### PR TITLE
[ONNX] Add converter for QAttention from Microsoft onnxruntime contrib opset

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1401,9 +1401,11 @@ class QAttention(OnnxOpConverter):
         # (3 * out_hidden,)
         bias = inputs[2]
 
+        # Scale of quantized input tensor.
         # Scalar, which means a per-tensor/layer quantization
         input_scale = inputs[3]
 
+        # Scale of quantized weight tensor.
         # Scalar or a 1D tensor, which means a per-tensor/per-column quantization.
         # Its size should be 3 * out_hidden if it is per-column quantization
         weight_scale = inputs[4]
@@ -1420,9 +1422,11 @@ class QAttention(OnnxOpConverter):
         #  Currently only (batch, past_seq_length + seq_length) shape is supported.
         mask_index = inputs[5]
 
+        # Zero point of quantized input tensor.
         # Scalar, which means a per-tensor/layer quantization
         input_zero_point = inputs[6]
 
+        # Zero point of quantized weight tensor.
         # Scalar or a 1D tensor, which means a per-tensor/per-column quantization.
         # Its size should be 3 * out_hidden if it is per-column quantization
         weight_zero_point = inputs[7]
@@ -1549,11 +1553,11 @@ class QAttention(OnnxOpConverter):
             result = _qnn.op.batch_matmul(
                 lhs, rhs_transposed, lhs_zero_point, rhs_zero_point, lhs_scale, rhs_scale
             )
+            # In our case zero point and scale are scalar, therefore 'axis' doesn't matter
             result = _qnn.op.dequantize(
                 result,
                 _op.multiply(lhs_scale, rhs_scale),
                 zero_point_zero,
-                axis=-1,  # TODO(agladyshev): what is 'axis' parameter for?
             )
             result = _op.add(result, bias)
             return result

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1536,6 +1536,7 @@ class QAttention(OnnxOpConverter):
         # ************************* Create Relay *************************
         # Add batch dimension for QNN Batch Matmul
         weight = _op.expand_dims(weight, 0, num_newaxis=1)
+        weight = _op.concatenate([weight] * batch_size, axis=0)
 
         # Split weight and biases and do the Matmul
         w_Q, w_K, w_V = _op.split(weight, 3, axis=-1)

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1387,12 +1387,12 @@ class QAttention(OnnxOpConverter):
 
     @classmethod
     def _impl_v1(cls, inputs, attr, params):
-        # *****************
+        # ************************* Read attrs *************************
         num_heads = attr["num_heads"]
         # TODO: support unidirectional
         assert "unidirectional" not in attr, "unidirectional attention not current supported"
 
-        # *************************
+        # ************************* Read inputs *************************
         # (batch, seq, in_hidden)
         input_emb = inputs[0]
 
@@ -1422,112 +1422,141 @@ class QAttention(OnnxOpConverter):
         # (2, batch, num_heads, past_seq, head_size)
         past = inputs[8]
 
-        # **********************************************
+        # ************************* Parse inputs *************************
+        t1 = ["int8", "uint8"]
+        t2 = ["int8", "uint8"]
+        t3 = ["float32", "float16"]
+        t4 = ["int32"]
 
+        # input
+        assert infer_type(input_emb).checked_type.dtype in t1
+        assert len(infer_shape(input_emb)) == 3, \
+            "Input should be 3D tensor with shape (batch_size, sequence_length, input_hidden_size)"
+        (batch_size, seq_len, input_hidden) = infer_shape(input_emb)
 
-        (batch_size, seq_len, _) = infer_shape(input_emb)
-        (out_hidden_x3,) = infer_shape(bias)
-        assert out_hidden_x3 % 3 == 0, "bias shape should be divisible by 3"
+        # weight
+        assert infer_type(weight).checked_type.dtype in t2
+        assert len(infer_shape(weight)) == 2, \
+            "Weight should be 2D input tensor with shape (input_hidden_size, 3 * hidden_size), " \
+            "hidden_size = num_heads * head_size"
+        (input_hidden_weight, out_hidden_x3) = infer_shape(weight)
+        assert input_hidden == input_hidden_weight
+        assert out_hidden_x3 % 3 == 0, "output hidden shape should be divisible by 3: W_Q, W_K, W_V"
         out_hidden = out_hidden_x3 // 3
         assert (
                 out_hidden % num_heads == 0
         ), "output hidden size should be divisible by number of attention heads"
         head_size = out_hidden // num_heads
 
-        # TODO(agladyshev): now QNN Batch Matmul only supports scalar types for scale and zero_point.
+        # bias
+        assert infer_type(bias).checked_type.dtype in t3
+        assert len(infer_shape(bias)) == 1, \
+            "Bias should be 1D input tensor with shape (3 * hidden_size)"
+        (out_hidden_x3_bias,) = infer_shape(bias)
+        assert out_hidden_x3 == out_hidden_x3_bias
+
+        # input_scale
+        assert infer_type(input_scale).checked_type.dtype in t3
         input_scale = get_scalar(input_scale, params, dtype=infer_type(input_scale).checked_type.dtype)
+
+        # weight_scale
+        assert infer_type(weight_scale).checked_type.dtype in t3
+        # TODO(agladyshev): now QNN Batch Matmul only supports scalar types for scale.
         weight_scale = get_scalar(weight_scale, params, dtype=infer_type(weight_scale).checked_type.dtype)
 
-        # input_scale = fold_constant(try_resolve_var_to_const(ensure_scalar_shape(input_scale), params))
-        # weight_scale = fold_constant(try_resolve_var_to_const(ensure_scalar_shape(weight_scale), params))
-
+        # mask_index
         assert (
                 mask_index is not None
         ), "Attention import currently only supports required mask_index"
+        assert infer_type(mask_index).checked_type.dtype in t4
         mask_index_shape = infer_shape(mask_index)
         assert (
                 len(mask_index_shape) == 1
                 and mask_index_shape[0] == batch_size
         ), "mask_index shape should match batch_size"
 
-        # TODO
+        # TODO(agladyshev): int32 required for qnn.batch_matmul (QnnBatchMatmulRel)
+        zero_point_zero = _expr.const(0, "int32")
+
+        # input_zero_point
+        if input_zero_point is None:
+            input_zero_point = zero_point_zero
+        else:
+            assert infer_type(input_zero_point).checked_type.dtype in t1
+            # TODO(agladyshev): int32 required for qnn.batch_matmul (QnnBatchMatmulRel)
+            input_zero_point = get_scalar(input_zero_point, params, dtype="int32")
+
+        # weight_zero_point
+        if weight_zero_point is None:
+            weight_zero_point = zero_point_zero
+        else:
+            assert infer_type(weight_zero_point).checked_type.dtype in t2
+            # TODO(agladyshev): int32 required for qnn.batch_matmul (QnnBatchMatmulRel)
+            weight_zero_point = get_scalar(weight_zero_point, params, dtype="int32")
+
+        # past
         assert past is None, "past K, V state is not currently supported"
 
-        # ************************************
-
-        # prepare default values
-        zero = _expr.const(0, "int32")  # TODO(agladyshev): int32 required for qnn.batch_matmul (QnnBatchMatmulRel)
-
-        input_emb_dtype = infer_type(input_emb).checked_type.dtype
-        input_zero_point = zero if input_zero_point is None else input_zero_point
-        weight_zero_point = zero if weight_zero_point is None else weight_zero_point
-
-        # split weight and biases and do the matmuls
+        # ************************* Create Relay *************************
+        # Add batch dimension for QNN Batch Matmul
         weight = _op.expand_dims(weight, 0, num_newaxis=1)
-        w_Q, w_K, w_V = _op.split(weight, 3, axis=2)
-        # w_Q, w_K, w_V = _op.split(weight, 3, axis=1)
-        b_Q, b_K, b_V = _op.split(bias, 3, axis=0)
+
+        # Split weight and biases and do the Matmul
+        w_Q, w_K, w_V = _op.split(weight, 3, axis=-1)
+        b_Q, b_K, b_V = _op.split(bias, 3, axis=-1)
 
         def qmatmul_and_dequantize(lhs, rhs, lhs_scale, rhs_scale, lhs_zero_point, rhs_zero_point):
-            lhs_scale_scalar = fold_constant(try_resolve_var_to_const(lhs_scale, params))
-            rhs_scale_scalar = fold_constant(try_resolve_var_to_const(rhs_scale, params))
-            result = _qnn.op.batch_matmul(lhs, rhs, lhs_zero_point, rhs_zero_point, lhs_scale, rhs_scale)
+            rhs_transposed = _op.transpose(rhs, axes=[0, 2, 1])     # QNN Batch Matmul do: X * Y^T
+            result = _qnn.op.batch_matmul(lhs, rhs_transposed, lhs_zero_point, rhs_zero_point, lhs_scale, rhs_scale)
             result = _qnn.op.dequantize(
                 result,
-                fold_constant(_op.multiply(lhs_scale_scalar, rhs_scale_scalar)),
-                zero,
-                axis=0,     # TODO(agladyshev): ?
+                _op.multiply(lhs_scale, rhs_scale),
+                zero_point_zero,
+                axis=-1,     # TODO(agladyshev): what is 'axis' parameter for?
             )
+            assert infer_shape(result) == (batch_size, seq_len, out_hidden)
             return result
 
         Q = _op.add(qmatmul_and_dequantize(input_emb, w_Q, input_scale, weight_scale, input_zero_point, weight_zero_point), b_Q)
         K = _op.add(qmatmul_and_dequantize(input_emb, w_K, input_scale, weight_scale, input_zero_point, weight_zero_point), b_K)
         V = _op.add(qmatmul_and_dequantize(input_emb, w_V, input_scale, weight_scale, input_zero_point, weight_zero_point), b_V)
 
-
-        # massage tensors in preparation for batched matmul
-        def massage(tensor):
+        def split_into_heads(tensor):
+            """
+            In the implementation of Multi-head attention we just split the queries, keys, and values
+            we compute for a single-head attention into several parts.
+            """
             tensor = _op.reshape(tensor, (batch_size, seq_len, num_heads, head_size))
 
             # (batch_size, num_heads, seq_len, head_size)
             tensor = _op.transpose(tensor, axes=[0, 2, 1, 3])
 
-            # (batch_size * num_heads, seq_len, head_size)
+            # (batch_size * num_heads, seq_len, head_size), because nn.batch_matmul is expecting 3D tensor
             return _op.reverse_reshape(tensor, (-1, 0, 0))
 
-        Q = massage(Q)
-        K = massage(K)
-        V = massage(V)
+        Q = split_into_heads(Q)
+        K = split_into_heads(K)
+        V = split_into_heads(V)
 
-        # present state for key and value with shape (2, batch_size, num_heads, past_sequence_length + sequence_length, head_size)
+        # Present state for key and value with shape
+        # (2, batch_size, num_heads, past_sequence_length + sequence_length, head_size)
         K_present = _op.reshape(K, (batch_size, num_heads, seq_len, head_size))
         V_present = _op.reshape(V, (batch_size, num_heads, seq_len, head_size))
         present = _op.stack([K_present, V_present], axis=0)
-        print("K_present: ", infer_shape(K_present))
-
 
         att_scores = _op.nn.batch_matmul(Q, K, transpose_a=False, transpose_b=True)
-        print(infer_shape(Q))
-        print(infer_shape(K))
-        print("Score shape: ", infer_shape(att_scores))
         score_dtype = infer_type(att_scores).checked_type.dtype
         att_scores = _op.divide(
             att_scores,
             _op.const(np.sqrt(head_size), dtype=infer_type(att_scores).checked_type.dtype),
         )
         att_scores = _op.reshape(att_scores, (batch_size, num_heads, seq_len, seq_len))
-        print("Score shape: ", infer_shape(att_scores))
 
         # build the attention mask
-        print("mask_index: ", infer_shape(mask_index))
         att_mask = _op.cast(mask_index, score_dtype)
-        print("att_mask: ", infer_shape(att_mask))
-        att_mask = _op.expand_dims(att_mask, 1, num_newaxis=3)
-        print("att_mask: ", infer_shape(att_mask))
-        # att_mask = _op.expand_dims(att_mask, seq_len, num_newaxis=3)
+        att_mask = _op.expand_dims(att_mask, 1, num_newaxis=3)  # Expand to batch dimension
         att_mask = _op.subtract(_op.const(1, dtype=score_dtype), att_mask)
         att_mask = _op.multiply(att_mask, _op.const(-10000, dtype=score_dtype))
-        print("att_mask: ", infer_shape(att_mask))
 
         # apply the mask
         att_scores = _op.add(att_scores, att_mask)

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -1409,7 +1409,8 @@ class QAttention(OnnxOpConverter):
         weight_scale = inputs[4]
 
         # TODO(agladyshev):
-        #  ORT documentation says that shape is (batch,), but in ORT source code we have following comment:
+        #  ORT documentation says that shape is (batch,),
+        #  but in ORT source code we have following comment:
         #       1. (batch_size)
         #       2. (2 * batch_size)
         #       3. (batch_size, 1)
@@ -1442,8 +1443,8 @@ class QAttention(OnnxOpConverter):
         ), "Input should be 3D tensor with shape (batch_size, sequence_length, input_hidden_size)"
         (batch_size, seq_len, input_hidden) = infer_shape(input_emb)
         assert input_hidden > 0, (
-            "The weight tensor has (input_hidden_size, 3 * output_hidden_size) shape,"
-            f" so it doesn't make sense to have ({input_hidden}, 3 * output_hidden_size) weight tensor."
+            "The weight tensor has (input_hidden_size, 3 * output_hidden_size) shape, so it doesn't"
+            f" make sense to have ({input_hidden}, 3 * output_hidden_size) weight tensor."
         )
         assert seq_len > 0, (
             "The output tensor has (batch_size, sequence_length, hidden_size) shape,"
@@ -1481,7 +1482,7 @@ class QAttention(OnnxOpConverter):
 
         # weight_scale
         assert infer_type(weight_scale).checked_type.dtype in t3
-        # TODO(agladyshev): now QNN Batch Matmul only supports scalar types for scale and zero_point.
+        # TODO(agladyshev): now QNN Batch Matmul only supports scalar types for scale and zero_point
         weight_scale = get_scalar(
             weight_scale, params, dtype=infer_type(weight_scale).checked_type.dtype
         )
@@ -1568,7 +1569,7 @@ class QAttention(OnnxOpConverter):
 
         def split_into_heads(tensor):
             """
-            In the implementation of Multi-head attention we just split the queries, keys, and values
+            In the implementation of Multi-head attention we just split queries, keys, and values
             we compute for a single-head attention into several parts:
             (batch_size, num_heads, seq_len, head_size)
             """
@@ -1647,7 +1648,8 @@ class QAttention(OnnxOpConverter):
 
         # Apply the mask
         att_scores = _op.add(att_scores, att_mask)
-        # TODO(agladyshev): comment from ORT source code (onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h):
+        # TODO(agladyshev):
+        #   Comment from ORT source code (onnxruntime/contrib_ops/cpu/bert/attention_cpu_base.h):
         #   "Fix unidirectional mask to be parity with huggingface implementation"
         if unidirectional:
             att_scores = _op.multiply(att_scores, create_unidirectional_mask(1, 0))

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5889,7 +5889,18 @@ def test_attention(target, dev):
 def test_qattention(target, dev):
     """test_qattention"""
 
-    def verify_attention(_unidirectional, _input, _weight, _bias, _input_scale, _weight_scale, _mask_index=None, _input_zero_point=None, _weight_zero_point=None, _past=None):
+    def verify_attention(
+        _unidirectional,
+        _input,
+        _weight,
+        _bias,
+        _input_scale,
+        _weight_scale,
+        _mask_index=None,
+        _input_zero_point=None,
+        _weight_zero_point=None,
+        _past=None,
+    ):
         input_names = ["input", "weight", "bias", "input_scale", "weight_scale"]
         if _mask_index is not None:
             input_names.append("mask_index")
@@ -5910,7 +5921,13 @@ def test_qattention(target, dev):
         )
 
         past_shape = (2, batch_size, num_heads, past_sequence_length, head_size)
-        present_output_shape = (2, batch_size, num_heads, past_sequence_length + sequence_length, head_size)
+        present_output_shape = (
+            2,
+            batch_size,
+            num_heads,
+            past_sequence_length + sequence_length,
+            head_size,
+        )
 
         inputs_info = [
             helper.make_tensor_value_info("input", TensorProto.UINT8, list(_input.shape)),
@@ -5968,8 +5985,8 @@ def test_qattention(target, dev):
             [_input.shape, present_output_shape],
             target=target,
             dev=dev,
-            rtol=1e-4,
-            atol=1e-4,
+            rtol=1e-3,
+            atol=1e-3,
         )
 
     batch_size = 11
@@ -5983,7 +6000,9 @@ def test_qattention(target, dev):
     total_sequence_length = past_sequence_length + sequence_length
 
     # Required inputs
-    input_array = np.random.randint(0, 255, (batch_size, sequence_length, input_hidden_size)).astype("uint8")
+    input_array = np.random.randint(
+        0, 255, (batch_size, sequence_length, input_hidden_size)
+    ).astype("uint8")
     weight = np.random.randint(0, 255, (input_hidden_size, 3 * weight_hidden_size)).astype("uint8")
     bias = np.random.randn(3 * weight_hidden_size).astype("float32")
     input_scale = np.random.random(1).astype("float32")
@@ -5992,20 +6011,62 @@ def test_qattention(target, dev):
     # Optional inputs
     input_zero_point = np.random.randint(0, 255, 1).astype("uint8")
     weight_zero_point = np.random.randint(0, 255, 1).astype("uint8")
-    past = np.random.random((2, batch_size, num_heads, past_sequence_length, head_size)).astype("float32")
+    past = np.random.random((2, batch_size, num_heads, past_sequence_length, head_size)).astype(
+        "float32"
+    )
 
     for unidirectional in [0, 1]:
         for have_past in [False, True]:
             if not have_past:
                 mask_index = np.random.randint(0, 2, (batch_size, sequence_length)).astype("int32")
 
-                verify_attention(unidirectional, input_array, weight, bias, input_scale, weight_scale, mask_index)
-                verify_attention(unidirectional, input_array, weight, bias, input_scale, weight_scale, mask_index, input_zero_point)
-                verify_attention(unidirectional, input_array, weight, bias, input_scale, weight_scale, mask_index, input_zero_point, weight_zero_point)
+                verify_attention(
+                    unidirectional,
+                    input_array,
+                    weight,
+                    bias,
+                    input_scale,
+                    weight_scale,
+                    mask_index,
+                )
+                verify_attention(
+                    unidirectional,
+                    input_array,
+                    weight,
+                    bias,
+                    input_scale,
+                    weight_scale,
+                    mask_index,
+                    input_zero_point,
+                )
+                verify_attention(
+                    unidirectional,
+                    input_array,
+                    weight,
+                    bias,
+                    input_scale,
+                    weight_scale,
+                    mask_index,
+                    input_zero_point,
+                    weight_zero_point,
+                )
             else:
-                mask_index = np.random.randint(0, 2, (batch_size, total_sequence_length)).astype("int32")
+                mask_index = np.random.randint(0, 2, (batch_size, total_sequence_length)).astype(
+                    "int32"
+                )
 
-                verify_attention(unidirectional, input_array, weight, bias, input_scale, weight_scale, mask_index, input_zero_point, weight_zero_point, past)
+                verify_attention(
+                    unidirectional,
+                    input_array,
+                    weight,
+                    bias,
+                    input_scale,
+                    weight_scale,
+                    mask_index,
+                    input_zero_point,
+                    weight_zero_point,
+                    past,
+                )
 
 
 @tvm.testing.parametrize_targets


### PR DESCRIPTION
This PR adds support for [QAttention](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.QAttention) - quantized version of [Attention](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.Attention) from Microsoft onnxruntime contrib opset.
An explanation and illustration of how this layer works can be found, for example, in @lena-voita [NLP course](https://lena-voita.github.io/nlp_course/seq2seq_and_attention.html).