### PR TITLE
[TIR] Create Layout with specified axis dtype

### DIFF
--- a/include/tvm/tir/data_layout.h
+++ b/include/tvm/tir/data_layout.h
@@ -137,8 +137,10 @@ class Layout : public ObjectRef {
    *        the corresponding lower case with factor size
    *        indicates the split dimension.
    *        return undefined layout if "__undef__" is passed.
+   * \param dtype The dtype of generated axes vars in the returned layout.
+   *        It is required to be integer type.
    */
-  TVM_DLL Layout(const std::string& name);  // NOLINT(*)
+  TVM_DLL Layout(const std::string& name, DataType dtype = DataType::Int(32));  // NOLINT(*)
 
   /*!
    * \brief access the internal node container

--- a/python/tvm/tir/data_layout.py
+++ b/python/tvm/tir/data_layout.py
@@ -163,7 +163,7 @@ class BijectiveLayout(Object):
         return _ffi_api.BijectiveLayoutBackwardShape(self, shape)  # type: ignore
 
 
-def layout(layout_str: str) -> Layout:
+def layout(layout_str: str, dtype: str = "int32") -> Layout:
     """Create a layout node from a string.
 
     Parameters
@@ -177,12 +177,16 @@ def layout(layout_str: str) -> Layout:
         Here subordinate axis channel_block=16 is the factor size of
         the primal axis C (channel).
 
+    dtype : str
+        The dtype of generated axes vars in the returned layout.
+        It is required to be integer type.
+
     Returns
     -------
     layout : Layout
         The created layout
     """
-    return _ffi_api.Layout(layout_str)  # type: ignore
+    return _ffi_api.Layout(layout_str, dtype)  # type: ignore
 
 
 def bijective_layout(

--- a/tests/python/unittest/test_tir_data_layout.py
+++ b/tests/python/unittest/test_tir_data_layout.py
@@ -16,8 +16,9 @@
 # under the License.
 """Test layout and bijective-layout node"""
 
+import pytest
 import tvm
-from tvm import te
+import tvm.error
 from tvm.topi.utils import get_const_tuple
 
 
@@ -50,6 +51,29 @@ def test_layout():
     assert layout[3] == "W"
     assert layout[4] == "c"
     assert layout[-1] == "c"
+
+
+def test_layout_dtype():
+    layout_i32 = tvm.tir.layout("NCHW")
+    assert layout_i32.axes[0].var.dtype == "int32"
+    assert layout_i32.axes[0].dom.min.dtype == "int32"
+    assert layout_i32.axes[0].dom.extent.dtype == "int32"
+    assert layout_i32.axes[1].var.dtype == "int32"
+    assert layout_i32.axes[1].dom.min.dtype == "int32"
+    assert layout_i32.axes[1].dom.extent.dtype == "int32"
+
+    layout_i64 = tvm.tir.layout("NCHW", dtype="int64")
+    assert layout_i64.axes[2].var.dtype == "int64"
+    assert layout_i64.axes[2].dom.min.dtype == "int64"
+    assert layout_i64.axes[2].dom.extent.dtype == "int64"
+    assert layout_i64.axes[3].var.dtype == "int64"
+    assert layout_i64.axes[3].dom.min.dtype == "int64"
+    assert layout_i64.axes[3].dom.extent.dtype == "int64"
+
+    with pytest.raises(TypeError):
+        tvm.tir.layout("NCHW", dtype="float32")
+    with pytest.raises(TypeError):
+        tvm.tir.layout("NCHW", dtype=None)
 
 
 def test_bilayout_convertible():
@@ -88,6 +112,7 @@ def test_bilayout_index():
 
 if __name__ == "__main__":
     test_layout()
+    test_layout_dtype()
     test_bilayout_convertible()
     test_bilayout_shape()
     test_bilayout_index()


### PR DESCRIPTION
This PR brings the support for specifying axis dtype when creating `tir::Layout`.

Prior to this PR, the construction of `tir::Layout` uses int32 for every axis. With this specification, the output of `BijectiveLayout::ForwardShape/BackwardShape(...)` will always be int32 shape, no matter if the input shape is in int32 or int64.

As we will be gradually moving to int64 default dtype for tensor shapes, there are increasingly more cases where we need to handle int64 shapes. Thus, `tir::Layout` need some updates for int64 shapes. Since the creation of an `tir::Layout` instance is agnostic to the dtype of the shapes that the instance will handle later, one way of the such updates is to add a dtype parameter to the constructor of `tir::Layout`, to specify the dtype explicitly. This PR enhances `tir::Layout` in this way, with appropriate unit tests for dtype check.

cc @tqchen 