### PR TITLE
[BugFix] Pylance emits the warnning 'Code is unreachable' 

### DIFF
--- a/python/tvm/ir/base.py
+++ b/python/tvm/ir/base.py
@@ -120,7 +120,7 @@ class EnvFunc(Object):
         return _ffi_api.EnvFuncGet(name)
 
 
-def load_json(json_str):
+def load_json(json_str) -> Object:
     """Load tvm object from json_str.
 
     Parameters
@@ -141,7 +141,7 @@ def load_json(json_str):
         return tvm.runtime._ffi_node_api.LoadJSON(json_str)
 
 
-def save_json(node):
+def save_json(node) -> str:
     """Save tvm object as json string.
 
     Parameters


### PR DESCRIPTION
For the users who use vscode to write code, Pylance in vscode will shadow  the code below the function calls `tvm.ir.load_json/save_json` and tell users "Code is unreachable" like the picture below:
 
![image](https://user-images.githubusercontent.com/28034077/210043063-670f71b4-c7f8-4353-a1dd-4985eca0edd1.png)

The issue maybe confuses users and make the code a little "dirty".

This PR fixes this by adding a return type hint to the functions `load_json` and `save_json`.