### PR TITLE
[TOPI] Expose mem_scope from generic conv2d variants to be more reusable

### DIFF
--- a/python/tvm/topi/generic/conv2d.py
+++ b/python/tvm/topi/generic/conv2d.py
@@ -132,6 +132,7 @@ def schedule_conv_NCHWc_cpu_common_int8(
     int8_elems=4,
     intrin=None,
     inline_fused=True,
+    mem_scope="global",
 ):
     """
     Defines the schedule for INT8 for Intel and ARM machines
@@ -186,7 +187,7 @@ def schedule_conv_NCHWc_cpu_common_int8(
 
     # schedule 5-D NCHW[x]c conv
     C, O = conv_out, last
-    CC = s.cache_write(C, "global")
+    CC = s.cache_write(C, mem_scope)
 
     batch, oc_chunk, oh, ow, oc_block = s[C].op.axis
     ow_chunk, ow_block = s[C].split(ow, factor=reg_n)
@@ -279,6 +280,7 @@ def schedule_conv_NCHWc_cpu_1x1_int8(
     int8_elems=4,
     intrin=None,
     inline_fused=False,
+    mem_scope="global",
 ):
     """
     Defines the 1x1 conv schedule for INT8 for Intel and ARM machines
@@ -323,7 +325,7 @@ def schedule_conv_NCHWc_cpu_1x1_int8(
         s[kernel_vec].parallel(parallel_axis)
 
     C, O = conv_out, last
-    CC = s.cache_write(C, "global")
+    CC = s.cache_write(C, mem_scope)
 
     batch, oc_chunk, oh, ow, oc_block = s[C].op.axis
     oh_outer, oh_inner = s[C].split(oh, factor=oh_factor)


### PR DESCRIPTION
This small PR enhances generic conv2d TOPI schedules to be even more reusable.

#### Changes:

1. Continues [PR #6714](https://github.com/apache/tvm/pull/6714) and expose memory scope via ```mem_scope```
2. Enhanches [schedule_conv_NCHWc_cpu_common_int8](https://github.com/apache/tvm/blob/f3d3ecebe189af77ba3ac5163882591aaf67d8b3/python/tvm/topi/generic/conv2d.py#L124) and [schedule_conv_NCHWc_cpu_1x1_int8](https://github.com/apache/tvm/blob/f3d3ecebe189af77ba3ac5163882591aaf67d8b3/python/tvm/topi/generic/conv2d.py#L271)

Does **not change current behaviour**, memory scope remains "global" by default.

#### Goal:

Flexibility and reusability of key generic schedules is desirable for targets, especially custom ISA/ASIC.
There are use-cases where cache memory is not directly visible ("local") but generic TOPI is still very useful as-is.

---
Cc @masahi , @vinx13 , @ZihengJiang please help with the review.

Thank you,
~Cristian.