### PR TITLE
Remove temporary VTCM workspace APIs

### DIFF
--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -157,20 +157,6 @@ void HexagonDeviceAPI::FreeWorkspace(Device dev, void* data) {
   dmlc::ThreadLocalStore<HexagonWorkspacePool>::Get()->FreeWorkspace(dev, data);
 }
 
-void* HexagonDeviceAPI::AllocVtcmWorkspace(Device dev, int ndim, const int64_t* shape,
-                                           DLDataType dtype, Optional<String> mem_scope) {
-  // must be Hexagon device (not CPU)
-  CHECK(dev.device_type == kDLHexagon) << "dev.device_type: " << dev.device_type;
-  CHECK((ndim == 1 || ndim == 2) && "Hexagon Device API supports only 1d and 2d allocations");
-  return AllocDataSpace(dev, ndim, shape, dtype, mem_scope);
-}
-
-void HexagonDeviceAPI::FreeVtcmWorkspace(Device dev, void* ptr) {
-  // must be Hexagon device (not CPU)
-  CHECK(dev.device_type == kDLHexagon) << "dev.device_type: " << dev.device_type;
-  FreeDataSpace(dev, ptr);
-}
-
 void HexagonDeviceAPI::CopyDataFromTo(DLTensor* from, DLTensor* to, TVMStreamHandle stream) {
   CHECK_EQ(from->byte_offset, 0);
   CHECK_EQ(to->byte_offset, 0);
@@ -268,7 +254,7 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.alloc_nd").set_body([](TVMArgs args, TVM
   type_hint.lanes = 1;
 
   HexagonDeviceAPI* hexapi = HexagonDeviceAPI::Global();
-  *rv = hexapi->AllocVtcmWorkspace(dev, ndim, shape, type_hint, String(scope));
+  *rv = hexapi->AllocDataSpace(dev, ndim, shape, type_hint, String(scope));
 });
 
 TVM_REGISTER_GLOBAL("device_api.hexagon.free_nd").set_body([](TVMArgs args, TVMRetValue* rv) {
@@ -283,7 +269,7 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.free_nd").set_body([](TVMArgs args, TVMR
   dev.device_id = device_id;
 
   HexagonDeviceAPI* hexapi = HexagonDeviceAPI::Global();
-  hexapi->FreeVtcmWorkspace(dev, ptr);
+  hexapi->FreeDataSpace(dev, ptr);
   *rv = static_cast<int32_t>(0);
 });
 

--- a/src/runtime/hexagon/hexagon_device_api.h
+++ b/src/runtime/hexagon/hexagon_device_api.h
@@ -139,20 +139,6 @@ class HexagonDeviceAPI final : public DeviceAPI {
                        Optional<String> mem_scope) final;
 
   /*!
-   * \brief Allocate an Nd VTCM workspace.
-   * \param dev The device to perform the operation.
-   * \param ndim The number of dimensions of allocated tensor.
-   * \param shape The shape of allocated tensor.
-   * \param dtype The element type.
-   * \return The allocated HexagonBuffer pointer.
-   */
-  void* AllocVtcmWorkspace(Device dev, int ndim, const int64_t* shape, DLDataType dtype,
-                           Optional<String> mem_scope);
-
-  //! \brief Free the allocated Nd VTCM workspace.
-  void FreeVtcmWorkspace(Device dev, void* ptr);
-
-  /*!
    * \brief Copy data from one storage to another.
    * \note This API is designed to support special memory with shape dependent layout.
    *       DLTensor's are passed with shape information to support these cases.


### PR DESCRIPTION
AllocVtcmWorkspace and FreeVtcmWorkspace were temporary APIs for allocating VTCM.  Now that AllocDataSpace supports VTCM, these can be removed as they are just wrappers.

cc:  @adstraw 