### PR TITLE
[CMake][OpenCL] Remove warning for OpenCL wrapper

### DIFF
--- a/cmake/modules/OpenCL.cmake
+++ b/cmake/modules/OpenCL.cmake
@@ -43,7 +43,6 @@ if(USE_OPENCL)
   tvm_file_glob(GLOB RUNTIME_OPENCL_SRCS src/runtime/opencl/*.cc)
 
   if(${USE_OPENCL} MATCHES ${IS_TRUE_PATTERN})
-    message(WARNING "Build with OpenCL wrapper")
     file_glob_append(RUNTIME_OPENCL_SRCS
       "src/runtime/opencl/opencl_wrapper/opencl_wrapper.cc"
     )

--- a/cmake/modules/OpenCL.cmake
+++ b/cmake/modules/OpenCL.cmake
@@ -43,7 +43,7 @@ if(USE_OPENCL)
   tvm_file_glob(GLOB RUNTIME_OPENCL_SRCS src/runtime/opencl/*.cc)
 
   if(${USE_OPENCL} MATCHES ${IS_TRUE_PATTERN})
-    message(STATUS "Enabled runtime search for OpenCL installation location")
+    message(STATUS "Enabled runtime search for OpenCL library location")
     file_glob_append(RUNTIME_OPENCL_SRCS
       "src/runtime/opencl/opencl_wrapper/opencl_wrapper.cc"
     )

--- a/cmake/modules/OpenCL.cmake
+++ b/cmake/modules/OpenCL.cmake
@@ -43,6 +43,7 @@ if(USE_OPENCL)
   tvm_file_glob(GLOB RUNTIME_OPENCL_SRCS src/runtime/opencl/*.cc)
 
   if(${USE_OPENCL} MATCHES ${IS_TRUE_PATTERN})
+    message(STATUS "Enabled runtime search for OpenCL installation location")
     file_glob_append(RUNTIME_OPENCL_SRCS
       "src/runtime/opencl/opencl_wrapper/opencl_wrapper.cc"
     )


### PR DESCRIPTION
Previously, setting `set(USE_OPENCL ON)` would result in a warning, stating that the runtime wrapper for OpenCL would be used.  Since this is the desired behavior when OpenCL support is enabled, and is not something that a user should fix, this commit removes the warning.