### PR TITLE
[BugFix][Runtime] Add missing check for `PackedFunc`

### DIFF
--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -1903,6 +1903,11 @@ inline TVMRetValue& TVMRetValue::operator=(TObjectRef other) {
          ptr->IsInstance<Module::ContainerType>())) {
       return operator=(Module(std::move(other.data_)));
     }
+    if (std::is_base_of<PackedFunc::ContainerType, ContainerType>::value ||
+        (std::is_base_of<ContainerType, PackedFunc::ContainerType>::value &&
+         ptr->IsInstance<PackedFunc::ContainerType>())) {
+      return operator=(PackedFunc(std::move(other.data_)));
+    }
     SwitchToObject(kTVMObjectHandle, std::move(other.data_));
   } else {
     SwitchToPOD(kTVMNullptr);

--- a/tests/cpp/packed_func_test.cc
+++ b/tests/cpp/packed_func_test.cc
@@ -156,6 +156,19 @@ TEST(PackedFunc, Type) {
   ICHECK(get_type2("float32x2").operator DataType() == DataType::Float(32, 2));
 }
 
+TEST(PackedFunc, AsTVMRetValue) {
+  using namespace tvm;
+  using namespace tvm::runtime;
+  ObjectRef obj = PackedFunc([](TVMArgs args, TVMRetValue* rv) {
+    PrimExpr x = args[0];
+    *rv = x.as<tvm::tir::IntImmNode>()->value + 1;
+  });
+  TVMRetValue value;
+  value = obj;
+  value.operator PackedFunc();
+  ICHECK_EQ(value.operator PackedFunc()(1).operator int(), 2);
+}
+
 TEST(TypedPackedFunc, HighOrder) {
   using namespace tvm;
   using namespace tvm::runtime;

--- a/tests/cpp/packed_func_test.cc
+++ b/tests/cpp/packed_func_test.cc
@@ -165,7 +165,6 @@ TEST(PackedFunc, AsTVMRetValue) {
   });
   TVMRetValue value;
   value = obj;
-  value.operator PackedFunc();
   ICHECK_EQ(value.operator PackedFunc()(1).operator int(), 2);
 }
 


### PR DESCRIPTION
This pr fixs the missing check when assigning a `PackedFunc` into `TVMRetValue`.
For, example,
```
TVMRetValue value;
ObjectRef obj = some_packed_func;
value = obj; // Fails here
^^^^^^^^^^^
value.operator PackedFunc()
```