### PR TITLE
[VTA] Provide zero-initialization for VTAGenericInsn

### DIFF
--- a/vta/runtime/runtime.cc
+++ b/vta/runtime/runtime.cc
@@ -915,7 +915,7 @@ class InsnQueue : public BaseQueue<VTAGenericInsn> {
  protected:
   /*! \return Add new instruction to the buffer. */
   VTAGenericInsn* NextInsn() {
-    VTAGenericInsn insn;
+    VTAGenericInsn insn = {};
     dram_buffer_.push_back(insn);
     return &dram_buffer_.back();
   }


### PR DESCRIPTION
Previously, this line caused a warning for `-Wmaybe-uninitialized` when compiling in g++ 11.3.0.