### PR TITLE
[TIR][Schedule] Improve cache_index to cache common subexpressions

### DIFF
--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -419,10 +419,12 @@ class ScheduleNode : public runtime::Object {
    * \brief Create a block to cache precomputed index for later use.
    * if there is no index computation, keep unchanged.
    * \param block_rv The target block
-   * \param buffer_index The index of the target buffer in block's read region
+   * \param storage_scope The storage scope of cached block
+   * \param cse_thresh The repeat threshold that determines a common sub expr
    * \return The cache stage blocks.
    */
-  virtual Array<BlockRV> CacheIndex(const BlockRV& block_rv, int buffer_index) = 0;
+  virtual Array<BlockRV> CacheIndex(const BlockRV& block_rv, const String& storage_scope,
+                                    int cse_thresh) = 0;
   /*!
    * \brief Create a block that read/write a buffer region into a read/write cache with reindexing.
    * The layout of the cache will be the same as by the iterators of the block that reads/writes the

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -1294,7 +1294,10 @@ class Schedule(Object):
 
     @type_checked
     def cache_index(
-        self, block: Union[BlockRV, str], buffer_index: Union[int, str, Buffer]
+        self,
+        block: Union[BlockRV, str],
+        storage_scope: str,
+        cse_thresh: int = 0,
     ) -> List[BlockRV]:
         """Create a block to cache precomputed index for later use.
         if there is no index computation, keep unchanged.
@@ -1304,8 +1307,12 @@ class Schedule(Object):
         block : Union[BlockRV, str]
             The target block operates on the target buffer.
 
-        buffer_index: int
-            The index of the target buffer in block's read region
+        storage_scope: str
+            The storage scope of cached block.
+
+        cse_thresh: int
+            The repeat threshold that determines a common sub expr,
+            default 0 means cache all index computation.
 
 
         Returns
@@ -1334,7 +1341,7 @@ class Schedule(Object):
 
             sch = tir.Schedule(resize)
             block_a = sch.get_block("A")
-            sch.cache_index(block_a, 0)
+            sch.cache_index(block_a, "global", 1)
             print(sch.mod["main"].script())
 
         After applying cache_index, the IR becomes:
@@ -1370,12 +1377,8 @@ class Schedule(Object):
         """
         block = self._normalize_block_arg(block)
 
-        if not isinstance(buffer_index, int):
-            _, buffer_index, _ = self._normalize_buffer_arg(
-                block, buffer_index, required_buffer_type="read"
-            )
         return _ffi_api.ScheduleCacheIndex(  # type: ignore # pylint: disable=no-member
-            self, block, buffer_index
+            self, block, storage_scope, cse_thresh
         )
 
     @type_checked

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -581,10 +581,11 @@ Array<BlockRV> ConcreteScheduleNode::CacheInplace(const BlockRV& block_rv, int w
   return return_blocks;
 }
 
-Array<BlockRV> ConcreteScheduleNode::CacheIndex(const BlockRV& block_rv, int buffer_index) {
+Array<BlockRV> ConcreteScheduleNode::CacheIndex(const BlockRV& block_rv,
+                                                const String& storage_scope, int cse_thresh) {
   Array<StmtSRef> result;
   TVM_TIR_SCHEDULE_BEGIN();
-  result = tir::CacheIndex(state_, this->GetSRef(block_rv), buffer_index);
+  result = tir::CacheIndex(state_, this->GetSRef(block_rv), storage_scope, cse_thresh);
   TVM_TIR_SCHEDULE_END("cache-index", this->error_render_level_);
   this->state_->DebugVerify();
   Array<BlockRV> return_blocks;

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -118,7 +118,8 @@ class ConcreteScheduleNode : public ScheduleNode {
                      const Array<BlockRV> consumer_blocks = {}) override;
   Array<BlockRV> CacheInplace(const BlockRV& block_rv, int read_buffer_index,
                               const String& storage_scope) override;
-  Array<BlockRV> CacheIndex(const BlockRV& block_rv, int write_buffer_index) override;
+  Array<BlockRV> CacheIndex(const BlockRV& block_rv, const String& storage_scope,
+                            int cse_thresh) override;
   BlockRV ReIndex(const BlockRV& block_rv, int buffer_index,
                   BufferIndexType buffer_index_type) override;
   /******** Schedule: Compute location ********/

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -285,11 +285,12 @@ TVM_DLL Array<StmtSRef> CacheInplace(ScheduleState self, const StmtSRef& block_s
  * \brief Create a block to cache precomputed index for later use.
  * if there is no index computation, keep unchanged.
  * \param block_sref The target block
- * \param buffer_index The index of the target buffer in block's read region,
+ * \param storage_scope The storage scope of cached block
+ * \param cse_thresh The repeat threshold that determines a common sub expr
  * \return The cache stage block.
  */
 TVM_DLL Array<StmtSRef> CacheIndex(ScheduleState self, const StmtSRef& block_sref,
-                                   int buffer_index);
+                                   const String& storage_scope, int cse_thresh);
 /*!
  *!
  * \brief Create a block that read/write a buffer region into a read/write cache with reindexing.

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -325,8 +325,9 @@ Array<BlockRV> TracedScheduleNode::CacheInplace(const BlockRV& block_rv, int rea
   return result;
 }
 
-Array<BlockRV> TracedScheduleNode::CacheIndex(const BlockRV& block_rv, int buffer_index) {
-  Array<BlockRV> result = ConcreteScheduleNode::CacheIndex(block_rv, buffer_index);
+Array<BlockRV> TracedScheduleNode::CacheIndex(const BlockRV& block_rv, const String& storage_scope,
+                                              int cse_thresh) {
+  Array<BlockRV> result = ConcreteScheduleNode::CacheIndex(block_rv, storage_scope, cse_thresh);
   Array<ObjectRef> outputs;
   for (const BlockRV& r : result) {
     outputs.push_back(r);
@@ -334,7 +335,7 @@ Array<BlockRV> TracedScheduleNode::CacheIndex(const BlockRV& block_rv, int buffe
   static const InstructionKind& kind = InstructionKind::Get("CacheIndex");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{block_rv},
-                                      /*attrs=*/{Integer(buffer_index)},
+                                      /*attrs=*/{storage_scope, Integer(cse_thresh)},
                                       /*outputs=*/outputs));
   return result;
 }

--- a/src/tir/schedule/traced_schedule.h
+++ b/src/tir/schedule/traced_schedule.h
@@ -80,7 +80,8 @@ class TracedScheduleNode : public ConcreteScheduleNode {
                               const String& storage_scope) final;
   BlockRV ReIndex(const BlockRV& block_rv, int buffer_index,
                   BufferIndexType buffer_index_type) final;
-  Array<BlockRV> CacheIndex(const BlockRV& block_rv, int buffer_index) final;
+  Array<BlockRV> CacheIndex(const BlockRV& block_rv, const String& storage_scope,
+                            int cse_thresh) final;
   /******** Schedule: Compute location ********/
   void ComputeAt(const BlockRV& block_rv, const LoopRV& loop_rv, bool preserve_unit_loops,
                  int index = -1) final;


### PR DESCRIPTION
Much of the index computation is duplicated, so this PR is to do common subexpression analyze when performing cache_index.
And because all block var related computation could be cached, buffer-based cache is somehow too restrictive. So here make it block-based.

A threshold number is needed when identifying a common sub expr, since we only want to cache the most frequently appeared sub expressions.  A common use case may be like this: calling _tvm.arith.detect_common_subexpr()_ and determining based on its result whether to perform cache_index and its corresponding threshold.
cc @wrongtest-intellif @Hzfengsy 