### PR TITLE
[TIR] Fix dtype mismatch error due to LetStmt

### DIFF
--- a/include/tvm/tir/data_type_rewriter.h
+++ b/include/tvm/tir/data_type_rewriter.h
@@ -54,6 +54,7 @@ class DataTypeLegalizer : public StmtExprMutator {
   Stmt VisitStmt_(const BlockRealizeNode* op) override;
   Stmt VisitStmt_(const BlockNode* op) override;
   Stmt VisitStmt_(const LetStmtNode* op) override;
+  PrimExpr VisitExpr_(const VarNode* op) override;
   PrimExpr VisitExpr_(const SelectNode* op) override;
   PrimExpr VisitExpr_(const RampNode* op) override;
   PrimExpr VisitExpr_(const AddNode* op) override;
@@ -80,6 +81,8 @@ class DataTypeLegalizer : public StmtExprMutator {
   // a map from IterVar before rewrite to that after rewrite,
   // ensures one old IterVar maps to exactly one new IterVar
   std::unordered_map<const IterVarNode*, IterVar> ivmap_;
+  // a map from original vars to ones with new dtype
+  std::unordered_map<const VarNode*, Var> var_remap_;
 };
 
 /*!
@@ -124,7 +127,6 @@ class IndexDataTypeRewriter : public DataTypeLegalizer {
   // indicator of condition
   bool is_condition_{false};
 
-  Map<Var, Var> var_remap_;
   Map<Buffer, Buffer> buffer_remap_;
 };
 

--- a/include/tvm/tir/data_type_rewriter.h
+++ b/include/tvm/tir/data_type_rewriter.h
@@ -53,6 +53,7 @@ class DataTypeLegalizer : public StmtExprMutator {
   Stmt VisitStmt_(const AttrStmtNode* op) override;
   Stmt VisitStmt_(const BlockRealizeNode* op) override;
   Stmt VisitStmt_(const BlockNode* op) override;
+  Stmt VisitStmt_(const LetStmtNode* op) override;
   PrimExpr VisitExpr_(const SelectNode* op) override;
   PrimExpr VisitExpr_(const RampNode* op) override;
   PrimExpr VisitExpr_(const AddNode* op) override;

--- a/src/tir/ir/data_type_rewriter.cc
+++ b/src/tir/ir/data_type_rewriter.cc
@@ -122,6 +122,7 @@ Stmt DataTypeLegalizer::VisitStmt_(const LetStmtNode* op) {
     Map<Var, PrimExpr> vmap{{op->var, new_var}};
     auto new_body = SubstituteWithDataTypeLegalization(
         std::move(body), [&](const Var& var) { return vmap.Get(var); });
+    // We need to visit the body again to insert additional casts
     return LetStmt(new_var, value, this->VisitStmt(new_body), op->span);
   }
 }

--- a/src/tir/transforms/narrow_datatype.cc
+++ b/src/tir/transforms/narrow_datatype.cc
@@ -233,11 +233,11 @@ class NarrowDataTypeRewriter : public IndexDataTypeRewriter {
   }
 
   PrimExpr VisitExpr_(const VarNode* op) final {
-    if (auto it = var_remap_.find(GetRef<Var>(op)); it != var_remap_.end()) {
+    if (auto it = var_remap_.find(op); it != var_remap_.end()) {
       return (*it).second;
     } else if (visitor_.vmap.find(op) != visitor_.vmap.end()) {
       Var v = Var(op->name_hint, visitor_.vmap[op]);
-      var_remap_.Set(GetRef<Var>(op), v);
+      var_remap_[op] = v;
       return v;
     }
     return Parent::VisitExpr_(op);

--- a/src/tir/transforms/narrow_datatype.cc
+++ b/src/tir/transforms/narrow_datatype.cc
@@ -233,12 +233,8 @@ class NarrowDataTypeRewriter : public IndexDataTypeRewriter {
   }
 
   PrimExpr VisitExpr_(const VarNode* op) final {
-    if (auto it = var_remap_.find(op); it != var_remap_.end()) {
-      return (*it).second;
-    } else if (visitor_.vmap.find(op) != visitor_.vmap.end()) {
-      Var v = Var(op->name_hint, visitor_.vmap[op]);
-      var_remap_[op] = v;
-      return v;
+    if (auto it = visitor_.vmap.find(op); !var_remap_.count(op) && it != visitor_.vmap.end()) {
+      var_remap_[op] = Var(op->name_hint, it->second);
     }
     return Parent::VisitExpr_(op);
   }
@@ -266,9 +262,6 @@ class NarrowDataTypeRewriter : public IndexDataTypeRewriter {
  private:
   // the internal visitor to deduce the narrowed dtype
   DataTypeVisitor visitor_;
-  // a map from Var before rewrite to that after rewrite,
-  // ensures one old Var maps to exactly one new Var
-  std::unordered_map<const VarNode*, Var> vmap_;
 };
 
 Stmt NarrowDataType(Stmt stmt, int target_bits) {


### PR DESCRIPTION
Previously, even if the dtype of the rhs of `LetStmt` is casted to int64, the bound variable doesn't get updated. This results in the following invalid IR to be generated:
```
p0_red_temp_v0 = T.alloc_buffer([T.int64(1), T.int64(56), T.int64(56)], dtype="int32")
...
for ax0, ax1, ax2, k3 in T.grid(T.int64(1), T.int64(56), T.int64(56), T.int64(64)):
   with T.block("p0_red_temp"):
        ...
        v_p0_red_temp_v0: T.int32 = T.Select(p0_red_temp_v1[v_ax0, v_ax1, v_ax2] > p0[v_ax0, v_ax1, v_ax2, v_k3] or (p0_red_temp_v1[v_ax0, v_ax1, v_ax2] == p0[v_ax0, v_ax1, v_ax2, v_k3] and T.Cast("int64", p0_red_temp_v0[v_ax0, v_ax1, v_ax2]) < v_k3), T.Cast("int64", p0_red_temp_v0[v_ax0, v_ax1, v_ax2]), v_k3)
        p0_red_temp_v0[v_ax0, v_ax1, v_ax2] = v_p0_red_temp_v0
```

cc @vinx13 