### PR TITLE
[Tests] Replace pytest.main with tvm.testing.main

### DIFF
--- a/tests/micro/stm32/test_code_emitter.py
+++ b/tests/micro/stm32/test_code_emitter.py
@@ -392,4 +392,4 @@ def test_mnist():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([os.path.dirname(__file__)] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_cublas.py
+++ b/tests/python/contrib/test_cublas.py
@@ -378,4 +378,4 @@ def test_relay_cublas_dense(n, m, k, in_dtype, out_dtype):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_binary_elementwise_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_binary_elementwise_matcher.py
@@ -175,4 +175,4 @@ def test_ethosu_binary_elementwise_matcher(
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_block_config.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_block_config.py
@@ -457,4 +457,4 @@ def test_force_block_config_elementwise(ofm_layout, block_config_str, expected_b
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_conv2d_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_conv2d_matcher.py
@@ -179,4 +179,4 @@ def test_ethosu_conv2d_block_config_from_matcher(
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_depthwise2d_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_depthwise2d_matcher.py
@@ -100,4 +100,4 @@ def test_ethosu_depthwise2d_matcher(kernel, stride, dilation, padding, ifm_layou
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_identity_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_identity_matcher.py
@@ -55,4 +55,4 @@ def test_ethosu_identity_matcher():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_inline_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_inline_matcher.py
@@ -47,4 +47,4 @@ def test_ethosu_inline_matcher():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_part.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_part.py
@@ -57,4 +57,4 @@ def test_ethosu_part():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_part_performance.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_part_performance.py
@@ -231,4 +231,4 @@ def test_conv_performance(
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_pooling_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_pooling_matcher.py
@@ -79,4 +79,4 @@ def test_ethosu_pooling_matcher(pool_shape, stride, padding, ifm_layout, ofm_lay
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_ethosu_unary_elementwise_matcher.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_ethosu_unary_elementwise_matcher.py
@@ -131,4 +131,4 @@ def test_ethosu_unary_elementwise_matcher(ofm_shape, ifm_layout, ofm_layout, op_
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_graph.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_graph.py
@@ -201,4 +201,4 @@ def test_create_diamond_graph(MobileNetv2DiamondTE):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_pareto.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_pareto.py
@@ -146,4 +146,4 @@ def test_pareto_cull_plans(num_plans, max_plans, SRAM):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_plan.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_plan.py
@@ -241,4 +241,4 @@ def test_plan_merge(DRAM, SRAM):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_plan_generator.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_plan_generator.py
@@ -302,4 +302,4 @@ if ethosu_enabled:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_propagator.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_propagator.py
@@ -133,4 +133,4 @@ def test_propagate(propagator, input_stripe_config, output_stripe_config):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_proposal_generator.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_proposal_generator.py
@@ -157,4 +157,4 @@ if ethosu_enabled:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_scheduler.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_scheduler.py
@@ -80,4 +80,4 @@ def test_compute_cycles_annotation(SRAM, FLASH, TwoConv2DTE):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_stripe_config.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_stripe_config.py
@@ -212,4 +212,4 @@ def test_count_stripes_sliding_window(stripe_config, expected_stripe_counts):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/cascader/test_tensor_config.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_tensor_config.py
@@ -107,4 +107,4 @@ def test_get_recompute_buffer(DRAM):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_attr_passing.py
+++ b/tests/python/contrib/test_ethosu/test_attr_passing.py
@@ -45,4 +45,4 @@ def test_compiler_attr_default():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -1144,7 +1144,4 @@ def test_tflite_fully_connected(
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_compiler.py
+++ b/tests/python/contrib/test_ethosu/test_compiler.py
@@ -63,4 +63,4 @@ def test_lower_to_tir_arg_count(relay_function, arg_count):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_copy_compute_reordering.py
+++ b/tests/python/contrib/test_ethosu/test_copy_compute_reordering.py
@@ -679,4 +679,4 @@ def test_reordering_based_on_cycles_luts_present():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_create_tiles.py
+++ b/tests/python/contrib/test_ethosu/test_create_tiles.py
@@ -167,4 +167,4 @@ def test_create_tiles_multiple_var_occurrences():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_encode_constants.py
+++ b/tests/python/contrib/test_ethosu/test_encode_constants.py
@@ -529,4 +529,4 @@ def test_constant_as_input():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_extract_constants.py
+++ b/tests/python/contrib/test_ethosu/test_extract_constants.py
@@ -96,4 +96,4 @@ def test_extract_constants_multi():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_layout_optimizer.py
+++ b/tests/python/contrib/test_ethosu/test_layout_optimizer.py
@@ -737,4 +737,4 @@ def test_layout_optimizer_runs_in_compilation_pipeline():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__] + sys.argv[1:])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_legalize.py
+++ b/tests/python/contrib/test_ethosu/test_legalize.py
@@ -2807,4 +2807,4 @@ def test_tflite_hard_swish(ifm_shape):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_lookup_table.py
+++ b/tests/python/contrib/test_ethosu/test_lookup_table.py
@@ -172,4 +172,4 @@ def test_random_lut(accel_type):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_lower_to_te.py
+++ b/tests/python/contrib/test_ethosu/test_lower_to_te.py
@@ -60,4 +60,4 @@ def test_ethosu_conv2d():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_networks.py
+++ b/tests/python/contrib/test_ethosu/test_networks.py
@@ -199,4 +199,4 @@ def test_networks_with_usmp_and_cascader_with_striping(accel_type, model_url, wo
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_preprocess.py
+++ b/tests/python/contrib/test_ethosu/test_preprocess.py
@@ -340,4 +340,4 @@ def test_4ins_2outs():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_remove_concatenates.py
+++ b/tests/python/contrib/test_ethosu/test_remove_concatenates.py
@@ -81,4 +81,4 @@ def test_concat():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_replace_binary_elementwise.py
+++ b/tests/python/contrib/test_ethosu/test_replace_binary_elementwise.py
@@ -341,4 +341,4 @@ def test_shift_binary_elementwise_single(
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_replace_conv2d.py
+++ b/tests/python/contrib/test_ethosu/test_replace_conv2d.py
@@ -818,4 +818,4 @@ def test_conv2d_big_pad():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_replace_copy.py
+++ b/tests/python/contrib/test_ethosu/test_replace_copy.py
@@ -132,4 +132,4 @@ def test_weight_stream():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_replace_identity.py
+++ b/tests/python/contrib/test_ethosu/test_replace_identity.py
@@ -113,4 +113,4 @@ def test_identity(ifm_shape):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_replace_pooling.py
+++ b/tests/python/contrib/test_ethosu/test_replace_pooling.py
@@ -278,4 +278,4 @@ def test_correct_stride_with_multiple_pooling():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_replace_unary_elementwise.py
+++ b/tests/python/contrib/test_ethosu/test_replace_unary_elementwise.py
@@ -154,4 +154,4 @@ def test_unary_elementwise_single(
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_rolling_buffer.py
+++ b/tests/python/contrib/test_ethosu/test_rolling_buffer.py
@@ -100,4 +100,4 @@ def test_rolling_buffer_3_layers(axis, ifm_shape, pool_shape):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_scheduler.py
+++ b/tests/python/contrib/test_ethosu/test_scheduler.py
@@ -234,4 +234,4 @@ def test_copy_constants_fully_connected_weights():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_tir_to_cs_translator.py
+++ b/tests/python/contrib/test_ethosu/test_tir_to_cs_translator.py
@@ -1499,4 +1499,4 @@ def test_translate_ethosu_binary_elementwise_broadcasting(operator_type):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_type_inference.py
+++ b/tests/python/contrib/test_ethosu/test_type_inference.py
@@ -475,4 +475,4 @@ def test_ethosu_unary_elementwise_invalid_dtype():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_ethosu/test_vela_api.py
+++ b/tests/python/contrib/test_ethosu/test_vela_api.py
@@ -560,4 +560,4 @@ def test_encode_weights(accel):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_libtorch_ops.py
+++ b/tests/python/contrib/test_libtorch_ops.py
@@ -90,4 +90,4 @@ def test_backend():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_nnpack.py
+++ b/tests/python/contrib/test_nnpack.py
@@ -217,4 +217,4 @@ def test_convolution_inference_without_weight_transform():
 
 
 if __name__ == "__main__":
-    pytest.main()
+    tvm.testing.main()

--- a/tests/python/contrib/test_vitis_ai/test_vitis_ai_codegen.py
+++ b/tests/python/contrib/test_vitis_ai/test_vitis_ai_codegen.py
@@ -380,4 +380,4 @@ if __name__ == "__main__":
     if sys.platform == "win32":
         print("Skip test on Windows for now")
         sys.exit(0)
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/contrib/test_vitis_ai/test_vitis_ai_runtime_cpu_part.py
+++ b/tests/python/contrib/test_vitis_ai/test_vitis_ai_runtime_cpu_part.py
@@ -84,4 +84,4 @@ if __name__ == "__main__":
     if sys.platform == "win32":
         print("Skip test on Windows for now")
         sys.exit(0)
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/driver/tvmc/test_pass_list.py
+++ b/tests/python/driver/tvmc/test_pass_list.py
@@ -33,4 +33,4 @@ def test_parse_pass_list_str():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -2363,4 +2363,4 @@ def test_forward_split_v2(
 
 
 if __name__ == "__main__":
-    pytest.main(["test_forward.py"])
+    tvm.testing.main()

--- a/tests/python/frontend/paddlepaddle/test_forward.py
+++ b/tests/python/frontend/paddlepaddle/test_forward.py
@@ -1682,4 +1682,4 @@ def test_forward_rnn():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -5835,4 +5835,4 @@ def test_forward_dense_bincount():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/frontend/tensorflow2/test_functional_models.py
+++ b/tests/python/frontend/tensorflow2/test_functional_models.py
@@ -646,4 +646,4 @@ def test_bincount_2d():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/frontend/tensorflow2/test_sequential_models.py
+++ b/tests/python/frontend/tensorflow2/test_sequential_models.py
@@ -165,4 +165,4 @@ def test_tensorlist_read_model():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/integration/test_reduce.py
+++ b/tests/python/integration/test_reduce.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Test scheduling of reduction operations."""
-import pytest
 import numpy as np
 
 import tvm
@@ -675,4 +674,4 @@ def test_reduce_storage_reuse():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/integration/test_winograd_nnpack.py
+++ b/tests/python/integration/test_winograd_nnpack.py
@@ -183,6 +183,4 @@ def test_conv2d_nchw():
 
 
 if __name__ == "__main__":
-    import pytest
-
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_adt.py
+++ b/tests/python/relay/test_adt.py
@@ -821,4 +821,4 @@ def test_iterate():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_analysis_basic_block_normal_form.py
+++ b/tests/python/relay/test_analysis_basic_block_normal_form.py
@@ -211,4 +211,4 @@ def test_higher_order_nested():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_analysis_extract_intermediate_expr.py
+++ b/tests/python/relay/test_analysis_extract_intermediate_expr.py
@@ -127,4 +127,4 @@ def test_extract():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_analysis_extract_operators.py
+++ b/tests/python/relay/test_analysis_extract_operators.py
@@ -104,4 +104,4 @@ def test_extract_resnet():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_auto_scheduler_task_extraction.py
+++ b/tests/python/relay/test_auto_scheduler_task_extraction.py
@@ -291,4 +291,4 @@ def test_custom_hash_func_extract_tasks():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_backend_graph_executor.py
+++ b/tests/python/relay/test_backend_graph_executor.py
@@ -527,4 +527,4 @@ def test_benchmark_end_to_end_rpc():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_backend_interpreter.py
+++ b/tests/python/relay/test_backend_interpreter.py
@@ -286,4 +286,4 @@ def test_functional_returns():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_call_graph.py
+++ b/tests/python/relay/test_call_graph.py
@@ -145,4 +145,4 @@ def test_recursive_func():
 
 
 if __name__ == "__main__":
-    pytest.main()
+    tvm.testing.main()

--- a/tests/python/relay/test_name_mangling.py
+++ b/tests/python/relay/test_name_mangling.py
@@ -35,4 +35,4 @@ def test_mangle_mod_name():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_op_grad_level2.py
+++ b/tests/python/relay/test_op_grad_level2.py
@@ -364,4 +364,4 @@ def test_conv2d_backward_weight_infer_type():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_op_grad_level3.py
+++ b/tests/python/relay/test_op_grad_level3.py
@@ -194,4 +194,4 @@ def test_zeros_ones_grad_dynamic(executor_kind):
 
 
 if __name__ == "__main__":
-    pytest.main()
+    tvm.testing.main()

--- a/tests/python/relay/test_op_grad_level4.py
+++ b/tests/python/relay/test_op_grad_level4.py
@@ -123,4 +123,4 @@ def test_strided_slice_grad(executor_kind):
 
 
 if __name__ == "__main__":
-    pytest.main()
+    tvm.testing.main()

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -864,4 +864,4 @@ def test_extern_concat_injective_fuse():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_op_level6.py
+++ b/tests/python/relay/test_op_level6.py
@@ -173,4 +173,4 @@ def test_searchsorted():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -1948,4 +1948,4 @@ def test_alter_with_reduce():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_convert_op_layout.py
+++ b/tests/python/relay/test_pass_convert_op_layout.py
@@ -2786,4 +2786,4 @@ def test_conv_l2n_convert_layout():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_defunctionalization.py
+++ b/tests/python/relay/test_pass_defunctionalization.py
@@ -227,4 +227,4 @@ def @main(%l: List[int32]) -> int32 {
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_defuse_ops.py
+++ b/tests/python/relay/test_pass_defuse_ops.py
@@ -212,4 +212,4 @@ def test_defuse_complex():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_dynamic_to_static.py
+++ b/tests/python/relay/test_pass_dynamic_to_static.py
@@ -638,4 +638,4 @@ def test_dynamic_to_static_dynamic_if():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_flexible_shape_dispatch.py
+++ b/tests/python/relay/test_pass_flexible_shape_dispatch.py
@@ -116,4 +116,4 @@ def test_multiple_outputs():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -829,4 +829,4 @@ def test_fuse_softmax():
 
 
 if __name__ == "__main__":
-    pytest.main([__pfile__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_gradient.py
+++ b/tests/python/relay/test_pass_gradient.py
@@ -457,4 +457,4 @@ def test_global_function():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_inline.py
+++ b/tests/python/relay/test_pass_inline.py
@@ -827,4 +827,4 @@ def test_callee_not_inline_leaf_inline_extern_compiler():
 
 
 if __name__ == "__main__":
-    pytest.main()
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_lambda_lift.py
+++ b/tests/python/relay/test_pass_lambda_lift.py
@@ -83,4 +83,4 @@ def test_recursive():
 
 
 if __name__ == "__main__":
-    pytest.main()
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_manager.py
+++ b/tests/python/relay/test_pass_manager.py
@@ -614,4 +614,4 @@ def test_print_debug_callback():
 
 
 if __name__ == "__main__":
-    pytest.main()
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_merge_composite.py
+++ b/tests/python/relay/test_pass_merge_composite.py
@@ -980,4 +980,4 @@ def test_type_check():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_remove_unused_functions.py
+++ b/tests/python/relay/test_pass_remove_unused_functions.py
@@ -121,4 +121,4 @@ def test_call_globalvar_without_args():
 
 
 if __name__ == "__main__":
-    pytest.main()
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_simplify_expr.py
+++ b/tests/python/relay/test_pass_simplify_expr.py
@@ -745,4 +745,4 @@ def test_simplify_add():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_to_basic_block_normal_form.py
+++ b/tests/python/relay/test_pass_to_basic_block_normal_form.py
@@ -514,4 +514,4 @@ def test_immutability():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pass_unmatched_cases.py
+++ b/tests/python/relay/test_pass_unmatched_cases.py
@@ -467,4 +467,4 @@ def @expand_on_empty_tuple_match(%a: (List[()], ())) -> int {
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_pipeline_executor.py
+++ b/tests/python/relay/test_pipeline_executor.py
@@ -624,4 +624,4 @@ def test_pipeline():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_tensor_array.py
+++ b/tests/python/relay/test_tensor_array.py
@@ -782,4 +782,4 @@ def test_static_tensor_get_data():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_to_mixed_precision.py
+++ b/tests/python/relay/test_to_mixed_precision.py
@@ -538,4 +538,4 @@ def test_convert_follow_node_with_integer_arguments(target_precision):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/relay/test_type_infer.py
+++ b/tests/python/relay/test_type_infer.py
@@ -583,6 +583,4 @@ def test_argreduce_infer_return_type():
 
 
 if __name__ == "__main__":
-    import sys
-
-    pytest.main(sys.argv)
+    tvm.testing.main()

--- a/tests/python/relay/test_vm_serialization.py
+++ b/tests/python/relay/test_vm_serialization.py
@@ -316,4 +316,4 @@ def test_dynamic_bcast():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_aot_legalize_packed_call.py
+++ b/tests/python/unittest/test_aot_legalize_packed_call.py
@@ -115,4 +115,4 @@ def test_aot_packed_call():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_arith_deduce_bound.py
+++ b/tests/python/unittest/test_arith_deduce_bound.py
@@ -234,4 +234,4 @@ def test_deduce_non_support():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -1071,4 +1071,4 @@ def test_if_then_else_simplify():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_arith_solve_linear_equations.py
+++ b/tests/python/unittest/test_arith_solve_linear_equations.py
@@ -178,4 +178,4 @@ def test_ill_formed():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_arith_solve_linear_inequality.py
+++ b/tests/python/unittest/test_arith_solve_linear_inequality.py
@@ -197,4 +197,4 @@ def test_no_solution():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_ir_container.py
+++ b/tests/python/unittest/test_ir_container.py
@@ -113,4 +113,4 @@ def test_ndarray_container():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_micro_model_library_format.py
+++ b/tests/python/unittest/test_micro_model_library_format.py
@@ -633,4 +633,4 @@ def test_multiple_relay_modules_aot_graph():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+    tvm.testing.main()

--- a/tests/python/unittest/test_target_codegen_cuda.py
+++ b/tests/python/unittest/test_target_codegen_cuda.py
@@ -1045,4 +1045,4 @@ def test_try_unaligned_vector_load():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_analysis_stmt_finding.py
+++ b/tests/python/unittest/test_tir_analysis_stmt_finding.py
@@ -51,4 +51,4 @@ def test_no_anchor_block():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_buffer.py
+++ b/tests/python/unittest/test_tir_buffer.py
@@ -277,4 +277,4 @@ def test_buffer_broadcast_expr():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -525,4 +525,4 @@ def test_tir_allocate():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_te_extern_primfunc.py
+++ b/tests/python/unittest/test_tir_te_extern_primfunc.py
@@ -222,4 +222,4 @@ def tensors_from_extern_op(extern, func):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_convert_for_loops_serial.py
+++ b/tests/python/unittest/test_tir_transform_convert_for_loops_serial.py
@@ -59,4 +59,4 @@ def test_nn_conv2d_add_fixed_point_multiply_clip_cast_cast_2():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_hoist_if.py
+++ b/tests/python/unittest/test_tir_transform_hoist_if.py
@@ -809,4 +809,4 @@ def test_hoisting_op_conv():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_inject_rolling_buffer.py
+++ b/tests/python/unittest/test_tir_transform_inject_rolling_buffer.py
@@ -277,4 +277,4 @@ def test_rolling_buffer_ir_transform():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_ir_utils.py
+++ b/tests/python/unittest/test_tir_transform_ir_utils.py
@@ -37,4 +37,4 @@ def test_convert_ssa():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_lower_warp_memory.py
+++ b/tests/python/unittest/test_tir_transform_lower_warp_memory.py
@@ -349,4 +349,4 @@ def test_lower_warp_memory_divide_by_factor():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_transform_make_unpacked_api.py
+++ b/tests/python/unittest/test_tir_transform_make_unpacked_api.py
@@ -135,4 +135,4 @@ def test_body():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_usmp_analysis_extract_bufferinfo.py
+++ b/tests/python/unittest/test_tir_usmp_analysis_extract_bufferinfo.py
@@ -1690,4 +1690,4 @@ def test_multiple_calls_to_same_primfunc():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__] + sys.argv[1:])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_usmp_transform_convert_pool_allocations_to_offsets.py
+++ b/tests/python/unittest/test_tir_usmp_transform_convert_pool_allocations_to_offsets.py
@@ -622,4 +622,4 @@ def test_tensor_intrin():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__] + sys.argv[1:])
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_usmp_utils.py
+++ b/tests/python/unittest/test_tir_usmp_utils.py
@@ -198,4 +198,4 @@ def test_create_array_buffer_info():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__] + sys.argv[1:])
+    tvm.testing.main()

--- a/tests/python/unittest/test_type_annotation_checker.py
+++ b/tests/python/unittest/test_type_annotation_checker.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Tuple, Union, Callable
 import pytest
 import _pytest
 
+import tvm
 from tvm.tir.schedule._type_checker import type_checked
 
 
@@ -187,4 +188,4 @@ def test_not_matches(type_annotation, case):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main(sys.argv))
+    tvm.testing.main()


### PR DESCRIPTION
This ensures that if you want to run a specific test script then at least it's reasonably consistent and as people copy test files they'll use the new function :smile_cat: