### PR TITLE
[Arith] Use ConstIntBound to remove negative numerator when lowering

### DIFF
--- a/src/tir/transforms/lower_intrin.cc
+++ b/src/tir/transforms/lower_intrin.cc
@@ -120,7 +120,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
       arith::ConstIntBound const_int_bound = analyzer_->const_int_bound(op->a);
       if (const_int_bound->min_value != arith::ConstIntBound::kNegInf &&
           const_int_bound->min_value < 0 &&
-          const_int_bound->min_value > -(1LL << (op->a->dtype.bits() - 1))) {
+          const_int_bound->min_value > Downcast<IntImm>(tvm::min_value(op->a->dtype))->value) {
         IntImm min(op->a->dtype, const_int_bound->min_value);
         PrimExpr ceildiv = truncdiv((op->b - 1) - min, op->b);
         PrimExpr offset_numerator = analyzer_->Simplify(op->a + op->b * ceildiv);
@@ -186,7 +186,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
       arith::ConstIntBound const_int_bound = analyzer_->const_int_bound(op->a);
       if (const_int_bound->min_value != arith::ConstIntBound::kNegInf &&
           const_int_bound->min_value < 0 &&
-          const_int_bound->min_value > -(1LL << (op->a->dtype.bits() - 1))) {
+          const_int_bound->min_value > Downcast<IntImm>(tvm::min_value(op->a->dtype))->value) {
         IntImm min(op->a->dtype, const_int_bound->min_value);
         PrimExpr ceildiv = truncdiv(-min + (op->b - 1), op->b);
         PrimExpr offset_numerator = analyzer_->Simplify(op->a + op->b * ceildiv);


### PR DESCRIPTION
Negative numerators to modulo/remainder operations are not supported by the Vulkan API.  While the SPIR-V instructions
[`OpSRem`](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpSRem) and [`OpSMod`](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpSMod) have identical semantics to `tir::Mod` and `tir::FloorMod`, respectively, use of either instruction within Vulkan results in undefined behavior.  From the [Vulkan spec](https://registry.khronos.org/vulkan/specs/1.3/html/chap37.html#spirvenv-op-prec):

> For the OpSRem and OpSMod instructions, if either operand is negative the result is undefined.
>
> Note: While the OpSRem and OpSMod instructions are supported by the Vulkan environment, they require non-negative values and thus do not enable additional functionality beyond what OpUMod provides.

This issue was first noticed in https://github.com/apache/tvm/pull/13530, where use of integer arithmetic resulted in negative numerators.  This hadn't caused issues previously, because most use of div/mod use a denominator that is a power of two.  In these cases, `tir.LowerIntrin` implements floordiv and floormod using only bitwise operations.  When the denominator isn't a power of two, both `tir::FloorDiv` and `tir::FloorMod` are implemented in terms of `tir::Mod`, which triggers the undefined behavior for negative numerators.

This commit alters the lowering of FloorDiv/FloorMod to TruncDiv/TruncMod, in cases where the denominator is positive, the numerator is sometimes negative, and the range of the numerator is known.  In these cases, the FloorDiv/FloorMod is now implemented by offsetting the numerator such that it is always positive.