### PR TITLE
[HotFix][docs] Use correct Colab button URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,7 +153,7 @@ COLAB_URL_BASE = "https://colab.research.google.com/github"
 IPYTHON_GITHUB_BASE = "apache/tvm-site/blob/asf-site/docs/_downloads/"
 
 # The SVG image of the "Open in Colab" button.
-BUTTON = "https://raw.githubusercontent.com/apache/web-data/main/images/utilities/colab_button.svg"
+BUTTON = "https://raw.githubusercontent.com/tlc-pack/web-data/main/images/utilities/colab_button.svg"
 
 
 @monkey_patch("sphinx_gallery.gen_rst", "save_rst_example")


### PR DESCRIPTION
PR #13627 added Google Colab support to the TVM tutorials, allowing them to be opened interactively with one click. This mostly works - [try it yourself](https://tvm.apache.org/docs/how_to/extend_tvm/low_level_custom_pass.html)!

However, the button to open the tutorial in Google Colab does not render, as #13627 used the wrong URL:

![image](https://user-images.githubusercontent.com/3069006/211185795-5d2e85f5-2308-4df5-b28a-f929bc4b4927.png)

The file is stored in the repo tlc-pack/web-data, not apache/web-data. This PR fixes the bug and makes the button render correctly.

cc @mehrdadh