### PR TITLE
[Docs] Add `typing-extensions` dependency guide

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -331,6 +331,12 @@ like ``virtualenv``.
 
        pip3 install --user numpy decorator attrs
 
+   * If you want to use ``tvmc``: the TVM command line driver.
+
+   .. code:: bash
+
+       pip3 install --user typing-extensions
+
    * If you want to use RPC Tracker
 
    .. code:: bash


### PR DESCRIPTION
Although TVM does not, but `tvmc` depends on `typing-extensions`, which is not mentioned in the documentation.