### PR TITLE
[microNPU] Add support for TFLite PAD

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/util.py
+++ b/python/tvm/relay/backend/contrib/ethosu/util.py
@@ -143,6 +143,16 @@ class QDenseArgs(Enum):
     WEIGHTS_SCALE = 5
 
 
+class QPad2DArgs(Enum):
+    """
+    This is a helper enum to obtain the correct index
+    of nn.pad arguments.
+    """
+
+    IFM = 0
+    IFM_ZERO_POINT = 1
+
+
 def is_npu_func(func: relay.Function) -> bool:
     """Check if the given function is an NPU function."""
     return func.attrs and "Compiler" in func.attrs and func.attrs["Compiler"] == "ethos-u"

--- a/python/tvm/relay/op/contrib/ethosu.py
+++ b/python/tvm/relay/op/contrib/ethosu.py
@@ -1772,6 +1772,86 @@ def hard_swish_pattern():
     return quantize
 
 
+class PadParams:
+    """
+    This class will parse a call to a ethosu.pad2d composite function
+    and extract the parameter information.
+    """
+
+    composite_name = "ethos-u.pad2d"
+    # The ethos-u.pad2d composite function will be transformed to the
+    # ethosu_depthwise_conv2d operator.
+    # For the ethosu_depthwise_conv2d the hardware only supports padding
+    # upto the numbers as follows, so we define such padding limits
+    padding_bounds = [31, 31, 32, 32]
+
+    def __init__(self, func_body: Call):
+        from tvm.relay.backend.contrib.ethosu.util import QPad2DArgs
+
+        # there is no 'layout' attribute in nn.pad
+        layout = "NHWC"
+        self.ifm = TensorParams(
+            tensor=func_body.args[QPad2DArgs.IFM.value],
+            layout=layout,
+            scale=tvm.relay.Constant(tvm.nd.array(np.array(1.0, dtype="float32"))),
+            zero_point=func_body.args[QPad2DArgs.IFM_ZERO_POINT.value],
+        )
+
+        self.padding = self.extract_padding(func_body)
+        self.ofm = TensorParams(
+            tensor=func_body,
+            layout=layout,
+            scale=tvm.relay.Constant(tvm.nd.array(np.array(1.0, dtype="float32"))),
+            zero_point=func_body.args[QPad2DArgs.IFM_ZERO_POINT.value],
+        )
+
+    @staticmethod
+    def extract_padding(
+        padding: relay.Call,
+    ) -> Optional[Tuple[int, int, int, int]]:
+        """
+        Here we check whether a separate padding operation can be rewritten
+        as NPU depthwise convolution. If the padding specified by the
+        separate nn.pad operation is not supported by NPU depthwise convolution,
+        None will be returned. This will cause the nn.pad not to be offloaded to NPU.
+        """
+        pad_width = padding.attrs["pad_width"]
+        if len(pad_width) != 4:
+            return None
+        if list(pad_width[0]) != [0, 0] or list(pad_width[3]) != [0, 0]:
+            return None
+        return [
+            pad_width[1][0],
+            pad_width[2][0],
+            pad_width[1][1],
+            pad_width[2][1],
+        ]
+
+    def is_valid(self):
+        """
+        This function checks whether pad has compatible attributes
+        with the NPU depthwise convolution
+        """
+        tensor_params = [self.ifm, self.ofm]
+        if not check_valid_dtypes(tensor_params, supported_dtypes=[np.uint8, np.int8]):
+            return False
+        if self.ifm.dtype != self.ofm.dtype:
+            return False
+        if not check_batch_size(self.ifm):
+            return False
+        if not self.padding or not check_padding(self.padding, self.padding_bounds):
+            return False
+        if not check_dimensions(self.ifm) or not check_dimensions(self.ofm):
+            return False
+        return True
+
+
+def pad_pattern():
+    """Create pattern for pad"""
+    pattern = is_op("nn.pad")(wildcard(), is_constant())
+    return pattern
+
+
 @register_pattern_table("ethos-u")
 def pattern_table() -> List[Tuple[str, tvm.relay.dataflow_pattern.DFPattern, Callable]]:
     return [
@@ -1804,6 +1884,11 @@ def pattern_table() -> List[Tuple[str, tvm.relay.dataflow_pattern.DFPattern, Cal
             AvgPool2DParams.composite_name,
             qnn_avgpool2d_pattern(),
             lambda pat: AvgPool2DParams(pat).is_valid(),
+        ),
+        (
+            PadParams.composite_name,
+            pad_pattern(),
+            lambda pat: PadParams(pat).is_valid(),
         ),
         (
             AddParams.composite_name,

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -258,6 +258,29 @@ def test_tflite_depthwise_conv2d_with_separate_pad():
     infra.compare_tvm_with_tflite(depthwise_conv2d, [ifm_shape], "ethos-u55-256")
 
 
+@pytest.mark.parametrize("ifm_shape", [(1, 55, 55, 3), (1, 23, 32, 7)])
+@pytest.mark.parametrize("padding", [(0, 1, 0, 0), (1, 1, 1, 1), (1, 1, 5, 5)])
+@pytest.mark.parametrize("const_value", [0, 5, 125, -5])
+def test_tflite_separate_pad(
+    ifm_shape,
+    padding,
+    const_value,
+):
+
+    np.random.seed(0)
+
+    @tf.function
+    def pad2d(x):
+        return tf.pad(
+            x,
+            [[0, 0], [padding[0], padding[2]], [padding[1], padding[3]], [0, 0]],
+            "CONSTANT",
+            const_value,
+        )
+
+    infra.compare_tvm_with_tflite(pad2d, [ifm_shape], "ethos-u55-256")
+
+
 @pytest.mark.parametrize(
     "accel_type",
     ACCEL_TYPES,


### PR DESCRIPTION
A separate nn.pad relay operator is legalized to an Ethos-U depthwise_conv2d operator. For ethosu_depthwise_conv2d the hardware only supports padding up to 31, 31, 32, 32, 32, so the pad size for legalization on the NPU is within these limits.

cc @leandron, @ekalda, @lhutton1