### PR TITLE
[Hexagon][QNN] Improve performance wo QNN canonicalization

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -710,6 +710,10 @@ TVM_DLL Function UnCPS(const Function& f);
  */
 TVM_DLL Expr DeDup(const Expr& e);
 
+namespace legalize {
+TVM_DLL Expr Legalize(const Expr& expr, const std::string& legalize_map_attr_name);
+}  // namespace legalize
+
 }  // namespace relay
 }  // namespace tvm
 

--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -1613,6 +1613,9 @@ constexpr const char* meta_schedule_auto_tensorize_init = "meta_schedule.auto_te
  */
 constexpr const char* warp_execution = "warp_execution";
 
+/*! \brief Mark that a block is disallowed in auto inline. */
+constexpr const char* meta_schedule_inline_rule = "meta_schedule.inline_rule";
+
 /*!
  * \brief Check if attr_key is a pragma key extension
  * \param attr_key The attr key to be compared

--- a/python/tvm/relay/qnn/op/_qnn.py
+++ b/python/tvm/relay/qnn/op/_qnn.py
@@ -22,7 +22,7 @@ from tvm import topi
 from .. import strategy
 from ...op.op import register_compute
 from ...op.op import register_injective_schedule
-from ...op.op import register_strategy, register_pattern, OpPattern
+from ...op.op import register_strategy, register_pattern, register_alter_op_layout, OpPattern
 
 
 @register_compute("qnn.simulated_quantize")
@@ -83,7 +83,13 @@ register_pattern("qnn.concatenate", OpPattern.INJECTIVE)
 
 # qnn.conv2d
 register_strategy("qnn.conv2d", strategy.qnn_conv2d_strategy)
-register_pattern("qnn.conv2d", OpPattern.OUT_ELEMWISE_FUSABLE)
+
+
+@register_alter_op_layout("qnn.conv2d")
+def alter_op_layout_qnn_conv2d(attrs, inputs, tinfos, out_type):
+    """Alternate the layout of qnn.conv2d"""
+    return topi.nn.qnn_conv2d_alter_layout(attrs, inputs, tinfos, out_type)
+
 
 # qnn.dense
 register_strategy("qnn.dense", strategy.qnn_dense_strategy)

--- a/python/tvm/topi/hexagon/qnn/__init__.py
+++ b/python/tvm/topi/hexagon/qnn/__init__.py
@@ -29,3 +29,4 @@ from .nn import *
 from .qdepthwise_conv2d_slice import qdepthwise_conv2d_compute, qdepthwise_conv2d_schedule
 from .adaptive_avg_pool1d import *
 from .global_avg_pool2d import *
+from .conv2d_alter_op import *

--- a/python/tvm/topi/hexagon/qnn/conv2d_alter_op.py
+++ b/python/tvm/topi/hexagon/qnn/conv2d_alter_op.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""QNN Conv2d alter op functions for Hexagon"""
+
+from tvm import relay
+from ...nn import qnn_conv2d_alter_layout
+from ...utils import get_const_tuple
+
+
+@qnn_conv2d_alter_layout.register("hexagon")
+def _alter_qnn_conv2d_layout(attrs, inputs, tinfos, _out_type):
+    data_layout = attrs["data_layout"]
+    kernel_layout = attrs["kernel_layout"]
+    data_tensor, kernel_tensor, _, _, _, _ = tinfos
+
+    if (
+        "int8" in data_tensor.dtype
+        and "int8" in kernel_tensor.dtype
+        and data_layout == "NCHW"
+        and kernel_layout == "OIHW"
+    ):
+        out_channel, in_channel, _, _ = get_const_tuple(kernel_tensor.shape)
+
+        if out_channel % 32 != 0 or in_channel % 4 != 0:
+            return None
+
+        n_elems = 4
+        oc_bn = 32
+        ic_bn = min(in_channel, 32)
+
+        new_attrs = dict(attrs)
+        new_attrs["channels"] = out_channel
+        new_attrs["data_layout"] = "NCHW%dc" % ic_bn
+        new_attrs["kernel_layout"] = "OIHW{:n}i{:n}o{:n}i".format(ic_bn // n_elems, oc_bn, n_elems)
+        new_attrs["out_layout"] = "NCHW%dc" % oc_bn
+
+        return relay.qnn.op.conv2d(*inputs, **new_attrs)
+
+    return None

--- a/python/tvm/topi/nn/qnn.py
+++ b/python/tvm/topi/nn/qnn.py
@@ -236,3 +236,22 @@ def qnn_add_alter_layout(_attrs, _inputs, _tinfos, _out_type):
     Unlike other TOPI functions, this function operates on both graph level and operator level.
     """
     return None
+
+
+@tvm.target.generic_func
+def qnn_conv2d_alter_layout(_attrs, _inputs, _tinfos, _out_type):
+    """Change qnn.conv2D layout.
+    Not to change by default
+
+    Parameters
+    ----------
+    attrs : tvm.ir.Attrs
+        Attributes of current convolution
+    inputs : tvm.relay.Expr
+        Grouped input symbols
+    tinfos : list
+        Input shape and dtype
+    out_type: type
+        The output type
+    """
+    return None

--- a/src/meta_schedule/schedule_rule/auto_inline.cc
+++ b/src/meta_schedule/schedule_rule/auto_inline.cc
@@ -139,6 +139,11 @@ inline InlineType AutoInlineNode::CheckInline(const tir::Schedule& sch,
       }
     }
   }
+  // Cond 6. The block is disallowed for auto inline
+  if (Optional<String> ann =
+          tir::GetAnn<String>(block_sref, tir::attr::meta_schedule_inline_rule)) {
+    if (ann.value() == "disable") return InlineType::kNoInline;
+  }
   // Last cond: Check inline into the consumers or the spatial producer
   tir::StmtSRef scope_block = tir::GetScopeRoot(sch->state(), block_sref,
                                                 /*require_stage_pipeline=*/false);

--- a/src/relay/qnn/op/convolution.cc
+++ b/src/relay/qnn/op/convolution.cc
@@ -860,7 +860,8 @@ operator to understand how to scale back the int32 output to (u)int8 or (u)int16
     .add_type_rel("QnnConv2D", QnnConv2DRel)
     .set_attr<TNonComputational>("TNonComputational", true)
     .set_attr<FTVMLegalize>("FTVMQnnCanonicalize", QnnConv2DCanonicalize)
-    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", QnnConvInferCorrectLayout);
+    .set_attr<FInferCorrectLayout>("FInferCorrectLayout", QnnConvInferCorrectLayout)
+    .set_attr<TOpPattern>("TOpPattern", kOutEWiseFusable);
 
 TVM_REGISTER_GLOBAL("relay.qnn.op._make.conv2d").set_body_typed(MakeQnnConv2D);
 

--- a/src/relay/qnn/op/requantize.cc
+++ b/src/relay/qnn/op/requantize.cc
@@ -76,10 +76,17 @@ InferCorrectLayoutOutput RequantizeInferCorrectLayout(const Attrs& attrs,
       if (old_dim == layout_dim) {
         new_axis = tvm::Integer(axis_index);
       }
-      // Collect only the primal axis.
+
       if (layout_axis.IsPrimal()) {
         new_layout_string += layout_dim;
         axis_index++;
+      } else {
+        // Propogate layout if input_zero_point and input_scale are scalar values.
+        ICHECK_GE(old_in_types.size(), 3);
+        if (IsScalarType(old_in_types[1]) && IsScalarType(old_in_types[2])) {
+          new_layout_string += std::to_string(new_in_layouts[0].FactorOf(layout_axis)) + layout_dim;
+          axis_index++;
+        }
       }
     }
 

--- a/src/relay/qnn/pass/legalize.cc
+++ b/src/relay/qnn/pass/legalize.cc
@@ -30,10 +30,28 @@ namespace qnn {
 
 namespace transform {
 
+// QnnLegalize pass is a wrapper for relay::legalize::Legalize pass.
+Pass QnnLegalize() {
+  runtime::TypedPackedFunc<Function(Function, IRModule, relay::transform::PassContext)> pass_func =
+      [=](Function f, IRModule m, relay::transform::PassContext pc) {
+        return Downcast<Function>(relay::legalize::Legalize(f, "FTVMQnnLegalize"));
+      };
+  return relay::transform::CreateFunctionPass(pass_func, 1, "QnnLegalize", {"InferType"});
+}
+
+// QnnCanonicalize pass is a wrapper for relay::legalize::Legalize pass.
+Pass QnnCanonicalize() {
+  runtime::TypedPackedFunc<Function(Function, IRModule, relay::transform::PassContext)> pass_func =
+      [=](Function f, IRModule m, relay::transform::PassContext pc) {
+        return Downcast<Function>(relay::legalize::Legalize(f, "FTVMQnnCanonicalize"));
+      };
+  return relay::transform::CreateFunctionPass(pass_func, 1, "QnnCanonicalize", {"InferType"});
+}
+
 Pass Legalize() {
   Array<Pass> pass_seqs;
-  pass_seqs.push_back(relay::transform::Legalize("FTVMQnnLegalize"));
-  pass_seqs.push_back(relay::transform::Legalize("FTVMQnnCanonicalize"));
+  pass_seqs.push_back(QnnLegalize());
+  pass_seqs.push_back(QnnCanonicalize());
   relay::transform::Pass seq = relay::transform::Sequential(pass_seqs, "qnn.Legalize");
   return seq;
 }


### PR DESCRIPTION
This commit improves performance of different models tuned with MetaScheduler for Hexagon target and without QNN canonicalization.

Benchmarking of several models on Snapdragon 8gen1 and tuned with MS:

Model               | QNN canon enabled, ms | QNN canon disabled, ms |   speedup   |
-----------------|-----------------------------|----------------------------|--------------|
ResNet, int8      |                   50                   |                     48                |     +4.2%     |
Inception, int8  |                  103                  |                    106               |      -2.8%     |
SRGAN, int8      |                 348                   |                    431               |     -19.3%    |

**What was done:**

1. Added 2 new passes: `QnnLegalize `and `QnnCanonicalize`. But this is just wrappers for Legalize("FTVMQnnLegalize") and Legalize("FTVMQnnCanonicalize").

2. Added ability to disable inline for specific blocks in MetaSchedule AutoInline rule. For example, it can be done through the `T.block_attr({"meta_schedule.inline_rule": "disable"}).`

3. Implemented compute, alter op and legalization functions for `qnn.conv2d` operation (for Hexagon target).