### PR TITLE
[Bugfix][TIR] Fix version conflict with typing for Python 3.8.0

### DIFF
--- a/python/tvm/tir/schedule/_type_checker.py
+++ b/python/tvm/tir/schedule/_type_checker.py
@@ -98,7 +98,7 @@ if hasattr(typing, "_GenericAlias"):
         @staticmethod
         def callable(type_: Any) -> Optional[List[type]]:
             if _Subtype._origin(type_) is collections.abc.Callable:
-                if hasattr(typing, "get_args"):
+                if hasattr(typing, "get_args") and not type_._special:
                     subtypes = typing.get_args(type_)  # type: ignore
                 else:
                     subtypes = type_.__args__


### PR DESCRIPTION
I came across this bug under python3.8.0 with error from `typing.get_args()` while trying to run testcases like `tests/python/unittest/test_tir_schedule_set_axis_separator.py::test_set_axis_separator[transform_layout_named]`
```
>           if get_origin(tp) is collections.abc.Callable and res[0] is not Ellipsis:
E           IndexError: tuple index out of range
```
And the root cause here is a difference  between python3.8.0 and later version:
```diff
        get_args(Callable[[], T][int]) == ([], int)
    """
-     if isinstance(tp, _GenericAlias):    // python3.8.0
+    if isinstance(tp, _GenericAlias) and not tp._special:    // python3.8.15
        res = tp.__args__
        if get_origin(tp) is collections.abc.Callable and res[0] is not Ellipsis:
}
```
So I added it back to `python/tvm/tir/schedule/_type_checker.py`