### PR TITLE
[Arith] Support eq in detect_clip_bound

### DIFF
--- a/src/arith/detect_linear_equation.cc
+++ b/src/arith/detect_linear_equation.cc
@@ -204,6 +204,7 @@ bool DetectClipBound(const PrimExpr& cond,
     if (!op->a.dtype().is_int()) return false;
     canonical = op->a - op->b;
   } else if (const EQNode* op = cond.as<EQNode>()) {
+    if (!op->a.dtype().is_int()) return false;
     canonical = op->a - op->b;
     is_eq = true;
   } else {
@@ -214,31 +215,40 @@ bool DetectClipBound(const PrimExpr& cond,
   if (!LinearEqDetector(var).Detect(canonical, &ret)) return false;
   ret.coeff = analyzer.Simplify(ret.coeff);
   IntervalEntry& p = (*bmap)[var.get()];
+
+  Optional<PrimExpr> min_value;
+  Optional<PrimExpr> max_value;
   if (is_const_int(ret.coeff, 1)) {
     // var + shift >=0 -> var >= -shift
-    if (p.min_value.defined()) {
-      p.min_value = max(p.min_value, -ret.base);
-    } else {
-      p.min_value = -ret.base;
-    }
+    min_value = -ret.base;
     if (is_eq) {
-      p.max_value = p.min_value;
+      max_value = min_value;
     }
-    return true;
-  }
-  if (is_const_int(ret.coeff, -1)) {
+  } else if (is_const_int(ret.coeff, -1)) {
     // -var + shift >=0 -> var <= shift
-    if (p.max_value.defined()) {
-      p.max_value = min(p.max_value, ret.base);
-    } else {
-      p.max_value = ret.base;
-    }
+    max_value = ret.base;
     if (is_eq) {
-      p.min_value = p.max_value;
+      min_value = max_value;
     }
-    return true;
   }
-  return false;
+  if (!min_value.defined() && !max_value.defined()) {
+    return false;
+  }
+  if (min_value.defined()) {
+    if (p.min_value.defined()) {
+      p.min_value = max(p.min_value, min_value.value());
+    } else {
+      p.min_value = min_value.value();
+    }
+  }
+  if (max_value.defined()) {
+    if (p.max_value.defined()) {
+      p.max_value = min(p.max_value, max_value.value());
+    } else {
+      p.max_value = max_value.value();
+    }
+  }
+  return true;
 }
 
 template <typename OP>

--- a/src/arith/detect_linear_equation.cc
+++ b/src/arith/detect_linear_equation.cc
@@ -189,6 +189,7 @@ bool DetectClipBound(const PrimExpr& cond,
   PostOrderVisit(cond, fvisit);
   if (flag != 1) return false;
   // canonical form: exp >= 0
+  bool is_eq = false;
   PrimExpr canonical;
   if (const LTNode* op = cond.as<LTNode>()) {
     if (!op->a.dtype().is_int()) return false;
@@ -202,6 +203,9 @@ bool DetectClipBound(const PrimExpr& cond,
   } else if (const GENode* op = cond.as<GENode>()) {
     if (!op->a.dtype().is_int()) return false;
     canonical = op->a - op->b;
+  } else if (const EQNode* op = cond.as<EQNode>()) {
+    canonical = op->a - op->b;
+    is_eq = true;
   } else {
     return false;
   }
@@ -217,6 +221,9 @@ bool DetectClipBound(const PrimExpr& cond,
     } else {
       p.min_value = -ret.base;
     }
+    if (is_eq) {
+      p.max_value = p.min_value;
+    }
     return true;
   }
   if (is_const_int(ret.coeff, -1)) {
@@ -225,6 +232,9 @@ bool DetectClipBound(const PrimExpr& cond,
       p.max_value = min(p.max_value, ret.base);
     } else {
       p.max_value = ret.base;
+    }
+    if (is_eq) {
+      p.min_value = p.max_value;
     }
     return true;
   }

--- a/tests/python/unittest/test_arith_detect_clip_bound.py
+++ b/tests/python/unittest/test_arith_detect_clip_bound.py
@@ -39,5 +39,18 @@ def test_basic():
     tvm.testing.assert_prim_expr_equal(m[2], 4)
 
 
+def test_trivial_eq():
+    a = te.var("a")
+    b = te.var("b")
+    m = tvm.arith.detect_clip_bound(b == 3, [a, b])
+    tvm.testing.assert_prim_expr_equal(m[2], 3)
+    tvm.testing.assert_prim_expr_equal(m[3], 3)
+    m = tvm.arith.detect_clip_bound(tvm.tir.all(a == 4, b == 3), [a, b])
+    tvm.testing.assert_prim_expr_equal(m[0], 4)
+    tvm.testing.assert_prim_expr_equal(m[1], 4)
+    tvm.testing.assert_prim_expr_equal(m[2], 3)
+    tvm.testing.assert_prim_expr_equal(m[3], 3)
+
+
 if __name__ == "__main__":
     test_basic()


### PR DESCRIPTION
Hi~ this is a patch to handle EqNode in `detect_clip_bound`. We got some regression failure when using this methodology as the power of upstream arithmetic simplifier grows.

Many trivial cases like `x >= 4, x in [0, 4]` seems to get well simplified to `x==4`  and certain assumptions on some condition be non-eq comparation do not hold then.