### PR TITLE
[Docker update] Update ci_cpu tag to the latest from tlcpackstaging

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -19,7 +19,7 @@
 [jenkins]
 ci_arm: tlcpack/ci-arm:20221013-060115-61c9742ea
 ci_cortexm: tlcpack/ci-cortexm:20221013-060115-61c9742ea
-ci_cpu: tlcpack/ci-cpu:20221013-060115-61c9742ea
+ci_cpu: tlcpack/ci-cpu:20230110-070003-d00168ffb
 ci_gpu: tlcpack/ci-gpu:20221128-070141-ae4fd7df7
 ci_hexagon: tlcpack/ci-hexagon:20221013-060115-61c9742ea
 ci_i386: tlcpack/ci-i386:20221013-060115-61c9742ea


### PR DESCRIPTION
After the NPU driver update to 22.11, changes need
to be tested with latest docker build. This commit
updates the hash for ci_cpu from tlcpackstaging.

https://github.com/apache/tvm/pull/13637

cc @lhutton1 