### PR TITLE
[microTVM] CVE-2007-4559 patch.

### DIFF
--- a/apps/microtvm/arduino/template_project/microtvm_api_server.py
+++ b/apps/microtvm/arduino/template_project/microtvm_api_server.py
@@ -177,11 +177,28 @@ class Handler(server.ProjectAPIHandler):
         for component in unused_components:
             shutil.rmtree(source_dir / "standalone_crt" / component)
 
+    def _safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+        def is_within_directory(directory, target):
+
+            abs_directory = os.path.abspath(directory)
+            abs_target = os.path.abspath(target)
+
+            prefix = os.path.commonprefix([abs_directory, abs_target])
+
+            return prefix == abs_directory
+
+        for member in tar.getmembers():
+            member_path = os.path.join(path, member.name)
+            if not is_within_directory(path, member_path):
+                raise Exception("Attempted Path Traversal in Tar File")
+
+        tar.extractall(path, members, numeric_owner)
+
     def _disassemble_mlf(self, mlf_tar_path, source_dir):
         with tempfile.TemporaryDirectory() as mlf_unpacking_dir_str:
             mlf_unpacking_dir = pathlib.Path(mlf_unpacking_dir_str)
             with tarfile.open(mlf_tar_path, "r:") as tar:
-                tar.extractall(mlf_unpacking_dir)
+                self._safe_extract(tar, mlf_unpacking_dir)
 
             model_dir = source_dir / "model"
             model_dir.mkdir()
@@ -421,7 +438,7 @@ class Handler(server.ProjectAPIHandler):
         # Populate extra_files
         if extra_files_tar:
             with tarfile.open(extra_files_tar, mode="r:*") as tf:
-                tf.extractall(project_dir)
+                self._safe_extract(tf, project_dir)
 
         build_extra_flags = '"build.extra_flags='
         if extra_files_tar:

--- a/apps/microtvm/zephyr/template_project/microtvm_api_server.py
+++ b/apps/microtvm/zephyr/template_project/microtvm_api_server.py
@@ -657,7 +657,26 @@ class Handler(server.ProjectAPIHandler):
         # Populate extra_files
         if extra_files_tar:
             with tarfile.open(extra_files_tar, mode="r:*") as tf:
-                tf.extractall(project_dir)
+
+                def is_within_directory(directory, target):
+
+                    abs_directory = os.path.abspath(directory)
+                    abs_target = os.path.abspath(target)
+
+                    prefix = os.path.commonprefix([abs_directory, abs_target])
+
+                    return prefix == abs_directory
+
+                def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+
+                    for member in tar.getmembers():
+                        member_path = os.path.join(path, member.name)
+                        if not is_within_directory(path, member_path):
+                            raise Exception("Attempted Path Traversal in Tar File")
+
+                    tar.extractall(path, members, numeric_owner)
+
+                safe_extract(tf, project_dir)
 
     def build(self, options):
         verbose = options.get("verbose")


### PR DESCRIPTION
Borrowed from https://github.com/tlc-pack/relax/pull/335. The original author is @TrellixVulnTeam from the Advanced Research Center at [Trellix](https://www.trellix.com). 

This PR patches the security vulnerability CVE-2007-4559 in the codebase. CVE-2007-4559 is a 15 year old bug in the Python tarfile package. By using extract() or extractall() on a tarfile object without sanitizing input, a maliciously crafted .tar file could perform a directory path traversal attack. The patch essentially checks to see if all tarfile members will be extracted safely and throws an exception otherwise. Further technical information about the vulnerability can be found in this [blog](https://www.trellix.com/en-us/about/newsroom/stories/research/tarfile-exploiting-the-world.html).

---

Co-authored-by: TrellixVulnTeam <kasimir.schulz@trellix.com>