### PR TITLE
Remove tutorials CMSIS dependency when not needed

### DIFF
--- a/gallery/how_to/work_with_microtvm/install_cmsis.rst
+++ b/gallery/how_to/work_with_microtvm/install_cmsis.rst
@@ -33,3 +33,7 @@ Install CMSIS-NN
         wget ${CMSIS_URL} -O "${DOWNLOAD_PATH}"
         tar -xf "${DOWNLOAD_PATH}" -C ${CMSIS_PATH} --strip-components=1
         rm ${DOWNLOAD_PATH}
+
+        CMSIS_NN_TAG="v4.0.0"
+        CMSIS_NN_URL="https://github.com/ARM-software/CMSIS-NN.git"
+        git clone ${CMSIS_NN_URL} --branch ${CMSIS_NN_TAG} --single-branch ${CMSIS_PATH}/CMSIS-NN

--- a/gallery/how_to/work_with_microtvm/micro_aot.py
+++ b/gallery/how_to/work_with_microtvm/micro_aot.py
@@ -164,7 +164,6 @@ if use_physical_hw:
         "board": BOARD,
         "serial_number": SERIAL,
         "config_main_stack_size": 4096,
-        "cmsis_path": os.getenv("CMSIS_PATH", default="/content/cmsis"),
         "zephyr_base": os.getenv("ZEPHYR_BASE", default="/content/zephyrproject/zephyr"),
     }
 

--- a/gallery/how_to/work_with_microtvm/micro_aot.py
+++ b/gallery/how_to/work_with_microtvm/micro_aot.py
@@ -46,17 +46,12 @@ import os
 # By default, this tutorial runs on x86 CPU using TVM's C runtime. If you would like
 # to run on real Zephyr hardware, you must export the `TVM_MICRO_USE_HW` environment
 # variable. Otherwise (if you are using the C runtime), you can skip installing
-# Zephyr and CMSIS-NN. It takes ~20 minutes to install both of them.
+# Zephyr. It takes ~20 minutes to install Zephyr.
 use_physical_hw = bool(os.getenv("TVM_MICRO_USE_HW"))
 
 ######################################################################
 #
 #     .. include:: ../../../../gallery/how_to/work_with_microtvm/install_zephyr.rst
-#
-
-######################################################################
-#
-#     .. include:: ../../../../gallery/how_to/work_with_microtvm/install_cmsis.rst
 #
 
 ######################################################################

--- a/gallery/how_to/work_with_microtvm/micro_autotune.py
+++ b/gallery/how_to/work_with_microtvm/micro_autotune.py
@@ -38,7 +38,7 @@ from tvm import testing
 testing.utils.install_request_hook(depth=3)
 # sphinx_gallery_end_ignore
 
-# You can skip the following two sections (installing Zephyr and CMSIS-NN) if the following flag is False.
+# You can skip the following section (installing Zephyr) if the following flag is False.
 # Installing Zephyr takes ~20 min.
 import os
 
@@ -49,10 +49,6 @@ use_physical_hw = bool(os.getenv("TVM_MICRO_USE_HW"))
 #     .. include:: ../../../../gallery/how_to/work_with_microtvm/install_zephyr.rst
 #
 
-######################################################################
-#
-#     .. include:: ../../../../gallery/how_to/work_with_microtvm/install_cmsis.rst
-#
 
 ######################################################################
 # Import Python dependencies

--- a/gallery/how_to/work_with_microtvm/micro_tflite.py
+++ b/gallery/how_to/work_with_microtvm/micro_tflite.py
@@ -224,7 +224,6 @@ if use_physical_hw:
         "board": BOARD,
         "serial_number": SERIAL,
         "config_main_stack_size": 4096,
-        "cmsis_path": os.getenv("CMSIS_PATH", default="/content/cmsis"),
         "zephyr_base": os.getenv("ZEPHYR_BASE", default="/content/zephyrproject/zephyr"),
     }
 

--- a/gallery/how_to/work_with_microtvm/micro_tflite.py
+++ b/gallery/how_to/work_with_microtvm/micro_tflite.py
@@ -41,17 +41,12 @@ import os
 # By default, this tutorial runs on x86 CPU using TVM's C runtime. If you would like
 # to run on real Zephyr hardware, you must export the `TVM_MICRO_USE_HW` environment
 # variable. Otherwise (if you are using the C runtime), you can skip installing
-# Zephyr and CMSIS-NN. It takes ~20 minutes to install both of them.
+# Zephyr. It takes ~20 minutes to install Zephyr.
 use_physical_hw = bool(os.getenv("TVM_MICRO_USE_HW"))
 
 ######################################################################
 #
 #     .. include:: ../../../../gallery/how_to/work_with_microtvm/install_zephyr.rst
-#
-
-######################################################################
-#
-#     .. include:: ../../../../gallery/how_to/work_with_microtvm/install_cmsis.rst
 #
 
 ######################################################################


### PR DESCRIPTION
Pr #13656 added support for CMSIS NN from a new GitHub location.
The project at the new location uses a new header `arm_acle.h` which is not always present.
This pr removes the CMSIS dependency for the tutorials in `gallery/how_to/work_with_microtvm` when the tutorials are run with Zephyr.
We need this pr, otherwise, when the docker image will be updated there will be errors, due to the missing header.