### PR TITLE
[Test][Topi] Avoid depending on f32 rounding behavior for crop_and_divide tests

### DIFF
--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -238,12 +238,14 @@ class TestCropAndResize:
 
         if layout == "NHWC":
             img_shape = (10, 224, 224, 3)
-            boxes = np.array([[0.1, 0.2, 0.8, 0.7], [0.2, 0, 1, 0.6]]).astype("float32")
+            boxes = np.array([[0.125, 0.25, 0.8125, 0.71875], [0.25, 0, 1, 0.625]]).astype(
+                "float32"
+            )
             box_indices = np.array([1, 0]).astype("int32")
             crop_size = np.array([20, 30]).astype("int32")
         elif layout == "NCHW":
             img_shape = (5, 3, 255, 255)
-            boxes = np.array([[0, 0, 1, 1], [0.2, 0.1, 1, 0.9]]).astype("float32")
+            boxes = np.array([[0, 0, 1, 1], [0.25, 0.125, 1, 0.9375]]).astype("float32")
             box_indices = np.array([0, 1]).astype("int32")
             crop_size = np.array([30, 30]).astype("int32")
         else:

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -235,29 +235,24 @@ class TestCropAndResize:
             pytest.xfail("Known failing case for these parameters")
 
         extrapolation_value = 0.0
+
+        np.random.seed(0)
+
         eps = 1e-4
 
         if layout == "NHWC":
             img_shape = (10, 224, 224, 3)
-            boxes = np.array(
-                [
-                    [0.125 + eps, 0.25 + eps, 0.8125 - eps, 0.71875 - eps],
-                    [0.25 + eps, 0 + eps, 1 - eps, 0.625 - eps],
-                ]
-            ).astype("float32")
+            boxes = np.random.uniform(size=(2, 4)).astype("float32")
             box_indices = np.array([1, 0]).astype("int32")
             crop_size = np.array([20, 30]).astype("int32")
         elif layout == "NCHW":
             img_shape = (5, 3, 255, 255)
-            boxes = np.array(
-                [[0, 0, 1, 1], [0.25 + eps, 0.125 + eps, 1 - eps, 0.9375 - eps]]
-            ).astype("float32")
+            boxes = np.random.uniform(size=(2, 4)).astype("float32")
             box_indices = np.array([0, 1]).astype("int32")
             crop_size = np.array([30, 30]).astype("int32")
         else:
             raise ValueError(f"Unknown layout: {layout}")
 
-        np.random.seed(0)
         image_data = np.random.uniform(size=img_shape).astype("float32")
 
         ref_res = tvm.topi.testing.crop_and_resize_python(

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -235,17 +235,23 @@ class TestCropAndResize:
             pytest.xfail("Known failing case for these parameters")
 
         extrapolation_value = 0.0
+        eps = 1e-4
 
         if layout == "NHWC":
             img_shape = (10, 224, 224, 3)
-            boxes = np.array([[0.125, 0.25, 0.8125, 0.71875], [0.25, 0, 1, 0.625]]).astype(
-                "float32"
-            )
+            boxes = np.array(
+                [
+                    [0.125 + eps, 0.25 + eps, 0.8125 - eps, 0.71875 - eps],
+                    [0.25 + eps, 0 + eps, 1 - eps, 0.625 - eps],
+                ]
+            ).astype("float32")
             box_indices = np.array([1, 0]).astype("int32")
             crop_size = np.array([20, 30]).astype("int32")
         elif layout == "NCHW":
             img_shape = (5, 3, 255, 255)
-            boxes = np.array([[0, 0, 1, 1], [0.25, 0.125, 1, 0.9375]]).astype("float32")
+            boxes = np.array(
+                [[0, 0, 1, 1], [0.25 + eps, 0.125 + eps, 1 - eps, 0.9375 - eps]]
+            ).astype("float32")
             box_indices = np.array([0, 1]).astype("int32")
             crop_size = np.array([30, 30]).astype("int32")
         else:

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -251,6 +251,7 @@ class TestCropAndResize:
         else:
             raise ValueError(f"Unknown layout: {layout}")
 
+        np.random.seed(0)
         image_data = np.random.uniform(size=img_shape).astype("float32")
 
         ref_res = tvm.topi.testing.crop_and_resize_python(


### PR DESCRIPTION
The `crop_and_resize` operator uses floating-point arithmetic to determine whether an index is within a view-box.  This can cause the use of `extrapolation_value` to depend on target-dependent rounding differences.

For example, this issue was initially noticed on Vulkan during debugging of https://github.com/apache/tvm/pull/13530, and was the result of computing `0.2*223.0 + 0.8*223.0 < 223.0`.  If all intermediates are cast to float32, the left-hand side evaluates to `223.00002`.  If intermediates are kept at a higher precision, the left-hand side evaluates to `223.0`.

The floating-point indexing can't be removed, because the operator must match the API defined by TensorFlow's operator implementation. The TensorFlow documentation for [`CropAndResize`](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/crop-and-resize) does not specify behavior in these cases, nor do the current TensorFlow unit tests check cases of rounding error.  Since the TensorFlow unit tests only use binary fractions for the `boxes` argument, which largely avoids the rounding issue, this commit updates the TVM unit tests to avoid depending on floating-point precision.