### PR TITLE
[Target] Make `key=arm_cpu` --> `key=arm_cpu,cpu` on AArch64

### DIFF
--- a/src/target/parsers/aprofile.cc
+++ b/src/target/parsers/aprofile.cc
@@ -134,15 +134,17 @@ static TargetFeatures GetFeatures(TargetJSON target) {
 }
 
 static Array<String> MergeKeys(Optional<Array<String>> existing_keys) {
-  const String kExtraKey = "arm_cpu";
+  const Array<String> kExtraKeys = {"arm_cpu", "cpu"};
 
   if (!existing_keys) {
-    return {kExtraKey};
+    return kExtraKeys;
   }
 
   Array<String> keys = existing_keys.value();
-  if (std::find(keys.begin(), keys.end(), kExtraKey) == keys.end()) {
-    keys.push_back(kExtraKey);
+  for (String key : kExtraKeys) {
+    if (std::find(keys.begin(), keys.end(), key) == keys.end()) {
+      keys.push_back(key);
+    }
   }
   return keys;
 }

--- a/tests/cpp/target/parsers/aprofile_test.cc
+++ b/tests/cpp/target/parsers/aprofile_test.cc
@@ -48,7 +48,6 @@ static TargetFeatures ParseTargetWithAttrs(String mcpu, String mtriple, Array<St
 TEST(AProfileParser, ParseTargetKeys) {
   TargetJSON target = ParseTarget({});
   Array<String> keys = Downcast<Array<String>>(target.at("keys"));
-  ASSERT_EQ(keys.size(), 1);
   ASSERT_EQ(keys.size(), 2);
   ASSERT_EQ(keys[0], "arm_cpu");
   ASSERT_EQ(keys[1], "cpu");

--- a/tests/cpp/target/parsers/aprofile_test.cc
+++ b/tests/cpp/target/parsers/aprofile_test.cc
@@ -49,7 +49,9 @@ TEST(AProfileParser, ParseTargetKeys) {
   TargetJSON target = ParseTarget({});
   Array<String> keys = Downcast<Array<String>>(target.at("keys"));
   ASSERT_EQ(keys.size(), 1);
+  ASSERT_EQ(keys.size(), 2);
   ASSERT_EQ(keys[0], "arm_cpu");
+  ASSERT_EQ(keys[1], "cpu");
 }
 
 TEST(AProfileParser, ParseTargetWithExistingKeys) {


### PR DESCRIPTION
The `key` in a target is used in dispatching to different strategies. 

In most of the code base `arm_cpu` implies also having `cpu`. E.g. in `python/tvm/target/target.py`:

```
def arm_cpu(...):
    opts = ["-keys=arm_cpu,cpu", "-device=arm_cpu"] + pre_defined_opt
    opts = _merge_opts(opts, options)
    return Target(" ".join(["llvm"] + opts))
```

In `src/target/parsers/mprofile.cc`: 
```
static Array<String> MergeKeys(Optional<Array<String>> existing_keys) {
  const Array<String> kExtraKeys = {"arm_cpu", "cpu"};

  if (!existing_keys) {
    return kExtraKeys;
  }

  Array<String> keys = existing_keys.value();
  for (String key : kExtraKeys) {
    if (std::find(keys.begin(), keys.end(), key) == keys.end()) {
      keys.push_back(key);
    }
  }
  return keys;
}
```

However A-series targets did not have both `arm_cpu` and `cpu` keys. Rather they only had `arm_cpu` keys. This PR makes it so it includes both, matching everywhere else in codebase. 

This also may lead to increased performance speedups as previously A-series targets would dispatch to generic strategy instead of cpu optimized strategy. With this, they should properly dispatch to `arm_cpu` strategy, and fallback to `cpu` strategy.