### PR TITLE
[Adreno] Update interface of AnnotateMemoryScope pass

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -584,7 +584,7 @@ TVM_DLL Pass CapturePostDfsIndexInSpans();
  * \brief Calls device dependent memory scope analysis pass, collects mapping of desirable
  * expr->memory_scope and annotates expressions by VirtualDevice with required memory_scope
  */
-TVM_DLL Pass AnnotateMemoryScope(CompilationConfig config);
+TVM_DLL Pass AnnotateMemoryScope();
 
 /*!
  * \brief Removes non-fused reshapes after lowering the graph.

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -396,7 +396,7 @@ class RelayBuildModule : public runtime::ModuleNode {
     relay_module = transform::Inline()(relay_module);
     relay_module = transform::InferType()(relay_module);
     relay_module = transform::LabelOps()(relay_module);
-    relay_module = transform::AnnotateMemoryScope(config_)(relay_module);
+    relay_module = transform::AnnotateMemoryScope()(relay_module);
 
     ICHECK(relay_module.defined());
 

--- a/src/relay/transforms/annotate_texture_storage.cc
+++ b/src/relay/transforms/annotate_texture_storage.cc
@@ -645,7 +645,7 @@ Map<Expr, Map<Expr, Array<String>>> CollectStorageInfo(const Expr& expr) {
   return storage_info;
 }
 
-Expr AnnotateMemoryScopeExpr(const Expr& expr, const IRModule& mod, CompilationConfig config) {
+Expr AnnotateMemoryScopeExpr(const Expr& expr, const IRModule& mod) {
   auto storage_scope = CollectStorageInfo(expr);
   if (storage_scope.size()) {
     return RewriteVDStorageScopes(storage_scope).Rewrite(expr);
@@ -655,10 +655,10 @@ Expr AnnotateMemoryScopeExpr(const Expr& expr, const IRModule& mod, CompilationC
 }
 
 namespace transform {
-tvm::transform::Pass AnnotateMemoryScope(CompilationConfig config) {
+tvm::transform::Pass AnnotateMemoryScope() {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
-      [config = std::move(config)](Function f, IRModule m, PassContext pc) {
-        return Downcast<Function>(AnnotateMemoryScopeExpr(f, m, config));
+      [](Function f, IRModule m, PassContext pc) {
+        return Downcast<Function>(AnnotateMemoryScopeExpr(f, m));
       };
   return CreateFunctionPass(pass_func, 2, "AnnotateMemoryScope", {});
 }


### PR DESCRIPTION
Removed redundant and unused parameter from AnnotateMemoryScope pass.