### PR TITLE
[TIR][Fix] IndexDataTypeNormalizer not unwrapping float casting

### DIFF
--- a/python/tvm/tir/buffer.py
+++ b/python/tvm/tir/buffer.py
@@ -179,7 +179,7 @@ class Buffer(Object):
 
     def __getitem__(self, indices):
         from ..arith import Analyzer  # pylint: disable=import-outside-toplevel
-        from .expr import BufferLoad, Ramp  # pylint: disable=import-outside-toplevel
+        from .expr import BufferLoad, Ramp, const  # pylint: disable=import-outside-toplevel
         from .stmt import BufferRegion  # pylint: disable=import-outside-toplevel
 
         if not isinstance(indices, (tuple, list)):
@@ -195,7 +195,11 @@ class Buffer(Object):
                     stop = self.shape[i] if index.stop is None else index.stop
                     region.append(Range.from_min_extent(start, analyzer.simplify(stop - start)))
                 else:
-                    region.append(Range.from_min_extent(index, 1))
+                    region.append(
+                        Range.from_min_extent(
+                            index, const(1, index.dtype) if isinstance(index, PrimExpr) else 1
+                        )
+                    )
             return BufferRegion(self, region)
         else:
             expr_indices = []

--- a/src/tir/ir/data_type_rewriter.cc
+++ b/src/tir/ir/data_type_rewriter.cc
@@ -574,7 +574,10 @@ PrimExpr IndexDataTypeNormalizer::VisitExpr_(const VarNode* op) {
 }
 
 PrimExpr IndexDataTypeNormalizer::VisitExpr_(const CastNode* op) {
-  if (is_enabled_) {
+  // Unwrap the cast only when the dtype of this cast is integer dtype.
+  // When the dtype of this cast is not integer dtype, it means that this cast
+  // has some other purpose, and we should not unwrap the cast.
+  if (is_enabled_ && op->dtype.is_int()) {
     PrimExpr value = IndexDataTypeNormalizer::VisitExpr(op->value);
     return value->dtype == target_data_type_ ? value : Cast(target_data_type_, value);
   }


### PR DESCRIPTION
This PR fixes a bug of IndexDataTypeNormalizer that is used by CreatePrimFunc.

#13449 enhanced the normalizer by unwrapping unnecessary casts, by the rule that “if the value to be casted already has the target index dtype`, the cast will be omitted. However, there are cases where a cast here is for other purpose. Like in image resize operators, there are sometimes rounding operation for indices, like
```python
 T.Cast("int64", T.round(T.float32(128) / T.Cast("float32", oh) * T.Cast("float32", v_i2), dtype="float32"))
```
is used as a final index. Note that this PrimExpr contains casts that directly operated on indices, such as `T.Cast("float32", oh)`. This cast is for division purpose, in order to have floating point division result. As a result, it is not expected to unwrap such casts, while the previous implementation did remove the casts.

Therefore, this PR patches this issue by only unwrapping the casts whose target dtype is integer dtype.

cc @vinx13 @tqchen 