### PR TITLE
[MeteSchedule] Bugfix: Add checks for nullable `run_secs`

### DIFF
--- a/src/meta_schedule/measure_callback/update_cost_model.cc
+++ b/src/meta_schedule/measure_callback/update_cost_model.cc
@@ -44,7 +44,8 @@ class UpdateCostModelNode : public MeasureCallbackNode {
     for (int i = 0; i < n; i++) {
       if (!builder_results[i]->error_msg.defined() &&  //
           (runner_results[i]->error_msg.defined() ||   //
-           Sum(runner_results[i]->run_secs.value()) > 0)) {
+           (runner_results[i]->run_secs.defined() &&
+            Sum(runner_results[i]->run_secs.value()) > 0))) {
         pruned_candidate.push_back(measure_candidates[i]);
         pruned_runner_result.push_back(runner_results[i]);
       }


### PR DESCRIPTION
Runner sec is an Optional ObjectRef, so we need to check it's defined before we access its value.