### PR TITLE
[FIX] Fix Typos in Docs and Comments

### DIFF
--- a/docs/dev/how_to/debugging_tvm.rst
+++ b/docs/dev/how_to/debugging_tvm.rst
@@ -53,7 +53,7 @@ optimization). To enable VLOGging, do the following:
    level assignments of the form ``<file_name>=<level>``. Here are some specializations:
 
     - The special filename ``DEFAULT`` sets the VLOG level setting for all files.
-    - ``<level>>`` can be set to ``-1`` to disable VLOG in that file.
+    - ``<level>`` can be set to ``-1`` to disable VLOG in that file.
     - ``<file_name>`` is the name of the c++ source file (e.g. ``.cc``, not ``.h``) relative to the
       ``src/`` directory in the TVM repo. You do not need to supply ``src/`` when specifying the
       file path, but if you do, VLOG will still interpret the path correctly.

--- a/gallery/tutorial/autotvm_relay_x86.py
+++ b/gallery/tutorial/autotvm_relay_x86.py
@@ -344,7 +344,7 @@ tuning_option = {
 # .. admonition:: Setting Tuning Parameters
 #
 #   In this example, in the interest of time, we set the number of trials and
-#   early stopping to 10. You will likely see more performance improvements if
+#   early stopping to 20 and 100. You will likely see more performance improvements if
 #   you set these values to be higher but this comes at the expense of time
 #   spent tuning. The number of trials required for convergence will vary
 #   depending on the specifics of the model and the target platform.

--- a/gallery/tutorial/tvmc_command_line_driver.py
+++ b/gallery/tutorial/tvmc_command_line_driver.py
@@ -52,7 +52,7 @@ capabilities, and set the stage for understanding how TVM works.
 # will vary depending on your platform and installation method.
 #
 # Alternatively, if you have TVM as a Python module on your
-# ``$PYTHONPATH``,you can access the command line driver functionality
+# ``$PYTHONPATH``, you can access the command line driver functionality
 # via the executable python module, ``python -m tvm.driver.tvmc``.
 #
 # For simplicity, this tutorial will mention TVMC command line using

--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -265,7 +265,7 @@ class Var : public Expr {
 };
 
 /*!
- * \brief Returns \p vor with the given properties. A null property denotes 'no change'.
+ * \brief Returns \p var with the given properties. A null property denotes 'no change'.
  * Returns \p var if all properties are unchanged. Otherwise, returns a copy with the new
  * fields.
  */


### PR DESCRIPTION
- [[Fix] Fix Typo in relay/expr.h](https://github.com/apache/tvm/commit/12539a88b54bdf1f301810ac611c50d7ad71f65d)
    - `vor` -> `var`
- [[Fix] Remove Duplicated Right Angle Bracket](https://github.com/apache/tvm/commit/e2cc3309f493c6685bb040ecd9f9d924cd0e89f9)
    - `<level>>` -> `<level>`
- [[Fix] Add WhiteSpace](https://github.com/apache/tvm/commit/25ab989021f0ad09d50fe877e2c07a6110f0e6c6)
    - Add space after comma
- [[Fix] Fix Parameter Values](https://github.com/apache/tvm/commit/138a8354d06adfb49ee74e7d6ee90b4495925112)
    - In the above example of this comment, the number of trials is `20` and the number of early stopping is `100`.