### PR TITLE
[skip ci][ci][docker] Add cross compilation libs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -68,6 +68,7 @@ github:
           - minimal/pr-head
           - riscv/pr-head
           - wasm/pr-head
+          - cross-isa-minimal/pr-head
 
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -24,6 +24,6 @@ ci_gpu: tlcpack/ci-gpu:20221128-070141-ae4fd7df7
 ci_hexagon: tlcpack/ci-hexagon:20221013-060115-61c9742ea
 ci_i386: tlcpack/ci-i386:20221013-060115-61c9742ea
 ci_lint: tlcpack/ci-lint:20221013-060115-61c9742ea
-ci_minimal: tlcpack/ci-minimal:20221013-060115-61c9742ea
+ci_minimal: tlcpack/ci-minimal:20230117-070124-125886350
 ci_riscv: tlcpack/ci-riscv:20221013-060115-61c9742ea
 ci_wasm: tlcpack/ci-wasm:20221013-060115-61c9742ea


### PR DESCRIPTION
This updates ci_minimal to use the changes following on to #13714 and makes the job required for merges. Skipping CI since the job is currently running on PRs/commits but failing since the old ci_minimal image doesn't have the cross-compilation dependencies.