### PR TITLE
[docker][microTVM]Update zephyr version to 3.2 and Zephyr SDK to 0.15.2

### DIFF
--- a/docker/install/ubuntu_init_zephyr_project.sh
+++ b/docker/install/ubuntu_init_zephyr_project.sh
@@ -51,7 +51,7 @@ if [ "$1" == "--branch" ]; then
     BRANCH=$1
     shift
 else
-    BRANCH="v2.7-branch"
+    BRANCH="v3.2-branch"
 fi
 
 COMMIT=

--- a/docker/install/ubuntu_install_zephyr.sh
+++ b/docker/install/ubuntu_install_zephyr.sh
@@ -58,7 +58,6 @@ chmod -R o+w ${ZEPHYR_PROJECT_PATH}
 mkdir zephyr/.cache
 chmod o+rwx zephyr/.cache
 
-#/opt/west/bin/pip3 install -r /opt/zephyrproject/zephyr/scripts/requirements.txt
 pip3 install -r /opt/zephyrproject/zephyr/scripts/requirements.txt
 
 # the requirements above overwrite junintparser with an older version, but it is not

--- a/docker/install/ubuntu_install_zephyr_sdk.sh
+++ b/docker/install/ubuntu_install_zephyr_sdk.sh
@@ -42,10 +42,10 @@ fi
 INSTALLATION_PATH=$1
 shift
 
-ZEPHYR_SDK_VERSION=0.13.2
-ZEPHYR_SDK_FILE=zephyr-sdk-linux-setup.run
-wget --no-verbose -O $ZEPHYR_SDK_FILE \
-    https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION}/zephyr-sdk-${ZEPHYR_SDK_VERSION}-linux-x86_64-setup.run
-chmod +x $ZEPHYR_SDK_FILE
-"./$ZEPHYR_SDK_FILE" -- -d ${INSTALLATION_PATH}
-rm "$ZEPHYR_SDK_FILE"
+ZEPHYR_SDK_FILE_SHA=8e3572fbca9f9ba18a4436c00d680af34a85e239f7fe66c7988da85571a0d23d
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.15.2_linux-x86_64.tar.gz
+echo "$ZEPHYR_SDK_FILE_SHA zephyr-sdk-0.15.2_linux-x86_64.tar.gz" | sha256sum --check
+
+tar xvf zephyr-sdk-0.15.2_linux-x86_64.tar.gz
+mv zephyr-sdk-0.15.2 zephyr-sdk
+rm zephyr-sdk-0.15.2_linux-x86_64.tar.gz


### PR DESCRIPTION
This PR updates Zephyr version and Zephyr SDK version to the latest release only in docker build scripts.