### PR TITLE
[TIR]Fix the crash of the pass RemoveNoOp

### DIFF
--- a/src/tir/transforms/remove_no_op.cc
+++ b/src/tir/transforms/remove_no_op.cc
@@ -119,6 +119,11 @@ class NoOpRemover : public arith::IRMutatorWithAnalyzer {
   Stmt VisitStmt_(const IfThenElseNode* op) final {
     Stmt stmt = Parent::VisitStmt_(op);
     op = stmt.as<IfThenElseNode>();
+    // Sometimes the condition can be statically determined,
+    // in which the type of the `stmt` will not be IfThenElseNode.
+    if (!op) {
+      return stmt;
+    }
     if (op->else_case) {
       bool no_op_else = is_no_op(op->else_case.value());
       bool no_op_then = is_no_op(op->then_case);

--- a/tests/python/unittest/test_tir_transform_remove_no_op.py
+++ b/tests/python/unittest/test_tir_transform_remove_no_op.py
@@ -603,5 +603,19 @@ class TestRemoveWriteIntoTemporary(BaseBeforeAfter):
             C[0] = C[0] + B[i]
 
 
+class TestCertainConditon(BaseBeforeAfter):
+    """The conditon of the If-Else node is certain.
+    This would cause `Segmentation fault` error before."""
+
+    def before():
+        if True:
+            T.evaluate(0)
+        else:
+            T.evaluate(0)
+
+    def expected():
+        T.evaluate(0)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR tries to fix the crash of the pass `RemoveNoOp` when the condition of IfThenElseNode can be statically determined. For example:
```python
  @L.prim_func
  def remove_no_op():
    if True:
      L.evaluate(0)
    else:
      L.evaluate(0)
```
This case will cause `Segment fault` error because `RemoveNoOp` don't cover the case the return of `Parent::VisitStmt_` is not a `IfThenElseNode`, which will result in the `stmt.as<IfThenElseNode>()`  being `null`.