### PR TITLE
[COMMUNITY] alanmacd -> Reviewer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -144,6 +144,7 @@ We do encourage everyone to work anything they are interested in.
 - [Eric Lunderberg](https://github.com/Lunderberg): @Lunderberg
 - [Andrew Z. Luo](https://github.com/AndrewZhaoLuo): @AndrewZhaoLuo
 - [Steven Lyubomirsky](https://github.com/slyubomirsky): @slyubomirsky
+- [Alan MacDonald](https://github.com/alanmacd): @alanmacd
 - [Masahiro Masuda](https://github.com/masahi): @masahi
 - [Andrey Malyshev](https://github.com/elvin-n): @elvin-n
 - [Sergey Mironov](https://github.com/grwlf): @grwlf


### PR DESCRIPTION
Please welcome @alanmacd as a new Reviewer in TVM. Alan has contributed to microTVM and improving CI on Windows and MacOS. Moreover, Alan has been consistently doing code-reviews in many patches related to microTVM.

- [Commits History](https://github.com/apache/tvm/commits?author=alanmacd)
- [Code Review](https://github.com/apache/tvm/pulls?utf8=%E2%9C%93&q=reviewed-by:alanmacd)
- [Discuss Forum](https://discuss.tvm.apache.org/u/alanmacd)