### PR TITLE
[TVMScript] Implicit root block syntax sugar for TVMScript printer

### DIFF
--- a/src/script/printer/tir/function.cc
+++ b/src/script/printer/tir/function.cc
@@ -131,7 +131,51 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
         }
       }
       // Step 4. Handle `func->body`
-      AsDocBody(func->body, p->Attr("body"), frame->get(), d);
+      Optional<tir::Block> implicit_root_block = [&]() -> Optional<tir::Block> {
+        const tir::BlockRealizeNode* root_block_realize = func->body.as<tir::BlockRealizeNode>();
+        if (root_block_realize && !root_block_realize->iter_values.size()) {
+          tir::Block root_block = root_block_realize->block;
+          if (!root_block->annotations.size()) {
+            const tir::BlockRealizeNode* block_realize =
+                root_block->body.as<tir::BlockRealizeNode>();
+            if (root_block->alloc_buffers.size() ||
+                (block_realize && block_realize->block->iter_vars.size()) ||
+                (!block_realize && tir::ContainsNode<tir::BlockRealizeNode>(root_block->body))) {
+              return root_block;
+            }
+          }
+        }
+        return NullOpt;
+      }();
+      if (implicit_root_block) {
+        tir::Block root_block = implicit_root_block.value();
+        ObjectPath root_block_p = p->Attr("body")->Attr("body");
+        // Handle root block `alloc_buffer`
+        for (int i = 0, n = root_block->alloc_buffers.size(); i < n; ++i) {
+          tir::Buffer buffer = root_block->alloc_buffers[i];
+          ObjectPath buffer_p = root_block_p->Attr("alloc_buffers")->ArrayIndex(i);
+          IdDoc lhs = DefineBuffer(buffer, *frame, d);
+          ExprDoc rhs = BufferDecl(buffer, "alloc_buffer", {}, buffer_p, *frame, d);
+          (*frame)->stmts.push_back(AssignDoc(lhs, rhs, NullOpt));
+        }
+        // Handle root block `match_buffer`
+        for (int i = 0, n = root_block->match_buffers.size(); i < n; ++i) {
+          tir::MatchBufferRegion buffer_region = root_block->match_buffers[i];
+          ObjectPath buffer_region_p = root_block_p->Attr("match_buffers")->ArrayIndex(i);
+          StmtDoc doc = d->AsDoc<StmtDoc>(buffer_region, buffer_region_p);
+          (*frame)->stmts.push_back(doc);
+        }
+        // Handle root block `init` block
+        if (root_block->init.defined()) {
+          tir::Stmt init = root_block->init.value();
+          With<TIRFrame> init_frame(d, init);
+          AsDocBody(init, root_block_p->Attr("init"), init_frame->get(), d);
+          (*frame)->stmts.push_back(ScopeDoc(NullOpt, TIR("init")->Call({}), (*init_frame)->stmts));
+        }
+        AsDocBody(root_block->body, root_block_p->Attr("body"), frame->get(), d);
+      } else {
+        AsDocBody(func->body, p->Attr("body"), frame->get(), d);
+      }
       Optional<ExprDoc> ret_type = NullOpt;
       if (func->ret_type.defined()) {
         const auto* as_tuple = func->ret_type.as<TupleTypeNode>();


### PR DESCRIPTION
This PR implements the syntax sugar of implicit root block for new TVMScript printer. This syntax sugar will skip the `T.block("root")`, when the root block realize is simple and we shall reconstruct that root block via `tvm::tir::ScriptComplete` when roundtripping. For example, it will change
```python
@T.prim_func
def root_block_explicitly():
  with T.block("root"):
    a = T.alloc_buffer([128, 128])
    for i, j in T.grid(128, 128):
      with T.block():
        T.evaluate(0)
```
into
```python
@T.prim_func
def main():
  a = T.alloc_buffer((128, 128))
  for i, j in T.grid(128, 128):
    with T.block(""):
      T.evaluate(0)
```