### PR TITLE
[Bugfix][TIR] Fix version conflict with typing for different Python versions (3.8.0-3.10.0)

### DIFF
--- a/python/tvm/tir/schedule/_type_checker.py
+++ b/python/tvm/tir/schedule/_type_checker.py
@@ -26,7 +26,8 @@ import typing
 def _is_none_type(type_: Any) -> bool:
     return type_ is None or type_ is type(None)
 
-def get_subtypes(type_: Any):
+
+def _get_subtypes(type_: Any) -> Any:
     # TODO(@tvm-team): This is hot fix to support subtle difference between python versions
     #                  Would be nice to find a better way if possible
     if hasattr(typing, "_SpecialGenericAlias"):
@@ -37,6 +38,7 @@ def get_subtypes(type_: Any):
     else:
         subtypes = type_.__args__
     return subtypes
+
 
 if hasattr(typing, "_GenericAlias"):
     # For python versions 3.7 onward, check the __origin__ attribute.
@@ -75,7 +77,7 @@ if hasattr(typing, "_GenericAlias"):
         @staticmethod
         def tuple_(type_: Any) -> Optional[List[type]]:
             if _Subtype._origin(type_) is tuple:
-                subtypes = get_subtypes(type_)
+                subtypes = _get_subtypes(type_)
                 return subtypes
             return None
 
@@ -84,7 +86,7 @@ if hasattr(typing, "_GenericAlias"):
             type_: Any,
         ) -> Optional[List[type]]:
             if _Subtype._origin(type_) is Union:
-                subtypes = get_subtypes(type_)
+                subtypes = _get_subtypes(type_)
                 if len(subtypes) == 2 and _is_none_type(subtypes[1]):
                     return [subtypes[0]]
             return None
@@ -92,7 +94,7 @@ if hasattr(typing, "_GenericAlias"):
         @staticmethod
         def union(type_: Any) -> Optional[List[type]]:  # pylint: disable=missing-function-docstring
             if _Subtype._origin(type_) is Union:
-                subtypes = get_subtypes(type_)
+                subtypes = _get_subtypes(type_)
                 if len(subtypes) != 2 or not _is_none_type(subtypes[1]):
                     return list(subtypes)
             return None
@@ -100,7 +102,7 @@ if hasattr(typing, "_GenericAlias"):
         @staticmethod
         def callable(type_: Any) -> Optional[List[type]]:
             if _Subtype._origin(type_) is collections.abc.Callable:
-                subtypes = get_subtypes(type_)
+                subtypes = _get_subtypes(type_)
                 return subtypes
             return None
 

--- a/python/tvm/tir/schedule/_type_checker.py
+++ b/python/tvm/tir/schedule/_type_checker.py
@@ -26,6 +26,17 @@ import typing
 def _is_none_type(type_: Any) -> bool:
     return type_ is None or type_ is type(None)
 
+def get_subtypes(type_: Any):
+    # TODO(@tvm-team): This is hot fix to support subtle difference between python versions
+    #                  Would be nice to find a better way if possible
+    if hasattr(typing, "_SpecialGenericAlias"):
+        if hasattr(typing, "get_args"):
+            subtypes = typing.get_args(type_)  # type: ignore
+        else:
+            subtypes = type_.__args__
+    else:
+        subtypes = type_.__args__
+    return subtypes
 
 if hasattr(typing, "_GenericAlias"):
     # For python versions 3.7 onward, check the __origin__ attribute.
@@ -64,10 +75,7 @@ if hasattr(typing, "_GenericAlias"):
         @staticmethod
         def tuple_(type_: Any) -> Optional[List[type]]:
             if _Subtype._origin(type_) is tuple:
-                if hasattr(typing, "get_args"):
-                    subtypes = typing.get_args(type_)  # type: ignore
-                else:
-                    subtypes = type_.__args__
+                subtypes = get_subtypes(type_)
                 return subtypes
             return None
 
@@ -76,10 +84,7 @@ if hasattr(typing, "_GenericAlias"):
             type_: Any,
         ) -> Optional[List[type]]:
             if _Subtype._origin(type_) is Union:
-                if hasattr(typing, "get_args"):
-                    subtypes = typing.get_args(type_)  # type: ignore
-                else:
-                    subtypes = type_.__args__
+                subtypes = get_subtypes(type_)
                 if len(subtypes) == 2 and _is_none_type(subtypes[1]):
                     return [subtypes[0]]
             return None
@@ -87,10 +92,7 @@ if hasattr(typing, "_GenericAlias"):
         @staticmethod
         def union(type_: Any) -> Optional[List[type]]:  # pylint: disable=missing-function-docstring
             if _Subtype._origin(type_) is Union:
-                if hasattr(typing, "get_args"):
-                    subtypes = typing.get_args(type_)  # type: ignore
-                else:
-                    subtypes = type_.__args__
+                subtypes = get_subtypes(type_)
                 if len(subtypes) != 2 or not _is_none_type(subtypes[1]):
                     return list(subtypes)
             return None
@@ -98,10 +100,7 @@ if hasattr(typing, "_GenericAlias"):
         @staticmethod
         def callable(type_: Any) -> Optional[List[type]]:
             if _Subtype._origin(type_) is collections.abc.Callable:
-                if hasattr(typing, "get_args") and not type_._special:
-                    subtypes = typing.get_args(type_)  # type: ignore
-                else:
-                    subtypes = type_.__args__
+                subtypes = get_subtypes(type_)
                 return subtypes
             return None
 


### PR DESCRIPTION
This PR fixes the following issue with recent PR: https://github.com/apache/tvm/pull/13744#issuecomment-1399038390
Tested with Python 3.8.0, 3.8.15, 3.9.0, 3.10.0.

cc. @vinx13 @Ever-Kid @junrushao 