### PR TITLE
[TVMScript] Add ObjectPath to LiteralDoc

### DIFF
--- a/include/tvm/script/printer/doc.h
+++ b/include/tvm/script/printer/doc.h
@@ -23,6 +23,8 @@
 #include <tvm/node/node.h>
 #include <tvm/runtime/data_type.h>
 
+#include <string>
+
 namespace tvm {
 namespace script {
 namespace printer {
@@ -243,40 +245,54 @@ class LiteralDocNode : public ExprDocNode {
  */
 class LiteralDoc : public ExprDoc {
  protected:
-  explicit LiteralDoc(ObjectRef value);
-  LiteralDoc(ObjectRef value, ObjectPath object_path);
+  explicit LiteralDoc(ObjectRef value, const Optional<ObjectPath>& object_path);
 
  public:
   /*!
    * \brief Create a LiteralDoc to represent None/null/empty value.
+   * \param p The object path
    */
-  static LiteralDoc None() { return LiteralDoc(ObjectRef(nullptr)); }
+  static LiteralDoc None(const Optional<ObjectPath>& p) {
+    return LiteralDoc(ObjectRef(nullptr), p);
+  }
   /*!
    * \brief Create a LiteralDoc to represent integer.
    * \param v The integer value.
+   * \param p The object path
    */
-  static LiteralDoc Int(int64_t v) { return LiteralDoc(IntImm(DataType::Int(64), v)); }
+  static LiteralDoc Int(int64_t v, const Optional<ObjectPath>& p) {
+    return LiteralDoc(IntImm(DataType::Int(64), v), p);
+  }
   /*!
    * \brief Create a LiteralDoc to represent boolean.
    * \param v The boolean value.
+   * \param p The object path
    */
-  static LiteralDoc Boolean(bool v) { return LiteralDoc(IntImm(DataType::Bool(), v)); }
+  static LiteralDoc Boolean(bool v, const Optional<ObjectPath>& p) {
+    return LiteralDoc(IntImm(DataType::Bool(), v), p);
+  }
   /*!
    * \brief Create a LiteralDoc to represent float.
    * \param v The float value.
+   * \param p The object path
    */
-  static LiteralDoc Float(double v) { return LiteralDoc(FloatImm(DataType::Float(64), v)); }
+  static LiteralDoc Float(double v, const Optional<ObjectPath>& p) {
+    return LiteralDoc(FloatImm(DataType::Float(64), v), p);
+  }
   /*!
    * \brief Create a LiteralDoc to represent string.
    * \param v The string value.
+   * \param p The object path
    */
-  static LiteralDoc Str(const String& v) { return LiteralDoc(v); }
+  static LiteralDoc Str(const String& v, const Optional<ObjectPath>& p) { return LiteralDoc(v, p); }
   /*!
    * \brief Create a LiteralDoc to represent string.
    * \param v The string value.
+   * \param p The object path
    */
-  static LiteralDoc DataType(const DLDataType& v) {
-    return LiteralDoc::Str(runtime::DLDataType2String(v));
+  static LiteralDoc DataType(const runtime::DataType& v, const Optional<ObjectPath>& p) {
+    std::string dtype = v.is_void() ? "void" : runtime::DLDataType2String(v);
+    return LiteralDoc::Str(dtype, p);
   }
 
   TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(LiteralDoc, ExprDoc, LiteralDocNode);

--- a/include/tvm/script/printer/ir_docsifier.h
+++ b/include/tvm/script/printer/ir_docsifier.h
@@ -259,11 +259,12 @@ inline void FrameNode::ExitWithScope() {
 
 template <class TDoc>
 inline TDoc IRDocsifierNode::AsDoc(const ObjectRef& obj, const ObjectPath& path) const {
-  if (!obj.defined()) {
-    return Downcast<TDoc>(LiteralDoc::None());
+  if (obj.defined()) {
+    Doc d = IRDocsifier::vtable()(dispatch_tokens.back(), obj, path, GetRef<IRDocsifier>(this));
+    d->source_paths.push_back(path);
+    return Downcast<TDoc>(d);
   }
-  return Downcast<TDoc>(
-      IRDocsifier::vtable()(dispatch_tokens.back(), obj, path, GetRef<IRDocsifier>(this)));
+  return Downcast<TDoc>(LiteralDoc::None(path));
 }
 
 inline void FrameNode::AddDispatchToken(const IRDocsifier& d, const String& token) {

--- a/python/tvm/script/printer/doc.py
+++ b/python/tvm/script/printer/doc.py
@@ -155,17 +155,37 @@ class LiteralDoc(ExprDoc):
 
     value: Union[str, IntImm, FloatImm, None]
 
-    def __init__(self, value: Union[str, float, bool, int, None]):
+    def __init__(
+        self,
+        value: Union[str, float, bool, int, None],
+        path: Optional[ObjectPath] = None,
+    ):
         if value is None:
-            self.__init_handle_by_constructor__(_ffi_api.LiteralDocNone)  # type: ignore # pylint: disable=no-member
+            self.__init_handle_by_constructor__(_ffi_api.LiteralDocNone, path)  # type: ignore # pylint: disable=no-member
         elif isinstance(value, str):
-            self.__init_handle_by_constructor__(_ffi_api.LiteralDocStr, value)  # type: ignore # pylint: disable=no-member
+            self.__init_handle_by_constructor__(
+                _ffi_api.LiteralDocStr,  # type: ignore # pylint: disable=no-member
+                value,
+                path,
+            )
         elif isinstance(value, float):
-            self.__init_handle_by_constructor__(_ffi_api.LiteralDocFloat, value)  # type: ignore # pylint: disable=no-member
+            self.__init_handle_by_constructor__(
+                _ffi_api.LiteralDocFloat,  # type: ignore # pylint: disable=no-member
+                value,
+                path,
+            )
         elif isinstance(value, bool):
-            self.__init_handle_by_constructor__(_ffi_api.LiteralDocBoolean, value)  # type: ignore # pylint: disable=no-member
+            self.__init_handle_by_constructor__(
+                _ffi_api.LiteralDocBoolean,  # type: ignore # pylint: disable=no-member
+                value,
+                path,
+            )
         elif isinstance(value, int):
-            self.__init_handle_by_constructor__(_ffi_api.LiteralDocInt, value)  # type: ignore # pylint: disable=no-member
+            self.__init_handle_by_constructor__(
+                _ffi_api.LiteralDocInt,  # type: ignore # pylint: disable=no-member
+                value,
+                path,
+            )
         else:
             raise TypeError(f"Unsupported type {type(value)} for LiteralDoc")
 

--- a/src/script/printer/doc.cc
+++ b/src/script/printer/doc.cc
@@ -48,16 +48,12 @@ StmtBlockDoc::StmtBlockDoc(Array<StmtDoc> stmts) {
   this->data_ = std::move(n);
 }
 
-LiteralDoc::LiteralDoc(ObjectRef value) {
+LiteralDoc::LiteralDoc(ObjectRef value, const Optional<ObjectPath>& object_path) {
   ObjectPtr<LiteralDocNode> n = make_object<LiteralDocNode>();
   n->value = value;
-  this->data_ = std::move(n);
-}
-
-LiteralDoc::LiteralDoc(ObjectRef value, ObjectPath object_path) {
-  ObjectPtr<LiteralDocNode> n = make_object<LiteralDocNode>();
-  n->value = value;
-  n->source_paths.push_back(object_path);
+  if (object_path.defined()) {
+    n->source_paths.push_back(object_path.value());
+  }
   this->data_ = std::move(n);
 }
 
@@ -250,15 +246,11 @@ TVM_REGISTER_GLOBAL("script.printer.StmtBlockDoc").set_body_typed([](Array<StmtD
 });
 
 TVM_REGISTER_NODE_TYPE(LiteralDocNode);
-TVM_REGISTER_GLOBAL("script.printer.LiteralDocNone").set_body_typed<LiteralDoc()>(LiteralDoc::None);
-TVM_REGISTER_GLOBAL("script.printer.LiteralDocInt")
-    .set_body_typed<LiteralDoc(int64_t)>(LiteralDoc::Int);
-TVM_REGISTER_GLOBAL("script.printer.LiteralDocBoolean")
-    .set_body_typed<LiteralDoc(bool)>(LiteralDoc::Boolean);
-TVM_REGISTER_GLOBAL("script.printer.LiteralDocFloat")
-    .set_body_typed<LiteralDoc(double)>(LiteralDoc::Float);
-TVM_REGISTER_GLOBAL("script.printer.LiteralDocStr")
-    .set_body_typed<LiteralDoc(const String&)>(LiteralDoc::Str);
+TVM_REGISTER_GLOBAL("script.printer.LiteralDocNone").set_body_typed(LiteralDoc::None);
+TVM_REGISTER_GLOBAL("script.printer.LiteralDocInt").set_body_typed(LiteralDoc::Int);
+TVM_REGISTER_GLOBAL("script.printer.LiteralDocBoolean").set_body_typed(LiteralDoc::Boolean);
+TVM_REGISTER_GLOBAL("script.printer.LiteralDocFloat").set_body_typed(LiteralDoc::Float);
+TVM_REGISTER_GLOBAL("script.printer.LiteralDocStr").set_body_typed(LiteralDoc::Str);
 
 TVM_REGISTER_NODE_TYPE(IdDocNode);
 TVM_REGISTER_GLOBAL("script.printer.IdDoc").set_body_typed([](String name) { return IdDoc(name); });

--- a/src/script/printer/ir/ir.cc
+++ b/src/script/printer/ir/ir.cc
@@ -63,26 +63,26 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<GlobalVar>("", [](GlobalVar gv, ObjectPath p, IRDocsifier d) -> Doc {
-      return IR("GlobalVar")->Call({LiteralDoc::Str(gv->name_hint)});
+      return IR("GlobalVar")->Call({LiteralDoc::Str(gv->name_hint, p->Attr("name_hint"))});
     });
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<Op>("", [](Op op, ObjectPath p, IRDocsifier d) -> Doc {
-      return IR("Op")->Call({LiteralDoc::Str(op->name)});
+      return IR("Op")->Call({LiteralDoc::Str(op->name, p->Attr("name"))});
     });
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<TypeVar>("", [](TypeVar type_var, ObjectPath p, IRDocsifier d) -> Doc {
-      return IR("TypeVar")->Call({LiteralDoc::Str(type_var->name_hint),  //
-                                  LiteralDoc::Str(TypeKind2String(type_var->kind))});
+    .set_dispatch<TypeVar>("", [](TypeVar var, ObjectPath p, IRDocsifier d) -> Doc {
+      return IR("TypeVar")->Call({LiteralDoc::Str(var->name_hint, p->Attr("name_hint")),  //
+                                  LiteralDoc::Str(TypeKind2String(var->kind), p->Attr("kind"))});
     });
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<GlobalTypeVar>(  //
-        "", [](GlobalTypeVar type_var, ObjectPath p, IRDocsifier d) -> Doc {
+        "", [](GlobalTypeVar var, ObjectPath p, IRDocsifier d) -> Doc {
           return IR("GlobalTypeVar")
-              ->Call({LiteralDoc::Str(type_var->name_hint),  //
-                      LiteralDoc::Str(TypeKind2String(type_var->kind))});
+              ->Call({LiteralDoc::Str(var->name_hint, p->Attr("name_hint")),
+                      LiteralDoc::Str(TypeKind2String(var->kind), p->Attr("kind"))});
         });
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
@@ -94,7 +94,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<TensorType>("", [](TensorType type, ObjectPath p, IRDocsifier d) -> Doc {
       return IR("TensorType")
           ->Call({d->AsDoc<ExprDoc>(type->shape, p->Attr("shape")),
-                  LiteralDoc::DataType(type->dtype)});
+                  LiteralDoc::DataType(type->dtype, p->Attr("dtype"))});
     });
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)

--- a/src/script/printer/ir/misc.cc
+++ b/src/script/printer/ir/misc.cc
@@ -24,7 +24,7 @@ namespace printer {
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<String>("", [](String s, ObjectPath p, IRDocsifier d) -> Doc {
-      return LiteralDoc::Str(s);
+      return LiteralDoc::Str(s, p);
     });
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)

--- a/src/script/printer/legacy_repr.cc
+++ b/src/script/printer/legacy_repr.cc
@@ -588,7 +588,6 @@ TVM_STATIC_IR_FUNCTOR(ReprLegacyPrinter, vtable)
 
 TVM_STATIC_IR_FUNCTOR(ReprLegacyPrinter, vtable)
     .set_dispatch<PrimFuncNode>([](const ObjectRef& ref, ReprLegacyPrinter* p) {
-      // TODO(tvm-team) redirect to Text printer once we have a good text format.
       auto* node = static_cast<const PrimFuncNode*>(ref.get());
       (*p) << "PrimFunc(" << node->params << ") ";
       if (node->attrs.defined()) {

--- a/src/tir/analysis/control_flow_graph.cc
+++ b/src/tir/analysis/control_flow_graph.cc
@@ -25,7 +25,6 @@
 #include "control_flow_graph.h"
 
 #include <tvm/runtime/registry.h>
-#include <tvm/script/printer/printer.h>
 #include <tvm/tir/analysis.h>
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/expr.h>


### PR DESCRIPTION
This PR adds ObjectPath to LiteralDoc to allow integer/float/string/... literals to have their own object path. This is a final preparation towards structural error rendering when SEqual fails.