### PR TITLE
[Metaschedule] get_top_k should not return not built records

### DIFF
--- a/src/meta_schedule/database/json_database.cc
+++ b/src/meta_schedule/database/json_database.cc
@@ -127,7 +127,11 @@ class JSONDatabaseNode : public DatabaseNode {
     Array<TuningRecord> results;
     results.reserve(top_k);
     for (const TuningRecord& record : this->tuning_records_) {
-      if (!record->run_secs.defined() || record->run_secs.value().empty()) {
+      auto run_secs = record->run_secs;
+      if (!run_secs.defined() || run_secs.value().empty() ||
+          std::all_of(run_secs.value().begin(), run_secs.value().end(),
+                      // 1e10 is used as a stub for undefined measurement times.
+                      [](tvm::FloatImm v) { return v.defined() && v->value == 1e10; })) {
         continue;
       }
       if (record->workload.same_as(workload) ||

--- a/tests/python/unittest/test_meta_schedule_database.py
+++ b/tests/python/unittest/test_meta_schedule_database.py
@@ -554,10 +554,14 @@ def call_get_top_k(run_secs_list, database, k):
 
 @pytest.mark.parametrize(
     "k,expected",
-    [(0, []), (3, [[0.0, 2.0], [2.0], [1.5, 4.5]]), (5, [[0.0, 2.0], [2.0], [1.5, 4.5]])],
+    [
+        (0, []),
+        (4, [[0.0, 2.0], [2.0], [1.5, 4.5], [3.0, 1e10]]),
+        (5, [[0.0, 2.0], [2.0], [1.5, 4.5], [3.0, 1e10]]),
+    ],
 )
 def test_memory_database_get_top_k(k, expected):
-    run_secs_list = [[1.5, 4.5], [], [0.0, 2.0], None, [2.0]]
+    run_secs_list = [[1.5, 4.5], [], [0.0, 2.0], None, [2.0], [3.0, 1e10], [1e10]]
     database = ms.database.MemoryDatabase()
     result = call_get_top_k(run_secs_list, database, k)
     assert result == expected
@@ -565,10 +569,14 @@ def test_memory_database_get_top_k(k, expected):
 
 @pytest.mark.parametrize(
     "k,expected",
-    [(0, []), (3, [[0.0, 2.0], [2.0], [1.5, 4.5]]), (5, [[0.0, 2.0], [2.0], [1.5, 4.5]])],
+    [
+        (0, []),
+        (4, [[0.0, 2.0], [2.0], [1.5, 4.5], [3.0, 1e10]]),
+        (5, [[0.0, 2.0], [2.0], [1.5, 4.5], [3.0, 1e10]]),
+    ],
 )
 def test_json_database_get_top_k(k, expected):
-    run_secs_list = [[1.5, 4.5], [], [0.0, 2.0], None, [2.0]]
+    run_secs_list = [[1.5, 4.5], [], [0.0, 2.0], None, [2.0], [3.0, 1e10], [1e10]]
     with tempfile.TemporaryDirectory() as tmpdir:
         database = _create_tmp_database(tmpdir)
         result = call_get_top_k(run_secs_list, database, k)


### PR DESCRIPTION
Avoid the situation when the records have measurements equal to 1e10, which is used as a stub for an indefinite measurement time, for example, when forming a cost models of the meta scheduler. The result of this will be extracting a record(that fails while building) as the best and an error in applying the tuning.