### PR TITLE
[Metaschedule] ApplyCustomRule only if present

### DIFF
--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -120,6 +120,14 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
     Array<tir::Schedule> result{sch};
     Array<tir::BlockRV> all_blocks = BlockCollector::Collect(sch, f_block_filter_);
 
+    bool isApplyCustomRulePresent = false;
+    for (ScheduleRule sch_rule : sch_rules.value()) {
+      if (ScheduleRule::IsApplyCustomRule(sch_rule)) {
+        isApplyCustomRulePresent = true;
+        break;
+      }
+    }
+
     for (ScheduleRule sch_rule : sch_rules.value()) {
       for (const tir::Schedule& sch : result) {
         stack.emplace_back(sch, all_blocks);
@@ -141,7 +149,7 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
           stack.emplace_back(sch, blocks);
           continue;
         }
-        if (!ScheduleRule::IsApplyCustomRule(sch_rule)) {
+        if (isApplyCustomRulePresent && !ScheduleRule::IsApplyCustomRule(sch_rule)) {
           if (tir::GetAnn<String>(sch->GetSRef(block_rv), "schedule_rule").defined()) {
             stack.emplace_back(sch, blocks);
             continue;

--- a/tests/python/unittest/test_meta_schedule_schedule_rule_apply_custom_rule.py
+++ b/tests/python/unittest/test_meta_schedule_schedule_rule_apply_custom_rule.py
@@ -62,5 +62,22 @@ def test_custom_rule():
     assert "ValueError: Intended for meta_schedule.cpu.test_apply_custom_rule" in str(e_info.value)
 
 
+def test_custom_rule_not_present():
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sch_rules = []
+            space_gen = ms.space_generator.PostOrderApply(sch_rules=sch_rules)
+            ms.tune_tir(
+                mod=Matmul,
+                target="llvm -num-cores=1",
+                work_dir=tmpdir,
+                max_trials_global=1,
+                space=space_gen,
+            )
+    except ValueError as e_info:
+        pytest.fail("custom schedule rule called without ApplyCustomRule()")
+
+
 if __name__ == "__main__":
     test_custom_rule()
+    test_custom_rule_not_present()


### PR DESCRIPTION
When a PrimFunc contains the `schedule_rule` attribute, all schedule rules are ignored except `ApplyCustomRule()`, regardless of whether `ApplyCustomRule()` itself is available or not.

This patch changes the code so that `schedule_rule` attribute is only considered when `ApplyCustomRule()` is one of the schedule_rules passed to post_order_apply and ignored otherwise in favor of the existing custom rules.

This was needed as some topi.nn computes contain the `schedule_rule` attribute, which causes them to be ignored by meta_schedule irrespective of whether a custom rule function is registered or not.