### PR TITLE
[docker][microTVM]Fix Zephyr 0.15.2 SDK installation and separate Zephyr python environment

### DIFF
--- a/docker/Dockerfile.ci_cortexm
+++ b/docker/Dockerfile.ci_cortexm
@@ -76,12 +76,15 @@ COPY install/ubuntu_install_sccache.sh /install/ubuntu_install_sccache.sh
 RUN bash /install/ubuntu_install_sccache.sh
 ENV PATH /opt/sccache:$PATH
 
-# Zephyr SDK deps
+# Zephyr Project
 COPY install/ubuntu_install_zephyr.sh /install/ubuntu_install_zephyr.sh
 COPY install/ubuntu_init_zephyr_project.sh /install/ubuntu_init_zephyr_project.sh
-COPY install/ubuntu_install_zephyr_sdk.sh /install/ubuntu_install_zephyr_sdk.sh
 RUN bash /install/ubuntu_install_zephyr.sh
 ENV ZEPHYR_BASE=/opt/zephyrproject/zephyr
+
+#Zephyr SDK
+COPY install/ubuntu_install_zephyr_sdk.sh /install/ubuntu_install_zephyr_sdk.sh
+RUN bash /install/ubuntu_install_zephyr_sdk.sh /opt/zephyr-sdk
 ENV PATH /opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/bin:$PATH
 
 # NRF

--- a/docker/Dockerfile.ci_riscv
+++ b/docker/Dockerfile.ci_riscv
@@ -80,12 +80,16 @@ COPY install/ubuntu_install_sccache.sh /install/ubuntu_install_sccache.sh
 RUN bash /install/ubuntu_install_sccache.sh
 ENV PATH /opt/sccache:$PATH
 
-# Zephyr SDK deps
+# Zephyr Project
 COPY install/ubuntu_install_zephyr.sh /install/ubuntu_install_zephyr.sh
 COPY install/ubuntu_init_zephyr_project.sh /install/ubuntu_init_zephyr_project.sh
-COPY install/ubuntu_install_zephyr_sdk.sh /install/ubuntu_install_zephyr_sdk.sh
 RUN bash /install/ubuntu_install_zephyr.sh
 ENV ZEPHYR_BASE=/opt/zephyrproject/zephyr
+
+#Zephyr SDK
+COPY install/ubuntu_install_zephyr_sdk.sh /install/ubuntu_install_zephyr_sdk.sh
+RUN bash /install/ubuntu_install_zephyr_sdk.sh /opt/zephyr-sdk
+ENV PATH /opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/bin:$PATH
 
 # Download RISC-V gcc toolchain (linux)
 COPY install/ubuntu_download_xuantie_gcc_linux.sh /install/ubuntu_download_xuantie_gcc_linux.sh

--- a/docker/install/ubuntu_install_zephyr.sh
+++ b/docker/install/ubuntu_install_zephyr.sh
@@ -38,11 +38,27 @@ sudo apt-get update
 
 sudo apt-install-and-clear -y cmake
 
+# Find release version
+apt-get update
+apt-install-and-clear -y \
+    lsb-core
+
+release=$(lsb_release -sc)
+if [ "${release}" == "bionic" ]; then
+     python_cmd="python3"
+elif [ "${release}" == "focal" ]; then
+     python_cmd="python3.8"
+else
+    echo "Don't know which version of python to use for Zephyr."
+    exit 2
+fi
+
 # Current Zephyr version is compatible with python3.8.
 # We use a different python env for Zephyr to test the
 # real world scenario where TVM and Zephyr could be in different
 # python environments.
-python3.8 -m pip install west
+# TODO: use virtual env for Zephyr.
+$python_cmd -m pip install west
 
 # Init ZephyrProject
 ZEPHYR_PROJECT_PATH=/opt/zephyrproject
@@ -62,4 +78,4 @@ chmod -R o+w ${ZEPHYR_PROJECT_PATH}
 mkdir zephyr/.cache
 chmod o+rwx zephyr/.cache
 
-python3.8 -m pip install -r /opt/zephyrproject/zephyr/scripts/requirements.txt
+$python_cmd -m pip install -r /opt/zephyrproject/zephyr/scripts/requirements.txt

--- a/docker/install/ubuntu_install_zephyr.sh
+++ b/docker/install/ubuntu_install_zephyr.sh
@@ -38,7 +38,11 @@ sudo apt-get update
 
 sudo apt-install-and-clear -y cmake
 
-pip3 install west
+# Current Zephyr version is compatible with python3.8.
+# We use a different python env for Zephyr to test the
+# real world scenario where TVM and Zephyr could be in different
+# python environments.
+python3.8 -m pip install west
 
 # Init ZephyrProject
 ZEPHYR_PROJECT_PATH=/opt/zephyrproject
@@ -58,10 +62,4 @@ chmod -R o+w ${ZEPHYR_PROJECT_PATH}
 mkdir zephyr/.cache
 chmod o+rwx zephyr/.cache
 
-pip3 install -r /opt/zephyrproject/zephyr/scripts/requirements.txt
-
-# the requirements above overwrite junintparser with an older version, but it is not
-# used so overwrite it again with the correct version
-pip3 install junitparser==2.4.2
-
-bash /install/ubuntu_install_zephyr_sdk.sh /opt/zephyr-sdk
+python3.8 -m pip install -r /opt/zephyrproject/zephyr/scripts/requirements.txt

--- a/docker/install/ubuntu_install_zephyr_sdk.sh
+++ b/docker/install/ubuntu_install_zephyr_sdk.sh
@@ -43,9 +43,14 @@ INSTALLATION_PATH=$1
 shift
 
 ZEPHYR_SDK_FILE_SHA=8e3572fbca9f9ba18a4436c00d680af34a85e239f7fe66c7988da85571a0d23d
+ZEPHYR_SDK_FILE_NAME=zephyr-sdk-0.15.2_linux-x86_64.tar.gz
 wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.15.2_linux-x86_64.tar.gz
-echo "$ZEPHYR_SDK_FILE_SHA zephyr-sdk-0.15.2_linux-x86_64.tar.gz" | sha256sum --check
+echo "$ZEPHYR_SDK_FILE_SHA ${ZEPHYR_SDK_FILE_NAME}" | sha256sum --check
 
-tar xvf zephyr-sdk-0.15.2_linux-x86_64.tar.gz
-mv zephyr-sdk-0.15.2 zephyr-sdk
-rm zephyr-sdk-0.15.2_linux-x86_64.tar.gz
+mkdir ${INSTALLATION_PATH}
+tar -xvf ${ZEPHYR_SDK_FILE_NAME} -C "${INSTALLATION_PATH}" --strip-components=1
+rm ${ZEPHYR_SDK_FILE_NAME}
+
+# Setup SDK
+cd ${INSTALLATION_PATH}
+./setup.sh -h


### PR DESCRIPTION
This PR fixes the SDK installation and separates SDK installation from ZephyrProject installation.
Also it separates the Zephyr python environment to 3.8 which is the required version and it is different than tvm virtual env.