### PR TITLE
[CLML][CODEGEN] CLML native codegen utility

### DIFF
--- a/apps/cpp_clml/CMakeLists.txt
+++ b/apps/cpp_clml/CMakeLists.txt
@@ -31,11 +31,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 #we do not want to pass -fno-exceptions
 if(${CMAKE_CXX_FLAGS} MATCHES "-fno-exceptions")
+  message ( WARNING "Disabling -fno-exceptions")
   string(REGEX REPLACE "-fno-exceptions" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif()
 
 #we do not want to pass -fno-rtti
 if(${CMAKE_CXX_FLAGS} MATCHES "-fno-rtti")
+  message ( WARNING "Disabling -fno-rtti")
   string(REGEX REPLACE "-fno-rtti" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif()
 

--- a/apps/cpp_clml/CMakeLists.txt
+++ b/apps/cpp_clml/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(clml_run VERSION 2.0)
+
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  message( FATAL_ERROR "CMAKE_TOOLCHAIN_FILE Not set, forcing exit. Suggested value: {ANDROID_NDK_PATH}/build/cmake/android.toolchain.cmake." )
+endif(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+
+if(NOT DEFINED ANDROID_ABI)
+  message( FATAL_ERROR "ANDROID_ABI Not set, forcing exit. Suggested value(s): arm64-v8a (64), armeabi-v7a (32)" )
+endif(NOT DEFINED ANDROID_ABI)
+
+if(NOT DEFINED CLML_SDK)
+  message( FATAL_ERROR "CLML_SDK Not set, forcing exit." )
+endif(NOT DEFINED CLML_SDK)
+
+# CMake/Android variables
+set( ANDROID_STL  c++_static CACHE STRING "Target Android STL") # default
+
+# Source variables
+set( OPENCL_INCLUDE_DIRS  ${CLML_SDK} CACHE PATH "filepath to OpenCL headers")
+set( ANDROID_SOURCE_TREE /path/to/android/au/ CACHE FILEPATH "optional filepath to the Android AU Tree, for building examples using ION Buffers") # tree required to build ION/DMA Buffer samples
+
+#c++ 11 is required
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+# set(CMAKE_CXX_FLAGS "-Wall -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+#we do not want to pass -fno-exceptions
+if(${CMAKE_CXX_FLAGS} MATCHES "-fno-exceptions")
+  string(REGEX REPLACE "-fno-exceptions" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+endif()
+
+#we do not want to pass -fno-rtti
+if(${CMAKE_CXX_FLAGS} MATCHES "-fno-rtti")
+  string(REGEX REPLACE "-fno-rtti" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+endif()
+
+set(COMMON_SOURCE_FILES
+        clml_models.cc
+        clml_runner.cc
+        clml_runner.h
+        main.cc
+        ../../3rdparty/cnpy/cnpy.cpp
+        )
+
+include_directories(
+        src
+        ${OPENCL_INCLUDE_DIRS}
+        "../../3rdparty/dmlc-core/include"
+        "../../3rdparty/cnpy/"
+        )
+
+add_executable(clml_run ${COMMON_SOURCE_FILES})
+target_link_options(clml_run PRIVATE -Wl,--unresolved-symbols=ignore-in-shared-libs)
+target_link_libraries(clml_run ${CLML_SDK}/lib64/libOpenCL.so z)

--- a/apps/cpp_clml/CMakeLists.txt
+++ b/apps/cpp_clml/CMakeLists.txt
@@ -14,18 +14,20 @@ if(NOT DEFINED CLML_SDK)
   message( FATAL_ERROR "CLML_SDK Not set, forcing exit." )
 endif(NOT DEFINED CLML_SDK)
 
+if (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY STREQUAL "ONLY")
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+endif()
+
+find_library(CLML_LIBRARIES NAMES libOpenCL.so NO_DEFAULT_PATH PATHS ${CLML_SDK}/lib ${CLML_SDK}/lib64)
+
 # CMake/Android variables
 set( ANDROID_STL  c++_static CACHE STRING "Target Android STL") # default
 
 # Source variables
 set( OPENCL_INCLUDE_DIRS  ${CLML_SDK} CACHE PATH "filepath to OpenCL headers")
-set( ANDROID_SOURCE_TREE /path/to/android/au/ CACHE FILEPATH "optional filepath to the Android AU Tree, for building examples using ION Buffers") # tree required to build ION/DMA Buffer samples
 
-#c++ 11 is required
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-# set(CMAKE_CXX_FLAGS "-Wall -Werror")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 #we do not want to pass -fno-exceptions
 if(${CMAKE_CXX_FLAGS} MATCHES "-fno-exceptions")
@@ -54,4 +56,4 @@ include_directories(
 
 add_executable(clml_run ${COMMON_SOURCE_FILES})
 target_link_options(clml_run PRIVATE -Wl,--unresolved-symbols=ignore-in-shared-libs)
-target_link_libraries(clml_run ${CLML_SDK}/lib64/libOpenCL.so z)
+target_link_libraries(clml_run ${CLML_LIBRARIES} z)

--- a/apps/cpp_clml/README.md
+++ b/apps/cpp_clml/README.md
@@ -1,0 +1,145 @@
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
+# OpenCLML Debug Tool
+
+Tool to generate OpenCLML source file given a model from any framework and compile it as a native application that runs on Android target.
+This tool helps to debug or triage OpenCLML offloaded sub graphs as a standalone application.
+
+### Codegen
+
+Models can be downloaded from well known frameworks like Tensorflow, PyTorch, TFLite, Onnx ..etc.
+Assuming  ```resnet50.h5``` is a Keras ResNet50 model file, use the below command to generate a OpenCLML source for the model.
+
+```bash
+python3 scripts/clml_codegen.py resnet50.h5
+```
+
+Above command generates ```clml_models.cc``` and ```clml_params.npz```.
+```clml_models.cc``` contains cpp representation of all OpenCLML subgraphs offloaded by TVM compilation. This file will be used to build tool ```clml_run```.
+```clml_params.npz``` is a numpy dump of all params involved in all sub graphs of TVM module. This file to be copied to target.
+
+### Build Tool
+
+Copy the generated models source ```clml_models.cc``` under ```cpp_clml```.
+
+Below commands will compile the tool ```clml_run``` from generated source and other static dependents.
+
+```bash
+cmake -S . -B build_64 -D ANDROID_ABI=arm64-v8a -D CLML_SDK=<CLML SDK PATH> -D CMAKE_TOOLCHAIN_FILE=<ANDROID NDK PATH>/build/cmake/android.toolchain.cmake -D ANDROID_PLATFORM=latest
+cmake --build build_64
+```
+
+### Run the tool
+
+Copy ```clml_params.npz``` and ```clml_run``` to the target Android device
+
+```bash
+Android:/data/local/tmp $ ./clml_run --dump-meta
+Input         =
+Output        =
+Params        =
+DumpMeta      = 1
+.....
+Subgraph Name: tvmgen_default_clml_main_1
+    Input Count  : 1
+    Output Count : 1
+    Input MetaInfo
+        Input: tvmgen_default_clml_main_1_input_0
+            Dtype : float32
+            Shape : [1, 1, 1, 2048]
+    Output MetaInfo
+        Output: tvmgen_default_clml_main_1_layer_out_5
+            Dtype : float32
+            Shape : [1, 1000]
+
+Subgraph Name: tvmgen_default_clml_main_0
+    Input Count  : 1
+    Output Count : 1
+    Input MetaInfo
+        Input: tvmgen_default_clml_main_0_input_0
+            Dtype : float32
+            Shape : [1, 3, 230, 230]
+    Output MetaInfo
+        Output: tvmgen_default_clml_main_0_layer_out_406
+            Dtype : float32
+            Shape : [1, 2048, 1, 1]
+.....
+```
+
+The meta information above indicates that the ResNet50 model is partitioned such a way that there exists two OpenCLML subgraphs.
+
+Below command runs the models by setting the parameters from ```clml_params.npz```.
+
+```bash
+Android:/data/local/tmp $ ./clml_run --params=./clml_params.npz
+Input         =
+Output        =
+Params        = ./clml_params.npz
+DumpMeta      = 1
+......
+CLMLRunner Loading Params:./clml_params.npz
+CLMLRunner Loading Params:./clml_params.npz
+CLMLRunner::Run :tvmgen_default_clml_main_1
+CLMLRunner::Run :tvmgen_default_clml_main_0
+......
+```
+
+Below command can set the model inputs from ```input.npz```  and can output sub graph outputs to ```output.npz```.
+```input.npz``` should have numpy arrays for ```tvmgen_default_clml_main_1_input_0``` from sub graph ```tvmgen_default_clml_main_1``` and ```tvmgen_default_clml_main_0_input_0``` from sub graph ```tvmgen_default_clml_main_0```.
+
+```bash
+Android:/data/local/tmp $ ./clml_run --params=./clml_params.npz --input=./input.npz --output=./output.npz                                                                       <
+Input         = ./input.npz
+Output        = ./output.npz
+Params        = ./clml_params.npz
+DumpMeta      = 0
+Call Build Modules
+CLMLRunner Constructor: Input:./input.npz Output:./output.npz Params:./clml_params.npz
+CLML Target version:3
+CLMLRunner Loading Params:./clml_params.npz
+CLMLRunner Loading Inputs:./input.npz
+Set Input For:tvmgen_default_clml_main_1_input_0
+
+CLMLRunner Constructor: Input:./input.npz Output:./output.npz Params:./clml_params.npz
+CLML Target version:3
+CLMLRunner Loading Params:./clml_params.npz
+CLMLRunner Loading Inputs:./input.npz
+Set Input For:tvmgen_default_clml_main_0_input_0
+
+Loop Through the Modules
+CLMLRunner::Run :tvmgen_default_clml_main_1
+Saving Output:tvmgen_default_clml_main_1_layer_out_5
+CLMLRunner::Run :tvmgen_default_clml_main_0
+Saving Output:tvmgen_default_clml_main_0_layer_out_406
+......
+```
+
+The generated output file ```output.npz``` contains all the output from all sub modules.
+In this case it contains ```tvmgen_default_clml_main_1_layer_out_5``` for sub graph ```tvmgen_default_clml_main_1``` and ```tvmgen_default_clml_main_0_layer_out_406``` for sub graph ```tvmgen_default_clml_main_0``` as shown below.
+
+
+```bash
+Android:/data/local/tmp $ unzip -l output.npz
+Archive:  output.npz
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+     4080  1980-00-00 00:00   tvmgen_default_clml_main_1_layer_out_5.npy
+     8272  1980-00-00 00:00   tvmgen_default_clml_main_0_layer_out_406.npy
+---------                     -------
+    12352                     2 files
+```

--- a/apps/cpp_clml/clml_runner.cc
+++ b/apps/cpp_clml/clml_runner.cc
@@ -59,12 +59,12 @@ CLMLRunner::CLMLRunner(std::string name, ToolArgs& args, cl_platform_id arg_plat
   cl_int majorVersions[MAX_VERSIONS];
   cl_int minorVersions[MAX_VERSIONS];
   cl_uint numVersions = 0;
-  result = clQueryMLInterfaceVersionsQCOM(NULL, NULL, 0, &numVersions);
+  result = clQueryMLInterfaceVersionsQCOM(nullptr, nullptr, 0, &numVersions);
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
   CLML_SDK_TEST_AND_EXIT(numVersions > 0u);
   CLML_SDK_TEST_AND_EXIT(numVersions <= MAX_VERSIONS);
 
-  result = clQueryMLInterfaceVersionsQCOM(majorVersions, minorVersions, numVersions, NULL);
+  result = clQueryMLInterfaceVersionsQCOM(majorVersions, minorVersions, numVersions, nullptr);
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
 
   for (cl_uint i = 0; i < numVersions; ++i) {
@@ -74,7 +74,7 @@ CLMLRunner::CLMLRunner(std::string name, ToolArgs& args, cl_platform_id arg_plat
       break;
     }
   }
-  CLML_SDK_TEST_AND_EXIT(this->h_ClmlIntf != NULL);
+  CLML_SDK_TEST_AND_EXIT(this->h_ClmlIntf != nullptr);
 
   result = h_ClmlIntf->clCreateMLTuningCacheQCOM(&tuning_cache);
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
@@ -103,8 +103,8 @@ int CLMLRunner::Run(void) {
   cl_int result;
 
   for (size_t i = 0; i < this->function.size(); ++i) {
-    result =
-        h_ClmlIntf->clEnqueueMLOpQCOM(queue, this->function[i], this->descriptorSet, 0, NULL, NULL);
+    result = h_ClmlIntf->clEnqueueMLOpQCOM(queue, this->function[i], this->descriptorSet, 0,
+                                           nullptr, nullptr);
     CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
   }
   if (!r_args.output.empty()) {
@@ -155,13 +155,13 @@ void CLMLRunner::PrintMetaInfo(void) { LOG(INFO) << "\n" << this->meta_info; }
 void CLMLRunner::CopyDataToCLMLTensor(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> tensor,
                                       void* data, cl_ml_tensor_layout_qcom layout) {
   cl_int result = 0;
-  cl_event evt = NULL;
+  cl_event evt = nullptr;
   result = h_ClmlIntf->clEnqueueWriteMLTensorDataQCOM(this->queue, data, layout, tensor->tensor,
                                                       tensor->memory,
-                                                      0,      // n waitlist
-                                                      NULL,   // waitlist
-                                                      &evt);  // event
-  CLML_SDK_TEST_AND_EXIT((evt != NULL) && result == CL_SUCCESS);
+                                                      0,        // n waitlist
+                                                      nullptr,  // waitlist
+                                                      &evt);    // event
+  CLML_SDK_TEST_AND_EXIT((evt != nullptr) && result == CL_SUCCESS);
 }
 
 /*!
@@ -173,12 +173,12 @@ void CLMLRunner::CopyDataToCLMLTensor(std::shared_ptr<cl_ml_tensor_memory_desc_q
 void CLMLRunner::CopyDataFromCLMLTensor(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> tensor,
                                         void* data, cl_ml_tensor_layout_qcom layout) {
   cl_int result = 0;
-  cl_event readEvent = NULL;
+  cl_event readEvent = nullptr;
   // Read the output tensor
   result = h_ClmlIntf->clEnqueueReadMLTensorDataQCOM(this->queue, tensor->tensor, tensor->memory,
                                                      data, layout,
                                                      0,            // n waitlist
-                                                     NULL,         // waitlist
+                                                     nullptr,      // waitlist
                                                      &readEvent);  // event
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
   result = clWaitForEvents(1, &readEvent);
@@ -194,12 +194,12 @@ cl_int CLMLRunner::AllocateTensorMemory(
     std::shared_ptr<cl_ml_tensor_memory_desc_qcom> pTensorMemDesc) {
   uint32_t size = 0;
   cl_int result = CL_OUT_OF_HOST_MEMORY;
-  cl_mem buffer = NULL;
+  cl_mem buffer = nullptr;
 
   result = h_ClmlIntf->clGetMLTensorMemorySizeQCOM(context, pTensorMemDesc->tensor, &size);
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
 
-  buffer = clCreateBuffer(context, CL_MEM_READ_WRITE, size, NULL, &result);
+  buffer = clCreateBuffer(context, CL_MEM_READ_WRITE, size, nullptr, &result);
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
 
   pTensorMemDesc->memory = buffer;
@@ -257,7 +257,7 @@ void CLMLRunner::MakeUnusedTensor(void) {
   cl_ml_tensor_desc_qcom desc = {};
   desc.num_dimensions = CL_TENSOR_UNUSED_QCOM;
   this->unusedTensor = std::make_shared<cl_ml_tensor_memory_desc_qcom>();
-  result = this->h_ClmlIntf->clCreateMLTensorQCOM(this->context, NULL, &desc,
+  result = this->h_ClmlIntf->clCreateMLTensorQCOM(this->context, nullptr, &desc,
                                                   &(this->unusedTensor->tensor));
   CLML_SDK_TEST_AND_EXIT(this->unusedTensor && result == CL_SUCCESS);
 }
@@ -321,7 +321,8 @@ std::shared_ptr<cl_ml_tensor_memory_desc_qcom> CLMLRunner::MakeCLMLTensor(
   auto tensor_dsc = std::make_shared<cl_ml_tensor_memory_desc_qcom>();
   cl_ml_tensor_desc_qcom desc = {
       cl_dtype, layout, dims.n, dims.c, dims.h, dims.w, 0, CL_TENSOR_DIMENSIONS_4D_QCOM, {0}};
-  result = this->h_ClmlIntf->clCreateMLTensorQCOM(this->context, NULL, &desc, &tensor_dsc->tensor);
+  result =
+      this->h_ClmlIntf->clCreateMLTensorQCOM(this->context, nullptr, &desc, &tensor_dsc->tensor);
   CLML_SDK_TEST_AND_EXIT(tensor_dsc->tensor && result == CL_SUCCESS);
   return tensor_dsc;
 }
@@ -372,7 +373,7 @@ void CLMLRunner::MakeConv2D(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input
                                            {clml_dilation[0], clml_dilation[1]},
                                            0,
                                            cl_arithmetic_mode};
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   if (!has_act) {
     result = h_ClmlIntf->clCreateMLOpConvolutionForwardQCOM(
         this->context, 0, &conv_desc, input_desc->tensor, weight_desc->tensor, bias_desc->tensor,
@@ -381,7 +382,7 @@ void CLMLRunner::MakeConv2D(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input
   } else {
     result = h_ClmlIntf->clCreateMLOpFusedConvolutionActivationForwardQCOM(
         this->context, 0, &conv_desc, &act_desc, input_desc->tensor, weight_desc->tensor,
-        bias_desc->tensor, NULL, output_desc->tensor, &op, tuning_cache);
+        bias_desc->tensor, nullptr, output_desc->tensor, &op, tuning_cache);
     CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
   }
   this->function.push_back(op);
@@ -443,7 +444,7 @@ void CLMLRunner::MakeConv2DWithBN(std::shared_ptr<cl_ml_tensor_memory_desc_qcom>
                                            {clml_dilation[0], clml_dilation[1]},
                                            0,
                                            cl_arithmetic_mode};
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_ml_op_batchnorm_desc_qcom bn_desc = {CL_BATCHNORM_MODE_SPATIAL_QCOM, cl_arithmetic_mode};
   if (!has_act) {
     result = h_ClmlIntf->clCreateMLOpFusedConvolutionBatchNormForwardQCOM(
@@ -454,7 +455,7 @@ void CLMLRunner::MakeConv2DWithBN(std::shared_ptr<cl_ml_tensor_memory_desc_qcom>
   } else {
     result = h_ClmlIntf->clCreateMLOpFusedConvolutionBatchNormActivationForwardQCOM(
         this->context, 0, &conv_desc, &bn_desc, &act_desc, input_desc->tensor, weight_desc->tensor,
-        bias_desc->tensor, output_desc->tensor, NULL, bn_mean->tensor, bn_var->tensor,
+        bias_desc->tensor, output_desc->tensor, nullptr, bn_mean->tensor, bn_var->tensor,
         bn_scale->tensor, bn_bias->tensor, &op, tuning_cache);
     CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
   }
@@ -472,7 +473,7 @@ void CLMLRunner::MakeRelu(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_d
                           std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
                           cl_activation_function_qcom relu_type, std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
   cl_ml_op_activation_desc_qcom act_desc = {relu_type, CL_PROPAGATE_NAN_QCOM, cl_arithmetic_mode};
 
@@ -502,7 +503,7 @@ void CLMLRunner::MakeBatchNorm(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> in
                                std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_var,
                                std::vector<float> bn_attrs, std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
 
   cl_ml_op_batchnorm_desc_qcom bn_desc = {CL_BATCHNORM_MODE_SPATIAL_QCOM, cl_arithmetic_mode};
@@ -531,7 +532,7 @@ void CLMLRunner::MakePool2D(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input
                             std::vector<cl_uint> padding, std::string pool_type,
                             std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
 
   cl_ml_op_pooling_desc_qcom pool_desc = {
@@ -567,7 +568,7 @@ void CLMLRunner::MakeGlobalPool2D(std::shared_ptr<cl_ml_tensor_memory_desc_qcom>
                                   std::vector<cl_uint> in_shape, std::string pool_type,
                                   std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
   cl_ml_op_pooling_desc_qcom pool_desc = {
       pool_type == "nn.global_max_pool2d" ? CL_POOLING_MODE_MAX_QCOM
@@ -599,7 +600,7 @@ void CLMLRunner::MakeReshape(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> inpu
                              std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
                              std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
 
   result = h_ClmlIntf->clCreateMLOpReshapeQCOM(this->context, 0, input_desc->tensor,
@@ -620,7 +621,7 @@ void CLMLRunner::MakeConcatenate(
     std::vector<std::shared_ptr<cl_ml_tensor_memory_desc_qcom>> in_list,
     std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc, int axis, std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
 
   cl_ml_tensor_qcom* concatInputs = new cl_ml_tensor_qcom[in_list.size()];
@@ -650,7 +651,7 @@ void CLMLRunner::MakeDense(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_
                            std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bias_desc,
                            std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
 
   cl_ml_op_convolution_desc_qcom conv_desc = {CL_CONVOLUTION_MODE_CONVOLUTION_QCOM,
@@ -681,7 +682,7 @@ void CLMLRunner::MakeSoftMax(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> inpu
                              std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
                              std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
 
   cl_ml_op_softmax_desc_qcom softmax_desc = {CL_SOFTMAX_ALGORITHM_ACCURATE_QCOM,
@@ -706,7 +707,7 @@ void CLMLRunner::MakePad(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_de
                          std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
                          std::string pad_mode, std::vector<cl_uint> padding, std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
 
   cl_pad_mode_qcom clml_pad_mode = CL_PAD_MODE_CONSTANT_QCOM;
@@ -741,7 +742,7 @@ void CLMLRunner::MakeBatchFlatten(std::shared_ptr<cl_ml_tensor_memory_desc_qcom>
                                   std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
                                   std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
 
   result = h_ClmlIntf->clCreateMLOpReshapeQCOM(this->context, 0, input_desc->tensor,
@@ -763,7 +764,7 @@ void CLMLRunner::MakeClip(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_d
                           float a_min, std::string dtype) {
   LOG(INFO) << "MakeClip called";
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
 
   cl_ml_op_clip_desc_qcom clip_desc = {
@@ -788,7 +789,7 @@ void CLMLRunner::MakeBinaryOp(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> inp
                               std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
                               std::string op_name, std::string dtype) {
   cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
-  cl_ml_op_qcom op = NULL;
+  cl_ml_op_qcom op = nullptr;
   cl_int result;
 
   cl_binary_op_qcom binary_op = CL_TENSOR_OP_ADD_QCOM;

--- a/apps/cpp_clml/clml_runner.cc
+++ b/apps/cpp_clml/clml_runner.cc
@@ -1,0 +1,826 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file clml_runner.cc
+ * \brief CLML model runner implementation.
+ */
+
+#include "clml_runner.h"
+
+#include <fstream>
+#include <iostream>
+#include <streambuf>
+#include <string>
+
+namespace tvm {
+namespace runtime {
+
+/*!
+ * \brief Constructor for CLMLRunner.
+ * \param name is unique name for the sub graph or this CLML Runner.
+ * \param args tool or utility arguments.
+ * \param arg_platform_id is the OpenCL platform.
+ * \param arg_context is the OpenCL context.
+ * \param arg_device_id is the OpenCL device_id.
+ * \param arg_queue is the OpenCL queue.
+ */
+CLMLRunner::CLMLRunner(std::string name, ToolArgs& args, cl_platform_id arg_platform_id,
+                       cl_context arg_context, cl_device_id arg_device_id,
+                       cl_command_queue arg_queue)
+    : r_args(args),
+      r_name(name),
+      platform(arg_platform_id),
+      context(arg_context),
+      device_id(arg_device_id),
+      queue(arg_queue) {
+  LOG(INFO) << "CLMLRunner Constructor: Input:" << r_args.input << " Output:" << r_args.output
+            << " Params:" << r_args.params;
+  cl_int result;
+
+  // Query and Get CLML Interface
+  static const cl_uint MAX_VERSIONS = 256;
+  cl_int majorVersions[MAX_VERSIONS];
+  cl_int minorVersions[MAX_VERSIONS];
+  cl_uint numVersions = 0;
+  result = clQueryMLInterfaceVersionsQCOM(NULL, NULL, 0, &numVersions);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+  CLML_SDK_TEST_AND_EXIT(numVersions > 0u);
+  CLML_SDK_TEST_AND_EXIT(numVersions <= MAX_VERSIONS);
+
+  result = clQueryMLInterfaceVersionsQCOM(majorVersions, minorVersions, numVersions, NULL);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+
+  for (cl_uint i = 0; i < numVersions; ++i) {
+#if CL_QCOM_ML_OPS_H_MAJOR_VERSION == 2
+    if (majorVersions[i] == 2) {
+      this->h_ClmlIntf = clGetMLInterfaceV2QCOM(0);
+      LOG(INFO) << "CLML Target version:" << majorVersions[i];
+      break;
+    }
+#endif
+#if CL_QCOM_ML_OPS_H_MAJOR_VERSION == 3
+    if (majorVersions[i] == 3) {
+      this->h_ClmlIntf = clGetMLInterfaceV3QCOM(0);
+      LOG(INFO) << "CLML Target version:" << majorVersions[i];
+      break;
+    }
+#endif
+  }
+  CLML_SDK_TEST_AND_EXIT(this->h_ClmlIntf != NULL);
+
+  result = h_ClmlIntf->clCreateMLTuningCacheQCOM(&tuning_cache);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+
+  if (!r_args.params.empty()) {
+    LOG(INFO) << "CLMLRunner Loading Params:" << r_args.params;
+    npz_params = cnpy::npz_load(r_args.params);
+  } else {
+    LOG(INFO) << "CLMLRunner : No parameters supplied";
+  }
+
+  if (!r_args.input.empty()) {
+    LOG(INFO) << "CLMLRunner Loading Inputs:" << r_args.input;
+    npz_input = cnpy::npz_load(r_args.input);
+  } else {
+    LOG(INFO) << "CLMLRunner : No Input's given. Asuming a dry-run.";
+  }
+}
+
+/*!
+ * \brief Call one cycle of execution for the model.
+ * \return 0 on success else error code.
+ */
+int CLMLRunner::Run(void) {
+  LOG(INFO) << "CLMLRunner::Run :" << GetModName();
+  cl_int result;
+
+  for (size_t i = 0; i < this->function.size(); ++i) {
+    result =
+        h_ClmlIntf->clEnqueueMLOpQCOM(queue, this->function[i], this->descriptorSet, 0, NULL, NULL);
+    CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+  }
+  if (!r_args.output.empty()) {
+    for (auto it = this->outputs.begin(); it != this->outputs.end(); it++) {
+      auto out_name = it->first;
+      auto out_desc = it->second;
+      auto dtype = outputs_dtypes[out_name];
+      auto shape = outputs_shapes[out_name];
+      size_t size = 1;
+      for (auto si : shape) size *= si;
+      if (dtype == "float32") {
+        void* data = (void*)malloc(size * 4);
+        CopyDataFromCLMLTensor(out_desc, data);
+        LOG(INFO) << "Saving Output:" << out_name;
+        cnpy::npz_save<float>(r_args.output, out_name, (float*)data, shape, "a");
+        free(data);
+      } else if (dtype == "int8") {
+        void* data = (void*)malloc(size);
+        CopyDataFromCLMLTensor(out_desc, data);
+        LOG(INFO) << "Saving Output:" << out_name;
+        cnpy::npz_save<int8_t>(r_args.output, out_name, (int8_t*)data, shape, "a");
+        free(data);
+      } else {
+        LOG(WARNING) << "Unsupported dtype to dump :" << dtype;
+      }
+    }
+  }
+  return 0;
+}
+
+/*!
+ * \brief Set meta information.
+ * \param minfo is the meta information of the sub graph.
+ */
+void CLMLRunner::SetMetaInfo(std::string minfo) { this->meta_info = minfo; }
+
+/*!
+ * \brief Print the meta information.
+ */
+void CLMLRunner::PrintMetaInfo(void) { LOG(INFO) << "\n" << this->meta_info; }
+
+/*!
+ * \brief Copy the bytedata into tensor.
+ * \param tensor is tensor descriptor to copy data.
+ * \param data is pointer to bytedata.
+ * \param layout is source data layout
+ */
+void CLMLRunner::CopyDataToCLMLTensor(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> tensor,
+                                      void* data, cl_ml_tensor_layout_qcom layout) {
+  cl_int result = 0;
+  cl_event evt = NULL;
+  result = h_ClmlIntf->clEnqueueWriteMLTensorDataQCOM(this->queue, data, layout, tensor->tensor,
+                                                      tensor->memory,
+                                                      0,      // n waitlist
+                                                      NULL,   // waitlist
+                                                      &evt);  // event
+  CLML_SDK_TEST_AND_EXIT((evt != NULL) && result == CL_SUCCESS);
+}
+
+/*!
+ * \brief Copy the bytedata into tensor.
+ * \param tensor is tensor descriptor to copy data.
+ * \param data is pointer to bytedata.
+ * \param layout is source data layout
+ */
+void CLMLRunner::CopyDataFromCLMLTensor(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> tensor,
+                                        void* data, cl_ml_tensor_layout_qcom layout) {
+  cl_int result = 0;
+  cl_event readEvent = NULL;
+  // Read the output tensor
+  result = h_ClmlIntf->clEnqueueReadMLTensorDataQCOM(this->queue, tensor->tensor, tensor->memory,
+                                                     data, layout,
+                                                     0,            // n waitlist
+                                                     NULL,         // waitlist
+                                                     &readEvent);  // event
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+  result = clWaitForEvents(1, &readEvent);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+}
+
+/*!
+ * \brief Allocate backing memory for tensor descriptor.
+ * \param pTensorMemDesc is tensor descriptor.
+ * \return memory alocation status (CL_SUCCESS or error code).
+ */
+cl_int CLMLRunner::AllocateTensorMemory(
+    std::shared_ptr<cl_ml_tensor_memory_desc_qcom> pTensorMemDesc) {
+  uint32_t size = 0;
+  cl_int result = CL_OUT_OF_HOST_MEMORY;
+  cl_mem buffer = NULL;
+
+  result = h_ClmlIntf->clGetMLTensorMemorySizeQCOM(context, pTensorMemDesc->tensor, &size);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+
+  buffer = clCreateBuffer(context, CL_MEM_READ_WRITE, size, NULL, &result);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+
+  pTensorMemDesc->memory = buffer;
+
+  return result;
+}
+
+/*!
+ * \brief Allocate memory for all tensor dectiptor in storage map.
+ * Also set data for tensors given params and input numpy dumps
+ */
+void CLMLRunner::AllocateMemAndPopulateParams(void) {
+  cl_int result;
+  for (auto it = this->storage_map.begin(); it != this->storage_map.end(); it++) {
+    auto node_id = it->first;
+    auto tensor_desc = it->second;
+
+    AllocateTensorMemory(tensor_desc);
+
+    if (npz_params.find(node_id) != npz_params.end()) {
+      CopyDataToCLMLTensor(tensor_desc, npz_params[node_id].data<char>());
+    }
+
+    if (npz_input.find(node_id) != npz_input.end()) {
+      LOG(INFO) << "Set Input For:" << node_id;
+      CopyDataToCLMLTensor(tensor_desc, npz_input[node_id].data<char>());
+    }
+
+    this->tensorMemDescs.push_back(*tensor_desc);
+  }
+  if (!r_args.dump_meta) {
+    // Cross check all params
+    for (auto nid : consts) {
+      if (npz_params.find(nid) == npz_params.end()) {
+        LOG(WARNING) << "Param not found in npz:" << nid;
+      }
+    }
+  }
+  // Initialize Tensor Descriptors
+  result = h_ClmlIntf->clCreateMLTensorMemoryDescriptorSetQCOM(&this->descriptorSet);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+
+  result = h_ClmlIntf->clUpdateMLTensorMemoryDescriptorSetQCOM(
+      this->descriptorSet, static_cast<uint32_t>(this->tensorMemDescs.size()),
+      this->tensorMemDescs.data());
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+}
+
+/*!
+ * \brief Initializes an unused tensor.
+ * It is used across operators.
+ */
+void CLMLRunner::MakeUnusedTensor(void) {
+  cl_int result;
+  cl_ml_tensor_desc_qcom desc = {};
+  desc.num_dimensions = CL_TENSOR_UNUSED_QCOM;
+  this->unusedTensor = std::make_shared<cl_ml_tensor_memory_desc_qcom>();
+  result = this->h_ClmlIntf->clCreateMLTensorQCOM(this->context, NULL, &desc,
+                                                  &(this->unusedTensor->tensor));
+  CLML_SDK_TEST_AND_EXIT(this->unusedTensor && result == CL_SUCCESS);
+}
+
+/*!
+ * \brief Convert string datatype to cl channel type.
+ * \param dtype the datatype as string.
+ * \return cl channel type corresponding to the datatype.
+ */
+cl_channel_type MakeCLDataType(const std::string& dtype) {
+  if (dtype == "float32") {
+    return CL_FLOAT;
+  } else if (dtype == "float16") {
+    return CL_HALF_FLOAT;
+  } else {
+    LOG(FATAL) << "Datatype: " << dtype << " unsupported by CLML runtime";
+  }
+  return CL_FLOAT;
+}
+
+/*!
+ * \brief Map operator arthemetic mode based on data type and accumulation type.
+ * \param data_type is cl channel type for computation.
+ * \param acc_tpe is cl channel type for accumulation.
+ * \return the arthemetic mode.
+ */
+cl_arithmetic_mode_qcom MakeCLArithMode(const cl_channel_type& data_type,
+                                        const cl_channel_type& acc_type = CL_FLOAT) {
+  if (data_type == CL_FLOAT && acc_type == CL_FLOAT) {
+    return CL_ARITHMETIC_MODE_FP32_QCOM;
+  } else if (data_type == CL_HALF_FLOAT && acc_type == CL_FLOAT) {
+    return CL_ARITHMETIC_MODE_FP16_ACC32_QCOM;
+  } else if (data_type == CL_HALF_FLOAT && acc_type == CL_HALF_FLOAT) {
+    return CL_ARITHMETIC_MODE_FP16_QCOM;
+  } else {
+    LOG(FATAL) << "Datatype " << data_type << " unsupported by CLML runtime";
+  }
+}
+
+/*!
+ * \brief Creates a tensor descriptor.
+ * \param shape is shape of tensor.
+ * \param dtype tensor data type as string.
+ * \param layout is the data layout to be used.
+ * \return newly created tensor descriptor.
+ */
+std::shared_ptr<cl_ml_tensor_memory_desc_qcom> CLMLRunner::MakeCLMLTensor(
+    std::vector<size_t> shape, std::string dtype, cl_ml_tensor_layout_qcom layout) {
+  cl_int result;
+  tensor_dims_t dims;
+  // Make sure the tensors with dimensions less than 4 are padded with 1.
+  shape.push_back(1);
+  shape.push_back(1);
+  shape.push_back(1);
+
+  dims.n = shape[0];
+  dims.c = shape[1];
+  dims.h = shape[2];
+  dims.w = shape[3];
+  cl_channel_type cl_dtype = MakeCLDataType(dtype);
+  auto tensor_dsc = std::make_shared<cl_ml_tensor_memory_desc_qcom>();
+  cl_ml_tensor_desc_qcom desc = {
+      cl_dtype, layout, dims.n, dims.c, dims.h, dims.w, 0, CL_TENSOR_DIMENSIONS_4D_QCOM, {0}};
+  result = this->h_ClmlIntf->clCreateMLTensorQCOM(this->context, NULL, &desc, &tensor_dsc->tensor);
+  CLML_SDK_TEST_AND_EXIT(tensor_dsc->tensor && result == CL_SUCCESS);
+  return tensor_dsc;
+}
+
+/*!
+ * \brief Convolution2D implementation.
+ * \param input_desc is input tensor descriptor.
+ * \param weight_desc is the kernel as tensor descriptor.
+ * \param bias_desc is bias as tensor descriptor.
+ * \param output_desc is the placeholder for convolution output.
+ * \param padding padding to be applied on input tensor.
+ * \param dilation is convolution dilation parameter.
+ * \param strides is convolution strides parameter.
+ * \param groups number of groups.
+ * \param mode is it normal convolution of depthwise convolution.
+ * \param activation activation to be applied on result.
+ * \param has_bias is bias tensor valid.
+ * \param has_activation is activation to be applied.
+ * \param dtype operator data type.
+ */
+void CLMLRunner::MakeConv2D(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                            std::shared_ptr<cl_ml_tensor_memory_desc_qcom> weight_desc,
+                            std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bias_desc,
+                            std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                            std::vector<cl_uint> padding, std::vector<cl_uint> dilation,
+                            std::vector<cl_uint> strides, int groups, cl_convolution_mode_qcom mode,
+                            cl_activation_function_qcom activation, bool has_bias, bool has_act,
+                            std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_int result;
+  if (CL_CONVOLUTION_MODE_CONVOLUTION_QCOM == mode) {
+    CLML_SDK_TEST_AND_EXIT(groups == 1);  // CLML convolution only supports group size of 1
+  } else {
+    groups = 1;  // Don't need to pass groups to depthwise
+  }
+  cl_ml_op_activation_desc_qcom act_desc = {activation, CL_PROPAGATE_NAN_QCOM, cl_arithmetic_mode};
+  cl_uint clml_padding_b[CL_ML_TENSOR_MAX_SPATIAL_DIMS_QCOM] = {padding[0], padding[1]};
+  cl_uint clml_padding_a[CL_ML_TENSOR_MAX_SPATIAL_DIMS_QCOM] = {padding[2], padding[3]};
+  cl_uint clml_strides[CL_ML_TENSOR_MAX_SPATIAL_DIMS_QCOM] = {strides[0], strides[1]};
+  cl_uint clml_dilation[CL_ML_TENSOR_MAX_SPATIAL_DIMS_QCOM] = {dilation[0], dilation[1]};
+
+  cl_ml_op_convolution_desc_qcom conv_desc{mode,
+                                           static_cast<cl_uint>(groups),
+                                           4,
+                                           {clml_padding_b[0], clml_padding_b[1]},
+                                           {clml_padding_a[0], clml_padding_a[1]},
+                                           {clml_strides[0], clml_strides[1]},
+                                           {clml_dilation[0], clml_dilation[1]},
+                                           0,
+                                           cl_arithmetic_mode};
+  cl_ml_op_qcom op = NULL;
+  if (!has_act) {
+    result = h_ClmlIntf->clCreateMLOpConvolutionForwardQCOM(
+        this->context, 0, &conv_desc, input_desc->tensor, weight_desc->tensor, bias_desc->tensor,
+        output_desc->tensor, &op, tuning_cache);
+    CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  } else {
+    result = h_ClmlIntf->clCreateMLOpFusedConvolutionActivationForwardQCOM(
+        this->context, 0, &conv_desc, &act_desc, input_desc->tensor, weight_desc->tensor,
+        bias_desc->tensor, NULL, output_desc->tensor, &op, tuning_cache);
+    CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  }
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief Fused Convolution2D+BatchNorm implementation.
+ * \param input_desc is input tensor descriptor.
+ * \param weight_desc is the kernel as tensor descriptor.
+ * \param bias_desc is bias as tensor descriptor.
+ * \param output_desc is the placeholder for convolution output.
+ * \param bn_scale fused batchnorm scale tensor descriptor.
+ * \param bn_bias fused batchnorm scale tensor descriptor.
+ * \param bn_mean fused batchnorm mean tensor descriptor.
+ * \param bn_var fused batchnorm variance tensor descriptor.
+ * \param bn_attrs batchnorm other attributes.
+ * \param padding padding to be applied on input tensor.
+ * \param dilation is convolution dilation parameter.
+ * \param strides is convolution strides parameter.
+ * \param groups number of groups.
+ * \param mode is it normal convolution of depthwise convolution.
+ * \param activation activation to be applied on result.
+ * \param has_bias is bias tensor valid.
+ * \param has_activation is activation to be applied.
+ * \param dtype operator data type.
+ */
+void CLMLRunner::MakeConv2DWithBN(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> weight_desc,
+                                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bias_desc,
+                                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_scale,
+                                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_bias,
+                                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_mean,
+                                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_var,
+                                  std::vector<float> bn_attrs, std::vector<cl_uint> padding,
+                                  std::vector<cl_uint> dilation, std::vector<cl_uint> strides,
+                                  int groups, cl_convolution_mode_qcom mode,
+                                  cl_activation_function_qcom activation, bool has_bias,
+                                  bool has_act, std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_int result;
+  if (CL_CONVOLUTION_MODE_CONVOLUTION_QCOM == mode) {
+    CLML_SDK_TEST_AND_EXIT(groups == 1);  // CLML convolution only supports group size of 1
+  } else {
+    groups = 1;  // Don't need to pass groups to depthwise
+  }
+  cl_ml_op_activation_desc_qcom act_desc = {activation, CL_PROPAGATE_NAN_QCOM, cl_arithmetic_mode};
+  cl_uint clml_padding_b[CL_ML_TENSOR_MAX_SPATIAL_DIMS_QCOM] = {padding[0], padding[1]};
+  cl_uint clml_padding_a[CL_ML_TENSOR_MAX_SPATIAL_DIMS_QCOM] = {padding[2], padding[3]};
+  cl_uint clml_strides[CL_ML_TENSOR_MAX_SPATIAL_DIMS_QCOM] = {strides[0], strides[1]};
+  cl_uint clml_dilation[CL_ML_TENSOR_MAX_SPATIAL_DIMS_QCOM] = {dilation[0], dilation[1]};
+
+  cl_ml_op_convolution_desc_qcom conv_desc{mode,
+                                           static_cast<cl_uint>(groups),
+                                           4,
+                                           {clml_padding_b[0], clml_padding_b[1]},
+                                           {clml_padding_a[0], clml_padding_a[1]},
+                                           {clml_strides[0], clml_strides[1]},
+                                           {clml_dilation[0], clml_dilation[1]},
+                                           0,
+                                           cl_arithmetic_mode};
+  cl_ml_op_qcom op = NULL;
+  cl_ml_op_batchnorm_desc_qcom bn_desc = {CL_BATCHNORM_MODE_SPATIAL_QCOM, cl_arithmetic_mode};
+  if (!has_act) {
+    result = h_ClmlIntf->clCreateMLOpFusedConvolutionBatchNormForwardQCOM(
+        this->context, 0, &conv_desc, &bn_desc, input_desc->tensor, weight_desc->tensor,
+        bias_desc->tensor, output_desc->tensor, bn_mean->tensor, bn_var->tensor, bn_scale->tensor,
+        bn_bias->tensor, &op, tuning_cache);
+    CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  } else {
+    result = h_ClmlIntf->clCreateMLOpFusedConvolutionBatchNormActivationForwardQCOM(
+        this->context, 0, &conv_desc, &bn_desc, &act_desc, input_desc->tensor, weight_desc->tensor,
+        bias_desc->tensor, output_desc->tensor, NULL, bn_mean->tensor, bn_var->tensor,
+        bn_scale->tensor, bn_bias->tensor, &op, tuning_cache);
+    CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  }
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief All types of ReLU(6) implementation.
+ * \param input_desc input tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param relu_type the pf ReLU activation.
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakeRelu(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                          std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                          cl_activation_function_qcom relu_type, std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+  cl_ml_op_activation_desc_qcom act_desc = {relu_type, CL_PROPAGATE_NAN_QCOM, cl_arithmetic_mode};
+
+  result = h_ClmlIntf->clCreateMLOpActivationForwardQCOM(
+      this->context, 0, &act_desc, input_desc->tensor, this->unusedTensor->tensor,
+      output_desc->tensor, &op, tuning_cache);
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief Batch Normalization operator implementation.
+ * \param input_desc input tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param bn_scale fused batchnorm scale tensor descriptor.
+ * \param bn_bias fused batchnorm scale tensor descriptor.
+ * \param bn_mean fused batchnorm mean tensor descriptor.
+ * \param bn_var fused batchnorm variance tensor descriptor.
+ * \param bn_attrs batchnorm other attributes.
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakeBatchNorm(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                               std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                               std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_scale,
+                               std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_bias,
+                               std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_mean,
+                               std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_var,
+                               std::vector<float> bn_attrs, std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+
+  cl_ml_op_batchnorm_desc_qcom bn_desc = {CL_BATCHNORM_MODE_SPATIAL_QCOM, cl_arithmetic_mode};
+
+  result = h_ClmlIntf->clCreateMLOpBatchNormForwardQCOM(
+      this->context, 0, &bn_desc, input_desc->tensor, bn_mean->tensor, bn_var->tensor,
+      bn_scale->tensor, bn_bias->tensor, output_desc->tensor, &op, tuning_cache);
+
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief All types of Pool2D operator implementation.
+ * \param input_desc input tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param pool_size pooling window size.
+ * \param strides stride for pooling.
+ * \param padding is the input padding.
+ * \param pool_type is type of poling (max, avg ...etc).
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakePool2D(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                            std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                            std::vector<cl_uint> pool_size, std::vector<cl_uint> strides,
+                            std::vector<cl_uint> padding, std::string pool_type,
+                            std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+
+  cl_ml_op_pooling_desc_qcom pool_desc = {
+      pool_type == "nn.max_pool2d" ? CL_POOLING_MODE_MAX_QCOM
+                                   : CL_POOLING_MODE_AVERAGE_EXCLUDE_PADDING_QCOM,
+      4,  // reserved
+      {padding[0], padding[1]},
+      {padding[2], padding[3]},
+      {strides[0], strides[1]},
+      {pool_size[0], pool_size[1]},
+      CL_PROPAGATE_NAN_QCOM,
+      cl_arithmetic_mode,
+  };
+
+  result = h_ClmlIntf->clCreateMLOpPoolingForwardQCOM(
+      this->context, 0, &pool_desc, input_desc->tensor, this->unusedTensor->tensor,
+      output_desc->tensor, &op, tuning_cache);
+
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief All types of Global Pooling 2D operator implementation.
+ * \param input_desc input tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param in_shape is the input tensor shape.
+ * \param pool_type is the pool type (max or avg).
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakeGlobalPool2D(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                                  std::vector<cl_uint> in_shape, std::string pool_type,
+                                  std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+  cl_ml_op_pooling_desc_qcom pool_desc = {
+      pool_type == "nn.global_max_pool2d" ? CL_POOLING_MODE_MAX_QCOM
+                                          : CL_POOLING_MODE_AVERAGE_EXCLUDE_PADDING_QCOM,
+      4,  // reserved
+      {0, 0},
+      {0, 0},
+      {1, 1},
+      {in_shape[2], in_shape[3]},
+      CL_PROPAGATE_NAN_QCOM,
+      cl_arithmetic_mode,
+  };
+
+  result = h_ClmlIntf->clCreateMLOpPoolingForwardQCOM(
+      this->context, 0, &pool_desc, input_desc->tensor, this->unusedTensor->tensor,
+      output_desc->tensor, &op, tuning_cache);
+
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief Reshape Operator.
+ * \param input_desc input tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakeReshape(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                             std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                             std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+
+  result = h_ClmlIntf->clCreateMLOpReshapeQCOM(this->context, 0, input_desc->tensor,
+                                               output_desc->tensor, &op, tuning_cache);
+
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief Concatenate operator implementation.
+ * \param in_list list of input tensor descriptors to concatenate.
+ * \param output_desc output tensor descriptor.
+ * \param axis is the dimention on which we join the tensors.
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakeConcatenate(
+    std::vector<std::shared_ptr<cl_ml_tensor_memory_desc_qcom>> in_list,
+    std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc, int axis, std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+
+  cl_ml_tensor_qcom* concatInputs = new cl_ml_tensor_qcom[in_list.size()];
+  for (int i = 0; i < in_list.size(); i++) {
+    concatInputs[i] = in_list[i]->tensor;
+  }
+  cl_ml_op_concat_desc_qcom concatDesc = {1, (cl_uint)in_list.size(), cl_arithmetic_mode};
+  result = h_ClmlIntf->clCreateMLOpConcatQCOM(this->context, 0, &concatDesc, concatInputs,
+                                              output_desc->tensor, &op, tuning_cache);
+  delete[] concatInputs;
+
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief Dense operator implementation.
+ * \param input_desc input tensor descriptor.
+ * \param weight_desc weight tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param bias_desc bias tensor descriptor.
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakeDense(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                           std::shared_ptr<cl_ml_tensor_memory_desc_qcom> weight_desc,
+                           std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                           std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bias_desc,
+                           std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+
+  cl_ml_op_convolution_desc_qcom conv_desc = {CL_CONVOLUTION_MODE_CONVOLUTION_QCOM,
+                                              1,
+                                              4,
+                                              {0, 0},
+                                              {0, 0},
+                                              {1, 1},
+                                              {1, 1},
+                                              0,
+                                              cl_arithmetic_mode};
+
+  result = h_ClmlIntf->clCreateMLOpConvolutionForwardQCOM(
+      this->context, 0, &conv_desc, input_desc->tensor, weight_desc->tensor, bias_desc->tensor,
+      output_desc->tensor, &op, tuning_cache);
+
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief SoftMax operator implementation.
+ * \param input_desc input tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakeSoftMax(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                             std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                             std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+
+  cl_ml_op_softmax_desc_qcom softmax_desc = {CL_SOFTMAX_ALGORITHM_ACCURATE_QCOM,
+                                             CL_SOFTMAX_MODE_INSTANCE_QCOM, cl_arithmetic_mode};
+
+  result = h_ClmlIntf->clCreateMLOpSoftmaxQCOM(this->context, 0, &softmax_desc, input_desc->tensor,
+                                               output_desc->tensor, &op, tuning_cache);
+
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief .
+ * \param input_desc input tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param pad_mode type of padding to be applied (constant, edge, reflect ...etc).
+ * \param padding amount of padding.
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakePad(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                         std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                         std::string pad_mode, std::vector<cl_uint> padding, std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+
+  cl_pad_mode_qcom clml_pad_mode = CL_PAD_MODE_CONSTANT_QCOM;
+  if (pad_mode == "constant")
+    clml_pad_mode = CL_PAD_MODE_CONSTANT_QCOM;
+  else if (pad_mode == "edge")
+    clml_pad_mode = CL_PAD_MODE_SYMMETRIC_QCOM;
+  else if (pad_mode == "reflect")
+    clml_pad_mode = CL_PAD_MODE_REFLECT_QCOM;
+  else
+    LOG(FATAL) << "Padding mode not supported by CLML:" << pad_mode;
+
+  cl_ml_op_pad_desc_qcom pad_desc{clml_pad_mode,
+                                  {0, 0},
+                                  {padding[0], padding[1], padding[2], padding[3], 0, 0, 0, 0},
+                                  cl_arithmetic_mode};
+
+  result = h_ClmlIntf->clCreateMLOpPadQCOM(this->context, 0, &pad_desc, input_desc->tensor,
+                                           output_desc->tensor, &op, tuning_cache);
+
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief Batch Flatten operator implementation.
+ * \param input_desc input tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakeBatchFlatten(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                                  std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+
+  result = h_ClmlIntf->clCreateMLOpReshapeQCOM(this->context, 0, input_desc->tensor,
+                                               output_desc->tensor, &op, tuning_cache);
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief Clip operator.
+ * \param input_desc input tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param a_max is the upper bound to clip.
+ * \param a_min is the lower bound to clip.
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakeClip(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                          std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc, float a_max,
+                          float a_min, std::string dtype) {
+  LOG(INFO) << "MakeClip called";
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+
+  cl_ml_op_clip_desc_qcom clip_desc = {
+      CL_CLIP_BY_VALUE_QCOM, {{a_max}, CL_FLOAT}, {{a_min}, CL_FLOAT}, cl_arithmetic_mode};
+
+  result = h_ClmlIntf->clCreateMLOpClipQCOM(this->context, 0, &clip_desc, input_desc->tensor,
+                                            output_desc->tensor, &op, tuning_cache);
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+/*!
+ * \brief All types of Binary operators.
+ * \param input_a first input tensor descriptor.
+ * \param input_b second input tensor descriptor.
+ * \param output_desc output tensor descriptor.
+ * \param op_name is the binary operator.
+ * \param dtype operator datatype.
+ */
+void CLMLRunner::MakeBinaryOp(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_a,
+                              std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_b,
+                              std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                              std::string op_name, std::string dtype) {
+  cl_arithmetic_mode_qcom cl_arithmetic_mode = MakeCLArithMode(MakeCLDataType(dtype));
+  cl_ml_op_qcom op = NULL;
+  cl_int result;
+
+  cl_binary_op_qcom binary_op = CL_TENSOR_OP_ADD_QCOM;
+  if (op_name == "subtract")
+    binary_op = CL_TENSOR_OP_SUB_QCOM;
+  else if (op_name == "multiply")
+    binary_op = CL_TENSOR_OP_MUL_QCOM;
+  else if (op_name == "divide")
+    binary_op = CL_TENSOR_OP_DIV_QCOM;
+  else if (op_name == "minimum")
+    binary_op = CL_TENSOR_OP_MIN_QCOM;
+  else if (op_name == "maximum")
+    binary_op = CL_TENSOR_OP_MAX_QCOM;
+  cl_ml_op_binary_desc_qcom add_desc = {
+      binary_op, {{1.0}, CL_FLOAT}, {{1.0}, CL_FLOAT}, {{0.0}, CL_FLOAT}, cl_arithmetic_mode};
+
+  result =
+      h_ClmlIntf->clCreateMLOpBinaryQCOM(this->context, 0, &add_desc, input_a->tensor,
+                                         input_b->tensor, output_desc->tensor, &op, tuning_cache);
+
+  CLML_SDK_TEST_AND_EXIT(op && result == CL_SUCCESS);
+  this->function.push_back(op);
+}
+
+}  // namespace runtime
+}  // namespace tvm

--- a/apps/cpp_clml/clml_runner.cc
+++ b/apps/cpp_clml/clml_runner.cc
@@ -68,20 +68,11 @@ CLMLRunner::CLMLRunner(std::string name, ToolArgs& args, cl_platform_id arg_plat
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
 
   for (cl_uint i = 0; i < numVersions; ++i) {
-#if CL_QCOM_ML_OPS_H_MAJOR_VERSION == 2
-    if (majorVersions[i] == 2) {
-      this->h_ClmlIntf = clGetMLInterfaceV2QCOM(0);
+    if (majorVersions[i] == CL_QCOM_ML_OPS_H_MAJOR_VERSION) {
+      this->h_ClmlIntf = GET_ML_INTERFACE(0);
       LOG(INFO) << "CLML Target version:" << majorVersions[i];
       break;
     }
-#endif
-#if CL_QCOM_ML_OPS_H_MAJOR_VERSION == 3
-    if (majorVersions[i] == 3) {
-      this->h_ClmlIntf = clGetMLInterfaceV3QCOM(0);
-      LOG(INFO) << "CLML Target version:" << majorVersions[i];
-      break;
-    }
-#endif
   }
   CLML_SDK_TEST_AND_EXIT(this->h_ClmlIntf != NULL);
 

--- a/apps/cpp_clml/clml_runner.h
+++ b/apps/cpp_clml/clml_runner.h
@@ -51,6 +51,11 @@
     }                                                                                           \
   }
 
+#define CAT_I(a, b) a##b
+#define CAT(a, b) CAT_I(a, b)
+#define GET_ML_INTERFACE CAT(CAT(clGetMLInterfaceV, CL_QCOM_ML_OPS_H_MAJOR_VERSION), QCOM)
+#define GET_ML_API_INTERFACE CAT(CAT(CLMLInterfaceV, CL_QCOM_ML_OPS_H_MAJOR_VERSION), QCOM)
+
 namespace tvm {
 namespace runtime {
 
@@ -221,14 +226,8 @@ class CLMLRunner {
   /*! \brief Unused tensor used across various ops */
   std::shared_ptr<cl_ml_tensor_memory_desc_qcom> unusedTensor;
 
-#if CL_QCOM_ML_OPS_H_MAJOR_VERSION == 2
-  /*! \brief  V2 ML API interface */
-  CLMLInterfaceV2QCOM* h_ClmlIntf = NULL;
-#endif
-#if CL_QCOM_ML_OPS_H_MAJOR_VERSION == 3
-  /*! \brief  V3 ML API interface */
-  CLMLInterfaceV3QCOM* h_ClmlIntf = NULL;
-#endif
+  /*! \brief  ML API interface */
+  GET_ML_API_INTERFACE* h_ClmlIntf = NULL;
   /*! \brief  Tuning cache object */
   cl_ml_tuningcache_qcom tuning_cache = NULL;
   /*! \brief  Flag to inticate a tuning run */

--- a/apps/cpp_clml/clml_runner.h
+++ b/apps/cpp_clml/clml_runner.h
@@ -229,20 +229,20 @@ class CLMLRunner {
   /*! \brief  ML API interface */
   GET_ML_API_INTERFACE* h_ClmlIntf = nullptr;
   /*! \brief  Tuning cache object */
-  cl_ml_tuningcache_qcom tuning_cache = NULL;
+  cl_ml_tuningcache_qcom tuning_cache = nullptr;
   /*! \brief  Flag to inticate a tuning run */
   bool is_tuning_run;
   /*! \brief  The tuning file for loading or storing cache */
   char* tuning_file;
 
   /*! \brief  OpenCL platform */
-  cl_platform_id platform{NULL};
+  cl_platform_id platform{nullptr};
   /*! \brief  OpenCL context */
-  cl_context context{NULL};
+  cl_context context{nullptr};
   /*! \brief  OpenCL device */
-  cl_device_id device_id{NULL};
+  cl_device_id device_id{nullptr};
   /*! \brief  OpenCL Queue */
-  cl_command_queue queue{NULL};
+  cl_command_queue queue{nullptr};
   /*! \brief  Numpy object for params */
   cnpy::npz_t npz_params;
   /*! \brief  Numpy object for inputs */

--- a/apps/cpp_clml/clml_runner.h
+++ b/apps/cpp_clml/clml_runner.h
@@ -227,7 +227,7 @@ class CLMLRunner {
   std::shared_ptr<cl_ml_tensor_memory_desc_qcom> unusedTensor;
 
   /*! \brief  ML API interface */
-  GET_ML_API_INTERFACE* h_ClmlIntf = NULL;
+  GET_ML_API_INTERFACE* h_ClmlIntf = nullptr;
   /*! \brief  Tuning cache object */
   cl_ml_tuningcache_qcom tuning_cache = NULL;
   /*! \brief  Flag to inticate a tuning run */

--- a/apps/cpp_clml/clml_runner.h
+++ b/apps/cpp_clml/clml_runner.h
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file clml_runner.h
+ * \brief CLML model runner.
+ */
+#ifndef CLML_APPS_CPP_RCLML_RUNNER_H_
+#define CLML_APPS_CPP_RCLML_RUNNER_H_
+
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#if defined(__linux__) || defined(__ANDROID__)
+#include <unistd.h>
+#endif
+
+#include <CL/cl_qcom_ml_ops.h>
+#include <cnpy.h>
+#include <dmlc/io.h>
+
+#include "CL/cl.h"
+
+#define CLML_SDK_TEST_AND_EXIT(expression)                                                      \
+  {                                                                                             \
+    {                                                                                           \
+      int _n_ = !(expression);                                                                  \
+      if (_n_) {                                                                                \
+        fprintf(stderr, "Error on line %d of %s\nFailing expression: %s\n", __LINE__, __FILE__, \
+                #expression);                                                                   \
+        exit(1);                                                                                \
+      }                                                                                         \
+    }                                                                                           \
+  }
+
+namespace tvm {
+namespace runtime {
+
+/**
+ * \brief Tensor dimensions, batch, channel, height, width
+ *
+ */
+struct tensor_dims_t {
+  uint32_t n, c, h, w;
+};
+
+/*!
+ * \brief Tool Arguments.
+ * \arg input Numpy file for the model input
+ * \arg output Numpy file name to dump the model output as numpy
+ * \arg parsms Numpy file holding the params for models
+ */
+struct ToolArgs {
+  std::string input;
+  std::string output;
+  std::string params;
+  bool dump_meta = false;
+};
+
+/*!
+ * \brief encapsulates CLML Runner functionality for the sub graph
+ */
+class CLMLRunner {
+ public:
+  /*! \brief Constructor */
+  CLMLRunner(std::string name, ToolArgs& args, cl_platform_id arg_platform_id,
+             cl_context arg_context, cl_device_id arg_device_id, cl_command_queue arg_queue);
+
+  /*! \brief Returns the name for this sub graph */
+  std::string GetModName(void) { return r_name; }
+  /*! \brief Executes one cycle all CLML ops */
+  int Run(void);
+  /*! \brief set meta information */
+  void SetMetaInfo(std::string minfo);
+  /*! \brief Print function to show all meta information */
+  void PrintMetaInfo(void);
+  /*! \brief initializes the unusedTensor */
+  void MakeUnusedTensor(void);
+  /*! \brief Copy given bytestream of data to the tensor */
+  void CopyDataToCLMLTensor(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> tensor, void* data,
+                            cl_ml_tensor_layout_qcom layout = CL_TENSOR_LAYOUT_NCHW_QCOM);
+  /*! \brief Copy tensor data to data in expected layout format */
+  void CopyDataFromCLMLTensor(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> tensor, void* data,
+                              cl_ml_tensor_layout_qcom layout = CL_TENSOR_LAYOUT_NCHW_QCOM);
+  /*! \brief Allocates memory for the tensor descriptor */
+  cl_int AllocateTensorMemory(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> pTensorMemDesc);
+  /*!
+   * \brief Allocates memory for all tensor descriptor in storage map.
+   * Also initializes the parameter nodes, inputs from given numpy dumps if provided.
+   */
+  void AllocateMemAndPopulateParams(void);
+  /*! \brief Create a tensor descriptor given it's shape, dtype and layout */
+  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> MakeCLMLTensor(
+      std::vector<size_t> shape, std::string dtype = "float32",
+      cl_ml_tensor_layout_qcom layout = CL_TENSOR_LAYOUT_OPTIMAL_QCOM);
+  /*! \brief Conv2D layer implementattion */
+  void MakeConv2D(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> weight_desc,
+                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bias_desc,
+                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                  std::vector<cl_uint> padding, std::vector<cl_uint> dilation,
+                  std::vector<cl_uint> strides, int groups, cl_convolution_mode_qcom mode,
+                  cl_activation_function_qcom activation, bool has_bias, bool has_act,
+                  std::string dtype);
+
+  /*! \brief Conv2D with Fused BatchNorm layer implementattion */
+  void MakeConv2DWithBN(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                        std::shared_ptr<cl_ml_tensor_memory_desc_qcom> weight_desc,
+                        std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bias_desc,
+                        std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                        std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_scale,
+                        std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_bias,
+                        std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_mean,
+                        std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_var,
+                        std::vector<float> bn_attrs, std::vector<cl_uint> padding,
+                        std::vector<cl_uint> dilation, std::vector<cl_uint> strides, int groups,
+                        cl_convolution_mode_qcom mode, cl_activation_function_qcom activation,
+                        bool has_bias, bool has_act, std::string dtype);
+
+  /*! \brief ReLU layer implementattion */
+  void MakeRelu(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                cl_activation_function_qcom relu_type, std::string dtype);
+
+  /*! \brief Batch Normalization layer implementattion */
+  void MakeBatchNorm(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                     std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                     std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_scale,
+                     std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_bias,
+                     std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_mean,
+                     std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bn_var,
+                     std::vector<float> bn_attrs, std::string dtype);
+
+  /*! \brief Pool2D (with all variants) layer implementattion */
+  void MakePool2D(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                  std::vector<cl_uint> pool_size, std::vector<cl_uint> strides,
+                  std::vector<cl_uint> padding, std::string pool_type, std::string dtype);
+
+  /*! \brief GlobalPool2D (with all variants) layer implementattion */
+  void MakeGlobalPool2D(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                        std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                        std::vector<cl_uint> in_shape, std::string pool_type, std::string dtype);
+
+  /*! \brief Reshape layer implementattion */
+  void MakeReshape(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                   std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc, std::string dtype);
+
+  /*! \brief Concatenate layer implementattion */
+  void MakeConcatenate(std::vector<std::shared_ptr<cl_ml_tensor_memory_desc_qcom>> in_list,
+                       std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc, int axis,
+                       std::string dtype);
+
+  /*! \brief Dense layer implementattion */
+  void MakeDense(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                 std::shared_ptr<cl_ml_tensor_memory_desc_qcom> weight_desc,
+                 std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                 std::shared_ptr<cl_ml_tensor_memory_desc_qcom> bias_desc, std::string dtype);
+
+  /*! \brief SoftMax layer implementattion */
+  void MakeSoftMax(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                   std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc, std::string dtype);
+
+  /*! \brief Pad layer implementattion */
+  void MakePad(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+               std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc, std::string pad_mode,
+               std::vector<cl_uint> padding, std::string dtype);
+
+  /*! \brief Batch Flatten layer implementattion */
+  void MakeBatchFlatten(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                        std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc,
+                        std::string dtype);
+
+  /*! \brief Clip layer implementattion */
+  void MakeClip(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_desc,
+                std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc, float a_max,
+                float a_min, std::string dtype);
+
+  /*! \brief Binary Operator (with all types) layer implementattion */
+  void MakeBinaryOp(std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_a,
+                    std::shared_ptr<cl_ml_tensor_memory_desc_qcom> input_b,
+                    std::shared_ptr<cl_ml_tensor_memory_desc_qcom> output_desc, std::string op_name,
+                    std::string dtype);
+
+  /*! \brief Vector of created operators */
+  std::vector<cl_ml_op_qcom> function;
+  /*! \brief Vector of graph's input tensor descriptors */
+  std::vector<std::shared_ptr<cl_ml_tensor_memory_desc_qcom>> inputs;
+  /*! \brief Map of graph's output tensor descriptors with names */
+  std::map<std::string, std::shared_ptr<cl_ml_tensor_memory_desc_qcom>> outputs;
+  /*! \brief Map of graph's output tensor names and dtypes */
+  std::map<std::string, std::string> outputs_dtypes;
+  /*! \brief Map of graph's output tensor names and shapes */
+  std::map<std::string, std::vector<size_t>> outputs_shapes;
+  /*! \brief Overall storage map for all tensor descriptors involved */
+  std::map<std::string, std::shared_ptr<cl_ml_tensor_memory_desc_qcom>> storage_map;
+  /*! \brief List of const tensor of the graph */
+  std::vector<std::string> consts;
+  /*! \brief List of all memory descriptor in graph */
+  std::vector<cl_ml_tensor_memory_desc_qcom> tensorMemDescs;
+  /*! \brief Tensor memory descriptor set */
+  cl_ml_tensor_mem_desc_set_qcom descriptorSet;
+  /*! \brief Unused tensor used across various ops */
+  std::shared_ptr<cl_ml_tensor_memory_desc_qcom> unusedTensor;
+
+#if CL_QCOM_ML_OPS_H_MAJOR_VERSION == 2
+  /*! \brief  V2 ML API interface */
+  CLMLInterfaceV2QCOM* h_ClmlIntf = NULL;
+#endif
+#if CL_QCOM_ML_OPS_H_MAJOR_VERSION == 3
+  /*! \brief  V3 ML API interface */
+  CLMLInterfaceV3QCOM* h_ClmlIntf = NULL;
+#endif
+  /*! \brief  Tuning cache object */
+  cl_ml_tuningcache_qcom tuning_cache = NULL;
+  /*! \brief  Flag to inticate a tuning run */
+  bool is_tuning_run;
+  /*! \brief  The tuning file for loading or storing cache */
+  char* tuning_file;
+
+  /*! \brief  OpenCL platform */
+  cl_platform_id platform{NULL};
+  /*! \brief  OpenCL context */
+  cl_context context{NULL};
+  /*! \brief  OpenCL device */
+  cl_device_id device_id{NULL};
+  /*! \brief  OpenCL Queue */
+  cl_command_queue queue{NULL};
+  /*! \brief  Numpy object for params */
+  cnpy::npz_t npz_params;
+  /*! \brief  Numpy object for inputs */
+  cnpy::npz_t npz_input;
+
+ private:
+  /*! \brief unique name for the runner */
+  std::string r_name;
+  /*! \brief arguments */
+  ToolArgs r_args;
+  /*! \brief Holds meta information from clml codegen */
+  std::string meta_info;
+};
+
+}  // namespace runtime
+}  // namespace tvm
+#endif  // CLML_APPS_CPP_RCLML_RUNNER_H_

--- a/apps/cpp_clml/main.cc
+++ b/apps/cpp_clml/main.cc
@@ -190,7 +190,7 @@ int ExecuteModel(ToolArgs& args) {
   result = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device_id, NULL);
   CLML_SDK_TEST_AND_EXIT(device_id && result == CL_SUCCESS);
 
-  ExtensionStringPresent(platform, device_id);
+  CLML_SDK_TEST_AND_EXIT(ExtensionStringPresent(platform, device_id) == true);
 
   context = clCreateContext(0, 1, &device_id, NULL, NULL, &result);
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);

--- a/apps/cpp_clml/main.cc
+++ b/apps/cpp_clml/main.cc
@@ -173,7 +173,7 @@ int ExecuteModel(ToolArgs& args) {
 
   // Init OpenCL Environment
   cl_int result;
-  cl_event readEvent = NULL;
+  cl_event readEvent = nullptr;
   cl_platform_id platform = NULL;
   cl_context context = NULL;
   cl_device_id device_id = NULL;

--- a/apps/cpp_clml/main.cc
+++ b/apps/cpp_clml/main.cc
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file main.cc
+ * \brief CLML Model execution application.
+ */
+
+#include "clml_runner.h"
+
+using namespace tvm::runtime;
+
+/*!
+ * \brief Auto generated model file (clml_models.cc) entry function definition.
+ * \param args The tool arguments to forward
+ * \param arg_platform OpenCL platform
+ * \param arg_context OpenCL context
+ * \param arg_device_id OpenCL device id
+ * \param queue OpenCL queue
+ * \return List of CLMLRunner objects corresponding to all sub graphs of a TVM module.
+ */
+std::vector<CLMLRunner> BuildModules(ToolArgs& args, cl_platform_id arg_platform,
+                                     cl_context arg_context, cl_device_id arg_device_id,
+                                     cl_command_queue queue);
+
+static const std::string kUsage =
+    "Command line usage\n"
+    "--input        - Numpy file for the model input (optional and we use random of not given)\n"
+    "--output       - Numpy file name to dump the model output as numpy\n"
+    "--params       - Numpy file with params\n"
+    "--dump-meta    - Dump model meta information\n"
+    "\n"
+    "  Example\n"
+    "  ./clml_run --dump-meta\n"
+    "  ./clml_run --params=clmlparams.npz\n"
+    "  ./clml_run --input=input.npz --output=output.npz --params=clml_params.npz\n"
+    "\n";
+
+/*!
+ * \brief PrintArgs print the contents of ToolArgs
+ * \param args ToolArgs structure
+ */
+void PrintArgs(const ToolArgs& args) {
+  LOG(INFO) << "Input         = " << args.input;
+  LOG(INFO) << "Output        = " << args.output;
+  LOG(INFO) << "Params        = " << args.params;
+  LOG(INFO) << "DumpMeta      = " << args.dump_meta;
+}
+
+#if defined(__linux__) || defined(__ANDROID__)
+/*!
+ * \brief CtrlCHandler, exits if Ctrl+C is pressed
+ * \param s signal
+ */
+void CtrlCHandler(int s) {
+  LOG(INFO) << "User pressed Ctrl+C, Exiting";
+  exit(1);
+}
+
+/*!
+ * \brief HandleCtrlC Register for handling Ctrl+C event.
+ */
+void HandleCtrlC() {
+  // Ctrl+C handler
+  struct sigaction sigIntHandler;
+  sigIntHandler.sa_handler = CtrlCHandler;
+  sigemptyset(&sigIntHandler.sa_mask);
+  sigIntHandler.sa_flags = 0;
+  sigaction(SIGINT, &sigIntHandler, nullptr);
+}
+#endif
+/*!
+ * \brief GetCmdOption Parse and find the command option.
+ * \param argc arg counter
+ * \param argv arg values
+ * \param option command line option to search for.
+ * \param key whether the option itself is key
+ * \return value corresponding to option.
+ */
+std::string GetCmdOption(int argc, char* argv[], std::string option, bool key = false) {
+  std::string cmd;
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg.find(option) == 0) {
+      if (key) {
+        cmd = argv[i];
+        return cmd;
+      }
+      // We assume "=" is the end of option.
+      // ICHECK_EQ(*option.rbegin(), '=');
+      cmd = arg.substr(arg.find('=') + 1);
+      return cmd;
+    }
+  }
+  return cmd;
+}
+
+/*!
+ * \brief ParseCmdArgs parses the command line arguments.
+ * \param argc arg counter
+ * \param argv arg values
+ * \param args the output structure which holds the parsed values
+ */
+void ParseCmdArgs(int argc, char* argv[], struct ToolArgs& args) {
+  const std::string input = GetCmdOption(argc, argv, "--input=");
+  if (!input.empty()) {
+    args.input = input;
+  }
+
+  const std::string output = GetCmdOption(argc, argv, "--output=");
+  if (!output.empty()) {
+    args.output = output;
+  }
+
+  const std::string params = GetCmdOption(argc, argv, "--params=");
+  if (!params.empty()) {
+    args.params = params;
+  }
+
+  const std::string pmeta = GetCmdOption(argc, argv, "--dump-meta", true);
+  if (!pmeta.empty()) {
+    args.dump_meta = true;
+  }
+}
+
+/*!
+ * \brief Check CLML extension availability in the CL device.
+ * \param platform_id OpenCL platform
+ * \param device_id OpenCL device id
+ * \return true if extension present else false.
+ */
+bool ExtensionStringPresent(cl_platform_id platform_id, cl_device_id device_id) {
+  cl_int result = 0;
+  size_t reqd_size = 0;
+  result = clGetDeviceInfo(device_id, CL_DEVICE_EXTENSIONS, 0, NULL, &reqd_size);
+  CLML_SDK_TEST_AND_EXIT(reqd_size > 0u && result == CL_SUCCESS);
+
+  std::vector<char> buf(reqd_size);
+  result = clGetDeviceInfo(device_id, CL_DEVICE_EXTENSIONS, reqd_size, buf.data(), NULL);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+
+  std::string extensions(buf.data());
+  LOG(WARNING) << "OpenCL Extensions:" << extensions;
+  return (extensions.find("cl_qcom_ml_ops") != std::string::npos);
+}
+
+/*!
+ * \brief Loads and Executes the model on given Target.
+ * \param args tool arguments
+ * \return result of operation.
+ */
+int ExecuteModel(ToolArgs& args) {
+#if defined(__linux__) || defined(__ANDROID__)
+  // Ctrl+C handler
+  HandleCtrlC();
+#endif
+
+  // Init OpenCL Environment
+  cl_int result;
+  cl_event readEvent = NULL;
+  cl_platform_id platform = NULL;
+  cl_context context = NULL;
+  cl_device_id device_id = NULL;
+  cl_command_queue queue = NULL;
+
+  // Initialize Context and Command Queue
+  result = clGetPlatformIDs(1, &platform, NULL);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+
+  uint32_t num_devices = 0;
+  result = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 0, NULL, &num_devices);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS && num_devices == 1);
+
+  result = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device_id, NULL);
+  CLML_SDK_TEST_AND_EXIT(device_id && result == CL_SUCCESS);
+
+  ExtensionStringPresent(platform, device_id);
+
+  context = clCreateContext(0, 1, &device_id, NULL, NULL, &result);
+  CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
+
+  cl_command_queue_properties queue_props = 0;
+
+  queue = clCreateCommandQueue(context, device_id, queue_props, &result);
+  CLML_SDK_TEST_AND_EXIT(queue && result == CL_SUCCESS);
+
+  // Populate the runner with model
+  LOG(INFO) << "Call Build Modules\n";
+  auto runners = BuildModules(args, platform, context, device_id, queue);
+
+  LOG(INFO) << "Loop Through the Modules";
+  for (auto runner : runners) {
+    if (args.dump_meta) {
+      // Print Meta Information
+      runner.PrintMetaInfo();
+    }
+
+    // Run the model
+    runner.Run();
+  }
+
+  return 0;
+}
+
+/*!
+ * \brief main The main function.
+ * \param argc arg counter
+ * \param argv arg values
+ * \return result of operation.
+ */
+int main(int argc, char* argv[]) {
+  if (argc <= 1) {
+    LOG(INFO) << kUsage;
+    return 0;
+  }
+
+  ToolArgs args;
+  ParseCmdArgs(argc, argv, args);
+  PrintArgs(args);
+
+  if (ExecuteModel(args)) {
+    PrintArgs(args);
+    LOG(INFO) << kUsage;
+    return -1;
+  }
+  return 0;
+}

--- a/apps/cpp_clml/main.cc
+++ b/apps/cpp_clml/main.cc
@@ -148,11 +148,11 @@ void ParseCmdArgs(int argc, char* argv[], struct ToolArgs& args) {
 bool ExtensionStringPresent(cl_platform_id platform_id, cl_device_id device_id) {
   cl_int result = 0;
   size_t reqd_size = 0;
-  result = clGetDeviceInfo(device_id, CL_DEVICE_EXTENSIONS, 0, NULL, &reqd_size);
+  result = clGetDeviceInfo(device_id, CL_DEVICE_EXTENSIONS, 0, nullptr, &reqd_size);
   CLML_SDK_TEST_AND_EXIT(reqd_size > 0u && result == CL_SUCCESS);
 
   std::vector<char> buf(reqd_size);
-  result = clGetDeviceInfo(device_id, CL_DEVICE_EXTENSIONS, reqd_size, buf.data(), NULL);
+  result = clGetDeviceInfo(device_id, CL_DEVICE_EXTENSIONS, reqd_size, buf.data(), nullptr);
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
 
   std::string extensions(buf.data());
@@ -174,25 +174,25 @@ int ExecuteModel(ToolArgs& args) {
   // Init OpenCL Environment
   cl_int result;
   cl_event readEvent = nullptr;
-  cl_platform_id platform = NULL;
-  cl_context context = NULL;
-  cl_device_id device_id = NULL;
-  cl_command_queue queue = NULL;
+  cl_platform_id platform = nullptr;
+  cl_context context = nullptr;
+  cl_device_id device_id = nullptr;
+  cl_command_queue queue = nullptr;
 
   // Initialize Context and Command Queue
-  result = clGetPlatformIDs(1, &platform, NULL);
+  result = clGetPlatformIDs(1, &platform, nullptr);
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
 
   uint32_t num_devices = 0;
-  result = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 0, NULL, &num_devices);
+  result = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 0, nullptr, &num_devices);
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS && num_devices == 1);
 
-  result = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device_id, NULL);
+  result = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device_id, nullptr);
   CLML_SDK_TEST_AND_EXIT(device_id && result == CL_SUCCESS);
 
   CLML_SDK_TEST_AND_EXIT(ExtensionStringPresent(platform, device_id) == true);
 
-  context = clCreateContext(0, 1, &device_id, NULL, NULL, &result);
+  context = clCreateContext(0, 1, &device_id, nullptr, nullptr, &result);
   CLML_SDK_TEST_AND_EXIT(result == CL_SUCCESS);
 
   cl_command_queue_properties queue_props = 0;

--- a/apps/cpp_clml/scripts/clml_codegen.py
+++ b/apps/cpp_clml/scripts/clml_codegen.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import sys
+import numpy as np
+
+import tvm
+from tvm import relay
+from tvm.driver import tvmc
+from tvm.relay.op.contrib import clml
+from tvm.contrib import utils
+from string import Template
+
+
+def main():
+    print("CLML Codegen")
+    if len(sys.argv) != 2:
+        print("Usage: python clml_codegen.py <model_path>")
+        return
+
+    tvmc_model = tvmc.load(sys.argv[1])
+    mod = tvmc_model.mod
+    params = tvmc_model.params
+    with tvm.transform.PassContext(opt_level=3):
+        mod = tvmc.transform.convert_graph_layout(mod, "NCHW")
+    with tvm.transform.PassContext(opt_level=3, disabled_pass=["AlterOpLayout"]):
+        clml_mod = clml.partition_for_clml(mod, params)
+        libm = relay.build(
+            clml_mod,
+            target="opencl -device=adreno",
+            target_host="llvm -mtriple=aarch64-linux-gnu",
+            params=params,
+        )
+
+        # Extract CLML related params
+        (clml_params_save, gen_src) = clml.CLMLGenSrc(libm).get_artifacts()
+        np.savez("clml_params.npz", **clml_params_save)
+
+        f_src = open("../clml_models.cc", "w")
+        f_src.write("\n".join(gen_src))
+        f_src.close()
+        os.popen("clang-format-10 -i ../clml_models.cc")
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/modules/contrib/CLML.cmake
+++ b/cmake/modules/contrib/CLML.cmake
@@ -54,7 +54,7 @@ if(USE_CLML_GRAPH_EXECUTOR)
     include_directories(${CLML_INCLUDE_DIRS})
     find_library(EXTERN_CLML_COMPUTE_LIB
           NAMES OpenCL libOpenCL
-          HINTS "${CLML_PATH}" "${CLML_PATH}/lib" "${CLML_PATH}/lib64"
+          HINTS "${CLML_PATH}" "${CLML_PATH}/lib64" "${CLML_PATH}/lib"
           )
     list(APPEND TVM_RUNTIME_LINKER_LIBS ${EXTERN_CLML_COMPUTE_LIB})
     list(APPEND RUNTIME_SRCS ${CLML_CONTRIB_SRC})

--- a/cmake/modules/contrib/CLML.cmake
+++ b/cmake/modules/contrib/CLML.cmake
@@ -54,7 +54,7 @@ if(USE_CLML_GRAPH_EXECUTOR)
     include_directories(${CLML_INCLUDE_DIRS})
     find_library(EXTERN_CLML_COMPUTE_LIB
           NAMES OpenCL libOpenCL
-          HINTS "${CLML_PATH}" "${CLML_PATH}/lib64"
+          HINTS "${CLML_PATH}" "${CLML_PATH}/lib" "${CLML_PATH}/lib64"
           )
     list(APPEND TVM_RUNTIME_LINKER_LIBS ${EXTERN_CLML_COMPUTE_LIB})
     list(APPEND RUNTIME_SRCS ${CLML_CONTRIB_SRC})

--- a/docker/Dockerfile.ci_adreno
+++ b/docker/Dockerfile.ci_adreno
@@ -27,3 +27,6 @@ ENV ANDROID_HOME=/opt/android-sdk-linux
 ENV ANDROID_NDK_HOME=/opt/android-sdk-linux/ndk/21.3.6528147
 ENV ANDROID_NDK_MAJOR=21
 ENV PATH /opt/android-sdk-linux/platform-tools:$PATH
+
+# Clang tool for CLML source codegen
+RUN apt-get update && apt-install-and-clear -y clang-format-10

--- a/src/relay/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relay/backend/contrib/codegen_json/codegen_json.h
@@ -340,6 +340,7 @@ class JSONSerializer : public MemoizedExprTranslator<std::vector<JSONGraphNodeEn
       node_row_ptr.push_back(num_entry);
     }
     writer->BeginObject();
+    writer->WriteObjectKeyValue("symbol", symbol_);
     writer->WriteObjectKeyValue("nodes", nodes_);
     writer->WriteObjectKeyValue("arg_nodes", arg_nodes);
     writer->WriteObjectKeyValue("heads", heads_);

--- a/src/runtime/const_loader_module.cc
+++ b/src/runtime/const_loader_module.cc
@@ -77,6 +77,16 @@ class ConstLoaderModuleNode : public ModuleNode {
       initialized_[name] = true;
     }
 
+    if (name == "get_const_var_ndarray") {
+      return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+        Map<String, ObjectRef> ret_map;
+        for (const auto& kv : const_var_ndarray_) {
+          ret_map.Set(kv.first, kv.second);
+        }
+        *rv = ret_map;
+      });
+    }
+
     // Run the module.
     // Normally we would only have a limited number of submodules. The runtime
     // symobl lookup overhead should be minimal.

--- a/src/runtime/contrib/json/json_runtime.h
+++ b/src/runtime/contrib/json/json_runtime.h
@@ -228,6 +228,7 @@ class JSONRuntimeBase : public ModuleNode {
   void Load(dmlc::JSONReader* reader) {
     reader->BeginObject();
     std::string key;
+    std::string symbol_;
     while (reader->NextObjectItem(&key)) {
       if (key == "nodes") {
         reader->Read(&nodes_);
@@ -237,6 +238,8 @@ class JSONRuntimeBase : public ModuleNode {
         reader->Read(&node_row_ptr_);
       } else if (key == "heads") {
         reader->Read(&outputs_);
+      } else if (key == "symbol") {
+        reader->Read(&symbol_);
       } else {
         LOG(FATAL) << "Unknown key: " << key;
       }


### PR DESCRIPTION
This util generates native CLML code given a DNN model. It does import via tvmc, extracts clml_modules, get the json source and finally generates clml_models.cc that holds source for various sub graphs. cpp_clml tool has additional infrastructure to compile it as a standalone binary that runs these models.

This PR adds symbol name to the generated json graph. Also, extends const_loader interface to get constant params.