### PR TITLE
Enhance the --help message of composite target

### DIFF
--- a/python/tvm/driver/tvmc/target.py
+++ b/python/tvm/driver/tvmc/target.py
@@ -72,7 +72,7 @@ def _generate_codegen_args(parser, codegen_name):
                     target_group.add_argument(
                         f"--target-{codegen_name}-{target_option}",
                         type=python_type,
-                        help=f"target {codegen_name} {target_option}{python_type}",
+                        help=field.description,
                     )
 
 

--- a/tests/python/driver/tvmc/test_target_options.py
+++ b/tests/python/driver/tvmc/test_target_options.py
@@ -60,6 +60,7 @@ def test_mapping_target_args():
     assert reconstruct_target_args(parsed) == {"llvm": {"mcpu": "cortex-m3"}}
 
 
+@tvm.testing.requires_vitis_ai
 def test_composite_target_cmd_line_help():
     parser = argparse.ArgumentParser()
     generate_target_args(parser)

--- a/tests/python/driver/tvmc/test_target_options.py
+++ b/tests/python/driver/tvmc/test_target_options.py
@@ -60,6 +60,28 @@ def test_mapping_target_args():
     assert reconstruct_target_args(parsed) == {"llvm": {"mcpu": "cortex-m3"}}
 
 
+def test_composite_target_cmd_line_help():
+    parser = argparse.ArgumentParser()
+    generate_target_args(parser)
+    assert parser._option_string_actions["--target-vitis-ai-dpu"].help == "Vitis AI DPU identifier"
+    assert (
+        parser._option_string_actions["--target-vitis-ai-build_dir"].help
+        == "Build directory to be used (optional, debug)"
+    )
+    assert (
+        parser._option_string_actions["--target-vitis-ai-work_dir"].help
+        == "Work directory to be used (optional, debug)"
+    )
+    assert (
+        parser._option_string_actions["--target-vitis-ai-export_runtime_module"].help
+        == "Export the Vitis AI runtime module to this file"
+    )
+    assert (
+        parser._option_string_actions["--target-vitis-ai-load_runtime_module"].help
+        == "Load the Vitis AI runtime module to this file"
+    )
+
+
 @tvm.testing.requires_cmsisnn
 def test_include_known_codegen():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Presently --help for vitis displays the target and option string,
it has no description.  Eg:  target vitis-ai dpu<class 'str'>

This can be made more meaningful by fetching the description from the config node of the target.  Eg: Vitis AI DPU identifier

Here, adding test cases to verify the fix

Signed-off-by: MNGanesan <mnganesan@yahoo.co.uk>