### PR TITLE
[ETHOSN] Apply FoldConstant before NPU partitioning

### DIFF
--- a/python/tvm/relay/op/contrib/ethosn.py
+++ b/python/tvm/relay/op/contrib/ethosn.py
@@ -129,6 +129,7 @@ def partition_for_ethosn(mod, params=None, **opts):
 
     passes = [
         transform.InferType(),
+        transform.FoldConstant(fold_qnn=True),
         transform.MergeComposite(pattern_table()),
         transform.AnnotateTarget("ethos-n"),
         transform.MergeCompilerRegions(),

--- a/tests/python/contrib/test_ethosn/test_networks.py
+++ b/tests/python/contrib/test_ethosn/test_networks.py
@@ -218,6 +218,6 @@ def test_ssd_mobilenet_v1():
         input_dict={"normalized_input_image_tensor": (1, 300, 300, 3)},
         compile_hash=_compile_hash,
         output_count=4,
-        host_ops=26,
+        host_ops=14,
         npu_partitions=1,
     )


### PR DESCRIPTION
Introduced FoldConstant before NPU partitioning. Added a qnn.add test where both inputs are constants. Updated the number of operators remaining in the host code for ssd_mobilenet_v1 as the FoldConstant reduces the number of operators.

cc @lhutton1 