### PR TITLE
[RUNTIME] Fix the manual determination of cores in FillDataForMeasure

### DIFF
--- a/src/runtime/contrib/random/mt_random_engine.cc
+++ b/src/runtime/contrib/random/mt_random_engine.cc
@@ -192,12 +192,12 @@ class RandomEngine {
     struct ParallelTask {
       static int RunTask(int task_id, TVMParallelGroupEnv* penv, void* cdata) {
         ParallelTask* task = static_cast<ParallelTask*>(cdata);
-        task->Run(task_id);
+        task->Run(task_id, penv->num_task);
         return 0;
       }
 
-      void Run(int i) {
-        int64_t chunk_size = size / num_threads;
+      void Run(int i, int num_tasks) {
+        int64_t chunk_size = size / num_tasks;
         int64_t st = i * chunk_size;
         int64_t ed = std::min(st + chunk_size, size);
         self->FillDataImpl(data, st, ed, dtype);
@@ -205,7 +205,6 @@ class RandomEngine {
 
       RandomEngine* self;
       void* data;
-      int num_threads;
       int64_t size;
       DLDataType dtype;
     };
@@ -220,8 +219,7 @@ class RandomEngine {
     }
     if (dtype.bits == 1 || dtype.bits == 4 || dtype.bits == 8 || dtype.bits == 16 ||
         dtype.bits == 32 || dtype.bits == 64) {
-      int num_threads = task.num_threads = runtime::threading::MaxConcurrency();
-      int res = TVMBackendParallelLaunch(ParallelTask::RunTask, &task, num_threads);
+      int res = TVMBackendParallelLaunch(ParallelTask::RunTask, &task, 0);
       ICHECK_EQ(res, 0) << "RandomFillForMeasure: TVMBackendParallelLaunch failed";
     } else {
       LOG(FATAL) << "Doesn't support dtype code " << dtype.code << " dtype bits " << dtype.bits;

--- a/src/runtime/contrib/random/mt_random_engine.cc
+++ b/src/runtime/contrib/random/mt_random_engine.cc
@@ -192,12 +192,12 @@ class RandomEngine {
     struct ParallelTask {
       static int RunTask(int task_id, TVMParallelGroupEnv* penv, void* cdata) {
         ParallelTask* task = static_cast<ParallelTask*>(cdata);
-        task->Run(task_id);
+        task->Run(task_id, penv->num_task);
         return 0;
       }
 
-      void Run(int i) {
-        int64_t chunk_size = size / num_threads;
+      void Run(int i, int num_threads) {
+        int64_t chunk_size = ceil(size / num_threads);
         int64_t st = i * chunk_size;
         int64_t ed = std::min(st + chunk_size, size);
         self->FillDataImpl(data, st, ed, dtype);
@@ -220,8 +220,7 @@ class RandomEngine {
     }
     if (dtype.bits == 1 || dtype.bits == 4 || dtype.bits == 8 || dtype.bits == 16 ||
         dtype.bits == 32 || dtype.bits == 64) {
-      int num_threads = task.num_threads = runtime::threading::MaxConcurrency();
-      int res = TVMBackendParallelLaunch(ParallelTask::RunTask, &task, num_threads);
+      int res = TVMBackendParallelLaunch(ParallelTask::RunTask, &task, 0);
       ICHECK_EQ(res, 0) << "RandomFillForMeasure: TVMBackendParallelLaunch failed";
     } else {
       LOG(FATAL) << "Doesn't support dtype code " << dtype.code << " dtype bits " << dtype.bits;

--- a/src/runtime/contrib/random/mt_random_engine.cc
+++ b/src/runtime/contrib/random/mt_random_engine.cc
@@ -209,6 +209,9 @@ class RandomEngine {
       DLDataType dtype;
     };
 
+    int num_workers = tvm::runtime::threading::MaxConcurrency();
+    LOG(FATAL) << "MaxConcurrency = " << num_workers;
+
     ParallelTask task;
     task.self = this;
     task.data = tensor->data;

--- a/src/runtime/contrib/random/mt_random_engine.cc
+++ b/src/runtime/contrib/random/mt_random_engine.cc
@@ -197,7 +197,7 @@ class RandomEngine {
       }
 
       void Run(int i, int num_threads) {
-        int64_t chunk_size = ceil(size / num_threads);
+        int64_t chunk_size = size / num_threads;
         int64_t st = i * chunk_size;
         int64_t ed = std::min(st + chunk_size, size);
         self->FillDataImpl(data, st, ed, dtype);
@@ -205,7 +205,6 @@ class RandomEngine {
 
       RandomEngine* self;
       void* data;
-      int num_threads;
       int64_t size;
       DLDataType dtype;
     };

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -338,7 +338,6 @@ class ThreadPool {
       // The SpscTaskQueue only hosts ONE item at a time
       queues_.emplace_back(std::make_unique<SpscTaskQueue>());
     }
-    ICHECK_EQ(tvm::runtime::threading::MaxConcurrency(), 1) << "MaxConcurrency is not equal to 1";
     threads_ = std::make_unique<tvm::runtime::threading::ThreadGroup>(
         num_workers_, [this](int worker_id) { this->RunWorker(worker_id); },
         exclude_worker0_ /* include_main_thread */);

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -338,6 +338,7 @@ class ThreadPool {
       // The SpscTaskQueue only hosts ONE item at a time
       queues_.emplace_back(std::make_unique<SpscTaskQueue>());
     }
+    ICHECK_EQ(tvm::runtime::threading::MaxConcurrency(), 1) << "MaxConcurrency is not equal to 1";
     threads_ = std::make_unique<tvm::runtime::threading::ThreadGroup>(
         num_workers_, [this](int worker_id) { this->RunWorker(worker_id); },
         exclude_worker0_ /* include_main_thread */);

--- a/tests/python/contrib/test_random.py
+++ b/tests/python/contrib/test_random.py
@@ -20,6 +20,7 @@ import numpy as np
 from tvm.contrib import random
 from tvm import rpc
 import tvm.testing
+import threading
 
 
 def test_randint():
@@ -160,7 +161,7 @@ def test_random_fill_mt():
     Particularly when MaxConcurrency != num_workers_used_ which is actual for big-little systems.
     """
     no_exception_happened = True
-    
+
     def test_body():
         try:
             num_thread_used = 1
@@ -178,7 +179,7 @@ def test_random_fill_mt():
     x = threading.Thread(target=test_body)
     x.start()
     x.join()
-    assert no_exception_happened 
+    assert no_exception_happened
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_random.py
+++ b/tests/python/contrib/test_random.py
@@ -154,8 +154,9 @@ def test_random_fill():
             test_local(dev, dtype)
         test_rpc(dtype)
 
+
 def test_random_fill_mt():
-    """ Check random filler applicability in case of nontrivial thread pool configuration.
+    """Check random filler applicability in case of nontrivial thread pool configuration.
     Particularly when MaxConcurrency != num_workers_used_ which is actual for big-little systems.
     """
     num_threads_used = 1
@@ -166,6 +167,7 @@ def test_random_fill_mt():
     test_input = tvm.runtime.ndarray.empty((64, 64))
     random_fill = tvm.get_global_func("tvm.contrib.random.random_fill_for_measure")
     random_fill(test_input)
+
 
 if __name__ == "__main__":
     test_randint()

--- a/tests/python/contrib/test_random.py
+++ b/tests/python/contrib/test_random.py
@@ -154,9 +154,22 @@ def test_random_fill():
             test_local(dev, dtype)
         test_rpc(dtype)
 
+def test_random_fill_mt():
+    """ Check random filler applicability in case of nontrivial thread pool configuration.
+    Particularly when MaxConcurrency != num_workers_used_ which is actual for big-little systems.
+    """
+    num_threads_used = 1
+
+    configure_threads = tvm.get_global_func("runtime.config_threadpool")
+    configure_threads(1, num_threads_used)
+
+    test_input = tvm.runtime.ndarray.empty((64, 64))
+    random_fill = tvm.get_global_func("tvm.contrib.random.random_fill_for_measure")
+    random_fill(test_input)
 
 if __name__ == "__main__":
     test_randint()
     test_uniform()
     test_normal()
     test_random_fill()
+    test_random_fill_mt()

--- a/tests/python/contrib/test_random.py
+++ b/tests/python/contrib/test_random.py
@@ -155,7 +155,7 @@ def test_random_fill():
         test_rpc(dtype)
 
 
-def test_random_fill_for_measure_mt():
+def test_random_fill_mt():
     """Check random filler applicability in case of nontrivial thread pool configuration.
     Particularly when MaxConcurrency != num_workers_used_ which is actual for big-little systems.
     """


### PR DESCRIPTION
**Motivation:** Assertion failed during tuning

**Error message from _thread_pool.cc:295_:**
`Check failed: num_task <= num_workers_used_ (8 vs. 1) : Request parallel sync task larger than number of threads used  workers=1 request=8`

**Main problem description:**
Tuning of the _ARM Snapdragon 888 CPU_ architecture ends with an error above.

**Suspected reason:**
Incorrect (manual) determination of the number of threads. The number of threads is determined using _MaxConcurrency_ and returns 8 threads for this architecture, but the number of actually used threads is 4. This fix urges to use automatic determination of the number of threads by passing 'zero' as 'num_threads' attribute in 'TVMBackendParallelLaunch' to avoid the abovementioned discrepancy.
