### PR TITLE
[topi] remove comment redundancy in resize.py

### DIFF
--- a/python/tvm/topi/image/resize.py
+++ b/python/tvm/topi/image/resize.py
@@ -813,12 +813,6 @@ def resize2d(
     layout: string, optional
         "NCHW", "NHWC", or "NCHWc".
 
-    coordinate_transformation_mode: string, optional
-        Describes how to transform the coordinate in the resized tensor
-        to the coordinate in the original tensor.
-        Refer to the ONNX Resize operator specification for details.
-        Available options are "half_pixel", "align_corners" and "asymmetric".
-
     method: string, optional
         method of interpolation ("nearest", "linear", "bicubic")
 


### PR DESCRIPTION
@mbrookhart 
Hi, It seems redundant, and I removed the departed one.