### PR TITLE
[TVMScript] Robustify the Highlight Printer

### DIFF
--- a/python/tvm/script/highlight.py
+++ b/python/tvm/script/highlight.py
@@ -20,14 +20,11 @@
 import os
 import sys
 import warnings
-from typing import Optional, Union
-
-from tvm.ir import IRModule
-from tvm.tir import PrimFunc
+from typing import Any, Optional, Union
 
 
 def cprint(
-    printable: Union[IRModule, PrimFunc, str],
+    printable: Union[Any, str],
     style: Optional[str] = None,
     black_format: bool = True,
 ) -> None:
@@ -61,8 +58,12 @@ def cprint(
     The default pygmentize style can also be set with the environment
     variable "TVM_PYGMENTIZE_STYLE".
     """
-    if isinstance(printable, (IRModule, PrimFunc)):
+    if hasattr(printable, "script") and callable(getattr(printable, "script")):
         printable = printable.script()
+    elif not isinstance(printable, str):
+        raise TypeError(
+            f"Only can print strings or objects with `script` method, but got: {type(printable)}"
+        )
 
     if black_format:
         printable = _format(printable)

--- a/tests/python/unittest/test_tvmscript_printer_highlight.py
+++ b/tests/python/unittest/test_tvmscript_printer_highlight.py
@@ -58,9 +58,14 @@ def test_cprint():
     # Print nodes with `script` method, e.g. PrimExpr
     cprint(tvm.tir.Var("v", "int32") + 1)
 
-    # Cannot print non-Python-style codes
-    with pytest.raises(ValueError):
-        cprint("if (a == 1) { a +=1; }")
+    # Cannot print non-Python-style codes if black installed
+    try:
+        import black
+
+        with pytest.raises(ValueError):
+            cprint("if (a == 1) { a +=1; }")
+    except ImportError:
+        pass
 
     # Cannot print unsupported nodes (nodes without `script` method)
     with pytest.raises(TypeError):

--- a/tests/python/unittest/test_tvmscript_printer_highlight.py
+++ b/tests/python/unittest/test_tvmscript_printer_highlight.py
@@ -14,10 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import pytest
 
 import tvm
+import tvm.testing
+from tvm import relay
 from tvm.script import tir as T
+from tvm.script.highlight import cprint
 
 
 def test_highlight_script():
@@ -45,3 +49,23 @@ def test_highlight_script():
     Module["main"].show(style="light")
     Module["main"].show(style="dark")
     Module["main"].show(style="ansi")
+
+
+def test_cprint():
+    # Print string
+    cprint("a + 1")
+
+    # Print nodes with `script` method, e.g. PrimExpr
+    cprint(tvm.tir.Var("v", "int32") + 1)
+
+    # Cannot print non-Python-style codes
+    with pytest.raises(ValueError):
+        cprint("if (a == 1) { a +=1; }")
+
+    # Cannot print unsupported nodes (nodes without `script` method)
+    with pytest.raises(TypeError):
+        cprint(relay.const(1))
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Current `cprint` allows `PrimFunc` and `IRModule` as input. However, after the fragment printing enabled by @junrushao, we can make it robust to support any Objects that have method `script`

cc @junrushao @cyx-6 