### PR TITLE
[ONNX] Support SequenceEmpty op

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -6148,6 +6148,15 @@ class SequenceConstruct(OnnxOpConverter):
         return _expr.Tuple(inputs)
 
 
+class SequenceEmpty(OnnxOpConverter):
+    """Operator converter for sequence empty op."""
+
+    @classmethod
+    def _impl_v11(cls, inputs, attr, params):
+        # Construct an empty tuple.
+        return _expr.Tuple(None)
+
+
 class SequenceErase(OnnxOpConverter):
     """Operator converter for sequence erase op."""
 
@@ -6523,6 +6532,7 @@ def _get_convert_map(opset):
         "LinearRegressor": LinearRegressor.get_converter(opset),
         # Sequence operators
         "SequenceConstruct": SequenceConstruct.get_converter(opset),
+        "SequenceEmpty": SequenceEmpty.get_converter(opset),
         "SequenceErase": SequenceErase.get_converter(opset),
         "SequenceInsert": SequenceInsert.get_converter(opset),
         "SequenceLength": SequenceLength.get_converter(opset),

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -6154,7 +6154,7 @@ class SequenceEmpty(OnnxOpConverter):
     @classmethod
     def _impl_v11(cls, inputs, attr, params):
         # Construct an empty tuple.
-        return _expr.Tuple(None)
+        return _expr.Tuple([])
 
 
 class SequenceErase(OnnxOpConverter):

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -7829,6 +7829,38 @@ def test_sequence(target, dev):
     verify_sequence_ops((3, 3, 3, 3), 4, axis=2, new_axis=1)
 
 
+@tvm.testing.parametrize_targets
+def test_empty_sequence(target, dev):
+    """test_empty_sequence"""
+
+    # Test creating an empty tensor sequence.
+    empty_node = helper.make_node(
+        "SequenceEmpty", inputs=[], outputs=["empty_sequence"],
+    )
+
+    length_node = helper.make_node(
+        "SequenceLength", inputs=["empty_sequence"], outputs=["output"]
+    )
+
+    graph_outputs = [helper.make_tensor_value_info("output", TensorProto.INT64, [])]
+
+    graph_nodes = [empty_node, length_node]
+
+    graph = helper.make_graph(
+        graph_nodes,
+        "Sequence_test",
+        inputs=[],
+        outputs=graph_outputs,
+    )
+
+    model = helper.make_model(
+        graph,
+        producer_name="Sequence_empty_test",
+    )
+
+    verify_with_ort_with_inputs(model, [], target=target, dev=dev)
+
+
 def test_exporting_node_renamed_model():
     """test exproting model when export_node_renamed_model is set"""
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -7835,12 +7835,12 @@ def test_empty_sequence(target, dev):
 
     # Test creating an empty tensor sequence.
     empty_node = helper.make_node(
-        "SequenceEmpty", inputs=[], outputs=["empty_sequence"],
+        "SequenceEmpty",
+        inputs=[],
+        outputs=["empty_sequence"],
     )
 
-    length_node = helper.make_node(
-        "SequenceLength", inputs=["empty_sequence"], outputs=["output"]
-    )
+    length_node = helper.make_node("SequenceLength", inputs=["empty_sequence"], outputs=["output"])
 
     graph_outputs = [helper.make_tensor_value_info("output", TensorProto.INT64, [])]
 
@@ -7848,7 +7848,7 @@ def test_empty_sequence(target, dev):
 
     graph = helper.make_graph(
         graph_nodes,
-        "Sequence_test",
+        "Sequence_empty_test",
         inputs=[],
         outputs=graph_outputs,
     )


### PR DESCRIPTION
Support SequenceEmpty op in ONNX front-end and its test. The test is needed SequenceLength ([PR](https://github.com/apache/tvm/pull/13863) was merged for it)