### PR TITLE
[Hexagon][CI] Update the docker image ID to reflect newer LLVM

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -21,7 +21,7 @@ ci_arm: tlcpack/ci-arm:20221013-060115-61c9742ea
 ci_cortexm: tlcpack/ci-cortexm:20230116-133924-dad13d1c1
 ci_cpu: tlcpack/ci-cpu:20230110-070003-d00168ffb
 ci_gpu: tlcpack/ci-gpu:20221128-070141-ae4fd7df7
-ci_hexagon: tlcpack/ci-hexagon:20221013-060115-61c9742ea
+ci_hexagon: tlcpack/ci_hexagon:20230127-185848-95fa22308
 ci_i386: tlcpack/ci-i386:20221013-060115-61c9742ea
 ci_lint: tlcpack/ci-lint:20221013-060115-61c9742ea
 ci_minimal: tlcpack/ci-minimal:20230117-070124-125886350

--- a/tests/scripts/task_config_build_hexagon.sh
+++ b/tests/scripts/task_config_build_hexagon.sh
@@ -31,11 +31,12 @@ echo set\(USE_LLVM "${CLANG_LLVM_HOME}/bin/llvm-config"\) >> config.cmake
 
 if [[ ${CI:-false} == "true" ]]; then
     # sccache needs to be used in CI to speed up builds
-    echo set\(CMAKE_CXX_COMPILER "/opt/sccache/clang++"\) >> config.cmake
+    echo set\(CMAKE_C_COMPILER "/opt/sccache/cc"\) >> config.cmake
+    echo set\(CMAKE_CXX_COMPILER "/opt/sccache/c++"\) >> config.cmake
 else
     echo 'Skipping sccache setup for local build'
-    echo set\(CMAKE_CXX_COMPILER \"/usr/bin/c++\"\) >> config.cmake
     echo set\(CMAKE_C_COMPILER \"/usr/bin/cc\"\) >> config.cmake
+    echo set\(CMAKE_CXX_COMPILER \"/usr/bin/c++\"\) >> config.cmake
 fi
 
 echo set\(USE_HEXAGON "ON"\) >> config.cmake


### PR DESCRIPTION
The latest image ID is ci_hexagon:20230127-185848-95fa22308.