### PR TITLE
[CI] NNPACK build issue workaround

### DIFF
--- a/docker/install/ubuntu_install_nnpack.sh
+++ b/docker/install/ubuntu_install_nnpack.sh
@@ -26,7 +26,7 @@ git clone https://github.com/Maratyszcza/NNPACK NNPACK
 git clone https://github.com/Maratyszcza/pthreadpool  NNPACK/pthreadpool
 
 # Use specific versioning tag.
-(cd NNPACK && git checkout 1e005b0c2)
+(cd NNPACK && sed -i 's/GIT_TAG master/GIT_TAG main/g' ./cmake/DownloadCpuinfo.cmake && git checkout 1e005b0c2)
 (cd NNPACK/pthreadpool && git checkout 13da0b4c)
 
 mkdir -p NNPACK/build


### PR DESCRIPTION
There is currently a problem building and installing NNPACK using the script `ubuntu_install_nnpack.sh`. The build fails to complete with CMake errors, complaining about missing libraries.

This issue is due to a change in the imported dependency pytorch/cpuinfo that has moved the default branch name to 'main'.

This patch has been submitted as a workaround to the issue raised at https://github.com/apache/tvm/issues/13871

CC @ashutosh-arm @leandron @driazati @areusch 