### PR TITLE
[TIR][TOPI][CI] Fix number of arguments in calls of llvm_pure_intrin

### DIFF
--- a/python/tvm/tir/tensor_intrin/x86.py
+++ b/python/tvm/tir/tensor_intrin/x86.py
@@ -59,7 +59,7 @@ def dot_product_16x4_u8i8i32_vnni(
 
         C[T.ramp(T.int32(0), 1, 16)] = T.call_llvm_pure_intrin(
             T.llvm_lookup_intrinsic_id("llvm.x86.avx512.vpdpbusd.512"),
-            T.uint32(0),
+            T.uint32(3),
             C_i32x16,
             T.broadcast(A_i32, 16),
             B_i32x16,

--- a/python/tvm/topi/x86/tensor_intrin.py
+++ b/python/tvm/topi/x86/tensor_intrin.py
@@ -120,14 +120,14 @@ def dot_16x1x16_uint8_int8_int32_skylake():
             pair_reduction = tvm.tir.call_llvm_pure_intrin(
                 int_lx32,
                 pmaddubs,
-                tvm.tir.const(0, "uint32"),
+                tvm.tir.const(2, "uint32"),
                 vec_a,
                 vec_b,
             )
             quad_reduction = tvm.tir.call_llvm_pure_intrin(
                 int_32xl,
                 pmaddw,
-                tvm.tir.const(0, "uint32"),
+                tvm.tir.const(2, "uint32"),
                 pair_reduction,
                 vec_one,
             )
@@ -215,7 +215,7 @@ def dot_16x1x16_uint8_int8_int16():
                 pair_reduction = tvm.tir.call_llvm_pure_intrin(
                     "int16x32",
                     "llvm.x86.avx512.pmaddubs.w.512",
-                    tvm.tir.const(0, "uint32"),
+                    tvm.tir.const(2, "uint32"),
                     vec_a,
                     vec_b,
                 )
@@ -309,7 +309,7 @@ def dot_16x1x16_uint8_int8_int32_cascadelake():
                 quad_reduction = tvm.tir.call_llvm_pure_intrin(
                     "int32x16",
                     "llvm.x86.avx512.vpdpbusd.512",
-                    tvm.tir.const(0, "uint32"),
+                    tvm.tir.const(3, "uint32"),
                     vec_c,
                     vec_ai32,
                     vec_bi32,
@@ -321,14 +321,14 @@ def dot_16x1x16_uint8_int8_int32_cascadelake():
                 pair_reduction = tvm.tir.call_llvm_pure_intrin(
                     "int16x32",
                     "llvm.x86.avx512.pmaddubs.w.512",
-                    tvm.tir.const(0, "uint32"),
+                    tvm.tir.const(2, "uint32"),
                     vec_a,
                     vec_b,
                 )
                 quad_reduction = tvm.tir.call_llvm_pure_intrin(
                     "int32x16",
                     "llvm.x86.avx512.pmaddw.d.512",
-                    tvm.tir.const(0, "uint32"),
+                    tvm.tir.const(2, "uint32"),
                     pair_reduction,
                     vec_one,
                 )

--- a/tests/python/unittest/test_meta_schedule_postproc_rewrite_tensorize.py
+++ b/tests/python/unittest/test_meta_schedule_postproc_rewrite_tensorize.py
@@ -236,7 +236,7 @@ class Conv2dNCHWcVNNIModuleTensorized:
                     C_i32x16 = C.vload([0], dtype="int32x16")
                     C[T.ramp(0, 1, 16)] = T.call_llvm_pure_intrin(
                         T.llvm_lookup_intrinsic_id("llvm.x86.avx512.vpdpbusd.512"),
-                        T.uint32(0),
+                        T.uint32(3),
                         C_i32x16,
                         T.broadcast(A_i32, 16),
                         B_i32x16,

--- a/tests/python/unittest/test_meta_schedule_trace_apply.py
+++ b/tests/python/unittest/test_meta_schedule_trace_apply.py
@@ -1182,7 +1182,7 @@ def get_conv2d_vnni_mod(intrin_id):
                             B_i8x64: T.int8x64 = B[0, 0:64]
                             B_i32x16: T.int32x16 = T.reinterpret(B_i8x64, dtype="int32x16")
                             C_i32x16: T.int32x16 = C[0:16]
-                            C[0:16] = T.call_llvm_pure_intrin(T.uint32(intrin_id), T.uint32(0), C_i32x16, T.broadcast(A_i32, 16), B_i32x16, dtype="int32x16")
+                            C[0:16] = T.call_llvm_pure_intrin(T.uint32(intrin_id), T.uint32(3), C_i32x16, T.broadcast(A_i32, 16), B_i32x16, dtype="int32x16")
                     for ax0, ax1, ax2, ax3 in T.grid(1, 1, 1, 7):
                         for ax4_fused in T.vectorized(16):
                             with T.block("T_cast_8"):


### PR DESCRIPTION
All `call_llvm_pure_intrin(...)` methods were rechecked and argument corresponding number of input args was corrected for some of them. Corresponding tests were upstreamed