### PR TITLE
[TVMC] Stop printing a wall of warnings with tvmc tune

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -541,7 +541,7 @@ def _build_func_common(measure_input, runtime=None, checks=None, build_option=No
                 instruments=current_pass_context.instruments,
                 config=current_config,
             ):
-                func = build(s, args, target_host=task.target_host, runtime=runtime)
+                func = build(s, args, target=target, runtime=runtime)
     return func, tuple((get_const_tuple(x.shape), x.dtype) for x in args)
 
 

--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -112,8 +112,7 @@ def add_tune_parser(subparsers, _, json_params):
     generate_target_args(parser)
     parser.add_argument(
         "--target-host",
-        help="the host compilation target, defaults to 'llvm'",
-        default="llvm",
+        help="the host compilation target.",
     )
 
     parser.add_argument("--timeout", type=int, default=10, help="compilation timeout, in seconds")


### PR DESCRIPTION
A simple tvmc tune command currently results in a huge wall of warnings about target_host parameter being deprecated, even when the user hasn't provided a target-host cmd line argument.

We can prevent that happening from just not providing the default target-host to tvmc. Also, ensure that when the user does provide target-host, we print the warning once, not 500 times.