### PR TITLE
[COMMUNITY] Wrongtest -> PMC

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,7 +90,7 @@ We do encourage everyone to work anything they are interested in.
 - [Hao Yu](https://github.com/comaniac): @comaniac (PMC) - relay, byoc, auto_scheduler
 - [Lianmin Zheng](https://github.com/merrymercy) (PMC): @merrymercy - autotvm, auto_scheduler, topi, relay
 - [Xiyou Zhou](https://github.com/zxybazh): @zxybazh - relay
-- [wrongtest](https://github.com/wrongtest-intellif): @wrongtest-intellif - tir, tvm-script, arith
+- [wrongtest](https://github.com/wrongtest-intellif) (PMC): @wrongtest-intellif - tir, tvm-script, arith
 
 ## Reviewers
 


### PR DESCRIPTION
Dear community:

Please join us to welcome Wrongtest (@wrongtest-intellif) as a new PMC member.

Wrongtest has been actively improving and contributing to the TIR Schedule and arithmetic analysis implementation. He’s been actively involved in several components of the TVM top to bottom, including but not limited to,

- Relay
- TOPI
- MetaSchedule
- TIR
- TVMScript
- Arithmetic analysis in TIR
- Codegen for Cuda and LLVM
- Runtime

He has a deep understanding of the whole part of one of the compilation flows in the TVM(Relay-TIR-Codegen). He focuses on applying TVM to their NPU backend, contributing features back to the community, and cultivating more active community contributors in his company.

In addition, He has been very actively participating in the community, discussion and sharing his ideas in the forum. He has been also actively managing the PRs and issues.

* [Commits History](https://github.com/apache/tvm/commits?author=wrongtest-intellif)
* [Code Review](https://github.com/apache/tvm/pulls?q=+reviewed-by%3Awrongtest-intellif+)
* [Community Forum Summary](https://discuss.tvm.apache.org/u/wrongtest/summary)