### PR TITLE
[ONNX] Support ScatterElements with reduction

### DIFF
--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -164,6 +164,18 @@ struct ScatterAddAttrs : public tvm::AttrsNode<ScatterAddAttrs> {
   }
 };
 
+struct ScatterElementsAttrs : public tvm::AttrsNode<ScatterElementsAttrs> {
+  Integer axis;
+  String reduction;
+
+  TVM_DECLARE_ATTRS(ScatterElementsAttrs, "relay.attrs.ScatterElementsAttrs") {
+    TVM_ATTR_FIELD(axis).set_default(0).describe("The axis over which to select values.");
+    TVM_ATTR_FIELD(reduction).set_default("update").describe(
+        "Reduction mode of the scatter elements, "
+        "either \"update\" or \"add\" or \"mul\" or \"min\" or \"max\".");
+  }
+};
+
 struct ScatterNDAttrs : public tvm::AttrsNode<ScatterNDAttrs> {
   String mode;
 

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -172,7 +172,7 @@ struct ScatterElementsAttrs : public tvm::AttrsNode<ScatterElementsAttrs> {
     TVM_ATTR_FIELD(axis).set_default(0).describe("The axis over which to select values.");
     TVM_ATTR_FIELD(reduction).set_default("update").describe(
         "Reduction mode of the scatter elements, "
-        "either \"update\" or \"add\" or \"mul\" or \"min\" or \"max\".");
+        "either \"update\", \"add\", \"mul\", \"min\" or \"max\".");
   }
 };
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2874,7 +2874,9 @@ class ScatterElements(OnnxOpConverter):
             reduction = attr.get("reduction", None)
             if reduction is None:
                 reduction = "update"
-            assert reduction in red_valids
+            assert reduction in red_valids, "Only {} modes are supported, but {} is gotten".format(
+                red_valids, reduction
+            )
             ret.append(reduction)
 
         return ret

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2872,6 +2872,8 @@ class ScatterElements(OnnxOpConverter):
 
         if red_valids:
             reduction = attr.get("reduction", None)
+            if reduction is None:
+                reduction = "update"
             assert reduction in red_valids
             ret.append(reduction)
 
@@ -2885,29 +2887,15 @@ class ScatterElements(OnnxOpConverter):
 
     @classmethod
     def _impl_v16(cls, inputs, attr, params):
-        axis, reduction = cls._args_check(inputs, attr, [None, "add", "mul"])
+        axis, reduction = cls._args_check(inputs, attr, ["update", "add", "mul"])
 
-        if not reduction:
-            return _op.scatter(inputs[0], inputs[1], inputs[2], axis)
-        elif reduction == "add":
-            return _op.scatter_add(inputs[0], inputs[1], inputs[2], axis)
-        # else: # There is no other choices due to it was checked earlier
-        #     return _op.scatter_mul(inputs[0], inputs[1], inputs[2], axis)
+        return _op.scatter_elements(inputs[0], inputs[1], inputs[2], axis, reduction)
 
     @classmethod
     def _impl_v18(cls, inputs, attr, params):
-        axis, reduction = cls._args_check(inputs, attr, [None, "add", "mul", "min", "max"])
+        axis, reduction = cls._args_check(inputs, attr, ["update", "add", "mul", "min", "max"])
 
-        if not reduction:
-            return _op.scatter(inputs[0], inputs[1], inputs[2], axis)
-        elif reduction == "add":
-            return _op.scatter_add(inputs[0], inputs[1], inputs[2], axis)
-        # elif reduction == "mul":
-        #     return _op.scatter_mul(inputs[0], inputs[1], inputs[2], axis)
-        # elif reduction == "min":
-        #     return _op.scatter_min(inputs[0], inputs[1], inputs[2], axis)
-        # else: # There is no other choices due to it was checked earlier
-        #     return _op.scatter_max(inputs[0], inputs[1], inputs[2], axis)
+        return _op.scatter_elements(inputs[0], inputs[1], inputs[2], axis, reduction)
 
 
 class ScatterND(OnnxOpConverter):

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2848,7 +2848,7 @@ class Scatter(OnnxOpConverter):
     """Operator converter for Scatter."""
 
     @classmethod
-    def _impl_v1(cls, inputs, attr, params):
+    def _impl_v9(cls, inputs, attr, params):
         axis = attr.get("axis", 0)
         return _op.scatter(inputs[0], inputs[1], inputs[2], axis)
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2873,7 +2873,8 @@ class ScatterElements(OnnxOpConverter):
         if red_valids:
             reduction = attr.get("reduction", None)
             if reduction is None:
-                reduction = "update"
+                reduction = b"update"
+            reduction.decode("utf-8")
             assert reduction in red_valids, "Only {} modes are supported, but {} is gotten".format(
                 red_valids, reduction
             )

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2874,7 +2874,7 @@ class ScatterElements(OnnxOpConverter):
             reduction = attr.get("reduction", None)
             if reduction is None:
                 reduction = b"update"
-            reduction.decode("utf-8")
+            reduction = reduction.decode("utf-8")
             assert reduction in red_valids, "Only {} modes are supported, but {} is gotten".format(
                 red_valids, reduction
             )

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -2886,7 +2886,7 @@ class ScatterElements(OnnxOpConverter):
     def _impl_v11(cls, inputs, attr, params):
         axis = cls._args_check(inputs, attr)
 
-        return _op.scatter(inputs[0], inputs[1], inputs[2], axis)
+        return _op.scatter_elements(inputs[0], inputs[1], inputs[2], axis, "update")
 
     @classmethod
     def _impl_v16(cls, inputs, attr, params):

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -204,6 +204,15 @@ def compute_scatter_add(attrs, inputs, output_type):
 
 _reg.register_strategy("scatter_add", strategy.scatter_add_strategy)
 
+# scatter_elements
+@_reg.register_compute("scatter_elements")
+def compute_scatter_elements(attrs, inputs, output_type):
+    """Compute definition of scatter_elements"""
+    return [topi.scatter_elements(inputs[0], inputs[1], inputs[2], attrs.axis, attrs.reduction)]
+
+
+_reg.register_strategy("scatter_elements", strategy.scatter_elements_strategy)
+
 # scatter_nd
 @_reg.register_compute("scatter_nd")
 def compute_scatter_nd(attrs, inputs, output_type):
@@ -679,6 +688,7 @@ def argwhere_shape_func(attrs, inputs, out_ndims):
 
 _reg.register_shape_func("scatter", False, elemwise_shape_func)
 _reg.register_shape_func("scatter_add", False, elemwise_shape_func)
+_reg.register_shape_func("scatter_elements", False, elemwise_shape_func)
 _reg.register_shape_func("scatter_nd", False, elemwise_shape_func)
 
 

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -639,6 +639,11 @@ class ScatterAddAttrs(Attrs):
     """Attributes used in scatter_add operators"""
 
 
+@tvm._ffi.register_object("relay.attrs.ScatterElementsAttrs")
+class ScatterElementsAttrs(Attrs):
+    """Attributes used in scatter_elements operators"""
+
+
 @tvm._ffi.register_object("relay.attrs.ScatterNDAttrs")
 class ScatterNDAttrs(Attrs):
     """Attributes used in scatter_nd operators"""

--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -1099,6 +1099,20 @@ def scatter_add_cuda(attrs, inputs, out_type, target):
     return strategy
 
 
+@scatter_elements_strategy.register(["cuda", "gpu"])
+def scatter_elements_cuda(attrs, inputs, out_type, target):
+    """scatter elements cuda strategy"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_compute_scatter_elements(topi.cuda.scatter_elements),
+        wrap_topi_schedule(topi.cuda.schedule_extern),
+        name="scatter_elements.cuda",
+        plevel=10,
+    )
+    # TODO(vvchernov): There is possible specification for rank=1 as for scatter
+    return strategy
+
+
 @scatter_nd_strategy.register(["cuda", "gpu"])
 def scatter_nd_cuda(attrs, inputs, out_type, target):
     """scatter_nd cuda strategy"""

--- a/python/tvm/relay/op/strategy/generic.py
+++ b/python/tvm/relay/op/strategy/generic.py
@@ -1580,6 +1580,28 @@ def scatter_add_strategy(attrs, outs, out_type, target):
     return strategy
 
 
+# scatter_elements
+@override_native_generic_func("scatter_elements_strategy")
+def scatter_elements_strategy(attrs, inputs, out_type, target):
+    """scatter_elements generic strategy"""
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_compute_scatter_elements(topi.scatter_elements),
+        wrap_topi_schedule(topi.generic.schedule_extern),
+        name="scatter_elements.generic",
+    )
+    return strategy
+
+
+def wrap_compute_scatter_elements(topi_compute):
+    """Wrap scatter_elements topi compute"""
+
+    def _compute_scatter_elements(attrs, inputs, _):
+        return [topi_compute(inputs[0], inputs[1], inputs[2], attrs.axis, attrs.reduction)]
+
+    return _compute_scatter_elements
+
+
 # scatter_nd
 @override_native_generic_func("scatter_nd_strategy")
 def scatter_nd_strategy(attrs, inputs, out_type, target):

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -403,8 +403,9 @@ def scatter_add(data, indices, updates, axis):
     return _make.scatter_add(data, indices, updates, axis)
 
 
-def scatter_elements(data, indices, updates, axis, reduction):
-    """Update data by adding values in updates at positions defined by indices.
+def scatter_elements(data, indices, updates, axis, reduction="update"):
+    """Scatter elements with updating data by reduction of values in updates
+    at positions defined by indices.
 
     Parameters
     ----------
@@ -421,7 +422,8 @@ def scatter_elements(data, indices, updates, axis, reduction):
         The axis to scatter_add on.
 
     reduction : string, optional
-        The reduction mode for scatter. Choise is from ["update", "add", "mul", "min", max"]
+        The reduction mode for scatter. Choise is from ["update", "add", "mul", "min", max"].
+        It is "update" by default.
 
     Returns
     -------

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -403,6 +403,34 @@ def scatter_add(data, indices, updates, axis):
     return _make.scatter_add(data, indices, updates, axis)
 
 
+def scatter_elements(data, indices, updates, axis, reduction):
+    """Update data by adding values in updates at positions defined by indices.
+
+    Parameters
+    ----------
+    data : relay.Expr
+        The input data to the operator.
+
+    indices : relay.Expr
+        The index locations to update.
+
+    updates : relay.Expr
+        The values to add.
+
+    axis : int
+        The axis to scatter_add on.
+
+    reduction : string, optional
+        The reduction mode for scatter. Choise is from ["update", "add", "mul", "min", max"]
+
+    Returns
+    -------
+    ret : relay.Expr
+        The computed result.
+    """
+    return _make.scatter_elements(data, indices, updates, axis, reduction)
+
+
 def scatter_nd(data, indices, updates, mode="update"):
     """Scatter values from an array and update.
 

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -403,7 +403,7 @@ def scatter_add(data, indices, updates, axis):
     return _make.scatter_add(data, indices, updates, axis)
 
 
-def scatter_elements(data, indices, updates, axis, reduction="update"):
+def scatter_elements(data, indices, updates, axis=0, reduction="update"):
     """Scatter elements with updating data by reduction of values in updates
     at positions defined by indices.
 
@@ -416,14 +416,19 @@ def scatter_elements(data, indices, updates, axis, reduction="update"):
         The index locations to update.
 
     updates : relay.Expr
-        The values to add.
+        The values to update.
 
     axis : int
-        The axis to scatter_add on.
+        The axis to scatter elements on. It is zero by default.
 
     reduction : string, optional
-        The reduction mode for scatter. Choise is from ["update", "add", "mul", "min", max"].
-        It is "update" by default.
+        The reduction mode for scatter. Choise is from ["update", "add", "mul", "min", max"]
+        If update, the update values will replace the input data
+        If add, the update values will be added to the input data
+        If mul, the update values will be multiply to the input data
+        If min, there is choice of minimal between the update values and the input data
+        If max, there is choice of maximal between the update values and the input data
+        It is "update" by default
 
     Returns
     -------

--- a/python/tvm/topi/__init__.py
+++ b/python/tvm/topi/__init__.py
@@ -38,6 +38,7 @@ from .transform import *
 from .broadcast import *
 from .sort import *
 from .scatter import *
+from .scatter_elements import *
 from .sparse_fill_empty_rows import *
 from .sparse_reshape import *
 from .scatter_add import *

--- a/python/tvm/topi/cuda/__init__.py
+++ b/python/tvm/topi/cuda/__init__.py
@@ -46,6 +46,7 @@ from .ssd import *
 from .nms import get_valid_counts, non_max_suppression, all_class_non_max_suppression
 from .rcnn import *
 from .scatter import *
+from .scatter_elements import *
 from .sort import *
 from .conv2d_nhwc_tensorcore import *
 from .conv3d_ndhwc_tensorcore import *

--- a/python/tvm/topi/cuda/scatter_elements.py
+++ b/python/tvm/topi/cuda/scatter_elements.py
@@ -67,7 +67,7 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
     if not isinstance(axis, int):
         axis = get_const_int(axis)
 
-    def gen_ir(data, indices, updates, out):
+    def gen_ir(data, indices, updates, out, axis):
         ib = tir.ir_builder.create()
 
         data_ptr = ib.buffer_ptr(data)
@@ -92,7 +92,7 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
         full_range = before_axis_range * before_axis_stride
 
         ind_shape = indices.shape
-        ind_axis_range = shape[axis]
+        ind_axis_range = ind_shape[axis]
 
         ind_before_axis_range = 1
         ind_after_axis_range = 1
@@ -173,7 +173,7 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
     return te.extern(
         [data.shape],
         [data, indices, updates],
-        lambda ins, outs: gen_ir(ins[0], ins[1], ins[2], outs[0]),
+        lambda ins, outs: gen_ir(ins[0], ins[1], ins[2], outs[0], axis),
         dtype=data.dtype,
         out_buffers=[out_buf],
         name="scatter_elements_cuda",

--- a/python/tvm/topi/cuda/scatter_elements.py
+++ b/python/tvm/topi/cuda/scatter_elements.py
@@ -102,7 +102,6 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
             elif i > axis:
                 ind_after_axis_range *= value
         ind_before_axis_stride = ind_axis_range * ind_after_axis_range
-        ind_full_range = ind_before_axis_range * ind_before_axis_stride
         ind_full_range_excl_axis = ind_before_axis_range * ind_after_axis_range
 
         max_threads = int(tvm.target.Target.current(allow_none=False).max_num_threads)

--- a/python/tvm/topi/cuda/scatter_elements.py
+++ b/python/tvm/topi/cuda/scatter_elements.py
@@ -126,10 +126,12 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
             ib.scope_attr(bx1, "thread_extent", num_blocks_1)
             ib.scope_attr(tx1, "thread_extent", max_threads)
 
-            ind_fused = bx2 * max_threads + tx2
+            ind_fused = bx1 * max_threads + tx1
             with ib.if_scope(ind_fused < ind_full_range):
                 index_check = tir.LT(indices_ptr[ind_fused], tir.const(0, indices.dtype))
-                indices_ptr[ind_fused] += tir.Select(index_check, axis_range, tir.const(0, indices.dtype))
+                indices_ptr[ind_fused] += tir.Select(
+                    index_check, axis_range, tir.const(0, indices.dtype)
+                )
                 # TODO(vvchernov): assert for index out of bounds
 
         # TODO (vvchernov): use atomic function for special conditions (see cuda.scatter_nd)

--- a/python/tvm/topi/cuda/scatter_elements.py
+++ b/python/tvm/topi/cuda/scatter_elements.py
@@ -1,0 +1,157 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Scatter operator """
+import tvm
+from tvm import te
+from tvm import tir
+from ..utils import ceil_div, get_const_int
+from ..math import cast
+
+
+def scatter_elements(data, indices, updates, axis=0, reduction="update"):
+    """Scatter elements from updates to corresponding indices of copied data.
+
+    Data, indices, updates and output have the same shape.
+    Indices can not have duplicates (if idx1 != idx2, then indices[idx1] != indices[idx2])
+    if reduction == "update".
+
+    .. code-block::
+
+        output[indices[i][j]][j] = f(output[indices[i][j]][j], updates[i][j]) if axis = 0
+        output[i][indices[i][j]] = f(output[i][indices[i][j]], updates[i][j]) if axis = 1
+
+    where the update function f is determinted by the reduction.
+    Five types of the function are supported: "update", "add", "mul", "min" and "max" (see below)
+
+    Parameters
+    ----------
+    data : tvm.te.Tensor
+        The source array.
+
+    indices : tvm.te.Tensor
+        The indices of the values to extract.
+
+    updates : tvm.te.Tensor
+        The updates to apply at the Indices
+
+    axis : optional, int
+        The axis to scatter on. It is zero by default.
+
+    reduction : optional, string
+        The update mode for the algorithm, either "update", "add", "mul", "min" or "max"
+        If update, the update values will replace the input data
+        If add, the update values will be added to the input data
+        If mul, the update values will be multiply to the input data
+        If min, there is choice of minimal between the update values and the input data
+        If max, there is choice of maximal between the update values and the input data
+        It is "update" by default
+
+    Returns
+    -------
+    ret : tvm.te.Tensor
+    """
+    if not isinstance(axis, int):
+        axis = get_const_int(axis)
+
+    shape = data.shape
+    axis_range = cast(shape[axis], indices.dtype)
+
+    if axis < 0:
+        axis = len(shape) + axis
+
+    # Prepare ranges and strides
+    before_axis_range = 1
+    after_axis_range = 1
+    for i, value in enumerate(shape, 0):
+        if i < axis:
+            before_axis_range *= value
+        elif i > axis:
+            after_axis_range *= value
+    before_axis_stride = axis_range * after_axis_range
+    full_range = before_axis_range * before_axis_stride
+    full_range_excl_axis = before_axis_range * after_axis_range
+
+    def gen_ir(data_ptr, indices_ptr, updates_ptr, out_ptr):
+        ib = tir.ir_builder.create()
+
+        data = ib.buffer_ptr(data_ptr)
+        indices = ib.buffer_ptr(indices_ptr)
+        updates = ib.buffer_ptr(updates_ptr)
+        out = ib.buffer_ptr(out_ptr)
+
+        max_threads = int(tvm.target.Target.current(allow_none=False).max_num_threads)
+        # Copy initial input data to output
+        with ib.new_scope():
+            num_blocks = ceil_div(full_range, max_threads)
+            bx = te.thread_axis("blockIdx.x")
+            tx = te.thread_axis("threadIdx.x")
+            ib.scope_attr(bx, "thread_extent", num_blocks)
+            ib.scope_attr(tx, "thread_extent", max_threads)
+
+            index = bx * max_threads + tx
+            with ib.if_scope(index < full_range):
+                out[index] = data[index]
+
+        # TODO (vvchernov): use atomic function for special conditions (see cuda.scatter_nd)
+        with ib.new_scope():
+            num_blocks_2 = ceil_div(full_range_excl_axis, max_threads)
+            bx2 = te.thread_axis("blockIdx.x")
+            tx2 = te.thread_axis("threadIdx.x")
+            ib.scope_attr(bx2, "thread_extent", num_blocks_2)
+            ib.scope_attr(tx2, "thread_extent", max_threads)
+
+            fused = bx2 * max_threads + tx2
+            with ib.if_scope(fused < full_range_excl_axis):
+                i = fused // after_axis_range
+                j = fused % after_axis_range
+                pre_index = i * before_axis_stride + j
+                with ib.for_range(0, axis_range, "k") as k:
+                    index1 = pre_index + k * after_axis_range
+                    # TODO(vvchernov): assert for out of bounds, separated check for indices
+                    k_new = indices[index1]
+                    index_check = tir.LT(k_new, tir.const(0, indices.dtype))
+                    k_new += tir.Select(index_check, axis_range, tir.const(0, indices.dtype))
+                    index2 = pre_index + k_new * after_axis_range
+                    if reduction == "update":
+                        out[index2] = updates[index1]
+                    elif reduction == "add":
+                        out[index2] += updates[index1]
+                    elif reduction == "mul":
+                        out[index2] *= updates[index1]
+                    elif reduction == "min":
+                        tir.min(out[index2], updates[index1])
+                    elif reduction == "max":
+                        tir.max(out[index2], updates[index1])
+                    else:
+                        raise NotImplementedError(
+                            "scatter_elements reduction not in [update, add, mul, min, max]:",
+                            reduction,
+                        )
+
+        return ib.get()
+
+    out_buf = tir.decl_buffer(data.shape, data.dtype, "out_buf")
+    return te.extern(
+        [data.shape],
+        [data, indices, updates],
+        lambda ins, outs: gen_ir(ins[0], ins[1], ins[2], outs[0]),
+        dtype=data.dtype,
+        out_buffers=[out_buf],
+        name="scatter_elements_cuda",
+        tag="scatter_elements_cuda",
+    )

--- a/python/tvm/topi/cuda/scatter_elements.py
+++ b/python/tvm/topi/cuda/scatter_elements.py
@@ -68,11 +68,10 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
     if not isinstance(axis, int):
         axis = get_const_int(axis)
 
-    if axis < 0:
-        axis = len(shape) + axis
-
     # Prepare ranges and strides
     shape = data.shape
+    if axis < 0:
+        axis = len(shape) + axis
     axis_range = cast(shape[axis], indices.dtype)
 
     before_axis_range = 1

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -101,10 +101,10 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
                 with ib.for_range(0, axis_range, "k") as k:
                     pre_index = i * before_axis_stride + j
                     index1 = pre_index + k * after_axis_range
-                    # TODO(vvchernov): assert for out of bounds
+                    # TODO(vvchernov): assert for out of bounds, separated check for indices
                     k_new = indices[index1]
-                    if k_new < 0:
-                        k_new += axis_range
+                    index_check = tir.LT(k_new, tir.const(0, indices.dtype))
+                    k_new += tir.Select(index_check, axis_range, tir.const(0, indices.dtype))
                     index2 = pre_index + k_new * after_axis_range
                     if reduction == "update":
                         out[index2] = updates[index1]

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -29,11 +29,11 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
 
     .. code-block::
 
-        output[indices[i][j]][j] = f(output[indices[i][j]][j], updates[i][j]) if axis = 0,
-        output[i][indices[i][j]] = f(output[i][indices[i][j]], updates[i][j]) if axis = 1,
+        output[indices[i][j]][j] = f(output[indices[i][j]][j], updates[i][j]) if axis = 0
+        output[i][indices[i][j]] = f(output[i][indices[i][j]], updates[i][j]) if axis = 1
 
     where the update function f is determinted by the reduction.
-    Five types of the function are supported: replace, +, *, min or max
+    Five types of the function are supported: replace, +, \*, min or max
 
     Parameters
     ----------

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -66,11 +66,10 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
     if not isinstance(axis, int):
         axis = utils.get_const_int(axis)
 
-    if axis < 0:
-        axis = len(shape) + axis
-
     # Prepare ranges and strides
     shape = data.shape
+    if axis < 0:
+        axis = len(shape) + axis
     axis_range = cast(shape[axis], indices.dtype)
 
     full_range = 1

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -14,10 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=redefined-builtin, invalid-name, too-many-arguments, too-many-nested-blocks
 """ScatterElements operator"""
-from ..te import extern
-from ..tir import min, max, decl_buffer, ir_builder
+from tvm import te
+from tvm import tir
 
 
 def scatter_elements(data, indices, updates, axis=0, reduction="update"):
@@ -65,7 +64,7 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
 
     def gen_ir(data_ptr, indices_ptr, updates_ptr, out_ptr):
         # pylint: disable=invalid-name
-        ib = ir_builder.create()
+        ib = tir.ir_builder.create()
 
         data = ib.buffer_ptr(data_ptr)
         indices = ib.buffer_ptr(indices_ptr)
@@ -103,9 +102,9 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
                     elif reduction == "mul":
                         out[index2] *= updates[index1]
                     elif reduction == "min":
-                        min(out[index2], updates[index1])
+                        tir.min(out[index2], updates[index1])
                     elif reduction == "max":
-                        max(out[index2], updates[index1])
+                        tir.max(out[index2], updates[index1])
                     else:
                         raise NotImplementedError(
                             "scatter_elements reduction not in [update, add, mul, min, max]:",
@@ -114,8 +113,8 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
 
         return ib.get()
 
-    out_buf = decl_buffer(data.shape, data.dtype, "out_buf")
-    return extern(
+    out_buf = tir.decl_buffer(data.shape, data.dtype, "out_buf")
+    return te.extern(
         [data.shape],
         [data, indices, updates],
         lambda ins, outs: gen_ir(ins[0], ins[1], ins[2], outs[0]),

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -66,7 +66,7 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
         axis = utils.get_const_int(axis)
 
     shape = data.shape
-    axis_range = shape[axis]
+    axis_range = int(shape[axis])
 
     if axis < 0:
         axis = len(shape) + axis

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -18,6 +18,7 @@
 from tvm import te
 from tvm import tir
 from . import utils
+from .math import cast
 
 
 def scatter_elements(data, indices, updates, axis=0, reduction="update"):
@@ -66,7 +67,7 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
         axis = utils.get_const_int(axis)
 
     shape = data.shape
-    axis_range = int(shape[axis])
+    axis_range = cast(shape[axis], indices.dtype)
 
     if axis < 0:
         axis = len(shape) + axis

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -95,9 +95,10 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
         with ib.for_range(0, full_range, "i", kind="parallel") as i:
             out[i] = data[i]
 
+        # TODO(vvchernov): find optimal parallel approach
         with ib.for_range(0, before_axis_range, "i", kind="parallel") as i:
-            with ib.for_range(0, after_axis_range, "j", kind="parallel") as j:
-                with ib.for_range(0, axis_range, "k", kind="parallel") as k:
+            with ib.for_range(0, after_axis_range, "j") as j:
+                with ib.for_range(0, axis_range, "k") as k:
                     pre_index = i * before_axis_stride + j
                     index1 = pre_index + k * after_axis_range
                     index2 = pre_index + indices[index1] * after_axis_range

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -1,0 +1,126 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=redefined-builtin, invalid-name, too-many-arguments, too-many-nested-blocks
+"""ScatterElements operator"""
+from ..te import extern
+from ..tir import min, max, decl_buffer, ir_builder
+
+
+def scatter_elements(data, indices, updates, axis=0, reduction="update"):
+    """Scatter elements from updates to corresponding indices of copied data.
+
+    Data, indices, updates and output have the same shape.
+    Indices can not have duplicates (if idx1 != idx2, then indices[idx1] != indices[idx2])
+    if reduction == "update".
+
+    .. code-block::
+
+        output[indices[i][j]][j] = f(output[indices[i][j]][j], updates[i][j]) if axis = 0,
+        output[i][indices[i][j]] = f(output[i][indices[i][j]], updates[i][j]) if axis = 1,
+
+    where the update function f is determinted by the reduction.
+    Five types of the function are supported: replace, +, *, min or max
+
+    Parameters
+    ----------
+    data : tvm.te.Tensor
+        The source array.
+
+    indices : tvm.te.Tensor
+        The indices of the values to extract.
+
+    updates : tvm.te.Tensor
+        The updates to apply at the Indices
+
+    axis : optional, int
+        The axis to scatter on. It is zero by default.
+
+    reduction : optional, string
+        The update mode for the algorithm, either "update", "add", "mul", "min" or "max"
+        If update, the update values will replace the input data
+        If add, the update values will be added to the input data
+        If mul, the update values will be multiply to the input data
+        If min, there is choice of minimal between the update values and the input data
+        If max, there is choice of maximal between the update values and the input data
+        It is "update" by default
+
+    Returns
+    -------
+    ret : tvm.te.Tensor
+    """
+
+    def gen_ir(data_ptr, indices_ptr, updates_ptr, out_ptr):
+        # pylint: disable=invalid-name
+        ib = ir_builder.create()
+
+        data = ib.buffer_ptr(data_ptr)
+        indices = ib.buffer_ptr(indices_ptr)
+        updates = ib.buffer_ptr(updates_ptr)
+        out = ib.buffer_ptr(out_ptr)
+
+        # Prepare ranges and strides
+        before_axis_range = 1
+        for i in data_ptr.shape[:axis]:
+            before_axis_range *= i
+
+        axis_range = data_ptr.shape[axis]
+
+        after_axis_range = 1
+        for i in data_ptr.shape[axis + 1 :]:
+            after_axis_range *= i
+        before_axis_stride = axis_range * after_axis_range
+
+        # Copy initial input data to output
+        fused_shape = before_axis_range * before_axis_stride
+
+        with ib.for_range(0, fused_shape) as i:
+            out[i] = data[i]
+
+        with ib.for_range(0, before_axis_range, kind="parallel") as i:
+            with ib.for_range(0, after_axis_range, kind="parallel") as j:
+                with ib.for_range(0, axis_range, kind="parallel") as k:
+                    pre_index = i * before_axis_stride + j
+                    index1 = pre_index + k * after_axis_range
+                    index2 = pre_index + indices[index1]
+                    if reduction == "update":
+                        out[index2] = updates[index1]
+                    elif reduction == "add":
+                        out[index2] += updates[index1]
+                    elif reduction == "mul":
+                        out[index2] *= updates[index1]
+                    elif reduction == "min":
+                        min(out[index2], updates[index1])
+                    elif reduction == "max":
+                        max(out[index2], updates[index1])
+                    else:
+                        raise NotImplementedError(
+                            "scatter_elements reduction not in [update, add, mul, min, max]:",
+                            reduction,
+                        )
+
+        return ib.get()
+
+    out_buf = decl_buffer(data.shape, data.dtype, "out_buf")
+    return extern(
+        [data.shape],
+        [data, indices, updates],
+        lambda ins, outs: gen_ir(ins[0], ins[1], ins[2], outs[0]),
+        dtype=data.dtype,
+        out_buffers=[out_buf],
+        name="scatter_elements.generic",
+        tag="scatter_elements.generic",
+    )

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -33,7 +33,7 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
         output[i][indices[i][j]] = f(output[i][indices[i][j]], updates[i][j]) if axis = 1
 
     where the update function f is determinted by the reduction.
-    Five types of the function are supported: replace, +, \*, min or max
+    Five types of the function are supported: "update", "add", "mul", "min" and "max" (see below)
 
     Parameters
     ----------

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -113,13 +113,13 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
             i = fused // ind_after_axis_range
             j = fused % ind_after_axis_range
             with ib.for_range(0, ind_axis_range, "k") as k:
-                # Offset allong indices or updates
+                # Offset along indices or updates
                 index1 = i * ind_before_axis_stride + k * ind_after_axis_range + j
                 # TODO(vvchernov): assert for out of bounds, separated check for indices
                 k_new = indices[index1]
                 index_check = tir.LT(k_new, tir.const(0, indices.dtype))
                 k_new += tir.Select(index_check, axis_range, tir.const(0, indices.dtype))
-                # Offset allong data
+                # Offset along data
                 index2 = i * before_axis_stride + k_new * after_axis_range + j
                 if reduction == "update":
                     out[index2] = updates[index1]

--- a/python/tvm/topi/scatter_elements.py
+++ b/python/tvm/topi/scatter_elements.py
@@ -101,7 +101,11 @@ def scatter_elements(data, indices, updates, axis=0, reduction="update"):
                 with ib.for_range(0, axis_range, "k") as k:
                     pre_index = i * before_axis_stride + j
                     index1 = pre_index + k * after_axis_range
-                    index2 = pre_index + indices[index1] * after_axis_range
+                    # TODO(vvchernov): assert for out of bounds
+                    k_new = indices[index1]
+                    if k_new < 0:
+                        k_new += axis_range
+                    index2 = pre_index + k_new * after_axis_range
                     if reduction == "update":
                         out[index2] = updates[index1]
                     elif reduction == "add":

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -1237,7 +1237,7 @@ TVM_REGISTER_GLOBAL("relay.op._make.scatter_elements").set_body_typed(MakeScatte
 
 // scatter_elements op has extern schedules: convert to Opaque to prevent compilation failures
 RELAY_REGISTER_OP("scatter_elements")
-    .describe(R"code(Scatter elements with updating data by reduction values in updates
+    .describe(R"code(Scatter elements with updating data by reduction of values in updates
 at positions defined by indices.)code" TVM_ADD_FILELINE)
     .set_num_inputs(3)
     .add_argument("data", "Tensor", "The input tensor.")

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -393,7 +393,8 @@ Select::Select(PrimExpr condition, PrimExpr true_value, PrimExpr false_value, Sp
   ICHECK(false_value.defined()) << "ValueError: true_value is undefined";
   ICHECK(condition.dtype().is_bool());
   ICHECK(condition.dtype().lanes() == true_value.dtype().lanes() || condition.dtype().lanes() == 1);
-  ICHECK(false_value.dtype() == true_value.dtype()) << "TypeError: mismatched types";
+  ICHECK(false_value.dtype() == true_value.dtype()) << "TypeError: mismatched types. " <<
+    "False type: " << false_value.dtype() << "; True type: " << true_value.dtype();
 
   ObjectPtr<SelectNode> node = make_object<SelectNode>();
   node->dtype = true_value.dtype();

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -393,8 +393,9 @@ Select::Select(PrimExpr condition, PrimExpr true_value, PrimExpr false_value, Sp
   ICHECK(false_value.defined()) << "ValueError: true_value is undefined";
   ICHECK(condition.dtype().is_bool());
   ICHECK(condition.dtype().lanes() == true_value.dtype().lanes() || condition.dtype().lanes() == 1);
-  ICHECK(false_value.dtype() == true_value.dtype()) << "TypeError: mismatched types. " <<
-    "False type: " << false_value.dtype() << "; True type: " << true_value.dtype();
+  ICHECK(false_value.dtype() == true_value.dtype())
+    << "TypeError: mismatched types. "
+    << "False type: " << false_value.dtype() << "; True type: " << true_value.dtype();
 
   ObjectPtr<SelectNode> node = make_object<SelectNode>();
   node->dtype = true_value.dtype();

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -394,8 +394,8 @@ Select::Select(PrimExpr condition, PrimExpr true_value, PrimExpr false_value, Sp
   ICHECK(condition.dtype().is_bool());
   ICHECK(condition.dtype().lanes() == true_value.dtype().lanes() || condition.dtype().lanes() == 1);
   ICHECK(false_value.dtype() == true_value.dtype())
-    << "TypeError: mismatched types. "
-    << "False type: " << false_value.dtype() << "; True type: " << true_value.dtype();
+      << "TypeError: mismatched types. "
+      << "False type: " << false_value.dtype() << "; True type: " << true_value.dtype();
 
   ObjectPtr<SelectNode> node = make_object<SelectNode>();
   node->dtype = true_value.dtype();

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -922,7 +922,7 @@ def test_scatter_elements(target, dev):
         0,
         "mul",
     )
-    # TODO(vvchernov): min and mul options are supported from 18 version, but CI supports 17 only
+    # TODO(vvchernov): min and max options are supported from 18 version, but CI supports 17 only
     # # Scatter elements with min reduction of duplicates
     # verify_scatter_elements(
     #     (3, 3, 3),
@@ -5468,7 +5468,6 @@ unsupported_onnx_tests = [
     "test_reduce_sum_negative_axes_keepdims_example",
     "test_reduce_sum_negative_axes_keepdims_random",
     "test_roialign_aligned_true",
-    "test_scatter_elements_with_duplicate_indices",
     "test_sequence_insert_at_back",
     "test_sequence_insert_at_front",
     "test_sequence_map_add_1_sequence_1_tensor",

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -856,7 +856,9 @@ def test_scatter(target, dev):
             outputs=[helper.make_tensor_value_info("output", TensorProto.FLOAT, list(in_shape))],
         )
         model = helper.make_model(graph, producer_name="scatter_test")
-        verify_with_ort_with_inputs(model, [x, indices, updates], target=target, dev=dev, opset=16)
+        # Scatter operator has been supported from version 9 and
+        # deprecated since version 11 of the default ONNX operator set
+        verify_with_ort_with_inputs(model, [x, indices, updates], target=target, dev=dev, opset=9)
 
     verify_scatter((4,), [1], 0)
     verify_scatter((1, 4), [[0]], 0)

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -844,7 +844,7 @@ def test_scatter(target, dev):
         updates = np.random.uniform(size=indices.shape).astype("float32")
 
         y = helper.make_node(
-            "ScatterElements", ["data", "indices", "updates"], ["output"], axis=axis
+            "Scatter", ["data", "indices", "updates"], ["output"], axis=axis
         )
 
         graph = helper.make_graph(
@@ -866,6 +866,76 @@ def test_scatter(target, dev):
     verify_scatter((2, 2), [[1, 0], [0, 1]], 1)
     verify_scatter((3, 3, 3), [[[-1, -3]]], -1)
     verify_scatter((4, 3, 5, 6), [[[[2, 1, 0, 0]]]], 0)
+
+
+@tvm.testing.parametrize_targets
+def test_scatter_elements(target, dev):
+    """test_scatter_elements"""
+
+    def verify_scatter_elements(in_shape, indices, axis=0, reduction="update"):
+        x = np.random.uniform(size=in_shape).astype("float32")
+        indices = np.array(indices, dtype="int32")
+        updates = np.random.uniform(size=indices.shape).astype("float32")
+
+        scatter_elements_node = helper.make_node(
+            "ScatterElements",
+            ["data", "indices", "updates"],
+            ["output"],
+            axis=axis,
+            reduction=reduction,
+        )
+
+        graph = helper.make_graph(
+            [scatter_elements_node],
+            "scatter_elements_test",
+            inputs=[
+                helper.make_tensor_value_info("data", TensorProto.FLOAT, list(in_shape)),
+                helper.make_tensor_value_info("indices", TensorProto.INT32, list(indices.shape)),
+                helper.make_tensor_value_info("updates", TensorProto.FLOAT, list(indices.shape)),
+            ],
+            outputs=[helper.make_tensor_value_info("output", TensorProto.FLOAT, list(in_shape))],
+        )
+        model = helper.make_model(graph, producer_name="scatter_elements_test")
+        verify_with_ort_with_inputs(model, [x, indices, updates], target=target, dev=dev)
+
+    # Usual scatter for 1d input
+    verify_scatter_elements((4,), [2, 3])
+    # Usual scatter with specified positive axis
+    verify_scatter_elements((2, 2), [[1, 0], [0, 1]], 1)
+    # Usual scatter for 3d input with spicified negative indices and axis
+    verify_scatter_elements((3, 3, 3), [[[-1, -3]]], -1)
+    # Usual scatter for 4d input
+    verify_scatter_elements((4, 3, 5, 6), [[[[2, 1, 0, 0]]]])
+    # Scatter elements with addition reduction of duplicates
+    verify_scatter_elements(
+        (3, 3, 3),
+        [[[0, 2, 1], [1, 1, 1], [2, 1, 0]], [[0, 2, 1], [1, 1, 1], [2, 1, 0]]],
+        0,
+        "add",
+    )
+    # Scatter elements with reduction and specified axis
+    verify_scatter_elements((3, 3, 3), [[[2, 2, 2], [1, 1, 1], [0, 0, 0]]], 2, "add")
+    # Scatter elements with multiplication reduction of duplicates
+    verify_scatter_elements(
+        (3, 3, 3),
+        [[[0, 2, 1], [1, 1, 1], [2, 1, 0]], [[0, 2, 1], [1, 1, 1], [2, 1, 0]]],
+        0,
+        "mul",
+    )
+    # Scatter elements with min reduction of duplicates
+    verify_scatter_elements(
+        (3, 3, 3),
+        [[[0, 2, 1], [1, 1, 1], [2, 1, 0]], [[0, 2, 1], [1, 1, 1], [2, 1, 0]]],
+        0,
+        "min",
+    )
+    # Scatter elements with max reduction of duplicates
+    verify_scatter_elements(
+        (3, 3, 3),
+        [[[0, 2, 1], [1, 1, 1], [2, 1, 0]], [[0, 2, 1], [1, 1, 1], [2, 1, 0]]],
+        0,
+        "max",
+    )
 
 
 @tvm.testing.parametrize_targets

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -856,7 +856,7 @@ def test_scatter(target, dev):
             outputs=[helper.make_tensor_value_info("output", TensorProto.FLOAT, list(in_shape))],
         )
         model = helper.make_model(graph, producer_name="scatter_test")
-        verify_with_ort_with_inputs(model, [x, indices, updates], target=target, dev=dev)
+        verify_with_ort_with_inputs(model, [x, indices, updates], target=target, dev=dev, opset=16)
 
     verify_scatter((4,), [1], 0)
     verify_scatter((1, 4), [[0]], 0)

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -843,9 +843,7 @@ def test_scatter(target, dev):
         indices = np.array(indices, dtype="int32")
         updates = np.random.uniform(size=indices.shape).astype("float32")
 
-        y = helper.make_node(
-            "Scatter", ["data", "indices", "updates"], ["output"], axis=axis
-        )
+        y = helper.make_node("Scatter", ["data", "indices", "updates"], ["output"], axis=axis)
 
         graph = helper.make_graph(
             [y],

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -922,20 +922,21 @@ def test_scatter_elements(target, dev):
         0,
         "mul",
     )
-    # Scatter elements with min reduction of duplicates
-    verify_scatter_elements(
-        (3, 3, 3),
-        [[[0, 2, 1], [1, 1, 1], [2, 1, 0]], [[0, 2, 1], [1, 1, 1], [2, 1, 0]]],
-        0,
-        "min",
-    )
-    # Scatter elements with max reduction of duplicates
-    verify_scatter_elements(
-        (3, 3, 3),
-        [[[0, 2, 1], [1, 1, 1], [2, 1, 0]], [[0, 2, 1], [1, 1, 1], [2, 1, 0]]],
-        0,
-        "max",
-    )
+    # TODO(vvchernov): min and mul options are supported from 18 version, but CI supports 17 only
+    # # Scatter elements with min reduction of duplicates
+    # verify_scatter_elements(
+    #     (3, 3, 3),
+    #     [[[0, 2, 1], [1, 1, 1], [2, 1, 0]], [[0, 2, 1], [1, 1, 1], [2, 1, 0]]],
+    #     0,
+    #     "min",
+    # )
+    # # Scatter elements with max reduction of duplicates
+    # verify_scatter_elements(
+    #     (3, 3, 3),
+    #     [[[0, 2, 1], [1, 1, 1], [2, 1, 0]], [[0, 2, 1], [1, 1, 1], [2, 1, 0]]],
+    #     0,
+    #     "max",
+    # )
 
 
 @tvm.testing.parametrize_targets


### PR DESCRIPTION
Support ScatterElements on ONNX front-end as described in ONNX docs. Just now Scatter op implementation is used where `reduction` attribute is not supported at all. Also CI tests are supported for the op.

P.S. In other PRs after that I plan: 1. remove scatter_add and reconnect all its using to ScatterElements(reduction="add") 2. remove scatter implementation and use ScatterElements(reduction="update") instead of it. It will remove the restriction related to input tensor rank size (just now rank <= 4)