### PR TITLE
Fix numpy version constraint

### DIFF
--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -252,7 +252,7 @@ CONSTRAINTS = [
     ("image", None),
     ("matplotlib", None),
     # Workaround, see https://github.com/apache/tvm/issues/13647
-    ("numpy", "<=1.23.*"),
+    ("numpy", "<=1.23"),
     ("onnx", None),
     ("onnxoptimizer", None),
     ("onnxruntime", None),


### PR DESCRIPTION
Issue #13911 reported that newer versions of setuptools crash with the version constraint "<=1.23.*", this commit implements the suggested fix by using "<=1.23".

cc @mikeseven @driazati @leandron @Liam-Sturge 