### PR TITLE
[TIR] Allow TransformLayout index_map to contain RVs

### DIFF
--- a/include/tvm/tir/index_map.h
+++ b/include/tvm/tir/index_map.h
@@ -146,9 +146,11 @@ class IndexMapNode : public Object {
 
   /*!
    * \brief Convert to string representation in Python.
+   * \param f_name_map Optional function to specify the stringified name of the variables.
    * \return The stringified lambda expression in Python.
    */
-  String ToPythonString() const;
+  String ToPythonString(
+      const std::function<Optional<String>(const Var& var)>& f_name_map = nullptr) const;
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("initial_indices", &initial_indices);
@@ -203,6 +205,17 @@ class IndexMap : public ObjectRef {
    */
   IndexMap Inverse(Array<Range> initial_ranges) const;
 
+  /*! \brief Rename the variables in the index map and ensure the names are unique.
+   *
+   * Construct a new index map with the same transformation, but with name_hint of variables to be
+   * guaranteed unique. The optional f_name_map can be provided to rename the variables.
+   *
+   * \param f_name_map The optional name map to rename the variables.
+   * \return The renamed index map.
+   */
+  IndexMap RenameVariables(
+      const std::function<Optional<String>(const Var& var)>& f_name_map = nullptr) const;
+
   /*! \brief Generate the inverse mapping.
    *
    * Determine the inverse, where the output range may contain
@@ -216,6 +229,14 @@ class IndexMap : public ObjectRef {
 
   TVM_DEFINE_OBJECT_REF_METHODS(IndexMap, ObjectRef, IndexMapNode);
 };
+
+/*! \brief Substitute variables in an index map.
+ *
+ * \param index_map The index_map
+ * \param f_subst The substitution function
+ */
+IndexMap Substitute(const IndexMap& index_map,
+                    std::function<Optional<PrimExpr>(const Var& var)> f_subst);
 
 }  // namespace tir
 }  // namespace tvm

--- a/python/tvm/tir/schedule/trace.py
+++ b/python/tvm/tir/schedule/trace.py
@@ -20,9 +20,10 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 from tvm._ffi import register_object as _register_object
 from tvm.runtime import Object
 
-from ...ir import Array, Map
+from ...ir import Array, Map, save_json
 from ...runtime import String
 from ..expr import FloatImm, IntImm
+from ..function import IndexMap
 from . import _ffi_api
 from .instruction import ATTR_TYPE, INPUT_RV_TYPE, Instruction
 
@@ -45,6 +46,8 @@ def _json_from_tvm(obj):
         return str(obj)
     if isinstance(obj, (IntImm, FloatImm)):
         return obj.value
+    if isinstance(obj, IndexMap):
+        return save_json(obj)
     raise TypeError("Not supported type: " + str(type(obj)))
 
 

--- a/src/meta_schedule/database/database_utils.cc
+++ b/src/meta_schedule/database/database_utils.cc
@@ -78,7 +78,7 @@ void JSONDumps(ObjectRef json_obj, std::ostringstream& os) {
     }
     os << "}";
   } else if (json_obj->IsInstance<tir::IndexMapNode>()) {
-    // Do nothing for index maps to start
+    JSONDumps(String(SaveJSON(json_obj)), os);
   } else {
     LOG(FATAL) << "TypeError: Unsupported type in JSON object: " << json_obj->GetTypeKey();
   }

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -546,8 +546,8 @@ class ScheduleBuilder : public ExprVisitor {
             TuningRecord record = opt_record.value();
             for (const Instruction& inst : record->trace->insts) {
               if (inst->kind.same_as(kind_transform_layout)) {
-                ICHECK_EQ(inst->attrs.size(), 4);
-                auto index_map = Downcast<IndexMap>(inst->attrs[2]);
+                ICHECK_EQ(inst->inputs.size(), 2);
+                auto index_map = Downcast<IndexMap>(inst->inputs[1]);
 
                 if (!const_collector.constants.empty()) {
                   // In this case, RewriteLayout is acting on an AllocateConst node.

--- a/src/tir/ir/index_map.cc
+++ b/src/tir/ir/index_map.cc
@@ -24,6 +24,7 @@
 #include <tvm/arith/analyzer.h>
 #include <tvm/arith/int_set.h>
 #include <tvm/arith/iter_affine_map.h>
+#include <tvm/ir/name_supply.h>
 #include <tvm/tir/index_map.h>
 #include <tvm/tir/op.h>
 #include <tvm/tir/stmt_functor.h>
@@ -310,8 +311,59 @@ runtime::NDArray IndexMapNode::MapNDArray(runtime::NDArray arr_src) const {
   return arr_dst;
 }
 
+IndexMap IndexMap::RenameVariables(
+    const std::function<Optional<String>(const Var& var)>& f_name_map) const {
+  std::unordered_set<std::string> used_names;
+  Map<Var, PrimExpr> var_remap;
+  NameSupply name_supply{""};
+  const IndexMapNode* n = this->get();
+  if (f_name_map != nullptr) {
+    // Collect variables with pre-defined names provided by f_name_map.
+    std::unordered_set<const Object*> visited;
+    std::for_each(n->final_indices.begin(), n->final_indices.end(), [&](const PrimExpr& expr) {
+      PostOrderVisit(expr, [&](const ObjectRef& obj) {
+        if (!obj->IsInstance<VarNode>()) {
+          return;
+        }
+        if (visited.count(obj.get())) {
+          return;
+        }
+        visited.emplace(obj.get());
+        Var var = Downcast<Var>(obj);
+        if (Optional<String> opt_name = f_name_map(var); opt_name.defined()) {
+          String name = opt_name.value();
+          ICHECK(!name_supply->ContainsName(name, /*add_prefix=*/false));
+          name_supply->ReserveName(name, /*add_prefix=*/false);
+          var_remap.Set(var, Var(name, var->dtype));
+        }
+      });
+    });
+  }
+
+  for (const Var& initial_index : n->initial_indices) {
+    if (var_remap.count(initial_index)) {
+      // The name of the variable is pre-defined.
+      continue;
+    }
+    String unique_name = name_supply->FreshName(initial_index->name_hint, /*add_prefix=*/false);
+    if (unique_name != initial_index->name_hint) {
+      var_remap.Set(initial_index, Var(unique_name));
+    }
+  }
+
+  auto new_initial_indices = n->initial_indices.Map(
+      [&](const Var& var) { return Downcast<Var>(Substitute(var, var_remap)); });
+  auto new_final_indices =
+      n->final_indices.Map([&](const PrimExpr& expr) { return Substitute(expr, var_remap); });
+  Optional<IndexMap> new_inverse_index_map = NullOpt;
+  if (n->inverse_index_map.defined()) {
+    new_inverse_index_map = Downcast<IndexMap>(n->inverse_index_map).RenameVariables(f_name_map);
+  }
+  return IndexMap(new_initial_indices, new_final_indices, new_inverse_index_map);
+}
+
 /*!
- * \brief Auxilarry function to comvert an index map to lambda expression in Python.
+ * \brief Auxilarry function to convert an index map to lambda expression in Python.
  * \param initial_indices The initial indices in the index map.
  * \param final_indices The final indices in the index map.
  * \return The lambda expression string.
@@ -320,53 +372,53 @@ std::string IndexMap2PythonLambdaExpr(const Array<Var>& initial_indices,
                                       const Array<PrimExpr>& final_indices) {
   std::unordered_set<std::string> used_names;
   Map<Var, PrimExpr> var_remap;
-  for (const Var& initial_index : initial_indices) {
-    if (used_names.count(initial_index->name_hint)) {
-      std::string new_name = initial_index->name_hint + std::to_string(used_names.size());
-      used_names.insert(new_name);
-      var_remap.Set(initial_index, Var(new_name));
-    } else {
-      used_names.insert(initial_index->name_hint);
-    }
-  }
   std::ostringstream oss;
   oss << "lambda ";
   for (size_t i = 0; i < initial_indices.size(); ++i) {
     if (i != 0) {
       oss << ", ";
     }
-    auto it = var_remap.find(initial_indices[i]);
-    if (it != var_remap.end()) {
-      oss << (*it).second;
-    } else {
-      oss << initial_indices[i];
-    }
+    oss << initial_indices[i];
   }
   oss << ": (";
   for (size_t i = 0; i < final_indices.size(); ++i) {
     if (i != 0) {
       oss << " ";
     }
-    oss << Substitute(final_indices[i], var_remap);
+    oss << final_indices[i];
     oss << ",";
   }
   oss << ")";
   return oss.str();
 }
 
-String IndexMapNode::ToPythonString() const {
-  std::string lambda_expr = IndexMap2PythonLambdaExpr(initial_indices, final_indices);
-  if (!inverse_index_map.defined()) {
+String IndexMapNode::ToPythonString(
+    const std::function<Optional<String>(const Var& var)>& f_name_map) const {
+  auto index_map = GetRef<IndexMap>(this).RenameVariables(f_name_map);
+  std::string lambda_expr =
+      IndexMap2PythonLambdaExpr(index_map->initial_indices, index_map->final_indices);
+  if (!index_map->inverse_index_map.defined()) {
     return String(lambda_expr);
   }
   // Also convert the inverse index map.
-  IndexMap inverse = Downcast<IndexMap>(inverse_index_map.value());
+  IndexMap inverse = Downcast<IndexMap>(index_map->inverse_index_map.value());
   std::string inverse_lambda_expr =
       IndexMap2PythonLambdaExpr(inverse->initial_indices, inverse->final_indices);
   std::ostringstream oss;
   oss << "tvm.tir.IndexMap.from_func(" << lambda_expr
       << ", inverse_index_map=" << inverse_lambda_expr << ")";
   return String(oss.str());
+}
+
+IndexMap Substitute(const IndexMap& index_map,
+                    std::function<Optional<PrimExpr>(const Var& var)> f_subst) {
+  Array<PrimExpr> new_output =
+      index_map->final_indices.Map([&](const PrimExpr& expr) { return Substitute(expr, f_subst); });
+  Optional<IndexMap> new_inverse_map = NullOpt;
+  if (index_map->inverse_index_map.defined()) {
+    new_inverse_map = Substitute(Downcast<IndexMap>(index_map->inverse_index_map.value()), f_subst);
+  }
+  return IndexMap{index_map->initial_indices, new_output, new_inverse_map};
 }
 
 TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -805,11 +805,7 @@ void ConcreteScheduleNode::TransformLayout(const BlockRV& block_rv, int buffer_i
   auto f_subst = [&](const Var& var) -> Optional<PrimExpr> {
     return Downcast<Optional<PrimExpr>>(symbol_table_.Get(var));
   };
-
-  auto new_index_map =
-      IndexMap(index_map->initial_indices, index_map->final_indices.Map([&](const PrimExpr& expr) {
-        return Substitute(expr, f_subst);
-      }));
+  auto new_index_map = Substitute(index_map, f_subst);
   tir::TransformLayout(state_, this->GetSRef(block_rv), buffer_index, buffer_index_type,
                        new_index_map, pad_value);
   this->state_->DebugVerify();

--- a/src/tir/schedule/instruction.cc
+++ b/src/tir/schedule/instruction.cc
@@ -79,6 +79,8 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
           std::ostringstream os;
           os << new_expr;
           inputs.push_back(String(os.str()));
+        } else if (obj.as<IndexMapNode>()) {
+          inputs.push_back(obj);
         } else {
           LOG(FATAL) << "TypeError: Stringifying is not supported for type: " << obj->GetTypeKey();
           throw;

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -530,8 +530,8 @@ void TracedScheduleNode::TransformLayout(const BlockRV& block_rv, int buffer_ind
   trace_->Append(
       /*inst=*/Instruction(
           /*kind=*/kind,
-          /*inputs=*/{block_rv},
-          /*attrs=*/{Integer(buffer_index), Integer(buffer_index_type), index_map, pad_value},
+          /*inputs=*/{block_rv, index_map},
+          /*attrs=*/{Integer(buffer_index), Integer(buffer_index_type), pad_value},
           /*outputs=*/{}));
 }
 

--- a/tests/python/unittest/test_tir_schedule_transform_layout.py
+++ b/tests/python/unittest/test_tir_schedule_transform_layout.py
@@ -196,6 +196,15 @@ def test_two_elementwise_transform_intermediate_buffer(use_block_name):
     verify_trace_roundtrip(sch=sch, mod=two_elementwise)
 
 
+def test_transform_layout_with_sampling():
+    sch = tir.Schedule(two_elementwise, debug_mask="all")
+    block_b = sch.get_block("B")
+    loop = sch.get_loops(block_b)[-1]
+    j0, j1, j2 = sch.sample_perfect_tile(loop, 3, decision=[4, 8, 4])
+    sch.transform_layout(block_b, ("write", 0), lambda i, j: (i, j // (j1 * j2), j % (j1 * j2)))
+    verify_trace_roundtrip(sch=sch, mod=two_elementwise, text_format="json")
+
+
 def test_two_elementwise_transform_input_buffer(use_block_name):
     sch = tir.Schedule(two_elementwise, debug_mask="all")
 


### PR DESCRIPTION
This changes `index_map` argument of `TransformLayout` from attr to input. It allows the index map to capture the random variables in the environment. This will allow tuning with different `index_map` applied.

cc @Hzfengsy 