### PR TITLE
[ETHOSN] Support for addition with constant input

### DIFF
--- a/src/relay/backend/contrib/ethosn/codegen.cc
+++ b/src/relay/backend/contrib/ethosn/codegen.cc
@@ -192,9 +192,7 @@ void InferTensorsVisitor::VisitExpr_(const CallNode* cn) {
 
 void ConstructNetworkVisitor::VisitExpr_(const ConstantNode* cn) {
   Constant constant = GetRef<Constant>(cn);
-  std::cout << "Traversing constant..." << std::endl;
   if (tensor_table_.count(constant)) {
-    std::cout << "Found constant...." << std::endl;
     sl::TensorInfo tensor_info = tensor_table_[constant][0];
     sl::TensorAndId<sl::Constant> tensor_and_id =
         sl::AddConstant(network_, tensor_info, constant->data->data);

--- a/src/relay/backend/contrib/ethosn/codegen.cc
+++ b/src/relay/backend/contrib/ethosn/codegen.cc
@@ -190,6 +190,19 @@ void InferTensorsVisitor::VisitExpr_(const CallNode* cn) {
   }
 }
 
+void ConstructNetworkVisitor::VisitExpr_(const ConstantNode* cn) {
+  Constant constant = GetRef<Constant>(cn);
+  std::cout << "Traversing constant..." << std::endl;
+  if (tensor_table_.count(constant)) {
+    std::cout << "Found constant...." << std::endl;
+    sl::TensorInfo tensor_info = tensor_table_[constant][0];
+    sl::TensorAndId<sl::Constant> tensor_and_id =
+        sl::AddConstant(network_, tensor_info, constant->data->data);
+    auto operand = sl::GetOperand(tensor_and_id.tensor);
+    operand_table_[constant] = std::vector{operand};
+  }
+}
+
 void InferTensorsVisitor::VisitExpr_(const TupleNode* tn) {
   auto tuple = GetRef<Tuple>(tn);
   ICHECK(tensor_table_.find(tuple) != tensor_table_.end());

--- a/src/relay/backend/contrib/ethosn/codegen_ethosn.h
+++ b/src/relay/backend/contrib/ethosn/codegen_ethosn.h
@@ -192,6 +192,7 @@ class ConstructNetworkVisitor : public MixedModeVisitor, private ErrorReportingP
   sl::TensorsAndId HandleCall(const CallNode*);
 
   void VisitExpr_(const CallNode* cn) final;
+  void VisitExpr_(const ConstantNode* cn) final;
   void VisitExpr_(const TupleNode* op) final;
   void VisitExpr_(const TupleGetItemNode* tg) final;
   void VisitLeaf(const Expr& expr) final;

--- a/tests/python/contrib/test_ethosn/test_addition.py
+++ b/tests/python/contrib/test_ethosn/test_addition.py
@@ -183,7 +183,7 @@ def test_addition_both_inputs_constants(
     ],
 )
 def test_addition_with_one_constant(dtype, lhs_shape, lhs_is_constant, rhs_shape, rhs_is_constant):
-    """Compare addition to depthwise with TVM."""
+    """Validate addition with one input as a constant."""
     np.random.seed(0)
 
     iinfo = np.iinfo(dtype)

--- a/tests/python/contrib/test_ethosn/test_addition.py
+++ b/tests/python/contrib/test_ethosn/test_addition.py
@@ -178,6 +178,61 @@ def test_addition_both_inputs_constants(
 @pytest.mark.parametrize(
     "lhs_shape,lhs_is_constant,rhs_shape,rhs_is_constant",
     [
+        ((1, 4, 4, 8), False, (1, 4, 4, 8), True),
+        ((1, 16, 12, 4), True, (1, 16, 12, 4), False),
+    ],
+)
+def test_addition_with_one_constant(dtype, lhs_shape, lhs_is_constant, rhs_shape, rhs_is_constant):
+    """Compare addition to depthwise with TVM."""
+    np.random.seed(0)
+
+    iinfo = np.iinfo(dtype)
+    data_min = iinfo.min
+    data_max = iinfo.max
+    lhs_zp, lhs_sc, rhs_zp, rhs_sc, out_zp, out_sc = _get_addition_qnn_params(dtype)
+
+    model = _get_model(
+        lhs_shape,
+        rhs_shape,
+        lhs_zp,
+        lhs_sc,
+        rhs_zp,
+        rhs_sc,
+        out_zp,
+        out_sc,
+        dtype,
+        lhs_is_constant=lhs_is_constant,
+        rhs_is_constant=rhs_is_constant,
+    )
+    input_shape = rhs_shape if lhs_is_constant else lhs_shape
+    input_name = "b" if lhs_is_constant else "a"
+    inputs = {
+        input_name: tvm.nd.array(
+            np.random.randint(data_min, data_max + 1, size=input_shape, dtype=dtype)
+        )
+    }
+
+    outputs = []
+    for npu in [False, True]:
+        mod = tei.make_module(model, {})
+        outputs.append(
+            tei.build_and_run(
+                mod,
+                inputs,
+                1,
+                {},
+                npu=npu,
+                additional_config_args={"inline_non_compute_intensive_partitions": False},
+            )
+        )
+    tei.verify(outputs, dtype, 1)
+
+
+@requires_ethosn
+@pytest.mark.parametrize("dtype", ["uint8", "int8"])
+@pytest.mark.parametrize(
+    "lhs_shape,lhs_is_constant,rhs_shape,rhs_is_constant",
+    [
         ((1, 4, 4, 8), False, (1, 1, 1, 8), True),
         ((4,), True, (1, 16, 12, 4), False),
         ((1, 1, 1, 8), True, (1, 4, 4, 8), False),


### PR DESCRIPTION
After NPU driver 22.11 update, constants can be provided as inputs to addition operator.
This commit traverses constants to update operand entries for it and adds tests to verify these cases.

cc @lhutton1 