### PR TITLE
[TVMScript] Support `show_meta`

### DIFF
--- a/include/tvm/node/repr_printer.h
+++ b/include/tvm/node/repr_printer.h
@@ -63,6 +63,8 @@ class ReprLegacyPrinter {
   TVM_DLL void Print(const ObjectRef& node);
   /*! \brief Print indent to the stream */
   TVM_DLL void PrintIndent();
+  /*! \brief Could the LegacyPrinter dispatch the node */
+  TVM_DLL static bool CanDispatch(const ObjectRef& node);
   /*! \brief Return the ostream it maintains */
   TVM_DLL std::ostream& Stream() const;
   // Allow registration to be printer.

--- a/include/tvm/node/script_printer.h
+++ b/include/tvm/node/script_printer.h
@@ -35,6 +35,10 @@ namespace tvm {
 
 class PrinterConfigNode : public Object {
  public:
+  /*! \brief A stack that tracks the names of the binding hierarchy */
+  Array<String> binding_names = {};
+  /*! \brief Whether or not to show metadata. */
+  bool show_meta = false;
   /*! \brief The prefix of IR nodes */
   std::string ir_prefix = "I";
   /*! \brief The prefix of TIR nodes */
@@ -71,6 +75,8 @@ class PrinterConfigNode : public Object {
   Map<ObjectRef, String> obj_to_annotate = Map<ObjectRef, String>();
 
   void VisitAttrs(AttrVisitor* v) {
+    v->Visit("binding_names", &binding_names);
+    v->Visit("show_meta", &show_meta);
     v->Visit("ir_prefix", &ir_prefix);
     v->Visit("buffer_dtype", &buffer_dtype);
     v->Visit("int_dtype", &int_dtype);

--- a/include/tvm/script/printer/ir_docsifier.h
+++ b/include/tvm/script/printer/ir_docsifier.h
@@ -141,10 +141,10 @@ class IRDocsifierNode : public Object {
    * when converting IR node object to Doc.
    */
   Array<String> dispatch_tokens;
-  /*! \brief The IRModule to be docsifier is handling */
-  Optional<IRModule> mod;
   /*! \brief Mapping from a var to its info */
   std::unordered_map<ObjectRef, VariableInfo, ObjectPtrHash, ObjectPtrEqual> obj2info;
+  /*! \brief Metadata printing */
+  std::unordered_map<String, Array<ObjectRef>> metadata;
   /*! \brief The variable names used already */
   std::unordered_set<String> defined_names;
   /*! \brief Common prefixes of variable usages */
@@ -155,8 +155,8 @@ class IRDocsifierNode : public Object {
   void VisitAttrs(tvm::AttrVisitor* v) {
     v->Visit("frames", &frames);
     v->Visit("dispatch_tokens", &dispatch_tokens);
-    v->Visit("mod", &mod);
     // `obj2info` is not visited
+    // `metadata` is not visited
     // `defined_names` is not visited
     // `common_prefix` is not visited
     // `ir_usage` is not visited
@@ -204,7 +204,8 @@ class IRDocsifierNode : public Object {
    * \return The doc for variable, if it exists in the table. Otherwise it returns NullOpt.
    */
   Optional<ExprDoc> GetVarDoc(const ObjectRef& obj) const;
-
+  /*! \brief Add a TVM object to the metadata section*/
+  ExprDoc AddMetadata(const ObjectRef& obj);
   /*!
    * \brief Check if a variable exists in the table.
    * \param obj The variable object.

--- a/python/tvm/runtime/script_printer.py
+++ b/python/tvm/runtime/script_printer.py
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 """Configuration of TVMScript printer"""
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional, Sequence
 
-from tvm._ffi import register_object
+from tvm._ffi import get_global_func, register_object
 from tvm.runtime import Object
 
 from . import _ffi_node_api
@@ -28,6 +28,8 @@ from .object_path import ObjectPath
 class PrinterConfig(Object):
     """Configuration of TVMScript printer"""
 
+    binding_names: Sequence[str]
+    show_meta: bool
     ir_prefix: str
     tir_prefix: str
     relax_prefix: str
@@ -47,6 +49,8 @@ class PrinterConfig(Object):
     def __init__(
         self,
         *,
+        name: Optional[str] = None,
+        show_meta: bool = False,
         ir_prefix: str = "I",
         tir_prefix: str = "T",
         relax_prefix: str = "R",
@@ -65,30 +69,39 @@ class PrinterConfig(Object):
     ) -> None:
         if num_context_lines is None:
             num_context_lines = -1
+        cfg = {
+            "show_meta": show_meta,
+            "ir_prefix": ir_prefix,
+            "tir_prefix": tir_prefix,
+            "relax_prefix": relax_prefix,
+            "buffer_dtype": buffer_dtype,
+            "int_dtype": int_dtype,
+            "float_dtype": float_dtype,
+            "verbose_expr": verbose_expr,
+            "indent_spaces": indent_spaces,
+            "print_line_numbers": print_line_numbers,
+            "num_context_lines": num_context_lines,
+            "syntax_sugar": syntax_sugar,
+            "path_to_underline": path_to_underline,
+            "path_to_annotate": path_to_annotate,
+            "obj_to_underline": obj_to_underline,
+            "obj_to_annotate": obj_to_annotate,
+        }
+
+        if name is not None:
+            cfg["name"] = name
         self.__init_handle_by_constructor__(
-            _ffi_node_api.PrinterConfig,  # type: ignore # pylint: disable=no-member
-            {
-                "ir_prefix": ir_prefix,
-                "tir_prefix": tir_prefix,
-                "relax_prefix": relax_prefix,
-                "buffer_dtype": buffer_dtype,
-                "int_dtype": int_dtype,
-                "float_dtype": float_dtype,
-                "verbose_expr": verbose_expr,
-                "indent_spaces": indent_spaces,
-                "print_line_numbers": print_line_numbers,
-                "num_context_lines": num_context_lines,
-                "syntax_sugar": syntax_sugar,
-                "path_to_underline": path_to_underline,
-                "path_to_annotate": path_to_annotate,
-                "obj_to_underline": obj_to_underline,
-                "obj_to_annotate": obj_to_annotate,
-            },
+            _ffi_node_api.PrinterConfig, cfg  # type: ignore # pylint: disable=no-member
         )
 
 
 def _script(obj: Object, config: PrinterConfig) -> str:
     return _ffi_node_api.TVMScriptPrinterScript(obj, config)  # type: ignore # pylint: disable=no-member
+
+
+def _relax_script(obj: Object, config: PrinterConfig) -> str:
+    func = get_global_func("script.printer.ReprPrintRelax")
+    return func(obj, config)
 
 
 class Scriptable:
@@ -97,6 +110,8 @@ class Scriptable:
     def script(
         self,
         *,
+        name: Optional[str] = None,
+        show_meta: bool = False,
         ir_prefix: str = "I",
         tir_prefix: str = "T",
         relax_prefix: str = "R",
@@ -117,6 +132,10 @@ class Scriptable:
 
         Parameters
         ----------
+        name : Optional[str] = None
+            The name of the object
+        show_meta : bool = False
+            Whether to print the meta data of the object
         ir_prefix : str = "I"
             The prefix of AST nodes from tvm.ir
         tir_prefix : str = "T"
@@ -156,6 +175,52 @@ class Scriptable:
         return _script(
             self,
             PrinterConfig(
+                name=name,
+                show_meta=show_meta,
+                ir_prefix=ir_prefix,
+                tir_prefix=tir_prefix,
+                relax_prefix=relax_prefix,
+                buffer_dtype=buffer_dtype,
+                int_dtype=int_dtype,
+                float_dtype=float_dtype,
+                verbose_expr=verbose_expr,
+                indent_spaces=indent_spaces,
+                print_line_numbers=print_line_numbers,
+                num_context_lines=num_context_lines,
+                syntax_sugar=syntax_sugar,
+                path_to_underline=path_to_underline,
+                path_to_annotate=path_to_annotate,
+                obj_to_underline=obj_to_underline,
+                obj_to_annotate=obj_to_annotate,
+            ),
+        )
+
+    def _relax_script(
+        self,
+        *,
+        name: Optional[str] = None,
+        show_meta: bool = False,
+        ir_prefix: str = "I",
+        tir_prefix: str = "T",
+        relax_prefix: str = "R",
+        buffer_dtype: str = "float32",
+        int_dtype: str = "int32",
+        float_dtype: str = "void",
+        verbose_expr: bool = False,
+        indent_spaces: int = 4,
+        print_line_numbers: bool = False,
+        num_context_lines: int = -1,
+        syntax_sugar: bool = True,
+        path_to_underline: Optional[List[ObjectPath]] = None,
+        path_to_annotate: Optional[Dict[ObjectPath, str]] = None,
+        obj_to_underline: Optional[List[Object]] = None,
+        obj_to_annotate: Optional[Dict[Object, str]] = None,
+    ) -> str:
+        return _relax_script(
+            self,
+            PrinterConfig(
+                name=name,
+                show_meta=show_meta,
                 ir_prefix=ir_prefix,
                 tir_prefix=tir_prefix,
                 relax_prefix=relax_prefix,
@@ -179,6 +244,8 @@ class Scriptable:
         style: Optional[str] = None,
         black_format: bool = True,
         *,
+        name: Optional[str] = None,
+        show_meta: bool = False,
         ir_prefix: str = "I",
         tir_prefix: str = "T",
         relax_prefix: str = "R",
@@ -204,6 +271,10 @@ class Scriptable:
             `tvm.script.highlight.cprint` for more details.
         black_format: bool
             If true (default), use the formatter Black to format the TVMScript
+        name : Optional[str] = None
+            The name of the object
+        show_meta : bool = False
+            Whether to print the meta data of the object
         ir_prefix : str = "I"
             The prefix of AST nodes from tvm.ir
         tir_prefix : str = "T"
@@ -241,6 +312,8 @@ class Scriptable:
 
         cprint(
             self.script(
+                name=name,
+                show_meta=show_meta,
                 ir_prefix=ir_prefix,
                 tir_prefix=tir_prefix,
                 relax_prefix=relax_prefix,

--- a/python/tvm/script/ir_builder/tir/ir.py
+++ b/python/tvm/script/ir_builder/tir/ir.py
@@ -34,7 +34,7 @@ from tvm.target import Target
 
 # pylint: disable=unused-import
 from tvm.target.codegen import llvm_lookup_intrinsic_id
-from tvm.tir import Buffer, BufferRegion, PrimExpr
+from tvm.tir import Buffer, BufferRegion, IndexMap, PrimExpr
 from tvm.tir import op as _tir_op
 from tvm.tir import type_annotation
 
@@ -1522,6 +1522,15 @@ def comm_reducer(combiner: Callable, identity: List[PrimExpr]) -> CommReducer:
     return CommReducer(args[: num_args // 2], args[num_args // 2 :], res, identity)
 
 
+def index_map(
+    mapping: Callable,
+    *,
+    inverse_index_map: Optional[Callable] = None,
+) -> IndexMap:
+    """Create a TIR Index mapping"""
+    return IndexMap.from_func(mapping, inverse_index_map=inverse_index_map)
+
+
 def target(target_config: Union[Dict, str]) -> Target:
     """
     Create a target
@@ -1824,6 +1833,7 @@ __all__ = [
     "max",
     "iter_var",
     "comm_reducer",
+    "index_map",
     "target",
     "buffer_var",
     "abs",

--- a/src/node/repr_printer.cc
+++ b/src/node/repr_printer.cc
@@ -58,8 +58,18 @@ void ReprLegacyPrinter::Print(const ObjectRef& node) {
   } else if (f.can_dispatch(node)) {
     f(node, this);
   } else {
-    stream << node;  // Use ReprPrinter
+    try {
+      stream << node;  // Use ReprPrinter
+    } catch (const tvm::Error& e) {
+      LOG(WARNING) << "ReprPrinter fails";
+      stream << node->GetTypeKey() << '(' << node.get() << ')';
+    }
   }
+}
+
+bool ReprLegacyPrinter::CanDispatch(const ObjectRef& node) {
+  static const FType& f = vtable();
+  return !node.defined() || f.can_dispatch(node);
 }
 
 void ReprLegacyPrinter::PrintIndent() {

--- a/src/node/script_printer.cc
+++ b/src/node/script_printer.cc
@@ -37,6 +37,12 @@ std::string TVMScriptPrinter::Script(const ObjectRef& node, const Optional<Print
 
 PrinterConfig::PrinterConfig(Map<String, ObjectRef> config_dict) {
   runtime::ObjectPtr<PrinterConfigNode> n = make_object<PrinterConfigNode>();
+  if (auto v = config_dict.Get("name")) {
+    n->binding_names.push_back(Downcast<String>(v));
+  }
+  if (auto v = config_dict.Get("show_meta")) {
+    n->show_meta = Downcast<IntImm>(v)->value;
+  }
   if (auto v = config_dict.Get("ir_prefix")) {
     n->ir_prefix = Downcast<String>(v);
   }

--- a/src/relay/ir/function.cc
+++ b/src/relay/ir/function.cc
@@ -262,6 +262,14 @@ TVM_REGISTER_GLOBAL("relay.ir.FuncWithAttr")
       return NullOpt;
     });
 
+TVM_REGISTER_GLOBAL("relay.ir.FuncWithoutAttr")
+    .set_body_typed([](BaseFunc func, String key) -> Optional<Function> {
+      if (func->IsInstance<relay::FunctionNode>()) {
+        return WithoutAttr(Downcast<relay::Function>(std::move(func)), key);
+      }
+      return NullOpt;
+    });
+
 TVM_REGISTER_NODE_TYPE(FunctionNode);
 
 TVM_REGISTER_GLOBAL("relay.ir.Function")

--- a/src/script/printer/ir/utils.h
+++ b/src/script/printer/ir/utils.h
@@ -34,12 +34,6 @@ namespace tvm {
 namespace script {
 namespace printer {
 
-/*! \brief Creates the IR common prefix, which is by default `I` */
-inline ExprDoc IR(const IRDocsifier& d, const String& attr) {
-  d->ir_usage.insert("ir");
-  return IdDoc(d->cfg->ir_prefix)->Attr(attr);
-}
-
 class IRFrameNode : public FrameNode {
  public:
   void VisitAttrs(AttrVisitor* v) { FrameNode::VisitAttrs(v); }
@@ -65,9 +59,7 @@ inline std::string ReprPrintIR(const ObjectRef& obj, const PrinterConfig& cfg) {
   IRDocsifier d(cfg);
   With<IRFrame> f(d);
   (*f)->AddDispatchToken(d, "ir");
-  std::ostringstream oss;
-  oss << Docsify(obj, d, *f, cfg);
-  return oss.str();
+  return Docsify(obj, d, *f, cfg);
 }
 
 }  // namespace printer

--- a/src/script/printer/ir_docsifier.cc
+++ b/src/script/printer/ir_docsifier.cc
@@ -21,26 +21,16 @@
 #include <tvm/runtime/registry.h>
 #include <tvm/script/printer/ir_docsifier.h>
 
+#include "./utils.h"
+
 namespace tvm {
 namespace script {
 namespace printer {
 
-String GenerateUniqueName(std::string name_hint, std::unordered_set<String>* defined_names) {
-  for (char& c : name_hint) {
-    if (c != '_' && !std::isalnum(c)) {
-      c = '_';
-    }
-  }
-  std::string name = name_hint;
-  for (int i = 1; !defined_names->insert(name).second; ++i) {
-    name = name_hint + "_" + std::to_string(i);
-  }
-  return name;
-}
-
 IdDoc IRDocsifierNode::Define(const ObjectRef& obj, const Frame& frame, const String& name_hint) {
   ICHECK(obj2info.find(obj) == obj2info.end()) << "Duplicated object: " << obj;
-  String name = GenerateUniqueName(name_hint, &this->defined_names);
+  String name = GenerateUniqueName(name_hint, this->defined_names);
+  this->defined_names.insert(name);
   DocCreator doc_factory = [name]() { return IdDoc(name); };
   obj2info.insert({obj, VariableInfo{std::move(doc_factory), name}});
   IdDoc def_doc(name);
@@ -60,6 +50,17 @@ Optional<ExprDoc> IRDocsifierNode::GetVarDoc(const ObjectRef& obj) const {
     return NullOpt;
   }
   return it->second.creator();
+}
+
+ExprDoc IRDocsifierNode::AddMetadata(const ObjectRef& obj) {
+  ICHECK(obj.defined()) << "TypeError: Cannot add nullptr to metadata";
+  String key = obj->GetTypeKey();
+  Array<ObjectRef>& array = metadata[key];
+  int index = array.size();
+  array.push_back(obj);
+  return IdDoc("metadata")               //
+      [{LiteralDoc::Str(key, NullOpt)}]  //
+      [{LiteralDoc::Int(index, NullOpt)}];
 }
 
 bool IRDocsifierNode::IsVarDefined(const ObjectRef& obj) const { return obj2info.count(obj); }

--- a/src/script/printer/utils.h
+++ b/src/script/printer/utils.h
@@ -19,10 +19,11 @@
 #ifndef TVM_SCRIPT_PRINTER_UTILS_H_
 #define TVM_SCRIPT_PRINTER_UTILS_H_
 
+#include <tvm/node/serialization.h>
 #include <tvm/script/printer/ir_docsifier.h>
 
 #include <string>
-#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -39,9 +40,19 @@ inline void RedirectedReprPrinterMethod(const ObjectRef& obj, ReprPrinter* p) {
   try {
     p->stream << TVMScriptPrinter::Script(obj, NullOpt);
   } catch (const tvm::Error& e) {
-    LOG(WARNING) << "TVMScript printer falls back to the legacy ReprPrinter with the error:\n"
-                 << e.what();
-    p->stream << AsLegacyRepr(obj);
+    if (ReprLegacyPrinter::CanDispatch(obj)) {
+      LOG(WARNING) << "TVMScript printer falls back to the legacy ReprPrinter with the error:\n"
+                   << e.what();
+      try {
+        p->stream << AsLegacyRepr(obj);
+      } catch (const tvm::Error& e) {
+        LOG(WARNING) << "AsLegacyRepr fails. Falling back to the basic address printer";
+      }
+    } else {
+      LOG(WARNING) << "TVMScript printer falls back to the basic address printer with the error:\n"
+                   << e.what();
+    }
+    p->stream << obj->GetTypeKey() << '(' << obj.get() << ')';
   }
 }
 
@@ -62,7 +73,37 @@ inline std::string Docsify(const ObjectRef& obj, const IRDocsifier& d, const Fra
   } else {
     LOG(FATAL) << "TypeError: Unexpected doc type: " << doc->GetTypeKey();
   }
-  return DocToPythonScript(StmtBlockDoc(f->stmts), cfg);
+  std::ostringstream os;
+  if (!d->metadata.empty()) {
+    if (d->cfg->show_meta) {
+      os << "metadata = tvm.ir.load_json("
+         << SaveJSON(Map<String, ObjectRef>(d->metadata.begin(), d->metadata.end())) << ")"
+         << "\n";
+    } else {
+      f->stmts.push_back(
+          CommentDoc("Metadata omitted. Use show_meta=True in script() method to show it."));
+    }
+  }
+  os << DocToPythonScript(StmtBlockDoc(f->stmts), cfg);
+  return os.str();
+}
+
+/*! \brief Creates the IR common prefix, which is by default `I` */
+inline ExprDoc IR(const IRDocsifier& d, const String& attr) {
+  d->ir_usage.insert("ir");
+  return IdDoc(d->cfg->ir_prefix)->Attr(attr);
+}
+
+/*! \brief Creates the TIR common prefix, which is by default `T` */
+inline ExprDoc TIR(const IRDocsifier& d, const String& attr) {
+  d->ir_usage.insert("tir");
+  return IdDoc(d->cfg->tir_prefix)->Attr(attr);
+}
+
+/*! \brief Creates the TIR common prefix, which is by default `T` */
+inline ExprDoc Relax(const IRDocsifier& d, const String& attr) {
+  d->ir_usage.insert("relax");
+  return IdDoc(d->cfg->relax_prefix)->Attr(attr);
 }
 
 inline std::string DType2Str(const runtime::DataType& dtype) {
@@ -87,6 +128,34 @@ inline Doc HeaderWrapper(const IRDocsifier& d, const Doc& doc) {
     return StmtBlockDoc(stmts);
   }
   return doc;
+}
+
+inline Optional<String> GetBindingName(const IRDocsifier& d) {
+  return d->cfg->binding_names.empty() ? Optional<String>(NullOpt) : d->cfg->binding_names.back();
+}
+
+inline Optional<String> FindFunctionName(const IRDocsifier& d, const BaseFunc& f) {
+  if (Optional<String> name = GetBindingName(d)) {
+    return name.value();
+  }
+  if (Optional<String> sym = f->GetAttr<String>(tvm::attr::kGlobalSymbol)) {
+    return sym.value();
+  }
+  return NullOpt;
+}
+
+inline String GenerateUniqueName(std::string name_hint,
+                                 const std::unordered_set<String>& defined_names) {
+  for (char& c : name_hint) {
+    if (c != '_' && !std::isalnum(c)) {
+      c = '_';
+    }
+  }
+  std::string name = name_hint;
+  for (int i = 1; defined_names.count(name) > 0; ++i) {
+    name = name_hint + "_" + std::to_string(i);
+  }
+  return name;
 }
 
 }  // namespace printer

--- a/src/tir/ir/index_map.cc
+++ b/src/tir/ir/index_map.cc
@@ -369,12 +369,6 @@ String IndexMapNode::ToPythonString() const {
   return String(oss.str());
 }
 
-TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
-    .set_dispatch<IndexMapNode>([](const ObjectRef& node, ReprPrinter* p) {
-      auto* op = static_cast<const IndexMapNode*>(node.get());
-      p->stream << "index_map(" << op->ToPythonString() << ")";
-    });
-
 TVM_REGISTER_NODE_TYPE(IndexMapNode);
 
 TVM_REGISTER_GLOBAL("tir.IndexMap")


### PR DESCRIPTION
This PR adds the functionality to roundtrip metadata during printing. Users may turn on the flag below to allow the printer to dump metadata to screen.

```python
ir_node.show(show_meta=True, ...)
```