### PR TITLE
[CI] Fix for NNPack error due to misalignment with pthreadpool library

### DIFF
--- a/docker/install/ubuntu_install_nnpack.sh
+++ b/docker/install/ubuntu_install_nnpack.sh
@@ -27,9 +27,11 @@ git clone https://github.com/Maratyszcza/pthreadpool  NNPACK/pthreadpool
 
 # Use specific versioning tag.
 (cd NNPACK && git checkout 70a77f485)
-(cd NNPACK/pthreadpool && git checkout 13da0b4c)
+(cd NNPACK/pthreadpool && git checkout 43edadc)
 
 mkdir -p NNPACK/build
 cd NNPACK/build
-cmake -DCMAKE_INSTALL_PREFIX:PATH=. -DNNPACK_INFERENCE_ONLY=OFF -DNNPACK_CONVOLUTION_ONLY=OFF -DNNPACK_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DPTHREADPOOL_SOURCE_DIR=pthreadpool .. && make -j2 && make install
+cmake -DCMAKE_INSTALL_PREFIX:PATH=. -DNNPACK_INFERENCE_ONLY=OFF -DNNPACK_CONVOLUTION_ONLY=OFF -DNNPACK_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DPTHREADPOOL_SOURCE_DIR=pthreadpool ..
+make -j2
+make install
 cd -


### PR DESCRIPTION
Recently NNPack SHA was modified to align with CPUInfo, which is a dependent package. Pthreadpool is another dependent library that needs SHA update to work in tandem with NNPack.

cc @Liam-Sturge @lhutton1 @neildhickey 