### PR TITLE
[CI] Enable USE_MICRO in minimal cross ISA build

### DIFF
--- a/ci/jenkins/generated/minimal_cross_isa_jenkinsfile.groovy
+++ b/ci/jenkins/generated/minimal_cross_isa_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2023-02-02T20:12:16.769381
+// Generated at 2023-02-07T23:01:16.071376
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -554,7 +554,7 @@ def build() {
         )
         cmake_build(ci_minimal, 'build', '-j2')
         sh(
-            script: "./${jenkins_scripts_root}/s3.py --action upload --bucket ${s3_bucket} --prefix ${s3_prefix}/cpu-minimal-cross-isa --items build/libtvm.so build/libtvm_runtime.so build/config.cmake build/libtvm_allvisible.so",
+            script: "./${jenkins_scripts_root}/s3.py --action upload --bucket ${s3_bucket} --prefix ${s3_prefix}/cpu-minimal-cross-isa --items build/libtvm.so build/libtvm_runtime.so build/config.cmake build/libtvm_allvisible.so build/standalone_crt build/build.ninja build/microtvm_template_projects",
             label: 'Upload artifacts to S3',
           )
           }

--- a/ci/jenkins/templates/minimal_cross_isa_jenkinsfile.groovy.j2
+++ b/ci/jenkins/templates/minimal_cross_isa_jenkinsfile.groovy.j2
@@ -29,7 +29,7 @@
     label: 'Create CPU minimal cmake config',
   )
   cmake_build(ci_minimal, 'build', '-j2')
-  {{ m.upload_artifacts(tag='cpu-minimal-cross-isa', filenames=tvm_lib + tvm_allvisible) }}
+  {{ m.upload_artifacts(tag='cpu-minimal-cross-isa', filenames=tvm_lib + tvm_allvisible + standalone_crt + microtvm_template_projects) }}
 {% endcall %}
 
 

--- a/tests/scripts/task_config_build_minimal_cross_isa.sh
+++ b/tests/scripts/task_config_build_minimal_cross_isa.sh
@@ -24,6 +24,7 @@ cd "$BUILD_DIR"
 cp ../cmake/config.cmake .
 
 echo set\(USE_SORT ON\) >> config.cmake
+echo set\(USE_MICRO ON\) >> config.cmake
 echo set\(USE_RELAY_DEBUG ON\) >> config.cmake
 echo set\(CMAKE_BUILD_TYPE=Debug\) >> config.cmake
 echo set\(CMAKE_CXX_FLAGS \"-Werror -Wp,-D_GLIBCXX_ASSERTIONS\"\) >> config.cmake


### PR DESCRIPTION
This PR enables USE_MICRO in cross compilation build. This is part of ongoing efforts on enabling microTVM in default TVM build.
cc @alanmacd @driazati @gigiblender 