### PR TITLE
[TensorRT] Fix BiasAdd with correct axis attribute

### DIFF
--- a/src/runtime/contrib/tensorrt/tensorrt_ops.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_ops.cc
@@ -961,11 +961,9 @@ class BiasAddOpConverter : public TensorRTOpConverter {
     int axis = std::stoi(params->node.GetAttr<std::vector<std::string>>("axis")[0]);
     if (axis == -1) {
       // Make sure there are 2 dimensions after channel dimension,
-      if (input_nbDims + 2 > required_rank)
-        required_rank = input_nbDims + 2;
+      if (input_nbDims + 2 > required_rank) required_rank = input_nbDims + 2;
       axis = input_nbDims - 1;
-    }
-    else if (TRT_HAS_IMPLICIT_BATCH(params))
+    } else if (TRT_HAS_IMPLICIT_BATCH(params))
       axis -= 1;
     ICHECK(input_dims.size() > 0 && input_dims.size() <= required_rank);
     const bool need_reshape_on_input = input_dims.size() != required_rank;
@@ -980,8 +978,9 @@ class BiasAddOpConverter : public TensorRTOpConverter {
 
     nvinfer1::Weights scale{weight_type, nullptr, 0};
     nvinfer1::Weights power{weight_type, nullptr, 0};
-    nvinfer1::IScaleLayer* scale_layer = params->network->addScaleNd(
-        *input_tensor, nvinfer1::ScaleMode::kCHANNEL, params->inputs.at(1).weight, scale, power, axis);
+    nvinfer1::IScaleLayer* scale_layer =
+        params->network->addScaleNd(*input_tensor, nvinfer1::ScaleMode::kCHANNEL,
+                                    params->inputs.at(1).weight, scale, power, axis);
     ICHECK(scale_layer != nullptr);
     auto output_tensor = scale_layer->getOutput(0);
     if (need_reshape_on_input) {

--- a/src/runtime/contrib/tensorrt/tensorrt_ops.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_ops.cc
@@ -956,7 +956,17 @@ class BiasAddOpConverter : public TensorRTOpConverter {
   void Convert(TensorRTOpConverterParams* params) const {
     auto input_tensor = params->inputs.at(0).tensor;
     auto input_dims = TrtDimsToVector(input_tensor->getDimensions());
-    const size_t required_rank = TRT_HAS_IMPLICIT_BATCH(params) ? 3 : 4;
+    size_t required_rank = TRT_HAS_IMPLICIT_BATCH(params) ? 3 : 4;
+    const size_t input_nbDims = input_tensor->getDimensions().nbDims;
+    int axis = std::stoi(params->node.GetAttr<std::vector<std::string>>("axis")[0]);
+    if (axis == -1) {
+      // Make sure there are 2 dimensions after channel dimension,
+      if (input_nbDims + 2 > required_rank)
+        required_rank = input_nbDims + 2;
+      axis = input_nbDims - 1;
+    }
+    else if (TRT_HAS_IMPLICIT_BATCH(params))
+      axis -= 1;
     ICHECK(input_dims.size() > 0 && input_dims.size() <= required_rank);
     const bool need_reshape_on_input = input_dims.size() != required_rank;
     if (need_reshape_on_input) {
@@ -968,10 +978,10 @@ class BiasAddOpConverter : public TensorRTOpConverter {
 
     const nvinfer1::DataType weight_type = params->inputs.at(1).weight.type;
 
-    nvinfer1::Weights shift{weight_type, nullptr, 0};
+    nvinfer1::Weights scale{weight_type, nullptr, 0};
     nvinfer1::Weights power{weight_type, nullptr, 0};
-    nvinfer1::IScaleLayer* scale_layer = params->network->addScale(
-        *input_tensor, nvinfer1::ScaleMode::kCHANNEL, params->inputs.at(1).weight, shift, power);
+    nvinfer1::IScaleLayer* scale_layer = params->network->addScaleNd(
+        *input_tensor, nvinfer1::ScaleMode::kCHANNEL, params->inputs.at(1).weight, scale, power, axis);
     ICHECK(scale_layer != nullptr);
     auto output_tensor = scale_layer->getOutput(0);
     if (need_reshape_on_input) {

--- a/src/runtime/contrib/tensorrt/tensorrt_ops.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_ops.cc
@@ -963,8 +963,9 @@ class BiasAddOpConverter : public TensorRTOpConverter {
       // Make sure there are 2 dimensions after channel dimension,
       if (input_nbDims + 2 > required_rank) required_rank = input_nbDims + 2;
       axis = input_nbDims - 1;
-    } else if (TRT_HAS_IMPLICIT_BATCH(params))
+    } else if (TRT_HAS_IMPLICIT_BATCH(params)) {
       axis -= 1;
+    }
     ICHECK(input_dims.size() > 0 && input_dims.size() <= required_rank);
     const bool need_reshape_on_input = input_dims.size() != required_rank;
     if (need_reshape_on_input) {

--- a/tests/python/contrib/test_tensorrt.py
+++ b/tests/python/contrib/test_tensorrt.py
@@ -416,15 +416,16 @@ def test_batch_matmul(run_module):
 
 
 def test_bias_add(run_module):
-    def get_graph(x_shape=(1, 16), channels=16):
+    def get_graph(x_shape=(1, 16), channels=16, axis=1):
         x = relay.var("x", shape=(x_shape), dtype="float32")
         bias = relay.var("bias", shape=(channels,), dtype="float32")
-        out = relay.nn.bias_add(x, bias)
+        out = relay.nn.bias_add(x, bias, axis)
         f = relay.Function([x, bias], out)
         return f, {"x": x_shape, "bias": (channels,)}, ["bias"]
 
     run_and_verify_func(get_graph(), run_module=run_module)
     run_and_verify_func(get_graph((1, 6, 3, 4), 6), run_module=run_module)
+    run_and_verify_func(get_graph((1, 6, 3, 4), 4, -1), run_module=run_module)
 
 
 def test_pool2d(run_module):


### PR DESCRIPTION
The original TensorRT BiasAdd converter does not use `axis` attribute from `nn.bias_add` so it only works with `NC, NCHW` and implicit mode (when batch dimension is removed). 
We recently found some NLP and Vision Transformer models are parsed with `axis=-1` which caused reshape error later during conversion.
```
[20:37:10] /home/ubuntu/apache_tvm/tvm/src/runtime/contrib/tensorrt/tensorrt_logger.h:51: Error: ERROR: 4: [graphShapeAnalyzer.cpp::analyzeShapes::1294] Error Code 4: Miscellaneous (IShuffleLayer (Unnamed Layer* 2) [Shuffle]: reshape changes volume. Reshaping [1,768,768,1] to [1,197,768].)
```
This CR adds support of `axis` attribute during conversion and related test case for `axis=-1`