### PR TITLE
[TIR] Fix crash on transform_layout

### DIFF
--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -2760,6 +2760,7 @@ class Schedule(Object):
 
         """
         block = self._normalize_block_arg(block)
+        block_name = self.get(block).name_hint
         buffer_index_type, buffer_index, buffer_obj = self._normalize_buffer_arg(block, buffer)
 
         ndim = len(buffer_obj.shape)
@@ -2789,6 +2790,7 @@ class Schedule(Object):
         _ffi_api.ScheduleTransformLayout(  # type: ignore # pylint: disable=no-member
             self, block, buffer_index, buffer_index_type_enum, index_map, pad_value
         )
+        block = self.get_block(block_name)
         if axis_separators:
             _ffi_api.ScheduleSetAxisSeparator(  # type: ignore # pylint: disable=no-member
                 self, block, buffer_index, buffer_index_type_enum, axis_separators

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -2760,7 +2760,8 @@ class Schedule(Object):
 
         """
         block = self._normalize_block_arg(block)
-        block_name = self.get(block).name_hint
+        block_obj: Block = self.get(block)
+        block_name = block_obj.name_hint
         buffer_index_type, buffer_index, buffer_obj = self._normalize_buffer_arg(block, buffer)
 
         ndim = len(buffer_obj.shape)


### PR DESCRIPTION
When `ScheduleTransformLayout` is called, the block corresponding to the BlockRV named `block` is potentially changed. The symbol_table_ however is not updated for changes to BlockRV and hence when the same blockRV `block` is passed to `ScheduleSetAxisSeparator`, the sref corresponding to that is invalid and that results in crash as unknown type_index_

This PR is a temporary fix and a permanent fix would probably need to identify that the BlockRV is not pointing to a valid sref and throw a proper error or update the symbol_table_ appropriately to avoid this error completely.