### PR TITLE
[TVMScript] Enable Safe Autocasting in BufferStore

### DIFF
--- a/src/script/ir_builder/tir/utils.h
+++ b/src/script/ir_builder/tir/utils.h
@@ -21,6 +21,7 @@
 
 #include <tvm/script/ir_builder/tir/frame.h>
 #include <tvm/script/ir_builder/tir/ir.h>
+#include <tvm/tir/op.h>
 #include <tvm/tir/stmt.h>
 
 namespace tvm {

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -507,6 +507,12 @@ BufferStore::BufferStore(Buffer buffer, PrimExpr value, Array<PrimExpr> indices,
       << "Cannot store value with " << value.dtype().lanes() << ", expected value with "
       << index_lanes * buffer_lanes << " (" << index_lanes << " index lanes * " << buffer_lanes
       << " buffer element lanes)";
+  if (buffer->dtype.with_lanes(buffer_lanes * index_lanes) != value.dtype()) {
+    LOG(FATAL) << "TypeError: dtype mismatch on BufferStore: "      //
+               << "buffer's dtype is `" << buffer->dtype            //
+               << "`, the lanes of indexing are: `" << index_lanes  //
+               << "`, but RHS's dtype is `" << value.dtype() << "`";
+  }
 
   ObjectPtr<BufferStoreNode> node = make_object<BufferStoreNode>();
   node->buffer = std::move(buffer);

--- a/tests/python/unittest/test_tir_constructor.py
+++ b/tests/python/unittest/test_tir_constructor.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import pytest
-
 import tvm
 from tvm import te
 
@@ -153,7 +152,7 @@ def test_stmt_constructor():
 
     buffer_var = tvm.tir.Var("buf", tvm.ir.PointerType(tvm.ir.PrimType("uint1")))
     buffer = tvm.tir.decl_buffer([16], "uint1", data=buffer_var)
-    x = tvm.tir.BufferStore(buffer, 1, [10])
+    x = tvm.tir.BufferStore(buffer, tvm.tir.IntImm("bool", 1), [10])
     assert isinstance(x, tvm.tir.BufferStore)
     assert x.buffer == buffer
     assert x.buffer.data == buffer_var


### PR DESCRIPTION
Previously, when writing a BufferStore statement in TVMScript, dtype
mismatch will not be detected but silently allowed.

For example, in the snippet below:

```python
buffer[indices] = RHS
```

even if the elements of `buffer` is floating point numbers, while RHS
is a handle, there is no mechanism to warn, fix, or error out.

This PR introduces auto casting mechanism in TVMScript to ensure that
the dtype of RHS matches LHS. When there is possible precision loss, it
will emit a warning so that the users could adjust accordingly.