### PR TITLE
[Fix][MetaSchedule] RPCRunner timeout when queueing up

### DIFF
--- a/python/tvm/meta_schedule/runner/rpc_runner.py
+++ b/python/tvm/meta_schedule/runner/rpc_runner.py
@@ -27,7 +27,6 @@ from tvm.runtime import Device, Module
 from ..logging import get_logger
 from ..profiler import Profiler
 from ..utils import (
-    cpu_count,
     derived_object,
     get_global_func_on_rpc_session,
     get_global_func_with_default_on_worker,
@@ -270,7 +269,7 @@ class RPCRunner(PyRunner):
         f_cleanup: Union[T_CLEANUP, str, None]
             The function name to cleanup the session or the function itself.
         max_workers: Optional[int] = None
-            The maximum number of connections. Defaults to number of logical CPU cores.
+            The maximum number of connections. Defaults to 1.
         initializer: Optional[Callable[[], None]]
             The initializer function.
         """
@@ -285,11 +284,10 @@ class RPCRunner(PyRunner):
         self.f_run_evaluator = f_run_evaluator
         self.f_cleanup = f_cleanup
         if max_workers is None:
-            max_workers = cpu_count(logical=True)
+            max_workers = 1
         logger.info("RPCRunner: max_workers = %d", max_workers)
         self.pool = PopenPoolExecutor(
             max_workers=max_workers,
-            timeout=rpc_config.session_timeout_sec,
             initializer=initializer,
         )
         self._sanity_check()


### PR DESCRIPTION
This PR fixes the timeout rule of MetaSchedule RPCRunner.

Prior to this PR, the RPCRunner sets a timeout threshold for jobs submitted to popen pool. As a result, the jobs are timed since the time that they are sent to the remote side.

Consider the case where there is only a single device for measurement. In this case, all jobs can only be executed serially and jobs must queue up. Therefore, the previous timeout configuration means the time spent on queueing will also be counted. This causes some jobs, in the worst cases, gets timeout without even started to execute, and has negative impacts on RPC MetaSchedule tuning, from the perspectives of both efficiency and result performance.

To address the problem, this PR
* removes the RPCRunner timeout requirement for PopenExecutor. Since now, the RPCRunner timeout will only be raised from the RPC server side.
* changes the default maximum number of RPCRunner workers to 1, which is to avoid the case where too many jobs waiting in line.

Co-authored-by: Bohan Hou <32121147+spectrometerHBH@users.noreply.github.com>