### PR TITLE
[Diagnostic] Support constructing Diagnostic Error through ObjectRef

### DIFF
--- a/include/tvm/ir/diagnostic.h
+++ b/include/tvm/ir/diagnostic.h
@@ -56,6 +56,14 @@ class DiagnosticNode : public Object {
   DiagnosticLevel level;
   /*! \brief The span at which to report an error. */
   Span span;
+  /*!
+   * \brief The object location at which to report an error.
+   *
+   * The object loc provides a location when span is not always
+   * available during transformation. The error reporter can
+   * still pick up loc->span if necessary.
+   */
+  ObjectRef loc;
   /*! \brief The diagnostic message. */
   String message;
 
@@ -84,6 +92,18 @@ class Diagnostic : public ObjectRef {
   static DiagnosticBuilder Warning(Span span);
   static DiagnosticBuilder Note(Span span);
   static DiagnosticBuilder Help(Span span);
+  // variants uses object location
+  static DiagnosticBuilder Bug(ObjectRef loc);
+  static DiagnosticBuilder Error(ObjectRef loc);
+  static DiagnosticBuilder Warning(ObjectRef loc);
+  static DiagnosticBuilder Note(ObjectRef loc);
+  static DiagnosticBuilder Help(ObjectRef loc);
+  // variants uses object ptr.
+  static DiagnosticBuilder Bug(const Object* loc);
+  static DiagnosticBuilder Error(const Object* loc);
+  static DiagnosticBuilder Warning(const Object* loc);
+  static DiagnosticBuilder Note(const Object* loc);
+  static DiagnosticBuilder Help(const Object* loc);
 
   TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(Diagnostic, ObjectRef, DiagnosticNode);
 };
@@ -102,6 +122,11 @@ class DiagnosticBuilder {
   /*! \brief The span of the diagnostic. */
   Span span;
 
+  /*!
+   * \brief The object location at which to report an error.
+   */
+  ObjectRef loc;
+
   template <typename T>
   DiagnosticBuilder& operator<<(const T& val) {  // NOLINT(*)
     stream_ << val;
@@ -114,6 +139,8 @@ class DiagnosticBuilder {
       : level(builder.level), source_name(builder.source_name), span(builder.span) {}
 
   DiagnosticBuilder(DiagnosticLevel level, Span span) : level(level), span(span) {}
+
+  DiagnosticBuilder(DiagnosticLevel level, ObjectRef loc) : level(level), loc(loc) {}
 
   operator Diagnostic() { return Diagnostic(this->level, this->span, this->stream_.str()); }
 

--- a/src/ir/diagnostic.cc
+++ b/src/ir/diagnostic.cc
@@ -66,6 +66,34 @@ DiagnosticBuilder Diagnostic::Help(Span span) {
   return DiagnosticBuilder(DiagnosticLevel::kHelp, span);
 }
 
+DiagnosticBuilder Diagnostic::Bug(ObjectRef loc) {
+  return DiagnosticBuilder(DiagnosticLevel::kBug, loc);
+}
+
+DiagnosticBuilder Diagnostic::Error(ObjectRef loc) {
+  return DiagnosticBuilder(DiagnosticLevel::kError, loc);
+}
+
+DiagnosticBuilder Diagnostic::Warning(ObjectRef loc) {
+  return DiagnosticBuilder(DiagnosticLevel::kWarning, loc);
+}
+
+DiagnosticBuilder Diagnostic::Note(ObjectRef loc) {
+  return DiagnosticBuilder(DiagnosticLevel::kNote, loc);
+}
+
+DiagnosticBuilder Diagnostic::Help(ObjectRef loc) {
+  return DiagnosticBuilder(DiagnosticLevel::kHelp, loc);
+}
+
+DiagnosticBuilder Diagnostic::Bug(const Object* loc) { return Bug(GetRef<ObjectRef>(loc)); }
+
+DiagnosticBuilder Diagnostic::Error(const Object* loc) { return Error(GetRef<ObjectRef>(loc)); }
+
+DiagnosticBuilder Diagnostic::Note(const Object* loc) { return Note(GetRef<ObjectRef>(loc)); }
+
+DiagnosticBuilder Diagnostic::Help(const Object* loc) { return Help(GetRef<ObjectRef>(loc)); }
+
 /* Diagnostic Renderer */
 TVM_REGISTER_NODE_TYPE(DiagnosticRendererNode);
 
@@ -284,7 +312,7 @@ DiagnosticRenderer TerminalRenderer(std::ostream& out) {
   });
 }
 
-TVM_REGISTER_GLOBAL(DEFAULT_RENDERER).set_body_typed([]() { return TerminalRenderer(std::cout); });
+TVM_REGISTER_GLOBAL(DEFAULT_RENDERER).set_body_typed([]() { return TerminalRenderer(std::cerr); });
 
 TVM_REGISTER_GLOBAL("diagnostics.GetRenderer").set_body_typed([]() { return GetRenderer(); });
 


### PR DESCRIPTION
This PR supports creating a diagnostic error from an arbitrary Object.

Given that we are bringing the diagnostic error for general uses in the long term, in which case
* not every Expr necessarily has a span,
* we have well-implemented elegant location-aware printer for an object itself,
* we may need to print some object other than Expr, or does even not have a span field,

we support diagnostic error with arbitrary object to denote the location.

Co-authored-by: Tianqi Chen <tianqi.tchen@gmail.com>