### PR TITLE
[microNPU] Sum legalization support

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/legalize.py
+++ b/python/tvm/relay/backend/contrib/ethosu/legalize.py
@@ -1121,6 +1121,74 @@ class MeanRewriter(DFPatternCallback):
         return reduced_op
 
 
+class SumRewriter(DFPatternCallback):
+    """
+    Convert ethosu.sum composite functions to pooling operations
+    """
+
+    def __init__(self):
+        super().__init__(require_type=True)
+        self.pattern = (
+            wildcard().has_attr({"Composite": ethosu_patterns.SumParams.composite_name})
+        )(wildcard())
+
+    def callback(
+        self, pre: tvm.relay.Expr, post: tvm.relay.Expr, node_map: tvm.ir.container.Map
+    ) -> tvm.relay.Expr:
+
+        params = ethosu_patterns.SumParams(post.op.body)
+
+        ifm_shape = params.ifm.shape
+        ofm_shape = params.ofm.shape
+        lut = relay.const([], "int8")
+        reduced_op = post.args[0]
+
+        # Enforce 4d input
+        if len(ifm_shape) == 3:
+            ifm_shape = [1, params.height, params.width, ifm_shape[2]]
+            reduced_op = relay.reshape(reduced_op, ifm_shape)
+
+        reduced_op = ethosu_ops.ethosu_pooling(
+            ifm=reduced_op,
+            lut=lut,
+            pooling_type="SUM",
+            ifm_scale=float(params.ifm.q_params.scale_f32),
+            ifm_zero_point=int(params.ifm.q_params.zero_point),
+            ofm_scale=float(params.ofm.q_params.scale_f32),
+            ofm_zero_point=0,
+            pool_shape=(1, 1),
+            ofm_channels=1,
+            ifm_layout=params.ifm.layout,
+            ofm_layout=params.ofm.layout,
+            rounding_mode="NATURAL",
+        )
+
+        scalar_tensor = relay.const(np.zeros([1, 1, 1, 1], dtype="int32"), dtype="int32")
+        # operation to convert tensor dtype from int32 to int8
+        reduced_op = ethosu_ops.ethosu_binary_elementwise(
+            ifm=reduced_op,
+            ifm2=scalar_tensor,
+            lut=lut,
+            operator_type="SHR",
+            ifm_scale=1,
+            ifm_zero_point=0,
+            ifm2_scale=1,
+            ifm2_zero_point=0,
+            ofm_scale=1,
+            ofm_zero_point=int(params.ofm.q_params.zero_point),
+            ifm_channels=1,
+            ifm2_channels=1,
+            reversed_operands=False,
+            ofm_dtype="int8",
+        )
+
+        # Reshape to original ofm shape
+        if len(ofm_shape) < 4:
+            reduced_op = relay.reshape(reduced_op, ofm_shape)
+
+        return reduced_op
+
+
 class ConcatRewriter(DFPatternCallback):
     """The newer versions of TFLite converters return a concatenate operator that concatenates
     tensors with same QNN params (if the QNN params of tensors were initially different,
@@ -1443,6 +1511,7 @@ class LegalizeEthosU:
             HardSwishRewriter(),
             LeakyReLURewriter(),
             MeanRewriter(),
+            SumRewriter(),
             ConcatRewriter(),
             SigmoidRewriter(),
             RequantizeRewriter(),

--- a/python/tvm/relay/backend/contrib/ethosu/tir_to_cs_translator.py
+++ b/python/tvm/relay/backend/contrib/ethosu/tir_to_cs_translator.py
@@ -822,7 +822,10 @@ def _create_npu_quantization(
     """This is a helper function to capture a list
     of arguments to create Vela NpuQuantization object.
     """
-    return vapi.NpuQuantization(scale_f32=float(scale), zero_point=int(zero_point))
+    scale = float(scale)
+    if scale == 0.0:
+        scale = None
+    return vapi.NpuQuantization(scale_f32=scale, zero_point=int(zero_point))
 
 
 def _create_npu_weights_zero_point(

--- a/python/tvm/relay/backend/contrib/ethosu/tir_to_cs_translator.py
+++ b/python/tvm/relay/backend/contrib/ethosu/tir_to_cs_translator.py
@@ -960,6 +960,8 @@ def _create_npu_op_pooling(serial_pooling: spec.SerialPooling):
         npu_pooling_op = vapi.NpuPoolingOp.AVERAGE
     elif pooling_type == "MAX":
         npu_pooling_op = vapi.NpuPoolingOp.MAX
+    elif pooling_type == "SUM":
+        npu_pooling_op = vapi.NpuPoolingOp.REDUCE_SUM
 
     npu_pooling_op = vapi.NpuPoolingOperation(npu_pooling_op)
     npu_pooling_op.ifm = _create_npu_feature_map(serial_pooling.ifm)

--- a/python/tvm/relay/op/contrib/ethosu.py
+++ b/python/tvm/relay/op/contrib/ethosu.py
@@ -1375,6 +1375,82 @@ def mean_pattern() -> tvm.relay.dataflow_pattern.DFPattern:
     return pattern
 
 
+class SumParams:
+    """
+    This class will parse a call to ethosu.sum composite function
+    and extract the parameter information.
+    """
+
+    composite_name = "ethos-u.sum"
+
+    def __init__(self, func_body: Call):
+        from tvm.relay.backend.contrib.ethosu.util import RequantArgs
+
+        requantize = func_body
+        sum_op = requantize.args[0]
+        attrs = sum_op.attrs
+        cast = sum_op.args[0]
+
+        layout = "NHWC"
+        self.ifm = TensorParams(
+            cast.args[0],
+            layout,
+            requantize.args[RequantArgs.IFM_SCALE.value],
+            requantize.args[RequantArgs.IFM_ZERO_POINT.value],
+        )
+        self.ofm = TensorParams(
+            requantize,
+            layout,
+            requantize.args[RequantArgs.OFM_SCALE.value],
+            requantize.args[RequantArgs.OFM_ZERO_POINT.value],
+        )
+
+        ifm_shape = self.ifm.shape
+        self.height = ifm_shape[0] if len(ifm_shape) in (2, 3) else ifm_shape[1]
+        self.width = ifm_shape[1] if len(ifm_shape) in (2, 3) else ifm_shape[2]
+        self.keepdims = attrs.keepdims
+
+        self.axis = list(sorted(attrs.axis))
+        if attrs.exclude:
+            self.axis = [i for i in range(len(self.ifm.shape)) if i not in self.axis]
+
+    def is_valid(self) -> bool:
+        """
+        Checks whether Sum has compatible attributes with HW.
+        """
+
+        ifm_shape_len = len(self.ifm.shape)
+
+        if not check_valid_dtypes([self.ifm], [np.uint8, np.int8, np.int16, np.int32]):
+            return False
+        if not check_valid_dtypes([self.ofm], [np.int8]):
+            return False
+        if not ifm_shape_len in (3, 4):
+            return False
+        if ifm_shape_len == 3 and self.axis not in [[2]]:
+            return False
+        if ifm_shape_len == 4 and self.axis not in [[3]]:
+            return False
+
+        return True
+
+
+def sum_pattern() -> tvm.relay.dataflow_pattern.DFPattern:
+    """
+    This function creates the pattern for sum.
+    """
+    pattern = is_op("cast")(wildcard())
+    pattern = is_op("sum")(pattern)
+    pattern = is_op("qnn.requantize")(
+        pattern,
+        is_constant(),
+        is_constant(),
+        is_constant(),
+        is_constant(),
+    )
+    return pattern
+
+
 class ConcatParams:
     """
     This class will parse a call to a ethos-u.concat composite function
@@ -1994,6 +2070,11 @@ def pattern_table() -> List[Tuple[str, tvm.relay.dataflow_pattern.DFPattern, Cal
             MeanParams.composite_name,
             mean_pattern(),
             lambda pat: MeanParams(pat).is_valid(),
+        ),
+        (
+            SumParams.composite_name,
+            sum_pattern(),
+            lambda pat: SumParams(pat).is_valid(),
         ),
         (
             LeakyReLUParams.composite_name,

--- a/src/relay/op/contrib/ethosu/op_attrs.h
+++ b/src/relay/op/contrib/ethosu/op_attrs.h
@@ -361,7 +361,9 @@ struct EthosuPoolingAttrs : public tvm::AttrsNode<EthosuPoolingAttrs> {
 
   TVM_DECLARE_ATTRS(EthosuPoolingAttrs, "relay.attrs.EthosuPoolingAttrs") {
     TVM_ATTR_FIELD(pooling_type)
-        .describe("The type of the pooling. 'AVG' - average pool, 'MAX' - max pool.");
+        .describe(
+            "The type of the pooling. 'AVG' - average pool, 'MAX' - max pool, "
+            "'SUM' - reduce sum pool.");
     TVM_ATTR_FIELD(ifm_scale).describe("The quantization scale for the Input Feature Map tensor.");
     TVM_ATTR_FIELD(ifm_zero_point)
         .describe("The quantization zero point for the Input Feature Map tensor.");

--- a/src/relay/op/contrib/ethosu/pooling.cc
+++ b/src/relay/op/contrib/ethosu/pooling.cc
@@ -55,10 +55,10 @@ bool EthosuPoolingRel(const Array<Type>& types, int num_inputs, const Attrs& att
     return false;
   }
 
-  std::initializer_list<DataType> max_avg_pooling_ifm_dtypes =
-    {DataType::UInt(8), DataType::Int(8), DataType::Int(16)};
-  std::initializer_list<DataType> sum_pooling_ifm_dtypes =
-    {DataType::UInt(8), DataType::Int(8), DataType::Int(16), DataType::Int(32)};
+  std::initializer_list<DataType> max_avg_pooling_ifm_dtypes = {DataType::UInt(8), DataType::Int(8),
+                                                                DataType::Int(16)};
+  std::initializer_list<DataType> sum_pooling_ifm_dtypes = {DataType::UInt(8), DataType::Int(8),
+                                                            DataType::Int(16), DataType::Int(32)};
 
   std::initializer_list<DataType>& allowed_ifm_dtypes = max_avg_pooling_ifm_dtypes;
   auto ofm_dtype = ifm->dtype;

--- a/src/relay/op/contrib/ethosu/pooling.cc
+++ b/src/relay/op/contrib/ethosu/pooling.cc
@@ -46,14 +46,27 @@ bool EthosuPoolingRel(const Array<Type>& types, int num_inputs, const Attrs& att
 
   const String operator_name = "ethosu_pooling";
 
-  if (param->pooling_type != "AVG" && param->pooling_type != "MAX") {
+  if (param->pooling_type != "AVG" && param->pooling_type != "MAX" &&
+      param->pooling_type != "SUM") {
     reporter->GetDiagCtx().EmitFatal(Diagnostic::Error(reporter->GetSpan())
                                      << "Invalid operator: expected " << operator_name
-                                     << " type 'AVG' or 'MAX' but was " << param->pooling_type);
+                                     << " type 'AVG', 'MAX', or 'SUM' but was "
+                                     << param->pooling_type);
     return false;
   }
 
-  CheckDataType(reporter, ifm->dtype, {DataType::UInt(8), DataType::Int(8)}, operator_name, "ifm",
+  auto max_avg_pooling_ifm_dtypes = {DataType::UInt(8), DataType::Int(8)};
+  auto sum_pooling_ifm_dtypes = {DataType::UInt(8), DataType::Int(8), DataType::Int(16),
+                                 DataType::Int(32)};
+
+  auto& allowed_ifm_dtypes = max_avg_pooling_ifm_dtypes;
+  auto ofm_dtype = ifm->dtype;
+  if (param->pooling_type == "SUM") {
+    allowed_ifm_dtypes = sum_pooling_ifm_dtypes;
+    ofm_dtype = DataType::Int(32);
+  }
+
+  CheckDataType(reporter, ifm->dtype, allowed_ifm_dtypes, operator_name, "ifm",
                 param->pooling_type);
 
   CheckUpscaleMethod(reporter, param->upscale, {"NONE", "ZEROS", "NEAREST"}, operator_name);
@@ -67,7 +80,8 @@ bool EthosuPoolingRel(const Array<Type>& types, int num_inputs, const Attrs& att
   auto ofm_shape = EthosuInferKernelOutput(
       ifm_shape, param->ifm_layout, param->ofm_layout, param->pool_shape, param->ofm_channels,
       Array<IndexExpr>({1, 1}), param->strides, param->padding);
-  reporter->Assign(types[result_index], TensorType(ofm_shape, ifm->dtype));
+
+  reporter->Assign(types[result_index], TensorType(ofm_shape, ofm_dtype));
   return true;
 }
 

--- a/src/relay/op/contrib/ethosu/pooling.cc
+++ b/src/relay/op/contrib/ethosu/pooling.cc
@@ -55,11 +55,12 @@ bool EthosuPoolingRel(const Array<Type>& types, int num_inputs, const Attrs& att
     return false;
   }
 
-  auto max_avg_pooling_ifm_dtypes = {DataType::UInt(8), DataType::Int(8)};
-  auto sum_pooling_ifm_dtypes = {DataType::UInt(8), DataType::Int(8), DataType::Int(16),
-                                 DataType::Int(32)};
+  std::initializer_list<DataType> max_avg_pooling_ifm_dtypes =
+    {DataType::UInt(8), DataType::Int(8), DataType::Int(16)};
+  std::initializer_list<DataType> sum_pooling_ifm_dtypes =
+    {DataType::UInt(8), DataType::Int(8), DataType::Int(16), DataType::Int(32)};
 
-  auto& allowed_ifm_dtypes = max_avg_pooling_ifm_dtypes;
+  std::initializer_list<DataType>& allowed_ifm_dtypes = max_avg_pooling_ifm_dtypes;
   auto ofm_dtype = ifm->dtype;
   if (param->pooling_type == "SUM") {
     allowed_ifm_dtypes = sum_pooling_ifm_dtypes;

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -495,21 +495,22 @@ def test_mean(accel_type, ifm_shape, axis, keep_dims, use_same_quantization):
     ACCEL_TYPES,
 )
 @pytest.mark.parametrize(
-    "ifm_shape, axis, keepdims",
+    "ifm_shape, axis, keepdims, relu",
     [
-        [(1, 4, 2, 8), 3, False],
-        [(1, 4, 4, 1), 3, False],
-        [(3, 5, 7), 2, False],
-        [(1, 4, 2, 8), 3, True],
-        [(3, 5, 7), 2, True],
+        [(1, 4, 2, 8), 3, False, False],
+        [(1, 4, 4, 1), 3, False, True],
+        [(3, 5, 7), 2, False, True],
+        [(1, 4, 2, 8), 3, True, False],
+        [(3, 5, 7), 2, True, False],
     ],
 )
-def test_ethosu_sum(accel_type, ifm_shape, axis, keepdims):
+def test_ethosu_sum(accel_type, ifm_shape, axis, keepdims, relu):
     np.random.seed(0)
 
     @tf.function
     def sum_func(x):
-        return tf.math.reduce_sum(x, axis=axis, keepdims=keepdims)
+        op = tf.math.reduce_sum(x, axis=axis, keepdims=keepdims)
+        return tf.nn.relu(op) if relu else op
 
     infra.compare_tvm_with_tflite(
         sum_func,

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -490,6 +490,35 @@ def test_mean(accel_type, ifm_shape, axis, keep_dims, use_same_quantization):
     infra.verify_source(compiled_models, test_runner)
 
 
+@pytest.mark.parametrize(
+    "accel_type",
+    ACCEL_TYPES,
+)
+@pytest.mark.parametrize(
+    "ifm_shape, axis, keepdims",
+    [
+        [(1, 4, 2, 8), 3, False],
+        [(1, 4, 4, 1), 3, False],
+        [(3, 5, 7), 2, False],
+        [(1, 4, 2, 8), 3, True],
+        [(3, 5, 7), 2, True],
+    ],
+)
+def test_ethosu_sum(accel_type, ifm_shape, axis, keepdims):
+    np.random.seed(0)
+
+    @tf.function
+    def sum_func(x):
+        return tf.math.reduce_sum(x, axis=axis, keepdims=keepdims)
+
+    infra.compare_tvm_with_tflite(
+        sum_func,
+        [ifm_shape],
+        accel_type,
+        enable_cascader=is_u55_accel_type(accel_type),
+    )
+
+
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)
 @pytest.mark.parametrize("dtype", ["int8", "uint8"])
 @pytest.mark.parametrize("constant", [np.ones((1, 1, 1, 1)), np.array(1)])

--- a/tests/python/contrib/test_ethosu/test_legalize.py
+++ b/tests/python/contrib/test_ethosu/test_legalize.py
@@ -1695,6 +1695,120 @@ def test_mean(ifm_shape, axis, keep_dims, use_same_quantization):
 
 
 @pytest.mark.parametrize(
+    "ifm_shape, axis, keepdims",
+    [
+        [(1, 4, 2, 8), 3, False],
+        [(1, 4, 4, 1), 3, False],
+        [(3, 5, 7), 2, False],
+        [(1, 4, 2, 8), 3, True],
+        [(3, 5, 7), 2, True],
+    ],
+)
+def test_ethosu_sum(ifm_shape, axis, keepdims):
+    dtype = "int8"
+
+    def create_tflite_graph():
+        class Model(tf.Module):
+            @tf.function
+            def tf_function(self, x):
+                return tf.math.reduce_sum(x, axis=axis, keepdims=keepdims)
+
+        model = Model()
+        concrete_func = model.tf_function.get_concrete_function(
+            tf.TensorSpec(ifm_shape, dtype=tf.float32)
+        )
+
+        # Convert the model
+        def representative_dataset():
+            for _ in range(100):
+                data = np.random.rand(*tuple(ifm_shape))
+                yield [data.astype(np.float32)]
+
+        converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
+        converter.optimizations = [tf.lite.Optimize.DEFAULT]
+        converter.representative_dataset = representative_dataset
+        converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+        converter.inference_input_type = tf.int8
+        converter.inference_output_type = tf.int8
+        tflite_model = converter.convert()
+        tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model, 0)
+
+        mod, _ = relay.frontend.from_tflite(
+            tflite_model,
+            shape_dict={"input": ifm_shape},
+            dtype_dict={"input": dtype},
+        )
+        return mod
+
+    def verify(ext_func):
+        out_var = ext_func.body
+
+        binary_elementwise_op = None
+        pooling_op = None
+        next_op = out_var
+        if (
+            isinstance(next_op, relay.expr.Call)
+            and isinstance(next_op.op, tvm.ir.op.Op)
+            and next_op.op.name == "reshape"
+        ):
+            next_op = next_op.args[0]
+        binary_elementwise_op = next_op
+        pooling_op = binary_elementwise_op.args[0]
+        next_op = pooling_op.args[0]
+        if (
+            isinstance(next_op, relay.expr.Call)
+            and isinstance(next_op.op, tvm.ir.op.Op)
+            and next_op.op.name == "reshape"
+        ):
+            next_op = next_op.args[0]
+        in_var = next_op
+
+        def calculate_expected_output_shape():
+            for i in range(len(ifm_shape)):
+                if i != axis:
+                    yield ifm_shape[i]
+                elif keepdims:
+                    yield 1
+
+        out_shape = tuple(calculate_expected_output_shape())
+
+        # check IFM
+        assert tuple(in_var.checked_type.shape) == ifm_shape
+        assert in_var.checked_type.dtype == dtype
+
+        # check OFM
+        assert tuple(out_var.checked_type.shape) == out_shape
+        assert out_var.checked_type.dtype == dtype
+
+        # check expected legalization case
+        assert pooling_op
+        attrs = pooling_op.attrs
+        assert attrs.pooling_type == "SUM"
+
+        assert binary_elementwise_op
+        attrs = binary_elementwise_op.attrs
+        assert attrs.operator_type == "SHR"
+        assert attrs.ifm_channels == attrs.ifm2_channels == 1
+        assert attrs.ofm_dtype == "int8"
+
+    rewriter = legalize.SumRewriter()
+    pattern_table = [
+        (
+            ethosu.SumParams.composite_name,
+            ethosu.sum_pattern(),
+            lambda pat: ethosu.SumParams(pat).is_valid(),
+        ),
+    ]
+
+    mod = create_tflite_graph()
+    mod = partition_ethosu_by_table(mod, pattern_table)
+    mod["tvmgen_default_ethos_u_main_0"] = dataflow_pattern.rewrite(
+        rewriter, mod["tvmgen_default_ethos_u_main_0"]
+    )
+    verify(mod["tvmgen_default_ethos_u_main_0"])
+
+
+@pytest.mark.parametrize(
     "shapes, axis",
     [
         ([(2, 3), (4, 3)], 0),

--- a/tests/python/contrib/test_ethosu/test_replace_pooling.py
+++ b/tests/python/contrib/test_ethosu/test_replace_pooling.py
@@ -38,6 +38,7 @@ def _create_serial_pooling(
     activation="NONE",
     rounding_mode="TFL",
     upscale="NONE",
+    ofm_dtype="int8",
 ):
     upscale_factor = 2 if upscale != "NONE" else 1
     if ifm_layout == "NHWC":
@@ -70,12 +71,14 @@ def _create_serial_pooling(
         ofm_stride_c = 16 * ofm_width if ofm_channels >= 16 else 1
         ofm_stride_h = 16 * ofm_width * ((ofm_channels - 1) // 16 + 1)
 
+    ifm_channels = ofm_channels if pooling_type != "SUM" else ifm_shape[-1]
+
     return spec.SerialPooling(
         ifm=spec.SerialFeatureMap(
             data_type="int8",
             height=ifm_shape[1],
             width=ifm_shape[2] if ifm_layout == "NHWC" else ifm_shape[3],
-            channels=ofm_channels,
+            channels=ifm_channels,
             tile_height_0=ifm_shape[1],
             tile_height_1=0,
             tile_width_0=ifm_shape[2] if ifm_layout == "NHWC" else ifm_shape[3],
@@ -91,7 +94,7 @@ def _create_serial_pooling(
             stride_c=ifm_stride_c,
         ),
         ofm=spec.SerialFeatureMap(
-            data_type="int8",
+            data_type=ofm_dtype,
             height=ofm_height,
             width=ofm_width,
             channels=ofm_channels,
@@ -145,7 +148,7 @@ def _create_serial_pooling(
 )
 @pytest.mark.parametrize("pooling_type", ["AVG", "MAX"])
 @pytest.mark.parametrize("activation", ["NONE", "CLIP"])
-def test_pooling_single(
+def test_avg_max_pooling_single(
     ifm_shape,
     ofm_channels,
     ifm_layout,
@@ -203,6 +206,61 @@ def test_pooling_single(
         activation,
         rounding_mode,
         upscale,
+    )
+    assert data[0] == ["ethosu_pooling"] + list(serial_pooling)
+
+
+@pytest.mark.parametrize(
+    "ifm_shape, ofm_layout, rounding_mode",
+    [
+        ((1, 5, 9, 3), "NHWC", "TFL"),
+        ((1, 8, 9, 40), "NHCWB16", "TFL"),
+        ((1, 8, 9, 8), "NHCWB16", "TRUNCATE"),
+        ((1, 5, 9, 3), "NHWC", "NATURAL"),
+    ],
+)
+@pytest.mark.parametrize("activation", ["NONE", "CLIP"])
+def test_sum_pooling_single(
+    ifm_shape,
+    ofm_layout,
+    activation,
+    rounding_mode,
+):
+    ifm = relay.var("ifm", shape=ifm_shape, dtype="int8")
+    pooling = make_ethosu_pooling(
+        ifm=ifm,
+        pooling_type="SUM",
+        pool_shape=(1, 1),
+        ofm_channels=1,
+        strides=(1, 1),
+        padding=(0, 0, 0, 0),
+        activation=activation,
+        ofm_layout=ofm_layout,
+        rounding_mode=rounding_mode,
+    )
+    func = relay.Function(relay.analysis.free_vars(pooling), pooling)
+    func = run_opt_pass(func, relay.transform.InferType())
+    mod, _ = _lower_to_tir(func)
+    data = []
+
+    def _visit(stmt):
+        if isinstance(stmt, tvm.tir.Call):
+            data.append(get_pooling_args(stmt))
+
+    tvm.tir.stmt_functor.post_order_visit(mod["main"].body, _visit)
+
+    serial_pooling = _create_serial_pooling(
+        ifm_shape=ifm_shape,
+        ofm_channels=1,
+        ifm_layout="NHWC",
+        ofm_layout=ofm_layout,
+        pool_shape=(1, 1),
+        pooling_type="SUM",
+        strides=(1, 1),
+        padding=(0, 0, 0, 0),
+        activation=activation,
+        rounding_mode=rounding_mode,
+        ofm_dtype="int32",
     )
     assert data[0] == ["ethosu_pooling"] + list(serial_pooling)
 


### PR DESCRIPTION
Supports legalizing a relay sum operation to an equivalent series of NPU operations. It supports case with int8 output type and channel axis.

cc @leandron, @ekalda, @lhutton1