### PR TITLE
[Keras] Fix importing conv2d_transpose for NHWC layout

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -370,6 +370,8 @@ def _convert_convolution(inexpr, keras_layer, etab, data_layout, input_shape=Non
     if data_layout == "NHWC":
         if is_depthconv:
             kernel_layout = "HWOI"
+        elif is_deconv:
+            kernel_layout = "HWOI"
         else:
             kernel_layout = "HWIO"
     else:

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -290,6 +290,17 @@ class TestKeras:
             keras_model = keras_mod.models.Model(data, x)
             verify_keras_frontend(keras_model)
 
+    def test_forward_conv2d_transpose_nhwc(self, keras_mod):
+        """test_forward_conv"""
+        data = keras_mod.layers.Input(shape=(32, 32, 128))
+        conv_funcs = [
+            keras_mod.layers.Conv2DTranspose(filters=64, kernel_size=(2, 2), padding="valid"),
+        ]
+        for conv_func in conv_funcs:
+            x = conv_func(data)
+            keras_model = keras_mod.models.Model(data, x)
+            verify_keras_frontend(keras_model, layout="NHWC")
+
     def test_forward_batch_norm(self, keras_mod):
         """test_forward_batch_norm"""
         data = keras_mod.layers.Input(shape=(32, 32, 3))

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -290,8 +290,8 @@ class TestKeras:
             keras_model = keras_mod.models.Model(data, x)
             verify_keras_frontend(keras_model)
 
-    def test_forward_conv2d_transpose_nhwc(self, keras_mod):
-        """test_forward_conv"""
+    def test_forward_conv_transpose(self, keras_mod):
+        """test_forward_conv_transpose"""
         data = keras_mod.layers.Input(shape=(32, 32, 128))
         conv_funcs = [
             keras_mod.layers.Conv2DTranspose(filters=64, kernel_size=(2, 2), padding="valid"),


### PR DESCRIPTION
The issue was in the shapes mismatch when `layout=NHWC` was passed to importer. In this case kernel layout in conv2d_transpose operation was set to HWIO but in params HWOI layout was used. And we got the following error:
```
`Tensor[(2, 2, 64, 128), float32]` does not match `Tensor[(2, 2, 128, 64), float32]`
```