### PR TITLE
[Build] Fix find_include_path when using TVM python package

### DIFF
--- a/python/tvm/_ffi/libinfo.py
+++ b/python/tvm/_ffi/libinfo.py
@@ -165,9 +165,11 @@ def find_include_path(name=None, search_path=None, optional=False):
     include_path : list(string)
         List of all found paths to header files.
     """
-    ffi_dir = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    source_dir = os.path.join(ffi_dir, "..", "..", "..")
-
+    if os.environ.get("TVM_HOME", None):
+        source_dir = os.environ["TVM_HOME"]
+    else:
+        ffi_dir = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+        source_dir = os.path.join(ffi_dir, "..", "..", "..")
     third_party_dir = os.path.join(source_dir, "3rdparty")
 
     header_path = []


### PR DESCRIPTION
When we are using TVM python package instead of building TVM from source, we are not able to find 3rdparty directory under python's site-package directory, so we cannot build module using 3rdparty in that situation. A fix is to let the user clone a TVM repo as TVM_HOME and find include path in that clone.

cc: @tqchen 
