### PR TITLE
[TVMC][TRANSFORMS] ToMixedPrecision transform support with custom options enabled

### DIFF
--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -39,7 +39,7 @@ from .main import register_parser
 from .model import TVMCModel
 from .target import target_from_cli, generate_target_args, reconstruct_target_args
 from .shape_parser import parse_shape_string
-from .transform import convert_graph_layout
+from .transform import generate_transform_args, parse_graph_transform_args, apply_graph_transforms
 
 
 # pylint: disable=invalid-name
@@ -127,12 +127,7 @@ def add_tune_parser(subparsers, _, json_params):
         metavar="PATH",
         help="path to an auto-tuning log file by AutoTVM.",
     )
-    parser.add_argument(
-        "--desired-layout",
-        choices=["NCHW", "NHWC"],
-        default=None,
-        help="change the data layout of the whole graph",
-    )
+    generate_transform_args(parser)
     parser.add_argument(
         "--enable-autoscheduler",
         help="enable tuning the graph through the AutoScheduler tuner",
@@ -269,6 +264,8 @@ def drive_tune(args):
         rpc_hostname = None
         rpc_port = None
 
+    transform_args = parse_graph_transform_args(args)
+
     tune_model(
         tvmc_model,
         args.target,
@@ -283,7 +280,7 @@ def drive_tune(args):
         tuner=args.tuner,
         min_repeat_ms=args.min_repeat_ms,
         early_stopping=args.early_stopping,
-        desired_layout=args.desired_layout,
+        transform_args=transform_args,
         timeout=args.timeout,
         repeat=args.repeat,
         number=args.number,
@@ -309,7 +306,7 @@ def tune_model(
     tuner: str = "xgb",
     min_repeat_ms: Optional[int] = None,
     early_stopping: Optional[int] = None,
-    desired_layout: Optional[str] = None,
+    transform_args: Optional[Dict[str, Any]] = None,
     timeout: int = 10,
     repeat: int = 1,
     number: int = 10,
@@ -354,10 +351,8 @@ def tune_model(
         Minimum time to run each trial. Defaults to 0 on x86 and 1000 on other targets.
     early_stopping : int, optional
         When specified, stop tuning after this number of trials if results aren't improving.
-    desired_layout : str, optional
-        Can be one of "NCHW" or "NHWC". When specified, compatible operations in the graph
-        will have their layout set to this format. Tasks will then be tuned using this
-        specified layout.
+    transform_args: dict, optional
+        Graph transformation arguments that are applied to the relay module.
     timeout : int, optional,
         If a kernel trial lasts longer than this duration in seconds, it will be
         considered a failure.
@@ -453,7 +448,7 @@ def tune_model(
                 mod=mod,
                 params=params,
                 target=target,
-                alter_layout=desired_layout,
+                transform_args=transform_args,
                 hardware_params=hardware_params,
                 include_simple_tasks=include_simple_tasks,
             )
@@ -475,7 +470,7 @@ def tune_model(
                 mod=mod,
                 params=params,
                 target=target,
-                alter_layout=desired_layout,
+                transform_args=transform_args,
             )
 
             # In autotvm, trials is specified per task. We can convert the per-model input
@@ -504,7 +499,7 @@ def autotvm_get_tuning_tasks(
     params: Dict[str, tvm.nd.NDArray],
     target: str,
     target_host: Optional[str] = None,
-    alter_layout: Optional[str] = None,
+    transform_args: Optional[Dict[str, Any]] = None,
 ):
     """Get the autotvm tuning tasks for a given relay module.
 
@@ -518,10 +513,8 @@ def autotvm_get_tuning_tasks(
         The compilation target.
     target_host : str, optional
         The compilation target for the host.
-    alter_layout : str, optional
-        The layout to convert the graph to. Note, the convert layout
-        pass doesn't currently guarantee the whole of the graph will
-        be converted to the chosen layout.
+    transform_args: dict, optional
+        Graph transformation arguments that are applied to the relay module.
 
     Returns
     -------
@@ -530,8 +523,7 @@ def autotvm_get_tuning_tasks(
     """
     target, target_host = Target.canon_target_and_host(target, target_host)
 
-    if alter_layout:
-        mod = convert_graph_layout(mod, alter_layout)
+    mod = apply_graph_transforms(mod, transform_args)
 
     tasks = autotvm.task.extract_from_program(
         mod["main"],
@@ -547,7 +539,7 @@ def autoscheduler_get_tuning_tasks(
     params: Dict[str, tvm.nd.NDArray],
     target: str,
     target_host: Optional[str] = None,
-    alter_layout: Optional[str] = None,
+    transform_args: Optional[Dict[str, Any]] = None,
     hardware_params: Optional[HardwareParams] = None,
     include_simple_tasks: bool = False,
 ):
@@ -563,10 +555,8 @@ def autoscheduler_get_tuning_tasks(
         The compilation target.
     target_host : str, optional
         The compilation target for the host.
-    alter_layout : str, optional
-        The layout to convert the graph to. Note, the convert layout
-        pass doesn't currently guarantee the whole of the graph will
-        be converted to the chosen layout.
+    transform_args: dict, optional
+        Graph transformation arguments that are applied to the relay module.
     hardware_params : Optional[HardwareParams]
         Hardware parameters used for the search tasks
 
@@ -579,8 +569,7 @@ def autoscheduler_get_tuning_tasks(
     """
     target, target_host = Target.canon_target_and_host(target, target_host)
 
-    if alter_layout:
-        mod = convert_graph_layout(mod, alter_layout)
+    mod = apply_graph_transforms(mod, transform_args)
 
     # Extract the tasks
     tasks, task_weights = auto_scheduler.extract_tasks(

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -286,13 +286,14 @@ def compile_model(
     desired_layout_ops: list[str], optional
         The list of operators to be transformed with desired layout.
     mixed_precision: bool
-        To enable mixed precision transformation.
+        To enable mixed precision transformation. Disabled by default.
     mixed_precision_ops: list[str], optional
         The list of operators to be converted to mixed precision.
+        Set to ["nn.conv2d", "nn.dense"] by default
     mixed_precision_calculation_type: str
-        The calculation dtype to be used while mixed precision.
+        The calculation dtype to be used while mixed precision. Set to "float16" by default.
     mixed_precision_acc_type: str
-        The accumulation data type to be used while mixed precision.
+        The accumulation data type to be used while mixed precision. Set to "float16" by default.
 
     Returns
     -------

--- a/python/tvm/driver/tvmc/transform.py
+++ b/python/tvm/driver/tvmc/transform.py
@@ -92,7 +92,7 @@ def convert_to_mixed_precision(mod, ops=None, calculation_type="float16", acc_ty
 
     with MixedPrecision(ops, acc_type):
         seq = transform.Sequential(
-            [relay.transform.InferType(), relay.transform.ToMixedPrecision()]
+            [relay.transform.InferType(), relay.transform.ToMixedPrecision(calculation_type)]
         )
         with transform.PassContext(
             config={"relay.ToMixedPrecision.keep_orig_output_dtype": True}, opt_level=3
@@ -160,7 +160,9 @@ def apply_graph_transforms(mod, args):
 
     # AlterLayout
     if args.get("desired_layout", False):
-        mod = convert_graph_layout(mod, args["desired_layout"])
+        mod = convert_graph_layout(
+            mod, args["desired_layout"], args.get("desired_layout_ops", None)
+        )
 
     # ToMixedPrecision
     if args.get("mixed_precision", False):

--- a/python/tvm/driver/tvmc/transform.py
+++ b/python/tvm/driver/tvmc/transform.py
@@ -13,6 +13,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language
+# pylint: disable=unused-argument
 """
 TVMC Graph Transforms
 """
@@ -20,8 +21,89 @@ TVMC Graph Transforms
 from tvm import relay, transform
 from tvm.driver.tvmc import TVMCException
 
+# ToMixedPrecision
+ACC_DTYPE = "float32"
 
-def convert_graph_layout(mod, desired_layout):
+
+def mixed_precision_rule(call_node: "relay.Call", mixed_precision_type: str):
+    global ACC_DTYPE
+    return [
+        relay.transform.mixed_precision.MIXED_PRECISION_ALWAYS,
+        ACC_DTYPE,
+        mixed_precision_type,
+    ]
+
+
+class MixedPrecision(object):
+    """Temporarily changes attr of ops to enable required precision."""
+
+    def __init__(self, ops):
+        """Saves the required info for RAII pattern usage.
+
+        Parameters
+        ----------
+        ops : list
+            list of operators
+        """
+        self.older_attr = {}
+        self.ops = ops
+        self.attr_key = "FTVMMixedPrecisionConversionType"
+
+    def __enter__(self):
+        for op_name in self.ops:
+            op = relay.op.get(op_name)
+            self.older_attr[op_name] = op.get_attr(self.attr_key)
+            op.reset_attr(self.attr_key)
+            op.set_attr(self.attr_key, mixed_precision_rule)
+        return self
+
+    def __exit__(self, ptype, value, trace):
+        for op_name in self.ops:
+            op = relay.op.get(op_name)
+            op.reset_attr(self.attr_key)
+            if self.older_attr[op_name]:
+                op.set_attr(self.attr_key, self.older_attr[op_name])
+
+
+def convert_to_mixed_precision(
+    mod, ops="nn.conv2d,nn.dense", input_type="float16", out_type="float16"
+):
+    """Converts the operator datatypes
+
+    Parameters
+    ----------
+    mod : tvm.IRModule
+        The relay module to convert.
+    ops : str
+        List of operators to be precision converted.
+    input_type: str
+        Input precision to be used.
+    output_type: str
+        Output or accumulation precision to be used.
+
+    Returns
+    -------
+    mod : tvm.IRModule
+        The converted module.
+    """
+
+    global ACC_DTYPE
+    ACC_DTYPE = out_type
+
+    with MixedPrecision(ops.split(",")):
+        seq = transform.Sequential(
+            [relay.transform.InferType(), relay.transform.ToMixedPrecision()]
+        )
+        with transform.PassContext(
+            config={"relay.ToMixedPrecision.keep_orig_output_dtype": True}, opt_level=3
+        ):
+            try:
+                return seq(mod)
+            except Exception as err:
+                raise TVMCException("Error converting mixed precision : {0}".format(str(err)))
+
+
+def convert_graph_layout(mod, desired_layout, ops="nn.conv2d,nn.conv2d_transpose,qnn.conv2d"):
     """Alter the layout of the input graph.
 
     Parameters
@@ -30,6 +112,8 @@ def convert_graph_layout(mod, desired_layout):
         The relay module to convert.
     desired_layout : str
         The layout to convert to.
+    ops : str
+        List of operators to be layout converted.
 
     Returns
     -------
@@ -37,13 +121,7 @@ def convert_graph_layout(mod, desired_layout):
         The converted module.
     """
 
-    # Assume for the time being that graphs only have
-    # conv2d as heavily-sensitive operators.
-    desired_layouts = {
-        "nn.conv2d": [desired_layout, "default"],
-        "nn.conv2d_transpose": [desired_layout, "default"],
-        "qnn.conv2d": [desired_layout, "default"],
-    }
+    desired_layouts = {op: [desired_layout, "default"] for op in ops.split(",")}
 
     # Convert the layout of the graph where possible.
     seq = transform.Sequential(
@@ -58,3 +136,105 @@ def convert_graph_layout(mod, desired_layout):
         return seq(mod)
     except Exception as err:
         raise TVMCException("Error converting layout to {0}: {1}".format(desired_layout, str(err)))
+
+
+def apply_graph_transforms(mod, args):
+    """Alter the layout of the input graph.
+
+    Parameters
+    ----------
+    mod : tvm.IRModule
+        The relay module to convert.
+    args : dict
+        The transform arguments.
+
+    Returns
+    -------
+    mod : tvm.IRModule
+        The converted module.
+    """
+    if not args:
+        return mod
+
+    # AlterLayout
+    if args.get("desired_layout", False):
+        mod = convert_graph_layout(mod, args["desired_layout"])
+
+    # ToMixedPrecision
+    if args.get("mixed_precision", False):
+        mod = convert_to_mixed_precision(
+            mod,
+            args.get("mixed_precision_ops", "nn.conv2d,nn.dense"),
+            args.get("mixed_precision_input", "float16"),
+            args.get("mixed_precision_output", "float16"),
+        )
+    return mod
+
+
+def parse_graph_transform_args(args):
+    """Parse incoming options for graph transform arguments.
+
+    Parameters
+    ----------
+    args: argparse.Namespace
+        Arguments from command line parser.
+
+    Returns
+    -------
+    transform_args : dict
+        Graph transform arguments
+    """
+
+    args_dict = vars(args)
+
+    transform_args = [
+        "desired_layout",
+        "desired_layout_ops",
+        "mixed_precision",
+        "mixed_precision_ops",
+        "mixed_precision_input",
+        "mixed_precision_output",
+    ]
+    transform_args = {key: args_dict.get(key, None) for key in transform_args}
+    return transform_args
+
+
+def generate_transform_args(parser):
+    """Add graph transform related args"""
+
+    # AlterLayout
+    parser.add_argument(
+        "--desired-layout",
+        choices=["NCHW", "NHWC"],
+        default=None,
+        help="Change the data layout of the whole graph.",
+    )
+    parser.add_argument(
+        "--desired-layout-ops",
+        default="nn.conv2d,nn.conv2d_transpose,qnn.conv2d",
+        help="List of operators to be layout converted.",
+    )
+
+    # ToMixedPrecision
+    parser.add_argument(
+        "--mixed-precision",
+        help="Enable mixed precision conversion",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--mixed-precision-ops",
+        default="nn.conv2d,nn.dense",
+        help="List of operators to be converted to mixed precision",
+    )
+    parser.add_argument(
+        "--mixed-precision-input",
+        choices=["float16", "float32"],
+        default="float16",
+        help="Input precision type",
+    )
+    parser.add_argument(
+        "--mixed-precision-output",
+        choices=["float16", "float32"],
+        default="float16",
+        help="Output or accumulator precision type",
+    )

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -72,7 +72,7 @@ def verify_compile_tflite_module(model, shape_dict=None, use_vm=False):
         tvmc_model,
         target="llvm",
         dump_code="ll",
-        transform_args={"desired_layout": "NCHW"},
+        desired_layout="NCHW",
         use_vm=use_vm,
     )
     dumps_path = tvmc_package.package_path + ".ll"
@@ -290,9 +290,7 @@ def test_cross_compile_options_aarch64_onnx_module(onnx_resnet50):
 def verify_compile_paddle_module(model, shape_dict=None):
     pytest.importorskip("paddle")
     tvmc_model = tvmc.load(model, "paddle", shape_dict=shape_dict)
-    tvmc_package = tvmc.compile(
-        tvmc_model, target="llvm", dump_code="ll", transform_args={"desired_layout": "NCHW"}
-    )
+    tvmc_package = tvmc.compile(tvmc_model, target="llvm", dump_code="ll", desired_layout="NCHW")
     dumps_path = tvmc_package.package_path + ".ll"
 
     # check for output types
@@ -374,7 +372,7 @@ def test_compile_opencl(tflite_mobilenet_v1_0_25_128):
     tvmc_package = tvmc.compile(
         tvmc_model,
         target="opencl -host=llvm",
-        transform_args={"desired_layout": "NCHW"},
+        desired_layout="NCHW",
         dump_code="asm",
     )
     dumps_path = tvmc_package.package_path + ".asm"

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -69,7 +69,11 @@ def verify_compile_tflite_module(model, shape_dict=None, use_vm=False):
     pytest.importorskip("tflite")
     tvmc_model = tvmc.load(model, shape_dict=shape_dict)
     tvmc_package = tvmc.compile(
-        tvmc_model, target="llvm", dump_code="ll", desired_layout="NCHW", use_vm=use_vm
+        tvmc_model,
+        target="llvm",
+        dump_code="ll",
+        transform_args={"desired_layout": "NCHW"},
+        use_vm=use_vm,
     )
     dumps_path = tvmc_package.package_path + ".ll"
     verify_tvmc_package(tvmc_package, dumps_path, use_vm=use_vm)
@@ -286,7 +290,9 @@ def test_cross_compile_options_aarch64_onnx_module(onnx_resnet50):
 def verify_compile_paddle_module(model, shape_dict=None):
     pytest.importorskip("paddle")
     tvmc_model = tvmc.load(model, "paddle", shape_dict=shape_dict)
-    tvmc_package = tvmc.compile(tvmc_model, target="llvm", dump_code="ll", desired_layout="NCHW")
+    tvmc_package = tvmc.compile(
+        tvmc_model, target="llvm", dump_code="ll", transform_args={"desired_layout": "NCHW"}
+    )
     dumps_path = tvmc_package.package_path + ".ll"
 
     # check for output types
@@ -368,7 +374,7 @@ def test_compile_opencl(tflite_mobilenet_v1_0_25_128):
     tvmc_package = tvmc.compile(
         tvmc_model,
         target="opencl -host=llvm",
-        desired_layout="NCHW",
+        transform_args={"desired_layout": "NCHW"},
         dump_code="asm",
     )
     dumps_path = tvmc_package.package_path + ".asm"

--- a/tests/python/driver/tvmc/test_transform.py
+++ b/tests/python/driver/tvmc/test_transform.py
@@ -76,7 +76,7 @@ def test_layout_transform_to_mixed_precision_pass_args(relay_conv2d, monkeypatch
     mixed precision arguments are provided.
     """
     mock_mixed_precision = MagicMock()
-    mock_mixed_precision.return_value = tvm.driver.tvmc.transform.MixedPrecision([])
+    mock_mixed_precision.return_value = tvm.driver.tvmc.transform.MixedPrecision([], "")
     monkeypatch.setattr(tvm.driver.tvmc.transform, "MixedPrecision", mock_mixed_precision)
 
     with tvm.transform.PassContext(opt_level=3):
@@ -84,40 +84,23 @@ def test_layout_transform_to_mixed_precision_pass_args(relay_conv2d, monkeypatch
             relay_conv2d,
             {
                 "mixed_precision": True,
+                "mixed_precision_ops": ["nn.conv2d"],
+                "mixed_precision_calculation_type": "float16",
+                "mixed_precision_acc_type": "float16",
             },
         )
-        mock_mixed_precision.assert_called_with(["nn.conv2d", "nn.dense"])
+        mock_mixed_precision.assert_called_with(["nn.conv2d"], "float16")
 
         apply_graph_transforms(
             relay_conv2d,
             {
                 "mixed_precision": True,
-                "mixed_precision_ops": "nn.conv2d",
+                "mixed_precision_ops": ["nn.conv2d", "nn.dense"],
+                "mixed_precision_calculation_type": "float16",
+                "mixed_precision_acc_type": "float32",
             },
         )
-        mock_mixed_precision.assert_called_with(["nn.conv2d"])
-
-        apply_graph_transforms(
-            relay_conv2d,
-            {
-                "mixed_precision": True,
-                "mixed_precision_ops": "nn.conv2d,nn.dense",
-                "mixed_precision_input": "float16",
-                "mixed_precision_output": "float16",
-            },
-        )
-        mock_mixed_precision.assert_called_with(["nn.conv2d", "nn.dense"])
-
-        apply_graph_transforms(
-            relay_conv2d,
-            {
-                "mixed_precision": True,
-                "mixed_precision_ops": "nn.conv2d,nn.dense",
-                "mixed_precision_input": "float16",
-                "mixed_precision_output": "float32",
-            },
-        )
-        mock_mixed_precision.assert_called_with(["nn.conv2d", "nn.dense"])
+        mock_mixed_precision.assert_called_with(["nn.conv2d", "nn.dense"], "float32")
 
 
 if __name__ == "__main__":

--- a/tests/python/driver/tvmc/test_transform.py
+++ b/tests/python/driver/tvmc/test_transform.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock
 
 import tvm
 from tvm import relay
+from tvm.relay import testing
+from tvm.relay.expr_functor import ExprMutator
 from tvm.ir.instrument import pass_instrument
 from tvm.driver.tvmc.transform import apply_graph_transforms
 
@@ -70,7 +72,7 @@ def test_layout_transform_convert_layout_pass_args(relay_conv2d, monkeypatch):
     )
 
 
-def test_layout_transform_to_mixed_precision_pass_args(relay_conv2d, monkeypatch):
+def test_layout_transform_to_mixed_precision_pass_args_mock(relay_conv2d, monkeypatch):
     """
     Check the mixed precision arugments which are expected when
     mixed precision arguments are provided.
@@ -101,6 +103,66 @@ def test_layout_transform_to_mixed_precision_pass_args(relay_conv2d, monkeypatch
             },
         )
         mock_mixed_precision.assert_called_with(["nn.conv2d", "nn.dense"], "float32")
+
+
+def test_layout_transform_to_mixed_precision_pass_args_graph():
+    """
+    Check the mixed precision arugments application with in a graph.
+    """
+
+    mod, params = testing.mobilenet.get_workload(batch_size=1, dtype="float32")
+
+    class CheckOpMutator(ExprMutator):
+        """Inspect Ops According to expected types."""
+
+        def __init__(self, calculation_type, acc_type, op):
+            self.calculation_type = calculation_type
+            self.acc_type = acc_type
+            self.op = op
+            self.is_expected = True
+            super().__init__()
+
+        def visit_call(self, call):
+            visit = super().visit(call.args[0])
+            if call.op == relay.op.get(self.op):
+                if self.is_expected:
+                    self.is_expected = (
+                        call.checked_type.dtype == self.acc_type
+                        or call.args[0].checked_type.dtype == self.calculation_type
+                    )
+            return call
+
+        def check(self, func):
+            self.visit(func)
+            return self.is_expected
+
+    mod = apply_graph_transforms(
+        mod,
+        {
+            "mixed_precision": True,
+            "mixed_precision_ops": ["nn.conv2d", "nn.dense"],
+            "mixed_precision_calculation_type": "float16",
+            "mixed_precision_acc_type": "float16",
+        },
+    )
+    ret = CheckOpMutator("float16", "float16", "nn.conv2d").check(mod["main"])
+    assert ret
+    ret = CheckOpMutator("float16", "float16", "nn.dense").check(mod["main"])
+    assert ret
+
+    mod = apply_graph_transforms(
+        mod,
+        {
+            "mixed_precision": True,
+            "mixed_precision_ops": ["nn.conv2d", "nn.dense"],
+            "mixed_precision_calculation_type": "float16",
+            "mixed_precision_acc_type": "float32",
+        },
+    )
+    ret = CheckOpMutator("float16", "float32", "nn.conv2d").check(mod["main"])
+    assert ret
+    ret = CheckOpMutator("float16", "float32", "nn.dense").check(mod["main"])
+    assert ret
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds new command line options:
* `--mixed-precision` - Enable mixed precision conversion
* `--mixed-precision-ops` - List of operators to be converted to mixed precision
* `--mixed-precision-calculation-type` - Calculation precision type
* `--mixed-precision-acc-type` - Accumulator precision type
    
And: 
* `--desired-layout-ops` - The list of operators to be transformed with desired layout.