### PR TITLE
[FIX][RUNTIME] Convert container with function value type

### DIFF
--- a/python/tvm/runtime/object_generic.py
+++ b/python/tvm/runtime/object_generic.py
@@ -35,7 +35,7 @@ class ObjectGeneric(object):
         raise NotImplementedError()
 
 
-ObjectTypes = (ObjectBase, NDArrayBase, Module, ObjectRValueRef, PyNativeObject)
+ObjectTypes = (ObjectBase, NDArrayBase, Module, ObjectRValueRef, PackedFuncBase, PyNativeObject)
 
 
 def convert_to_object(value, span=None):
@@ -79,6 +79,8 @@ def convert_to_object(value, span=None):
         return _ffi_api.Map(*vlist)
     if isinstance(value, ObjectGeneric):
         return value.asobject()
+    if callable(value):
+        return convert_to_tvm_func(value)
     if value is None:
         return None
 
@@ -99,13 +101,12 @@ def convert(value, span=None):
     -------
     tvm_val : Object or Function
         Converted value in TVM
+
+    Note
+    ----
+    This function is redirected to `convert_to_object` as it is widely used in
+    the codebase. We can choose one to keep and discard the other one later.
     """
-    if isinstance(value, (PackedFuncBase, ObjectBase)):
-        return value
-
-    if callable(value):
-        return convert_to_tvm_func(value)
-
     return convert_to_object(value, span=span)
 
 

--- a/tests/python/all-platform-minimal-test/test_runtime_packed_func.py
+++ b/tests/python/all-platform-minimal-test/test_runtime_packed_func.py
@@ -153,6 +153,18 @@ def test_ndarray_args():
     assert tvm.testing.object_use_count(x) == 1
 
 
+def test_dict_function_value_type():
+    from tvm import tir  # pylint: disable=import-outside-toplevel
+
+    te_func_dict = {"add": lambda a, b: a + b}
+
+    converted_dict = tvm.runtime.convert(te_func_dict)
+    f = converted_dict["add"]
+    a = tir.Var("a", "float32")
+    b = tir.Var("b", "float32")
+    tvm.ir.assert_structural_equal(f(a, b), tir.Add(a, b))
+
+
 if __name__ == "__main__":
     test_ndarray_args()
     test_numpy_scalar()
@@ -164,3 +176,4 @@ if __name__ == "__main__":
     test_return_func()
     test_byte_array()
     test_device()
+    test_dict_function_value_type()


### PR DESCRIPTION
Prior to this PR, though the `convert` function is capable of converting a single Python function/lambda to TVM func, it is not able to convert a container whose values inside are functions to TVM object.

This PR adds function conversion to `convert_to_object` and redirects `convert` to `convert_to_object`, so that now the conversion is always recursive, and therefore will work well on function container value type.

Co-authored-by: Chaofan Lin <1713833595@qq.com>