### PR TITLE
[Unity] Disallow inline prim_func in relax IR

### DIFF
--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -139,6 +139,16 @@ def visit_function_def(self: Parser, node: doc.FunctionDef) -> None:
                     R.func_ret_struct_info(ann_sinfo)
 
                 self.visit(node.args)
+
+                for stmt in node.body:
+                    if isinstance(stmt, doc.FunctionDef):
+                        if not stmt.decorator_list:
+                            self.report_error(stmt, "Function must be decorated")
+                        dec = self.eval_expr(stmt.decorator_list[-1])
+                        # inline prim_func was found
+                        if dec.dispatch_token == "tir":
+                            self.report_error(stmt, "inline prim_func is disallowed in Relax IR")
+
                 self.visit_body(node.body)
 
 

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -316,7 +316,11 @@ class WellFormedChecker : public relax::ExprVisitor,
   }
 
   void VisitBinding_(const VarBindingNode* binding) final {
-    this->VisitExpr(binding->value);
+    if (binding->value->IsInstance<tir::PrimFuncNode>()) {
+      Malformed(Diagnostic::Error(binding->value) << "Inline PrimFunc is disallowed in Relax IR.");
+    } else {
+      this->VisitExpr(binding->value);
+    }
     this->VisitVarDef(binding->var);
   }
 

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -469,12 +469,6 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
    * \note This function create a new binding for non-leaf expressions except for tuple.
    */
   Expr NormalizeArgument(const Expr& arg) final {
-    // Temp patch to ensure we handle inline PrimFunc case.
-    // TODO(relax-team) remove such cases from parser and testcases.
-    if (auto* prim_func = arg.as<tir::PrimFuncNode>()) {
-      return NormalizePrimFunc(GetRef<tir::PrimFunc>(prim_func));
-    }
-
     if (!block_stack_.empty()) {
       // cache lookup
       BlockFrame* cur_frame = CurrentBlockFrame();
@@ -520,23 +514,7 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
 
   Expr VisitExpr_(const DataflowVarNode* var) final { return VisitVar_<DataflowVar>(var); }
 
-  // Temp patch to ensure we handle inline PrimFunc case.
-  // TODO(relax-team) remove such cases from parser and testcases.
-  Expr NormalizePrimFunc(tir::PrimFunc prim_func) {
-    if (!prim_func->struct_info_.defined()) {
-      auto finfo = FuncStructInfo::OpaqueFunc(StructInfoFromType(prim_func->ret_type));
-      UpdateStructInfo(prim_func, finfo);
-    }
-    return prim_func;
-  }
-
   Expr VisitExpr(const Expr& expr) final {
-    // Temp patch to ensure we handle inline PrimFunc case.
-    // TODO(relax-team) remove such cases from parser and testcases.
-    if (auto* prim_func = expr.as<tir::PrimFuncNode>()) {
-      return NormalizePrimFunc(GetRef<tir::PrimFunc>(prim_func));
-    }
-
     // lookup normalize map
     if (!block_stack_.empty()) {
       BlockFrame* cur_frame = CurrentBlockFrame();


### PR DESCRIPTION
Disallow inline PrimFunc in Relax IR, upstreaming from tlc-pack/relax.

cc: @tqchen @YuchenJin @junrushao  