### PR TITLE
[Runtime] Add missing Type2Str for TVMByteArray

### DIFF
--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -1458,6 +1458,10 @@ template <>
 struct Type2Str<TVMArgValue> {
   static std::string v() { return "TVMArgValue"; }
 };
+template <>
+struct Type2Str<TVMByteArray> {
+  static std::string v() { return "TVMByteArray"; }
+};
 template <typename FType>
 struct Type2Str<TypedPackedFunc<FType>> {
   static std::string v() { return SignaturePrinter<function_signature<FType>>::F(); }


### PR DESCRIPTION
To support register function return TVMByteArray.