### PR TITLE
[CI] Fix test skipping pytest attribute

### DIFF
--- a/tests/python/integration/test_auto_tensorize.py
+++ b/tests/python/integration/test_auto_tensorize.py
@@ -334,7 +334,7 @@ def test_dp4a_conv2d():
 
 
 @tvm.testing.requires_cascadelake
-@pytest.mark.skip_if(tvm.testing.IS_IN_CI, reason="Slow on CI")
+@pytest.mark.skipif(tvm.testing.IS_IN_CI, reason="Slow on CI")
 def test_vnni_bert_int8():
     relay_mod, params, input_info = load_quantized_bert_base()
     _test_bert_int8(


### PR DESCRIPTION
The test previously had the incorrect pytest attribute skip_if, this replaces with the correct one