### PR TITLE
[Unity][Layout] Add layout transformation analysis for PrimFunc

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -33,6 +33,7 @@
 #include <tvm/tir/function.h>
 
 #include <functional>
+#include <unordered_map>
 #include <utility>
 
 namespace tvm {
@@ -411,6 +412,19 @@ TVM_DLL bool HasReshapePattern(const tir::PrimFunc& func);
  * will be well tested and will not be blocked by not having structure info.
  */
 TVM_DLL bool WellFormed(IRModule m, bool check_struct_info = true);
+
+/*!
+ * \brief Using the layout transforms on the outputs, suggest layout transformation on the blocks
+ * and buffers for the PrimFunc.
+ *
+ * \param fn The PrimFunc to be analyzed.
+ * \param write_buffer_transformations Array of IndexMap transformations on PrimFunc outputs.
+ * \return Suggested transforms per block in `fn`. For each block the returned value is a map
+ * from the object (block or buffer) to it's index map transformation.
+ */
+
+TVM_DLL Map<tir::Block, Map<ObjectRef, tir::IndexMap>> SuggestLayoutTransforms(
+    const Function& fn, Array<tir::IndexMap> write_buffer_transformations);
 
 }  // namespace relax
 }  // namespace tvm

--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -33,7 +33,6 @@
 #include <tvm/tir/function.h>
 
 #include <functional>
-#include <unordered_map>
 #include <utility>
 
 namespace tvm {

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -316,5 +316,6 @@ def suggest_layout_transforms(
     for transform in write_buffer_transforms:
         if callable(transform):
             transform = IndexMap.from_func(transform)
+        assert isinstance(transform, IndexMap)
         write_buffer_index_maps.append(transform)
     return _ffi_api.suggest_layout_transforms(func, write_buffer_index_maps)  # type: ignore

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -21,7 +21,7 @@ This file contains the set of passes for Relax, which exposes an interface for
 configuring the passes and scripting them in Python.
 """
 
-from typing import Dict, List
+from typing import Dict, List, Union, Callable
 from enum import IntEnum
 
 from tvm import tir
@@ -29,6 +29,7 @@ from tvm import IRModule
 from tvm.relax.ty import Type
 from tvm.relax.struct_info import StructInfo, FuncStructInfo
 from tvm.relax.expr import DataflowBlock, Var, Expr, Function, Call, Binding
+from tvm.tir import IndexMap, PrimFunc, Block, Buffer
 from . import _ffi_api
 
 
@@ -289,3 +290,31 @@ def well_formed(mod: IRModule, check_struct_info: bool = True) -> bool:
     will be well tested and will not be blocked by not having structure info.
     """
     return _ffi_api.well_formed(mod, check_struct_info)  # type: ignore
+
+
+def suggest_layout_transforms(
+    func: PrimFunc, write_buffer_transforms: List[Union[IndexMap, Callable]]
+) -> Dict[Block, Dict[Union[Block, Buffer], IndexMap]]:
+    """Suggest Layout transformations of blocks and buffers in a PrimFunc.
+
+    Parameters
+    ----------
+    func: PrimFunc
+        PrimFunc on which analysis will be performed and transformations suggested.
+
+    write_buffer_transforms: List[Union[IndexMap, Callable]
+        List of layout transformations on the output buffers. The number of layout
+        transformations must match the number of outputs of the PrimFunc.
+
+    Returns
+    -------
+    ret: Dict[Block, Dict[Union[Block, Buffer], IndexMap]]
+         Suggested transforms per block in `func`. For each block the returned value is a map
+         from the object (block or buffer) to it's index map transformation.
+    """
+    write_buffer_index_maps = []
+    for transform in write_buffer_transforms:
+        if callable(transform):
+            transform = IndexMap.from_func(transform)
+        write_buffer_index_maps.append(transform)
+    return _ffi_api.suggest_layout_transforms(func, write_buffer_index_maps)  # type: ignore

--- a/src/relax/analysis/layout_transformation.cc
+++ b/src/relax/analysis/layout_transformation.cc
@@ -358,7 +358,7 @@ class BlockAnalyzer : public StmtExprVisitor {
     };
 
     // Check that write has sequential access within the block.
-    const auto& write_spatial_layout = get_spatial_layout(write_buffer);
+    SpatialLayout write_spatial_layout = get_spatial_layout(write_buffer);
     if (write_spatial_layout.empty()) {
       can_transform_block_ = false;
       return;
@@ -388,7 +388,7 @@ class BlockAnalyzer : public StmtExprVisitor {
 
     // Infer read buffer transformations from write buffer transformation.
     for (const auto& r : block->reads) {
-      const auto& read_spatial_layout = get_spatial_layout(r->buffer);
+      SpatialLayout read_spatial_layout = get_spatial_layout(r->buffer);
       if (read_spatial_layout.empty()) continue;
       if (!IsSequentialAccess(read_spatial_layout, iter_var_to_block_index)) continue;
 

--- a/src/relax/analysis/layout_transformation.cc
+++ b/src/relax/analysis/layout_transformation.cc
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file relax/analysis/layout_transormation.cc
+ * \brief Analyze the PrimFunc and suggest layout transformation on it's blocks and buffers based on
+ * the user provided layout transformations on it's outputs.
+ */
+#include <tvm/arith/iter_affine_map.h>
+#include <tvm/ir/function.h>
+#include <tvm/relax/analysis.h>
+#include <tvm/relax/expr.h>
+#include <tvm/relax/transform.h>
+#include <tvm/relax/type.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/index_map.h>
+#include <tvm/tir/stmt_functor.h>
+
+#include <queue>
+
+#include "../../tir/schedule/analysis.h"
+
+namespace tvm {
+namespace relax {
+
+using namespace tir;
+
+using IterSetTy = Optional<tir::Var>;
+using ArrayIterSetTy = Array<IterSetTy>;
+using VarSet = std::unordered_set<tir::Var, ObjectPtrHash, ObjectPtrEqual>;
+
+static inline Array<PrimExpr> RegionToIndices(const Region& region) {
+  ICHECK(region.size() != 0);
+  Array<PrimExpr> indices;
+  for (const auto& r : region) {
+    if (!is_one(r->extent)) return {};
+    indices.push_back(r->min);
+  }
+  return indices;
+}
+
+template <typename T>
+static inline Array<T> list_to_array(std::list<T> l) {
+  Array<T> array;
+  for (auto& v : l) {
+    array.push_back(v);
+  }
+  return array;
+}
+
+template <typename T>
+static inline std::list<T> array_to_list(Array<T> array) {
+  std::list<T> l;
+  for (auto& v : array) {
+    l.push_back(v);
+  }
+  return l;
+}
+
+// Gather all tir::VarNodes in an expr
+static inline void GatherVars(const PrimExpr& expr, std::unordered_set<const tir::VarNode*>* vars) {
+  tir::PostOrderVisit(expr, [&vars](const ObjectRef& node) {
+    if (const tir::VarNode* op = node.as<tir::VarNode>()) {
+      vars->insert(op);
+    }
+  });
+}
+static inline bool HasUndefinedVars(const PrimExpr& expr, const VarSet& defs) {
+  bool has_undefined_vars = false;
+  tir::PostOrderVisit(expr, [&](const ObjectRef& node) {
+    if (const tir::VarNode* op = node.as<tir::VarNode>()) {
+      if (defs.count(GetRef<tir::Var>(op)) == 0) {
+        has_undefined_vars = true;
+      }
+    }
+  });
+  return has_undefined_vars;
+}
+
+class IterMapAnalyzer : public ExprVisitor {
+ public:
+  Array<tir::Var> Analyze(const PrimExpr& expr) {
+    VisitExpr(expr);
+    return iterators_;
+  }
+
+ private:
+  /*! \brief Override VisitExpr for iter expr type processing */
+  void VisitExpr(const PrimExpr& expr) override {
+    if (const auto* op = expr.as<arith::IterSumExprNode>()) {
+      Visit_(GetRef<arith::IterSumExpr>(op));
+      return;
+    }
+    if (const auto* op = expr.as<arith::IterSplitExprNode>()) {
+      Visit_(GetRef<arith::IterSplitExpr>(op));
+      return;
+    }
+    return ExprVisitor::VisitExpr(expr);
+  }
+
+  void Visit_(const arith::IterMark& op) {
+    if (const auto* var = op->source.as<tir::VarNode>()) {
+      iterators_.push_back(GetRef<tir::Var>(var));
+      return;
+    }
+    VisitExpr(op->source);
+    VisitExpr(op->extent);
+  }
+  void Visit_(const arith::IterSplitExpr& op) {
+    Visit_(op->source);
+    VisitExpr(op->lower_factor);
+    VisitExpr(op->extent);
+    VisitExpr(op->scale);
+    return;
+  }
+  void Visit_(const arith::IterSumExpr& op) {
+    for (const auto& arg : op->args) {
+      Visit_(arg);
+    }
+    VisitExpr(op->base);
+    return;
+  }
+
+ private:
+  Array<tir::Var> iterators_;
+};
+
+class PrimFuncAnalyzer : public StmtExprVisitor {
+ public:
+  explicit PrimFuncAnalyzer(const PrimFunc& func, IndexMap write_transformation)
+      : can_be_transformed_(true), write_transformation_(write_transformation) {
+    for (const tir::Var& param : func->params) {
+      Optional<Buffer> param_buf = func->buffer_map.Get(param);
+      if (param_buf.defined()) {
+        param_buffers_.insert(param_buf.value());
+      }
+    }
+  }
+
+ private:
+  bool IterVarsToDomain(const Array<IterVar>& itervars) {
+    for (const IterVar& v : itervars) {
+      // Only support
+      if (v->iter_type == kDataPar)
+        spatial_dom_.Set(v->var, v->dom);
+      else if (v->iter_type == kCommReduce)
+        reduction_dom_.Set(v->var, v->dom);
+      else
+        return false;
+    }
+    return true;
+  }
+
+  // Helper to break down the indices of buffer access
+  void DetectRegionIterMap(const BufferRegion& buffer_region, arith::Analyzer* analyzer) {
+    auto indices = RegionToIndices(buffer_region->region);
+    if (indices.empty()) {
+      LOG(WARNING) << "Buffer: " << buffer_region
+                   << " cannot be transformed because extent of indices is not 1";
+      return;
+    }
+    auto result = arith::DetectIterMap(
+        /*indices=*/indices, /*input_iters*/ spatial_dom_,
+        /*predicate*/ tir::const_true(),
+        /*check_level*/ arith::IterMapLevel::Surjective, /*analyzer*/ analyzer);
+    if (result->indices.empty()) {
+      LOG(WARNING) << "Buffer: " << buffer_region << " cannot be transformed because "
+                   << result->errors;
+      return;
+    }
+    auto [is_supported, iterators] = GetIteratorAccess(result);
+    if (!is_supported) return;
+    buffer_to_iter_map_result_[buffer_region] = std::move(iterators);
+  }
+
+  // Get the iterator access
+  std::tuple<bool, ArrayIterSetTy> GetIteratorAccess(const arith::IterMapResult& iter_map_result) {
+    ICHECK(!iter_map_result->indices.empty());
+    ArrayIterSetTy result;
+    for (const arith::IterSumExpr& index : iter_map_result->indices) {
+      IterMapAnalyzer index_analyzer;
+      auto iter_vars = index_analyzer.Analyze(index);
+      if (iter_vars.size() >= 2) return {false, {}};
+      if (iter_vars.empty()) {
+        result.push_back({});
+        continue;
+      }
+      // iter_vars.size() == 1
+      result.push_back(iter_vars[0]);
+    }
+    return {true, result};
+  }
+
+  bool IsSequentialAccess(const ArrayIterSetTy& iterators,
+                          const std::unordered_map<const tir::VarNode*, int>& iter_to_block_index) {
+    int last_value = -1;
+    for (const auto& i : iterators) {
+      if (!i.defined()) continue;
+      int blk_index = iter_to_block_index.at(i.value().get());
+      if (blk_index <= last_value) return false;
+      last_value = blk_index;
+    }
+    return true;
+  }
+
+  IndexMap GetTransformation(const ArrayIterSetTy& src_iterators,
+                             const IndexMap& src_transformation,
+                             const ArrayIterSetTy& tgt_iterators) {
+    // Copy over the src transformation intial and final indices
+    auto initial_indices = array_to_list(src_transformation->initial_indices);
+    auto final_indices = array_to_list(src_transformation->final_indices);
+
+    // Remove any indices on both sides
+    VarSet tgt_var_set;
+    for (const auto& i : tgt_iterators) {
+      if (i.defined()) tgt_var_set.insert(i.value());
+    }
+
+    // Drop vars that do not occur in tgt iterators
+    auto initial_indices_it = initial_indices.begin();
+    VarSet defs;
+    for (const auto& i : src_iterators) {
+      ICHECK(i.defined());
+      if (tgt_var_set.count(i.value())) {
+        defs.insert(*initial_indices_it);
+        initial_indices_it++;
+        continue;
+      }
+      initial_indices_it = initial_indices.erase(initial_indices_it);
+    }
+
+    // Erase any expressions in final indices that have undefined vars
+    auto final_indices_it = final_indices.begin();
+    while (final_indices_it != final_indices.end()) {
+      if (!HasUndefinedVars(*final_indices_it, defs)) {
+        final_indices_it++;
+        continue;
+      }
+      final_indices_it = final_indices.erase(final_indices_it);
+    }
+
+    VarSet src_var_set;
+    for (const auto& i : src_iterators) {
+      ICHECK(i.defined());
+      src_var_set.insert(i.value());
+    }
+
+    initial_indices_it = initial_indices.begin();
+    final_indices_it = final_indices.begin();
+    for (const auto& i : tgt_iterators) {
+      if (i.defined() && src_var_set.count(i.value())) {
+        initial_indices_it++;
+        if (final_indices_it != final_indices.end()) final_indices_it++;
+        continue;
+      }
+
+      auto v = tir::Var("dim");
+      initial_indices.insert(initial_indices_it, v);
+      final_indices.insert(final_indices_it, v);
+    }
+
+    auto ret = IndexMap(list_to_array(initial_indices), list_to_array(final_indices));
+    return ret;
+  }
+  void VisitStmt_(const BlockNode* op) final {
+    if (op->name_hint == "root") {
+      // Skip the root block
+      StmtVisitor::VisitStmt_(op);
+      return;
+    }
+    // For now we can only transform functions with a single block.
+    if (block_.defined()) {
+      can_be_transformed_ = false;
+      return;
+    }
+
+    Block block = GetRef<Block>(op);
+    block_ = block;
+    if (!IterVarsToDomain(block->iter_vars)) {
+      can_be_transformed_ = false;
+      return;
+    }
+
+    // Only handle blocks which write to a single param buffer.
+    if (block->writes.size() != 1) {
+      can_be_transformed_ = false;
+    }
+
+    // All the buffer access are quasi-affine expressions on spatial domain.
+    tvm::arith::Analyzer analyzer;
+    for (const auto& w : block->writes) DetectRegionIterMap(w, &analyzer);
+    if (can_be_transformed_ == false) return;
+    for (const auto& r : block->reads) DetectRegionIterMap(r, &analyzer);
+
+    // Get loop ordering in block iterators
+    std::unordered_map<const tir::VarNode*, IterVarType> iter_var_to_type;
+    int index = 0;
+    for (const auto& iter_var : block->iter_vars) {
+      iter_var_to_block_index_[iter_var->var.get()] = index++;
+      iter_var_to_type[iter_var->var.get()] = iter_var->iter_type;
+    }
+
+    // Map from write indices to blk indices
+    // Write has sequential access
+    // This would mean that the mapping between spatial dom vars and their use in the buffer
+    // access is sequential.
+    auto write_region = block->writes[0];
+    auto it = buffer_to_iter_map_result_.find(write_region);
+    if (it == buffer_to_iter_map_result_.end()) {
+      can_be_transformed_ = false;
+      return;
+    }
+    auto write_access_iterators = it->second;
+    if (!IsSequentialAccess(write_access_iterators, iter_var_to_block_index_)) {
+      can_be_transformed_ = false;
+      return;
+    }
+    // Propose transformation of block
+    ArrayIterSetTy block_iterators;
+    for (const auto& i : block->iter_vars) {
+      block_iterators.push_back(i->var);
+    }
+    block_transformation_ =
+        GetTransformation(write_access_iterators, write_transformation_, block_iterators);
+
+    // Map from read indices to blk indices
+    for (const auto& r : block->reads) {
+      auto it = buffer_to_iter_map_result_.find(r);
+      if (it == buffer_to_iter_map_result_.end()) continue;
+      auto read_access_iterators = it->second;
+      if (!IsSequentialAccess(read_access_iterators, iter_var_to_block_index_)) continue;
+      if (read_buffer_transformation_.count(r->buffer)) continue;
+
+      auto read_transformation =
+          GetTransformation(write_access_iterators, write_transformation_, read_access_iterators);
+      read_buffer_transformation_.Set(r->buffer, read_transformation);
+    }
+  }
+
+ private:
+  bool can_be_transformed_;
+  /*! \brief The buffers from function params. I.e. the input and output buffers. */
+  std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual> param_buffers_;
+  std::unordered_map<BufferRegion, ArrayIterSetTy, ObjectPtrHash, ObjectPtrEqual>
+      buffer_to_iter_map_result_;
+  Map<tir::Var, Range> spatial_dom_;
+  Map<tir::Var, Range> reduction_dom_;
+
+  std::unordered_map<const tir::VarNode*, int> iter_var_to_block_index_;
+  IndexMap write_transformation_;
+
+ public:
+  Optional<Block> block_;
+  IndexMap block_transformation_;
+  Map<Buffer, IndexMap> read_buffer_transformation_;
+
+ public:
+  bool CanBeTransformed() { return can_be_transformed_; }
+  Block GetBlock() {
+    ICHECK(block_.defined());
+    return block_.value();
+  }
+};
+
+Map<tir::Block, Map<ObjectRef, tir::IndexMap>> SuggestLayoutTransforms(
+    const PrimFunc& prim_func, Array<IndexMap> write_buffer_transformations) {
+  Map<tir::Block, Map<ObjectRef, tir::IndexMap>> result;
+  // No changes to the PrimFunc are required if no transformations on output buffers.
+  if (write_buffer_transformations.empty()) return result;
+
+  if (write_buffer_transformations.size() > 1) {
+    LOG(WARNING) << "PrimFunc with more than one outputs is not supported yet";
+    return result;
+  }
+  ICHECK(write_buffer_transformations.size() == 1);
+
+  PrimFuncAnalyzer analyzer(prim_func, write_buffer_transformations[0]);
+  analyzer(prim_func->body);
+  auto can_be_transformed = analyzer.CanBeTransformed();
+  if (!can_be_transformed) {
+    LOG(WARNING) << "Requested PrimFunc cannot be transformed";
+    return result;
+  }
+
+  Map<ObjectRef, IndexMap> block_result;
+
+  Block block = analyzer.GetBlock();
+  block_result.Set(block, analyzer.block_transformation_);
+  block_result.Set(block->writes[0]->buffer, write_buffer_transformations[0]);
+
+  for (const auto& read_buffer_region : block->reads) {
+    if (analyzer.read_buffer_transformation_.count(read_buffer_region->buffer) == 0) continue;
+    const auto& buffer_transformation =
+        analyzer.read_buffer_transformation_[read_buffer_region->buffer];
+    block_result.Set(read_buffer_region->buffer, buffer_transformation);
+  }
+  result.Set(block, block_result);
+  return result;
+}
+
+TVM_REGISTER_GLOBAL(("relax.analysis.suggest_layout_transforms"))
+    .set_body_typed([](PrimFunc fn, Array<tir::IndexMap> write_buffer_transformations) {
+      return SuggestLayoutTransforms(fn, write_buffer_transformations);
+    });
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/analysis/layout_transformation.cc
+++ b/src/relax/analysis/layout_transformation.cc
@@ -41,20 +41,14 @@ namespace relax {
 
 using namespace tir;
 
-using IterSetTy = Optional<tir::Var>;
-using ArrayIterSetTy = Array<IterSetTy>;
 using VarSet = std::unordered_set<tir::Var, ObjectPtrHash, ObjectPtrEqual>;
+using SpatialLayout = Array<Optional<tir::Var>>;
+using VarToBlockIndexMap = std::unordered_map<tir::Var, int, ObjectPtrHash, ObjectPtrEqual>;
+using VarToIterTypeMap = std::unordered_map<tir::Var, IterVarType, ObjectPtrHash, ObjectPtrEqual>;
 
-static inline Array<PrimExpr> RegionToIndices(const Region& region) {
-  ICHECK(region.size() != 0);
-  Array<PrimExpr> indices;
-  for (const auto& r : region) {
-    if (!is_one(r->extent)) return {};
-    indices.push_back(r->min);
-  }
-  return indices;
-}
+/********** Helper Functions **********/
 
+/*! \brief Converts a list to an Array */
 template <typename T>
 static inline Array<T> list_to_array(std::list<T> l) {
   Array<T> array;
@@ -64,6 +58,7 @@ static inline Array<T> list_to_array(std::list<T> l) {
   return array;
 }
 
+/*! \brief Converts an Array to a list */
 template <typename T>
 static inline std::list<T> array_to_list(Array<T> array) {
   std::list<T> l;
@@ -73,14 +68,7 @@ static inline std::list<T> array_to_list(Array<T> array) {
   return l;
 }
 
-// Gather all tir::VarNodes in an expr
-static inline void GatherVars(const PrimExpr& expr, std::unordered_set<const tir::VarNode*>* vars) {
-  tir::PostOrderVisit(expr, [&vars](const ObjectRef& node) {
-    if (const tir::VarNode* op = node.as<tir::VarNode>()) {
-      vars->insert(op);
-    }
-  });
-}
+/*! \brief Checks the PrimExpr for any vars not defined in `defs` */
 static inline bool HasUndefinedVars(const PrimExpr& expr, const VarSet& defs) {
   bool has_undefined_vars = false;
   tir::PostOrderVisit(expr, [&](const ObjectRef& node) {
@@ -93,9 +81,13 @@ static inline bool HasUndefinedVars(const PrimExpr& expr, const VarSet& defs) {
   return has_undefined_vars;
 }
 
-class IterMapAnalyzer : public ExprVisitor {
+/*! \brief Analyzes the indices returned from DetectIterMap analysis. It collects the spatial
+ * iterator vars that are used in indices. This is important to get which spatial iter vars are
+ * accessed in each index of buffer access.
+ */
+class IndexAnalyzer : public ExprVisitor {
  public:
-  Array<tir::Var> Analyze(const PrimExpr& expr) {
+  Array<tir::Var> Analyze(const arith::IterSumExpr& expr) {
     VisitExpr(expr);
     return iterators_;
   }
@@ -141,277 +133,384 @@ class IterMapAnalyzer : public ExprVisitor {
   Array<tir::Var> iterators_;
 };
 
-class PrimFuncAnalyzer : public StmtExprVisitor {
+/*! \brief Analyzes IterMapResult to get the spatial layout */
+static inline SpatialLayout GetSpatialLayout(const arith::IterMapResult& iter_map_result) {
+  ICHECK(!iter_map_result->indices.empty());
+  SpatialLayout result;
+  for (const arith::IterSumExpr& index : iter_map_result->indices) {
+    IndexAnalyzer index_analyzer;
+    Array<tir::Var> iter_vars = index_analyzer.Analyze(index);
+    if (iter_vars.size() >= 2) return {};
+    if (iter_vars.empty()) {
+      result.push_back({});
+      continue;
+    }
+    result.push_back(iter_vars[0]);
+  }
+  return result;
+}
+
+/*! \brief Checks if the two spatial layouts are identical. Two empty spatial layouts are treated as
+ * unequal.*/
+static inline bool AreIdenticalSpatialAccess(const SpatialLayout& s0, const SpatialLayout& s1) {
+  if (s0.empty() || s1.empty()) return false;
+  if (s0.size() != s1.size()) return false;
+  for (size_t i = 0; i < s0.size(); ++i) {
+    if ((!s0[i].defined() && s1[i].defined()) || (s0[i].defined() && !s1[i].defined()))
+      return false;
+    if (!s0[i].same_as(s1[i])) return false;
+  }
+  return true;
+}
+
+/*! \brief Given the spatial layout and t*/
+static bool IsSequentialAccess(const SpatialLayout& iterators,
+                               const VarToBlockIndexMap& iter_to_block_index) {
+  int last_value = -1;
+  for (const auto& i : iterators) {
+    if (!i.defined()) continue;
+    auto it = iter_to_block_index.find(i.value());
+    ICHECK(it != iter_to_block_index.end());
+    int blk_index = it->second;
+    if (blk_index <= last_value) return false;
+    last_value = blk_index;
+  }
+  return true;
+}
+
+/*! \brief Checks if two IndexMap transforms are identical*/
+static inline bool AreIdenticalTransforms(const IndexMap& t0, const IndexMap& t1) {
+  LOG(INFO) << "Comparing index maps: " << t0 << " :: " << t1;
+  if (t0->initial_indices.size() != t1->initial_indices.size()) return false;
+  if (t0->final_indices.size() != t1->final_indices.size()) return false;
+  if (t0->initial_indices.empty()) return false;
+
+  // Create a new shape expression.
+  Array<PrimExpr> indices;
+  for (size_t i = 0; i < t0->initial_indices.size(); ++i) indices.push_back(tir::Var("d"));
+  LOG(INFO) << indices;
+  auto t0_output = t0->MapIndices(indices);
+  auto t1_output = t1->MapIndices(indices);
+  for (size_t i = 0; i < t0_output.size(); ++i) {
+    LOG(INFO) << "Comparing expr: " << t0_output[i] << " :: " << t1_output[i];
+    if (!t0_output[i].same_as(t1_output[i])) {
+      LOG(INFO) << "Not identical";
+      return false;
+    }
+  }
+  return true;
+}
+
+static IndexMap GetTransformation(const SpatialLayout& src_spatial_layout,
+                                  const IndexMap& src_transformation,
+                                  const SpatialLayout& tgt_spatial_layout) {
+  // Copy over the src transformation intial and final indices
+  auto initial_indices = array_to_list(src_transformation->initial_indices);
+  auto final_indices = array_to_list(src_transformation->final_indices);
+
+  // Remove any indices on both sides
+  VarSet tgt_var_set;
+  for (const auto& i : tgt_spatial_layout) {
+    if (i.defined()) tgt_var_set.insert(i.value());
+  }
+
+  // Drop vars that do not occur in tgt iterators
+  auto initial_indices_it = initial_indices.begin();
+  VarSet defs;
+  for (const auto& i : src_spatial_layout) {
+    ICHECK(i.defined());
+    if (tgt_var_set.count(i.value())) {
+      defs.insert(*initial_indices_it);
+      initial_indices_it++;
+      continue;
+    }
+    initial_indices_it = initial_indices.erase(initial_indices_it);
+  }
+
+  // Erase any expressions in final indices that have undefined vars
+  auto final_indices_it = final_indices.begin();
+  while (final_indices_it != final_indices.end()) {
+    if (!HasUndefinedVars(*final_indices_it, defs)) {
+      final_indices_it++;
+      continue;
+    }
+    final_indices_it = final_indices.erase(final_indices_it);
+  }
+
+  VarSet src_var_set;
+  for (const auto& i : src_spatial_layout) {
+    ICHECK(i.defined());
+    src_var_set.insert(i.value());
+  }
+
+  initial_indices_it = initial_indices.begin();
+  final_indices_it = final_indices.begin();
+  for (const auto& i : tgt_spatial_layout) {
+    if (i.defined() && src_var_set.count(i.value())) {
+      initial_indices_it++;
+      if (final_indices_it != final_indices.end()) final_indices_it++;
+      continue;
+    }
+
+    auto v = tir::Var("dim");
+    initial_indices.insert(initial_indices_it, v);
+    final_indices.insert(final_indices_it, v);
+  }
+
+  auto ret = IndexMap(list_to_array(initial_indices), list_to_array(final_indices));
+  return ret;
+}
+class BlockAnalyzer : public StmtExprVisitor {
  public:
-  explicit PrimFuncAnalyzer(const PrimFunc& func, IndexMap write_transformation)
-      : can_be_transformed_(true), write_transformation_(write_transformation) {
-    for (const tir::Var& param : func->params) {
-      Optional<Buffer> param_buf = func->buffer_map.Get(param);
-      if (param_buf.defined()) {
-        param_buffers_.insert(param_buf.value());
+  explicit BlockAnalyzer(const Block& block, IndexMap write_transformation)
+      : can_transform_block_(true), write_transformation_(write_transformation), block_(block) {
+    ICHECK(block_->writes.size() == 1);
+    ComputeDomain();
+
+    // Get load/store access patterns
+    VisitStmt(block_->body);
+
+    // While visiting the load/store patterns it is possible we see an unexpected pattern, such as
+    // nested block or write access to multiple buffers. In such a case, we can return early as we
+    // would not be making any layout suggesstions.
+    if (!can_transform_block_) {
+      LOG(WARNING) << "Unable to transform block " << block->name_hint;
+      return;
+    }
+
+    // Get loop ordering in block iterators
+    VarToIterTypeMap iter_var_to_type;
+    VarToBlockIndexMap iter_var_to_block_index;
+    SpatialLayout block_spatial_layout;
+    int index = 0;
+    for (const auto& iter_var : block->iter_vars) {
+      auto var = iter_var->var;
+      iter_var_to_block_index[var] = index++;
+      iter_var_to_type[var] = iter_var->iter_type;
+      block_spatial_layout.push_back(var);
+    }
+
+    auto get_spatial_layout = [&](Buffer b) -> SpatialLayout {
+      auto it = buffer_access_info_.find(b);
+      if (it == buffer_access_info_.end()) {
+        return {};
       }
+      auto access_info = it->second;
+      return access_info.GetValidSpatialLayout();
+    };
+
+    auto write_buffer = block_->writes[0]->buffer;
+
+    const auto& write_spatial_layout = get_spatial_layout(write_buffer);
+    if (write_spatial_layout.empty()) {
+      can_transform_block_ = false;
+      return;
+    }
+    if (!IsSequentialAccess(write_spatial_layout, iter_var_to_block_index)) {
+      can_transform_block_ = false;
+      return;
+    }
+
+    block_transformation_ =
+        GetTransformation(write_spatial_layout, write_transformation_, block_spatial_layout);
+    Array<Range> block_iter_ranges;
+    for (const auto& iter_var : block_->iter_vars) {
+      block_iter_ranges.push_back(iter_var->dom);
+    }
+    Array<Range> block_ranges = block_->iter_vars.Map([](const IterVar& i) { return i->dom; });
+    try {
+      block_transformation_.Inverse(block_ranges);
+    } catch (...) {
+      LOG(WARNING) << "Inferred block transformation is not bijective affine";
+      can_transform_block_ = false;
+      return;
+    }
+
+    for (const auto& r : block->reads) {
+      const auto& read_spatial_layout = get_spatial_layout(r->buffer);
+      if (read_spatial_layout.empty()) continue;
+      if (!IsSequentialAccess(read_spatial_layout, iter_var_to_block_index)) continue;
+      auto read_transformation =
+          GetTransformation(write_spatial_layout, write_transformation_, read_spatial_layout);
+      read_buffer_transformations_.Set(r->buffer, read_transformation);
     }
   }
 
  private:
-  bool IterVarsToDomain(const Array<IterVar>& itervars) {
-    for (const IterVar& v : itervars) {
-      // Only support
-      if (v->iter_type == kDataPar)
-        spatial_dom_.Set(v->var, v->dom);
-      else if (v->iter_type == kCommReduce)
-        reduction_dom_.Set(v->var, v->dom);
-      else
-        return false;
+  class BufferAccessInfo {
+   public:
+    BufferAccessInfo() : is_valid_(true) {}
+    void Update(SpatialLayout s) {
+      if (!IsValid()) return;
+      if (spatial_layout_.empty()) spatial_layout_ = s;
+      if (!AreIdenticalSpatialAccess(s, spatial_layout_)) {
+        Invalidate();
+        return;
+      }
     }
-    return true;
-  }
+    bool IsValid() { return is_valid_; }
+    void Invalidate() { is_valid_ = false; }
+    SpatialLayout GetValidSpatialLayout() {
+      if (!IsValid()) return {};
+      return spatial_layout_;
+    }
 
-  // Helper to break down the indices of buffer access
-  void DetectRegionIterMap(const BufferRegion& buffer_region, arith::Analyzer* analyzer) {
-    auto indices = RegionToIndices(buffer_region->region);
-    if (indices.empty()) {
-      LOG(WARNING) << "Buffer: " << buffer_region
-                   << " cannot be transformed because extent of indices is not 1";
+   private:
+    bool is_valid_;
+    SpatialLayout spatial_layout_;
+  };
+  void VisitStmt_(const BlockNode* op) final {
+    // Blocks with nested blocks cannot be handled yet.
+    LOG(WARNING) << "Found nested block";
+    can_transform_block_ = false;
+  }
+  void VisitStmt_(const BufferStoreNode* op) final {
+    StmtExprVisitor::VisitStmt_(op);
+
+    BufferAccessInfo& access_info = buffer_access_info_[op->buffer];
+
+    // Fast path to ignore further analysis if we know that the buffer access is invalid.
+    if (!access_info.IsValid()) return;
+
+    // Only single write buffer is supported for each block.
+    if (!op->buffer.same_as(block_->writes[0]->buffer)) {
+      access_info.Invalidate();
+      LOG(WARNING) << "unexpected write access to a different buffer";
+
+      can_transform_block_ = false;
       return;
     }
+
+    // If the write buffer access cannot be analyzed, no transformation to the block will be made.
+    auto detected_spatial_layout = DetectBufferAccessIterMap(op->indices);
+    if (detected_spatial_layout.empty()) {
+      access_info.Invalidate();
+      return;
+    }
+
+    // Check if we have access info for this buffer, if present, the two accesses must be
+    // identical.
+    access_info.Update(detected_spatial_layout);
+  }
+
+  void VisitExpr_(const BufferLoadNode* op) final {
+    Buffer read_buffer = op->buffer;
+    BufferAccessInfo& access_info = buffer_access_info_[op->buffer];
+
+    auto detected_spatial_layout = DetectBufferAccessIterMap(op->indices);
+
+    if (detected_spatial_layout.empty()) {
+      access_info.Invalidate();
+      return;
+    }
+    access_info.Update(detected_spatial_layout);
+  }
+
+  // Helper to break down the indices of buffer access.
+  SpatialLayout DetectBufferAccessIterMap(Array<PrimExpr> indices) {
     auto result = arith::DetectIterMap(
         /*indices=*/indices, /*input_iters*/ spatial_dom_,
         /*predicate*/ tir::const_true(),
-        /*check_level*/ arith::IterMapLevel::Surjective, /*analyzer*/ analyzer);
+        /*check_level*/ arith::IterMapLevel::Surjective, /*analyzer*/ &arith_analyzer_);
     if (result->indices.empty()) {
-      LOG(WARNING) << "Buffer: " << buffer_region << " cannot be transformed because "
-                   << result->errors;
+      LOG(WARNING) << "Failed to analyze indices " << indices << ", error: " << result->errors;
+      return {};
+    }
+    return GetSpatialLayout(result);
+  }
+
+  void ComputeDomain() {
+    for (const IterVar& v : block_->iter_vars) {
+      if (v->iter_type == kDataPar) {
+        spatial_dom_.Set(v->var, v->dom);
+        continue;
+      }
+      if (v->iter_type == kCommReduce) {
+        reduction_dom_.Set(v->var, v->dom);
+        continue;
+      }
+      // Unknown iter type
+      LOG(WARNING) << "Unable to compute domain of block";
+      can_transform_block_ = false;
       return;
     }
-    auto [is_supported, iterators] = GetIteratorAccess(result);
-    if (!is_supported) return;
-    buffer_to_iter_map_result_[buffer_region] = std::move(iterators);
   }
 
-  // Get the iterator access
-  std::tuple<bool, ArrayIterSetTy> GetIteratorAccess(const arith::IterMapResult& iter_map_result) {
-    ICHECK(!iter_map_result->indices.empty());
-    ArrayIterSetTy result;
-    for (const arith::IterSumExpr& index : iter_map_result->indices) {
-      IterMapAnalyzer index_analyzer;
-      auto iter_vars = index_analyzer.Analyze(index);
-      if (iter_vars.size() >= 2) return {false, {}};
-      if (iter_vars.empty()) {
-        result.push_back({});
-        continue;
-      }
-      // iter_vars.size() == 1
-      result.push_back(iter_vars[0]);
+ public:
+  bool CanBeTransformed() { return can_transform_block_; }
+  IndexMap GetBlockTransformation() { return block_transformation_; }
+  Map<Buffer, IndexMap> GetReadBufferTransformations() { return read_buffer_transformations_; }
+
+ private:
+  bool can_transform_block_;
+  IndexMap write_transformation_;
+  Map<tir::Var, Range> spatial_dom_;
+  Map<tir::Var, Range> reduction_dom_;
+  arith::Analyzer arith_analyzer_;
+
+  Block block_;
+  IndexMap block_transformation_;
+
+  Map<Buffer, IndexMap> read_buffer_transformations_;
+  std::unordered_map<Buffer, BufferAccessInfo, ObjectPtrHash, ObjectPtrEqual> buffer_access_info_;
+};  // namespace relax
+
+class PrimFuncAnalyzer : public StmtExprVisitor {
+ public:
+  explicit PrimFuncAnalyzer(const PrimFunc& func, Array<IndexMap> write_transformations) {
+    ICHECK(write_transformations.size() <= func->params.size())
+        << "Incompatible PrimFunc and write_transformations";
+
+    size_t first_write_index = func->params.size() - write_transformations.size();
+    for (size_t i = 0; i < write_transformations.size(); ++i) {
+      auto param = func->params[first_write_index + i];
+      Optional<Buffer> param_buf = func->buffer_map.Get(param);
+      ICHECK(param_buf.defined());
+      buffer_transformations_.Set(param_buf.value(), write_transformations[i]);
     }
-    return {true, result};
+    VisitStmt(func->body);
   }
+  Map<Block, Map<ObjectRef, IndexMap>> GetSuggestedTransforms() { return suggested_transforms_; }
 
-  bool IsSequentialAccess(const ArrayIterSetTy& iterators,
-                          const std::unordered_map<const tir::VarNode*, int>& iter_to_block_index) {
-    int last_value = -1;
-    for (const auto& i : iterators) {
-      if (!i.defined()) continue;
-      int blk_index = iter_to_block_index.at(i.value().get());
-      if (blk_index <= last_value) return false;
-      last_value = blk_index;
-    }
-    return true;
-  }
-
-  IndexMap GetTransformation(const ArrayIterSetTy& src_iterators,
-                             const IndexMap& src_transformation,
-                             const ArrayIterSetTy& tgt_iterators) {
-    // Copy over the src transformation intial and final indices
-    auto initial_indices = array_to_list(src_transformation->initial_indices);
-    auto final_indices = array_to_list(src_transformation->final_indices);
-
-    // Remove any indices on both sides
-    VarSet tgt_var_set;
-    for (const auto& i : tgt_iterators) {
-      if (i.defined()) tgt_var_set.insert(i.value());
-    }
-
-    // Drop vars that do not occur in tgt iterators
-    auto initial_indices_it = initial_indices.begin();
-    VarSet defs;
-    for (const auto& i : src_iterators) {
-      ICHECK(i.defined());
-      if (tgt_var_set.count(i.value())) {
-        defs.insert(*initial_indices_it);
-        initial_indices_it++;
-        continue;
-      }
-      initial_indices_it = initial_indices.erase(initial_indices_it);
-    }
-
-    // Erase any expressions in final indices that have undefined vars
-    auto final_indices_it = final_indices.begin();
-    while (final_indices_it != final_indices.end()) {
-      if (!HasUndefinedVars(*final_indices_it, defs)) {
-        final_indices_it++;
-        continue;
-      }
-      final_indices_it = final_indices.erase(final_indices_it);
-    }
-
-    VarSet src_var_set;
-    for (const auto& i : src_iterators) {
-      ICHECK(i.defined());
-      src_var_set.insert(i.value());
-    }
-
-    initial_indices_it = initial_indices.begin();
-    final_indices_it = final_indices.begin();
-    for (const auto& i : tgt_iterators) {
-      if (i.defined() && src_var_set.count(i.value())) {
-        initial_indices_it++;
-        if (final_indices_it != final_indices.end()) final_indices_it++;
-        continue;
-      }
-
-      auto v = tir::Var("dim");
-      initial_indices.insert(initial_indices_it, v);
-      final_indices.insert(final_indices_it, v);
-    }
-
-    auto ret = IndexMap(list_to_array(initial_indices), list_to_array(final_indices));
-    return ret;
-  }
+ private:
   void VisitStmt_(const BlockNode* op) final {
     if (op->name_hint == "root") {
       // Skip the root block
       StmtVisitor::VisitStmt_(op);
       return;
     }
-    // For now we can only transform functions with a single block.
-    if (block_.defined()) {
-      can_be_transformed_ = false;
-      return;
-    }
 
     Block block = GetRef<Block>(op);
-    block_ = block;
-    if (!IterVarsToDomain(block->iter_vars)) {
-      can_be_transformed_ = false;
-      return;
-    }
+    // Get block write buffer transformation.
+    if (block->writes.size() != 1) return;
+    auto write_buffer = block->writes[0]->buffer;
+    BlockAnalyzer block_analyzer(block, buffer_transformations_[write_buffer]);
 
-    // Only handle blocks which write to a single param buffer.
-    if (block->writes.size() != 1) {
-      can_be_transformed_ = false;
-    }
+    if (!block_analyzer.CanBeTransformed()) return;
+    // Collect the suggested transformations
+    Map<ObjectRef, IndexMap> suggested_block_transormations;
+    suggested_block_transormations.Set(block, block_analyzer.GetBlockTransformation());
 
-    // All the buffer access are quasi-affine expressions on spatial domain.
-    tvm::arith::Analyzer analyzer;
-    for (const auto& w : block->writes) DetectRegionIterMap(w, &analyzer);
-    if (can_be_transformed_ == false) return;
-    for (const auto& r : block->reads) DetectRegionIterMap(r, &analyzer);
-
-    // Get loop ordering in block iterators
-    std::unordered_map<const tir::VarNode*, IterVarType> iter_var_to_type;
-    int index = 0;
-    for (const auto& iter_var : block->iter_vars) {
-      iter_var_to_block_index_[iter_var->var.get()] = index++;
-      iter_var_to_type[iter_var->var.get()] = iter_var->iter_type;
+    for (const auto& [buffer, index_map] : block_analyzer.GetReadBufferTransformations()) {
+      suggested_block_transormations.Set(buffer, index_map);
     }
-
-    // Map from write indices to blk indices
-    // Write has sequential access
-    // This would mean that the mapping between spatial dom vars and their use in the buffer
-    // access is sequential.
-    auto write_region = block->writes[0];
-    auto it = buffer_to_iter_map_result_.find(write_region);
-    if (it == buffer_to_iter_map_result_.end()) {
-      can_be_transformed_ = false;
-      return;
-    }
-    auto write_access_iterators = it->second;
-    if (!IsSequentialAccess(write_access_iterators, iter_var_to_block_index_)) {
-      can_be_transformed_ = false;
-      return;
-    }
-    // Propose transformation of block
-    ArrayIterSetTy block_iterators;
-    for (const auto& i : block->iter_vars) {
-      block_iterators.push_back(i->var);
-    }
-    block_transformation_ =
-        GetTransformation(write_access_iterators, write_transformation_, block_iterators);
-
-    // Map from read indices to blk indices
-    for (const auto& r : block->reads) {
-      auto it = buffer_to_iter_map_result_.find(r);
-      if (it == buffer_to_iter_map_result_.end()) continue;
-      auto read_access_iterators = it->second;
-      if (!IsSequentialAccess(read_access_iterators, iter_var_to_block_index_)) continue;
-      if (read_buffer_transformation_.count(r->buffer)) continue;
-
-      auto read_transformation =
-          GetTransformation(write_access_iterators, write_transformation_, read_access_iterators);
-      read_buffer_transformation_.Set(r->buffer, read_transformation);
-    }
+    suggested_block_transormations.Set(write_buffer, buffer_transformations_[write_buffer]);
+    suggested_transforms_.Set(block, suggested_block_transormations);
   }
 
  private:
-  bool can_be_transformed_;
-  /*! \brief The buffers from function params. I.e. the input and output buffers. */
-  std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual> param_buffers_;
-  std::unordered_map<BufferRegion, ArrayIterSetTy, ObjectPtrHash, ObjectPtrEqual>
-      buffer_to_iter_map_result_;
-  Map<tir::Var, Range> spatial_dom_;
-  Map<tir::Var, Range> reduction_dom_;
-
-  std::unordered_map<const tir::VarNode*, int> iter_var_to_block_index_;
-  IndexMap write_transformation_;
-
- public:
-  Optional<Block> block_;
-  IndexMap block_transformation_;
-  Map<Buffer, IndexMap> read_buffer_transformation_;
-
- public:
-  bool CanBeTransformed() { return can_be_transformed_; }
-  Block GetBlock() {
-    ICHECK(block_.defined());
-    return block_.value();
-  }
-};
+  Map<Buffer, IndexMap> buffer_transformations_;
+  Map<Buffer, Block> buffer_to_block_;
+  Map<Block, Map<ObjectRef, IndexMap>> suggested_transforms_;
+};  // namespace relax
 
 Map<tir::Block, Map<ObjectRef, tir::IndexMap>> SuggestLayoutTransforms(
     const PrimFunc& prim_func, Array<IndexMap> write_buffer_transformations) {
-  Map<tir::Block, Map<ObjectRef, tir::IndexMap>> result;
   // No changes to the PrimFunc are required if no transformations on output buffers.
-  if (write_buffer_transformations.empty()) return result;
+  if (write_buffer_transformations.empty()) return {};
 
-  if (write_buffer_transformations.size() > 1) {
-    LOG(WARNING) << "PrimFunc with more than one outputs is not supported yet";
-    return result;
-  }
-  ICHECK(write_buffer_transformations.size() == 1);
-
-  PrimFuncAnalyzer analyzer(prim_func, write_buffer_transformations[0]);
-  analyzer(prim_func->body);
-  auto can_be_transformed = analyzer.CanBeTransformed();
-  if (!can_be_transformed) {
-    LOG(WARNING) << "Requested PrimFunc cannot be transformed";
-    return result;
-  }
-
-  Map<ObjectRef, IndexMap> block_result;
-
-  Block block = analyzer.GetBlock();
-  block_result.Set(block, analyzer.block_transformation_);
-  block_result.Set(block->writes[0]->buffer, write_buffer_transformations[0]);
-
-  for (const auto& read_buffer_region : block->reads) {
-    if (analyzer.read_buffer_transformation_.count(read_buffer_region->buffer) == 0) continue;
-    const auto& buffer_transformation =
-        analyzer.read_buffer_transformation_[read_buffer_region->buffer];
-    block_result.Set(read_buffer_region->buffer, buffer_transformation);
-  }
-  result.Set(block, block_result);
-  return result;
+  PrimFuncAnalyzer analyzer(prim_func, write_buffer_transformations);
+  return analyzer.GetSuggestedTransforms();
 }
 
 TVM_REGISTER_GLOBAL(("relax.analysis.suggest_layout_transforms"))

--- a/src/relax/analysis/layout_transformation.cc
+++ b/src/relax/analysis/layout_transformation.cc
@@ -23,18 +23,8 @@
  * the user provided layout transformations on it's outputs.
  */
 #include <tvm/arith/iter_affine_map.h>
-#include <tvm/ir/function.h>
 #include <tvm/relax/analysis.h>
-#include <tvm/relax/expr.h>
-#include <tvm/relax/transform.h>
-#include <tvm/relax/type.h>
-#include <tvm/tir/analysis.h>
-#include <tvm/tir/index_map.h>
 #include <tvm/tir/stmt_functor.h>
-
-#include <queue>
-
-#include "../../tir/schedule/analysis.h"
 
 namespace tvm {
 namespace relax {
@@ -42,7 +32,6 @@ namespace relax {
 using namespace tir;
 
 using VarSet = std::unordered_set<tir::Var, ObjectPtrHash, ObjectPtrEqual>;
-using SpatialLayout = Array<Optional<tir::Var>>;
 using VarToBlockIndexMap = std::unordered_map<tir::Var, int, ObjectPtrHash, ObjectPtrEqual>;
 using VarToIterTypeMap = std::unordered_map<tir::Var, IterVarType, ObjectPtrHash, ObjectPtrEqual>;
 
@@ -68,6 +57,19 @@ static inline std::list<T> array_to_list(Array<T> array) {
   return l;
 }
 
+/*! \brief Checks if `expr` is dependent on any var in `defs`*/
+static inline bool IsDependentOn(const PrimExpr& expr, const VarSet& vars) {
+  bool is_dependent = false;
+  tir::PostOrderVisit(expr, [&](const ObjectRef& node) {
+    if (const tir::VarNode* op = node.as<tir::VarNode>()) {
+      if (vars.count(GetRef<tir::Var>(op)) != 0) {
+        is_dependent = true;
+      }
+    }
+  });
+  return is_dependent;
+}
+
 /*! \brief Checks the PrimExpr for any vars not defined in `defs` */
 static inline bool HasUndefinedVars(const PrimExpr& expr, const VarSet& defs) {
   bool has_undefined_vars = false;
@@ -81,8 +83,22 @@ static inline bool HasUndefinedVars(const PrimExpr& expr, const VarSet& defs) {
   return has_undefined_vars;
 }
 
+/* Checks if a transformation is bijective affine over the given ranges*/
+static inline bool IsBijectiveAffine(const IndexMap& m, const Array<Range>& ranges) {
+  Map<tir::Var, Range> input_iters;
+  ICHECK_EQ(m->initial_indices.size(), ranges.size());
+  for (size_t i = 0; i < ranges.size(); i++) {
+    input_iters.Set(m->initial_indices[i], ranges[i]);
+  }
+  arith::Analyzer analyzer;
+  auto iter_map_result = DetectIterMap(m->final_indices, input_iters, /* predicate = */ 1,
+                                       /*check_level=*/arith::IterMapLevel::Bijective, &analyzer,
+                                       /*simplify_trivial_iterators=*/true);
+  return !iter_map_result->indices.empty();
+}
+
 /*! \brief Analyzes the indices returned from DetectIterMap analysis. It collects the spatial
- * iterator vars that are used in indices. This is important to get which spatial iter vars are
+ * iterators that are used in indices. This is important to get which spatial iter vars are
  * accessed in each index of buffer access.
  */
 class IndexAnalyzer : public ExprVisitor {
@@ -96,51 +112,55 @@ class IndexAnalyzer : public ExprVisitor {
   /*! \brief Override VisitExpr for iter expr type processing */
   void VisitExpr(const PrimExpr& expr) override {
     if (const auto* op = expr.as<arith::IterSumExprNode>()) {
-      Visit_(GetRef<arith::IterSumExpr>(op));
+      for (const auto& arg : op->args) VisitExpr(arg);
+      VisitExpr(op->base);
       return;
     }
     if (const auto* op = expr.as<arith::IterSplitExprNode>()) {
-      Visit_(GetRef<arith::IterSplitExpr>(op));
+      VisitIterMark(op->source);
+      VisitExpr(op->lower_factor);
+      VisitExpr(op->extent);
+      VisitExpr(op->scale);
       return;
     }
     return ExprVisitor::VisitExpr(expr);
   }
 
-  void Visit_(const arith::IterMark& op) {
-    if (const auto* var = op->source.as<tir::VarNode>()) {
+  void VisitIterMark(const arith::IterMark& op) {
+    if (const auto* var = op->source.as<tir::VarNode>())
       iterators_.push_back(GetRef<tir::Var>(var));
-      return;
-    }
-    VisitExpr(op->source);
+    else
+      VisitExpr(op->source);
     VisitExpr(op->extent);
-  }
-  void Visit_(const arith::IterSplitExpr& op) {
-    Visit_(op->source);
-    VisitExpr(op->lower_factor);
-    VisitExpr(op->extent);
-    VisitExpr(op->scale);
-    return;
-  }
-  void Visit_(const arith::IterSumExpr& op) {
-    for (const auto& arg : op->args) {
-      Visit_(arg);
-    }
-    VisitExpr(op->base);
-    return;
   }
 
  private:
   Array<tir::Var> iterators_;
 };
 
-/*! \brief Analyzes IterMapResult to get the spatial layout */
+/*! \brief Analyzes IterMapResult to get the Spatial Layout of buffer access. We define Spatial
+ * Layout of a buffer access as an array of length equal to the dimensions of the buffer. i-th
+ * element of Spatial Layout contains spatial iter var used from the block iteration domain. For
+ * indices, where no spatial iter vars are used, the spatial layout element is empty. If any of the
+ * buffer access indices use multiple spatial iter vars, the spatial layout is undefined.
+ * Here are a few examples of inferred spatial layout from buffer access. si denotes i-th spatial
+ * iter var, and ri denotes i-th reduction iter var.
+ * SpatialLayout(A[s0*constant, s1]) = {s0, s1}
+ * SpatialLayout(A[s0, constant, r0, s1]) = {s0, null, null, s1}
+ * SpatialLayout(A[s0 * c + s1]) = undefined
+ */
+using SpatialLayout = Array<Optional<tir::Var>>;
 static inline SpatialLayout GetSpatialLayout(const arith::IterMapResult& iter_map_result) {
   ICHECK(!iter_map_result->indices.empty());
   SpatialLayout result;
   for (const arith::IterSumExpr& index : iter_map_result->indices) {
     IndexAnalyzer index_analyzer;
     Array<tir::Var> iter_vars = index_analyzer.Analyze(index);
-    if (iter_vars.size() >= 2) return {};
+    if (iter_vars.size() >= 2) {
+      LOG(WARNING) << "Unable to get spatial layout of access: "
+                   << arith::NormalizeIterMapToExpr(index);
+      return {};
+    }
     if (iter_vars.empty()) {
       result.push_back({});
       continue;
@@ -163,7 +183,9 @@ static inline bool AreIdenticalSpatialAccess(const SpatialLayout& s0, const Spat
   return true;
 }
 
-/*! \brief Given the spatial layout and t*/
+/*! \brief Checks if the block accesses a buffer sequentially in terms of spatial dimensions
+ * (ignoring reduction iterators). It checks that the order of spatial iter vars in spatial layout
+ * of a buffer access is same as the order of spatial iter vars in block domain.*/
 static bool IsSequentialAccess(const SpatialLayout& iterators,
                                const VarToBlockIndexMap& iter_to_block_index) {
   int last_value = -1;
@@ -178,49 +200,70 @@ static bool IsSequentialAccess(const SpatialLayout& iterators,
   return true;
 }
 
-/*! \brief Checks if two IndexMap transforms are identical*/
+/*! \brief Checks if two IndexMaps represent identical transforms*/
 static inline bool AreIdenticalTransforms(const IndexMap& t0, const IndexMap& t1) {
-  LOG(INFO) << "Comparing index maps: " << t0 << " :: " << t1;
   if (t0->initial_indices.size() != t1->initial_indices.size()) return false;
   if (t0->final_indices.size() != t1->final_indices.size()) return false;
-  if (t0->initial_indices.empty()) return false;
 
   // Create a new shape expression.
-  Array<PrimExpr> indices;
-  for (size_t i = 0; i < t0->initial_indices.size(); ++i) indices.push_back(tir::Var("d"));
-  LOG(INFO) << indices;
-  auto t0_output = t0->MapIndices(indices);
-  auto t1_output = t1->MapIndices(indices);
+  Array<PrimExpr> t1_initial_indices =
+      t1->initial_indices.Map([](tir::Var i) -> PrimExpr { return i; });
+  auto t0_output = t0->MapIndices(t1_initial_indices);
+  arith::Analyzer analyzer;
   for (size_t i = 0; i < t0_output.size(); ++i) {
-    LOG(INFO) << "Comparing expr: " << t0_output[i] << " :: " << t1_output[i];
-    if (!t0_output[i].same_as(t1_output[i])) {
-      LOG(INFO) << "Not identical";
-      return false;
-    }
+    if (!analyzer.CanProveEqual(t0_output[i], t1->final_indices[i])) return false;
   }
   return true;
 }
 
-static IndexMap GetTransformation(const SpatialLayout& src_spatial_layout,
-                                  const IndexMap& src_transformation,
-                                  const SpatialLayout& tgt_spatial_layout) {
+/*! Given the source buffer spatial layout and its transformation, this function infers the
+ * transformation for the target buffer whose spatial layout is given as `tgt_spatial_layout`. The
+ * algorithm used is as follows. We start by copying over the source transformation.
+ *
+ * For example, let's say the source transformation is lambda N, C, H, W -> (N, H, W, C // 4, C %
+ * 4), source spatial layout is 'NCHW' and target spatial layout is 'KCHW'.
+ *
+ * Step 1
+ * Copy over the source transformation initial & final indices to target transformation initial
+ * and final indices.
+ * target transformation = lambda N, C, H, W -> (N, H, W, C // 4, C %4)
+ *
+ * Step 2
+ * Drop any vars from initial indices which do not occur in target buffer using source and target
+ * spatial layouts.
+ * target transformation = lambda C, H, W -> (N, H, W, C // 4, C %4)
+ *
+ * Step 3
+ * Erase any expression from final indices which is dependent on a var not present in initial
+ * indices. target transformation = lambda C, H, W -> (H, W, C // 4, C %4)
+ *
+ * Step 4
+ * Go over the target spatial layout and add any missing dims to both initial and final indices.
+ * This is done by checking if any iterator in target spatial layout is not present in source
+ * spatial layout.
+ * target transformation = lambda dim, C, H, W -> (dim, H, W, C // 4, C %4)
+ */
+static Optional<IndexMap> InferLayoutTransformation(const SpatialLayout& src_spatial_layout,
+                                                    const IndexMap& src_transformation,
+                                                    const SpatialLayout& tgt_spatial_layout) {
   // Copy over the src transformation intial and final indices
   auto initial_indices = array_to_list(src_transformation->initial_indices);
   auto final_indices = array_to_list(src_transformation->final_indices);
 
-  // Remove any indices on both sides
+  // Get the iterator var set used in target spatial layout.
   VarSet tgt_var_set;
   for (const auto& i : tgt_spatial_layout) {
     if (i.defined()) tgt_var_set.insert(i.value());
   }
 
-  // Drop vars that do not occur in tgt iterators
+  // Erase initial indices corresponding to iter vars that do not occur in target spatial layout.
+  // Also compute the var set of initial indices.
   auto initial_indices_it = initial_indices.begin();
-  VarSet defs;
+  VarSet initial_indices_var_set;
   for (const auto& i : src_spatial_layout) {
     ICHECK(i.defined());
     if (tgt_var_set.count(i.value())) {
-      defs.insert(*initial_indices_it);
+      initial_indices_var_set.insert(*initial_indices_it);
       initial_indices_it++;
       continue;
     }
@@ -230,13 +273,27 @@ static IndexMap GetTransformation(const SpatialLayout& src_spatial_layout,
   // Erase any expressions in final indices that have undefined vars
   auto final_indices_it = final_indices.begin();
   while (final_indices_it != final_indices.end()) {
-    if (!HasUndefinedVars(*final_indices_it, defs)) {
+    if (!HasUndefinedVars(*final_indices_it, initial_indices_var_set)) {
       final_indices_it++;
       continue;
+    }
+    // We are about to drop this expr from final indices since it has undefined vars. Check if it is
+    // dependent on any of the initial indices. If it is dependent, this cannot be dropped and we
+    // bail by returning null.
+    // This captures the scenario where the source transformation is unpacking a dimension (e.g,
+    // "H4h" -> "H*4+h" ) and the buffer we are trying to infer the transformation of has 'h'
+    // dimension, but not 'H'. So, it is dependent on undefined var 'H' and defined var 'h'.
+    if (IsDependentOn(*final_indices_it, initial_indices_var_set)) {
+      LOG(WARNING)
+          << "[LayoutInference] Buffer access is dependent on both defined and undefined vars";
+      return {};
     }
     final_indices_it = final_indices.erase(final_indices_it);
   }
 
+  // Go over the target spatial layout and add any missing dims to both initial and final indices.
+  // This is done by checking if any iterator in target spatial layout is not present in source
+  // spatial layout.
   VarSet src_var_set;
   for (const auto& i : src_spatial_layout) {
     ICHECK(i.defined());
@@ -252,25 +309,42 @@ static IndexMap GetTransformation(const SpatialLayout& src_spatial_layout,
       continue;
     }
 
-    auto v = tir::Var("dim");
-    initial_indices.insert(initial_indices_it, v);
-    final_indices.insert(final_indices_it, v);
+    auto new_dim = tir::Var("d");
+    initial_indices.insert(initial_indices_it, new_dim);
+    final_indices.insert(final_indices_it, new_dim);
   }
 
-  auto ret = IndexMap(list_to_array(initial_indices), list_to_array(final_indices));
-  return ret;
+  return IndexMap(list_to_array(initial_indices), list_to_array(final_indices));
 }
+
+/*! \brief Analyzes the Block and given output buffer transformations to propose
+ * transformations of block and read buffers. It does a best effort analysis to
+ * propose transformations which would preserve sequential access to buffers (especially output
+ * buffers). Since this is best effort, it is possible that the Block is too complex for
+ * analysis. In such a case, no transformations are proposed.
+ * Limitations:
+ * 1. Expects exactly one write buffer in the block whose transformation is given by
+ * `write_transformation`.
+ * 2. Expects write buffer access to be affine and only use spatial iterators of the block.
+ * 3. Proposes transformations to a read buffer if all access to it are affine.
+ */
 class BlockAnalyzer : public StmtExprVisitor {
  public:
-  explicit BlockAnalyzer(const Block& block, IndexMap write_transformation)
-      : can_transform_block_(true), write_transformation_(write_transformation), block_(block) {
+  explicit BlockAnalyzer(const Block& block, const Map<Buffer, IndexMap>& transformation_cache,
+                         IndexMap write_transformation)
+      : can_transform_block_(true),
+        write_transformation_(write_transformation),
+        block_(block),
+        buffer_transformation_cache_(transformation_cache) {
     ICHECK(block_->writes.size() == 1);
-    ComputeDomain();
+    auto write_buffer = block_->writes[0]->buffer;
 
-    // Get load/store access patterns
+    ComputeBlockSpatialDomain();
+
+    // Visit the block body to collect load/store access patterns of different buffers.
     VisitStmt(block_->body);
 
-    // While visiting the load/store patterns it is possible we see an unexpected pattern, such as
+    // While visiting the load/store accesses it is possible we see an unexpected pattern, such as
     // nested block or write access to multiple buffers. In such a case, we can return early as we
     // would not be making any layout suggesstions.
     if (!can_transform_block_) {
@@ -278,7 +352,7 @@ class BlockAnalyzer : public StmtExprVisitor {
       return;
     }
 
-    // Get loop ordering in block iterators
+    // Get iterator ordering, it's types and it's spatial layout.
     VarToIterTypeMap iter_var_to_type;
     VarToBlockIndexMap iter_var_to_block_index;
     SpatialLayout block_spatial_layout;
@@ -290,6 +364,7 @@ class BlockAnalyzer : public StmtExprVisitor {
       block_spatial_layout.push_back(var);
     }
 
+    // Helper to get the spatial layout of buffer from buffer access map.
     auto get_spatial_layout = [&](Buffer b) -> SpatialLayout {
       auto it = buffer_access_info_.find(b);
       if (it == buffer_access_info_.end()) {
@@ -299,8 +374,7 @@ class BlockAnalyzer : public StmtExprVisitor {
       return access_info.GetValidSpatialLayout();
     };
 
-    auto write_buffer = block_->writes[0]->buffer;
-
+    // Check that write has sequential access within the block.
     const auto& write_spatial_layout = get_spatial_layout(write_buffer);
     if (write_spatial_layout.empty()) {
       can_transform_block_ = false;
@@ -311,32 +385,47 @@ class BlockAnalyzer : public StmtExprVisitor {
       return;
     }
 
-    block_transformation_ =
-        GetTransformation(write_spatial_layout, write_transformation_, block_spatial_layout);
-    Array<Range> block_iter_ranges;
-    for (const auto& iter_var : block_->iter_vars) {
-      block_iter_ranges.push_back(iter_var->dom);
-    }
-    Array<Range> block_ranges = block_->iter_vars.Map([](const IterVar& i) { return i->dom; });
-    try {
-      block_transformation_.Inverse(block_ranges);
-    } catch (...) {
-      LOG(WARNING) << "Inferred block transformation is not bijective affine";
+    // Infer Block transformation from write buffer transformation.
+    auto maybe_block_transformation = InferLayoutTransformation(
+        write_spatial_layout, write_transformation_, block_spatial_layout);
+    if (!maybe_block_transformation.defined()) {
       can_transform_block_ = false;
       return;
     }
+    block_transformation_ = maybe_block_transformation.value();
 
+    Array<Range> block_ranges = block_->iter_vars.Map([](const IterVar& i) { return i->dom; });
+    if (!IsBijectiveAffine(block_transformation_, block_ranges)) {
+      can_transform_block_ = false;
+      LOG(WARNING) << "Inferred block transformation is not bijective affine, transformation: ("
+                   << block_transformation_ << ") over range (" << block_ranges << ")";
+      return;
+    }
+
+    // Infer read buffer transformations from write buffer transformation.
     for (const auto& r : block->reads) {
       const auto& read_spatial_layout = get_spatial_layout(r->buffer);
       if (read_spatial_layout.empty()) continue;
       if (!IsSequentialAccess(read_spatial_layout, iter_var_to_block_index)) continue;
-      auto read_transformation =
-          GetTransformation(write_spatial_layout, write_transformation_, read_spatial_layout);
+
+      auto maybe_read_transformation = InferLayoutTransformation(
+          write_spatial_layout, write_transformation_, read_spatial_layout);
+      if (!maybe_read_transformation.defined()) continue;
+      IndexMap read_transformation = maybe_read_transformation.value();
+      if (buffer_transformation_cache_.count(r->buffer) != 0) {
+        if (!AreIdenticalTransforms(read_transformation, buffer_transformation_cache_[r->buffer]))
+          LOG(WARNING) << "Buffer: " << r->buffer
+                       << " has conflicting transform proposals -- (preferred) "
+                       << buffer_transformation_cache_[r->buffer] << " vs. " << read_transformation;
+        continue;
+      }
       read_buffer_transformations_.Set(r->buffer, read_transformation);
     }
   }
 
  private:
+  // Helper class to keep track of spatial layout of buffer as we visit multiple accesses to this
+  // buffer within the block.
   class BufferAccessInfo {
    public:
     BufferAccessInfo() : is_valid_(true) {}
@@ -359,6 +448,35 @@ class BlockAnalyzer : public StmtExprVisitor {
     bool is_valid_;
     SpatialLayout spatial_layout_;
   };
+
+  // Helper to break down the indices of buffer access.
+  SpatialLayout DetectBufferAccessIterMap(Array<PrimExpr> indices) {
+    auto result = arith::DetectIterMap(
+        /*indices=*/indices, /*input_iters*/ spatial_dom_,
+        /*predicate*/ 1, /*check_level*/ arith::IterMapLevel::NoCheck, &arith_analyzer_);
+    if (result->indices.empty()) {
+      LOG(WARNING) << "Failed to analyze indices " << indices << ", error: " << result->errors;
+      return {};
+    }
+    return GetSpatialLayout(result);
+  }
+
+  // Compute the spatial domain map of block
+  void ComputeBlockSpatialDomain() {
+    for (const IterVar& v : block_->iter_vars) {
+      if (v->iter_type == kDataPar) {
+        spatial_dom_.Set(v->var, v->dom);
+        continue;
+      }
+      if (v->iter_type == kCommReduce) continue;
+      LOG(WARNING)
+          << "Cannot compute block spatial domain in presence of unknown block iter_type : "
+          << v->iter_type;
+      can_transform_block_ = false;
+      return;
+    }
+  }
+
   void VisitStmt_(const BlockNode* op) final {
     // Blocks with nested blocks cannot be handled yet.
     LOG(WARNING) << "Found nested block";
@@ -376,7 +494,6 @@ class BlockAnalyzer : public StmtExprVisitor {
     if (!op->buffer.same_as(block_->writes[0]->buffer)) {
       access_info.Invalidate();
       LOG(WARNING) << "unexpected write access to a different buffer";
-
       can_transform_block_ = false;
       return;
     }
@@ -406,36 +523,6 @@ class BlockAnalyzer : public StmtExprVisitor {
     access_info.Update(detected_spatial_layout);
   }
 
-  // Helper to break down the indices of buffer access.
-  SpatialLayout DetectBufferAccessIterMap(Array<PrimExpr> indices) {
-    auto result = arith::DetectIterMap(
-        /*indices=*/indices, /*input_iters*/ spatial_dom_,
-        /*predicate*/ tir::const_true(),
-        /*check_level*/ arith::IterMapLevel::Surjective, /*analyzer*/ &arith_analyzer_);
-    if (result->indices.empty()) {
-      LOG(WARNING) << "Failed to analyze indices " << indices << ", error: " << result->errors;
-      return {};
-    }
-    return GetSpatialLayout(result);
-  }
-
-  void ComputeDomain() {
-    for (const IterVar& v : block_->iter_vars) {
-      if (v->iter_type == kDataPar) {
-        spatial_dom_.Set(v->var, v->dom);
-        continue;
-      }
-      if (v->iter_type == kCommReduce) {
-        reduction_dom_.Set(v->var, v->dom);
-        continue;
-      }
-      // Unknown iter type
-      LOG(WARNING) << "Unable to compute domain of block";
-      can_transform_block_ = false;
-      return;
-    }
-  }
-
  public:
   bool CanBeTransformed() { return can_transform_block_; }
   IndexMap GetBlockTransformation() { return block_transformation_; }
@@ -445,20 +532,26 @@ class BlockAnalyzer : public StmtExprVisitor {
   bool can_transform_block_;
   IndexMap write_transformation_;
   Map<tir::Var, Range> spatial_dom_;
-  Map<tir::Var, Range> reduction_dom_;
   arith::Analyzer arith_analyzer_;
 
   Block block_;
   IndexMap block_transformation_;
 
   Map<Buffer, IndexMap> read_buffer_transformations_;
+  const Map<Buffer, IndexMap>& buffer_transformation_cache_;
   std::unordered_map<Buffer, BufferAccessInfo, ObjectPtrHash, ObjectPtrEqual> buffer_access_info_;
-};  // namespace relax
+};
 
+/*! \brief Analyzes the PrimFunc and user provided output buffer transformations to propose
+ * transformations of block and buffers within the PrimFunc. It does a best effort analysis to
+ * propose transformations which would preserve sequential access to buffers (especially output
+ * buffers). Since this is best effort, it is possible that the PrimFunc is too complex for
+ * analysis. In such a case, no transformations are proposed.
+ */
 class PrimFuncAnalyzer : public StmtExprVisitor {
  public:
   explicit PrimFuncAnalyzer(const PrimFunc& func, Array<IndexMap> write_transformations) {
-    ICHECK(write_transformations.size() <= func->params.size())
+    ICHECK_LE(write_transformations.size(), func->params.size())
         << "Incompatible PrimFunc and write_transformations";
 
     size_t first_write_index = func->params.size() - write_transformations.size();
@@ -466,11 +559,24 @@ class PrimFuncAnalyzer : public StmtExprVisitor {
       auto param = func->params[first_write_index + i];
       Optional<Buffer> param_buf = func->buffer_map.Get(param);
       ICHECK(param_buf.defined());
-      buffer_transformations_.Set(param_buf.value(), write_transformations[i]);
+      ICHECK_EQ(param_buf.value()->shape.size(), write_transformations[i]->initial_indices.size())
+          << "Mismatch between output buffer shape and index map";
+      buffer_transformation_cache_.Set(param_buf.value(), write_transformations[i]);
     }
     VisitStmt(func->body);
   }
-  Map<Block, Map<ObjectRef, IndexMap>> GetSuggestedTransforms() { return suggested_transforms_; }
+  Map<Block, Map<ObjectRef, IndexMap>> GetSuggestedTransforms() {
+    Map<Block, Map<ObjectRef, IndexMap>> result;
+    for (const auto& [block, index_map] : block_transformations_) {
+      Map<ObjectRef, IndexMap> block_transformations;
+      block_transformations.Set(block, index_map);
+      for (const auto& buffer : block_to_buffer_[block]) {
+        block_transformations.Set(buffer, buffer_transformation_cache_[buffer]);
+      }
+      result.Set(block, block_transformations);
+    }
+    return result;
+  }
 
  private:
   void VisitStmt_(const BlockNode* op) final {
@@ -484,25 +590,29 @@ class PrimFuncAnalyzer : public StmtExprVisitor {
     // Get block write buffer transformation.
     if (block->writes.size() != 1) return;
     auto write_buffer = block->writes[0]->buffer;
-    BlockAnalyzer block_analyzer(block, buffer_transformations_[write_buffer]);
+    block_to_buffer_[block].push_back(write_buffer);
+    BlockAnalyzer block_analyzer(block, buffer_transformation_cache_,
+                                 buffer_transformation_cache_[write_buffer]);
 
     if (!block_analyzer.CanBeTransformed()) return;
     // Collect the suggested transformations
-    Map<ObjectRef, IndexMap> suggested_block_transormations;
-    suggested_block_transormations.Set(block, block_analyzer.GetBlockTransformation());
+    block_transformations_.Set(block, block_analyzer.GetBlockTransformation());
 
     for (const auto& [buffer, index_map] : block_analyzer.GetReadBufferTransformations()) {
-      suggested_block_transormations.Set(buffer, index_map);
+      // BlockAnalyzer makes sure that it does not propose transformation for a buffer for which a
+      // transformation has already been proposed by other blocks or by write_transformations which
+      // are input to this analysis.
+      ICHECK_EQ(buffer_transformation_cache_.count(buffer), 0);
+      buffer_transformation_cache_.Set(buffer, index_map);
+      block_to_buffer_[block].push_back(buffer);
     }
-    suggested_block_transormations.Set(write_buffer, buffer_transformations_[write_buffer]);
-    suggested_transforms_.Set(block, suggested_block_transormations);
   }
 
  private:
-  Map<Buffer, IndexMap> buffer_transformations_;
-  Map<Buffer, Block> buffer_to_block_;
-  Map<Block, Map<ObjectRef, IndexMap>> suggested_transforms_;
-};  // namespace relax
+  Map<Buffer, IndexMap> buffer_transformation_cache_;
+  Map<Block, IndexMap> block_transformations_;
+  std::unordered_map<Block, Array<Buffer>, ObjectPtrHash, ObjectPtrEqual> block_to_buffer_;
+};
 
 Map<tir::Block, Map<ObjectRef, tir::IndexMap>> SuggestLayoutTransforms(
     const PrimFunc& prim_func, Array<IndexMap> write_buffer_transformations) {

--- a/src/support/array.h
+++ b/src/support/array.h
@@ -21,6 +21,7 @@
 #include <tvm/ir/expr.h>
 #include <tvm/runtime/container/array.h>
 
+#include <list>
 #include <vector>
 
 namespace tvm {
@@ -81,10 +82,34 @@ inline std::vector<TDst> AsVector(const Array<TSrc>& vec);
  * \brief Convert a std::vector to tvm::runtime::Array
  * \tparam TSrc The type of elements in the source vector
  * \tparam TDst The type of elements in the result Array
- * \return The result vector
+ * \return The result Array
  */
 template <class TSrc, class TDst>
 inline Array<TDst> AsArray(const std::vector<TSrc>& vec);
+
+/*!
+ * \brief Convert a tvm::runtime::Array to std::list
+ * \tparam T The type of elements in the source array
+ * \return The result list
+ */
+template <class T>
+inline std::list<T> AsList(const Array<T>& array) {
+  std::list<T> list;
+  for (const auto& v : array) list.push_back(v);
+  return list;
+}
+
+/*!
+ * \brief Convert a std::list to tvm::runtime::Array
+ * \tparam T The type of elements in the source list
+ * \return The result list
+ */
+template <class T>
+inline Array<T> AsArray(const std::list<T>& list) {
+  Array<T> array;
+  for (const auto& v : list) array.push_back(v);
+  return array;
+}
 
 /*!
  * \brief Get the shape tuple as array

--- a/tests/python/relax/test_analysis_suggest_layout_transforms.py
+++ b/tests/python/relax/test_analysis_suggest_layout_transforms.py
@@ -825,3 +825,7 @@ def test_op_split_tiling_split_dim():
     )
     after = apply_transformations(before, suggested_transforms)
     tvm.ir.assert_structural_equal(after, expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_analysis_suggest_layout_transforms.py
+++ b/tests/python/relax/test_analysis_suggest_layout_transforms.py
@@ -258,10 +258,10 @@ def test_SRSR_block():
 def test_op_elemwise_symbolic():
     @T.prim_func
     def before(arg: T.handle, relu: T.handle):
-        N = T.var("int64")
-        C = T.var("int64")
-        H = T.var("int64")
-        W = T.var("int64")
+        N = T.int64()
+        C = T.int64()
+        H = T.int64()
+        W = T.int64()
         Arg = T.match_buffer(arg, (N, C, H, W))
         Relu = T.match_buffer(relu, (N, C, H, W))
         for i0, i1, i2, i3 in T.grid(N, C, H, W):
@@ -273,10 +273,10 @@ def test_op_elemwise_symbolic():
 
     @T.prim_func
     def expected(arg: T.handle, relu: T.handle):
-        N = T.var("int64")
-        H = T.var("int64")
-        W = T.var("int64")
-        C = T.var("int64")
+        N = T.int64()
+        C = T.int64()
+        H = T.int64()
+        W = T.int64()
         Arg = T.match_buffer(arg, (N, H, W, C))
         Relu = T.match_buffer(relu, (N, H, W, C))
         # with T.block("root"):

--- a/tests/python/relax/test_analysis_suggest_layout_transforms.py
+++ b/tests/python/relax/test_analysis_suggest_layout_transforms.py
@@ -1,0 +1,509 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+import tvm.testing
+
+from typing import Callable, Any
+from tvm import relay, topi
+from tvm import relax, tir
+from tvm.script import relax as R, tir as T, ir as I
+
+
+def apply_transformations(func, suggested_transfoms):
+    sch = tir.Schedule(func)
+    for block, per_block_transformations in suggested_transfoms.items():
+        blockrv = sch.get_block(block.name_hint)
+        for obj, index_map in per_block_transformations.items():
+            if isinstance(obj, tir.Block):
+                block_name = obj.name_hint
+                print("Block transformation: ", block_name, " :: ", index_map)
+                sch.transform_block_layout(block_name, index_map)
+            elif isinstance(obj, tir.Buffer):
+                buffer = obj
+                print("Buffer transformation: ", buffer, " :: ", index_map)
+                sch.transform_layout(blockrv, buffer, index_map)
+            else:
+                print("Unknown object: ", obj)
+                return
+    return sch.mod["main"]
+
+
+def test_op_elemwise():
+    @T.prim_func
+    def before(
+        arg: T.Buffer((32, 64, 224, 224), "float32"),
+        relu: T.Buffer((32, 64, 224, 224), "float32"),
+    ):
+        for i0, i1, i2, i3 in T.grid(32, 64, 224, 224):
+            with T.block("compute"):
+                v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                T.reads(arg[v_i0, v_i1, v_i2, v_i3])
+                T.writes(relu[v_i0, v_i1, v_i2, v_i3])
+                relu[v_i0, v_i1, v_i2, v_i3] = T.max(arg[v_i0, v_i1, v_i2, v_i3], T.float32(0))
+
+    @T.prim_func
+    def expected(
+        arg: T.Buffer((32, 224, 224, 64), "float32"),
+        relu: T.Buffer((32, 224, 224, 64), "float32"),
+    ):
+        for ax0, ax1, ax2, ax3 in T.grid(32, 224, 224, 64):
+            with T.block("compute"):
+                v0, v1, v2, v3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(arg[v0, v1, v2, v3])
+                T.writes(relu[v0, v1, v2, v3])
+                relu[v0, v1, v2, v3] = T.max(arg[v0, v1, v2, v3], T.float32(0))
+
+    suggested_transforms = relax.analysis.suggest_layout_transforms(
+        func=before, write_buffer_transforms=[lambda n, c, h, w: (n, h, w, c)]
+    )
+    after = apply_transformations(before, suggested_transforms)
+    tvm.ir.assert_structural_equal(after, expected)
+
+
+def test_op_pool_nchw_nhwc():
+    @T.prim_func
+    def before(
+        arg: T.Buffer((32, 64, 224, 224), "float32"),
+        pool_max: T.Buffer((32, 64, 111, 223), "float32"),
+    ):
+        for ax0, ax1, ax2, ax3, rv0, rv1 in T.grid(32, 64, 111, 223, 2, 2):
+            with T.block("pool_max"):
+                v_ax0, v_ax1, v_ax2, v_ax3, v_rv0, v_rv1 = T.axis.remap(
+                    "SSSSRR", [ax0, ax1, ax2, ax3, rv0, rv1]
+                )
+                T.reads(
+                    arg[
+                        v_ax0,
+                        v_ax1,
+                        v_ax2 * 2 + v_rv0 * 2,
+                        v_ax3 + v_rv1,
+                    ]
+                )
+                T.writes(pool_max[v_ax0, v_ax1, v_ax2, v_ax3])
+                T.block_attr({"schedule_rule": "meta_schedule.pool_max"})
+                with T.init():
+                    pool_max[v_ax0, v_ax1, v_ax2, v_ax3] = T.float32(-3.4028234663852886e38)
+                pool_max[v_ax0, v_ax1, v_ax2, v_ax3] = T.max(
+                    pool_max[v_ax0, v_ax1, v_ax2, v_ax3],
+                    arg[
+                        v_ax0,
+                        v_ax1,
+                        v_ax2 * 2 + v_rv0 * 2,
+                        v_ax3 + v_rv1,
+                    ],
+                )
+
+    @T.prim_func
+    def expected(
+        arg: T.Buffer((32, 224, 224, 64), "float32"),
+        pool_max: T.Buffer((32, 111, 223, 64), "float32"),
+    ):
+        # with T.block("root"):
+        for ax0, ax1, ax2, ax3, ax4, ax5 in T.grid(32, 111, 223, 64, 2, 2):
+            with T.block("pool_max"):
+                v0, v1, v2, v3, v4, v5 = T.axis.remap("SSSSRR", [ax0, ax1, ax2, ax3, ax4, ax5])
+                T.reads(arg[v0, v1 * 2 + v4 * 2, v2 + v5, v3])
+                T.writes(pool_max[v0, v1, v2, v3])
+                T.block_attr({"schedule_rule": "meta_schedule.pool_max"})
+                with T.init():
+                    pool_max[v0, v1, v2, v3] = T.float32(-3.4028234663852886e38)
+                pool_max[v0, v1, v2, v3] = T.max(
+                    pool_max[v0, v1, v2, v3],
+                    arg[v0, v1 * 2 + v4 * 2, v2 + v5, v3],
+                )
+
+    suggested_transforms = relax.analysis.suggest_layout_transforms(
+        func=before,
+        write_buffer_transforms=[lambda n, c, h, w: (n, h, w, c)],
+    )
+    after = apply_transformations(before, suggested_transforms)
+    tvm.ir.assert_structural_equal(after, expected)
+
+
+def test_op_pool_nchw16c_nhwc():
+    @T.prim_func
+    def before(
+        arg: T.Buffer(
+            (32, 4, 224, 224, 16),
+            "float32",
+        ),
+        pool_max: T.Buffer(
+            (32, 4, 110, 220, 16),
+            "float32",
+        ),
+    ):
+        for ax0, ax1, ax2, ax3, ax4, rv0, rv1 in T.grid(32, 4, 110, 220, 16, 5, 5):
+            with T.block("pool_max"):
+                v_ax0, v_ax1, v_ax2, v_ax3, v_ax4, v_rv0, v_rv1 = T.axis.remap(
+                    "SSSSSRR", [ax0, ax1, ax2, ax3, ax4, rv0, rv1]
+                )
+                T.reads(arg[v_ax0, v_ax1, v_ax2 * 2 + v_rv0, v_ax3 + v_rv1, v_ax4])
+                T.writes(pool_max[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4])
+                T.block_attr({"schedule_rule": "meta_schedule.pool_max"})
+                with T.init():
+                    pool_max[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = T.float32(-3.4028234663852886e38)
+                pool_max[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = T.max(
+                    pool_max[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4],
+                    arg[v_ax0, v_ax1, v_ax2 * 2 + v_rv0, v_ax3 + v_rv1, v_ax4],
+                )
+
+    @T.prim_func
+    def expected(
+        arg: T.Buffer((32, 224, 224, 64), "float32"),
+        pool_max: T.Buffer((32, 110, 220, 64), "float32"),
+    ):
+        for ax0, ax1, ax2, ax3, ax4, ax5 in T.grid(32, 110, 220, 64, 5, 5):
+            with T.block("pool_max"):
+                v0, v1, v2, v3, v4, v5 = T.axis.remap("SSSSRR", [ax0, ax1, ax2, ax3, ax4, ax5])
+                T.reads(arg[v0, v1 * 2 + v4, v2 + v5, v3])
+                T.writes(pool_max[v0, v1, v2, v3])
+                T.block_attr({"schedule_rule": "meta_schedule.pool_max"})
+                with T.init():
+                    pool_max[v0, v1, v2, v3] = T.float32(-3.4028234663852886e38)
+                pool_max[v0, v1, v2, v3] = T.max(
+                    pool_max[v0, v1, v2, v3],
+                    arg[v0, v1 * 2 + v4, v2 + v5, v3],
+                )
+
+    suggested_transforms = relax.analysis.suggest_layout_transforms(
+        func=before,
+        write_buffer_transforms=[lambda n, C, h, w, c: (n, h, w, C * 16 + c)],
+    )
+    after = apply_transformations(before, suggested_transforms)
+    tvm.ir.assert_structural_equal(after, expected)
+
+
+def test_op_reduce():
+    @T.prim_func
+    def before(
+        arg: T.Buffer((32, 64, 224, 224), "float32"),
+        sum: T.Buffer((32, 64), "float32"),
+    ):
+        for ax0, ax1, k2, k3 in T.grid(32, 64, 224, 224):
+            with T.block("rxplaceholder_red"):
+                v_ax0, v_ax1, v_k2, v_k3 = T.axis.remap("SSRR", [ax0, ax1, k2, k3])
+                T.reads(arg[v_ax0, v_ax1, v_k2, v_k3])
+                T.writes(sum[v_ax0, v_ax1])
+                with T.init():
+                    sum[v_ax0, v_ax1] = T.float32(0)
+                sum[v_ax0, v_ax1] = sum[v_ax0, v_ax1] + arg[v_ax0, v_ax1, v_k2, v_k3]
+
+    @T.prim_func
+    def expected(
+        arg: T.Buffer((32, 4, 224, 224, 16), "float32"),
+        sum: T.Buffer((32, 4, 16), "float32"),
+    ):
+        for ax0, ax1, ax2, ax3, ax4 in T.grid(32, 4, 224, 224, 16):
+            with T.block("rxplaceholder_red"):
+                v0, v1, v2, v3, v4 = T.axis.remap("SSRRS", [ax0, ax1, ax2, ax3, ax4])
+                T.reads(arg[v0, v1, v2, v3, v4])
+                T.writes(sum[v0, v1, v4])
+                with T.init():
+                    sum[v0, v1, v4] = T.float32(0)
+                sum[v0, v1, v4] = sum[v0, v1, v4] + arg[v0, v1, v2, v3, v4]
+
+    suggested_transforms = relax.analysis.suggest_layout_transforms(
+        func=before, write_buffer_transforms=[lambda n, c: (n, c // 16, c % 16)]
+    )
+    after = apply_transformations(before, suggested_transforms)
+    tvm.ir.assert_structural_equal(after, expected)
+
+
+def test_op_upsampling():
+    # relay materializes the layout if H, W or D dimensions are moved or tiled.
+    @T.prim_func
+    def before(
+        arg: T.Buffer((32, 64, 224, 224), "float32"),
+        resize: T.Buffer((32, 64, 202, 246), "float32"),
+    ):
+        for i0, i1, i2, i3 in T.grid(32, 64, 202, 246):
+            with T.block("resize"):
+                v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                T.reads(arg[v_i0, v_i1, 0:224, 0:224])
+                T.writes(resize[v_i0, v_i1, v_i2, v_i3])
+                resize[v_i0, v_i1, v_i2, v_i3] = arg[
+                    v_i0,
+                    v_i1,
+                    T.max(
+                        T.min(
+                            T.Cast(
+                                "int64",
+                                T.floor(
+                                    T.float32(1.1089109182357788) * T.Cast("float32", v_i2)
+                                    + T.float32(1.0000000000000001e-05)
+                                ),
+                            ),
+                            223,
+                        ),
+                        0,
+                    ),
+                    T.max(
+                        T.min(
+                            T.Cast(
+                                "int64",
+                                T.floor(
+                                    T.float32(0.91056913137435913) * T.Cast("float32", v_i3)
+                                    + T.float32(1.0000000000000001e-05)
+                                ),
+                            ),
+                            223,
+                        ),
+                        0,
+                    ),
+                ]
+
+    @T.prim_func
+    def expected(
+        arg: T.Buffer((32, 64, 224, 224), "float32"),
+        resize: T.Buffer((32, 202, 246, 64), "float32"),
+    ):
+        # with T.block("root"):
+        for ax0, ax1, ax2, ax3 in T.grid(32, 202, 246, 64):
+            with T.block("resize"):
+                v0, v1, v2, v3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(arg[v0, v3, 0:224, 0:224])
+                T.writes(resize[v0, v1, v2, v3])
+                resize[v0, v1, v2, v3] = arg[
+                    v0,
+                    v3,
+                    T.max(
+                        T.min(
+                            T.Cast(
+                                "int64",
+                                T.floor(
+                                    T.float32(1.1089109182357788) * T.Cast("float32", v1)
+                                    + T.float32(1.0000000000000001e-05)
+                                ),
+                            ),
+                            T.int64(223),
+                        ),
+                        T.int64(0),
+                    ),
+                    T.max(
+                        T.min(
+                            T.Cast(
+                                "int64",
+                                T.floor(
+                                    T.float32(0.91056913137435913) * T.Cast("float32", v2)
+                                    + T.float32(1.0000000000000001e-05)
+                                ),
+                            ),
+                            T.int64(223),
+                        ),
+                        T.int64(0),
+                    ),
+                ]
+
+    suggested_transforms = relax.analysis.suggest_layout_transforms(
+        func=before, write_buffer_transforms=[lambda n, c, h, w: (n, h, w, c)]
+    )
+    after = apply_transformations(before, suggested_transforms)
+    tvm.ir.assert_structural_equal(after, expected)
+
+
+def test_op_strided_slice():
+    @T.prim_func
+    def before(
+        arg: T.Buffer((32, 64, 224, 224), "float32"),
+        T_strided_slice_with_axes: T.Buffer((32, 64, 10, 8), "float32"),
+    ):
+        for ax0, ax1, ax2, ax3 in T.grid(32, 64, 10, 8):
+            with T.block("T_strided_slice_with_axes"):
+                v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(
+                    arg[
+                        v_ax0,
+                        v_ax1,
+                        v_ax2 * 5 + 2,
+                        v_ax3 * 7 + 4,
+                    ]
+                )
+                T.writes(T_strided_slice_with_axes[v_ax0, v_ax1, v_ax2, v_ax3])
+                T_strided_slice_with_axes[v_ax0, v_ax1, v_ax2, v_ax3] = arg[
+                    v_ax0,
+                    v_ax1,
+                    v_ax2 * 5 + 2,
+                    v_ax3 * 7 + 4,
+                ]
+
+    @T.prim_func
+    def expected(
+        arg: T.Buffer((32, 224, 224, 16, 4), "float32"),
+        T_strided_slice_with_axes: T.Buffer((32, 10, 8, 16, 4), "float32"),
+    ):
+        # with T.block("root"):
+        for ax0, ax1, ax2, ax3, ax4 in T.grid(32, 10, 8, 16, 4):
+            with T.block("T_strided_slice_with_axes"):
+                v0, v1, v2, v3, v4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
+                T.reads(arg[v0, v1 * 5 + 2, v2 * 7 + 4, v3, v4])
+                T.writes(T_strided_slice_with_axes[v0, v1, v2, v3, v4])
+                T_strided_slice_with_axes[v0, v1, v2, v3, v4] = arg[
+                    v0, v1 * 5 + 2, v2 * 7 + 4, v3, v4
+                ]
+
+    suggested_transforms = relax.analysis.suggest_layout_transforms(
+        func=before, write_buffer_transforms=[lambda n, c, h, w: (n, h, w, c // 4, c % 4)]
+    )
+    after = apply_transformations(before, suggested_transforms)
+    tvm.ir.assert_structural_equal(after, expected)
+
+
+def test_op_binary_broadcast():
+    @T.prim_func
+    def before(
+        arg0: T.Buffer((32, 64, 224, 224), "float32"),
+        arg1: T.Buffer((64, 224, 224), "float32"),
+        T_add: T.Buffer((32, 64, 224, 224), "float32"),
+    ):
+        T.func_attr({"tir.noalias": True})
+        # with T.block("root"):
+        for ax0, ax1, ax2, ax3 in T.grid(32, 64, 224, 224):
+            with T.block("T_add"):
+                v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(
+                    arg0[v_ax0, v_ax1, v_ax2, v_ax3],
+                    arg1[v_ax1, v_ax2, v_ax3],
+                )
+                T.writes(T_add[v_ax0, v_ax1, v_ax2, v_ax3])
+                T_add[v_ax0, v_ax1, v_ax2, v_ax3] = (
+                    arg0[v_ax0, v_ax1, v_ax2, v_ax3] + arg1[v_ax1, v_ax2, v_ax3]
+                )
+
+    @T.prim_func
+    def expected(
+        arg0: T.Buffer((32, 224, 224, 16, 4), "float32"),
+        arg1: T.Buffer((224, 224, 16, 4), "float32"),
+        T_add: T.Buffer((32, 224, 224, 16, 4), "float32"),
+    ):
+        T.func_attr({"tir.noalias": True})
+        # with T.block("root"):
+        for ax0, ax1, ax2, ax3, ax4 in T.grid(32, 224, 224, 16, 4):
+            with T.block("T_add"):
+                v0, v1, v2, v3, v4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
+                T.reads(arg0[v0, v1, v2, v3, v4], arg1[v1, v2, v3, v4])
+                T.writes(T_add[v0, v1, v2, v3, v4])
+                T_add[v0, v1, v2, v3, v4] = arg0[v0, v1, v2, v3, v4] + arg1[v1, v2, v3, v4]
+
+    suggested_transforms = relax.analysis.suggest_layout_transforms(
+        func=before, write_buffer_transforms=[lambda n, c, h, w: (n, h, w, c // 4, c % 4)]
+    )
+    after = apply_transformations(before, suggested_transforms)
+    tvm.ir.assert_structural_equal(after, expected)
+
+
+def test_op_transpose():
+    @T.prim_func
+    def before(
+        arg: T.Buffer((32, 64, 224, 224), "float32"),
+        T_transpose: T.Buffer((32, 224, 224, 64), "float32"),
+    ):
+        for ax0, ax1, ax2, ax3 in T.grid(32, 224, 224, 64):
+            with T.block("T_transpose"):
+                v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(arg[v_ax0, v_ax3, v_ax1, v_ax2])
+                T.writes(T_transpose[v_ax0, v_ax1, v_ax2, v_ax3])
+                T_transpose[v_ax0, v_ax1, v_ax2, v_ax3] = arg[v_ax0, v_ax3, v_ax1, v_ax2]
+
+    @T.prim_func
+    def expected(
+        arg: T.Buffer((32, 64, 224, 224), "float32"),
+        T_transpose: T.Buffer((32, 224, 64, 224), "float32"),
+    ):
+        for ax0, ax1, ax2, ax3 in T.grid(32, 224, 64, 224):
+            with T.block("T_transpose"):
+                v0, v1, v2, v3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(arg[v0, v2, v3, v1])
+                T.writes(T_transpose[v0, v1, v2, v3])
+                T_transpose[v0, v1, v2, v3] = arg[v0, v2, v3, v1]
+
+    suggested_transforms = relax.analysis.suggest_layout_transforms(
+        func=before, write_buffer_transforms=[lambda n, c, h, w: (n, h, w, c)]
+    )
+    after = apply_transformations(before, suggested_transforms)
+    tvm.ir.assert_structural_equal(after, expected)
+
+
+def test_op_pad():
+    @T.prim_func
+    def before(
+        arg: T.Buffer((32, 64, 224, 224), "float32"),
+        PadInput: T.Buffer((32, 64, 230, 230), "float32"),
+    ):
+        for i0, i1, i2, i3 in T.grid(32, 64, 230, 230):
+            with T.block("PadInput"):
+                v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                T.reads(arg[v_i0, v_i1, v_i2 - 2, v_i3 - 2])
+                T.writes(PadInput[v_i0, v_i1, v_i2, v_i3])
+                PadInput[v_i0, v_i1, v_i2, v_i3] = T.if_then_else(
+                    2 <= v_i2 and v_i2 < 226 and 2 <= v_i3 and v_i3 < 226,
+                    arg[v_i0, v_i1, v_i2 - 2, v_i3 - 2],
+                    T.float32(2),
+                )
+
+    @T.prim_func
+    def expected(
+        arg: T.Buffer((32, 224, 224, 16, 4), "float32"),
+        PadInput: T.Buffer((32, 230, 230, 16, 4), "float32"),
+    ):
+        for ax0, ax1, ax2, ax3, ax4 in T.grid(32, 230, 230, 16, 4):
+            with T.block("PadInput"):
+                v0, v1, v2, v3, v4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
+                T.reads(arg[v0, v1 - 2, v2 - 2, v3, v4])
+                T.writes(PadInput[v0, v1, v2, v3, v4])
+                PadInput[v0, v1, v2, v3, v4] = T.if_then_else(
+                    2 <= v1 and v1 < 226 and 2 <= v2 and v2 < 226,
+                    arg[v0, v1 - 2, v2 - 2, v3, v4],
+                    T.float32(2),
+                )
+
+    suggested_transforms = relax.analysis.suggest_layout_transforms(
+        func=before, write_buffer_transforms=[lambda n, c, h, w: (n, h, w, c // 4, c % 4)]
+    )
+    after = apply_transformations(before, suggested_transforms)
+    tvm.ir.assert_structural_equal(after, expected)
+
+
+def test_op_split():
+    @T.prim_func
+    def before(
+        arg: T.Buffer((32, 64, 224, 224), "float32"),
+        T_split_sections: T.Buffer((32, 32, 224, 224), "float32"),
+        T_split_sections_1: T.Buffer((32, 32, 224, 224), "float32"),
+    ):
+        for ax0, ax1, ax2, ax3 in T.grid(32, 32, 224, 224):
+            with T.block("T_split_sections"):
+                v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(arg[v_ax0, v_ax1, v_ax2, v_ax3])
+                T.writes(T_split_sections[v_ax0, v_ax1, v_ax2, v_ax3])
+                T_split_sections[v_ax0, v_ax1, v_ax2, v_ax3] = arg[v_ax0, v_ax1, v_ax2, v_ax3]
+        for ax0, ax1, ax2, ax3 in T.grid(32, 32, 224, 224):
+            with T.block("T_split_sections_1"):
+                v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(arg[v_ax0, v_ax1 + 32, v_ax2, v_ax3])
+                T.writes(T_split_sections_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                T_split_sections_1[v_ax0, v_ax1, v_ax2, v_ax3] = arg[
+                    v_ax0, v_ax1 + 32, v_ax2, v_ax3
+                ]
+
+    suggested_transforms = relax.analysis.suggest_layout_transforms(
+        func=before,
+        write_buffer_transforms=[lambda n, c, h, w: (n, h, w, c), lambda n, c, h, w: (n, h, w, c)],
+    )
+    after = apply_transformations(before, suggested_transforms)
+    # no transformation for split as multiple write transformations are not handled yet.
+    tvm.ir.assert_structural_equal(after, before)

--- a/tests/python/relax/test_analysis_suggest_layout_transforms.py
+++ b/tests/python/relax/test_analysis_suggest_layout_transforms.py
@@ -22,7 +22,7 @@ from tvm import relax, tir
 from tvm.script import tir as T
 
 
-def apply_transformations(func, suggested_transfoms, print_transformation = False):
+def apply_transformations(func, suggested_transfoms, print_transformation=False):
     sch = tir.Schedule(func)
     for block, per_block_transformations in suggested_transfoms.items():
         blockrv = sch.get_block(block.name_hint)


### PR DESCRIPTION
This change adds a PrimFunc level analysis to propose layout transformations to block and buffers in the PrimFunc based on the layout transformations to PrimFunc outputs. It analyzes buffer access to figure this out. It tries to preserve sequential access to buffers when it does this.

For example given the following PrimFunc and write buffer "relu" transformation `lambda n, c, h, w: (n, h, w, c // 4, c % 4)`, it will suggest to make the following transformations.

* Block transformation on "compute": `lambda n, c, h, w: (n, h, w, c // 4, c % 4)`
* Buffer transformation on  "relu": `lambda n, c, h, w: (n, h, w, c // 4, c % 4)`
* Buffer transformation on "arg":  `lambda n, c, h, w: (n, h, w, c // 4, c % 4)`
```python
@T.prim_func
  def elemwise_relu(
      arg: T.Buffer((32, 64, 224, 224), "float32"),
      relu: T.Buffer((32, 64, 224, 224), "float32"),
  ):
      for i0, i1, i2, i3 in T.grid(32, 64, 224, 224):
          with T.block("compute"):
              v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
              T.reads(arg[v_i0, v_i1, v_i2, v_i3])
              T.writes(relu[v_i0, v_i1, v_i2, v_i3])
              relu[v_i0, v_i1, v_i2, v_i3] = T.max(arg[v_i0, v_i1, v_i2, v_i3], T.float32(0))
```
These transformations can then be applied on the PrimFunc to get the PrimFunc with new layout.

```python
@T.prim_func
def elemwise_relu(
    arg: T.Buffer((32, 224, 224, 16, 4), "float32"),
    relu: T.Buffer((32, 224, 224, 16, 4), "float32"),
):
    for ax0, ax1, ax2, ax3, ax4 in T.grid(32, 224, 224, 16, 4):
        with T.block("compute"):
            v0, v1, v2, v3, v4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
            T.reads(arg[v0, v1, v2, v3, v4])
            T.writes(relu[v0, v1, v2, v3, v4])
            relu[v0, v1, v2, v3, v4] = T.max(arg[v0, v1, v2, v3, v4], T.float32(0))
```

Note: This PR is migrated from https://github.com/tlc-pack/relax/pull/449 to Unity branch