### PR TITLE
[Codegen][CUDA] Add error message for missing fragment info

### DIFF
--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -1272,6 +1272,8 @@ void CodeGenCUDA::PrintWmmaScope(const std::string& scope, DataType t, const Var
                                  std::ostream& os) {
   std::stringstream type;
   PrintType(t, type);
+  ICHECK(fragment_shapes.count(variable))
+      << "Cannot find shape of the wmma fragment " << variable->name_hint;
   std::string shape_str = fragment_shapes.at(variable);
   if ((t.is_int() || t.is_uint()) && t.bits() < 8 && t.lanes() == 1) {
     type.str(std::string());
@@ -1321,6 +1323,8 @@ int stoi(const std::string& str) {
 
 int32_t CodeGenCUDA::GetWmmaFragmentSize(const std::string& scope, const VarNode* variable,
                                          int32_t size) {
+  ICHECK(fragment_shapes.count(variable))
+      << "Cannot find shape of the wmma fragment " << variable->name_hint;
   std::string shape_str = fragment_shapes.at(variable);
   size_t m, n, k;
   size_t last_pos = 0, pos = 0;


### PR DESCRIPTION
This PR added error message when wmma fragment info is missing. This happens when the wmma fragment memory scope is used but `tensorize` is not called. Previously, it shows error message like `tvm._ffi.base.TVMError: _Map_base: :at` that doesn't provide enough information.

cc @masahi 