### PR TITLE
[microTVM] Fix tvmc tutorial

### DIFF
--- a/gallery/how_to/work_with_microtvm/micro_tvmc.sh
+++ b/gallery/how_to/work_with_microtvm/micro_tvmc.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,18 +16,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-: '
-.. _tutorial-micro-cli-tool:
+# bash-ignore
+set -euxo pipefail
+# bash-ignore
 
-1. microTVM CLI Tool
-====================
-**Author**: `Mehrdad Hessar <https://github.com/mehrdadh>`_
-
-This tutorial explains how to compile a tiny model for a micro device,
-build a program on Zephyr platform to execute this model, flash the program
-and run the model all using `tvmc micro` command.
-You need to install python and Zephyr dependencies before processing with this tutorial.
-'
+# bash-comment
+# """
+# .. _tutorial-micro-cli-tool:
+#
+# 1. microTVM CLI Tool
+# ====================
+# **Author**: `Mehrdad Hessar <https://github.com/mehrdadh>`_
+#
+# This tutorial explains how to compile a tiny model for a micro device,
+# build a program on Zephyr platform to execute this model, flash the program
+# and run the model all using `tvmc micro` command.
+# You need to install python and Zephyr dependencies before processing with this tutorial.
+# """
+# bash-comment
 
 ######################################################################
 #
@@ -126,7 +133,7 @@ tvmc micro create \
     project \
     model.tar \
     zephyr \
-    --project-option project_type=host_driven zephyr_board=qemu_x86
+    --project-option project_type=host_driven board=qemu_x86
 # bash
 # This will generate a ``Host-Driven`` Zephyr project for ``qemu_x86`` Zephyr board. In Host-Driven template project,
 # the Graph Executor will run on host and perform the model execution on Zephyr device by issuing commands to the

--- a/tests/python/ci/test_script_converter.py
+++ b/tests/python/ci/test_script_converter.py
@@ -28,13 +28,7 @@ from tvm.contrib import utils
 from .test_utils import REPO_ROOT
 
 sys.path.insert(0, str(REPO_ROOT / "docs"))
-from script_convert import (
-    bash_to_python,
-    BASH,
-    BASH_IGNORE,
-    BASH_MULTILINE_COMMENT_START,
-    BASH_MULTILINE_COMMENT_END,
-)
+from script_convert import bash_to_python, BASH, BASH_IGNORE, BASH_MULTILINE_COMMENT
 
 # pylint: enable=wrong-import-position,wrong-import-order
 
@@ -57,7 +51,7 @@ def test_bash_cmd():
     with open(dest_path, "r") as dest_f:
         generated_cmd = dest_f.read()
 
-    expected_cmd = "# .. code-block:: bash\n" "#\n" "#\t  tvmc\n" "#\n"
+    expected_cmd = "# .. code-block:: bash\n" "#\n" "# \t  tvmc\n" "#\n"
 
     assert generated_cmd == expected_cmd
 
@@ -126,7 +120,7 @@ def test_text_and_bash_command():
     with open(dest_path, "r") as dest_f:
         generated_cmd = dest_f.read()
 
-    expected_cmd = "# start\n" "# .. code-block:: bash\n" "#\n" "#\t  tvmc\n" "#\n" "# end\n"
+    expected_cmd = "# start\n" "# .. code-block:: bash\n" "#\n" "# \t  tvmc\n" "#\n" "# end\n"
 
     assert generated_cmd == expected_cmd
 
@@ -158,10 +152,11 @@ def test_multiline_comment():
     dest_path = temp / "dest.py"
 
     with open(src_path, "w") as src_f:
-        src_f.write(BASH_MULTILINE_COMMENT_START)
+        src_f.write(BASH_MULTILINE_COMMENT)
         src_f.write("\n")
-        src_f.write("comment\n")
-        src_f.write(BASH_MULTILINE_COMMENT_END)
+        src_f.write('# """\n')
+        src_f.write("# comment\n")
+        src_f.write(BASH_MULTILINE_COMMENT)
         src_f.write("\n")
 
     bash_to_python(src_path, dest_path)
@@ -169,7 +164,7 @@ def test_multiline_comment():
     with open(dest_path, "r") as dest_f:
         generated_cmd = dest_f.read()
 
-    expected_cmd = '"""\n' "comment\n" '"""\n'
+    expected_cmd = '"""\ncomment\n'
 
     assert generated_cmd == expected_cmd
 

--- a/tests/scripts/setup-pytest-env.sh
+++ b/tests/scripts/setup-pytest-env.sh
@@ -92,4 +92,6 @@ function run_pytest() {
     if [ "$exit_code" -ne "0" ] && [ "$exit_code" -ne "5" ]; then
         pytest_errors+=("${suite_name}: $@")
     fi
+    # To avoid overwriting.
+    set -e
 }


### PR DESCRIPTION
This PR applies appropriate changes to make sure the CI fails if `micro_tvmc.sh` tutorial fails. This issue was captured in https://github.com/apache/tvm/issues/14074.
This PR also makes changes to avoid this breakage in bash script tutorials in future. In addition, this PR fixes the bug in running TVMC tutorial which happened due to renaming `zephyr_board` to `board`.