### PR TITLE
[CI] Update Compute Library to v22.11

### DIFF
--- a/docker/install/ubuntu_download_arm_compute_lib_binaries.sh
+++ b/docker/install/ubuntu_download_arm_compute_lib_binaries.sh
@@ -28,7 +28,7 @@ if [ "$architecture_type" != "aarch64" ]; then
     gcc-aarch64-linux-gnu
 fi
 
-compute_lib_version="v22.08"
+compute_lib_version="v22.11"
 compute_lib_variant="arm64-v8a-neon"
 compute_lib_full_name="arm_compute-${compute_lib_version}-bin-linux-${compute_lib_variant}"
 compute_lib_base_url="https://github.com/ARM-software/ComputeLibrary/releases/download/${compute_lib_version}"


### PR DESCRIPTION
This updates Compute Library from v22.08 to v22.11.

Changelog for this version can be found at:
https://arm-software.github.io/ComputeLibrary/v22.11/

cc @lhutton1 @neildhickey @ashutosh-arm 