### PR TITLE
[Unity][Fix][Pass] FoldConstant with DCE in dataflow block

### DIFF
--- a/src/relax/analysis/udchain.cc
+++ b/src/relax/analysis/udchain.cc
@@ -52,7 +52,10 @@ class UDChain : public relax::ExprVisitor {
 
   void VisitExpr_(const VarNode* op) override { to_users[op].insert(cur_user_); }
   void VisitVarDef(const Var& var) override { to_users[var.get()] = {}; }
-  void VisitExpr_(const FunctionNode* op) override { ExprVisitor::VisitExpr_(op); }
+  void VisitExpr_(const FunctionNode* op) override {
+    cur_user_ = nullptr;
+    ExprVisitor::VisitExpr_(op);
+  }
 
   void VisitExpr_(const DataflowVarNode* op) override {
     VisitExpr_(static_cast<const VarNode*>(op));

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -165,9 +165,6 @@ def test_dataflow_fold():
 
         @R.function
         def expected(c1: R.Tensor((16, 16), "float32")):
-            with R.dataflow():
-                gv0 = c1
-                R.output(gv0)
             return c1
 
     c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)


### PR DESCRIPTION
The current FoldConstant pass does not support removing unused bindings in the post-folding function. Therefore, for large real-world models, the built executable will be overlarge because of the redundant unused constants.

This PR removes the redundant unused constant bindings in FoldConstant by using the analysis function "RemoveAllUnused".

Note that "RemoveAllUnused" only works at dataflow block level. Therefore FoldConstant will not remove unused bindings outside of dataflow block as well.