### PR TITLE
[Unity][Relax] Set Shape Function to Be Host Function

### DIFF
--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -531,6 +531,11 @@ class VMShapeLowerMutator
     // the shape_func to indicate that this is a host function
     // This could require us to attach target to the relax function here.
     tir::PrimFunc shape_func(params, body, ret_type, buffer_map);
+    if (shape_func->attrs.GetAttr<tvm::Target>(tvm::attr::kTarget) == nullptr) {
+      // kTarget and kIsHostFunc are mutually exclusive
+      shape_func =
+          WithAttr<tir::PrimFunc>(std::move(shape_func), tvm::tir::attr::kIsHostFunc, Integer(1));
+    }
     GlobalVar shape_func_var = builder_->AddFunction(shape_func, "shape_func");
     builder_->Emit(Call(shape_func_var, {shape_heap_}), "_");
     return to_compute.size();

--- a/tests/python/relax/test_backend_transform_shape_lower.py
+++ b/tests/python/relax/test_backend_transform_shape_lower.py
@@ -178,6 +178,7 @@ def test_symbolic_compute():
         @T.prim_func
         def shape_func(H: T.Buffer(T.int64(4), "int64")):
             # generated compute function
+            T.func_attr({"tir.is_host_func": 1})
             H[T.int64(sindex["k+1"])] = H[T.int64(sindex["k"])] + T.int64(1)
 
         @R.function


### PR DESCRIPTION
This PR follows up #14020 to utilize the `is_host_func` attribute and make sure the shape function is computed on target host. Modified previous symbolic shape unit test to adopt and cover the current change.

CC: @junrushao @YuchenJin @tqchen 