### PR TITLE
[microTVM][Zephyr] Remove unnecessary use of generate_c_interface_header

### DIFF
--- a/apps/microtvm/zephyr/template_project/CMakeLists.txt.template
+++ b/apps/microtvm/zephyr/template_project/CMakeLists.txt.template
@@ -68,7 +68,7 @@ endforeach(crt_lib_name ${CRT_LIBS})
 zephyr_library_named(tvm_model)
 file(GLOB_RECURSE tvm_model_srcs model/codegen/host/src/*.c model/codegen/host/lib/*.o)
 target_sources(tvm_model PRIVATE ${tvm_model_srcs})
-target_include_directories(tvm_model PRIVATE ${CMAKE_SOURCE_DIR}/include crt_config crt/include ${cmsis_includes})
+target_include_directories(tvm_model PRIVATE ${CMAKE_SOURCE_DIR}/include crt_config crt/include model/codegen/host/include ${cmsis_includes})
 target_compile_options(tvm_model PRIVATE -Wno-unused-variable)  # TVM-generated code tends to include lots of these.
 target_link_libraries(app PRIVATE tvm_model)
 
@@ -83,4 +83,4 @@ endif()
 
 file(GLOB_RECURSE app_srcs src/**.c src/**.cc)
 target_sources(app PRIVATE ${app_srcs} ${cmsis_lib_srcs})
-target_include_directories(app PRIVATE crt_config include ${CMAKE_SOURCE_DIR}/include crt/include ${cmsis_includes})
+target_include_directories(app PRIVATE crt_config include ${CMAKE_SOURCE_DIR}/include crt/include model/codegen/host/include ${cmsis_includes})

--- a/gallery/how_to/work_with_microtvm/micro_mlperftiny.py
+++ b/gallery/how_to/work_with_microtvm/micro_mlperftiny.py
@@ -68,7 +68,6 @@ from tvm import relay
 from tvm.relay.backend import Executor, Runtime
 from tvm.contrib.download import download_testdata
 from tvm.micro import export_model_library_format
-from tvm.micro.model_library_format import generate_c_interface_header
 import tvm.micro.testing
 from tvm.micro.testing.utils import (
     create_header_file,
@@ -212,14 +211,6 @@ extra_tar_dir = tvm.contrib.utils.tempdir()
 extra_tar_file = extra_tar_dir / "extra.tar"
 
 with tarfile.open(extra_tar_file, "w:gz") as tf:
-    with tempfile.TemporaryDirectory() as tar_temp_dir:
-        model_files_path = os.path.join(tar_temp_dir, "include")
-        os.mkdir(model_files_path)
-        header_path = generate_c_interface_header(
-            module.libmod_name, [input_name], [output_name], [], {}, [], 0, model_files_path, {}, {}
-        )
-        tf.add(header_path, arcname=os.path.relpath(header_path, tar_temp_dir))
-
     create_header_file(
         "output_data",
         np.zeros(

--- a/tests/micro/zephyr/test_zephyr.py
+++ b/tests/micro/zephyr/test_zephyr.py
@@ -668,13 +668,13 @@ def test_qemu_make_fail(workspace_dir, board, microtvm_debug, serial_number):
     runtime = Runtime("crt", {"system-lib": True})
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
         lowered = relay.build(ir_mod, target, executor=executor, runtime=runtime)
-    
+
     project_options = {
         "project_type": "host_driven",
         "verbose": bool(build_config.get("debug")),
         "board": board,
     }
-    
+
     sample = np.zeros(shape=shape, dtype=dtype)
     project = tvm.micro.generate_project(
         str(utils.TEMPLATE_PROJECT_DIR),
@@ -693,6 +693,7 @@ def test_qemu_make_fail(workspace_dir, board, microtvm_debug, serial_number):
     with pytest.raises(server.JSONRPCError) as excinfo:
         project.transport().open()
     assert "QEMU setup failed" in str(excinfo.value)
+
 
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/micro/zephyr/utils.py
+++ b/tests/micro/zephyr/utils.py
@@ -31,7 +31,6 @@ import requests
 
 import tvm.micro
 from tvm.micro import export_model_library_format
-from tvm.micro.model_library_format import generate_c_interface_header
 from tvm.micro.testing.utils import create_header_file
 from tvm.micro.testing.utils import (
     mlf_extract_workspace_size_bytes,
@@ -160,20 +159,6 @@ def generate_project(
                     tf.add(
                         model_files_path, arcname=os.path.relpath(model_files_path, tar_temp_dir)
                     )
-                header_path = generate_c_interface_header(
-                    lowered.libmod_name,
-                    ["input_1"],
-                    ["Identity"],
-                    [],
-                    {},
-                    [],
-                    0,
-                    model_files_path,
-                    {},
-                    {},
-                )
-                tf.add(header_path, arcname=os.path.relpath(header_path, tar_temp_dir))
-
             create_header_file("input_data", sample, "include/tvm", tf)
             create_header_file(
                 "output_data", np.zeros(shape=output_shape, dtype=output_type), "include/tvm", tf


### PR DESCRIPTION
In standalone mode we can use the generated tvmgen_default.h in model/host/include instead of regenerating it using generate_c_interface_header. 
This PR also moves test_qemu_make_fail to test_zephyr since this test is not a standalone mode test.