### PR TITLE
[Unity] Relax Recursive function

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -297,15 +297,6 @@ TVM_DLL tvm::Array<Var> FreeVars(const Expr& expr);
 TVM_DLL tvm::Array<Var> AllVars(const Expr& expr);
 
 /*!
- * \brief Get all global variables used in calls in expression expr.
- *
- * \param expr the expression.
- *
- * \return List of all global variables called in expr.
- */
-TVM_DLL tvm::Array<GlobalVar> CalledGlobalVars(const Expr& expr);
-
-/*!
  * \brief Get all global variables from expression expr.
  *
  * AllVars is a superset of BoundVars and FreeVars.

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -110,6 +110,13 @@ TVM_DLL tvm::relax::Var Emit(
 TVM_DLL tvm::relax::Var EmitMatchCast(const tvm::relax::Expr& value,
                                       const tvm::relax::StructInfo& struct_info);
 
+/*!
+ * \brief Emit a binding to the last binding block frame.
+ * \param binding The binding to be emitted.
+ * \return The left side var of the emitted binding.
+ */
+TVM_DLL tvm::relax::Var EmitVarBinding(const tvm::relax::VarBinding& binding);
+
 ///////////////////////////// If Then Else /////////////////////////////
 
 /*!

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import tvm
 from tvm import DataType, relax
 from tvm.ir import PrimExpr
-from tvm.relax import Call, Expr, ExternFunc, TupleGetItem, Var, const
+from tvm.relax import Call, Expr, ExternFunc, TupleGetItem, Var, VarBinding, const
 
 ############################### Operators ###############################
 from tvm.relax.op import (
@@ -342,6 +342,20 @@ def emit_match_cast(value: Expr, struct_info: StructInfo) -> Var:
     return _ffi_api.EmitMatchCast(value, struct_info)  # type: ignore
 
 
+def emit_var_binding(value: VarBinding) -> Var:
+    """Emit a binding to the last binding block frame.
+    Parameters
+    ----------
+    value: VarBinding
+        The binding to be emitted.
+    Returns
+    -------
+    var: Var
+        The left side var of the emitted binding.
+    """
+    return _ffi_api.EmitVarBinding(value)  # pylint: disable=no-member # type: ignore
+
+
 ############################# If Then Else #############################
 
 
@@ -497,6 +511,7 @@ __all__ = [
     "divide",
     "dtype",
     "emit",
+    "emit_var_binding",
     "emit_match_cast",
     "equal",
     "ewise_fma",

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -353,7 +353,7 @@ def emit_var_binding(value: VarBinding) -> Var:
     var: Var
         The left side var of the emitted binding.
     """
-    return _ffi_api.EmitVarBinding(value)  # pylint: disable=no-member # type: ignore
+    return _ffi_api.EmitVarBinding(value)  # type: ignore
 
 
 ############################# If Then Else #############################

--- a/src/relax/analysis/analysis.cc
+++ b/src/relax/analysis/analysis.cc
@@ -87,15 +87,6 @@ class VarVisitor : protected ExprVisitor {
     return ret;
   }
 
-  Array<GlobalVar> CalledGlobalVars(const Expr& expr) {
-    this->VisitExpr(expr);
-    Array<GlobalVar> ret;
-    for (const auto& v : called_global_vars_.data) {
-      ret.push_back(v);
-    }
-    return ret;
-  }
-
   void MarkBounded(const Var& v) {
     bound_vars_.Insert(v);
     vars_.Insert(v);
@@ -123,10 +114,6 @@ class VarVisitor : protected ExprVisitor {
     for (Expr arg : call_node->args) {
       VisitExpr(arg);
     }
-
-    if (const GlobalVarNode* global_var_node = call_node->op.as<GlobalVarNode>()) {
-      called_global_vars_.Insert(GetRef<GlobalVar>(global_var_node));
-    }
   }
 
   void VisitBinding_(const VarBindingNode* binding) final {
@@ -144,7 +131,6 @@ class VarVisitor : protected ExprVisitor {
   InsertionSet<Var> vars_;
   InsertionSet<Var> bound_vars_;
   InsertionSet<GlobalVar> global_vars_;
-  InsertionSet<GlobalVar> called_global_vars_;
 };
 
 tvm::Array<Var> FreeVars(const Expr& expr) { return VarVisitor().Free(expr); }
@@ -155,10 +141,6 @@ tvm::Array<Var> AllVars(const Expr& expr) { return VarVisitor().All(expr); }
 
 tvm::Array<GlobalVar> AllGlobalVars(const Expr& expr) { return VarVisitor().AllGlobalVars(expr); }
 
-tvm::Array<GlobalVar> CalledGlobalVars(const Expr& expr) {
-  return VarVisitor().CalledGlobalVars(expr);
-}
-
 TVM_REGISTER_GLOBAL("relax.analysis.free_vars").set_body_typed(FreeVars);
 
 TVM_REGISTER_GLOBAL("relax.analysis.bound_vars").set_body_typed(BoundVars);
@@ -166,8 +148,6 @@ TVM_REGISTER_GLOBAL("relax.analysis.bound_vars").set_body_typed(BoundVars);
 TVM_REGISTER_GLOBAL("relax.analysis.all_vars").set_body_typed(AllVars);
 
 TVM_REGISTER_GLOBAL("relax.analysis.all_global_vars").set_body_typed(AllGlobalVars);
-
-TVM_REGISTER_GLOBAL("relax.analysis.called_global_vars").set_body_typed(CalledGlobalVars);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -203,8 +203,17 @@ tvm::relax::Var EmitMatchCast(const tvm::relax::Expr& value,
   return var;
 }
 
+tvm::relax::Var EmitVarBinding(const tvm::relax::VarBinding& binding) {
+  BlockFrame block_frame = CheckBlockFrameExistAndUnended();
+  const tvm::relax::BlockBuilder& block_builder = GetBlockBuilder();
+  block_builder->EmitNormalized(binding);
+  block_frame->emitted_vars.push_back(binding->var);
+  return binding->var;
+}
+
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.Emit").set_body_typed(Emit);
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitMatchCast").set_body_typed(EmitMatchCast);
+TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitVarBinding").set_body_typed(EmitVarBinding);
 
 ///////////////////////////// If Then Else /////////////////////////////
 

--- a/tests/python/relax/test_utils.py
+++ b/tests/python/relax/test_utils.py
@@ -69,7 +69,7 @@ def test_copy_with_new_vars_on_ir_module_nested_function():
         @R.function
         def func(x: R.Tensor((3,), "float32"), y: R.Tensor((3,), "float32")):
             @R.function
-            def inner(x: R.Tensor((3,), "float32")):
+            def inner(x: R.Tensor((3,), "float32")) -> R.Tensor((3,), dtype="float32"):
                 gv = R.add(x, x)
                 return gv
 
@@ -81,7 +81,7 @@ def test_copy_with_new_vars_on_ir_module_nested_function():
         @R.function
         def func(x: R.Tensor((3,), "float32"), y: R.Tensor((3,), "float32")):
             @R.function
-            def inner(x: R.Tensor((3,), "float32")):
+            def inner(x: R.Tensor((3,), "float32")) -> R.Tensor((3,), dtype="float32"):
                 gv = R.add(x, x)
                 return gv
 
@@ -91,7 +91,7 @@ def test_copy_with_new_vars_on_ir_module_nested_function():
         @R.function
         def func_copied(x: R.Tensor((3,), "float32"), y: R.Tensor((3,), "float32")):
             @R.function
-            def inner(x: R.Tensor((3,), "float32")):
+            def inner(x: R.Tensor((3,), "float32")) -> R.Tensor((3,), dtype="float32"):
                 gv = R.add(x, x)
                 return gv
 


### PR DESCRIPTION
this pull request adds:

- TVMScript local recursive function support
- Update lambda lifting pass. Removed CalledGlobalVars, it was not used anymore.
- Update well-form pass. Previously the [well-form pass](https://github.com/tlc-pack/relax/blob/relax/src/relax/analysis/well_formed.cc#L180-L182) doesn't allow un-defined vars, which doesn't work for var used for recursive call

cc: @YuchenJin @tqchen @Hzfengsy 