### PR TITLE
[Unity] Allow duplicated parameters in the same call arguments in FuseOps

### DIFF
--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -407,7 +407,7 @@ class AddWithSameOperands_partitioned:
     ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
         R.func_attr({"Composite": "tensorrt.add", "Primitive": 1})
         with R.dataflow():
-            gv: R.Tensor((1, 64, 56, 56), dtype="float32") = R.add(data, data)
+            gv: R.Tensor((1, 64, 56, 56), dtype="float32") = R.add(data, data_1)
             R.output(gv)
         return gv
 

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -401,7 +401,10 @@ class AddWithSameOperands:
 @tvm.script.ir_module
 class AddWithSameOperands_partitioned:
     @R.function
-    def fused_relax_add(data: R.Tensor((1, 64, 56, 56), dtype="float32"), data_1: R.Tensor((1, 64, 56, 56), dtype="float32")) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+    def fused_relax_add(
+        data: R.Tensor((1, 64, 56, 56), dtype="float32"),
+        data_1: R.Tensor((1, 64, 56, 56), dtype="float32"),
+    ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
         R.func_attr({"Composite": "tensorrt.add", "Primitive": 1})
         with R.dataflow():
             gv: R.Tensor((1, 64, 56, 56), dtype="float32") = R.add(data, data)
@@ -409,7 +412,9 @@ class AddWithSameOperands_partitioned:
         return gv
 
     @R.function
-    def main(data: R.Tensor((1, 64, 56, 56), dtype="float32")) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+    def main(
+        data: R.Tensor((1, 64, 56, 56), dtype="float32")
+    ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
         with R.dataflow():
             gv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_add(data, data)
             R.output(gv)


### PR DESCRIPTION
Currently, when `FuseOps` and `FuseOpsByPattern` see a call node whose arguments have duplicated parameters, e.g.
```
with R.dataflow():
    out = R.add(data, data)
    R.output(out)
```

they create a grouped function whose signature has parameters deduplicated:
```
    @R.function
    def main(data: R.Tensor((1, 64, 56, 56), dtype="float32")) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
        with R.dataflow():
            gv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_add(data)
            R.output(gv)
        return gv

    @R.function
    def fused_relax_add(data: R.Tensor((1, 64, 56, 56), dtype="float32")) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
        R.func_attr({"Composite": "tensorrt.add", "Primitive": 1})
        with R.dataflow():
            gv: R.Tensor((1, 64, 56, 56), dtype="float32") = R.add(data, data)
            R.output(gv)
        return gv
```

This is fine if the grouped function is codegen-ed automatically by TVM, but for BYOC use cases (`FuseOpsByPattern`) this is problematic. If a user creates a pattern 

```
add_pat = is_op("relax.add")(wildcard(), wildcard())
```

he / she expects to create a function with two parameters, that does addition. Indeed, if I replace the RHS with an expression other than `data`, such function is created. The fact that the same expression happens to be used for both LHS and RHS shouldn't matter when creating a grouped function. So the current behavior doesn't match user's intention. Moreover, a backend needs to able to handle multiple cases for code-generating the same `add` function with different signatures (one or two arguments).

This PR modifies the behavior of `FuseOps` and `FuseOpsByPattern`, so that duplicated parameters in the same call arguments are allowed to appear as distinct parameters in a grouped function. If the same expression is used in different bindings, like below, it is deduplicated (the current behavior is preserved). 
```
with R.dataflow():
    lv = R.call_tir(add, (x, p0), out_sinfo=R.Tensor((1, 16, 64, 64), dtype="float32"))
    lv1 = R.call_tir(add, (x, p1), out_sinfo=R.Tensor((1, 16, 64, 64), dtype="float32"))
    lv2 = R.call_tir(add, (x, p2), out_sinfo=R.Tensor((1, 16, 64, 64), dtype="float32"))
```

@sunggg @Hzfengsy @vinx13 @yelite 