### PR TITLE
[CI] Add onnx dependency to test_auto_tensorize.py::test_vnni_bert_int8

### DIFF
--- a/tests/python/integration/test_auto_tensorize.py
+++ b/tests/python/integration/test_auto_tensorize.py
@@ -336,6 +336,7 @@ def test_dp4a_conv2d():
 @tvm.testing.requires_cascadelake
 @pytest.mark.skipif(tvm.testing.IS_IN_CI, reason="Slow on CI")
 def test_vnni_bert_int8():
+    pytest.importorskip("onnx")
     relay_mod, params, input_info = load_quantized_bert_base()
     _test_bert_int8(
         relay_mod,


### PR DESCRIPTION
The test modified by this PR relies on onnx conversion to run successfully, skipping if onnx isn't available, which is the case for ci_cpu docker image