### PR TITLE
[Unity][BYOC]Add relax backend pattern registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,7 @@ tvm_file_glob(GLOB_RECURSE COMPILER_SRCS
     src/relax/transform/*.cc
     src/relax/backend/vm/*.cc
     src/relax/backend/task_extraction.cc
+    src/relax/backend/pattern_registry.cc
     src/relax/utils.cc
     )
 

--- a/python/tvm/relax/backend/__init__.py
+++ b/python/tvm/relax/backend/__init__.py
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Relax backends"""
+
+from . import contrib
+from .pattern_registry import get_pattern, get_patterns_with_prefix

--- a/python/tvm/relax/backend/_ffi_api.py
+++ b/python/tvm/relax/backend/_ffi_api.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""FFI API for Relax BYOC."""
+
+import tvm._ffi
+
+tvm._ffi._init_api("relax.backend", __name__)

--- a/python/tvm/relax/backend/_ffi_api.py
+++ b/python/tvm/relax/backend/_ffi_api.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""FFI API for Relax BYOC."""
+"""FFI API for Relax backend."""
 
 import tvm._ffi
 

--- a/python/tvm/relax/backend/contrib/__init__.py
+++ b/python/tvm/relax/backend/contrib/__init__.py
@@ -15,4 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from . import cutlass
+"""External backend codegen modules for Relax."""
+
+from .cutlass import partition_for_cutlass

--- a/python/tvm/relax/backend/contrib/__init__.py
+++ b/python/tvm/relax/backend/contrib/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from . import cutlass

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Pattern table for CUTLASS backend"""
+
+from ..pattern_registry import register_patterns
+from ..patterns import make_fused_bias_activation_pattern, make_matmul_pattern
+
+register_patterns(
+    [
+        (
+            "cutlass.conv2d",
+            make_fused_bias_activation_pattern(
+                "relax.nn.conv2d",
+                with_bias=False,
+                activation=None,
+            ),
+        ),
+        (
+            "cutlass.conv2d_bias_relu",
+            make_fused_bias_activation_pattern(
+                "relax.nn.conv2d",
+                with_bias=True,
+                activation="relax.nn.relu",
+            ),
+        ),
+        (
+            "cutlass.matmul",
+            make_matmul_pattern(
+                with_bias=False,
+            ),
+        ),
+        (
+            "cutlass.matmul_bias",
+            make_matmul_pattern(
+                with_bias=True,
+            ),
+        ),
+        (
+            "cutlass.matmul_bias_relu",
+            make_matmul_pattern(
+                with_bias=True,
+                activation="relax.nn.relu",
+            ),
+        ),
+        (
+            "cutlass.matmul_bias_gelu",
+            make_matmul_pattern(
+                with_bias=True,
+                activation="relax.nn.gelu",
+            ),
+        ),
+    ]
+)

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -17,7 +17,9 @@
 
 """Pattern table for CUTLASS backend"""
 
-from ..pattern_registry import register_patterns
+from tvm.relax import transform
+
+from ..pattern_registry import get_patterns_with_prefix, register_patterns
 from ..patterns import make_fused_bias_activation_pattern, make_matmul_pattern
 
 register_patterns(
@@ -66,3 +68,23 @@ register_patterns(
         ),
     ]
 )
+
+
+def partition_for_cutlass(mod):
+    """
+    Partition the input module into CUTLASS-supported subgraphs.
+
+    Parameters
+    ----------
+    mod: tvm.IRModule
+        The IRModule to be partitioned.
+
+    Returns
+    -------
+    mod: tvm.IRModule
+        The resulting IRModule, containing partitioned subgraphs to be
+        compiled by the CUTLASS backend.
+    """
+
+    cutlass_patterns = get_patterns_with_prefix("cutlass")
+    return transform.FuseOpsByPattern(cutlass_patterns, annotate_codegen=True)(mod)

--- a/python/tvm/relax/backend/pattern_registry.py
+++ b/python/tvm/relax/backend/pattern_registry.py
@@ -28,6 +28,25 @@ from . import _ffi_api
 
 @tvm._ffi.register_object("relax.backend.PatternRegistryEntry")
 class PatternRegistryEntry(Object):
+    """
+    An entry in the pattern registry. This represents a single pattern that
+    can be used to identify expressions that can be handled by external
+    backends, like CUTLASS and TensorRT.
+
+    Parameters
+    ----------
+    name: str
+        The name of pattern. Usually it starts with the name of backend, like 'cutlass.matmul'.
+
+    pattern: DFPattern
+        The dataflow pattern that will be used to match expressions that can be handled
+        by external backends.
+
+    arg_patterns: Mapping[str, DFPattern]
+        The mapping from arg name to its pattern. It can be used to extract arg expression
+        from match result. All DFPattern in this map should be part of the `pattern`.
+    """
+
     name: str
     pattern: DFPattern
     arg_patterns: Mapping[str, DFPattern]
@@ -46,6 +65,16 @@ Pattern = Union[
 
 
 def register_patterns(patterns: List[Pattern]):
+    """
+    Register patterns which will be used to partition the DataflowBlock into
+    subgraphs that are supported by external backends.
+
+    Parameters
+    ----------
+    patterns: List[Pattern]
+        Patterns to be registered. Patterns that appear later in the list have
+        higher priority when partitioning DataflowBlock.
+    """
     entries = []
     for item in patterns:
         if isinstance(item, PatternRegistryEntry):
@@ -63,8 +92,34 @@ def register_patterns(patterns: List[Pattern]):
 
 
 def get_patterns_with_prefix(prefix: str) -> List[PatternRegistryEntry]:
+    """
+    Get a list of patterns whose names startwith `prefix`.
+
+    Parameters
+    ----------
+    prefix: str
+        The prefix of pattern name.
+
+    Returns
+    -------
+    patterns: PatternRegistryEntry
+        Matched patterns, ordered by priority from high to low.
+    """
     return _ffi_api.GetPatternsWithPrefix(prefix)
 
 
 def get_pattern(name: str) -> Optional[PatternRegistryEntry]:
+    """
+    Find the pattern with a particular name.
+
+    Parameters
+    ----------
+    name: str
+        The pattern name.
+
+    Returns
+    -------
+    pattern: Optional[PatternRegistryEntry]
+        The matched pattern. Returns None if such pattern is not found.
+    """
     return _ffi_api.GetPattern(name)

--- a/python/tvm/relax/backend/pattern_registry.py
+++ b/python/tvm/relax/backend/pattern_registry.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Pattern registry for BYOC backends"""
+
+from typing import List, Mapping, Optional, Tuple, Union
+
+import tvm
+from tvm.relax.dpl import DFPattern
+from tvm.runtime import Object
+
+from . import _ffi_api
+
+
+@tvm._ffi.register_object("relax.backend.PatternRegistryEntry")
+class PatternRegistryEntry(Object):
+    name: str
+    pattern: DFPattern
+    arg_patterns: Mapping[str, DFPattern]
+
+    def __init__(self, name: str, pattern: DFPattern, arg_patterns: Mapping[str, DFPattern]):
+        self.__init_handle_by_constructor__(
+            _ffi_api.PatternRegistryEntry, name, pattern, arg_patterns  # type: ignore
+        )
+
+
+Pattern = Union[
+    PatternRegistryEntry,
+    Tuple[str, DFPattern],
+    Tuple[str, Tuple[DFPattern, Mapping[str, DFPattern]]],
+]
+
+
+def register_patterns(patterns: List[Pattern]):
+    entries = []
+    for item in patterns:
+        if isinstance(item, PatternRegistryEntry):
+            entries.append(item)
+        elif isinstance(item, tuple):
+            name, pattern_or_tuple = item
+            if isinstance(pattern_or_tuple, tuple):
+                pattern, arg_patterns = pattern_or_tuple
+            else:
+                pattern, arg_patterns = pattern_or_tuple, {}
+            entries.append(PatternRegistryEntry(name, pattern, arg_patterns))
+        else:
+            raise TypeError(f"Cannot register type {type(pattern)} as pattern")
+    _ffi_api.RegisterPatterns(entries)
+
+
+def get_patterns_with_prefix(prefix: str) -> List[PatternRegistryEntry]:
+    return _ffi_api.GetPatternsWithPrefix(prefix)
+
+
+def get_pattern(name: str) -> Optional[PatternRegistryEntry]:
+    return _ffi_api.GetPattern(name)

--- a/python/tvm/relax/backend/patterns.py
+++ b/python/tvm/relax/backend/patterns.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Common patterns used in BYOC"""
+
+from tvm.relax.dpl.pattern import DFPattern, is_op, wildcard
+
+
+def _with_bias_activation_pattern(out, args, with_bias=False, activation=None):
+    if with_bias:
+        args["bias"] = bias = wildcard()
+        out = is_op("relax.add")(out, bias)
+
+    if activation:
+        out = is_op(activation)(out)
+
+    return out, args
+
+
+def make_fused_bias_activation_pattern(op_name, with_bias=False, activation=None):
+    """
+    A simple utility to create patterns for an operation fused with bias addition and activation.
+
+    Parameters
+    ----------
+    op_name: str
+        The name of a Relax op, such as "relax.nn.conv2d"
+
+    with_bias: bool
+        Whether or not to include bias addition
+
+    activation: str
+        The name of an activation Relax op, such as "relax.nn.relu"
+
+    Returns
+    -------
+    pattern: DFPattern
+        The resulting pattern describing a fused operation
+    """
+    lhs = wildcard()
+    rhs = wildcard()
+    args = {"lhs": lhs, "rhs": rhs}
+    out = is_op(op_name)(lhs, rhs)
+
+    return _with_bias_activation_pattern(out, args, with_bias, activation)
+
+
+def make_matmul_pattern(with_bias=False, activation=None, transposed_rhs=False):
+    lhs = wildcard()
+    rhs = wildcard()
+    args = {"lhs": lhs, "rhs": rhs}
+
+    if transposed_rhs:
+        rhs = is_op("relax.permute_dims")(rhs)
+
+    out = is_op("relax.matmul")(lhs, rhs)
+
+    return _with_bias_activation_pattern(out, args, with_bias, activation)

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -1082,14 +1082,3 @@ def make_fused_bias_activation_pattern(op_name, with_bias=False, activation=None
     out = is_op(op_name)(lhs, rhs)
 
     return _add_bias_activation_pattern(out, with_bias, activation)
-
-
-def make_matmul_pattern(with_bias=False, activation=None, transposed_b=False):
-    lhs = wildcard()
-    if transposed_b:
-        rhs = is_op("relax.permute_dims")(wildcard())
-    else:
-        rhs = wildcard()
-    out = is_op("relax.matmul")(lhs, rhs)
-
-    return _add_bias_activation_pattern(out, with_bias, activation)

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -1046,17 +1046,6 @@ def _only_used_by(
     return ffi.only_used_by(lhs, rhs, index)  # type: ignore
 
 
-def _add_bias_activation_pattern(out, with_bias=False, activation=None):
-    if with_bias:
-        bias = wildcard()
-        out = is_op("relax.add")(out, bias)
-
-    if activation:
-        return is_op(activation)(out)
-
-    return out
-
-
 def make_fused_bias_activation_pattern(op_name, with_bias=False, activation=None):
     """
     A simple utility to create patterns for an operation fused with bias addition and activation.
@@ -1081,4 +1070,11 @@ def make_fused_bias_activation_pattern(op_name, with_bias=False, activation=None
     rhs = wildcard()
     out = is_op(op_name)(lhs, rhs)
 
-    return _add_bias_activation_pattern(out, with_bias, activation)
+    if with_bias:
+        bias = wildcard()
+        out = is_op("relax.add")(out, bias)
+
+    if activation:
+        return is_op(activation)(out)
+
+    return out

--- a/src/relax/backend/pattern_registry.cc
+++ b/src/relax/backend/pattern_registry.cc
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "./pattern_registry.h"
+
+#include "../../support/utils.h"
+
+namespace tvm {
+namespace relax {
+namespace backend {
+
+PatternRegistryEntry::PatternRegistryEntry(String name, DFPattern pattern,
+                                           Map<String, DFPattern> arg_patterns) {
+  ObjectPtr<PatternRegistryEntryNode> n = make_object<PatternRegistryEntryNode>();
+  n->name = std::move(name);
+  n->pattern = std::move(pattern);
+  n->arg_patterns = std::move(arg_patterns);
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(PatternRegistryEntryNode);
+
+static std::vector<PatternRegistryEntry>* GetRegistryTable() {
+  static std::vector<PatternRegistryEntry> table;
+  return &table;
+}
+
+void RegisterPatterns(Array<PatternRegistryEntry> entries) {
+  auto* table = GetRegistryTable();
+  for (const auto& entry : entries) {
+    table->push_back(entry);
+  }
+}
+
+Array<PatternRegistryEntry> GetPatternsWithPrefix(const String& prefix) {
+  auto* table = GetRegistryTable();
+  Array<PatternRegistryEntry> result;
+  for (auto it = table->rbegin(); it != table->rend(); ++it) {
+    if (support::StartsWith((*it)->name, prefix.data())) {
+      result.push_back(*it);
+    }
+  }
+  return result;
+}
+
+Optional<PatternRegistryEntry> GetPattern(const String& pattern_name) {
+  auto* table = GetRegistryTable();
+  for (auto it = table->rbegin(); it != table->rend(); ++it) {
+    if ((*it)->name == pattern_name) {
+      return *it;
+    }
+  }
+  return NullOpt;
+}
+
+TVM_REGISTER_GLOBAL("relax.backend.PatternRegistryEntry")
+    .set_body_typed([](String name, DFPattern pattern, Map<String, DFPattern> arg_patterns) {
+      return PatternRegistryEntry(name, pattern, arg_patterns);
+    });
+TVM_REGISTER_GLOBAL("relax.backend.RegisterPatterns").set_body_typed(RegisterPatterns);
+TVM_REGISTER_GLOBAL("relax.backend.GetPatternsWithPrefix").set_body_typed(GetPatternsWithPrefix);
+TVM_REGISTER_GLOBAL("relax.backend.GetPattern").set_body_typed(GetPattern);
+
+}  // namespace backend
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/backend/pattern_registry.h
+++ b/src/relax/backend/pattern_registry.h
@@ -1,0 +1,72 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file relax/backend/contrib/pattern_registry.h
+ * \brief Functions related to registering and retrieving patterns for
+ * functions handled by backends.
+ */
+#ifndef TVM_RELAX_BACKEND_PATTERN_REGISTRY_H_
+#define TVM_RELAX_BACKEND_PATTERN_REGISTRY_H_
+
+#include <tvm/relax/dataflow_pattern.h>
+#include <tvm/relax/expr.h>
+#include <tvm/runtime/container/optional.h>
+#include <tvm/runtime/object.h>
+
+namespace tvm {
+namespace relax {
+namespace backend {
+
+class PatternRegistryEntryNode : public Object {
+ public:
+  String name;
+  DFPattern pattern;
+  Map<String, DFPattern> arg_patterns;
+
+  void VisitAttrs(tvm::AttrVisitor* v) {
+    v->Visit("name", &name);
+    v->Visit("pattern", &pattern);
+    v->Visit("arg_patterns", &arg_patterns);
+  }
+
+  static constexpr const char* _type_key = "relax.backend.PatternRegistryEntry";
+  TVM_DECLARE_FINAL_OBJECT_INFO(PatternRegistryEntryNode, Object);
+};
+
+class PatternRegistryEntry : public ObjectRef {
+ public:
+  PatternRegistryEntry(String name, DFPattern pattern, Map<String, DFPattern> arg_patterns);
+
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(PatternRegistryEntry, ObjectRef,
+                                            PatternRegistryEntryNode);
+};
+
+void RegisterPatterns(Array<PatternRegistryEntry> entries);
+
+Array<PatternRegistryEntry> GetPatternsWithPrefix(const String& prefix);
+
+Optional<PatternRegistryEntry> GetPattern(const String& pattern_name);
+
+}  // namespace backend
+}  // namespace relax
+}  // namespace tvm
+
+#endif  // TVM_RELAX_BACKEND_PATTERN_REGISTRY_H_

--- a/src/relax/backend/pattern_registry.h
+++ b/src/relax/backend/pattern_registry.h
@@ -35,10 +35,28 @@ namespace tvm {
 namespace relax {
 namespace backend {
 
+/*!
+ * \brief An entry in the pattern registry. This represents a single pattern that
+ * can be used to identify expressions that can be handled by external
+ * backends, like CUTLASS and TensorRT.
+ */
 class PatternRegistryEntryNode : public Object {
  public:
+  /*!
+   * \brief The name of pattern. Usually it starts with the name of backend, like
+   * 'cutlass.matmul'.
+   */
   String name;
+  /*!
+   * \brief The dataflow pattern that will be used to match expressions that can
+   * be handled by external backends.
+   */
   DFPattern pattern;
+  /*!
+   * \brief The mapping from arg name to its pattern. It can be used to extract
+   * arg expression from match result. All DFPattern in this map should be part of
+   * the `pattern`.
+   */
   Map<String, DFPattern> arg_patterns;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
@@ -59,11 +77,27 @@ class PatternRegistryEntry : public ObjectRef {
                                             PatternRegistryEntryNode);
 };
 
+/*!
+ * \brief Register patterns which will be used to partition the DataflowBlock
+ *        into subgraphs that are supported by external backends.
+ * \param patterns Patterns to be registered. Patterns that appear later in the list have
+ *        higher priority when partitioning DataflowBlock.
+ */
 void RegisterPatterns(Array<PatternRegistryEntry> entries);
 
+/*!
+ * \brief Find patterns whose name starts with a particular prefix.
+ * \param prefx The pattern name prefix.
+ * \return Matched patterns, ordered by priority from high to low.
+ */
 Array<PatternRegistryEntry> GetPatternsWithPrefix(const String& prefix);
 
-Optional<PatternRegistryEntry> GetPattern(const String& pattern_name);
+/*!
+ * \brief Find the pattern with a particular name.
+ * \param name The pattern name.
+ * \return The matched pattern. NullOpt if not found.
+ */
+Optional<PatternRegistryEntry> GetPattern(const String& name);
 
 }  // namespace backend
 }  // namespace relax


### PR DESCRIPTION
This PR adds pattern registry to manage patterns used by different BYOC backends. It provides API for registering and retrieving patterns. 

The main motivation of this PR is to make it easier to do analysis in backend codegen, by making the pattern behind the partitioned function accessible to codegen.

cc @vinx13 @masahi 