### PR TITLE
[Runtime] Fix Potential DeviceAPIManager Memory Bug

### DIFF
--- a/python/tvm/relay/function.py
+++ b/python/tvm/relay/function.py
@@ -98,7 +98,6 @@ class Function(BaseFunc):
         return astext(self, show_meta_data, annotate)
 
 
-@tvm._ffi.register_func("relay.FunctionWithFields")
 def FunctionWithFields(
     function,
     params=None,

--- a/src/runtime/c_runtime_api.cc
+++ b/src/runtime/c_runtime_api.cc
@@ -90,7 +90,7 @@ uint8_t ParseCustomDatatype(const std::string& s, const char** scan) {
 
 class DeviceAPIManager {
  public:
-  static const int kMaxDeviceAPI = 32;
+  static const int kMaxDeviceAPI = TVMDeviceExtType_End;
   // Get API
   static DeviceAPI* Get(const Device& dev) { return Get(dev.device_type); }
   static DeviceAPI* Get(int dev_type, bool allow_missing = false) {


### PR DESCRIPTION
This PR do 2 things:

1. Fix a potential memory bug, we meet this bug because our device type is greater than 32, so the cross-border access happened in device api manager code.

2. Remove a useless decorator, it seems there isn't any code use it, and it will cause the Python function become as a packed function, so the caller can't use the key word argument when call it.