### PR TITLE
[Unity] Update tests again to adapt to latest TVMScript syntax

### DIFF
--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -516,8 +516,8 @@ class BlockBuilder(Object):
                             var_compute: T.handle) -> None:
                     # function attr dict
                     T.func_attr({"tir.noalias": True})
-                    m = T.var("int64")
-                    n = T.var("int64")
+                    m = T.int64()
+                    n = T.int64()
                     rxplaceholder = T.match_buffer(var_rxplaceholder, [n, m], dtype="float32")
                     rxplaceholder_1 = T.match_buffer(var_rxplaceholder_1, [n, m], dtype="float32")
                     compute = T.match_buffer(var_compute, [128, 128], dtype="float32")

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -422,9 +422,9 @@ def LegalizeOps(customize_legalize_map: Optional[Dict[str, LegalizeFunc]] = None
 
             @T.prim_func
             def add(
-                A: T.Buffer[(2, 3), "float32"],
-                B: T.Buffer[(2, 3), "float32"],
-                T_add: T.Buffer[(2, 3), "float32"],
+                A: T.Buffer((2, 3), "float32"),
+                B: T.Buffer((2, 3), "float32"),
+                T_add: T.Buffer((2, 3), "float32"),
             ):
                 T.func_attr({"tir.noalias": True})
                 for ax0, ax1 in T.grid(2, 3):
@@ -436,9 +436,9 @@ def LegalizeOps(customize_legalize_map: Optional[Dict[str, LegalizeFunc]] = None
 
             @T.prim_func
             def multiply(
-                A: T.Buffer[(2, 3), "float32"],
-                B: T.Buffer[(2, 3), "float32"],
-                T_multiply: T.Buffer[(2, 3), "float32"],
+                A: T.Buffer((2, 3), "float32"),
+                B: T.Buffer((2, 3), "float32"),
+                T_multiply: T.Buffer((2, 3), "float32"),
             ):
                 T.func_attr({"tir.noalias": True})
                 for ax0, ax1 in T.grid(2, 3):

--- a/src/relax/transform/merge_composite_functions.cc
+++ b/src/relax/transform/merge_composite_functions.cc
@@ -324,16 +324,12 @@ IRModule MergeCompositeFunctions(IRModule mod) {
   auto new_mod = MakeGroupedFunctions(mod, group_map);
 
   CompositeInliner inliner(mod);
-  std::vector<std::pair<GlobalVar, BaseFunc>> to_update;
   for (const auto& [gvar, func] : new_mod->functions) {
     if (func->GetAttr<String>(attr::kCodegen)) {
       auto new_func = inliner.Run(Downcast<Function>(func));
       new_func = WithAttr(new_func, tvm::attr::kGlobalSymbol, gvar->name_hint);
-      to_update.emplace_back(gvar, new_func);
+      new_mod->Update(gvar, new_func);
     }
-  }
-  for (const auto& [gvar, func] : to_update) {
-    new_mod->Update(gvar, func);
   }
   // TODO(@tvm-team): Implicit pass dependency. Revisit when we have a better way to handle this.
   return RemoveUnusedFunctions(new_mod, {"main"});

--- a/src/script/printer/relax/tir.cc
+++ b/src/script/printer/relax/tir.cc
@@ -53,12 +53,7 @@ Doc PrintTIRVar(tir::Var n, ObjectPath n_p, IRDocsifier d) {
     }
     IdDoc var = d->Define(n, GetRef<Frame>(f), n->name_hint.empty() ? "v" : n->name_hint);
     var->source_paths.push_back(n_p);
-    f->stmts.push_back(AssignDoc(var,
-                                 TIR(d, "Var")->Call({
-                                     LiteralDoc::Str(var->name, n_p->Attr("name_hint")),
-                                     LiteralDoc::DataType(n->dtype, n_p->Attr("dtype")),
-                                 }),
-                                 NullOpt));
+    f->stmts.push_back(AssignDoc(var, TIR(d, DType2Str(n->dtype))->Call({}), NullOpt));
   }
   if (Optional<ExprDoc> doc = d->GetVarDoc(n)) {
     return doc.value();

--- a/tests/python/relax/test_backend_transform_shape_lower.py
+++ b/tests/python/relax/test_backend_transform_shape_lower.py
@@ -164,8 +164,8 @@ def test_symbolic_compute():
         def main(
             x: R.Tensor(["n", "m"], "float32"), y: R.Tensor(ndim=3, dtype=None)
         ) -> R.Shape(ndim=3):
-            n = T.Var("n", "int64")
-            k = T.Var("k", "int64")
+            n = T.int64()
+            k = T.int64()
             z = R.match_cast(y, R.Tensor([k, m, k + 1], dtype=None))
             return R.shape([k + 1, m, 2])
 
@@ -185,8 +185,8 @@ def test_symbolic_compute():
         def main(
             x: R.Tensor(["n", "m"], "float32"), y: R.Tensor(ndim=3, dtype=None)
         ) -> R.Shape(ndim=3):
-            n = T.Var("n", "int64")
-            k = T.Var("k", "int64")
+            n = T.int64()
+            k = T.int64()
             shape_heap = R.call_builtin_with_ctx(
                 "vm.builtin.alloc_shape_heap",
                 [R.prim_value(4)],

--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -142,7 +142,7 @@ def test_match_cast():
         @R.function
         def main(x: R.Tensor):
             q = x
-            m, n = T.var("int64"), T.var("int64")
+            m, n = T.int64(), T.int64()
             z = R.match_cast(q, R.Tensor((m, n)))
             w = z
             return w
@@ -153,7 +153,7 @@ def test_match_cast():
         def main(x: R.Tensor):
             q = x
             # can't get rid of z because its shape_ is different from x's
-            m, n = T.var("int64"), T.var("int64")
+            m, n = T.int64(), T.int64()
             z = R.match_cast(x, R.Tensor((m, n)))
             w = z
             return z
@@ -167,7 +167,7 @@ def test_same_shape():
     class TestSameShape:
         @R.function
         def main(x: R.Tensor(("m", "n"), "float32")):
-            m, n = T.var("int64"), T.var("int64")
+            m, n = T.int64(), T.int64()
             y = x
             # trivial check
             z = R.match_cast(x, R.Tensor((m, n), "float32"))
@@ -179,7 +179,7 @@ def test_same_shape():
     class Expected:
         @R.function
         def main(x: R.Tensor(("m", "n"), "float32")):
-            m, n = T.var("int64"), T.var("int64")
+            m, n = T.int64(), T.int64()
             y = x
             # canonicalized into a var binding
             z = x
@@ -198,7 +198,7 @@ def test_change_shape():
         def main(x: R.Tensor(("m", "n"))):
             y = x
             # not trivial: introduces new shape vars
-            o, p = T.var("int64"), T.var("int64")
+            o, p = T.int64(), T.int64()
             z = R.match_cast(x, R.Tensor((o, p)))
             w = z
             q = R.add(w, y)
@@ -209,7 +209,7 @@ def test_change_shape():
         @R.function
         def main(x: R.Tensor(("m", "n"))):
             y = x
-            o, p = T.var("int64"), T.var("int64")
+            o, p = T.int64(), T.int64()
             z = R.match_cast(x, R.Tensor((o, p)))
             w = z
             # the shape_ field on q will need to be updated

--- a/tests/python/relax/test_transform_legalize_ops_manipulate.py
+++ b/tests/python/relax/test_transform_legalize_ops_manipulate.py
@@ -802,7 +802,7 @@ def test_collapse_sum_like():
             return gv
 
         @T.prim_func
-        def collapse_sum(rxplaceholder: T.Buffer[(T.int64(2), T.int64(3)), "float32"], rxplaceholder_red: T.Buffer[(T.int64(1), T.int64(3)), "float32"]):
+        def collapse_sum(rxplaceholder: T.Buffer((T.int64(2), T.int64(3)), "float32"), rxplaceholder_red: T.Buffer((T.int64(1), T.int64(3)), "float32")):
             T.func_attr({"tir.noalias": True})
             for i0, i1, i2 in T.grid(T.int64(1), T.int64(3), T.int64(2)):
                 with T.block("rxplaceholder_red"):
@@ -825,7 +825,7 @@ def test_collapse_sum_like_symbolic():
     class CollapseSumLike:
         @R.function
         def main(x: R.Tensor(("a", "b", "a"), "float32"), y: R.Tensor(("b", 1), "float32")) -> R.Tensor(("b", 1), "float32"):
-            b = T.var("int64")
+            b = T.int64()
             gv: R.Tensor((b, 1), "float32") = R.collapse_sum_like(x, y)
             return gv
 
@@ -855,7 +855,7 @@ def test_collapse_sum_to():
             return gv
 
         @T.prim_func
-        def collapse_sum(rxplaceholder: T.Buffer[(T.int64(3), T.int64(2), T.int64(3)), "float32"], rxplaceholder_red: T.Buffer[(T.int64(2), T.int64(1)), "float32"]):
+        def collapse_sum(rxplaceholder: T.Buffer((T.int64(3), T.int64(2), T.int64(3)), "float32"), rxplaceholder_red: T.Buffer((T.int64(2), T.int64(1)), "float32")):
             T.func_attr({"tir.noalias": True})
             for ax0, ax1, k0, k2 in T.grid(T.int64(2), T.int64(1), T.int64(3), T.int64(3)):
                 with T.block("rxplaceholder_red"):
@@ -878,7 +878,7 @@ def test_collapse_sum_to_symbolic():
     class CollapseSumTo:
         @R.function
         def main(x: R.Tensor(("a", "b", "c"), "float32")) -> R.Tensor(("b", 1), "float32"):
-            b = T.var("int64")
+            b = T.int64()
             gv: R.Tensor((b, 1), "float32") = R.collapse_sum_to(x, (b, 1))
             return gv
 

--- a/tests/python/relax/test_transform_legalize_ops_nn.py
+++ b/tests/python/relax/test_transform_legalize_ops_nn.py
@@ -868,7 +868,7 @@ def test_log_softmax():
             return gv
 
         @T.prim_func
-        def log_softmax(rxplaceholder: T.Buffer[(T.int64(2), T.int64(3), T.int64(16), T.int64(32)), "float32"], compute: T.Buffer[(T.int64(2), T.int64(3), T.int64(16), T.int64(32)), "float32"],):
+        def log_softmax(rxplaceholder: T.Buffer((T.int64(2), T.int64(3), T.int64(16), T.int64(32)), "float32"), compute: T.Buffer((T.int64(2), T.int64(3), T.int64(16), T.int64(32)), "float32"),):
             T.func_attr({"tir.noalias": True})
             T_softmax_maxelem = T.alloc_buffer([T.int64(2), T.int64(3), T.int64(32)], dtype="float32")
             compute_1 = T.alloc_buffer([T.int64(2), T.int64(3), T.int64(32)], dtype="float32")
@@ -907,9 +907,9 @@ def test_log_softmax_symbolic():
     class LogSoftmax:
         @R.function
         def main(x: R.Tensor(("a", "b", "c"), "float32")) -> R.Tensor(("a", "b", "c"), "float32"):
-            a = T.var("int64")
-            b = T.var("int64")
-            c = T.var("int64")
+            a = T.int64()
+            b = T.int64()
+            c = T.int64()
             gv: R.Tensor((a, b, c), "float32") = R.nn.log_softmax(x)
             return gv
 
@@ -917,9 +917,9 @@ def test_log_softmax_symbolic():
     class Expected:
         @R.function
         def main(x: R.Tensor(("a", "b", "c"), dtype="float32")) -> R.Tensor(("a", "b", "c"), dtype="float32"):
-            a = T.var("int64")
-            b = T.var("int64")
-            c = T.var("int64")
+            a = T.int64()
+            b = T.int64()
+            c = T.int64()
             # block 0
             gv = R.call_tir(log_softmax, (x,), R.Tensor((a, b, c), dtype="float32"))
             return gv
@@ -927,9 +927,9 @@ def test_log_softmax_symbolic():
         @T.prim_func
         def log_softmax(var_rxplaceholder: T.handle, var_compute: T.handle):
             T.func_attr({"tir.noalias": True})
-            a = T.var("int64")
-            b = T.var("int64")
-            c = T.var("int64")
+            a = T.int64()
+            b = T.int64()
+            c = T.int64()
             rxplaceholder = T.match_buffer(var_rxplaceholder, [a, b, c], dtype="float32")
             compute = T.match_buffer(var_compute, [a, b, c], dtype="float32")
             T_softmax_maxelem = T.alloc_buffer([a, b], dtype="float32")
@@ -980,7 +980,7 @@ def test_cross_entropy_with_logits():
             return gv
 
         @T.prim_func
-        def cross_entropy_with_logits(rxplaceholder: T.Buffer[T.int64(3), "float32"], rxplaceholder_1: T.Buffer[T.int64(3), "float32"], T_multiply: T.Buffer[(), "float32"]):
+        def cross_entropy_with_logits(rxplaceholder: T.Buffer(T.int64(3), "float32"), rxplaceholder_1: T.Buffer(T.int64(3), "float32"), T_multiply: T.Buffer((), "float32")):
             T.func_attr({"tir.noalias": True})
             T_multiply_1 = T.alloc_buffer([T.int64(3)], dtype="float32")
             T_multiply_red = T.alloc_buffer([], dtype="float32")
@@ -1026,7 +1026,7 @@ def test_cross_entropy_with_logits_batch():
             return gv
 
         @T.prim_func
-        def cross_entropy_with_logits(rxplaceholder: T.Buffer[(T.int64(2), T.int64(3)), "float32"], rxplaceholder_1: T.Buffer[(T.int64(2), T.int64(3)), "float32"], T_divide: T.Buffer[(), "float32"]):
+        def cross_entropy_with_logits(rxplaceholder: T.Buffer((T.int64(2), T.int64(3)), "float32"), rxplaceholder_1: T.Buffer((T.int64(2), T.int64(3)), "float32"), T_divide: T.Buffer((), "float32")):
             T.func_attr({"tir.noalias": True})
             T_multiply = T.alloc_buffer([T.int64(2), T.int64(3)], dtype="float32")
             T_multiply_red = T.alloc_buffer([], dtype="float32")
@@ -1067,8 +1067,8 @@ def test_cross_entropy_with_logits_batch_symbolic():
     class CrossEntropyWithLogits:
         @R.function
         def main(x: R.Tensor(("n", "m"), "float32"), y: R.Tensor(("n", "m"), "float32")) -> R.Tensor(None, "float32", ndim=2):
-            n = T.var("int64")
-            m = T.var("int64")
+            n = T.int64()
+            m = T.int64()
             gv: R.Tensor((), "float32") = R.nn.cross_entropy_with_logits(x, y)
             return gv
 
@@ -1080,10 +1080,10 @@ def test_cross_entropy_with_logits_batch_symbolic():
             return gv
 
         @T.prim_func
-        def cross_entropy_with_logits(var_rxplaceholder: T.handle, var_rxplaceholder_1: T.handle, T_divide: T.Buffer[(), "float32"]):
+        def cross_entropy_with_logits(var_rxplaceholder: T.handle, var_rxplaceholder_1: T.handle, T_divide: T.Buffer((), "float32")):
             T.func_attr({"tir.noalias": True})
-            m = T.var("int64")
-            n = T.var("int64")
+            m = T.int64()
+            n = T.int64()
             rxplaceholder = T.match_buffer(var_rxplaceholder, [n, m], dtype="float32")
             rxplaceholder_1 = T.match_buffer(var_rxplaceholder_1, [n, m], dtype="float32")
             T_multiply = T.alloc_buffer([n, m], dtype="float32")

--- a/tests/python/relax/test_transform_remove_unused_funcs.py
+++ b/tests/python/relax/test_transform_remove_unused_funcs.py
@@ -34,9 +34,9 @@ def test_unused_relax_func():
     class InputModule:
         @T.prim_func
         def tir_add(
-            x: T.Buffer[(16, 16), "float32"],
-            y: T.Buffer[(16, 16), "float32"],
-            z: T.Buffer[(16, 16), "float32"],
+            x: T.Buffer((16, 16), "float32"),
+            y: T.Buffer((16, 16), "float32"),
+            z: T.Buffer((16, 16), "float32"),
         ) -> None:
             for i, j in T.grid(16, 16):
                 with T.block("add"):
@@ -68,9 +68,9 @@ def test_unused_relax_func_custom_entry_func():
     class InputModule:
         @T.prim_func
         def tir_add(
-            x: T.Buffer[(16, 16), "float32"],
-            y: T.Buffer[(16, 16), "float32"],
-            z: T.Buffer[(16, 16), "float32"],
+            x: T.Buffer((16, 16), "float32"),
+            y: T.Buffer((16, 16), "float32"),
+            z: T.Buffer((16, 16), "float32"),
         ) -> None:
             for i, j in T.grid(16, 16):
                 with T.block("add"):
@@ -105,9 +105,9 @@ def test_unused_relax_func_symbolic_shape():
     class InputModule:
         @T.prim_func
         def tir_add(
-            x: T.Buffer[(16, 16), "float32"],
-            y: T.Buffer[(16, 16), "float32"],
-            z: T.Buffer[(16, 16), "float32"],
+            x: T.Buffer((16, 16), "float32"),
+            y: T.Buffer((16, 16), "float32"),
+            z: T.Buffer((16, 16), "float32"),
         ) -> None:
             for i, j in T.grid(16, 16):
                 with T.block("add"):
@@ -121,7 +121,7 @@ def test_unused_relax_func_symbolic_shape():
 
         @R.function
         def main(x: R.Tensor(("m", "n"), "float32"), w: R.Tensor(("n", "k"), "float32")):
-            m, k = T.var("int64"), T.var("int64")
+            m, k = T.int64(), T.int64()
             gv0 = R.call_tir(tir_add, (x, w), R.Tensor((m + 1, k), dtype="float32"))
             return gv0
 
@@ -139,9 +139,9 @@ def test_unused_prim_func():
     class InputModule:
         @T.prim_func
         def unused_func(
-            x: T.Buffer[(16, 16), "float32"],
-            y: T.Buffer[(16, 16), "float32"],
-            z: T.Buffer[(16, 16), "float32"],
+            x: T.Buffer((16, 16), "float32"),
+            y: T.Buffer((16, 16), "float32"),
+            z: T.Buffer((16, 16), "float32"),
         ) -> None:
             T.func_attr({"global_symbol": "tir_unused"})
             for i, j in T.grid(16, 16):
@@ -175,9 +175,9 @@ def test_multiple_unused_funcs():
     class InputModule:
         @T.prim_func
         def unused_func1(
-            x: T.Buffer[(16, 16), "float32"],
-            y: T.Buffer[(16, 16), "float32"],
-            z: T.Buffer[(16, 16), "float32"],
+            x: T.Buffer((16, 16), "float32"),
+            y: T.Buffer((16, 16), "float32"),
+            z: T.Buffer((16, 16), "float32"),
         ) -> None:
             T.func_attr({"global_symbol": "tir_unused"})
             for i, j in T.grid(16, 16):

--- a/tests/python/relax/test_tvmscript_printer_relax.py
+++ b/tests/python/relax/test_tvmscript_printer_relax.py
@@ -17,6 +17,7 @@
 # pylint: disable=missing-docstring
 import tvm
 import pytest
+import tvm.testing
 from tvm import IRModule, relax, tir
 from tvm.script import relax as R
 
@@ -99,7 +100,7 @@ def test_shape_struct_info_2():
     _assert_print(
         obj,
         """
-a = T.Var("a", "int64")
+a = T.int64()
 R.Shape([1, a, 3])""",
     )
 
@@ -112,7 +113,7 @@ def test_tensor_struct_info():
     _assert_print(
         obj,
         """
-a = T.Var("a", "int64")
+a = T.int64()
 R.Tensor((1, a, 3), dtype="float32")
 """,
     )
@@ -134,7 +135,7 @@ def test_tuple_struct_info():
     _assert_print(
         obj,
         """
-a = T.Var("a", "int64")
+a = T.int64()
 R.Tuple(R.Prim("float32"), R.Object, R.Shape([1, a, 3]))
 """,
     )
@@ -155,7 +156,7 @@ def test_func_struct_info():
     _assert_print(
         obj,
         """
-a = T.Var("a", "int64")
+a = T.int64()
 R.Callable((R.Prim("float32"), R.Object, R.Shape([1, a, 3])), R.Tensor((1, 2, 3), dtype="float32"))
 """,
     )
@@ -226,7 +227,7 @@ def test_var():
     _assert_print(
         obj,
         """
-x = T.Var("x", "int64")
+x = T.int64()
 a: R.Tensor((1, x, 3), dtype="float32")
 a""",
     )
@@ -237,7 +238,7 @@ def test_dataflow_var():
     _assert_print(
         obj,
         """
-x = T.Var("x", "int64")
+x = T.int64()
 a: R.Tensor((1, x, 3), dtype="float32")
 a""",
     )
@@ -254,11 +255,11 @@ def test_tuple():
     _assert_print(
         obj,
         """
-x = T.Var("x", "int64")
+x = T.int64()
 a: R.Tensor((1, x, 3), dtype="float32")
-y = T.Var("y", "int64")
+y = T.int64()
 b: R.Tensor((1, y, 3), dtype="float32")
-z = T.Var("z", "int64")
+z = T.int64()
 c: R.Tensor((1, z, 3), dtype="float32")
 (a, b, c)
 """,
@@ -279,11 +280,11 @@ def test_tuple_get_item():
     _assert_print(
         obj,
         """
-x = T.Var("x", "int64")
+x = T.int64()
 a: R.Tensor((1, x, 3), dtype="float32")
-y = T.Var("y", "int64")
+y = T.int64()
 b: R.Tensor((1, y, 3), dtype="float32")
-z = T.Var("z", "int64")
+z = T.int64()
 c: R.Tensor((1, z, 3), dtype="float32")
 (a, b, c)[0]
 """,
@@ -302,7 +303,7 @@ def test_call():
     _assert_print(
         obj,
         """
-x = T.Var("x", "int64")
+x = T.int64()
 a: R.Tensor((1, x, 3), dtype="float32")
 R.call_tir("my_func", (a,), out_sinfo=R.Tensor((1, x, 3), dtype="float32"), tir_vars=R.shape([x]))
 """,
@@ -330,7 +331,7 @@ def test_seq_expr():
     _assert_print(
         obj,
         """
-x = T.Var("x", "int64")
+x = T.int64()
 a: R.Tensor((1, x, 3), dtype="float32")
 with R.dataflow():
     b: R.Tensor((1, x, 3), dtype="float32") = R.sin(a)
@@ -356,7 +357,7 @@ def test_binding_block():
     _assert_print(
         obj,
         """
-x = T.Var("x", "int64")
+x = T.int64()
 a: R.Tensor((1, x, 3), dtype="float32")
 b: R.Tensor((1, x, 3), dtype="float32") = R.sin(a)
 c: R.Tensor((1, x, 3), dtype="float32") = R.sin(b)
@@ -379,7 +380,7 @@ def test_dataflow_block():
     _assert_print(
         obj,
         """
-x = T.Var("x", "int64")
+x = T.int64()
 a: R.Tensor((1, x, 3), dtype="float32")
 with R.dataflow():
     b: R.Tensor((1, x, 3), dtype="float32") = R.sin(a)
@@ -401,7 +402,7 @@ def test_match_cast():
     _assert_print(
         obj,
         """
-x = T.Var("x", "int64")
+x = T.int64()
 a: R.Tensor((1, x, 3), dtype="float32")
 b: R.Tensor((1, 5, 3), dtype="float32") = R.match_cast(a, R.Tensor((1, 5, 3), dtype="float32"))
 """,
@@ -417,7 +418,7 @@ def test_var_binding():
     _assert_print(
         obj,
         """
-x = T.Var("x", "int64")
+x = T.int64()
 a: R.Tensor((1, x, 3), dtype="float32")
 b: R.Tensor((1, x, 3), dtype="float32") = R.sin(a)
 """,

--- a/tests/python/relax/test_vm_codegen_only.py
+++ b/tests/python/relax/test_vm_codegen_only.py
@@ -194,8 +194,8 @@ def test_shape_check_builtin(exec_mode):
         @R.function
         def main(x: R.Tensor(["n", "m"], "float32")) -> R.Shape(ndim=3):
             R.func_attr({"global_symbol": "main"})
-            n = T.Var("n", "int64")
-            k = T.Var("k", "int64")
+            n = T.int64()
+            k = T.int64()
             shape_heap = R.call_builtin_with_ctx(
                 "vm.builtin.alloc_shape_heap",
                 [R.prim_value(3)],

--- a/tests/python/unittest/test_arith_detect_cse.py
+++ b/tests/python/unittest/test_arith_detect_cse.py
@@ -20,9 +20,9 @@ from tvm.script import tir as T
 
 
 def test_detect_cs():
-    x = T.Var("x", dtype="int32")
-    y = T.Var("y", dtype="int32")
-    z = T.Var("z", dtype="int32")
+    x = T.int32()
+    y = T.int32()
+    z = T.int32()
     c = T.floor(x + y + 0.5) + x + z * (T.floor(x + y + 0.5))
     m = tvm.arith.detect_common_subexpr(c, 2)
     assert c.a.a in m


### PR DESCRIPTION
Now IRPrinter prints `T.Var("n", "int64")` for tir Vars in Relax functions. But in the new TVMScript syntax, it should be `T.int64()`.

This PR fixes this bug and updates tests in favor of the new TVMScript syntax. To be specific, this PR modifies these:
- `T.var("...")` -> `T.dtype()`
- `T.Var(name, dtype)` -> `T.dtype()`
- `T.Buffer[...]` -> `T.Buffer(...)`