### PR TITLE
[Unity][Legalize] Fix Scalar Constant Legalization

### DIFF
--- a/python/tvm/relax/transform/legalize_ops/common.py
+++ b/python/tvm/relax/transform/legalize_ops/common.py
@@ -19,6 +19,7 @@ from typing import Callable, Optional, Union
 
 import tvm
 from tvm import te
+from tvm.tir import FloatImm, IntImm
 from ...block_builder import BlockBuilder
 from ...expr import Call, Expr, Constant
 
@@ -41,10 +42,14 @@ LegalizeFunc = Callable[[BlockBuilder, Call], Expr]
 
 def _try_convert_to_scalar_const(
     expr: Expr, python_native: bool = False
-) -> Union[Expr, bool, float, int]:
+) -> Union[Expr, FloatImm, IntImm, bool, float, int]:
     """Check if the input Expr is a scalar constant.
     If it is, return its plain value with the same data type or in native python type.
     If it is not, return the input expr.
+
+    Note that if the python_native flag is True, the returned value will be in native python type,
+    this might cause loss of data type for example, a float16 constant will be converted to float32
+    and a int64 constant will be converted to int32.
 
     Parameters
     ----------

--- a/python/tvm/relax/transform/legalize_ops/common.py
+++ b/python/tvm/relax/transform/legalize_ops/common.py
@@ -56,10 +56,10 @@ def _try_convert_to_scalar_const(expr: Expr) -> Union[Expr, bool, float, int]:
         expr is a scalar constant. Or return the input itself
         if it is not.
     """
-    if isinstance(expr, Constant) and expr.struct_info.ndim == 0:
-        return expr.data.numpy()[()].item()
-    else:
-        return expr
+    # TODO: uncomment this once we have better way to support scalar prim value
+    # if isinstance(expr, Constant) and expr.struct_info.ndim == 0:
+    #     return expr.data.numpy()[()].item()
+    return expr
 
 
 def _call_topi_without_attr(te_func: TEFunc, primfunc_name: Optional[str] = None) -> LegalizeFunc:

--- a/python/tvm/relax/transform/legalize_ops/common.py
+++ b/python/tvm/relax/transform/legalize_ops/common.py
@@ -20,7 +20,7 @@ from typing import Callable, Optional, Union
 import tvm
 from tvm import te
 from ...block_builder import BlockBuilder
-from ...expr import Call, Expr, Constant
+from ...expr import Call, Expr
 
 
 ##################### Types #####################

--- a/python/tvm/relax/transform/legalize_ops/creation.py
+++ b/python/tvm/relax/transform/legalize_ops/creation.py
@@ -27,7 +27,9 @@ from .common import LegalizeFunc, register_legalize, _try_convert_to_scalar_cons
 def _full(is_like: bool, fill_value: Optional[float], primfunc_name: str) -> LegalizeFunc:
     def full_call_te(bb: BlockBuilder, call: Call) -> Expr:
         _fill_value = (
-            _try_convert_to_scalar_const(call.args[1]) if fill_value is None else fill_value
+            _try_convert_to_scalar_const(call.args[1], python_native=True)
+            if fill_value is None
+            else fill_value
         )
 
         return bb.call_te(

--- a/python/tvm/relax/transform/legalize_ops/datatype.py
+++ b/python/tvm/relax/transform/legalize_ops/datatype.py
@@ -24,7 +24,7 @@ from .common import _try_convert_to_scalar_const, register_legalize
 
 @register_legalize("relax.astype")
 def _astype(bb: BlockBuilder, call: Call) -> Expr:
-    arg = _try_convert_to_scalar_const(call.args[0])
+    arg = _try_convert_to_scalar_const(call.args[0], python_native=True)
     if isinstance(arg, Expr):  # type: ignore
         return bb.call_te(topi.cast, arg, call.attrs.dtype)
     else:

--- a/tests/python/relax/test_transform_legalize_ops.py
+++ b/tests/python/relax/test_transform_legalize_ops.py
@@ -111,7 +111,6 @@ def test_legalize_multiple_types_of_call():
                     T.writes(T_multiply[v_ax0, v_ax1])
                     T_multiply[v_ax0, v_ax1] = rxplaceholder[v_ax0, v_ax1] * T.float32(2)
 
-
         @R.function
         def main(x1: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((3, 3), dtype="float32"):
             gv1: R.Tensor((3, 3), dtype="float32") = mul2(x1)

--- a/tests/python/relax/test_transform_legalize_ops.py
+++ b/tests/python/relax/test_transform_legalize_ops.py
@@ -89,11 +89,7 @@ def test_legalize_multiple_types_of_call():
     class Expected:
         @R.function
         def mul2(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((3, 3), dtype="float32"):
-            gv = R.call_tir(
-                multiply,
-                (x, R.const(2, "float32")),
-                out_sinfo=R.Tensor((3, 3), dtype="float32"),
-            )
+            gv = R.call_tir(multiply, (x,), R.Tensor((3, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -106,21 +102,21 @@ def test_legalize_multiple_types_of_call():
                     T_id[v_ax0, v_ax1] = rxplaceholder[v_ax0, v_ax1]
 
         @T.prim_func
-        def multiply(rxplaceholder: T.Buffer((T.int64(3), T.int64(3)), "float32"), rxplaceholder_1: T.Buffer((), "float32"), T_multiply: T.Buffer((T.int64(3), T.int64(3)), "float32")):
+        def multiply(rxplaceholder: T.Buffer((T.int64(3), T.int64(3)), "float32"), T_multiply: T.Buffer((T.int64(3), T.int64(3)), "float32")):
             T.func_attr({"tir.noalias": True})
             for ax0, ax1 in T.grid(T.int64(3), T.int64(3)):
                 with T.block("T_multiply"):
                     v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
-                    T.reads(rxplaceholder[v_ax0, v_ax1], rxplaceholder_1[()])
+                    T.reads(rxplaceholder[v_ax0, v_ax1])
                     T.writes(T_multiply[v_ax0, v_ax1])
-                    T_multiply[v_ax0, v_ax1] = rxplaceholder[v_ax0, v_ax1] * rxplaceholder_1[()]
+                    T_multiply[v_ax0, v_ax1] = rxplaceholder[v_ax0, v_ax1] * T.float32(2)
 
 
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((3, 3), dtype="float32"):
-            gv: R.Tensor((3, 3), dtype="float32") = mul2(x)
-            gv1 = R.call_tir(identity, (gv,), out_sinfo=R.Tensor((3, 3), dtype="float32"))
-            gv2 = R.call_tir(multiply, (gv1, R.const(2, "float32")), out_sinfo=R.Tensor((3, 3), dtype="float32"))
+        def main(x1: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((3, 3), dtype="float32"):
+            gv1: R.Tensor((3, 3), dtype="float32") = mul2(x1)
+            gv11 = R.call_tir(identity, gv1, R.Tensor((3, 3), dtype="float32"))
+            gv2 = R.call_tir(multiply, (gv11,), R.Tensor((3, 3), dtype="float32"))
             return gv2
     # fmt: on
 
@@ -161,21 +157,34 @@ def test_can_not_legalize():
     tvm.ir.assert_structural_equal(After1, Before1)
 
 
-def test_legalize_scalar_data_type_preservation():
+def test_legalize_scalar_data_type_preserve():
     # fmt: off
     @tvm.script.ir_module
-    class Before:
+    class Before0:
         @R.function
         def main(x: R.Tensor((3, 3), "float16")):
             gv: R.Tensor((3, 3), "float16") = R.multiply(x, R.const(1.14514, "float16"))
             return gv
 
     @tvm.script.ir_module
-    class After:
+    class Before1:
+        @R.function
+        def main(x: R.Tensor((3, 3), "uint8")):
+            gv: R.Tensor((3, 3), "uint8") = R.multiply(x, R.const(2, "uint8"))
+            return gv
+
+    @tvm.script.ir_module
+    class Before2:
+        @R.function
+        def main(x: R.Tensor((3, 3), "bool")):
+            gv: R.Tensor((3, 3), "bool") = R.equal(x, R.const(True, "bool"))
+            return gv
+
+    @tvm.script.ir_module
+    class Expected0:
         @T.prim_func
         def multiply(
             rxplaceholder: T.Buffer((T.int64(3), T.int64(3)), "float16"),
-            rxplaceholder_1: T.Buffer((), "float16"),
             T_multiply: T.Buffer((T.int64(3), T.int64(3)), "float16"),
         ):
             T.func_attr({"tir.noalias": True})
@@ -183,24 +192,66 @@ def test_legalize_scalar_data_type_preservation():
             for ax0, ax1 in T.grid(T.int64(3), T.int64(3)):
                 with T.block("T_multiply"):
                     v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
-                    T.reads(rxplaceholder[v_ax0, v_ax1], rxplaceholder_1[()])
+                    T.reads(rxplaceholder[v_ax0, v_ax1])
                     T.writes(T_multiply[v_ax0, v_ax1])
-                    T_multiply[v_ax0, v_ax1] = (
-                        rxplaceholder[v_ax0, v_ax1] * rxplaceholder_1[()]
+                    T_multiply[v_ax0, v_ax1] = rxplaceholder[v_ax0, v_ax1] * T.float16(
+                        1.1455078125
                     )
 
         @R.function
         def main(x: R.Tensor((3, 3), dtype="float16")) -> R.Tensor((3, 3), dtype="float16"):
-            gv = R.call_tir(
-                multiply,
-                (x, R.const(1.14514, "float16")),
-                out_sinfo=R.Tensor((3, 3), dtype="float16"),
-            )
+            gv = R.call_tir(multiply, (x,), out_sinfo=R.Tensor((3, 3), dtype="float16"))
+            return gv
+
+    @tvm.script.ir_module
+    class Expected1:
+        @T.prim_func
+        def multiply(
+            rxplaceholder: T.Buffer((T.int64(3), T.int64(3)), "uint8"),
+            T_multiply: T.Buffer((T.int64(3), T.int64(3)), "uint8"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            # with T.block("root"):
+            for ax0, ax1 in T.grid(T.int64(3), T.int64(3)):
+                with T.block("T_multiply"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(rxplaceholder[v_ax0, v_ax1])
+                    T.writes(T_multiply[v_ax0, v_ax1])
+                    T_multiply[v_ax0, v_ax1] = rxplaceholder[v_ax0, v_ax1] * T.uint8(2)
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="uint8")) -> R.Tensor((3, 3), dtype="uint8"):
+            gv = R.call_tir(multiply, (x,), out_sinfo=R.Tensor((3, 3), dtype="uint8"))
+            return gv
+
+    @tvm.script.ir_module
+    class Expected2:
+        @T.prim_func
+        def equal(
+            rxplaceholder: T.Buffer((T.int64(3), T.int64(3)), "bool"),
+            T_equal: T.Buffer((T.int64(3), T.int64(3)), "bool"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            # with T.block("root"):
+            for ax0, ax1 in T.grid(T.int64(3), T.int64(3)):
+                with T.block("T_equal"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(rxplaceholder[v_ax0, v_ax1])
+                    T.writes(T_equal[v_ax0, v_ax1])
+                    T_equal[v_ax0, v_ax1] = rxplaceholder[v_ax0, v_ax1] == tvm.tir.const(True, "bool")
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="bool")) -> R.Tensor((3, 3), dtype="bool"):
+            gv = R.call_tir(equal, (x,), out_sinfo=R.Tensor((3, 3), dtype="bool"))
             return gv
     # fmt: on
 
-    mod = LegalizeOps()(Before)
-    tvm.ir.assert_structural_equal(mod, After)
+    After0 = LegalizeOps()(Before0)
+    tvm.ir.assert_structural_equal(After0, Expected0)
+    After1 = LegalizeOps()(Before1)
+    tvm.ir.assert_structural_equal(After1, Expected1)
+    After2 = LegalizeOps()(Before2)
+    tvm.ir.assert_structural_equal(After2, Expected2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes the issue of loss of data type during Legalization. Previously, if we use a constant scalar in operators like `multiply`, it will automatically be converted to a python data type variable, which may lose its original data type. For example, `float16` may become python `float` and be interpreted as `float32` later.

This is now fixed by avoiding scalar value conversion. The conversion could be added back once we have better support for scalar prim value.

Co-authored by @sunggg and @vinx13.

CC: @MasterJH5574 @tqchen 