### PR TITLE
[Unity][BYOC] Add transposed matmul support to Relax CUTLASS BYOC

### DIFF
--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -87,6 +87,7 @@ from . import transform
 from . import block_builder
 from . import op
 from . import struct_info
+from . import backend
 
 # VM
 from .vm_build import build, Executable

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -66,6 +66,36 @@ register_patterns(
                 activation="relax.nn.gelu",
             ),
         ),
+        (
+            "cutlass.matmul_transposed",
+            make_matmul_pattern(
+                with_bias=False,
+                transposed_rhs=True,
+            ),
+        ),
+        (
+            "cutlass.matmul_transposed_bias",
+            make_matmul_pattern(
+                with_bias=True,
+                transposed_rhs=True,
+            ),
+        ),
+        (
+            "cutlass.matmul_transposed_bias_relu",
+            make_matmul_pattern(
+                with_bias=True,
+                activation="relax.nn.relu",
+                transposed_rhs=True,
+            ),
+        ),
+        (
+            "cutlass.matmul_transposed_bias_gelu",
+            make_matmul_pattern(
+                with_bias=True,
+                activation="relax.nn.gelu",
+                transposed_rhs=True,
+            ),
+        ),
     ]
 )
 

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -204,6 +204,31 @@ class DFPattern(Node):
         """
         return ffi.match_expr(self, expr, var2val)  # type: ignore
 
+    def extract_matched_expr(
+        self, expr, var2val: Optional[Dict[Var, Expr]] = None
+    ) -> Optional[Dict["DFPattern", Expr]]:
+        """
+        Match a relax.Expr and return a map from matching patterns to matched expressions.
+
+        Parameters
+        ----------
+        expr : tvm.relax.Expr
+            The expression to match
+        var2val : Optional[Dict[tvm.relax.Var, tvm.relax.Expr]]
+            A mapping from relax.Var to relax.Expr for autojump.
+
+        Returns
+        -------
+        result: Optional[Dict[DFPattern, Expr]]
+            Map from matching patterns to matched expressions.
+            Return None if the pattern does not match expr.
+
+        Note
+        ----
+        Check the note of `match` for the meaning of var2val.
+        """
+        return ffi.extract_matched_expr(self, expr, var2val)
+
     def used_by(self, other: Union["DFPattern", "PatternSeq"], index=-1) -> "PatternSeq":
         """
         The current pattern being used by another pattern (sequence)

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -515,6 +515,8 @@ Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(DFPattern pattern, Expr expr,
   return matching;
 }
 
+TVM_REGISTER_GLOBAL("relax.dpl.extract_matched_expr").set_body_typed(ExtractMatchedExpr);
+
 bool MatchExpr(DFPattern pattern, Expr expr, Optional<Map<Var, Expr>> bindings_opt) {
   return static_cast<bool>(ExtractMatchedExpr(pattern, expr, bindings_opt));
 }


### PR DESCRIPTION
This PR adds support of transposed matmul to Relax CUTLASS backend. It is able to offload Relax expr like `R.nn.relu(R.matmul(x, R.permute_dims(y)) + bias)`.

Most of this PR is for handling the arg ordering in the fused function and remove the assumption of arg ordering in the CUTLASS GEMM codegen. This is because the fused function of transpose matmul will have `y` as the first argument due to how FuseOpsByPattern is implemented.
```
def fused_transposed_matmul(y, x, bias):
    ...
```

cc @vinx13 @masahi 