### PR TITLE
[Fix][Relay] Fix axis transformation in squeeze shape function

### DIFF
--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -920,7 +920,9 @@ def squeeze_shape_func(attrs, inputs, _):
     keep_axes = []
     remove_axes = []
     if axis is not None:
-        for i in range(inputs[0].shape[0].value):
+        ndim = inputs[0].shape[0].value
+        axis = [i + ndim if i < 0 else i for i in axis]
+        for i in range(ndim):
             if i not in axis:
                 keep_axes.append(i)
             else:

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -520,12 +520,8 @@ def test_any_squeeze():
     verify_any_squeeze(
         (1, relay.Any(), relay.Any(), 1, relay.Any(), relay.Any()), (0, 3), (1, 12, 2, 1, 9, 17)
     )
-    verify_any_squeeze_sqrt(
-        (1, relay.Any(), 12, 32, 1), (-1,), (1, 100, 12, 32, 1)
-    )
-    verify_any_squeeze_sqrt(
-        (relay.Any(), relay.Any(), relay.Any(), 1), (-1,), (1, 9, 8, 1)
-    )
+    verify_any_squeeze_sqrt((1, relay.Any(), 12, 32, 1), (-1,), (1, 100, 12, 32, 1))
+    verify_any_squeeze_sqrt((relay.Any(), relay.Any(), relay.Any(), 1), (-1,), (1, 9, 8, 1))
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -501,12 +501,30 @@ def verify_any_squeeze(data_shape, axis, static_data_shape):
     check_result([data_np], mod, ref_out)
 
 
+def verify_any_squeeze_sqrt(data_shape, axis, static_data_shape):
+    mod = tvm.IRModule()
+    dtype = "float32"
+    data = relay.var("data", shape=data_shape, dtype=dtype)
+    y = relay.squeeze(data, axis=axis)
+    y = relay.sqrt(y)
+    mod["main"] = relay.Function([data], y)
+    data_np = np.random.uniform(size=static_data_shape).astype(dtype)
+    ref_out = np.sqrt(np.squeeze(data_np, axis))
+    check_result([data_np], mod, ref_out)
+
+
 @tvm.testing.uses_gpu
 def test_any_squeeze():
     verify_any_squeeze((relay.Any(), relay.Any(), relay.Any()), (0,), (1, 9, 8))
     verify_any_squeeze((1, relay.Any(), relay.Any()), (0,), (1, 9, 8))
     verify_any_squeeze(
         (1, relay.Any(), relay.Any(), 1, relay.Any(), relay.Any()), (0, 3), (1, 12, 2, 1, 9, 17)
+    )
+    verify_any_squeeze_sqrt(
+        (1, relay.Any(), 12, 32, 1), (-1,), (1, 100, 12, 32, 1)
+    )
+    verify_any_squeeze_sqrt(
+        (relay.Any(), relay.Any(), relay.Any(), 1), (-1,), (1, 9, 8, 1)
     )
 
 


### PR DESCRIPTION
This PR fix the issue https://github.com/apache/tvm/issues/14134.

Currently in squeeze shape function do not transform axis, which means negative axis such as -1 will lead to wrong result.
This PR fix this issue and add simple testcases. 
