### PR TITLE
[TVMScript][Printer] Remove relax prefix for now

### DIFF
--- a/include/tvm/node/script_printer.h
+++ b/include/tvm/node/script_printer.h
@@ -43,8 +43,6 @@ class PrinterConfigNode : public Object {
   std::string ir_prefix = "I";
   /*! \brief The prefix of TIR nodes */
   std::string tir_prefix = "T";
-  /*! \brief The prefix of Relax nodes */
-  std::string relax_prefix = "R";
   /*! \brief Default data type of TIR buffer */
   DataType buffer_dtype = DataType::Float(32);
   /*! \brief Default data type of integer literals */

--- a/python/tvm/runtime/script_printer.py
+++ b/python/tvm/runtime/script_printer.py
@@ -32,7 +32,6 @@ class PrinterConfig(Object):
     show_meta: bool
     ir_prefix: str
     tir_prefix: str
-    relax_prefix: str
     buffer_dtype: str
     int_dtype: str
     float_dtype: str
@@ -53,7 +52,6 @@ class PrinterConfig(Object):
         show_meta: bool = False,
         ir_prefix: str = "I",
         tir_prefix: str = "T",
-        relax_prefix: str = "R",
         buffer_dtype: str = "float32",
         int_dtype: str = "int32",
         float_dtype: str = "void",
@@ -73,7 +71,6 @@ class PrinterConfig(Object):
             "show_meta": show_meta,
             "ir_prefix": ir_prefix,
             "tir_prefix": tir_prefix,
-            "relax_prefix": relax_prefix,
             "buffer_dtype": buffer_dtype,
             "int_dtype": int_dtype,
             "float_dtype": float_dtype,
@@ -114,7 +111,6 @@ class Scriptable:
         show_meta: bool = False,
         ir_prefix: str = "I",
         tir_prefix: str = "T",
-        relax_prefix: str = "R",
         buffer_dtype: str = "float32",
         int_dtype: str = "int32",
         float_dtype: str = "void",
@@ -140,8 +136,7 @@ class Scriptable:
             The prefix of AST nodes from tvm.ir
         tir_prefix : str = "T"
             The prefix of AST nodes from tvm.tir
-        relax_prefix : str = "R"
-            The prefix of AST nodes from tvm.relax
+
         buffer_dtype : str = "float32"
             The default data type of buffer
         int_dtype : str = "int32"
@@ -179,51 +174,6 @@ class Scriptable:
                 show_meta=show_meta,
                 ir_prefix=ir_prefix,
                 tir_prefix=tir_prefix,
-                relax_prefix=relax_prefix,
-                buffer_dtype=buffer_dtype,
-                int_dtype=int_dtype,
-                float_dtype=float_dtype,
-                verbose_expr=verbose_expr,
-                indent_spaces=indent_spaces,
-                print_line_numbers=print_line_numbers,
-                num_context_lines=num_context_lines,
-                syntax_sugar=syntax_sugar,
-                path_to_underline=path_to_underline,
-                path_to_annotate=path_to_annotate,
-                obj_to_underline=obj_to_underline,
-                obj_to_annotate=obj_to_annotate,
-            ),
-        )
-
-    def _relax_script(
-        self,
-        *,
-        name: Optional[str] = None,
-        show_meta: bool = False,
-        ir_prefix: str = "I",
-        tir_prefix: str = "T",
-        relax_prefix: str = "R",
-        buffer_dtype: str = "float32",
-        int_dtype: str = "int32",
-        float_dtype: str = "void",
-        verbose_expr: bool = False,
-        indent_spaces: int = 4,
-        print_line_numbers: bool = False,
-        num_context_lines: int = -1,
-        syntax_sugar: bool = True,
-        path_to_underline: Optional[List[ObjectPath]] = None,
-        path_to_annotate: Optional[Dict[ObjectPath, str]] = None,
-        obj_to_underline: Optional[List[Object]] = None,
-        obj_to_annotate: Optional[Dict[Object, str]] = None,
-    ) -> str:
-        return _relax_script(
-            self,
-            PrinterConfig(
-                name=name,
-                show_meta=show_meta,
-                ir_prefix=ir_prefix,
-                tir_prefix=tir_prefix,
-                relax_prefix=relax_prefix,
                 buffer_dtype=buffer_dtype,
                 int_dtype=int_dtype,
                 float_dtype=float_dtype,
@@ -248,7 +198,6 @@ class Scriptable:
         show_meta: bool = False,
         ir_prefix: str = "I",
         tir_prefix: str = "T",
-        relax_prefix: str = "R",
         buffer_dtype: str = "float32",
         int_dtype: str = "int32",
         float_dtype: str = "void",
@@ -279,8 +228,7 @@ class Scriptable:
             The prefix of AST nodes from tvm.ir
         tir_prefix : str = "T"
             The prefix of AST nodes from tvm.tir
-        relax_prefix : str = "R"
-            The prefix of AST nodes from tvm.relax
+
         buffer_dtype : str = "float32"
             The default data type of buffer
         int_dtype : str = "int32"
@@ -316,7 +264,6 @@ class Scriptable:
                 show_meta=show_meta,
                 ir_prefix=ir_prefix,
                 tir_prefix=tir_prefix,
-                relax_prefix=relax_prefix,
                 buffer_dtype=buffer_dtype,
                 int_dtype=int_dtype,
                 float_dtype=float_dtype,

--- a/src/node/script_printer.cc
+++ b/src/node/script_printer.cc
@@ -49,9 +49,7 @@ PrinterConfig::PrinterConfig(Map<String, ObjectRef> config_dict) {
   if (auto v = config_dict.Get("tir_prefix")) {
     n->tir_prefix = Downcast<String>(v);
   }
-  if (auto v = config_dict.Get("relax_prefix")) {
-    n->relax_prefix = Downcast<String>(v);
-  }
+
   if (auto v = config_dict.Get("buffer_dtype")) {
     n->buffer_dtype = DataType(runtime::String2DLDataType(Downcast<String>(v)));
   }

--- a/src/script/printer/utils.h
+++ b/src/script/printer/utils.h
@@ -103,12 +103,6 @@ inline ExprDoc TIR(const IRDocsifier& d, const String& attr) {
   return IdDoc(d->cfg->tir_prefix)->Attr(attr);
 }
 
-/*! \brief Creates the TIR common prefix, which is by default `T` */
-inline ExprDoc Relax(const IRDocsifier& d, const String& attr) {
-  d->ir_usage.insert("relax");
-  return IdDoc(d->cfg->relax_prefix)->Attr(attr);
-}
-
 inline std::string DType2Str(const runtime::DataType& dtype) {
   return dtype.is_void() ? "void" : runtime::DLDataType2String(dtype);
 }
@@ -123,9 +117,7 @@ inline Doc HeaderWrapper(const IRDocsifier& d, const Doc& doc) {
     if (d->ir_usage.count("tir")) {
       stmts.push_back(CommentDoc("from tvm.script import tir as " + d->cfg->tir_prefix));
     }
-    if (d->ir_usage.count("relax")) {
-      stmts.push_back(CommentDoc("from tvm.script import relax as " + d->cfg->relax_prefix));
-    }
+
     stmts.push_back(CommentDoc(""));
     stmts.push_back(Downcast<StmtDoc>(doc));
     return StmtBlockDoc(stmts);


### PR DESCRIPTION
This PR cleans up relax prefix in printer for now. While these setups are useful and do not cause any technical debts in the codebase. We remove it given requests. They can be added back to unity branch and later as part of upstream.