### PR TITLE
[Android] Fix using system libraries in Android apps

### DIFF
--- a/apps/android_camera/README.md
+++ b/apps/android_camera/README.md
@@ -108,3 +108,13 @@ Run uninstall first:
 ```bash
 $ANDROID_HOME/platform-tools/adb uninstall ml.apache.tvm.android.androidcamerademo
 ```
+### Troubleshooting
+
+If you build the application in Android Studio and see error similar to this one:
+```
+A problem occurred evaluating project ':app'.
+> Failed to apply plugin 'com.android.internal.version-check'.
+   > Minimum supported Gradle version is 7.5. Current version is 7.4. If using the gradle wrapper, try editing the distributionUrl in /Users/echuraev/Workspace/OctoML/tvm_android_test/apps/android_deploy/gradle/wrapper/gradle-wrapper.properties to gradle-7.5-all.zip
+```
+Run project syncing `File -> Sync Project with Gradle Files`. It should sync the
+project and create gradle-wrapper files.

--- a/apps/android_camera/app/src/main/AndroidManifest.xml
+++ b/apps/android_camera/app/src/main/AndroidManifest.xml
@@ -25,6 +25,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup,MissingApplicationIcon">
+        <uses-native-library
+            android:name="libOpenCL.so"
+            android:required="false"/>
         <activity
             android:name="org.apache.tvm.android.androidcamerademo.MainActivity"
             android:exported="true"

--- a/apps/android_camera/models/prepare_model.py
+++ b/apps/android_camera/models/prepare_model.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         raise RuntimeError("Require environment variable TVM_NDK_CC")
     models_path = Path().absolute().parent.joinpath("app/src/main/assets/models/")
     if not models_path.exists():
-        models_path.mkdir()
+        models_path.mkdir(parents=True)
     models = {
         "mobilenet_v2": models_path.joinpath("mobilenet_v2"),
         "resnet18_v1": models_path.joinpath("resnet18_v1"),

--- a/apps/android_deploy/README.md
+++ b/apps/android_deploy/README.md
@@ -120,3 +120,14 @@ Copied these compiled model deploy_lib.so, deploy_graph.json and deploy_param.pa
 Install compiled android application on phone and enjoy the image classifier demo using extraction model
 
 You can define your own TVM operators and deploy via this demo application on your Android device to find the most optimized TVM schedule.
+
+### Troubleshooting
+
+If you build the application in Android Studio and see error similar to this one:
+```
+A problem occurred evaluating project ':app'.
+> Failed to apply plugin 'com.android.internal.version-check'.
+   > Minimum supported Gradle version is 7.5. Current version is 7.4. If using the gradle wrapper, try editing the distributionUrl in /Users/echuraev/Workspace/OctoML/tvm_android_test/apps/android_deploy/gradle/wrapper/gradle-wrapper.properties to gradle-7.5-all.zip
+```
+Run project syncing `File -> Sync Project with Gradle Files`. It should sync the
+project and create gradle-wrapper files.

--- a/apps/android_deploy/app/src/main/AndroidManifest.xml
+++ b/apps/android_deploy/app/src/main/AndroidManifest.xml
@@ -31,6 +31,9 @@ under the License.
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme" >
+        <uses-native-library
+            android:name="libOpenCL.so"
+            android:required="false"/>
         <activity
             android:name="org.apache.tvm.android.demo.MainActivity"
             android:theme="@style/AppTheme.NoActionBar"

--- a/apps/android_rpc/README.md
+++ b/apps/android_rpc/README.md
@@ -157,3 +157,14 @@ Run GPU(Vulkan Flavor) test ...
 ```
 
 You can define your own TVM operators and test via this RPC app on your Android device to find the most optimized TVM schedule.
+
+### Troubleshooting
+
+If you build the application in Android Studio and see error similar to this one:
+```
+A problem occurred evaluating project ':app'.
+> Failed to apply plugin 'com.android.internal.version-check'.
+   > Minimum supported Gradle version is 7.5. Current version is 7.4. If using the gradle wrapper, try editing the distributionUrl in /Users/echuraev/Workspace/OctoML/tvm_android_test/apps/android_deploy/gradle/wrapper/gradle-wrapper.properties to gradle-7.5-all.zip
+```
+Run project syncing `File -> Sync Project with Gradle Files`. It should sync the
+project and create gradle-wrapper files.

--- a/apps/android_rpc/app/src/main/AndroidManifest.xml
+++ b/apps/android_rpc/app/src/main/AndroidManifest.xml
@@ -29,6 +29,9 @@ under the License.
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:icon="@mipmap/ic_launcher">
+        <uses-native-library
+            android:name="libOpenCL.so"
+            android:required="false"/>
         <activity
             android:name=".MainActivity"
             android:theme="@style/AppTheme.NoActionBar"


### PR DESCRIPTION
- Starting from API 31, using `uses-native-library` is required if we
  want to open system library:
  https://developer.android.com/about/versions/12/reference/compat-framework-changes#enforce_native_shared_library_dependencies

  We should specify OpenCL library in `user-native-library` in all
  applications where OpenCL backend might be used.

- Updated README files and describe how to fix synchronization issues
  in Android Studio.