### PR TITLE
[Runtime] Fix high RAM usage when saving / loading paramters of big models  

### DIFF
--- a/python/tvm/runtime/__init__.py
+++ b/python/tvm/runtime/__init__.py
@@ -32,6 +32,6 @@ from .ndarray import device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl
 from .ndarray import vpi, rocm, ext_dev
 from .module import load_module, enabled, system_lib, load_static_library
 from .container import String, ShapeTuple
-from .params import save_param_dict, load_param_dict, load_param_dict_from_file
+from .params import save_param_dict, load_param_dict, save_param_dict_to_file, load_param_dict_from_file
 
 from . import executor

--- a/python/tvm/runtime/__init__.py
+++ b/python/tvm/runtime/__init__.py
@@ -32,6 +32,6 @@ from .ndarray import device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl
 from .ndarray import vpi, rocm, ext_dev
 from .module import load_module, enabled, system_lib, load_static_library
 from .container import String, ShapeTuple
-from .params import save_param_dict, load_param_dict
+from .params import save_param_dict, load_param_dict, load_param_dict_from_file
 
 from . import executor

--- a/python/tvm/runtime/__init__.py
+++ b/python/tvm/runtime/__init__.py
@@ -32,6 +32,11 @@ from .ndarray import device, cpu, cuda, gpu, opencl, cl, vulkan, metal, mtl
 from .ndarray import vpi, rocm, ext_dev
 from .module import load_module, enabled, system_lib, load_static_library
 from .container import String, ShapeTuple
-from .params import save_param_dict, load_param_dict, save_param_dict_to_file, load_param_dict_from_file
+from .params import (
+    save_param_dict,
+    load_param_dict,
+    save_param_dict_to_file,
+    load_param_dict_from_file,
+)
 
 from . import executor

--- a/python/tvm/runtime/params.py
+++ b/python/tvm/runtime/params.py
@@ -67,3 +67,19 @@ def load_param_dict(param_bytes):
     if isinstance(param_bytes, (bytes, str)):
         param_bytes = bytearray(param_bytes)
     return _ffi_api.LoadParams(param_bytes)
+
+
+def load_param_dict_from_file(file_name):
+    """Load parameter dictionary to binary bytes.
+
+    Parameters
+    ----------
+    param_bytes: bytearray
+        Serialized parameters.
+
+    Returns
+    -------
+    params : dict of str to NDArray
+        The parameter dictionary.
+    """
+    return _ffi_api.LoadParamsFromFile(file_name)

--- a/python/tvm/runtime/params.py
+++ b/python/tvm/runtime/params.py
@@ -16,7 +16,19 @@
 # under the License.
 # pylint: disable=invalid-name
 """Helper utility to save and load parameter dicts."""
-from . import _ffi_api, ndarray
+from . import _ffi_api, ndarray, NDArray
+
+
+def _to_ndarray(params):
+    transformed = {}
+
+    for (k, v) in params.items():
+        if not isinstance(v, NDArray):
+            transformed[k] = ndarray.array(v)
+        else:
+            transformed[k] = v
+
+    return transformed
 
 
 def save_param_dict(params):
@@ -47,8 +59,7 @@ def save_param_dict(params):
        # Pass in byte array to module to directly set parameters
        tvm.runtime.load_param_dict(param_bytes)
     """
-    transformed = {k: ndarray.array(v) for (k, v) in params.items()}
-    return _ffi_api.SaveParams(transformed)
+    return _ffi_api.SaveParams(_to_ndarray(params))
 
 
 def save_param_dict_to_file(params, path):
@@ -79,8 +90,7 @@ def save_param_dict_to_file(params, path):
        # Pass in byte array to module to directly set parameters
        tvm.runtime.load_param_dict(param_bytes)
     """
-    transformed = {k: ndarray.array(v) for (k, v) in params.items()}
-    return _ffi_api.SaveParamsToFile(transformed, path)
+    return _ffi_api.SaveParamsToFile(_to_ndarray(params), path)
 
 
 def load_param_dict(param_bytes):

--- a/python/tvm/runtime/params.py
+++ b/python/tvm/runtime/params.py
@@ -63,38 +63,21 @@ def save_param_dict(params):
 
 
 def save_param_dict_to_file(params, path):
-    """Save parameter dictionary to binary bytes.
-
-    The result binary bytes can be loaded by the
-    GraphModule with API "load_params".
+    """Save parameter dictionary to file.
 
     Parameters
     ----------
     params : dict of str to NDArray
         The parameter dictionary.
 
-    Returns
-    -------
-    param_bytes: bytearray
-        Serialized parameters.
-
-    Examples
-    --------
-    .. code-block:: python
-
-       # set up the parameter dict
-       params = {"param0": arr0, "param1": arr1}
-       # save the parameters as byte array
-       param_bytes = tvm.runtime.save_param_dict(params)
-       # We can serialize the param_bytes and load it back later.
-       # Pass in byte array to module to directly set parameters
-       tvm.runtime.load_param_dict(param_bytes)
+    path: str
+        The path to the parameter file.
     """
     return _ffi_api.SaveParamsToFile(_to_ndarray(params), path)
 
 
 def load_param_dict(param_bytes):
-    """Load parameter dictionary to binary bytes.
+    """Load parameter dictionary from binary bytes.
 
     Parameters
     ----------
@@ -112,12 +95,12 @@ def load_param_dict(param_bytes):
 
 
 def load_param_dict_from_file(path):
-    """Load parameter dictionary to binary bytes.
+    """Load parameter dictionary from file.
 
     Parameters
     ----------
-    param_bytes: bytearray
-        Serialized parameters.
+    path: str
+        The path to the parameter file to load from.
 
     Returns
     -------

--- a/python/tvm/runtime/params.py
+++ b/python/tvm/runtime/params.py
@@ -51,6 +51,38 @@ def save_param_dict(params):
     return _ffi_api.SaveParams(transformed)
 
 
+def save_param_dict_to_file(params, path):
+    """Save parameter dictionary to binary bytes.
+
+    The result binary bytes can be loaded by the
+    GraphModule with API "load_params".
+
+    Parameters
+    ----------
+    params : dict of str to NDArray
+        The parameter dictionary.
+
+    Returns
+    -------
+    param_bytes: bytearray
+        Serialized parameters.
+
+    Examples
+    --------
+    .. code-block:: python
+
+       # set up the parameter dict
+       params = {"param0": arr0, "param1": arr1}
+       # save the parameters as byte array
+       param_bytes = tvm.runtime.save_param_dict(params)
+       # We can serialize the param_bytes and load it back later.
+       # Pass in byte array to module to directly set parameters
+       tvm.runtime.load_param_dict(param_bytes)
+    """
+    transformed = {k: ndarray.array(v) for (k, v) in params.items()}
+    return _ffi_api.SaveParamsToFile(transformed, path)
+
+
 def load_param_dict(param_bytes):
     """Load parameter dictionary to binary bytes.
 
@@ -69,7 +101,7 @@ def load_param_dict(param_bytes):
     return _ffi_api.LoadParams(param_bytes)
 
 
-def load_param_dict_from_file(file_name):
+def load_param_dict_from_file(path):
     """Load parameter dictionary to binary bytes.
 
     Parameters
@@ -82,4 +114,4 @@ def load_param_dict_from_file(file_name):
     params : dict of str to NDArray
         The parameter dictionary.
     """
-    return _ffi_api.LoadParamsFromFile(file_name)
+    return _ffi_api.LoadParamsFromFile(path)

--- a/src/runtime/file_utils.cc
+++ b/src/runtime/file_utils.cc
@@ -207,6 +207,11 @@ Map<String, NDArray> LoadParams(dmlc::Stream* strm) {
   return params;
 }
 
+Map<String, NDArray> LoadParamsFromFile(const std::string& file_name) {
+  tvm::runtime::SimpleBinaryFileStream strm(file_name, "rb");
+  return LoadParams(&strm);
+}
+
 void SaveParams(dmlc::Stream* strm, const Map<String, NDArray>& params) {
   std::vector<std::string> names;
   std::vector<const DLTensor*> arrays;
@@ -245,6 +250,10 @@ TVM_REGISTER_GLOBAL("runtime.SaveParams").set_body_typed([](const Map<String, ND
 });
 TVM_REGISTER_GLOBAL("runtime.LoadParams").set_body_typed([](const String& s) {
   return ::tvm::runtime::LoadParams(s);
+});
+
+TVM_REGISTER_GLOBAL("runtime.LoadParamsFromFile").set_body_typed([](const String& file_name) {
+  return ::tvm::runtime::LoadParamsFromFile(file_name);
 });
 
 }  // namespace runtime

--- a/src/runtime/file_utils.cc
+++ b/src/runtime/file_utils.cc
@@ -207,11 +207,6 @@ Map<String, NDArray> LoadParams(dmlc::Stream* strm) {
   return params;
 }
 
-Map<String, NDArray> LoadParamsFromFile(const std::string& file_name) {
-  tvm::runtime::SimpleBinaryFileStream strm(file_name, "rb");
-  return LoadParams(&strm);
-}
-
 void SaveParams(dmlc::Stream* strm, const Map<String, NDArray>& params) {
   std::vector<std::string> names;
   std::vector<const DLTensor*> arrays;
@@ -248,12 +243,20 @@ TVM_REGISTER_GLOBAL("runtime.SaveParams").set_body_typed([](const Map<String, ND
   rv = TVMByteArray{s.data(), s.size()};
   return rv;
 });
+
+TVM_REGISTER_GLOBAL("runtime.SaveParamsToFile")
+    .set_body_typed([](const Map<String, NDArray>& params, const String& path) {
+      tvm::runtime::SimpleBinaryFileStream strm(path, "wb");
+      SaveParams(&strm, params);
+    });
+
 TVM_REGISTER_GLOBAL("runtime.LoadParams").set_body_typed([](const String& s) {
   return ::tvm::runtime::LoadParams(s);
 });
 
-TVM_REGISTER_GLOBAL("runtime.LoadParamsFromFile").set_body_typed([](const String& file_name) {
-  return ::tvm::runtime::LoadParamsFromFile(file_name);
+TVM_REGISTER_GLOBAL("runtime.LoadParamsFromFile").set_body_typed([](const String& path) {
+  tvm::runtime::SimpleBinaryFileStream strm(path, "rb");
+  return LoadParams(&strm);
 });
 
 }  // namespace runtime

--- a/tests/python/unittest/test_runtime_graph.py
+++ b/tests/python/unittest/test_runtime_graph.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import tempfile
 import tvm
 import tvm.testing
 from tvm import te, runtime
@@ -138,6 +139,17 @@ def test_load_unexpected_params():
     rt_mod.load_params(runtime.save_param_dict(new_params))
 
 
+def test_save_load_file():
+    p = np.random.randn(10)
+    params = {"x": p}
+
+    with tempfile.NamedTemporaryFile() as fp:
+        tvm.runtime.save_param_dict_to_file(params, fp.name)
+        params_loaded = tvm.runtime.load_param_dict_from_file(fp.name)
+
+        assert "x" in params_loaded
+        np.testing.assert_equal(p, params_loaded["x"].numpy())
+
+
 if __name__ == "__main__":
-    test_graph_simple()
-    test_load_unexpected_params()
+    tvm.testing.main()


### PR DESCRIPTION
https://github.com/apache/tvm/pull/13877 lowered memory usage for VM runtime load / save. The same issue observed by @AndrewZhaoLuo is still present in the graph runtime counterpart, `tvm.runtime.load_param_dict` and `tvm.runtime.save_param_dict`. In addition, we are carelessly making another copy of `ndarray`s in `save_param_dict`. 

All of this leads to absurd RAM requirement when loading / serializing stable diffusion UNet. The total size of its parameters is < 3.5G, but loading or saving these params take more than 16G of RAM (!!):
```
$ cat test_params.py
import tvm
with open("unet.params", "rb") as fi:
    params_ref = tvm.runtime.load_param_dict(fi.read())

with open("unet.params", "wb") as fo:
    fo.write(tvm.runtime.save_param_dict(params_ref))

$ /usr/bin/time -v python test_params.py 
        ...
        System time (seconds): 9.57
        ....
        Maximum resident set size (kbytes): 16921216
        ...
``` 

I added new save / load utilities that bypass the intermediate byte buffer in the same way as https://github.com/apache/tvm/pull/13877. After this PR, saving / loading SD UNet takes only bare-minimum RAM:

```
$ /usr/bin/time -v python test_params.py 
        ...
        System time (seconds): 3.06
        ...
        Maximum resident set size (kbytes): 3492820
        ...
```

@AndrewZhaoLuo @tkonolige @vinx13 @tqchen 