### PR TITLE
[Unity] Add bind_constants option to FuseOpsByPattern

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -225,6 +225,8 @@ TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
  * of priority in which they are matched. Higher-priority patterns should come earlier in the list.
  * \param checks The callback functions with type (Map<DFPattern, Expr>, Expr) -> bool. It takes a
  * match result and returns a boolean value to indicate whether the match result is accepted.
+ * \param lift_constants Whether or not to lift bound constants to parameters of the grouped
+ * function.
  * \param annotate_codegen If true, wrap each created composite function with another function,
  * whose body consists only of a call to the composite function, and annotate the outer function
  * with kCodegen and kGlobalSymbol attributes. The kCodegen attribute is set as the prefix of the
@@ -235,7 +237,8 @@ TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
  */
 TVM_DLL Pass FuseOpsByPattern(const tvm::Array<runtime::String>& pattern_names,
                               const tvm::Array<DFPattern>& patterns,
-                              const tvm::Array<PackedFunc>& checks, bool annotate_codegen = false);
+                              const tvm::Array<PackedFunc>& checks, bool lift_constants = false,
+                              bool annotate_codegen = false);
 
 /*!
  * \brief Group one or multiple composite functions created by FuseOpsByPattern into a new

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -225,8 +225,7 @@ TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
  * of priority in which they are matched. Higher-priority patterns should come earlier in the list.
  * \param checks The callback functions with type (Map<DFPattern, Expr>, Expr) -> bool. It takes a
  * match result and returns a boolean value to indicate whether the match result is accepted.
- * \param lift_constants Whether or not to lift bound constants to parameters of the grouped
- * function.
+ * \param bind_constants Whether or not to keep bound constants of the grouped function.
  * \param annotate_codegen If true, wrap each created composite function with another function,
  * whose body consists only of a call to the composite function, and annotate the outer function
  * with kCodegen and kGlobalSymbol attributes. The kCodegen attribute is set as the prefix of the
@@ -237,7 +236,7 @@ TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
  */
 TVM_DLL Pass FuseOpsByPattern(const tvm::Array<runtime::String>& pattern_names,
                               const tvm::Array<DFPattern>& patterns,
-                              const tvm::Array<PackedFunc>& checks, bool lift_constants = false,
+                              const tvm::Array<PackedFunc>& checks, bool bind_constants = true,
                               bool annotate_codegen = false);
 
 /*!

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -117,6 +117,6 @@ def partition_for_cutlass(mod):
     """
 
     cutlass_patterns = get_patterns_with_prefix("cutlass")
-    return transform.FuseOpsByPattern(cutlass_patterns, lift_constants=True, annotate_codegen=True)(
+    return transform.FuseOpsByPattern(cutlass_patterns, bind_constants=True, annotate_codegen=True)(
         mod
     )

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -117,4 +117,6 @@ def partition_for_cutlass(mod):
     """
 
     cutlass_patterns = get_patterns_with_prefix("cutlass")
-    return transform.FuseOpsByPattern(cutlass_patterns, annotate_codegen=True)(mod)
+    return transform.FuseOpsByPattern(cutlass_patterns, lift_constants=True, annotate_codegen=True)(
+        mod
+    )

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -283,7 +283,7 @@ def FuseTIR() -> tvm.ir.transform.Pass:
 
 
 def FuseOpsByPattern(
-    patterns: List[Tuple], lift_constants: bool = False, annotate_codegen: bool = False
+    patterns: List[Tuple], bind_constants: bool = True, annotate_codegen: bool = False
 ) -> tvm.ir.transform.Pass:
     """Apply pattern matching to each function in the given module, and group matched expressions
     into a new function.
@@ -302,8 +302,8 @@ def FuseOpsByPattern(
         The string is the name of the corresponding pattern. It becomes the value of the kComposite
         attribute of a fused function after a successful matching.
 
-    lift_constants : bool
-        Whether or not to lift bound constants to parameters of the grouped function.
+    bind_constants : bool
+        Whether or not to keep bound constants in the grouped function.
 
     annotate_codegen : bool
         If True, wrap each created composite function with another function, whose body consists
@@ -335,7 +335,7 @@ def FuseOpsByPattern(
         else:
             raise ValueError("Invalid pattern: {}".format(tup))
     return _ffi_api.FuseOpsByPattern(
-        pattern_names, df_patterns, checks, lift_constants, annotate_codegen
+        pattern_names, df_patterns, checks, bind_constants, annotate_codegen
     )  # type: ignore
 
 

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -283,7 +283,7 @@ def FuseTIR() -> tvm.ir.transform.Pass:
 
 
 def FuseOpsByPattern(
-    patterns: List[Tuple], annotate_codegen: bool = False
+    patterns: List[Tuple], lift_constants: bool = False, annotate_codegen: bool = False
 ) -> tvm.ir.transform.Pass:
     """Apply pattern matching to each function in the given module, and group matched expressions
     into a new function.
@@ -301,6 +301,9 @@ def FuseOpsByPattern(
         they are matched. Higher-priority patterns should come earlier in the list.
         The string is the name of the corresponding pattern. It becomes the value of the kComposite
         attribute of a fused function after a successful matching.
+
+    lift_constants : bool
+        Whether or not to lift bound constants to parameters of the grouped function.
 
     annotate_codegen : bool
         If True, wrap each created composite function with another function, whose body consists
@@ -332,7 +335,7 @@ def FuseOpsByPattern(
         else:
             raise ValueError("Invalid pattern: {}".format(tup))
     return _ffi_api.FuseOpsByPattern(
-        pattern_names, df_patterns, checks, annotate_codegen
+        pattern_names, df_patterns, checks, lift_constants, annotate_codegen
     )  # type: ignore
 
 

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -1054,7 +1054,7 @@ class CompositeFunctionAnnotator : public ExprMutator {
 IRModule FuseOpsByPattern(const tvm::Array<String>& pattern_names,
                           const tvm::Array<DFPattern>& patterns,
                           const tvm::Array<runtime::PackedFunc>& checks, IRModule mod,
-                          bool lift_constants, bool annotate_codegen) {
+                          bool bind_constants, bool annotate_codegen) {
   support::Arena arena;
   for (size_t i = 0; i < pattern_names.size(); ++i) {
     OperatorFusor::GroupMap group_map;
@@ -1066,7 +1066,7 @@ IRModule FuseOpsByPattern(const tvm::Array<String>& pattern_names,
                                               entry.second, &arena);
       group_map.insert(map.begin(), map.end());
     }
-    mod = MakeGroupedFunctions(mod, group_map, /*lift_constants*/ lift_constants);
+    mod = MakeGroupedFunctions(mod, group_map, /*lift_constants*/ !bind_constants);
   }
   if (annotate_codegen) {
     return CompositeFunctionAnnotator(mod).Run();
@@ -1093,11 +1093,11 @@ TVM_REGISTER_GLOBAL("relax.transform.FuseOps").set_body_typed(FuseOps);
 
 Pass FuseOpsByPattern(const tvm::Array<String>& pattern_names,
                       const tvm::Array<DFPattern>& patterns,
-                      const tvm::Array<runtime::PackedFunc>& checks, bool lift_constants,
+                      const tvm::Array<runtime::PackedFunc>& checks, bool bind_constants,
                       bool annotate_codegen) {
   runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =  //
       [=](IRModule m, PassContext pc) {
-        return relax::FuseOpsByPattern(pattern_names, patterns, checks, m, lift_constants,
+        return relax::FuseOpsByPattern(pattern_names, patterns, checks, m, bind_constants,
                                        annotate_codegen);
       };
   return CreateModulePass(/*pass_function=*/pass_func,       //

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -574,6 +574,8 @@ class OperatorFusor : public ExprMutator {
    * \param mod The IRModule to be transformed
    * \param graph The indexed-forward graph of the input IRModule
    * \param groups The grouped result of the group partition on the input indexed-forward graph.
+   * \param lift_constant Whether or not to lift bound constants to parameters of the grouped
+   * function.
    */
   OperatorFusor(IRModule mod, const IndexedForwardGraph& graph, const std::vector<Group*>& groups,
                 bool lift_constant = true)
@@ -1052,7 +1054,7 @@ class CompositeFunctionAnnotator : public ExprMutator {
 IRModule FuseOpsByPattern(const tvm::Array<String>& pattern_names,
                           const tvm::Array<DFPattern>& patterns,
                           const tvm::Array<runtime::PackedFunc>& checks, IRModule mod,
-                          bool annotate_codegen) {
+                          bool lift_constants, bool annotate_codegen) {
   support::Arena arena;
   for (size_t i = 0; i < pattern_names.size(); ++i) {
     OperatorFusor::GroupMap group_map;
@@ -1064,7 +1066,7 @@ IRModule FuseOpsByPattern(const tvm::Array<String>& pattern_names,
                                               entry.second, &arena);
       group_map.insert(map.begin(), map.end());
     }
-    mod = MakeGroupedFunctions(mod, group_map, /*lift_constants*/ false);
+    mod = MakeGroupedFunctions(mod, group_map, /*lift_constants*/ lift_constants);
   }
   if (annotate_codegen) {
     return CompositeFunctionAnnotator(mod).Run();
@@ -1091,10 +1093,12 @@ TVM_REGISTER_GLOBAL("relax.transform.FuseOps").set_body_typed(FuseOps);
 
 Pass FuseOpsByPattern(const tvm::Array<String>& pattern_names,
                       const tvm::Array<DFPattern>& patterns,
-                      const tvm::Array<runtime::PackedFunc>& checks, bool annotate_codegen) {
+                      const tvm::Array<runtime::PackedFunc>& checks, bool lift_constants,
+                      bool annotate_codegen) {
   runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =  //
       [=](IRModule m, PassContext pc) {
-        return relax::FuseOpsByPattern(pattern_names, patterns, checks, m, annotate_codegen);
+        return relax::FuseOpsByPattern(pattern_names, patterns, checks, m, lift_constants,
+                                       annotate_codegen);
       };
   return CreateModulePass(/*pass_function=*/pass_func,       //
                           /*opt_level=*/0,                   //

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -226,7 +226,7 @@ def get_result_with_relax_cutlass_offload(mod, *args):
 
     seq = tvm.transform.Sequential(
         [
-            relax.transform.FuseOpsByPattern(patterns, lift_constants=True, annotate_codegen=True),
+            relax.transform.FuseOpsByPattern(patterns, bind_constants=False, annotate_codegen=True),
             relax.transform.RunCodegen({"cutlass": {"sm": 80, "find_first_valid": True}}),
         ]
     )

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -226,7 +226,7 @@ def get_result_with_relax_cutlass_offload(mod, *args):
 
     seq = tvm.transform.Sequential(
         [
-            relax.transform.FuseOpsByPattern(patterns, annotate_codegen=True),
+            relax.transform.FuseOpsByPattern(patterns, lift_constants=True, annotate_codegen=True),
             relax.transform.RunCodegen({"cutlass": {"sm": 80, "find_first_valid": True}}),
         ]
     )

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -389,8 +389,8 @@ conv2d_pat = make_fused_bias_activation_pattern("relax.nn.conv2d", activation=No
 conv2d_relu_pat = make_fused_bias_activation_pattern("relax.nn.conv2d", activation="relax.nn.relu")
 
 
-def check(mod, patterns, expected, annoatate_codegen=False):
-    partitioned = relax.transform.FuseOpsByPattern(patterns, annoatate_codegen)(mod)
+def check(mod, patterns, expected, lift_constants=False, annoatate_codegen=False):
+    partitioned = relax.transform.FuseOpsByPattern(patterns, lift_constants, annoatate_codegen)(mod)
     tvm.ir.assert_structural_equal(partitioned, expected)
 
 
@@ -424,7 +424,9 @@ def test_cyclic_dependency():
     add_pat = is_op("relax.add")(relu_pat, wildcard())
 
     with pytest.raises(tvm.error.TVMError) as err:
-        relax.transform.FuseOpsByPattern([("compiler_A.conv2d_relu_add", add_pat)])(Branch)
+        relax.transform.FuseOpsByPattern(
+            [("compiler_A.conv2d_relu_add", add_pat)], lift_constants=False
+        )(Branch)
 
     assert "A cyclic dependency detected" in str(err.value)
 
@@ -434,7 +436,9 @@ def test_bind_params():
     mod = tvm.transform.Sequential(
         [
             relax.transform.BindParams("main", {"weight1": weight_np}),
-            relax.transform.FuseOpsByPattern([("dnnl.conv2d_relu", conv2d_relu_pat)]),
+            relax.transform.FuseOpsByPattern(
+                [("dnnl.conv2d_relu", conv2d_relu_pat)], lift_constants=False
+            ),
         ]
     )(Conv2dReLU)
 
@@ -587,6 +591,55 @@ def test_check_pattern():
         return expr.struct_info.dtype == "float32"
 
     check(Conv2dx2, [("cutlass.conv2d", pat, pred)], Conv2dx2)  # expect no partitioning
+
+
+def test_lift_constants():
+    weight = np.random.randn(64, 64, 3, 3).astype("float32")
+
+    @I.ir_module
+    class Conv2dWithConstantWeight:
+        @R.function
+        def main(
+            data: R.Tensor((1, 64, 56, 56), "float32"),
+            weight1: R.Tensor((64, 64, 3, 3), "float32"),
+        ):
+            with R.dataflow():
+                conv1 = R.nn.conv2d(data, R.const(weight), padding=(1, 1))
+                R.output(conv1)
+            return conv1
+
+    @I.ir_module
+    class Conv2dWithConstantWeight_partitioned:
+        @R.function
+        def fused_relax_nn_conv2d(
+            data: R.Tensor((1, 64, 56, 56), dtype="float32"),
+            param_0: R.Tensor((64, 64, 3, 3), dtype="float32"),
+        ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+            R.func_attr({"Composite": "cutlass.conv2d", "Primitive": 1})
+            with R.dataflow():
+                gv = R.nn.conv2d(data, param_0, padding=(1, 1))
+                R.output(gv)
+            return gv
+
+        @R.function
+        def main(
+            data: R.Tensor((1, 64, 56, 56), dtype="float32"),
+            weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
+        ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+            with R.dataflow():
+                gv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(
+                    data, R.const(weight)
+                )
+                R.output(gv)
+            return gv
+
+    pat = make_fused_bias_activation_pattern("relax.nn.conv2d", with_bias=False, activation=None)
+    check(
+        Conv2dWithConstantWeight,
+        [("cutlass.conv2d", pat)],
+        Conv2dWithConstantWeight_partitioned,
+        lift_constants=True,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR added `lift_constants` option to FuseOpsByPattern since different BYOC backends have different requirements on whether constants should be lifted.

cc @masahi 