### PR TITLE
[Unity][Analysis] Checking function return struct info in well-formed check

### DIFF
--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -225,6 +225,12 @@ class WellFormedChecker : public relax::ExprVisitor,
       }
       param_var_func_map_.insert({param, GetRef<Function>(op)});
     }
+    // check function ret_struct_info
+    if (op->ret_struct_info.defined()) {
+      this->VisitStructInfo(op->ret_struct_info);
+    } else {
+      Malformed(Diagnostic::Error(op) << "Function must have defined ret_struct_info");
+    }
 
     if (auto seq = op->body.as<SeqExprNode>()) {
       this->VisitSeqExpr(seq);


### PR DESCRIPTION
The current well-formed misses the check of function return struct info, which may mistakenly pass the check if there are undefined vars in the function return struct info.