### PR TITLE
[TVMC][UMA] Support using UMA with TVMC

### DIFF
--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -48,7 +48,7 @@ logger = logging.getLogger("TVMC")
 
 
 @register_parser
-def add_tune_parser(subparsers, _, json_params):
+def add_tune_parser(subparsers, _, json_params, argv):
     """Include parser for 'tune' subcommand"""
 
     parser = subparsers.add_parser("tune", help="auto-tune a model")

--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -48,7 +48,7 @@ logger = logging.getLogger("TVMC")
 
 
 @register_parser
-def add_tune_parser(subparsers, _, json_params, argv):
+def add_tune_parser(subparsers, _, json_params, argv):  # pylint: disable=unused-argument
     """Include parser for 'tune' subcommand"""
 
     parser = subparsers.add_parser("tune", help="auto-tune a model")

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -71,9 +71,13 @@ def add_compile_parser(subparsers, main_parser, json_params, argv):
     disposable_parser = TVMCSuppressedArgumentParser(main_parser)
     try:
         known_args, _ = disposable_parser.parse_known_args(argv)
-        _handle_extensions(known_args.experimental_tvm_extension)
     except TVMCException:
         pass
+    try:
+        ext_dirs = known_args.experimental_tvm_extension
+    except AttributeError:
+        ext_dirs = []
+    _handle_extensions(ext_dirs)
 
     parser.add_argument(
         "--cross-compiler",

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -21,7 +21,6 @@ Provides support to compile networks both AOT and JIT.
 import logging
 import os.path
 import re
-import sys
 import itertools
 from copy import deepcopy
 from typing import Any, Optional, Dict, List, Union, Callable, Sequence
@@ -59,14 +58,15 @@ logger = logging.getLogger("TVMC")
 def add_compile_parser(subparsers, main_parser, json_params, argv):
     """Include parser for 'compile' subcommand"""
 
-    parser = subparsers.add_parser("compile", help="compile a model.")
+    parser = subparsers.add_parser("compile", help="compile a model.", add_help=False)
     parser.set_defaults(func=drive_compile)
 
     parser.add_argument(
         "--experimental-tvm-extension",
         default=[],
         action="append",
-        help="path from which to load packages named tvm_extension which implement the TVMExtension interface.",
+        help="path from which to load packages named tvm_extension which implement the "
+        "TVMExtension interface.",
     )
     disposable_parser = TVMCSuppressedArgumentParser(main_parser)
     try:

--- a/python/tvm/driver/tvmc/extensions.py
+++ b/python/tvm/driver/tvmc/extensions.py
@@ -29,7 +29,7 @@ from abc import abstractmethod
 _EXTENSIONS = []
 
 
-class TVMExtension(object):
+class TVMCExtension(object):
     @abstractmethod
     def uma_backends(self):
         return []
@@ -46,8 +46,8 @@ def load_extensions(paths):
     """
     Loads extensions from the given locations.
 
-    Extensions must implement the `TVMExtension` interface and be stored in a directory called
-    `tvm_extension`.
+    Extensions must implement the `TVMCExtension` interface and be stored in a directory called
+    `tvmc_extension`.
     """
 
     path_backup = copy.copy(sys.path)
@@ -55,7 +55,7 @@ def load_extensions(paths):
 
     top_modules = []
     try:
-        mod = importlib.import_module("tvm_extension")
+        mod = importlib.import_module("tvmc_extension")
         top_modules.append(mod)
     except ImportError:
         pass
@@ -125,4 +125,4 @@ def _scan_all(top_level):
 
 
 def _is_concrete_extension_type(obj):
-    return inspect.isclass(obj) and issubclass(obj, TVMExtension) and not inspect.isabstract(obj)
+    return inspect.isclass(obj) and issubclass(obj, TVMCExtension) and not inspect.isabstract(obj)

--- a/python/tvm/driver/tvmc/extensions.py
+++ b/python/tvm/driver/tvmc/extensions.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import sys
 import importlib
 import inspect
@@ -95,8 +112,4 @@ def _scan_all(top_level):
 
 
 def _is_concrete_extension_type(obj):
-    return (
-        inspect.isclass(obj)
-        and issubclass(obj, TVMExtension)
-        and not inspect.isabstract(obj)
-    )
+    return inspect.isclass(obj) and issubclass(obj, TVMExtension) and not inspect.isabstract(obj)

--- a/python/tvm/driver/tvmc/extensions.py
+++ b/python/tvm/driver/tvmc/extensions.py
@@ -1,0 +1,102 @@
+import sys
+import importlib
+import inspect
+import pkgutil
+import warnings
+from abc import abstractmethod
+
+
+_extensions = []
+
+
+class TVMExtension(object):
+    @abstractmethod
+    def uma_backends(self):
+        return []
+
+
+def get_extensions():
+    for ext in _extensions:
+        yield ext
+
+
+def load_extensions(paths):
+    path_backup = sys.path
+    sys.path.extend(paths)
+
+    top_modules = []
+    try:
+        mod = importlib.import_module("tvm_extension")
+        top_modules.append(mod)
+    except ImportError:
+        pass
+
+    sys.path = path_backup
+
+    extension_classes = _scan_all(top_modules)
+    for ext_cls in extension_classes:
+        _extensions.append(ext_cls())
+
+
+def _scan_all(top_level):
+    scanned_extensions = []
+    for mdl in top_level:
+        for importer, modname, ispkg in pkgutil.walk_packages(
+            path=mdl.__path__, prefix=mdl.__name__ + ".", onerror=lambda x: None
+        ):
+            try:
+                module_name = modname.rsplit(".", 1)[-1]
+                # If module's name starts with "_", do not load the module.
+                # But if the module's name starts with a "__", then load the
+                # module.
+                if module_name.startswith("_") and not module_name.startswith("__"):
+                    continue
+
+                with warnings.catch_warnings(record=True) as recorded_warnings:
+                    if sys.version_info < (3, 10):
+                        m = importer.find_module(modname)  # type: ignore
+                        assert m is not None
+                        loaded_mod = m.load_module(modname)
+                    else:
+                        spec = importer.find_spec(modname)
+                        assert spec is not None
+                        if modname in sys.modules:
+                            loaded_mod = sys.modules[modname]
+                        else:
+                            loaded_mod = importlib.util.module_from_spec(spec)
+                        if loaded_mod is not None:
+                            spec.loader.exec_module(loaded_mod)
+                            sys.modules[modname] = loaded_mod
+
+                if len(recorded_warnings) > 0:
+                    for w in recorded_warnings:
+                        warnings.showwarning(
+                            message=w.message,
+                            category=w.category,
+                            filename=w.filename,
+                            lineno=w.lineno,
+                            file=w.file,
+                            line=w.line,
+                        )
+
+                if loaded_mod is not None:
+                    for _name, obj in inspect.getmembers(loaded_mod):
+                        if _is_concrete_extension_type(obj):
+                            scanned_extensions.append(obj)
+            except ImportError as e:
+                warnings.warn(
+                    message=f"\n"
+                    f"\tError importing extension '{modname}'.\n"
+                    f"\t\t{type(e).__name__} : {e}",
+                    category=UserWarning,
+                )
+
+    return scanned_extensions
+
+
+def _is_concrete_extension_type(obj):
+    return (
+        inspect.isclass(obj)
+        and issubclass(obj, TVMExtension)
+        and not inspect.isabstract(obj)
+    )

--- a/python/tvm/driver/tvmc/main.py
+++ b/python/tvm/driver/tvmc/main.py
@@ -80,7 +80,7 @@ def _main(argv):
 
     subparser = parser.add_subparsers(title="commands")
     for make_subparser in REGISTERED_PARSER:
-        make_subparser(subparser, parser, json_config_values)
+        make_subparser(subparser, parser, json_config_values, argv)
 
     # Finally, add help for the main parser.
     parser.add_argument("-h", "--help", action="help", help="show this help message and exit.")

--- a/python/tvm/driver/tvmc/micro.py
+++ b/python/tvm/driver/tvmc/micro.py
@@ -46,7 +46,7 @@ except (ImportError, NameError):
 
 
 @register_parser
-def add_micro_parser(subparsers, main_parser, json_params):
+def add_micro_parser(subparsers, main_parser, json_params, argv):
     """Includes parser for 'micro' context and associated subcommands:
     create-project (create), build, and flash.
     """
@@ -163,7 +163,7 @@ def add_micro_parser(subparsers, main_parser, json_params):
 
     disposable_parser = TVMCSuppressedArgumentParser(main_parser)
     try:
-        known_args, _ = disposable_parser.parse_known_args()
+        known_args, _ = disposable_parser.parse_known_args(argv)
     except TVMCException:
         return
 

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -64,7 +64,7 @@ logger = logging.getLogger("TVMC")
 
 
 @register_parser
-def add_run_parser(subparsers, main_parser, json_params):
+def add_run_parser(subparsers, main_parser, json_params, argv):
     """Include parser for 'run' subcommand"""
 
     # Use conflict_handler='resolve' to allow '--list-options' option to be properly overriden when
@@ -157,7 +157,7 @@ def add_run_parser(subparsers, main_parser, json_params):
 
     disposable_parser = TVMCSuppressedArgumentParser(main_parser)
     try:
-        known_args, _ = disposable_parser.parse_known_args()
+        known_args, _ = disposable_parser.parse_known_args(argv)
     except TVMCException:
         return
 

--- a/python/tvm/micro/model_library_format.py
+++ b/python/tvm/micro/model_library_format.py
@@ -666,4 +666,4 @@ def export_model_library_format(
 
     _make_tar(tempdir.path, file_name, modules)
 
-    return file_name
+    return str(file_name)

--- a/python/tvm/relay/backend/contrib/uma/api/lower.py
+++ b/python/tvm/relay/backend/contrib/uma/api/lower.py
@@ -71,7 +71,9 @@ class UMALower:
         )
 
         compiler_attr = relay_prim_func.attrs["Compiler"]
-        target = tvm.target.Target(compiler_attr)
+        target = tvm.target.Target.current()
+        if target is None or target.kind.name != compiler_attr:
+            target = tvm.target.Target(compiler_attr)
 
         tir_prim_func = tir_prim_func.with_attr("target", target)
         tir_prim_func = tir_prim_func.with_attr("relay_attrs", relay_prim_func.attrs)

--- a/python/tvm/relay/backend/contrib/uma/api/lower.py
+++ b/python/tvm/relay/backend/contrib/uma/api/lower.py
@@ -71,9 +71,7 @@ class UMALower:
         )
 
         compiler_attr = relay_prim_func.attrs["Compiler"]
-        target = tvm.target.Target.current()
-        if target.kind.name != compiler_attr:
-            target = tvm.target.Target(compiler_attr)
+        target = tvm.target.Target(compiler_attr)
 
         tir_prim_func = tir_prim_func.with_attr("target", target)
         tir_prim_func = tir_prim_func.with_attr("relay_attrs", relay_prim_func.attrs)

--- a/python/tvm/relay/backend/contrib/uma/api/partitioner.py
+++ b/python/tvm/relay/backend/contrib/uma/api/partitioner.py
@@ -73,7 +73,7 @@ class UMAPartitioner:
         register_pattern_table(self.target_name, self._pattern_table)
 
     def partition(
-        self, mod: tvm.IRModule, params: Optional[Dict[str, tvm.runtime.NDArray]] = None
+        self, mod: tvm.IRModule, params: Optional[Dict[str, tvm.runtime.NDArray]] = None, mod_name: Optional[str] = "default"
     ) -> tvm.IRModule:
         """Partition the relay graph in parts supported and unsupported by the
         target hardware accelerator.
@@ -102,7 +102,7 @@ class UMAPartitioner:
         pass_sequence.append(relay.transform.AnnotateTarget(self.target_name))
         if self.merge_compiler_regions:
             pass_sequence.append(relay.transform.MergeCompilerRegions())
-        pass_sequence.append(relay.transform.PartitionGraph())
+        pass_sequence.append(relay.transform.PartitionGraph(mod_name=mod_name))
         pass_sequence.extend(
             [p[1] for p in self._relay_passes if p[0] == PassPhase.POST_PARTITIONING_0]
         )

--- a/python/tvm/relay/backend/contrib/uma/api/partitioner.py
+++ b/python/tvm/relay/backend/contrib/uma/api/partitioner.py
@@ -73,7 +73,10 @@ class UMAPartitioner:
         register_pattern_table(self.target_name, self._pattern_table)
 
     def partition(
-        self, mod: tvm.IRModule, params: Optional[Dict[str, tvm.runtime.NDArray]] = None, mod_name: Optional[str] = "default"
+        self,
+        mod: tvm.IRModule,
+        params: Optional[Dict[str, tvm.runtime.NDArray]] = None,
+        mod_name: Optional[str] = "default",
     ) -> tvm.IRModule:
         """Partition the relay graph in parts supported and unsupported by the
         target hardware accelerator.

--- a/python/tvm/relay/backend/contrib/uma/backend.py
+++ b/python/tvm/relay/backend/contrib/uma/backend.py
@@ -290,6 +290,9 @@ class UMABackend(ABC):
             self._tir_to_runtime.register()
 
     def partition(
-        self, mod: tvm.IRModule, params: Optional[Dict[str, tvm.runtime.NDArray]] = None, mod_name: Optional[str] = "default"
+        self,
+        mod: tvm.IRModule,
+        params: Optional[Dict[str, tvm.runtime.NDArray]] = None,
+        mod_name: Optional[str] = "default",
     ) -> tvm.IRModule:
         return self._relay_to_relay.partition(mod, params, mod_name=mod_name)

--- a/python/tvm/relay/backend/contrib/uma/backend.py
+++ b/python/tvm/relay/backend/contrib/uma/backend.py
@@ -290,6 +290,6 @@ class UMABackend(ABC):
             self._tir_to_runtime.register()
 
     def partition(
-        self, mod: tvm.IRModule, params: Optional[Dict[str, tvm.runtime.NDArray]] = None
+        self, mod: tvm.IRModule, params: Optional[Dict[str, tvm.runtime.NDArray]] = None, mod_name: Optional[str] = "default"
     ) -> tvm.IRModule:
-        return self._relay_to_relay.partition(mod, params)
+        return self._relay_to_relay.partition(mod, params, mod_name=mod_name)

--- a/tests/python/contrib/test_uma/invalid_ext/tvmc_extension/invalid.py
+++ b/tests/python/contrib/test_uma/invalid_ext/tvmc_extension/invalid.py
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import nonexistingmodule
+
+nonexistingmodule.value = 1

--- a/tests/python/contrib/test_uma/test_tvmc.py
+++ b/tests/python/contrib/test_uma/test_tvmc.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+pytest.importorskip("tensorflow")
+
+import os
+from unittest import mock
+import tvm
+from tensorflow import keras
+from tvm.relay.backend.contrib.uma import uma_available
+from tvm.driver.tvmc.main import _main
+
+pytestmark = pytest.mark.skipif(not uma_available(), reason="UMA not available")
+
+
+def test_conv2d(tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp("data")
+    model_path = os.path.join(tmpdir, "model.h5")
+    package_path = os.path.join(tmpdir, "out.tar")
+
+    model = keras.Sequential(
+        [
+            keras.layers.InputLayer(input_shape=[10, 10, 3], batch_size=1),
+            keras.layers.Conv2D(5, kernel_size=(3, 3)),
+            keras.layers.Activation("relu"),
+        ]
+    )
+    model.save(model_path)
+
+    extension_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "vanilla_ext")
+    compile_str = (
+        f"tvmc compile --target vanilla_accelerator,c -f mlf "
+        f"--experimental-tvm-extension={extension_dir} "
+        f"--desired-layout NCHW "
+        f"--output={package_path} {model_path}"
+    )
+    compile_args = compile_str.split(" ")[1:]
+    assert _main(compile_args) == 0
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/contrib/test_uma/vanilla_ext/tvm_extension/vanilla.py
+++ b/tests/python/contrib/test_uma/vanilla_ext/tvm_extension/vanilla.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from tvm.driver.tvmc.extensions import TVMExtension
+from tests.python.contrib.test_uma.test_uma_vanilla_accelerator import VanillaAcceleratorBackend
+
+
+class VanillaExtension(TVMExtension):
+    def __init__(self):
+        self.backend = VanillaAcceleratorBackend()
+
+    def uma_backends(self):
+        return [self.backend]

--- a/tests/python/contrib/test_uma/vanilla_ext/tvmc_extension/vanilla.py
+++ b/tests/python/contrib/test_uma/vanilla_ext/tvmc_extension/vanilla.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from tvm.driver.tvmc.extensions import TVMExtension
+from tvm.driver.tvmc.extensions import TVMCExtension
 from tests.python.contrib.test_uma.test_uma_vanilla_accelerator import VanillaAcceleratorBackend
 
 
-class VanillaExtension(TVMExtension):
+class VanillaExtension(TVMCExtension):
     def __init__(self):
         self.backend = VanillaAcceleratorBackend()
 


### PR DESCRIPTION
This change introduces:

- A `TVMExtension` interface to extend TVMC with custom code. Currently its only use is to add `UMABackend`s.
- A command line option `--experimental-tvm-extension <dir>` to point to extension modules.
- An envvar `$TVM_EXTENSION_DIR` for the same purpose.

See discussion thread: https://discuss.tvm.apache.org/t/tvmc-uma-integration/14309

@Mousius @cgerum @MichaelJKlaiber @PhilippvK 