### PR TITLE
[Unity][BYOC] Add batch matmul support to Relax CUTLASS BYOC

### DIFF
--- a/python/tvm/contrib/cutlass/gemm_operation.py
+++ b/python/tvm/contrib/cutlass/gemm_operation.py
@@ -287,7 +287,7 @@ def instantiate_gemm_template(attrs):
    {static_cast<ElementInputA*>(ptr_a), ${lda}}, ${batch_stride_A}
    {static_cast<ElementInputB*>(ptr_b), ${ldb}}, ${batch_stride_B}
    {static_cast<ElementOutput*>(${ptr_c}), ${c_stride}}, ${batch_stride_C}
-   {static_cast<ElementOutput*>(ptr_out), ${ldc}}, ${batch_stride_C}
+   {static_cast<ElementOutput*>(ptr_out), ${ldc}}, ${batch_stride_D}
    {${alpha_beta}},
    ${split_k_slices_or_batch}
   };
@@ -303,8 +303,7 @@ def instantiate_gemm_template(attrs):
 """
     has_bias = "bias" in attrs["op_type"]
     is_gelu = "gelu" in attrs["op_type"]
-    batched = "batch_matmul" in attrs["op_type"]
-
+    batched = "batch" in attrs
     aux_map = {"kernel": "Gemm"}
 
     if has_bias:
@@ -334,6 +333,10 @@ def instantiate_gemm_template(attrs):
             aux_map[key] = ""
         else:
             aux_map[key] = attrs[key] + ","
+
+    aux_map["batch_stride_D"] = aux_map["batch_stride_C"]
+    if has_bias and batched:
+        aux_map["batch_stride_C"] = "0,"
 
     if batched:
         attrs["split_k_slices_or_batch"] = attrs["batch"]

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -559,11 +559,7 @@ def instantiate_template(func_name, annotations, func_args):
 
         if batched:
             headers.append("cutlass/gemm/device/gemm_batched.h")
-            # TODO: Support dynamic shape
-            # With the support of more general broadcasting in batch matmul,
-            # like matmul with shape (a, b, c, 5, 6) x (6, 8),
-            # it needs more sophisticated code to handle dynamic shape
-            attrs["batch"] = str(int(annotations["batch"]))
+            attrs["batch"] = get_dim(annotations["batch"], lhs_arg, 0)
             attrs["batch_stride_A"] = get_batch_stride(
                 annotations["batch_stride_A"],
                 lhs_arg_idx,

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -561,6 +561,7 @@ def instantiate_template(func_name, annotations, func_args):
             headers.append("cutlass/gemm/device/gemm_batched.h")
             # TODO: Support dynamic shape
             # With the support of more general broadcasting in batch matmul,
+            # like matmul with shape (a, b, c, 5, 6) x (6, 8),
             # it needs more sophisticated code to handle dynamic shape
             attrs["batch"] = str(int(annotations["batch"]))
             attrs["batch_stride_A"] = get_batch_stride(

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -17,16 +17,56 @@
 
 """Pattern table for CUTLASS backend"""
 
-from tvm.relax import transform
+from typing import Mapping, Optional, Tuple
+
+import tvm
+from tvm.contrib.cutlass.build import is_valid_for_cutlass_matmul
+from tvm.relax import Call, Expr, ShapeExpr, transform
+from tvm.relax.dpl import DFPattern
 
 from ..pattern_registry import get_patterns_with_prefix, register_patterns
 from ..patterns import make_fused_bias_activation_pattern, make_matmul_pattern
+
+
+def _get_static_shape(shape: ShapeExpr) -> Optional[Tuple[int]]:
+    result = []
+    for dim in shape.values:
+        if isinstance(dim, tvm.tir.expr.IntImm):
+            result.append(int(dim))
+        else:
+            return None
+    return result
+
+
+def _check_matmul(
+    match_result: Mapping[DFPattern, Expr],
+    _: Expr,
+) -> bool:
+    matmul_call: Call = None
+    for _, expr in match_result.items():
+        if isinstance(expr, Call) and expr.op.name == "relax.matmul":
+            matmul_call = expr
+    if matmul_call is None:
+        raise ValueError("Cannot find call to matmul from match_result.")
+
+    lhs_shape = _get_static_shape(matmul_call.args[0].struct_info.shape)
+    rhs_shape = _get_static_shape(matmul_call.args[1].struct_info.shape)
+    if len(lhs_shape) < 2 or len(rhs_shape) < 2:
+        return False
+
+    lhs_dtype = matmul_call.args[0].struct_info.dtype
+    rhs_dtype = matmul_call.args[1].struct_info.dtype
+    if lhs_dtype != "float16" or rhs_dtype != "float16":
+        return False
+
+    return is_valid_for_cutlass_matmul(lhs_shape, rhs_shape)
+
 
 register_patterns(
     [
         (
             "cutlass.conv2d",
-            make_fused_bias_activation_pattern(
+            *make_fused_bias_activation_pattern(
                 "relax.nn.conv2d",
                 with_bias=False,
                 activation=None,
@@ -34,7 +74,7 @@ register_patterns(
         ),
         (
             "cutlass.conv2d_bias_relu",
-            make_fused_bias_activation_pattern(
+            *make_fused_bias_activation_pattern(
                 "relax.nn.conv2d",
                 with_bias=True,
                 activation="relax.nn.relu",
@@ -42,59 +82,67 @@ register_patterns(
         ),
         (
             "cutlass.matmul",
-            make_matmul_pattern(
+            *make_matmul_pattern(
                 with_bias=False,
             ),
+            _check_matmul,
         ),
         (
             "cutlass.matmul_bias",
-            make_matmul_pattern(
+            *make_matmul_pattern(
                 with_bias=True,
             ),
+            _check_matmul,
         ),
         (
             "cutlass.matmul_bias_relu",
-            make_matmul_pattern(
+            *make_matmul_pattern(
                 with_bias=True,
                 activation="relax.nn.relu",
             ),
+            _check_matmul,
         ),
         (
             "cutlass.matmul_bias_gelu",
-            make_matmul_pattern(
+            *make_matmul_pattern(
                 with_bias=True,
                 activation="relax.nn.gelu",
             ),
+            _check_matmul,
         ),
         (
             "cutlass.matmul_transposed",
-            make_matmul_pattern(
+            *make_matmul_pattern(
                 with_bias=False,
                 transposed_rhs=True,
             ),
+            _check_matmul,
         ),
         (
             "cutlass.matmul_transposed_bias",
-            make_matmul_pattern(
+            *make_matmul_pattern(
                 with_bias=True,
                 transposed_rhs=True,
             ),
+            _check_matmul,
         ),
         (
             "cutlass.matmul_transposed_bias_relu",
-            make_matmul_pattern(
+            *make_matmul_pattern(
                 with_bias=True,
                 activation="relax.nn.relu",
                 transposed_rhs=True,
             ),
+            _check_matmul,
         ),
         (
             "cutlass.matmul_transposed_bias_gelu",
-            make_matmul_pattern(
+            *make_matmul_pattern(
                 with_bias=True,
                 activation="relax.nn.gelu",
                 transposed_rhs=True,
             ),
+            _check_matmul,
         ),
     ]
 )
@@ -116,7 +164,6 @@ def partition_for_cutlass(mod):
         compiled by the CUTLASS backend.
     """
 
-    cutlass_patterns = get_patterns_with_prefix("cutlass")
-    return transform.FuseOpsByPattern(cutlass_patterns, bind_constants=True, annotate_codegen=True)(
-        mod
-    )
+    cutlass_pattern_entries = get_patterns_with_prefix("cutlass")
+    patterns = [(e.name, e.pattern, e.check) for e in cutlass_pattern_entries]
+    return transform.FuseOpsByPattern(patterns, bind_constants=True, annotate_codegen=True)(mod)

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -53,7 +53,11 @@ def _check_matmul(
 ) -> bool:
     matmul_call: Call = None
     for _, expr in match_result.items():
-        if isinstance(expr, Call) and expr.op.name == "relax.matmul":
+        if (
+            isinstance(expr, Call)
+            and isinstance(expr.op, tvm.ir.Op)
+            and expr.op.name == "relax.matmul"
+        ):
             matmul_call = expr
     if matmul_call is None:
         raise ValueError("Cannot find call to matmul from match_result.")
@@ -175,4 +179,4 @@ def partition_for_cutlass(mod):
 
     cutlass_pattern_entries = get_patterns_with_prefix("cutlass")
     patterns = [(e.name, e.pattern, e.check) for e in cutlass_pattern_entries]
-    return transform.FuseOpsByPattern(patterns, bind_constants=True, annotate_codegen=True)(mod)
+    return transform.FuseOpsByPattern(patterns, bind_constants=False, annotate_codegen=True)(mod)

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -38,6 +38,15 @@ def _get_static_shape(shape: ShapeExpr) -> Optional[Tuple[int]]:
     return result
 
 
+def _is_supported_dtype(lhs_dtype, rhs_dtype):
+    """Check if dtypes in the given workload are supported by CUTLASS."""
+    return (
+        (lhs_dtype == "float16" and rhs_dtype == "float16")
+        or (lhs_dtype == "float32" and rhs_dtype == "float32")
+        or (lhs_dtype in ("int8", "uint8") and rhs_dtype in ("int8", "uint8"))
+    )
+
+
 def _check_matmul(
     match_result: Mapping[DFPattern, Expr],
     _: Expr,
@@ -56,7 +65,7 @@ def _check_matmul(
 
     lhs_dtype = matmul_call.args[0].struct_info.dtype
     rhs_dtype = matmul_call.args[1].struct_info.dtype
-    if lhs_dtype != "float16" or rhs_dtype != "float16":
+    if not _is_supported_dtype(lhs_dtype, rhs_dtype):
         return False
 
     return is_valid_for_cutlass_matmul(lhs_shape, rhs_shape)

--- a/python/tvm/relax/backend/pattern_registry.py
+++ b/python/tvm/relax/backend/pattern_registry.py
@@ -17,14 +17,15 @@
 
 """Pattern registry for BYOC backends"""
 
-from typing import Callable, List, Mapping, Optional, Tuple, Union
+import atexit
+from typing import Callable, List, Mapping, Optional, Set, Tuple, Union
 
 import tvm
 from tvm.relax.dpl import DFPattern
 from tvm.runtime import Object
 
-from . import _ffi_api
 from ..expr import Expr
+from . import _ffi_api
 
 
 @tvm._ffi.register_object("relax.backend.PatternRegistryEntry")
@@ -46,25 +47,59 @@ class PatternRegistryEntry(Object):
     arg_patterns: Mapping[str, DFPattern]
         The mapping from arg name to its pattern. It can be used to extract arg expression
         from match result. All DFPattern in this map should be part of the `pattern`.
+
+    check: Callable[[Mapping[DFPattern, Expr], Expr], bool]
+        The function to check whether the match result is accepted.
     """
 
     name: str
     pattern: DFPattern
     arg_patterns: Mapping[str, DFPattern]
+    check: Callable[[Mapping[DFPattern, Expr], Expr], bool]
 
-    def __init__(self, name: str, pattern: DFPattern, arg_patterns: Mapping[str, DFPattern]):
+    def __init__(
+        self,
+        name: str,
+        pattern: DFPattern,
+        arg_patterns: Mapping[str, DFPattern],
+        check: Callable[[Mapping[DFPattern, Expr], Expr], bool],
+    ):
         self.__init_handle_by_constructor__(
-            _ffi_api.PatternRegistryEntry, name, pattern, arg_patterns  # type: ignore
+            _ffi_api.PatternRegistryEntry, name, pattern, arg_patterns, check  # type: ignore
         )
 
 
+_REGISTERED_PATTERN_NAMES: Set[str] = set()
+
+
+def _cleanup_registered_patterns():
+    _ffi_api.RemovePatterns(list(_REGISTERED_PATTERN_NAMES))  # type: ignore # pylint: disable=no-member
+
+
+_CLEANUP_REGISTERED = False
+
+
+def _ensure_cleanup_function_registered():
+    """
+    Add a cleanup function to be called on interpreter termination, to remove all
+    patterns registered on the Python side. Without cleaning up those patterns,
+    program will segfault on termination. It's because the check functiosn of pattern
+    entries are referenced from the static memory of libtvm, thus they will be cleaned
+    up at the very end, making calls to Py_DecRef after Python interpreter terminates.
+    """
+    global _CLEANUP_REGISTERED  # pylint: disable=global-statement
+
+    if not _CLEANUP_REGISTERED:
+        atexit.register(_cleanup_registered_patterns)
+        _CLEANUP_REGISTERED = True
+
+
+CheckFunc = Callable[[Mapping[DFPattern, Expr], Expr], bool]
 Pattern = Union[
     PatternRegistryEntry,
     Tuple[str, DFPattern],
-    Tuple[
-        str,
-        Tuple[DFPattern, Mapping[str, DFPattern], Callable[[Mapping[DFPattern, Expr], Expr], bool]],
-    ],
+    Tuple[str, DFPattern, Mapping[str, DFPattern]],
+    Tuple[str, DFPattern, Mapping[str, DFPattern], CheckFunc],
 ]
 
 
@@ -79,21 +114,27 @@ def register_patterns(patterns: List[Pattern]):
         Patterns to be registered. Patterns that appear later in the list have
         higher priority when partitioning DataflowBlock.
     """
+    _ensure_cleanup_function_registered()
+
     entries = []
     for item in patterns:
         if isinstance(item, PatternRegistryEntry):
             entries.append(item)
         elif isinstance(item, tuple):
-            name, pattern_or_tuple = item
-            if isinstance(pattern_or_tuple, tuple):
-                if len(pattern_or_tuple) == 2:
-                    pattern, arg_patterns = pattern_or_tuple
-                    check = lambda *_: True
-                else:
-                    pattern, arg_patterns, check = pattern_or_tuple
+            name, pattern, *rest = item
+
+            if len(rest) > 0:
+                arg_patterns = rest[0]
             else:
-                pattern, arg_patterns, check = pattern_or_tuple, {}, lambda *_: True
-            entries.append(PatternRegistryEntry(name, pattern, arg_patterns))
+                arg_patterns = {}
+
+            if len(rest) > 1:
+                check = rest[1]
+            else:
+                check = lambda *_: True
+
+            entries.append(PatternRegistryEntry(name, pattern, arg_patterns, check))
+            _REGISTERED_PATTERN_NAMES.add(name)
         else:
             raise TypeError(f"Cannot register type {type(pattern)} as pattern")
     _ffi_api.RegisterPatterns(entries)

--- a/python/tvm/relax/backend/pattern_registry.py
+++ b/python/tvm/relax/backend/pattern_registry.py
@@ -83,7 +83,7 @@ def _ensure_cleanup_function_registered():
     """
     Add a cleanup function to be called on interpreter termination, to remove all
     patterns registered on the Python side. Without cleaning up those patterns,
-    program will segfault on termination. It's because the check functiosn of pattern
+    program will segfault on termination. It's because the check functions of pattern
     entries are referenced from the static memory of libtvm, thus they will be cleaned
     up at the very end, making calls to Py_DecRef after Python interpreter terminates.
     """

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -40,7 +40,6 @@
 
 #include "../../relay/analysis/graph_partitioner.h"
 #include "../../support/arena.h"
-#include "../backend/pattern_registry.h"
 
 namespace tvm {
 namespace relax {

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -902,7 +902,7 @@ class PatternBasedPartitioner : ExprVisitor {
   using Group = GraphPartitioner::Group;
   using GroupMap = OperatorFusor::GroupMap;
   using ExprVisitor::VisitExpr_;
-  using FCheckMatch = backend::PatternRegistryEntryNode::FCheckMatch;
+  using FCheckMatch = runtime::TypedPackedFunc<bool(const Map<DFPattern, Expr>&, const Expr&)>;
 
   static GroupMap Run(String pattern_name, DFPattern pattern, FCheckMatch check, Expr expr,
                       support::Arena* arena) {

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -16,11 +16,14 @@
 # under the License.
 import numpy as np
 import pytest
+import scipy
 
 import tvm
 import tvm.testing
-from tvm import relax
+from tvm import relax, relay
+from tvm.contrib.cutlass.build import is_valid_for_cutlass_matmul
 from tvm.relax.backend import get_patterns_with_prefix
+from tvm.relax.backend.contrib.cutlass import partition_for_cutlass
 from tvm.script import relax as R
 
 
@@ -95,17 +98,13 @@ def build_and_run(mod, inputs_np, target, legalize=False):
 
 def get_result_with_relax_cutlass_offload(mod, *args):
     patterns = [(entry.name, entry.pattern) for entry in get_patterns_with_prefix("cutlass")]
-
     assert len(patterns) != 0, "Cannot find cutlass patterns"
 
-    seq = tvm.transform.Sequential(
-        [
-            relax.transform.FuseOpsByPattern(patterns, bind_constants=False, annotate_codegen=True),
-            relax.transform.RunCodegen({"cutlass": {"sm": 80, "find_first_valid": True}}),
-        ]
-    )
+    mod = partition_for_cutlass(mod)
+    codegen_pass = relax.transform.RunCodegen({"cutlass": {"sm": 80, "find_first_valid": True}})
+    mod = codegen_pass(mod)
 
-    return build_and_run(seq(mod), args, "cuda")
+    return build_and_run(mod, args, "cuda")
 
 
 def test_conv2d_offload():
@@ -120,12 +119,27 @@ def test_conv2d_offload():
     np.testing.assert_equal(out, ref)
 
 
+def test_kernel_sharing():
+    data_np = np.random.randn(16, 32, 32, 16).astype("float16")
+    weight1_np = np.random.randn(16, 3, 3, 16).astype("float16")
+    weight2_np = np.random.randn(16, 3, 3, 16).astype("float16")
+
+    out = get_result_with_relax_cutlass_offload(Conv2dx2, data_np, weight1_np, weight2_np)
+
+    relay_expr = get_relay_conv2d_relu_x2(data_np.shape, weight1_np.shape)
+    ref = get_relay_ref(relay_expr, data_np, weight1_np, weight2_np)
+
+    tvm.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
+
+
 def get_relax_matmul_module(x, y, transposed_y=False, with_bias=False, activation=None):
+    m, k = x.shape[-2:]
     if transposed_y:
         n = y.shape[-2]
     else:
         n = y.shape[-1]
     dtype = str(x.dtype)
+    y_shape = y.shape
 
     from tvm.script.ir_builder import IRBuilder
     from tvm.script.ir_builder import relax as relax_builder
@@ -140,7 +154,8 @@ def get_relax_matmul_module(x, y, transposed_y=False, with_bias=False, activatio
 
             with R.dataflow() as frame:
                 if transposed_y:
-                    y = R.emit(R.permute_dims(y))
+                    axes = list(range(len(y_shape) - 2)) + [-1, -2]
+                    y = R.emit(R.permute_dims(y, axes=axes))
                 result = R.emit(R.matmul(x, y, out_dtype=dtype))
                 if with_bias:
                     result = R.emit(result + bias)
@@ -154,140 +169,138 @@ def get_relax_matmul_module(x, y, transposed_y=False, with_bias=False, activatio
     return tvm.IRModule({"main": func})
 
 
-@pytest.fixture(params=["float16"])
-def target_dtype(request):
-    return request.param
-
-
-@pytest.fixture(
-    params=[
-        # M, K, N
-        (32, 6, 16),
-        (29, 17, 19),
-        (64, 128, 1024),
-    ]
+@pytest.mark.parametrize(
+    "x_shape, y_shape, transpose_y",
+    [
+        # Regular
+        ((32, 6), (6, 16), False),
+        # Transposed
+        ((4, 16), (16, 128), True),
+        ((35, 8), (8, 8), True),
+        # 3D x 3D
+        ((6, 32, 8), (6, 8, 10), False),
+        ((6, 32, 8), (6, 8, 10), True),
+        # 3D x 2D
+        ((6, 32, 8), (8, 10), False),
+        ((10, 16, 8), (8, 10), True),
+        # 2D x 3D
+        ((32, 8), (10, 8, 10), False),
+        ((32, 8), (10, 8, 10), True),
+        # ND x 2D
+        ((3, 6, 32, 8), (8, 10), False),
+        # 2D x ND
+        ((32, 8), (5, 3, 8, 10), False),
+        # ND x ND
+        ((5, 3, 32, 8), (5, 3, 8, 10), True),
+        ((3, 2, 4, 16, 15), (1, 1, 15, 2), True),
+        ((1, 1, 16, 15), (3, 2, 4, 15, 2), False),
+    ],
 )
-def matmul_size(request):
-    return request.param
+@pytest.mark.parametrize(
+    "with_bias, activation",
+    [
+        (True, None),
+        (False, None),
+        (True, R.nn.relu),
+        (True, R.nn.gelu),
+    ],
+    ids=[
+        "no_bias",
+        "biased",
+        "biased_relu",
+        "biased_gelu",
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float16",
+    ],
+)
+def test_matmul_offload(
+    x_shape,
+    y_shape,
+    transpose_y,
+    with_bias,
+    activation,
+    dtype,
+):
+    x = np.random.randn(*x_shape).astype(dtype)
+    y = np.random.randn(*y_shape).astype(dtype)
 
+    if transpose_y:
+        y = np.swapaxes(y, -2, -1)
 
-low, high = -10, 10
+    if with_bias:
+        bias = np.random.randn(y_shape[-1]).astype(dtype)
+        args = (x, y, bias)
+    else:
+        bias = None
+        args = (x, y)
 
-
-@pytest.fixture
-def matmul_x(matmul_size, target_dtype):
-    m, k, _ = matmul_size
-    return np.random.randint(low, high, size=(m, k)).astype(target_dtype)
-
-
-@pytest.fixture
-def matmul_y(matmul_size, target_dtype):
-    _, k, n = matmul_size
-    return np.random.randint(low, high, size=(k, n)).astype(target_dtype)
-
-
-@pytest.fixture
-def matmul_bias(matmul_size, target_dtype):
-    _, _, n = matmul_size
-    return np.random.randint(low, high, size=(n,)).astype(target_dtype)
-
-
-def test_matmul_offload(matmul_x, matmul_y):
-    x, y = matmul_x, matmul_y
-
-    mod = get_relax_matmul_module(x, y)
-    out = get_result_with_relax_cutlass_offload(mod, x, y)
-    ref = build_and_run(mod, [x, y], "llvm", legalize=True)
-
-    np.testing.assert_equal(out, ref)
-
-
-def test_matmul_bias_offload(matmul_x, matmul_y, matmul_bias):
-    x, y, bias = matmul_x, matmul_y, matmul_bias
-
-    mod = get_relax_matmul_module(x, y, with_bias=True)
-    out = get_result_with_relax_cutlass_offload(mod, x, y, bias)
-    ref = build_and_run(mod, [x, y, bias], "llvm", legalize=True)
-
-    np.testing.assert_equal(out, ref)
-
-
-def test_matmul_bias_relu_offload(matmul_x, matmul_y, matmul_bias):
-    x, y, bias = matmul_x, matmul_y, matmul_bias
-
-    mod = get_relax_matmul_module(x, y, with_bias=True, activation=R.nn.relu)
-    out = get_result_with_relax_cutlass_offload(mod, x, y, bias)
-    ref = build_and_run(mod, [x, y, bias], "llvm", legalize=True)
-
-    np.testing.assert_equal(out, ref)
-
-
-def test_matmul_bias_gelu_offload(matmul_x, matmul_y, matmul_bias):
-    x, y, bias = matmul_x, matmul_y, matmul_bias
-    mod = get_relax_matmul_module(x, y, with_bias=True, activation=R.nn.gelu)
-
-    out = get_result_with_relax_cutlass_offload(mod, x, y, bias)
-    ref = build_and_run(mod, [x, y, bias], "llvm", legalize=True)
+    mod = get_relax_matmul_module(
+        x, y, with_bias=with_bias, transposed_y=transpose_y, activation=activation
+    )
+    out = get_result_with_relax_cutlass_offload(mod, *args)
+    ref = build_and_run(mod, args, "llvm", legalize=True)
 
     tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-3)
 
 
-def test_kernel_sharing():
-    low, high = -1, 1
-    data_np = np.random.randint(low, high, size=(16, 32, 32, 8)).astype("float16")
-    weight1_np = np.random.randint(low, high, size=(8, 3, 3, 8)).astype("float16")
-    weight2_np = np.random.randint(low, high, size=(8, 3, 3, 8)).astype("float16")
-
-    out = get_result_with_relax_cutlass_offload(Conv2dx2, data_np, weight1_np, weight2_np)
-    ref = build_and_run(Conv2dx2, [data_np, weight1_np, weight2_np], "llvm", legalize=True)
-
-    np.testing.assert_equal(out, ref)
-
-
-def test_matmul_transposed_offload(matmul_x, matmul_y):
-    x, y = matmul_x, matmul_y
-
-    mod = get_relax_matmul_module(x, y.transpose(), transposed_y=True)
-    out = get_result_with_relax_cutlass_offload(mod, x, y.transpose())
-    ref = build_and_run(mod, [x, y.transpose()], "llvm", legalize=True)
-
-    np.testing.assert_equal(out, ref)
-
-
-def test_matmul_transposed_bias_offload(matmul_x, matmul_y, matmul_bias):
-    x, y, bias = matmul_x, matmul_y, matmul_bias
-
-    mod = get_relax_matmul_module(
-        x, y.transpose(), transposed_y=True, with_bias=True, activation=None
-    )
-    out = get_result_with_relax_cutlass_offload(mod, x, y.transpose(), bias)
-    ref = build_and_run(mod, [x, y.transpose(), bias], "llvm", legalize=True)
-
-    np.testing.assert_equal(out, ref)
+@pytest.mark.parametrize(
+    "x_shape, y_shape, expected",
+    [
+        # Regular matmul
+        ((3, 4), (4, 5), True),
+        # Batch matmul without stretching
+        ((3, 16, 15), (3, 15, 2), True),
+        # Broadcast 2D to 3D
+        ((3, 16, 15), (15, 2), True),
+        ((16, 15), (3, 15, 2), True),
+        # Broadcast one-length dimension
+        ((1, 16, 15), (3, 15, 2), True),
+        ((3, 16, 15), (1, 15, 2), True),
+        ((1, 1, 16, 15), (3, 2, 4, 15, 2), True),
+        # ND x ND
+        ((3, 2, 4, 16, 15), (3, 2, 4, 15, 2), True),
+        # ND x ND with one-length dimension
+        ((1, 2, 4, 16, 15), (1, 2, 4, 15, 2), True),
+        ((3, 2, 1, 16, 15), (3, 2, 1, 15, 2), True),
+        # Extra one-length dimension doesn't block broadcasting
+        ((3, 2, 1, 16, 15), (1, 1, 3, 2, 1, 15, 2), True),
+        # Not broadcasting all dims. Cannot be computed by stride-based batch gemm
+        ((3, 1, 1, 16, 15), (3, 2, 4, 15, 2), False),
+        ((3, 2, 4, 16, 15), (2, 4, 15, 2), False),
+        # Different shape
+        ((3, 4, 16, 15), (3, 2, 15, 2), False),
+    ],
+)
+def test_is_valid_for_cutlass_matmul(x_shape, y_shape, expected):
+    assert is_valid_for_cutlass_matmul(x_shape, y_shape) == expected
 
 
-def test_matmul_transposed_bias_relu_offload(matmul_x, matmul_y, matmul_bias):
-    x, y, bias = matmul_x, matmul_y, matmul_bias
+@pytest.mark.parametrize(
+    "x_shape, y_shape, transpose_y, dtype",
+    [
+        # Not broadcasting all dims. Cannot be computed by stride-based batch gemm
+        ((3, 1, 1, 16, 15), (3, 2, 4, 15, 2), False, "float16"),
+        ((1, 2, 1, 16, 15), (2, 1, 4, 15, 2), False, "float16"),
+        ((3, 2, 4, 16, 15), (2, 4, 15, 2), True, "float16"),
+        ((3, 16, 15), (2, 1, 3, 15, 2), True, "float16"),
+        # Unsupported dtype
+        ((4, 8), (8, 4), False, "float32"),
+        ((5, 4, 8), (8, 4), True, "float32"),
+    ],
+)
+def test_cutlass_partition_matmul_blocked(x_shape, y_shape, transpose_y, dtype):
+    x = np.random.randn(*x_shape).astype(dtype)
+    y = np.random.randn(*y_shape).astype(dtype)
+    if transpose_y:
+        y = np.swapaxes(y, -2, -1)
 
-    mod = get_relax_matmul_module(
-        x, y.transpose(), transposed_y=True, with_bias=True, activation=R.nn.relu
-    )
-    out = get_result_with_relax_cutlass_offload(mod, x, y.transpose(), bias)
-    ref = build_and_run(mod, [x, y.transpose(), bias], "llvm", legalize=True)
+    mod = get_relax_matmul_module(x, y, with_bias=False, transposed_y=transpose_y)
 
-    np.testing.assert_equal(out, ref)
-
-
-def test_matmul_transposed_bias_gelu_offload(matmul_x, matmul_y, matmul_bias):
-    x, y, bias = matmul_x, matmul_y, matmul_bias
-
-    mod = get_relax_matmul_module(
-        x, y.transpose(), transposed_y=True, with_bias=True, activation=R.nn.gelu
-    )
-    out = get_result_with_relax_cutlass_offload(mod, x, y.transpose(), bias)
-    ref = build_and_run(mod, [x, y.transpose(), bias], "llvm", legalize=True)
-
-    tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-3)
+    tvm.ir.assert_structural_equal(mod, partition_for_cutlass(mod))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the support of batch matmul to Relax CUTLASS BYOC. This includes batch matmul with shape 2D x ND, ND x 2D and ND x ND. Additionally, this supports bias, transposed y and all supported epilogues from regular matmul.

This PR also includes:
1. Add check function to all APIs related to PatternRegistryEntry (a follow up of #14109)
2. Add check function to CUTLASS pattern table, blocking unsupported matmul from being partitioned.
3. Reorganize the tests related to CUTLASS matmul.

cc @vinx13 @masahi 