### PR TITLE
[TE] Record primitives of Schedule for visualization

### DIFF
--- a/include/tvm/te/schedule.h
+++ b/include/tvm/te/schedule.h
@@ -460,9 +460,9 @@ class ScheduleContext {
   void EnterWithScope();
   void ExitWithScope();
 
-  /*! \brief the Schedule instance to store debug information */
+  /*! \brief Schedule instance to store information for debug */
   Schedule sch_;
-  /*! \brief string represents which primitive applied to Schedule */
+  /*! \brief String representing which primitive has been applied to sch_ */
   String current_primitive_name_;
 };
 
@@ -567,7 +567,7 @@ class StageNode : public Object {
   IterVar attach_ivar;
   /*! \brief The stage this node attaches to */
   Stage attach_stage;
-  /*! \brief The schedule of current stage attaches to */
+  /*! \brief The schedule current stage is attached to */
   const ScheduleNode* attach_sch;
   /*! \brief The thread storage scope level of the stage */
   std::string scope;
@@ -639,12 +639,10 @@ class ScheduleNode : public Object {
    */
   std::unordered_map<const Object*, Stage> op2stage_cache_;
   /*!
-   * \brief list of all schedules during primitives applied to stages.
-   * User could leverage TEDD to display the optimization strategy
-   * step by step to make sure the desired order and effect of
-   * different schedule primitives.
-   * The schedule-storing will take effect once "te.keep_schedule_record"
-   * is enabled in config of PassContext.
+   * \brief list of all transformed schedules
+   * User can display the optimization strategy via TEDD step by step to check
+   * the order and effect of primitives. Set "te.keep_schedule_record" in
+   * PassContext config as true to enable recording.
    */
   Array<Schedule> schedule_record;
   /*!

--- a/python/tvm/contrib/tedd.py
+++ b/python/tvm/contrib/tedd.py
@@ -80,12 +80,10 @@ def insert_dot_id(sch):
 
 def itervar_equal(iv_a, iv_b):
     """A helper method that compares the equality of two iterative variables"""
-    # after schedule.normalize was called, domains of iterative variables inside
-    # stage.leaf_iter_vars would be discarded and expected to be inferred in later
-    # InferBound call
-    # this rebase behavior would make plain comparison fail (i.e. ivar == itervar)
-    # here we adopt a new comparison method to serach the correct relationship of
-    # itervars
+    # When InferBound is invoked, domain min and max of iterative variables inside
+    # stage.leaf_iter_vars will be rebased.
+    # this rebase behavior makes plain comparison fail (i.e. ivar == itervar)
+    # Adopt the following comparison method for itervars
     def _var_equal(v_a, v_b):
         condtions = [
             v_a.name == v_b.name,

--- a/python/tvm/contrib/tedd.py
+++ b/python/tvm/contrib/tedd.py
@@ -80,10 +80,9 @@ def insert_dot_id(sch):
 
 def itervar_equal(iv_a, iv_b):
     """A helper method that compares the equality of two iterative variables"""
-    # When InferBound is invoked, domain min and max of iterative variables inside
-    # stage.leaf_iter_vars will be rebased.
-    # this rebase behavior makes plain comparison fail (i.e. ivar == itervar)
-    # Adopt the following comparison method for itervars
+    # Adopt the following method to assure the equality between two itervars.
+    # The plain comparison might fail (i.e. iv_a == iv_b) after the change of
+    # domain bounds from InferBound.
     def _var_equal(v_a, v_b):
         condtions = [
             v_a.name == v_b.name,
@@ -110,10 +109,10 @@ class ObjectManager:
             self.dict[stage] = [stage_idx]
             for itervar_idx, itervar in enumerate(stage.all_iter_vars):
                 self.dict[itervar] = [stage_idx, itervar_idx]
-                # the rebased itervars should also be mapped to the original one
-                for rebased in stage.leaf_iter_vars:
-                    if itervar_equal(rebased, itervar):
-                        self.dict[rebased] = [stage_idx, itervar_idx]
+                # the itervars of leaf should also be mapped to the original one
+                for leaf_iv in stage.leaf_iter_vars:
+                    if itervar_equal(leaf_iv, itervar):
+                        self.dict[leaf_iv] = [stage_idx, itervar_idx]
             for rel_idx, rel in enumerate(stage.relations):
                 self.dict[rel] = [stage_idx, rel_idx]
             for tensor_idx in range(stage.op.num_outputs):

--- a/src/te/schedule/schedule_dataflow_rewrite.cc
+++ b/src/te/schedule/schedule_dataflow_rewrite.cc
@@ -174,10 +174,12 @@ Tensor Schedule::cache_read(const Tensor& tensor, const std::string& scope,
   Array<Stage>& stages = (*this)->stages;
   Stage op_stage = operator[](tensor->op);
   size_t pos = FindNodeRef(stages.GetArrayNode(), op_stage);
-  Stage cache_stage = Stage(cache->op);
-  cache_stage.set_scope(scope);
+  Stage cache_stage = Stage(cache->op, this->operator->());
   ICHECK_LT(pos, stages.size());
   stages.insert(stages.begin() + pos + 1, cache_stage);
+  // in order to obtain correct copy on schedule_record,
+  // make sure "set_scope" primitive is applied after stage being added
+  cache_stage.set_scope(scope);
   (*this)->stage_map.Set(cache->op, cache_stage);
   // Update group
   cache_stage->group = op_stage->group;
@@ -266,10 +268,12 @@ Array<Tensor> ReplaceOriginalOp(Schedule sch, Stage orig_stage, const std::strin
   // create schedule for new cached stage.
   Array<Stage>& stages = sch->stages;
   size_t pos = FindNodeRef(stages.GetArrayNode(), orig_stage);
-  Stage cache_stage = Stage(cache_op);
-  cache_stage.set_scope(scope);
+  Stage cache_stage = Stage(cache_op, sch.operator->());
   ICHECK_LT(pos, stages.size());
   stages.insert(stages.begin() + pos, cache_stage);
+  // in order to obtain correct copy on schedule_record,
+  // make sure "set_scope" primitive is applied after stage being added
+  cache_stage.set_scope(scope);
   sch->stage_map.Set(cache_op, cache_stage);
   // Update group
   cache_stage->group = orig_stage->group;
@@ -892,7 +896,7 @@ Array<Tensor> Schedule::rfactor(const Tensor& tensor, const IterVar& axis, int f
   Operation factor_op(n);
   Array<Stage>& stages = (*this)->stages;
   size_t stage_pos = FindNodeRef(stages.GetArrayNode(), reduce_stage);
-  Stage factor_stage = Stage(factor_op);
+  Stage factor_stage = Stage(factor_op, this->operator->());
   factor_stage->relations = rels;
   ICHECK_LT(stage_pos, stages.size());
   stages.insert(stages.begin() + stage_pos, factor_stage);

--- a/src/te/schedule/schedule_lang.cc
+++ b/src/te/schedule/schedule_lang.cc
@@ -21,6 +21,7 @@
  * \file schedule_lang.cc
  */
 #include <dmlc/thread_local.h>
+#include <tvm/ir/transform.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/te/operation.h>
 #include <tvm/te/schedule.h>
@@ -91,7 +92,7 @@ void SplitHelper(StageNode* self, IterVar parent, PrimExpr factor, PrimExpr npar
   leaf_vars.insert(leaf_vars.begin() + pos, outer);
 }
 
-Stage::Stage(Operation op) {
+Stage::Stage(Operation op, const ScheduleNode* sch) {
   auto n = make_object<StageNode>();
   n->op = op;
   n->origin_op = op;
@@ -106,6 +107,7 @@ Stage::Stage(Operation op) {
   } else {
     n->leaf_iter_vars = clean;
   }
+  n->attach_sch = sch;
   data_ = std::move(n);
 }
 
@@ -124,11 +126,13 @@ Stage Stage::GetAttachSpec() const {
 }
 
 Stage& Stage::set_scope(std::string scope) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   (*this)->scope = scope;
   return *this;
 }
 
 Stage& Stage::compute_at(Stage parent, IterVar scope) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   ICHECK_NE((*this)->attach_type, kScanUpdate) << "Cannot specify compute_at for scan updates";
   // Group constraint checking.
   Stage group = (*this)->group;
@@ -156,18 +160,21 @@ Stage& Stage::compute_at(Stage parent, IterVar scope) {  // NOLINT(*)
 }
 
 Stage& Stage::compute_inline() {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   ICHECK_NE((*this)->attach_type, kScanUpdate) << "Cannot specify compute_at for scan updates";
   (*this)->attach_type = kInline;
   return *this;
 }
 
 Stage& Stage::compute_root() {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   ICHECK_NE((*this)->attach_type, kScanUpdate) << "Cannot specify compute_at for scan updates";
   (*this)->attach_type = kGroupRoot;
   return *this;
 }
 
 Stage& Stage::bind(IterVar ivar, IterVar thread_ivar) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   StageNode* self = operator->();
   ICHECK(ivar->iter_type == kDataPar || ivar->iter_type == kCommReduce)
       << "Cannot bind " << IterVarType2String(ivar->iter_type) << " to thread";
@@ -194,6 +201,7 @@ Stage& Stage::bind(IterVar ivar, IterVar thread_ivar) {  // NOLINT(*)
 }
 
 Stage& Stage::env_threads(Array<IterVar> threads) {
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   StageNode* self = operator->();
   ICHECK(self->op.defined() && self->op.as<ScanOpNode>())
       << "env_threads is only valid for composite ops such as ScanOp";
@@ -211,6 +219,7 @@ Stage& Stage::env_threads(Array<IterVar> threads) {
 }
 
 Stage& Stage::set_store_predicate(PrimExpr predicate) {
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   StageNode* self = operator->();
   self->store_predicate = predicate;
   return *this;
@@ -218,17 +227,20 @@ Stage& Stage::set_store_predicate(PrimExpr predicate) {
 
 Stage& Stage::split(IterVar parent, PrimExpr factor, IterVar* p_outer,
                     IterVar* p_inner) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   SplitHelper(operator->(), parent, factor, PrimExpr(), p_outer, p_inner);
   return *this;
 }
 
 Stage& Stage::split_by_nparts(IterVar parent, PrimExpr nparts, IterVar* p_outer,
                               IterVar* p_inner) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   SplitHelper(operator->(), parent, PrimExpr(), nparts, p_outer, p_inner);
   return *this;
 }
 
 Stage& Stage::fuse(IterVar outer, IterVar inner, IterVar* p_target) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   StageNode* self = operator->();
   ICHECK(outer->iter_type == kDataPar || outer->iter_type == kCommReduce ||
          outer->iter_type == kOrdered)
@@ -264,6 +276,7 @@ Stage& Stage::fuse(IterVar outer, IterVar inner, IterVar* p_target) {  // NOLINT
 }
 
 Stage& Stage::fuse(const Array<IterVar>& axes, IterVar* p_target) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   if (axes.size() != 0) {
     IterVar fused = axes[0];
     for (size_t i = 1; i < axes.size(); ++i) {
@@ -287,6 +300,7 @@ Stage& Stage::fuse(const Array<IterVar>& axes, IterVar* p_target) {  // NOLINT(*
 }
 
 Stage& Stage::reorder(const Array<IterVar>& order) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   std::unordered_set<IterVar> seen_var;
   StageNode* self = operator->();
   for (IterVar iv : order) {
@@ -347,6 +361,7 @@ inline void SetAttrIterType(StageNode* self, IterVar var, IterVarType iter_type)
 }
 
 Stage& Stage::vectorize(IterVar var) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   ICHECK(var->iter_type == kDataPar || var->iter_type == kOpaque || var->iter_type == kUnrolled ||
          var->iter_type == kVectorized || var->iter_type == kTensorized ||
          var->iter_type == kParallelized)
@@ -356,6 +371,7 @@ Stage& Stage::vectorize(IterVar var) {  // NOLINT(*)
 }
 
 Stage& Stage::tensorize(IterVar var, TensorIntrin f) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   UpdateIterVarAttr(operator->(), var, [f](IterVarAttrNode* n) {
     n->iter_type = kTensorized;
     n->tensor_intrin = f;
@@ -364,11 +380,13 @@ Stage& Stage::tensorize(IterVar var, TensorIntrin f) {  // NOLINT(*)
 }
 
 Stage& Stage::unroll(IterVar var) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   SetAttrIterType(operator->(), var, kUnrolled);
   return *this;
 }
 
 Stage& Stage::parallel(IterVar var) {  // NOLINT(*)
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   SetAttrIterType(operator->(), var, kParallelized);
   return *this;
 }
@@ -380,6 +398,7 @@ Stage& Stage::pragma(IterVar var, const std::string& pragma_type,
   } else if (pragma_type == "vectorize") {
     this->vectorize(var);
   } else {
+    With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
     UpdateIterVarAttr(operator->(), var, [pragma_type, pragma_value](IterVarAttrNode* n) {
       n->pragma_keys.push_back(tir::StringImm(pragma_type));
       n->pragma_values.push_back(pragma_value);
@@ -389,6 +408,7 @@ Stage& Stage::pragma(IterVar var, const std::string& pragma_type,
 }
 
 Stage& Stage::prefetch(const Tensor& tensor, IterVar var, PrimExpr offset) {
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   StageNode* self = operator->();
   ArrayNode* all_vars = self->all_iter_vars.CopyOnWrite();
   ArrayNode* leaf_vars = self->leaf_iter_vars.CopyOnWrite();
@@ -407,6 +427,7 @@ Stage& Stage::prefetch(const Tensor& tensor, IterVar var, PrimExpr offset) {
 }
 
 Stage& Stage::storage_align(IterVar axis, int factor, int offset) {
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   StageNode* self = operator->();
   UpdateIterVarAttr(
       self, axis,
@@ -419,6 +440,7 @@ Stage& Stage::storage_align(IterVar axis, int factor, int offset) {
 }
 
 Stage& Stage::double_buffer() {
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   StageNode* self = operator->();
   ICHECK(!self->is_output) << "Cannot apply double buffer on output";
   self->double_buffer = true;
@@ -426,6 +448,7 @@ Stage& Stage::double_buffer() {
 }
 
 Stage& Stage::rolling_buffer() {
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   StageNode* self = operator->();
   ICHECK(!self->is_output) << "Cannot apply rolling buffer on output";
   self->rolling_buffer = true;
@@ -434,6 +457,7 @@ Stage& Stage::rolling_buffer() {
 Stage& Stage::transform_layout(const Array<Var>& initial_indices,
                                const Array<PrimExpr>& final_indices,
                                Array<IterVar>* out_iter_vars) {
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   StageNode* self = operator->();
   IndexMap map(initial_indices, final_indices);
   self->layout_transforms.push_back(map);
@@ -501,6 +525,7 @@ Stage& Stage::transform_layout(const Array<Var>& initial_indices,
 }
 
 Stage& Stage::set_axis_separators(const Array<IntImm>& axis_separators) {
+  With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
   StageNode* self = operator->();
   self->axis_separators = axis_separators;
   return *this;
@@ -630,6 +655,7 @@ Stage Schedule::create_group(const Array<Tensor>& outputs, const Array<Tensor>& 
   }
   // Create the new group stage.
   Stage gstage(make_object<StageNode>());
+  gstage->attach_sch = this->operator->();
   gstage->group = parent_group;
   if (parent_group.defined()) {
     ++parent_group->num_child_stages;
@@ -718,6 +744,8 @@ bool ScheduleNode::Contain(const Operation& op) const {
   return stage_map.find(op) != stage_map.end();
 }
 
+TVM_REGISTER_PASS_CONFIG_OPTION("te.keep_schedule_record", Bool);
+
 Schedule::Schedule(Array<Operation> ops) {
   auto n = make_object<ScheduleNode>();
   data_ = n;
@@ -730,7 +758,7 @@ Schedule::Schedule(Array<Operation> ops) {
     output_set.insert(x);
   }
   for (Operation op : post_order) {
-    Stage stage(op);
+    Stage stage(op, this->operator->());
     stage->is_output = output_set.count(op) != 0;
     n->stages.push_back(stage);
     n->stage_map.Set(op, stage);
@@ -753,6 +781,25 @@ Schedule::Schedule(Array<Operation> ops) {
         ICHECK(scan_group.same_as(s->group));
       }
     }
+  }
+  transform::PassContext pass_ctx = transform::PassContext::Current();
+  n->keep_schedule_record = pass_ctx->GetConfig<Bool>("te.keep_schedule_record", Bool(false));
+  if (n->keep_schedule_record.value()) {
+    // push plain schedule as the very first one
+    n->schedule_record.push_back(copy());
+    n->primitive_record.push_back("vanilla");
+  }
+}
+
+ScheduleContext::ScheduleContext(const ScheduleNode* sch_node, String current_primitive_name)
+    : sch_(GetRef<Schedule>(sch_node)), current_primitive_name_(current_primitive_name) {}
+
+void ScheduleContext::EnterWithScope() {}
+
+void ScheduleContext::ExitWithScope() {
+  if (sch_.defined() && sch_->keep_schedule_record.value()) {
+    sch_->schedule_record.push_back(sch_.copy());
+    sch_->primitive_record.push_back(current_primitive_name_);
   }
 }
 


### PR DESCRIPTION
- Make Stage link to its Schedule via attach_sch.
- Add two array attributes, primitive_record and schedule_record to Schedule.
- Create a new class, ScheduleContext, to record primitives.
- Register a pass config variable, keep_schedule_record to enable/disable the recording.
- Add test cases for TEDD, build_module and schedule ops.