### PR TITLE
[bugfix] Fix the write buffer scope of `mma_store_impl`

### DIFF
--- a/python/tvm/tir/tensor_intrin/cuda.py
+++ b/python/tvm/tir/tensor_intrin/cuda.py
@@ -392,7 +392,7 @@ def get_mma_store_intrin(dtype, local_size, scope="global"):
             a, [WARP_SIZE, local_size], dtype=dtype, scope="warp", offset_factor=1
         )
         C = T.match_buffer(
-            c, [M_DIM, N_DIM], dtype=dtype, scope="global", offset_factor=1, strides=[s0, s1]
+            c, [M_DIM, N_DIM], dtype=dtype, scope=scope, offset_factor=1, strides=[s0, s1]
         )
 
         with T.block("root"):


### PR DESCRIPTION
# The Bug
`mma_store` has a scope field but we only supports `global`, which is problematic if we want a `mma_store` intrinsic that writes to `shared` scope.

Credit to @cyx-6 for finding this bug.