### PR TITLE
[TVMC] Fix logging in TVMC

### DIFF
--- a/python/tvm/driver/tvmc/autotuner.py
+++ b/python/tvm/driver/tvmc/autotuner.py
@@ -87,6 +87,7 @@ def add_tune_parser(subparsers, _, json_params):
         required=True,
         help="output file to store the tuning records for the tuning process",
     )
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="increase verbosity.")
     parser.add_argument(
         "--parallel",
         default=4,

--- a/python/tvm/driver/tvmc/main.py
+++ b/python/tvm/driver/tvmc/main.py
@@ -85,9 +85,12 @@ def _main(argv):
     parser.add_argument("-h", "--help", action="help", help="show this help message and exit.")
 
     args = parser.parse_args(argv)
-    if args.verbose > 4:
-        args.verbose = 4
+    if args.verbose > 3:
+        args.verbose = 3
 
+    # See the meaning of the logging levels at
+    # https://docs.python.org/3/library/logging.html#logging-levels
+    logging.basicConfig(stream=sys.stdout)
     logging.getLogger("TVMC").setLevel(40 - args.verbose * 10)
 
     if args.version:

--- a/python/tvm/driver/tvmc/runner.py
+++ b/python/tvm/driver/tvmc/runner.py
@@ -109,6 +109,7 @@ def add_run_parser(subparsers, main_parser, json_params):
         "Profiling may also have an impact on inference time, "
         "making it take longer to be generated. (non-micro devices only)",
     )
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="increase verbosity.")
     parser.add_argument(
         "--end-to-end",
         action="store_true",

--- a/tests/python/driver/tvmc/test_command_line.py
+++ b/tests/python/driver/tvmc/test_command_line.py
@@ -18,7 +18,6 @@ import os
 import platform
 import pytest
 import shutil
-import re
 
 from pytest_lazyfixture import lazy_fixture
 from unittest import mock

--- a/tests/python/driver/tvmc/test_command_line.py
+++ b/tests/python/driver/tvmc/test_command_line.py
@@ -216,6 +216,7 @@ def test_tvmc_compile_input_model(mock_compile_model, tmpdir_factory, model):
 
 
 def test_tvmc_logger(caplog, tmpdir_factory, keras_simple):
+    pytest.importorskip("tensorflow")
     tmpdir = tmpdir_factory.mktemp("out")
 
     # TUNE
@@ -259,6 +260,7 @@ def test_tvmc_logger(caplog, tmpdir_factory, keras_simple):
 # actually writes the logging output to sys.stdout, but we can test that we call
 # logging.basicConfig with the correct arguments
 def test_tvmc_logger_set_basicConfig(monkeypatch, tmpdir_factory, keras_simple):
+    pytest.importorskip("tensorflow")
     mock_basicConfig = MagicMock()
     monkeypatch.setattr(logging, "basicConfig", mock_basicConfig)
 


### PR DESCRIPTION
Three logger related changes in this patch:
* Currently we don't set the output stream on the Python logger, so it defaults to sys.stderr, which means we only get some logger output when the command fails. So set the output stream to sys.stdout
* Currently we can add -v flag to anywhere in the command line for `tvmc compile`, but only between `tvmc` and `run`/`tune` for `run` and `tune`. Unify the behaviour such that we can add the flag anywhere on the command line.
* Set the effective upper bound of `-v`s to 3 as 4 could result in NOTSET which would not output anything.