### PR TITLE
[CRT][microTVM]Use AoTExecutor by default for CRT runtime

### DIFF
--- a/gallery/how_to/work_with_microtvm/micro_autotune.py
+++ b/gallery/how_to/work_with_microtvm/micro_autotune.py
@@ -54,7 +54,7 @@ import numpy as np
 import pathlib
 
 import tvm
-from tvm.relay.backend import Runtime
+from tvm.relay.backend import Runtime, Executor
 import tvm.micro.testing
 
 ####################
@@ -103,6 +103,7 @@ params = {"weight": weight_sample}
 #
 
 RUNTIME = Runtime("crt", {"system-lib": True})
+EXECUTOR = Executor("graph")
 TARGET = tvm.micro.testing.get_target("crt")
 
 # Compiling for physical hardware
@@ -212,7 +213,9 @@ for task in tasks:
 #
 
 with pass_context:
-    lowered = tvm.relay.build(relay_mod, target=TARGET, runtime=RUNTIME, params=params)
+    lowered = tvm.relay.build(
+        relay_mod, target=TARGET, runtime=RUNTIME, params=params, executor=EXECUTOR
+    )
 
 temp_dir = tvm.contrib.utils.tempdir()
 project = tvm.micro.generate_project(
@@ -256,7 +259,9 @@ with tvm.micro.Session(project.transport()) as session:
 
 with tvm.autotvm.apply_history_best(str(autotune_log_file)):
     with pass_context:
-        lowered_tuned = tvm.relay.build(relay_mod, target=TARGET, runtime=RUNTIME, params=params)
+        lowered_tuned = tvm.relay.build(
+            relay_mod, target=TARGET, runtime=RUNTIME, params=params, executor=EXECUTOR
+        )
 
 temp_dir = tvm.contrib.utils.tempdir()
 project = tvm.micro.generate_project(

--- a/gallery/how_to/work_with_microtvm/micro_tflite.py
+++ b/gallery/how_to/work_with_microtvm/micro_tflite.py
@@ -223,18 +223,16 @@ generated_project.flash()
 # to stand in for an attached microcontroller.
 
 with tvm.micro.Session(transport_context_manager=generated_project.transport()) as session:
-    graph_mod = tvm.micro.create_local_graph_executor(
-        module.get_graph_json(), session.get_system_lib(), session.device
-    )
+    aot_mod = tvm.micro.create_local_aot_executor(session)
 
     # Set the model parameters using the lowered parameters produced by `relay.build`.
-    graph_mod.set_input(**module.get_params())
+    aot_mod.set_input(**module.get_params())
 
     # The model consumes a single float32 value and returns a predicted sine value.  To pass the
     # input value we construct a tvm.nd.array object with a single contrived number as input. For
     # this model values of 0 to 2Pi are acceptable.
-    graph_mod.set_input(input_tensor, tvm.nd.array(np.array([0.5], dtype="float32")))
-    graph_mod.run()
+    aot_mod.set_input(input_tensor, tvm.nd.array(np.array([0.5], dtype="float32")))
+    aot_mod.run()
 
-    tvm_output = graph_mod.get_output(0).numpy()
+    tvm_output = aot_mod.get_output(0).numpy()
     print("result is: " + str(tvm_output))

--- a/gallery/how_to/work_with_microtvm/micro_tflite.py
+++ b/gallery/how_to/work_with_microtvm/micro_tflite.py
@@ -134,7 +134,7 @@ if use_physical_hw:
 
 ######################################################################
 # Now, compile the model for the target. If you do not specify Executor,
-# by default it uses GraphExecutor.
+# by default it uses AOTExecutor.
 
 with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
     module = relay.build(mod, target=TARGET, runtime=RUNTIME, params=params)

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -278,7 +278,7 @@ def build(
     ir_mod,
     target=None,
     target_host=None,
-    executor=Executor("graph"),
+    executor=None,
     runtime=Runtime("cpp"),
     workspace_memory_pools=None,
     constant_memory_pools=None,
@@ -304,7 +304,8 @@ def build(
 
     executor : Optional[Executor]
         The executor configuration with which to build the model.
-        Defaults to "graph" if no executor specified.
+        Defaults to "aot" if runtime is CRT, otherwise defaults to
+        "graph" if no executor specified.
 
     runtime : Optional[Runtime]
         Runtime configuration to use when building the model.
@@ -334,6 +335,12 @@ def build(
     """
     # pylint: enable=line-too-long
     # fmt: on
+
+    if executor is None:
+        if "crt" in runtime:
+            executor = Executor("aot")
+        else:
+            executor = Executor("graph")
 
     if not isinstance(ir_mod, (IRModule, _function.Function)):
         raise ValueError("Type of input parameter mod must be tvm.IRModule")

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -337,7 +337,7 @@ def build(
     # fmt: on
 
     if executor is None:
-        if "crt" in runtime:
+        if runtime.name == "crt":
             executor = Executor("aot")
         else:
             executor = Executor("graph")

--- a/tests/micro/zephyr/test_ms_tuning.py
+++ b/tests/micro/zephyr/test_ms_tuning.py
@@ -168,6 +168,7 @@ def test_ms_tuning_conv2d(workspace_dir, board, microtvm_debug, use_fvp, serial_
             target=target,
             params=params,
             runtime=runtime,
+            executor=Executor("graph"),
         )
     ref_mod.export_library(workspace_dir / "compiled_lib2.so")
     mod2: tvm.runtime.Module = tvm.runtime.load_module(workspace_dir / "compiled_lib2.so")

--- a/tests/python/relay/test_pass_partition_graph.py
+++ b/tests/python/relay/test_pass_partition_graph.py
@@ -23,7 +23,7 @@ import numpy as np
 
 import tvm
 from tvm.relay.backend import te_compiler
-from tvm.relay.backend.runtime import Runtime
+from tvm.relay.backend import Runtime, Executor
 import tvm.relay.testing
 import tvm.relay.op as reg
 from tvm import relay
@@ -168,7 +168,9 @@ def check_result(
     def check_graph_executor_result():
         te_compiler.get().clear()
         with tvm.transform.PassContext(opt_level=3):
-            json, lib, param = relay.build(mod, target=target, params=params, runtime=runtime)
+            json, lib, param = relay.build(
+                mod, target=target, params=params, runtime=runtime, executor=Executor("graph")
+            )
         lib = update_lib(lib)
         rt_mod = tvm.contrib.graph_executor.create(json, lib, device)
 
@@ -1617,24 +1619,4 @@ def test_not_bind_constant():
 
 
 if __name__ == "__main__":
-    test_multi_node_compiler()
-    test_extern_ccompiler_single_op()
-    test_extern_ccompiler_default_ops()
-    test_extern_ccompiler_multiple_functions()
-    test_extern_ccompiler()
-    test_extern_dnnl()
-    test_extern_dnnl_mobilenet()
-    test_function_lifting()
-    test_function_lifting_inline()
-    test_constant_propagation()
-    test_multiple_outputs()
-    test_mixed_single_multiple_outputs()
-    test_dnnl_fuse()
-    test_multiple_use_of_an_output()
-    test_duplicate_outputs()
-    test_duplicate_merge_and_tuplegetitem()
-    test_constant_tuples()
-    test_flatten_tuple_output()
-    test_tuple_output_exec()
-    test_extern_opt()
-    test_not_bind_constant()
+    tvm.testing.main()

--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -129,7 +129,9 @@ def test_graph_executor():
 
     runtime = Runtime("crt", {"system-lib": True})
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
-        factory = tvm.relay.build(relay_mod, target=TARGET, runtime=runtime)
+        factory = tvm.relay.build(
+            relay_mod, target=TARGET, runtime=runtime, executor=Executor("graph")
+        )
 
     def do_test(graph_mod):
 
@@ -404,7 +406,9 @@ def test_autotune():
 
     # Build without tuning
     with pass_context:
-        lowered = tvm.relay.build(mod, target=TARGET, runtime=runtime, params=params)
+        lowered = tvm.relay.build(
+            mod, target=TARGET, runtime=runtime, executor=Executor("graph"), params=params
+        )
 
     temp_dir = tvm.contrib.utils.tempdir()
     with _make_session(temp_dir, lowered) as sess:
@@ -419,7 +423,9 @@ def test_autotune():
     # Build using autotune logs
     with tvm.autotvm.apply_history_best(str(tune_log_file)):
         with pass_context:
-            lowered_tuned = tvm.relay.build(mod, target=target, runtime=runtime, params=params)
+            lowered_tuned = tvm.relay.build(
+                mod, target=target, runtime=runtime, executor=Executor("graph"), params=params
+            )
 
     temp_dir = tvm.contrib.utils.tempdir()
     with _make_session(temp_dir, lowered_tuned) as sess:

--- a/tests/python/unittest/test_micro_model_library_format.py
+++ b/tests/python/unittest/test_micro_model_library_format.py
@@ -268,6 +268,7 @@ def test_export_model_library_format_llvm():
                 relay_mod,
                 target,
                 runtime=Runtime("crt", {"system-lib": True}),
+                executor=Executor("graph"),
                 mod_name="add",
                 params={"c": np.array([[2.0, 4.0]], dtype="float32")},
             )
@@ -460,7 +461,9 @@ def test_export_byoc_c_module():
     mod = tvm.relay.transform.InferType()(mod)
 
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
-        factory = tvm.relay.build(mod, tvm.target.target.micro("host"), runtime=Runtime("crt"))
+        factory = tvm.relay.build(
+            mod, tvm.target.target.micro("host"), runtime=Runtime("crt"), executor=Executor("graph")
+        )
 
     temp_dir = utils.tempdir()
     mlf_tar_path = temp_dir.relpath("lib.tar")

--- a/tests/python/unittest/test_micro_ms_tuning.py
+++ b/tests/python/unittest/test_micro_ms_tuning.py
@@ -113,6 +113,7 @@ def test_micro_tuning_with_meta_schedule():
             target=target,
             params=params,
             runtime=runtime,
+            executor=Executor("graph"),
         )
     ref_mod.export_library(work_dir / "compiled_lib2.so")
     mod2: tvm.runtime.Module = tvm.runtime.load_module(work_dir / "compiled_lib2.so")


### PR DESCRIPTION
This PR changes default `executor` to `None` at `relay.build` and set the default inside the function based on the runtime. The default executor is set to AOTExecutor if runtime=CRT, otherwise it is set to GraphExecutor.