### PR TITLE
Add v0.11.0 docs link to site

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -649,7 +649,7 @@ html_context = {
     "header_dropdown": header_dropdown,
     "header_logo": header_logo,
     "header_logo_link": header_logo_link,
-    "version_prefixes": ["main", "v0.8.0/", "v0.9.0/", "v0.10.0/"],
+    "version_prefixes": ["main", "v0.8.0/", "v0.9.0/", "v0.10.0/", "v0.11.0/"],
     "display_github": True,
     "github_user": "apache",
     "github_repo": "tvm",


### PR DESCRIPTION
Update the version menu in TVM documentation to add a specific `v0.11.0` release docs link.

@tqchen @leandron 