### PR TITLE
[TVMC] Add option to dump TIR code to file

### DIFF
--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -459,8 +459,7 @@ def add_tir_to_dumps(config, dumps):
 
     tir_lower_passes = config.get("tir.add_lower_pass", [])
     tir_lower_passes.append((phase, _dump_tir_pass))
-    if tir_lower_passes:
-        config["tir.add_lower_pass"] = tir_lower_passes
+    config["tir.add_lower_pass"] = tir_lower_passes
 
     return config, dumps
 

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -88,7 +88,7 @@ def test_compile_tflite_module(use_vm, tflite_mobilenet_v1_1_quant):
     verify_compile_tflite_module(tflite_mobilenet_v1_1_quant, shape_dict, use_vm=use_vm)
 
 
-def test_tir_dump(tflite_mobilenet_v1_1_quant):
+def test_single_tir_dump(tflite_mobilenet_v1_1_quant):
     pytest.importorskip("tflite")
     tvmc_model = tvmc.load(tflite_mobilenet_v1_1_quant)
     tvmc_package = tvmc.compile(tvmc_model, target="llvm", dump_code="tir")
@@ -96,6 +96,18 @@ def test_tir_dump(tflite_mobilenet_v1_1_quant):
     assert os.path.exists(dumps_path)
     with open(dumps_path) as f:
         assert "tir" in f.read()
+
+
+def test_code_dumps(tflite_mobilenet_v1_1_quant):
+    pytest.importorskip("tflite")
+    tvmc_model = tvmc.load(tflite_mobilenet_v1_1_quant)
+    dump_code = ["asm", "ll", "tir", "relay"]
+    tvmc_package = tvmc.compile(tvmc_model, target="llvm", dump_code=dump_code)
+    for ext in dump_code:
+        dumps_path = tvmc_package.package_path + "." + ext
+        assert os.path.exists(dumps_path)
+        with open(dumps_path) as f:
+            assert len(f.read()) > 0
 
 
 # This test will be skipped if the AArch64 cross-compilation toolchain is not installed.


### PR DESCRIPTION
Currently dumps the TIR code after the final phase of lowering (phase 3 from https://github.com/apache/tvm/blob/665dd413bc85d14f7836324daf7cc0dd9281c85a/gallery/how_to/extend_tvm/low_level_custom_pass.py#L152) before codegen. This is done by running a pass to capture the TIR module as it is not saved during the build. The result is saved to file similar to the other code dumps.

In the future it seems good to have more granularity in the IR that is being dumped, e.g. print IR before/after named pass. I thought this might be helpful in the meantime.

cc @ekalda @ashutosh-arm @neildhickey