### PR TITLE
[HotFix][MetaSchedule] Turn off database shash check

### DIFF
--- a/src/meta_schedule/database/json_database.cc
+++ b/src/meta_schedule/database/json_database.cc
@@ -172,9 +172,13 @@ Database Database::JSONDatabase(String path_workload, String path_tuning_record,
     for (int i = 0; i < n_objs; ++i) {
       Workload workload = Workload::FromJSON(json_objs[i]);
       auto recalc_hash = n->GetModuleEquality().Hash(workload->mod);
-      CHECK_EQ(recalc_hash, workload->shash)
-          << "ValueError: Module hash changed. Given: " << workload->shash
-          << "; Recalculated: " << recalc_hash;
+      // Todo(tvm-team): re-enable the shash check when we get environment
+      // independent structural hash values.
+      if (recalc_hash != workload->shash) {
+        ObjectPtr<WorkloadNode> wkl = make_object<WorkloadNode>(*workload.get());
+        wkl->shash = recalc_hash;
+        workload = Workload(wkl);
+      }
       n->workloads2idx_.emplace(workload, i);
       workloads.push_back(workload);
     }


### PR DESCRIPTION
At this moment, the structural hash values of IR in TVM is platform dependent (e.g., the hash values of a String may differ on different platforms). In our recent practice, we found this an obstacle for us to apply one existing database on different platforms (say we tune an IRModule with MetaSchedule on Metal, and then apply the database on CUDA, etc.)

To clear this obstacle, we decide to remove the shash value check. The purpose of that check is mainly to ensure safety, and thus turning it off will make no difference in terms of using MetaSchedule in most of the cases that we can imagine.

Meanwhile, it is equally important that we need to make our structural hash platform independent. There are plans ongoing for this target.