### PR TITLE
[TOPI] Batch Norm Training Mode

### DIFF
--- a/tests/python/topi/python/test_topi_batch_norm.py
+++ b/tests/python/topi/python/test_topi_batch_norm.py
@@ -33,19 +33,19 @@ _BATCH_NORM_IMPLEMENT = {
 
 
 @pytest.mark.parametrize(
-    "shape, axis, epsilon, center, scale",
+    "shape, axis, epsilon, center, scale, training, momentum",
     [
-        ((1,), 0, 0.1, True, True),
-        ((2, 3), 0, 0.1, True, True),
-        ((1, 2, 4), 0, 0.1, True, True),
-        ((1, 2, 3, 4), 0, 0.001, False, False),
-        ((2, 3, 4, 1), 1, 0.01, False, True),
-        ((3, 4, 1, 2), 2, 0.1, True, False),
-        ((4, 1, 2, 3), 3, 1.0, True, True),
-        ((1, 2, 4, 4, 5), 0, 0.1, True, True),
+        ((1,), 0, 0.1, True, True, False, 0.1),
+        ((2, 3), 0, 0.1, True, True, False, 0.1),
+        ((1, 2, 4), 0, 0.1, True, True, False, 0.1),
+        ((1, 2, 3, 4), 0, 0.001, False, False, False, 0.1),
+        ((2, 3, 4, 1), 1, 0.01, False, True, False, 0.1),
+        ((3, 4, 1, 2), 2, 0.1, True, False, True, 0.1),
+        ((4, 1, 2, 3), 3, 1.0, True, True, True, 0.2),
+        ((1, 2, 4, 4, 5), 0, 0.1, True, True, True, 0.3),
     ],
 )
-def test_batch_norm(shape, axis, epsilon, center, scale):
+def test_batch_norm(shape, axis, epsilon, center, scale, training, momentum):
     x_np = np.random.random(shape).astype("float32")
     gamma_np = np.random.random(shape[axis]).astype("float32")
     beta_np = np.random.random(shape[axis]).astype("float32")
@@ -53,7 +53,17 @@ def test_batch_norm(shape, axis, epsilon, center, scale):
     moving_var_np = np.random.random(shape[axis]).astype("float32")
 
     out_x_np, out_moving_mean_np, out_moving_var_np = tvm.topi.testing.batch_norm(
-        x_np, gamma_np, beta_np, moving_mean_np, moving_var_np, axis, epsilon, center, scale
+        x_np,
+        gamma_np,
+        beta_np,
+        moving_mean_np,
+        moving_var_np,
+        axis,
+        epsilon,
+        center,
+        scale,
+        training,
+        momentum,
     )
 
     x_te = te.placeholder(shape, name="x", dtype="float32")
@@ -65,7 +75,17 @@ def test_batch_norm(shape, axis, epsilon, center, scale):
     with tvm.target.Target(_DEVICE):
         fcompute, fschedule = tvm.topi.testing.dispatch(_DEVICE, _BATCH_NORM_IMPLEMENT)
         out_x, out_moving_mean, out_moving_var = fcompute(
-            x_te, gamma_te, beta_te, moving_mean_te, moving_var_te, axis, epsilon, center, scale
+            x_te,
+            gamma_te,
+            beta_te,
+            moving_mean_te,
+            moving_var_te,
+            axis,
+            epsilon,
+            center,
+            scale,
+            training,
+            momentum,
         )
         s = fschedule([out_x, out_moving_mean, out_moving_var])
 
@@ -113,4 +133,4 @@ def test_batch_norm(shape, axis, epsilon, center, scale):
 
 
 if __name__ == "__main__":
-    test_batch_norm()
+    tvm.testing.main()


### PR DESCRIPTION
Prior to this PR, TOPI batch_norm only supports inference. 

This PR adds `training: bool` flag and `momentum: float` argument to support training mode (update `moving_mean / var` and return), which aligns with `torch.nn.functional.batch_norm`.