### PR TITLE
[MetaSchedule][ARM] Enable ARM CPU intrinsic for MetaSchedule

### DIFF
--- a/include/tvm/meta_schedule/schedule_rule.h
+++ b/include/tvm/meta_schedule/schedule_rule.h
@@ -300,6 +300,8 @@ class ScheduleRule : public runtime::ObjectRef {
   TVM_DLL static Array<ScheduleRule, void> DefaultHexagon();
   /*! \brief Create default schedule rules for Micro */
   TVM_DLL static Array<ScheduleRule, void> DefaultMicro();
+  /*! \brief Create default schedule rules for ARM CPU (NEON and DOTPROD) */
+  TVM_DLL static Array<ScheduleRule, void> DefaultARM(const String& type);
 
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(ScheduleRule, ObjectRef, ScheduleRuleNode);
 };

--- a/include/tvm/runtime/container/array.h
+++ b/include/tvm/runtime/container/array.h
@@ -580,6 +580,36 @@ class Array : public ObjectRef {
     }
   }
 
+  template <typename... Args>
+  static size_t CalcCapacityImpl() {
+    return 0;
+  }
+
+  template <typename... Args>
+  static size_t CalcCapacityImpl(Array<T> value, Args... args) {
+    return value.size() + CalcCapacityImpl(args...);
+  }
+
+  template <typename... Args>
+  static size_t CalcCapacityImpl(T value, Args... args) {
+    return 1 + CalcCapacityImpl(args...);
+  }
+
+  template <typename... Args>
+  static void AgregateImpl(Array<T>& dest) {}  // NOLINT(*)
+
+  template <typename... Args>
+  static void AgregateImpl(Array<T>& dest, Array<T> value, Args... args) {  // NOLINT(*)
+    dest.insert(dest.end(), value.begin(), value.end());
+    AgregateImpl(dest, args...);
+  }
+
+  template <typename... Args>
+  static void AgregateImpl(Array<T>& dest, T value, Args... args) {  // NOLINT(*)
+    dest.push_back(value);
+    AgregateImpl(dest, args...);
+  }
+
  public:
   // Array's own methods
 
@@ -679,6 +709,19 @@ class Array : public ObjectRef {
 
   /*! \brief specify container node */
   using ContainerType = ArrayNode;
+
+  /*!
+   * \brief Agregate arguments into a single Array<T>
+   * \param args sequence of T or Array<T> elements
+   * \return Agregated Array<T>
+   */
+  template <typename... Args>
+  static Array<T> Agregate(Args... args) {
+    Array<T> result;
+    result.reserve(CalcCapacityImpl(args...));
+    AgregateImpl(result, args...);
+    return result;
+  }
 
  private:
   /*!

--- a/python/tvm/tir/tensor_intrin/arm_cpu.py
+++ b/python/tvm/tir/tensor_intrin/arm_cpu.py
@@ -26,7 +26,7 @@ from .dot_product_common import DP4A_INTRIN  # pylint: disable=unused-import
 
 
 @T.prim_func
-def dot_product_4x4_i8i8i32_desc(
+def neon_4x4_i8i8i32_desc(
     A: T.Buffer((4,), "int8", offset_factor=1),
     B: T.Buffer((4, 4), "int8", offset_factor=1),
     C: T.Buffer((4,), "int32", offset_factor=1),
@@ -42,7 +42,7 @@ def dot_product_4x4_i8i8i32_desc(
 
 
 @T.prim_func
-def dot_product_4x4_i8i8i32_neon(
+def neon_4x4_i8i8i32_impl(
     A: T.Buffer((4,), "int8", offset_factor=1),
     B: T.Buffer((4, 4), "int8", offset_factor=1),
     C: T.Buffer((4,), "int32", offset_factor=1),
@@ -102,42 +102,71 @@ def dot_product_4x4_i8i8i32_neon(
         )
 
 
-@T.prim_func
-def dot_product_4x4_i8i8i32_sdot(
-    A: T.Buffer((4,), "int8", offset_factor=1),
-    B: T.Buffer((4, 4), "int8", offset_factor=1),
-    C: T.Buffer((4,), "int32", offset_factor=1),
-) -> None:
-    with T.block("root"):
-        T.reads(C[0:4], A[0:4], B[0:4, 0:4])
-        T.writes(C[0:4])
+def get_dotprod_intrin(in_dtype, out_dtype):
+    if in_dtype == "uint8":
+        instr = "udot.v4u32.v16u8"
+    else:  # if in_dtype == "int8"
+        instr = "sdot.v4i32.v16i8"
 
-        A_i8x4 = A.vload([0], "int8x4")
-        A_i32 = T.reinterpret(A_i8x4, dtype="int32")
-        vec_ai32 = T.broadcast(A_i32, 4)
-        vec_a = T.reinterpret(vec_ai32, dtype="int8x16")
+    in_dtype_x4 = "{TYPE}x4".format(TYPE=in_dtype)
+    out_dtype_x4 = "{TYPE}x4".format(TYPE=out_dtype)
+    in_dtype_x16 = "{TYPE}x16".format(TYPE=in_dtype)
 
-        vec_b = B.vload([0, 0], dtype="int8x16")
+    @T.prim_func
+    def dot_prod_desc(a: T.handle, b: T.handle, c: T.handle) -> None:
+        A = T.match_buffer(a, (4,), dtype=in_dtype, offset_factor=1)
+        B = T.match_buffer(b, (4, 4), dtype=in_dtype, offset_factor=1)
+        C = T.match_buffer(c, (4,), dtype=out_dtype, offset_factor=1)
+        with T.block("root"):
+            T.reads(C[0:4], A[0:4], B[0:4, 0:4])
+            T.writes(C[0:4])
+            for i in T.serial(0, 4):
+                for k in T.serial(0, 4):
+                    with T.block("update"):
+                        vi, vk = T.axis.remap("SR", [i, k])
+                        C[vi] = C[vi] + T.cast(A[vk], dtype=out_dtype) * T.cast(
+                            B[vi, vk], dtype=out_dtype
+                        )
 
-        vec_c = C.vload([0], dtype="int32x4")
+    @T.prim_func
+    def dot_prod_impl(a: T.handle, b: T.handle, c: T.handle) -> None:
+        A = T.match_buffer(a, (4,), dtype=in_dtype, offset_factor=1)
+        B = T.match_buffer(b, (4, 4), dtype=in_dtype, offset_factor=1)
+        C = T.match_buffer(c, (4,), dtype=out_dtype, offset_factor=1)
+        with T.block("root"):
+            T.reads(C[0:4], A[0:4], B[0:4, 0:4])
+            T.writes(C[0:4])
 
-        C[T.ramp(T.int32(0), 1, 4)] = T.call_llvm_pure_intrin(
-            T.llvm_lookup_intrinsic_id("llvm.aarch64.neon.sdot.v4i32.v16i8"),
-            T.uint32(3),
-            vec_c,
-            vec_a,
-            vec_b,
-            dtype="int32x4",
-        )
+            A_i8x4 = A.vload([0], in_dtype_x4)
+            A_i32 = T.reinterpret(A_i8x4, dtype=out_dtype)
+            vec_ai32 = T.broadcast(A_i32, 4)
+            vec_a = T.reinterpret(vec_ai32, dtype=in_dtype_x16)
+
+            vec_b = B.vload([0, 0], dtype=in_dtype_x16)
+
+            vec_c = C.vload([0], dtype=out_dtype_x4)
+
+            C[T.ramp(T.int32(0), 1, 4)] = T.call_llvm_pure_intrin(
+                T.llvm_lookup_intrinsic_id("llvm.aarch64.neon.{INSTR}".format(INSTR=instr)),
+                T.uint32(3),
+                vec_c,
+                vec_a,
+                vec_b,
+                dtype=out_dtype_x4,
+            )
+
+    return dot_prod_desc, dot_prod_impl
 
 
 ARM_DOT_4x4_i8_NEON_INTRIN = "dot_4x4_i8i8s32_neon"
 ARM_DOT_4x4_i8_SDOT_INTRIN = "dot_4x4_i8i8s32_sdot"
+ARM_DOT_4x4_u8_UDOT_INTRIN = "dot_4x4_u8u8u32_udot"
+ARM_DOT_4x4_u8_HDOT_INTRIN = "dot_4x4_u8u8i32_hdot"
 
-TensorIntrin.register(
-    ARM_DOT_4x4_i8_NEON_INTRIN, dot_product_4x4_i8i8i32_desc, dot_product_4x4_i8i8i32_neon
-)
+TensorIntrin.register(ARM_DOT_4x4_i8_NEON_INTRIN, neon_4x4_i8i8i32_desc, neon_4x4_i8i8i32_impl)
 
-TensorIntrin.register(
-    ARM_DOT_4x4_i8_SDOT_INTRIN, dot_product_4x4_i8i8i32_desc, dot_product_4x4_i8i8i32_sdot
-)
+TensorIntrin.register(ARM_DOT_4x4_i8_SDOT_INTRIN, *get_dotprod_intrin("int8", "int32"))
+
+TensorIntrin.register(ARM_DOT_4x4_u8_UDOT_INTRIN, *get_dotprod_intrin("uint8", "uint32"))
+
+TensorIntrin.register(ARM_DOT_4x4_u8_HDOT_INTRIN, *get_dotprod_intrin("uint8", "int32"))


### PR DESCRIPTION
Motivation:
The purpose of this PR is to add support for intrinsics to optimize matrix multiplication operations (e.g. matmul, convolution) during tuning with MetaScheduler.

Information about PR:
The present PR integrates the existing neon and dotprod (namely, sdot and udot) ARM CPU intrinsics into MetaScheduler, introduces a new "hybrid" dotprod intrinsic ("hdot") working with uint8, uint8 -> int32 data types, and changes the intrinsic selection and application processes for the ARM CPU case, since we operate with multiple intrinsics, rather than with a specific one.