### PR TITLE
[Unity][Frontend] Attach imported model weights, deprecate ImporterOutput

### DIFF
--- a/tests/python/relax/test_frontend_common.py
+++ b/tests/python/relax/test_frontend_common.py
@@ -14,7 +14,28 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-Frontends for constructing Relax programs, with the model importers
-"""
-from .common import detach_params
+import tvm
+import tvm.testing
+from tvm.relax.frontend import detach_params
+from tvm.script.parser import relax as R
+
+
+def test_detach_params():
+    @R.function
+    def func(x: R.Tensor((2, 3), "float32")):
+        return x
+
+    param = tvm.nd.empty((3,), "float32")
+    mod = tvm.IRModule({"func": func.with_attr("params", [param])})
+    detached_mod, detached_params = detach_params(mod)
+
+    tvm.ir.assert_structural_equal(detached_mod, tvm.IRModule({"func": func}))
+    assert len(detached_params) == 1
+    assert "func" in detached_params
+    assert isinstance(detached_params["func"], list)
+    assert len(detached_params["func"]) == 1
+    tvm.testing.assert_allclose(detached_params["func"][0].numpy(), param.numpy())
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_frontend_dynamo.py
+++ b/tests/python/relax/test_frontend_dynamo.py
@@ -147,7 +147,7 @@ def test_subgraph_capture():
             return gv
 
     model = Input1()
-    mod = dynamo_capture_subgraphs(model, torch.randn(10, 100)).mod
+    mod = dynamo_capture_subgraphs(model, torch.randn(10, 100))
     binding = {"w0": model.lin.weight.detach().numpy(), "w1": model.lin.bias.detach().numpy()}
     binding = {k: tvm.nd.array(v) for k, v in binding.items()}
     expected = relax.transform.BindParams("subgraph_0", binding)(Expected1)
@@ -190,7 +190,7 @@ def test_subgraph_capture():
                 R.output(gv1)
             return gv1
 
-    mod = dynamo_capture_subgraphs(Input2, torch.randn(10), torch.ones(10)).mod
+    mod = dynamo_capture_subgraphs(Input2, torch.randn(10), torch.ones(10))
     tvm.ir.assert_structural_equal(mod, Expected2)
 
 


### PR DESCRIPTION
The class ImporterOutput introduced by #14197 turns out introducing inconvenience for use, as it is a wrapper of IRModule and the parameters, and prevents good composability when we want to combine multiple ImporterOutput together.

From the perspective of easy use, we would like to return IRModule only. Therefore, as another approach, we can make the imported parameters as one function attribute, and detach the parameters later.

This PR implements this and provides the param detachment function. With only IRModule being manipulated, we can easily combine the results from multiple imports.