### PR TITLE
[Unity][Frontend] FX translator supports unwrapping unit return tuple

### DIFF
--- a/python/tvm/relax/frontend/torch/dynamo.py
+++ b/python/tvm/relax/frontend/torch/dynamo.py
@@ -148,7 +148,12 @@ def dynamo_capture_subgraphs(model, *params, **kwargs) -> tvm.IRModule:
     def _capture(graph_module: fx.GraphModule, example_inputs):
         assert isinstance(graph_module, torch.fx.GraphModule)
         input_info = [(tuple(tensor.shape), str(tensor.dtype)) for tensor in example_inputs]
-        mod_ = from_fx(graph_module, input_info, keep_params_as_input)
+        mod_ = from_fx(
+            graph_module,
+            input_info,
+            keep_params_as_input=keep_params_as_input,
+            unwrap_unit_return_tuple=True,
+        )
         mod[f"subgraph_{len(mod.get_global_vars())}"] = mod_["main"]
         return graph_module.forward
 

--- a/tests/python/relax/test_frontend_dynamo.py
+++ b/tests/python/relax/test_frontend_dynamo.py
@@ -135,14 +135,14 @@ def test_subgraph_capture():
             inp_0: R.Tensor((10, 100), dtype="float32"),
             w0: R.Tensor((10, 100), dtype="float32"),
             w1: R.Tensor((10,), dtype="float32"),
-        ) -> R.Tuple(R.Tensor((10, 10), dtype="float32")):
+        ) -> R.Tensor((10, 10), dtype="float32"):
             # block 0
             with R.dataflow():
                 lv: R.Tensor((100, 10), dtype="float32") = R.permute_dims(w0, axes=None)
                 lv1: R.Tensor((10, 10), dtype="float32") = R.matmul(inp_0, lv, out_dtype="float32")
                 lv2: R.Tensor((10, 10), dtype="float32") = R.add(lv1, w1)
                 lv3: R.Tensor((10, 10), dtype="float32") = R.nn.relu(lv2)
-                gv: R.Tuple(R.Tensor((10, 10), dtype="float32")) = (lv3,)
+                gv: R.Tensor((10, 10), dtype="float32") = lv3
                 R.output(gv)
             return gv
 
@@ -182,11 +182,11 @@ def test_subgraph_capture():
         @R.function
         def subgraph_1(
             inp_01: R.Tensor((10,), dtype="float32"), inp_11: R.Tensor((10,), dtype="float32")
-        ) -> R.Tuple(R.Tensor((10,), dtype="float32")):
+        ) -> R.Tensor((10,), dtype="float32"):
             # block 0
             with R.dataflow():
                 lv5: R.Tensor((10,), dtype="float32") = R.multiply(inp_11, inp_01)
-                gv1: R.Tuple(R.Tensor((10,), dtype="float32")) = (lv5,)
+                gv1: R.Tensor((10,), dtype="float32") = lv5
                 R.output(gv1)
             return gv1
 


### PR DESCRIPTION
Previously we found that the FX GraphModule captured by torch.dynamo will always return a tuple at the end, even if the Module being traced returns a single object. Unwrapping the unit tuple in that case can help and ease model deployment. Therefore, this PR introduces an option "unwrap_return_unit_tuple" to `from_fx`, to indicate if we caller wants to unwrap the returned unit tuple.

`dynamo_subgraph_capture` now will always use True on this option.