### PR TITLE
[Unity][WEB] Improve webgpu codegen options to skip readonly

### DIFF
--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -189,6 +189,10 @@ class TVM_DLL ModuleNode : public Object {
    * \return The corresponding function.
    */
   const PackedFunc* GetFuncFromEnv(const std::string& name);
+
+  /*! \brief Clear all imports of the module. */
+  void ClearImports() { imports_.clear(); }
+
   /*! \return The module it imports from */
   const std::vector<Module>& imports() const { return imports_; }
 

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -251,6 +251,10 @@ class Module(object):
         """
         return _ffi_api.ModuleIsDSOExportable(self)
 
+    def clear_imports(self):
+        """Remove all imports of the module."""
+        _ffi_api.ModuleClearImports(self)
+
     def save(self, file_name, fmt=""):
         """Save the module to file.
 
@@ -441,7 +445,7 @@ class Module(object):
             raise RuntimeError("Cannot call export_library in runtime only mode")
         # Extra dependencies during runtime.
         from pathlib import Path
-        from tvm.contrib import cc as _cc, tar as _tar, utils as _utils
+        from tvm.contrib import cc as _cc, tar as _tar, utils as _utils, tvmjs as _tvmjs
 
         if isinstance(file_name, Path):
             file_name = str(file_name)
@@ -506,6 +510,8 @@ class Module(object):
         if not fcompile:
             if file_name.endswith(".tar"):
                 fcompile = _tar.tar
+            elif file_name.endswith(".wasm"):
+                fcompile = _tvmjs.create_tvmjs_wasm
             else:
                 fcompile = _cc.create_shared
 

--- a/src/runtime/metal/metal_module.mm
+++ b/src/runtime/metal/metal_module.mm
@@ -277,6 +277,15 @@ Module MetalModuleCreate(std::string data, std::string fmt,
   return Module(n);
 }
 
+TVM_REGISTER_GLOBAL("runtime.module.create_metal_module")
+    .set_body_typed([](std::string data, std::string fmap_json) {
+      std::istringstream stream(fmap_json);
+      std::unordered_map<std::string, FunctionInfo> fmap;
+      dmlc::JSONReader reader(&stream);
+      reader.Read(&fmap);
+      return MetalModuleCreate(data, "metal", fmap, "");
+    });
+
 // Load module from module.
 Module MetalModuleLoadFile(const std::string& file_name, const std::string& format) {
   std::string data;

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -186,6 +186,10 @@ TVM_REGISTER_GLOBAL("runtime.ModuleGetImport").set_body_typed([](Module mod, int
   return mod->imports().at(index);
 });
 
+TVM_REGISTER_GLOBAL("runtime.ModuleClearImports").set_body_typed([](Module mod) {
+  mod->ClearImports();
+});
+
 TVM_REGISTER_GLOBAL("runtime.ModuleGetTypeKey").set_body_typed([](Module mod) {
   return std::string(mod->type_key());
 });

--- a/src/target/source/codegen_webgpu.h
+++ b/src/target/source/codegen_webgpu.h
@@ -48,7 +48,7 @@ class CodeGenWebGPU final : public CodeGenC {
   explicit CodeGenWebGPU(Target target);
   // overrides
   std::string Finish() final;
-  runtime::FunctionInfo AddFunction(const PrimFunc& f);  // NOLINT(*)
+  runtime::FunctionInfo AddFunction(const PrimFunc& f, bool skip_readonly_decl);  // NOLINT(*)
   void InitFuncState(const PrimFunc& f) final;
   void PrintStorageSync(const CallNode* op) final;     // NOLINT(*)
   void PrintType(DataType t, std::ostream& os) final;  // NOLINT(*)

--- a/web/apps/browser/rpc_server.html
+++ b/web/apps/browser/rpc_server.html
@@ -130,7 +130,8 @@
     <button onclick="connectRPC()">Connect To Proxy</button>
     <button onclick="clearLog()">Clear Log</button>
     <div id="progress">
-      <label id="progress-tracker-label"></div>
+      <label id="gpu-tracker-label"> </label><br>
+      <label id="progress-tracker-label"> </label> <br>
       <progress id="progress-tracker-progress" max="100" value="100"> </progress>
     </div>
     <div id="includeRPCPlugin"></div>

--- a/web/src/rpc_server.ts
+++ b/web/src/rpc_server.ts
@@ -19,7 +19,7 @@
 
 import { SizeOf, ArgTypeCode } from "./ctypes";
 import { assert, StringToUint8Array, Uint8ArrayToString } from "./support";
-import { detectGPUDevice } from "./webgpu";
+import { detectGPUDevice, GPUDeviceDetectOutput } from "./webgpu";
 import * as compact from "./compact";
 import * as runtime from "./runtime";
 import { Disposable } from "./types";
@@ -272,11 +272,11 @@ export class RPCServer {
       );
 
       try {
-        const gpuDevice: GPUDevice | undefined | null = await detectGPUDevice();
-        if (gpuDevice !== undefined && gpuDevice !== null) {
-          const label = gpuDevice.label?.toString() || "WebGPU";
+        const output: GPUDeviceDetectOutput | undefined = await detectGPUDevice();
+        if (output !== undefined) {
+          const label = "WebGPU: "+ output.adapterInfo.description;
           this.log("Initialize GPU device: " + label);
-          inst.initWebGPU(gpuDevice);
+          inst.initWebGPU(output.device);
         } else {
           this.log("Cannot find WebGPU device in the env");
         }

--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -1373,10 +1373,8 @@ export class Instance implements Disposable {
         text += Math.ceil(fetchedBytes / (1024 * 1024)).toString() + "MB fetched "
         text += Math.floor(fetchedBytes * 100 / totalBytes).toString() + "% completed, "
         text += timeElapsed + " secs elapsed";
-        if (timeElapsed != 0){
-          text += ", speed=" + (fetchedBytes / timeElapsed / (1024 * 1024)).toFixed(1) + " MB/sec."
-        }
-        text += " This can take a while during first load.";
+        text += " It can take a while when we first visit this page to populate the cache."
+        text += " Later refreshes will become faster.";
         this.fetchProgressCallback[j]({
           fetchedBytes: fetchedBytes,
           totalBytes: totalBytes,
@@ -1391,7 +1389,7 @@ export class Instance implements Disposable {
         fetchedBytes: 0,
         totalBytes: totalBytes,
         timeElapsed: 0,
-        text: "Start to fetch " + ndarrayCacheUrl
+        text: "Start to fetch params",
       });
     }
     const cache = await caches.open("tvmjs");


### PR DESCRIPTION
Readonly detection can cause the kernel arg order
to be different from other shaders, add options to optionally skip it.

Also makes export auto use emcc for wasm target.
