### PR TITLE
[MetaSchedule] Change anchor trace apply to block-mapping based approach

### DIFF
--- a/python/tvm/meta_schedule/trace_apply.py
+++ b/python/tvm/meta_schedule/trace_apply.py
@@ -16,11 +16,14 @@
 # under the License.
 """Specialized applications of trace"""
 from ..tir.schedule import Schedule, Trace
+from ..ir.module import IRModule
 from ..target import Target
 from . import _ffi_api
 
 
-def schedule_using_anchor_trace(sch: Schedule, anchor_trace: Trace, target: Target) -> None:
+def schedule_using_anchor_trace(
+    sch: Schedule, anchor_trace: Trace, record_mod: IRModule, target: Target
+) -> None:
     """Apply the trace from a TIR module whose anchor block is the same but fused elemewise op
     blocks differ. This function can be used for transferring a trace tuned on a conv2d -> add
     subgraph to other subgraphs having the same conv2d workload, for example. We call such trace
@@ -33,7 +36,9 @@ def schedule_using_anchor_trace(sch: Schedule, anchor_trace: Trace, target: Targ
         The target schedule
     anchor_trace: Trace
         The trace generated for other TIR module having the same anchor block
+    record_mod : IRModule
+        The IR Module where anchor trace is tuned on
     target : tvm.target.Target
         The compilation target
     """
-    _ffi_api.ScheduleUsingAnchorTrace(sch, anchor_trace, target)  # type: ignore
+    _ffi_api.ScheduleUsingAnchorTrace(sch, anchor_trace, record_mod, target)  # type: ignore

--- a/src/meta_schedule/trace_apply.cc
+++ b/src/meta_schedule/trace_apply.cc
@@ -48,7 +48,8 @@ bool IsAncestor(BlockRV b1, BlockRV b2, Schedule sch) {
 }
 
 // Inline or reverse inline spatial blocks after the anchor block
-void InlinePostBlocks(Schedule sch, Trace anchor_trace, Target target) {
+void InlinePostBlocks(Schedule sch, Trace anchor_trace, Target target,
+                      Map<String, String> target2record_block_mapping) {
   static auto kind_get_block = InstructionKind::Get("GetBlock");
   // We let blocks whose names are referenced in the anchor trace be scheduled by the anchor trace.
   // We record such block names to avoid inlining them here.
@@ -72,9 +73,9 @@ void InlinePostBlocks(Schedule sch, Trace anchor_trace, Target target) {
       auto anchor_block_rv = sch->GetBlock(anchor_block->name_hint);
       if (IsAncestor(block, anchor_block_rv, sch)) continue;
     }
-    // Spatial blocks which are not referenced in the anchor trace will be inlined here.
+    // Spatial blocks which are not mapped between record mod and target mod will be inlined here.
     auto block_sref = sch->GetSRef(block);
-    if (IsSpatial(block_sref) && !get_block_names.count(name)) {
+    if (IsSpatial(block_sref) && !target2record_block_mapping.count(name)) {
       StmtSRef scopeRoot =
           (name != "root") ? GetScopeRoot(sch->state(), block_sref, false) : block_sref;
       if (IsOutputBlock(sch->state(), block_sref, scopeRoot)) {
@@ -97,22 +98,95 @@ void InlinePostBlocks(Schedule sch, Trace anchor_trace, Target target) {
   }
 }
 
+// Same to Structural Equal except ignoring float constant difference
+class SEqualHandlerIgnoreFloat : public SEqualHandlerDefault {
+ public:
+  SEqualHandlerIgnoreFloat() : SEqualHandlerDefault(false, nullptr, false) {}
+
+ protected:
+  bool DispatchSEqualReduce(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_vars,
+                            const Optional<ObjectPathPair>& current_paths) {
+    if (auto lhs_ptr = lhs.as<FloatImmNode>(), rhs_ptr = rhs.as<FloatImmNode>();
+        lhs_ptr && rhs_ptr) {
+      return true;
+    }
+    return SEqualHandlerDefault::DispatchSEqualReduce(lhs, rhs, map_free_vars, current_paths);
+  }
+};
+
+// Extract all blocks from a module
+class BlockExtractor : public StmtExprVisitor {
+ public:
+  static Array<Block> ExtractBlocks(Stmt stmt) {
+    BlockExtractor extractor;
+    extractor(stmt);
+    return extractor.blocks;
+  }
+
+ private:
+  void VisitStmt_(const BlockNode* block) final {
+    if (block->name_hint == "root") {
+      StmtExprVisitor::VisitStmt_(block);
+      return;
+    }
+    ICHECK(!in_block_) << "Nested blocks are not supported";
+    in_block_ = true;
+    blocks.push_back(GetRef<Block>(block));
+    StmtExprVisitor::VisitStmt_(block);
+    in_block_ = false;
+  }
+  Array<Block> blocks;
+  bool in_block_ = false;
+};
+
+// Map blocks between record mod and target mod
+std::pair<Map<String, String>, Map<String, String>> GetBlockMapping(IRModule target_mod,
+                                                                    IRModule record_mod) {
+  PrimFunc record_func = Downcast<PrimFunc>(record_mod->Lookup("main"));
+  Array<Block> blocks_from_record = BlockExtractor::ExtractBlocks(record_func->body);
+  PrimFunc target_func = Downcast<PrimFunc>(target_mod->Lookup("main"));
+  Array<Block> blocks_from_target = BlockExtractor::ExtractBlocks(target_func->body);
+  // Map blocks between record mod and target mod
+  Map<String, String> record2target{{"root", "root"}};
+  Map<String, String> target2record{{"root", "root"}};
+
+  for (int i = 0; i < static_cast<int>(blocks_from_record.size()); i++) {
+    for (int j = 0; j < static_cast<int>(blocks_from_target.size()); j++) {
+      if (SEqualHandlerIgnoreFloat().Equal(blocks_from_record[i], blocks_from_target[j], false) &&
+          !target2record.count(blocks_from_target[j]->name_hint)) {
+        record2target.Set(blocks_from_record[i]->name_hint, blocks_from_target[j]->name_hint);
+        target2record.Set(blocks_from_target[j]->name_hint, blocks_from_record[i]->name_hint);
+        break;
+      }
+    }
+  }
+  return std::make_pair(target2record, record2target);
+}
+
 // Apply instructions from the anchor trace to the target schedule, and returns blocks
 // that remain unscheduled.
-std::vector<BlockRV> ApplyAnchorTrace(Schedule sch, Trace anchor_trace) {
+std::vector<BlockRV> ApplyAnchorTrace(Schedule sch, Trace anchor_trace, const IRModule& record_mod,
+                                      Map<String, String> record2target,
+                                      Map<String, String> target2record) {
   static auto kind_get_child_blocks = InstructionKind::Get("GetChildBlocks");
   static auto kind_get_block = InstructionKind::Get("GetBlock");
   static auto kind_compute_inline = InstructionKind::Get("ComputeInline");
   static auto kind_reverse_compute_inline = InstructionKind::Get("ReverseComputeInline");
+  static auto kind_decompose_reduction = InstructionKind::Get("DecomposeReduction");
+  static auto kind_blockize = InstructionKind::Get("Blockize");
 
   const auto block_names_orig = GetBlockNames(sch->mod());
   const auto sch_orig = sch->Copy();
-
-  std::unordered_map<const Object*, const Object*> rv_map;
+  Schedule sch_for_record_mod =
+      Schedule::Traced(record_mod,
+                       /*rand_state=*/-1,
+                       /*debug_mode=*/0,
+                       /*error_render_level=*/tir::ScheduleErrorRenderLevel::kDetail);
+  std::unordered_map<const Object*, const Object*> rv_map_record_mod;
+  std::unordered_map<const Object*, const Object*> rv_map_target_mod;
   // Blocks and loops that appear in the anchor trace but are not part of the target schedule.
   std::unordered_set<BlockRV, ObjectHash, ObjectEqual> foreign_blocks;
   std::unordered_set<LoopRV, ObjectHash, ObjectEqual> foreign_loops;
-
   // Instructions in the anchor trace can be applied only if all inputs are part of the target
   // schedule.
   auto is_inst_applicable = [&foreign_blocks, &foreign_loops](Instruction inst) {
@@ -127,6 +201,14 @@ std::vector<BlockRV> ApplyAnchorTrace(Schedule sch, Trace anchor_trace) {
   };
 
   for (const auto& inst : anchor_trace->insts) {
+    // execute instruction on record module
+    auto inputs_for_record_mod = TranslateInputRVs(inst->inputs, rv_map_record_mod);
+    Optional<ObjectRef> decision = anchor_trace->GetDecision(inst);
+    Array<ObjectRef> outputs_for_record_mod = inst->kind->f_apply_to_schedule(
+        sch_for_record_mod, inputs_for_record_mod, inst->attrs, decision);
+    TranslateAddOutputRVs(inst->outputs, outputs_for_record_mod, &rv_map_record_mod);
+
+    // execute instruction on target module
     if (!is_inst_applicable(inst)) {
       // If we find an instruction that is not applicable, its outputs are recorded as "foreign"
       // to the target schedule.
@@ -140,56 +222,125 @@ std::vector<BlockRV> ApplyAnchorTrace(Schedule sch, Trace anchor_trace) {
       continue;
     }
 
-    Array<ObjectRef> inputs = TranslateInputRVs(inst->inputs, rv_map);
-
-    if (inst->kind.same_as(kind_get_block) && !HasBlock(sch, Downcast<String>(inst->attrs[0]))) {
-      // The anchor trace does get_block on a block that is not part of the target schedule.
-      auto block = Downcast<BlockRV>(inst->outputs[0]);
-      foreign_blocks.insert(block);
-      continue;
+    Array<ObjectRef> inputs = TranslateInputRVs(inst->inputs, rv_map_target_mod);
+    Array<ObjectRef> attrs = inst->attrs;
+    if (inst->kind.same_as(kind_get_block)) {
+      BlockRV block_rv_record = Downcast<BlockRV>(outputs_for_record_mod[0]);
+      Block block_record = Downcast<Block>(sch_for_record_mod->Get(block_rv_record));
+      if (!record2target.count(block_record->name_hint)) {
+        // The anchor trace does get_block on a block that is not part of the target schedule.
+        auto block = Downcast<BlockRV>(inst->outputs[0]);
+        foreign_blocks.insert(block);
+        continue;
+      }
+      attrs.Set(0, record2target[block_record->name_hint]);
     } else if (inst->kind.same_as(kind_reverse_compute_inline)) {
       // The anchor trace does reverse_compute_inline on a block, but the block with the same name
       // in the target schedule cannot be reverse compute inline-ed.
       // In such cases, it should be possible to apply compute_inline instead.
-      auto block = Downcast<BlockRV>(inputs[0]);
-      auto block_sref = sch->GetSRef(block);
+      auto block_rv = Downcast<BlockRV>(inputs[0]);
+      auto block_sref = sch->GetSRef(block_rv);
+      Block block = sch->Get(block_rv);
+      if (target2record.count(block->name_hint)) {
+        String record_block_name = target2record[block->name_hint];
+        target2record.erase(block->name_hint);
+        record2target.erase(record_block_name);
+      }
       if (!CanReverseComputeInline(sch->state(), block_sref)) {
         ICHECK(CanComputeInline(sch->state(), block_sref));
-        sch->ComputeInline(block);
+        sch->ComputeInline(block_rv);
         continue;
       }
     } else if (inst->kind.same_as(kind_compute_inline)) {
       // Similar to the reverse_compute_inline case above.
-      auto block = Downcast<BlockRV>(inputs[0]);
-      auto block_sref = sch->GetSRef(block);
+      auto block_rv = Downcast<BlockRV>(inputs[0]);
+      auto block_sref = sch->GetSRef(block_rv);
+      Block block = sch->Get(block_rv);
+      if (target2record.count(block->name_hint)) {
+        String record_block_name = target2record[block->name_hint];
+        target2record.erase(block->name_hint);
+        record2target.erase(record_block_name);
+      }
       auto state = sch->state();
       if (!CanComputeInline(state, block_sref)) {
         ICHECK(IsOutputBlock(state, block_sref, GetScopeRoot(state, block_sref, false)))
             << "If a spatial block cannot be inlined, it should be the output block";
         if (CanReverseComputeInline(sch->state(), block_sref)) {
-          sch->ReverseComputeInline(block);
+          sch->ReverseComputeInline(block_rv);
         }
         continue;
       }
     }
 
-    Optional<ObjectRef> decision = anchor_trace->GetDecision(inst);
-    Array<ObjectRef> outputs = inst->kind->f_apply_to_schedule(sch, inputs, inst->attrs, decision);
+    Array<ObjectRef> outputs = inst->kind->f_apply_to_schedule(sch, inputs, attrs, decision);
 
     if (inst->kind.same_as(kind_get_child_blocks)) {
-      // We want to allow a trace generated for a single conv2d block to be applied to
-      // conv2d -> elemwise blocks, where two conv2d are the same workload.
-      // GetChildBlocks returns a different number of blocks for the two cases above, which
-      // violates the assumption made by TranslateAddOutputRVs: old_outputs.size() ==
-      // new_outputs.size(). We workaround this problem by assuming that the prefix of the "new"
-      // outputs matches with the "old" outputs, and truncating the new outputs accordingly.
-      ICHECK(inst->outputs.size() <= outputs.size());
-      TranslateAddOutputRVs(
-          inst->outputs, Array<ObjectRef>(outputs.begin(), outputs.begin() + inst->outputs.size()),
-          &rv_map);
-    } else {
-      TranslateAddOutputRVs(inst->outputs, outputs, &rv_map);
+      BlockRV input_rv = Downcast<BlockRV>(inputs[0]);
+      Block input_block = Downcast<Block>(sch->Get(input_rv));
+      // only add the mapped blocks to the output rvs
+      Array<ObjectRef> new_target_outputs;
+      for (int i = 0; i < static_cast<int>(outputs.size()); i++) {
+        auto block_target = sch->Get(Downcast<BlockRV>(outputs[i]));
+        if (target2record.count(block_target->name_hint)) {
+          new_target_outputs.push_back(outputs[i]);
+        }
+      }
+      Array<ObjectRef> new_inst_outputs;
+      for (int i = 0; i < static_cast<int>(outputs_for_record_mod.size()); i++) {
+        auto block_record = sch_for_record_mod->Get(Downcast<BlockRV>(outputs_for_record_mod[i]));
+        if (record2target.count(block_record->name_hint)) {
+          new_inst_outputs.push_back(inst->outputs[i]);
+        } else {
+          foreign_blocks.insert(Downcast<BlockRV>(inst->outputs[i]));
+        }
+      }
+      TranslateAddOutputRVs(new_inst_outputs, new_target_outputs, &rv_map_target_mod);
+      continue;
     }
+    // maintain block mapping
+    ICHECK(outputs.size() == outputs_for_record_mod.size());
+    for (int i = 0; i < static_cast<int>(outputs.size()); i++) {
+      if (outputs[i]->IsInstance<BlockRVNode>()) {
+        ICHECK(outputs_for_record_mod[i]->IsInstance<BlockRVNode>());
+        auto block_rv_record = Downcast<BlockRV>(outputs_for_record_mod[i]);
+        auto block_record = Downcast<Block>(sch_for_record_mod->Get(block_rv_record));
+        auto block_rv_target = Downcast<BlockRV>(outputs[i]);
+        auto block_target = Downcast<Block>(sch->Get(block_rv_target));
+        record2target.Set(block_record->name_hint, block_target->name_hint);
+        target2record.Set(block_target->name_hint, block_record->name_hint);
+      }
+    }
+    if (inst->kind.same_as(kind_decompose_reduction)) {
+      // decompose_reduction will modify input block
+      ICHECK(inputs.size() == inputs_for_record_mod.size());
+      for (int i = 0; i < static_cast<int>(inputs.size()); i++) {
+        if (inputs[i]->IsInstance<BlockRVNode>()) {
+          auto block_rv_record = Downcast<BlockRV>(inputs_for_record_mod[i]);
+          auto block_record = Downcast<Block>(sch_for_record_mod->Get(block_rv_record));
+          auto block_rv_target = Downcast<BlockRV>(inputs[i]);
+          auto block_target = Downcast<Block>(sch->Get(block_rv_target));
+          record2target.Set(block_record->name_hint, block_target->name_hint);
+          target2record.Set(block_target->name_hint, block_record->name_hint);
+        }
+      }
+    } else if (inst->kind.same_as(kind_blockize)) {
+      // blockize will generate a block under the init block
+      Block target_output_block = Downcast<Block>(sch->Get(Downcast<BlockRV>(outputs[0])));
+      if (target_output_block->init.defined()) {
+        Array<Block> target_init_blocks =
+            BlockExtractor::ExtractBlocks(target_output_block->init.value());
+        Block record_output_block =
+            Downcast<Block>(sch_for_record_mod->Get(Downcast<BlockRV>(outputs_for_record_mod[0])));
+        ICHECK(record_output_block->init.defined());
+        Array<Block> record_init_blocks =
+            BlockExtractor::ExtractBlocks(record_output_block->init.value());
+        ICHECK(target_init_blocks.size() == 1);
+        ICHECK(record_init_blocks.size() == 1);
+        record2target.Set(record_init_blocks[0]->name_hint, target_init_blocks[0]->name_hint);
+        target2record.Set(target_init_blocks[0]->name_hint, record_init_blocks[0]->name_hint);
+      }
+    }
+    TranslateAddOutputRVs(inst->outputs, outputs, &rv_map_target_mod);
   }
 
   auto is_scheduled = [=](const std::string& block_name) {
@@ -216,14 +367,17 @@ std::vector<BlockRV> ApplyAnchorTrace(Schedule sch, Trace anchor_trace) {
       unscheduled_blocks.push_back(sch->GetBlock(name));
     }
   }
-
   return unscheduled_blocks;
 }
 
-void ScheduleUsingAnchorTrace(Schedule sch, const Trace& anchor_trace, const tvm::Target& target) {
-  InlinePostBlocks(sch, anchor_trace, target);
+void ScheduleUsingAnchorTrace(Schedule sch, const Trace& anchor_trace, const IRModule& record_mod,
+                              const tvm::Target& target) {
+  Map<String, String> record2target, target2record;
+  std::tie(target2record, record2target) = GetBlockMapping(sch->mod(), record_mod);
+  InlinePostBlocks(sch, anchor_trace, target, target2record);
 
-  auto unscheduled_blocks = ApplyAnchorTrace(sch, anchor_trace);
+  auto unscheduled_blocks =
+      ApplyAnchorTrace(sch, anchor_trace, record_mod, record2target, target2record);
   ICHECK(unscheduled_blocks.size() <= 1)
       << "All blocks should have been scheduled or only one (fused) spatial block can remain "
          "unscheduled at this point.";

--- a/src/meta_schedule/trace_apply.h
+++ b/src/meta_schedule/trace_apply.h
@@ -37,10 +37,11 @@ namespace meta_schedule {
  * inlined or parallelized.
  * \param sch The schedule to apply the anchor trace.
  * \param anchor_trace The trace tuned on other subgraph with the same anchor-block workload.
+ * \param record_mod The IR module where anchor trace is tuned on
  * \param target The target information needed for inlining and parallelization.
  */
 void ScheduleUsingAnchorTrace(tir::Schedule sch, const tir::Trace& anchor_trace,
-                              const tvm::Target& target);
+                              const IRModule& record_mod, const tvm::Target& target);
 
 }  // namespace meta_schedule
 }  // namespace tvm

--- a/src/relay/backend/te_compiler_cache.cc
+++ b/src/relay/backend/te_compiler_cache.cc
@@ -653,7 +653,8 @@ class ScheduleBuilder : public ExprVisitor {
               // When the database lookup succeeds while structural equality check fails,
               // it implies that the anchor block based equality has been used during tuning.
               // The trace in the record cannot directly be applied to this query module.
-              meta_schedule::ScheduleUsingAnchorTrace(sch, record->trace, target_);
+              meta_schedule::ScheduleUsingAnchorTrace(sch, record->trace, record->workload->mod,
+                                                      target_);
             } else {
               record->trace->ApplyToSchedule(sch, /*remove_postproc=*/false);
             }

--- a/tests/python/unittest/test_meta_schedule_trace_apply.py
+++ b/tests/python/unittest/test_meta_schedule_trace_apply.py
@@ -87,6 +87,70 @@ class DenseAdd:
                 T.writes(T_add[ax0, ax1])
                 T_add[ax0, ax1] = T_matmul_NT[ax0, ax1] + compile_engine_const[()]
 
+@tvm.script.ir_module
+class AddDense:
+    @T.prim_func
+    def main(
+        p0: T.Buffer((128, 128), "float32"),
+        p1: T.Buffer((128, 128), "float32"),
+        T_matmul_NT: T.Buffer((128, 128), "float32"),
+    ) -> None:
+        # function attr dict
+        T.func_attr({"global_symbol": "main", "tir.noalias": True, "layout_free_buffers": [1]})
+        # body
+        # with T.block("root")
+        T_add_0 = T.alloc_buffer([128, 128], dtype="float32")
+
+        for i0, i1 in T.grid(128, 128):
+            with T.block("T_add_0"):
+                ax0, ax1 = T.axis.remap("SS", [i0, i1])
+                T.reads(p0[ax0, ax1])
+                T.writes(T_add_0[ax0, ax1])
+                T_add_0[ax0, ax1] = p0[ax0, ax1] + T.float32(1)
+        for i0, i1, i2 in T.grid(128, 128, 128):
+            with T.block("T_matmul_NT"):
+                i, j, k = T.axis.remap("SSR", [i0, i1, i2])
+                T.reads(T_add_0[i, k], p1[j, k])
+                T.writes(T_matmul_NT[i, j])
+                T.block_attr({"layout_free_placeholders": []})
+                with T.init():
+                    T_matmul_NT[i, j] = T.float32(0)
+                T_matmul_NT[i, j] = T_matmul_NT[i, j] + T_add_0[i, k] * p1[j, k]
+
+@tvm.script.ir_module
+class DenseAdd_different_name:
+    @T.prim_func
+    def main(
+        p00: T.Buffer((128, 128), "float32"),
+        p10: T.Buffer((128, 128), "float32"),
+        T_add_: T.Buffer((128, 128), "float32"),
+    ) -> None:
+        # function attr dict
+        T.func_attr({"global_symbol": "main", "tir.noalias": True, "layout_free_buffers": [1]})
+        # body
+        # with T.block("root")
+        T_matmul_NT_ = T.alloc_buffer([128, 128], dtype="float32")
+        compile_engine_const_ = T.alloc_buffer([], dtype="float32")
+        for i0, i1, i2 in T.grid(128, 128, 128):
+            with T.block("T_matmul_NT_"):
+                i, j, k = T.axis.remap("SSR", [i0, i1, i2])
+                T.reads(p00[i, k], p10[j, k])
+                T.writes(T_matmul_NT_[i, j])
+                T.block_attr({"layout_free_placeholders": []})
+                with T.init():
+                    T_matmul_NT_[i, j] = T.float32(0)
+                T_matmul_NT_[i, j] = T_matmul_NT_[i, j] + p00[i, k] * p10[j, k]
+        with T.block("compile_engine_const_"):
+            vi = T.axis.spatial(1, 0)
+            T.reads()
+            T.writes(compile_engine_const_[()])
+            compile_engine_const_[()] = T.float32(1)
+        for i0, i1 in T.grid(128, 128):
+            with T.block("T_add_"):
+                ax0, ax1 = T.axis.remap("SS", [i0, i1])
+                T.reads(T_matmul_NT_[ax0, ax1], compile_engine_const_[()])
+                T.writes(T_add_[ax0, ax1])
+                T_add_[ax0, ax1] = T_matmul_NT_[ax0, ax1] + compile_engine_const_[()]
 
 @tvm.script.ir_module
 class DenseAdd_scheduled_cpu:
@@ -1810,6 +1874,182 @@ class Conv2dInt8_with_predicate_scheduled:
                             T.writes(compute[v0 // 3136, v0 % 3136 // 56, v0 % 56, v1])
                             compute[v0 // 3136, v0 % 3136 // 56, v0 % 56, v1] = T.max(T.min(T.q_multiply_shift(T.max(T.min(p7[()] + T.q_multiply_shift_per_axis(conv2d_nhwc_reindex_shared[v0, v1] - p2[0, 0, 0, v1] + p3[0, 0, 0, v1], p4[v1], p5[v1], p6[v1], 31, False, True, dtype="int32"), 255), 0) - p8[0], 1457846997, 31, 0, dtype="int32") + T.q_multiply_shift(p9[v0 // 3136, v0 % 3136 // 56, v0 % 56, v1], 2101000910, 31, 0, dtype="int32"), 255), 0)
 
+@tvm.script.ir_module
+class GroupNormSigmoidMultiply:
+    @T.prim_func
+    def main(lv79: T.Buffer((T.int64(1), T.int64(512), T.int64(64), T.int64(64)), "float32"), param_0: T.Buffer((T.int64(512),), "float32"), param_1: T.Buffer((T.int64(512),), "float32"), T_multiply: T.Buffer((T.int64(1), T.int64(512), T.int64(64), T.int64(64)), "float16")):
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        # with T.block("root"):
+        T_reshape = T.alloc_buffer((T.int64(1), T.int64(32), T.int64(16), T.int64(64), T.int64(64)))
+        rxplaceholder_red_temp_v0 = T.alloc_buffer((T.int64(1), T.int64(32)))
+        rxplaceholder_red_temp_v1 = T.alloc_buffer((T.int64(1), T.int64(32)))
+        T_reshape_1 = T.alloc_buffer((T.int64(32), T.int64(16)))
+        T_reshape_2 = T.alloc_buffer((T.int64(32), T.int64(16)))
+        T_group_norm = T.alloc_buffer((T.int64(1), T.int64(32), T.int64(16), T.int64(64), T.int64(64)))
+        T_reshape_3 = T.alloc_buffer((T.int64(1), T.int64(512), T.int64(64), T.int64(64)))
+        compute = T.alloc_buffer((T.int64(1), T.int64(512), T.int64(64), T.int64(64)), "float16")
+        compute_1 = T.alloc_buffer((T.int64(1), T.int64(512), T.int64(64), T.int64(64)), "float16")
+        for ax0, ax1, ax2, ax3, ax4 in T.grid(T.int64(1), T.int64(32), T.int64(16), T.int64(64), T.int64(64)):
+            with T.block("T_reshape"):
+                v_ax0, v_ax1, v_ax2, v_ax3, v_ax4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
+                T.reads(lv79[T.int64(0), (v_ax1 * T.int64(16) + (v_ax4 // T.int64(64) + v_ax3) // T.int64(64) + v_ax2) % T.int64(512), (v_ax4 // T.int64(64) + v_ax3) % T.int64(64), v_ax4 % T.int64(64)])
+                T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4])
+                T_reshape[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = lv79[T.int64(0), (v_ax1 * T.int64(16) + (v_ax4 // T.int64(64) + v_ax3) // T.int64(64) + v_ax2) % T.int64(512), (v_ax4 // T.int64(64) + v_ax3) % T.int64(64), v_ax4 % T.int64(64)]
+        for ax0, ax1, k2, k3, k4 in T.grid(T.int64(1), T.int64(32), T.int64(16), T.int64(64), T.int64(64)):
+            with T.block("rxplaceholder_red_temp"):
+                v_ax0, v_ax1, v_k2, v_k3, v_k4 = T.axis.remap("SSRRR", [ax0, ax1, k2, k3, k4])
+                T.reads(T_reshape[v_ax0, v_ax1, v_k2, v_k3, v_k4])
+                T.writes(rxplaceholder_red_temp_v0[v_ax0, v_ax1], rxplaceholder_red_temp_v1[v_ax0, v_ax1])
+                with T.init():
+                    rxplaceholder_red_temp_v0[v_ax0, v_ax1] = T.float32(0)
+                    rxplaceholder_red_temp_v1[v_ax0, v_ax1] = T.float32(0)
+                v_rxplaceholder_red_temp_v0: T.float32 = rxplaceholder_red_temp_v0[v_ax0, v_ax1] + T_reshape[v_ax0, v_ax1, v_k2, v_k3, v_k4]
+                v_rxplaceholder_red_temp_v1: T.float32 = rxplaceholder_red_temp_v1[v_ax0, v_ax1] + T_reshape[v_ax0, v_ax1, v_k2, v_k3, v_k4] * T_reshape[v_ax0, v_ax1, v_k2, v_k3, v_k4]
+                rxplaceholder_red_temp_v0[v_ax0, v_ax1] = v_rxplaceholder_red_temp_v0
+                rxplaceholder_red_temp_v1[v_ax0, v_ax1] = v_rxplaceholder_red_temp_v1
+        for ax0, ax1 in T.grid(T.int64(32), T.int64(16)):
+            with T.block("T_reshape_1"):
+                v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(param_0[(v_ax0 * T.int64(16) + v_ax1) % T.int64(512)])
+                T.writes(T_reshape_1[v_ax0, v_ax1])
+                T_reshape_1[v_ax0, v_ax1] = param_0[(v_ax0 * T.int64(16) + v_ax1) % T.int64(512)]
+        for ax0, ax1 in T.grid(T.int64(32), T.int64(16)):
+            with T.block("T_reshape_2"):
+                v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(param_1[(v_ax0 * T.int64(16) + v_ax1) % T.int64(512)])
+                T.writes(T_reshape_2[v_ax0, v_ax1])
+                T_reshape_2[v_ax0, v_ax1] = param_1[(v_ax0 * T.int64(16) + v_ax1) % T.int64(512)]
+        for ax0, ax1, ax2, ax3, ax4 in T.grid(T.int64(1), T.int64(32), T.int64(16), T.int64(64), T.int64(64)):
+            with T.block("T_group_norm"):
+                v_ax0, v_ax1, v_ax2, v_ax3, v_ax4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
+                T.reads(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4], rxplaceholder_red_temp_v0[v_ax0, v_ax1], rxplaceholder_red_temp_v1[v_ax0, v_ax1], T_reshape_1[v_ax1, v_ax2], T_reshape_2[v_ax1, v_ax2])
+                T.writes(T_group_norm[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4])
+                T_group_norm[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = (T_reshape[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] - rxplaceholder_red_temp_v0[v_ax0, v_ax1] * T.float32(1.52587890625e-05)) * T.rsqrt(rxplaceholder_red_temp_v1[v_ax0, v_ax1] * T.float32(1.52587890625e-05) - rxplaceholder_red_temp_v0[v_ax0, v_ax1] * T.float32(1.52587890625e-05) * (rxplaceholder_red_temp_v0[v_ax0, v_ax1] * T.float32(1.52587890625e-05)) + T.float32(9.9999999999999995e-07)) * T_reshape_1[v_ax1, v_ax2] + T_reshape_2[v_ax1, v_ax2]
+        for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(512), T.int64(64), T.int64(64)):
+            with T.block("T_reshape_3"):
+                v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(T_group_norm[T.int64(0), ((v_ax3 // T.int64(64) + v_ax2) // T.int64(64) + v_ax1) % T.int64(512) // T.int64(16), ((v_ax3 // T.int64(64) + v_ax2) // T.int64(64) + v_ax1) % T.int64(16), (v_ax3 // T.int64(64) + v_ax2) % T.int64(64), v_ax3 % T.int64(64)])
+                T.writes(T_reshape_3[v_ax0, v_ax1, v_ax2, v_ax3])
+                T_reshape_3[v_ax0, v_ax1, v_ax2, v_ax3] = T_group_norm[T.int64(0), ((v_ax3 // T.int64(64) + v_ax2) // T.int64(64) + v_ax1) % T.int64(512) // T.int64(16), ((v_ax3 // T.int64(64) + v_ax2) // T.int64(64) + v_ax1) % T.int64(16), (v_ax3 // T.int64(64) + v_ax2) % T.int64(64), v_ax3 % T.int64(64)]
+        for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(512), T.int64(64), T.int64(64)):
+            with T.block("compute"):
+                v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                T.reads(T_reshape_3[v_i0, v_i1, v_i2, v_i3])
+                T.writes(compute[v_i0, v_i1, v_i2, v_i3])
+                compute[v_i0, v_i1, v_i2, v_i3] = T.Cast("float16", T_reshape_3[v_i0, v_i1, v_i2, v_i3])
+        for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(512), T.int64(64), T.int64(64)):
+            with T.block("compute_1"):
+                v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                T.reads(compute[v_i0, v_i1, v_i2, v_i3])
+                T.writes(compute_1[v_i0, v_i1, v_i2, v_i3])
+                compute_1[v_i0, v_i1, v_i2, v_i3] = T.sigmoid(compute[v_i0, v_i1, v_i2, v_i3])
+        for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(512), T.int64(64), T.int64(64)):
+            with T.block("T_multiply"):
+                v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(compute[v_ax0, v_ax1, v_ax2, v_ax3], compute_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                T.writes(T_multiply[v_ax0, v_ax1, v_ax2, v_ax3])
+                T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = compute[v_ax0, v_ax1, v_ax2, v_ax3] * compute_1[v_ax0, v_ax1, v_ax2, v_ax3]
+
+@tvm.script.ir_module
+class GroupNorm:
+    @T.prim_func
+    def main(lv84: T.Buffer((T.int64(1), T.int64(512), T.int64(64), T.int64(64)), "float32"), param_0: T.Buffer((T.int64(512),), "float32"), param_1: T.Buffer((T.int64(512),), "float32"), compute: T.Buffer((T.int64(1), T.int64(512), T.int64(64), T.int64(64)), "float16")):
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        # with T.block("root"):
+        T_reshape = T.alloc_buffer((T.int64(1), T.int64(32), T.int64(16), T.int64(64), T.int64(64)))
+        rxplaceholder_red_temp_v0 = T.alloc_buffer((T.int64(1), T.int64(32)))
+        rxplaceholder_red_temp_v1 = T.alloc_buffer((T.int64(1), T.int64(32)))
+        T_reshape_1 = T.alloc_buffer((T.int64(32), T.int64(16)))
+        T_reshape_2 = T.alloc_buffer((T.int64(32), T.int64(16)))
+        T_group_norm = T.alloc_buffer((T.int64(1), T.int64(32), T.int64(16), T.int64(64), T.int64(64)))
+        T_reshape_3 = T.alloc_buffer((T.int64(1), T.int64(512), T.int64(64), T.int64(64)))
+        for ax0, ax1, ax2, ax3, ax4 in T.grid(T.int64(1), T.int64(32), T.int64(16), T.int64(64), T.int64(64)):
+            with T.block("T_reshape"):
+                v_ax0, v_ax1, v_ax2, v_ax3, v_ax4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
+                T.reads(lv84[T.int64(0), (v_ax1 * T.int64(16) + (v_ax4 // T.int64(64) + v_ax3) // T.int64(64) + v_ax2) % T.int64(512), (v_ax4 // T.int64(64) + v_ax3) % T.int64(64), v_ax4 % T.int64(64)])
+                T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4])
+                T_reshape[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = lv84[T.int64(0), (v_ax1 * T.int64(16) + (v_ax4 // T.int64(64) + v_ax3) // T.int64(64) + v_ax2) % T.int64(512), (v_ax4 // T.int64(64) + v_ax3) % T.int64(64), v_ax4 % T.int64(64)]
+        for ax0, ax1, k2, k3, k4 in T.grid(T.int64(1), T.int64(32), T.int64(16), T.int64(64), T.int64(64)):
+            with T.block("rxplaceholder_red_temp"):
+                v_ax0, v_ax1, v_k2, v_k3, v_k4 = T.axis.remap("SSRRR", [ax0, ax1, k2, k3, k4])
+                T.reads(T_reshape[v_ax0, v_ax1, v_k2, v_k3, v_k4])
+                T.writes(rxplaceholder_red_temp_v0[v_ax0, v_ax1], rxplaceholder_red_temp_v1[v_ax0, v_ax1])
+                with T.init():
+                    rxplaceholder_red_temp_v0[v_ax0, v_ax1] = T.float32(0)
+                    rxplaceholder_red_temp_v1[v_ax0, v_ax1] = T.float32(0)
+                v_rxplaceholder_red_temp_v0: T.float32 = rxplaceholder_red_temp_v0[v_ax0, v_ax1] + T_reshape[v_ax0, v_ax1, v_k2, v_k3, v_k4]
+                v_rxplaceholder_red_temp_v1: T.float32 = rxplaceholder_red_temp_v1[v_ax0, v_ax1] + T_reshape[v_ax0, v_ax1, v_k2, v_k3, v_k4] * T_reshape[v_ax0, v_ax1, v_k2, v_k3, v_k4]
+                rxplaceholder_red_temp_v0[v_ax0, v_ax1] = v_rxplaceholder_red_temp_v0
+                rxplaceholder_red_temp_v1[v_ax0, v_ax1] = v_rxplaceholder_red_temp_v1
+        for ax0, ax1 in T.grid(T.int64(32), T.int64(16)):
+            with T.block("T_reshape_1"):
+                v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(param_0[(v_ax0 * T.int64(16) + v_ax1) % T.int64(512)])
+                T.writes(T_reshape_1[v_ax0, v_ax1])
+                T_reshape_1[v_ax0, v_ax1] = param_0[(v_ax0 * T.int64(16) + v_ax1) % T.int64(512)]
+        for ax0, ax1 in T.grid(T.int64(32), T.int64(16)):
+            with T.block("T_reshape_2"):
+                v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(param_1[(v_ax0 * T.int64(16) + v_ax1) % T.int64(512)])
+                T.writes(T_reshape_2[v_ax0, v_ax1])
+                T_reshape_2[v_ax0, v_ax1] = param_1[(v_ax0 * T.int64(16) + v_ax1) % T.int64(512)]
+        for ax0, ax1, ax2, ax3, ax4 in T.grid(T.int64(1), T.int64(32), T.int64(16), T.int64(64), T.int64(64)):
+            with T.block("T_group_norm"):
+                v_ax0, v_ax1, v_ax2, v_ax3, v_ax4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
+                T.reads(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4], rxplaceholder_red_temp_v0[v_ax0, v_ax1], rxplaceholder_red_temp_v1[v_ax0, v_ax1], T_reshape_1[v_ax1, v_ax2], T_reshape_2[v_ax1, v_ax2])
+                T.writes(T_group_norm[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4])
+                T_group_norm[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = (T_reshape[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] - rxplaceholder_red_temp_v0[v_ax0, v_ax1] * T.float32(1.52587890625e-05)) * T.rsqrt(rxplaceholder_red_temp_v1[v_ax0, v_ax1] * T.float32(1.52587890625e-05) - rxplaceholder_red_temp_v0[v_ax0, v_ax1] * T.float32(1.52587890625e-05) * (rxplaceholder_red_temp_v0[v_ax0, v_ax1] * T.float32(1.52587890625e-05)) + T.float32(9.9999999999999995e-07)) * T_reshape_1[v_ax1, v_ax2] + T_reshape_2[v_ax1, v_ax2]
+        for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(512), T.int64(64), T.int64(64)):
+            with T.block("T_reshape_3"):
+                v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(T_group_norm[T.int64(0), ((v_ax3 // T.int64(64) + v_ax2) // T.int64(64) + v_ax1) % T.int64(512) // T.int64(16), ((v_ax3 // T.int64(64) + v_ax2) // T.int64(64) + v_ax1) % T.int64(16), (v_ax3 // T.int64(64) + v_ax2) % T.int64(64), v_ax3 % T.int64(64)])
+                T.writes(T_reshape_3[v_ax0, v_ax1, v_ax2, v_ax3])
+                T_reshape_3[v_ax0, v_ax1, v_ax2, v_ax3] = T_group_norm[T.int64(0), ((v_ax3 // T.int64(64) + v_ax2) // T.int64(64) + v_ax1) % T.int64(512) // T.int64(16), ((v_ax3 // T.int64(64) + v_ax2) // T.int64(64) + v_ax1) % T.int64(16), (v_ax3 // T.int64(64) + v_ax2) % T.int64(64), v_ax3 % T.int64(64)]
+        for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(512), T.int64(64), T.int64(64)):
+            with T.block("compute"):
+                v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                T.reads(T_reshape_3[v_i0, v_i1, v_i2, v_i3])
+                T.writes(compute[v_i0, v_i1, v_i2, v_i3])
+                compute[v_i0, v_i1, v_i2, v_i3] = T.Cast("float16", T_reshape_3[v_i0, v_i1, v_i2, v_i3])
+
+@tvm.script.ir_module
+class GroupNorm_scheduled:
+    @T.prim_func
+    def main(lv84: T.Buffer((T.int64(1), T.int64(512), T.int64(64), T.int64(64)), "float32"), param_0: T.Buffer((T.int64(512),), "float32"), param_1: T.Buffer((T.int64(512),), "float32"), compute: T.Buffer((T.int64(1), T.int64(512), T.int64(64), T.int64(64)), "float16")):
+        T.func_attr({"global_symbol": "main", "tir.noalias": True})
+        # with T.block("root"):
+        rxplaceholder_red_temp_v0 = T.alloc_buffer((T.int64(1), T.int64(32)))
+        rxplaceholder_red_temp_v1 = T.alloc_buffer((T.int64(1), T.int64(32)))
+        for ax0_ax1_fused in T.thread_binding(T.int64(32), thread="blockIdx.x", annotations={"pragma_auto_unroll_max_step": 512, "pragma_unroll_explicit": 1}):
+            for k2_k3_k4_fused_0 in range(T.int64(256)):
+                for k2_k3_k4_fused_1 in T.thread_binding(T.int64(256), thread="threadIdx.x"):
+                    with T.block("rxplaceholder_red_temp"):
+                        v_ax0 = T.axis.spatial(T.int64(1), T.int64(0))
+                        v_ax1 = T.axis.spatial(T.int64(32), ax0_ax1_fused)
+                        v_k2 = T.axis.reduce(T.int64(16), (k2_k3_k4_fused_0 * T.int64(256) + k2_k3_k4_fused_1) // T.int64(4096))
+                        v_k3 = T.axis.reduce(T.int64(64), (k2_k3_k4_fused_0 * T.int64(256) + k2_k3_k4_fused_1) % T.int64(4096) // T.int64(64))
+                        v_k4 = T.axis.reduce(T.int64(64), (k2_k3_k4_fused_0 * T.int64(256) + k2_k3_k4_fused_1) % T.int64(64))
+                        T.reads(lv84[T.int64(0), (v_ax1 * T.int64(16) + (v_k4 // T.int64(64) + v_k3) // T.int64(64) + v_k2) % T.int64(512), (v_k4 // T.int64(64) + v_k3) % T.int64(64), v_k4 % T.int64(64)])
+                        T.writes(rxplaceholder_red_temp_v0[v_ax0, v_ax1], rxplaceholder_red_temp_v1[v_ax0, v_ax1])
+                        with T.init():
+                            rxplaceholder_red_temp_v0[v_ax0, v_ax1] = T.float32(0)
+                            rxplaceholder_red_temp_v1[v_ax0, v_ax1] = T.float32(0)
+                        v_rxplaceholder_red_temp_v0: T.float32 = rxplaceholder_red_temp_v0[v_ax0, v_ax1] + lv84[T.int64(0), (v_ax1 * T.int64(16) + (v_k4 // T.int64(64) + v_k3) // T.int64(64) + v_k2) % T.int64(512), (v_k4 // T.int64(64) + v_k3) % T.int64(64), v_k4 % T.int64(64)]
+                        v_rxplaceholder_red_temp_v1: T.float32 = rxplaceholder_red_temp_v1[v_ax0, v_ax1] + lv84[T.int64(0), (v_ax1 * T.int64(16) + (v_k4 // T.int64(64) + v_k3) // T.int64(64) + v_k2) % T.int64(512), (v_k4 // T.int64(64) + v_k3) % T.int64(64), v_k4 % T.int64(64)] * lv84[T.int64(0), (v_ax1 * T.int64(16) + (v_k4 // T.int64(64) + v_k3) // T.int64(64) + v_k2) % T.int64(512), (v_k4 // T.int64(64) + v_k3) % T.int64(64), v_k4 % T.int64(64)]
+                        rxplaceholder_red_temp_v0[v_ax0, v_ax1] = v_rxplaceholder_red_temp_v0
+                        rxplaceholder_red_temp_v1[v_ax0, v_ax1] = v_rxplaceholder_red_temp_v1
+        for ax0_ax1_ax2_ax3_ax4_fused_1 in T.thread_binding(T.int64(256), thread="blockIdx.x"):
+            for ax0_ax1_ax2_ax3_ax4_fused_2 in T.thread_binding(T.int64(1024), thread="threadIdx.x"):
+                for ax0_ax1_ax2_ax3_ax4_fused_0 in range(T.int64(8)):
+                    with T.block("T_group_norm"):
+                        v_ax0 = T.axis.spatial(T.int64(1), T.int64(0))
+                        v_ax1 = T.axis.spatial(T.int64(32), (ax0_ax1_ax2_ax3_ax4_fused_0 * T.int64(262144) + ax0_ax1_ax2_ax3_ax4_fused_1 * T.int64(1024) + ax0_ax1_ax2_ax3_ax4_fused_2) // T.int64(65536))
+                        v_ax2 = T.axis.spatial(T.int64(16), (ax0_ax1_ax2_ax3_ax4_fused_0 * T.int64(262144) + ax0_ax1_ax2_ax3_ax4_fused_1 * T.int64(1024) + ax0_ax1_ax2_ax3_ax4_fused_2) % T.int64(65536) // T.int64(4096))
+                        v_ax3 = T.axis.spatial(T.int64(64), (ax0_ax1_ax2_ax3_ax4_fused_0 * T.int64(262144) + ax0_ax1_ax2_ax3_ax4_fused_1 * T.int64(1024) + ax0_ax1_ax2_ax3_ax4_fused_2) % T.int64(4096) // T.int64(64))
+                        v_ax4 = T.axis.spatial(T.int64(64), (ax0_ax1_ax2_ax3_ax4_fused_0 * T.int64(262144) + ax0_ax1_ax2_ax3_ax4_fused_1 * T.int64(1024) + ax0_ax1_ax2_ax3_ax4_fused_2) % T.int64(64))
+                        T.reads(lv84[T.int64(0), (v_ax1 * T.int64(16) + (v_ax4 // T.int64(64) + v_ax3) // T.int64(64) + v_ax2) % T.int64(512), (v_ax4 // T.int64(64) + v_ax3) % T.int64(64), v_ax4 % T.int64(64)], rxplaceholder_red_temp_v0[v_ax0, v_ax1], rxplaceholder_red_temp_v1[v_ax0, v_ax1], param_0[(v_ax1 * T.int64(16) + v_ax2) % T.int64(512)], param_1[(v_ax1 * T.int64(16) + v_ax2) % T.int64(512)])
+                        T.writes(compute[T.int64(0), v_ax1 * T.int64(16) + v_ax2, v_ax3, v_ax4])
+                        compute[T.int64(0), v_ax2 + v_ax1 * T.int64(16), v_ax3, v_ax4] = T.Cast("float16", (lv84[T.int64(0), (v_ax1 * T.int64(16) + (v_ax4 // T.int64(64) + v_ax3) // T.int64(64) + v_ax2) % T.int64(512), (v_ax4 // T.int64(64) + v_ax3) % T.int64(64), v_ax4 % T.int64(64)] - rxplaceholder_red_temp_v0[v_ax0, v_ax1] * T.float32(1.52587890625e-05)) * T.rsqrt(rxplaceholder_red_temp_v1[v_ax0, v_ax1] * T.float32(1.52587890625e-05) - rxplaceholder_red_temp_v0[v_ax0, v_ax1] * T.float32(1.52587890625e-05) * (rxplaceholder_red_temp_v0[v_ax0, v_ax1] * T.float32(1.52587890625e-05)) + T.float32(9.9999999999999995e-07)) * param_0[(v_ax1 * T.int64(16) + v_ax2) % T.int64(512)] + param_1[(v_ax1 * T.int64(16) + v_ax2) % T.int64(512)])
 
 # fmt: on
 def verify(anchor_mod, anchor_trace_fun, target_mod, target, ref):
@@ -1819,8 +2059,7 @@ def verify(anchor_mod, anchor_trace_fun, target_mod, target, ref):
 
     sch = Schedule(target_mod)
 
-    ms.trace_apply.schedule_using_anchor_trace(sch, anchor_trace, Target(target))
-
+    ms.trace_apply.schedule_using_anchor_trace(sch, anchor_trace, anchor_mod, Target(target))
     tvm.ir.assert_structural_equal(ref, sch.mod)
 
 
@@ -2058,6 +2297,111 @@ def test_dense_add_gpu():
         b115 = sch.decompose_reduction(block=b104, loop=l108)
 
     verify(Dense, apply_anchor_trace, DenseAdd, "cuda", DenseAdd_scheduled_gpu)
+
+
+def test_add_dense_gpu():
+    def apply_anchor_trace(sch: Schedule) -> None:
+        b0 = sch.get_block(name="T_matmul_NT", func_name="main")
+        b1 = sch.get_block(name="root", func_name="main")
+        sch.annotate(block_or_loop=b0, ann_key="meta_schedule.tiling_structure", ann_val="SSSRRSRS")
+        l2, l3, l4 = sch.get_loops(block=b0)
+        v5, v6, v7, v8, v9 = sch.sample_perfect_tile(
+            loop=l2, n=5, max_innermost_factor=64, decision=[8, 1, 16, 1, 1]
+        )
+        l10, l11, l12, l13, l14 = sch.split(
+            loop=l2, factors=[v5, v6, v7, v8, v9], preserve_unit_iters=True
+        )
+        v15, v16, v17, v18, v19 = sch.sample_perfect_tile(
+            loop=l3, n=5, max_innermost_factor=64, decision=[4, 1, 8, 4, 1]
+        )
+        l20, l21, l22, l23, l24 = sch.split(
+            loop=l3, factors=[v15, v16, v17, v18, v19], preserve_unit_iters=True
+        )
+        v25, v26, v27 = sch.sample_perfect_tile(
+            loop=l4, n=3, max_innermost_factor=64, decision=[32, 1, 4]
+        )
+        l28, l29, l30 = sch.split(loop=l4, factors=[v25, v26, v27], preserve_unit_iters=True)
+        sch.reorder(l10, l20, l11, l21, l12, l22, l28, l29, l13, l23, l30, l14, l24)
+        l31 = sch.fuse(l10, l20, preserve_unit_iters=True)
+        sch.bind(loop=l31, thread_axis="blockIdx.x")
+        l32 = sch.fuse(l11, l21, preserve_unit_iters=True)
+        sch.bind(loop=l32, thread_axis="vthread.x")
+        l33 = sch.fuse(l12, l22, preserve_unit_iters=True)
+        sch.bind(loop=l33, thread_axis="threadIdx.x")
+        sch.annotate(
+            block_or_loop=b0, ann_key="meta_schedule.thread_extent_low_inclusive", ann_val=16
+        )
+        sch.annotate(
+            block_or_loop=b0, ann_key="meta_schedule.thread_extent_high_inclusive", ann_val=256
+        )
+        b34 = sch.cache_write(block=b0, write_buffer_index=0, storage_scope="local")
+        sch.reverse_compute_at(block=b34, loop=l33, preserve_unit_loops=True, index=-1)
+        b35 = sch.cache_read(
+            block=b0, read_buffer_index=0, storage_scope="shared", consumer_blocks=[b0]
+        )
+        sch.compute_at(block=b35, loop=l28, preserve_unit_loops=True, index=-1)
+        l36, l37, l38, l39, l40, l41 = sch.get_loops(block=b35)
+        l42 = sch.fuse(l40, l41, preserve_unit_iters=True)
+        v43 = sch.sample_categorical(
+            candidates=[1, 2, 3, 4], probs=[0.25, 0.25, 0.25, 0.25], decision=1
+        )
+        sch.annotate(block_or_loop=b35, ann_key="meta_schedule.cooperative_fetch", ann_val=v43)
+        b44 = sch.cache_read(
+            block=b0, read_buffer_index=1, storage_scope="shared", consumer_blocks=[b0]
+        )
+        sch.compute_at(block=b44, loop=l28, preserve_unit_loops=True, index=-1)
+        l45, l46, l47, l48, l49, l50 = sch.get_loops(block=b44)
+        l51 = sch.fuse(l49, l50, preserve_unit_iters=True)
+        v52 = sch.sample_categorical(
+            candidates=[1, 2, 3, 4], probs=[0.25, 0.25, 0.25, 0.25], decision=3
+        )
+        sch.annotate(block_or_loop=b44, ann_key="meta_schedule.cooperative_fetch", ann_val=v52)
+        v53 = sch.sample_categorical(
+            candidates=[0, 16, 64, 512, 1024],
+            probs=[
+                0.20000000000000001,
+                0.20000000000000001,
+                0.20000000000000001,
+                0.20000000000000001,
+                0.20000000000000001,
+            ],
+            decision=2,
+        )
+        sch.annotate(block_or_loop=b1, ann_key="meta_schedule.unroll_explicit", ann_val=v53)
+        sch.enter_postproc()
+        sch.unannotate(block_or_loop=b35, ann_key="meta_schedule.cooperative_fetch")
+        l54, l55, l56, l57, l58 = sch.get_loops(block=b35)
+        l59, l60, l61 = sch.split(loop=l58, factors=[None, 128, 2], preserve_unit_iters=True)
+        sch.vectorize(loop=l61)
+        sch.bind(loop=l60, thread_axis="threadIdx.x")
+        sch.unannotate(block_or_loop=b44, ann_key="meta_schedule.cooperative_fetch")
+        l62, l63, l64, l65, l66 = sch.get_loops(block=b44)
+        l67, l68, l69 = sch.split(loop=l66, factors=[None, 128, 4], preserve_unit_iters=True)
+        sch.vectorize(loop=l69)
+        sch.bind(loop=l68, thread_axis="threadIdx.x")
+        b70 = sch.get_block(name="root", func_name="main")
+        sch.unannotate(block_or_loop=b70, ann_key="meta_schedule.unroll_explicit")
+        _, b71, b72, b73, b74 = sch.get_child_blocks(b70)
+        l75, l76, l77, l78, l79, l80, l81 = sch.get_loops(block=b71)
+        sch.annotate(block_or_loop=l75, ann_key="pragma_auto_unroll_max_step", ann_val=64)
+        sch.annotate(block_or_loop=l75, ann_key="pragma_unroll_explicit", ann_val=1)
+        l82, l83, l84, l85, l86, l87, l88 = sch.get_loops(block=b72)
+        sch.annotate(block_or_loop=l82, ann_key="pragma_auto_unroll_max_step", ann_val=64)
+        sch.annotate(block_or_loop=l82, ann_key="pragma_unroll_explicit", ann_val=1)
+        l89, l90, l91, l92, l93, l94, l95, l96, l97, l98 = sch.get_loops(block=b73)
+        sch.annotate(block_or_loop=l89, ann_key="pragma_auto_unroll_max_step", ann_val=64)
+        sch.annotate(block_or_loop=l89, ann_key="pragma_unroll_explicit", ann_val=1)
+        l99, l100, l101, l102, l103 = sch.get_loops(block=b74)
+        sch.annotate(block_or_loop=l99, ann_key="pragma_auto_unroll_max_step", ann_val=64)
+        sch.annotate(block_or_loop=l99, ann_key="pragma_unroll_explicit", ann_val=1)
+        b104 = sch.get_block(name="T_matmul_NT", func_name="main")
+        l105, l106, l107, l108, l109, l110, l111, l112, l113, l114 = sch.get_loops(block=b104)
+        b115 = sch.decompose_reduction(block=b104, loop=l108)
+        # schedule the first add
+        b_add = sch.get_block(name="T_add_0", func_name="main")
+        sch.compute_inline(b_add)
+
+    verify(AddDense, apply_anchor_trace, DenseAdd, "cuda", DenseAdd_scheduled_gpu)
 
 
 def test_conv2d_int8_tensorcore():
@@ -3368,5 +3712,178 @@ def test_inline_order():
     )
 
 
+def test_dense_add_gpu_different_name():
+    def apply_anchor_trace(sch: Schedule) -> None:
+        b0 = sch.get_block(name="T_matmul_NT", func_name="main")
+        b1 = sch.get_block(name="root", func_name="main")
+        sch.annotate(block_or_loop=b0, ann_key="meta_schedule.tiling_structure", ann_val="SSSRRSRS")
+        l2, l3, l4 = sch.get_loops(block=b0)
+        v5, v6, v7, v8, v9 = sch.sample_perfect_tile(
+            loop=l2, n=5, max_innermost_factor=64, decision=[8, 1, 16, 1, 1]
+        )
+        l10, l11, l12, l13, l14 = sch.split(
+            loop=l2, factors=[v5, v6, v7, v8, v9], preserve_unit_iters=True
+        )
+        v15, v16, v17, v18, v19 = sch.sample_perfect_tile(
+            loop=l3, n=5, max_innermost_factor=64, decision=[4, 1, 8, 4, 1]
+        )
+        l20, l21, l22, l23, l24 = sch.split(
+            loop=l3, factors=[v15, v16, v17, v18, v19], preserve_unit_iters=True
+        )
+        v25, v26, v27 = sch.sample_perfect_tile(
+            loop=l4, n=3, max_innermost_factor=64, decision=[32, 1, 4]
+        )
+        l28, l29, l30 = sch.split(loop=l4, factors=[v25, v26, v27], preserve_unit_iters=True)
+        sch.reorder(l10, l20, l11, l21, l12, l22, l28, l29, l13, l23, l30, l14, l24)
+        l31 = sch.fuse(l10, l20, preserve_unit_iters=True)
+        sch.bind(loop=l31, thread_axis="blockIdx.x")
+        l32 = sch.fuse(l11, l21, preserve_unit_iters=True)
+        sch.bind(loop=l32, thread_axis="vthread.x")
+        l33 = sch.fuse(l12, l22, preserve_unit_iters=True)
+        sch.bind(loop=l33, thread_axis="threadIdx.x")
+        sch.annotate(
+            block_or_loop=b0, ann_key="meta_schedule.thread_extent_low_inclusive", ann_val=16
+        )
+        sch.annotate(
+            block_or_loop=b0, ann_key="meta_schedule.thread_extent_high_inclusive", ann_val=256
+        )
+        b34 = sch.cache_write(block=b0, write_buffer_index=0, storage_scope="local")
+        sch.reverse_compute_at(block=b34, loop=l33, preserve_unit_loops=True, index=-1)
+        b35 = sch.cache_read(
+            block=b0, read_buffer_index=0, storage_scope="shared", consumer_blocks=[b0]
+        )
+        sch.compute_at(block=b35, loop=l28, preserve_unit_loops=True, index=-1)
+        l36, l37, l38, l39, l40, l41 = sch.get_loops(block=b35)
+        l42 = sch.fuse(l40, l41, preserve_unit_iters=True)
+        v43 = sch.sample_categorical(
+            candidates=[1, 2, 3, 4], probs=[0.25, 0.25, 0.25, 0.25], decision=1
+        )
+        sch.annotate(block_or_loop=b35, ann_key="meta_schedule.cooperative_fetch", ann_val=v43)
+        b44 = sch.cache_read(
+            block=b0, read_buffer_index=1, storage_scope="shared", consumer_blocks=[b0]
+        )
+        sch.compute_at(block=b44, loop=l28, preserve_unit_loops=True, index=-1)
+        l45, l46, l47, l48, l49, l50 = sch.get_loops(block=b44)
+        l51 = sch.fuse(l49, l50, preserve_unit_iters=True)
+        v52 = sch.sample_categorical(
+            candidates=[1, 2, 3, 4], probs=[0.25, 0.25, 0.25, 0.25], decision=3
+        )
+        sch.annotate(block_or_loop=b44, ann_key="meta_schedule.cooperative_fetch", ann_val=v52)
+        v53 = sch.sample_categorical(
+            candidates=[0, 16, 64, 512, 1024],
+            probs=[
+                0.20000000000000001,
+                0.20000000000000001,
+                0.20000000000000001,
+                0.20000000000000001,
+                0.20000000000000001,
+            ],
+            decision=2,
+        )
+        sch.annotate(block_or_loop=b1, ann_key="meta_schedule.unroll_explicit", ann_val=v53)
+        sch.enter_postproc()
+        sch.unannotate(block_or_loop=b35, ann_key="meta_schedule.cooperative_fetch")
+        l54, l55, l56, l57, l58 = sch.get_loops(block=b35)
+        l59, l60, l61 = sch.split(loop=l58, factors=[None, 128, 2], preserve_unit_iters=True)
+        sch.vectorize(loop=l61)
+        sch.bind(loop=l60, thread_axis="threadIdx.x")
+        sch.unannotate(block_or_loop=b44, ann_key="meta_schedule.cooperative_fetch")
+        l62, l63, l64, l65, l66 = sch.get_loops(block=b44)
+        l67, l68, l69 = sch.split(loop=l66, factors=[None, 128, 4], preserve_unit_iters=True)
+        sch.vectorize(loop=l69)
+        sch.bind(loop=l68, thread_axis="threadIdx.x")
+        b70 = sch.get_block(name="root", func_name="main")
+        sch.unannotate(block_or_loop=b70, ann_key="meta_schedule.unroll_explicit")
+        b71, b72, b73, b74 = sch.get_child_blocks(b70)
+        l75, l76, l77, l78, l79, l80, l81 = sch.get_loops(block=b71)
+        sch.annotate(block_or_loop=l75, ann_key="pragma_auto_unroll_max_step", ann_val=64)
+        sch.annotate(block_or_loop=l75, ann_key="pragma_unroll_explicit", ann_val=1)
+        l82, l83, l84, l85, l86, l87, l88 = sch.get_loops(block=b72)
+        sch.annotate(block_or_loop=l82, ann_key="pragma_auto_unroll_max_step", ann_val=64)
+        sch.annotate(block_or_loop=l82, ann_key="pragma_unroll_explicit", ann_val=1)
+        l89, l90, l91, l92, l93, l94, l95, l96, l97, l98 = sch.get_loops(block=b73)
+        sch.annotate(block_or_loop=l89, ann_key="pragma_auto_unroll_max_step", ann_val=64)
+        sch.annotate(block_or_loop=l89, ann_key="pragma_unroll_explicit", ann_val=1)
+        l99, l100, l101, l102, l103 = sch.get_loops(block=b74)
+        sch.annotate(block_or_loop=l99, ann_key="pragma_auto_unroll_max_step", ann_val=64)
+        sch.annotate(block_or_loop=l99, ann_key="pragma_unroll_explicit", ann_val=1)
+        b104 = sch.get_block(name="T_matmul_NT", func_name="main")
+        l105, l106, l107, l108, l109, l110, l111, l112, l113, l114 = sch.get_loops(block=b104)
+        b115 = sch.decompose_reduction(block=b104, loop=l108)
+
+    verify(Dense, apply_anchor_trace, DenseAdd_different_name, "cuda", DenseAdd_scheduled_gpu)
+
+
+def test_inline_with_get_child_blocks():
+    def apply_anchor_trace(sch: Schedule) -> None:
+        b0 = sch.get_block(name="T_reshape", func_name="main")
+        b1 = sch.get_block(name="rxplaceholder_red_temp", func_name="main")
+        b2 = sch.get_block(name="T_reshape_1", func_name="main")
+        b3 = sch.get_block(name="T_reshape_2", func_name="main")
+        b4 = sch.get_block(name="T_group_norm", func_name="main")
+        b5 = sch.get_block(name="T_reshape_3", func_name="main")
+        b6 = sch.get_block(name="compute", func_name="main")
+        b7 = sch.get_block(name="compute_1", func_name="main")
+        b8 = sch.get_block(name="T_multiply", func_name="main")
+        b9 = sch.get_block(name="root", func_name="main")
+        sch.compute_inline(block=b7)
+        sch.compute_inline(block=b6)
+        sch.compute_inline(block=b5)
+        sch.compute_inline(block=b4)
+        sch.compute_inline(block=b3)
+        sch.compute_inline(block=b2)
+        sch.compute_inline(block=b0)
+        v10 = sch.sample_categorical(
+            candidates=[4, 8, 16, 32, 64, 128, 256, 512],
+            probs=[0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125],
+            decision=6,
+        )
+        l11, l12, l13, l14, l15 = sch.get_loops(block=b1)
+        l16 = sch.fuse(l13, l14, l15, preserve_unit_iters=True)
+        l17, l18 = sch.split(loop=l16, factors=[None, v10], preserve_unit_iters=True)
+        sch.bind(loop=l18, thread_axis="threadIdx.x")
+        v19 = sch.sample_categorical(
+            candidates=[0, 16, 64, 512, 1024],
+            probs=[
+                0.20000000000000001,
+                0.20000000000000001,
+                0.20000000000000001,
+                0.20000000000000001,
+                0.20000000000000001,
+            ],
+            decision=3,
+        )
+        sch.annotate(block_or_loop=b9, ann_key="meta_schedule.unroll_explicit", ann_val=v19)
+        l20, l21, l22, l23 = sch.get_loops(block=b8)
+        l24 = sch.fuse(l20, l21, l22, l23, preserve_unit_iters=True)
+        l25, l26, l27 = sch.split(loop=l24, factors=[None, 256, 1024], preserve_unit_iters=True)
+        sch.reorder(l26, l27, l25)
+        sch.bind(loop=l26, thread_axis="blockIdx.x")
+        sch.bind(loop=l27, thread_axis="threadIdx.x")
+        print(sch.mod.script())
+        l28, l29, l30, l31 = sch.get_loops(block=b1)
+        l32 = sch.fuse(l28, l29, preserve_unit_iters=True)
+        sch.bind(loop=l32, thread_axis="blockIdx.x")
+        sch.enter_postproc()
+        b33 = sch.get_block(name="root", func_name="main")
+        sch.unannotate(block_or_loop=b33, ann_key="meta_schedule.unroll_explicit")
+        b34, b35 = sch.get_child_blocks(b33)
+        l36, l37, l38 = sch.get_loops(block=b34)
+        sch.annotate(block_or_loop=l36, ann_key="pragma_auto_unroll_max_step", ann_val=512)
+        sch.annotate(block_or_loop=l36, ann_key="pragma_unroll_explicit", ann_val=1)
+        l39, l40, l41 = sch.get_loops(block=b35)
+        sch.annotate(block_or_loop=l39, ann_key="pragma_auto_unroll_max_step", ann_val=512)
+        sch.annotate(block_or_loop=l39, ann_key="pragma_unroll_explicit", ann_val=1)
+
+    verify(
+        GroupNormSigmoidMultiply,
+        apply_anchor_trace,
+        GroupNorm,
+        "nvidia/geforce-rtx-3090-ti",
+        GroupNorm_scheduled,
+    )
+
+
 if __name__ == "__main__":
-    tvm.testing.main()
+    # tvm.testing.main()
+    test_inline_with_get_child_blocks()

--- a/tests/python/unittest/test_meta_schedule_trace_apply.py
+++ b/tests/python/unittest/test_meta_schedule_trace_apply.py
@@ -3884,5 +3884,4 @@ def test_inline_with_get_child_blocks():
 
 
 if __name__ == "__main__":
-    # tvm.testing.main()
-    test_inline_with_get_child_blocks()
+    tvm.testing.main()

--- a/tests/python/unittest/test_meta_schedule_trace_apply.py
+++ b/tests/python/unittest/test_meta_schedule_trace_apply.py
@@ -3860,7 +3860,6 @@ def test_inline_with_get_child_blocks():
         sch.reorder(l26, l27, l25)
         sch.bind(loop=l26, thread_axis="blockIdx.x")
         sch.bind(loop=l27, thread_axis="threadIdx.x")
-        print(sch.mod.script())
         l28, l29, l30, l31 = sch.get_loops(block=b1)
         l32 = sch.fuse(l28, l29, preserve_unit_iters=True)
         sch.bind(loop=l32, thread_axis="blockIdx.x")


### PR DESCRIPTION
The old anchor trace apply assumes that the prefix of the "new" outputs matches with the "old" outputs, which is not the case for some tasks in complex models. Also the old approach use block name to match corresponding blocks among the old module in database and the new module to apply trace on.  In some cases, the block names may differ even though the block body are identical. In this PR, I maintain a block mapping between the old IRmodule and the new IRmodule, so that we can find the matching parts in both IRmodule with no assumptions of the relationship of their locations in IRModule.

cc: @tqchen @junrushao @masahi 