### PR TITLE
[MetaSchedule] preseve global_symbol attached to function after applying MS

### DIFF
--- a/python/tvm/meta_schedule/tune_context.py
+++ b/python/tvm/meta_schedule/tune_context.py
@@ -44,7 +44,8 @@ if TYPE_CHECKING:
 def _normalize_mod(mod: Union[PrimFunc, IRModule]) -> IRModule:
     """Normalize the input to an IRModule"""
     if isinstance(mod, PrimFunc):
-        mod = mod.with_attr("global_symbol", "main")
+        if not (mod.attrs and "global_symbol" in mod.attrs):
+            mod = mod.with_attr("global_symbol", "main")
         mod = mod.with_attr("tir.noalias", True)
         mod = IRModule({"main": mod})
     if not isinstance(mod, IRModule):


### PR DESCRIPTION
Right now seems a global symbol main will be attached to every fused prim_func after Meta Schedule tuning.
Although the problem get hidden because we will re-attach global symbols, this is a behavior that need to be fixed.
Now the transformed prim func preserves the original global symbol. If it doesn't exist, attach global symbol main.

cc: @tqchen @junrushao 