### PR TITLE
[Unity] ensure memory.alloc_tensor/storage roundtrippable

### DIFF
--- a/python/tvm/relax/op/vm/__init__.py
+++ b/python/tvm/relax/op/vm/__init__.py
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=wildcard-import, redefined-builtin
+"""Relax vm primitives."""
+
+from .vm import *

--- a/python/tvm/relax/op/vm/_ffi_api.py
+++ b/python/tvm/relax/op/vm/_ffi_api.py
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+"""FFI APIs for tvm.relax.op.vm"""
+import tvm._ffi
+
+tvm._ffi._init_api("relax.op.vm", __name__)

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -439,16 +439,6 @@ class AffineGridAttrs(Attrs):
     """Attributes used in affine_grid operators"""
 
 
-@tvm._ffi.register_object("relay.attrs.AllocStorageAttrs")
-class AllocStorageAttrs(Attrs):
-    """Attributes used in alloc_storage operators"""
-
-
-@tvm._ffi.register_object("relay.attrs.AllocTensorAttrs")
-class AllocTensorAttrs(Attrs):
-    """Attributes used in alloc_tensor operators"""
-
-
 @tvm._ffi.register_object("relay.attrs.CastHintAttrs")
 class CastHintAttrs(Attrs):
     """Attributes used in cast_hint annotation operators"""

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union, Callable
 import tvm
 from tvm import DataType, relax
 from tvm.ir import PrimExpr
-from tvm.relax import Call, Expr, ExternFunc, TupleGetItem, Var, VarBinding, const
+from tvm.relax import Call, Expr, ExternFunc, TupleGetItem, ShapeExpr, Var, VarBinding, const
 from tvm.relax.block_builder import BlockBuilder as rx_bb
 
 ############################### Operators ###############################
@@ -113,6 +113,7 @@ from tvm.relax.op import (
     tril,
     triu,
     unique,
+    vm,
     where,
     zeros,
     zeros_like,
@@ -598,6 +599,7 @@ __all__ = [
     "round",
     "shape",
     "shape_of",
+    "ShapeExpr",
     "std",
     "str",
     "strided_slice",
@@ -621,6 +623,7 @@ __all__ = [
     "tuple",
     "unique",
     "variance",
+    "vm",
     "where",
     "zeros",
     "zeros_like",

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -296,21 +296,18 @@ RELAY_REGISTER_OP("relax.memory.alloc_storage")
     .set_num_inputs(4)
     .add_argument("total_space", "Expr", "The total space of the storage to allocate.")
     .add_argument(
-        "virtual_device_index", "int64_t",
+        "virtual_device_index", "PrimValue",
         "The virtual device index indicating on which device the storage is to be allocated, "
         "Index -1 is reserved for the host device.")
-    .add_argument("storage_scope", "string",
+    .add_argument("storage_scope", "StringImm",
                   "The storage scope of the storage to allocate. Default is global.")
-    .add_argument("dtype", "DataType", "The dtype of the tensor to allocate.")
+    .add_argument("dtype", "DataTypeImm", "The dtype of the tensor to allocate.")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnObjectStructInfo);
 
-Expr MakeAllocStorage(Expr size, int64_t virtual_device_index, std::string storage_scope,
-                      DataType dtype) {
+Expr MakeAllocStorage(Expr size, PrimValue virtual_device_index, StringImm storage_scope,
+                      DataTypeImm dtype) {
   static const Op& op = Op::Get("relax.memory.alloc_storage");
-  return Call(
-      op,
-      {size, PrimValue::Int64(virtual_device_index), StringImm(storage_scope), DataTypeImm(dtype)},
-      Attrs(), {});
+  return Call(op, {size, virtual_device_index, storage_scope, dtype}, Attrs(), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.memory.alloc_storage").set_body_typed(MakeAllocStorage);
@@ -331,14 +328,14 @@ StructInfo InferStructInfoMemAllocTensor(const Call& call, const BlockBuilder& c
 RELAY_REGISTER_OP("relax.memory.alloc_tensor")
     .set_num_inputs(4)
     .add_argument("storage", "Expr", "The storage to allocate the tensor to.")
-    .add_argument("offset", "int", "Storage offset to allocate the tensor.")
+    .add_argument("offset", "PrimValue", "Storage offset to allocate the tensor.")
     .add_argument("shape", "Expr", "The shape of the tensor to allocate.")
-    .add_argument("dtype", "DataType", "The dtype of the tensor to allocate.")
+    .add_argument("dtype", "DataTypeImm", "The dtype of the tensor to allocate.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoMemAllocTensor);
 
-Expr MakeMemAllocTensor(Expr storage, int offset, Expr shape, DataType dtype) {
+Expr MakeMemAllocTensor(Expr storage, PrimValue offset, Expr shape, DataTypeImm dtype) {
   static const Op& op = Op::Get("relax.memory.alloc_tensor");
-  return Call(op, {storage, PrimValue::Int64(offset), shape, DataTypeImm(dtype)}, Attrs(), {});
+  return Call(op, {storage, offset, shape, dtype}, Attrs(), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.memory.alloc_tensor").set_body_typed(MakeMemAllocTensor);
@@ -376,15 +373,15 @@ TVM_REGISTER_GLOBAL("relax.op.memory.kill_tensor").set_body_typed(MakeMemKillTen
 RELAY_REGISTER_OP("relax.vm.alloc_storage")
     .set_num_inputs(3)
     .add_argument("size", "Expr", "The size of the storage to allocate.")
-    .add_argument("dtype", "DataType", "The dtype of the tensor to allocate.")
-    .add_argument("runtime_device_index", "int64_t",
+    .add_argument("dtype", "DataTypeImm", "The dtype of the tensor to allocate.")
+    .add_argument("runtime_device_index", "PrimValue",
                   "The device index indicating on which device the tensor is "
                   "to be allocated at runtime.")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnObjectStructInfo);
 
-Expr MakeVMAllocStorage(Expr size, int64_t runtime_device_index, DataType dtype) {
+Expr MakeVMAllocStorage(Expr size, PrimValue runtime_device_index, DataTypeImm dtype) {
   static const Op& op = Op::Get("relax.vm.alloc_storage");
-  return Call(op, {size, PrimValue::Int64(runtime_device_index), DataTypeImm(dtype)}, Attrs(), {});
+  return Call(op, {size, runtime_device_index, dtype}, Attrs(), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.vm.alloc_storage").set_body_typed(MakeVMAllocStorage);
@@ -408,14 +405,14 @@ StructInfo InferStructInfoVMAllocTensor(const Call& call, const BlockBuilder& ct
 RELAY_REGISTER_OP("relax.vm.alloc_tensor")
     .set_num_inputs(4)
     .add_argument("storage", "Expr", "The storage to allocate the tensor to.")
-    .add_argument("offset", "int", "Storage offset to allocate the tensor.")
+    .add_argument("offset", "PrimValue", "Storage offset to allocate the tensor.")
     .add_argument("shape", "Expr", "The shape of the tensor to allocate.")
-    .add_argument("dtype", "DataType", "The dtype of the tensor to allocate.")
+    .add_argument("dtype", "DataTypeImm", "The dtype of the tensor to allocate.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoVMAllocTensor);
 
-Expr MakeVMAllocTensor(Expr storage, int offset, Expr shape, DataType dtype) {
+Expr MakeVMAllocTensor(Expr storage, PrimValue offset, Expr shape, DataTypeImm dtype) {
   static const Op& op = Op::Get("relax.vm.alloc_tensor");
-  return Call(op, {storage, PrimValue::Int64(offset), shape, DataTypeImm(dtype)}, Attrs(), {});
+  return Call(op, {storage, offset, shape, dtype}, Attrs(), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.vm.alloc_tensor").set_body_typed(MakeVMAllocTensor);


### PR DESCRIPTION
- make R.memory.alloc_tensor/alloc_storage roundtrippable
- Expose relax.vm ops to python side

cc: @MasterJH5574 