### PR TITLE
[TEST] Fix division by 0 in llvm codegen test

### DIFF
--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -525,7 +525,7 @@ def test_llvm_div():
     ]:
         for dstart, dend in [
             (-11, -1),
-            (-11, 0),
+            (-11, 1),
             (-4, -4),
             (-2, -2),
             (1, 11),
@@ -534,7 +534,7 @@ def test_llvm_div():
             (2, 2),
             (-11, 11),
         ]:
-            if end < start or dend < dstart or (dend == 0 and dstart == 0):
+            if end < start or dend < dstart or (dend == 0 and dstart == 0) or dend == 0:
                 continue
             check(start, end, dstart, dend, "int32", floor_div=False)
             check(start, end, dstart, dend, "int32", floor_div=True)


### PR DESCRIPTION
In the test `test_llvm_div`, some cases can lead to a division by 0. Consider the case when `start=-12, end=-12, dstart=-2 and dend=0`, the range of values input to clipb() will be: [-12, ..., -1, 1] (with 1 being specially selected to prevent division by 0). For the input 1, clipb evaluates to: `min(/*dend=*/0, max(/*dstart=*/-12, /*i=*/1)) = 0`, thus leading to a division by 0.

LLVM11, which runs in CI, doesn't seem to throw any kind of error, while using LLVM15 leads to a "floating point exception". Regardless, since division by 0 is undefined behaviour and the compiler can do anything, the solution here is to fix the test so division by 0 doesn't occur.