### PR TITLE
[LLVM][BugFix] Fix include Triplet.h bug when LLVM version>= 17

### DIFF
--- a/src/target/llvm/codegen_blob.cc
+++ b/src/target/llvm/codegen_blob.cc
@@ -26,7 +26,11 @@
 
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
+#if LLVM_VERSION_MAJOR >= 17
+#include <llvm/TargetParser/Triple.h>
+#else
 #include <llvm/ADT/Triple.h>
+#endif
 #include <llvm/ADT/Twine.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Constants.h>

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -27,7 +27,11 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
+#if LLVM_VERSION_MAJOR >= 17
+#include <llvm/TargetParser/Triple.h>
+#else
 #include <llvm/ADT/Triple.h>
+#endif
 #include <llvm/Analysis/TargetTransformInfo.h>
 #if TVM_LLVM_VERSION >= 50
 #include <llvm/BinaryFormat/Dwarf.h>


### PR DESCRIPTION
In the latest version of [llvm-project](https://github.com/llvm/llvm-project), the `llvm/ADT/Triple.h` has been moved to `llvm/TargetParser/Triple.h`. Thus, anyone who compile and install llvm from source may encounter this:
```shell
fatal error: llvm/ADT/Triple.h: No such file or directory
   30 | #include <llvm/ADT/Triple.h>
```
This error can be solved by adding `LLVM_VERSION_MAJOR` judgement to include correct head file.

#14136 