### PR TITLE
Update to v0.12.dev0

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-{% set version = '0.11.dev0' %}
+{% set version = '0.12.dev0' %}
 {% set pkg_name = 'tvm' %}
 {% set cuda_tag = cuda_version | replace('.', '') %} # [cuda]
 {% set pkg_name = pkg_name + '-cu' + cuda_tag %} # [cuda]

--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -73,7 +73,7 @@
 #endif
 
 // TVM version
-#define TVM_VERSION "0.11.dev0"
+#define TVM_VERSION "0.12.dev0"
 
 // TVM Runtime is DLPack compatible.
 #include <dlpack/dlpack.h>

--- a/python/tvm/_ffi/libinfo.py
+++ b/python/tvm/_ffi/libinfo.py
@@ -222,4 +222,4 @@ def find_include_path(name=None, search_path=None, optional=False):
 # We use the version of the incoming release for code
 # that is under development.
 # The following line is set by tvm/python/update_version.py
-__version__ = "0.11.dev0"
+__version__ = "0.12.dev0"

--- a/version.py
+++ b/version.py
@@ -44,7 +44,7 @@ import subprocess
 # Two tag formats are supported:
 # - vMAJ.MIN.PATCH (e.g. v0.8.0) or
 # - vMAJ.MIN.devN (e.g. v0.8.dev0)
-__version__ = "0.11.dev0"
+__version__ = "0.12.dev0"
 
 # ---------------------------------------------------
 

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "tvmjs",
   "displayName": "TVM Wasm JS runtime",
   "license": "Apache-2.0",
-  "version": "0.11.0-dev0",
+  "version": "0.12.0-dev0",
   "scripts": {
     "prepwasm": "make && python3 tests/python/prepare_test_libs.py",
     "build": "tsc -b && make rmtypedep",


### PR DESCRIPTION
This bumps all the version numbers following the v0.11.0 branch cut.
Fixes #14208.