### PR TITLE
[Unity][Op][Tweak] Improve `StructInfo` inference for `shape_of`

### DIFF
--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -554,7 +554,7 @@ def test_print_type_annotation_non_var():
 
     call_str = strip_whitespace(dump_ast(call))
     # we expect the shape_of call to have a checked_type_ of ShapeType
-    type_str = "checked_type_=ShapeType(ndim=-1)"
+    type_str = "checked_type_=ShapeType(ndim=0)"
     assert type_str in call_str
 
 


### PR DESCRIPTION
This PR improves the `FInferStructInfo` for `shape_of`. Namely, it checks if the argument has `TensorStructInfo` and transfers over the shape information if it is present.