### PR TITLE
Add typing_extensions requirement

### DIFF
--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -72,6 +72,7 @@ REQUIREMENTS_BY_PIECE: RequirementsByPieceType = [
                 "scipy",
                 "synr",
                 "tornado",
+                "typing_extensions",
             ],
         ),
     ),
@@ -277,6 +278,7 @@ CONSTRAINTS = [
     ("torch", None),
     ("torchvision", None),
     ("tornado", None),
+    ("typing_extensions", None),
     ("xgboost", ">=1.1.0,<1.6.0"),  # From PR #4953 & Issue #12009
 ]
 


### PR DESCRIPTION
This fixes a python error that happens after running `import tvm` when you install apache-tvm-0.11.0 wheel into a pristine virtualenv.

@leandron @driazati @junrushao 