### PR TITLE
[CI] Update cpu and gpu image

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -19,8 +19,8 @@
 [jenkins]
 ci_arm: tlcpack/ci-arm:20230223-070143-a3b51f11b
 ci_cortexm: tlcpackstaging/ci_cortexm:20230124-233207-fd3f8035c
-ci_cpu: tlcpack/ci-cpu:20230223-070143-a3b51f11b
-ci_gpu: tlcpack/ci-gpu:20221128-070141-ae4fd7df7
+ci_cpu: tlcpack/ci-cpu:20230308-070109-9d732d0fa
+ci_gpu: tlcpack/ci-gpu:20230308-070109-9d732d0fa
 ci_hexagon: tlcpack/ci_hexagon:20230127-185848-95fa22308
 ci_i386: tlcpack/ci-i386:20221013-060115-61c9742ea
 ci_lint: tlcpack/ci-lint:20221013-060115-61c9742ea


### PR DESCRIPTION
As requested in https://github.com/apache/tvm/pull/14206, update the CPU and GPU image for paddle 2.4.2. Verified in https://github.com/apache/tvm/tree/ci-docker-staging

@jiangjiajun 

cc @driazati to confirm if this is the correct way to update CI images