### PR TITLE
[CI][ETHOSN] Add ssh to the driver stack installation

### DIFF
--- a/docker/install/ubuntu_install_ethosn_driver_stack.sh
+++ b/docker/install/ubuntu_install_ethosn_driver_stack.sh
@@ -47,7 +47,8 @@ apt-install-and-clear -y \
     python-dev \
     python3 \
     scons \
-    wget
+    wget \
+    openssh-client
 
 cd "$tmpdir"
 git clone --branch "$repo_revision" "$repo_url" "$repo_dir"


### PR DESCRIPTION
Some use cases of the NPU integration rely on ssh being available within the docker image in order to launch an RPC server on a remote device. This commit adds ssh as a dependency on the NPU driver stack installation.

cc @ashutosh-arm @Liam-Sturge 