### PR TITLE
[TIR][Utility] More flexible tir::Substitute arguments

### DIFF
--- a/include/tvm/runtime/container/array.h
+++ b/include/tvm/runtime/container/array.h
@@ -829,6 +829,12 @@ class Array : public ObjectRef {
   }
 };
 
+template <typename T>
+inline constexpr bool is_tvm_array = false;
+
+template <typename T>
+inline constexpr bool is_tvm_array<Array<T>> = true;
+
 /*!
  * \brief Concat two Arrays.
  * \param lhs first Array to be concatenated.

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -186,7 +186,7 @@ BlockRealize GenerateBlockFromTensors(const te::ComputeOp& compute_op,
                                       arith::Analyzer* analyzer) {
   // Step 1. Push_back data_par axis and reduce_axis into block_vars.
   Array<IterVar> iter_vars;
-  std::unordered_map<const VarNode*, PrimExpr> var_map;
+  std::unordered_map<const VarNode*, Var> var_map;
   iter_vars.reserve(compute_op->axis.size() + compute_op->reduce_axis.size());
   auto f_push_block_vars = [&iter_vars, &var_map, &analyzer](const Array<IterVar>& iters) {
     for (IterVar iter_var : iters) {

--- a/src/te/operation/cross_thread_reduction.cc
+++ b/src/te/operation/cross_thread_reduction.cc
@@ -22,6 +22,7 @@
  * \file cross_thread_reduction.cc
  */
 #include <tvm/tir/builtin.h>
+#include <tvm/tir/stmt_functor.h>
 
 #include "compute_op.h"
 #include "op_utils.h"

--- a/src/te/operation/hybrid_op.cc
+++ b/src/te/operation/hybrid_op.cc
@@ -228,9 +228,7 @@ Stmt ApplyLoopShapes(const Stage& stage, const std::unordered_map<IterVar, Range
 
     Stmt VisitStmt_(const ForNode* op) final {
       if (op->loop_var.get() == parent) {
-        std::unordered_map<const VarNode*, PrimExpr> rmap;
-        rmap[op->loop_var.get()] = inner + outer * factor;
-        Stmt ret = tir::Substitute(op->body, rmap);
+        Stmt ret = tir::Substitute(op->body, {{op->loop_var, inner + outer * factor}});
         PrimExpr cond = likely(outer * factor < (op->extent - inner));
         ret = IfThenElse(cond, ret);
         ret = For(inner->var, PrimExpr(0), inner->dom->extent,

--- a/src/te/operation/op_utils.cc
+++ b/src/te/operation/op_utils.cc
@@ -254,22 +254,6 @@ PrimExpr ReplaceTensor(PrimExpr expr, const std::unordered_map<Tensor, Tensor>& 
   return repl.found ? ret : expr;
 }
 
-Stmt Substitute(Stmt s, const std::unordered_map<IterVar, PrimExpr>& value_map) {
-  std::unordered_map<const VarNode*, PrimExpr> init;
-  for (const auto& kv : value_map) {
-    init[kv.first->var.get()] = kv.second;
-  }
-  return tir::Substitute(s, init);
-}
-
-PrimExpr Substitute(PrimExpr s, const std::unordered_map<IterVar, PrimExpr>& value_map) {
-  std::unordered_map<const VarNode*, PrimExpr> init;
-  for (const auto& kv : value_map) {
-    init[kv.first->var.get()] = kv.second;
-  }
-  return tir::Substitute(s, init);
-}
-
 IterVarType ForKindToIterVarType(tir::ForKind kind) {
   switch (kind) {
     case ForKind::kSerial:

--- a/src/te/operation/op_utils.h
+++ b/src/te/operation/op_utils.h
@@ -80,22 +80,6 @@ Stmt ReplaceTensor(Stmt stmt, const std::unordered_map<Tensor, Tensor>& replace)
 PrimExpr ReplaceTensor(PrimExpr expr, const std::unordered_map<Tensor, Tensor>& replace);
 
 /*!
- * \brief Substitute the variables of stmt by value map.
- * \param stmt the statment
- * \param value_map The value map.
- * \return Substituted result.
- */
-Stmt Substitute(Stmt stmt, const std::unordered_map<IterVar, PrimExpr>& value_map);
-
-/*!
- * \brief Substitute the variables of primExpr by value map.
- * \param expr the expression to be processed.
- * \param value_map The value map.
- * \return Substituted result.
- */
-PrimExpr Substitute(PrimExpr expr, const std::unordered_map<IterVar, PrimExpr>& value_map);
-
-/*!
  * \brief Converts Halide ForKind to its corresponding IterVarType
  * \param kind The ForKind to be converted
  */

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -701,8 +701,7 @@ Array<PrimExpr> CommReducerNode::operator()(Array<PrimExpr> a, Array<PrimExpr> b
     value_map.Set(lhs[i], a[i]);
     value_map.Set(rhs[i], b[i]);
   }
-  auto ret = this->result.Map([&value_map](const PrimExpr& e) { return Substitute(e, value_map); });
-  return ret;
+  return Substitute(this->result, value_map);
 }
 
 TVM_REGISTER_GLOBAL("tir.CommReducer")

--- a/src/tir/ir/index_map.cc
+++ b/src/tir/ir/index_map.cc
@@ -314,7 +314,7 @@ runtime::NDArray IndexMapNode::MapNDArray(runtime::NDArray arr_src) const {
 IndexMap IndexMap::RenameVariables(
     const std::function<Optional<String>(const Var& var)>& f_name_map) const {
   std::unordered_set<std::string> used_names;
-  Map<Var, PrimExpr> var_remap;
+  Map<Var, Var> var_remap;
   NameSupply name_supply{""};
   const IndexMapNode* n = this->get();
   if (f_name_map != nullptr) {

--- a/src/tir/ir/stmt_functor.cc
+++ b/src/tir/ir/stmt_functor.cc
@@ -754,17 +754,6 @@ PrimExpr Substitute(PrimExpr expr, std::function<Optional<PrimExpr>(const Var&)>
   return IRSubstitute(vmap)(std::move(expr));
 }
 
-Array<Range> Substitute(const Array<Range>& region, const Map<Var, PrimExpr>& vmap) {
-  Array<Range> result;
-  result.reserve(region.size());
-  for (const Range& range : region) {
-    PrimExpr min = Substitute(range->min, vmap);
-    PrimExpr extent = Substitute(range->extent, vmap);
-    result.push_back(Range::FromMinExtent(std::move(min), std::move(extent)));
-  }
-  return result;
-}
-
 void PreOrderVisit(const ObjectRef& stmt_or_expr,
                    const std::function<bool(const ObjectRef&)>& fvisit) {
   class PreOrderVisitor : public StmtExprVisitor {

--- a/src/tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/tir/schedule/primitive/blockize_tensorize.cc
@@ -288,7 +288,7 @@ BlockRealize GenerateInner(bool is_write_reduction,
 Stmt GenerateOuterInit(const Stmt& block_init, const BlockRealize& inner_realize,
                        const std::vector<const ForNode*>& loops, String block_name) {
   const Block& inner_block = inner_realize->block;
-  Map<Var, PrimExpr> subst_map;
+  Map<Var, Var> subst_map;
   // Step 1: Create new block vars for the block inside the init stmt of outer block
   // A iter is used in the block if
   // 1) It is data parallel

--- a/src/tir/schedule/primitive/cache_index.cc
+++ b/src/tir/schedule/primitive/cache_index.cc
@@ -272,7 +272,7 @@ Array<Block> MakeIndexCacheStage(IndexInfo* info, const String& storage_scope) {
 
     // Create loop vars and block vars' binding_value
     std::vector<Var> loop_vars;
-    Map<Var, PrimExpr> replace_table;
+    Map<Var, Var> replace_table;
     for (const Var& it : iter_vars) {
       DataType data_type = DetermineDatatype(arith::IntSet::FromRange(info->range_map.at(it)));
       Var loop_var("ax" + std::to_string(replace_table.size()), data_type);
@@ -290,7 +290,7 @@ Array<Block> MakeIndexCacheStage(IndexInfo* info, const String& storage_scope) {
     Region access_region;
     // indices used in block body
     Array<PrimExpr> access_indices;
-    Map<Var, PrimExpr> block_var_map;
+    Map<Var, Var> block_var_map;
     // Create block vars, block's accessed region and accessing indices
     for (size_t i = 0; i < info->origin_block_vars[expr_index].size(); i++) {
       const Var& block_var = info->origin_block_vars[expr_index][i];

--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -156,7 +156,7 @@ Block MakeReindexCacheStage(const BufferRegion& cache_region, ReindexCacheStageI
   // bindings in block realize
   std::vector<PrimExpr> iter_values;
   // Create loop vars and block vars' binding_value
-  Map<Var, PrimExpr> var_map;
+  Map<Var, Var> var_map;
   for (size_t i = 0; i < info->loop_vars.size(); ++i) {
     Var original_var = info->loop_vars[i];
     Var loop_var(original_var->name_hint, original_var.dtype());
@@ -316,7 +316,7 @@ Block MakeReIndexStage(const Block& block, CacheStageInfo* info,
   // iters of the reindex block
   Array<IterVar> new_block_iters;
   // the substition map from the original block iter to the iters of the reindex block
-  std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectEqual> block_var_replace_map;
+  std::unordered_map<Var, Var, ObjectPtrHash, ObjectEqual> block_var_replace_map;
   // indices to access the reindex buffer and the target buffer
   Array<PrimExpr> reindex_indices, target_indices;
 

--- a/src/tir/schedule/primitive/reduction.cc
+++ b/src/tir/schedule/primitive/reduction.cc
@@ -208,7 +208,7 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
   init_realize->block = Block(init_block);
   // Step 1. Create new block vars and their bindings
   // Maps an old block var to the new corresponding block var
-  std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual> block_var_map;
+  std::unordered_map<Var, Var, ObjectPtrHash, ObjectPtrEqual> block_var_map;
   block_var_map.reserve(block->iter_vars.size());
   for (int i = 0, n = block->iter_vars.size(); i < n; ++i) {
     const IterVar& iter_var = block->iter_vars[i];
@@ -261,7 +261,7 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
   //         We discard predicate that is related to discarded loops
   init_realize->predicate = RemakePredicate(realize->predicate, discarded_loops);
   // Step 5. Create new loops above init block
-  std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual> loop_var_map;
+  std::unordered_map<Var, Var, ObjectPtrHash, ObjectPtrEqual> loop_var_map;
   Stmt body = BlockRealize(init_realize);
   for (int i : chosen_loops) {
     const ForNode* old_loop = TVM_SREF_TO_FOR(loops[i]);
@@ -936,7 +936,7 @@ class RFactorBlockCreator : public BaseBlockCreator {
    * substitute the loop vars which appear in the bindings of some old block iters with the new
    * created block iters
    */
-  std::unordered_map<const VarNode*, PrimExpr> loop_var2block_binding_;
+  std::unordered_map<const VarNode*, Var> loop_var2block_binding_;
 };
 
 /*!
@@ -1028,7 +1028,7 @@ Stmt CreateLoopOutsideRfactorBlock(BlockRealize rf_block_realize, const Array<Fo
 
   // Step 1. Create new loop vars.
   Array<For> new_loops;
-  std::unordered_map<const VarNode*, PrimExpr> new_loop_var_map;
+  std::unordered_map<const VarNode*, Var> new_loop_var_map;
   new_loops.reserve(n_loops);
   new_loop_var_map.reserve(n_loops);
   for (const For& old_loop : loops) {

--- a/src/tir/transforms/inject_virtual_thread.cc
+++ b/src/tir/transforms/inject_virtual_thread.cc
@@ -461,8 +461,7 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
     } else {
       // insert a for loop
       Var idx(var_->name_hint + ".s", var_->dtype);
-      Map<Var, PrimExpr> values{{var_, idx}};
-      stmt = Substitute(stmt, values);
+      stmt = Substitute(stmt, {{var_, idx}});
       return For(idx, make_zero(idx.dtype()), make_const(idx.dtype(), num_threads_),
                  ForKind::kSerial, stmt);
     }

--- a/src/tir/transforms/lower_cross_thread_reduction.cc
+++ b/src/tir/transforms/lower_cross_thread_reduction.cc
@@ -372,7 +372,7 @@ Stmt TransformReductionBlock(const BlockRealizeNode* realize,            //
     int n_iter = static_cast<int>(block->iter_vars.size());
     Array<IterVar> iter_vars;
     Array<PrimExpr> bindings;
-    Map<Var, PrimExpr> var_map;
+    Map<Var, Var> var_map;
     iter_vars.reserve(n_iter);
     bindings.reserve(n_iter);
     for (int i = 0; i < n_iter; ++i) {

--- a/src/tir/transforms/manifest_shared_memory_local_stage.cc
+++ b/src/tir/transforms/manifest_shared_memory_local_stage.cc
@@ -132,7 +132,7 @@ class IntermediateStageRewriter {
         Downcast<Block>(local_stage));
 
     // Step 2: Add outer loops
-    Map<Var, PrimExpr> subst_map;
+    Map<Var, Var> subst_map;
     for (const ForNode* relaxed_loop : relaxed_loops) {
       ObjectPtr<ForNode> for_node = make_object<ForNode>(*relaxed_loop);
       for_node->loop_var = for_node->loop_var.copy_with_suffix("");

--- a/src/tir/transforms/split_host_device.cc
+++ b/src/tir/transforms/split_host_device.cc
@@ -166,7 +166,7 @@ class HostDeviceSplitter : public StmtMutator {
 
     Array<Var> params;
     Array<PrimExpr> arguments;
-    Map<tir::Var, PrimExpr> remap_vars;
+    Map<tir::Var, tir::Var> remap_vars;
 
     // Strictly order the arguments: Var pointers, positional arguments.
     for (Var var : use_def.undefined_) {

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1597,7 +1597,7 @@ class VectorTypeRewriter : public StmtExprMutator {
     auto* n = func.CopyOnWrite();
 
     // Remap any remaining references to the old buffer variables
-    Map<Var, PrimExpr> var_remap;
+    Map<Var, Var> var_remap;
     for (const auto& pair : rewrite_map_) {
       const auto& info = pair.second;
       var_remap.Set(info.old_buffer_var, info.new_buffer_var);

--- a/src/tir/transforms/vectorize_loop.cc
+++ b/src/tir/transforms/vectorize_loop.cc
@@ -560,8 +560,7 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
   // scalarize the statment
   Stmt Scalarize(Stmt stmt) {
     Var idx(var_->name_hint + ".s", var_->dtype);
-    Map<Var, PrimExpr> values{{var_, idx}};
-    stmt = Substitute(stmt, values);
+    stmt = Substitute(stmt, {{var_, idx}});
     return For(idx, IntImm(var_->dtype, 0), IntImm(var_->dtype, var_lanes_), ForKind::kSerial,
                stmt);
   }


### PR DESCRIPTION
Previously, the `tir::Substitute` method had overloads that supported a few ways of providing the variable map (e.g. `const Map<Var,PrimExpr>&`, `std::unordered_map<const VarNode*, PrimExpr>&`, etc.), delegating out to the overload that uses `std::function<Optional<PrimExpr>(const Var&)>`.  However, the types supported for the variable map depended on the type being substituted (e.g. only supporting `const Map<Var,PrimExpr>&` with substituting into a `Array<Range>`), which would be unexpected to new developers.

This PR makes the `tir::Substitute` utility more uniform in the arguments that it accepts.

* For any type that is supported by `tir::Substitute`, `Array<T>` is also supported.

* Any variable mapping type can be used with any substitution type. All variable mapping types are normalized to `std::function<Optional<PrimExpr>(const Var&)>`.

* For `Map` and `std::unordered_map` arguments, the value type may be any subclass of `PrimExpr` (e.g. `Map<Var, Var>` instead of `Map<Var, PrimExpr>`).  Previously, the calling scope needed to either construct a temporary map that returned `PrimExpr`, or to use a broader value type in the map than otherwise required.

The initial and primary goal was to allow a `Map<Var, Var>` to be used as an argument to `tir::Substitute`, rather than a `Map<Var, PrimExpr>`, and making the utility more general was more straightforward than adding multiple overloads specificall for `Map<Var, Var>`.