### PR TITLE
[Unity][BYOC] Add conv2d and residual block patterns for Relax cutlass BYOC

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -633,13 +633,17 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
     def handle_conv2d(self, f, op_type):
         """Tune and annotate a conv2d op."""
         signature = _extract_relax_function_signature(f)
+        arg_idx = _extract_arg_idx(op_type, f)
         op_attrs = _get_call_node(f.body, "relax.nn.conv2d").attrs
 
-        d_shape = signature["arg0_shape"]
-        w_shape = signature["arg1_shape"]
+        data_arg = f"arg{arg_idx['lhs']}"
+        weight_arg = f"arg{arg_idx['rhs']}"
+
+        d_shape = signature[f"{data_arg}_shape"]
+        w_shape = signature[f"{weight_arg}_shape"]
         out_shape = signature["ret_shape"]
-        data_dtype = signature["arg0_dtype"]
-        weight_dtype = signature["arg1_dtype"]
+        data_dtype = signature[f"{data_arg}_dtype"]
+        weight_dtype = signature[f"{weight_arg}_dtype"]
         out_dtype = signature["ret_dtype"]
         padding = op_attrs["padding"]
         strides = op_attrs["strides"]
@@ -673,6 +677,10 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         return f.with_attrs(
             {
                 "op_type": op_type,
+                "data_arg_idx": arg_idx["lhs"],
+                "weight_arg_idx": arg_idx["rhs"],
+                "bias_arg_idx": arg_idx.get("bias"),
+                "residual_arg_idx": arg_idx.get("residual"),
                 "arg0_dtype": data_dtype,
                 "arg1_dtype": weight_dtype,
                 "ret_dtype": out_dtype,

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -26,9 +26,10 @@ from tvm.relax.dpl import CallPattern, DFPattern
 
 from ..pattern_registry import get_patterns_with_prefix, register_patterns
 from ..patterns import (
+    make_attention_pattern,
     make_fused_bias_activation_pattern,
     make_matmul_pattern,
-    make_attention_pattern,
+    make_residual_block_pattern,
 )
 
 
@@ -51,21 +52,61 @@ def _is_supported_dtype(lhs_dtype, rhs_dtype):
     )
 
 
-def _check_matmul(
-    match_result: Mapping[DFPattern, Expr],
-    _: Expr,
-) -> bool:
-    matmul_call: Call = None
+def _find_call(op_name: str, match_result: Mapping[DFPattern, Expr]) -> Optional[Expr]:
+    result = None
+
     for pattern, expr in match_result.items():
         if (
             isinstance(expr, Call)
             and isinstance(pattern, CallPattern)
             and isinstance(expr.op, tvm.ir.Op)
-            and expr.op.name == "relax.matmul"
+            and expr.op.name == op_name
         ):
-            matmul_call = expr
+            if result is not None:
+                raise ValueError(f"Found multiple matched call node for {op_name}")
+            result = expr
+
+    return result
+
+
+def _is_depthwise_conv2d(ic, oc, groups):
+    return ic == oc == groups
+
+
+def _check_conv2d(
+    match_result: Mapping[DFPattern, Expr],
+    _: Expr,
+):
+    """Check if the given conv2d workload can be offloaded to CUTLASS."""
+
+    conv2d_call = _find_call("relax.nn.conv2d", match_result)
+    if conv2d_call is None:
+        return False
+
+    data_layout = conv2d_call.attrs.data_layout
+    kernel_layout = conv2d_call.attrs.kernel_layout
+    data, weight, *_ = conv2d_call.args
+    if (
+        data_layout != "NHWC"
+        or kernel_layout != "OHWI"
+        or not _is_supported_dtype(data.struct_info.dtype, weight.struct_info.dtype)
+    ):
+        return False
+
+    IC = data.struct_info.shape.values[3]
+    OC = weight.struct_info.shape.values[0]
+    return not _is_depthwise_conv2d(IC, OC, conv2d_call.attrs.groups)
+
+
+def _check_matmul(
+    match_result: Mapping[DFPattern, Expr],
+    _: Expr,
+) -> bool:
+    """Check if the given matmul workload can be offloaded to CUTLASS."""
+
+    matmul_call: Call = _find_call("relax.matmul", match_result)
     if matmul_call is None:
-        raise ValueError("Cannot find call to matmul from match_result.")
+        return False
 
     lhs, rhs, *_ = matmul_call.args
 
@@ -79,88 +120,89 @@ def _check_matmul(
     return is_shape_valid_for_cutlass_matmul(lhs_shape, rhs_shape)
 
 
-register_patterns(
-    [
-        (
-            "cutlass.conv2d",
+def _get_activation_from_name(pattern_name):
+    if "_relu" in pattern_name:
+        return "relax.nn.relu"
+    elif "_gelu" in pattern_name:
+        return "relax.nn.gelu"
+    elif "_silu" in pattern_name:
+        return "relax.nn.silu"
+    else:
+        return None
+
+
+def matmul_patterns():
+    def _matmul_pattern(pattern_name):
+        transposed_rhs = "_transposed" in pattern_name
+        with_bias = "_bias" in pattern_name
+        activation = _get_activation_from_name(pattern_name)
+
+        return (
+            pattern_name,
+            *make_matmul_pattern(
+                transposed_rhs=transposed_rhs,
+                with_bias=with_bias,
+                activation=activation,
+            ),
+            _check_matmul,
+        )
+
+    return [
+        _matmul_pattern("cutlass.matmul"),
+        _matmul_pattern("cutlass.matmul_bias"),
+        _matmul_pattern("cutlass.matmul_bias_relu"),
+        _matmul_pattern("cutlass.matmul_bias_gelu"),
+        _matmul_pattern("cutlass.matmul_transposed"),
+        _matmul_pattern("cutlass.matmul_transposed_bias"),
+        _matmul_pattern("cutlass.matmul_transposed_bias_relu"),
+        _matmul_pattern("cutlass.matmul_transposed_bias_gelu"),
+    ]
+
+
+def conv2d_patterns():
+    def _conv2d_pattern(pattern_name):
+        with_bias = "_bias" in pattern_name
+        activation = _get_activation_from_name(pattern_name)
+
+        return (
+            pattern_name,
             *make_fused_bias_activation_pattern(
                 "relax.nn.conv2d",
-                with_bias=False,
-                activation=None,
+                with_bias=with_bias,
+                activation=activation,
             ),
-        ),
-        (
-            "cutlass.conv2d_bias_relu",
-            *make_fused_bias_activation_pattern(
-                "relax.nn.conv2d",
-                with_bias=True,
-                activation="relax.nn.relu",
-            ),
-        ),
-        (
-            "cutlass.matmul",
-            *make_matmul_pattern(
-                with_bias=False,
-            ),
-            _check_matmul,
-        ),
-        (
-            "cutlass.matmul_bias",
-            *make_matmul_pattern(
-                with_bias=True,
-            ),
-            _check_matmul,
-        ),
-        (
-            "cutlass.matmul_bias_relu",
-            *make_matmul_pattern(
-                with_bias=True,
-                activation="relax.nn.relu",
-            ),
-            _check_matmul,
-        ),
-        (
-            "cutlass.matmul_bias_gelu",
-            *make_matmul_pattern(
-                with_bias=True,
-                activation="relax.nn.gelu",
-            ),
-            _check_matmul,
-        ),
-        (
-            "cutlass.matmul_transposed",
-            *make_matmul_pattern(
-                with_bias=False,
-                transposed_rhs=True,
-            ),
-            _check_matmul,
-        ),
-        (
-            "cutlass.matmul_transposed_bias",
-            *make_matmul_pattern(
-                with_bias=True,
-                transposed_rhs=True,
-            ),
-            _check_matmul,
-        ),
-        (
-            "cutlass.matmul_transposed_bias_relu",
-            *make_matmul_pattern(
-                with_bias=True,
-                activation="relax.nn.relu",
-                transposed_rhs=True,
-            ),
-            _check_matmul,
-        ),
-        (
-            "cutlass.matmul_transposed_bias_gelu",
-            *make_matmul_pattern(
-                with_bias=True,
-                activation="relax.nn.gelu",
-                transposed_rhs=True,
-            ),
-            _check_matmul,
-        ),
+            _check_conv2d,
+        )
+
+    return [
+        _conv2d_pattern("cutlass.conv2d"),
+        _conv2d_pattern("cutlass.conv2d_bias"),
+        _conv2d_pattern("cutlass.conv2d_bias_relu"),
+        _conv2d_pattern("cutlass.conv2d_bias_silu"),
+    ]
+
+
+def residual_block_patterns():
+    patterns = []
+
+    for activation, name_postfix in [(None, ""), ("relax.nn.relu", "_relu")]:
+        for name, pat, arg_pat, _ in conv2d_patterns()[1:]:
+            for bin_op in ["relax.add", "relax.multiply"]:
+                patterns.append(
+                    (
+                        name + "_residual_" + bin_op.split(".")[-1] + name_postfix,
+                        *make_residual_block_pattern(
+                            (pat, arg_pat), binary_op=bin_op, activation=activation
+                        ),
+                        _check_conv2d,
+                    )
+                )
+
+    return patterns
+
+
+def attention_patterns():
+    return [
         (
             "cutlass.attention",
             *make_attention_pattern(),
@@ -169,6 +211,15 @@ register_patterns(
             "cutlass.attention_bias",
             *make_attention_pattern(with_bias=True),
         ),
+    ]
+
+
+register_patterns(
+    [
+        *conv2d_patterns(),
+        *matmul_patterns(),
+        *residual_block_patterns(),
+        *attention_patterns(),
     ]
 )
 

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -69,10 +69,6 @@ def _find_call(op_name: str, match_result: Mapping[DFPattern, Expr]) -> Optional
     return result
 
 
-def _is_depthwise_conv2d(ic, oc, groups):
-    return ic == oc == groups
-
-
 def _check_conv2d(
     match_result: Mapping[DFPattern, Expr],
     _: Expr,
@@ -93,9 +89,11 @@ def _check_conv2d(
     ):
         return False
 
+    # pylint: disable=invalid-name
     IC = data.struct_info.shape.values[3]
     OC = weight.struct_info.shape.values[0]
-    return not _is_depthwise_conv2d(IC, OC, conv2d_call.attrs.groups)
+    # not depthwise conv2d
+    return not IC == OC == conv2d_call.attrs.groups
 
 
 def _check_matmul(
@@ -132,6 +130,10 @@ def _get_activation_from_name(pattern_name):
 
 
 def matmul_patterns():
+    """
+    Returns a list of all matmul patterns in cutlass BYOC backend.
+    """
+
     def _matmul_pattern(pattern_name):
         transposed_rhs = "_transposed" in pattern_name
         with_bias = "_bias" in pattern_name
@@ -160,6 +162,10 @@ def matmul_patterns():
 
 
 def conv2d_patterns():
+    """
+    Returns a list of all conv2d patterns in cutlass BYOC backend.
+    """
+
     def _conv2d_pattern(pattern_name):
         with_bias = "_bias" in pattern_name
         activation = _get_activation_from_name(pattern_name)
@@ -183,6 +189,9 @@ def conv2d_patterns():
 
 
 def residual_block_patterns():
+    """
+    Returns a list of all residual block patterns in cutlass BYOC backend.
+    """
     patterns = []
 
     for activation, name_postfix in [(None, ""), ("relax.nn.relu", "_relu")]:
@@ -202,6 +211,9 @@ def residual_block_patterns():
 
 
 def attention_patterns():
+    """
+    Returns a list of all attention patterns in cutlass BYOC backend.
+    """
     return [
         (
             "cutlass.attention",


### PR DESCRIPTION
This PR adds cutlass BYOC pattern for conv2d and conv2d residual block. 

In additional to the new patterns in the cutlass pattern table, this PR:
1. Remove the assumption on fused function arg order from the conv2d codegen.
2. Restructure how the cutlass pattern table is constructed, making it more readable.

The check logic at https://github.com/apache/tvm/blob/main/python/tvm/relay/op/contrib/cutlass.py#L200 isn't implemented in this PR yet because it requires non-trivial change to the interface of FuseOpsByPattern. I will send a separate PR to do this.

cc @vinx13 @masahi 