### PR TITLE
[ci] Add -LARGE suffix to instance labels

### DIFF
--- a/ci/jenkins/data.py
+++ b/ci/jenkins/data.py
@@ -65,15 +65,15 @@ aws_ecr_url = "dkr.ecr." + aws_default_region + ".amazonaws.com"
 docker_images = {
     "ci_arm": {
         "tag": "tlcpack/ci-arm:20221013-060115-61c9742ea",
-        "platform": "ARM",
+        "platform": "ARM-LARGE",
     },
     "ci_cortexm": {
         "tag": "tlcpack/ci-cortexm:20221013-060115-61c9742ea",
-        "platform": "CPU",
+        "platform": "CPU-LARGE",
     },
     "ci_cpu": {
         "tag": "tlcpack/ci-cpu:20221013-060115-61c9742ea",
-        "platform": "CPU",
+        "platform": "CPU-LARGE",
     },
     "ci_gpu": {
         "tag": "tlcpack/ci-gpu:20221019-060125-0b4836739",
@@ -81,27 +81,27 @@ docker_images = {
     },
     "ci_hexagon": {
         "tag": "tlcpack/ci-hexagon:20221013-060115-61c9742ea",
-        "platform": "CPU",
+        "platform": "CPU-LARGE",
     },
     "ci_i386": {
         "tag": "tlcpack/ci-i386:20221013-060115-61c9742ea",
-        "platform": "CPU",
+        "platform": "CPU-LARGE",
     },
     "ci_lint": {
         "tag": "tlcpack/ci-lint:20221013-060115-61c9742ea",
-        "platform": "CPU",
+        "platform": "CPU-LARGE",
     },
     "ci_minimal": {
         "tag": "tlcpack/ci-minimal:20221013-060115-61c9742ea",
-        "platform": "CPU",
+        "platform": "CPU-LARGE",
     },
     "ci_riscv": {
         "tag": "tlcpack/ci-riscv:20221013-060115-61c9742ea",
-        "platform": "CPU",
+        "platform": "CPU-LARGE",
     },
     "ci_wasm": {
         "tag": "tlcpack/ci-wasm:20221013-060115-61c9742ea",
-        "platform": "CPU",
+        "platform": "CPU-LARGE",
     },
 }
 

--- a/ci/jenkins/generated/docker_jenkinsfile.groovy
+++ b/ci/jenkins/generated/docker_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2023-02-02T20:12:16.699838
+// Generated at 2023-03-09T10:45:48.656514
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -626,7 +626,7 @@ def deploy() {
       parallel(
   'Upload built Docker images': {
     if (env.DEPLOY_DOCKER_IMAGES == 'yes' && rebuild_docker_images && upstream_revision != null) {
-      node('CPU') {
+      node('CPU-SMALL') {
         ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/deploy-docker") {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
@@ -671,7 +671,7 @@ def deploy() {
   },
   'Tag tlcpackstaging to tlcpack': {
     if (env.DEPLOY_DOCKER_IMAGES == 'yes') {
-      node('CPU') {
+      node('CPU-SMALL') {
         ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/tag-images") {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
@@ -849,7 +849,7 @@ if (rebuild_docker_images) {
   stage('Docker Image Build') {
     parallel(
       'ci_arm': {
-        node('ARM') {
+        node('ARM-LARGE') {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
             // We're purposefully not setting the built image here since they
@@ -860,7 +860,7 @@ if (rebuild_docker_images) {
         }
       },
       'ci_cortexm': {
-        node('CPU') {
+        node('CPU-LARGE') {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
             // We're purposefully not setting the built image here since they
@@ -871,7 +871,7 @@ if (rebuild_docker_images) {
         }
       },
       'ci_cpu': {
-        node('CPU') {
+        node('CPU-LARGE') {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
             // We're purposefully not setting the built image here since they
@@ -893,7 +893,7 @@ if (rebuild_docker_images) {
         }
       },
       'ci_hexagon': {
-        node('CPU') {
+        node('CPU-LARGE') {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
             // We're purposefully not setting the built image here since they
@@ -904,7 +904,7 @@ if (rebuild_docker_images) {
         }
       },
       'ci_i386': {
-        node('CPU') {
+        node('CPU-LARGE') {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
             // We're purposefully not setting the built image here since they
@@ -915,7 +915,7 @@ if (rebuild_docker_images) {
         }
       },
       'ci_lint': {
-        node('CPU') {
+        node('CPU-LARGE') {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
             // We're purposefully not setting the built image here since they
@@ -926,7 +926,7 @@ if (rebuild_docker_images) {
         }
       },
       'ci_minimal': {
-        node('CPU') {
+        node('CPU-LARGE') {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
             // We're purposefully not setting the built image here since they
@@ -937,7 +937,7 @@ if (rebuild_docker_images) {
         }
       },
       'ci_riscv': {
-        node('CPU') {
+        node('CPU-LARGE') {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
             // We're purposefully not setting the built image here since they
@@ -948,7 +948,7 @@ if (rebuild_docker_images) {
         }
       },
       'ci_wasm': {
-        node('CPU') {
+        node('CPU-LARGE') {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()
             // We're purposefully not setting the built image here since they

--- a/ci/jenkins/generated/gpu_jenkinsfile.groovy
+++ b/ci/jenkins/generated/gpu_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2023-02-02T20:12:16.640362
+// Generated at 2023-03-09T10:22:31.286391
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -1319,7 +1319,7 @@ def deploy() {
       parallel(
   'Deploy Docs': {
     if (env.DOCS_DEPLOY_ENABLED == 'yes') {
-      node('CPU') {
+      node('CPU-SMALL') {
         ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/deploy-docs") {
           timeout(time: max_time, unit: 'MINUTES') {
             init_git()

--- a/ci/jenkins/templates/utils/macros.j2
+++ b/ci/jenkins/templates/utils/macros.j2
@@ -109,7 +109,7 @@ test()
 {% macro deploy_step(name, feature_flag, ws) %}
   '{{ name }}': {
     if ({{ feature_flag }}) {
-      node('CPU') {
+      node('CPU-SMALL') {
         ws({{ per_exec_ws(ws) }}) {
           timeout(time: max_time, unit: 'MINUTES') {
             {{ caller() | indent(width=10) | trim }}

--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -43,6 +43,14 @@ function shard1 {
   echo "black check..."
   tests/lint/git-black.sh
 
+  echo "checking for the proper instance types in Jenkinsfiles..."
+  grep -rqE "('|\")CPU('|\")" ci/
+  exit_code=$?
+  if [ "$exit_code" -eq "0" ]; then
+    echo "the CPU and ARM instance types are deprecated, do not use them"
+    exit 1
+  fi
+
   echo "Linting the Python code with flake8..."
   tests/lint/flake8.sh
 


### PR DESCRIPTION
This changes the `CPU` and `ARM` labels to `CPU-LARGE` and `ARM-LARGE`
respectively to indicate that these should not be used by default. Once
all occurences of `CPU` and `ARM` are removed, we can rename `CPU-SMALL`
to be `CPU` and get rid of `CPU-SMALL`, so in the end there will just be
`CPU` (equivalent to `CPU-SMALL` today) and `CPU-LARGE` (equivalent to
`CPU` today).