### PR TITLE
[Hexagon] Add concept of DMA groups

### DIFF
--- a/include/tvm/meta_schedule/postproc.h
+++ b/include/tvm/meta_schedule/postproc.h
@@ -111,10 +111,9 @@ class Postproc : public runtime::ObjectRef {
   TVM_DLL static Postproc DisallowDynamicLoop();
   /*!
    * \brief Create a postprocessor that checks if all async mem copies are not strided.
-   * \param merge_async_commit_queue_scope Whether or not to merge async commit queue scope.
    * \return The postprocessor created
    */
-  TVM_DLL static Postproc DisallowAsyncStridedMemCopy(bool merge_async_commit_queue_scope = true);
+  TVM_DLL static Postproc DisallowAsyncStridedMemCopy();
   /*!
    * \brief Create a postprocessor that rewrites the cooperative fetch annotation to
    * actual vectorized cooperative fetching in loop bindings.

--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -735,6 +735,9 @@ TVM_DLL const Op& dma_copy();
  */
 TVM_DLL const Op& dma_wait();
 
+TVM_DLL const Op& dma_start_group();
+TVM_DLL const Op& dma_end_group();
+
 /*!
  * \brief Provide a true statement that can be used for simplifications
  *

--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -726,16 +726,23 @@ TVM_DLL const Op& texture2d_store();
 TVM_DLL const Op& texture2d_load();
 
 /*!
- * \brief Initiate a non-blocking DMA copy from source to destination
+ * \brief Initiate a non-blocking DMA copy from source to destination; a DMA copy outside of a group has a defacto group size of one
  */
 TVM_DLL const Op& dma_copy();
 
 /*!
- * \brief Wait until the number of DMAs in flight is less than or equal to some maximum
+ * \brief Wait until the number of DMA groups in flight is less than or equal to some maximum
  */
 TVM_DLL const Op& dma_wait();
 
+/*!
+ * \brief Start a group of DMA copies
+ */
 TVM_DLL const Op& dma_start_group();
+
+/*!
+ * \brief End a group of DMA copies
+ */
 TVM_DLL const Op& dma_end_group();
 
 /*!

--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -726,7 +726,8 @@ TVM_DLL const Op& texture2d_store();
 TVM_DLL const Op& texture2d_load();
 
 /*!
- * \brief Initiate a non-blocking DMA copy from source to destination; a DMA copy outside of a group has a defacto group size of one
+ * \brief Initiate a non-blocking DMA copy from source to destination; a DMA copy outside of a group
+ * has a defacto group size of one
  */
 TVM_DLL const Op& dma_copy();
 

--- a/python/tvm/meta_schedule/postproc/disallow_async_strided_mem_copy.py
+++ b/python/tvm/meta_schedule/postproc/disallow_async_strided_mem_copy.py
@@ -24,15 +24,9 @@ from .postproc import Postproc
 @register_object("meta_schedule.DisallowAsyncStridedMemCopy")
 class DisallowAsyncStridedMemCopy(Postproc):
     """A postprocessor that disallows schedules that use async strided mem copies.
-
-    Parameters
-    ----------
-    merge_async_commit_queue_scope : bool
-       Whether or not to merge the async commit queue scope.
     """
 
-    def __init__(self, merge_async_commit_queue_scope=True) -> None:
+    def __init__(self) -> None:
         self.__init_handle_by_constructor__(
             _ffi_api.PostprocDisallowAsyncStridedMemCopy,  # type: ignore # pylint: disable=no-member
-            merge_async_commit_queue_scope,
         )

--- a/python/tvm/meta_schedule/postproc/disallow_async_strided_mem_copy.py
+++ b/python/tvm/meta_schedule/postproc/disallow_async_strided_mem_copy.py
@@ -23,8 +23,7 @@ from .postproc import Postproc
 
 @register_object("meta_schedule.DisallowAsyncStridedMemCopy")
 class DisallowAsyncStridedMemCopy(Postproc):
-    """A postprocessor that disallows schedules that use async strided mem copies.
-    """
+    """A postprocessor that disallows schedules that use async strided mem copies."""
 
     def __init__(self) -> None:
         self.__init_handle_by_constructor__(

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -52,7 +52,6 @@ TVM_REGISTER_PASS_CONFIG_OPTION("tir.is_entry_func", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.add_lower_pass", Array<Array<ObjectRef>>);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.debug_keep_trivial_loop", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.use_async_copy", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tir.merge_async_commit_queue_scope", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.instrument_lwp", Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.vtcm_capacity", Integer);
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.ptx_ldg32", Bool);

--- a/src/meta_schedule/postproc/disallow_async_strided_mem_copy.cc
+++ b/src/meta_schedule/postproc/disallow_async_strided_mem_copy.cc
@@ -166,7 +166,6 @@ class DisallowAsyncStridedMemCopyNode : public PostprocNode {
     return Postproc(n);
   }
 
-
   static constexpr const char* _type_key = "meta_schedule.DisallowAsyncStridedMemCopy";
   TVM_DECLARE_FINAL_OBJECT_INFO(DisallowAsyncStridedMemCopyNode, PostprocNode);
 };

--- a/src/meta_schedule/postproc/disallow_async_strided_mem_copy.cc
+++ b/src/meta_schedule/postproc/disallow_async_strided_mem_copy.cc
@@ -145,9 +145,6 @@ class DisallowAsyncStridedMemCopyNode : public PostprocNode {
           pass_list.push_back(tir::transform::InjectDoubleBuffer());
           pass_list.push_back(tir::transform::VectorizeLoop(true));
           pass_list.push_back(tir::transform::StorageRewrite());
-          transform::PassContext pass_ctx = transform::PassContext::Current();
-          pass_ctx->config.Set("tir.merge_async_commit_queue_scope",
-                               Bool(merge_async_commit_queue_scope));
           tir::PrimFunc f = WithAttr(GetRef<tir::PrimFunc>(prim_func), "global_symbol",
                                      runtime::String(g_var->name_hint));
           IRModule mod = IRModule(Map<GlobalVar, BaseFunc>({{GlobalVar(g_var->name_hint), f}}));
@@ -169,15 +166,13 @@ class DisallowAsyncStridedMemCopyNode : public PostprocNode {
     return Postproc(n);
   }
 
-  bool merge_async_commit_queue_scope = true;
 
   static constexpr const char* _type_key = "meta_schedule.DisallowAsyncStridedMemCopy";
   TVM_DECLARE_FINAL_OBJECT_INFO(DisallowAsyncStridedMemCopyNode, PostprocNode);
 };
 
-Postproc Postproc::DisallowAsyncStridedMemCopy(bool merge_async_commit_queue_scope) {
+Postproc Postproc::DisallowAsyncStridedMemCopy() {
   ObjectPtr<DisallowAsyncStridedMemCopyNode> n = make_object<DisallowAsyncStridedMemCopyNode>();
-  n->merge_async_commit_queue_scope = merge_async_commit_queue_scope;
   return Postproc(n);
 }
 

--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -233,6 +233,19 @@ TVM_REGISTER_GLOBAL("device_api.hexagon.dma_wait").set_body([](TVMArgs args, TVM
   *rv = static_cast<int32_t>(0);
 });
 
+TVM_REGISTER_GLOBAL("device_api.hexagon.dma_start_group")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      int queue_id = args[0];
+      HexagonDeviceAPI::Global()->UserDMA()->StartGroup(queue_id);
+      *rv = static_cast<int32_t>(0);
+    });
+
+TVM_REGISTER_GLOBAL("device_api.hexagon.dma_end_group").set_body([](TVMArgs args, TVMRetValue* rv) {
+  int queue_id = args[0];
+  HexagonDeviceAPI::Global()->UserDMA()->EndGroup(queue_id);
+  *rv = static_cast<int32_t>(0);
+});
+
 TVM_REGISTER_GLOBAL("device_api.hexagon.alloc_nd").set_body([](TVMArgs args, TVMRetValue* rv) {
   int32_t device_type = args[0];
   int32_t device_id = args[1];

--- a/src/runtime/hexagon/hexagon_user_dma.cc
+++ b/src/runtime/hexagon/hexagon_user_dma.cc
@@ -125,7 +125,8 @@ HexagonUserDMA::HexagonUserDMA() {
     unsigned int done = dma_desc_get_done(dma_desc);
     return (done != DESC_DONE_COMPLETE);
   };
-  descriptors_ = new QueuedRingBuffer<dma_desc_2d_t>(MAX_DMA_QUEUES, MAX_DMA_DESCRIPTORS, desc_in_flight);
+  descriptors_ =
+      new QueuedRingBuffer<dma_desc_2d_t>(MAX_DMA_QUEUES, MAX_DMA_DESCRIPTORS, desc_in_flight);
 }
 
 HexagonUserDMA::~HexagonUserDMA() {

--- a/src/runtime/hexagon/hexagon_user_dma.cc
+++ b/src/runtime/hexagon/hexagon_user_dma.cc
@@ -125,7 +125,7 @@ HexagonUserDMA::HexagonUserDMA() {
     unsigned int done = dma_desc_get_done(dma_desc);
     return (done != DESC_DONE_COMPLETE);
   };
-  descriptors_ = new QueuedRingBuffer<dma_desc_2d_t>(MAX_DMA_DESCRIPTORS, desc_in_flight);
+  descriptors_ = new QueuedRingBuffer<dma_desc_2d_t>(MAX_DMA_QUEUES, MAX_DMA_DESCRIPTORS, desc_in_flight);
 }
 
 HexagonUserDMA::~HexagonUserDMA() {

--- a/src/runtime/hexagon/hexagon_user_dma.h
+++ b/src/runtime/hexagon/hexagon_user_dma.h
@@ -67,6 +67,9 @@ class HexagonUserDMA {
    */
   uint32_t Poll(int queue_id);
 
+  void StartGroup(int queue_id) { descriptors_->StartGroup(queue_id); }
+  void EndGroup(int queue_id) { descriptors_->EndGroup(queue_id); }
+
  private:
   //! \brief Initializes the Hexagon User DMA engine
   unsigned int Init();

--- a/src/runtime/hexagon/hexagon_user_dma.h
+++ b/src/runtime/hexagon/hexagon_user_dma.h
@@ -48,6 +48,7 @@ class HexagonUserDMA {
 
   /*!
    * \brief Initiate DMA to copy memory from source to destination address
+   * \param queue_id The virtual DMA queue
    * \param dst Destination address
    * \param src Source address
    * \param length Length in bytes to copy
@@ -57,6 +58,7 @@ class HexagonUserDMA {
 
   /*!
    * \brief Wait until the number of DMAs in flight is less than or equal to some maximum
+   * \param queue_id The virtual DMA queue
    * \param max_dmas_in_flight Maximum number of DMAs allowed to be in flight
    * to satisfy the `Wait` e.g. use `Wait(0)` to wait on "all" outstanding DMAs to complete
    */
@@ -64,18 +66,31 @@ class HexagonUserDMA {
 
   /*!
    * \brief Poll the number of DMAs in flight
+   * \param queue_id The virtual DMA queue
    * \returns Number of DMAs in flight
    */
   uint32_t Poll(int queue_id);
 
+  /*!
+   * \brief Start a group of DMA copies
+   * \param queue_id The virtual DMA queue
+   */
   void StartGroup(int queue_id) { descriptors_->StartGroup(queue_id); }
+
+  /*!
+   * \brief End a group of DMA copies
+   * \param queue_id The virtual DMA queue
+   */
   void EndGroup(int queue_id) { descriptors_->EndGroup(queue_id); }
 
  private:
   //! \brief Initializes the Hexagon User DMA engine
   unsigned int Init();
 
-  //! \brief Calculates and returns the number of DMAs in flight
+  /*!
+   * \brief Calculates and returns the number of DMAs in flight
+   * \param queue_id The virtual DMA queue
+   */
   uint32_t DMAsInFlight(int queue_id);
 
   //! \brief Tracks whether the very first DMA has been executed

--- a/src/runtime/hexagon/hexagon_user_dma.h
+++ b/src/runtime/hexagon/hexagon_user_dma.h
@@ -34,6 +34,7 @@ namespace hexagon {
 #define DMA_FAILURE -1
 #define DMA_RETRY 1
 #define MAX_DMA_DESCRIPTORS 100
+#define MAX_DMA_QUEUES 3
 #define SYNC_DMA_QUEUE -1
 
 class HexagonUserDMA {

--- a/src/runtime/hexagon/hexagon_user_dma.h
+++ b/src/runtime/hexagon/hexagon_user_dma.h
@@ -34,7 +34,7 @@ namespace hexagon {
 #define DMA_FAILURE -1
 #define DMA_RETRY 1
 #define MAX_DMA_DESCRIPTORS 100
-#define MAX_DMA_QUEUES 3
+#define MAX_DMA_QUEUES 10
 #define SYNC_DMA_QUEUE -1
 
 class HexagonUserDMA {

--- a/src/runtime/hexagon/ring_buffer.h
+++ b/src/runtime/hexagon/ring_buffer.h
@@ -98,14 +98,14 @@ class QueuedRingBuffer : RingBuffer<T> {
  public:
   QueuedRingBuffer(uint32_t max_queues, uint32_t ring_buff_size, std::function<bool(T*)> in_flight)
       : RingBuffer<T>(ring_buff_size, in_flight), max_queues_(max_queues) {
-      queue_descriptors_.resize(max_queues_);
-    }
+    queue_descriptors_.resize(max_queues_);
+  }
 
   //! \brief Returns pointer to next T; add the queue ID for tracking
   T* Next(int queue_id) {
     CHECK_LT(queue_id, max_queues_);
     queue_ids_.push_back(queue_id);
-    queue_descriptor *d = &queue_descriptors_[queue_id];
+    queue_descriptor* d = &queue_descriptors_[queue_id];
     if (d->group_started) {
       // if we have a group started just update then pending count
       d->pending_in_group++;
@@ -120,7 +120,7 @@ class QueuedRingBuffer : RingBuffer<T> {
   //! \brief Returns the number of groups of Ts in flight for a given queue ID
   uint32_t InFlight(int queue_id) {
     CHECK_LT(queue_id, max_queues_);
-    queue_descriptor *d = &queue_descriptors_[queue_id];
+    queue_descriptor* d = &queue_descriptors_[queue_id];
     CHECK(!d->group_started);
 
     uint32_t in_flight = 0;
@@ -145,7 +145,7 @@ class QueuedRingBuffer : RingBuffer<T> {
   //! \brief Start a group of Ts, if not called the deafault group size is one
   void StartGroup(int queue_id) {
     CHECK_LT(queue_id, max_queues_);
-    queue_descriptor *d = &queue_descriptors_[queue_id];
+    queue_descriptor* d = &queue_descriptors_[queue_id];
     CHECK(!d->group_started);
 
     // start group
@@ -156,7 +156,7 @@ class QueuedRingBuffer : RingBuffer<T> {
   //! \brief End a group of Ts
   void EndGroup(int queue_id) {
     CHECK_LT(queue_id, max_queues_);
-    queue_descriptor *d = &queue_descriptors_[queue_id];
+    queue_descriptor* d = &queue_descriptors_[queue_id];
     CHECK(d->group_started);
     CHECK(d->pending_in_group);
 

--- a/src/tir/op/builtin.cc
+++ b/src/tir/op/builtin.cc
@@ -335,6 +335,12 @@ TIR_DEFINE_BUILTIN_FUNC(dma_copy).set_attr<TCallEffectKind>("TCallEffectKind",
 TIR_DEFINE_BUILTIN_FUNC(dma_wait).set_attr<TCallEffectKind>("TCallEffectKind",
                                                             Integer(CallEffectKind::kOpaque));
 
+TIR_DEFINE_BUILTIN_FUNC(dma_start_group)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_BUILTIN_FUNC(dma_end_group)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
 TIR_DEFINE_BUILTIN_FUNC(assume)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kEmbedInfo))
     .set_num_inputs(1);

--- a/src/tir/transforms/inject_software_pipeline.cc
+++ b/src/tir/transforms/inject_software_pipeline.cc
@@ -999,7 +999,7 @@ class PipelineInjector : private StmtExprMutator {
   }
 
  private:
-  explicit PipelineInjector() {}
+  PipelineInjector() {}
 
   /*!
    * \brief Check the pipeline satisfies the following conditions:
@@ -1134,9 +1134,9 @@ class PipelineInjector : private StmtExprMutator {
     ValidatePipelineBody(pipeline_info, original_order);
 
     // Step 4: Rewrite the pipeline body.
-    Stmt pipeline = PipelineRewriter::Rewrite(
-        buffer_data_to_buffer_, double_buffers, pipeline_allocs, GetRef<For>(op), pipeline_info,
-        fragment_info_, preserved_annotations);
+    Stmt pipeline = PipelineRewriter::Rewrite(buffer_data_to_buffer_, double_buffers,
+                                              pipeline_allocs, GetRef<For>(op), pipeline_info,
+                                              fragment_info_, preserved_annotations);
 
     if (const auto* realize = op->body.as<BlockRealizeNode>()) {
       const auto& block = realize->block;

--- a/src/tir/transforms/inject_software_pipeline.cc
+++ b/src/tir/transforms/inject_software_pipeline.cc
@@ -309,10 +309,9 @@ class PipelineRewriter : public StmtExprMutator {
       const Array<Buffer> pipeline_allocs, const For& pipeline_loop,
       const PipelineInfo& pipeline_info,
       const std::unordered_map<const VarNode*, FragmentInfo>& fragment_info,
-      const Map<String, ObjectRef> preserved_annotations, bool merge_async_commit_queue_scope) {
+      const Map<String, ObjectRef> preserved_annotations) {
     PipelineRewriter rewriter(buffer_data_to_buffer, double_buffers, pipeline_allocs, pipeline_loop,
-                              pipeline_info, fragment_info, preserved_annotations,
-                              merge_async_commit_queue_scope);
+                              pipeline_info, fragment_info, preserved_annotations);
     return rewriter.BuildPipeline();
   }
 
@@ -322,8 +321,7 @@ class PipelineRewriter : public StmtExprMutator {
                    const Array<Buffer>& pipeline_allocs, const For& pipeline_loop,
                    const PipelineInfo& pipeline_info,
                    const std::unordered_map<const VarNode*, FragmentInfo>& fragment_info,
-                   const Map<String, ObjectRef> preserved_annotations,
-                   bool merge_async_commit_queue_scope)
+                   const Map<String, ObjectRef> preserved_annotations)
 
       : buffer_data_to_buffer_(std::move(buffer_data_to_buffer)),
         double_buffers_(double_buffers),
@@ -331,8 +329,7 @@ class PipelineRewriter : public StmtExprMutator {
         pipeline_loop_(pipeline_loop),
         pipeline_info_(pipeline_info),
         fragment_info_(fragment_info),
-        preserved_annotations_(preserved_annotations),
-        merge_async_commit_queue_scope_(merge_async_commit_queue_scope) {}
+        preserved_annotations_(preserved_annotations) {}
 
   Stmt BuildPipeline() {
     // Step 1: Analyze accesses to the buffers in the pipeline and compute the number of versions
@@ -766,7 +763,7 @@ class PipelineRewriter : public StmtExprMutator {
           group_bodies.push_back(new_blocks[i].block->body);
         }
 
-        if (merge_async_commit_queue_scope_ && group_bodies.size() > 1) {
+        if (group_bodies.size() > 1) {
           auto merged_bodies = SeqStmt(group_bodies);
           group_bodies.clear();
           group_bodies.push_back(merged_bodies);
@@ -853,8 +850,7 @@ class PipelineRewriter : public StmtExprMutator {
         auto& local_state = async_states_local[stage];
 
         int commit_group_id = -1;
-        if (local_state.commit_groups.empty() || local_state.consumed ||
-            !merge_async_commit_queue_scope_) {
+        if (local_state.commit_groups.empty() || local_state.consumed) {
           // consumed == true means there is already a consumer stage waiting for an
           // eariler async operation of this stage. In such cases, we make multiple commit_queue
           // for this stage.
@@ -954,7 +950,6 @@ class PipelineRewriter : public StmtExprMutator {
   Array<Block> ordered_stmts_;
   std::map<int, AsyncStateGlobal> async_states;
   Map<String, ObjectRef> preserved_annotations_;
-  bool merge_async_commit_queue_scope_ = true;
 };
 
 /*!
@@ -993,8 +988,8 @@ void BuildDependencyGraph(
 
 class PipelineInjector : private StmtExprMutator {
  public:
-  static Stmt Inject(const PrimFunc& func, bool merge_async_commit_queue_scope) {
-    PipelineInjector injector(merge_async_commit_queue_scope);
+  static Stmt Inject(const PrimFunc& func) {
+    PipelineInjector injector;
     for (const auto& kv : func->buffer_map) {
       const Buffer& buffer = kv.second;
       injector.buffer_data_to_buffer_.Set(buffer->data, buffer);
@@ -1004,8 +999,7 @@ class PipelineInjector : private StmtExprMutator {
   }
 
  private:
-  explicit PipelineInjector(bool merge_async_commit_queue_scope)
-      : merge_async_commit_queue_scope_(merge_async_commit_queue_scope) {}
+  explicit PipelineInjector() {}
 
   /*!
    * \brief Check the pipeline satisfies the following conditions:
@@ -1142,7 +1136,7 @@ class PipelineInjector : private StmtExprMutator {
     // Step 4: Rewrite the pipeline body.
     Stmt pipeline = PipelineRewriter::Rewrite(
         buffer_data_to_buffer_, double_buffers, pipeline_allocs, GetRef<For>(op), pipeline_info,
-        fragment_info_, preserved_annotations, merge_async_commit_queue_scope_);
+        fragment_info_, preserved_annotations);
 
     if (const auto* realize = op->body.as<BlockRealizeNode>()) {
       const auto& block = realize->block;
@@ -1211,7 +1205,6 @@ class PipelineInjector : private StmtExprMutator {
   Map<Var, Buffer> buffer_data_to_buffer_;
   std::unordered_map<const VarNode*, FragmentInfo> fragment_info_;
   std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual> double_buffers;
-  bool merge_async_commit_queue_scope_ = true;
 };
 
 }  // namespace software_pipeline
@@ -1225,9 +1218,7 @@ namespace transform {
 Pass InjectSoftwarePipeline() {
   auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
     auto* fptr = f.CopyOnWrite();
-    bool merge_async_commit_queue_scope =
-        ctx->GetConfig<Bool>("tir.merge_async_commit_queue_scope", Bool(true)).value();
-    fptr->body = software_pipeline::PipelineInjector::Inject(f, merge_async_commit_queue_scope);
+    fptr->body = software_pipeline::PipelineInjector::Inject(f);
     fptr->body = ConvertSSA(std::move(fptr->body));
     return f;
   };

--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -319,6 +319,10 @@ class BuiltinLower : public StmtExprMutator {
       return MakeDMACopy(op);
     } else if (op->op.same_as(builtin::dma_wait())) {
       return MakeDMAWait(op);
+    } else if (op->op.same_as(builtin::dma_start_group())) {
+      return MakeDMAStartGroup(op);
+    } else if (op->op.same_as(builtin::dma_end_group())) {
+      return MakeDMAEndGroup(op);
     } else {
       return StmtExprMutator::VisitExpr_(op);
     }
@@ -349,6 +353,28 @@ class BuiltinLower : public StmtExprMutator {
 
     Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(),
                             {StringImm(fdevapi_prefix + ".dma_wait"), queue_id, inflight});
+    return VisitExpr(call_packed);
+  }
+
+  PrimExpr MakeDMAStartGroup(const CallNode* op) {
+    PrimExpr queue_id = op->args[0];
+
+    std::string fdevapi_prefix =
+        "device_api." + std::string(runtime::DeviceName(device_type_.as<IntImmNode>()->value));
+
+    Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(),
+                            {StringImm(fdevapi_prefix + ".dma_start_group"), queue_id});
+    return VisitExpr(call_packed);
+  }
+
+  PrimExpr MakeDMAEndGroup(const CallNode* op) {
+    PrimExpr queue_id = op->args[0];
+
+    std::string fdevapi_prefix =
+        "device_api." + std::string(runtime::DeviceName(device_type_.as<IntImmNode>()->value));
+
+    Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(),
+                            {StringImm(fdevapi_prefix + ".dma_end_group"), queue_id});
     return VisitExpr(call_packed);
   }
 

--- a/tests/cpp-runtime/hexagon/ring_buffer_tests.cc
+++ b/tests/cpp-runtime/hexagon/ring_buffer_tests.cc
@@ -190,7 +190,9 @@ TEST_F(RingBufferTest, half_in_flight_blocked) {
 }
 
 class QueuedRingBufferTest : public RingBufferTest {
-  void SetUp() override { queued_ring_buff = new QueuedRingBuffer<int>(MAX_QUEUES, size, in_flight); }
+  void SetUp() override {
+    queued_ring_buff = new QueuedRingBuffer<int>(MAX_QUEUES, size, in_flight);
+  }
   void TearDown() override { delete queued_ring_buff; }
 
  public:

--- a/tests/cpp-runtime/hexagon/ring_buffer_tests.cc
+++ b/tests/cpp-runtime/hexagon/ring_buffer_tests.cc
@@ -160,11 +160,11 @@ TEST_F(RingBufferTest, half_in_flight) {
 
   // mark it inflight and check
   *ptr = inflight;
-  ASSERT_EQ(ring_buff->InFlight(), 3);
+  ASSERT_EQ(ring_buff->InFlight(), half + 1);
 
   // mark it finished and check also blocked
   *ptr = finished;
-  ASSERT_EQ(ring_buff->InFlight(), 3);
+  ASSERT_EQ(ring_buff->InFlight(), half + 1);
 }
 
 TEST_F(RingBufferTest, half_in_flight_blocked) {

--- a/tests/cpp-runtime/hexagon/ring_buffer_tests.cc
+++ b/tests/cpp-runtime/hexagon/ring_buffer_tests.cc
@@ -40,7 +40,7 @@ class RingBufferTest : public ::testing::Test {
 
   int finished = 42;
   int inflight = 43;
-  uint32_t size = 4;
+  uint32_t size = 8;
   uint32_t half = size / 2;
   RingBuffer<int>* ring_buff = nullptr;
 };
@@ -213,6 +213,191 @@ TEST_F(QueuedRingBufferTest, two_queues) {
   ASSERT_EQ(queued_ring_buff->InFlight(1), 1);
 
   *q1 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 0);
+  ASSERT_EQ(queued_ring_buff->InFlight(1), 0);
+}
+
+TEST_F(QueuedRingBufferTest, group_end_before_group_start) {
+  ASSERT_THROW(queued_ring_buff->EndGroup(0), InternalError);
+}
+
+TEST_F(QueuedRingBufferTest, group_restart) {
+  queued_ring_buff->StartGroup(0);
+  ASSERT_THROW(queued_ring_buff->StartGroup(0), InternalError);
+}
+
+TEST_F(QueuedRingBufferTest, zero_size_group) {
+  queued_ring_buff->StartGroup(0);
+  ASSERT_THROW(queued_ring_buff->EndGroup(0), InternalError);
+}
+
+TEST_F(QueuedRingBufferTest, in_flight_before_group_end) {
+  queued_ring_buff->StartGroup(0);
+  ASSERT_THROW(queued_ring_buff->InFlight(0), InternalError);
+}
+
+TEST_F(QueuedRingBufferTest, group_of_one) {
+  queued_ring_buff->StartGroup(0);
+  int* g0_0 = queued_ring_buff->Next(0);
+  *g0_0 = inflight;
+  queued_ring_buff->EndGroup(0);
+
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+  *g0_0 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 0);
+}
+
+TEST_F(QueuedRingBufferTest, group_of_two) {
+  queued_ring_buff->StartGroup(0);
+  int* g0_0 = queued_ring_buff->Next(0);
+  *g0_0 = inflight;
+  int* g0_1 = queued_ring_buff->Next(0);
+  *g0_1 = inflight;
+  queued_ring_buff->EndGroup(0);
+
+  // neither done => group in flight
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+
+  // half done => group in flight
+  *g0_0 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+
+  // both done => group finished
+  *g0_1 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 0);
+}
+
+TEST_F(QueuedRingBufferTest, group_of_three) {
+  queued_ring_buff->StartGroup(0);
+  int* g0_0 = queued_ring_buff->Next(0);
+  *g0_0 = inflight;
+  int* g0_1 = queued_ring_buff->Next(0);
+  *g0_1 = inflight;
+  int* g0_2 = queued_ring_buff->Next(0);
+  *g0_2 = inflight;
+  queued_ring_buff->EndGroup(0);
+
+  // neither done => group in flight
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+
+  // 1/3 done => group in flight
+  *g0_0 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+
+  // 2/3 done => group in flight
+  *g0_1 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+
+  // all done => group finished
+  *g0_2 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 0);
+}
+
+TEST_F(QueuedRingBufferTest, two_groups_of_two) {
+  queued_ring_buff->StartGroup(0);
+  int* g0_0 = queued_ring_buff->Next(0);
+  *g0_0 = inflight;
+  int* g0_1 = queued_ring_buff->Next(0);
+  *g0_1 = inflight;
+  queued_ring_buff->EndGroup(0);
+
+  queued_ring_buff->StartGroup(0);
+  int* g1_0 = queued_ring_buff->Next(0);
+  *g1_0 = inflight;
+  int* g1_1 = queued_ring_buff->Next(0);
+  *g1_1 = inflight;
+  queued_ring_buff->EndGroup(0);
+
+  // two groups in flight
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 2);
+
+  // group 0 half done => two groups in flight
+  *g0_0 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 2);
+
+  // group 0 done => one group in flight
+  *g0_1 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+
+  // group 1 half done => one group in flight
+  *g1_0 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+
+  // group 1 done => zero groups in flight
+  *g1_1 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 0);
+}
+
+TEST_F(QueuedRingBufferTest, two_queues_two_groups_of_two) {
+  queued_ring_buff->StartGroup(0);
+  int* q0g0_0 = queued_ring_buff->Next(0);
+  *q0g0_0 = inflight;
+  int* q0g0_1 = queued_ring_buff->Next(0);
+  *q0g0_1 = inflight;
+  queued_ring_buff->EndGroup(0);
+
+  queued_ring_buff->StartGroup(1);
+  int* q1g0_0 = queued_ring_buff->Next(1);
+  *q1g0_0 = inflight;
+  int* q1g0_1 = queued_ring_buff->Next(1);
+  *q1g0_1 = inflight;
+  queued_ring_buff->EndGroup(1);
+
+  queued_ring_buff->StartGroup(0);
+  int* q0g1_0 = queued_ring_buff->Next(0);
+  *q0g1_0 = inflight;
+  int* q0g1_1 = queued_ring_buff->Next(0);
+  *q0g1_1 = inflight;
+  queued_ring_buff->EndGroup(0);
+
+  queued_ring_buff->StartGroup(1);
+  int* q1g1_0 = queued_ring_buff->Next(1);
+  *q1g1_0 = inflight;
+  int* q1g1_1 = queued_ring_buff->Next(1);
+  *q1g1_1 = inflight;
+  queued_ring_buff->EndGroup(1);
+
+  // two queues with two groups in flight each
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 2);
+  ASSERT_EQ(queued_ring_buff->InFlight(1), 2);
+
+  // queue 0 group 0 half done => no change
+  *q0g0_0 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 2);
+  ASSERT_EQ(queued_ring_buff->InFlight(1), 2);
+
+  // queue 0 group 0 done => queue 0 with one group in flight
+  *q0g0_1 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+  ASSERT_EQ(queued_ring_buff->InFlight(1), 2);
+
+  // queue 1 group 0 half done => no change
+  *q1g0_0 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+  ASSERT_EQ(queued_ring_buff->InFlight(1), 2);
+
+  // queue 1 group 0 done => queue 1 with one group in flight
+  *q1g0_1 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+  ASSERT_EQ(queued_ring_buff->InFlight(1), 1);
+
+  // queue 0 group 1 half done => no change
+  *q0g1_0 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 1);
+  ASSERT_EQ(queued_ring_buff->InFlight(1), 1);
+
+  // queue 0 group 1 done => queue 0 with zero groups in flight
+  *q0g1_1 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 0);
+  ASSERT_EQ(queued_ring_buff->InFlight(1), 1);
+
+  // queue 1 group 1 half done => no change
+  *q1g1_0 = finished;
+  ASSERT_EQ(queued_ring_buff->InFlight(0), 0);
+  ASSERT_EQ(queued_ring_buff->InFlight(1), 1);
+
+  // queue 1 group 1 done => queue 1 with zero groups in flight
+  *q1g1_1 = finished;
   ASSERT_EQ(queued_ring_buff->InFlight(0), 0);
   ASSERT_EQ(queued_ring_buff->InFlight(1), 0);
 }

--- a/tests/cpp-runtime/hexagon/ring_buffer_tests.cc
+++ b/tests/cpp-runtime/hexagon/ring_buffer_tests.cc
@@ -190,12 +190,20 @@ TEST_F(RingBufferTest, half_in_flight_blocked) {
 }
 
 class QueuedRingBufferTest : public RingBufferTest {
-  void SetUp() override { queued_ring_buff = new QueuedRingBuffer<int>(size, in_flight); }
+  void SetUp() override { queued_ring_buff = new QueuedRingBuffer<int>(MAX_QUEUES, size, in_flight); }
   void TearDown() override { delete queued_ring_buff; }
 
  public:
+  int MAX_QUEUES = 2;
   QueuedRingBuffer<int>* queued_ring_buff = nullptr;
 };
+
+TEST_F(QueuedRingBufferTest, invalid_queue) {
+  ASSERT_THROW(queued_ring_buff->Next(MAX_QUEUES), InternalError);
+  ASSERT_THROW(queued_ring_buff->InFlight(MAX_QUEUES), InternalError);
+  ASSERT_THROW(queued_ring_buff->StartGroup(MAX_QUEUES), InternalError);
+  ASSERT_THROW(queued_ring_buff->EndGroup(MAX_QUEUES), InternalError);
+}
 
 TEST_F(QueuedRingBufferTest, two_queues) {
   int* q0 = queued_ring_buff->Next(0);

--- a/tests/python/contrib/test_hexagon/metaschedule_e2e/test_resnet50_int8.py
+++ b/tests/python/contrib/test_hexagon/metaschedule_e2e/test_resnet50_int8.py
@@ -521,7 +521,6 @@ def test_async_dma_resnet50(hexagon_launcher):
 
     pass_config = {
         "tir.use_async_copy": 1,
-        "tir.merge_async_commit_queue_scope": False,
         "relay.backend.use_meta_schedule": True,
         "relay.backend.tir_converter": "default",
     }

--- a/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
+++ b/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
@@ -883,7 +883,7 @@ def test_non_contiguous():
     """Test Non Contiguous memory lowering."""
     sch = tvm.tir.Schedule(conv2d_async_non_contig)
     target_hexagon = tvm.target.hexagon("v68", link_params=True)
-    err_rgx = r"Unable to lower async dma for non contiguous memory access with load index: "
+    err_rgx = r"Unable to lower async dma due to non contiguous memory access"
     # Currently we do not support non contiguous memory access being lowered to
     # async dma so we throw an error.
     with pytest.raises(tvm.TVMError, match=err_rgx):

--- a/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
+++ b/tests/python/contrib/test_hexagon/test_async_dma_pipeline.py
@@ -268,7 +268,6 @@ def evaluate(
     c_data,
     expected_output=None,
     use_async_copy=0,
-    merge_async_commit_queue_scope=False,
 ):
     """Evaluate function."""
     target_hexagon = tvm.target.hexagon("v68", link_params=True)
@@ -276,7 +275,6 @@ def evaluate(
         config={
             "tir.use_async_copy": use_async_copy,
             "tir.experimental_dma_bypass_cache": 1,
-            "tir.merge_async_commit_queue_scope": merge_async_commit_queue_scope,
         }
     ):
         func_tir = tvm.build(
@@ -485,7 +483,6 @@ class TestAsyncDMAPipeline:
             np.zeros(expected_output.shape, "int32"),
             expected_output,
             use_async_copy=1,
-            merge_async_commit_queue_scope=False,
         )
 
         sch = get_fake_conv_vtcm_schedule(size_a, size_w)
@@ -893,7 +890,6 @@ def test_non_contiguous():
         with tvm.transform.PassContext(
             config={
                 "tir.use_async_copy": 1,
-                "tir.merge_async_commit_queue_scope": 0,
             }
         ):
             tvm.build(

--- a/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
+++ b/tests/python/contrib/test_hexagon/test_software_pipeline_async.py
@@ -181,7 +181,6 @@ class TestAsyncSoftwarePipeline:
             config={
                 "tir.use_async_copy": 1,
                 "tir.experimental_dma_bypass_cache": 1,
-                "tir.merge_async_commit_queue_scope": False,
             }
         ):
             # tvm.lower(schedule.mod["main"]).show()


### PR DESCRIPTION
Add the concept of DMA group to align Hexagon User DMA with existing async copy solutions e.g. nVidia.  Allows for the grouping of one or more DMA copies into a group and tracking the group with "in flight" counts created by InjectSoftwarePipeline pass.  For now, this allows for the removal of `merge_async_commit_queue_scope` which was a Hexagon specific workaround due to lack of support for grouping DMA copies.  Later, in a future PR, this functionality may lead to the possibility of doing DMA copy on Hexagon over non-contiguous regions.