### PR TITLE
[Unity] Allow user defined func attrs in emit_te

### DIFF
--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -298,8 +298,13 @@ class BlockBuilder(Object):
 
         kwargs : Any, optional
             The keyword arguments passed to the function.
-            Note that the key "primfunc_name_hint" is reserved for passing name hint
-            to the PrimFunc that gets generated.
+            Note that the following keyword args are reserved:
+
+                - 'primfunc_name_hint' for passing name hint to the PrimFunc
+                  that gets generated.
+                - 'primfunc_attrs' is reserved for passing func attributes to
+                  be added to the PrimFunc that gets created.
+
 
         Returns
         -------

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -292,6 +292,8 @@ def gen_call_tir_inputs(
 
     kwargs : Any, optional
         The keyword arguments passed to the function.
+        Note that the keyword args 'primfunc_attrs' is reserved for passing func
+        attributes to be added to the PrimFunc that gets created.
 
     Returns
     -------
@@ -408,6 +410,8 @@ def gen_call_tir_inputs(
             [tir.stmt_functor.substitute(value, tir_var_inverse_map) for value in shape_values]
         )
 
+    primfunc_attrs = kwargs.pop("primfunc_attrs", None)
+
     tir_var_map: Dict[tir.Var, tir.PrimExpr] = {}
     new_args, te_arg_list = _convert_te_arg(args, tir_var_map)
     new_kwargs, te_kwarg_list = _convert_te_arg(kwargs, tir_var_map)
@@ -424,6 +428,9 @@ def gen_call_tir_inputs(
 
     inputs = [*te_args] + outs
     tir_func = create_relax_prim_func(inputs, unbound_tir_vars, "int64")
+
+    if primfunc_attrs:
+        tir_func = tir_func.with_attrs(primfunc_attrs)
 
     tir_func = tir_func.without_attr("global_symbol")
 

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -350,8 +350,12 @@ def emit_te(func: Callable, *args: Any, **kwargs: Any) -> Call:
 
     kwargs : Any, optional
         The keyword arguments passed to the function.
-        Note that the key "primfunc_name_hint" is reserved for passing name hint
-        to the PrimFunc that gets generated.
+        Note that the following keyword args are reserved:
+
+            - 'primfunc_name_hint' for passing name hint to the PrimFunc
+                that gets generated.
+            - 'primfunc_attrs' is reserved for passing func attributes to
+                be added to the PrimFunc that gets created.
 
     Returns
     -------

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -200,7 +200,6 @@ def test_emit_te_primfunc_attrs():
 
         @R.function
         def foo(x: R.Tensor((128, 128), "float32")) -> R.Tensor((128, 128), "float32"):
-            # TODO(Siyuan): Need to change to `TestModule.tir_func`
             gv0 = R.call_tir(plus_one, x, R.Tensor((128, 128), dtype="float32"))
             return gv0
 
@@ -1075,7 +1074,7 @@ def test_arith_operators():
         a3 = x * y
         a4 = x / y
         a5 = x // y
-        a6 = x**y
+        a6 = x ** y
 
         c0 = x > y
         c1 = x < y

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1074,7 +1074,7 @@ def test_arith_operators():
         a3 = x * y
         a4 = x / y
         a5 = x // y
-        a6 = x ** y
+        a6 = x**y
 
         c0 = x > y
         c1 = x < y

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1075,7 +1075,7 @@ def test_arith_operators():
         a3 = x * y
         a4 = x / y
         a5 = x // y
-        a6 = x ** y
+        a6 = x**y
 
         c0 = x > y
         c1 = x < y


### PR DESCRIPTION
Allow users to specify PrimFunc attributes to be added when using `emit_te`.

`bb.emit_te` and `R.emit_te` would now have a reserved keyword arg `primfunc_attrs` which would be function attrs to be added to the generated PrimFunc.