### PR TITLE
[Unity][ci] Use CPU-SMALL instances

### DIFF
--- a/ci/jenkins/unity_jenkinsfile.groovy
+++ b/ci/jenkins/unity_jenkinsfile.groovy
@@ -164,7 +164,7 @@ stage('Prepare') {
 
 stage('Sanity Check') {
   timeout(time: max_time, unit: 'MINUTES') {
-    node('CPU') {
+    node('CPU-SMALL') {
       ws(per_exec_ws('tvm/sanity')) {
         init_git()
         is_docs_only_build = sh (
@@ -322,7 +322,7 @@ stage('Build and Test') {
       }
     },
     'BUILD: CPU': {
-      node('CPU') {
+      node('CPU-SMALL') {
         ws(per_exec_ws('tvm/build-cpu')) {
           init_git()
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh build"


### PR DESCRIPTION
We prefer these instances in CI unless there is a lot of heavy building going on (the normal tvm build is cached with sccache so this is usually just for docker builds).