### PR TITLE
[Unity][TVMScript] Expose CallNode::attrs for CallTIR

### DIFF
--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # pylint: disable=redefined-builtin
 """The base Relax operators."""
-from typing import Union, List, Tuple, Optional
+from typing import Union, List, Tuple, Optional, Dict
 
 
 import tvm
@@ -49,6 +49,7 @@ def call_tir(
     args: Expr,
     out_sinfo: Union[TensorStructInfo, List[TensorStructInfo]],
     tir_vars: Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]] = None,
+    attrs: Optional[Union[tvm.ir.Attrs, Dict]] = None,
 ) -> Call:
     """
     Call a destination-passing-style function and return the output.
@@ -69,6 +70,9 @@ def call_tir(
     tir_vars : Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]]
         ShapeExpr representing a tuple of integers to unpack when calling func. Is null if not used
 
+    attrs: Optional[Union[tvm.ir.Attrs,Dict]]
+        The attributes of the `relax::Call` node.
+
     Returns
     -------
     ret: Call
@@ -86,7 +90,10 @@ def call_tir(
     if isinstance(tir_vars, (list, tuple)):
         tir_vars = ShapeExpr(tir_vars)
 
-    return _ffi_api.call_tir(func, args, out_sinfo, tir_vars)  # type: ignore
+    if isinstance(attrs, dict):
+        attrs = tvm.ir.make_node("DictAttrs", **attrs)
+
+    return _ffi_api.call_tir(func, args, out_sinfo, tir_vars, attrs)  # type: ignore
 
 
 @args_converter.auto

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -93,7 +93,7 @@ RELAY_REGISTER_OP("relax.call_tir")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallTIR);
 
 Expr MakeCallTIR(Expr func, Tuple args, Array<TensorStructInfo> out_sinfo_list,
-                 Optional<Expr> packed_ints) {
+                 Optional<Expr> packed_ints, Optional<Attrs> opt_attrs) {
   for (const TensorStructInfo& sinfo : out_sinfo_list) {
     const auto* shape = sinfo->shape.as<ShapeExprNode>();
     CHECK(shape != nullptr) << "out_sinfo of call_tir should have defined ShapeExpr as shape. "
@@ -108,13 +108,15 @@ Expr MakeCallTIR(Expr func, Tuple args, Array<TensorStructInfo> out_sinfo_list,
     out_sinfo = TupleStructInfo({out_sinfo_list.begin(), out_sinfo_list.end()});
   }
 
+  Attrs attrs = opt_attrs.value_or({});
+
   static const Op& op = Op::Get("relax.call_tir");
   Call call;
   if (!packed_ints) {
     // don't use additional optional argument
-    call = Call(op, {func, args}, {}, {out_sinfo});
+    call = Call(op, {func, args}, attrs, {out_sinfo});
   } else {
-    call = Call(op, {func, args, packed_ints.value()}, {}, {out_sinfo});
+    call = Call(op, {func, args, packed_ints.value()}, attrs, {out_sinfo});
   }
   return call;
 }

--- a/src/script/printer/relax/call.cc
+++ b/src/script/printer/relax/call.cc
@@ -128,6 +128,13 @@ Optional<ExprDoc> PrintCallTIR(const relax::Call& n, const ObjectPath& n_p, cons
     kwargs_keys.push_back("tir_vars");
     kwargs_values.push_back(d->AsDoc<ExprDoc>(n->args[2], n_p->Attr("args")->ArrayIndex(2)));
   }
+
+  // Step 5. Print any attributes as an additional keyword argument
+  if (n->attrs.defined()) {
+    kwargs_keys.push_back("attrs");
+    kwargs_values.push_back(d->AsDoc<ExprDoc>(n->attrs, n_p->Attr("attrs")));
+  }
+
   return Relax(d, "call_tir")->Call(args, kwargs_keys, kwargs_values);
 }
 


### PR DESCRIPTION
Previously, the `attrs` field exists within the `relax::CallNode` object, and could be accessed through the Python FFI, but could neither be defined through TVMScript nor shown using the TVMScript printer.  This commit updates the parser and printer for a keyword argument `attrs` in `R.call_tir`.