### PR TITLE
[TIR][Schedule] Fix reverse_compute_inline

### DIFF
--- a/src/tir/schedule/primitive/compute_inline.cc
+++ b/src/tir/schedule/primitive/compute_inline.cc
@@ -844,9 +844,11 @@ void ReverseComputeInlineImpl(ScheduleState self, const StmtSRef& consumer_block
       NotSingleReadWriteBuffer::GetSingleRead(self, consumer_block, scope_root_sref);
   // Step 2. Check completeness
   CheckCompleteBlock(self, consumer_block_sref, scope_root_sref);
-  // Step 3. Check if the consumer has a single complete producer
+  // Step 3. Check if the consumer has a single complete producer, and the producer is not an output
+  // block
   StmtSRef producer_block_sref =
       NonSingleProducerError::Check(self, consumer_block_sref, scope_root_sref);
+  CheckNotOutputBlock(self, producer_block_sref, scope_root_sref);
   // Step 4. Analyze the block body
   ReverseComputeInliner inliner(inlined_buffer, producer_block_sref->StmtAs<BlockNode>(),
                                 consumer_block_realize, scope_root_sref, self->mod);


### PR DESCRIPTION
We can not reverse compute inline a block whose producer is an output block, since its content is visible to the caller.