### PR TITLE
[Unity] Consider target context for Relay to Relax conversion

### DIFF
--- a/python/tvm/relax/testing/relay_translator.py
+++ b/python/tvm/relax/testing/relay_translator.py
@@ -236,7 +236,7 @@ def from_relay(
 
     # Since optimization passes and OpStrategy are highly context-dependent,
     # we match the exact same context with `extract_task_from_relay()` env
-    with _autotvm_silencer(), tvm.transform.PassContext(
+    with target, _autotvm_silencer(), tvm.transform.PassContext(
         opt_level=opt_level,
         config=pass_config,
         disabled_pass=disabled_pass,


### PR DESCRIPTION
Some of Relay passes are target specific (for example, AlterOpLayout). This commit adds target information for Relay -> Relax conversion.