### PR TITLE
[TVMC] Improve --desired-layouts functionality

### DIFF
--- a/python/tvm/driver/tvmc/transform.py
+++ b/python/tvm/driver/tvmc/transform.py
@@ -130,8 +130,6 @@ def convert_graph_layout(mod, desired_layouts, ops=None):
         assert isinstance(desired_layouts, str)
         desired_layouts = [desired_layouts]
 
-    assert len(desired_layouts) > 0
-
     if len(desired_layouts) != len(ops):
         if len(desired_layouts) != 1:
             raise TVMCException(

--- a/python/tvm/driver/tvmc/transform.py
+++ b/python/tvm/driver/tvmc/transform.py
@@ -236,7 +236,7 @@ def generate_transform_args(parser):
         help="Change the data/kernel layout of the graph. (i.e. NCHW or NHWC:HWIO)"
         "This option can be provided multiple times to specify per-operator layouts, "
         "e.g. '--desired-layout NHWC:HWIO' (Apply same layout for every operator)."
-        "e.g. '--desired-layout-ops nn.conv2d nn.avg_pool2d --desired-layout NCHW NHWC'."
+        "e.g. '--desired-layout-ops nn.conv2d nn.avg_pool2d --desired-layout NCHW NHWC'.",
     )
     parser.add_argument(
         "--desired-layout-ops",

--- a/python/tvm/driver/tvmc/transform.py
+++ b/python/tvm/driver/tvmc/transform.py
@@ -235,7 +235,7 @@ def generate_transform_args(parser):
     parser.add_argument(
         "--desired-layout",
         nargs="+",
-        help="Change the data/kernel layout of the graph. (i.e. NCHW or NHWC:HWIO)",
+        help="Change the data/kernel layout of the graph. (i.e. NCHW or NHWC:HWIO)"
         "This option can be provided multiple times to specify per-operator layouts, "
         "e.g. '--desired-layout NHWC:HWIO' (Apply same layout for every operator)."
         "e.g. '--desired-layout-ops nn.conv2d nn.avg_pool2d --desired-layout NCHW NHWC'."

--- a/python/tvm/driver/tvmc/transform.py
+++ b/python/tvm/driver/tvmc/transform.py
@@ -125,7 +125,12 @@ def convert_graph_layout(mod, desired_layouts, ops=None):
     if ops is None:
         ops = ["nn.conv2d", "nn.conv2d_transpose", "qnn.conv2d"]
 
-    assert isinstance(desired_layouts, list) and len(desired_layouts) > 0
+    if not isinstance(desired_layouts, list):
+        # For backwards compatibility
+        assert isinstance(desired_layouts, str)
+        desired_layouts = [desired_layouts]
+
+    assert len(desired_layouts) > 0
 
     if len(desired_layouts) != len(ops):
         if len(desired_layouts) != 1:
@@ -231,6 +236,9 @@ def generate_transform_args(parser):
         "--desired-layout",
         nargs="+",
         help="Change the data/kernel layout of the graph. (i.e. NCHW or NHWC:HWIO)",
+        "This option can be provided multiple times to specify per-operator layouts, "
+        "e.g. '--desired-layout NHWC:HWIO' (Apply same layout for every operator)."
+        "e.g. '--desired-layout-ops nn.conv2d nn.avg_pool2d --desired-layout NCHW NHWC'."
     )
     parser.add_argument(
         "--desired-layout-ops",

--- a/tests/python/driver/tvmc/test_transform.py
+++ b/tests/python/driver/tvmc/test_transform.py
@@ -74,6 +74,28 @@ def test_layout_transform_convert_layout_pass_args(relay_conv2d, monkeypatch):
     )
 
 
+def test_layout_transform_convert_kernel_layout_pass_args(relay_conv2d, monkeypatch):
+    """
+    Check the convert layout desired layouts arugment is what is expected when
+    a non-default kernel layout is provided.
+    """
+    desired_layout = "NHWC:HWIO"
+    desired_layout_ops = ["nn.nonv2d"]
+
+    mock_convert_layout = MagicMock()
+    mock_convert_layout.return_value = relay.transform.ConvertLayout({})
+    monkeypatch.setattr(relay.transform, "ConvertLayout", mock_convert_layout)
+
+    with tvm.transform.PassContext(opt_level=3):
+        apply_graph_transforms(relay_conv2d, {"desired_layout": [desired_layout], "desired_layout_ops": desired_layout_ops})
+
+    mock_convert_layout.assert_called_once_with(
+        {
+            "nn.conv2d": ["NHWC", "HWIO"],
+        }
+    )
+
+
 def test_layout_transform_convert_layout_pass_args_multiple(relay_conv2d, monkeypatch):
     """
     Check the convert layout desired layouts arugment is what is expected when

--- a/tests/python/driver/tvmc/test_transform.py
+++ b/tests/python/driver/tvmc/test_transform.py
@@ -80,7 +80,7 @@ def test_layout_transform_convert_kernel_layout_pass_args(relay_conv2d, monkeypa
     a non-default kernel layout is provided.
     """
     desired_layout = "NHWC:HWIO"
-    desired_layout_ops = ["nn.nonv2d"]
+    desired_layout_ops = ["nn.conv2d"]
 
     mock_convert_layout = MagicMock()
     mock_convert_layout.return_value = relay.transform.ConvertLayout({})

--- a/tests/python/driver/tvmc/test_transform.py
+++ b/tests/python/driver/tvmc/test_transform.py
@@ -87,7 +87,10 @@ def test_layout_transform_convert_kernel_layout_pass_args(relay_conv2d, monkeypa
     monkeypatch.setattr(relay.transform, "ConvertLayout", mock_convert_layout)
 
     with tvm.transform.PassContext(opt_level=3):
-        apply_graph_transforms(relay_conv2d, {"desired_layout": [desired_layout], "desired_layout_ops": desired_layout_ops})
+        apply_graph_transforms(
+            relay_conv2d,
+            {"desired_layout": [desired_layout], "desired_layout_ops": desired_layout_ops},
+        )
 
     mock_convert_layout.assert_called_once_with(
         {
@@ -109,7 +112,10 @@ def test_layout_transform_convert_layout_pass_args_multiple(relay_conv2d, monkey
     monkeypatch.setattr(relay.transform, "ConvertLayout", mock_convert_layout)
 
     with tvm.transform.PassContext(opt_level=3):
-        apply_graph_transforms(relay_conv2d, {"desired_layout": desired_layout, "desired_layout_ops": desired_layout_ops})
+        apply_graph_transforms(
+            relay_conv2d,
+            {"desired_layout": desired_layout, "desired_layout_ops": desired_layout_ops},
+        )
 
     mock_convert_layout.assert_called_once_with(
         {
@@ -119,13 +125,20 @@ def test_layout_transform_convert_layout_pass_args_multiple(relay_conv2d, monkey
     )
 
 
-@pytest.mark.parametrize("desired", [
-    (["NHWC", "NCHW"], ["nn.max_pool2d"]),
-    (["NHWC", "NCHW"], None),
-])
-def test_layout_transform_convert_layout_pass_args_multiple_invalid(relay_conv2d, monkeypatch, desired):
+@pytest.mark.parametrize(
+    "desired",
+    [
+        (["NHWC", "NCHW"], ["nn.max_pool2d"]),
+        (["NHWC", "NCHW"], None),
+    ],
+)
+def test_layout_transform_convert_layout_pass_args_multiple_invalid(
+    relay_conv2d,
+    monkeypatch,
+    desired,
+):
     """
-    TODO
+    Check invalid cases when passing multiple values to the desired layouts argument.
     """
     desired_layout, desired_layout_ops = desired
 
@@ -135,7 +148,10 @@ def test_layout_transform_convert_layout_pass_args_multiple_invalid(relay_conv2d
 
     with pytest.raises(TVMCException):
         with tvm.transform.PassContext(opt_level=3):
-            apply_graph_transforms(relay_conv2d, {"desired_layout": desired_layout, "desired_layout_ops": desired_layout_ops})
+            apply_graph_transforms(
+                relay_conv2d,
+                {"desired_layout": desired_layout, "desired_layout_ops": desired_layout_ops},
+            )
 
 
 def test_layout_transform_to_mixed_precision_pass_args_mock(relay_conv2d, monkeypatch):

--- a/tests/python/driver/tvmc/test_transform.py
+++ b/tests/python/driver/tvmc/test_transform.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
 from unittest.mock import MagicMock
 
 import tvm
@@ -23,6 +24,7 @@ from tvm.relay import testing
 from tvm.relay.expr_functor import ExprMutator
 from tvm.ir.instrument import pass_instrument
 from tvm.driver.tvmc.transform import apply_graph_transforms
+from tvm.driver.tvmc.model import TVMCException
 
 
 def test_layout_transform_fold_constant(relay_conv2d):
@@ -41,7 +43,7 @@ def test_layout_transform_fold_constant(relay_conv2d):
 
     pass_names = CollectPassNames()
     with tvm.transform.PassContext(opt_level=3, instruments=[pass_names]):
-        apply_graph_transforms(relay_conv2d, {"desired_layout": desired_layout})
+        apply_graph_transforms(relay_conv2d, {"desired_layout": [desired_layout]})
 
     names = pass_names.names
     assert "ConvertLayout" in names
@@ -61,7 +63,7 @@ def test_layout_transform_convert_layout_pass_args(relay_conv2d, monkeypatch):
     monkeypatch.setattr(relay.transform, "ConvertLayout", mock_convert_layout)
 
     with tvm.transform.PassContext(opt_level=3):
-        apply_graph_transforms(relay_conv2d, {"desired_layout": desired_layout})
+        apply_graph_transforms(relay_conv2d, {"desired_layout": [desired_layout]})
 
     mock_convert_layout.assert_called_once_with(
         {
@@ -70,6 +72,48 @@ def test_layout_transform_convert_layout_pass_args(relay_conv2d, monkeypatch):
             "qnn.conv2d": ["NHWC", "default"],
         }
     )
+
+
+def test_layout_transform_convert_layout_pass_args_multiple(relay_conv2d, monkeypatch):
+    """
+    Check the convert layout desired layouts arugment is what is expected when
+    a multiple desired layouts are provided.
+    """
+    desired_layout = ["NHWC", "NCHW"]
+    desired_layout_ops = ["nn.max_pool2d", "qnn.conv2d"]
+
+    mock_convert_layout = MagicMock()
+    mock_convert_layout.return_value = relay.transform.ConvertLayout({})
+    monkeypatch.setattr(relay.transform, "ConvertLayout", mock_convert_layout)
+
+    with tvm.transform.PassContext(opt_level=3):
+        apply_graph_transforms(relay_conv2d, {"desired_layout": desired_layout, "desired_layout_ops": desired_layout_ops})
+
+    mock_convert_layout.assert_called_once_with(
+        {
+            "nn.max_pool2d": ["NHWC", "default"],
+            "qnn.conv2d": ["NCHW", "default"],
+        }
+    )
+
+
+@pytest.mark.parametrize("desired", [
+    (["NHWC", "NCHW"], ["nn.max_pool2d"]),
+    (["NHWC", "NCHW"], None),
+])
+def test_layout_transform_convert_layout_pass_args_multiple_invalid(relay_conv2d, monkeypatch, desired):
+    """
+    TODO
+    """
+    desired_layout, desired_layout_ops = desired
+
+    mock_convert_layout = MagicMock()
+    mock_convert_layout.return_value = relay.transform.ConvertLayout({})
+    monkeypatch.setattr(relay.transform, "ConvertLayout", mock_convert_layout)
+
+    with pytest.raises(TVMCException):
+        with tvm.transform.PassContext(opt_level=3):
+            apply_graph_transforms(relay_conv2d, {"desired_layout": desired_layout, "desired_layout_ops": desired_layout_ops})
 
 
 def test_layout_transform_to_mixed_precision_pass_args_mock(relay_conv2d, monkeypatch):


### PR DESCRIPTION
this aims to make the `--desired-layout` argument more powerful based on the previously merged changes from #14010 (@srkreddy1238) by introducing two new features:

1. Allow passing multiple arguments to `--desired-layout` instead of only one, to specify one layout per transformed operator specified in `--desired-layout-ops`. (Number of arguments has to bei either 1 or match the number of transformed operators)
2. Optionally, you can now specify a non-default kernel layout as follows: `NHWC:HWIO`

Example Usage: `tvmc compile … --desired-layout nn.max_pool2d qnn.conv2d --desired-layout-ops NCHW NHWC:HWIO`

I also added unit tests for the new use-cases.

### Known Limitations:
* It would make sense to specify individual kernel layouts for regular convolutions and depthwise ones. However since both are usually implemented as generalized `nn.conv2d`, we can not transform them individually. Are there any good workarounds for this?
* The arguments of `--desired-layouts` have previously been checked for validity during cmdline parsing (e.g. only NCHW and NHWC are allowed) which is not possible anymore. Should I add a regular expression for that?