### PR TITLE
[TVMC] Expose tir and relay.qnn passes to --disable-pass argument

### DIFF
--- a/python/tvm/driver/tvmc/pass_list.py
+++ b/python/tvm/driver/tvmc/pass_list.py
@@ -50,7 +50,7 @@ def parse_pass_list_str(input_string):
                 else:
                     p = p.replace(short, long, 1)
                 break
-            elif reverse and p.startswith(long):
+            if reverse and p.startswith(long):
                 p = p.replace(long, short, 1)
                 break
         return p

--- a/tests/python/driver/tvmc/test_pass_list.py
+++ b/tests/python/driver/tvmc/test_pass_list.py
@@ -23,12 +23,13 @@ from tvm.driver.tvmc.pass_list import parse_pass_list_str
 def test_parse_pass_list_str():
     assert [""] == parse_pass_list_str("")
     assert ["FoldScaleAxis", "FuseOps"] == parse_pass_list_str("FoldScaleAxis,FuseOps")
+    assert ["tir.UnrollLoop", "qnn.Legalize"] == parse_pass_list_str("tir.UnrollLoop,qnn.Legalize")
 
     with pytest.raises(argparse.ArgumentTypeError) as ate:
-        parse_pass_list_str("MyYobaPass,MySuperYobaPass,FuseOps")
+        parse_pass_list_str("MyYobaPass,qnn.MySuperYobaPass,FuseOps")
 
     assert "MyYobaPass" in str(ate.value)
-    assert "MySuperYobaPass" in str(ate.value)
+    assert "qnn.MySuperYobaPass" in str(ate.value)
     assert "FuseOps" in str(ate.value)
 
 


### PR DESCRIPTION
I recently tried to disable the `qnn.Legalize` pass on the TVMC command line and learned, that the list of passes is actuallt not complete. It lacks:
* Custom relay passes which not not follow the `relay._transform.` scheme such as `relay.qnn._transform.Legalize`
* Any TIR passes. Is this intentional, i.e. to keep complexity down and not overwhelm users?

My patch fixes this by automatically mapping user-provided path names to fully-qualified TVM passes as follows:
```python
replacements = {
    "tir.": "tir.transform.",
    "qnn.": "relay.qnn._transform.",
    "": "relay._transform.",
}
```

A small unit test for this use case was added. 

**Example usage:** `tvmc compile ... --disabled-pass tir.UnrollLoop,qnn.Legalize`

### Discussion
* To not break the compatibility with the older interface, I still use an empty prefix for the `relay._transform.` passes which is inconsistent with the QNN & TIR ones. Should I allow `relay.ABC` inputs instead and deprecate the unprefixed version instead?
* Having these non-trivial mappings might lead to users struggling how to find the expected names for these passes. Allowing to specify the fully-qualified pass name (i.e. `relay._transform.RemoveUnusedFunctions`) would be help but also blow up the number of allowed passes which would be printed in case of a failed lookup in `pass_list.py`.
* A number of passes is currently not exposed automatically for two reasons:
    ```
    relay.transform.LiftConstants
    relay.transform.RecoverVirtualDeviceMap
    relay.transform.ManifestAlloc
    relay.transform.MemoryPlan
    tir.usmp.transform.ConvertPoolAllocationsToOffsets
    tir.usmp.transform.CreateAllocatesForIO
    tir.usmp.transform.AssignPoolInfo
    ```
  1. Using `relay.transform.` as prefix instead of `relay._transform.`. Can anyone explain why?
  2. Mapping `tir.usmp.transform.` -> `tir.usmp.` is currently not implemented. Should I add it?