### PR TITLE
[TVMScript][Unity] Improve PyLint Compatibility

### DIFF
--- a/include/tvm/node/script_printer.h
+++ b/include/tvm/node/script_printer.h
@@ -45,6 +45,11 @@ class PrinterConfigNode : public Object {
   std::string tir_prefix = "T";
   /*! \brief The prefix of Relax nodes */
   std::string relax_prefix = "R";
+  /*!
+   * \brief The alias of the current module at cross-function call
+   * \note Directly use module name if it's empty.
+   */
+  std::string module_alias = "cls";
   /*! \brief Default data type of TIR buffer */
   DataType buffer_dtype = DataType::Float(32);
   /*! \brief Default data type of integer literals */
@@ -78,6 +83,9 @@ class PrinterConfigNode : public Object {
     v->Visit("binding_names", &binding_names);
     v->Visit("show_meta", &show_meta);
     v->Visit("ir_prefix", &ir_prefix);
+    v->Visit("tir_prefix", &tir_prefix);
+    v->Visit("relax_prefix", &relax_prefix);
+    v->Visit("module_alias", &module_alias);
     v->Visit("buffer_dtype", &buffer_dtype);
     v->Visit("int_dtype", &int_dtype);
     v->Visit("float_dtype", &float_dtype);
@@ -91,6 +99,8 @@ class PrinterConfigNode : public Object {
     v->Visit("obj_to_underline", &obj_to_underline);
     v->Visit("obj_to_annotate", &obj_to_annotate);
   }
+
+  Array<String> GetBuiltinKeywords();
 
   static constexpr const char* _type_key = "node.PrinterConfig";
   TVM_DECLARE_FINAL_OBJECT_INFO(PrinterConfigNode, Object);

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -524,7 +524,7 @@ class VarBinding(Binding):
 
 
 @tvm._ffi.register_object("relax.expr.BindingBlock")
-class BindingBlock(Node):
+class BindingBlock(Node, Scriptable):
     """base class of binding block, bindings inside can be impure
     (with side effect or control flow)"""
 

--- a/python/tvm/runtime/script_printer.py
+++ b/python/tvm/runtime/script_printer.py
@@ -33,6 +33,7 @@ class PrinterConfig(Object):
     ir_prefix: str
     tir_prefix: str
     relax_prefix: str
+    module_alias: str
     buffer_dtype: str
     int_dtype: str
     float_dtype: str
@@ -54,6 +55,7 @@ class PrinterConfig(Object):
         ir_prefix: str = "I",
         tir_prefix: str = "T",
         relax_prefix: str = "R",
+        module_alias: str = "cls",
         buffer_dtype: str = "float32",
         int_dtype: str = "int32",
         float_dtype: str = "void",
@@ -74,6 +76,7 @@ class PrinterConfig(Object):
             "ir_prefix": ir_prefix,
             "tir_prefix": tir_prefix,
             "relax_prefix": relax_prefix,
+            "module_alias": module_alias,
             "buffer_dtype": buffer_dtype,
             "int_dtype": int_dtype,
             "float_dtype": float_dtype,
@@ -115,6 +118,7 @@ class Scriptable:
         ir_prefix: str = "I",
         tir_prefix: str = "T",
         relax_prefix: str = "R",
+        module_alias: str = "cls",
         buffer_dtype: str = "float32",
         int_dtype: str = "int32",
         float_dtype: str = "void",
@@ -142,6 +146,9 @@ class Scriptable:
             The prefix of AST nodes from tvm.tir
         relax_prefix : str = "R"
             The prefix of AST nodes from tvm.relax
+        module_alias : str = "cls"
+            The alias of the current module at cross-function call,
+            Directly use module name if it's empty.
         buffer_dtype : str = "float32"
             The default data type of buffer
         int_dtype : str = "int32"
@@ -180,6 +187,7 @@ class Scriptable:
                 ir_prefix=ir_prefix,
                 tir_prefix=tir_prefix,
                 relax_prefix=relax_prefix,
+                module_alias=module_alias,
                 buffer_dtype=buffer_dtype,
                 int_dtype=int_dtype,
                 float_dtype=float_dtype,
@@ -203,6 +211,7 @@ class Scriptable:
         ir_prefix: str = "I",
         tir_prefix: str = "T",
         relax_prefix: str = "R",
+        module_alias: str = "cls",
         buffer_dtype: str = "float32",
         int_dtype: str = "int32",
         float_dtype: str = "void",
@@ -224,6 +233,7 @@ class Scriptable:
                 ir_prefix=ir_prefix,
                 tir_prefix=tir_prefix,
                 relax_prefix=relax_prefix,
+                module_alias=module_alias,
                 buffer_dtype=buffer_dtype,
                 int_dtype=int_dtype,
                 float_dtype=float_dtype,
@@ -249,6 +259,7 @@ class Scriptable:
         ir_prefix: str = "I",
         tir_prefix: str = "T",
         relax_prefix: str = "R",
+        module_alias: str = "cls",
         buffer_dtype: str = "float32",
         int_dtype: str = "int32",
         float_dtype: str = "void",
@@ -281,6 +292,9 @@ class Scriptable:
             The prefix of AST nodes from tvm.tir
         relax_prefix : str = "R"
             The prefix of AST nodes from tvm.relax
+        module_alias : str = "cls"
+            The alias of the current module at cross-function call,
+            Directly use module name if it's empty.
         buffer_dtype : str = "float32"
             The default data type of buffer
         int_dtype : str = "int32"
@@ -317,6 +331,7 @@ class Scriptable:
                 ir_prefix=ir_prefix,
                 tir_prefix=tir_prefix,
                 relax_prefix=relax_prefix,
+                module_alias=module_alias,
                 buffer_dtype=buffer_dtype,
                 int_dtype=int_dtype,
                 float_dtype=float_dtype,

--- a/python/tvm/script/parser/core/parser.py
+++ b/python/tvm/script/parser/core/parser.py
@@ -19,10 +19,12 @@
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Set, Union
-import numpy as np
-from tvm._ffi.base import TVMError
 
+import numpy as np
+
+from tvm._ffi.base import TVMError
 from tvm.error import DiagnosticError
+from tvm.ir import GlobalVar
 
 from . import dispatch, doc
 from .diagnostics import Diagnostics, Source
@@ -493,10 +495,10 @@ class Parser(doc.NodeVisitor):
         _dispatch_wrapper(func)(self, node)
         _dispatch(self, "post_visit_local_function")(self, node)
 
-    def visit_tvm_declare_function(self, node: doc.FunctionDef) -> None:
+    def visit_tvm_declare_function(self, node: doc.FunctionDef) -> GlobalVar:
         token = self.get_dispatch_token(node)
         with self.with_dispatch_token(token):
-            _dispatch(self, "tvm_declare_function")(self, node)
+            return _dispatch(self, "tvm_declare_function")(self, node)
 
     def visit_ClassDef(self, node: doc.ClassDef) -> Any:  # pylint: disable=invalid-name
         """The general class definition visiting method.

--- a/python/tvm/script/parser/ir/parser.py
+++ b/python/tvm/script/parser/ir/parser.py
@@ -21,6 +21,15 @@ from ...ir_builder import ir as I
 from .._core import Parser, dispatch, doc
 
 
+class ModuleWithGlobalVars:
+    """A Module that can add global vars during parsing, to support `Module.function` syntax."""
+
+    def __getattr__(self, attr):
+        # Customize the error message.
+        # NOTE: `__getattr__` is only called when the attribute access fails with an AttributeError
+        raise AttributeError(f"Cannot find the function `{attr}` in the current IRModule")
+
+
 @dispatch.register(token="ir", type_name="ClassDef")
 def _visit_class_def(self: Parser, node: doc.ClassDef) -> None:
     """The class definition visiting method for ir module.
@@ -36,13 +45,25 @@ def _visit_class_def(self: Parser, node: doc.ClassDef) -> None:
 
     with self.var_table.with_frame():
         with I.ir_module():
+            # Step 0. Add the class name to the var table
+            fake_module = ModuleWithGlobalVars()
+            self.var_table.add(node.name, fake_module)
+
+            # Step 1. Visit non-function stmts, including but not limited to
+            # 1. `I.module_attrs`
+            # 2. `I.module_global_infos`
             with self.with_dispatch_token("ir"):
                 for stmt in node.body:
                     if not isinstance(stmt, doc.FunctionDef):
                         self.visit(stmt)
+
+            # Step 2. Visit function stmts to declare the global vars
             for stmt in node.body:
                 if isinstance(stmt, doc.FunctionDef):
-                    self.visit_tvm_declare_function(stmt)
+                    global_var = self.visit_tvm_declare_function(stmt)
+                    fake_module.__setattr__(stmt.name, global_var)
+
+            # Step 3. Visit and parse the functions
             with self.with_dispatch_token("ir"):
                 for stmt in node.body:
                     if isinstance(stmt, doc.FunctionDef):

--- a/python/tvm/script/parser/relax/__init__.py
+++ b/python/tvm/script/parser/relax/__init__.py
@@ -15,10 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 """Initial impl of relax parser for sugars"""
+
+from typing import TYPE_CHECKING
+
 from ...ir_builder.relax import *  # pylint: disable=redefined-builtin
 from ...ir_builder.relax import ir as _relax
 from . import parser as _parser
-from .entry import Callable, Object, Prim, Shape, Tensor, Tuple, function, match_cast
+from .entry import Callable, Object, Prim, Shape, Tensor, Tuple, match_cast
+
+if TYPE_CHECKING:
+    # pylint: disable=invalid-name
+    # Define prim_func and make it type check as static method
+    # so most tvmscript won't trigger pylint error here.
+    function = staticmethod
+else:
+    from .entry import function
 
 __all__ = _relax.__all__ + [
     "Callable",

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -81,7 +81,8 @@ def bind_assign_value(
             )
         var = R.emit_match_cast(value.value, value.struct_info)
     else:
-        raise TypeError(f"Unsupported type {type(value)} in assignment")
+        return value
+        # raise TypeError(f"Unsupported type {type(value)} in assignment")
 
     IRBuilder.name(var_name, var)
     return var
@@ -202,7 +203,7 @@ def visit_function_def(self: Parser, node: doc.FunctionDef) -> None:
 
 
 @dispatch.register(token="relax", type_name="tvm_declare_function")
-def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> None:
+def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> GlobalVar:
     with self.var_table.with_frame():
         collect_symbolic_var_from_params(self, node)
 
@@ -220,8 +221,7 @@ def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> None:
             params.append(relax.Var(arg.arg, param_sinfo))
 
     func_signature = relax.Function.create_empty(params, ret_sinfo)
-    global_var = I.decl_function(node.name, func_signature)
-    self.var_table.add(node.name, global_var)
+    return I.decl_function(node.name, func_signature)
 
 
 @dispatch.register(token="relax", type_name="pre_visit_local_function")

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -21,7 +21,7 @@ from functools import partial
 from typing import Any
 
 import tvm
-from tvm.ir import PrimType
+from tvm.ir import GlobalVar, PrimType
 from tvm.tir import Buffer, IterVar, PrimExpr, Var
 
 from ...ir_builder import ir as I
@@ -475,7 +475,7 @@ def visit_return(self: Parser, node: doc.Return) -> None:
 
 
 @dispatch.register(token="tir", type_name="tvm_declare_function")
-def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> None:
+def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> GlobalVar:
     """The function declaration step for tir
 
     Parameters
@@ -495,5 +495,4 @@ def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> None:
 
     # Only ret_type is needed for func_signature.
     func_signature = tvm.tir.PrimFunc([], None, ret_type=ret_type)
-    global_var = I.decl_function(node.name, func_signature)
-    self.var_table.add(node.name, global_var)
+    return I.decl_function(node.name, func_signature)

--- a/src/node/script_printer.cc
+++ b/src/node/script_printer.cc
@@ -21,6 +21,8 @@
 #include <tvm/node/script_printer.h>
 #include <tvm/runtime/registry.h>
 
+#include <regex>
+
 namespace tvm {
 
 TVMScriptPrinter::FType& TVMScriptPrinter::vtable() {
@@ -33,6 +35,11 @@ std::string TVMScriptPrinter::Script(const ObjectRef& node, const Optional<Print
     return AsLegacyRepr(node);
   }
   return TVMScriptPrinter::vtable()(node, cfg.value_or(PrinterConfig()));
+}
+
+bool IsIdentifier(const std::string& name) {
+  static const std::regex kValidIdentifier("^[a-zA-Z_][a-zA-Z0-9_]*$");
+  return std::regex_match(name, kValidIdentifier);
 }
 
 PrinterConfig::PrinterConfig(Map<String, ObjectRef> config_dict) {
@@ -51,6 +58,9 @@ PrinterConfig::PrinterConfig(Map<String, ObjectRef> config_dict) {
   }
   if (auto v = config_dict.Get("relax_prefix")) {
     n->relax_prefix = Downcast<String>(v);
+  }
+  if (auto v = config_dict.Get("module_alias")) {
+    n->module_alias = Downcast<String>(v);
   }
   if (auto v = config_dict.Get("buffer_dtype")) {
     n->buffer_dtype = DataType(runtime::String2DLDataType(Downcast<String>(v)));
@@ -90,7 +100,23 @@ PrinterConfig::PrinterConfig(Map<String, ObjectRef> config_dict) {
   if (auto v = config_dict.Get("syntax_sugar")) {
     n->syntax_sugar = Downcast<IntImm>(v)->value;
   }
+
+  // Checking prefixes if they are valid Python identifiers.
+  CHECK(IsIdentifier(n->ir_prefix)) << "Invalid `ir_prefix`: " << n->ir_prefix;
+  CHECK(IsIdentifier(n->tir_prefix)) << "Invalid `tir_prefix`: " << n->tir_prefix;
+  CHECK(IsIdentifier(n->relax_prefix)) << "Invalid `relax_prefix`: " << n->relax_prefix;
+  CHECK(n->module_alias.empty() || IsIdentifier(n->module_alias))
+      << "Invalid `module_alias`: " << n->module_alias;
+
   this->data_ = std::move(n);
+}
+
+Array<String> PrinterConfigNode::GetBuiltinKeywords() {
+  Array<String> result{this->ir_prefix, this->tir_prefix, this->relax_prefix};
+  if (!this->module_alias.empty()) {
+    result.push_back(this->module_alias);
+  }
+  return result;
 }
 
 TVM_REGISTER_NODE_TYPE(PrinterConfigNode);

--- a/src/script/printer/ir_docsifier.cc
+++ b/src/script/printer/ir_docsifier.cc
@@ -149,6 +149,10 @@ IRDocsifier::IRDocsifier(const PrinterConfig& cfg) {
   auto n = make_object<IRDocsifierNode>();
   n->cfg = cfg;
   n->dispatch_tokens.push_back("");
+  // Define builtin keywords according to cfg.
+  for (const String& keyword : cfg->GetBuiltinKeywords()) {
+    n->defined_names.insert(keyword);
+  }
   data_ = std::move(n);
 }
 

--- a/src/script/printer/relax/function.cc
+++ b/src/script/printer/relax/function.cc
@@ -28,6 +28,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<relax::Function>("", [](relax::Function n, ObjectPath n_p, IRDocsifier d) -> Doc {
       std::unordered_set<const tir::VarNode*> func_vars;
       With<RelaxFrame> f(d);
+      IdDoc func_name = d->Define(n, f(), FindFunctionName(d, n).value_or("main"));
       (*f)->AddDispatchToken(d, "relax");
       (*f)->is_func = true;
       (*f)->func_vars = &func_vars;
@@ -59,8 +60,8 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
       Array<StmtDoc> body =
           PrintSeqExpr(Downcast<relax::SeqExpr>(n->body), n_p->Attr("body"), d, /*use_ret=*/true);
       (*f)->stmts.insert((*f)->stmts.end(), body.begin(), body.end());
-      return HeaderWrapper(d, FunctionDoc(IdDoc(FindFunctionName(d, n).value_or("main")), params,
-                                          {Relax(d, "function")}, ret_type, (*f)->stmts));
+      return HeaderWrapper(
+          d, FunctionDoc(func_name, params, {Relax(d, "function")}, ret_type, (*f)->stmts));
     });
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)

--- a/src/script/printer/relax/utils.h
+++ b/src/script/printer/relax/utils.h
@@ -37,6 +37,7 @@ namespace printer {
 class RelaxFrameNode : public FrameNode {
  public:
   bool is_func = false;
+  bool module_alias_printed = false;
   std::unordered_set<const tir::VarNode*>* func_vars = nullptr;
 
   void VisitAttrs(AttrVisitor* v) {

--- a/src/script/printer/tir/function.cc
+++ b/src/script/printer/tir/function.cc
@@ -68,6 +68,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<tir::PrimFunc>("", [](tir::PrimFunc func, ObjectPath p, IRDocsifier d) -> Doc {
       With<TIRFrame> f(d, func);
       (*f)->AddDispatchToken(d, "tir");
+      IdDoc func_name = d->Define(func, f(), FindFunctionName(d, func).value_or("main"));
       d->SetCommonPrefix(func, [](const ObjectRef& obj) {
         return obj->IsInstance<tir::VarNode>() || obj->IsInstance<tir::BufferNode>();
       });
@@ -166,7 +167,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
         }
       }
       return HeaderWrapper(d, FunctionDoc(
-                                  /*name=*/IdDoc(FindFunctionName(d, func).value_or("main")),
+                                  /*name=*/func_name,
                                   /*args=*/args,
                                   /*decorators=*/{TIR(d, "prim_func")},
                                   /*return_type=*/ret_type,

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -188,12 +188,13 @@ class VarExample:
 
     @R.function
     def main(x: R.Tensor, y: R.Tensor) -> R.Tensor:
+        cls = VarExample
         z = R.add(x, y)
         # no binding here
         _ = R.match_cast(x, R.Tensor((5, 5)))
         with R.dataflow():
             q = R.add(z, z)
-            p = func(q)
+            p = cls.func(q)
             r = R.match_cast(p, R.Tensor((5, 5)))
             s = r
             R.output(s)

--- a/tests/python/relax/test_analysis_estimate_memory_usage.py
+++ b/tests/python/relax/test_analysis_estimate_memory_usage.py
@@ -68,13 +68,14 @@ def test_basic():
 
         @R.function
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
+            cls = Module
             storage: R.Object = R.memory.alloc_storage(
                 R.shape([32]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(
                 storage, offset=0, shape=R.shape([2, 4]), dtype="float32"
             )
-            _: R.Tuple() = exp(x, alloc)
+            _: R.Tuple() = cls.exp(x, alloc)
             lv: R.Tensor((2, 4), dtype="float32") = alloc
             lv1: R.Tensor((8,), dtype="float32") = R.call_packed(
                 "vm.builtin.reshape", lv, R.shape([8]), sinfo_args=[R.Tensor((8,), dtype="float32")]
@@ -85,26 +86,26 @@ def test_basic():
             alloc1: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(
                 storage1, offset=0, shape=R.shape([8]), dtype="float32"
             )
-            _1: R.Tuple() = relu(lv1, alloc1)
+            _1: R.Tuple() = cls.relu(lv1, alloc1)
             _2: R.Tuple() = R.memory.kill_tensor(alloc)
             _3: R.Tuple() = R.memory.kill_tensor(lv1)
             lv2: R.Tensor((8,), dtype="float32") = alloc1
             alloc2: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(
                 storage, offset=0, shape=R.shape([8]), dtype="float32"
             )
-            _4: R.Tuple() = add(lv2, R.const(1, "float32"), alloc2)
+            _4: R.Tuple() = cls.add(lv2, R.const(1, "float32"), alloc2)
             _5: R.Tuple() = R.memory.kill_tensor(alloc1)
             lv3: R.Tensor((8,), dtype="float32") = alloc2
             alloc3: R.Tensor((10,), dtype="float32") = R.memory.alloc_tensor(
                 storage1, offset=0, shape=R.shape([10]), dtype="float32"
             )
-            _6: R.Tuple() = pad(lv3, alloc3)
+            _6: R.Tuple() = cls.pad(lv3, alloc3)
             _7: R.Tuple() = R.memory.kill_tensor(alloc2)
             lv4: R.Tensor((10,), dtype="float32") = alloc3
             alloc4: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([10]), dtype="float32", runtime_device_index=0
             )
-            _8: R.Tuple() = log(lv4, alloc4)
+            _8: R.Tuple() = cls.log(lv4, alloc4)
             _9: R.Tuple() = R.memory.kill_tensor(alloc3)
             gv5: R.Tensor((10,), dtype="float32") = alloc4
             _11: R.Tuple() = R.memory.kill_storage(storage)

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -442,7 +442,7 @@ def test_call_tir():
         @R.function
         def foo(x: R.Tensor(("m", "n"), "float32")):
             m, n = T.var("int64"), T.var("int64")
-            gv0 = R.call_tir(addone, (x,), R.Tensor((m, n), dtype="float32"))
+            gv0 = R.call_tir(TestCallTIR.addone, (x,), R.Tensor((m, n), dtype="float32"))
             return gv0
 
     mod = TestCallTIR

--- a/tests/python/relax/test_backend_transform_shape_lower.py
+++ b/tests/python/relax/test_backend_transform_shape_lower.py
@@ -164,7 +164,7 @@ def test_symbolic_compute():
         def main(
             x: R.Tensor(["n", "m"], "float32"), y: R.Tensor(ndim=3, dtype=None)
         ) -> R.Shape(ndim=3):
-            n = T.int64()
+            m = T.int64()
             k = T.int64()
             z = R.match_cast(y, R.Tensor([k, m, k + 1], dtype=None))
             return R.shape([k + 1, m, 2])
@@ -185,8 +185,9 @@ def test_symbolic_compute():
         def main(
             x: R.Tensor(["n", "m"], "float32"), y: R.Tensor(ndim=3, dtype=None)
         ) -> R.Shape(ndim=3):
-            n = T.int64()
+            m = T.int64()
             k = T.int64()
+            cls = Expected
             shape_heap = R.call_builtin_with_ctx(
                 "vm.builtin.alloc_shape_heap",
                 [R.prim_value(4)],
@@ -224,7 +225,7 @@ def test_symbolic_compute():
                 "",
                 sinfo_args=[R.Tuple()],
             )
-            _ = shape_func(shape_heap)
+            _ = cls.shape_func(shape_heap)
             # extra assertion on y's shape after shape computation
             _ = R.call_packed(
                 "vm.builtin.match_shape",

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -54,9 +54,10 @@ class Module:
 
     @R.function
     def main(x: R.Tensor((32, 32), "float32"), w: R.Tensor((32, 32), "float32")) -> R.Tensor:
+        cls = Module
         with R.dataflow():
-            lv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((32, 32), dtype="float32"))
-            lv1 = R.call_tir(tir_relu, (lv0), R.Tensor((32, 32), dtype="float32"))
+            lv0 = R.call_tir(cls.tir_matmul, (x, w), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir(cls.tir_relu, (lv0), R.Tensor((32, 32), dtype="float32"))
             R.output(lv1)
         return lv1
 
@@ -461,7 +462,7 @@ class SmallParallel:
         return lv2
 
 
-def test_distiguish_diamond_and_parallel():
+def test_distinguish_diamond_and_parallel():
     # relay pattern lang cannot distinguish the two cases above.
     diamond = SmallDiamond["main"].body.blocks[0]
     parallel = SmallParallel["main"].body.blocks[0]
@@ -479,7 +480,7 @@ def test_distiguish_diamond_and_parallel():
     with PatternContext() as ctx:
         # describe a parallel pattern
         join = is_call_dps_packed("my_add")
-        # Due to one-one mathcing:
+        # Due to one-one matching:
         # is_call_dps_packed("my_relu") creates the 1st relu
         is_call_dps_packed("my_relu") >> join
         # is_call_dps_packed("my_relu")
@@ -555,7 +556,7 @@ def test_counter_single_crb():
         )
         dfb = CBRx2["main"].body.blocks[0]
         assert not ctx.match_dfb(dfb)
-        # Quickly fails unpromising matches by assumiung `start_hint` must be matched by a pattern.
+        # Quickly fails unpromising matches by assuming `start_hint` must be matched by a pattern.
         # This is usually faster than the full match:
         # Full match: let one pattern to match -> all Var: complexity ~ #Var
         # must_include_hint: let `start_hint` to match -> all patterns: complexity ~ #patterns

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -82,7 +82,7 @@ def test_call_tir_rewrite():
         @R.function
         def foo(x: R.Tensor(("m", "n"), "float32")):
             m, n = T.int64(), T.int64()
-            gv0 = R.call_tir(exp, (x,), R.Tensor((m, n), dtype="float32"))
+            gv0 = R.call_tir(TestCallTIRRewrite.exp, (x,), R.Tensor((m, n), dtype="float32"))
             return gv0
 
     mod = TestCallTIRRewrite

--- a/tests/python/relax/test_transform_attach_global_symbol.py
+++ b/tests/python/relax/test_transform_attach_global_symbol.py
@@ -45,7 +45,7 @@ class Before:
     @R.function
     def main(x: R.Tensor(("m", "n"), "float32"), w: R.Tensor(("n", "k"), "float32")) -> R.Tensor:
         m, n, k = T.int64(), T.int64(), T.int64()
-        gv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((m, k), dtype="float32"))
+        gv0 = R.call_tir(Before.tir_matmul, (x, w), R.Tensor((m, k), dtype="float32"))
         return gv0
 
 
@@ -75,7 +75,7 @@ def test_basic():
         ) -> R.Tensor:
             R.func_attr({"global_symbol": "main"})
             m, n, k = T.int64(), T.int64(), T.int64()
-            gv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((m, k), dtype="float32"))
+            gv0 = R.call_tir(Expected.tir_matmul, (x, w), R.Tensor((m, k), dtype="float32"))
             return gv0
 
     before = Before

--- a/tests/python/relax/test_transform_bind_params.py
+++ b/tests/python/relax/test_transform_bind_params.py
@@ -48,7 +48,7 @@ def test_bind_params(use_np_array):
         def main(
             x: R.Tensor((16, 16), "float32"), w: R.Tensor((16, 16), "float32")
         ) -> R.Tensor((16, 16), "float32"):
-            gv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((16, 16), dtype="float32"))
+            gv0 = R.call_tir(InputModule.tir_matmul, (x, w), R.Tensor((16, 16), dtype="float32"))
             return gv0
 
     x_np = np.random.rand(16, 16).astype(np.float32)

--- a/tests/python/relax/test_transform_codegen_pass.py
+++ b/tests/python/relax/test_transform_codegen_pass.py
@@ -141,7 +141,7 @@ def test_tensorrt_only():
     )(mod)
 
     ex0 = relax.build(new_mod, target, params={})
-    # Sanity check for the correctness and rountrip
+    # Sanity check for the correctness and roundtrip
     check_roundtrip(ex0, dev, inputs, expected)
 
 
@@ -175,7 +175,7 @@ def test_mix_use_tensorrt_and_tvm():
     with transform.PassContext(opt_level=0):
         ex0 = relax.build(new_mod, target, params={})
 
-    # Sanity check for the correctness and rountrip
+    # Sanity check for the correctness and roundtrip
     check_roundtrip(ex0, dev, inputs, expected)
 
 
@@ -187,11 +187,12 @@ class Conv2dx2:
         weight1: R.Tensor((16, 3, 3, 16), dtype="float16"),
         weight2: R.Tensor((16, 3, 3, 16), dtype="float16"),
     ) -> R.Tensor((16, 32, 32, 16), dtype="float16"):
+        cls = Conv2dx2
         with R.dataflow():
-            lv: R.Tensor((16, 32, 32, 16), dtype="float16") = fused_relax_nn_conv2d_tensorrt(
+            lv: R.Tensor((16, 32, 32, 16), dtype="float16") = cls.fused_relax_nn_conv2d_tensorrt(
                 data, weight1
             )
-            gv: R.Tensor((16, 32, 32, 16), dtype="float16") = fused_relax_nn_conv2d_tensorrt(
+            gv: R.Tensor((16, 32, 32, 16), dtype="float16") = cls.fused_relax_nn_conv2d_tensorrt(
                 lv, weight2
             )
             R.output(gv)

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -67,7 +67,8 @@ def test_one_fold_addone():
 
         @R.function
         def before(c0: R.Tensor((16, 16), "float32")):
-            lv0 = relax.call_tir(addone, (c0,), R.Tensor((16, 16), dtype="float32"))
+            cls = Module
+            lv0 = relax.call_tir(cls.addone, (c0,), R.Tensor((16, 16), dtype="float32"))
             return lv0
 
         @R.function
@@ -97,7 +98,8 @@ def test_one_fold_transpose():
 
         @R.function
         def before(c0: R.Tensor((2, 3), "float32")):
-            lv0 = relax.call_tir(func, (c0,), R.Tensor((3, 2), dtype="float32"))
+            cls = Module
+            lv0 = relax.call_tir(cls.func, (c0,), R.Tensor((3, 2), dtype="float32"))
             return lv0
 
         @R.function
@@ -126,8 +128,9 @@ def test_two_hop_addone():
 
         @R.function
         def before(c0: R.Tensor((2, 2), "float32")):
-            lv0 = relax.call_tir(addone, (c0,), R.Tensor((2, 2), dtype="float32"))
-            lv1 = relax.call_tir(addone, (lv0,), R.Tensor((2, 2), dtype="float32"))
+            cls = Module
+            lv0 = relax.call_tir(cls.addone, (c0,), R.Tensor((2, 2), dtype="float32"))
+            lv1 = relax.call_tir(cls.addone, (lv0,), R.Tensor((2, 2), dtype="float32"))
             return lv1
 
         @R.function
@@ -158,8 +161,9 @@ def test_dataflow_fold():
 
         @R.function
         def before(c0: R.Tensor((16, 16), "float32")):
+            cls = Module
             with R.dataflow():
-                gv0 = relax.call_tir(identity, (c0,), R.Tensor((16, 16), dtype="float32"))
+                gv0 = relax.call_tir(cls.identity, (c0,), R.Tensor((16, 16), dtype="float32"))
                 R.output(gv0)
             return gv0
 
@@ -204,15 +208,16 @@ def test_fold_mixed_case():
         @R.function
         def before(c0: R.Tensor((16, 16), "float32"), x: R.Tensor("float32", ndim=2)):
             n, m = T.int64(), T.int64()
+            cls = Module
             x0 = R.match_cast(x, R.Tensor((n, m), "float32"))
             # this line cannot be folded because n is unknown
-            lv0 = relax.call_tir(addone, (c0,), R.Tensor((n, 16), dtype="float32"))
+            lv0 = relax.call_tir(cls.addone, (c0,), R.Tensor((n, 16), dtype="float32"))
             # this line can be folded
-            lv1 = relax.call_tir(addone, (c0,), R.Tensor((16, 16), dtype="float32"))
+            lv1 = relax.call_tir(cls.addone, (c0,), R.Tensor((16, 16), dtype="float32"))
             # this line can be folded because all inputs are const
-            lv2 = relax.call_tir(sub, (c0, lv1), R.Tensor((16, 16), dtype="float32"))
+            lv2 = relax.call_tir(cls.sub, (c0, lv1), R.Tensor((16, 16), dtype="float32"))
             # this line can not be folded because x's shape is unknown
-            lv3 = relax.call_tir(sub, (lv2, x), R.Tensor((16, 16), dtype="float32"))
+            lv3 = relax.call_tir(cls.sub, (lv2, x), R.Tensor((16, 16), dtype="float32"))
             return lv3
 
         @R.function
@@ -223,15 +228,16 @@ def test_fold_mixed_case():
             x: R.Tensor("float32", ndim=2),
         ) -> R.Tensor:
             n, m = T.int64(), T.int64()
+            cls = Module
             x0 = R.match_cast(x, R.Tensor((n, m), "float32"))
             # this line cannot be folded because n is unknown
-            lv0 = relax.call_tir(addone, (c0,), R.Tensor((n, 16), dtype="float32"))
+            lv0 = relax.call_tir(cls.addone, (c0,), R.Tensor((n, 16), dtype="float32"))
             # this line can be folded
             lv1 = c1
             # this line can be folded because all inputs are const
             lv2 = c2
             # this line can not be folded because x's shape is unknown
-            lv3 = relax.call_tir(sub, (c2, x), R.Tensor((16, 16), dtype="float32"))
+            lv3 = relax.call_tir(cls.sub, (c2, x), R.Tensor((16, 16), dtype="float32"))
             return lv3
 
     c0_np = np.arange((16 * 16)).astype("float32").reshape(16, 16)
@@ -256,7 +262,8 @@ def test_int32_fold():
 
         @R.function
         def before(c0: R.Tensor((16, 16), "int32")):
-            lv0 = relax.call_tir(addone, (c0,), R.Tensor((16, 16), dtype="int32"))
+            cls = Module
+            lv0 = relax.call_tir(cls.addone, (c0,), R.Tensor((16, 16), dtype="int32"))
             return lv0
 
         @R.function

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -45,10 +45,11 @@ class Conv2dReLU_composite_annotated:
         data: R.Tensor((1, 64, 56, 56), dtype="float32"),
         weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+        cls = Conv2dReLU_composite_annotated
         with R.dataflow():
             gv: R.Tensor(
                 (1, 64, 56, 56), dtype="float32"
-            ) = fused_relax_nn_conv2d_relax_nn_relu_dnnl(data, weight1)
+            ) = cls.fused_relax_nn_conv2d_relax_nn_relu_dnnl(data, weight1)
             R.output(gv)
         return gv
 
@@ -105,13 +106,14 @@ class Conv2dReLUx2Partitioned:
         weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
         weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        cls = Conv2dReLUx2Partitioned
         with R.dataflow():
-            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu(
-                data, weight1
-            )
-            gv: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu1(
-                lv, weight2
-            )
+            lv: R.Tensor(
+                (1, 64, 56, 56), dtype="float32"
+            ) = cls.fused_relax_nn_conv2d_relax_nn_relu(data, weight1)
+            gv: R.Tensor(
+                (1, 64, 54, 54), dtype="float32"
+            ) = cls.fused_relax_nn_conv2d_relax_nn_relu1(lv, weight2)
             R.output(gv)
         return gv
 
@@ -152,10 +154,15 @@ class Conv2dReLUx2Partitioned_only_conv2d:
         weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
         weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        cls = Conv2dReLUx2Partitioned_only_conv2d
         with R.dataflow():
-            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(data, weight1)
+            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = cls.fused_relax_nn_conv2d(
+                data, weight1
+            )
             conv1: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.relu(lv)
-            lv1: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d1(conv1, weight2)
+            lv1: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_nn_conv2d1(
+                conv1, weight2
+            )
             conv2d: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.relu(lv1)
             R.output(conv2d)
         return conv2d
@@ -211,11 +218,14 @@ class Conv2dConv2dReLUPartitioned:
         weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
         weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        cls = Conv2dConv2dReLUPartitioned
         with R.dataflow():
-            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(data, weight1)
-            gv: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu(
-                lv, weight2
+            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = cls.fused_relax_nn_conv2d(
+                data, weight1
             )
+            gv: R.Tensor(
+                (1, 64, 54, 54), dtype="float32"
+            ) = cls.fused_relax_nn_conv2d_relax_nn_relu(lv, weight2)
             R.output(gv)
         return gv
 
@@ -273,10 +283,11 @@ class BranchTupleOutputPartitioned:
         weight: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
         with R.dataflow():
+            cls = BranchTupleOutputPartitioned
             lv: R.Tuple(
                 R.Tensor((1, 64, 54, 54), dtype="float32"),
                 R.Tensor((1, 64, 54, 54), dtype="float32"),
-            ) = fused_relax_nn_conv2d_relax_nn_relu(data, weight)
+            ) = cls.fused_relax_nn_conv2d_relax_nn_relu(data, weight)
             lv1: R.Tensor((1, 64, 54, 54), dtype="float32") = lv[1]  # conv1
             lv2: R.Tensor((1, 64, 54, 54), dtype="float32") = lv[0]  # relu(conv1)
             gelu1: R.Tensor((1, 64, 54, 54), dtype="float32") = R.nn.gelu(lv2)
@@ -346,11 +357,12 @@ class Conv2dx2_partitioned:
         weight1: R.Tensor((16, 3, 3, 16), dtype="float16"),
         weight2: R.Tensor((16, 3, 3, 16), dtype="float16"),
     ) -> R.Tensor((16, 32, 32, 16), dtype="float16"):
+        cls = Conv2dx2_partitioned
         with R.dataflow():
-            lv: R.Tensor((16, 32, 32, 16), dtype="float16") = fused_relax_nn_conv2d_cutlass(
+            lv: R.Tensor((16, 32, 32, 16), dtype="float16") = cls.fused_relax_nn_conv2d_cutlass(
                 data, weight1
             )
-            gv: R.Tensor((16, 32, 32, 16), dtype="float16") = fused_relax_nn_conv2d_cutlass(
+            gv: R.Tensor((16, 32, 32, 16), dtype="float16") = cls.fused_relax_nn_conv2d_cutlass(
                 lv, weight2
             )
             R.output(gv)
@@ -389,8 +401,8 @@ conv2d_pat = make_fused_bias_activation_pattern("relax.nn.conv2d", activation=No
 conv2d_relu_pat = make_fused_bias_activation_pattern("relax.nn.conv2d", activation="relax.nn.relu")
 
 
-def check(mod, patterns, expected, bind_constants=True, annoatate_codegen=False):
-    partitioned = relax.transform.FuseOpsByPattern(patterns, bind_constants, annoatate_codegen)(mod)
+def check(mod, patterns, expected, bind_constants=True, annotate_codegen=False):
+    partitioned = relax.transform.FuseOpsByPattern(patterns, bind_constants, annotate_codegen)(mod)
     tvm.ir.assert_structural_equal(partitioned, expected)
 
 
@@ -455,13 +467,13 @@ def test_annotate_codegen():
         Conv2dReLU,
         [("dnnl.conv2d_relu", conv2d_relu_pat)],
         Conv2dReLU_composite_annotated,
-        annoatate_codegen=True,
+        annotate_codegen=True,
     )
 
 
 def test_multiple_calls_same_extern():
     pat = make_fused_bias_activation_pattern("relax.nn.conv2d", with_bias=False, activation=None)
-    check(Conv2dx2, [("cutlass.conv2d", pat)], Conv2dx2_partitioned, annoatate_codegen=True)
+    check(Conv2dx2, [("cutlass.conv2d", pat)], Conv2dx2_partitioned, annotate_codegen=True)
 
 
 def test_ignore_call_tir():
@@ -483,7 +495,9 @@ def test_ignore_call_tir():
         ):
             with R.dataflow():
                 conv1 = R.nn.conv2d(data, weight1, padding=(1, 1))
-                relu1 = R.call_tir(relu, (conv1,), R.Tensor((64, 64, 56, 56), "float32"))
+                relu1 = R.call_tir(
+                    Conv2dReLUCallTIR.relu, (conv1,), R.Tensor((64, 64, 56, 56), "float32")
+                )
                 R.output(relu1)
 
             return relu1
@@ -522,12 +536,13 @@ def test_ignore_call_tir():
             data: R.Tensor((1, 64, 56, 56), dtype="float32"),
             weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
         ) -> R.Tensor((64, 64, 56, 56), dtype="float32"):
+            cls = Conv2dReLUCallTIR_partitioned
             with R.dataflow():
-                lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(
+                lv: R.Tensor((1, 64, 56, 56), dtype="float32") = cls.fused_relax_nn_conv2d(
                     data, weight1
                 )
                 relu1 = R.call_tir(
-                    relu, (lv,), out_sinfo=R.Tensor((64, 64, 56, 56), dtype="float32")
+                    cls.relu, (lv,), out_sinfo=R.Tensor((64, 64, 56, 56), dtype="float32")
                 )
                 R.output(relu1)
             return relu1
@@ -571,8 +586,9 @@ def test_unused():
             data: R.Tensor((1, 64, 56, 56), dtype="float32"),
             weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
         ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+            cls = Conv2dReLU_partitioned
             with R.dataflow():
-                gv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(
+                gv: R.Tensor((1, 64, 56, 56), dtype="float32") = cls.fused_relax_nn_conv2d(
                     data, weight1
                 )
                 relu: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.relu(data)
@@ -626,8 +642,9 @@ def test_bind_constants():
             data: R.Tensor((1, 64, 56, 56), dtype="float32"),
             weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
         ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+            cls = Conv2dWithConstantWeight_partitioned
             with R.dataflow():
-                gv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(
+                gv: R.Tensor((1, 64, 56, 56), dtype="float32") = cls.fused_relax_nn_conv2d(
                     data, R.const(weight)
                 )
                 R.output(gv)

--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -607,7 +607,7 @@ def test_multiple_relax_functions():
         def func1(x: R.Tensor((10, 20), dtype="float32")) -> R.Tensor((10, 20), dtype="float32"):
             with R.dataflow():
                 gv2 = R.call_tir(
-                    fused_add_exp_squeeze,
+                    Expected.fused_add_exp_squeeze,
                     (x, R.const(1, "float32")),
                     out_sinfo=R.Tensor((10, 20), dtype="float32"),
                 )
@@ -618,7 +618,7 @@ def test_multiple_relax_functions():
         def func2(x: R.Tensor((20, 10), dtype="float32")) -> R.Tensor((20, 10), dtype="float32"):
             with R.dataflow():
                 gv3 = R.call_tir(
-                    fused_add1_exp1_squeeze1,
+                    Expected.fused_add1_exp1_squeeze1,
                     (x, R.const(1, "float32")),
                     out_sinfo=R.Tensor((20, 10), dtype="float32"),
                 )

--- a/tests/python/relax/test_transform_lambda_lift.py
+++ b/tests/python/relax/test_transform_lambda_lift.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import pytest
 import tvm
 import tvm.testing
 from tvm import relax
@@ -54,7 +53,7 @@ def test_basic():
         def main(
             x1: R.Tensor((10, 5), "float32"), y1: R.Tensor((10, 5), "float32")
         ) -> R.Tensor((10, 5), "float32"):
-            inner = lifted_func_0
+            inner = Expected.lifted_func_0
             gv1: R.Tensor((10, 5), "float32") = inner(x1, y1)
             return gv1
 
@@ -91,7 +90,7 @@ def test_closure():
         def main(
             x: R.Tensor((2, 3), "float32"), y: R.Tensor((2, 3), "float32")
         ) -> R.Tensor((2, 3), "float32"):
-            outer_func = lifted_func_0
+            outer_func = Expected.lifted_func_0
             in_call = outer_func(x)
             res = R.invoke_closure(in_call, (y,), sinfo_args=(R.Tensor((2, 3), dtype="float32")))
             return res
@@ -103,7 +102,7 @@ def test_closure():
 
         @R.function
         def lifted_func_0(y: R.Tensor((2, 3), "float32")) -> R.Object:
-            inner_func = R.make_closure(lifted_func_1, (y,))
+            inner_func = R.make_closure(Expected.lifted_func_1, (y,))
             return inner_func
 
     # IRModule to perform Lambda Lifting
@@ -150,7 +149,7 @@ def test_recursive():
             if cond:
                 new_i: R.Tensor((), "int32") = R.add(i, c)
                 new_s: R.Tensor((2, 3), "float32") = R.add(s, x)
-                new_r = lifted_func_0(new_i, new_s, x)
+                new_r = Expected.lifted_func_0(new_i, new_s, x)
                 r = new_r
             else:
                 r = s
@@ -158,7 +157,7 @@ def test_recursive():
 
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), dtype="float32"):
-            while_loop = R.make_closure(lifted_func_0, (x,))
+            while_loop = R.make_closure(Expected.lifted_func_0, (x,))
             gv: R.Tensor((2, 3), dtype="float32") = R.invoke_closure(
                 while_loop,
                 (R.const(0), x),
@@ -211,7 +210,7 @@ def test_multi_func():
         def glob_func_1(
             x1: R.Tensor((10, 5), "float32"), y1: R.Tensor((10, 5), "float32")
         ) -> R.Tensor(None, "float32", ndim=2):
-            inner = lifted_func_0
+            inner = Expected.lifted_func_0
             gv1: R.Tensor((10, 5), "float32") = inner(x1, y1)
             return gv1
 
@@ -219,7 +218,7 @@ def test_multi_func():
         def glob_func_2(
             x11: R.Tensor((10, 5), "float32"), y11: R.Tensor((10, 5), "float32")
         ) -> R.Tensor(None, "float32", ndim=2):
-            inner = lifted_func_1
+            inner = Expected.lifted_func_1
             gv11: R.Tensor((10, 5), "float32") = inner(x11, y11)
             return gv11
 
@@ -293,7 +292,7 @@ def test_no_local_func():
 
         @R.function
         def before(c0: R.Tensor((16, 16), "float32"), x: R.Tensor(dtype="float32", ndim=2)):
-            s = R.call_tir(sub, (c0, x), R.Tensor((16, 16), dtype="float32"))
+            s = R.call_tir(Before.sub, (c0, x), R.Tensor((16, 16), dtype="float32"))
             return s
 
     before = Before

--- a/tests/python/relax/test_transform_legalize_ops.py
+++ b/tests/python/relax/test_transform_legalize_ops.py
@@ -37,7 +37,8 @@ def test_customize_legalize():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "float32"):
-            gv = R.call_tir(add, (y, x), R.Tensor((4, 3, 2, 3), dtype="float32"))
+            cls = Expected
+            gv = R.call_tir(cls.add, (y, x), R.Tensor((4, 3, 2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -80,8 +81,9 @@ def test_legalize_multiple_types_of_call():
 
         @R.function
         def main(x: R.Tensor((3, 3), "float32")):
-            gv: R.Tensor((3, 3), "float32") = mul2(x)
-            gv1 = R.call_tir(identity, gv, R.Tensor((3, 3), dtype="float32"))
+            cls = Before
+            gv: R.Tensor((3, 3), "float32") = cls.mul2(x)
+            gv1 = R.call_tir(cls.identity, gv, R.Tensor((3, 3), dtype="float32"))
             gv2 = R.multiply(gv1, R.const(2.0, "float32"))
             return gv2
 
@@ -89,7 +91,8 @@ def test_legalize_multiple_types_of_call():
     class Expected:
         @R.function
         def mul2(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((3, 3), dtype="float32"):
-            gv = R.call_tir(multiply, (x,), R.Tensor((3, 3), dtype="float32"))
+            cls = Expected
+            gv = R.call_tir(cls.multiply, (x,), R.Tensor((3, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -113,9 +116,10 @@ def test_legalize_multiple_types_of_call():
 
         @R.function
         def main(x1: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((3, 3), dtype="float32"):
-            gv1: R.Tensor((3, 3), dtype="float32") = mul2(x1)
-            gv11 = R.call_tir(identity, gv1, R.Tensor((3, 3), dtype="float32"))
-            gv2 = R.call_tir(multiply, (gv11,), R.Tensor((3, 3), dtype="float32"))
+            cls = Expected
+            gv1: R.Tensor((3, 3), dtype="float32") = cls.mul2(x1)
+            gv11 = R.call_tir(cls.identity, gv1, R.Tensor((3, 3), dtype="float32"))
+            gv2 = R.call_tir(cls.multiply, (gv11,), R.Tensor((3, 3), dtype="float32"))
             return gv2
     # fmt: on
 
@@ -199,7 +203,8 @@ def test_legalize_scalar_data_type_preserve():
 
         @R.function
         def main(x: R.Tensor((3, 3), dtype="float16")) -> R.Tensor((3, 3), dtype="float16"):
-            gv = R.call_tir(multiply, (x,), out_sinfo=R.Tensor((3, 3), dtype="float16"))
+            cls = Expected0
+            gv = R.call_tir(cls.multiply, (x,), out_sinfo=R.Tensor((3, 3), dtype="float16"))
             return gv
 
     @tvm.script.ir_module
@@ -220,7 +225,8 @@ def test_legalize_scalar_data_type_preserve():
 
         @R.function
         def main(x: R.Tensor((3, 3), dtype="uint8")) -> R.Tensor((3, 3), dtype="uint8"):
-            gv = R.call_tir(multiply, (x,), out_sinfo=R.Tensor((3, 3), dtype="uint8"))
+            cls = Expected1
+            gv = R.call_tir(cls.multiply, (x,), out_sinfo=R.Tensor((3, 3), dtype="uint8"))
             return gv
 
     @tvm.script.ir_module
@@ -241,7 +247,8 @@ def test_legalize_scalar_data_type_preserve():
 
         @R.function
         def main(x: R.Tensor((3, 3), dtype="bool")) -> R.Tensor((3, 3), dtype="bool"):
-            gv = R.call_tir(equal, (x,), out_sinfo=R.Tensor((3, 3), dtype="bool"))
+            cls = Expected2
+            gv = R.call_tir(cls.equal, (x,), out_sinfo=R.Tensor((3, 3), dtype="bool"))
             return gv
     # fmt: on
 

--- a/tests/python/relax/test_transform_legalize_ops_binary.py
+++ b/tests/python/relax/test_transform_legalize_ops_binary.py
@@ -38,7 +38,7 @@ def test_add():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "float32"):
-            gv = R.call_tir(add, (x, y), R.Tensor((4, 3, 2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.add, (x, y), R.Tensor((4, 3, 2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -69,7 +69,7 @@ def test_add_with_arg0_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(add, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.add, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -100,7 +100,7 @@ def test_add_with_arg1_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(add, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.add, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -139,7 +139,7 @@ def test_add_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(add, (x, y), R.Tensor((a, b, c, d), dtype="float32"))
+            gv = R.call_tir(Expected.add, (x, y), R.Tensor((a, b, c, d), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -177,7 +177,7 @@ def test_divide():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "float32"):
-            gv = R.call_tir(divide, (x, y), R.Tensor((4, 3, 2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.divide, (x, y), R.Tensor((4, 3, 2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -208,7 +208,7 @@ def test_divide_with_arg0_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(divide, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.divide, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -239,7 +239,7 @@ def test_divide_with_arg1_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(divide, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.divide, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -278,7 +278,7 @@ def test_divide_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(divide, (x, y), R.Tensor((a, b, c, d), dtype="float32"))
+            gv = R.call_tir(Expected.divide, (x, y), R.Tensor((a, b, c, d), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -316,7 +316,7 @@ def test_floor_divide():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "float32"):
-            gv = R.call_tir(floor_divide, (x, y), R.Tensor((4, 3, 2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.floor_divide, (x, y), R.Tensor((4, 3, 2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -347,7 +347,7 @@ def test_floor_divide_with_arg0_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(floor_divide, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.floor_divide, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -378,7 +378,7 @@ def test_floor_divide_with_arg1_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(floor_divide, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.floor_divide, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -417,7 +417,7 @@ def test_floor_divide_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(floor_divide, (x, y), R.Tensor((a, b, c, d), dtype="float32"))
+            gv = R.call_tir(Expected.floor_divide, (x, y), R.Tensor((a, b, c, d), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -455,7 +455,7 @@ def test_multiply():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "float32"):
-            gv = R.call_tir(multiply, (x, y), R.Tensor((4, 3, 2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.multiply, (x, y), R.Tensor((4, 3, 2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -494,7 +494,7 @@ def test_multiply_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(multiply, (x, y), R.Tensor((a, b, c, d), dtype="float32"))
+            gv = R.call_tir(Expected.multiply, (x, y), R.Tensor((a, b, c, d), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -543,7 +543,7 @@ def test_power():
 
         @R.function
         def main(x: R.Tensor((1, 2, 3), dtype="float32"), y: R.Tensor((4, 3, 2, 1), dtype="float32")) -> R.Tensor((4, 3, 2, 3), dtype="float32"):
-            gv = R.call_tir(power, (x, y), out_sinfo=R.Tensor((4, 3, 2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.power, (x, y), out_sinfo=R.Tensor((4, 3, 2, 3), dtype="float32"))
             return gv
 
     # fmt: on
@@ -591,7 +591,7 @@ def test_power_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(power, (x, y), out_sinfo=R.Tensor((a, b, c, d), dtype="float32"))
+            gv = R.call_tir(Expected.power, (x, y), out_sinfo=R.Tensor((a, b, c, d), dtype="float32"))
             return gv
     # fmt: on
 
@@ -612,7 +612,7 @@ def test_subtract():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "float32"):
-            gv = R.call_tir(subtract, (x, y), R.Tensor((4, 3, 2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.subtract, (x, y), R.Tensor((4, 3, 2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -651,7 +651,7 @@ def test_subtract_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(subtract, (x, y), R.Tensor((a, b, c, d), dtype="float32"))
+            gv = R.call_tir(Expected.subtract, (x, y), R.Tensor((a, b, c, d), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -692,7 +692,7 @@ def test_equal():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "bool"):
-            gv = R.call_tir(equal, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.equal, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -723,7 +723,7 @@ def test_equal_with_arg0_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "bool"):
-            gv = R.call_tir(equal, (x,), R.Tensor((2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.equal, (x,), R.Tensor((2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -754,7 +754,7 @@ def test_equal_with_arg1_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "bool"):
-            gv = R.call_tir(equal, (x,), R.Tensor((2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.equal, (x,), R.Tensor((2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -793,7 +793,7 @@ def test_equal_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(equal, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
+            gv = R.call_tir(Expected.equal, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -831,7 +831,7 @@ def test_greater():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "bool"):
-            gv = R.call_tir(greater, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.greater, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -862,7 +862,7 @@ def test_greater_with_arg0_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "bool"):
-            gv = R.call_tir(greater, (x,), R.Tensor((2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.greater, (x,), R.Tensor((2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -893,7 +893,7 @@ def test_greater_with_arg1_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "bool"):
-            gv = R.call_tir(greater, (x,), R.Tensor((2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.greater, (x,), R.Tensor((2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -932,7 +932,7 @@ def test_greater_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(greater, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
+            gv = R.call_tir(Expected.greater, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -970,7 +970,7 @@ def test_greater_equal():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "bool"):
-            gv = R.call_tir(greater_equal, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.greater_equal, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -1009,7 +1009,7 @@ def test_greater_equal_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(greater_equal, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
+            gv = R.call_tir(Expected.greater_equal, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -1047,7 +1047,7 @@ def test_less():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "bool"):
-            gv = R.call_tir(less, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.less, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -1086,7 +1086,7 @@ def test_less_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(less, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
+            gv = R.call_tir(Expected.less, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -1124,7 +1124,7 @@ def test_less_equal():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "bool"):
-            gv = R.call_tir(less_equal, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.less_equal, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -1155,7 +1155,7 @@ def test_less_equal_with_arg0_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "bool"):
-            gv = R.call_tir(less_equal, (x,), R.Tensor((2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.less_equal, (x,), R.Tensor((2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -1186,7 +1186,7 @@ def test_less_equal_with_arg1_constant_scalar():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "bool"):
-            gv = R.call_tir(less_equal, (x,), R.Tensor((2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.less_equal, (x,), R.Tensor((2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -1225,7 +1225,7 @@ def test_less_equal_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(less_equal, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
+            gv = R.call_tir(Expected.less_equal, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -1263,7 +1263,7 @@ def test_not_equal():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3), "float32"), y: R.Tensor((4, 3, 2, 1), "float32")) -> R.Tensor((4, 3, 2, 3), "bool"):
-            gv = R.call_tir(not_equal, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
+            gv = R.call_tir(Expected.not_equal, (x, y), R.Tensor((4, 3, 2, 3), dtype="bool"))
             return gv
 
         @T.prim_func
@@ -1302,7 +1302,7 @@ def test_not_equal_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(not_equal, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
+            gv = R.call_tir(Expected.not_equal, (x, y), R.Tensor((a, b, c, d), dtype="bool"))
             return gv
 
         @T.prim_func

--- a/tests/python/relax/test_transform_legalize_ops_create_datatype.py
+++ b/tests/python/relax/test_transform_legalize_ops_create_datatype.py
@@ -37,7 +37,7 @@ def test_full():
     class Expected:
         @R.function
         def main(v: R.Tensor((), "int32")) -> R.Tensor((2, 3), "int32"):
-            gv = R.call_tir(full, (v,), R.Tensor((2, 3), dtype="int32"))
+            gv = R.call_tir(Expected.full, (v,), R.Tensor((2, 3), dtype="int32"))
             return gv
 
         @T.prim_func
@@ -68,7 +68,7 @@ def test_full_constant_scalar_fill_value():
     class Expected:
         @R.function
         def main() -> R.Tensor((2, 3), "int32"):
-            gv = R.call_tir(full, R.tuple(), R.Tensor((2, 3), dtype="int32"))
+            gv = R.call_tir(Expected.full, R.tuple(), R.Tensor((2, 3), dtype="int32"))
             return gv
 
         @T.prim_func
@@ -99,7 +99,7 @@ def test_full_different_dtype():
     class Expected:
         @R.function
         def main(v: R.Tensor((), "int32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(full, (v,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.full, (v,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -134,7 +134,7 @@ def test_full_symbolic():
         def main(dumb_param: R.Tensor(("m", "n")), v: R.Tensor((), "int32")) -> R.Tensor(("m", "n"), "int32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(full, (v,), R.Tensor((m, n), dtype="int32"))
+            gv = R.call_tir(Expected.full, (v,), R.Tensor((m, n), dtype="int32"))
             return gv
 
         @T.prim_func
@@ -168,7 +168,7 @@ def test_full_like():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "int32"), v: R.Tensor((), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(full, (v,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.full, (v,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -199,7 +199,7 @@ def test_full_like_constant_scalar_fill_value():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "int32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(full, R.tuple(), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.full, R.tuple(), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -230,7 +230,7 @@ def test_full_like_different_dtype():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "int32"), v: R.Tensor((), "float32")) -> R.Tensor((2, 3), "float64"):
-            gv = R.call_tir(full, (v,), R.Tensor((2, 3), dtype="float64"))
+            gv = R.call_tir(Expected.full, (v,), R.Tensor((2, 3), dtype="float64"))
             return gv
 
         @T.prim_func
@@ -265,7 +265,7 @@ def test_full_like_symbolic():
         def main(x: R.Tensor(("m", "n"), "int32"), v: R.Tensor((), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(full, (v,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.full, (v,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -299,7 +299,7 @@ def test_ones():
     class Expected:
         @R.function
         def main() -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(ones, R.tuple(), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.ones, R.tuple(), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -334,7 +334,7 @@ def test_ones_symbolic():
         def main(dumb_param: R.Tensor(("m", "n"))) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(ones, R.tuple(), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.ones, R.tuple(), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -368,7 +368,7 @@ def test_ones_like():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "int32"):
-            gv = R.call_tir(ones, R.tuple(), R.Tensor((2, 3), dtype="int32"))
+            gv = R.call_tir(Expected.ones, R.tuple(), R.Tensor((2, 3), dtype="int32"))
             return gv
 
         @T.prim_func
@@ -403,7 +403,7 @@ def test_ones_like_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(ones, R.tuple(), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.ones, R.tuple(), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -437,7 +437,7 @@ def test_zeros():
     class Expected:
         @R.function
         def main() -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(zeros, R.tuple(), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.zeros, R.tuple(), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -472,7 +472,7 @@ def test_zeros_symbolic():
         def main(dumb_param: R.Tensor(("m", "n"))) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(zeros, R.tuple(), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.zeros, R.tuple(), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -506,7 +506,7 @@ def test_zeros_like():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "int32"):
-            gv = R.call_tir(zeros, R.tuple(), R.Tensor((2, 3), dtype="int32"))
+            gv = R.call_tir(Expected.zeros, R.tuple(), R.Tensor((2, 3), dtype="int32"))
             return gv
 
         @T.prim_func
@@ -541,7 +541,7 @@ def test_zeros_like_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(zeros, R.tuple(), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.zeros, R.tuple(), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -575,7 +575,7 @@ def test_tril():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4), "float32")) -> R.Tensor((2, 3, 4), "float32"):
-            gv = R.call_tir(tril, (x,), R.Tensor((2, 3, 4), dtype="float32"))
+            gv = R.call_tir(Expected.tril, (x,), R.Tensor((2, 3, 4), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -612,7 +612,7 @@ def test_tril_symbolic():
             m = T.int64()
             n = T.int64()
             k = T.int64()
-            gv = R.call_tir(tril, (x,), R.Tensor((m, n, k), dtype="int8"))
+            gv = R.call_tir(Expected.tril, (x,), R.Tensor((m, n, k), dtype="int8"))
             return gv
 
         @T.prim_func
@@ -648,7 +648,7 @@ def test_triu():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4), "float32")) -> R.Tensor((2, 3, 4), "float32"):
-            gv = R.call_tir(triu, (x,), R.Tensor((2, 3, 4), dtype="float32"))
+            gv = R.call_tir(Expected.triu, (x,), R.Tensor((2, 3, 4), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -685,7 +685,7 @@ def test_triu_symbolic():
             m = T.int64()
             n = T.int64()
             k = T.int64()
-            gv = R.call_tir(triu, (x,), R.Tensor((m, n, k), dtype="int8"))
+            gv = R.call_tir(Expected.triu, (x,), R.Tensor((m, n, k), dtype="int8"))
             return gv
 
         @T.prim_func
@@ -724,7 +724,7 @@ def test_astype():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4), "float32")) -> R.Tensor((2, 3, 4), "int32"):
-            gv = R.call_tir(cast, (x,), R.Tensor((2, 3, 4), dtype="int32"))
+            gv = R.call_tir(Expected.cast, (x,), R.Tensor((2, 3, 4), dtype="int32"))
             return gv
 
         @T.prim_func
@@ -780,7 +780,7 @@ def test_astype_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "int32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(cast, (x,), R.Tensor((m, n), dtype="int32"))
+            gv = R.call_tir(Expected.cast, (x,), R.Tensor((m, n), dtype="int32"))
             return gv
 
         @T.prim_func

--- a/tests/python/relax/test_transform_legalize_ops_image.py
+++ b/tests/python/relax/test_transform_legalize_ops_image.py
@@ -34,7 +34,7 @@ def test_image_resize2d():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 8, 8, 3), "float32")) -> R.Tensor((2, 16, 16, 3), "float32"):
-            gv = R.call_tir(resize2d, (x,), R.Tensor((2, 16, 16, 3), dtype="float32"))
+            gv = R.call_tir(Expected.resize2d, (x,), R.Tensor((2, 16, 16, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -73,7 +73,7 @@ def test_image_resize2d_symbolic():
             c = T.int64()
             oh = T.int64()
             ow = T.int64()
-            gv = R.call_tir(resize2d, (x,), R.Tensor((n, c, oh, ow, 16), dtype="float32"))
+            gv = R.call_tir(Expected.resize2d, (x,), R.Tensor((n, c, oh, ow, 16), dtype="float32"))
             return gv
 
         @T.prim_func

--- a/tests/python/relax/test_transform_legalize_ops_index_linear_algebra.py
+++ b/tests/python/relax/test_transform_legalize_ops_index_linear_algebra.py
@@ -37,7 +37,7 @@ def test_take():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4), "float32"), indices: R.Tensor((4,), "int64")) -> R.Tensor((2, 4, 4), "float32"):
-            gv = R.call_tir(take, (x, indices), R.Tensor((2, 4, 4), dtype="float32"))
+            gv = R.call_tir(Expected.take, (x, indices), R.Tensor((2, 4, 4), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -72,7 +72,7 @@ def test_take_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32"), indices: R.Tensor(("i",), "int64")) -> R.Tensor(("m", "i"), "float32"):
             m = T.int64()
             i = T.int64()
-            gv = R.call_tir(take, (x, indices), R.Tensor((m, i), dtype="float32"))
+            gv = R.call_tir(Expected.take, (x, indices), R.Tensor((m, i), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -109,7 +109,7 @@ def test_strided_slice():
     class Expected:
         @R.function
         def main(x: R.Tensor((8, 9, 10, 10), dtype="float32")) -> R.Tensor((4, 9, 10, 3), dtype="float32"):
-            gv = R.call_tir(strided_slice, (x,), R.Tensor((4, 9, 10, 3), dtype="float32"))
+            gv = R.call_tir(Expected.strided_slice, (x,), R.Tensor((4, 9, 10, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -140,7 +140,7 @@ def test_strided_slice_no_strides():
     class Expected:
         @R.function
         def main(x: R.Tensor((8, 9, 10, 10), dtype="float32")) -> R.Tensor((4, 9, 10, 3), dtype="float32"):
-            gv = R.call_tir(strided_slice, (x,), out_sinfo=R.Tensor((7, 9, 10, 2), dtype="float32"))
+            gv = R.call_tir(Expected.strided_slice, (x,), out_sinfo=R.Tensor((7, 9, 10, 2), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -189,7 +189,7 @@ def test_strided_slice_symbolic():
         @R.function
         def main(x: R.Tensor((10, "n"), dtype="float32")) -> R.Tensor((3, "n"), dtype="float32"):
             n = T.int64()
-            gv = R.call_tir(strided_slice, (x,), R.Tensor((3, n), dtype="float32"))
+            gv = R.call_tir(Expected.strided_slice, (x,), R.Tensor((3, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -226,7 +226,7 @@ def test_matmul_1_4():
     class Expected:
         @R.function
         def main(x: R.Tensor((4,), "float32"), y: R.Tensor((2, 3, 4, 5), "float32")) -> R.Tensor((2, 3, 5), "float32"):
-            gv = R.call_tir(matmul, (x, y), R.Tensor((2, 3, 5), dtype="float32"))
+            gv = R.call_tir(Expected.matmul, (x, y), R.Tensor((2, 3, 5), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -259,7 +259,7 @@ def test_matmul_4_1():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), "float32"), y: R.Tensor((5,), "float32")) -> R.Tensor((2, 3, 4), "float32"):
-            gv = R.call_tir(matmul, (x, y), R.Tensor((2, 3, 4), dtype="float32"))
+            gv = R.call_tir(Expected.matmul, (x, y), R.Tensor((2, 3, 4), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -292,7 +292,7 @@ def test_matmul_1_1():
     class Expected:
         @R.function
         def main(x: R.Tensor((4,), "float32"), y: R.Tensor((4,), "float32")) -> R.Tensor((), "float32"):
-            gv = R.call_tir(matmul, (x, y), R.Tensor((), dtype="float32"))
+            gv = R.call_tir(Expected.matmul, (x, y), R.Tensor((), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -325,7 +325,7 @@ def test_matmul_4_5():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), "float16"), y: R.Tensor((6, 2, 3, 5, 7), "float16")) -> R.Tensor((6, 2, 3, 4, 7), "float32"):
-            gv = R.call_tir(matmul, (x, y), R.Tensor((6, 2, 3, 4, 7), dtype="float32"))
+            gv = R.call_tir(Expected.matmul, (x, y), R.Tensor((6, 2, 3, 4, 7), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -368,7 +368,7 @@ def test_matmul_4_5_symbolic():
             c = T.int64()
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(matmul, (x, y), R.Tensor((a, b, c, m, n), dtype="float32"))
+            gv = R.call_tir(Expected.matmul, (x, y), R.Tensor((a, b, c, m, n), dtype="float32"))
             return gv
 
         @T.prim_func

--- a/tests/python/relax/test_transform_legalize_ops_manipulate.py
+++ b/tests/python/relax/test_transform_legalize_ops_manipulate.py
@@ -38,7 +38,7 @@ def test_broadcast_to():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 1, 3), "float32")) -> R.Tensor((4, 2, 5, 3), "float32"):
-            gv = R.call_tir(broadcast_to, (x,), R.Tensor((4, 2, 5, 3), dtype="float32"))
+            gv = R.call_tir(Expected.broadcast_to, (x,), R.Tensor((4, 2, 5, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -77,7 +77,7 @@ def test_broadcast_to_symbolic():
             b = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(broadcast_to, (x,), R.Tensor((a, b, c, d), dtype="float32"))
+            gv = R.call_tir(Expected.broadcast_to, (x,), R.Tensor((a, b, c, d), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -114,7 +114,7 @@ def test_concat():
     class Expected:
         @R.function
         def main(x1: R.Tensor((1, 2, 3), "float32"), x2: R.Tensor((1, 3, 3), "float32"), x3: R.Tensor((1, 4, 3), "float32")) -> R.Tensor((1, 9, 3), "float32"):
-            gv = R.call_tir(concatenate, (x1, x2, x3), R.Tensor((1, 9, 3), dtype="float32"))
+            gv = R.call_tir(Expected.concatenate, (x1, x2, x3), R.Tensor((1, 9, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -147,7 +147,7 @@ def test_concat_input_tuple_var():
         def main(t: R.Tuple(R.Tensor((3, 4), "float32"), R.Tensor((3, 5), "float32"))) -> R.Tensor((3, 9), "float32"):
             gv: R.Tensor((3, 4), dtype="float32") = t[0]
             gv1: R.Tensor((3, 5), dtype="float32") = t[1]
-            gv2 = R.call_tir(concatenate, (gv, gv1), R.Tensor((3, 9), dtype="float32"))
+            gv2 = R.call_tir(Expected.concatenate, (gv, gv1), R.Tensor((3, 9), dtype="float32"))
             return gv2
 
         @T.prim_func
@@ -189,7 +189,7 @@ def test_concat_input_tuple_var_symbolic():
             gv: R.Tensor((a, b0), dtype="float32") = t[0]
             gv1: R.Tensor((a, b1), dtype="float32") = t[1]
             gv2: R.Tensor((a, b2), dtype="float32") = t[2]
-            gv3 = R.call_tir(concatenate, (gv, gv1, gv2), R.Tensor((a, ((b0 + b1) + b2)), dtype="float32"))
+            gv3 = R.call_tir(Expected.concatenate, (gv, gv1, gv2), R.Tensor((a, ((b0 + b1) + b2)), dtype="float32"))
             return gv3
 
         @T.prim_func
@@ -228,7 +228,7 @@ def test_expand_dims():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4), "float32")) -> R.Tensor((2, 1, 1, 1, 3, 1, 4, 1), "float32"):
-            gv = R.call_tir(expand_dims, (x,), R.Tensor((2, 1, 1, 1, 3, 1, 4, 1), dtype="float32"))
+            gv = R.call_tir(Expected.expand_dims, (x,), R.Tensor((2, 1, 1, 1, 3, 1, 4, 1), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -265,7 +265,7 @@ def test_expand_dims_symbolic():
             a = T.int64()
             b = T.int64()
             c = T.int64()
-            gv = R.call_tir(expand_dims, (x,), R.Tensor((a, 1, b, 1, c, 1), dtype="float32"))
+            gv = R.call_tir(Expected.expand_dims, (x,), R.Tensor((a, 1, b, 1, c, 1), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -301,7 +301,7 @@ def test_flatten():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4), "float32")) -> R.Tensor((24,), "float32"):
-            gv = R.call_tir(reshape, (x,), R.Tensor((24,), dtype="float32"))
+            gv = R.call_tir(Expected.reshape, (x,), R.Tensor((24,), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -332,7 +332,7 @@ def test_flatten_zero_rank():
     class Expected:
         @R.function
         def main(x: R.Tensor((), "float32")) -> R.Tensor((1,), "float32"):
-            gv = R.call_tir(reshape, (x,), R.Tensor((1,), dtype="float32"))
+            gv = R.call_tir(Expected.reshape, (x,), R.Tensor((1,), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -369,7 +369,7 @@ def test_flatten_symbolic():
             a = T.int64()
             b = T.int64()
             c = T.int64()
-            gv = R.call_tir(reshape, (x,), R.Tensor((((a * b) * c),), dtype="float32"))
+            gv = R.call_tir(Expected.reshape, (x,), R.Tensor((((a * b) * c),), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -405,7 +405,7 @@ def test_permute_dims():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3, 4), "float32")) -> R.Tensor((2, 4, 3, 1), "float32"):
-            gv = R.call_tir(transpose, (x,), R.Tensor((2, 4, 3, 1), dtype="float32"))
+            gv = R.call_tir(Expected.transpose, (x,), R.Tensor((2, 4, 3, 1), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -444,7 +444,7 @@ def test_permute_dims_symbolic():
             d = T.int64()
             c = T.int64()
             a = T.int64()
-            gv = R.call_tir(transpose, (x,), R.Tensor((b, d, c, a), dtype="float32"))
+            gv = R.call_tir(Expected.transpose, (x,), R.Tensor((b, d, c, a), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -481,7 +481,7 @@ def test_reshape():
     class Expected:
         @R.function
         def main(x: R.Tensor((1, 2, 3, 4), "float32")) -> R.Tensor((8, 3), "float32"):
-            gv = R.call_tir(reshape, (x,), R.Tensor((8, 3), dtype="float32"))
+            gv = R.call_tir(Expected.reshape, (x,), R.Tensor((8, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -516,7 +516,7 @@ def test_reshape_symbolic():
         def main(x: R.Tensor(("a", "b"), "float32")) -> R.Tensor(("a // 2", "b * 2"), "float32"):
             a = T.int64()
             b = T.int64()
-            gv = R.call_tir(reshape, (x,), R.Tensor(((a // 2), (b * 2)), dtype="float32"))
+            gv = R.call_tir(Expected.reshape, (x,), R.Tensor(((a // 2), (b * 2)), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -551,7 +551,7 @@ def test_split_by_indices():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 10, 4), "float32")) -> R.Tuple([R.Tensor((2, 3, 4), "float32"), R.Tensor((2, 4, 4), "float32"), R.Tensor((2, 3, 4), "float32")]):
-            gv = R.call_tir(split, (x,), [R.Tensor((2, 3, 4), "float32"), R.Tensor((2, 4, 4), "float32"), R.Tensor((2, 3, 4), "float32")])
+            gv = R.call_tir(Expected.split, (x,), [R.Tensor((2, 3, 4), "float32"), R.Tensor((2, 4, 4), "float32"), R.Tensor((2, 3, 4), "float32")])
             return gv
 
         @T.prim_func
@@ -608,7 +608,7 @@ def test_split_by_indices_n_section_divisible():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 10, 4), "float32")) -> R.Tuple([R.Tensor((2, 5, 4), "float32"), R.Tensor((2, 5, 4), "float32")]):
-            gv = R.call_tir(split, (x,), [R.Tensor((2, 5, 4), "float32"), R.Tensor((2, 5, 4), "float32")])
+            gv = R.call_tir(Expected.split, (x,), [R.Tensor((2, 5, 4), "float32"), R.Tensor((2, 5, 4), "float32")])
             return gv
 
         @T.prim_func
@@ -649,7 +649,7 @@ def test_split_by_indices_n_section_divisible_symbolic():
         def main(dumb_param: R.Tensor(("n",)), x: R.Tensor(("m", "(n * 3)"), "float32")) -> R.Tuple(R.Tensor(("m", "((n * 3) // 3)"), "float32"), R.Tensor(("m", "((((n * 3) // 3) * 2) - ((n * 3) // 3))"), "float32"), R.Tensor(("m", "((n * 3) - (((n * 3) // 3) * 2))"), "float32")):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(split, (x,), [R.Tensor((m, ((n * 3) // 3)), "float32"), R.Tensor((m, ((((n * 3) // 3) * 2) - ((n * 3) // 3))), "float32"), R.Tensor((m, ((n * 3) - (((n * 3) // 3) * 2))), "float32")], tir_vars=(n,))
+            gv = R.call_tir(Expected.split, (x,), [R.Tensor((m, ((n * 3) // 3)), "float32"), R.Tensor((m, ((((n * 3) // 3) * 2) - ((n * 3) // 3))), "float32"), R.Tensor((m, ((n * 3) - (((n * 3) // 3) * 2))), "float32")], tir_vars=(n,))
             return gv
 
         @T.prim_func
@@ -697,7 +697,7 @@ def test_squeeze():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 1, 3, 1, 1, 4), "float32")) -> R.Tensor((2, 3, 1, 4), "float32"):
-            gv = R.call_tir(squeeze, (x,), R.Tensor((2, 3, 1, 4), dtype="float32"))
+            gv = R.call_tir(Expected.squeeze, (x,), R.Tensor((2, 3, 1, 4), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -728,7 +728,7 @@ def test_squeeze_no_axis():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 1, 3, 1, 1, 4), "float32")) -> R.Tensor((2, 3, 1, 4), "float32"):
-            gv = R.call_tir(squeeze, (x,), R.Tensor((2, 3, 4), dtype="float32"))
+            gv = R.call_tir(Expected.squeeze, (x,), R.Tensor((2, 3, 4), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -763,7 +763,7 @@ def test_squeeze_symbolic():
         def main(x: R.Tensor(("a", 1, "b", 1), "float32")) -> R.Tensor(("a", "b", 1), "float32"):
             a = T.int64()
             b = T.int64()
-            gv = R.call_tir(squeeze, (x,), R.Tensor((a, b, 1), dtype="float32"))
+            gv = R.call_tir(Expected.squeeze, (x,), R.Tensor((a, b, 1), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -798,7 +798,7 @@ def test_collapse_sum_like():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32"), y: R.Tensor((1, 3), "float32")) -> R.Tensor((1, 3), "float32"):
-            gv = R.call_tir(collapse_sum, (x,), R.Tensor((1, 3), dtype="float32"))
+            gv = R.call_tir(Expected.collapse_sum, (x,), R.Tensor((1, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -851,7 +851,7 @@ def test_collapse_sum_to():
             x: R.Tensor((3, 2, 3), dtype="float32")
         ) -> R.Tensor((2, 1), dtype="float32"):
             # block 0
-            gv = R.call_tir(collapse_sum, (x,), R.Tensor((2, 1), dtype="float32"))
+            gv = R.call_tir(Expected.collapse_sum, (x,), R.Tensor((2, 1), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -901,7 +901,7 @@ def test_repeat():
     class Expected:
         @R.function
         def main(x: R.Tensor((3, 2, 3), dtype="float32")) -> R.Tensor((6, 2, 3), dtype="float32"):
-            gv = R.call_tir(repeat, (x,), out_sinfo=R.Tensor((6, 2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.repeat, (x,), out_sinfo=R.Tensor((6, 2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -935,7 +935,7 @@ def test_repeat_no_axis():
         def main(
             x: R.Tensor((3, 2, 3), dtype="float32")
         ) -> R.Tensor((36,), dtype="float32"):
-            gv = R.call_tir(repeat, (x,), out_sinfo=R.Tensor((36,), dtype="float32"))
+            gv = R.call_tir(Expected.repeat, (x,), out_sinfo=R.Tensor((36,), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1006,7 +1006,7 @@ def test_repeat_symbolic():
             a = T.Var("a", "int64")
             b = T.Var("b", "int64")
             c = T.Var("c", "int64")
-            gv = R.call_tir(repeat, (x,), out_sinfo=R.Tensor((2 * a, b, c), dtype="float32"))
+            gv = R.call_tir(Expected.repeat, (x,), out_sinfo=R.Tensor((2 * a, b, c), dtype="float32"))
             return gv
     # fmt: on
 
@@ -1038,7 +1038,7 @@ def test_tile():
 
         @R.function
         def main(x: R.Tensor((3, 2, 3), dtype="float32")) -> R.Tensor((2, 3, 4, 9), dtype="float32"):
-            gv = R.call_tir(tile, (x,), out_sinfo=R.Tensor((2, 3, 4, 9), dtype="float32"))
+            gv = R.call_tir(Expected.tile, (x,), out_sinfo=R.Tensor((2, 3, 4, 9), dtype="float32"))
             return gv
     # fmt: on
 
@@ -1078,7 +1078,7 @@ def test_tile_symbolic():
             a = T.Var("a", "int64")
             b = T.Var("b", "int64")
             c = T.Var("c", "int64")
-            gv = R.call_tir(tile, (x,), out_sinfo=R.Tensor((2, a, b * 2, c * 3), dtype="float32"))
+            gv = R.call_tir(Expected.tile, (x,), out_sinfo=R.Tensor((2, a, b * 2, c * 3), dtype="float32"))
             return gv
     # fmt: on
     mod = LegalizeOps()(Tile)

--- a/tests/python/relax/test_transform_legalize_ops_nn.py
+++ b/tests/python/relax/test_transform_legalize_ops_nn.py
@@ -38,7 +38,7 @@ def test_conv2d():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 128, 28, 28), "float32"), w: R.Tensor((64, 16, 3, 3), "float32")) -> R.Tensor((2, 64, 13, 13), "float32"):
-            gv = R.call_tir(conv2d, (x, w), R.Tensor((2, 64, 13, 13), dtype="float32"))
+            gv = R.call_tir(Expected.conv2d, (x, w), R.Tensor((2, 64, 13, 13), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -78,7 +78,7 @@ def test_conv2d_with_out_dtype():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")) -> R.Tensor((2, 4, 26, 26), "float16"):
-            gv = R.call_tir(conv2d, (x, w), R.Tensor((2, 4, 26, 26), dtype="float16"))
+            gv = R.call_tir(Expected.conv2d, (x, w), R.Tensor((2, 4, 26, 26), dtype="float16"))
             return gv
 
         @T.prim_func
@@ -118,7 +118,7 @@ def test_conv2d_nhwc():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 28, 28, 128), "float32"), w: R.Tensor((64, 128, 3, 3), "float32")) -> R.Tensor((2, 26, 26, 64), "float32"):
-            gv = R.call_tir(conv2d, (x, w), R.Tensor((2, 26, 26, 64), dtype="float32"))
+            gv = R.call_tir(Expected.conv2d, (x, w), R.Tensor((2, 26, 26, 64), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -170,7 +170,7 @@ def test_conv2d_symbolic():
             kh = T.int64()
             w = T.int64()
             kw = T.int64()
-            gv = R.call_tir(conv2d, (x, kernel), R.Tensor((n, f, ((h - kh) + 1), ((w - kw) + 1)), dtype="float32"))
+            gv = R.call_tir(Expected.conv2d, (x, kernel), R.Tensor((n, f, ((h - kh) + 1), ((w - kw) + 1)), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -220,7 +220,7 @@ def test_conv2d_transpose():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 128, 28, 28), dtype="float32"), w: R.Tensor((128, 16, 3, 3), dtype="float32")) -> R.Tensor((2, 128, 56, 84), dtype="float32"):
-            gv = R.call_tir(conv2d_transpose, (x, w), out_sinfo=R.Tensor((2, 128, 56, 84), dtype="float32"))
+            gv = R.call_tir(Expected.conv2d_transpose, (x, w), out_sinfo=R.Tensor((2, 128, 56, 84), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -275,7 +275,7 @@ def test_conv2d_transpose_with_out_dtype():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((3, 4, 3, 3), dtype="float32")) -> R.Tensor((2, 4, 30, 30), dtype="float16"):
-            gv = R.call_tir(conv2d_transpose, (x, w), out_sinfo=R.Tensor((2, 4, 30, 30), dtype="float16"))
+            gv = R.call_tir(Expected.conv2d_transpose, (x, w), out_sinfo=R.Tensor((2, 4, 30, 30), dtype="float16"))
             return gv
 
         @T.prim_func
@@ -337,7 +337,7 @@ def test_conv2d_transpose_symbolic():
             w = T.Var("w", "int64")
             kw = T.Var("kw", "int64")
             f = T.Var("f", "int64")
-            gv = R.call_tir(conv2d_transpose, (x, kernel), out_sinfo=R.Tensor((n, c, h * 3 + kh - 3, w * 3 + kw - 3), dtype="float32"))
+            gv = R.call_tir(Expected.conv2d_transpose, (x, kernel), out_sinfo=R.Tensor((n, c, h * 3 + kh - 3, w * 3 + kw - 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -402,7 +402,7 @@ def test_max_pool2d():
     class Expected:
         @R.function
         def main(x: R.Tensor((4, 112, 112, 6), "float32")) -> R.Tensor((4, 56, 56, 6), "float32"):
-            gv = R.call_tir(max_pool2d, (x,), R.Tensor((4, 56, 56, 6), dtype="float32"))
+            gv = R.call_tir(Expected.max_pool2d, (x,), R.Tensor((4, 56, 56, 6), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -443,7 +443,7 @@ def test_max_pool2d_NCHW16c():
     class Expected:
         @R.function
         def main(x: R.Tensor((4, 4, 112, 112, 16), "float32")) -> R.Tensor((4, 4, 110, 110, 16), "float32"):
-            gv = R.call_tir(max_pool2d, (x,), R.Tensor((4, 4, 110, 110, 16), dtype="float32"))
+            gv = R.call_tir(Expected.max_pool2d, (x,), R.Tensor((4, 4, 110, 110, 16), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -477,7 +477,7 @@ def test_max_pool2d_ceil_mode():
     class Expected:
         @R.function
         def main(x: R.Tensor((4, 6, 112, 112), dtype="float32")) -> R.Tensor((4, 6, 38, 38), dtype="float32"):
-            gv = R.call_tir(max_pool2d, (x,), R.Tensor((4, 6, 38, 38), dtype="float32"))
+            gv = R.call_tir(Expected.max_pool2d, (x,), R.Tensor((4, 6, 38, 38), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -568,7 +568,7 @@ def test_avg_pool2d():
 
         @R.function
         def main(x: R.Tensor((4, 112, 112, 6), dtype="float32")) -> R.Tensor((4, 56, 56, 6), dtype="float32"):
-            gv = R.call_tir(avg_pool2d, (x,), out_sinfo=R.Tensor((4, 56, 56, 6), dtype="float32"))
+            gv = R.call_tir(Expected.avg_pool2d, (x,), out_sinfo=R.Tensor((4, 56, 56, 6), dtype="float32"))
             return gv
     # fmt: on
 
@@ -610,7 +610,7 @@ def test_avg_pool2d_NCHW16c():
 
         @R.function
         def main(x: R.Tensor((4, 4, 112, 112, 16), dtype="float32")) -> R.Tensor((4, 4, 110, 110, 16), dtype="float32"):
-            gv = R.call_tir(avg_pool2d, (x,), out_sinfo=R.Tensor((4, 4, 110, 110, 16), dtype="float32"))
+            gv = R.call_tir(Expected.avg_pool2d, (x,), out_sinfo=R.Tensor((4, 4, 110, 110, 16), dtype="float32"))
             return gv
     # fmt: on
 
@@ -659,7 +659,7 @@ def test_avg_pool2d_ceil_mode():
 
         @R.function
         def main(x: R.Tensor((4, 6, 112, 112), dtype="float32")) -> R.Tensor((4, 6, 38, 38), dtype="float32"):
-            gv = R.call_tir(avg_pool2d, (x,), out_sinfo=R.Tensor((4, 6, 38, 38), dtype="float32"))
+            gv = R.call_tir(Expected.avg_pool2d, (x,), out_sinfo=R.Tensor((4, 6, 38, 38), dtype="float32"))
             return gv
 
     # fmt: on
@@ -703,7 +703,7 @@ def test_adaptive_avg_pool2d():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 4, 7, 7, 16), "float32")) -> R.Tensor((2, 4, 1, 1, 16), "float32"):
-            gv = R.call_tir(adaptive_avg_pool2d, (x,), R.Tensor((2, 4, 1, 1, 16), dtype="float32"))
+            gv = R.call_tir(Expected.adaptive_avg_pool2d, (x,), R.Tensor((2, 4, 1, 1, 16), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -744,7 +744,7 @@ def test_adaptive_avg_pool2d_without_output_size():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 16, 7, 7), "float32")) -> R.Tensor((2, 16, 7, 7), "float32"):
-            gv = R.call_tir(adaptive_avg_pool2d, (x,), R.Tensor((2, 16, 7, 7), dtype="float32"))
+            gv = R.call_tir(Expected.adaptive_avg_pool2d, (x,), R.Tensor((2, 16, 7, 7), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -804,7 +804,7 @@ def test_relu():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(relu, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.relu, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -839,7 +839,7 @@ def test_relu_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(relu, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.relu, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -874,7 +874,7 @@ def test_gelu():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(gelu, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.gelu, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -937,7 +937,7 @@ def test_gelu_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(gelu, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.gelu, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1000,7 +1000,7 @@ def test_silu():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(silu, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.silu, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1042,7 +1042,7 @@ def test_silu_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(silu, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.silu, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1084,7 +1084,7 @@ def test_softmax():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 16, 32), "float32")) -> R.Tensor((2, 3, 16, 32), "float32"):
-            gv = R.call_tir(softmax, (x,), R.Tensor((2, 3, 16, 32), dtype="float32"))
+            gv = R.call_tir(Expected.softmax, (x,), R.Tensor((2, 3, 16, 32), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1147,7 +1147,7 @@ def test_softmax_symbolic():
             a = T.int64()
             b = T.int64()
             c = T.int64()
-            gv = R.call_tir(softmax, (x,), R.Tensor((a, b, c), dtype="float32"))
+            gv = R.call_tir(Expected.softmax, (x,), R.Tensor((a, b, c), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1209,7 +1209,7 @@ def test_log_softmax():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 16, 32), dtype="float32")) -> R.Tensor((2, 3, 16, 32), dtype="float32"):
-            gv = R.call_tir(log_softmax, (x,), R.Tensor((2, 3, 16, 32), dtype="float32"))
+            gv = R.call_tir(Expected.log_softmax, (x,), R.Tensor((2, 3, 16, 32), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1266,7 +1266,7 @@ def test_log_softmax_symbolic():
             b = T.int64()
             c = T.int64()
             # block 0
-            gv = R.call_tir(log_softmax, (x,), R.Tensor((a, b, c), dtype="float32"))
+            gv = R.call_tir(Expected.log_softmax, (x,), R.Tensor((a, b, c), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1321,7 +1321,7 @@ def test_cross_entropy_with_logits():
     class Expected:
         @R.function
         def main(x: R.Tensor((3,), dtype="float32"), y: R.Tensor((3,), dtype="float32")) -> R.Tensor(dtype="float32", ndim=2):
-            gv = R.call_tir(cross_entropy_with_logits, (x, y), R.Tensor((), dtype="float32"))
+            gv = R.call_tir(Expected.cross_entropy_with_logits, (x, y), R.Tensor((), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1367,7 +1367,7 @@ def test_cross_entropy_with_logits_batch():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="float32")) -> R.Tensor(dtype="float32", ndim=2):
-            gv = R.call_tir(cross_entropy_with_logits, (x, y), R.Tensor((), dtype="float32"))
+            gv = R.call_tir(Expected.cross_entropy_with_logits, (x, y), R.Tensor((), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1421,7 +1421,7 @@ def test_cross_entropy_with_logits_batch_symbolic():
     class Expected:
         @R.function
         def main(x: R.Tensor(("n", "m"), dtype="float32"), y: R.Tensor(("n", "m"), dtype="float32")) -> R.Tensor(dtype="float32", ndim=2):
-            gv = R.call_tir(cross_entropy_with_logits, (x, y), R.Tensor((), dtype="float32"))
+            gv = R.call_tir(Expected.cross_entropy_with_logits, (x, y), R.Tensor((), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1477,7 +1477,7 @@ def test_batch_norm():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 28, 28), "float32"), gamma: R.Tensor((3,), "float32"), beta: R.Tensor((3,), "float32"), moving_mean: R.Tensor((3,), "float32"), moving_var: R.Tensor((3,), "float32")) -> R.Tuple(R.Tensor((2, 3, 28, 28), "float32"), R.Tensor((3,), "float32"), R.Tensor((3,), "float32")):
-            gv = R.call_tir(batch_norm, (x, gamma, beta, moving_mean, moving_var), [R.Tensor((2, 3, 28, 28), "float32"), R.Tensor((3,), "float32"), R.Tensor((3,), "float32")])
+            gv = R.call_tir(Expected.batch_norm, (x, gamma, beta, moving_mean, moving_var), [R.Tensor((2, 3, 28, 28), "float32"), R.Tensor((3,), "float32"), R.Tensor((3,), "float32")])
             return gv
 
         @T.prim_func
@@ -1591,7 +1591,7 @@ def test_batch_norm_symbolic():
             h = T.int64()
             w = T.int64()
             c = T.int64()
-            gv = R.call_tir(batch_norm, (x, gamma, beta, moving_mean, moving_var), [R.Tensor((n, h, w, c), "float32"), R.Tensor((c,), "float32"), R.Tensor((c,), "float32")])
+            gv = R.call_tir(Expected.batch_norm, (x, gamma, beta, moving_mean, moving_var), [R.Tensor((n, h, w, c), "float32"), R.Tensor((c,), "float32"), R.Tensor((c,), "float32")])
             return gv
 
         @T.prim_func
@@ -1709,7 +1709,7 @@ def test_layer_norm():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), "float32"), gamma: R.Tensor((4, 5), "float32"), beta: R.Tensor((4, 5), "float32")) -> R.Tensor((2, 3, 4, 5), "float32"):
-            gv = R.call_tir(layer_norm, (x, gamma, beta), R.Tensor((2, 3, 4, 5), dtype="float32"))
+            gv = R.call_tir(Expected.layer_norm, (x, gamma, beta), R.Tensor((2, 3, 4, 5), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1759,7 +1759,7 @@ def test_layer_norm_symbolic():
             n = T.int64()
             s = T.int64()
             f = T.int64()
-            gv = R.call_tir(layer_norm, (x, gamma, beta), R.Tensor((n, s, f), dtype="float32"))
+            gv = R.call_tir(Expected.layer_norm, (x, gamma, beta), R.Tensor((n, s, f), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1862,7 +1862,7 @@ def test_group_norm():
 
         @R.function
         def main(x: R.Tensor((2, 4, 4, 5), dtype="float32"), gamma: R.Tensor((4,), dtype="float32"), beta: R.Tensor((4,), dtype="float32")) -> R.Tensor((2, 4, 4, 5), dtype="float32"):
-            gv = R.call_tir(group_norm, (x, gamma, beta), out_sinfo=R.Tensor((2, 4, 4, 5), dtype="float32"))
+            gv = R.call_tir(Expected.group_norm, (x, gamma, beta), out_sinfo=R.Tensor((2, 4, 4, 5), dtype="float32"))
             return gv
     # fmt: on
 
@@ -1951,7 +1951,7 @@ def test_group_norm_symbolic():
             c = T.int64()
             h = T.int64()
             w = T.int64()
-            gv = R.call_tir(group_norm, (x, gamma, beta), out_sinfo=R.Tensor((n, 4 * c, h, w), dtype="float32"), tir_vars=R.shape([c]))
+            gv = R.call_tir(Expected.group_norm, (x, gamma, beta), out_sinfo=R.Tensor((n, 4 * c, h, w), dtype="float32"), tir_vars=R.shape([c]))
             return gv
     # fmt: on
 

--- a/tests/python/relax/test_transform_legalize_ops_search_statistical.py
+++ b/tests/python/relax/test_transform_legalize_ops_search_statistical.py
@@ -37,7 +37,7 @@ def test_where():
     class Expected:
         @R.function
         def main(condition: R.Tensor((3, 2, 1), "bool"), x: R.Tensor((2, 3), "float32"), y: R.Tensor((2, 1), "float32")) -> R.Tensor((3, 2, 3), "float32"):
-            gv = R.call_tir(where, (condition, x, y), R.Tensor((3, 2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.where, (condition, x, y), R.Tensor((3, 2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -74,7 +74,7 @@ def test_where_symbolic():
             a = T.int64()
             b = T.int64()
             c = T.int64()
-            gv = R.call_tir(where, (condition, x, y), R.Tensor((a, b, c), dtype="float32"))
+            gv = R.call_tir(Expected.where, (condition, x, y), R.Tensor((a, b, c), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -112,7 +112,7 @@ def test_argmax():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), dtype="float32")) -> R.Tensor((2, 4, 5), dtype="int64"):
-            gv = R.call_tir(argmax, (x,), out_sinfo=R.Tensor((2, 4, 5), dtype="int64"))
+            gv = R.call_tir(Expected.argmax, (x,), out_sinfo=R.Tensor((2, 4, 5), dtype="int64"))
             return gv
 
         @T.prim_func
@@ -163,7 +163,7 @@ def test_argmax_symbolic():
             a = T.int64()
             c = T.int64()
             d = T.int64()
-            gv = R.call_tir(argmax, (x,), out_sinfo=R.Tensor((a, 1, c, d), dtype="int64"))
+            gv = R.call_tir(Expected.argmax, (x,), out_sinfo=R.Tensor((a, 1, c, d), dtype="int64"))
             return gv
 
         @T.prim_func
@@ -238,7 +238,7 @@ def test_argmin():
 
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), dtype="float32")) -> R.Tensor((), dtype="int64"):
-            gv = R.call_tir(argmin, (x,), out_sinfo=R.Tensor((), dtype="int64"))
+            gv = R.call_tir(Expected.argmin, (x,), out_sinfo=R.Tensor((), dtype="int64"))
             return gv
     # fmt: on
 
@@ -288,7 +288,7 @@ def test_argmin_symbolic():
 
         @R.function
         def main(x: R.Tensor(("a", "b", "c", "d"), dtype="float32")) -> R.Tensor((1, 1, 1, 1), dtype="int64"):
-            gv = R.call_tir(argmin, (x,), out_sinfo=R.Tensor((1, 1, 1, 1), dtype="int64"))
+            gv = R.call_tir(Expected.argmin, (x,), out_sinfo=R.Tensor((1, 1, 1, 1), dtype="int64"))
             return gv
     # fmt: on
 
@@ -312,7 +312,7 @@ def test_max():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), "float32")) -> R.Tensor((2, 5), "float32"):
-            gv = R.call_tir(max, (x,), R.Tensor((2, 5), dtype="float32"))
+            gv = R.call_tir(Expected.max, (x,), R.Tensor((2, 5), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -349,7 +349,7 @@ def test_max_symbolic():
         def main(x: R.Tensor(("a", "b", "c", "d"), "float32")) -> R.Tensor(("a", "d"), "float32"):
             a = T.int64()
             d = T.int64()
-            gv = R.call_tir(max, (x,), R.Tensor((a, d), dtype="float32"))
+            gv = R.call_tir(Expected.max, (x,), R.Tensor((a, d), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -388,7 +388,7 @@ def test_min():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), "float32")) -> R.Tensor((2, 1, 1, 5), "float32"):
-            gv = R.call_tir(min, (x,), R.Tensor((2, 1, 1, 5), dtype="float32"))
+            gv = R.call_tir(Expected.min, (x,), R.Tensor((2, 1, 1, 5), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -425,7 +425,7 @@ def test_min_symbolic():
         def main(x: R.Tensor(("a", "b", "c", "d"), "float32")) -> R.Tensor(("a", 1, 1, "d"), "float32"):
             a = T.int64()
             d = T.int64()
-            gv = R.call_tir(min, (x,), R.Tensor((a, 1, 1, d), dtype="float32"))
+            gv = R.call_tir(Expected.min, (x,), R.Tensor((a, 1, 1, d), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -464,7 +464,7 @@ def test_sum():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), "float32")) -> R.Tensor((), "float32"):
-            gv = R.call_tir(sum, (x,), R.Tensor((), dtype="float32"))
+            gv = R.call_tir(Expected.sum, (x,), R.Tensor((), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -497,7 +497,7 @@ def test_sum_symbolic():
     class Expected:
         @R.function
         def main(x: R.Tensor(("a", "b", "c", "d"), "float32")) -> R.Tensor((), "float32"):
-            gv = R.call_tir(sum, (x,), R.Tensor((), dtype="float32"))
+            gv = R.call_tir(Expected.sum, (x,), R.Tensor((), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -535,7 +535,7 @@ def test_prod():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), "float32")) -> R.Tensor((1, 1, 1, 1), "float32"):
-            gv = R.call_tir(prod, (x,), R.Tensor((1, 1, 1, 1), dtype="float32"))
+            gv = R.call_tir(Expected.prod, (x,), R.Tensor((1, 1, 1, 1), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -568,7 +568,7 @@ def test_prod_symbolic():
     class Expected:
         @R.function
         def main(x: R.Tensor(("a", "b", "c", "d"), "float32")) -> R.Tensor((1, 1, 1, 1), "float32"):
-            gv = R.call_tir(prod, (x,), R.Tensor((1, 1, 1, 1), dtype="float32"))
+            gv = R.call_tir(Expected.prod, (x,), R.Tensor((1, 1, 1, 1), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -606,7 +606,7 @@ def test_mean():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), "float32")) -> R.Tensor((3, 4), "float32"):
-            gv = R.call_tir(mean, (x,), R.Tensor((3, 4), dtype="float32"))
+            gv = R.call_tir(Expected.mean, (x,), R.Tensor((3, 4), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -650,7 +650,7 @@ def test_mean_symbolic():
         def main(x: R.Tensor(("a", "b", "c", "d"), dtype="float32")) -> R.Tensor(("b", "c"), dtype="float32"):
             b = T.int64()
             c = T.int64()
-            gv = R.call_tir(mean, (x,), R.Tensor((b, c), dtype="float32"))
+            gv = R.call_tir(Expected.mean, (x,), R.Tensor((b, c), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -696,7 +696,7 @@ def test_std():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), "float32")) -> R.Tensor((), "float32"):
-            gv = R.call_tir(std, (x,), R.Tensor((), dtype="float32"))
+            gv = R.call_tir(Expected.std, (x,), R.Tensor((), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -770,7 +770,7 @@ def test_std_symbolic():
     class Expected:
         @R.function
         def main(x: R.Tensor(("a", "b", "c", "d"), "float32")) -> R.Tensor((), "float32"):
-            gv = R.call_tir(std, (x,), R.Tensor((), dtype="float32"))
+            gv = R.call_tir(Expected.std, (x,), R.Tensor((), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -849,7 +849,7 @@ def test_variance():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), dtype="float32")) -> R.Tensor((1, 3, 4, 1), dtype="float32"):
-            gv = R.call_tir(variance, (x,), R.Tensor((1, 3, 4, 1), dtype="float32"))
+            gv = R.call_tir(Expected.variance, (x,), R.Tensor((1, 3, 4, 1), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -923,7 +923,7 @@ def test_variance_symbolic():
         def main(x: R.Tensor(("a", "b", "c", "d"), "float32")) -> R.Tensor((1, "b", "c", 1), "float32"):
             b = T.int64()
             c = T.int64()
-            gv = R.call_tir(variance, (x,), R.Tensor((1, b, c, 1), dtype="float32"))
+            gv = R.call_tir(Expected.variance, (x,), R.Tensor((1, b, c, 1), dtype="float32"))
             return gv
 
         @T.prim_func

--- a/tests/python/relax/test_transform_legalize_ops_unary.py
+++ b/tests/python/relax/test_transform_legalize_ops_unary.py
@@ -36,7 +36,7 @@ def test_abs():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
-            gv = R.call_tir(tir_abs, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_abs, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -71,7 +71,7 @@ def test_abs_symbolic():
         def main(x: R.Tensor(("m", "n"), dtype="float32")) -> R.Tensor(("m", "n"), dtype="float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_abs, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_abs, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -116,7 +116,7 @@ def test_ceil():
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
-            gv = R.call_tir(tir_ceil, (x,), out_sinfo=R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_ceil, (x,), out_sinfo=R.Tensor((2, 3), dtype="float32"))
             return gv
     # fmt: on
 
@@ -147,7 +147,7 @@ def test_ceil_int():
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="int32")) -> R.Tensor((2, 3), dtype="int32"):
-            gv = R.call_tir(tir_ceil, (x,), out_sinfo=R.Tensor((2, 3), dtype="int32"))
+            gv = R.call_tir(Expected.tir_ceil, (x,), out_sinfo=R.Tensor((2, 3), dtype="int32"))
             return gv
     # fmt: on
 
@@ -186,7 +186,7 @@ def test_ceil_symbolic():
         def main(x: R.Tensor(("m", "n"), dtype="float32")) -> R.Tensor(("m", "n"), dtype="float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_ceil, (x,), out_sinfo=R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_ceil, (x,), out_sinfo=R.Tensor((m, n), dtype="float32"))
             return gv
     # fmt: on
 
@@ -207,7 +207,7 @@ def test_cos():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(tir_cos, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_cos, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -242,7 +242,7 @@ def test_cos_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_cos, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_cos, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -277,7 +277,7 @@ def test_exp():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
-            gv = R.call_tir(tir_exp, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_exp, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -312,7 +312,7 @@ def test_exp_symbolic():
         def main(x: R.Tensor(("m", "n"), dtype="float32")) -> R.Tensor(("m", "n"), dtype="float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_exp, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_exp, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -357,7 +357,7 @@ def test_floor():
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
-            gv = R.call_tir(tir_floor, (x,), out_sinfo=R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_floor, (x,), out_sinfo=R.Tensor((2, 3), dtype="float32"))
             return gv
     # fmt: on
 
@@ -388,7 +388,7 @@ def test_floor_int():
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="int32")) -> R.Tensor((2, 3), dtype="int32"):
-            gv = R.call_tir(tir_floor, (x,), out_sinfo=R.Tensor((2, 3), dtype="int32"))
+            gv = R.call_tir(Expected.tir_floor, (x,), out_sinfo=R.Tensor((2, 3), dtype="int32"))
             return gv
     # fmt: on
 
@@ -427,7 +427,7 @@ def test_floor_symbolic():
         def main(x: R.Tensor(("m", "n"), dtype="float32")) -> R.Tensor(("m", "n"), dtype="float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_floor, (x,), out_sinfo=R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_floor, (x,), out_sinfo=R.Tensor((m, n), dtype="float32"))
             return gv
     # fmt: on
 
@@ -448,7 +448,7 @@ def test_log():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(tir_log, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_log, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -483,7 +483,7 @@ def test_log_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_log, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_log, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -518,7 +518,7 @@ def test_negative():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(tir_negative, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_negative, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -553,7 +553,7 @@ def test_negative_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_negative, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_negative, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -598,7 +598,7 @@ def test_round():
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
-            gv = R.call_tir(tir_round, (x,), out_sinfo=R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_round, (x,), out_sinfo=R.Tensor((2, 3), dtype="float32"))
             return gv
     # fmt: on
 
@@ -629,7 +629,7 @@ def test_round_int():
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="int32")) -> R.Tensor((2, 3), dtype="int32"):
-            gv = R.call_tir(tir_round, (x,), out_sinfo=R.Tensor((2, 3), dtype="int32"))
+            gv = R.call_tir(Expected.tir_round, (x,), out_sinfo=R.Tensor((2, 3), dtype="int32"))
             return gv
     # fmt: on
 
@@ -668,7 +668,7 @@ def test_round_symbolic():
         def main(x: R.Tensor(("m", "n"), dtype="float32")) -> R.Tensor(("m", "n"), dtype="float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_round, (x,), out_sinfo=R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_round, (x,), out_sinfo=R.Tensor((m, n), dtype="float32"))
             return gv
     # fmt: on
 
@@ -689,7 +689,7 @@ def test_sigmoid():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(tir_sigmoid, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_sigmoid, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -724,7 +724,7 @@ def test_sigmoid_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_sigmoid, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_sigmoid, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -769,7 +769,7 @@ def test_sign():
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
-            gv = R.call_tir(tir_sign, (x,), out_sinfo=R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_sign, (x,), out_sinfo=R.Tensor((2, 3), dtype="float32"))
             return gv
     # fmt: on
 
@@ -800,7 +800,7 @@ def test_sign_int():
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="int32")) -> R.Tensor((2, 3), dtype="int32"):
-            gv = R.call_tir(tir_sign, (x,), out_sinfo=R.Tensor((2, 3), dtype="int32"))
+            gv = R.call_tir(Expected.tir_sign, (x,), out_sinfo=R.Tensor((2, 3), dtype="int32"))
             return gv
     # fmt: on
 
@@ -839,7 +839,7 @@ def test_sign_symbolic():
         def main(x: R.Tensor(("m", "n"), dtype="float32")) -> R.Tensor(("m", "n"), dtype="float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_sign, (x,), out_sinfo=R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_sign, (x,), out_sinfo=R.Tensor((m, n), dtype="float32"))
             return gv
     # fmt: on
 
@@ -860,7 +860,7 @@ def test_sin():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(tir_sin, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_sin, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -895,7 +895,7 @@ def test_sin_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_sin, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_sin, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -930,7 +930,7 @@ def test_sqrt():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(tir_sqrt, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_sqrt, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -965,7 +965,7 @@ def test_sqrt_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_sqrt, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_sqrt, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1000,7 +1000,7 @@ def test_tanh():
     class Expected:
         @R.function
         def main(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
-            gv = R.call_tir(tir_tanh, (x,), R.Tensor((2, 3), dtype="float32"))
+            gv = R.call_tir(Expected.tir_tanh, (x,), R.Tensor((2, 3), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1035,7 +1035,7 @@ def test_tanh_symbolic():
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor(("m", "n"), "float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_tanh, (x,), R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_tanh, (x,), R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func
@@ -1073,7 +1073,7 @@ def test_clip_symbolic():
         def main(x: R.Tensor(("m", "n"), dtype="float32")) -> R.Tensor(("m", "n"), dtype="float32"):
             m = T.int64()
             n = T.int64()
-            gv = R.call_tir(tir_clip, (x,), out_sinfo=R.Tensor((m, n), dtype="float32"))
+            gv = R.call_tir(Expected.tir_clip, (x,), out_sinfo=R.Tensor((m, n), dtype="float32"))
             return gv
 
         @T.prim_func

--- a/tests/python/relax/test_transform_lift_transform_params.py
+++ b/tests/python/relax/test_transform_lift_transform_params.py
@@ -42,9 +42,10 @@ def test_basic():
             w2: R.Tensor((16, 16, 3, 3), "float32"),
         ) -> R.Tensor((1, 16, 224, 224), "float32"):
             R.func_attr({"num_input": 1})
+            cls = Before
             with R.dataflow():
                 w1_transformed = R.call_tir(
-                    transform_layout_IOHW_to_OIHW, w1, R.Tensor((16, 3, 3, 3), "float32")
+                    cls.transform_layout_IOHW_to_OIHW, w1, R.Tensor((16, 3, 3, 3), "float32")
                 )
                 conv1 = R.nn.conv2d(
                     x, w1_transformed, padding=(1, 1), data_layout="NCHW", kernel_layout="OIHW"
@@ -113,11 +114,12 @@ def test_basic():
         ) -> R.Tuple(
             R.Tensor((16, 16, 3, 3), dtype="float32"), R.Tensor((16, 3, 3, 3), dtype="float32")
         ):
+            cls = Expected
             with R.dataflow():
                 lv: R.Tensor((16, 16, 3, 3), dtype="float32") = params[1]
                 lv1: R.Tensor((3, 16, 3, 3), dtype="float32") = params[0]
                 lv2 = R.call_tir(
-                    transform_layout_IOHW_to_OIHW,
+                    cls.transform_layout_IOHW_to_OIHW,
                     (lv1,),
                     out_sinfo=R.Tensor((16, 3, 3, 3), dtype="float32"),
                 )

--- a/tests/python/relax/test_transform_merge_composite_functions.py
+++ b/tests/python/relax/test_transform_merge_composite_functions.py
@@ -29,13 +29,14 @@ class Conv2dReLUx2:
         weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
         weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        cls = Conv2dReLUx2
         with R.dataflow():
-            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu(
-                data, weight1
-            )
-            gv: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d_relax_nn_relu1(
-                lv, weight2
-            )
+            lv: R.Tensor(
+                (1, 64, 56, 56), dtype="float32"
+            ) = cls.fused_relax_nn_conv2d_relax_nn_relu(data, weight1)
+            gv: R.Tensor(
+                (1, 64, 54, 54), dtype="float32"
+            ) = cls.fused_relax_nn_conv2d_relax_nn_relu1(lv, weight2)
             R.output(gv)
         return gv
 
@@ -80,10 +81,11 @@ class Conv2dReLUx2_merged:
         weight1: R.Tensor((64, 64, 3, 3), dtype="float32"),
         weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        cls = Conv2dReLUx2_merged
         with R.dataflow():
             gv: R.Tensor(
                 (1, 64, 54, 54), dtype="float32"
-            ) = fused_relax_nn_conv2d_relax_nn_relu_relax_nn_conv2d_relax_nn_relu1(
+            ) = cls.fused_relax_nn_conv2d_relax_nn_relu_relax_nn_conv2d_relax_nn_relu1(
                 data, weight1, weight2
             )
             R.output(gv)
@@ -150,11 +152,14 @@ class Diamond:
         data: R.Tensor((1, 64, 56, 56), dtype="float32"),
         weight: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        cls = Diamond
         with R.dataflow():
-            lv2: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d(data, weight)
-            lv3: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_relu(lv2)
-            lv4: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_gelu(lv2)
-            gv2: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_add(lv3, lv4)
+            lv2: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_nn_conv2d(
+                data, weight
+            )
+            lv3: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_nn_relu(lv2)
+            lv4: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_nn_gelu(lv2)
+            gv2: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_add(lv3, lv4)
             R.output(gv2)
         return gv2
 
@@ -299,11 +304,11 @@ class Diamond_merged:
         data2: R.Tensor((1, 64, 56, 56), dtype="float32"),
         weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
-        # block 0
+        cls = Diamond_merged
         with R.dataflow():
             gv5: R.Tensor(
                 (1, 64, 54, 54), dtype="float32"
-            ) = fused_relax_nn_conv2d_relax_nn_relu_relax_nn_gelu_relax_add(data2, weight2)
+            ) = cls.fused_relax_nn_conv2d_relax_nn_relu_relax_nn_gelu_relax_add(data2, weight2)
             R.output(gv5)
         return gv5
 
@@ -315,11 +320,14 @@ class Diamond_cyclic_dep:
         data: R.Tensor((1, 64, 56, 56), dtype="float32"),
         weight: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        cls = Diamond_cyclic_dep
         with R.dataflow():
-            lv2: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_conv2d(data, weight)
-            lv3: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_relu(lv2)
-            lv4: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_gelu(lv2)
-            gv2: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_add(lv3, lv4)
+            lv2: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_nn_conv2d(
+                data, weight
+            )
+            lv3: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_nn_relu(lv2)
+            lv4: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_nn_gelu(lv2)
+            gv2: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_add(lv3, lv4)
             R.output(gv2)
         return gv2
 
@@ -377,15 +385,16 @@ class Diamond_cyclic_dep_merged:
         data2: R.Tensor((1, 64, 56, 56), dtype="float32"),
         weight2: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 54, 54), dtype="float32"):
+        cls = Diamond_cyclic_dep_merged
         with R.dataflow():
             lv4: R.Tuple(
                 R.Tensor((1, 64, 54, 54), dtype="float32"),
                 R.Tensor((1, 64, 54, 54), dtype="float32"),
-            ) = fused_relax_nn_conv2d_relax_nn_relu(data2, weight2)
+            ) = cls.fused_relax_nn_conv2d_relax_nn_relu(data2, weight2)
             lv12: R.Tensor((1, 64, 54, 54), dtype="float32") = lv4[0]
             lv22: R.Tensor((1, 64, 54, 54), dtype="float32") = lv4[1]
-            lv31: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_nn_gelu1(lv12)
-            gv5: R.Tensor((1, 64, 54, 54), dtype="float32") = fused_relax_add1(lv22, lv31)
+            lv31: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_nn_gelu1(lv12)
+            gv5: R.Tensor((1, 64, 54, 54), dtype="float32") = cls.fused_relax_add1(lv22, lv31)
             R.output(gv5)
         return gv5
 
@@ -489,12 +498,13 @@ class MultipleProducers:
     def main(
         x1: R.Tensor((10,), dtype="float32"), x2: R.Tensor((10,), dtype="float32")
     ) -> R.Tensor((10,), dtype="float32"):
+        cls = MultipleProducers
         with R.dataflow():
-            lv1: R.Tensor((10,), dtype="float32") = fused_relax_nn_relu(x1)
-            lv2: R.Tensor((10,), dtype="float32") = fused_relax_nn_gelu(x2)
-            lv3: R.Tensor((10,), dtype="float32") = fused_relax_nn_relu(lv1)
-            lv4: R.Tensor((10,), dtype="float32") = fused_relax_nn_gelu(lv2)
-            gv1: R.Tensor((10,), dtype="float32") = fused_relax_add(lv3, lv4)
+            lv1: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_relu(x1)
+            lv2: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_gelu(x2)
+            lv3: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_relu(lv1)
+            lv4: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_gelu(lv2)
+            gv1: R.Tensor((10,), dtype="float32") = cls.fused_relax_add(lv3, lv4)
             R.output(gv1)
         return gv1
 
@@ -592,11 +602,13 @@ class MultipleProducers_merged:
     def main(
         x12: R.Tensor((10,), dtype="float32"), x22: R.Tensor((10,), dtype="float32")
     ) -> R.Tensor((10,), dtype="float32"):
-        # block 0
+        cls = MultipleProducers_merged
         with R.dataflow():
             gv4: R.Tensor(
                 (10,), dtype="float32"
-            ) = fused_relax_nn_relu_relax_nn_gelu_relax_nn_relu_relax_nn_gelu_relax_add(x12, x22)
+            ) = cls.fused_relax_nn_relu_relax_nn_gelu_relax_nn_relu_relax_nn_gelu_relax_add(
+                x12, x22
+            )
             R.output(gv4)
         return gv4
 
@@ -605,11 +617,12 @@ class MultipleProducers_merged:
 class MultipleProducersCyclic:
     @R.function
     def main(x1: R.Tensor((10,), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
+        cls = MultipleProducersCyclic
         with R.dataflow():
-            lv1: R.Tensor((10,), dtype="float32") = fused_relax_nn_relu(x1)
+            lv1: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_relu(x1)
             lv2: R.Tensor((10,), dtype="float32") = R.nn.relu(lv1)
-            lv3: R.Tensor((10,), dtype="float32") = fused_relax_nn_gelu(lv2)
-            gv1: R.Tensor((10,), dtype="float32") = fused_relax_add(lv1, lv3)
+            lv3: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_gelu(lv2)
+            gv1: R.Tensor((10,), dtype="float32") = cls.fused_relax_add(lv1, lv3)
             R.output(gv1)
         return gv1
 
@@ -648,11 +661,11 @@ class MultipleProducersCyclic:
 class MultipleProducersCyclic_merged:
     @R.function
     def main(x1: R.Tensor((10,), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
-        # block 0
+        cls = MultipleProducersCyclic_merged
         with R.dataflow():
-            lv: R.Tensor((10,), dtype="float32") = fused_relax_nn_relu1(x1)
+            lv: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_relu1(x1)
             lv2: R.Tensor((10,), dtype="float32") = R.nn.relu(lv)
-            gv: R.Tensor((10,), dtype="float32") = fused_relax_nn_gelu_relax_add(lv2, lv)
+            gv: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_gelu_relax_add(lv2, lv)
             R.output(gv)
         return gv
 
@@ -733,14 +746,15 @@ class MergeCompilerRegionsExample:
         x2: R.Tensor((10,), dtype="float32"),
         x3: R.Tensor((10,), dtype="float32"),
     ) -> R.Tensor((10,), dtype="float32"):
+        cls = MergeCompilerRegionsExample
         with R.dataflow():
-            lv: R.Tensor((10,), dtype="float32") = fused_relax_add(x1, x2)
-            lv1: R.Tensor((10,), dtype="float32") = fused_relax_nn_gelu(x3)
-            lv11: R.Tensor((10,), dtype="float32") = fused_relax_add(lv, lv1)
-            lv12: R.Tensor((10,), dtype="float32") = fused_relax_nn_gelu(lv11)
-            lv2: R.Tensor((10,), dtype="float32") = fused_relax_nn_relu(lv11)
-            lv21: R.Tensor((10,), dtype="float32") = fused_relax_add(lv12, lv2)
-            gv1: R.Tensor((10,), dtype="float32") = fused_relax_nn_relu(lv21)
+            lv: R.Tensor((10,), dtype="float32") = cls.fused_relax_add(x1, x2)
+            lv1: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_gelu(x3)
+            lv11: R.Tensor((10,), dtype="float32") = cls.fused_relax_add(lv, lv1)
+            lv12: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_gelu(lv11)
+            lv2: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_relu(lv11)
+            lv21: R.Tensor((10,), dtype="float32") = cls.fused_relax_add(lv12, lv2)
+            gv1: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_relu(lv21)
             R.output(gv1)
         return gv1
 
@@ -881,15 +895,16 @@ class MergeCompilerRegionsExampleRef:
         x22: R.Tensor((10,), dtype="float32"),
         x32: R.Tensor((10,), dtype="float32"),
     ) -> R.Tensor((10,), dtype="float32"):
+        cls = MergeCompilerRegionsExampleRef
         with R.dataflow():
-            lv5: R.Tensor((10,), dtype="float32") = fused_relax_nn_gelu1(x32)
+            lv5: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_gelu1(x32)
             lv13: R.Tuple(
                 R.Tensor((10,), dtype="float32"), R.Tensor((10,), dtype="float32")
-            ) = fused_relax_add_relax_add_relax_nn_relu(x12, x22, lv5)
+            ) = cls.fused_relax_add_relax_add_relax_nn_relu(x12, x22, lv5)
             lv23: R.Tensor((10,), dtype="float32") = lv13[0]
             lv32: R.Tensor((10,), dtype="float32") = lv13[1]
-            lv41: R.Tensor((10,), dtype="float32") = fused_relax_nn_gelu1(lv23)
-            gv6: R.Tensor((10,), dtype="float32") = fused_relax_add_relax_nn_relu(lv41, lv32)
+            lv41: R.Tensor((10,), dtype="float32") = cls.fused_relax_nn_gelu1(lv23)
+            gv6: R.Tensor((10,), dtype="float32") = cls.fused_relax_add_relax_nn_relu(lv41, lv32)
             R.output(gv6)
         return gv6
 
@@ -901,8 +916,9 @@ class ModuleWithNonComposite:
         data: R.Tensor((1, 64, 56, 56), dtype="float32"),
         weight: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+        cls = ModuleWithNonComposite
         with R.dataflow():
-            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d(data, weight)
+            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = cls.fused_relax_nn_conv2d(data, weight)
             conv: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.relu(lv)
             R.output(conv)
         return conv
@@ -930,8 +946,11 @@ class ModuleWithNonComposite_ref:
         data: R.Tensor((1, 64, 56, 56), dtype="float32"),
         weight: R.Tensor((64, 64, 3, 3), dtype="float32"),
     ) -> R.Tensor((1, 64, 56, 56), dtype="float32"):
+        cls = ModuleWithNonComposite_ref
         with R.dataflow():
-            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = fused_relax_nn_conv2d1(data, weight)
+            lv: R.Tensor((1, 64, 56, 56), dtype="float32") = cls.fused_relax_nn_conv2d1(
+                data, weight
+            )
             conv: R.Tensor((1, 64, 56, 56), dtype="float32") = R.nn.relu(lv)
             R.output(conv)
         return conv

--- a/tests/python/relax/test_transform_meta_schedule_tuning.py
+++ b/tests/python/relax/test_transform_meta_schedule_tuning.py
@@ -60,9 +60,10 @@ class InputModule:
 
     @R.function
     def main(x: R.Tensor((32, 32), "float32"), w: R.Tensor((32, 32), "float32")) -> R.Tensor:
+        cls = InputModule
         with R.dataflow():
-            lv0 = R.call_tir(tir_matmul, (x, w), R.Tensor((32, 32), dtype="float32"))
-            lv1 = R.call_tir(tir_relu, (lv0), R.Tensor((32, 32), dtype="float32"))
+            lv0 = R.call_tir(cls.tir_matmul, (x, w), R.Tensor((32, 32), dtype="float32"))
+            lv1 = R.call_tir(cls.tir_relu, (lv0), R.Tensor((32, 32), dtype="float32"))
             R.output(lv1)
         return lv1
 

--- a/tests/python/relax/test_transform_remove_unused_funcs.py
+++ b/tests/python/relax/test_transform_remove_unused_funcs.py
@@ -52,7 +52,7 @@ def test_unused_relax_func():
         def main(
             x: R.Tensor((16, 16), "float32"), w: R.Tensor((16, 16), "float32")
         ) -> R.Tensor((16, 16), "float32"):
-            gv0 = R.call_tir(tir_add, (x, w), R.Tensor((16, 16), dtype="float32"))
+            gv0 = R.call_tir(InputModule.tir_add, (x, w), R.Tensor((16, 16), dtype="float32"))
             return gv0
 
     mod = InputModule
@@ -86,7 +86,7 @@ def test_unused_relax_func_custom_entry_func():
         def foo(
             x: R.Tensor((16, 16), "float32"), w: R.Tensor((16, 16), "float32")
         ) -> R.Tensor((16, 16), "float32"):
-            gv0 = R.call_tir(tir_add, (x, w), R.Tensor((16, 16), dtype="float32"))
+            gv0 = R.call_tir(InputModule.tir_add, (x, w), R.Tensor((16, 16), dtype="float32"))
             return gv0
 
     mod = InputModule
@@ -122,7 +122,7 @@ def test_unused_relax_func_symbolic_shape():
         @R.function
         def main(x: R.Tensor(("m", "n"), "float32"), w: R.Tensor(("n", "k"), "float32")):
             m, k = T.int64(), T.int64()
-            gv0 = R.call_tir(tir_add, (x, w), R.Tensor((m + 1, k), dtype="float32"))
+            gv0 = R.call_tir(InputModule.tir_add, (x, w), R.Tensor((m + 1, k), dtype="float32"))
             return gv0
 
     mod = InputModule
@@ -158,7 +158,7 @@ def test_unused_prim_func():
         def main(
             x: R.Tensor((16, 16), "float32"), w: R.Tensor((16, 16), "float32")
         ) -> R.Tensor((16, 16), "float32"):
-            gv0 = relax_add(x, w)
+            gv0 = InputModule.relax_add(x, w)
             return gv0
 
     mod = InputModule

--- a/tests/python/relax/test_transform_rewrite_dataflow_reshape.py
+++ b/tests/python/relax/test_transform_rewrite_dataflow_reshape.py
@@ -65,9 +65,12 @@ def test_reshape_expand_dims():
         def main(
             x: R.Tensor((8, 3), dtype="float32")
         ) -> R.Tensor((2, 1, 4, 1, 3), dtype="float32"):
+            cls = Module
             with R.dataflow():
-                y = R.call_tir(reshape, (x,), out_sinfo=R.Tensor((2, 4, 3), dtype="float32"))
-                z = R.call_tir(expand_dims, (y,), out_sinfo=R.Tensor((2, 1, 4, 1, 3), "float32"))
+                y = R.call_tir(cls.reshape, (x,), out_sinfo=R.Tensor((2, 4, 3), dtype="float32"))
+                z = R.call_tir(
+                    cls.expand_dims, (y,), out_sinfo=R.Tensor((2, 1, 4, 1, 3), "float32")
+                )
                 R.output(z)
             return z
 
@@ -114,11 +117,12 @@ def test_reshape_expand_dims():
             x: R.Tensor((8, 3), dtype="float32")
         ) -> R.Tensor((2, 1, 4, 1, 3), dtype="float32"):
             with R.dataflow():
+                cls = Expected
                 y: R.Tensor((2, 4, 3), "float32") = R.reshape(x, (2, 4, 3))
                 # Note: `z` is the output var of the dataflow block, and is thus
                 # not expected to be rewritten.
                 z = R.call_tir(
-                    expand_dims, (y,), out_sinfo=R.Tensor((2, 1, 4, 1, 3), dtype="float32")
+                    cls.expand_dims, (y,), out_sinfo=R.Tensor((2, 1, 4, 1, 3), dtype="float32")
                 )
                 R.output(z)
             return z
@@ -153,7 +157,8 @@ def test_reshape_non_dataflow():
 
         @R.function
         def main(x: R.Tensor((8, 3), dtype="float32")) -> R.Tensor((2, 4, 3), dtype="float32"):
-            y = R.call_tir(reshape, (x,), out_sinfo=R.Tensor((2, 4, 3), dtype="float32"))
+            cls = Module
+            y = R.call_tir(cls.reshape, (x,), out_sinfo=R.Tensor((2, 4, 3), dtype="float32"))
             return y
 
     assert relax.analysis.has_reshape_pattern(Module["reshape"])

--- a/tests/python/relax/test_transform_static_plan_block_memory.py
+++ b/tests/python/relax/test_transform_static_plan_block_memory.py
@@ -51,21 +51,22 @@ def test_basic():
 
         @R.function
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
+            cls = Module
             alloc: R.Tensor((2, 4), dtype="float32") = R.builtin.alloc_tensor(R.shape([2, 4]), dtype="float32", runtime_device_index=0)
-            _: R.Tuple() = exp(x, alloc)
+            _: R.Tuple() = cls.exp(x, alloc)
             lv: R.Tensor((2, 4), dtype="float32") = alloc
             lv1: R.Tensor((8,), dtype="float32") = R.reshape(lv, (8,))
             alloc1: R.Tensor((8,), dtype="float32") = R.builtin.alloc_tensor(R.shape([8]), dtype="float32", runtime_device_index=0)
-            _1: R.Tuple() = relu(lv1, alloc1)
+            _1: R.Tuple() = cls.relu(lv1, alloc1)
             lv2: R.Tensor((8,), dtype="float32") = alloc1
             alloc2: R.Tensor((8,), dtype="float32") = R.builtin.alloc_tensor(R.shape([8]), dtype="float32", runtime_device_index=0)
-            _2: R.Tuple() = add(lv2, R.const(1, "float32"), alloc2)
+            _2: R.Tuple() = cls.add(lv2, R.const(1, "float32"), alloc2)
             lv3: R.Tensor((8,), dtype="float32") = alloc2
             alloc3: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor(R.shape([10]), dtype="float32", runtime_device_index=0)
-            _3: R.Tuple() = pad(lv3, alloc3)
+            _3: R.Tuple() = cls.pad(lv3, alloc3)
             lv4: R.Tensor((10,), dtype="float32") = alloc3
             alloc4: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor(R.shape([10]), dtype="float32", runtime_device_index=0)
-            _4: R.Tuple() = log(lv4, alloc4)
+            _4: R.Tuple() = cls.log(lv4, alloc4)
             gv: R.Tensor((10,), dtype="float32") = alloc4
             return gv
 
@@ -97,27 +98,28 @@ def test_basic():
 
         @R.function
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
+            cls = Expected
             storage: R.Object = R.memory.alloc_storage(R.shape([32]), virtual_device_index=0, storage_scope="global", dtype="float32")
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, 0, R.shape([2, 4]), dtype="float32")
-            _: R.Tuple() = exp(x, alloc)
+            _: R.Tuple() = cls.exp(x, alloc)
             lv: R.Tensor((2, 4), dtype="float32") = alloc
             lv1: R.Tensor((8,), dtype="float32") = R.reshape(lv, (8,))
             storage1: R.Object = R.memory.alloc_storage(R.shape([40]), virtual_device_index=0, storage_scope="global", dtype="float32")
             alloc1: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(storage1, 0, R.shape([8]), dtype="float32")
-            _1: R.Tuple() = relu(lv1, alloc1)
+            _1: R.Tuple() = cls.relu(lv1, alloc1)
             _2: R.Tuple() = R.memory.kill_tensor(alloc)
             _3: R.Tuple() = R.memory.kill_tensor(lv1)
             lv2: R.Tensor((8,), dtype="float32") = alloc1
             alloc2: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(storage, 0, R.shape([8]), dtype="float32")
-            _4: R.Tuple() = add(lv2, R.const(1, "float32"), alloc2)
+            _4: R.Tuple() = cls.add(lv2, R.const(1, "float32"), alloc2)
             _5: R.Tuple() = R.memory.kill_tensor(alloc1)
             lv3: R.Tensor((8,), dtype="float32") = alloc2
             alloc3: R.Tensor((10,), dtype="float32") = R.memory.alloc_tensor(storage1, 0, R.shape([10]), dtype="float32")
-            _6: R.Tuple() = pad(lv3, alloc3)
+            _6: R.Tuple() = cls.pad(lv3, alloc3)
             _7: R.Tuple() = R.memory.kill_tensor(alloc2)
             lv4: R.Tensor((10,), dtype="float32") = alloc3
             alloc4: R.Tensor((10,), dtype="float32") = R.builtin.alloc_tensor(R.shape([10]), dtype="float32", runtime_device_index=0)
-            _8: R.Tuple() = log(lv4, alloc4)
+            _8: R.Tuple() = cls.log(lv4, alloc4)
             _9: R.Tuple() = R.memory.kill_tensor(alloc3)
             gv5: R.Tensor((10,), dtype="float32") = alloc4
             _11: R.Tuple() = R.memory.kill_storage(storage)
@@ -152,15 +154,16 @@ def test_different_dtype():
         def main(
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="int32")
         ) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Module
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _: R.Tuple() = add(x, x, alloc)
+            _: R.Tuple() = cls.add(x, x, alloc)
             gv: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="int32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="int32", runtime_device_index=0
             )
-            _1: R.Tuple() = add1(y, y, alloc1)
+            _1: R.Tuple() = cls.add1(y, y, alloc1)
             gv1: R.Tensor((2, 3), dtype="int32") = alloc1
             return x
 
@@ -186,13 +189,14 @@ def test_different_dtype():
         def main(
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="int32")
         ) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Expected
             storage: R.Object = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage, 0, R.shape([2, 3]), dtype="float32"
             )
-            _: R.Tuple() = add(x, x, alloc)
+            _: R.Tuple() = cls.add(x, x, alloc)
             _1: R.Tuple() = R.memory.kill_tensor(alloc)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc
             storage1: R.Object = R.memory.alloc_storage(
@@ -201,7 +205,7 @@ def test_different_dtype():
             alloc1: R.Tensor((2, 3), dtype="int32") = R.memory.alloc_tensor(
                 storage1, 0, R.shape([2, 3]), dtype="int32"
             )
-            _2: R.Tuple() = add1(y, y, alloc1)
+            _2: R.Tuple() = cls.add1(y, y, alloc1)
             _3: R.Tuple() = R.memory.kill_tensor(alloc1)
             gv12: R.Tensor((2, 3), dtype="int32") = alloc1
             _5: R.Tuple() = R.memory.kill_storage(storage)
@@ -227,15 +231,16 @@ def test_same_dtype():
         def main(
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="float32")
         ) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Module
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _: R.Tuple() = add(x, x, alloc)
+            _: R.Tuple() = cls.add(x, x, alloc)
             gv: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _1: R.Tuple() = add(y, y, alloc1)
+            _1: R.Tuple() = cls.add(y, y, alloc1)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc1
             return x
 
@@ -253,19 +258,20 @@ def test_same_dtype():
         def main(
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="float32")
         ) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Expected
             storage: R.Object = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage, 0, R.shape([2, 3]), dtype="float32"
             )
-            _: R.Tuple() = add(x, x, alloc)
+            _: R.Tuple() = cls.add(x, x, alloc)
             _1: R.Tuple() = R.memory.kill_tensor(alloc)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage, 0, R.shape([2, 3]), dtype="float32"
             )
-            _2: R.Tuple() = add(y, y, alloc1)
+            _2: R.Tuple() = cls.add(y, y, alloc1)
             _3: R.Tuple() = R.memory.kill_tensor(alloc1)
             gv12: R.Tensor((2, 3), dtype="float32") = alloc1
             _4: R.Tuple() = R.memory.kill_storage(storage)
@@ -288,10 +294,11 @@ def test_if_cond():
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Module
             alloc: R.Tensor((), dtype="bool") = R.builtin.alloc_tensor(
                 R.shape([]), dtype="bool", runtime_device_index=0
             )
-            _: R.Tuple() = all_less_than_zero(x, alloc)
+            _: R.Tuple() = cls.all_less_than_zero(x, alloc)
             x1: R.Tensor((), dtype="bool") = alloc
             if x1:
                 y: R.Tensor((2, 3), dtype="float32") = x
@@ -299,7 +306,7 @@ def test_if_cond():
                 alloc1: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                     R.shape([2, 3]), dtype="float32", runtime_device_index=0
                 )
-                _1: R.Tuple() = exp(x, alloc1)
+                _1: R.Tuple() = cls.exp(x, alloc1)
                 gv3: R.Tensor((2, 3), dtype="float32") = alloc1
                 y: R.Tensor((2, 3), dtype="float32") = gv3
             return x
@@ -320,10 +327,11 @@ def test_if_then_else():
         def main(
             cond: R.Tensor((), dtype="bool"), x: R.Tensor((2, 3), dtype="float32")
         ) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Module
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _: R.Tuple() = exp(x, alloc)
+            _: R.Tuple() = cls.exp(x, alloc)
             y: R.Tensor((2, 3), dtype="float32") = alloc
             if cond:
                 z: R.Tensor((2, 3), dtype="float32") = y
@@ -347,23 +355,24 @@ def test_cross_block_use():
         def main(
             cond: R.Tensor((), dtype="bool"), x: R.Tensor((2, 3), dtype="float32")
         ) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Module
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _: R.Tuple() = exp(x, alloc)
+            _: R.Tuple() = cls.exp(x, alloc)
             y: R.Tensor((2, 3), dtype="float32") = alloc
             if cond:
                 alloc1: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                     R.shape([2, 3]), dtype="float32", runtime_device_index=0
                 )
-                _1: R.Tuple() = exp(y, alloc1)
+                _1: R.Tuple() = cls.exp(y, alloc1)
                 y2: R.Tensor((2, 3), dtype="float32") = alloc1
                 z: R.Tensor((2, 3), dtype="float32") = y2
             else:
                 alloc2: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                     R.shape([2, 3]), dtype="float32", runtime_device_index=0
                 )
-                _2: R.Tuple() = exp(y, alloc2)
+                _2: R.Tuple() = cls.exp(y, alloc2)
                 y2: R.Tensor((2, 3), dtype="float32") = alloc2
                 z: R.Tensor((2, 3), dtype="float32") = y2
             return x
@@ -385,17 +394,18 @@ def test_nested_tuple():
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _: R.Tuple() = exp(x, alloc)
+            cls = Module
+            _: R.Tuple() = cls.exp(x, alloc)
             y1: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _1: R.Tuple() = exp(x, alloc1)
+            _1: R.Tuple() = cls.exp(x, alloc1)
             y2: R.Tensor((2, 3), dtype="float32") = alloc1
             alloc2: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _2: R.Tuple() = exp(x, alloc2)
+            _2: R.Tuple() = cls.exp(x, alloc2)
             y3: R.Tensor((2, 3), dtype="float32") = alloc2
             t: R.Tuple(R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")) = (
                 y1,
@@ -414,17 +424,17 @@ def test_nested_tuple():
             alloc3: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _3: R.Tuple() = exp(y1_, alloc3)
+            _3: R.Tuple() = cls.exp(y1_, alloc3)
             z1: R.Tensor((2, 3), dtype="float32") = alloc3
             alloc4: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _4: R.Tuple() = exp(y2_, alloc4)
+            _4: R.Tuple() = cls.exp(y2_, alloc4)
             z2: R.Tensor((2, 3), dtype="float32") = alloc4
             alloc5: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _5: R.Tuple() = exp(y3_, alloc5)
+            _5: R.Tuple() = cls.exp(y3_, alloc5)
             z3: R.Tensor((2, 3), dtype="float32") = alloc5
             return x
 
@@ -436,13 +446,14 @@ def test_nested_tuple():
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Expected
             storage: R.Object = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage, 0, R.shape([2, 3]), dtype="float32"
             )
-            _: R.Tuple() = exp(x, alloc)
+            _: R.Tuple() = cls.exp(x, alloc)
             y1: R.Tensor((2, 3), dtype="float32") = alloc
             storage1: R.Object = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
@@ -450,7 +461,7 @@ def test_nested_tuple():
             alloc1: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage1, 0, R.shape([2, 3]), dtype="float32"
             )
-            _1: R.Tuple() = exp(x, alloc1)
+            _1: R.Tuple() = cls.exp(x, alloc1)
             y2: R.Tensor((2, 3), dtype="float32") = alloc1
             storage2: R.Object = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
@@ -458,7 +469,7 @@ def test_nested_tuple():
             alloc2: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage2, 0, R.shape([2, 3]), dtype="float32"
             )
-            _2: R.Tuple() = exp(x, alloc2)
+            _2: R.Tuple() = cls.exp(x, alloc2)
             y3: R.Tensor((2, 3), dtype="float32") = alloc2
             t: R.Tuple(R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")) = (
                 y1,
@@ -480,21 +491,21 @@ def test_nested_tuple():
             alloc3: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage3, 0, R.shape([2, 3]), dtype="float32"
             )
-            _3: R.Tuple() = exp(y1_, alloc3)
+            _3: R.Tuple() = cls.exp(y1_, alloc3)
             _4: R.Tuple() = R.memory.kill_tensor(alloc)
             _11: R.Tuple() = R.memory.kill_tensor(alloc3)
             z1: R.Tensor((2, 3), dtype="float32") = alloc3
             alloc4: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage, 0, R.shape([2, 3]), dtype="float32"
             )
-            _41: R.Tuple() = exp(y2_, alloc4)
+            _41: R.Tuple() = cls.exp(y2_, alloc4)
             _21: R.Tuple() = R.memory.kill_tensor(alloc1)
             _31: R.Tuple() = R.memory.kill_tensor(alloc4)
             z2: R.Tensor((2, 3), dtype="float32") = alloc4
             alloc5: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage3, 0, R.shape([2, 3]), dtype="float32"
             )
-            _5: R.Tuple() = exp(y3_, alloc5)
+            _5: R.Tuple() = cls.exp(y3_, alloc5)
             _42: R.Tuple() = R.memory.kill_tensor(alloc2)
             _51: R.Tuple() = R.memory.kill_tensor(alloc5)
             z3: R.Tensor((2, 3), dtype="float32") = alloc5
@@ -543,7 +554,7 @@ def test_symbolic_shape():
             alloc: R.Tensor((m, n), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([m, n]), dtype="float32", runtime_device_index=0
             )
-            _ = exp(x, alloc)
+            _ = Module.exp(x, alloc)
             y: R.Tensor((m, n), dtype="float32") = alloc
             return x
 
@@ -599,7 +610,7 @@ def test_reshape_param():
             alloc: R.Tensor((2, 25, 2), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 25, 2]), dtype="float32", runtime_device_index=0
             )
-            _: R.Tuple() = add(lv, lv1, alloc)
+            _: R.Tuple() = Module.add(lv, lv1, alloc)
             gv: R.Tensor((2, 25, 2), dtype="float32") = alloc
             return gv
 
@@ -631,15 +642,16 @@ def test_multiple_functions():
         def func1(
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="int32")
         ) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Module
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _: R.Tuple() = add(x, x, alloc)
+            _: R.Tuple() = cls.add(x, x, alloc)
             gv: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="int32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="int32", runtime_device_index=0
             )
-            _1: R.Tuple() = add1(y, y, alloc1)
+            _1: R.Tuple() = cls.add1(y, y, alloc1)
             gv1: R.Tensor((2, 3), dtype="int32") = alloc1
             return x
 
@@ -647,15 +659,16 @@ def test_multiple_functions():
         def func2(
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="float32")
         ) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Module
             alloc: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _: R.Tuple() = add(x, x, alloc)
+            _: R.Tuple() = cls.add(x, x, alloc)
             gv: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="float32") = R.builtin.alloc_tensor(
                 R.shape([2, 3]), dtype="float32", runtime_device_index=0
             )
-            _1: R.Tuple() = add(y, y, alloc1)
+            _1: R.Tuple() = cls.add(y, y, alloc1)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc1
             return x
 
@@ -681,13 +694,14 @@ def test_multiple_functions():
         def func1(
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="int32")
         ) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Expected
             storage: R.Object = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage, 0, R.shape([2, 3]), dtype="float32"
             )
-            _: R.Tuple() = add(x, x, alloc)
+            _: R.Tuple() = cls.add(x, x, alloc)
             _1: R.Tuple() = R.memory.kill_tensor(alloc)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc
             storage1: R.Object = R.memory.alloc_storage(
@@ -696,7 +710,7 @@ def test_multiple_functions():
             alloc1: R.Tensor((2, 3), dtype="int32") = R.memory.alloc_tensor(
                 storage1, 0, R.shape([2, 3]), dtype="int32"
             )
-            _2: R.Tuple() = add1(y, y, alloc1)
+            _2: R.Tuple() = cls.add1(y, y, alloc1)
             _3: R.Tuple() = R.memory.kill_tensor(alloc1)
             gv12: R.Tensor((2, 3), dtype="int32") = alloc1
             _5: R.Tuple() = R.memory.kill_storage(storage)
@@ -707,19 +721,20 @@ def test_multiple_functions():
         def func2(
             x: R.Tensor((2, 3), dtype="float32"), y: R.Tensor((2, 3), dtype="float32")
         ) -> R.Tensor((2, 3), dtype="float32"):
+            cls = Expected
             storage: R.Object = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage, 0, R.shape([2, 3]), dtype="float32"
             )
-            _: R.Tuple() = add(x, x, alloc)
+            _: R.Tuple() = cls.add(x, x, alloc)
             _1: R.Tuple() = R.memory.kill_tensor(alloc)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc
             alloc1: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
                 storage, 0, R.shape([2, 3]), dtype="float32"
             )
-            _2: R.Tuple() = add(y, y, alloc1)
+            _2: R.Tuple() = cls.add(y, y, alloc1)
             _3: R.Tuple() = R.memory.kill_tensor(alloc1)
             gv12: R.Tensor((2, 3), dtype="float32") = alloc1
             _4: R.Tuple() = R.memory.kill_storage(storage)

--- a/tests/python/relax/test_tuning_api.py
+++ b/tests/python/relax/test_tuning_api.py
@@ -57,7 +57,8 @@ class TestModule:
     # Input IRModule.
     @R.function
     def before(c0: R.Tensor((16, 16), "int32")):
-        lv0 = R.call_tir(addone, (c0,), R.Tensor((16, 16), dtype="int32"))
+        cls = TestModule
+        lv0 = R.call_tir(cls.addone, (c0,), R.Tensor((16, 16), dtype="int32"))
         return lv0
 
     # Expected IRModule after transformation.

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -194,8 +194,8 @@ def test_simple_module():
 
         @R.function
         def foo(x: R.Tensor((128, 128), "float32")) -> R.Tensor((128, 128), "float32"):
-            # TODO(Siyuan): Need to change to `TestModule.tir_func`
-            gv0 = R.call_tir(tir_func, x, R.Tensor((128, 128), dtype="float32"))
+            cls = TestModule
+            gv0 = R.call_tir(cls.tir_func, x, R.Tensor((128, 128), dtype="float32"))
             return gv0
 
     x = relax.Var("x", R.Tensor((128, 128), "float32"))
@@ -223,7 +223,8 @@ def test_emit_te_primfunc_attrs():
 
         @R.function
         def foo(x: R.Tensor((128, 128), "float32")) -> R.Tensor((128, 128), "float32"):
-            gv0 = R.call_tir(plus_one, x, R.Tensor((128, 128), dtype="float32"))
+            cls = TestModule
+            gv0 = R.call_tir(cls.plus_one, x, R.Tensor((128, 128), dtype="float32"))
             return gv0
 
     x = relax.Var("x", R.Tensor((128, 128), "float32"))
@@ -284,8 +285,8 @@ def test_module_with_attr_and_global_info():
 
         @R.function
         def foo(x: R.Tensor((128, 128), "float32")) -> R.Tensor((128, 128), "float32"):
-            # TODO(Siyuan): Need to change to `TestModule.tir_func`
-            gv0 = R.call_tir(tir_func, x, R.Tensor((128, 128), dtype="float32"))
+            cls = TestModule
+            gv0 = R.call_tir(cls.tir_func, x, R.Tensor((128, 128), dtype="float32"))
             return gv0
 
     x = relax.Var("x", R.Tensor((128, 128), "float32"))
@@ -825,7 +826,8 @@ def test_call_tir_with_tir_var():
             dumb_param: R.Tensor(("n",), "float32"), x: R.Tensor(("n * 2", "float32"))
         ) -> R.Tensor(("n * 2",), "float32"):
             n = T.int64()
-            y = R.call_tir(copy, (x,), R.Tensor(((n * 2,)), dtype="float32"), tir_vars=(n,))
+            cls = Module
+            y = R.call_tir(cls.copy, (x,), R.Tensor(((n * 2,)), dtype="float32"), tir_vars=(n,))
             return y
 
         @T.prim_func
@@ -905,18 +907,20 @@ def test_cross_function_call():
 
         @R.function
         def main(x: R.Tensor((10, 5), "float32")):
-            inner = foo
+            cls = Mod0
+            inner = cls.foo
             gv1 = inner(x)
-            gv2 = foo(x)
+            gv2 = Mod0.foo(x)
             return (inner, gv1, gv2)
 
     @I.ir_module
     class Mod1:
         @R.function
         def main(x: R.Tensor((10, 5), "float32")):
-            inner = foo
+            cls = Mod1
+            inner = cls.foo
             gv1 = inner(x)
-            gv2 = foo(x)
+            gv2 = Mod1.foo(x)
             return (inner, gv1, gv2)
 
         @R.function
@@ -1221,7 +1225,7 @@ def test_function_void_return_type():
     class Foo:
         @R.function
         def main(x: R.Tensor((3, 3), dtype="float32")):
-            res = mul(x)
+            res = Foo.mul(x)
             return res
 
         @R.function
@@ -1239,7 +1243,7 @@ def test_function_void_return_type():
     class Bar:
         @R.function
         def main(x1: R.Tensor((3, 3), dtype="float32")):
-            res1 = mul(x1)
+            res1 = Bar.mul(x1)
             return res1
 
         @R.function
@@ -1286,8 +1290,9 @@ def test_context_aware_parsing():
 
         @R.function
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
+            cls = Module
             alloc = R.builtin.alloc_tensor(R.shape([2, 4]), dtype="float32", runtime_device_index=0)
-            _: R.Tuple() = add(x, R.const(1, "float32"), alloc)
+            _: R.Tuple() = cls.add(x, R.const(1, "float32"), alloc)
             return alloc
 
     _check(Module)

--- a/tests/python/relax/test_tvmscript_printer_relax.py
+++ b/tests/python/relax/test_tvmscript_printer_relax.py
@@ -16,10 +16,11 @@
 # under the License.
 # pylint: disable=missing-docstring
 import tvm
-import pytest
 import tvm.testing
 from tvm import IRModule, relax, tir
+from tvm.script import ir as I
 from tvm.script import relax as R
+from tvm.script import tir as T
 
 
 def _assert_print(obj, expected):
@@ -319,7 +320,6 @@ R.call_dps_packed("my_dps_func", (a,), out_sinfo=R.Tensor((1, x, 3), dtype="floa
     )
 
 
-@pytest.mark.skip(reason="`relax.op.sin` is not upstreamed yet")
 def test_seq_expr():
     x = tir.Var("x", "int64")
     a = relax.Var("a", relax.TensorStructInfo([1, x, 3], "float32"))
@@ -351,7 +351,6 @@ c
     )
 
 
-@pytest.mark.skip(reason="`relax.op.sin` is not upstreamed yet")
 def test_binding_block():
     x = tir.Var("x", "int64")
     a = relax.Var("a", relax.TensorStructInfo([1, x, 3], "float32"))
@@ -374,7 +373,6 @@ c: R.Tensor((1, x, 3), dtype="float32") = R.sin(b)
     )
 
 
-@pytest.mark.skip(reason="`relax.op.sin` is not upstreamed yet")
 def test_dataflow_block():
     x = tir.Var("x", "int64")
     a = relax.Var("a", relax.TensorStructInfo([1, x, 3], "float32"))
@@ -418,7 +416,6 @@ b: R.Tensor((1, 5, 3), dtype="float32") = R.match_cast(a, R.Tensor((1, 5, 3), dt
     )
 
 
-@pytest.mark.skip(reason="`relax.op.sin` is not upstreamed yet")
 def test_var_binding():
     x = tir.Var("x", "int64")
     a = relax.Var("a", relax.TensorStructInfo([1, x, 3], "float32"))
@@ -453,6 +450,81 @@ if a:
 else:
     c: R.Tensor((1, 2, 3), dtype="float32")
     c
+""",
+    )
+
+
+def test_builtin_keywords():
+    x = tir.Var("x", "int64")
+    a = relax.Var("R", relax.TensorStructInfo([1, x, 3], "float32"))
+    b = relax.Var("T", relax.TensorStructInfo([1, x, 3], "float32"))
+    obj = relax.VarBinding(b, relax.op.sin(a))
+    _assert_print(
+        obj,
+        """
+x = T.int64()
+R_1: R.Tensor((1, x, 3), dtype="float32")
+T_1: R.Tensor((1, x, 3), dtype="float32") = R.sin(R_1)
+""",
+    )
+
+
+def test_module_cross_func_call():
+    @I.ir_module
+    class TestModule:
+        @T.prim_func
+        def tir_func(
+            x: T.Buffer((T.int64(128),), "float32"), y: T.Buffer((T.int64(128),), "float32")
+        ):
+            T.evaluate(0)
+
+        @R.function
+        def foo(x: R.Tensor((128,), "float32")) -> R.Tensor((128,), "float32"):
+            cls = TestModule
+            gv0 = R.call_tir(cls.tir_func, x, R.Tensor((128,), dtype="float32"))
+            return gv0
+
+    # default behavior
+    _assert_print(
+        TestModule,
+        """
+# from tvm.script import ir as I
+# from tvm.script import tir as T
+# from tvm.script import relax as R
+
+@I.ir_module
+class Module:
+    @T.prim_func
+    def tir_func(x: T.Buffer((T.int64(128),), "float32"), y: T.Buffer((T.int64(128),), "float32")):
+        T.evaluate(0)
+
+    @R.function
+    def foo(x: R.Tensor((128,), dtype="float32")) -> R.Tensor((128,), dtype="float32"):
+        cls = Module
+        gv0 = R.call_tir(cls.tir_func, (x,), out_sinfo=R.Tensor((128,), dtype="float32"))
+        return gv0
+""",
+    )
+
+    # empty module alias
+    module_str = TestModule.script(module_alias="")
+    _assert_print(
+        module_str,
+        """
+# from tvm.script import ir as I
+# from tvm.script import tir as T
+# from tvm.script import relax as R
+
+@I.ir_module
+class Module:
+    @T.prim_func
+    def tir_func(x: T.Buffer((T.int64(128),), "float32"), y: T.Buffer((T.int64(128),), "float32")):
+        T.evaluate(0)
+
+    @R.function
+    def foo(x: R.Tensor((128,), dtype="float32")) -> R.Tensor((128,), dtype="float32"):
+        gv0 = R.call_tir(Module.tir_func, (x,), out_sinfo=R.Tensor((128,), dtype="float32"))
+        return gv0
 """,
     )
 

--- a/tests/python/relax/test_vm_codegen_tir.py
+++ b/tests/python/relax/test_vm_codegen_tir.py
@@ -74,7 +74,7 @@ def test_tir_call():
         @R.function
         def foo(x: R.Tensor):
             R.func_attr({"global_symbol": "foo"})
-            _ = shape_func(x)
+            _ = Before.shape_func(x)
             return x
 
     @tvm.script.ir_module

--- a/tests/python/unittest/test_tvmscript_printer_ir.py
+++ b/tests/python/unittest/test_tvmscript_printer_ir.py
@@ -15,7 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-docstring
-from tvm import IRModule
+
+import pytest
+
+from tvm import IRModule, TVMError
 from tvm.script.ir_builder import IRBuilder
 from tvm.script.ir_builder import ir as I
 from tvm.script.ir_builder import tir as T
@@ -48,5 +51,17 @@ class Module:
     )
 
 
+def test_failed_invalid_prefix():
+    with IRBuilder() as ib:  # pylint: disable=invalid-name
+        with I.ir_module():
+            with T.prim_func():
+                T.func_name("foo")
+    mod = ib.get()
+
+    with pytest.raises(TVMError):
+        mod.script(ir_prefix="2I")
+
+
 if __name__ == "__main__":
     test_ir_module()
+    test_failed_invalid_prefix()


### PR DESCRIPTION
The current cross-function calls in TVMScript will cause PyLint warnings, since the GlobalVar will be marked as undefined vars, e.g.:

```python
@I.ir_module
class TestModule:
    @T.prim_func
    def tir_func(
        x: T.Buffer((T.int64(128),), "float32"), y: T.Buffer((T.int64(128),), "float32")
    ):
        T.evaluate(0)

    @R.function
    def foo(x: R.Tensor((128,), "float32")) -> R.Tensor((128,), "float32"):
        gv0 = R.call_tir(tir_func, x, R.Tensor((128,), dtype="float32"))  # <= `tir_func` is not defined in Python syntax.
        return gv0
```

This PR changes the behavior into `TestModule.tir_func` instead of direct `tir_func`
```python
@I.ir_module
class TestModule:
    @T.prim_func
    def tir_func(
        x: T.Buffer((T.int64(128),), "float32"), y: T.Buffer((T.int64(128),), "float32")
    ):
        T.evaluate(0)

    @R.function
    def foo(x: R.Tensor((128,), "float32")) -> R.Tensor((128,), "float32"):
        cls = TestModule  # Use `cls` to refer the current Module
        gv0 = R.call_tir(cls.tir_func, x, R.Tensor((128,), dtype="float32"))
        return gv0
```

NOTE: It's a breaking change, the old style is deprecated.

Additionally, this PR contains the following minor fixes:
- mark `R.function` as staticmethod as what we do for `T.prim_func`
- make `I`, `R`, `T`, `cls` be the builtin keywords for the printer
- define names for functions, modules to prevent naming conflict
- checking the var names is valid via regex expression
- fix typos

cc @tqchen 