### PR TITLE
[fix][relay][qnn] Bug fix for 8-bit quantized mul

### DIFF
--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -107,9 +107,7 @@ def register_annotate_function(op_name, frewrite=None, level=10):
                 return default_rewrite(ref_call, new_args, ctx)
             return func(ref_call, new_args, ctx)
 
-        return tvm.ir.register_op_attr(
-            op_name, "FQAnnotateRewrite", frewrite_with_guard, level
-        )
+        return tvm.ir.register_op_attr(op_name, "FQAnnotateRewrite", frewrite_with_guard, level)
 
     return _register(frewrite) if frewrite is not None else _register
 
@@ -127,11 +125,7 @@ def attach_simulated_quantize(data, kind, sign=True, rounding="round"):
     """
     quantize_op = _op.get("relay.op.annotation.simulated_quantize")
     if isinstance(data, _expr.Call) and data.op == quantize_op:
-        if (
-            data.attrs.kind == kind
-            and data.attrs.sign == sign
-            and data.attrs.rounding == rounding
-        ):
+        if data.attrs.kind == kind and data.attrs.sign == sign and data.attrs.rounding == rounding:
             return data
 
     qctx = quantize_context()
@@ -142,16 +136,12 @@ def attach_simulated_quantize(data, kind, sign=True, rounding="round"):
     dom_scale = _expr.var("dom_scale")
     clip_min = _expr.var("clip_min")
     clip_max = _expr.var("clip_max")
-    qnode = _quantize.simulated_quantize(
-        data, dom_scale, clip_min, clip_max, kind, sign, rounding
-    )
+    qnode = _quantize.simulated_quantize(data, dom_scale, clip_min, clip_max, kind, sign, rounding)
     qctx.qnode_map[key] = qnode
     return qnode
 
 
-tvm._ffi.register_func(
-    "relay.quantize.attach_simulated_quantize", attach_simulated_quantize
-)
+tvm._ffi.register_func("relay.quantize.attach_simulated_quantize", attach_simulated_quantize)
 
 
 @register_annotate_function("nn.contrib_conv2d_NCHWc")
@@ -301,16 +291,13 @@ def add_rewrite(ref_call, new_args, ctx):
         if lhs_kind == QAnnotateKind.INPUT and rhs_kind == QAnnotateKind.INPUT:
             expr = _forward_op(ref_call, [lhs_expr, rhs_expr])
             return QAnnotateExpr(expr, QAnnotateKind.INPUT)
-        if (
-            lhs_kind == QAnnotateKind.ACTIVATION
-            and rhs_kind == QAnnotateKind.ACTIVATION
-        ):
+        if lhs_kind == QAnnotateKind.ACTIVATION and rhs_kind == QAnnotateKind.ACTIVATION:
             rhs_expr = attach_simulated_quantize(rhs_expr, QAnnotateKind.INPUT)
             expr = _forward_op(ref_call, [lhs_expr, rhs_expr])
             return QAnnotateExpr(expr, QAnnotateKind.ACTIVATION)
-        if (
-            lhs_kind == QAnnotateKind.ACTIVATION and rhs_kind == QAnnotateKind.INPUT
-        ) or (lhs_kind == QAnnotateKind.INPUT and rhs_kind == QAnnotateKind.ACTIVATION):
+        if (lhs_kind == QAnnotateKind.ACTIVATION and rhs_kind == QAnnotateKind.INPUT) or (
+            lhs_kind == QAnnotateKind.INPUT and rhs_kind == QAnnotateKind.ACTIVATION
+        ):
             expr = _forward_op(ref_call, [lhs_expr, rhs_expr])
             return QAnnotateExpr(expr, QAnnotateKind.ACTIVATION)
     raise ValueError()
@@ -410,9 +397,7 @@ def concatenate_rewrite(ref_call, new_args, ctx):
         return None
     for i, k in enumerate(kind_list):
         if k is None:
-            expr_list[i] = attach_simulated_quantize(
-                expr_list[i], QAnnotateKind.ACTIVATION
-            )
+            expr_list[i] = attach_simulated_quantize(expr_list[i], QAnnotateKind.ACTIVATION)
     expr = _forward_op(ref_call, [_expr.Tuple(expr_list)])
     return QAnnotateExpr(expr, QAnnotateKind.ACTIVATION)
 

--- a/python/tvm/relay/quantize/_partition.py
+++ b/python/tvm/relay/quantize/_partition.py
@@ -133,6 +133,11 @@ def mul_partition_generic(ref_call, new_args, ctx):
         lhs = new_args[0].realize()
         return QPartitionExpr(_forward_op(ref_call, [lhs, rhs]))
 
+    if rhs_cond:
+        # introduced by efficientnet
+        rhs = new_args[1].realize()
+        return QPartitionExpr(_forward_op(ref_call, [lhs, rhs]))
+
     if not lhs_cond and not rhs_cond:
         # trivial case
         return None


### PR DESCRIPTION
When attempting to run inference with an 8-bit quantized version of [EfficientNet](https://arxiv.org/abs/1905.11946) ([PyTorch implementation](https://github.com/pytorch/vision/blob/main/torchvision/models/efficientnet.py)), I found that the quantization process crashed, which you can reproduce with [this gist](https://gist.github.com/Wheest/bd4fd601a15d6813e45c9ed5cdbae64f).

Upon closer inspection, I believe that the issue is related to the "Squeeze-and-Excitation block", where we multiply the output of a sigmoid with an earlier output.

Sample IR:

```
  %363 = sigmoid(%362);
  %364 = multiply(%362, %363);
  %365 = nn.adaptive_avg_pool2d(%364, output_size=[1, 1]);
  %366 = nn.conv2d(%365, %features.7.0.block.2.fc1.weight, padding=[0, 0, 0, 0], channels=48, kernel_size=[1, 1]);
  %367 = nn.bias_add(%366, %features.7.0.block.2.fc1.bias);
  %368 = sigmoid(%367);
  %369 = multiply(%367, %368);
```

However this fails when we attempt to quantize, because the mul operation quantization operation [does not cover this case](https://github.com/apache/tvm/blob/9a99fc89a2970b9fca151a573de7a5e409b5d9ee/python/tvm/relay/quantize/_partition.py#L126) (where `lhs_cond` is False, but `rhs_cond` is True).

I've updated the relevant files to cover this case, and with this fix the model can successfully compile.

Looking at the [quantization code](https://github.com/apache/tvm/blob/main/python/tvm/relay/quantize/_partition.py), this is not the only place where assumptions about LHS and RHS are being made.

However, I think it's only "general purpose" ops, like mul and add where we need to be agnostic.
Looking around, I don't see any obvious cases we aren't covering right now, but perhaps there are some tests that could be added.

Potential reviewers: @zhiics @jwfromm @anijain2305; listed as having quantization familiarity