### PR TITLE
Rewrite and simplify after InjectSoftwarePipeline to reduce mem footprint

### DIFF
--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -363,6 +363,11 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const SubNode* op) {
     TVM_TRY_REWRITE(matches_one_of(max(x, y) - y, x - min(y, x)), max(x - y, 0));
     TVM_TRY_REWRITE(matches_one_of(x - min(x, y), max(y, x) - y), max(0, x - y));
 
+    TVM_TRY_REWRITE(x - max(x + y, 0), min(x, 0 - y));
+    TVM_TRY_REWRITE(x - max(0, x + y), min(x, 0 - y));
+    TVM_TRY_REWRITE(x - min(x + y, 0), max(x, 0 - y));
+    TVM_TRY_REWRITE(x - min(0, x + y), max(x, 0 - y));
+
     // mul co-efficient folding
     TVM_TRY_REWRITE(x - x, ZeroWithTypeLike(x));
     TVM_TRY_REWRITE(matches_one_of(x * y - x, y * x - x), x * (y - 1));

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -213,7 +213,6 @@ Array<tvm::transform::Pass> CreatePassList(bool disable_loop_partition) {
   pass_list.push_back(tir::transform::ConvertBlocksToOpaque());
   pass_list.push_back(tir::transform::UnifyThreadBinding());
   pass_list.push_back(tir::transform::ManifestSharedMemoryLocalStage());
-  pass_list.push_back(tir::transform::CompactBufferAllocation());
   pass_list.push_back(tir::transform::LowerMatchBuffer());
   pass_list.push_back(tir::transform::InjectSoftwarePipeline());
   pass_list.push_back(tir::transform::CompactBufferAllocation());

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -216,6 +216,7 @@ Array<tvm::transform::Pass> CreatePassList(bool disable_loop_partition) {
   pass_list.push_back(tir::transform::CompactBufferAllocation());
   pass_list.push_back(tir::transform::LowerMatchBuffer());
   pass_list.push_back(tir::transform::InjectSoftwarePipeline());
+  pass_list.push_back(tir::transform::CompactBufferAllocation());
   pass_list.push_back(tir::transform::LowerOpaqueBlock());
   pass_list.push_back(tir::transform::FlattenBuffer());
   pass_list.push_back(tir::transform::BF16Legalize());

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -215,6 +215,7 @@ Array<tvm::transform::Pass> CreatePassList(bool disable_loop_partition) {
   pass_list.push_back(tir::transform::ManifestSharedMemoryLocalStage());
   pass_list.push_back(tir::transform::LowerMatchBuffer());
   pass_list.push_back(tir::transform::InjectSoftwarePipeline());
+  pass_list.push_back(tir::transform::Simplify());
   pass_list.push_back(tir::transform::CompactBufferAllocation());
   pass_list.push_back(tir::transform::LowerOpaqueBlock());
   pass_list.push_back(tir::transform::FlattenBuffer());

--- a/src/tir/transforms/inject_software_pipeline.cc
+++ b/src/tir/transforms/inject_software_pipeline.cc
@@ -1231,8 +1231,7 @@ Pass InjectSoftwarePipeline() {
     fptr->body = ConvertSSA(std::move(fptr->body));
     return f;
   };
-  auto inner = CreatePrimFuncPass(pass_func, 0, "tir.InjectSoftwarePipelineInner", {});
-  return Sequential({inner, Simplify()}, "tir.InjectSoftwarePipeline");
+  return CreatePrimFuncPass(pass_func, 0, "tir.InjectSoftwarePipeline", {});
 }
 
 TVM_REGISTER_GLOBAL("tir.transform.InjectSoftwarePipeline").set_body_typed(InjectSoftwarePipeline);

--- a/src/tir/transforms/inject_software_pipeline.cc
+++ b/src/tir/transforms/inject_software_pipeline.cc
@@ -1231,7 +1231,8 @@ Pass InjectSoftwarePipeline() {
     fptr->body = ConvertSSA(std::move(fptr->body));
     return f;
   };
-  return CreatePrimFuncPass(pass_func, 0, "tir.InjectSoftwarePipeline", {});
+  auto inner = CreatePrimFuncPass(pass_func, 0, "tir.InjectSoftwarePipelineInner", {});
+  return Sequential({inner, Simplify()}, "tir.InjectSoftwarePipeline");
 }
 
 TVM_REGISTER_GLOBAL("tir.transform.InjectSoftwarePipeline").set_body_typed(InjectSoftwarePipeline);

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -611,6 +611,10 @@ class TestMinIndex(BaseCompare):
         TestCase(tvm.te.min(x * (-2), 4), tvm.te.max(x, -2) * -2),
         TestCase(tvm.te.min(x * (0), 4), 0),
         TestCase(tvm.te.min(x * (0), -4), -4),
+        TestCase(x - tvm.te.max(x + y, 0), tvm.te.min(x, 0 - y)),
+        TestCase(x - tvm.te.max(0, x + y), tvm.te.min(x, 0 - y)),
+        TestCase(x - tvm.te.min(x + y, 0), tvm.te.max(x, 0 - y)),
+        TestCase(x - tvm.te.min(0, x + y), tvm.te.max(x, 0 - y)),
         # DivMod rules
         # truc div
         TestCase(tvm.te.min(tdiv(x + 3, 4) * 4, x), x),


### PR DESCRIPTION
Rewrite and simplify after `InjectSoftwarePipeline` to reduce memory footprint.  Memory footprint reduction is done with `CompactBufferAllocation` pass which is moved after `InjectSoftwarePipeline` in the driver.