### PR TITLE
[CI] Update CUDA to 11.7

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -17,7 +17,7 @@
 
 # CI docker GPU env
 # tag: v0.60
-FROM nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
+FROM nvidia/cuda:11.7.1-cudnn8-devel-ubuntu18.04
 
 COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 


### PR DESCRIPTION
The last time we updated the CUDA version on CI was [two years ago](https://github.com/apache/tvm/pull/8119), I think it is a good time for another update.

v11.7 is the latest version officially supported by PyTorch (https://pytorch.org/get-started/locally/). Rather than jumping directly to v12, I think it is better to stay in the stable v11 line for now. 

This would unblock the PR https://github.com/apache/tvm/pull/14291 which uses a relatively new feature in cuBLAS introduced in v11.4.