### PR TITLE
[Do not merge][CI] Update ci_arm docker image to have LLVM 15

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -17,7 +17,7 @@
 
 # This data file is read during when Jenkins runs job to determine docker images.
 [jenkins]
-ci_arm: tlcpack/ci-arm:20230223-070143-a3b51f11b
+ci_arm: tlcpackstaging/ci_arm:20230314-060145-ccc0b9162
 ci_cortexm: tlcpackstaging/ci_cortexm:20230124-233207-fd3f8035c
 ci_cpu: tlcpack/ci-cpu:20230308-070109-9d732d0fa
 ci_gpu: tlcpack/ci-gpu:20230308-070109-9d732d0fa


### PR DESCRIPTION
Update `ci_arm` to have support for LLVM 15, which brings better support for vectorisation.
The proposed docker tag is: `20230314-060145-ccc0b9162`.

Note: I'll run a CI run to test the image, before moving it from `tlcpackstaging` to `tlcpack` namespace.

cc @Mousius @neildhickey @lhutton1 for reviews

