### PR TITLE
[Fix][TIR] Fix tvm::arith::UnionLowerBound

### DIFF
--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -865,6 +865,7 @@ IntSet UnionLowerBound(const Array<IntSet>& sets) {
   PrimExpr min_inclusive{nullptr};
   PrimExpr max_inclusive(nullptr);
   for (const IntSet& int_set : sets) {
+    if (int_set.IsNothing()) continue;
     if (const auto* interval_set = int_set.as<IntervalSetNode>()) {
       PrimExpr new_min_inclusive = interval_set->min_value;
       PrimExpr new_max_inclusive = interval_set->max_value;

--- a/tests/python/unittest/test_arith_intset.py
+++ b/tests/python/unittest/test_arith_intset.py
@@ -373,6 +373,10 @@ def test_union_lower_bound():
     result = tvm.arith.int_set.union_lower_bound([set_0, set_1])
     assert result.min_value.same_as(neg_inf)
     assert result.max_value.same_as(pos_inf)
+    set_2 = tvm.arith.IntervalSet(min_value=pos_inf, max_value=neg_inf)
+    result = tvm.arith.int_set.union_lower_bound([set_0, set_2])
+    assert result.min_value.same_as(neg_inf)
+    assert result.max_value.same_as(0)
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_arith_intset.py
+++ b/tests/python/unittest/test_arith_intset.py
@@ -374,9 +374,9 @@ def test_union_lower_bound():
     assert result.min_value.same_as(neg_inf)
     assert result.max_value.same_as(pos_inf)
     set_2 = tvm.arith.IntervalSet(min_value=pos_inf, max_value=neg_inf)
-    result = tvm.arith.int_set.union_lower_bound([set_0, set_2])
+    result = tvm.arith.int_set.union_lower_bound([set_0, set_1, set_2])
     assert result.min_value.same_as(neg_inf)
-    assert result.max_value.same_as(0)
+    assert result.max_value.same_as(pos_inf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The UnionLowerBound function does not take into account the condition that  the empty set has a special representation [+inf, -inf].

cc @wrongtest-intellif