### PR TITLE
Add a data type check for TVMArrayCopyFromTo

### DIFF
--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -140,6 +140,9 @@ class NDArray(NDArrayBase):
             Reference to self.
         """
         if isinstance(source_array, NDArrayBase):
+            if(source_array.dtype!=self.dtype):
+                raise TypeError("source dtype: {0} is different with target dtype: {1}".format(
+                    source_array.dtype, self.dtype))
             source_array.copyto(self)
             return self
 

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -140,9 +140,12 @@ class NDArray(NDArrayBase):
             Reference to self.
         """
         if isinstance(source_array, NDArrayBase):
-            if(source_array.dtype!=self.dtype):
-                raise TypeError("source dtype: {0} is different with target dtype: {1}".format(
-                    source_array.dtype, self.dtype))
+            if source_array.dtype != self.dtype:
+                raise TypeError(
+                    "source dtype: {0} is different with target dtype: {1}".format(
+                        source_array.dtype, self.dtype
+                    )
+                )
             source_array.copyto(self)
             return self
 


### PR DESCRIPTION
Add a data type check for tvm.nd.array's API TVMArrayCopyFromTo. Lacking the type check
leads to a value error in some situations. 
For example, the user input x to a built graph, the x has a shape of [200,10] and has a dtype of 'float32'. When copying the x
to the NDarray placeholder with type 'float64' whose shape is [100,10], the program doesn't report a warning, because it can pass the size check i.e. 200\*10\*32==100\*10\*64, however, every 64 continous bits in inputx is treated a number  and copyed to the new ndarray, the values change. because of different hardcode. More importantly, this kind of error is implict.    
@masahi                          