### PR TITLE
[Unity][BYOC] Improve expressiveness of the pattern check function in FuseOpsByPattern

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -220,7 +220,7 @@ TVM_DLL Pass FuseOps(int fuse_opt_level = -1);
  * fused, it needs to be matched with `pattern` and the `check` function needs to return
  * true.
  */
-class FuseOpsPatternNode : public Object {
+class FusionPatternNode : public Object {
  public:
   /*!
    * \brief The name of pattern. It becomes the value of the kComposite attribute
@@ -245,7 +245,7 @@ class FuseOpsPatternNode : public Object {
    * NullOpt if check function is not necessary for this pattern.
    *
    * It should have signature
-   * bool(const PatternCheckFunctionInput& input)
+   * bool(const PatternCheckContext& context)
    */
   Optional<PackedFunc> check;
 
@@ -256,28 +256,28 @@ class FuseOpsPatternNode : public Object {
     v->Visit("check", &check);
   }
 
-  static constexpr const char* _type_key = "relax.transform.FuseOpsPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(FuseOpsPatternNode, Object);
+  static constexpr const char* _type_key = "relax.transform.FusionPattern";
+  TVM_DECLARE_FINAL_OBJECT_INFO(FusionPatternNode, Object);
 };
 
-class FuseOpsPattern : public ObjectRef {
+class FusionPattern : public ObjectRef {
  public:
-  FuseOpsPattern(String name, DFPattern pattern, Map<String, DFPattern> annotation_patterns,
-                 Optional<PackedFunc> check);
+  FusionPattern(String name, DFPattern pattern, Map<String, DFPattern> annotation_patterns,
+                Optional<PackedFunc> check);
 
-  FuseOpsPattern(String name, DFPattern pattern) : FuseOpsPattern(name, pattern, {}, NullOpt) {}
+  FusionPattern(String name, DFPattern pattern) : FusionPattern(name, pattern, {}, NullOpt) {}
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(FuseOpsPattern, ObjectRef, FuseOpsPatternNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(FusionPattern, ObjectRef, FusionPatternNode);
 };
 
 /*!
- * \brief The input of FuseOpsPattern::check.
+ * \brief The input of FusionPattern::check.
  */
-class PatternCheckFunctionInputNode : public Object {
+class PatternCheckContextNode : public Object {
  public:
   /*!
    * \brief A map which contains all expressions matched by the sub patterns in
-   * FuseOpsPatternNode::annotation_patterns.
+   * FusionPattern::annotation_patterns.
    */
   Map<String, Expr> annotated_expr;
 
@@ -297,17 +297,17 @@ class PatternCheckFunctionInputNode : public Object {
     v->Visit("value_to_bound_var", &value_to_bound_var);
   }
 
-  static constexpr const char* _type_key = "relax.transform.PatternCheckFunctionInput";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PatternCheckFunctionInputNode, Object);
+  static constexpr const char* _type_key = "relax.transform.PatternCheckContext";
+  TVM_DECLARE_FINAL_OBJECT_INFO(PatternCheckContextNode, Object);
 };
 
-class PatternCheckFunctionInput : public ObjectRef {
+class PatternCheckContext : public ObjectRef {
  public:
-  PatternCheckFunctionInput(Map<String, Expr> annotated_expr, Map<Var, Array<Var>> var_usages,
-                            Map<Expr, Var> value_to_bound_var);
+  PatternCheckContext(Map<String, Expr> annotated_expr, Map<Var, Array<Var>> var_usages,
+                      Map<Expr, Var> value_to_bound_var);
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(PatternCheckFunctionInput, ObjectRef,
-                                            PatternCheckFunctionInputNode);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(PatternCheckContext, ObjectRef,
+                                            PatternCheckContextNode);
 };
 
 /*!
@@ -326,8 +326,8 @@ class PatternCheckFunctionInput : public ObjectRef {
  * an external backend without using the MergeCompositeFunctions pass.
  * \return The Pass.
  */
-TVM_DLL Pass FuseOpsByPattern(const tvm::Array<FuseOpsPattern>& patterns,
-                              bool bind_constants = true, bool annotate_codegen = false);
+TVM_DLL Pass FuseOpsByPattern(const tvm::Array<FusionPattern>& patterns, bool bind_constants = true,
+                              bool annotate_codegen = false);
 
 /*!
  * \brief Group one or multiple composite functions created by FuseOpsByPattern into a new

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -568,11 +568,11 @@ def _extract_arg_idx(pattern_name, f):
     func_args = list(f.params)
 
     arg_idx = {}
-    for arg_name, arg_pattern in pattern_entry.arg_patterns.items():
-        arg_expr = matched_expr[arg_pattern]
+    for name, annotation_pattern in pattern_entry.annotation_patterns.items():
+        arg_expr = matched_expr[annotation_pattern]
         if arg_expr not in func_args:
-            raise ValueError(f"Cannot find arg {arg_name} in the fused function parameters")
-        arg_idx[arg_name] = func_args.index(arg_expr)
+            continue
+        arg_idx[name] = func_args.index(arg_expr)
 
     return arg_idx
 

--- a/python/tvm/relax/backend/pattern_registry.py
+++ b/python/tvm/relax/backend/pattern_registry.py
@@ -21,7 +21,7 @@ import atexit
 from typing import Callable, List, Mapping, Optional, Set, Tuple, Union
 
 from tvm.relax.dpl import DFPattern
-from tvm.relax.transform import FuseOpsPattern
+from tvm.relax.transform import FusionPattern
 
 from ..expr import Expr
 from . import _ffi_api
@@ -53,7 +53,7 @@ def _ensure_cleanup_function_registered():
 
 CheckFunc = Callable[[Mapping[DFPattern, Expr], Expr], bool]
 Pattern = Union[
-    FuseOpsPattern,
+    FusionPattern,
     Tuple[str, DFPattern],
     Tuple[str, DFPattern, Mapping[str, DFPattern]],
     Tuple[str, DFPattern, Mapping[str, DFPattern], CheckFunc],
@@ -75,17 +75,17 @@ def register_patterns(patterns: List[Pattern]):
 
     entries = []
     for item in patterns:
-        if isinstance(item, FuseOpsPattern):
+        if isinstance(item, FusionPattern):
             entries.append(item)
         elif isinstance(item, tuple):
-            entries.append(FuseOpsPattern(*item))
+            entries.append(FusionPattern(*item))
             _REGISTERED_PATTERN_NAMES.add(item[0])
         else:
             raise TypeError(f"Cannot register type {type(item)} as pattern")
     _ffi_api.RegisterPatterns(entries)
 
 
-def get_patterns_with_prefix(prefix: str) -> List[FuseOpsPattern]:
+def get_patterns_with_prefix(prefix: str) -> List[FusionPattern]:
     """
     Get a list of patterns whose names startwith `prefix`.
 
@@ -96,13 +96,13 @@ def get_patterns_with_prefix(prefix: str) -> List[FuseOpsPattern]:
 
     Returns
     -------
-    patterns: FuseOpsPattern
+    patterns: FusionPattern
         Matched patterns, ordered by priority from high to low.
     """
     return _ffi_api.GetPatternsWithPrefix(prefix)
 
 
-def get_pattern(name: str) -> Optional[FuseOpsPattern]:
+def get_pattern(name: str) -> Optional[FusionPattern]:
     """
     Find the pattern with a particular name.
 
@@ -113,7 +113,7 @@ def get_pattern(name: str) -> Optional[FuseOpsPattern]:
 
     Returns
     -------
-    pattern: Optional[FuseOpsPattern]
+    pattern: Optional[FusionPattern]
         The matched pattern. Returns None if such pattern is not found.
     """
     return _ffi_api.GetPattern(name)

--- a/python/tvm/relax/backend/pattern_registry.py
+++ b/python/tvm/relax/backend/pattern_registry.py
@@ -20,54 +20,11 @@
 import atexit
 from typing import Callable, List, Mapping, Optional, Set, Tuple, Union
 
-import tvm
 from tvm.relax.dpl import DFPattern
-from tvm.runtime import Object
+from tvm.relax.transform import FuseOpsPattern
 
 from ..expr import Expr
 from . import _ffi_api
-
-
-@tvm._ffi.register_object("relax.backend.PatternRegistryEntry")
-class PatternRegistryEntry(Object):
-    """
-    An entry in the pattern registry. This represents a single pattern that
-    can be used to identify expressions that can be handled by external
-    backends, like CUTLASS and TensorRT.
-
-    Parameters
-    ----------
-    name: str
-        The name of pattern. Usually it starts with the name of backend, like 'cutlass.matmul'.
-
-    pattern: DFPattern
-        The dataflow pattern that will be used to match expressions that can be handled
-        by external backends.
-
-    arg_patterns: Mapping[str, DFPattern]
-        The mapping from arg name to its pattern. It can be used to extract arg expression
-        from match result. All DFPattern in this map should be part of the `pattern`.
-
-    check: Callable[[Mapping[DFPattern, Expr], Expr], bool]
-        The function to check whether the match result is accepted.
-    """
-
-    name: str
-    pattern: DFPattern
-    arg_patterns: Mapping[str, DFPattern]
-    check: Callable[[Mapping[DFPattern, Expr], Expr], bool]
-
-    def __init__(
-        self,
-        name: str,
-        pattern: DFPattern,
-        arg_patterns: Mapping[str, DFPattern],
-        check: Callable[[Mapping[DFPattern, Expr], Expr], bool],
-    ):
-        self.__init_handle_by_constructor__(
-            _ffi_api.PatternRegistryEntry, name, pattern, arg_patterns, check  # type: ignore
-        )
-
 
 _REGISTERED_PATTERN_NAMES: Set[str] = set()
 
@@ -96,7 +53,7 @@ def _ensure_cleanup_function_registered():
 
 CheckFunc = Callable[[Mapping[DFPattern, Expr], Expr], bool]
 Pattern = Union[
-    PatternRegistryEntry,
+    FuseOpsPattern,
     Tuple[str, DFPattern],
     Tuple[str, DFPattern, Mapping[str, DFPattern]],
     Tuple[str, DFPattern, Mapping[str, DFPattern], CheckFunc],
@@ -118,29 +75,17 @@ def register_patterns(patterns: List[Pattern]):
 
     entries = []
     for item in patterns:
-        if isinstance(item, PatternRegistryEntry):
+        if isinstance(item, FuseOpsPattern):
             entries.append(item)
         elif isinstance(item, tuple):
-            name, pattern, *rest = item
-
-            if len(rest) > 0:
-                arg_patterns = rest[0]
-            else:
-                arg_patterns = {}
-
-            if len(rest) > 1:
-                check = rest[1]
-            else:
-                check = lambda *_: True
-
-            entries.append(PatternRegistryEntry(name, pattern, arg_patterns, check))
-            _REGISTERED_PATTERN_NAMES.add(name)
+            entries.append(FuseOpsPattern(*item))
+            _REGISTERED_PATTERN_NAMES.add(item[0])
         else:
-            raise TypeError(f"Cannot register type {type(pattern)} as pattern")
+            raise TypeError(f"Cannot register type {type(item)} as pattern")
     _ffi_api.RegisterPatterns(entries)
 
 
-def get_patterns_with_prefix(prefix: str) -> List[PatternRegistryEntry]:
+def get_patterns_with_prefix(prefix: str) -> List[FuseOpsPattern]:
     """
     Get a list of patterns whose names startwith `prefix`.
 
@@ -151,13 +96,13 @@ def get_patterns_with_prefix(prefix: str) -> List[PatternRegistryEntry]:
 
     Returns
     -------
-    patterns: PatternRegistryEntry
+    patterns: FuseOpsPattern
         Matched patterns, ordered by priority from high to low.
     """
     return _ffi_api.GetPatternsWithPrefix(prefix)
 
 
-def get_pattern(name: str) -> Optional[PatternRegistryEntry]:
+def get_pattern(name: str) -> Optional[FuseOpsPattern]:
     """
     Find the pattern with a particular name.
 
@@ -168,7 +113,7 @@ def get_pattern(name: str) -> Optional[PatternRegistryEntry]:
 
     Returns
     -------
-    pattern: Optional[PatternRegistryEntry]
+    pattern: Optional[FuseOpsPattern]
         The matched pattern. Returns None if such pattern is not found.
     """
     return _ffi_api.GetPattern(name)

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -19,11 +19,16 @@
 import functools
 import inspect
 import types
-from typing import Callable, Dict, Union, Optional, List, Tuple
-from tvm.tir import PrimFunc, IndexMap
+from typing import Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
 import numpy as np  # type: ignore
+
 import tvm.ir
-from tvm.runtime import NDArray
+from tvm.relax import Expr, Var
+from tvm.relax.dpl import DFPattern
+from tvm.runtime import NDArray, Object
+from tvm.tir import IndexMap, PrimFunc
+
 from . import _ffi_api
 from .legalize_ops.common import LegalizeFunc
 
@@ -283,8 +288,76 @@ def FuseTIR() -> tvm.ir.transform.Pass:
     return _ffi_api.FuseTIR()  # type: ignore
 
 
+@tvm._ffi.register_object("relax.transform.PatternCheckFunctionInput")
+class PatternCheckFunctionInput(Object):
+    """
+    The input of check function `FuseOpsPattern.check`.
+
+    Parameters
+    ----------
+    annotated_expr: Mapping[str, Expr]
+        A map which contains all expressions matched by the sub patterns in
+        FuseOpsPattern.annotation_patterns.
+
+    var_usages: Mapping[Var, Sequence[Var]]
+        A map mapping variable definitions to a set of uses.
+
+    value_to_bound_var: Mapping[Expr, Var]
+        Map from value to its bound variable.
+    """
+
+    annotated_expr: Mapping[str, Expr]
+    var_usages: Mapping[Var, Sequence[Var]]
+    value_to_bound_var: Mapping[Expr, Var]
+
+
+@tvm._ffi.register_object("relax.transform.FuseOpsPattern")
+class FuseOpsPattern(Object):
+    """
+    An entry in the pattern registry. This represents a single pattern that
+    can be used to identify expressions that can be handled by external
+    backends, like CUTLASS and TensorRT.
+
+    Parameters
+    ----------
+    name: str
+        The name of pattern. Usually it starts with the name of backend, like 'cutlass.matmul'.
+
+    pattern: DFPattern
+        The dataflow pattern that will be used to match expressions that can be handled
+        by external backends.
+
+    annotation_patterns: Mapping[str, DFPattern]
+        The mapping from arg name to its pattern. It can be used to extract arg expression
+        from match result. All DFPattern in this map should be part of the `pattern`.
+
+    check: Callable[[Mapping[DFPattern, Expr], Expr], bool]
+        The function to check whether the match result is accepted.
+    """
+
+    name: str
+    pattern: DFPattern
+    annotation_patterns: Mapping[str, DFPattern]
+    check: Callable[[PatternCheckFunctionInput], bool]
+
+    def __init__(
+        self,
+        name: str,
+        pattern: DFPattern,
+        annotation_patterns: Optional[Mapping[str, DFPattern]] = None,
+        check: Optional[Callable[[Mapping[str, Expr]], bool]] = None,
+    ):
+        if annotation_patterns is None:
+            annotation_patterns = {}
+        self.__init_handle_by_constructor__(
+            _ffi_api.FuseOpsPattern, name, pattern, annotation_patterns, check  # type: ignore
+        )
+
+
 def FuseOpsByPattern(
-    patterns: List[Tuple], bind_constants: bool = True, annotate_codegen: bool = False
+    patterns: List[Union[FuseOpsPattern, Tuple]],
+    bind_constants: bool = True,
+    annotate_codegen: bool = False,
 ) -> tvm.ir.transform.Pass:
     """Apply pattern matching to each function in the given module, and group matched expressions
     into a new function.
@@ -293,15 +366,12 @@ def FuseOpsByPattern(
 
     Parameters
     ----------
-    patterns : List[Union[Tuple[str, DFPattern], Tuple[str, DFPattern, Callable]]]
-        A list of tuple of (name, pattern) or (name, pattern, predicate) to be matched.
-        The predicate is a function with type (Map<DFPattern, Expr>, Expr) -> bool. It takes a
-        match result and returns a boolean value to indicate whether the match result is accepted.
+    patterns : List[Union[FuseOpsPattern, Tuple]]
+        A list of patterns to be matched. The order of the patterns determines the order of priority
+        in which they are matched. Higher-priority patterns should come earlier in the list.
 
-        The patterns to detect. The order of the patterns determines the order of priority in which
-        they are matched. Higher-priority patterns should come earlier in the list.
-        The string is the name of the corresponding pattern. It becomes the value of the kComposite
-        attribute of a fused function after a successful matching.
+        In addition to FuseOpsPattern, a tuple can be passed as item of this list. The pattern
+        will be constructed through FuseOpsPattern(*item)
 
     bind_constants : bool
         Whether or not to keep bound constants in the grouped function.
@@ -321,22 +391,19 @@ def FuseOpsByPattern(
         The registered pass for pattern-based fusion.
 
     """
-    pattern_names = []
-    df_patterns = []
-    checks = []
-    for tup in patterns:
-        if len(tup) == 2:
-            pattern_names.append(tup[0])
-            df_patterns.append(tup[1])
-            checks.append(lambda *_: True)
-        elif len(tup) == 3:
-            pattern_names.append(tup[0])
-            df_patterns.append(tup[1])
-            checks.append(tup[2])
+    converted_patterns = []
+    for pattern in patterns:
+        if isinstance(pattern, tuple):
+            converted_patterns.append(FuseOpsPattern(*pattern))
+        elif isinstance(pattern, FuseOpsPattern):
+            converted_patterns.append(pattern)
         else:
-            raise ValueError("Invalid pattern: {}".format(tup))
+            raise ValueError(f"Invalid pattern: {pattern}")
+
     return _ffi_api.FuseOpsByPattern(
-        pattern_names, df_patterns, checks, bind_constants, annotate_codegen
+        converted_patterns,
+        bind_constants,
+        annotate_codegen,
     )  # type: ignore
 
 

--- a/src/relax/backend/pattern_registry.cc
+++ b/src/relax/backend/pattern_registry.cc
@@ -24,25 +24,12 @@
 namespace tvm {
 namespace relax {
 namespace backend {
-
-PatternRegistryEntry::PatternRegistryEntry(String name, DFPattern pattern,
-                                           Map<String, DFPattern> arg_patterns, PackedFunc check) {
-  ObjectPtr<PatternRegistryEntryNode> n = make_object<PatternRegistryEntryNode>();
-  n->name = std::move(name);
-  n->pattern = std::move(pattern);
-  n->arg_patterns = std::move(arg_patterns);
-  n->check = check;
-  data_ = std::move(n);
-}
-
-TVM_REGISTER_NODE_TYPE(PatternRegistryEntryNode);
-
-static std::vector<PatternRegistryEntry>* GetRegistryTable() {
-  static std::vector<PatternRegistryEntry> table;
+static std::vector<FuseOpsPattern>* GetRegistryTable() {
+  static std::vector<FuseOpsPattern> table;
   return &table;
 }
 
-void RegisterPatterns(Array<PatternRegistryEntry> entries) {
+void RegisterPatterns(Array<FuseOpsPattern> entries) {
   auto* table = GetRegistryTable();
   for (const auto& entry : entries) {
     table->push_back(entry);
@@ -53,16 +40,15 @@ void RemovePatterns(Array<String> names) {
   std::unordered_set<String> name_set{names.begin(), names.end()};
 
   auto* table = GetRegistryTable();
-  table->erase(std::remove_if(table->begin(), table->end(),
-                              [&](const PatternRegistryEntry& entry) {
-                                return name_set.count(entry->name) > 0;
-                              }),
-               table->end());
+  table->erase(
+      std::remove_if(table->begin(), table->end(),
+                     [&](const FuseOpsPattern& entry) { return name_set.count(entry->name) > 0; }),
+      table->end());
 }
 
-Array<PatternRegistryEntry> GetPatternsWithPrefix(const String& prefix) {
+Array<FuseOpsPattern> GetPatternsWithPrefix(const String& prefix) {
   auto* table = GetRegistryTable();
-  Array<PatternRegistryEntry> result;
+  Array<FuseOpsPattern> result;
   for (auto it = table->rbegin(); it != table->rend(); ++it) {
     if (support::StartsWith((*it)->name, prefix.data())) {
       result.push_back(*it);
@@ -71,7 +57,7 @@ Array<PatternRegistryEntry> GetPatternsWithPrefix(const String& prefix) {
   return result;
 }
 
-Optional<PatternRegistryEntry> GetPattern(const String& pattern_name) {
+Optional<FuseOpsPattern> GetPattern(const String& pattern_name) {
   auto* table = GetRegistryTable();
   for (auto it = table->rbegin(); it != table->rend(); ++it) {
     if ((*it)->name == pattern_name) {
@@ -81,11 +67,6 @@ Optional<PatternRegistryEntry> GetPattern(const String& pattern_name) {
   return NullOpt;
 }
 
-TVM_REGISTER_GLOBAL("relax.backend.PatternRegistryEntry")
-    .set_body_typed([](String name, DFPattern pattern, Map<String, DFPattern> arg_patterns,
-                       PackedFunc check) {
-      return PatternRegistryEntry(name, pattern, arg_patterns, check);
-    });
 TVM_REGISTER_GLOBAL("relax.backend.RegisterPatterns").set_body_typed(RegisterPatterns);
 TVM_REGISTER_GLOBAL("relax.backend.RemovePatterns").set_body_typed(RemovePatterns);
 TVM_REGISTER_GLOBAL("relax.backend.GetPatternsWithPrefix").set_body_typed(GetPatternsWithPrefix);

--- a/src/relax/backend/pattern_registry.cc
+++ b/src/relax/backend/pattern_registry.cc
@@ -24,12 +24,12 @@
 namespace tvm {
 namespace relax {
 namespace backend {
-static std::vector<FuseOpsPattern>* GetRegistryTable() {
-  static std::vector<FuseOpsPattern> table;
+static std::vector<FusionPattern>* GetRegistryTable() {
+  static std::vector<FusionPattern> table;
   return &table;
 }
 
-void RegisterPatterns(Array<FuseOpsPattern> entries) {
+void RegisterPatterns(Array<FusionPattern> entries) {
   auto* table = GetRegistryTable();
   for (const auto& entry : entries) {
     table->push_back(entry);
@@ -42,13 +42,13 @@ void RemovePatterns(Array<String> names) {
   auto* table = GetRegistryTable();
   table->erase(
       std::remove_if(table->begin(), table->end(),
-                     [&](const FuseOpsPattern& entry) { return name_set.count(entry->name) > 0; }),
+                     [&](const FusionPattern& entry) { return name_set.count(entry->name) > 0; }),
       table->end());
 }
 
-Array<FuseOpsPattern> GetPatternsWithPrefix(const String& prefix) {
+Array<FusionPattern> GetPatternsWithPrefix(const String& prefix) {
   auto* table = GetRegistryTable();
-  Array<FuseOpsPattern> result;
+  Array<FusionPattern> result;
   for (auto it = table->rbegin(); it != table->rend(); ++it) {
     if (support::StartsWith((*it)->name, prefix.data())) {
       result.push_back(*it);
@@ -57,7 +57,7 @@ Array<FuseOpsPattern> GetPatternsWithPrefix(const String& prefix) {
   return result;
 }
 
-Optional<FuseOpsPattern> GetPattern(const String& pattern_name) {
+Optional<FusionPattern> GetPattern(const String& pattern_name) {
   auto* table = GetRegistryTable();
   for (auto it = table->rbegin(); it != table->rend(); ++it) {
     if ((*it)->name == pattern_name) {

--- a/src/relax/backend/pattern_registry.h
+++ b/src/relax/backend/pattern_registry.h
@@ -36,7 +36,7 @@ namespace tvm {
 namespace relax {
 namespace backend {
 
-using transform::FuseOpsPattern;
+using transform::FusionPattern;
 
 /*!
  * \brief Register patterns which will be used to partition the DataflowBlock
@@ -44,7 +44,7 @@ using transform::FuseOpsPattern;
  * \param patterns Patterns to be registered. Patterns that appear later in the list have
  *        higher priority when partitioning DataflowBlock.
  */
-void RegisterPatterns(Array<FuseOpsPattern> entries);
+void RegisterPatterns(Array<FusionPattern> patterns);
 
 /*!
  * \brief Remove patterns from the registry by their name.
@@ -57,14 +57,14 @@ void RemovePatterns(Array<String> names);
  * \param prefx The pattern name prefix.
  * \return Matched patterns, ordered by priority from high to low.
  */
-Array<FuseOpsPattern> GetPatternsWithPrefix(const String& prefix);
+Array<FusionPattern> GetPatternsWithPrefix(const String& prefix);
 
 /*!
  * \brief Find the pattern with a particular name.
  * \param name The pattern name.
  * \return The matched pattern. NullOpt if not found.
  */
-Optional<FuseOpsPattern> GetPattern(const String& name);
+Optional<FusionPattern> GetPattern(const String& name);
 
 }  // namespace backend
 }  // namespace relax

--- a/src/relax/backend/pattern_registry.h
+++ b/src/relax/backend/pattern_registry.h
@@ -28,6 +28,7 @@
 
 #include <tvm/relax/dataflow_pattern.h>
 #include <tvm/relax/expr.h>
+#include <tvm/relax/transform.h>
 #include <tvm/runtime/container/optional.h>
 #include <tvm/runtime/object.h>
 
@@ -35,57 +36,7 @@ namespace tvm {
 namespace relax {
 namespace backend {
 
-/*!
- * \brief An entry in the pattern registry. This represents a single pattern that
- * can be used to identify expressions that can be handled by external
- * backends, like CUTLASS and TensorRT.
- */
-class PatternRegistryEntryNode : public Object {
- public:
-  /*!
-   * \brief The name of pattern. Usually it starts with the name of backend, like
-   * 'cutlass.matmul'.
-   */
-  String name;
-  /*!
-   * \brief The dataflow pattern that will be used to match expressions that can
-   * be handled by external backends.
-   */
-  DFPattern pattern;
-  /*!
-   * \brief The mapping from arg name to its pattern. It can be used to extract
-   * arg expression from match result. All DFPattern in this map should be part of
-   * the `pattern`.
-   */
-  Map<String, DFPattern> arg_patterns;
-
-  /*!
-   * \brief The function to check whether the match result is accepted.
-   *
-   * It should have signature
-   * bool(const Map<DFPattern, Expr>& match_result, const Expr& matched_expr)
-   */
-  PackedFunc check;
-
-  void VisitAttrs(tvm::AttrVisitor* v) {
-    v->Visit("name", &name);
-    v->Visit("pattern", &pattern);
-    v->Visit("arg_patterns", &arg_patterns);
-    v->Visit("check", &check);
-  }
-
-  static constexpr const char* _type_key = "relax.backend.PatternRegistryEntry";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PatternRegistryEntryNode, Object);
-};
-
-class PatternRegistryEntry : public ObjectRef {
- public:
-  PatternRegistryEntry(String name, DFPattern pattern, Map<String, DFPattern> arg_patterns,
-                       PackedFunc check);
-
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(PatternRegistryEntry, ObjectRef,
-                                            PatternRegistryEntryNode);
-};
+using transform::FuseOpsPattern;
 
 /*!
  * \brief Register patterns which will be used to partition the DataflowBlock
@@ -93,7 +44,7 @@ class PatternRegistryEntry : public ObjectRef {
  * \param patterns Patterns to be registered. Patterns that appear later in the list have
  *        higher priority when partitioning DataflowBlock.
  */
-void RegisterPatterns(Array<PatternRegistryEntry> entries);
+void RegisterPatterns(Array<FuseOpsPattern> entries);
 
 /*!
  * \brief Remove patterns from the registry by their name.
@@ -106,14 +57,14 @@ void RemovePatterns(Array<String> names);
  * \param prefx The pattern name prefix.
  * \return Matched patterns, ordered by priority from high to low.
  */
-Array<PatternRegistryEntry> GetPatternsWithPrefix(const String& prefix);
+Array<FuseOpsPattern> GetPatternsWithPrefix(const String& prefix);
 
 /*!
  * \brief Find the pattern with a particular name.
  * \param name The pattern name.
  * \return The matched pattern. NullOpt if not found.
  */
-Optional<PatternRegistryEntry> GetPattern(const String& name);
+Optional<FuseOpsPattern> GetPattern(const String& name);
 
 }  // namespace backend
 }  // namespace relax

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -40,6 +40,7 @@
 
 #include "../../relay/analysis/graph_partitioner.h"
 #include "../../support/arena.h"
+#include "tvm/relax/expr.h"
 
 namespace tvm {
 namespace relax {
@@ -905,18 +906,30 @@ class PatternBasedPartitioner : ExprVisitor {
   using Group = GraphPartitioner::Group;
   using GroupMap = OperatorFusor::GroupMap;
   using ExprVisitor::VisitExpr_;
-  using FCheckMatch = runtime::TypedPackedFunc<bool(const Map<DFPattern, Expr>&, const Expr&)>;
+  using FCheckMatch = runtime::TypedPackedFunc<bool(const transform::PatternCheckFunctionInput&)>;
 
-  static GroupMap Run(String pattern_name, DFPattern pattern, FCheckMatch check, Expr expr,
+  static GroupMap Run(String pattern_name, DFPattern pattern,
+                      Map<String, DFPattern> annotation_patterns, FCheckMatch check, Expr expr,
                       support::Arena* arena) {
-    PatternBasedPartitioner part(pattern_name, pattern, check, arena);
+    PatternBasedPartitioner part(pattern_name, pattern, annotation_patterns, check, arena);
     part.VisitExpr(expr);
     return part.group_map_;
   }
 
-  PatternBasedPartitioner(String pattern_name, DFPattern pattern, FCheckMatch check,
+  PatternBasedPartitioner(String pattern_name, DFPattern pattern,
+                          Map<String, DFPattern> annotation_patterns, FCheckMatch check,
                           support::Arena* arena)
-      : pat_name_(pattern_name), pat_(pattern), check_(check), arena_(arena) {}
+      : pat_name_(pattern_name),
+        pat_(pattern),
+        annotation_pat_(annotation_patterns),
+        check_(check),
+        arena_(arena) {}
+
+  void VisitBindingBlock_(const DataflowBlockNode* block) final {
+    current_block_use_def_ = DataflowBlockUseDef(GetRef<DataflowBlock>(block));
+    ExprVisitor::VisitBindingBlock_(block);
+    current_block_use_def_ = {};
+  }
 
   void VisitVarDef(const Var& var) final { group_map_[var.get()] = arena_->make<Group>(); }
 
@@ -931,7 +944,9 @@ class PatternBasedPartitioner : ExprVisitor {
   void VisitBinding_(const VarBindingNode* binding, const CallNode* call) final {
     VisitVarDef(binding->var);
     if (auto matches_opt = ExtractMatchedExpr(pat_, GetRef<Call>(call), bindings_)) {
-      if (!check_(matches_opt.value(), GetRef<Call>(call))) {
+      if (check_ != nullptr && !check_(transform::PatternCheckFunctionInput(
+                                   GetAnnotatedExpr(matches_opt.value()), current_block_use_def_,
+                                   value_to_bound_var_))) {
         return;
       }
       // If a match is found, put all matching expressions into the same group.
@@ -975,12 +990,24 @@ class PatternBasedPartitioner : ExprVisitor {
     return group_map_[bound_var.get()]->FindRoot();
   }
 
+  Map<String, Expr> GetAnnotatedExpr(const Map<DFPattern, Expr> matched_result) {
+    Map<String, Expr> annotated_expr;
+    for (const auto& it : annotation_pat_) {
+      if (matched_result.count(it.second)) {
+        annotated_expr.Set(it.first, matched_result[it.second]);
+      }
+    }
+    return annotated_expr;
+  }
+
   String pat_name_;
   DFPattern pat_;
+  Map<String, DFPattern> annotation_pat_;
   FCheckMatch check_;
   support::Arena* arena_;
   Map<Var, Expr> bindings_;
   Map<Expr, Var> value_to_bound_var_;
+  Map<Var, Array<Var>> current_block_use_def_;
   GroupMap group_map_;
 };
 
@@ -1054,19 +1081,18 @@ class CompositeFunctionAnnotator : public ExprMutator {
   std::unordered_map<const GlobalVarNode*, GlobalVar> gvar_map_;
 };
 
-IRModule FuseOpsByPattern(const tvm::Array<String>& pattern_names,
-                          const tvm::Array<DFPattern>& patterns,
-                          const tvm::Array<runtime::PackedFunc>& checks, IRModule mod,
+IRModule FuseOpsByPattern(const tvm::Array<transform::FuseOpsPattern>& patterns, IRModule mod,
                           bool bind_constants, bool annotate_codegen) {
   support::Arena arena;
-  for (size_t i = 0; i < pattern_names.size(); ++i) {
+  for (const auto& pattern : patterns) {
     OperatorFusor::GroupMap group_map;
     for (const auto& entry : mod->functions) {
       if (entry.second->IsInstance<tir::PrimFuncNode>()) {
         continue;
       }
-      auto map = PatternBasedPartitioner::Run(pattern_names[i], patterns[i], checks[i],
-                                              entry.second, &arena);
+      auto map = PatternBasedPartitioner::Run(
+          pattern->name, pattern->pattern, pattern->annotation_patterns,
+          pattern->check.value_or(nullptr), entry.second, &arena);
       group_map.insert(map.begin(), map.end());
     }
     mod = MakeGroupedFunctions(mod, group_map, /*lift_constants*/ !bind_constants);
@@ -1078,6 +1104,36 @@ IRModule FuseOpsByPattern(const tvm::Array<String>& pattern_names,
 }
 
 namespace transform {
+
+FuseOpsPattern::FuseOpsPattern(String name, DFPattern pattern,
+                               Map<String, DFPattern> annotation_patterns,
+                               Optional<PackedFunc> check) {
+  ObjectPtr<FuseOpsPatternNode> n = make_object<FuseOpsPatternNode>();
+  n->name = std::move(name);
+  n->pattern = std::move(pattern);
+  n->annotation_patterns = std::move(annotation_patterns);
+  n->check = check;
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(FuseOpsPatternNode);
+TVM_REGISTER_GLOBAL("relax.transform.FuseOpsPattern")
+    .set_body_typed([](String name, DFPattern pattern, Map<String, DFPattern> annotation_patterns,
+                       PackedFunc check) {
+      return FuseOpsPattern(name, pattern, annotation_patterns, check);
+    });
+
+PatternCheckFunctionInput::PatternCheckFunctionInput(Map<String, Expr> annotated_expr,
+                                                     Map<Var, Array<Var>> var_usages,
+                                                     Map<Expr, Var> value_to_bound_var) {
+  ObjectPtr<PatternCheckFunctionInputNode> n = make_object<PatternCheckFunctionInputNode>();
+  n->annotated_expr = std::move(annotated_expr);
+  n->var_usages = std::move(var_usages);
+  n->value_to_bound_var = std::move(value_to_bound_var);
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(PatternCheckFunctionInputNode);
 
 Pass FuseOps(int fuse_opt_level) {
   runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =  //
@@ -1094,14 +1150,11 @@ Pass FuseOps(int fuse_opt_level) {
 
 TVM_REGISTER_GLOBAL("relax.transform.FuseOps").set_body_typed(FuseOps);
 
-Pass FuseOpsByPattern(const tvm::Array<String>& pattern_names,
-                      const tvm::Array<DFPattern>& patterns,
-                      const tvm::Array<runtime::PackedFunc>& checks, bool bind_constants,
+Pass FuseOpsByPattern(const tvm::Array<FuseOpsPattern>& patterns, bool bind_constants,
                       bool annotate_codegen) {
   runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =  //
       [=](IRModule m, PassContext pc) {
-        return relax::FuseOpsByPattern(pattern_names, patterns, checks, m, bind_constants,
-                                       annotate_codegen);
+        return relax::FuseOpsByPattern(patterns, m, bind_constants, annotate_codegen);
       };
   return CreateModulePass(/*pass_function=*/pass_func,       //
                           /*opt_level=*/0,                   //

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -26,7 +26,6 @@ from tvm.contrib.pickle_memoize import memoize
 from tvm.relax.backend import get_patterns_with_prefix
 from tvm.relax.backend.contrib.cutlass import partition_for_cutlass
 from tvm.script import relax as R
-from tvm.script import tir as T
 from tvm.script.ir_builder import IRBuilder
 from tvm.script.ir_builder import relax as relax_builder
 
@@ -284,6 +283,43 @@ def test_conv2d_offload(data_shape, weight_shape, dtype, epilogue, residual_bloc
     tvm.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
 
 
+def test_cutlass_partition_conv2d_residual_blocked():
+    @tvm.script.ir_module
+    class Conv2dReLU:
+        """
+        This conv2d should not be fused as conv2d residual block, because both lhs and rhs of
+        the last R.add depends on the result of conv2d.
+        """
+
+        @R.function
+        def main(
+            data: R.Tensor((32, 3, 3, 16), "float32"),
+            weight: R.Tensor((16, 3, 3, 16), "float32"),
+            bias: R.Tensor((1, 1, 1, 16), "float32"),
+        ):
+            with R.dataflow():
+                conv1 = R.nn.conv2d(
+                    data,
+                    weight,
+                    padding=(1, 1),
+                    data_layout="NHWC",
+                    kernel_layout="OHWI",
+                )
+                out = R.nn.relu(conv1 + bias)
+                # residual depends on conv result, which cannot be handled in cutlass
+                result = out + out
+                R.output(result)
+
+            return result
+
+    mod = partition_for_cutlass(Conv2dReLU, annotate_codegen=False)
+    for f_var in mod.functions:
+        func = mod[f_var]
+        if func.attrs and "Composite" in func.attrs:
+            # verify that the function is not fused as residual block
+            assert func.attrs["Composite"] == "cutlass.conv2d_bias_relu"
+
+
 @pytest.mark.parametrize(
     "x_shape, y_shape, transpose_y, epilogue",
     [
@@ -428,6 +464,7 @@ def test_cutlass_partition_matmul_blocked(x_shape, y_shape, transpose_y, dtype):
     mod = get_relax_matmul_module(
         x_shape, y_shape, dtype, with_bias=False, transposed_y=transpose_y
     )
+    mod = partition_for_cutlass(mod)
 
     assert len(mod.functions) == 1
 

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -20,6 +20,7 @@ import pytest
 import tvm
 from tvm import relax
 from tvm.relax.dpl.pattern import is_op, make_fused_bias_activation_pattern, wildcard
+from tvm.relax.transform import PatternCheckContext
 from tvm.script import ir as I
 from tvm.script import relax as R
 from tvm.script import tir as T
@@ -606,10 +607,10 @@ def test_check_pattern():
     out = is_op("relax.nn.conv2d")(lhs, rhs)
     annotation_patterns = {"root": out, "lhs": lhs, "rhs": rhs}
 
-    def pred(check_input):
-        lhs = check_input.annotated_expr["lhs"]
-        rhs = check_input.annotated_expr["rhs"]
-        expr = check_input.annotated_expr["root"]
+    def pred(context: PatternCheckContext):
+        lhs = context.annotated_expr["lhs"]
+        rhs = context.annotated_expr["rhs"]
+        expr = context.annotated_expr["root"]
         assert isinstance(lhs, relax.expr.Var) and lhs.name_hint == "data"
         assert isinstance(rhs, relax.expr.Var) and rhs.name_hint == "weight1"
         assert isinstance(expr, relax.expr.Call) and expr.op.name == "relax.nn.conv2d"

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -14,14 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import pytest
 import numpy as np
+import pytest
 
 import tvm
-
 from tvm import relax
-from tvm.script import relax as R, tir as T, ir as I
-from tvm.relax.dpl.pattern import make_fused_bias_activation_pattern, is_op, wildcard
+from tvm.relax.dpl.pattern import is_op, make_fused_bias_activation_pattern, wildcard
+from tvm.script import ir as I
+from tvm.script import relax as R
+from tvm.script import tir as T
 
 
 @tvm.script.ir_module
@@ -600,13 +601,23 @@ def test_unused():
 
 
 def test_check_pattern():
-    pat = make_fused_bias_activation_pattern("relax.nn.conv2d", with_bias=False, activation=None)
+    lhs = wildcard()
+    rhs = wildcard()
+    out = is_op("relax.nn.conv2d")(lhs, rhs)
+    annotation_patterns = {"root": out, "lhs": lhs, "rhs": rhs}
 
-    def pred(match, expr):
+    def pred(check_input):
+        lhs = check_input.annotated_expr["lhs"]
+        rhs = check_input.annotated_expr["rhs"]
+        expr = check_input.annotated_expr["root"]
+        assert isinstance(lhs, relax.expr.Var) and lhs.name_hint == "data"
+        assert isinstance(rhs, relax.expr.Var) and rhs.name_hint == "weight1"
         assert isinstance(expr, relax.expr.Call) and expr.op.name == "relax.nn.conv2d"
-        return expr.struct_info.dtype == "float32"
+        return False
 
-    check(Conv2dx2, [("cutlass.conv2d", pat, pred)], Conv2dx2)  # expect no partitioning
+    check(
+        Conv2dReLU, [("cutlass.conv2d", out, annotation_patterns, pred)], Conv2dReLU
+    )  # expect no partitioning
 
 
 def test_bind_constants():


### PR DESCRIPTION
This PR change the interface of the check function in FuseOpsByPattern, in order to make it possible to broader types of check during fusion. In particular,
1. The old check function signature is `bool(const Map<DFPattern, Expr>& match_result, const Expr& matched_expr)`, which isn't very useful because:
    - The `Map<DFPattern, Expr> match_result` is hard to consume. To retrieve the wanted expr from this map, one has to either keep track of the DFPattern that matches the expr, or to iterate through the map values and filter by expr type.
    - The `matched_expr` provides little help because one cannot traverse to other expressions from `matched_expr`, without the help from things like `var2val`.
2. The new signature is `bool(const PatternCheckContext&)`. A dedicated type `PatternCheckContext` is created for passing information to the check function. This prevents old check functions from being broken when new input needs to be supplied to the check function. Currently `PatternCheckContext` has 
```
  /*!
   * \brief A map which contains all expressions matched by the sub patterns in
   * FuseOpsPatternNode::annotation_patterns.
   */
  Map<String, Expr> annotated_expr;

  /*!
   * \brief A map mapping variable definitions to a set of uses.
   */
  Map<Var, Array<Var>> var_usages;

  /*!
   * \brief Map from value to its bound variable.
   */
  Map<Expr, Var> value_to_bound_var;
```
3. This PR also changes the signature of `FuseOpsByPattern`, while keeping it backward compatible.

As an example usage of the new FuseOpsByPattern API, this PR includes an improvement to the check function of cutlass conv2d residual block pattern, as a follow up of #14252.

cc @vinx13 @masahi 