### PR TITLE
[Bugfix][TVMScript] Preserve foldable constants while parsing

### DIFF
--- a/python/tvm/script/parser/tir/operation.py
+++ b/python/tvm/script/parser/tir/operation.py
@@ -44,14 +44,21 @@ def _register_expr_op(ty: Type):  # pylint: disable=invalid-name
     def r(op: Type, i: int, m: OpMethod):  # pylint: disable=invalid-name
         register_op(ty, op, i)(m)
 
+    # The operator overloads in python delegate to the C++ operator
+    # overloads, which perform constant folding.  While useful in most
+    # circumstances, the script parsing should avoid performing any
+    # manipulations while parsing, as this can invalidate unit tests
+    # that rely on known TIR inputs.  Therefore, we use the registered
+    # ops to avoid using the operator overloads for PrimExpr parsing,
+    # and instead construct the TIR objects directly.
     for i in [0, 1]:
         # Case 1. binop
-        # doc.Add <-- is overloaded
-        # doc.Sub <-- is overloaded
-        # doc.Mult <-- is overloaded
-        # doc.Div <-- is overloaded
-        # doc.FloorDiv <-- is overloaded
-        # doc.Mod <-- is overloaded
+        r(doc.Add, i, tir.Add)
+        r(doc.Sub, i, tir.Sub)
+        r(doc.Mult, i, tir.Mul)
+        r(doc.Div, i, tir.Div)
+        r(doc.FloorDiv, i, tir.FloorDiv)
+        r(doc.Mod, i, tir.FloorMod)
         # doc.LShift <-- is overloaded
         # doc.RShift <-- is overloaded
         # doc.BitOr <-- is overloaded

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -399,5 +399,17 @@ def test_implicit_evaluate_call_extern():
     assert_structural_equal(implicit, explicit)
 
 
+def test_preserve_foldable_constant():
+    @T.prim_func
+    def explicit(i: T.int32):
+        T.evaluate(T.Add(i, 0))
+
+    @T.prim_func
+    def implicit(i: T.int32):
+        T.evaluate(i + 0)
+
+    assert_structural_equal(implicit, explicit)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Avoid folding constants while parsing TVMScript.  This looks like a bug, which was introduced as part of the parsing changes implemented in https://github.com/apache/tvm/pull/14200.

The operator overloads in python delegate to the C++ operator overloads, which perform constant folding.  While useful in most circumstances, the script parsing should avoid performing any manipulations while parsing, as this can invalidate unit tests that rely on known TIR inputs.  This wasn't caught by any of the existing unit tests in `test_tvmscript_roundtrip.py`, as the inputs to those unit tests are generated by the parsing, and already have their constants folded.

There are a few edge cases that would still be constant-folded while parsing the TVMScript, but these only impact subexpressions that do not contain TVM-specific constructs.  For example, `T.evaluate(1 + 2)` would be parsed as `T.evaluate(3)`, because the `1 + 2` subexpression is evaluated during parsing.