### PR TITLE
[Bugfix][TVMScript] Preserve variable names in LetStmt

### DIFF
--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -145,6 +145,7 @@ def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -
     elif isinstance(value, PrimExpr):
         frame = T.LetStmt(value)
         var = frame.var
+        IRBuilder.name(var_name, var)
         frame.add_callback(partial(frame.__exit__, None, None, None))
         frame.__enter__()
         return var

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -399,5 +399,18 @@ def test_implicit_evaluate_call_extern():
     assert_structural_equal(implicit, explicit)
 
 
+def test_preserve_variable_name():
+    """Use variable name when generating tir::LetStmt"""
+
+    @T.prim_func
+    def func():
+        for i in T.serial(16):
+            j = i // 4
+            T.evaluate(j)
+
+    var_name = func.body.body.var.name
+    assert var_name == "j"
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
When the TVMScript parser generates a `tir::LetStmt` to represent assignment to a variable, the name of the TVMScript variable should be used as the name of the `tir::Var` in the `tir::LetStmt`.

This bug was introduced in https://github.com/apache/tvm/pull/14207.