### PR TITLE
[Unity][Web] WebGPU explicit max buffer size

### DIFF
--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -43,6 +43,7 @@ export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefin
     const adapterInfo = await adapter.requestAdapterInfo();
     const device = await adapter.requestDevice({
       requiredLimits: {
+        maxBufferSize: 1 << 30,
         maxStorageBufferBindingSize: 1 << 30,
         maxComputeWorkgroupStorageSize: 32 << 10,
       }


### PR DESCRIPTION
This PR specifies the maximum buffer size limit of WebGPU runtime explicitly so that the limit will not be a tight one by default.

In the future, we can analysis and detect the needed max buffer size limit and actively request the GPU.

Co-authored-by: Tianqi Chen <tianqi.tchen@gmail.com>