### PR TITLE
[Unity][Op] Fix Strided Slice Shape Inference

### DIFF
--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -24,7 +24,6 @@
 
 #include "index.h"
 
-#include <algorithm>
 #include <utility>
 #include <vector>
 
@@ -147,7 +146,7 @@ inline PrimExpr CanonicalizeIndex(PrimExpr index, PrimExpr extent, int64_t strid
   PrimExpr begin_range = stride < 0 ? -1 : 0;
   PrimExpr end_range = stride < 0 ? extent - 1 : extent;
   index = if_then_else(index < 0, index + extent, index);
-  return min(max(index, begin_range), end_range);
+  return min(max(index, begin_range), end_range);  // NOLINT
 }
 
 PrimExpr GetLength(PrimExpr begin, PrimExpr end, const int stride, const PrimExpr& ndim) {

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -24,6 +24,7 @@
 
 #include "index.h"
 
+#include <algorithm>
 #include <utility>
 #include <vector>
 

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -151,8 +151,6 @@ inline PrimExpr CanonicalizeIndex(PrimExpr index, PrimExpr extent, int64_t strid
 }
 
 PrimExpr GetLength(PrimExpr begin, PrimExpr end, const int stride, const PrimExpr& ndim) {
-  ICHECK_NE(stride, 0) << "Stride cannot be 0.";
-
   begin = CanonicalizeIndex(begin, ndim, stride);
   end = CanonicalizeIndex(end, ndim, stride);
 

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -151,9 +151,9 @@ inline PrimExpr CanonicalizeIndex(PrimExpr index, PrimExpr extent, int64_t strid
   return min(max(index, begin_range), end_range);  // NOLINT
 }
 
-PrimExpr GetLength(PrimExpr begin, PrimExpr end, const int64_t stride, const PrimExpr& ndim) {
-  begin = CanonicalizeIndex(begin, ndim, stride);
-  end = CanonicalizeIndex(end, ndim, stride);
+PrimExpr GetLength(PrimExpr begin, PrimExpr end, const int64_t stride, const PrimExpr& length) {
+  begin = CanonicalizeIndex(begin, length, stride);
+  end = CanonicalizeIndex(end, length, stride);
 
   if (stride < 0) {
     return ceildiv(begin - end, IntImm(DataType::Int(64), -stride));

--- a/tests/python/relax/test_op_index.py
+++ b/tests/python/relax/test_op_index.py
@@ -409,22 +409,22 @@ def test_strided_slice_infer_struct_info_shape_symbolic():
     _check_inference(
         bb,
         relax.op.strided_slice(x0, axes=[0], begin=[1], end=[3]),
-        relax.TensorStructInfo((2, n), "float32"),
+        relax.TensorStructInfo((tir.min(3, m) - tir.min(1, m) + 1 - 1, n), "float32"),
     )
     _check_inference(
         bb,
         relax.op.strided_slice(x0, axes=[0], begin=[1], end=[8], strides=[3]),
-        relax.TensorStructInfo((3, n), "float32"),
+        relax.TensorStructInfo(((tir.min(8, m) - tir.min(1, m) + 3 - 1) // 3, n), "float32"),
     )
     _check_inference(
         bb,
         relax.op.strided_slice(x1, axes=[0], begin=[1], end=[3]),
-        relax.TensorStructInfo((2, n), dtype=""),
+        relax.TensorStructInfo((tir.min(3, m) - tir.min(1, m) + 1 - 1, n), dtype=""),
     )
     _check_inference(
         bb,
         relax.op.strided_slice(x1, axes=[0], begin=[1], end=[8], strides=[3]),
-        relax.TensorStructInfo((3, n), dtype=""),
+        relax.TensorStructInfo(((tir.min(8, m) - tir.min(1, m) + 3 - 1) // 3, n), dtype=""),
     )
 
 

--- a/tests/python/relax/test_op_index.py
+++ b/tests/python/relax/test_op_index.py
@@ -366,6 +366,39 @@ def test_strided_slice_infer_struct_info():
     )
 
 
+def test_strided_slice_infer_struct_info_shape_out_of_range():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((20, 10, 5), "float32"))
+    _check_inference(
+        bb,
+        relax.op.strided_slice(
+            x0, axes=[0, 1, 2], begin=[20, 10, 4], end=[0, 0, 1], strides=[-1, -3, -2]
+        ),
+        relax.TensorStructInfo((19, 3, 2), "float32"),
+    )
+    _check_inference(
+        bb,
+        relax.op.strided_slice(
+            x0, axes=[0, 1, 2], begin=[200, 10, 4], end=[0, 0, 1], strides=[-1, -3, -2]
+        ),
+        relax.TensorStructInfo((19, 3, 2), "float32"),
+    )
+    _check_inference(
+        bb,
+        relax.op.strided_slice(
+            x0, axes=[0, 1, 2], begin=[200, 10, 100], end=[0, 0, 1], strides=[-1, -3, -5]
+        ),
+        relax.TensorStructInfo((19, 3, 1), "float32"),
+    )
+    _check_inference(
+        bb,
+        relax.op.strided_slice(
+            x0, axes=[0, 1, 2], begin=[-21, -11, -6], end=[1, 1, 1], strides=[1000, 1000, 1000]
+        ),
+        relax.TensorStructInfo((1, 1, 1), "float32"),
+    )
+
+
 def test_strided_slice_infer_struct_info_shape_symbolic():
     bb = relax.BlockBuilder()
     m = tir.Var("m", "int64")


### PR DESCRIPTION
In the case where the begin index of strided slice is out of [-ndim, dim), the strided slice operator will yield some incorrect shape inference. This PR corrected this issue by canonicalizing the begin and end index for strided slice and calculate the symbolic shape. Added some new unit tests for out of range begin locations and changed some symbolic shape tests.

I have 2 questions that we can follow up in the design:
1. Is it expected that in the case of symbolic shape input tensor we should have symbolic shape inferenced for generated tensors after strided slice? See unit test change for details, when we have different input shape at runtime we may have corresponding symbolic output shape.
2. We do have the similar function / logic in topi strided slice implementation. Should we unify them some how? Is it expected that we use some mechanism to store the shape inference logic for both relax / topi operators?

Would be great to see other contributors opinions on this.

CC: @MasterJH5574 @sunggg @tqchen 