### PR TITLE
[Unity][Pass] Reuse prior infra to implement more complete DCE

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -387,6 +387,7 @@ TVM_DLL Pass ConvertLayout(Map<String, Array<String>> desired_layouts);
 
 /*!
  * \brief Dead code elimination.
+ * \sa RemoveAllUnused
  * Currently it removes:
  *   1. Unused local VarBindings in a DataflowBlock.
  *   2. Unused DataflowBlocks in a function.

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -389,12 +389,8 @@ TVM_DLL Pass ConvertLayout(Map<String, Array<String>> desired_layouts);
  * \brief Dead code elimination.
  * Currently it removes:
  *   1. Unused local VarBindings in a DataflowBlock.
- *      The used var set is set to empty at the beginning of each DataflowBlock.
- *      We reverse scan the DataflowBlock, if a VarBinding
- *        - bindings to a dataflowvar, or
- *        - is used in the used var set
- *      We keep it and add its var to the used var set. Otherwise, we remove it.
- *   2. Unused Relax functions in the module.
+ *   2. Unused DataflowBlocks in a function.
+ *   3. Unused Relax functions in the module.
  *      We detect the call chain from the entry function, and remove all unused functions.
  * \return The Pass.
  */

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -316,7 +316,9 @@ def name_to_binding(func: Function) -> Dict[str, List[Binding]]:
 
 
 def remove_all_unused(func: Function) -> Function:
-    """Remove all unused variables from the function.
+    """It removes:
+    1. Unused local VarBindings in a DataflowBlock.
+    2. Unused DataflowBlocks in a function.
 
     Parameters
     ----------

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -325,6 +325,10 @@ def remove_all_unused(func: Function) -> Function:
     func : Function
         The input function to be analyzed.
 
+    Notes
+    -----
+    For IRModule-wise DCE, use py:func:`tvm.relax.transform.DeadCodeElimination`.
+
     Returns
     -------
     Function

--- a/python/tvm/relax/binding_rewrite.py
+++ b/python/tvm/relax/binding_rewrite.py
@@ -112,7 +112,7 @@ class DataflowBlockRewrite(Object):
 
     def remove_all_unused(self) -> None:
         """
-        Remove all unused variables. For IRModule-wise DCE, use py:func:`tvm.relax.transform.DeadCodeElimination`.
+        Remove all unused variables.
 
         Notes
         -----

--- a/python/tvm/relax/binding_rewrite.py
+++ b/python/tvm/relax/binding_rewrite.py
@@ -112,7 +112,7 @@ class DataflowBlockRewrite(Object):
 
     def remove_all_unused(self) -> None:
         """
-        Remove all unused variables.
+        Remove all unused variables. For IRModule-wise DCE, use py:func:`tvm.relax.transform.DeadCodeElimination`.
 
         Notes
         -----

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -658,7 +658,7 @@ def ConvertLayout(desired_layouts: Dict[str, List[str]]) -> tvm.ir.transform.Pas
 
 
 def DeadCodeElimination(entry_functions: Optional[List[str]] = None) -> tvm.ir.transform.Pass:
-    """Remove dead code in the program.
+    """Remove dead code in the IRModule. For function-wise DCE, use py:func:`tvm.relax.analysis.remove_all_unused`.
        Currently it removes:
        1. Unused local VarBindings in a DataflowBlock.
        2. Unused DataflowBlocks in a function.

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -661,12 +661,8 @@ def DeadCodeElimination(entry_functions: Optional[List[str]] = None) -> tvm.ir.t
     """Remove dead code in the program.
        Currently it removes:
        1. Unused local VarBindings in a DataflowBlock.
-          The used var set is set to empty at the beginning of each DataflowBlock.
-          We reverse scan the DataflowBlock, if a VarBinding
-            - bindings to a dataflowvar, or
-            - is used in the used var set
-          We keep it and add its var to the used var set. Otherwise, we remove it.
-        2. Unused Relax functions in the module.
+       2. Unused DataflowBlocks in a function.
+       3. Unused Relax functions in the module.
           We detect the call chain from the entry function, and remove all unused functions.
 
     Parameters

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -658,7 +658,7 @@ def ConvertLayout(desired_layouts: Dict[str, List[str]]) -> tvm.ir.transform.Pas
 
 
 def DeadCodeElimination(entry_functions: Optional[List[str]] = None) -> tvm.ir.transform.Pass:
-    """Remove dead code in the IRModule. For function-wise DCE, use py:func:`tvm.relax.analysis.remove_all_unused`.
+    """Remove dead code in the IRModule.
        Currently it removes:
        1. Unused local VarBindings in a DataflowBlock.
        2. Unused DataflowBlocks in a function.
@@ -669,6 +669,10 @@ def DeadCodeElimination(entry_functions: Optional[List[str]] = None) -> tvm.ir.t
     ----------
     entry_functions: Optional[List[str]]
         The set of entry functions to start from.
+
+    Notes
+    -----
+    For function-wise DCE, use py:func:`tvm.relax.analysis.remove_all_unused`.
 
     Returns
     -------

--- a/src/relax/transform/dead_code_elimination.cc
+++ b/src/relax/transform/dead_code_elimination.cc
@@ -21,15 +21,6 @@
 /*!
  * \file tvm/relax/transform/dead_code_elimination.cc
  * \brief Dead code elimination pass.
- * Currently it removes:
- *   1. Unused local VarBindings in a DataflowBlock.
- *      The used var set is set to empty at the beginning of each DataflowBlock.
- *      We reverse scan the DataflowBlock, if a VarBinding
- *        - bindings to a DataflowVar, or
- *        - is used in the used var set
- *      We keep it and add its var to the used var set. Otherwise, we remove it.
- *   2. Unused Relax functions in the module.
- *      We detect the call chain from the entry function, and remove all unused functions.
  */
 
 #include <tvm/relax/analysis.h>
@@ -104,61 +95,6 @@ IRModule RemoveUnusedFunctions(IRModule mod_, Array<runtime::String> entry_funcs
   }
   return mod_;
 }
-
-class DeadCodeEliminator : public ExprMutator {
- private:
-  Expr VisitExpr_(const VarNode* op) final {
-    ICHECK(!used_vars_.empty());
-    used_vars_.back().insert(GetRef<Var>(op));
-    return GetRef<Expr>(op);
-  }
-
-  Expr VisitExpr_(const DataflowVarNode* op) final {
-    ICHECK(!used_vars_.empty());
-    used_vars_.back().insert(GetRef<Var>(op));
-    return GetRef<Expr>(op);
-  }
-
-  void VisitBinding_(const VarBindingNode* binding) { this->VisitExpr(binding->value); }
-
-  void VisitBinding_(const MatchCastNode* binding) {
-    this->VisitExpr(binding->value);
-    this->VisitAndCheckStructInfoFieldUnchanged(binding->struct_info);
-  }
-
-  BindingBlock VisitBindingBlock_(const DataflowBlockNode* block) final {
-    // reverse scan the data flow block to find the used vars
-    used_vars_.push_back({});
-
-    std::vector<Binding> new_bindings;
-    for (auto rit = block->bindings.rbegin(); rit != block->bindings.rend(); rit++) {
-      const Var& var = (*rit)->var;
-      // only keep the used bindings or non dataflow var bindings
-      if (used_vars_.back().count(var) || !var->IsInstance<DataflowVarNode>()) {
-        new_bindings.push_back(*rit);
-        // collect the used vars
-        this->VisitBinding((*rit));
-      }
-    }
-
-    used_vars_.pop_back();
-    // reverse the bindings
-    std::reverse(new_bindings.begin(), new_bindings.end());
-    if (new_bindings.size() == block->bindings.size()) {
-      return GetRef<BindingBlock>(block);
-    } else {
-      auto n = make_object<DataflowBlockNode>(*block);
-      n->bindings = std::move(new_bindings);
-      return BindingBlock(n);
-    }
-  }
-
-  BindingBlock VisitBindingBlock_(const BindingBlockNode* block) final {
-    return GetRef<BindingBlock>(block);
-  }
-
-  std::vector<std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>> used_vars_{{}};
-};
 
 IRModule DeadCodeElimination(const IRModule& mod, Array<runtime::String> entry_functions) {
   // S1: remove unused functions to reduce the number of functions to be analyzed.

--- a/src/relax/transform/dead_code_elimination.cc
+++ b/src/relax/transform/dead_code_elimination.cc
@@ -21,6 +21,13 @@
 /*!
  * \file tvm/relax/transform/dead_code_elimination.cc
  * \brief Dead code elimination pass.
+ * \sa tvm/relax/ir/binding_rewrite.cc
+ *
+ * Currently it removes:
+ *   1. Unused local VarBindings in a DataflowBlock.
+ *   2. Unused DataflowBlocks in a function.
+ *   3. Unused Relax functions in the module.
+ *      We detect the call chain from the entry function, and remove all unused functions.
  */
 
 #include <tvm/relax/analysis.h>

--- a/src/relax/transform/dead_code_elimination.cc
+++ b/src/relax/transform/dead_code_elimination.cc
@@ -89,7 +89,7 @@ class CallTracer : ExprVisitor {
   std::unordered_set<Expr, ObjectPtrHash, ObjectPtrEqual> visiting_;
 };
 
-IRModule RemoveDeadFunctions(IRModule mod_, Array<runtime::String> entry_funcs) {
+IRModule RemoveUnusedFunctions(IRModule mod_, Array<runtime::String> entry_funcs) {
   auto tracer = CallTracer(mod_);
   for (auto entry : entry_funcs) {
     tracer.Trace(entry);
@@ -162,7 +162,7 @@ class DeadCodeEliminator : public ExprMutator {
 
 IRModule DeadCodeElimination(const IRModule& mod, Array<runtime::String> entry_functions) {
   // S1: remove unused functions to reduce the number of functions to be analyzed.
-  IRModule tmp_mod = RemoveDeadFunctions(mod, entry_functions);
+  IRModule tmp_mod = RemoveUnusedFunctions(mod, entry_functions);
   // S2: remove unused variables in each function.
   for (const auto& gv : tmp_mod->GetGlobalVars()) {
     auto func = tmp_mod->Lookup(gv);
@@ -171,7 +171,7 @@ IRModule DeadCodeElimination(const IRModule& mod, Array<runtime::String> entry_f
     }
   }
   // S3: remove unused functions again as some callers may be removed in S2.
-  return RemoveDeadFunctions(tmp_mod, entry_functions);
+  return RemoveUnusedFunctions(tmp_mod, entry_functions);
 }
 
 namespace transform {

--- a/tests/python/relax/test_transform_dead_code_elimination.py
+++ b/tests/python/relax/test_transform_dead_code_elimination.py
@@ -17,7 +17,6 @@
 
 import tvm
 import tvm.testing
-from tvm.relax.analysis import remove_all_unused
 from tvm.relax.transform import DeadCodeElimination
 from tvm.script.parser import ir as I, relax as R, tir as T
 


### PR DESCRIPTION
As a follow-up to https://github.com/apache/tvm/pull/14262, I just noticed that I previously implemented a function called `RemoveAllUnused` (https://github.com/apache/tvm/pull/14043) that can do function-wise DCE and should be more complete than https://github.com/apache/tvm/pull/14262 as `RemoveAllUnused` can also remove dead dataflow blocks (added two test-cases to show that). 

Sorry, I should have mentioned that earlier to avoid duplication... but still I am putting a patch here in case it is desired.

cc: @spectrometerHBH @tqchen 
