### PR TITLE
[Unity] Remove Python interface of RemoveUnusedFunction

### DIFF
--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -190,24 +190,6 @@ def BindParams(
     return _ffi_api.BindParams(func_name, tvm_params)  # type: ignore
 
 
-def RemoveUnusedFunctions(entry_functions: Optional[List[str]] = None) -> tvm.ir.transform.Pass:
-    """Remove unused relax/prim functions without external linkage in a IRModule.
-
-    Parameters
-    ----------
-    entry_functions: Optional[List[str]]
-        The set of entry functions to start from.
-
-    Returns
-    -------
-    ret : tvm.transform.Pass
-        The registered pass to remove unused functions.
-    """
-    if entry_functions is None:
-        entry_functions = ["main"]
-    return _ffi_api.RemoveUnusedFunctions(entry_functions)  # type: ignore
-
-
 def RunCodegen(
     target_options: Optional[dict] = None,
     entry_functions: Optional[List[str]] = None,

--- a/src/relax/transform/alter_op_impl.cc
+++ b/src/relax/transform/alter_op_impl.cc
@@ -92,6 +92,8 @@ class AlterOpImplMutator : public ExprMutator {
   }
 
  private:
+  using ExprMutator::VisitExpr_;
+
   Expr VisitExpr_(const CallNode* op) final {
     auto call = Downcast<Call>(ExprMutator::VisitExpr_(op));
 

--- a/src/relax/transform/to_mixed_precision.cc
+++ b/src/relax/transform/to_mixed_precision.cc
@@ -321,7 +321,7 @@ class ToMixedPrecisionRewriter : public ExprMutator {
   // Util function to check if any of the tensors in the args is fp32
   bool AnyArgIsFP32(const NType& cur_type) {
     bool result = false;
-    auto fvisitleaf = [&, this](const String& dtype) {
+    auto fvisitleaf = [&](const String& dtype) {
       if (dtype == "float32") {
         result = true;
       }


### PR DESCRIPTION
The pass RemoveUnusedFunctions was renamed and enhanced to the DCE pass in #14262. This PR removes the Python interface of RemoveUnusedFunctions in transform.py.

It is surprising that this Python API was never tested in any testing file before.

This PR also fixes `alter_op_impl.cc` and `to_mixed_precision.cc` to for Clang build warnings.