### PR TITLE
[Unity][TVMScript] Register the dispatch for `runtime::Module`

### DIFF
--- a/src/script/printer/ir/ir.cc
+++ b/src/script/printer/ir/ir.cc
@@ -103,6 +103,14 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     });
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
+    .set_dispatch<runtime::Module>("",
+                                   [](runtime::Module rtmod, ObjectPath p, IRDocsifier d) -> Doc {
+                                     std::ostringstream oss;
+                                     oss << rtmod << ", " << rtmod.get();
+                                     return LiteralDoc::Str(String(oss.str()), NullOpt);
+                                   });
+
+TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<DictAttrs>("", [](DictAttrs attrs, ObjectPath p, IRDocsifier d) -> Doc {
       return d->AsDoc(attrs->dict, p->Attr("dict"));
     });


### PR DESCRIPTION
This PR registers the dispatch for `runtime::Module` so that we can print `IRModule` with BYOC runtime after `RunCodegen` pass. 

cc. @yelite @junrushao 