### PR TITLE
[Docs] Update listed tvmc python dependencies

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -335,7 +335,7 @@ like ``virtualenv``.
 
    .. code:: bash
 
-       pip3 install --user typing-extensions
+       pip3 install --user typing-extensions psutil scipy
 
    * If you want to use RPC Tracker
 


### PR DESCRIPTION
Update the list of python packages required to run a `tvmc` invocation after building TVM from source.