### PR TITLE
[TOPI] Fix data race of batch multibox detection

### DIFF
--- a/python/tvm/topi/cuda/ssd/multibox.py
+++ b/python/tvm/topi/cuda/ssd/multibox.py
@@ -234,7 +234,7 @@ def transform_loc_pre(cls_prob, valid_count, temp_valid_count, temp_cls_id, temp
                     temp_valid_count[tid * num_anchors + k] += temp_valid_count[
                         tid * num_anchors + k - 1
                     ]
-            valid_count[i] = temp_valid_count[tid * num_anchors + num_anchors - 1]
+            valid_count[tid] = temp_valid_count[tid * num_anchors + num_anchors - 1]
 
     return ib.get()
 
@@ -342,7 +342,7 @@ def transform_loc_ir(
         j = idxm(tid, num_anchors)
 
         with ib.if_scope(cls_id[tid] > 0):
-            with ib.if_scope(tid == 0):
+            with ib.if_scope(j == 0):
                 out_base_idx = i * num_anchors * 6
                 out_loc[out_base_idx] = cls_id[tid] - 1.0
                 out_loc[out_base_idx + 1] = score[tid]

--- a/python/tvm/topi/vision/ssd/multibox.py
+++ b/python/tvm/topi/vision/ssd/multibox.py
@@ -137,17 +137,17 @@ def multibox_prior(data, sizes=(1,), ratios=(1,), steps=(-1, -1), offsets=(0.5, 
 
 
 @hybrid.script
-def _hybridy_transform_loc(box, pred_loc, variance, clip):
+def _hybridy_transform_loc(box, pred_loc, variance, clip, batch_idx):
     """Transform prior anchor box to output box through location predictions."""
-    al = box[0]
-    at = box[1]
-    ar = box[2]
-    ab = box[3]
+    al = box[batch_idx, 0]
+    at = box[batch_idx, 1]
+    ar = box[batch_idx, 2]
+    ab = box[batch_idx, 3]
 
-    px = pred_loc[0]
-    py = pred_loc[1]
-    pw = pred_loc[2]
-    ph = pred_loc[3]
+    px = pred_loc[batch_idx, 0]
+    py = pred_loc[batch_idx, 1]
+    pw = pred_loc[batch_idx, 2]
+    ph = pred_loc[batch_idx, 3]
 
     vx = variance[0]
     vy = variance[1]
@@ -206,8 +206,20 @@ def hybrid_multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, v
     batch_size = cls_prob.shape[0]
     num_classes = cls_prob.shape[1]
     num_anchors = cls_prob.shape[2]
-    box_coord = allocate((4,), loc_pred.dtype)
-    pred_coord = allocate((4,), loc_pred.dtype)
+    box_coord = allocate(
+        (
+            batch_size,
+            4,
+        ),
+        loc_pred.dtype,
+    )
+    pred_coord = allocate(
+        (
+            batch_size,
+            4,
+        ),
+        loc_pred.dtype,
+    )
     out_loc = output_tensor((batch_size, num_anchors, 6), loc_pred.dtype)
     valid_count = output_tensor((batch_size,), "int32")
 
@@ -230,9 +242,9 @@ def hybrid_multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, v
                 out_loc[i, valid_count[i], 0] = cls_id - 1.0
                 out_loc[i, valid_count[i], 1] = score
                 for l in range(4):
-                    box_coord[l] = anchor[0, j, l]
-                    pred_coord[l] = loc_pred[i, j * 4 + l]
-                out_coord = _hybridy_transform_loc(box_coord, pred_coord, variances, clip)
+                    box_coord[i, l] = anchor[0, j, l]
+                    pred_coord[i, l] = loc_pred[i, j * 4 + l]
+                out_coord = _hybridy_transform_loc(box_coord, pred_coord, variances, clip, i)
                 out_loc[i, valid_count[i], 2] = out_coord[0]
                 out_loc[i, valid_count[i], 3] = out_coord[1]
                 out_loc[i, valid_count[i], 4] = out_coord[2]

--- a/python/tvm/topi/vision/ssd/multibox.py
+++ b/python/tvm/topi/vision/ssd/multibox.py
@@ -137,12 +137,12 @@ def multibox_prior(data, sizes=(1,), ratios=(1,), steps=(-1, -1), offsets=(0.5, 
 
 
 @hybrid.script
-def _hybridy_transform_loc(box, pred_loc, variance, clip, batch_idx):
+def _hybridy_transform_loc(anchor, pred_loc, variance, clip, batch_idx, anchor_idx):
     """Transform prior anchor box to output box through location predictions."""
-    al = box[batch_idx, 0]
-    at = box[batch_idx, 1]
-    ar = box[batch_idx, 2]
-    ab = box[batch_idx, 3]
+    al = anchor[0, anchor_idx, 0]
+    at = anchor[0, anchor_idx, 1]
+    ar = anchor[0, anchor_idx, 2]
+    ab = anchor[0, anchor_idx, 3]
 
     px = pred_loc[batch_idx, 0]
     py = pred_loc[batch_idx, 1]
@@ -242,9 +242,8 @@ def hybrid_multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, v
                 out_loc[i, valid_count[i], 0] = cls_id - 1.0
                 out_loc[i, valid_count[i], 1] = score
                 for l in range(4):
-                    box_coord[i, l] = anchor[0, j, l]
                     pred_coord[i, l] = loc_pred[i, j * 4 + l]
-                out_coord = _hybridy_transform_loc(box_coord, pred_coord, variances, clip, i)
+                out_coord = _hybridy_transform_loc(anchor, pred_coord, variances, clip, i, j)
                 out_loc[i, valid_count[i], 2] = out_coord[0]
                 out_loc[i, valid_count[i], 3] = out_coord[1]
                 out_loc[i, valid_count[i], 4] = out_coord[2]

--- a/python/tvm/topi/vision/ssd/multibox.py
+++ b/python/tvm/topi/vision/ssd/multibox.py
@@ -206,13 +206,6 @@ def hybrid_multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, v
     batch_size = cls_prob.shape[0]
     num_classes = cls_prob.shape[1]
     num_anchors = cls_prob.shape[2]
-    box_coord = allocate(
-        (
-            batch_size,
-            4,
-        ),
-        loc_pred.dtype,
-    )
     pred_coord = allocate(
         (
             batch_size,


### PR DESCRIPTION
- For cpu,  currently the buffer space of `box_coord` and `pred_coord` is shared across parallel batch like
```python
for i in parallel(batch_size):
    # ...
                for l in range(4):
                    box_coord[l] = anchor[0, j, l]
                    pred_coord[l] = loc_pred[i, j * 4 + l]
```

- For cuda, fix two index usage error of batch idx.