### PR TITLE
[CI][Lint] Update black

### DIFF
--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -35,7 +35,7 @@ ENV PYTHONNOUSERSITE 1  # Disable .local directory from affecting CI.
 
 RUN apt-get update && apt-install-and-clear -y doxygen graphviz curl shellcheck
 
-RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==22.3.0 flake8==3.9.2 blocklint==0.2.3 jinja2==3.0.3
+RUN pip3 install cpplint pylint==2.4.4 mypy==0.902 black==22.12.0 flake8==3.9.2 blocklint==0.2.3 jinja2==3.0.3
 
 # Rust env (build early; takes a while)
 COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh


### PR DESCRIPTION
Goes to the latest revision in the same major version (22.12.0). 

23.1.0 is released but it involves some style changes so we would need to reformat the entire codebase. 

I need 22.12.0 to properly deal with processing some files found in this PR: 

https://github.com/apache/tvm/pull/14167

Where black cannot parse the file in the current version, but can in the updated version.