### PR TITLE
[Unity] Support model kwargs in dynamo_capture_subgraph

### DIFF
--- a/python/tvm/relax/frontend/torch/dynamo.py
+++ b/python/tvm/relax/frontend/torch/dynamo.py
@@ -142,7 +142,7 @@ def dynamo_capture_subgraphs(model, *params, **kwargs) -> tvm.IRModule:
     from torch import _dynamo as dynamo  # type: ignore[import]
 
     keep_params_as_input = "keep_params_as_input" in kwargs and kwargs["keep_params_as_input"]
-
+    kwargs.pop("keep_params_as_input", None)
     mod = tvm.IRModule()
 
     def _capture(graph_module: fx.GraphModule, example_inputs):
@@ -159,7 +159,7 @@ def dynamo_capture_subgraphs(model, *params, **kwargs) -> tvm.IRModule:
 
     dynamo.reset()
     compiled_model = torch.compile(model, backend=_capture)
-    compiled_model(*params)
+    compiled_model(*params, **kwargs)
     return mod
 
 


### PR DESCRIPTION
This PR enables user to pass the torch model's kwargs of forward function to dynamo_capture_subgraph, which makes it more flexible. 

cc: @spectrometerHBH 