### PR TITLE
[Unity][BYOC] Check leaked intermediate variables in cutlass patterns

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -276,23 +276,38 @@ class FusionPattern : public ObjectRef {
 class PatternCheckContextNode : public Object {
  public:
   /*!
+   * \brief The expression that's matched with the FusionPattern::pattern.
+   */
+  Expr matched_expr;
+
+  /*!
    * \brief A map which contains all expressions matched by the sub patterns in
    * FusionPattern::annotation_patterns.
    */
   Map<String, Expr> annotated_expr;
 
   /*!
-   * \brief A map mapping variable definitions to a set of uses.
+   * \brief Map from variable to its value. It contains variables from bindings that
+   * is being fused by FuseOpsByPattern.
+   */
+  Map<Var, Expr> matched_bindings;
+
+  /*!
+   * \brief A map mapping variable definitions to a set of uses. It has all variables
+   * used in the function.
    */
   Map<Var, Array<Var>> var_usages;
 
   /*!
-   * \brief Map from value to its bound variable.
+   * \brief Map from value to its bound variable. It doesn't have variables after the
+   * matched expression.
    */
   Map<Expr, Var> value_to_bound_var;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
+    v->Visit("matched_expr", &matched_expr);
     v->Visit("annotated_expr", &annotated_expr);
+    v->Visit("matched_bindings", &matched_bindings);
     v->Visit("var_usages", &var_usages);
     v->Visit("value_to_bound_var", &value_to_bound_var);
   }
@@ -303,7 +318,8 @@ class PatternCheckContextNode : public Object {
 
 class PatternCheckContext : public ObjectRef {
  public:
-  PatternCheckContext(Map<String, Expr> annotated_expr, Map<Var, Array<Var>> var_usages,
+  PatternCheckContext(Expr matched_expr, Map<String, Expr> annotated_expr,
+                      Map<Var, Expr> matched_bindings, Map<Var, Array<Var>> var_usages,
                       Map<Expr, Var> value_to_bound_var);
 
   TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(PatternCheckContext, ObjectRef,

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -277,18 +277,29 @@ class PatternCheckContext(Object):
 
     Parameters
     ----------
+    matched_expr: Expr
+        The expression that's matched with the FusionPattern.pattern.
+
     annotated_expr: Mapping[str, Expr]
         A map which contains all expressions matched by the sub patterns in
         FusionPattern.annotation_patterns.
 
+    matched_bindings: Mapping[Var, Expr]
+        Map from variable to its value. It contains variables from bindings that is
+        being fused by FuseOpsByPattern.
+
     var_usages: Mapping[Var, Sequence[Var]]
-        A map mapping variable definitions to a set of uses.
+        A map mapping variable definitions to a set of uses. It has all variables
+        used in the function.
 
     value_to_bound_var: Mapping[Expr, Var]
-        Map from value to its bound variable.
+        Map from value to its bound variable. It doesn't have variables after the
+        matched expression.
     """
 
+    matched_expr: Expr
     annotated_expr: Mapping[str, Expr]
+    matched_bindings: Mapping[Var, Expr]
     var_usages: Mapping[Var, Sequence[Var]]
     value_to_bound_var: Mapping[Expr, Var]
 


### PR DESCRIPTION
This PR adds new check logic to the BYOC patterns for cutlass, to ensure intermediate variables in the fused region aren't used outside.

For example, 
```python
@R.function
def main(x: R.Tensor((128, 128), "float16"), w: R.Tensor((128, 128), "float16")):
    with R.dataflow():
        lv = R.matmul(x, w)
        lv1 = R.power(lv, R.const(2.0, "float16"))
        lv2 = R.add(lv, lv1)
        R.output(lv2)
    return lv2
```
Without the new check logic, this function would be fused as biased matmul, which isn't correct because the bias (`lv1`) depends on the result of matmul.

cc @vinx13 @masahi 