### PR TITLE
[Unity] Add support to append relay op attrs in translator

### DIFF
--- a/tests/python/relax/test_relay_translator.py
+++ b/tests/python/relax/test_relay_translator.py
@@ -296,5 +296,17 @@ def test_translate_tuple_arg():
     assert_structural_equal(relax_mod, bb.get())
 
 
+def test_append_op_attrs():
+    x = relay.var("x", shape=(10, 16))
+    y = relay.var("y", shape=(10, 16))
+    relay_mod = tvm.IRModule.from_expr(relay.Function([x, y], relay.concatenate((x, y), axis=-1)))
+    relax_mod_wo_attrs = relay_translator.from_relay(relay_mod["main"], target="llvm")
+    relax_mod_with_attrs = relay_translator.from_relay(
+        relay_mod["main"], target="llvm", append_op_attrs=True
+    )
+    assert "op_attrs" in relax_mod_with_attrs["concatenate"].attrs
+    assert "op_attrs" not in relax_mod_wo_attrs["concatenate"].attrs
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This PR adds an argument to the relay to relax translator to append the relay Op Attrs as function attributes to the generated TIR PrimFuncs

This information is really useful in Relax as the absence of this prevents us from being able schedule efficiently for ops that are heavily sensitive to the attributes.

For example, the `groups` attribute to `conv2d` op is needed to differentiate between regular conv2d and depthwise conv2d.