### PR TITLE
[Unity][Fix] Fix block memory plan to handle bool

### DIFF
--- a/src/relax/transform/static_plan_block_memory.cc
+++ b/src/relax/transform/static_plan_block_memory.cc
@@ -107,8 +107,7 @@ class StorageToken : public ObjectRef {
     }
 
     ObjectPtr<StorageTokenNode> n = make_object<StorageTokenNode>();
-    int bytes_per_element = (dtype.bits() * dtype.lanes() + 7) / 8;
-    n->bytes = size * bytes_per_element;
+    n->bytes = size * dtype.bytes() * dtype.lanes();
     n->dtype = dtype;
     data_ = std::move(n);
   }

--- a/src/relax/transform/static_plan_block_memory.cc
+++ b/src/relax/transform/static_plan_block_memory.cc
@@ -107,7 +107,8 @@ class StorageToken : public ObjectRef {
     }
 
     ObjectPtr<StorageTokenNode> n = make_object<StorageTokenNode>();
-    n->bytes = (size * dtype.bits() * dtype.lanes() + 7) / 8;
+    int bytes_per_element = (dtype.bits() * dtype.lanes() + 7) / 8;
+    n->bytes = size * bytes_per_element;
     n->dtype = dtype;
     data_ = std::move(n);
   }


### PR DESCRIPTION
This PR fixes the size calculation of storage tokens in Static Plan Block Memory pass. Prior to this PR the storage for a tensor  `R.Tensor((2, 3), dtype="bool")` would be calculated as `R.memory.alloc_storage(R.shape([1]), dtype="bool")` instead of `R.memory.alloc_storage(R.shape([6]), dtype="bool")`

cc @jwfromm @MasterJH5574 