### PR TITLE
[Unity][Fix] Allow scalar layout initialization

### DIFF
--- a/src/relax/transform/infer_layout_utils.cc
+++ b/src/relax/transform/infer_layout_utils.cc
@@ -53,7 +53,7 @@ int FindAxis(const Layout& dst, int axis) {
 }
 
 Layout InitialLayout(int ndim) {
-  ICHECK(ndim > 0 && ndim <= 26) << "Only support up to 26 dimensions";
+  ICHECK(ndim >= 0 && ndim <= 26) << "Only support up to 26 dimensions, but got " << ndim;
   return Layout("ABCDEFGHIJKLMNOPQRSTUVWXYZ").SubLayout(0, ndim);
 }
 
@@ -61,7 +61,7 @@ LayoutDecision InitialLayoutDecision(int ndim) {
   if (ndim == kUnknownNDim) {
     return LayoutDecision::InitUnknownDim();
   }
-  ICHECK(ndim >= 0 && ndim <= 26) << "Only support up to 26 dimensions";
+  ICHECK(ndim >= 0 && ndim <= 26) << "Only support up to 26 dimensions, but got " << ndim;
   return Layout("ABCDEFGHIJKLMNOPQRSTUVWXYZ").SubLayout(0, ndim);
 }
 

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -708,6 +708,19 @@ def test_conv2d_transpose():
     verify(Input, Expected)
 
 
+def test_expand_dims_scalar():
+    @I.ir_module
+    class Input:
+        @R.function
+        def main() -> R.Tensor((1,), dtype="int64"):
+            with R.dataflow():
+                gv: R.Tensor((1,), dtype="int64") = R.expand_dims(R.const(0, "int64"), axis=[0])
+                R.output(gv)
+            return gv
+
+    verify(Input, Input)
+
+
 def test_conv2d_expand_dims():
     @I.ir_module
     class Input:


### PR DESCRIPTION
Fix assert to allow scalar (ndim=0) layout initialization.

cc @jwfromm @spectrometerHBH 