### PR TITLE
[Unity][VM] Add CUDA graph vm builtins

### DIFF
--- a/cmake/modules/CUDA.cmake
+++ b/cmake/modules/CUDA.cmake
@@ -92,6 +92,10 @@ if(USE_CUDA)
     tvm_file_glob(GLOB RUNTIME_CUDA_GRAPH_SRCS src/runtime/graph_executor/cuda_graph/*.cc)
     list(APPEND RUNTIME_SRCS ${RUNTIME_CUDA_GRAPH_SRCS})
   endif()
+
+  # Add CUDA builtins to RelaxVM
+  tvm_file_glob(GLOB RELAX_VM_CUDA_BUILTIN_SRC_CC src/runtime/relax_vm/cuda/*.cc)
+  list(APPEND RUNTIME_SRCS ${RELAX_VM_CUDA_BUILTIN_SRC_CC})
 else(USE_CUDA)
   list(APPEND COMPILER_SRCS src/target/opt/build_cuda_off.cc)
 endif(USE_CUDA)

--- a/src/runtime/relax_vm/cuda/cuda_graph_builtin.cc
+++ b/src/runtime/relax_vm/cuda/cuda_graph_builtin.cc
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/runtime/relax_vm/cuda_graph_builtin.cc
+ * \brief The CUDA graph related builtin functions for Relax virtual machine.
+ */
+
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/runtime/relax_vm/vm.h>
+
+#include "../../cuda/cuda_common.h"
+namespace tvm {
+namespace runtime {
+namespace relax_vm {
+
+/*! \brief Represents a CUDA graph. */
+class CUDAGraphNode : public Object {
+ public:
+  cudaGraph_t handle_ = nullptr;
+
+  ~CUDAGraphNode() {
+    if (handle_ != nullptr) {
+      cudaGraphDestroy(handle_);
+    }
+  }
+
+  TVM_DECLARE_FINAL_OBJECT_INFO(CUDAGraphNode, Object);
+};
+
+/*!
+ * \brief Managed reference to CUDAGraphNode
+ * \sa CUDAGraphNode
+ */
+class CUDAGraph : public ObjectRef {
+ public:
+  explicit CUDAGraph(cudaGraph_t handle) {
+    auto n = make_object<CUDAGraphNode>();
+    n->handle_ = handle;
+    data_ = std::move(n);
+  }
+  TVM_DEFINE_OBJECT_REF_METHODS(CUDAGraph, ObjectRef, CUDAGraphNode);
+};
+
+/*! \brief The cache states of a CUDA graph. */
+class CUDAGraphCache : public Object {
+ public:
+  struct CaptureResult {
+    /*!
+     * \brief Tuple of intemediate tensors in the capture func that will be used outside the
+     * capture func
+     */
+    ObjectRef states;
+    /*! \brief The cuda graph instance */
+    CUDAGraph graph;
+  };
+
+  static CUDAGraphCache* Get() { return dmlc::ThreadLocalStore<CUDAGraphCache>::Get(); }
+
+  /*!
+   * \brief Launch the cuda graph if it has been cached, otherwise execute it in capture mode.
+   * \param vm The virutal machine.
+   * \param capture_func The function of type (args...) -> Tuple[ObjectRef], where 'args' are the
+   * static arguments that are the same for all invocations of the capture function, the returned
+   * tuple contains the intermediate tensors that will be used outside the capture function.
+   * \params args The static arguments of the capture function
+   * \param entry_index The unique index of the capture function used for lookup.
+   * \return The return value of the capture function.
+   */
+  ObjectRef RunOrCapture(VirtualMachine* vm, const ObjectRef& capture_func, ObjectRef args,
+                         int64_t entry_index) {
+    if (auto it = capture_cache_.find(entry_index); it != capture_cache_.end()) {
+      LOG(INFO) << "HIT";
+      // Launch CUDA graph
+      const auto& [states, cuda_graph] = it->second;
+      cudaGraphExec_t cuda_graph_exec;
+      CUDA_CALL(cudaGraphInstantiate(&cuda_graph_exec, cuda_graph->handle_, NULL, NULL, 0));
+      CUDA_CALL(cudaGraphLaunch(cuda_graph_exec, CUDAThreadEntry::ThreadLocal()->stream));
+      CUDA_CALL(cudaGraphExecDestroy(cuda_graph_exec));
+      return states;
+    }
+
+    cudaStream_t capture_stream;
+    CUDA_CALL(cudaStreamCreate(&capture_stream));
+    CUDAGraphCache::CaptureResult entry;
+
+    // Set up arguments for the graph execution
+    Array<ObjectRef> tuple_args = Downcast<Array<ObjectRef>>(args);
+    int nargs = static_cast<int>(tuple_args.size());
+    std::vector<TVMValue> values(nargs);
+    std::vector<int> tcodes(nargs);
+    TVMArgsSetter setter(values.data(), tcodes.data());
+    for (int i = 0; i < nargs; ++i) {
+      ObjectRef arg = tuple_args[i];
+      setter(i, arg);
+    }
+
+    TVMRetValue capture_func_rv;
+    // Run the function without CUDA graph. This is a warm up step to do necessary initialization
+    // of the CUDA module such as loading module data, setting kernel attributes.
+    vm->InvokeClosurePacked(capture_func, TVMArgs(values.data(), tcodes.data(), nargs),
+                            &capture_func_rv);
+
+    // Run the graph in capture mode
+    cudaGraph_t graph;
+    std::swap(capture_stream, CUDAThreadEntry::ThreadLocal()->stream);
+    CUDA_CALL(cudaStreamBeginCapture(CUDAThreadEntry::ThreadLocal()->stream,
+                                     cudaStreamCaptureModeGlobal));
+
+    vm->InvokeClosurePacked(capture_func, TVMArgs(values.data(), tcodes.data(), nargs),
+                            &capture_func_rv);
+    entry.states = capture_func_rv;
+    CUDA_CALL(cudaStreamEndCapture(CUDAThreadEntry::ThreadLocal()->stream, &graph));
+    std::swap(capture_stream, CUDAThreadEntry::ThreadLocal()->stream);
+
+    entry.graph = CUDAGraph(graph);
+    capture_cache_[entry_index] = entry;
+    CUDA_CALL(cudaStreamDestroy(capture_stream));
+    return entry.states;
+  }
+
+  /*!
+   * \brief Get the cached allocation from the cache or run the allocation function.
+   * \param vm The virtual machine.
+   * \param alloc_func The function of type () -> ObjectRef, where the returned object is the
+   * tuple of allocated storage objects.
+   * \param entry_index The unique index of the allocation function used for lookup.
+   */
+  ObjectRef GetCachedAllocation(VirtualMachine* vm, const ObjectRef& alloc_func,
+                                int64_t entry_index) {
+    if (auto it = alloc_cache_.find(entry_index); it != alloc_cache_.end()) {
+      return it->second;
+    }
+    TVMRetValue alloc_func_rv;
+    vm->InvokeClosurePacked(alloc_func, TVMArgs(nullptr, nullptr, 0), &alloc_func_rv);
+    ObjectRef alloc_result = alloc_func_rv;
+    alloc_cache_[entry_index] = alloc_result;
+    return alloc_result;
+  }
+
+ private:
+  /*!
+   * \brief The cache of captured cuda graphs. The key is a unique index for the capture function.
+   * The value is the result of the capture.
+   */
+  std::unordered_map<int64_t, CaptureResult> capture_cache_;
+  /*!
+   * \brief The cache of allocations. The key is a unique index for the allocation function.
+   * The value is the cached allocations, which is a tuple of storages.
+   */
+  std::unordered_map<int64_t, ObjectRef> alloc_cache_;
+};
+
+TVM_REGISTER_GLOBAL("vm.builtin.cuda_graph.run_or_capture")
+    .set_body_typed([](TVMArgValue vm_ptr, ObjectRef capture_func, ObjectRef func_args,
+                       int64_t entry_index) {
+      VirtualMachine* vm = VirtualMachine::GetContextPtr(vm_ptr);
+      CUDAGraphCache* cache = CUDAGraphCache::Get();
+      return cache->RunOrCapture(vm, capture_func, func_args, entry_index);
+    });
+
+TVM_REGISTER_GLOBAL("vm.builtin.cuda_graph.get_cached_alloc")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      ICHECK_EQ(args.size(), 3);
+      VirtualMachine* vm = VirtualMachine::GetContextPtr(args[0]);
+      ObjectRef alloc_func = args[1];
+      int64_t entry_index = args[2];
+      CUDAGraphCache* cache = CUDAGraphCache::Get();
+      *rv = cache->GetCachedAllocation(vm, alloc_func, entry_index);
+    });
+
+}  // namespace relax_vm
+}  // namespace runtime
+}  // namespace tvm

--- a/tests/python/relax/test_vm_cuda_graph.py
+++ b/tests/python/relax/test_vm_cuda_graph.py
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+from tvm.script import tir as T, relax as R, ir as I
+from tvm import relax
+import tvm.testing
+import numpy as np
+
+
+# fmt: off
+
+
+@I.ir_module
+class Module:
+    @R.function
+    def main(x: R.Tensor((16, 16), dtype="float32")) -> R.Tensor((16, 16), dtype="float32"):
+        cls = Module
+        R.func_attr({"global_symbol": "main"})
+        gv: R.Tuple(R.Object, R.Object) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.get_cached_alloc", (cls.cuda_graph_alloc, R.prim_value(0)), sinfo_args=(R.Tuple(R.Object, R.Object),))
+        storage: R.Object = gv[0]
+        alloc: R.Tensor(dtype="float32") = R.vm.alloc_tensor(storage, R.prim_value(0), R.shape((16, 16)), R.dtype("float32"))
+        _: R.Tuple = cls.add(x, alloc)
+        storage1: R.Object = gv[1]
+        gv1: R.Tuple(R.Tensor(dtype="float32"), R.Object, R.Object) = (alloc, storage1, storage)
+        gv2: R.Tuple(R.Tensor((16, 16), dtype="float32")) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.run_or_capture", (cls.cuda_graph_capture, gv1, R.prim_value(0)), sinfo_args=(R.Tuple(R.Tensor((16, 16), dtype="float32")),))
+        storage2: R.Object = R.vm.alloc_storage(R.shape((1024,)), R.prim_value(0), R.dtype("float32"))
+        alloc3: R.Tensor(dtype="float32") = R.vm.alloc_tensor(storage2, R.prim_value(0), R.shape((16, 16)), R.dtype("float32"))
+        lv4: R.Tensor((16, 16), dtype="float32") = gv2[0]
+        _3: R.Tuple = cls.add(lv4, alloc3)
+        lv5: R.Tensor(dtype="float32") = alloc3
+        return lv5
+
+    @T.prim_func
+    def add(A: T.Buffer((16, 16), "float32"), B: T.Buffer((16, 16), "float32")):
+        T.func_attr({"global_symbol": "add"})
+        with T.block("root"):
+            for i in T.thread_binding(16, thread="threadIdx.x"):
+                for j in range(16):
+                    with T.block("update"):
+                        vi, vj = T.axis.remap("SS", [i, j])
+                        B[vi, vj] = A[vi, vj] + T.float32(1)
+
+    @R.function
+    def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object):
+        R.func_attr({"global_symbol": "cuda_graph_alloc"})
+        storage: R.Object = R.vm.alloc_storage(R.shape((1024,)), R.prim_value(0), R.dtype("float32"))
+        storage1: R.Object = R.vm.alloc_storage(R.shape((1024,)), R.prim_value(0), R.dtype("float32"))
+        gv: R.Tuple(R.Object, R.Object) = (storage, storage1)
+        return gv
+
+    @R.function
+    def cuda_graph_capture(alloc: R.Tensor((16, 16), dtype="float32"), storage1: R.Object, storage: R.Object) -> R.Tuple(R.Tensor((16, 16), dtype="float32")):
+        cls = Module
+        R.func_attr({"global_symbol": "cuda_graph_capture"})
+        lv0: R.Tensor((16, 16), dtype="float32") = alloc
+        alloc1: R.Tensor(dtype="float32") = R.vm.alloc_tensor(storage1, R.prim_value(0), R.shape((16, 16)), R.dtype("float32"))
+        _1: R.Tuple = cls.add(lv0, alloc1)
+        lv1: R.Tensor(dtype="float32") = alloc1
+        lv2: R.Tuple(R.Tensor(dtype="float32")) = (lv1,)
+        lv3: R.Tensor(dtype="float32") = lv2[0]
+        alloc2: R.Tensor(dtype="float32") = R.vm.alloc_tensor(storage, R.prim_value(0), R.shape((16, 16)), R.dtype("float32"))
+        _2: R.Tuple = cls.add(lv3, alloc2)
+        lv4: R.Tensor(dtype="float32") = alloc2
+        gv: R.Tuple(R.Tensor(dtype="float32")) = (lv4,)
+        return gv
+
+
+# fmt: on
+
+
+def codegen(mod, target, exec_mode="bytecode"):
+    builder = relax.ExecBuilder()
+    leftover_mod = relax.vm_build._vmcodegen(builder, mod, exec_mode=exec_mode)
+    tir_mod = relax.vm_build._filter_tir(leftover_mod)
+    return relax.vm_build._vmlink(builder, target, tir_mod)
+
+
+@tvm.testing.requires_cuda
+def test_vm_run():
+    mod = Module
+    target = tvm.target.Target("cuda", host="llvm")
+    ex = codegen(mod, target)
+    dev = tvm.cuda(0)
+    vm = relax.VirtualMachine(ex, dev)
+    x_np = np.random.uniform(size=(16, 16)).astype("float32")
+    x = tvm.nd.array(x_np, dev)
+    y = vm["main"](x)
+    y_np = x_np + 1.0 + 1.0 + 1.0 + 1.0
+    tvm.testing.assert_allclose(y.asnumpy(), y_np, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR added Relax VM builtin functions to execute with CUDA graph.
* `vm.builtin.cuda_graph.get_cached_alloc`: Allocate and cache storage objects for future vm invocation
* `vm.builtin.cuda_graph.run_or_capture`: Launched captured CUDA graph or capture the CUDA graph using CUDA API and save in the cache

The graph rewriting to enable CUDA graph backend will be done in a separate PR.

cc @tqchen @spectrometerHBH @MasterJH5574 