### PR TITLE
[Unity] Also include output dtype in simt MathInstruction

### DIFF
--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -94,6 +94,7 @@ def generate_sm50_simt(
                 DataType.f32,
                 DataType.f32,
                 DataType.f32,
+                DataType.f32,
                 OpcodeClass.Simt,
                 MathOperation.multiply_add,
             ),


### PR DESCRIPTION
Fixes a bug where this stacktrace is generated:

```
  File "/opt/scorecard/relax/python/tvm/contrib/cutlass/gen_tensor_op.py", line 189, in generate_sm75_tensor_op_1688
    return generate_sm50_simt(
  File "/opt/scorecard/relax/python/tvm/contrib/cutlass/gen_tensor_op.py", line 119, in generate_sm50_simt
    return generate_tensor_op_common(
  File "/opt/scorecard/relax/python/tvm/contrib/cutlass/gen_tensor_op.py", line 71, in generate_tensor_op_common
    out = op_creator(tile_descriptions, data_type, alignment_constraints)
  File "/opt/scorecard/relax/python/tvm/contrib/cutlass/gen_gemm.py", line 151, in enumerate_gemm_operators
    op.procedural_name(),
  File "/opt/scorecard/relax/python/tvm/contrib/cutlass/gemm_operation.py", line 110, in procedural_name
    opcode_class_name = OpcodeClassNames[self.tile_description.math_instruction.opcode_class]
KeyError: <MathOperation.multiply_add: 1>
```

@masahi  @jwfromm 