### PR TITLE
[Hexagon] Allow scalar tensors to have null shape during allocation

### DIFF
--- a/src/runtime/hexagon/hexagon_device_api.cc
+++ b/src/runtime/hexagon/hexagon_device_api.cc
@@ -52,7 +52,7 @@ void HexagonDeviceAPI::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv)
 // DataSpace: static allocations for Hexagon
 void* HexagonDeviceAPI::AllocDataSpace(Device dev, int ndim, const int64_t* shape, DLDataType dtype,
                                        Optional<String> mem_scope) {
-  CHECK(shape) << "shape array is null";
+  CHECK(shape || ndim == 0) << "shape array is null for a non-scalar tensor, ndim = " << ndim;
   CHECK(IsValidDevice(dev)) << "dev.device_type: " << dev.device_type;
 
   // IMPORTANT NOTE!

--- a/tests/cpp-runtime/hexagon/hexagon_device_api_tests.cc
+++ b/tests/cpp-runtime/hexagon/hexagon_device_api_tests.cc
@@ -134,6 +134,9 @@ TEST_F(HexagonDeviceAPITest, alloc_scalar) {
 
   void* hexscalar = hexapi->AllocDataSpace(hex_dev, 0, new int64_t, int8, global_vtcm_scope);
   CHECK(hexscalar != nullptr);
+
+  hexscalar = hexapi->AllocDataSpace(hex_dev, 0, nullptr, int8, global_vtcm_scope);
+  CHECK(hexscalar != nullptr);
 }
 
 // alloc and free of the same buffer on different devices should throw


### PR DESCRIPTION
Update assert during buffer allocation.  Zero dimensional tensors (scalars) can have a null shape.

cc: @csullivan, @farshidsp 