### PR TITLE
[Unity] [Hexagon] Fix deprecated call for data layout size in bits

### DIFF
--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -86,7 +86,7 @@ class CodeGenHexagon final : public CodeGenCPU {
 
   uint64_t GetTypeSizeInBits(llvm::Type* type) const {
 #if TVM_LLVM_VERSION >= 100
-    return data_layout_->getTypeSizeInBits(type).getFixedSize();
+    return data_layout_->getTypeSizeInBits(type).getFixedValue();
 #else
     return data_layout_->getTypeSizeInBits(type);
 #endif


### PR DESCRIPTION
The unity branch has errors for deprecated APIs.  Updating the codegen for Hexagon call from llvm::DataLayout::getTypeSizeInBits.getFixedSize() to llvm::DataLayout::getTypeSizeInBits.getFixedValue()

Verified this works on main as well.