### PR TITLE
[TIR] not estimating the flops when there is a default estimated flops as attr

### DIFF
--- a/src/tir/analysis/estimate_flops.cc
+++ b/src/tir/analysis/estimate_flops.cc
@@ -212,8 +212,7 @@ double EstimateTIRFlops(const IRModule& mod) {
   VisitPrimFuncs(mod, [&result, &counter, &cached_result](const PrimFuncNode* f) {
     if (auto cached = f->attrs.GetAttr<Integer>("estimated_flops")) {
       cached_result += cached.value()->value;
-    }
-    else {
+    } else {
       result += counter.VisitStmt(f->body);  //
     }
   });

--- a/src/tir/analysis/estimate_flops.cc
+++ b/src/tir/analysis/estimate_flops.cc
@@ -208,10 +208,16 @@ double EstimateTIRFlops(const Stmt& stmt) {
 double EstimateTIRFlops(const IRModule& mod) {
   FlopEstimator counter;
   TResult result;
-  VisitPrimFuncs(mod, [&result, &counter](const PrimFuncNode* f) {
-    result += counter.VisitStmt(f->body);  //
+  double cached_result = 0;
+  VisitPrimFuncs(mod, [&result, &counter, &cached_result](const PrimFuncNode* f) {
+    if (auto cached = f->attrs.GetAttr<Integer>("estimated_flops")) {
+      cached_result += cached.value()->value;
+    }
+    else {
+      result += counter.VisitStmt(f->body);  //
+    }
   });
-  return PostprocessResults(result);
+  return PostprocessResults(result) + cached_result;
 }
 
 TVM_REGISTER_GLOBAL("tir.analysis.EstimateTIRFlops").set_body_typed([](ObjectRef obj) -> double {

--- a/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
+++ b/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
@@ -77,5 +77,39 @@ def test_flops_with_if():
     assert flops == 16
 
 
+@T.prim_func
+def flops_with_forloop_as_expression(A: T.Buffer(1)):
+    for i in T.serial(0, 16):
+        for k in T.serial(0, i):
+            A[0] = A[0] + 1
+
+
+@T.prim_func
+def flops_override(a: T.Buffer(16, "float32"), b: T.Buffer(16, "float32")):
+    T.func_attr({"estimated_flops": 32})
+    for i in range(16):
+        if i % 2 == 0:
+            a[i] = b[i]
+        else:
+            if i % 3 == 0:
+                a[i] = b[i - 1] + b[i - 2]
+
+
+def test_estimate_flops_forloop_as_experssion():
+    flops = estimate_tir_flops(
+        IRModule({"main": flops_with_forloop_as_expression.with_attr("estimated_flops", 32)})
+    )
+    assert flops == 32
+
+    # test whether the user estimated flop would over ride
+    flops = estimate_tir_flops(IRModule({"main": flops_override}))
+    assert flops == 32
+
+
+def test_exception():
+    with pytest.raises(tvm.TVMError):
+        flops = estimate_tir_flops(IRModule({"main": flops_with_forloop_as_expression}))
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
+++ b/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
@@ -85,14 +85,10 @@ def flops_with_forloop_as_expression(A: T.Buffer(1)):
 
 
 @T.prim_func
-def flops_override(a: T.Buffer(16, "float32"), b: T.Buffer(16, "float32")):
+def flops_override(A: T.Buffer(16, "float32")):
     T.func_attr({"estimated_flops": 32})
     for i in range(16):
-        if i % 2 == 0:
-            a[i] = b[i]
-        else:
-            if i % 3 == 0:
-                a[i] = b[i - 1] + b[i - 2]
+        A[0] = A[0] + 1
 
 
 def test_estimate_flops_forloop_as_experssion():


### PR DESCRIPTION
FlopEstimator is run as part of the Meta Schedule as an estimate for which primfunc to spend time on; e.g. which primfunc to send more trials on.  In a case that the for loop extent is an expression, it’s getting stuck on the calculation of the FLOPS.

This PR add a function annotation to the main primfunc and then have FlopEstimator check for this annotation before visiting the function. And if the annotation exists, just use the handcoded flops instead of trying to estimate.

@Lunderberg  @csullivan 