### PR TITLE
[FuseOps][Relax][Fix] Do not replace ConstantNodes with Vars in FuseOps

### DIFF
--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -520,7 +520,7 @@ class FuseMutator : private MixedModeMutator {
       auto* arg_group = gmap_.at(arg.get())->FindRoot();
       auto type = arg->checked_type();
       Expr new_arg = this->Mutate(arg);
-      if (current_group != arg_group) {
+      if (current_group != arg_group && new_arg.as<ConstantNode>() == nullptr) {
         if (!link_params_ || new_arg.as<ConstantNode>() == nullptr) {
           Var param = ginfo_[current_group].GetOrAllocParam(new_arg, type);
           new_args.push_back(param);

--- a/tests/python/relax/test_transform_fuse_ops.py
+++ b/tests/python/relax/test_transform_fuse_ops.py
@@ -87,7 +87,6 @@ def test_fuse_const():
     def expected():
         bb = relax.BlockBuilder()
         x = relax.Var("x", R.Tensor([10, 20], "float32"))
-        y = relax.const(1, "float32")
         p0 = relax.Var("p0", R.Tensor((), "float32"))
 
         with bb.function("fused_add_exp_squeeze", [x, p0], attrs={"Primitive": 1}):
@@ -99,6 +98,7 @@ def test_fuse_const():
         fused_add_exp_squeeze = bb.get().get_global_var("fused_add_exp_squeeze")
 
         x = relax.Var("x", R.Tensor([10, 20], "float32"))
+        y = relax.const(1, "float32")
         with bb.function("main", [x]):
             with bb.dataflow():
                 gv = bb.emit_output(

--- a/tests/python/relax/test_transform_fuse_ops.py
+++ b/tests/python/relax/test_transform_fuse_ops.py
@@ -68,6 +68,47 @@ def test_fuse_simple():
 
     _check(before(), expected())
 
+def test_fuse_const():
+    """Simple testcase with a constant node."""
+
+    def before():
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", R.Tensor([10, 20], "float32"))
+        y = relax.const(1, "float32")
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                lv0 = bb.emit_te(topi.add, x, y)
+                lv1 = bb.emit_te(topi.exp, lv0)
+                gv = bb.emit_output(bb.call_te(topi.squeeze, lv1))
+            bb.emit_func_output(gv)
+
+        return bb.get()
+
+    def expected():
+        bb = relax.BlockBuilder()
+        x = relax.Var("x", R.Tensor([10, 20], "float32"))
+        y = relax.const(1, "float32")
+        p0 = relax.Var("p0", R.Tensor((), "float32"))
+
+        with bb.function("fused_add_exp_squeeze", [x, p0], attrs={"Primitive": 1}):
+            with bb.dataflow():
+                lv0 = bb.emit_te(topi.add, x, p0)
+                lv1 = bb.emit_te(topi.exp, lv0)
+                gv = bb.emit_output(bb.call_te(topi.squeeze, lv1))
+            bb.emit_func_output(gv)
+        fused_add_exp_squeeze = bb.get().get_global_var("fused_add_exp_squeeze")
+
+        x = relax.Var("x", R.Tensor([10, 20], "float32"))
+        with bb.function("main", [x]):
+            with bb.dataflow():
+                gv = bb.emit_output(
+                    relax.Call(fused_add_exp_squeeze, [x, y])
+                )
+            bb.emit_func_output(gv)
+
+        return bb.get()
+
+    _check(before(), expected())
 
 def test_conv2d_fuse():
     """Test fusion case of conv2d"""

--- a/tests/python/relax/test_transform_fuse_ops.py
+++ b/tests/python/relax/test_transform_fuse_ops.py
@@ -101,9 +101,7 @@ def test_fuse_const():
         y = relax.const(1, "float32")
         with bb.function("main", [x]):
             with bb.dataflow():
-                gv = bb.emit_output(
-                    relax.Call(fused_add_exp_squeeze, [x, y])
-                )
+                gv = bb.emit_output(relax.Call(fused_add_exp_squeeze, [x, y]))
             bb.emit_func_output(gv)
 
         return bb.get()


### PR DESCRIPTION
Bug fix, ConstantNodes should not be replaced with Vars.

Looking at unit tests now to see how to verify this - tests/python/relax/test_transform_fuse_ops.py

cc: @csullivan @farshidsp 