### PR TITLE
[Rewrite] Fix rewriting division to constant to handle vector case

### DIFF
--- a/src/relay/transforms/div_to_mul.cc
+++ b/src/relay/transforms/div_to_mul.cc
@@ -68,7 +68,8 @@ class DivToMulRewrite : public MixedModeMutator {
               const_has_zero_flag = const_has_values<double>(num_ele, rhs, {0.});
           } else if (dtype == "float16") {
               static_cast<uint16_t*>(one->data)[0] = __gnu_f2h_ieee(1.);
-              const_has_zero_flag = const_has_values<uint16_t>(num_ele, rhs, {0});
+              // have to handle both + and - zero semantics manually here
+              const_has_zero_flag = const_has_values<uint16_t>(num_ele, rhs, {0x00, 0x80});
           } else {
               LOG(WARNING) << "Unknown dtype not handled for div_to_mull: " << rhs->data.DataType(); 
               return post;
@@ -77,7 +78,7 @@ class DivToMulRewrite : public MixedModeMutator {
           if (const_has_zero_flag) {
             return post;
           }
-          
+
           // rely on constant folding to fold things 
           return Multiply(call_node->args[0], Divide(Constant(one), call_node->args[1]));
         }

--- a/src/relay/transforms/div_to_mul.cc
+++ b/src/relay/transforms/div_to_mul.cc
@@ -69,7 +69,7 @@ class DivToMulRewrite : public MixedModeMutator {
           } else if (dtype == "float16") {
             static_cast<uint16_t*>(one->data)[0] = __gnu_f2h_ieee(1.);
             // have to handle both + and - zero semantics manually here
-            const_has_zero_flag = const_has_values<uint16_t>(num_ele, rhs, {0x00, 0x80});
+            const_has_zero_flag = const_has_values<uint16_t>(num_ele, rhs, {0x0000, 0x8000});
           } else {
             LOG(WARNING) << "Unknown dtype not handled for div_to_mull: " << rhs->data.DataType();
             return post;


### PR DESCRIPTION
Previously only handle scalar case. That is rewriting `a ./ 5 --> a .* 0.2`. Now handle vector case `a ./ [2, 3, 4] --> a .* [0.5, 0.33, 0.25]`

Also changes the pass to rely on constant folding for proper folding instead of manually constructing constant data.

cc @Johnson9009  @tkonolige 