### PR TITLE
[Unity] Add missing #include <array>

### DIFF
--- a/tests/cpp/nested_msg_test.cc
+++ b/tests/cpp/nested_msg_test.cc
@@ -25,6 +25,7 @@
 #include <tvm/tir/expr.h>
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <functional>
 #include <iterator>


### PR DESCRIPTION
The file tests/cpp/nested_msg_test.cc may fail to compile if <array> is not included explicitly.