### PR TITLE
[CI][microTVM] Enable USE_MICRO for mac and windows CI builds

### DIFF
--- a/conda/recipe/bld.bat
+++ b/conda/recipe/bld.bat
@@ -27,6 +27,7 @@ cmake ^
       -DUSE_LLVM=ON ^
       -DUSE_RPC=ON ^
       -DUSE_CPP_RPC=ON ^
+      -DUSE_MICRO=ON ^
       -DUSE_SORT=ON ^
       -DUSE_RANDOM=ON ^
       -DUSE_PROFILER=ON ^

--- a/conda/recipe/build.sh
+++ b/conda/recipe/build.sh
@@ -49,6 +49,7 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DCMAKE_BUILD_TYPE=Release \
       -DUSE_RPC=ON \
       -DUSE_CPP_RPC=OFF \
+      -DUSE_MICRO=ON \
       -DUSE_SORT=ON \
       -DUSE_RANDOM=ON \
       -DUSE_PROFILER=ON \


### PR DESCRIPTION
Enable USE_MICRO for mac and windows CI builds to ensure code building doesn't break for those platforms;