### PR TITLE
[Unity] Support simple dynamic-shape-aware fusion

### DIFF
--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -402,6 +402,18 @@ class WellFormedChecker : public relax::ExprVisitor,
     }
   }
 
+  void VisitStructInfo_(const FuncStructInfoNode* op) final {
+    if (op->params.defined()) {
+      WithMode(VisitMode::kMatchVarDef, [&]() {
+        ICHECK(mode_ == VisitMode::kMatchVarDef);
+        for (StructInfo param : op->params.value()) {
+          this->VisitStructInfo(param);
+        }
+      });
+    }
+    this->VisitStructInfo(op->ret);
+  }
+
   void VisitStructInfoExprField(const Expr& expr) final {
     if (mode_ == VisitMode::kMatchVarDef) {
       // populate symbolic var in first occurrence

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -577,7 +577,10 @@ Expr ExprMutator::VisitExpr_(const FunctionNode* op) {
   for (Var param : op->params) {
     Var new_param = this->VisitVarDef(param);
     params.push_back(new_param);
-    all_params_unchanged &= param.same_as(new_param);
+    if (!param.same_as(new_param)) {
+      var_remap_[param->vid] = new_param;
+      all_params_unchanged = false;
+    }
   }
 
   Expr body = this->VisitWithNewScope(op->body, params);

--- a/src/runtime/relax_vm/cuda/cuda_graph_builtin.cc
+++ b/src/runtime/relax_vm/cuda/cuda_graph_builtin.cc
@@ -76,11 +76,11 @@ class CUDAGraphCache : public Object {
 
   /*!
    * \brief Launch the cuda graph if it has been cached, otherwise execute it in capture mode.
-   * \param vm The virutal machine.
+   * \param vm The virtual machine.
    * \param capture_func The function of type (args...) -> Tuple[ObjectRef], where 'args' are the
    * static arguments that are the same for all invocations of the capture function, the returned
    * tuple contains the intermediate tensors that will be used outside the capture function.
-   * \params args The static arguments of the capture function
+   * \param args The static arguments of the capture function
    * \param entry_index The unique index of the capture function used for lookup.
    * \return The return value of the capture function.
    */

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -520,5 +520,18 @@ def test_sinfo_erase_to_well_formed():
     assert not rx.analysis.well_formed(mod)
 
 
+def test_func_sinfo_well_formed():
+    @R.function
+    def foo():
+        @R.function
+        def local(x: R.Tensor(["m", "n"], "float32")):
+            return x
+
+        return local
+
+    mod = rx.transform.Normalize()(tvm.IRModule.from_expr(foo))
+    assert rx.analysis.well_formed(mod)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR adds support for simple dynamic-shape-aware fusion, which is the first step towards supporting dynamic shapes. The main changes are as follows:

- Fix FuncStructInfo in well-formed checks
- Renew symbolic var defs in fuse_ops to prevent malformed functions

cc @tqchen @MasterJH5574 @jinhongyii 