### PR TITLE
[TIR] Update LowerTVMBuiltin to use Optional<T>

### DIFF
--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -228,14 +228,13 @@ class BuiltinLower : public StmtExprMutator {
         return stmt;
       }
     }
-    if (device_type_.defined()) {
-      if (const auto* dev_type = device_type_.as<IntImmNode>()) {
-        auto storage_scope = Downcast<PointerType>(op->buffer_var->type_annotation)->storage_scope;
-        if (dev_type->value == kDLCPU && storage_scope == "global") {
-          size_t constant_size = op->ConstantAllocationSize();
-          if (constant_size > 0 && constant_size * nbytes < runtime::kMaxStackAlloca) {
-            return stmt;
-          }
+    if (const auto* dev_type = device_type_.as<IntImmNode>();
+        dev_type && dev_type->value == kDLCPU) {
+      auto storage_scope = Downcast<PointerType>(op->buffer_var->type_annotation)->storage_scope;
+      if (storage_scope == "global") {
+        size_t constant_size = op->ConstantAllocationSize();
+        if (constant_size > 0 && constant_size * nbytes < runtime::kMaxStackAlloca) {
+          return stmt;
         }
       }
     }
@@ -244,24 +243,24 @@ class BuiltinLower : public StmtExprMutator {
       // set total_bytes to uint64 to avoid overflow
       total_bytes = total_bytes * op->extents[i];
     }
-    ICHECK(device_type_.defined()) << "Unknown device type in current IR";
-    ICHECK(device_id_.defined()) << "Unknown device id in current IR";
+    ICHECK(device_type_) << "Unknown device type in current IR";
+    ICHECK(device_id_) << "Unknown device id in current IR";
     Stmt throw_last_error = Evaluate(Call(DataType::Int(32), builtin::tvm_throw_last_error(), {}));
 
     Stmt body = SeqStmt({IfThenElse(Call(DataType::Bool(1), builtin::isnullptr(), {op->buffer_var}),
                                     throw_last_error),
                          op->body});
-    Stmt alloca =
-        LetStmt(op->buffer_var,
-                Call(op->buffer_var.dtype(), Op::Get("tir.TVMBackendAllocWorkspace"),
-                     {cast(DataType::Int(32), device_type_), cast(DataType::Int(32), device_id_),
-                      total_bytes, IntImm(DataType::Int(32), op->dtype.code()),
-                      IntImm(DataType::Int(32), op->dtype.bits())}),
-                body);
+    Stmt alloca = LetStmt(op->buffer_var,
+                          Call(op->buffer_var.dtype(), Op::Get("tir.TVMBackendAllocWorkspace"),
+                               {cast(DataType::Int(32), device_type_.value()),
+                                cast(DataType::Int(32), device_id_.value()), total_bytes,
+                                IntImm(DataType::Int(32), op->dtype.code()),
+                                IntImm(DataType::Int(32), op->dtype.bits())}),
+                          body);
 
     PrimExpr free_op = Call(DataType::Int(32), Op::Get("tir.TVMBackendFreeWorkspace"),
-                            {cast(DataType::Int(32), device_type_),
-                             cast(DataType::Int(32), device_id_), op->buffer_var});
+                            {cast(DataType::Int(32), device_type_.value()),
+                             cast(DataType::Int(32), device_id_.value()), op->buffer_var});
     Stmt free_stmt = IfThenElse(free_op != make_zero(DataType::Int(32)), throw_last_error);
     body = SeqStmt({alloca, free_stmt});
     body = AttrStmt(op->buffer_var, attr::storage_alignment,
@@ -271,11 +270,11 @@ class BuiltinLower : public StmtExprMutator {
 
   Stmt VisitStmt_(const AttrStmtNode* op) final {
     if (op->attr_key == attr::device_id) {
-      ICHECK(!device_id_.defined());
+      ICHECK(!device_id_);
       device_id_ = op->value;
       return this->VisitStmt(op->body);
     } else if (op->attr_key == attr::device_type) {
-      ICHECK(!device_type_.defined());
+      ICHECK(!device_type_);
       device_type_ = op->value;
       return this->VisitStmt(op->body);
     } else {
@@ -329,6 +328,20 @@ class BuiltinLower : public StmtExprMutator {
     }
   }
 
+  StringImm GetDeviceMethodName(const char* method_name) const {
+    CHECK(device_type_) << "Method " << method_name << " requires the device type, "
+                        << "but occurred outside of a \"device_type\" annotation";
+
+    auto as_int = device_type_.as<IntImmNode>();
+    CHECK(as_int) << "Method " << method_name
+                  << " requires the device type to be a DLDeviceType enum value, "
+                  << "but was instead the expression " << device_type_ << " with type "
+                  << device_type_.value()->GetTypeKey();
+
+    String device_name = runtime::DeviceName(as_int->value);
+    return StringImm("device_api." + device_name + "." + method_name);
+  }
+
   PrimExpr MakeDMACopy(const CallNode* op) {
     PrimExpr queue_id = op->args[0];
     PrimExpr dst = op->args[1];
@@ -336,12 +349,9 @@ class BuiltinLower : public StmtExprMutator {
     PrimExpr size = op->args[3];
     PrimExpr bypass_cache = op->args[4];
 
-    std::string fdevapi_prefix =
-        "device_api." + std::string(runtime::DeviceName(device_type_.as<IntImmNode>()->value));
-
-    Call call_packed =
-        Call(DataType::Int(32), builtin::tvm_call_packed(),
-             {StringImm(fdevapi_prefix + ".dma_copy"), queue_id, dst, src, size, bypass_cache});
+    auto method_name = GetDeviceMethodName("dma_copy");
+    Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(),
+                            {method_name, queue_id, dst, src, size, bypass_cache});
     return VisitExpr(call_packed);
   }
 
@@ -349,33 +359,25 @@ class BuiltinLower : public StmtExprMutator {
     PrimExpr queue_id = op->args[0];
     PrimExpr inflight = op->args[1];
 
-    std::string fdevapi_prefix =
-        "device_api." + std::string(runtime::DeviceName(device_type_.as<IntImmNode>()->value));
-
-    Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(),
-                            {StringImm(fdevapi_prefix + ".dma_wait"), queue_id, inflight});
+    auto method_name = GetDeviceMethodName("dma_wait");
+    Call call_packed =
+        Call(DataType::Int(32), builtin::tvm_call_packed(), {method_name, queue_id, inflight});
     return VisitExpr(call_packed);
   }
 
   PrimExpr MakeDMAStartGroup(const CallNode* op) {
     PrimExpr queue_id = op->args[0];
 
-    std::string fdevapi_prefix =
-        "device_api." + std::string(runtime::DeviceName(device_type_.as<IntImmNode>()->value));
-
-    Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(),
-                            {StringImm(fdevapi_prefix + ".dma_start_group"), queue_id});
+    auto method_name = GetDeviceMethodName("dma_start_group");
+    Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(), {method_name, queue_id});
     return VisitExpr(call_packed);
   }
 
   PrimExpr MakeDMAEndGroup(const CallNode* op) {
     PrimExpr queue_id = op->args[0];
 
-    std::string fdevapi_prefix =
-        "device_api." + std::string(runtime::DeviceName(device_type_.as<IntImmNode>()->value));
-
-    Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(),
-                            {StringImm(fdevapi_prefix + ".dma_end_group"), queue_id});
+    auto method_name = GetDeviceMethodName("dma_end_group");
+    Call call_packed = Call(DataType::Int(32), builtin::tvm_call_packed(), {method_name, queue_id});
     return VisitExpr(call_packed);
   }
 
@@ -437,12 +439,12 @@ class BuiltinLower : public StmtExprMutator {
     }
     prep_seq.emplace_back(TVMStructSet(scope.stack_array, idx, builtin::kArrByteOffset,
                                        cast(DataType::UInt(64), byte_offset)));
-    ICHECK(device_type_.defined()) << "Unknown device type in current IR";
-    ICHECK(device_id_.defined()) << "Unknown device id in current IR";
+    ICHECK(device_type_) << "Unknown device type in current IR";
+    ICHECK(device_id_) << "Unknown device id in current IR";
     prep_seq.emplace_back(TVMStructSet(scope.stack_array, idx, builtin::kArrDeviceId,
-                                       cast(DataType::Int(32), device_id_)));
+                                       cast(DataType::Int(32), device_id_.value())));
     prep_seq.emplace_back(TVMStructSet(scope.stack_array, idx, builtin::kArrDeviceType,
-                                       cast(DataType::Int(32), device_type_)));
+                                       cast(DataType::Int(32), device_type_.value())));
     return TVMStructGet(DataType::Handle(), scope.stack_array, idx, builtin::kArrAddr);
   }
   // call packed.
@@ -561,8 +563,8 @@ class BuiltinLower : public StmtExprMutator {
   }
 
   Stmt MakeNdMemAllocWithScope(const LetStmtNode* let, const CallNode* call) {
-    ICHECK(device_type_.defined()) << "Unknown device type in current IR";
-    ICHECK(device_id_.defined()) << "Unknown device id in current IR";
+    ICHECK(device_type_) << "Unknown device type in current IR";
+    ICHECK(device_id_) << "Unknown device id in current IR";
     Stmt throw_last_error = Evaluate(Call(DataType::Int(32), builtin::tvm_throw_last_error(), {}));
 
     Stmt body = SeqStmt(
@@ -576,9 +578,9 @@ class BuiltinLower : public StmtExprMutator {
     fdevapi_prefix += runtime::DeviceName(device_type_.as<IntImmNode>()->value);
 
     Array<PrimExpr> args = {
-        StringImm(fdevapi_prefix + ".alloc_nd"),
-        device_type_,
-        device_id_,
+        GetDeviceMethodName("alloc_nd"),
+        device_type_.value(),
+        device_id_.value(),
         IntImm(DataType::Int(32), dtype.code()),
         IntImm(DataType::Int(32), dtype.bits()),
     };
@@ -592,7 +594,7 @@ class BuiltinLower : public StmtExprMutator {
 
     PrimExpr storage_scope = call->args[0];
     Call free_op = Call(DataType::Int(32), builtin::tvm_call_packed(),
-                        {StringImm(fdevapi_prefix + ".free_nd"), device_type_, device_id_,
+                        {GetDeviceMethodName("free_nd"), device_type_.value(), device_id_.value(),
                          storage_scope, let->var});
 
     Stmt free_stmt = IfThenElse(free_op != make_zero(DataType::Int(32)), throw_last_error);
@@ -614,8 +616,8 @@ class BuiltinLower : public StmtExprMutator {
 
   // The prepration sequence to be emitted before the current statement.
   std::vector<std::vector<Stmt>> prep_seq_stack_;
-  PrimExpr device_type_;
-  PrimExpr device_id_;
+  Optional<PrimExpr> device_type_{NullOpt};
+  Optional<PrimExpr> device_id_{NullOpt};
 
   bool is_precheck_{false};
 


### PR DESCRIPTION
The member variables `device_type_` and `device_id_` are tracked during `LowerTVMBuiltin`, are initially undefined, and are checked before use.  This is the usage pattern expected for `Optional<T>`, but these variables previously had the type `PrimExpr`.

This commit updates these to `Optional<PrimExpr>`, and uses the helper function `GetDeviceMethodName` to add more detail to the error messages when they are undefined.