### PR TITLE
[microNPU] Add support for ResizeNearestNeighbor with half_pixel_centers=True

### DIFF
--- a/python/tvm/relay/op/contrib/ethosu.py
+++ b/python/tvm/relay/op/contrib/ethosu.py
@@ -1671,7 +1671,18 @@ class Resize2dParams:
             return False
         if self.method not in ("nearest_neighbor", "linear"):
             return False
-        if self.coordinate_transformation_mode not in ("asymmetric", "align_corners"):
+        if self.coordinate_transformation_mode not in (
+            "asymmetric",
+            "align_corners",
+            "half_pixel",
+        ):
+            return False
+        if (
+            self.coordinate_transformation_mode == "half_pixel"
+            and self.rounding_method != "round_prefer_ceil"
+        ):
+            return False
+        if self.coordinate_transformation_mode != "half_pixel" and self.rounding_method != "":
             return False
         if not check_compatible_size(
             self.coordinate_transformation_mode,
@@ -1679,8 +1690,6 @@ class Resize2dParams:
             self.size,
             self.ifm.shape[1:3],
         ):
-            return False
-        if self.rounding_method != "":
             return False
         if self.out_dtype and self.out_dtype != "int8":
             return False

--- a/python/tvm/relay/op/contrib/ethosu.py
+++ b/python/tvm/relay/op/contrib/ethosu.py
@@ -1680,9 +1680,9 @@ class Resize2dParams:
         if (
             self.coordinate_transformation_mode == "half_pixel"
             and self.rounding_method != "round_prefer_ceil"
+            or self.coordinate_transformation_mode != "half_pixel"
+            and self.rounding_method != ""
         ):
-            return False
-        if self.coordinate_transformation_mode != "half_pixel" and self.rounding_method != "":
             return False
         if not check_compatible_size(
             self.coordinate_transformation_mode,

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -1101,7 +1101,10 @@ def test_tflite_resize2d_nearest_neighbor(accel_type, ifm_shape, size, half_pixe
     @tf.function
     def resize_model(x):
         return tf.compat.v1.image.resize_nearest_neighbor(
-            x, size, align_corners=align_corners, half_pixel_centers=half_pixel,
+            x,
+            size,
+            align_corners=align_corners,
+            half_pixel_centers=half_pixel,
         )
 
     infra.compare_tvm_with_tflite(

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -1084,14 +1084,15 @@ def test_tflite_squeeze(accel_type, ifm_shape, axis):
 
 
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)
-@pytest.mark.parametrize("half_pixel", [False, True])
 @pytest.mark.parametrize(
-    "ifm_shape,size",
+    "ifm_shape,size,half_pixel",
     [
-        [(1, 2, 2, 1), (4, 4)],
-        [(1, 4, 7, 3), (8, 14)],
-        [(1, 3, 5, 3), (3, 5)],
-        [(1, 6, 6, 96), (12, 12)],
+        [(1, 2, 2, 1), (4, 4), False],
+        [(1, 2, 2, 1), (4, 4), True],
+        [(1, 4, 7, 3), (8, 14), False],
+        [(1, 3, 5, 3), (3, 5), False],
+        [(1, 6, 6, 96), (12, 12), False],
+        [(1, 6, 6, 96), (12, 12), True],
     ],
 )
 def test_tflite_resize2d_nearest_neighbor(accel_type, ifm_shape, size, half_pixel):

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -1084,18 +1084,24 @@ def test_tflite_squeeze(accel_type, ifm_shape, axis):
 
 
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)
+@pytest.mark.parametrize("half_pixel", [False, True])
 @pytest.mark.parametrize(
     "ifm_shape,size",
-    [[(1, 2, 2, 1), (4, 4)], [(1, 4, 7, 3), (8, 14)], [(1, 3, 5, 3), (3, 5)]],
+    [
+        [(1, 2, 2, 1), (4, 4)],
+        [(1, 4, 7, 3), (8, 14)],
+        [(1, 3, 5, 3), (3, 5)],
+        [(1, 6, 6, 96), (12, 12)],
+    ],
 )
-def test_tflite_resize2d_nearest_neighbor(accel_type, ifm_shape, size):
+def test_tflite_resize2d_nearest_neighbor(accel_type, ifm_shape, size, half_pixel):
     np.random.seed(0)
     align_corners = False
 
     @tf.function
     def resize_model(x):
         return tf.compat.v1.image.resize_nearest_neighbor(
-            x, size, align_corners=align_corners, half_pixel_centers=False
+            x, size, align_corners=align_corners, half_pixel_centers=half_pixel,
         )
 
     infra.compare_tvm_with_tflite(

--- a/tests/python/contrib/test_ethosu/test_legalize.py
+++ b/tests/python/contrib/test_ethosu/test_legalize.py
@@ -2341,15 +2341,17 @@ def test_tflite_squeeze(ifm_shape, axis):
     verify(mod["tvmgen_default_ethos_u_main_0"])
 
 
+@pytest.mark.parametrize("half_pixel", [False, True])
 @pytest.mark.parametrize(
     "ifm_shape,size",
     [
         [(1, 2, 2, 1), (4, 4)],
         [(1, 4, 7, 3), (8, 14)],
         [(1, 3, 5, 3), (3, 5)],
+        [(1, 6, 6, 96), (12, 12)],
     ],
 )
-def test_tflite_resize2d_nearest_neighbor(ifm_shape, size):
+def test_tflite_resize2d_nearest_neighbor(ifm_shape, size, half_pixel):
     align_corners = False
     dtype = "int8"
 
@@ -2357,7 +2359,7 @@ def test_tflite_resize2d_nearest_neighbor(ifm_shape, size):
         @tf.function
         def resize_model(x):
             return tf.compat.v1.image.resize_nearest_neighbor(
-                x, size, align_corners=align_corners, half_pixel_centers=False
+                x, size, align_corners=align_corners, half_pixel_centers=half_pixel,
             )
 
         concrete_func = resize_model.get_concrete_function(

--- a/tests/python/contrib/test_ethosu/test_legalize.py
+++ b/tests/python/contrib/test_ethosu/test_legalize.py
@@ -2341,14 +2341,15 @@ def test_tflite_squeeze(ifm_shape, axis):
     verify(mod["tvmgen_default_ethos_u_main_0"])
 
 
-@pytest.mark.parametrize("half_pixel", [False, True])
 @pytest.mark.parametrize(
-    "ifm_shape,size",
+    "ifm_shape,size,half_pixel",
     [
-        [(1, 2, 2, 1), (4, 4)],
-        [(1, 4, 7, 3), (8, 14)],
-        [(1, 3, 5, 3), (3, 5)],
-        [(1, 6, 6, 96), (12, 12)],
+        [(1, 2, 2, 1), (4, 4), False],
+        [(1, 2, 2, 1), (4, 4), True],
+        [(1, 4, 7, 3), (8, 14), False],
+        [(1, 3, 5, 3), (3, 5), False],
+        [(1, 6, 6, 96), (12, 12), False],
+        [(1, 6, 6, 96), (12, 12), True],
     ],
 )
 def test_tflite_resize2d_nearest_neighbor(ifm_shape, size, half_pixel):

--- a/tests/python/contrib/test_ethosu/test_legalize.py
+++ b/tests/python/contrib/test_ethosu/test_legalize.py
@@ -2359,7 +2359,10 @@ def test_tflite_resize2d_nearest_neighbor(ifm_shape, size, half_pixel):
         @tf.function
         def resize_model(x):
             return tf.compat.v1.image.resize_nearest_neighbor(
-                x, size, align_corners=align_corners, half_pixel_centers=half_pixel,
+                x,
+                size,
+                align_corners=align_corners,
+                half_pixel_centers=half_pixel,
             )
 
         concrete_func = resize_model.get_concrete_function(


### PR DESCRIPTION
This PR involves supporting the legalization case of RESIZE_NEAREST_NEIGHBOR where coordinate transformation mode is set to half_pixel.