### PR TITLE
[Runtime] Introduce runtime module property

### DIFF
--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -45,21 +45,17 @@ namespace runtime {
  * \brief Property of runtime module
  * We classify the property of runtime module into the following categories.
  * - kBinarySerializable: we can serialize the module to the stream of bytes. CUDA/OpenCL/JSON
- * runtime are representative examples.
+ * runtime are representative examples. A binary exportable module can be integrated into final
+ * runtime artifact by being serialized as data into the artifact, then deserialzied at runtime.
+ * This class of modules must implement SaveToBinary, and have a matching deserializer registered as
+ * 'runtime.module.loadbinary_<type_key>'.
  * - kRunnable: we can run the module directly. LLVM/CUDA/JSON runtime, executors (e.g,
  * virtual machine) runtimes are runnable. Non-runnable modules, such as CSourceModule, requires a
  * few extra steps (e.g,. compilation, link) to make it runnable.
- * - kBinaryExportable: when the module is kBinarySerializable and kRunnable, we consider this
- * module as binary exportable. A binary exportable module can be integrated into final runtime
- * artifact by being serialized as data into the artifact, then deserialzied at runtime. This class
- * of modules must implement SaveToBinary, and have a matching deserializer registered as
- * 'runtime.module.loadbinary_<type_key>'.
  * - kDSOExportable: we can export the module as DSO. A DSO exportable module (e.g., a
  * CSourceModuleNode of type_key 'c') can be incorporated into the final runtime artifact (ie shared
  * library) by compilation and/or linking using the external compiler (llvm, nvcc, etc). DSO
  * exportable modules must implement SaveToFile.
- *
- * Please note that kDSOExportable is a mutual exclusive property with kBinaryExportable.
  */
 namespace property {
 /*! \brief Binary serializable runtime module */
@@ -68,8 +64,6 @@ constexpr const uint8_t kBinarySerializable = 0b001;
 constexpr const uint8_t kRunnable = 0b010;
 /*! \brief DSO exportable runtime module */
 constexpr const uint8_t kDSOExportable = 0b100;
-/*! \brief Binary exportable runtime module */
-constexpr const uint8_t kBinaryExportable = kBinarySerializable | kRunnable;
 };  // namespace property
 
 class ModuleNode;

--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -223,7 +223,7 @@ class TVM_DLL ModuleNode : public Object {
   virtual int GetProperty() const { return 0b000; }
 
   /*! \brief Returns true if this module is 'DSO exportable'. */
-  bool IsDSOExportable() const { return GetProperty() == ModulePropertyMask::kDSOExportable; };
+  bool IsDSOExportable() const { return GetProperty() & ModulePropertyMask::kDSOExportable; };
 
   /*!
    * \brief Returns true if this module has a definition for a function of \p name. If

--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -57,14 +57,12 @@ namespace runtime {
  * library) by compilation and/or linking using the external compiler (llvm, nvcc, etc). DSO
  * exportable modules must implement SaveToFile.
  */
-namespace property {
-/*! \brief Binary serializable runtime module */
-constexpr const uint8_t kBinarySerializable = 0b001;
-/*! \brief Runnable runtime module */
-constexpr const uint8_t kRunnable = 0b010;
-/*! \brief DSO exportable runtime module */
-constexpr const uint8_t kDSOExportable = 0b100;
-};  // namespace property
+
+enum ModulePropertyMask : int {
+  kBinarySerializable = 0b001,
+  kRunnable = 0b010,
+  kDSOExportable = 0b100
+};
 
 class ModuleNode;
 class PackedFunc;
@@ -222,10 +220,10 @@ class TVM_DLL ModuleNode : public Object {
    * By default, none of the property is set. Derived class can override this function and set its
    * own property.
    */
-  virtual uint8_t GetProperty() const { return 0x000; }
+  virtual int GetProperty() const { return 0b000; }
 
   /*! \brief Returns true if this module is 'DSO exportable'. */
-  bool IsDSOExportable() const { return GetProperty() == property::kDSOExportable; };
+  bool IsDSOExportable() const { return GetProperty() == ModulePropertyMask::kDSOExportable; };
 
   /*!
    * \brief Returns true if this module has a definition for a function of \p name. If

--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -228,10 +228,10 @@ class TVM_DLL ModuleNode : public Object {
    * By default, none of the property is set. Derived class can override this function and set its
    * own property.
    */
-  virtual uint8_t GetProperty() const { return 0x000; };
+  virtual uint8_t GetProperty() const { return 0x000; }
 
   /*! \brief Returns true if this module is 'DSO exportable'. */
-  virtual bool IsDSOExportable() const final { return GetProperty() == property::kDSOExportable; };
+  bool IsDSOExportable() const { return GetProperty() == property::kDSOExportable; };
 
   /*!
    * \brief Returns true if this module has a definition for a function of \p name. If

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -66,6 +66,9 @@ class TVM_DLL Executable : public ModuleNode {
    */
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kBinarySerializable; };
+
   /*!
    * \brief Write the Executable to the binary stream in serialized form.
    *

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -67,7 +67,7 @@ class TVM_DLL Executable : public ModuleNode {
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinarySerializable; };
+  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable; };
 
   /*!
    * \brief Write the Executable to the binary stream in serialized form.

--- a/include/tvm/runtime/vm/executable.h
+++ b/include/tvm/runtime/vm/executable.h
@@ -67,7 +67,7 @@ class TVM_DLL Executable : public ModuleNode {
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable; };
+  int GetPropertyMask() const final { return ModulePropertyMask::kBinarySerializable; };
 
   /*!
    * \brief Write the Executable to the binary stream in serialized form.

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -179,7 +179,7 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   virtual void LoadExecutable(const ObjectPtr<Executable>& exec);
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kRunnable; }
+  int GetProperty() const final { return ModulePropertyMask::kRunnable; }
 
  protected:
   /*! \brief Push a call frame on to the call stack. */

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -178,6 +178,9 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
    */
   virtual void LoadExecutable(const ObjectPtr<Executable>& exec);
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kRunnable; }
+
  protected:
   /*! \brief Push a call frame on to the call stack. */
   void PushFrame(Index arg_count, Index ret_pc, const VMFunction& vm_func);

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -179,7 +179,7 @@ class TVM_DLL VirtualMachine : public runtime::ModuleNode {
   virtual void LoadExecutable(const ObjectPtr<Executable>& exec);
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kRunnable; }
+  int GetPropertyMask() const final { return ModulePropertyMask::kRunnable; }
 
  protected:
   /*! \brief Push a call frame on to the call stack. */

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -425,7 +425,9 @@ class Module(object):
         stack.append(self)
         while stack:
             module = stack.pop()
-            assert module.is_dso_exportable or module.is_binary_serializable
+            assert (
+                module.is_dso_exportable or module.is_binary_serializable
+            ), f"Module {module.type_key} should be either dso exportable or binary serializable."
 
             if filter_func(module):
                 dso_modules.append(module)

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -96,6 +96,14 @@ class BenchmarkResult:
         )
 
 
+class ModulePropertyMask(object):
+    """Runtime Module Property Mask."""
+
+    BINARY_SERIALIZABLE = 0b001
+    RUNNABLE = 0b010
+    DSO_EXPORTABLE = 0b100
+
+
 class Module(object):
     """Runtime Module."""
 
@@ -239,6 +247,40 @@ class Module(object):
         nmod = _ffi_api.ModuleImportsSize(self)
         return [_ffi_api.ModuleGetImport(self, i) for i in range(nmod)]
 
+    def get_property_mask(self):
+        """Get the runtime module property mask. The mapping is stated in ModulePropertyMask.
+
+        Returns
+        -------
+        mask : int
+            Bitmask of runtime module property
+        """
+        return _ffi_api.ModuleGetPropertyMask(self)
+
+    @property
+    def is_binary_serializable(self):
+        """Returns true if module is 'binary serializable', ie can be serialzed into binary
+         stream and loaded back to the runtime module.
+
+        Returns
+        -------
+        b : Bool
+            True if the module is binary serializable.
+        """
+        return (self.get_property_mask() & ModulePropertyMask.BINARY_SERIALIZABLE) != 0
+
+    @property
+    def is_runnable(self):
+        """Returns true if module is 'runnable'. ie can be executed without any extra
+        compilation/linking steps.
+
+        Returns
+        -------
+        b : Bool
+            True if the module is runnable.
+        """
+        return (self.get_property_mask() & ModulePropertyMask.RUNNABLE) != 0
+
     @property
     def is_dso_exportable(self):
         """Returns true if module is 'DSO exportable', ie can be included in result of
@@ -249,7 +291,7 @@ class Module(object):
         b : Bool
             True if the module is DSO exportable.
         """
-        return _ffi_api.ModuleIsDSOExportable(self)
+        return (self.get_property_mask() & ModulePropertyMask.DSO_EXPORTABLE) != 0
 
     def save(self, file_name, fmt=""):
         """Save the module to file.
@@ -383,6 +425,8 @@ class Module(object):
         stack.append(self)
         while stack:
             module = stack.pop()
+            assert module.is_dso_exportable or module.is_binary_serializable
+
             if filter_func(module):
                 dso_modules.append(module)
             for m in module.imported_modules:

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -1357,8 +1357,9 @@ class AOTExecutorCodegenModule : public runtime::ModuleNode {
   }
 
   const char* type_key() const final { return "RelayGraphRuntimeCodegenModule"; }
+  
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return runtime::property::kRunnable; }
+  int GetProperty() const final { return runtime::ModulePropertyMask::kRunnable; }
 
  private:
   void init(void* mod, const Array<Target>& targets) {

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -1357,9 +1357,9 @@ class AOTExecutorCodegenModule : public runtime::ModuleNode {
   }
 
   const char* type_key() const final { return "RelayGraphRuntimeCodegenModule"; }
-  
+
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return runtime::ModulePropertyMask::kRunnable; }
+  int GetPropertyMask() const final { return runtime::ModulePropertyMask::kRunnable; }
 
  private:
   void init(void* mod, const Array<Target>& targets) {

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -1357,6 +1357,8 @@ class AOTExecutorCodegenModule : public runtime::ModuleNode {
   }
 
   const char* type_key() const final { return "RelayGraphRuntimeCodegenModule"; }
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return runtime::property::kRunnable; }
 
  private:
   void init(void* mod, const Array<Target>& targets) {

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -283,6 +283,9 @@ class RelayBuildModule : public runtime::ModuleNode {
    */
   const char* type_key() const final { return "RelayBuildModule"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return runtime::property::kRunnable; }
+
   /*!
    * \brief Build relay IRModule for graph executor
    *

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -284,7 +284,7 @@ class RelayBuildModule : public runtime::ModuleNode {
   const char* type_key() const final { return "RelayBuildModule"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return runtime::ModulePropertyMask::kRunnable; }
+  int GetPropertyMask() const final { return runtime::ModulePropertyMask::kRunnable; }
 
   /*!
    * \brief Build relay IRModule for graph executor

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -284,7 +284,7 @@ class RelayBuildModule : public runtime::ModuleNode {
   const char* type_key() const final { return "RelayBuildModule"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return runtime::property::kRunnable; }
+  int GetProperty() const final { return runtime::ModulePropertyMask::kRunnable; }
 
   /*!
    * \brief Build relay IRModule for graph executor

--- a/src/relay/backend/contrib/ethosu/source_module.cc
+++ b/src/relay/backend/contrib/ethosu/source_module.cc
@@ -122,7 +122,7 @@ class EthosUModuleNode : public ModuleNode {
   }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const { return ModulePropertyMask::kDSOExportable; }
+  int GetPropertyMask() const { return ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find_if(compilation_artifacts_.begin(), compilation_artifacts_.end(),

--- a/src/relay/backend/contrib/ethosu/source_module.cc
+++ b/src/relay/backend/contrib/ethosu/source_module.cc
@@ -121,7 +121,8 @@ class EthosUModuleNode : public ModuleNode {
     return Module(n);
   }
 
-  uint8_t GetProperty() const { return property::kDSOExportable; }
+  /*! \brief Get the property of the runtime module .*/
+  int GetProperty() const { return ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find_if(compilation_artifacts_.begin(), compilation_artifacts_.end(),

--- a/src/relay/backend/contrib/ethosu/source_module.cc
+++ b/src/relay/backend/contrib/ethosu/source_module.cc
@@ -121,7 +121,7 @@ class EthosUModuleNode : public ModuleNode {
     return Module(n);
   }
 
-  bool IsDSOExportable() const final { return true; }
+  uint8_t GetProperty() const { return property::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find_if(compilation_artifacts_.begin(), compilation_artifacts_.end(),

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -688,7 +688,7 @@ class GraphExecutorCodegenModule : public runtime::ModuleNode {
   const char* type_key() const final { return "RelayGraphExecutorCodegenModule"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return runtime::property::kRunnable; }
+  int GetProperty() const final { return runtime::ModulePropertyMask::kRunnable; }
 
  private:
   std::shared_ptr<GraphExecutorCodegen> codegen_;

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -688,7 +688,7 @@ class GraphExecutorCodegenModule : public runtime::ModuleNode {
   const char* type_key() const final { return "RelayGraphExecutorCodegenModule"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return runtime::ModulePropertyMask::kRunnable; }
+  int GetPropertyMask() const final { return runtime::ModulePropertyMask::kRunnable; }
 
  private:
   std::shared_ptr<GraphExecutorCodegen> codegen_;

--- a/src/relay/backend/graph_executor_codegen.cc
+++ b/src/relay/backend/graph_executor_codegen.cc
@@ -687,6 +687,9 @@ class GraphExecutorCodegenModule : public runtime::ModuleNode {
 
   const char* type_key() const final { return "RelayGraphExecutorCodegenModule"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return runtime::property::kRunnable; }
+
  private:
   std::shared_ptr<GraphExecutorCodegen> codegen_;
   LoweredOutput output_;

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -94,7 +94,7 @@ class VMCompiler : public runtime::ModuleNode {
   const char* type_key() const final { return "VMCompiler"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kRunnable; }
+  int GetProperty() const final { return ModulePropertyMask::kRunnable; }
 
   /*!
    * \brief Set the parameters

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -93,6 +93,9 @@ class VMCompiler : public runtime::ModuleNode {
 
   const char* type_key() const final { return "VMCompiler"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kRunnable; }
+
   /*!
    * \brief Set the parameters
    *

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -94,7 +94,7 @@ class VMCompiler : public runtime::ModuleNode {
   const char* type_key() const final { return "VMCompiler"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kRunnable; }
+  int GetPropertyMask() const final { return ModulePropertyMask::kRunnable; }
 
   /*!
    * \brief Set the parameters

--- a/src/relay/printer/model_library_format_printer.cc
+++ b/src/relay/printer/model_library_format_printer.cc
@@ -38,7 +38,7 @@ class ModelLibraryFormatPrinter : public ::tvm::runtime::ModuleNode {
   const char* type_key() const final { return "model_library_format_printer"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return runtime::ModulePropertyMask::kRunnable; }
+  int GetPropertyMask() const final { return runtime::ModulePropertyMask::kRunnable; }
 
   std::string Print(const ObjectRef& node) {
     std::ostringstream oss;

--- a/src/relay/printer/model_library_format_printer.cc
+++ b/src/relay/printer/model_library_format_printer.cc
@@ -37,6 +37,9 @@ class ModelLibraryFormatPrinter : public ::tvm::runtime::ModuleNode {
 
   const char* type_key() const final { return "model_library_format_printer"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return runtime::property::kRunnable; }
+
   std::string Print(const ObjectRef& node) {
     std::ostringstream oss;
     oss << node;

--- a/src/relay/printer/model_library_format_printer.cc
+++ b/src/relay/printer/model_library_format_printer.cc
@@ -38,7 +38,7 @@ class ModelLibraryFormatPrinter : public ::tvm::runtime::ModuleNode {
   const char* type_key() const final { return "model_library_format_printer"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return runtime::property::kRunnable; }
+  int GetProperty() const final { return runtime::ModulePropertyMask::kRunnable; }
 
   std::string Print(const ObjectRef& node) {
     std::ostringstream oss;

--- a/src/runtime/aot_executor/aot_executor.h
+++ b/src/runtime/aot_executor/aot_executor.h
@@ -52,7 +52,7 @@ class TVM_DLL AotExecutor : public ModuleNode {
   const char* type_key() const final { return "AotExecutor"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kRunnable; }
+  int GetProperty() const final { return ModulePropertyMask::kRunnable; }
 
   void Run();
 

--- a/src/runtime/aot_executor/aot_executor.h
+++ b/src/runtime/aot_executor/aot_executor.h
@@ -52,7 +52,7 @@ class TVM_DLL AotExecutor : public ModuleNode {
   const char* type_key() const final { return "AotExecutor"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kRunnable; }
+  int GetPropertyMask() const final { return ModulePropertyMask::kRunnable; }
 
   void Run();
 

--- a/src/runtime/aot_executor/aot_executor.h
+++ b/src/runtime/aot_executor/aot_executor.h
@@ -51,6 +51,9 @@ class TVM_DLL AotExecutor : public ModuleNode {
    */
   const char* type_key() const final { return "AotExecutor"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kRunnable; }
+
   void Run();
 
   /*!

--- a/src/runtime/aot_executor/aot_executor_factory.h
+++ b/src/runtime/aot_executor/aot_executor_factory.h
@@ -66,7 +66,7 @@ class TVM_DLL AotExecutorFactory : public runtime::ModuleNode {
   const char* type_key() const final { return "AotExecutorFactory"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable; }
+  int GetPropertyMask() const final { return ModulePropertyMask::kBinarySerializable; }
 
   /*!
    * \brief Save the module to binary stream.

--- a/src/runtime/aot_executor/aot_executor_factory.h
+++ b/src/runtime/aot_executor/aot_executor_factory.h
@@ -66,7 +66,7 @@ class TVM_DLL AotExecutorFactory : public runtime::ModuleNode {
   const char* type_key() const final { return "AotExecutorFactory"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinarySerializable; }
+  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable; }
 
   /*!
    * \brief Save the module to binary stream.

--- a/src/runtime/aot_executor/aot_executor_factory.h
+++ b/src/runtime/aot_executor/aot_executor_factory.h
@@ -65,6 +65,9 @@ class TVM_DLL AotExecutorFactory : public runtime::ModuleNode {
    */
   const char* type_key() const final { return "AotExecutorFactory"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kBinarySerializable; }
+
   /*!
    * \brief Save the module to binary stream.
    * \param stream The binary stream to save to.

--- a/src/runtime/const_loader_module.cc
+++ b/src/runtime/const_loader_module.cc
@@ -101,7 +101,7 @@ class ConstLoaderModuleNode : public ModuleNode {
   const char* type_key() const final { return "const_loader"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable; };
+  int GetPropertyMask() const final { return ModulePropertyMask::kBinarySerializable; };
 
   /*!
    * \brief Get the list of constants that is required by the given module.

--- a/src/runtime/const_loader_module.cc
+++ b/src/runtime/const_loader_module.cc
@@ -100,7 +100,8 @@ class ConstLoaderModuleNode : public ModuleNode {
 
   const char* type_key() const final { return "const_loader"; }
 
-  uint8_t GetProperty() const final { return property::kBinarySerializable; };
+  /*! \brief Get the property of the runtime module .*/
+  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable; };
 
   /*!
    * \brief Get the list of constants that is required by the given module.

--- a/src/runtime/const_loader_module.cc
+++ b/src/runtime/const_loader_module.cc
@@ -100,6 +100,8 @@ class ConstLoaderModuleNode : public ModuleNode {
 
   const char* type_key() const final { return "const_loader"; }
 
+  uint8_t GetProperty() const final { return property::kBinarySerializable; };
+
   /*!
    * \brief Get the list of constants that is required by the given module.
    * \param symbol The symbol that is being queried.

--- a/src/runtime/contrib/coreml/coreml_runtime.h
+++ b/src/runtime/contrib/coreml/coreml_runtime.h
@@ -105,6 +105,9 @@ class CoreMLRuntime : public ModuleNode {
    */
   virtual PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self);
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kBinaryExportable; };
+
   /*!
    * \brief Serialize the content of the mlmodelc directory and save it to
    *        binary stream.

--- a/src/runtime/contrib/coreml/coreml_runtime.h
+++ b/src/runtime/contrib/coreml/coreml_runtime.h
@@ -106,7 +106,7 @@ class CoreMLRuntime : public ModuleNode {
   virtual PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self);
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinaryExportable; };
+  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; };
 
   /*!
    * \brief Serialize the content of the mlmodelc directory and save it to

--- a/src/runtime/contrib/coreml/coreml_runtime.h
+++ b/src/runtime/contrib/coreml/coreml_runtime.h
@@ -106,7 +106,9 @@ class CoreMLRuntime : public ModuleNode {
   virtual PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self);
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable; };
+  int GetPropertyMask() const final {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  }
 
   /*!
    * \brief Serialize the content of the mlmodelc directory and save it to

--- a/src/runtime/contrib/coreml/coreml_runtime.h
+++ b/src/runtime/contrib/coreml/coreml_runtime.h
@@ -106,7 +106,7 @@ class CoreMLRuntime : public ModuleNode {
   virtual PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self);
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; };
+  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable; };
 
   /*!
    * \brief Serialize the content of the mlmodelc directory and save it to

--- a/src/runtime/contrib/ethosn/ethosn_runtime.h
+++ b/src/runtime/contrib/ethosn/ethosn_runtime.h
@@ -104,6 +104,11 @@ class EthosnModule : public ModuleNode {
 
   const char* type_key() const override { return "ethos-n"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  int GetPropertyMask() const final {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  };
+
  private:
   /*! \brief A map between ext_symbols (function names) and ordered compiled networks. */
   std::map<std::string, OrderedCompiledNetwork> network_map_;

--- a/src/runtime/contrib/json/json_runtime.h
+++ b/src/runtime/contrib/json/json_runtime.h
@@ -58,6 +58,9 @@ class JSONRuntimeBase : public ModuleNode {
 
   const char* type_key() const override { return "json"; }  // May be overridden
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const { return property::kBinaryExportable; }
+
   /*! \brief Initialize a specific json runtime. */
   virtual void Init(const Array<NDArray>& consts) = 0;
 

--- a/src/runtime/contrib/json/json_runtime.h
+++ b/src/runtime/contrib/json/json_runtime.h
@@ -59,7 +59,7 @@ class JSONRuntimeBase : public ModuleNode {
   const char* type_key() const override { return "json"; }  // May be overridden
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const { return property::kBinaryExportable; }
+  uint8_t GetProperty() const { return property::kBinarySerializable | property::kRunnable; }
 
   /*! \brief Initialize a specific json runtime. */
   virtual void Init(const Array<NDArray>& consts) = 0;

--- a/src/runtime/contrib/json/json_runtime.h
+++ b/src/runtime/contrib/json/json_runtime.h
@@ -59,7 +59,7 @@ class JSONRuntimeBase : public ModuleNode {
   const char* type_key() const override { return "json"; }  // May be overridden
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const { return property::kBinarySerializable | property::kRunnable; }
+  int GetProperty() const { return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable; }
 
   /*! \brief Initialize a specific json runtime. */
   virtual void Init(const Array<NDArray>& consts) = 0;

--- a/src/runtime/contrib/json/json_runtime.h
+++ b/src/runtime/contrib/json/json_runtime.h
@@ -59,7 +59,9 @@ class JSONRuntimeBase : public ModuleNode {
   const char* type_key() const override { return "json"; }  // May be overridden
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const { return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable; }
+  int GetPropertyMask() const {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  }
 
   /*! \brief Initialize a specific json runtime. */
   virtual void Init(const Array<NDArray>& consts) = 0;

--- a/src/runtime/contrib/libtorch/libtorch_runtime.cc
+++ b/src/runtime/contrib/libtorch/libtorch_runtime.cc
@@ -89,7 +89,7 @@ class TorchModuleNode : public ModuleNode {
 
   const char* type_key() const { return "torch"; }
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; };
+  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable; };
 
   /*!
    * \brief Get a packed function.

--- a/src/runtime/contrib/libtorch/libtorch_runtime.cc
+++ b/src/runtime/contrib/libtorch/libtorch_runtime.cc
@@ -89,7 +89,7 @@ class TorchModuleNode : public ModuleNode {
 
   const char* type_key() const { return "torch"; }
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinaryExportable; };
+  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; };
 
   /*!
    * \brief Get a packed function.

--- a/src/runtime/contrib/libtorch/libtorch_runtime.cc
+++ b/src/runtime/contrib/libtorch/libtorch_runtime.cc
@@ -89,7 +89,9 @@ class TorchModuleNode : public ModuleNode {
 
   const char* type_key() const { return "torch"; }
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable; };
+  int GetPropertyMask() const final {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  }
 
   /*!
    * \brief Get a packed function.

--- a/src/runtime/contrib/libtorch/libtorch_runtime.cc
+++ b/src/runtime/contrib/libtorch/libtorch_runtime.cc
@@ -88,6 +88,8 @@ class TorchModuleNode : public ModuleNode {
       : symbol_name_(symbol_name), module_(module) {}
 
   const char* type_key() const { return "torch"; }
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kBinaryExportable; };
 
   /*!
    * \brief Get a packed function.

--- a/src/runtime/contrib/onnx/onnx_module.cc
+++ b/src/runtime/contrib/onnx/onnx_module.cc
@@ -36,7 +36,7 @@ class ONNXSourceModuleNode : public runtime::ModuleNode {
   const char* type_key() const { return "onnx"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kRunnable; };
+  int GetProperty() const final { return ModulePropertyMask::kRunnable; };
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     if (name == "get_symbol") {

--- a/src/runtime/contrib/onnx/onnx_module.cc
+++ b/src/runtime/contrib/onnx/onnx_module.cc
@@ -35,6 +35,9 @@ class ONNXSourceModuleNode : public runtime::ModuleNode {
       : code_(code), symbol_(symbol), const_vars_(const_vars) {}
   const char* type_key() const { return "onnx"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kRunnable; };
+
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     if (name == "get_symbol") {
       return PackedFunc(

--- a/src/runtime/contrib/onnx/onnx_module.cc
+++ b/src/runtime/contrib/onnx/onnx_module.cc
@@ -36,7 +36,7 @@ class ONNXSourceModuleNode : public runtime::ModuleNode {
   const char* type_key() const { return "onnx"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kRunnable; };
+  int GetPropertyMask() const final { return ModulePropertyMask::kRunnable; };
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     if (name == "get_symbol") {

--- a/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
@@ -97,6 +97,9 @@ class TensorRTRuntime : public JSONRuntimeBase {
    */
   const char* type_key() const final { return "tensorrt"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kBinaryExportable; }
+
   /*!
    * \brief Initialize runtime. Create TensorRT layer from JSON
    * representation.

--- a/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
@@ -98,7 +98,7 @@ class TensorRTRuntime : public JSONRuntimeBase {
   const char* type_key() const final { return "tensorrt"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinaryExportable; }
+  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; }
 
   /*!
    * \brief Initialize runtime. Create TensorRT layer from JSON

--- a/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
@@ -98,7 +98,7 @@ class TensorRTRuntime : public JSONRuntimeBase {
   const char* type_key() const final { return "tensorrt"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final {
+  int GetPropertyMask() const final {
     return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
   }
 

--- a/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_runtime.cc
@@ -98,7 +98,9 @@ class TensorRTRuntime : public JSONRuntimeBase {
   const char* type_key() const final { return "tensorrt"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; }
+  int GetProperty() const final {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  }
 
   /*!
    * \brief Initialize runtime. Create TensorRT layer from JSON

--- a/src/runtime/contrib/tflite/tflite_runtime.h
+++ b/src/runtime/contrib/tflite/tflite_runtime.h
@@ -61,7 +61,7 @@ class TFLiteRuntime : public ModuleNode {
   const char* type_key() const { return "TFLiteRuntime"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kRunnable; };
+  int GetProperty() const final { return ModulePropertyMask::kRunnable; };
 
   /*!
    * \brief Invoke the internal tflite interpreter and run the whole model in

--- a/src/runtime/contrib/tflite/tflite_runtime.h
+++ b/src/runtime/contrib/tflite/tflite_runtime.h
@@ -60,6 +60,9 @@ class TFLiteRuntime : public ModuleNode {
    */
   const char* type_key() const { return "TFLiteRuntime"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kRunnable; };
+
   /*!
    * \brief Invoke the internal tflite interpreter and run the whole model in
    * dependency order.

--- a/src/runtime/contrib/tflite/tflite_runtime.h
+++ b/src/runtime/contrib/tflite/tflite_runtime.h
@@ -61,7 +61,7 @@ class TFLiteRuntime : public ModuleNode {
   const char* type_key() const { return "TFLiteRuntime"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kRunnable; };
+  int GetPropertyMask() const final { return ModulePropertyMask::kRunnable; };
 
   /*!
    * \brief Invoke the internal tflite interpreter and run the whole model in

--- a/src/runtime/contrib/vitis_ai/vitis_ai_runtime.h
+++ b/src/runtime/contrib/vitis_ai/vitis_ai_runtime.h
@@ -87,7 +87,7 @@ class VitisAIRuntime : public ModuleNode {
   const char* type_key() const { return "VitisAIRuntime"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final {
+  int GetPropertyMask() const final {
     return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
   };
 

--- a/src/runtime/contrib/vitis_ai/vitis_ai_runtime.h
+++ b/src/runtime/contrib/vitis_ai/vitis_ai_runtime.h
@@ -87,7 +87,7 @@ class VitisAIRuntime : public ModuleNode {
   const char* type_key() const { return "VitisAIRuntime"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinaryExportable; };
+  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; };
 
   /*!
    * \brief Serialize the content of the pyxir directory and save it to

--- a/src/runtime/contrib/vitis_ai/vitis_ai_runtime.h
+++ b/src/runtime/contrib/vitis_ai/vitis_ai_runtime.h
@@ -87,7 +87,9 @@ class VitisAIRuntime : public ModuleNode {
   const char* type_key() const { return "VitisAIRuntime"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; };
+  int GetProperty() const final {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  };
 
   /*!
    * \brief Serialize the content of the pyxir directory and save it to

--- a/src/runtime/contrib/vitis_ai/vitis_ai_runtime.h
+++ b/src/runtime/contrib/vitis_ai/vitis_ai_runtime.h
@@ -86,6 +86,9 @@ class VitisAIRuntime : public ModuleNode {
    */
   const char* type_key() const { return "VitisAIRuntime"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kBinaryExportable; };
+
   /*!
    * \brief Serialize the content of the pyxir directory and save it to
    *        binary stream.

--- a/src/runtime/cuda/cuda_module.cc
+++ b/src/runtime/cuda/cuda_module.cc
@@ -66,7 +66,7 @@ class CUDAModuleNode : public runtime::ModuleNode {
   const char* type_key() const final { return "cuda"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final {
+  int GetPropertyMask() const final {
     return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
   }
 

--- a/src/runtime/cuda/cuda_module.cc
+++ b/src/runtime/cuda/cuda_module.cc
@@ -65,6 +65,9 @@ class CUDAModuleNode : public runtime::ModuleNode {
 
   const char* type_key() const final { return "cuda"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kBinaryExportable; }
+
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
   void SaveToFile(const std::string& file_name, const std::string& format) final {

--- a/src/runtime/cuda/cuda_module.cc
+++ b/src/runtime/cuda/cuda_module.cc
@@ -66,7 +66,7 @@ class CUDAModuleNode : public runtime::ModuleNode {
   const char* type_key() const final { return "cuda"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinaryExportable; }
+  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 

--- a/src/runtime/cuda/cuda_module.cc
+++ b/src/runtime/cuda/cuda_module.cc
@@ -66,7 +66,9 @@ class CUDAModuleNode : public runtime::ModuleNode {
   const char* type_key() const final { return "cuda"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; }
+  int GetProperty() const final {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 

--- a/src/runtime/graph_executor/graph_executor.h
+++ b/src/runtime/graph_executor/graph_executor.h
@@ -90,7 +90,7 @@ class TVM_DLL GraphExecutor : public ModuleNode {
   void Run();
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kRunnable; }
+  int GetPropertyMask() const final { return ModulePropertyMask::kRunnable; }
 
   /*!
    * \brief Initialize the graph executor with graph and device.

--- a/src/runtime/graph_executor/graph_executor.h
+++ b/src/runtime/graph_executor/graph_executor.h
@@ -90,7 +90,7 @@ class TVM_DLL GraphExecutor : public ModuleNode {
   void Run();
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kRunnable; }
+  int GetProperty() const final { return ModulePropertyMask::kRunnable; }
 
   /*!
    * \brief Initialize the graph executor with graph and device.

--- a/src/runtime/graph_executor/graph_executor.h
+++ b/src/runtime/graph_executor/graph_executor.h
@@ -89,6 +89,9 @@ class TVM_DLL GraphExecutor : public ModuleNode {
   const char* type_key() const final { return "GraphExecutor"; }
   void Run();
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kRunnable; }
+
   /*!
    * \brief Initialize the graph executor with graph and device.
    * \param graph_json The execution graph.

--- a/src/runtime/graph_executor/graph_executor_factory.h
+++ b/src/runtime/graph_executor/graph_executor_factory.h
@@ -68,7 +68,7 @@ class TVM_DLL GraphExecutorFactory : public runtime::ModuleNode {
   const char* type_key() const final { return "GraphExecutorFactory"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable; }
+  int GetPropertyMask() const final { return ModulePropertyMask::kBinarySerializable; }
 
   /*!
    * \brief Save the module to binary stream.

--- a/src/runtime/graph_executor/graph_executor_factory.h
+++ b/src/runtime/graph_executor/graph_executor_factory.h
@@ -67,6 +67,9 @@ class TVM_DLL GraphExecutorFactory : public runtime::ModuleNode {
    */
   const char* type_key() const final { return "GraphExecutorFactory"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kBinarySerializable; }
+
   /*!
    * \brief Save the module to binary stream.
    * \param stream The binary stream to save to.

--- a/src/runtime/graph_executor/graph_executor_factory.h
+++ b/src/runtime/graph_executor/graph_executor_factory.h
@@ -68,7 +68,7 @@ class TVM_DLL GraphExecutorFactory : public runtime::ModuleNode {
   const char* type_key() const final { return "GraphExecutorFactory"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinarySerializable; }
+  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable; }
 
   /*!
    * \brief Save the module to binary stream.

--- a/src/runtime/hexagon/hexagon_module.h
+++ b/src/runtime/hexagon/hexagon_module.h
@@ -62,6 +62,9 @@ class HexagonModuleNode : public runtime::ModuleNode {
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) override;
   std::string GetSource(const std::string& format) override;
   const char* type_key() const final { return "hexagon"; }
+  virtual uint8_t GetProperty() const {
+    return property::kBinarySerializable | property::kRunnable;
+  };
   void SaveToFile(const std::string& file_name, const std::string& format) override;
   void SaveToBinary(dmlc::Stream* stream) override;
 

--- a/src/runtime/hexagon/hexagon_module.h
+++ b/src/runtime/hexagon/hexagon_module.h
@@ -62,8 +62,9 @@ class HexagonModuleNode : public runtime::ModuleNode {
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) override;
   std::string GetSource(const std::string& format) override;
   const char* type_key() const final { return "hexagon"; }
-  virtual uint8_t GetProperty() const {
-    return property::kBinarySerializable | property::kRunnable;
+  /*! \brief Get the property of the runtime module .*/
+  int GetProperty() const {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
   };
   void SaveToFile(const std::string& file_name, const std::string& format) override;
   void SaveToBinary(dmlc::Stream* stream) override;

--- a/src/runtime/hexagon/hexagon_module.h
+++ b/src/runtime/hexagon/hexagon_module.h
@@ -63,9 +63,9 @@ class HexagonModuleNode : public runtime::ModuleNode {
   std::string GetSource(const std::string& format) override;
   const char* type_key() const final { return "hexagon"; }
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const {
+  int GetPropertyMask() const {
     return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
-  };
+  }
   void SaveToFile(const std::string& file_name, const std::string& format) override;
   void SaveToBinary(dmlc::Stream* stream) override;
 

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -41,9 +41,9 @@ class LibraryModuleNode final : public ModuleNode {
       : lib_(lib), packed_func_wrapper_(wrapper) {}
 
   const char* type_key() const final { return "library"; }
-  
+
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final {
+  int GetPropertyMask() const final {
     return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
   };
 

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -41,7 +41,11 @@ class LibraryModuleNode final : public ModuleNode {
       : lib_(lib), packed_func_wrapper_(wrapper) {}
 
   const char* type_key() const final { return "library"; }
-  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; };
+  
+  /*! \brief Get the property of the runtime module .*/
+  int GetProperty() const final {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  };
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     TVMBackendPackedCFunc faddr;

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -41,7 +41,7 @@ class LibraryModuleNode final : public ModuleNode {
       : lib_(lib), packed_func_wrapper_(wrapper) {}
 
   const char* type_key() const final { return "library"; }
-  uint8_t GetProperty() const final { return property::kBinaryExportable; };
+  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; };
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     TVMBackendPackedCFunc faddr;

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -41,6 +41,7 @@ class LibraryModuleNode final : public ModuleNode {
       : lib_(lib), packed_func_wrapper_(wrapper) {}
 
   const char* type_key() const final { return "library"; }
+  uint8_t GetProperty() const final { return property::kBinaryExportable; };
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     TVMBackendPackedCFunc faddr;

--- a/src/runtime/metadata.cc
+++ b/src/runtime/metadata.cc
@@ -89,7 +89,7 @@ class MetadataModuleNode : public ::tvm::runtime::ModuleNode {
   const char* type_key() const final { return "metadata_module"; }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinarySerializable; }
+  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable; }
 
   static Module LoadFromBinary() {
     return Module(make_object<MetadataModuleNode>(runtime::metadata::Metadata()));

--- a/src/runtime/metadata.cc
+++ b/src/runtime/metadata.cc
@@ -89,7 +89,7 @@ class MetadataModuleNode : public ::tvm::runtime::ModuleNode {
   const char* type_key() const final { return "metadata_module"; }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kBinarySerializable; }
+  int GetPropertyMask() const final { return ModulePropertyMask::kBinarySerializable; }
 
   static Module LoadFromBinary() {
     return Module(make_object<MetadataModuleNode>(runtime::metadata::Metadata()));

--- a/src/runtime/metadata.cc
+++ b/src/runtime/metadata.cc
@@ -88,6 +88,9 @@ class MetadataModuleNode : public ::tvm::runtime::ModuleNode {
 
   const char* type_key() const final { return "metadata_module"; }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kBinarySerializable; }
+
   static Module LoadFromBinary() {
     return Module(make_object<MetadataModuleNode>(runtime::metadata::Metadata()));
   }

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -197,8 +197,8 @@ TVM_REGISTER_GLOBAL("runtime.ModuleLoadFromFile").set_body_typed(Module::LoadFro
 TVM_REGISTER_GLOBAL("runtime.ModuleSaveToFile")
     .set_body_typed([](Module mod, String name, tvm::String fmt) { mod->SaveToFile(name, fmt); });
 
-TVM_REGISTER_GLOBAL("runtime.ModuleIsDSOExportable").set_body_typed([](Module mod) {
-  return mod->IsDSOExportable();
+TVM_REGISTER_GLOBAL("runtime.ModuleGetPropertyMask").set_body_typed([](Module mod) {
+  return mod->GetPropertyMask();
 });
 
 TVM_REGISTER_GLOBAL("runtime.ModuleImplementsFunction")

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -132,8 +132,6 @@ std::string ModuleNode::GetFormat() {
   LOG(FATAL) << "Module[" << type_key() << "] does not support GetFormat";
 }
 
-bool ModuleNode::IsDSOExportable() const { return false; }
-
 bool ModuleNode::ImplementsFunction(const String& name, bool query_imports) {
   return GetFunction(name, query_imports) != nullptr;
 }

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -432,7 +432,7 @@ class OpenCLModuleNode : public ModuleNode {
   const char* type_key() const final { return workspace_->type_key.c_str(); }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final {
+  int GetPropertyMask() const final {
     return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
   }
 

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -431,6 +431,9 @@ class OpenCLModuleNode : public ModuleNode {
 
   const char* type_key() const final { return workspace_->type_key.c_str(); }
 
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kBinaryExportable; }
+
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
   void SaveToFile(const std::string& file_name, const std::string& format) final;
   void SaveToBinary(dmlc::Stream* stream) final;

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -432,7 +432,7 @@ class OpenCLModuleNode : public ModuleNode {
   const char* type_key() const final { return workspace_->type_key.c_str(); }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinaryExportable; }
+  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
   void SaveToFile(const std::string& file_name, const std::string& format) final;

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -432,7 +432,9 @@ class OpenCLModuleNode : public ModuleNode {
   const char* type_key() const final { return workspace_->type_key.c_str(); }
 
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kBinarySerializable | property::kRunnable; }
+  int GetProperty() const final {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
   void SaveToFile(const std::string& file_name, const std::string& format) final;

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -175,6 +175,8 @@ class RPCModuleNode final : public ModuleNode {
   }
 
   const char* type_key() const final { return "rpc"; }
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return property::kRunnable; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     if (name == "CloseRPCConnection") {

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -176,7 +176,7 @@ class RPCModuleNode final : public ModuleNode {
 
   const char* type_key() const final { return "rpc"; }
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return property::kRunnable; }
+  int GetProperty() const final { return ModulePropertyMask::kRunnable; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     if (name == "CloseRPCConnection") {

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -176,7 +176,7 @@ class RPCModuleNode final : public ModuleNode {
 
   const char* type_key() const final { return "rpc"; }
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return ModulePropertyMask::kRunnable; }
+  int GetPropertyMask() const final { return ModulePropertyMask::kRunnable; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     if (name == "CloseRPCConnection") {

--- a/src/runtime/static_library.cc
+++ b/src/runtime/static_library.cc
@@ -63,7 +63,8 @@ class StaticLibraryNode final : public runtime::ModuleNode {
   }
 
   // TODO(tvm-team): Make this module serializable
-  uint8_t GetProperty() const { return property::kDSOExportable; }
+  /*! \brief Get the property of the runtime module .*/
+  int GetProperty() const { return ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();

--- a/src/runtime/static_library.cc
+++ b/src/runtime/static_library.cc
@@ -62,7 +62,8 @@ class StaticLibraryNode final : public runtime::ModuleNode {
     SaveBinaryToFile(file_name, data_);
   }
 
-  bool IsDSOExportable() const final { return true; }
+  // TODO(tvm-team): Make this module serializable
+  uint8_t GetProperty() const { return property::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();

--- a/src/runtime/static_library.cc
+++ b/src/runtime/static_library.cc
@@ -64,7 +64,7 @@ class StaticLibraryNode final : public runtime::ModuleNode {
 
   // TODO(tvm-team): Make this module serializable
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const { return ModulePropertyMask::kDSOExportable; }
+  int GetPropertyMask() const { return ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -92,7 +92,10 @@ class LLVMModuleNode final : public runtime::ModuleNode {
   const char* type_key() const final { return "llvm"; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
-
+  virtual uint8_t GetProperty() const {
+    return runtime::property::kBinarySerializable | runtime::property::kRunnable |
+           runtime::property::kDSOExportable;
+  };
   void SaveToFile(const std::string& file_name, const std::string& format) final;
   void SaveToBinary(dmlc::Stream* stream) final;
   std::string GetSource(const std::string& format) final;
@@ -100,7 +103,6 @@ class LLVMModuleNode final : public runtime::ModuleNode {
   void Init(const IRModule& mod, const Target& target);
   void Init(std::unique_ptr<llvm::Module> module, std::unique_ptr<LLVMInstance> llvm_instance);
   void LoadIR(const std::string& file_name);
-  uint8_t GetProperty() const { return runtime::property::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final;
 

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -92,9 +92,10 @@ class LLVMModuleNode final : public runtime::ModuleNode {
   const char* type_key() const final { return "llvm"; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
-  virtual uint8_t GetProperty() const {
-    return runtime::property::kBinarySerializable | runtime::property::kRunnable |
-           runtime::property::kDSOExportable;
+  /*! \brief Get the property of the runtime module .*/
+  int GetProperty() const {
+    return runtime::ModulePropertyMask::kBinarySerializable |
+           runtime::ModulePropertyMask::kRunnable | runtime::ModulePropertyMask::kDSOExportable;
   };
   void SaveToFile(const std::string& file_name, const std::string& format) final;
   void SaveToBinary(dmlc::Stream* stream) final;

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -95,9 +95,9 @@ class LLVMModuleNode final : public runtime::ModuleNode {
 
   /*! \brief Get the property of the runtime module .*/
   // TODO(tvm-team): Make it serializable
-  int GetProperty() const {
+  int GetPropertyMask() const {
     return runtime::ModulePropertyMask::kRunnable | runtime::ModulePropertyMask::kDSOExportable;
-  };
+  }
 
   void SaveToFile(const std::string& file_name, const std::string& format) final;
   void SaveToBinary(dmlc::Stream* stream) final;

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -100,7 +100,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
   void Init(const IRModule& mod, const Target& target);
   void Init(std::unique_ptr<llvm::Module> module, std::unique_ptr<LLVMInstance> llvm_instance);
   void LoadIR(const std::string& file_name);
-  bool IsDSOExportable() const final { return true; }
+  uint8_t GetProperty() const { return runtime::property::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final;
 

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -92,11 +92,13 @@ class LLVMModuleNode final : public runtime::ModuleNode {
   const char* type_key() const final { return "llvm"; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
+
   /*! \brief Get the property of the runtime module .*/
+  // TODO(tvm-team): Make it serializable
   int GetProperty() const {
-    return runtime::ModulePropertyMask::kBinarySerializable |
-           runtime::ModulePropertyMask::kRunnable | runtime::ModulePropertyMask::kDSOExportable;
+    return runtime::ModulePropertyMask::kRunnable | runtime::ModulePropertyMask::kDSOExportable;
   };
+
   void SaveToFile(const std::string& file_name, const std::string& format) final;
   void SaveToBinary(dmlc::Stream* stream) final;
   std::string GetSource(const std::string& format) final;

--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -490,7 +490,7 @@ class WebGPUSourceModuleNode final : public runtime::ModuleNode {
 
   const char* type_key() const final { return "webgpu"; }
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return runtime::ModulePropertyMask::kBinarySerializable; }
+  int GetPropertyMask() const final { return runtime::ModulePropertyMask::kBinarySerializable; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     LOG(FATAL) << "WebGPUSourceModule is not directly runnable, export and run through tvmjs";

--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -490,7 +490,7 @@ class WebGPUSourceModuleNode final : public runtime::ModuleNode {
 
   const char* type_key() const final { return "webgpu"; }
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return runtime::property::kBinarySerializable; }
+  int GetProperty() const final { return runtime::ModulePropertyMask::kBinarySerializable; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     LOG(FATAL) << "WebGPUSourceModule is not directly runnable, export and run through tvmjs";

--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -489,6 +489,8 @@ class WebGPUSourceModuleNode final : public runtime::ModuleNode {
       : smap_(smap), fmap_(fmap) {}
 
   const char* type_key() const final { return "webgpu"; }
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return runtime::property::kBinarySerializable; }
 
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     LOG(FATAL) << "WebGPUSourceModule is not directly runnable, export and run through tvmjs";

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -130,7 +130,7 @@ class CSourceModuleNode : public runtime::ModuleNode {
     }
   }
 
-  bool IsDSOExportable() const final { return true; }
+  uint8_t GetProperty() const { return runtime::property::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();
@@ -200,7 +200,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
     }
   }
 
-  bool IsDSOExportable() const final { return true; }
+  uint8_t GetProperty() const { return runtime::property::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();
@@ -1009,6 +1009,8 @@ class DeviceSourceModuleNode final : public runtime::ModuleNode {
   }
 
   const char* type_key() const final { return type_key_.c_str(); }
+  /*! \brief Get the property of the runtime module .*/
+  uint8_t GetProperty() const final { return runtime::property::kBinarySerializable; }
 
   void SaveToFile(const std::string& file_name, const std::string& format) final {
     std::string fmt = GetFileFormat(file_name, format);

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -130,7 +130,7 @@ class CSourceModuleNode : public runtime::ModuleNode {
     }
   }
 
-  int GetProperty() const { return runtime::ModulePropertyMask::kDSOExportable; }
+  int GetPropertyMask() const { return runtime::ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();
@@ -200,7 +200,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
     }
   }
 
-  int GetProperty() const { return runtime::ModulePropertyMask::kDSOExportable; }
+  int GetPropertyMask() const { return runtime::ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();
@@ -1010,7 +1010,7 @@ class DeviceSourceModuleNode final : public runtime::ModuleNode {
 
   const char* type_key() const final { return type_key_.c_str(); }
   /*! \brief Get the property of the runtime module .*/
-  int GetProperty() const final { return runtime::ModulePropertyMask::kBinarySerializable; }
+  int GetPropertyMask() const final { return runtime::ModulePropertyMask::kBinarySerializable; }
 
   void SaveToFile(const std::string& file_name, const std::string& format) final {
     std::string fmt = GetFileFormat(file_name, format);

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -130,7 +130,7 @@ class CSourceModuleNode : public runtime::ModuleNode {
     }
   }
 
-  uint8_t GetProperty() const { return runtime::property::kDSOExportable; }
+  int GetProperty() const { return runtime::ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();
@@ -200,7 +200,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
     }
   }
 
-  uint8_t GetProperty() const { return runtime::property::kDSOExportable; }
+  int GetProperty() const { return runtime::ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();
@@ -1010,7 +1010,7 @@ class DeviceSourceModuleNode final : public runtime::ModuleNode {
 
   const char* type_key() const final { return type_key_.c_str(); }
   /*! \brief Get the property of the runtime module .*/
-  uint8_t GetProperty() const final { return runtime::property::kBinarySerializable; }
+  int GetProperty() const final { return runtime::ModulePropertyMask::kBinarySerializable; }
 
   void SaveToFile(const std::string& file_name, const std::string& format) final {
     std::string fmt = GetFileFormat(file_name, format);

--- a/tests/python/unittest/test_micro_model_library_format.py
+++ b/tests/python/unittest/test_micro_model_library_format.py
@@ -414,7 +414,7 @@ def test_export_non_dso_exportable():
 
     temp_dir = utils.tempdir()
 
-    with pytest.raises(micro.UnsupportedInModelLibraryFormatError) as exc:
+    with pytest.raises(AssertionError) as exc:
         model_library_format._populate_codegen_dir([module], temp_dir.relpath("codegen"))
 
         assert str(exc.exception) == (

--- a/tests/python/unittest/test_runtime_module_property.py
+++ b/tests/python/unittest/test_runtime_module_property.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+from tvm import te
+import tvm.runtime._ffi_api
+import tvm.target._ffi_api
+
+
+def checker(mod, expected):
+    assert mod.is_binary_serializable == expected["is_binary_serializable"]
+    assert mod.is_runnable == expected["is_runnable"]
+    assert mod.is_dso_exportable == expected["is_dso_exportable"]
+
+
+def create_csource_module():
+    return tvm.runtime._ffi_api.CSourceModuleCreate("", "cc", [], None)
+
+
+def create_llvm_module():
+    A = te.placeholder((1024,), name="A")
+    B = te.compute(A.shape, lambda *i: A(*i) + 1.0, name="B")
+    s = te.create_schedule(B.op)
+    return tvm.build(s, [A, B], "llvm", name="myadd0")
+
+
+def create_aot_module():
+    return tvm.get_global_func("relay.build_module._AOTExecutorCodegen")()
+
+
+def test_property():
+    checker(
+        create_csource_module(),
+        expected={"is_binary_serializable": False, "is_runnable": False, "is_dso_exportable": True},
+    )
+
+    checker(
+        create_llvm_module(),
+        expected={"is_binary_serializable": False, "is_runnable": True, "is_dso_exportable": True},
+    )
+
+    checker(
+        create_aot_module(),
+        expected={"is_binary_serializable": False, "is_runnable": True, "is_dso_exportable": False},
+    )
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Currently, we only classify whether the runtime module is DSO-exportable.

This PR further classifies each runtime module into the properties as follows:
- `kBinarySerializable`: we can serialize the module to the stream of bytes. CUDA/OpenCL/JSON runtime are representative examples.
- `kRunnable`: we can run the module directly. LLVM/CUDA/JSON runtime, executors (e.g, virtual machine) runtimes are runnable. Non-runnable modules, such as CSourceModule, requires a few extra steps (e.g,. compilation, link) to make it runnable.
- `kBinaryExportable`: when the module is kBinarySerializable and kRunnable, we consider this module as binary exportable. A binary exportable module can be integrated into final runtime artifact by being serialized as data into the artifact, then deserialzied at runtime. This class of modules must implement `SaveToBinary`, and have a matching deserializer registered as `runtime.module.loadbinary_<type_key>`.
- `kDSOExportable`: we can export the module as DSO. A DSO exportable module (e.g., a CSourceModuleNode of type_key 'c') can be incorporated into the final runtime artifact (ie shared library) by compilation and/or linking using the external compiler (llvm, nvcc, etc). DSO exportable modules must implement `SaveToFile`.

Please note that `kDSOExportable` is a mutual exclusive property with `kBinaryExportable`. 

To represent each category, the following status bits are defined.
```
namespace property {
/*! \brief Binary serializable runtime module */
constexpr const uint8_t kBinarySerializable = 0b001;
/*! \brief Runnable runtime module */
constexpr const uint8_t kRunnable = 0b010;
/*! \brief DSO exportable runtime module */
constexpr const uint8_t kDSOExportable = 0b100;
/*! \brief Binary exportable runtime module */
constexpr const uint8_t kBinaryExportable = kBinarySerializable | kRunnable;
};  // namespace property
```

## Edit based on the review

This PR further classifies each runtime module into the properties as follows:
- `kBinarySerializable`: we can serialize the module to the stream of bytes. CUDA/OpenCL/JSON runtime are representative examples. A binary exportable module can be integrated into final runtime artifact by being serialized as data into the artifact, then deserialized at runtime. This class of modules must implement `SaveToBinary`, and have a matching deserializer registered as `runtime.module.loadbinary_<type_key>`.
- `kRunnable`: we can run the module directly. LLVM/CUDA/JSON runtime, executors (e.g, virtual machine) runtimes are runnable. Non-runnable modules, such as `CSourceModule`, requires a few extra steps (e.g,. compilation, link) to make it runnable. 
- `kDSOExportable`: we can export the module as DSO. A DSO exportable module (e.g., a `CSourceModuleNode` of type_key 'c') can be incorporated into the final runtime artifact (ie shared library) by compilation and/or linking using the external compiler (llvm, nvcc, etc). DSO-exportable modules must implement `SaveToFile`. In general, DSO exportable modules are not runnable unless there is a special support like JIT for `LLVMModule`. 

To represent each category, the following status bits are defined.
```
enum ModulePropertyMask : int {
  kBinarySerializable = 0b001,
  kRunnable = 0b010,
  kDSOExportable = 0b100
};
```

cc. @tqchen 