### PR TITLE
[MetaSchedule][Hexagon] Improve vectorization for standalone elementwise op

### DIFF
--- a/tests/python/unittest/test_meta_schedule_postproc_rewrite_parallel_vectorize_unroll.py
+++ b/tests/python/unittest/test_meta_schedule_postproc_rewrite_parallel_vectorize_unroll.py
@@ -142,6 +142,42 @@ def after_matmul_vectorize(
                     T_matmul_NT[v0, v1] = T_matmul_NT_global[v0, v1]
 
 
+@T.prim_func
+def before_postproc_add(
+    lhs: T.Buffer((1, 8, 56, 56, 32), "uint8"),
+    rhs: T.Buffer((1, 8, 56, 56, 32), "uint8"),
+    add_compute: T.Buffer((1, 8, 56, 56, 32), "uint8"),
+) -> None:
+    with T.block("root"):
+        T.block_attr({"meta_schedule.parallel":64, "meta_schedule.vectorize":128})
+        for n, c0, h, w, c1 in T.grid(1, 8, 56, 56, 32):
+            with T.block("add_compute"):
+                v0, v1, v2, v3, v4 = T.axis.remap("SSSSS", [n, c0, h, w, c1])
+                T.reads(lhs[v0, v1, v2, v3, v4], rhs[v0, v1, v2, v3, v4])
+                T.writes(add_compute[v0, v1, v2, v3, v4])
+                add_compute[v0, v1, v2, v3, v4] = lhs[v0, v1, v2, v3, v4] + rhs[v0, v1, v2, v3, v4]
+
+
+@T.prim_func
+def after_postproc_add(
+    lhs: T.Buffer((1, 8, 56, 56, 32), "uint8"),
+    rhs: T.Buffer((1, 8, 56, 56, 32), "uint8"),
+    add_compute: T.Buffer((1, 8, 56, 56, 32), "uint8"),
+) -> None:
+    with T.block("root"):
+        for n_c0_h_w_c1_fused_0 in T.parallel(0, 6272):
+            for n_c0_h_w_c1_fused_1 in T.vectorized(0, 128):
+                with T.block("add_compute"):
+                    v0 = T.axis.spatial(1, 0)
+                    v1 = T.axis.spatial(8, (n_c0_h_w_c1_fused_0 * 128 + n_c0_h_w_c1_fused_1) // 100352)
+                    v2 = T.axis.spatial(56, (n_c0_h_w_c1_fused_0 * 128 + n_c0_h_w_c1_fused_1) % 100352 // 1792)
+                    v3 = T.axis.spatial(56, (n_c0_h_w_c1_fused_0 * 128 + n_c0_h_w_c1_fused_1) % 1792 // 32)
+                    v4 = T.axis.spatial(32, (n_c0_h_w_c1_fused_0 * 128 + n_c0_h_w_c1_fused_1) % 32)
+                    T.reads(lhs[v0, v1, v2, v3, v4], rhs[v0, v1, v2, v3, v4])
+                    T.writes(add_compute[v0, v1, v2, v3, v4])
+                    add_compute[v0, v1, v2, v3, v4] = lhs[v0, v1, v2, v3, v4] + rhs[v0, v1, v2, v3, v4]
+
+
 # fmt: on
 # pylint: enable=invalid-name,no-member,line-too-long,too-many-nested-blocks,no-self-argument,not-callable
 
@@ -161,6 +197,14 @@ def test_vectorize_inner_loop():
     tvm.ir.assert_structural_equal(sch.mod["main"], after_matmul_vectorize)
 
 
+def test_parallel_vectorize_add():
+    sch = Schedule(before_postproc_add)
+    rule = RewriteParallelVectorizeUnroll()
+    assert rule.apply(sch)
+    tvm.ir.assert_structural_equal(sch.mod["main"], after_postproc_add)
+
+
 if __name__ == "__main__":
     test_meta_schedule_postproc_rewrite_parallel_unroll_vectorize()
     test_vectorize_inner_loop()
+    test_parallel_vectorize_add()


### PR DESCRIPTION
**Motivation:**
It was found that for standalone elementwise operations (add, sub, etc.) MetaScheduler generates code with poor performance due to lack of vector code on some input tensor shapes. Current implementation is not able to vectorize if innermost loops extent is not multiple of the vector length.

**What was done:**
Core changes: it checks current loops nest, if all loops are "simple", i.e. loops without annotations, bindings, reduce axis, then it does the following:
 1) Fuse all loops into single one.
 2) Split this new loop into 2 parts: inner and outer. Herewith split factor for the inner loop is equal to '_max_vectorize_extent_' MetaScheduler parameter.
 3) Parallelize outer loop and vectorize inner loop.

**Performance measurement**:
Measurement was done on Qualcomm Snapdragon 888. As it was expected, 1 and 2 got significant performance boost, 3 and 4 - without changes.

N |    op   | Dtype |      Shape       | Before fix, ms | After fix, ms | speedup |
--|---------|-------|------------------|----------------|---------------|---------|
1 | add     | uint8 | 1, 8, 56, 56, 32 |      1.264     |     0.167     |  7.5x   |
2 | qnn.add | uint8 | 1, 8, 56, 56, 32 |      2.213     |     0.336     |  6.6x   |
3 | add     | int32 | 1, 8, 56, 56, 32 |      0.161     |     0.150     |  1.07x  |
4 | seq*    | uint8 | 1, 64, 56, 56    |      2.634     |     2.679     |  0.98x  |

seq* - test of the ops sequence: qnn.conv2d + bias_add + qnn.requantize,
       weights shape = [256, 64, 1, 1]