### PR TITLE
[skip ci] Replace magic_wand model with micro_speech

### DIFF
--- a/gallery/how_to/work_with_microtvm/micro_tvmc.sh
+++ b/gallery/how_to/work_with_microtvm/micro_tvmc.sh
@@ -81,13 +81,13 @@ tvmc micro --help
 # Obtain a Tiny Model
 ############################################################
 #
-# For this tutorial, we will use Magic Wand model from tflite micro. Magic Wand is a
-# Depthwise Convolution Layer model which recognizes gestures with an accelerometer.
+# For this tutorial, we will use Micro Speech model from tflite micro. Micro Speech is a
+# Depthwise Convolution Layer model to recognize keywords in speech.
 #
 # For this tutorial we will be using the model in tflite format.
 #
 # bash
-wget https://github.com/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite
+wget https://github.com/tensorflow/tflite-micro/raw/a56087ffa2703b4d5632f024a8a4c899815c31bb/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite
 # bash
 
 ############################################################
@@ -100,10 +100,10 @@ wget https://github.com/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/e
 #
 # Here, we generate a MLF file for ``qemu_x86`` Zephyr board. You can chooses `aot` or `graph` executor type
 # to run this tutorial, however, we recommend to use `aot` for microTVM targets since `aot` uses ahead of time
-# compilation with static memory allocation. To generate MLF output for the ``magic_wand`` tflite model:
+# compilation with static memory allocation. To generate MLF output for the ``micro_speech`` tflite model:
 #
 # bash
-tvmc compile magic_wand.tflite \
+tvmc compile micro_speech.tflite \
     --target='c -keys=cpu -model=host' \
     --runtime=crt \
     --runtime-crt-system-lib 1 \
@@ -198,5 +198,5 @@ tvmc run \
 #      # remote: microTVM Zephyr runtime - running
 #      # INFO:__main__:b'[100%] Built target run\n'
 #      # [[3.         1.         2.         0.        ]
-#      # [0.47213247 0.41364592 0.07525456 0.03896701]]
+#      # [113 -121 -120 -128]]
 #

--- a/gallery/how_to/work_with_microtvm/micro_tvmc.sh
+++ b/gallery/how_to/work_with_microtvm/micro_tvmc.sh
@@ -197,6 +197,6 @@ tvmc run \
 #      # INFO:__main__:b'[100%] [QEMU] CPU: qemu32,+nx,+pae\n'
 #      # remote: microTVM Zephyr runtime - running
 #      # INFO:__main__:b'[100%] Built target run\n'
-#      # [[3.         1.         2.         0.        ]
-#      # [113 -121 -120 -128]]
+#      # [[   3    2    1    0]
+#      #  [ 113 -120 -121 -128]]
 #

--- a/gallery/how_to/work_with_microtvm/micro_tvmc.sh
+++ b/gallery/how_to/work_with_microtvm/micro_tvmc.sh
@@ -87,7 +87,7 @@ tvmc micro --help
 # For this tutorial we will be using the model in tflite format.
 #
 # bash
-wget https://github.com/tensorflow/tflite-micro/raw/1b68490dcfd087c308a1f8d14012ab1cb39c9ac0/tensorflow/lite/micro/examples/magic_wand/magic_wand.tflite
+wget https://github.com/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite
 # bash
 
 ############################################################

--- a/gallery/how_to/work_with_microtvm/micro_tvmc.sh
+++ b/gallery/how_to/work_with_microtvm/micro_tvmc.sh
@@ -87,7 +87,7 @@ tvmc micro --help
 # For this tutorial we will be using the model in tflite format.
 #
 # bash
-wget https://github.com/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/examples/magic_wand/magic_wand.tflite
+wget https://github.com/tensorflow/tflite-micro/raw/1b68490dcfd087c308a1f8d14012ab1cb39c9ac0/tensorflow/lite/micro/examples/magic_wand/magic_wand.tflite
 # bash
 
 ############################################################

--- a/tests/micro/arduino/test_utils.py
+++ b/tests/micro/arduino/test_utils.py
@@ -67,7 +67,7 @@ def make_kws_project(board, microtvm_debug, workspace_dir, serial_number: str):
     build_config = {"debug": microtvm_debug}
 
     mod, params = fetch_model_from_url(
-        url="https://github.com/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite",
+        url="https://github.com/tensorflow/tflite-micro/raw/a56087ffa2703b4d5632f024a8a4c899815c31bb/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite",
         model_format="tflite",
         sha256="09e5e2a9dfb2d8ed78802bf18ce297bff54281a66ca18e0c23d69ca14f822a83",
     )

--- a/tests/micro/common/test_autotune.py
+++ b/tests/micro/common/test_autotune.py
@@ -36,7 +36,7 @@ TUNING_RUNS_PER_OPERATOR = 2
 )
 def test_kws_autotune_workflow(platform, board, tmp_path):
     mod, params = fetch_model_from_url(
-        url="https://github.com/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite",
+        url="https://github.com/tensorflow/tflite-micro/raw/a56087ffa2703b4d5632f024a8a4c899815c31bb/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite",
         model_format="tflite",
         sha256="09e5e2a9dfb2d8ed78802bf18ce297bff54281a66ca18e0c23d69ca14f822a83",
     )

--- a/tests/micro/common/test_tvmc.py
+++ b/tests/micro/common/test_tvmc.py
@@ -31,7 +31,7 @@ from tvm.contrib.download import download_testdata
 
 TVMC_COMMAND = [sys.executable, "-m", "tvm.driver.tvmc"]
 
-MODEL_URL = "https://github.com/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite"
+MODEL_URL = "https://github.com/tensorflow/tflite-micro/raw/a56087ffa2703b4d5632f024a8a4c899815c31bb/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite"
 MODEL_FILE = "micro_speech.tflite"
 
 executor = tvm.testing.parameter("aot", "graph")

--- a/tests/scripts/request_hook/request_hook.py
+++ b/tests/scripts/request_hook/request_hook.py
@@ -142,7 +142,7 @@ URL_MAP = {
     "https://github.com/shicai/MobileNet-Caffe/blob/master/mobilenet_v2.caffemodel?raw=true": f"{BASE}/shicai/MobileNet-Caffe/blob/master/mobilenet_v2.caffemodel"
     + quote("?raw=true"),
     "https://github.com/shicai/MobileNet-Caffe/raw/master/mobilenet_v2_deploy.prototxt": f"{BASE}/shicai/MobileNet-Caffe/raw/master/mobilenet_v2_deploy.prototxt",
-    "https://github.com/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite": f"{BASE}/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite",
+    "https://github.com/tensorflow/tflite-micro/raw/a56087ffa2703b4d5632f024a8a4c899815c31bb/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite": f"{BASE}/tensorflow/tflite-micro/raw/a56087ffa2703b4d5632f024a8a4c899815c31bb/tensorflow/lite/micro/examples/micro_speech/micro_speech.tflite",
     "https://github.com/mlcommons/tiny/raw/v0.7/benchmark/training/visual_wake_words/trained_models/vww_96_int8.tflite": f"{BASE}/mlcommons/tiny/raw/v0.7/benchmark/training/visual_wake_words/trained_models/vww_96_int8.tflite",
     "https://github.com/uwsampl/web-data/raw/main/vta/models/synset.txt": f"{BASE}/2022-10-05/synset.txt",
     "https://homes.cs.washington.edu/~cyulin/media/gnn_model/gcn_cora.torch": f"{BASE}/gcn_cora.torch",


### PR DESCRIPTION
Model magic_wand was replaced by model micro_speech since model magic_wand was removed in the [commit](https://github.com/tensorflow/tflite-micro/commit/bef8fe8bc6183cc4e1ce852579abcb7a171f8a5c). Also added commit's sha to the link to avoid this issue in the future.

cc @mehrdadh