### PR TITLE
[Unity] Minor updates to DataFlowBlockRewrite

### DIFF
--- a/include/tvm/relax/binding_rewrite.h
+++ b/include/tvm/relax/binding_rewrite.h
@@ -60,7 +60,7 @@ class DataflowBlockRewriteNode : public Object {
   void RemoveAllUnused();
 
   /*! \brief The rewritten dataflow block. */
-  DataflowBlock MutatedDataflowBlock() { return dfb_.value(); }
+  DataflowBlock MutatedDataflowBlock() { return dfb_; }
   /*! \brief The rewritten function. */
   Function MutatedFunc() { return root_fn_.value(); }
   /*! \brief The rewritten IRModule. */
@@ -78,7 +78,7 @@ class DataflowBlockRewriteNode : public Object {
  protected:
   friend class DataflowBlockRewrite;
 
-  Optional<DataflowBlock> dfb_;          //!< The rewritten dataflow block.
+  DataflowBlock dfb_;                    //!< The rewritten dataflow block.
   Optional<Function> root_fn_;           //!< The rewritten function.
   const FunctionNode* original_fn_ptr_;  //!< Pointer to the original function.
   Map<Var, Array<Var>> to_users_;        //!< Map from variable to its users.

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -92,3 +92,5 @@ from . import frontend
 
 # VM
 from .vm_build import build, Executable
+
+from .binding_rewrite import DataflowBlockRewrite


### PR DESCRIPTION
* `relax/binding_rewrite.py` is not imported by default, so we get errors like `AttributeError: <class 'tvm.runtime.object.Object'> has no attribute add` if we try to pass the C++ object to python

* `DataflowBlock` member variable shouldn't be optional, but it is declared with `Optional<DataflowBlock> dfb_` and accessed via `dfb_.value()` all over the places.

* `root_fn_` **should** be optional (e.g. when `DataFlowBlockRewrite` is used inside another `ExprMutator`) , but it's always updated via `root_fn_.value()` without checking   

* Other minor style updates that hopefully improve readability.

@ganler @tqchen 