### PR TITLE
[Typo] Fix name of iter var type 4

### DIFF
--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -417,7 +417,7 @@ class IterVar(Object, ExprOp, Scriptable):
     ThreadIndex = 1
     CommReduce = 2
     Ordered = 3
-    DimInfo = 4
+    Opaque = 4
     Unrolled = 5
     Vectorized = 6
     Parallelized = 7

--- a/tests/python/unittest/test_tvmscript_ir_builder_tir.py
+++ b/tests/python/unittest/test_tvmscript_ir_builder_tir.py
@@ -193,7 +193,7 @@ def test_ir_builder_tir_axis():
             tir.IterVar((0, 8), tir.Var("", "int32"), iter_type=tir.IterVar.DataPar),
             tir.IterVar((0, 16), tir.Var("", "int32"), iter_type=tir.IterVar.CommReduce),
             tir.IterVar((0, 32), tir.Var("", "int32"), iter_type=tir.IterVar.Ordered),
-            tir.IterVar((0, 64), tir.Var("", "int32"), iter_type=tir.IterVar.DimInfo),
+            tir.IterVar((0, 64), tir.Var("", "int32"), iter_type=tir.IterVar.Opaque),
         ],
         reads=[],
         writes=[],


### PR DESCRIPTION
IterVarType enum 4 should be opaque.