### PR TITLE
[Hexagon] Fix deprecated call for data layout size in bits

### DIFF
--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -85,7 +85,9 @@ class CodeGenHexagon final : public CodeGenCPU {
   llvm::Module* GetModulePtr() const { return module_.get(); }
 
   uint64_t GetTypeSizeInBits(llvm::Type* type) const {
-#if TVM_LLVM_VERSION >= 100
+#if TVM_LLVM_VERSION >= 160
+    return data_layout_->getTypeSizeInBits(type).getFixedValue();
+#elif TVM_LLVM_VERSION >= 100
     return data_layout_->getTypeSizeInBits(type).getFixedSize();
 #else
     return data_layout_->getTypeSizeInBits(type);


### PR DESCRIPTION
Ported from Unity PR - https://github.com/apache/tvm/pull/14378/

Updating the codegen for Hexagon call from llvm::DataLayout::getTypeSizeInBits.getFixedSize() to llvm::DataLayout::getTypeSizeInBits.getFixedValue().  This fails in the unity branch because the deprecated warning is an error.

cc: @masahi 