### PR TITLE
[Unity][Graph matching] Automatically add `used-by` constraints for `is_op` pattern

### DIFF
--- a/include/tvm/relax/dataflow_matcher.h
+++ b/include/tvm/relax/dataflow_matcher.h
@@ -65,15 +65,6 @@ TVM_DLL tvm::runtime::Map<DFPattern, Var> MatchGraph(const PatternContext& ctx,
                                                      Optional<Var> start_hint = NullOpt,
                                                      bool must_include_hint = false);
 
-/**
- * \brief Match a graph-wise pattern with the current context (PatternContext::Current()).
- */
-inline tvm::runtime::Map<DFPattern, Var> MatchGraphDefault(const DataflowBlock& dfb,
-                                                           Optional<Var> start_hint = NullOpt,
-                                                           bool must_include_hint = false) {
-  return MatchGraph(PatternContext::Current(), dfb, start_hint, must_include_hint);
-}
-
 }  // namespace relax
 }  // namespace tvm
 

--- a/include/tvm/relax/dataflow_pattern.h
+++ b/include/tvm/relax/dataflow_pattern.h
@@ -245,15 +245,15 @@ class PatternContext : public ObjectRef {
     }
   }
 
-  /*! \brief Get the pass context object on the top of the stack */
+  /*! \brief Get the constraint context object on the top of the stack */
   TVM_DLL static Optional<PatternContext> Current();
 
   class Internal;
 
  private:
-  /*! \brief The RAII-like entry of a pass context scope */
+  /*! \brief The RAII-like entry of a constraint context scope */
   TVM_DLL void EnterWithScope();
-  /*! \brief The RAII-like exit of a pass context scope */
+  /*! \brief The RAII-like exit of a constraint context scope */
   TVM_DLL void ExitWithScope();
   friend class Internal;
   friend class With<PatternContext>;

--- a/include/tvm/relax/dataflow_pattern.h
+++ b/include/tvm/relax/dataflow_pattern.h
@@ -246,7 +246,7 @@ class PatternContext : public ObjectRef {
   }
 
   /*! \brief Get the pass context object on the top of the stack */
-  TVM_DLL static PatternContext Current();
+  TVM_DLL static Optional<PatternContext> Current();
 
   class Internal;
 

--- a/src/relax/ir/dataflow_pattern.cc
+++ b/src/relax/ir/dataflow_pattern.cc
@@ -394,8 +394,8 @@ std::stack<PatternContext>& pattern_ctx_stack() {
   return graph_pattern_managers;
 }
 
-PatternContext PatternContext::Current() {
-  ICHECK(!pattern_ctx_stack().empty()) << "No active PatternContext found.";
+Optional<PatternContext> PatternContext::Current() {
+  if (pattern_ctx_stack().empty()) return NullOpt;
   return pattern_ctx_stack().top();
 }
 
@@ -419,7 +419,9 @@ void PatternContext::ExitWithScope() {
 }
 
 static void sync_graph_constraints(const DFPattern& lhs, const DFPattern& rhs, PairCons pcon) {
-  PatternContext::Current().add_constraint(lhs, rhs, pcon);
+  if (auto ctx = PatternContext::Current()) {
+    ctx.value().add_constraint(lhs, rhs, pcon);
+  }
 }
 
 TVM_REGISTER_NODE_TYPE(PatternSeqNode);

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -1034,15 +1034,6 @@ def test_attention_qkv():
         matmul2 = is_op("relax.matmul")(inp_pat, K_weight_pat)
         matmul3 = is_op("relax.matmul")(inp_pat, V_weight_pat)
 
-        # TODO(masahi): Automate addition of used_by constraints during is_op
-        inp_pat.used_by(matmul1, 0)
-        inp_pat.used_by(matmul2, 0)
-        inp_pat.used_by(matmul3, 0)
-
-        Q_weight_pat.only_used_by(matmul1, 1)
-        K_weight_pat.only_used_by(matmul2, 1)
-        V_weight_pat.only_used_by(matmul3, 1)
-
         dfb = QKV_proj["main"].body.blocks[0]
         out = ctx.match_dfb(dfb)
 


### PR DESCRIPTION
Compared to the typical, structural matching (e.g. matching `is_op` based pattern against `CallNode`), graph pattern matching requires additionally specifying `used_by` constraints. This leads to an obvious redundancy in the usage:

```
matmul1 = is_op("relax.matmul")(inp_pat, Q_weight_pat)
matmul2 = is_op("relax.matmul")(inp_pat, K_weight_pat)
matmul3 = is_op("relax.matmul")(inp_pat, V_weight_pat)

inp_pat.used_by(matmul1, 0)
inp_pat.used_by(matmul2, 0)
inp_pat.used_by(matmul3, 0)

Q_weight_pat.only_used_by(matmul1, 1)
K_weight_pat.only_used_by(matmul2, 1)
V_weight_pat.only_used_by(matmul3, 1)
``` 

This PR hacks `is_op` constructor by automatically adding such `used_by` constraints between caller and callee patterns. See the simplified test case for QOL improvement.

@ganler @sunggg 