### PR TITLE
[Unity][Graph matching] Clean up undo stack for parent and child nodes properly

### DIFF
--- a/include/tvm/relax/dataflow_matcher.h
+++ b/include/tvm/relax/dataflow_matcher.h
@@ -58,12 +58,12 @@ Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(
  * \param dfb The function to match.
  * \param start_hint The starting point expression to match to distinguish multiple matches.
  * \param must_include_hint If start_hint is given, the return pattern must include start_hint.
- * \return tvm::runtime::Map<DFPattern, Var>
+ * \return Matched patterns and corresponding bound variables
  */
-TVM_DLL tvm::runtime::Map<DFPattern, Var> MatchGraph(const PatternContext& ctx,
-                                                     const DataflowBlock& dfb,
-                                                     Optional<Var> start_hint = NullOpt,
-                                                     bool must_include_hint = false);
+TVM_DLL Optional<Map<DFPattern, Var>> MatchGraph(const PatternContext& ctx,
+                                                 const DataflowBlock& dfb,
+                                                 Optional<Var> start_hint = NullOpt,
+                                                 bool must_include_hint = false);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/analysis/udchain.cc
+++ b/src/relax/analysis/udchain.cc
@@ -75,7 +75,7 @@ std::pair<runtime::Map<Var, runtime::Array<Var>>, runtime::Array<Var>> FunctionU
     uses.reserve(users.size());
     for (const auto& v : users) {
       if (v == nullptr &&
-          std::find(fn_outs.begin(), fn_outs.end(), GetRef<Var>(var)) == fn_outs.end() ) {
+          std::find(fn_outs.begin(), fn_outs.end(), GetRef<Var>(var)) == fn_outs.end()) {
         fn_outs.push_back(GetRef<Var>(var));
       } else {
         uses.push_back(GetRef<Var>(v));

--- a/src/relax/analysis/udchain.cc
+++ b/src/relax/analysis/udchain.cc
@@ -65,36 +65,36 @@ class UDChain : public relax::ExprVisitor {
 std::pair<runtime::Map<Var, runtime::Array<Var>>, runtime::Array<Var>> FunctionUseDef(
     const Function& fn) {
   UDChain udchain;
-  udchain.VisitExpr_(fn.get());
+  udchain.VisitExpr(fn);
 
   Map<Var, Array<Var>> user_map;
   Array<Var> fn_outs;
 
-  for (const auto& kv : udchain.to_users) {
+  for (const auto& [var, users] : udchain.to_users) {
     Array<Var> uses{};
-    uses.reserve(kv.second.size());
-    for (const auto& v : kv.second) {
-      if (nullptr == v &&
-          fn_outs.end() == std::find(fn_outs.begin(), fn_outs.end(), GetRef<Var>(kv.first))) {
-        fn_outs.push_back(GetRef<Var>(kv.first));
+    uses.reserve(users.size());
+    for (const auto& v : users) {
+      if (v == nullptr &&
+          std::find(fn_outs.begin(), fn_outs.end(), GetRef<Var>(var)) == fn_outs.end() ) {
+        fn_outs.push_back(GetRef<Var>(var));
       } else {
         uses.push_back(GetRef<Var>(v));
       }
     }
-    user_map.Set(GetRef<Var>(kv.first), std::move(uses));
+    user_map.Set(GetRef<Var>(var), std::move(uses));
   }
   return std::make_pair(std::move(user_map), std::move(fn_outs));
 }
 
 runtime::Map<Var, Array<Var>> DataflowBlockUseDef(const DataflowBlock& dfb) {
   UDChain udchain;
-  udchain.VisitBindingBlock_(dfb.get());
+  udchain.VisitBindingBlock(dfb);
   runtime::Map<Var, Array<Var>> ret;
-  for (const auto& kv : udchain.to_users) {
+  for (const auto& [var, users] : udchain.to_users) {
     Array<Var> uses{};
-    uses.reserve(kv.second.size());
-    for (const auto& v : kv.second) uses.push_back(GetRef<Var>(v));
-    ret.Set(GetRef<Var>(kv.first), std::move(uses));
+    uses.reserve(users.size());
+    for (const auto& v : users) uses.push_back(GetRef<Var>(v));
+    ret.Set(GetRef<Var>(var), std::move(uses));
   }
   return ret;
 }

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -573,6 +573,7 @@ static std::optional<UndoItems> try_match(
   const auto try_match_update_undo = [&](PNode* p, RNode* r) {
     if (auto undo_more = try_match(p, r, m, def2use, use2def)) {
       undo.insert(undo.end(), undo_more->begin(), undo_more->end());
+      return true;
     }
     return false;
   };

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -34,7 +34,6 @@
 #include <cstddef>
 #include <limits>
 #include <optional>
-#include <stack>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -558,8 +558,6 @@ static std::optional<UndoStack> try_match(
       ICHECK_EQ(p->matched, r->ptr);
       return;
     }
-    // TODO(ganler, masahi): Why this condition can fail?
-    // ICHECK(r->matched == nullptr);
     p->matched = r->ptr;
     r->matched = p->ptr;
     undo.emplace(p, r);
@@ -567,7 +565,7 @@ static std::optional<UndoStack> try_match(
 
   const auto quit = [&undo] {
     while (!undo.empty()) {
-      auto& [p_node, r_node] = undo.top();
+      const auto& [p_node, r_node] = undo.top();
       p_node->matched = nullptr;
       r_node->matched = nullptr;
       undo.pop();


### PR DESCRIPTION
This is a fix for the issue described in https://github.com/apache/tvm/pull/14417#issuecomment-1490049917

In graph pattern matching, backtracking behavior is implemented by undoing matchings in `undo_stack`. When an intermediate fails to match, `undo_stack`s for parent and child nodes that have matched tentatively also need to be cleaned up as well. This corner-case handling is missing in the current implementation. 

The fix is to return `undo_stack` from recursive `try_match` calls when matching succeeds, and merge parent / child `undo_stack` with the `undo_stack` for the "current" node

@ganler @sunggg @cyx-6 