### PR TITLE
[Unity][Op][Docs] Update comment for `call_tir_dyn`

### DIFF
--- a/python/tvm/relax/op/vm/vm.py
+++ b/python/tvm/relax/op/vm/vm.py
@@ -88,12 +88,13 @@ def alloc_tensor(
 
 @args_converter.auto
 def call_tir_dyn(func: Expr, args: Tuple) -> Call:
-    """Construct a Call to kill a storage.
+    """Construct a Call to call_tir_dyn (invoke the given TIR PrimFunc)
+    consisting of the input tensors and the shape of the result.
 
     Parameters
     ----------
     func : Expr
-        The storage to be killed.
+        An expression evaluating to a TIR PrimFunc.
 
     args : Tuple
         The input args, includes a list of tensors, and a ShapeExpr.


### PR DESCRIPTION
The comment for the `vm.call_tir_dyn` operator was out of date. This PR corrects it with a more applicable distinction.

Note: I was still unable to figure out what it actually does. Only a TVMScript parsing test actually uses this op. https://github.com/tlc-pack/relax/pull/57 was the PR that introduced it and it also does not include a very specific description. If anybody could tell me how exactly the op works, I will update the description to be more precise.