### PR TITLE
[Unity] Pattern-based rewriting for dataflow block

### DIFF
--- a/python/tvm/relax/dpl/__init__.py
+++ b/python/tvm/relax/dpl/__init__.py
@@ -19,3 +19,4 @@
 
 from .pattern import *
 from .context import *
+from .rewrite import rewrite_call, rewrite_bindings

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -1125,7 +1125,7 @@ def make_fused_bias_activation_pattern(op_name, with_bias=False, activation=None
     return out
 
 
-def rewrite(
+def rewrite_call(
     pattern: DFPattern, rewriter: Callable[[Expr, Dict[DFPattern, Expr]], Expr], func: Function
 ) -> Function:
     """
@@ -1158,4 +1158,34 @@ def rewrite(
     rewritten_func: Function
         The rewritten or the input function, depending on the pattern matching result.
     """
-    return ffi.rewrite(pattern, rewriter, func)
+    return ffi.rewrite_call(pattern, rewriter, func)
+
+
+def rewrite_bindings(
+    ctx, rewriter: Callable[[Expr, Dict[DFPattern, Expr]], Expr], func: Function
+) -> Function:
+    """
+    Rewrite a function with the given pattern and the rewriter function.
+    Parameters
+    ----------
+    pattern: DFPattern
+        The pattern to match.
+    rewriter: Callable[[Expr, Dict[DFPattern, Expr]], Expr]
+        The function to be called on a successful matching for rewriting. Given the matched
+        call node and the map of patterns and matched expressions, it should return a new call node
+        to replace the original one or the original matched call node as is.
+        For example, to replace x + x with 2 * x, we can write the rewriter as follows:
+        ```
+        x = wildcard()
+        pattern = is_op("relax.add")(x, x)
+        def rewriter(orig, matchings):
+            return R.multiply(matchings[x], R.const(2, "float32"))
+        ```
+    func: Function
+        The function to rewrite.
+    Returns
+    -------
+    rewritten_func: Function
+        The rewritten or the input function, depending on the pattern matching result.
+    """
+    return ffi.rewrite_bindings(ctx, rewriter, func)

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -20,7 +20,7 @@
 # pylint: disable=pointless-statement
 
 import typing
-from typing import Dict, List, Optional, Tuple, Union, Callable
+from typing import Dict, List, Optional, Tuple, Union
 
 import tvm
 import tvm._ffi as tvm_ffi
@@ -31,7 +31,7 @@ from tvm.relay.op import get
 from ...ir import make_node
 from ...ir.base import Node
 from ...runtime import Object
-from ..expr import Expr, Var, Function
+from ..expr import Expr, Var
 from . import _ffi as ffi
 
 
@@ -1123,69 +1123,3 @@ def make_fused_bias_activation_pattern(op_name, with_bias=False, activation=None
         return is_op(activation)(out)
 
     return out
-
-
-def rewrite_call(
-    pattern: DFPattern, rewriter: Callable[[Expr, Dict[DFPattern, Expr]], Expr], func: Function
-) -> Function:
-    """
-    Rewrite a function with the given pattern and the rewriter function.
-
-    Parameters
-    ----------
-    pattern: DFPattern
-        The pattern to match.
-
-    rewriter: Callable[[Expr, Dict[DFPattern, Expr]], Expr]
-        The function to be called on a successful matching for rewriting. Given the matched
-        call node and the map of patterns and matched expressions, it should return a new call node
-        to replace the original one or the original matched call node as is.
-
-        For example, to replace x + x with 2 * x, we can write the rewriter as follows:
-        ```
-        x = wildcard()
-        pattern = is_op("relax.add")(x, x)
-
-        def rewriter(orig, matchings):
-            return R.multiply(matchings[x], R.const(2, "float32"))
-        ```
-
-    func: Function
-        The function to rewrite.
-
-    Returns
-    -------
-    rewritten_func: Function
-        The rewritten or the input function, depending on the pattern matching result.
-    """
-    return ffi.rewrite_call(pattern, rewriter, func)
-
-
-def rewrite_bindings(
-    ctx, rewriter: Callable[[Expr, Dict[DFPattern, Expr]], Expr], func: Function
-) -> Function:
-    """
-    Rewrite a function with the given pattern and the rewriter function.
-    Parameters
-    ----------
-    pattern: DFPattern
-        The pattern to match.
-    rewriter: Callable[[Expr, Dict[DFPattern, Expr]], Expr]
-        The function to be called on a successful matching for rewriting. Given the matched
-        call node and the map of patterns and matched expressions, it should return a new call node
-        to replace the original one or the original matched call node as is.
-        For example, to replace x + x with 2 * x, we can write the rewriter as follows:
-        ```
-        x = wildcard()
-        pattern = is_op("relax.add")(x, x)
-        def rewriter(orig, matchings):
-            return R.multiply(matchings[x], R.const(2, "float32"))
-        ```
-    func: Function
-        The function to rewrite.
-    Returns
-    -------
-    rewritten_func: Function
-        The rewritten or the input function, depending on the pattern matching result.
-    """
-    return ffi.rewrite_bindings(ctx, rewriter, func)

--- a/python/tvm/relax/dpl/rewrite.py
+++ b/python/tvm/relax/dpl/rewrite.py
@@ -1,0 +1,115 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""APIs for pattern-based rewriting."""
+from typing import Dict, Callable
+from .pattern import DFPattern
+from .context import PatternContext
+
+from ..expr import Expr, Function, Var
+from . import _ffi as ffi
+
+
+def rewrite_call(
+    pattern: DFPattern, rewriter: Callable[[Expr, Dict[DFPattern, Expr]], Expr], func: Function
+) -> Function:
+    """
+    Rewrite a function with the given pattern and the rewriter function.
+
+    Parameters
+    ----------
+    pattern: DFPattern
+        The pattern to match.
+
+    rewriter: Callable[[Expr, Dict[DFPattern, Expr]], Expr]
+        The function to be called on a successful matching for rewriting. Given the matched
+        call node and the map of patterns and matched expressions, it should return a new call node
+        to replace the original one or the original matched call node as is.
+
+        For example, to replace x + x with 2 * x, we can write the rewriter as follows:
+        ```
+        x = wildcard()
+        pattern = is_op("relax.add")(x, x)
+
+        def rewriter(orig, matchings):
+            return R.multiply(matchings[x], R.const(2, "float32"))
+        ```
+
+    func: Function
+        The function to rewrite.
+
+    Returns
+    -------
+    rewritten_func: Function
+        The rewritten or the input function, depending on the pattern matching result.
+    """
+    return ffi.rewrite_call(pattern, rewriter, func)
+
+
+def rewrite_bindings(
+    ctx: PatternContext, rewriter: Callable[[Dict[DFPattern, Var]], Dict[Var, Expr]], func: Function
+) -> Function:
+    """
+    Rewrite a function with the given pattern and the rewriter function.
+
+    Parameters
+    ----------
+    ctx: PatternContext
+        The pattern constraint context under which rewriting takes place.
+
+    rewriter: Callable[[Dict[DFPattern, Var]], Dict[Var, Expr]]
+        The function to be called on a successful matching for rewriting. Given the map of patterns
+        and corresponding variables (bound variables or parameters), it should return a map that
+        specifies new values for matched bound variables.
+
+        For example, to rewrite three matmuls for QKV projection in transformer models into one
+        matmul followed by slicing, one can use the follwoing rewriter:
+        ```
+        inp_pat = wildcard()
+        Q_weight_pat, K_weight_pat, V_weight_pat = wildcard(), wildcard(), wildcard()
+
+        matmul1 = is_op("relax.matmul")(inp_pat, Q_weight_pat)
+        matmul2 = is_op("relax.matmul")(inp_pat, K_weight_pat)
+        matmul3 = is_op("relax.matmul")(inp_pat, V_weight_pat)
+
+        def rewriter(matchings):
+            inp = matchings[inp_pat]
+            Q_weight = matchings[Q_weight_pat]
+            K_weight = matchings[K_weight_pat]
+            V_weight = matchings[V_weight_pat]
+            width = Q_weight.struct_info.shape[1]
+
+            concat = R.concat([Q_weight, K_weight, V_weight], axis=1)
+            matmul = R.matmul(inp, concat)
+            Q = R.strided_slice(matmul, axes=[2], begin=[0], end=[width])
+            K = R.strided_slice(matmul, axes=[2], begin=[width], end=[width * 2])
+            V = R.strided_slice(matmul, axes=[2], begin=[width * 2], end=[width * 3])
+
+            # matchings[matmul1] gives the bound variable in the binding whose RHS matches with
+            # the matmul1 pattern. For example, lv0 in lv0 = R.matmul(x1, w0).
+            # We want to replace the RHS of this binding with Q.
+            return {matchings[matmul1]: Q, matchings[matmul2]: K, matchings[matmul3]: V}
+        ```
+
+    func: Function
+        The function to rewrite.
+
+    Returns
+    -------
+    rewritten_func: Function
+        The rewritten or the input function, depending on the pattern matching result.
+    """
+    return ffi.rewrite_bindings(ctx, rewriter, func)

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -850,10 +850,13 @@ class PatternRewriter : ExprMutator {
     }
 
     size_t num_unemitted = unemitted_vars.size();
-    for (const auto& binding : pending_bindings) {
+    for (size_t i = 0; i < pending_bindings.size(); ++i) {
+      const auto& binding = pending_bindings[i];
       if (auto var_bind = binding.as<VarBindingNode>();
           var_bind && unemitted_vars.count(var_bind->var.get())) {
-        EmitUsedVars(var_bind->value, pending_bindings, emitted_vars);
+        // var_bind->value may also depend on other unemitted vars in this range
+        Array<Binding> prev_bindings(pending_bindings.begin(), pending_bindings.begin() + i);
+        EmitUsedVars(var_bind->value, prev_bindings, emitted_vars);
         this->VisitBinding(binding);
         emitted_vars->insert(var_bind->var.get());
         if (--num_unemitted == 0) {

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -18,7 +18,7 @@
 import pytest
 import tvm.testing
 
-from tvm import relay
+from tvm import relay, relax
 from tvm.relax.dpl import *
 from tvm.relax.analysis import get_var2val
 from tvm import relax as rx, tir
@@ -1218,6 +1218,13 @@ def test_combine_matmul_emit_order():
         )
         rewritten = rewrite_bindings(ctx, rewriter, main)
         tvm.ir.assert_structural_equal(rewritten, expected)
+
+        # make sure it builds
+        mod = tvm.IRModule()
+        mod["main"] = rewritten
+        mod = relax.transform.LegalizeOps()(mod)
+
+        relax.build(mod, target="llvm")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Compared to the existing call node based matching & rewriting that requires a common post-dominator in a pattern (introduced in https://github.com/apache/tvm/pull/14312), it lets us match a tree structure and replace leaf nodes or branches with new expression.

This can be immediately used for combining any number of multiple matmuls sharing the same LHS into one matmul. In Relay, we have a dedicated pass for that purpose (`CombineParallelDense`), but we can achieve the same thing via graph (tree) matching and rewrite. 

For example, in SD UNet we have many three parallel matmul for QKV projections. In addition, there are also highly non-obvious parallel matmuls consisting of 32 or 22 of them. Those patterns can all be matched and rewritten via the following generic pattern and rewriter. 
https://github.com/masahi/web-stable-diffusion/blob/unet-opt/test.py#L37-L68

I got all matmul combining for SD UNet working. It reduces the number of `R.matmul` from 200 to 116.
Original: https://gist.github.com/masahi/0dab4b8f53115da9c33f4352c9175a87
Rewritten: https://gist.github.com/masahi/57ab925a43d2343cbfdb79a31c5b9946 (look for `R.concat` followed by `R.matmul` to see where rewriting happened)

This is exactly the same reduction possible using Relay passes on an equivalent Relay mod.

@ganler @sunggg @psrivas2 @cyx-6 @vinx13  