### PR TITLE
[Bugfix] Fix unclear pattern replacer behavior in PrintMMAAssembly

### DIFF
--- a/src/target/source/ptx.cc
+++ b/src/target/source/ptx.cc
@@ -481,7 +481,7 @@ inline std::tuple<std::string, std::string, std::string> GetMMAOperands(int m, i
   templates << "}";
   // templates of metadata and sparse selector for sparse mma.
   if (sparse) {
-    templates << ", %" << (arg_counter++) << ", F";
+    templates << ", %" << (arg_counter++) << ", {F}";
   }
 
   // generate inputs
@@ -489,20 +489,20 @@ inline std::tuple<std::string, std::string, std::string> GetMMAOperands(int m, i
     if (i != 0) {
       inputs << ", ";
     }
-    inputs << "\"" << frag_attr_a.reg_type << "\"((" << frag_attr_a.ptr_type << "(A))[" << i
+    inputs << "\"" << frag_attr_a.reg_type << "\"((" << frag_attr_a.ptr_type << "({A}))[" << i
            << "])";
   }
   for (int i = 0; i < num_operands_b; ++i) {
-    inputs << ", \"" << frag_attr_b.reg_type << "\"((" << frag_attr_b.ptr_type << "(B))[" << i
+    inputs << ", \"" << frag_attr_b.reg_type << "\"((" << frag_attr_b.ptr_type << "({B}))[" << i
            << "])";
   }
   for (int i = 0; i < num_operands_c; ++i) {
-    inputs << ", \"" << frag_attr_c.reg_type << "\"((" << frag_attr_c.ptr_type << "(C))[" << i
+    inputs << ", \"" << frag_attr_c.reg_type << "\"((" << frag_attr_c.ptr_type << "({C}))[" << i
            << "])";
   }
   // input of metadata for sparse mma.
   if (sparse) {
-    inputs << ", \"r\"(((unsigned *)(E))[0])";
+    inputs << ", \"r\"(((unsigned *)({E}))[0])";
   }
 
   // generate outputs
@@ -510,7 +510,7 @@ inline std::tuple<std::string, std::string, std::string> GetMMAOperands(int m, i
     if (i != 0) {
       outputs << ",";
     }
-    outputs << " \"=" << frag_attr_c.reg_type << "\"((" << frag_attr_c.ptr_type << "(D))[" << i
+    outputs << " \"=" << frag_attr_c.reg_type << "\"((" << frag_attr_c.ptr_type << "({D}))[" << i
             << "])";
   }
   return std::make_tuple(templates.str(), inputs.str(), outputs.str());
@@ -561,12 +561,12 @@ std::string PrintMMAAssembly(const std::string& shape, const std::string& A_layo
   replacer.register_rule("{inputs}", inputs_str);
   asm_code = replacer.rewrite(asm_code);
   replacer.empty_rules();
-  replacer.register_rule("A", a_ptr + " + " + a_elem_offset);
-  replacer.register_rule("B", b_ptr + " + " + b_elem_offset);
-  replacer.register_rule("C", c_ptr + " + " + c_elem_offset);
-  replacer.register_rule("D", c_ptr + " + " + c_elem_offset);
-  replacer.register_rule("E", metadata + " + " + metadata_offset);
-  replacer.register_rule("F", sparsity_selector);
+  replacer.register_rule("{A}", a_ptr + " + " + a_elem_offset);
+  replacer.register_rule("{B}", b_ptr + " + " + b_elem_offset);
+  replacer.register_rule("{C}", c_ptr + " + " + c_elem_offset);
+  replacer.register_rule("{D}", c_ptr + " + " + c_elem_offset);
+  replacer.register_rule("{E}", metadata + " + " + metadata_offset);
+  replacer.register_rule("{F}", sparsity_selector);
   asm_code = replacer.rewrite(asm_code);
   return asm_code;
 }


### PR DESCRIPTION
In current cuda codegen, the `PrintMMAAssembly`  instantiates the final asm code by replacing the A, B... in the template. However, this matching method is incorrect in some cases, as replacing a single letter can lead to confusion in the results.

https://github.com/apache/tvm/blob/49e6695586d07c33c84097d2b0f58c79c2abd51e/src/target/source/ptx.cc#L564-L571

for example, the case I had meet:

```
  {
    __asm__ __volatile__(
      "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16"
      "{%0, %1}, {%2, %3, %4, %5}, {%6, %7}, {%8, %9};\n"
      :  "=r"(((unsigned *)(C_warp + ((ii_2 * 16) + (jj_2 * 8))))[0]), "=r"(((unsigned *)(C_warp + ((ii_2 * 16) + (jj_2 * 8))))[1])
      : "r"(((unsigned *)(AC_warp + ((ii_2 * 16) + (jj_2 * 8))_shared_warp + (ii_2 * 8)))[0]), "r"(((unsigned *)(AC_warp + ((ii_2 * 16) + (jj_2 * 8))_shared_warp + (ii_2 * 8)))[1]), "r"(((unsigned *)(AC_warp + ((ii_2 * 16) + (jj_2 * 8))_shared_warp + (ii_2 * 8)))[2]), "r"(((unsigned *)(AC_warp + ((ii_2 * 16) + (jj_2 * 8))_shared_warp + (ii_2 * 8)))[3]), "r"(((unsigned *)(BC_warp + ((ii_2 * 16) + (jj_2 * 8))_shared_warp + (jj_2 * 8)))[0]), "r"(((unsigned *)(BC_warp + ((ii_2 * 16) + (jj_2 * 8))_shared_warp + (jj_2 * 8)))[1]), "r"(((unsigned *)(C_warp + ((ii_2 * 16) + (jj_2 * 8))))[0]), "r"(((unsigned *)(C_warp + ((ii_2 * 16) + (jj_2 * 8))))[1]));
  }
```

the source ptx and offset actually should be 

```
          {
            __asm__ __volatile__(
                "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16"
                "{%0, %1}, {%2, %3, %4, %5}, {%6, %7}, {%8, %9};\n"
                : "=r"(((unsigned *)(C_warp + ((ii_2 * 64) + (jj_2 * 8))))[0]), "=r"(((unsigned *)(C_warp + ((ii_2 * 64) + (jj_2 * 8))))[1])
                : "r"(((unsigned *)(ACast_shared_warp + (ii_2 * 8)))[0]), "r"(((unsigned *)(ACast_shared_warp + (ii_2 * 8)))[1]), "r"(((unsigned *)(ACast_shared_warp + (ii_2 * 8)))[2]), "r"(((unsigned *)(ACast_shared_warp + (ii_2 * 8)))[3]), "r"(((unsigned *)(BCast_shared_warp + (jj_2 * 8)))[0]), "r"(((unsigned *)(BCast_shared_warp + (jj_2 * 8)))[1]), "r"(((unsigned *)(C_warp + ((ii_2 * 64) + (jj_2 * 8))))[0]), "r"(((unsigned *)(C_warp + ((ii_2 * 64) + (jj_2 * 8))))[1]));
          }
``` 

By replacing the pattern "A" with "{A}", "B" with "{B}" .. , we can have a simple fix.