### PR TITLE
[TVMScript][Bugfix] Tuple on the RHS of AssignDoc

### DIFF
--- a/src/script/printer/doc_printer/python_doc_printer.cc
+++ b/src/script/printer/doc_printer/python_doc_printer.cc
@@ -549,7 +549,11 @@ void PythonDocPrinter::PrintTypedDoc(const AssignDoc& doc) {
   if (doc->rhs) {
     output_ << " = ";
     if (const auto* tuple_doc = doc->rhs.as<TupleDocNode>()) {
-      PrintJoinedDocs(tuple_doc->elements, ", ");
+      if (tuple_doc->elements.size() > 1) {
+        PrintJoinedDocs(tuple_doc->elements, ", ");
+      } else {
+        PrintDoc(doc->rhs.value());
+      }
     } else {
       PrintDoc(doc->rhs.value());
     }

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1325,5 +1325,27 @@ def test_context_aware_parsing():
     _check(Module)
 
 
+def test_unit_tuple_on_rhs_of_assign():
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(input: R.Tensor((5, 5))) -> R.Tuple(R.Tensor((5, 5))):
+            gv = (input,)
+            return gv
+
+    _check(Module)
+
+
+def test_empty_tuple_on_rhs_of_assign():
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(input: R.Tensor((5, 5))) -> R.Tuple():
+            gv = ()
+            return gv
+
+    _check(Module)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR fixes a bug in TVMScript printer handling tuples on the RHS of an assignment, i.e.:

```python
... = (a, b, c)
      ^^^^^^^^^
```

The existing  sugar removes the brackets surrounding `(a, b, c)`, which makes it slightly more readable as:

```python
... = a, b, c
```

However, it overlooks a possibility where the tuple could be empty or has only one element, i.e.

```python
... = (a, ) // Case 1: The tuple has only one element
... = ()    // Case 2: The tuple is empty
```

In both cases, removing brackets may lead to wrong outcome.

This patch fixes this bug.