### PR TITLE
[relay] preserve the order of input_info of pytorch

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -5016,12 +5016,15 @@ def from_pytorch(
             func_args.append(arg)
 
     # Ensures the order of data_input is the same as the order of inputs specified in input_info.
-    order_input_infos = {input_info[0]: idx for idx, input_info in enumerate(input_infos)}
+    order_input_infos = {
+        input_info[0]: len(input_infos) - idx for idx, input_info in enumerate(input_infos)
+    }
     data_inputs = sorted(
         data_inputs,
         key=lambda data_input: order_input_infos[data_input.name_hint]
         if data_input.name_hint in order_input_infos
         else -1,
+        reverse=True,
     )
 
     func_args = data_inputs + func_args

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -5015,7 +5015,7 @@ def from_pytorch(
         else:
             func_args.append(arg)
 
-    # Ensures that the order of data_input is the same as the order of inputs specified in input_info.
+    # Ensures the order of data_input is the same as the order of inputs specified in input_info.
     _data_inputs = []
     for input_info in input_infos:
         _data_input = [di for di in data_inputs if di.name_hint == input_info[0]]
@@ -5024,7 +5024,7 @@ def from_pytorch(
             raise RuntimeError(msg)
         _data_inputs.append(_data_input[0])
     data_inputs = _data_inputs
-                
+
     func_args = data_inputs + func_args
 
     mod["main"] = tvm.relay.Function(func_args, ret)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -5016,14 +5016,13 @@ def from_pytorch(
             func_args.append(arg)
 
     # Ensures the order of data_input is the same as the order of inputs specified in input_info.
-    _data_inputs = []
-    for input_info in input_infos:
-        _data_input = [di for di in data_inputs if di.name_hint == input_info[0]]
-        if len(_data_input) != 1:
-            msg = "Unexpected input name ({}) which is unreachable.".format(input_info[0])
-            raise RuntimeError(msg)
-        _data_inputs.append(_data_input[0])
-    data_inputs = _data_inputs
+    order_input_infos = {input_info[0]: idx for idx, input_info in enumerate(input_infos)}
+    data_inputs = sorted(
+        data_inputs,
+        key=lambda data_input: order_input_infos[data_input.name_hint]
+        if data_input.name_hint in order_input_infos
+        else -1,
+    )
 
     func_args = data_inputs + func_args
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -5014,6 +5014,17 @@ def from_pytorch(
             data_inputs.append(arg)
         else:
             func_args.append(arg)
+
+    # Ensures that the order of data_input is the same as the order of inputs specified in input_info.
+    _data_inputs = []
+    for input_info in input_infos:
+        _data_input = [di for di in data_inputs if di.name_hint == input_info[0]]
+        if len(_data_input) != 1:
+            msg = "Unexpected input name ({}) which is unreachable.".format(input_info[0])
+            raise RuntimeError(msg)
+        _data_inputs.append(_data_input[0])
+    data_inputs = _data_inputs
+                
     func_args = data_inputs + func_args
 
     mod["main"] = tvm.relay.Function(func_args, ret)


### PR DESCRIPTION
This is for resolving https://github.com/apache/tvm/issues/14461

The direct cause of this problem is that the order of input nodes found in `_analysis.free_vars(ret)` is not guaranteed in the order of names in `input_info`. From what I understand, `_analysis.free_vars(ret)` uses DFS to find input nodes from output nodes. Since DFS cannot guarantee the order in which nodes are found, it is intuitive to modify the order of input nodes after DFS, as shown in this PR.