### PR TITLE
[CI] Update ci_cpu image and build with llvm-15

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -19,7 +19,7 @@
 [jenkins]
 ci_arm: tlcpack/ci-arm:20230314-060145-ccc0b9162
 ci_cortexm: tlcpackstaging/ci_cortexm:20230124-233207-fd3f8035c
-ci_cpu: tlcpack/ci-cpu:20230308-070109-9d732d0fa
+ci_cpu: tlcpack/ci_cpu:20230409-060118-a84a2cbe0
 ci_gpu: tlcpack/ci-gpu:20230318-060139-2ff41c615
 ci_hexagon: tlcpack/ci_hexagon:20230127-185848-95fa22308
 ci_i386: tlcpack/ci-i386:20221013-060115-61c9742ea

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -1790,7 +1790,8 @@ class TestConv2DInt8Intrinsics:
     @tvm.testing.parametrize_targets(*unsupported_targets)
     @pytest.mark.parametrize("dtypes", [("uint8", "int8", "int32")])
     def test_uses_vectorized_instruction(self, assembly):
-        assert "pmulhw" in assembly and "paddd" in assembly
+        assert "pmulhw" in assembly or "pmaddwd" in assembly
+        assert "paddd" in assembly
 
 
 @tvm.testing.uses_gpu

--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -29,7 +29,7 @@ echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 echo set\(USE_PROFILER ON\) >> config.cmake
 echo set\(USE_DNNL ON\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
-echo set\(USE_LLVM llvm-config-11\) >> config.cmake
+echo set\(USE_LLVM llvm-config\) >> config.cmake
 echo set\(USE_NNPACK ON\) >> config.cmake
 echo set\(NNPACK_PATH /NNPACK/build/\) >> config.cmake
 echo set\(USE_ANTLR ON\) >> config.cmake


### PR DESCRIPTION
Update docker image tag as a follow up step for https://github.com/apache/tvm/pull/14303.

cc @Hzfengsy @wrongtest-intellif @elvin-n 