### PR TITLE
[LLVM] Add missing `override` to GetFormat and GetPropertyMask

### DIFF
--- a/src/relay/backend/contrib/ethosu/source_module.cc
+++ b/src/relay/backend/contrib/ethosu/source_module.cc
@@ -89,7 +89,7 @@ class EthosUModuleNode : public ModuleNode {
 
   std::string GetSource(const std::string& format) final { return c_source; }
 
-  std::string GetFormat() { return "c"; }
+  std::string GetFormat() override { return "c"; }
 
   Array<CompilationArtifact> GetArtifacts() { return compilation_artifacts_; }
 
@@ -122,7 +122,7 @@ class EthosUModuleNode : public ModuleNode {
   }
 
   /*! \brief Get the property of the runtime module .*/
-  int GetPropertyMask() const { return ModulePropertyMask::kDSOExportable; }
+  int GetPropertyMask() const override { return ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find_if(compilation_artifacts_.begin(), compilation_artifacts_.end(),

--- a/src/runtime/contrib/json/json_runtime.h
+++ b/src/runtime/contrib/json/json_runtime.h
@@ -59,7 +59,7 @@ class JSONRuntimeBase : public ModuleNode {
   const char* type_key() const override { return "json"; }  // May be overridden
 
   /*! \brief Get the property of the runtime module .*/
-  int GetPropertyMask() const {
+  int GetPropertyMask() const override {
     return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
   }
 

--- a/src/runtime/hexagon/hexagon_module.h
+++ b/src/runtime/hexagon/hexagon_module.h
@@ -63,7 +63,7 @@ class HexagonModuleNode : public runtime::ModuleNode {
   std::string GetSource(const std::string& format) override;
   const char* type_key() const final { return "hexagon"; }
   /*! \brief Get the property of the runtime module .*/
-  int GetPropertyMask() const {
+  int GetPropertyMask() const override {
     return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
   }
   void SaveToFile(const std::string& file_name, const std::string& format) override;

--- a/src/runtime/static_library.cc
+++ b/src/runtime/static_library.cc
@@ -64,7 +64,7 @@ class StaticLibraryNode final : public runtime::ModuleNode {
 
   // TODO(tvm-team): Make this module serializable
   /*! \brief Get the property of the runtime module .*/
-  int GetPropertyMask() const { return ModulePropertyMask::kDSOExportable; }
+  int GetPropertyMask() const override { return ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -95,7 +95,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
 
   /*! \brief Get the property of the runtime module .*/
   // TODO(tvm-team): Make it serializable
-  int GetPropertyMask() const {
+  int GetPropertyMask() const override {
     return runtime::ModulePropertyMask::kRunnable | runtime::ModulePropertyMask::kDSOExportable;
   }
 

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -76,7 +76,7 @@ class SourceModuleNode : public runtime::ModuleNode {
 
   std::string GetSource(const std::string& format) final { return code_; }
 
-  std::string GetFormat() { return fmt_; }
+  std::string GetFormat() override { return fmt_; }
 
  protected:
   std::string code_;
@@ -117,7 +117,7 @@ class CSourceModuleNode : public runtime::ModuleNode {
 
   std::string GetSource(const std::string& format) final { return code_; }
 
-  std::string GetFormat() { return fmt_; }
+  std::string GetFormat() override { return fmt_; }
 
   void SaveToFile(const std::string& file_name, const std::string& format) final {
     std::string fmt = GetFileFormat(file_name, format);
@@ -130,7 +130,7 @@ class CSourceModuleNode : public runtime::ModuleNode {
     }
   }
 
-  int GetPropertyMask() const { return runtime::ModulePropertyMask::kDSOExportable; }
+  int GetPropertyMask() const override { return runtime::ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();
@@ -183,7 +183,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
 
   std::string GetSource(const std::string& format) final { return code_.str(); }
 
-  std::string GetFormat() { return fmt_; }
+  std::string GetFormat() override { return fmt_; }
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final {
     return PackedFunc();
   }
@@ -200,7 +200,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
     }
   }
 
-  int GetPropertyMask() const { return runtime::ModulePropertyMask::kDSOExportable; }
+  int GetPropertyMask() const override { return runtime::ModulePropertyMask::kDSOExportable; }
 
   bool ImplementsFunction(const String& name, bool query_imports) final {
     return std::find(func_names_.begin(), func_names_.end(), name) != func_names_.end();


### PR DESCRIPTION
These functions are virtual, and some of the overrides were not marked as either `final` or `override` causing compilation warnings.