### PR TITLE
[Unity][BYOC] Fix `RunCodegen` pass on symbolic shape

### DIFF
--- a/src/relax/transform/run_codegen.cc
+++ b/src/relax/transform/run_codegen.cc
@@ -93,7 +93,8 @@ class CodeGenRunner : ExprMutator {
         Expr new_func = VisitExpr(func);
 
         if (new_func->IsInstance<ExternFuncNode>()) {
-          extern_funcs_[gvar_node] = {new_func, func->ret_struct_info};
+	  auto ret_sinfo = GetStructInfo(call);
+          extern_funcs_[gvar_node] = {new_func, ret_sinfo};
           // Remove the global symbol and codegen attributes from the function so that it can be
           // removed the module.
           static const runtime::PackedFunc* RemoveFuncAttrFunc =
@@ -102,7 +103,7 @@ class CodeGenRunner : ExprMutator {
           func = (*RemoveFuncAttrFunc)(func, tvm::attr::kGlobalSymbol);
           func = (*RemoveFuncAttrFunc)(func, attr::kCodegen);
           builder_->UpdateFunction(gvar, func);
-          return create_call_dps_packed(new_func, func->ret_struct_info);
+          return create_call_dps_packed(new_func, ret_sinfo);
         }
       }
     }

--- a/src/relax/transform/run_codegen.cc
+++ b/src/relax/transform/run_codegen.cc
@@ -93,7 +93,7 @@ class CodeGenRunner : ExprMutator {
         Expr new_func = VisitExpr(func);
 
         if (new_func->IsInstance<ExternFuncNode>()) {
-	  auto ret_sinfo = GetStructInfo(call);
+          auto ret_sinfo = GetStructInfo(call);
           extern_funcs_[gvar_node] = {new_func, ret_sinfo};
           // Remove the global symbol and codegen attributes from the function so that it can be
           // removed the module.


### PR DESCRIPTION
BYOC tests using symbolic shapes have been broken since https://github.com/apache/tvm/pull/14396. A BYOC function's return `sinfo` refers to a sym var defined inside that function. When a call to that is replaced by an opaque `call_dps_packed`, we cannot use `func->ret_struct_info` anymore since it refers to a sym var that's gone. 

It's more mysterious why `RunCodegen` on symbolic shape had been working before 14396... Perhaps `main` happens to define the same-named sym var, which happens to capture the undefined variable in `func->ret_struct_info`. Perhaps that is exactly what https://github.com/apache/tvm/pull/14396 prevents. 

The failing cutlass test is now working but it is not tested on CI. Cublas tests will be added in https://github.com/apache/tvm/pull/14291 which run on CI. We should also consider enabling cutlass tests on CI. 

@sunggg @vinx13 @psrivas2 @Hzfengsy 