### PR TITLE
[pytest] Don't return values from test_* functions

### DIFF
--- a/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
+++ b/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
@@ -331,7 +331,7 @@ class TestElementWise:
             assert len(buffer.shape) == expected_physical_dimensions
 
     def test_lower(self, schedule_args):
-        return tvm.lower(*schedule_args)
+        tvm.lower(*schedule_args)
 
     @requires_hexagon_toolchain
     def test_build(self, schedule_args, target_host, input_layout, working_layout, output_layout):

--- a/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
+++ b/tests/python/contrib/test_hexagon/test_2d_physical_buffers.py
@@ -331,7 +331,7 @@ class TestElementWise:
             assert len(buffer.shape) == expected_physical_dimensions
 
     def test_lower(self, schedule_args):
-        tvm.lower(*schedule_args)
+        assert tvm.lower(*schedule_args)
 
     @requires_hexagon_toolchain
     def test_build(self, schedule_args, target_host, input_layout, working_layout, output_layout):

--- a/tests/python/contrib/test_hexagon/test_maxpool2d_blocked.py
+++ b/tests/python/contrib/test_hexagon/test_maxpool2d_blocked.py
@@ -151,7 +151,7 @@ class TestMaxPooling(BaseMaxPooling):
             padding=(pad, pad, pad, pad),
             dtype=dtype,
         )
-        assert all([output, ref_output])
+        assert all([output is not None, ref_output is not None])
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_hexagon/test_maxpool2d_blocked.py
+++ b/tests/python/contrib/test_hexagon/test_maxpool2d_blocked.py
@@ -151,6 +151,7 @@ class TestMaxPooling(BaseMaxPooling):
             padding=(pad, pad, pad, pad),
             dtype=dtype,
         )
+        assert all([output, ref_output])
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_hexagon/test_maxpool2d_blocked.py
+++ b/tests/python/contrib/test_hexagon/test_maxpool2d_blocked.py
@@ -151,7 +151,6 @@ class TestMaxPooling(BaseMaxPooling):
             padding=(pad, pad, pad, pad),
             dtype=dtype,
         )
-        return output, ref_output
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Pytest expects test functions to return None, and errors to be flagged via exceptions. It actually emits warnings for "return" statements encountered in test_ functions.