### PR TITLE
[Relay] Check if the attribute "name" exists before accessing it

### DIFF
--- a/python/tvm/relay/qnn/op/_qnn.py
+++ b/python/tvm/relay/qnn/op/_qnn.py
@@ -101,7 +101,11 @@ def legalize_clip(attrs, inputs, tinfos):
     implementations (like Cortex-M) need it to be done earlier in legalization.
     """
 
-    if hasattr(inputs[0], "op") and inputs[0].op.name == "qnn.requantize":
+    if (
+        hasattr(inputs[0], "op")
+        and hasattr(inputs[0].op, "name")
+        and inputs[0].op.name == "qnn.requantize"
+    ):
         dtype_info = np.iinfo(tinfos[0].dtype)
         if dtype_info.min == attrs.a_min and dtype_info.max == attrs.a_max:
             return inputs[0]


### PR DESCRIPTION
I found that some models fail to compile with tvm when the target is: `compute-library, llvm -mtriple=aarch64-linux-gnu -mattr=+v8.2a,+neon`

The error is:  `AttributeError: <class 'tvm.ir.expr.GlobalVar'> has no attribute name`.

This patch checks if the attribute `name` exists before accessing it, and solves the compilation issues that I had, producing the expected result during the following inference.