### PR TITLE
[TIR] Use same DataType of builtin::tvm_struct_set in C++ and Python

### DIFF
--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -527,7 +527,7 @@ def tvm_struct_set(arr, index, field, value):
     call : PrimExpr
         The call expression.
     """
-    return call_intrin("handle", "tir.tvm_struct_set", arr, index, field, value)
+    return call_intrin("int32", "tir.tvm_struct_set", arr, index, field, value)
 
 
 def address_of(buffer_load, span=None):


### PR DESCRIPTION
Prior to this commit, the python API `tvm.tir.op.tvm_struct_set` defined the return type of `builtin::tvm_struct_set` as `"handle"`, while the C++ API `tvm::tir::TVMStructSet` defined the return type as `DataType::Int(32)`.  The data type used for this builtin has no effect, because no value is returned.  However, this discrepancy can cause failure to roundtrip through TVMScript.

This commit updates the Python API to use `"int32"`, for consistency with the C++ API and with `CodeGenCPU`.

This is part of changes described in https://github.com/apache/tvm/pull/14486, to improve round-trip failures that occur in lowering.