### PR TITLE
[TIR] [Schedule] Add get_output_blocks primitive

### DIFF
--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -291,6 +291,14 @@ class ScheduleNode : public runtime::Object {
    * block
    */
   virtual Array<BlockRV> GetConsumers(const BlockRV& block_rv) = 0;
+  /*!
+   * \brief Get the list of output blocks
+   * An output block is a block which has atleast one buffer being written
+   * to, but is not allocated within the PrimFunc
+   * \return A list of all blocks that write to some output buffer
+   * block
+   */
+  virtual Array<BlockRV> GetOutputBlocks(const Optional<String>& func_name = NullOpt) = 0;
   /******** Schedule: Transform loops ********/
   /*!
    * \brief Merge a list of loops into one. The loops under their LCA requires:

--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -292,13 +292,14 @@ class ScheduleNode : public runtime::Object {
    */
   virtual Array<BlockRV> GetConsumers(const BlockRV& block_rv) = 0;
   /*!
-   * \brief Get the list of output blocks
+   * \brief Get the list of output blocks within the given scope
    * An output block is a block which has atleast one buffer being written
    * to, but is not allocated within the PrimFunc
+   * \param scope_block_rv The scope block from which output blocks are collected
    * \return A list of all blocks that write to some output buffer
    * block
    */
-  virtual Array<BlockRV> GetOutputBlocks(const Optional<String>& func_name = NullOpt) = 0;
+  virtual Array<BlockRV> GetOutputBlocks(const BlockRV& scope_block_rv) = 0;
   /******** Schedule: Transform loops ********/
   /*!
    * \brief Merge a list of loops into one. The loops under their LCA requires:

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -543,11 +543,16 @@ class Schedule(Object):
     @type_checked
     def get_output_blocks(
         self,
-        func_name: Optional[str] = None,
+        scope_block: Union[BlockRV, str],
     ) -> List[BlockRV]:
-        """Get the list of output blocks
+        """Get the list of output blocks within the given scope
         An output block is a block which has atleast one buffer being written
         to, but is not allocated within the PrimFunc
+
+        Parameters
+        ----------
+        scope_block : Union[BlockRV, str],
+            The scope block from which output blocks are collected
 
         Returns
         -------
@@ -555,7 +560,8 @@ class Schedule(Object):
             A list of all blocks that write to some output buffer
 
         """
-        return list(_ffi_api.ScheduleGetOutputBlocks(self, func_name))  # type: ignore # pylint: disable=no-member
+        scope_block = self._normalize_block_arg(scope_block)
+        return list(_ffi_api.ScheduleGetOutputBlocks(self, scope_block))  # type: ignore # pylint: disable=no-member
 
     ########## Schedule: Transform loops ##########
     @type_checked

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -540,6 +540,23 @@ class Schedule(Object):
         block = self._normalize_block_arg(block)
         return list(_ffi_api.ScheduleGetConsumers(self, block))  # type: ignore # pylint: disable=no-member
 
+    @type_checked
+    def get_output_blocks(
+        self,
+        func_name: Optional[str] = None,
+    ) -> List[BlockRV]:
+        """Get the list of output blocks
+        An output block is a block which has atleast one buffer being written
+        to, but is not allocated within the PrimFunc
+
+        Returns
+        -------
+        output_blocks : List[BlockRV]
+            A list of all blocks that write to some output buffer
+
+        """
+        return list(_ffi_api.ScheduleGetOutputBlocks(self, func_name))  # type: ignore # pylint: disable=no-member
+
     ########## Schedule: Transform loops ##########
     @type_checked
     def merge(

--- a/src/tir/schedule/analysis.h
+++ b/src/tir/schedule/analysis.h
@@ -386,13 +386,14 @@ Array<StmtSRef> GetProducers(const StmtSRef& block_sref, const BlockScope& scope
 Array<StmtSRef> GetConsumers(const StmtSRef& block_sref, const BlockScope& scope);
 
 /*!
- * \brief Get the list of output blocks
+ * \brief Get the list of output blocks within the given scope
  * An output block is a block which has atleast one buffer being written
  * to, but is not allocated within the PrimFunc
+ * \param scope_block_rv The scope block from which output blocks are collected
  * \return A list of all blocks that write to some output buffer
  * block
  */
-Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const PrimFuncNode* func);
+Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const BlockNode* scope_block);
 
 /*!
  * \brief A solution to split a ordered list of subtrees into two parts,

--- a/src/tir/schedule/analysis.h
+++ b/src/tir/schedule/analysis.h
@@ -386,6 +386,15 @@ Array<StmtSRef> GetProducers(const StmtSRef& block_sref, const BlockScope& scope
 Array<StmtSRef> GetConsumers(const StmtSRef& block_sref, const BlockScope& scope);
 
 /*!
+ * \brief Get the list of output blocks
+ * An output block is a block which has atleast one buffer being written
+ * to, but is not allocated within the PrimFunc
+ * \return A list of all blocks that write to some output buffer
+ * block
+ */
+Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const PrimFuncNode* func);
+
+/*!
  * \brief A solution to split a ordered list of subtrees into two parts,
  * where producers are on the LHS and consumers are on the RHS.
  * For example, subtree[0, 3) are on the LHS, and subtree[3, 6) are on the RHS.

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -1052,7 +1052,8 @@ Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const PrimFuncNode* f
       ICHECK(it != self_->stmt2ref.end());
       auto block_sref = it->second;
       if (block_sref->parent != nullptr) {
-        StmtSRef scope_root_sref = GetScopeRoot(self_, block_sref, /*require_stage_pipeline=*/false);
+        StmtSRef scope_root_sref =
+            GetScopeRoot(self_, block_sref, /*require_stage_pipeline=*/false);
         if (IsOutputBlock(self_, block_sref, scope_root_sref)) {
           results_.push_back(block_sref);
         }

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -1043,6 +1043,32 @@ Array<StmtSRef> GetConsumers(const StmtSRef& block_sref, const BlockScope& scope
   return results;
 }
 
+Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const PrimFuncNode* func) {
+  struct OutputBlockCollector : public StmtVisitor {
+    explicit OutputBlockCollector(const ScheduleState& self) : self_(self) {}
+
+    void VisitStmt_(const BlockNode* block) override {
+      auto it = self_->stmt2ref.find(block);
+      ICHECK(it != self_->stmt2ref.end());
+      auto block_sref = it->second;
+      if (block_sref->parent != nullptr) {
+        StmtSRef scope_root_sref = GetScopeRoot(self_, block_sref, /*require_stage_pipeline=*/false);
+        if (IsOutputBlock(self_, block_sref, scope_root_sref)) {
+          results_.push_back(block_sref);
+        }
+      }
+      StmtVisitor::VisitStmt_(block);
+    }
+
+    const ScheduleState& self_;
+    Array<StmtSRef> results_;
+  };
+  OutputBlockCollector collector(self);
+  collector(func->body);
+  auto results = collector.results_;
+  return results;
+}
+
 ProducerConsumerSplit ProducerConsumerSplit::Find(
     const ScheduleState& self, const Array<Stmt>& subtrees,
     const Array<StmtSRef>& producer_block_srefs, const Array<StmtSRef>& consumer_block_srefs,

--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -1043,7 +1043,7 @@ Array<StmtSRef> GetConsumers(const StmtSRef& block_sref, const BlockScope& scope
   return results;
 }
 
-Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const PrimFuncNode* func) {
+Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const BlockNode* scope_block) {
   struct OutputBlockCollector : public StmtVisitor {
     explicit OutputBlockCollector(const ScheduleState& self) : self_(self) {}
 
@@ -1065,7 +1065,7 @@ Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const PrimFuncNode* f
     Array<StmtSRef> results_;
   };
   OutputBlockCollector collector(self);
-  collector(func->body);
+  collector(scope_block->body);
   auto results = collector.results_;
   return results;
 }

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -354,6 +354,23 @@ Array<BlockRV> ConcreteScheduleNode::GetConsumers(const BlockRV& block_rv) {
   throw;
 }
 
+Array<BlockRV> ConcreteScheduleNode::GetOutputBlocks(const Optional<String>& func_name) {
+  TVM_TIR_SCHEDULE_BEGIN();
+  GlobalVar gv = NullValue<GlobalVar>();
+  if (func_name.defined()) {
+    gv = state_->mod->GetGlobalVar(func_name.value());
+  } else if (func_working_on_.defined()) {
+    gv = this->func_working_on_.value();
+  } else {
+    LOG(FATAL) << "ValueError: `get_output_blocks` does not know which function to be working on. Please "
+                  "specify the function name explicitly, or call `work_on` to specify the function "
+                  "before using `get_output_blocks`.";
+  }
+  return CreateRV<BlockRV>(tir::GetOutputBlocks(state_, gv));
+  TVM_TIR_SCHEDULE_END("get-output-blocks", this->error_render_level_);
+  throw;
+}
+
 /******** Schedule: Transform loops ********/
 
 LoopRV ConcreteScheduleNode::Merge(const Array<LoopRV>& loop_rvs) {

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -362,9 +362,10 @@ Array<BlockRV> ConcreteScheduleNode::GetOutputBlocks(const Optional<String>& fun
   } else if (func_working_on_.defined()) {
     gv = this->func_working_on_.value();
   } else {
-    LOG(FATAL) << "ValueError: `get_output_blocks` does not know which function to be working on. Please "
-                  "specify the function name explicitly, or call `work_on` to specify the function "
-                  "before using `get_output_blocks`.";
+    LOG(FATAL)
+        << "ValueError: `get_output_blocks` does not know which function to be working on. Please "
+           "specify the function name explicitly, or call `work_on` to specify the function "
+           "before using `get_output_blocks`.";
   }
   return CreateRV<BlockRV>(tir::GetOutputBlocks(state_, gv));
   TVM_TIR_SCHEDULE_END("get-output-blocks", this->error_render_level_);

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -354,20 +354,9 @@ Array<BlockRV> ConcreteScheduleNode::GetConsumers(const BlockRV& block_rv) {
   throw;
 }
 
-Array<BlockRV> ConcreteScheduleNode::GetOutputBlocks(const Optional<String>& func_name) {
+Array<BlockRV> ConcreteScheduleNode::GetOutputBlocks(const BlockRV& scope_block_rv) {
   TVM_TIR_SCHEDULE_BEGIN();
-  GlobalVar gv = NullValue<GlobalVar>();
-  if (func_name.defined()) {
-    gv = state_->mod->GetGlobalVar(func_name.value());
-  } else if (func_working_on_.defined()) {
-    gv = this->func_working_on_.value();
-  } else {
-    LOG(FATAL)
-        << "ValueError: `get_output_blocks` does not know which function to be working on. Please "
-           "specify the function name explicitly, or call `work_on` to specify the function "
-           "before using `get_output_blocks`.";
-  }
-  return CreateRV<BlockRV>(tir::GetOutputBlocks(state_, gv));
+  return CreateRV<BlockRV>(tir::GetOutputBlocks(state_, this->GetSRef(scope_block_rv)));
   TVM_TIR_SCHEDULE_END("get-output-blocks", this->error_render_level_);
   throw;
 }

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -99,6 +99,7 @@ class ConcreteScheduleNode : public ScheduleNode {
   Array<BlockRV> GetChildBlocks(const LoopRV& loop_rv) override;
   Array<BlockRV> GetProducers(const BlockRV& block_rv) override;
   Array<BlockRV> GetConsumers(const BlockRV& block_rv) override;
+  Array<BlockRV> GetOutputBlocks(const Optional<String>& func_name) override;
   /******** Schedule: Transform loops ********/
   LoopRV Fuse(const Array<LoopRV>& loop_rvs, bool preserve_unit_iters) override;
   LoopRV Merge(const Array<LoopRV>& loop_rvs) override;

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -99,7 +99,7 @@ class ConcreteScheduleNode : public ScheduleNode {
   Array<BlockRV> GetChildBlocks(const LoopRV& loop_rv) override;
   Array<BlockRV> GetProducers(const BlockRV& block_rv) override;
   Array<BlockRV> GetConsumers(const BlockRV& block_rv) override;
-  Array<BlockRV> GetOutputBlocks(const Optional<String>& func_name) override;
+  Array<BlockRV> GetOutputBlocks(const BlockRV& scope_block_rv) override;
   /******** Schedule: Transform loops ********/
   LoopRV Fuse(const Array<LoopRV>& loop_rvs, bool preserve_unit_iters) override;
   LoopRV Merge(const Array<LoopRV>& loop_rvs) override;

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -148,6 +148,14 @@ Array<StmtSRef> GetProducers(const ScheduleState& self, const StmtSRef& block_sr
  * \return A list of blocks, the consumers of the given block
  */
 Array<StmtSRef> GetConsumers(const ScheduleState& self, const StmtSRef& block_sref);
+/*!
+ * \brief Get the list of output blocks
+ * An output block is a block which has atleast one buffer being written
+ * to, but is not allocated within the PrimFunc
+ * \return A list of all blocks that write to some output buffer
+ * block
+ */
+Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const GlobalVar& gv);
 /******** Schedule: Transform loops ********/
 /*!
  * Split a loop into a list of consecutive loops. It requires:

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -149,13 +149,14 @@ Array<StmtSRef> GetProducers(const ScheduleState& self, const StmtSRef& block_sr
  */
 Array<StmtSRef> GetConsumers(const ScheduleState& self, const StmtSRef& block_sref);
 /*!
- * \brief Get the list of output blocks
+ * \brief Get the list of output blocks within the given scope
  * An output block is a block which has atleast one buffer being written
  * to, but is not allocated within the PrimFunc
+ * \param scope_block_rv The scope block from which output blocks are collected
  * \return A list of all blocks that write to some output buffer
  * block
  */
-Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const GlobalVar& gv);
+Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const StmtSRef& scope_sref);
 /******** Schedule: Transform loops ********/
 /*!
  * Split a loop into a list of consecutive loops. It requires:

--- a/src/tir/schedule/primitive/get_block_loop.cc
+++ b/src/tir/schedule/primitive/get_block_loop.cc
@@ -233,9 +233,7 @@ struct GetOutputBlocksTraits : public UnpackedInstTraits<GetOutputBlocksTraits> 
   static constexpr size_t kNumAttrs = 0;
   static constexpr size_t kNumDecisions = 0;
 
-  static Array<BlockRV> UnpackedApplyToSchedule(Schedule sch) {
-    return sch->GetOutputBlocks();
-  }
+  static Array<BlockRV> UnpackedApplyToSchedule(Schedule sch) { return sch->GetOutputBlocks(); }
 
   static String UnpackedAsPython(Array<String> outputs) {
     PythonAPICall py("get_output_blocks");

--- a/src/tir/schedule/schedule.cc
+++ b/src/tir/schedule/schedule.cc
@@ -152,6 +152,8 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleGetProducers")
     .set_body_method<Schedule>(&ScheduleNode::GetProducers);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleGetConsumers")
     .set_body_method<Schedule>(&ScheduleNode::GetConsumers);
+TVM_REGISTER_GLOBAL("tir.schedule.ScheduleGetOutputBlocks")
+    .set_body_method<Schedule>(&ScheduleNode::GetOutputBlocks);
 /******** (FFI) Transform loops ********/
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleMerge").set_body_method<Schedule>(&ScheduleNode::Merge);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleFuse").set_body_method<Schedule>(&ScheduleNode::Fuse);

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -174,12 +174,12 @@ Array<BlockRV> TracedScheduleNode::GetConsumers(const BlockRV& block_rv) {
   return results;
 }
 
-Array<BlockRV> TracedScheduleNode::GetOutputBlocks(const Optional<String>& func_name) {
-  Array<BlockRV> results = ConcreteScheduleNode::GetOutputBlocks(func_name);
+Array<BlockRV> TracedScheduleNode::GetOutputBlocks(const BlockRV& scope_block_rv) {
+  Array<BlockRV> results = ConcreteScheduleNode::GetOutputBlocks(scope_block_rv);
 
   static const InstructionKind& kind = InstructionKind::Get("GetOutputBlocks");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,  //
-                                      /*inputs=*/{},
+                                      /*inputs=*/{scope_block_rv},
                                       /*attrs=*/{},
                                       /*outputs=*/{results.begin(), results.end()}));
   return results;

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -174,6 +174,17 @@ Array<BlockRV> TracedScheduleNode::GetConsumers(const BlockRV& block_rv) {
   return results;
 }
 
+Array<BlockRV> TracedScheduleNode::GetOutputBlocks(const Optional<String>& func_name) {
+  Array<BlockRV> results = ConcreteScheduleNode::GetOutputBlocks(func_name);
+
+  static const InstructionKind& kind = InstructionKind::Get("GetOutputBlocks");
+  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,  //
+                                      /*inputs=*/{},
+                                      /*attrs=*/{},
+                                      /*outputs=*/{results.begin(), results.end()}));
+  return results;
+}
+
 /******** Schedule: Transform loops ********/
 
 LoopRV TracedScheduleNode::Merge(const Array<LoopRV>& loop_rvs) {

--- a/src/tir/schedule/traced_schedule.h
+++ b/src/tir/schedule/traced_schedule.h
@@ -59,6 +59,7 @@ class TracedScheduleNode : public ConcreteScheduleNode {
   Array<BlockRV> GetChildBlocks(const LoopRV& loop_rv) final;
   Array<BlockRV> GetProducers(const BlockRV& block_rv) final;
   Array<BlockRV> GetConsumers(const BlockRV& block_rv) final;
+  Array<BlockRV> GetOutputBlocks(const Optional<String>& func_name) final;
   /******** Schedule: Transform loops ********/
   LoopRV Fuse(const Array<LoopRV>& loop_rvs, bool preserve_unit_iters) final;
   LoopRV Merge(const Array<LoopRV>& loop_rvs) final;

--- a/src/tir/schedule/traced_schedule.h
+++ b/src/tir/schedule/traced_schedule.h
@@ -59,7 +59,7 @@ class TracedScheduleNode : public ConcreteScheduleNode {
   Array<BlockRV> GetChildBlocks(const LoopRV& loop_rv) final;
   Array<BlockRV> GetProducers(const BlockRV& block_rv) final;
   Array<BlockRV> GetConsumers(const BlockRV& block_rv) final;
-  Array<BlockRV> GetOutputBlocks(const Optional<String>& func_name) final;
+  Array<BlockRV> GetOutputBlocks(const BlockRV& scope_block_rv) final;
   /******** Schedule: Transform loops ********/
   LoopRV Fuse(const Array<LoopRV>& loop_rvs, bool preserve_unit_iters) final;
   LoopRV Merge(const Array<LoopRV>& loop_rvs) final;

--- a/tests/python/unittest/test_tir_schedule_utilities.py
+++ b/tests/python/unittest/test_tir_schedule_utilities.py
@@ -360,7 +360,7 @@ def test_annotate_unannotate_block():
 
 def test_get_output_blocks_single_output():
     sch = tir.Schedule(mod=matmul_relu, debug_mask="all")
-    output_blocks = sch.get_output_blocks()
+    output_blocks = sch.get_output_blocks("root")
     assert len(output_blocks) == 1, "Unexpected number of blocks when 1 was expected"
     block = sch.get(output_blocks[0])
     assert block.name_hint == "relu"
@@ -370,7 +370,7 @@ def test_get_output_blocks_single_output():
 
 def test_get_output_blocks_multiple_outputs():
     sch = tir.Schedule(mod=matmul, debug_mask="all")
-    output_blocks = sch.get_output_blocks()
+    output_blocks = sch.get_output_blocks("root")
     assert len(output_blocks) == 2, "Unexpected number of blocks when 2 were expected"
     block_1 = sch.get(output_blocks[0])
     assert block_1.name_hint == "init"
@@ -397,7 +397,7 @@ def test_get_output_blocks_nested():
                     B[vi, vj] = A[vi, vj] * 2.0
 
     sch = tir.Schedule(mod=blockized, debug_mask="all")
-    output_blocks = sch.get_output_blocks()
+    output_blocks = sch.get_output_blocks("root")
     assert len(output_blocks) == 2, "Unexpected number of blocks when 2 were expected"
     block_1 = sch.get(output_blocks[0])
     assert block_1.name_hint == "blockized_B"
@@ -407,6 +407,14 @@ def test_get_output_blocks_nested():
     assert sch.get(blockized_block).same_as(block_1)
     b_block = sch.get_block("B")
     assert sch.get(b_block).same_as(block_2)
+
+    sch = tir.Schedule(mod=blockized, debug_mask="all")
+    output_blocks = sch.get_output_blocks("blockized_B")
+    assert len(output_blocks) == 1, "Unexpected number of blocks when 1 were expected"
+    block = sch.get(output_blocks[0])
+    assert block.name_hint == "B"
+    b_block = sch.get_block("B")
+    assert sch.get(b_block).same_as(block)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When scheduling fused ops, its really useful to be able to get all the output blocks and schedule other blocks in the fused op with respect to output blocks. This helps avoid hardcoding block names in manually written schedules in many cases