### PR TITLE
[TIR] Use String instead of StringImm for AttrStmtNode::node

### DIFF
--- a/src/tir/transforms/make_packed_api.cc
+++ b/src/tir/transforms/make_packed_api.cc
@@ -266,7 +266,7 @@ PrimFunc MakePackedAPI(PrimFunc&& func) {
                   StringImm(name_hint + "_compute_"), body);
   // Set device context
   if (vmap.count(device_id.get())) {
-    PrimExpr node = StringImm("default");
+    ObjectRef node = String("default");
     seq_check.push_back(AttrStmt(node, attr::device_id, device_id, nop));
     seq_check.push_back(AttrStmt(node, attr::device_type, device_type, nop));
 

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -3692,6 +3692,17 @@ def tvm_shfl_builtins():
     return func
 
 
+def make_packed_api_result():
+    @T.prim_func
+    def func(A: T.Buffer(64, "float32")):
+        T.func_attr({"global_symbol": "main", "target": T.target("cuda")})
+        bx = T.launch_thread("blockIdx.x", 64)
+        T.evaluate(A[bx])
+
+    mod = tvm.IRModule.from_expr(func)
+    return tvm.tir.transform.MakePackedAPI()(mod)
+
+
 ir_generator = tvm.testing.parameter(
     launch_env_thread,
     opt_gemm_normalize,
@@ -3757,6 +3768,7 @@ ir_generator = tvm.testing.parameter(
     merge_shape_var_def,
     if_then_else_var,
     tvm_shfl_builtins,
+    make_packed_api_result,
 )
 
 


### PR DESCRIPTION
`tir::StringImm` can round-trip through TVMScript when used in a context that requires a PrimExpr, such as the arguments of a `tir::Call`.  However, contexts that only require a `ObjectRef`, such as the `AttrStmtNode::node`, use the same TVMScript representation as `"string_value"`, but are parsed `tvm::String` instances.

This commit updates `MakePackedAPI` to use `String` instead of `StringImm` in its default value for `AttrStmtNode::node`.

This is part of changes described in https://github.com/apache/tvm/pull/14486, to improve round-trip failures that occur in lowering.