### PR TITLE
[Unity][Graph matching] Improved matching algorithm and implementation

### DIFF
--- a/include/tvm/relax/dataflow_matcher.h
+++ b/include/tvm/relax/dataflow_matcher.h
@@ -51,19 +51,12 @@ Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(
 
 /**
  * \brief Match a sub-graph in a DataflowBlock with a graph of patterns and return the mapping.
- * \note This algorithm returns the first matched sub-graph. Use `start_hint` to specify the
- * starting point of the matching so that we can distinguish multiple matches.
- *
  * \param ctx The graph-wise patterns.
  * \param dfb The function to match.
- * \param start_hint The starting point expression to match to distinguish multiple matches.
- * \param must_include_hint If start_hint is given, the return pattern must include start_hint.
  * \return Matched patterns and corresponding bound variables
  */
 TVM_DLL Optional<Map<DFPattern, Var>> MatchGraph(const PatternContext& ctx,
-                                                 const DataflowBlock& dfb,
-                                                 Optional<Var> start_hint = NullOpt,
-                                                 bool must_include_hint = false);
+                                                 const DataflowBlock& dfb);
 
 }  // namespace relax
 }  // namespace tvm

--- a/python/tvm/relax/dpl/context.py
+++ b/python/tvm/relax/dpl/context.py
@@ -63,8 +63,6 @@ class PatternContext(tvm.runtime.Object):
     def match_dfb(
         self,
         dfb: DataflowBlock,
-        start_hint: Optional[Var] = None,
-        must_include_hint: bool = False,
     ) -> Dict[DFPattern, Var]:
         """
         Match a DataflowBlock via a graph of DFPattern and corresponding constraints
@@ -73,14 +71,10 @@ class PatternContext(tvm.runtime.Object):
         ----------
         dfb : DataflowBlock
             The DataflowBlock to match
-        start_hint : Optional[Var], optional
-            Indicating the starting expression to match, by default None
-        must_include_hint : bool, optional
-            Whether the start_hint expression must be matched, by default False
 
         Returns
         -------
         Dict[DFPattern, Var]
             The mapping from DFPattern to matched expression
         """
-        return ffi.match_dfb(self, dfb, start_hint, must_include_hint)  # type: ignore
+        return ffi.match_dfb(self, dfb)  # type: ignore

--- a/python/tvm/relax/dpl/context.py
+++ b/python/tvm/relax/dpl/context.py
@@ -17,7 +17,7 @@
 
 """The Graph Matching Context Manager for Dataflow Pattern Language."""
 
-from typing import Optional, Dict
+from typing import Dict
 
 import tvm
 from ..expr import DataflowBlock, Var

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -578,9 +578,9 @@ struct MatchState {
     match_r_p[r] = p;
   }
 
-  void add(const MatchState& other) {
-    match_p_r.insert(other.match_p_r.cbegin(), other.match_p_r.cend());
-    match_r_p.insert(other.match_r_p.cbegin(), other.match_r_p.cend());
+  void add(MatchState&& other) {
+    match_p_r.merge(std::move(other.match_p_r));
+    match_r_p.merge(std::move(other.match_r_p));
   }
 
   const VarNode* matched(const PNode* p) const {
@@ -655,7 +655,7 @@ static std::optional<MatchState> TryMatch(const PNode& p, const RNode& r, DFPatt
 
       if (auto match_rec = TryMatch(*pchild, *rchild, m, ud_analysis)) {
         result.add(pchild, rchild);
-        result.add(*match_rec);
+        result.add(std::move(*match_rec));
       }
     }
     if (!result.matched(pchild) || !any_cons_sat) return std::nullopt;
@@ -694,7 +694,7 @@ static std::optional<MatchState> MatchTree(
       // Recursivly try to match the next subtree.
       if (auto matches_rec = MatchTree(*matches, current_root_idx + 1, pattern2node, var2node,
                                        matcher, roots, ud_analysis)) {
-        matches->add(*matches_rec);
+        matches->add(std::move(*matches_rec));
         return matches;
       }
       // Recursive matching has failed, backtrack.

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -590,8 +590,8 @@ struct MatchState {
   }
 
   const DFPatternNode* matched(const RNode* r) const {
-    if (!match_r_p.count(r)) return nullptr;
-    return match_r_p.at(r)->ptr;
+    if (auto it = match_r_p.find(p); it != match_r_p.end()) return it->ptr;
+    return nullptr;
   }
 
   const VarNode* matched(const PNode& p) const { return matched(&p); }

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -612,12 +612,12 @@ static std::optional<MatchState> TryMatch(const PNode& p, const RNode& r, DFPatt
 
   for (size_t i = 0; i < p.parents.size(); ++i) {
     const auto p_node_parent = p.parents[i].first;
+    if (auto v = result.matched(p_node_parent); v && v != r.parents[i]->ptr) {
+      // A parent pattern is already matched to other variable.
+      return std::nullopt;
+    }
     if (p_node_parent->ptr->IsInstance<WildcardPatternNode>()) {
       ICHECK_EQ(p.parents.size(), r.parents.size());
-      if (auto v = result.matched(p_node_parent); v && v != r.parents[i]->ptr) {
-        // A parent wildcard pattern is already matched to other variable.
-        return std::nullopt;
-      }
       result.add(p_node_parent, r.parents[i]);
     }
   }

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -629,7 +629,9 @@ static std::optional<MatchState> TryMatch(const PNode& p, const RNode& r, DFPatt
   for (const auto& [pchild, constraints] : p.children) {
     bool any_cons_sat = false;
     for (const auto& rchild : r.children) {
-      if (auto p = result.matched(rchild); p && p != pchild->ptr) continue;
+      if (auto p = result.matched(rchild); p && p != pchild->ptr) {
+        continue;
+      }
 
       const auto& uses = ud_analysis.def2use.at(r.ptr);
 

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -584,12 +584,16 @@ struct MatchState {
   }
 
   const VarNode* matched(const PNode* p) const {
-    if (auto it = match_p_r.find(p); it != match_p_r.end()) return it->second->ptr;
+    if (auto it = match_p_r.find(p); it != match_p_r.end()) {
+      return it->second->ptr;
+    }
     return nullptr;
   }
 
   const DFPatternNode* matched(const RNode* r) const {
-    if (auto it = match_r_p.find(r); it != match_r_p.end()) return it->second->ptr;
+    if (auto it = match_r_p.find(r); it != match_r_p.end()) {
+      return it->second->ptr;
+    }
     return nullptr;
   }
 

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -666,11 +666,11 @@ static std::optional<MatchState> TryMatch(const PNode& p, const RNode& r, DFPatt
 }
 
 static std::optional<MatchState> MatchTree(
-    const MatchState& current_matches, int current_root_idx,
+    const MatchState& current_matches, size_t current_root_idx,
     const std::unordered_map<const DFPatternNode*, PNode>& pattern2node,
     const std::unordered_map<const VarNode*, RNode>& var2node, DFPatternMatcher* matcher,
     const std::vector<DFPattern>& roots, const MatcherUseDefAnalysis& ud_analysis) {
-  auto get_next_root = [&](int root_idx) -> const PNode* {
+  auto get_next_root = [&](size_t root_idx) -> const PNode* {
     // Look for the next unmatched root node.
     for (; root_idx < roots.size(); ++root_idx) {
       const auto& root = pattern2node.at(roots[root_idx].get());

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -579,9 +579,8 @@ struct MatchState {
   }
 
   void add(const MatchState& other) {
-    for (const auto& [p, r] : other.match_p_r) {
-      add(p, r);
-    }
+    match_p_r.insert(other.match_p_r.cbegin(), other.match_p_r.cend());
+    match_r_p.insert(other.match_r_p.cbegin(), other.match_r_p.cend());
   }
 
   const VarNode* matched(const PNode* p) const {

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -585,8 +585,8 @@ struct MatchState {
   }
 
   const VarNode* matched(const PNode* p) const {
-    if (!match_p_r.count(p)) return nullptr;
-    return match_p_r.at(p)->ptr;
+    if (auto it = match_p_r.find(p); it != match_p_r.end()) return it->ptr;
+    return nullptr;
   }
 
   const DFPatternNode* matched(const RNode* r) const {

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -584,12 +584,12 @@ struct MatchState {
   }
 
   const VarNode* matched(const PNode* p) const {
-    if (auto it = match_p_r.find(p); it != match_p_r.end()) return it->ptr;
+    if (auto it = match_p_r.find(p); it != match_p_r.end()) return it->second->ptr;
     return nullptr;
   }
 
   const DFPatternNode* matched(const RNode* r) const {
-    if (auto it = match_r_p.find(p); it != match_r_p.end()) return it->ptr;
+    if (auto it = match_r_p.find(r); it != match_r_p.end()) return it->second->ptr;
     return nullptr;
   }
 

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -612,8 +612,9 @@ static std::optional<MatchState> TryMatch(const PNode& p, const RNode& r, DFPatt
   MatchState result;
 
   for (size_t i = 0; i < p.parents.size(); ++i) {
-    auto p_node_parent = p.parents[i].first;
+    const auto p_node_parent = p.parents[i].first;
     if (p_node_parent->ptr->IsInstance<WildcardPatternNode>()) {
+      ICHECK_EQ(p.parents.size(), r.parents.size());
       if (auto v = result.matched(p_node_parent); v && v != r.parents[i]->ptr) {
         // A parent wildcard pattern is already matched to other variable.
         return std::nullopt;
@@ -625,9 +626,9 @@ static std::optional<MatchState> TryMatch(const PNode& p, const RNode& r, DFPatt
   result.add(&p, &r);
 
   // forward matching;
-  for (auto& [pchild, constraints] : p.children) {
+  for (const auto& [pchild, constraints] : p.children) {
     bool any_cons_sat = false;
-    for (auto& rchild : r.children) {
+    for (const auto& rchild : r.children) {
       if (auto p = result.matched(rchild); p && p != pchild->ptr) continue;
 
       const auto& uses = ud_analysis.def2use.at(r.ptr);

--- a/src/relax/ir/dataflow_pattern.cc
+++ b/src/relax/ir/dataflow_pattern.cc
@@ -406,6 +406,7 @@ PatternContext::PatternContext(bool incremental) {
         << "Incremental context needs to be built inside a existing context.";
     n->allow_extern_use = pattern_ctx_stack().top()->allow_extern_use;
     n->constraints = pattern_ctx_stack().top()->constraints;
+    n->src_ordered = pattern_ctx_stack().top()->src_ordered;
   }
 
   data_ = std::move(n);


### PR DESCRIPTION
* As discussed and agreed in https://github.com/apache/tvm/pull/14417#discussion_r1152443315, remove `start_hint` feature to simplify the API and the implementation

* To support the `start_hint` feature, the current algorithm has "bidirectional" nature: Matching can start from any node. This introduces recursive matching on both child and parent nodes, which makes the implementation complicated and reasoning about the algorithm almost impossible. Since this PR removes `start_hint`, we can now implement the algorithm in a purely one-directional manner, by starting matching from root nodes (those without parent nodes). Note that the pattern constraint graph is assumed to be a DAG. 

* The current implementation relies on side-effecting operations to maintain matchings. So when matching fails in the middle, we need to carefully "undo" matchings in the intermediate state (see https://github.com/apache/tvm/pull/14440). This, again, makes reasoning about the algorithm more difficult. I've reworked the data structure so that the matching algorithm is now "purely functional". Also, we can use `const` everywhere now.

Overall, this PR makes the matching algorithm a fairly standard one based on backtracking search. The implementation is also easier to understand and safer.

@ganler @sunggg @vinx13 @cyx-6 @psrivas2