### PR TITLE
[TensorIR][Schedule] Bugfix on `compute_inline` when buffer has symbolic shape

### DIFF
--- a/include/tvm/tir/analysis.h
+++ b/include/tvm/tir/analysis.h
@@ -102,7 +102,6 @@ TVM_DLL double EstimateTIRFlops(const IRModule& mod);
 TVM_DLL Array<Var> UndefinedVars(const Stmt& stmt, const Array<Var>& defs = {},
                                  bool visit_buffer = true);
 
-
 /*!
  * \brief Find undefined vars in the expression.
  * \param expr The expression to be checked.

--- a/include/tvm/tir/analysis.h
+++ b/include/tvm/tir/analysis.h
@@ -96,7 +96,7 @@ TVM_DLL double EstimateTIRFlops(const IRModule& mod);
  * \brief Find undefined vars in the statement.
  * \param stmt The statement to be checked.
  * \param defs The vars that is defined.
- * \param visit_buffer Whether to visit buffer shape/strides/etc.
+ * \param visit_buffer Whether to visit buffer shape/strides.
  * \return Array of undefined vars.
  */
 TVM_DLL Array<Var> UndefinedVars(const Stmt& stmt, const Array<Var>& defs = {},
@@ -106,7 +106,7 @@ TVM_DLL Array<Var> UndefinedVars(const Stmt& stmt, const Array<Var>& defs = {},
  * \brief Find undefined vars in the expression.
  * \param expr The expression to be checked.
  * \param defs The vars that is defined.
- * \param visit_buffer Whether to visit buffer shape/strides/etc.
+ * \param visit_buffer Whether to visit buffer shape/strides.
  * \return Array of undefined vars.
  */
 TVM_DLL Array<Var> UndefinedVars(const PrimExpr& expr, const Array<Var>& defs = {},

--- a/include/tvm/tir/analysis.h
+++ b/include/tvm/tir/analysis.h
@@ -96,24 +96,22 @@ TVM_DLL double EstimateTIRFlops(const IRModule& mod);
  * \brief Find undefined vars in the statement.
  * \param stmt The statement to be checked.
  * \param defs The vars that is defined.
+ * \param visit_buffer Whether to visit buffer shape/strides/etc.
  * \return Array of undefined vars.
  */
-TVM_DLL Array<Var> UndefinedVars(const Stmt& stmt, const Array<Var>& defs);
+TVM_DLL Array<Var> UndefinedVars(const Stmt& stmt, const Array<Var>& defs = {},
+                                 bool visit_buffer = true);
 
-/*!
- * \brief Find undefined vars in the expression.
- * \param expr The expression to be checked.
- * \return Array of undefined vars.
- */
-TVM_DLL Array<Var> UndefinedVars(const PrimExpr& expr);
 
 /*!
  * \brief Find undefined vars in the expression.
  * \param expr The expression to be checked.
  * \param defs The vars that is defined.
+ * \param visit_buffer Whether to visit buffer shape/strides/etc.
  * \return Array of undefined vars.
  */
-TVM_DLL Array<Var> UndefinedVars(const PrimExpr& expr, const Array<Var>& defs);
+TVM_DLL Array<Var> UndefinedVars(const PrimExpr& expr, const Array<Var>& defs = {},
+                                 bool visit_buffer = true);
 
 /*!
  * \brief Analyze the side effect

--- a/src/tir/analysis/var_use_def_analysis.cc
+++ b/src/tir/analysis/var_use_def_analysis.cc
@@ -151,15 +151,13 @@ void VarUseDefAnalyzer::HandleUse(const VarNode* v) {
   }
 }
 
-Array<Var> UndefinedVars(const Stmt& stmt, const Array<Var>& args,
-                         bool visit_buffer) {
+Array<Var> UndefinedVars(const Stmt& stmt, const Array<Var>& args, bool visit_buffer) {
   VarUseDefAnalyzer m(args, true, visit_buffer);
   m(stmt);
   return m.undefined_;
 }
 
-Array<Var> UndefinedVars(const PrimExpr& expr, const Array<Var>& args,
-                         bool visit_buffer) {
+Array<Var> UndefinedVars(const PrimExpr& expr, const Array<Var>& args, bool visit_buffer) {
   VarUseDefAnalyzer m(args, true, visit_buffer);
   m(expr);
   return m.undefined_;

--- a/src/tir/analysis/var_use_def_analysis.h
+++ b/src/tir/analysis/var_use_def_analysis.h
@@ -36,14 +36,17 @@ namespace tir {
  * \brief Visitor class to perform use/def analysis, also delete unreferenced lets.
  * \param defined_vars Variables that have been defined.
  * \param visit_thread_extent Whether enters thread extent expressions or not.
+ * \param visit_buffer Whether enters buffer node or not.
  * \sa UndefinedVars
  */
 class VarUseDefAnalyzer : public StmtExprVisitor {
  public:
-  explicit VarUseDefAnalyzer(const Array<Var>& defined_vars, bool visit_thread_extent = true);
+  explicit VarUseDefAnalyzer(const Array<Var>& defined_vars, bool visit_thread_extent = true,
+                             bool visit_buffer = true);
   // The fields are publically readible to
   // be accessible to the users.
-  bool visit_thread_extent_{true};
+  bool visit_thread_extent_;
+  bool visit_buffer_;
   Array<Var> undefined_;
 
   std::unordered_map<const VarNode*, int> use_count_;

--- a/src/tir/schedule/primitive/compute_inline.cc
+++ b/src/tir/schedule/primitive/compute_inline.cc
@@ -296,7 +296,7 @@ class BaseInliner : public StmtExprMutator {
    */
   static int GetNumUndefinedNonpointerVars(const Stmt& stmt) {
     // Do not visit buffer shape/strides.
-    auto undefined_vars = UndefinedVars(stmt, {}, false);
+    auto undefined_vars = UndefinedVars(/*stmt=*/stmt, /*defs=*/{}, /*visit_buffer=*/false);
     // Buffer pointers and the inlined indices are allowed, but no
     // other variables may appear in the inlined block.
     int num_nonpointer_vars = 0;

--- a/src/tir/schedule/primitive/compute_inline.cc
+++ b/src/tir/schedule/primitive/compute_inline.cc
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include "../../analysis/var_use_def_analysis.h"
 #include "../utils.h"
 
 namespace tvm {
@@ -296,15 +295,8 @@ class BaseInliner : public StmtExprMutator {
    * \param stmt The statement in which to count undefined variables
    */
   static int GetNumUndefinedNonpointerVars(const Stmt& stmt) {
-    // exclude variables appeared in Buffer shape/strides.
-    VarUseDefAnalyzer buffer_vars_analyzer({}, false);
-    for (const PrimExpr& expr : Downcast<BufferStore>(stmt)->buffer->shape) {
-      buffer_vars_analyzer(expr);
-    }
-    for (const PrimExpr& expr : Downcast<BufferStore>(stmt)->buffer->strides) {
-      buffer_vars_analyzer(expr);
-    }
-    auto undefined_vars = UndefinedVars(stmt, buffer_vars_analyzer.undefined_);
+    // Do not visit buffer shape/strides.
+    auto undefined_vars = UndefinedVars(stmt, {}, false);
     // Buffer pointers and the inlined indices are allowed, but no
     // other variables may appear in the inlined block.
     int num_nonpointer_vars = 0;


### PR DESCRIPTION
# The bug
Currently, the `compute_inline` function would report an error if we try to `compute_inline` a block where the buffer has a symbolic shape, below is a minimal reproduction:

```python
import tvm
import numpy as np
from tvm.script import tir as T

@T.prim_func
def failed_compute_inline(a: T.handle, b: T.handle):
    N = T.int32()
    A = T.match_buffer(a, (N, 32), "float32")
    temp = T.alloc_buffer((N, 32), "float32", scope="local")
    B = T.match_buffer(b, (N, 32), "float32")
    for i in range(N):
        for j in range(32):
            with T.block("T"):
                vi, vj = T.axis.remap("SS", [i, j])
                temp[vi, vj] = A[vi, vj] + 1
        for j in range(32):
            with T.block("B"):
                vi, vj = T.axis.remap("SS", [i, j])
                B[vi, vj] = temp[vi, vj] * A[vi, vj]

sch = tvm.tir.Schedule(failed_compute_inline)
T = sch.get_block("T")
B = sch.get_block("B")
j = sch.get_loops(B)[-1]
sch.compute_inline(T)
```

The reason is that the validity check analysis would use `UndefinedVars` to find variables that appeared in the block being `compute_inline` 'd. However, the `UndefinedVars` would visit `Buffer` and counts variables in buffer shape/strides,  and actually, we only care about buffer access indices. 

# Fix
This PR fixes the issue by adding a `visit_buffer` argument in the `UndefinedVars` function so that we can exclude variables that appeared in buffer shape/strides.

cc @Lunderberg @cyx-6 @junrushao @wrongtest-intellif 