### PR TITLE
[Unity][Op] vm.alloc_tensor infer struct info

### DIFF
--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -501,6 +501,12 @@ StructInfo InferStructInfoVMAllocTensor(const Call& call, const BlockBuilder& ct
   }
   if (const auto* output_shape = call->args[2].as<ShapeExprNode>()) {
     return TensorStructInfo(GetRef<Expr>(output_shape), out_dtype);
+  } else if (const auto* shape_sinfo = GetStructInfoAs<ShapeStructInfoNode>(call->args[2])) {
+    if (shape_sinfo->values.defined()) {
+      return TensorStructInfo(ShapeExpr(shape_sinfo->values.value()), out_dtype);
+    } else {
+      return TensorStructInfo(out_dtype, shape_sinfo->ndim);
+    }
   }
   return TensorStructInfo(out_dtype, kUnknownNDim);
 }

--- a/tests/python/relax/test_op_misc.py
+++ b/tests/python/relax/test_op_misc.py
@@ -103,6 +103,15 @@ def test_vm_alloc_tensor():
     tvm.ir.assert_structural_equal(alloc.struct_info, R.Tensor([4, 5], "float32"))
 
 
+def test_vm_alloc_tensor_infer_struct_info():
+    bb = rx.BlockBuilder()
+    s1 = rx.Var("s", R.Shape(ndim=3))
+    storage = rx.Var("storage", rx.TensorStructInfo(dtype="float32"))
+    alloc = rx.op.vm.alloc_tensor(storage, offset=0, shape=s1, dtype="float32")
+    ret = bb.normalize(alloc)
+    tvm.ir.assert_structural_equal(ret.struct_info, R.Tensor(dtype="float32", ndim=3))
+
+
 def test_builtin_stop_lift_params():
     bb = rx.BlockBuilder()
     x = rx.Var("x", rx.TensorStructInfo(shape=[4, 5], dtype="float32"))


### PR DESCRIPTION
Let the `vm.alloc_tensor` utilize the shape sinfo of shape to do better sinfo inference.