### PR TITLE
[TensorIR][Doc] Docstring of `reorder_block_iter_var`

### DIFF
--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -840,6 +840,57 @@ class Schedule(Object):
             The block to be transformed.
         new_order : List[int]
             The new block itervar order.
+        
+        Examples
+        --------
+
+        Before reorder_block_iter_var, in TensorIR, the IR is:
+
+        .. code-block:: python
+
+            @T.prim_func
+            def matmul(
+                A: T.Buffer((128, 128), "float32"),
+                B: T.Buffer((128, 128), "float32"),
+                C: T.Buffer((128, 128), "float32"),
+            ) -> None:
+                for i, j, k in T.grid(128, 128, 128):
+                    with T.block("C"):
+                        vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                        with T.init():
+                            C[vi, vj] = 0.0
+                        C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vj, vk]
+        
+        Create the schedule and do reorder_block_iter_var:
+
+        .. code-block:: python
+
+            sch = tir.Schedule(matmul)
+            C = sch.get_block("C")
+            sch.reorder_block_iter_var(C, [2, 1, 0])
+        
+        After applying reorder_block_iter_var, the IR becomes:
+
+        .. code-block:: python
+
+            @T.prim_func
+            def matmul_after_reorder_block_iter_var(
+                A: T.Buffer((128, 128), "float32"),
+                B: T.Buffer((128, 128), "float32"),
+                C: T.Buffer((128, 128), "float32"),
+            ):
+                for i, j, k in T.grid(128, 128, 128):
+                    with T.block("C"):
+                        vk, vj, vi = T.axis.remap("RSS", [k, j, i])
+                        T.reads(A[vi, vk], B[vj, vk])
+                        T.writes(C[vi, vj])
+                        with T.init():
+                            C[vi, vj] = T.float32(0)
+                        C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vj, vk]
+
+        See Also
+        --------
+        reorder
         """
         _ffi_api.ScheduleReorderBlockIterVar(self, block, new_order)  # type: ignore # pylint: disable=no-member
 

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -840,7 +840,7 @@ class Schedule(Object):
             The block to be transformed.
         new_order : List[int]
             The new block itervar order.
-        
+
         Examples
         --------
 
@@ -860,7 +860,7 @@ class Schedule(Object):
                         with T.init():
                             C[vi, vj] = 0.0
                         C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vj, vk]
-        
+
         Create the schedule and do reorder_block_iter_var:
 
         .. code-block:: python
@@ -868,7 +868,7 @@ class Schedule(Object):
             sch = tir.Schedule(matmul)
             C = sch.get_block("C")
             sch.reorder_block_iter_var(C, [2, 1, 0])
-        
+
         After applying reorder_block_iter_var, the IR becomes:
 
         .. code-block:: python


### PR DESCRIPTION
I forget to add docstring for the `reorder_block_iter_var` schedule primitive introduced in #14448 , this PR completes this part.

