### PR TITLE
[QNN] Convert fake quantized take to quantized op

### DIFF
--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -622,3 +622,14 @@ register_unary_qnn("hardswish", relay.qnn.op.hardswish)
 register_unary_qnn("tanh", relay.qnn.op.tanh)
 register_unary_qnn("abs", relay.qnn.op.abs)
 register_unary_qnn("log", relay.qnn.op.log)
+
+
+@register_fake_quantization_to_integer("take")
+def take(expr, type_map):
+    """Rewrite a take op"""
+    arg = expr.args[0]
+    indices = expr.args[1]
+    t = type_map[arg]
+
+    out = relay.op.take(arg, indices, **expr.attrs)
+    return [out, t]

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -1100,5 +1100,19 @@ def test_fq_qat_intermediate_infertype():
     compare_expected_fq_qat_to_int(expr, expected_expr, [x_np])
 
 
+def test_fake_quantize_take():
+    x = relay.var("x", shape=[33, 11], dtype="int8")
+    indices_np = np.random.randint(0, 33, size=[37], dtype="int32")
+    indices = relay.const(indices_np)
+
+    x = relay.qnn.op.dequantize(x, relay.const(2.0), relay.const(114))
+    op = relay.op.take(x, indices, axis=0)
+    op = relay.qnn.op.quantize(op, relay.const(2.0), relay.const(114), out_dtype="uint8")
+
+    x_np = np.random.randint(-25, 25, size=[33, 11], dtype="int8")
+
+    compare_fq_to_int(op, [x_np])
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Just using the vanila `take` op should be fine. I referred to how `pad` op is handled.

Note this implementation works only for constant indices. To handle non constant indices, I'm guessing we should modify `src/relay/transforms/fake_quantization_to_integer.cc` so that it allows integer inputs without dequantize. Specifically, I think it should capture the following pattern:
```
x  i
|  |
dq |
|  |
\  /
take
 |
 q
```
but I'm not 100% sure.