### PR TITLE
[Unity][Refactor] Use NameSupply for unique symbol generation and remove NameTable

### DIFF
--- a/include/tvm/ir/name_supply.h
+++ b/include/tvm/ir/name_supply.h
@@ -54,7 +54,9 @@ class NameSupplyNode : public Object {
    * \brief Generates a unique name from this NameSupply.
    * \param name The name from which the generated name is derived.
    * \param add_prefix If set to true, then the prefix of this NameSupply will be prepended to the
-   * name. \return A unique name.
+   * name.
+   * \param add_underscore If set to true, add '_' between prefix and a digit.
+   * \return A unique name.
    */
   String FreshName(const String& name, bool add_prefix = true, bool add_underscore = true);
 
@@ -93,6 +95,7 @@ class NameSupplyNode : public Object {
   /*!
    * \brief Function that will generate a unique name.
    * \param name The name to be used as a base.
+   * \param add_underscore If set to true, add '_' between prefix and a digit.
    * \return A unique name.
    */
   std::string GetUniqueName(std::string name, bool add_underscore = true);
@@ -115,6 +118,12 @@ class NameSupply : public ObjectRef {
   TVM_DLL explicit NameSupply(const String& prefix,
                               std::unordered_map<std::string, int> name_map = {});
 
+  /*!
+   * \brief Construct NameSupply with a name map created from the given iterator range and
+   * the functor.
+   *
+   * The functor should return the name of the dereferenced object.
+   */
   template <typename Iter, typename Lambda>
   TVM_DLL explicit NameSupply(Iter begin, Iter end, Lambda f)
       : NameSupply("", GetNameMap(begin, end, f)) {}

--- a/include/tvm/ir/name_supply.h
+++ b/include/tvm/ir/name_supply.h
@@ -24,6 +24,7 @@
 #ifndef TVM_IR_NAME_SUPPLY_H_
 #define TVM_IR_NAME_SUPPLY_H_
 
+#include <algorithm>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/include/tvm/ir/name_supply.h
+++ b/include/tvm/ir/name_supply.h
@@ -56,7 +56,7 @@ class NameSupplyNode : public Object {
    * \param add_prefix If set to true, then the prefix of this NameSupply will be prepended to the
    * name. \return A unique name.
    */
-  String FreshName(const String& name, bool add_prefix = true);
+  String FreshName(const String& name, bool add_prefix = true, bool add_underscore = true);
 
   /*!
    * \brief Reserves an existing name with this NameSupply.
@@ -95,7 +95,7 @@ class NameSupplyNode : public Object {
    * \param name The name to be used as a base.
    * \return A unique name.
    */
-  std::string GetUniqueName(std::string name);
+  std::string GetUniqueName(std::string name, bool add_underscore = true);
 
   /*! \brief A map that is used to generate unique names. */
   std::unordered_map<std::string, int> name_map;

--- a/include/tvm/relax/binding_rewrite.h
+++ b/include/tvm/relax/binding_rewrite.h
@@ -24,9 +24,9 @@
 
 #ifndef TVM_RELAX_BINDING_REWRITE_H_
 
+#include <tvm/ir/name_supply.h>
 #include <tvm/relax/analysis.h>
 #include <tvm/relax/expr.h>
-#include <tvm/relax/utils.h>
 
 #include <map>
 #include <set>
@@ -52,7 +52,8 @@ class DataflowBlockRewriteNode : public Object {
   }
   /*! \brief Insert an expression as VarBinding with automatic variable name. */
   void Add(Expr expr, bool is_dfvar = false) {
-    Add(name_table_.GetUniqueName("tmp"), expr, is_dfvar);
+    Add(name_supply_->FreshName("tmp", /*add_prefix*/ false, /*add_underscore*/ false), expr,
+        is_dfvar);
   }
   /*! \brief Remove the definition statement of an unused variable. */
   void RemoveUnused(Var unused, bool allow_undef = false);
@@ -85,7 +86,7 @@ class DataflowBlockRewriteNode : public Object {
   Array<Var> fn_outputs_;                //!< Variables required by function outputs.
 
  private:
-  NameTable name_table_;  //!< Name table for tracking and generating unique names.
+  NameSupply name_supply_;  //!< Name supply for tracking and generating unique names.
 };
 
 /*!

--- a/include/tvm/relax/binding_rewrite.h
+++ b/include/tvm/relax/binding_rewrite.h
@@ -52,8 +52,7 @@ class DataflowBlockRewriteNode : public Object {
   }
   /*! \brief Insert an expression as VarBinding with automatic variable name. */
   void Add(Expr expr, bool is_dfvar = false) {
-    Add(name_supply_->FreshName("tmp", /*add_prefix*/ false, /*add_underscore*/ false), expr,
-        is_dfvar);
+    Add(name_supply_->FreshName("tmp"), expr, is_dfvar);
   }
   /*! \brief Remove the definition statement of an unused variable. */
   void RemoveUnused(Var unused, bool allow_undef = false);

--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -24,6 +24,7 @@
 #ifndef TVM_RELAX_BLOCK_BUILDER_H_
 #define TVM_RELAX_BLOCK_BUILDER_H_
 
+#include <tvm/ir/name_supply.h>
 #include <tvm/arith/analyzer.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/utils.h>
@@ -67,11 +68,11 @@ class BlockBuilderNode : public Object {
   // Global Context management
   //-------------------------------
   /*!
-   * \brief Get the name table for generating unique names.
+   * \brief Get the name supply for generating unique names.
    *
-   * \return The name table.
+   * \return The name supply.
    */
-  virtual NameTable* name_table() = 0;
+  virtual NameSupply name_supply() = 0;
 
   /*!
    * \brief Get the context IRModule in this builder.

--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -24,8 +24,8 @@
 #ifndef TVM_RELAX_BLOCK_BUILDER_H_
 #define TVM_RELAX_BLOCK_BUILDER_H_
 
-#include <tvm/ir/name_supply.h>
 #include <tvm/arith/analyzer.h>
+#include <tvm/ir/name_supply.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/utils.h>
 #include <tvm/runtime/object.h>

--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -38,29 +38,6 @@ namespace tvm {
 namespace relax {
 
 /*!
- * \brief Utility data structure for generating unique names for IR construction.
- */
-class NameTable {
- public:
-  /*!
-   * \brief Generate a unique name with a specified prefix.
-   * \param prefix The name prefix.
-   * \return The generated name.
-   */
-  inline std::string GetUniqueName(std::string prefix) {
-    return name_sup->FreshName(prefix, /*add_prefix*/ false, /*add_underscore*/ false);
-  }
-
-  NameTable() : name_sup("") {}
-
-  template <typename Iter, typename Lambda>
-  explicit NameTable(Iter begin, Iter end, Lambda f) : name_sup(begin, end, f) {}
-
- private:
-  NameSupply name_sup;
-};
-
-/*!
  * \brief Bind the variables to a Relax expression. This is a helper
  * function usually called by other pass functions to help optimizations.
  * If any free variables are introduced into a function, those are added

--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -28,12 +28,6 @@
 #include <tvm/ir/name_supply.h>
 #include <tvm/runtime/logging.h>
 
-#include <algorithm>
-#include <cctype>
-#include <string>
-#include <type_traits>
-#include <unordered_map>
-
 namespace tvm {
 namespace relax {
 

--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -25,7 +25,6 @@
 #define TVM_RELAX_UTILS_H_
 
 #include <tvm/ir/module.h>
-#include <tvm/ir/name_supply.h>
 #include <tvm/runtime/logging.h>
 
 namespace tvm {

--- a/src/ir/name_supply.cc
+++ b/src/ir/name_supply.cc
@@ -83,7 +83,6 @@ std::string NameSupplyNode::GetUniqueName(std::string name, bool add_underscore)
       std::ostringstream os;
       os << name << (add_underscore? "_" : "") << (++it->second);
       new_name = os.str();
-      LOG(INFO) << new_name;
     }
     return new_name;
   }

--- a/src/ir/name_supply.cc
+++ b/src/ir/name_supply.cc
@@ -81,7 +81,7 @@ std::string NameSupplyNode::GetUniqueName(std::string name, bool add_underscore)
     auto new_name = name;
     while (!name_map.insert({new_name, 0}).second) {
       std::ostringstream os;
-      os << name << (add_underscore? "_" : "") << (++it->second);
+      os << name << (add_underscore ? "_" : "") << (++it->second);
       new_name = os.str();
     }
     return new_name;

--- a/src/ir/name_supply.cc
+++ b/src/ir/name_supply.cc
@@ -43,12 +43,12 @@ String NameSupplyNode::ReserveName(const String& name, bool add_prefix) {
   return final_name;
 }
 
-String NameSupplyNode::FreshName(const String& name, bool add_prefix) {
+String NameSupplyNode::FreshName(const String& name, bool add_prefix, bool add_underscore) {
   String unique_name = name;
   if (add_prefix) {
     unique_name = add_prefix_to_name(name);
   }
-  unique_name = GetUniqueName(unique_name);
+  unique_name = GetUniqueName(unique_name, add_underscore);
   return unique_name;
 }
 
@@ -72,7 +72,7 @@ String NameSupplyNode::add_prefix_to_name(const String& name) {
   return ss.str();
 }
 
-std::string NameSupplyNode::GetUniqueName(std::string name) {
+std::string NameSupplyNode::GetUniqueName(std::string name, bool add_underscore) {
   for (size_t i = 0; i < name.size(); ++i) {
     if (name[i] == '.') name[i] = '_';
   }
@@ -81,8 +81,9 @@ std::string NameSupplyNode::GetUniqueName(std::string name) {
     auto new_name = name;
     while (!name_map.insert({new_name, 0}).second) {
       std::ostringstream os;
-      os << name << "_" << (++it->second);
+      os << name << (add_underscore? "_" : "") << (++it->second);
       new_name = os.str();
+      LOG(INFO) << new_name;
     }
     return new_name;
   }

--- a/src/relax/ir/binding_rewrite.cc
+++ b/src/relax/ir/binding_rewrite.cc
@@ -43,8 +43,8 @@ DataflowBlockRewrite::DataflowBlockRewrite(DataflowBlock dfb, Function root_fn) 
   auto p = FunctionUseDef(root_fn);
   n->to_users_ = std::move(p.first);
   n->fn_outputs_ = std::move(p.second);
-  n->name_table_ = NameTable(n->to_users_.begin(), n->to_users_.end(),
-                             [](const auto& p) { return p.first->name_hint(); });
+  n->name_supply_ = NameSupply(n->to_users_.begin(), n->to_users_.end(),
+                               [](const auto& p) { return p.first->name_hint(); });
 
   data_ = std::move(n);
 }

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -252,10 +252,6 @@ class BlockBuilderImpl : public BlockBuilderNode {
 
   arith::Analyzer* GetAnalyzer() final { return &analyzer_; }
 
-  std::string GetUniqueName(const std::string& prefix) {
-    return name_supply_->FreshName(prefix, /*add_prefix*/ false, /*add_underscore*/ false);
-  }
-
  protected:
   /*!
    * \brief A representation of a block frame.
@@ -374,6 +370,10 @@ class BlockBuilderImpl : public BlockBuilderNode {
   }
 
  private:
+  std::string GetUniqueName(const std::string& prefix) {
+    return name_supply_->FreshName(prefix, /*add_prefix*/ false, /*add_underscore*/ false);
+  }
+
   /*!
    * \brief A hashmap to store the mapping of Relax functions and TIR PrimFuncs
    * in context_mod to their GlobalVar to avoid generating duplicated functions.

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -28,7 +28,6 @@
 #include <tvm/relax/struct_info.h>
 #include <tvm/relax/struct_info_functor.h>
 #include <tvm/relax/type.h>
-#include <tvm/relax/utils.h>
 #include <tvm/relay/op.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/tir/function.h>
@@ -55,7 +54,8 @@ namespace relax {
 //---------------------------------------
 class BlockBuilderImpl : public BlockBuilderNode {
  public:
-  explicit BlockBuilderImpl(IRModule context_mod) : context_mod_(std::move(context_mod)) {}
+  explicit BlockBuilderImpl(IRModule context_mod)
+      : name_supply_(""), context_mod_(std::move(context_mod)) {}
 
   ~BlockBuilderImpl() {
     if (!block_stack_.empty()) {
@@ -66,7 +66,7 @@ class BlockBuilderImpl : public BlockBuilderNode {
   //-------------------------------
   // Global Context management
   //-------------------------------
-  NameTable* name_table() final { return name_table_.get(); }
+  NameSupply name_supply() final { return name_supply_; }
 
   IRModule GetContextIRModule() const final { return context_mod_; }
 
@@ -76,9 +76,9 @@ class BlockBuilderImpl : public BlockBuilderNode {
     if (it == ctx_func_dedup_map_->end()) {
       context_mod_.CopyOnWrite();
 
-      String func_name = name_table_->GetUniqueName(func_name_hint);
+      String func_name = GetUniqueName(func_name_hint);
       while (context_mod_->ContainGlobalVar(func_name)) {
-        func_name = name_table_->GetUniqueName(func_name_hint);
+        func_name = GetUniqueName(func_name_hint);
       }
       GlobalVar gvar = GlobalVar(func_name);
 
@@ -252,6 +252,10 @@ class BlockBuilderImpl : public BlockBuilderNode {
 
   arith::Analyzer* GetAnalyzer() final { return &analyzer_; }
 
+  std::string GetUniqueName(const std::string& prefix) {
+    return name_supply_->FreshName(prefix, /*add_prefix*/ false, /*add_underscore*/ false);
+  }
+
  protected:
   /*!
    * \brief A representation of a block frame.
@@ -300,8 +304,8 @@ class BlockBuilderImpl : public BlockBuilderNode {
   /*! \brief A binding table that maps var to value. */
   std::unordered_map<Id, Expr, ObjectPtrHash, ObjectPtrEqual> binding_table_;
 
-  /*! \brief A name table to get unique names for IR construction. */
-  std::unique_ptr<NameTable> name_table_ = std::make_unique<NameTable>();
+  /*! \brief A name supply to get unique names for IR construction. */
+  NameSupply name_supply_;
 
   /*! \brief The IRModule being built by the BlockBuilder. */
   IRModule context_mod_;
@@ -364,7 +368,7 @@ class BlockBuilderImpl : public BlockBuilderNode {
     if (name_hint.empty()) {
       name_hint = is_dataflow ? "lv" : "gv";
     }
-    Id vid = Id(name_table_->GetUniqueName(name_hint));
+    Id vid = Id(GetUniqueName(name_hint));
     return is_dataflow ? DataflowVar(vid, /*struct_info_annotation=*/NullOpt)
                        : Var(vid, /*struct_info_annotation=*/NullOpt);
   }
@@ -921,7 +925,8 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitNormalized")
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderGetUniqueName")
     .set_body_typed([](BlockBuilder builder, String name_hint) {
-      return builder->name_table()->GetUniqueName(name_hint);
+      return builder->name_supply()->FreshName(name_hint, /*add_prefix*/ false,
+                                               /*add_underscore*/ false);
     });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderAddFunction")


### PR DESCRIPTION
`NameTable` is used in Relax code but we now have `NameSupply` in `main`. They serve exactly the same purpose (gensym), so we should use the more standard one (`NameSupply`) for consistency. 

@tqchen @slyubomirsky 