### PR TITLE
[Target] Fix Jetson AGX Xavier CPU core count

### DIFF
--- a/src/target/tag.cc
+++ b/src/target/tag.cc
@@ -92,7 +92,7 @@ TVM_REGISTER_TARGET_TAG("nvidia/jetson-agx-xavier")
                  {"host", Map<String, ObjectRef>{{"kind", String("llvm")},
                                                  {"mtriple", String("aarch64-linux-gnu")},
                                                  {"mcpu", String("carmel")},
-                                                 {"num-cores", Integer(4)}}}});
+                                                 {"num-cores", Integer(8)}}}});
 
 #define TVM_REGISTER_CUDA_TAG(Name, Arch, SharedMem, RegPerBlock) \
   TVM_REGISTER_TARGET_TAG(Name).set_config({                      \


### PR DESCRIPTION
It has 8 cores.
[NVIDIA Jetson AGX Xavier Delivers 32 TeraOps for New Era of AI in Robotics | NVIDIA Technical Blog](https://developer.nvidia.com/blog/nvidia-jetson-agx-xavier-32-teraops-ai-robotics/)

cc @junrushao @zxybazh