### PR TITLE
[Unity][Analysis] Get symbolic TIR vars from struct info

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -260,6 +260,14 @@ TVM_DLL bool IsBaseOf(const StructInfo& base, const StructInfo& derived,
 TVM_DLL StructInfo StructInfoLCA(const StructInfo& lhs, const StructInfo& rhs,
                                  arith::Analyzer* ana = nullptr);
 
+/*!
+ * \brief Get the TIR variables that appear in the input struct info.
+ * The returned list is deduplicated - each TIR variable will appear at most once.
+ * \param sinfo The struct info object to be analyzed.
+ * \return The list of TIR variables that appear in the input struct info.
+ */
+TVM_DLL Array<tir::Var> TIRVarsInStructInfo(const StructInfo& sinfo);
+
 //-----------------------------------
 // General IR analysis
 //-----------------------------------

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -167,6 +167,23 @@ def struct_info_lca(lhs: StructInfo, rhs: StructInfo) -> StructInfo:
     return _ffi_api.StructInfoLCA(lhs, rhs)  # type: ignore
 
 
+def tir_vars_in_struct_info(sinfo: StructInfo) -> List[tir.Var]:
+    """Get the TIR variables that appear in the input struct info.
+    The returned list is deduplicated - each TIR variable will appear at most once.
+
+    Parameters
+    ----------
+    sinfo : StructInfo
+        The struct info object to be analyzed.
+
+    Returns
+    -------
+    ret : List[tir.Var]
+        The list of TIR variables that appear in the input struct info.
+    """
+    return _ffi_api.TIRVarsInStructInfo(sinfo)  # type: ignore
+
+
 def bound_vars(expr: Expr) -> List[Var]:
     """
     Return all bound variables from expression expr.

--- a/tests/python/relax/test_analysis_struct_info_analysis.py
+++ b/tests/python/relax/test_analysis_struct_info_analysis.py
@@ -557,5 +557,22 @@ def test_struct_info_lca():
     _check_lca(fopaque2(), fn_info_shape(1), fopaque2())
 
 
+def test_tir_vars_in_struct_info():
+    n, m = tir.Var("n", "int64"), tir.Var("m", "int64")
+    shape0 = rx.ShapeStructInfo([1, n, 3])
+    shape1 = rx.ShapeStructInfo([1, 2 * n, n, m])
+    tensor0 = rx.TensorStructInfo([1, n, 3], "int32")
+    tensor1 = rx.TensorStructInfo([1, 2 * n, n, m], "int32")
+    func = rx.FuncStructInfo(
+        [rx.TensorStructInfo([1, 2 * n, n, m], "int32")], rx.TensorStructInfo([1, n, 3], "int32")
+    )
+
+    tvm.ir.assert_structural_equal(rx.analysis.tir_vars_in_struct_info(shape0), [n])
+    tvm.ir.assert_structural_equal(rx.analysis.tir_vars_in_struct_info(shape1), [n, m])
+    tvm.ir.assert_structural_equal(rx.analysis.tir_vars_in_struct_info(tensor0), [n])
+    tvm.ir.assert_structural_equal(rx.analysis.tir_vars_in_struct_info(tensor1), [n, m])
+    tvm.ir.assert_structural_equal(rx.analysis.tir_vars_in_struct_info(func), [n, m])
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR adds an analysis function which helps to fetch all the TIR variables that appear in a given struct info object. This is helpful for passes that need to be aware of symbolic shape dynamism.