### PR TITLE
[Unity] Memory planning with TIR var upper bound

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -109,6 +109,19 @@ TVM_DLL Pass RewriteDataflowReshape();
  * The pass will reuse allocated memory to its best effort, in order to
  * reduce the total amount of allocated memory size.
  *
+ * The pass "supports" dynamic shape in the way of TIR variable upper bound
+ * annotation. We can optionally annotate the attribute "tir_var_upper_bound"
+ * to Relax functions. The attribute value is a dict from strings to integers,
+ * denoting the name of TIR variables to the upper bound values of the TIR vars.
+ * Note: The annotated upper bound attribute only applies to TIR vars in the
+ * function signature for clarity.
+ *
+ * For example, we can annotate a Relax function with
+ *   `R.func_attr({"tir_var_upper_bound": {"n": 1024}})`.
+ * It means the maximum value of variable that names "n" in the function
+ * signature will have upper bound 1024. And we will use 1024 as its value
+ * during memory planning.
+ *
  * \return The pass.
  */
 TVM_DLL Pass StaticPlanBlockMemory();

--- a/python/tvm/relax/analysis/estimate_memory_usage.py
+++ b/python/tvm/relax/analysis/estimate_memory_usage.py
@@ -153,9 +153,10 @@ def estimate_memory_usage(mod: Union[IRModule, Function]) -> str:
                 "memory allocation(s) with total size "
                 "{0:.4} GB.\n".format(self.planned_alloc_mem / 2**30)
             )
-            est += " * Memory planning reduces constant memory size to " "{0:.1%}.".format(
-                self.planned_alloc_mem / self.total_alloc_tensor_mem
-            )
+            if self.total_alloc_tensor_mem != 0:
+                est += " * Memory planning reduces constant memory size to " "{0:.1%}.".format(
+                    self.planned_alloc_mem / self.total_alloc_tensor_mem
+                )
             return "- Function " + func_name + ":\n" + est
 
     if isinstance(mod, Function):

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -131,6 +131,20 @@ def StaticPlanBlockMemory() -> tvm.ir.transform.Pass:
     """The static memory planning pass on BindingBlock level.
     The pass will reuse allocated memory to its best effort, in order to
     reduce the total amount of allocated memory size.
+
+    The pass "supports" dynamic shape in the way of TIR variable upper bound
+    annotation. We can optionally annotate the attribute "tir_var_upper_bound"
+    to Relax functions. The attribute value is a dict from strings to integers,
+    denoting the name of TIR variables to the upper bound values of the TIR vars.
+    Note: The annotated upper bound attribute only applies to TIR vars in the
+    function signature for clarity.
+
+    For example, we can annotate a Relax function with
+      `R.func_attr({"tir_var_upper_bound": {"n": 1024}})`.
+    It means the maximum value of variable that names "n" in the function
+    signature will have upper bound 1024. And we will use 1024 as its value
+    during memory planning.
+
     Returns
     -------
     ret : tvm.ir.transform.Pass

--- a/tests/python/relax/test_transform_static_plan_block_memory.py
+++ b/tests/python/relax/test_transform_static_plan_block_memory.py
@@ -836,5 +836,178 @@ def test_multiple_functions():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_tir_var_upper_bound():
+    # fmt: off
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func
+        def add(rxplaceholder: T.handle, rxplaceholder_1: T.handle, T_add: T.handle):
+            T.evaluate(0)
+
+        @T.prim_func
+        def reshape(rxplaceholder: T.handle, T_reshape: T.handle):
+            T.evaluate(0)
+
+        @T.prim_func
+        def relu(rxplaceholder: T.handle, compute: T.handle):
+            T.evaluate(0)
+
+        @T.prim_func
+        def log(rxplaceholder: T.handle, compute: T.handle):
+            T.evaluate(0)
+
+        @T.prim_func
+        def exp(rxplaceholder: T.handle, compute: T.handle):
+            T.evaluate(0)
+
+        @T.prim_func
+        def pad(rxplaceholder: T.handle, PadInput: T.handle):
+            T.evaluate(0)
+
+        @R.function
+        def main(x: R.Tensor((2, "n"), dtype="float32")) -> R.Tensor(("2 * n + 2",), dtype="float32"):
+            R.func_attr({"tir_var_upper_bound": {"n": 4}})
+            n = T.int64()
+            cls = Module
+            alloc: R.Tensor((2, n), dtype="float32") = R.builtin.alloc_tensor(R.shape([2, n]), dtype="float32", runtime_device_index=0)
+            _: R.Tuple() = cls.exp(x, alloc)
+            lv: R.Tensor((2, n), dtype="float32") = alloc
+            lv1: R.Tensor((2 * n,), dtype="float32") = R.reshape(lv, (2 * n,))
+            alloc1: R.Tensor((2 * n,), dtype="float32") = R.builtin.alloc_tensor(R.shape([2 * n]), dtype="float32", runtime_device_index=0)
+            _1: R.Tuple() = cls.relu(lv1, alloc1)
+            lv2: R.Tensor((2 * n,), dtype="float32") = alloc1
+            alloc2: R.Tensor((2 * n,), dtype="float32") = R.builtin.alloc_tensor(R.shape([2 * n]), dtype="float32", runtime_device_index=0)
+            _2: R.Tuple() = cls.add(lv2, R.const(1, "float32"), alloc2)
+            lv3: R.Tensor((2 * n,), dtype="float32") = alloc2
+            alloc3: R.Tensor((2 * n + 2,), dtype="float32") = R.builtin.alloc_tensor(R.shape([2 * n + 2]), dtype="float32", runtime_device_index=0)
+            _3: R.Tuple() = cls.pad(lv3, alloc3)
+            lv4: R.Tensor((2 * n + 2,), dtype="float32") = alloc3
+            alloc4: R.Tensor((2 * n + 2,), dtype="float32") = R.builtin.alloc_tensor(R.shape([10]), dtype="float32", runtime_device_index=0)
+            _4: R.Tuple() = cls.log(lv4, alloc4)
+            gv: R.Tensor((2 * n + 2,), dtype="float32") = alloc4
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @T.prim_func
+        def add(rxplaceholder: T.handle, rxplaceholder_1: T.handle, T_add: T.handle):
+            T.evaluate(0)
+
+        @T.prim_func
+        def exp(rxplaceholder: T.handle, compute: T.handle):
+            T.evaluate(0)
+
+        @T.prim_func
+        def log(rxplaceholder: T.handle, compute: T.handle):
+            T.evaluate(0)
+
+        @T.prim_func
+        def pad(rxplaceholder: T.handle, PadInput: T.handle):
+            T.evaluate(0)
+
+        @T.prim_func
+        def relu(rxplaceholder: T.handle, compute: T.handle):
+            T.evaluate(0)
+
+        @T.prim_func
+        def reshape(rxplaceholder: T.handle, T_reshape: T.handle):
+            T.evaluate(0)
+
+        @R.function
+        def main(x: R.Tensor((2, "n"), dtype="float32")) -> R.Tensor(("2 * n + 2",), dtype="float32"):
+            n = T.int64()
+            R.func_attr({"tir_var_upper_bound": {"n": 4}})
+            cls = Expected
+            storage: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            alloc: R.Tensor((2, n), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([2, n]), R.dtype("float32"))
+            _: R.Tuple = cls.exp(x, alloc)
+            lv: R.Tensor((2, n), dtype="float32") = alloc
+            lv1: R.Tensor((2 * n,), dtype="float32") = R.reshape(lv, R.shape([2 * n]))
+            storage1: R.Object = R.memory.alloc_storage(R.shape([40]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            alloc1: R.Tensor((2 * n,), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([2 * n]), R.dtype("float32"))
+            _1: R.Tuple = cls.relu(lv1, alloc1)
+            __1: R.Tuple = R.memory.kill_tensor(alloc)
+            _1_1: R.Tuple = R.memory.kill_tensor(lv1)
+            lv2: R.Tensor((2 * n,), dtype="float32") = alloc1
+            alloc2: R.Tensor((2 * n,), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([2 * n]), R.dtype("float32"))
+            _2: R.Tuple = cls.add(lv2, R.const(1, "float32"), alloc2)
+            _2_1: R.Tuple = R.memory.kill_tensor(alloc1)
+            lv3: R.Tensor((2 * n,), dtype="float32") = alloc2
+            alloc3: R.Tensor((2 * n + 2,), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([2 * n + 2]), R.dtype("float32"))
+            _3: R.Tuple = cls.pad(lv3, alloc3)
+            _3_1: R.Tuple = R.memory.kill_tensor(alloc2)
+            lv4: R.Tensor((2 * n + 2,), dtype="float32") = alloc3
+            alloc4: R.Tensor((2 * n + 2,), dtype="float32") = R.builtin.alloc_tensor(R.shape([10]), R.dtype("float32"), R.prim_value(0))
+            _4: R.Tuple = cls.log(lv4, alloc4)
+            _4_1: R.Tuple = R.memory.kill_tensor(alloc3)
+            gv: R.Tensor((2 * n + 2,), dtype="float32") = alloc4
+            _5: R.Tuple = R.memory.kill_storage(storage)
+            _6: R.Tuple = R.memory.kill_storage(storage1)
+            return gv
+    # fmt: on
+
+    mod = relax.transform.StaticPlanBlockMemory()(Module)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_tir_var_decreasing_monotone():
+    # fmt: off
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def tir_exp(var_rxplaceholder: T.handle, var_compute: T.handle):
+            T.evaluate(0)
+
+        @R.function
+        def main(x: R.Tensor(("n", "m", "T.max(n - m, 1)"), dtype="float32")) -> R.Tensor(("n", "m", "T.max(n - m, 1)"), dtype="float32"):
+            n = T.int64()
+            m = T.int64()
+            R.func_attr({"tir_var_upper_bound": {"m": 5, "n": 20}})
+            cls = Module
+            alloc: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = R.builtin.alloc_tensor(R.shape([n, m, T.max(n - m, 1)]), R.dtype("float32"), R.prim_value(0))
+            _: R.Tuple = cls.tir_exp(x, alloc)
+            y: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = alloc
+            alloc1: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = R.builtin.alloc_tensor(R.shape([n, m, T.max(n - m, 1)]), R.dtype("float32"), R.prim_value(0))
+            _1: R.Tuple = cls.tir_exp(y, alloc1)
+            z: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = alloc1
+            alloc2: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = R.builtin.alloc_tensor(R.shape([n, m, T.max(n - m, 1)]), R.dtype("float32"), R.prim_value(0))
+            _2: R.Tuple = cls.tir_exp(z, alloc2)
+            r: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = alloc2
+            return r
+
+    @I.ir_module
+    class Expected:
+        @T.prim_func
+        def tir_exp(var_rxplaceholder: T.handle, var_compute: T.handle):
+            T.evaluate(0)
+
+        @R.function
+        def main(x: R.Tensor(("n", "m", "T.max(n - m, 1)"), dtype="float32")) -> R.Tensor(("n", "m", "T.max(n - m, 1)"), dtype="float32"):
+            n = T.int64()
+            m = T.int64()
+            R.func_attr({"tir_var_upper_bound": {"m": 5, "n": 20}})
+            cls = Expected
+            storage: R.Object = R.memory.alloc_storage(R.shape([8000]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            alloc: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([n, m, T.max(n - m, 1)]), R.dtype("float32"))
+            _: R.Tuple = cls.tir_exp(x, alloc)
+            y: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = alloc
+            storage1: R.Object = R.memory.alloc_storage(R.shape([8000]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            alloc1: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([n, m, T.max(n - m, 1)]), R.dtype("float32"))
+            _1: R.Tuple = cls.tir_exp(y, alloc1)
+            __1: R.Tuple = R.memory.kill_tensor(alloc)
+            z: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = alloc1
+            alloc2: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = R.builtin.alloc_tensor(R.shape([n, m, T.max(n - m, 1)]), R.dtype("float32"), R.prim_value(0))
+            _2: R.Tuple = cls.tir_exp(z, alloc2)
+            _1_1: R.Tuple = R.memory.kill_tensor(alloc1)
+            r: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = alloc2
+            _2_1: R.Tuple = R.memory.kill_storage(storage)
+            _3: R.Tuple = R.memory.kill_storage(storage1)
+            return r
+    # fmt: on
+
+    mod = relax.transform.StaticPlanBlockMemory()(Module)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR enhances the memory planning pass with TIR var upper bound
annotation, so that it supports dynamic shape cases when we have
an estimate for the maximum values of the dynamic vars.