### PR TITLE
[Unity] Support Simple Dynamic-Shape-Aware in FuseTIR

### DIFF
--- a/src/runtime/contrib/json/json_runtime.h
+++ b/src/runtime/contrib/json/json_runtime.h
@@ -59,7 +59,7 @@ class JSONRuntimeBase : public ModuleNode {
   const char* type_key() const override { return "json"; }  // May be overridden
 
   /*! \brief Get the property of the runtime module .*/
-  int GetPropertyMask() const {
+  int GetPropertyMask() const override {
     return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
   }
 


### PR DESCRIPTION
In the last PR https://github.com/apache/tvm/pull/14396, we enable dynamic-shape-aware fusion in FuseOps. In this PR, we support the following FuseTIR pass for simple cases.

This PR also fixes a minor compilation warning in `json_runtime.h`

cc @tqchen @MasterJH5574 