### PR TITLE
[Fix] symbolic thread extent program compilation

### DIFF
--- a/src/tir/transforms/memhammer_lower_auto_copy.cc
+++ b/src/tir/transforms/memhammer_lower_auto_copy.cc
@@ -750,7 +750,9 @@ class ThreadExtentCollector : public StmtVisitor {
   }
   void VisitStmt_(const ForNode* op) final {
     if (op->thread_binding.defined() && op->thread_binding.value()->iter_type == kThreadIndex) {
-      thread_extent_.Set(op->thread_binding.value()->thread_tag, Downcast<Integer>(op->extent));
+      if (const auto* extent = op->extent.as<IntImmNode>()) {
+        thread_extent_.Set(op->thread_binding.value()->thread_tag, GetRef<Integer>(extent));
+      }
     }
     StmtVisitor::VisitStmt_(op);
   }


### PR DESCRIPTION
Fix when compiling a program with symbolic thread extent, which is important to dyn kernels.

```py
@I.ir_module
class Module:
    @T.prim_func
    def matmul(var_rxplaceholder: T.handle, var_rxplaceholder_1: T.handle, var_matmul: T.handle):
        T.func_attr({"tir.noalias": T.bool(True)})
        n = T.int64()
        rxplaceholder = T.match_buffer(var_rxplaceholder, (n, T.int64(4)))
        rxplaceholder_1 = T.match_buffer(var_rxplaceholder_1, (T.int64(4), n))
        matmul_1 = T.match_buffer(var_matmul, (n, n))
        # with T.block("root"):
        for i0 in T.thread_binding(n, thread="blockIdx.x"):
            for i1 in T.thread_binding(n, thread="threadIdx.x"):
                for k in range(T.int64(4)):
                    with T.block("matmul"):
                        v_i0, v_i1, v_k = T.axis.remap("SSR", [i0, i1, k])
                        T.reads(rxplaceholder[v_i0, v_k], rxplaceholder_1[v_k, v_i1])
                        T.writes(matmul_1[v_i0, v_i1])
                        with T.init():
                            matmul_1[v_i0, v_i1] = T.float32(0)
                        matmul_1[v_i0, v_i1] = matmul_1[v_i0, v_i1] + rxplaceholder[v_i0, v_k] * rxplaceholder_1[v_k, v_i1]

    @R.function
    def main(x: R.Tensor(("n", 4), dtype="float32"), y: R.Tensor((4, "n"), dtype="float32")) -> R.Tensor(("n", "n"), dtype="float32"):
        n = T.int64()
        cls = Module
        gv = R.call_tir(cls.matmul, (x, y), out_sinfo=R.Tensor((n, n), dtype="float32"))
        return gv
```
