### PR TITLE
[Object] Implemented .as<T> for ObjectRef param, returns Optional<T>

### DIFF
--- a/include/tvm/runtime/container/optional.h
+++ b/include/tvm/runtime/container/optional.h
@@ -153,6 +153,15 @@ class Optional : public ObjectRef {
   static constexpr bool _type_is_nullable = true;
 };
 
+template <typename ObjectRefType, typename>
+inline Optional<ObjectRefType> ObjectRef::as() const {
+  if (auto* ptr = this->as<typename ObjectRefType::ContainerType>()) {
+    return GetRef<ObjectRefType>(ptr);
+  } else {
+    return NullOptType{};
+  }
+}
+
 }  // namespace runtime
 
 // expose the functions to the root namespace.

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -651,8 +651,8 @@ class CanonicalSimplifier::Impl : public RewriteSimplifier::Impl {
    * \return The transformed SplitExpr.
    */
   SplitExpr ToSplitExpr(PrimExpr expr) {
-    if (const auto* op = expr.as<SplitExprNode>()) {
-      return GetRef<SplitExpr>(op);
+    if (auto op = expr.as<SplitExpr>()) {
+      return op.value();
     }
     if (const auto* op = expr.as<SumExprNode>()) {
       if (op->base == 0 && op->args.size() == 1) return op->args[0];
@@ -694,8 +694,8 @@ class CanonicalSimplifier::Impl : public RewriteSimplifier::Impl {
    * \return The transformed SumExpr.
    */
   SumExpr ToSumExpr(PrimExpr expr) {
-    if (const auto* op = expr.as<SumExprNode>()) {
-      return GetRef<SumExpr>(op);
+    if (auto op = expr.as<SumExpr>()) {
+      return op.value();
     }
     ObjectPtr<SumExprNode> n = make_object<SumExprNode>();
     n->dtype = expr.dtype();
@@ -727,8 +727,8 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const AddNode* op) {
 
   if (const auto* op = b.as<IntImmNode>()) {
     ret.CopyOnWrite()->AddToSelf(op->value);
-  } else if (const auto* op = b.as<SumExprNode>()) {
-    ret.CopyOnWrite()->AddToSelf(GetRef<SumExpr>(op), 1);
+  } else if (auto op = b.as<SumExpr>()) {
+    ret.CopyOnWrite()->AddToSelf(op.value(), 1);
   } else {
     ret.CopyOnWrite()->AddToSelf(ToSplitExpr(b), 1);
   }
@@ -751,8 +751,8 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const SubNode* op) {
 
   if (const auto* op = b.as<IntImmNode>()) {
     ret.CopyOnWrite()->AddToSelf(-op->value);
-  } else if (const auto* op = b.as<SumExprNode>()) {
-    ret.CopyOnWrite()->AddToSelf(GetRef<SumExpr>(op), -1);
+  } else if (auto op = b.as<SumExpr>()) {
+    ret.CopyOnWrite()->AddToSelf(op.value(), -1);
   } else {
     ret.CopyOnWrite()->AddToSelf(ToSplitExpr(b), -1);
   }

--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -349,8 +349,8 @@ inline IntervalSet Combine<tir::Min>(Analyzer* analzyer, IntervalSet a, Interval
 
 // internal helper function to get an interval set
 IntervalSet ToIntervalSet(IntSet set) {
-  if (auto* node = set.as<IntervalSetNode>()) {
-    return GetRef<IntervalSet>(node);
+  if (auto node = set.as<IntervalSet>()) {
+    return node.value();
   }
   DLOG(INFO) << "cannot resolve int set " << set;
   return IntervalSet::Everything();
@@ -379,6 +379,7 @@ class IntervalSetEvaluator : public ExprFunctor<IntervalSet(const PrimExpr&)> {
     IntervalSet min_set = this->Eval(val->min_value);
     IntervalSet max_set = this->Eval(val->max_value);
     --recur_depth_;
+
     return IntervalSet(min_set->min_value, max_set->max_value);
   }
 

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -723,10 +723,10 @@ class IterMapRewriter : public ExprMutator {
    * \return The transformed IterSumExpr.
    */
   static IterSumExpr ToIterSumExpr(const PrimExpr& expr) {
-    if (const auto* op = expr.as<IterSumExprNode>()) {
-      return GetRef<IterSumExpr>(op);
-    } else if (const auto* op = expr.as<IterSplitExprNode>()) {
-      return IterSumExpr({GetRef<IterSplitExpr>(op)}, make_zero(expr->dtype));
+    if (auto op = expr.as<IterSumExpr>()) {
+      return op.value();
+    } else if (auto op = expr.as<IterSplitExpr>()) {
+      return IterSumExpr({op.value()}, make_zero(expr->dtype));
     } else {
       ICHECK(!expr->IsInstance<IterMapExprNode>());
       return IterSumExpr({}, expr);
@@ -1071,14 +1071,15 @@ bool MatchBoundConstraints(PrimExpr pred, Map<Var, Range>* input_iters,
         }
       }
       // If it is a predicate for a single input iter
-      if (const auto* var_ptr = iter.as<VarNode>()) {
-        auto it = input_iters->find(GetRef<Var>(var_ptr));
+      if (auto opt = iter.as<Var>()) {
+        auto var = opt.value();
+        auto it = input_iters->find(var);
         if (it != input_iters->end()) {
           PrimExpr iter_min = (*it).second->min;
           PrimExpr iter_max = (*it).second->min + (*it).second->extent;
           if (lower_bound.defined()) iter_min = max(iter_min, lower_bound.value());
           if (upper_bound.defined()) iter_max = min(iter_max, upper_bound.value());
-          input_iters->Set(GetRef<Var>(var_ptr), Range(iter_min, iter_max));
+          input_iters->Set(var, Range(iter_min, iter_max));
         }
       } else {
         result->emplace_back(iter, lower_bound, upper_bound, 0);
@@ -1225,10 +1226,10 @@ PrimExpr IterMapRewriter::VisitExpr_(const AddNode* op) {
 
   if (!b->IsInstance<IterMapExprNode>()) {
     ret.CopyOnWrite()->base += b;
-  } else if (const auto* op = b.as<IterSumExprNode>()) {
-    AddToLhs(ret.CopyOnWrite(), GetRef<IterSumExpr>(op), 1);
-  } else if (const auto* op = b.as<IterSplitExprNode>()) {
-    AddToLhs(ret.CopyOnWrite(), GetRef<IterSplitExpr>(op), 1);
+  } else if (auto op = b.as<IterSumExpr>()) {
+    AddToLhs(ret.CopyOnWrite(), op.value(), 1);
+  } else if (auto op = b.as<IterSplitExpr>()) {
+    AddToLhs(ret.CopyOnWrite(), op.value(), 1);
   } else {
     AddToLhs(ret.CopyOnWrite(), ToIterSumExpr(b), 1);
   }
@@ -1260,10 +1261,10 @@ PrimExpr IterMapRewriter::VisitExpr_(const SubNode* op) {
 
   if (!b->IsInstance<IterMapExprNode>()) {
     ret.CopyOnWrite()->base -= b;
-  } else if (const auto* op = b.as<IterSumExprNode>()) {
-    AddToLhs(ret.CopyOnWrite(), GetRef<IterSumExpr>(op), -1);
-  } else if (const auto* op = b.as<IterSplitExprNode>()) {
-    AddToLhs(ret.CopyOnWrite(), GetRef<IterSplitExpr>(op), -1);
+  } else if (auto op = b.as<IterSumExpr>()) {
+    AddToLhs(ret.CopyOnWrite(), op.value(), -1);
+  } else if (auto op = b.as<IterSplitExpr>()) {
+    AddToLhs(ret.CopyOnWrite(), op.value(), -1);
   } else {
     AddToLhs(ret.CopyOnWrite(), ToIterSumExpr(b), -1);
   }
@@ -1697,10 +1698,10 @@ class IterMapToExprNormalizer : public ExprMutator {
  private:
   /*! \brief Override VisitExpr for iter expr type processing */
   PrimExpr VisitExpr(const PrimExpr& expr) override {
-    if (const auto* op = expr.as<IterSplitExprNode>()) {
-      return ConvertIterSplitExpr(GetRef<IterSplitExpr>(op));
-    } else if (const auto* op = expr.as<IterSumExprNode>()) {
-      return ConvertIterSumExpr(GetRef<IterSumExpr>(op));
+    if (auto op = expr.as<IterSplitExpr>()) {
+      return ConvertIterSplitExpr(op.value());
+    } else if (auto op = expr.as<IterSumExpr>()) {
+      return ConvertIterSumExpr(op.value());
     } else {
       return ExprMutator::VisitExpr(expr);
     }
@@ -1717,10 +1718,10 @@ class IterMapToExprNormalizer : public ExprMutator {
 
   PrimExpr ConvertIterSplitExpr(const IterSplitExpr& expr) {
     PrimExpr source;
-    if (const auto* op = expr->source->source.as<VarNode>()) {
-      source = GetRef<Var>(op);
-    } else if (const auto* op = expr->source->source.as<IterSumExprNode>()) {
-      source = ConvertIterSumExpr(GetRef<IterSumExpr>(op));
+    if (auto opt = expr->source->source.as<Var>()) {
+      source = opt.value();
+    } else if (auto opt = expr->source->source.as<IterSumExpr>()) {
+      source = ConvertIterSumExpr(opt.value());
     } else {
       source = VisitExpr(expr->source->source);
     }
@@ -1859,10 +1860,10 @@ class SubspaceDivider {
 
    private:
     static IterSplitExpr GetAsSplit(const IterMapExpr& expr, const PrimExpr& extent) {
-      if (const auto* op = expr.as<IterSplitExprNode>()) {
-        return GetRef<IterSplitExpr>(op);
-      } else if (const auto* op = expr.as<IterSumExprNode>()) {
-        return IterSplitExpr(IterMark(GetRef<IterSumExpr>(op), extent));
+      if (auto op = expr.as<IterSplitExpr>()) {
+        return op.value();
+      } else if (auto op = expr.as<IterSumExpr>()) {
+        return IterSplitExpr(IterMark(op.value(), extent));
       } else {
         LOG(FATAL) << "Unknown IterMapExpr type";
       }
@@ -1951,10 +1952,10 @@ class SubspaceDivider {
  private:
   DivisionResult AddBase(DivisionResult division, PrimExpr base) {
     DivisionResult res = division;
-    if (const auto* op = division.inner.as<IterSplitExprNode>()) {
-      res.inner = IterSumExpr({GetRef<IterSplitExpr>(op)}, base);
-    } else if (const auto* op = division.inner.as<IterSumExprNode>()) {
-      const auto& expr = GetRef<IterSumExpr>(op);
+    if (auto op = division.inner.as<IterSplitExpr>()) {
+      res.inner = IterSumExpr({op.value()}, base);
+    } else if (auto op = division.inner.as<IterSumExpr>()) {
+      const auto& expr = op.value();
       res.inner = IterSumExpr(expr->args, expr->base + base);
     }
     return res;
@@ -1981,9 +1982,9 @@ class SubspaceDivider {
       return it->second;
     }
     const Array<IterSplitExpr>& splits = collector_.mark2splits_.at(expr->source);
-    if (const auto* iter_ptr = expr->source->source.as<VarNode>()) {
+    if (auto iter_ptr = expr->source->source.as<Var>()) {
       // source is input_iter
-      bool inner = sub_iters_.count(GetRef<Var>(iter_ptr));
+      bool inner = sub_iters_.count(iter_ptr.value());
       for (const IterSplitExpr& split : splits) {
         if (inner) {
           // 0*E(split)+split
@@ -1993,7 +1994,7 @@ class SubspaceDivider {
           split_map_.emplace(split, DivisionResult::Outer(split, split->extent));
         }
       }
-    } else if (const auto* iter_ptr = expr->source->source.as<IterSumExprNode>()) {
+    } else if (auto iter_ptr = expr->source->source.as<IterSumExpr>()) {
       // source = Y*E+X
       // splits = [s1, s2, ..., sn]
       // we can divide if there exists i, such that extent(s1)extent(s2)...extent(si)=extent(Y)
@@ -2006,8 +2007,7 @@ class SubspaceDivider {
       // Case 2. splits = [s1, s2, s3] = [source / 4, (source / 2) % 2, source % 2],
       //         where extent(s1) = 3, extent(s2) = 2, extent(s3) = 2.
       //         It's impossible to rewrite s1, s2, s3 in the form of Y*E(X) + X.
-      DivisionResult mark_division =
-          DivideIterSumExpr(GetRef<IterSumExpr>(iter_ptr), expr->source->extent);
+      DivisionResult mark_division = DivideIterSumExpr(iter_ptr.value(), expr->source->extent);
       if (splits.size() == 1) {
         return mark_division;
       }
@@ -2191,8 +2191,8 @@ class InverseAffineIterMapTransformer {
       } else {
         const auto* split_expr = expr.as<IterSplitExprNode>();
         ICHECK(split_expr);
-        if (const auto* source = split_expr->source->source.as<IterMapExprNode>()) {
-          fvisit(GetRef<IterMapExpr>(source));
+        if (auto source = split_expr->source->source.as<IterMapExpr>()) {
+          fvisit(source.value());
         }
       }
       post_dfs_order.push_back(expr.get());

--- a/src/contrib/hybrid/codegen_hybrid.cc
+++ b/src/contrib/hybrid/codegen_hybrid.cc
@@ -471,8 +471,8 @@ void CodeGenHybrid::DumpStmt(const Stmt& stmt, const Array<ObjectRef>& inputs,
   stream << "def " << name << "(";
   for (size_t i = 0; i < inputs.size(); ++i) {
     if (i) stream << ", ";
-    if (auto tensor = inputs[i].as<TensorNode>()) {
-      stream << GetTensorID(GetRef<Tensor>(tensor));
+    if (auto tensor = inputs[i].as<Tensor>()) {
+      stream << GetTensorID(tensor.value());
     } else {
       auto var = inputs[i].as<VarNode>();
       ICHECK(var) << "Input should either be a tensor or a variable!";

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -97,8 +97,8 @@ void GetBinds(const Array<ObjectRef>& args, bool compact,
   *out_binds = binds;
 
   for (const ObjectRef& x : args) {
-    if (const te::TensorNode* tensor_node = x.as<te::TensorNode>()) {
-      te::Tensor x_ref = GetRef<te::Tensor>(tensor_node);
+    if (auto tensor_node = x.as<te::Tensor>()) {
+      te::Tensor x_ref = tensor_node.value();
       if (out_binds->find(x_ref) == out_binds->end()) {
         tir::Buffer buf = tir::BufferWithOffsetAlignment(x_ref->shape, x_ref->dtype,
                                                          x_ref->op->name, -1, 0, compact);
@@ -183,8 +183,7 @@ Array<tvm::transform::Pass> CreatePassList(bool disable_loop_partition) {
 
     CHECK_GE(phase_num_val, 0);
 
-    const tvm::transform::PassNode* pass_node = phase_pass[1].as<tvm::transform::PassNode>();
-    tvm::transform::Pass pass = GetRef<tvm::transform::Pass>(pass_node);
+    auto pass = Downcast<tvm::transform::Pass>(phase_pass[1]);
     // Copy the pass into the correct phase
     if (phase_num_val == 0) {
       user_lower_phase0.push_back(pass);

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -38,14 +38,14 @@ PrimExpr::PrimExpr(float value) : PrimExpr(FloatImm(DataType::Float(32), value))
 
 PrimExpr PrimExpr::FromObject_(ObjectRef ref) {
   using runtime::ObjectTypeChecker;
-  if (auto* ptr = ref.as<tir::IterVarNode>()) {
-    return GetRef<tir::IterVar>(ptr)->var;
+  if (const auto* ptr = ref.as<tir::IterVarNode>()) {
+    return ptr->var;
   }
-  if (auto* ptr = ref.as<te::TensorNode>()) {
-    return GetRef<te::Tensor>(ptr)();
+  if (auto opt = ref.as<te::Tensor>()) {
+    return opt.value()();
   }
-  if (auto* ptr = ref.as<runtime::StringObj>()) {
-    return tir::StringImm(GetRef<runtime::String>(ptr));
+  if (auto opt = ref.as<runtime::String>()) {
+    return tir::StringImm(opt.value());
   }
   if (const auto* buffer_region = ref.as<tir::BufferRegionNode>()) {
     Array<PrimExpr> indices;

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -322,8 +322,8 @@ std::pair<IRModule, GlobalVar> IRModule::FromExprInContext(
 
   // All global definitions must be functions.
   BaseFunc func;
-  if (auto* func_node = expr.as<BaseFuncNode>()) {
-    func = GetRef<BaseFunc>(func_node);
+  if (auto func_node = expr.as<BaseFunc>()) {
+    func = func_node.value();
     if (auto opt = func->GetAttr<String>(tvm::attr::kGlobalSymbol)) {
       // Function literal has been annotated with it's required global symbol.
       gv_name = opt.value();

--- a/src/ir/type_functor.cc
+++ b/src/ir/type_functor.cc
@@ -115,8 +115,8 @@ Type TypeMutator::VisitType_(const FuncTypeNode* op) {
   for (auto type_param : op->type_params) {
     auto new_type_param = VisitType(type_param);
     changed = changed || !new_type_param.same_as(type_param);
-    if (const TypeVarNode* tin = new_type_param.as<TypeVarNode>()) {
-      type_params.push_back(GetRef<TypeVar>(tin));
+    if (auto tin = new_type_param.as<TypeVar>()) {
+      type_params.push_back(tin.value());
     } else {
       LOG(FATAL) << new_type_param;
     }
@@ -126,8 +126,8 @@ Type TypeMutator::VisitType_(const FuncTypeNode* op) {
   for (auto type_cs : op->type_constraints) {
     auto new_type_cs = VisitType(type_cs);
     changed = changed || !new_type_cs.same_as(type_cs);
-    if (const TypeConstraintNode* tin = new_type_cs.as<TypeConstraintNode>()) {
-      type_constraints.push_back(GetRef<TypeConstraint>(tin));
+    if (auto tin = new_type_cs.as<TypeConstraint>()) {
+      type_constraints.push_back(tin.value());
     } else {
       LOG(FATAL) << new_type_cs;
     }

--- a/src/meta_schedule/database/database_utils.cc
+++ b/src/meta_schedule/database/database_utils.cc
@@ -58,8 +58,8 @@ void JSONDumps(ObjectRef json_obj, std::ostringstream& os) {
     std::vector<std::pair<String, ObjectRef>> key_values;
     key_values.reserve(n);
     for (const auto& kv : *dict) {
-      if (const auto* k = kv.first.as<StringObj>()) {
-        key_values.emplace_back(GetRef<String>(k), kv.second);
+      if (auto key = kv.first.as<String>()) {
+        key_values.emplace_back(key.value(), kv.second);
       } else {
         LOG(FATAL) << "TypeError: Only string keys are supported in JSON dumps, but got: "
                    << kv.first->GetTypeKey();

--- a/src/meta_schedule/postproc/verify_gpu_code.cc
+++ b/src/meta_schedule/postproc/verify_gpu_code.cc
@@ -131,8 +131,8 @@ class VerifyGPUCodeNode : public PostprocNode {
 
   bool Verify(const IRModule& mod) const {
     for (const auto& kv : mod->functions) {
-      if (const auto* prim_func = kv.second.as<tir::PrimFuncNode>()) {
-        if (!tir::VerifyGPUCode(GetRef<tir::PrimFunc>(prim_func), this->target_constraints_)) {
+      if (auto prim_func = kv.second.as<tir::PrimFunc>()) {
+        if (!tir::VerifyGPUCode(prim_func.value(), this->target_constraints_)) {
           return false;
         }
       }

--- a/src/meta_schedule/postproc/verify_vtcm_limit.cc
+++ b/src/meta_schedule/postproc/verify_vtcm_limit.cc
@@ -37,8 +37,8 @@ class VerifyVTCMLimitNode : public PostprocNode {
 
   bool Verify(const IRModule& mod) const {
     for (const auto& kv : mod->functions) {
-      if (const auto* prim_func = kv.second.as<tir::PrimFuncNode>()) {
-        if (!tir::VerifyVTCMLimit(GetRef<tir::PrimFunc>(prim_func), vtcm_capacity)) {
+      if (auto prim_func = kv.second.as<tir::PrimFunc>()) {
+        if (!tir::VerifyVTCMLimit(prim_func.value(), vtcm_capacity)) {
           return false;
         }
       }

--- a/src/meta_schedule/space_generator/schedule_fn.cc
+++ b/src/meta_schedule/space_generator/schedule_fn.cc
@@ -51,15 +51,15 @@ class ScheduleFnNode : public SpaceGeneratorNode {
       return {sch};
     }
     ObjectRef obj = rv;
-    if (const auto* sch = obj.as<tir::ScheduleNode>()) {
-      return {GetRef<tir::Schedule>(sch)};
+    if (auto sch = obj.as<tir::Schedule>()) {
+      return {sch.value()};
     }
     if (const auto* arr = obj.as<runtime::ArrayNode>()) {
       Array<tir::Schedule> result;
       result.reserve(arr->size());
       for (const ObjectRef& obj : *arr) {
-        if (const auto* sch = obj.as<tir::ScheduleNode>()) {
-          result.push_back(GetRef<tir::Schedule>(sch));
+        if (auto sch = obj.as<tir::Schedule>()) {
+          result.push_back(sch.value());
         } else {
           LOG(FATAL) << "TypeError: Expect return type of ScheduleFn to be None, Schedule or "
                         "List[Schedule], but got: "

--- a/src/relay/analysis/call_graph.cc
+++ b/src/relay/analysis/call_graph.cc
@@ -44,10 +44,9 @@ CallGraph::CallGraph(IRModule module) {
   n->module = std::move(module);
   auto gvar_funcs = n->module->functions;
   for (const auto& it : gvar_funcs) {
-    if (const auto* fn = it.second.as<FunctionNode>()) {
-      auto func = GetRef<Function>(fn);
+    if (auto func = it.second.as<Function>()) {
       // Add the global function to gradually build up the call graph.
-      n->AddToCallGraph(it.first, func);
+      n->AddToCallGraph(it.first, func.value());
     }
   }
   data_ = std::move(n);
@@ -76,9 +75,8 @@ void CallGraphNode::AddToCallGraph(const GlobalVar& gv, const Function& func) {
             LookupGlobalVar(Downcast<GlobalVar>(props.attrs.metadata["prim_shape_fn_var"]));
         cg_node->AddCalledGlobal(callee_cg_node);
       }
-    } else if (const auto* global_var_node = expr.as<GlobalVarNode>()) {
-      auto callee = GetRef<GlobalVar>(global_var_node);
-      CallGraphEntry* callee_cg_node = LookupGlobalVar(callee);
+    } else if (auto callee = expr.as<GlobalVar>()) {
+      CallGraphEntry* callee_cg_node = LookupGlobalVar(callee.value());
       cg_node->AddCalledGlobal(callee_cg_node);
     }
   });

--- a/src/relay/analysis/match_exhaustion.cc
+++ b/src/relay/analysis/match_exhaustion.cc
@@ -169,10 +169,10 @@ Array<Pattern> ExpandWildcardsTuple(const PatternTuple& clause_tuple, const Patt
 // Returns a list of all possible expansions.
 Array<Pattern> ExpandWildcards(const Pattern& clause_pat, const Pattern& cand,
                                const IRModule& mod) {
-  if (auto clause_ctor = clause_pat.as<PatternConstructorNode>()) {
-    return ExpandWildcardsConstructor(GetRef<PatternConstructor>(clause_ctor), cand, mod);
-  } else if (auto clause_tup = clause_pat.as<PatternTupleNode>()) {
-    return ExpandWildcardsTuple(GetRef<PatternTuple>(clause_tup), cand, mod);
+  if (auto clause_ctor = clause_pat.as<PatternConstructor>()) {
+    return ExpandWildcardsConstructor(clause_ctor.value(), cand, mod);
+  } else if (auto clause_tup = clause_pat.as<PatternTuple>()) {
+    return ExpandWildcardsTuple(clause_tup.value(), cand, mod);
   } else {
     return {cand};
   }

--- a/src/relay/analysis/type_solver.cc
+++ b/src/relay/analysis/type_solver.cc
@@ -160,7 +160,7 @@ class TypeSolver::Unifier : public TypeFunctor<Type(const Type&, const Type&)> {
   // default: unify only if structural-equal
   Type VisitTypeDefault_(const Object* op, const Type& tn) final {
     ObjectRef nr = GetRef<ObjectRef>(op);
-    Type t1 = GetRef<Type>(nr.as<tvm::relay::TypeNode>());
+    Type t1 = Downcast<Type>(nr);
     if (!tvm::StructuralEqual()(t1, tn)) {
       return Type(nullptr);
     }
@@ -405,7 +405,7 @@ class TypeSolver::Propagator : public TypeFunctor<void(const Type&)> {
 
   void VisitTypeDefault_(const Object* op) override {
     ObjectRef nr = GetRef<ObjectRef>(op);
-    Type t = GetRef<Type>(nr.as<tvm::relay::TypeNode>());
+    Type t = Downcast<Type>(nr);
     UpdateRelSet(t);
   }
 
@@ -489,7 +489,7 @@ class TypeSolver::Merger : public TypeFunctor<void(const Type&)> {
 
   void VisitTypeDefault_(const Object* op) override {
     ObjectRef nr = GetRef<ObjectRef>(op);
-    Type t = GetRef<Type>(nr.as<tvm::relay::TypeNode>());
+    Type t = Downcast<Type>(nr);
     TransferLinks(t);
   }
 

--- a/src/relay/backend/annotate_used_memory.cc
+++ b/src/relay/backend/annotate_used_memory.cc
@@ -185,9 +185,8 @@ class AnnotateUsedMemoryMutator : public transform::DeviceAwareExprMutator {
    * \brief Check if a call is a primitive function callsite.
    */
   bool CheckPrimitiveFunctionCall(const Call& callsite) {
-    if (const auto* var_node = callsite->op.as<VarNode>()) {
-      Var var = GetRef<Var>(var_node);
-      if (let_bound_prim_func_.find(var) != let_bound_prim_func_.end()) {
+    if (auto var = callsite->op.as<Var>()) {
+      if (let_bound_prim_func_.find(var.value()) != let_bound_prim_func_.end()) {
         return true;
       }
     }

--- a/src/relay/backend/aot/aot_lower_main.cc
+++ b/src/relay/backend/aot/aot_lower_main.cc
@@ -221,7 +221,7 @@ class AOTMainLowerer : public MixedModeVisitor {
     IRModule lowered_mod = GetRef<IRModule>(mod.CopyOnWrite());
 
     auto lowered_main = lowered_mod->Lookup("main");
-    auto lowered_main_func = GetRef<Function>(lowered_main.as<FunctionNode>());
+    auto lowered_main_func = Downcast<Function>(lowered_main);
 
     // Assign StorageInfo to all the Relay exprs and get the return SIDs
     std::tie(expr_storage_map_, return_sid_) = CreateStorage(lowered_main_func);

--- a/src/relay/backend/aot_executor_codegen.cc
+++ b/src/relay/backend/aot_executor_codegen.cc
@@ -1103,7 +1103,7 @@ class AOTExecutorCodegen : public MixedModeVisitor {
       lowered_mod = transform::RemoveStandaloneReshapes()(lowered_mod);
     }
     auto lowered_main = lowered_mod->Lookup("main");
-    auto lowered_main_func = GetRef<Function>(lowered_main.as<FunctionNode>());
+    auto lowered_main_func = Downcast<Function>(lowered_main);
 
     // Post-lowering storage map for writing main func
     AOTOnDemandAllocator final_aot_allocator;

--- a/src/relay/backend/contrib/cmsisnn/extract_constants.cc
+++ b/src/relay/backend/contrib/cmsisnn/extract_constants.cc
@@ -186,8 +186,8 @@ class ExtractConstantsMutator : public MixedModeMutator {
 
     // Since the constants are extracted from partitioned functions
     // a new call to global function is needed
-    if (auto* glob_var_node = post_call->op.as<GlobalVarNode>()) {
-      auto glob_var = GetRef<GlobalVar>(glob_var_node);
+    if (auto opt = post_call->op.as<GlobalVar>()) {
+      auto glob_var = opt.value();
       auto glob_func = Downcast<Function>(mod_->Lookup(glob_var));
       auto new_glob_func = VisitExpr(glob_func);
       if (!new_glob_func.same_as(glob_func)) {
@@ -199,8 +199,8 @@ class ExtractConstantsMutator : public MixedModeMutator {
 
     // Since the constants are extracted from the local partitioned functions
     // a new call to local function is needed
-    if (auto* func_node = call->op.as<FunctionNode>()) {
-      Function func = GetRef<Function>(func_node);
+    if (auto opt = call->op.as<Function>()) {
+      Function func = opt.value();
       auto new_func = VisitExpr(func);
       Array<Expr> new_args = CreateNewCallArgsFromExtractedConstants(GetRef<Call>(post_call), func);
       final_call = Call(new_func, new_args);

--- a/src/relay/backend/contrib/cmsisnn/relay_to_tir.cc
+++ b/src/relay/backend/contrib/cmsisnn/relay_to_tir.cc
@@ -404,19 +404,19 @@ class RelayToTIRVisitor : public MixedModeMutator {
 
   void EmitPool2D(const GlobalVar& global_var, const Expr& expr, const String pool_name) {
     Call clip, pool;
-    Call final_call = GetRef<Call>(expr.as<CallNode>());
-    Op final_op = GetRef<Op>(final_call->op.as<OpNode>());
+    Call final_call = Downcast<Call>(expr);
+    Op final_op = Downcast<Op>(final_call->op);
     if (final_op->name == "clip") {
       clip = final_call;
-      Call clip_input = GetRef<Call>(clip->args[0].as<CallNode>());
-      Op clip_input_op = GetRef<Op>(clip_input->op.as<OpNode>());
+      Call clip_input = Downcast<Call>(clip->args[0]);
+      Op clip_input_op = Downcast<Op>(clip_input->op);
       if (clip_input_op->name == "cast") {
-        pool = GetRef<Call>(clip_input->args[0].as<CallNode>());
+        pool = Downcast<Call>(clip_input->args[0]);
       } else {  // max_pool2d
         pool = clip_input;
       }
     } else if (final_op->name == "cast") {
-      pool = GetRef<Call>(final_call->args[0].as<CallNode>());
+      pool = Downcast<Call>(final_call->args[0]);
     } else {  // max_pool2d
       pool = final_call;
     }
@@ -556,11 +556,11 @@ class RelayToTIRVisitor : public MixedModeMutator {
 
   BinaryElementwiseClipPattern ParseBinaryElementwiseOpClipPattern(const Expr& expr) {
     BinaryElementwiseClipPattern pattern;
-    Call final_call = GetRef<Call>(expr.as<CallNode>());
+    Call final_call = Downcast<Call>(expr);
     const OpNode* final_op = final_call->op.as<OpNode>();
     if (final_op->name == "clip") {
       pattern.clip_op = final_call;
-      pattern.binary_op = GetRef<Call>(final_call->args[0].as<CallNode>());
+      pattern.binary_op = Downcast<Call>(final_call->args[0]);
     } else {
       pattern.binary_op = final_call;
       pattern.clip_op = Optional<Call>{nullptr};

--- a/src/relay/backend/contrib/cmsisnn/scalar_to_tensor_constant.cc
+++ b/src/relay/backend/contrib/cmsisnn/scalar_to_tensor_constant.cc
@@ -72,8 +72,8 @@ class ScalarToTensorConstantMutator : public MixedModeMutator {
       final_call = ReplaceScalarWithTensorVariable(GetRef<Call>(call));
     }
 
-    if (auto* glob_var_node = call->op.as<GlobalVarNode>()) {
-      GlobalVar global_var = GetRef<GlobalVar>(glob_var_node);
+    if (auto opt = call->op.as<GlobalVar>()) {
+      GlobalVar global_var = opt.value();
       Function func = Downcast<Function>(mod_->Lookup(global_var));
       auto new_body = VisitExpr(func->body);
       if (new_body.same_as(func->body)) {
@@ -87,9 +87,8 @@ class ScalarToTensorConstantMutator : public MixedModeMutator {
     }
 
     // Substitute scalar constant with tensor constant in the call to composite function.
-    if (auto* func_node = call->op.as<FunctionNode>()) {
-      Function func = GetRef<Function>(func_node);
-      final_call = ReplaceScalarWithTensorConstant(GetRef<Call>(call), func);
+    if (auto func = call->op.as<Function>()) {
+      final_call = ReplaceScalarWithTensorConstant(GetRef<Call>(call), func.value());
     }
 
     return final_call;

--- a/src/relay/backend/contrib/ethosu/codegen.cc
+++ b/src/relay/backend/contrib/ethosu/codegen.cc
@@ -191,7 +191,7 @@ class RemoveRedundantIdentities : public MixedModeMutator {
       }
 
       if (const auto* parent_callnode = current_arg.as<CallNode>()) {
-        if (const auto* parent_op = parent_callnode->op.as<OpNode>()) {
+        if (auto parent_op = parent_callnode->op.as<OpNode>()) {
           Call parent_call = GetRef<Call>(parent_callnode);
           if (parent_op->name == "contrib.ethosu.identity" && IdentityDoesNothing(parent_call) &&
               CheckIdentityBetweenTransformOperations(call, parent_call)) {

--- a/src/relay/backend/contrib/ethosu/preprocess.cc
+++ b/src/relay/backend/contrib/ethosu/preprocess.cc
@@ -189,8 +189,8 @@ class ExternalFuncIOHandler : public ExprRewriter {
   Expr Rewrite_(const CallNode* call, const Expr& post) final {
     auto post_call = Downcast<Call>(post);
 
-    if (auto glb_var_node = post_call->op.as<GlobalVar>()) {
-      auto glb_var = GetRef<GlobalVar>(glb_var_node);
+    if (auto optional_glb_var = post_call->op.as<GlobalVar>()) {
+      auto glb_var = optional_glb_var.value();
       auto func = Downcast<Function>(module_->functions[glb_var]);
 
       // If the number of inputs and output are 1 --> no need to do anything

--- a/src/relay/backend/contrib/ethosu/preprocess.cc
+++ b/src/relay/backend/contrib/ethosu/preprocess.cc
@@ -189,7 +189,7 @@ class ExternalFuncIOHandler : public ExprRewriter {
   Expr Rewrite_(const CallNode* call, const Expr& post) final {
     auto post_call = Downcast<Call>(post);
 
-    if (auto glb_var_node = post_call->op.as<GlobalVarNode>()) {
+    if (auto glb_var_node = post_call->op.as<GlobalVar>()) {
       auto glb_var = GetRef<GlobalVar>(glb_var_node);
       auto func = Downcast<Function>(module_->functions[glb_var]);
 
@@ -233,9 +233,9 @@ class ExternalFuncIOHandler : public ExprRewriter {
 
 IRModule PreprocessExternalFuncIO_(const IRModule& module) {
   ExternalFuncIOHandler ex_func_io_handle(module);
-  auto func = GetRef<Function>(module->Lookup("main").as<FunctionNode>());
+  auto func = Downcast<Function>(module->Lookup("main"));
   auto preprocessed = PostOrderRewrite(func, &ex_func_io_handle);
-  module->Update(module->GetGlobalVar("main"), GetRef<Function>(preprocessed.as<FunctionNode>()));
+  module->Update(module->GetGlobalVar("main"), Downcast<Function>(preprocessed));
   return module;
 }
 

--- a/src/relay/backend/contrib/example_target_hooks/relay_to_tir.cc
+++ b/src/relay/backend/contrib/example_target_hooks/relay_to_tir.cc
@@ -68,7 +68,7 @@ class ConvertAddToSubtract : public MixedModeMutator {
 
   IRModule Mutate() {
     GlobalVar main_global_var = ir_module_->GetGlobalVar("main");
-    Function main = GetRef<Function>(ir_module_->Lookup(main_global_var).as<FunctionNode>());
+    Function main = Downcast<Function>(ir_module_->Lookup(main_global_var));
     Function mutated_main = WithFields(main, main->params, VisitExpr(main->body));
 
     ir_module_->Update(main_global_var, mutated_main);
@@ -212,17 +212,18 @@ class ConvertAddToSubtract : public MixedModeMutator {
         return nullptr;
       }
       return function_node;
-    } else if (const auto* global_var_node = expr.as<GlobalVarNode>()) {
-      return AsLowerableFunction(ir_module_->Lookup(GetRef<GlobalVar>(global_var_node)));
+    } else if (auto global_var_node = expr.as<GlobalVar>()) {
+      return AsLowerableFunction(ir_module_->Lookup(global_var_node.value()));
     } else {
       return nullptr;
     }
   }
 
   const GlobalVarNode* AsAlreadyLoweredFunction(const Expr& expr) {
-    if (const auto* global_var_node = expr.as<GlobalVarNode>()) {
-      if (ir_module_->Lookup(GetRef<GlobalVar>(global_var_node)).as<tir::PrimFuncNode>()) {
-        return global_var_node;
+    if (auto opt = expr.as<GlobalVar>()) {
+      auto global_var = opt.value();
+      if (ir_module_->Lookup(global_var).as<tir::PrimFuncNode>()) {
+        return global_var.get();
       }
     }
     return nullptr;

--- a/src/relay/backend/te_compiler.cc
+++ b/src/relay/backend/te_compiler.cc
@@ -651,8 +651,8 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
         BaseFunc base_func = module_->Lookup(GetRef<GlobalVar>(global_var_node));
         return ResolveToPrimitive(base_func);
       }
-    } else if (const auto* prim_func_node = expr.as<tir::PrimFuncNode>()) {
-      return GetRef<tir::PrimFunc>(prim_func_node);
+    } else if (auto prim_func = expr.as<tir::PrimFunc>()) {
+      return prim_func.value();
     } else if (const auto* var_node = expr.as<VarNode>()) {
       auto itr = primitive_functions_.find(var_node);
       if (itr == primitive_functions_.end()) {
@@ -726,8 +726,8 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
     }
 
     // Alas, WithAttr cannot work with base classes.
-    if (const auto* prim_func_node = original_function.as<te::PrimFuncNode>()) {
-      auto func_with_metadata = GetRef<te::PrimFunc>(prim_func_node);
+    if (auto opt = original_function.as<te::PrimFunc>()) {
+      auto func_with_metadata = opt.value();
       func_with_metadata = WithAttr(func_with_metadata, "prim_fn_var", prim_fn_var);
       func_with_metadata = WithAttr(func_with_metadata, "prim_funcs", prim_fns);
       func_with_metadata = WithAttr(func_with_metadata, tvm::attr::kTarget, target);
@@ -737,9 +737,7 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
       }
       this->process_fn_(func_with_metadata);
     } else {
-      const auto* function_node = original_function.as<FunctionNode>();
-      ICHECK(function_node);
-      auto func_with_metadata = GetRef<Function>(function_node);
+      auto func_with_metadata = original_function.as<Function>().value();
       func_with_metadata = WithAttr(func_with_metadata, "prim_fn_var", prim_fn_var);
       func_with_metadata = WithAttr(func_with_metadata, "prim_funcs", prim_fns);
       func_with_metadata = WithAttr(func_with_metadata, tvm::attr::kTarget, target);
@@ -866,8 +864,8 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
     BaseFunc primitive_func = ResolveToPrimitive(call_node->op);
     if (!primitive_func.defined()) {
       // Cases 5 and 6: Leave as ordinary call.
-      if (const auto* function_node = call_node->op.as<FunctionNode>()) {
-        process_fn_(GetRef<Function>(function_node));
+      if (auto function = call_node->op.as<Function>()) {
+        process_fn_(function.value());
       }
       return WithFields(GetRef<Call>(call_node), std::move(new_op), std::move(new_args));
     }
@@ -887,15 +885,14 @@ class LowerTensorExprMutator : public DeviceAwareExprMutator {
     ICHECK(call_node->type_args.empty()) << "lowered functions cannot be polymorphic";
 
     // Case 4: If the function has already been lowered we just need to update the call.
-    if (const auto* prim_func_node = primitive_func.as<tir::PrimFuncNode>()) {
+    if (auto prim_func = primitive_func.as<tir::PrimFunc>()) {
       // Function should already be Target annotated by this point
       // but the TE Compiler metadata is still needed for the callback
       // TODO(Mousius) - Robustify this to not assume we're in the GlobalVar for Target Hooks
       Optional<Target> opt_target = primitive_func->GetAttr<Target>(tvm::attr::kTarget);
       ICHECK(opt_target.defined());
       auto prim_fn_var = Downcast<GlobalVar>(call_node->op);
-      tir::PrimFunc prim_func = GetRef<tir::PrimFunc>(prim_func_node);
-      Map<GlobalVar, BaseFunc> prim_fns = {{prim_fn_var, prim_func}};
+      Map<GlobalVar, BaseFunc> prim_fns = {{prim_fn_var, prim_func.value()}};
       return MakeLoweredCall(primitive_func, prim_fn_var, std::move(new_args), call_node->span,
                              opt_target.value(), prim_fns);
     }

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -693,13 +693,13 @@ class VMFunctionCompiler : DeviceAwareExprFunctor<void(const Expr& n)> {
       auto constructor = GetRef<Constructor>(constructor_node);
       Emit(Instruction::AllocADT(constructor->tag, call_node->args.size(), args_registers,
                                  NewRegister()));
-    } else if (const auto* var_node = call_node->op.as<VarNode>()) {
+    } else if (auto var = call_node->op.as<Var>()) {
       // If we are calling a variable, it must be the case that it is a closure so we
       // emit invoke closure here.
-      VisitExpr(GetRef<Var>(var_node));
+      VisitExpr(var.value());
       Emit(Instruction::InvokeClosure(last_register_, args_registers, NewRegister()));
-    } else if (auto inner_call_node = call_node->op.as<CallNode>()) {
-      VisitExpr(GetRef<Call>(inner_call_node));
+    } else if (auto inner_call = call_node->op.as<Call>()) {
+      VisitExpr(inner_call.value());
       Emit(Instruction::InvokeClosure(last_register_, args_registers, NewRegister()));
     } else {
       // Finally if there are any other cases this is a bug.
@@ -921,12 +921,13 @@ void VMCompiler::LowerImpl(IRModule mod) {
 
   for (const auto& pair : context_.module->functions) {
     auto gvar = pair.first;
-    if (auto* n = pair.second.as<FunctionNode>()) {
-      if (n->HasNonzeroAttr(attr::kExtern)) {
+    if (auto opt = pair.second.as<Function>()) {
+      auto func = opt.value();
+      if (func->HasNonzeroAttr(attr::kExtern)) {
         // Already compiled during lowering.
         continue;
       }
-      auto func = GetRef<Function>(n);
+
       VMFunctionCompiler func_compiler(&context_, config_->host_virtual_device);
       auto vm_func = func_compiler.Compile(gvar, func);
 

--- a/src/relay/backend/vm/lambda_lift.cc
+++ b/src/relay/backend/vm/lambda_lift.cc
@@ -81,8 +81,8 @@ class LambdaLifter : public transform::DeviceAwareExprMutator {
 
   Expr DeviceAwareVisitExpr_(const CallNode* call_node) final {
     auto call = Downcast<Call>(DeviceAwareExprMutator::DeviceAwareVisitExpr_(call_node));
-    if (auto var_node = call_node->op.as<VarNode>()) {
-      auto var = GetRef<Var>(var_node);
+    if (auto opt = call_node->op.as<Var>()) {
+      auto var = opt.value();
       if (!letrec_.empty() && var == letrec_.back()) {
         auto it = lambda_map_.find(var);
         ICHECK(it != lambda_map_.end());

--- a/src/relay/backend/vm/removed_unused_funcs.cc
+++ b/src/relay/backend/vm/removed_unused_funcs.cc
@@ -57,8 +57,8 @@ struct CallTracer : ExprVisitor {
   void VisitExpr_(const GlobalVarNode* op) final {
     called_funcs_.insert(op->name_hint);
     auto func = module_->Lookup(op->name_hint);
-    if (const auto* function_node = func.as<FunctionNode>()) {
-      VisitExpr(GetRef<Function>(function_node));
+    if (auto function_node = func.as<Function>()) {
+      VisitExpr(function_node.value());
     }
     // else: Don't visit PrimFuncs -- we don't need to collect any tir.Calls therein.
   }

--- a/src/relay/collage/mock_cost_estimator.cc
+++ b/src/relay/collage/mock_cost_estimator.cc
@@ -88,8 +88,7 @@ Cost MockCostEstimatorNode::Estimate(const IRModule& mod, const Target& target) 
   double op_cost = static_cast<double>(target_costs_.at(target->kind->name)->value);
   double cost = 0.0;
   for (const auto& kv : mod->functions) {
-    if (const auto* function_node = kv.second.as<FunctionNode>()) {
-      auto function = GetRef<Function>(function_node);
+    if (const auto* function = kv.second.as<FunctionNode>()) {
       if (kv.first->name_hint == "main") {
         // Only tensor args are allowed to main.
         for (const auto& param : function->params) {

--- a/src/relay/collage/sub_graph.cc
+++ b/src/relay/collage/sub_graph.cc
@@ -325,8 +325,8 @@ std::pair<OpPatternKind, std::string> SubExprKindAndLabel(const Expr& sub_expr) 
   class Visitor : public ExprFunctor<std::pair<OpPatternKind, std::string>(const Expr&)> {
    private:
     std::pair<OpPatternKind, std::string> VisitExpr_(const CallNode* call_node) final {
-      if (const auto* op_node = call_node->op.as<OpNode>()) {
-        auto op = GetRef<Op>(op_node);
+      if (auto optional = call_node->op.as<Op>()) {
+        auto op = optional.value();
         static auto fpattern = Op::GetAttrMap<TOpPattern>("TOpPattern");
         if (fpattern.count(op) == 0) {
           VLOG(1) << "no TOpPattern known for " << op->name << ", considering opaque";

--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -128,8 +128,8 @@ bool DFPatternMatcher::VisitDFPattern_(const AttrPatternNode* attr_pattern, cons
     return matches;
   }
   auto attributes = attr_pattern->attrs.as<DictAttrsNode>()->dict;
-  if (const auto* op_node = expr.as<OpNode>()) {
-    Op op = GetRef<Op>(op_node);
+  if (auto optional = expr.as<Op>()) {
+    Op op = optional.value();
     for (auto kv : attributes) {
       auto attr_name = kv.first;
       auto attr_value = kv.second;

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -532,8 +532,8 @@ Function SubstituteBoundVars(const Function& func, const tvm::Map<Var, Expr>& ar
     if (!args_map.count(func->params[i])) {
       new_params.push_back(func->params[i]);
     } else {
-      if (const VarNode* var = args_map[func->params[i]].as<VarNode>()) {
-        new_params.push_back(GetRef<Var>(var));
+      if (auto var = args_map[func->params[i]].as<Var>()) {
+        new_params.push_back(var.value());
       } else {
         ICHECK(false) << "Expected all values in args_map to be vars, but found "
                       << args_map[func->params[i]]->GetTypeKey();

--- a/src/relay/ir/function.cc
+++ b/src/relay/ir/function.cc
@@ -147,8 +147,8 @@ TVM_REGISTER_GLOBAL("relay.ir.PrintIR")
 
 TVM_REGISTER_GLOBAL("relay.ir.WarnIfMalformed")
     .set_body_typed([](const IRModule& mod, const BaseFunc& base_func) -> void {
-      if (const auto* relay_func = base_func.as<FunctionNode>()) {
-        Function func = Downcast<relay::Function>(relay::DeDup(GetRef<Function>(relay_func)));
+      if (auto relay_func = base_func.as<Function>()) {
+        Function func = Downcast<relay::Function>(relay::DeDup(relay_func.value()));
         // Type check the item before we add it to the module.
         auto fv = relay::FreeVars(func);
         auto ftv = relay::FreeTypeVars(func, mod);

--- a/src/relay/op/memory/memory.cc
+++ b/src/relay/op/memory/memory.cc
@@ -224,8 +224,8 @@ RELAY_REGISTER_OP("memory.kill")
     .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout);
 
 static void FlattenTupleTypeAux(const Type& type, std::vector<TensorType>* out) {
-  if (auto tt = type.as<TensorTypeNode>()) {
-    out->push_back(GetRef<TensorType>(tt));
+  if (auto tt = type.as<TensorType>()) {
+    out->push_back(tt.value());
   } else if (auto tuple_ty = type.as<TupleTypeNode>()) {
     for (auto field : tuple_ty->fields) {
       FlattenTupleTypeAux(field, out);

--- a/src/relay/op/type_relations.cc
+++ b/src/relay/op/type_relations.cc
@@ -139,8 +139,8 @@ bool BroadcastCompRel(const Array<Type>& types, int num_inputs, const Attrs& att
 
 bool IdentityCompRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
                      const TypeReporter& reporter) {
-  if (auto* t0 = types[0].as<TensorTypeNode>()) {
-    Type out_type = TensorType(GetRef<TensorType>(t0)->shape, DataType::Bool());
+  if (const auto* t0 = types[0].as<TensorTypeNode>()) {
+    Type out_type = TensorType(t0->shape, DataType::Bool());
     reporter->Assign(types[1], out_type);
     return true;
   }

--- a/src/relay/parser/parser.cc
+++ b/src/relay/parser/parser.cc
@@ -1366,8 +1366,8 @@ class Parser {
       }
       // TODO(@jroesch): not sure about this being the right way to handle nulls.
       case TokenType::kIdentifier: {
-        if (auto text = next->data.as<tvm::StringObj>()) {
-          std::string id = GetRef<String>(text);
+        if (auto text = next->data.as<tvm::String>()) {
+          std::string id = text.value();
           if (id == "nullptr") {
             Match(TokenType::kIdentifier);
             return ObjectRef();

--- a/src/relay/printer/relay_text_printer.cc
+++ b/src/relay/printer/relay_text_printer.cc
@@ -445,11 +445,11 @@ Doc RelayTextPrinter::PrintFunc(const Doc& prefix, const relay::Function& fn) {
 }
 
 Doc RelayTextPrinter::PrintFunc(const Doc& prefix, const BaseFunc& base_func) {
-  if (auto* n = base_func.as<relay::FunctionNode>()) {
-    return PrintFunc(prefix, GetRef<relay::Function>(n));
-  } else if (auto* n = base_func.as<tir::PrimFuncNode>()) {
+  if (auto func = base_func.as<relay::Function>()) {
+    return PrintFunc(prefix, func.value());
+  } else if (auto func = base_func.as<tir::PrimFunc>()) {
     std::ostringstream os;
-    os << GetRef<tir::PrimFunc>(n);
+    os << func.value();
     return Doc::RawText(os.str());
   } else {
     // def @xyz = meta['ExternalFunc'][id]
@@ -896,18 +896,18 @@ Doc RelayTextPrinter::PrintAttributeValue(const ObjectRef& value, bool force_met
     Doc printed_attr;
     if (value.as<tvm::tir::AnyNode>()) {
       printed_attr << "?";
-    } else if (auto str_obj = value.as<tvm::StringObj>()) {
-      printed_attr << Doc::StrLiteral(GetRef<String>(str_obj));
+    } else if (auto str_obj = value.as<tvm::String>()) {
+      printed_attr << Doc::StrLiteral(str_obj.value());
     } else if (force_meta) {
       printed_attr = meta_->GetMetaNode(Downcast<ObjectRef>(value));
-    } else if (const auto* virtual_device_node = value.as<VirtualDeviceNode>()) {
+    } else if (auto virtual_device_node = value.as<VirtualDevice>()) {
       if (show_meta_data_) {
-        printed_attr = meta_->GetMetaNode(GetRef<ObjectRef>(virtual_device_node));
+        printed_attr = meta_->GetMetaNode(virtual_device_node.value());
       } else {
         // Special case: The ReprPrinter for VirtualDeviceNodes is much easier to work with while
         // debugging.
         std::ostringstream os;
-        os << GetRef<VirtualDevice>(virtual_device_node);
+        os << virtual_device_node.value();
         return Doc::Text(os.str());
       }
     } else if (const auto* base_attr_node = value.as<BaseAttrsNode>()) {
@@ -925,11 +925,11 @@ Doc RelayTextPrinter::PrintAttributeValue(const ObjectRef& value, bool force_met
         // Special case: Show maps fields as key=value pairs to help debugging.
         printed_attr << PrintMapAsAttributeValue(GetRef<Map<ObjectRef, ObjectRef>>(base_map_node));
       }
-    } else if (const auto* global_var_node = value.as<GlobalVarNode>()) {
+    } else if (auto global_var = value.as<GlobalVar>()) {
       if (show_meta_data_) {
-        printed_attr = meta_->GetMetaNode(GetRef<ObjectRef>(global_var_node));
+        printed_attr = meta_->GetMetaNode(global_var.value());
       } else {
-        printed_attr << "'" << global_var_node->name_hint << "'";
+        printed_attr << "'" << global_var.value()->name_hint << "'";
       }
     } else {
       printed_attr = VisitAttr(value);

--- a/src/relay/transforms/canonicalize_cast.cc
+++ b/src/relay/transforms/canonicalize_cast.cc
@@ -68,8 +68,8 @@ class CastCanonicalizer : public ExprMutator {
   Expr VisitExpr_(const CallNode* call) {
     static auto fpattern = Op::GetAttrMap<TOpPattern>("TOpPattern");
 
-    if (const OpNode* opnode = call->op.as<OpNode>()) {
-      auto pattern = fpattern[GetRef<Op>(opnode)];
+    if (auto call_op = call->op.as<Op>()) {
+      auto pattern = fpattern[call_op.value()];
       if (pattern <= kBroadcast) {
         Array<Expr> call_args = call->args;
         bool unchanged = true;

--- a/src/relay/transforms/compiler_function_utils.cc
+++ b/src/relay/transforms/compiler_function_utils.cc
@@ -166,8 +166,8 @@ class OuterInliner : public MixedModeMutator {
 
   Expr Rewrite_(const CallNode* pre, const Expr& post) final {
     Call new_call = Downcast<Call>(post);
-    if (const auto* global_var_node = new_call->op.as<GlobalVarNode>()) {
-      auto global_var = GetRef<GlobalVar>(global_var_node);
+    if (auto global_var_node = new_call->op.as<GlobalVar>()) {
+      auto global_var = global_var_node.value();
       if (std::find(global_vars_.begin(), global_vars_.end(), global_var) != global_vars_.end()) {
         BaseFunc base_func = mod_->Lookup(global_var);
         const auto* function_node = base_func.as<FunctionNode>();

--- a/src/relay/transforms/dead_code.cc
+++ b/src/relay/transforms/dead_code.cc
@@ -549,8 +549,8 @@ Pass DeadCodeElimination(bool inline_once, bool ignore_impurity) {
     IRModule result(/*functions=*/{}, mod->type_definitions, mod->Imports(), mod->source_map,
                     mod->attrs);
     for (const auto& kv : mod->functions) {
-      if (const auto* function_node = kv.second.as<FunctionNode>()) {
-        auto function = GetRef<Function>(function_node);
+      if (auto opt = kv.second.as<Function>()) {
+        auto function = opt.value();
 
         VLOG(1) << "processing " << PrettyPrint(kv.first);
 

--- a/src/relay/transforms/dynamic_to_static.cc
+++ b/src/relay/transforms/dynamic_to_static.cc
@@ -250,8 +250,8 @@ class DynamicToStaticMutator : public MixedModeMutator {
 
   Expr PrepareInput(const Expr& expr) {
     BaseFunc func;
-    if (auto* func_node = expr.as<BaseFuncNode>()) {
-      func = GetRef<BaseFunc>(func_node);
+    if (auto func_node = expr.as<BaseFunc>()) {
+      func = func_node.value();
     } else {
       func =
           relay::Function(relay::FreeVars(expr), expr, Type(), relay::FreeTypeVars(expr, mod_), {});

--- a/src/relay/transforms/eta_expand.cc
+++ b/src/relay/transforms/eta_expand.cc
@@ -68,8 +68,8 @@ class EtaExpander : public ExprMutator {
   IRModule Expand() {
     for (GlobalVar global_var : mod_->GetGlobalVars()) {
       const BaseFunc base_func = mod_->Lookup(global_var);
-      if (auto* n = base_func.as<FunctionNode>()) {
-        const Function new_func = Downcast<Function>(VisitExpr(GetRef<Function>(n)));
+      if (auto func = base_func.as<Function>()) {
+        const Function new_func = Downcast<Function>(VisitExpr(func.value()));
         mod_->Update(global_var, new_func);
       }
     }
@@ -119,9 +119,9 @@ class EtaExpander : public ExprMutator {
       return std::move(gvar);
     }
     const auto base_func = mod_->Lookup(gvar);
-    if (auto* ptr = base_func.as<FunctionNode>()) {
+    if (auto opt = base_func.as<Function>()) {
       // handle relay function, skip external functions.
-      auto func = GetRef<Function>(ptr);
+      auto func = opt.value();
       tvm::Array<Expr> params;
       tvm::Array<Var> args;
       for (size_t i = 0; i < func->params.size(); ++i) {

--- a/src/relay/transforms/fold_constant.cc
+++ b/src/relay/transforms/fold_constant.cc
@@ -235,8 +235,8 @@ class ConstantFolder : public MixedModeMutator {
     if (value->IsInstance<runtime::NDArray::ContainerType>()) {
       auto nd_array = Downcast<runtime::NDArray>(value);
       return Constant(nd_array);
-    } else if (const auto* val = value.as<runtime::ADTObj>()) {
-      runtime::ADT adt = GetRef<runtime::ADT>(val);
+    } else if (auto opt = value.as<runtime::ADT>()) {
+      runtime::ADT adt = opt.value();
       Array<Expr> fields;
       for (size_t i = 0; i < adt.size(); ++i) {
         fields.push_back(ObjectToExpr(adt[i]));

--- a/src/relay/transforms/fuse_ops.cc
+++ b/src/relay/transforms/fuse_ops.cc
@@ -187,8 +187,8 @@ class IndexedForwardGraphCreator : private ExprVisitor {
     // Finally if the operator position is not a call node we will
     // need to call Update, as it may be an arbitrary expression.
     OpPatternKind op_pattern = kOpaque;
-    if (const OpNode* opnode = call->op.as<OpNode>()) {
-      auto op = GetRef<Op>(opnode);
+    if (auto optional = call->op.as<Op>()) {
+      auto op = optional.value();
       if (IsDynamic(call->checked_type()) && IsDataDependent(call)) {
         // output of a shape func can't be fed to a data-dependent shape func
         op_pattern = kOpaque;

--- a/src/relay/transforms/inline.cc
+++ b/src/relay/transforms/inline.cc
@@ -185,9 +185,8 @@ IRModule Inline(const IRModule& module) {
     // functions.
     if (it->empty() || (it->IsRecursive() && it->size() == 1)) continue;
     auto base_func = module->Lookup(it->GetNameHint());
-    if (const auto* fn = base_func.as<FunctionNode>()) {
-      auto func = GetRef<Function>(fn);
-      auto new_func = Inliner(it, cg.operator->()).Inline(func);
+    if (auto func = base_func.as<Function>()) {
+      auto new_func = Inliner(it, cg.operator->()).Inline(func.value());
       // TODO(zhiics) Maybe move this to CallGraph, but updating function from
       // CallGraph arbitarily may lead to incorrect CallGraph.
       cg->module->Update(it->GetGlobalVar(), new_func);
@@ -201,8 +200,7 @@ IRModule Inline(const IRModule& module) {
     if (cgn->IsRecursive() || original_entry.count(cgn)) continue;
     auto base_func = cg->GetGlobalFunction(cgn->GetGlobalVar());
     // Skip calls to PrimFuncs since they can't be inlined.
-    if (const auto* fn = base_func.as<FunctionNode>()) {
-      auto func = GetRef<Function>(fn);
+    if (const auto* func = base_func.as<FunctionNode>()) {
       if (func->HasNonzeroAttr(attr::kInline)) {
         ICHECK_EQ(cgn->GetRefCount(), 0U)
             << cgn->GetNameHint() << " is marked as inline but not inlined.";

--- a/src/relay/transforms/lazy_gradient_init.cc
+++ b/src/relay/transforms/lazy_gradient_init.cc
@@ -157,8 +157,8 @@ class LazyGradientInitializer : public ExprMutator, public TypeMutator {
   }
 
   Expr VisitExpr_(const CallNode* call_node) final {
-    if (auto* op = (call_node->op).as<OpNode>()) {
-      Expr op_expr = GetRef<Op>(op);
+    if (auto op = call_node->op.as<Op>()) {
+      Expr op_expr = op.value();
 
       if (op_expr == Op::Get("add")) {
         return CallGradCellFunction(call_node, module_->GetGlobalVar("AddGradCell"));

--- a/src/relay/transforms/partial_eval.cc
+++ b/src/relay/transforms/partial_eval.cc
@@ -635,8 +635,8 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
     ICHECK(mod_.defined());
     if (gv_map_.count(gv) == 0) {
       BaseFunc base_func = mod_->Lookup(gv);
-      if (auto* n = base_func.as<FunctionNode>()) {
-        Function func = GetRef<Function>(n);
+      if (auto opt = base_func.as<Function>()) {
+        auto func = opt.value();
         InitializeFuncId(func);
         Func f = VisitFuncStatic(func, gv);
         gv_map_.insert({gv, HasStatic(MkSFunc(f), gv)});
@@ -879,10 +879,10 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
     if (v->IsInstance<runtime::NDArray::ContainerType>()) {
       auto nd_array = Downcast<runtime::NDArray>(v);
       return HasStatic(MkSTensor(nd_array), ll->Push(Constant(nd_array)));
-    } else if (const runtime::ADTObj* op = v.as<runtime::ADTObj>()) {
+    } else if (auto opt = v.as<runtime::ADT>()) {
       std::vector<PStatic> fields;
       tvm::Array<Expr> fields_dyn;
-      auto adt = GetRef<runtime::ADT>(op);
+      auto adt = opt.value();
       for (size_t i = 0; i < adt.size(); ++i) {
         PStatic ps = Reify(adt[i], ll);
         fields.push_back(ps);

--- a/src/relay/transforms/partition_graph.cc
+++ b/src/relay/transforms/partition_graph.cc
@@ -213,8 +213,8 @@ class Partitioner : public MixedModeMutator {
   IRModule Partition() {
     auto glob_funcs = module_->functions;
     for (const auto& pair : glob_funcs) {
-      if (auto* fn = pair.second.as<FunctionNode>()) {
-        Function func = GetRef<Function>(fn);
+      if (auto opt = pair.second.as<Function>()) {
+        Function func = opt.value();
         func = WithFields(func, func->params, VisitExpr(func->body));
         module_->Update(pair.first, func);
         module_ = transform::InferType()(module_);
@@ -426,8 +426,8 @@ IRModule RemoveDefaultAnnotations(IRModule module) {
   // module is mutable, hence, we make a copy of it.
   module.CopyOnWrite();
   for (const auto& pair : glob_funcs) {
-    if (auto* fn = pair.second.as<FunctionNode>()) {
-      auto func = GetRef<Function>(fn);
+    if (auto opt = pair.second.as<Function>()) {
+      auto func = opt.value();
       DefaultRemover remover;
       auto removed = PostOrderRewrite(func->body, &remover);
       func = WithFields(func, func->params, removed);
@@ -482,8 +482,8 @@ IRModule FlattenTupleOutputs(IRModule module) {
   // module is mutable, hence, we make a copy of it.
   module.CopyOnWrite();
   for (const auto& pair : glob_funcs) {
-    if (auto* fn = pair.second.as<FunctionNode>()) {
-      Function func = GetRef<Function>(fn);
+    if (auto opt = pair.second.as<Function>()) {
+      Function func = opt.value();
       TupleOutFlattener to_flattener;
       auto removed = PostOrderRewrite(func->body, &to_flattener);
       func = WithFields(func, func->params, removed);
@@ -505,8 +505,8 @@ class NameMangleExtFuncs : public MixedModeMutator {
     // Collect function names to be mangled and create
     // global mangled variables
     for (const auto& pair : glob_funcs) {
-      if (auto* fn = pair.second.as<FunctionNode>()) {
-        auto func = GetRef<Function>(fn);
+      if (auto opt = pair.second.as<Function>()) {
+        auto func = opt.value();
         if (func->GetAttr<String>(attr::kCompiler).defined()) {
           auto fn_name_mangled = tvm::runtime::SanitizeName(mangle_fn_(pair.first->name_hint));
           GlobalVar gvar = GlobalVar(fn_name_mangled);
@@ -521,8 +521,8 @@ class NameMangleExtFuncs : public MixedModeMutator {
     new_module->functions = {};
 
     for (const auto& pair : glob_funcs) {
-      if (auto* fn = pair.second.as<FunctionNode>()) {
-        auto func = GetRef<Function>(fn);
+      if (auto opt = pair.second.as<Function>()) {
+        auto func = opt.value();
 
         if (func->GetAttr<String>(attr::kCompiler).defined()) {
           auto new_dict = func->attrs->dict;

--- a/src/relay/transforms/simplify_expr.cc
+++ b/src/relay/transforms/simplify_expr.cc
@@ -581,8 +581,8 @@ class ConcretizeLikeRewrite : public DFPatternRewrite {
     const TensorTypeNode* like_ty = pre->checked_type().as<TensorTypeNode>();
     Array<Integer> cshape;
     for (const auto& dim : like_ty->shape) {
-      if (const auto* imm = dim.as<IntImmNode>()) {
-        cshape.push_back(Integer(GetRef<IntImm>(imm)));
+      if (auto imm = dim.as<IntImm>()) {
+        cshape.push_back(Integer(imm.value()));
       } else {
         // shape is not static, don't concretize
         return post;

--- a/src/relay/transforms/type_infer.cc
+++ b/src/relay/transforms/type_infer.cc
@@ -681,7 +681,7 @@ class TypeInferencer::Resolver : public MixedModeMutator, PatternMutator {
 
   Var VisitVar(const Var& v) final {
     if (vmap_.count(v) == 0) {
-      vmap_[v] = GetRef<Var>(AttachCheckedType(v.as<VarNode>()).as<VarNode>());
+      vmap_[v] = Downcast<Var>(AttachCheckedType(v.as<VarNode>()));
     }
     return vmap_.at(v);
   }
@@ -969,9 +969,7 @@ Pass InferType() {
 
           // In the future we plan a unified type checker
           // that works on TIR and Relay at the same time.
-          if (auto* func_node = it.second.as<FunctionNode>()) {
-            auto func = GetRef<Function>(func_node);
-
+          if (auto func = it.second.as<Function>()) {
             // // If a function already has type information we can skip checking it.
             // if (func->checked_type_.defined()) {
             //   continue;
@@ -980,7 +978,7 @@ Pass InferType() {
             // TODO(@jroesch): we should be able to move the type inferencer outside
             // of this function but it seems to be more stateful then I expect.
             auto inferencer = TypeInferencer(mod, pass_ctx->diag_ctx.value());
-            auto updated_func = inferencer.Infer(it.first, func);
+            auto updated_func = inferencer.Infer(it.first, func.value());
 
             pass_ctx->diag_ctx.value().Render();
 

--- a/src/runtime/debug.cc
+++ b/src/runtime/debug.cc
@@ -108,10 +108,10 @@ void AppendADT(std::ostream& os, const ADT& adt, const DLDevice& host_device, bo
 
 void AppendRuntimeObject(std::ostream& os, const ObjectRef& object, const DLDevice& host_device,
                          bool show_contents) {
-  if (const auto* adt_obj = object.as<ADTObj>()) {
-    AppendADT(os, GetRef<ADT>(adt_obj), host_device, show_contents);
-  } else if (const auto* nd_array_cont = object.as<NDArray::Container>()) {
-    AppendNDArray(os, GetRef<NDArray>(nd_array_cont), host_device, show_contents);
+  if (auto adt = object.as<ADT>()) {
+    AppendADT(os, adt.value(), host_device, show_contents);
+  } else if (auto nd_array_cont = object.as<NDArray>()) {
+    AppendNDArray(os, nd_array_cont.value(), host_device, show_contents);
   } else {
     os << "?";
   }

--- a/src/script/ir_builder/tir/ir.cc
+++ b/src/script/ir_builder/tir/ir.cc
@@ -173,10 +173,10 @@ void Reads(Array<ObjectRef> buffer_slices) {
   }
   Array<BufferRegion> reads;
   for (const ObjectRef& obj : buffer_slices) {
-    if (const auto* buffer_region = obj.as<BufferRegionNode>()) {
-      reads.push_back(GetRef<BufferRegion>(buffer_region));
-    } else if (const auto* buffer_load = obj.as<BufferLoadNode>()) {
-      reads.push_back(BufferRegionFromLoad(GetRef<BufferLoad>(buffer_load)));
+    if (auto buffer_region = obj.as<BufferRegion>()) {
+      reads.push_back(buffer_region.value());
+    } else if (auto buffer_load = obj.as<BufferLoad>()) {
+      reads.push_back(BufferRegionFromLoad(buffer_load.value()));
     } else {
       LOG(FATAL) << "Invalid type for buffer reads.";
     }
@@ -193,10 +193,10 @@ void Writes(Array<ObjectRef> buffer_slices) {
   }
   Array<BufferRegion> writes;
   for (const ObjectRef& obj : buffer_slices) {
-    if (const auto* buffer_region = obj.as<BufferRegionNode>()) {
-      writes.push_back(GetRef<BufferRegion>(buffer_region));
-    } else if (const auto* buffer_load = obj.as<BufferLoadNode>()) {
-      writes.push_back(BufferRegionFromLoad(GetRef<BufferLoad>(buffer_load)));
+    if (auto buffer_region = obj.as<BufferRegion>()) {
+      writes.push_back(buffer_region.value());
+    } else if (auto buffer_load = obj.as<BufferLoad>()) {
+      writes.push_back(BufferRegionFromLoad(buffer_load.value()));
     } else {
       LOG(FATAL) << "Invalid type for buffer writes.";
     }
@@ -576,8 +576,8 @@ TVM_STATIC_IR_FUNCTOR(Namer, vtable)
       int n = buffer->strides.size();
       for (int i = 0; i < n; ++i) {
         PrimExpr e = buffer->strides[i];
-        if (const tvm::tir::VarNode* v = e.as<tvm::tir::VarNode>()) {
-          Namer::Name(GetRef<tvm::tir::Var>(v), name + "_s" + std::to_string(i));
+        if (auto v = e.as<tvm::tir::Var>()) {
+          Namer::Name(v.value(), name + "_s" + std::to_string(i));
         }
       }
     });
@@ -608,11 +608,11 @@ TVM_REGISTER_GLOBAL("script.ir_builder.tir.PrimFunc").set_body_typed(PrimFunc);
 TVM_REGISTER_GLOBAL("script.ir_builder.tir.Arg")
     .set_body_typed([](String name, ObjectRef obj) -> ObjectRef {
       using namespace tvm::tir;
-      if (const auto* var = obj.as<VarNode>()) {
-        return Arg(name, GetRef<tvm::tir::Var>(var));
+      if (auto var = obj.as<Var>()) {
+        return Arg(name, var.value());
       }
-      if (const auto* buffer = obj.as<BufferNode>()) {
-        return Arg(name, GetRef<Buffer>(buffer));
+      if (auto buffer = obj.as<Buffer>()) {
+        return Arg(name, buffer.value());
       }
       LOG(FATAL) << "ValueError: Unexpected type for TIR Arg: " << obj->GetTypeKey();
       throw;
@@ -657,10 +657,10 @@ TVM_REGISTER_GLOBAL("script.ir_builder.tir.Else").set_body_typed(Else);
 TVM_REGISTER_GLOBAL("script.ir_builder.tir.DeclBuffer").set_body_typed(DeclBuffer);
 TVM_REGISTER_GLOBAL("script.ir_builder.tir.LaunchThread")
     .set_body_typed([](ObjectRef thread_tag_or_var, PrimExpr extent) {
-      if (const auto* var = thread_tag_or_var.as<tvm::tir::VarNode>()) {
-        return LaunchThread(GetRef<tvm::tir::Var>(var), extent);
-      } else if (const auto* str = thread_tag_or_var.as<StringObj>()) {
-        return LaunchThread(GetRef<String>(str), extent);
+      if (auto var = thread_tag_or_var.as<tvm::tir::Var>()) {
+        return LaunchThread(var.value(), extent);
+      } else if (auto str = thread_tag_or_var.as<String>()) {
+        return LaunchThread(str.value(), extent);
       } else {
         LOG(FATAL) << "ValueError: Unexpected type for TIR LaunchThread: "
                    << thread_tag_or_var->GetTypeKey();

--- a/src/script/printer/doc_printer/base_doc_printer.cc
+++ b/src/script/printer/doc_printer/base_doc_printer.cc
@@ -294,54 +294,54 @@ String DocPrinter::GetString() const {
 void DocPrinter::PrintDoc(const Doc& doc) {
   size_t start_pos = output_.tellp();
 
-  if (const auto* doc_node = doc.as<LiteralDocNode>()) {
-    PrintTypedDoc(GetRef<LiteralDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<IdDocNode>()) {
-    PrintTypedDoc(GetRef<IdDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<AttrAccessDocNode>()) {
-    PrintTypedDoc(GetRef<AttrAccessDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<IndexDocNode>()) {
-    PrintTypedDoc(GetRef<IndexDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<OperationDocNode>()) {
-    PrintTypedDoc(GetRef<OperationDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<CallDocNode>()) {
-    PrintTypedDoc(GetRef<CallDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<LambdaDocNode>()) {
-    PrintTypedDoc(GetRef<LambdaDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<ListDocNode>()) {
-    PrintTypedDoc(GetRef<ListDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<TupleDocNode>()) {
-    PrintTypedDoc(GetRef<TupleDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<DictDocNode>()) {
-    PrintTypedDoc(GetRef<DictDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<SliceDocNode>()) {
-    PrintTypedDoc(GetRef<SliceDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<StmtBlockDocNode>()) {
-    PrintTypedDoc(GetRef<StmtBlockDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<AssignDocNode>()) {
-    PrintTypedDoc(GetRef<AssignDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<IfDocNode>()) {
-    PrintTypedDoc(GetRef<IfDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<WhileDocNode>()) {
-    PrintTypedDoc(GetRef<WhileDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<ForDocNode>()) {
-    PrintTypedDoc(GetRef<ForDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<ScopeDocNode>()) {
-    PrintTypedDoc(GetRef<ScopeDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<ExprStmtDocNode>()) {
-    PrintTypedDoc(GetRef<ExprStmtDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<AssertDocNode>()) {
-    PrintTypedDoc(GetRef<AssertDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<ReturnDocNode>()) {
-    PrintTypedDoc(GetRef<ReturnDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<FunctionDocNode>()) {
-    PrintTypedDoc(GetRef<FunctionDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<ClassDocNode>()) {
-    PrintTypedDoc(GetRef<ClassDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<CommentDocNode>()) {
-    PrintTypedDoc(GetRef<CommentDoc>(doc_node));
-  } else if (const auto* doc_node = doc.as<DocStringDocNode>()) {
-    PrintTypedDoc(GetRef<DocStringDoc>(doc_node));
+  if (auto doc_node = doc.as<LiteralDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<IdDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<AttrAccessDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<IndexDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<OperationDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<CallDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<LambdaDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<ListDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<TupleDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<DictDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<SliceDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<StmtBlockDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<AssignDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<IfDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<WhileDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<ForDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<ScopeDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<ExprStmtDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<AssertDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<ReturnDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<FunctionDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<ClassDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<CommentDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<DocStringDoc>()) {
+    PrintTypedDoc(doc_node.value());
   } else {
     LOG(FATAL) << "Do not know how to print " << doc->GetTypeKey();
     throw;

--- a/src/script/printer/ir/ir.cc
+++ b/src/script/printer/ir/ir.cc
@@ -73,8 +73,8 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
         if (const auto* stmt_block = doc.as<StmtBlockDocNode>()) {
           (*f)->stmts.push_back(stmt_block->stmts.back());
           (*f)->stmts.back()->source_paths = std::move(doc->source_paths);
-        } else if (const auto* stmt = doc.as<StmtDocNode>()) {
-          (*f)->stmts.push_back(GetRef<StmtDoc>(stmt));
+        } else if (auto stmt = doc.as<StmtDoc>()) {
+          (*f)->stmts.push_back(stmt.value());
         } else {
           (*f)->stmts.push_back(Downcast<FunctionDoc>(doc));
         }

--- a/src/script/printer/tir/block.cc
+++ b/src/script/printer/tir/block.cc
@@ -34,9 +34,9 @@ Doc PrintBlock(IRDocsifier d, tir::Block block, ObjectPath block_p,  //
   std::unordered_map<const tir::VarNode*, tir::For> loop_vars;
   for (Frame f : d->frames) {
     if (const auto* tir_f = f.as<TIRFrameNode>()) {
-      if (const auto* for_loop = tir_f->tir.as<tir::ForNode>()) {
-        for (const tir::ForNode* l = for_loop; l != nullptr; l = l->body.as<tir::ForNode>()) {
-          loop_vars.insert(std::make_pair(l->loop_var.get(), GetRef<tir::For>(l)));
+      if (auto for_loop = tir_f->tir.as<tir::For>()) {
+        for (Optional<tir::For> loop = for_loop; loop; loop = loop.value()->body.as<tir::For>()) {
+          loop_vars.insert(std::make_pair(loop.value()->loop_var.get(), loop.value()));
         }
       }
     }

--- a/src/script/printer/tir/expr.cc
+++ b/src/script/printer/tir/expr.cc
@@ -239,15 +239,16 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           Op::GetAttrMap<tir::TScriptDtypePrintLocation>("TScriptDtypePrintLocation");
       tir::ScriptDtypePrintLocation dtype_print_location = tir::ScriptDtypePrintLocation::kNone;
       ExprDoc prefix{nullptr};
-      if (const auto* op = call->op.as<OpNode>()) {
-        String name = op_names.get(GetRef<Op>(op), op->name);
-        if (op_names.count(GetRef<Op>(op)) == 0) {
+      if (auto optional_op = call->op.as<Op>()) {
+        auto op = optional_op.value();
+        String name = op_names.get(op, op->name);
+        if (op_names.count(op) == 0) {
           LOG(WARNING) << "No TScriptPrinterName attribute for " << op->name;
         }
         prefix = TIR(d, name);
-        if (dtype_locations.count(GetRef<Op>(op))) {
-          dtype_print_location = static_cast<tir::ScriptDtypePrintLocation>(
-              dtype_locations[GetRef<Op>(op)].IntValue());
+        if (dtype_locations.count(op)) {
+          dtype_print_location =
+              static_cast<tir::ScriptDtypePrintLocation>(dtype_locations[op].IntValue());
         }
       } else if (const auto* gv = call->op.as<GlobalVarNode>()) {
         prefix = LiteralDoc::Str(gv->name_hint, call_p->Attr("op"));

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1705,8 +1705,8 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const BufferLoadNode* op) {
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const CallNode* op) {
-  if (auto* ptr_op = op->op.as<OpNode>()) {
-    auto call_op = GetRef<Op>(ptr_op);
+  if (auto opt_call_op = op->op.as<Op>()) {
+    auto call_op = opt_call_op.value();
     if (op->op.same_as(builtin_call_extern_) || op->op.same_as(builtin_call_pure_extern_)) {
       // call extern intrinsic
       ICHECK_GE(op->args.size(), 1U);

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -526,8 +526,8 @@ void CodeGenC::PrintCallExtern(Type ret_type, String global_symbol, const Array<
 }
 
 void CodeGenC::VisitExpr_(const CallNode* op, std::ostream& os) {  // NOLINT(*)
-  if (auto* ptr_op = op->op.as<OpNode>()) {
-    auto call_op = GetRef<Op>(ptr_op);
+  if (auto opt_call_op = op->op.as<Op>()) {
+    auto call_op = opt_call_op.value();
 
     if (op->op.same_as(builtin::tvm_check_return())) {
       const CallNode* call = op->args[2].as<CallNode>();

--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -687,8 +687,8 @@ void CodeGenCUDA::PrintCallExtern(Type ret_type, String global_symbol, const Arr
 }
 
 void CodeGenCUDA::VisitExpr_(const CallNode* op, std::ostream& os) {
-  if (auto* ptr_op = op->op.as<OpNode>()) {
-    Op call_op = GetRef<Op>(ptr_op);
+  if (auto opt_call_opt = op->op.as<Op>()) {
+    Op call_op = opt_call_opt.value();
     // This is only for backward compatibility with __shfl_{up/down}.
     // A macro will be used to replace *_sync calls to legacy ones.
     if (op_need_warp_shuffle_.get(call_op, false)) {

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -427,10 +427,10 @@ ObjectRef TargetInternal::ParseType(const ObjectRef& obj,
     return GetRef<String>(ObjTypeCheck<StringObj>(obj, "String"));
   } else if (info.type_index == Target::ContainerType::_GetOrAllocRuntimeTypeIndex()) {
     // Parsing target
-    if (const auto* ptr = obj.as<TargetNode>()) {
-      return GetRef<Target>(ptr);
-    } else if (const auto* ptr = obj.as<StringObj>()) {
-      return Target(TargetInternal::FromString(GetRef<String>(ptr)));
+    if (auto opt = obj.as<Target>()) {
+      return opt.value();
+    } else if (auto str = obj.as<String>()) {
+      return Target(TargetInternal::FromString(str.value()));
     } else if (const auto* ptr = obj.as<MapNode>()) {
       for (const auto& kv : *ptr) {
         if (!kv.first->IsInstance<StringObj>()) {
@@ -495,8 +495,8 @@ std::string TargetInternal::StringifyAtomicType(const ObjectRef& obj) {
   if (const auto* p = obj.as<IntImmNode>()) {
     return std::to_string(p->value);
   }
-  if (const auto* p = obj.as<StringObj>()) {
-    auto s = static_cast<std::string>(GetRef<String>(p));
+  if (auto tvm_str = obj.as<String>()) {
+    std::string s = tvm_str.value();
     auto u = Uninterpret(s);
     if (u.find_first_of(' ') != std::string::npos && !IsQuoted(u)) {
       u = Quote(u);
@@ -660,9 +660,7 @@ Map<String, ObjectRef> TargetNode::Export() const {
   return result;
 }
 
-Optional<Target> TargetNode::GetHost() const {
-  return GetRef<Optional<Target>>(this->host.as<TargetNode>());
-}
+Optional<Target> TargetNode::GetHost() const { return this->host.as<Target>(); }
 
 int TargetNode::GetTargetDeviceType() const {
   if (Optional<Integer> device_type = GetAttr<Integer>("target_device_type")) {
@@ -853,8 +851,8 @@ ObjectPtr<Object> TargetInternal::FromConfig(Map<String, ObjectRef> config) {
 
   // parse 'kind'
   if (config.count(kKind)) {
-    if (const auto* kind = config[kKind].as<StringObj>()) {
-      target->kind = GetTargetKind(GetRef<String>(kind));
+    if (auto kind = config[kKind].as<String>()) {
+      target->kind = GetTargetKind(kind.value());
       ICHECK(!(target->kind->preprocessor != nullptr && target->kind->target_parser != nullptr))
           << "Cannot use both set_attrs_preprocessor and set_target_parser";
 
@@ -878,8 +876,8 @@ ObjectPtr<Object> TargetInternal::FromConfig(Map<String, ObjectRef> config) {
   }
   // parse "tag"
   if (config.count(kTag)) {
-    if (const auto* tag = config[kTag].as<StringObj>()) {
-      target->tag = GetRef<String>(tag);
+    if (auto tag = config[kTag].as<String>()) {
+      target->tag = tag.value();
       config.erase(kTag);
     } else {
       throw Error(": Expect type of field \"tag\" is String, but get type: " +
@@ -896,8 +894,8 @@ ObjectPtr<Object> TargetInternal::FromConfig(Map<String, ObjectRef> config) {
       // user provided keys
       if (const auto* cfg_keys = config[kKeys].as<ArrayNode>()) {
         for (const ObjectRef& e : *cfg_keys) {
-          if (const auto* key = e.as<StringObj>()) {
-            keys.push_back(GetRef<String>(key));
+          if (auto key = e.as<String>()) {
+            keys.push_back(key.value());
           } else {
             throw Error(
                 ": Expect 'keys' to be an array of strings, but it "
@@ -912,8 +910,8 @@ ObjectPtr<Object> TargetInternal::FromConfig(Map<String, ObjectRef> config) {
     }
     // add device name
     if (config.count(kDeviceName)) {
-      if (const auto* device = config.at(kDeviceName).as<StringObj>()) {
-        keys.push_back(GetRef<String>(device));
+      if (auto device = config.at(kDeviceName).as<String>()) {
+        keys.push_back(device.value());
       }
     }
     if (!has_user_keys) {

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -135,10 +135,9 @@ void CheckOrSetAttr(Map<String, ObjectRef>* attrs, const String& name, const Str
   if (iter == attrs->end()) {
     attrs->Set(name, value);
   } else {
-    const auto* str = (*iter).second.as<StringObj>();
-    ICHECK(str != nullptr && GetRef<String>(str) == value)
-        << "ValueError: Expects \"" << name << "\" to be \"" << value
-        << "\", but gets: " << (*iter).second;
+    auto str = (*iter).second.as<String>();
+    ICHECK(str && str.value() == value) << "ValueError: Expects \"" << name << "\" to be \""
+                                        << value << "\", but gets: " << (*iter).second;
   }
 }
 

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -126,8 +126,8 @@ class LayoutFreePlaceholdersNormalizer : public StmtMutator {
  public:
   PrimFunc Process(PrimFunc func) {
     for (int i = 0, n = func->params.size(); i < n; ++i) {
-      if (const auto* v = func->params[i].as<VarNode>()) {
-        if (Optional<Buffer> buffer = func->buffer_map.Get(GetRef<Var>(v))) {
+      if (auto v = func->params[i].as<Var>()) {
+        if (Optional<Buffer> buffer = func->buffer_map.Get(v.value())) {
           buffer2index_[buffer.value()] = i;
         }
       }
@@ -298,8 +298,8 @@ BlockRealize GenerateBlockFromTensors(const te::ComputeOp& compute_op,
   // Step 5. Add script_parsing_detect_access attr for auto complete the whole IR.
   Map<String, ObjectRef> annotations;
   auto mutate_attr = [&info](const ObjectRef& value) -> ObjectRef {
-    if (const auto* tensor_value = value.as<te::TensorNode>()) {
-      return info->tensor2buffers.at(GetRef<te::Tensor>(tensor_value));
+    if (auto tensor_value = value.as<te::Tensor>()) {
+      return info->tensor2buffers.at(tensor_value.value());
     } else {
       return value;
     }
@@ -499,13 +499,12 @@ void RewriteStageToBlock(const te::Operation& op, CreateFuncInfo* info, Array<St
           decl_buffer(placeholder->shape, placeholder->dtype, placeholder->name, "global");
       info->tensor2buffers[tensor] = buffer;
     }
-  } else if (const auto* compute_op = op.as<te::ComputeOpNode>()) {
+  } else if (auto compute_op = op.as<te::ComputeOp>()) {
     // Case 2. ComputeOp (te.compute)
-    root_stmts->push_back(
-        GenerateStmtFromCompute(GetRef<te::ComputeOp>(compute_op), info, analyzer));
-  } else if (const auto extern_op = op.as<te::ExternOpNode>()) {
+    root_stmts->push_back(GenerateStmtFromCompute(compute_op.value(), info, analyzer));
+  } else if (const auto extern_op = op.as<te::ExternOp>()) {
     // Case 3. ExternOp (te.extern)
-    root_stmts->push_back(GenerateStmtFromExternOp(GetRef<te::ExternOp>(extern_op), info));
+    root_stmts->push_back(GenerateStmtFromExternOp(extern_op.value(), info));
   } else {
     ICHECK(false) << "TypeError: Unsupported Operation: " << op->GetTypeKey() << ". "
                   << "Only te.placeholder and te.compute are allowed for now.";

--- a/src/tir/analysis/calculate_allocated_memory.cc
+++ b/src/tir/analysis/calculate_allocated_memory.cc
@@ -101,9 +101,8 @@ namespace transform {
 Pass VerifyVTCMLimit(const Integer& limit) {
   auto pass_func = [=](IRModule mod, PassContext ctx) {
     for (auto kv : mod->functions) {
-      if (auto* n = kv.second.as<PrimFuncNode>()) {
-        auto func = GetRef<PrimFunc>(n);
-        auto sizes = CalculateAllocatedBytes(func);
+      if (auto func = kv.second.as<PrimFunc>()) {
+        auto sizes = CalculateAllocatedBytes(func.value());
         const auto vtcm_allocated = sizes.Get("global.vtcm").value_or(0);
         if (limit.IntValue() > 0 && vtcm_allocated.IntValue() > limit.IntValue()) {
           LOG(FATAL) << "RuntimeError: The global.vtcm memory allocation limit has been "

--- a/src/tir/analysis/control_flow_graph.cc
+++ b/src/tir/analysis/control_flow_graph.cc
@@ -291,11 +291,11 @@ class ControlFlowGraphBuilder final : public IRVisitorWithAnalyzer {
 
     tir::BufferLoad load;
     PrimExpr value;
-    if (auto* as_load = as_equal_node->a.as<tir::BufferLoadNode>()) {
-      load = GetRef<tir::BufferLoad>(as_load);
+    if (auto opt = as_equal_node->a.as<tir::BufferLoad>()) {
+      load = opt.value();
       value = as_equal_node->b;
-    } else if (auto* as_load = as_equal_node->b.as<tir::BufferLoadNode>()) {
-      load = GetRef<tir::BufferLoad>(as_load);
+    } else if (auto opt = as_equal_node->b.as<tir::BufferLoad>()) {
+      load = opt.value();
       value = as_equal_node->a;
     } else if (!from_assume_statement) {
       return;

--- a/src/tir/analysis/estimate_flops.cc
+++ b/src/tir/analysis/estimate_flops.cc
@@ -220,10 +220,10 @@ double EstimateTIRFlops(const IRModule& mod) {
 }
 
 TVM_REGISTER_GLOBAL("tir.analysis.EstimateTIRFlops").set_body_typed([](ObjectRef obj) -> double {
-  if (const auto* mod = obj.as<IRModuleNode>()) {
-    return EstimateTIRFlops(GetRef<IRModule>(mod));
-  } else if (const auto* stmt = obj.as<StmtNode>()) {
-    return EstimateTIRFlops(GetRef<Stmt>(stmt));
+  if (auto mod = obj.as<IRModule>()) {
+    return EstimateTIRFlops(mod.value());
+  } else if (auto stmt = obj.as<Stmt>()) {
+    return EstimateTIRFlops(stmt.value());
   } else {
     LOG(FATAL) << "TypeError: Expect the input to be either IRModule or Stmt, but gets: "
                << obj->GetTypeKey();

--- a/src/tir/analysis/identify_memcpy.cc
+++ b/src/tir/analysis/identify_memcpy.cc
@@ -58,8 +58,8 @@ std::variant<MemCpyDetails, std::string> IdentifyMemCpyImpl(const For& loop,
   }
 
   BufferStore store;
-  if (auto* ptr = stmt.as<BufferStoreNode>()) {
-    store = GetRef<BufferStore>(ptr);
+  if (auto opt = stmt.as<BufferStore>()) {
+    store = opt.value();
   } else {
     return static_cast<const std::stringstream&>(
                std::stringstream()
@@ -68,8 +68,8 @@ std::variant<MemCpyDetails, std::string> IdentifyMemCpyImpl(const For& loop,
   }
 
   BufferLoad load;
-  if (auto* ptr = store->value.as<BufferLoadNode>()) {
-    load = GetRef<BufferLoad>(ptr);
+  if (auto opt = store->value.as<BufferLoad>()) {
+    load = opt.value();
   } else {
     return static_cast<const std::stringstream&>(
                std::stringstream()

--- a/src/tir/analysis/side_effect.cc
+++ b/src/tir/analysis/side_effect.cc
@@ -45,8 +45,8 @@ class ExprSideEffect : public ExprVisitor {
   void VisitExpr_(const CallNode* op) final {
     static auto op_call_effect = Op::GetAttrMap<TCallEffectKind>("TCallEffectKind");
 
-    if (auto* ptr_op = op->op.as<OpNode>()) {
-      this->UpdateEffect(static_cast<CallEffectKind>(op_call_effect[GetRef<Op>(ptr_op)]->value));
+    if (auto opt = op->op.as<Op>()) {
+      this->UpdateEffect(static_cast<CallEffectKind>(op_call_effect[opt.value()]->value));
     } else {
       this->UpdateEffect(CallEffectKind::kOpaque);
     }

--- a/src/tir/analysis/verify_gpu_code.cc
+++ b/src/tir/analysis/verify_gpu_code.cc
@@ -328,9 +328,8 @@ namespace transform {
 Pass VerifyGPUCode(Map<String, PrimExpr> constraints) {
   auto pass_func = [=](IRModule mod, PassContext ctx) {
     for (auto kv : mod->functions) {
-      if (auto* n = kv.second.as<PrimFuncNode>()) {
-        auto func = GetRef<PrimFunc>(n);
-        auto errs = VerifyGPUCode_(func, constraints);
+      if (auto func = kv.second.as<PrimFunc>()) {
+        auto errs = VerifyGPUCode_(func.value(), constraints);
         if (errs.size() != 0) {
           std::stringstream s;
           for (auto& err : errs) {

--- a/src/tir/analysis/verify_memory.cc
+++ b/src/tir/analysis/verify_memory.cc
@@ -195,9 +195,8 @@ namespace transform {
 Pass VerifyMemory() {
   auto pass_func = [=](IRModule mod, PassContext ctx) {
     for (auto kv : mod->functions) {
-      if (auto* n = kv.second.as<PrimFuncNode>()) {
-        auto func = GetRef<PrimFunc>(n);
-        auto errs = VerifyMemory_(func);
+      if (auto func = kv.second.as<PrimFunc>()) {
+        auto errs = VerifyMemory_(func.value());
         if (errs.size() > 0) {
           std::stringstream s;
           for (auto& err : errs) {

--- a/src/tir/analysis/verify_ssa.cc
+++ b/src/tir/analysis/verify_ssa.cc
@@ -146,9 +146,8 @@ namespace transform {
 Pass VerifySSA() {
   auto pass_func = [=](IRModule mod, PassContext ctx) {
     for (auto kv : mod->functions) {
-      if (auto* n = kv.second.as<PrimFuncNode>()) {
-        auto func = GetRef<PrimFunc>(n);
-        ICHECK(VerifySSA(func)) << "RuntimeError: IR is not in SSA form" << func;
+      if (auto func = kv.second.as<PrimFunc>()) {
+        ICHECK(VerifySSA(func.value())) << "RuntimeError: IR is not in SSA form" << func;
       }
     }
     return mod;

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -513,7 +513,7 @@ TVM_REGISTER_GLOBAL("tir.Call")
         if (const auto* str = it.as<runtime::StringObj>()) {
           prim_expr_args.push_back(StringImm(str->data));
         } else if (const auto* iter_var = it.as<IterVarNode>()) {
-          prim_expr_args.push_back(GetRef<IterVar>(iter_var)->var);
+          prim_expr_args.push_back(iter_var->var);
         } else if (const auto* br = it.as<BufferRegionNode>()) {
           Array<PrimExpr> indices;
           for (Range r : br->region) {

--- a/src/tir/ir/stmt_functor.cc
+++ b/src/tir/ir/stmt_functor.cc
@@ -708,8 +708,8 @@ class IRSubstitute : public StmtExprMutator {
     Stmt ret = StmtExprMutator::VisitStmt_(op);
     op = ret.as<AttrStmtNode>();
     // remap var node in attr
-    if (const auto* var_node = op->node.as<VarNode>()) {
-      if (auto mapped_var = vmap_(GetRef<Var>(var_node))) {
+    if (auto var_node = op->node.as<Var>()) {
+      if (auto mapped_var = vmap_(var_node.value())) {
         return AttrStmt(mapped_var, op->attr_key, op->value, op->body);
       }
     }
@@ -770,10 +770,10 @@ void PreOrderVisit(const ObjectRef& stmt_or_expr,
   };
 
   PreOrderVisitor visitor(fvisit);
-  if (const auto* stmt = stmt_or_expr.as<StmtNode>()) {
-    visitor(GetRef<Stmt>(stmt));
-  } else if (const auto* expr = stmt_or_expr.as<PrimExprNode>()) {
-    visitor(GetRef<PrimExpr>(expr));
+  if (auto stmt = stmt_or_expr.as<Stmt>()) {
+    visitor(stmt.value());
+  } else if (auto expr = stmt_or_expr.as<PrimExpr>()) {
+    visitor(expr.value());
   } else {
     LOG(FATAL) << "InternalError: PreOrderVisit does not accept object with type: "
                << stmt_or_expr->GetTypeKey();
@@ -840,8 +840,8 @@ class IRSubstituteWithDataTypeLegalization : public DataTypeLegalizer {
     Stmt ret = StmtExprMutator::VisitStmt_(op);
     op = ret.as<AttrStmtNode>();
     // remap var node in attr
-    if (const auto* var_node = op->node.as<VarNode>()) {
-      if (auto mapped_var = vmap_(GetRef<Var>(var_node))) {
+    if (auto var_node = op->node.as<Var>()) {
+      if (auto mapped_var = vmap_(var_node.value())) {
         return AttrStmt(mapped_var, op->attr_key, op->value, op->body);
       }
     }

--- a/src/tir/schedule/analysis/layout.cc
+++ b/src/tir/schedule/analysis/layout.cc
@@ -105,8 +105,8 @@ class SplitExprCollector {
         return;
       }
       exprs_.push_back(SplitExpr{GetRef<Var>(var), *lower_factor, *extent});
-    } else if (const auto* iter_sum_expr = expr->source->source.as<arith::IterSumExprNode>()) {
-      Visit(GetRef<arith::IterSumExpr>(iter_sum_expr));
+    } else if (auto iter_sum_expr = expr->source->source.as<arith::IterSumExpr>()) {
+      Visit(iter_sum_expr.value());
     } else {
       ICHECK(false) << "Unexpected type: " << expr->source->source->GetTypeKey();
     }

--- a/src/tir/schedule/analysis/reducer.cc
+++ b/src/tir/schedule/analysis/reducer.cc
@@ -437,20 +437,20 @@ std::pair<Array<PrimExpr>, Array<BufferStore>> GetInitValuesAndUpdatesFromReduct
   Array<BufferStore> updates;
 
   // Step 1. Extract the BufferStores serving as block inits.
-  if (const auto* init = block->init.as<BufferStoreNode>()) {
-    inits.push_back(GetRef<BufferStore>(init));
+  if (auto init = block->init.as<BufferStore>()) {
+    inits.push_back(init.value());
   } else if (const auto* seq_init = block->init.as<SeqStmtNode>()) {
     std::unordered_set<const BufferNode*> init_buffers;
     for (const Stmt& stmt : seq_init->seq) {
-      init = stmt.as<BufferStoreNode>();
-      if (init == nullptr) {
+      auto init = stmt.as<BufferStore>();
+      if (!init) {
         ErrorRFactorCrossThreadReductionNotApplicable(self, std::move(block), /*violated_cond=*/1);
       }
-      auto insert_result = init_buffers.insert(init->buffer.get());
+      auto insert_result = init_buffers.insert(init.value()->buffer.get());
       if (!insert_result.second) {
         ErrorRFactorCrossThreadReductionNotApplicable(self, std::move(block), /*violated_cond=*/2);
       }
-      inits.push_back(GetRef<BufferStore>(init));
+      inits.push_back(init.value());
     }
   } else {
     ErrorRFactorCrossThreadReductionNotApplicable(self, std::move(block), /*violated_cond=*/1);

--- a/src/tir/schedule/primitive/annotate.cc
+++ b/src/tir/schedule/primitive/annotate.cc
@@ -97,11 +97,11 @@ struct AnnotateTraits : public UnpackedInstTraits<AnnotateTraits> {
 
   static void UnpackedApplyToSchedule(Schedule sch, ObjectRef block_or_loop_rv, ObjectRef ann_val,
                                       String ann_key) {
-    if (const auto* block = block_or_loop_rv.as<BlockRVNode>()) {
-      return sch->Annotate(GetRef<BlockRV>(block), ann_key, ann_val);
+    if (auto block = block_or_loop_rv.as<BlockRV>()) {
+      return sch->Annotate(block.value(), ann_key, ann_val);
     }
-    if (const auto* loop = block_or_loop_rv.as<LoopRVNode>()) {
-      return sch->Annotate(GetRef<LoopRV>(loop), ann_key, ann_val);
+    if (auto loop = block_or_loop_rv.as<LoopRV>()) {
+      return sch->Annotate(loop.value(), ann_key, ann_val);
     }
     LOG(FATAL) << "TypeError: Expected Block or Loop, but gets: " << block_or_loop_rv->GetTypeKey();
     throw;
@@ -130,11 +130,11 @@ struct UnannotateTraits : public UnpackedInstTraits<UnannotateTraits> {
   static constexpr size_t kNumDecisions = 0;
 
   static void UnpackedApplyToSchedule(Schedule sch, ObjectRef block_or_loop_rv, String ann_key) {
-    if (const auto* block = block_or_loop_rv.as<BlockRVNode>()) {
-      return sch->Unannotate(GetRef<BlockRV>(block), ann_key);
+    if (auto block = block_or_loop_rv.as<BlockRV>()) {
+      return sch->Unannotate(block.value(), ann_key);
     }
-    if (const auto* loop = block_or_loop_rv.as<LoopRVNode>()) {
-      return sch->Unannotate(GetRef<LoopRV>(loop), ann_key);
+    if (auto loop = block_or_loop_rv.as<LoopRV>()) {
+      return sch->Unannotate(loop.value(), ann_key);
     }
     LOG(FATAL) << "TypeError: Expected Block or Loop, but gets: " << block_or_loop_rv->GetTypeKey();
     throw;

--- a/src/tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/tir/schedule/primitive/blockize_tensorize.cc
@@ -654,10 +654,10 @@ struct TensorizeTraits : public UnpackedInstTraits<TensorizeTraits> {
 
   static void UnpackedApplyToSchedule(Schedule sch, ObjectRef block_or_loop_rv, String intrin,
                                       Bool preserve_unit_iters) {
-    if (const auto* block = block_or_loop_rv.as<BlockRVNode>()) {
-      sch->Tensorize(GetRef<BlockRV>(block), intrin, preserve_unit_iters.operator bool());
-    } else if (const auto* loop = block_or_loop_rv.as<LoopRVNode>()) {
-      sch->Tensorize(GetRef<LoopRV>(loop), intrin, preserve_unit_iters.operator bool());
+    if (auto block = block_or_loop_rv.as<BlockRV>()) {
+      sch->Tensorize(block.value(), intrin, preserve_unit_iters.operator bool());
+    } else if (auto loop = block_or_loop_rv.as<LoopRV>()) {
+      sch->Tensorize(loop.value(), intrin, preserve_unit_iters.operator bool());
     } else {
       LOG(FATAL) << "TypeError: Expected Block or Loop, but gets: "
                  << block_or_loop_rv->GetTypeKey();

--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -2013,8 +2013,8 @@ StmtSRef ReIndex(ScheduleState self, const StmtSRef& block_sref, int buffer_inde
   std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> covered;
   for (const PrimExpr& index : original_indices) {
     PreOrderVisit(index, [&](const ObjectRef& obj) -> bool {
-      if (const VarNode* var = obj.as<VarNode>()) {
-        covered.insert(GetRef<Var>(var));
+      if (auto var = obj.as<Var>()) {
+        covered.insert(var.value());
       }
       return true;
     });

--- a/src/tir/schedule/primitive/decompose_padding.cc
+++ b/src/tir/schedule/primitive/decompose_padding.cc
@@ -291,10 +291,10 @@ static std::pair<Stmt, BlockRealize> CreateInBoundBlock(const BlockRealizeNode* 
     repl_dict.Set(origin_itervar->var, new_var + info.in_bound_region[i]->min);
 
     // update new loop range
-    Var loop_var = GetRef<Var>(realize->iter_values[i].as<VarNode>());
-    if (loop_var.defined() && new_loop_ranges.count(loop_var)) {
+    if (auto opt = realize->iter_values[i].as<Var>(); opt && new_loop_ranges.count(opt.value())) {
       // if the block binding is the loop var with single child, mutate loop range
       // instead of insert extra block predicate
+      auto loop_var = opt.value();
       new_loop_ranges.Set(loop_var, new_range);
       new_iter_binding.push_back(realize->iter_values[i]);
       repl_dict.Set(loop_var, loop_var + info.in_bound_region[i]->min);

--- a/src/tir/schedule/primitive/get_block_loop.cc
+++ b/src/tir/schedule/primitive/get_block_loop.cc
@@ -149,11 +149,11 @@ struct GetChildBlocksTraits : public UnpackedInstTraits<GetChildBlocksTraits> {
   static constexpr size_t kNumDecisions = 0;
 
   static Array<BlockRV> UnpackedApplyToSchedule(Schedule sch, ObjectRef block_or_loop_rv) {
-    if (const auto* block = block_or_loop_rv.as<BlockRVNode>()) {
-      return sch->GetChildBlocks(GetRef<BlockRV>(block));
+    if (auto block = block_or_loop_rv.as<BlockRV>()) {
+      return sch->GetChildBlocks(block.value());
     }
-    if (const auto* loop = block_or_loop_rv.as<LoopRVNode>()) {
-      return sch->GetChildBlocks(GetRef<LoopRV>(loop));
+    if (auto loop = block_or_loop_rv.as<LoopRV>()) {
+      return sch->GetChildBlocks(loop.value());
     }
     LOG(FATAL) << "TypeError: Expected Block or Loop, but gets: " << block_or_loop_rv->GetTypeKey();
     throw;

--- a/src/tir/schedule/primitive/loop_transformation.cc
+++ b/src/tir/schedule/primitive/loop_transformation.cc
@@ -1059,10 +1059,10 @@ struct AddUnitLoopTraits : public UnpackedInstTraits<AddUnitLoopTraits> {
   static constexpr size_t kNumDecisions = 0;
 
   static LoopRV UnpackedApplyToSchedule(Schedule sch, ObjectRef rv) {
-    if (const auto* block = rv.as<BlockRVNode>()) {
-      return sch->AddUnitLoop(GetRef<BlockRV>(block));
-    } else if (const auto* loop = rv.as<LoopRVNode>()) {
-      return sch->AddUnitLoop(GetRef<LoopRV>(loop));
+    if (auto block = rv.as<BlockRV>()) {
+      return sch->AddUnitLoop(block.value());
+    } else if (auto loop = rv.as<LoopRV>()) {
+      return sch->AddUnitLoop(loop.value());
     } else {
       LOG(FATAL) << "TypeError: AddUnitLoop expects a loop or block";
       throw;

--- a/src/tir/schedule/schedule.cc
+++ b/src/tir/schedule/schedule.cc
@@ -82,14 +82,14 @@ TVM_REGISTER_GLOBAL("tir.schedule.TracedSchedule")
 
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleGet")
     .set_body_typed([](Schedule self, ObjectRef obj) -> ObjectRef {
-      if (const auto* loop_rv = obj.as<LoopRVNode>()) {
-        return self->Get(GetRef<LoopRV>(loop_rv));
+      if (auto loop_rv = obj.as<LoopRV>()) {
+        return self->Get(loop_rv.value());
       }
-      if (const auto* block_rv = obj.as<BlockRVNode>()) {
-        return self->Get(GetRef<BlockRV>(block_rv));
+      if (auto block_rv = obj.as<BlockRV>()) {
+        return self->Get(block_rv.value());
       }
-      if (const auto* expr_rv = obj.as<ExprRVNode>()) {
-        return self->Get(GetRef<ExprRV>(expr_rv));
+      if (auto expr_rv = obj.as<ExprRV>()) {
+        return self->Get(expr_rv.value());
       }
       LOG(FATAL) << "TypeError: Cannot evaluate the random variable of type: " << obj->GetTypeKey()
                  << ". Its value is: " << obj;
@@ -97,28 +97,28 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleGet")
     });
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleGetSRef")
     .set_body_typed([](Schedule self, ObjectRef obj) -> Optional<ObjectRef> {
-      if (const auto* loop_rv = obj.as<LoopRVNode>()) {
-        return self->GetSRef(GetRef<LoopRV>(loop_rv));
+      if (auto loop_rv = obj.as<LoopRV>()) {
+        return self->GetSRef(loop_rv.value());
       }
-      if (const auto* block_rv = obj.as<BlockRVNode>()) {
-        return self->GetSRef(GetRef<BlockRV>(block_rv));
+      if (auto block_rv = obj.as<BlockRV>()) {
+        return self->GetSRef(block_rv.value());
       }
-      if (const auto* stmt = obj.as<StmtNode>()) {
-        return self->GetSRef(GetRef<Stmt>(stmt));
+      if (auto stmt = obj.as<Stmt>()) {
+        return self->GetSRef(stmt.value());
       }
       LOG(FATAL) << "TypeError: Invalid type: " << obj->GetTypeKey();
       throw;
     });
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleRemoveRV")
     .set_body_typed([](Schedule self, ObjectRef obj) -> void {
-      if (const auto* loop_rv = obj.as<LoopRVNode>()) {
-        return self->RemoveRV(GetRef<LoopRV>(loop_rv));
+      if (auto loop_rv = obj.as<LoopRV>()) {
+        return self->RemoveRV(loop_rv.value());
       }
-      if (const auto* block_rv = obj.as<BlockRVNode>()) {
-        return self->RemoveRV(GetRef<BlockRV>(block_rv));
+      if (auto block_rv = obj.as<BlockRV>()) {
+        return self->RemoveRV(block_rv.value());
       }
-      if (const auto* expr_rv = obj.as<ExprRVNode>()) {
-        return self->RemoveRV(GetRef<ExprRV>(expr_rv));
+      if (auto expr_rv = obj.as<ExprRV>()) {
+        return self->RemoveRV(expr_rv.value());
       }
       LOG(FATAL) << "TypeError: Invalid type: " << obj->GetTypeKey();
       throw;
@@ -138,11 +138,11 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleGetLoops")
     .set_body_method<Schedule>(&ScheduleNode::GetLoops);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleGetChildBlocks")
     .set_body_typed([](Schedule self, ObjectRef rv) {
-      if (const auto* block_rv = rv.as<BlockRVNode>()) {
-        return self->GetChildBlocks(GetRef<BlockRV>(block_rv));
+      if (auto block_rv = rv.as<BlockRV>()) {
+        return self->GetChildBlocks(block_rv.value());
       }
-      if (const auto* loop_rv = rv.as<LoopRVNode>()) {
-        return self->GetChildBlocks(GetRef<LoopRV>(loop_rv));
+      if (auto loop_rv = rv.as<LoopRV>()) {
+        return self->GetChildBlocks(loop_rv.value());
       }
       LOG(FATAL) << "TypeError: Cannot evaluate the random variable of type: " << rv->GetTypeKey()
                  << ". Its value is: " << rv;
@@ -162,10 +162,10 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleReorderBlockIterVar")
     .set_body_method<Schedule>(&ScheduleNode::ReorderBlockIterVar);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleAddUnitLoop")
     .set_body_typed([](Schedule self, ObjectRef rv) -> LoopRV {
-      if (const auto* loop_rv = rv.as<LoopRVNode>()) {
-        return self->AddUnitLoop(GetRef<LoopRV>(loop_rv));
-      } else if (const auto* block_rv = rv.as<BlockRVNode>()) {
-        return self->AddUnitLoop(GetRef<BlockRV>(block_rv));
+      if (auto loop_rv = rv.as<LoopRV>()) {
+        return self->AddUnitLoop(loop_rv.value());
+      } else if (auto block_rv = rv.as<BlockRV>()) {
+        return self->AddUnitLoop(block_rv.value());
       } else {
         LOG(FATAL) << "TypeError: Cannot evaluate the random variable of type: " << rv->GetTypeKey()
                    << ". Its value is: " << rv;
@@ -227,10 +227,10 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleBlockize")
     .set_body_method<Schedule>(&ScheduleNode::Blockize);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleTensorize")
     .set_body_typed([](Schedule self, ObjectRef rv, String intrin, bool preserve_unit_iters) {
-      if (const auto* block_rv = rv.as<BlockRVNode>()) {
-        self->Tensorize(GetRef<BlockRV>(block_rv), intrin, preserve_unit_iters);
-      } else if (const auto* loop_rv = rv.as<LoopRVNode>()) {
-        self->Tensorize(GetRef<LoopRV>(loop_rv), intrin, preserve_unit_iters);
+      if (auto block_rv = rv.as<BlockRV>()) {
+        self->Tensorize(block_rv.value(), intrin, preserve_unit_iters);
+      } else if (auto loop_rv = rv.as<LoopRV>()) {
+        self->Tensorize(loop_rv.value(), intrin, preserve_unit_iters);
       } else {
         LOG(FATAL) << "TypeError: Cannot evaluate the random variable of type: " << rv->GetTypeKey()
                    << ". Its value is: " << rv;
@@ -241,11 +241,11 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleTensorize")
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleAnnotate")
     .set_body_typed([](Schedule self, ObjectRef rv, const String& ann_key,
                        const ObjectRef& ann_val) {
-      if (const auto* block_rv = rv.as<BlockRVNode>()) {
-        return self->Annotate(GetRef<BlockRV>(block_rv), ann_key, ann_val);
+      if (auto block_rv = rv.as<BlockRV>()) {
+        return self->Annotate(block_rv.value(), ann_key, ann_val);
       }
-      if (const auto* loop_rv = rv.as<LoopRVNode>()) {
-        return self->Annotate(GetRef<LoopRV>(loop_rv), ann_key, ann_val);
+      if (auto loop_rv = rv.as<LoopRV>()) {
+        return self->Annotate(loop_rv.value(), ann_key, ann_val);
       }
       LOG(FATAL) << "TypeError: Cannot evaluate the random variable of type: " << rv->GetTypeKey()
                  << ". Its value is: " << rv;
@@ -253,11 +253,11 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleAnnotate")
     });
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleUnannotate")
     .set_body_typed([](Schedule self, ObjectRef rv, const String& ann_key) {
-      if (const auto* block_rv = rv.as<BlockRVNode>()) {
-        return self->Unannotate(GetRef<BlockRV>(block_rv), ann_key);
+      if (auto block_rv = rv.as<BlockRV>()) {
+        return self->Unannotate(block_rv.value(), ann_key);
       }
-      if (const auto* loop_rv = rv.as<LoopRVNode>()) {
-        return self->Unannotate(GetRef<LoopRV>(loop_rv), ann_key);
+      if (auto loop_rv = rv.as<LoopRV>()) {
+        return self->Unannotate(loop_rv.value(), ann_key);
       }
       LOG(FATAL) << "TypeError: Cannot evaluate the random variable of type: " << rv->GetTypeKey()
                  << ". Its value is: " << rv;

--- a/src/tir/schedule/state.cc
+++ b/src/tir/schedule/state.cc
@@ -421,8 +421,9 @@ class StateCreator : private StmtVisitor {
     StateCreator creator(self);
     for (const auto& kv : n->mod->functions) {
       const BaseFunc& base_func = kv.second;
-      if (const auto* func = base_func.as<PrimFuncNode>()) {
-        VerifyWellFormed(GetRef<PrimFunc>(func));
+      if (auto opt = base_func.as<PrimFunc>()) {
+        auto func = opt.value();
+        VerifyWellFormed(func);
         creator.VisitStmt(func->body);
         BlockInfoCollector::Collect(self, func->body);
       }

--- a/src/tir/schedule/trace.cc
+++ b/src/tir/schedule/trace.cc
@@ -78,13 +78,13 @@ Array<ObjectRef> TranslateInputRVs(const Array<ObjectRef>& inputs,
       auto it = rv_map.find(input.get());
       ICHECK(it != rv_map.end()) << "IndexError: Random variable doesn't exist: " << input;
       result.push_back(GetRef<ObjectRef>(it->second));
-    } else if (const auto* expr = input.as<PrimExprNode>()) {  // RV: Expr
-      result.push_back(Substitute(GetRef<PrimExpr>(expr), f_subst_with_rv_map));
-    } else if (const auto* index_map = input.as<IndexMapNode>()) {
-      result.push_back(Substitute(GetRef<IndexMap>(index_map), f_subst_with_rv_map));
-    } else if (input->IsInstance<ArrayNode>()) {
+    } else if (auto expr = input.as<PrimExpr>()) {  // RV: Expr
+      result.push_back(Substitute(expr.value(), f_subst_with_rv_map));
+    } else if (auto index_map = input.as<IndexMap>()) {
+      result.push_back(Substitute(index_map.value(), f_subst_with_rv_map));
+    } else if (auto arr = input.as<Array<ObjectRef>>()) {
       // Recursively convert elements of the array into a new list of ObjectRefs.
-      result.push_back(TranslateInputRVs(Downcast<Array<ObjectRef>>(input), rv_map));
+      result.push_back(TranslateInputRVs(arr.value(), rv_map));
     } else {
       ICHECK(false) << "TypeError: Cannot recognize the type of an input random variable: "
                     << input->GetTypeKey();

--- a/src/tir/transforms/bf16_legalize.cc
+++ b/src/tir/transforms/bf16_legalize.cc
@@ -304,13 +304,13 @@ class BF16ComputeLegalizer : public StmtExprMutator {
     Stmt ret = StmtExprMutator::VisitStmt_(op);
     op = ret.as<AttrStmtNode>();
 
-    if (auto* buffer = op->node.as<BufferNode>()) {
-      auto it = buffer_remap_.find(GetRef<Buffer>(buffer));
+    if (auto buffer = op->node.as<Buffer>()) {
+      auto it = buffer_remap_.find(buffer.value());
       if (it != buffer_remap_.end()) {
         return AttrStmt(it->second, op->attr_key, op->value, op->body);
       }
-    } else if (auto* var = op->node.as<VarNode>()) {
-      auto it = var_remap_.find(GetRef<Var>(var));
+    } else if (auto var = op->node.as<Var>()) {
+      auto it = var_remap_.find(var.value());
       if (it != var_remap_.end()) {
         return AttrStmt(it->second, op->attr_key, op->value, op->body);
       }
@@ -523,13 +523,13 @@ class BF16StorageLegalizer : public StmtExprMutator {
     Stmt ret = StmtExprMutator::VisitStmt_(op);
     op = ret.as<AttrStmtNode>();
 
-    if (auto* buffer = op->node.as<BufferNode>()) {
-      auto it = buffer_remap_.find(GetRef<Buffer>(buffer));
+    if (auto buffer = op->node.as<Buffer>()) {
+      auto it = buffer_remap_.find(buffer.value());
       if (it != buffer_remap_.end()) {
         return AttrStmt(it->second, op->attr_key, op->value, op->body);
       }
-    } else if (auto* var = op->node.as<VarNode>()) {
-      auto it = var_remap_.find(GetRef<Var>(var));
+    } else if (auto var = op->node.as<Var>()) {
+      auto it = var_remap_.find(var.value());
       if (it != var_remap_.end()) {
         return AttrStmt(it->second, op->attr_key, op->value, op->body);
       }

--- a/src/tir/transforms/extract_constants.cc
+++ b/src/tir/transforms/extract_constants.cc
@@ -95,9 +95,8 @@ tvm::transform::Pass ExtractPrimFuncConstants() {
   auto pass_func = [=](IRModule module, tvm::transform::PassContext pc) {
     auto m = GetRef<IRModule>(module.CopyOnWrite());
     for (const auto& kv : m->functions) {
-      BaseFunc f = kv.second;
-      if (f->IsInstance<PrimFuncNode>()) {
-        m->Update(kv.first, prim_func_pass(GetRef<PrimFunc>(f.as<PrimFuncNode>()), m, pc));
+      if (auto func = kv.second.as<PrimFunc>()) {
+        m->Update(kv.first, prim_func_pass(func.value(), m, pc));
       }
     }
     return m;

--- a/src/tir/transforms/hoist_expression.cc
+++ b/src/tir/transforms/hoist_expression.cc
@@ -254,8 +254,8 @@ class HoistInfoCollector : public StmtExprVisitor {
     Var var;
     if (const auto* node_iter_var = op->node.as<IterVarNode>()) {
       var = node_iter_var->var;
-    } else if (const auto* node_var = op->node.as<VarNode>()) {
-      var = GetRef<Var>(node_var);
+    } else if (auto opt = op->node.as<Var>()) {
+      var = opt.value();
     } else {
       return Parent::VisitStmt_(op);
     }

--- a/src/tir/transforms/inject_rolling_buffer.cc
+++ b/src/tir/transforms/inject_rolling_buffer.cc
@@ -213,7 +213,7 @@ class RollingBufferInjector : public StmtExprMutator {
     auto stmt{StmtExprMutator::VisitStmt_(op)};
     op = stmt.as<AttrStmtNode>();
 
-    if (rolling_buffers.count(Downcast<Buffer>(op->node))) {
+    if (auto opt = op->node.as<Buffer>(); opt && rolling_buffers.count(opt.value())) {
       // Remove the attribute statements attached to rolling buffers
       // because they will have been hoisted to the relevant rolling
       // scope

--- a/src/tir/transforms/inject_rolling_buffer.cc
+++ b/src/tir/transforms/inject_rolling_buffer.cc
@@ -102,8 +102,8 @@ class RollingBufferInjector : public StmtExprMutator {
   }
 
   Stmt VisitStmt_(const AttrStmtNode* op) final {
-    if (auto b = op->node.as<BufferNode>()) {
-      auto buffer = GetRef<Buffer>(b);
+    if (auto opt = op->node.as<Buffer>()) {
+      auto buffer = opt.value();
       // Keep a dictionary associating attribute statements with the buffers
       // they reference. We'll need this if the buffer gets hoisted and we
       // need to hoist all of its attributes at the same time.
@@ -213,7 +213,7 @@ class RollingBufferInjector : public StmtExprMutator {
     auto stmt{StmtExprMutator::VisitStmt_(op)};
     op = stmt.as<AttrStmtNode>();
 
-    if (rolling_buffers.count(GetRef<Buffer>(op->node.as<BufferNode>()))) {
+    if (rolling_buffers.count(Downcast<Buffer>(op->node))) {
       // Remove the attribute statements attached to rolling buffers
       // because they will have been hoisted to the relevant rolling
       // scope

--- a/src/tir/transforms/lower_custom_datatypes.cc
+++ b/src/tir/transforms/lower_custom_datatypes.cc
@@ -166,8 +166,8 @@ class CustomDatatypesLowerer : public StmtExprMutator {
     // remap these vars when needed
     // TODO(tvm-team): remove the rewriting once the buffer var
     // attrs are being refactored into the corresponding definition node
-    if (const auto* var_node = op->node.as<VarNode>()) {
-      auto it = var_remap_.find(GetRef<Var>(var_node));
+    if (auto var_node = op->node.as<Var>()) {
+      auto it = var_remap_.find(var_node.value());
       if (it != var_remap_.end()) {
         return AttrStmt(it->second, op->attr_key, op->value, op->body);
       }

--- a/src/tir/transforms/lower_opaque_block.cc
+++ b/src/tir/transforms/lower_opaque_block.cc
@@ -138,10 +138,10 @@ class OpaqueBlockLower : public StmtExprMutator {
   PrimExpr ConvertAttrValue(const String& key, const ObjectRef& obj) {
     if (!obj.defined()) {
       return PrimExpr();
-    } else if (const PrimExprNode* expr = obj.as<PrimExprNode>()) {
-      return GetRef<PrimExpr>(expr);
-    } else if (const StringObj* str = obj.as<StringObj>()) {
-      return std::move(StringImm(str->data));
+    } else if (auto expr = obj.as<PrimExpr>()) {
+      return expr.value();
+    } else if (auto str = obj.as<String>()) {
+      return std::move(StringImm(str.value()));
     } else {
       LOG(FATAL) << "Illegal attribute of key " << key << ", value type " << obj->GetTypeKey()
                  << " not supported";

--- a/src/tir/transforms/make_packed_api.cc
+++ b/src/tir/transforms/make_packed_api.cc
@@ -305,8 +305,8 @@ Pass MakePackedAPI() {
     std::vector<std::pair<GlobalVar, PrimFunc>> updates;
 
     for (const auto& kv : mptr->functions) {
-      if (auto* n = kv.second.as<PrimFuncNode>()) {
-        PrimFunc func = GetRef<PrimFunc>(n);
+      if (auto opt = kv.second.as<PrimFunc>()) {
+        auto func = opt.value();
         if (func->GetAttr<Integer>(tvm::attr::kCallingConv, Integer(CallingConv::kDefault)) ==
             CallingConv::kDefault) {
           auto updated_func = MakePackedAPI(std::move(func));

--- a/src/tir/transforms/make_unpacked_api.cc
+++ b/src/tir/transforms/make_unpacked_api.cc
@@ -93,8 +93,8 @@ Pass MakeUnpackedAPI() {
     std::vector<std::pair<GlobalVar, PrimFunc>> updates;
 
     for (const auto& kv : mptr->functions) {
-      if (auto* n = kv.second.as<PrimFuncNode>()) {
-        PrimFunc func = GetRef<PrimFunc>(n);
+      if (auto opt = kv.second.as<PrimFunc>()) {
+        auto func = opt.value();
         if (func->GetAttr<Integer>(tvm::attr::kCallingConv, Integer(CallingConv::kDefault)) ==
             CallingConv::kDefault) {
           auto updated_func = MakeUnpackedAPI(std::move(func));

--- a/src/tir/transforms/profile_instrumentation.cc
+++ b/src/tir/transforms/profile_instrumentation.cc
@@ -267,11 +267,10 @@ Pass InstrumentProfileIntrinsics() {
     if (reset_start_id) lwp::start_id = 0;
     std::vector<std::pair<GlobalVar, PrimFunc>> updates;
     for (const auto& kv : mptr->functions) {
-      if (auto* n = kv.second.as<PrimFuncNode>()) {
-        PrimFunc func = GetRef<PrimFunc>(n);
-        auto updated_func =
-            lwp::AddProfileBuiltins(func, max_instr_depth.IntValue(), min_instr_height.IntValue(),
-                                    instr_siblings, disable_func_instrumentation);
+      if (auto func = kv.second.as<PrimFunc>()) {
+        auto updated_func = lwp::AddProfileBuiltins(func.value(), max_instr_depth.IntValue(),
+                                                    min_instr_height.IntValue(), instr_siblings,
+                                                    disable_func_instrumentation);
         updates.push_back({kv.first, updated_func});
       }
     }

--- a/src/tir/transforms/reduce_branching_through_overcompute.cc
+++ b/src/tir/transforms/reduce_branching_through_overcompute.cc
@@ -85,8 +85,8 @@ class ElseBranchStripper : public StmtExprMutator {
  private:
   Stmt VisitStmt_(const IfThenElseNode* op) override {
     IfThenElse ret = Downcast<IfThenElse>(StmtExprMutator::VisitStmt_(op));
-    auto as_eval = ret->else_case.as<EvaluateNode>();
-    if (as_eval && new_else_clauses_.count(GetRef<Evaluate>(as_eval))) {
+    if (auto as_eval = ret->else_case.as<Evaluate>();
+        as_eval && new_else_clauses_.count(as_eval.value())) {
       return IfThenElse(ret->condition, ret->then_case);
     } else {
       return std::move(ret);

--- a/src/tir/transforms/renew_defs.cc
+++ b/src/tir/transforms/renew_defs.cc
@@ -181,8 +181,8 @@ class RenewDefMutator : public StmtExprMutator {
       auto it = remap_.find(expr);
       if (it != remap_.end()) {
         return Downcast<PrimExpr>((*it).second);
-      } else if (const VarNode* var = expr.as<VarNode>()) {
-        return this->ReDefineVar(GetRef<Var>(var));
+      } else if (auto var = expr.as<Var>()) {
+        return this->ReDefineVar(var.value());
       } else {
         return ExprMutator::VisitExpr(expr);
       }

--- a/src/tir/transforms/rewrite_unsafe_select.cc
+++ b/src/tir/transforms/rewrite_unsafe_select.cc
@@ -49,8 +49,8 @@ class UnsafeExprDetector : public ExprFunctor<bool(const PrimExpr& n)> {
         }
       }
       return false;
-    } else if (auto* ptr_op = op->op.as<OpNode>()) {
-      auto effect_kind = op_call_effect_[GetRef<Op>(ptr_op)];
+    } else if (auto opt = op->op.as<Op>()) {
+      auto effect_kind = op_call_effect_[opt.value()];
       if (effect_kind == CallEffectKind::kPure || effect_kind == CallEffectKind::kExprAnnotation) {
         for (PrimExpr e : op->args) {
           if (VisitExpr(e)) return true;

--- a/src/tir/transforms/thread_storage_sync.cc
+++ b/src/tir/transforms/thread_storage_sync.cc
@@ -353,7 +353,7 @@ class ThreadSyncInserter : public StmtExprMutator {
       PrimExpr expr = StmtExprMutator::VisitExpr_(op);
       op = expr.as<CallNode>();
       ICHECK_EQ(op->args.size(), 5U);
-      Var buffer_var(GetRef<Var>(op->args[1].as<VarNode>()));
+      Var buffer_var(Downcast<Var>(op->args[1]));
       const IntImmNode* flag = op->args[4].as<IntImmNode>();
       if ((flag->value & 1) && sync_scope_.rank == StorageRank::kGlobal &&
           GetScope(buffer_var).rank == StorageRank::kGlobal) {

--- a/src/tir/transforms/vectorize_loop.cc
+++ b/src/tir/transforms/vectorize_loop.cc
@@ -329,8 +329,8 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
       Array<PrimExpr> new_args{op->args[0], op->args[1], op->args[2], mutated_value[0]};
       return Call(op->dtype.with_lanes(lane), op->op, new_args);
     }
-    auto* op_ptr = op->op.as<OpNode>();
-    bool vectorizable = op_ptr && op_vectorizable_.get(GetRef<Op>(op_ptr), false);
+    auto optional_op = op->op.as<Op>();
+    bool vectorizable = optional_op && op_vectorizable_.get(optional_op.value(), false);
 
     if (!vectorizable) {
       // Cannot vectorize this op


### PR DESCRIPTION
Prior to this PR, the `ObjectRef::as<T>()` method could be used for any `T` that inherits from `tvm::Object`, and would return a `const T*` if the class could be cast to the specified type, or `nullptr` otherwise.  However, if the caller needed a `ObjectRef`, they would then need to call `GetRef<MyObjRef>` to convert from a `const T*`.

This PR extends `ObjectRef::as<T>` to operate on a `T` that inherits from `tvm::ObjectRef` as well.  In this case, the return type is `Optional<T>`, returning either an instance of the specified subclass, or `NullOpt` if the object was not an instance of the specified subclass.  Example usage of this new conversion, along with how it relates to existing functionality, is shown below.

```c++
// Unconditionally convert, throwing an exception if the object isn't
// of the specified type.  In contexts where the type of the object is
// unknown, this shouldn't be used.
PrimExpr expr = Downcast<PrimExpr>(obj);

// Protect the Downcast from throwing an exception using IsInstance.
// This avoids the error, but performs the type-checking twice.  In
// addition, it requires the caller to specify both the ObjectRef
// subclass and the Object subclass, even though these usually have a
// 1:1 correspondence.
if (obj->IsInstance<PrimExprNode>()) {
  PrimExpr expr = Downcast<PrimExpr>(obj);
}

// Perform both type-checking and downcasting with the ObjectRef::as()
// method, then use GetRef to convert to an ObjectRef.  This avoids
// double-checking the type, but still requires the caller to
if (const PrimExprNode* ptr = obj.as<PrimExprNode>()) {
  PrimExpr expr = GetRef<PrimExpr>(ptr);
}

// New method introduced by this PR.  The type-checking is only
// performed once, and the Object subclass is inferred from the
// ObjectRef subclass.
if (Optional<PrimExpr> opt = obj.as<PrimExpr>()) {
  PrimExpr expr = opt.value();
}
```

This PR is implemented as two commits.  The first commit implements the new functionality, but makes no further changes.  The second commit looks for cases where `object_ref.as<TNode>()` was immediately followed by `GetRef<T>()`, replacing with either `object_ref.as<T>()` or with `Downcast<T>(object_ref)`.