### PR TITLE
[Runtime] Runtime module property mask for Metal and Vulkan

### DIFF
--- a/src/runtime/metal/metal_module.mm
+++ b/src/runtime/metal/metal_module.mm
@@ -49,6 +49,11 @@ class MetalModuleNode final : public runtime::ModuleNode {
   }
   const char* type_key() const final { return "metal"; }
 
+  /*! \brief Get the property of the runtime module. */
+  int GetPropertyMask() const final {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  }
+
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
   void SaveToFile(const std::string& file_name, const std::string& format) final {

--- a/src/runtime/vulkan/vulkan_wrapped_func.h
+++ b/src/runtime/vulkan/vulkan_wrapped_func.h
@@ -89,6 +89,11 @@ class VulkanModuleNode final : public runtime::ModuleNode {
 
   const char* type_key() const final { return "vulkan"; }
 
+  /*! \brief Get the property of the runtime module. */
+  int GetPropertyMask() const final {
+    return ModulePropertyMask::kBinarySerializable | ModulePropertyMask::kRunnable;
+  }
+
   PackedFunc GetFunction(const std::string& name, const ObjectPtr<Object>& sptr_to_self) final;
 
   std::shared_ptr<VulkanPipeline> GetPipeline(size_t device_id, const std::string& func_name,


### PR DESCRIPTION
Following #14406, this PR adds the runtime module property mask for Metal and Vulkan backend, which were left before.