### PR TITLE
[Unity] Properly handle tuple-outputting function in `FuseOpsByPattern`

### DIFF
--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -734,7 +734,7 @@ class OperatorFusor : public ExprMutator {
       if (IsTupleOutput(func) && tuple_get_indices_.count(binding->var.get())) {
         if (!GetStructInfo(binding->var)->IsInstance<TupleStructInfoNode>() ||
             IsNestedTupleOutput(func)) {
-          // When binding_var itself is a tuple, we do not need to remap this variable to the
+          // When binding->var itself is a tuple, we do not need to remap this variable to the
           // output of TupleGetItem unless the output is a nested tuple.
           pending_tuple_get[group].push_back(binding->var);
         }
@@ -1034,7 +1034,7 @@ class PatternBasedPartitioner : ExprVisitor {
       parent_group->attrs.Set(attr::kComposite, pat_name_);
       for (const auto& [pat, match] : matches_opt.value()) {
         // Put all matching expressions into the parent group. But we need to be careful not to
-        // merge expressions matched by a wildcard pattern, since a wildcard can match the output of
+        // merge expressions matched by a wildcard pattern, since a wildcard can match an output of
         // the previous group. For example, when there are two back-to-back conv2d ops, the output
         // of the first conv2d is matched to the input of the second conv2d via a wildcard pattern.
         // But we must avoid merging the first conv2d into the group of the second conv2d.

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -766,7 +766,7 @@ class OperatorFusor : public ExprMutator {
       }
 
       // Step c. Update the mapping used for the remapping of the binding variables.
-      if (!pending_tuple_get.empty()) {
+      if (IsTupleOutput(func) && !pending_tuple_get.empty()) {
         // If the output is a tuple, attach TupleGetItem to all tuple elements, and
         // remap variables approriately.
         // The variables that need to be remapped and the corresponding tuple indices are


### PR DESCRIPTION
Previously, it has been assumed that when a fused function outputs a tuple, `TupleGetItem` needs to be attached to each output element to properly remap variables. But when an op that emits a tuple (e.g. `split`) is wrapped into a new function by this pass, that tuple can become the output of the fused function on its own. In such cases, a user of the output of such functions expects to get a tuple, so `TupleGetItem` must not be attached.

This PR also fixes a bug in the grouping algorithm, where `TupleGetItemPattern` that has been matched is not put into the matching group. 

@cyx-6  