### PR TITLE
[Arith][Bugfix] Simplify "x - 1 < y" into "x <= y"

### DIFF
--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -750,6 +750,23 @@ class TestComparisons(BaseCompare):
         TestCase((x - 10).equal(0), x.equal(10)),
         TestCase((10 - x).equal(0), x.equal(10)),
         TestCase((x * y).equal(0), tvm.tir.Or(x.equal(0), y.equal(0))),
+        # Write LT as LE for integer arguments, if possible
+        TestCase(x - 1 < y, x <= y),
+        TestCase(x + (-1) < y, x <= y),
+        TestCase(x < y - (-1), x <= y),
+        TestCase(x < y + 1, x <= y),
+        TestCase(x + 2 < y + 3, x <= y),
+        TestCase(x - 3 < y - 2, x <= y),
+        TestCase(x - 3 < y + (-2), x <= y),
+        TestCase(x + (-3) < y - 2, x <= y),
+        # Merge constants on the LHS/RHS of a LT expression.
+        TestCase(x + 10 < y + 10, x < y),
+        TestCase(x + 5 < y + 10, x < y + 5),
+        TestCase(x + 10 < y + 5, x + 5 < y),
+        TestCase(x - 5 < y - 10, x + 5 < y),
+        TestCase(x - 10 < y - 5, x < y + 5),
+        TestCase(x < y - 10, x + 10 < y),
+        TestCase(x - 10 < y, x < y + 10),
         # cmp bound
         TestCase(x + y < x + z, y < z),
         TestCase(x + y < z + x, y < z),
@@ -815,7 +832,7 @@ class TestComparisons(BaseCompare):
         TestCase(tdiv(x, 4) * 4 < x - y, tvm.tir.LT(y, tmod(x, 4))),
         TestCase(tdiv(x + 2, 4) * 4 >= x, tvm.tir.LE(tmod(x + 2, 4), 2)),
         TestCase(tdiv(x + 2, 4) * 4 >= x + y, tvm.tir.LE(tmod(x + 2, 4) + y, 2)),
-        TestCase(tdiv(x + 2, 4) * 4 >= x - y, tvm.tir.LE(tmod(x + 2, 4) + (-2), y)),
+        TestCase(tdiv(x + 2, 4) * 4 >= x - y, tvm.tir.LE(tmod(x + 2, 4), y + 2)),
         # floor div
         TestCase(fld(x, 2) < 3, x < 6),
         TestCase(3 < fld(x, 2), tvm.tir.LT(7, x)),
@@ -833,7 +850,7 @@ class TestComparisons(BaseCompare):
         TestCase(fld(x, 4) * 4 < x - y, tvm.tir.LT(y, flm(x, 4))),
         TestCase(fld(x + 2, 4) * 4 >= x, tvm.tir.LE(flm(x + 2, 4), 2)),
         TestCase(fld(x + 2, 4) * 4 >= x + y, tvm.tir.LE(flm(x + 2, 4) + y, 2)),
-        TestCase(fld(x + 2, 4) * 4 >= x - y, tvm.tir.LE(flm(x + 2, 4) + (-2), y)),
+        TestCase(fld(x + 2, 4) * 4 >= x - y, tvm.tir.LE(flm(x + 2, 4), y + 2)),
         # End DivMod Rules
         # merging flm/fld into known value
         TestCase(tir.all(fld(x, 8) == 3, flm(x, 8) == 4), x == 28),


### PR DESCRIPTION
This simplification was introduced in https://github.com/apache/tvm/pull/13217, and was erroneously removed in https://github.com/apache/tvm/pull/13933.  This commit re-enables this simplification, and adds unit tests to prevent any future regression.