### PR TITLE
[AOT] Fix warning on dropping const in TVMAotExecutor_GetInputName

### DIFF
--- a/include/tvm/runtime/crt/aot_executor.h
+++ b/include/tvm/runtime/crt/aot_executor.h
@@ -100,7 +100,7 @@ int TVMAotExecutor_GetInputIndex(TVMAotExecutor* executor, const char* name);
  * \param name Output for retrieving name.
  * \return Pointer to input name in `name`.
  */
-int TVMAotExecutor_GetInputName(TVMAotExecutor* executor, int index, char** name);
+int TVMAotExecutor_GetInputName(TVMAotExecutor* executor, int index, const char** name);
 
 /*!
  * \brief Run the generated program.

--- a/src/runtime/crt/aot_executor/aot_executor.c
+++ b/src/runtime/crt/aot_executor/aot_executor.c
@@ -82,7 +82,7 @@ int TVMAotExecutor_GetInputIndex(TVMAotExecutor* executor, const char* name) {
   return rv;
 }
 
-int TVMAotExecutor_GetInputName(TVMAotExecutor* executor, int index, char** name) {
+int TVMAotExecutor_GetInputName(TVMAotExecutor* executor, int index, const char** name) {
   const TVMMetadata* md = executor->metadata;
   *name = md->inputs[index].name;
   return 0;


### PR DESCRIPTION
Prior to this commit, the `TVMAotExecutor_GetInputName` function accepted a `char** name` output parameter.  When used, assignment of a `const char*` into `*name` dropped the `const`, resulting in a warning.  Changing the argument type to `const char**` (pointer to a mutable pointer to a `const char`) resolves this warning.