### PR TITLE
[CI] Pin sccache version to 0.3.3

### DIFF
--- a/docker/install/ubuntu_install_sccache.sh
+++ b/docker/install/ubuntu_install_sccache.sh
@@ -20,7 +20,7 @@ set -e
 set -u
 set -o pipefail
 
-cargo install sccache
+cargo install --version 0.3.3 sccache
 
 # The docs specifically recommend hard links: https://github.com/mozilla/sccache#known-caveats
 mkdir /opt/sccache


### PR DESCRIPTION
As disscussed in https://github.com/apache/tvm/pull/14466 ，let's pin sccache version to v0.3.3, otherwise new docker images keeps fail with: "sccache: error: Timed out waiting for server startup."

cc @lhutton1 @driazati 