### PR TITLE
[Target] Add Apple M1 GPU tag with 256-thread restriction

### DIFF
--- a/src/target/tag.cc
+++ b/src/target/tag.cc
@@ -388,6 +388,7 @@ TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.24xlarge", 48, "cascadelake");
                                        {"mcpu", String("apple-latest")}}}});
 
 TVM_REGISTER_METAL_GPU_TAG("apple/m1-gpu", 1024, 32768, 32);
+TVM_REGISTER_METAL_GPU_TAG("apple/m1-gpu-restricted", 256, 32768, 32);
 TVM_REGISTER_METAL_GPU_TAG("apple/m2-gpu", 1024, 32768, 32);
 
 #undef TVM_REGISTER_METAL_TAG


### PR DESCRIPTION
During our development and exploration on WebGPU, we noticed that the WebGPU backend on Apple Silicon machines have the restriction on the number of threads in a thread block, requiring the number of threads no more than 256, which is smaller than the native requirement of Metal.

Therefore, we introduce the restricted backend for convenience.