### PR TITLE
[Unity][Pass] Enhance Dynamic-aware FuseOps

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -268,6 +268,21 @@ TVM_DLL StructInfo StructInfoLCA(const StructInfo& lhs, const StructInfo& rhs,
  */
 TVM_DLL Array<tir::Var> TIRVarsInStructInfo(const StructInfo& sinfo);
 
+/*!
+ * \brief Get the TIR variables that defined in the input function.
+ * The returned list is deduplicated - each TIR variable will appear at most once.
+ * \param func The function object to be analyzed.
+ * \return The list of TIR variables that are defined in the input function.
+ */
+TVM_DLL Array<tir::Var> DefinedSymbolicVars(const Function& func);
+
+/*!
+ * \brief Get the TIR variables that are used but not defined in the input function.
+ * The returned list is deduplicated - each TIR variable will appear at most once.
+ * \param func The function object to be analyzed.
+ * \return The list of TIR variables that are used but not defined in the input function.
+ */
+TVM_DLL Array<tir::Var> FreeSymbolicVars(const Function& func);
 //-----------------------------------
 // General IR analysis
 //-----------------------------------

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -184,6 +184,40 @@ def tir_vars_in_struct_info(sinfo: StructInfo) -> List[tir.Var]:
     return _ffi_api.TIRVarsInStructInfo(sinfo)  # type: ignore
 
 
+def defined_symbolic_vars(func: Function) -> List[Var]:
+    """Get the TIR variables that defined in the input function.
+    The returned list is deduplicated - each TIR variable will appear at most once.
+
+    Parameters
+    ----------
+    func : Function
+        The function object to be analyzed.
+
+    Returns
+    -------
+    ret : List[Var]
+        The list of symbolic variables that are defined in the input function.
+    """
+    return _ffi_api.DefinedSymbolicVars(func)  # type: ignore
+
+
+def free_symbolic_vars(func: Function) -> List[Var]:
+    """Get the TIR variables that are used but not defined in the input function.
+    The returned list is deduplicated - each TIR variable will appear at most once.
+
+    Parameters
+    ----------
+    func : Function
+        The function object to be analyzed.
+
+    Returns
+    -------
+    ret : List[Var]
+        The list of symbolic variables that are used but not defined in the input function.
+    """
+    return _ffi_api.FreeSymbolicVars(func)  # type: ignore
+
+
 def bound_vars(expr: Expr) -> List[Var]:
     """
     Return all bound variables from expression expr.

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -421,5 +421,18 @@ def test_reshape_pattern_reject_reduction():
     assert not has_reshape_pattern(reduction)
 
 
+def test_reshape_pattern_reject_reduction():
+    @T.prim_func
+    def reduction(A: T.Buffer((4, 4), "float32"), B: T.Buffer((4,), "float32")):
+        for i0, i1 in T.grid(4, 4):
+            with T.block("identity"):
+                vi0, vi1 = T.axis.remap("SR", [i0, i1])
+                with T.init():
+                    B[vi0] = T.float32(0)
+                B[vi0] = B[vi0] + A[vi0, vi1]
+
+    assert not has_reshape_pattern(reduction)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
The current fuse_ops pass only supports symbolic vars that are all defined in the parameter `struct_info`. This commit enhances the pass to support free symbolic vars by adding them to the parameter explicitly

cc @tqchen @MasterJH5574 