### PR TITLE
[CI] Add JAX deps in Dockerfiles

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -108,6 +108,10 @@ RUN bash /install/ubuntu_install_tensorflow.sh
 COPY install/ubuntu_install_tflite.sh /install/ubuntu_install_tflite.sh
 RUN bash /install/ubuntu_install_tflite.sh
 
+# JAX deps
+COPY install/ubuntu_install_jax.sh /install/ubuntu_install_jax.sh
+RUN bash /install/ubuntu_install_jax.sh "cpu"
+
 # Compute Library
 COPY install/ubuntu_download_arm_compute_lib_binaries.sh /install/ubuntu_download_arm_compute_lib_binaries.sh
 RUN bash /install/ubuntu_download_arm_compute_lib_binaries.sh

--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -89,6 +89,9 @@ RUN bash /install/ubuntu_install_coreml.sh
 COPY install/ubuntu_install_tensorflow.sh /install/ubuntu_install_tensorflow.sh
 RUN bash /install/ubuntu_install_tensorflow.sh
 
+COPY install/ubuntu_install_jax.sh /install/ubuntu_install_jax.sh
+RUN bash /install/ubuntu_install_jax.sh "cuda"
+
 COPY install/ubuntu_install_darknet.sh /install/ubuntu_install_darknet.sh
 RUN bash /install/ubuntu_install_darknet.sh
 

--- a/docker/install/ubuntu_install_jax.sh
+++ b/docker/install/ubuntu_install_jax.sh
@@ -23,12 +23,13 @@ set -o pipefail
 # Install jax and jaxlib
 if [ "$1" == "cuda" ]; then
     pip3 install --upgrade \
-        "jax[cuda11_pip]==0.4.7" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+        jaxlib==0.3.25 \
+        "jax[cuda11_pip]==0.3.25" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 else
     pip3 install --upgrade \
-        'jax[cpu]==0.4.8' \
-        jaxlib==0.4.7
+        jaxlib==0.3.25 \
+        "jax[cpu]==0.3.25"
 fi
 
 # Install flax
-pip3 install flax==0.6.7
+pip3 install flax==0.6.4

--- a/docker/install/ubuntu_install_jax.sh
+++ b/docker/install/ubuntu_install_jax.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+# Install jax and jaxlib
+if [ "$1" == "cuda" ]; then
+    pip3 install --upgrade \
+        "jax[cuda11_pip]==0.4.7" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+else
+    pip3 install --upgrade \
+        'jax[cpu]==0.4.8' \
+        jaxlib==0.4.7
+fi
+
+# Install flax
+pip3 install flax==0.6.7


### PR DESCRIPTION
I am trying to add JAX related packages into cpu and gpu dockerfiles, then CI should be able to support JAX, Flax, StableHLO/MLIR Python Bindings, etc.

cc: @driazati @tqchen 