### PR TITLE
[Unity] Fix emit_te with symbolic input

### DIFF
--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -312,6 +312,7 @@ class BlockBuilder(Object):
 
         primfunc_name = kwargs.pop("primfunc_name_hint", None)
         tir_func, call_args, output_sinfo, tir_vars = gen_call_tir_inputs(func, *args, **kwargs)
+
         if not primfunc_name:
             primfunc_name = func.__name__
         gvar = self.add_func(tir_func, primfunc_name)

--- a/tests/python/relax/test_blockbuilder_core.py
+++ b/tests/python/relax/test_blockbuilder_core.py
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+"""Block builder unit test"""
+# The test here do not depend on tvmscript to cover most basic features
 import pytest
 import tvm
 import tvm.testing

--- a/tests/python/relax/test_blockbuilder_emit_te.py
+++ b/tests/python/relax/test_blockbuilder_emit_te.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+""" This file tests advanced emit_te features with help of TVMScript assertion"""
+# The tests here depend on tvmscript
+from tvm import te, tir
+from tvm import relax as rx
+from tvm.ir.base import assert_structural_equal
+from tvm.script.parser import ir as I
+from tvm.script.parser import relax as R
+from tvm.script.parser import tir as T
+
+
+def test_emit_te_with_symbolic_arg():
+    bb = rx.BlockBuilder()
+    m = tir.Var("m", "int64")
+    x = rx.Var("x", R.Tensor([10], "float32"))
+    y = rx.Var("y", R.Shape([m]))
+
+    def te_func(A, offset):
+        return te.compute(A.shape, lambda i: A[i + offset], name="B")
+
+    with bb.function("main", [x, y]):
+        out = bb.emit_te(te_func, x, m)
+        bb.emit_func_output(out)
+
+    after = bb.get()
+
+    @I.ir_module
+    class Expected:
+        @T.prim_func
+        def te_func(
+            A: T.Buffer((T.int64(10),), "float32"),
+            B: T.Buffer((T.int64(10),), "float32"),
+            m: T.int64,
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            for i in range(T.int64(10)):
+                with T.block("B"):
+                    v_i = T.axis.spatial(T.int64(10), i)
+                    T.writes(B[v_i])
+                    B[v_i] = A[v_i + m]
+
+        @R.function
+        def main(
+            x: R.Tensor((10,), dtype="float32"), y: R.Shape(["m"])
+        ) -> R.Tensor((10,), dtype="float32"):
+            m = T.int64()
+            cls = Expected
+            gv = R.call_tir(
+                cls.te_func,
+                (x,),
+                out_sinfo=R.Tensor((10,), dtype="float32"),
+                tir_vars=R.shape([m]),
+            )
+            return gv
+
+    assert_structural_equal(after, Expected)


### PR DESCRIPTION
This PR fixes the use of emit_te with symbolic shape input.

Testcases are added