### PR TITLE
[Unity] Preserve symbolic var args when applying call_tir

### DIFF
--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -794,7 +794,9 @@ class TIRFuseMutator : public ExprMutator {
       if (const auto* gv = call->args[0].as<GlobalVarNode>()) {
         tir::PrimFunc func = Downcast<tir::PrimFunc>(mod_->Lookup(GetRef<GlobalVar>(gv)));
         GlobalVar new_gv = this->builder_->AddFunction(func, gv->name_hint);
-        return Call(call->op, {new_gv, call->args[1]}, call->attrs, call->sinfo_args, call->span);
+        Array<Expr> new_args = call->args;
+        new_args.Set(0, new_gv);
+        return Call(call->op, new_args, call->attrs, call->sinfo_args, call->span);
       }
     }
 

--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -23,7 +23,6 @@ from tvm.script import ir as I, relax as R, tir as T
 
 def _check(mod_before, mod_expected):
     mod = relax.transform.FuseTIR()(mod_before)
-    print(mod)
     tvm.ir.assert_structural_equal(mod, mod_expected)
 
 

--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -23,6 +23,7 @@ from tvm.script import ir as I, relax as R, tir as T
 
 def _check(mod_before, mod_expected):
     mod = relax.transform.FuseTIR()(mod_before)
+    print(mod)
     tvm.ir.assert_structural_equal(mod, mod_expected)
 
 
@@ -792,6 +793,64 @@ def test_symbolic_shape_aware_fuse_with_allocation():
 
     _check(Before, Expected)
 
+
+def test_symbolic_var_in_call_tir_args():
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def rotary_embedding(rxplaceholder: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"), rxplaceholder_1: T.Buffer((T.int64(2048), T.int64(128)), "float32"), rxplaceholder_2: T.Buffer((T.int64(2048), T.int64(128)), "float32"), rotary: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"), m: T.int64):
+            T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(
+                True), "tir_var_upper_bound": {"m": 2048}})
+            # with T.block("root"):
+            for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
+                with T.block("rotary"):
+                    v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                    T.reads(rxplaceholder_1[m + v_i1 - T.int64(1), v_i3], rxplaceholder[v_i0, v_i1, v_i2, v_i3 - T.int64(
+                        64):v_i3 - T.int64(64) + T.int64(129)], rxplaceholder_2[m + v_i1 - T.int64(1), v_i3])
+                    T.writes(rotary[v_i0, v_i1, v_i2, v_i3])
+                    rotary[v_i0, v_i1, v_i2, v_i3] = rxplaceholder_1[m + v_i1 - T.int64(1), v_i3] * rxplaceholder[v_i0, v_i1, v_i2, v_i3] + rxplaceholder_2[m + v_i1 - T.int64(
+                        1), v_i3] * T.Select(T.int64(64) <= v_i3, rxplaceholder[v_i0, v_i1, v_i2, v_i3 - T.int64(64)], rxplaceholder[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float32(-1))
+
+        @R.function
+        def main(
+            x: R.Tensor((1, 1, 32, 128), dtype="float32"),
+            sin: R.Tensor((2048, 128), dtype="float32"),
+            cos: R.Tensor((2048, 128), dtype="float32"),
+            len: R.Shape(["m"]),
+        ):
+            m = T.int64()
+            cls = Before
+            with R.dataflow():
+                gv = R.call_tir(cls.rotary_embedding, [x, sin, cos], out_sinfo=R.Tensor((1, 1, 32, 128), dtype="float32"), tir_vars=R.shape([m]))
+                R.output(gv)
+            return gv
+        
+    @I.ir_module
+    class Expected:
+        @T.prim_func
+        def rotary_embedding(rxplaceholder: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"), rxplaceholder_1: T.Buffer((T.int64(2048), T.int64(128)), "float32"), rxplaceholder_2: T.Buffer((T.int64(2048), T.int64(128)), "float32"), rotary: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"), m: T.int64):
+            T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(
+                True), "tir_var_upper_bound": {"m": 2048}})
+            # with T.block("root"):
+            for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
+                with T.block("rotary"):
+                    v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                    T.reads(rxplaceholder_1[m + v_i1 - T.int64(1), v_i3], rxplaceholder[v_i0, v_i1, v_i2, v_i3 - T.int64(
+                        64):v_i3 - T.int64(64) + T.int64(129)], rxplaceholder_2[m + v_i1 - T.int64(1), v_i3])
+                    T.writes(rotary[v_i0, v_i1, v_i2, v_i3])
+                    rotary[v_i0, v_i1, v_i2, v_i3] = rxplaceholder_1[m + v_i1 - T.int64(1), v_i3] * rxplaceholder[v_i0, v_i1, v_i2, v_i3] + rxplaceholder_2[m + v_i1 - T.int64(
+                        1), v_i3] * T.Select(T.int64(64) <= v_i3, rxplaceholder[v_i0, v_i1, v_i2, v_i3 - T.int64(64)], rxplaceholder[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float32(-1))
+
+        @R.function
+        def main(x: R.Tensor((1, 1, 32, 128), dtype="float32"), sin: R.Tensor((2048, 128), dtype="float32"), cos: R.Tensor((2048, 128), dtype="float32"), len: R.Shape(["m"])) -> R.Tensor((1, 1, 32, 128), dtype="float32"):
+            m = T.int64()
+            cls = Expected
+            with R.dataflow():
+                gv = R.call_tir(cls.rotary_embedding, (x, sin, cos), out_sinfo=R.Tensor(
+                    (1, 1, 32, 128), dtype="float32"), tir_vars=R.shape([m]))
+                R.output(gv)
+            return gv
+    _check(Before, Expected)
 
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -798,18 +798,37 @@ def test_symbolic_var_in_call_tir_args():
     @I.ir_module
     class Before:
         @T.prim_func
-        def rotary_embedding(rxplaceholder: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"), rxplaceholder_1: T.Buffer((T.int64(2048), T.int64(128)), "float32"), rxplaceholder_2: T.Buffer((T.int64(2048), T.int64(128)), "float32"), rotary: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"), m: T.int64):
-            T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(
-                True), "tir_var_upper_bound": {"m": 2048}})
+        def rotary_embedding(
+            rxplaceholder: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"),
+            rxplaceholder_1: T.Buffer((T.int64(2048), T.int64(128)), "float32"),
+            rxplaceholder_2: T.Buffer((T.int64(2048), T.int64(128)), "float32"),
+            rotary: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"),
+            m: T.int64,
+        ):
+            T.func_attr(
+                {"op_pattern": 8, "tir.noalias": T.bool(True), "tir_var_upper_bound": {"m": 2048}}
+            )
             # with T.block("root"):
             for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
                 with T.block("rotary"):
                     v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
-                    T.reads(rxplaceholder_1[m + v_i1 - T.int64(1), v_i3], rxplaceholder[v_i0, v_i1, v_i2, v_i3 - T.int64(
-                        64):v_i3 - T.int64(64) + T.int64(129)], rxplaceholder_2[m + v_i1 - T.int64(1), v_i3])
+                    T.reads(
+                        rxplaceholder_1[m + v_i1 - T.int64(1), v_i3],
+                        rxplaceholder[
+                            v_i0, v_i1, v_i2, v_i3 - T.int64(64) : v_i3 - T.int64(64) + T.int64(129)
+                        ],
+                        rxplaceholder_2[m + v_i1 - T.int64(1), v_i3],
+                    )
                     T.writes(rotary[v_i0, v_i1, v_i2, v_i3])
-                    rotary[v_i0, v_i1, v_i2, v_i3] = rxplaceholder_1[m + v_i1 - T.int64(1), v_i3] * rxplaceholder[v_i0, v_i1, v_i2, v_i3] + rxplaceholder_2[m + v_i1 - T.int64(
-                        1), v_i3] * T.Select(T.int64(64) <= v_i3, rxplaceholder[v_i0, v_i1, v_i2, v_i3 - T.int64(64)], rxplaceholder[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float32(-1))
+                    rotary[v_i0, v_i1, v_i2, v_i3] = rxplaceholder_1[
+                        m + v_i1 - T.int64(1), v_i3
+                    ] * rxplaceholder[v_i0, v_i1, v_i2, v_i3] + rxplaceholder_2[
+                        m + v_i1 - T.int64(1), v_i3
+                    ] * T.Select(
+                        T.int64(64) <= v_i3,
+                        rxplaceholder[v_i0, v_i1, v_i2, v_i3 - T.int64(64)],
+                        rxplaceholder[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float32(-1),
+                    )
 
         @R.function
         def main(
@@ -821,36 +840,71 @@ def test_symbolic_var_in_call_tir_args():
             m = T.int64()
             cls = Before
             with R.dataflow():
-                gv = R.call_tir(cls.rotary_embedding, [x, sin, cos], out_sinfo=R.Tensor((1, 1, 32, 128), dtype="float32"), tir_vars=R.shape([m]))
+                gv = R.call_tir(
+                    cls.rotary_embedding,
+                    [x, sin, cos],
+                    out_sinfo=R.Tensor((1, 1, 32, 128), dtype="float32"),
+                    tir_vars=R.shape([m]),
+                )
                 R.output(gv)
             return gv
-        
+
     @I.ir_module
     class Expected:
         @T.prim_func
-        def rotary_embedding(rxplaceholder: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"), rxplaceholder_1: T.Buffer((T.int64(2048), T.int64(128)), "float32"), rxplaceholder_2: T.Buffer((T.int64(2048), T.int64(128)), "float32"), rotary: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"), m: T.int64):
-            T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(
-                True), "tir_var_upper_bound": {"m": 2048}})
+        def rotary_embedding(
+            rxplaceholder: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"),
+            rxplaceholder_1: T.Buffer((T.int64(2048), T.int64(128)), "float32"),
+            rxplaceholder_2: T.Buffer((T.int64(2048), T.int64(128)), "float32"),
+            rotary: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float32"),
+            m: T.int64,
+        ):
+            T.func_attr(
+                {"op_pattern": 8, "tir.noalias": T.bool(True), "tir_var_upper_bound": {"m": 2048}}
+            )
             # with T.block("root"):
             for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
                 with T.block("rotary"):
                     v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
-                    T.reads(rxplaceholder_1[m + v_i1 - T.int64(1), v_i3], rxplaceholder[v_i0, v_i1, v_i2, v_i3 - T.int64(
-                        64):v_i3 - T.int64(64) + T.int64(129)], rxplaceholder_2[m + v_i1 - T.int64(1), v_i3])
+                    T.reads(
+                        rxplaceholder_1[m + v_i1 - T.int64(1), v_i3],
+                        rxplaceholder[
+                            v_i0, v_i1, v_i2, v_i3 - T.int64(64) : v_i3 - T.int64(64) + T.int64(129)
+                        ],
+                        rxplaceholder_2[m + v_i1 - T.int64(1), v_i3],
+                    )
                     T.writes(rotary[v_i0, v_i1, v_i2, v_i3])
-                    rotary[v_i0, v_i1, v_i2, v_i3] = rxplaceholder_1[m + v_i1 - T.int64(1), v_i3] * rxplaceholder[v_i0, v_i1, v_i2, v_i3] + rxplaceholder_2[m + v_i1 - T.int64(
-                        1), v_i3] * T.Select(T.int64(64) <= v_i3, rxplaceholder[v_i0, v_i1, v_i2, v_i3 - T.int64(64)], rxplaceholder[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float32(-1))
+                    rotary[v_i0, v_i1, v_i2, v_i3] = rxplaceholder_1[
+                        m + v_i1 - T.int64(1), v_i3
+                    ] * rxplaceholder[v_i0, v_i1, v_i2, v_i3] + rxplaceholder_2[
+                        m + v_i1 - T.int64(1), v_i3
+                    ] * T.Select(
+                        T.int64(64) <= v_i3,
+                        rxplaceholder[v_i0, v_i1, v_i2, v_i3 - T.int64(64)],
+                        rxplaceholder[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float32(-1),
+                    )
 
         @R.function
-        def main(x: R.Tensor((1, 1, 32, 128), dtype="float32"), sin: R.Tensor((2048, 128), dtype="float32"), cos: R.Tensor((2048, 128), dtype="float32"), len: R.Shape(["m"])) -> R.Tensor((1, 1, 32, 128), dtype="float32"):
+        def main(
+            x: R.Tensor((1, 1, 32, 128), dtype="float32"),
+            sin: R.Tensor((2048, 128), dtype="float32"),
+            cos: R.Tensor((2048, 128), dtype="float32"),
+            len: R.Shape(["m"]),
+        ) -> R.Tensor((1, 1, 32, 128), dtype="float32"):
             m = T.int64()
             cls = Expected
             with R.dataflow():
-                gv = R.call_tir(cls.rotary_embedding, (x, sin, cos), out_sinfo=R.Tensor(
-                    (1, 1, 32, 128), dtype="float32"), tir_vars=R.shape([m]))
+                gv = R.call_tir(
+                    cls.rotary_embedding,
+                    (x, sin, cos),
+                    out_sinfo=R.Tensor((1, 1, 32, 128), dtype="float32"),
+                    tir_vars=R.shape([m]),
+                )
                 R.output(gv)
             return gv
+
     _check(Before, Expected)
+
 
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Currently fuse_tir will remove the symbolic var args of call_tir. This PR fixes this behavior.