### PR TITLE
[Bugfix] [Relay] fix a bug caused by IncompleteTypeNode in EinsumRel while doing MergeComposite

### DIFF
--- a/src/relay/op/tensor/math.cc
+++ b/src/relay/op/tensor/math.cc
@@ -59,6 +59,10 @@ bool EinsumRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   }
 
   // Check the input tuple consists of tensors with consistent dtype.
+  if (tensor_tuple->fields[0].as<IncompleteTypeNode>()) {
+    return false;
+  }
+  ICHECK(tensor_tuple->fields[0].as<TensorTypeNode>());
   const auto& first = Downcast<TensorType>(tensor_tuple->fields[0]);
   const DataType dtype = first->dtype;
   std::vector<Array<PrimExpr>> input_shapes;

--- a/tests/python/relay/test_pass_merge_composite.py
+++ b/tests/python/relay/test_pass_merge_composite.py
@@ -980,7 +980,7 @@ def test_type_check():
 
 
 def test_einsum_reshape_pattern():
-    r"""Test MergeComposite do not cause error for operators."""
+    """Test MergeComposite does not cause error with einsum operator."""
 
     def make_einsum_reshape_pattern():
         x = wildcard()
@@ -991,7 +991,12 @@ def test_einsum_reshape_pattern():
         r = is_op("reshape")(z) | z
         return r
 
-    pattern_table = [("einsum_reshape", make_einsum_reshape_pattern(), )]
+    pattern_table = [
+        (
+            "einsum_reshape",
+            make_einsum_reshape_pattern(),
+        )
+    ]
 
     def before():
         a = relay.var("a", shape=(10, 10))

--- a/tests/python/relay/test_pass_merge_composite.py
+++ b/tests/python/relay/test_pass_merge_composite.py
@@ -18,7 +18,7 @@
 import pytest
 import tvm
 from tvm import relay, tir
-from tvm.relay.dataflow_pattern import TupleGetItemPattern, is_op, wildcard
+from tvm.relay.dataflow_pattern import TuplePattern, TupleGetItemPattern, is_op, wildcard
 from tvm.relay.testing import run_opt_pass
 
 
@@ -977,6 +977,46 @@ def test_type_check():
         ("conv_bias_relu", make_conv_bias_relu_pattern(), _check_type_true),
     ]
     check_result(pattern_table_true, before(), expected_true())
+
+
+def test_einsum_reshape_pattern():
+    r"""Test MergeComposite do not cause error for operators."""
+
+    def make_einsum_reshape_pattern():
+        x = wildcard()
+        x = is_op("reshape")(x) | x
+        y = wildcard()
+        y = is_op("reshape")(y) | y
+        z = is_op("einsum")(TuplePattern([x, y]))
+        r = is_op("reshape")(z) | z
+        return r
+
+    pattern_table = [("einsum_reshape", make_einsum_reshape_pattern(), )]
+
+    def before():
+        a = relay.var("a", shape=(10, 10))
+        b = relay.var("b", shape=(10, 10))
+        c = relay.reshape(a, [20, 5])
+        d = relay.reshape(b, [20, 5])
+        r = relay.einsum([c, d], "...ab,...cb->...ac")
+        return relay.Function([a, b], r)
+
+    def expected():
+        a = relay.var("a", shape=(10, 10))
+        b = relay.var("b", shape=(10, 10))
+        c = relay.reshape(a, [20, 5])
+        d = relay.reshape(b, [20, 5])
+        r = relay.einsum([c, d], "...ab,...cb->...ac")
+        func = relay.Function([a, b], r)
+        func = func.with_attr("Composite", "einsum_reshape")
+        func = func.with_attr("PartitionedFromPattern", "reshape_reshape_Tuple_einsum_")
+
+        input0 = relay.var("a", shape=(10, 10))
+        input1 = relay.var("b", shape=(10, 10))
+        output = func(input0, input1)
+        return relay.Function([input0, input1], output)
+
+    check_result(pattern_table, before(), expected())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, it was reported that when using MergeComposite on a model with broadcast_to OP, an error caused by IncompleteTypeNode occurs during compiling model. See https://discuss.tvm.apache.org/t/incomplete-type-in-broadcasttorel-while-doing-mergecomposite/10439

A similar bug also occurs if the model contains einsum OP. This PR fixes this bug for einsum OP and add a test case.


