### PR TITLE
[LLVM] Validate generated LLVM module before optimization

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -343,10 +343,13 @@ void CodeGenLLVM::HandleImport(const std::string& code) {
 
   mlib->setTargetTriple(llvm_target_->GetTargetTriple());
   mlib->setDataLayout(llvm_target_->GetOrCreateTargetMachine()->createDataLayout());
-  // mark all the functions as force inline
+  // Mark all the functions as force inline, so long as the
+  // incompatible OptimizeNone is not already present.
   for (llvm::Function& f : mlib->functions()) {
-    f.removeFnAttr(llvm::Attribute::NoInline);
-    f.addFnAttr(llvm::Attribute::AlwaysInline);
+    if (!f.hasFnAttribute(llvm::Attribute::OptimizeNone)) {
+      f.removeFnAttr(llvm::Attribute::NoInline);
+      f.addFnAttr(llvm::Attribute::AlwaysInline);
+    }
     f.setLinkage(llvm::GlobalValue::AvailableExternallyLinkage);
   }
   // add to linker libraries.

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -343,13 +343,11 @@ void CodeGenLLVM::HandleImport(const std::string& code) {
 
   mlib->setTargetTriple(llvm_target_->GetTargetTriple());
   mlib->setDataLayout(llvm_target_->GetOrCreateTargetMachine()->createDataLayout());
-  // Mark all the functions as force inline, so long as the
-  // incompatible OptimizeNone is not already present.
+  // mark all the functions as force inline
   for (llvm::Function& f : mlib->functions()) {
-    if (!f.hasFnAttribute(llvm::Attribute::OptimizeNone)) {
-      f.removeFnAttr(llvm::Attribute::NoInline);
-      f.addFnAttr(llvm::Attribute::AlwaysInline);
-    }
+    f.removeFnAttr(llvm::Attribute::OptimizeNone);
+    f.removeFnAttr(llvm::Attribute::NoInline);
+    f.addFnAttr(llvm::Attribute::AlwaysInline);
     f.setLinkage(llvm::GlobalValue::AvailableExternallyLinkage);
   }
   // add to linker libraries.

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -146,6 +146,12 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    * \return the created module.
    */
   virtual std::unique_ptr<llvm::Module> Finish();
+
+  /*!
+   * \brief Validate the generated module using llvm::verifyModule
+   */
+  void Verify() const;
+
   /*!
    * \brief Add functions from the (unordered) range to the current module in a deterministic order.
    *        The range consists of objects convertible to PrimFunc.

--- a/src/target/llvm/codegen_nvptx.cc
+++ b/src/target/llvm/codegen_nvptx.cc
@@ -121,7 +121,7 @@ class CodeGenNVPTX : public CodeGenLLVM {
         ICHECK(storage_scope.rank == runtime::StorageRank::kShared)
             << "Can only allocate shared or local memory inside kernel";
         buf = AllocateSharedMemory(op->dtype, constant_size, 3, info.alignment,
-                                   llvm::GlobalValue::PrivateLinkage);
+                                   llvm::GlobalValue::ExternalLinkage);
       }
     }
 

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -39,7 +39,6 @@
 #include <llvm/IR/MDBuilder.h>
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
-#include <llvm/IR/Verifier.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/SourceMgr.h>
@@ -330,11 +329,6 @@ void LLVMModuleNode::Init(const IRModule& mod, const Target& target) {
   if (tm->getTargetTriple().isOSDarwin()) {
     module_->addModuleFlag(llvm::Module::Override, "Dwarf Version", 2);
   }
-  std::string verify_errors_storage;
-  llvm::raw_string_ostream verify_errors(verify_errors_storage);
-  LOG_IF(FATAL, llvm::verifyModule(*module_, &verify_errors))
-      << "LLVM module verification failed with the following errors: \n"
-      << verify_errors.str();
 }
 
 void LLVMModuleNode::Init(std::unique_ptr<llvm::Module> module,
@@ -514,12 +508,6 @@ runtime::Module CreateLLVMCppMetadataModule(runtime::metadata::Metadata metadata
     mod->addModuleFlag(llvm::Module::Override, "Dwarf Version", 2);
   }
 
-  std::string verify_errors_storage;
-  llvm::raw_string_ostream verify_errors(verify_errors_storage);
-  LOG_IF(FATAL, llvm::verifyModule(*mod, &verify_errors))
-      << "LLVM module verification failed with the following errors: \n"
-      << verify_errors.str();
-
   auto n = make_object<LLVMModuleNode>();
   n->Init(std::move(mod), std::move(llvm_instance));
 
@@ -559,12 +547,6 @@ runtime::Module CreateLLVMCrtMetadataModule(const Array<runtime::Module>& module
   if (llvm_target->GetOrCreateTargetMachine()->getTargetTriple().isOSDarwin()) {
     mod->addModuleFlag(llvm::Module::Override, "Dwarf Version", 2);
   }
-
-  std::string verify_errors_storage;
-  llvm::raw_string_ostream verify_errors(verify_errors_storage);
-  LOG_IF(FATAL, llvm::verifyModule(*mod, &verify_errors))
-      << "LLVM module verification failed with the following errors: \n"
-      << verify_errors.str();
 
   auto n = make_object<LLVMModuleNode>();
   n->Init(std::move(mod), std::move(llvm_instance));


### PR DESCRIPTION
Because LLVM's optimizations assume that the generated module is valid, validation should be done before optimization, rather than after.  This has the additional benefit of providing error messages from LLVM that more closely relate to the TVM-generated LLVM IR, rather than the optimized LLVM IR.