### PR TITLE
[LLVM] Expand tvm::Type to DWARF conversion

### DIFF
--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -299,32 +299,22 @@ llvm::DIType* CodeGenCPU::GetDebugType(const Type& ty_tir, llvm::Type* ty_llvm) 
 
   } else if (auto* prim_type = ty_tir.as<PrimTypeNode>()) {
     DataType dtype = prim_type->dtype;
-    auto [name, dwarf_type] = [&]() -> std::tuple<const char*, llvm::dwarf::TypeKind> {
+    auto dwarf_type = [&]() -> llvm::dwarf::TypeKind {
       if (dtype.is_bool()) {
-        return {"bool", llvm::dwarf::DW_ATE_boolean};
+        return llvm::dwarf::DW_ATE_boolean;
       } else if (dtype.is_float()) {
-        return {"float", llvm::dwarf::DW_ATE_float};
+        return llvm::dwarf::DW_ATE_float;
       } else if (dtype.is_int()) {
-        return {"int", llvm::dwarf::DW_ATE_signed};
+        return llvm::dwarf::DW_ATE_signed;
       } else if (dtype.is_uint()) {
-        return {"uint", llvm::dwarf::DW_ATE_unsigned};
+        return llvm::dwarf::DW_ATE_unsigned;
       } else {
         LOG(FATAL) << "No DWARF representation for TIR type " << dtype;
       }
     }();
 
-    std::stringstream ss;
-    ss << name;
-
-    if (!dtype.is_bool()) {
-      ss << dtype.bits();
-    }
-    if (dtype.lanes() > 1) {
-      ss << "x" << dtype.lanes();
-    }
-
-    return dbg_info_->di_builder_->createBasicType(ss.str(), dtype.bits() * dtype.lanes(),
-                                                   dwarf_type);
+    return dbg_info_->di_builder_->createBasicType(DLDataType2String(dtype),
+                                                   dtype.bits() * dtype.lanes(), dwarf_type);
 
   } else {
     std::string type_str;

--- a/tests/python/unittest/test_target_codegen_llvm.py
+++ b/tests/python/unittest/test_target_codegen_llvm.py
@@ -1002,5 +1002,25 @@ def test_llvm_assume():
     m = tvm.build(mod, [inp, out], target="llvm")
 
 
+@tvm.testing.requires_llvm
+def test_debug_symbol_for_float64():
+    """Check that LLVM can define DWARF debug type for float64
+
+    In previous versions, only specific data types could exist in the
+    function signature.  In this test, the "calling_conv" attribute
+    prevents lowering to the PackedFunc API.
+    """
+
+    @T.prim_func
+    def func(a: T.handle("float64"), b: T.handle("float64"), n: T.int64):
+        T.func_attr({"calling_conv": 2})
+        A = T.Buffer(16, "float64", data=a)
+        B = T.Buffer(16, "float64", data=b)
+        for i in range(n):
+            B[i] = A[i]
+
+    tvm.build(func, target="llvm")
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Prior to this commit, DWARF debug symbols for `float32`, `int8`, and `int32` could be generated, with other datatypes resulting in an error.  This commit expands the range of types with debug symbols to allow for any `DLDataTypeCode::kDLInt`, `kDLUint`, or `kDLFloat`, regardless of the bitsize.