### PR TITLE
[Node] Allow alternative root names in ObjectPath::Root()

### DIFF
--- a/include/tvm/node/object_path.h
+++ b/include/tvm/node/object_path.h
@@ -122,7 +122,7 @@ class ObjectPathNode : public Object {
 class ObjectPath : public ObjectRef {
  public:
   /*! \brief Create a path that represents the root object itself. */
-  static ObjectPath Root();
+  static ObjectPath Root(Optional<String> name = NullOpt);
 
   TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ObjectPath, ObjectRef, ObjectPathNode);
 };
@@ -135,7 +135,9 @@ class ObjectPath : public ObjectRef {
 
 class RootPathNode final : public ObjectPathNode {
  public:
-  explicit RootPathNode();
+  Optional<String> name;
+
+  explicit RootPathNode(Optional<String> name = NullOpt);
 
   static constexpr const char* _type_key = "RootPath";
   TVM_DECLARE_FINAL_OBJECT_INFO(RootPathNode, ObjectPathNode);

--- a/python/tvm/runtime/object_path.py
+++ b/python/tvm/runtime/object_path.py
@@ -20,6 +20,8 @@ ObjectPath class that represents a path from a root object to one of its descend
 via attribute access, array indexing etc.
 """
 
+from typing import Optional
+
 import tvm._ffi
 from tvm.runtime import Object
 from . import _ffi_node_api
@@ -52,8 +54,8 @@ class ObjectPath(Object):
         )
 
     @staticmethod
-    def root() -> "ObjectPath":
-        return _ffi_node_api.ObjectPathRoot()
+    def root(root_name: Optional[str] = None) -> "ObjectPath":
+        return _ffi_node_api.ObjectPathRoot(root_name)
 
     def __eq__(self, other):
         return _ffi_node_api.ObjectPathEqual(self, other)

--- a/tests/python/unittest/test_object_path.py
+++ b/tests/python/unittest/test_object_path.py
@@ -30,6 +30,16 @@ def test_root_path():
     assert root.parent is None
 
 
+def test_named_root_path():
+    root = ObjectPath.root("base_name")
+    assert isinstance(root, object_path.RootPath)
+    assert str(root) == "base_name"
+    assert len(root) == 1
+    assert root != ObjectPath.root()
+    assert root == ObjectPath.root("base_name")
+    assert root.parent is None
+
+
 def test_path_attr():
     path = ObjectPath.root().attr("foo")
     assert isinstance(path, object_path.AttributeAccessPath)


### PR DESCRIPTION
Previously, the `ObjectPath` utility allowed tracking of an object's location within a tree-like structure.  However, the base of the path structure was hard-coded to be the string `<root>`.  For use cases such as `StructuralEqual`, there is a clear root node.  However, other cases such as using `ObjectPath` to specify an object's location relative to a known variable, would require using that known variable's name as the root, rather than the hard-coded string `<root>`.

This commit adds an optional parameter to provide an alternative name for the root node, to allow for these use cases.