### PR TITLE
[Unity] Update legalizer for variance

### DIFF
--- a/python/tvm/relax/transform/legalize_ops/statistical.py
+++ b/python/tvm/relax/transform/legalize_ops/statistical.py
@@ -45,8 +45,8 @@ def _te_mean(x: te.Tensor, axis: List[tir.IntImm], keepdims: bool) -> te.Tensor:
 
 
 def _te_variance(x: te.Tensor, axis: List[tir.IntImm], keepdims: bool) -> te.Tensor:
-    dev = x - _te_mean(x, axis, True)
-    return _te_mean(dev * dev, axis, keepdims)
+    mean = _te_mean(x, axis, keepdims)
+    return _te_mean(x * x, axis, keepdims) - mean * mean
 
 
 @register_legalize("relax.mean")

--- a/tests/python/relax/test_transform_legalize_ops_search_statistical.py
+++ b/tests/python/relax/test_transform_legalize_ops_search_statistical.py
@@ -692,44 +692,26 @@ def test_std():
             gv: R.Tensor((), "float32") = R.std(x)
             return gv
 
+
     @I.ir_module
     class Expected:
         @T.prim_func
         def std(rxplaceholder: T.Buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)), "float32"), compute: T.Buffer((), "float32")):
-            T.func_attr({"tir.noalias": True})
+            T.func_attr({"tir.noalias": T.bool(True)})
             # with T.block("root"):
-            rxplaceholder_red = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(1), T.int64(1)))
-            T_divide = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(1), T.int64(1)))
-            T_subtract = T.alloc_buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)))
             T_multiply = T.alloc_buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)))
             T_multiply_red = T.alloc_buffer(())
+            T_divide = T.alloc_buffer(())
+            rxplaceholder_red = T.alloc_buffer(())
             T_divide_1 = T.alloc_buffer(())
-            for ax0, ax1, ax2, ax3, k0, k1, k2, k3 in T.grid(T.int64(1), T.int64(1), T.int64(1), T.int64(1), T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
-                with T.block("rxplaceholder_red"):
-                    v_ax0, v_ax1, v_ax2, v_ax3, v_k0, v_k1, v_k2, v_k3 = T.axis.remap("SSSSRRRR", [ax0, ax1, ax2, ax3, k0, k1, k2, k3])
-                    T.reads(rxplaceholder[v_k0, v_k1, v_k2, v_k3])
-                    T.writes(rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3])
-                    with T.init():
-                        rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] = T.float32(0)
-                    rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] + rxplaceholder[v_k0, v_k1, v_k2, v_k3]
-            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(1), T.int64(1)):
-                with T.block("T_divide"):
-                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
-                    T.reads(rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T.writes(T_divide[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T_divide[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] * T.float32(0.0083333333333333332)
-            for ax0, ax1, ax2, ax3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
-                with T.block("T_subtract"):
-                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
-                    T.reads(rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3], T_divide[T.int64(0), T.int64(0), T.int64(0), T.int64(0)])
-                    T.writes(T_subtract[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T_subtract[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3] - T_divide[T.int64(0), T.int64(0), T.int64(0), T.int64(0)]
+            T_multiply_1 = T.alloc_buffer(())
+            T_subtract = T.alloc_buffer(())
             for ax0, ax1, ax2, ax3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
                 with T.block("T_multiply"):
                     v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
-                    T.reads(T_subtract[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.reads(rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3])
                     T.writes(T_multiply[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = T_subtract[v_ax0, v_ax1, v_ax2, v_ax3] * T_subtract[v_ax0, v_ax1, v_ax2, v_ax3]
+                    T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3] * rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3]
             for k0, k1, k2, k3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
                 with T.block("T_multiply_red"):
                     v_k0, v_k1, v_k2, v_k3 = T.axis.remap("RRRR", [k0, k1, k2, k3])
@@ -738,16 +720,39 @@ def test_std():
                     with T.init():
                         T_multiply_red[()] = T.float32(0)
                     T_multiply_red[()] = T_multiply_red[()] + T_multiply[v_k0, v_k1, v_k2, v_k3]
-            with T.block("T_divide_1"):
+            with T.block("T_divide"):
                 vi = T.axis.spatial(1, T.int64(0))
                 T.reads(T_multiply_red[()])
+                T.writes(T_divide[()])
+                T_divide[()] = T_multiply_red[()] * T.float32(0.0083333333333333332)
+            for k0, k1, k2, k3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
+                with T.block("rxplaceholder_red"):
+                    v_k0, v_k1, v_k2, v_k3 = T.axis.remap("RRRR", [k0, k1, k2, k3])
+                    T.reads(rxplaceholder[v_k0, v_k1, v_k2, v_k3])
+                    T.writes(rxplaceholder_red[()])
+                    with T.init():
+                        rxplaceholder_red[()] = T.float32(0)
+                    rxplaceholder_red[()] = rxplaceholder_red[()] + rxplaceholder[v_k0, v_k1, v_k2, v_k3]
+            with T.block("T_divide_1"):
+                vi = T.axis.spatial(1, T.int64(0))
+                T.reads(rxplaceholder_red[()])
                 T.writes(T_divide_1[()])
-                T_divide_1[()] = T_multiply_red[()] * T.float32(0.0083333333333333332)
-            with T.block("compute"):
+                T_divide_1[()] = rxplaceholder_red[()] * T.float32(0.0083333333333333332)
+            with T.block("T_multiply_1"):
                 vi = T.axis.spatial(1, T.int64(0))
                 T.reads(T_divide_1[()])
+                T.writes(T_multiply_1[()])
+                T_multiply_1[()] = T_divide_1[()] * T_divide_1[()]
+            with T.block("T_subtract"):
+                vi = T.axis.spatial(1, T.int64(0))
+                T.reads(T_divide[()], T_multiply_1[()])
+                T.writes(T_subtract[()])
+                T_subtract[()] = T_divide[()] - T_multiply_1[()]
+            with T.block("compute"):
+                vi = T.axis.spatial(1, T.int64(0))
+                T.reads(T_subtract[()])
                 T.writes(compute[()])
-                compute[()] = T.sqrt(T_divide_1[()])
+                compute[()] = T.sqrt(T_subtract[()])
 
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
@@ -773,42 +778,23 @@ def test_std_symbolic():
     class Expected:
         @T.prim_func
         def std(var_rxplaceholder: T.handle, compute: T.Buffer((), "float32")):
-            T.func_attr({"tir.noalias": True})
+            T.func_attr({"tir.noalias": T.bool(True)})
             a, b, c, d = T.int64(), T.int64(), T.int64(), T.int64()
             rxplaceholder = T.match_buffer(var_rxplaceholder, (a, b, c, d))
             # with T.block("root"):
-            rxplaceholder_red = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(1), T.int64(1)))
-            T_divide = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(1), T.int64(1)))
-            T_subtract = T.alloc_buffer((a, b, c, d))
             T_multiply = T.alloc_buffer((a, b, c, d))
             T_multiply_red = T.alloc_buffer(())
+            T_divide = T.alloc_buffer(())
+            rxplaceholder_red = T.alloc_buffer(())
             T_divide_1 = T.alloc_buffer(())
-            for ax0, ax1, ax2, ax3, k0, k1, k2, k3 in T.grid(T.int64(1), T.int64(1), T.int64(1), T.int64(1), a, b, c, d):
-                with T.block("rxplaceholder_red"):
-                    v_ax0, v_ax1, v_ax2, v_ax3, v_k0, v_k1, v_k2, v_k3 = T.axis.remap("SSSSRRRR", [ax0, ax1, ax2, ax3, k0, k1, k2, k3])
-                    T.reads(rxplaceholder[v_k0, v_k1, v_k2, v_k3])
-                    T.writes(rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3])
-                    with T.init():
-                        rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] = T.float32(0)
-                    rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] + rxplaceholder[v_k0, v_k1, v_k2, v_k3]
-            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(1), T.int64(1)):
-                with T.block("T_divide"):
-                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
-                    T.reads(rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T.writes(T_divide[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T_divide[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] / T.Cast("float32", a * b * c * d)
-            for ax0, ax1, ax2, ax3 in T.grid(a, b, c, d):
-                with T.block("T_subtract"):
-                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
-                    T.reads(rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3], T_divide[T.int64(0), T.int64(0), T.int64(0), T.int64(0)])
-                    T.writes(T_subtract[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T_subtract[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3] - T_divide[T.int64(0), T.int64(0), T.int64(0), T.int64(0)]
+            T_multiply_1 = T.alloc_buffer(())
+            T_subtract = T.alloc_buffer(())
             for ax0, ax1, ax2, ax3 in T.grid(a, b, c, d):
                 with T.block("T_multiply"):
                     v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
-                    T.reads(T_subtract[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.reads(rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3])
                     T.writes(T_multiply[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = T_subtract[v_ax0, v_ax1, v_ax2, v_ax3] * T_subtract[v_ax0, v_ax1, v_ax2, v_ax3]
+                    T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3] * rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3]
             for k0, k1, k2, k3 in T.grid(a, b, c, d):
                 with T.block("T_multiply_red"):
                     v_k0, v_k1, v_k2, v_k3 = T.axis.remap("RRRR", [k0, k1, k2, k3])
@@ -817,16 +803,39 @@ def test_std_symbolic():
                     with T.init():
                         T_multiply_red[()] = T.float32(0)
                     T_multiply_red[()] = T_multiply_red[()] + T_multiply[v_k0, v_k1, v_k2, v_k3]
-            with T.block("T_divide_1"):
+            with T.block("T_divide"):
                 vi = T.axis.spatial(1, T.int64(0))
                 T.reads(T_multiply_red[()])
+                T.writes(T_divide[()])
+                T_divide[()] = T_multiply_red[()] / T.Cast("float32", a * b * c * d)
+            for k0, k1, k2, k3 in T.grid(a, b, c, d):
+                with T.block("rxplaceholder_red"):
+                    v_k0, v_k1, v_k2, v_k3 = T.axis.remap("RRRR", [k0, k1, k2, k3])
+                    T.reads(rxplaceholder[v_k0, v_k1, v_k2, v_k3])
+                    T.writes(rxplaceholder_red[()])
+                    with T.init():
+                        rxplaceholder_red[()] = T.float32(0)
+                    rxplaceholder_red[()] = rxplaceholder_red[()] + rxplaceholder[v_k0, v_k1, v_k2, v_k3]
+            with T.block("T_divide_1"):
+                vi = T.axis.spatial(1, T.int64(0))
+                T.reads(rxplaceholder_red[()])
                 T.writes(T_divide_1[()])
-                T_divide_1[()] = T_multiply_red[()] / T.Cast("float32", a * b * c * d)
-            with T.block("compute"):
+                T_divide_1[()] = rxplaceholder_red[()] / T.Cast("float32", a * b * c * d)
+            with T.block("T_multiply_1"):
                 vi = T.axis.spatial(1, T.int64(0))
                 T.reads(T_divide_1[()])
+                T.writes(T_multiply_1[()])
+                T_multiply_1[()] = T_divide_1[()] * T_divide_1[()]
+            with T.block("T_subtract"):
+                vi = T.axis.spatial(1, T.int64(0))
+                T.reads(T_divide[()], T_multiply_1[()])
+                T.writes(T_subtract[()])
+                T_subtract[()] = T_divide[()] - T_multiply_1[()]
+            with T.block("compute"):
+                vi = T.axis.spatial(1, T.int64(0))
+                T.reads(T_subtract[()])
                 T.writes(compute[()])
-                compute[()] = T.sqrt(T_divide_1[()])
+                compute[()] = T.sqrt(T_subtract[()])
 
         @R.function
         def main(x: R.Tensor(("a", "b", "c", "d"), dtype="float32")) -> R.Tensor((), dtype="float32"):
@@ -852,61 +861,70 @@ def test_variance():
             gv: R.Tensor((1, 3, 4, 1), "float32") = R.variance(x, [0, 3], keepdims=True)
             return gv
 
-    @tvm.script.ir_module
+    @I.ir_module
     class Expected:
+        @T.prim_func
+        def variance(rxplaceholder: T.Buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)), "float32"), T_subtract: T.Buffer((T.int64(1), T.int64(3), T.int64(4), T.int64(1)), "float32")):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            T_multiply = T.alloc_buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)))
+            T_multiply_red = T.alloc_buffer((T.int64(1), T.int64(3), T.int64(4), T.int64(1)))
+            T_divide = T.alloc_buffer((T.int64(1), T.int64(3), T.int64(4), T.int64(1)))
+            rxplaceholder_red = T.alloc_buffer((T.int64(1), T.int64(3), T.int64(4), T.int64(1)))
+            T_divide_1 = T.alloc_buffer((T.int64(1), T.int64(3), T.int64(4), T.int64(1)))
+            T_multiply_1 = T.alloc_buffer((T.int64(1), T.int64(3), T.int64(4), T.int64(1)))
+            for ax0, ax1, ax2, ax3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
+                with T.block("T_multiply"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_multiply[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3] * rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3]
+            for ax0, ax1, ax2, ax3, k0, k3 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1), T.int64(2), T.int64(5)):
+                with T.block("T_multiply_red"):
+                    v_ax0, v_ax1, v_ax2, v_ax3, v_k0, v_k3 = T.axis.remap("SSSSRR", [ax0, ax1, ax2, ax3, k0, k3])
+                    T.reads(T_multiply[v_k0, v_ax1, v_ax2, v_k3])
+                    T.writes(T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3])
+                    with T.init():
+                        T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3] = T.float32(0)
+                    T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3] = T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3] + T_multiply[v_k0, v_ax1, v_ax2, v_k3]
+            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1)):
+                with T.block("T_divide"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_divide[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_divide[v_ax0, v_ax1, v_ax2, v_ax3] = T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3] * T.float32(0.10000000000000001)
+            for ax0, ax1, ax2, ax3, k0, k3 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1), T.int64(2), T.int64(5)):
+                with T.block("rxplaceholder_red"):
+                    v_ax0, v_ax1, v_ax2, v_ax3, v_k0, v_k3 = T.axis.remap("SSSSRR", [ax0, ax1, ax2, ax3, k0, k3])
+                    T.reads(rxplaceholder[v_k0, v_ax1, v_ax2, v_k3])
+                    T.writes(rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3])
+                    with T.init():
+                        rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] = T.float32(0)
+                    rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] + rxplaceholder[v_k0, v_ax1, v_ax2, v_k3]
+            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1)):
+                with T.block("T_divide_1"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] * T.float32(0.10000000000000001)
+            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1)):
+                with T.block("T_multiply_1"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_multiply_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_multiply_1[v_ax0, v_ax1, v_ax2, v_ax3] = T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3] * T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3]
+            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1)):
+                with T.block("T_subtract"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(T_divide[v_ax0, v_ax1, v_ax2, v_ax3], T_multiply_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_subtract[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_subtract[v_ax0, v_ax1, v_ax2, v_ax3] = T_divide[v_ax0, v_ax1, v_ax2, v_ax3] - T_multiply_1[v_ax0, v_ax1, v_ax2, v_ax3]
+
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), dtype="float32")) -> R.Tensor((1, 3, 4, 1), dtype="float32"):
-            gv = R.call_tir(Expected.variance, (x,), R.Tensor((1, 3, 4, 1), dtype="float32"))
+            cls = Expected
+            gv = R.call_tir(cls.variance, (x,), out_sinfo=R.Tensor((1, 3, 4, 1), dtype="float32"))
             return gv
-
-        @T.prim_func
-        def variance(rxplaceholder: T.Buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)), "float32"), T_divide: T.Buffer((T.int64(1), T.int64(3), T.int64(4), T.int64(1)), "float32")):
-            T.func_attr({"tir.noalias": True})
-            rxplaceholder_red = T.alloc_buffer([T.int64(1), T.int64(3), T.int64(4), T.int64(1)], dtype="float32")
-            T_divide_1 = T.alloc_buffer([T.int64(1), T.int64(3), T.int64(4), T.int64(1)], dtype="float32")
-            T_subtract = T.alloc_buffer([T.int64(2), T.int64(3), T.int64(4), T.int64(5)], dtype="float32")
-            T_multiply = T.alloc_buffer([T.int64(2), T.int64(3), T.int64(4), T.int64(5)], dtype="float32")
-            T_multiply_red = T.alloc_buffer([T.int64(1), T.int64(3), T.int64(4), T.int64(1)], dtype="float32")
-            for i0, i1, i2, i3, i4, i5 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1), T.int64(2), T.int64(5)):
-                with T.block("rxplaceholder_red"):
-                    ax0, ax1, ax2, ax3, k0, k3 = T.axis.remap("SSSSRR", [i0, i1, i2, i3, i4, i5])
-                    T.reads(rxplaceholder[k0, ax1, ax2, k3])
-                    T.writes(rxplaceholder_red[ax0, ax1, ax2, ax3])
-                    with T.init():
-                        rxplaceholder_red[ax0, ax1, ax2, ax3] = T.float32(0)
-                    rxplaceholder_red[ax0, ax1, ax2, ax3] = rxplaceholder_red[ax0, ax1, ax2, ax3] + rxplaceholder[k0, ax1, ax2, k3]
-            for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1)):
-                with T.block("T_divide"):
-                    ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
-                    T.reads(rxplaceholder_red[ax0, ax1, ax2, ax3])
-                    T.writes(T_divide_1[ax0, ax1, ax2, ax3])
-                    T_divide_1[ax0, ax1, ax2, ax3] = rxplaceholder_red[ax0, ax1, ax2, ax3] * T.float32(0.10000000000000001)
-            for i0, i1, i2, i3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
-                with T.block("T_subtract"):
-                    ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
-                    T.reads(rxplaceholder[ax0, ax1, ax2, ax3], T_divide_1[T.int64(0), ax1, ax2, T.int64(0)])
-                    T.writes(T_subtract[ax0, ax1, ax2, ax3])
-                    T_subtract[ax0, ax1, ax2, ax3] = rxplaceholder[ax0, ax1, ax2, ax3] - T_divide_1[T.int64(0), ax1, ax2, T.int64(0)]
-            for i0, i1, i2, i3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
-                with T.block("T_multiply"):
-                    ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
-                    T.reads(T_subtract[ax0, ax1, ax2, ax3])
-                    T.writes(T_multiply[ax0, ax1, ax2, ax3])
-                    T_multiply[ax0, ax1, ax2, ax3] = T_subtract[ax0, ax1, ax2, ax3] * T_subtract[ax0, ax1, ax2, ax3]
-            for i0, i1, i2, i3, i4, i5 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1), T.int64(2), T.int64(5)):
-                with T.block("T_multiply_red"):
-                    ax0, ax1, ax2, ax3, k0, k3 = T.axis.remap("SSSSRR", [i0, i1, i2, i3, i4, i5])
-                    T.reads(T_multiply[k0, ax1, ax2, k3])
-                    T.writes(T_multiply_red[ax0, ax1, ax2, ax3])
-                    with T.init():
-                        T_multiply_red[ax0, ax1, ax2, ax3] = T.float32(0)
-                    T_multiply_red[ax0, ax1, ax2, ax3] = T_multiply_red[ax0, ax1, ax2, ax3] + T_multiply[k0, ax1, ax2, k3]
-            for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1)):
-                with T.block("T_divide_1"):
-                    ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
-                    T.reads(T_multiply_red[ax0, ax1, ax2, ax3])
-                    T.writes(T_divide[ax0, ax1, ax2, ax3])
-                    T_divide[ax0, ax1, ax2, ax3] = T_multiply_red[ax0, ax1, ax2, ax3] * T.float32(0.10000000000000001)
     # fmt: on
 
     mod = LegalizeOps()(Variance)
@@ -924,69 +942,77 @@ def test_variance_symbolic():
             gv: R.Tensor((1, b, c, 1), "float32") = R.variance(x, [0, 3], keepdims=True)
             return gv
 
-    @tvm.script.ir_module
+    @I.ir_module
     class Expected:
-        @R.function
-        def main(x: R.Tensor(("a", "b", "c", "d"), "float32")) -> R.Tensor((1, "b", "c", 1), "float32"):
-            b = T.int64()
-            c = T.int64()
-            gv = R.call_tir(Expected.variance, (x,), R.Tensor((1, b, c, 1), dtype="float32"))
-            return gv
-
         @T.prim_func
-        def variance(var_rxplaceholder: T.handle, var_T_divide: T.handle):
-            T.func_attr({"tir.noalias": True})
-            a = T.int64()
+        def variance(var_rxplaceholder: T.handle, var_T_subtract: T.handle):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            a, b, c, d = T.int64(), T.int64(), T.int64(), T.int64()
+            rxplaceholder = T.match_buffer(var_rxplaceholder, (a, b, c, d))
+            T_subtract = T.match_buffer(var_T_subtract, (T.int64(1), b, c, T.int64(1)))
+            # with T.block("root"):
+            T_multiply = T.alloc_buffer((a, b, c, d))
+            T_multiply_red = T.alloc_buffer((T.int64(1), b, c, T.int64(1)))
+            T_divide = T.alloc_buffer((T.int64(1), b, c, T.int64(1)))
+            rxplaceholder_red = T.alloc_buffer((T.int64(1), b, c, T.int64(1)))
+            T_divide_1 = T.alloc_buffer((T.int64(1), b, c, T.int64(1)))
+            T_multiply_1 = T.alloc_buffer((T.int64(1), b, c, T.int64(1)))
+            for ax0, ax1, ax2, ax3 in T.grid(a, b, c, d):
+                with T.block("T_multiply"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_multiply[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3] * rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3]
+            for ax0, ax1, ax2, ax3, k0, k3 in T.grid(T.int64(1), b, c, T.int64(1), a, d):
+                with T.block("T_multiply_red"):
+                    v_ax0, v_ax1, v_ax2, v_ax3, v_k0, v_k3 = T.axis.remap("SSSSRR", [ax0, ax1, ax2, ax3, k0, k3])
+                    T.reads(T_multiply[v_k0, v_ax1, v_ax2, v_k3])
+                    T.writes(T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3])
+                    with T.init():
+                        T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3] = T.float32(0)
+                    T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3] = T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3] + T_multiply[v_k0, v_ax1, v_ax2, v_k3]
+            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), b, c, T.int64(1)):
+                with T.block("T_divide"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_divide[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_divide[v_ax0, v_ax1, v_ax2, v_ax3] = T_multiply_red[v_ax0, v_ax1, v_ax2, v_ax3] / T.Cast("float32", a * d)
+            for ax0, ax1, ax2, ax3, k0, k3 in T.grid(T.int64(1), b, c, T.int64(1), a, d):
+                with T.block("rxplaceholder_red"):
+                    v_ax0, v_ax1, v_ax2, v_ax3, v_k0, v_k3 = T.axis.remap("SSSSRR", [ax0, ax1, ax2, ax3, k0, k3])
+                    T.reads(rxplaceholder[v_k0, v_ax1, v_ax2, v_k3])
+                    T.writes(rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3])
+                    with T.init():
+                        rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] = T.float32(0)
+                    rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] + rxplaceholder[v_k0, v_ax1, v_ax2, v_k3]
+            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), b, c, T.int64(1)):
+                with T.block("T_divide_1"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] / T.Cast("float32", a * d)
+            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), b, c, T.int64(1)):
+                with T.block("T_multiply_1"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_multiply_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_multiply_1[v_ax0, v_ax1, v_ax2, v_ax3] = T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3] * T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3]
+            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), b, c, T.int64(1)):
+                with T.block("T_subtract"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(T_divide[v_ax0, v_ax1, v_ax2, v_ax3], T_multiply_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_subtract[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_subtract[v_ax0, v_ax1, v_ax2, v_ax3] = T_divide[v_ax0, v_ax1, v_ax2, v_ax3] - T_multiply_1[v_ax0, v_ax1, v_ax2, v_ax3]
+
+        @R.function
+        def main(x: R.Tensor(("a", "b", "c", "d"), dtype="float32")) -> R.Tensor((1, "b", "c", 1), dtype="float32"):
             b = T.int64()
             c = T.int64()
+            a = T.int64()
             d = T.int64()
-            rxplaceholder = T.match_buffer(var_rxplaceholder, [a, b, c, d], dtype="float32")
-            T_divide = T.match_buffer(var_T_divide, [T.int64(1), b, c, T.int64(1)], dtype="float32")
-            rxplaceholder_red = T.alloc_buffer([T.int64(1), b, c, T.int64(1)], dtype="float32")
-            T_divide_1 = T.alloc_buffer([T.int64(1), b, c, T.int64(1)], dtype="float32")
-            T_subtract = T.alloc_buffer([a, b, c, d], dtype="float32")
-            T_multiply = T.alloc_buffer([a, b, c, d], dtype="float32")
-            T_multiply_red = T.alloc_buffer([T.int64(1), b, c, T.int64(1)], dtype="float32")
-            for i0, i1, i2, i3, i4, i5 in T.grid(T.int64(1), b, c, T.int64(1), a, d):
-                with T.block("rxplaceholder_red"):
-                    ax0, ax1, ax2, ax3, k0, k3 = T.axis.remap("SSSSRR", [i0, i1, i2, i3, i4, i5])
-                    T.reads(rxplaceholder[k0, ax1, ax2, k3])
-                    T.writes(rxplaceholder_red[ax0, ax1, ax2, ax3])
-                    with T.init():
-                        rxplaceholder_red[ax0, ax1, ax2, ax3] = T.float32(0)
-                    rxplaceholder_red[ax0, ax1, ax2, ax3] = rxplaceholder_red[ax0, ax1, ax2, ax3] + rxplaceholder[k0, ax1, ax2, k3]
-            for i0, i1, i2, i3 in T.grid(T.int64(1), b, c, T.int64(1)):
-                with T.block("T_divide"):
-                    ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
-                    T.reads(rxplaceholder_red[ax0, ax1, ax2, ax3])
-                    T.writes(T_divide_1[ax0, ax1, ax2, ax3])
-                    T_divide_1[ax0, ax1, ax2, ax3] = rxplaceholder_red[ax0, ax1, ax2, ax3] / T.Cast("float32", a * d)
-            for i0, i1, i2, i3 in T.grid(a, b, c, d):
-                with T.block("T_subtract"):
-                    ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
-                    T.reads(rxplaceholder[ax0, ax1, ax2, ax3], T_divide_1[T.int64(0), ax1, ax2, T.int64(0)])
-                    T.writes(T_subtract[ax0, ax1, ax2, ax3])
-                    T_subtract[ax0, ax1, ax2, ax3] = rxplaceholder[ax0, ax1, ax2, ax3] - T_divide_1[T.int64(0), ax1, ax2, T.int64(0)]
-            for i0, i1, i2, i3 in T.grid(a, b, c, d):
-                with T.block("T_multiply"):
-                    ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
-                    T.reads(T_subtract[ax0, ax1, ax2, ax3])
-                    T.writes(T_multiply[ax0, ax1, ax2, ax3])
-                    T_multiply[ax0, ax1, ax2, ax3] = T_subtract[ax0, ax1, ax2, ax3] * T_subtract[ax0, ax1, ax2, ax3]
-            for i0, i1, i2, i3, i4, i5 in T.grid(T.int64(1), b, c, T.int64(1), a, d):
-                with T.block("T_multiply_red"):
-                    ax0, ax1, ax2, ax3, k0, k3 = T.axis.remap("SSSSRR", [i0, i1, i2, i3, i4, i5])
-                    T.reads(T_multiply[k0, ax1, ax2, k3])
-                    T.writes(T_multiply_red[ax0, ax1, ax2, ax3])
-                    with T.init():
-                        T_multiply_red[ax0, ax1, ax2, ax3] = T.float32(0)
-                    T_multiply_red[ax0, ax1, ax2, ax3] = T_multiply_red[ax0, ax1, ax2, ax3] + T_multiply[k0, ax1, ax2, k3]
-            for i0, i1, i2, i3 in T.grid(T.int64(1), b, c, T.int64(1)):
-                with T.block("T_divide_1"):
-                    ax0, ax1, ax2, ax3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
-                    T.reads(T_multiply_red[ax0, ax1, ax2, ax3])
-                    T.writes(T_divide[ax0, ax1, ax2, ax3])
-                    T_divide[ax0, ax1, ax2, ax3] = T_multiply_red[ax0, ax1, ax2, ax3] / T.Cast("float32", a * d)
+            cls = Expected
+            gv = R.call_tir(cls.variance, (x,), out_sinfo=R.Tensor((1, b, c, 1), dtype="float32"))
+            return gv
     # fmt: on
 
     mod = LegalizeOps()(Variance)
@@ -1005,40 +1031,21 @@ def test_variance_no_keepdims():
     @I.ir_module
     class Expected:
         @T.prim_func
-        def variance(rxplaceholder: T.Buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)), "float32"), T_divide: T.Buffer((T.int64(3), T.int64(4)), "float32")):
-            T.func_attr({"tir.noalias": True})
+        def variance(rxplaceholder: T.Buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)), "float32"), T_subtract: T.Buffer((T.int64(3), T.int64(4)), "float32")):
+            T.func_attr({"tir.noalias": T.bool(True)})
             # with T.block("root"):
-            rxplaceholder_red = T.alloc_buffer((T.int64(1), T.int64(3), T.int64(4), T.int64(1)))
-            T_divide_1 = T.alloc_buffer((T.int64(1), T.int64(3), T.int64(4), T.int64(1)))
-            T_subtract = T.alloc_buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)))
             T_multiply = T.alloc_buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)))
             T_multiply_red = T.alloc_buffer((T.int64(3), T.int64(4)))
-            for ax0, ax1, ax2, ax3, k0, k3 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1), T.int64(2), T.int64(5)):
-                with T.block("rxplaceholder_red"):
-                    v_ax0, v_ax1, v_ax2, v_ax3, v_k0, v_k3 = T.axis.remap("SSSSRR", [ax0, ax1, ax2, ax3, k0, k3])
-                    T.reads(rxplaceholder[v_k0, v_ax1, v_ax2, v_k3])
-                    T.writes(rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3])
-                    with T.init():
-                        rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] = T.float32(0)
-                    rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] + rxplaceholder[v_k0, v_ax1, v_ax2, v_k3]
-            for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(3), T.int64(4), T.int64(1)):
-                with T.block("T_divide"):
-                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
-                    T.reads(rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T.writes(T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T_divide_1[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder_red[v_ax0, v_ax1, v_ax2, v_ax3] * T.float32(0.10000000000000001)
-            for ax0, ax1, ax2, ax3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
-                with T.block("T_subtract"):
-                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
-                    T.reads(rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3], T_divide_1[T.int64(0), v_ax1, v_ax2, T.int64(0)])
-                    T.writes(T_subtract[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T_subtract[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3] - T_divide_1[T.int64(0), v_ax1, v_ax2, T.int64(0)]
+            T_divide = T.alloc_buffer((T.int64(3), T.int64(4)))
+            rxplaceholder_red = T.alloc_buffer((T.int64(3), T.int64(4)))
+            T_divide_1 = T.alloc_buffer((T.int64(3), T.int64(4)))
+            T_multiply_1 = T.alloc_buffer((T.int64(3), T.int64(4)))
             for ax0, ax1, ax2, ax3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
                 with T.block("T_multiply"):
                     v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
-                    T.reads(T_subtract[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.reads(rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3])
                     T.writes(T_multiply[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = T_subtract[v_ax0, v_ax1, v_ax2, v_ax3] * T_subtract[v_ax0, v_ax1, v_ax2, v_ax3]
+                    T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3] * rxplaceholder[v_ax0, v_ax1, v_ax2, v_ax3]
             for ax0, ax1, k0, k3 in T.grid(T.int64(3), T.int64(4), T.int64(2), T.int64(5)):
                 with T.block("T_multiply_red"):
                     v_ax0, v_ax1, v_k0, v_k3 = T.axis.remap("SSRR", [ax0, ax1, k0, k3])
@@ -1048,11 +1055,37 @@ def test_variance_no_keepdims():
                         T_multiply_red[v_ax0, v_ax1] = T.float32(0)
                     T_multiply_red[v_ax0, v_ax1] = T_multiply_red[v_ax0, v_ax1] + T_multiply[v_k0, v_ax0, v_ax1, v_k3]
             for ax0, ax1 in T.grid(T.int64(3), T.int64(4)):
-                with T.block("T_divide_1"):
+                with T.block("T_divide"):
                     v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
                     T.reads(T_multiply_red[v_ax0, v_ax1])
                     T.writes(T_divide[v_ax0, v_ax1])
                     T_divide[v_ax0, v_ax1] = T_multiply_red[v_ax0, v_ax1] * T.float32(0.10000000000000001)
+            for ax0, ax1, k0, k3 in T.grid(T.int64(3), T.int64(4), T.int64(2), T.int64(5)):
+                with T.block("rxplaceholder_red"):
+                    v_ax0, v_ax1, v_k0, v_k3 = T.axis.remap("SSRR", [ax0, ax1, k0, k3])
+                    T.reads(rxplaceholder[v_k0, v_ax0, v_ax1, v_k3])
+                    T.writes(rxplaceholder_red[v_ax0, v_ax1])
+                    with T.init():
+                        rxplaceholder_red[v_ax0, v_ax1] = T.float32(0)
+                    rxplaceholder_red[v_ax0, v_ax1] = rxplaceholder_red[v_ax0, v_ax1] + rxplaceholder[v_k0, v_ax0, v_ax1, v_k3]
+            for ax0, ax1 in T.grid(T.int64(3), T.int64(4)):
+                with T.block("T_divide_1"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(rxplaceholder_red[v_ax0, v_ax1])
+                    T.writes(T_divide_1[v_ax0, v_ax1])
+                    T_divide_1[v_ax0, v_ax1] = rxplaceholder_red[v_ax0, v_ax1] * T.float32(0.10000000000000001)
+            for ax0, ax1 in T.grid(T.int64(3), T.int64(4)):
+                with T.block("T_multiply_1"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(T_divide_1[v_ax0, v_ax1])
+                    T.writes(T_multiply_1[v_ax0, v_ax1])
+                    T_multiply_1[v_ax0, v_ax1] = T_divide_1[v_ax0, v_ax1] * T_divide_1[v_ax0, v_ax1]
+            for ax0, ax1 in T.grid(T.int64(3), T.int64(4)):
+                with T.block("T_subtract"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(T_divide[v_ax0, v_ax1], T_multiply_1[v_ax0, v_ax1])
+                    T.writes(T_subtract[v_ax0, v_ax1])
+                    T_subtract[v_ax0, v_ax1] = T_divide[v_ax0, v_ax1] - T_multiply_1[v_ax0, v_ax1]
 
         @R.function
         def main(x: R.Tensor((2, 3, 4, 5), dtype="float32")) -> R.Tensor((1, 3, 4, 1), dtype="float32"):


### PR DESCRIPTION
Now the legalization method for relax.variance is:
```
var(x) = mean((x - mean(x)) ** 2)
```
This PR changes the legalization method into
```
var(x) = mean(x * x) - mean(x) ** 2
```
for better data locality (which means better performance)