### PR TITLE
[Arith] Fix solve inequality of unbound var ranges

### DIFF
--- a/tests/python/unittest/test_arith_solve_linear_inequality.py
+++ b/tests/python/unittest/test_arith_solve_linear_inequality.py
@@ -196,5 +196,20 @@ def test_no_solution():
     assert not rel
 
 
+def test_unbound_var_range():
+    x = te.var("x0")
+    free_var = te.var("fv")
+    vranges = {x: tvm.ir.Range.from_min_extent(0, tvm.tir.Cast("int32", 1 + tvm.tir.log(free_var)))}
+    problem = [x > 3]
+    solution = arith.solve_linear_inequalities(
+        problem,
+        [x],
+        vranges,
+    )
+    assert len(solution.variables) == 1
+    assert len(solution.ranges) == 0
+    assert len(solution.relations) == 3
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Fix an issue in `FindBestRange` where if `IntSet::max()` if inf, it could not take part in general arithmetic computations.