### PR TITLE
[Unity] Add pass for combining parallel matmul

### DIFF
--- a/include/tvm/relax/dataflow_matcher.h
+++ b/include/tvm/relax/dataflow_matcher.h
@@ -58,6 +58,7 @@ Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(
 TVM_DLL Optional<Map<DFPattern, Var>> MatchGraph(const PatternContext& ctx,
                                                  const DataflowBlock& dfb);
 
+TVM_DLL Function RewriteBindings(const PatternContext& ctx, PackedFunc rewriter, Function f);
 }  // namespace relax
 }  // namespace tvm
 

--- a/include/tvm/relax/dataflow_matcher.h
+++ b/include/tvm/relax/dataflow_matcher.h
@@ -58,6 +58,15 @@ Optional<Map<DFPattern, Expr>> ExtractMatchedExpr(
 TVM_DLL Optional<Map<DFPattern, Var>> MatchGraph(const PatternContext& ctx,
                                                  const DataflowBlock& dfb);
 
+/**
+ * \brief Rewrite a function with the given pattern and the rewriter function.
+ * \param ctx The pattern constraint context under which rewriting takes place.
+ * \param rewriter The function to be called on a successful matching for rewriting.
+    Given the map of patterns and corresponding variables (bound variables or parameters),
+    it should return a map that specifies new values for matched bound variables.
+ * \param f The function to rewrite
+ * \return The rewritten or the input function, depending on the pattern matching result.
+ */
 TVM_DLL Function RewriteBindings(const PatternContext& ctx, PackedFunc rewriter, Function f);
 }  // namespace relax
 }  // namespace tvm

--- a/include/tvm/relax/dataflow_pattern.h
+++ b/include/tvm/relax/dataflow_pattern.h
@@ -248,14 +248,12 @@ class PatternContext : public ObjectRef {
   /*! \brief Get the constraint context object on the top of the stack */
   TVM_DLL static Optional<PatternContext> Current();
 
-  class Internal;
+  /*! \brief The RAII-like entry of a constraint context scope */
+  TVM_DLL void EnterWithScope() const;
+  /*! \brief The RAII-like exit of a constraint context scope */
+  TVM_DLL void ExitWithScope() const;
 
  private:
-  /*! \brief The RAII-like entry of a constraint context scope */
-  TVM_DLL void EnterWithScope();
-  /*! \brief The RAII-like exit of a constraint context scope */
-  TVM_DLL void ExitWithScope();
-  friend class Internal;
   friend class With<PatternContext>;
 };
 

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -935,6 +935,18 @@ def SplitCallTIRByPattern(patterns, fcodegen) -> tvm.ir.transform.Pass:
 
 
 def CombineParallelMatmul():
+    """Combine multiple matmul operators sharing the same LHS matrix into one,
+    followed by slicing. When all matmul branches in a tree have the same set of fused ops,
+    the fused ops are applied to the combined matmul output before slicing.
+
+    Currently, only a limited set of fused ops is supported. It includes bias add,
+    relu, gelu, and silu activation.
+
+    Returns
+    -------
+    ret : tvm.transform.Pass
+        The corresponding pass.
+    """
     return _ffi_api.CombineParallelMatmul()  # type: ignore
 
 

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -934,6 +934,10 @@ def SplitCallTIRByPattern(patterns, fcodegen) -> tvm.ir.transform.Pass:
     return _ffi_api.SplitCallTIRByPattern(patterns, fcodegen)  # type: ignore
 
 
+def CombineParallelMatmul():
+    return _ffi_api.CombineParallelMatmul()  # type: ignore
+
+
 def _wrap_class_function_pass(pass_cls, pass_info):
     """Wrap a python class as function pass."""
 

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -791,7 +791,7 @@ class PatternRewriter : ExprMutator {
       : ctx_(ctx), rewriter_func_(rewriter_func), params_(params) {}
 
   template <typename PatternType>
-  static Expr Run(PatternType pat, PackedFunc rewriter_func, Function f) {
+  static Function Run(PatternType pat, PackedFunc rewriter_func, Function f) {
     std::unordered_set<const VarNode*> params;
     for (const auto& p : f->params) {
       params.insert(p.get());
@@ -909,15 +909,16 @@ class PatternRewriter : ExprMutator {
   std::unordered_map<const Object*, Expr> memo_;
 };
 
+Function RewriteBindings(const PatternContext& ctx, PackedFunc rewriter, Function f) {
+  return PatternRewriter::Run(ctx, rewriter, f);
+}
+
 TVM_REGISTER_GLOBAL("relax.dpl.rewrite_call")
     .set_body_typed([](DFPattern pat, PackedFunc rewriter, Function f) {
       return PatternRewriter::Run(pat, rewriter, f);
     });
 
-TVM_REGISTER_GLOBAL("relax.dpl.rewrite_bindings")
-    .set_body_typed([](const PatternContext& ctx, PackedFunc rewriter, Function f) {
-      return PatternRewriter::Run(ctx, rewriter, f);
-    });
+TVM_REGISTER_GLOBAL("relax.dpl.rewrite_bindings").set_body_typed(RewriteBindings);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -865,6 +865,9 @@ class PatternRewriter : ExprMutator {
     if (auto matches = MatchGraph(ctx_.value(), Downcast<DataflowBlock>(block))) {
       builder_->BeginDataflowBlock();
       Map<Var, Expr> replacements = rewriter_func_(matches.value());
+      if (replacements.empty()) {
+	return block;
+      }
 
       std::unordered_set<const VarNode*> emitted_vars;
 

--- a/src/relax/ir/dataflow_pattern.cc
+++ b/src/relax/ir/dataflow_pattern.cc
@@ -412,9 +412,9 @@ PatternContext::PatternContext(bool incremental) {
   data_ = std::move(n);
 }
 
-void PatternContext::EnterWithScope() { pattern_ctx_stack().push(*this); }
+void PatternContext::EnterWithScope() const { pattern_ctx_stack().push(*this); }
 
-void PatternContext::ExitWithScope() {
+void PatternContext::ExitWithScope() const {
   ICHECK(pattern_ctx_stack().top().same_as(*this));
   pattern_ctx_stack().pop();
 }
@@ -610,15 +610,13 @@ TVM_REGISTER_GLOBAL("relax.dpl.current_context").set_body_typed([] {
   return PatternContext::Current();
 });
 
-class PatternContext::Internal {
- public:
-  static void EnterScope(PatternContext pass_ctx) { pass_ctx.EnterWithScope(); }
-  static void ExitScope(PatternContext pass_ctx) { pass_ctx.ExitWithScope(); }
-};
+TVM_REGISTER_GLOBAL("relax.dpl.enter_context").set_body_typed([](const PatternContext& ctx) {
+  ctx.EnterWithScope();
+});
 
-TVM_REGISTER_GLOBAL("relax.dpl.enter_context").set_body_typed(PatternContext::Internal::EnterScope);
-
-TVM_REGISTER_GLOBAL("relax.dpl.exit_context").set_body_typed(PatternContext::Internal::ExitScope);
+TVM_REGISTER_GLOBAL("relax.dpl.exit_context").set_body_typed([](const PatternContext& ctx) {
+  ctx.ExitWithScope();
+});
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/transform/combine_parallel_matmul.cc
+++ b/src/relax/transform/combine_parallel_matmul.cc
@@ -18,6 +18,7 @@
  */
 #include <tvm/relax/dataflow_matcher.h>
 #include <tvm/relax/dataflow_pattern.h>
+#include <tvm/relax/expr_functor.h>
 #include <tvm/relax/struct_info.h>
 #include <tvm/relax/transform.h>
 
@@ -61,7 +62,8 @@ Function Rewrite(Function f, int num_branches, int slice_axis) {
           weights.push_back(matchings[weight_pat]);
         }
 
-        auto concat_weights = concat(Tuple(weights), Integer(1));  // TODO: axis
+	auto concat_axis = Downcast<TensorStructInfo>(GetStructInfo(weights[0]))->ndim - 1;
+        auto concat_weights = concat(Tuple(weights), Integer(concat_axis));
         auto out_dtype =
             Downcast<TensorStructInfo>(GetStructInfo(matchings[matmul_patterns[0]]))->dtype;
         auto matmul_combined = matmul(inp, concat_weights, out_dtype);

--- a/src/relax/transform/combine_parallel_matmul.cc
+++ b/src/relax/transform/combine_parallel_matmul.cc
@@ -161,11 +161,11 @@ runtime::TypedPackedFunc<Map<Var, Expr>(Map<DFPattern, Var>)> GetRewriter(
       }
 
       if (branch_info.activation) {
-        if (*branch_info.activation == "relu") {
+        if (*branch_info.activation == "relax.nn.relu") {
           matmul_combined = relu(matmul_combined);
-        } else if (*branch_info.activation == "gelu") {
+        } else if (*branch_info.activation == "relax.nn.gelu") {
           matmul_combined = gelu(matmul_combined);
-        } else if (*branch_info.activation == "silu") {
+        } else if (*branch_info.activation == "relax.nn.silu") {
           matmul_combined = silu(matmul_combined);
         } else {
           LOG(FATAL) << "Unsupported activation: " << *branch_info.activation;
@@ -231,7 +231,8 @@ std::vector<BranchInfo> GetBranchInfo(Function f) {
         }
 
         for (size_t i = 0; i < activations.size(); ++i) {
-          if (match.value().count(activation_pat[i])) {
+          if (match.value().count(activation_pat[i]) ||
+              match.value().count(bias_activation_pat[i])) {
             activation = activations[i];
           }
         }

--- a/src/relax/transform/combine_parallel_matmul.cc
+++ b/src/relax/transform/combine_parallel_matmul.cc
@@ -108,7 +108,7 @@ Patterns CreatePatterns(const BranchInfo& branch_info) {
 /*! \brief Create a rewriter for the given parallel matmul branches. */
 runtime::TypedPackedFunc<Map<Var, Expr>(Map<DFPattern, Var>)> GetRewriter(
     const Patterns& patterns, const BranchInfo& branch_info) {
-  auto batch_dims_compatible = [](int rhs_dim, const std::vector<size_t>& indices,
+  auto batch_dims_compatible = [](size_t rhs_dim, const std::vector<size_t>& indices,
                                   const std::vector<Array<PrimExpr>>& rhs_shapes) {
     arith::Analyzer ana;
     for (auto ind : indices) {

--- a/src/relax/transform/combine_parallel_matmul.cc
+++ b/src/relax/transform/combine_parallel_matmul.cc
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <tvm/relax/dataflow_matcher.h>
+#include <tvm/relax/dataflow_pattern.h>
+#include <tvm/relax/struct_info.h>
+#include <tvm/relax/transform.h>
+
+#include <vector>
+
+#include "../op/tensor/index.h"
+#include "../op/tensor/linear_algebra.h"
+#include "../op/tensor/manipulate.h"
+
+namespace tvm {
+namespace relax {
+
+using runtime::Map;
+
+Function CombineParallelMatmul(Function f) {
+  PatternContext ctx;
+  WildcardPattern input_pattern;
+  std::vector<WildcardPattern> weight_patterns;
+  std::vector<CallPattern> matmul_patterns;
+  const int num_branches = 32;
+
+  runtime::TypedPackedFunc<Map<Var, Expr>(Map<DFPattern, Var>)> rewriter =
+      [=](Map<DFPattern, Var> matchings) {
+        auto inp = matchings[input_pattern];
+
+        Array<Expr> weights;
+        for (const auto& weight_pat : weight_patterns) {
+          weights.push_back(matchings[weight_pat]);
+        }
+
+        auto concat_weights = concat(Tuple(weights), Integer(1));
+        auto matmul_combined = matmul(inp, concat_weights, DataType::Float(16));
+
+        Map<Var, Expr> replacements;
+        PrimExpr begin{0};
+        int slice_axis = 2;
+        Array<PrimExpr> strides{1};
+
+        for (size_t i = 0; i < num_branches; ++i) {
+          auto sinfo = GetStructInfo(weights[i]);
+          auto width = Downcast<TensorStructInfo>(sinfo)->GetShape().value()[1];
+          auto bound_var = matchings[matmul_patterns[i]];
+          auto slice =
+              strided_slice(matmul_combined, {slice_axis}, {begin}, {begin + width}, strides);
+          replacements.Set(bound_var, slice);
+          begin += width;
+        }
+
+        return replacements;
+      };
+  return RewriteBindings(ctx, rewriter, f);
+}
+
+namespace transform {
+
+Pass CombineParallelMatmul() {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
+      [=](Function f, IRModule m, PassContext pc) { return relax::CombineParallelMatmul(f); };
+  return CreateFunctionPass(/*pass_function=*/pass_func,            //
+                            /*opt_level=*/0,                        //
+                            /*pass_name=*/"CombineParallelMatmul",  //
+                            /*required=*/{});
+}
+
+}  // namespace transform
+
+}  // namespace relax
+}  // namespace tvm

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -18,7 +18,7 @@
 import pytest
 import tvm.testing
 
-from tvm import relay, relax
+from tvm import relay
 from tvm.relax.dpl import *
 from tvm.relax.analysis import get_var2val
 from tvm import relax as rx, tir
@@ -1177,9 +1177,9 @@ def test_combine_matmul_emit_order():
         # make sure it builds
         mod = tvm.IRModule()
         mod["main"] = rewritten
-        mod = relax.transform.LegalizeOps()(mod)
+        mod = rx.transform.LegalizeOps()(mod)
 
-        relax.build(mod, target="llvm")
+        rx.build(mod, target="llvm")
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_transform_combine_parallel_matmul.py
+++ b/tests/python/relax/test_transform_combine_parallel_matmul.py
@@ -1,0 +1,97 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm.testing
+
+from tvm import relax, tir
+from tvm.script import relax as R, tir as T
+from tvm.relax.transform import CombineParallelMatmul
+from tvm.script.ir_builder import IRBuilder
+from tvm.script.ir_builder import relax as relax_builder
+
+
+def get_parallel_matmul(
+    num_branches,
+    with_bias=False,
+    activation=None,
+):
+    shape = (640, 640)
+    dtype = "float32"
+
+    with IRBuilder() as builder:
+        with relax_builder.function():
+            R.func_name("main")
+            x = R.arg("x", R.Tensor(shape, dtype))
+
+            rhs = []
+            bias = []
+
+            for _ in range(num_branches):
+                rhs.append(R.arg("y", R.Tensor(shape, dtype)))
+
+                if with_bias:
+                    bias.append(R.arg("bias", R.Tensor((shape[1],), dtype)))
+
+            with R.dataflow() as frame:
+                branches = []
+
+                for i, r in enumerate(rhs):
+                    result = R.emit(R.matmul(x, r, out_dtype=dtype))
+                    if with_bias:
+                        result = R.emit(result + bias[i])
+                    if activation is not None:
+                        result = R.emit(activation(result))
+
+                    branches.append(result)
+
+                R.output(R.emit(R.concat(branches, axis=1)))
+
+            R.func_ret_value(frame.output_vars[0])
+
+    func = builder.get()
+    return tvm.IRModule({"main": func})
+
+
+def test_attention_qkv():
+    @tvm.script.ir_module
+    class QKV_proj:
+        @R.function
+        def main(
+            x: R.Tensor((2, 1024, 640), "float32"),
+            w0: R.Tensor((640, 640), "float32"),
+            w1: R.Tensor((640, 640), "float32"),
+            w2: R.Tensor((640, 640), "float32"),
+        ) -> R.Tensor:
+            with R.dataflow():
+                lv0 = R.matmul(x, w0)
+                lv1 = R.matmul(x, w1)
+                lv2 = R.matmul(x, w2)
+                out = (lv0, lv1, lv2)
+                R.output(out)
+            return out
+
+    mod = get_parallel_matmul(3)
+
+    # tvm.ir.assert_structural_equal(mod, QKV_proj)
+    mod = CombineParallelMatmul()(mod)
+
+
+    print(mod)
+
+
+if __name__ == "__main__":
+    # tvm.testing.main()
+    test_attention_qkv()


### PR DESCRIPTION
Building on pattern-based binding rewriting work https://github.com/apache/tvm/pull/14446, I'm adding a new pass for combining parallel matmul sharing the same LHS into one. In contrast to the equivalent Relay pass which is based on dedicated pattern-matching algorithm (completely separate from dataflow pattern matcher), this pass is implemented in terms of the generic binding rewriting infra.

When all matmul branches in a tree have the same set of fused ops, the fused ops are applied to the combined matmul output before slicing. So bias adds are also combined, for example. See the test cases. 

Applied to the SD UNet from web-stable-diffusion, it reduces the number of `R.matmul` from 200 to 100. See below for the IR comparison.

Before combining: https://gist.github.com/masahi/0dab4b8f53115da9c33f4352c9175a87
After: https://gist.github.com/masahi/57ab925a43d2343cbfdb79a31c5b9946

@vinx13 @sunggg @psrivas2 @spectrometerHBH 