### PR TITLE
[Docs] Fix typo in the Vitis AI Integration docs

### DIFF
--- a/docs/how_to/deploy/vitis_ai.rst
+++ b/docs/how_to/deploy/vitis_ai.rst
@@ -180,7 +180,7 @@ the Zynq board will first have to be set up and more information on that can be 
       chmod 600 /swapfile
       mkswap /swapfile
       swapon /swapfile
-      echo "/swapfile swap swap defaults 0 0" > /etc/fstab
+      echo "/swapfile swap swap defaults 0 0" >> /etc/fstab
 
 7. Install hdf5 dependency (will take between 30 min and 1 hour to finish)
 


### PR DESCRIPTION
`/etc/fstab` is overwritten.

cc @zxybazh @masahi @junrushao 