### PR TITLE
[Docker] Support rootless docker when using docker/bash.sh

### DIFF
--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -337,11 +337,17 @@ DOCKER_ENV+=( --env CI_BUILD_HOME="${REPO_MOUNT_POINT}"
               --env CI_IMAGE_NAME="${DOCKER_IMAGE_NAME}"
             )
 
-# Remove the container once it finishes running (--rm) and share the
-# PID namespace (--pid=host).  The process inside does not have pid 1
-# and SIGKILL is propagated to the process inside, allowing jenkins to
-# kill it if needed.
-DOCKER_FLAGS+=( --rm --pid=host)
+# Remove the container once it finishes running (--rm).
+DOCKER_FLAGS+=(--rm)
+
+# Share the PID namespace (--pid=host).  The process inside does not
+# have pid 1 and SIGKILL is propagated to the process inside, allowing
+# jenkins to kill it if needed.  This is only necessary for docker
+# daemons running as root.
+if [ -z "${DOCKER_IS_ROOTLESS}" ]; then
+    DOCKER_FLAGS+=(--pid=host)
+fi
+
 
 # Expose services running in container to the host.
 if $USE_NET_HOST; then
@@ -460,6 +466,16 @@ if [ -f "${REPO_DIR}/.git" ]; then
     fi
 fi
 
+# If the docker daemon is running as root, use the TVM-provided
+# "with_the_same_user" script to update the PID.  When using rootless
+# docker, this step is unnecessary.
+if [ -z "${DOCKER_IS_ROOTLESS}" ]; then
+    COMMAND=(
+        bash --login /docker/with_the_same_user
+        ${COMMAND[@]+"${COMMAND[@]}"}
+    )
+fi
+
 # Print arguments.
 echo "REPO_DIR: ${REPO_DIR}"
 echo "DOCKER CONTAINER NAME: ${DOCKER_IMAGE_NAME}"
@@ -473,7 +489,6 @@ DOCKER_CMD=(${DOCKER_BINARY} run
             ${DOCKER_MOUNT[@]+"${DOCKER_MOUNT[@]}"}
             ${DOCKER_DEVICES[@]+"${DOCKER_DEVICES[@]}"}
             "${DOCKER_IMAGE_NAME}"
-            bash --login /docker/with_the_same_user
             ${COMMAND[@]+"${COMMAND[@]}"}
            )
 

--- a/docker/dev_common.sh
+++ b/docker/dev_common.sh
@@ -27,6 +27,8 @@ INVOCATION_PWD="$(pwd)"
 
 GIT_TOPLEVEL=$(cd $(dirname ${BASH_SOURCE[0]}) && git rev-parse --show-toplevel)
 
+DOCKER_IS_ROOTLESS=$(docker info 2> /dev/null | grep 'Context: \+rootless')
+
 
 function lookup_image_spec() {
     img_spec=$(python3 "${GIT_TOPLEVEL}/ci/jenkins/data.py" "$1")


### PR DESCRIPTION
The `docker/bash.sh` script should omit the `--pid=host` argument and `docker/with_the_same_user` arguments when the host's docker daemon is running in [rootless mode](https://docs.docker.com/engine/security/rootless/).  The `with_the_same_user` script is unnecessary in this mode, as rootless docker daemons already use the privileges of the user.

The `--pid=host` flag is required when running in CI, and while it may be useful when running tests locally, it is only supported for rootless docker in versions docker versions 22.06 or greater ([requires this commit](https://github.com/moby/moby/pull/41893)).