### PR TITLE
[MetaSchedule] Handle cases when no features found by FeatureExtractor

### DIFF
--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -479,7 +479,14 @@ class XGBModel(PyCostModel):
             return float(np.median([float(s) for s in x.run_secs]))
 
         new_features = [_feature(x) for x in self.extractor.extract_from(context, candidates)]
-        new_mean_costs = np.array([_mean_cost(x) for x in results]).astype("float32")
+        new_mean_costs = [_mean_cost(x) for x in results]
+
+        # Filter instances with no features
+        new_mean_costs = [c for i, c in enumerate(new_mean_costs) if len(new_features[i]) != 0]
+        new_features = [f for f in new_features if len(f) != 0]
+        new_mean_costs = np.array(new_mean_costs).astype("float32")
+        if not new_features:
+            return
 
         # Steps 3. Run validation
         if group is not None and self.booster is not None:

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -483,8 +483,8 @@ class XGBModel(PyCostModel):
 
         # Filter instances with no features
         new_mean_costs = [c for i, c in enumerate(new_mean_costs) if len(new_features[i]) != 0]
+        new_mean_costs_np = np.array(new_mean_costs).astype("float32")
         new_features = [f for f in new_features if len(f) != 0]
-        new_mean_costs = np.array(new_mean_costs).astype("float32")
         if not new_features:
             return
 
@@ -496,7 +496,7 @@ class XGBModel(PyCostModel):
                     f"{key}: {score:.6f}"
                     for key, score in self._validate(
                         xs=new_features,
-                        ys=group.min_cost / new_mean_costs,
+                        ys=group.min_cost / new_mean_costs_np,
                     )
                 ),
             )
@@ -506,10 +506,10 @@ class XGBModel(PyCostModel):
             group = FeatureGroup(
                 group_hash=new_group_hash,
                 features=new_features,
-                costs=new_mean_costs,
+                costs=new_mean_costs_np,
             )
         else:
-            group.append(new_features, new_mean_costs)
+            group.append(new_features, new_mean_costs_np)
         self.data[new_group_hash] = group
         self.data_size += len(new_features)
 

--- a/src/meta_schedule/feature_extractor/per_store_feature.cc
+++ b/src/meta_schedule/feature_extractor/per_store_feature.cc
@@ -217,12 +217,16 @@ int64_t GetVarStride(const std::vector<MultiIndex>& multi_indices, const IntVec&
 /*!
  * \brief Converts a 2-dimensional STL vector to a TVM NDArray
  * \param src The source 2-dimensional STL vector
+ * \param second_dim_size The length of the second dimension. When the first dim of src is 0,
+ * second_dim_size must be specified, and in such case the shape of the result NDArray is
+ * (0, second_dim_size).
  * \return The converted TVM NDArray
  */
-runtime::NDArray AsNDArray(const std::vector<std::vector<double>>& src) {
-  ICHECK(!src.empty());
+runtime::NDArray AsNDArray(const std::vector<std::vector<double>>& src,
+                           int second_dim_size = -1) {
   int n = src.size();
-  int m = src[0].size();
+  ICHECK(!src.empty() || second_dim_size != -1);
+  int m = src.empty() ? second_dim_size : src[0].size();
   runtime::NDArray tgt = runtime::NDArray::Empty(
       /*shape=*/{n, m},
       /*dtype=*/DLDataType{kDLFloat, 64, 1},
@@ -1404,7 +1408,7 @@ class PerStoreFeatureNode : public FeatureExtractorNode {
           feature_group6->Export(&feature);
         }
       }
-      results[task_id] = tir::utils::AsNDArray(features);
+      results[task_id] = tir::utils::AsNDArray(features, this->feature_vector_length);
     };
     support::parallel_for_dynamic(0, candidates.size(), tune_context->num_threads, f);
     return results;

--- a/src/meta_schedule/feature_extractor/per_store_feature.cc
+++ b/src/meta_schedule/feature_extractor/per_store_feature.cc
@@ -222,8 +222,7 @@ int64_t GetVarStride(const std::vector<MultiIndex>& multi_indices, const IntVec&
  * (0, second_dim_size).
  * \return The converted TVM NDArray
  */
-runtime::NDArray AsNDArray(const std::vector<std::vector<double>>& src,
-                           int second_dim_size = -1) {
+runtime::NDArray AsNDArray(const std::vector<std::vector<double>>& src, int second_dim_size = -1) {
   int n = src.size();
   ICHECK(!src.empty() || second_dim_size != -1);
   int m = src.empty() ? second_dim_size : src[0].size();


### PR DESCRIPTION
This PR fixes the problem that ops like `topi.full` cannot be correctly tuned.

Currently, metaSchedule system adopts a XGBoost model to predict the running performance of an IRModule based on features extracted from it. 

However, Some operators like `topi.full` has so simple IRModule that no feature can be extracted. `topi.full` contains only one BufferStore node with a FloatImm value, so `PerStoreFeature` extractor cannot find any feature from it. And the XGBModel also cannot handle cases when there is no features.

This PR specifically handles this case in `PerStoreFeatureNode` and `XGBModel`.

Thanks to @junrushao 