### PR TITLE
[ARITH][TensorIR] Improve CompactBufferRegion for symbolic shape

### DIFF
--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -72,7 +72,7 @@ enum class ProofStrength : int {
   /*!
    * \brief Prove using symbolic bound analysis
    */
-  kSymbolicBound = 1
+  kSymbolicBound = 1,
 };
 
 /*!
@@ -668,6 +668,23 @@ class TVM_DLL Analyzer {
    * \note Analyzer will call into sub-analyzers to get the result.
    */
   bool CanProveEqual(const PrimExpr& lhs, const PrimExpr& rhs);
+  /*!
+   * \brief Whether we can prove lhs is smaller than possibly symbolic shape.
+   *
+   * By calling this function, the caller gives an extra hint that shape > 0,
+   * because it appeared in buffer shape.
+   *
+   * This is useful to prove condition such as 32 <= 32 * n where the 32 * n
+   * is known to be a shape. Use this routine to reduce the symbolic comparisons
+   * in buffer compaction.
+   *
+   * The underlying analyzer will use the kSymbolicBound proof.
+   *
+   * \param lhs The input lhs.
+   * \param shape The symbolic shape.
+   * \return Whether we can prove lhs <= shape.
+   */
+  bool CanProveLessEqualThanSymbolicShapeValue(const PrimExpr& lhs, const PrimExpr& shape);
   /*!
    * \brief Whether can we prove condition.
    *

--- a/src/tir/transforms/compact_buffer_region.cc
+++ b/src/tir/transforms/compact_buffer_region.cc
@@ -54,7 +54,14 @@ Region SimplifyAndNarrowBufferRegionFromNDIntSet(
     const arith::IntSet& int_set = nd_int_set[i];
     Range range = int_set.CoverRange(Range(/*begin=*/0, /*end=*/original_shape[i]));
     PrimExpr min = analyzer->Simplify(tvm::max(0, range->min));
-    PrimExpr extent = analyzer->Simplify(tvm::min(original_shape[i], range->extent));
+    PrimExpr extent = range->extent;
+
+    // Apply stronger symbolic proof to help us remove symbolic min here.
+    if (!analyzer->CanProveLessEqualThanSymbolicShapeValue(range->extent, original_shape[i])) {
+      extent = tvm::min(original_shape[i], range->extent);
+    }
+
+    extent = analyzer->Simplify(extent);
 
     // Check the buffer region is not loop dependent, since loop dependent
     // allocation is not supported yet.
@@ -89,6 +96,7 @@ NDIntSet NDIntSetEval(Region region, PrimExpr predicate,
   }
   Optional<Array<arith::IntSet>> eval_res =
       arith::EstimateRegionUpperBound(region, var_dom, predicate, analyzer);
+
   if (eval_res.defined()) {
     return NDIntSet(eval_res.value().begin(), eval_res.value().end());
   }
@@ -203,8 +211,9 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
   }
 
   void VisitStmt_(const BlockNode* op) final {
-    // Step 0. Check there is no init part.
+    // Step 0. Check there is no init part and block is opaque
     ICHECK(!op->init.defined());
+    ICHECK_EQ(op->iter_vars.size(), 0) << "CompactBufferRegion only works on opaque blocks";
     // Step 1. Record and update current read/write region annotations
     std::unordered_map<Buffer, std::vector<BufferRegion>, ObjectPtrHash, ObjectPtrEqual>
         cur_access_annotations;
@@ -281,6 +290,7 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
       // Step 2. Relax the access region
       NDIntSet nd_int_set =
           NDIntSetEval(buffer_region->region, predicate_in_scope, dom_map_, &dom_analyzer_);
+
       // Step 3. Restore the non-relaxed ancestor loops domain
       for (size_t i = 0; i < n_ancestor_loops; ++i) {
         const VarNode* v = ancestor_loops_[i]->loop_var.get();

--- a/tests/python/unittest/test_arith_iter_affine_map.py
+++ b/tests/python/unittest/test_arith_iter_affine_map.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from xml import dom
 import tvm
 import tvm.testing
 from tvm.tir import floormod, floordiv
@@ -1185,7 +1184,7 @@ def test_iter_map_simplify_unit_loop_order():
 
     # Even with simplifcation, it should follow the original order
     assert_iter_map_simplfy(
-        {x + y + (z // 4) * 4 + z % 4: x + y + z},
+        {x + y + (z // 4) * 4 + z % 4: z + x + y},
         var_dom([(x, 1), (y, 1), (z, 32)]),
         simplify_trivial_iterators=False,
     )
@@ -1193,6 +1192,14 @@ def test_iter_map_simplify_unit_loop_order():
     assert_iter_map_simplfy(
         {y + 64 - x % 2 * 64: y + 64 - x % 2 * 64},
         var_dom([(x, 6), (y, 64)]),
+        simplify_trivial_iterators=False,
+    )
+
+    # When we have iterators that have same scale but one of them come
+    # with unit extent, we should prioritize unit extent
+    assert_iter_map_simplfy(
+        {x // 128 + y + z: y + x // 128 + z},
+        var_dom([(x, 128), (y, 128), (z, 1)]),
         simplify_trivial_iterators=False,
     )
 


### PR DESCRIPTION
This PR improves compact buffer region for symbolic shape programs. We introduce a new function CanProveLessEqualThanSymbolicShapeValue which can take the extra information such that rhs is a non-negative shape.

The change is necessary to enable symbolic shape schedules. Test cases are added to cover the case