### PR TITLE
[Array] Add deduction guide for Array(IterType,IterType) constructor

### DIFF
--- a/include/tvm/runtime/container/array.h
+++ b/include/tvm/runtime/container/array.h
@@ -323,10 +323,8 @@ class Array : public ObjectRef {
    * \param last end of iterator
    * \tparam IterType The type of iterator
    */
-  template <typename IterType>
+  template <typename IterType, typename = std::enable_if_t<is_valid_iterator_v<T, IterType>>>
   Array(IterType first, IterType last) {
-    static_assert(is_valid_iterator_v<T, IterType>,
-                  "IterType cannot be inserted into a tvm::Array<T>");
     Assign(first, last);
   }
 

--- a/include/tvm/runtime/container/array.h
+++ b/include/tvm/runtime/container/array.h
@@ -872,6 +872,20 @@ class Array : public ObjectRef {
   }
 };
 
+/* Template deduction guide
+ *
+ * The default deduction guides are insufficient to determine the type
+ * parameter `T` in expressions such as `Array{vec.begin(),
+ * vec.end()}`.  If no type has been explicitly given, this guide
+ * prefers to generate an Array containing the same type as is
+ * produced by the iterator.
+ *
+ * That is, given `std::vector<PrimExpr> vec`, the expression
+ * `Array{vec.begin(), vec.end()}` should be of type `Array<PrimExpr>`.
+ */
+template <typename IterType>
+Array(IterType begin, IterType end) -> Array<std::decay_t<decltype(*begin)>>;
+
 template <typename T>
 inline constexpr bool is_tvm_array = false;
 

--- a/src/meta_schedule/schedule_rule/multi_level_tiling.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling.cc
@@ -27,6 +27,7 @@
 #include "../utils.h"
 
 namespace tvm {
+
 namespace tir {
 
 std::vector<int> GetReadBufferNDims(const StmtSRef& block_sref) {
@@ -246,7 +247,7 @@ std::vector<State> MultiLevelTilingNode::TileLoopNest(State state) const {
     sch->Bind(fused, tile_binds[i]);
     tiles[i] = {fused};
   }
-  state->tiles = Array<Array<LoopRV>>{tiles.begin(), tiles.end()};
+  state->tiles = Array{tiles.begin(), tiles.end()};
   if (this->thread_warp_size_ != -1) {
     int64_t low_inclusive = 1;
     int64_t high_inclusive = this->max_threads_per_block_;

--- a/src/tir/schedule/primitive/loop_transformation.cc
+++ b/src/tir/schedule/primitive/loop_transformation.cc
@@ -1223,7 +1223,7 @@ struct LoopPartitionTraits : public UnpackedInstTraits<LoopPartitionTraits> {
     thread_local ObjectRef loop_rv{nullptr};
     thread_local Array<ObjectRef> factors{nullptr};
     loop_rv = inputs[0];
-    factors = Array<ObjectRef>{inputs.begin() + 1, inputs.end()};
+    factors = Array{inputs.begin() + 1, inputs.end()};
     setter(delta, loop_rv);
     setter(delta + 1, factors);
   }

--- a/src/tir/schedule/trace.cc
+++ b/src/tir/schedule/trace.cc
@@ -448,8 +448,7 @@ void Trace::ApplyJSONToSchedule(ObjectRef json, Schedule sch) {
 
 Trace TraceNode::WithDecision(Instruction inst, ObjectRef decision, bool remove_postproc) const {
   int n_insts = GetNumValidInstructions(this->insts, remove_postproc);
-  Array<Instruction> new_insts =
-      Array<Instruction>{this->insts.begin(), this->insts.begin() + n_insts};
+  auto new_insts = Array{this->insts.begin(), this->insts.begin() + n_insts};
   Map<Instruction, ObjectRef> new_decisions{this->decisions.begin(), this->decisions.end()};
   new_decisions.Set(std::move(inst), std::move(decision));
   return Trace(new_insts, new_decisions);


### PR DESCRIPTION
Previously, the `Array(IterType,IterType)` constructor required the class template parameter `T` to be explicitly provided.  This commit adds a template deduction guide, specifying the intended type `T` as the type produced by de-referencing the iterator, to remove the requirement.

Fixes https://github.com/apache/tvm/issues/14600