### PR TITLE
[Unity] Fix ForceNarrowI32 with pod arguments

### DIFF
--- a/include/tvm/tir/data_type_rewriter.h
+++ b/include/tvm/tir/data_type_rewriter.h
@@ -74,6 +74,7 @@ class DataTypeLegalizer : public StmtExprMutator {
   PrimExpr VisitExpr_(const GENode* op) override;
   PrimExpr VisitExpr_(const CallNode* op) override;
   PrimExpr VisitExpr_(const CastNode* op) override;
+  PrimExpr VisitExpr_(const LetNode* op) override;
 
   using StmtExprMutator::VisitExpr_;
   using StmtExprMutator::VisitStmt_;
@@ -115,6 +116,8 @@ class IndexDataTypeRewriter : public DataTypeLegalizer {
   PrimExpr VisitExpr_(const GTNode* op) override;
   PrimExpr VisitExpr_(const GENode* op) override;
   PrimExpr VisitExpr_(const CallNode* op) override;
+  PrimExpr VisitExpr_(const SelectNode* op) override;
+
   Stmt VisitStmt_(const ForNode* op) override;
 
   Buffer VisitBuffer(const Buffer& buffer);
@@ -146,9 +149,9 @@ class IndexDataTypeNormalizer : public IndexDataTypeRewriter {
   using Parent = IndexDataTypeRewriter;
   using Parent::VisitExpr_;
   using Parent::VisitStmt_;
-  PrimExpr VisitExpr_(const IntImmNode* op) final;
-  PrimExpr VisitExpr_(const VarNode* op) final;
-  PrimExpr VisitExpr_(const CastNode* op) final;
+  PrimExpr VisitExpr_(const IntImmNode* op) override;
+  PrimExpr VisitExpr_(const VarNode* op) override;
+  PrimExpr VisitExpr_(const CastNode* op) override;
 
   DataType target_data_type_ = DataType::Int(64);
 };

--- a/tests/python/relax/test_transform_legalize_ops_search_statistical.py
+++ b/tests/python/relax/test_transform_legalize_ops_search_statistical.py
@@ -16,10 +16,11 @@
 # under the License.
 
 import tvm
-from tvm.relax.transform import LegalizeOps
-from tvm.script import relax as R, tir as T, ir as I
 import tvm.testing
-
+from tvm.relax.transform import LegalizeOps
+from tvm.script import ir as I
+from tvm.script import relax as R
+from tvm.script import tir as T
 
 ##################### Search #####################
 
@@ -48,7 +49,7 @@ def test_where():
                     ax0, ax1, ax2 = T.axis.remap("SSS", [i0, i1, i2])
                     T.reads(rxplaceholder[ax0, ax1, T.int64(0)], rxplaceholder_1[ax1, ax2], rxplaceholder_2[ax1, T.int64(0)])
                     T.writes(T_where[ax0, ax1, ax2])
-                    T_where[ax0, ax1, ax2] = T.Select(0 < T.Cast("int32", rxplaceholder[ax0, ax1, T.int64(0)]), rxplaceholder_1[ax1, ax2], rxplaceholder_2[ax1, T.int64(0)])
+                    T_where[ax0, ax1, ax2] = T.Select(T.int64(0) < T.Cast("int64", rxplaceholder[ax0, ax1, T.int64(0)]), rxplaceholder_1[ax1, ax2], rxplaceholder_2[ax1, T.int64(0)])
     # fmt: on
 
     mod = LegalizeOps()(Where)
@@ -92,7 +93,7 @@ def test_where_symbolic():
                     ax0, ax1, ax2 = T.axis.remap("SSS", [i0, i1, i2])
                     T.reads(rxplaceholder[ax0, ax1, T.int64(0)], rxplaceholder_1[ax1, ax2], rxplaceholder_2[ax1, T.int64(0)])
                     T.writes(T_where[ax0, ax1, ax2])
-                    T_where[ax0, ax1, ax2] = T.Select(0 < T.Cast("int32", rxplaceholder[ax0, ax1, T.int64(0)]), rxplaceholder_1[ax1, ax2], rxplaceholder_2[ax1, T.int64(0)])
+                    T_where[ax0, ax1, ax2] = T.Select(T.int64(0) < T.Cast("int64", rxplaceholder[ax0, ax1, T.int64(0)]), rxplaceholder_1[ax1, ax2], rxplaceholder_2[ax1, T.int64(0)])
     # fmt: on
 
     mod = LegalizeOps()(Where)

--- a/tests/python/relax/test_transform_legalize_ops_unary.py
+++ b/tests/python/relax/test_transform_legalize_ops_unary.py
@@ -866,7 +866,7 @@ def test_sign_int():
                     v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
                     T.reads(rxplaceholder[v_ax0, v_ax1])
                     T.writes(T_sign[v_ax0, v_ax1])
-                    T_sign[v_ax0, v_ax1] = T.Select(0 < rxplaceholder[v_ax0, v_ax1], 1, T.Select(rxplaceholder[v_ax0, v_ax1] < 0, -1, 0))
+                    T_sign[v_ax0, v_ax1] = T.Select(T.int64(0) < T.Cast("int64", rxplaceholder[v_ax0, v_ax1]), 1, T.Select(T.Cast("int64", rxplaceholder[v_ax0, v_ax1]) < T.int64(0), -1, 0))
 
         @R.function
         def main(x: R.Tensor((2, 3), dtype="int32")) -> R.Tensor((2, 3), dtype="int32"):


### PR DESCRIPTION
This PR fixes ForceNarrowI32 for functions that comes with pod arguments.

Test cases are added