### PR TITLE
[Unity][UX] Symbolic Variables Used in Multiple Functions

### DIFF
--- a/python/tvm/relax/ir/instrument.py
+++ b/python/tvm/relax/ir/instrument.py
@@ -34,5 +34,4 @@ class WellFormedInstrument:
 
     def run_after_pass(self, mod, pass_info):
         if pass_info.name not in self.skip_pass_name:
-            mod.show()
             assert relax.analysis.well_formed(mod)

--- a/python/tvm/relax/ir/instrument.py
+++ b/python/tvm/relax/ir/instrument.py
@@ -34,4 +34,5 @@ class WellFormedInstrument:
 
     def run_after_pass(self, mod, pass_info):
         if pass_info.name not in self.skip_pass_name:
+            mod.show()
             assert relax.analysis.well_formed(mod)

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include "transform/utils.h"
+
 #include <tvm/relax/expr_functor.h>
 
 namespace tvm {
@@ -109,43 +111,6 @@ bool IsLeafOrTuple(const Expr& expr) {
          expr.as<OpNode>() || expr.as<TupleNode>();
 }
 
-class StructInfoCopier : public StructInfoMutator {
- public:
-  StructInfo Copy(const StructInfo& old_sinfo) { return this->VisitStructInfo(old_sinfo); }
-
- private:
-  std::unordered_map<tir::Var, tir::Var, ObjectPtrHash, ObjectPtrEqual> symbolic_var_remap_;
-  std::unordered_set<tir::Var, ObjectPtrHash, ObjectPtrEqual> remapped_vars_;
-
-  Expr VisitStructInfoExprField(const Expr& expr) final {
-    if (auto* shape_expr = expr.as<ShapeExprNode>()) {
-      Array<PrimExpr> values = shape_expr->values.Map(
-          [this](const PrimExpr& expr) { return this->VisitStructInfoExprField(expr); });
-      return ShapeExpr(values, expr->span);
-    }
-    return expr;
-  }
-
-  PrimExpr VisitStructInfoExprField(const PrimExpr& expr) final {
-    if (!expr->IsInstance<tir::VarNode>()) {
-      return expr;
-    }
-    auto var = Downcast<tir::Var>(expr);
-    // avoid repeatedly copy
-    if (remapped_vars_.find(var) != remapped_vars_.end()) {
-      return expr;
-    }
-    if (symbolic_var_remap_.find(var) != symbolic_var_remap_.end()) {
-      return symbolic_var_remap_[var];
-    }
-    // copy symbolic var and remap
-    tir::Var new_var(var->name_hint, var->dtype);
-    symbolic_var_remap_.insert({var, new_var});
-    remapped_vars_.insert(new_var);
-    return new_var;
-  }
-};
-
 /*! \brief Helper to implement CopyWithNewVars.*/
 class FunctionCopier : public ExprMutator {
  public:
@@ -155,32 +120,22 @@ class FunctionCopier : public ExprMutator {
     // to satisfy the restriction in the well-formed check: Variables in Relax
     // must be bound exactly once.
     auto new_func = Downcast<Function>(copier.VisitExpr(func));
-    auto new_ret_sinfo = copier.VisitExprDepStructInfoField(func->ret_struct_info);
-    return Function(new_func->params, new_func->body, new_ret_sinfo, new_func->attrs);
+    return SymbolicVarRenewMutator::Renew(new_func);
   }
 
   Var VisitVarDef_(const DataflowVarNode* var) override {
     Var new_var = ExprMutator::VisitVarDef_(var);
-    StructInfo new_sinfo = this->VisitExprDepStructInfoField(GetStructInfo(new_var));
-    Var copied_var = DataflowVar(new_var->name_hint(), new_sinfo, new_var->span);
+    Var copied_var = DataflowVar(new_var->name_hint(), GetStructInfo(new_var), new_var->span);
     var_remap_[var->vid] = copied_var;
     return copied_var;
   }
 
   Var VisitVarDef_(const VarNode* var) override {
     Var new_var = ExprMutator::VisitVarDef_(var);
-    StructInfo new_sinfo = this->VisitExprDepStructInfoField(GetStructInfo(new_var));
-    Var copied_var = Var(new_var->name_hint(), new_sinfo, new_var->span);
+    Var copied_var = Var(new_var->name_hint(), GetStructInfo(new_var), new_var->span);
     var_remap_[var->vid] = copied_var;
     return copied_var;
   }
-
-  StructInfo VisitExprDepStructInfoField(const StructInfo& struct_info) {
-    return sinfo_copier_.Copy(struct_info);
-  }
-
- private:
-  StructInfoCopier sinfo_copier_;
 };
 
 /*!

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -142,6 +142,20 @@ def test_symbolic_var():
     assert not rx.analysis.well_formed(mod, check_struct_info=False)
 
 
+def test_symbolic_var_across_functions():
+    # Error: Symbolic Var s presents across different functions
+    s = tir.Var("s", "int64")
+    v0 = rx.Var("v0", R.Tensor([5, s], "float32"))
+    v1 = rx.Var("v1", R.Tensor([s, 7], "float32"))
+    bb = rx.BlockBuilder()
+    with bb.function("func1", [v0]):
+        bb.emit_func_output(v0)
+    with bb.function("func2", [v1]):
+        bb.emit_func_output(v1)
+    mod = bb.get()
+    assert not rx.analysis.well_formed(mod, check_struct_info=False)
+
+
 def test_symbolic_var_invalid_type():
     with pytest.raises(
         tvm.TVMError, match="the value in ShapeStructInfo can only have dtype of int64"

--- a/tests/python/relax/test_utils.py
+++ b/tests/python/relax/test_utils.py
@@ -36,6 +36,21 @@ def test_copy_with_new_vars():
         assert before_var != after_var
 
 
+def test_copy_with_new_vars_copied_symbolic_vars():
+    @R.function
+    def before(x: R.Tensor(("m",), "float32"), y: R.Tensor(("m",), "float32")):
+        gv = R.add(x, y)
+        return gv
+
+    after = relax.utils.copy_with_new_vars(before)
+    assert_structural_equal(after, before)
+
+    assert len(after.params) == len(before.params)
+    for before_var, after_var in zip(before.params, after.params):
+        assert before_var != after_var
+        assert before_var.struct_info.shape[0] != after_var.struct_info.shape[0]
+
+
 def test_copy_with_new_vars_on_ir_module():
     @tvm.script.ir_module
     class Actual:
@@ -104,4 +119,5 @@ def test_copy_with_new_vars_on_ir_module_nested_function():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    # pytest.main([__file__])
+    test_copy_with_new_vars_copied_symbolic_vars()

--- a/tests/python/relax/test_utils.py
+++ b/tests/python/relax/test_utils.py
@@ -119,5 +119,4 @@ def test_copy_with_new_vars_on_ir_module_nested_function():
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    test_copy_with_new_vars_copied_symbolic_vars()
+    pytest.main([__file__])


### PR DESCRIPTION
Prior to this PR, there is no constraint to prevent user defining multiple functions which may use the same symbolic TIR var. For example, user may write the following script:
```
batch_size = tir.Var("batch_size", "int64")

@I.ir_module
class Test:
    @R.function
    def main(
        x: R.Tensor((batch_size, 10), "float32"),
    ):
        with R.dataflow():
            lv = R.sum(x, axis=1)
            lv1 = R.mean(x, axis=1)
            out = R.add(lv, lv1)
            R.output(out)
        return out

    @R.function
    def main1(
        x: R.Tensor((batch_size, 10), "float32"),
        y: R.Tensor((batch_size, 10), "float32"),
    ):
        with R.dataflow():
            out = R.subtract(x, y)
            R.output(out)
        return out

lowered_mod = LegalizeOps()(Test)

ex = relax.build(lowered_mod, "llvm")
vm = relax.VirtualMachine(ex, tvm.cpu(0))
```
But this script can not be built because `VMShapeLower` can not handle this case well.
Since it is a illegal behaviour, we need to prevent user from doing this. Specifically, this PR contains two parts of work:
- Let well form checker to check this case.
- Let `CopyWithNewVars` util copies the symbolic vars in the struct info inside the function.