### PR TITLE
[Docs] Expand MetaSchedule API Document

### DIFF
--- a/docs/reference/api/python/meta_schedule.rst
+++ b/docs/reference/api/python/meta_schedule.rst
@@ -21,3 +21,96 @@ tvm.meta_schedule
    :members:
    :imported-members:
    :autosummary:
+
+tvm.meta_schedule.arg_info
+---------------------------
+.. automodule:: tvm.meta_schedule.arg_info
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.builder
+-------------------------
+.. automodule:: tvm.meta_schedule.builder
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.runner
+------------------------
+.. automodule:: tvm.meta_schedule.runner
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.database
+--------------------------
+.. automodule:: tvm.meta_schedule.database
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.cost_model
+----------------------------
+.. automodule:: tvm.meta_schedule.cost_model
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.feature_extractor
+-----------------------------------
+.. automodule:: tvm.meta_schedule.feature_extractor
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.measure_callback
+----------------------------------
+.. automodule:: tvm.meta_schedule.measure_callback
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.mutator
+-------------------------
+.. automodule:: tvm.meta_schedule.mutator
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.postproc
+--------------------------
+.. automodule:: tvm.meta_schedule.postproc
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.schedule_rule
+-------------------------------
+.. automodule:: tvm.meta_schedule.schedule_rule
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.search_strategy
+---------------------------------
+.. automodule:: tvm.meta_schedule.search_strategy
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.space_generator
+---------------------------------
+.. automodule:: tvm.meta_schedule.space_generator
+   :members:
+   :imported-members:
+   :autosummary:
+
+tvm.meta_schedule.task_scheduler
+--------------------------------
+.. automodule:: tvm.meta_schedule.task_scheduler
+   :members:
+   :imported-members:
+   :autosummary:
+
+

--- a/docs/reference/api/python/meta_schedule.rst
+++ b/docs/reference/api/python/meta_schedule.rst
@@ -112,5 +112,3 @@ tvm.meta_schedule.task_scheduler
    :members:
    :imported-members:
    :autosummary:
-
-

--- a/python/tvm/meta_schedule/__init__.py
+++ b/python/tvm/meta_schedule/__init__.py
@@ -48,7 +48,7 @@ from .schedule_rule import ScheduleRule
 from .search_strategy import MeasureCandidate, SearchStrategy
 from .space_generator import SpaceGenerator
 from .task_scheduler import TaskScheduler
-from .tir_integration import tune_tir
+from .tir_integration import tune_tir, compile_tir
 from .tune import tune_tasks
 from .tune_context import TuneContext
 from .utils import derived_object

--- a/python/tvm/meta_schedule/database/json_database.py
+++ b/python/tvm/meta_schedule/database/json_database.py
@@ -37,6 +37,7 @@ class JSONDatabase(Database):
     module_equality : Optional[str]
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
+
           - "structural": Use StructuralEqual/Hash
           - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
                               equality testing and hashing.

--- a/python/tvm/meta_schedule/database/memory_database.py
+++ b/python/tvm/meta_schedule/database/memory_database.py
@@ -30,6 +30,7 @@ class MemoryDatabase(Database):
     module_equality : Optional[str]
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
+
           - "structural": Use StructuralEqual/Hash
           - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
                               equality testing and hashing.

--- a/python/tvm/meta_schedule/database/ordered_union_database.py
+++ b/python/tvm/meta_schedule/database/ordered_union_database.py
@@ -96,6 +96,7 @@ class OrderedUnionDatabase(Database):
     )
     # returns the better one between r3 and r4
     merged_db.query_tuning_record(..., target_workload)
+
     """
 
     def __init__(self, *databases: Database) -> None:

--- a/python/tvm/meta_schedule/database/schedule_fn_database.py
+++ b/python/tvm/meta_schedule/database/schedule_fn_database.py
@@ -36,6 +36,7 @@ class ScheduleFnDatabase(Database):
     module_equality : Optional[str]
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
+
           - "structural": Use StructuralEqual/Hash
           - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
                               equality testing and hashing.

--- a/python/tvm/meta_schedule/relay_integration.py
+++ b/python/tvm/meta_schedule/relay_integration.py
@@ -152,6 +152,7 @@ def extract_tasks(
     module_equality : Optional[str]
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
+
           - "structural": Use StructuralEqual/Hash
           - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
                               equality testing and hashing.
@@ -315,6 +316,7 @@ def tune_relay(
     module_equality : Optional[str]
         A string to specify the module equality testing and hashing method.
         It must be one of the followings:
+
           - "structural": Use StructuralEqual/Hash
           - "ignore-ndarray": Same as "structural", but ignore ndarray raw data during
                               equality testing and hashing.


### PR DESCRIPTION
Following up #14480, some of the secondary classes are not compiled into MetaSchedule API documents. This PR fixes this issue by expanding the original indexing file and introduce more documents.

CC: @junrushao 