### PR TITLE
[Unity][AMP] Fix merging concrete type and "unknown" type

### DIFF
--- a/src/relax/transform/infer_amp_utils.cc
+++ b/src/relax/transform/infer_amp_utils.cc
@@ -40,6 +40,11 @@ NType NTypeMerge(const NType& a, const NType& b) {
   auto fcombine = [&](const String& a_str, const String& b_str) -> String {
     DataType a = DataType(String2DLDataType(a_str));
     DataType b = DataType(String2DLDataType(b_str));
+    if (a_str == "") {
+      return b_str;
+    } else if (b_str == "") {
+      return a_str;
+    }
     ICHECK_EQ(a.code(), b.code());
     ICHECK_EQ(a.lanes(), b.lanes());
     return a.bits() > b.bits() ? a_str : b_str;

--- a/src/relax/transform/infer_amp_utils.cc
+++ b/src/relax/transform/infer_amp_utils.cc
@@ -38,13 +38,14 @@ NType NTypeFrom(const Expr& expr, DataType dtype) { return NTypeFrom(GetStructIn
 
 NType NTypeMerge(const NType& a, const NType& b) {
   auto fcombine = [&](const String& a_str, const String& b_str) -> String {
-    DataType a = DataType(String2DLDataType(a_str));
-    DataType b = DataType(String2DLDataType(b_str));
     if (a_str == "") {
       return b_str;
     } else if (b_str == "") {
       return a_str;
     }
+
+    DataType a = DataType(String2DLDataType(a_str));
+    DataType b = DataType(String2DLDataType(b_str));
     ICHECK_EQ(a.code(), b.code());
     ICHECK_EQ(a.lanes(), b.lanes());
     return a.bits() > b.bits() ? a_str : b_str;


### PR DESCRIPTION
In AMP, an abstract type representing "unknown" type has a string representation "". `String2DLDataType` returns `DataType::Void()`  https://github.com/apache/tvm/blob/c452e6966c33047512155f42f63aef4e0586d129/include/tvm/runtime/data_type.h#L351-L352 for such string. 

So when the abstract type is `unknown_`,  `ICHECK_EQ(a.code(), b.code())` in `NTypeMerge` always fails because we try to merge a concrete type such as "float32" with void.

@spectrometerHBH 