### PR TITLE
[Unity][CODEGEN] Fix metal codegen when with only single working dim

### DIFF
--- a/src/target/source/codegen_metal.h
+++ b/src/target/source/codegen_metal.h
@@ -59,6 +59,7 @@ class CodeGenMetal final : public CodeGenC {
 
  private:
   int thread_index_bits_{32};
+  int thread_work_dim_{0};
   Target target_;
 };
 }  // namespace codegen


### PR DESCRIPTION
This PR fixes the metal introduces by a previous commit that removes the workdim remapping that caused issues for kernels with only threadIdx.x and blockIdx.x