### PR TITLE
[Unity] `enable_warning` option for LegalizeOps and MSApplyDatabase

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -195,9 +195,11 @@ TVM_DLL Pass FoldConstant();
  *
  * \param cmap The customized operator legalization function map. The customized function
  * will override the default one.
+ * \param enable_warning A boolean value indicating if to print warnings for TIR functions not
+ * showing up in the database.
  * \return The Pass.
  */
-TVM_DLL Pass LegalizeOps(Optional<Map<String, PackedFunc>> cmap);
+TVM_DLL Pass LegalizeOps(Optional<Map<String, PackedFunc>> cmap, bool enable_warning = false);
 
 /*!
  * \brief Lift transformation of the parameters of a function.

--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -321,6 +321,7 @@ def compile_relax(
     mod: IRModule,
     target: Union[Target, str],
     params: Optional[Dict[str, NDArray]],
+    enable_warning: bool = False,
 ) -> "relax.Executable":
     """Compile a relax program with a MetaSchedule database.
 
@@ -334,6 +335,9 @@ def compile_relax(
         The compilation target
     params : Optional[Dict[str, tvm.runtime.NDArray]]
         The associated parameters of the program
+    enable_warning : bool
+        A boolean value indicating if to print warnings for TIR functions not
+        showing up in the database. By default we don't print warning.
 
     Returns
     -------
@@ -351,6 +355,6 @@ def compile_relax(
         mod = BindParams("main", params)(mod)
 
     with target, database, PassContext(opt_level=3):
-        relax_mod = MetaScheduleApplyDatabase()(mod)
+        relax_mod = MetaScheduleApplyDatabase(enable_warning=enable_warning)(mod)
         relax_ex = relax_build(relax_mod, target=target)
     return relax_ex

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -631,7 +631,9 @@ def LiftTransformParams() -> tvm.ir.transform.Pass:
     return _ffi_api.LiftTransformParams()  # type: ignore
 
 
-def LegalizeOps(customize_legalize_map: Optional[Dict[str, LegalizeFunc]] = None):
+def LegalizeOps(
+    customize_legalize_map: Optional[Dict[str, LegalizeFunc]] = None, enable_warning: bool = False
+):
     """Legalize high-level operator calls in Relax functions to call_tir
     with corresponding low-level TIR PrimFuncs.
 
@@ -655,6 +657,11 @@ def LegalizeOps(customize_legalize_map: Optional[Dict[str, LegalizeFunc]] = None
     customize_legalize_map : Optional[Dict[str, LegalizeFunc]]
         The customized operator legalization function map. The customized function will override
         the default one.
+
+    enable_warning : bool
+        A boolean value indicating if to print warnings for CallNode whose op's
+        legalization function is not registered. By default we don't print
+        warnings.
 
     Returns
     -------
@@ -730,22 +737,29 @@ def LegalizeOps(customize_legalize_map: Optional[Dict[str, LegalizeFunc]] = None
                         T_multiply[v_ax0, v_ax1] = A[v_ax0, v_ax1] * B[v_ax0, v_ax1]
     """
 
-    return _ffi_api.LegalizeOps(customize_legalize_map)  # type: ignore
+    return _ffi_api.LegalizeOps(customize_legalize_map, enable_warning)  # type: ignore
 
 
 def MetaScheduleApplyDatabase(
-    work_dir: Optional[str] = None,
+    work_dir: Optional[str] = None, enable_warning: bool = False
 ) -> tvm.ir.transform.Pass:
     """Apply the best schedule from tuning database.
+
+    Parameters
+    ----------
     work_dir : Optional[str]
        work directory to deduce default database if database is not provided
        (it will be ignored when an user passes database)
+    enable_warning : bool
+        A boolean value indicating if to print warnings for TIR functions not
+        showing up in the database. By default we don't print warning.
+
     Returns
     -------
     ret : tvm.transform.Pass
         The registered pass
     """
-    return _ffi_api.MetaScheduleApplyDatabase(work_dir)  # type: ignore
+    return _ffi_api.MetaScheduleApplyDatabase(work_dir, enable_warning)  # type: ignore
 
 
 def MetaScheduleTuneTIR(

--- a/src/relax/transform/meta_schedule.cc
+++ b/src/relax/transform/meta_schedule.cc
@@ -83,7 +83,7 @@ class MetaScheduleTuner {
   const runtime::PackedFunc* normalize_mod_func_;
 };
 
-Pass MetaScheduleApplyDatabase(Optional<String> work_dir) {
+Pass MetaScheduleApplyDatabase(Optional<String> work_dir, bool enable_warning = false) {
   using tvm::meta_schedule::Database;
   Target target = Target::Current(false);
   const runtime::PackedFunc* normalize_mod_func_ =
@@ -123,7 +123,7 @@ Pass MetaScheduleApplyDatabase(Optional<String> work_dir) {
           new_prim_func = WithAttr(std::move(new_prim_func), tir::attr::kIsScheduled, Bool(true));
           result.Set(gv, new_prim_func);
           continue;
-        } else {
+        } else if (enable_warning) {
           LOG(WARNING) << "Tuning record is not found for primfunc: " << gv->name_hint;
         }
       }


### PR DESCRIPTION
This PR introduces the `enable_warning` argument for the LegalizeOps pass and the MetaScheduleApplyDatabase pass. These two passes now will emit warnings only when the `enable_warning` argument is true.

We introduce this because in our recent practice of [Web LLM](https://github.com/mlc-ai/web-llm), we leverage three passes to generate the GPU code for the TIR functions in a given IRModule. The passes are MetaScheduleDatabaseApply, DispatchTIROperator (one pass that substitutes a TIR func with another handmade one or hand-scheduled one), and DefaultGPUSchedule, in order. (https://github.com/mlc-ai/web-llm/blob/514f6e3132f91a2460f012a74861cd57b43560fb/build.py#L157-L161)

In this case (and most of the cases), we always have the DefaultGPUSchedule pass as a safe guard, and it is common and often that one TIR function does not exist in the MetaSchedule database. For this reason, always printing warning is not ideal and can be too much and annoying for both users and developers.

The same reason applies to LegalizeOps as well. In our practice of WebLLM, we bring in some high-level operator that is not intended to be legalized (of course, it does not have a legalization function). Always printing the warnings is also not expected as well.

According to these experiences, we try to introduce a new argument for configuring the behavior of if emitting warnings or not.