### PR TITLE
Fix bug about wrong attribute name

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -3460,7 +3460,7 @@ class Constant(OnnxOpConverter):
     @classmethod
     def _impl_v9(cls, inputs, attr, params):
         if "value" not in attr:
-            raise tvm.errors.OpAttributeRequired("no value in Constant")
+            raise tvm.error.OpAttributeRequired("no value in Constant")
         value = attr.pop("value")
         # Constants may rarely have string types. These are likely exported
         # from other frameworks and not actually used in TVM. We'll just use


### PR DESCRIPTION
The attribute 'errors' is a wrong name. When code was executed at this line, It will throw an error: message `"AttributeError: module 'tvm' has no attribute 'errors'"`. This PR fix it!