### PR TITLE
[Unity] Improve error message in webgpu request

### DIFF
--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -40,12 +40,46 @@ export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefin
     if (adapter == null) {
       throw Error("Cannot find adapter that matches the request");
     }
+    const computeMB = (value: number) => {
+      return Math.ceil(value  / (1 << 20)) + "MB";
+    }
+
+    // more detailed error message
+    const requiedMaxBufferSize = 1 << 30;
+    if (requiedMaxBufferSize > adapter.limits.maxBufferSize) {
+      throw Error(
+        `Cannot initialize runtime because of requested maxBufferSize ` +
+        `exceeds limit. requested=${computeMB(requiedMaxBufferSize)}, ` +
+        `limit=${computeMB(adapter.limits.maxBufferSize)}. ` +
+        `This error may be caused by an older version of the browser (e.g. Chrome 112). ` +
+        `You can try to upgrade your browser to Chrome 113 or later.`
+      );
+    }
+
+    const requiredMaxStorageBufferBindingSize = 1 << 30;
+    if (requiredMaxStorageBufferBindingSize > adapter.limits.maxStorageBufferBindingSize) {
+      throw Error(
+        `Cannot initialize runtime because of requested maxStorageBufferBindingSize ` +
+        `exceeds limit. requested=${computeMB(requiredMaxStorageBufferBindingSize)}, ` +
+        `limit=${computeMB(adapter.limits.maxStorageBufferBindingSize)}. `
+      );
+    }
+
+    const requiredMaxComputeWorkgroupStorageSize = 32 << 10;
+    if (requiredMaxComputeWorkgroupStorageSize> adapter.limits.maxComputeWorkgroupStorageSize) {
+      throw Error(
+        `Cannot initialize runtime because of requested maxComputeWorkgroupStorageSize ` +
+        `exceeds limit. requested=${requiredMaxComputeWorkgroupStorageSize}, ` +
+        `limit=${adapter.limits.maxComputeWorkgroupStorageSize}. `
+      );
+    }
+
     const adapterInfo = await adapter.requestAdapterInfo();
     const device = await adapter.requestDevice({
       requiredLimits: {
-        maxBufferSize: 1 << 30,
-        maxStorageBufferBindingSize: 1 << 30,
-        maxComputeWorkgroupStorageSize: 32 << 10,
+        maxBufferSize: requiedMaxBufferSize,
+        maxStorageBufferBindingSize: requiredMaxStorageBufferBindingSize,
+        maxComputeWorkgroupStorageSize: requiredMaxComputeWorkgroupStorageSize,
       }
     });
     return {


### PR DESCRIPTION
Sometimes user may get confused with an old version of browser, add more precise error message