### PR TITLE
[Unity][TARGET] Updates vulkan codegen for DeclBuffer

### DIFF
--- a/src/runtime/vulkan/vulkan_device.cc
+++ b/src/runtime/vulkan/vulkan_device.cc
@@ -144,7 +144,11 @@ VulkanDeviceProperties::VulkanDeviceProperties(const VulkanInstance& instance,
   max_num_threads = properties.properties.limits.maxComputeWorkGroupInvocations;
 
   // Even if we can't query it, warp size must be at least 1.
-  thread_warp_size = std::max(subgroup.subgroupSize, 1U);
+  // thread_warp_size = std::max(subgroup.subgroupSize, 1U);
+  // vulkan's subgroup may not directly map to warp and atm
+  // can cause issues in softmax allreduce in NVidia GPU
+  // disable warp setting to be safe.
+  thread_warp_size = 1U;
 
   max_block_size_x = properties.properties.limits.maxComputeWorkGroupSize[0];
   max_block_size_y = properties.properties.limits.maxComputeWorkGroupSize[1];

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -687,6 +687,8 @@ void CodeGenSPIRV::VisitStmt_(const AllocateNode* op) {
   this->VisitStmt(op->body);
 }
 
+void CodeGenSPIRV::VisitStmt_(const DeclBufferNode* op) { this->VisitStmt(op->body); }
+
 void CodeGenSPIRV::VisitStmt_(const AttrStmtNode* op) {
   if (op->attr_key == tir::attr::thread_extent) {
     IterVar iv = Downcast<IterVar>(op->node);

--- a/src/target/spirv/codegen_spirv.h
+++ b/src/target/spirv/codegen_spirv.h
@@ -107,6 +107,7 @@ class CodeGenSPIRV : public ExprFunctor<spirv::Value(const PrimExpr&)>,
   void VisitStmt_(const WhileNode* op) override;
   void VisitStmt_(const IfThenElseNode* op) override;
   void VisitStmt_(const AllocateNode* op) override;
+  void VisitStmt_(const DeclBufferNode* op) override;
   void VisitStmt_(const AttrStmtNode* op) override;
   void VisitStmt_(const AssertStmtNode* op) override;
   void VisitStmt_(const LetStmtNode* op) override;


### PR DESCRIPTION
This PR updates vulkan codegen to support for DeclBuffer. We also disabled subgroup operations.

This is because we find that on Nvidia GPU subgroup were detected to be 8 and the generated code for softmax produces wrong results.

Setting it to be 32(the typical size of CUDA warp) also does not produce the right result.

We directly hard set the value to 1 to be ensure correctness. The team can revisit this behavior later.