### PR TITLE
[MetaSchedule] PostProc not rewriting unroll for purely spatial block

### DIFF
--- a/tests/python/unittest/test_meta_schedule_postproc_rewrite_parallel_vectorize_unroll.py
+++ b/tests/python/unittest/test_meta_schedule_postproc_rewrite_parallel_vectorize_unroll.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=missing-module-docstring,missing-function-docstring,missing-class-docstring
 import tvm
+import tvm.testing
 from tvm.meta_schedule.postproc import RewriteParallelVectorizeUnroll
 from tvm.script import tir as T
 from tvm.tir.schedule import Schedule
@@ -204,7 +205,69 @@ def test_parallel_vectorize_add():
     tvm.ir.assert_structural_equal(sch.mod["main"], after_postproc_add)
 
 
+def test_no_unroll_for_spatial_block():
+    # fmt: off
+    @T.prim_func
+    def layer_norm(A: T.Buffer((1, 4, 4, 32), "float32"), B: T.Buffer((4, 4, 32), "float32"), C: T.Buffer((4, 4, 32), "float32"), T_layer_norm: T.Buffer((1, 4, 4, 32), "float32")):
+        with T.block("root"):
+            T.block_attr({"meta_schedule.unroll_explicit": 512})
+            A_red_temp_v0 = T.alloc_buffer((1,))
+            A_red_temp_v1 = T.alloc_buffer((1,))
+            for ax0, k1, k2, k3 in T.grid(1, 4, 4, 32):
+                with T.block("A_red_temp"):
+                    v_ax0, v_k1, v_k2, v_k3 = T.axis.remap("SRRR", [ax0, k1, k2, k3])
+                    T.reads(A[v_ax0, v_k1, v_k2, v_k3])
+                    T.writes(A_red_temp_v0[v_ax0], A_red_temp_v1[v_ax0])
+                    with T.init():
+                        A_red_temp_v0[v_ax0] = T.float32(0)
+                        A_red_temp_v1[v_ax0] = T.float32(0)
+                    v_A_red_temp_v0: T.float32 = A_red_temp_v0[v_ax0] + A[v_ax0, v_k1, v_k2, v_k3]
+                    v_A_red_temp_v1: T.float32 = A_red_temp_v1[v_ax0] + A[v_ax0, v_k1, v_k2, v_k3] * A[v_ax0, v_k1, v_k2, v_k3]
+                    A_red_temp_v0[v_ax0] = v_A_red_temp_v0
+                    A_red_temp_v1[v_ax0] = v_A_red_temp_v1
+            for ax0, ax1, ax2, ax3 in T.grid(1, 4, 4, 32):
+                with T.block("T_layer_norm"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(A[v_ax0, v_ax1, v_ax2, v_ax3], A_red_temp_v0[v_ax0], A_red_temp_v1[v_ax0], B[v_ax1, v_ax2, v_ax3], C[v_ax1, v_ax2, v_ax3])
+                    T.writes(T_layer_norm[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_layer_norm[v_ax0, v_ax1, v_ax2, v_ax3] = (A[v_ax0, v_ax1, v_ax2, v_ax3] - A_red_temp_v0[v_ax0] * T.float32(0.001953125)) * T.rsqrt(A_red_temp_v1[v_ax0] * T.float32(0.001953125) - A_red_temp_v0[v_ax0] * T.float32(0.001953125) * (A_red_temp_v0[v_ax0] * T.float32(0.001953125)) + T.float32(1.0000000000000001e-05)) * B[v_ax1, v_ax2, v_ax3] + C[v_ax1, v_ax2, v_ax3]
+
+    @T.prim_func
+    def expected(A: T.Buffer((1, 4, 4, 32), "float32"), B: T.Buffer((4, 4, 32), "float32"), C: T.Buffer((4, 4, 32), "float32"), T_layer_norm: T.Buffer((1, 4, 4, 32), "float32")):
+        with T.block("root"):
+            T.reads(A[0, 0:4, 0:4, 0:32], B[0:4, 0:4, 0:32], C[0:4, 0:4, 0:32])
+            T.writes(T_layer_norm[0, 0:4, 0:4, 0:32])
+            A_red_temp_v0 = T.alloc_buffer((1,))
+            A_red_temp_v1 = T.alloc_buffer((1,))
+            for ax0 in T.serial(1, annotations={"pragma_auto_unroll_max_step": 512, "pragma_unroll_explicit": 1}):
+                for k1, k2, k3 in T.grid(4, 4, 32):
+                    with T.block("A_red_temp"):
+                        v_ax0 = T.axis.spatial(1, 0)
+                        v_k1, v_k2, v_k3 = T.axis.remap("RRR", [k1, k2, k3])
+                        T.reads(A[0, v_k1, v_k2, v_k3])
+                        T.writes(A_red_temp_v0[0], A_red_temp_v1[0])
+                        with T.init():
+                            A_red_temp_v0[0] = T.float32(0)
+                            A_red_temp_v1[0] = T.float32(0)
+                        v_A_red_temp_v0: T.float32 = A_red_temp_v0[0] + A[0, v_k1, v_k2, v_k3]
+                        v_A_red_temp_v1: T.float32 = A_red_temp_v1[0] + A[0, v_k1, v_k2, v_k3] * A[0, v_k1, v_k2, v_k3]
+                        A_red_temp_v0[0] = v_A_red_temp_v0
+                        A_red_temp_v1[0] = v_A_red_temp_v1
+            for ax0, ax1, ax2, ax3 in T.grid(1, 4, 4, 32):
+                with T.block("T_layer_norm"):
+                    v_ax0 = T.axis.spatial(1, 0)
+                    v_ax1, v_ax2, v_ax3 = T.axis.remap("SSS", [ax1, ax2, ax3])
+                    T.reads(A[0, v_ax1, v_ax2, v_ax3], A_red_temp_v0[0], A_red_temp_v1[0], B[v_ax1, v_ax2, v_ax3], C[v_ax1, v_ax2, v_ax3])
+                    T.writes(T_layer_norm[0, v_ax1, v_ax2, v_ax3])
+                    T_layer_norm[0, v_ax1, v_ax2, v_ax3] = (A[0, v_ax1, v_ax2, v_ax3] - A_red_temp_v0[0] * T.float32(0.001953125)) * T.rsqrt(A_red_temp_v1[0] * T.float32(0.001953125) - A_red_temp_v0[0] * T.float32(0.001953125) * (A_red_temp_v0[0] * T.float32(0.001953125)) + T.float32(1.0000000000000001e-05)) * B[v_ax1, v_ax2, v_ax3] + C[v_ax1, v_ax2, v_ax3]
+    # fmt: on
+
+    postproc = RewriteParallelVectorizeUnroll()
+    sch = Schedule(layer_norm)
+    assert postproc.apply(sch)
+    mod = tvm.tir.transform.Simplify()(sch.mod)
+    tvm.ir.assert_structural_equal(mod["main"], expected)
+
+
 if __name__ == "__main__":
-    test_meta_schedule_postproc_rewrite_parallel_unroll_vectorize()
-    test_vectorize_inner_loop()
-    test_parallel_vectorize_add()
+    tvm.testing.main()


### PR DESCRIPTION
This PR adds a behavior to the MetaSchedule post-processor RewriteParallelVectorizeUnroll, so that it does not annotate spatial blocks with the unroll annotation.

This is because the optimization for spatial blocks (standalone in a GPU kernel, for example) can be done by purely thread binding. As a result, annotating loop unrolling for spatial blocks does not help. In some case where the unroll factor is very large (e.g., 512 or 1024), unrolling the spatial blocks will consume much time during the kernel compilation and introduces unnecessary overhead.

Therefore, we turn off the behavior of unrolling spatial blocks.