### PR TITLE
[Unity][BYOC] Fuse attention pattern with `strided_slice`

### DIFF
--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -247,11 +247,19 @@ def attention_patterns():
         ),
         (
             "cutlass.stacked_attention",
-            *make_stacked_attention_pattern(),
+            *make_stacked_attention_pattern(start_op="split"),
         ),
         (
             "cutlass.stacked_attention",
-            *make_stacked_attention_pattern(with_bias=True),
+            *make_stacked_attention_pattern(start_op="split", with_bias=True),
+        ),
+        (
+            "cutlass.stacked_attention",
+            *make_stacked_attention_pattern(start_op="strided_slice"),
+        ),
+        (
+            "cutlass.stacked_attention",
+            *make_stacked_attention_pattern(start_op="strided_slice", with_bias=True),
         ),
     ]
 

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -682,7 +682,6 @@ def get_relax_stacked_attention_module(qkv, b, s, n, h, h_v, op, bias=None, qk_s
                     k = R.reshape(qkv_tuple[1], [b, s, n, h])
                     v = R.reshape(qkv_tuple[2], [b, s, n, h_v])
                 elif op == "strided_slice":
-                    qkv_tuple = R.split(qkv, [n * h, n * h * 2], axis=2)
                     q = R.reshape(R.strided_slice(qkv, [2], [0], [n * h], [1]), [b, s, n, h])
                     k = R.reshape(
                         R.strided_slice(qkv, [2], [n * h], [n * h * 2], [1]), [b, s, n, h]


### PR DESCRIPTION
This PR expands the support for fused stacked attention patterns strating with `strided_slice`. Initially, we only support fused stacked attention pattern starting with `split` in #14608. But with the help of #14583, we may have similar patterns starting with `strided_slice` as well.