### PR TITLE
[MetaSchedule] Handle output cases for InlineConstantScalars

### DIFF
--- a/src/meta_schedule/schedule_rule/auto_inline.cc
+++ b/src/meta_schedule/schedule_rule/auto_inline.cc
@@ -209,7 +209,10 @@ class InlineConstantScalarsNode : public ScheduleRuleNode {
     auto block = sch->Get(block_rv);
     if (block->reads.size() == 0 && block->writes.size() == 1 &&
         block->writes[0]->buffer->shape.size() == 0) {
-      sch->ComputeInline(block_rv);
+      auto sref = sch->GetSRef(block_rv);
+      if (!tir::IsOutputBlock(sch->state(), sref, tir::GetScopeRoot(sch->state(), sref, true))) {
+        sch->ComputeInline(block_rv);
+      }
     }
     return {sch};
   }


### PR DESCRIPTION
Now the InlineConstantScalars rule will inline all blocks with no reads and only one scalar output. 

However, if such block is an output block, it should not be inlined. For example, `topi.full((), "float32", 1.0)` contains only one block, which should not be inlined.

This PR fixes this problem by skipping output blocks in the InlineConstantScalars rule.

cc @vinx13 