### PR TITLE
[Runtime] Fix Can't "query_imports" Bug of VM Executable

### DIFF
--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -116,9 +116,8 @@ PackedFunc Executable::GetFunction(const std::string& name, const ObjectPtr<Obje
       Map<String, NDArray> map = args[0];
       LoadLateBoundConstantsFromMap(map);
     });
-  } else {
-    LOG(FATAL) << "Unknown packed function: " << name;
   }
+  return nullptr;
 }
 
 const VMFunction& Executable::GetVMFunctionWithName(const std::string& func_name) const {


### PR DESCRIPTION
This "LOG(FATAL)" will error out when the function isn't found in “executable”, so it will prevent the recursive query the function in the imported modules of "executable".

For example, if the module hierarchy is something like below.
executable
|---LLVMModuleNode
|___NPUModuleNode

This bug will cause we can't get the function in NPUModuleNode by the call "executalbe.get_function("npu_func1", query_imports=True)".

From Arm China.