### PR TITLE
[Unity] Add MultiSpan and attach it to CallNode produced by FuseOps

### DIFF
--- a/include/tvm/ir/source_map.h
+++ b/include/tvm/ir/source_map.h
@@ -114,7 +114,7 @@ class SpanNode : public Object {
   }
 
   static constexpr const char* _type_key = "Span";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SpanNode, Object);
+  TVM_DECLARE_BASE_OBJECT_INFO(SpanNode, Object);
 };
 
 class Span : public ObjectRef {
@@ -125,6 +125,31 @@ class Span : public ObjectRef {
   TVM_DLL Span Merge(const Span& other) const;
 
   TVM_DEFINE_OBJECT_REF_METHODS(Span, ObjectRef, SpanNode);
+};
+
+class MultiSpanNode : public SpanNode {
+ public:
+  Map<Span, ObjectRef> spans;
+
+  // override attr visitor
+  void VisitAttrs(AttrVisitor* v) { v->Visit("spans", &spans); }
+
+  bool SEqualReduce(const MultiSpanNode* other, SEqualReducer equal) const {
+    return equal(spans, other->spans);
+  }
+
+  static constexpr const char* _type_key = "MultiSpan";
+  TVM_DECLARE_FINAL_OBJECT_INFO(MultiSpanNode, SpanNode);
+};
+
+/*!
+ * \brief Attaches multiple disjoint Span to a given IR node.
+ */
+class MultiSpan : public Span {
+ public:
+  TVM_DLL MultiSpan(Map<Span, ObjectRef> spans);
+
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(MultiSpan, Span, MultiSpanNode);
 };
 
 /*! \brief A program source in any language.

--- a/include/tvm/ir/source_map.h
+++ b/include/tvm/ir/source_map.h
@@ -129,7 +129,7 @@ class Span : public ObjectRef {
 
 class MultiSpanNode : public SpanNode {
  public:
-  Map<Span, ObjectRef> spans;
+  Map<String, Span> spans;
 
   // override attr visitor
   void VisitAttrs(AttrVisitor* v) { v->Visit("spans", &spans); }
@@ -147,7 +147,7 @@ class MultiSpanNode : public SpanNode {
  */
 class MultiSpan : public Span {
  public:
-  TVM_DLL MultiSpan(Map<Span, ObjectRef> spans);
+  TVM_DLL MultiSpan(Map<String, Span> spans);
 
   TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(MultiSpan, Span, MultiSpanNode);
 };

--- a/src/ir/source_map.cc
+++ b/src/ir/source_map.cc
@@ -88,6 +88,14 @@ Span Span::Merge(const Span& other) const {
 
 TVM_REGISTER_NODE_TYPE(SpanNode);
 
+MultiSpan::MultiSpan(Map<Span, ObjectRef> spans) {
+  auto n = make_object<MultiSpanNode>();
+  n->spans = spans;
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(MultiSpanNode);
+
 TVM_REGISTER_GLOBAL("ir.Span").set_body_typed([](SourceName source_name, int line, int end_line,
                                                  int column, int end_column) {
   return Span(source_name, line, end_line, column, end_column);

--- a/src/ir/source_map.cc
+++ b/src/ir/source_map.cc
@@ -88,7 +88,7 @@ Span Span::Merge(const Span& other) const {
 
 TVM_REGISTER_NODE_TYPE(SpanNode);
 
-MultiSpan::MultiSpan(Map<Span, ObjectRef> spans) {
+MultiSpan::MultiSpan(Map<String, Span> spans) {
   auto n = make_object<MultiSpanNode>();
   n->spans = spans;
   data_ = std::move(n);

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -490,7 +490,7 @@ class FunctionCreator : public ExprMutator {
    * \brief Build a MultiSpan that contains all Span from fused Call nodes.
    */
   MultiSpan BuildMultiSpanForCallSite() {
-    Map<Span, ObjectRef> spans;
+    Map<String, Span> spans;
     for (Binding binding : bindings_) {
       const auto* var_binding = binding.as<VarBindingNode>();
       if (!var_binding->value->IsInstance<CallNode>()) {
@@ -498,7 +498,9 @@ class FunctionCreator : public ExprMutator {
       }
       Call call = Downcast<Call>(var_binding->value);
       if (call->span.defined()) {
-        spans.Set(call->span, call);
+        std::stringstream ss;
+        ss << call->op << "@" << call.get();
+        spans.Set(String(ss.str()), call->span);
       }
     }
     return MultiSpan(spans);

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -752,7 +752,6 @@ class OperatorFusor : public ExprMutator {
       //  - Otherwise, emit a dataflow variable.
       Var new_var;
       Call call_to_emit = Call(gv, UpdateArgs(func_info.arguments_), {}, {}, new_span);
-      LOG(INFO) << "Created fused call " << call_to_emit << " with span " << new_span;
 
       if (var_binding->var->IsInstance<DataflowVarNode>()) {
         new_var = builder_->Emit(call_to_emit);


### PR DESCRIPTION
I'm sending this PR to solicit feedback on this approach and am open to revisions or upstreaming parts of it into the `main` branch if needed.

This PR makes it possible for Relax pipelines to keep track of which original Relax operators were fused into which PackedFunc. To accomplish this, it introduces a new IR node: MultiSpan, which contains an Array<Span>. , it subclasses Span. Therefore, in a MultiSpan instance, the `Span` fields should be ignored. A more proper way to do this would be to rename Span to e.g. SingleSpan, but this would create so many conflicts that it would need to happen upstream first.

At the moment, this is only implemented in the FuseOps Relax pass. There will be limitations of this approach--for example, a `VarNode` referenced from multiple places in an IRModule will not be able to have distinct Spans. My interest here lies *only* in tracking this information in Relax functions where fusion and other "graph-level" transforms will occur, so I'm not sure I can justify doing something more elaborate such as introducing a new ObjectPath-based IR tracking facility. However, my hope is that the benefits are spelled out enough here to motivate a somewhat inferior approach as a starting point, and we can learn from this and improve as needed.

Please let me know your thoughts.

@junrushao @yelite @tqchen @masahi @jwfromm 