### PR TITLE
[CI] sccache support while using ci.py under multi user environments

### DIFF
--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -187,6 +187,7 @@ def docker(
         env["CC"] = "/opt/sccache/cc"
         env["CXX"] = "/opt/sccache/c++"
         env["SCCACHE_CACHE_SIZE"] = os.getenv("SCCACHE_CACHE_SIZE", "50G")
+        env["SCCACHE_SERVER_PORT"] = os.getenv("SCCACHE_SERVER_PORT", "4226")
 
     docker_bash = REPO_ROOT / "docker" / "bash.sh"
 


### PR DESCRIPTION
sccache fails to start while multiple users in same environment. Now we can export SCCACHE_SERVER_PORT with different port and use.