### PR TITLE
[Unity] Use custom hash in `BlockBuilder` to avoid hashing large constants

### DIFF
--- a/src/meta_schedule/module_equality.cc
+++ b/src/meta_schedule/module_equality.cc
@@ -53,19 +53,6 @@ class SEqualHandlerIgnoreNDArray : public SEqualHandlerDefault {
   }
 };
 
-class SHashHandlerIgnoreNDArray : public SHashHandlerDefault {
- protected:
-  void DispatchSHash(const ObjectRef& object, bool map_free_vars) override {
-    ICHECK(object.defined());
-    if (auto ndarray = object.as<runtime::NDArray::Container>()) {
-      SHashReducer hash_reduce(this, map_free_vars);
-      NDArrayHash(ndarray, &hash_reduce, false);
-    } else {
-      SHashHandlerDefault::DispatchSHash(object, map_free_vars);
-    }
-  }
-};
-
 class ModuleEqualityIgnoreNDArray : public ModuleEquality {
  public:
   size_t Hash(IRModule mod) const { return SHashHandlerIgnoreNDArray().Hash(mod, false); }

--- a/src/node/ndarray_hash_equal.h
+++ b/src/node/ndarray_hash_equal.h
@@ -20,11 +20,19 @@
 #define TVM_NODE_NDARRAY_HASH_EQUAL_H_
 
 #include <tvm/runtime/ndarray.h>
+#include <tvm/node/structural_hash.h>
 
 namespace tvm {
 
 class SEqualReducer;
 class SHashReducer;
+
+/*! \brief A custom hash handler that ignores NDArray raw data. */
+class SHashHandlerIgnoreNDArray : public SHashHandlerDefault {
+ protected:
+  void DispatchSHash(const ObjectRef& object, bool map_free_vars) override;
+};
+
 
 /*!
  * \brief Test two NDArrays for equality.

--- a/src/node/ndarray_hash_equal.h
+++ b/src/node/ndarray_hash_equal.h
@@ -19,8 +19,8 @@
 #ifndef TVM_NODE_NDARRAY_HASH_EQUAL_H_
 #define TVM_NODE_NDARRAY_HASH_EQUAL_H_
 
-#include <tvm/runtime/ndarray.h>
 #include <tvm/node/structural_hash.h>
+#include <tvm/runtime/ndarray.h>
 
 namespace tvm {
 
@@ -32,7 +32,6 @@ class SHashHandlerIgnoreNDArray : public SHashHandlerDefault {
  protected:
   void DispatchSHash(const ObjectRef& object, bool map_free_vars) override;
 };
-
 
 /*!
  * \brief Test two NDArrays for equality.

--- a/src/node/structural_hash.cc
+++ b/src/node/structural_hash.cc
@@ -297,6 +297,16 @@ uint64_t StructuralHash::operator()(const ObjectRef& object) const {
   return SHashHandlerDefault().Hash(object, false);
 }
 
+void SHashHandlerIgnoreNDArray::DispatchSHash(const ObjectRef& object, bool map_free_vars) {
+  ICHECK(object.defined());
+  if (auto ndarray = object.as<runtime::NDArray::Container>()) {
+    SHashReducer hash_reduce(this, map_free_vars);
+    NDArrayHash(ndarray, &hash_reduce, false);
+  } else {
+    SHashHandlerDefault::DispatchSHash(object, map_free_vars);
+  }
+}
+
 // SEQualReduce traits for runtime containers.
 struct StringObjTrait {
   static constexpr const std::nullptr_t VisitAttrs = nullptr;

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -376,6 +376,7 @@ class BlockBuilderImpl : public BlockBuilderNode {
     return name_supply_->FreshName(prefix, /*add_prefix*/ false, /*add_underscore*/ false);
   }
 
+  /*! \brief A custom structural hashing that ignores NDArray raw data. */
   class StructuralHashIgnoreNDarray : public BaseValueHash {
    public:
     using BaseValueHash::operator();
@@ -402,6 +403,7 @@ class BlockBuilderImpl : public BlockBuilderNode {
   /*!
    * \brief A hashmap to store the mapping of Relax functions and TIR PrimFuncs
    * in context_mod to their GlobalVar to avoid generating duplicated functions.
+   * We use a custom hash to avoid hashing constants that may be bound to each BaseFunc.
    */
   std::unique_ptr<
       std::unordered_map<BaseFunc, GlobalVar, StructuralHashIgnoreNDarray, StructuralEqual>>

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -36,6 +36,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "../../node/ndarray_hash_equal.h"
+
 // Block builder have three categories of logics that are interdependent with each other.
 //
 // The logics are somewhat interdependent with each other.
@@ -374,11 +376,35 @@ class BlockBuilderImpl : public BlockBuilderNode {
     return name_supply_->FreshName(prefix, /*add_prefix*/ false, /*add_underscore*/ false);
   }
 
+  class StructuralHashIgnoreNDarray : public BaseValueHash {
+   public:
+    using BaseValueHash::operator();
+
+    uint64_t operator()(const ObjectRef& key) const {
+      return SHashHandlerIgnoreNDArray().Hash(key, false);
+    }
+
+   private:
+    class SHashHandlerIgnoreNDArray : public SHashHandlerDefault {
+     protected:
+      void DispatchSHash(const ObjectRef& object, bool map_free_vars) override {
+        ICHECK(object.defined());
+        if (auto ndarray = object.as<runtime::NDArray::Container>()) {
+          SHashReducer hash_reduce(this, map_free_vars);
+          NDArrayHash(ndarray, &hash_reduce, false);
+        } else {
+          SHashHandlerDefault::DispatchSHash(object, map_free_vars);
+        }
+      }
+    };
+  };
+
   /*!
    * \brief A hashmap to store the mapping of Relax functions and TIR PrimFuncs
    * in context_mod to their GlobalVar to avoid generating duplicated functions.
    */
-  std::unique_ptr<std::unordered_map<BaseFunc, GlobalVar, StructuralHash, StructuralEqual>>
+  std::unique_ptr<
+      std::unordered_map<BaseFunc, GlobalVar, StructuralHashIgnoreNDarray, StructuralEqual>>
       ctx_func_dedup_map_ = nullptr;
 
   /*!
@@ -387,7 +413,7 @@ class BlockBuilderImpl : public BlockBuilderNode {
   void LazyInitCtxFuncDedupMap() {
     if (ctx_func_dedup_map_ != nullptr) return;
     ctx_func_dedup_map_ = std::make_unique<
-        std::unordered_map<BaseFunc, GlobalVar, StructuralHash, StructuralEqual>>();
+        std::unordered_map<BaseFunc, GlobalVar, StructuralHashIgnoreNDarray, StructuralEqual>>();
     for (const auto& kv : context_mod_->functions) {
       const GlobalVar gv = kv.first;
       const BaseFunc func = kv.second;

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -384,20 +384,6 @@ class BlockBuilderImpl : public BlockBuilderNode {
     uint64_t operator()(const ObjectRef& key) const {
       return SHashHandlerIgnoreNDArray().Hash(key, false);
     }
-
-   private:
-    class SHashHandlerIgnoreNDArray : public SHashHandlerDefault {
-     protected:
-      void DispatchSHash(const ObjectRef& object, bool map_free_vars) override {
-        ICHECK(object.defined());
-        if (auto ndarray = object.as<runtime::NDArray::Container>()) {
-          SHashReducer hash_reduce(this, map_free_vars);
-          NDArrayHash(ndarray, &hash_reduce, false);
-        } else {
-          SHashHandlerDefault::DispatchSHash(object, map_free_vars);
-        }
-      }
-    };
   };
 
   /*!


### PR DESCRIPTION
I found that if I use `BindParams` early in my BYOC workflow, some Relax passes become extremely slow. For example, `partition_for_cutlass` takes more than 40 sec on SD UNet if parameters are bound, while otherwise it only takes 1 sec.

This massive regression is due to the `unordered_map` used by `BlockBuilder`, https://github.com/apache/tvm/blob/unity/src/relax/ir/block_builder.cc#L381-L382

This map is keyed on `BaseFunc` and it uses structural equal / hash. So if large parameters are bound on each func, those params are hashed / compared repeatedly. 

This is solved by introducing a custom struct hash that ignores NDArray content.

@tqchen @Hzfengsy @slyubomirsky 