### PR TITLE
[Unity] Reduce cast to fp32 for constant input in AMP

### DIFF
--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -86,6 +86,9 @@ def _check_residual(root_call: Call, context: PatternCheckContext) -> bool:
     if "residual" in context.annotated_expr:
         residual = context.annotated_expr["residual"]
         if not isinstance(residual, Var):
+            if not residual in context.value_to_bound_var:
+                return False
+
             residual = context.value_to_bound_var[residual]
 
         root_var = context.value_to_bound_var[root_call]
@@ -141,7 +144,7 @@ def _check_matmul(context: PatternCheckContext) -> bool:
     if not _is_supported_dtype(lhs_dtype, rhs_dtype):
         return False
 
-    if not _check_residual(lhs, context):
+    if not _check_residual(context.annotated_expr["root"], context):
         return False
 
     lhs_shape = lhs.struct_info.shape.values

--- a/src/relax/op/nn/attention.cc
+++ b/src/relax/op/nn/attention.cc
@@ -108,12 +108,18 @@ StructInfo InferStructInfoAttention(const Call& call, const BlockBuilder& ctx) {
   return TensorStructInfo(ShapeExpr(output_shape), q_sinfo->dtype);
 }
 
+Call InferMixedPrecisionAttention(const Call& call, const DataType& out_dtype) {
+  return Downcast<Call>(attention(call->args[0], call->args[1], call->args[2], NullOpt, NullOpt));
+}
+
 TVM_REGISTER_OP("relax.nn.attention")
     .set_attrs_type<AttentionAttrs>()
     .set_num_inputs(3)
     .add_argument("query", "Tensor", "The input queries tensor.")
     .add_argument("key", "Tensor", "The input keys tensor.")
     .add_argument("value", "Tensor", "The input values tensor.")
+    .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
+    .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionAttention)
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAttention);
 
 TVM_REGISTER_OP("relax.nn.attention_bias")
@@ -123,6 +129,8 @@ TVM_REGISTER_OP("relax.nn.attention_bias")
     .add_argument("key", "Tensor", "The input keys tensor.")
     .add_argument("value", "Tensor", "The input values tensor.")
     .add_argument("bias", "Tensor", "The input bias tensor.")
+    .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
+    .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionAttention)
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAttention);
 
 }  // namespace relax

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -248,7 +248,8 @@ class ConstantFolder : public ExprMutator {
       // Check if we can them to call_tir
       if (legalize_map.count(op)) {
         // Get the legalized expression
-        Expr legalized_expr = builder_->Normalize(legalize_map[op](builder_, post_call));
+        Call post_call_normalized = Downcast<Call>(builder_->Normalize(post_call));
+        Expr legalized_expr = builder_->Normalize(legalize_map[op](builder_, post_call_normalized));
         // If the legalized expression is call_tir, try to fold it.
         const CallNode* call = legalized_expr.as<CallNode>();
         if (call && call->op.same_as(call_tir_op)) {

--- a/tests/python/relax/test_transform_to_mixed_precision.py
+++ b/tests/python/relax/test_transform_to_mixed_precision.py
@@ -30,7 +30,6 @@ def _assert_test(input, expected=None, expected2=None):
 
     if expected2:
         mod = ToMixedPrecision(out_dtype="float16")(input)
-        print(mod.script())
         tvm.ir.assert_structural_equal(mod, expected2)
 
 
@@ -894,6 +893,101 @@ def test_tuple_get():
             return out
 
     _assert_test(Module, expected2=Expected)
+
+
+def test_conv2d_bias_fp32():
+    @tvm.script.ir_module
+    class Input:
+        @R.function
+        def main(
+            x: R.Tensor((1, 4, 64, 64), dtype="float32"),
+            w: R.Tensor((512, 4, 3, 3), dtype="float32"),
+            bias: R.Tensor((512,), dtype="float32"),
+        ) -> R.Tensor((1, 512, 64, 64), dtype="float32"):
+            # block 0
+            with R.dataflow():
+                lv142: R.Tensor((1, 4, 64, 64), dtype="float32") = R.nn.conv2d(
+                    x,
+                    w,
+                    strides=[1, 1],
+                    padding=[0, 0, 0, 0],
+                    out_dtype="float32",
+                )
+                lv143: R.Tensor((1, 4, 1, 1), dtype="float32") = R.reshape(bias, (1, 512, 1, 1))
+                lv144: R.Tensor((1, 4, 64, 64), dtype="float32") = R.add(lv142, lv143)
+                R.output(lv144)
+            return lv144
+
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor((1, 4, 64, 64), dtype="float32"),
+            w: R.Tensor((512, 4, 3, 3), dtype="float32"),
+            bias: R.Tensor((512,), dtype="float32"),
+        ) -> R.Tensor((1, 512, 64, 64), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((1, 4, 64, 64), dtype="float16") = R.astype(x, dtype="float16")
+                lv1: R.Tensor((512, 4, 3, 3), dtype="float16") = R.astype(w, dtype="float16")
+                lv142: R.Tensor((1, 512, 62, 62), dtype="float16") = R.nn.conv2d(
+                    lv,
+                    lv1,
+                    strides=[1, 1],
+                    padding=[0, 0, 0, 0],
+                    out_dtype="float16",
+                )
+                lv2: R.Tensor((512,), dtype="float16") = R.astype(bias, dtype="float16")
+                lv143: R.Tensor((1, 512, 1, 1), dtype="float16") = R.reshape(
+                    lv2, R.shape([1, 512, 1, 1])
+                )
+                lv3: R.Tensor((1, 512, 62, 62), dtype="float16") = R.add(lv142, lv143)
+                lv144: R.Tensor((1, 512, 62, 62), dtype="float32") = R.astype(lv3, dtype="float32")
+                R.output(lv144)
+            return lv144
+
+    @tvm.script.ir_module
+    class Expected_no_bias_cast:
+        @R.function
+        def main(
+            x: R.Tensor((1, 4, 64, 64), dtype="float32"),
+            w: R.Tensor((512, 4, 3, 3), dtype="float32"),
+            bias: R.Tensor((512,), dtype="float32"),
+        ) -> R.Tensor((1, 512, 64, 64), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((1, 4, 64, 64), dtype="float16") = R.astype(x, dtype="float16")
+                lv1: R.Tensor((512, 4, 3, 3), dtype="float16") = R.astype(w, dtype="float16")
+                lv142: R.Tensor((1, 512, 62, 62), dtype="float16") = R.nn.conv2d(
+                    lv,
+                    lv1,
+                    strides=[1, 1],
+                    padding=[0, 0, 0, 0],
+                    out_dtype="float16",
+                )
+                lv143: R.Tensor((1, 512, 1, 1), dtype="float32") = R.reshape(
+                    bias, R.shape([1, 512, 1, 1])
+                )
+                lv2: R.Tensor((1, 512, 62, 62), dtype="float32") = R.astype(lv142, dtype="float32")
+                lv144: R.Tensor((1, 512, 62, 62), dtype="float32") = R.add(lv2, lv143)
+                R.output(lv144)
+            return lv144
+
+    binding_np = {
+        "w": np.random.uniform(size=(512, 4, 3, 3)).astype("float32"),
+        "bias": np.random.uniform(size=(512,)).astype("float32"),
+    }
+    binding = {k: tvm.nd.array(v) for k, v in binding_np.items()}
+
+    Input_bound = relax.transform.BindParams("main", binding)(Input)
+    Expected = relax.transform.BindParams("main", binding)(Expected)
+
+    _assert_test(Input_bound, expected2=Expected)
+
+    binding_np["bias"][0] = 70000  # Out of fp16 range
+    binding = {k: tvm.nd.array(v) for k, v in binding_np.items()}
+    Input_bound = relax.transform.BindParams("main", binding)(Input)
+    Expected_no_bias_cast = relax.transform.BindParams("main", binding)(Expected_no_bias_cast)
+
+    _assert_test(Input_bound, expected2=Expected_no_bias_cast)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently in AMP, the decision to insert a cast to fp32 is overly conservative. In particular, if the bias is fp32, the fp16 activation is cast back to fp32 instead of keeping it to fp16 and casting bias to fp16. So it results in a lot of patterns like below. 

```
lv16: R.Tensor((2, 1280), dtype="float16") = R.matmul(lv1_1, lv2_1, out_dtype="float16")
lv3_1: R.Tensor((2, 1280), dtype="float32") = R.astype(lv16, dtype="float32")
lv17: R.Tensor((2, 1280), dtype="float32") = R.add(lv3_1, unet_time_embedding_linear_1_bias)
```

This PR reduces the number of unnecessary cast to fp32 by checking the range of a constant argument. If it fits within fp16, there is no need to cast it to fp32, and if all args are fp16 or castable to fp16, we can keep activations to fp16.

Also added AMP support for the attention op.

@spectrometerHBH    