### PR TITLE
[CI] Downgrade ci_cpu llvm version back to 11

### DIFF
--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -29,7 +29,7 @@ echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 echo set\(USE_PROFILER ON\) >> config.cmake
 echo set\(USE_DNNL ON\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
-echo set\(USE_LLVM llvm-config\) >> config.cmake
+echo set\(USE_LLVM llvm-config-11\) >> config.cmake
 echo set\(USE_NNPACK ON\) >> config.cmake
 echo set\(NNPACK_PATH /NNPACK/build/\) >> config.cmake
 echo set\(USE_ANTLR ON\) >> config.cmake


### PR DESCRIPTION
The upgrade to llvm 15 caused failures in topi tests python/topi/python/test_topi_math.py::test_cast[float64-float16-llvm]. It seems to be a miscompilation due to opaque pointers. Downgrading while working to fix the issue.