### PR TITLE
unify search path approach to various libs

### DIFF
--- a/cmake/utils/FindCUDA.cmake
+++ b/cmake/utils/FindCUDA.cmake
@@ -76,7 +76,7 @@ macro(find_cuda use_cuda use_cudnn)
     else(MSVC)
       find_library(_CUDA_CUDA_LIBRARY cuda
         PATHS ${CUDA_TOOLKIT_ROOT_DIR}
-        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs
+        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs lib/x86_64-linux-gnu
         NO_DEFAULT_PATH)
       if(_CUDA_CUDA_LIBRARY)
         set(CUDA_CUDA_LIBRARY ${_CUDA_CUDA_LIBRARY})
@@ -86,20 +86,19 @@ macro(find_cuda use_cuda use_cudnn)
         PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs lib/x86_64-linux-gnu
         NO_DEFAULT_PATH)
       find_library(CUDA_CURAND_LIBRARY curand
-        ${CUDA_TOOLKIT_ROOT_DIR}/lib64
-        ${CUDA_TOOLKIT_ROOT_DIR}/lib
+        PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs lib/x86_64-linux-gnu
         NO_DEFAULT_PATH)
       find_library(CUDA_CUBLAS_LIBRARY cublas
-        ${CUDA_TOOLKIT_ROOT_DIR}/lib64
-        ${CUDA_TOOLKIT_ROOT_DIR}/lib
+        PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs lib/x86_64-linux-gnu
         NO_DEFAULT_PATH)
       # search default path if cannot find cublas in non-default
       find_library(CUDA_CUBLAS_LIBRARY cublas)
       find_library(CUDA_CUBLASLT_LIBRARY
         NAMES cublaslt cublasLt
-        PATHS
-        ${CUDA_TOOLKIT_ROOT_DIR}/lib64
-        ${CUDA_TOOLKIT_ROOT_DIR}/lib
+        PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+        PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs lib/x86_64-linux-gnu
         NO_DEFAULT_PATH)
       # search default path if cannot find cublaslt in non-default
       find_library(CUDA_CUBLASLT_LIBRARY NAMES cublaslt cublasLt)
@@ -115,8 +114,8 @@ macro(find_cuda use_cuda use_cudnn)
           ${CUDA_TOOLKIT_ROOT_DIR}/lib/Win32)
       else(MSVC)
         find_library(CUDA_CUDNN_LIBRARY cudnn
-          ${CUDA_TOOLKIT_ROOT_DIR}/lib64
-          ${CUDA_TOOLKIT_ROOT_DIR}/lib
+          PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+          PATH_SUFFIXES lib lib64 targets/x86_64-linux/lib targets/x86_64-linux/lib/stubs lib64/stubs lib/x86_64-linux-gnu
           NO_DEFAULT_PATH)
         # search default path if cannot find cudnn in non-default
         find_library(CUDA_CUDNN_LIBRARY cudnn)


### PR DESCRIPTION
The FindCUDA looks for the various libraries in a more or less limited set of locations.
For nvrtc we currently have the most complete search, the others are lacking one or more locations.
This makes FindCUDA look in all typical linux lib dirs (e.g. Debian's CUDA install wants that).

Thank you for considering.