### PR TITLE
add comment to cuda kernel code about the intended block/grid layout

### DIFF
--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -99,7 +99,10 @@ void CodeGenCUDA::PrintExtraAttrs(const PrimFunc& f) {
     }
     stream << " __launch_bounds__(" << threadIdx_ext_int->value << ")";
   }
-  stream << "\n// intended to be called with\n// dim3 block(" << extractor.threadIdx_x_ext << ", " << extractor.threadIdx_y_ext << ", " << extractor.threadIdx_z_ext << ");\n// dim3 grid(" << extractor.blockIdx_x_ext << ", " << extractor.blockIdx_y_ext << ", " << extractor.blockIdx_z_ext << ");\n";
+  stream << "\n// intended to be called with\n// dim3 block(" << extractor.threadIdx_x_ext << ", "
+         << extractor.threadIdx_y_ext << ", " << extractor.threadIdx_z_ext << ");\n// dim3 grid("
+         << extractor.blockIdx_x_ext << ", " << extractor.blockIdx_y_ext << ", "
+         << extractor.blockIdx_z_ext << ");\n";
 }
 
 std::string CodeGenCUDA::Finish() {

--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -64,6 +64,15 @@ class ThreadIdxExtractor : public tir::StmtVisitor {
       if (iv->var->name_hint == "threadIdx.z" || iv->thread_tag == "threadIdx.z") {
         threadIdx_z_ext = op->value;
       }
+      if (iv->var->name_hint == "blockIdx.x" || iv->thread_tag == "blockIdx.x") {
+        blockIdx_x_ext = op->value;
+      }
+      if (iv->var->name_hint == "blockIdx.y" || iv->thread_tag == "blockIdx.y") {
+        blockIdx_y_ext = op->value;
+      }
+      if (iv->var->name_hint == "blockIdx.z" || iv->thread_tag == "blockIdx.z") {
+        blockIdx_z_ext = op->value;
+      }
     }
     StmtVisitor::VisitStmt_(op);
   }
@@ -72,6 +81,9 @@ class ThreadIdxExtractor : public tir::StmtVisitor {
   PrimExpr threadIdx_x_ext = Integer(1);
   PrimExpr threadIdx_y_ext = Integer(1);
   PrimExpr threadIdx_z_ext = Integer(1);
+  PrimExpr blockIdx_x_ext = Integer(1);
+  PrimExpr blockIdx_y_ext = Integer(1);
+  PrimExpr blockIdx_z_ext = Integer(1);
 };
 
 void CodeGenCUDA::PrintExtraAttrs(const PrimFunc& f) {
@@ -87,6 +99,7 @@ void CodeGenCUDA::PrintExtraAttrs(const PrimFunc& f) {
     }
     stream << " __launch_bounds__(" << threadIdx_ext_int->value << ")";
   }
+  stream << "\n// intended to be called with\n// dim3 block(" << extractor.threadIdx_x_ext << ", " << extractor.threadIdx_y_ext << ", " << extractor.threadIdx_z_ext << ");\n// dim3 grid(" << extractor.blockIdx_x_ext << ", " << extractor.blockIdx_y_ext << ", " << extractor.blockIdx_z_ext << ");\n";
 }
 
 std::string CodeGenCUDA::Finish() {

--- a/tests/python/unittest/test_tir_transform_inject_ptx_async_copy.py
+++ b/tests/python/unittest/test_tir_transform_inject_ptx_async_copy.py
@@ -201,7 +201,11 @@ expected_cuda_script = r"""
   #define int64_t long long
   #define uint64_t unsigned long long
 #endif
-extern "C" __global__ void __launch_bounds__(16) main_kernel0(float* __restrict__ A, float* __restrict__ B, float* __restrict__ C) {
+extern "C" __global__ void __launch_bounds__(16)
+// intended to be called with
+// dim3 block(16, 1, 1);
+// dim3 grid(1, 1, 1);
+ main_kernel0(float* __restrict__ A, float* __restrict__ B, float* __restrict__ C) {
   __shared__ float A_shared[64];
   __shared__ float B_shared[64];
   A_shared[((int)threadIdx.x)] = 0.000000e+00f;


### PR DESCRIPTION
When inspecting the kernel code, it would be neat to also have the information how (which thread layout) it is called.
This PR adds the block/grid layout.