### PR TITLE
[Unity][TensorIR][Schedule] Fix dtype bugs in Rfactor rule

### DIFF
--- a/src/script/ir_builder/tir/ir.cc
+++ b/src/script/ir_builder/tir/ir.cc
@@ -45,7 +45,7 @@ Buffer BufferDecl(Array<PrimExpr> shape, DataType dtype, String buffer_name, Opt
     buffer_data = data.value();
   }
   if (!elem_offset.defined() && offset_factor) {
-    DataType shape_dtype = shape.empty() ? DataType::Int(32) : shape[0]->dtype;
+    DataType shape_dtype = shape.empty() ? tvm::tir::DefaultIndexType() : shape[0]->dtype;
     elem_offset = tvm::tir::Var("elem_offset", shape_dtype);
   }
   return Buffer(buffer_data, dtype, shape, strides.value_or(Array<PrimExpr>()),

--- a/src/script/ir_builder/tir/ir.cc
+++ b/src/script/ir_builder/tir/ir.cc
@@ -45,7 +45,7 @@ Buffer BufferDecl(Array<PrimExpr> shape, DataType dtype, String buffer_name, Opt
     buffer_data = data.value();
   }
   if (!elem_offset.defined() && offset_factor) {
-    DataType shape_dtype = shape.empty() ? tvm::tir::DefaultIndexType() : shape[0]->dtype;
+    DataType shape_dtype = shape.empty() ? DataType::Int(32) : shape[0]->dtype;
     elem_offset = tvm::tir::Var("elem_offset", shape_dtype);
   }
   return Buffer(buffer_data, dtype, shape, strides.value_or(Array<PrimExpr>()),

--- a/src/tir/schedule/primitive/reduction.cc
+++ b/src/tir/schedule/primitive/reduction.cc
@@ -912,7 +912,9 @@ class RFactorBlockCreator : public BaseBlockCreator {
     write_regions_.reserve(old_block->writes.size());
     for (const BufferRegion& write_region : old_block->writes) {
       Array<Range> region = write_region->region;
-      region.insert(region.begin() + factor_axis_, Range::FromMinExtent(additional_iter_->var, 1));
+      region.insert(
+          region.begin() + factor_axis_,
+          Range::FromMinExtent(additional_iter_->var, make_const(additional_iter_->var->dtype, 1)));
       Optional<Buffer> rf_buffer = buffer_map.Get(write_region->buffer);
       ICHECK(rf_buffer.defined());
       write_regions_.push_back(BufferRegion(rf_buffer.value(), Substitute(region, var_map_)));
@@ -1005,7 +1007,7 @@ class WriteBackBlockCreator : public BaseBlockCreator {
       Array<Range> region;
       region.reserve(buf_load->indices.size());
       for (const PrimExpr& index : buf_load->indices) {
-        region.push_back(Range::FromMinExtent(index, 1));
+        region.push_back(Range::FromMinExtent(index, make_const(index->dtype, 1)));
       }
       buf_regions.push_back(BufferRegion(buf_load->buffer, std::move(region)));
     }

--- a/tests/python/unittest/test_tir_schedule_rfactor.py
+++ b/tests/python/unittest/test_tir_schedule_rfactor.py
@@ -1413,7 +1413,7 @@ def test_reduction_rfactor_zero_dim():
     assert s.get(rf_block).same_as(s.get(s.get_block("B_rf")))
     assert s.get(B).same_as(s.get(s.get_block("B")))
     verify_trace_roundtrip(s, mod=rowsum_zero_dim)
-test_reduction_rfactor_zero_dim()
+
 
 def test_reduction_rfactor_outermost_loop_multiple_children_fail():  # pylint: disable=invalid-name
     s = tir.Schedule(multiple_reduction_blocks, debug_mask="all")
@@ -1640,5 +1640,5 @@ def test_reduction_rfactor_topi_argmin():
     verify_trace_roundtrip(s, mod=argmin_topi)
 
 
-# if __name__ == "__main__":
-#     tvm.testing.main()
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/unittest/test_tir_schedule_rfactor.py
+++ b/tests/python/unittest/test_tir_schedule_rfactor.py
@@ -482,12 +482,12 @@ def rowsum_transformed(a: T.handle, b: T.handle) -> None:
 
 @T.prim_func
 def rowsum_zero_dim(a: T.handle, b: T.handle) -> None:
-    A = T.match_buffer(a, [128])
+    A = T.match_buffer(a, [T.int64(128)])
     B = T.match_buffer(b, [])
 
-    for k0 in range(128):
+    for k0 in range(T.int64(128)):
         with T.block("B"):
-            k = T.axis.R(128, k0)
+            k = T.axis.R(T.int64(128), k0)
             with T.init():
                 B[()] = 0.0
             B[()] = B[()] + A[k]
@@ -495,18 +495,18 @@ def rowsum_zero_dim(a: T.handle, b: T.handle) -> None:
 
 @T.prim_func
 def rowsum_zero_dim_rfactor(a: T.handle, b: T.handle) -> None:
-    A = T.match_buffer(a, [128])
+    A = T.match_buffer(a, [T.int64(128)])
     B = T.match_buffer(b, [])
-    B_rf = T.alloc_buffer([128])
+    B_rf = T.alloc_buffer([T.int64(128)])
 
-    for i in range(128):
+    for i in range(T.int64(128)):
         with T.block("B_rf"):
-            vi0 = T.axis.S(128, i)
+            vi0 = T.axis.S(T.int64(128), i)
             B_rf[vi0] = A[vi0]
 
-    for i in range(128):
+    for i in range(T.int64(128)):
         with T.block("B"):
-            vi0_1 = T.axis.R(128, i)
+            vi0_1 = T.axis.R(T.int64(128), i)
             with T.init():
                 B[()] = 0.0
             B[()] = B[()] + B_rf[vi0_1]
@@ -1413,7 +1413,7 @@ def test_reduction_rfactor_zero_dim():
     assert s.get(rf_block).same_as(s.get(s.get_block("B_rf")))
     assert s.get(B).same_as(s.get(s.get_block("B")))
     verify_trace_roundtrip(s, mod=rowsum_zero_dim)
-
+test_reduction_rfactor_zero_dim()
 
 def test_reduction_rfactor_outermost_loop_multiple_children_fail():  # pylint: disable=invalid-name
     s = tir.Schedule(multiple_reduction_blocks, debug_mask="all")
@@ -1640,5 +1640,5 @@ def test_reduction_rfactor_topi_argmin():
     verify_trace_roundtrip(s, mod=argmin_topi)
 
 
-if __name__ == "__main__":
-    tvm.testing.main()
+# if __name__ == "__main__":
+#     tvm.testing.main()


### PR DESCRIPTION
Currently test `test_reduction_rfactor_zero_dim` in file `tests/python/unittest/test_tir_schedule_rfactor.py` fails on unity branch.

The reason is there exists mixture of int32/int64 dtype in this testcase as well as in TIR RFactor schedule rule. 

This PR fixes these problems by unifying dtype to int64 as current unity branch sets  int64 as default dtype.

Besides, this PR adds a `tvm::tir::DefaultIndexType()` interface to determine the correct dtype.

`test_reduction_rfactor_zero_dim` is a regression test so we does not need more unit tests.