### PR TITLE
[Unity][Training] Trainer and SetupTrainer

### DIFF
--- a/python/tvm/relax/training/__init__.py
+++ b/python/tvm/relax/training/__init__.py
@@ -16,8 +16,11 @@
 # under the License.
 """The Relax training APIs."""
 
-from . import optimizer
-from . import utils
 from . import loss
+from . import optimizer
+from . import trainer
+from . import utils
 
+from .setup_trainer import SetupTrainer
+from .trainer import Trainer
 from .utils import AppendLoss

--- a/python/tvm/relax/training/setup_trainer.py
+++ b/python/tvm/relax/training/setup_trainer.py
@@ -1,0 +1,214 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=not-callable, unused-argument
+"""Setup Trainer Pass."""
+from typing import List
+
+import tvm
+from tvm import TVMError
+from tvm.ir.module import IRModule
+from tvm.tir.expr import IntImm
+
+from ..analysis import well_formed
+from ..expr import Tuple
+from ..struct_info import TensorStructInfo
+from ..training.utils import AppendLoss
+from ..transform import LegalizeOps, Gradient, DecomposeOpsForInference, DecomposeOpsForTraining
+from .loss import Loss
+from .optimizer import Optimizer
+
+
+@tvm.transform.module_pass(opt_level=0, name="SetupTrainer")
+class SetupTrainer:
+    """Transform a backbone module to a complete, legalized trainer module.
+
+    The provided backbone module should contain at least a function named `backbone`, and has two
+    int attributes `param_num` and `state_num`, as follows:
+
+    .. code-block:: python
+        @I.ir_module
+        class Backbone:
+            I.module_attrs({"param_num": 1, "state_num": 1})
+            @R.function
+            def backbone(input_instances, parameters, states):
+                # Predicts the result
+                # Should contain only one DataflowBlock
+                ...
+                return backbone_result, updated_states
+
+    Here each of input_instances, parameters, states, backbone_result and updated_states can
+    denote a number of parameters. The length of parameters and the length of states is specified
+    by param_num and state_num respectively.
+
+    `states` denote the states that we need to maintain as the training process proceeds, such as
+    the running mean and the running var of the batch norm operator. The updated states is returned
+    in `updated_states`. States can be empty if there is no state that needs to be updated.
+
+    The transformed module will at least contain the functions and attributes listed below:
+
+    .. code-block:: python
+        @I.ir_module
+        class Module:
+            I.module_attrs({"input_num": 1, "param_num": 1, "state_num": 1, "optim_states": ...})
+
+            @R.function
+            def backbone(input_instances, parameters, states):
+                # Predicts the result. It is provided in the input module.
+                ...
+                return backbone_result, updated_states
+
+            @R.function
+            def backbone_loss(input_instances, parameters, states, targets):
+                # Runs like backbone and then computes the loss between the result and targets.
+                ...
+                return loss, updated_states
+
+            @R.function
+            def backbone_loss_adjoint(input_instances, parameters, states, targets):
+                # Runs like backbone_loss and then calculates the gradient of parameters.
+                ...
+                return (loss, updated_states), gradient_of_params
+
+            @R.function
+            def optimizer(params, gradients, optim_states):
+                # Update parameters and optimizer states with the gradient computed
+                ...
+                return (updated_params, updated_optim_states)
+
+    The transformed module contains an attribute `optim_states` as the initial optimizer states.
+
+    Then the transformed module will be legalized by `relax.transform.LegalizeOps()` to lower
+    relax operators into TIR functions.
+
+    Parameters
+    ----------
+    loss : Loss
+        The loss function. It will be appended to the backbone function using
+        relax.transform.AppendLoss.
+
+    optimizer : Optimizer
+        The optimizer. It will be put as the `optimizer` function of the transformed module.
+
+    loss_args : List[TensorStructInfo]
+        The arguments to call the loss function.
+
+    legalize : bool
+        Whether to legalize the module. Default: True.
+    """
+
+    BACKBONE_FUNC: str = "backbone"
+    BACKBONE_LOSS_FUNC: str = "backbone_loss"
+    ADJOINT_FUNC: str = "backbone_loss_adjoint"
+    OPTIMIZER_FUNC: str = "optimizer"
+
+    PARAM_NUM_ATTR_KEY: str = "param_num"
+    STATE_NUM_ATTR_KEY: str = "state_num"
+
+    def __init__(
+        self, loss: Loss, optimizer: Optimizer, loss_args: List[TensorStructInfo], legalize=True
+    ):
+        self._loss = loss
+        self._optimizer = optimizer
+        self._loss_args = loss_args
+        self._legalize = legalize
+
+    def _check_well_formed(self, mod: IRModule):
+        if not well_formed(mod):
+            raise ValueError("SetupTrainer: The backbone module is not well formed.")
+        try:
+            func = mod[self.BACKBONE_FUNC]
+        except TVMError as exc:
+            raise ValueError(
+                f"SetupTrainer: The backbone module does not contain a function named "
+                f"{self.BACKBONE_FUNC}"
+            ) from exc
+
+        # Check function attrs
+        if (
+            mod.attrs is None
+            or not self.PARAM_NUM_ATTR_KEY in mod.attrs
+            or not isinstance(mod.attrs[self.PARAM_NUM_ATTR_KEY], IntImm)
+        ):
+            raise ValueError(
+                f"SetupTrainer: The backbone module should has an integer attribute named "
+                f"{self.PARAM_NUM_ATTR_KEY}"
+            )
+        if (
+            mod.attrs is None
+            or not self.STATE_NUM_ATTR_KEY in mod.attrs
+            or not isinstance(mod.attrs[self.STATE_NUM_ATTR_KEY], IntImm)
+        ):
+            raise ValueError(
+                f"SetupTrainer: The backbone module should has an integer attribute named "
+                f"{self.STATE_NUM_ATTR_KEY}"
+            )
+
+        nparam = int(mod.attrs[self.PARAM_NUM_ATTR_KEY])
+        nstate = int(mod.attrs[self.STATE_NUM_ATTR_KEY])
+
+        # Check parameters and return values
+        if len(func.params) < nparam + nstate:
+            raise ValueError(
+                "SetupTrainer: The number of parameters of the predict function should be no less "
+                "than the number of parameters and states"
+            )
+
+        if nstate > 0:
+            if not isinstance(func.body.body, Tuple) or len(func.body.body) <= nstate:
+                raise ValueError(
+                    "SetupTrainer: When model state exists, the predict function should return a "
+                    "tuple of length more than the number of states"
+                )
+
+    def transform_module(self, mod: IRModule, ctx: tvm.transform.PassContext) -> IRModule:
+        """Transform the backbone module into a trainer module."""
+        self._check_well_formed(mod)
+
+        mod = AppendLoss(
+            self.BACKBONE_FUNC,
+            self._loss(*self._loss_args),  # type: ignore
+            self._loss.num_backbone_outputs,
+            self.BACKBONE_LOSS_FUNC,
+        )(mod)
+
+        # Decompose batch_norm operator, which behaves differently in inference and training stages
+        mod = DecomposeOpsForInference(self.BACKBONE_FUNC)(mod)
+        mod = DecomposeOpsForTraining(self.BACKBONE_LOSS_FUNC)(mod)
+
+        # Gradient pass.
+        param_num = int(mod.attrs[self.PARAM_NUM_ATTR_KEY])
+        state_num = int(mod.attrs[self.STATE_NUM_ATTR_KEY])
+        input_num = len(mod[self.BACKBONE_FUNC].params) - param_num - state_num
+        params = mod[self.BACKBONE_LOSS_FUNC].params[input_num : input_num + param_num]
+        mod = Gradient(self.BACKBONE_LOSS_FUNC, require_grads=params, target_index=0)(mod)
+
+        # Add optimizer function.
+        self._optimizer.init(params)
+        mod[self.OPTIMIZER_FUNC] = self._optimizer.get_function()
+
+        # Module attrs
+        mod = mod.with_attrs(
+            {
+                "input_num": input_num,
+                "optim_state": self._optimizer.state,
+            }
+        )
+
+        if self._legalize:
+            mod = LegalizeOps()(mod)
+
+        return mod

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -1,0 +1,393 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Unified Trainer API for relax training."""
+from typing import Union, List, Optional, Dict
+import numpy as np  # type: ignore
+
+import tvm
+from tvm import relax, TVMError
+from tvm.ir.module import IRModule
+from tvm.runtime.ndarray import NDArray
+
+
+class Trainer:
+    r"""Unified wrapper for relax training. It accepts the IRModule (that is the result of
+    SetupTrainer) and the relax VM (that contains the built result of the IRModule), and helps run
+    the VM. It maintains the parameters, the model states and the optimizer states internally.
+
+    Parameters
+    ----------
+    train_mod : tvm.IRModule
+        The IRModule that will be run. Should be the result of a backbone module being transformed
+        by the SetupTrainer pass.
+
+    vm : tvm.relax.VirtualMachine
+        The relax virtual machine that contains the built result of train_mod. Considering the
+        complexity and flexibility of building, we require user build the train_mod outside of
+        trainer and pass the result vm.
+
+    device : tvm.runtime.Device
+        The device to place the parameters and states in.
+
+    zero_init_param_state : bool
+        If true, all parameters and states will be inited to zero. It requires all parameters and
+        states have static shape.
+
+    Examples
+    --------
+    .. code-block:: python
+        setup_trainer = SetupTrainer(
+            MSELoss(reduction="sum"),
+            SGD(0.001),
+            [pred_sinfo, target_sinfo],
+        )
+        train_mod = setup_trainer(Backbone)
+        ex = relax.build(train_mod, target)
+        vm = relax.VirtualMachine(ex, dev)
+
+        trainer = training.Trainer(train_mod, vm, dev, False)
+
+        trainer.xaiver_uniform_init_params()
+        trainer.predict(input_instances)
+        trainer.update([input_instances], [labels])
+        trainer.profile_adjoint([input_instances], [labels])
+    """
+
+    BACKBONE_FUNC: str = "backbone"
+    BACKBONE_LOSS_FUNC: str = "backbone_loss"
+    ADJOINT_FUNC: str = "backbone_loss_adjoint"
+    OPTIMIZER_FUNC: str = "optimizer"
+
+    def __init__(
+        self,
+        train_mod: IRModule,
+        vm: relax.VirtualMachine,
+        device: tvm.runtime.Device,
+        zero_init_param_state: bool = True,
+    ) -> None:
+        self.mod = train_mod.without_attr("optim_state")
+        self.vm = vm
+        self.device = device
+
+        self._optim_state = [d.copyto(device) for d in train_mod.attrs["optim_state"]]
+
+        self._input_num = int(train_mod.attrs["input_num"])
+        self._param_num = int(train_mod.attrs["param_num"])
+        self._state_num = int(train_mod.attrs["state_num"])
+
+        # are used to initialize params and states
+        self._param_vars = train_mod[self.ADJOINT_FUNC].params[
+            self._input_num : self._input_num + self._param_num
+        ]
+        self._state_vars = train_mod[self.ADJOINT_FUNC].params[
+            (self._input_num + self._param_num) : (
+                self._input_num + self._param_num + self._state_num
+            )
+        ]
+
+        self._params: List[Optional[NDArray]] = [None] * self._param_num
+        self._param_name_to_pos: Dict[str, int] = {
+            p.name_hint: i for i, p in enumerate(self._param_vars)
+        }
+
+        self._states: List[Optional[NDArray]] = [None] * self._state_num
+        self._state_name_to_pos: Dict[str, int] = {
+            s.name_hint: i for i, s in enumerate(self._state_vars)
+        }
+
+        if zero_init_param_state:
+            self.zero_init_params()
+            self.zero_init_states()
+
+    @staticmethod
+    def _get_shape_list(expr):
+        return [int(dim) for dim in expr.struct_info.shape]
+
+    def xaiver_uniform_init_params(self):
+        """Xaiver uniformly initialize parameters using the method described in `Understanding the
+        difficulty of training deep feedforward neural networks` - Glorot, X. & Bengio, Y.
+        (2010).
+
+        Requires all parameters have static shapes.
+        """
+        self._params = []
+        for p in self._param_vars:
+            shape, dtype = self._get_shape_list(p), p.struct_info.dtype
+            self._params.append(
+                tvm.nd.array(
+                    (np.sqrt(6.0 / np.sum(shape)) * np.random.uniform(-1.0, 1.0, shape)).astype(
+                        dtype
+                    ),
+                    self.device,
+                )
+            )
+
+    def zero_init_params(self):
+        """Zero initialize all parameters. Requires all parameters have static shapes."""
+        self._params = [
+            tvm.nd.array(np.zeros(self._get_shape_list(p), p.struct_info.dtype), self.device)
+            for p in self._param_vars
+        ]
+
+    def zero_init_states(self):
+        """Zero initialize all states. Requires all states have static shapes."""
+        self._states = [
+            tvm.nd.array(np.zeros(self._get_shape_list(s), s.struct_info.dtype), self.device)
+            for s in self._state_vars
+        ]
+
+    def load_params(
+        self,
+        params: Union[List[Union[np.ndarray, NDArray]], Dict[str, Union[np.ndarray, NDArray]]],
+    ):
+        """Load parameters from a dict or a list. Will convert parameters into tvm.runtime.NDArray
+        in self.device.
+
+        Parameters
+        ----------
+        params : List[Union[np.ndarray, NDArray]], Dict[str, Union[np.ndarray, NDArray]]
+            The numerical value of the parameters.
+
+            If params is a list, its length should be param_num. The value of parameters at the
+            corresponding index will be updated.
+
+            If params is a dict, it should map variable name to value. The name should be the same
+            as the parameter name in the backbone function. The values of the corresponding
+            parameters will be updated.
+        """
+        if isinstance(params, list):
+            if len(params) != self._param_num:
+                raise ValueError(
+                    f"The length of extern parameters is {len(params)}, which does not "
+                    f"match the number of parameters {self._param_num}"
+                )
+            self._params = [tvm.nd.array(v, self.device) for v in params]
+        elif isinstance(params, dict):
+            for key, val in params.items():
+                if key not in self._param_name_to_pos:
+                    raise ValueError(f"Parameter {key} is not found in the model")
+                self._params[self._param_name_to_pos[key]] = tvm.nd.array(val, self.device)
+        else:
+            raise ValueError(f"The type of extern_params should be either list or dict")
+
+    def load_states(
+        self,
+        states: Union[List[Union[np.ndarray, NDArray]], Dict[str, Union[np.ndarray, NDArray]]],
+    ):
+        """Load model states from a dict or a list. Will convert states into tvm.runtime.NDArray
+        in self.device.
+
+        Parameters
+        ----------
+        states : List[Union[np.ndarray, NDArray]], Dict[str, Union[np.ndarray, NDArray]]
+            The numerical value of the model states.
+
+            If states is a list, its length should be state_num. The value of states at the
+            corresponding index will be updated.
+
+            If params is a dict, it should map variable name to value. The name should be the same
+            as the state name in the backbone function. The values of the corresponding states will
+            be updated.
+        """
+        if isinstance(states, list):
+            if len(states) != self._state_num:
+                raise ValueError(
+                    f"The length of extern states is {len(states)}, which does not match "
+                    f"the number of model states {self._state_num}"
+                )
+            self._states = [tvm.nd.array(v, self.device) for v in states]
+        elif isinstance(states, dict):
+            for key, val in states.items():
+                if key not in self._param_name_to_pos:
+                    raise ValueError(f"Parameter {key} is not found in the model")
+                self._states[self._param_name_to_pos[key]] = tvm.nd.array(val, self.device)
+        else:
+            raise ValueError(f"The type of extern_states should be either list or dict")
+
+    def export_params(self) -> Dict[str, NDArray]:
+        """Export parameters to a dict (parameter name -> NDArray).
+
+        Returns
+        -------
+        exported_dict : Dict[str, NDArray]
+            The exported dictionary of parameters.
+        """
+        return {key: self._params[pos] for key, pos in self._param_name_to_pos.items()}
+
+    def export_states(self) -> Dict[str, NDArray]:
+        """Export model states to a dict (parameter name -> NDArray).
+
+        Returns
+        -------
+        exported_dict : Dict[str, NDArray]
+            The exported dictionary of model states.
+        """
+        return {key: self._states[pos] for key, pos in self._state_name_to_pos.items()}
+
+    def _check_inited(self):
+        """Check that all parameters and model states are initialized."""
+        idx_not_inited_param = next((i for i, p in enumerate(self._params) if p is None), -1)
+        if idx_not_inited_param != -1:
+            raise TVMError(
+                f"The {idx_not_inited_param}-th parameter is not initialized before training or "
+                "inference."
+            )
+
+        idx_not_inited_state = next((i for i, s in enumerate(self._states) if s is None), -1)
+        if idx_not_inited_state != -1:
+            raise TVMError(
+                f"The {idx_not_inited_state}-th model state is not initialized before training or "
+                "inference."
+            )
+
+    def predict(self, *input_instances: Union[np.ndarray, NDArray]) -> NDArray:
+        """Call the `backbone` function and return the prediction result of the backbone.
+
+        Parameters
+        ----------
+        *input_instances : Union[np.ndarray, NDArray]
+            The values corresponding to the input_instances part of the backbone function.
+            Parameters and model states are not needed to provide.
+
+        Returns
+        -------
+        output : NDArray
+            The result of the backbone function. If the backbone contains model states, the updated
+            states WILL NOT be returned.
+        """
+        self._check_inited()
+        if len(input_instances) != self._input_num:
+            raise ValueError("The length of the input does not match the backbone")
+        all_inputs: List[NDArray] = (
+            [tvm.nd.array(i, self.device) for i in input_instances] + self._params + self._states
+        )
+        res = self.vm[self.BACKBONE_FUNC](*all_inputs)
+
+        # remove the states part, if they exist
+        if self._state_num != 0:
+            res = res[: -self._state_num]
+            if len(res) == 1:
+                res = res[0]
+        return res
+
+    def update(
+        self,
+        input_instances: Union[np.ndarray, NDArray, List[Union[np.ndarray, NDArray]]],
+        targets: Union[np.ndarray, NDArray, List[Union[np.ndarray, NDArray]]],
+    ) -> NDArray:
+        """Update parameters and model states. It will calculate the gradients of parameters
+        and update them using the `optimizer` function.
+
+        Parameters, model states and optimizer states are provided in the function, so you do not
+        need to provied them.
+
+        Parameters
+        ----------
+        input_instances : Union[np.ndarray, NDArray, List[Union[np.ndarray, NDArray]]]
+            The values corresponding to the input_instances part of the backbone function.
+            Parameters and model states are not needed to provide.
+
+            If there are more than one input instances, you can provide a list.
+
+        targets : Union[np.ndarray, NDArray, List[Union[np.ndarray, NDArray]]]
+            The values corresponding to the targets part of the backbone function.
+
+            If there are more than one targets, you can provide a list.
+
+        Returns
+        -------
+        loss : NDArray
+            The loss stored in tvm.runtime.NDArray.
+        """
+        self._check_inited()
+
+        if not isinstance(input_instances, list):
+            input_instances = [input_instances]
+
+        if not isinstance(targets, list):
+            targets = [targets]
+
+        if len(input_instances) != self._input_num:
+            raise ValueError("The length of the input does not match the backbone")
+
+        all_inputs: List[NDArray] = (
+            [tvm.nd.array(i, self.device) for i in input_instances]
+            + self._params
+            + self._states
+            + [tvm.nd.array(i, self.device) for i in targets]
+        )
+        ret, grads = self.vm[self.ADJOINT_FUNC](*all_inputs)
+
+        # update model states
+        if self._state_num != 0:
+            self._states = list(ret[1:])
+            ret = ret[0]
+
+        # update params
+        new_params, self._optim_state = self.vm[self.OPTIMIZER_FUNC](
+            self._params, grads, self._optim_state
+        )
+        self._params = list(new_params)
+
+        return ret
+
+    def profile_adjoint(
+        self,
+        input_instances: List[Union[np.ndarray, NDArray]],
+        targets: List[Union[np.ndarray, NDArray]],
+    ) -> tvm.runtime.profiling.Report:
+        """Profile the adjoint function. It requires the VM to be constructed with `profile=True`,
+        and runs `tvm.relax.VirtualMachine.profile()` internally.
+
+        Parameters
+        ----------
+        input_instances : Union[np.ndarray, NDArray, List[Union[np.ndarray, NDArray]]]
+            The values corresponding to the input_instances part of the backbone function.
+            Parameters and model states are not needed to provide.
+
+            If there are more than one input instances, you can provide a list.
+
+        targets : Union[np.ndarray, NDArray, List[Union[np.ndarray, NDArray]]]
+            The values corresponding to the targets part of the backbone function.
+
+            If there are more than one targets, you can provide a list.
+
+        Returns
+        -------
+        report : tvm.runtime.profiling.Report
+            The formatted profiling result.
+        """
+        self._check_inited()
+
+        if not isinstance(input_instances, list):
+            input_instances = [input_instances]
+
+        if not isinstance(targets, list):
+            targets = [targets]
+
+        if len(input_instances) != self._input_num:
+            raise ValueError("The length of the input does not match the backbone")
+
+        all_inputs: List[NDArray] = (
+            [tvm.nd.array(i) for i in input_instances]
+            + self._params
+            + self._states
+            + [tvm.nd.array(i) for i in targets]
+        )
+        all_inputs = [i.copyto(self.device) for i in all_inputs]
+        return self.vm.profile(self.ADJOINT_FUNC, *all_inputs)

--- a/tests/python/relax/test_training_setup_trainer.py
+++ b/tests/python/relax/test_training_setup_trainer.py
@@ -1,0 +1,229 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+import tvm
+import tvm.testing
+
+from tvm import relax, TVMError
+from tvm.ir.base import assert_structural_equal
+from tvm.relax.training import SetupTrainer
+from tvm.relax.training.optimizer import SGD, MomentumSGD
+from tvm.relax.training.loss import MSELoss
+from tvm.script import ir as I, relax as R
+
+
+def test_simple():
+    # fmt: off
+    @I.ir_module
+    class Backbone:
+        I.module_attrs({"param_num": 1, "state_num": 0})
+        @R.function
+        def backbone(x: R.Tensor((2, 2), "float64"), y: R.Tensor((2, 2), "float64")):
+            with R.dataflow():
+                x1 = x + y
+                R.output(x1)
+            return x1
+
+    @I.ir_module
+    class Expected:
+        I.module_attrs({"input_num": 1, "param_num": 1, "state_num": 0})
+        @R.function
+        def backbone(x: R.Tensor((2, 2), dtype="float64"), y: R.Tensor((2, 2), dtype="float64")) -> R.Tensor((2, 2), dtype="float64"):
+            with R.dataflow():
+                x1: R.Tensor((2, 2), dtype="float64") = R.add(x, y)
+                R.output(x1)
+            return x1
+
+        @R.function
+        def backbone_loss(x: R.Tensor((2, 2), dtype="float64"), y: R.Tensor((2, 2), dtype="float64"), targets: R.Tensor((2, 2), dtype="float64")) -> R.Tensor((), dtype="float64"):
+            with R.dataflow():
+                x1: R.Tensor((2, 2), dtype="float64") = R.add(x, y)
+                lv: R.Tensor((2, 2), dtype="float64") = R.subtract(x1, targets)
+                lv1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv, lv)
+                gv: R.Tensor((), dtype="float64") = R.sum(lv1, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+
+        @R.function
+        def backbone_loss_adjoint(x: R.Tensor((2, 2), dtype="float64"), y: R.Tensor((2, 2), dtype="float64"), targets: R.Tensor((2, 2), dtype="float64")) -> R.Tuple(R.Tensor((), dtype="float64"), R.Tuple(R.Tensor((2, 2), dtype="float64"))):
+            with R.dataflow():
+                x1: R.Tensor((2, 2), dtype="float64") = R.add(x, y)
+                lv: R.Tensor((2, 2), dtype="float64") = R.subtract(x1, targets)
+                lv1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv, lv)
+                gv: R.Tensor((), dtype="float64") = R.sum(lv1, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float64") = R.ones(R.shape([]), dtype="float64")
+                lv1_adjoint: R.Tensor((2, 2), dtype="float64") = R.broadcast_to(gv_adjoint, R.shape([2, 2]))
+                lv_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
+                lv1_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
+                lv_adjoint: R.Tensor((2, 2), dtype="float64") = R.add(lv_1, lv1_1)
+                x1_adjoint: R.Tensor((2, 2), dtype="float64") = lv_adjoint
+                y_adjoint: R.Tensor((2, 2), dtype="float64") = x1_adjoint
+                R.output(gv, y_adjoint)
+            return (gv, (y_adjoint,))
+
+        @R.function
+        def optimizer(params: R.Tuple(R.Tensor((2, 2), dtype="float64")), gradients: R.Tuple(R.Tensor((2, 2), dtype="float64")), optim_states: R.Tuple(R.Tensor((), dtype="int64"))) -> R.Tuple(R.Tuple(R.Tensor((2, 2), dtype="float64")), R.Tuple(R.Tensor((), dtype="int64"))):
+            with R.dataflow():
+                num_steps: R.Tensor((), dtype="int64") = optim_states[0]
+                num_steps_new: R.Tensor((), dtype="int64") = R.add(num_steps, R.const(1, "int64"))
+                y: R.Tensor((2, 2), dtype="float64") = params[0]
+                y_grad: R.Tensor((2, 2), dtype="float64") = gradients[0]
+                lv: R.Tensor((2, 2), dtype="float64") = R.multiply(R.const(0.10000000000000001, "float64"), y_grad)
+                y_new: R.Tensor((2, 2), dtype="float64") = R.subtract(y, lv)
+                params_new: R.Tuple(R.Tensor((2, 2), dtype="float64")) = (y_new,)
+                optim_states_new: R.Tuple(R.Tensor((), dtype="int64")) = (num_steps_new,)
+                R.output(params_new, optim_states_new)
+            return (params_new, optim_states_new)
+    # fmt: on
+
+    sinfo = relax.TensorStructInfo((2, 2), "float64")
+    setup_trainer = SetupTrainer(MSELoss(reduction="sum"), SGD(0.1), [sinfo, sinfo], legalize=False)
+    train_mod = setup_trainer(Backbone)
+    assert_structural_equal(train_mod.without_attr("optim_state"), Expected)
+
+
+def test_states():
+    # fmt: off
+    @I.ir_module
+    class Backbone:
+        I.module_attrs({"param_num": 1, "state_num": 1})
+        @R.function
+        def backbone(x: R.Tensor((2, 2), "float64"), y: R.Tensor((2, 2), "float64"), z: R.Tensor((2, 2), "float64")):
+            with R.dataflow():
+                x1 = x + y
+                z1 = z + R.const(1, "float64")
+                R.output(x1, z1)
+            return x1, z1
+
+    @I.ir_module
+    class Expected:
+        I.module_attrs({"input_num": 1, "param_num": 1, "state_num": 1})
+        @R.function
+        def backbone(x: R.Tensor((2, 2), dtype="float64"), y: R.Tensor((2, 2), dtype="float64"), z: R.Tensor((2, 2), dtype="float64")) -> R.Tuple(R.Tensor((2, 2), dtype="float64"), R.Tensor((2, 2), dtype="float64")):
+            with R.dataflow():
+                x1: R.Tensor((2, 2), dtype="float64") = R.add(x, y)
+                z1: R.Tensor((2, 2), dtype="float64") = R.add(z, R.const(1, "float64"))
+                R.output(x1, z1)
+            return (x1, z1)
+
+        @R.function
+        def backbone_loss(x: R.Tensor((2, 2), dtype="float64"), y: R.Tensor((2, 2), dtype="float64"), z: R.Tensor((2, 2), dtype="float64"), targets: R.Tensor((2, 2), dtype="float64")) -> R.Tuple(R.Tensor((), dtype="float64"), R.Tensor((2, 2), dtype="float64")):
+            with R.dataflow():
+                x1: R.Tensor((2, 2), dtype="float64") = R.add(x, y)
+                z1: R.Tensor((2, 2), dtype="float64") = R.add(z, R.const(1, "float64"))
+                lv: R.Tensor((2, 2), dtype="float64") = R.subtract(x1, targets)
+                lv1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv, lv)
+                gv: R.Tensor((), dtype="float64") = R.sum(lv1, axis=None, keepdims=False)
+                R.output(z1, gv)
+            return (gv, z1)
+
+        @R.function
+        def backbone_loss_adjoint(x: R.Tensor((2, 2), dtype="float64"), y: R.Tensor((2, 2), dtype="float64"), z: R.Tensor((2, 2), dtype="float64"), targets: R.Tensor((2, 2), dtype="float64")) -> R.Tuple(R.Tuple(R.Tensor((), dtype="float64"), R.Tensor((2, 2), dtype="float64")), R.Tuple(R.Tensor((2, 2), dtype="float64"))):
+            with R.dataflow():
+                x1: R.Tensor((2, 2), dtype="float64") = R.add(x, y)
+                z1: R.Tensor((2, 2), dtype="float64") = R.add(z, R.const(1, "float64"))
+                lv: R.Tensor((2, 2), dtype="float64") = R.subtract(x1, targets)
+                lv1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv, lv)
+                gv: R.Tensor((), dtype="float64") = R.sum(lv1, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float64") = R.ones(R.shape([]), dtype="float64")
+                lv1_adjoint: R.Tensor((2, 2), dtype="float64") = R.broadcast_to(gv_adjoint, R.shape([2, 2]))
+                lv_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
+                lv1_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
+                lv_adjoint: R.Tensor((2, 2), dtype="float64") = R.add(lv_1, lv1_1)
+                x1_adjoint: R.Tensor((2, 2), dtype="float64") = lv_adjoint
+                y_adjoint: R.Tensor((2, 2), dtype="float64") = x1_adjoint
+                R.output(z1, gv, y_adjoint)
+            return ((gv, z1), (y_adjoint,))
+
+        @R.function
+        def optimizer(params: R.Tuple(R.Tensor((2, 2), dtype="float64")), gradients: R.Tuple(R.Tensor((2, 2), dtype="float64")), optim_states: R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64"))) -> R.Tuple(R.Tuple(R.Tensor((2, 2), dtype="float64")), R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64"))):
+            with R.dataflow():
+                num_steps: R.Tensor((), dtype="int64") = optim_states[0]
+                num_steps_new: R.Tensor((), dtype="int64") = R.add(num_steps, R.const(1, "int64"))
+                y: R.Tensor((2, 2), dtype="float64") = params[0]
+                y_grad: R.Tensor((2, 2), dtype="float64") = gradients[0]
+                y_v: R.Tensor((2, 2), dtype="float64") = optim_states[1]
+                lv: R.Tensor((2, 2), dtype="float64") = R.multiply(R.const(0.10000000000000001, "float64"), y_v)
+                y_v_new: R.Tensor((2, 2), dtype="float64") = R.add(lv, y_grad)
+                lv1: R.Tensor((2, 2), dtype="float64") = R.multiply(R.const(0.10000000000000001, "float64"), y_v_new)
+                y_new: R.Tensor((2, 2), dtype="float64") = R.subtract(y, lv1)
+                params_new: R.Tuple(R.Tensor((2, 2), dtype="float64")) = (y_new,)
+                optim_states_new: R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64")) = (num_steps_new, y_v_new)
+                R.output(params_new, optim_states_new)
+            return (params_new, optim_states_new)
+    # fmt: on
+
+    sinfo = relax.TensorStructInfo((2, 2), "float64")
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"), MomentumSGD(0.1, 0.1), [sinfo, sinfo], legalize=False
+    )
+    train_mod = setup_trainer(Backbone)
+    assert_structural_equal(train_mod.without_attr("optim_state"), Expected)
+
+
+def test_invalid_mod():
+    @I.ir_module
+    class NoAttr:
+        @R.function
+        def backbone(
+            w0: R.Tensor((10, 5), "float32"),
+            b0: R.Tensor((5,), "float32"),
+            x: R.Tensor((1, 10), "float32"),
+        ):
+            with R.dataflow():
+                lv0 = R.matmul(x, w0)
+                gv = R.add(lv0, b0)
+                out = R.nn.relu(gv)
+                R.output(gv, out)
+            return gv, out
+
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.001),
+        [pred_sinfo, pred_sinfo],
+    )
+
+    with pytest.raises(TVMError):
+        SetupTrainer(
+            MSELoss(reduction="sum"),
+            SGD(0.001),
+            [pred_sinfo, pred_sinfo],
+        )(NoAttr)
+
+    @I.ir_module
+    class WrongFuncName:
+        @R.function
+        def main(
+            w0: R.Tensor((10, 5), "float32"),
+            b0: R.Tensor((5,), "float32"),
+            x: R.Tensor((1, 10), "float32"),
+        ):
+            with R.dataflow():
+                lv0 = R.matmul(x, w0)
+                lv1 = R.add(lv0, b0)
+                out = R.nn.relu(lv1)
+                R.output(out)
+            return out
+
+    with pytest.raises(ValueError):
+        setup_trainer(WrongFuncName)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_training_trainer_numeric.py
+++ b/tests/python/relax/test_training_trainer_numeric.py
@@ -1,0 +1,170 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+import tvm.testing
+import numpy as np
+
+import tvm
+from tvm import relax, TVMError
+from tvm.relax.training import SetupTrainer, Trainer
+from tvm.relax.training.optimizer import SGD, Adam
+from tvm.relax.training.loss import MSELoss
+from tvm.script import ir as I, relax as R
+
+
+def _get_backbone():
+    @I.ir_module
+    class MLP:
+        I.module_attrs({"param_num": 2, "state_num": 0})
+
+        @R.function
+        def backbone(
+            x: R.Tensor((1, 10), "float32"),
+            w0: R.Tensor((10, 5), "float32"),
+            b0: R.Tensor((5,), "float32"),
+        ):
+            with R.dataflow():
+                lv0 = R.matmul(x, w0)
+                lv1 = R.add(lv0, b0)
+                out = R.nn.relu(lv1)
+                R.output(out)
+            return out
+
+    return MLP
+
+
+def _make_dataset():
+    N = 100
+    return [[np.ones((1, 10)).astype(np.float32), np.array([[0, 0, 1, 0, 0]], np.float32)]] * N
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_execute(target, dev):
+    backbone = _get_backbone()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        Adam(0.01),
+        [pred_sinfo, pred_sinfo],
+    )
+
+    train_mod = setup_trainer(backbone)
+    ex = relax.build(train_mod, target)
+    vm = relax.VirtualMachine(ex, dev, profile=True)
+
+    trainer = Trainer(train_mod, vm, dev, False)
+    trainer.zero_init_params()
+    trainer.xaiver_uniform_init_params()
+
+    dataset = _make_dataset()
+    trainer.predict(dataset[0][0])
+    trainer.update(dataset[0][0], dataset[0][1])
+    trainer.profile_adjoint(dataset[0][0], dataset[0][1])
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_execute_numeric(target, dev):
+    backbone = _get_backbone()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.01),
+        [pred_sinfo, pred_sinfo],
+    )
+
+    train_mod = setup_trainer(backbone)
+    ex = relax.build(train_mod, target)
+    vm = relax.VirtualMachine(ex, dev)
+
+    trainer = Trainer(train_mod, vm, dev, False)
+    trainer.zero_init_params()
+
+    dataset = _make_dataset()
+    for _ in range(2):
+        for input, label in dataset:
+            loss = trainer.update(input, label)
+    tvm.testing.assert_allclose(loss.numpy(), 3.1974423e-14)
+
+    result = trainer.predict(dataset[0][0])
+    result_expected = np.array([[0, 0, 0.9999998, 0, 0]], np.float32)
+    tvm.testing.assert_allclose(result.numpy(), result_expected)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_load_export_params(target, dev):
+    backbone = _get_backbone()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.01),
+        [pred_sinfo, pred_sinfo],
+    )
+
+    train_mod = setup_trainer(backbone)
+    ex = relax.build(train_mod, target)
+    vm = relax.VirtualMachine(ex, dev)
+
+    trainer = Trainer(train_mod, vm, dev, False)
+    trainer.xaiver_uniform_init_params()
+
+    dataset = _make_dataset()
+    for input, label in dataset:
+        trainer.update(input, label)
+
+    param_dict = trainer.export_params()
+    assert "w0" in param_dict
+    assert "b0" in param_dict
+
+    trainer1 = Trainer(train_mod, vm, dev, False)
+    trainer1.load_params(param_dict)
+
+    x_sample = dataset[np.random.randint(len(dataset))][0]
+    tvm.testing.assert_allclose(
+        trainer.predict(x_sample).numpy(), trainer1.predict(x_sample).numpy()
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_setting_error(target, dev):
+    backbone = _get_backbone()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.01),
+        [pred_sinfo, pred_sinfo],
+    )
+
+    train_mod = setup_trainer(backbone)
+    ex = relax.build(train_mod, target)
+    vm = relax.VirtualMachine(ex, dev)
+
+    trainer = Trainer(train_mod, vm, dev, False)
+
+    dataset = _make_dataset()
+    # parameters are not inited
+    with pytest.raises(TVMError):
+        trainer.predict(dataset[0][0])
+    with pytest.raises(TVMError):
+        trainer.update(dataset[0][0], dataset[0][1])
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR adds two utilities to simplify the training process: Trainer and SetupTrainer.

SetupTrainer is basically a pass, transforming a backbone module to a complete, legalized trainer module. It is a combination of Gradient pass, loss function, optimizer, AppendLoss pass, LegalizeOps, etc. You can store the trainer module into a file and load it to somewhere else.

Trainer is a runtime utility that accepts the IRModule (that is the result of SetupTrainer) and the relax VM (that contains the built result of the IRModule), and helps run the VM. It maintains the parameters, the model states and the optimizer states internally.

Co-authored-by: Chaofan Lin <siriusneo@sjtu.edu.cn>