### PR TITLE
[Keras][Bugfix] fix a bug about alpha attribute in LeakyReLU which lead to passes conflict

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -156,6 +156,8 @@ def _convert_advanced_activation(inexpr, keras_layer, etab, data_layout, input_s
             return _op.multiply(negative_slope, _op.subtract(inexpr, threshold))
         return _op.nn.relu(inexpr)
     if act_type == "LeakyReLU":
+        if np.isnan(keras_layer.alpha).any():
+            raise tvm.error.OpAttributeInvalid("The alpha value of a LeakyReLU cannot be None.")
         return _op.nn.leaky_relu(inexpr, alpha=float(keras_layer.alpha))
     if act_type == "ELU":
         alpha = keras_layer.alpha if hasattr(keras_layer, "alpha") else 1.0

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -214,8 +214,8 @@ class TestKeras:
 
     def test_forward_activations_except(self, keras_mod):
         """
-        test invalid attribute alpha=None for LeakyReLU,
-        after version 2.3.1 in keras, checking was added to reject the invalid api call: 
+        test invalid attribute alpha=None for LeakyReLU.
+        after version 2.3.1 in keras, checking was added to reject the invalid api call:
         LeakyReLU(alpha=None), (issue: https://github.com/tensorflow/tensorflow/pull/47017)
         Thus, it's necessary to check the keras version to avoid crash at LeakyReLU(alpha=None)
         """

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -215,9 +215,9 @@ class TestKeras:
     def test_forward_activations_except(self, keras_mod):
         """
         test invalid attribute alpha=None for LeakyReLU,
-        after version 2.3.1 in keras, keras add check to reject the valid api call: LeakyReLU(alpha=None),
-        (related issue: https://github.com/tensorflow/tensorflow/pull/47017)
-        Thus, it's necessary to check the keras version for avoiding crash when call LeakyReLU(alpha=None)
+        after version 2.3.1 in keras, checking was added to reject the invalid api call: 
+        LeakyReLU(alpha=None), (issue: https://github.com/tensorflow/tensorflow/pull/47017)
+        Thus, it's necessary to check the keras version to avoid crash at LeakyReLU(alpha=None)
         """
         if package_version.parse(keras_mod.__version__.split("-tf")[0]) <= package_version.parse(
             "2.3.1"

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -765,6 +765,7 @@ if __name__ == "__main__":
         sut.test_forward_merge_dot(keras_mod=k)
         sut.test_forward_merge(keras_mod=k)
         sut.test_forward_activations(keras_mod=k)
+        sut.test_forward_activations_special(keras_mod=k)
         sut.test_forward_dense(keras_mod=k)
         sut.test_forward_permute(keras_mod=k)
         sut.test_forward_sequential(keras_mod=k)

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -211,13 +211,18 @@ class TestKeras:
             keras_model = keras_mod.models.Model(data, x)
             verify_keras_frontend(keras_model)
             verify_keras_frontend(keras_model, need_transpose=False, layout="NHWC")
-        # test invalid attribute alpha=None for LeakyReLU
+
+    def test_forward_activations_special(self, keras_mod):
+        # test invalid attribute alpha=None for LeakyReLU,
+        # after version 2.3.1 in keras, keras add check to reject the valid api call:  LeakyReLU(alpha=None),
+        # (related issue: https://github.com/tensorflow/tensorflow/pull/47017)
+        # Thus, it's necessary to check the keras version for avoiding crash when call  LeakyReLU(alpha=None)
         if package_version.parse(keras_mod.__version__.split("-tf")[0]) <= package_version.parse(
             "2.3.1"
         ):
             data = keras_mod.layers.Input(shape=(2, 3, 4))
-            x = keras_mod.layers.LeakyReLU(alpha=None)(data)
-            keras_model = keras_mod.models.Model(data, x)
+            layer = keras_mod.layers.LeakyReLU(alpha=None)(data)
+            keras_model = keras_mod.models.Model(data, layer)
             with pytest.raises(tvm.error.OpAttributeInvalid):
                 verify_keras_frontend(keras_model)
 

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -211,13 +211,16 @@ class TestKeras:
             keras_model = keras_mod.models.Model(data, x)
             verify_keras_frontend(keras_model)
             verify_keras_frontend(keras_model, need_transpose=False, layout="NHWC")
-        # test invalid attribute alpha=None for LeakyReLU    
+        # test invalid attribute alpha=None for LeakyReLU
+        if package_version.parse(keras_mod.__version__.split("-tf")[0]) <= package_version.parse(
+            "2.3.1"
+        ):
         if package_version.parse(keras_mod.__version__.split('-tf')[0]) <= package_version.parse("2.3.1"):
             data = keras_mod.layers.Input(shape=(2, 3, 4))
             x = keras_mod.layers.LeakyReLU(alpha=None)(data)
             keras_model = keras_mod.models.Model(data, x)
             with pytest.raises(tvm.error.OpAttributeInvalid):
-                verify_keras_frontend(keras_model)        
+                verify_keras_frontend(keras_model)
 
     def test_forward_dense(self, keras_mod):
         """test_forward_dense"""

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -15,12 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for various models and operators"""
+from packaging import version as package_version
 import numpy as np
 import tvm
 from tvm import relay
 from tvm.contrib import graph_executor
 import tvm.testing
-from packaging import version as package_version
 import pytest
 
 try:

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -215,7 +215,6 @@ class TestKeras:
         if package_version.parse(keras_mod.__version__.split("-tf")[0]) <= package_version.parse(
             "2.3.1"
         ):
-        if package_version.parse(keras_mod.__version__.split('-tf')[0]) <= package_version.parse("2.3.1"):
             data = keras_mod.layers.Input(shape=(2, 3, 4))
             x = keras_mod.layers.LeakyReLU(alpha=None)(data)
             keras_model = keras_mod.models.Model(data, x)

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -212,11 +212,13 @@ class TestKeras:
             verify_keras_frontend(keras_model)
             verify_keras_frontend(keras_model, need_transpose=False, layout="NHWC")
 
-    def test_forward_activations_special(self, keras_mod):
-        # test invalid attribute alpha=None for LeakyReLU,
-        # after version 2.3.1 in keras, keras add check to reject the valid api call:  LeakyReLU(alpha=None),
-        # (related issue: https://github.com/tensorflow/tensorflow/pull/47017)
-        # Thus, it's necessary to check the keras version for avoiding crash when call  LeakyReLU(alpha=None)
+    def test_forward_activations_except(self, keras_mod):
+        """
+        test invalid attribute alpha=None for LeakyReLU,
+        after version 2.3.1 in keras, keras add check to reject the valid api call: LeakyReLU(alpha=None),
+        (related issue: https://github.com/tensorflow/tensorflow/pull/47017)
+        Thus, it's necessary to check the keras version for avoiding crash when call LeakyReLU(alpha=None)
+        """
         if package_version.parse(keras_mod.__version__.split("-tf")[0]) <= package_version.parse(
             "2.3.1"
         ):
@@ -765,7 +767,7 @@ if __name__ == "__main__":
         sut.test_forward_merge_dot(keras_mod=k)
         sut.test_forward_merge(keras_mod=k)
         sut.test_forward_activations(keras_mod=k)
-        sut.test_forward_activations_special(keras_mod=k)
+        sut.test_forward_activations_except(keras_mod=k)
         sut.test_forward_dense(keras_mod=k)
         sut.test_forward_permute(keras_mod=k)
         sut.test_forward_sequential(keras_mod=k)


### PR DESCRIPTION
The `alpha` attribute in LeakyReLU lacks exception checking. If the `alpha=nan` , the keras frontend can convert it to relay ir successful, but in the optimization stage, it will trigger an  unexpected crash and throws `TVMError: Observed 100 rewrite passes, possible conflicting passes?`

The relay IR is the following:
![image](https://user-images.githubusercontent.com/29506758/233846389-bd435603-d536-434e-8f19-addb9f5d8894.png)


This patch fixes the bug!

The StackTrace:
```
    model = relay.build_module.create_executor("graph", mod, tvm.cpu(0), 'llvm', params).evaluate()  # crash
  File "/workplace/software/tvm/tvm/python/tvm/relay/backend/interpreter.py", line 171, in evaluate
    return self._make_executor()
  File "/workplace/software/tvm/tvm/python/tvm/relay/build_module.py", line 519, in _make_executor
    mod = build(self.mod, target=self.target)
  File "/workplace/software/tvm/tvm/python/tvm/relay/build_module.py", line 372, in build
    mod_name=mod_name,
  File "/workplace/software/tvm/tvm/python/tvm/relay/build_module.py", line 169, in build
    mod_name,
  File "/workplace/software/tvm/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 237, in __call__
    raise get_last_ffi_error()
tvm._ffi.base.TVMError: Traceback (most recent call last):
  14: TVMFuncCall
  13: tvm::relay::backend::RelayBuildModule::GetFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tvm::runtime::ObjectPtr<tvm::runtime::Object> const&)::{lambda(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)#3}::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const
  12: tvm::relay::backend::RelayBuildModule::Build(tvm::IRModule, tvm::runtime::Array<tvm::Target, void> const&, tvm::Target const&, tvm::relay::Executor const&, tvm::relay::Runtime const&, tvm::WorkspaceMemoryPools const&, tvm::ConstantMemoryPools const&, tvm::runtime::String)
  11: tvm::relay::backend::RelayBuildModule::BuildRelay(tvm::IRModule, tvm::runtime::String const&)
  10: tvm::relay::backend::RelayBuildModule::OptimizeImpl(tvm::IRModule)
  9: tvm::transform::Pass::operator()(tvm::IRModule) const
  8: tvm::transform::Pass::operator()(tvm::IRModule, tvm::transform::PassContext const&) const
  7: tvm::transform::SequentialNode::operator()(tvm::IRModule, tvm::transform::PassContext const&) const
  6: tvm::transform::Pass::operator()(tvm::IRModule, tvm::transform::PassContext const&) const
  5: tvm::relay::transform::FunctionPassNode::operator()(tvm::IRModule, tvm::transform::PassContext const&) const
  4: tvm::runtime::PackedFuncObj::Extractor<tvm::runtime::PackedFuncSubObj<tvm::runtime::TypedPackedFunc<tvm::relay::Function (tvm::relay::Function, tvm::IRModule, tvm::transform::PassContext)>::AssignTypedLambda<tvm::relay::transform::SimplifyExpr()::$_0>(tvm::relay::transform::SimplifyExpr()::$_0)::{lambda(tvm::runtime::TVMArgs const&, tvm::runtime::TVMRetValue*)#1}> >::Call(tvm::runtime::PackedFuncObj const*, tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)
  3: tvm::relay::SimplifyExpr(tvm::RelayExpr const&, tvm::IRModule const&)
  2: tvm::relay::RewritePatterns(tvm::runtime::Array<tvm::relay::DFPatternCallback, void>, tvm::RelayExpr, tvm::IRModule)
  1: tvm::relay::PatternRewriter::Rewrite(tvm::runtime::Array<tvm::relay::DFPatternCallback, void> const&, tvm::RelayExpr const&)
  0: _ZN3tvm7runtime6detail
  File "/workplace/software/tvm/tvm/src/relay/ir/dataflow_matcher.cc", line 829
TVMError: Observed 100 rewrite passes, possible conflicting passes?

```

