### PR TITLE
[Unity] Allow modifying function signature by AMP to accept fp16 inputs 

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -29,8 +29,6 @@
 #include <tvm/relax/expr.h>
 #include <tvm/tir/function.h>
 #include <tvm/tir/index_map.h>
-
-#include "tvm/runtime/container/optional.h"
 namespace tvm {
 namespace relax {
 namespace transform {
@@ -481,6 +479,8 @@ TVM_DLL Pass DeadCodeElimination(Array<runtime::String> entry_functions);
  * \brief Automatic mixed precision pass. Currently the pass assumes the input module to be fp32
  * only, and will automatically cast fp32 to fp16 for certain ops.
  * \param out_dtype The output data type of gemm/conv, which is the data type of the accumulator.
+ * \param fp16_input_names The names of function parameters whose dtype should become fp16. The
+ * function signature would change accordingly.
  * \return The Pass.
  */
 TVM_DLL Pass ToMixedPrecision(const DataType& out_dtype,

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -29,6 +29,8 @@
 #include <tvm/relax/expr.h>
 #include <tvm/tir/function.h>
 #include <tvm/tir/index_map.h>
+
+#include "tvm/runtime/container/optional.h"
 namespace tvm {
 namespace relax {
 namespace transform {
@@ -481,7 +483,8 @@ TVM_DLL Pass DeadCodeElimination(Array<runtime::String> entry_functions);
  * \param out_dtype The output data type of gemm/conv, which is the data type of the accumulator.
  * \return The Pass.
  */
-TVM_DLL Pass ToMixedPrecision(const DataType& out_dtype);
+TVM_DLL Pass ToMixedPrecision(const DataType& out_dtype,
+                              Optional<Array<String>> fp16_input_names = NullOpt);
 
 /*!
  * \brief Rewrite a Relax module for executing with CUDA graph. This pass identifies

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -914,7 +914,7 @@ def DeadCodeElimination(entry_functions: Optional[List[str]] = None) -> tvm.ir.t
     return _ffi_api.DeadCodeElimination(entry_functions)  # type: ignore
 
 
-def ToMixedPrecision(out_dtype="float32") -> tvm.ir.transform.Pass:
+def ToMixedPrecision(out_dtype="float32", fp16_input_names=None) -> tvm.ir.transform.Pass:
     """Automatic mixed precision pass. Currently the pass assumes the input module to be fp32
     only, and will automatically cast fp32 to fp16 for certain ops.
     Parameters
@@ -926,7 +926,7 @@ def ToMixedPrecision(out_dtype="float32") -> tvm.ir.transform.Pass:
     ret : tvm.transform.Pass
         The registered pass for mixed precision.
     """
-    return _ffi_api.ToMixedPrecision(out_dtype)  # type: ignore
+    return _ffi_api.ToMixedPrecision(out_dtype, fp16_input_names)  # type: ignore
 
 
 def SplitCallTIRByPattern(patterns, fcodegen) -> tvm.ir.transform.Pass:

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -915,7 +915,7 @@ def DeadCodeElimination(entry_functions: Optional[List[str]] = None) -> tvm.ir.t
 
 
 def ToMixedPrecision(
-    out_dtype="float32", fp16_input_names=Optional[List[str]]
+    out_dtype="float32", fp16_input_names: Optional[List[str]] = None
 ) -> tvm.ir.transform.Pass:
     """Automatic mixed precision pass. Currently the pass assumes the input module to be fp32
     only, and will automatically cast fp32 to fp16 for certain ops.

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -914,13 +914,19 @@ def DeadCodeElimination(entry_functions: Optional[List[str]] = None) -> tvm.ir.t
     return _ffi_api.DeadCodeElimination(entry_functions)  # type: ignore
 
 
-def ToMixedPrecision(out_dtype="float32", fp16_input_names=None) -> tvm.ir.transform.Pass:
+def ToMixedPrecision(
+    out_dtype="float32", fp16_input_names=Optional[List[str]]
+) -> tvm.ir.transform.Pass:
     """Automatic mixed precision pass. Currently the pass assumes the input module to be fp32
     only, and will automatically cast fp32 to fp16 for certain ops.
     Parameters
     ----------
     out_dtype : str
         The output data type of gemm/conv, which is the data type of the accumulator.
+    fp16_input_names : List[str]
+        The names of function parameters whose dtype should become fp16. The  function signature
+        would change accordingly.
+
     Returns
     -------
     ret : tvm.transform.Pass

--- a/src/relax/transform/to_mixed_precision.cc
+++ b/src/relax/transform/to_mixed_precision.cc
@@ -27,11 +27,14 @@
 
 #include <array>
 #include <cstdint>
+#include <unordered_set>
 
 #include "../op/nn/convolution.h"
 #include "../op/tensor/datatype.h"
 #include "../op/tensor/linear_algebra.h"
 #include "infer_amp_utils.h"
+#include "tvm/relax/struct_info.h"
+#include "tvm/runtime/data_type.h"
 #include "utils.h"
 
 namespace tvm {
@@ -273,13 +276,30 @@ class DTypeDecisionCollector : public ExprVisitor {
 
 class ToMixedPrecisionRewriter : public ExprMutator {
  public:
-  explicit ToMixedPrecisionRewriter(const VarDTypeMap* only_fp16_map, DataType output_dtype)
-      : only_fp16_map_(only_fp16_map), output_dtype_(output_dtype) {}
+  explicit ToMixedPrecisionRewriter(const VarDTypeMap* only_fp16_map, DataType output_dtype,
+                                    const std::unordered_set<std::string>& fp16_input_names)
+      : only_fp16_map_(only_fp16_map),
+        output_dtype_(output_dtype),
+        fp16_input_names_(fp16_input_names) {}
 
  private:
   Var GetRemapped(const Var& var) {
     auto it = var_remap_.find(var->vid);
-    return it == var_remap_.end() ? var : it->second;
+    if (it != var_remap_.end()) {
+      return it->second;
+    } else {
+      if (fp16_input_names_.count(var->name_hint())) {
+        auto sinfo = GetStructInfo(var);
+        if (auto tensor_sinfo = sinfo.as<TensorStructInfoNode>()) {
+          TensorStructInfo fp16_sinfo(tensor_sinfo->shape.value(), DataType::Float(16),
+                                      tensor_sinfo->span);
+          Var fp16_var(var->vid, fp16_sinfo, var->span);
+          var_remap_[var->vid] = fp16_var;
+          return fp16_var;
+        }
+      }
+      return var;
+    }
   }
 
   Array<Expr> RemapArgs(const Array<Expr>& args) {
@@ -427,6 +447,10 @@ class ToMixedPrecisionRewriter : public ExprMutator {
     return VisitVar_(GetRef<Var>(op));
   }
 
+  Var VisitVarDef(const Var& var) {
+    return GetRemapped(var);
+  }
+
   Expr VisitExpr_(const DataflowVarNode* op) final {
     if (!builder_->CurrentBlockIsDataFlow()) {
       return ExprMutator::VisitExpr_(op);
@@ -561,22 +585,28 @@ class ToMixedPrecisionRewriter : public ExprMutator {
   DataType fp32_ = DataType(DataType::TypeCode::kFloat, 32, 1);
   DataType output_dtype_;
   Array<Var> params_;
+  std::unordered_set<std::string> fp16_input_names_;
 
   const Op& wrap_param_op = Op::Get("relax.wrap_param");
 };
 
-Expr ToMixedPrecision(const Function& f, const DataType& out_dtype) {
+Expr ToMixedPrecision(const Function& f, const DataType& out_dtype,
+                      Optional<Array<String>> fp16_input_names) {
   VarDTypeMap only_fp16_map = std::move(DTypeDecisionCollector::Collect(f, out_dtype));
-  ToMixedPrecisionRewriter mutator(&only_fp16_map, out_dtype);
+  std::unordered_set<std::string> fp16_input_names_set;
+  if (fp16_input_names) {
+    fp16_input_names_set.insert(fp16_input_names.value().begin(), fp16_input_names.value().end());
+  }
+  ToMixedPrecisionRewriter mutator(&only_fp16_map, out_dtype, fp16_input_names_set);
   return mutator(f);
 }
 
 namespace transform {
 
-Pass ToMixedPrecision(const DataType& out_dtype) {
+Pass ToMixedPrecision(const DataType& out_dtype, Optional<Array<String>> fp16_input_names) {
   runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
       [=](Function f, IRModule m, PassContext pc) {
-        return Downcast<Function>(ToMixedPrecision(f, out_dtype));
+        return Downcast<Function>(ToMixedPrecision(f, out_dtype, fp16_input_names));
       };
   return CreateFunctionPass(pass_func, 0, "ToMixedPrecision", {});
 }

--- a/src/relax/transform/to_mixed_precision.cc
+++ b/src/relax/transform/to_mixed_precision.cc
@@ -33,8 +33,6 @@
 #include "../op/tensor/datatype.h"
 #include "../op/tensor/linear_algebra.h"
 #include "infer_amp_utils.h"
-#include "tvm/relax/struct_info.h"
-#include "tvm/runtime/data_type.h"
 #include "utils.h"
 
 namespace tvm {

--- a/src/relax/transform/to_mixed_precision.cc
+++ b/src/relax/transform/to_mixed_precision.cc
@@ -445,9 +445,7 @@ class ToMixedPrecisionRewriter : public ExprMutator {
     return VisitVar_(GetRef<Var>(op));
   }
 
-  Var VisitVarDef(const Var& var) {
-    return GetRemapped(var);
-  }
+  Var VisitVarDef(const Var& var) { return GetRemapped(var); }
 
   Expr VisitExpr_(const DataflowVarNode* op) final {
     if (!builder_->CurrentBlockIsDataFlow()) {

--- a/tests/python/relax/test_transform_to_mixed_precision.py
+++ b/tests/python/relax/test_transform_to_mixed_precision.py
@@ -1018,74 +1018,23 @@ def test_convert_sig():
         @R.function
         def main(
             x: R.Tensor((1, 4, 64, 64), dtype="float32"),
-            w: R.Tensor((512, 4, 3, 3), dtype="float32"),
-            bias: R.Tensor((512,), dtype="float32"),
+            w: R.Tensor((512, 4, 3, 3), dtype="float16"),
+            bias: R.Tensor((512,), dtype="float16"),
         ) -> R.Tensor((1, 512, 64, 64), dtype="float32"):
             with R.dataflow():
-                lv: R.Tensor((1, 4, 64, 64), dtype="float16") = R.astype(x, dtype="float16")
-                lv1: R.Tensor((512, 4, 3, 3), dtype="float16") = R.astype(w, dtype="float16")
-                lv142: R.Tensor((1, 512, 62, 62), dtype="float16") = R.nn.conv2d(
-                    lv,
-                    lv1,
-                    strides=[1, 1],
-                    padding=[0, 0, 0, 0],
-                    out_dtype="float16",
+                lv = R.astype(x, dtype="float16")
+                lv142 = R.nn.conv2d(
+                    lv, w, strides=[1, 1], padding=[0, 0, 0, 0], out_dtype="float16"
                 )
-                lv2: R.Tensor((512,), dtype="float16") = R.astype(bias, dtype="float16")
-                lv143: R.Tensor((1, 512, 1, 1), dtype="float16") = R.reshape(
-                    lv2, R.shape([1, 512, 1, 1])
-                )
-                lv3: R.Tensor((1, 512, 62, 62), dtype="float16") = R.add(lv142, lv143)
-                lv144: R.Tensor((1, 512, 62, 62), dtype="float32") = R.astype(lv3, dtype="float32")
+                lv143 = R.reshape(bias, R.shape([1, 512, 1, 1]))
+                lv1 = R.add(lv142, lv143)
+                lv144 = R.astype(lv1, dtype="float32")
                 R.output(lv144)
             return lv144
 
-    @tvm.script.ir_module
-    class Expected_no_bias_cast:
-        @R.function
-        def main(
-            x: R.Tensor((1, 4, 64, 64), dtype="float32"),
-            w: R.Tensor((512, 4, 3, 3), dtype="float32"),
-            bias: R.Tensor((512,), dtype="float32"),
-        ) -> R.Tensor((1, 512, 64, 64), dtype="float32"):
-            with R.dataflow():
-                lv: R.Tensor((1, 4, 64, 64), dtype="float16") = R.astype(x, dtype="float16")
-                lv1: R.Tensor((512, 4, 3, 3), dtype="float16") = R.astype(w, dtype="float16")
-                lv142: R.Tensor((1, 512, 62, 62), dtype="float16") = R.nn.conv2d(
-                    lv,
-                    lv1,
-                    strides=[1, 1],
-                    padding=[0, 0, 0, 0],
-                    out_dtype="float16",
-                )
-                lv143: R.Tensor((1, 512, 1, 1), dtype="float32") = R.reshape(
-                    bias, R.shape([1, 512, 1, 1])
-                )
-                lv2: R.Tensor((1, 512, 62, 62), dtype="float32") = R.astype(lv142, dtype="float32")
-                lv144: R.Tensor((1, 512, 62, 62), dtype="float32") = R.add(lv2, lv143)
-                R.output(lv144)
-            return lv144
-
-    binding_np = {
-        "w": np.random.uniform(size=(512, 4, 3, 3)).astype("float32"),
-        "bias": np.random.uniform(size=(512,)).astype("float32"),
-    }
-    binding = {k: tvm.nd.array(v) for k, v in binding_np.items()}
-
-    print(ToMixedPrecision(out_dtype="float16", fp16_input_names=["w", "bias"])(Input))
-    # Input_bound = relax.transform.BindParams("main", binding)(Input)
-    # Expected = relax.transform.BindParams("main", binding)(Expected)
-
-    # _assert_test(Input_bound, expected2=Expected)
-
-    # binding_np["bias"][0] = 70000  # Out of fp16 range
-    # binding = {k: tvm.nd.array(v) for k, v in binding_np.items()}
-    # Input_bound = relax.transform.BindParams("main", binding)(Input)
-    # Expected_no_bias_cast = relax.transform.BindParams("main", binding)(Expected_no_bias_cast)
-
-    # _assert_test(Input_bound, expected2=Expected_no_bias_cast)
+    mod = ToMixedPrecision(out_dtype="float16", fp16_input_names=["w", "bias"])(Input)
+    tvm.ir.assert_structural_equal(mod, Expected)
 
 
 if __name__ == "__main__":
-    # tvm.testing.main()
-    test_convert_sig()
+    tvm.testing.main()


### PR DESCRIPTION
When a user doesn't want to bind params at compile time and still benefit from AMP, it is important that these params are provided at runtime as fp16 tensors. Otherwise the conservative nature of AMP kicks in and we end up with lots of cast to fp32 before bias add etc. Also when the same model is executed many times with runtime weights (e.g. SD UNet), we would end up casting input fp32 weights repeatedly in the inference loop.

To allow ingesting fp16 tensors as input, this PR lets users provide a list of parameter names whose dtype should become fp16 at runtime.

cc @spectrometerHBH 