### PR TITLE
[Unity][CUTLASS] Fixed memory leak in attention kernel offload

### DIFF
--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -149,6 +149,10 @@ def instantiate_attention_template(attrs):
 
   CHECK(Attention::check_supported(p));
   kernel_fn<<<p.getBlocksGrid(), p.getThreadsGrid(), smem_bytes>>>(p);
+
+  if (Attention::kNeedsOutputAccumulatorBuffer) {
+    cudaFree(p.output_accum_ptr);
+  }
 """
 
     template = substitute_template(


### PR DESCRIPTION
We are doing `cudaMalloc` on every call to the CUTLASS attention kernel, but we are not freeing the allocated memory. This leads to a serious problem for SD UNet. Thanks @jwfromm for finding the memory leak problem.
https://github.com/apache/tvm/blob/b98ba5568eb01e54f48f0b49e232b78ce44de935/python/tvm/contrib/cutlass/attention_operation.py#L118-L123

This makes me realize that we are doing the same alloc / free on every call to attention. Instead, it is desirable to allocate once and use the same allocation throughout. AITemplate does this, apparently. 

@cyx-6 @jwfromm 