### PR TITLE
[Unity][CUTLASS] Fixed stacked attention offload when QKV reshape uses the same shape expression

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -790,8 +790,15 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
             arg["arg0_shape"] = signature["arg0_shape"]
             arg["arg0_dtype"] = signature["arg0_dtype"]
             arg["arg1_shape"] = q_shape = signature["arg1_shape"]
-            arg["arg2_shape"] = k_shape = signature["arg2_shape"]
-            arg["arg3_shape"] = v_shape = signature["arg3_shape"]
+
+            if "arg2_shape" not in signature:
+                arg["arg2_shape"] = k_shape = signature["arg1_shape"]
+                arg["arg3_shape"] = v_shape = signature["arg1_shape"]
+            else:
+                assert "arg3_shape" in signature
+                arg["arg2_shape"] = k_shape = signature["arg2_shape"]
+                arg["arg3_shape"] = v_shape = signature["arg3_shape"]
+
             if "arg4_dtype" in signature:
                 arg["bias_dtype"] = signature["arg4_dtype"]
             if "arg4_shape" in signature:


### PR DESCRIPTION
When a single expression, such as `R.shape([2, 4096, 8, 40])` is used by all `reshape` for QKV, the following composite function that only gets one shape parameter is generated. This is currently not handled properly by codegen.

```
@R.function
def fused_relax_split_relax_reshape_relax_reshape_relax_reshape_relax_nn_attention_cutlass(qkv: R.Tensor((4, 8, 6144), dtype="float32"), param_0: R.Shape([4, 8, 32, 64])) -> R.Tensor((4, 8, 32, 64), dtype="float32"):
    R.func_attr({"Codegen": "cutlass", "global_symbol": "fused_relax_split_relax_reshape_relax_reshape_relax_reshape_relax_nn_attention_cutlass"})
    # from tvm.script import relax as R
    
    @R.function
    def gv_1(qkv_1: R.Tensor((4, 8, 6144), dtype="float32"), param_0_1: R.Shape([4, 8, 32, 64])) -> R.Tensor((4, 8, 32, 64), dtype="float32"):
        R.func_attr({"Composite": "cutlass.stacked_attention", "Primitive": 1})
        with R.dataflow():
            lv: R.Tuple(R.Tensor((4, 8, 2048), dtype="float32"), R.Tensor((4, 8, 2048), dtype="float32"), R.Tensor((4, 8, 2048), dtype="float32")) = R.split(qkv_1, indices_or_sections=[2048, 4096], axis=2)
            lv1: R.Tensor((4, 8, 2048), dtype="float32") = lv[0]
            lv2: R.Tensor((4, 8, 32, 64), dtype="float32") = R.reshape(lv1, param_0_1)
            lv3: R.Tensor((4, 8, 2048), dtype="float32") = lv[1]
            lv4: R.Tensor((4, 8, 32, 64), dtype="float32") = R.reshape(lv3, param_0_1)
            lv5: R.Tensor((4, 8, 2048), dtype="float32") = lv[2]
            lv6: R.Tensor((4, 8, 32, 64), dtype="float32") = R.reshape(lv5, param_0_1)
            gv_2: R.Tensor((4, 8, 32, 64), dtype="float32") = R.nn.attention(lv2, lv4, lv6, scale=None)
            R.output(gv_2)
        return gv_2

    gv1: R.Tensor((4, 8, 32, 64), dtype="float32") = gv(qkv, param_0)
    return gv1
```

Apparently, it is due to `EliminateCommonSubexpr()` pass that I'm using which turns the original three `reshape` ops below into ones that share the same `R.shape([2, 4096, 8, 40])`.

```
lv_3: R.Tensor((2, 4096, 8, 40), dtype="float32") = R.reshape(lv_2, R.shape([2, 4096, 8, 40]))
lv1_2: R.Tensor((2, 4096, 8, 40), dtype="float32") = R.reshape(lv1_1, R.shape([2, 4096, 8, 40]))
lv2_3: R.Tensor((2, 4096, 8, 40), dtype="float32") = R.reshape(lv2_2, R.shape([2, 4096, 8, 40]))
lv_4: R.Tensor((2, 4096, 8, 40), dtype="float32") = cls.fused_relax_nn_attention_cutlass(lv_3, lv1_2, lv2_3)
```


@cyx-6 