### PR TITLE
[Unity] Add options to MS tuning pass to enable more fine-grained tuning

### DIFF
--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -194,6 +194,8 @@ def tune_relax(
         The maximum number of trials to run
     max_trials_per_task : Optional[int]
         The maximum number of trials to run for each task
+    op_names: Optional[List[str]]
+        A list of operator names to specify which op to tune
     num_trials_per_iter : int
         The number of trials to run per iteration
     builder : BuilderType
@@ -304,6 +306,8 @@ def _tune_relax(
         The maximum number of trials to run
     max_trials_per_task : Optional[int]
         The maximum number of trials to run for each task
+    op_names: Optional[List[str]]
+        A list of operator names to specify which op to tune
     num_trials_per_iter : int
         The number of trials to run per iteration
     builder : BuilderType

--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -163,8 +163,9 @@ def tune_relax(
     target: Union[str, Target],
     work_dir: str,
     max_trials_global: int,
-    *,
     max_trials_per_task: Optional[int] = None,
+    op_names = None,
+    *,
     num_trials_per_iter: int = 64,
     builder: Builder.BuilderType = "local",
     runner: Runner.RunnerType = "local",
@@ -229,8 +230,20 @@ def tune_relax(
     database : Database
         The database that contains the tuning records
     """
+    all_tasks = extract_tasks(mod, target, params, module_equality=module_equality)
+
+    if not op_names:
+        selected_tasks = all_tasks
+    else:
+        selected_tasks = []
+
+        for task in all_tasks:
+            for op_name in op_names:
+                if op_name in task.mod.task_name:
+                    selected_tasks.append(task)
+
     tasks, task_weights = extracted_tasks_to_tune_contexts(
-        extracted_tasks=extract_tasks(mod, target, params, module_equality=module_equality),
+        extracted_tasks=selected_tasks,
         work_dir=work_dir,
         space=space,
         strategy=strategy,
@@ -260,8 +273,9 @@ def _tune_relax(
     target: Union[str, Target],
     work_dir: str,
     max_trials_global: int,
-    *,
     max_trials_per_task: Optional[int] = None,
+    op_names: Optional[List[str]] = None,
+    *,
     num_trials_per_iter: int = 64,
     builder: Builder.BuilderType = "local",
     runner: Runner.RunnerType = "local",
@@ -337,6 +351,7 @@ def _tune_relax(
         max_trials_global,
         max_trials_per_task=max_trials_per_task,
         num_trials_per_iter=num_trials_per_iter,
+        op_names=op_names,
         builder=builder,
         runner=runner,
         database=database,

--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -164,7 +164,7 @@ def tune_relax(
     work_dir: str,
     max_trials_global: int,
     max_trials_per_task: Optional[int] = None,
-    op_names:Optional[List[str]] = None,
+    op_names: Optional[List[str]] = None,
     *,
     num_trials_per_iter: int = 64,
     builder: Builder.BuilderType = "local",

--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -195,7 +195,8 @@ def tune_relax(
     max_trials_per_task : Optional[int]
         The maximum number of trials to run for each task
     op_names: Optional[List[str]]
-        A list of operator names to specify which op to tune
+        A list of operator names to specify which op to tune. When it is None, all operators
+        are tuned.
     num_trials_per_iter : int
         The number of trials to run per iteration
     builder : BuilderType
@@ -307,7 +308,8 @@ def _tune_relax(
     max_trials_per_task : Optional[int]
         The maximum number of trials to run for each task
     op_names: Optional[List[str]]
-        A list of operator names to specify which op to tune
+        A list of operator names to specify which op to tune. When it is None, all operators
+        are tuned.
     num_trials_per_iter : int
         The number of trials to run per iteration
     builder : BuilderType

--- a/python/tvm/meta_schedule/relax_integration.py
+++ b/python/tvm/meta_schedule/relax_integration.py
@@ -164,7 +164,7 @@ def tune_relax(
     work_dir: str,
     max_trials_global: int,
     max_trials_per_task: Optional[int] = None,
-    op_names = None,
+    op_names:Optional[List[str]] = None,
     *,
     num_trials_per_iter: int = 64,
     builder: Builder.BuilderType = "local",
@@ -239,7 +239,7 @@ def tune_relax(
 
         for task in all_tasks:
             for op_name in op_names:
-                if op_name in task.mod.task_name:
+                if op_name in task.task_name:
                     selected_tasks.append(task)
 
     tasks, task_weights = extracted_tasks_to_tune_contexts(
@@ -342,6 +342,8 @@ def _tune_relax(
     """
     if isinstance(max_trials_global, IntImm):
         max_trials_global = int(max_trials_global)
+    if isinstance(max_trials_per_task, IntImm):
+        max_trials_per_task = int(max_trials_per_task)
 
     tune_relax(
         mod,

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -799,7 +799,8 @@ def MetaScheduleTuneIRMod(
     max_trials_per_task: int
        maximum number of trials per task
     op_names: Optional[List[str]]
-       A list of operator names to specify which op to tune
+       A list of operator names to specify which op to tune. When it is None, all operators
+        are tuned.
 
     Returns
     -------

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -805,7 +805,9 @@ def MetaScheduleTuneIRMod(
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.MetaScheduleTuneIRMod(params, work_dir, max_trials_global, max_trials_per_task, op_names)  # type: ignore
+    return _ffi_api.MetaScheduleTuneIRMod(
+        params, work_dir, max_trials_global, max_trials_per_task, op_names
+    )  # type: ignore
 
 
 def DecomposeOpsForInference(func_name: Optional[str] = None) -> tvm.ir.transform.Pass:

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -796,6 +796,11 @@ def MetaScheduleTuneIRMod(
        work directory
     max_trials_gloabl: int
        maximum number of total trials allowed for tuning
+    max_trials_per_task: int
+       maximum number of trials per task
+    op_names: Optional[List[str]]
+       A list of operator names to specify which op to tune
+
     Returns
     -------
     ret: tvm.ir.transform.Pass

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -784,6 +784,8 @@ def MetaScheduleTuneIRMod(
     params: Dict[str, NDArray],
     work_dir: str,
     max_trials_global: int,
+    max_trials_per_task: Optional[int] = None,
+    op_names: Optional[List[str]] = None,
 ) -> tvm.ir.transform.Pass:
     """Tune Relax IRModule with MetaSchedule.
     Parameters
@@ -798,7 +800,7 @@ def MetaScheduleTuneIRMod(
     -------
     ret: tvm.ir.transform.Pass
     """
-    return _ffi_api.MetaScheduleTuneIRMod(params, work_dir, max_trials_global)  # type: ignore
+    return _ffi_api.MetaScheduleTuneIRMod(params, work_dir, max_trials_global, max_trials_per_task, op_names)  # type: ignore
 
 
 def DecomposeOpsForInference(func_name: Optional[str] = None) -> tvm.ir.transform.Pass:

--- a/src/relax/transform/meta_schedule.cc
+++ b/src/relax/transform/meta_schedule.cc
@@ -52,9 +52,10 @@ class MetaScheduleTuner {
 
   // TODO(@sunggg): Currently, only supports basic arguments.
   IRModule TuneIRMod(IRModule mod, transform::PassContext ctx) {
-    Choice choice("tvm.meta_schedule.tune_relax",
-                  {params_, target_, work_dir_, max_trials_global_, max_trials_global_, op_names_},
-                  "relax.tuning_api.Choice.default_constr_func", {});
+    Choice choice(
+        "tvm.meta_schedule.tune_relax",
+        {params_, target_, work_dir_, max_trials_global_, max_trials_per_task_, op_names_},
+        "relax.tuning_api.Choice.default_constr_func", {});
     Knob knob("meta_schedule.tune_irmod", {{"0", choice}});
     knob->Apply(mod, "0");
     /*

--- a/src/relax/transform/meta_schedule.cc
+++ b/src/relax/transform/meta_schedule.cc
@@ -28,7 +28,6 @@
 
 #include "../src/meta_schedule/module_equality.h"
 #include "../src/meta_schedule/trace_apply.h"
-#include "tvm/runtime/container/optional.h"
 
 namespace tvm {
 namespace relax {

--- a/tests/python/relax/test_transform_meta_schedule_tuning.py
+++ b/tests/python/relax/test_transform_meta_schedule_tuning.py
@@ -136,7 +136,7 @@ def test_ms_tuning_primfunc():
                 params={},
                 work_dir=work_dir,
                 max_trials_global=4,
-                max_trials_per_task=4,
+                max_trials_per_task=2,
                 op_names=["matmul"],
             )
             tuning_pass(mod)
@@ -144,6 +144,8 @@ def test_ms_tuning_primfunc():
             db = ms.database.JSONDatabase(
                 work_dir + "/database_workload.json", work_dir + "/database_tuning_record.json"
             )
+
+            assert len(db.get_all_tuning_records()) == 2
 
             for rec in db.get_all_tuning_records():
                 assert rec.workload.mod["main"].attrs["global_symbol"] == "tir_matmul"


### PR DESCRIPTION
Currently, `MetaScheduleTuneIRMod` pass only has `max_trials_global` param to control the duration of tuning. Now that we have good BYOC support and `DefaultGPUSchedule` pass, we should add more options to allow more fine-grained tuning. 

For example, in SD UNet, I want to tune only layer and group norm, for small number of trials each. And I don't want to spend any seconds "tuning" trivial ops such as `cast`, `concat` etc. 

To realize these goals, I'm adding `max_trials_per_task` and `op_names` params. The latter is used to select which op to tune. For SD UNet I'd use it like `op_names=["layer_norm", "group_norm"]`.

@sunggg @zxybazh  