### PR TITLE
[Unity][CUTLASS] Add layer norm support

### DIFF
--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name, unused-wildcard-import, wildcard-import
+# pylint: disable=invalid-name
 """Generator for CUTLASS attention kernels."""
-from .library import *
+from .library import substitute_template
 
 
 def instantiate_attention_template(attrs):

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -32,6 +32,7 @@ from . import _ffi_api as ffi
 from .attention_operation import instantiate_attention_template
 from .conv2d_operation import instantiate_conv2d_template
 from .gemm_operation import instantiate_gemm_template
+from .layer_norm_operation import instantiate_layer_norm_template
 from .library import (
     DataType,
     DataTypeSize,
@@ -763,6 +764,13 @@ def instantiate_template(func_name, annotations, func_args):
             # kSupportsBias should be set true, or there are nan's as result.
             attrs["kSupportsBias"] = attrs["scale"] < 0
         code = instantiate_attention_template(attrs)
+        return CodegenResult(code, headers)
+    elif "layer_norm" in func_name:
+        headers.append("cutlass/util/device_layernorm.h")
+        headers.append("cutlass/layout/matrix.h")
+        attrs = {"input": func_args[0], "gamma": func_args[1], "beta": func_args[2]}
+        attrs.update(dict(annotations))
+        code = instantiate_layer_norm_template(attrs)
         return CodegenResult(code, headers)
 
     raise ValueError("Do not have a template for {}".format(func_name))

--- a/python/tvm/contrib/cutlass/layer_norm_operation.py
+++ b/python/tvm/contrib/cutlass/layer_norm_operation.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Generator for CUTLASS layer norm kernels."""
+from .library import substitute_template
+
+
+def instantiate_layer_norm_template(attrs):
+    """
+    Return CUTLASS host code for layer norm based on
+    a template and the provided attribute map.
+    """
+    template = """
+    using data_type = ${data_type};
+    using namespace cutlass::layout;
+
+    auto M = ${M};
+    auto N = ${N};
+    cutlass::MatrixCoord size(M, N);
+    auto layout_2D = RowMajor::packed(size);
+    auto layout_channels = RowMajor::packed({1, N});
+
+    cutlass::TensorRef<data_type, RowMajor> _input((data_type*)${input}->data, layout_2D);
+    cutlass::TensorRef<data_type, RowMajor> _gamma((data_type*)${gamma}->data, layout_channels);
+    cutlass::TensorRef<data_type, RowMajor> _beta((data_type*)${beta}->data, layout_channels);
+    cutlass::TensorRef<data_type, RowMajor> _output((data_type*)out0->data, layout_2D);
+
+    cutlass::layernorm(size, _output, _input, _gamma, _beta, NULL);
+    """
+    return substitute_template(template, attrs)

--- a/python/tvm/relax/backend/patterns.py
+++ b/python/tvm/relax/backend/patterns.py
@@ -252,3 +252,12 @@ def make_stacked_attention_pattern(start_op: str, with_bias: bool = False):
     else:
         out = is_op("relax.nn.attention")(query, key, value)
     return out, annotations
+
+
+def make_layer_norm_pattern():
+    """Create a layer norm pattern."""
+    inp = wildcard()
+    gamma = wildcard()
+    beta = wildcard()
+
+    return is_op("relax.nn.layer_norm")(inp, gamma, beta), {}


### PR DESCRIPTION
Layer norm in SD UNet is expensive and so far we've been using MS tuning for it. CUTLASS has a layer norm kernel which I found to be more than 2x faster than a MS-tuned one on SD workloads.  

@cyx-6 @yelite 