### PR TITLE
[Unity] Fix ForceNarrowIndexToI32 so it ignores i16

### DIFF
--- a/include/tvm/tir/data_type_rewriter.h
+++ b/include/tvm/tir/data_type_rewriter.h
@@ -153,6 +153,9 @@ class IndexDataTypeNormalizer : public IndexDataTypeRewriter {
   PrimExpr VisitExpr_(const VarNode* op) override;
   PrimExpr VisitExpr_(const CastNode* op) override;
 
+  /*! \brief Specifies which data type we can rewrite */
+  virtual bool CanRewriteDType(DataType dtype) const;
+
   DataType target_data_type_ = DataType::Int(64);
 };
 

--- a/src/tir/transforms/force_narrow_index_to_i32.cc
+++ b/src/tir/transforms/force_narrow_index_to_i32.cc
@@ -35,7 +35,7 @@ class Int32DTypeNarrower : public IndexDataTypeNormalizer {
   static PrimFunc RewriteDataType(PrimFunc func) {
     // Check if the integer parameter buffers have dtype other than int32.
     for (auto it : func->buffer_map) {
-      if (it.second->dtype.is_int() && it.second->dtype.bits() != 32) {
+      if (it.second->dtype.is_int() && it.second->dtype.bits() > 32) {
         LOG(FATAL) << "The buffer " << it.second << " in the function buffer map has dtype "
                    << it.second->dtype << ". The function is " << func;
       }
@@ -62,7 +62,7 @@ class Int32DTypeNarrower : public IndexDataTypeNormalizer {
     Block block_ = Downcast<Block>(IndexDataTypeNormalizer::VisitStmt_(block));
     // Check if the allocated integer buffers have dtype other than int32.
     for (const Buffer& buf : block_->alloc_buffers) {
-      if (buf->dtype.is_int() && buf->dtype.bits() != 32) {
+      if (buf->dtype.is_int() && buf->dtype.bits() > 32) {
         LOG(FATAL) << "The buffer " << buf << " allocated in the function has dtype " << buf->dtype
                    << ". The function is " << func_;
       }


### PR DESCRIPTION
This PR fixes the forece narrow to i32 pass so it ignores integer with smaller bitwidth