### PR TITLE
[Uniy][Op] Expand support of attention bias layout

### DIFF
--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -741,11 +741,21 @@ def instantiate_template(func_name, annotations, func_args):
         if "bias" in attrs:
             attrs["kSupportsBias"] = True
             if len(annotations["bias_shape"]) == 4:
-                attrs["bias_layout"] = "BNSS'"
-            elif len(annotations["bias_shape"]) == 3:
-                attrs["bias_layout"] = "B1SS'"
-            elif len(annotations["bias_shape"]) == 2:
-                attrs["bias_layout"] = "B11S'"
+                strides = "p.num_keys"
+                if annotations["bias_shape"][2] == 1:
+                    attrs["bias_strideM"] = 0
+                else:
+                    attrs["bias_strideM"] = strides
+                    strides = f"p.num_queries * {strides}"
+                if annotations["bias_shape"][1] == 1:
+                    attrs["bias_strideH"] = 0
+                else:
+                    attrs["bias_strideH"] = strides
+                    strides = f"p.num_heads * {strides}"
+                if annotations["bias_shape"][0] == 1:
+                    attrs["bias_strideB"] = 0
+                else:
+                    attrs["bias_strideB"] = strides
             else:
                 raise NotImplementedError()
         else:

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -1009,8 +1009,8 @@ def attention(
 
     bias: Optional[Expr]
         The optional attention bias to the operator. The layout of the attention bias should be
-        (batch_size, num_head, seq_len, seq_len_kv),
-        (batch_size, seq_len, seq_len_kv) or (batch_size, seq_len_kv).
+        a 4-D tensor ending with seq_len_kv, and broadcastable to
+        (batch_size, num_head, seq_len, seq_len_kv).
 
     scale: Optional[FloatImm]
         The custom scale applied before the softmax. The default value is 1 / sqrt(head_dim).

--- a/python/tvm/relax/transform/legalize_ops/nn.py
+++ b/python/tvm/relax/transform/legalize_ops/nn.py
@@ -336,10 +336,6 @@ def _te_attention(
         p = topi.divide(p, tir.sqrt(tir.Cast(p.dtype, head_dim)))
     if bias is not None:
         p = topi.reshape(p, [batch_size, num_head, seq_len, seq_len_kv])
-        if len(bias.shape) == 2:
-            bias = topi.reshape(bias, [batch_size, 1, 1, seq_len_kv])
-        elif len(bias.shape) == 3:
-            bias = topi.reshape(bias, [batch_size, 1, seq_len, seq_len_kv])
         p = topi.add(p, bias)
         p = topi.reshape(p, [batch_size * num_head, seq_len, seq_len_kv])
     s = topi.nn.softmax(p)


### PR DESCRIPTION
This PR expands the support of attention bias layout. In the past, we only support 3 types of layout, with `BNSS'`, `BSS'`, `BS'`, e.g. `BNSS'` for (batch_size, num_head, seq_len, seq_len_kv).  However, cutlass accepts 8 types of layout, as long as the shape ends with `S` and is broadcastable to `BNSS'`. So in this PR, we fixed the ndim of `bias` to 4 and accepts all 8 types of layout as cutlass.