### PR TITLE
[TIR] Keep block annotations from tensorization

### DIFF
--- a/src/tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/tir/schedule/primitive/blockize_tensorize.cc
@@ -604,7 +604,7 @@ void Tensorize(ScheduleState self, const StmtSRef& sref, const TensorIntrin& int
     BlockNode* block = block_realize.CopyOnWrite()->block.CopyOnWrite();
     block->body = impl_block->body;
     block->match_buffers = std::move(match_buffer_regions);
-    for (auto [key, val] : impl_block->annotations) {
+    for (const auto& [key, val] : impl_block->annotations) {
       if (block->annotations.count(key) && block->annotations[key] != val) {
         LOG(WARNING) << "Conflict of annotation \"" << key << "\". Tensor intrinsic and schedule "
                      << "has different values : " << block->annotations[key] << " vs " << val << " "


### PR DESCRIPTION
TIR TensorIntrin implementation may contains some annotation. Current logic will skip all existing annotations. But in some cases it may be helpful to transfer annotations to resulting schedule.