### PR TITLE
[bugfix][relay] Fix alpha attribute with None in ELU 

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -160,6 +160,8 @@ def _convert_advanced_activation(inexpr, keras_layer, etab, data_layout, input_s
             raise tvm.error.OpAttributeInvalid("The alpha value of a LeakyReLU cannot be None.")
         return _op.nn.leaky_relu(inexpr, alpha=float(keras_layer.alpha))
     if act_type == "ELU":
+        if np.isnan(keras_layer.alpha).any():
+            raise tvm.error.OpAttributeInvalid("The alpha value of a ELU cannot be None.")
         alpha = keras_layer.alpha if hasattr(keras_layer, "alpha") else 1.0
         alpha = _expr.const(alpha, dtype="float32")
         return _get_elu(inexpr, alpha)

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -214,19 +214,26 @@ class TestKeras:
 
     def test_forward_activations_except(self, keras_mod):
         """
-        test invalid attribute alpha=None for LeakyReLU.
+        test invalid attribute alpha=None for LeakyReLU and ELU.
         after version 2.3.1 in keras, checking was added to reject the invalid api call:
-        LeakyReLU(alpha=None), (issue: https://github.com/tensorflow/tensorflow/pull/47017)
+        LeakyReLU(alpha=None) and ELU(alpha=None),
+        (see issue: https://github.com/tensorflow/tensorflow/pull/47017)
         Thus, it's necessary to check the keras version to avoid crash at LeakyReLU(alpha=None)
+        and ELU(alpha=None)
         """
         if package_version.parse(keras_mod.__version__.split("-tf")[0]) <= package_version.parse(
             "2.3.1"
         ):
+            act_funcs = [
+                keras_mod.layers.LeakyReLU(alpha=None),
+                keras_mod.layers.LEU(2, 3, 4),
+            ]
             data = keras_mod.layers.Input(shape=(2, 3, 4))
-            layer = keras_mod.layers.LeakyReLU(alpha=None)(data)
-            keras_model = keras_mod.models.Model(data, layer)
-            with pytest.raises(tvm.error.OpAttributeInvalid):
-                verify_keras_frontend(keras_model)
+            for act_func in act_funcs:
+                layer = act_func(data)
+                keras_model = keras_mod.models.Model(data, layer)
+                with pytest.raises(tvm.error.OpAttributeInvalid):
+                    verify_keras_frontend(keras_model)
 
     def test_forward_dense(self, keras_mod):
         """test_forward_dense"""


### PR DESCRIPTION
This patch fixes a bug in ELU. when the alpha=None, It will lead to a wrong compilation and give a confusing inference result.
For example, the following script will produce inconsistent inference results between TVM and Keras. However, we hope tvm can reject it immediately in the model loading stage. Because the model is invalid (see Line 210-212 in [keras source code file](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/layers/advanced_activations.py)). 


This PR is a similar fix to the [pr-14707](https://github.com/apache/tvm/pull/14707). pr-14707 fixed a similar bug in  LeakyReLU.

![image](https://user-images.githubusercontent.com/29506758/235206195-1bff01c1-28c1-419e-831b-dfe7b56ecb73.png)

### Reproducible script
```
import tvm
import tvm.relay as relay
import numpy as np
from tensorflow import keras
from tensorflow.keras import layers, models


input_shape = (1, 2, 3, 4)
input_data = np.random.random(input_shape)
x = layers.Input(shape=input_shape[1:], dtype='float32')

layer = keras.layers.ELU(alpha=None)
layer.set_weights(layer.get_weights())

y = layer(x)
model = models.Model(x, y)

res_keras = model.predict(input_data)

shape_dict = {'input_1': input_shape}
mod, params = relay.frontend.from_keras(model, shape_dict)

with tvm.transform.PassContext(opt_level=3):
    model = relay.build_module.create_executor("graph", mod, tvm.cpu(0), 'llvm', params).evaluate()


test_x_tvm = input_data
res_tvm = model(tvm.nd.array(test_x_tvm.astype('float32'))).numpy()

np.testing.assert_allclose(res_keras, res_tvm, atol=1e-3, rtol=1e-3)
```

