### PR TITLE
[Unity][BYOC] Support implicit attention patterns

### DIFF
--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -370,7 +370,7 @@ register_patterns(
     ]
 )
 
-rewrite_patterns = [*attention_rewrite_patterns()]
+_REWRITE_PATTERNS = [*attention_rewrite_patterns()]
 
 
 def partition_for_cutlass(mod, annotate_codegen=True):
@@ -393,7 +393,7 @@ def partition_for_cutlass(mod, annotate_codegen=True):
         The resulting IRModule, containing partitioned subgraphs to be
         compiled by the CUTLASS backend.
     """
-    for pattern, rewriter in rewrite_patterns:
+    for pattern, rewriter in _REWRITE_PATTERNS:
         mod["main"] = rewrite_call(pattern, rewriter, mod["main"])
     patterns = get_patterns_with_prefix("cutlass")
     return transform.FuseOpsByPattern(

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -22,6 +22,7 @@ from typing import Mapping, Sequence
 from tvm.contrib.cutlass.build import is_shape_valid_for_cutlass_matmul
 from tvm.relax import DataflowVar, Var, transform, Call
 from tvm.relax.transform import PatternCheckContext
+from tvm.relax.dpl import rewrite_call
 
 from ..pattern_registry import get_patterns_with_prefix, register_patterns
 from ..patterns import (
@@ -31,6 +32,7 @@ from ..patterns import (
     make_residual_block_pattern,
     make_stacked_attention_pattern,
     make_layer_norm_pattern,
+    make_attention_rewrite_pattern,
 )
 
 
@@ -346,6 +348,18 @@ def layer_norm_pattern():
     ]
 
 
+def attention_rewrite_patterns():
+    """
+    Returns a list of all attention rewriting patterns in cutlass BYOC backend.
+    """
+    patterns = []
+    for qkv_layout in ["BSNH", "BSH"]:
+        for out_layout in ["BSNH", "BSH"]:
+            for with_bias in [True, False]:
+                patterns.append(make_attention_rewrite_pattern(qkv_layout, out_layout, with_bias))
+    return patterns
+
+
 register_patterns(
     [
         *conv2d_patterns(),
@@ -355,6 +369,8 @@ register_patterns(
         *layer_norm_pattern(),
     ]
 )
+
+rewrite_patterns = [*attention_rewrite_patterns()]
 
 
 def partition_for_cutlass(mod, annotate_codegen=True):
@@ -377,7 +393,8 @@ def partition_for_cutlass(mod, annotate_codegen=True):
         The resulting IRModule, containing partitioned subgraphs to be
         compiled by the CUTLASS backend.
     """
-
+    for pattern, rewriter in rewrite_patterns:
+        mod["main"] = rewrite_call(pattern, rewriter, mod["main"])
     patterns = get_patterns_with_prefix("cutlass")
     return transform.FuseOpsByPattern(
         patterns, bind_constants=False, annotate_codegen=annotate_codegen

--- a/python/tvm/relax/backend/patterns.py
+++ b/python/tvm/relax/backend/patterns.py
@@ -17,9 +17,9 @@
 
 """Common patterns used in BYOC"""
 
-from typing import Dict, Mapping, Tuple, Union
-
-from tvm.relax.dpl.pattern import DFPattern, is_op, is_tuple_get_item, wildcard
+from typing import Dict, Mapping, Tuple, Union, Optional
+from tvm.script import relax as R, tir as T
+from tvm.relax.dpl.pattern import DFPattern, is_const, is_op, is_tuple_get_item, wildcard
 
 
 def _with_bias_activation_pattern(
@@ -261,3 +261,146 @@ def make_layer_norm_pattern():
     beta = wildcard()
 
     return is_op("relax.nn.layer_norm")(inp, gamma, beta), {}
+
+
+def make_attention_rewrite_pattern(qkv_layout: str, out_layout: str, with_bias: bool):
+    def handle_input(tensor, layout, transpose):
+        if layout == "BSNH":
+            permuted = is_op("relax.permute_dims")(tensor)
+            shape = wildcard()
+            reshaped = is_op("relax.reshape")(permuted, shape)
+            if transpose:
+                transposed = is_op("relax.permute_dims")(reshaped)
+
+            def rewriter(matchings, x):
+                if matchings[tensor].struct_info.ndim != 4:
+                    return None
+                if list(matchings[permuted].attrs.axes) != [0, 2, 1, 3]:
+                    return None
+                before_reshape = matchings[permuted].struct_info.shape.values
+                after_reshape = matchings[shape].struct_info.values
+                if not (
+                    len(before_reshape) == 4
+                    and len(after_reshape) == 3
+                    and before_reshape[-2:] == after_reshape[-2:]
+                ):
+                    return None
+                if transpose and list(matchings[transposed].attrs.axes) != [0, 2, 1]:
+                    return None
+                return x, x.struct_info.shape
+
+            if transpose:
+                return transposed, rewriter
+            else:
+                return reshaped, rewriter
+        elif layout == "BSH":
+            if transpose:
+                transposed = is_op("relax.permute_dims")(tensor)
+
+            def rewriter(matchings, x):
+                if matchings[tensor].struct_info.ndim != 3:
+                    return None
+                if transpose and list(matchings[transposed].attrs.axes) != [0, 2, 1]:
+                    return None
+                before_reshape = x.struct_info.shape.values
+                after_reshape = [before_reshape[0], before_reshape[1], 1, before_reshape[2]]
+                return R.reshape(x, after_reshape), after_reshape
+
+            if transpose:
+                return transposed, rewriter
+            else:
+                return tensor, rewriter
+        else:
+            raise NotImplementedError()
+
+    def handle_output(tensor, layout):
+        if layout == "BSNH":
+            shape = wildcard()
+            reshaped = is_op("relax.reshape")(tensor, shape)
+            permuted = is_op("relax.permute_dims")(reshaped)
+
+            def rewriter(matchings, x):
+                if matchings[tensor].struct_info.ndim != 3:
+                    return None
+                before_reshape = matchings[tensor].struct_info.shape.values
+                after_reshape = matchings[shape].struct_info.values
+                if not (
+                    len(before_reshape) == 3
+                    and len(after_reshape) == 4
+                    and before_reshape[-2:] == after_reshape[-2:]
+                ):
+                    return None
+                if list(matchings[permuted].attrs.axes) != [0, 2, 1, 3]:
+                    return None
+                return x
+
+            return permuted, rewriter
+        elif layout == "BSH":
+
+            def rewriter(matchings, x):
+                if matchings[tensor].struct_info.ndim != 3:
+                    return None
+                return R.reshape(x, matchings[tensor].struct_info.shape.values)
+
+            return tensor, rewriter
+        else:
+            raise NotImplementedError()
+
+    q_raw, k_raw, v_raw = wildcard(), wildcard(), wildcard()
+    q, q_rewriter = handle_input(q_raw, qkv_layout, False)
+    k, k_rewriter = handle_input(k_raw, qkv_layout, True)
+    v, v_rewriter = handle_input(v_raw, qkv_layout, False)
+    matmul_1 = is_op("relax.matmul")(q, k)
+    scale = is_const()
+    multiply = is_op("relax.multiply")(matmul_1, scale)
+    if with_bias:
+        bias_raw = wildcard()
+        add = is_op("relax.add")(multiply, bias_raw)
+        softmax = is_op("relax.nn.softmax")(add)
+    else:
+        softmax = is_op("relax.nn.softmax")(multiply)
+    matmul_2 = is_op("relax.matmul")(softmax, v)
+    out, out_rewriter = handle_output(matmul_2, out_layout)
+
+    def rewriter(original, matchings):
+        query, query_shape = q_rewriter(matchings, matchings[q_raw])
+        key, key_shape = k_rewriter(matchings, matchings[k_raw])
+        value, _ = v_rewriter(matchings, matchings[v_raw])
+        if query is None or key is None or value is None:
+            return original
+        if matchings[softmax].attrs.axis != -1:
+            return original
+        b, s, n, _ = query_shape
+        _, s_kv, _, _ = key_shape
+        if with_bias:
+            bias = matchings[bias_raw]
+            bias_shape = list(bias.struct_info.shape)
+            if bias_shape == [b * n, s, s_kv]:
+                bias = R.reshape(bias, [b, n, s, s_kv])
+            elif bias_shape == [b * n, 1, s_kv]:
+                bias = R.reshape(bias, [b, n, 1, s_kv])
+            elif bias_shape == [b, s, s_kv]:
+                bias = R.reshape(bias, [b, 1, s, s_kv])
+            elif bias_shape == [b, 1, s_kv]:
+                bias = R.reshape(bias, [b, 1, 1, s_kv])
+            elif bias_shape in [[1, s, s_kv], [s, s_kv]]:
+                bias = R.reshape(bias, [1, 1, s, s_kv])
+            elif bias_shape in [[1, 1, s_kv], [1, s_kv], [s_kv]]:
+                bias = R.reshape(bias, [1, 1, 1, s_kv])
+            else:
+                return original
+        else:
+            bias = None
+        out = out_rewriter(
+            matchings,
+            R.nn.attention(
+                query,
+                key,
+                value,
+                bias,
+                T.FloatImm(matchings[scale].data.dtype, float(matchings[scale].data.numpy())),
+            ),
+        )
+        return out
+
+    return out, rewriter


### PR DESCRIPTION
In this PR, we add the support for the implicit attention pattern matching in BYOC. By adding a rewriting stage before `FuseOpsByPattern` , we are able to match and rewrite the patterns like `matmul - softmax - matmul` to `R.nn.attention` with other operators needed.

cc: @masahi @yelite 