### PR TITLE
[CUDA] Fixed the call of the min function in the schedule for cuda

### DIFF
--- a/python/tvm/topi/cuda/scatter.py
+++ b/python/tvm/topi/cuda/scatter.py
@@ -227,8 +227,8 @@ def scatter_nd(data, indices, updates, mode):
             fused_shape *= i
 
         max_threads = int(tvm.target.Target.current(allow_none=False).max_num_threads)
-        tdim = min(max_threads, fused_updates_dimension)
 
+        tdim = tvm.tir.min(max_threads, fused_updates_dimension)
         with ib.new_scope():
             bdim = ceil_div(fused_shape, tdim)
             bx = te.thread_axis("blockIdx.x")

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -2149,6 +2149,29 @@ def test_scatter_nd():
 
 
 @tvm.testing.uses_gpu
+def test_scatter_nd_any_updates():
+    def verify_scatter_nd_any_updates(data_np, indices_np, updates_np, ref_res):
+        indices_shape = (2, relay.Any())
+        updates_shape = (relay.Any(), relay.Any())
+        data = relay.var("data", shape=data_np.shape, dtype=str(data_np.dtype))
+        indices = relay.var("indices", relay.TensorType(indices_shape, str(indices_np.dtype)))
+        updates = relay.var("updates", relay.TensorType(updates_shape, str(updates_np.dtype)))
+
+        out = relay.op.scatter_nd(data, indices, updates, "add")
+
+        mod = tvm.IRModule()
+        mod["main"] = relay.Function([data, indices, updates], out)
+
+        check_result([data_np, indices_np, updates_np], mod, [ref_res])
+
+    data = np.zeros((3, 3)).astype("int64")
+    indices = np.array([[1, 1, 2, 1], [0, 1, 2, 1]])
+    updates = np.array([[2, 3], [1, 1]])
+    out = np.array([[0, 0, 0], [0, 0, 0], [2, 3, 1]])
+    verify_scatter_nd_any_updates(data, indices, updates, out)
+
+
+@tvm.testing.uses_gpu
 def test_gather():
     def verify_gather(data_shape, indices_shape, data_shape_np, indices_shape_np, axis):
         x = relay.var("x", relay.TensorType(data_shape, "float32"))

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -59,6 +59,7 @@ def check_result(
                 continue
             if kind == "debug" and (only_vm or dev.device_type != tvm.cpu().device_type):
                 continue
+            print(tgt)
             result = relay.create_executor(kind, mod=mod, device=dev, target=tgt).evaluate()(*args)
             if isinstance(result, tvm.runtime.container.ADT):
                 result = [r.numpy() for r in result]
@@ -2152,7 +2153,7 @@ def test_scatter_nd():
 def test_scatter_nd_any_updates():
     def verify_scatter_nd_any_updates(data_np, indices_np, updates_np, ref_res):
         indices_shape = (2, relay.Any())
-        updates_shape = (relay.Any(), relay.Any())
+        updates_shape = (2, relay.Any())
         data = relay.var("data", shape=data_np.shape, dtype=str(data_np.dtype))
         indices = relay.var("indices", relay.TensorType(indices_shape, str(indices_np.dtype)))
         updates = relay.var("updates", relay.TensorType(updates_shape, str(updates_np.dtype)))
@@ -2163,13 +2164,13 @@ def test_scatter_nd_any_updates():
         mod["main"] = relay.Function([data, indices, updates], out)
 
         check_result(
-            [data_np, indices_np, updates_np], mod, [ref_res], targets=[('cuda', tvm.cuda(0))]
+            [data_np, indices_np, updates_np], mod, [ref_res], only_vm=True
         )
 
     data = np.zeros((3, 3)).astype("int64")
-    indices = np.array([[1, 1, 2, 1], [0, 1, 2, 1]])
-    updates = np.array([[2, 3], [1, 1]])
-    out = np.array([[0, 0, 0], [0, 0, 0], [2, 3, 1]])
+    indices = np.array([[1, 1], [0, 1]])
+    updates = np.array([[2, 2], [1, 1]])
+    out = np.array([[0, 0, 0], [0, 0, 0], [2, 2, 1]])
     verify_scatter_nd_any_updates(data, indices, updates, out)
 
 

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -2163,9 +2163,7 @@ def test_scatter_nd_any_updates():
         mod = tvm.IRModule()
         mod["main"] = relay.Function([data, indices, updates], out)
 
-        check_result(
-            [data_np, indices_np, updates_np], mod, [ref_res], only_vm=True
-        )
+        check_result([data_np, indices_np, updates_np], mod, [ref_res], only_vm=True)
 
     data = np.zeros((3, 3)).astype("int64")
     indices = np.array([[1, 1], [0, 1]])

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -59,7 +59,6 @@ def check_result(
                 continue
             if kind == "debug" and (only_vm or dev.device_type != tvm.cpu().device_type):
                 continue
-            print(tgt)
             result = relay.create_executor(kind, mod=mod, device=dev, target=tgt).evaluate()(*args)
             if isinstance(result, tvm.runtime.container.ADT):
                 result = [r.numpy() for r in result]

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -2162,7 +2162,9 @@ def test_scatter_nd_any_updates():
         mod = tvm.IRModule()
         mod["main"] = relay.Function([data, indices, updates], out)
 
-        check_result([data_np, indices_np, updates_np], mod, [ref_res], targets=[('cuda', tvm.cuda(0))])
+        check_result(
+            [data_np, indices_np, updates_np], mod, [ref_res], targets=[('cuda', tvm.cuda(0))]
+        )
 
     data = np.zeros((3, 3)).astype("int64")
     indices = np.array([[1, 1, 2, 1], [0, 1, 2, 1]])

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -2162,7 +2162,7 @@ def test_scatter_nd_any_updates():
         mod = tvm.IRModule()
         mod["main"] = relay.Function([data, indices, updates], out)
 
-        check_result([data_np, indices_np, updates_np], mod, [ref_res])
+        check_result([data_np, indices_np, updates_np], mod, [ref_res], targets=[('cuda', tvm.cuda(0))])
 
     data = np.zeros((3, 3)).astype("int64")
     indices = np.array([[1, 1, 2, 1], [0, 1, 2, 1]])


### PR DESCRIPTION
When using a scatter layer for cuda target, it gives the following error:

`ValueError: Cannot use and / or / not operator to Expr, hint: use tvm.tir.all / tvm.tir.any instead`


This is due to the call to the min function here:
https://github.com/apache/tvm/blob/d32dea800baeda14d144d0524a5da435c9cb160b/python/tvm/topi/cuda/scatter.py#L228-L231

This PR fixes this bug