### PR TITLE
[Unity][VM] `kill_tensor` and `kill_storage` releasing NDArray in VM at runtime

### DIFF
--- a/include/tvm/runtime/relax_vm/bytecode.h
+++ b/include/tvm/runtime/relax_vm/bytecode.h
@@ -80,7 +80,7 @@ struct Instruction {
   static constexpr ExecWord kValueMaxLimit = (static_cast<ExecWord>(1) << (kValueBit - 1)) - 1;
   /*! \brief Minimum possible value, remove 1 slot to keep things symmetric. */
   static constexpr ExecWord kValueMinLimit = -kValueMaxLimit;
-  /*! \brief Begining of special register section. */
+  /*! \brief Beginning of special register section. */
   static constexpr RegName kBeginSpecialReg = static_cast<ExecWord>(1) << 54;
   /*! \brief Random magic number that represents void argument, indicate null value */
   static constexpr RegName kVoidRegister = kBeginSpecialReg + 0;
@@ -127,7 +127,7 @@ struct Instruction {
      */
     static Arg FuncIdx(Index index) { return Arg(ArgKind::kFuncIdx, index); }
     /*!
-     * \brief Get the kind of argument..
+     * \brief Get the kind of argument.
      * \return The kind of argument.
      */
     ArgKind kind() const {

--- a/python/tvm/relax/op/vm/vm.py
+++ b/python/tvm/relax/op/vm/vm.py
@@ -86,6 +86,23 @@ def alloc_tensor(
     return _ffi_api.alloc_tensor(storage, offset, shape, dtype)  # type: ignore
 
 
+def kill_object(obj: Expr) -> Call:
+    """Construct a Call to set the register corresponding to the input object to
+    null at runtime, in order to kill the input object.
+
+    Parameters
+    ----------
+    obj : Expr
+        The object to be killed.
+
+    Returns
+    -------
+    result : Call
+        CallNode that kills the input object.
+    """
+    return _ffi_api.kill_object(obj)  # type: ignore
+
+
 @args_converter.auto
 def call_tir_dyn(func: Expr, args: Tuple) -> Call:
     """Construct a Call to call_tir_dyn (invoke the given TIR PrimFunc)

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -526,6 +526,20 @@ Expr MakeVMAllocTensor(Expr storage, PrimValue offset, Expr shape, DataTypeImm d
 
 TVM_REGISTER_GLOBAL("relax.op.vm.alloc_tensor").set_body_typed(MakeVMAllocTensor);
 
+// vm kill_object
+
+TVM_REGISTER_OP("relax.vm.kill_object")
+    .set_num_inputs(1)
+    .add_argument("obj", "Expr", "The object to be killed.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", ReturnVoidStructInfo);
+
+Expr MakeVMKillObject(Expr obj) {
+  static const Op& op = Op::Get("relax.vm.kill_object");
+  return Call(op, {std::move(obj)}, Attrs(), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.vm.kill_object").set_body_typed(MakeVMKillObject);
+
 // vm call_tir_dyn
 
 RELAY_REGISTER_OP("relax.vm.call_tir_dyn")

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -53,7 +53,7 @@ NDArray AllocShapeHeap(void* ctx_ptr, int64_t size) {
   VirtualMachine* vm = static_cast<VirtualMachine*>(ctx_ptr);
   // use host allocator, which is always last element.
   size_t host_device_index = vm->devices.size() - 1;
-  // specialy handle hexagon on-device RT.
+  // specially handle hexagon on-device RT.
   // TODO(relax-team): visit and consider other possible choices.
   if (vm->devices[0].device_type == kDLHexagon) {
     host_device_index = 0;
@@ -323,6 +323,11 @@ TVM_REGISTER_GLOBAL("vm.builtin.copy").set_body([](TVMArgs args, TVMRetValue* rv
 
 TVM_REGISTER_GLOBAL("vm.builtin.reshape").set_body_typed([](NDArray data, ShapeTuple new_shape) {
   return data.CreateView(new_shape, data->dtype);
+});
+
+TVM_REGISTER_GLOBAL("vm.builtin.null_value").set_body([](TVMArgs args, TVMRetValue* rv) {
+  CHECK_EQ(args.size(), 0);
+  *rv = nullptr;
 });
 
 /*!

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -327,7 +327,7 @@ class VirtualMachineImpl : public VirtualMachine {
     } else {
       ICHECK_EQ(reg, Instruction::kVMRegister);
       // per convention, ctx ptr must be VirtualMachine* casted to void.
-      // this and VirtualMachine* may or maynot be the same
+      // this and VirtualMachine* may or may not be the same
       // do first cast to VirtualMachine* then to void*
       ret = static_cast<void*>(static_cast<VirtualMachine*>(this));
     }
@@ -870,7 +870,7 @@ void VirtualMachineImpl::RunLoop() {
   VMFrame* curr_frame = frames_.back().get();
 
   while (true) {
-    ICHECK_LT(static_cast<size_t>(pc_), exec_->instr_offset.size()) << "run into invalide section";
+    ICHECK_LT(static_cast<size_t>(pc_), exec_->instr_offset.size()) << "run into invalid section";
     Instruction instr = exec_->GetInstruction(pc_);
     switch (instr.op) {
       case Opcode::Call: {
@@ -1005,7 +1005,7 @@ class VirtualMachineProfiler : public VirtualMachineImpl {
       std::unordered_map<std::string, ObjectRef> metrics;
       metrics["Argument Shapes"] = profiling::ShapeString(arrs);
 
-      // If a sutiable device is found, enable profiling.
+      // If a suitable device is found, enable profiling.
       if (dev) {
         profiling = true;
         prof_->StartCall(f_name, *dev, metrics);

--- a/tests/python/relax/test_op_misc.py
+++ b/tests/python/relax/test_op_misc.py
@@ -112,6 +112,14 @@ def test_vm_alloc_tensor_infer_struct_info():
     tvm.ir.assert_structural_equal(ret.struct_info, R.Tensor(dtype="float32", ndim=3))
 
 
+def test_vm_kill_object():
+    bb = rx.BlockBuilder()
+    storage = rx.Var("storage", rx.TensorStructInfo(dtype="float32"))
+    kill = rx.op.vm.kill_object(storage)
+    ret = bb.normalize(kill)
+    tvm.ir.assert_structural_equal(ret.struct_info, R.Tuple([]))
+
+
 def test_builtin_stop_lift_params():
     bb = rx.BlockBuilder()
     x = rx.Var("x", rx.TensorStructInfo(shape=[4, 5], dtype="float32"))

--- a/tests/python/relax/test_transform_static_plan_block_memory.py
+++ b/tests/python/relax/test_transform_static_plan_block_memory.py
@@ -125,10 +125,69 @@ def test_basic():
             _11: R.Tuple() = R.memory.kill_storage(storage)
             _10: R.Tuple() = R.memory.kill_storage(storage1)
             return gv5
+
+    @I.ir_module
+    class ExpectedLowered:
+        @T.prim_func
+        def add(rxplaceholder: T.Buffer((T.int64(8),), "float32"), rxplaceholder_1: T.Buffer((), "float32"), T_add: T.Buffer((T.int64(8),), "float32")):
+            T.evaluate(0)
+
+        @T.prim_func
+        def exp(rxplaceholder: T.Buffer((T.int64(2), T.int64(4)), "float32"), compute: T.Buffer((T.int64(2), T.int64(4)), "float32")):
+            T.evaluate(0)
+
+        @T.prim_func
+        def log(rxplaceholder: T.Buffer((T.int64(10),), "float32"), compute: T.Buffer((T.int64(10),), "float32")):
+            T.evaluate(0)
+
+        @T.prim_func
+        def pad(rxplaceholder: T.Buffer((T.int64(8),), "float32"), PadInput: T.Buffer((T.int64(10),), "float32")):
+            T.evaluate(0)
+
+        @T.prim_func
+        def relu(rxplaceholder: T.Buffer((T.int64(8),), "float32"), compute: T.Buffer((T.int64(8),), "float32")):
+            T.evaluate(0)
+
+        @T.prim_func
+        def reshape(rxplaceholder: T.Buffer((T.int64(2), T.int64(4)), "float32"), T_reshape: T.Buffer((T.int64(8),), "float32")):
+            T.evaluate(0)
+
+        @R.function
+        def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
+            cls = ExpectedLowered
+            storage: R.Object = R.vm.alloc_storage(R.shape([32]), R.prim_value(0), R.dtype("float32"))
+            alloc: R.Tensor((2, 4), dtype="float32") = R.vm.alloc_tensor(storage, R.prim_value(0), R.shape([2, 4]), R.dtype("float32"))
+            _: R.Tuple = cls.exp(x, alloc)
+            lv: R.Tensor((2, 4), dtype="float32") = alloc
+            lv1: R.Tensor((8,), dtype="float32") = R.call_packed("vm.builtin.reshape", lv, R.shape([8]), sinfo_args=(R.Tensor((8,), dtype="float32"),))
+            storage1: R.Object = R.vm.alloc_storage(R.shape([40]), R.prim_value(0), R.dtype("float32"))
+            alloc1: R.Tensor((8,), dtype="float32") = R.vm.alloc_tensor(storage1, R.prim_value(0), R.shape([8]), R.dtype("float32"))
+            _1: R.Tuple = cls.relu(lv1, alloc1)
+            __1: R.Tuple = R.vm.kill_object(alloc)
+            _1_1: R.Tuple = R.vm.kill_object(lv1)
+            lv2: R.Tensor((8,), dtype="float32") = alloc1
+            alloc2: R.Tensor((8,), dtype="float32") = R.vm.alloc_tensor(storage, R.prim_value(0), R.shape([8]), R.dtype("float32"))
+            _2: R.Tuple = cls.add(lv2, R.const(1, "float32"), alloc2)
+            _2_1: R.Tuple = R.vm.kill_object(alloc1)
+            lv3: R.Tensor((8,), dtype="float32") = alloc2
+            alloc3: R.Tensor((10,), dtype="float32") = R.vm.alloc_tensor(storage1, R.prim_value(0), R.shape([10]), R.dtype("float32"))
+            _3: R.Tuple = cls.pad(lv3, alloc3)
+            _3_1: R.Tuple = R.vm.kill_object(alloc2)
+            lv4: R.Tensor((10,), dtype="float32") = alloc3
+            storage_1: R.Object = R.vm.alloc_storage(R.shape([40]), R.prim_value(0), R.dtype("float32"))
+            alloc4: R.Tensor((10,), dtype="float32") = R.vm.alloc_tensor(storage_1, R.prim_value(0), R.shape([10]), R.dtype("float32"))
+            _4: R.Tuple = cls.log(lv4, alloc4)
+            _4_1: R.Tuple = R.vm.kill_object(alloc3)
+            gv: R.Tensor((10,), dtype="float32") = alloc4
+            _5: R.Tuple = R.vm.kill_object(storage)
+            _6: R.Tuple = R.vm.kill_object(storage1)
+            return gv
     # fmt: on
 
     mod = relax.transform.StaticPlanBlockMemory()(Module)
     tvm.ir.assert_structural_equal(mod, Expected)
+    mod = relax.transform.VMBuiltinLower()(mod)
+    tvm.ir.assert_structural_equal(mod, ExpectedLowered)
 
 
 def test_different_dtype():

--- a/tests/python/relax/test_vm_codegen_only.py
+++ b/tests/python/relax/test_vm_codegen_only.py
@@ -25,6 +25,7 @@ import tvm.testing
 from tvm import relax
 from tvm.relax.testing.runtime_builtin import MakeShapeCode, MatchShapeCode
 from tvm.relax.testing.vm import check_saved_func
+from tvm.script import ir as I
 from tvm.script import relax as R
 from tvm.script import tir as T
 
@@ -329,6 +330,70 @@ def test_vm_builtin_reshape(exec_mode):
     res = vm["main"](input)
     expected = input_np.reshape(6, 2)
     tvm.testing.assert_allclose(res.numpy(), expected, rtol=1e-7, atol=1e-7)
+
+
+@pytest.mark.parametrize("exec_mode", EXEC_MODE)
+def test_vm_kill_object(exec_mode):
+    @I.ir_module
+    class TestKillObject:
+        @T.prim_func
+        def full(T_full: T.Buffer((T.int64(4),), "float32")):
+            T.func_attr({"global_symbol": "full", "tir.noalias": T.bool(True)})
+            for ax0 in range(T.int64(4)):
+                with T.block("T_full"):
+                    v_ax0 = T.axis.spatial(T.int64(4), ax0)
+                    T.reads()
+                    T.writes(T_full[v_ax0])
+                    T_full[v_ax0] = T.float32(0)
+
+        @T.prim_func
+        def full1(T_full: T.Buffer((T.int64(4),), "float32")):
+            T.func_attr({"global_symbol": "full1", "tir.noalias": T.bool(True)})
+            for ax0 in range(T.int64(4)):
+                with T.block("T_full"):
+                    v_ax0 = T.axis.spatial(T.int64(4), ax0)
+                    T.reads()
+                    T.writes(T_full[v_ax0])
+                    T_full[v_ax0] = T.float32(1)
+
+        @R.function
+        def main() -> R.Tensor((4,), dtype="float32"):
+            R.func_attr({"global_symbol": "main"})
+            cls = TestKillObject
+            storage: R.Object = R.vm.alloc_storage(
+                R.shape([16]), R.prim_value(0), R.dtype("float32")
+            )
+            alloc: R.Tensor((4,), dtype="float32") = R.vm.alloc_tensor(
+                storage, R.prim_value(0), R.shape([4]), R.dtype("float32")
+            )
+            _: R.Tuple = cls.full(alloc)
+            __1: R.Tuple = R.vm.kill_object(alloc)
+            x: R.Tensor((4,), dtype="float32") = alloc
+            alloc1: R.Tensor((4,), dtype="float32") = R.vm.alloc_tensor(
+                storage, R.prim_value(0), R.shape([4]), R.dtype("float32")
+            )
+            _1: R.Tuple = cls.full(alloc1)
+            _1_1: R.Tuple = R.vm.kill_object(alloc1)
+            y: R.Tensor((4,), dtype="float32") = alloc1
+            storage_1: R.Object = R.vm.alloc_storage(
+                R.shape([16]), R.prim_value(0), R.dtype("float32")
+            )
+            alloc2: R.Tensor((4,), dtype="float32") = R.vm.alloc_tensor(
+                storage_1, R.prim_value(0), R.shape([4]), R.dtype("float32")
+            )
+            _2: R.Tuple = cls.full1(alloc2)
+            z: R.Tensor((4,), dtype="float32") = alloc2
+            _2_1: R.Tuple = R.vm.kill_object(storage)
+            return z
+
+    mod = TestKillObject
+    target = tvm.target.Target("llvm", host="llvm")
+    ex = codegen(mod, target, exec_mode)
+    dev = tvm.cpu()
+    vm = relax.VirtualMachine(ex, dev)
+
+    res = vm["main"]()
+    tvm.testing.assert_allclose(res.numpy(), np.ones((4,), "float32"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR lowers `memory.kill_tensor` and `memory.kill_storage` ops to a runtime function "`kill_object`" that releases the corresponding NDArray of the "tensor" and "storage" in VM at runtime.

Previously these two ops are just ignored and skipped in VMBuiltinLower, and the "kills" didn't take effect. This PR supports the "real kill" so that the VM will release the NDArrays upon kill, and get better memory management for us.