### PR TITLE
[Unity] Fix FX translator no output issue

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1255,7 +1255,8 @@ class TorchFXImporter:
                                 output = []
                                 for ret in args[0]:
                                     output.append(self.block_builder.emit_output(ret))
-                        else:
+
+                        if output is None:
                             output = self.block_builder.emit_output(args[0])
                         break
                     elif node.op == "get_attr":


### PR DESCRIPTION
PR 14639 introduces the `no_bind_return_tuple` flag to FX translator. That PR fails two unit tests in `test_frontend_dynamo.py`. This failure is not revealed in CI because CI doesn't yet have torch dynamo and does not test the file.

This PR fixes the issue. The tests can now pass at my local side.