### PR TITLE
[Vulkan] Add `VK_NV_cooperative_matrix` support

### DIFF
--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -797,7 +797,7 @@ TVM_DLL const Op& start_profile_intrinsic();
  */
 TVM_DLL const Op& end_profile_intrinsic();
 
-// Intrinsics for the VK_NV_cooperative_matrix Vulkan extention.
+// Intrinsics for the VK_NV_cooperative_matrix Vulkan extension.
 
 /*! \brief The intrinsic corresponding to the OpCooperativeMatrixLoadNV instruction. */
 TVM_DLL const Op& cooperative_matrix_load_NV();
@@ -808,7 +808,7 @@ TVM_DLL const Op& cooperative_matrix_store_NV();
 /*!
  * \brief Create a new cooperative matrix filled with the provided value.
  *
- * There is no such instruction in the extention, but it is added for convenience.
+ * There is no such instruction in the extension, but it is added for convenience.
  */
 TVM_DLL const Op& cooperative_matrix_fill_NV();
 

--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -797,9 +797,22 @@ TVM_DLL const Op& start_profile_intrinsic();
  */
 TVM_DLL const Op& end_profile_intrinsic();
 
+// Intrinsics for the VK_NV_cooperative_matrix Vulkan extention.
+
+/*! \brief The intrinsic corresponding to the OpCooperativeMatrixLoadNV instruction. */
 TVM_DLL const Op& cooperative_matrix_load_NV();
+
+/*! \brief The intrinsic corresponding to the OpCooperativeMatrixStoreNV instruction. */
 TVM_DLL const Op& cooperative_matrix_store_NV();
+
+/*!
+ * \brief Create a new cooperative matrix filled with the provided value.
+ *
+ * There is no such instruction in the extention, but it is added for convenience.
+ */
 TVM_DLL const Op& cooperative_matrix_fill_NV();
+
+/*! \brief The intrinsic corresponding to the OpCooperativeMatrixMulAddNV instruction. */
 TVM_DLL const Op& cooperative_matrix_mad_NV();
 
 /*! \brief The kind of structure field info used in intrinsic */

--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -797,6 +797,11 @@ TVM_DLL const Op& start_profile_intrinsic();
  */
 TVM_DLL const Op& end_profile_intrinsic();
 
+TVM_DLL const Op& cooperative_matrix_load_NV();
+TVM_DLL const Op& cooperative_matrix_store_NV();
+TVM_DLL const Op& cooperative_matrix_fill_NV();
+TVM_DLL const Op& cooperative_matrix_mad_NV();
+
 /*! \brief The kind of structure field info used in intrinsic */
 enum TVMStructFieldKind : int {
   // array head address

--- a/python/tvm/script/ir_builder/tir/ir.py
+++ b/python/tvm/script/ir_builder/tir/ir.py
@@ -1820,6 +1820,10 @@ TVMBackendAllocWorkspace = _op_wrapper(_tir_op.TVMBackendAllocWorkspace)
 TVMBackendFreeWorkspace = _op_wrapper(_tir_op.TVMBackendFreeWorkspace)
 start_profile_intrinsic = _op_wrapper(_tir_op.start_profile_intrinsic)
 end_profile_intrinsic = _op_wrapper(_tir_op.end_profile_intrinsic)
+cooperative_matrix_load_NV = _op_wrapper(_tir_op.cooperative_matrix_load_NV)
+cooperative_matrix_store_NV = _op_wrapper(_tir_op.cooperative_matrix_store_NV)
+cooperative_matrix_fill_NV = _op_wrapper(_tir_op.cooperative_matrix_fill_NV)
+cooperative_matrix_mad_NV = _op_wrapper(_tir_op.cooperative_matrix_mad_NV)
 
 
 def _dtype_forward(func):
@@ -2144,4 +2148,8 @@ __all__ = [
     "IterVar",
     "CommReducer",
     "Range",
+    "cooperative_matrix_load_NV",
+    "cooperative_matrix_store_NV",
+    "cooperative_matrix_fill_NV",
+    "cooperative_matrix_mad_NV",
 ]

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -3061,7 +3061,7 @@ def cooperative_matrix_load_NV(buffer_mat, offset, src, rows, cols, stride, colu
         The number of columns in the matrix.
 
     stride: Expr
-        The stride of the matrix.
+        The stride of the matrix in the number of elements.
 
     column_major: bool
         Whether the matrix elements are stored in the column-major order.
@@ -3099,7 +3099,7 @@ def cooperative_matrix_store_NV(dst, buffer_mat, offset, stride, column_major):
         The element offset for the matrix to be stored in the destination buffer.
 
     stride: Expr
-        The stride of the matrix.
+        The stride of the matrix in the number of elements.
 
     column_major: bool
         Whether the matrix elements are stored in the column-major order.

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -3037,20 +3037,20 @@ def TVMBackendFreeWorkspace(device_type, device_id, ptr):
     return call_intrin("int32", "tir.TVMBackendFreeWorkspace", device_type, device_id, ptr)
 
 
-def cooperative_matrix_load_NV():
-     return call_intrin("handle", "tir.cooperative_matrix_load_NV")
+def cooperative_matrix_load_NV(mat, src, stdride, column_major):
+     return call_intrin("handle", "tir.cooperative_matrix_load_NV", mat, src, stdride, column_major)
 
 
-def cooperative_matrix_store_NV():
-     return call_intrin("handle", "tir.cooperative_matrix_store_NV")
+def cooperative_matrix_store_NV(dst, mat, stride, column_major):
+     return call_intrin("handle", "tir.cooperative_matrix_store_NV", dst, mat, stride, column_major)
 
 
-def cooperative_matrix_fill_NV():
-     return call_intrin("handle", "tir.cooperative_matrix_fill_NV")
+def cooperative_matrix_fill_NV(mat, v):
+     return call_intrin("handle", "tir.cooperative_matrix_fill_NV", mat, v)
 
 
-def cooperative_matrix_mad_NV():
-     return call_intrin("handle", "tir.cooperative_matrix_mad_NV")
+def cooperative_matrix_mad_NV(A, B, C):
+     return call_intrin("handle", "tir.cooperative_matrix_mad_NV", A, B, C)
 
 
 # pylint: disable=unnecessary-lambda

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -3037,7 +3037,7 @@ def TVMBackendFreeWorkspace(device_type, device_id, ptr):
     return call_intrin("int32", "tir.TVMBackendFreeWorkspace", device_type, device_id, ptr)
 
 
-# Intrinsics for the VK_NV_cooperative_matrix Vulkan extention.
+# Intrinsics for the VK_NV_cooperative_matrix Vulkan extension.
 
 
 def cooperative_matrix_load_NV(buffer_mat, offset, src, rows, cols, stride, column_major):
@@ -3117,7 +3117,7 @@ def cooperative_matrix_store_NV(dst, buffer_mat, offset, stride, column_major):
 def cooperative_matrix_fill_NV(buffer_mat, offset, rows, cols, value):
     """Create a new cooperative matrix filled with the provided value.
 
-    There is no such instruction in the extention, but it is added for convenience.
+    There is no such instruction in the extension, but it is added for convenience.
 
     Parameters
     ----------

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -3049,8 +3049,8 @@ def cooperative_matrix_fill_NV(mat, offset, v):
      return call_intrin("handle", "tir.cooperative_matrix_fill_NV", mat, offset, v)
 
 
-def cooperative_matrix_mad_NV(A, B, C):
-     return call_intrin("handle", "tir.cooperative_matrix_mad_NV", A, B, C)
+def cooperative_matrix_mad_NV(A, A_off, B, B_off, C, C_off):
+     return call_intrin("handle", "tir.cooperative_matrix_mad_NV", A, A_off, B, B_off, C, C_off)
 
 
 # pylint: disable=unnecessary-lambda

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -3037,6 +3037,22 @@ def TVMBackendFreeWorkspace(device_type, device_id, ptr):
     return call_intrin("int32", "tir.TVMBackendFreeWorkspace", device_type, device_id, ptr)
 
 
+def cooperative_matrix_load_NV():
+     return call_intrin("handle", "tir.cooperative_matrix_load_NV")
+
+
+def cooperative_matrix_store_NV():
+     return call_intrin("handle", "tir.cooperative_matrix_store_NV")
+
+
+def cooperative_matrix_fill_NV():
+     return call_intrin("handle", "tir.cooperative_matrix_fill_NV")
+
+
+def cooperative_matrix_mad_NV():
+     return call_intrin("handle", "tir.cooperative_matrix_mad_NV")
+
+
 # pylint: disable=unnecessary-lambda
 sum = comm_reducer(lambda x, y: x + y, lambda t: const(0, dtype=t), name="sum")
 min = comm_reducer(lambda x, y: _ffi_api._OpMin(x, y, None), max_value, name="min")  # type: ignore

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -3037,20 +3037,146 @@ def TVMBackendFreeWorkspace(device_type, device_id, ptr):
     return call_intrin("int32", "tir.TVMBackendFreeWorkspace", device_type, device_id, ptr)
 
 
-def cooperative_matrix_load_NV(mat, offset, src, rows, cols, stride, column_major):
-     return call_intrin("handle", "tir.cooperative_matrix_load_NV", mat, offset, src, rows, cols, stride, column_major)
+# Intrinsics for the VK_NV_cooperative_matrix Vulkan extention.
 
 
-def cooperative_matrix_store_NV(dst, mat, offset, stride, column_major):
-     return call_intrin("handle", "tir.cooperative_matrix_store_NV", dst, mat, offset, stride, column_major)
+def cooperative_matrix_load_NV(buffer_mat, offset, src, rows, cols, stride, column_major):
+    """The intrinsic corresponding to the OpCooperativeMatrixLoadNV instruction.
+
+    Parameters
+    ----------
+    buffer_mat: Var
+        The destination buffer with "cooperative_matrix_nv" scope.
+
+    offset: IntImm
+        The element offset for the matrix to be loaded in the destination buffer.
+
+    src: Expr
+        The source pointer expression.
+
+    rows: int
+        The number of rows in the matrix.
+
+    cols: int
+        The number of columns in the matrix.
+
+    stride: Expr
+        The stride of the matrix.
+
+    column_major: bool
+        Whether the matrix elements are stored in the column-major order.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin(
+        "handle",
+        "tir.cooperative_matrix_load_NV",
+        buffer_mat,
+        offset,
+        src,
+        rows,
+        cols,
+        stride,
+        column_major,
+    )
 
 
-def cooperative_matrix_fill_NV(mat, offset, rows, cols, v):
-     return call_intrin("handle", "tir.cooperative_matrix_fill_NV", mat, offset, rows, cols, v)
+def cooperative_matrix_store_NV(dst, buffer_mat, offset, stride, column_major):
+    """The intrinsic corresponding to the OpCooperativeMatrixStoreNV instruction.
+
+    Parameters
+    ----------
+    dst: Expr
+        The destination pointer expression.
+
+    buffer_mat: Var
+        The source buffer with "cooperative_matrix_nv" scope.
+
+    offset: IntImm
+        The element offset for the matrix to be stored in the destination buffer.
+
+    stride: Expr
+        The stride of the matrix.
+
+    column_major: bool
+        Whether the matrix elements are stored in the column-major order.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin(
+        "handle", "tir.cooperative_matrix_store_NV", dst, buffer_mat, offset, stride, column_major
+    )
+
+
+def cooperative_matrix_fill_NV(buffer_mat, offset, rows, cols, value):
+    """Create a new cooperative matrix filled with the provided value.
+
+    There is no such instruction in the extention, but it is added for convenience.
+
+    Parameters
+    ----------
+
+    buffer_mat: Var
+        The buffer with "cooperative_matrix_nv" scope to be filled.
+
+    offset: IntImm
+        The element offset for the matrix to be filled in `buffer_mat`.
+
+    rows: int
+        The number of rows in the matrix.
+
+    cols: int
+        The number of columns in the matrix.
+
+    value: Expr
+        The value the matrix will be filled with.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin(
+        "handle", "tir.cooperative_matrix_fill_NV", buffer_mat, offset, rows, cols, value
+    )
 
 
 def cooperative_matrix_mad_NV(A, A_off, B, B_off, C, C_off):
-     return call_intrin("handle", "tir.cooperative_matrix_mad_NV", A, A_off, B, B_off, C, C_off)
+    """The intrinsic corresponding to the OpCooperativeMatrixMulAddNV instruction.
+
+    Parameters
+    ----------
+
+    A : Var
+        The buffer with "cooperative_matrix_nv" scope corresponding to the "A" matrix.
+
+    A_off : IntImm
+        The element offset of the "A" matrix in the buffer `A`.
+
+    B : Var
+        The buffer with "cooperative_matrix_nv" scope corresponding to the "B" matrix.
+
+    B_off : IntImm
+        The element offset of the "B" matrix in the buffer `B`.
+
+    C : Var
+        The buffer with "cooperative_matrix_nv" scope corresponding to the "C" matrix.
+
+    C_off : IntImm
+        The element offset of the "C" matrix in the buffer `C`.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin("handle", "tir.cooperative_matrix_mad_NV", A, A_off, B, B_off, C, C_off)
 
 
 # pylint: disable=unnecessary-lambda

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -3037,16 +3037,16 @@ def TVMBackendFreeWorkspace(device_type, device_id, ptr):
     return call_intrin("int32", "tir.TVMBackendFreeWorkspace", device_type, device_id, ptr)
 
 
-def cooperative_matrix_load_NV(mat, offset, src, stride, column_major):
-     return call_intrin("handle", "tir.cooperative_matrix_load_NV", mat, offset, src, stride, column_major)
+def cooperative_matrix_load_NV(mat, offset, src, rows, cols, stride, column_major):
+     return call_intrin("handle", "tir.cooperative_matrix_load_NV", mat, offset, src, rows, cols, stride, column_major)
 
 
 def cooperative_matrix_store_NV(dst, mat, offset, stride, column_major):
      return call_intrin("handle", "tir.cooperative_matrix_store_NV", dst, mat, offset, stride, column_major)
 
 
-def cooperative_matrix_fill_NV(mat, offset, v):
-     return call_intrin("handle", "tir.cooperative_matrix_fill_NV", mat, offset, v)
+def cooperative_matrix_fill_NV(mat, offset, rows, cols, v):
+     return call_intrin("handle", "tir.cooperative_matrix_fill_NV", mat, offset, rows, cols, v)
 
 
 def cooperative_matrix_mad_NV(A, A_off, B, B_off, C, C_off):

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -3037,16 +3037,16 @@ def TVMBackendFreeWorkspace(device_type, device_id, ptr):
     return call_intrin("int32", "tir.TVMBackendFreeWorkspace", device_type, device_id, ptr)
 
 
-def cooperative_matrix_load_NV(mat, src, stdride, column_major):
-     return call_intrin("handle", "tir.cooperative_matrix_load_NV", mat, src, stdride, column_major)
+def cooperative_matrix_load_NV(mat, offset, src, stride, column_major):
+     return call_intrin("handle", "tir.cooperative_matrix_load_NV", mat, offset, src, stride, column_major)
 
 
-def cooperative_matrix_store_NV(dst, mat, stride, column_major):
-     return call_intrin("handle", "tir.cooperative_matrix_store_NV", dst, mat, stride, column_major)
+def cooperative_matrix_store_NV(dst, mat, offset, stride, column_major):
+     return call_intrin("handle", "tir.cooperative_matrix_store_NV", dst, mat, offset, stride, column_major)
 
 
-def cooperative_matrix_fill_NV(mat, v):
-     return call_intrin("handle", "tir.cooperative_matrix_fill_NV", mat, v)
+def cooperative_matrix_fill_NV(mat, offset, v):
+     return call_intrin("handle", "tir.cooperative_matrix_fill_NV", mat, offset, v)
 
 
 def cooperative_matrix_mad_NV(A, B, C):

--- a/src/runtime/thread_storage_scope.h
+++ b/src/runtime/thread_storage_scope.h
@@ -64,6 +64,7 @@ enum class StorageRank {
   kTexture = 7,
   /*! \brief global scope amx tmm memory */
   kAMXTMM = 8,
+  kCooperativeMatrixNV = 9,
 };
 
 /*!
@@ -154,6 +155,9 @@ struct StorageScope {
     } else if (s.compare(0, 7, "amx.tmm") == 0) {
       r.rank = StorageRank::kAMXTMM;
       r.tag = s.substr(7, std::string::npos);
+    } else if (s == "cooperative_matrix_nv") {
+      r.rank = StorageRank::kCooperativeMatrixNV;
+      r.tag = "";
     } else {
       LOG(FATAL) << "unknown storage scope " << s;
     }

--- a/src/runtime/thread_storage_scope.h
+++ b/src/runtime/thread_storage_scope.h
@@ -66,7 +66,7 @@ enum class StorageRank {
   kAMXTMM = 8,
   /*!
    *  \brief Scope representing the cooperative matrix in the Vulkan
-   *  VK_NV_cooperative_matrix extention.
+   *  VK_NV_cooperative_matrix extension.
    */
   kCooperativeMatrixNV = 9,
 };

--- a/src/runtime/thread_storage_scope.h
+++ b/src/runtime/thread_storage_scope.h
@@ -64,6 +64,10 @@ enum class StorageRank {
   kTexture = 7,
   /*! \brief global scope amx tmm memory */
   kAMXTMM = 8,
+  /*!
+   *  \brief Scope representing the cooperative matrix in the Vulkan
+   *  VK_NV_cooperative_matrix extention.
+   */
   kCooperativeMatrixNV = 9,
 };
 

--- a/src/runtime/vulkan/vulkan_device.cc
+++ b/src/runtime/vulkan/vulkan_device.cc
@@ -133,6 +133,7 @@ VulkanDeviceProperties::VulkanDeviceProperties(const VulkanInstance& instance,
       !support::BoolEnvironmentVar("TVM_VULKAN_DISABLE_DEDICATED_ALLOCATION");
 
   supports_integer_dot_product = device.HasExtension("VK_KHR_shader_integer_dot_product");
+  supports_cooperative_matrix_nv = device.HasExtension("VK_NV_cooperative_matrix");
 
   // The check of VK_SHADER_STAGE_COMPUTE_BIT isn't technically
   // needed, since it will be set so long at least one queue has
@@ -435,7 +436,8 @@ std::vector<const char*> VulkanDevice::SelectEnabledExtensions() const {
                                                "VK_KHR_get_memory_requirements2",
                                                "VK_KHR_dedicated_allocation",
                                                "VK_KHR_spirv_1_4",
-                                               "VK_KHR_shader_integer_dot_product"};
+                                               "VK_KHR_shader_integer_dot_product",
+                                               "VK_NV_cooperative_matrix"};
 
   uint32_t device_extension_prop_count;
   VULKAN_CALL(vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,

--- a/src/runtime/vulkan/vulkan_device.h
+++ b/src/runtime/vulkan/vulkan_device.h
@@ -88,6 +88,7 @@ struct VulkanDeviceProperties {
   bool supports_push_descriptor{false};
   bool supports_dedicated_allocation{false};
   bool supports_integer_dot_product{false};
+  bool supports_cooperative_matrix_nv{false};
   uint32_t supported_subgroup_operations{0};
   uint32_t max_num_threads{1};
   uint32_t thread_warp_size{1};

--- a/src/runtime/vulkan/vulkan_device_api.cc
+++ b/src/runtime/vulkan/vulkan_device_api.cc
@@ -241,6 +241,10 @@ void VulkanDeviceAPI::GetTargetProperty(Device dev, const std::string& property,
     *rv = prop.supports_integer_dot_product;
   }
 
+  if (property == "supports_cooperative_matrix_nv") {
+    *rv = prop.supports_cooperative_matrix_nv;
+  }
+
   if (property == "device_name") {
     *rv = prop.device_name;
   }

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -28,6 +28,7 @@
 #include <tvm/tir/op.h>
 
 #include <string>
+#include <unordered_set>
 
 #include "../../runtime/pack_args.h"
 #include "../../runtime/vulkan/vulkan_common.h"

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -419,8 +419,8 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const CallNode* op) {
 
     auto column_major = MakeValue(op->args[6]);
 
-    auto mat_ty = builder_->GetCooperativeMatrixNVType(builder_->GetBufferElementType(ptr),
-						       rows, cols);
+    auto mat_ty =
+        builder_->GetCooperativeMatrixNVType(builder_->GetBufferElementType(ptr), rows, cols);
     auto mat = builder_->CallCooperativeMatrixLoadNV(mat_ty, src_ptr, stride, column_major);
     ICHECK(elem_offset->IsInstance<IntImmNode>());
     builder_->SetJointMatrixDef(ptr, elem_offset.as<IntImmNode>()->value, mat);
@@ -465,7 +465,7 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const CallNode* op) {
     auto C_ptr = Downcast<Var>(op->args[4]);
     ICHECK(C_ptr.defined());
     auto mat_ty =
-      builder_->GetCooperativeMatrixNVType(builder_->GetBufferElementType(C_ptr), 16, 16);
+        builder_->GetCooperativeMatrixNVType(builder_->GetBufferElementType(C_ptr), 16, 16);
 
     auto get_matrix = [this](PrimExpr arg, int offset) {
       auto buffer_var_mat = Downcast<Var>(arg);
@@ -671,7 +671,8 @@ void CodeGenSPIRV::VisitStmt_(const ForNode* op) {
   std::vector<spirv::PhiValue> joint_matrix_phis;
   for (auto [var, elem_offsets] : acc_mat_collector.joint_matrices) {
     Var buffer_var_mat = GetRef<Var>(var);
-    auto mat_ty = builder_->GetCooperativeMatrixNVType(builder_->GetBufferElementType(buffer_var_mat), 16, 16);
+    auto mat_ty = builder_->GetCooperativeMatrixNVType(
+        builder_->GetBufferElementType(buffer_var_mat), 16, 16);
     for (auto offset : elem_offsets) {
       spirv::PhiValue mat_phi = builder_->MakePhi(mat_ty, 2);
       auto mat_def = builder_->GetJointMatrixDef(buffer_var_mat, offset);
@@ -703,7 +704,6 @@ void CodeGenSPIRV::VisitStmt_(const ForNode* op) {
 
   spirv::Value next_value = builder_->Add(loop_var, one);
   loop_var.SetIncoming(1, next_value, continue_label);
-
 
   builder_->MakeInst(spv::OpBranch, head_label);
 

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -626,8 +626,6 @@ class AccumulatedJointMatrixCollector : public StmtExprVisitor {
  public:
   void VisitExpr_(const CallNode* op) final {
     if (op->op.same_as(builtin::cooperative_matrix_mad_NV())) {
-      // TODO
-      LOG(FATAL) << "Not implemented";
       auto C_elem_offset = op->args[5];
       ICHECK(C_elem_offset->IsInstance<IntImmNode>());
       auto buffer_var_C = Downcast<Var>(op->args[4]);

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -648,7 +648,7 @@ void CodeGenSPIRV::VisitStmt_(const ForNode* op) {
   // Each matrix is identified by an element offset into the buffer. This encoding lets us bridge
   // the gap between a typical TIR matmul schedule (which uses
   // `cache_read(..., "cooperative_matrix_nv")` from arbitrary-sized shared memory) and
-  // the fixed-size matrices as expected by the extention.
+  // the fixed-size matrices as expected by the extension.
   std::unordered_map<const VarNode*, std::unordered_set<int>> accum_matrices;
 
   if (op->kind == ForKind::kSerial) {

--- a/src/target/spirv/ir_builder.cc
+++ b/src/target/spirv/ir_builder.cc
@@ -60,6 +60,9 @@ void IRBuilder::InitHeader() {
   }
 #endif
 
+  // TODO
+  capabilities_used_.insert(spv::CapabilityCooperativeMatrixNV);
+
   // memory model
   ib_.Begin(spv::OpMemoryModel)
       .AddSeq(spv::AddressingModelLogical, spv::MemoryModelGLSL450)

--- a/src/target/spirv/ir_builder.cc
+++ b/src/target/spirv/ir_builder.cc
@@ -62,6 +62,7 @@ void IRBuilder::InitHeader() {
 
   // TODO
   capabilities_used_.insert(spv::CapabilityCooperativeMatrixNV);
+  extensions_used_.insert("SPV_NV_cooperative_matrix");
 
   // memory model
   ib_.Begin(spv::OpMemoryModel)

--- a/src/target/spirv/ir_builder.cc
+++ b/src/target/spirv/ir_builder.cc
@@ -60,9 +60,10 @@ void IRBuilder::InitHeader() {
   }
 #endif
 
-  // TODO
-  capabilities_used_.insert(spv::CapabilityCooperativeMatrixNV);
-  extensions_used_.insert("SPV_NV_cooperative_matrix");
+  if (spirv_support_.supports_cooperative_matrix_nv) {
+    capabilities_used_.insert(spv::CapabilityCooperativeMatrixNV);
+    extensions_used_.insert("SPV_NV_cooperative_matrix");
+  }
 
   // memory model
   ib_.Begin(spv::OpMemoryModel)

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -440,13 +440,14 @@ class IRBuilder {
 
     auto rows_spv = IntImm(t_int32_, rows);
     auto cols_spv = IntImm(t_int32_, cols);
+    auto scope = IntImm(t_int32_, spv::Scope::ScopeSubgroup);
 
     SType t;
     t.id = id_counter_++;
     t.element_type_id = elem_ty.id;
     ib_.Begin(spv::Op::OpTypeCooperativeMatrixNV)
-        .AddSeq(t, elem_ty, spv::Scope::ScopeSubgroup, rows_spv, cols_spv)
-        .Commit(&global_);
+      .AddSeq(t, elem_ty, scope, rows_spv, cols_spv)
+      .Commit(&global_);
 
     cooperative_matrix_type_tbl_[key] = t;
     return t;

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -593,7 +593,8 @@ class IRBuilder {
   Value GE(Value a, Value b);
   Value Select(Value cond, Value a, Value b);
 
-  // VK_NV_cooperative_matrix related
+  // The VK_NV_cooperative_matrix extention related, see the documentation for the
+  // SPIRV SPV_NV_cooperative_matrix extention for details.
   SType GetCooperativeMatrixNVType(const SType& elem_ty, int rows, int cols);
   Value CallCooperativeMatrixLoadNV(const SType& mat_type, Value src, Value stride,
                                     Value column_major);
@@ -601,6 +602,9 @@ class IRBuilder {
   Value CallCooperativeMatrixFillNV(const SType& mat_type, Value v);
   Value CallCooperativeMatrixMadNV(Value A, Value B, Value C);
 
+  // Helper functions for cooperative matrix support
+
+  /*! \brief Return the pointer element type for the buffer.*/
   SType GetBufferElementType(const tir::Var& buffer) {
     const auto* ptr = buffer->type_annotation.as<PointerTypeNode>();
     ICHECK(ptr) << "Expects a pointer type.";
@@ -609,11 +613,13 @@ class IRBuilder {
     return GetSType(prim->dtype);
   };
 
+  /*! \brief Associate a TIR buffer at the provided offset with the matrix. */
   void SetCooperativeMatrix(const tir::Var& buffer_var_mat, int elem_offset, Value mat) {
     auto key = std::make_pair(buffer_var_mat.get(), elem_offset);
     cooperative_matrix_defs[key] = mat;
   }
 
+  /*! \brief Retrieve the matrix corresponding to the provided offset in a TIR buffer. */
   Value GetCooperativeMatrix(const tir::Var& buffer_var_mat, int elem_offset) {
     auto key = std::make_pair(buffer_var_mat.get(), elem_offset);
     auto entry = cooperative_matrix_defs.find(key);
@@ -733,7 +739,7 @@ class IRBuilder {
   std::map<std::pair<uint32_t, uint64_t>, Value> const_tbl_;
   /*! \brief map from name of an ExtInstImport to its value */
   std::map<std::string, Value> ext_inst_tbl_;
-  /*! \brief map from (element-type code, rows, cols) to a Cooperative Matrix type */
+  /*! \brief map from (element-type code, rows, cols) to a cooperative matrix type */
   std::map<std::tuple<uint32_t, int, int>, SType> cooperative_matrix_type_tbl_;
 
   /*! \brief Header segment
@@ -775,7 +781,7 @@ class IRBuilder {
   std::vector<uint32_t> function_scope_vars_;
   /*! \brief Function segment */
   std::vector<uint32_t> function_;
-  /*! \brief map from (element-type code, rows, cols) to a Cooperative Matrix type */
+  /*! \brief map from (element-type code, rows, cols) a cooperative matrix */
   std::map<std::pair<const tir::VarNode*, int>, Value> cooperative_matrix_defs;
 };
 

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -452,6 +452,36 @@ class IRBuilder {
     return t;
   }
 
+  Value CallCooperativeMatrixLoadNV(const SType& mat_type, Value src, Value stride,
+                                    Value column_major) {
+    Value val = NewValue(mat_type, kNormal);
+
+    ib_.Begin(spv::Op::OpCooperativeMatrixLoadNV)
+        .AddSeq(mat_type, val, src, stride, column_major)
+        .Commit(&function_);
+    return val;
+  }
+
+  Value CallCooperativeMatrixLoadNV(const SType& mat_type, Value v) {
+    Value val = NewValue(mat_type, kNormal);
+    ib_.Begin(spv::OpCompositeConstruct).AddSeq(mat_type, val, v).Commit(&function_);
+    return val;
+  }
+
+  Value CallJointMatrixMadIntel(const SType& mat_type, Value A, Value B, Value C) {
+    Value val = NewValue(mat_type, kNormal);
+    ib_.Begin(spv::Op::OpCooperativeMatrixMulAddNV)
+        .AddSeq(mat_type, val, A, B, C)
+        .Commit(&function_);
+    return val;
+  }
+
+  void CallJointMatrixStoreIntel(Value dst, Value mat, Value stride, Value column_major) {
+    ib_.Begin(spv::Op::OpCooperativeMatrixStoreNV)
+        .AddSeq(dst, mat, stride, column_major)
+        .Commit(&function_);
+  }
+
   /*!
    * \brief Build vector by concatenating components
    *

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -446,8 +446,8 @@ class IRBuilder {
     t.id = id_counter_++;
     t.element_type_id = elem_ty.id;
     ib_.Begin(spv::Op::OpTypeCooperativeMatrixNV)
-      .AddSeq(t, elem_ty, scope, rows_spv, cols_spv)
-      .Commit(&global_);
+        .AddSeq(t, elem_ty, scope, rows_spv, cols_spv)
+        .Commit(&global_);
 
     cooperative_matrix_type_tbl_[key] = t;
     return t;
@@ -647,7 +647,7 @@ class IRBuilder {
 
   struct JointMatrixDef {
     Value cur_value;
-    Label defined_label; // TODO: remove it
+    Label defined_label;  // TODO: remove it
   };
 
   void SetJointMatrixDef(const tir::Var& buffer_var_mat, int alloc_id, Value mat) {

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -462,24 +462,24 @@ class IRBuilder {
     return val;
   }
 
-  Value CallCooperativeMatrixLoadNV(const SType& mat_type, Value v) {
+  void CallCooperativeMatrixStoreNV(Value dst, Value mat, Value stride, Value column_major) {
+    ib_.Begin(spv::Op::OpCooperativeMatrixStoreNV)
+        .AddSeq(dst, mat, stride, column_major)
+        .Commit(&function_);
+  }
+
+  Value CallCooperativeMatrixFillNV(const SType& mat_type, Value v) {
     Value val = NewValue(mat_type, kNormal);
     ib_.Begin(spv::OpCompositeConstruct).AddSeq(mat_type, val, v).Commit(&function_);
     return val;
   }
 
-  Value CallJointMatrixMadIntel(const SType& mat_type, Value A, Value B, Value C) {
+  Value CallCooperativeMatrixMadNV(const SType& mat_type, Value A, Value B, Value C) {
     Value val = NewValue(mat_type, kNormal);
     ib_.Begin(spv::Op::OpCooperativeMatrixMulAddNV)
         .AddSeq(mat_type, val, A, B, C)
         .Commit(&function_);
     return val;
-  }
-
-  void CallJointMatrixStoreIntel(Value dst, Value mat, Value stride, Value column_major) {
-    ib_.Begin(spv::Op::OpCooperativeMatrixStoreNV)
-        .AddSeq(dst, mat, stride, column_major)
-        .Commit(&function_);
   }
 
   /*!

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -593,8 +593,8 @@ class IRBuilder {
   Value GE(Value a, Value b);
   Value Select(Value cond, Value a, Value b);
 
-  // The VK_NV_cooperative_matrix extention related, see the documentation for the
-  // SPIRV SPV_NV_cooperative_matrix extention for details.
+  // The VK_NV_cooperative_matrix extension related, see the documentation for the
+  // SPIRV SPV_NV_cooperative_matrix extension for details.
   SType GetCooperativeMatrixNVType(const SType& elem_ty, int rows, int cols);
   Value CallCooperativeMatrixLoadNV(const SType& mat_type, Value src, Value stride,
                                     Value column_major);

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -611,7 +611,7 @@ class IRBuilder {
     const auto* prim = ptr->element_type.as<PrimTypeNode>();
     ICHECK(prim) << "Expects a primitive type.";
     return GetSType(prim->dtype);
-  };
+  }
 
   /*! \brief Associate a TIR buffer at the provided offset with the matrix. */
   void SetCooperativeMatrix(const tir::Var& buffer_var_mat, int elem_offset, Value mat) {

--- a/src/target/spirv/spirv_support.cc
+++ b/src/target/spirv/spirv_support.cc
@@ -92,6 +92,10 @@ SPIRVSupport::SPIRVSupport(tvm::Target target) {
   if (target->GetAttr<Bool>("supports_integer_dot_product")) {
     supports_integer_dot_product = target->GetAttr<Bool>("supports_integer_dot_product").value();
   }
+  if (target->GetAttr<Bool>("supports_cooperative_matrix_nv")) {
+    supports_cooperative_matrix_nv =
+        target->GetAttr<Bool>("supports_cooperative_matrix_nv").value();
+  }
   // Check whether integer dot product is enabled in mattr.
   if (const Optional<Array<String>>& v = target->GetAttr<Array<String>>("mattr")) {
     for (const String& s : v.value()) {

--- a/src/target/spirv/spirv_support.h
+++ b/src/target/spirv/spirv_support.h
@@ -277,7 +277,7 @@ struct SPIRVSupport {
    */
   bool supports_integer_dot_product{false};
 
-  /*! \brief Whether the driver supports VK_NV_cooperative_matrix extention. */
+  /*! \brief Whether the driver supports VK_NV_cooperative_matrix extension. */
   bool supports_cooperative_matrix_nv{false};
 };
 

--- a/src/target/spirv/spirv_support.h
+++ b/src/target/spirv/spirv_support.h
@@ -276,6 +276,9 @@ struct SPIRVSupport {
    * attempting to perform integer dot product.
    */
   bool supports_integer_dot_product{false};
+
+  /*! \brief Whether the driver supports VK_NV_cooperative_matrix extention. */
+  bool supports_cooperative_matrix_nv{false};
 };
 
 }  // namespace codegen

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -378,6 +378,7 @@ TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)
     .add_attr_option<Bool>("supports_push_descriptor")
     .add_attr_option<Bool>("supports_dedicated_allocation")
     .add_attr_option<Bool>("supports_integer_dot_product")
+    .add_attr_option<Bool>("supports_cooperative_matrix_nv")
     .add_attr_option<Integer>("supported_subgroup_operations")
     // Physical device limits
     .add_attr_option<Integer>("max_num_threads", Integer(256))

--- a/src/tir/op/builtin.cc
+++ b/src/tir/op/builtin.cc
@@ -355,6 +355,17 @@ TIR_DEFINE_BUILTIN_FUNC(start_profile_intrinsic)
 TIR_DEFINE_BUILTIN_FUNC(end_profile_intrinsic)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
 
+TIR_DEFINE_BUILTIN_FUNC(cooperative_matrix_load_NV)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_BUILTIN_FUNC(cooperative_matrix_store_NV)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_BUILTIN_FUNC(cooperative_matrix_fill_NV)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_BUILTIN_FUNC(cooperative_matrix_mad_NV)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
 }  // namespace builtin
 }  // namespace tir
 }  // namespace tvm

--- a/tests/python/unittest/test_target_codegen_vulkan.py
+++ b/tests/python/unittest/test_target_codegen_vulkan.py
@@ -964,8 +964,9 @@ def test_cooperative_matrix_nv(out_dtype):
     sch.tensorize(sch.get_loops(block)[2], MAD_INTRIN)
 
     target = "vulkan -from_device=0"
+    tgt_attrs = tvm.target.Target(target).attrs
 
-    if tvm.target.Target(target).attrs["supports_cooperative_matrix_nv"]:
+    if tgt_attrs.get("supports_cooperative_matrix_nv"):
         f = tvm.build(sch.mod, target=target)
 
         dev = tvm.device(target, 0)

--- a/tests/python/unittest/test_target_codegen_vulkan.py
+++ b/tests/python/unittest/test_target_codegen_vulkan.py
@@ -29,6 +29,7 @@ import tvm.testing
 from tvm import relay, te
 from tvm.topi.math import cast
 from tvm.script import tir as T
+from tvm.tir import TensorIntrin, IntImm, Cast, Schedule
 
 
 dtype = tvm.testing.parameter("float32", "int32", "float16", "int8")
@@ -151,10 +152,10 @@ def test_vulkan_stress(target, dev):
             a = tvm.nd.empty((n,), A.dtype, dev).copyfrom(np.random.uniform(size=(n,)))
             b = tvm.nd.empty((n,), B.dtype, dev).copyfrom(np.random.uniform(size=(n,)))
             cs = [tvm.nd.empty((n,), A.dtype, dev) for _ in fs]
-            for ((f, _), c) in zip(fs, cs):
+            for (f, _), c in zip(fs, cs):
                 f(a, b, c)
 
-            for ((_, ref), c) in zip(fs, cs):
+            for (_, ref), c in zip(fs, cs):
                 tvm.testing.assert_allclose(c.numpy(), ref(a.numpy(), b.numpy()))
 
         ts = [threading.Thread(target=worker) for _ in range(np.random.randint(1, 10))]
@@ -277,6 +278,7 @@ def test_unique(target, dev):
 
 vulkan_parameter_impl = tvm.testing.parameter("push_constants", "ubo")
 vulkan_parameter_dtype = tvm.testing.parameter("int32", "float32", "int64")
+
 
 # Only run on vulkan because extremely large numbers of input
 # parameters can crash cuda/llvm compiler.
@@ -598,6 +600,380 @@ def test_negative_operand_divmod(target, dev):
 
     np.testing.assert_array_equal(a[:, 0], (np.arange(N) - offset) // divisor)
     np.testing.assert_array_equal(a[:, 1], (np.arange(N) - offset) % divisor)
+
+
+@T.prim_func
+def cooperative_matrix_load_desc(a: T.handle, c: T.handle) -> None:
+    A = T.match_buffer(a, (16, 16), "float16", align=64, offset_factor=8, scope="shared")
+    C = T.match_buffer(
+        c, (16, 16), "float16", align=64, offset_factor=8, scope="cooperative_matrix_nv"
+    )
+
+    with T.block("root"):
+        T.reads(A[0:16, 0:16])
+        T.writes(C[0:16, 0:16])
+        for i, j in T.grid(16, 16):
+            with T.block("load"):
+                vii, vjj = T.axis.remap("SS", [i, j])
+                C[vii, vjj] = A[vii, vjj]
+
+
+def get_load_impl(column_major):
+    @T.prim_func
+    def cooperative_matrix_load_impl(a: T.handle, c: T.handle) -> None:
+        s1 = T.var("int32")
+        s0 = T.var("int32")
+        A = T.match_buffer(
+            a,
+            (16, 16),
+            "float16",
+            align=64,
+            offset_factor=8,
+            scope="shared",
+            strides=[s1, s0],
+        )
+        C = T.match_buffer(
+            c,
+            (16, 16),
+            "float16",
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+
+        with T.block("root"):
+            T.reads(A[0:16, 0:16])
+            T.writes(C[0:16, 0:16])
+            tx = T.env_thread("threadIdx.x")
+            T.launch_thread(tx, 32)
+            T.evaluate(
+                T.cooperative_matrix_load_NV(
+                    C.data,
+                    C.elem_offset,
+                    A.access_ptr("r"),
+                    16,
+                    16,
+                    s1,
+                    column_major,
+                    dtype="handle",
+                )
+            )
+
+    return cooperative_matrix_load_impl
+
+
+def get_store_desc(out_dtype="float32", out_scope="global"):
+    @T.prim_func
+    def cooperative_matrix_store_desc(a: T.handle, c: T.handle) -> None:
+        A = T.match_buffer(
+            a,
+            (16, 16),
+            out_dtype,
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+        C = T.match_buffer(c, (16, 16), out_dtype, align=64, offset_factor=8, scope=out_scope)
+        with T.block("root"):
+            T.reads(A[0:16, 0:16])
+            T.writes(C[0:16, 0:16])
+            for i, j in T.grid(16, 16):
+                with T.block("store"):
+                    vii, vjj = T.axis.remap("SS", [i, j])
+                    C[vii, vjj] = A[vii, vjj]
+
+    return cooperative_matrix_store_desc
+
+
+def get_store_impl(out_dtype="float32", out_scope="global"):
+    @T.prim_func
+    def cooperative_matrix_store_impl(a: T.handle, c: T.handle) -> None:
+        s1 = T.var("int32")
+        s0 = T.var("int32")
+        A = T.match_buffer(
+            a,
+            (16, 16),
+            out_dtype,
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+        C = T.match_buffer(
+            c,
+            (16, 16),
+            out_dtype,
+            align=64,
+            offset_factor=8,
+            scope=out_scope,
+            strides=[s1, s0],
+        )
+
+        with T.block("root"):
+            T.reads(A[0:16, 0:16])
+            T.writes(C[0:16, 0:16])
+            tx = T.env_thread("threadIdx.x")
+            T.launch_thread(tx, 32)
+            T.evaluate(
+                T.cooperative_matrix_store_NV(
+                    C.access_ptr("w"), A.data, A.elem_offset, s1, False, dtype="handle"
+                )
+            )
+
+    return cooperative_matrix_store_impl
+
+
+def get_fill_desc(out_dtype="float32"):
+    zero = IntImm("int32", 0).astype(out_dtype)
+
+    @T.prim_func
+    def cooperative_matrix_fill_desc(c: T.handle) -> None:
+        C = T.match_buffer(
+            c,
+            (16, 16),
+            out_dtype,
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+
+        with T.block("root"):
+            T.reads()
+            T.writes(C[0:16, 0:16])
+            for i, j in T.grid(16, 16):
+                with T.block("init"):
+                    vii, vjj = T.axis.remap("SS", [i, j])
+                    C[vii, vjj] = zero
+
+    return cooperative_matrix_fill_desc
+
+
+def get_fill_impl(out_dtype="float32"):
+    zero = IntImm("int32", 0).astype(out_dtype)
+
+    @T.prim_func
+    def cooperative_matrix_fill_impl(c: T.handle) -> None:
+        C = T.match_buffer(
+            c,
+            (16, 16),
+            out_dtype,
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+
+        with T.block("root"):
+            T.reads()
+            T.writes(C[0:16, 0:16])
+            tx = T.env_thread("threadIdx.x")
+            T.launch_thread(tx, 32)
+            T.evaluate(
+                T.cooperative_matrix_fill_NV(C.data, C.elem_offset, 16, 16, zero, dtype="handle")
+            )
+
+    return cooperative_matrix_fill_impl
+
+
+def get_mad_desc(out_dtype="float32"):
+    def maybe_cast(v):
+        if out_dtype in ["float32", "int32"]:
+            return Cast(out_dtype, v)
+        return v
+
+    @T.prim_func
+    def cooperative_matrix_mad_desc(a: T.handle, b: T.handle, c: T.handle) -> None:
+        A = T.match_buffer(
+            a,
+            (16, 16),
+            "float16",
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+        B = T.match_buffer(
+            b,
+            (16, 16),
+            "float16",
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+        C = T.match_buffer(
+            c,
+            (16, 16),
+            out_dtype,
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+
+        with T.block("root"):
+            T.reads(C[0:16, 0:16], A[0:16, 0:16], B[0:16, 0:16])
+            T.writes(C[0:16, 0:16])
+            for i, j, k in T.grid(16, 16, 16):
+                with T.block("update"):
+                    vii, vjj, vkk = T.axis.remap("SSR", [i, j, k])
+                    C[vii, vjj] = C[vii, vjj] + maybe_cast(A[vii, vkk]) * maybe_cast(B[vkk, vjj])
+
+    return cooperative_matrix_mad_desc
+
+
+def get_mad_impl(out_dtype="float32"):
+    @T.prim_func
+    def cooperative_matrix_mad_impl(a: T.handle, b: T.handle, c: T.handle) -> None:
+        A = T.match_buffer(
+            a,
+            (16, 16),
+            "float16",
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+        B = T.match_buffer(
+            b,
+            (16, 16),
+            "float16",
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+        C = T.match_buffer(
+            c,
+            (16, 16),
+            out_dtype,
+            align=64,
+            offset_factor=8,
+            scope="cooperative_matrix_nv",
+        )
+
+        with T.block("root"):
+            T.reads(C[0:16, 0:16], A[0:16, 0:16], B[0:16, 0:16])
+            T.writes(C[0:16, 0:16])
+            tx = T.env_thread("threadIdx.x")
+            T.launch_thread(tx, 32)
+            T.evaluate(
+                T.cooperative_matrix_mad_NV(
+                    A.data,
+                    A.elem_offset,
+                    B.data,
+                    B.elem_offset,
+                    C.data,
+                    C.elem_offset,
+                    dtype="handle",
+                )
+            )
+
+    return cooperative_matrix_mad_impl
+
+
+TensorIntrin.register("cooperative_matrix_load", cooperative_matrix_load_desc, get_load_impl(False))
+
+
+@pytest.mark.parametrize("out_dtype", ["float32", "float16"])
+def test_cooperative_matrix_nv(out_dtype):
+    STORE_INTRIN = "cooperative_matrix_store_{}".format(out_dtype)
+    FILL_INTRIN = "cooperative_matrix_fill_{}".format(out_dtype)
+    MAD_INTRIN = "cooperative_matrix_mad_{}".format(out_dtype)
+
+    TensorIntrin.register(
+        STORE_INTRIN,
+        get_store_desc(out_dtype),
+        get_store_impl(out_dtype),
+    )
+    TensorIntrin.register(FILL_INTRIN, get_fill_desc(out_dtype), get_fill_impl(out_dtype))
+    TensorIntrin.register(MAD_INTRIN, get_mad_desc(out_dtype), get_mad_impl(out_dtype))
+
+    def get_matmul(m, n, k, out_dtype="float32"):
+        X = te.placeholder((m, k), name="X", dtype="float16")
+        W = te.placeholder((k, n), name="W", dtype="float16")
+        ak = te.reduce_axis((0, k), name="k")
+
+        if out_dtype == "float32":
+            matmul = te.compute(
+                (m, n),
+                lambda i, j: te.sum(
+                    X[i, ak].astype("float32") * W[ak, j].astype("float32"),
+                    axis=ak,
+                ),
+                name="compute",
+            )
+        else:
+            matmul = te.compute(
+                (m, n),
+                lambda i, j: te.sum(X[i, ak] * W[ak, j], axis=ak),
+                name="compute",
+            )
+
+        return te.create_prim_func([X, W, matmul])
+
+    M, N, K = 16, 16, 32
+    func = get_matmul(M, N, K, out_dtype)
+    sch = Schedule(func)
+    block = sch.get_block("compute")
+
+    i, j, k = sch.get_loops(block)
+    i_outer, i_inner = sch.split(i, factors=[None, 16])
+    j_outer, j_inner = sch.split(j, factors=[None, 16])
+    k_outer, k_inner = sch.split(k, factors=[None, 16])
+    sch.reorder(i_outer, j_outer, k_outer, i_inner, j_inner, k_inner)
+    fused_outer = sch.fuse(i_outer, j_outer)
+    sch.bind(fused_outer, "blockIdx.x")
+
+    def fetch_to_shared(block, idx):
+        block_read = sch.cache_read(block, idx, "shared")
+        sch.compute_at(block_read, k_outer)
+        warp_size = 32
+
+        fused = sch.fuse(*sch.get_loops(block_read)[-2:])
+
+        vector_size = 4
+        _, f_2, f_3 = sch.split(fused, factors=[None, warp_size, vector_size])
+        sch.bind(f_2, "threadIdx.x")
+        sch.vectorize(f_3)
+
+    def tensorize_load(block, dim, intrin):
+        loops = sch.get_loops(block)
+        i, j = loops[-dim : (len(loops) - dim + 2)]
+
+        i0, i1 = sch.split(i, factors=[None, 16])
+        j0, j1 = sch.split(j, factors=[None, 16])
+        sch.reorder(i0, j0, i1, j1)
+        sch.unroll(i0)
+        sch.unroll(j0)
+        sch.tensorize(i1, intrin)
+
+    fetch_to_shared(block, 0)
+    fetch_to_shared(block, 1)
+
+    A_mat = sch.cache_read(block, 0, "cooperative_matrix_nv")
+    B_mat = sch.cache_read(block, 1, "cooperative_matrix_nv")
+
+    tensorize_load(A_mat, 2, "cooperative_matrix_load")
+    tensorize_load(B_mat, 2, "cooperative_matrix_load")
+
+    store = sch.cache_write(block, 0, "cooperative_matrix_nv")
+    sch.reverse_compute_at(store, fused_outer)
+    init = sch.decompose_reduction(block, sch.get_loops(block)[1])
+
+    sch.tensorize(sch.get_loops(init)[1], FILL_INTRIN)
+    sch.tensorize(sch.get_loops(store)[1], STORE_INTRIN)
+    sch.tensorize(sch.get_loops(block)[2], MAD_INTRIN)
+
+    target = "vulkan -from_device=0"
+    f = tvm.build(sch.mod, target=target)
+
+    dev = tvm.device(target, 0)
+
+    A = tvm.nd.array(np.random.randn(M, K).astype("float16"), dev)
+    B = tvm.nd.array(np.random.randn(K, N).astype("float16"), dev)
+    C = tvm.nd.array(np.random.randn(M, N).astype(out_dtype), dev)
+
+    f(A, B, C)
+
+    A_np = A.numpy()
+    B_np = B.numpy()
+    ref = np.dot(A_np.astype("float32"), B_np.astype("float32"))
+
+    tvm.testing.assert_allclose(C.numpy(), ref, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_target_codegen_vulkan.py
+++ b/tests/python/unittest/test_target_codegen_vulkan.py
@@ -865,9 +865,6 @@ def get_mad_impl(out_dtype="float32"):
     return cooperative_matrix_mad_impl
 
 
-TensorIntrin.register("cooperative_matrix_load", cooperative_matrix_load_desc, get_load_impl(False))
-
-
 @pytest.mark.parametrize("out_dtype", ["float32", "float16"])
 def test_cooperative_matrix_nv(out_dtype):
     STORE_INTRIN = "cooperative_matrix_store_{}".format(out_dtype)
@@ -875,12 +872,20 @@ def test_cooperative_matrix_nv(out_dtype):
     MAD_INTRIN = "cooperative_matrix_mad_{}".format(out_dtype)
 
     TensorIntrin.register(
+        "cooperative_matrix_load", cooperative_matrix_load_desc, get_load_impl(False), override=True
+    )
+    TensorIntrin.register(
         STORE_INTRIN,
         get_store_desc(out_dtype),
         get_store_impl(out_dtype),
+        override=True,
     )
-    TensorIntrin.register(FILL_INTRIN, get_fill_desc(out_dtype), get_fill_impl(out_dtype))
-    TensorIntrin.register(MAD_INTRIN, get_mad_desc(out_dtype), get_mad_impl(out_dtype))
+    TensorIntrin.register(
+        FILL_INTRIN, get_fill_desc(out_dtype), get_fill_impl(out_dtype), override=True
+    )
+    TensorIntrin.register(
+        MAD_INTRIN, get_mad_desc(out_dtype), get_mad_impl(out_dtype), override=True
+    )
 
     def get_matmul(m, n, k, out_dtype="float32"):
         X = te.placeholder((m, k), name="X", dtype="float16")

--- a/tests/python/unittest/test_target_codegen_vulkan.py
+++ b/tests/python/unittest/test_target_codegen_vulkan.py
@@ -959,21 +959,23 @@ def test_cooperative_matrix_nv(out_dtype):
     sch.tensorize(sch.get_loops(block)[2], MAD_INTRIN)
 
     target = "vulkan -from_device=0"
-    f = tvm.build(sch.mod, target=target)
 
-    dev = tvm.device(target, 0)
+    if tvm.target.Target(target).attrs["supports_cooperative_matrix_nv"]:
+        f = tvm.build(sch.mod, target=target)
 
-    A = tvm.nd.array(np.random.randn(M, K).astype("float16"), dev)
-    B = tvm.nd.array(np.random.randn(K, N).astype("float16"), dev)
-    C = tvm.nd.array(np.random.randn(M, N).astype(out_dtype), dev)
+        dev = tvm.device(target, 0)
 
-    f(A, B, C)
+        A = tvm.nd.array(np.random.randn(M, K).astype("float16"), dev)
+        B = tvm.nd.array(np.random.randn(K, N).astype("float16"), dev)
+        C = tvm.nd.array(np.random.randn(M, N).astype(out_dtype), dev)
 
-    A_np = A.numpy()
-    B_np = B.numpy()
-    ref = np.dot(A_np.astype("float32"), B_np.astype("float32"))
+        f(A, B, C)
 
-    tvm.testing.assert_allclose(C.numpy(), ref, rtol=1e-2, atol=1e-2)
+        A_np = A.numpy()
+        B_np = B.numpy()
+        ref = np.dot(A_np.astype("float32"), B_np.astype("float32"))
+
+        tvm.testing.assert_allclose(C.numpy(), ref, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR enables using tensorcore on vulkan target for NV devices. The semantics of the instructions are pretty much the same as WMMA. See https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/NV/SPV_NV_cooperative_matrix.html for the reference.

The script https://github.com/masahi/tensorir-experiment/blob/master/vk_cooperative_matrix_nv/test_4k.py shows the usage of this extension in a realistic matmul schedule. It gets 36 TFLOPs for f16f16f32 matmul on RTX 3070 (peak being 41 TFLOPs). It also demonstrates AutoTVM-style MS tuning for tiling parameters.  

Contrary to our WMMA support, which relies on [a complicated "fragment index" concept](https://github.com/apache/tvm/blob/main/python/tvm/tir/tensor_intrin/cuda.py#L550-L556) and generating an "array" of fragment and indexing them in the source code (not possible with SPIRV), my solution materializes all cooperative matrices in the codegen and explicitly unroll all instructions on them. Each matrix is identified by an element offset into the buffer with cooperative matrix scope, so an element offset is required to be a constant. I'm not sure if that is a reasonable assumption, but other than that I believe my solution is better than how we are supporting WMMA for CUDA. See `codegen_spirv.cc` for details.  

@tqchen @Lunderberg @vinx13 @spectrometerHBH 