### PR TITLE
[BugFix][Relay] fix `scatter_nd` type relation

### DIFF
--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -1185,7 +1185,7 @@ bool ScatterNDRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   const size_t kdim = indices->shape.size() - 1;
   const size_t ndim = out_shape.size();
   ICHECK_LE(size_t(mdim->value), ndim)
-      << "ScatterND: Given data with shape (Y_0, ..., Y_{K-1}, X_M, ..., X_{N-1}), and indices "
+      << "ScatterND: Given updates with shape (Y_0, ..., Y_{K-1}, X_M, ..., X_{N-1}), and indices "
          "with shape (M, Y_0, ..., Y_{K-1}), M must be less than or equal to N.";
   // Indices: (M, Y_0, .. Y_{K-1}) data: (Y_0, .. Y_{K-1}, ...), verify Y's.
   for (size_t i = 0; i < kdim; i++) {
@@ -1197,9 +1197,9 @@ bool ScatterNDRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     oshape.push_back(x);
   }
 
-  // data: (Y_0, .. Y_{K-1}, X_M, .. X_{N-1}) out: (X_0, .. X_{N-1}), verify X_M to X_{N-1}
+  // updates: (Y_0, .. Y_{K-1}, X_M, .. X_{N-1}) out: (X_0, .. X_{N-1}), verify X_M to X_{N-1}
   for (size_t i = mdim->value; i < ndim; i++) {
-    reporter->AssertEQ(data->shape[i - mdim->value + kdim], oshape[i]);
+    reporter->AssertEQ(updates->shape[i - mdim->value + kdim], oshape[i]);
   }
 
   reporter->Assign(types[3], TensorType(data->shape, data->dtype));


### PR DESCRIPTION
```python
import tvm
import numpy as np
from tvm import relay


def should_pass():

    data = relay.const(np.zeros([1,1,10], 'float32'))
    indices = relay.const(np.ones([2,1,1,1], 'int64'))
    updates = relay.const(np.random.rand(1,1,1,10).astype('float32'))

    scatter_nd = relay.scatter_nd(data, indices, updates)

    mod = tvm.IRModule.from_expr(scatter_nd)
    mod = relay.transform.InferType()(mod)


def should_fail():
    data = relay.const(np.zeros([1,1,10], 'float32'))
    indices = relay.const(np.ones([2,1,1], 'int64'))
    updates = relay.const(np.random.rand(1,1,5).astype('float32'))

    scatter_nd = relay.scatter_nd(data, indices, updates)

    mod = tvm.IRModule.from_expr(scatter_nd)
    mod = relay.transform.InferType()(mod)
```

case `should_pass` will report a error
> Check failed: (0 <= i && i < p->size_) is false: IndexError: indexing 3 on an array of size 3

case `should_fail` will pass incorrectly. however FoldConstant will find the error:
> AssertionError: Dimension of updates[2] (5) must equal dimension of out_shape[2] (10).

It looks like #7927 changes the implementation of `relay.scatter_nd` into onnx-like. but a change from `data` into `updates` is missing.