### PR TITLE
[Bugfix][Codegen][CUDA] Wrong casting in ASM

### DIFF
--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -931,8 +931,8 @@ void CodeGenCUDA::VisitExpr_(const CallNode* op, std::ostream& os) {
   } else if (op->op.same_as(builtin::ptx_commit_group())) {
     this->stream << "__asm__ __volatile__(\"cp.async.commit_group;\");\n\n";
   } else if (op->op.same_as(builtin::ptx_wait_group())) {
-    std::string N = this->PrintExpr(op->args[0]);
-    this->stream << "__asm__ __volatile__(\"cp.async.wait_group " + N + ";\");\n\n";
+    int n = Downcast<IntImm>(op->args[0])->value;
+    this->stream << "__asm__ __volatile__(\"cp.async.wait_group " << n << ";\");\n\n";
   } else if (op->op.same_as(builtin::ptx_ldg32())) {
     /*
     asm volatile (


### PR DESCRIPTION
The current HEAD will emit the inlined assembly that mistakenly include type casting, which is not allowed syntax, for example:

```c++
__asm__ __volatile__("cp.async.wait_group (int64_t)2;");
````

This commit fixes this bug.