### PR TITLE
[FIX] fix typo in comment

### DIFF
--- a/python/tvm/ir/instrument.py
+++ b/python/tvm/ir/instrument.py
@@ -53,7 +53,7 @@ class PassInstrument(tvm.runtime.Object):
             return getattr(self, name)
 
         # Create runtime pass instrument object.
-        # reister instance's enter_pass_ctx,exit_pass_ctx, should_run, run_before_pass and
+        # register instance's enter_pass_ctx,exit_pass_ctx, should_run, run_before_pass and
         # run_after_pass methods to it if present.
         self.__init_handle_by_constructor__(
             _ffi_instrument_api.PassInstrument,

--- a/src/tir/transforms/inject_rolling_buffer.cc
+++ b/src/tir/transforms/inject_rolling_buffer.cc
@@ -59,7 +59,7 @@ class RollingBufferInjector : public StmtExprMutator {
   std::map<Buffer, std::vector<AttrStmt>> buffer_to_attrs{};
   std::map<Buffer, RollingBufferInfo> rolling_buffer_to_info{};
   // The actual key type is Var, ObjectRef has been used because
-  // of the ambiguous overload for ‘operator<’
+  // of the ambiguous overload for 'operator<'
   std::map<ObjectRef, std::vector<BufferRealize>> hoist_buffer_to_for{};
 
  public:

--- a/tests/python/driver/tvmc/test_parse_config_file.py
+++ b/tests/python/driver/tvmc/test_parse_config_file.py
@@ -166,7 +166,7 @@ def test_tvmc_get_configs_json_dir(tmpdir_factory, monkeypatch):
     monkeypatch.setattr(tvm.driver.tvmc.config_options, "CONFIGS_JSON_DIR", None)
     monkeypatch.setenv("TVM_CONFIGS_JSON_DIR", "not_a_directory")
     result = get_configs_json_dir()
-    assert_msg = "Non-existant directory passed via TVM_CONFIGS_JSON_DIR should be ignored."
+    assert_msg = "Non-existent directory passed via TVM_CONFIGS_JSON_DIR should be ignored."
     assert result == default_dir, assert_msg
 
     # Set custom dir which does exist


### PR DESCRIPTION
In this pr, I fix some typo in comment:

- `reister` -> `register`
- `‘operator<’` -> `'operator<'` (`‘` make MSVC compile error) 
- `existant` -> `existent`
