### PR TITLE
[NDArray] Allow arbitrary stride when the corresponding shape is 1

### DIFF
--- a/src/tir/transforms/arg_binder.cc
+++ b/src/tir/transforms/arg_binder.cc
@@ -230,7 +230,7 @@ void ArgBinder::BindDLTensor(const Buffer& buffer, const PrimExpr& device_type,
     for (size_t i = buffer->shape.size(); i != 0; --i) {
       size_t k = i - 1;
       PrimExpr svalue = cast(stype, BufferLoad(buf_strides, {IntImm(DataType::Int(32), k)}));
-      conds.push_back(expect_stride == svalue);
+      conds.push_back(buffer->shape[k] == 1 || expect_stride == svalue);
       expect_stride = expect_stride * buffer->shape[k];
     }
     std::ostringstream stride_err_msg;

--- a/tests/python/unittest/test_runtime_dlpack.py
+++ b/tests/python/unittest/test_runtime_dlpack.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+import tvm.testing
+from tvm import te
+import numpy as np
+
+
+@tvm.testing.requires_package("torch")
+def test_from_dlpack_shape_one():
+    # A test case for the issue https://github.com/pytorch/pytorch/issues/99803
+    import torch
+    from torch.utils.dlpack import to_dlpack
+
+    tgt = tvm.target.Target(target="llvm", host="llvm")
+
+    rows = 1
+    a = tvm.runtime.ndarray.from_dlpack(to_dlpack(torch.randn(rows, 16)))
+
+    A = te.placeholder((rows, 16), name="A")
+    B = te.placeholder((rows, 16), name="B")
+    C = te.compute(A.shape, lambda i, j: A[i, j] + B[i, j], name="C")
+
+    s = te.create_schedule(C.op)
+
+    fadd = tvm.build(s, [A, B, C], tgt)
+
+    dev = tvm.device(tgt.kind.name, 0)
+
+    b = tvm.nd.array(np.random.uniform(size=(rows, 16)).astype(B.dtype), dev)
+    c = tvm.nd.array(np.zeros((rows, 16), dtype=C.dtype), dev)
+    fadd(a, b, c)
+
+    tvm.testing.assert_allclose(c.numpy(), a.numpy() + b.numpy())
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
As discussed in https://github.com/pytorch/pytorch/issues/99803, as of PT 1.13, PT started to fill in a stride with 1 whenever the corresponding shape axis has size 1 during PT tensor to DLPack conversion. This breaks `tvm.runtime.ndarray.from_dlpack` when the shape is like `(1, 77)` (clip for SD) or whenever the batch size is 1 in vision models. So this is going to be a common problem that people would encounter in practice (see https://discuss.tvm.apache.org/t/a-pytorch-and-tvm-version-incompatibility-problem-while-using-from-dlpack-and-to-dlpack/14771).

This PR fixes this issue by relaxing the runtime stride check. An alternative is to modify the strides during `from_dlpack`, but since PT introduced this change for a good reason, I felt that trying to calculate the "correct" strides on our side again is not a good idea.   

@tqchen @junrushao 
 