### PR TITLE
[CUTLASS] Add NDEBUG option to CUTLASS compile to speed up attention kernel

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -59,6 +59,7 @@ def _get_cutlass_compile_options(sm, threads, use_fast_math=False):
         "-c",
         "-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1",
         "-gencode=arch=compute_%d,code=[sm_%d,compute_%d]" % (sm, sm, sm),
+        "-DNDEBUG",
         "-Xcompiler=-fPIC",
         "-Xcompiler=-Wconversion",
         "-Xcompiler=-fno-strict-aliasing",


### PR DESCRIPTION
I found that adding this option brings non-trivial perf improvement to the attention kernel (2.4 vs 2.7 msec for the most heavy workload in SD UNet, see below). This results in a few msec speed up for SD UNet e2e.

Before (nvprof output on `test_attention_offload((2, (4096, 4096), 8, (40, 40), "float16)`)
```
 Time (%)  Total Time (ns)  Instances   Avg (ns)     Med (ns)    Min (ns)   Max (ns)   StdDev (ns)     GridXYZ         BlockXYZ                       
                              Name                                                 
 --------  ---------------  ---------  -----------  -----------  ---------  ---------  -----------  --------------  --------------  ------------------
----------------------------------------------------------------------------------
 100.0        8,325,790          3  2,775,263.3  2,773,023.0  2,768,736  2,784,031      7,889.8    64    8    2    32    4    1  void attention_kernel_batched_impl<AttentionKernel<cutlass::half_t, cutlass::arch::Sm80, (bool)1, (…
```

After
```
   Time (%)  Total Time (ns)  Instances   Avg (ns)     Med (ns)    Min (ns)   Max (ns)   StdDev (ns)     GridXYZ         BlockXYZ                                                     Name                                                
 --------  ---------------  ---------  -----------  -----------  ---------  ---------  -----------  --------------  --------------  ----------------------------------------------------------------------------------------------------
 100.0        7,466,320          3  2,488,773.3  2,483,845.0  2,481,606  2,500,869     10,534.8    64    8    2    32    4    1  void attention_kernel_batched_impl<AttentionKernel<cutlass::half_t, cutlass::arch::Sm80, (bool)1, (…
```

@cyx-6 @vinx13 