### PR TITLE
[Unity] Fix CUDA graph rewrite var used before def

### DIFF
--- a/src/runtime/relax_vm/cuda/cuda_graph_builtin.cc
+++ b/src/runtime/relax_vm/cuda/cuda_graph_builtin.cc
@@ -87,7 +87,6 @@ class CUDAGraphCache : public Object {
   ObjectRef RunOrCapture(VirtualMachine* vm, const ObjectRef& capture_func, ObjectRef args,
                          int64_t entry_index) {
     if (auto it = capture_cache_.find(entry_index); it != capture_cache_.end()) {
-      LOG(INFO) << "HIT";
       // Launch CUDA graph
       const auto& [states, cuda_graph] = it->second;
       cudaGraphExec_t cuda_graph_exec;


### PR DESCRIPTION
CUDA graph rewriting may result reordering of original bindings, for example when a variable is used as an input of the lifted function. If the variable comes from the output of another function, we need to make sure output unpacking is emitted.