### PR TITLE
[Unity][BYOC] Add shape validation for bias arg in cuBLAS

### DIFF
--- a/src/runtime/contrib/cublas/cublas_json_runtime.cc
+++ b/src/runtime/contrib/cublas/cublas_json_runtime.cc
@@ -49,6 +49,8 @@ class CublasJSONRuntime : public JSONRuntimeBase {
 
   void Init(const Array<NDArray>& consts) override {}
 
+  const char* type_key() const override { return "cublas_json"; }  // May be overridden
+
   void Run() override {
     // TODO(masahi): Reuse the same handle across different subgraphs
     cublasLtHandle_t handle;

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -362,7 +362,7 @@ def test_matmul_offload(
         x_shape,
         y_shape,
         dtype,
-        with_bias=with_bias,
+        bias_shape=bias.shape if with_bias else None,
         transposed_y=transpose_y,
         activation=activation,
         residual_bin_op=residual_bin_op,
@@ -439,9 +439,7 @@ def test_cutlass_partition_matmul_blocked(x_shape, y_shape, transpose_y, dtype):
     if transpose_y:
         y_shape = (*y_shape[:-2], y_shape[-1], y_shape[-2])
 
-    mod = get_relax_matmul_module(
-        x_shape, y_shape, dtype, with_bias=False, transposed_y=transpose_y
-    )
+    mod = get_relax_matmul_module(x_shape, y_shape, dtype, transposed_y=transpose_y)
     mod = partition_for_cutlass(mod)
 
     assert len(mod.functions) == 1
@@ -525,7 +523,8 @@ def get_relax_attention_module(q, k, v, bias=None, qk_scale=None):
     dtype = str(q.dtype)
 
     from tvm.script.ir_builder import IRBuilder
-    from tvm.script.ir_builder import relax as relax_builder, tir as T
+    from tvm.script.ir_builder import relax as relax_builder
+    from tvm.script.ir_builder import tir as T
 
     if qk_scale is not None:
         qk_scale = T.FloatImm("float32", qk_scale)
@@ -671,7 +670,8 @@ def get_relax_stacked_attention_module(
     dtype = str(qkv.dtype)
 
     from tvm.script.ir_builder import IRBuilder
-    from tvm.script.ir_builder import relax as relax_builder, tir as T
+    from tvm.script.ir_builder import relax as relax_builder
+    from tvm.script.ir_builder import tir as T
 
     if qk_scale is not None:
         qk_scale = T.FloatImm("float32", qk_scale)
@@ -778,7 +778,8 @@ def get_relax_attention_rewrite_module(
     q_shape, k_shape, v_shape, out_shape, dtype, bias_shape=None, scale=None
 ):
     from tvm.script.ir_builder import IRBuilder
-    from tvm.script.ir_builder import relax as relax_builder, tir as T
+    from tvm.script.ir_builder import relax as relax_builder
+    from tvm.script.ir_builder import tir as T
 
     with IRBuilder() as builder:
         with relax_builder.function():


### PR DESCRIPTION
This PR adds more logic on bias shape in cuBLAS partitioning. This prevents matmul with residual input to be offloaded to cuBLAS as matmul with bias. cuBLAS only support 1D bias input.

This PR also fixes the type key for cublas json runtime, so that it can be deserialized correctly.

cc @masahi @vinx13

