### PR TITLE
[Unity][Relax] gelu-tanh operator

### DIFF
--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -158,6 +158,8 @@ def _check_matmul(context: PatternCheckContext) -> bool:
 def _get_activation_from_name(pattern_name):
     if "_relu" in pattern_name:
         return "relax.nn.relu"
+    elif "_gelu_tanh" in pattern_name:
+        return "relax.nn.gelu_tanh"
     elif "_gelu" in pattern_name:
         return "relax.nn.gelu"
     elif "_silu" in pattern_name:

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -579,7 +579,7 @@ def gelu_tanh(data: Expr) -> Expr:
     """Gaussian Error Linear Units function with tanh approximation
 
     .. math::
-        \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}(\sqrt(2 / \pi) * (x + 0.044715 * x^3)))
+        text{GELU}(x) = 0.5 * x * (1 + text{Tanh}(\sqrt(2 / \pi) * (x + 0.044715 * x^3)))
 
     Parameters
     ----------

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -575,6 +575,29 @@ def gelu(data: Expr) -> Expr:
     return _ffi_api.gelu(data)  # type: ignore
 
 
+def gelu_tanh(data: Expr) -> Expr:
+    """Gaussian Error Linear Units function with tanh approximation
+
+    .. math::
+        \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}(\sqrt(2 / \pi) * (x + 0.044715 * x^3)))
+
+    Parameters
+    ----------
+    data : relax.Expr
+        The input data
+
+    Returns
+    -------
+    result : relax.Expr
+        The computed result.
+
+    Note
+    ----
+    The input tensor is required to have float dtype
+    """
+    return _ffi_api.gelu_tanh(data)  # type: ignore
+
+
 def silu(data: Expr) -> Expr:
     """Sigmoid Linear Unit function
 

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -532,10 +532,10 @@ def adaptive_avg_pool2d(
 
 
 def relu(data: Expr) -> Expr:
-    """Rectified linear unit.
+    r"""Rectified linear unit.
 
     .. math::
-        text{ReLU}(x) = max(x, 0)
+        \text{ReLU}(x) = \max(x, 0)
 
     Parameters
     ----------
@@ -551,10 +551,10 @@ def relu(data: Expr) -> Expr:
 
 
 def gelu(data: Expr) -> Expr:
-    """Gaussian Error Linear Units function
+    r"""Gaussian Error Linear Units function
 
     .. math::
-        text{GeLU}(x) = 0.5 * x * (1 + erf(x * 0.5**0.5))
+        \text{GeLU}(x) = 0.5 * x * (1 + \text{erf}(x * 0.5**0.5))
 
     where :math:`erf` is the Gauss Error function.
 
@@ -576,10 +576,10 @@ def gelu(data: Expr) -> Expr:
 
 
 def gelu_tanh(data: Expr) -> Expr:
-    """Gaussian Error Linear Units function with tanh approximation
+    r"""Gaussian Error Linear Units function with tanh approximation
 
     .. math::
-        text{GELU}(x) = 0.5 * x * (1 + text{Tanh}(\sqrt(2 / \pi) * (x + 0.044715 * x^3)))
+        \text{GELU}(x) = 0.5 * x * (1 + \text{Tanh}(\sqrt(2 / \pi) * (x + 0.044715 * x^3)))
 
     Parameters
     ----------
@@ -599,10 +599,10 @@ def gelu_tanh(data: Expr) -> Expr:
 
 
 def silu(data: Expr) -> Expr:
-    """Sigmoid Linear Unit function
+    r"""Sigmoid Linear Unit function
 
     .. math::
-        text{SiLU}(x) = x * sigmoid(x)
+        \text{SiLU}(x) = x * \text{sigmoid}(x)
 
     Parameters
     ----------
@@ -624,7 +624,7 @@ def silu(data: Expr) -> Expr:
 def softmax(data: Expr, axis: int = -1) -> Expr:
     r"""Computes softmax.
 
-    .. math:: text{softmax}(x)_i = frac{exp(x_i)}{\sum_j exp(x_j)}
+    .. math:: \text{softmax}(x)_i = \frac{\exp(x_i)}{\sum_j \exp(x_j)}
 
     Parameters
     ----------

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -970,7 +970,7 @@ def CombineParallelMatmul():
     the fused ops are applied to the combined matmul output before slicing.
 
     Currently, only a limited set of fused ops is supported. It includes bias add,
-    relu, gelu, and silu activation.
+    relu, gelu, gelu_tanh and silu activation.
 
     Returns
     -------

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -31,6 +31,9 @@ RELAX_REGISTER_UNARY_NN_OP_AND_IMPL(relu, "nn.relu", /*require_float_dtype=*/fal
 /* relax.nn.gelu */
 RELAX_REGISTER_UNARY_NN_OP_AND_IMPL(gelu, "nn.gelu", /*require_float_dtype=*/true);
 
+/* relax.nn.gelu_tanh */
+RELAX_REGISTER_UNARY_NN_OP_AND_IMPL(gelu_tanh, "nn.gelu_tanh", /*require_float_dtype=*/true);
+
 /* relax.nn.silu */
 RELAX_REGISTER_UNARY_NN_OP_AND_IMPL(silu, "nn.silu", /*require_float_dtype=*/true);
 

--- a/src/relax/op/nn/nn.h
+++ b/src/relax/op/nn/nn.h
@@ -51,6 +51,9 @@ Expr relu(Expr data);
 /*! \brief Gaussian Error Linear Units function. */
 Expr gelu(Expr data);
 
+/*! \brief Gaussian Error Linear Units function approximated by tanh. */
+Expr gelu_tanh(Expr data);
+
 /*! \brief Sigmoid Linear Unit function. */
 Expr silu(Expr data);
 

--- a/src/relax/transform/combine_parallel_matmul.cc
+++ b/src/relax/transform/combine_parallel_matmul.cc
@@ -169,6 +169,8 @@ runtime::TypedPackedFunc<Map<Var, Expr>(Map<DFPattern, Var>)> GetRewriter(
           matmul_combined = relu(matmul_combined);
         } else if (*branch_info.activation == "relax.nn.gelu") {
           matmul_combined = gelu(matmul_combined);
+        } else if (*branch_info.activation == "relax.nn.gelu_tanh") {
+          matmul_combined = gelu_tanh(matmul_combined);
         } else if (*branch_info.activation == "relax.nn.silu") {
           matmul_combined = silu(matmul_combined);
         } else {
@@ -212,7 +214,7 @@ std::vector<BranchInfo> GetBranchInfo(Function f) {
   auto matmul_pat = IsOp("relax.matmul")(Wildcard(), Wildcard());
   auto bias_add_pat = IsOp("relax.add")(matmul_pat, bias_pat);
 
-  std::vector<std::string> activations{"relax.nn.relu", "relax.nn.gelu", "relax.nn.silu"};
+  std::vector<std::string> activations{"relax.nn.relu", "relax.nn.gelu", "relax.nn.gelu_tanh", "relax.nn.silu"};
 
   std::vector<DFPattern> activation_pat, bias_activation_pat;
   for (const auto& act : activations) {

--- a/src/relax/transform/combine_parallel_matmul.cc
+++ b/src/relax/transform/combine_parallel_matmul.cc
@@ -214,7 +214,8 @@ std::vector<BranchInfo> GetBranchInfo(Function f) {
   auto matmul_pat = IsOp("relax.matmul")(Wildcard(), Wildcard());
   auto bias_add_pat = IsOp("relax.add")(matmul_pat, bias_pat);
 
-  std::vector<std::string> activations{"relax.nn.relu", "relax.nn.gelu", "relax.nn.gelu_tanh", "relax.nn.silu"};
+  std::vector<std::string> activations{"relax.nn.relu", "relax.nn.gelu", "relax.nn.gelu_tanh",
+                                       "relax.nn.silu"};
 
   std::vector<DFPattern> activation_pat, bias_activation_pat;
   for (const auto& act : activations) {


### PR DESCRIPTION
# Motivation
The gelu operator has different implementations, in [PyTorch](https://pytorch.org/docs/stable/generated/torch.nn.GELU.html), they are distinguished by `approximate='none'` or `approximate='tanh'`. Currently, Relax only implements the case where `approximate="none"`  which depends on erf function, this PR implements the gelu operator approximated by tanh. In hugging face transformers, the gelu with tanh operator is called [gelu_new](https://github.com/huggingface/transformers/blob/366a8ca09e8dd92dfb1956c8be3118b5a2b13639/src/transformers/activations.py#L49) and was used in many models.

## Difference with erf gelu
Actually, I only observed a very slight numerical difference between the two implementations, so I'm still not sure whether it necessary to include this variant or not.

Below is a figure showing the numerical difference between the two, and the script:
![image](https://github.com/apache/tvm/assets/11773619/e002b8a5-9e0a-49ed-9e61-eebdfb7c0eba)

```python
import numpy as np
import torch
import torch.nn.functional as F
import matplotlib.pyplot as plt

x = np.linspace(-6, 6, 200)
x = torch.from_numpy(x).float()
y_none = F.gelu(x, approximate='none')
y_tanh = F.gelu(x, approximate='tanh')
plt.plot(x.numpy(), (y_tanh - y_none).numpy(), label='difference')
plt.legend()
plt.show()
```

The largest difference is 5e-4.