### PR TITLE
[Unity] NDArray Cache Efficient Load in OpenCL

### DIFF
--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -164,8 +164,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
OpenCL runtime may allocate mirror memory
for device memory that serves as host copy target.

This PR uses a staging buffer for parameter load
to avoid this problem.

Authored by Tianqi.

----

Co-authored-by: Tianqi Chen <tqchenml@gmail.com>