### PR TITLE
[Vulkan] Add cooperative matrix support

### DIFF
--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -174,9 +174,23 @@ class Target(Object):
         return int(self.attrs["max_num_threads"])
 
     @property
+    def max_block_size_x(self):
+        """Returns the max block size in x-dimension from the target if it exists."""
+        return int(self.attrs["max_block_size_x"])
+
+    @property
+    def max_block_size_y(self):
+        """Returns the max block size in y-dimension from the target if it exists."""
+        return int(self.attrs["max_block_size_y"])
+
+    @property
     def thread_warp_size(self):
         """Returns the thread_warp_size from the target if it exists."""
         return int(self.attrs["thread_warp_size"])
+
+    @property
+    def max_shared_memory_per_block(self):
+        return int(self.attrs["max_shared_memory_per_block"])
 
     @property
     def max_function_args(self):
@@ -218,6 +232,13 @@ class Target(Object):
     @property
     def libs(self):
         return list(self.attrs.get("libs", []))
+
+    @property
+    def supports_cooperative_matrix(self):
+        if self.attrs.get("supports_cooperative_matrix", []):
+            return bool(self.attrs["supports_cooperative_matrix"])
+        else:
+            return False
 
     @property
     def features(self):

--- a/src/runtime/vulkan/vulkan_device.cc
+++ b/src/runtime/vulkan/vulkan_device.cc
@@ -134,6 +134,8 @@ VulkanDeviceProperties::VulkanDeviceProperties(const VulkanInstance& instance,
 
   supports_integer_dot_product = device.HasExtension("VK_KHR_shader_integer_dot_product");
 
+  supports_cooperative_matrix = device.HasExtension("VK_NV_cooperative_matrix");
+
   // The check of VK_SHADER_STAGE_COMPUTE_BIT isn't technically
   // needed, since it will be set so long at least one queue has
   // VK_QUEUE_COMPUTE_BIT.  Including it to avoid potential future
@@ -435,7 +437,8 @@ std::vector<const char*> VulkanDevice::SelectEnabledExtensions() const {
                                                "VK_KHR_get_memory_requirements2",
                                                "VK_KHR_dedicated_allocation",
                                                "VK_KHR_spirv_1_4",
-                                               "VK_KHR_shader_integer_dot_product"};
+                                               "VK_KHR_shader_integer_dot_product",
+                                               "VK_NV_cooperative_matrix"};
 
   uint32_t device_extension_prop_count;
   VULKAN_CALL(vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,

--- a/src/runtime/vulkan/vulkan_device.h
+++ b/src/runtime/vulkan/vulkan_device.h
@@ -88,6 +88,7 @@ struct VulkanDeviceProperties {
   bool supports_push_descriptor{false};
   bool supports_dedicated_allocation{false};
   bool supports_integer_dot_product{false};
+  bool supports_cooperative_matrix{false};
   uint32_t supported_subgroup_operations{0};
   uint32_t max_num_threads{1};
   uint32_t thread_warp_size{1};

--- a/src/runtime/vulkan/vulkan_device_api.cc
+++ b/src/runtime/vulkan/vulkan_device_api.cc
@@ -241,6 +241,10 @@ void VulkanDeviceAPI::GetTargetProperty(Device dev, const std::string& property,
     *rv = prop.supports_integer_dot_product;
   }
 
+  if (property == "supports_cooperative_matrix") {
+    *rv = prop.supports_cooperative_matrix;
+  }
+
   if (property == "device_name") {
     *rv = prop.device_name;
   }

--- a/src/target/spirv/codegen_spirv.cc
+++ b/src/target/spirv/codegen_spirv.cc
@@ -129,6 +129,7 @@ void CodeGenSPIRV::InitFuncState() {
   builder_.reset(new spirv::IRBuilder(spirv_support_));
   builder_->InitHeader();
   shared_memory_bytes_used_ = 0;
+  fragment_info_.clear();
 }
 
 spirv::Value CodeGenSPIRV::GetThreadIndex(const IterVar& iv, const PrimExpr& extent) {
@@ -394,6 +395,120 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const CallNode* op) {
     LOG(FATAL) << "SPIR-V shader cannot make extern calls.  Graph contains extern \""
                << Downcast<StringImm>(op->args[0]) << "\"";
     return spirv::Value();
+  } else if (op->op.same_as(builtin::tvm_fill_fragment())) {
+    ICHECK_EQ(op->args.size(), 6U);
+    const VarNode* buffer_node = op->args[0].as<VarNode>();
+    ICHECK(buffer_node && fragment_info_.count(buffer_node));
+    DataType ele_dtype = GetElementDataType(buffer_node);
+    ICHECK(ele_dtype.is_float()) << "Only floating point fragment accumulator is supported";
+    spirv::SType ele_stype = builder_->GetSType(ele_dtype);
+    spirv::SType& fragment_type = fragment_info_[buffer_node].stype;
+    double init = static_cast<uint64_t>(Downcast<FloatImm>(op->args[5])->value);
+    PrimExpr prim_index = op->args[4];
+    spirv::Value init_val = builder_->GetCompositeConst(ele_stype, fragment_type, init);
+    spirv::SType ptr_type =
+        builder_->GetPointerType(fragment_type, fragment_info_[buffer_node].sclass);
+    spirv::Value index = MakeValue(prim_index);
+    ICHECK(var_map_.count(buffer_node));
+    spirv::Value ptr = builder_->StructArrayAccess(ptr_type, var_map_[buffer_node], index);
+    builder_->MakeInst(spv::OpStore, ptr, init_val, spv::MemoryAccessMaskNone);
+    return spirv::Value();
+
+  } else if (op->op.same_as(builtin::tvm_load_matrix_sync())) {
+    ICHECK_EQ(op->args.size(), 8U);
+    const VarNode* buffer_node = op->args[0].as<VarNode>();
+    ICHECK(buffer_node && fragment_info_.count(buffer_node));
+    spirv::SType& fragment_type = fragment_info_[buffer_node].stype;
+    PrimExpr dst_index = op->args[4];
+    PrimExpr src_ptr_expr = op->args[5];
+    int stride = static_cast<int>(Downcast<IntImm>(op->args[6])->value);
+    auto type_int = builder_->GetSType(DataType::Int(32));
+    spirv::Value stride_val = builder_->IntImm(type_int, stride);
+    std::string layout = (op->args[7].as<StringImmNode>())->value;
+    spirv::SType dst_ptr_type =
+        builder_->GetPointerType(fragment_type, fragment_info_[buffer_node].sclass);
+    spirv::Value dst_ptr =
+        builder_->StructArrayAccess(dst_ptr_type, var_map_[buffer_node], MakeValue(dst_index));
+    spirv::Value src_ptr = VisitExpr(op->args[5]);
+    spirv::SType type_bool = builder_->GetSType(DataType::UInt(1));
+    spirv::Value t_val = builder_->UIntImm(type_bool, 1);
+    spirv::Value f_val = builder_->UIntImm(type_bool, 0);
+    spirv::Value loaded =
+        builder_->MakeValue(spv::OpCooperativeMatrixLoadNV, fragment_type, src_ptr, stride_val,
+                            (layout != "row_major") ? t_val : f_val);
+    builder_->MakeInst(spv::OpStore, dst_ptr, loaded, spv::MemoryAccessMaskNone);
+    return spirv::Value();
+  } else if (op->op.same_as(builtin::tvm_mma_sync())) {
+    const VarNode* buffer_d = op->args[0].as<VarNode>();
+    const VarNode* buffer_a = op->args[2].as<VarNode>();
+    const VarNode* buffer_b = op->args[4].as<VarNode>();
+    const VarNode* buffer_c = op->args[6].as<VarNode>();
+    PrimExpr index_d = op->args[1];
+    PrimExpr index_a = op->args[3];
+    PrimExpr index_b = op->args[5];
+    tvm::tir::ExprDeepEqual expr_equal;
+    PrimExpr index_c = op->args[7];
+    bool is_equal = ((buffer_d == buffer_c) && expr_equal(index_d, index_c));
+    spirv::SType& fragment_type_d = fragment_info_[buffer_d].stype;
+    spirv::SType& fragment_type_a = fragment_info_[buffer_a].stype;
+    spirv::SType& fragment_type_b = fragment_info_[buffer_b].stype;
+    spirv::SType& fragment_type_c = fragment_info_[buffer_c].stype;
+    spv::StorageClass storage = fragment_info_[buffer_d].sclass;
+    spirv::SType ptr_type_d = builder_->GetPointerType(fragment_type_d, storage);
+    spirv::SType ptr_type_a = builder_->GetPointerType(fragment_type_a, storage);
+    spirv::SType ptr_type_b = builder_->GetPointerType(fragment_type_b, storage);
+    spirv::SType ptr_type_c = builder_->GetPointerType(fragment_type_c, storage);
+    spirv::Value ptr_d =
+        builder_->StructArrayAccess(ptr_type_d, var_map_[buffer_d], MakeValue(index_d));
+    spirv::Value ptr_a =
+        builder_->StructArrayAccess(ptr_type_a, var_map_[buffer_a], MakeValue(index_a));
+    spirv::Value ptr_b =
+        builder_->StructArrayAccess(ptr_type_b, var_map_[buffer_b], MakeValue(index_b));
+    spirv::Value ptr_c =
+        is_equal ? ptr_d
+                 : builder_->StructArrayAccess(ptr_type_c, var_map_[buffer_c], MakeValue(index_c));
+    uint32_t mask = spv::MemoryAccessMaskNone;
+    spirv::Value loaded_a = builder_->MakeValue(spv::OpLoad, fragment_type_a, ptr_a, mask);
+    spirv::Value loaded_b = builder_->MakeValue(spv::OpLoad, fragment_type_b, ptr_b, mask);
+    spirv::Value loaded_c = builder_->MakeValue(spv::OpLoad, fragment_type_c, ptr_c, mask);
+    spirv::Value result = builder_->MakeValue(spv::OpCooperativeMatrixMulAddNV, fragment_type_d,
+                                              loaded_a, loaded_b, loaded_c);
+    builder_->MakeInst(spv::OpStore, ptr_d, result, spv::MemoryAccessMaskNone);
+    return spirv::Value();
+  } else if (op->op.same_as(builtin::tvm_store_matrix_sync())) {
+    ICHECK_EQ(op->args.size(), 8U);
+    const VarNode* buffer_node = op->args[0].as<VarNode>();
+    PrimExpr index = op->args[4];
+    PrimExpr buffer_ptr = op->args[5];
+    int stride = static_cast<int>(Downcast<IntImm>(op->args[6])->value);
+    auto type_int = builder_->GetSType(DataType::Int(32));
+    spirv::Value stride_val = builder_->IntImm(type_int, stride);
+    std::string layout = (op->args[7].as<StringImmNode>())->value;
+    spirv::Value dst_ptr = VisitExpr(op->args[5]);
+    spirv::SType& fragment_type = fragment_info_[buffer_node].stype;
+    spv::StorageClass storage = fragment_info_[buffer_node].sclass;
+    spirv::SType ptr_type = builder_->GetPointerType(fragment_type, storage);
+    spirv::Value ptr =
+        builder_->StructArrayAccess(ptr_type, var_map_[buffer_node], MakeValue(index));
+    uint32_t mask = spv::MemoryAccessMaskNone;
+    spirv::Value loaded = builder_->MakeValue(spv::OpLoad, fragment_type, ptr, mask);
+    spirv::SType type_bool = builder_->GetSType(DataType::UInt(1));
+    spirv::Value t_val = builder_->UIntImm(type_bool, 1);
+    spirv::Value f_val = builder_->UIntImm(type_bool, 0);
+    builder_->MakeInst(spv::OpCooperativeMatrixStoreNV, dst_ptr, loaded, stride_val,
+                       (layout != "row_major") ? t_val : f_val);
+    return spirv::Value();
+  } else if (op->op.same_as(builtin::address_of())) {
+    const BufferLoadNode* load = op->args[0].as<BufferLoadNode>();
+    Var buffer_var = load->buffer->data;
+    const VarNode* buffer_node = buffer_var.get();
+    PrimExpr index = load->indices[0];
+    DataType ele_dtype = GetElementDataType(buffer_node);
+    spirv::SType ele_stype = builder_->GetSType(ele_dtype);
+    spirv::Value buffer_val = MakeValue(buffer_var);
+    spirv::SType ptr_type = builder_->GetPointerType(ele_stype, buffer_val.stype.storage_class);
+    ICHECK(var_map_.count(buffer_node));
+    return builder_->StructArrayAccess(ptr_type, var_map_[buffer_node], MakeValue(index));
   } else {
     LOG(FATAL) << "Unresolved call  " << op->op;
   }
@@ -657,22 +772,46 @@ void CodeGenSPIRV::VisitStmt_(const AllocateNode* op) {
   ICHECK_GT(constant_size, 0) << "Can only handle constant size stack allocation in GPU";
 
   spirv::Value buf;
-  auto storage_scope = runtime::StorageScope::Create(GetPtrStorageScope(op->buffer_var));
+  const std::string scope = GetPtrStorageScope(op->buffer_var);
+  auto storage_scope = runtime::StorageScope::Create(scope);
   spirv::SType etype = builder_->GetSType(op->dtype);
-  if (storage_scope.rank == runtime::StorageRank::kLocal) {
-    buf =
-        builder_->Allocate(etype, static_cast<uint32_t>(constant_size), spv::StorageClassFunction);
-  } else if (storage_scope.rank == runtime::StorageRank::kShared) {
-    // Shared memory
-    // Aligned on 4-byte boundary
-    int32_t aligned_constant_size = ((constant_size + 3) & ~0x3);
-    buf = builder_->Allocate(etype, static_cast<uint32_t>(aligned_constant_size),
-                             spv::StorageClassWorkgroup);
+  runtime::StorageRank rank = storage_scope.rank;
+  spv::StorageClass storage_class;
+  const VarNode* var_node = (op->buffer_var).get();
 
-    size_t num_bytes = op->dtype.bytes() * op->dtype.lanes() * static_cast<uint32_t>(constant_size);
-    shared_memory_bytes_used_ += num_bytes;
-  } else {
-    LOG(FATAL) << "Can only allocate shared or local memory inside kernel";
+  switch (rank) {
+    case runtime::StorageRank::kWMMAMatrixA:
+    case runtime::StorageRank::kWMMAMatrixB:
+    case runtime::StorageRank::kWMMAAccumulator: {
+      ICHECK(fragment_info_.count(var_node));
+      fragment_info_[var_node].scope = scope;
+      etype = GetFragmentSType(var_node, op->dtype);
+      storage_class = spv::StorageClassFunction;
+      fragment_info_[var_node].sclass = storage_class;
+      ICHECK(fragment_info_.count(var_node));
+      const std::string& scope = fragment_info_[var_node].scope;
+      const std::string& shape_str = fragment_info_.at(var_node).shape;
+      std::pair<int32_t, int32_t> dim = GetWmmaFragmentDimSize(shape_str, scope);
+      int64_t size = dim.first * dim.second;
+      buf = builder_->Allocate(etype, static_cast<uint32_t>(constant_size) / size, storage_class);
+    } break;
+    case runtime::StorageRank::kLocal: {
+      storage_class = spv::StorageClassFunction;
+      buf = builder_->Allocate(etype, static_cast<uint32_t>(constant_size), storage_class);
+    } break;
+    case runtime::StorageRank::kShared: {
+      storage_class = spv::StorageClassWorkgroup;
+      // Shared memory
+      // Aligned on 4-byte boundary
+      int32_t aligned_constant_size = ((constant_size + 3) & ~0x3);
+      buf = builder_->Allocate(etype, static_cast<uint32_t>(aligned_constant_size), storage_class);
+
+      size_t num_bytes =
+          op->dtype.bytes() * op->dtype.lanes() * static_cast<uint32_t>(aligned_constant_size);
+      shared_memory_bytes_used_ += num_bytes;
+    } break;
+    default:
+      LOG(FATAL) << "Can only allocate shared or local memory inside kernel";
   }
 
   builder_->SetName(buf, op->buffer_var->name_hint);
@@ -700,6 +839,13 @@ void CodeGenSPIRV::VisitStmt_(const AttrStmtNode* op) {
     const VarNode* v = op->node.as<VarNode>();
     ICHECK(v);
     storage_info_[v].is_volatile = true;
+  } else if (op->attr_key == tir::attr::buffer_bind_scope) {
+    const VarNode* v = op->node.as<VarNode>();
+    ICHECK(v);
+  } else if (op->attr_key == tir::attr::fragment_shape) {
+    const VarNode* buffer = op->node.as<VarNode>();
+    const StringImmNode* shape_str = op->value.as<StringImmNode>();
+    fragment_info_[buffer] = {shape_str->value};
   }
   this->VisitStmt(op->body);
 }
@@ -724,6 +870,23 @@ void CodeGenSPIRV::VisitStmt_(const SeqStmtNode* op) {
 }
 
 void CodeGenSPIRV::VisitStmt_(const EvaluateNode* op) { MakeValue(op->value); }
+
+spirv::SType CodeGenSPIRV::GetFragmentSType(const VarNode* buffer, const DataType& dtype) {
+  ICHECK(fragment_info_.count(buffer));
+  const std::string& scope = fragment_info_[buffer].scope;
+  const std::string& shape_str = fragment_info_.at(buffer).shape;
+  std::pair<int32_t, int32_t> dim = GetWmmaFragmentDimSize(shape_str, scope);
+  int64_t size = dim.first * dim.second;
+  spirv::SType stype = builder_->GetSType(dtype.with_lanes(size), dim.first, dim.second);
+  fragment_info_[buffer].stype = stype;
+  return stype;
+}
+
+DataType CodeGenSPIRV::GetElementDataType(const VarNode* buffer) {
+  auto it = storage_info_.find(buffer);
+  ICHECK(it != storage_info_.end());
+  return it->second.element_type;
+}
 
 }  // namespace codegen
 }  // namespace tvm

--- a/src/target/spirv/codegen_spirv.h
+++ b/src/target/spirv/codegen_spirv.h
@@ -34,6 +34,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "../../runtime/spirv/spirv_shader.h"
@@ -171,6 +172,14 @@ class CodeGenSPIRV : public ExprFunctor<spirv::Value(const PrimExpr&)>,
       element_type_known = true;
     }
   };
+
+  struct FragmentInfo {
+    std::string shape;
+    std::string scope;
+    spirv::SType stype;
+    spv::StorageClass sclass;
+  };
+
   // Reset the state so it works for a new function.
   void InitFuncState();
   // Get the thread index
@@ -178,6 +187,9 @@ class CodeGenSPIRV : public ExprFunctor<spirv::Value(const PrimExpr&)>,
 
   spirv::Value CreateStorageSync(const CallNode* op);
   void Scalarize(const PrimExpr& e, std::function<void(int i, spirv::Value v)> f);
+
+  spirv::SType GetFragmentSType(const VarNode* buffer, const DataType& dtype);
+  DataType GetElementDataType(const VarNode* buffer);
 
   // SPIRV-related capabilities of the target
   SPIRVSupport spirv_support_;
@@ -218,6 +230,8 @@ class CodeGenSPIRV : public ExprFunctor<spirv::Value(const PrimExpr&)>,
   // Running total of the number of bytes of shared memory used.
   // Checked against the max_shared_memory_per_group
   size_t shared_memory_bytes_used_{0};
+
+  std::unordered_map<const VarNode*, FragmentInfo> fragment_info_;
 };
 
 }  // namespace codegen

--- a/src/target/spirv/ir_builder.h
+++ b/src/target/spirv/ir_builder.h
@@ -65,7 +65,8 @@ enum ValueKind {
   kPushConstantPtr,
   kFunction,
   kExtInst,
-  kUniformPtr
+  kUniformPtr,
+  kSpecConst,
 };
 
 /*! \brief Represent the SPIRV Value */
@@ -443,7 +444,7 @@ class IRBuilder {
    * \param dtype The data type.
    * \return The corresponding spirv type.
    */
-  SType GetSType(const tvm::DataType& dtype);
+  SType GetSType(const tvm::DataType& dtype, uint32_t row = 0, uint32_t col = 0);
   /*!
    * \brief Get the pointer type that points to value_type
    * \param value_type.
@@ -592,6 +593,19 @@ class IRBuilder {
   Value GT(Value a, Value b);
   Value GE(Value a, Value b);
   Value Select(Value cond, Value a, Value b);
+  /*
+   * \brief Get composite constant
+   * \param ele_stype The value type of elements in the composite.
+   * \param composite_type The value type of the composite.
+   * \param dval The initial value for all elements in the composite.
+   */
+  Value GetCompositeConst(const SType& ele_stype, const SType& composite_stype, double dval);
+  /*
+   * Get specialization constant
+   * \param dtype The content value type
+   * \param value The default value
+   */
+  Value GetSpecConst(const SType& dtype, uint64_t value);
 
  private:
   /*!
@@ -640,8 +654,9 @@ class IRBuilder {
 
   // get constant given value encoded in uint64_t
   Value GetConst_(const SType& dtype, const uint64_t* pvalue);
+
   // declare type
-  SType DeclareType(const DataType& dtype);
+  SType DeclareType(const DataType& dtype, uint32_t row = 0, uint32_t col = 0);
 
   // Declare the appropriate SPIR-V capabilities and extensions to use
   // this data type.
@@ -696,13 +711,15 @@ class IRBuilder {
   /*! \brief whether push constant is defined */
   Value push_const_;
   /*! \brief map from type code to the type */
-  std::unordered_map<uint32_t, SType> pod_type_tbl_;
+  std::unordered_map<uint64_t, SType> pod_type_tbl_;
   /*! \brief map from value to array type */
   std::map<std::tuple<uint32_t, uint32_t, bool>, SType> struct_array_type_tbl_;
   /*! \brief map from value to its pointer type */
   std::map<std::pair<uint32_t, spv::StorageClass>, SType> pointer_type_tbl_;
   /*! \brief map from constant int to its value */
   std::map<std::pair<uint32_t, uint64_t>, Value> const_tbl_;
+  /*! \brief map from floating point composite constant to its value */
+  std::map<std::pair<uint32_t, double>, Value> composite_const_tbl_;
   /*! \brief map from name of a ExtInstImport to its value */
   std::map<std::string, Value> ext_inst_tbl_;
 

--- a/src/target/spirv/spirv_support.cc
+++ b/src/target/spirv/spirv_support.cc
@@ -102,6 +102,10 @@ SPIRVSupport::SPIRVSupport(tvm::Target target) {
       }
     }
   }
+  // Check whether cooperative matrix is enabled in the target string.
+  if (target->GetAttr<Bool>("supports_cooperative_matrix")) {
+    supports_cooperative_matrix = target->GetAttr<Bool>("supports_cooperative_matrix").value();
+  }
 }
 
 }  // namespace codegen

--- a/src/target/spirv/spirv_support.h
+++ b/src/target/spirv/spirv_support.h
@@ -276,6 +276,20 @@ struct SPIRVSupport {
    * attempting to perform integer dot product.
    */
   bool supports_integer_dot_product{false};
+
+  /*!
+   * \brief  Whether the driver supports operations involving cooperative matrix.
+   *
+   * Vulkan extension: VK_NV_cooperative_matrix
+   * SPV Extension name: SPV_NV_cooperative_matrix
+   * SPV Capability: spv::CapabilityCooperativeMatrixNV
+   *
+   * If support is present, can perform cooperative matrix operations.  If
+   * support is not present, codegen will throw exception on
+   * attempting to perform cooperative matrix.
+   */
+
+  bool supports_cooperative_matrix{false};
 };
 
 }  // namespace codegen

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -378,6 +378,7 @@ TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)
     .add_attr_option<Bool>("supports_push_descriptor")
     .add_attr_option<Bool>("supports_dedicated_allocation")
     .add_attr_option<Bool>("supports_integer_dot_product")
+    .add_attr_option<Bool>("supports_cooperative_matrix")
     .add_attr_option<Integer>("supported_subgroup_operations")
     // Physical device limits
     .add_attr_option<Integer>("max_num_threads", Integer(256))

--- a/src/tir/transforms/ir_utils.h
+++ b/src/tir/transforms/ir_utils.h
@@ -342,6 +342,14 @@ using StorageAlignAnnotation = Array<StorageAlignTuple>;
  */
 std::unordered_map<Var, StorageAlignAnnotation, ObjectPtrHash, ObjectPtrEqual>
 CollectStorageAlignAnnotation(const Stmt& body);
+/*!
+ * \brief Split string separated by "," to get wmma fragment dimension size.
+ * \param  shape_str The string to split.
+ * \param  scope The scope to match.
+ * \return The result pair of fragment dimension size.
+ */
+std::pair<int32_t, int32_t> GetWmmaFragmentDimSize(const std::string& shape_str,
+                                                   const std::string& scope);
 
 }  // namespace tir
 }  // namespace tvm

--- a/tests/python/unittest/test_target_codegen_vulkan.py
+++ b/tests/python/unittest/test_target_codegen_vulkan.py
@@ -29,6 +29,17 @@ import tvm.testing
 from tvm import relay, te
 from tvm.topi.math import cast
 from tvm.script import tir as T
+from tvm.tir import TensorIntrin, IntImm, Cast, Schedule
+from tvm.tir.tensor_intrin.cuda import (
+    WMMA_LOAD_16x16x16_F16_A_INTRIN,
+    WMMA_LOAD_16x16x16_F16_B_INTRIN,
+    WMMA_SYNC_16x16x16_f16f16f32_INTRIN,
+    WMMA_FILL_16x16x16_F32_INTRIN,
+    WMMA_STORE_16x16x16_F32_GLOBAL_INTRIN,
+    WMMA_SYNC_16x16x16_f16f16f16_INTRIN,
+    WMMA_FILL_16x16x16_F16_INTRIN,
+    WMMA_STORE_16x16x16_F16_GLOBAL_INTRIN,
+)
 
 
 dtype = tvm.testing.parameter("float32", "int32", "float16", "int8")
@@ -598,6 +609,123 @@ def test_negative_operand_divmod(target, dev):
 
     np.testing.assert_array_equal(a[:, 0], (np.arange(N) - offset) // divisor)
     np.testing.assert_array_equal(a[:, 1], (np.arange(N) - offset) % divisor)
+
+
+@pytest.mark.parametrize("out_dtype", ["float32", "float16"])
+def test_cooperative_matrix(out_dtype):
+    def get_matmul(m, n, k, out_dtype="float32"):
+        X = te.placeholder((m, k), name="X", dtype="float16")
+        W = te.placeholder((k, n), name="W", dtype="float16")
+        ak = te.reduce_axis((0, k), name="k")
+
+        if out_dtype == "float32":
+            matmul = te.compute(
+                (m, n),
+                lambda i, j: te.sum(
+                    X[i, ak].astype("float32") * W[ak, j].astype("float32"),
+                    axis=ak,
+                ),
+                name="compute",
+            )
+        else:
+            matmul = te.compute(
+                (m, n),
+                lambda i, j: te.sum(X[i, ak] * W[ak, j], axis=ak),
+                name="compute",
+            )
+
+        return te.create_prim_func([X, W, matmul])
+
+    M, N, K = 16, 16, 32
+    func = get_matmul(M, N, K, out_dtype)
+    sch = Schedule(func)
+    block = sch.get_block("compute")
+
+    i, j, k = sch.get_loops(block)
+    i_outer, i_inner = sch.split(i, factors=[None, 16])
+    j_outer, j_inner = sch.split(j, factors=[None, 16])
+    k_outer, k_inner = sch.split(k, factors=[None, 16])
+    sch.reorder(i_outer, j_outer, k_outer, i_inner, j_inner, k_inner)
+    fused_outer = sch.fuse(i_outer, j_outer)
+    sch.bind(fused_outer, "blockIdx.x")
+
+    def fetch_to_shared(block, idx):
+        block_read = sch.cache_read(block, idx, "shared")
+        sch.compute_at(block_read, k_outer)
+        warp_size = 32
+
+        fused = sch.fuse(*sch.get_loops(block_read)[-2:])
+
+        vector_size = 4
+        _, f_2, f_3 = sch.split(fused, factors=[None, warp_size, vector_size])
+        sch.bind(f_2, "threadIdx.x")
+        sch.vectorize(f_3)
+
+    def tensorize_load(block, dim):
+        loops = sch.get_loops(block)
+        i, j = loops[-dim : (len(loops) - dim + 2)]
+
+        i0, i1 = sch.split(i, factors=[None, 16])
+        j0, j1 = sch.split(j, factors=[None, 16])
+        sch.reorder(i0, j0, i1, j1)
+        sch.unroll(i0)
+        sch.unroll(j0)
+        return i1
+
+    fetch_to_shared(block, 0)
+    fetch_to_shared(block, 1)
+
+    c_warp_scope = "wmma.accumulator"
+    a_warp_scope = "wmma.matrix_a"
+    b_warp_scope = "wmma.matrix_b"
+
+    A_mat = sch.cache_read(block, 0, a_warp_scope)
+    B_mat = sch.cache_read(block, 1, b_warp_scope)
+
+    loop_a = tensorize_load(A_mat, 2)
+    sch.tensorize(loop_a, WMMA_LOAD_16x16x16_F16_A_INTRIN)
+
+    loop_b = tensorize_load(B_mat, 2)
+    sch.tensorize(loop_b, WMMA_LOAD_16x16x16_F16_B_INTRIN)
+
+    store = sch.cache_write(block, 0, c_warp_scope)
+    sch.reverse_compute_at(store, fused_outer)
+    init = sch.decompose_reduction(block, sch.get_loops(block)[1])
+
+    intrin = WMMA_FILL_16x16x16_F32_INTRIN
+    if out_dtype == "float16":
+        intrin = WMMA_FILL_16x16x16_F16_INTRIN
+    sch.tensorize(sch.get_loops(init)[1], intrin)
+
+    intrin = WMMA_STORE_16x16x16_F32_GLOBAL_INTRIN
+    if out_dtype == "float16":
+        intrin = WMMA_STORE_16x16x16_F16_GLOBAL_INTRIN
+    sch.tensorize(sch.get_loops(store)[1], intrin)
+
+    intrin = WMMA_SYNC_16x16x16_f16f16f32_INTRIN
+    if out_dtype == "float16":
+        intrin = WMMA_SYNC_16x16x16_f16f16f16_INTRIN
+    sch.tensorize(sch.get_loops(block)[2], intrin)
+
+    target = "vulkan -from_device=0"
+    tgt_attrs = tvm.target.Target(target).attrs
+
+    if tgt_attrs.get("supports_cooperative_matrix"):
+        f = tvm.build(sch.mod, target=target)
+
+        dev = tvm.device(target, 0)
+
+        A = tvm.nd.array(np.random.randn(M, K).astype("float16"), dev)
+        B = tvm.nd.array(np.random.randn(K, N).astype("float16"), dev)
+        C = tvm.nd.array(np.random.randn(M, N).astype(out_dtype), dev)
+
+        f(A, B, C)
+
+        A_np = A.numpy()
+        B_np = B.numpy()
+        ref = np.dot(A_np.astype("float32"), B_np.astype("float32"))
+
+        tvm.testing.assert_allclose(C.numpy(), ref, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[Vulkan] Add SPIR-V code generation for "SPV_NV_cooperative_matrix" extension
Add im2col implementation for direct Conv2D.  Currently only 16x16x16 FP16 wmma fragments with FP32 intermediates are supported.  Add "min_design_space" as a parameter to give minimum design space for meta scheduler tuning. Add "use_int32_const" as a paramter to use int32 type for constants. Allow target query to be called from the schedules so that samplings are constrained to produce legal schedules. Do not allow the reuse of buffers with different dtypes. Add a unit test test_wmma.py.