### PR TITLE
[Unity] Cover all Relax functions in implicit attention rewrite

### DIFF
--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -435,10 +435,10 @@ def partition_for_cutlass(mod, annotate_codegen=True):
         The resulting IRModule, containing partitioned subgraphs to be
         compiled by the CUTLASS backend.
     """
-    for gv, func in mod.functions.items():
+    for func_name, func in mod.functions.items():
         if isinstance(func, Function):
             for pattern, rewriter in _REWRITE_PATTERNS:
-                mod[gv] = rewrite_call(pattern, rewriter, func)
+                mod[func_name] = rewrite_call(pattern, rewriter, func)
     patterns = get_patterns_with_prefix("cutlass")
     return tvm.transform.Sequential(
         [

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -17,24 +17,24 @@
 
 """Pattern table for CUTLASS backend"""
 import operator
-from typing import Mapping, Sequence
 from functools import reduce
+from typing import Mapping, Sequence
 
 import tvm
 from tvm.contrib.cutlass.build import is_shape_valid_for_cutlass_matmul
-from tvm.relax import DataflowVar, Var, transform, Call, PyExprMutator, expr_functor, Function
-from tvm.relax.transform import PatternCheckContext
+from tvm.relax import Call, DataflowVar, Function, PyExprMutator, Var, expr_functor, transform
 from tvm.relax.dpl import rewrite_call
+from tvm.relax.transform import PatternCheckContext
 
 from ..pattern_registry import get_patterns_with_prefix, register_patterns
 from ..patterns import (
     make_attention_pattern,
+    make_attention_rewrite_pattern,
     make_fused_bias_activation_pattern,
+    make_layer_norm_pattern,
     make_matmul_pattern,
     make_residual_block_pattern,
     make_stacked_attention_pattern,
-    make_layer_norm_pattern,
-    make_attention_rewrite_pattern,
 )
 
 
@@ -435,8 +435,10 @@ def partition_for_cutlass(mod, annotate_codegen=True):
         The resulting IRModule, containing partitioned subgraphs to be
         compiled by the CUTLASS backend.
     """
-    for pattern, rewriter in _REWRITE_PATTERNS:
-        mod["main"] = rewrite_call(pattern, rewriter, mod["main"])
+    for gv, func in mod.functions.items():
+        if isinstance(func, Function):
+            for pattern, rewriter in _REWRITE_PATTERNS:
+                mod[gv] = rewrite_call(pattern, rewriter, func)
     patterns = get_patterns_with_prefix("cutlass")
     return tvm.transform.Sequential(
         [


### PR DESCRIPTION
This PR avoids the usage of hardcoded 'main' function in implicit attention rewrite.

cc @cyx-6 @zxybazh 