### PR TITLE
[TFLite][Frontend] Generate name when tensor name is missing

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -4116,7 +4116,12 @@ def get_tensor_name(subgraph, tensor_idx):
     -------
         tensor name in UTF-8 encoding
     """
-    return subgraph.Tensors(tensor_idx).Name().decode("utf-8")
+    tensor_name = subgraph.Tensors(tensor_idx).Name()
+    if tensor_name is not None:
+        tensor_name = tensor_name.decode("utf-8")
+    else:
+        tensor_name = "tvmgen_tensor_" + str(tensor_idx)
+    return tensor_name
 
 
 def _decode_type(n):
@@ -4150,7 +4155,8 @@ def _input_type(model):
             tensor = subgraph.Tensors(input_)
             input_shape = tuple(tensor.ShapeAsNumpy())
             tensor_type = tensor.Type()
-            input_name = tensor.Name().decode("utf8")
+            tensor_name = get_tensor_name(subgraph, input_)
+            input_name = tensor_name if isinstance(tensor_name, str) else tensor_name.decode("utf8")
             shape_dict[input_name] = input_shape
             dtype_dict[input_name] = _decode_type(tensor_type)
 

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -4155,8 +4155,7 @@ def _input_type(model):
             tensor = subgraph.Tensors(input_)
             input_shape = tuple(tensor.ShapeAsNumpy())
             tensor_type = tensor.Type()
-            tensor_name = get_tensor_name(subgraph, input_)
-            input_name = tensor_name if isinstance(tensor_name, str) else tensor_name.decode("utf8")
+            input_name = get_tensor_name(subgraph, input_)
             shape_dict[input_name] = input_shape
             dtype_dict[input_name] = _decode_type(tensor_type)
 

--- a/tests/python/contrib/test_cmsisnn/test_networks.py
+++ b/tests/python/contrib/test_cmsisnn/test_networks.py
@@ -128,7 +128,7 @@ def test_keyword_scramble():
     base_url = (
         "https://github.com/tensorflow/tflite-micro/raw/"
         "de8f61a074460e1fa5227d875c95aa303be01240/"
-        "tensorflow/lite/micro/models/"
+        "tensorflow/lite/micro/models"
     )
     file_to_download = "keyword_scrambled.tflite"
     file_saved = "keyword_scrambled.tflite"

--- a/tests/python/contrib/test_cmsisnn/test_networks.py
+++ b/tests/python/contrib/test_cmsisnn/test_networks.py
@@ -120,5 +120,32 @@ def test_cnn_small(test_runner):
     )
 
 
+@tvm.testing.requires_package("tflite")
+def test_keyword_scramble():
+    """Download keyword_scrambled and test for Relay conversion.
+    In future, this test can be extended for CMSIS-NN"""
+    # download the model
+    base_url = (
+        "https://github.com/tensorflow/tflite-micro/raw/"
+        "de8f61a074460e1fa5227d875c95aa303be01240/"
+        "tensorflow/lite/micro/models/"
+    )
+    file_to_download = "keyword_scrambled.tflite"
+    file_saved = "keyword_scrambled.tflite"
+    model_file = download_testdata("{}/{}".format(base_url, file_to_download), file_saved)
+
+    with open(model_file, "rb") as f:
+        tflite_model_buf = f.read()
+
+    input_shape = (1, 96)
+    dtype = "int8"
+    in_min, in_max = get_dtype_range(dtype)
+    rng = np.random.default_rng(12345)
+    input_data = rng.integers(in_min, high=in_max, size=input_shape, dtype=dtype)
+
+    with pytest.raises(tvm.error.OpNotImplemented):
+        _, _ = _convert_to_relay(tflite_model_buf, input_data, "input")
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/scripts/request_hook/request_hook.py
+++ b/tests/scripts/request_hook/request_hook.py
@@ -212,7 +212,7 @@ URL_MAP = {
     "https://github.com/tlc-pack/web-data/raw/main/testdata/microTVM/data/image_classification_int8_0.npy": f"{BASE}/tlc-pack/web-data/raw/main/testdata/microTVM/data/image_classification_int8_0.npy",
     "https://github.com/tlc-pack/web-data/raw/main/testdata/microTVM/data/vww_sample_person.jpg": f"{BASE}/tlc-pack/web-data/testdata/microTVM/data/vww_sample_person.jpg",
     "https://github.com/tlc-pack/web-data/raw/main/testdata/microTVM/data/vww_sample_not_person.jpg": f"{BASE}/tlc-pack/web-data/testdata/microTVM/data/vww_sample_not_person.jpg",
-    "https://github.com/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/models/keyword_scrambled_8bit.tflite": f"{BASE}/models/tflite/keyword_scrambled_8bit.tflite",
+    "https://github.com/tensorflow/tflite-micro/raw/de8f61a074460e1fa5227d875c95aa303be01240/tensorflow/lite/micro/models/keyword_scrambled.tflite": f"{BASE}/models/tflite/keyword_scrambled_8bit.tflite",
 }
 
 

--- a/tests/scripts/request_hook/request_hook.py
+++ b/tests/scripts/request_hook/request_hook.py
@@ -212,6 +212,7 @@ URL_MAP = {
     "https://github.com/tlc-pack/web-data/raw/main/testdata/microTVM/data/image_classification_int8_0.npy": f"{BASE}/tlc-pack/web-data/raw/main/testdata/microTVM/data/image_classification_int8_0.npy",
     "https://github.com/tlc-pack/web-data/raw/main/testdata/microTVM/data/vww_sample_person.jpg": f"{BASE}/tlc-pack/web-data/testdata/microTVM/data/vww_sample_person.jpg",
     "https://github.com/tlc-pack/web-data/raw/main/testdata/microTVM/data/vww_sample_not_person.jpg": f"{BASE}/tlc-pack/web-data/testdata/microTVM/data/vww_sample_not_person.jpg",
+    "https://github.com/tensorflow/tflite-micro/raw/main/tensorflow/lite/micro/models/keyword_scrambled_8bit.tflite": f"{BASE}/models/tflite/keyword_scrambled_8bit.tflite",
 }
 
 


### PR DESCRIPTION
After upgrade to TFLite 2.6, some networks have missing tensor names.
This commit generates names with prefix tvmgen_ from TFLite frontend.

cc @leandron @lhutton1 @NicolaLancellotti 