### PR TITLE
[BugFix] Fix memory leak in Registry::Remove

### DIFF
--- a/src/runtime/registry.cc
+++ b/src/runtime/registry.cc
@@ -80,6 +80,7 @@ bool Registry::Remove(const std::string& name) {
   std::lock_guard<std::mutex> lock(m->mutex);
   auto it = m->fmap.find(name);
   if (it == m->fmap.end()) return false;
+  delete it->second;
   m->fmap.erase(it);
   return true;
 }


### PR DESCRIPTION
The Registry should be deleted before being erased from the map. Otherwise, there will be a memory leak.