### PR TITLE
[Bugfix][Relay] Fix AdaptiveAvgPool2d about wrong dtype prasing

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1107,6 +1107,10 @@ class PyTorchOpConverter:
     def adaptive_avg_pool(self, op, inputs, input_types):
         data = inputs[0]
         output_size = inputs[1]
+        for i, item in enumerate(output_size):
+            if isinstance(item, tvm.relay.expr.Constant):
+                # convert Constant to int
+                output_size[i] = item.data.numpy()[()]
 
         def func(x):
             return op(x, output_size=output_size)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -869,6 +869,9 @@ def test_forward_adaptive_avgpool():
     input_data = torch.rand([1, 3, 10]).float()
     verify_model(torch.nn.AdaptiveAvgPool1d([1]).eval(), input_data=input_data)
     verify_model(torch.nn.AdaptiveAvgPool1d([5]).eval(), input_data=input_data)
+    
+    input_data = torch.rand([1, 3, 5, 6]).float()
+    verify_model(torch.nn.AdaptiveAvgPool1d([3, None]).eval(), input_data=input_data)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -871,7 +871,7 @@ def test_forward_adaptive_avgpool():
     verify_model(torch.nn.AdaptiveAvgPool1d([5]).eval(), input_data=input_data)
 
     input_data = torch.rand([1, 3, 5, 6]).float()
-    verify_model(torch.nn.AdaptiveAvgPool1d([3, None]).eval(), input_data=input_data)
+    verify_model(torch.nn.AdaptiveAvgPool2d([3, None]).eval(), input_data=input_data)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -869,7 +869,7 @@ def test_forward_adaptive_avgpool():
     input_data = torch.rand([1, 3, 10]).float()
     verify_model(torch.nn.AdaptiveAvgPool1d([1]).eval(), input_data=input_data)
     verify_model(torch.nn.AdaptiveAvgPool1d([5]).eval(), input_data=input_data)
-    
+
     input_data = torch.rand([1, 3, 5, 6]).float()
     verify_model(torch.nn.AdaptiveAvgPool1d([3, None]).eval(), input_data=input_data)
 


### PR DESCRIPTION
This PR is to fix the bug in the [issue-14794](https://github.com/apache/tvm/issues/14794). 

When the `output_size`  include a None, TVM can correctly parse the `None` according to the input, but give a wrong dtype (i.e., tvm.relay.expr.Constant). This pr fixes it by converting the `tvm.relay.expr.Constant` to 'int'.

cc @echuraev @Hzfengsy 