### PR TITLE
[TVMScript] Print Executor, Runtime, and FunctionInfo as metadata

### DIFF
--- a/src/script/printer/ir/relay.cc
+++ b/src/script/printer/ir/relay.cc
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <tvm/relay/executor.h>
+#include <tvm/relay/runtime.h>
+
+#include "../../../relay/backend/utils.h"
+#include "./utils.h"
+
+namespace tvm {
+namespace script {
+namespace printer {
+
+TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
+    .set_dispatch<relay::Executor>("", [](relay::Executor ty, ObjectPath p, IRDocsifier d) -> Doc {
+      return d->AddMetadata(ty);
+    });
+
+TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
+    .set_dispatch<relay::Runtime>("", [](relay::Runtime ty, ObjectPath p, IRDocsifier d) -> Doc {
+      return d->AddMetadata(ty);
+    });
+
+TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
+    .set_dispatch<relay::backend::FunctionInfo>("",
+                                                [](relay::backend::FunctionInfo ty, ObjectPath p,
+                                                   IRDocsifier d) -> Doc {
+                                                  return d->AddMetadata(ty);
+                                                });
+
+}  // namespace printer
+}  // namespace script
+}  // namespace tvm


### PR DESCRIPTION
Instances of `relay::Executor`, `relay::Runtime`, and `relay::backend::FunctionInfo` may be inserted into a PrimFunc's attributes for bookkeeping purposes.  In these flows, the function should still be able to be printed for debugging purposes.