### PR TITLE
[Unity][FX] Add support for PT2.0 scaled_dot_product_attention

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1003,12 +1003,21 @@ class TorchFXImporter:
         )
 
     def _scaled_dot_product_attention(self, node: fx.node.Node) -> relax.Var:
-        assert len(node.args) == 3, "Attention mask, dropout, and causal masking are not supported."
+        assert len(node.args) <= 4, "Dropout, and causal masking are not supported."
         transpose_S_H = lambda tensor: relax.op.permute_dims(tensor, [0, 2, 1, 3])
         query = transpose_S_H(self.env[node.args[0]])
         key = transpose_S_H(self.env[node.args[1]])
         value = transpose_S_H(self.env[node.args[2]])
-        return self.block_builder.emit(relax.op.nn.attention(query, key, value))
+
+        if len(node.args) == 4:
+            mask = self.env[node.args[3]]
+            msg = "Only a float mask is supported for the attn_mask input."
+            assert "float" in mask.struct_info.dtype, msg
+            attn = relax.op.nn.attention(query, key, value, bias=mask)
+        else:
+            attn = relax.op.nn.attention(query, key, value)
+
+        return self.block_builder.emit(attn)
 
     ########## Others ##########
 

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1008,11 +1008,7 @@ class TorchFXImporter:
         query = transpose_S_H(self.env[node.args[0]])
         key = transpose_S_H(self.env[node.args[1]])
         value = transpose_S_H(self.env[node.args[2]])
-        return self.block_builder.emit(
-            relax.op.nn.attention(
-                query, key, value
-            )
-        )
+        return self.block_builder.emit(relax.op.nn.attention(query, key, value))
 
     ########## Others ##########
 

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -36,7 +36,6 @@ def verify_model(torch_model, input_info, binding, expected):
     tvm.ir.assert_structural_equal(mod, expected)
 
 
-@tvm.testing.requires_gpu
 def test_conv1d():
     import torch
     from torch.nn import Module
@@ -122,7 +121,6 @@ def test_conv1d():
     verify_model(model, input_info, binding, expected2)
 
 
-@tvm.testing.requires_gpu
 def test_conv2d():
     import torch
     from torch.nn import Module
@@ -208,7 +206,6 @@ def test_conv2d():
     verify_model(model, input_info, binding, expected2)
 
 
-@tvm.testing.requires_gpu
 def test_linear():
     import torch
     from torch.nn import Module
@@ -311,7 +308,6 @@ def test_linear():
     )
 
 
-@tvm.testing.requires_gpu
 def test_bmm():
     import torch
     from torch.nn import Module
@@ -350,7 +346,6 @@ def test_bmm():
     )
 
 
-@tvm.testing.requires_gpu
 def test_baddbmm():
     import torch
     from torch.nn import Module
@@ -419,7 +414,6 @@ def test_baddbmm():
     )
 
 
-@tvm.testing.requires_gpu
 def test_relu():
     import torch
     from torch.nn import Module
@@ -456,7 +450,6 @@ def test_relu():
     verify_model(ReLU1(), input_info, {}, expected)
 
 
-@tvm.testing.requires_gpu
 def test_relu6():
     import torch
     from torch.nn import Module
@@ -486,7 +479,6 @@ def test_relu6():
     verify_model(ReLU6(), input_info, {}, expected)
 
 
-@tvm.testing.requires_gpu
 def test_maxpool2d():
     import torch
     from torch.nn import Module
@@ -588,7 +580,6 @@ def test_maxpool2d():
     verify_model(MaxPool2d3(), input_info, {}, expected3)
 
 
-@tvm.testing.requires_gpu
 def test_avgpool2d():
     import torch
     from torch.nn import Module
@@ -665,7 +656,6 @@ def test_avgpool2d():
     verify_model(AvgPool2d3(), input_info, {}, expected2)
 
 
-@tvm.testing.requires_gpu
 def test_adaptive_avgpool2d():
     import torch
     from torch.nn import Module
@@ -706,7 +696,6 @@ def test_adaptive_avgpool2d():
     verify_model(AdaptiveAvgPool2d1(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_flatten():
     import torch
     from torch.nn import Module
@@ -743,7 +732,6 @@ def test_flatten():
     verify_model(torch.nn.Flatten(2, -1), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_batchnorm2d():
     import torch
     from torch.nn import Module
@@ -803,7 +791,6 @@ def test_batchnorm2d():
     verify_model(BatchNorm2d(), input_info, binding, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_embedding():
     import torch
     from torch.nn import Module
@@ -840,7 +827,6 @@ def test_embedding():
     verify_model(model, input_info, binding, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_dropout():
     import torch
     from torch.nn import Module
@@ -878,7 +864,6 @@ def test_dropout():
     verify_model(Dropout2(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_layernorm():
     import torch
     from torch.nn import Module
@@ -927,7 +912,6 @@ def test_layernorm():
     verify_model(LayerNorm(), input_info, binding, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_functional_layernorm():
     import torch
     from torch.nn import Module
@@ -979,7 +963,6 @@ def test_functional_layernorm():
     verify_model(model, input_info, binding, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_cross_entropy():
     import torch
     from torch.nn import Module
@@ -1072,7 +1055,6 @@ def test_cross_entropy():
     verify_model(CrossEntropy3(), input_info, {}, expected3)
 
 
-@tvm.testing.requires_gpu
 def test_functional_cross_entropy():
     import torch
     from torch.nn import Module
@@ -1105,7 +1087,6 @@ def test_functional_cross_entropy():
     verify_model(model, input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_silu():
     import torch
     from torch.nn import Module
@@ -1144,7 +1125,6 @@ def test_silu():
     verify_model(SiLU2(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_groupnorm():
     import torch
     from torch.nn import Module
@@ -1194,7 +1174,6 @@ def test_groupnorm():
     verify_model(model, input_info, binding, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_softmax():
     import torch
     from torch.nn import Module
@@ -1228,7 +1207,6 @@ def test_softmax():
     verify_model(Softmax(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_binary():
     import torch
     from torch.nn import Module
@@ -1513,7 +1491,6 @@ def test_binary():
     verify_model(LT2(), input_info2, {}, expected14)
 
 
-@tvm.testing.requires_gpu
 def test_size():
     import torch
     from torch.nn import Module
@@ -1540,7 +1517,6 @@ def test_size():
     verify_model(Size(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_squeeze():
     import torch
     from torch.nn import Module
@@ -1586,7 +1562,6 @@ def test_squeeze():
     verify_model(Squeeze2(), input_info, {}, Expected2)
 
 
-@tvm.testing.requires_gpu
 def test_unsqueeze():
     import torch
     from torch.nn import Module
@@ -1634,7 +1609,6 @@ def test_unsqueeze():
     verify_model(Unsqueeze2(), input_info, {}, expected2)
 
 
-@tvm.testing.requires_gpu
 def test_getattr():
     import torch
     from torch.nn import Module
@@ -1661,7 +1635,6 @@ def test_getattr():
     verify_model(GetAttr1(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_getitem():
     import torch
     from torch.nn import Module
@@ -1718,7 +1691,6 @@ def test_getitem():
     verify_model(Slice2(), [([8, 16], "float32")], {}, expected2)
 
 
-@tvm.testing.requires_gpu
 def test_unary():
     import torch
     from torch.nn import Module
@@ -1849,7 +1821,6 @@ def test_unary():
     verify_model(Round(), input_info, {}, expected5)
 
 
-@tvm.testing.requires_gpu
 def test_gelu():
     import torch
     from torch.nn import Module
@@ -1879,7 +1850,6 @@ def test_gelu():
     verify_model(Gelu(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_tanh():
     import torch
     from torch.nn import Module
@@ -1909,7 +1879,6 @@ def test_tanh():
     verify_model(Tanh(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_clamp():
     import torch
     from torch import fx
@@ -1964,7 +1933,6 @@ def test_clamp():
         from_fx(gm, input_info)
 
 
-@tvm.testing.requires_gpu
 def test_interpolate():
     import torch
     from torch.nn import Module
@@ -2006,7 +1974,6 @@ def test_interpolate():
     verify_model(Interpolate(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_addmm():
     import torch
     from torch.nn import Module
@@ -2043,7 +2010,6 @@ def test_addmm():
     verify_model(Addmm(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_split():
     import torch
     from torch.nn import Module
@@ -2085,7 +2051,6 @@ def test_split():
     verify_model(Split(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_cumsum():
     import torch
     from torch.nn import Module
@@ -2115,7 +2080,6 @@ def test_cumsum():
     verify_model(Cumsum(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_chunk():
     import torch
     from torch.nn import Module
@@ -2157,7 +2121,6 @@ def test_chunk():
     verify_model(Chunk(), input_info, {}, Expected)
 
 
-@tvm.testing.requires_gpu
 def test_inplace_fill():
     import torch
     from torch.nn import Module
@@ -2185,7 +2148,6 @@ def test_inplace_fill():
     verify_model(InplaceFill(), [([10, 10], "float32")], {}, Expected)
 
 
-@tvm.testing.requires_gpu
 def test_arange():
     import numpy as np
     import torch
@@ -2210,7 +2172,6 @@ def test_arange():
     )
 
 
-@tvm.testing.requires_gpu
 def test_empty():
     import torch
     from torch import fx
@@ -2233,7 +2194,6 @@ def test_empty():
     assert mod["main"].body.blocks[0].bindings[0].value.data.dtype == "float32"
 
 
-@tvm.testing.requires_gpu
 def test_tensor():
     import torch
     from torch import fx
@@ -2268,7 +2228,6 @@ def test_tensor():
     assert mod2["main"].body.blocks[0].bindings[0].value.data.dtype == "int64"
 
 
-@tvm.testing.requires_gpu
 def test_tril():
     import torch
     from torch.nn import Module
@@ -2304,7 +2263,6 @@ def test_tril():
     verify_model(InplaceTril(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_triu():
     import torch
     from torch.nn import Module
@@ -2340,7 +2298,6 @@ def test_triu():
     verify_model(InplaceTriu(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_new_ones():
     import torch
     from torch.nn import Module
@@ -2370,7 +2327,6 @@ def test_new_ones():
     verify_model(NewOnes(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_expand():
     import torch
     from torch.nn import Module
@@ -2400,7 +2356,6 @@ def test_expand():
     verify_model(Expand(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_reduce():
     import torch
     from torch.nn import Module
@@ -2431,7 +2386,6 @@ def test_reduce():
     verify_model(Sum(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_datatype():
     import torch
     from torch.nn import Module
@@ -2501,7 +2455,6 @@ def test_datatype():
     verify_model(AsType(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_permute():
     import torch
     from torch.nn import Module
@@ -2531,7 +2484,6 @@ def test_permute():
     verify_model(Permute(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_reshape():
     import torch
     from torch.nn import Module
@@ -2559,7 +2511,6 @@ def test_reshape():
     verify_model(Reshape(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_transpose():
     import torch
     from torch.nn import Module
@@ -2589,7 +2540,6 @@ def test_transpose():
     verify_model(Transpose(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_view():
     import torch
     from torch.nn import Module
@@ -2617,7 +2567,6 @@ def test_view():
     verify_model(View(), input_info, {}, expected1)
 
 
-@tvm.testing.requires_gpu
 def test_keep_params():
     import torch
     from torch import fx
@@ -2678,7 +2627,6 @@ def test_keep_params():
     tvm.testing.assert_allclose(params[1].numpy(), model.conv.weight.detach().numpy())
 
 
-@tvm.testing.requires_gpu
 def test_unwrap_unit_return_tuple():
     import torch.fx as fx
     from torch.nn import Module
@@ -2707,7 +2655,6 @@ def test_unwrap_unit_return_tuple():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
-@tvm.testing.requires_gpu
 def test_no_bind_return_tuple():
     import torch.fx as fx
     from torch.nn import Module
@@ -2740,7 +2687,6 @@ def test_no_bind_return_tuple():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
-@tvm.testing.requires_gpu
 def test_argmax():
     import torch
     from torch.nn import Module
@@ -2783,7 +2729,6 @@ def test_argmax():
     verify_model(Argmax2(), [([256, 256], "float32")], {}, Expected2)
 
 
-@tvm.testing.requires_gpu
 def test_argmin():
     import torch
     from torch.nn import Module
@@ -2826,7 +2771,6 @@ def test_argmin():
     verify_model(Argmin2(), [([256, 256], "float32")], {}, Expected2)
 
 
-@tvm.testing.requires_gpu
 def test_to():
     import torch
     from torch.nn import Module
@@ -2866,7 +2810,6 @@ def test_to():
     verify_model(To2(), [([256, 256], "float32")], {}, Expected2)
 
 
-@tvm.testing.requires_gpu
 def test_mean():
     import torch
     from torch.nn import Module
@@ -2905,7 +2848,6 @@ def test_mean():
     verify_model(MeanKeepDim(), [([256, 256], "float32")], {}, Expected2)
 
 
-@tvm.testing.requires_gpu
 def test_rsqrt():
     import torch
     from torch.nn import Module
@@ -2929,7 +2871,6 @@ def test_rsqrt():
     verify_model(Rsqrt(), [([256, 256], "float32")], {}, Expected1)
 
 
-@tvm.testing.requires_gpu
 def test_neg():
     import torch
     from torch.nn import Module
@@ -2953,7 +2894,6 @@ def test_neg():
     verify_model(Neg(), [([256, 256], "float32")], {}, Expected1)
 
 
-@tvm.testing.requires_gpu
 def test_max():
     import torch
     from torch.nn import Module

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -17,6 +17,8 @@
 import pytest
 import torch
 import torch.nn.functional as F
+from torch import fx
+from torch.nn import Module
 
 import tvm
 from tvm import relax
@@ -24,13 +26,11 @@ import tvm.testing
 from tvm.script import ir as I
 from tvm.script import relax as R
 from tvm.script import tir as T
+from tvm.relax.frontend import detach_params
+from tvm.relax.frontend.torch import from_fx
 
 
 def verify_model(torch_model, input_info, binding, expected):
-    import torch
-    from torch import fx
-    from tvm.relax.frontend.torch import from_fx
-
     graph_model = fx.symbolic_trace(torch_model)
     mod = from_fx(graph_model, input_info)
     binding = {k: tvm.nd.array(v) for k, v in binding.items()}
@@ -39,12 +39,6 @@ def verify_model(torch_model, input_info, binding, expected):
 
 
 def test_conv1d():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     class Conv1D1(Module):
         def __init__(self):
             super().__init__()
@@ -124,12 +118,6 @@ def test_conv1d():
 
 
 def test_conv2d():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     class Conv2D1(Module):
         def __init__(self):
             super().__init__()
@@ -209,12 +197,6 @@ def test_conv2d():
 
 
 def test_linear():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     # nn.Linear
     class Dense1(Module):
         def __init__(self):
@@ -311,12 +293,6 @@ def test_linear():
 
 
 def test_bmm():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     class BMM(Module):
         def __init__(self):
             super().__init__()
@@ -349,12 +325,6 @@ def test_bmm():
 
 
 def test_baddbmm():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     class BAddBMM1(Module):
         def __init__(self):
             super().__init__()
@@ -417,11 +387,6 @@ def test_baddbmm():
 
 
 def test_relu():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-
     class ReLU0(Module):
         def __init__(self):
             super().__init__()
@@ -453,11 +418,6 @@ def test_relu():
 
 
 def test_relu6():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-
     class ReLU6(Module):
         def __init__(self):
             super().__init__()
@@ -482,12 +442,6 @@ def test_relu6():
 
 
 def test_maxpool2d():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class MaxPool2d(Module):
@@ -583,12 +537,6 @@ def test_maxpool2d():
 
 
 def test_avgpool2d():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class AvgPool2d(Module):
@@ -659,12 +607,6 @@ def test_avgpool2d():
 
 
 def test_adaptive_avgpool2d():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class AdaptiveAvgPool2d0(Module):
@@ -699,12 +641,6 @@ def test_adaptive_avgpool2d():
 
 
 def test_flatten():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Flatten(Module):
@@ -735,12 +671,6 @@ def test_flatten():
 
 
 def test_batchnorm2d():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class BatchNorm2d(Module):
@@ -794,12 +724,6 @@ def test_batchnorm2d():
 
 
 def test_embedding():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([4], "int64")]
 
     class Embedding(Module):
@@ -830,12 +754,6 @@ def test_embedding():
 
 
 def test_dropout():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Dropout1(Module):
@@ -867,12 +785,6 @@ def test_dropout():
 
 
 def test_layernorm():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class LayerNorm(Module):
@@ -915,12 +827,6 @@ def test_layernorm():
 
 
 def test_functional_layernorm():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class LayerNorm(Module):
@@ -966,12 +872,6 @@ def test_functional_layernorm():
 
 
 def test_cross_entropy():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([3, 2], "float32"), ([3], "int32")]
 
     class CrossEntropy1(Module):
@@ -1058,12 +958,6 @@ def test_cross_entropy():
 
 
 def test_functional_cross_entropy():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([3, 10], "float32"), ([3], "int32")]
 
     class CrossEntropy(Module):
@@ -1090,12 +984,6 @@ def test_functional_cross_entropy():
 
 
 def test_silu():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class SiLU(Module):
@@ -1177,12 +1065,6 @@ def test_groupnorm():
 
 
 def test_softmax():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Softmax(Module):
@@ -1210,12 +1092,6 @@ def test_softmax():
 
 
 def test_binary():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info1 = [([1, 3, 10, 10], "float32"), ([1, 3, 10, 10], "float32")]
     input_info2 = [([1, 3, 10, 10], "float32")]
 
@@ -1494,12 +1370,6 @@ def test_binary():
 
 
 def test_size():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Size(Module):
@@ -1520,12 +1390,6 @@ def test_size():
 
 
 def test_squeeze():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([3, 1, 4, 1], "float32")]
 
     class Squeeze1(Module):
@@ -1565,12 +1429,6 @@ def test_squeeze():
 
 
 def test_unsqueeze():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Unsqueeze1(Module):
@@ -1612,12 +1470,6 @@ def test_unsqueeze():
 
 
 def test_getattr():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class GetAttr1(Module):
@@ -1638,12 +1490,6 @@ def test_getattr():
 
 
 def test_getitem():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     class Slice1(Module):
         def forward(self, x):
             return x[0, 1::2, :, :3]
@@ -1694,12 +1540,6 @@ def test_getitem():
 
 
 def test_unary():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     # sin
@@ -1824,12 +1664,6 @@ def test_unary():
 
 
 def test_gelu():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Gelu(Module):
@@ -1853,12 +1687,6 @@ def test_gelu():
 
 
 def test_tanh():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Tanh(Module):
@@ -1882,13 +1710,6 @@ def test_tanh():
 
 
 def test_clamp():
-    import torch
-    from torch import fx
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Clamp(Module):
@@ -1936,12 +1757,6 @@ def test_clamp():
 
 
 def test_interpolate():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Interpolate(Module):
@@ -1977,12 +1792,6 @@ def test_interpolate():
 
 
 def test_addmm():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [
         ([10, 10], "float32"),
         ([10, 10], "float32"),
@@ -2013,12 +1822,6 @@ def test_addmm():
 
 
 def test_split():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Split(Module):
@@ -2054,12 +1857,6 @@ def test_split():
 
 
 def test_cumsum():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 2, 3, 4], "float32")]
 
     class Cumsum(Module):
@@ -2083,12 +1880,6 @@ def test_cumsum():
 
 
 def test_chunk():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 3, 10, 10], "float32")]
 
     class Chunk(Module):
@@ -2124,12 +1915,6 @@ def test_chunk():
 
 
 def test_inplace_fill():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     class InplaceFill(Module):
         def forward(self, input):
             input.fill_(1.5)
@@ -2152,11 +1937,6 @@ def test_inplace_fill():
 
 def test_arange():
     import numpy as np
-    import torch
-    from torch import fx
-    from torch.nn import Module
-    from tvm.relax.frontend.torch import from_fx
-
     torch.set_grad_enabled(False)
     torch.random.manual_seed(0)
 
@@ -2175,14 +1955,6 @@ def test_arange():
 
 
 def test_empty():
-    import torch
-    from torch import fx
-    from torch.nn import Module
-    from tvm.relax.frontend.torch import from_fx
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     class Empty(Module):
         def forward(self, input):
             return torch.empty((10, 10), dtype=torch.float32)
@@ -2197,14 +1969,6 @@ def test_empty():
 
 
 def test_tensor():
-    import torch
-    from torch import fx
-    from torch.nn import Module
-    from tvm.relax.frontend.torch import from_fx
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     class Empty1(Module):
         def forward(self, input):
             return torch.tensor(3, dtype=torch.float32)
@@ -2231,12 +1995,6 @@ def test_tensor():
 
 
 def test_tril():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([10, 10], "float32")]
 
     class Tril(Module):
@@ -2266,12 +2024,6 @@ def test_tril():
 
 
 def test_triu():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([10, 10], "float32")]
 
     class Triu(Module):
@@ -2301,12 +2053,6 @@ def test_triu():
 
 
 def test_new_ones():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 2, 3], "float32")]
 
     class NewOnes(Module):
@@ -2330,12 +2076,6 @@ def test_new_ones():
 
 
 def test_expand():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 2, 3, 4], "float32")]
 
     class Expand(Module):
@@ -2359,12 +2099,6 @@ def test_expand():
 
 
 def test_reduce():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 2, 3, 4], "float32")]
 
     # sum
@@ -2389,12 +2123,6 @@ def test_reduce():
 
 
 def test_datatype():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 2, 3, 4], "float32")]
 
     # float
@@ -2458,12 +2186,6 @@ def test_datatype():
 
 
 def test_permute():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 2, 3, 4], "float32")]
 
     class Permute(Module):
@@ -2487,12 +2209,6 @@ def test_permute():
 
 
 def test_reshape():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 2, 3, 4], "float32")]
 
     class Reshape(Module):
@@ -2514,12 +2230,6 @@ def test_reshape():
 
 
 def test_transpose():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 2, 3, 4], "float32")]
 
     class Transpose(Module):
@@ -2543,12 +2253,6 @@ def test_transpose():
 
 
 def test_view():
-    import torch
-    from torch.nn import Module
-
-    torch.set_grad_enabled(False)
-    torch.random.manual_seed(0)
-
     input_info = [([1, 2, 3, 4], "float32")]
 
     class View(Module):
@@ -2570,12 +2274,6 @@ def test_view():
 
 
 def test_keep_params():
-    import torch
-    from torch import fx
-    from torch.nn import Module
-    from tvm.relax.frontend import detach_params
-    from tvm.relax.frontend.torch import from_fx
-
     class Conv2D1(Module):
         def __init__(self):
             super().__init__()
@@ -2630,10 +2328,6 @@ def test_keep_params():
 
 
 def test_unwrap_unit_return_tuple():
-    import torch.fx as fx
-    from torch.nn import Module
-    from tvm.relax.frontend.torch import from_fx
-
     class Identity(Module):
         def __init__(self):
             super().__init__()
@@ -2658,10 +2352,6 @@ def test_unwrap_unit_return_tuple():
 
 
 def test_no_bind_return_tuple():
-    import torch.fx as fx
-    from torch.nn import Module
-    from tvm.relax.frontend.torch import from_fx
-
     class Identity(Module):
         def __init__(self):
             super().__init__()
@@ -2690,9 +2380,6 @@ def test_no_bind_return_tuple():
 
 
 def test_argmax():
-    import torch
-    from torch.nn import Module
-
     class Argmax1(Module):
         def __init__(self) -> None:
             super().__init__()
@@ -2732,9 +2419,6 @@ def test_argmax():
 
 
 def test_argmin():
-    import torch
-    from torch.nn import Module
-
     class Argmin1(Module):
         def __init__(self) -> None:
             super().__init__()
@@ -2774,9 +2458,6 @@ def test_argmin():
 
 
 def test_to():
-    import torch
-    from torch.nn import Module
-
     class To1(Module):
         def forward(self, input):
             return input.to(torch.float16)
@@ -2813,9 +2494,6 @@ def test_to():
 
 
 def test_mean():
-    import torch
-    from torch.nn import Module
-
     class Mean(Module):
         def forward(self, input):
             return input.mean(-1)
@@ -2851,9 +2529,6 @@ def test_mean():
 
 
 def test_rsqrt():
-    import torch
-    from torch.nn import Module
-
     class Rsqrt(Module):
         def forward(self, input):
             return torch.rsqrt(input)
@@ -2874,9 +2549,6 @@ def test_rsqrt():
 
 
 def test_neg():
-    import torch
-    from torch.nn import Module
-
     class Neg(Module):
         def forward(self, input):
             return -input
@@ -2897,9 +2569,6 @@ def test_neg():
 
 
 def test_max():
-    import torch
-    from torch.nn import Module
-
     class Max(Module):
         def forward(self, x, y):
             return torch.max(x, y)


### PR DESCRIPTION
diffusers started to use `scaled_dot_product_attention` as of v0.16 in SD VAE. See the doc https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html. We cannot support attention mask, dropout, and causal mask optimization for now. 

The PT attention op requires a different input format than our attention op, so we need to transpose inputs. Luckily those transpose can be canceled in practice, since diffusers does transpose on q/k/v before calling `scaled_dot_product_attention` anyway (a design mistake?): https://github.com/huggingface/diffusers/blob/909742dbd6873052995dc6cd5f4150ff238015d2/src/diffusers/models/attention_processor.py#L906-L908

I'm also doing clean up on FX test cases. We shouldn't need `@tvm.testing.requires_gpu` since the tests don't execute anything on GPU. I'll also try removing local `import torch` if possible (CI should have PT installed, right?)

@MasterJH5574 @jinhongyii  @cyx-6 