### PR TITLE
[Docker] Install PyTorch on cpu image

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -145,3 +145,7 @@ ENV PATH /opt/sccache:$PATH
 # Libxsmm deps
 COPY install/ubuntu_install_libxsmm.sh /install
 RUN bash /install/ubuntu_install_libxsmm.sh
+
+# ONNX and PyTorch
+COPY install/ubuntu_install_onnx.sh /install/ubuntu_install_onnx.sh
+RUN bash /install/ubuntu_install_onnx.sh


### PR DESCRIPTION
As discussed in https://github.com/apache/tvm/pull/14841, it is desirable to install PT on cpu image as well, to remove many workarounds in tests. Even for the gpu image, we have been using the cpu-build of PT, since we only use it for reference / model import.