### PR TITLE
[bugfix][Relay] Fix softplus in paddlepaddle frontend

### DIFF
--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -2163,7 +2163,10 @@ def convert_softplus(g, op, block):
     dtype = infer_type(x).checked_type.dtype
     beta = op.attr("beta")
     beta = _expr.const(beta, dtype=dtype)
-    out = _op.log(_op.exp(x * beta) + _expr.const(1.0, dtype=dtype)) / beta
+    threshold = op.attr("threshold")
+    threshold = _expr.const(threshold, dtype=dtype)
+    out_softplus = _op.log(_op.exp(x * beta) + _expr.const(1.0, dtype=dtype)) / beta
+    out = _op.where(_op.greater(x * beta, threshold), x, out_softplus)
     g.add_node(op.output("Out")[0], out)
 
 

--- a/tests/python/frontend/paddlepaddle/test_forward.py
+++ b/tests/python/frontend/paddlepaddle/test_forward.py
@@ -1722,7 +1722,7 @@ def test_forward_sin():
 
 @run_math_api
 def test_forward_softplus():
-    x = paddle.to_tensor([-0.4, 1], dtype='float32')
+    x = paddle.to_tensor([-0.4, 1], dtype="float32")
     m = paddle.nn.Softplus(5, 1)
     verify_model(m, [x])
 

--- a/tests/python/frontend/paddlepaddle/test_forward.py
+++ b/tests/python/frontend/paddlepaddle/test_forward.py
@@ -1722,7 +1722,9 @@ def test_forward_sin():
 
 @run_math_api
 def test_forward_softplus():
-    pass
+    x = paddle.to_tensor([-0.4, 1], dtype='float32')
+    m = paddle.nn.Softplus(5, 1)
+    verify_model(m, [x])
 
 
 @run_math_api


### PR DESCRIPTION
This PR fixed a similar bug with #14821  in the PaddlePaddle frontend.

For the [PaddlePaddle documentation](https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/nn/Softplus_en.html), when input * beta > threshold, Softplus(x) = x. 
![image](https://github.com/apache/tvm/assets/29506758/7311ae30-fc81-4ec5-8d59-ef57281732f3)

TVM miss this special case handling. It would cause wrong inference results.

A patch and a Test case that can trigger this bug are submitted in this PR.


cc @Hzfengsy @echuraev @jiangjiajun 

