### PR TITLE
[Unity][CI] Update CPU image to install PyTorch

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -19,7 +19,7 @@
 [jenkins]
 ci_arm: tlcpackstaging/ci_arm:20230504-142417-4d37a0a0
 ci_cortexm: tlcpackstaging/ci_cortexm:20230504-142417-4d37a0a0
-ci_cpu: tlcpackstaging/ci_cpu:20230504-142417-4d37a0a0
+ci_cpu: tlcpackstaging/ci_cpu:20230513-200357-e54bbc73
 ci_gpu: tlcpackstaging/ci_gpu:20230504-142417-4d37a0a0
 ci_hexagon: tlcpackstaging/ci_hexagon:20230504-142417-4d37a0a0
 ci_i386: tlcpackstaging/ci_i386:20230504-142417-4d37a0a0


### PR DESCRIPTION
Follow up to https://github.com/apache/tvm/pull/14842 to actually update the image.