### PR TITLE
[BugFix][Target][Web] Fix the wrong dtype for the shift expression

### DIFF
--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -252,6 +252,24 @@ void CodeGenWebGPU::VisitExpr_(const CallNode* op, std::ostream& os) {  // NOLIN
       this->EndScope(else_scope);
     }
     os << result;
+  } else if (op->op.same_as(builtin::shift_left()) || op->op.same_as(builtin::shift_right())) {
+    const char* opstr = op->op.same_as(builtin::shift_left()) ? " << " : " >> ";
+    ICHECK_EQ(op->args.size(), 2U);
+    os << '(';
+    this->PrintExpr(op->args[0], os);
+    os << opstr;
+
+    // the rhs cannot be i32.
+    const auto& rhs = op->args[1];
+    if (rhs.dtype().is_int()) {
+      os << "u32(";
+      this->PrintExpr(rhs, os);
+      os << "))";
+    } else {
+      ICHECK(rhs.dtype().is_uint());
+      this->PrintExpr(rhs, os);
+      os << ')';
+    }
   } else {
     CodeGenC::VisitExpr_(op, os);
   }


### PR DESCRIPTION
This PR fixes the wrong data type for the shift expression in WGSL.

In [WGSL standard](https://www.w3.org/TR/WGSL/#bit-expr), The number of bits to shift must be u32, but the generated code may has i32 type, such as the following:
```wgsl
pad_temp_shared[((i32(threadIdx.z) * 7) + i32(threadIdx.x))] = p0[(((((rc_outer * 784) + ((i32(threadIdx.z) >> 2i) * 196)) + (i32(blockIdx.y) * 28)) + ((i32(threadIdx.z) & 3) * 7)) + i32(threadIdx.x))];
```
And the error message in tint:
```console
error: no matching overload for operator >> (i32, i32)
```

This PR adds a convert, if the number of bits to shift is i32, it will be converted to u32. E.g.   `2i` -> `u32(2i)`.
