### PR TITLE
[Unity]Lazy transform param now only work on non-dataflow block

### DIFF
--- a/python/tvm/relax/transform/lazy_transform_params.py
+++ b/python/tvm/relax/transform/lazy_transform_params.py
@@ -85,11 +85,11 @@ class LivenessAnalysis(PyExprVisitor):
         self.input_params = input_params
         self.var_liveness_end = {}
 
-    def visit_dataflow_block_(self, block: relax.DataflowBlock) -> None:
+    def visit_binding_block_(self, block: relax.BindingBlock) -> None:
         for binding in reversed(block.bindings):
             self.visit_binding(binding)
 
-    def visit_dataflow_var_(self, op: relax.DataflowVar) -> None:
+    def visit_var_(self, op: relax.Var) -> None:
         if op in self.input_params:
             self.last_appear_in_var_binding.append(op)
             self.input_params.remove(op)


### PR DESCRIPTION
As #14829 mentioned, `set_item` is an impure function, so LazyTransformParam Pass should be done after manually applyiyng ToNonDataflow pass. This PR corrects the behavior.

cc: @slyubomirsky 