### PR TITLE
[MicroTVM] Use self.close_transport() on error

### DIFF
--- a/src/runtime/crt/host/microtvm_api_server.py
+++ b/src/runtime/crt/host/microtvm_api_server.py
@@ -218,7 +218,7 @@ class Handler(server.ProjectAPIHandler):
             to_return = 0
 
         if not to_return:
-            self.disconnect_transport()
+            self.close_transport()
             raise server.TransportClosedError()
 
         return to_return
@@ -239,7 +239,7 @@ class Handler(server.ProjectAPIHandler):
                 num_written = 0
 
             if not num_written:
-                self.disconnect_transport()
+                self.close_transport()
                 raise server.TransportClosedError()
 
             data = data[num_written:]


### PR DESCRIPTION
Previously, the non-existent `self.disconnect_transport()` method was called prior to raising `server.TransportClosedError()`.  This commit updates to call the `self.close_transport()` method instead.