### PR TITLE
[bugfix] fix the undeclared identifier 'f'

### DIFF
--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -466,13 +466,14 @@ llvm::Value* CodeGenCPU::CreateCallExtern(Type ret_type, String global_symbol,
   llvm::FunctionType* ftype = llvm::FunctionType::get(GetLLVMType(ret_type), arg_types, false);
   // Check if it is available in global function table as injected function.
 
+  llvm::Function* f = module_->getFunction(MakeStringRef(global_symbol));
   auto callee = [&]() -> llvm::Value* {
     if (auto it = gv_func_map_.find(global_symbol); it != gv_func_map_.end()) {
       if (it->second == nullptr) {
         it->second = InitContextPtr(ftype->getPointerTo(), "__" + global_symbol);
       }
       return GetContextPtr(it->second);
-    } else if (llvm::Function* f = module_->getFunction(MakeStringRef(global_symbol))) {
+    } else if (f) {
       return f;
     } else {
       return llvm::Function::Create(ftype, llvm::Function::ExternalLinkage,


### PR DESCRIPTION
This pr fixed the source code build problem found in issue #14878 

The variable 'f' is a local variable that is inviable for the outside code. This pr moved the 'f' definition to the outside of the condition and fix the crash.

cc @Lunderberg @kparzysz-quic 