### PR TITLE
[bugfix] [Relay] fix broadcast in PyTorch frontend 

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2261,7 +2261,11 @@ class PyTorchOpConverter:
         import torch
 
         infer_shape_value = [self.infer_shape(t) for t in tensor_list]
-        res_shape = list(torch.broadcast_tensors(*map(torch.empty, infer_shape_value))[0].shape)
+        # "torch.broadcast_shapes" is available after PyTorch 1.8.0
+        if hasattr(torch, "broadcast_shapes"):
+            res_shape = list(torch.broadcast_shapes(*infer_shape_value))
+        else:
+            res_shape = list(torch.broadcast_tensors(*map(torch.empty, infer_shape_value))[0].shape)
         return [_op.broadcast_to(tensor, res_shape) for tensor in tensor_list]
 
     def Bool(self, inputs, input_types):

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2260,7 +2260,8 @@ class PyTorchOpConverter:
         tensor_list = inputs[0]
         import torch
 
-        res_shape = list(torch.broadcast_shapes(*[self.infer_shape(t) for t in tensor_list]))
+        infer_shape_value = [self.infer_shape(t) for t in tensor_list]
+        res_shape = list(torch.broadcast_tensors(*map(torch.empty, infer_shape_value))[0].shape)
         return [_op.broadcast_to(tensor, res_shape) for tensor in tensor_list]
 
     def Bool(self, inputs, input_types):

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -4798,6 +4798,7 @@ def test_forward_l1_loss():
     verify_model(torch.nn.L1Loss().eval(), input_data=[predictions, targets])
     verify_model(torch.nn.L1Loss(reduction="sum").eval(), input_data=[predictions, targets])
     verify_model(torch.nn.L1Loss(reduction="none").eval(), input_data=[predictions, targets])
+    verify_model(torch.nn.L1Loss().eval(), input_data=[predictions, targets])
 
     # multidimension l1 loss
     d1, d2 = 2, 3
@@ -4817,6 +4818,7 @@ def test_forward_mse_loss():
     verify_model(torch.nn.MSELoss().eval(), input_data=[predictions, targets])
     verify_model(torch.nn.MSELoss(reduction="sum").eval(), input_data=[predictions, targets])
     verify_model(torch.nn.MSELoss(reduction="none").eval(), input_data=[predictions, targets])
+    verify_model(torch.nn.MSELoss().eval(), input_data=[predictions, targets])
 
     # multidimension mse loss
     d1, d2 = 2, 3

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -4798,7 +4798,6 @@ def test_forward_l1_loss():
     verify_model(torch.nn.L1Loss().eval(), input_data=[predictions, targets])
     verify_model(torch.nn.L1Loss(reduction="sum").eval(), input_data=[predictions, targets])
     verify_model(torch.nn.L1Loss(reduction="none").eval(), input_data=[predictions, targets])
-    verify_model(torch.nn.L1Loss().eval(), input_data=[predictions, targets])
 
     # multidimension l1 loss
     d1, d2 = 2, 3
@@ -4818,7 +4817,6 @@ def test_forward_mse_loss():
     verify_model(torch.nn.MSELoss().eval(), input_data=[predictions, targets])
     verify_model(torch.nn.MSELoss(reduction="sum").eval(), input_data=[predictions, targets])
     verify_model(torch.nn.MSELoss(reduction="none").eval(), input_data=[predictions, targets])
-    verify_model(torch.nn.MSELoss().eval(), input_data=[predictions, targets])
 
     # multidimension mse loss
     d1, d2 = 2, 3


### PR DESCRIPTION
`broadcast_shapes` is a newly introduced operator after PyTorch 1.8.0. If you install PyTorch < 1.8.0, the usage `torch.broadcast_shapes` will lead to a crash and throw:   **AttributeError: module 'torch' has no attribute 'broadcast_shapes'**.

This PR replaces `broadcast_shapes` with an old operator `broadcast_tensors`, which was introduced since PyTorch 1.0.0.

### Reference: [PyTorch Documentation](https://pytorch.org/docs/1.8.0/generated/torch.broadcast_shapes.html?highlight=broadcast_shapes#torch.broadcast_shapes)
![image](https://github.com/apache/tvm/assets/29506758/63138b14-de75-4b6a-80ec-9cb0f6252d11)





### Reproducible script
```
import torch
from tvm import relay
import tvm

m = torch.nn.L1Loss()
input_shape_ = [10, 3]
input_data=[torch.randn(input_shape_, dtype=torch.float64), torch.randn(input_shape_, dtype=torch.float64)]
trace = torch.jit.trace(m, input_data)

#input_shapes = [('input0', torch.Size(input_shape))]
input_shapes = [('input0', torch.Size(input_shape_)), ('input1', torch.Size(input_shape_))]
mod, params = relay.frontend.from_pytorch(trace, input_shapes)

with tvm.transform.PassContext(opt_level=3):
    exe = relay.create_executor('vm', mod=mod, params=params, device=tvm.device('llvm', 0), target='llvm').evaluate()
```


BTW, this bug can be triggered by existing test cases. Thus, we needn't add new test cases.

cc @echuraev @vvchernov @yongwww 