### PR TITLE
[Fix] Fix typo in error message

### DIFF
--- a/src/tir/ir/data_layout.cc
+++ b/src/tir/ir/data_layout.cc
@@ -328,7 +328,7 @@ inline Array<PrimExpr> TransformShape(const Array<PrimExpr>& src_shape,
                                       const Array<PrimExpr>& transform_rule) {
   arith::Analyzer ana;
   ICHECK_EQ(src_shape.size(), src_axis.size())
-      << "Input shape size " << src_shape.size() << " mismatch with the exepected shape size "
+      << "Input shape size " << src_shape.size() << " mismatch with the expected shape size "
       << src_axis.size();
   // bind variables for original axes
   // for major-axis, bind the corresponding size


### PR DESCRIPTION
This PR fixes a typo in an error message when informing the user of a shape mismatch.