### PR TITLE
[Unity][CUTLASS] Fix for purity tracking

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -862,7 +862,7 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
     def visit_function_(self, f):
         if "Composite" not in f.attrs:
             body = super().visit_expr(f.body)
-            return relax.Function(f.params, body, f.ret_struct_info, f.attrs, f.span)
+            return relax.Function(f.params, body, f.ret_struct_info, f.is_pure, f.attrs, f.span)
 
         op_type = f.attrs["Composite"]
 


### PR DESCRIPTION
CUTLASS BYOC has been broken since https://github.com/apache/tvm/pull/14394. We should enable CUTLASS in CI tests.

@vinx13 @yelite @slyubomirsky 