### PR TITLE
[TIR][Doc] Fix formatting in pop_trace docstring

### DIFF
--- a/python/tvm/ir/transform.py
+++ b/python/tvm/ir/transform.py
@@ -173,7 +173,7 @@ class PassContext(tvm.runtime.Object):
 
     def pop_trace(self, return_current=True):
         """Pop a topmost trace from the stack.
-         Returns
+        Returns
         -------
         Trace : Optional[relax.tuning.Trace]
         """


### PR DESCRIPTION
This fixes the following error when generating docs:
```
$ make singlehtml
...
updating environment: [new config] 209 added, 0 changed, 0 removed
:3: (SEVERE/4) Incomplete section title.python/ir

-------
Trace : Optional[relax.tuning.Trace]

reST markup error:
:3: (SEVERE/4) Incomplete section title.
```