### PR TITLE
[Unity] Allow eliminating only call nodes in CSE pass

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -169,8 +169,9 @@ TVM_DLL Pass CanonicalizeBindings();
  *
  * \note For functions local to dataflow blocks, this pass performs
  * CSE *within* those functions.
+ * \param call_only If true, enable eliminating only call nodes.
  */
-TVM_DLL Pass EliminateCommonSubexpr();
+TVM_DLL Pass EliminateCommonSubexpr(bool call_only = false);
 
 /*!
  * \brief Bind params of function of the module to constant tensors.

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -290,18 +290,23 @@ def CanonicalizeBindings() -> tvm.ir.transform.Pass:
     return _ffi_api.CanonicalizeBindings()  # type: ignore
 
 
-def EliminateCommonSubexpr() -> DataflowBlockPass:
+def EliminateCommonSubexpr(call_only=False) -> DataflowBlockPass:
     """Eliminate common subexpressions within dataflow blocks.
 
     Note: For functions local to dataflow blocks, this pass performs
     CSE *within* those functions
+
+    Parameters
+    ----------
+    call_only : bool
+        If True, enable eliminating only call nodes.
 
     Returns
     -------
     ret : tvm.transform.Pass
         The registered pass that eliminates common subexpressions.
     """
-    return _ffi_api.EliminateCommonSubexpr()  # type: ignore
+    return _ffi_api.EliminateCommonSubexpr(call_only)  # type: ignore
 
 
 def RewriteDataflowReshape() -> tvm.ir.transform.Pass:


### PR DESCRIPTION
The CSE pass eliminates expressions very eagerly. This can result in an undesirable result, for example `relax.arange(...)` op  which requires all of its inputs to be `PrimValue` complains when its inputs are CSE variables. 

https://github.com/apache/tvm/blob/unity/src/relax/op/tensor/create.cc#L248-L253

```
  File "/Users/masa/projects/dev/tvm/src/relax/ir/block_builder.cc", line 138
TVMError: Arange expects the `start` to be a PrimValue, but got relax.expr.DataflowVar
```

That error can be easily fixed, but I've also hit similar issues with other ops like `strided_slice` as well. Since I only need common CallNodes to be eliminated, I'm adding an option to avoid the default fine-grained elimination.

cc @slyubomirsky @sunggg   