### PR TITLE
[Unity] Only process relax functions in workspace annotation

### DIFF
--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -410,8 +410,9 @@ def annotate_workspace(mod, _):
     """Pass to annotate a workspace requirement for each CUTLASS-offloaded function."""
     annotator = WorkspaceAnnotator(mod)
     for name, f in mod.functions.items():
-        new_f = annotator.visit_expr(f)
-        mod.update_func(name, new_f)
+        if isinstance(f, Function):
+            new_f = annotator.visit_expr(f)
+            mod.update_func(name, new_f)
     return mod
 
 


### PR DESCRIPTION
Currently it fails on IRModule with TIR functions

cc @masahi 