### PR TITLE
[LLVM] Codegen subroutine call when CallNode::op is GlobalVar

### DIFF
--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -220,18 +220,17 @@ llvm::DISubprogram* CodeGenCPU::CreateDebugFunction(const PrimFunc& f) {
 #endif
 }
 
-void CodeGenCPU::AddFunction(const PrimFunc& f) {
+void CodeGenCPU::AddFunction(const GlobalVar& gvar, const PrimFunc& f) {
 #if TVM_LLVM_VERSION >= 50
   di_subprogram_ = CreateDebugFunction(f);
 #endif
   EmitDebugLocation(f->span);
-  CodeGenLLVM::AddFunction(f);
+  CodeGenLLVM::AddFunction(gvar, f);
   if (f_tvm_register_system_symbol_ != nullptr) {
-    auto global_symbol = f->GetAttr<String>(tvm::attr::kGlobalSymbol);
-    ICHECK(global_symbol.defined())
-        << "CodeGenLLVM: Expect PrimFunc to have the global_symbol attribute";
-    export_system_symbols_.emplace_back(
-        std::make_pair(global_symbol.value().operator std::string(), function_));
+    if (auto global_symbol = f->GetAttr<String>(tvm::attr::kGlobalSymbol)) {
+      export_system_symbols_.emplace_back(
+          std::make_pair(global_symbol.value().operator std::string(), function_));
+    }
   }
   AddDebugInformation(f, function_);
 }

--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -67,7 +67,7 @@ class CodeGenCPU : public CodeGenLLVM {
   void Init(const std::string& module_name, LLVMTarget* llvm_target,
             Optional<String> system_lib_prefix, bool dynamic_lookup,
             bool target_c_runtime) override;
-  void AddFunction(const PrimFunc& f) override;
+  void AddFunction(const GlobalVar& gvar, const PrimFunc& f) override;
   void AddMainFunction(const std::string& entry_func_name) override;
   std::unique_ptr<llvm::Module> Finish() override;
   void VisitStmt_(const AssertStmtNode* op) override;

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -547,7 +547,6 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
 
   auto cg = std::make_unique<CodeGenHexagon>();
 
-  std::vector<PrimFunc> funcs;
   std::string entry_func;
 
   for (auto kv : mod->functions) {
@@ -562,11 +561,10 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
       ICHECK(global_symbol.defined());
       entry_func = global_symbol.value();
     }
-    funcs.emplace_back(f);
   }
 
   cg->Init("TVMHexagonModule", llvm_target.get(), NullOpt, false, false);
-  cg->AddFunctionsOrdered(funcs.begin(), funcs.end());
+  cg->AddFunctionsOrdered(mod->functions.begin(), mod->functions.end());
   if (entry_func.length() != 0) {
     cg->AddMainFunction(entry_func);
   }

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -63,6 +63,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -132,11 +133,17 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    */
   void SetFastMathFlags(llvm::FastMathFlags fmf);
 
+  virtual llvm::Function* DeclareFunction(const GlobalVar& gvar, const PrimFunc& f);
+
   /*!
    * \brief Compile and add function f to the current module.
+   *
+   * \param gvar The GlobalVar which may be used to may internal calls
+   * to this function from elsewhere in the module.
+   *
    * \param f The function to be added.
    */
-  virtual void AddFunction(const PrimFunc& f);
+  virtual void AddFunction(const GlobalVar& gvar, const PrimFunc& f);
   /*!
    * \brief Add main function as the entry name
    * \param entry_func_name The name of entry function to be added.
@@ -356,7 +363,28 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   virtual int NativeVectorBits(const runtime::StorageScope& storage_scope) const;
   // Get correct address space depending on the backend
   virtual unsigned GetGlobalAddressSpace() const;
-  void AddFunctionInternal(const PrimFunc& f, bool ret_void);
+
+  /*! \brief Get the linkage parameters for the function
+   *
+   * Returns a tuple whose first element is the name of the function
+   * and whose second element is the linkage type to be used
+   * (e.g. llvm::Function::ExternalLinkage or
+   * llvm::Function::PrivateLinkage)
+   *
+   * \param func The PrimFunc whose symbol name and linkage type
+   * should be returned
+   *
+   * \param gvar The GlobalVar to be used when generating the symbol
+   * name.  Only used for internal functions, for which the
+   * kGlobalSymbol attribute is not defined.
+   */
+  std::tuple<std::string, llvm::Function::LinkageTypes> GetLinkage(const GlobalVar& gvar,
+                                                                   const PrimFunc& func);
+
+  llvm::Function* DeclareFunctionInternal(const GlobalVar& gvar, const PrimFunc& f, bool ret_void);
+
+  void AddFunctionInternal(const GlobalVar& gvar, const PrimFunc& f, bool ret_void);
+
   // Create extern call
   llvm::CallInst* CreateCallExtern(llvm::Type* ret, const std::string& name,
                                    const std::vector<llvm::Value*>& value);
@@ -517,6 +545,11 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   std::unordered_map<const VarNode*, llvm::Value*> var_map_;
   // global strings
   std::unordered_map<std::string, llvm::Constant*> str_map_;
+
+  // Map from TVM's GlobalVar to the llvm::Function that represents
+  // that function.
+  std::unordered_map<const GlobalVarNode*, llvm::Function*> functions_;
+
   // Whether current function is restricted
   bool is_restricted_{true};
   // The analyzer information
@@ -569,18 +602,26 @@ inline int CodeGenLLVM::GetVectorNumElements(llvm::Value* vec) {
 
 template <typename IterType, typename ConvType>
 void CodeGenLLVM::AddFunctionsOrdered(IterType begin, IterType end, ConvType pfunc) {
-  std::vector<PrimFunc> funcs;
+  std::vector<std::tuple<GlobalVar, PrimFunc>> funcs;
   for (auto it = begin; it != end; ++it) {
-    funcs.push_back(pfunc(*it));
+    auto [gvar, func] = *it;
+    auto converted = pfunc(func);
+    funcs.push_back({gvar, Downcast<PrimFunc>(converted)});
   }
-  std::sort(funcs.begin(), funcs.end(), [](PrimFunc func_a, PrimFunc func_b) {
-    std::string name_a = func_a->GetAttr<String>(tvm::attr::kGlobalSymbol).value();
-    std::string name_b = func_b->GetAttr<String>(tvm::attr::kGlobalSymbol).value();
+  std::sort(funcs.begin(), funcs.end(), [this](const auto& pair_a, const auto& pair_b) {
+    const auto& [gvar_a, func_a] = pair_a;
+    std::string name_a = std::get<std::string>(GetLinkage(gvar_a, func_a));
+
+    const auto& [gvar_b, func_b] = pair_b;
+    std::string name_b = std::get<std::string>(GetLinkage(gvar_b, func_b));
     return name_a < name_b;
   });
-  for (auto& f : funcs) {
-    auto global_symbol = f->GetAttr<String>(tvm::attr::kGlobalSymbol);
-    AddFunction(f);
+
+  for (const auto& [gvar, func] : funcs) {
+    DeclareFunction(gvar, func);
+  }
+  for (const auto& [gvar, func] : funcs) {
+    AddFunction(gvar, func);
   }
 }
 


### PR DESCRIPTION
Previously, the `CallNode::op` must be a known built-in operation.  This commit allows LLVM codegen to produce a subroutine call to another function within the same IRModule, with `CallNode::op` specifying the `GlobalVar` that represents that function.