### PR TITLE
[Test Cases][BugFix] Add some version check to make test cases run in all PyTorch versions

### DIFF
--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -1012,11 +1012,13 @@ def test_forward_tensor_split():
         def forward(self, *args):
             return torch.tensor_split(args[0], self.split_size_or_sections, self.dim)
 
-    input_data = torch.rand(input_shape).float()
-    verify_model(Tensor_Split(2, 0).float().eval(), input_data=input_data)
-    verify_model(Tensor_Split(torch.tensor(3), 1).float().eval(), input_data=input_data)
-    verify_model(Tensor_Split([2, 3, 5], 1).float().eval(), input_data=input_data)
-    verify_model(Tensor_Split((2, 3, 5), 1).float().eval(), input_data=input_data)
+    # tensor_split was introduced when torch > 1.7.1
+    if package_version.parse(torch.__version__) > package_version.parse("1.7.1"):
+        input_data = torch.rand(input_shape).float()
+        verify_model(Tensor_Split(2, 0).float().eval(), input_data=input_data)
+        verify_model(Tensor_Split(torch.tensor(3), 1).float().eval(), input_data=input_data)
+        verify_model(Tensor_Split([2, 3, 5], 1).float().eval(), input_data=input_data)
+        verify_model(Tensor_Split((2, 3, 5), 1).float().eval(), input_data=input_data)
 
 
 @tvm.testing.uses_gpu
@@ -5025,6 +5027,10 @@ def test_grid_sample():
     grid_3D = torch.rand([4, 8, 8, 8, 3]).float()
 
     for _method in methods:
+        # bicubic was introduced when pytorch > 1.7.1
+        torch_version = package_version.parse(torch.__version__)
+        if _method=='bicubic' and torch_version <= package_version.parse("1.7.1"):
+            continue
         for _padding in padding_modes:
             for _align in align_corners:
                 # ATTENTION:

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -5029,7 +5029,7 @@ def test_grid_sample():
     for _method in methods:
         # bicubic was introduced when pytorch > 1.7.1
         torch_version = package_version.parse(torch.__version__)
-        if _method=='bicubic' and torch_version <= package_version.parse("1.7.1"):
+        if _method == "bicubic" and torch_version <= package_version.parse("1.7.1"):
             continue
         for _padding in padding_modes:
             for _align in align_corners:


### PR DESCRIPTION
This PR added some version checks to avoid calling the operator/attribute, which has not been introduced yet！


When the PyTorch <=1.7.1, test cases will fail.

```
FAILED frontend/pytorch/test_forward.py::test_forward_tensor_split - AttributeError: module 'torch' has no attribute 'tensor_split'
FAILED frontend/pytorch/test_forward.py::test_grid_sample - ValueError: nn.functional.grid_sample(): expected mode to be 'bilinear' or 'nearest', but got: 'bicubic'
```

cc @echuraev @Hzfengsy @shingjan 