### PR TITLE
[Unity][WebGPU] Try F16 support for  WebGPU Backend

### DIFF
--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -139,8 +139,8 @@ runtime::FunctionInfo CodeGenWebGPU::AddFunction(const PrimFunc& f, bool skip_re
       << "CodeGenWebGPU: Expect PrimFunc to have the global_symbol attribute";
 
   header_stream << "//----------------------------------------\n"
-              << "// Function: " << global_symbol.value() << "\n"
-              << "//----------------------------------------\n";
+                << "// Function: " << global_symbol.value() << "\n"
+                << "//----------------------------------------\n";
   runtime::FunctionInfo func_info;
   func_info.name = global_symbol.value();
 

--- a/src/target/source/codegen_webgpu.h
+++ b/src/target/source/codegen_webgpu.h
@@ -87,7 +87,8 @@ class CodeGenWebGPU final : public CodeGenC {
   // whether enable fp16
   bool enable_fp16_{false};
 
-  /*! \brief the header stream for function label and enable directive if any, goes before any other declaration */
+  /*! \brief the header stream for function label and enable directive if any, goes before any other
+   * declaration */
   std::ostringstream header_stream;
 
   Target target_;

--- a/src/target/source/codegen_webgpu.h
+++ b/src/target/source/codegen_webgpu.h
@@ -83,6 +83,13 @@ class CodeGenWebGPU final : public CodeGenC {
    * \brief Storage type of bool values.
    */
   DataType boolean_storage_type_{DataType::Int(8)};
+
+  // whether enable fp16
+  bool enable_fp16_{false};
+
+  /*! \brief the header stream for function label and enable directive if any, goes before any other declaration */
+  std::ostringstream header_stream;
+
   Target target_;
 };
 }  // namespace codegen

--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -74,13 +74,20 @@ export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefin
       );
     }
 
+    let requiredFeatures = [] as string[];
+    // Always require f16 if available
+    if (adapter.features.has("shader-f16")) {
+      requiredFeatures.push("shader-f16");
+    }
+
     const adapterInfo = await adapter.requestAdapterInfo();
     const device = await adapter.requestDevice({
       requiredLimits: {
         maxBufferSize: requiedMaxBufferSize,
         maxStorageBufferBindingSize: requiredMaxStorageBufferBindingSize,
         maxComputeWorkgroupStorageSize: requiredMaxComputeWorkgroupStorageSize,
-      }
+      },
+      requiredFeatures
     });
     return {
       adapter: adapter,


### PR DESCRIPTION
This PR try to add fp16 support to WebGPU backend by adding `enable f16` directive into WGSL codegen if necessary and requiring f16 feature when creating WebGPU device if available.