### PR TITLE
[Unity] Support causal mask for `R.nn.attention`

### DIFF
--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -313,10 +313,13 @@ struct DropoutAttrs : public tvm::AttrsNode<DropoutAttrs> {
 /*! \brief Attributes used in dropout operator */
 struct AttentionAttrs : public tvm::AttrsNode<AttentionAttrs> {
   Optional<FloatImm> scale;
+  Optional<String> causal_mask;
 
   TVM_DECLARE_ATTRS(AttentionAttrs, "relax.attrs.AttentionAttrs") {
     TVM_ATTR_FIELD(scale).describe(
         "The custom scale applied before the softmax. The default value is 1 / sqrt(head_dim).");
+    TVM_ATTR_FIELD(causal_mask)
+        .describe("The type of the causal mask, i.e. 'TopLeft' and 'BottomRight'.");
   }
 };  // struct AttentionAttrs
 

--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -108,6 +108,7 @@ def instantiate_attention_template(attrs):
   p.num_queries = ${num_queries}; // S
   p.num_keys = ${num_keys}; // S'
   p.scale = ${scale};
+  p.custom_mask_type = ${custom_mask_type};
 
 
   p.o_strideM = p.head_dim_value * p.num_heads; // H' * N

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -831,6 +831,15 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         _, _, _, head_dim_value = v_shape
         scale = op_attrs.scale
 
+        if op_attrs.causal_mask is None:
+            custom_mask_type = 0
+        if op_attrs.causal_mask == "TopLeft":
+            custom_mask_type = 1
+        elif op_attrs.causal_mask == "BottomRight":
+            custom_mask_type = 2
+        else:
+            raise NotImplementedError()
+
         return f.with_attrs(
             {
                 "op_type": op_type,
@@ -845,6 +854,7 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
                 "scale": scale,
                 "arch": self.options["sm"],
                 "qkv_layout": qkv_layout,
+                "custom_mask_type": custom_mask_type,
                 **arg,
             }
         )

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -721,6 +721,8 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["scale"] = (
             float(1 / math.sqrt(h.value)) if annotations["scale"] is None else annotations["scale"]
         )
+        attrs["custom_mask_type"] = annotations["custom_mask_type"]
+
         assert (
             attrs["scale"] > 0 or attrs["scale"] < 0
         ), "Cutlass may generate nan occasionally when scale == 0.0"

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1022,9 +1022,7 @@ class TorchFXImporter:
         query = transpose_S_H(self.env[node.args[0]])
         key = transpose_S_H(self.env[node.args[1]])
         value = transpose_S_H(self.env[node.args[2]])
-        causal_mask = (
-            "TopLeft" if "is_causal" in node.kwargs and node.kwargs["is_causal"] is True else None
-        )
+        causal_mask = "TopLeft" if node.kwargs.get("is_causal", False) else None
 
         if len(node.args) == 4:
             mask = self.env[node.args[3]]

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1015,19 +1015,24 @@ class TorchFXImporter:
         )
 
     def _scaled_dot_product_attention(self, node: fx.node.Node) -> relax.Var:
-        assert len(node.args) <= 4, "Dropout, and causal masking are not supported."
+        assert (
+            len(node.args) <= 4
+        ), "Dropout is not supported, and is_causal should be called by kwargs."
         transpose_S_H = lambda tensor: relax.op.permute_dims(tensor, [0, 2, 1, 3])
         query = transpose_S_H(self.env[node.args[0]])
         key = transpose_S_H(self.env[node.args[1]])
         value = transpose_S_H(self.env[node.args[2]])
+        causal_mask = (
+            "TopLeft" if "is_causal" in node.kwargs and node.kwargs["is_causal"] is True else None
+        )
 
         if len(node.args) == 4:
             mask = self.env[node.args[3]]
             msg = "Only a float mask is supported for the attn_mask input."
             assert "float" in mask.struct_info.dtype, msg
-            attn = relax.op.nn.attention(query, key, value, bias=mask)
+            attn = relax.op.nn.attention(query, key, value, bias=mask, causal_mask=causal_mask)
         else:
-            attn = relax.op.nn.attention(query, key, value)
+            attn = relax.op.nn.attention(query, key, value, causal_mask=causal_mask)
 
         return self.block_builder.emit(attn)
 

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -1038,6 +1038,8 @@ def attention(
 
     causal_mask: Optional[str]
         The optional causal mask, i.e. 'TopLeft' and 'BottomRight'.
+        For 'TopLeft', the mask matrix is as `np.tril(*, k=0)`,
+        while for 'BottomRight', the mask matrix is as `np.tril(*, k=abs(seq_len - seq_len_kv))`
         For example, with seq_len = 4, seq_len_kv = 2,
         mask for 'TopLeft':
         [[1, 0],

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -1005,6 +1005,7 @@ def attention(
     value: Expr,
     bias: Optional[Expr] = None,
     scale: Optional[FloatImm] = None,
+    causal_mask: Optional[str] = None,
 ) -> Expr:
     r"""Computes fused multi head attention.
 
@@ -1035,8 +1036,27 @@ def attention(
         a 4-D tensor ending with seq_len_kv, and broadcastable to
         (batch_size, num_head, seq_len, seq_len_kv).
 
-    scale: Optional[FloatImm]
-        The custom scale applied before the softmax. The default value is 1 / sqrt(head_dim).
+    causal_mask: Optional[str]
+        The optional causal mask, i.e. 'TopLeft' and 'BottomRight'.
+        For example, with seq_len = 4, seq_len_kv = 2,
+        mask for 'TopLeft':
+        [[1, 0],
+         [1, 1],
+         [1, 1],
+         [1, 1]]
+        mask for 'BottomRight':
+        [[1, 1],
+         [1, 1],
+         [1, 1],
+         [1, 1]]
+        with seq_len = 2, seq_len_kv = 4,
+        mask for 'TopLeft':
+        [[1, 0, 0, 0],
+         [1, 1, 0, 0]]
+        mask for 'BottomRight':
+        [[1, 1, 1, 0],
+         [1, 1, 1, 1]]
+
 
     Returns
     -------
@@ -1044,4 +1064,4 @@ def attention(
         The computed result. The layout of the output should be
         (batch_size, seq_len, num_head, head_dim_v).
     """
-    return _ffi_api.attention(query, key, value, bias, scale)  # type: ignore
+    return _ffi_api.attention(query, key, value, bias, scale, causal_mask)  # type: ignore

--- a/python/tvm/relax/transform/legalize_ops/nn.py
+++ b/python/tvm/relax/transform/legalize_ops/nn.py
@@ -364,9 +364,9 @@ def _te_attention(
         s = topi.nn.softmax(p)
     else:
         if causal_mask == "TopLeft":
-            offset = 0
+            offset = tir.IntImm("int32", 0)
         elif causal_mask == "BottomRight":
-            offset = abs(seq_len - seq_len_kv)
+            offset = tir.IntImm("int32", abs(seq_len - seq_len_kv))
         else:
             raise NotImplementedError()
         p_masked = topi.trilu(p, k=offset, upper=False)

--- a/python/tvm/relax/transform/legalize_ops/nn.py
+++ b/python/tvm/relax/transform/legalize_ops/nn.py
@@ -18,6 +18,7 @@
 """Default legalization function for neural network operators."""
 import logging
 import math
+from typing import Optional
 
 from tvm import topi, tir, te
 from ...block_builder import BlockBuilder
@@ -335,7 +336,12 @@ def _nn_dropout(bb: BlockBuilder, call: Call) -> Expr:
 
 
 def _te_attention(
-    q: te.Tensor, k: te.Tensor, v: te.Tensor, bias: te.Tensor, scale: tir.FloatImm
+    q: te.Tensor,
+    k: te.Tensor,
+    v: te.Tensor,
+    bias: te.Tensor,
+    scale: tir.FloatImm,
+    causal_mask: Optional[str],
 ) -> te.Tensor:
     batch_size, seq_len, num_head, head_dim = q.shape
     _, seq_len_kv, _, head_dim_v = v.shape
@@ -354,7 +360,21 @@ def _te_attention(
         p = topi.reshape(p, [batch_size, num_head, seq_len, seq_len_kv])
         p = topi.add(p, bias)
         p = topi.reshape(p, [batch_size * num_head, seq_len, seq_len_kv])
-    s = topi.nn.softmax(p)
+    if causal_mask is None:
+        s = topi.nn.softmax(p)
+    else:
+        if causal_mask == "TopLeft":
+            offset = 0
+        elif causal_mask == "BottomRight":
+            offset = abs(seq_len - seq_len_kv)
+        else:
+            raise NotImplementedError()
+        p_masked = topi.trilu(p, k=offset, upper=False)
+        p_masked_exp = topi.trilu(
+            topi.exp(p_masked - topi.max(p_masked, axis=-1, keepdims=True)), k=offset, upper=False
+        )
+        p_masked_sum = topi.sum(p_masked_exp, axis=-1, keepdims=True)
+        s = topi.divide(p_masked_exp, p_masked_sum)
     o = topi.nn.batch_matmul(s, v, transpose_b=False)
     o = topi.reshape(o, [batch_size, num_head, seq_len, head_dim_v])
     return topi.transpose(o, [0, 2, 1, 3])
@@ -369,6 +389,7 @@ def _nn_attention(bb: BlockBuilder, call: Call) -> Expr:
         call.args[2],
         None,
         call.attrs.scale,
+        call.attrs.causal_mask,
         primfunc_name_hint="attention",
     )
 
@@ -382,6 +403,7 @@ def _nn_attention_bias(bb: BlockBuilder, call: Call) -> Expr:
         call.args[2],
         call.args[3],
         call.attrs.scale,
+        call.attrs.causal_mask,
         primfunc_name_hint="attention_bias",
     )
 

--- a/src/relax/op/nn/attention.cc
+++ b/src/relax/op/nn/attention.cc
@@ -28,9 +28,11 @@ namespace relax {
 /* relax.nn.attention */
 TVM_REGISTER_NODE_TYPE(AttentionAttrs);
 
-Expr attention(Expr query, Expr key, Expr value, Optional<Expr> bias, Optional<FloatImm> scale) {
+Expr attention(Expr query, Expr key, Expr value, Optional<Expr> bias, Optional<FloatImm> scale,
+               Optional<String> causal_mask) {
   ObjectPtr<AttentionAttrs> attrs = make_object<AttentionAttrs>();
   attrs->scale = scale;
+  attrs->causal_mask = causal_mask;
   if (bias.defined()) {
     return Call(Op::Get("relax.nn.attention_bias"),
                 {std::move(query), std::move(key), std::move(value), std::move(bias.value())},
@@ -110,7 +112,8 @@ StructInfo InferStructInfoAttention(const Call& call, const BlockBuilder& ctx) {
 }
 
 Call InferMixedPrecisionAttention(const Call& call, const DataType& out_dtype) {
-  return Downcast<Call>(attention(call->args[0], call->args[1], call->args[2], NullOpt, NullOpt));
+  return Downcast<Call>(
+      attention(call->args[0], call->args[1], call->args[2], NullOpt, NullOpt, NullOpt));
 }
 
 TVM_REGISTER_OP("relax.nn.attention")

--- a/src/relax/op/nn/attention.h
+++ b/src/relax/op/nn/attention.h
@@ -33,7 +33,8 @@ namespace tvm {
 namespace relax {
 
 /*! \brief fused multi head attention */
-Expr attention(Expr query, Expr key, Expr value, Optional<Expr> bias, Optional<FloatImm> scale);
+Expr attention(Expr query, Expr key, Expr value, Optional<Expr> bias, Optional<FloatImm> scale,
+               Optional<String> causal_mask);
 
 }  // namespace relax
 }  // namespace tvm


### PR DESCRIPTION
This PR introduces the causal mask for `R.nn.attention` and its cutlass dispatch and legalization. The `causal_mask` argument accepts 2 types of causal masks - "TopLeft" and "BottomRight". 

For example, with `seq_len = 4`, `seq_len_kv = 2`, 
mask for "TopLeft":
```
[[1, 0],
 [1, 1],
 [1, 1],
 [1, 1]]
```
mask for "BottomRight":
```
[[1, 1],
 [1, 1],
 [1, 1],
 [1, 1]]
```
with `seq_len = 2`, `seq_len_kv = 4`,
mask for "TopLeft":
```
[[1, 0, 0, 0],
 [1, 1, 0, 0]]
```
mask for "BottomRight":
```
[[1, 1, 1, 0],
 [1, 1, 1, 1]]
```

@vinx13 @masahi @yelite 