### PR TITLE
[TypoFix] fix some typo problem in keras frontend

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -475,7 +475,7 @@ def _convert_convolution3d(inexpr, keras_layer, etab, data_layout, input_shape=N
         if is_deconv:
             kernel_layout = "IODHW"
         msg = (
-            f"Kernel layout with {data_layout} is not supported for operator Convolution3D "
+            f"Kernel layout with {kernel_layout} is not supported for operator Convolution3D "
             f"in frontend Keras."
         )
         raise tvm.error.OpAttributeUnImplemented(msg)

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -299,7 +299,7 @@ def _convert_convolution1d(inexpr, keras_layer, etab, data_layout, input_shape=N
         if is_deconv:
             kernel_layout = "IOW"
         msg = (
-            f"Kernel layout with {data_layout} is not supported for operator Convolution1D "
+            f"Kernel layout with {kernel_layout} is not supported for operator Convolution1D "
             f"in frontend Keras."
         )
         raise tvm.error.OpAttributeUnImplemented(msg)


### PR DESCRIPTION
This pr fixed a typo problem which could give an ambiguous crash message.

@echuraev @merrymercy @masahi 