### PR TITLE
[Unity][Transform] Fix bug for tir expression in shape in fuse_tir

### DIFF
--- a/include/tvm/tir/schedule/block_scope.h
+++ b/include/tvm/tir/schedule/block_scope.h
@@ -41,6 +41,7 @@ namespace tir {
  * - Parent sref: The parent reference of an sref is the block or loop reference to the closest
  schedulable statement. We define closest to be the nearest schedulable statement of an ancestor in
  the AST.
+ * schedulable statement of its ancestors on the TensorIR AST.
  * - Root sref: Sref to the root block. Every sref has exactly one parent sref except for root sref.
  * - Sref tree: The parent-children-relationship of srefs that forms a tree, uniquely determined by
  * the TensorIR AST.

--- a/include/tvm/tir/schedule/block_scope.h
+++ b/include/tvm/tir/schedule/block_scope.h
@@ -41,7 +41,6 @@ namespace tir {
  * - Parent sref: The parent reference of an sref is the block or loop reference to the closest
  schedulable statement. We define closest to be the nearest schedulable statement of an ancestor in
  the AST.
- * schedulable statement of its ancestors on the TensorIR AST.
  * - Root sref: Sref to the root block. Every sref has exactly one parent sref except for root sref.
  * - Sref tree: The parent-children-relationship of srefs that forms a tree, uniquely determined by
  * the TensorIR AST.

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -450,8 +450,7 @@ class FusedTIRConstructor : public ExprVisitor {
         ICHECK_GE(num_params, vars.size());
         for (size_t i = 0; i < vars.size(); ++i) {
           const tir::Var& param = prim_func->params[num_params - vars.size() + i];
-          ICHECK(!func_info_.symbolic_var_remap.count(param));
-          func_info_.symbolic_var_remap.Set(param, vars[i]);
+          func_info_.symbolic_var_matcher.Match(param, vars[i]);
         }
       } else {
         LOG(FATAL) << "TIR vars should be a shape expr, but got: " << tir_vars->GetTypeKey();

--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -1031,6 +1031,7 @@ def test_tir_expression_in_shape():
                 R.output(lv)
             return lv
 
+    @I.ir_module
     class Expected:
         @T.prim_func
         def fused_transpose_matmul(
@@ -1069,7 +1070,7 @@ def test_tir_expression_in_shape():
             tir_vars: R.Shape(["n"]),
         ) -> R.Tensor(("n - 1", 3), dtype="float32"):
             n = T.int64()
-            cls = Module
+            cls = Expected
             with R.dataflow():
                 lv = R.call_tir(
                     cls.fused_transpose_matmul,

--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -1043,19 +1043,14 @@ def test_tir_expression_in_shape():
             T.func_attr({"tir.noalias": T.bool(True)})
             y = T.match_buffer(p_y, (n - T.int64(1), T.int64(4)))
             var_T_matmul_intermediate = T.match_buffer(p_output0, (n - T.int64(1), T.int64(3)))
-            # with T.block("root"):
             var_T_transpose_intermediate = T.alloc_buffer((T.int64(4), T.int64(3)))
             for ax0, ax1 in T.grid(T.int64(4), T.int64(3)):
                 with T.block("T_transpose"):
                     v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
-                    T.reads(x[v_ax1, v_ax0])
-                    T.writes(var_T_transpose_intermediate[v_ax0, v_ax1])
                     var_T_transpose_intermediate[v_ax0, v_ax1] = x[v_ax1, v_ax0]
             for ax0, ax1, k in T.grid(n - T.int64(1), T.int64(3), T.int64(4)):
                 with T.block("T_matmul"):
                     v_ax0, v_ax1, v_k = T.axis.remap("SSR", [ax0, ax1, k])
-                    T.reads(y[v_ax0, v_k], var_T_transpose_intermediate[v_k, v_ax1])
-                    T.writes(var_T_matmul_intermediate[v_ax0, v_ax1])
                     with T.init():
                         var_T_matmul_intermediate[v_ax0, v_ax1] = T.float32(0)
                     var_T_matmul_intermediate[v_ax0, v_ax1] = (

--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -1003,5 +1003,85 @@ def test_same_buffer_multiple_read():
     _check(Module, Expected)
 
 
+def test_tir_expression_in_shape():
+    @I.ir_module
+    class Module:
+        @R.function
+        def fused_transpose_matmul(
+            x: R.Tensor((3, 4), dtype="float32"),
+            y: R.Tensor(("n - 1", 4), dtype="float32"),
+            tir_vars: R.Shape(["n"]),
+        ) -> R.Tensor(("n - 1", 3), dtype="float32"):
+            R.func_attr({"Primitive": 1})
+            with R.dataflow():
+                lv = R.emit_te(topi.transpose, x)
+                gv = R.emit_te(topi.matmul, y, lv)
+                R.output(gv)
+            return gv
+
+        @R.function
+        def main(
+            x: R.Tensor((3, 4), dtype="float32"),
+            y: R.Tensor(("n - 1", 4), dtype="float32"),
+            tir_vars: R.Shape(["n"]),
+        ) -> R.Tensor(("n - 1", 3), dtype="float32"):
+            cls = Module
+            with R.dataflow():
+                lv = cls.fused_transpose_matmul(x, y, tir_vars)
+                R.output(lv)
+            return lv
+
+    class Expected:
+        @T.prim_func
+        def fused_transpose_matmul(
+            x: T.Buffer((T.int64(3), T.int64(4)), "float32"),
+            p_y: T.handle,
+            p_output0: T.handle,
+            n: T.int64,
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            y = T.match_buffer(p_y, (n - T.int64(1), T.int64(4)))
+            var_T_matmul_intermediate = T.match_buffer(p_output0, (n - T.int64(1), T.int64(3)))
+            # with T.block("root"):
+            var_T_transpose_intermediate = T.alloc_buffer((T.int64(4), T.int64(3)))
+            for ax0, ax1 in T.grid(T.int64(4), T.int64(3)):
+                with T.block("T_transpose"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(x[v_ax1, v_ax0])
+                    T.writes(var_T_transpose_intermediate[v_ax0, v_ax1])
+                    var_T_transpose_intermediate[v_ax0, v_ax1] = x[v_ax1, v_ax0]
+            for ax0, ax1, k in T.grid(n - T.int64(1), T.int64(3), T.int64(4)):
+                with T.block("T_matmul"):
+                    v_ax0, v_ax1, v_k = T.axis.remap("SSR", [ax0, ax1, k])
+                    T.reads(y[v_ax0, v_k], var_T_transpose_intermediate[v_k, v_ax1])
+                    T.writes(var_T_matmul_intermediate[v_ax0, v_ax1])
+                    with T.init():
+                        var_T_matmul_intermediate[v_ax0, v_ax1] = T.float32(0)
+                    var_T_matmul_intermediate[v_ax0, v_ax1] = (
+                        var_T_matmul_intermediate[v_ax0, v_ax1]
+                        + y[v_ax0, v_k] * var_T_transpose_intermediate[v_k, v_ax1]
+                    )
+
+        @R.function
+        def main(
+            x: R.Tensor((3, 4), dtype="float32"),
+            y: R.Tensor(("n - 1", 4), dtype="float32"),
+            tir_vars: R.Shape(["n"]),
+        ) -> R.Tensor(("n - 1", 3), dtype="float32"):
+            n = T.int64()
+            cls = Module
+            with R.dataflow():
+                lv = R.call_tir(
+                    cls.fused_transpose_matmul,
+                    (x, y),
+                    out_sinfo=R.Tensor((n - 1, 3), dtype="float32"),
+                    tir_vars=R.shape([n]),
+                )
+                R.output(lv)
+            return lv
+
+    _check(Module, Expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Currently fuse_tir cannot handle cases when the shape of arguments of call_tir contains tir expressions (e.g. `n-1` other than `n`). 

In this case, 
1. The tir vars in the tir expression will be collected and provided as the third parameter of call_tir
2. fuse_tir has a special logic to handle these vars. However, it wrongly checks such vars cannot already exist in `symbolic_var_remap`. In fact, the var has been stored in `symbolic_var_remap` when previously matching arguments to tir buffers, where the shape of the argument is visited.

This PR fixes this problem by using `symbolic_var_matcher.Match` instead.
