### PR TITLE
[Unity][Training] Enhance op gradient

### DIFF
--- a/python/tvm/relax/op/_op_gradient.py
+++ b/python/tvm/relax/op/_op_gradient.py
@@ -88,6 +88,11 @@ def _get_dtype(expr: Expr) -> str:
 
 
 def _fit_shape(bb: BlockBuilder, expr: Expr, target: Expr) -> Expr:
+    """When expr and target has the same shape, return expr;
+    otherwise return `collapse_sum_to(expr, target.struct_info.shape)`.
+
+    Will use BlockBuilder to normalize expr first.
+    """
     target_shape = _get_shape(target)
     expr_sinfo = _get_shape(bb.normalize(expr)).struct_info
     target_sinfo = target_shape.struct_info

--- a/python/tvm/relax/op/_op_gradient.py
+++ b/python/tvm/relax/op/_op_gradient.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=unused-argument, redefined-builtin
+# pylint: disable=unused-argument, redefined-builtin, invalid-name
 """Gradient definitions for Relax operators."""
 import functools
 import operator
@@ -56,7 +56,7 @@ from .manipulate import (
 from .nn import conv2d_transpose, conv2d
 from .search import where
 from .statistical import sum, cumsum
-from .unary import cos, exp, log, sin, sqrt, sigmoid
+from .unary import cos, exp, log, sin, sigmoid
 
 
 # TODO(yixin, chaofan): handle symbolic shape for most of the gradients
@@ -116,12 +116,11 @@ def _fit_shape(bb: BlockBuilder, expr: Expr, target: Expr) -> Expr:
 
 
 def _get_shape_prod(expr, axis):
-    # Requires constant shape
+    # Requires static shape
     shape = _get_shape(expr)
     if axis is None:
         return functools.reduce(operator.mul, (int(i) for i in shape), 1)
-    else:
-        return functools.reduce(operator.mul, (int(shape[int(i)]) for i in axis), 1)
+    return functools.reduce(operator.mul, (int(shape[int(i)]) for i in axis), 1)
 
 
 ##################### Binary #####################
@@ -720,8 +719,7 @@ def permute_dims_grad(
         for i in range(dims):
             new_axes[int(axes[i])] = i
         return [permute_dims(output_grad, axes=new_axes)]
-    else:
-        return [permute_dims(output_grad)]
+    return [permute_dims(output_grad)]
 
 
 @register_gradient("relax.concat")

--- a/tests/python/relax/test_transform_gradient.py
+++ b/tests/python/relax/test_transform_gradient.py
@@ -1138,9 +1138,9 @@ def test_mlp_script():
                 lv4: R.Tensor((3, 5), dtype="float32") = R.multiply(lv2, lv3)
                 out_adjoint: R.Tensor((3, 5), dtype="float32") = R.subtract(logits_adjoint, lv4)
                 lv0_adjoint: R.Tensor((3, 5), dtype="float32") = out_adjoint
-                lv5: R.Tensor((10, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
-                lv6: R.Tensor((10, 5), dtype="float32") = R.matmul(lv5, lv0_adjoint, out_dtype="void")
-                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.collapse_sum_to(lv6, R.shape([10, 5]))
+                lv5: R.Tensor((5, 10), dtype="float32") = R.permute_dims(w0, axes=[1, 0])
+                lv6: R.Tensor((10, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
+                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.matmul(lv6, lv0_adjoint, out_dtype="void")
                 b0_adjoint: R.Tensor((5,), dtype="float32") = R.collapse_sum_to(out_adjoint, R.shape([5]))
                 R.output(loss, w0_adjoint, b0_adjoint)
             return (loss, (w0_adjoint, b0_adjoint))


### PR DESCRIPTION
This PR updates the logic of the `_fit_shape` helper function to first use BlockBuilder to acquire the shape, instead of providing the shape. 

It will make it easier for expressions that are hard to provide shapes, such as matmul.

The correctness of these op gradients are checked in `tests/python/relax/test_op_gradient_numeric.py`, and does not need additional checks.