### PR TITLE
[BUILD] Enable log before throw message in windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,9 @@ if(MSVC)
   add_definitions(-D_SCL_SECURE_NO_WARNINGS)
   add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
   add_definitions(-DNOMINMAX)
+  # log error before throw as usually windows
+  # may have issues with stack trace
+  add_definitions(-DDMLC_LOG_BEFORE_THROW=1)
   # regeneration does not work well with msbuild custom rules.
   set(CMAKE_SUPPRESS_REGENERATION ON)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")

--- a/include/tvm/runtime/logging.h
+++ b/include/tvm/runtime/logging.h
@@ -367,7 +367,11 @@ class LogFatal {
       this->lineno_ = lineno;
     }
     [[noreturn]] TVM_NO_INLINE dmlc::Error Finalize() {
-      throw InternalError(file_, lineno_, stream_.str());
+      InternalError error(file_, lineno_, stream_.str());
+#if DMLC_LOG_BEFORE_THROW
+      std::cerr << error.what() << std::endl;
+#endif
+      throw error;
     }
     std::ostringstream stream_;
     std::string file_;


### PR DESCRIPTION
This PR enables log before throw in windows.
The error handling in windows sometimes can be tricky and it is helpful to be able to get as many information as possible. Turning this option on can help us detect possible errors here.