### PR TITLE
[TVMScript] Prevent bool to int conversion in T.Assert condition

### DIFF
--- a/python/tvm/script/ir_builder/tir/ir.py
+++ b/python/tvm/script/ir_builder/tir/ir.py
@@ -862,6 +862,8 @@ def Assert(condition: PrimExpr, message: str) -> frame.AssertFrame:  # pylint: d
     res : frame.AssertFrame
         The result AssertFrame.
     """
+    if isinstance(condition, bool):
+        condition = IntImm("bool", condition)
     return _ffi_api.Assert(condition, message)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -80,6 +80,9 @@ TVM_REGISTER_NODE_TYPE(AttrStmtNode);
 // AssertStmt
 AssertStmt::AssertStmt(PrimExpr condition, PrimExpr message, Stmt body, Span span) {
   ICHECK(condition.defined());
+  CHECK(condition.dtype().is_bool())
+      << "AssertStmt should have boolean condition, "
+      << "but received " << condition << " with dtype " << condition.dtype();
   ICHECK(message.dtype() == DataType::Int(32) || message.as<StringImmNode>())
       << "TypeError: AssertStmt message must be an int or string:" << message << "\n";
 

--- a/src/tir/transforms/make_packed_api.cc
+++ b/src/tir/transforms/make_packed_api.cc
@@ -42,6 +42,7 @@ namespace tir {
 
 static constexpr const char* kDeviceContextVar = "device_api_context";
 
+namespace {
 class ReturnRewriter : public StmtMutator {
  public:
   explicit ReturnRewriter(Var ret_var, Var ret_tcode) : ret_var_(ret_var), ret_tcode_(ret_tcode) {}
@@ -175,6 +176,8 @@ class SubroutineCallRewriter : public StmtExprMutator {
   const Map<GlobalVar, String>& packed_func_methods;
   bool made_change_{false};
 };
+
+}  // namespace
 
 inline Stmt MakeAssertEQ(PrimExpr lhs, PrimExpr rhs, std::string msg) {
   return AssertStmt(lhs == rhs, tvm::tir::StringImm(msg), Evaluate(0));

--- a/src/tir/transforms/make_unpacked_api.cc
+++ b/src/tir/transforms/make_unpacked_api.cc
@@ -40,6 +40,8 @@
 namespace tvm {
 namespace tir {
 
+namespace {
+
 class SubroutineCallRewriter : public StmtExprMutator {
  public:
   static Optional<Stmt> Apply(const std::unordered_set<const GlobalVarNode*>& external_methods,
@@ -83,6 +85,8 @@ class SubroutineCallRewriter : public StmtExprMutator {
   const std::unordered_set<const GlobalVarNode*>& external_methods_;
   bool made_change_{false};
 };
+
+}  // namespace
 
 PrimFunc MakeUnpackedAPI(PrimFunc func) {
   // A function with an explicit calling convention has already been

--- a/tests/python/unittest/test_tvmscript_printer_tir.py
+++ b/tests/python/unittest/test_tvmscript_printer_tir.py
@@ -277,13 +277,13 @@ with T.attr("pragma", "unroll", 1):
 
 def test_assert_stmt():
     with IRBuilder() as ib:
-        with T.Assert(1, "assertion"):
+        with T.Assert(True, "assertion"):
             T.evaluate(0)
     obj = ib.get()
     _assert_print(
         obj,
         """
-with T.Assert(1, "assertion"):
+with T.Assert(T.bool(True), "assertion"):
     T.evaluate(0)
 """,
     )

--- a/tests/python/unittest/test_tvmscript_syntax_sugar.py
+++ b/tests/python/unittest/test_tvmscript_syntax_sugar.py
@@ -452,5 +452,40 @@ def test_preserve_variable_name():
     assert var_name == "j"
 
 
+def test_boolean_constant():
+    """Python booleans should become T.Bool objects"""
+
+    @T.prim_func
+    def explicit():
+        T.evaluate(T.bool(True))
+
+    @T.prim_func
+    def implicit():
+        T.evaluate(True)
+
+    assert_structural_equal(implicit, explicit)
+
+
+def test_foldable_boolean_in_assert():
+    """Foldable booleans T.Bool objects
+
+    The condition of an assert statement should be a boolean
+    expression.  Previously, this test failed because the FFI does not
+    distinguish between integer primitives and boolean primitives.
+    """
+
+    @T.prim_func
+    def explicit():
+        assert T.bool(False), "Message"
+        T.evaluate(0)
+
+    @T.prim_func
+    def implicit():
+        assert 0 == 1, "Message"
+        T.evaluate(0)
+
+    assert_structural_equal(implicit, explicit)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Previously, while literal `True` and `False` values were converted to `tvm::Bool` instances, constant-foldable expressions (e.g. `0 == 1`) would be evaluated to `True`, but were then passed directly to the FFI.  Because the FFI uses the same representation for integer and boolean values, the conversion to `PrimExpr` resulted in a `tvm::Integer` instead of `tvm::Bool`.

This commit converts the argument of `T.Assert` to a `tvm::Bool` before calling the FFI, avoiding the ambiguity.  In addition, the `AssertStmt` constructor now validates the datatype of the condition, to prevent it from re-occurring.

This was first caught in the unit test `test_debug_info.py::test_llvm_ir_debug_info`, which failed validation on some versions of LLVM due to the use of `i32` as the condition of an assert.