### PR TITLE
[TIR] Restrict tir.transform.CombineContextCall to host functions

### DIFF
--- a/include/tvm/target/target.h
+++ b/include/tvm/target/target.h
@@ -72,6 +72,16 @@ class TargetNode : public Object {
   TVM_DLL int GetTargetDeviceType() const;
 
   /*!
+   * \brief Check if the target contains a key
+   *
+   * \param query_key The string name of the key to be checked
+   *
+   * \return True if the target's `TargetNode::keys` contains the
+   * specified key, False otherwise.
+   */
+  TVM_DLL bool HasKey(const std::string& query_key) const;
+
+  /*!
    * \brief Returns a human readable representation of \p Target which includes all fields,
    * especially the host. Useful for diagnostic messages and debugging.
    *

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -669,6 +669,11 @@ int TargetNode::GetTargetDeviceType() const {
   return kind->default_device_type;
 }
 
+bool TargetNode::HasKey(const std::string& query_key) const {
+  return std::any_of(keys.begin(), keys.end(),
+                     [&query_key](const auto& key) { return key == query_key; });
+}
+
 String TargetNode::ToDebugString() const {
   std::ostringstream os;
   os << "Target(";

--- a/src/tir/transforms/combine_context_call.cc
+++ b/src/tir/transforms/combine_context_call.cc
@@ -33,6 +33,8 @@
 
 #include <unordered_map>
 
+#include "ir_utils.h"
+
 namespace tvm {
 namespace tir {
 
@@ -102,8 +104,9 @@ namespace transform {
 
 Pass CombineContextCall() {
   auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
-    auto* n = f.CopyOnWrite();
-    n->body = ContextCallCombiner().Combine(std::move(n->body));
+    if (IsHostFunc(f).value_or(false)) {
+      f.CopyOnWrite()->body = ContextCallCombiner().Combine(f->body);
+    }
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tir.CombineContextCall", {});

--- a/src/tir/transforms/ir_utils.cc
+++ b/src/tir/transforms/ir_utils.cc
@@ -692,6 +692,16 @@ std::pair<int32_t, int32_t> GetWmmaFragmentDimSize(const std::string& shape_str,
   return std::pair<int32_t, int32_t>(0, 0);
 }
 
+std::optional<bool> IsHostFunc(const PrimFunc& func) {
+  if (func->HasNonzeroAttr(tvm::tir::attr::kIsHostFunc)) {
+    return true;
+  } else if (auto target = func->GetAttr<Target>(tvm::attr::kTarget)) {
+    return target.value()->HasKey("cpu");
+  } else {
+    return std::nullopt;
+  }
+}
+
 namespace transform {
 Pass ConvertSSA() {
   auto pass_func = [](IRModule mod, PassContext ctx) {

--- a/src/tir/transforms/ir_utils.h
+++ b/src/tir/transforms/ir_utils.h
@@ -34,6 +34,7 @@
 #include <tvm/tir/op.h>
 
 #include <limits>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -350,6 +351,17 @@ CollectStorageAlignAnnotation(const Stmt& body);
  */
 std::pair<int32_t, int32_t> GetWmmaFragmentDimSize(const std::string& shape_str,
                                                    const std::string& scope);
+
+/*! \brief Check if a PrimFunc is a host function
+ *
+ * \param func The function to be inspected
+ *
+ * \return True if the function is known to run on the host, false if
+ * the function is known to run on the device.  If it cannot be
+ * determined (e.g. a function without a tvm::attr::kTarget
+ * attribute), returns std::nullopt.
+ */
+std::optional<bool> IsHostFunc(const PrimFunc& func);
 
 }  // namespace tir
 }  // namespace tvm


### PR DESCRIPTION
Previously, the `tir.transform.CombineContextCall` pass applied to all functions in an `IRModule`, but was only applied to modules that contain only host functions.  This commit updates `tir.transform.CombineContextCall` to apply only to host functions.