### PR TITLE
[Unity] Fix MergeCompositeFunctions for non-CallNode dataflow inputs 

### DIFF
--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -402,7 +402,7 @@ class FunctionCreator : public ExprMutator {
             CheckDefAndUpdateParam(arg);
           }
         }
-      } else if (var_binding->value.as<TupleGetItemNode>()){
+      } else if (var_binding->value.as<TupleGetItemNode>()) {
         const auto* tuple_item = var_binding->value.as<TupleGetItemNode>();
         CheckDefAndUpdateParam(tuple_item->tuple);
       }

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -404,7 +404,6 @@ class FunctionCreator : public ExprMutator {
         }
       } else if (var_binding->value.as<TupleGetItemNode>()){
         const auto* tuple_item = var_binding->value.as<TupleGetItemNode>();
-        ICHECK(tuple_item != nullptr);
         CheckDefAndUpdateParam(tuple_item->tuple);
       }
 

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -402,7 +402,7 @@ class FunctionCreator : public ExprMutator {
             CheckDefAndUpdateParam(arg);
           }
         }
-      } else {
+      } else if (var_binding->value.as<TupleGetItemNode>()){
         const auto* tuple_item = var_binding->value.as<TupleGetItemNode>();
         ICHECK(tuple_item != nullptr);
         CheckDefAndUpdateParam(tuple_item->tuple);

--- a/src/relax/transform/merge_composite_functions.cc
+++ b/src/relax/transform/merge_composite_functions.cc
@@ -84,6 +84,13 @@ class CompositeGroupsBuilder : public MemoizedExprTranslator<Group*> {
     for (const auto& param : func->params) {
       memo_[param] = arena_->make<Group>();
     }
+
+    PostOrderVisit(func, [this](Expr e) {
+      if (e->IsInstance<ConstantNode>() || e->IsInstance<ShapeExprNode>()) {
+	memo_[e] = arena_->make<Group>();
+      }
+    });
+
     VisitExpr(func->body);
 
     GroupMap group_map;

--- a/src/relax/transform/merge_composite_functions.cc
+++ b/src/relax/transform/merge_composite_functions.cc
@@ -86,8 +86,12 @@ class CompositeGroupsBuilder : public MemoizedExprTranslator<Group*> {
     }
 
     PostOrderVisit(func, [this](Expr e) {
-      if (e->IsInstance<ConstantNode>() || e->IsInstance<ShapeExprNode>()) {
-	memo_[e] = arena_->make<Group>();
+      // Make default groups for dataflow nodes other than CallNode.
+      // Groups for CallNode are created in its visitor.
+      if (e->IsInstance<ConstantNode>() || e->IsInstance<ShapeExprNode>() ||
+          e->IsInstance<TupleNode>() || e->IsInstance<TupleGetItemNode>() ||
+          e->IsInstance<PrimValueNode>()) {
+        memo_[e] = arena_->make<Group>();
       }
     });
 


### PR DESCRIPTION
Fix for https://discuss.tvm.apache.org/t/segfault-on-mergecompositefunctions/14999. We are not creating `Group` for non `CallNodes` that appear in the arguments of another `CallNode`. This results in a segfault when OpFuser tries to look up the group for all call node inputs.

@vinx13 @yelite  