### PR TITLE
[Bug] Add typing_extensions requirement again

### DIFF
--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -72,6 +72,7 @@ REQUIREMENTS_BY_PIECE: RequirementsByPieceType = [
                 "psutil",
                 "scipy",
                 "tornado",
+                "typing_extensions",
             ],
         ),
     ),
@@ -277,6 +278,7 @@ CONSTRAINTS = [
     ("torch", None),
     ("torchvision", None),
     ("tornado", None),
+    ("typing_extensions", None),
     ("xgboost", ">=1.1.0"),  # From PR #4953 & Issue #12009
 ]
 


### PR DESCRIPTION
This python dependency missing problem has been reported in https://github.com/apache/tvm/pull/14244, the same code was merged before, but strangely, the relevant changes were reverted in the latest commit. @areusch

But it can be confirmed that typing_extensions is still needed by tvmc at least: [source code of tvm.meta_shedule.builder.builder](https://github.com/apache/tvm/blob/main/python/tvm/meta_schedule/builder/builder.py#L21)

It is worth mentioning that this problem affects the [tvm source code download page](https://tvm.apache.org/download), at least version 0.12.0. In fact, I encountered the **ModuleNotFoundError** error when installing tvm from source code and trying to **call tvmc**. You can reproduce this error with the following command:

```sh
# download, compile and install.
wget https://dlcdn.apache.org/tvm/tvm-v0.12.0/apache-tvm-src-v0.12.0.tar.gz \
    && tar -zxvf apache-tvm-src-v0.12.0.tar.gz \
    && mkdir -p apache-tvm-src-v0.12.0/build \
    && cd apache-tvm-src-v0.12.0/build/ \
    && cp ../cmake/config.cmake ./ \
    && sed -i 's/set(USE_LLVM OFF)/set(USE_LLVM ON)/g' config.cmake \
    && wget https://apt.llvm.org/llvm.sh \
    && sed -i 's/add-apt-repository "\${REPO_NAME}"/add-apt-repository "\${REPO_NAME}" -y/g' llvm.sh \
    && cmake .. \
    && make -j$(nproc) \
    && python ../python/setup.py install 
# try calling tvmc
tvmc
```
@leandron @driazati @junrushao