### PR TITLE
[Unity] Fix ConvertLayout on binary elemwise ops involving scalar input

### DIFF
--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -92,10 +92,19 @@ InferLayoutOutput InferLayoutBinaryEwise(const Call& call,
       << "Unknown dim tensors should not be handled by this function";
 
   if (x1_sinfo->ndim <= x2_sinfo->ndim) {
+    if (x1_sinfo->ndim == 0) {
+      LayoutDecision out_layout = layout2;
+      return InferLayoutOutput({LayoutDecision(""), layout2}, {out_layout}, Attrs(call->attrs));
+    }
     LayoutDecision out_layout = FollowDecision(layout1, x2_sinfo->ndim);
     return InferLayoutOutput({layout1, out_layout}, {out_layout}, Attrs(call->attrs));
   } else {
+    if (x2_sinfo->ndim == 0) {
+      LayoutDecision out_layout = layout1;
+      return InferLayoutOutput({layout1, LayoutDecision("")}, {out_layout}, Attrs(call->attrs));
+    }
     LayoutDecision out_layout = FollowDecision(layout2, x1_sinfo->ndim);
+
     return InferLayoutOutput({out_layout, layout2}, {out_layout}, Attrs(call->attrs));
   }
 }

--- a/src/relax/transform/convert_layout.cc
+++ b/src/relax/transform/convert_layout.cc
@@ -90,8 +90,7 @@ class LayoutConvertMutator : public ExprMutator {
   Expr RewriteExpr(const Expr& expr, const NLayout& to) {
     auto fvisitleaf = [&](const Expr& expr, std::array<NLayout, 2> layouts) -> Expr {
       NLayout from = layouts[0], to = layouts[1];
-      if (NLayoutEqual()(from, to)) return expr;
-      if (layouts[0].LeafValue()->layout->name == "") return expr;
+      if (NLayoutEqual()(from, to) || layouts[0].LeafValue()->layout->name == "") return expr;
       // If not both from and to are unknown, then none of them can be unknown.
       ICHECK(!NLayoutEqual()(from, LayoutDecision::InitUnknownDim()) &&
              !NLayoutEqual()(to, LayoutDecision::InitUnknownDim()))

--- a/src/relax/transform/convert_layout.cc
+++ b/src/relax/transform/convert_layout.cc
@@ -91,6 +91,7 @@ class LayoutConvertMutator : public ExprMutator {
     auto fvisitleaf = [&](const Expr& expr, std::array<NLayout, 2> layouts) -> Expr {
       NLayout from = layouts[0], to = layouts[1];
       if (NLayoutEqual()(from, to)) return expr;
+      if (layouts[0].LeafValue()->layout->name == "") return expr;
       // If not both from and to are unknown, then none of them can be unknown.
       ICHECK(!NLayoutEqual()(from, LayoutDecision::InitUnknownDim()) &&
              !NLayoutEqual()(to, LayoutDecision::InitUnknownDim()))

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -1406,8 +1406,7 @@ def test_binary_ewise_scalar():
     class Input:
         @R.function
         def main(
-            x: R.Tensor((2, 3, 28, 28), "float32"),
-            w: R.Tensor((4, 3, 3, 3), "float32")
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
         ) -> R.Tensor(None, "float32", ndim=4):
             with R.dataflow():
                 gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(x, w, out_dtype="float32")
@@ -1418,13 +1417,28 @@ def test_binary_ewise_scalar():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")) -> R.Tensor((2, 4, 26, 26), dtype="float32"):
+        def main(
+            x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+        ) -> R.Tensor((2, 4, 26, 26), dtype="float32"):
             with R.dataflow():
                 lv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.permute_dims(x, axes=[0, 2, 3, 1])
                 lv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.permute_dims(w, axes=[0, 2, 3, 1])
-                gv: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(lv, lv1, strides=[1, 1], padding=[0, 0, 0, 0], dilation=[1, 1], groups=1, data_layout="NHWC", kernel_layout="OHWI", out_layout="NHWC", out_dtype="float32")
+                gv: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+                    lv,
+                    lv1,
+                    strides=[1, 1],
+                    padding=[0, 0, 0, 0],
+                    dilation=[1, 1],
+                    groups=1,
+                    data_layout="NHWC",
+                    kernel_layout="OHWI",
+                    out_layout="NHWC",
+                    out_dtype="float32",
+                )
                 lv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.add(gv, R.const(1, "float32"))
-                gv2: R.Tensor((2, 4, 26, 26), dtype="float32") = R.permute_dims(lv2, axes=[0, 3, 1, 2])
+                gv2: R.Tensor((2, 4, 26, 26), dtype="float32") = R.permute_dims(
+                    lv2, axes=[0, 3, 1, 2]
+                )
                 R.output(gv2)
             return gv2
 

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -24,7 +24,6 @@ from tvm.script.parser import ir as I, relax as R, tir as T
 def verify(input, expected):
     mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(input)
     mod = Normalize()(mod)
-    print(mod.script())
     tvm.ir.assert_structural_equal(mod, expected)
 
 
@@ -1396,6 +1395,36 @@ def test_binary_broadcast():
                     gv, axes=[0, 3, 1, 2]
                 )
                 gv2: R.Tensor((2, 4, 26, 26), dtype="float32") = R.add(lv2, bias)
+                R.output(gv2)
+            return gv2
+
+    verify(Input, Expected)
+
+
+def test_binary_ewise_scalar():
+    @I.ir_module
+    class Input:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"),
+            w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            with R.dataflow():
+                gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(x, w, out_dtype="float32")
+                gv2: R.Tensor((2, 4, 26, 26), "float32") = R.add(gv, R.const(1, "float32"))
+                R.output(gv2)
+            return gv2
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")) -> R.Tensor((2, 4, 26, 26), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.permute_dims(x, axes=[0, 2, 3, 1])
+                lv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.permute_dims(w, axes=[0, 2, 3, 1])
+                gv: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(lv, lv1, strides=[1, 1], padding=[0, 0, 0, 0], dilation=[1, 1], groups=1, data_layout="NHWC", kernel_layout="OHWI", out_layout="NHWC", out_dtype="float32")
+                lv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.add(gv, R.const(1, "float32"))
+                gv2: R.Tensor((2, 4, 26, 26), dtype="float32") = R.permute_dims(lv2, axes=[0, 3, 1, 2])
                 R.output(gv2)
             return gv2
 


### PR DESCRIPTION
Currently when one of the inputs to elemwise op is a scalar, `ConvertLayout` inserts NHWC -> NCHW fallback conversion, ending up the following undesirable result:

```
gv: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(lv, lv1, data_layout="NHWC", kernel_layout="OHWI", out_layout="NHWC")
lv2: R.Tensor((2, 4, 26, 26), dtype="float32") = R.permute_dims(gv, axes=[0, 3, 1, 2])
gv2: R.Tensor((2, 4, 26, 26), dtype="float32") = R.add(lv2, R.const(1, "float32"))
```

@spectrometerHBH 