### PR TITLE
[METAL] Fix int8 vectorized cast

### DIFF
--- a/src/target/source/codegen_metal.cc
+++ b/src/target/source/codegen_metal.cc
@@ -220,11 +220,6 @@ void CodeGenMetal::PrintType(DataType t, std::ostream& os) {  // NOLINT(*)
     if (t.is_uint()) {
       os << 'u';
     }
-    if (t.bits() == 8 && t.lanes() == 4) {
-      // directly 4 8 bit int in integer.
-      os << "int";
-      return;
-    }
     switch (t.bits()) {
       case 8:
         os << "char";


### PR DESCRIPTION
Current codegen output `(half4)*(device uint*)A` tries to create a `int32` number and then cast it to `half4`, which is not the expected behavior.

As Metal natively supports `uchar4` and `char4` types ([ref](https://developer.apple.com/documentation/metal/mtldatatype/uchar4)), we can direct use them to solve that problem.

cc @tqchen 