### PR TITLE
[Hexagon] Add support for v73, make v68 default

### DIFF
--- a/apps/hexagon_launcher/README.md
+++ b/apps/hexagon_launcher/README.md
@@ -43,10 +43,10 @@ Create a subdirectory for the build files, and run `cmake` with the
 following variables set:
 
 ```
-cmake -DCMAKE_C_COMPILER=/path/to/hexagon-clang \
+cmake -DCMAKE_C_COMPILER=/path/to/hexagon-clang     \
       -DCMAKE_CXX_COMPILER=/path/to/hexagon-clang++ \
-      -DUSE_HEXAGON_ARCH=v65|v66|v68|v69 \
-      -DUSE_HEXAGON_SDK=/path/to/hexagon/SDK \
+      -DUSE_HEXAGON_ARCH=v65|v66|v68|v69|v73        \
+      -DUSE_HEXAGON_SDK=/path/to/hexagon/SDK        \
       /path/to/apps/hexagon_launcher/cmake/hexagon
 ```
 
@@ -60,10 +60,10 @@ the TVM runtime for Hexagon will be built as a part of the process.
 
 ```
 cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/android-ndk/build/cmake/android.toolchain.cmake \
-      -DANDROID_ABI=arm64-v8a \
-      -DANDROID_PLATFORM=android-28 \
-      -DUSE_HEXAGON_SDK=/p/Hexagon_SDK/4.3.0.0
-      -DUSE_HEXAGON_ARCH=v65|v66|v68|v69
+      -DANDROID_ABI=arm64-v8a                       \
+      -DANDROID_PLATFORM=android-28                 \
+      -DUSE_HEXAGON_SDK=/p/Hexagon_SDK/4.3.0.0      \
+      -DUSE_HEXAGON_ARCH=v65|v66|v68|v69|v73        \
       /path/to/apps/hexagon_launcher/cmake/android
 ```
 

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -331,8 +331,8 @@ set(USE_HEXAGON_RPC OFF)
 # compiling _by_ TVM). This applies to components like the TVM runtime, but is
 # also used to select correct include/library paths from the Hexagon SDK when
 # building runtime for Android.
-# Valid values are v65, v66, v68, v69.
-set(USE_HEXAGON_ARCH "v66")
+# Valid values are v65, v66, v68, v69, v73.
+set(USE_HEXAGON_ARCH "v68")
 
 # Whether to use QHL library
 set(USE_HEXAGON_QHL OFF)

--- a/cmake/modules/HexagonSDK.cmake
+++ b/cmake/modules/HexagonSDK.cmake
@@ -107,12 +107,13 @@ function(_get_hexagon_sdk_property_impl
   set(_hexarch_dir_v65 "computev65")
   set(_hexarch_dir_v66 "computev66")
   set(_hexarch_dir_v68 "computev68")
-  set(_hexarch_dir_v69 "computev68")   # Use computev68 for v69
+  set(_hexarch_dir_v69 "computev69")
+  set(_hexarch_dir_v73 "computev73")
   set(_hexarch_dir_str "_hexarch_dir_${_hexagon_arch}")
   set(_hexarch_dir "${${_hexarch_dir_str}}")
 
   if(NOT _hexarch_dir)
-    message(SEND_ERROR "Please set Hexagon architecture to one of v65, v66, v68, v69")
+    message(SEND_ERROR "Please set Hexagon architecture to one of v65, v66, v68, v69, v73")
   endif()
 
   if(_property STREQUAL "VERSION")

--- a/python/tvm/contrib/hexagon/tools.py
+++ b/python/tvm/contrib/hexagon/tools.py
@@ -90,7 +90,7 @@ def link_shared(so_name, objs, extra_args=None):
     objs : list[str,StringImm]
     extra_args : dict (str->str) or Map<String,String>
         Additional arguments:
-            'hex_arch' - Hexagon architecture, e.g. v66
+            'hex_arch' - Hexagon architecture, e.g. v68
             'verbose'  - Print additional information if the key is present
 
     Returns
@@ -110,7 +110,7 @@ def link_shared(so_name, objs, extra_args=None):
 
     if not extra_args:
         extra_args = {}
-    hex_arch = extra_args.get("hex_arch") or "v66"
+    hex_arch = extra_args.get("hex_arch") or "v68"
     linker = tvm.get_global_func("tvm.contrib.hexagon.hexagon_link")()
     if extra_args.get("verbose"):
         print("tvm.contrib.hexagon.link_shared:")
@@ -161,7 +161,7 @@ def link_shared_macos(so_name, objs, extra_args=None):
     objs : list[str,StringImm]
     extra_args : dict (str->str) or Map<String,String>
         Additional arguments:
-            'hex_arch' - Hexagon architecture, e.g. v66
+            'hex_arch' - Hexagon architecture, e.g. v68
 
     Returns
     -------
@@ -180,7 +180,7 @@ def link_shared_macos(so_name, objs, extra_args=None):
 
     if not extra_args:
         extra_args = {}
-    hex_arch = extra_args.get("hex_arch") or "v66"
+    hex_arch = extra_args.get("hex_arch") or "v68"
 
     ses = ContainerSession(HEXAGON_SDK_DOCKER_IMAGE)
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -646,12 +646,12 @@ def riscv_cpu(model="sifive-u54", options=None):
     return Target(" ".join(["llvm"] + opts))
 
 
-def hexagon(cpu_ver="v66", **kwargs):
+def hexagon(cpu_ver="v68", **kwargs):
     """Returns a Hexagon target.
 
     Parameters
     ----------
-    cpu_ver : str (default: "v66")
+    cpu_ver : str (default: "v68")
         CPU version used for code generation. Not all allowed cpu str
         will be valid, LLVM will throw an error.
 
@@ -679,7 +679,7 @@ def hexagon(cpu_ver="v66", **kwargs):
     # in place of '-'.
 
     # Example compiler arguments
-    # llvm -mtriple=hexagon -mcpu=hexagonv66 -mattr=+hvxv66,+hvx-length128b
+    # llvm -mtriple=hexagon -mcpu=hexagonv68 -mattr=+hvxv68,+hvx-length128b
 
     def get_arch_version(cpu_ver):
         m = re.match(r"v([0-9]+).*", cpu_ver)
@@ -687,7 +687,7 @@ def hexagon(cpu_ver="v66", **kwargs):
         return int(m.group(1))
 
     # Check for valid codegen cpu
-    valid_hex = ["v65", "v66", "v67", "v67t", "v68", "v69"]
+    valid_hex = ["v65", "v66", "v67", "v67t", "v68", "v69", "v71", "v73"]
     try:
         cpu_ver = cpu_ver[cpu_ver.index("v") :].lower()
         assert cpu_ver in valid_hex

--- a/src/runtime/hexagon/README.md
+++ b/src/runtime/hexagon/README.md
@@ -54,7 +54,7 @@ ANDROID_ABI=aarch64-v8a
 ANDROID_PLATFORM=android-28
 CMAKE_TOOLCHAIN_FILE=/path/to/android-ndk/build/cmake/android.toolchain.cmake
 USE_HEXAGON=ON
-USE_HEXAGON_ARCH=v65|v66|v68|v69
+USE_HEXAGON_ARCH=v65|v66|v68|v69|v73
 USE_HEXAGON_SDK=/path/to/sdk
 ```
 
@@ -63,8 +63,11 @@ Building for Hexagon requires setting the C/C++ compiler to `hexagon-clang/++`:
 CMAKE_C_COMPILER=hexagon-clang
 CMAKE_CXX_COMPILER=hexagon-clang++
 USE_HEXAGON=ON
-USE_HEXAGON_ARCH=v65|v66|v68|v69
+USE_HEXAGON_ARCH=v65|v66|v68|v69|v73
 USE_HEXAGON_SDK=/path/to/sdk
 ```
 
 As mentioned before, only build the `runtime` component (e.g. `make runtime`).
+
+Please note that the Hexagon SDK version needs to support the architecture
+specified in `USE_HEXAGON_ARCH`.

--- a/src/runtime/hexagon/rpc/simulator/session.cc
+++ b/src/runtime/hexagon/rpc/simulator/session.cc
@@ -434,18 +434,30 @@ std::string SimulatorRPCChannel::Core_::str() const {
 
 std::string SimulatorRPCChannel::Cpu_::str() const {
   switch (c) {
+#ifdef HEX_CPU_ID_V65A_512
     case HEX_CPU_V65:
       return "v65";
+#endif
+#ifdef HEX_CPU_ID_V66A_512
     case HEX_CPU_V66:
       return "v66";
+#endif
+#ifdef HEX_CPU_ID_V68N_1024
     case HEX_CPU_V68:
       return "v68";
+#endif
+#ifdef HEX_CPU_ID_V69NA
     case HEX_CPU_V69:
       return "v69";
+#endif
+#ifdef HEX_CPU_ID_V71H_MDM_SCA
     case HEX_CPU_V71:
       return "v71";
+#endif
+#ifdef HEX_CPU_ID_V73NA_1
     case HEX_CPU_V73:
       return "v73";
+#endif
     default:
       break;
   }
@@ -545,12 +557,24 @@ HEX_8u_t SimulatorRPCChannel::PassVirtAddrCallback(void* handle, int threadno, H
 std::optional<HEXAPI_Cpu> SimulatorRPCChannel::GetCPU(const detail::MaybeString& cpu_str) {
   if (!cpu_str) return std::nullopt;
   return detail::StringSwitch<std::optional<HEXAPI_Cpu>>(*cpu_str)
+#ifdef HEX_CPU_ID_V65A_512
       .Case("v65", HEX_CPU_V65)
+#endif
+#ifdef HEX_CPU_ID_V66A_512
       .Case("v66", HEX_CPU_V66)
+#endif
+#ifdef HEX_CPU_ID_V68N_1024
       .Case("v68", HEX_CPU_V68)
+#endif
+#ifdef HEX_CPU_ID_V69NA
       .Case("v69", HEX_CPU_V69)
+#endif
+#ifdef HEX_CPU_ID_V71H_MDM_SCA
       .Case("v71", HEX_CPU_V71)
+#endif
+#ifdef HEX_CPU_ID_V73NA_1
       .Case("v73", HEX_CPU_V73)
+#endif
       .Default(std::nullopt);
 }
 

--- a/src/runtime/hexagon/rpc/simulator/session.cc
+++ b/src/runtime/hexagon/rpc/simulator/session.cc
@@ -442,6 +442,10 @@ std::string SimulatorRPCChannel::Cpu_::str() const {
       return "v68";
     case HEX_CPU_V69:
       return "v69";
+    case HEX_CPU_V71:
+      return "v71";
+    case HEX_CPU_V73:
+      return "v73";
     default:
       break;
   }
@@ -545,6 +549,8 @@ std::optional<HEXAPI_Cpu> SimulatorRPCChannel::GetCPU(const detail::MaybeString&
       .Case("v66", HEX_CPU_V66)
       .Case("v68", HEX_CPU_V68)
       .Case("v69", HEX_CPU_V69)
+      .Case("v71", HEX_CPU_V71)
+      .Case("v73", HEX_CPU_V73)
       .Default(std::nullopt);
 }
 

--- a/tests/python/contrib/test_hexagon/README.md
+++ b/tests/python/contrib/test_hexagon/README.md
@@ -49,7 +49,7 @@ cd build
 cmake -DANDROID_ABI=arm64-v8a \
         -DANDROID_PLATFORM=android-28 \
         -DUSE_ANDROID_TOOLCHAIN="path to `android-ndk/build/cmake/android.toolchain.cmake` file" \
-        -DUSE_HEXAGON_ARCH=v65|v66|v68|v69 \
+        -DUSE_HEXAGON_ARCH=v65|v66|v68|v69|v73 \
         -DUSE_HEXAGON_SDK="path to Hexagon SDK" \
         -DUSE_HEXAGON_TOOLCHAIN="path to Hexagon toolchain `Tools` sub-directory which explained above" \
         -DUSE_OUTPUT_BINARY_DIR="path to `build/hexagon_api_output` which is a sub-directory of `tvm`" ..


### PR DESCRIPTION
Snapdragon 8 Gen2 is v73, Hexagon SDK 5.2+ supports it.