### PR TITLE
[Unity][CUTLASS] Support more residual input shape

### DIFF
--- a/python/tvm/contrib/cutlass/conv2d_operation.py
+++ b/python/tvm/contrib/cutlass/conv2d_operation.py
@@ -522,6 +522,7 @@ def instantiate_conv2d_template(attrs):
     else:
         aux_map["A_shape"] = "activation_shape"
         aux_map["B_shape"] = "weight_shape"
+        aux_map["D_shape"] = "output_shape"
 
         if has_residual_block:
             res_shape = list(attrs.pop("residual_shape"))
@@ -534,10 +535,10 @@ def instantiate_conv2d_template(attrs):
             if res_shape == [int(attrs[c]) for c in ["N", "H", "W", "K"]]:
                 aux_map["tensor_c_layout"] = "layout_C"
             else:
+                # bias-like residual input
                 aux_map["tensor_c_layout"] = "cutlass::layout::TensorNHWC::Stride(0)"
         else:
             aux_map["C_shape"] = "output_shape"
-        aux_map["D_shape"] = "output_shape"
 
     if use_split_k:
         aux_map["ElementOutput"] = "EpilogueOutputOp::ElementOutput"

--- a/python/tvm/contrib/cutlass/conv2d_operation.py
+++ b/python/tvm/contrib/cutlass/conv2d_operation.py
@@ -525,10 +525,10 @@ def instantiate_conv2d_template(attrs):
 
         if has_residual_block:
             res_shape = list(attrs.pop("residual_shape"))
-            res_shape = f"cutlass::make_Coord({res_shape[0]}, {res_shape[1]}, {res_shape[2]}, K)"
+            shape_str = f"cutlass::make_Coord({res_shape[0]}, {res_shape[1]}, {res_shape[2]}, K)"
             aux_map[
                 "residual_shape_decl"
-            ] = f"auto residual_shape = TensorNHWC::packed({res_shape});"
+            ] = f"auto residual_shape = TensorNHWC::packed({shape_str});"
             aux_map["C_shape"] = "residual_shape"
 
             if res_shape == [int(attrs[c]) for c in ["N", "H", "W", "K"]]:

--- a/python/tvm/contrib/cutlass/conv2d_operation.py
+++ b/python/tvm/contrib/cutlass/conv2d_operation.py
@@ -528,7 +528,7 @@ def instantiate_conv2d_template(attrs):
             attrs.pop("residual_shape")
             aux_map[
                 "residual_shape_decl"
-            ] = "auto residual_shape = TensorNHWC::packed(cutlass::make_Coord((int){}, (int){}, (int){}, K));".format(
+            ] = "auto residual_shape = TensorNHWC::packed(cutlass::make_Coord({}, {}, {}, K));".format(
                 residual_shape[0], residual_shape[1], residual_shape[2]
             )
             aux_map["C_shape"] = "residual_shape"

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -689,6 +689,9 @@ def instantiate_template(func_name, annotations, func_args):
             attrs["split_k_mode"] = "kSerial"
             attrs["split_k_slices"] = 1
 
+        if "residual_shape" in annotations:
+            attrs["residual_shape"] = annotations["residual_shape"]
+
         code = instantiate_conv2d_template(attrs)
         return CodegenResult(code, headers)
 

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -101,11 +101,11 @@ def _check_residual(root_call: Call, context: PatternCheckContext) -> bool:
             # If residual depends on the result of the root call, this cannot be handled by cutlass.
             return False
 
-        shape1 = [int(s) for s in root_var.struct_info.shape]
-        shape2 = [int(s) for s in residual.struct_info.shape]
+        # shape1 = [int(s) for s in root_var.struct_info.shape]
+        # shape2 = [int(s) for s in residual.struct_info.shape]
 
-        if shape1 != shape2:
-            return False
+        # if shape1 != shape2:
+        #     return False
 
     return True
 

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -111,7 +111,7 @@ def _check_residual(root_call: Call, context: PatternCheckContext) -> bool:
         out_channel = shape1[-1]
         is_bias_like = lambda shape: (shape[-1] == out_channel and _shape_1d(shape) == out_channel)
 
-        if shape1 != shape2 or is_bias_like(shape2):
+        if shape1 != shape2 and not is_bias_like(shape2):
             return False
 
     return True

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -47,6 +47,10 @@ def _is_supported_dtype(lhs_dtype, rhs_dtype):
     )
 
 
+def _shape_1d(shape):
+    return reduce(operator.mul, shape, 1)
+
+
 def _has_leaking_intermediate_variables(context: PatternCheckContext) -> bool:
     """
     Check whether intermediate variables in the region to be fused are used outside
@@ -101,11 +105,14 @@ def _check_residual(root_call: Call, context: PatternCheckContext) -> bool:
             # If residual depends on the result of the root call, this cannot be handled by cutlass.
             return False
 
-        # shape1 = [int(s) for s in root_var.struct_info.shape]
-        # shape2 = [int(s) for s in residual.struct_info.shape]
+        shape1 = [int(s) for s in root_var.struct_info.shape]
+        shape2 = [int(s) for s in residual.struct_info.shape]
 
-        # if shape1 != shape2:
-        #     return False
+        out_channel = shape1[-1]
+        is_bias_like = lambda shape: (shape[-1] == out_channel and _shape_1d(shape) == out_channel)
+
+        if shape1 != shape2 or is_bias_like(shape2):
+            return False
 
     return True
 
@@ -402,7 +409,7 @@ class WorkspaceAnnotator(PyExprMutator):
         if "attention" in f.attrs["Composite"]:
             # Workspace is needed only for larger head sizes, but for simplicity we always allocate.
             out_dtype = f.ret_struct_info.dtype
-            out_size_1d = reduce(operator.mul, f.ret_struct_info.shape, 1)
+            out_size_1d = _shape_1d(f.ret_struct_info.shape)
             # This needs to be in sync with the actual value that the kernel expects.
             workspace_size_bytes = out_size_1d * {"float16": 2, "float32": 4}[out_dtype]
             return f.with_attr("WorkspaceSize", workspace_size_bytes)


### PR DESCRIPTION
So far we've been supporting residual input of the same size as the conv2d output. In SD UNet there are residual add where the shapes of residual inputs are bias-like, for example (1, 1, 1, 320).  

According to https://github.com/NVIDIA/cutlass/discussions/959#discussioncomment-6001066, CUTLASS also supports "batched bias" like shape (2, 1, 1, 320), but I was not able to get the correct output when I tested.  

@vinx13 @yelite 