### PR TITLE
[Unity] Allow filtering out unwanted branches in matmul combining pass

### DIFF
--- a/python/tvm/relax/dpl/rewrite.py
+++ b/python/tvm/relax/dpl/rewrite.py
@@ -60,7 +60,9 @@ def rewrite_call(
 
 
 def rewrite_bindings(
-    ctx: PatternContext, rewriter: Callable[[Dict[DFPattern, Var], Dict[Var, Expr]], Dict[Var, Expr]], func: Function
+    ctx: PatternContext,
+    rewriter: Callable[[Dict[DFPattern, Var], Dict[Var, Expr]], Dict[Var, Expr]],
+    func: Function,
 ) -> Function:
     """
     Rewrite a function with the given pattern and the rewriter function.

--- a/python/tvm/relax/dpl/rewrite.py
+++ b/python/tvm/relax/dpl/rewrite.py
@@ -60,7 +60,7 @@ def rewrite_call(
 
 
 def rewrite_bindings(
-    ctx: PatternContext, rewriter: Callable[[Dict[DFPattern, Var]], Dict[Var, Expr]], func: Function
+    ctx: PatternContext, rewriter: Callable[[Dict[DFPattern, Var], Dict[Var, Expr]], Dict[Var, Expr]], func: Function
 ) -> Function:
     """
     Rewrite a function with the given pattern and the rewriter function.
@@ -70,10 +70,11 @@ def rewrite_bindings(
     ctx: PatternContext
         The pattern constraint context under which rewriting takes place.
 
-    rewriter: Callable[[Dict[DFPattern, Var]], Dict[Var, Expr]]
+    rewriter: Callable[[Dict[DFPattern, Var], Dict[Var, Expr]], Dict[Var, Expr]]
         The function to be called on a successful matching for rewriting. Given the map of patterns
         and corresponding variables (bound variables or parameters), it should return a map that
-        specifies new values for matched bound variables.
+        specifies new values for matched bound variables. It can refer to the passed bindings to
+        create the replacement expressions.
 
         For example, to rewrite three matmuls for QKV projection in transformer models into one
         matmul followed by slicing, one can use the follwoing rewriter:

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -1012,7 +1012,7 @@ def SplitCallTIRByPattern(patterns, fcodegen) -> tvm.ir.transform.Pass:
     return _ffi_api.SplitCallTIRByPattern(patterns, fcodegen)  # type: ignore
 
 
-def CombineParallelMatmul():
+def CombineParallelMatmul(check=None):
     """Combine multiple matmul operators sharing the same LHS matrix into one,
     followed by slicing. When all matmul branches in a tree have the same set of fused ops,
     the fused ops are applied to the combined matmul output before slicing.
@@ -1020,12 +1020,20 @@ def CombineParallelMatmul():
     Currently, only a limited set of fused ops is supported. It includes bias add,
     relu, gelu, gelu_tanh and silu activation.
 
+    Parameters
+    ----------
+    check : Callable[[Var, List[Var], List[Var], Dict[Var, Expr]], bool]
+        A function to filter out unwanted branches, with the signature
+        (input, [rhs], [bias], binding) -> bool.
+
     Returns
     -------
     ret : tvm.transform.Pass
         The corresponding pass.
     """
-    return _ffi_api.CombineParallelMatmul()  # type: ignore
+    if check is None:
+        check = lambda _: True
+    return _ffi_api.CombineParallelMatmul(check)  # type: ignore
 
 
 def RewriteCUDAGraph() -> tvm.ir.transform.Pass:

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -1032,7 +1032,7 @@ def CombineParallelMatmul(check=None):
         The corresponding pass.
     """
     if check is None:
-        check = lambda _: True
+        check = lambda *_: True
     return _ffi_api.CombineParallelMatmul(check)  # type: ignore
 
 

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -863,9 +863,12 @@ class PatternRewriter : ExprMutator {
 
   // Repeat until all matchable subsets of bindings are rewritten.
   BindingBlock RewriteDataflowBlockFixedPoint(BindingBlock block) {
-    if (auto matches = MatchGraph(ctx_.value(), Downcast<DataflowBlock>(block))) {
+    auto df_block = Downcast<DataflowBlock>(block);
+    if (auto matches = MatchGraph(ctx_.value(), df_block)) {
+      Map<Var, Expr> bindings = AnalyzeVar2Value(df_block);
+
       builder_->BeginDataflowBlock();
-      Map<Var, Expr> replacements = rewriter_func_(matches.value());
+      Map<Var, Expr> replacements = rewriter_func_(matches.value(), bindings);
 
       std::unordered_set<const VarNode*> emitted_vars;
 

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -914,9 +914,10 @@ class PatternRewriter : ExprMutator {
    * - (Call, Map<DFPattern, Expr>) -> Call for call node rewriting. Given the matched
    *    call node and the map of patterns and matched expressions, it should return a new call node
    *    to replace the original one or the original matched call node as is.
-   * - Map<DFPattern, Var> -> Map<Var, Expr> for dataflow block rewriting. Given the map of patterns
-   *   and corresponding variables (bound variables or parameters), it should return a map that
-   *   specifies new values for matched bound variables.
+   * - (Map<DFPattern, Var>, Map<Var, Expr>) -> Map<Var, Expr> for dataflow block rewriting.
+   *    Given the map of patterns and corresponding variables (bound variables or parameters),
+   *    it should return a map that specifies new values for matched bound variables. It can refer
+   *    to the passed bindings to create the replacement expressions.
    */
   PackedFunc rewriter_func_;
   std::unordered_set<const VarNode*> params_;

--- a/src/relax/transform/combine_parallel_matmul.cc
+++ b/src/relax/transform/combine_parallel_matmul.cc
@@ -106,7 +106,7 @@ Patterns CreatePatterns(const BranchInfo& branch_info) {
 }
 
 /*! \brief Create a rewriter for the given parallel matmul branches. */
-runtime::TypedPackedFunc<Map<Var, Expr>(Map<DFPattern, Var>)> GetRewriter(
+runtime::TypedPackedFunc<Map<Var, Expr>(Map<DFPattern, Var>, Map<Var, Expr>)> GetRewriter(
     const Patterns& patterns, const BranchInfo& branch_info) {
   auto batch_dims_compatible = [](size_t rhs_dim, const std::vector<size_t>& indices,
                                   const std::vector<Array<PrimExpr>>& rhs_shapes) {
@@ -123,7 +123,7 @@ runtime::TypedPackedFunc<Map<Var, Expr>(Map<DFPattern, Var>)> GetRewriter(
     return true;
   };
 
-  return [=](Map<DFPattern, Var> matchings) {
+  return [=](Map<DFPattern, Var> matchings, Map<Var, Expr>) {
     std::vector<Array<PrimExpr>> rhs_shapes;
     for (const auto& rhs_pat : patterns.rhs) {
       auto rhs_shape_opt = GetTensorSInfo(matchings[rhs_pat])->GetShape();

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -1033,7 +1033,7 @@ def test_attention_fake_qkv():
 def get_qkv_proj_rewriter(
     inp_pat, Q_weight_pat, K_weight_pat, V_weight_pat, matmul1, matmul2, matmul3
 ):
-    def qkv_proj_rewriter(matchings):
+    def qkv_proj_rewriter(matchings, _):
         inp = matchings[inp_pat]
         Q_weight = matchings[Q_weight_pat]
         K_weight = matchings[K_weight_pat]


### PR DESCRIPTION
Currently, `CombineParallelMatmul` eagerly combines all parallel branches it finds. Sometimes, it is desirable to ignore certain patterns based on, for example, the number of matmuls.  

This PR adds a user-defined "check function" to `CombineParallelMatmul` that is used like this:

```
Var inp;
Array<Var> rhs, bias;
Map<Var, Expr> bindings; // Passed from DF rewriter

if (!check(inp, rhs, bias, bindings)) {
  continue;
}
```

It also modifies the signature of the DF binding rewrite function to additionally pass the current bindings (`Map<Var, Expr>`). This can be useful for querying the attributes of the matched `CallNode` expressions. Until now, only matched `Var`s (`Map<DFPattern, Var>`) are being passed, so there has been no way to retrieve the corresponding matched expressions. 

@vinx13 @yelite @jwfromm 