### PR TITLE
[Hexagon] Remove "c" as aot_host_target tvm/contrib/hexagon/pytest_pl…

### DIFF
--- a/python/tvm/contrib/hexagon/pytest_plugin.py
+++ b/python/tvm/contrib/hexagon/pytest_plugin.py
@@ -309,7 +309,7 @@ def terminate_rpc_servers():
         os.system("ps ax | grep tvm_rpc_x86 | awk '{print $1}' | xargs kill")
 
 
-aot_host_target = tvm.testing.parameter("c", HEXAGON_AOT_LLVM_TARGET)
+aot_host_target = tvm.testing.parameter(HEXAGON_AOT_LLVM_TARGET)
 
 
 @tvm.testing.fixture


### PR DESCRIPTION
…ugin.py

After PR#14918 (changes to SplitHostDevice), LowerIntrin code generates fma, which then becomes the LLVM intrinsic fmuladd. Problem is, the code then goes to the C codegen, which knows nothing about LLVM intrinsics. The result is an abort at compile-time:
```
E     File ".../src/target/source/codegen_c.cc", line 611
E   TVMError: Unresolved call Op(tir.call_llvm_pure_intrin)
```

Why this didn't happen before is unclear at the moment, but using C codegen with Hexagon code doesn't sound like a winning combination. Hexagon-related code assumes LLVM codegen, and the above crash is the result of that.