### PR TITLE
[Minor] Fix compilation warnings

### DIFF
--- a/src/runtime/vulkan/vulkan_amdrgp.cc
+++ b/src/runtime/vulkan/vulkan_amdrgp.cc
@@ -38,8 +38,10 @@ void AmdRgpProfiler::capture() {
     device_->queue_insert_debug_utils_label_functions->vkQueueInsertDebugUtilsLabelEXT(
         device_->Queue(), &frame_end_label);
 
-    VkDebugUtilsLabelEXT frame_begin_label = {
-        VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, nullptr, "AmdFrameBegin", {0.0f, 0.0f, 0.0f, 0.0f}};
+    VkDebugUtilsLabelEXT frame_begin_label = {VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
+                                              nullptr,
+                                              "AmdFrameBegin",
+                                              {0.0f, 0.0f, 0.0f, 0.0f}};
     device_->queue_insert_debug_utils_label_functions->vkQueueInsertDebugUtilsLabelEXT(
         device_->Queue(), &frame_begin_label);
 

--- a/src/runtime/vulkan/vulkan_amdrgp.cc
+++ b/src/runtime/vulkan/vulkan_amdrgp.cc
@@ -34,12 +34,12 @@ void AmdRgpProfiler::capture() {
   // Trigger RGP capture by using dummy present and switch state from READY to RUNNING
   if (curr_state_ == READY) {
     VkDebugUtilsLabelEXT frame_end_label = {
-        VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, NULL, "AmdFrameEnd", {0.0f, 0.0f, 0.0f, 0.0f}};
+        VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, nullptr, "AmdFrameEnd", {0.0f, 0.0f, 0.0f, 0.0f}};
     device_->queue_insert_debug_utils_label_functions->vkQueueInsertDebugUtilsLabelEXT(
         device_->Queue(), &frame_end_label);
 
     VkDebugUtilsLabelEXT frame_begin_label = {
-        VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, NULL, "AmdFrameBegin", {0.0f, 0.0f, 0.0f, 0.0f}};
+        VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, nullptr, "AmdFrameBegin", {0.0f, 0.0f, 0.0f, 0.0f}};
     device_->queue_insert_debug_utils_label_functions->vkQueueInsertDebugUtilsLabelEXT(
         device_->Queue(), &frame_begin_label);
 

--- a/src/runtime/vulkan/vulkan_buffer.cc
+++ b/src/runtime/vulkan/vulkan_buffer.cc
@@ -98,7 +98,7 @@ bool VulkanBuffer::UseDedicatedAllocation(const VulkanDevice& device, VkBuffer b
     // What information to request
     VkMemoryDedicatedRequirementsKHR dedicated_req;
     dedicated_req.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR;
-    dedicated_req.pNext = 0;
+    dedicated_req.pNext = nullptr;
 
     VkMemoryRequirements2KHR req2 = {VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR};
     req2.pNext = &dedicated_req;

--- a/src/runtime/vulkan/vulkan_instance.cc
+++ b/src/runtime/vulkan/vulkan_instance.cc
@@ -81,8 +81,8 @@ VulkanInstance::VulkanInstance() {
   {
     // Result from vkGetInstanceProcAddr is NULL if driver only
     // supports vulkan 1.0.
-    auto vkEnumerateInstanceVersion =
-        (PFN_vkEnumerateInstanceVersion)vkGetInstanceProcAddr(nullptr, "vkEnumerateInstanceVersion");
+    auto vkEnumerateInstanceVersion = (PFN_vkEnumerateInstanceVersion)vkGetInstanceProcAddr(
+        nullptr, "vkEnumerateInstanceVersion");
     if (vkEnumerateInstanceVersion) {
       vkEnumerateInstanceVersion(&api_version);
     }

--- a/src/runtime/vulkan/vulkan_instance.cc
+++ b/src/runtime/vulkan/vulkan_instance.cc
@@ -82,7 +82,7 @@ VulkanInstance::VulkanInstance() {
     // Result from vkGetInstanceProcAddr is NULL if driver only
     // supports vulkan 1.0.
     auto vkEnumerateInstanceVersion =
-        (PFN_vkEnumerateInstanceVersion)vkGetInstanceProcAddr(NULL, "vkEnumerateInstanceVersion");
+        (PFN_vkEnumerateInstanceVersion)vkGetInstanceProcAddr(nullptr, "vkEnumerateInstanceVersion");
     if (vkEnumerateInstanceVersion) {
       vkEnumerateInstanceVersion(&api_version);
     }

--- a/src/runtime/vulkan/vulkan_stream.cc
+++ b/src/runtime/vulkan/vulkan_stream.cc
@@ -54,7 +54,7 @@ VulkanStream::VulkanStream(const VulkanDevice* device)
   cb_begin.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
   cb_begin.pNext = nullptr;
   cb_begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-  cb_begin.pInheritanceInfo = 0;
+  cb_begin.pInheritanceInfo = nullptr;
   VULKAN_CALL(vkBeginCommandBuffer(state_->cmd_buffer_, &cb_begin));
 
   if (support::BoolEnvironmentVar("TVM_USE_AMD_RGP")) {
@@ -135,7 +135,7 @@ void VulkanStream::Synchronize() {
   cb_submit.pNext = nullptr;
   cb_submit.waitSemaphoreCount = 0;
   cb_submit.pWaitSemaphores = nullptr;
-  cb_submit.pWaitDstStageMask = 0;
+  cb_submit.pWaitDstStageMask = nullptr;
   cb_submit.commandBufferCount = 1;
   cb_submit.pCommandBuffers = &(state_->cmd_buffer_);
   cb_submit.signalSemaphoreCount = 0;
@@ -161,7 +161,7 @@ void VulkanStream::Synchronize() {
   cb_begin.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
   cb_begin.pNext = nullptr;
   cb_begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-  cb_begin.pInheritanceInfo = 0;
+  cb_begin.pInheritanceInfo = nullptr;
   VULKAN_CALL(vkBeginCommandBuffer(state_->cmd_buffer_, &cb_begin));
 }
 

--- a/src/runtime/vulkan/vulkan_wrapped_func.cc
+++ b/src/runtime/vulkan/vulkan_wrapped_func.cc
@@ -101,7 +101,7 @@ void VulkanWrappedFunc::operator()(TVMArgs args, TVMRetValue* rv,
 
       if (device.UseDebugUtilsLabel()) {
         VkDebugUtilsLabelEXT dispatch_label = {VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
-                                               NULL,
+                                               nullptr,
                                                func_name_.c_str(),
                                                {0.0f, 0.0f, 0.0f, 0.0f}};
         device.queue_insert_debug_utils_label_functions->vkQueueInsertDebugUtilsLabelEXT(
@@ -118,14 +118,14 @@ void VulkanWrappedFunc::operator()(TVMArgs args, TVMRetValue* rv,
     write_descriptor_sets.resize(descriptor_buffers.size());
     for (size_t i = 0; i < write_descriptor_sets.size(); i++) {
       write_descriptor_sets[i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-      write_descriptor_sets[i].pNext = 0;
+      write_descriptor_sets[i].pNext = nullptr;
       write_descriptor_sets[i].dstSet = pipeline->descriptor_set;
       write_descriptor_sets[i].dstBinding = i;
       write_descriptor_sets[i].dstArrayElement = 0;
       write_descriptor_sets[i].descriptorCount = 1;
-      write_descriptor_sets[i].pImageInfo = 0;
+      write_descriptor_sets[i].pImageInfo = nullptr;
       write_descriptor_sets[i].pBufferInfo = &(descriptor_buffers[i]);
-      write_descriptor_sets[i].pTexelBufferView = 0;
+      write_descriptor_sets[i].pTexelBufferView = nullptr;
 
       if (pipeline->use_ubo && i == write_descriptor_sets.size() - 1) {
         // The last binding is for UBO
@@ -135,7 +135,7 @@ void VulkanWrappedFunc::operator()(TVMArgs args, TVMRetValue* rv,
       }
     }
     vkUpdateDescriptorSets(device, write_descriptor_sets.size(), write_descriptor_sets.data(), 0,
-                           0);
+                           nullptr);
   };
   const auto& deferred_kernel = [this, pipeline, wl, pack_args_storage, nbytes_scalars,
                                  device_id](VulkanStreamState* state) {
@@ -176,7 +176,7 @@ void VulkanWrappedFunc::operator()(TVMArgs args, TVMRetValue* rv,
 
   if (device.UseDebugUtilsLabel()) {
     VkDebugUtilsLabelEXT dispatch_label = {VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
-                                           NULL,
+                                           nullptr,
                                            func_name_.c_str(),
                                            {0.0f, 0.0f, 0.0f, 0.0f}};
     device.queue_insert_debug_utils_label_functions->vkQueueInsertDebugUtilsLabelEXT(
@@ -388,7 +388,7 @@ std::shared_ptr<VulkanPipeline> VulkanModuleNode::GetPipeline(size_t device_id,
   if (device.UseImmediate()) {
     VkDescriptorUpdateTemplateCreateInfoKHR descrip_template_cinfo;
     descrip_template_cinfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR;
-    descrip_template_cinfo.pNext = 0;
+    descrip_template_cinfo.pNext = nullptr;
     descrip_template_cinfo.flags = 0;
     descrip_template_cinfo.descriptorUpdateEntryCount = arg_template.size();
     descrip_template_cinfo.pDescriptorUpdateEntries = arg_template.data();
@@ -398,7 +398,7 @@ std::shared_ptr<VulkanPipeline> VulkanModuleNode::GetPipeline(size_t device_id,
     descrip_template_cinfo.pipelineLayout = pe->pipeline_layout;
     descrip_template_cinfo.set = 0;
     VULKAN_CALL(device.descriptor_template_khr_functions->vkCreateDescriptorUpdateTemplateKHR(
-        device, &descrip_template_cinfo, 0, &(pe->descriptor_update_template)));
+        device, &descrip_template_cinfo, nullptr, &(pe->descriptor_update_template)));
   }
   ecache_[device_id][func_name] = pe;
   return pe;

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -941,7 +941,7 @@ CodeGenCPU::PackedCall CodeGenCPU::MakeCallPackedLowered(const Array<PrimExpr>& 
 
   llvm::BasicBlock* end_block = CheckCallSuccess(call);
 
-  PackedCall pc = {0};
+  PackedCall pc = {nullptr};
 
   if (!r_type.is_void()) {
     // Load the return value and cast it to the designated type (r_type).

--- a/src/tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/tir/schedule/primitive/blockize_tensorize.cc
@@ -673,7 +673,6 @@ class BlockizeRewriter : public StmtMutator {
     const SeqStmtNode* seq = stmt.as<SeqStmtNode>();
     ICHECK(seq) << "Target blocks must not be nested with each other!";
     int idx_start = -1;
-    int found_cnt = 0;
     int last_found_idx = -1;
     size_t cur_idx = 0;
     Array<Stmt> new_seq;
@@ -688,7 +687,6 @@ class BlockizeRewriter : public StmtMutator {
           ICHECK_EQ(last_found_idx, cur_idx - 1) << "Target blocks must be consecutive!";
         }
         last_found_idx = cur_idx;
-        ++found_cnt;
       } else {
         new_seq.push_back(it);
       }


### PR DESCRIPTION
This PR fixes the following compilation warnings:
- use `nullptr` instead of `NULL` and `0`
- unused variable at `src/tir/schedule/primitive/blockize_tensorize.cc`