### PR TITLE
[Hotfix] Remove `LOG(INFO)` from unsupported dtype legalization pass

### DIFF
--- a/src/tir/transforms/unsupported_dtype_legalize.cc
+++ b/src/tir/transforms/unsupported_dtype_legalize.cc
@@ -716,7 +716,6 @@ TVM_REGISTER_GLOBAL("tir.transform.FP8ComputeLegalize").set_body_typed(FP8Comput
 
 Pass FP8StorageLegalize() {
   auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
-    LOG(INFO) << f;
     // TODO(tvm-team): skip if the target supports fp8
     return FP8StorageLegalizer().Legalize(f);
   };


### PR DESCRIPTION
I introduced a `LOG(INFO)` in a previous PR #14863 , which pollutes user output.
This PR fixes the issue.

cc @tqchen @junrushao @MasterJH5574 @Hzfengsy .