### PR TITLE
Fix type parse error about AdaptiveMaxPool

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1124,6 +1124,10 @@ class PyTorchOpConverter:
     def adaptive_max_pool(self, op, inputs, input_types):
         data = inputs[0]
         output_size = inputs[1]
+        for i, item in enumerate(output_size):
+            if isinstance(item, tvm.relay.expr.Constant):
+                # convert Constant to int
+                output_size[i] = item.data.numpy()[()]
         # returns dummy indices too
         return op(data, output_size=output_size), None
 

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -886,6 +886,8 @@ def test_forward_adaptive_avgpool():
 
     input_data = torch.rand([1, 3, 5, 6]).float()
     verify_model(torch.nn.AdaptiveAvgPool2d([3, None]).eval(), input_data=input_data)
+    input_data = torch.rand([1, 1, 3, 5, 6]).float()
+    verify_model(torch.nn.AdaptiveAvgPool3d([3, None, None]).eval(), input_data=input_data)
 
 
 @tvm.testing.uses_gpu
@@ -900,6 +902,11 @@ def test_forward_adaptive_maxpool():
     input_data = torch.rand([1, 3, 10]).float()
     verify_model(torch.nn.AdaptiveMaxPool1d([1]).eval(), input_data=input_data)
     verify_model(torch.nn.AdaptiveMaxPool1d([5]).eval(), input_data=input_data)
+
+    input_data = torch.rand([1, 3, 5, 6]).float()
+    verify_model(torch.nn.AdaptiveMaxPool2d([3, None]).eval(), input_data=input_data)
+    input_data = torch.rand([1, 1, 3, 5, 6]).float()
+    verify_model(torch.nn.AdaptiveMaxPool3d([3, None, None]).eval(), input_data=input_data)
 
 
 @tvm.testing.uses_gpu


### PR DESCRIPTION
This PR is similar to the [pr-14837](https://github.com/apache/tvm/pull/14837)

This pr fixed a type parse bug when the out_size attribute of the `AdaptiveMaxPool2d` or `AdaptiveMaxPool3d` contains `None`, which means has the same size as the input. But the op can't be parsed by Relay and throws an error message:
**"Check failed: (!checked_type.defined()) is false: Expected Array[PrimExpr], but got Array[index 1: relay.Constant]"**





The op introduction in the [PyTorch documentation](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveMaxPool3d.html)
![image](https://github.com/apache/tvm/assets/29506758/a3de324e-e9ed-4b22-9423-a1070287b159)


### Bug triggering Script
```
import torch
from tvm import relay

m = torch.nn.AdaptiveMaxPool3d((3, None, None),)   
input_data=[torch.randn([1, 1, 3, 5, 6], dtype=torch.float32)]
trace = torch.jit.trace(m, input_data)
input_shapes = [('input0', torch.Size([1, 1, 3, 5, 6]))]

mod, params = relay.frontend.from_pytorch(trace, input_shapes)
```

### Traceback
```
Traceback (most recent call last):
  File "test.py", line 13, in <module>
    mod, params = relay.frontend.from_pytorch(trace, input_shapes)
  File "/workplace/software/tvm/tvm/python/tvm/relay/frontend/pytorch.py", line 4970, in from_pytorch
    outputs = converter.convert_operators(operator_nodes, outputs, ret_name)
  File "/workplace/software/tvm/tvm/python/tvm/relay/frontend/pytorch.py", line 4240, in convert_operators
    _get_input_types(op_node, outputs, default_dtype=self.default_dtype),
  File "/workplace/software/tvm/tvm/python/tvm/relay/frontend/pytorch.py", line 1127, in adaptive_max_pool
    return op(data, output_size=output_size), None
  File "/workplace/software/tvm/tvm/python/tvm/relay/op/nn/nn.py", line 3435, in adaptive_max_pool3d
    return _make.adaptive_max_pool3d(data, output_size, layout, out_layout)
  File "/workplace/software/tvm/tvm/python/tvm/_ffi/_ctypes/packed_func.py", line 238, in __call__
    raise get_last_ffi_error()
tvm._ffi.base.TVMError: Traceback (most recent call last):
  4: TVMFuncCall
  3: _ZN3tvm7runtime13Pac
  2: tvm::runtime::TypedPackedFunc<tvm::RelayExpr (tvm::RelayExpr, tvm::runtime::Array<tvm::PrimExpr, void>, tvm::runtime::String, tvm::runtime::String)>::AssignTypedLambda<tvm::RelayExpr (*)(tvm::RelayExpr, tvm::runtime::Array<tvm::PrimExpr, void>, tvm::runtime::String, tvm::runtime::String)>(tvm::RelayExpr (*)(tvm::RelayExpr, tvm::runtime::Array<tvm::PrimExpr, void>, tvm::runtime::String, tvm::runtime::String), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)::{lambda(tvm::runtime::TVMArgs const&, tvm::runtime::TVMRetValue*)#1}::operator()(tvm::runtime::TVMArgs const&, tvm::runtime::TVMRetValue*) const
  1: tvm::runtime::TVMMovableArgValueWithContext_::operator tvm::runtime::Array<tvm::PrimExpr, void><tvm::runtime::Array<tvm::PrimExpr, void> >() const
  0: _ZN3tvm7runtime6detail
  6: TVMFuncCall
  5: _ZN3tvm7runtime13Pac
  4: tvm::runtime::TypedPackedFunc<tvm::RelayExpr (tvm::RelayExpr, tvm::runtime::Array<tvm::PrimExpr, void>, tvm::runtime::String, tvm::runtime::String)>::AssignTypedLambda<tvm::RelayExpr (*)(tvm::RelayExpr, tvm::runtime::Array<tvm::PrimExpr, void>, tvm::runtime::String, tvm::runtime::String)>(tvm::RelayExpr (*)(tvm::RelayExpr, tvm::runtime::Array<tvm::PrimExpr, void>, tvm::runtime::String, tvm::runtime::String), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)::{lambda(tvm::runtime::TVMArgs const&, tvm::runtime::TVMRetValue*)#1}::operator()(tvm::runtime::TVMArgs const&, tvm::runtime::TVMRetValue*) const
  3: tvm::runtime::TVMMovableArgValueWithContext_::operator tvm::runtime::Array<tvm::PrimExpr, void><tvm::runtime::Array<tvm::PrimExpr, void> >() const
  2: tvm::runtime::TVMMovableArgValue_::operator tvm::runtime::Array<tvm::PrimExpr, void><tvm::runtime::Array<tvm::PrimExpr, void>, void>() const
  1: tvm::runtime::Array<tvm::PrimExpr, void> tvm::runtime::TVMPODValue_::AsObjectRef<tvm::runtime::Array<tvm::PrimExpr, void> >() const
  0: _ZN3tvm7runtime6detail
  File "/workplace/software/tvm/tvm/include/tvm/runtime/packed_func.h", line 777
TVMError: In function relay.op.nn._make.adaptive_max_pool3d(0: RelayExpr, 1: Array<PrimExpr>, 2: runtime.String, 3: runtime.String) -> RelayExpr: error while converting argument 1: [07:33:53] /workplace/software/tvm/tvm/include/tvm/runtime/packed_func.h:1866: 
---------------------------------------------------------------
An error occurred during the execution of TVM.
For more information, please see: https://tvm.apache.org/docs/errors.html
---------------------------------------------------------------
  Check failed: (!checked_type.defined()) is false: Expected Array[PrimExpr], but got Array[index 1: relay.Constant]
```

cc @Hzfengsy @echuraev 