### PR TITLE
[Unity] Added bounds checking on TupleGetItem index

### DIFF
--- a/include/tvm/relax/nested_msg.h
+++ b/include/tvm/relax/nested_msg.h
@@ -330,7 +330,6 @@ NestedMsg<T> MapToNestedMsgBySInfo(Expr expr, FType fmapleaf) {
         field = expr_tuple->fields[i];
       } else {
         field = TupleGetItem(expr, i);
-        UpdateStructInfo(field, tuple->fields[i]);
       }
       res.push_back(MapToNestedMsgBySInfo<T, FType>(field, fmapleaf));
     }
@@ -513,7 +512,6 @@ Expr TransformTupleLeaf(Expr expr, std::array<NestedMsg<T>, N> msgs, FType ftran
         field = expr_tuple->fields[i];
       } else {
         field = TupleGetItem(expr, i);
-        UpdateStructInfo(field, tuple->fields[i]);
       }
       std::array<NestedMsg<T>, N> sub_msgs;
       for (size_t j = 0; j < N; ++j) {

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -229,7 +229,18 @@ class ExprWithOp(Expr, Scriptable):
         result: ExprWithOp
             The result expression.
         """
-        return TupleGetItem(self, index)
+        try:
+            return TupleGetItem(self, index)
+        except tvm.TVMError as err:
+            # For Python objects with __getitem__, but without
+            # __len__, tuple unpacking is done by iterating over
+            # sequential indices until IndexError is raised.
+            # Therefore, convert from TVMError to IndexError for
+            # compatibility.
+            if "Index out of bounds" in err.args[0]:
+                raise IndexError from err
+            else:
+                raise
 
 
 @tvm._ffi.register_object("relax.expr.Call")

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -239,8 +239,7 @@ class ExprWithOp(Expr, Scriptable):
             # compatibility.
             if "Index out of bounds" in err.args[0]:
                 raise IndexError from err
-            else:
-                raise
+            raise
 
 
 @tvm._ffi.register_object("relax.expr.Call")

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -634,7 +634,7 @@ class VMShapeLowerMutator
   Expr MakeTupleGetItem(Expr value, int64_t index) {
     if (auto* tuple_expr = value.as<TupleNode>()) {
       return tuple_expr->fields[index];
-    } else if (auto* tuple_sinfo = GetStructInfoAs<TupleStructInfoNode>(value)) {
+    } else if (GetStructInfoAs<TupleStructInfoNode>(value)) {
       // value is tuple type, it is OK to run tuple get item.
       return TupleGetItem(value, index);
     } else {

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -636,9 +636,7 @@ class VMShapeLowerMutator
       return tuple_expr->fields[index];
     } else if (auto* tuple_sinfo = GetStructInfoAs<TupleStructInfoNode>(value)) {
       // value is tuple type, it is OK to run tuple get item.
-      auto ret = TupleGetItem(value, index);
-      UpdateStructInfo(ret, tuple_sinfo->fields[index]);
-      return ret;
+      return TupleGetItem(value, index);
     } else {
       // call runtime tuple get item, and return a object.
       Call call(builtin_tuple_getitem_, {value, PrimValue::Int64(index)}, Attrs(), {object_sinfo_});

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -174,7 +174,9 @@ TupleGetItem::TupleGetItem(Expr tuple, int index, Span span) {
     CHECK_LT(index, tuple_info->fields.size())
         << "Index out of bounds: Tuple " << tuple << " is of size " << tuple_info->fields.size()
         << ", and cannot be accessed with index " << index;
-    n->struct_info_ = tuple_info->fields[index];
+    auto sinfo = tuple_info->fields[index];
+    n->struct_info_ = sinfo;
+    n->checked_type_ = GetStaticType(sinfo);
   }
   n->tuple = std::move(tuple);
   n->index = index;

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -166,7 +166,16 @@ Tuple WithFields(Tuple tuple, Optional<Array<Expr>> opt_fields, Optional<Span> o
 }
 
 TupleGetItem::TupleGetItem(Expr tuple, int index, Span span) {
+  CHECK_GE(index, 0) << "Index out of bounds: Tuple " << tuple
+                     << " cannot be accessed with negative index " << index;
   ObjectPtr<TupleGetItemNode> n = make_object<TupleGetItemNode>();
+
+  if (auto* tuple_info = tuple->struct_info_.as<TupleStructInfoNode>()) {
+    CHECK_LT(index, tuple_info->fields.size())
+        << "Index out of bounds: Tuple " << tuple << " is of size " << tuple_info->fields.size()
+        << ", and cannot be accessed with index " << index;
+    n->struct_info_ = tuple_info->fields[index];
+  }
   n->tuple = std::move(tuple);
   n->index = index;
   n->span = std::move(span);


### PR DESCRIPTION
The index provided must be non-negative, and less than the size of the tuple.  When the tuple being accessed has `TupleStructInfo`, the upper bound can also be checked immediately.