### PR TITLE
[Unity][NN] Allow nn.Placeholder/Parameter prior to BlockBuilder

### DIFF
--- a/python/tvm/relax/testing/nn.py
+++ b/python/tvm/relax/testing/nn.py
@@ -61,11 +61,11 @@ def _try_unique_name(name: str):
 
 
     """
-    bb = relax.BlockBuilder.current()
-    if bb is None:
+    block_builder = relax.BlockBuilder.current()
+    if block_builder is None:
         return name
     else:
-        return bb.get_unique_name(name)
+        return block_builder.get_unique_name(name)
 
 
 class Placeholder(relax.Var):


### PR DESCRIPTION
Prior to this commit, use of `nn.Placeholder` or `nn.Parameter` outside of a `with block_builder.function('name'):` scope resulted in an error.  This commit updates the behavior to allow declaration prior to entering the `with` block.  This can be useful for declaring a model object, which is then used to define several related functions.

The scope was required so that `relax.BlockBuilder.current()` could de-duplicate variable names.  While two distinct variables in Relax may have identical names, for user readability it is convenient to have all names be unique within a Relax function.  This commit maintains the de-duplication of names if a `nn.Placeholder` or `nn.Parameter` is defined within an active `relax.BlockBuilder`, that context may be used to provide a unique name.