### PR TITLE
[Unity] Provide FuncStructInfo from `bb.emit_te`

### DIFF
--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -30,7 +30,13 @@ from .expr import Expr, ShapeExpr, Function, PrimValue, StringImm, te_tensor
 from .expr import _update_struct_info
 from ..te import Tensor as te_Tensor, create_relax_prim_func
 from ..ir import Array, Attrs, Type, Map
-from .struct_info import PrimStructInfo, ShapeStructInfo, TensorStructInfo, FuncStructInfo
+from .struct_info import (
+    PrimStructInfo,
+    ShapeStructInfo,
+    TensorStructInfo,
+    FuncStructInfo,
+    TupleStructInfo,
+)
 
 
 def metadata_partitioner(rx_txt: str) -> List[str]:
@@ -460,12 +466,11 @@ def gen_call_tir_inputs(
         return TensorStructInfo(_shape_with_old_tir_var(arg.shape, tir_var_inverse_map), arg.dtype)
 
     input_sinfo = [te_to_sinfo(arg) for arg in te_args]
-    if len(outs) == 1:
-        output_sinfo = te_to_sinfo(outs[0])
-    else:
-        output_sinfo = TupleStructInfo(output_sinfo=[te_to_sinfo(out) for out in outs])
+    output_sinfo = [te_to_sinfo(out) for out in outs]
 
-    primfunc_sinfo = FuncStructInfo(input_sinfo, output_sinfo)
+    primfunc_sinfo = FuncStructInfo(
+        input_sinfo, output_sinfo[0] if len(output_sinfo) == 1 else TupleStructInfo(output_sinfo)
+    )
     _update_struct_info(tir_func, primfunc_sinfo)
 
     tir_vars = None

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -468,9 +468,7 @@ def gen_call_tir_inputs(
     input_sinfo = [te_to_sinfo(arg) for arg in te_args]
     output_sinfo = [te_to_sinfo(out) for out in outs]
 
-    primfunc_sinfo = FuncStructInfo(
-        input_sinfo, output_sinfo[0] if len(output_sinfo) == 1 else TupleStructInfo(output_sinfo)
-    )
+    primfunc_sinfo = FuncStructInfo([*input_sinfo, *output_sinfo], PrimStructInfo("void"))
     _update_struct_info(tir_func, primfunc_sinfo)
 
     tir_vars = None

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -456,10 +456,8 @@ def gen_call_tir_inputs(
     # with old set of variables.
     tir_var_inverse_map = {v: k for k, v in tir_var_map.items()}
 
-    def te_to_sinfo(te_tensor):
-        return TensorStructInfo(
-            _shape_with_old_tir_var(te_tensor.shape, tir_var_inverse_map), te_tensor.dtype
-        )
+    def te_to_sinfo(arg):
+        return TensorStructInfo(_shape_with_old_tir_var(arg.shape, tir_var_inverse_map), arg.dtype)
 
     input_sinfo = [te_to_sinfo(arg) for arg in te_args]
     if len(outs) == 1:

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -463,9 +463,14 @@ def gen_call_tir_inputs(
     tir_var_inverse_map = {v: k for k, v in tir_var_map.items()}
 
     def te_to_sinfo(arg):
-        return TensorStructInfo(_shape_with_old_tir_var(arg.shape, tir_var_inverse_map), arg.dtype)
+        if isinstance(arg, tir.Var):
+            return PrimStructInfo(arg.dtype)
+        else:
+            return TensorStructInfo(
+                _shape_with_old_tir_var(arg.shape, tir_var_inverse_map), arg.dtype
+            )
 
-    input_sinfo = [te_to_sinfo(arg) for arg in te_args]
+    input_sinfo = [te_to_sinfo(arg) for arg in [*te_args, *unbound_tir_vars]]
     output_sinfo = [te_to_sinfo(out) for out in outs]
 
     primfunc_sinfo = FuncStructInfo([*input_sinfo, *output_sinfo], PrimStructInfo("void"))


### PR DESCRIPTION
Prior to this commit, the PrimFunc generated by `bb.call_te` had no struct info associated with it.  This commit updates `gen_call_tir_inputs`, which converts from a TE expression into a TIR PrimFunc, to annotate the PrimFunc with `FuncStructInfo` representing the input and output shapes.

Providing this functionality for PrimFuncs produced from TE is a simpler case than a general PrimFunc, as TE has well-defined input and output tensors.