### PR TITLE
[BYOC] Hide internal cutlass symbols

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -61,6 +61,7 @@ def _get_cutlass_compile_options(sm, threads, use_fast_math=False):
         "-Xcompiler=-fPIC",
         "-Xcompiler=-Wconversion",
         "-Xcompiler=-fno-strict-aliasing",
+        "-Xcompiler=-fvisibility=hidden",
         "-O3",
         "-std=c++17",
         f"-I{cutlass_include}",


### PR DESCRIPTION
Cutlass internally may use static variables flags to control initialization. When multiple modules are loaded at runtime, duplicating symbols in the dynamic libraries cause subsequent modules failure to initialize cutlass.

cc @masahi @jwfromm @junrushao 