### PR TITLE
[Unity][BYOC] Cache cuBlasLt handle with thread entry

### DIFF
--- a/src/runtime/contrib/cublas/cublas_json_runtime.cc
+++ b/src/runtime/contrib/cublas/cublas_json_runtime.cc
@@ -42,6 +42,8 @@ using namespace tvm::runtime;
 using namespace tvm::runtime::json;
 
 class CublasJSONRuntime : public JSONRuntimeBase {
+  using tvm::contrib::CuBlasLtThreadEntry;
+
  public:
   CublasJSONRuntime(const std::string& symbol_name, const std::string& graph_json,
                     const Array<String> const_names)
@@ -52,9 +54,7 @@ class CublasJSONRuntime : public JSONRuntimeBase {
   const char* type_key() const override { return "cublas_json"; }  // May be overridden
 
   void Run() override {
-    // TODO(masahi): Reuse the same handle across different subgraphs
-    cublasLtHandle_t handle;
-    cublasLtCreate(&handle);
+    CuBlasLtThreadEntry* entry_ptr = CuBlasLtThreadEntry::ThreadLocal();
 
     for (size_t i = 0; i < nodes_.size(); ++i) {
       const auto& node = nodes_[i];
@@ -88,11 +88,10 @@ class CublasJSONRuntime : public JSONRuntimeBase {
 
         auto [a_ptr, b_ptr, bias_ptr] = get_inputs(node, epilogue != CUBLASLT_EPILOGUE_DEFAULT);
 
-        tvm::contrib::CallCublasLt(handle, a_ptr, b_ptr, bias_ptr, out_ptr, transa, transb,
-                                   epilogue);
+        tvm::contrib::CallCublasLt(entry_ptr->handle, a_ptr, b_ptr, bias_ptr, out_ptr, transa,
+                                   transb, epilogue);
       }
     }
-    cublasLtDestroy(handle);
   }
 
  private:

--- a/src/runtime/contrib/cublas/cublas_json_runtime.cc
+++ b/src/runtime/contrib/cublas/cublas_json_runtime.cc
@@ -42,8 +42,6 @@ using namespace tvm::runtime;
 using namespace tvm::runtime::json;
 
 class CublasJSONRuntime : public JSONRuntimeBase {
-  using tvm::contrib::CuBlasLtThreadEntry;
-
  public:
   CublasJSONRuntime(const std::string& symbol_name, const std::string& graph_json,
                     const Array<String> const_names)
@@ -54,7 +52,7 @@ class CublasJSONRuntime : public JSONRuntimeBase {
   const char* type_key() const override { return "cublas_json"; }  // May be overridden
 
   void Run() override {
-    CuBlasLtThreadEntry* entry_ptr = CuBlasLtThreadEntry::ThreadLocal();
+    auto* entry_ptr = tvm::contrib::CuBlasLtThreadEntry::ThreadLocal();
 
     for (size_t i = 0; i < nodes_.size(); ++i) {
       const auto& node = nodes_[i];

--- a/src/runtime/contrib/cublas/cublas_utils.cc
+++ b/src/runtime/contrib/cublas/cublas_utils.cc
@@ -48,5 +48,20 @@ CuBlasThreadEntry* CuBlasThreadEntry::ThreadLocal() {
   return retval;
 }
 
+CuBlasLtThreadEntry::CuBlasLtThreadEntry() { CHECK_CUBLAS_ERROR(cublasLtCreate(&handle)); }
+
+CuBlasLtThreadEntry::~CuBlasLtThreadEntry() {
+  if (handle) {
+    cublasLtDestroy(handle);
+    handle = nullptr;
+  }
+}
+
+typedef dmlc::ThreadLocalStore<CuBlasLtThreadEntry> CuBlasLtThreadStore;
+
+CuBlasLtThreadEntry* CuBlasLtThreadEntry::ThreadLocal() {
+  return CuBlasLtThreadStore::Get();
+}
+
 }  // namespace contrib
 }  // namespace tvm

--- a/src/runtime/contrib/cublas/cublas_utils.cc
+++ b/src/runtime/contrib/cublas/cublas_utils.cc
@@ -59,9 +59,7 @@ CuBlasLtThreadEntry::~CuBlasLtThreadEntry() {
 
 typedef dmlc::ThreadLocalStore<CuBlasLtThreadEntry> CuBlasLtThreadStore;
 
-CuBlasLtThreadEntry* CuBlasLtThreadEntry::ThreadLocal() {
-  return CuBlasLtThreadStore::Get();
-}
+CuBlasLtThreadEntry* CuBlasLtThreadEntry::ThreadLocal() { return CuBlasLtThreadStore::Get(); }
 
 }  // namespace contrib
 }  // namespace tvm

--- a/src/runtime/contrib/cublas/cublas_utils.h
+++ b/src/runtime/contrib/cublas/cublas_utils.h
@@ -77,6 +77,13 @@ struct CuBlasThreadEntry {
   static CuBlasThreadEntry* ThreadLocal();
 };  // CuBlasThreadEntry
 
+struct CuBlasLtThreadEntry {
+  CuBlasLtThreadEntry();
+  ~CuBlasLtThreadEntry();
+  cublasLtHandle_t handle{nullptr};
+  static CuBlasLtThreadEntry* ThreadLocal();
+};  // CuBlasLtThreadEntry
+
 inline cudaDataType_t GetCudaDataType(DLDataType type) {
   if (type.code == kDLInt) {
     switch (type.bits) {


### PR DESCRIPTION
Added `CuBlasLtThreadEntry` to cache cublasLt handle. Without it, `cudaDeviceSynchonize` is inserted and causes overhead.

cc @masahi @yelite 