### PR TITLE
[TIR] Handle DeclBuffer in Inline/ComputeAt/ReverseComputeAt

### DIFF
--- a/src/tir/transforms/ir_utils.cc
+++ b/src/tir/transforms/ir_utils.cc
@@ -75,6 +75,11 @@ Stmt MergeNest(const std::vector<Stmt>& nest, Stmt body) {
       ICHECK(is_no_op(n->body));
       n->body = body;
       body = Stmt(n);
+    } else if (const auto* alloc = s.as<AllocateConstNode>()) {
+      auto n = make_object<AllocateConstNode>(*alloc);
+      ICHECK(is_no_op(n->body));
+      n->body = body;
+      body = Stmt(n);
     } else if (const auto* decl_buffer = s.as<DeclBufferNode>()) {
       auto n = make_object<DeclBufferNode>(*decl_buffer);
       ICHECK(is_no_op(n->body));


### PR DESCRIPTION
Part of changes being split out from https://github.com/apache/tvm/pull/14778 into independent portions.  This commit allows TIR `compute_inline`, `compute_at`, and `reverse_compute_at` schedule primitives to preserve `DeclBuffer`
nodes.