### PR TITLE
[TIR][USMP] Preserve DeclBuffer in PoolAllocationToOffsetConverter

### DIFF
--- a/src/tir/usmp/transform/convert_pool_allocations_to_offsets.cc
+++ b/src/tir/usmp/transform/convert_pool_allocations_to_offsets.cc
@@ -99,6 +99,7 @@ class PoolAllocationToOffsetConverter : public StmtExprMutator {
   PrimExpr VisitExpr_(const VarNode* op) override;
   PrimExpr VisitExpr_(const BufferLoadNode* op) override;
   Stmt VisitStmt_(const BufferStoreNode* op) override;
+  Stmt VisitStmt_(const DeclBufferNode* op) override;
 
   Stmt VisitStmt_(const AllocateConstNode* op) override;
   LetStmt ToLetStmt(const PoolAllocation& pool_allocation, const Var& buffer_var, const Stmt& body);
@@ -384,6 +385,16 @@ Stmt PoolAllocationToOffsetConverter::VisitStmt_(const BufferStoreNode* op) {
     store.CopyOnWrite()->buffer = remapped;
   }
   return std::move(store);
+}
+
+Stmt PoolAllocationToOffsetConverter::VisitStmt_(const DeclBufferNode* op) {
+  auto decl = Downcast<DeclBuffer>(StmtExprMutator::VisitStmt_(op));
+
+  Buffer remapped = GetRemappedBuffer(decl->buffer);
+  if (!op->buffer.same_as(remapped)) {
+    decl.CopyOnWrite()->buffer = remapped;
+  }
+  return std::move(decl);
 }
 
 PrimExpr PoolAllocationToOffsetConverter::VisitExpr_(const BufferLoadNode* op) {


### PR DESCRIPTION
Previously, `PoolAllocationToOffsetConverter` did not remap buffer objects occurring in `DeclBuffer` nodes.  This commit updates `PoolAllocationToOffsetConverter` to handle `DeclBuffer` nodes.  This is a subset of changes, being split out from https://github.com/apache/tvm/pull/14778 into independent portions.