### PR TITLE
[TIR] Handle DeclBuffer in InjectDoubleBuffer

### DIFF
--- a/src/tir/transforms/inject_double_buffer.cc
+++ b/src/tir/transforms/inject_double_buffer.cc
@@ -106,21 +106,29 @@ class DoubleBufferInjector : public StmtExprMutator {
     const VarNode* buf = op->buffer_var.as<VarNode>();
     auto it = dbuffer_info_.find(buf);
     if (it != dbuffer_info_.end()) {
-      it->second.scope = GetPtrStorageScope(op->buffer_var);
+      StorageEntry& entry = it->second;
+      entry.scope = GetPtrStorageScope(op->buffer_var);
 
       ICHECK_EQ(op->extents.size(), 1) << "InjectDoubleBuffer expects flat 1-d buffers.  "
                                        << "Has StorageFlatten (TE-based schedules) or "
                                        << "FlattenBuffer (TIR-based schedules) been run?";
-      it->second.stride = op->extents[0];
+      entry.stride = op->extents[0];
       Stmt stmt = StmtExprMutator::VisitStmt_(op);
       op = stmt.as<AllocateNode>();
 
       Array<PrimExpr> new_extents = {op->extents[0] * make_const(op->extents[0].dtype(), 2)};
-      ICHECK(it->second.loop != nullptr);
-      auto& alloc_nest = loop_allocs_[it->second.loop];
+      ICHECK(entry.loop != nullptr);
+      auto& alloc_nest = loop_allocs_[entry.loop];
       alloc_nest.emplace_back(
           Allocate(op->buffer_var, op->dtype, new_extents, op->condition, Evaluate(0)));
-      return op->body;
+      Stmt body = op->body;
+      if (auto ptr = body.as<DeclBufferNode>()) {
+        auto new_buf = GetRemappedBuffer(ptr->buffer, entry.stride);
+        alloc_nest.emplace_back(DeclBuffer(new_buf, Evaluate(0)));
+        body = ptr->body;
+      }
+
+      return body;
     } else {
       return StmtExprMutator::VisitStmt_(op);
     }
@@ -226,8 +234,10 @@ class DoubleBufferInjector : public StmtExprMutator {
     ICHECK_EQ(buf->shape.size(), 1) << "InjectDoubleBuffer expects flat 1-d buffers.  "
                                     << "Has StorageFlatten (TE-based schedules) or "
                                     << "FlattenBuffer (TIR-based schedules) been run?";
-    auto writer = buf.CopyOnWrite();
-    writer->shape = {buf->shape[0] * stride};
+
+    // Stride gives the distance between the two halves of the
+    // double-buffer, not the stride of the buffer's index.
+    buf.CopyOnWrite()->shape = {buf->shape[0] + stride};
 
     buf_remap_[key] = buf;
     return buf;


### PR DESCRIPTION
Preserve DeclBuffer node when transforming with `InjectDoubleBuffer` This is a subset of changes, being split out from https://github.com/apache/tvm/pull/14778 into independent portions.