### PR TITLE
[TIR][Analysis] Handle DeclBuffer in FlopEstimator

### DIFF
--- a/src/tir/analysis/estimate_flops.cc
+++ b/src/tir/analysis/estimate_flops.cc
@@ -174,6 +174,7 @@ class FlopEstimator : private ExprFunctor<TResult(const PrimExpr& n)>,
   TResult VisitExpr_(const FloatImmNode* op) override { return TResult(); }
   TResult VisitExpr_(const CastNode* op) override { return VisitExpr(op->value); }
   TResult VisitStmt_(const AllocateConstNode* op) override { return VisitStmt(op->body); }
+  TResult VisitStmt_(const DeclBufferNode* op) override { return VisitStmt(op->body); }
 
   TResult VisitStmt_(const SeqStmtNode* seq) override {
     TResult result;

--- a/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
+++ b/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
@@ -107,5 +107,22 @@ def test_exception():
         flops = estimate_tir_flops(IRModule({"main": flops_with_forloop_as_expression}))
 
 
+def test_estimate_flops_with_decl_buffer():
+    def make_func(use_decl_buffer):
+        buffer_func = T.decl_buffer if use_decl_buffer else T.Buffer
+
+        @T.prim_func
+        def func(A_data: T.handle("float32")):
+            A = buffer_func(16, "float32", data=A_data)
+            for i in range(16):
+                A[0] = A[0] + 1
+
+        return func
+
+    flops_with_decl_buffer = estimate_tir_flops(IRModule.from_expr(make_func(True)))
+    flops_without_decl_buffer = estimate_tir_flops(IRModule.from_expr(make_func(True)))
+    assert flops_with_decl_buffer == flops_without_decl_buffer
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Previously, any `DeclBuffer` node in the TIR passed to `FlopEstimator` would throw an error.  This is a subset of changes being split out from https://github.com/apache/tvm/pull/14778 into independent portions.