### PR TITLE
[#14992][DOC][TUTORIAL] Fix typo for the 'Making your Hardware Accelerator TVM-ready with UMA'

### DIFF
--- a/gallery/tutorial/uma.py
+++ b/gallery/tutorial/uma.py
@@ -79,7 +79,7 @@ Making your Hardware Accelerator TVM-ready with UMA
 #
 
 ################################################################################
-# uma_cli.py generates these files in the directory ``vanilla_accelerator`` which we are going to revist.
+# uma_cli.py generates these files in the directory ``vanilla_accelerator`` which we are going to revisit.
 #
 # .. code-block:: bash
 #

--- a/src/relay/printer/relay_text_printer.cc
+++ b/src/relay/printer/relay_text_printer.cc
@@ -555,7 +555,7 @@ Doc RelayTextPrinter::VisitExpr_(const MatchNode* op) {
     Doc clause_doc;
     clause_doc << PrintPattern(clause->lhs, false) << " => ";
     Doc rhs_doc = PrintScope(clause->rhs);
-    // TODO(@jroesch): This is unsound right now, and we need to revist it.
+    // TODO(@jroesch): This is unsound right now, and we need to revisit it.
     // if (clause->rhs.as<LetNode>()) {
     // only add braces if there are multiple lines on the rhs
     rhs_doc = Doc::Brace("{", rhs_doc, "}");


### PR DESCRIPTION
Hi @Hzfengsy @comaniac 

This is a minor PR and it aims to fix the typo in the tutorial. I would appreciate that if you can help to review/manage it, thanks.

https://github.com/apache/tvm/issues/14992