### PR TITLE
[CMSIS-NN] Update CMSIS-NN release to v4.1.0

### DIFF
--- a/docker/install/ubuntu_install_cmsis.sh
+++ b/docker/install/ubuntu_install_cmsis.sh
@@ -49,7 +49,7 @@ echo "$CMSIS_SHASUM" ${DOWNLOAD_PATH} | sha512sum -c
 tar -xf "${DOWNLOAD_PATH}" -C "${INSTALLATION_PATH}" --strip-components=1
 touch "${INSTALLATION_PATH}"/"${CMSIS_SHA}".sha
 
-CMSIS_NN_TAG="v4.0.0"
+CMSIS_NN_TAG="v4.1.0"
 CMSIS_NN_URL="https://github.com/ARM-software/CMSIS-NN.git"
 git clone ${CMSIS_NN_URL} --branch ${CMSIS_NN_TAG} --single-branch ${INSTALLATION_PATH}/CMSIS-NN
 echo "SUCCESS"


### PR DESCRIPTION
Routine update of CMSIS-NN to v4.1.0. Release notes can be found at http://github.com/ARM-software/CMSIS-NN/releases/tag/v4.1.0.

cc @leandron @NicolaLancellotti @lhutton1 @neildhickey 