### PR TITLE
[TOPI][Adreno] Fix problem with ceil_log2

### DIFF
--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -865,4 +865,7 @@ def ceil_log2(x):
 
         return res
 
+    if "adreno" in tvm.target.Target.current().device_name:
+        return cast(tvm.tir.ceil(tvm.tir.log2(cast(x, "float32"))), x.dtype)
+
     return cast(tvm.tir.ceil(tvm.tir.log2(cast(x, "float64"))), x.dtype)


### PR DESCRIPTION
On Adreno devices double type is not supported by OpenCL. Modified `ceil_log2` operation to cast value to float instead of double in case of Adreno.