### PR TITLE
[#15043][Docs] Updated the copyright year from 2020 to 2023

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache TVM
-Copyright 2019-2022 The Apache Software Foundation
+Copyright 2019-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ sys.path.insert(0, str(tvm_path.resolve() / "docs"))
 # General information about the project.
 project = "tvm"
 author = "Apache Software Foundation"
-copyright = "2020 - 2022, %s" % author
+copyright = "2020 - 2023, %s" % author
 github_doc_root = "https://github.com/apache/tvm/tree/main/docs/"
 
 os.environ["TVM_BUILD_DOC"] = "1"
@@ -589,10 +589,10 @@ tvm_alias_check_map = {
 ## Setup header and other configs
 import tlcpack_sphinx_addon
 
-footer_copyright = "© 2022 Apache Software Foundation | All rights reserved"
+footer_copyright = "© 2023 Apache Software Foundation | All rights reserved"
 footer_note = " ".join(
     """
-Copyright © 2022 The Apache Software Foundation. Apache TVM, Apache, the Apache feather,
+Copyright © 2023 The Apache Software Foundation. Apache TVM, Apache, the Apache feather,
 and the Apache TVM project logo are either trademarks or registered trademarks of
 the Apache Software Foundation.""".split(
         "\n"


### PR DESCRIPTION
Hi @yzh119 @Hzfengsy 

This is a minor PR and it aims to update the copyright year from 2020 to 2023. I would appreciate that if you can help to review/manage it, thanks.

#15043