### PR TITLE
[TVMScript] Avoid visiting repetition tensor in SetCommonPrefix Visitor

### DIFF
--- a/src/script/printer/ir_docsifier.cc
+++ b/src/script/printer/ir_docsifier.cc
@@ -95,6 +95,10 @@ void IRDocsifierNode::SetCommonPrefix(const ObjectRef& root,
       if (obj == nullptr) {
         return;
       }
+      if (std::find(visited_.begin(), visited_.end(), obj) != visited_.end()) {
+        return;
+      }
+      visited_.push_back(obj);
       stack_.push_back(obj);
       if (obj->IsInstance<ArrayNode>()) {
         const ArrayNode* array = static_cast<const ArrayNode*>(obj);
@@ -134,6 +138,7 @@ void IRDocsifierNode::SetCommonPrefix(const ObjectRef& root,
 
     ReflectionVTable* vtable_ = ReflectionVTable::Global();
     std::vector<const Object*> stack_;
+    std::vector<const Object*> visited_;
 
    public:
     runtime::TypedPackedFunc<bool(ObjectRef)> is_var;

--- a/src/script/printer/ir_docsifier.cc
+++ b/src/script/printer/ir_docsifier.cc
@@ -96,6 +96,9 @@ void IRDocsifierNode::SetCommonPrefix(const ObjectRef& root,
         return;
       }
       if (std::find(visited_.begin(), visited_.end(), obj) != visited_.end()) {
+        if (is_var(GetRef<ObjectRef>(obj))) {
+          HandleVar(obj);
+        }
         return;
       }
       visited_.push_back(obj);


### PR DESCRIPTION
This commit fix the issue about:
[Bug] [TVMScript] Progress hang on lowerTE during build dynamic Relay IR caused by endless ReprPrintTIR. #15048