### PR TITLE
[Bugfix][Relay][Keras] Fix UpSampling2D about the wrong assertion about size

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -767,10 +767,8 @@ def _convert_upsample(
         params["scale_h"] = h
     elif upsample_type == "UpSampling2D":
         h, w = keras_layer.size
-        if h != w:
-            raise tvm.error.OpAttributeInvalid("Height must equal width for operator Upsample.")
         params["scale_h"] = h
-        params["scale_w"] = h
+        params["scale_w"] = w
 
         if hasattr(keras_layer, "interpolation"):
             interpolation = keras_layer.interpolation

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -389,6 +389,11 @@ class TestKeras:
         x = keras_mod.layers.UpSampling2D(size=(3, 3), interpolation=interpolation)(data)
         keras_model = keras_mod.models.Model(data, x)
         verify_keras_frontend(keras_model)
+        # Height and width are not equal for the attribute size
+        data = keras_mod.layers.Input(shape=(2, 2, 1, 3))
+        x = keras_mod.layers.UpSampling2D(size=(1, 2), interpolation=interpolation)(data)
+        keras_model = keras_mod.models.Model(data, x)
+        verify_keras_frontend(keras_model)
 
     def test_forward_reshape(self, keras_mod):
         """test_forward_reshape"""

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -390,7 +390,7 @@ class TestKeras:
         keras_model = keras_mod.models.Model(data, x)
         verify_keras_frontend(keras_model)
         # Height and width are not equal for the attribute size
-        data = keras_mod.layers.Input(shape=(2, 2, 1, 3))
+        data = keras_mod.layers.Input(shape=(2, 1, 3))
         x = keras_mod.layers.UpSampling2D(size=(1, 2), interpolation=interpolation)(data)
         keras_model = keras_mod.models.Model(data, x)
         verify_keras_frontend(keras_model)


### PR DESCRIPTION
This PR removed the wrong assertion about UpSampling2D.


In the Keras frontend of TVM, The UpSampling2D has a wired constraint: "Height must equal width for operator Upsample." 

However,  from the [documentation about UpSampling2D](https://keras.io/api/layers/reshaping_layers/up_sampling2d/), The constraint about `size` is, " Int, or tuple of 2 integers".  Meanwhile, An official example from the Keras documentation uses the size(1, 2)
![image](https://github.com/apache/tvm/assets/29506758/457f54ef-89e3-4196-9ae5-44f5a8fc0249). 

Thus, the assertion in TVM is wrong. I deleted the related statements and added a bug-triggering test case.


@echuraev @masahi @Hzfengsy 