### PR TITLE
[TVMScript] Avoid visiting repetition tensor in SetCommonPrefix Visitor

### DIFF
--- a/src/script/printer/ir_docsifier.cc
+++ b/src/script/printer/ir_docsifier.cc
@@ -95,13 +95,13 @@ void IRDocsifierNode::SetCommonPrefix(const ObjectRef& root,
       if (obj == nullptr) {
         return;
       }
-      if (std::find(visited_.begin(), visited_.end(), obj) != visited_.end()) {
+      if (visited_.count(obj)) {
         if (is_var(GetRef<ObjectRef>(obj))) {
           HandleVar(obj);
         }
         return;
       }
-      visited_.push_back(obj);
+      visited_.insert(obj);
       stack_.push_back(obj);
       if (obj->IsInstance<ArrayNode>()) {
         const ArrayNode* array = static_cast<const ArrayNode*>(obj);
@@ -141,7 +141,7 @@ void IRDocsifierNode::SetCommonPrefix(const ObjectRef& root,
 
     ReflectionVTable* vtable_ = ReflectionVTable::Global();
     std::vector<const Object*> stack_;
-    std::vector<const Object*> visited_;
+    std::unordered_set<const Object*> visited_;
 
    public:
     runtime::TypedPackedFunc<bool(ObjectRef)> is_var;

--- a/src/script/printer/ir_docsifier.cc
+++ b/src/script/printer/ir_docsifier.cc
@@ -95,6 +95,13 @@ void IRDocsifierNode::SetCommonPrefix(const ObjectRef& root,
       if (obj == nullptr) {
         return;
       }
+      if (std::find(visited_.begin(), visited_.end(), obj) != visited_.end()) {
+        if (is_var(GetRef<ObjectRef>(obj))) {
+          HandleVar(obj);
+        }
+        return;
+      }
+      visited_.push_back(obj);
       stack_.push_back(obj);
       if (obj->IsInstance<ArrayNode>()) {
         const ArrayNode* array = static_cast<const ArrayNode*>(obj);
@@ -134,6 +141,7 @@ void IRDocsifierNode::SetCommonPrefix(const ObjectRef& root,
 
     ReflectionVTable* vtable_ = ReflectionVTable::Global();
     std::vector<const Object*> stack_;
+    std::vector<const Object*> visited_;
 
    public:
     runtime::TypedPackedFunc<bool(ObjectRef)> is_var;


### PR DESCRIPTION
This commit fix the issue about:
[Bug] [TVMScript] Progress hang on lowerTE during build dynamic Relay IR caused by endless ReprPrintTIR. https://github.com/apache/tvm/issues/15048