### PR TITLE
[Target][rocm] Replace rocm arch parsing from int to string

### DIFF
--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -261,7 +261,7 @@ TargetJSON UpdateROCmAttrs(TargetJSON target) {
   }
   return target;
 }
-    
+
 /*!
  * \brief Test Target Parser
  * \param target The Target to update
@@ -272,7 +272,7 @@ TargetJSON TestTargetParser(TargetJSON target) {
   target.Set("features", features);
   return target;
 }
-    
+
 /**********  Register Target kinds and attributes  **********/
 
 TVM_REGISTER_TARGET_KIND("llvm", kDLCPU)

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -104,7 +104,25 @@ static int ExtractIntWithPrefix(const std::string& str, const std::string& prefi
   }
   return result;
 }
-
+    
+/*!
+ * \brief Extract a string from the string with the given prefix.
+ * For example, when `str` is "sm_20" and `prefix` is "sm_".
+ * This function first checks if `str` starts with `prefix`,
+ * then return the integer 20 after the `prefix`
+ * \param str The string to be extracted
+ * \param prefix The prefix to be checked
+ * \return A string, the extracted string. "" if the check fails
+ */
+std::string ExtractStringWithPrefix(const std::string& str, const std::string& prefix) {
+  if (str.find(prefix) != 0) return "";
+  std::size_t pos = prefix.length();
+  while (pos < str.length() && (std::isdigit(str[pos]) || std::isalpha(str[pos]))) {
+    ++pos;
+  }
+  return str.substr(prefix.length(), pos - prefix.length());
+}
+    
 /*!
  * \brief Using TVM DeviceAPI to detect the device flag
  * \param device The device to be detected
@@ -206,20 +224,20 @@ TargetJSON UpdateNVPTXAttrs(TargetJSON target) {
 TargetJSON UpdateROCmAttrs(TargetJSON target) {
   CheckOrSetAttr(&target, "mtriple", "amdgcn-amd-amdhsa-hcc");
   // Update -mcpu=gfx
-  int arch;
+  std::string arch;
   if (target.count("mcpu")) {
     String mcpu = Downcast<String>(target.at("mcpu"));
-    arch = ExtractIntWithPrefix(mcpu, "gfx");
-    ICHECK(arch != -1) << "ValueError: ROCm target gets an invalid GFX version: -mcpu=" << mcpu;
+    arch = ExtractStringWithPrefix(mcpu, "gfx");
+    ICHECK(!arch.empty()) << "ValueError: ROCm target gets an invalid GFX version: -mcpu=" << mcpu;
   } else {
     TVMRetValue val;
     if (!DetectDeviceFlag({kDLROCM, 0}, runtime::kGcnArch, &val)) {
       LOG(WARNING) << "Unable to detect ROCm compute arch, default to \"-mcpu=gfx900\" instead";
-      arch = 900;
+      arch = "900";
     } else {
-      arch = val.operator int();
+      arch = val.operator std::string();
     }
-    target.Set("mcpu", String("gfx") + std::to_string(arch));
+    target.Set("mcpu", String("gfx") + arch);
   }
   // Update -mattr before ROCm 3.5:
   //   Before ROCm 3.5 we needed code object v2, starting
@@ -241,17 +259,6 @@ TargetJSON UpdateROCmAttrs(TargetJSON target) {
     mattr.push_back("-code-object-v3");
     target.Set("mattr", mattr);
   }
-  return target;
-}
-
-/*!
- * \brief Test Target Parser
- * \param target The Target to update
- * \return The updated attributes
- */
-TargetJSON TestTargetParser(TargetJSON target) {
-  Map<String, ObjectRef> features = {{"is_test", Bool(true)}};
-  target.Set("features", features);
   return target;
 }
 

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -261,7 +261,18 @@ TargetJSON UpdateROCmAttrs(TargetJSON target) {
   }
   return target;
 }
-
+    
+/*!
+ * \brief Test Target Parser
+ * \param target The Target to update
+ * \return The updated attributes
+ */
+TargetJSON TestTargetParser(TargetJSON target) {
+  Map<String, ObjectRef> features = {{"is_test", Bool(true)}};
+  target.Set("features", features);
+  return target;
+}
+    
 /**********  Register Target kinds and attributes  **********/
 
 TVM_REGISTER_TARGET_KIND("llvm", kDLCPU)

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -104,7 +104,7 @@ static int ExtractIntWithPrefix(const std::string& str, const std::string& prefi
   }
   return result;
 }
-    
+
 /*!
  * \brief Extract a string from the string with the given prefix.
  * For example, when `str` is "sm_20" and `prefix` is "sm_".
@@ -122,7 +122,7 @@ std::string ExtractStringWithPrefix(const std::string& str, const std::string& p
   }
   return str.substr(prefix.length(), pos - prefix.length());
 }
-    
+
 /*!
  * \brief Using TVM DeviceAPI to detect the device flag
  * \param device The device to be detected


### PR DESCRIPTION
now llvm declares rocm arch in a different way, as we can observe that gfx90a/90c is not an integer only arch name which will cause some issues when generate code under the latest amd gpus:

```cpp
 ``EF_AMDGPU_MACH_AMDGCN_GFX801``     0x028      ``gfx801``
 ``EF_AMDGPU_MACH_AMDGCN_GFX802``     0x029      ``gfx802``
 ``EF_AMDGPU_MACH_AMDGCN_GFX803``     0x02a      ``gfx803``
 ``EF_AMDGPU_MACH_AMDGCN_GFX810``     0x02b      ``gfx810``
 ``EF_AMDGPU_MACH_AMDGCN_GFX900``     0x02c      ``gfx900``
 ``EF_AMDGPU_MACH_AMDGCN_GFX902``     0x02d      ``gfx902``
 ``EF_AMDGPU_MACH_AMDGCN_GFX904``     0x02e      ``gfx904``
 ``EF_AMDGPU_MACH_AMDGCN_GFX906``     0x02f      ``gfx906``
 ``EF_AMDGPU_MACH_AMDGCN_GFX908``     0x030      ``gfx908``
 ``EF_AMDGPU_MACH_AMDGCN_GFX909``     0x031      ``gfx909``
 ``EF_AMDGPU_MACH_AMDGCN_GFX90C``     0x032      ``gfx90c``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1010``    0x033      ``gfx1010``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1011``    0x034      ``gfx1011``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1012``    0x035      ``gfx1012``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1030``    0x036      ``gfx1030``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1031``    0x037      ``gfx1031``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1032``    0x038      ``gfx1032``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1033``    0x039      ``gfx1033``
 ``EF_AMDGPU_MACH_AMDGCN_GFX602``     0x03a      ``gfx602``
 ``EF_AMDGPU_MACH_AMDGCN_GFX705``     0x03b      ``gfx705``
 ``EF_AMDGPU_MACH_AMDGCN_GFX805``     0x03c      ``gfx805``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1035``    0x03d      ``gfx1035``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1034``    0x03e      ``gfx1034``
 ``EF_AMDGPU_MACH_AMDGCN_GFX90A``     0x03f      ``gfx90a``
 ``EF_AMDGPU_MACH_AMDGCN_GFX940``     0x040      ``gfx940``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1100``    0x041      ``gfx1100``
 ``EF_AMDGPU_MACH_AMDGCN_GFX1013``    0x042      ``gfx1013``
```

for example, on MI200, the codegen will failed when we specified arch to gfx90a.

```python

@tvm.script.ir_module
class MyModule:
    @T.prim_func
    def main(a: T.handle, b: T.handle):
        T.func_attr({"global_symbol": "main"})
        A = T.match_buffer(a, (M, N), dtype="float32")
        B = T.match_buffer(b, (M, N), dtype="float32")
        for i, j in T.grid(M, N):
            with T.block("B"):
                vi, vj = T.axis.remap("SS", [i, j])
                B[vi, vj] = A[vi, vj] * 2.0
ir_module = MyModule
sch = tvm.tir.Schedule(ir_module, debug_mask="all")
block_b = sch.get_block("B")
i, j = sch.get_loops(block_b)
sch.bind(i, "blockIdx.x")
sch.bind(j, "threadIdx.x")
with tvm.transform.PassContext():
    rocm_mod = tvm.build(sch.mod, target="rocm -mcpu=gfx90a")
```

enabling this fix will figure it out.