### PR TITLE
[Docker] Update ci-cortexm docker image to contain CMSIS-NN release v…

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -18,7 +18,7 @@
 # This data file is read during when Jenkins runs job to determine docker images.
 [jenkins]
 ci_arm: tlcpack/ci-arm:20230504-142417-4d37a0a0
-ci_cortexm: tlcpack/ci-cortexm:20230504-142417-4d37a0a0
+ci_cortexm: tlcpack/ci-cortexm:20230613-060122-21361a63a
 ci_cpu: tlcpack/ci_cpu:20230604-060130-0af9ff90e
 ci_gpu: tlcpack/ci-gpu:20230504-142417-4d37a0a0
 ci_hexagon: tlcpack/ci-hexagon:20230504-142417-4d37a0a0


### PR DESCRIPTION
CMSIS-NN release [v4.1.0](https://github.com/ARM-software/CMSIS-NN/releases/tag/v4.1.0) update available with latest
tlcpack ci-cortexm image. This commit enables upstream
CI validations using the [latest](https://hub.docker.com/layers/tlcpack/ci-cortexm/20230613-060122-21361a63a/images/sha256-5b5ccb9d938ffccb088c9c7ea6af7b2e7cc739979786645c2c2fa5642f3f3390?context=explore) image.
