### PR TITLE
[Unity] Fix FewShotTuning Failure When Missing Global Symbol

### DIFF
--- a/src/relax/transform/few_shot_tuning.cc
+++ b/src/relax/transform/few_shot_tuning.cc
@@ -45,7 +45,8 @@ tir::PrimFunc FewShotTunePrimFunc(const tir::PrimFunc& prim_func, const Target& 
     ICHECK(runner.defined()) << "ValueError: The local runner is not defined!";
   }
   // create an IRModule
-  IRModule mod = IRModule(Map<GlobalVar, BaseFunc>({{GlobalVar("main"), prim_func}}));
+  IRModule mod = IRModule(Map<GlobalVar, BaseFunc>(
+      {{GlobalVar("main"), WithAttr(prim_func, tvm::attr::kGlobalSymbol, String("main"))}}));
   // fetch the number of physical cores
   static const auto* f_cpu_count = runtime::Registry::Get("meta_schedule.cpu_count");
   ICHECK(f_cpu_count) << "ValueError: Cannot find the packed function \"meta_schedule._cpu_count\"";


### PR DESCRIPTION
Previously the building of PrimFuncs in Few Shot Tuning pass will fail when the function attribute `global_symbol` is missing. This PR manually adds a global symbol of `main` for each PrimFunc to tune and the unit tests are modfied accordingly.

Thanks @masahi for identifying this issue.