### PR TITLE
[Docker] Update docker images for llvm-16

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -17,9 +17,9 @@
 
 # This data file is read during when Jenkins runs job to determine docker images.
 [jenkins]
-ci_arm: tlcpack/ci-arm:20230504-142417-4d37a0a0
+ci_arm: tlcpack/ci-arm:20230615-060132-62a5e7acf
 ci_cortexm: tlcpack/ci-cortexm:20230613-060122-21361a63a
-ci_cpu: tlcpack/ci_cpu:20230604-060130-0af9ff90e
+ci_cpu: tlcpack/ci-cpu:20230604-060130-0af9ff90e
 ci_gpu: tlcpack/ci-gpu:20230504-142417-4d37a0a0
 ci_hexagon: tlcpack/ci-hexagon:20230504-142417-4d37a0a0
 ci_i386: tlcpack/ci-i386:20230504-142417-4d37a0a0


### PR DESCRIPTION
Update ci_arm docker image to take llvm-16 from package.

Update ci_cpu docker image to correctly named one.