### PR TITLE
[Unity][BYOC] Integrate fp16 A - int4 B GEMM kernel from FasterTransformer into CUTLASS BYOC 

### DIFF
--- a/cmake/modules/contrib/CUTLASS.cmake
+++ b/cmake/modules/contrib/CUTLASS.cmake
@@ -21,6 +21,7 @@ if(USE_CUDA AND USE_CUTLASS)
 
   set(CUTLASS_DIR ${PROJECT_SOURCE_DIR}/3rdparty/cutlass)
   add_subdirectory(${PROJECT_SOURCE_DIR}/3rdparty/cutlass_fpA_intB_gemm)
+  list(APPEND RUNTIME_SRCS src/runtime/contrib/cutlass/weight_preprocess.cc)
 
   message(STATUS "Build with CUTLASS")
 endif()

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -701,17 +701,17 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         lhs_arg = f"arg{arg_idx['lhs']}"
         lhs_shape = signature[f"{lhs_arg}_shape"]
         attrs = {
-                    "op_type": op_type,
-                    "lhs_arg_idx": arg_idx["lhs"],
-                    "rhs_arg_idx": arg_idx["w_encoded"],
-                    "scales_arg_idx": arg_idx["scales"],
-                    "bias_arg_idx": arg_idx.get("bias"),
-                    "batch_offset": len(lhs_shape) - 2,
-                }
+            "op_type": op_type,
+            "lhs_arg_idx": arg_idx["lhs"],
+            "rhs_arg_idx": arg_idx["w_encoded"],
+            "scales_arg_idx": arg_idx["scales"],
+            "bias_arg_idx": arg_idx.get("bias"),
+            "batch_offset": len(lhs_shape) - 2,
+        }
 
         if "residual" in op_type:
             residual_pos = op_type.find("residual_")
-            postfix = op_type[residual_pos + len("residual_"):]
+            postfix = op_type[residual_pos + len("residual_") :]
 
             if postfix.startswith("multiply"):
                 binary_op = "multiply"
@@ -726,16 +726,18 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
             activation = "identity"
 
             for act in ["relu", "silu", "gelu"]:
-                if act in op_type[op_type.find("matmul_") + len("matmul_"): residual_pos]:
+                if act in op_type[op_type.find("matmul_") + len("matmul_") : residual_pos]:
                     activation = act
                     break
 
-            attrs.update({
+            attrs.update(
+                {
                     "unary_op": unary_op,
                     "binary_op": binary_op,
                     "activation": activation,
                     "residual_arg_idx": arg_idx["residual"],
-            })
+                }
+            )
 
         return f.with_attrs(attrs)
 

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -57,6 +57,7 @@ def _get_cutlass_compile_options(sm, threads, use_fast_math=False):
     cutlass_include = os.path.join(cutlass_root, "include")
     cutlass_util_include = os.path.join(cutlass_root, "tools/util/include")
     cutlass_attention_include = os.path.join(cutlass_root, "examples/41_fused_multi_head_attention")
+    cutlass_fpA_intB_gemm_include = os.path.join(cutlass_root, "../cutlass_fpA_intB_gemm")
 
     kwargs = {}
     kwargs["cc"] = "nvcc"
@@ -74,6 +75,7 @@ def _get_cutlass_compile_options(sm, threads, use_fast_math=False):
         f"-I{cutlass_include}",
         f"-I{cutlass_util_include}",
         f"-I{cutlass_attention_include}",
+        f"-I{cutlass_fpA_intB_gemm_include}",
     ]
     if use_fast_math:
         kwargs["options"].append("-DCUTLASS_USE_TANH_FOR_SIGMOID")
@@ -693,6 +695,19 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
 
         return f.with_attrs(attrs)
 
+    def handle_decode_matmul(self, f, op_type):
+        arg_idx = _extract_arg_idx(op_type, f)
+        return f.with_attrs(
+            {
+                "op_type": op_type,
+                "lhs_arg_idx": arg_idx["lhs"],
+                "rhs_arg_idx": arg_idx["rhs"],
+                "scales_arg_idx": arg_idx["scales"],
+                "bias_arg_idx": arg_idx.get("bias"),
+                "residual_arg_idx": arg_idx.get("residual"),
+            }
+        )
+
     def handle_matmul(self, f, op_type):
         """Tune and annotate a dense op."""
         signature = _extract_relax_function_signature(f)
@@ -882,6 +897,8 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
 
         if "conv2d" in op_type:
             return self.handle_conv2d(f, op_type)
+        elif "decode" in op_type:
+            return self.handle_decode_matmul(f, op_type)
         elif "matmul" in op_type:
             return self.handle_matmul(f, op_type)
         elif "attention" in op_type:

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -697,14 +697,18 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
 
     def handle_decode_matmul(self, f, op_type):
         arg_idx = _extract_arg_idx(op_type, f)
+        signature = _extract_relax_function_signature(f)
+        lhs_arg = f"arg{arg_idx['lhs']}"
+        lhs_shape = signature[f"{lhs_arg}_shape"]
         return f.with_attrs(
             {
                 "op_type": op_type,
                 "lhs_arg_idx": arg_idx["lhs"],
-                "rhs_arg_idx": arg_idx["rhs"],
+                "rhs_arg_idx": arg_idx["w_encoded"],
                 "scales_arg_idx": arg_idx["scales"],
                 "bias_arg_idx": arg_idx.get("bias"),
                 "residual_arg_idx": arg_idx.get("residual"),
+                "batch_offset": len(lhs_shape) - 2,
             }
         )
 

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -696,6 +696,7 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         return f.with_attrs(attrs)
 
     def handle_decode_matmul(self, f, op_type):
+        """Annotate a decode -> matmul op."""
         arg_idx = _extract_arg_idx(op_type, f)
         signature = _extract_relax_function_signature(f)
         lhs_arg = f"arg{arg_idx['lhs']}"
@@ -742,7 +743,7 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         return f.with_attrs(attrs)
 
     def handle_matmul(self, f, op_type):
-        """Tune and annotate a dense op."""
+        """Tune and annotate a matmul op."""
         signature = _extract_relax_function_signature(f)
         arg_idx = _extract_arg_idx(op_type, f)
 

--- a/python/tvm/contrib/cutlass/gemm_operation.py
+++ b/python/tvm/contrib/cutlass/gemm_operation.py
@@ -408,6 +408,8 @@ def instantiate_gemm_template(attrs):
 
 
 def emit_fp16A_int4B_matmul(attrs):
+    """Return CUTLASS host code for fp16 A and int4 B GEMM."""
+
     attrs["template_common"] = substitute_template(
         """
   using namespace fastertransformer;

--- a/python/tvm/contrib/cutlass/gemm_operation.py
+++ b/python/tvm/contrib/cutlass/gemm_operation.py
@@ -408,12 +408,15 @@ def instantiate_gemm_template(attrs):
 
 
 def emit_fp16A_int4B_matmul(attrs):
-    attrs["template_common"] = substitute_template("""
+    attrs["template_common"] = substitute_template(
+        """
   using namespace fastertransformer;
   int m = ${A_arg}->shape[${batch_offset}];
   int n = ${B_arg}->shape[1] * 2;
   int k = ${B_arg}->shape[0];
-    """, attrs)
+    """,
+        attrs,
+    )
 
     template = """
   ${template_common}
@@ -446,11 +449,15 @@ def emit_fp16A_int4B_matmul(attrs):
 """
 
     if "residual_arg" in attrs and "bias_arg" in attrs:
-        template_residual = substitute_template(template_residual, {"bias": "static_cast<cutlass::half_t*>(${bias_arg}->data)"})
+        template_residual = substitute_template(
+            template_residual, {"bias": "static_cast<cutlass::half_t*>(${bias_arg}->data)"}
+        )
         return substitute_template(template_residual, attrs)
+
     if "residual_arg" in attrs:
         template_residual = substitute_template(template_residual, {"bias": "nullptr"})
         return substitute_template(template_residual, attrs)
+
     if "bias_arg" in attrs:
         return substitute_template(template_bias, attrs)
 

--- a/python/tvm/contrib/cutlass/gemm_operation.py
+++ b/python/tvm/contrib/cutlass/gemm_operation.py
@@ -441,7 +441,7 @@ def emit_fp16A_int4B_matmul(attrs):
                  static_cast<cutlass::half_t*>(${scales_arg}->data),
                  ${bias},
                  static_cast<cutlass::half_t*>(${residual_arg}->data),
-                 static_cast<cutlass::half_t*>(out0->data), "identity", "plus", "identity", // todo
+                 static_cast<cutlass::half_t*>(out0->data), "${activation}", "${binary_op}", "${unary_op}",
                  m, n, k, nullptr, 0, nullptr);
 """
 

--- a/python/tvm/contrib/cutlass/gemm_operation.py
+++ b/python/tvm/contrib/cutlass/gemm_operation.py
@@ -298,7 +298,7 @@ def instantiate_gemm_template(attrs):
     static_cast<ElementInputB*>(ptr_b),
     static_cast<ElementOutput*>(ptr_residual),
     static_cast<ElementOutput*>(ptr_out),
-    static_cast<ElementOutput*>(ptr_bias),
+    static_cast<ElementOutput*>(${ptr_bias}),
     nullptr, // ptr_Tensor
     ${batch_stride_A}
     ${batch_stride_B}
@@ -344,6 +344,7 @@ def instantiate_gemm_template(attrs):
   CHECK(status == cutlass::Status::kSuccess);
   status = gemm_op.initialize(arguments, workspace.get());
   CHECK(status == cutlass::Status::kSuccess);
+
   status = gemm_op();
   CHECK(status == cutlass::Status::kSuccess);
 """
@@ -395,7 +396,13 @@ def instantiate_gemm_template(attrs):
         attrs["split_k_slices_or_batch"] = 1
 
     if has_residual_block:
+        if has_bias:
+            argument_template_residual = substitute_template(argument_template_residual, {"ptr_bias": "ptr_bias"})
+        else:
+            argument_template_residual = substitute_template(argument_template_residual, {"ptr_bias": "nullptr"})
+
         template = substitute_template(template, {"argument": argument_template_residual})
+
         aux_map["residual_decl"] = "void* ptr_residual = (void*)(${residual_arg}->data);\n"
         aux_map["gemm_universal_mode"] = "kBatched" if batched else "kGemm"
     else:
@@ -403,5 +410,72 @@ def instantiate_gemm_template(attrs):
         aux_map["residual_decl"] = ""
 
     template = substitute_template(template, aux_map)
+
+    return substitute_template(template, attrs)
+
+
+def emit_fp16A_int4B_matmul(attrs):
+    template = """
+  using namespace fastertransformer;
+  int m = ${A_arg}->shape[1]; // [0] is batch
+  int n = ${B_arg}->shape[1] * 2;
+  int k = ${B_arg}->shape[0];
+  gemm_fp16_int4(static_cast<cutlass::half_t*>(${A_arg}->data),
+                 static_cast<cutlass::uint4b_t*>(${B_arg}->data),
+                 static_cast<cutlass::half_t*>(${scales_arg}->data),
+                 static_cast<cutlass::half_t*>(out0->data),
+                 m, n, k, nullptr, 0, nullptr);
+"""
+
+    template_bias = """
+  using namespace fastertransformer;
+  int m = ${A_arg}->shape[1]; // [0] is batch
+  int n = ${B_arg}->shape[1] * 2;
+  int k = ${B_arg}->shape[0];
+
+  gemm_fp16_int4_bias(static_cast<cutlass::half_t*>(${A_arg}->data),
+                 static_cast<cutlass::uint4b_t*>(${B_arg}->data),
+                 static_cast<cutlass::half_t*>(${scales_arg}->data),
+                 static_cast<cutlass::half_t*>(${bias_arg}->data),
+                 static_cast<cutlass::half_t*>(out0->data),
+                 m, n, k, nullptr, 0, nullptr);
+"""
+
+    template_residual = """
+  using namespace fastertransformer;
+  int m = ${A_arg}->shape[1]; // [0] is batch
+  int n = ${B_arg}->shape[1] * 2;
+  int k = ${B_arg}->shape[0];
+
+  gemm_fp16_int4_bias_act_residual(static_cast<cutlass::half_t*>(${A_arg}->data),
+                 static_cast<cutlass::uint4b_t*>(${B_arg}->data),
+                 static_cast<cutlass::half_t*>(${scales_arg}->data),
+                 static_cast<cutlass::half_t*>(${bias_arg}->data),
+                 static_cast<cutlass::half_t*>(${residual_arg}->data),
+                 static_cast<cutlass::half_t*>(out0->data), "identity", "plus", "identity", // todo
+                 m, n, k, nullptr, 0, nullptr);
+"""
+
+    template_residual_no_bias = """
+  using namespace fastertransformer;
+  int m = ${A_arg}->shape[1]; // [0] is batch
+  int n = ${B_arg}->shape[1] * 2;
+  int k = ${B_arg}->shape[0];
+
+  gemm_fp16_int4_bias_act_residual(static_cast<cutlass::half_t*>(${A_arg}->data),
+                 static_cast<cutlass::uint4b_t*>(${B_arg}->data),
+                 static_cast<cutlass::half_t*>(${scales_arg}->data),
+                 nullptr,
+                 static_cast<cutlass::half_t*>(${residual_arg}->data),
+                 static_cast<cutlass::half_t*>(out0->data), "silu", "multiply", "identity", // todo
+                 m, n, k, nullptr, 0, nullptr);
+"""
+
+    if "residual_arg" in attrs and "bias_arg" in attrs:
+        return substitute_template(template_residual, attrs)
+    if "residual_arg" in attrs:
+        return substitute_template(template_residual_no_bias, attrs)
+    if "bias_arg" in attrs:
+        return substitute_template(template_bias, attrs)
 
     return substitute_template(template, attrs)

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -523,6 +523,7 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["A_arg"] = func_args[lhs_arg_idx]
         attrs["B_arg"] = func_args[rhs_arg_idx]
         attrs["scales_arg"] = func_args[scales_arg_idx]
+        attrs["batch_offset"] = _get_optional_int_annotation(annotations, "batch_offset", 0)
 
         if bias_arg_idx is not None:
             attrs["bias_arg"] = func_args[bias_arg_idx]

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -524,11 +524,14 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["B_arg"] = func_args[rhs_arg_idx]
         attrs["scales_arg"] = func_args[scales_arg_idx]
         attrs["batch_offset"] = _get_optional_int_annotation(annotations, "batch_offset", 0)
+        attrs["activation"] = annotations.get("activation", "identity")
 
         if bias_arg_idx is not None:
             attrs["bias_arg"] = func_args[bias_arg_idx]
         if residual_arg_idx is not None:
             attrs["residual_arg"] = func_args[residual_arg_idx]
+            attrs["binary_op"] = annotations["binary_op"]
+            attrs["unary_op"] = annotations["unary_op"]
 
         code = emit_fp16A_int4B_matmul(attrs)
         return CodegenResult(code, headers)

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -528,6 +528,7 @@ def instantiate_template(func_name, annotations, func_args):
 
         if bias_arg_idx is not None:
             attrs["bias_arg"] = func_args[bias_arg_idx]
+
         if residual_arg_idx is not None:
             attrs["residual_arg"] = func_args[residual_arg_idx]
             attrs["binary_op"] = annotations["binary_op"]

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -482,7 +482,7 @@ def instantiate_template(func_name, annotations, func_args):
         if k in annotations:
             attrs[k] = annotations[k]
 
-    headers = ["tvm/runtime/registry.h"]
+    headers = []
 
     if "relu" in func_name:
         headers.append("cutlass/epilogue/thread/linear_combination_bias_relu.h")
@@ -523,12 +523,15 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["A_arg"] = func_args[lhs_arg_idx]
         attrs["B_arg"] = func_args[rhs_arg_idx]
         attrs["scales_arg"] = func_args[scales_arg_idx]
+
         if bias_arg_idx is not None:
             attrs["bias_arg"] = func_args[bias_arg_idx]
         if residual_arg_idx is not None:
             attrs["residual_arg"] = func_args[residual_arg_idx]
+
         code = emit_fp16A_int4B_matmul(attrs)
         return CodegenResult(code, headers)
+
     elif "dense" in func_name or "matmul" in func_name:
         batched = "batch" in annotations
         transposed = "transposed" in func_name

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -22,7 +22,16 @@ from typing import Mapping, Sequence
 
 import tvm
 from tvm.contrib.cutlass.build import is_shape_valid_for_cutlass_matmul
-from tvm.relax import Call, DataflowVar, Function, PyExprMutator, Var, expr_functor, transform
+from tvm.relax import (
+    Call,
+    DataflowVar,
+    Function,
+    PyExprMutator,
+    Var,
+    expr_functor,
+    transform,
+    ExternFunc,
+)
 from tvm.relax.dpl import rewrite_call
 from tvm.relax.transform import PatternCheckContext
 from tvm.relax.dpl.pattern import GlobalVarPattern, TuplePattern, is_op, wildcard
@@ -240,9 +249,10 @@ def _check_decode_matmul(ctx):
     if packed_weight.struct_info.dtype != "int8":
         return False
 
-    # # The kernel expects the weight to be preprocessed by this packed function.
+    # The kernel expects the weight to be preprocessed by this packed function.
     if (
         isinstance(packed_weight, Call)
+        and isinstance(packed_weight.args[0], ExternFunc)
         and packed_weight.args[0].global_symbol != "cutlass.ft_preprocess_weight_int4"
     ):
         return False

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -241,7 +241,10 @@ def _check_decode_matmul(ctx):
         return False
 
     # # The kernel expects the weight to be preprocessed by this packed function.
-    if isinstance(packed_weight, Call) and packed_weight.args[0].global_symbol != "cutlass.ft_preprocess_weight_int4":
+    if (
+        isinstance(packed_weight, Call)
+        and packed_weight.args[0].global_symbol != "cutlass.ft_preprocess_weight_int4"
+    ):
         return False
 
     # packed weight needs to be of shape (K, N // 2)
@@ -269,6 +272,7 @@ def _check_decode_matmul(ctx):
 
 def decode_matmul_patterns():
     """Returns a list of supported decode -> matmul patterns."""
+
     def _decode_matmul_pattern(name):
         scales = wildcard()
         x = wildcard()

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -240,12 +240,12 @@ def _check_decode_matmul(ctx):
     if packed_weight.struct_info.dtype != "int8":
         return False
 
-    # The kernel expects the weight to be preprocessed by this packed function.
-    if isinstance(packed_weight, Call) and packed_weight.args[0] != "cutlass.ft_preprocess_weight_int4":
+    # # The kernel expects the weight to be preprocessed by this packed function.
+    if isinstance(packed_weight, Call) and packed_weight.args[0].global_symbol != "cutlass.ft_preprocess_weight_int4":
         return False
 
     # packed weight needs to be of shape (K, N // 2)
-    if packed_weight.shape[0] != K or packed_weight.shape[1] != N // 2:
+    if packed_weight.struct_info.shape[0] != K or packed_weight.struct_info.shape[1] != N // 2:
         return False
 
     scales = ctx.annotated_expr["scales"]

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+# pylint: disable=invalid-name
 """Pattern table for CUTLASS backend"""
 import operator
 from functools import reduce

--- a/src/runtime/contrib/cutlass/weight_preprocess.cc
+++ b/src/runtime/contrib/cutlass/weight_preprocess.cc
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/packed_func.h>
 #include <tvm/runtime/registry.h>

--- a/src/runtime/contrib/cutlass/weight_preprocess.cc
+++ b/src/runtime/contrib/cutlass/weight_preprocess.cc
@@ -1,0 +1,23 @@
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+
+#include "../../../3rdparty/cutlass_fpA_intB_gemm/cutlass_kernels/cutlass_preprocessors.h"
+
+namespace tvm {
+namespace runtime {
+
+TVM_REGISTER_GLOBAL("cutlass.ft_preprocess_weight").set_body_typed([](NDArray packed_weight) {
+  int rows = packed_weight->shape[0];
+  int cols = packed_weight->shape[1];
+  std::vector<int8_t> input_cpu(rows * cols);
+  std::vector<int8_t> output_cpu(rows * cols);
+  packed_weight.CopyToBytes(input_cpu.data(), input_cpu.size());
+  fastertransformer::preprocess_weights(output_cpu.data(), input_cpu.data(), rows, cols * 2, true, 80);
+  auto out = NDArray::Empty(packed_weight.Shape(), packed_weight->dtype, packed_weight->device);
+  out.CopyFromBytes(output_cpu.data(), output_cpu.size());
+  return out;
+});
+
+}  // namespace runtime
+}  // namespace tvm

--- a/src/runtime/contrib/cutlass/weight_preprocess.cc
+++ b/src/runtime/contrib/cutlass/weight_preprocess.cc
@@ -36,7 +36,7 @@ TVM_REGISTER_GLOBAL("cutlass.ft_preprocess_weight_int4")
       // multiply cols by 2 since the "col" params in preprocess_weights refers to the column of
       // the unpacked weight.
       fastertransformer::preprocess_weights(output_cpu.data(), input_cpu.data(), rows, cols * 2,
-                                            true /*is_int4*/ , sm);
+                                            true /*is_int4*/, sm);
       auto out = NDArray::Empty(packed_weight.Shape(), packed_weight->dtype, packed_weight->device);
       out.CopyFromBytes(output_cpu.data(), output_cpu.size());
       return out;

--- a/src/runtime/contrib/cutlass/weight_preprocess.cc
+++ b/src/runtime/contrib/cutlass/weight_preprocess.cc
@@ -26,6 +26,15 @@
 namespace tvm {
 namespace runtime {
 
+// This packed function applies the set of preprocessings on the weight, which are required by
+// the FT kernel. They consist of permuting / transposing / interleaving the weight elements,
+// and changing the weight dtype to be unsigned by adding a bias. The output has the same size
+// as the input.
+//
+// These processes are not well documented, so we wrap them into a packed function and use it as a
+// black box.
+//
+// The preprocessing functions are defined in C++, so we need to copy the input weight to CPU.
 TVM_REGISTER_GLOBAL("cutlass.ft_preprocess_weight_int4")
     .set_body_typed([](NDArray packed_weight, int sm) {
       int rows = packed_weight->shape[0];

--- a/src/runtime/contrib/cutlass/weight_preprocess.cc
+++ b/src/runtime/contrib/cutlass/weight_preprocess.cc
@@ -7,17 +7,21 @@
 namespace tvm {
 namespace runtime {
 
-TVM_REGISTER_GLOBAL("cutlass.ft_preprocess_weight").set_body_typed([](NDArray packed_weight) {
-  int rows = packed_weight->shape[0];
-  int cols = packed_weight->shape[1];
-  std::vector<int8_t> input_cpu(rows * cols);
-  std::vector<int8_t> output_cpu(rows * cols);
-  packed_weight.CopyToBytes(input_cpu.data(), input_cpu.size());
-  fastertransformer::preprocess_weights(output_cpu.data(), input_cpu.data(), rows, cols * 2, true, 80);
-  auto out = NDArray::Empty(packed_weight.Shape(), packed_weight->dtype, packed_weight->device);
-  out.CopyFromBytes(output_cpu.data(), output_cpu.size());
-  return out;
-});
+TVM_REGISTER_GLOBAL("cutlass.ft_preprocess_weight_int4")
+    .set_body_typed([](NDArray packed_weight, int sm) {
+      int rows = packed_weight->shape[0];
+      int cols = packed_weight->shape[1];
+      std::vector<int8_t> input_cpu(rows * cols);
+      std::vector<int8_t> output_cpu(rows * cols);
+      packed_weight.CopyToBytes(input_cpu.data(), input_cpu.size());
+      // multiply cols by 2 since the "col" params in preprocess_weights refers to the column of
+      // the unpacked weight.
+      fastertransformer::preprocess_weights(output_cpu.data(), input_cpu.data(), rows, cols * 2,
+                                            true /*is_int4*/ , sm);
+      auto out = NDArray::Empty(packed_weight.Shape(), packed_weight->dtype, packed_weight->device);
+      out.CopyFromBytes(output_cpu.data(), output_cpu.size());
+      return out;
+    });
 
 }  // namespace runtime
 }  // namespace tvm

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1438,6 +1438,183 @@ def test_fp16A_int4B_gemm():
     # print("ok")
 
 
+def test_fp16A_int4B_gemm_residual():
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def decode(
+            A: T.Buffer((T.int64(64), T.int64(64)), "int8"),
+            B: T.Buffer((T.int64(128),), "float16"),
+            decode_1: T.Buffer((T.int64(64), T.int64(128)), "float16"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            for i, j in T.grid(T.int64(64), T.int64(128)):
+                with T.block("decode"):
+                    v_i, v_j = T.axis.remap("SS", [i, j])
+                    T.reads(A[v_i, v_j // T.int64(2)], B[v_j])
+                    T.writes(decode_1[v_i, v_j])
+                    decode_1[v_i, v_j] = (
+                        T.Cast(
+                            "float16",
+                            T.shift_right(
+                                T.shift_left(
+                                    T.bitwise_and(
+                                        T.shift_right(
+                                            T.Cast("int32", A[v_i, v_j // T.int64(2)]),
+                                            T.Cast("int32", v_j % T.int64(2)) * 4,
+                                        ),
+                                        15,
+                                    ),
+                                    28,
+                                ),
+                                28,
+                            ),
+                        )
+                        * B[v_j]
+                    )
+
+        @T.prim_func
+        def encode(
+            A: T.Buffer((T.int64(128), T.int64(64)), "float16"),
+            w_gathered: T.Buffer((T.int64(64), T.int64(64)), "int8"),
+            compute: T.Buffer((T.int64(128),), "float16"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            max_abs_value = T.alloc_buffer((T.int64(128),), "float16")
+            scale = T.alloc_buffer((T.int64(128),))
+            for i, k in T.grid(T.int64(128), T.int64(64)):
+                with T.block("max_abs_value"):
+                    v_i, v_k = T.axis.remap("SR", [i, k])
+                    T.reads(A[v_i, v_k])
+                    T.writes(max_abs_value[v_i])
+                    with T.init():
+                        max_abs_value[v_i] = T.float16(-65504)
+                    max_abs_value[v_i] = T.max(max_abs_value[v_i], T.fabs(A[v_i, v_k]))
+            for i in range(T.int64(128)):
+                with T.block("scale"):
+                    v_i = T.axis.spatial(T.int64(128), i)
+                    T.reads(max_abs_value[v_i])
+                    T.writes(scale[v_i])
+                    scale[v_i] = T.max(
+                        T.Cast("float32", max_abs_value[v_i]), T.float32(0.0001)
+                    ) * T.float32(0.125)
+            for j, i, k in T.grid(T.int64(64), T.int64(64), T.int64(2)):
+                with T.block("w_gathered"):
+                    v_j, v_i, v_k = T.axis.remap("SSR", [j, i, k])
+                    T.reads(A[v_i * T.int64(2) + v_k, v_j], scale[v_i * T.int64(2) + v_k])
+                    T.writes(w_gathered[v_j, v_i])
+                    with T.init():
+                        w_gathered[v_j, v_i] = T.int8(0)
+                    w_gathered[v_j, v_i] = T.bitwise_or(
+                        w_gathered[v_j, v_i],
+                        T.if_then_else(
+                            v_i * T.int64(2) + v_k < T.int64(128),
+                            T.shift_left(
+                                T.bitwise_and(
+                                    T.Cast(
+                                        "int8",
+                                        T.min(
+                                            T.max(
+                                                T.round(
+                                                    T.Cast(
+                                                        "float32", A[v_i * T.int64(2) + v_k, v_j]
+                                                    )
+                                                    / scale[v_i * T.int64(2) + v_k]
+                                                ),
+                                                T.float32(-8),
+                                            ),
+                                            T.float32(7),
+                                        ),
+                                    ),
+                                    T.int8(15),
+                                ),
+                                T.Cast("int8", v_k) * T.int8(4),
+                            ),
+                            T.int8(0),
+                        ),
+                    )
+            for i0 in range(T.int64(128)):
+                with T.block("compute"):
+                    v_i0 = T.axis.spatial(T.int64(128), i0)
+                    T.reads(scale[v_i0])
+                    T.writes(compute[v_i0])
+                    compute[v_i0] = T.Cast("float16", scale[v_i0])
+
+        @R.function
+        def main(
+            x: R.Tensor((64, 64), dtype="float16"),
+            y: R.Tensor((128, 64), dtype="float16"),
+            bias: R.Tensor((1, 128), dtype="float16"),
+            residual: R.Tensor((64, 128), dtype="float16"),
+        ) -> R.Tensor((64, 128), dtype="float16"):
+            R.func_attr({"num_input": 1})
+            cls = Module
+            with R.dataflow():
+                lv = R.call_tir(
+                    cls.encode,
+                    (y,),
+                    out_sinfo=[R.Tensor((64, 64), dtype="int8"), R.Tensor((128,), dtype="float16")],
+                )
+                lv1 = lv[0]
+                lv2 = R.call_pure_packed(
+                    "cutlass.ft_preprocess_weight_int4",
+                    lv1,
+                    sinfo_args=(R.Tensor((64, 64), dtype="int8"),),
+                )
+                lv3: R.Tensor((128,), dtype="float16") = lv[1]
+                lv6 = R.call_tir(
+                    cls.decode, (lv2, lv3), out_sinfo=R.Tensor((64, 128), dtype="float16")
+                )
+                lv1_1: R.Tensor((64, 128), dtype="float16") = R.matmul(x, lv6, out_dtype="float16")
+                lv2_1: R.Tensor((64, 128), dtype="float16") = R.add(lv1_1, bias)
+                lv3_1: R.Tensor((64, 128), dtype="float16") = R.add(lv2_1, residual)
+                R.output(lv3_1)
+            return lv3_1
+
+    x_shape = (64, 64)
+    y_shape = (128, 64)
+
+    mod = partition_for_cutlass(Module)
+    print(mod)
+    # mod = relax.transform.RunCodegen(
+    #     {"cutlass": {"sm": 80, "find_first_valid": False}},
+    # )(mod)
+
+    # x = np.random.randn(*x_shape).astype("float16")
+    # y = np.random.normal(0, 0.002, size=y_shape).astype("float16")
+    # bias = np.random.randn(1, y_shape[0]).astype("float16")
+
+    # mod = relax.pipeline.get_pipeline()(mod)
+    # mod = relax.transform.LiftTransformParams()(mod)
+
+    # mod_transform, mod_deploy = split_transform_deploy_mod(mod)
+
+    # ex = relax.build(mod_transform, target="llvm")
+    # vm = relax.vm.VirtualMachine(ex, tvm.cpu(0))
+
+    # packed_weight, scales, bias_trans = vm["main_transform_params"](
+    #     (tvm.nd.array(y), tvm.nd.array(bias))
+    # )
+
+    # dev = tvm.device("cuda", 0)
+    # ex = relax.build(mod_deploy, target="cuda")
+    # vm = relax.vm.VirtualMachine(ex, dev)
+
+    # inp = [
+    #     tvm.nd.array(x, dev),
+    #     (packed_weight.copyto(dev), scales.copyto(dev), bias_trans.copyto(dev)),
+    # ]
+
+    # out = vm["main"](*inp).numpy()
+
+    # ref = np.dot(x, y.transpose()) + bias
+
+    # tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+    # print("ok")
+
+
 if __name__ == "__main__":
     # tvm.testing.main()
-    test_fp16A_int4B_gemm()
+    test_fp16A_int4B_gemm_residual()

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1383,7 +1383,7 @@ def test_fp16A_int4B_gemm():
                 )
                 lv1 = lv[0]
                 lv2 = R.call_pure_packed(
-                    "cutlass.ft_preprocess_weight",
+                    "cutlass.ft_preprocess_weight_int4",
                     lv1,
                     sinfo_args=(R.Tensor((64, 64), dtype="int8"),),
                 )

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1489,5 +1489,4 @@ def test_fp16A_int4B_gemm():
 
 
 if __name__ == "__main__":
-    # tvm.testing.main()
-    test_fp16A_int4B_gemm()
+    tvm.testing.main()

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1400,41 +1400,42 @@ def test_fp16A_int4B_gemm():
     y_shape = (128, 64)
 
     mod = partition_for_cutlass(Module)
-    mod = relax.transform.RunCodegen(
-        {"cutlass": {"sm": 80, "find_first_valid": False}},
-    )(mod)
+    print(mod)
+    # mod = relax.transform.RunCodegen(
+    #     {"cutlass": {"sm": 80, "find_first_valid": False}},
+    # )(mod)
 
-    x = np.random.randn(*x_shape).astype("float16")
-    y = np.random.normal(0, 0.002, size=y_shape).astype("float16")
-    bias = np.random.randn(1, y_shape[0]).astype("float16")
+    # x = np.random.randn(*x_shape).astype("float16")
+    # y = np.random.normal(0, 0.002, size=y_shape).astype("float16")
+    # bias = np.random.randn(1, y_shape[0]).astype("float16")
 
-    mod = relax.pipeline.get_pipeline()(mod)
-    mod = relax.transform.LiftTransformParams()(mod)
+    # mod = relax.pipeline.get_pipeline()(mod)
+    # mod = relax.transform.LiftTransformParams()(mod)
 
-    mod_transform, mod_deploy = split_transform_deploy_mod(mod)
+    # mod_transform, mod_deploy = split_transform_deploy_mod(mod)
 
-    ex = relax.build(mod_transform, target="llvm")
-    vm = relax.vm.VirtualMachine(ex, tvm.cpu(0))
+    # ex = relax.build(mod_transform, target="llvm")
+    # vm = relax.vm.VirtualMachine(ex, tvm.cpu(0))
 
-    packed_weight, scales, bias_trans = vm["main_transform_params"](
-        (tvm.nd.array(y), tvm.nd.array(bias))
-    )
+    # packed_weight, scales, bias_trans = vm["main_transform_params"](
+    #     (tvm.nd.array(y), tvm.nd.array(bias))
+    # )
 
-    dev = tvm.device("cuda", 0)
-    ex = relax.build(mod_deploy, target="cuda")
-    vm = relax.vm.VirtualMachine(ex, dev)
+    # dev = tvm.device("cuda", 0)
+    # ex = relax.build(mod_deploy, target="cuda")
+    # vm = relax.vm.VirtualMachine(ex, dev)
 
-    inp = [
-        tvm.nd.array(x, dev),
-        (packed_weight.copyto(dev), scales.copyto(dev), bias_trans.copyto(dev)),
-    ]
+    # inp = [
+    #     tvm.nd.array(x, dev),
+    #     (packed_weight.copyto(dev), scales.copyto(dev), bias_trans.copyto(dev)),
+    # ]
 
-    out = vm["main"](*inp).numpy()
+    # out = vm["main"](*inp).numpy()
 
-    ref = np.dot(x, y.transpose()) + bias
+    # ref = np.dot(x, y.transpose()) + bias
 
-    tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
-    print("ok")
+    # tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+    # print("ok")
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1250,5 +1250,193 @@ def test_attention_rewrite_fp16():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def split_transform_deploy_mod(mod):
+    mod_transform = tvm.IRModule()
+    mod_deploy = tvm.IRModule().with_attrs(mod.attrs)
+
+    for gv, func in mod.functions.items():
+        if gv.name_hint == "main_transform_params" or isinstance(func, tvm.tir.PrimFunc):
+            mod_transform[gv] = func
+        else:
+            mod_deploy[gv] = func
+
+    return mod_transform, mod_deploy
+
+
+def test_fp16A_int4B_gemm():
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def decode(
+            A: T.Buffer((T.int64(64), T.int64(64)), "int8"),
+            B: T.Buffer((T.int64(128),), "float16"),
+            decode_1: T.Buffer((T.int64(64), T.int64(128)), "float16"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            for i, j in T.grid(T.int64(64), T.int64(128)):
+                with T.block("decode"):
+                    v_i, v_j = T.axis.remap("SS", [i, j])
+                    T.reads(A[v_i, v_j // T.int64(2)], B[v_j])
+                    T.writes(decode_1[v_i, v_j])
+                    decode_1[v_i, v_j] = (
+                        T.Cast(
+                            "float16",
+                            T.shift_right(
+                                T.shift_left(
+                                    T.bitwise_and(
+                                        T.shift_right(
+                                            T.Cast("int32", A[v_i, v_j // T.int64(2)]),
+                                            T.Cast("int32", v_j % T.int64(2)) * 4,
+                                        ),
+                                        15,
+                                    ),
+                                    28,
+                                ),
+                                28,
+                            ),
+                        )
+                        * B[v_j]
+                    )
+
+        @T.prim_func
+        def encode(
+            A: T.Buffer((T.int64(128), T.int64(64)), "float16"),
+            w_gathered: T.Buffer((T.int64(64), T.int64(64)), "int8"),
+            compute: T.Buffer((T.int64(128),), "float16"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            max_abs_value = T.alloc_buffer((T.int64(128),), "float16")
+            scale = T.alloc_buffer((T.int64(128),))
+            for i, k in T.grid(T.int64(128), T.int64(64)):
+                with T.block("max_abs_value"):
+                    v_i, v_k = T.axis.remap("SR", [i, k])
+                    T.reads(A[v_i, v_k])
+                    T.writes(max_abs_value[v_i])
+                    with T.init():
+                        max_abs_value[v_i] = T.float16(-65504)
+                    max_abs_value[v_i] = T.max(max_abs_value[v_i], T.fabs(A[v_i, v_k]))
+            for i in range(T.int64(128)):
+                with T.block("scale"):
+                    v_i = T.axis.spatial(T.int64(128), i)
+                    T.reads(max_abs_value[v_i])
+                    T.writes(scale[v_i])
+                    scale[v_i] = T.max(
+                        T.Cast("float32", max_abs_value[v_i]), T.float32(0.0001)
+                    ) * T.float32(0.125)
+            for j, i, k in T.grid(T.int64(64), T.int64(64), T.int64(2)):
+                with T.block("w_gathered"):
+                    v_j, v_i, v_k = T.axis.remap("SSR", [j, i, k])
+                    T.reads(A[v_i * T.int64(2) + v_k, v_j], scale[v_i * T.int64(2) + v_k])
+                    T.writes(w_gathered[v_j, v_i])
+                    with T.init():
+                        w_gathered[v_j, v_i] = T.int8(0)
+                    w_gathered[v_j, v_i] = T.bitwise_or(
+                        w_gathered[v_j, v_i],
+                        T.if_then_else(
+                            v_i * T.int64(2) + v_k < T.int64(128),
+                            T.shift_left(
+                                T.bitwise_and(
+                                    T.Cast(
+                                        "int8",
+                                        T.min(
+                                            T.max(
+                                                T.round(
+                                                    T.Cast(
+                                                        "float32", A[v_i * T.int64(2) + v_k, v_j]
+                                                    )
+                                                    / scale[v_i * T.int64(2) + v_k]
+                                                ),
+                                                T.float32(-8),
+                                            ),
+                                            T.float32(7),
+                                        ),
+                                    ),
+                                    T.int8(15),
+                                ),
+                                T.Cast("int8", v_k) * T.int8(4),
+                            ),
+                            T.int8(0),
+                        ),
+                    )
+            for i0 in range(T.int64(128)):
+                with T.block("compute"):
+                    v_i0 = T.axis.spatial(T.int64(128), i0)
+                    T.reads(scale[v_i0])
+                    T.writes(compute[v_i0])
+                    compute[v_i0] = T.Cast("float16", scale[v_i0])
+
+        @R.function
+        def main(
+            x: R.Tensor((64, 64), dtype="float16"),
+            y: R.Tensor((128, 64), dtype="float16"),
+            bias: R.Tensor((1, 128), dtype="float16"),
+        ) -> R.Tensor((64, 128), dtype="float16"):
+            R.func_attr({"num_input": 1})
+            cls = Module
+            with R.dataflow():
+                lv = R.call_tir(
+                    cls.encode,
+                    (y,),
+                    out_sinfo=[R.Tensor((64, 64), dtype="int8"), R.Tensor((128,), dtype="float16")],
+                )
+                lv1 = lv[0]
+                lv2 = R.call_pure_packed(
+                    "cutlass.ft_preprocess_weight",
+                    lv1,
+                    sinfo_args=(R.Tensor((64, 64), dtype="int8"),),
+                )
+                lv3: R.Tensor((128,), dtype="float16") = lv[1]
+                lv6 = R.call_tir(
+                    cls.decode, (lv2, lv3), out_sinfo=R.Tensor((64, 128), dtype="float16")
+                )
+                lv1_1: R.Tensor((64, 128), dtype="float16") = R.matmul(x, lv6, out_dtype="float16")
+                lv2_1: R.Tensor((64, 128), dtype="float16") = R.add(lv1_1, bias)
+                R.output(lv2_1)
+            return lv2_1
+
+    x_shape = (64, 64)
+    y_shape = (128, 64)
+
+    mod = partition_for_cutlass(Module)
+    mod = relax.transform.RunCodegen(
+        {"cutlass": {"sm": 80, "find_first_valid": False}},
+    )(mod)
+
+    x = np.random.randn(*x_shape).astype("float16")
+    y = np.random.normal(0, 0.002, size=y_shape).astype("float16")
+    bias = np.random.randn(1, y_shape[0]).astype("float16")
+
+    mod = relax.pipeline.get_pipeline()(mod)
+    mod = relax.transform.LiftTransformParams()(mod)
+
+    mod_transform, mod_deploy = split_transform_deploy_mod(mod)
+
+    ex = relax.build(mod_transform, target="llvm")
+    vm = relax.vm.VirtualMachine(ex, tvm.cpu(0))
+
+    packed_weight, scales, bias_trans = vm["main_transform_params"](
+        (tvm.nd.array(y), tvm.nd.array(bias))
+    )
+
+    dev = tvm.device("cuda", 0)
+    ex = relax.build(mod_deploy, target="cuda")
+    vm = relax.vm.VirtualMachine(ex, dev)
+
+    inp = [
+        tvm.nd.array(x, dev),
+        (packed_weight.copyto(dev), scales.copyto(dev), bias_trans.copyto(dev)),
+    ]
+
+    out = vm["main"](*inp).numpy()
+
+    ref = np.dot(x, y.transpose()) + bias
+
+    tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+    print("ok")
+
+
 if __name__ == "__main__":
-    tvm.testing.main()
+    # tvm.testing.main()
+    test_fp16A_int4B_gemm()


### PR DESCRIPTION
This PR integrates the kernel from https://github.com/tlc-pack/cutlass_fpA_intB_gemm. In addition to the original features in FasterTransformer, this derived implementation also supports residual fusion by https://github.com/tlc-pack/cutlass_fpA_intB_gemm/pull/1. 

* It only supports int4 weight for now, while the kernel supports int8 as well. 
* The kernel expects a simple symmetric quantization scheme where each column of `(K, N)` matrix is scaled by the corresponding element from a scale vector of shape `(N,)`. Each scale is calculated over the K axis.
* The weight matrix needs to be packed into int8 storage with shape `(K, N / 2)`. 
* The packed weight needs to be preprocessed by a special function defined in `contrib/cutlass/weight_preprocess.cc`, which in turn does various preprocessings on the weight implemented in https://github.com/tlc-pack/cutlass_fpA_intB_gemm/blob/main/cutlass_kernels/cutlass_preprocessors.cc. These processes are not well documented, so we wrap them into a packed function and use it as a black box. 

The test case demonstrates the overall integration flow. It is interesting to note that, although encode / decode functions are expressed as TIR, we can still use the graph-based BYOC to integrate this kernel.

@sunggg @yelite @vinx13 @Hzfengsy @yzh119 