### PR TITLE
[microNPU] Upgrade Vela to v3.8.0

### DIFF
--- a/apps/microtvm/cmsisnn/requirements.txt
+++ b/apps/microtvm/cmsisnn/requirements.txt
@@ -7,8 +7,8 @@ cloudpickle==2.0.0 \
 decorator==5.1.0 \
     --hash=sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374 \
     --hash=sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7
-ethos-u-vela==3.7.0 \
-    --hash=sha256:314b761e171d19bf03e141684f9a371af7bf830f739b9b2f90b5f303a7fb1203
+ethos-u-vela==3.8.0 \
+    --hash=sha256:cb0b1f5b1f886242d67ff0072efb88ac90cc87574ebe92fc98db4609f7797acf
 flatbuffers==2.0.7 \
     --hash=sha256:0ae7d69c5b82bf41962ca5fde9cc43033bc9501311d975fd5a25e8a7d29c1245 \
     --hash=sha256:71e135d533be527192819aaab757c5e3d109cb10fbb01e687f6bdb7a61ad39d1

--- a/apps/microtvm/ethosu/requirements.txt
+++ b/apps/microtvm/ethosu/requirements.txt
@@ -7,8 +7,8 @@ cloudpickle==2.0.0 \
 decorator==5.1.0 \
     --hash=sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374 \
     --hash=sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7
-ethos-u-vela==3.7.0 \
-    --hash=sha256:314b761e171d19bf03e141684f9a371af7bf830f739b9b2f90b5f303a7fb1203
+ethos-u-vela==3.8.0 \
+    --hash=sha256:cb0b1f5b1f886242d67ff0072efb88ac90cc87574ebe92fc98db4609f7797acf
 flatbuffers==2.0.7 \
     --hash=sha256:0ae7d69c5b82bf41962ca5fde9cc43033bc9501311d975fd5a25e8a7d29c1245 \
     --hash=sha256:71e135d533be527192819aaab757c5e3d109cb10fbb01e687f6bdb7a61ad39d1

--- a/docker/install/ubuntu_install_vela.sh
+++ b/docker/install/ubuntu_install_vela.sh
@@ -20,4 +20,4 @@ set -e
 set -u
 set -o pipefail
 
-pip3 install ethos-u-vela==3.7.0 numpy==1.23.*
+pip3 install ethos-u-vela==3.8.0 numpy==1.23.*

--- a/gallery/how_to/work_with_microtvm/micro_ethosu.py
+++ b/gallery/how_to/work_with_microtvm/micro_ethosu.py
@@ -84,7 +84,7 @@ TVM to offload operators to the Ethos(TM)-U55 where possible.
 #     attrs==21.2.0
 #     cloudpickle==2.0.0
 #     decorator==5.1.0
-#     ethos-u-vela==3.7.0
+#     ethos-u-vela==3.8.0
 #     flatbuffers==2.0.7
 #     lxml==4.6.3
 #     nose==1.3.7

--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -247,7 +247,7 @@ CONSTRAINTS = [
         "docutils",
         "<0.17",
     ),  # Work around https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
-    ("ethos-u-vela", "==3.7.0"),
+    ("ethos-u-vela", "==3.8.0"),
     ("future", None),
     ("h5py", "==2.10.0"),
     ("image", None),


### PR DESCRIPTION
Upgrading ethos-u-vela version to 3.8.0.

cc @neildhickey, @lhutton1, @ekalda, @leandron