### PR TITLE
[FRONTEND][TFLITE] Add support for TFLite's regular NMS operator

### DIFF
--- a/include/tvm/relay/attrs/vision.h
+++ b/include/tvm/relay/attrs/vision.h
@@ -146,12 +146,9 @@ struct RegularNonMaximumSuppressionAttrs
                     "relay.attrs.RegularNonMaximumSuppressionAttrs") {
     TVM_ATTR_FIELD(max_detections_per_class)
         .describe("The maxinum number of output selected boxes per class.");
-    TVM_ATTR_FIELD(max_detections)
-        .describe("The maxinum number of output selected boxes.");
-    TVM_ATTR_FIELD(num_classes)
-        .describe("The number of classes without background.");
-    TVM_ATTR_FIELD(iou_threshold)
-        .describe("The IoU threshold for box the overlap test.");
+    TVM_ATTR_FIELD(max_detections).describe("The maxinum number of output selected boxes.");
+    TVM_ATTR_FIELD(num_classes).describe("The number of classes without background.");
+    TVM_ATTR_FIELD(iou_threshold).describe("The IoU threshold for box the overlap test.");
     TVM_ATTR_FIELD(score_threshold)
         .describe("Score threshold to filter out low score boxes early.");
   }

--- a/include/tvm/relay/attrs/vision.h
+++ b/include/tvm/relay/attrs/vision.h
@@ -61,6 +61,7 @@ struct MultiBoxTransformLocAttrs : public tvm::AttrsNode<MultiBoxTransformLocAtt
   bool clip;
   double threshold;
   Array<IndexExpr> variances;
+  bool keep_background;
 
   TVM_DECLARE_ATTRS(MultiBoxTransformLocAttrs, "relay.attrs.MultiBoxTransformLocAttrs") {
     TVM_ATTR_FIELD(clip).set_default(true).describe("Clip out-of-boundary boxes.");
@@ -68,6 +69,9 @@ struct MultiBoxTransformLocAttrs : public tvm::AttrsNode<MultiBoxTransformLocAtt
     TVM_ATTR_FIELD(variances)
         .set_default(Array<IndexExpr>({0.1f, 0.1f, 0.2f, 0.2f}))
         .describe("Variances to be decoded from box regression output.");
+    TVM_ATTR_FIELD(keep_background)
+        .set_default(false)
+        .describe("Whether to keep boxes detected as background or not");
   }
 };
 
@@ -126,6 +130,30 @@ struct AllClassNonMaximumSuppressionAttrs
         .describe(
             "Output format, onnx or tensorflow. Returns outputs in a way that can be easily "
             "consumed by each frontend.");
+  }
+};
+
+/*! \brief Attributes used in regular_non_maximum_suppression operator */
+struct RegularNonMaximumSuppressionAttrs
+    : public tvm::AttrsNode<RegularNonMaximumSuppressionAttrs> {
+  int32_t max_detections_per_class;
+  int32_t max_detections;
+  int32_t num_classes;
+  double iou_threshold;
+  double score_threshold;
+
+  TVM_DECLARE_ATTRS(RegularNonMaximumSuppressionAttrs,
+                    "relay.attrs.RegularNonMaximumSuppressionAttrs") {
+    TVM_ATTR_FIELD(max_detections_per_class)
+        .describe("The maxinum number of output selected boxes per class.");
+    TVM_ATTR_FIELD(max_detections)
+        .describe("The maxinum number of output selected boxes.");
+    TVM_ATTR_FIELD(num_classes)
+        .describe("The number of classes without background.");
+    TVM_ATTR_FIELD(iou_threshold)
+        .describe("The IoU threshold for box the overlap test.");
+    TVM_ATTR_FIELD(score_threshold)
+        .describe("Score threshold to filter out low score boxes early.");
   }
 };
 

--- a/python/tvm/relay/op/vision/_vision.py
+++ b/python/tvm/relay/op/vision/_vision.py
@@ -48,6 +48,9 @@ reg.register_pattern("vision.non_max_suppression", OpPattern.OPAQUE)
 reg.register_strategy("vision.all_class_non_max_suppression", strategy.all_class_nms_strategy)
 reg.register_pattern("vision.all_class_non_max_suppression", OpPattern.OPAQUE)
 
+reg.register_strategy("vision.regular_non_max_suppression", strategy.regular_nms_strategy)
+reg.register_pattern("vision.regular_non_max_suppression", OpPattern.OPAQUE)
+
 
 @script
 def _get_valid_counts_shape_func(data_shape):
@@ -120,6 +123,33 @@ def all_class_nms_shape_func(attrs, inputs, _):
     if attrs.output_format == "onnx":
         return _all_class_nms_shape_func_onnx(inputs[0], inputs[1])
     return _all_class_nms_shape_func_tf(inputs[0], inputs[1])
+
+
+@script
+def _regular_nms_shape_func(boxes_shape, scores_shape, attrs):
+    out_boxes_shape = output_tensor((3,), "int64")
+    out_classes_shape = output_tensor((2,), "int64")
+    out_scores_shape = output_tensor((2,), "int64")
+    out_num_detections_shape = output_tensor((1,), "int64")
+
+    out_boxes_shape[0] = boxes_shape[0]
+    out_boxes_shape[1] = int64(attrs.max_detections)
+    out_boxes_shape[2] = int64(4)
+
+    out_classes_shape[0] = boxes_shape[0]
+    out_classes_shape[1] = int64(attrs.max_detections)
+
+    out_scores_shape[0] = boxes_shape[0]
+    out_scores_shape[1] = int64(attrs.max_detections)
+
+    out_num_detections_shape[0] = int64(1)
+
+    return out_boxes_shape, out_classes_shape, out_scores_shape, out_num_detections_shape
+
+
+@reg.register_shape_func("vision.regular_non_max_suppression", False)
+def regular_nms_shape_func(attrs, inputs, _):
+    return _regular_nms_shape_func(inputs[0], inputs[1], attrs)
 
 
 @script

--- a/python/tvm/relay/op/vision/_vision.py
+++ b/python/tvm/relay/op/vision/_vision.py
@@ -142,7 +142,7 @@ def _regular_nms_shape_func(boxes_shape, scores_shape, attrs):
     out_scores_shape[0] = boxes_shape[0]
     out_scores_shape[1] = int64(attrs.max_detections)
 
-    out_num_detections_shape[0] = int64(1)
+    out_num_detections_shape[0] = boxes_shape[0]
 
     return out_boxes_shape, out_classes_shape, out_scores_shape, out_num_detections_shape
 

--- a/python/tvm/relay/op/vision/multibox.py
+++ b/python/tvm/relay/op/vision/multibox.py
@@ -53,7 +53,13 @@ def multibox_prior(
 
 
 def multibox_transform_loc(
-    cls_prob, loc_pred, anchor, clip=True, threshold=0.01, variances=(0.1, 0.1, 0.2, 0.2)
+    cls_prob,
+    loc_pred,
+    anchor,
+    clip=True,
+    threshold=0.01,
+    variances=(0.1, 0.1, 0.2, 0.2),
+    keep_background=False,
 ):
     """Location transformation for multibox detection
 
@@ -77,10 +83,22 @@ def multibox_transform_loc(
     variances : Tuple of float, optional
         variances to be decoded from box regression output.
 
+    keep_background : boolean, optional
+        Whether to keep boxes detected as background or not.
+
     Returns
     -------
     ret : tuple of tvm.relay.Expr
     """
     return expr.TupleWrapper(
-        _make.multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, variances), 2
+        _make.multibox_transform_loc(
+            cls_prob,
+            loc_pred,
+            anchor,
+            clip,
+            threshold,
+            variances,
+            keep_background,
+        ),
+        2,
     )

--- a/python/tvm/relay/op/vision/nms.py
+++ b/python/tvm/relay/op/vision/nms.py
@@ -226,3 +226,62 @@ def all_class_non_max_suppression(
         return expr.TupleWrapper(out, 2)
 
     return expr.TupleWrapper(out, 3)
+
+
+def regular_non_max_suppression(
+    boxes,
+    scores,
+    max_detections_per_class,
+    max_detections,
+    num_classes,
+    iou_threshold,
+    score_threshold,
+):
+    """Regular non-maximum suppression operator for object detection, corresponding to TFLite's
+    regular NMS. NMS is performed for each class separately.
+
+    Parameters
+    ----------
+    boxes : relay.Expr
+        3-D tensor with shape (batch_size, num_boxes, 4). The four values in boxes
+        encode (ymin, xmin, ymax, xmax) coordinates of a box
+
+    scores: relay.Expr
+        3-D tensor with shape (batch_size, num_boxes, num_classes_with_background)
+
+    max_detections_per_class : int
+        The maxinum number of output selected boxes per class
+
+    max_detections : int
+        The maxinum number of output selected boxes
+
+    num_classes : int
+        The number of classes without background
+
+    iou_threshold : float
+        IoU test threshold
+
+    score_threshold : float
+        Score threshold to filter out low score boxes early
+
+    Returns
+    -------
+    out : relay.Tuple
+        The output is a relay.Tuple of four tensors. The first is `detection_boxes` of size
+        `(batch_size, max_detections , 4)`, the second is `detection_classes` of size
+        `(batch_size, max_detections)`, the third is `detection_scores` of size
+        `(batch_size, max_detections)`, and the fourth is `num_detections` of size `(batch_size,)`
+        representing the total number of selected boxes per batch.
+    """
+    return expr.TupleWrapper(
+        _make.regular_non_max_suppression(
+            boxes,
+            scores,
+            max_detections_per_class,
+            max_detections,
+            num_classes,
+            iou_threshold,
+            score_threshold,
+        ),
+        4,
+    )

--- a/python/tvm/topi/cuda/ssd/multibox.py
+++ b/python/tvm/topi/cuda/ssd/multibox.py
@@ -364,7 +364,7 @@ def transform_loc_ir(
             with ib.if_scope(j == 0):
                 out_base_idx = i * num_anchors * 6
                 out_loc[out_base_idx] = (
-                    float(cls_id[tid]) if keep_background == 1 else cls_id[tid] - 1.0
+                    cls_id[tid] * 1.0 if keep_background == 1 else cls_id[tid] - 1.0
                 )
                 out_loc[out_base_idx + 1] = score[tid]
                 (
@@ -386,7 +386,7 @@ def transform_loc_ir(
             with ib.else_scope():
                 out_base_idx = i * num_anchors * 6 + temp_valid_count[tid - 1] * 6
                 out_loc[out_base_idx] = (
-                    float(cls_id[tid]) if keep_background == 1 else cls_id[tid] - 1.0
+                    cls_id[tid] * 1.0 if keep_background == 1 else cls_id[tid] - 1.0
                 )
                 out_loc[out_base_idx + 1] = score[tid]
                 (

--- a/python/tvm/topi/cuda/ssd/multibox.py
+++ b/python/tvm/topi/cuda/ssd/multibox.py
@@ -223,15 +223,13 @@ def transform_loc_pre(
     idxd = tvm.tir.indexdiv
     idxm = tvm.tir.indexmod
 
-    start_cls_idx = 0 if keep_background == 1 else 1
-
     with ib.if_scope(tid < batch_size * num_anchors):
         i = idxd(tid, num_anchors)
         j = idxm(tid, num_anchors)
         valid_count[i] = 0
         score[tid] = -1.0
         cls_id[tid] = 0
-        with ib.for_range(start_cls_idx, num_classes) as k:
+        with ib.for_range(0, num_classes) as k:
             temp = cls_prob[i * num_classes * num_anchors + k * num_anchors + j]
             cls_id[tid] = if_then_else(temp > score[tid], k, cls_id[tid])
             score[tid] = tvm.te.max(temp, score[tid])

--- a/python/tvm/topi/cuda/ssd/multibox.py
+++ b/python/tvm/topi/cuda/ssd/multibox.py
@@ -363,9 +363,7 @@ def transform_loc_ir(
         with ib.if_scope(tvm.tir.any(keep_background == 1, cls_id[tid] > 0)):
             with ib.if_scope(j == 0):
                 out_base_idx = i * num_anchors * 6
-                out_loc[out_base_idx] = (
-                    cls_id[tid] - 0.0 if keep_background == 1 else cls_id[tid] - 1.0
-                )
+                out_loc[out_base_idx] = cls_id[tid] if keep_background == 1 else cls_id[tid] - 1.0
                 out_loc[out_base_idx + 1] = score[tid]
                 (
                     out_loc[out_base_idx + 2],
@@ -385,9 +383,7 @@ def transform_loc_ir(
                 )
             with ib.else_scope():
                 out_base_idx = i * num_anchors * 6 + temp_valid_count[tid - 1] * 6
-                out_loc[out_base_idx] = (
-                    cls_id[tid] - 0.0 if keep_background == 1 else cls_id[tid] - 1.0
-                )
+                out_loc[out_base_idx] = cls_id[tid] if keep_background == 1 else cls_id[tid] - 1.0
                 out_loc[out_base_idx + 1] = score[tid]
                 (
                     out_loc[out_base_idx + 2],

--- a/python/tvm/topi/cuda/ssd/multibox.py
+++ b/python/tvm/topi/cuda/ssd/multibox.py
@@ -158,7 +158,15 @@ def multibox_prior(data, sizes=(1,), ratios=(1,), steps=(-1, -1), offsets=(0.5, 
     return out
 
 
-def transform_loc_pre(cls_prob, valid_count, temp_valid_count, temp_cls_id, temp_score, threshold):
+def transform_loc_pre(
+    cls_prob,
+    valid_count,
+    temp_valid_count,
+    temp_cls_id,
+    temp_score,
+    threshold,
+    keep_background,
+):
     """Low level IR routing for transform location data preparation.
 
     Parameters
@@ -181,6 +189,9 @@ def transform_loc_pre(cls_prob, valid_count, temp_valid_count, temp_cls_id, temp
     threshold : float
         Threshold to be a positive prediction.
 
+    keep_background : int
+        1 to keep background, 0 to remove it.
+
     Returns
     -------
     stmt : Stmt
@@ -199,6 +210,7 @@ def transform_loc_pre(cls_prob, valid_count, temp_valid_count, temp_cls_id, temp
     score = ib.buffer_ptr(temp_score)
 
     threshold = tvm.tir.FloatImm("float32", threshold)
+    keep_background = tvm.tir.IntImm("int8", keep_background)
 
     max_threads = int(tvm.target.Target.current(allow_none=False).max_num_threads)
     nthread_tx = max_threads
@@ -218,12 +230,16 @@ def transform_loc_pre(cls_prob, valid_count, temp_valid_count, temp_cls_id, temp
         score[tid] = -1.0
         cls_id[tid] = 0
         with ib.for_range(0, num_classes - 1) as k:
-            temp = cls_prob[i * num_classes * num_anchors + (k + 1) * num_anchors + j]
-            cls_id[tid] = if_then_else(temp > score[tid], k + 1, cls_id[tid])
+            with ib.if_scope(keep_background == 1):
+                temp = cls_prob[i * num_classes * num_anchors + k * num_anchors + j]
+                cls_id[tid] = if_then_else(temp > score[tid], k, cls_id[tid])
+            with ib.else_scope():
+                temp = cls_prob[i * num_classes * num_anchors + (k + 1) * num_anchors + j]
+                cls_id[tid] = if_then_else(temp > score[tid], k + 1, cls_id[tid])
             score[tid] = tvm.te.max(temp, score[tid])
         with ib.if_scope(tvm.tir.all(cls_id[tid] > 0, score[tid] < threshold)):
             cls_id[tid] = 0
-        with ib.if_scope(cls_id[tid] > 0):
+        with ib.if_scope(tvm.tir.any(keep_background == 1, cls_id[tid] > 0)):
             temp_valid_count[tid] = 1
         with ib.else_scope():
             temp_valid_count[tid] = 0
@@ -250,6 +266,7 @@ def transform_loc_ir(
     variances,
     batch_size,
     num_anchors,
+    keep_background,
 ):
     """Low level IR routing for transform location in multibox_detection operator.
 
@@ -284,6 +301,9 @@ def transform_loc_ir(
 
     num_anchors : int
         Number of anchors
+
+    keep_background : int
+        1 to keep background, 0 to remove it.
 
     Returns
     -------
@@ -325,6 +345,8 @@ def transform_loc_ir(
     score = ib.buffer_ptr(temp_score)
     out_loc = ib.buffer_ptr(out)
 
+    keep_background = tvm.tir.IntImm("int8", keep_background)
+
     max_threads = int(tvm.target.Target.current(allow_none=False).max_num_threads)
     nthread_tx = max_threads
     nthread_bx = (batch_size * num_anchors) // max_threads + 1
@@ -341,7 +363,7 @@ def transform_loc_ir(
         i = idxd(tid, num_anchors)
         j = idxm(tid, num_anchors)
 
-        with ib.if_scope(cls_id[tid] > 0):
+        with ib.if_scope(tvm.tir.any(keep_background == 1, cls_id[tid] > 0)):
             with ib.if_scope(j == 0):
                 out_base_idx = i * num_anchors * 6
                 out_loc[out_base_idx] = cls_id[tid] - 1.0
@@ -387,7 +409,13 @@ def transform_loc_ir(
 
 
 def multibox_transform_loc(
-    cls_prob, loc_pred, anchor, clip=True, threshold=0.01, variances=(0.1, 0.1, 0.2, 0.2)
+    cls_prob,
+    loc_pred,
+    anchor,
+    clip=True,
+    threshold=0.01,
+    variances=(0.1, 0.1, 0.2, 0.2),
+    keep_background=False,
 ):
     """Location transformation for multibox detection
 
@@ -410,6 +438,9 @@ def multibox_transform_loc(
 
     variances : tuple of float
         Variances to be decoded from box regression output.
+
+    keep_background : boolean
+        Whether to keep boxes detected as background or not.
 
     Returns
     -------
@@ -481,7 +512,15 @@ def multibox_transform_loc(
             ),
         ],
         [cls_prob],
-        lambda ins, outs: transform_loc_pre(ins[0], outs[0], outs[1], outs[2], outs[3], threshold),
+        lambda ins, outs: transform_loc_pre(
+            ins[0],
+            outs[0],
+            outs[1],
+            outs[2],
+            outs[3],
+            threshold,
+            int(keep_background),
+        ),
         dtype=[valid_count_dtype, valid_count_dtype, valid_count_dtype, cls_prob.dtype],
         out_buffers=[valid_count_buf, temp_valid_count_buf, temp_cls_id_buf, temp_score_buf],
         tag="multibox_transform_loc_phase_one",
@@ -501,6 +540,7 @@ def multibox_transform_loc(
             variances,
             batch_size,
             num_anchors,
+            int(keep_background),
         ),
         in_buffers=[
             loc_pred_buf,

--- a/python/tvm/topi/cuda/ssd/multibox.py
+++ b/python/tvm/topi/cuda/ssd/multibox.py
@@ -363,7 +363,9 @@ def transform_loc_ir(
         with ib.if_scope(tvm.tir.any(keep_background == 1, cls_id[tid] > 0)):
             with ib.if_scope(j == 0):
                 out_base_idx = i * num_anchors * 6
-                out_loc[out_base_idx] = cls_id[tid] if keep_background == 1 else cls_id[tid] - 1.0
+                out_loc[out_base_idx] = (
+                    float(cls_id[tid]) if keep_background == 1 else cls_id[tid] - 1.0
+                )
                 out_loc[out_base_idx + 1] = score[tid]
                 (
                     out_loc[out_base_idx + 2],
@@ -383,7 +385,9 @@ def transform_loc_ir(
                 )
             with ib.else_scope():
                 out_base_idx = i * num_anchors * 6 + temp_valid_count[tid - 1] * 6
-                out_loc[out_base_idx] = cls_id[tid] if keep_background == 1 else cls_id[tid] - 1.0
+                out_loc[out_base_idx] = (
+                    float(cls_id[tid]) if keep_background == 1 else cls_id[tid] - 1.0
+                )
                 out_loc[out_base_idx + 1] = score[tid]
                 (
                     out_loc[out_base_idx + 2],

--- a/python/tvm/topi/vision/ssd/multibox.py
+++ b/python/tvm/topi/vision/ssd/multibox.py
@@ -137,7 +137,7 @@ def multibox_prior(data, sizes=(1,), ratios=(1,), steps=(-1, -1), offsets=(0.5, 
 
 
 @hybrid.script
-def _hybridy_transform_loc(anchor, pred_loc, variance, clip, batch_idx, anchor_idx):
+def _hybrid_transform_loc(anchor, pred_loc, variance, clip, batch_idx, anchor_idx):
     """Transform prior anchor box to output box through location predictions."""
     al = anchor[0, anchor_idx, 0]
     at = anchor[0, anchor_idx, 1]
@@ -172,7 +172,15 @@ def _hybridy_transform_loc(anchor, pred_loc, variance, clip, batch_idx, anchor_i
 
 
 @hybrid.script
-def hybrid_multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, variances):
+def hybrid_multibox_transform_loc(
+    cls_prob,
+    loc_pred,
+    anchor,
+    clip,
+    threshold,
+    variances,
+    keep_background,
+):
     """Hybrid routing for transform location in multibox_detection operator.
 
     Parameters
@@ -194,6 +202,9 @@ def hybrid_multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, v
 
     variances : tvm.nd.NDArray
         Variances to be decoded from box regression output.
+
+    keep_background : tvm.tir.const
+        Whether to keep boxes detected as background or not.
 
     Returns
     -------
@@ -223,7 +234,7 @@ def hybrid_multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, v
             score = -1.0
             cls_id = 0
             for k in range(num_classes):
-                if k > 0:
+                if keep_background or k > 0:
                     temp = cls_prob[i, k, j]
                     cls_id = k if temp > score else cls_id
                     score = max(temp, score)
@@ -231,12 +242,12 @@ def hybrid_multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, v
                 cls_id = 0
             # [id, prob, xmin, ymin, xmax, ymax]
             # Remove background, restore original id
-            if cls_id > 0:
+            if keep_background or cls_id > 0:
                 out_loc[i, valid_count[i], 0] = cls_id - 1.0
                 out_loc[i, valid_count[i], 1] = score
                 for l in range(4):
                     pred_coord[i, l] = loc_pred[i, j * 4 + l]
-                out_coord = _hybridy_transform_loc(anchor, pred_coord, variances, clip, i, j)
+                out_coord = _hybrid_transform_loc(anchor, pred_coord, variances, clip, i, j)
                 out_loc[i, valid_count[i], 2] = out_coord[0]
                 out_loc[i, valid_count[i], 3] = out_coord[1]
                 out_loc[i, valid_count[i], 4] = out_coord[2]
@@ -247,7 +258,13 @@ def hybrid_multibox_transform_loc(cls_prob, loc_pred, anchor, clip, threshold, v
 
 
 def multibox_transform_loc(
-    cls_prob, loc_pred, anchor, clip=True, threshold=0.01, variances=(0.1, 0.1, 0.2, 0.2)
+    cls_prob,
+    loc_pred,
+    anchor,
+    clip=True,
+    threshold=0.01,
+    variances=(0.1, 0.1, 0.2, 0.2),
+    keep_background=False,
 ):
     """Location transformation for multibox detection
 
@@ -271,10 +288,14 @@ def multibox_transform_loc(
     variances : tuple of float
         Variances to be decoded from box regression output.
 
+    keep_background : boolean
+        Whether to keep boxes detected as background or not.
+
     Returns
     -------
     ret : tuple of tvm.te.Tensor
     """
+
     return hybrid_multibox_transform_loc(
         cls_prob,
         loc_pred,
@@ -282,6 +303,7 @@ def multibox_transform_loc(
         tvm.tir.const(clip, "bool"),
         tvm.tir.const(threshold, "float32"),
         tvm.runtime.convert(variances),
+        tvm.tir.const(keep_background, "bool"),
     )
 
 

--- a/python/tvm/topi/vision/ssd/multibox.py
+++ b/python/tvm/topi/vision/ssd/multibox.py
@@ -243,7 +243,7 @@ def hybrid_multibox_transform_loc(
             # [id, prob, xmin, ymin, xmax, ymax]
             # Remove background, restore original id
             if keep_background or cls_id > 0:
-                out_loc[i, valid_count[i], 0] = cls_id - 1.0
+                out_loc[i, valid_count[i], 0] = cls_id - 0.0 if keep_background else cls_id - 1.0
                 out_loc[i, valid_count[i], 1] = score
                 for l in range(4):
                     pred_coord[i, l] = loc_pred[i, j * 4 + l]

--- a/src/relay/op/vision/multibox_op.cc
+++ b/src/relay/op/vision/multibox_op.cc
@@ -116,11 +116,12 @@ bool MultiBoxTransformLocRel(const Array<Type>& types, int num_inputs, const Att
 }
 
 Expr MakeMultiBoxTransformLoc(Expr cls_prob, Expr loc_pred, Expr anchor, bool clip,
-                              double threshold, Array<IndexExpr> variances) {
+                              double threshold, Array<IndexExpr> variances, bool keep_background) {
   auto attrs = make_object<MultiBoxTransformLocAttrs>();
   attrs->clip = std::move(clip);
   attrs->threshold = std::move(threshold);
   attrs->variances = std::move(variances);
+  attrs->keep_background = std::move(keep_background);
   static const Op& op = Op::Get("vision.multibox_transform_loc");
   return Call(op, {cls_prob, loc_pred, anchor}, Attrs(attrs), {});
 }

--- a/src/relay/op/vision/nms.cc
+++ b/src/relay/op/vision/nms.cc
@@ -245,8 +245,8 @@ bool RegularNMSRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
 }
 
 Expr MakeRegularNMS(Expr boxes, Expr scores, int32_t max_detections_per_class,
-                    int32_t max_detections, int32_t num_classes,
-                    double iou_threshold, double score_threshold) {
+                    int32_t max_detections, int32_t num_classes, double iou_threshold,
+                    double score_threshold) {
   auto attrs = make_object<RegularNonMaximumSuppressionAttrs>();
   attrs->max_detections_per_class = max_detections_per_class;
   attrs->max_detections = max_detections;
@@ -264,10 +264,10 @@ RELAY_REGISTER_OP("vision.regular_non_max_suppression")
     .describe(R"doc(TBD)doc" TVM_ADD_FILELINE)
     .set_num_inputs(2)
     .add_argument("boxes", "Tensor",
-      "3-D tensor with shape (batch_size, num_boxes, 4). The four values in boxes "
-      "encode (ymin, xmin, ymax, xmax) coordinates of a box.")
+                  "3-D tensor with shape (batch_size, num_boxes, 4). The four values in boxes "
+                  "encode (ymin, xmin, ymax, xmax) coordinates of a box.")
     .add_argument("scores", "Tensor",
-      "3-D tensor with shape (batch_size, num_boxes, num_classes_with_background).")
+                  "3-D tensor with shape (batch_size, num_boxes, num_classes_with_background).")
     .set_support_level(5)
     .add_type_rel("RegularNMS", RegularNMSRel);
 

--- a/src/relay/op/vision/nms.cc
+++ b/src/relay/op/vision/nms.cc
@@ -210,5 +210,66 @@ RELAY_REGISTER_OP("vision.all_class_non_max_suppression")
     .set_support_level(5)
     .add_type_rel("AllClassNMS", AllClassNMSRel);
 
+TVM_REGISTER_NODE_TYPE(RegularNonMaximumSuppressionAttrs);
+
+bool RegularNMSRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
+                   const TypeReporter& reporter) {
+  ICHECK_EQ(types.size(), 3);
+  const auto* boxes = types[0].as<TensorTypeNode>();
+  if (boxes == nullptr) return false;
+  const auto* scores = types[1].as<TensorTypeNode>();
+  if (scores == nullptr) return false;
+
+  const auto& boxes_shape = boxes->shape;
+  const auto& scores_shape = scores->shape;
+  ICHECK_EQ(boxes_shape.size(), 3) << "Input boxes should be 3-D.";
+  ICHECK_EQ(scores_shape.size(), 3) << "Input scores count should be 3-D.";
+
+  IndexExpr num_batches = boxes_shape[0];
+
+  const auto* param = attrs.as<RegularNonMaximumSuppressionAttrs>();
+  CHECK(param);
+
+  std::vector<Type> fields;
+  std::vector<IndexExpr> nmsed_boxes_shape{num_batches, param->max_detections, 4};
+  std::vector<IndexExpr> nmsed_classes_shape{num_batches, param->max_detections};
+  std::vector<IndexExpr> nmsed_scores_shape{num_batches, param->max_detections};
+  std::vector<IndexExpr> nmsed_detections_number_shape{num_batches};
+  fields.push_back(TensorType(nmsed_boxes_shape, DataType::Float(32)));
+  fields.push_back(TensorType(nmsed_classes_shape, DataType::Float(32)));
+  fields.push_back(TensorType(nmsed_scores_shape, DataType::Float(32)));
+  fields.push_back(TensorType(nmsed_detections_number_shape, DataType::Int(32)));
+
+  reporter->Assign(types[2], TupleType(Array<Type>(fields)));
+  return true;
+}
+
+Expr MakeRegularNMS(Expr boxes, Expr scores, int32_t max_detections_per_class,
+                    int32_t max_detections, int32_t num_classes,
+                    double iou_threshold, double score_threshold) {
+  auto attrs = make_object<RegularNonMaximumSuppressionAttrs>();
+  attrs->max_detections_per_class = max_detections_per_class;
+  attrs->max_detections = max_detections;
+  attrs->num_classes = num_classes;
+  attrs->iou_threshold = iou_threshold;
+  attrs->score_threshold = score_threshold;
+  static const Op& op = Op::Get("vision.regular_non_max_suppression");
+  return Call(op, {boxes, scores}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relay.op.vision._make.regular_non_max_suppression")
+    .set_body_typed(MakeRegularNMS);
+
+RELAY_REGISTER_OP("vision.regular_non_max_suppression")
+    .describe(R"doc(TBD)doc" TVM_ADD_FILELINE)
+    .set_num_inputs(2)
+    .add_argument("boxes", "Tensor",
+      "3-D tensor with shape (batch_size, num_boxes, 4). The four values in boxes "
+      "encode (ymin, xmin, ymax, xmax) coordinates of a box.")
+    .add_argument("scores", "Tensor",
+      "3-D tensor with shape (batch_size, num_boxes, num_classes_with_background).")
+    .set_support_level(5)
+    .add_type_rel("RegularNMS", RegularNMSRel);
+
 }  // namespace relay
 }  // namespace tvm

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -4566,6 +4566,8 @@ def _test_detection_postprocess(tf_model_file, box_encodings_size, class_predict
 
 def test_detection_postprocess():
     """Detection PostProcess"""
+
+    # Fast-NMS
     box_encodings_size = (1, 1917, 4)
     class_predictions_size = (1, 1917, 91)
     tf_model_file = tf_testing.get_workload_official(
@@ -4575,11 +4577,21 @@ def test_detection_postprocess():
     )
     _test_detection_postprocess(tf_model_file, box_encodings_size, class_predictions_size)
 
+    # Fast-NMS
     box_encodings_size = (1, 2034, 4)
     class_predictions_size = (1, 2034, 91)
     tf_model_file = download_testdata(
         "https://github.com/czh978/models_for_tvm_test/raw/main/tflite_graph_with_postprocess.pb",
         "tflite_graph_with_postprocess.pb",
+    )
+    _test_detection_postprocess(tf_model_file, box_encodings_size, class_predictions_size)
+
+    # Regular NMS
+    box_encodings_size = (1, 1917, 4)
+    class_predictions_size = (1, 1917, 91)
+    tf_model_file = download_testdata(
+        "https://github.com/Grovety/ModelZoo/raw/main/models/object_detection/ssd_mobilenet_v1/tflite_int8/tflite_graph_with_regular_nms.pb",
+        "tflite_graph_with_regular_nms.pb",
     )
     _test_detection_postprocess(tf_model_file, box_encodings_size, class_predictions_size)
 

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -4591,8 +4591,8 @@ def test_detection_postprocess():
     class_predictions_size = (1, 1917, 91)
     tf_model_file = download_testdata(
         (
-            "https://github.com/Grovety/ModelZoo/raw/main/models/object_detection/ssd_mobilenet_v1/"
-            "tflite_int8/tflite_graph_with_regular_nms.pb"
+            "https://github.com/Grovety/ModelZoo/raw/52fb82156ae8c8e3f62c7d7caf6867b25261dda4/"
+            "models/object_detection/ssd_mobilenet_v1/tflite_int8/tflite_graph_with_regular_nms.pb"
         ),
         "tflite_graph_with_regular_nms.pb",
     )

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -4590,7 +4590,10 @@ def test_detection_postprocess():
     box_encodings_size = (1, 1917, 4)
     class_predictions_size = (1, 1917, 91)
     tf_model_file = download_testdata(
-        "https://github.com/Grovety/ModelZoo/raw/main/models/object_detection/ssd_mobilenet_v1/tflite_int8/tflite_graph_with_regular_nms.pb",
+        (
+            "https://github.com/Grovety/ModelZoo/raw/main/models/object_detection/ssd_mobilenet_v1/"
+            "tflite_int8/tflite_graph_with_regular_nms.pb"
+        ),
         "tflite_graph_with_regular_nms.pb",
     )
     _test_detection_postprocess(tf_model_file, box_encodings_size, class_predictions_size)

--- a/tests/scripts/request_hook/request_hook.py
+++ b/tests/scripts/request_hook/request_hook.py
@@ -213,6 +213,7 @@ URL_MAP = {
     "https://github.com/tlc-pack/web-data/raw/main/testdata/microTVM/data/vww_sample_person.jpg": f"{BASE}/tlc-pack/web-data/testdata/microTVM/data/vww_sample_person.jpg",
     "https://github.com/tlc-pack/web-data/raw/main/testdata/microTVM/data/vww_sample_not_person.jpg": f"{BASE}/tlc-pack/web-data/testdata/microTVM/data/vww_sample_not_person.jpg",
     "https://github.com/tensorflow/tflite-micro/raw/de8f61a074460e1fa5227d875c95aa303be01240/tensorflow/lite/micro/models/keyword_scrambled.tflite": f"{BASE}/models/tflite/keyword_scrambled_8bit.tflite",
+    "https://github.com/Grovety/ModelZoo/raw/52fb82156ae8c8e3f62c7d7caf6867b25261dda4/models/object_detection/ssd_mobilenet_v1/tflite_int8/tflite_graph_with_regular_nms.pb": f"{BASE}/ssd_mobilenet_v1/tflite_int8/tflite_graph_with_regular_nms.pb",
 }
 
 


### PR DESCRIPTION
This PR adds support of regular NMS operator.

Open questions:

1. How to properly test added functionality? 
Other NMS implementations, e.g., fast NMS, use a TF frozen graph from TF official website to convert a model to TFLite and keep NMS operations only. In order to create a similar test, we need to find an archive on TF official website that contains a frozen graph of a model compiled with `--use-regular-nms=True` flag. We haven't found it yet, so any help is appreciated.
3. Regular NMS requires two sort operations:
   - Sorting the scores after selecting scores above `nms_score_threshold`. This PR implements this with a simple bubble sort in order to prove the algorithm's semantics. We tried to replace it with `tvm.contrib.sort.argsort`. It works well when testing the regular NMS with `run_tvm_graph` as fast NMS test does or building and running the regular NMS with llvm target. At the same time, it fails to build (error is provided below) when `target=ethos-u,cmsis-nn,c`. It seems that `__tvm_module_ctx` variable is only being initialized when `cpp` runtime is chosen.
   The error:
`error: '__tvm_module_ctx' undeclared (first use in this function)
203 | if (TVMBackendGetFuncFromEnv(__tvm_module_ctx, "tvm.contrib.sort.argsort", &tvm_contrib_sort_argsort_packed) != 0) {`
   - Sorting the scores of previous and current NMS steps. There are two alternatives here:
      - implement some sorting algorithm as part of hybrid script (to replace current bubble sort)
      - save the result of each NMS step and use `argsort` after the hybrid script part. This approach has a drawback as it requires significant amount of memory to store the results of each NMS step.