### PR TITLE
[ARITH] NormalizeToIterSum

### DIFF
--- a/include/tvm/arith/iter_affine_map.h
+++ b/include/tvm/arith/iter_affine_map.h
@@ -420,6 +420,25 @@ Array<Array<IterMark>> SubspaceDivide(const Array<PrimExpr>& bindings,
  */
 PrimExpr NormalizeIterMapToExpr(const PrimExpr& expr);
 
+/*!
+ * \brief Rewrite index as IterSumExpr
+ *
+ * ((i0 // b0) % a0) * s0 + ((i0 // b1) % a1) * s1 ... + base
+ *
+ * The iterators are ordered such that s0 > s1 ...
+ * if we can prove the relation.
+ *
+ * Note that base may contain expressions that cannot be detected
+ * as the right pattern.
+ *
+ * \param index The input index
+ * \param input_iters The input iterators.
+ * \param analyzer The input analyzer.
+ * \note This function is useful to detect iterator stride patterns.
+ */
+IterSumExpr NormalizeToIterSum(PrimExpr index, const Map<Var, Range>& input_iters,
+                               arith::Analyzer* analyzer);
+
 }  // namespace arith
 }  // namespace tvm
 #endif  // TVM_ARITH_ITER_AFFINE_MAP_H_

--- a/python/tvm/arith/__init__.py
+++ b/python/tvm/arith/__init__.py
@@ -32,6 +32,7 @@ from .iter_affine_map import (
     detect_iter_map,
     iter_map_simplify,
     normalize_iter_map_to_expr,
+    normalize_to_iter_sum,
     subspace_divide,
     inverse_affine_iter_map,
 )

--- a/python/tvm/arith/iter_affine_map.py
+++ b/python/tvm/arith/iter_affine_map.py
@@ -156,6 +156,37 @@ def detect_iter_map(
     )
 
 
+def normalize_to_iter_sum(index, input_iters):
+    """Normalize expr to iter sum.
+
+    The normalized result ensures that
+    each scale is in the form of (symbol_prod) * cscale
+    It will also sort in desc order by cscale then len(symbol_prod).
+
+    Parameters
+    ----------
+    index : PrimExpr
+        The input index
+
+    input_iters : Map[Var, Range]
+        The domain of each input iterators.
+
+    Returns
+    -------
+    iter_sum: IterSumExpr
+        The result iter sum
+
+    Note
+    ----
+    This function does best effort detection, so some undetected
+    part can go into iter_sum.base
+
+    This function is useful to decide the stride multiplier and
+    division factor in buffer access patterns.
+    """
+    return _ffi_api.NormalizeToIterSum(index, input_iters)
+
+
 def iter_map_simplify(
     indices,
     input_iters,

--- a/src/arith/product_normal_form.h
+++ b/src/arith/product_normal_form.h
@@ -54,14 +54,7 @@ inline void UnpackReduction(const PrimExpr& value, FLeaf fleaf) {
  *
  * NOTE on multiplication order: when have have shape (s[0], s[1], s[2]),
  * we prefer to multiple in order of s[0] * s[1] * s[2]
- *
- * That means when we are looking at the pattern of split iterator:
- *
- * - result = (source // lower_factor) % extent * scale
- *
- * We should take the order of lower_factor, extent, scale.
- * Please do best keeping this order to make future simplifcation easy.
- *
+
  * \param lhs The lhs iterator
  * \param rhs The rhs iterator
  * \return the result.


### PR DESCRIPTION
This PR adds an arith util function NormalizeToIterSum.

This function normalizes an index to sum of iterators by scale.

The iterator splits are simplified when possible and ordered by their constant scale and number of prod symbols in descenting order.

We also ensures that each scale is in the form of symbol * const (e.g. n * m * 4). This function is useful to detect stride patterns in buffer access.