### PR TITLE
GraphExecutor: Fix wild pointer assign when input and output are reshape

### DIFF
--- a/src/runtime/graph_executor/graph_executor.cc
+++ b/src/runtime/graph_executor/graph_executor.cc
@@ -230,6 +230,16 @@ void GraphExecutor::SetOutputZeroCopy(int index, DLTensor* data_ref) {
   // check the consistency of output
   CheckExternalDLTensor(data_ref, output_node_eid);
 
+  if (nodes_[output_node.node_id].op_type == "tvm_op" &&
+      nodes_[output_node.node_id].param.func_name == "__nop") {
+    const NodeEntry& input_node = nodes_[output_node.node_id].inputs[0];
+    output_node_eid = this->entry_id(input_node);
+    ICHECK_NE(node_output_dltensors_[output_node_eid].size(), 0);
+    for (DLTensor* t : node_output_dltensors_[output_node_eid]) {
+      t->data = static_cast<char*>(data_ref->data) + data_ref->byte_offset;
+    }
+  }
+
   // Update the data pointer for output op
   for (DLTensor* t : output_dltensors_[output_node_eid]) {
     t->data = static_cast<char*>(data_ref->data) + data_ref->byte_offset;
@@ -524,6 +534,13 @@ void GraphExecutor::SetupOpExecs() {
       if (input_node_eids.count(input_eid) > 0) {
         input_dltensors_[input_eid].push_back(
             static_cast<DLTensor*>(op_args->arg_values[i].v_handle));
+      } else {
+        const auto& arg_node = nodes_[inode.inputs[i].node_id];
+        if (arg_node.op_type == "tvm_op" && arg_node.param.func_name == "__nop") {
+          uint32_t arg_input_eid = this->entry_id(arg_node.inputs[0]);
+          input_dltensors_[arg_input_eid].push_back(
+              static_cast<DLTensor*>(op_args->arg_values[i].v_handle));
+        }
       }
       // check if any model output is the input of the op
       if (output_node_eids.count(input_eid) > 0) {
@@ -537,6 +554,11 @@ void GraphExecutor::SetupOpExecs() {
       // check if op output is model output
       if (output_node_eids.count(output_eid) > 0) {
         output_dltensors_[output_eid].push_back(
+            static_cast<DLTensor*>(op_args->arg_values[i].v_handle));
+      } else {
+        // If the node is not an output, keep its output for record and support set_output_zero_copy
+        // of reshape __nop nodes.
+        node_output_dltensors_[output_eid].push_back(
             static_cast<DLTensor*>(op_args->arg_values[i].v_handle));
       }
     }
@@ -566,7 +588,7 @@ std::pair<std::function<void()>, std::shared_ptr<GraphExecutor::OpArgs>> GraphEx
   }
 
   if (param.func_name == "__nop") {
-    return {[]() {}, arg_ptr};
+    return {[arg_ptr]() {}, arg_ptr};
   } else if (param.func_name == "__copy") {
     // Perform cross device data copy.
     // Directly copy data from the input to the output.

--- a/src/runtime/graph_executor/graph_executor.h
+++ b/src/runtime/graph_executor/graph_executor.h
@@ -460,6 +460,8 @@ class TVM_DLL GraphExecutor : public ModuleNode {
   std::vector<std::vector<DLTensor*>> output_dltensors_;
   /*! \brief Used for quick node(both model output and op input) DLTensor* lookup given an eid. */
   std::vector<std::vector<DLTensor*>> both_output_opinput_dltensors_;
+  /*! \brief Used for quick node output DLTensor* lookup given a nop's input eid. */
+  std::unordered_map<int, std::vector<DLTensor*>> node_output_dltensors_;
   /*! \brief Used for quick entry indexing. */
   std::vector<uint32_t> node_row_ptr_;
   /*! \brief Output entries. */

--- a/tests/python/contrib/test_reshape_0_copy.py
+++ b/tests/python/contrib/test_reshape_0_copy.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import numpy as np
 
 import tvm

--- a/tests/python/contrib/test_reshape_0_copy.py
+++ b/tests/python/contrib/test_reshape_0_copy.py
@@ -26,8 +26,12 @@ def test_reshape_0_copy():
         lib = relay.build(mod, target="llvm")
     m = graph_executor.GraphModule(lib["default"](tvm.cpu(0)))
 
-    data_ndarray0 = tvm.nd.array(np.random.random(shape0).astype(np.float32), device=tvm.device("llvm", 0))
-    data_ndarray1 = tvm.nd.array(np.random.random(shape1).astype(np.float32), device=tvm.device("llvm", 0))
+    data_ndarray0 = tvm.nd.array(
+        np.random.random(shape0).astype(np.float32), device=tvm.device("llvm", 0)
+    )
+    data_ndarray1 = tvm.nd.array(
+        np.random.random(shape1).astype(np.float32), device=tvm.device("llvm", 0)
+    )
 
     def expected():
         m.set_input(in_name0, data_ndarray0)
@@ -51,4 +55,3 @@ def test_reshape_0_copy():
 
 if __name__ == "__main__":
     test_reshape_0_copy()
-

--- a/tests/python/contrib/test_reshape_0_copy.py
+++ b/tests/python/contrib/test_reshape_0_copy.py
@@ -1,0 +1,53 @@
+import torch
+import numpy as np
+
+import tvm
+from tvm import relay
+from tvm.contrib import graph_executor
+from tvm.relay.frontend.common import infer_shape
+
+def test_reshape_0_copy():
+    shape0 = (56, 224)
+    shape1 = (112, 112)
+    in_name0 = "infeats0"
+    in_name1 = "infeats1"
+    x0 = relay.var(in_name0, shape=shape0, dtype="float32")
+    x0 = relay.reshape(x0, shape1)
+
+    x1 = relay.var(in_name1, shape=shape1, dtype="float32")
+    mat = relay.nn.matmul(x0, x1)
+    _y = relay.reshape(mat, (-1))
+    func = relay.Function(relay.analysis.free_vars(_y), _y)
+
+    with tvm.transform.PassContext(opt_level=3):
+        lib = relay.build(func, target="llvm")
+    m = graph_executor.GraphModule(lib['default'](tvm.cpu(0)))
+
+    data0 = torch.rand(shape0, dtype=torch.float32, device=torch.device("cpu:0"))
+    data1 = torch.rand(shape1, dtype=torch.float32, device=torch.device("cpu:0"))
+
+    data_ndarray0 = tvm.nd.from_dlpack(torch.to_dlpack(data0))
+    data_ndarray1 = tvm.nd.from_dlpack(torch.to_dlpack(data1))
+
+    def expected():
+        m.set_input(in_name0, data_ndarray0)
+        m.set_input(in_name1, data_ndarray1)
+        m.run()
+        return torch.from_dlpack(m.get_output(0)).cpu().detach().numpy()
+
+    def zero_copy():
+        outshape = infer_shape(_y)
+        output = torch.empty(outshape, device=torch.device("cpu:0"))
+        output_view = tvm.nd.from_dlpack(torch.to_dlpack(output))
+        m.set_input_zero_copy(in_name0, data_ndarray0)
+        m.set_input_zero_copy(in_name1, data_ndarray1)
+        m.set_output_zero_copy(0, output_view)
+        m.run()
+        return output.cpu().detach().numpy()
+
+    golden_out = expected()
+    out = zero_copy()
+    np.testing.assert_equal(golden_out, out)
+
+if __name__ == "__main__":
+    test_reshape_0_copy()


### PR DESCRIPTION
If reshape in our relay expression, like reshape + matmul expr, when we use set_input_zero_copy or set_output_zero_copy，the result goes wrong.