### PR TITLE
[Bugfix][Relay][Keras] Fix SeparableConv2D conversion in dilation_rate attribute

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -569,13 +569,17 @@ def _convert_separable_convolution(inexpr, keras_layer, etab, data_layout, input
         weight0 = weightList[0].transpose([2, 3, 0, 1])
     else:
         weight0 = weightList[0]
+    if isinstance(keras_layer.dilation_rate, (list, tuple)):
+        dilation = [keras_layer.dilation_rate[0], keras_layer.dilation_rate[1]]
+    else:
+        dilation = [keras_layer.dilation_rate, keras_layer.dilation_rate]
     params0 = {
         "weight": etab.new_const(weight0),
         "channels": in_channels * depth_mult,
         "groups": in_channels,
         "kernel_size": [kernel_h, kernel_w],
         "strides": [stride_h, stride_w],
-        "dilation": [1, 1],
+        "dilation": dilation,
         "padding": [0, 0],
         "data_layout": data_layout,
         "kernel_layout": kernel_layout,

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -310,7 +310,7 @@ class TestKeras:
             keras_mod.layers.DepthwiseConv2D(kernel_size=(3, 3), padding="same"),
             keras_mod.layers.Conv2DTranspose(filters=10, kernel_size=(3, 3), padding="valid"),
             keras_mod.layers.SeparableConv2D(filters=10, kernel_size=(3, 3), padding="same"),
-            keras_mod.layers.SeparableConv2D(filters=10, kernel_size=(3, 3), dilation_rate=[2,2]),
+            keras_mod.layers.SeparableConv2D(filters=10, kernel_size=(3, 3), dilation_rate=(2, 2)),
             keras_mod.layers.SeparableConv2D(filters=2, kernel_size=(3, 3), dilation_rate=2),
         ]
         for conv_func in conv_funcs:

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -310,6 +310,8 @@ class TestKeras:
             keras_mod.layers.DepthwiseConv2D(kernel_size=(3, 3), padding="same"),
             keras_mod.layers.Conv2DTranspose(filters=10, kernel_size=(3, 3), padding="valid"),
             keras_mod.layers.SeparableConv2D(filters=10, kernel_size=(3, 3), padding="same"),
+            keras_mod.layers.SeparableConv2D(filters=10, kernel_size=(3, 3), dilation_rate=[2,2]),
+            keras_mod.layers.SeparableConv2D(filters=2, kernel_size=(3, 3), dilation_rate=2),
         ]
         for conv_func in conv_funcs:
             x = conv_func(data)


### PR DESCRIPTION
This PR fixed a bug about `dilation_rate` in SeparableConv2D.

The attribute `dilation_rate` about SeparableConv2D layer has the following constraints in [Keras documentation](https://keras.io/api/layers/convolution_layers/separable_convolution2d/#:~:text=dilation_rate%3A%20An%20integer%20or%20tuple/list%20of%202%20integers%2C%20specifying%20the%20dilation%20rate%20to%20use%20for%20dilated%20convolution.):

> **dilation_rate: An integer or tuple/list of 2 integers, specifying the dilation rate to use for dilated convolution.**

TVM always considered the `dilation_rate` as a default value. This will lead to wrong calculation results.

This PR fix this bug and added the bug-triggering test cases.





### Steps to reproduce
```
import tvm
import tvm.relay as relay
import numpy as np
from tensorflow import keras
from tensorflow.keras import layers, models
input_shape = (2, 32,32,3)
input_data = np.random.random(size=input_shape)
x = layers.Input(shape=input_shape[1:], dtype='float32')

kwargs={'filters':2,'kernel_size':[3, 3],'dilation_rate':2,} 
layer = keras.layers.SeparableConv2D(**kwargs)
layer.set_weights(layer.get_weights())

y = layer(x)
model = models.Model(x, y)
model.summary()
res_keras = model(input_data)

shape_dict = {'input_1': input_shape}
mod, params = relay.frontend.from_keras(model, shape_dict,layout='NHWC')
with tvm.transform.PassContext(opt_level=3):
    model = relay.build_module.create_executor("graph", mod, tvm.cpu(0), 'llvm', params).evaluate()

test_x_tvm = input_data
res_tvm = model(tvm.nd.array(test_x_tvm.astype('float32'))).numpy()

np.testing.assert_allclose(res_keras, res_tvm, atol=1e-3, rtol=1e-3)

```

![image](https://github.com/apache/tvm/assets/29506758/f574f5ee-856a-4208-b8dc-1454eb18abcb)



cc @Hzfengsy @echuraev @leandron 
