### PR TITLE
[Unity] Minor fix to `RewriteDataflowReshape` condition 

### DIFF
--- a/src/relax/transform/rewrite_dataflow_reshape.cc
+++ b/src/relax/transform/rewrite_dataflow_reshape.cc
@@ -72,7 +72,8 @@ class DataflowReshapeRewriter : public ExprMutator {
   }
 
   Expr VisitExpr_(const CallNode* call) final {
-    if (call->args.size() < 2) {
+    static const Op& call_tir_op = Op::Get("relax.call_tir");
+    if (call->op != call_tir_op) {
       return GetRef<Call>(call);
     }
 
@@ -103,10 +104,6 @@ class DataflowReshapeRewriter : public ExprMutator {
   }
 
   bool IsCallingTIRReshape(const CallNode* call, Expr inp) {
-    static const Op& call_tir_op = Op::Get("relax.call_tir");
-    if (call->op != call_tir_op) {
-      return false;
-    }
     const GlobalVar& global_var = Downcast<GlobalVar>(call->args[0]);
     const auto* func = mod_->functions.Get(global_var).as<tir::PrimFuncNode>();
     ICHECK_NOTNULL(func);


### PR DESCRIPTION
Follow-up to https://github.com/apache/tvm/pull/15112. Now `Downcast<GlobalVar>` at https://github.com/apache/tvm/blob/unity/src/relax/transform/rewrite_dataflow_reshape.cc#L83 can fail because we can now reach this line even if `call->op` is not `call_tir`.

Fixed by tweaking the reshape detection condition a bit.

@kparzysz-quic 