### PR TITLE
[LLVM] Remove the "ret_void" argument of AddFunction

### DIFF
--- a/src/target/llvm/codegen_amdgpu.cc
+++ b/src/target/llvm/codegen_amdgpu.cc
@@ -89,7 +89,7 @@ class CodeGenAMDGPU : public CodeGenLLVM {
 
   void AddFunction(const GlobalVar& gvar, const PrimFunc& f) final {
     // add function as void return value
-    CodeGenLLVM::AddFunctionInternal(gvar, f, true);
+    CodeGenLLVM::AddFunctionInternal(gvar, f);
     function_->setCallingConv(llvm::CallingConv::AMDGPU_KERNEL);
     std::ostringstream attr;
     attr << "1," << DetectROCMmaxThreadsPerBlock();

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -381,9 +381,9 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   std::tuple<std::string, llvm::Function::LinkageTypes> GetLinkage(const GlobalVar& gvar,
                                                                    const PrimFunc& func);
 
-  llvm::Function* DeclareFunctionInternal(const GlobalVar& gvar, const PrimFunc& f, bool ret_void);
+  llvm::Function* DeclareFunctionInternal(const GlobalVar& gvar, const PrimFunc& f);
 
-  void AddFunctionInternal(const GlobalVar& gvar, const PrimFunc& f, bool ret_void);
+  void AddFunctionInternal(const GlobalVar& gvar, const PrimFunc& f);
 
   // Create extern call
   llvm::CallInst* CreateCallExtern(llvm::Type* ret, const std::string& name,

--- a/src/target/llvm/codegen_nvptx.cc
+++ b/src/target/llvm/codegen_nvptx.cc
@@ -68,11 +68,11 @@ class CodeGenNVPTX : public CodeGenLLVM {
  public:
   llvm::Function* DeclareFunction(const GlobalVar& gvar, const PrimFunc& f) final {
     // add function as void return value
-    return CodeGenLLVM::DeclareFunctionInternal(gvar, f, true);
+    return CodeGenLLVM::DeclareFunctionInternal(gvar, f);
   }
   void AddFunction(const GlobalVar& gvar, const PrimFunc& f) final {
     // add function as void return value
-    CodeGenLLVM::AddFunctionInternal(gvar, f, true);
+    CodeGenLLVM::AddFunctionInternal(gvar, f);
     // annotate as kernel function
     llvm::LLVMContext* ctx = llvm_target_->GetContext();
     module_->getOrInsertNamedMetadata("nvvm.annotations")


### PR DESCRIPTION
Prior to this commit, the `"ret_void"` argument needed to be explicitly provided to `CodeGenLLVM::AddFunction` and `CodeGenLLVM::DeclareFunction`.  If this was inconsistent with the `builtin::ret()` usage within the `PrimFunc`, this could cause the incorrect return type in the generated LLVM-IR, resulting in LLVM IR verification failures.

This commit removes the `"ret_void"` argument, instead using the type annotation in `PrimFunc::ret_type`, removing this opportunity for inconsistency.

This PR is intended to fix a ROCm regression reported in https://github.com/apache/tvm/pull/14901#issuecomment-1598863567.