### PR TITLE
[Arith][TIR] Recognize empty extents

### DIFF
--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -1053,11 +1053,17 @@ Map<Var, arith::IntSet> AsIntSet(const Map<Var, Range>& var_dom) {
 /*! \brief Helper function to convert IterSumExpr to the actual touched range. */
 static Optional<IntSet> EvalIterSum(const IterSumExpr& iter_min, const PrimExpr& extent,
                                     Analyzer* analyzer) {
+  if (analyzer->CanProve(extent == 0)) {
+    return IntSet::Nothing();
+  }
   if (iter_min->args.empty()) {
     return IntSet::FromMinExtent(iter_min->base, extent);
   }
   ICHECK_EQ(iter_min->args.size(), 1) << "The `EvalIterSum` expects fused iter sum expr";
   const IterSplitExpr& split = iter_min->args[0];
+  if (analyzer->CanProve(split->extent == 0)) {
+    return IntSet::Nothing();
+  }
   if (!analyzer->CanProve(extent >= split->scale)) {
     return NullOpt;
   }

--- a/src/tir/schedule/state.cc
+++ b/src/tir/schedule/state.cc
@@ -99,6 +99,9 @@ bool ProducerCoversConsumer(const Array<PrimExpr>& buffer_shape,
     if (produced_region[i].IsNothing()) {
       return false;
     }
+    if (consumed_region[i].IsNothing()) {
+      continue;
+    }
     arith::IntSet produced =
         arith::IntSet::Interval(analyzer->canonical_simplify(produced_region[i].min()),
                                 analyzer->canonical_simplify(produced_region[i].max()));


### PR DESCRIPTION
Generate empty interval sets when empty extents are encountered.
Handle empty regions when constructing ScheduleState.

The direct cause of the crash was constructing an expression `0 - pos_inf`: the latter operand is actually of type `handle`.  The root cause of the issue was that the region connected to `T.grid(0, 8, 8)` was not explicitly recognized as empty early enough, and the extent of 0 was simply used in the related arithmetic to compute further expressions.

Without the fix, the testcase fails with the following traceback:
```
[15:08:28] /w/src/aitools/tvm-upstream/src/tir/op/op.cc:174: 0 pos_inf
Traceback (most recent call last):
  File "grid0.py", line 27, in <module>
    sch = tvm.tir.Schedule(foo)
  File "/w/src/aitools/tvm-upstream/python/tvm/tir/schedule/_type_checker.py", line 340, in wrap
    return func(*args, **kwargs)
  File "/w/src/aitools/tvm-upstream/python/tvm/tir/schedule/schedule.py", line 160, in __init__
    self.__init_handle_by_constructor__(
  File "tvm/_ffi/_cython/./object.pxi", line 132, in tvm._ffi._cy3.core.ObjectBase.__init_handle_by_constructor__
  File "tvm/_ffi/_cython/./packed_func.pxi", line 287, in tvm._ffi._cy3.core.ConstructorCall
  File "tvm/_ffi/_cython/./packed_func.pxi", line 276, in tvm._ffi._cy3.core.FuncCall
  File "tvm/_ffi/_cython/./base.pxi", line 181, in tvm._ffi._cy3.core.CHECK_CALL
tvm._ffi.base.TVMError: Traceback (most recent call last):
  12: TVMFuncCall
  11: tvm::runtime::PackedFuncObj::Extractor<tvm::runtime::PackedFuncSubObj<void tvm::runtime::TypedPackedFunc<tvm::tir::Schedule (tvm::IRModule, long, int, int, bool)>::AssignTypedLambda<tvm::tir::$_5>(tvm::tir::$_5, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>)::'lambda'(tvm::runtime::TVMArgs const&, tvm::runtime::TVMRetValue*)>>::Call(tvm::runtime::PackedFuncObj const*, tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)
  10: tvm::tir::Schedule::Traced(tvm::IRModule, long, int, tvm::tir::ScheduleErrorRenderLevel, bool)
  9: tvm::tir::ScheduleState::ScheduleState(tvm::IRModule, int, bool)
  8: tvm::tir::StateCreator::Create(tvm::IRModule, int, bool)
  7: tvm::tir::BlockInfoCollector::VisitStmt_(tvm::tir::BlockRealizeNode const*)
  6: tvm::tir::BlockInfoCollector::MakeBlockInfo(tvm::tir::StmtSRef)
  5: tvm::tir::BlockInfoCollector::CheckRegionCoverAndStagePipeline(tvm::tir::BlockInfo const&, tvm::tir::StmtSRef const&, tvm::runtime::Array<tvm::tir::StmtSRef, void> const&)
  4: tvm::tir::ProducerCoversConsumer(tvm::runtime::Array<tvm::PrimExpr, void> const&, tvm::runtime::Array<tvm::arith::IntSet, void> const&, tvm::runtime::Array<tvm::arith::IntSet, void> const&, tvm::arith::Analyzer*)
  3: tvm::operator-(tvm::PrimExpr, tvm::PrimExpr)
  2: tvm::sub(tvm::PrimExpr, tvm::PrimExpr, tvm::Span)
  1: tvm::BinaryOpMatchTypes(tvm::PrimExpr&, tvm::PrimExpr&, tvm::Span)
  0: _ZN3tvm7runtime6detail
  File "/w/src/aitools/tvm-upstream/src/tir/op/op.cc", line 175
TVMError: Cannot match type int32 vs handle
```