### PR TITLE
[Unity][Relax] Check for call_tir early in DataflowReshapeRewriter

### DIFF
--- a/src/relax/transform/rewrite_dataflow_reshape.cc
+++ b/src/relax/transform/rewrite_dataflow_reshape.cc
@@ -72,7 +72,8 @@ class DataflowReshapeRewriter : public ExprMutator {
   }
 
   Expr VisitExpr_(const CallNode* call) final {
-    if (call->args.size() < 2) {
+    static const Op& call_tir_op = Op::Get("relax.call_tir");
+    if (call->op != call_tir_op || call->args.size() < 2) {
       return GetRef<Call>(call);
     }
 
@@ -103,10 +104,6 @@ class DataflowReshapeRewriter : public ExprMutator {
   }
 
   bool IsCallingTIRReshape(const CallNode* call, Expr inp) {
-    static const Op& call_tir_op = Op::Get("relax.call_tir");
-    if (call->op != call_tir_op) {
-      return false;
-    }
     const GlobalVar& global_var = Downcast<GlobalVar>(call->args[0]);
     const auto* func = mod_->functions.Get(global_var).as<tir::PrimFuncNode>();
     ICHECK_NOTNULL(func);


### PR DESCRIPTION
In an earlier commit, the check for `call_tir` was moved until later, which exposed some of the code to any calls, not just `call_tir`. The code was making assumptions about some of the arguments, which now are not necessarily met. Specifically, that there are at least two arguments, and that the first argument was a `GlobalVar`.

Move the check for `call_tir` back to the beginning of the function.