### PR TITLE
[NDArray] Allow creating a view from a strided array

### DIFF
--- a/tests/python/unittest/test_runtime_dlpack.py
+++ b/tests/python/unittest/test_runtime_dlpack.py
@@ -48,5 +48,18 @@ def test_from_dlpack_shape_one():
     tvm.testing.assert_allclose(c.numpy(), a.numpy() + b.numpy())
 
 
+@tvm.testing.requires_package("torch")
+def test_from_dlpack_strided():
+    import torch
+    from torch.utils.dlpack import to_dlpack
+
+    rows = 1
+    inp = torch.randn(rows, 16)
+    a = tvm.runtime.ndarray.from_dlpack(to_dlpack(inp))
+    view = a._create_view((2, 8))
+
+    np.testing.assert_equal(inp.numpy().reshape(2, 8), view.numpy())
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Currently, `NDArray::CreateView(...)` requires the strides of the input array to be null. This makes it impossible to apply, for example, reshaping on an array which originally comes from PyTorch via `from_dlpack`.  

This PR relaxes the null check to allow non-null strides, as long as they are "compact". But after creating a view, the returned array no longer has strides.

This is a subset of new functionalities from another PR https://github.com/apache/tvm/pull/14771, which ended up causing disruptive changes across the stack. 

@Lunderberg @tqchen @vinx13 @yelite @sunggg 