### PR TITLE
[Test] Improve check for TVMError exception in test_cast

### DIFF
--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -118,9 +118,12 @@ def test_cast():
     assert z.lanes == 4
 
     s = tvm.tir.StringImm("s")
-    with pytest.raises(tvm.error.TVMError) as cm:
-        s.astype("int")
-        assert "Can't cast a handle to other types" in str(cm.execption)
+    with pytest.raises(tvm.error.TVMError):
+        try:
+            s.astype("int")
+        except Exception as e:
+            assert "Can't cast a handle to other types" in str(e)
+            raise
 
 
 def test_attr():


### PR DESCRIPTION
The original code has
```
with pytest.raises(tvm.error.TVMError):
    s.astype("int")
    assert "Can't cast a handle to other types" in str(e)
```
The `astype` is expected to throw a TVMError exception, but if it does, the following assertion never gets executed.

Add try/except to the test to verify that the expected exception is thrown.