### PR TITLE
[TIR] Block dependence analysis without schedules

### DIFF
--- a/include/tvm/tir/block_dependence_info.h
+++ b/include/tvm/tir/block_dependence_info.h
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file tvm/tir/block_dependence_info.h
+ * \brief Define BlockDependenceInfoNode that uses the BlockScope and StmtSRef objects to
+ * store the block level dependences
+ * \sa BlockDependenceInfoNode
+ */
+
+/**
+ * @brief An object that builds and maintains block scope and StmtSref mapping for Dependence
+ * analysis
+ */
+
+#ifndef TVM_TIR_BLOCK_DEPENDENCE_INFO_H_
+#define TVM_TIR_BLOCK_DEPENDENCE_INFO_H_
+
+#include <tvm/tir/block_scope.h>
+
+#include <unordered_map>
+
+namespace tvm {
+namespace tir {
+
+/**
+ * @brief An object that helps build and query block level dependences using the 2 core objects
+ * BlockScope and StmtSRef
+ *
+ * The data structures exposed are:
+ * 1) sref2scope: Mapping from the srefs to its corresponding BlockScope
+ * 2) stmt2ref: Mapping from blocks to corresponding StmtSRefs
+ *
+ * Note that this object does not store SRefs to loops as the purpose is only to expose block level
+ * dependences. This provides the advantage that the scope block (parent block) for a given block
+ * sref can be directly accessed using the sref->parent member
+ */
+class BlockDependenceInfoNode : public Object {
+ public:
+  /*!
+   * \brief Mapping from a block sref to its correpsonding BlockScope,
+   * tracking the dependency inside the block scope,
+   */
+  std::unordered_map<StmtSRef, BlockScope, ObjectPtrHash, ObjectPtrEqual> sref2scope;
+  /*! \brief The reverse mapping from block/for-loop to their corresponding srefs */
+  std::unordered_map<const StmtNode*, StmtSRef> stmt2ref;
+
+  void VisitAttrs(AttrVisitor* v) {}
+
+  static constexpr const char* _type_key = "tir.BlockDependenceInfo";
+  TVM_DECLARE_FINAL_OBJECT_INFO(BlockDependenceInfoNode, Object);
+
+  /*!
+   * \brief Get the BlockScope correpsonding to the sref of scope root block
+   * \param scope_root The block sref to be retrieved
+   * \return The corresponding BlockScope
+   */
+  BlockScope GetBlockScope(const StmtSRef& scope_root) const {
+    auto it = sref2scope.find(scope_root);
+    CHECK(it != sref2scope.end())
+        << "IndexError: Cannot find the corresponding BlockScope to the block sref:\n"
+        << GetRef<Stmt>(scope_root->stmt);
+    return it->second;
+  }
+};
+
+/*!
+ * \brief Managed reference to BlockDependenceInfoNode
+ * \sa BlockDependenceInfo
+ */
+class BlockDependenceInfo : public ObjectRef {
+  /*! \brief Construct an empty BlockDependenceInfo
+   */
+  TVM_DLL BlockDependenceInfo();
+
+ public:
+  /*! \brief Construct a BlockDependenceInfo from IRModule
+   */
+  TVM_DLL BlockDependenceInfo(IRModule mod);
+
+  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(BlockDependenceInfo, ObjectRef,
+                                                    BlockDependenceInfoNode);
+};
+
+}  // namespace tir
+}  // namespace tvm
+#endif  // TVM_TIR_BLOCK_DEPENDENCE_INFO_H_

--- a/include/tvm/tir/block_scope.h
+++ b/include/tvm/tir/block_scope.h
@@ -25,9 +25,14 @@
 #ifndef TVM_TIR_BLOCK_SCOPE_H_
 #define TVM_TIR_BLOCK_SCOPE_H_
 
+#include <tvm/ir/module.h>
+#include <tvm/tir/function.h>
 #include <tvm/tir/stmt.h>
+#include <tvm/tir/stmt_functor.h>
 
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace tvm {
 namespace tir {
@@ -140,6 +145,52 @@ class StmtSRef : public ObjectRef {
    *   compute-at-impl(block, loop_sref)    otherwise
    */
   TVM_DLL static StmtSRef RootMark();
+};
+
+class SRefTreeCreator : private StmtVisitor {
+ public:
+  /*!
+   * \brief StmtSRef Tree Creator
+   * \param mod The module being scheduled.
+   * \param include_loops Ignore ForNodes if this value is false
+   */
+  static std::unordered_map<const StmtNode*, StmtSRef> Create(IRModule mod,
+                                                              bool include_loops = true) {
+    SRefTreeCreator creator(include_loops);
+    for (const auto& kv : mod->functions) {
+      const BaseFunc& base_func = kv.second;
+      if (auto opt = base_func.as<PrimFunc>()) {
+        auto func = opt.value();
+        creator.VisitStmt(func->body);
+      }
+    }
+    return std::move(creator.stmt2ref_);
+  }
+
+ private:
+  explicit SRefTreeCreator(bool include_loops) : include_loops_(include_loops) {}
+
+  /*!
+   * \brief Add a new statement to the stack, which becomes the current scope
+   * \param stmt A for-loop statement or a block statement
+   * \return A sref to the stmt
+   */
+  void PushSRef(const StmtNode* stmt);
+
+  /*! \brief Pop the top of the scope and record it in stmt2ref map */
+  void PopAndRecordSRef();
+
+  void VisitStmt_(const ForNode* loop) final;
+
+  void VisitStmt_(const BlockRealizeNode* realize) final;
+
+  void VisitStmt_(const SeqStmtNode* seq_stmt) final;
+
+  bool include_loops_;
+  /*! \brief The result ScheduleStateNode */
+  std::unordered_map<const StmtNode*, StmtSRef> stmt2ref_;
+  /*! \brief The stack frame used to indicate the current scope */
+  std::vector<StmtSRef> srefs_;
 };
 
 /*!

--- a/include/tvm/tir/block_scope.h
+++ b/include/tvm/tir/block_scope.h
@@ -173,7 +173,6 @@ class SRefTreeCreator : private StmtVisitor {
   /*!
    * \brief Add a new statement to the stack, which becomes the current scope
    * \param stmt A for-loop statement or a block statement
-   * \return A sref to the stmt
    */
   void PushSRef(const StmtNode* stmt);
 

--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -79,6 +79,7 @@ from .op import start_profile_intrinsic, end_profile_intrinsic
 from .generic import add, subtract, multiply
 
 from .schedule import StmtSRef, BlockScope, ScheduleState, Schedule, ScheduleError
+from .block_dependence_info import BlockDependenceInfo
 
 from . import schedule
 from . import ir_builder

--- a/python/tvm/tir/block_dependence_info.py
+++ b/python/tvm/tir/block_dependence_info.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Define BlockDependenceInfoNode that uses the BlockScope and StmtSRef objects
+to store the block level dependences"""
+
+from typing import Union, Optional
+from tvm._ffi import register_object
+from tvm.ir.module import IRModule
+from tvm.runtime import Object
+from tvm.tir import Block, PrimFunc
+
+from .block_scope import BlockScope, StmtSRef
+from . import _ffi_api
+
+
+@register_object("tir.BlockDependenceInfo")
+class BlockDependenceInfo(Object):
+    """
+    BlockDependenceInfo
+    An object that helps build and query block level dependences using the 2 core objects
+    BlockScope and StmtSRef
+
+    The data structures exposed are:
+    1) sref2scope: Mapping from the srefs to its corresponding BlockScope
+    2) stmt2ref: Mapping from blocks to corresponding StmtSRefs
+
+    Note that this object does not store SRefs to loops as the purpose is only to expose block level
+    dependences. This provides the advantage that the scope block (parent block) for a given block
+    sref can be directly accessed as sref->parent
+    """
+
+    mod: IRModule
+
+    def __init__(self, mod: Union[IRModule, PrimFunc]):
+        if isinstance(mod, PrimFunc):
+            mod = IRModule({"main": mod})
+        if not isinstance(mod, IRModule):
+            raise TypeError(f"Expected `mod` to be PrimFunc or IRModule, but gets: {mod}")
+        self.__init_handle_by_constructor__(
+            _ffi_api.BlockDependenceInfo,  # type: ignore # pylint: disable=no-member
+            mod,
+        )
+
+    def get_sref(self, block: Block) -> Optional[StmtSRef]:
+        """Return the corresponding sref that points to the block
+
+        Parameters
+        ----------
+        stmt : Block
+            The block for which the sref is to be retrived
+
+        Returns
+        -------
+        sref : StmtSRef
+            The corresponding sref
+        """
+        return _ffi_api.BlockDependenceInfoGetSRef(self, block)  # type: ignore # pylint: disable=no-member
+
+    def get_block_scope(self, block_sref: StmtSRef) -> BlockScope:
+        """Get the BlockScope correpsonding to the block sref
+
+        Parameters
+        ----------
+        block_sref : StmtSRef
+            The block sref to be retrieved
+
+        Returns
+        -------
+        scope : StmtSRef
+            The corresponding BlockScope
+        """
+        return _ffi_api.BlockDependenceInfoGetBlockScope(  # type: ignore # pylint: disable=no-member
+            self, block_sref
+        )

--- a/src/tir/ir/block_dependence_info.cc
+++ b/src/tir/ir/block_dependence_info.cc
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <tvm/tir/block_dependence_info.h>
+#include <tvm/tir/utils.h>
+
+namespace tvm {
+namespace tir {
+
+/**
+ * @brief A helper class to collect and build Block Dependences using BlockScope class
+ */
+class BlockDependenceInfoCollector : private StmtVisitor {
+ public:
+  static void Collect(BlockDependenceInfoNode* self, const Stmt& stmt) {
+    BlockDependenceInfoCollector collector(self);
+    collector.VisitStmt(stmt);
+  }
+
+  explicit BlockDependenceInfoCollector(BlockDependenceInfoNode* self)
+      : self_(self), block_frames_{} {
+    block_frames_.emplace_back();
+  }
+
+  void MakeBlockScope(StmtSRef scope) {
+    Array<StmtSRef> child_block_srefs = std::move(block_frames_.back());
+    self_->sref2scope[scope] = BlockScope(child_block_srefs);
+  }
+
+  void VisitStmt_(const BlockRealizeNode* realize) final {
+    block_frames_.emplace_back();
+    const BlockNode* block = realize->block.get();
+    // Recursive visit
+    VisitStmt(block->body);  // `block->init` is not visited
+    // Create BlockInfo for the block
+    auto sref = self_->stmt2ref.at(block);
+    MakeBlockScope(sref);
+    // Update parent scope
+    block_frames_.pop_back();
+    block_frames_.back().push_back(sref);
+  }
+
+  void VisitStmt_(const SeqStmtNode* seq_stmt) final {
+    // Set `seq_index` information for SeqStmtNode
+    StmtVisitor::VisitStmt_(seq_stmt);
+    SetSeqIndexInChildren(self_->stmt2ref, seq_stmt, false);
+  }
+
+  BlockDependenceInfoNode* self_;
+  /*! \brief The stack frames of blocks in the DFS visit. */
+  std::vector<Array<StmtSRef>> block_frames_;
+};
+
+BlockDependenceInfo::BlockDependenceInfo() { data_ = make_object<BlockDependenceInfoNode>(); }
+
+BlockDependenceInfo::BlockDependenceInfo(IRModule mod) {
+  ObjectPtr<BlockDependenceInfoNode> n = make_object<BlockDependenceInfoNode>();
+  BlockDependenceInfoNode* self = n.get();
+  n->stmt2ref = SRefTreeCreator::Create(mod, /* include_loops */ false);
+
+  for (const auto& kv : mod->functions) {
+    const BaseFunc& base_func = kv.second;
+    if (auto opt = base_func.as<PrimFunc>()) {
+      auto func = opt.value();
+      BlockDependenceInfoCollector::Collect(self, func->body);
+    }
+  }
+  data_ = std::move(n);
+}
+
+TVM_REGISTER_NODE_TYPE(BlockDependenceInfoNode);
+TVM_REGISTER_GLOBAL("tir.BlockDependenceInfo")
+    .set_body_typed([](IRModule mod) -> BlockDependenceInfo { return BlockDependenceInfo(mod); });
+TVM_REGISTER_GLOBAL("tir.BlockDependenceInfoGetBlockScope")
+    .set_body_method<BlockDependenceInfo>(&BlockDependenceInfoNode::GetBlockScope);
+TVM_REGISTER_GLOBAL("tir.BlockDependenceInfoGetSRef")
+    .set_body_typed([](BlockDependenceInfo self, Stmt stmt) -> Optional<StmtSRef> {
+      auto it = self->stmt2ref.find(stmt.get());
+      return it != self->stmt2ref.end() ? it->second : Optional<StmtSRef>(NullOpt);
+    });
+
+}  // namespace tir
+}  // namespace tvm

--- a/src/tir/ir/block_scope.cc
+++ b/src/tir/ir/block_scope.cc
@@ -139,7 +139,6 @@ Array<Dependency> BlockScopeNode::GetDepsByDst(const StmtSRef& block_sref) const
 /*!
  * \brief Add a new statement to the stack, which becomes the current scope
  * \param stmt A for-loop statement or a block statement
- * \return A sref to the stmt
  */
 void SRefTreeCreator::PushSRef(const StmtNode* stmt) {
   if (srefs_.empty()) {

--- a/src/tir/ir/block_scope.cc
+++ b/src/tir/ir/block_scope.cc
@@ -136,6 +136,55 @@ Array<Dependency> BlockScopeNode::GetDepsByDst(const StmtSRef& block_sref) const
   }
 }
 
+/*!
+ * \brief Add a new statement to the stack, which becomes the current scope
+ * \param stmt A for-loop statement or a block statement
+ * \return A sref to the stmt
+ */
+void SRefTreeCreator::PushSRef(const StmtNode* stmt) {
+  if (srefs_.empty()) {
+    srefs_.push_back(
+        StmtSRef(stmt,
+                 /*parent=*/nullptr,
+                 /*seq_index=*/-1));  // `seq_index` will be set properly in SetSeqIndex
+  } else {
+    StmtSRefNode* parent = srefs_.back().get();
+    srefs_.push_back(
+        StmtSRef(stmt, parent,
+                 /*seq_index=*/-1));  // `seq_index` will be set properly in SetSeqIndex
+  }
+}
+
+/*! \brief Pop the top of the scope and record it in stmt2ref map */
+void SRefTreeCreator::PopAndRecordSRef() {
+  StmtSRef sref = std::move(srefs_.back());
+  stmt2ref_[sref->stmt] = sref;
+  srefs_.pop_back();
+}
+
+void SRefTreeCreator::VisitStmt_(const ForNode* loop) {
+  if (!include_loops_) {
+    VisitStmt(loop->body);
+  } else {
+    PushSRef(loop);
+    VisitStmt(loop->body);
+    PopAndRecordSRef();
+  }
+}
+
+void SRefTreeCreator::VisitStmt_(const BlockRealizeNode* realize) {
+  const BlockNode* block = realize->block.get();
+  PushSRef(block);
+  VisitStmt(block->body);  // `block->init` is not visited
+  PopAndRecordSRef();
+}
+
+void SRefTreeCreator::VisitStmt_(const SeqStmtNode* seq_stmt) {
+  // Set `seq_index` information for SeqStmtNode
+  StmtVisitor::VisitStmt_(seq_stmt);
+  SetSeqIndexInChildren(stmt2ref_, seq_stmt, include_loops_);
+}
+
 /******** FFI ********/
 
 TVM_REGISTER_NODE_TYPE(StmtSRefNode);

--- a/src/tir/schedule/state.cc
+++ b/src/tir/schedule/state.cc
@@ -125,42 +125,6 @@ bool ProducerCoversConsumer(const Array<PrimExpr>& buffer_shape,
 }
 
 /*!
- * \brief Set the `StmtSRefNode::seq_index` field for stmt
- * \param self The schedule class
- * \param stmt The statement, or the realize node of the statement whose sref to be set
- * \param seq_index The seq_index to be set
- * \note The method is NOP for statements that are not schedulable, i.e. not For or Block
- */
-void SetSeqIndex(ScheduleStateNode* self, const Stmt& stmt, int seq_index) {
-  if (const auto* realize = stmt.as<BlockRealizeNode>()) {
-    const BlockNode* block = realize->block.get();
-    ICHECK(self->stmt2ref.count(block));
-    self->stmt2ref.at(block)->seq_index = seq_index;
-  } else if (const auto* block = stmt.as<BlockNode>()) {
-    ICHECK(self->stmt2ref.count(block));
-    self->stmt2ref.at(block)->seq_index = seq_index;
-  } else if (const auto* loop = stmt.as<ForNode>()) {
-    ICHECK(self->stmt2ref.count(loop));
-    self->stmt2ref.at(loop)->seq_index = seq_index;
-  } else {
-    // do nothing
-  }
-}
-
-/*!
- * \brief Update seq_index of the children of a SeqStmt
- * \param self The schedule class
- * \param seq_stmt The SeqStmt whose children need updating
- */
-void SetSeqIndexInChildren(ScheduleStateNode* self, const SeqStmtNode* seq_stmt) {
-  int i = 0;
-  for (const Stmt& stmt : seq_stmt->seq) {
-    SetSeqIndex(self, stmt, i);
-    ++i;
-  }
-}
-
-/*!
  * \brief Update the sref information on the schedule class, as well as the statement of sref itself
  * More specifically, update
  *  `sref->stmt` to `new_stmt`
@@ -385,7 +349,7 @@ class BlockInfoCollector : private StmtVisitor {
   void VisitStmt_(const SeqStmtNode* seq_stmt) final {
     // Set `seq_index` information for SeqStmtNode
     StmtVisitor::VisitStmt_(seq_stmt);
-    SetSeqIndexInChildren(self_, seq_stmt);
+    SetSeqIndexInChildren(self_->stmt2ref, seq_stmt);
   }
 
   /*! \brief The ScheduleStateNode we are operating on */
@@ -400,102 +364,31 @@ class BlockInfoCollector : private StmtVisitor {
   arith::Analyzer analyzer_;
 };
 
-/*! \brief A helper class to create a new ScheduleStateNode from an IRModule */
-class StateCreator : private StmtVisitor {
- public:
-  /*!
-   * \brief ScheduleState Creator
-   * \param mod The module being scheduled.
-   * \param debug_mask Do extra correctness checking after the class creation
-   * and each time after calling the Replace method.
-   * \param enable_check Whether to enable prequisite checks for schedule primitives.
-   */
-  static ObjectPtr<ScheduleStateNode> Create(IRModule mod, int debug_mask, bool enable_check) {
-    ObjectPtr<ScheduleStateNode> n = make_object<ScheduleStateNode>();
-    ScheduleStateNode* self = n.get();
-    // Set `n->mod`
-    n->mod = std::move(mod);
-    // Set `n->debug_mask`
-    n->debug_mask = debug_mask;
-    // Set `n->enable_check`
-    n->enable_check = enable_check;
-    // Set `n->stmt2ref` and `n->block_info`
-    StateCreator creator(self);
-    for (const auto& kv : n->mod->functions) {
-      const BaseFunc& base_func = kv.second;
-      if (auto opt = base_func.as<PrimFunc>()) {
-        auto func = opt.value();
-        VerifyWellFormed(func);
-        creator.VisitStmt(func->body);
-        BlockInfoCollector::Collect(self, func->body);
-      }
-    }
-    return n;
-  }
-
- private:
-  /*!
-   * \brief The entry function
-   * \param self The schedule state to be completed
-   */
-  explicit StateCreator(ScheduleStateNode* self) : self_(self) {}
-
-  /*!
-   * \brief Add a new statement to the stack, which becomes the current scope
-   * \param stmt A for-loop statement or a block statement
-   * \return A sref to the stmt
-   */
-  void PushSRef(const StmtNode* stmt) {
-    if (srefs_.empty()) {
-      srefs_.push_back(
-          StmtSRef(stmt,
-                   /*parent=*/nullptr,
-                   /*seq_index=*/-1));  // `seq_index` will be set properly in SetSeqIndex
-    } else {
-      StmtSRefNode* parent = srefs_.back().get();
-      srefs_.push_back(
-          StmtSRef(stmt, parent,
-                   /*seq_index=*/-1));  // `seq_index` will be set properly in SetSeqIndex
-    }
-  }
-
-  /*! \brief Pop the top of the scope and record it in stmt2ref map */
-  void PopAndRecordSRef() {
-    StmtSRef sref = std::move(srefs_.back());
-    self_->stmt2ref[sref->stmt] = sref;
-    srefs_.pop_back();
-  }
-
-  void VisitStmt_(const ForNode* loop) final {
-    PushSRef(loop);
-    VisitStmt(loop->body);
-    PopAndRecordSRef();
-  }
-
-  void VisitStmt_(const BlockRealizeNode* realize) final {
-    const BlockNode* block = realize->block.get();
-    PushSRef(block);
-    VisitStmt(block->body);  // `block->init` is not visited
-    PopAndRecordSRef();
-  }
-
-  void VisitStmt_(const SeqStmtNode* seq_stmt) final {
-    // Set `seq_index` information for SeqStmtNode
-    StmtVisitor::VisitStmt_(seq_stmt);
-    SetSeqIndexInChildren(self_, seq_stmt);
-  }
-
-  /*! \brief The result ScheduleStateNode */
-  ScheduleStateNode* self_;
-  /*! \brief The stack frame used to indicate the current scope */
-  std::vector<StmtSRef> srefs_;
-};
-
 /**************** Constructor ****************/
 
 ScheduleState::ScheduleState(IRModule mod, int debug_mask, bool enable_check) {
   CHECK_GE(debug_mask, -1) << "ValueError: negative `debug_mask` other than -1 is not supported";
-  data_ = StateCreator::Create(mod, debug_mask, enable_check);
+  ObjectPtr<ScheduleStateNode> n = make_object<ScheduleStateNode>();
+  ScheduleStateNode* self = n.get();
+  // Set `n->mod`
+  n->mod = std::move(mod);
+  // Set `n->debug_mask`
+  n->debug_mask = debug_mask;
+  // Set `n->enable_check`
+  n->enable_check = enable_check;
+  std::unordered_map<const StmtNode*, StmtSRef> stmt2ref;
+  // Set `n->stmt2ref`
+  self->stmt2ref = SRefTreeCreator::Create(self->mod);
+  // Set `n->block_info`
+  for (const auto& kv : n->mod->functions) {
+    const BaseFunc& base_func = kv.second;
+    if (auto opt = base_func.as<PrimFunc>()) {
+      auto func = opt.value();
+      VerifyWellFormed(func);
+      BlockInfoCollector::Collect(self, func->body);
+    }
+  }
+  data_ = std::move(n);
 }
 
 /**************** Replace ****************/
@@ -783,7 +676,7 @@ class SRefUpdater : public StmtVisitor {
 
   void VisitStmt_(const SeqStmtNode* seq_stmt) final {
     StmtVisitor::VisitStmt_(seq_stmt);
-    SetSeqIndexInChildren(self_.get(), seq_stmt);
+    SetSeqIndexInChildren(self_->stmt2ref, seq_stmt);
   }
 
   void UpdateBlockInfo(const StmtSRef& block_sref) {
@@ -1023,7 +916,7 @@ void ScheduleStateNode::Replace(const tir::StmtSRef& _src_sref, const Stmt& tgt_
       // As the invariance of SRefUpdater,
       // the `seq_index` of the root of `tgt_stmt` is set as -1,
       // which might be incorrect
-      SetSeqIndex(this, child_tgt_stmt, child_sref->seq_index);
+      SetSeqIndex(this->stmt2ref, child_tgt_stmt, child_sref->seq_index);
     } else {
       // Point `child_sref` to `child_tgt_stmt`
       UpdateSRef(this, child_sref, child_tgt_stmt.get());

--- a/tests/python/unittest/test_tir_block_dependence_info.py
+++ b/tests/python/unittest/test_tir_block_dependence_info.py
@@ -1,0 +1,152 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=missing-function-docstring,missing-module-docstring
+import gc
+import sys
+
+import pytest
+import tvm
+import tvm.testing
+from tvm import tir
+from tvm.ir import IRModule
+from tvm.script import tir as T
+from tvm.tir import PrimFunc, BlockDependenceInfo
+from tvm.tir.stmt_functor import post_order_visit
+from tvm.tir.block_scope import DepKind
+
+# pylint: disable=no-member,invalid-name,unused-variable
+
+
+@T.prim_func
+def elementwise(a: T.handle, c: T.handle) -> None:
+    A = T.match_buffer(a, (128, 128), "float32")
+    C = T.match_buffer(c, (128, 128), "float32")
+    B = T.alloc_buffer((128, 128), "float32")
+    for i, j in T.grid(128, 128):
+        with T.block("B"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            B[vi, vj] = A[vi, vj] * 2.0
+    for i, j in T.grid(128, 128):
+        with T.block("C"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            C[vi, vj] = B[vi, vj] + 1.0
+    for i, j in T.grid(128, 128):
+        with T.block("D"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            C[vi, vj] = B[vi, vj] + 1.0
+
+
+@T.prim_func
+def war_dependency(a: T.handle, b: T.handle, c: T.handle) -> None:
+    A = T.match_buffer(a, (128, 128))
+    B = T.match_buffer(b, (128, 128))
+    C = T.match_buffer(c, (128, 128))
+
+    for i, j in T.grid(128, 128):
+        with T.block("C"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            C[vi, vj] = B[vi, vj] + 1.0
+        with T.block("B"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            B[vi, vj] = A[vi, vj] * 2.0
+
+
+@T.prim_func
+def matmul(a: T.handle, b: T.handle, c: T.handle) -> None:
+    A = T.match_buffer(a, [128, 128])
+    B = T.match_buffer(b, [128, 128])
+    C = T.match_buffer(c, [128, 128])
+    for i, j in T.grid(128, 128):
+        with T.block("init"):
+            vi, vj = T.axis.remap("SS", [i, j])
+            C[vi, vj] = T.float32(0)
+        for k in range(0, 128):
+            with T.block("update"):
+                vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vj, vk]
+
+
+# pylint: enable=no-member,invalid-name,unused-variable
+
+
+def get_blocks(func: PrimFunc):
+    blocks = {}
+
+    def update_blocks(node):
+        if isinstance(node, tvm.tir.Block):
+            blocks[node.name_hint] = node
+
+    # post_order_visit(func.body, lambda node: blocks[node.name_hint] = node if isinstance(node, tvm.tir.Block) else None)
+    post_order_visit(func.body, update_blocks)
+    return blocks
+
+
+def _verify_dependence(dependence_info, src_block, dst_block, kind):
+    src_sref = dependence_info.get_sref(src_block)
+    dst_sref = dependence_info.get_sref(dst_block)
+    scope = dependence_info.get_block_scope(src_sref.parent)
+
+    def _find_dependence(deps):
+        for dep in deps:
+            if dep.src == src_sref and dep.dst == dst_sref and dep.kind == kind:
+                return dep
+        return None
+
+    def _get_dependency_kind_name(dep_kind):
+        if isinstance(dep_kind, int):
+            dep_kind = DepKind(dep_kind)
+        return dep_kind.name
+
+    # Check dependences by src
+    deps_by_src = scope.get_deps_by_src(src_sref)
+    dependence = _find_dependence(deps_by_src)
+    assert (
+        dependence
+    ), f"Expected a dependency with src block {src_block.name_hint} and dst block {dst_block.name_hint} of kind {kind.name}"
+
+    # Check dependences by dst
+    deps_by_dst = scope.get_deps_by_dst(dst_sref)
+    dependence = _find_dependence(deps_by_dst)
+    assert (
+        dependence
+    ), f"Expected a dependency with src block {src_block.name_hint} and dst block {dst_block.name_hint}"
+
+
+def test_RAW_dependences():
+    func = elementwise
+    dependence_info = BlockDependenceInfo(func)
+    blocks = get_blocks(func)
+    _verify_dependence(dependence_info, blocks["B"], blocks["C"], DepKind.RAW)
+
+
+def test_WAR_dependences():
+    func = war_dependency
+    dependence_info = BlockDependenceInfo(func)
+    blocks = get_blocks(func)
+    _verify_dependence(dependence_info, blocks["C"], blocks["B"], DepKind.WAR)
+
+
+def test_RAW_and_WAW_dependences():
+    func = matmul
+    dependence_info = BlockDependenceInfo(func)
+    blocks = get_blocks(func)
+    _verify_dependence(dependence_info, blocks["init"], blocks["update"], DepKind.RAW)
+    _verify_dependence(dependence_info, blocks["init"], blocks["update"], DepKind.WAW)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This work introduces a new object called `BlockDependenceInfo` that computes and returns block dependences. The idea is to be able to expose block level dependences to TIR passes without having to create an explicit schedules.

The patch introduces 2 main classes:
1. `SRefTreeCreator` - This creates and returns a new SRefTree and returns a map from original statements to corresponding srefs
2. `BlockDependenceInfo` - This object computes the actual dependences between blocks within a block scope and returns it for access in TIR passes

This is a continuation to
[PR #15034](https://github.com/apache/tvm/pull/15034) and completes the work started there to expose block level dependences to TIR passes

Note: One major difference between the SRef Tree created for dependence analysis here versus the one already present in schedules is that this SRef tree only contains block nodes and not loops. This makes it easier to find the parent blocks (by just accessing `parent` member)