### PR TITLE
[microNPU][ETHOSU] Add option to disable copying constants for case without cascader

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/codegen.py
+++ b/python/tvm/relay/backend/contrib/ethosu/codegen.py
@@ -526,7 +526,8 @@ def relay_to_tir(mod: tvm.ir.IRModule) -> tvm.ir.IRModule:
         sram = extract_memory_info(workspace_memory_pools.pools[0], memory_pressure)
         tir_mod = LowerToTIR(_ethos_u55_cascader(sram, util.is_striping_enabled()))(mod)
     else:
-        tir_mod = LowerToTIR(copy_constants())(mod)
+        scheduler = None if util.is_copying_constants_disabled() else copy_constants()
+        tir_mod = LowerToTIR(scheduler)(mod)
 
     return tir_mod
 

--- a/python/tvm/relay/backend/contrib/ethosu/util.py
+++ b/python/tvm/relay/backend/contrib/ethosu/util.py
@@ -258,6 +258,12 @@ def is_cascader_enabled():
     return compiler_attrs.enable_cascader
 
 
+def is_copying_constants_disabled():
+    """Determine whether copying constants is disabled for case without cascader"""
+    compiler_attrs = tvm.get_global_func("relay.ext.ethos-u.get_compiler_attrs")()
+    return compiler_attrs.disable_copying_constants
+
+
 def is_striping_enabled():
     """Determine whether the cascader is enabled"""
     compiler_attrs = tvm.get_global_func("relay.ext.ethos-u.get_compiler_attrs")()

--- a/python/tvm/relay/backend/contrib/ethosu/util.py
+++ b/python/tvm/relay/backend/contrib/ethosu/util.py
@@ -258,10 +258,10 @@ def is_cascader_enabled():
     return compiler_attrs.enable_cascader
 
 
-def is_copying_constants_disabled():
+def is_copying_constants_disabled() -> bool:
     """Determine whether copying constants is disabled for case without cascader"""
     compiler_attrs = tvm.get_global_func("relay.ext.ethos-u.get_compiler_attrs")()
-    return compiler_attrs.disable_copying_constants
+    return bool(compiler_attrs.disable_copying_constants)
 
 
 def is_striping_enabled():

--- a/src/relay/backend/contrib/ethosu/compiler_attrs.cc
+++ b/src/relay/backend/contrib/ethosu/compiler_attrs.cc
@@ -41,6 +41,7 @@ struct EthosUCompilerConfigNode : public tvm::AttrsNode<EthosUCompilerConfigNode
   String accelerator_config;
   bool enable_cascader;
   bool enable_striping;
+  bool disable_copying_constants;
   String dev_force_block_config;
   String dev_max_open_plans;
   String dev_max_closed_plans;
@@ -58,6 +59,9 @@ struct EthosUCompilerConfigNode : public tvm::AttrsNode<EthosUCompilerConfigNode
         .set_default("ethos-u55-256");
     TVM_ATTR_FIELD(enable_cascader)
         .describe("Whether the cascader should be enabled")
+        .set_default(false);
+    TVM_ATTR_FIELD(disable_copying_constants)
+        .describe("Whether copying constants is disabled for case without cascader")
         .set_default(false);
     TVM_ATTR_FIELD(enable_striping)
         .describe("Whether the cascader should be striping")

--- a/src/relay/backend/contrib/ethosu/compiler_attrs.cc
+++ b/src/relay/backend/contrib/ethosu/compiler_attrs.cc
@@ -41,7 +41,7 @@ struct EthosUCompilerConfigNode : public tvm::AttrsNode<EthosUCompilerConfigNode
   String accelerator_config;
   bool enable_cascader;
   bool enable_striping;
-  bool disable_copying_constants;
+  Bool disable_copying_constants = Bool(false);
   String dev_force_block_config;
   String dev_max_open_plans;
   String dev_max_closed_plans;
@@ -62,7 +62,7 @@ struct EthosUCompilerConfigNode : public tvm::AttrsNode<EthosUCompilerConfigNode
         .set_default(false);
     TVM_ATTR_FIELD(disable_copying_constants)
         .describe("Whether copying constants is disabled for case without cascader")
-        .set_default(false);
+        .set_default(Bool(false));
     TVM_ATTR_FIELD(enable_striping)
         .describe("Whether the cascader should be striping")
         .set_default(false);

--- a/src/relay/backend/contrib/ethosu/compiler_attrs.cc
+++ b/src/relay/backend/contrib/ethosu/compiler_attrs.cc
@@ -61,7 +61,12 @@ struct EthosUCompilerConfigNode : public tvm::AttrsNode<EthosUCompilerConfigNode
         .describe("Whether the cascader should be enabled")
         .set_default(false);
     TVM_ATTR_FIELD(disable_copying_constants)
-        .describe("Whether copying constants is disabled for case without cascader")
+        .describe(
+            "Whether copying constants is disabled for case without the cascader. When this option "
+            "is "
+            "enabled, it is assumed that the constants should be located in SRAM (user determines "
+            "in "
+            "the linker script for section \".rodata.tvm\" that the constants are located in SRAM)")
         .set_default(Bool(false));
     TVM_ATTR_FIELD(enable_striping)
         .describe("Whether the cascader should be striping")


### PR DESCRIPTION
Added the option to disable copying constants for the case when the user determines in the linker script for section ".rodata.tvm" that the constants are located in SRAM.
To activate this option, pass the `--target-ethos-u-disable_copying_constants=1` argument to tvmc.

cc @neildhickey, @lhutton1, @ekalda, @leandron