### PR TITLE
[TensorIR][Visitor] Visit buffer members in `match_buffer`'s in block visitor functions

### DIFF
--- a/src/tir/ir/stmt_functor.cc
+++ b/src/tir/ir/stmt_functor.cc
@@ -254,10 +254,8 @@ class StmtMutator::Internal {
           MutateArray(self, buffer->axis_separators,
                       [self](const IntImm& e) { return Downcast<IntImm>(self->VisitExpr(e)); });
 
-      if (elem_offset.same_as(buffer->elem_offset) &&
-          strides.same_as(buffer->strides) &&
-          shape.same_as(buffer->shape) &&
-          axis_separators.same_as(buffer->axis_separators)) {
+      if (elem_offset.same_as(buffer->elem_offset) && strides.same_as(buffer->strides) &&
+          shape.same_as(buffer->shape) && axis_separators.same_as(buffer->axis_separators)) {
         if (region.same_as(match_buffer_region->source->region)) {
           return match_buffer_region;
         } else {
@@ -265,12 +263,9 @@ class StmtMutator::Internal {
                                    BufferRegion(match_buffer_region->source->buffer, region));
         }
       } else {
-        Buffer new_buffer(buffer->data, buffer->dtype,
-                          shape, strides, elem_offset, buffer->name,
-                          buffer->data_alignment,
-                          buffer->offset_factor,
-                          buffer->buffer_type, axis_separators,
-                          buffer->span);
+        Buffer new_buffer(buffer->data, buffer->dtype, shape, strides, elem_offset, buffer->name,
+                          buffer->data_alignment, buffer->offset_factor, buffer->buffer_type,
+                          axis_separators, buffer->span);
         return MatchBufferRegion(new_buffer,
                                  BufferRegion(match_buffer_region->source->buffer, region));
       }

--- a/src/tir/transforms/lower_match_buffer.cc
+++ b/src/tir/transforms/lower_match_buffer.cc
@@ -161,6 +161,7 @@ class MatchBufferLower : public StmtExprMutator {
     match_buffers_.Set(buffer, source);
     // Step.2.1. Update buffer data
     Bind(buffer->data, source_buffer->data, buffer->name + ".data");
+    LOG(INFO) << buffer->elem_offset;
 
     // Step.2.2. Update element offset
     // We use the ElemOffset method to avoid duplicating the index calculation.
@@ -172,6 +173,7 @@ class MatchBufferLower : public StmtExprMutator {
       }
 
       Array<PrimExpr> buffer_start_indices = source_buffer->ElemOffset(indices);
+      LOG(INFO) << buffer_start_indices;
       if (buffer_start_indices.size() == 1) {
         Bind(buffer->elem_offset, buffer_start_indices[0], buffer->name + ".elem_offset");
         CHECK(analyzer_.CanProve(truncmod(buffer->elem_offset, buffer->offset_factor) == 0))
@@ -219,6 +221,8 @@ class MatchBufferLower : public StmtExprMutator {
         << "The data type mismatched: " << arg->dtype << " vs. " << value->dtype;
     // Handle recursive case
     value = Substitute(std::move(value), var_map_);
+    LOG(INFO) << arg;
+    LOG(INFO) << value;
     if (arg->IsInstance<VarNode>()) {
       Var v = Downcast<Var>(arg);
       auto it = var_map_.find(v);

--- a/src/tir/transforms/lower_match_buffer.cc
+++ b/src/tir/transforms/lower_match_buffer.cc
@@ -161,7 +161,6 @@ class MatchBufferLower : public StmtExprMutator {
     match_buffers_.Set(buffer, source);
     // Step.2.1. Update buffer data
     Bind(buffer->data, source_buffer->data, buffer->name + ".data");
-    LOG(INFO) << buffer->elem_offset;
 
     // Step.2.2. Update element offset
     // We use the ElemOffset method to avoid duplicating the index calculation.
@@ -173,7 +172,6 @@ class MatchBufferLower : public StmtExprMutator {
       }
 
       Array<PrimExpr> buffer_start_indices = source_buffer->ElemOffset(indices);
-      LOG(INFO) << buffer_start_indices;
       if (buffer_start_indices.size() == 1) {
         Bind(buffer->elem_offset, buffer_start_indices[0], buffer->name + ".elem_offset");
         CHECK(analyzer_.CanProve(truncmod(buffer->elem_offset, buffer->offset_factor) == 0))
@@ -221,8 +219,6 @@ class MatchBufferLower : public StmtExprMutator {
         << "The data type mismatched: " << arg->dtype << " vs. " << value->dtype;
     // Handle recursive case
     value = Substitute(std::move(value), var_map_);
-    LOG(INFO) << arg;
-    LOG(INFO) << value;
     if (arg->IsInstance<VarNode>()) {
       Var v = Downcast<Var>(arg);
       auto it = var_map_.find(v);

--- a/tests/python/unittest/test_tir_lower_match_buffer.py
+++ b/tests/python/unittest/test_tir_lower_match_buffer.py
@@ -493,7 +493,7 @@ def match_buffer_with_offset(a: T.handle, idx: T.handle, offset: T.int32) -> Non
     I = T.match_buffer(idx, (4), dtype="int32")
     for i, j in T.grid(4, 2):
         with T.block():
-            sub_A = T.match_buffer(A[I[i], offset, j * 4:j * 4 + 4], (4))
+            sub_A = T.match_buffer(A[0, 0, j * 4:j * 4 + 4], (4), offset_factor=1)
             for ji in range(0, 4):
                 sub_A[j * 4 + ji] = 1
 

--- a/tests/python/unittest/test_tir_lower_match_buffer.py
+++ b/tests/python/unittest/test_tir_lower_match_buffer.py
@@ -487,6 +487,16 @@ def fail_match_func_param(a: T.handle, m: T.handle, n: T.handle) -> None:
             for jj in range(0, 4):
                 sub_A[i, j * 4 + jj] = 1
 
+@T.prim_func
+def match_buffer_with_offset(a: T.handle, idx: T.handle, offset: T.int32) -> None:
+    A = T.match_buffer(a, (8, 10, 8))
+    I = T.match_buffer(idx, (4), dtype="int32")
+    for i, j in T.grid(4, 2):
+        with T.block():
+            sub_A = T.match_buffer(A[I[i], offset, j * 4:j * 4 + 4], (4))
+            for ji in range(0, 4):
+                sub_A[j * 4 + ji] = 1
+
 
 def test_buffer_load_store():
     _check(buffer_load_store, transformed_buffer_load_store)
@@ -528,14 +538,20 @@ def test_fail_buffer_bind():
 def test_fail_match_func_param():
     _check_fail(fail_match_func_param)
 
+def test_elem_offset():
+    mod = tvm.IRModule.from_expr(match_buffer_with_offset)
+    mod = tvm.tir.transform.LowerMatchBuffer()(mod)
+    mod = tvm.tir.transform.Simplify()(mod)
+    print(mod["main"])
 
 if __name__ == "__main__":
-    test_buffer_load_store()
-    test_opaque_access()
-    test_high_dim_opaque_access()
-    test_recursive_match()
-    test_symbolic_match()
-    test_rank0_buffer()
-    test_fail_load_store()
-    test_fail_buffer_bind()
-    test_fail_match_func_param()
+    # test_buffer_load_store()
+    # test_opaque_access()
+    # test_high_dim_opaque_access()
+    # test_recursive_match()
+    # test_symbolic_match()
+    # test_rank0_buffer()
+    # test_fail_load_store()
+    # test_fail_buffer_bind()
+    # test_fail_match_func_param()
+    test_elem_offset()

--- a/tests/python/unittest/test_tir_lower_match_buffer.py
+++ b/tests/python/unittest/test_tir_lower_match_buffer.py
@@ -18,6 +18,7 @@
 import pytest
 
 import tvm
+import tvm.testing
 from tvm.script import tir as T
 
 
@@ -529,22 +530,6 @@ def test_fail_match_func_param():
     _check_fail(fail_match_func_param)
 
 
-def test_elem_offset():
-    mod = tvm.IRModule.from_expr(match_buffer_with_offset)
-    mod = tvm.tir.transform.UnifyThreadBinding()(mod)
-    # mod = tvm.tir.transform.LowerMatchBuffer()(mod)
-    # mod = tvm.tir.transform.Simplify()(mod)
-    print(mod["main"])
-
-
 if __name__ == "__main__":
-    # test_buffer_load_store()
-    # test_opaque_access()
-    # test_high_dim_opaque_access()
-    # test_recursive_match()
-    # test_symbolic_match()
-    # test_rank0_buffer()
-    # test_fail_load_store()
-    # test_fail_buffer_bind()
-    # test_fail_match_func_param()
-    test_elem_offset()
+    tvm.testing.main()
+    

--- a/tests/python/unittest/test_tir_lower_match_buffer.py
+++ b/tests/python/unittest/test_tir_lower_match_buffer.py
@@ -487,16 +487,6 @@ def fail_match_func_param(a: T.handle, m: T.handle, n: T.handle) -> None:
             for jj in range(0, 4):
                 sub_A[i, j * 4 + jj] = 1
 
-@T.prim_func
-def match_buffer_with_offset(a: T.handle, idx: T.handle, offset: T.int32) -> None:
-    A = T.match_buffer(a, (8, 10, 8))
-    I = T.match_buffer(idx, (4), dtype="int32")
-    for i, j in T.grid(4, 2):
-        with T.block():
-            sub_A = T.match_buffer(A[0, 0, j * 4:j * 4 + 4], (4), offset_factor=1)
-            for ji in range(0, 4):
-                sub_A[j * 4 + ji] = 1
-
 
 def test_buffer_load_store():
     _check(buffer_load_store, transformed_buffer_load_store)
@@ -538,11 +528,14 @@ def test_fail_buffer_bind():
 def test_fail_match_func_param():
     _check_fail(fail_match_func_param)
 
+
 def test_elem_offset():
     mod = tvm.IRModule.from_expr(match_buffer_with_offset)
-    mod = tvm.tir.transform.LowerMatchBuffer()(mod)
-    mod = tvm.tir.transform.Simplify()(mod)
+    mod = tvm.tir.transform.UnifyThreadBinding()(mod)
+    # mod = tvm.tir.transform.LowerMatchBuffer()(mod)
+    # mod = tvm.tir.transform.Simplify()(mod)
     print(mod["main"])
+
 
 if __name__ == "__main__":
     # test_buffer_load_store()

--- a/tests/python/unittest/test_tir_lower_match_buffer.py
+++ b/tests/python/unittest/test_tir_lower_match_buffer.py
@@ -532,4 +532,3 @@ def test_fail_match_func_param():
 
 if __name__ == "__main__":
     tvm.testing.main()
-    


### PR DESCRIPTION
# Motivation
Currently, the `elem_offset` member in `match_buffer`'s will not be visited in default block visitor functions, resulting in some passes cannot correctly rewrite the program because some fields have not been entered.

This PR fixes the issue by visiting this field in default StmtVisitor and StmtExpr.