### PR TITLE
[Runtime] Clean TVM stacktrace in error messages

### DIFF
--- a/include/tvm/runtime/logging.h
+++ b/include/tvm/runtime/logging.h
@@ -539,13 +539,6 @@ class VLogContextEntry {
   std::stringstream sstream_;
 };
 
-constexpr const char* kTVM_INTERNAL_ERROR_MESSAGE =
-    "\n"
-    "---------------------------------------------------------------\n"
-    "An error occurred during the execution of TVM.\n"
-    "For more information, please see: https://tvm.apache.org/docs/errors.html\n"
-    "---------------------------------------------------------------\n";
-
 template <typename X, typename Y>
 std::unique_ptr<std::string> LogCheckFormat(const X& x, const Y& y) {
   std::ostringstream os;
@@ -694,14 +687,12 @@ TVM_CHECK_FUNC(_NE, !=)
 #define ICHECK_BINARY_OP(name, op, x, y)                                   \
   if (auto __tvm__log__err = ::tvm::runtime::detail::LogCheck##name(x, y)) \
   ::tvm::runtime::detail::LogFatal(__FILE__, __LINE__).stream()            \
-      << ::tvm::runtime::detail::kTVM_INTERNAL_ERROR_MESSAGE << std::endl  \
-      << TVM_ICHECK_INDENT << "Check failed: " << #x " " #op " " #y << *__tvm__log__err << ": "
+      << "InternalError: Check failed: " << #x " " #op " " #y << *__tvm__log__err << ": "
 
-#define ICHECK(x)                                                                 \
-  if (!(x))                                                                       \
-  ::tvm::runtime::detail::LogFatal(__FILE__, __LINE__).stream()                   \
-      << ::tvm::runtime::detail::kTVM_INTERNAL_ERROR_MESSAGE << TVM_ICHECK_INDENT \
-      << "Check failed: (" #x << ") is false: "
+#define ICHECK(x)                                               \
+  if (!(x))                                                     \
+  ::tvm::runtime::detail::LogFatal(__FILE__, __LINE__).stream() \
+      << "InternalError: Check failed: (" #x << ") is false: "
 
 #define ICHECK_LT(x, y) ICHECK_BINARY_OP(_LT, <, x, y)
 #define ICHECK_GT(x, y) ICHECK_BINARY_OP(_GT, >, x, y)
@@ -711,8 +702,7 @@ TVM_CHECK_FUNC(_NE, !=)
 #define ICHECK_NE(x, y) ICHECK_BINARY_OP(_NE, !=, x, y)
 #define ICHECK_NOTNULL(x)                                                         \
   ((x) == nullptr ? ::tvm::runtime::detail::LogFatal(__FILE__, __LINE__).stream() \
-                        << ::tvm::runtime::detail::kTVM_INTERNAL_ERROR_MESSAGE    \
-                        << TVM_ICHECK_INDENT << "Check not null: " #x << ' ',     \
+                        << "InternalError: Check not null: " #x << ' ',           \
    (x) : (x))  // NOLINT(*)
 
 }  // namespace runtime

--- a/python/tvm/error.py
+++ b/python/tvm/error.py
@@ -25,7 +25,7 @@ copy the examples and raise errors with the same message convention.
 
     Please also refer to :ref:`error-handling-guide`.
 """
-from tvm._ffi.base import register_error, TVMError
+from tvm._ffi.base import TVMError, register_error
 
 
 @register_error
@@ -46,12 +46,6 @@ class InternalError(TVMError):
     """
 
     def __init__(self, msg):
-        # Patch up additional hint message.
-        if "TVM hint:" not in msg:
-            msg += (
-                "\nTVM hint: You hit an internal error. "
-                + "Please open a thread on https://discuss.tvm.apache.org/ to report it."
-            )
         super(InternalError, self).__init__(msg)
 
 


### PR DESCRIPTION
This PR introduces some cleanups on the stacktraces in TVM's error message by removing the meaningless frames, for example, C++ template dispatch with `std::enable_if`.