### PR TITLE
[TIR] Fix RenewDef for symbolic input shapes

### DIFF
--- a/src/tir/transforms/renew_defs.cc
+++ b/src/tir/transforms/renew_defs.cc
@@ -50,6 +50,18 @@ class RenewDefMutator : public StmtExprMutator {
     for (const auto& param : func->params) {
       params.push_back(generator.ReDefineVar(param));
     }
+    for (const auto& param : func->params) {
+      if (param->dtype.is_handle()) {
+        const Buffer& buffer = func->buffer_map.at(param);
+        for (const PrimExpr& e : buffer->shape) {
+          if (const auto* v = e.as<VarNode>()) {
+            if (generator.remap_.count(GetRef<Var>(v)) == 0) {
+              generator.ReDefineVar(GetRef<Var>(v));
+            }
+          }
+        }
+      }
+    }
     // Redefine buffers in order
     // TODO(Siyuan Feng): checking var is used after define
     Map<tir::Var, Buffer> buffer_map;


### PR DESCRIPTION
There are cases where the shapes of input buffers are symbolic, but the first symbol is a composite PrimExpr rather than a TIR Var, which the original implementation does not take this into account.

Example:

```python
@T.prim_func
def main(a: T.handle, b: T.handle):
    m = T.int64()
    A = T.match_buffer(a, (m * 2,))  // `m` first appears as composite
    B = T.match_buffer(b, (m, 2))
```