### PR TITLE
[Unity][UX][Tweak] Make it an error to mark a function private and specify a global symbol

### DIFF
--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -86,6 +86,10 @@ void FuncAttrs(Map<String, ObjectRef> attrs) {
   if (!frame->attrs.empty()) {
     LOG(FATAL) << "ValueError: Duplicate function attrs, previous one is:\n" << frame->attrs;
   }
+  if (attrs.count(tvm::attr::kGlobalSymbol) && frame->is_private.value_or(Bool(false))->value) {
+    LOG(FATAL) << "ValueError: Specifying a global symbol attribute even though the function is "
+                  "annotated as private";
+  }
   frame->attrs = attrs;
 }
 

--- a/tests/python/relax/test_transform_fuse_ops.py
+++ b/tests/python/relax/test_transform_fuse_ops.py
@@ -1446,7 +1446,7 @@ def test_partially_used_tuple_param():
 
     @I.ir_module
     class Expected:
-        @R.function
+        @R.function(private=True)
         def fused_add_divide(
             x_0: R.Tensor((2,), dtype="float32"),
             param_0: R.Tensor((), dtype="float32"),

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -60,7 +60,7 @@ class Conv2dReLU_composite_annotated:
             R.output(gv)
         return gv
 
-    @R.function(private=True)
+    @R.function
     def fused_relax_nn_conv2d_relax_nn_relu_dnnl(
         data1: R.Tensor((1, 64, 56, 56), dtype="float32"),
         weight11: R.Tensor((64, 64, 3, 3), dtype="float32"),
@@ -377,7 +377,7 @@ class Conv2dx2:
 
 @tvm.script.ir_module
 class Conv2dx2_partitioned:
-    @R.function(private=True)
+    @R.function
     def fused_relax_nn_conv2d_cutlass(
         data: R.Tensor((16, 32, 32, 16), dtype="float16"),
         weight1: R.Tensor((16, 3, 3, 16), dtype="float16"),

--- a/tests/python/relax/test_transform_rewrite_cuda_graph.py
+++ b/tests/python/relax/test_transform_rewrite_cuda_graph.py
@@ -294,7 +294,7 @@ def test_vm_builtin():
                         T.writes(compute[i0, i1])
                         compute[i0, i1] = T.exp(rxplaceholder[i0, i1])
 
-        @R.function
+        @R.function(private=True)
         def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object):
             R.func_attr({"relax.force_pure": True})
             storage: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
@@ -302,7 +302,7 @@ def test_vm_builtin():
             gv: R.Tuple(R.Object, R.Object) = (storage, storage1)
             return gv
 
-        @R.function
+        @R.function(private=True)
         def cuda_graph_capture(alloc: R.Tensor((2, 4), dtype="float32"), alloc1: R.Tensor((2, 4), dtype="float32"), storage: R.Object) -> R.Tuple(R.Tensor((2, 4), dtype="float32"), R.Tensor((2, 4), dtype="float32")):
             R.func_attr({"relax.force_pure": True})
             cls = Expected

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1510,5 +1510,35 @@ def test_private_function():
     _check(Addition, bb.get())
 
 
+def test_private_function_with_global_symbol_fail():
+    with pytest.raises(tvm.error.DiagnosticError):
+
+        @I.ir_module
+        class Addition:
+            @R.function(private=True)
+            def main(x: R.Tensor((), "int32")) -> R.Tensor((), "int32"):
+                # it is an error to simultaneously mark a function private
+                # and give it a global symbol manually
+                R.func_attr({"global_symbol": "main"})
+                y = R.add(x, x)
+                return y
+
+        # should not execute
+        _check(Addition)
+
+
+def test_private_function_with_global_symbol_no_module_fail():
+    with pytest.raises(tvm.error.DiagnosticError):
+
+        @R.function(private=True)
+        def func(x: R.Tensor((), "int32")) -> R.Tensor((), "int32"):
+            R.func_attr({"global_symbol": "main"})
+            y = R.add(x, x)
+            return y
+
+        # should not execute
+        _check(func)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
A small follow-up to #15140, which was merged before I could make this addition: This change throws an error if a function has been annotated as private but the user manually specifies the global symbol. Since it is a contradiction to do so, it is best to detect this error rather than have it silently work (with the effect of actually making the function public).