### PR TITLE
[Unity] Support clear global memory allocators

### DIFF
--- a/include/tvm/runtime/relax_vm/memory_manager.h
+++ b/include/tvm/runtime/relax_vm/memory_manager.h
@@ -97,6 +97,9 @@ class MemoryManager {
    */
   static Allocator* GetAllocator(Device dev);
 
+  /*! \brief Clear the allocators. */
+  static void Clear();
+
  private:
   MemoryManager() {}
 


### PR DESCRIPTION
This PR supports clearing up all the allocated memory in among relax VMs.

Prior to this PR, all the allocated memory are managed in the pool of memory manager. The allocated memory in the pool is never freed and the pool size always goes up monotonically.

While good to save time of memory allocation, in some cases (e.g., on mobile phones which may have running memory limit) we need to clear the pool and free all the memory in order to prevent the pool from endlessly growing up and some of allocated memory not being effectively utilized.

Therefore, this PR introduces a PackedFunc that helps clear the pool.