### PR TITLE
[RUNTIME] Add weak symbol to builtin fp16

### DIFF
--- a/src/runtime/builtin_fp16.cc
+++ b/src/runtime/builtin_fp16.cc
@@ -37,7 +37,7 @@ TVM_DLL TVM_WEAK float __gnu_h2f_ieee(uint16_t a) {
   return __extendXfYf2__<uint16_t, uint16_t, 10, float, uint32_t, 23>(a);
 }
 
-TVM_DLL uint16_t __truncdfhf2(double a) {
+TVM_DLL TVM_WEAK uint16_t __truncdfhf2(double a) {
   return __truncXfYf2__<double, uint64_t, 52, uint16_t, uint16_t, 10>(a);
 }
 


### PR DESCRIPTION
This PR add weak symbol to remaining functions in builtin fp16. Weak is needed because such builtin function can be provided by other libraries and we only need one runtime implementation of it.