### PR TITLE
[RPC] Disable socket SO_REUSEADDR for Windows

### DIFF
--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -34,6 +34,7 @@ import threading
 import multiprocessing
 import time
 import errno
+import sys
 import tvm._ffi
 
 from tvm._ffi.base import py_str
@@ -334,7 +335,12 @@ class PopenRPCServerState(object):
 
         if not is_proxy:
             sock = socket.socket(base.get_addr_family((host, port)), socket.SOCK_STREAM)
-            if reuse_addr:
+
+            # Never set socket SO_REUSEADDR on Windows. The SO_REUSEADDR flag allow reusing the
+            # inactivate TIME_WATI state sockets on POSIX, but on Windows it will allow two or more
+            # activate sockets to bind on the same address and port if they all set SO_REUSEADDR,
+            # and result in indeterminate behavior.
+            if reuse_addr and sys.platform != "win32":
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             if timeout is not None:
                 sock.settimeout(timeout)


### PR DESCRIPTION
This PR fix a RPC issue on Windows by disabling socket SO_REUSEADDR flag. This flag works as expected on POSIX platforms, but will cause indeterminate behaviors on Windows sockets.

Reference: https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse#using-so_reuseaddr