### PR TITLE
Fix super() visit function in PyExprVisitor and PyExprMutator

### DIFF
--- a/src/relax/ir/py_expr_functor.cc
+++ b/src/relax/ir/py_expr_functor.cc
@@ -568,12 +568,24 @@ TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitBinding")
 
 TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitBindingBlock")
     .set_body_typed([](PyExprVisitor visitor, const BindingBlock& block) {
-      visitor->ExprVisitor::VisitBindingBlock(block);
+      if (const auto* ptr = block.as<DataflowBlockNode>()) {
+        visitor->ExprVisitor::VisitBindingBlock_(ptr);
+      } else if (const auto* ptr = block.as<BindingBlockNode>()) {
+        visitor->ExprVisitor::VisitBindingBlock_(ptr);
+      } else {
+        LOG(FATAL) << "TypeError: Invalid type: " << block->GetTypeKey();
+      }
     });
 
 TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitVarDef")
     .set_body_typed([](PyExprVisitor visitor, const Var& var) {
-      visitor->ExprVisitor::VisitVarDef(var);
+      if (const auto* node = var.as<DataflowVarNode>()) {
+        visitor->ExprVisitor::VisitVarDef_(node);
+      } else if (const auto* node = var.as<VarNode>()) {
+        visitor->ExprVisitor::VisitVarDef_(node);
+      } else {
+        LOG(FATAL) << "TypeError: Invalid type: " << var->GetTypeKey();
+      }
     });
 
 TVM_REGISTER_GLOBAL("relax.ExprVisitorVisitSpan")
@@ -621,12 +633,24 @@ TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitBinding")
 
 TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitBindingBlock")
     .set_body_typed([](PyExprMutator mutator, const BindingBlock& block) {
-      return mutator->ExprMutator::VisitBindingBlock(block);
+      if (const auto* node = block.as<DataflowBlockNode>()) {
+        return mutator->ExprMutator::VisitBindingBlock_(node);
+      } else if (const auto* node = block.as<BindingBlockNode>()) {
+        return mutator->ExprMutator::VisitBindingBlock_(node);
+      } else {
+        LOG(FATAL) << "TypeError: Invalid type: " << block->GetTypeKey();
+      }
     });
 
 TVM_REGISTER_GLOBAL("relax.ExprMutatorVisitVarDef")
     .set_body_typed([](PyExprMutator mutator, const Var& var) {
-      return mutator->ExprMutator::VisitVarDef(var);
+      if (const auto* node = var.as<DataflowVarNode>()) {
+        return mutator->ExprMutator::VisitVarDef_(node);
+      } else if (const auto* node = var.as<VarNode>()) {
+        return mutator->ExprMutator::VisitVarDef_(node);
+      } else {
+        LOG(FATAL) << "TypeError: Invalid type: " << var->GetTypeKey();
+      }
     });
 
 TVM_REGISTER_GLOBAL("relax.PyExprMutatorVisitExprPostOrder")


### PR DESCRIPTION
As we discussed in https://discuss.tvm.apache.org/t/recursive-visiting-in-pyexprmutator/15224, 

It will run into an infinite recursion if we call the super() visit function in PyExprVisitor and PyExprMutator.

```python
super().visit_binding_block_()
super().visit_dataflow_block_()
super().visit_var_def_()
super().visit_dataflow_var_def_()
```

This PR fixes the behavior.