### PR TITLE
[Unity][BYOC] `PrimValue` handling in `FuseOpByPattern` for BYOC

### DIFF
--- a/src/relax/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relax/backend/contrib/codegen_json/codegen_json.h
@@ -347,7 +347,7 @@ class JSONSerializer : public relax::MemoizedExprTranslator<NodeEntries> {
 
     // TODO(@sunggg): Revisit when we have op naming convention.
     // Currently, simply remove "relax." prefix to make it work.
-    name = std::string("tensorrt.") + name.substr(6);
+    name = std::string("jsonruntime.") + name.substr(6);
 
     NodeEntries inputs;
     for (const auto& arg : cn->args) {

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -586,9 +586,12 @@ class FunctionCreator : public ExprMutator {
       }
 
       StructInfo param_sinfo = GetStructInfo(expr);
-      Var param(std::move(name), param_sinfo);
-      arguments_.push_back(expr);
-      params_.push_back(param);
+      // Exclude PrimValues from arg/params to make composite functions contain PrimValues.  
+      if(!expr->IsInstance<PrimValueNode>()){
+        Var param(std::move(name), GetStructInfo(expr));
+        arguments_.push_back(expr);
+        params_.push_back(param);
+      }
 
       // Mark the tuple parameter is partially referenced in the beginning.
       // We will remove it from the mapping once we find it is fully referenced.

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -586,8 +586,8 @@ class FunctionCreator : public ExprMutator {
       }
 
       StructInfo param_sinfo = GetStructInfo(expr);
-      // Exclude PrimValues from arg/params to make composite functions contain PrimValues.  
-      if(!expr->IsInstance<PrimValueNode>()){
+      // Exclude PrimValues from arg/params to make composite functions contain PrimValues.
+      if (!expr->IsInstance<PrimValueNode>()) {
         Var param(std::move(name), GetStructInfo(expr));
         arguments_.push_back(expr);
         params_.push_back(param);


### PR DESCRIPTION
Currently, `PrimValue` is treated just like a tensors and `FuseOpByPattern` pass creates composite functions that have `PrimValues` as function parameters. 
For example, `param_0` and `param_1` are defined to handle `PrimValues`
```Python
@I.ir_module
class Module:
    @R.function(private=True)
    def fused_relax_clip(x: R.Tensor((10, 10), dtype="float32"), param_0: R.Prim("int64"), param_1: R.Prim("int64")) -> R.Tensor((10, 10), dtype="float32"):
        R.func_attr({"Composite": "x.clip", "Primitive": 1})
        with R.dataflow():
            gv: R.Tensor((10, 10), dtype="float32") = R.clip(x, param_0, param_1)
            R.output(gv)
        return gv

    @R.function
    def main(x: R.Tensor((10, 10), dtype="float32")) -> R.Tensor((10, 10), dtype="float32"):
        cls = Module
        with R.dataflow():
            gv: R.Tensor((10, 10), dtype="float32") = cls.fused_relax_clip(x, R.prim_value(0), R.prim_value(4))
            R.output(gv)
        return gv
```

However, this does not comply with BYOC codegens since they expect each composite function to contain these information that would have been stored in operator attribute before the adoption of `PrimValue`.

Therefore, this PR fixes `FuseOpByPattern` to include `PrimValue` inside the composite function. 
With this change, the example above will have the following output.
```Python
@I.ir_module
    class Expected1:
        @R.function(private=True)
        def fused_relax_clip(x: R.Tensor((10, 10), dtype="float32")) -> R.Tensor((10, 10), dtype="float32"):
            R.func_attr({"Composite": "x.clip", "Primitive": 1})
            with R.dataflow():
                gv: R.Tensor((10, 10), dtype="float32") = R.clip(x, R.prim_value(0), R.prim_value(4))
                R.output(gv)
            return gv

        @R.function
        def main(x: R.Tensor((10, 10), dtype="float32")) -> R.Tensor((10, 10), dtype="float32"):
            cls = Expected1
            with R.dataflow():
                gv: R.Tensor((10, 10), dtype="float32") = cls.fused_relax_clip(x)
                R.output(gv)
            return gv

```

cc. @masahi 