### PR TITLE
[Unity] Allow specifying struct_info for relax constant

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -550,10 +550,13 @@ class ConstantNode : public LeafExprNode {
 
   bool SEqualReduce(const ConstantNode* other, SEqualReducer equal) const {
     // struct info can be deterministically derived from data.
-    return equal(data, other->data);
+    return equal(data, other->data) && equal(struct_info_, other->struct_info_);
   }
 
-  void SHashReduce(SHashReducer hash_reduce) const { hash_reduce(data); }
+  void SHashReduce(SHashReducer hash_reduce) const {
+    hash_reduce(data);
+    hash_reduce(struct_info_);
+  }
 
   static constexpr const char* _type_key = "relax.expr.Constant";
   TVM_DECLARE_FINAL_OBJECT_INFO(ConstantNode, LeafExprNode);
@@ -564,9 +567,12 @@ class Constant : public LeafExpr {
   /*!
    * \brief The constructor
    * \param data The data of the constant tensor.
-   * \param span The source span of the expression.
+   * \param struct_info_annotation The struct info of the constant tensor. If not specified, infer
+   * it from data. \param span The source span of the expression.
    */
-  TVM_DLL explicit Constant(runtime::NDArray data, Span span = Span());
+  TVM_DLL explicit Constant(runtime::NDArray data,
+                            Optional<StructInfo> struct_info_annotation = NullOpt,
+                            Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(Constant, LeafExpr, ConstantNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ConstantNode);

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -381,8 +381,12 @@ def make_shape(shape: Union[List[Any], typing.Tuple[Any, ...]]) -> ShapeExpr:
 
 @tvm._ffi.register_object("relax.expr.Constant")
 class Constant(ExprWithOp):
-    def __init__(self, data: tvm.nd.NDArray, span: Span = None) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.Constant, data, span)  # type: ignore
+    def __init__(
+        self, data: tvm.nd.NDArray, struct_info: Optional[StructInfo] = None, span: Span = None
+    ) -> None:
+        self.__init_handle_by_constructor__(
+            _ffi_api.Constant, data, struct_info, span
+        )  # type: ignore
 
 
 @tvm._ffi.register_object("relax.expr.Var")


### PR DESCRIPTION
This PR allows user to specify struct_info for R.constant in its constructor. This feature will be used in distributed constant tensor.

cc: @tqchen 