### PR TITLE
[Unity][Pass] `BindSymVar` pass

### DIFF
--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -412,6 +412,24 @@ def BindParams(
     return _ffi_api.BindParams(func_name, tvm_params)  # type: ignore
 
 
+def BindSymVars(
+    func_name: str,
+    binding_map: Dict[str, int],
+) -> tvm.ir.transform.Pass:
+    """Bind params of function of the module to constant tensors.
+    Parameters
+    ----------
+    func_name: str
+        The function name to be bound
+    binidng_map : Dict[str, int]
+        The map from symbolic varname to integer.
+    Returns
+    -------
+    ret: tvm.ir.transform.Pass
+    """
+    return _ffi_api.BindSymVars(func_name, binding_map)  # type: ignore
+
+
 def RunCodegen(
     target_options: Optional[dict] = None,
     entry_functions: Optional[List[str]] = None,

--- a/src/relax/transform/bind_symvars.cc
+++ b/src/relax/transform/bind_symvars.cc
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <tvm/driver/driver_api.h>
+#include <tvm/ir/function.h>
+#include <tvm/relax/expr.h>
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/transform.h>
+#include <tvm/relax/type.h>
+#include <tvm/tir/op.h>
+#include <tvm/relax/struct_info.h>
+#include <utility>
+
+namespace tvm {
+namespace relax {
+
+class ExprBinder : public ExprMutator {
+ public:
+  explicit ExprBinder(const tvm::Map<tir::Var, PrimExpr>& symvar_map)
+      : symvar_map_(symvar_map) {}
+
+ private:
+  Expr VisitExpr_(const FunctionNode* op) final {
+    tvm::Array<Var> params;
+    bool all_params_unchanged = true;
+    for (const Var& param : op->params) {
+      Var new_param = this->VisitVarDef(param);
+      params.push_back(new_param);
+      if (!param.same_as(new_param)) {
+        this->var_remap_[param->vid] = new_param;
+        all_params_unchanged = false;
+      }
+    }
+
+    Expr body = this->VisitWithNewScope(op->body, params);
+
+    // FuncStructInfo does not depend on Expr
+    if (all_params_unchanged && body.same_as(op->body)) {
+      return GetRef<Expr>(op);
+    } else {
+      // purity won't be affected, no need to update annotation
+      return Function(params, body, VisitExprDepStructInfoField(op->ret_struct_info), op->is_pure,
+                      op->attrs);
+    }
+  }
+
+  PrimExpr VisitPrimExpr(const PrimExpr& expr) final {
+
+    if (const tir::VarNode* var = expr.as<tir::VarNode>()) {
+      auto it = symvar_map_.find(GetRef<tir::Var>(var));
+      if (it != symvar_map_.end()) {
+        return (*it).second;
+      }
+    }else if(const auto* var = expr.as<tir::AddNode>() ){
+      return VisitPrimExpr(var->a) + VisitPrimExpr(var->b);
+    }else if(const auto* var = expr.as<tir::SubNode>() ){
+      return VisitPrimExpr(var->a) - VisitPrimExpr(var->b);
+    }else if(const auto* var = expr.as<tir::MulNode>() ){
+      return VisitPrimExpr(var->a) * VisitPrimExpr(var->b);
+    }else if(const auto* var = expr.as<tir::DivNode>() ){
+      return tir::Cast(DataType::Int(64), tir::Div(VisitPrimExpr(var->a), VisitPrimExpr(var->b)));
+    }else if(const auto* var = expr.as<tir::ModNode>() ){
+      return tir::Cast(DataType::Int(64), tir::Mod(VisitPrimExpr(var->a), VisitPrimExpr(var->b)));
+    }else if(const auto* var = expr.as<tir::FloorDivNode>() ){
+      return tir::Cast(DataType::Int(64), tir::FloorDiv(VisitPrimExpr(var->a), VisitPrimExpr(var->b)));
+    }else if(const auto* var = expr.as<tir::FloorModNode>() ){
+      return tir::Cast(DataType::Int(64), tir::FloorMod(VisitPrimExpr(var->a), VisitPrimExpr(var->b)));
+    }
+  
+    return ExprMutator::VisitPrimExpr(expr);
+  }
+
+
+ private:
+  const tvm::Map<tir::Var, PrimExpr>& symvar_map_;
+};
+
+/*!
+ * \brief Bind values to symbolic variables in a specific function 
+ * \param m The module
+ * \param func_name The name of the specific function
+ * \param binding_map User-provided map for symbolic variables and their values to bind
+ * \return The module after binding symvars.
+ */
+IRModule BindSymVars(IRModule m, String func_name, Map<String, Integer> binding_map) {
+  IRModuleNode* new_module = m.CopyOnWrite();
+  Function func = Downcast<Function>(m->Lookup(func_name));
+  Map<tir::Var, PrimExpr> smap;
+  Array<PrimExpr> shape_values;
+  for(auto param:func->params){
+    if(const auto* tsinfo = GetStructInfoAs<TensorStructInfoNode>(param)){
+      const auto* shape = tsinfo->shape.as<ShapeExprNode>();
+      ICHECK(shape != nullptr) << "Shape should be defined.";
+      shape_values = shape->values;
+    }else if(const auto* ssinfo = GetStructInfoAs<ShapeStructInfoNode>(param)){
+      shape_values = ssinfo->values.value();  
+    }else{
+        LOG(FATAL) << "Function params should have either TensorStructInfo or ShapeStructInfo.";
+    }
+
+    for(auto val:shape_values){
+      if(const auto* v = val.as<tir::VarNode>()){
+         if(binding_map.find(v->name_hint)!=binding_map.end())
+           smap.Set(GetRef<tir::Var>(v), binding_map[v->name_hint]);
+      }
+    }
+  }
+  GlobalVar gv = m->GetGlobalVar(func_name);
+  Expr bound_expr= ExprBinder(smap).VisitExpr(func);
+  Function bound_func = Downcast<Function>(bound_expr);
+  new_module->Update(gv, bound_func);
+  return GetRef<IRModule>(new_module);
+}
+
+namespace transform {
+
+Pass BindSymVars(String func_name, Map<String, Integer> binding_map) {
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =
+      [=](IRModule mod, PassContext pc) { return relax::BindSymVars(std::move(mod), func_name, binding_map); 
+      };
+  return CreateModulePass(pass_func, 0, "BindSymVars", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.BindSymVars").set_body_typed(BindSymVars);
+
+}  // namespace transform
+
+}  // namespace relax
+}  // namespace tvm

--- a/tests/python/relax/test_transform_bind_symvars.py
+++ b/tests/python/relax/test_transform_bind_symvars.py
@@ -1,0 +1,151 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.script
+import tvm.testing
+from tvm import relax
+from tvm.script import ir as I
+from tvm.script import relax as R
+from tvm.script import tir as T
+    
+def test_bind_tensors():
+    @tvm.script.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor(("batch", "m"), dtype="float32"),
+            w0: R.Tensor(("m", "n"), dtype="float32"),
+            w1: R.Tensor(("k", 10), dtype="float32"),
+        ) -> R.Tensor(("batch", "k"), dtype="float32"):
+            batch = T.Var("batch", "int64")
+            m = T.Var("m", "int64")
+            n = T.Var("n", "int64")
+            k = T.Var("k", "int64")
+            with R.dataflow():
+                lv0 = R.call_dps_packed(
+                    "test0", (x, w0), out_sinfo=R.Tensor((batch, n), dtype="float32")
+                )
+                out = R.call_dps_packed(
+                    "test1", (lv0, w1), out_sinfo=R.Tensor((batch, k), dtype="float32")
+                )
+                R.output(out)
+            return out
+
+    symvar_map = {"batch": 1, "k": 3}
+    target_func_name = "main"
+    After = relax.transform.BindSymVars(target_func_name, symvar_map)(Before)
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((1, "m"), dtype="float32"), w0: R.Tensor(("m", "n"), dtype="float32"), w1: R.Tensor((3, 10), dtype="float32")) -> R.Tensor((1, 3), dtype="float32"):
+            m = T.int64()
+            n = T.int64()
+            with R.dataflow():
+                lv0 = R.call_dps_packed("test0", (x, w0), out_sinfo=R.Tensor((1, n), dtype="float32"))
+                out = R.call_dps_packed("test1", (lv0, w1), out_sinfo=R.Tensor((1, 3), dtype="float32"))
+                R.output(out)
+            return out
+
+    tvm.ir.assert_structural_equal(After, Expected)
+
+def test_bind_shape():
+    @tvm.script.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Shape(("batch", "m")),
+            w0: R.Shape(("m", "n")),
+            w1: R.Shape(("k", 10)),
+        ) -> R.Shape(("batch", "k")):
+            batch = T.Var("batch", "int64")
+            m = T.Var("m", "int64")
+            n = T.Var("n", "int64")
+            k = T.Var("k", "int64")
+            with R.dataflow():
+                lv0 = R.call_dps_packed(
+                    "test0", (x, w0), out_sinfo=R.Tensor((batch, n))
+                )
+                out = R.call_dps_packed(
+                    "test1", (lv0, w1), out_sinfo=R.Tensor((batch, k))
+                )
+                R.output(out)
+            return out
+
+    symvar_map = {"batch": 1, "k": 3}
+    target_func_name = "main"
+    After = relax.transform.BindSymVars(target_func_name, symvar_map)(Before)
+   
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Shape([1, "m"]), w0: R.Shape(["m", "n"]), w1: R.Shape([3, 10])) -> R.Shape([1, 3]):
+            m = T.int64()
+            n = T.int64()
+            with R.dataflow():
+                lv0 = R.call_dps_packed("test0", (x, w0), out_sinfo=R.Tensor((1, n)))
+                out = R.call_dps_packed("test1", (lv0, w1), out_sinfo=R.Tensor((1, 3)))
+                R.output(out)
+            return out
+
+    tvm.ir.assert_structural_equal(After, Expected)
+
+def test_arith():
+    @tvm.script.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor(("batch", "m-1"), dtype="float32"),
+            w0: R.Tensor(("m", "n"), dtype="float32"),
+            w1: R.Tensor(("k", 10), dtype="float32"),
+        ) -> R.Tensor(("batch", "k*m"), dtype="float32"):
+            batch = T.Var("batch", "int64")
+            m = T.Var("m", "int64")
+            n = T.Var("n", "int64")
+            k = T.Var("k", "int64")
+            with R.dataflow():
+                lv0 = R.call_dps_packed(
+                    "test0", (x, w0), out_sinfo=R.Tensor((batch, m+n), dtype="float32")
+                )
+                out = R.call_dps_packed(
+                    "test1", (lv0, w1), out_sinfo=R.Tensor((batch, k+n), dtype="float32")
+                )
+                R.output(out)
+            return out
+
+    symvar_map = {"batch": 1, "k": 2, "m":3}
+    target_func_name = "main"
+    After = relax.transform.BindSymVars(target_func_name, symvar_map)(Before)
+   
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((1, 2), dtype="float32"), w0: R.Tensor((3, "n"), dtype="float32"), w1: R.Tensor((2, 10), dtype="float32")) -> R.Tensor((1, 6), dtype="float32"):
+            n = T.int64()
+            with R.dataflow():
+                lv0 = R.call_dps_packed("test0", (x, w0), out_sinfo=R.Tensor((1, 3 + n), dtype="float32"))
+                out = R.call_dps_packed("test1", (lv0, w1), out_sinfo=R.Tensor((1, 2 + n), dtype="float32"))
+                R.output(out)
+            return out
+
+    tvm.ir.assert_structural_equal(After, Expected)
+
+# TODO: Fix the issue with structural equality for mod, floordiv, floormod. 
+
+if __name__ == "__main__":
+   tvm.testing.main()


### PR DESCRIPTION
This PR introduces an utility pass that binds symbolic variables to user-provided integer values.
For example, say we have a following IRModule. 
```Python
@tvm.script.ir_module
class Before:
  @R.function
  def main(
    x: R.Tensor(("m", "n")),
    y: R.Tensor(("m", "n"))
   ) -> R.Tensor(("m", "n")):
      m = T.Var("m", "int64")
      n = T.Var("m", "int64")
      with R.dataflow():
        out = R.matmul(x, y)
        R.output(out)
      return out
```
We can conveniently bind the symbolic variable by applying `After = relax.transform.BindSymVars("main", {"m": 10, "n": 10})(Before)`.
```Python
@tvm.script.ir_module
class After:
  @R.function
  def main(
    x: R.Tensor((10, 10)),
    y: R.Tensor((10, 10))
   ) -> R.Tensor((10, 10)):
      with R.dataflow():
        out = R.matmul(x, y)
        R.output(out)
      return out
```

This would be useful when specializing shape and providing compile-time shape info (e.g., model params or batch sizes) by eliminating the need to rewrite the model. 
cc. @tqchen @psrivas2 