### PR TITLE
[CI] Add ml_dypes dependency for all docker images

### DIFF
--- a/docker/install/ubuntu2004_install_python_package.sh
+++ b/docker/install/ubuntu2004_install_python_package.sh
@@ -43,4 +43,5 @@ pip3 install --upgrade \
     junitparser==2.4.2 \
     six \
     tornado \
-    pytest-lazy-fixture
+    pytest-lazy-fixture \
+    ml_dtypes

--- a/docker/install/ubuntu2004_install_python_package.sh
+++ b/docker/install/ubuntu2004_install_python_package.sh
@@ -44,4 +44,5 @@ pip3 install --upgrade \
     six \
     tornado \
     pytest-lazy-fixture \
-    ml_dtypes
+    git+https://github.com/jax-ml/ml_dtypes.git@v0.2.0
+

--- a/docker/install/ubuntu2004_install_python_package.sh
+++ b/docker/install/ubuntu2004_install_python_package.sh
@@ -45,4 +45,3 @@ pip3 install --upgrade \
     tornado \
     pytest-lazy-fixture \
     git+https://github.com/jax-ml/ml_dtypes.git@v0.2.0
-


### PR DESCRIPTION
The PR #15183 adds ml_dtypes as a dependency of TVM, however, some of the CI docker images do not have ml_dtypes installed, the PR fixes the issue.

cc @yongwww , would you mind also helping upload the new images with ml_dtypes installed to docker hub?