### PR TITLE
[Unity][Pass] `BindSymVar` pass

### DIFF
--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -296,6 +296,17 @@ struct GroupNormAttrs : public tvm::AttrsNode<GroupNormAttrs> {
   }
 };  // struct GroupNormAttrs
 
+/*! \brief Attributes used in rms_norm operator */
+struct RMSNormAttrs : public tvm::AttrsNode<RMSNormAttrs> {
+  Array<Integer> axes;
+  double epsilon;
+
+  TVM_DECLARE_ATTRS(RMSNormAttrs, "relax.attrs.RMSNormAttrs") {
+    TVM_ATTR_FIELD(axes).describe("The axes that along which the normalization is applied.");
+    TVM_ATTR_FIELD(epsilon).describe("Small float added to variance to avoid dividing by zero");
+  }
+};  // struct RMSNormAttrs
+
 /*! \brief Attributes used in nll_loss operator */
 struct NLLLossAttrs : public tvm::AttrsNode<NLLLossAttrs> {
   String reduction;

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -183,6 +183,16 @@ TVM_DLL Pass EliminateCommonSubexpr(bool call_only = false);
 TVM_DLL Pass BindParams(String func_name, Map<String, runtime::NDArray> params);
 
 /*!
+ * \brief Bind symvars of function of the module to constant shape values.
+ *
+ * \param func_name The name of the function to bind shape values.
+ * \param binding_map The dictionary of symbolic variables and their constant shape values.
+ *
+ * \return The Pass.
+ */
+TVM_DLL Pass BindSymVars(String func_name, Map<String, Integer> binding_map);
+
+/*!
  * \brief Fold constant expressions.
  *
  * \return The Pass.

--- a/include/tvm/topi/nn/rms_norm.h
+++ b/include/tvm/topi/nn/rms_norm.h
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \brief root mean square normalization op constructions
+ * \file nn/rms_norm.h
+ */
+#ifndef TVM_TOPI_NN_RMS_NORM_H_
+#define TVM_TOPI_NN_RMS_NORM_H_
+
+#include <tvm/te/operation.h>
+#include <tvm/topi/reduction.h>
+#include <tvm/topi/tags.h>
+
+#include <string>
+
+namespace tvm {
+namespace topi {
+namespace nn {
+
+using namespace tvm::te;
+
+/*!
+ * \brief Root mean square normalization.
+ * \param data N-D tensor with shape [d_0, d_1, ..., d_{N-1}]
+ * \param weight K-D tensor with shape [r_0, r_1, ..., r_{K-1}] where K == len(axis) and
+ *               d_{axis_k} == r_k
+ * \param axis The axis to normalize over.
+ * \param epsilon The epsilon value to avoid division by zero.
+ * \param name The name of the operation.
+ * \param tag The tag to mark the operation.
+ * \return The normalized tensor, with the same shape as data.
+ */
+inline Tensor rms_norm(const Tensor& data, const Tensor& weight, const Array<Integer>& axis,
+                       double epsilon, std::string name = "T_rms_norm",
+                       std::string tag = kInjective) {
+  const auto& data_type = data->dtype;
+  const auto& weight_type = weight.defined() ? weight->dtype : data_type;
+  ICHECK(data_type == weight_type) << "rms_norm: data and weight must have the same type";
+  ICHECK(data_type == DataType::Float(32) || data_type == DataType::Float(16))
+      << "rms_norm: only support float32 and float16 for now";
+  bool is_float16 = data_type == DataType::Float(16);
+
+  auto x = is_float16 ? cast(data, DataType::Float(32)) : data;
+  auto w = is_float16 ? cast(weight, DataType::Float(32)) : weight;
+  auto square = multiply(x, x);
+  auto square_sum = sum(square, axis, /*keepdims=*/false, /*atleast1d=*/true);
+
+  auto ndim = data->shape.size();
+  ICHECK_NE(ndim, 0) << "Cannot reduce a 0 dim Tensor";
+  auto real_axis = GetRealAxis(static_cast<int>(ndim), axis);
+  auto reduce_extent = make_const(data->dtype, 1);
+  for (int i : real_axis) {
+    reduce_extent *= data->shape[i];
+  }
+  auto rms_norm_func = [&](const Array<Var>& indices) {
+    Array<Var> reduce_indices, non_reduce_indices;
+    for (int i = 0, n = static_cast<int>(indices.size()); i < n; ++i) {
+      if (std::find(real_axis.begin(), real_axis.end(), i) != real_axis.end()) {
+        reduce_indices.push_back(indices[i]);
+      } else {
+        non_reduce_indices.push_back(indices[i]);
+      }
+    }
+    auto output =
+        x(indices) * w(reduce_indices) *
+        tvm::rsqrt(square_sum(non_reduce_indices) / reduce_extent + make_const(data_type, epsilon));
+    return output;
+  };
+  auto rms_norm = tvm::te::compute(data->shape, rms_norm_func, name, tag);
+  return is_float16 ? cast(rms_norm, DataType::Float(16)) : rms_norm;
+}
+
+}  // namespace nn
+}  // namespace topi
+}  // namespace tvm
+
+#endif  // TVM_TOPI_NN_RMS_NORM_H_

--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -139,7 +139,11 @@ def instantiate_attention_template(attrs):
   }
 
   CHECK(Attention::check_supported(p));
-  kernel_fn<<<p.getBlocksGrid(), p.getThreadsGrid(), smem_bytes>>>(p);
+  auto func = tvm::runtime::Registry::Get("runtime.get_cuda_stream");
+  ICHECK(func != nullptr);
+  cudaStream_t stream = static_cast<cudaStream_t>((*func)().operator void*());
+
+  kernel_fn<<<p.getBlocksGrid(), p.getThreadsGrid(), smem_bytes, stream>>>(p);
 
   if (accumulator_buf_allocated) {
     cudaFree(p.output_accum_ptr);

--- a/python/tvm/contrib/cutlass/conv2d_operation.py
+++ b/python/tvm/contrib/cutlass/conv2d_operation.py
@@ -423,7 +423,12 @@ def instantiate_conv2d_template(attrs):
   status = conv2d_op.initialize(arguments, workspace.get());
   CHECK(status == cutlass::Status::kSuccess);
   ${split_k_update}
-  status = conv2d_op();
+
+  auto func = tvm::runtime::Registry::Get("runtime.get_cuda_stream");
+  ICHECK(func != nullptr);
+  cudaStream_t stream = static_cast<cudaStream_t>((*func)().operator void*());
+
+  status = conv2d_op(stream);
   CHECK(status == cutlass::Status::kSuccess);
   ${split_k_reduction}
 """

--- a/python/tvm/contrib/cutlass/gemm_operation.py
+++ b/python/tvm/contrib/cutlass/gemm_operation.py
@@ -344,7 +344,12 @@ def instantiate_gemm_template(attrs):
   CHECK(status == cutlass::Status::kSuccess);
   status = gemm_op.initialize(arguments, workspace.get());
   CHECK(status == cutlass::Status::kSuccess);
-  status = gemm_op();
+
+  auto func = tvm::runtime::Registry::Get("runtime.get_cuda_stream");
+  ICHECK(func != nullptr);
+  cudaStream_t stream = static_cast<cudaStream_t>((*func)().operator void*());
+
+  status = gemm_op(stream);
   CHECK(status == cutlass::Status::kSuccess);
 """
     op_type = attrs["op_type"]
@@ -416,38 +421,34 @@ def emit_fp16A_int4B_matmul(attrs):
   int m = ${A_arg}->shape[${batch_offset}];
   int n = ${B_arg}->shape[1] * 2;
   int k = ${B_arg}->shape[0];
+
+  auto func = tvm::runtime::Registry::Get("runtime.get_cuda_stream");
+  ICHECK(func != nullptr);
+  cudaStream_t stream = static_cast<cudaStream_t>((*func)().operator void*());
     """,
         attrs,
     )
 
     template = """
   ${template_common}
-  gemm_fp16_int4(static_cast<cutlass::half_t*>(${A_arg}->data),
-                 static_cast<cutlass::uint4b_t*>(${B_arg}->data),
-                 static_cast<cutlass::half_t*>(${scales_arg}->data),
-                 static_cast<cutlass::half_t*>(out0->data),
-                 m, n, k, nullptr, 0, nullptr);
-"""
-
-    template_bias = """
-  ${template_common}
-  gemm_fp16_int4_bias(static_cast<cutlass::half_t*>(${A_arg}->data),
-                 static_cast<cutlass::uint4b_t*>(${B_arg}->data),
-                 static_cast<cutlass::half_t*>(${scales_arg}->data),
-                 static_cast<cutlass::half_t*>(${bias_arg}->data),
-                 static_cast<cutlass::half_t*>(out0->data),
-                 m, n, k, nullptr, 0, nullptr);
+  gemm_fp16_int_bias_act(static_cast<cutlass::half_t*>(${A_arg}->data),
+                static_cast<${weight_dtype}*>(${B_arg}->data),
+                static_cast<cutlass::half_t*>(${scales_arg}->data),
+                ${bias},
+                static_cast<cutlass::half_t*>(out0->data),
+                "${activation}",
+                m, n, k, ${bias_stride}, nullptr, 0, stream);
 """
 
     template_residual = """
   ${template_common}
-  gemm_fp16_int4_bias_act_residual(static_cast<cutlass::half_t*>(${A_arg}->data),
-                 static_cast<cutlass::uint4b_t*>(${B_arg}->data),
-                 static_cast<cutlass::half_t*>(${scales_arg}->data),
-                 ${bias},
-                 static_cast<cutlass::half_t*>(${residual_arg}->data),
-                 static_cast<cutlass::half_t*>(out0->data), "${activation}", "${binary_op}", "${unary_op}",
-                 m, n, k, nullptr, 0, nullptr);
+  gemm_fp16_int_bias_act_residual(static_cast<cutlass::half_t*>(${A_arg}->data),
+                static_cast<${weight_dtype}*>(${B_arg}->data),
+                static_cast<cutlass::half_t*>(${scales_arg}->data),
+                ${bias},
+                static_cast<cutlass::half_t*>(${residual_arg}->data),
+                static_cast<cutlass::half_t*>(out0->data), "${activation}", "${binary_op}", "${unary_op}",
+                m, n, k, nullptr, 0, stream);
 """
 
     if "residual_arg" in attrs and "bias_arg" in attrs:

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -483,7 +483,7 @@ def instantiate_template(func_name, annotations, func_args):
         if k in annotations:
             attrs[k] = annotations[k]
 
-    headers = []
+    headers = ["tvm/runtime/registry.h"]
 
     if "relu" in func_name:
         headers.append("cutlass/epilogue/thread/linear_combination_bias_relu.h")

--- a/python/tvm/contrib/cutlass/layer_norm_operation.py
+++ b/python/tvm/contrib/cutlass/layer_norm_operation.py
@@ -39,6 +39,10 @@ def instantiate_layer_norm_template(attrs):
     cutlass::TensorRef<data_type, RowMajor> _beta((data_type*)${beta}->data, layout_channels);
     cutlass::TensorRef<data_type, RowMajor> _output((data_type*)out0->data, layout_2D);
 
-    cutlass::layernorm(size, _output, _input, _gamma, _beta, NULL);
+    auto func = tvm::runtime::Registry::Get("runtime.get_cuda_stream");
+    ICHECK(func != nullptr);
+    cudaStream_t stream = static_cast<cudaStream_t>((*func)().operator void*());
+
+    cutlass::layernorm(size, _output, _input, _gamma, _beta, stream);
     """
     return substitute_template(template, attrs)

--- a/python/tvm/contrib/cutlass/rms_norm_operation.py
+++ b/python/tvm/contrib/cutlass/rms_norm_operation.py
@@ -38,6 +38,10 @@ def instantiate_rms_norm_template(attrs):
     cutlass::TensorRef<data_type, RowMajor> _weight((data_type*)${weight}->data, layout_channels);
     cutlass::TensorRef<data_type, RowMajor> _output((data_type*)out0->data, layout_2D);
 
-    cutlass::rmsnorm(size, _output, _input, _weight, nullptr);
+    auto func = tvm::runtime::Registry::Get("runtime.get_cuda_stream");
+    ICHECK(func != nullptr);
+    cudaStream_t stream = static_cast<cudaStream_t>((*func)().operator void*());
+
+    cutlass::rmsnorm(size, _output, _input, _weight, stream);
     """
     return substitute_template(template, attrs)

--- a/python/tvm/dlight/gpu/decode_gemv.py
+++ b/python/tvm/dlight/gpu/decode_gemv.py
@@ -233,7 +233,11 @@ class DecodeGEMV(ScheduleRule):
                 _, *s = sch.get_loops(epilogue)  # pylint: disable=invalid-name
                 _, tx, ty = sch.split(sch.fuse(*s), factors=[None, len_tx, len_ty])
                 sch.bind(tx, "threadIdx.x")
-                sch.bind(ty, "threadIdx.x")
+                sch.bind(ty, "threadIdx.y")
             else:
+                # The epilogue is element-wise without broadcasting.
+                # Thus the remaining spatial part should be bind to tx.
                 sch.set_scope(block, 0, "local")
+                _, *s = sch.get_loops(epilogue)  # pylint: disable=invalid-name
+                sch.bind(sch.fuse(*s), "threadIdx.x")
         # pylint: enable=invalid-name

--- a/python/tvm/relax/op/__init__.py
+++ b/python/tvm/relax/op/__init__.py
@@ -39,7 +39,7 @@ from . import image
 from . import memory
 from . import nn
 
-# Operator gradient functions
+# Register operator gradient functions
 from . import _op_gradient
 
 

--- a/python/tvm/relax/op/grad/grad.py
+++ b/python/tvm/relax/op/grad/grad.py
@@ -43,6 +43,59 @@ def no_grad(input: Expr) -> Expr:
     return _ffi_api.no_grad(input)  # type: ignore
 
 
+def start_checkpoint(input: Expr) -> Expr:
+    """Mark the start of the checkpoint stage. The computation between start_checkpoint and
+    end_checkpoint will be marked as the checkpoint stage.
+
+    Rather than storing all intermediate activations of the entire computation graph for
+    computing backward, the checkpointed stage does not save intermediate activations, and instead
+    recomputes them in backward process.
+
+    For instance,
+    ```
+    a = relax.Var("a", relax.TensorStructInfo((2, 2), "float32"))
+    b = relax.Var("b", relax.TensorStructInfo((2, 2), "float32"))
+    c = a * 2
+    d = b * 2
+    c_cp = start_checkpoint(c)
+    d_cp = start_checkpoint(d)
+    e = c_cp + d_cp
+    e_out = end_checkpoint(e)
+    ```
+    Then `e` will be recomputed in the backward stage.
+
+    See tvm.relax.transform.Gradient, tvm.relax.testing.nn.checkpoint,
+    tvm.relax.op.grad.end_checkpoint for more information.
+
+    Parameters
+    ----------
+    input : relax.Expr
+      The tensor marking the input of the checkpoint stage.
+
+    Returns
+    -------
+    result : relax.Expr
+      The same tensor as the input.
+    """
+    return _ffi_api.start_checkpoint(input)  # type: ignore
+
+
+def end_checkpoint(input: Expr) -> Expr:
+    """Mark the end of checkpoint stage. See tvm.relax.op.grad.start_checkpoint.
+
+    Parameters
+    ----------
+    input : relax.Expr
+      The output of the checkpoint stage.
+
+    Returns
+    -------
+    result : relax.Expr
+      The same tensor as the input.
+    """
+    return _ffi_api.end_checkpoint(input)  # type: ignore
+
+
 def nll_loss_backward(
     output_grad: Expr,
     predictions: Expr,

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -925,6 +925,46 @@ def group_norm(
     )
 
 
+def rms_norm(
+    data: Expr,
+    weight: Expr,
+    axes: Union[int, List[int]],
+    epsilon: float = 1e-5,
+) -> Expr:
+    r"""
+    Root mean square normalization (Biao Zhang and et al., 2019).
+    Applies root mean square normalization to the n-dimensional input array.
+    This operator takes an n-dimensional input array and normalizes
+    the input using the given axis:
+
+    .. math::
+
+        out = \frac{data}{\sqrt{mean(data, axis)+\epsilon}} * weight
+
+    Parameters
+    ----------
+    data : relax.Expr
+        Input to which rms_norm will be applied.
+
+    weight : relax.Expr
+        The scale factor.
+
+    axes : Union[int, List[int]]
+        The axes that along which the normalization is applied.
+
+    epsilon : float
+        Small float added to variance to avoid dividing by zero.
+
+    Returns
+    -------
+    result : relax.Expr
+        The computed result.
+    """
+    if isinstance(axes, int):
+        axes = [axes]
+    return _ffi_api.rms_norm(data, weight, axes, epsilon)  # type: ignore
+
+
 def dropout(data: Expr, rate: float = 0.5) -> Expr:
     """Applies the dropout operation to the input tensor.
 

--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, unused-argument
 """Utility functions for relax training."""
 
 from typing import Optional, Callable
@@ -24,7 +24,7 @@ from tvm import relax
 from tvm._ffi.registry import register_func
 from tvm.relax.block_builder import BlockBuilder
 
-from ..expr import Function
+from ..expr import Function, Var, Call
 from . import _ffi_api
 
 
@@ -189,13 +189,13 @@ def register_te_gradient(te_grad_name: str, te_grad_func: Callable = None):
         # It will return the emitted var.
 
         def handler(
-            builder: BlockBuilder, output_grad_var: relax.Var, call_tir: relax.Call
+            orig_var: Var, call_tir_with_grad: Call, output_grad: Var, ctx: BlockBuilder
         ) -> relax.Expr:
-            return builder.emit_te(
+            return ctx.emit_te(
                 func,
-                output_grad_var,
-                *call_tir.args[1],
-                **call_tir.attrs.te_grad_kwargs,
+                output_grad,
+                *call_tir_with_grad.args[1],
+                **call_tir_with_grad.attrs.te_grad_kwargs,
                 primfunc_name_hint=te_grad_name,
             )
 

--- a/python/tvm/relax/transform/legalize_ops/grad.py
+++ b/python/tvm/relax/transform/legalize_ops/grad.py
@@ -29,6 +29,16 @@ def _no_grad(bb: BlockBuilder, call: Call) -> Expr:
     return call.args[0]
 
 
+@register_legalize("relax.grad.start_checkpoint")
+def _start_checkpoint(bb: BlockBuilder, call: Call) -> Expr:
+    return call.args[0]
+
+
+@register_legalize("relax.grad.end_checkpoint")
+def _end_checkpoint(bb: BlockBuilder, call: Call) -> Expr:
+    return call.args[0]
+
+
 @register_legalize("relax.grad.nll_loss_backward")
 def _grad_nll_loss_backward(bb: BlockBuilder, call: Call) -> Expr:
     # topi.sum don't support zero-dim x
@@ -51,9 +61,8 @@ def _grad_nll_loss_backward(bb: BlockBuilder, call: Call) -> Expr:
         if reduction == "sum":
             output_grad = topi.broadcast_to(output_grad, targets.shape)
         elif reduction == "mean":
-            output_grad = topi.divide(
-                topi.broadcast_to(output_grad, targets.shape), topi_sum_extend(all_weights)
-            )
+            weight_sum = topi_sum_extend(all_weights)
+            output_grad = topi.divide(topi.broadcast_to(output_grad, targets.shape), weight_sum)
 
         # handle no batch
         if predictions.ndim == 1:

--- a/python/tvm/relax/transform/legalize_ops/nn.py
+++ b/python/tvm/relax/transform/legalize_ops/nn.py
@@ -334,6 +334,17 @@ def _nn_group_norm(bb: BlockBuilder, call: Call) -> Expr:
     )
 
 
+@register_legalize("relax.nn.rms_norm")
+def _nn_rms_norm(bb: BlockBuilder, call: Call) -> Expr:
+    return bb.call_te(
+        topi.nn.rms_norm,
+        call.args[0],
+        call.args[1],
+        axis=call.attrs.axes,
+        epsilon=call.attrs.epsilon,
+    )
+
+
 @register_legalize("relax.nn.dropout")
 def _nn_dropout(bb: BlockBuilder, call: Call) -> Expr:
     logging.info("Dropout is handled by frontend translator at this moment and is not legalized.")

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -75,6 +75,10 @@ def Gradient(
                 R.output(original_outputs, grad_1, grad_2, ...)
             return (original_return_value, (grad_1, grad_2, ...))
 
+    This AD pass also supports checkpointing as described in
+    "Training deep nets with sublinear memory cost." - Chen, Tianqi, et al. (2016).
+    See tvm.relax.testing.nn.checkpoint for more details.
+
     Parameters
     ----------
     func_name : str

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -416,6 +416,24 @@ def BindParams(
     return _ffi_api.BindParams(func_name, tvm_params)  # type: ignore
 
 
+def BindSymVars(
+    func_name: str,
+    binding_map: Dict[str, int],
+) -> tvm.ir.transform.Pass:
+    """Bind params of function of the module to constant tensors.
+    Parameters
+    ----------
+    func_name: str
+        The function name to be bound
+    binidng_map : Dict[str, int]
+        The map from symbolic varname to integer.
+    Returns
+    -------
+    ret: tvm.ir.transform.Pass
+    """
+    return _ffi_api.BindSymVars(func_name, binding_map)  # type: ignore
+
+
 def RunCodegen(
     target_options: Optional[dict] = None,
     entry_functions: Optional[List[str]] = None,

--- a/python/tvm/topi/nn/__init__.py
+++ b/python/tvm/topi/nn/__init__.py
@@ -41,6 +41,7 @@ from .upsampling import *
 from .instance_norm import instance_norm
 from .layer_norm import layer_norm
 from .group_norm import group_norm
+from .rms_norm import rms_norm
 from .local_response_norm import *
 from .bitserial_conv2d import *
 from .bitserial_dense import *

--- a/python/tvm/topi/nn/rms_norm.py
+++ b/python/tvm/topi/nn/rms_norm.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Root mean square normalization operator."""
+from .. import cpp
+
+
+def rms_norm(data, weight, axis, epsilon=1e-5):
+    """Root mean square normalization operator.
+    It accepts fp16 and fp32 as input data type. It will cast the input to fp32
+    to perform the computation. The output will have the same data type as input.
+
+    Parameters
+    ----------
+    data : tvm.te.Tensor
+        N-D with shape (d_0, d_1, ..., d_{N-1})
+
+    weight: tvm.te.Tensor
+        K-D with shape (r_0, r_1, ..., r_{K-1}) where K == len(axis) and d_{axis_k} == r_k
+
+    axis : list of int
+        Axis over the normalization applied
+
+    epsilon : float
+        The epsilon value to avoid division by zero.
+
+    Returns
+    -------
+    result : tvm.te.Tensor
+        N-D with shape (d_0, d_1, ..., d_{N-1})
+    """
+    return cpp.nn.rms_norm(data, weight, axis, epsilon)

--- a/python/tvm/topi/testing/__init__.py
+++ b/python/tvm/topi/testing/__init__.py
@@ -46,6 +46,7 @@ from .roi_pool_python import roi_pool_nchw_python
 from .instance_norm_python import instance_norm_python
 from .layer_norm_python import layer_norm_python
 from .group_norm_python import group_norm_python
+from .rms_norm_python import rms_norm_python
 from .lrn_python import lrn_python
 from .l2_normalize_python import l2_normalize_python
 from .gather_python import gather_python

--- a/python/tvm/topi/testing/rms_norm_python.py
+++ b/python/tvm/topi/testing/rms_norm_python.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, line-too-long, unused-variable, too-many-locals
+"""Root mean square normalization in python"""
+import numpy as np
+
+
+def rms_norm_python(data, weight, axis, epsilon=1e-5):
+    """Root mean square normalization operator in Python.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        N-D with shape (d_0, d_1, ..., d_{N-1})
+
+    weight: numpy.ndarray
+        K-D with shape (r_0, r_1, ..., r_{K-1}) where K == len(axis) and d_{axis_k} == r_k
+
+    axis : int or tuple of ints
+        Axis over the normalization applied
+
+    epsilon : float
+        The epsilon value to avoid division by zero.
+
+    Returns
+    -------
+    result : np.ndarray
+        N-D with shape (d_0, d_1, ..., d_{N-1})
+    """
+    old_dtype = data.dtype
+    data = data.astype("float32")
+    square_mean = np.mean(np.square(data), axis, keepdims=True)
+    result = data * weight / np.sqrt(square_mean + epsilon)
+    return result.astype(old_dtype)

--- a/src/relax/op/nn/nn.h
+++ b/src/relax/op/nn/nn.h
@@ -78,6 +78,9 @@ Expr layer_norm(Expr data, Expr gamma, Expr beta, Array<Integer> axes, double ep
 Expr group_norm(Expr data, Expr gamma, Expr beta, int num_groups, int channel_axis,
                 Array<Integer> axes, double epsilon, bool center, bool scale);
 
+/*! \brief Compute root mean square normalization. */
+Expr rms_norm(Expr data, Expr weight, Array<Integer> axes, double epsilon);
+
 /*!
  * \brief Applies the dropout operation to the input tensor.
  * \param data The input data to the operator.

--- a/src/relax/transform/bind_symvars.cc
+++ b/src/relax/transform/bind_symvars.cc
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <tvm/driver/driver_api.h>
+#include <tvm/ir/function.h>
+#include <tvm/relax/expr.h>
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/struct_info.h>
+#include <tvm/relax/transform.h>
+#include <tvm/relax/type.h>
+#include <tvm/tir/op.h>
+
+#include <utility>
+
+namespace tvm {
+namespace relax {
+
+class SymVarBinder : public ExprMutator {
+ public:
+  explicit SymVarBinder(const tvm::Map<tir::Var, PrimExpr>& symvar_map) : symvar_map_(symvar_map) {}
+
+ private:
+  Expr VisitExpr_(const FunctionNode* op) final {
+    tvm::Array<Var> params;
+    bool all_params_unchanged = true;
+    for (const Var& param : op->params) {
+      Var new_param = this->VisitVarDef(param);
+      params.push_back(new_param);
+      if (!param.same_as(new_param)) {
+        this->var_remap_[param->vid] = new_param;
+        all_params_unchanged = false;
+      }
+    }
+
+    Expr body = this->VisitWithNewScope(op->body, params);
+
+    // FuncStructInfo does not depend on Expr
+    if (all_params_unchanged && body.same_as(op->body)) {
+      return GetRef<Expr>(op);
+    } else {
+      // purity won't be affected, no need to update annotation
+      return Function(params, body, VisitExprDepStructInfoField(op->ret_struct_info), op->is_pure,
+                      op->attrs);
+    }
+  }
+
+  PrimExpr VisitPrimExpr(const PrimExpr& expr) final {
+    if (const tir::VarNode* var = expr.as<tir::VarNode>()) {
+      auto it = symvar_map_.find(GetRef<tir::Var>(var));
+      if (it != symvar_map_.end()) {
+        return (*it).second;
+      }
+    } else if (const auto* var = expr.as<tir::AddNode>()) {
+      return VisitPrimExpr(var->a) + VisitPrimExpr(var->b);
+    } else if (const auto* var = expr.as<tir::SubNode>()) {
+      return VisitPrimExpr(var->a) - VisitPrimExpr(var->b);
+    } else if (const auto* var = expr.as<tir::MulNode>()) {
+      return VisitPrimExpr(var->a) * VisitPrimExpr(var->b);
+    } else if (const auto* var = expr.as<tir::DivNode>()) {
+      return tir::Cast(DataType::Int(64), tir::Div(VisitPrimExpr(var->a), VisitPrimExpr(var->b)));
+    } else if (const auto* var = expr.as<tir::ModNode>()) {
+      return tir::Cast(DataType::Int(64), tir::Mod(VisitPrimExpr(var->a), VisitPrimExpr(var->b)));
+    } else if (const auto* var = expr.as<tir::FloorDivNode>()) {
+      return tir::Cast(DataType::Int(64),
+                       tir::FloorDiv(VisitPrimExpr(var->a), VisitPrimExpr(var->b)));
+    } else if (const auto* var = expr.as<tir::FloorModNode>()) {
+      return tir::Cast(DataType::Int(64),
+                       tir::FloorMod(VisitPrimExpr(var->a), VisitPrimExpr(var->b)));
+    }
+    return ExprMutator::VisitPrimExpr(expr);
+  }
+
+ private:
+  const tvm::Map<tir::Var, PrimExpr>& symvar_map_;
+};
+
+/*!
+ * \brief Bind values to symbolic variables in a specific function
+ * \param m The module
+ * \param func_name The name of the specific function
+ * \param binding_map User-provided map for symbolic variables and their values to bind
+ * \return The module after binding symvars.
+ */
+IRModule BindSymVars(IRModule m, String func_name, Map<String, Integer> binding_map) {
+  IRModuleNode* new_module = m.CopyOnWrite();
+  Function func = Downcast<Function>(m->Lookup(func_name));
+  Map<tir::Var, PrimExpr> smap;
+  Array<PrimExpr> shape_values;
+  for (auto param : func->params) {
+    if (const auto* tsinfo = GetStructInfoAs<TensorStructInfoNode>(param)) {
+      const auto* shape = tsinfo->shape.as<ShapeExprNode>();
+      ICHECK(shape != nullptr) << "Shape should be defined.";
+      shape_values = shape->values;
+    } else if (const auto* ssinfo = GetStructInfoAs<ShapeStructInfoNode>(param)) {
+      shape_values = ssinfo->values.value();
+    } else {
+      LOG(FATAL) << "Function params should have either TensorStructInfo or ShapeStructInfo.";
+    }
+
+    for (auto val : shape_values) {
+      if (const auto* v = val.as<tir::VarNode>()) {
+        if (binding_map.find(v->name_hint) != binding_map.end())
+          smap.Set(GetRef<tir::Var>(v), binding_map[v->name_hint]);
+      }
+    }
+  }
+  GlobalVar gv = m->GetGlobalVar(func_name);
+  Expr bound_expr = SymVarBinder(smap).VisitExpr(func);
+  Function bound_func = Downcast<Function>(bound_expr);
+  new_module->Update(gv, bound_func);
+  return GetRef<IRModule>(new_module);
+}
+
+namespace transform {
+
+Pass BindSymVars(String func_name, Map<String, Integer> binding_map) {
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func = [=](IRModule mod,
+                                                                            PassContext pc) {
+    return relax::BindSymVars(std::move(mod), func_name, binding_map);
+  };
+  return CreateModulePass(pass_func, 0, "BindSymVars", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.BindSymVars").set_body_typed(BindSymVars);
+
+}  // namespace transform
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -300,5 +300,9 @@ TVM_DLL String GetCudaFreeMemory() {
 
 TVM_REGISTER_GLOBAL("runtime.GetCudaFreeMemory").set_body_typed(GetCudaFreeMemory);
 
+TVM_REGISTER_GLOBAL("runtime.get_cuda_stream").set_body_typed([]() {
+  return static_cast<void*>(CUDAThreadEntry::ThreadLocal()->stream);
+});
+
 }  // namespace runtime
 }  // namespace tvm

--- a/src/topi/nn.cc
+++ b/src/topi/nn.cc
@@ -35,6 +35,7 @@
 #include <tvm/topi/nn/local_response_norm.h>
 #include <tvm/topi/nn/mapping.h>
 #include <tvm/topi/nn/pooling.h>
+#include <tvm/topi/nn/rms_norm.h>
 #include <tvm/topi/nn/softmax.h>
 
 namespace tvm {
@@ -174,6 +175,11 @@ TVM_REGISTER_GLOBAL("topi.nn.group_norm").set_body([](TVMArgs args, TVMRetValue*
 /* Ops from nn/instance_norm.h */
 TVM_REGISTER_GLOBAL("topi.nn.instance_norm").set_body([](TVMArgs args, TVMRetValue* rv) {
   *rv = nn::instance_norm(args[0], args[1], args[2], args[3], static_cast<double>(args[4]));
+});
+
+/* Ops from nn/rms_norm.h */
+TVM_REGISTER_GLOBAL("topi.nn.rms_norm").set_body([](TVMArgs args, TVMRetValue* rv) {
+  *rv = nn::rms_norm(args[0], args[1], args[2], static_cast<double>(args[3]));
 });
 
 }  // namespace topi

--- a/tests/python/relax/test_op_gradient_numeric.py
+++ b/tests/python/relax/test_op_gradient_numeric.py
@@ -747,7 +747,7 @@ def test_nll_loss_no_batch(target, dev, nll_reduction1, nll_weighted1, nll_ignor
     )
 
 
-(c2d_shape1, c2d_shape2, c2d_kwargs,) = tvm.testing.parameters(
+(c2d_shape1, c2d_shape2, c2d_kwargs) = tvm.testing.parameters(
     (
         (3, 2, 10, 10),
         (3, 2, 3, 3),
@@ -797,7 +797,7 @@ def test_conv2d(target, dev, c2d_shape1, c2d_shape2, c2d_kwargs):
     )
 
 
-(pool_size, pool_kwargs,) = tvm.testing.parameters(
+(pool_size, pool_kwargs) = tvm.testing.parameters(
     (
         (3, 3),
         {},

--- a/tests/python/relax/test_training_setup_trainer.py
+++ b/tests/python/relax/test_training_setup_trainer.py
@@ -68,13 +68,14 @@ def test_simple():
                 gv: R.Tensor((), dtype="float64") = R.sum(lv1, axis=None, keepdims=False)
                 gv_adjoint: R.Tensor((), dtype="float64") = R.ones(R.shape([]), dtype="float64")
                 lv1_adjoint: R.Tensor((2, 2), dtype="float64") = R.broadcast_to(gv_adjoint, R.shape([2, 2]))
+                lv_adjoint: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
                 lv_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
-                lv1_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
-                lv_adjoint: R.Tensor((2, 2), dtype="float64") = R.add(lv_1, lv1_1)
-                x1_adjoint: R.Tensor((2, 2), dtype="float64") = lv_adjoint
+                lv_adjoint1: R.Tensor((2, 2), dtype="float64") = R.add(lv_adjoint, lv_1)
+                x1_adjoint: R.Tensor((2, 2), dtype="float64") = lv_adjoint1
                 y_adjoint: R.Tensor((2, 2), dtype="float64") = x1_adjoint
-                R.output(gv, y_adjoint)
-            return (gv, (y_adjoint,))
+                y_adjoint_out: R.Tensor((2, 2), dtype="float64") = y_adjoint
+                R.output(gv, y_adjoint_out)
+            return (gv, (y_adjoint_out,))
 
         @R.function
         def optimizer(params: R.Tuple(R.Tensor((2, 2), dtype="float64")), gradients: R.Tuple(R.Tensor((2, 2), dtype="float64")), optim_states: R.Tuple(R.Tensor((), dtype="int64"))) -> R.Tuple(R.Tuple(R.Tensor((2, 2), dtype="float64")), R.Tuple(R.Tensor((), dtype="int64"))):
@@ -142,13 +143,14 @@ def test_states():
                 gv: R.Tensor((), dtype="float64") = R.sum(lv1, axis=None, keepdims=False)
                 gv_adjoint: R.Tensor((), dtype="float64") = R.ones(R.shape([]), dtype="float64")
                 lv1_adjoint: R.Tensor((2, 2), dtype="float64") = R.broadcast_to(gv_adjoint, R.shape([2, 2]))
+                lv_adjoint: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
                 lv_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
-                lv1_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
-                lv_adjoint: R.Tensor((2, 2), dtype="float64") = R.add(lv_1, lv1_1)
-                x1_adjoint: R.Tensor((2, 2), dtype="float64") = lv_adjoint
+                lv_adjoint1: R.Tensor((2, 2), dtype="float64") = R.add(lv_adjoint, lv_1)
+                x1_adjoint: R.Tensor((2, 2), dtype="float64") = lv_adjoint1
                 y_adjoint: R.Tensor((2, 2), dtype="float64") = x1_adjoint
-                R.output(z1, gv, y_adjoint)
-            return ((gv, z1), (y_adjoint,))
+                y_adjoint_out: R.Tensor((2, 2), dtype="float64") = y_adjoint
+                R.output(z1, gv, y_adjoint_out)
+            return ((gv, z1), (y_adjoint_out,))
 
         @R.function
         def optimizer(params: R.Tuple(R.Tensor((2, 2), dtype="float64")), gradients: R.Tuple(R.Tensor((2, 2), dtype="float64")), optim_states: R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64"))) -> R.Tuple(R.Tuple(R.Tensor((2, 2), dtype="float64")), R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64"))):
@@ -163,9 +165,10 @@ def test_states():
                 lv1: R.Tensor((2, 2), dtype="float64") = R.multiply(R.const(0.10000000000000001, "float64"), y_v_new)
                 y_new: R.Tensor((2, 2), dtype="float64") = R.subtract(y, lv1)
                 params_new: R.Tuple(R.Tensor((2, 2), dtype="float64")) = (y_new,)
-                optim_states_new: R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64")) = (num_steps_new, y_v_new)
+                optim_states_new: R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64")) = num_steps_new, y_v_new
                 R.output(params_new, optim_states_new)
             return (params_new, optim_states_new)
+
     # fmt: on
 
     sinfo = relax.TensorStructInfo((2, 2), "float64")

--- a/tests/python/relax/test_transform_bind_symvars.py
+++ b/tests/python/relax/test_transform_bind_symvars.py
@@ -1,0 +1,173 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.script
+import tvm.testing
+from tvm import relax
+from tvm.script import ir as I
+from tvm.script import relax as R
+from tvm.script import tir as T
+
+
+def test_bind_tensors():
+    @tvm.script.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor(("batch", "m"), dtype="float32"),
+            w0: R.Tensor(("m", "n"), dtype="float32"),
+            w1: R.Tensor(("k", 10), dtype="float32"),
+        ) -> R.Tensor(("batch", "k"), dtype="float32"):
+            batch = T.Var("batch", "int64")
+            m = T.Var("m", "int64")
+            n = T.Var("n", "int64")
+            k = T.Var("k", "int64")
+            with R.dataflow():
+                lv0 = R.call_dps_packed(
+                    "test0", (x, w0), out_sinfo=R.Tensor((batch, n), dtype="float32")
+                )
+                out = R.call_dps_packed(
+                    "test1", (lv0, w1), out_sinfo=R.Tensor((batch, k), dtype="float32")
+                )
+                R.output(out)
+            return out
+
+    symvar_map = {"batch": 1, "k": 3}
+    target_func_name = "main"
+    After = relax.transform.BindSymVars(target_func_name, symvar_map)(Before)
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor((1, "m"), dtype="float32"),
+            w0: R.Tensor(("m", "n"), dtype="float32"),
+            w1: R.Tensor((3, 10), dtype="float32"),
+        ) -> R.Tensor((1, 3), dtype="float32"):
+            m = T.int64()
+            n = T.int64()
+            with R.dataflow():
+                lv0 = R.call_dps_packed(
+                    "test0", (x, w0), out_sinfo=R.Tensor((1, n), dtype="float32")
+                )
+                out = R.call_dps_packed(
+                    "test1", (lv0, w1), out_sinfo=R.Tensor((1, 3), dtype="float32")
+                )
+                R.output(out)
+            return out
+
+    tvm.ir.assert_structural_equal(After, Expected)
+
+
+def test_bind_shape():
+    @tvm.script.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Shape(("batch", "m")),
+            w0: R.Shape(("m", "n")),
+            w1: R.Shape(("k", 10)),
+        ) -> R.Shape(("batch", "k")):
+            batch = T.Var("batch", "int64")
+            m = T.Var("m", "int64")
+            n = T.Var("n", "int64")
+            k = T.Var("k", "int64")
+            with R.dataflow():
+                lv0 = R.call_dps_packed("test0", (x, w0), out_sinfo=R.Tensor((batch, n)))
+                out = R.call_dps_packed("test1", (lv0, w1), out_sinfo=R.Tensor((batch, k)))
+                R.output(out)
+            return out
+
+    symvar_map = {"batch": 1, "k": 3}
+    target_func_name = "main"
+    After = relax.transform.BindSymVars(target_func_name, symvar_map)(Before)
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Shape([1, "m"]), w0: R.Shape(["m", "n"]), w1: R.Shape([3, 10])
+        ) -> R.Shape([1, 3]):
+            m = T.int64()
+            n = T.int64()
+            with R.dataflow():
+                lv0 = R.call_dps_packed("test0", (x, w0), out_sinfo=R.Tensor((1, n)))
+                out = R.call_dps_packed("test1", (lv0, w1), out_sinfo=R.Tensor((1, 3)))
+                R.output(out)
+            return out
+
+    tvm.ir.assert_structural_equal(After, Expected)
+
+
+def test_arith():
+    @tvm.script.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor(("batch", "m-1"), dtype="float32"),
+            w0: R.Tensor(("m", "n"), dtype="float32"),
+            w1: R.Tensor(("k", 10), dtype="float32"),
+        ) -> R.Tensor(("batch", "k*m"), dtype="float32"):
+            batch = T.Var("batch", "int64")
+            m = T.Var("m", "int64")
+            n = T.Var("n", "int64")
+            k = T.Var("k", "int64")
+            with R.dataflow():
+                lv0 = R.call_dps_packed(
+                    "test0",
+                    (x, w0),
+                    out_sinfo=R.Tensor((batch, m + n), dtype="float32"),
+                )
+                out = R.call_dps_packed(
+                    "test1",
+                    (lv0, w1),
+                    out_sinfo=R.Tensor((batch, k + n), dtype="float32"),
+                )
+                R.output(out)
+            return out
+
+    symvar_map = {"batch": 1, "k": 2, "m": 3}
+    target_func_name = "main"
+    After = relax.transform.BindSymVars(target_func_name, symvar_map)(Before)
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor((1, 2), dtype="float32"),
+            w0: R.Tensor((3, "n"), dtype="float32"),
+            w1: R.Tensor((2, 10), dtype="float32"),
+        ) -> R.Tensor((1, 6), dtype="float32"):
+            n = T.int64()
+            with R.dataflow():
+                lv0 = R.call_dps_packed(
+                    "test0", (x, w0), out_sinfo=R.Tensor((1, 3 + n), dtype="float32")
+                )
+                out = R.call_dps_packed(
+                    "test1", (lv0, w1), out_sinfo=R.Tensor((1, 2 + n), dtype="float32")
+                )
+                R.output(out)
+            return out
+
+    tvm.ir.assert_structural_equal(After, Expected)
+
+
+# TODO: Fix the issue with structural equality for mod, floordiv, floormod.
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_transform_gradient.py
+++ b/tests/python/relax/test_transform_gradient.py
@@ -14,14 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import tvm
+import numpy as np
 import pytest
+
+import tvm
 import tvm.testing
 from tvm import relax
+from tvm._ffi.base import TVMError
 from tvm.ir.base import assert_structural_equal
 from tvm.script.parser import relax as R, tir as T, ir as I
-from tvm._ffi.base import TVMError
-import numpy as np
 
 
 def test_simple():
@@ -38,20 +39,21 @@ def test_simple():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor(None, "float32", ndim=0):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor(None, "float32", ndim=0),R.Tuple(R.Tensor(None, "float32", ndim=2)),):
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                x_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -74,27 +76,27 @@ def test_assign_binding():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
-            # block 0
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = x
-                lv2: R.Tensor((3, 3), "float32") = lv1
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tensor((3, 3), dtype="float32") = x
+                lv2: R.Tensor((3, 3), dtype="float32") = lv1
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = x
-                lv2: R.Tensor((3, 3), "float32") = lv1
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
-                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tensor((3, 3), dtype="float32") = x
+                lv2: R.Tensor((3, 3), dtype="float32") = lv1
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -117,27 +119,29 @@ def test_multiple_uses():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, x)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv1_adjoint)
+                x_adjoint2: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint1, lv1_adjoint)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint2
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.add(lv2_adjoint, lv1_adjoint)
-                x_adjoint: R.Tensor((3, 3), "float32") = R.add(lv, lv1_adjoint)
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, x)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -149,7 +153,7 @@ def test_unused():
     @I.ir_module
     class Before:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32")):
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")):
             with R.dataflow():
                 lv1 = R.add(x, x)
                 lv2 = R.add(lv1, x)
@@ -160,24 +164,25 @@ def test_unused():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
-                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
-                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                x_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, x)
+                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -189,11 +194,7 @@ def test_default_require_grads():
     @I.ir_module
     class Before:
         @R.function
-        def main(
-            x: R.Tensor((3, 3), "float32"),
-            y: R.Tensor((3, 3), "float32"),
-            z: R.Tensor((3, 3), "float32"),
-        ):
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")):
             with R.dataflow():
                 lv1 = R.add(x, y)
                 lv2 = R.add(lv1, z)
@@ -204,33 +205,31 @@ def test_default_require_grads():
     @I.ir_module
     class Expected1:
         @R.function
-        def main(
-            x: R.Tensor((3, 3), "float32"),
-            y: R.Tensor((3, 3), "float32"),
-            z: R.Tensor((3, 3), "float32"),
-        ) -> R.Tensor((), "float32"):
-            # block 0
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                z_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out, z_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out, z_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
-                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
-                y_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
-                z_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
-                R.output(gv, x_adjoint, y_adjoint, z_adjoint)
-            return (gv, (x_adjoint, y_adjoint, z_adjoint))
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After1 = relax.transform.Gradient("main")(Before)
@@ -240,28 +239,27 @@ def test_default_require_grads():
     @I.ir_module
     class Expected2:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
-            # block 0
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
-            # block 0
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
-                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After2 = relax.transform.Gradient("main", require_grads=Before["main"].params[0])(Before)
@@ -284,25 +282,27 @@ def test_target_index():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((), "float32"), R.Tensor((), "float32")):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((), dtype="float32"), R.Tensor((), dtype="float32")), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = x
-                lv2: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                lv3: R.Tensor((), "float32") = R.sum(y, axis=None, keepdims=False)
-                R.output(lv1, lv2, lv3)
-            return (lv1, lv2, lv3)
+                lv1: R.Tensor((3, 3), dtype="float32") = x
+                lv2: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                lv3: R.Tensor((), dtype="float32") = R.sum(y, axis=None, keepdims=False)
+                lv3_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(lv3_adjoint, R.shape([3, 3]))
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                R.output(lv1, lv2, lv3, x_adjoint_out, y_adjoint_out)
+            return ((lv1, lv2, lv3), (x_adjoint_out, y_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((), "float32"), R.Tensor((), "float32")), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((), dtype="float32"), R.Tensor((), dtype="float32")):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = x
-                lv2: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                lv3: R.Tensor((), "float32") = R.sum(y, axis=None, keepdims=False)
-                lv3_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                x_adjoint: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                y_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(lv3_adjoint, (3, 3))
-                R.output(lv1, lv2, lv3, x_adjoint, y_adjoint)
-            return ((lv1, lv2, lv3), (x_adjoint, y_adjoint))
+                lv1: R.Tensor((3, 3), dtype="float32") = x
+                lv2: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                lv3: R.Tensor((), dtype="float32") = R.sum(y, axis=None, keepdims=False)
+                R.output(lv1, lv2, lv3)
+            return (lv1, lv2, lv3)
     # fmt: on
 
     After = relax.transform.Gradient("main", target_index=2)(Before)
@@ -328,39 +328,43 @@ def test_tuple():
                 R.output(gv)
             return gv
 
+
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tensor(None, "float32", ndim=0):
+        def main_adjoint(x: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (y, z)
-                lv2: R.Tensor((3, 3), "float32") = x[0]
-                lv3: R.Tensor((3, 3), "float32") = lv1[0]
-                lv4: R.Tensor((3, 3), "float32") = R.add(lv2, lv3)
-                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (y, z)
+                lv2: R.Tensor((3, 3), dtype="float32") = x[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = lv1[0]
+                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv2, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
+                lv: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv1_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv3_adjoint, lv)
+                lv1_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                x_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv2_adjoint, lv1_1)
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[0]
+                z_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[1]
+                x_adjoint_out: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x_adjoint
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out, z_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out, z_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (y, z)
-                lv2: R.Tensor((3, 3), "float32") = x[0]
-                lv3: R.Tensor((3, 3), "float32") = lv1[0]
-                lv4: R.Tensor((3, 3), "float32") = R.add(lv2, lv3)
-                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv4_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv3_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
-                lv2_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv1_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv3_adjoint, lv)
-                lv11: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                x_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv2_adjoint, lv11)
-                y_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[0]
-                z_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[1]
-                R.output(gv, x_adjoint, y_adjoint, z_adjoint)
-            return (gv, (x_adjoint, y_adjoint, z_adjoint))
+                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (y, z)
+                lv2: R.Tensor((3, 3), dtype="float32") = x[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = lv1[0]
+                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv2, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -375,57 +379,60 @@ def test_tuple_assignment():
         def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")):
             with R.dataflow():
                 lv1 = (x, y)
-                lv4 = lv1[0]
-                lv7 = R.add(lv4, x)
-                lv2 = lv1
-                lv3 = lv2[0]
-                lv5 = R.add(lv3, lv7)
-                gv = R.sum(lv5)
+                lv2 = lv1[0]
+                lv3 = R.add(lv2, x)
+                lv4 = lv1
+                lv5 = lv4[0]
+                lv6 = R.add(lv5, lv3)
+                gv = R.sum(lv6)
                 R.output(gv)
             return gv
 
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv4: R.Tensor((3, 3), "float32") = lv1[0]
-                lv7: R.Tensor((3, 3), "float32") = R.add(lv4, x)
-                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1
-                lv3: R.Tensor((3, 3), "float32") = lv2[0]
-                lv5: R.Tensor((3, 3), "float32") = R.add(lv3, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = lv1[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, x)
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[0]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv5, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
+                lv: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv4_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv5_adjoint, lv)
+                lv1_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv4_adjoint
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = lv3_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv3_adjoint
+                lv1_1: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[0]
+                lv2_1: R.Tensor((3, 3), dtype="float32") = R.add(lv1_1, lv2_adjoint)
+                lv3_1: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[1]
+                lv1_adjoint1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv2_1, lv3_1)
+                lv4_1: R.Tensor((3, 3), dtype="float32") = lv1_adjoint1[0]
+                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv4_1)
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint1[1]
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint1
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
-            # block 0
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv4: R.Tensor((3, 3), "float32") = lv1[0]
-                lv7: R.Tensor((3, 3), "float32") = R.add(lv4, x)
-                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1
-                lv3: R.Tensor((3, 3), "float32") = lv2[0]
-                lv5: R.Tensor((3, 3), "float32") = R.add(lv3, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv5_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv3_adjoint: R.Tensor((3, 3), "float32") = lv5_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv2_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv3_adjoint, lv)
-                lv7_adjoint: R.Tensor((3, 3), "float32") = lv5_adjoint
-                lv4_adjoint: R.Tensor((3, 3), "float32") = lv7_adjoint
-                lv11: R.Tensor((3, 3), "float32") = lv2_adjoint[0]
-                lv21: R.Tensor((3, 3), "float32") = R.add(lv11, lv4_adjoint)
-                lv31: R.Tensor((3, 3), "float32") = lv2_adjoint[1]
-                lv1_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv21, lv31)
-                lv41: R.Tensor((3, 3), "float32") = lv1_adjoint[0]
-                x_adjoint: R.Tensor((3, 3), "float32") = R.add(lv7_adjoint, lv41)
-                y_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[1]
-                R.output(gv, x_adjoint, y_adjoint)
-            return (gv, (x_adjoint, y_adjoint))
+                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = lv1[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, x)
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[0]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv5, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -459,51 +466,66 @@ def test_tuple_nested():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = ((y, z), u)
-                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = x[0]
-                lv3: R.Tensor((3, 3), "float32") = lv2[0]
-                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1[0]
-                lv5: R.Tensor((3, 3), "float32") = lv4[1]
-                lv6: R.Tensor((3, 3), "float32") = R.add(lv3, lv5)
-                lv7: R.Tensor((3, 3), "float32") = x[1]
-                lv8: R.Tensor((3, 3), "float32") = R.add(lv6, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv8, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = ((y, z), u)
+                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = lv2[0]
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1[0]
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv3, lv5)
+                lv7: R.Tensor((3, 3), dtype="float32") = x[1]
+                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv6, lv7)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv8, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv8_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
+                lv7_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
+                lv: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv1_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                x_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = ((lv, lv1_1), lv7_adjoint)
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
+                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
+                lv2_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv4_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv2_1, lv5_adjoint)
+                lv3_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv1_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = (lv4_adjoint, lv3_1)
+                lv4_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv2_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv3_adjoint, lv4_1)
+                lv5_1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x_adjoint[0]
+                lv6_1: R.Tensor((3, 3), dtype="float32") = lv5_1[0]
+                lv7_1: R.Tensor((3, 3), dtype="float32") = lv2_adjoint[0]
+                lv8_1: R.Tensor((3, 3), dtype="float32") = R.add(lv6_1, lv7_1)
+                lv9: R.Tensor((3, 3), dtype="float32") = lv5_1[1]
+                lv10: R.Tensor((3, 3), dtype="float32") = lv2_adjoint[1]
+                lv11: R.Tensor((3, 3), dtype="float32") = R.add(lv9, lv10)
+                lv12: R.Tensor((3, 3), dtype="float32") = x_adjoint[1]
+                x_adjoint1: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = ((lv8_1, lv11), lv12)
+                lv13: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1_adjoint[0]
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv13[0]
+                z_adjoint: R.Tensor((3, 3), dtype="float32") = lv13[1]
+                u_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[1]
+                x_adjoint_out: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = x_adjoint1
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                u_adjoint_out: R.Tensor((3, 3), dtype="float32") = u_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out, z_adjoint_out, u_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out, z_adjoint_out, u_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = ((y, z), u)
-                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = x[0]
-                lv3: R.Tensor((3, 3), "float32") = lv2[0]
-                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1[0]
-                lv5: R.Tensor((3, 3), "float32") = lv4[1]
-                lv6: R.Tensor((3, 3), "float32") = R.add(lv3, lv5)
-                lv7: R.Tensor((3, 3), "float32") = x[1]
-                lv8: R.Tensor((3, 3), "float32") = R.add(lv6, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv8, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv8_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv7_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
-                lv6_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
-                lv5_adjoint: R.Tensor((3, 3), "float32") = lv6_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv4_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv, lv5_adjoint)
-                lv3_adjoint: R.Tensor((3, 3), "float32") = lv6_adjoint
-                lv11: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv2_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv3_adjoint, lv11)
-                lv21: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv1_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = (lv4_adjoint, lv21)
-                x_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = (lv2_adjoint, lv7_adjoint)
-                lv31: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1_adjoint[0]
-                y_adjoint: R.Tensor((3, 3), "float32") = lv31[0]
-                z_adjoint: R.Tensor((3, 3), "float32") = lv31[1]
-                u_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[1]
-                R.output(gv, x_adjoint, y_adjoint, z_adjoint, u_adjoint)
-            return (gv, (x_adjoint, y_adjoint, z_adjoint, u_adjoint))
+                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = ((y, z), u)
+                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = lv2[0]
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1[0]
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv3, lv5)
+                lv7: R.Tensor((3, 3), dtype="float32") = x[1]
+                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv6, lv7)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv8, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -512,7 +534,6 @@ def test_tuple_nested():
 
 def test_tuple_update():
     """One tensor `x` is used in and out of tuple many times."""
-
     # fmt: off
     @I.ir_module
     class Before:
@@ -536,61 +557,66 @@ def test_tuple_update():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv0: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = lv0[0]
-                lv3: R.Tensor((3, 3), "float32") = R.add(lv2, y)
-                lv4: R.Tensor((3, 3), "float32") = R.add(lv1, lv3)
-                lv5: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv6: R.Tensor((3, 3), "float32") = lv5[0]
-                lv7: R.Tensor((3, 3), "float32") = lv0[0]
-                lv8: R.Tensor((3, 3), "float32") = R.add(lv4, lv6)
-                lv9: R.Tensor((3, 3), "float32") = R.add(lv8, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv9, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv0: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = lv0[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, y)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv1, lv3)
+                lv5: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv6: R.Tensor((3, 3), dtype="float32") = lv5[0]
+                lv7: R.Tensor((3, 3), dtype="float32") = lv0[0]
+                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv4, lv6)
+                lv9: R.Tensor((3, 3), dtype="float32") = R.add(lv8, lv7)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv9, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv9_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv8_adjoint: R.Tensor((3, 3), dtype="float32") = lv9_adjoint
+                lv7_adjoint: R.Tensor((3, 3), dtype="float32") = lv9_adjoint
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
+                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
+                lv: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv0_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv7_adjoint, lv)
+                lv1_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv5_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv6_adjoint, lv1_1)
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv5_adjoint[0]
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv5_adjoint[1]
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = lv3_adjoint
+                y_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(y_adjoint, lv3_adjoint)
+                lv2_1: R.Tensor((3, 3), dtype="float32") = lv0_adjoint[0]
+                lv3_1: R.Tensor((3, 3), dtype="float32") = R.add(lv2_1, lv2_adjoint)
+                lv4_1: R.Tensor((3, 3), dtype="float32") = lv0_adjoint[1]
+                lv0_adjoint1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv3_1, lv4_1)
+                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv1_adjoint)
+                y_adjoint2: R.Tensor((3, 3), dtype="float32") = R.add(y_adjoint1, lv1_adjoint)
+                lv5_1: R.Tensor((3, 3), dtype="float32") = lv0_adjoint1[0]
+                x_adjoint2: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint1, lv5_1)
+                lv6_1: R.Tensor((3, 3), dtype="float32") = lv0_adjoint1[1]
+                y_adjoint3: R.Tensor((3, 3), dtype="float32") = R.add(y_adjoint2, lv6_1)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint2
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint3
+                R.output(gv, x_adjoint_out, y_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv0: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = lv0[0]
-                lv3: R.Tensor((3, 3), "float32") = R.add(lv2, y)
-                lv4: R.Tensor((3, 3), "float32") = R.add(lv1, lv3)
-                lv5: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv6: R.Tensor((3, 3), "float32") = lv5[0]
-                lv7: R.Tensor((3, 3), "float32") = lv0[0]
-                lv8: R.Tensor((3, 3), "float32") = R.add(lv4, lv6)
-                lv9: R.Tensor((3, 3), "float32") = R.add(lv8, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv9, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv9_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv8_adjoint: R.Tensor((3, 3), "float32") = lv9_adjoint
-                lv7_adjoint: R.Tensor((3, 3), "float32") = lv9_adjoint
-                lv6_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv5_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv6_adjoint, lv)
-                lv4_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
-                lv3_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
-                lv2_adjoint: R.Tensor((3, 3), "float32") = lv3_adjoint
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
-                lv11: R.Tensor((3, 3), "float32") = R.add(lv7_adjoint, lv2_adjoint)
-                lv21: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv0_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv11, lv21)
-                lv31: R.Tensor((3, 3), "float32") = lv5_adjoint[0]
-                lv41: R.Tensor((3, 3), "float32") = R.add(lv31, lv1_adjoint)
-                lv51: R.Tensor((3, 3), "float32") = lv0_adjoint[0]
-                x_adjoint: R.Tensor((3, 3), "float32") = R.add(lv41, lv51)
-                lv61: R.Tensor((3, 3), "float32") = lv5_adjoint[1]
-                lv71: R.Tensor((3, 3), "float32") = R.add(lv61, lv3_adjoint)
-                lv81: R.Tensor((3, 3), "float32") = R.add(lv71, lv1_adjoint)
-                lv91: R.Tensor((3, 3), "float32") = lv0_adjoint[1]
-                y_adjoint: R.Tensor((3, 3), "float32") = R.add(lv81, lv91)
-                R.output(gv, x_adjoint, y_adjoint)
-            return (gv, (x_adjoint, y_adjoint))
+                lv0: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = lv0[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, y)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv1, lv3)
+                lv5: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv6: R.Tensor((3, 3), dtype="float32") = lv5[0]
+                lv7: R.Tensor((3, 3), dtype="float32") = lv0[0]
+                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv4, lv6)
+                lv9: R.Tensor((3, 3), dtype="float32") = R.add(lv8, lv7)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv9, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -613,26 +639,27 @@ def test_tuple_op_simple():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((6,), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((6,), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((6,), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(x, indices_or_sections=2, axis=0)
-                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(x, indices_or_sections=2, axis=0)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv2_adjoint: R.Tensor((6,), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([6]))
+                lv1_adjoint: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
+                x_adjoint: R.Tensor((6,), dtype="float32") = R.concat(lv1_adjoint, axis=0)
+                x_adjoint_out: R.Tensor((6,), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((6,), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((6,), "float32"))):
+        def main(x: R.Tensor((6,), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(x, indices_or_sections=2, axis=0)
-                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv2_adjoint: R.Tensor((6,), "float32") = R.broadcast_to(gv_adjoint, (6,))
-                lv1_adjoint: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
-                x_adjoint: R.Tensor((6,), "float32") = R.concat(lv1_adjoint, axis=0)
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(x, indices_or_sections=2, axis=0)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -659,46 +686,48 @@ def test_tuple_op_construct():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3,), "float32"), y: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32"))) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3,), dtype="float32"), y: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32"))) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3,), dtype="float32"), R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = (x, x)
-                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
-                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), "float32") = R.concat(y, axis=0)
-                lv5: R.Tensor((6,), "float32") = R.add(lv2, lv3)
-                lv6: R.Tensor((6,), "float32") = R.add(lv5, lv4)
-                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = (x, x)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
+                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), dtype="float32") = R.concat(y, axis=0)
+                lv5: R.Tensor((6,), dtype="float32") = R.add(lv2, lv3)
+                lv6: R.Tensor((6,), dtype="float32") = R.add(lv5, lv4)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv6_adjoint: R.Tensor((6,), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([6]))
+                lv5_adjoint: R.Tensor((6,), dtype="float32") = lv6_adjoint
+                lv4_adjoint: R.Tensor((6,), dtype="float32") = lv6_adjoint
+                lv2_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
+                lv3_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
+                y_adjoint: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv4_adjoint, indices_or_sections=[3], axis=0)
+                lv: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
+                x_adjoint: R.Tensor((3,), dtype="float32") = lv[0]
+                lv1_1: R.Tensor((3,), dtype="float32") = lv[1]
+                x_adjoint1: R.Tensor((3,), dtype="float32") = R.add(x_adjoint, lv1_1)
+                lv1_adjoint: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
+                lv2_1: R.Tensor((3,), dtype="float32") = lv1_adjoint[0]
+                x_adjoint2: R.Tensor((3,), dtype="float32") = R.add(x_adjoint1, lv2_1)
+                lv3_1: R.Tensor((3,), dtype="float32") = lv1_adjoint[1]
+                x_adjoint3: R.Tensor((3,), dtype="float32") = R.add(x_adjoint2, lv3_1)
+                x_adjoint_out: R.Tensor((3,), dtype="float32") = x_adjoint3
+                y_adjoint_out: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = y_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3,), "float32"), y: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32"))) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3,), "float32"), R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")))):
+        def main(x: R.Tensor((3,), dtype="float32"), y: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32"))) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = (x, x)
-                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
-                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), "float32") = R.concat(y, axis=0)
-                lv5: R.Tensor((6,), "float32") = R.add(lv2, lv3)
-                lv6: R.Tensor((6,), "float32") = R.add(lv5, lv4)
-                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv6_adjoint: R.Tensor((6,), "float32") = R.broadcast_to(gv_adjoint, (6,))
-                lv5_adjoint: R.Tensor((6,), "float32") = lv6_adjoint
-                lv4_adjoint: R.Tensor((6,), "float32") = lv6_adjoint
-                lv3_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
-                lv2_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
-                lv1_adjoint: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
-                lv: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
-                lv11: R.Tensor((3,), "float32") = lv[0]
-                lv21: R.Tensor((3,), "float32") = lv[1]
-                lv31: R.Tensor((3,), "float32") = R.add(lv11, lv21)
-                lv41: R.Tensor((3,), "float32") = lv1_adjoint[0]
-                lv51: R.Tensor((3,), "float32") = R.add(lv31, lv41)
-                lv61: R.Tensor((3,), "float32") = lv1_adjoint[1]
-                x_adjoint: R.Tensor((3,), "float32") = R.add(lv51, lv61)
-                y_adjoint: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv4_adjoint, indices_or_sections=[3], axis=0)
-                R.output(gv, x_adjoint, y_adjoint)
-            return (gv, (x_adjoint, y_adjoint))
+                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = (x, x)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
+                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), dtype="float32") = R.concat(y, axis=0)
+                lv5: R.Tensor((6,), dtype="float32") = R.add(lv2, lv3)
+                lv6: R.Tensor((6,), dtype="float32") = R.add(lv5, lv4)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -728,43 +757,41 @@ def test_tuple_op_const():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3,), "float32")) -> R.Tensor((), "float32"):
-            # block 0
+        def main_adjoint(x: R.Tensor((3,), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3,), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((6,), "float32") = R.concat((c1, c2), axis=0)
-                lv2: R.Tensor((6,), "float32") = R.concat((c3, x), axis=0)
-                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), "float32") = R.add(lv1, lv2)
-                lv5: R.Tensor((6,), "float32") = R.add(lv4, lv3)
-                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tensor((6,), dtype="float32") = R.concat((c1, c2), axis=0)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat((c3, x), axis=0)
+                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), dtype="float32") = R.add(lv1, lv2)
+                lv5: R.Tensor((6,), dtype="float32") = R.add(lv4, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv5, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv5_adjoint: R.Tensor((6,), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([6]))
+                lv4_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
+                lv3_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
+                lv2_adjoint: R.Tensor((6,), dtype="float32") = lv4_adjoint
+                lv: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
+                x_adjoint: R.Tensor((3,), dtype="float32") = lv[0]
+                lv1_1: R.Tensor((3,), dtype="float32") = lv[1]
+                x_adjoint1: R.Tensor((3,), dtype="float32") = R.add(x_adjoint, lv1_1)
+                lv2_1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
+                lv3_1: R.Tensor((3,), dtype="float32") = lv2_1[1]
+                x_adjoint2: R.Tensor((3,), dtype="float32") = R.add(x_adjoint1, lv3_1)
+                x_adjoint_out: R.Tensor((3,), dtype="float32") = x_adjoint2
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3,), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3,), "float32"))):
-            # block 0
+        def main(x: R.Tensor((3,), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((6,), "float32") = R.concat((c1, c2), axis=0)
-                lv2: R.Tensor((6,), "float32") = R.concat((c3, x), axis=0)
-                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), "float32") = R.add(lv1, lv2)
-                lv5: R.Tensor((6,), "float32") = R.add(lv4, lv3)
-                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv5_adjoint: R.Tensor((6,), "float32") = R.broadcast_to(gv_adjoint, (6,))
-                lv4_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
-                lv3_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
-                lv2_adjoint: R.Tensor((6,), "float32") = lv4_adjoint
-                lv1_adjoint: R.Tensor((6,), "float32") = lv4_adjoint
-                lv: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
-                lv11: R.Tensor((3,), "float32") = lv[0]
-                lv21: R.Tensor((3,), "float32") = lv[1]
-                lv31: R.Tensor((3,), "float32") = R.add(lv11, lv21)
-                lv41: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
-                lv51: R.Tensor((3,), "float32") = lv41[1]
-                x_adjoint: R.Tensor((3,), "float32") = R.add(lv31, lv51)
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tensor((6,), dtype="float32") = R.concat((c1, c2), axis=0)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat((c3, x), axis=0)
+                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), dtype="float32") = R.add(lv1, lv2)
+                lv5: R.Tensor((6,), dtype="float32") = R.add(lv4, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv5, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -794,42 +821,85 @@ def test_const():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, cst)
-                lv2: R.Tensor((3, 3), "float32") = cst
-                lv3: R.Tuple(R.Tensor((3, 3), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))) = (cst, (cst, lv1))
-                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv3[1]
-                lv5: R.Tensor((3, 3), "float32") = lv4[1]
-                lv6: R.Tensor((3, 3), "float32") = R.subtract(lv5, lv2)
-                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, cst)
+                lv2: R.Tensor((3, 3), dtype="float32") = cst
+                lv3: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))) = (cst, (cst, lv1))
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3[1]
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.subtract(lv5, lv2)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
+                lv: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv4_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv, lv5_adjoint)
+                lv1_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv3_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))) = (lv1_1, lv4_adjoint)
+                lv2_1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3_adjoint[1]
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_1[1]
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, cst)
+                lv2: R.Tensor((3, 3), dtype="float32") = cst
+                lv3: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))) = (cst, (cst, lv1))
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3[1]
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.subtract(lv5, lv2)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After = relax.transform.Gradient("main")(Before)
+    assert_structural_equal(After, Expected)
+
+
+def test_shape_expr():
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor((3, 4), "float32")):
+            with R.dataflow():
+                s = R.shape([3, 2, 2])
+                lv = R.reshape(x, s)
+                gv = R.sum(lv)
                 R.output(gv)
             return gv
 
+    @I.ir_module
+    class Expected:
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main_adjoint(x: R.Tensor((3, 4), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 4), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, cst)
-                lv2: R.Tensor((3, 3), "float32") = cst
-                lv3: R.Tuple(R.Tensor((3, 3), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))) = (cst, (cst, lv1))
-                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv3[1]
-                lv5: R.Tensor((3, 3), "float32") = lv4[1]
-                lv6: R.Tensor((3, 3), "float32") = R.subtract(lv5, lv2)
-                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv6_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv5_adjoint: R.Tensor((3, 3), "float32") = lv6_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv4_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv, lv5_adjoint)
-                lv11: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv3_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))) = (lv11, lv4_adjoint)
-                lv2_adjoint: R.Tensor((3, 3), "float32") = R.negative(lv6_adjoint)
-                lv21: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv3_adjoint[1]
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv21[1]
-                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
-                y_adjoint: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                R.output(gv, x_adjoint, y_adjoint)
-            return (gv, (x_adjoint, y_adjoint))
+                s: R.Shape([3, 2, 2]) = R.shape([3, 2, 2])
+                lv: R.Tensor((3, 2, 2), dtype="float32") = R.reshape(x, s)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv_adjoint: R.Tensor((3, 2, 2), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 2, 2]))
+                x_adjoint: R.Tensor((3, 4), dtype="float32") = R.reshape(lv_adjoint, R.shape([3, 4]))
+                x_adjoint_out: R.Tensor((3, 4), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 4), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                s: R.Shape([3, 2, 2]) = R.shape([3, 2, 2])
+                lv: R.Tensor((3, 2, 2), dtype="float32") = R.reshape(x, s)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -890,6 +960,29 @@ def test_function_copy():
     old_bindings_len = len(old_bindings)
     new_bindings = After["main_adjoint"].body.blocks[0].bindings[:old_bindings_len]
     assert_structural_equal(old_bindings, new_bindings, True)
+    assert relax.analysis.well_formed(After)
+
+
+def test_tir_copy():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x0: R.Tensor(("n", "n"), "float32"),
+            x1: R.Tensor(("n", "n"), "float32"),
+            x2: R.Tensor(("n", "n"), "float32"),
+            x3: R.Tensor(("n", "n"), "float32"),
+        ):
+            with R.dataflow():
+                lv0 = R.add(x0, x1)
+                lv1 = R.add(x2, x3)
+                lv2 = R.add(lv0, lv1)
+                gv = R.sum(lv2)
+                R.output(gv)
+            return gv
+
+    After = relax.transform.Gradient("main")(Before)
+    assert relax.analysis.well_formed(After)
 
 
 def test_report_error():
@@ -1055,47 +1148,6 @@ def test_report_error():
         relax.transform.Gradient("main")(IntDtypeTuple)
 
 
-def test_shape_expr():
-    # fmt: off
-    @I.ir_module
-    class Before:
-        @R.function
-        def main(x: R.Tensor((3, 4), "float32")):
-            with R.dataflow():
-                s = R.shape([3, 2, 2])
-                lv = R.reshape(x, s)
-                gv = R.sum(lv)
-                R.output(gv)
-            return gv
-
-    @I.ir_module
-    class Expected:
-        @R.function
-        def main_adjoint(x: R.Tensor((3, 4), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 4), dtype="float32"))):
-            with R.dataflow():
-                s: R.Shape([3, 2, 2]) = R.shape([3, 2, 2])
-                lv = R.reshape(x, s)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
-                lv_adjoint : R.Tensor([3, 2, 2], "float32") = R.broadcast_to(gv_adjoint, R.shape([3, 2, 2]))
-                x_adjoint: R.Tensor((3, 4), dtype="float32") = R.reshape(lv_adjoint, R.shape([3, 4]))
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
-
-        @R.function
-        def main(x: R.Tensor((3, 4), dtype="float32")) -> R.Tensor((), dtype="float32"):
-            with R.dataflow():
-                s: R.Shape([3, 2, 2]) = R.shape([3, 2, 2])
-                lv = R.reshape(x, s)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
-    # fmt: on
-
-    After = relax.transform.Gradient("main")(Before)
-    assert_structural_equal(After, Expected)
-
-
 def test_mlp_script():
     """
     An example of single layer multi-layer perceptron. You can add extra layers if you want.
@@ -1133,17 +1185,18 @@ def test_mlp_script():
                 lv: R.Tensor((), dtype="float32") = R.divide(loss_adjoint, R.const(3, "float32"))
                 lv1: R.Tensor((), dtype="float32") = R.negative(lv)
                 logits_adjoint: R.Tensor((3, 5), dtype="float32") = R.multiply(lv1, label)
-                lv2: R.Tensor((3, 1), dtype="float32") = R.sum(logits_adjoint, axis=[-1], keepdims=True)
-                lv3: R.Tensor((3, 5), dtype="float32") = R.exp(logits)
-                lv4: R.Tensor((3, 5), dtype="float32") = R.multiply(lv2, lv3)
-                out_adjoint: R.Tensor((3, 5), dtype="float32") = R.subtract(logits_adjoint, lv4)
+                lv3: R.Tensor((3, 1), dtype="float32") = R.sum(logits_adjoint, axis=[-1], keepdims=True)
+                lv4: R.Tensor((3, 5), dtype="float32") = R.exp(logits)
+                lv5: R.Tensor((3, 5), dtype="float32") = R.multiply(lv3, lv4)
+                out_adjoint: R.Tensor((3, 5), dtype="float32") = R.subtract(logits_adjoint, lv5)
                 lv0_adjoint: R.Tensor((3, 5), dtype="float32") = out_adjoint
-                lv5: R.Tensor((5, 10), dtype="float32") = R.permute_dims(w0, axes=[1, 0])
-                lv6: R.Tensor((10, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
-                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.matmul(lv6, lv0_adjoint, out_dtype="void")
                 b0_adjoint: R.Tensor((5,), dtype="float32") = R.collapse_sum_to(out_adjoint, R.shape([5]))
-                R.output(loss, w0_adjoint, b0_adjoint)
-            return (loss, (w0_adjoint, b0_adjoint))
+                lv7: R.Tensor((10, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
+                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.matmul(lv7, lv0_adjoint, out_dtype="void")
+                w0_adjoint_out: R.Tensor((10, 5), dtype="float32") = w0_adjoint
+                b0_adjoint_out: R.Tensor((5,), dtype="float32") = b0_adjoint
+                R.output(loss, w0_adjoint_out, b0_adjoint_out)
+            return (loss, (w0_adjoint_out, b0_adjoint_out))
 
         @R.function
         def main(x: R.Tensor((3, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32"), label: R.Tensor((3, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):

--- a/tests/python/relax/test_transform_gradient_checkpoint.py
+++ b/tests/python/relax/test_transform_gradient_checkpoint.py
@@ -1,0 +1,689 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for gradient with checkpointing."""
+import tvm
+from tvm.relax.block_builder import BlockBuilder
+from tvm.relax.testing.nn import checkpoint, emit_checkpoint, emit_checkpoint_sequential
+import tvm.testing
+from tvm import relax
+from tvm.ir.base import assert_structural_equal
+from tvm.script.parser import relax as R, ir as I
+
+
+def test_sequential():
+    """Comp. graph is a sequence"""
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32")):
+            with R.dataflow():
+                x_scp = R.grad.start_checkpoint(x)
+                lv1 = R.power(x_scp, R.const(3, "float32"))
+                lv1_ecp = R.grad.end_checkpoint(lv1)
+                lv2 = R.power(lv1_ecp, R.const(3, "float32"))
+                lv2_scp = R.grad.start_checkpoint(lv2)
+                lv3 = R.power(lv2_scp, R.const(3, "float32"))
+                lv4 = R.power(lv3, R.const(3, "float32"))
+                gv = R.sum(lv4)
+                gv_ecp = R.grad.end_checkpoint(gv)
+                R.output(gv_ecp)
+            return gv_ecp
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
+                lv2: R.Tensor((3, 3), dtype="float32") = R.power(lv1, R.const(3, "float32"))
+                lv3: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
+                lv4: R.Tensor((3, 3), dtype="float32") = R.power(lv3, R.const(3, "float32"))
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_1: R.Tensor((), dtype="float32") = gv
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                gv_adjoint1: R.Tensor((), dtype="float32") = gv_adjoint
+                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint1, R.shape([3, 3]))
+                lv: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, R.const(3, "float32"))
+                lv1_1: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv2_1: R.Tensor((3, 3), dtype="float32") = R.power(lv3_cp, lv1_1)
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv, lv2_1)
+                lv6: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, R.const(3, "float32"))
+                lv7: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv8: R.Tensor((3, 3), dtype="float32") = R.power(lv2, lv7)
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, lv8)
+                lv1_cp: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
+                lv12: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, R.const(3, "float32"))
+                lv13: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv14: R.Tensor((3, 3), dtype="float32") = R.power(lv1_cp, lv13)
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv12, lv14)
+                lv18: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(3, "float32"))
+                lv19: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv20: R.Tensor((3, 3), dtype="float32") = R.power(x, lv19)
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv18, lv20)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                R.output(gv_1, x_adjoint_out)
+            return (gv_1, (x_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                x_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(x)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x_scp, R.const(3, "float32"))
+                lv1_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv1)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.power(lv1_ecp, R.const(3, "float32"))
+                lv2_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv2)
+                lv3: R.Tensor((3, 3), dtype="float32") = R.power(lv2_scp, R.const(3, "float32"))
+                lv4: R.Tensor((3, 3), dtype="float32") = R.power(lv3, R.const(3, "float32"))
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_ecp: R.Tensor((), dtype="float32") = R.grad.end_checkpoint(gv)
+                R.output(gv_ecp)
+            return gv_ecp
+    # fmt: on
+
+    After = relax.transform.Gradient("main")(Before)
+    assert_structural_equal(After, Expected)
+
+
+def test_sequential_consecutive():
+    """Comp. graph is a sequence"""
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32")):
+            with R.dataflow():
+                x_scp = R.grad.start_checkpoint(x)
+                lv1 = R.power(x_scp, R.const(3, "float32"))
+                lv2 = R.power(lv1, R.const(3, "float32"))
+                lv2_ecp = R.grad.end_checkpoint(lv2)
+                lv2_scp = R.grad.start_checkpoint(lv2_ecp)
+                lv3 = R.power(lv2_scp, R.const(3, "float32"))
+                lv4 = R.power(lv3, R.const(3, "float32"))
+                lv4_ecp = R.grad.end_checkpoint(lv4)
+                gv = R.sum(lv4_ecp)
+                R.output(gv)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
+                lv2: R.Tensor((3, 3), dtype="float32") = R.power(lv1, R.const(3, "float32"))
+                lv3: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
+                lv4: R.Tensor((3, 3), dtype="float32") = R.power(lv3, R.const(3, "float32"))
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, R.const(3, "float32"))
+                lv1_1: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv2_1: R.Tensor((3, 3), dtype="float32") = R.power(lv3_cp, lv1_1)
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv, lv2_1)
+                lv6: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, R.const(3, "float32"))
+                lv7: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv8: R.Tensor((3, 3), dtype="float32") = R.power(lv2, lv7)
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, lv8)
+                lv1_cp: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
+                lv12: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, R.const(3, "float32"))
+                lv13: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv14: R.Tensor((3, 3), dtype="float32") = R.power(lv1_cp, lv13)
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv12, lv14)
+                lv18: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(3, "float32"))
+                lv19: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv20: R.Tensor((3, 3), dtype="float32") = R.power(x, lv19)
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv18, lv20)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                x_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(x)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x_scp, R.const(3, "float32"))
+                lv2: R.Tensor((3, 3), dtype="float32") = R.power(lv1, R.const(3, "float32"))
+                lv2_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv2)
+                lv2_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv2_ecp)
+                lv3: R.Tensor((3, 3), dtype="float32") = R.power(lv2_scp, R.const(3, "float32"))
+                lv4: R.Tensor((3, 3), dtype="float32") = R.power(lv3, R.const(3, "float32"))
+                lv4_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv4)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4_ecp, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+
+    # fmt: on
+
+    After = relax.transform.Gradient("main")(Before)
+    assert_structural_equal(After, Expected)
+
+
+def test_tuple():
+    """Comp. graph is a sequence"""
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32")):
+            with R.dataflow():
+                x_scp = R.grad.start_checkpoint(x)
+                lv1 = R.power(x_scp, R.const(3, "float32"))
+                lv2 = (x, lv1)
+                lv3 = lv2
+                lv4 = R.power(lv3[0], R.const(3, "float32"))
+                lv4_ecp = R.grad.end_checkpoint(lv4)
+                gv = R.sum(lv4_ecp)
+                R.output(gv)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
+                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x, lv1
+                lv3: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv2
+                lv4: R.Tensor((3, 3), dtype="float32") = lv3[0]
+                lv4_1: R.Tensor((3, 3), dtype="float32") = R.power(lv4, R.const(3, "float32"))
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4_1, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv1_cp: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
+                lv2_cp: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x, lv1_cp
+                lv3_cp: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv2_cp
+                lv4_cp: R.Tensor((3, 3), dtype="float32") = lv3_cp[0]
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, R.const(3, "float32"))
+                lv1_1: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv2_1: R.Tensor((3, 3), dtype="float32") = R.power(lv4_cp, lv1_1)
+                lv4_adjoint1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv, lv2_1)
+                lv6: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv3_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv4_adjoint1, lv6
+                lv2_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint[0]
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint[1]
+                lv7: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(3, "float32"))
+                lv8: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv9: R.Tensor((3, 3), dtype="float32") = R.power(x, lv8)
+                lv12: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7, lv9)
+                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv12)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint1
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                x_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(x)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x_scp, R.const(3, "float32"))
+                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x, lv1
+                lv3: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv2
+                lv4: R.Tensor((3, 3), dtype="float32") = lv3[0]
+                lv4_1: R.Tensor((3, 3), dtype="float32") = R.power(lv4, R.const(3, "float32"))
+                lv4_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv4_1)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4_ecp, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After = relax.transform.Gradient("main")(Before)
+    assert_structural_equal(After, Expected)
+
+
+def test_tree():
+    """Comp. graph is a output-directed tree"""
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32"), v: R.Tensor((3, 3), "float32")):
+            with R.dataflow():
+                lv1 = x * y
+                lv1_scp = R.grad.start_checkpoint(lv1)
+                z_scp = R.grad.start_checkpoint(z)
+                lv2 = lv1_scp * z_scp
+                lv2_ecp = R.grad.end_checkpoint(lv2)
+                u_scp = R.grad.start_checkpoint(u)
+                v_scp = R.grad.start_checkpoint(v)
+                lv3 = u_scp * v_scp
+                lv3_ecp = R.grad.end_checkpoint(lv3)
+                lv4 = lv2_ecp * lv3_ecp
+                gv = R.sum(lv4)
+                R.output(gv)
+            return gv
+
+    @I.ir_module
+    class Expected1:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
+                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv2_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
+                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, lv3_cp)
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, lv2_cp)
+                u_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, v)
+                v_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, u)
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, z)
+                z_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, lv1)
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, y)
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, x)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                u_adjoint_out: R.Tensor((3, 3), dtype="float32") = u_adjoint
+                v_adjoint_out: R.Tensor((3, 3), dtype="float32") = v_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out, z_adjoint_out, u_adjoint_out, v_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out, z_adjoint_out, u_adjoint_out, v_adjoint_out))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                lv1 = x * y
+                lv1_scp = R.grad.start_checkpoint(lv1)
+                z_scp = R.grad.start_checkpoint(z)
+                lv2 = lv1_scp * z_scp
+                lv2_ecp = R.grad.end_checkpoint(lv2)
+                u_scp = R.grad.start_checkpoint(u)
+                v_scp = R.grad.start_checkpoint(v)
+                lv3 = u_scp * v_scp
+                lv3_ecp = R.grad.end_checkpoint(lv3)
+                lv4 = lv2_ecp * lv3_ecp
+                gv = R.sum(lv4)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After1 = relax.transform.Gradient("main")(Before)
+    assert_structural_equal(After1, Expected1)
+
+    # fmt: off
+    @I.ir_module
+    class Expected2:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
+                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, lv3_cp)
+                z_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, lv1)
+                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                R.output(gv, z_adjoint_out)
+            return (gv, (z_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                lv1 = x * y
+                lv1_scp = R.grad.start_checkpoint(lv1)
+                z_scp = R.grad.start_checkpoint(z)
+                lv2 = lv1_scp * z_scp
+                lv2_ecp = R.grad.end_checkpoint(lv2)
+                u_scp = R.grad.start_checkpoint(u)
+                v_scp = R.grad.start_checkpoint(v)
+                lv3 = u_scp * v_scp
+                lv3_ecp = R.grad.end_checkpoint(lv3)
+                lv4 = lv2_ecp * lv3_ecp
+                gv = R.sum(lv4)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After2 = relax.transform.Gradient("main", require_grads=Before["main"].params[2])(Before)
+    assert_structural_equal(After2, Expected2)
+
+
+def test_dag():
+    """Comp. graph is a DAG with only one output. Here we only test the simple case: comp. graph
+    is a sequence of sub-graphs, and the checkpoints are the intersections of connected
+    subgraphs."""
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32")):
+            with R.dataflow():
+                lv = R.grad.start_checkpoint(x)
+                lv1 = R.multiply(lv, R.const(2, "float32"))
+                lv2 = R.multiply(lv1, R.const(2, "float32"))
+                lv3 = R.grad.end_checkpoint(lv2)
+                lv4 = R.multiply(x, lv3)
+                lv5 = R.grad.start_checkpoint(lv4)
+                lv6 = R.multiply(lv5, R.const(2, "float32"))
+                lv7 = R.multiply(lv6, R.const(2, "float32"))
+                lv8 = R.grad.end_checkpoint(lv7)
+                lv9 = R.multiply(lv4, lv8)
+                lv10 = R.grad.start_checkpoint(lv9)
+                lv11 = R.multiply(lv10, R.const(2, "float32"))
+                lv12 = R.multiply(lv11, R.const(2, "float32"))
+                lv13 = R.grad.end_checkpoint(lv12)
+                lv14 = R.multiply(lv9, lv13)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv14, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, R.const(2, "float32"))
+                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, R.const(2, "float32"))
+                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(x, lv2)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, R.const(2, "float32"))
+                lv5: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4, R.const(2, "float32"))
+                lv6: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, lv5)
+                lv7: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, R.const(2, "float32"))
+                lv8: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7, R.const(2, "float32"))
+                lv9: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, lv8)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv9, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv9_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv7_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, R.const(2, "float32"))
+                lv8_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7_cp, R.const(2, "float32"))
+                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv9_adjoint, lv8_cp)
+                lv8_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv9_adjoint, lv6)
+                lv7_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv8_adjoint, R.const(2, "float32"))
+                lv1_1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7_adjoint, R.const(2, "float32"))
+                lv6_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(lv6_adjoint, lv1_1)
+                lv4_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, R.const(2, "float32"))
+                lv5_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_cp, R.const(2, "float32"))
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6_adjoint1, lv5_cp)
+                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6_adjoint1, lv3)
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv5_adjoint, R.const(2, "float32"))
+                lv4_1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, R.const(2, "float32"))
+                lv3_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(lv3_adjoint, lv4_1)
+                lv1_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(x, R.const(2, "float32"))
+                lv2_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_cp, R.const(2, "float32"))
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint1, lv2_cp)
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint1, x)
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, R.const(2, "float32"))
+                lv7_1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(2, "float32"))
+                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv7_1)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint1
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                lv = R.grad.start_checkpoint(x)
+                lv1 = R.multiply(lv, R.const(2, "float32"))
+                lv2 = R.multiply(lv1, R.const(2, "float32"))
+                lv3 = R.grad.end_checkpoint(lv2)
+                lv4 = R.multiply(x, lv3)
+                lv5 = R.grad.start_checkpoint(lv4)
+                lv6 = R.multiply(lv5, R.const(2, "float32"))
+                lv7 = R.multiply(lv6, R.const(2, "float32"))
+                lv8 = R.grad.end_checkpoint(lv7)
+                lv9 = R.multiply(lv4, lv8)
+                lv10 = R.grad.start_checkpoint(lv9)
+                lv11 = R.multiply(lv10, R.const(2, "float32"))
+                lv12 = R.multiply(lv11, R.const(2, "float32"))
+                lv13 = R.grad.end_checkpoint(lv12)
+                lv14 = R.multiply(lv9, lv13)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv14, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After = relax.transform.Gradient("main")(Before)
+    assert_structural_equal(After, Expected)
+
+
+def test_checkpoint_api():
+    """Test on tvm.relax.testing.nn.checkpoint API"""
+
+    def func1(x):
+        return relax.op.power(x, relax.const(3, "float32"))
+
+    def func2(x):
+        y = relax.op.power(relax.op.power(x, relax.const(3, "float32")), relax.const(3, "float32"))
+        return relax.op.sum(y)
+
+    bb = BlockBuilder()
+    x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
+    with bb.function("main", [x]):
+        with bb.dataflow():
+            lv1 = bb.emit(checkpoint(func1, x))
+            lv2 = bb.emit(relax.op.power(lv1, relax.const(3, "float32")))
+            lv3 = bb.emit_output(checkpoint(func2, lv2))
+        bb.emit_func_output(lv3)
+
+    # fmt: off
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32")):
+            with R.dataflow():
+                x_scp = R.grad.start_checkpoint(x)
+                lv1 = R.power(x_scp, R.const(3, "float32"))
+                lv1_ecp = R.grad.end_checkpoint(lv1)
+                lv2 = R.power(lv1_ecp, R.const(3, "float32"))
+                lv2_scp = R.grad.start_checkpoint(lv2)
+                lv3 = R.power(lv2_scp, R.const(3, "float32"))
+                lv4 = R.power(lv3, R.const(3, "float32"))
+                gv = R.sum(lv4)
+                gv_ecp = R.grad.end_checkpoint(gv)
+                R.output(gv_ecp)
+            return gv_ecp
+    # fmt: on
+
+    assert_structural_equal(bb.get(), Expected)
+
+
+def test_checkpoint_tree():
+    """Comp. graph is a output-directed tree"""
+
+    def func(x, y, z, w):
+        return x * y, z * w
+
+    bb = BlockBuilder()
+    x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
+    y = relax.Var("y", relax.TensorStructInfo((3, 3), "float32"))
+    z = relax.Var("z", relax.TensorStructInfo((3, 3), "float32"))
+    u = relax.Var("u", relax.TensorStructInfo((3, 3), "float32"))
+    v = relax.Var("v", relax.TensorStructInfo((3, 3), "float32"))
+    with bb.function("main", [x, y, z, u, v]):
+        with bb.dataflow():
+            lv1 = bb.emit(x * y)
+            cp = checkpoint(func, lv1, z, u, v)
+            lv2 = bb.emit(cp[0])
+            lv3 = bb.emit(cp[1])
+            lv4 = bb.emit(lv2 * lv3)
+            gv = bb.emit_output(relax.op.sum(lv4))
+        bb.emit_func_output(gv)
+
+    # fmt: off
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32"), v: R.Tensor((3, 3), "float32")):
+            with R.dataflow():
+                lv1 = x * y
+                lv1_scp = R.grad.start_checkpoint(lv1)
+                z_scp = R.grad.start_checkpoint(z)
+                lv2 = lv1_scp * z_scp
+                lv2_ecp = R.grad.end_checkpoint(lv2)
+                u_scp = R.grad.start_checkpoint(u)
+                v_scp = R.grad.start_checkpoint(v)
+                lv3 = u_scp * v_scp
+                lv3_ecp = R.grad.end_checkpoint(lv3)
+                lv4 = lv2_ecp * lv3_ecp
+                gv = R.sum(lv4)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    assert_structural_equal(bb.get(), Expected)
+
+
+def test_checkpoint_dag():
+    """Comp. graph is a DAG with only one output. Here we only test the simple case: comp. graph
+    is a sequence of sub-graphs, and the checkpoints are the intersections of connected
+    subgraphs."""
+
+    def func(x):
+        return x * relax.const(2, "float32") * relax.const(2, "float32")
+
+    bb = BlockBuilder()
+    x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
+    with bb.function("main", [x]):
+        with bb.dataflow():
+            lv1 = bb.emit(checkpoint(func, x))
+            lv2 = bb.emit(x * lv1)
+            lv3 = bb.emit(checkpoint(func, lv2))
+            lv4 = bb.emit(lv2 * lv3)
+            lv5 = bb.emit(checkpoint(func, lv4))
+            lv6 = bb.emit(lv4 * lv5)
+            gv = bb.emit_output(relax.op.sum(lv6))
+        bb.emit_func_output(gv)
+
+    # fmt: off
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                lv = R.grad.start_checkpoint(x)
+                lv1 = R.multiply(lv, R.const(2, "float32"))
+                lv2 = R.multiply(lv1, R.const(2, "float32"))
+                lv3 = R.grad.end_checkpoint(lv2)
+                lv4 = R.multiply(x, lv3)
+                lv5 = R.grad.start_checkpoint(lv4)
+                lv6 = R.multiply(lv5, R.const(2, "float32"))
+                lv7 = R.multiply(lv6, R.const(2, "float32"))
+                lv8 = R.grad.end_checkpoint(lv7)
+                lv9 = R.multiply(lv4, lv8)
+                lv10 = R.grad.start_checkpoint(lv9)
+                lv11 = R.multiply(lv10, R.const(2, "float32"))
+                lv12 = R.multiply(lv11, R.const(2, "float32"))
+                lv13 = R.grad.end_checkpoint(lv12)
+                lv14 = R.multiply(lv9, lv13)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv14, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    assert_structural_equal(bb.get(), Expected)
+
+
+def test_checkpoint_sequential():
+    def func(x):
+        return x + x
+
+    bb = BlockBuilder()
+    x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
+    with bb.function("main", [x]):
+        with bb.dataflow():
+            lv1 = emit_checkpoint_sequential([func] * 5, 2, x)
+            lv2 = emit_checkpoint_sequential([func] * 4, 2, lv1)
+            gv = bb.emit_output(lv2)
+        bb.emit_func_output(gv)
+
+    # fmt: off
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((3, 3), dtype="float32"):
+            with R.dataflow():
+                x_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(x)
+                lv: R.Tensor((3, 3), dtype="float32") = R.add(x_scp, x_scp)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(lv, lv)
+                lv1_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv1)
+                lv1_ecp_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv1_ecp)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1_ecp_scp, lv1_ecp_scp)
+                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, lv2)
+                lv3_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv3)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv3_ecp, lv3_ecp)
+                lv4_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv4)
+                lv5: R.Tensor((3, 3), dtype="float32") = R.add(lv4_scp, lv4_scp)
+                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv5, lv5)
+                lv6_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv6)
+                lv7: R.Tensor((3, 3), dtype="float32") = R.add(lv6_ecp, lv6_ecp)
+                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv7, lv7)
+                gv: R.Tensor((3, 3), dtype="float32") = lv8
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    assert_structural_equal(bb.get(), Expected)
+
+
+def test_checkpoint_sequential_checkpoint_last():
+    def func(x):
+        return x + x
+
+    bb = BlockBuilder()
+    x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
+    with bb.function("main", [x]):
+        with bb.dataflow():
+            lv1 = emit_checkpoint_sequential([func] * 5, 2, x, checkpoint_last=True)
+            lv2 = emit_checkpoint_sequential([func] * 4, 2, lv1, checkpoint_last=True)
+            gv = bb.emit_output(lv2)
+        bb.emit_func_output(gv)
+
+    # fmt: off
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((3, 3), dtype="float32"):
+            with R.dataflow():
+                x_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(x)
+                lv: R.Tensor((3, 3), dtype="float32") = R.add(x_scp, x_scp)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(lv, lv)
+                lv1_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv1)
+                lv1_ecp_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv1_ecp)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1_ecp_scp, lv1_ecp_scp)
+                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, lv2)
+                lv3_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv3)
+                lv3_ecp_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv3_ecp)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv3_ecp_scp, lv3_ecp_scp)
+                lv4_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv4)
+                lv4_ecp_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv4_ecp)
+                lv5: R.Tensor((3, 3), dtype="float32") = R.add(lv4_ecp_scp, lv4_ecp_scp)
+                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv5, lv5)
+                lv6_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv6)
+                lv6_ecp_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv6_ecp)
+                lv7: R.Tensor((3, 3), dtype="float32") = R.add(lv6_ecp_scp, lv6_ecp_scp)
+                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv7, lv7)
+                lv8_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv8)
+                gv: R.Tensor((3, 3), dtype="float32") = lv8_ecp
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    assert_structural_equal(bb.get(), Expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_transform_gradient_te_register.py
+++ b/tests/python/relax/test_transform_gradient_te_register.py
@@ -14,12 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Unit tests for relax training utils."""
+"""Unit tests for registering tir gradient functions in the gradient pass."""
 import pytest
 
 import tvm
 import tvm.testing
-from tvm import relax
+from tvm import relax, tir
 from tvm.ir.base import assert_structural_equal
 from tvm.script.parser import relax as R, tir as T, ir as I
 
@@ -91,21 +91,23 @@ def get_expected_1():
         def main_adjoint(a: R.Tensor((5, 5), dtype="float32"), b: R.Tensor((5, 5), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((5, 5), dtype="float32"), R.Tensor((5, 5), dtype="float32"))):
             cls = Expected
             with R.dataflow():
-                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mul_grad")
+                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"))
                 gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
                 gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
                 lv_adjoint: R.Tensor((5, 5), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([5, 5]))
                 lv_1 = R.call_tir(cls.f_mul_grad, (lv_adjoint, a, b), out_sinfo=[R.Tensor((5, 5), dtype="float32"), R.Tensor((5, 5), dtype="float32")])
                 a_adjoint: R.Tensor((5, 5), dtype="float32") = lv_1[0]
                 b_adjoint: R.Tensor((5, 5), dtype="float32") = lv_1[1]
-                R.output(gv, a_adjoint, b_adjoint)
-            return (gv, (a_adjoint, b_adjoint))
+                a_adjoint_out: R.Tensor((5, 5), dtype="float32") = a_adjoint
+                b_adjoint_out: R.Tensor((5, 5), dtype="float32") = b_adjoint
+                R.output(gv, a_adjoint_out, b_adjoint_out)
+            return (gv, (a_adjoint_out, b_adjoint_out))
 
         @R.function
         def main(a: R.Tensor((5, 5), dtype="float32"), b: R.Tensor((5, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
             cls = Expected
             with R.dataflow():
-                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mul_grad")
+                lv = R.call_tir_with_grad(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mul_grad")
                 gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
                 R.output(gv)
             return gv
@@ -113,7 +115,6 @@ def get_expected_1():
     return Expected
 
 
-@pytest.mark.skip("gradient will be refactored in later pull requests")
 def test_emit_te(register_te_grads):
     # Build the target module using emit_te
     def f_mul(src1, src2):
@@ -128,7 +129,11 @@ def test_emit_te(register_te_grads):
     bb = relax.BlockBuilder()
     with bb.function("main", [a, b]):
         with bb.dataflow():
-            d = bb.emit_te(f_mul, a, b, primfunc_name_hint="f_mul", te_grad_name="f_mul_grad")
+            d = bb.emit(
+                bb.call_te_with_grad(
+                    f_mul, a, b, primfunc_name_hint="f_mul", te_grad_name="f_mul_grad"
+                )
+            )
             out = bb.emit_output(R.sum(d))
         bb.emit_func_output(out)
 
@@ -137,7 +142,6 @@ def test_emit_te(register_te_grads):
     assert_structural_equal(After, get_expected_1())
 
 
-@pytest.mark.skip("gradient will be refactored in later pull requests")
 def test_call_tir(register_te_grads):
     # fmt: off
     @I.ir_module
@@ -157,7 +161,7 @@ def test_call_tir(register_te_grads):
         def main(a: R.Tensor((5, 5), dtype="float32"), b: R.Tensor((5, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
             cls = Before
             with R.dataflow():
-                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mul_grad")
+                lv = R.call_tir_with_grad(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mul_grad")
                 gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
                 R.output(gv)
             return gv
@@ -197,20 +201,21 @@ def get_expected_2():
         def main_adjoint(a: R.Tensor((5, 5), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((5, 5), dtype="float32"))):
             cls = Expected
             with R.dataflow():
-                lv = R.call_tir(cls.f_mul, (a,), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mulk_grad", te_grad_kwargs={"k": T.float32(2)})
+                lv = R.call_tir(cls.f_mul, (a,), out_sinfo=R.Tensor((5, 5), dtype="float32"))
                 gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
                 gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
                 lv_adjoint: R.Tensor((5, 5), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([5, 5]))
                 lv_1 = R.call_tir(cls.f_mulk_grad, (lv_adjoint, a), out_sinfo=R.Tensor((5, 5), dtype="float32"))
                 a_adjoint: R.Tensor((5, 5), dtype="float32") = lv_1
-                R.output(gv, a_adjoint)
-            return (gv, (a_adjoint,))
+                a_adjoint_out: R.Tensor((5, 5), dtype="float32") = a_adjoint
+                R.output(gv, a_adjoint_out)
+            return (gv, (a_adjoint_out,))
 
         @R.function
         def main(a: R.Tensor((5, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
             cls = Expected
             with R.dataflow():
-                lv = R.call_tir(cls.f_mul, (a,), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mulk_grad", te_grad_kwargs={"k": T.float32(2)})
+                lv = R.call_tir_with_grad(cls.f_mul, (a,), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mulk_grad", te_grad_kwargs={"k": T.float32(2)})
                 gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
                 R.output(gv)
             return gv
@@ -218,7 +223,6 @@ def get_expected_2():
     return Expected
 
 
-@pytest.mark.skip("gradient will be refactored in later pull requests")
 def test_emit_te_kwargs(register_te_grads):
     # Build the target module using emit_te
     def f_mul2(src):
@@ -229,24 +233,24 @@ def test_emit_te_kwargs(register_te_grads):
     bb = relax.BlockBuilder()
     with bb.function("main", [a]):
         with bb.dataflow():
-            d = bb.emit_te(
-                f_mul2,
-                a,
-                primfunc_name_hint="f_mul",
-                te_grad_name="f_mulk_grad",
-                te_grad_kwargs={"k": T.float32(2)},
+            d = bb.emit(
+                bb.call_te_with_grad(
+                    f_mul2,
+                    a,
+                    primfunc_name_hint="f_mul",
+                    te_grad_name="f_mulk_grad",
+                    te_grad_kwargs={"k": T.float32(2)},
+                )
             )
             out = bb.emit_output(R.sum(d))
         bb.emit_func_output(out)
 
     Before = bb.get()
     After = Gradient("main")(Before)
-    After.show(None, False)
 
     assert_structural_equal(After, get_expected_2())
 
 
-@pytest.mark.skip("gradient will be refactored in later pull requests")
 def test_call_tir_kwargs(register_te_grads):
     # fmt: off
     @I.ir_module
@@ -266,7 +270,7 @@ def test_call_tir_kwargs(register_te_grads):
         def main(a: R.Tensor((5, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
             cls = Before
             with R.dataflow():
-                lv = R.call_tir(cls.f_mul, (a,), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mulk_grad", te_grad_kwargs={"k": T.float32(2)})
+                lv = R.call_tir_with_grad(cls.f_mul, (a,), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mulk_grad", te_grad_kwargs={"k": T.float32(2)})
                 gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
                 R.output(gv)
             return gv
@@ -274,6 +278,106 @@ def test_call_tir_kwargs(register_te_grads):
 
     After = Gradient("main")(Before)
     assert_structural_equal(After, get_expected_2())
+
+
+def get_expected_3():
+    # fmt: off
+    @I.ir_module
+    class Expected:
+        @T.prim_func
+        def f_mul(var_A: T.handle, var_B: T.handle, var_f_mul: T.handle):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            n = T.int64()
+            A = T.match_buffer(var_A, (n, n))
+            B = T.match_buffer(var_B, (n, n))
+            f_mul_1 = T.match_buffer(var_f_mul, (n, n))
+            # with T.block("root"):
+            for i0, i1 in T.grid(n, n):
+                with T.block("f_mul"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(A[v_i0, v_i1], B[v_i0, v_i1])
+                    T.writes(f_mul_1[v_i0, v_i1])
+                    f_mul_1[v_i0, v_i1] = A[v_i0, v_i1] * B[v_i0, v_i1]
+
+        @T.prim_func
+        def f_mul_grad(var_A: T.handle, var_B: T.handle, var_C: T.handle, var_f_mul_grad_1: T.handle, var_f_mul_grad_2: T.handle):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            n = T.int64()
+            A = T.match_buffer(var_A, (n, n))
+            B = T.match_buffer(var_B, (n, n))
+            C = T.match_buffer(var_C, (n, n))
+            f_mul_grad_1 = T.match_buffer(var_f_mul_grad_1, (n, n))
+            f_mul_grad_2 = T.match_buffer(var_f_mul_grad_2, (n, n))
+            # with T.block("root"):
+            for i0, i1 in T.grid(n, n):
+                with T.block("f_mul_grad_1"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(C[v_i0, v_i1], A[v_i0, v_i1])
+                    T.writes(f_mul_grad_1[v_i0, v_i1])
+                    f_mul_grad_1[v_i0, v_i1] = C[v_i0, v_i1] * A[v_i0, v_i1]
+            for i0, i1 in T.grid(n, n):
+                with T.block("f_mul_grad_2"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(B[v_i0, v_i1], A[v_i0, v_i1])
+                    T.writes(f_mul_grad_2[v_i0, v_i1])
+                    f_mul_grad_2[v_i0, v_i1] = B[v_i0, v_i1] * A[v_i0, v_i1]
+
+        @R.function
+        def main_adjoint(a: R.Tensor(("n", "n"), dtype="float32"), b: R.Tensor(("n", "n"), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor(("n", "n"), dtype="float32"), R.Tensor(("n", "n"), dtype="float32"))):
+            n = T.int64()
+            cls = Expected
+            with R.dataflow():
+                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((n, n), dtype="float32"))
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv_adjoint: R.Tensor((n, n), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([n, n]))
+                lv_1 = R.call_tir(cls.f_mul_grad, (lv_adjoint, a, b), out_sinfo=[R.Tensor((n, n), dtype="float32"), R.Tensor((n, n), dtype="float32")])
+                a_adjoint: R.Tensor((n, n), dtype="float32") = lv_1[0]
+                b_adjoint: R.Tensor((n, n), dtype="float32") = lv_1[1]
+                a_adjoint_out: R.Tensor((n, n), dtype="float32") = a_adjoint
+                b_adjoint_out: R.Tensor((n, n), dtype="float32") = b_adjoint
+                R.output(gv, a_adjoint_out, b_adjoint_out)
+            return (gv, (a_adjoint_out, b_adjoint_out))
+
+        @R.function
+        def main(a: R.Tensor(("n", "n"), dtype="float32"), b: R.Tensor(("n", "n"), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            n = T.int64()
+            cls = Expected
+            with R.dataflow():
+                lv = R.call_tir_with_grad(cls.f_mul, (a, b), out_sinfo=R.Tensor((n, n), dtype="float32"), te_grad_name="f_mul_grad")
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+    return Expected
+
+
+def test_tir_var(register_te_grads):
+    def f_mul(src1, src2):
+        def mul(*idx):
+            return src1[idx] * src2[idx]
+
+        return tvm.te.compute(src1.shape, mul, name="f_mul")
+
+    n = tir.Var("n", "int64")
+    a = relax.Var("a", relax.TensorStructInfo([n, n], "float32"))
+    b = relax.Var("b", relax.TensorStructInfo([n, n], "float32"))
+
+    bb = relax.BlockBuilder()
+    with bb.function("main", [a, b]):
+        with bb.dataflow():
+            d = bb.emit(
+                bb.call_te_with_grad(
+                    f_mul, a, b, primfunc_name_hint="f_mul", te_grad_name="f_mul_grad"
+                )
+            )
+            out = bb.emit_output(R.sum(d))
+        bb.emit_func_output(out)
+
+    Before = bb.get()
+    After = Gradient("main")(Before)
+    assert_structural_equal(After, get_expected_3())
+    assert relax.analysis.well_formed(After)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_transform_legalize_ops_nn.py
+++ b/tests/python/relax/test_transform_legalize_ops_nn.py
@@ -2742,6 +2742,266 @@ def test_group_norm_symbolic():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_rms_norm():
+    # fmt: off
+    @tvm.script.ir_module
+    class RMSNorm:
+        @R.function
+        def main(x: R.Tensor((2, 3, 4, 5), "float32"), weight: R.Tensor((4, 5), "float32")) -> R.Tensor((2, 3, 4, 5), "float32"):
+            gv: R.Tensor((2, 3, 4, 5), "float32") = R.nn.rms_norm(x, weight, axes=[-2, -1])
+            return gv
+
+    @tvm.script.ir_module
+    class Expected:
+        @T.prim_func
+        def rms_norm(
+            A: T.Buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)), "float32"),
+            B: T.Buffer((T.int64(4), T.int64(5)), "float32"),
+            T_rms_norm: T.Buffer(
+                (T.int64(2), T.int64(3), T.int64(4), T.int64(5)), "float32"
+            ),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            T_multiply = T.alloc_buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)))
+            T_multiply_red = T.alloc_buffer((T.int64(2), T.int64(3)))
+            for ax0, ax1, ax2, ax3 in T.grid(
+                T.int64(2), T.int64(3), T.int64(4), T.int64(5)
+            ):
+                with T.block("T_multiply"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(A[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_multiply[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = (
+                        A[v_ax0, v_ax1, v_ax2, v_ax3] * A[v_ax0, v_ax1, v_ax2, v_ax3]
+                    )
+            for ax0, ax1, k2, k3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
+                with T.block("T_multiply_red"):
+                    v_ax0, v_ax1, v_k2, v_k3 = T.axis.remap("SSRR", [ax0, ax1, k2, k3])
+                    T.reads(T_multiply[v_ax0, v_ax1, v_k2, v_k3])
+                    T.writes(T_multiply_red[v_ax0, v_ax1])
+                    with T.init():
+                        T_multiply_red[v_ax0, v_ax1] = T.float32(0)
+                    T_multiply_red[v_ax0, v_ax1] = (
+                        T_multiply_red[v_ax0, v_ax1] + T_multiply[v_ax0, v_ax1, v_k2, v_k3]
+                    )
+            for ax0, ax1, ax2, ax3 in T.grid(
+                T.int64(2), T.int64(3), T.int64(4), T.int64(5)
+            ):
+                with T.block("T_rms_norm"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(
+                        A[v_ax0, v_ax1, v_ax2, v_ax3],
+                        B[v_ax2, v_ax3],
+                        T_multiply_red[v_ax0, v_ax1],
+                    )
+                    T.writes(T_rms_norm[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_rms_norm[v_ax0, v_ax1, v_ax2, v_ax3] = (
+                        A[v_ax0, v_ax1, v_ax2, v_ax3]
+                        * B[v_ax2, v_ax3]
+                        * T.rsqrt(
+                            T_multiply_red[v_ax0, v_ax1] * T.float32(0.05)
+                            + T.float32(1e-05)
+                        )
+                    )
+
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 4, 5), dtype="float32"),
+            weight: R.Tensor((4, 5), dtype="float32"),
+        ) -> R.Tensor((2, 3, 4, 5), dtype="float32"):
+            cls = Expected
+            gv = R.call_tir(
+                cls.rms_norm, (x, weight), out_sinfo=R.Tensor((2, 3, 4, 5), dtype="float32")
+            )
+            return gv
+    # fmt: on
+    mod = LegalizeOps()(RMSNorm)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_rms_norm_fp16():
+    # fmt: off
+    @tvm.script.ir_module
+    class RMSNorm:
+        @R.function
+        def main(x: R.Tensor((2, 3, 4, 5), "float16"), weight: R.Tensor((4, 5), "float16")) -> R.Tensor((2, 3, 4, 5), "float16"):
+            gv: R.Tensor((2, 3, 4, 5), "float16") = R.nn.rms_norm(x, weight, axes=[-2, -1])
+            return gv
+
+    @tvm.script.ir_module
+    class Expected:
+        @T.prim_func
+        def rms_norm(
+            A: T.Buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)), "float16"),
+            B: T.Buffer((T.int64(4), T.int64(5)), "float16"),
+            T_cast: T.Buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)), "float16"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            T_cast_1 = T.alloc_buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)))
+            T_cast_2 = T.alloc_buffer((T.int64(4), T.int64(5)))
+            T_multiply = T.alloc_buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)))
+            T_multiply_red = T.alloc_buffer((T.int64(2), T.int64(3)))
+            T_rms_norm = T.alloc_buffer((T.int64(2), T.int64(3), T.int64(4), T.int64(5)))
+            for ax0, ax1, ax2, ax3 in T.grid(
+                T.int64(2), T.int64(3), T.int64(4), T.int64(5)
+            ):
+                with T.block("T_cast"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(A[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_cast_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_cast_1[v_ax0, v_ax1, v_ax2, v_ax3] = T.Cast(
+                        "float32", A[v_ax0, v_ax1, v_ax2, v_ax3]
+                    )
+            for ax0, ax1 in T.grid(T.int64(4), T.int64(5)):
+                with T.block("T_cast_1"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(B[v_ax0, v_ax1])
+                    T.writes(T_cast_2[v_ax0, v_ax1])
+                    T_cast_2[v_ax0, v_ax1] = T.Cast("float32", B[v_ax0, v_ax1])
+            for ax0, ax1, ax2, ax3 in T.grid(
+                T.int64(2), T.int64(3), T.int64(4), T.int64(5)
+            ):
+                with T.block("T_multiply"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(T_cast_1[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_multiply[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_multiply[v_ax0, v_ax1, v_ax2, v_ax3] = (
+                        T_cast_1[v_ax0, v_ax1, v_ax2, v_ax3]
+                        * T_cast_1[v_ax0, v_ax1, v_ax2, v_ax3]
+                    )
+            for ax0, ax1, k2, k3 in T.grid(T.int64(2), T.int64(3), T.int64(4), T.int64(5)):
+                with T.block("T_multiply_red"):
+                    v_ax0, v_ax1, v_k2, v_k3 = T.axis.remap("SSRR", [ax0, ax1, k2, k3])
+                    T.reads(T_multiply[v_ax0, v_ax1, v_k2, v_k3])
+                    T.writes(T_multiply_red[v_ax0, v_ax1])
+                    with T.init():
+                        T_multiply_red[v_ax0, v_ax1] = T.float32(0)
+                    T_multiply_red[v_ax0, v_ax1] = (
+                        T_multiply_red[v_ax0, v_ax1] + T_multiply[v_ax0, v_ax1, v_k2, v_k3]
+                    )
+            for ax0, ax1, ax2, ax3 in T.grid(
+                T.int64(2), T.int64(3), T.int64(4), T.int64(5)
+            ):
+                with T.block("T_rms_norm"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(
+                        T_cast_1[v_ax0, v_ax1, v_ax2, v_ax3],
+                        T_cast_2[v_ax2, v_ax3],
+                        T_multiply_red[v_ax0, v_ax1],
+                    )
+                    T.writes(T_rms_norm[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_rms_norm[v_ax0, v_ax1, v_ax2, v_ax3] = (
+                        T_cast_1[v_ax0, v_ax1, v_ax2, v_ax3]
+                        * T_cast_2[v_ax2, v_ax3]
+                        * T.rsqrt(
+                            T_multiply_red[v_ax0, v_ax1]
+                            / T.Cast("float32", T.float16(4) * T.float16(5))
+                            + T.float32(1e-05)
+                        )
+                    )
+            for ax0, ax1, ax2, ax3 in T.grid(
+                T.int64(2), T.int64(3), T.int64(4), T.int64(5)
+            ):
+                with T.block("T_cast_2"):
+                    v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(T_rms_norm[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T.writes(T_cast[v_ax0, v_ax1, v_ax2, v_ax3])
+                    T_cast[v_ax0, v_ax1, v_ax2, v_ax3] = T.Cast(
+                        "float16", T_rms_norm[v_ax0, v_ax1, v_ax2, v_ax3]
+                    )
+
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 4, 5), dtype="float16"),
+            weight: R.Tensor((4, 5), dtype="float16"),
+        ) -> R.Tensor((2, 3, 4, 5), dtype="float16"):
+            cls = Expected
+            gv = R.call_tir(
+                cls.rms_norm, (x, weight), out_sinfo=R.Tensor((2, 3, 4, 5), dtype="float16")
+            )
+            return gv
+    # fmt: on
+    mod = LegalizeOps()(RMSNorm)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_rms_norm_symbolic():
+    # fmt: off
+    @tvm.script.ir_module
+    class RMSNorm:
+        @R.function
+        def main(x: R.Tensor(("n", "s", "f"), "float32"), weight: R.Tensor(("s", "f"), "float32")) -> R.Tensor(("n", "s", "f"), "float32"):
+            n = T.int64()
+            s = T.int64()
+            f = T.int64()
+            gv: R.Tensor((n, s, f), "float32") = R.nn.rms_norm(x, weight, axes=[1, 2])
+            return gv
+
+    @tvm.script.ir_module
+    class Expected:
+        @T.prim_func
+        def rms_norm(var_A: T.handle, var_B: T.handle, var_T_rms_norm: T.handle):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            n, s, f = T.int64(), T.int64(), T.int64()
+            A = T.match_buffer(var_A, (n, s, f))
+            B = T.match_buffer(var_B, (s, f))
+            T_rms_norm = T.match_buffer(var_T_rms_norm, (n, s, f))
+            # with T.block("root"):
+            T_multiply = T.alloc_buffer((n, s, f))
+            T_multiply_red = T.alloc_buffer((n,))
+            for ax0, ax1, ax2 in T.grid(n, s, f):
+                with T.block("T_multiply"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(A[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_multiply[v_ax0, v_ax1, v_ax2])
+                    T_multiply[v_ax0, v_ax1, v_ax2] = (
+                        A[v_ax0, v_ax1, v_ax2] * A[v_ax0, v_ax1, v_ax2]
+                    )
+            for ax0, k1, k2 in T.grid(n, s, f):
+                with T.block("T_multiply_red"):
+                    v_ax0, v_k1, v_k2 = T.axis.remap("SRR", [ax0, k1, k2])
+                    T.reads(T_multiply[v_ax0, v_k1, v_k2])
+                    T.writes(T_multiply_red[v_ax0])
+                    with T.init():
+                        T_multiply_red[v_ax0] = T.float32(0)
+                    T_multiply_red[v_ax0] = (
+                        T_multiply_red[v_ax0] + T_multiply[v_ax0, v_k1, v_k2]
+                    )
+            for ax0, ax1, ax2 in T.grid(n, s, f):
+                with T.block("T_rms_norm"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(A[v_ax0, v_ax1, v_ax2], B[v_ax1, v_ax2], T_multiply_red[v_ax0])
+                    T.writes(T_rms_norm[v_ax0, v_ax1, v_ax2])
+                    T_rms_norm[v_ax0, v_ax1, v_ax2] = (
+                        A[v_ax0, v_ax1, v_ax2]
+                        * B[v_ax1, v_ax2]
+                        * T.rsqrt(
+                            T_multiply_red[v_ax0]
+                            / (T.Cast("float32", s) * T.Cast("float32", f))
+                            + T.float32(1e-05)
+                        )
+                    )
+
+        @R.function
+        def main(
+            x: R.Tensor(("n", "s", "f"), dtype="float32"),
+            weight: R.Tensor(("s", "f"), dtype="float32"),
+        ) -> R.Tensor(("n", "s", "f"), dtype="float32"):
+            n = T.int64()
+            s = T.int64()
+            f = T.int64()
+            cls = Expected
+            gv = R.call_tir(
+                cls.rms_norm, (x, weight), out_sinfo=R.Tensor((n, s, f), dtype="float32")
+            )
+            return gv
+    # fmt: on
+    mod = LegalizeOps()(RMSNorm)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
 def test_attention():
     # fmt: off
     @tvm.script.ir_module

--- a/tests/python/topi/python/test_topi_rms_norm.py
+++ b/tests/python/topi/python/test_topi_rms_norm.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test code for rms_norm."""
+import numpy as np
+import pytest
+import tvm
+from tvm import te
+from tvm import topi
+from tvm.topi.utils import get_const_tuple
+import tvm.topi.testing
+
+import tvm.testing
+
+
+_rms_norm_schedule = {
+    "generic": topi.generic.schedule_injective,
+}
+
+
+# only test on llvm because schedule is missing
+@tvm.testing.parametrize_targets("llvm")
+@pytest.mark.parametrize("shape,axis", [([4, 16], (1,)), ([4, 16, 16], (1, 2))])
+@pytest.mark.parametrize("dtype", ["float32", "float16"])
+def test_rms_norm(target, dev, shape, axis, dtype, episilon=1e-5, rtol=5e-4, atol=5e-4):
+    data = te.placeholder(shape, dtype=dtype, name="data")
+    scale_shape = [shape[dim] for dim in axis]
+    weight = te.placeholder(scale_shape, dtype=dtype, name="weight")
+    B = topi.nn.rms_norm(data, weight, axis, episilon)
+
+    data_np = np.random.uniform(size=shape).astype(dtype)
+    weight_np = np.random.uniform(size=scale_shape).astype(dtype)
+    b_np = tvm.topi.testing.rms_norm_python(data_np, weight_np, axis, episilon)
+
+    with tvm.target.Target(target):
+        s_func = tvm.topi.testing.dispatch(target, _rms_norm_schedule)
+        s = s_func([B])
+    data_tvm = tvm.nd.array(data_np, dev)
+    weight_tvm = tvm.nd.array(weight_np, dev)
+    b_tvm = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=dtype), dev)
+    f = tvm.build(s, [data, weight, B], target)
+    f(data_tvm, weight_tvm, b_tvm)
+    tvm.testing.assert_allclose(b_tvm.numpy(), b_np, rtol=rtol, atol=atol)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR introduces an utility pass that binds symbolic variables to user-provided integer values.
For example, say we have a following IRModule. 
```Python
@tvm.script.ir_module
class Before:
  @R.function
  def main(
    x: R.Tensor(("m", "n")),
    y: R.Tensor(("m", "n"))
   ) -> R.Tensor(("m", "n")):
      m = T.Var("m", "int64")
      n = T.Var("m", "int64")
      with R.dataflow():
        out = R.matmul(x, y)
        R.output(out)
      return out
```
We can conveniently bind the symbolic variable by applying `After = relax.transform.BindSymVars("main", {"m": 10, "n": 10})(Before)`.
```Python
@tvm.script.ir_module
class After:
  @R.function
  def main(
    x: R.Tensor((10, 10)),
    y: R.Tensor((10, 10))
   ) -> R.Tensor((10, 10)):
      with R.dataflow():
        out = R.matmul(x, y)
        R.output(out)
      return out
```

This would be useful when specializing shape and providing compile-time shape info (e.g., model params or batch sizes) by eliminating the need to rewrite the model. 
cc. @tqchen @psrivas2 