### PR TITLE
[Unity] Add a Standalone VM Version Number

### DIFF
--- a/include/tvm/runtime/relax_vm/executable.h
+++ b/include/tvm/runtime/relax_vm/executable.h
@@ -33,6 +33,12 @@
 
 #include "./bytecode.h"
 
+// Convention: this version should set to minimum TVM version it support
+// NOTE: this file only changes if we change relax vm format
+// for example if relax vm format do not change in 0.15, this should remain as 0.14
+// if it changes in 0.16, we will change it to 0.16
+#define RELAX_VM_VERSION "0.14"
+
 namespace tvm {
 namespace runtime {
 namespace relax_vm {

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -183,7 +183,7 @@ Instruction Executable::GetInstruction(Index i) const {
 void SaveHeader(dmlc::Stream* strm) {
   uint64_t header = kTVMVMBytecodeMagic;
   strm->Write(header);
-  std::string version = TVM_VERSION;
+  std::string version = RELAX_VM_VERSION;
   strm->Write(version);
 }
 
@@ -196,7 +196,7 @@ void LoadHeader(dmlc::Stream* strm) {
   // Check version.
   std::string version;
   STREAM_CHECK(strm->Read(&version), "version");
-  STREAM_CHECK(version == TVM_VERSION, "version");
+  STREAM_CHECK(version == RELAX_VM_VERSION, "version");
 }
 
 void Executable::SaveToBinary(dmlc::Stream* stream) {


### PR DESCRIPTION
This PR introduces a new field, `RELAX_VM_VERSION`, to the `Executable` struct. The VM version is more stable than the TVM version, it would be the minimum TVM version it support the current VM status.

cc @tqchen 