### PR TITLE
[TIR] Implement TIR macros

### DIFF
--- a/python/tvm/script/parser/_core.py
+++ b/python/tvm/script/parser/_core.py
@@ -18,5 +18,5 @@
 # pylint: disable=unused-import
 from .core import dispatch, doc, utils
 from .core.dispatch import OpMethod, register_op
-from .core.entry import parse
+from .core.entry import parse, parse_macro
 from .core.parser import Parser

--- a/python/tvm/script/parser/core/entry.py
+++ b/python/tvm/script/parser/core/entry.py
@@ -25,6 +25,14 @@ from .error import ParserError
 from .parser import Parser
 
 
+def parse_macro(program: Union[Any, str]) -> Any:
+    """Generate the AST, and the source code for __repr__."""
+    # The AST will be converted into TIR at the time of insertion.
+    source = Source(program)
+    node = source.as_ast()
+    return node, source.source
+
+
 def parse(program: Union[doc.AST, Any, str], extra_vars: Dict[str, Any] = None) -> Any:
     """Register a method for a operand type, AST operator node and operand index.
 

--- a/python/tvm/script/parser/core/entry.py
+++ b/python/tvm/script/parser/core/entry.py
@@ -36,7 +36,7 @@ def _default_globals() -> Dict[str, Any]:
 
 def parse_macro(program: Union[Any, str], extra_vars: Dict[str, Any] = None) -> Any:
     """Generate the AST, and the source code for __repr__."""
-    # The AST will be converted into TIR at the time of insertion.
+    # The AST will be converted into TIR at the time of expansion.
     source = Source(program)
     source_txt = source.source
     source_ast = source.as_ast()

--- a/python/tvm/script/parser/core/entry.py
+++ b/python/tvm/script/parser/core/entry.py
@@ -25,12 +25,23 @@ from .error import ParserError
 from .parser import Parser
 
 
-def parse_macro(program: Union[Any, str]) -> Any:
+def _default_globals() -> Dict[str, Any]:
+    import tvm  # pylint: disable=import-outside-toplevel
+    from tvm.script.parser import ir  # pylint: disable=import-outside-toplevel
+    from tvm.script.parser import tir  # pylint: disable=import-outside-toplevel
+
+    extra_vars = {"tvm": tvm, "I": ir, "ir": ir, "T": tir, "tir": tir}
+    return extra_vars
+
+
+def parse_macro(program: Union[Any, str], extra_vars: Dict[str, Any] = None) -> Any:
     """Generate the AST, and the source code for __repr__."""
     # The AST will be converted into TIR at the time of insertion.
     source = Source(program)
-    node = source.as_ast()
-    return node, source.source
+    source_txt = source.source
+    source_ast = source.as_ast()
+    closure_vars = extra_vars or _default_globals()
+    return source_ast, source_txt, closure_vars
 
 
 def parse(program: Union[doc.AST, Any, str], extra_vars: Dict[str, Any] = None) -> Any:
@@ -50,17 +61,7 @@ def parse(program: Union[doc.AST, Any, str], extra_vars: Dict[str, Any] = None) 
         The parsed TVMScript program.
     """
     if extra_vars is None:
-        import tvm  # pylint: disable=import-outside-toplevel
-        from tvm.script.parser import ir  # pylint: disable=import-outside-toplevel
-        from tvm.script.parser import tir  # pylint: disable=import-outside-toplevel
-
-        extra_vars = {
-            "tvm": tvm,
-            "I": ir,
-            "ir": ir,
-            "T": tir,
-            "tir": tir,
-        }
+        extra_vars = _default_globals()
 
     ann = {}
     if inspect.isfunction(program):

--- a/python/tvm/script/parser/tir/__init__.py
+++ b/python/tvm/script/parser/tir/__init__.py
@@ -30,6 +30,6 @@ if TYPE_CHECKING:
     # so most tvmscript won't trigger pylint error here.
     prim_func = staticmethod
 else:
-    from .entry import prim_func, macro, insert
+    from .entry import prim_func, macro
 
-__all__ = _tir.__all__ + ["Buffer", "Ptr", "prim_func", "macro", "insert"]
+__all__ = _tir.__all__ + ["Buffer", "Ptr", "prim_func", "macro"]

--- a/python/tvm/script/parser/tir/__init__.py
+++ b/python/tvm/script/parser/tir/__init__.py
@@ -30,6 +30,6 @@ if TYPE_CHECKING:
     # so most tvmscript won't trigger pylint error here.
     prim_func = staticmethod
 else:
-    from .entry import prim_func
+    from .entry import prim_func, macro, insert
 
-__all__ = _tir.__all__ + ["Buffer", "Ptr", "prim_func"]
+__all__ = _tir.__all__ + ["Buffer", "Ptr", "prim_func", "macro", "insert"]

--- a/python/tvm/script/parser/tir/entry.py
+++ b/python/tvm/script/parser/tir/entry.py
@@ -81,7 +81,7 @@ class TIRMacro:
         return self.source_txt
 
 
-def macro(*, hygienic: bool = True) -> Callable:
+def macro(*args, hygienic: bool = True) -> Callable:
     """Decorator for macro definitions.
 
     Parameters
@@ -132,7 +132,14 @@ def macro(*, hygienic: bool = True) -> Callable:
         # in that function's name space.
         return obj
 
-    return _decorator
+    if len(args) == 0:
+        return _decorator
+    if len(args) == 1 and inspect.isfunction(args[0]):
+        return _decorator(args[0])
+
+    raise ValueError(
+        "Invalid use of T.macro. Usage: @T.macro, @T.macro(), @T.macro(hygienic=[True|False])"
+    )
 
 
 # There is no dispatch_token for macro, because macro doesn't invoke parser.

--- a/python/tvm/script/parser/tir/entry.py
+++ b/python/tvm/script/parser/tir/entry.py
@@ -54,12 +54,10 @@ setattr(prim_func, "dispatch_token", "tir")
 # - Function that is decorated with @T.macro can have any parameters that
 #   follow Python syntax, i.e. positional, keyword, etc. Type annotations
 #   are not required, but are allowed.
-# - The arguments to `T.insert` are: macro name (either as value, or as
-#   a string with the name), followed by the argument list.
-#   For `T.insert(arg1, arg2, arg3, ...)`, the values are substituted into
-#   the body of the macro as in the call `arg1(arg2, arg3, ...)`.
-#   The body with the substituted values is then inserted at the point
-#   where the `T.insert` is located.
+# - Macro use follows the same syntax as a function call.
+#   For `macro_name(arg1, arg2, arg3, ...)`, the values are substituted into
+#   the body of the macro, and the body with the substituted values is then
+#   inserted at the point where the call to the macro is located.
 
 
 class TIRMacro:
@@ -75,7 +73,8 @@ class TIRMacro:
 
 def macro(func: Callable) -> doc.AST:
     obj = TIRMacro(*parse_macro(func))
-    setattr(obj, "__name__", func.__name__)
+    obj.__name__ = func.__name__
+    obj.func = func
     # We don't need to explicitly store the return value anywhere.
     # This function is a decorator, so the return value will replace
     # the function definition (to which the decorator it is applied)
@@ -84,12 +83,6 @@ def macro(func: Callable) -> doc.AST:
 
 
 # There is no dispatch_token for macro, because macro doesn't invoke parser.
-
-
-def insert(name: Union[str, doc.Name], *args, **kwargs) -> Any:  # pylint: disable=unused-argument
-    """Placeholder function, so that T.insert (i.e. macro insertion)
-    can be parsed without errors.
-    """
 
 
 class BufferProxy:

--- a/python/tvm/script/parser/tir/entry.py
+++ b/python/tvm/script/parser/tir/entry.py
@@ -87,7 +87,9 @@ def macro(func: Callable) -> doc.AST:
 
 
 def insert(name: Union[str, doc.Name], *args, **kwargs) -> Any:  # pylint: disable=unused-argument
-    """Placeholder function, so that T.insert (i.e. macro insertion) can be parsed without errors."""
+    """Placeholder function, so that T.insert (i.e. macro insertion)
+    can be parsed without errors.
+    """
 
 
 class BufferProxy:

--- a/python/tvm/script/parser/tir/entry.py
+++ b/python/tvm/script/parser/tir/entry.py
@@ -75,6 +75,7 @@ def macro(func: Callable) -> doc.AST:
     obj = TIRMacro(*parse_macro(func))
     obj.__name__ = func.__name__
     obj.func = func
+    obj.closure_vars = utils.inspect_function_capture(func)
     # We don't need to explicitly store the return value anywhere.
     # This function is a decorator, so the return value will replace
     # the function definition (to which the decorator it is applied)

--- a/python/tvm/script/parser/tir/entry.py
+++ b/python/tvm/script/parser/tir/entry.py
@@ -87,8 +87,7 @@ def macro(func: Callable) -> doc.AST:
 
 
 def insert(name: Union[str, doc.Name], *args, **kwargs) -> Any:  # pylint: disable=unused-argument
-    """Placeholder function, so that T.insert (i.e. macro insertion) can be parsed without errors.
-    """
+    """Placeholder function, so that T.insert (i.e. macro insertion) can be parsed without errors."""
 
 
 class BufferProxy:

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -547,7 +547,7 @@ def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> GlobalVar
 
 def process_insert_macro(self: Parser, call: doc.Call) -> None:
     """Bind arguments to T.insert to the parameters of the macro, and pass the macro body
-       for further parsing.
+    for further parsing.
     """
 
     def find_macro_def(name: str, decl_list: doc.AST) -> Union[doc.FunctionDef, Any]:
@@ -608,7 +608,7 @@ def process_insert_macro(self: Parser, call: doc.Call) -> None:
     module_ast = ast.fix_missing_locations(module_ast)
     cmacro = compile(module_ast, filename="<tmp-string>", mode="exec")
     local_vars = {}
-    exec(cmacro, self.var_table.get(), local_vars)  # pylint disable=exec-used
+    exec(cmacro, self.var_table.get(), local_vars)  # pylint: disable=exec-used
     local_vars = local_vars[tmp_name]
 
     with self.var_table.with_frame():

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -558,7 +558,7 @@ def expand_macro(self: Parser, callee: TIRMacro, call: doc.Call) -> None:
 
     if isinstance(macro.doc, doc.Module):
         macro_def = find_macro_def(macro_name, macro.doc.body)
-    elif not isinstance(macro.doc, doc.FunctionDef) or macro.doc.name != macro_name:
+    else:
         macro_def = None
 
     if macro_def is None:

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -16,9 +16,10 @@
 # under the License.
 """The base parser for tir"""
 
+import ast
 import contextlib
 from functools import partial
-from typing import Any
+from typing import Any, Union
 
 import tvm
 from tvm.ir import GlobalVar, PrimType
@@ -427,6 +428,20 @@ def visit_expr_stmt(self: Parser, node: doc.Expr) -> None:
     node : doc.Expr
         The doc AST Expr node.
     """
+
+    def is_insert_macro(node: doc.Call) -> bool:
+        if not isinstance(node.func, doc.Attribute):
+            return False
+        attr = node.func
+        if not isinstance(attr.value, doc.Name):
+            return False
+        if attr.value.id != "T" or attr.attr != "insert":
+            return False
+        return True
+
+    if isinstance(node.value, doc.Call) and is_insert_macro(node.value):
+        return process_insert_macro(self, node.value)
+
     res = self.eval_expr(node.value)
     if res is None:
         pass
@@ -528,3 +543,76 @@ def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> GlobalVar
     # Only ret_type is needed for func_signature.
     func_signature = tvm.tir.PrimFunc([], None, ret_type=ret_type)
     return I.decl_function(node.name, func_signature)
+
+
+def process_insert_macro(self: Parser, call: doc.Call) -> None:
+    """Bind arguments to T.insert to the parameters of the macro, and pass the macro body
+       for further parsing.
+    """
+
+    def find_macro_def(name: str, decl_list: doc.AST) -> Union[doc.FunctionDef, Any]:
+        for decl in decl_list:
+            if isinstance(decl, doc.FunctionDef) and decl.name == name:
+                return decl
+        return None
+
+    macro_name = call.args[0]
+
+    if not isinstance(macro_name, doc.Name):
+        self.report_error(call, "Invalid macro name in T.insert")
+    macro_name = macro_name.id
+
+    macro = self.var_table.get().get(macro_name)
+    if macro is None:
+        self.report_error(node, f"Undefined macro '{macro_name}'")
+
+    if isinstance(macro.doc, doc.Module):
+        macro_def = find_macro_def(macro_name, macro.doc.body)
+    elif not isinstance(macro.doc, doc.FunctionDef) or macro.doc.name != macro_name:
+        macro_def = None
+
+    if macro_def is None:
+        self.report_error(call, f"Undefined macro {macro_name}")
+
+    # `macro_def` is a FunctionDef of the macro.
+
+    # We have the AST for the macro definition, and the AST for the call. We need to
+    # substitute the actual arguments from the call for the parameters from the
+    # definition. To allow full flexibility of python, i.e. positional, unnamed, and
+    # keyword parameters, get the python interpreter to do the work: create and execute
+    # the following:
+    # ```
+    # def macro_name(...macro parameters...)
+    #     return locals()
+    # tmp = macro_name(...arguments from the call...)
+    # ```
+    # Obtain the dictionary `tmp` resulting from the execution, and update the var_table
+    # with it.
+
+    # Construct the function with the macro's parameters, and returning locals().
+    macro_ast = doc.from_doc(macro_def)
+    macro_ast.body = [
+        ast.Return(value=ast.Call(func=ast.Name("locals", ctx=ast.Load()), args=[], keywords=[]))
+    ]
+    macro_ast.decorator_list = []
+
+    # Construct the assignment with the call.
+    call_ast = doc.from_doc(call)
+    call_ast.func = ast.Name(macro_name, ctx=ast.Load())
+    call_ast.args = call_ast.args[1:]
+    tmp_name = "__tmp_param_eval_64e98b523301204b"
+    assign_ast = ast.Assign(targets=[ast.Name(tmp_name, ctx=ast.Store())], value=call_ast)
+
+    # Finalize and execute the module:
+    module_ast = ast.Module(body=[macro_ast, assign_ast], type_ignores=[])
+    module_ast = ast.fix_missing_locations(module_ast)
+    cmacro = compile(module_ast, filename="<tmp-string>", mode="exec")
+    local_vars = {}
+    exec(cmacro, self.var_table.get(), local_vars)  # pylint disable=exec-used
+    local_vars = local_vars[tmp_name]
+
+    with self.var_table.with_frame():
+        for k, v in local_vars.items():
+            self.var_table.add(k, v)
+
+        self.visit_body(macro_def.body)

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -16,7 +16,6 @@
 # under the License.
 """The base parser for tir"""
 
-import ast
 import contextlib
 import inspect
 from functools import partial
@@ -457,6 +456,7 @@ def visit_expr_stmt(self: Parser, node: doc.Expr) -> None:
         pass
     else:
         self.report_error(node, f"Parsing resulted in unexpected type {type(res)}")
+    return None  # For pylint
 
 
 @dispatch.register(token="tir", type_name="If")

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -544,27 +544,17 @@ def expand_macro(self: Parser, callee: TIRMacro, call: doc.Call) -> None:
     and pass the macro body for further parsing.
     """
 
+    assert isinstance(callee, TIRMacro), f"Unexpected macro type {type(callee)}"
+
     def find_macro_def(name: str, decl_list: doc.AST) -> Union[doc.FunctionDef, Any]:
         for decl in decl_list:
             if isinstance(decl, doc.FunctionDef) and decl.name == name:
                 return decl
         return None
 
-    macro_name = callee.__name__
-    macro = self.var_table.get().get(macro_name)
-
-    if macro is None:
-        self.report_error(node, f"Undefined macro '{macro_name}'")
-
-    if isinstance(macro.doc, doc.Module):
-        macro_def = find_macro_def(macro_name, macro.doc.body)
-    else:
-        macro_def = None
-
-    if macro_def is None:
-        self.report_error(call, f"Undefined macro {macro_name}")
-
-    # `macro_def` is a FunctionDef of the macro.
+    macro_def = find_macro_def(callee.__name__, callee.source_ast.body)
+    assert macro_def is not None, f"Invalid macro AST for {callee.__name__}"
+    # `macro_def` is the FunctionDef of the macro.
 
     args = [self.eval_expr(arg) for arg in call.args]
     kwargs = {kw.arg: self.eval_expr(kw.value) for kw in call.keywords}

--- a/tests/python/unittest/test_tvmscript_parser_tir.py
+++ b/tests/python/unittest/test_tvmscript_parser_tir.py
@@ -16,6 +16,7 @@
 # under the License.
 """Unittests for tvm.script.parser.tir"""
 
+import pytest
 import tvm.testing
 from tvm.script.parser import tir as T
 from tvm import ir, tir

--- a/tests/python/unittest/test_tvmscript_parser_tir.py
+++ b/tests/python/unittest/test_tvmscript_parser_tir.py
@@ -84,7 +84,7 @@ def test_tir_macro():
         C = T.match_buffer(c, [128, 128])
         for i, j, k in T.grid(128, 128, 128):
             with T.block("update"):
-                T.insert(assign, i, j, k, t1=A, t2=B, t3=C)
+                assign(i, j, k, t1=A, t2=B, t3=C)
 
     @T.prim_func
     def matmul_no_macro(a: T.handle, b: T.handle, c: T.handle) -> None:

--- a/tests/python/unittest/test_tvmscript_parser_tir.py
+++ b/tests/python/unittest/test_tvmscript_parser_tir.py
@@ -85,7 +85,7 @@ def test_tir_macro_decorator():
 
     assert func2.hygienic
 
-    with pytests.raises(ValueException) as exc:
+    with pytest.raises(ValueException) as exc:
 
         @T.macro(True)
         def func3(n):

--- a/tests/python/unittest/test_tvmscript_parser_tir.py
+++ b/tests/python/unittest/test_tvmscript_parser_tir.py
@@ -72,26 +72,6 @@ def test_tir_func_name():
     assert matmul.__name__ == "matmul"
 
 
-def test_tir_macro_decorator():
-    @T.macro
-    def func1(n):
-        T.evaluate(n)
-
-    assert func1.hygienic
-
-    @T.macro()
-    def func2(n):
-        T.evaluate(n)
-
-    assert func2.hygienic
-
-    with pytest.raises(ValueException) as exc:
-
-        @T.macro(True)
-        def func3(n):
-            T.evaluate(n)
-
-
 def test_tir_macro_decorator_signature():
     @T.prim_func
     def evaluate0():


### PR DESCRIPTION
This patch introduces new symbol: `T.macro`. `T.macro` is a decorator that, when applied to a function, turns the body of that function into a piece of TIR that can be inserted into a PrimFunc by calling the macro the same way as a function.

For example:

```python
@T.macro
def copy_backwards(dst, src, size):
    with T.block("backwards"):
        for i in T.serial(size):
            ai = T.axis.remap("S", [i])
            T.reads(src[0:size])
            T.writes(dst[0:size])
            dst[ai] = src[size - ai - 1]

@T.prim_func
def foo_int32(A: T.Buffer((128,), "int32"), B: T.Buffer((128,), "int32")):
    copy_backwards(A, B, 128)

@T.prim_func
def foo_int8(A: T.Buffer((128,), "int8"), B: T.Buffer((128,), "int8")):
    copy_backwards(A, B, 128)
```

The above will generate two PrimFuncs that do the same backwards copy, but applied to buffers with different data types.

```python
@T.prim_func
def foo_int32(A: T.Buffer((128,), "int32"), B: T.Buffer((128,), "int32")):
    # with T.block("root"):
    for i in range(128):
        with T.block("copy"):
            ai = T.axis.spatial(128, i)
            T.reads(B[0:128])
            T.writes(A[0:128])
            A[ai] = B[128 - ai - 1]

@T.prim_func
def foo_int8(A: T.Buffer((128,), "int8"), B: T.Buffer((128,), "int8")):
    # with T.block("root"):
    for i in range(128):
        with T.block("copy"):
            ai = T.axis.spatial(128, i)
            T.reads(B[0:128])
            T.writes(A[0:128])
            A[ai] = B[128 - ai - 1]
```

Semantics:
- Function that is decorated with @T.macro can have any parameters that follow Python syntax, i.e. positional, keyword, etc. Type annotations are not required, but are allowed.
- For `macro_name(arg1, arg2, arg3, ...)`, the values are substituted into the body of the macro, and the body with the substituted values is then inserted at the point where the call is located.
- Macros are hygienic by default, but can be made non-hygienic via a keyword argument `hygienic` to `T.macro`, e.g. `T.macro(hygienic=False)`.