### PR TITLE
[bugfix][frontend][keras] Fix go_backwards attribute of LSTM in keras frontend

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1005,6 +1005,8 @@ def _convert_lstm(
     recurrent_weight = etab.new_const(weightList[1].transpose([1, 0]))
     if keras_layer.use_bias:
         in_bias = etab.new_const(weightList[2])
+    if keras_layer.go_backwards:
+        in_data = _op.reverse(in_data, axis=1)
     units = list(weightList[0].shape)[1]
     time_steps = in_shape[1]
     in_data = _op.squeeze(in_data, axis=[0])

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -525,6 +525,8 @@ class TestKeras:
         rnn_funcs = [
             keras_mod.layers.LSTM(16),
             keras_mod.layers.LSTM(16, return_sequences=True),
+            keras_mod.layers.LSTM(16, go_backwards=True),
+            keras_mod.layers.LSTM(16, return_sequences=True, go_backwards=True),
             keras_mod.layers.LSTM(16, return_sequences=True, use_bias=False),
         ]
         for rnn_func in rnn_funcs:


### PR DESCRIPTION
This PR fixed the bug proposed in #15176 and added bug-triggering test cases.


If `go_backwards=True`, the LSTM layer processes the input sequence backward and returns the reversed sequence.
Missing the support for `go_backwards` will lead to wrong inference results in TVM.

cc @Hzfengsy @echuraev  