### PR TITLE
[Bugfix][Dlight] Fix the schedule rule for decode-gemv

### DIFF
--- a/python/tvm/dlight/gpu/decode_gemv.py
+++ b/python/tvm/dlight/gpu/decode_gemv.py
@@ -271,7 +271,7 @@ class DecodeGEMV(ScheduleRule):
                 _, *s = sch.get_loops(epilogue)  # pylint: disable=invalid-name
                 _, tx, ty = sch.split(sch.fuse(*s), factors=[None, len_tx, len_ty])
                 sch.bind(tx, "threadIdx.x")
-                sch.bind(ty, "threadIdx.x")
+                sch.bind(ty, "threadIdx.y")
             else:
                 sch.set_scope(block, 0, "local")
         # pylint: enable=invalid-name


### PR DESCRIPTION
Currently, mlc-llm produces meaningless results if we compile models with dlight and set the quantization mode to `q4f16_0` (which transposes the weight matrix).
This is due to a typo in `decode-gemv`, thank @Hzfengsy for finding this bug.

cc @junrushao @Hzfengsy 