### PR TITLE
[Unity][Relax][Transform] Do not remove MatchCast for RemoveAllUnused

### DIFF
--- a/src/relax/ir/binding_rewrite.cc
+++ b/src/relax/ir/binding_rewrite.cc
@@ -249,7 +249,7 @@ class RemoveUnusedVars : public ExprMutator {
     auto prev_dfb = GetRef<DataflowBlock>(block);
     builder_->BeginDataflowBlock();
     for (Binding binding : block->bindings) {
-      if (!unused_vars.count(binding->var)) {
+      if (!unused_vars.count(binding->var) || binding.as<MatchCastNode>()) {
         VisitBinding(binding);
       }
     }


### PR DESCRIPTION
Match_cast can be used to capture symbolic shapes, remove MatchCast binding will cause `Prim Expr xxx has not been computed` in build stage.