### PR TITLE
[RPC] Fix socket bind errno on corner case

### DIFF
--- a/src/support/socket.h
+++ b/src/support/socket.h
@@ -262,17 +262,17 @@ class Socket {
           0) {
         return port;
       } else {
+#if defined(_WIN32)
+        if (WSAGetLastError() != WSAEADDRINUSE) {
+          Socket::Error("TryBindHost");
+        }
+#else
+        if (errno != EADDRINUSE) {
+          Socket::Error("TryBindHost");
+        }
+#endif
         LOG(WARNING) << "Bind failed to " << host << ":" << port;
       }
-#if defined(_WIN32)
-      if (WSAGetLastError() != WSAEADDRINUSE) {
-        Socket::Error("TryBindHost");
-      }
-#else
-      if (errno != EADDRINUSE) {
-        Socket::Error("TryBindHost");
-      }
-#endif
     }
     return -1;
   }


### PR DESCRIPTION
Because `LOG(WARNING)` may invoke system calls, the errno of socket bind failure is overwrite, which make `TryBindPort` exit without any more trials.  The errno check should be put just after `bind` return.

Here is an example from strace,
```
bind(3, {sa_family=AF_INET, sin_port=htons(9200), sin_addr=inet_addr("192.168.35.133")}, 16) = -1 EADDRINUSE (Address already in use)
openat(AT_FDCWD, "/etc/localtime", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
```
The stacktrace would be (errno became to be ENOENT):
```
terminate called after throwing an instance of 'tvm::runtime::InternalError'
  what():  [05:28:22] /tvm/apps/cpp_rpc/../../src/support/socket.h:362: Socket TryBindHost Error:No such file or directory
Stack trace:
  [bt] (0) /lib/libtvm_runtime.so(tvm::runtime::Backtrace[abi:cxx11]()+0x1c) [0xffff8f9f73cc]
  [bt] (1) tvm_rpc() [0x4061d0]
  [bt] (2) tvm_rpc() [0x409178]
  [bt] (3) tvm_rpc() [0x40c138]
  [bt] (4) tvm_rpc() [0x40728c]
  [bt] (5) /lib64/libc.so.6(__libc_start_main+0xe4) [0xffff8e98efac]
  [bt] (6) tvm_rpc() [0x407b60]
```