### PR TITLE
[Ethos-U] Replace ethos-u.constants with AllocateConst

### DIFF
--- a/src/relay/backend/contrib/ethosu/codegen.cc
+++ b/src/relay/backend/contrib/ethosu/codegen.cc
@@ -307,9 +307,6 @@ runtime::Module TIRToRuntime(IRModule mod, Target target) {
   Array<CompilationArtifact> compile_artifacts;
   for (const auto& kv : mod->functions) {
     const tir::PrimFunc& prim_func = Downcast<tir::PrimFunc>(kv.second);
-    Optional<Map<Integer, runtime::NDArray>> params =
-        prim_func->GetAttr<Map<Integer, runtime::NDArray>>("ethos-u.constants");
-    ICHECK(params) << "microNPU params should be present";
     auto primfunc_to_artifact_pf =
         tvm::runtime::Registry::Get("relay.ext.ethos-u.primfunc_to_artifact");
     ICHECK(primfunc_to_artifact_pf);

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -287,6 +287,7 @@ AllocateConst::AllocateConst(Var buffer_var, DataType dtype, Array<PrimExpr> ext
   }
   ICHECK(body.defined());
   ICHECK(data_or_idx.defined());
+  ICHECK(annotations.defined());
 
   ObjectPtr<AllocateConstNode> node = make_object<AllocateConstNode>();
   node->buffer_var = std::move(buffer_var);
@@ -323,9 +324,10 @@ int64_t AllocateConstNode::ConstantAllocationSize(const Array<PrimExpr>& extents
 }
 TVM_REGISTER_GLOBAL("tir.AllocateConst")
     .set_body_typed([](Var buffer_var, DataType dtype, Array<PrimExpr> extents,
-                       ObjectRef data_or_idx, Stmt body, Map<String, ObjectRef> annotations,
-                       Span span) {
-      return AllocateConst(buffer_var, dtype, extents, data_or_idx, body, annotations, span);
+                       ObjectRef data_or_idx, Stmt body,
+                       Optional<Map<String, ObjectRef>> annotations, Span span) {
+      return AllocateConst(buffer_var, dtype, extents, data_or_idx, body,
+                           annotations.value_or(Map<String, ObjectRef>()), span);
     });
 
 TVM_REGISTER_NODE_TYPE(AllocateConstNode);

--- a/tests/python/contrib/test_ethosu/cascader/test_integration.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_integration.py
@@ -124,7 +124,10 @@ def test_double_conv_compute_cycles_hint():
     for double convolution.
     """
     primfunc = _compile_model(_create_double_conv2d())
-    ops = primfunc.body.body.body.body.seq
+
+    ops = primfunc.body
+    while not isinstance(ops, tvm.tir.SeqStmt):
+        ops = ops.body
     compute_cycles_hints = [2944, 1408, 320, 240]
     for op, compute_cycle_hint in zip(ops, compute_cycles_hints):
         assert op.attr_key == "pragma_compute_cycles_hint"

--- a/tests/python/contrib/test_ethosu/cascader/test_integration.py
+++ b/tests/python/contrib/test_ethosu/cascader/test_integration.py
@@ -74,7 +74,9 @@ def _compile_model(relay_function):
     mod = tvm.IRModule()
     mod["main"] = relay_function
     mod = relay.transform.InferType()(mod)
-    tir_mod = _lower_to_tir(mod["main"], _ethos_u55_cascader())[0]
+    func = mod["main"]
+    cascader = _ethos_u55_cascader()
+    tir_mod = _lower_to_tir(func, cascader)
     return tir_mod["main"]
 
 
@@ -109,7 +111,7 @@ def test_single_conv_compute_cycles_hint():
     for single convolution.
     """
     primfunc = _compile_model(_create_single_conv2d())
-    ops = primfunc.body.body.seq
+    ops = primfunc.body.body.body.seq
     compute_cycles_hints = [2944, 320]
     for op, compute_cycle_hint in zip(ops, compute_cycles_hints):
         assert op.attr_key == "pragma_compute_cycles_hint"
@@ -135,7 +137,7 @@ def test_scalar_add_compute_cycles_hint():
     for add with scalar values.
     """
     primfunc = _compile_model(_create_scalar_add())
-    ops = primfunc.body.body.seq
+    ops = primfunc.body.body.body.seq
 
     compute_cycles_hints = [16, 24]
     for op, compute_cycle_hint in zip(ops, compute_cycles_hints):

--- a/tests/python/contrib/test_ethosu/test_codegen.py
+++ b/tests/python/contrib/test_ethosu/test_codegen.py
@@ -1081,10 +1081,11 @@ def test_ethosu_section_name():
         '__attribute__((section(".rodata.tvm"), aligned(16))) static int8_t tvmgen_default_ethos_u_main_0_cms_data_data'
         in source
     )
-    assert (
-        '__attribute__((section(".rodata.tvm"), aligned(16))) static int8_t tvmgen_default_ethos_u_main_0_weights'
-        in source
-    )
+    # The weights are now encoded by TVM in the AllocateConst node.
+    # assert (
+    #     '__attribute__((section(".rodata.tvm"), aligned(16))) static int8_t tvmgen_default_ethos_u_main_0_weights'
+    #     in source
+    # )
 
 
 @pytest.mark.parametrize("accel_type", ACCEL_TYPES)

--- a/tests/python/contrib/test_ethosu/test_compiler.py
+++ b/tests/python/contrib/test_ethosu/test_compiler.py
@@ -57,7 +57,7 @@ def test_lower_to_tir_arg_count(relay_function, arg_count):
     mod = tvm.IRModule()
     mod["main"] = relay_function()
     mod = relay.transform.InferType()(mod)
-    tir_mod = _lower_to_tir(mod["main"])[0]
+    tir_mod = _lower_to_tir(mod["main"])
     primfunc = tir_mod["main"]
     assert len(primfunc.params) == arg_count
 

--- a/tests/python/contrib/test_ethosu/test_replace_binary_elementwise.py
+++ b/tests/python/contrib/test_ethosu/test_replace_binary_elementwise.py
@@ -71,7 +71,7 @@ def test_binary_elementwise_single(
     )
     func = relay.Function(relay.analysis.free_vars(binary_elementwise), binary_elementwise)
     func = run_opt_pass(func, relay.transform.InferType())
-    mod, _ = _lower_to_tir(func)
+    mod = _lower_to_tir(func)
     data = []
 
     def _visit(stmt):
@@ -229,7 +229,7 @@ def test_shift_binary_elementwise_single(
     )
     func = relay.Function(relay.analysis.free_vars(binary_elementwise), binary_elementwise)
     func = run_opt_pass(func, relay.transform.InferType())
-    mod, _ = _lower_to_tir(func)
+    mod = _lower_to_tir(func)
     data = []
 
     def _visit(stmt):

--- a/tests/python/contrib/test_ethosu/test_replace_conv2d.py
+++ b/tests/python/contrib/test_ethosu/test_replace_conv2d.py
@@ -24,7 +24,7 @@ from tvm.relay.backend.contrib.ethosu.tir.scheduler import total_cascader
 from tvm.relay.testing import run_opt_pass
 from tvm.script import tir as T
 
-from .infra import make_ethosu_conv2d
+from .infra import make_ethosu_conv2d, copy_allocate_const_data
 
 
 def _create_serial_conv2d_params(
@@ -350,7 +350,7 @@ def test_conv2d_single(trial):
         [(1, 2, 12, 9, 16), 182, 67, (1, 3), (6, 3), (2, 2), (1, 1), "CLIP", "NHCWB16", "NHCWB16"],
     ]
     func = _get_func(*trial)
-    mod, _ = _lower_to_tir(func)
+    mod = _lower_to_tir(func)
     data = []
 
     def _visit(stmt):
@@ -370,10 +370,14 @@ class Conv2dDoubleCascade1:
     def main(input_placeholder_5: T.Buffer((1, 8, 8, 3), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 8, 8), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([304], "uint8")
-        buffer_1 = T.Buffer([80], "uint8")
-        buffer_2 = T.Buffer([320], "uint8")
-        buffer_3 = T.Buffer([160], "uint8")
+        data_1 = T.allocate_const([0]*80, "uint8", [80])
+        buffer_1 = T.Buffer([80], "uint8", data=data_1)
+        data = T.allocate_const([0]*304, "uint8", [304])
+        buffer = T.Buffer([304], "uint8", data=data)
+        data_2 = T.allocate_const([0]*320, "uint8", [320])
+        buffer_2 = T.Buffer([320], "uint8", data=data_2)
+        data_3 = T.allocate_const([0]*160, "uint8", [160])
+        buffer_3 = T.Buffer([160], "uint8", data=data_3)
         placeholder_5 = T.Buffer([192], 'int8', data=input_placeholder_5.data)
         ethosu_write_1 = T.Buffer([512], 'int8', data=input_ethosu_write_1.data)
         # body
@@ -392,10 +396,14 @@ class Conv2dDoubleCascade2:
     def main(input_placeholder_5: T.Buffer((1, 8, 8, 3), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 8, 8), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([80], "uint8")
-        buffer_1 = T.Buffer([320], "uint8")
-        buffer_2 = T.Buffer([1312], "uint8")
-        buffer_3 = T.Buffer([2608], "uint8")
+        data = T.allocate_const([0]*80, "uint8", [80])
+        buffer = T.Buffer([80], "uint8",data=data)
+        data_3 = T.allocate_const([0]*2608, "uint8", [2608])
+        buffer_3 = T.Buffer([2608], "uint8",data=data_3)
+        data_1 = T.allocate_const([0]*320, "uint8", [320])
+        buffer_1 = T.Buffer([320], "uint8", data=data_1)
+        data_2 = T.allocate_const([0]*1312, "uint8", [1312])
+        buffer_2 = T.Buffer([1312], "uint8", data=data_2)
         placeholder_5 = T.Buffer([192], 'int8', data=input_placeholder_5.data)
         ethosu_write_1 = T.Buffer([512], 'int8', data=input_ethosu_write_1.data)
         # body
@@ -414,10 +422,14 @@ class Conv2dDoubleCascade3:
     def main(input_placeholder_5: T.Buffer((1, 16, 16, 3), "int8"), input_ethosu_write_1: T.Buffer((1, 20, 4, 8), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([1744], "uint8")
-        buffer_1 = T.Buffer([80], "uint8")
-        buffer_2 = T.Buffer([320], "uint8")
-        buffer_3 = T.Buffer([880], "uint8")
+        data_1 = T.allocate_const([0]*80, "uint8", [80])
+        buffer_1 = T.Buffer([80], "uint8", data=data_1)
+        data = T.allocate_const([0]*1744, "uint8", [1744])
+        buffer = T.Buffer([1744], "uint8",data=data)
+        data_2 = T.allocate_const([0]*320, "uint8", [320])
+        buffer_2 = T.Buffer([320], "uint8", data=data_2)
+        data_3 = T.allocate_const([0]*880, "uint8", [880])
+        buffer_3 = T.Buffer([880], "uint8",data=data_3)
         placeholder_5 = T.Buffer([768], 'int8', data=input_placeholder_5.data)
         ethosu_write_1 = T.Buffer([640], 'int8', data=input_ethosu_write_1.data)
 
@@ -439,10 +451,14 @@ class Conv2dDoubleCascade4:
     def main(input_placeholder_5: T.Buffer((1, 8, 1, 8, 16), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 2, 8, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([1456], "uint8")
-        buffer_1 = T.Buffer([352], "uint8")
-        buffer_2 = T.Buffer([272], "uint8")
-        buffer_3 = T.Buffer([11040], "uint8")
+        data_2 = T.allocate_const([0]*272, "uint8", [272])
+        buffer_2 = T.Buffer([272], "uint8"  ,data=data_2)
+        data_3 = T.allocate_const([0]*11040, "uint8", [11040])
+        buffer_3 = T.Buffer([11040], "uint8",data=data_3)
+        data_1 = T.allocate_const([0]*352, "uint8", [352])
+        buffer_1 = T.Buffer([352], "uint8"  ,data=data_1)
+        data = T.allocate_const([0]*1456, "uint8", [1456])
+        buffer = T.Buffer([1456], "uint8",data=data)
         placeholder_5 = T.Buffer([1024], 'int8', data=input_placeholder_5.data)
         ethosu_write_1 = T.Buffer([2048], 'int8', data=input_ethosu_write_1.data)
         # body
@@ -461,10 +477,14 @@ class Conv2dDoubleCascade5:
     def main(input_placeholder: T.Buffer((1, 8, 8, 3), "int8"), input_ethosu_write: T.Buffer((1, 32, 32, 8), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([160], "uint8")
-        buffer_1 = T.Buffer([320], "uint8")
-        buffer_2 = T.Buffer([304], "uint8")
-        buffer_3 = T.Buffer([80], "uint8")
+        data_3 = T.allocate_const([0]*80, "uint8", [80])
+        buffer_3 = T.Buffer([80], "uint8",data=data_3)
+        data_2 = T.allocate_const([0]*304, "uint8", [304])
+        buffer_2 = T.Buffer([304], "uint8",data=data_2)
+        data_1 = T.allocate_const([0]*320, "uint8", [320])
+        buffer_1 = T.Buffer([320], "uint8",data=data_1)
+        data = T.allocate_const([0]*160, "uint8", [160])
+        buffer = T.Buffer([160], "uint8",data=data)
         placeholder = T.Buffer([192], 'int8', data=input_placeholder.data)
         ethosu_write = T.Buffer([8192], 'int8', data=input_ethosu_write.data)
         # body
@@ -483,10 +503,14 @@ class Conv2dDoubleCascade6:
     def main(input_placeholder: T.Buffer((1, 8, 1, 8, 16), "int8"), input_ethosu_write: T.Buffer((1, 32, 2, 32, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([1456], "uint8")
-        buffer_1 = T.Buffer([352], "uint8")
-        buffer_2 = T.Buffer([11040], "uint8")
-        buffer_3 = T.Buffer([272], "uint8")
+        data_3 = T.allocate_const([0]*272, "uint8", [272])
+        buffer_3 = T.Buffer([272], "uint8",data=data_3)
+        data_2 = T.allocate_const([0]*11040, "uint8", [11040])
+        buffer_2 = T.Buffer([11040], "uint8",data=data_2)
+        data_1 = T.allocate_const([0]*352, "uint8", [352])
+        buffer_1 = T.Buffer([352], "uint8",data=data_1)
+        data = T.allocate_const([0]*1456, "uint8", [1456])
+        buffer = T.Buffer([1456], "uint8",data=data)
         placeholder = T.Buffer([1024], 'int8', data=input_placeholder.data)
         ethosu_write = T.Buffer([32768], 'int8', data=input_ethosu_write.data)
         # body
@@ -638,9 +662,10 @@ def test_conv2d_double_cascade(trial):
     }
     with tvm.transform.PassContext(opt_level=3, config={"relay.ext.ethos-u.options": config}):
         func = _get_func(*params[:-1])
-        mod, _ = _lower_to_tir(func, cascader=total_cascader(params[-1]))
+        mod = _lower_to_tir(func, cascader=total_cascader(params[-1]))
         script = mod.script()
         mod = tvm.script.from_source(script)
+        reference_mod = copy_allocate_const_data(mod, reference_mod)
         tvm.ir.assert_structural_equal(mod["main"], reference_mod["main"], True)
 
 
@@ -697,7 +722,7 @@ def test_conv2d_inline_copy(trial):
     reference_mod = trial[0]
     params = trial[1:]
     func = _get_func(*params)
-    mod, _ = _lower_to_tir(func)
+    mod = _lower_to_tir(func)
     script = mod.script()
     mod = tvm.script.from_source(script)
     tvm.ir.assert_structural_equal(mod["main"], reference_mod["main"], True)
@@ -799,7 +824,7 @@ def test_conv2d_inline_reshape(trial):
     reference_mod = trial[0]
     params = trial[1:]
     func = _get_func(*params)
-    mod, _ = _lower_to_tir(func, cascader=total_cascader((1, 4, 6, 16)))
+    mod = _lower_to_tir(func, cascader=total_cascader((1, 4, 6, 16)))
     script = mod.script()
     mod = tvm.script.from_source(script)
     tvm.ir.assert_structural_equal(mod["main"], reference_mod["main"], True)
@@ -819,7 +844,7 @@ def test_conv2d_big_pad():
         return func
 
     func = _get_func()
-    mod, _ = _lower_to_tir(func, cascader=total_cascader((1, 4, 4, 16)))
+    mod = _lower_to_tir(func, cascader=total_cascader((1, 4, 4, 16)))
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_ethosu/test_replace_conv2d.py
+++ b/tests/python/contrib/test_ethosu/test_replace_conv2d.py
@@ -746,9 +746,9 @@ class Conv2dInlineReshape1:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
 
-        data = T.allocate_const([0]*192, 'uint8', 160)
+        data = T.allocate_const([0]*192, 'uint8', [160])
         buffer = T.Buffer([160], "uint8", data=data)
-        data_1 = T.allocate_const([0]*848, 'uint8', 848)
+        data_1 = T.allocate_const([0]*848, 'uint8', [848])
         buffer_1 = T.Buffer([848], "uint8", data=data_1)
         placeholder_3 = T.Buffer([192], 'int8', data=input_placeholder_3.data)
         ethosu_write_1 = T.Buffer([768], 'int8', data=input_ethosu_write_1.data)
@@ -764,9 +764,9 @@ class Conv2dInlineReshape2:
     def main(input_placeholder_3: T.Buffer((1, 24, 8), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 6, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        data = T.allocate_const([0]*192, 'uint8', 160)
+        data = T.allocate_const([0]*192, 'uint8', [160])
         buffer = T.Buffer([160], "uint8", data=data)
-        data_1 = T.allocate_const([0]*848, 'uint8', 848)
+        data_1 = T.allocate_const([0]*848, 'uint8', [848])
         buffer_1 = T.Buffer([848], "uint8", data=data_1)
         placeholder_3 = T.Buffer([192], 'int8', data=input_placeholder_3.data)
         ethosu_write_1 = T.Buffer([768], 'int8', data=input_ethosu_write_1.data)
@@ -782,9 +782,9 @@ class Conv2dInlineReshape3:
     def main(input_placeholder_3: T.Buffer((192, 1), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 6, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        data = T.allocate_const([0]*192, 'uint8', 160)
+        data = T.allocate_const([0]*192, 'uint8', [160])
         buffer = T.Buffer([160], "uint8", data=data)
-        data_1 = T.allocate_const([0]*848, 'uint8', 848)
+        data_1 = T.allocate_const([0]*848, 'uint8', [848])
         buffer_1 = T.Buffer([848], "uint8", data=data_1)
         placeholder_3 = T.Buffer([192], 'int8', data=input_placeholder_3.data)
         ethosu_write_1 = T.Buffer([768], 'int8', data=input_ethosu_write_1.data)
@@ -800,9 +800,9 @@ class Conv2dInlineReshape4:
     def main(placeholder_3: T.Buffer((192,), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 6, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        data = T.allocate_const([0]*192, 'uint8', 160)
+        data = T.allocate_const([0]*192, 'uint8', [160])
         buffer = T.Buffer([160], "uint8", data=data)
-        data_1 = T.allocate_const([0]*848, 'uint8', 848)
+        data_1 = T.allocate_const([0]*848, 'uint8', [848])
         buffer_1 = T.Buffer([848], "uint8", data=data_1)
         ethosu_write_1 = T.Buffer([768], 'int8', data=input_ethosu_write_1.data)
         # body

--- a/tests/python/contrib/test_ethosu/test_replace_conv2d.py
+++ b/tests/python/contrib/test_ethosu/test_replace_conv2d.py
@@ -676,8 +676,13 @@ class Conv2dInlineCopy1:
     def main(input_placeholder_3: T.Buffer((1, 10, 12, 8), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 8, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([848], "uint8")
-        buffer_1 = T.Buffer([160], "uint8")
+
+        data_1 = T.allocate_const([0]*160, 'uint8', [160])
+        buffer_1 = T.Buffer([160], "uint8", data=data_1)
+        data = T.allocate_const([0]*848, 'uint8', [848])
+        buffer = T.Buffer([848], "uint8", data=data)
+
+
         placeholder_3 = T.Buffer([960], 'int8', data=input_placeholder_3.data)
         ethosu_write_1 = T.Buffer([1024], 'int8', data=input_ethosu_write_1.data)
         # body
@@ -691,8 +696,13 @@ class Conv2dInlineCopy2:
     def main(input_placeholder_3: T.Buffer((1, 7, 9, 5), "int8"), input_ethosu_write_1: T.Buffer((1, 3, 5, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([160], "uint8")
-        buffer_1 = T.Buffer([656], "uint8")
+
+        data_1 = T.allocate_const([0]*656, 'uint8', [656])
+        buffer_1 = T.Buffer([656], "uint8", data=data_1)
+        data = T.allocate_const([0]*160, 'uint8', [160])
+        buffer = T.Buffer([160], "uint8", data=data)
+
+
         placeholder_3 = T.Buffer([315], 'int8', data=input_placeholder_3.data)
         ethosu_write_1 = T.Buffer([240], 'int8', data=input_ethosu_write_1.data)
         # body

--- a/tests/python/contrib/test_ethosu/test_replace_conv2d.py
+++ b/tests/python/contrib/test_ethosu/test_replace_conv2d.py
@@ -735,8 +735,11 @@ class Conv2dInlineReshape1:
     def main(input_placeholder_3: T.Buffer((4, 6, 8, 1), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 6, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([160], "uint8")
-        buffer_1 = T.Buffer([848], "uint8")
+
+        data = T.allocate_const([0]*192, 'uint8', 160)
+        buffer = T.Buffer([160], "uint8", data=data)
+        data_1 = T.allocate_const([0]*848, 'uint8', 848)
+        buffer_1 = T.Buffer([848], "uint8", data=data_1)
         placeholder_3 = T.Buffer([192], 'int8', data=input_placeholder_3.data)
         ethosu_write_1 = T.Buffer([768], 'int8', data=input_ethosu_write_1.data)
         # body
@@ -751,8 +754,10 @@ class Conv2dInlineReshape2:
     def main(input_placeholder_3: T.Buffer((1, 24, 8), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 6, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([160], "uint8")
-        buffer_1 = T.Buffer([848], "uint8")
+        data = T.allocate_const([0]*192, 'uint8', 160)
+        buffer = T.Buffer([160], "uint8", data=data)
+        data_1 = T.allocate_const([0]*848, 'uint8', 848)
+        buffer_1 = T.Buffer([848], "uint8", data=data_1)
         placeholder_3 = T.Buffer([192], 'int8', data=input_placeholder_3.data)
         ethosu_write_1 = T.Buffer([768], 'int8', data=input_ethosu_write_1.data)
         # body
@@ -767,8 +772,10 @@ class Conv2dInlineReshape3:
     def main(input_placeholder_3: T.Buffer((192, 1), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 6, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([160], "uint8")
-        buffer_1 = T.Buffer([848], "uint8")
+        data = T.allocate_const([0]*192, 'uint8', 160)
+        buffer = T.Buffer([160], "uint8", data=data)
+        data_1 = T.allocate_const([0]*848, 'uint8', 848)
+        buffer_1 = T.Buffer([848], "uint8", data=data_1)
         placeholder_3 = T.Buffer([192], 'int8', data=input_placeholder_3.data)
         ethosu_write_1 = T.Buffer([768], 'int8', data=input_ethosu_write_1.data)
         # body
@@ -783,8 +790,10 @@ class Conv2dInlineReshape4:
     def main(placeholder_3: T.Buffer((192,), "int8"), input_ethosu_write_1: T.Buffer((1, 8, 6, 16), "int8")) -> None:
         # function attr dict
         T.func_attr({"from_legacy_te_schedule": True, "global_symbol": "main", "tir.noalias": True})
-        buffer = T.Buffer([160], "uint8")
-        buffer_1 = T.Buffer([848], "uint8")
+        data = T.allocate_const([0]*192, 'uint8', 160)
+        buffer = T.Buffer([160], "uint8", data=data)
+        data_1 = T.allocate_const([0]*848, 'uint8', 848)
+        buffer_1 = T.Buffer([848], "uint8", data=data_1)
         ethosu_write_1 = T.Buffer([768], 'int8', data=input_ethosu_write_1.data)
         # body
         T.evaluate(T.call_extern("ethosu_conv2d", "int8", 5, 6, 4, 5, 0, 6, placeholder_3[0], 0, 0, 0, T.float32(0.5), 10, "NHWC", 24, 4, 1, "int8", 4, 6, 16, 4, 0, 6, ethosu_write_1[0], 0, 0, 0, T.float32(0.25), 14, "NHWC", 96, 16, 1, 3, 3, 1, 1, 1, 1, buffer_1[0], 848, T.int8(-1), T.int8(-1), 12, buffer[0], 160, T.int8(-1), T.int8(-1), 1, 1, 0, 1, "NONE", 0, 0, "TFL", "NONE", 0, 0, 0, dtype="handle"))
@@ -825,6 +834,7 @@ def test_conv2d_inline_reshape(trial):
     params = trial[1:]
     func = _get_func(*params)
     mod = _lower_to_tir(func, cascader=total_cascader((1, 4, 6, 16)))
+    reference_mod = copy_allocate_const_data(mod, reference_mod)
     script = mod.script()
     mod = tvm.script.from_source(script)
     tvm.ir.assert_structural_equal(mod["main"], reference_mod["main"], True)

--- a/tests/python/contrib/test_ethosu/test_replace_depthwise_conv2d.py
+++ b/tests/python/contrib/test_ethosu/test_replace_depthwise_conv2d.py
@@ -111,7 +111,7 @@ def test_depthwise_conv2d_single(request, trial):
         return func
 
     func = _get_func(*trial)
-    mod, _ = _lower_to_tir(func)
+    mod = _lower_to_tir(func)
     data = []
 
     def _visit(stmt):

--- a/tests/python/contrib/test_ethosu/test_replace_identity.py
+++ b/tests/python/contrib/test_ethosu/test_replace_identity.py
@@ -33,7 +33,7 @@ def test_identity(ifm_shape):
 
     func = relay.Function(relay.analysis.free_vars(identity), identity)
     func = run_opt_pass(func, relay.transform.InferType())
-    mod, _ = _lower_to_tir(func)
+    mod = _lower_to_tir(func)
     data = []
 
     def _visit(stmt):

--- a/tests/python/contrib/test_ethosu/test_replace_pooling.py
+++ b/tests/python/contrib/test_ethosu/test_replace_pooling.py
@@ -188,7 +188,7 @@ def test_avg_max_pooling_single(
     )
     func = relay.Function(relay.analysis.free_vars(pooling), pooling)
     func = run_opt_pass(func, relay.transform.InferType())
-    mod, _ = _lower_to_tir(func)
+    mod = _lower_to_tir(func)
     data = []
 
     def _visit(stmt):
@@ -244,7 +244,7 @@ def test_sum_pooling_single(
     )
     func = relay.Function(relay.analysis.free_vars(pooling), pooling)
     func = run_opt_pass(func, relay.transform.InferType())
-    mod, _ = _lower_to_tir(func)
+    mod = _lower_to_tir(func)
     data = []
 
     def _visit(stmt):
@@ -307,7 +307,7 @@ def test_correct_stride_with_multiple_pooling():
     )
     func = relay.Function(relay.analysis.free_vars(op), op)
     func = run_opt_pass(func, relay.transform.InferType())
-    mod, _ = _lower_to_tir(func)
+    mod = _lower_to_tir(func)
 
     data = []
 

--- a/tests/python/contrib/test_ethosu/test_replace_unary_elementwise.py
+++ b/tests/python/contrib/test_ethosu/test_replace_unary_elementwise.py
@@ -69,7 +69,7 @@ def test_unary_elementwise_single(
     )
     func = relay.Function(relay.analysis.free_vars(unary_elementwise), unary_elementwise)
     func = run_opt_pass(func, relay.transform.InferType())
-    mod, _ = _lower_to_tir(func)
+    mod = _lower_to_tir(func)
     data = []
 
     def _visit(stmt):

--- a/tests/python/unittest/test_tir_transform_make_packed_api.py
+++ b/tests/python/unittest/test_tir_transform_make_packed_api.py
@@ -147,7 +147,10 @@ def test_device_api_context_implicit_resource_handle():
         lambda f: f.with_attr("target", tvm.target.Target("llvm", host="llvm"))
     )(mod)
     mod = tvm.tir.transform.Apply(lambda f: f.with_attr("global_symbol", "main"))(mod)
-    func = tvm.tir.transform.MakePackedAPI()(mod)["main"]
+    mod.show(name="before")
+    mod = tvm.tir.transform.MakePackedAPI()(mod)
+    mod.show(name="after")
+    func = mod["main"]
 
     num_args = func.params[2]
     device_context_in_resource_handle = func.params[5]


### PR DESCRIPTION
Previously, constants for ethos-u were tracked using a function attribute `"ethos-u.constants"`.  This predates the introduction of `AllocateConst`, and had comments indicating that it should be replaced with `AllocateConst` when possible.

To minimize impact to existing passes, this commit preserves the `"ethos-u.constants"` attribute during ethosu-specific lowering passes.  The attribute is converted to `AllocateConst` at the end of the `lower_ethosu` pass, just prior to lowering with the usual TIR passes.