### PR TITLE
[Unity] Update CUTLASS Attention to incorprate upstream change

### DIFF
--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -88,7 +88,7 @@ def instantiate_attention_template(attrs):
                       /*is_aligned=*/${kIsAligned},
                       /*queries_per_block=*/${kQueriesPerBlock},
                       /*keys_per_block=*/${kKeysPerBlock},
-                      /*single_value_iteration=*/${kSingleValueIteration},
+                      /*kMaxK=*/${kMaxK},
                       /*supports_dropout=*/${kSupportsDropout},
                       /*supports_bias=*/${kSupportsBias}
       >;

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -729,6 +729,8 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["num_heads"] = n = annotations["num_heads"]
         attrs["head_dim"] = h = annotations["head_dim"]
         attrs["head_dim_value"] = h_v = annotations["head_dim_value"]
+        attrs["kMaxK"] = max(int(attrs["head_dim"]), int(attrs["head_dim_value"]))
+
         data_type_size = DataTypeSize[data_type]
         if (data_type_size * h // 8) % 16 == 0 and (data_type_size * h_v // 8) % 16 == 0:
             attrs["kIsAligned"] = True
@@ -737,8 +739,12 @@ def instantiate_template(func_name, annotations, func_args):
         else:
             raise NotImplementedError()
         if h_v > 64:
-            attrs["kQueriesPerBlock"] = 32
-            attrs["kKeysPerBlock"] = 128
+            if annotations["arch"] > 75:
+                attrs["kQueriesPerBlock"] = 32
+                attrs["kKeysPerBlock"] = 128
+            else:
+                attrs["kQueriesPerBlock"] = 64
+                attrs["kKeysPerBlock"] = 128
             attrs["kSingleValueIteration"] = h_v <= 128
         else:
             attrs["kQueriesPerBlock"] = 64

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -739,12 +739,8 @@ def instantiate_template(func_name, annotations, func_args):
         else:
             raise NotImplementedError()
         if h_v > 64:
-            if annotations["arch"] > 75:
-                attrs["kQueriesPerBlock"] = 32
-                attrs["kKeysPerBlock"] = 128
-            else:
-                attrs["kQueriesPerBlock"] = 64
-                attrs["kKeysPerBlock"] = 128
+            attrs["kQueriesPerBlock"] = 32
+            attrs["kKeysPerBlock"] = 128
             attrs["kSingleValueIteration"] = h_v <= 128
         else:
             attrs["kQueriesPerBlock"] = 64


### PR DESCRIPTION
https://github.com/NVIDIA/cutlass/pull/992

On RTX 4080, I got modest speed up on SD (49 -> 50 it / sec), and tiny speed up on Vicuna 7b (+ 0.2 - 0.3 tok / s). 

They recommend "setting blockSize to 64x128 rather than 32x128 after Sm75". On RTX 4080 + SD, there is no perf difference. But 64x128 is slightly slower than 32x128 on the attention workload in the vicuna decoder. So I didn't change the block size.   

@vinx13 @cyx-6 @sunggg @jwfromm 
