### PR TITLE
[Unity] fp16 A x int B GEMM update - support int8, more bias shape

### DIFF
--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -31,7 +31,7 @@ from tvm.tir import IntImm
 from . import _ffi_api as ffi
 from .attention_operation import instantiate_attention_template
 from .conv2d_operation import instantiate_conv2d_template
-from .gemm_operation import instantiate_gemm_template, emit_fp16A_int4B_matmul
+from .gemm_operation import instantiate_gemm_template, emit_fp16A_intB_matmul
 from .layer_norm_operation import instantiate_layer_norm_template
 from .rms_norm_operation import instantiate_rms_norm_template
 from .library import (
@@ -526,6 +526,7 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["scales_arg"] = func_args[scales_arg_idx]
         attrs["batch_offset"] = _get_optional_int_annotation(annotations, "batch_offset", 0)
         attrs["activation"] = annotations.get("activation", "identity")
+        attrs["bias_stride"] = annotations["bias_stride"]
 
         if bias_arg_idx is not None:
             attrs["bias_arg"] = func_args[bias_arg_idx]
@@ -535,7 +536,15 @@ def instantiate_template(func_name, annotations, func_args):
             attrs["binary_op"] = annotations["binary_op"]
             attrs["unary_op"] = annotations["unary_op"]
 
-        code = emit_fp16A_int4B_matmul(attrs)
+        if annotations["weight_nbit"] == 4:
+            attrs["weight_dtype"] = "cutlass::uint4b_t"
+            attrs["float_per_int"] = 2
+        else:
+            assert annotations["weight_nbit"] == 8
+            attrs["weight_dtype"] = "uint8_t"
+            attrs["float_per_int"] = 1
+
+        code = emit_fp16A_intB_matmul(attrs)
         return CodegenResult(code, headers)
 
     elif "dense" in func_name or "matmul" in func_name:
@@ -792,6 +801,12 @@ def instantiate_template(func_name, annotations, func_args):
         headers.append("cutlass/layout/matrix.h")
         attrs = {"input": func_args[0], "gamma": func_args[1], "beta": func_args[2]}
         attrs.update(dict(annotations))
+
+        if isinstance(attrs["M"], tvm.tir.Var):
+            attrs["M"] = " * ".join(
+                ["{}->shape[{}]".format(func_args[0], i) for i in range(int(attrs["batch_rank"]))]
+            )
+
         code = instantiate_layer_norm_template(attrs)
         return CodegenResult(code, headers)
     elif "rms_norm" in func_name:

--- a/python/tvm/contrib/cutlass/layer_norm_operation.py
+++ b/python/tvm/contrib/cutlass/layer_norm_operation.py
@@ -28,8 +28,8 @@ def instantiate_layer_norm_template(attrs):
     using data_type = ${data_type};
     using namespace cutlass::layout;
 
-    auto M = ${M};
-    auto N = ${N};
+    int M = ${M};
+    int N = ${N};
     cutlass::MatrixCoord size(M, N);
     auto layout_2D = RowMajor::packed(size);
     auto layout_channels = RowMajor::packed({1, N});

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -102,6 +102,15 @@ def _has_dependency(from_var: Var, to_var: Var, var_usages: Mapping[Var, Sequenc
     return False
 
 
+def _is_same_shape(shape1, shape2):
+    analyzer = tvm.arith.Analyzer()
+    return all([analyzer.can_prove_equal(s1, s2) for s1, s2 in zip(shape1, shape2)])
+
+
+def _is_bias_like(shape, out_channel):
+    return shape[-1] == out_channel and _shape_1d(shape) == out_channel
+
+
 def _check_residual(root_call: Call, context: PatternCheckContext) -> bool:
     if "residual" in context.annotated_expr:
         residual = context.annotated_expr["residual"]
@@ -116,14 +125,12 @@ def _check_residual(root_call: Call, context: PatternCheckContext) -> bool:
             # If residual depends on the result of the root call, this cannot be handled by cutlass.
             return False
 
-        # shape1 = [int(s) for s in root_var.struct_info.shape]
-        # shape2 = [int(s) for s in residual.struct_info.shape]
+        shape1 = root_var.struct_info.shape
+        shape2 = residual.struct_info.shape
+        out_channel = shape1[-1]
 
-        # out_channel = shape1[-1]
-        # is_bias_like = lambda shape: (shape[-1] == out_channel and _shape_1d(shape) == out_channel)
-
-        # if shape1 != shape2 and not is_bias_like(shape2):
-        #     return False
+        if not _is_same_shape(shape1, shape2) and not _is_bias_like(shape2, out_channel):
+            return False
 
     return True
 
@@ -239,7 +246,6 @@ def _check_decode_matmul(ctx):
         return False
 
     N = root.struct_info.shape[-1]
-    K = call_tir_decode.struct_info.shape[0]
 
     if ctx.annotated_expr["lhs"].struct_info.dtype != "float16":
         return False
@@ -258,10 +264,6 @@ def _check_decode_matmul(ctx):
     ):
         return False
 
-    # # packed weight needs to be of shape (K, N // 2)
-    # if packed_weight.struct_info.shape[0] != K or packed_weight.struct_info.shape[1] != N // 2:
-    #     return False
-
     scales = ctx.annotated_expr["scales"]
 
     if scales.struct_info.dtype != "float16":
@@ -271,12 +273,14 @@ def _check_decode_matmul(ctx):
     if len(scales.struct_info.shape) != 1 or scales.struct_info.shape[0] != N:
         return False
 
-    # # bias shape needs to be (N,), possibly with additional axes on the front.
-    # if "bias" in ctx.annotated_expr:
-    #     bias_shape = ctx.annotated_expr["bias"].struct_info.shape
-    #     bias_shape_1d = reduce(operator.mul, bias_shape, 1)
-    #     if bias_shape_1d != bias_shape[-1]:
-    #         return False
+    if "bias" in ctx.annotated_expr:
+        out_shape = root.struct_info.shape
+        bias_shape = ctx.annotated_expr["bias"].struct_info.shape
+
+        # bias shape needs to be (N,), possibly with additional axes on the front.
+        # It can also have the same shape as the output.
+        if not _is_bias_like(bias_shape, N) and not _is_same_shape(out_shape, bias_shape):
+            return False
 
     return True
 

--- a/src/runtime/contrib/cutlass/weight_preprocess.cc
+++ b/src/runtime/contrib/cutlass/weight_preprocess.cc
@@ -42,16 +42,13 @@ TVM_REGISTER_GLOBAL("cutlass.ft_preprocess_weight")
       std::vector<int8_t> input_cpu(rows * cols);
       std::vector<int8_t> output_cpu(rows * cols);
       packed_weight.CopyToBytes(input_cpu.data(), input_cpu.size());
-
       // multiply cols by 2 since the "col" params in preprocess_weights refers to the column of
       // the unpacked weight.
       if (is_int4) {
         cols *= 2;
       }
-
       fastertransformer::preprocess_weights(output_cpu.data(), input_cpu.data(), rows, cols,
                                             is_int4, sm);
-
       auto out = NDArray::Empty(packed_weight.Shape(), packed_weight->dtype, packed_weight->device);
       out.CopyFromBytes(output_cpu.data(), output_cpu.size());
       return out;

--- a/src/runtime/contrib/cutlass/weight_preprocess.cc
+++ b/src/runtime/contrib/cutlass/weight_preprocess.cc
@@ -35,17 +35,23 @@ namespace runtime {
 // black box.
 //
 // The preprocessing functions are defined in C++, so we need to copy the input weight to CPU.
-TVM_REGISTER_GLOBAL("cutlass.ft_preprocess_weight_int4")
-    .set_body_typed([](NDArray packed_weight, int sm) {
+TVM_REGISTER_GLOBAL("cutlass.ft_preprocess_weight")
+    .set_body_typed([](NDArray packed_weight, int sm, bool is_int4) {
       int rows = packed_weight->shape[0];
       int cols = packed_weight->shape[1];
       std::vector<int8_t> input_cpu(rows * cols);
       std::vector<int8_t> output_cpu(rows * cols);
       packed_weight.CopyToBytes(input_cpu.data(), input_cpu.size());
+
       // multiply cols by 2 since the "col" params in preprocess_weights refers to the column of
       // the unpacked weight.
-      fastertransformer::preprocess_weights(output_cpu.data(), input_cpu.data(), rows, cols * 2,
-                                            true /*is_int4*/, sm);
+      if (is_int4) {
+        cols *= 2;
+      }
+
+      fastertransformer::preprocess_weights(output_cpu.data(), input_cpu.data(), rows, cols,
+                                            is_int4, sm);
+
       auto out = NDArray::Empty(packed_weight.Shape(), packed_weight->dtype, packed_weight->device);
       out.CopyFromBytes(output_cpu.data(), output_cpu.size());
       return out;

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1258,6 +1258,25 @@ def test_attention_rewrite_fp16():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def split_transform_deploy_mod(mod):
+    mod_transform = tvm.IRModule()
+    mod_deploy = tvm.IRModule().with_attrs(mod.attrs)
+
+    transform_func_name = None
+
+    for gv, func in mod.functions.items():
+        if "transform_params" in gv.name_hint:
+            transform_func_name = gv.name_hint
+            mod_transform[gv] = func
+        elif isinstance(func, tvm.tir.PrimFunc):
+            mod_transform[gv] = func
+        else:
+            mod_deploy[gv] = func
+
+    assert transform_func_name is not None
+    return mod_transform, mod_deploy, transform_func_name
+
+
 def test_fp16A_int4B_gemm():
     @I.ir_module
     class Module:
@@ -1378,9 +1397,10 @@ def test_fp16A_int4B_gemm():
                 )
                 lv1 = lv[0]
                 lv2 = R.call_pure_packed(
-                    "cutlass.ft_preprocess_weight_int4",
+                    "cutlass.ft_preprocess_weight",
                     lv1,
                     80,
+                    True,
                     sinfo_args=(R.Tensor((64, 64), dtype="int8"),),
                 )
                 lv3: R.Tensor((128,), dtype="float16") = lv[1]
@@ -1409,9 +1429,10 @@ def test_fp16A_int4B_gemm():
                 )
                 lv1 = lv[0]
                 lv2 = R.call_pure_packed(
-                    "cutlass.ft_preprocess_weight_int4",
+                    "cutlass.ft_preprocess_weight",
                     lv1,
                     80,
+                    True,
                     sinfo_args=(R.Tensor((64, 64), dtype="int8"),),
                 )
                 lv3: R.Tensor((128,), dtype="float16") = lv[1]
@@ -1423,24 +1444,6 @@ def test_fp16A_int4B_gemm():
                 lv3_1: R.Tensor((64, 128), dtype="float16") = R.add(lv2_1, residual)
                 R.output(lv3_1)
             return lv3_1
-
-    def split_transform_deploy_mod(mod):
-        mod_transform = tvm.IRModule()
-        mod_deploy = tvm.IRModule().with_attrs(mod.attrs)
-
-        transform_func_name = None
-
-        for gv, func in mod.functions.items():
-            if "transform_params" in gv.name_hint:
-                transform_func_name = gv.name_hint
-                mod_transform[gv] = func
-            elif isinstance(func, tvm.tir.PrimFunc):
-                mod_transform[gv] = func
-            else:
-                mod_deploy[gv] = func
-
-        assert transform_func_name is not None
-        return mod_transform, mod_deploy, transform_func_name
 
     x_shape = (64, 64)
     y_shape = (128, 64)
@@ -1494,6 +1497,142 @@ def test_fp16A_int4B_gemm():
             ref += residual
 
         tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+
+
+def test_fp16A_int8B_gemm():
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def decode(
+            A: T.Buffer((T.int64(64), T.int64(64)), "int8"),
+            B: T.Buffer((T.int64(64),), "float16"),
+            decode_1: T.Buffer((T.int64(64), T.int64(64)), "float16"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            for i, j in T.grid(T.int64(64), T.int64(64)):
+                with T.block("decode"):
+                    v_i, v_j = T.axis.remap("SS", [i, j])
+                    T.reads(A[v_i, v_j], B[v_j])
+                    T.writes(decode_1[v_i, v_j])
+                    decode_1[v_i, v_j] = T.Cast("float16", A[v_i, v_j]) * B[v_j]
+
+        @T.prim_func
+        def encode(
+            A: T.Buffer((T.int64(64), T.int64(64)), "float16"),
+            w_gathered: T.Buffer((T.int64(64), T.int64(64)), "int8"),
+            compute: T.Buffer((T.int64(64),), "float16"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            max_abs_value = T.alloc_buffer((T.int64(64),), "float16")
+            scale = T.alloc_buffer((T.int64(64),))
+            for i, k in T.grid(T.int64(64), T.int64(64)):
+                with T.block("max_abs_value"):
+                    v_i, v_k = T.axis.remap("SR", [i, k])
+                    T.reads(A[v_i, v_k])
+                    T.writes(max_abs_value[v_i])
+                    with T.init():
+                        max_abs_value[v_i] = T.float16(-65504)
+                    max_abs_value[v_i] = T.max(max_abs_value[v_i], T.fabs(A[v_i, v_k]))
+            for i in range(T.int64(64)):
+                with T.block("scale"):
+                    v_i = T.axis.spatial(T.int64(64), i)
+                    T.reads(max_abs_value[v_i])
+                    T.writes(scale[v_i])
+                    scale[v_i] = T.max(
+                        T.Cast("float32", max_abs_value[v_i]), T.float32(0.0001)
+                    ) * T.float32(0.0078125)
+            for j, i in T.grid(T.int64(64), T.int64(64)):
+                with T.block("w_gathered"):
+                    v_j, v_i = T.axis.remap("SS", [j, i])
+                    T.reads(A[v_i, v_j], scale[v_i])
+                    T.writes(w_gathered[v_j, v_i])
+                    w_gathered[v_j, v_i] = T.Cast(
+                        "int8",
+                        T.min(
+                            T.max(
+                                T.round(T.Cast("float32", A[v_i, v_j]) / scale[v_i]),
+                                T.float32(-128),
+                            ),
+                            T.float32(127),
+                        ),
+                    )
+            for i0 in range(T.int64(64)):
+                with T.block("compute"):
+                    v_i0 = T.axis.spatial(T.int64(64), i0)
+                    T.reads(scale[v_i0])
+                    T.writes(compute[v_i0])
+                    compute[v_i0] = T.Cast("float16", scale[v_i0])
+
+        @R.function
+        def main(
+            x: R.Tensor((64, 64), dtype="float16"), y: R.Tensor((64, 64), dtype="float16")
+        ) -> R.Tensor((64, 64), dtype="float16"):
+            R.func_attr({"num_input": 1})
+            cls = Module
+            with R.dataflow():
+                lv = R.call_tir(
+                    cls.encode,
+                    (y,),
+                    out_sinfo=[R.Tensor((64, 64), dtype="int8"), R.Tensor((64,), dtype="float16")],
+                )
+                lv1: R.Tensor((64, 64), dtype="int8") = lv[0]
+                lv2: R.Tensor((64, 64), dtype="int8") = R.call_pure_packed(
+                    "cutlass.ft_preprocess_weight",
+                    lv1,
+                    R.prim_value(80),
+                    R.prim_value(0),
+                    sinfo_args=(R.Tensor((64, 64), dtype="int8"),),
+                )
+                lv3: R.Tensor((64,), dtype="float16") = lv[1]
+                lv4: R.Tensor((64, 64), dtype="int8") = R.builtin.stop_lift_params(lv2)
+                lv5: R.Tensor((64,), dtype="float16") = R.builtin.stop_lift_params(lv3)
+                lv6 = R.call_tir(
+                    cls.decode, (lv4, lv5), out_sinfo=R.Tensor((64, 64), dtype="float16")
+                )
+                lv1_1: R.Tensor((64, 64), dtype="float16") = R.matmul(x, lv6, out_dtype="float16")
+                R.output(lv1_1)
+            return lv1_1
+
+    x_shape = (64, 64)
+    y_shape = (64, 64)
+
+    mod = partition_for_cutlass(Module)
+    func_names = [name.name_hint for (name, _) in mod.functions.items()]
+    assert "fused_decode_relax_matmul_cutlass" in func_names
+
+    mod = relax.transform.RunCodegen(
+        {"cutlass": {"sm": 80, "find_first_valid": False}},
+    )(mod)
+
+    x = np.random.randn(*x_shape).astype("float16")
+    y = np.random.normal(0, 0.002, size=y_shape).astype("float16")
+
+    mod = relax.pipeline.get_pipeline()(mod)
+    mod = relax.transform.LiftTransformParams()(mod)
+
+    mod_transform, mod_deploy, transform_func_name = split_transform_deploy_mod(mod)
+
+    ex = relax.build(mod_transform, target="llvm")
+    vm = relax.vm.VirtualMachine(ex, tvm.cpu(0))
+
+    packed_weight, scales = vm[transform_func_name]((tvm.nd.array(y),))
+
+    dev = tvm.device("cuda", 0)
+    ex = relax.build(mod_deploy, target="cuda")
+    vm = relax.vm.VirtualMachine(ex, dev)
+
+    x_nd = tvm.nd.array(x, dev)
+    params = (packed_weight.copyto(dev), scales.copyto(dev))
+
+    inp = [x_nd, params]
+
+    out = vm["main"](*inp).numpy()
+
+    ref = np.dot(x, y.transpose())
+
+    tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
 
 
 def test_rms_norm():
@@ -1621,4 +1760,5 @@ def test_conv2d_cuda_graph():
 
 
 if __name__ == "__main__":
-    tvm.testing.main()
+    # tvm.testing.main()
+    test_fp16A_int8B_gemm()


### PR DESCRIPTION
Update the FT kernel integration to incorporate the following changes:
https://github.com/tlc-pack/cutlass_fpA_intB_gemm/pull/3
https://github.com/tlc-pack/cutlass_fpA_intB_gemm/pull/4

It also contains other misc changes to better support dolly and gptj (dynamic-size layer norm, residual check condition for dynamic-shape residual etc).

@vinx13 @sunggg @yzh119 
