### PR TITLE
[JVM] Fix the Maven pom.xml for OS X arm64 tvm4j build

### DIFF
--- a/jvm/native/osx-x86_64/pom.xml
+++ b/jvm/native/osx-x86_64/pom.xml
@@ -120,7 +120,7 @@ under the License.
           <compilerEndOptions>
             <compilerEndOption>-I../../../include</compilerEndOption>
             <compilerEndOption>-I${JAVA_HOME}/include</compilerEndOption>
-            <compilerEndOption>-I${JAVA_HOME}/include/linux</compilerEndOption>
+            <compilerEndOption>-I${JAVA_HOME}/include/darwin</compilerEndOption>
             <compilerEndOption>${cflags}</compilerEndOption>
           </compilerEndOptions>
           <linkerStartOptions>

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -172,7 +172,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
This PR fixes the pom.xml for OSX, and also updated the Maven Javadoc plugin version number to the latest.