### PR TITLE
[Dlight] Benchmarking Tools for Dynamic Shape PrimFuncs & Relax Function

### DIFF
--- a/python/tvm/dlight/benchmark/__init__.py
+++ b/python/tvm/dlight/benchmark/__init__.py
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 """Benchmarking dynamic shape workloads"""
-from .bench import benchmark, benchmark_relax_func
+from .bench import benchmark, benchmark_prim_func, benchmark_relax_func
 from .extract import extract_prim_func, extract_from_relax

--- a/python/tvm/dlight/benchmark/__init__.py
+++ b/python/tvm/dlight/benchmark/__init__.py
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Benchmarking dynamic shape workloads"""
+from .bench import benchmark, benchmark_relax_func
+from .extract import extract_prim_func, extract_from_relax

--- a/python/tvm/dlight/benchmark/__init__.py
+++ b/python/tvm/dlight/benchmark/__init__.py
@@ -16,4 +16,9 @@
 # under the License.
 """Benchmarking dynamic shape workloads"""
 from .bench import benchmark, benchmark_prim_func, benchmark_relax_func
-from .extract import extract_prim_func, extract_from_relax
+from .extract import (
+    extract_prim_func,
+    extract_from_relax,
+    extract_func_info_from_prim_func,
+    extract_all_func_info_from_relax,
+)

--- a/python/tvm/dlight/benchmark/bench.py
+++ b/python/tvm/dlight/benchmark/bench.py
@@ -1,0 +1,184 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Extract self-contained benchmarking scripts for dynamic shape workloads"""
+
+from typing import Dict, List, Union, Callable, Tuple
+
+import tvm
+from tvm import relax
+from tvm.ir import IRModule
+from tvm.tir import PrimFunc
+from tvm.meta_schedule.testing.tune_utils import generate_input_data
+
+from .extract import extract_func_info
+from .utils import (
+    populuate_input_shape,
+    default_dym_var_sample_func,
+    get_func_name_from_gv,
+    dym_var_sample_str,
+    print_results,
+)
+
+
+def benchmark(
+    mod_or_func: Union[PrimFunc, IRModule],
+    args: List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]],
+    dym_var_sample: Dict[str, int],
+    target: Union[str, tvm.target.Target] = "llvm -num-cores=4",
+    dev: tvm.runtime.Device = tvm.cpu(),
+    number=10,
+    repeat=10,
+) -> Tuple[List[Tuple[Tuple[int, ...], str]], float, float]:
+    """Benchmark a PrimFunc or IRModule with dynamic input shapes.
+
+    Parameters
+    ----------
+    mod_or_func : Union[PrimFunc, IRModule]
+        The PrimFunc or IRModule to be benchmarked.
+    args : List[relax.TensorStructInfo]
+        The input tensor information, including shape and dtype.
+    dym_var_sample : Dict[Union[relax.expr.Call, str], int]
+        The dynamic shape variable sample, e.g., {n: 64, m: 128}.
+    target : Union[str, tvm.target.Target]
+        The target to be benchmarked on.
+    dev : tvm.runtime.Device
+        The device to be benchmarked on.
+    number : int
+        The number of times to run the measurement.
+    repeat : int
+        The number of times to repeat the measurement.
+
+    Returns
+    -------
+    input_infos : List[Tuple[Tuple[int, ...], str]]
+        The input tensor information, including shape and dtype.
+    median : float
+        The median of the benchmarking results.
+    std : float
+        The standard deviation of the benchmarking results.
+    """
+    # produce IRModule and function name
+    if isinstance(mod_or_func, PrimFunc):
+        mod = IRModule.from_expr(mod_or_func.with_attr("global_symbol", "main"))
+        func_name = "main"
+    else:
+        mod = mod_or_func
+        # assume only one global function
+        (func_name,) = mod.get_global_vars()
+    # produce target
+    target = tvm.target.Target(target)
+    # populate input shapes
+    input_infos = populuate_input_shape(args, dym_var_sample)
+    # generate input tensors, including scalars
+    # scalars are appended to the end of the list due to parsing order
+    input_tensors = []
+    scalar_input_tensors: List[Tuple[Tuple[int], str]] = []
+    for input_shape, input_dtype in input_infos:
+        if input_dtype == "scalar":
+            # special case like [n], generate int value
+            assert isinstance(input_shape, int)
+            scalar_input_tensors.append(input_shape)
+        else:
+            # normal case like [1, n, 128], generate random tensor
+            input_tensors.append(
+                tvm.nd.array(generate_input_data(list(input_shape), input_dtype), device=dev)
+            )
+    # append scalar input tensors
+    input_tensors.extend(scalar_input_tensors)
+    # build locally
+    print("before build")
+    rt_mod = tvm.build(mod, target=target)
+    print("after build")
+    # benchmark locally
+    result = rt_mod.time_evaluator(func_name, dev=dev, number=number, repeat=repeat)(*input_tensors)
+    print("after time_evaluator")
+    # return input infos, median, std
+    return input_infos, result.median, result.std
+
+
+def benchmark_relax_func(
+    mod: tvm.ir.IRModule,
+    relax_func: Union[tvm.ir.GlobalVar, str],
+    sample_number: int = 2,
+    dym_var_sample_func: Callable[
+        [Dict[str, str]],
+        Dict[str, int],
+    ] = default_dym_var_sample_func,
+    target: Union[str, tvm.target.Target] = "llvm -num-cores=4",
+    dev: tvm.runtime.Device = tvm.cpu(),
+    number=10,
+    repeat=10,
+) -> None:
+    """Benchmark a relax function with dynamic input shapes.
+
+    Parameters
+    ----------
+    mod : tvm.ir.IRModule
+        The IRModule to be benchmarked.
+    relax_func : Union[tvm.ir.GlobalVar, str]
+        The relax function to be benchmarked.
+    sample_number : int
+        The number of times to sample dynamic shape variables.
+    dym_var_sample_func : Callable[[Dict[str, str]], Dict[str, int]]
+        The function to sample dynamic shape variables.
+    target : Union[str, tvm.target.Target]
+        The target to be benchmarked on.
+    dev : tvm.runtime.Device
+        The device to be benchmarked on.
+    number : int
+        The number of times to run the measurement.
+    repeat : int
+        The number of times to repeat the measurement.
+    """
+    relax_funcs, dynamic_var_dict = extract_func_info(mod)
+
+    if isinstance(relax_func, str):
+        for gv in relax_funcs:  # pylint: disable=invalid-name
+            if get_func_name_from_gv(gv) == relax_func:
+                relax_func = gv
+                break
+        if not isinstance(relax_func, tvm.ir.GlobalVar):
+            raise ValueError(f"Cannot find relax function with name {relax_func}")
+    for _ in range(sample_number):
+        dym_var_sample = dym_var_sample_func(dynamic_var_dict[relax_func])
+        bench_results = []
+        for functor in relax_funcs[relax_func]:
+            for args, weight in relax_funcs[relax_func][functor]:
+                _, median, _ = benchmark(
+                    mod[functor],
+                    args,
+                    dym_var_sample,
+                    target=target,
+                    dev=dev,
+                    number=number,
+                    repeat=repeat,
+                )
+                bench_results.append(
+                    {
+                        f"PrimFuncs in {get_func_name_from_gv(relax_func)}": get_func_name_from_gv(
+                            functor
+                        ),
+                        f"InputInfo({dym_var_sample_str(dym_var_sample)})": ", ".join(
+                            [str(w) for w in args]
+                        ),
+                        "Time(us)": median * 1e6,
+                        # "Std(us)": std * 1e6,
+                        "Weight": weight,
+                        "WxTime(ms)": median * weight * 1e3,
+                    }
+                )
+        print_results(bench_results)

--- a/python/tvm/dlight/benchmark/bench.py
+++ b/python/tvm/dlight/benchmark/bench.py
@@ -16,13 +16,17 @@
 # under the License.
 """Extract self-contained benchmarking scripts for dynamic shape workloads"""
 
-from typing import Dict, List, Union, Callable, Tuple
+from typing import TYPE_CHECKING, Dict, List, Union, Callable, Tuple, Optional
+
 
 import tvm
 from tvm import relax
 from tvm.ir import IRModule
 from tvm.tir import PrimFunc
+from tvm.meta_schedule.runner import EvaluatorConfig
 from tvm.meta_schedule.testing.tune_utils import generate_input_data
+from tvm.testing import rpc_run
+
 
 from .extract import extract_func_info
 from .utils import (
@@ -33,6 +37,9 @@ from .utils import (
     print_results,
 )
 
+if TYPE_CHECKING:
+    from tvm.meta_schedule.runner import RPCConfig
+
 
 def benchmark(
     mod_or_func: Union[PrimFunc, IRModule],
@@ -40,8 +47,8 @@ def benchmark(
     dym_var_sample: Dict[str, int],
     target: Union[str, tvm.target.Target] = "llvm -num-cores=4",
     dev: tvm.runtime.Device = tvm.cpu(),
-    number=10,
-    repeat=10,
+    evaluator_config: Optional["EvaluatorConfig"] = None,
+    rpc_config: Optional["RPCConfig"] = None,
 ) -> Tuple[List[Tuple[Tuple[int, ...], str]], float, float]:
     """Benchmark a PrimFunc or IRModule with dynamic input shapes.
 
@@ -57,10 +64,12 @@ def benchmark(
         The target to be benchmarked on.
     dev : tvm.runtime.Device
         The device to be benchmarked on.
-    number : int
-        The number of times to run the measurement.
-    repeat : int
-        The number of times to repeat the measurement.
+    evaluator_config : Optional["EvaluatorConfig"]
+        The evaluator configuration to use.
+        If none, will use default evaluator configuration.
+    rpc_config : Optional["RPCConfig"]
+        The RPC configuration to connect to the remote device.
+        If none, will use local mode.
 
     Returns
     -------
@@ -100,14 +109,113 @@ def benchmark(
     # append scalar input tensors
     input_tensors.extend(scalar_input_tensors)
     # build locally
-    print("before build")
     rt_mod = tvm.build(mod, target=target)
-    print("after build")
-    # benchmark locally
-    result = rt_mod.time_evaluator(func_name, dev=dev, number=number, repeat=repeat)(*input_tensors)
-    print("after time_evaluator")
+
+    # set up evaluator config
+    evaluator_config = EvaluatorConfig._normalized(  # pylint: disable=protected-access
+        evaluator_config
+    )
+    # run benchmark
+    if rpc_config is None:
+        profile_result = rt_mod.time_evaluator(
+            func_name,
+            dev=dev,
+            number=evaluator_config.number,
+            repeat=evaluator_config.repeat,
+            min_repeat_ms=evaluator_config.min_repeat_ms,
+            f_preproc="cache_flush_cpu_non_first_arg"
+            if evaluator_config.enable_cpu_cache_flush
+            else "",
+        )(*input_tensors)
+    else:
+        _, profile_result = rpc_run(
+            rt_mod,
+            device_type=dev.MASK2STR[dev.device_type],
+            args=[w.numpy() if isinstance(w, tvm.nd.NDArray) else w for w in input_tensors],
+            rpc_config=rpc_config,
+            evaluator_config=evaluator_config,
+        )
     # return input infos, median, std
-    return input_infos, result.median, result.std
+    return input_infos, profile_result.median, profile_result.std
+
+
+def benchmark_prim_func(
+    mod_or_func: Union[PrimFunc, IRModule],
+    args: List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]],
+    dym_var_dict: Dict[str, str],
+    dym_var_sample_func: Callable[[Dict[str, str]], Dict[str, int]] = default_dym_var_sample_func,
+    sample_number: int = 5,
+    target: Union[str, tvm.target.Target] = "llvm -num-cores=4",
+    dev: tvm.runtime.Device = tvm.cpu(),
+    weight: Optional[int] = 1,
+    relax_func_name: Optional[str] = None,
+    prim_func_name: Optional[str] = None,
+    evaluator_config: Optional["EvaluatorConfig"] = None,
+    rpc_config: Optional["RPCConfig"] = None,
+    sort_by: Optional[str] = None,
+    desc: Optional[bool] = True,
+):
+    """Benchmark a PrimFunc or IRModule with dynamic input shapes and show results.
+
+    Parameters
+    ----------
+    mod_or_func : Union[PrimFunc, IRModule]
+        The PrimFunc or IRModule to be benchmarked.
+    args : List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]]
+        The input tensor information, including shape and dtype.
+    dym_var_dict : Dict[str, str]
+        Dynamic shape variable dictionary, e.g., {"n": "int32", "m": "int32"}
+    dym_var_sample_func : Callable[[Dict[str, str]], Dict[str, int]]
+        The function to sample dynamic shape variables.
+    sample_number : int
+        The number of times to sample dynamic shape variables.
+    target : Union[str, tvm.target.Target]
+        The target to be benchmarked on.
+    dev : tvm.runtime.Device
+        The device to be benchmarked on.
+    weight : Optional[int]
+        The weight of this PrimFunc.
+    relax_func_name : Optional[str]
+        The name of the relax function.
+    prim_func_name : Optional[str]
+        The name of the PrimFunc.
+    evaluator_config : Optional["EvaluatorConfig"]
+        The evaluator configuration to use.
+        If none, will use default evaluator configuration.
+    rpc_config : Optional["RPCConfig"]
+        The RPC configuration to connect to the remote device.
+        If none, will use local mode.
+    sort_by : Optional[str]
+        Sort results by this key, if None, no sorting.
+    desc : Optional[bool]
+        Whether to sort results in descending order.
+    """
+    results = []
+    for _ in range(sample_number):
+        dym_var_sample = dym_var_sample_func(dym_var_dict)
+        _, median, std = benchmark(
+            mod_or_func,
+            args,
+            dym_var_sample=dym_var_sample,
+            target=target,
+            dev=dev,
+            evaluator_config=evaluator_config,
+            rpc_config=rpc_config,
+        )
+        row = {
+            "InputInfo": ", ".join([f"{k} = {v}" for k, v in dym_var_sample.items()]),
+            "Time(us)": median * 1e6,
+            "Std(us)": std * 1e6,
+        }
+        if relax_func_name is not None:
+            row["RelaxFunc"] = relax_func_name
+        if prim_func_name is not None:
+            row["PrimFunc"] = prim_func_name
+        weight = 1 if weight is None else weight
+        row["Weight"] = weight
+        row["WxTime(ms)"] = weight * median * 1e3
+        results.append(row)
+    print_results(results, sort_by=sort_by, desc=desc)
 
 
 def benchmark_relax_func(
@@ -120,8 +228,8 @@ def benchmark_relax_func(
     ] = default_dym_var_sample_func,
     target: Union[str, tvm.target.Target] = "llvm -num-cores=4",
     dev: tvm.runtime.Device = tvm.cpu(),
-    number=10,
-    repeat=10,
+    evaluator_config: Optional["EvaluatorConfig"] = None,
+    rpc_config: Optional["RPCConfig"] = None,
 ) -> None:
     """Benchmark a relax function with dynamic input shapes.
 
@@ -139,13 +247,15 @@ def benchmark_relax_func(
         The target to be benchmarked on.
     dev : tvm.runtime.Device
         The device to be benchmarked on.
-    number : int
-        The number of times to run the measurement.
-    repeat : int
-        The number of times to repeat the measurement.
+    evaluator_config : Optional["EvaluatorConfig"]
+        The evaluator configuration to use.
+        If none, will use default evaluator configuration.
+    rpc_config : Optional["RPCConfig"]
+        The RPC configuration to connect to the remote device.
     """
+    # extract function information
     relax_funcs, dynamic_var_dict = extract_func_info(mod)
-
+    # find the relax function global var
     if isinstance(relax_func, str):
         for gv in relax_funcs:  # pylint: disable=invalid-name
             if get_func_name_from_gv(gv) == relax_func:
@@ -153,9 +263,11 @@ def benchmark_relax_func(
                 break
         if not isinstance(relax_func, tvm.ir.GlobalVar):
             raise ValueError(f"Cannot find relax function with name {relax_func}")
+    # benchmark
     for _ in range(sample_number):
         dym_var_sample = dym_var_sample_func(dynamic_var_dict[relax_func])
         bench_results = []
+        # enumerate all functors
         for functor in relax_funcs[relax_func]:
             for args, weight in relax_funcs[relax_func][functor]:
                 _, median, _ = benchmark(
@@ -164,8 +276,8 @@ def benchmark_relax_func(
                     dym_var_sample,
                     target=target,
                     dev=dev,
-                    number=number,
-                    repeat=repeat,
+                    evaluator_config=evaluator_config,
+                    rpc_config=rpc_config,
                 )
                 bench_results.append(
                     {

--- a/python/tvm/dlight/benchmark/bench.py
+++ b/python/tvm/dlight/benchmark/bench.py
@@ -28,7 +28,7 @@ from tvm.meta_schedule.testing.tune_utils import generate_input_data
 from tvm.testing import rpc_run
 
 
-from .extract import extract_func_info_from_relax
+from .extract import extract_all_func_info_from_relax, extract_func_info_from_prim_func
 from .utils import (
     populuate_input_shape,
     default_dym_var_sample_func,
@@ -43,10 +43,11 @@ if TYPE_CHECKING:
 
 def benchmark(
     mod_or_func: Union[PrimFunc, IRModule],
-    args: List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]],
+    *,
     dym_var_sample: Dict[str, int],
-    target: Union[str, tvm.target.Target] = "llvm -num-cores=4",
-    dev: tvm.runtime.Device = tvm.cpu(),
+    args: Optional[List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]]],
+    target: Optional[Union[str, tvm.target.Target]] = None,
+    func_name: Optional[str] = None,
     evaluator_config: Optional["EvaluatorConfig"] = None,
     rpc_config: Optional["RPCConfig"] = None,
 ) -> Tuple[List[Tuple[Tuple[int, ...], str]], float, float]:
@@ -56,14 +57,15 @@ def benchmark(
     ----------
     mod_or_func : Union[PrimFunc, IRModule]
         The PrimFunc or IRModule to be benchmarked.
-    args : List[relax.TensorStructInfo]
-        The input tensor information, including shape and dtype.
-    dym_var_sample : Dict[Union[relax.expr.Call, str], int]
-        The dynamic shape variable sample, e.g., {n: 64, m: 128}.
-    target : Union[str, tvm.target.Target]
-        The target to be benchmarked on.
-    dev : tvm.runtime.Device
-        The device to be benchmarked on.
+    dym_var_sample : Optional[Dict[str, int]]
+        The dynamic shape variable sample, e.g., {"n": 64, "m": 128}.
+    args : Optional[List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]]]
+        The input tensor information, including shape and dtype. If none, will use
+        the input information from the PrimFunc or IRModule.
+    target : Optional[Union[str, tvm.target.Target]]
+        The target to be benchmarked on, if none, will get the target from context.
+    func_name : Optional[str]
+        The name of the function to be benchmarked, will use "main" by default if a PrimFunc is given.
     evaluator_config : Optional["EvaluatorConfig"]
         The evaluator configuration to use.
         If none, will use default evaluator configuration.
@@ -82,14 +84,23 @@ def benchmark(
     """
     # produce IRModule and function name
     if isinstance(mod_or_func, PrimFunc):
-        mod = IRModule.from_expr(mod_or_func.with_attr("global_symbol", "main"))
-        func_name = "main"
+        func_name = "main" if func_name is None else func_name
+        mod = IRModule.from_expr(mod_or_func.with_attr("global_symbol", func_name))
     else:
         mod = mod_or_func
         # assume only one global function
         (func_name,) = mod.get_global_vars()
-    # produce target
-    target = tvm.target.Target(target)
+    # produce input shapes
+    if args is None:
+        args, _ = extract_func_info_from_prim_func(mod[func_name])
+    # produce target & device
+    target = tvm.target.Target.current() if target is None else tvm.target.Target(target)
+    if target.kind.name == "llvm":
+        dev = tvm.cpu()
+    elif target.kind.name == "cuda":
+        dev = tvm.cuda()
+    else:
+        raise ValueError(f"Unsupported device type from {target.kind.name}")
     # populate input shapes
     input_infos = populuate_input_shape(args, dym_var_sample)
     # generate input tensors, including scalars
@@ -110,7 +121,6 @@ def benchmark(
     input_tensors.extend(scalar_input_tensors)
     # build locally
     rt_mod = tvm.build(mod, target=target)
-
     # set up evaluator config
     evaluator_config = EvaluatorConfig._normalized(  # pylint: disable=protected-access
         evaluator_config
@@ -141,12 +151,14 @@ def benchmark(
 
 def benchmark_prim_func(
     mod_or_func: Union[PrimFunc, IRModule],
-    args: List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]],
-    dym_var_dict: Dict[str, str],
+    *,
     dym_var_sample_func: Callable[[Dict[str, str]], Dict[str, int]] = default_dym_var_sample_func,
+    args: Optional[
+        List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]]
+    ] = None,
+    dym_var_dict: Optional[Dict[str, str]] = None,
     sample_number: int = 5,
-    target: Union[str, tvm.target.Target] = "llvm -num-cores=4",
-    dev: tvm.runtime.Device = tvm.cpu(),
+    target: Optional[Union[str, tvm.target.Target]] = None,
     weight: Optional[int] = 1,
     relax_func_name: Optional[str] = None,
     prim_func_name: Optional[str] = None,
@@ -161,18 +173,18 @@ def benchmark_prim_func(
     ----------
     mod_or_func : Union[PrimFunc, IRModule]
         The PrimFunc or IRModule to be benchmarked.
-    args : List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]]
-        The input tensor information, including shape and dtype.
-    dym_var_dict : Dict[str, str]
-        Dynamic shape variable dictionary, e.g., {"n": "int32", "m": "int32"}
     dym_var_sample_func : Callable[[Dict[str, str]], Dict[str, int]]
         The function to sample dynamic shape variables.
+    dym_var_dict : Optional[Dict[str, str]]
+        Dynamic shape variable dictionary, e.g., {"n": "int32", "m": "int32"}. If none, will use
+        the input information from the PrimFunc or IRModule.
+    args : Optional[List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]]]
+        The input tensor information, including shape and dtype. If none, will use
+        the input information from the PrimFunc or IRModule.
     sample_number : int
         The number of times to sample dynamic shape variables.
-    target : Union[str, tvm.target.Target]
-        The target to be benchmarked on.
-    dev : tvm.runtime.Device
-        The device to be benchmarked on.
+    target: Optional[Union[str, tvm.target.Target]]
+        The target to be benchmarked on, if none, will get the target from context.
     weight : Optional[int]
         The weight of this PrimFunc.
     relax_func_name : Optional[str]
@@ -191,14 +203,15 @@ def benchmark_prim_func(
         Whether to sort results in descending order.
     """
     results = []
+    if dym_var_dict is None or args is None:
+        args, dym_var_dict = extract_func_info_from_prim_func(mod_or_func)
     for _ in range(sample_number):
         dym_var_sample = dym_var_sample_func(dym_var_dict)
         _, median, std = benchmark(
             mod_or_func,
-            args,
+            args=args,
             dym_var_sample=dym_var_sample,
             target=target,
-            dev=dev,
             evaluator_config=evaluator_config,
             rpc_config=rpc_config,
         )
@@ -254,7 +267,7 @@ def benchmark_relax_func(
         The RPC configuration to connect to the remote device.
     """
     # extract function information
-    relax_funcs, dynamic_var_dict = extract_func_info_from_relax(mod)
+    relax_funcs, dynamic_var_dict = extract_all_func_info_from_relax(mod)
     # find the relax function global var
     if isinstance(relax_func, str):
         for gv in relax_funcs:  # pylint: disable=invalid-name
@@ -275,10 +288,9 @@ def benchmark_relax_func(
             for args, weight in relax_funcs[relax_func][functor]:
                 _, median, _ = benchmark(
                     mod[functor],
-                    args,
-                    dym_var_sample,
+                    args=args,
+                    dym_var_sample=dym_var_sample,
                     target=target,
-                    dev=dev,
                     evaluator_config=evaluator_config,
                     rpc_config=rpc_config,
                 )

--- a/python/tvm/dlight/benchmark/bench.py
+++ b/python/tvm/dlight/benchmark/bench.py
@@ -28,7 +28,7 @@ from tvm.meta_schedule.testing.tune_utils import generate_input_data
 from tvm.testing import rpc_run
 
 
-from .extract import extract_func_info
+from .extract import extract_func_info_from_relax
 from .utils import (
     populuate_input_shape,
     default_dym_var_sample_func,
@@ -254,7 +254,7 @@ def benchmark_relax_func(
         The RPC configuration to connect to the remote device.
     """
     # extract function information
-    relax_funcs, dynamic_var_dict = extract_func_info(mod)
+    relax_funcs, dynamic_var_dict = extract_func_info_from_relax(mod)
     # find the relax function global var
     if isinstance(relax_func, str):
         for gv in relax_funcs:  # pylint: disable=invalid-name

--- a/python/tvm/dlight/benchmark/bench.py
+++ b/python/tvm/dlight/benchmark/bench.py
@@ -95,7 +95,9 @@ def benchmark(
         args, _ = extract_func_info_from_prim_func(mod[func_name])
     # produce target & device
     target = tvm.target.Target.current() if target is None else tvm.target.Target(target)
-    if target.kind.name == "llvm":
+    if target is None:
+        raise ValueError("Target is not specified")
+    elif target.kind.name == "llvm":
         dev = tvm.cpu()
     elif target.kind.name == "cuda":
         dev = tvm.cuda()

--- a/python/tvm/dlight/benchmark/bench.py
+++ b/python/tvm/dlight/benchmark/bench.py
@@ -65,7 +65,7 @@ def benchmark(
     target : Optional[Union[str, tvm.target.Target]]
         The target to be benchmarked on, if none, will get the target from context.
     func_name : Optional[str]
-        The name of the function to be benchmarked, will use "main" by default if a PrimFunc is given.
+        The name of the function to be benchmarked, will use "main" by default.
     evaluator_config : Optional["EvaluatorConfig"]
         The evaluator configuration to use.
         If none, will use default evaluator configuration.
@@ -97,7 +97,7 @@ def benchmark(
     target = tvm.target.Target.current() if target is None else tvm.target.Target(target)
     if target is None:
         raise ValueError("Target is not specified")
-    elif target.kind.name == "llvm":
+    if target.kind.name == "llvm":
         dev = tvm.cpu()
     elif target.kind.name == "cuda":
         dev = tvm.cuda()
@@ -242,7 +242,6 @@ def benchmark_relax_func(
         Dict[str, int],
     ] = default_dym_var_sample_func,
     target: Union[str, tvm.target.Target] = "llvm -num-cores=4",
-    dev: tvm.runtime.Device = tvm.cpu(),
     evaluator_config: Optional["EvaluatorConfig"] = None,
     rpc_config: Optional["RPCConfig"] = None,
 ) -> None:

--- a/python/tvm/dlight/benchmark/extract.py
+++ b/python/tvm/dlight/benchmark/extract.py
@@ -298,9 +298,9 @@ def extract_prim_func(  # pylint: disable=too-many-arguments
             if dym_var_dict is not None
             else "None",
             "input_args": f"pickle.loads({cloudpickle.dumps(func_args)})" if func_args else "None",
-            "dym_var_sample_func": f"pickle.loads({
-                cloudpickle.dumps(default_dym_var_sample_func)
-            })",
+            "dym_var_sample_func": "pickle.loads("
+            + f"{cloudpickle.dumps(default_dym_var_sample_func)}"
+            + ")",
             "func_script": func.script(),
             "target": target_str,
         }

--- a/python/tvm/dlight/benchmark/extract.py
+++ b/python/tvm/dlight/benchmark/extract.py
@@ -31,14 +31,13 @@ import tvm
 from tvm import relax
 from tvm.script import tir as T
 
-from mlc_bench.benchmark import MLCBench
+from tvm.dlight.bench import benchmark_prim_func
 
 MODEL_NAME = "{model_name}"
 RELAX_FUNC_NAME = "{relax_func_name}"
 PRIM_FUNC_NAME = "{prim_func_name}"
 FUNC_HASH = {func_hash}
 WEIGHT = {weight}
-CAT = {category}
 SAMPLE_NUMBER = {sample_number}
 
 INPUT_ARGS = pickle.loads({input_args})
@@ -48,33 +47,21 @@ DYM_VAR_DICT = pickle.loads({dym_var_dict})
 {func_script}
 
 if __name__ == "__main__":
-    bench = MLCBench()
     target = tvm.target.Target("{target}")
     dev = {dev}
     print("Input args:", INPUT_ARGS)
-    for _ in range(SAMPLE_NUMBER):
-        dym_var_sample = DYM_VAR_SAMPLE_FUNC(DYM_VAR_DICT)
-        input_infos, median, std = bench.benchmark(
-            main,
-            INPUT_ARGS,
-            dym_var_sample=dym_var_sample,
-            target=target,
-            dev=dev,
-        )
-        bench.record(
-            {{
-                "RelaxFunc": RELAX_FUNC_NAME,
-                "PrimFunc": PRIM_FUNC_NAME,
-                "InputInfo": ", ".join(
-                    [f"{{k}} = {{v}}" for k, v in dym_var_sample.items()]
-                ),
-                "Time(us)": median*1e6,
-                "Std(us)": std*1e6,
-                "Weight": WEIGHT,
-                "WxTime(ms)": WEIGHT*median*1e3,
-            }}
-        )
-    bench.show()
+    benchmark_prim_func(
+        main,
+        args=INPUT_ARGS,
+        dym_var_dict=DYM_VAR_DICT,
+        dym_var_sample_func=DYM_VAR_SAMPLE_FUNC,
+        sample_number=SAMPLE_NUMBER,
+        target=target,
+        dev = dev,
+        weight = WEIGHT,
+        relax_func_name = RELAX_FUNC_NAME,
+        prim_func_name = PRIM_FUNC_NAME,
+    )
 """
 
 

--- a/python/tvm/dlight/benchmark/extract.py
+++ b/python/tvm/dlight/benchmark/extract.py
@@ -298,7 +298,9 @@ def extract_prim_func(  # pylint: disable=too-many-arguments
             if dym_var_dict is not None
             else "None",
             "input_args": f"pickle.loads({cloudpickle.dumps(func_args)})" if func_args else "None",
-            "dym_var_sample_func": f"pickle.loads({cloudpickle.dumps(default_dym_var_sample_func)})",
+            "dym_var_sample_func": f"pickle.loads({
+                cloudpickle.dumps(default_dym_var_sample_func)
+            })",
             "func_script": func.script(),
             "target": target_str,
         }

--- a/python/tvm/dlight/benchmark/extract.py
+++ b/python/tvm/dlight/benchmark/extract.py
@@ -276,6 +276,8 @@ def extract_prim_func(  # pylint: disable=too-many-arguments
     if target is None:
         target = tvm.target.Target.current()
         target_str = str(target)
+        if target is None:
+            raise ValueError("Target is not specified.")
     elif isinstance(target, str):
         target_str = target
         target = tvm.target.Target(target)
@@ -303,7 +305,12 @@ def extract_prim_func(  # pylint: disable=too-many-arguments
     )
 
 
-def extract_from_relax(mod: tvm.ir.IRModule, model_name: str, file_path: str) -> None:
+def extract_from_relax(
+    mod: tvm.ir.IRModule,
+    model_name: str,
+    file_path: str,
+    target: Optional[Union[str, tvm.target.Target]] = None,
+) -> None:
     """Extract self-contained PrimFunc test files from a Relax module.
 
     Parameters
@@ -314,6 +321,8 @@ def extract_from_relax(mod: tvm.ir.IRModule, model_name: str, file_path: str) ->
         The name of the model.
     file_path: str
         The path to store the extracted files.
+    target: Optional[Union[str, tvm.target.Target]]
+        The target device to run the PrimFunc. If None, will use target from the context.
     """
     relax_funcs, dym_var_dict = extract_all_func_info_from_relax(mod)
     Path(file_path).mkdir(parents=True, exist_ok=True)
@@ -334,6 +343,7 @@ def extract_from_relax(mod: tvm.ir.IRModule, model_name: str, file_path: str) ->
                             dym_var_dict=dym_var_dict[relax_func_gv],
                             func_args=func_args,
                             weight=weight,
+                            target=target,
                         ),
                         file=file,
                     )

--- a/python/tvm/dlight/benchmark/extract.py
+++ b/python/tvm/dlight/benchmark/extract.py
@@ -278,7 +278,7 @@ def extract_from_relax(mod: tvm.ir.IRModule, model_name: str, file_path: str) ->
     """
     relax_funcs, dym_var_dict = extract_func_info(mod)
     Path(file_path).mkdir(parents=True, exist_ok=True)
-    for relax_func_gv in relax_funcs.items():
+    for relax_func_gv in relax_funcs:  # pylint: disable=consider-using-dict-items
         relax_func_name = get_func_name_from_gv(relax_func_gv)
         for prim_func_gv in relax_funcs[relax_func_gv]:
             prim_func_name = get_func_name_from_gv(prim_func_gv)

--- a/python/tvm/dlight/benchmark/extract.py
+++ b/python/tvm/dlight/benchmark/extract.py
@@ -1,0 +1,286 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Performance debug tool for dynamic shape workloads"""
+
+from typing import List, Dict, Union, Tuple, Iterator
+from pathlib import Path
+
+import cloudpickle
+
+import tvm
+from tvm import relax
+from .utils import default_dym_var_sample_func, get_func_name_from_gv
+
+SKETCH = """import pickle
+
+import tvm
+from tvm import relax
+from tvm.script import tir as T
+
+from mlc_bench.benchmark import MLCBench
+
+MODEL_NAME = "{model_name}"
+RELAX_FUNC_NAME = "{relax_func_name}"
+PRIM_FUNC_NAME = "{prim_func_name}"
+FUNC_HASH = {func_hash}
+WEIGHT = {weight}
+CAT = {category}
+SAMPLE_NUMBER = {sample_number}
+
+INPUT_ARGS = pickle.loads({input_args})
+DYM_VAR_SAMPLE_FUNC = pickle.loads({dym_var_sample_func})
+DYM_VAR_DICT = pickle.loads({dym_var_dict})
+
+{func_script}
+
+if __name__ == "__main__":
+    bench = MLCBench()
+    target = tvm.target.Target("{target}")
+    dev = {dev}
+    print("Input args:", INPUT_ARGS)
+    for _ in range(SAMPLE_NUMBER):
+        dym_var_sample = DYM_VAR_SAMPLE_FUNC(DYM_VAR_DICT)
+        input_infos, median, std = bench.benchmark(
+            main,
+            INPUT_ARGS,
+            dym_var_sample=dym_var_sample,
+            target=target,
+            dev=dev,
+        )
+        bench.record(
+            {{
+                "RelaxFunc": RELAX_FUNC_NAME,
+                "PrimFunc": PRIM_FUNC_NAME,
+                "InputInfo": ", ".join(
+                    [f"{{k}} = {{v}}" for k, v in dym_var_sample.items()]
+                ),
+                "Time(us)": median*1e6,
+                "Std(us)": std*1e6,
+                "Weight": WEIGHT,
+                "WxTime(ms)": WEIGHT*median*1e3,
+            }}
+        )
+    bench.show()
+"""
+
+
+def extract_shape(
+    arg: Union[Tuple, List, relax.Tuple, relax.ShapeStructInfo]
+) -> List[relax.ShapeStructInfo]:
+    """Extract shape information from a relax argument.
+
+    Parameters
+    ----------
+    arg : Union[Tuple, List, relax.Tuple, relax.ShapeStructInfo]
+        The relax argument to be extracted.
+
+    Returns
+    -------
+    result : List[relax.ShapeStructInfo]
+        The extracted shape information.
+    """
+    if isinstance(arg, (tuple, list, tvm.relax.Tuple)):
+        results = []
+        for sub_arg in arg:
+            results.extend(extract_shape(sub_arg))
+        return results
+    else:
+        return [arg.struct_info]
+
+
+def prim_func_usage_gen(
+    mod: tvm.ir.IRModule,
+) -> Iterator[Tuple[tvm.ir.GlobalVar, tvm.ir.GlobalVar, List[relax.ShapeStructInfo]]]:
+    """Generate the usage of prim functions in a relax module.
+
+    Parameters
+    ----------
+    mod : tvm.ir.IRModule
+        The relax module to be analyzed.
+
+    Yields
+    ------
+    result : Tuple[tvm.ir.GlobalVar, tvm.ir.GlobalVar, List[relax.ShapeStructInfo]]
+        The usage of prim functions in a relax module.
+    """
+    for gv, func in mod.functions.items():  # pylint: disable=invalid-name
+        if isinstance(func, tvm.relax.Function):
+            for block in func.body.blocks:
+                for binding in block.bindings:
+                    if isinstance(binding.value, tvm.relax.expr.Call):
+                        raw_args = binding.value.args
+                        functor = raw_args[0]
+                        if isinstance(functor, tvm.ir.GlobalVar):
+                            if isinstance(mod.functions[functor], tvm.tir.PrimFunc):
+                                args = extract_shape(raw_args[1:]) + extract_shape(binding.value)
+                                yield gv, functor, args
+
+
+def extract_dynamic_var(
+    func_dict: Dict,
+) -> Dict[tvm.ir.GlobalVar, Dict[str, str]]:
+    """Extract dynamic shape variables from a relax function dictionary."""
+    dym_var_dict: Dict[tvm.ir.GlobalVar, Dict[str, str]] = {}
+    for gv in func_dict:  # pylint: disable=invalid-name
+        dym_var_dict[gv] = {}
+        for functor in func_dict[gv]:
+            for arg_list, _ in func_dict[gv][functor]:
+                for arg in arg_list:
+                    if isinstance(arg, tvm.relax.TensorStructInfo):
+                        for v in arg.shape.values:
+                            if isinstance(v, tvm.tir.Var):
+                                dym_var_dict[gv][str(v)] = v.dtype
+                    elif isinstance(arg, tvm.relax.ShapeStructInfo):
+                        for v in arg.values:
+                            if isinstance(v, tvm.tir.Var):
+                                dym_var_dict[gv][str(v)] = v.dtype
+                    else:
+                        raise NotImplementedError
+    return dym_var_dict
+
+
+def extract_func_info(
+    mod: tvm.ir.IRModule,
+) -> Tuple[
+    Dict[tvm.ir.GlobalVar, Dict[tvm.ir.GlobalVar, List[Tuple[List, int]]]],
+    Dict[tvm.ir.GlobalVar, Dict[str, str]],
+]:
+    """Extract function information from a relax module."""
+
+    def update_records(records, new_args):
+        for i, (args, count) in enumerate(records):
+            if new_args == args:
+                records[i] = (args, count + 1)
+                return
+        records.append((new_args, 1))
+
+    relax_func_dict: Dict[tvm.ir.GlobalVar, Dict[tvm.ir.GlobalVar, List[Tuple[List, int]]]] = {}
+    for gv, functor, args in prim_func_usage_gen(mod):  # pylint: disable=invalid-name
+        if isinstance(functor, tvm.ir.GlobalVar):
+            if not gv in relax_func_dict:
+                relax_func_dict[gv] = {}
+            if not functor in relax_func_dict[gv]:
+                relax_func_dict[gv][functor] = []
+            update_records(relax_func_dict[gv][functor], args)
+
+    dym_var_dict = extract_dynamic_var(relax_func_dict)
+    return relax_func_dict, dym_var_dict
+
+
+def extract_prim_func(
+    model_name: str,
+    relax_func_name: str,
+    prim_func_name: str,
+    func: tvm.tir.PrimFunc,
+    func_args: List[Tuple[tvm.relax.expr.Call, str]],
+    dym_var_dict: Dict[str, str],
+    weight: int,
+    file_path: str,
+    sample_number: int = 5,
+    target: Union[str, tvm.target.Target] = "llvm -num-cores=4",
+) -> None:
+    """Extract a self-contained PrimFunc test file from a Relax module.
+
+    Parameters
+    ----------
+    model_name: str
+        The name of the model.
+    relax_func_name: str
+        The name of the Relax function.
+    prim_func_name: str
+        The name of the prim function.
+    func: tvm.tir.PrimFunc
+        The name of the prim function to be extracted.
+    func_args: List[Tuple[tvm.relax.expr.Call, str]]
+        The arguments of the prim function, including both static and dynamic shape arguments.
+        Given in format [ ..., ((1, n, 128), "float32"), ... ].
+    dym_var_dict: Dict[str, str]
+        The dictionary of dynamic shape variables. Given in format {"n": "int32", "m": "int32"}.
+    weight: int
+        The weight of the prim function.
+    file_path: str
+        The path to store the extracted file.
+    sample_number: int
+        The number of times to sample dynamic shape variables.
+    """
+    if isinstance(target, str):
+        target_str = target
+        target = tvm.target.Target(target)
+    elif isinstance(target, tvm.target.Target):
+        target_str = str(target)
+    else:
+        raise TypeError("Unsupported target type: " + str(type(target)))
+
+    if target.kind.name == "cuda":
+        dev_str = "tvm.cuda()"
+    elif target.kind.name == "llvm":
+        dev_str = "tvm.cpu()"
+    else:
+        raise NotImplementedError("Only support cuda and llvm runtime device.")
+
+    file = open(file_path, "w")
+
+    print(
+        SKETCH.format(
+            **{
+                "model_name": model_name,
+                "relax_func_name": relax_func_name,
+                "prim_func_name": prim_func_name,
+                "func_hash": tvm.ir.structural_hash(func),
+                "weight": weight,
+                "sample_number": sample_number,
+                "dym_var_dict": cloudpickle.dumps(dym_var_dict),
+                "input_args": cloudpickle.dumps(func_args),
+                "dym_var_sample_func": cloudpickle.dumps(default_dym_var_sample_func),
+                "func_script": func.script(),
+                "target": target_str,
+                "dev": dev_str,
+            }
+        ),
+        file=file,
+    )
+
+
+def extract_from_relax(mod: tvm.ir.IRModule, model_name: str, file_path: str) -> None:
+    """Extract self-contained PrimFunc test files from a Relax module.
+
+    Parameters
+    ----------
+    mod: tvm.ir.IRModule
+        The Relax module to be extracted.
+    model_name: str
+        The name of the model.
+    file_path: str
+        The path to store the extracted files.
+    """
+    relax_funcs, dym_var_dict = extract_func_info(mod)
+    Path(file_path).mkdir(parents=True, exist_ok=True)
+    for relax_func_gv in relax_funcs:
+        relax_func_name = get_func_name_from_gv(relax_func_gv)
+        for prim_func_gv in relax_funcs[relax_func_gv]:
+            prim_func_name = get_func_name_from_gv(prim_func_gv)
+            for func_args, weight in relax_funcs[relax_func_gv][prim_func_gv]:
+                extract_prim_func(
+                    model_name=model_name,
+                    relax_func_name=relax_func_name,
+                    prim_func_name=prim_func_name,
+                    func=mod[prim_func_gv],
+                    dym_var_dict=dym_var_dict[relax_func_gv],
+                    func_args=func_args,
+                    weight=weight,
+                    file_path=f"{file_path}/{relax_func_name}_{prim_func_name}.py",
+                )

--- a/python/tvm/dlight/benchmark/utils.py
+++ b/python/tvm/dlight/benchmark/utils.py
@@ -1,0 +1,149 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Util functions for benchmarking dynamic shape workloads"""
+
+from typing import Dict, List, Tuple, Union, Any
+
+import tvm
+from tvm import relax
+
+INPUT_SHAPE_TYPE = List[Tuple[Tuple[int, ...], str]]  # pylint: disable=invalid-name
+
+
+def get_func_name_from_gv(gv: tvm.ir.GlobalVar) -> str:  # pylint: disable=invalid-name
+    """Get function name from a global variable.
+
+    Parameters
+    ----------
+    gv : tvm.ir.GlobalVar
+        The given global variable.
+
+    Returns
+    -------
+    result : str
+        The global variable name without the prefix "...@".
+    """
+    return gv.astext().split("@")[1] if "@" in gv.astext() else gv.astext()
+
+
+def dym_var_sample_str(sample: Dict[Union[str, tvm.relax.expr.Call], int]) -> str:
+    """Convert a variable value sample to a string.
+
+    Parameters
+    ----------
+    sample : Dict[Union[str, tvm.relax.expr.Call], int]
+        Variable value sample, e.g., {n: 64, m: 128} or {"n": 64, "m": 128}
+
+    Returns
+    -------
+    result : str
+        Variable value sample string, e.g., "n=64, m=128"
+    """
+    return ", ".join([f"{k}={v}" for k, v in sample.items()])
+
+
+def populuate_input_shape(
+    input_infos: List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]],
+    dym_var_sample: Dict[str, int],
+) -> INPUT_SHAPE_TYPE:
+    """
+    Populate input shapes with dynamic shape variable samples.
+
+    Parameters
+    ----------
+    input_infos : List[Union[relax.TensorStructInfo, Tuple[Tuple[Union[int, str], ...], str]]]
+        Input tensor information, including shape and dtype,
+        e.g., [..., Shape(1, n, 128) with dtype="int32", ...]
+    dym_var_sample : Dict[str, int]
+        Dynamic shape variable sample, e.g., {"n": 64}
+
+    Returns
+    -------
+    results : INPUT_SHAPE_TYPE
+        Input shapes with dynamic shape variable samples, e.g.,
+        [..., ((1, 64, 128), "int32"), ...] if n=64 or
+        [..., (128, "scalar"), ...] if n=128 for scalar input
+    """
+    results: INPUT_SHAPE_TYPE = []
+    for input_info in input_infos:
+        shape = []
+        if isinstance(input_info, relax.struct_info.ShapeStructInfo):
+            # scalar input
+            results.append(((dym_var_sample[str(input_info.values[0])],), "scalar"))
+        else:
+            if isinstance(input_info, relax.TensorStructInfo):
+                tensor_shape = input_info.shape
+                tensor_dtype = input_info.dtype
+            else:
+                tensor_shape, tensor_dtype = input_info  # type: ignore
+            for dim in tensor_shape:
+                if isinstance(dim, int):
+                    shape.append(dim)
+                elif isinstance(dim, tvm.tir.IntImm):
+                    shape.append(dim.value)
+                else:
+                    shape.append(dym_var_sample[str(dim)])
+            results.append(((*shape,), tensor_dtype))
+    return results
+
+
+def default_dym_var_sample_func(dym_var_dict: Dict[str, str]) -> Dict[str, int]:
+    """
+    Default dynamic shape variable sample function.
+    Sample a random value for each dynamic shape variable.
+
+    Parameters
+    ----------
+    dym_var_dict : Dict[str, str]
+        Dynamic shape variable dictionary, e.g., {"n": "int32", "m": "int32"}
+
+    Returns
+    -------
+    result : Dict[str, int]
+        Dynamic shape variable sample, e.g., {"n": 64, "m": 128}
+    """
+    results = {}
+    for var in dym_var_dict:
+        if dym_var_dict[var] in ["int32", "int64"]:
+            import random  # pylint: disable=import-outside-toplevel
+
+            results[var] = random.randint(2, 128)
+        else:
+            raise TypeError("Unsupported dynamic shape variable type: " + dym_var_dict[var])
+    return results
+
+
+def print_results(bench_results: List[Dict[str, Any]], sort_by: str = "WxTime(ms)"):
+    """Print benchmark results.
+
+    Parameters
+    ----------
+    bench_results : List[Dict[str, Any]]
+        Benchmark results as dictionary list.
+    sort_by : str
+        Sort results by this key, descending.
+    """
+    import pandas as pd  # pylint: disable=import-outside-toplevel
+
+    df = pd.DataFrame()  # pylint: disable=invalid-name
+    for record in bench_results:
+        df.append(
+            record,
+            ignore_index=True,
+        )
+    print(df.sort_values(sort_by, ascending=False).reset_index().drop("index", axis=1))
+    print("\n")

--- a/python/tvm/dlight/benchmark/utils.py
+++ b/python/tvm/dlight/benchmark/utils.py
@@ -142,18 +142,31 @@ def print_results(
         Whether to sort results in descending order.
     """
     # pylint: disable=invalid-name, import-outside-toplevel
-    import pandas as pd
+    try:
+        import pandas as pd
 
-    df = pd.DataFrame()
-    for record in bench_results:
-        df = pd.concat(
-            [df, pd.DataFrame(record, index=[0])],
-            ignore_index=True,
-        )
-    if sort_by is not None:
-        if sort_by not in df.columns:
-            raise ValueError(f"sort_by key {sort_by} not in benchmark results")
-        df = df.sort_values(sort_by, ascending=not desc).reset_index().drop("index", axis=1)
-    print(df)
+        df = pd.DataFrame()
+        for record in bench_results:
+            df = pd.concat(
+                [df, pd.DataFrame(record, index=[0])],
+                ignore_index=True,
+            )
+        if sort_by is not None:
+            if sort_by not in df.columns:
+                raise ValueError(f"sort_by key {sort_by} not in benchmark results")
+            df = df.sort_values(sort_by, ascending=not desc).reset_index().drop("index", axis=1)
+        print(df)
+    except ModuleNotFoundError:
+        print("Pandas not found, printing results in raw format.")
+        keys = []
+        if len(bench_results) > 0:
+            for key in bench_results[0]:
+                keys.append(str(key))
+        print("\t".join(keys))
+        for record in bench_results:
+            values = []
+            for key in keys:
+                values.append(str(record[key]))
+            print("\t".join(values))
     print("\n")
     # pylint: enable=invalid-name, import-outside-toplevel

--- a/python/tvm/dlight/benchmark/utils.py
+++ b/python/tvm/dlight/benchmark/utils.py
@@ -127,7 +127,9 @@ def default_dym_var_sample_func(dym_var_dict: Dict[str, str]) -> Dict[str, int]:
     return results
 
 
-def print_results(bench_results: List[Dict[str, Any]], sort_by: str = "WxTime(ms)"):
+def print_results(
+    bench_results: List[Dict[str, Any]], sort_by: str = "WxTime(ms)", desc: bool = True
+):
     """Print benchmark results.
 
     Parameters
@@ -135,15 +137,23 @@ def print_results(bench_results: List[Dict[str, Any]], sort_by: str = "WxTime(ms
     bench_results : List[Dict[str, Any]]
         Benchmark results as dictionary list.
     sort_by : str
-        Sort results by this key, descending.
+        Sort results by this key, if None, no sorting.
+    desc : bool
+        Whether to sort results in descending order.
     """
-    import pandas as pd  # pylint: disable=import-outside-toplevel
+    # pylint: disable=invalid-name, import-outside-toplevel
+    import pandas as pd
 
-    df = pd.DataFrame()  # pylint: disable=invalid-name
+    df = pd.DataFrame()
     for record in bench_results:
-        df.append(
-            record,
+        df = pd.concat(
+            [df, pd.DataFrame(record, index=[0])],
             ignore_index=True,
         )
-    print(df.sort_values(sort_by, ascending=False).reset_index().drop("index", axis=1))
+    if sort_by is not None:
+        if sort_by not in df.columns:
+            raise ValueError(f"sort_by key {sort_by} not in benchmark results")
+        df = df.sort_values(sort_by, ascending=not desc).reset_index().drop("index", axis=1)
+    print(df)
     print("\n")
+    # pylint: enable=invalid-name, import-outside-toplevel

--- a/python/tvm/meta_schedule/testing/tune_utils.py
+++ b/python/tvm/meta_schedule/testing/tune_utils.py
@@ -18,7 +18,6 @@
 from typing import Callable, Optional, Union, List, Dict
 from statistics import median
 import json
-import warnings
 import numpy as np  # type: ignore
 
 import tvm

--- a/python/tvm/meta_schedule/testing/tune_utils.py
+++ b/python/tvm/meta_schedule/testing/tune_utils.py
@@ -48,10 +48,6 @@ def generate_input_data(
     """
     if input_dtype.startswith("float"):
         return np.random.uniform(size=input_shape).astype(input_dtype)
-    if low is None or high is None:
-        warnings.warn(
-            f"Model input value range for shape {input_shape} of {input_dtype} is not set!"
-        )
     range_map = {
         "uint8": (0, 255),
         "int8": (-128, 127),

--- a/tests/python/dlight/test_benchmark.py
+++ b/tests/python/dlight/test_benchmark.py
@@ -15,113 +15,177 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-docstring
-import pytest
 
-import tvm.testing
-from tvm.dlight.benchmark import benchmark
 from tvm.script import tir as T
+from tvm import meta_schedule as ms
+from tvm.meta_schedule.testing.local_rpc import LocalRPC
 
+from tvm.dlight.benchmark import benchmark, benchmark_prim_func
+import tvm.testing
 
-def test_benchmark_prim_func():
-    # fmt: off
-    @T.prim_func
-    def before(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(4096)), "float32"), var_matmul: T.handle):
-        m = T.int64()
-        inp0 = T.match_buffer(var_inp0, (T.int64(1), m, T.int64(4096)))
-        matmul = T.match_buffer(var_matmul, (T.int64(1), m, T.int64(4096)))
-        for i0, i1, i2, k in T.grid(T.int64(1), m, T.int64(4096), T.int64(4096)):
-            with T.block("matmul"):
-                v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
-                with T.init():
-                    matmul[v_i0, v_i1, v_i2] = T.float32(0)
-                matmul[v_i0, v_i1, v_i2] = matmul[v_i0, v_i1, v_i2] + inp0[v_i0, v_i1, v_k] * inp1[v_k, v_i2]
-
-    @T.prim_func
-    def expected(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(4096)), "float32"), var_matmul: T.handle):
-        T.func_attr({"tir.is_scheduled": 1})
-        m = T.int64()
-        inp0 = T.match_buffer(var_inp0, (T.int64(1), m, T.int64(4096)))
-        matmul = T.match_buffer(var_matmul, (T.int64(1), m, T.int64(4096)))
-        # with T.block("root"):
-        matmul_reindex_pad_local = T.alloc_buffer((T.int64(1), (m + T.int64(31)) // T.int64(32) * T.int64(32), T.int64(4096)), scope="local")
-        inp0_reindex_pad_shared = T.alloc_buffer((T.int64(1), (m + T.int64(31)) // T.int64(32) * T.int64(32), T.int64(4096)), scope="shared")
-        inp1_reindex_shared = T.alloc_buffer((T.int64(1), T.int64(4096), T.int64(4096)), scope="shared")
-        for ax0 in T.thread_binding(T.int64(1), thread="blockIdx.z"):
-            for ax1_0 in T.thread_binding((m + T.int64(31)) // T.int64(32), thread="blockIdx.x"):
-                for ax2_0 in T.thread_binding(T.int64(64), thread="blockIdx.y"):
-                    for ax2_1 in T.thread_binding(T.int64(1), thread="vthread.y"):
-                        for ax1_1 in T.thread_binding(T.int64(1), thread="vthread.x"):
-                            for ax2_2 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
-                                for ax1_2 in T.thread_binding(T.int64(8), thread="threadIdx.x", annotations={"pragma_auto_unroll_max_step": 256, "pragma_unroll_explicit": 1}):
-                                    for ax2_3_init, ax1_3_init in T.grid(T.int64(4), T.int64(4)):
-                                        with T.block("matmul_init"):
+# fmt: off
+@T.prim_func
+def cuda_workload(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(4096)), "float32"), var_matmul: T.handle):
+    T.func_attr({"tir.is_scheduled": 1})
+    m = T.int64()
+    inp0 = T.match_buffer(var_inp0, (T.int64(1), m, T.int64(4096)))
+    matmul = T.match_buffer(var_matmul, (T.int64(1), m, T.int64(4096)))
+    # with T.block("root"):
+    matmul_reindex_pad_local = T.alloc_buffer((T.int64(1), (m + T.int64(31)) // T.int64(32) * T.int64(32), T.int64(4096)), scope="local")
+    inp0_reindex_pad_shared = T.alloc_buffer((T.int64(1), (m + T.int64(31)) // T.int64(32) * T.int64(32), T.int64(4096)), scope="shared")
+    inp1_reindex_shared = T.alloc_buffer((T.int64(1), T.int64(4096), T.int64(4096)), scope="shared")
+    for ax0 in T.thread_binding(T.int64(1), thread="blockIdx.z"):
+        for ax1_0 in T.thread_binding((m + T.int64(31)) // T.int64(32), thread="blockIdx.x"):
+            for ax2_0 in T.thread_binding(T.int64(64), thread="blockIdx.y"):
+                for ax2_1 in T.thread_binding(T.int64(1), thread="vthread.y"):
+                    for ax1_1 in T.thread_binding(T.int64(1), thread="vthread.x"):
+                        for ax2_2 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
+                            for ax1_2 in T.thread_binding(T.int64(8), thread="threadIdx.x", annotations={"pragma_auto_unroll_max_step": 256, "pragma_unroll_explicit": 1}):
+                                for ax2_3_init, ax1_3_init in T.grid(T.int64(4), T.int64(4)):
+                                    with T.block("matmul_init"):
+                                        v0 = T.axis.spatial(T.int64(1), ax0)
+                                        v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_init)
+                                        v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3_init)
+                                        T.reads()
+                                        T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
+                                        matmul_reindex_pad_local[T.int64(0), v1, v2] = T.float32(0)
+                                for ax3_0 in range(T.int64(256)):
+                                    for ax0_ax1_ax2_fused_0 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
+                                        for ax0_ax1_ax2_fused_1 in T.thread_binding(T.int64(8), thread="threadIdx.x"):
+                                            for ax0_ax1_ax2_fused_2 in range(T.int64(2)):
+                                                for ax0_ax1_ax2_fused_3 in T.vectorized(T.int64(2)):
+                                                    with T.block("inp0_reindex_pad_shared"):
+                                                        v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                                        v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + (ax0_ax1_ax2_fused_0 * T.int64(32) + ax0_ax1_ax2_fused_1 * T.int64(4) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) // T.int64(16))
+                                                        v2 = T.axis.spatial(T.int64(4096), ax3_0 * T.int64(16) + (ax0_ax1_ax2_fused_0 * T.int64(32) + ax0_ax1_ax2_fused_1 * T.int64(4) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) % T.int64(16))
+                                                        T.reads(inp0[v0, v1, v2])
+                                                        T.writes(inp0_reindex_pad_shared[v0, v1, v2])
+                                                        T.block_attr({"buffer_dim_align": [[0, 1, 8, 2]]})
+                                                        inp0_reindex_pad_shared[v0, v1, v2] = T.if_then_else(v1 < m, inp0[v0, v1, v2], T.float32(0))
+                                    for ax0_ax1_ax2_fused_0 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
+                                        for ax0_ax1_ax2_fused_1 in T.thread_binding(T.int64(8), thread="threadIdx.x"):
+                                            for ax0_ax1_ax2_fused_2 in range(T.int64(4)):
+                                                for ax0_ax1_ax2_fused_3 in T.vectorized(T.int64(2)):
+                                                    with T.block("inp1_reindex_shared"):
+                                                        v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                                        v1 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + (ax0_ax1_ax2_fused_0 * T.int64(64) + ax0_ax1_ax2_fused_1 * T.int64(8) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) // T.int64(16))
+                                                        v2 = T.axis.spatial(T.int64(4096), ax3_0 * T.int64(16) + (ax0_ax1_ax2_fused_0 * T.int64(64) + ax0_ax1_ax2_fused_1 * T.int64(8) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) % T.int64(16))
+                                                        T.reads(inp1[v2, v1])
+                                                        T.writes(inp1_reindex_shared[v0, v1, v2])
+                                                        T.block_attr({"buffer_dim_align": [[0, 1, 8, 2]]})
+                                                        inp1_reindex_shared[v0, v1, v2] = inp1[v2, v1]
+                                    for ax3_1, ax2_3, ax1_3 in T.grid(T.int64(16), T.int64(4), T.int64(4)):
+                                        with T.block("matmul_update"):
                                             v0 = T.axis.spatial(T.int64(1), ax0)
-                                            v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_init)
-                                            v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3_init)
-                                            T.reads()
+                                            v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3)
+                                            v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3)
+                                            v3 = T.axis.reduce(T.int64(4096), ax3_0 * T.int64(16) + ax3_1)
+                                            T.reads(matmul_reindex_pad_local[T.int64(0), v1, v2], inp0_reindex_pad_shared[T.int64(0), v1, v3], inp1_reindex_shared[T.int64(0), v2, v3])
                                             T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
-                                            matmul_reindex_pad_local[T.int64(0), v1, v2] = T.float32(0)
-                                    for ax3_0 in range(T.int64(256)):
-                                        for ax0_ax1_ax2_fused_0 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
-                                            for ax0_ax1_ax2_fused_1 in T.thread_binding(T.int64(8), thread="threadIdx.x"):
-                                                for ax0_ax1_ax2_fused_2 in range(T.int64(2)):
-                                                    for ax0_ax1_ax2_fused_3 in T.vectorized(T.int64(2)):
-                                                        with T.block("inp0_reindex_pad_shared"):
-                                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                                            v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + (ax0_ax1_ax2_fused_0 * T.int64(32) + ax0_ax1_ax2_fused_1 * T.int64(4) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) // T.int64(16))
-                                                            v2 = T.axis.spatial(T.int64(4096), ax3_0 * T.int64(16) + (ax0_ax1_ax2_fused_0 * T.int64(32) + ax0_ax1_ax2_fused_1 * T.int64(4) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) % T.int64(16))
-                                                            T.reads(inp0[v0, v1, v2])
-                                                            T.writes(inp0_reindex_pad_shared[v0, v1, v2])
-                                                            T.block_attr({"buffer_dim_align": [[0, 1, 8, 2]]})
-                                                            inp0_reindex_pad_shared[v0, v1, v2] = T.if_then_else(v1 < m, inp0[v0, v1, v2], T.float32(0))
-                                        for ax0_ax1_ax2_fused_0 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
-                                            for ax0_ax1_ax2_fused_1 in T.thread_binding(T.int64(8), thread="threadIdx.x"):
-                                                for ax0_ax1_ax2_fused_2 in range(T.int64(4)):
-                                                    for ax0_ax1_ax2_fused_3 in T.vectorized(T.int64(2)):
-                                                        with T.block("inp1_reindex_shared"):
-                                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                                            v1 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + (ax0_ax1_ax2_fused_0 * T.int64(64) + ax0_ax1_ax2_fused_1 * T.int64(8) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) // T.int64(16))
-                                                            v2 = T.axis.spatial(T.int64(4096), ax3_0 * T.int64(16) + (ax0_ax1_ax2_fused_0 * T.int64(64) + ax0_ax1_ax2_fused_1 * T.int64(8) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) % T.int64(16))
-                                                            T.reads(inp1[v2, v1])
-                                                            T.writes(inp1_reindex_shared[v0, v1, v2])
-                                                            T.block_attr({"buffer_dim_align": [[0, 1, 8, 2]]})
-                                                            inp1_reindex_shared[v0, v1, v2] = inp1[v2, v1]
-                                        for ax3_1, ax2_3, ax1_3 in T.grid(T.int64(16), T.int64(4), T.int64(4)):
-                                            with T.block("matmul_update"):
-                                                v0 = T.axis.spatial(T.int64(1), ax0)
-                                                v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3)
-                                                v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3)
-                                                v3 = T.axis.reduce(T.int64(4096), ax3_0 * T.int64(16) + ax3_1)
-                                                T.reads(matmul_reindex_pad_local[T.int64(0), v1, v2], inp0_reindex_pad_shared[T.int64(0), v1, v3], inp1_reindex_shared[T.int64(0), v2, v3])
-                                                T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
-                                                matmul_reindex_pad_local[T.int64(0), v1, v2] = matmul_reindex_pad_local[T.int64(0), v1, v2] + inp0_reindex_pad_shared[T.int64(0), v1, v3] * inp1_reindex_shared[T.int64(0), v2, v3]
-                                    for ax0_1, ax1, ax2_0_1 in T.grid(T.int64(1), T.int64(4), T.int64(2)):
-                                        for ax2_1_1 in T.vectorized(T.int64(2)):
-                                            with T.block("matmul_reindex_pad_local"):
-                                                v0 = T.axis.spatial(T.int64(1), ax0_1)
-                                                v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_2 * T.int64(4) + ax1)
-                                                v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_2 * T.int64(4) + ax2_0_1 * T.int64(2) + ax2_1_1)
-                                                T.reads(matmul_reindex_pad_local[v0, v1, v2])
-                                                T.writes(matmul[T.int64(0), v1, v2])
-                                                if v1 < m:
-                                                    matmul[T.int64(0), v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
-    # fmt: on
-    input_infos, median, std = benchmark(
-        before,
-        args=[((1, "m", 4096), "float32"), ((4096, 4096), "float32"), ((1, "m", 4096), "float32")],
-        dym_var_sample={"m": 1},
-        target="llvm -num-cores=4",
-        dev=tvm.cpu(),
+                                            matmul_reindex_pad_local[T.int64(0), v1, v2] = matmul_reindex_pad_local[T.int64(0), v1, v2] + inp0_reindex_pad_shared[T.int64(0), v1, v3] * inp1_reindex_shared[T.int64(0), v2, v3]
+                                for ax0_1, ax1, ax2_0_1 in T.grid(T.int64(1), T.int64(4), T.int64(2)):
+                                    for ax2_1_1 in T.vectorized(T.int64(2)):
+                                        with T.block("matmul_reindex_pad_local"):
+                                            v0 = T.axis.spatial(T.int64(1), ax0_1)
+                                            v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_2 * T.int64(4) + ax1)
+                                            v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_2 * T.int64(4) + ax2_0_1 * T.int64(2) + ax2_1_1)
+                                            T.reads(matmul_reindex_pad_local[v0, v1, v2])
+                                            T.writes(matmul[T.int64(0), v1, v2])
+                                            if v1 < m:
+                                                matmul[T.int64(0), v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
+# fmt: on
+
+
+def test_benchmark_prim_func_rpc():
+
+    with LocalRPC() as rpc:
+        rpc_config = ms.runner.RPCConfig(
+            tracker_host=rpc.tracker_host,
+            tracker_port=rpc.tracker_port,
+            tracker_key=rpc.tracker_key,
+            session_priority=1,
+            session_timeout_sec=100,
+        )
+        input_infos, _, _ = benchmark(
+            cuda_workload,
+            args=[
+                ((1, "m", 4096), "float32"),
+                ((4096, 4096), "float32"),
+                ((1, "m", 4096), "float32"),
+            ],
+            dym_var_sample={"m": 128},
+            target="nvidia/geforce-rtx-3070",
+            dev=tvm.cuda(),
+            rpc_config=rpc_config,
+        )
+        assert input_infos == [
+            ((1, 128, 4096), "float32"),
+            ((4096, 4096), "float32"),
+            ((1, 128, 4096), "float32"),
+        ]
+
+
+def test_benchmark_prim_func_local():
+    input_infos, _, _ = benchmark(
+        cuda_workload,
+        args=[
+            ((1, "m", 4096), "float32"),
+            ((4096, 4096), "float32"),
+            ((1, "m", 4096), "float32"),
+        ],
+        dym_var_sample={"m": 128},
+        target="nvidia/geforce-rtx-3070",
+        dev=tvm.cuda(),
+    )
+    assert input_infos == [
+        ((1, 128, 4096), "float32"),
+        ((4096, 4096), "float32"),
+        ((1, 128, 4096), "float32"),
+    ]
+
+
+def test_benchmark_prim_func_full_local():
+    benchmark_prim_func(
+        cuda_workload,
+        args=[
+            ((1, "m", 4096), "float32"),
+            ((4096, 4096), "float32"),
+            ((1, "m", 4096), "float32"),
+        ],
+        dym_var_dict={"m": "int32"},
+        target="nvidia/geforce-rtx-3070",
+        dev=tvm.cuda(),
     )
 
-    # input_infos, median, std = benchmark(
-    #     expected,
-    #     args=[((1, "m", 4096), "float32"), ((4096, 4096), "float32"), ((1, "m", 4096), "float32")],
-    #     dym_var_sample={"m": 128},
-    #     target="nvidia/geforce-rtx-3070",
-    #     dev=tvm.cuda(),
-    # )
+
+def test_benchmark_prim_func_full_rpc():
+    with LocalRPC() as rpc:
+        rpc_config = ms.runner.RPCConfig(
+            tracker_host=rpc.tracker_host,
+            tracker_port=rpc.tracker_port,
+            tracker_key=rpc.tracker_key,
+            session_priority=1,
+            session_timeout_sec=100,
+        )
+        benchmark_prim_func(
+            cuda_workload,
+            args=[
+                ((1, "m", 4096), "float32"),
+                ((4096, 4096), "float32"),
+                ((1, "m", 4096), "float32"),
+            ],
+            dym_var_dict={"m": "int32"},
+            target="nvidia/geforce-rtx-3070",
+            dev=tvm.cuda(),
+            rpc_config=rpc_config,
+            evaluator_config=ms.runner.EvaluatorConfig(
+                number=10,
+                repeat=10,
+                min_repeat_ms=0,
+                enable_cpu_cache_flush=False,
+            ),
+        )
 
 
 if __name__ == "__main__":
-    test_benchmark_prim_func()
+    tvm.testing.main()

--- a/tests/python/dlight/test_benchmark.py
+++ b/tests/python/dlight/test_benchmark.py
@@ -35,7 +35,7 @@ from tvm.dlight.benchmark import (
 )
 import tvm.testing
 
-# pylint: disable=no-self-argument,invalid-name,line-too-long
+# pylint: disable=no-self-argument,invalid-name,line-too-long,no-method-argument
 # fmt: off
 @I.ir_module
 class Module:
@@ -166,7 +166,7 @@ def cuda_workload(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(409
                                             if v1 < m:
                                                 matmul[T.int64(0), v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
 # fmt: on
-# pylint: enable=no-self-argument,invalid-name,line-too-long
+# pylint: enable=no-self-argument,invalid-name,line-too-long,no-method-argument
 
 
 @pytest.mark.skip("requires CUDA")
@@ -308,4 +308,4 @@ def test_extract_from_relax():
 
 
 if __name__ == "__main__":
-    test_extract_from_relax()
+    tvm.testing.main()

--- a/tests/python/dlight/test_benchmark.py
+++ b/tests/python/dlight/test_benchmark.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=missing-docstring
 
+import tempfile
 import pytest
 
 from tvm import meta_schedule as ms
@@ -25,7 +26,13 @@ from tvm.script import tir as T
 from tvm.script import relax as R
 
 
-from tvm.dlight.benchmark import benchmark, benchmark_prim_func, benchmark_relax_func
+from tvm.dlight.benchmark import (
+    benchmark,
+    benchmark_prim_func,
+    benchmark_relax_func,
+    extract_prim_func,
+    extract_from_relax,
+)
 import tvm.testing
 
 # pylint: disable=no-self-argument,invalid-name,line-too-long
@@ -260,5 +267,45 @@ def test_benchmark_relax_func():
     benchmark_relax_func(Module, "test")
 
 
+def test_extract_prim_func():
+    print(
+        extract_prim_func(
+            model_name="TEST",
+            relax_func_name="test",
+            prim_func_name="full1",
+            func=Module["full1"],  # type: ignore
+            func_args=[((1, 32, 1, "n"), "float16")],
+            dym_var_dict={"n": "int32"},
+            weight=2,
+            sample_number=10,
+        )
+    )
+    print(
+        extract_prim_func(
+            model_name="TEST",
+            relax_func_name="test",
+            prim_func_name="matmul1",
+            func=Module["matmul1"],  # type: ignore
+            func_args=[
+                ((1, 32, 1, "n"), "float16"),
+                ((1, 32, "n", 128), "float16"),
+                ((1, 32, 1, 128), "float16"),
+            ],
+            dym_var_dict={"n": "int32"},
+            weight=2,
+            sample_number=10,
+        )
+    )
+
+
+def test_extract_from_relax():
+    with tempfile.TemporaryDirectory() as filepath:
+        extract_from_relax(
+            Module,
+            "TEST",
+            file_path=filepath,
+        )
+
+
 if __name__ == "__main__":
-    test_benchmark_relax_func()
+    test_extract_from_relax()

--- a/tests/python/dlight/test_benchmark.py
+++ b/tests/python/dlight/test_benchmark.py
@@ -1,0 +1,127 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=missing-docstring
+import pytest
+
+import tvm.testing
+from tvm.dlight.benchmark import benchmark
+from tvm.script import tir as T
+
+
+def test_benchmark_prim_func():
+    # fmt: off
+    @T.prim_func
+    def before(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(4096)), "float32"), var_matmul: T.handle):
+        m = T.int64()
+        inp0 = T.match_buffer(var_inp0, (T.int64(1), m, T.int64(4096)))
+        matmul = T.match_buffer(var_matmul, (T.int64(1), m, T.int64(4096)))
+        for i0, i1, i2, k in T.grid(T.int64(1), m, T.int64(4096), T.int64(4096)):
+            with T.block("matmul"):
+                v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+                with T.init():
+                    matmul[v_i0, v_i1, v_i2] = T.float32(0)
+                matmul[v_i0, v_i1, v_i2] = matmul[v_i0, v_i1, v_i2] + inp0[v_i0, v_i1, v_k] * inp1[v_k, v_i2]
+
+    @T.prim_func
+    def expected(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(4096)), "float32"), var_matmul: T.handle):
+        T.func_attr({"tir.is_scheduled": 1})
+        m = T.int64()
+        inp0 = T.match_buffer(var_inp0, (T.int64(1), m, T.int64(4096)))
+        matmul = T.match_buffer(var_matmul, (T.int64(1), m, T.int64(4096)))
+        # with T.block("root"):
+        matmul_reindex_pad_local = T.alloc_buffer((T.int64(1), (m + T.int64(31)) // T.int64(32) * T.int64(32), T.int64(4096)), scope="local")
+        inp0_reindex_pad_shared = T.alloc_buffer((T.int64(1), (m + T.int64(31)) // T.int64(32) * T.int64(32), T.int64(4096)), scope="shared")
+        inp1_reindex_shared = T.alloc_buffer((T.int64(1), T.int64(4096), T.int64(4096)), scope="shared")
+        for ax0 in T.thread_binding(T.int64(1), thread="blockIdx.z"):
+            for ax1_0 in T.thread_binding((m + T.int64(31)) // T.int64(32), thread="blockIdx.x"):
+                for ax2_0 in T.thread_binding(T.int64(64), thread="blockIdx.y"):
+                    for ax2_1 in T.thread_binding(T.int64(1), thread="vthread.y"):
+                        for ax1_1 in T.thread_binding(T.int64(1), thread="vthread.x"):
+                            for ax2_2 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
+                                for ax1_2 in T.thread_binding(T.int64(8), thread="threadIdx.x", annotations={"pragma_auto_unroll_max_step": 256, "pragma_unroll_explicit": 1}):
+                                    for ax2_3_init, ax1_3_init in T.grid(T.int64(4), T.int64(4)):
+                                        with T.block("matmul_init"):
+                                            v0 = T.axis.spatial(T.int64(1), ax0)
+                                            v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_init)
+                                            v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3_init)
+                                            T.reads()
+                                            T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
+                                            matmul_reindex_pad_local[T.int64(0), v1, v2] = T.float32(0)
+                                    for ax3_0 in range(T.int64(256)):
+                                        for ax0_ax1_ax2_fused_0 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
+                                            for ax0_ax1_ax2_fused_1 in T.thread_binding(T.int64(8), thread="threadIdx.x"):
+                                                for ax0_ax1_ax2_fused_2 in range(T.int64(2)):
+                                                    for ax0_ax1_ax2_fused_3 in T.vectorized(T.int64(2)):
+                                                        with T.block("inp0_reindex_pad_shared"):
+                                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                                            v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + (ax0_ax1_ax2_fused_0 * T.int64(32) + ax0_ax1_ax2_fused_1 * T.int64(4) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) // T.int64(16))
+                                                            v2 = T.axis.spatial(T.int64(4096), ax3_0 * T.int64(16) + (ax0_ax1_ax2_fused_0 * T.int64(32) + ax0_ax1_ax2_fused_1 * T.int64(4) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) % T.int64(16))
+                                                            T.reads(inp0[v0, v1, v2])
+                                                            T.writes(inp0_reindex_pad_shared[v0, v1, v2])
+                                                            T.block_attr({"buffer_dim_align": [[0, 1, 8, 2]]})
+                                                            inp0_reindex_pad_shared[v0, v1, v2] = T.if_then_else(v1 < m, inp0[v0, v1, v2], T.float32(0))
+                                        for ax0_ax1_ax2_fused_0 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
+                                            for ax0_ax1_ax2_fused_1 in T.thread_binding(T.int64(8), thread="threadIdx.x"):
+                                                for ax0_ax1_ax2_fused_2 in range(T.int64(4)):
+                                                    for ax0_ax1_ax2_fused_3 in T.vectorized(T.int64(2)):
+                                                        with T.block("inp1_reindex_shared"):
+                                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                                            v1 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + (ax0_ax1_ax2_fused_0 * T.int64(64) + ax0_ax1_ax2_fused_1 * T.int64(8) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) // T.int64(16))
+                                                            v2 = T.axis.spatial(T.int64(4096), ax3_0 * T.int64(16) + (ax0_ax1_ax2_fused_0 * T.int64(64) + ax0_ax1_ax2_fused_1 * T.int64(8) + ax0_ax1_ax2_fused_2 * T.int64(2) + ax0_ax1_ax2_fused_3) % T.int64(16))
+                                                            T.reads(inp1[v2, v1])
+                                                            T.writes(inp1_reindex_shared[v0, v1, v2])
+                                                            T.block_attr({"buffer_dim_align": [[0, 1, 8, 2]]})
+                                                            inp1_reindex_shared[v0, v1, v2] = inp1[v2, v1]
+                                        for ax3_1, ax2_3, ax1_3 in T.grid(T.int64(16), T.int64(4), T.int64(4)):
+                                            with T.block("matmul_update"):
+                                                v0 = T.axis.spatial(T.int64(1), ax0)
+                                                v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3)
+                                                v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3)
+                                                v3 = T.axis.reduce(T.int64(4096), ax3_0 * T.int64(16) + ax3_1)
+                                                T.reads(matmul_reindex_pad_local[T.int64(0), v1, v2], inp0_reindex_pad_shared[T.int64(0), v1, v3], inp1_reindex_shared[T.int64(0), v2, v3])
+                                                T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
+                                                matmul_reindex_pad_local[T.int64(0), v1, v2] = matmul_reindex_pad_local[T.int64(0), v1, v2] + inp0_reindex_pad_shared[T.int64(0), v1, v3] * inp1_reindex_shared[T.int64(0), v2, v3]
+                                    for ax0_1, ax1, ax2_0_1 in T.grid(T.int64(1), T.int64(4), T.int64(2)):
+                                        for ax2_1_1 in T.vectorized(T.int64(2)):
+                                            with T.block("matmul_reindex_pad_local"):
+                                                v0 = T.axis.spatial(T.int64(1), ax0_1)
+                                                v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_2 * T.int64(4) + ax1)
+                                                v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_2 * T.int64(4) + ax2_0_1 * T.int64(2) + ax2_1_1)
+                                                T.reads(matmul_reindex_pad_local[v0, v1, v2])
+                                                T.writes(matmul[T.int64(0), v1, v2])
+                                                if v1 < m:
+                                                    matmul[T.int64(0), v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
+    # fmt: on
+    input_infos, median, std = benchmark(
+        before,
+        args=[((1, "m", 4096), "float32"), ((4096, 4096), "float32"), ((1, "m", 4096), "float32")],
+        dym_var_sample={"m": 1},
+        target="llvm -num-cores=4",
+        dev=tvm.cpu(),
+    )
+
+    # input_infos, median, std = benchmark(
+    #     expected,
+    #     args=[((1, "m", 4096), "float32"), ((4096, 4096), "float32"), ((1, "m", 4096), "float32")],
+    #     dym_var_sample={"m": 128},
+    #     target="nvidia/geforce-rtx-3070",
+    #     dev=tvm.cuda(),
+    # )
+
+
+if __name__ == "__main__":
+    test_benchmark_prim_func()

--- a/tests/python/dlight/test_benchmark.py
+++ b/tests/python/dlight/test_benchmark.py
@@ -281,12 +281,13 @@ def test_extract_prim_func():
 
 
 def test_extract_from_relax():
-    with tempfile.TemporaryDirectory() as filepath:
-        extract_from_relax(
-            Module,
-            "TEST",
-            file_path=filepath,
-        )
+    with tvm.target.Target("llvm -num-cores=4"):
+        with tempfile.TemporaryDirectory() as filepath:
+            extract_from_relax(
+                Module,
+                "TEST",
+                file_path=filepath,
+            )
 
 
 def test_extract_func_info_from_prim_func():

--- a/tests/python/dlight/test_benchmark.py
+++ b/tests/python/dlight/test_benchmark.py
@@ -253,7 +253,7 @@ def test_benchmark_relax_func():
         benchmark_relax_func(Module, "test")
 
 
-def test_extract_prim_func():
+def test_extract_prim_func_full1():
     print(
         extract_prim_func(
             model_name="TEST",
@@ -267,6 +267,9 @@ def test_extract_prim_func():
             target="llvm -num-cores=4",
         )
     )
+
+
+def test_extract_prim_func_matmul1():
     print(
         extract_prim_func(
             model_name="TEST",


### PR DESCRIPTION
This PR introduces benchmarking tools for dynamic shape PrimFuncs and Relax. It facilitates the following functionalities:
1. Automatically benchmark PrimFunc performance with user-speicified dynamic shape sampling function and input information. E.g., `n=random.randint(50, 100)` will benchmark performance of PrimFunc with Dynamic dimension `n` between 50-100.
2. Extract self-contained PrimFunc benchmarking files from Relax Module. E.g., it can produce multiple python files for each function in a Relax Module and automatically extract dynamic shape input information from bindings.
3. Conduct Relax Function level benchmarking using the same dynamic shape sample value across the Relax Function. E.g., the same value `n` is used consistently in a Relax Function for any PrimFunction call so we can figure out what is the performance bottleneck when we pin down the value of all dynamic dimensions like `n` or `m` (Yes, there could be multiple dynamic dimensions).
4. It can automatically generate valid input even when the input is not the dynamic shape but the value of the dynamic dimension, which is `n`. This is specific to `rotatry_embedding` for now.

Co-authored by @cyx-6
Thanks to @junrushao for advices.

Example Usage
```python
def benchmark_prim_func_full_rpc():
    with LocalRPC() as rpc:
        rpc_config = ms.runner.RPCConfig(
            tracker_host=rpc.tracker_host,
            tracker_port=rpc.tracker_port,
            tracker_key=rpc.tracker_key,
            session_priority=1,
            session_timeout_sec=100,
        )
        benchmark_prim_func(
            cuda_workload,
            args=[
                ((1, "m", 4096), "float32"),
                ((4096, 4096), "float32"),
                ((1, "m", 4096), "float32"),
            ],
            dym_var_dict={"m": "int32"},
            target="nvidia/geforce-rtx-3070",
            dev=tvm.cuda(),
            rpc_config=rpc_config,
            evaluator_config=ms.runner.EvaluatorConfig(
                number=10,
                repeat=10,
                min_repeat_ms=0,
                enable_cpu_cache_flush=False,
            ),
        )
```

Expected Results for the tested PrimFunc:
```
  InputInfo   Time(us)    Std(us)  Weight  WxTime(ms)
0   m = 126  752.48000  19.417429       1    0.752480
1    m = 56  430.68955   0.244274       1    0.430690
2    m = 13  340.11350   0.241286       1    0.340114
3    m = 89  692.58875   0.343988       1    0.692589
4    m = 98  819.43990   0.316655       1    0.819440
```