### PR TITLE
[Package] Remove cutlass media/docs inside cutlass_fpA_intB_gemm

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -95,6 +95,8 @@ def get_lib_path():
                         # remove large files
                         _remove_path(os.path.join(candidate_path, "cutlass", "docs"))
                         _remove_path(os.path.join(candidate_path, "cutlass", "media"))
+                        _remove_path(os.path.join(candidate_path, "cutlass_fpA_intB_gemm", "cutlass", "docs"))
+                        _remove_path(os.path.join(candidate_path, "cutlass_fpA_intB_gemm", "cutlass", "media"))
                     break
     else:
         libs = None

--- a/python/setup.py
+++ b/python/setup.py
@@ -95,8 +95,14 @@ def get_lib_path():
                         # remove large files
                         _remove_path(os.path.join(candidate_path, "cutlass", "docs"))
                         _remove_path(os.path.join(candidate_path, "cutlass", "media"))
-                        _remove_path(os.path.join(candidate_path, "cutlass_fpA_intB_gemm", "cutlass", "docs"))
-                        _remove_path(os.path.join(candidate_path, "cutlass_fpA_intB_gemm", "cutlass", "media"))
+                        _remove_path(
+                            os.path.join(candidate_path, "cutlass_fpA_intB_gemm", "cutlass", "docs")
+                        )
+                        _remove_path(
+                            os.path.join(
+                                candidate_path, "cutlass_fpA_intB_gemm", "cutlass", "media"
+                            )
+                        )
                     break
     else:
         libs = None


### PR DESCRIPTION
The `cutlass_fpA_intB_gemm` has another `cutlass` dependency which has some large files we didn't exclude in `setup.py`, and it makes our python package large.

This PR fixes the issue.

cc @masahi  @tqchen @junrushao