### PR TITLE
[Runtime] Device API to query L2 cache size

### DIFF
--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -48,7 +48,8 @@ enum DeviceAttrKind : int {
   kMaxRegistersPerBlock = 9,
   kGcnArch = 10,
   kApiVersion = 11,
-  kDriverVersion = 12
+  kDriverVersion = 12,
+  kGlobalMemCacheSizeBytes = 13,
 };
 
 #ifdef TVM_KALLOC_ALIGNMENT

--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -49,7 +49,7 @@ enum DeviceAttrKind : int {
   kGcnArch = 10,
   kApiVersion = 11,
   kDriverVersion = 12,
-  kGlobalMemCacheSizeBytes = 13,
+  kL2CacheSizeBytes = 13,
 };
 
 #ifdef TVM_KALLOC_ALIGNMENT

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -492,15 +492,17 @@ class Device(ctypes.Structure):
     def l2_cache_size_bytes(self):
         """Return the size of the device L2 cache in bytes
 
+        Supported devices include CUDA/ROCM/OpenCL.
+
         Returns
         -------
         l2_cache_size_bytes : int or None
             The size of the device L2 cache in bytes returned by device runtime API.
+            Return None if the device does not support this feature.
 
         Note
         ----
-        The value returned by opencl's API is smaller than real device L2 cache size.
-        Vulkan does not support this attribute.
+        The value returned by opencl's API is smaller than actual device L2 cache size.
         """
         return self._GetDeviceAttr(self.device_type, self.device_id, 13)
 

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -487,6 +487,12 @@ class Device(ctypes.Structure):
 
         """
         return self._GetDeviceAttr(self.device_type, self.device_id, 12)
+    
+    @property
+    def global_mem_cache_size(self):
+        """TODO(Zihao)
+        """
+        return self._GetDeviceAttr(self.device_type, self.device_id, 13)
 
     def texture_spatial_limit(self):
         """Returns limits for textures by spatial dimensions

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -487,10 +487,20 @@ class Device(ctypes.Structure):
 
         """
         return self._GetDeviceAttr(self.device_type, self.device_id, 12)
-    
+
     @property
-    def global_mem_cache_size(self):
-        """TODO(Zihao)
+    def l2_cache_size_bytes(self):
+        """Return the size of the device L2 cache in bytes
+
+        Returns
+        -------
+        l2_cache_size_bytes : int or None
+            The size of the device L2 cache in bytes returned by device runtime API.
+
+        Note
+        ----
+        The value returned by opencl's API is smaller than real device L2 cache size.
+        Vulkan does not support this attribute.
         """
         return self._GetDeviceAttr(self.device_type, self.device_id, 13)
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -243,7 +243,11 @@ class Target(Object):
     @property
     def features(self):
         return TargetFeatures(self)
-
+    
+    @property
+    def global_mem_cache_size(self):
+        return int(self.attrs.get("global_mem_cache_size", 0))
+    
     def get_kind_attr(self, attr_name):
         """Get additional attribute about the target kind.
 

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -243,11 +243,11 @@ class Target(Object):
     @property
     def features(self):
         return TargetFeatures(self)
-    
+
     @property
-    def global_mem_cache_size(self):
-        return int(self.attrs.get("global_mem_cache_size", 0))
-    
+    def l2_cache_size_bytes(self):
+        return int(self.attrs.get("l2_cache_size_bytes", 0))
+
     def get_kind_attr(self, attr_name):
         """Get additional attribute about the target kind.
 

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -105,7 +105,7 @@ class CUDADeviceAPI final : public DeviceAPI {
       }
       case kDriverVersion:
         return;
-      case kGlobalMemCacheSizeBytes:
+      case kL2CacheSizeBytes:
         // Get size of device l2 cache size in bytes.
         int l2_size = 0;
         CUDA_CALL(cudaDeviceGetAttribute(&l2_size, cudaDevAttrL2CacheSize, dev.device_id));

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -105,6 +105,12 @@ class CUDADeviceAPI final : public DeviceAPI {
       }
       case kDriverVersion:
         return;
+      case kGlobalMemCacheSizeBytes:
+        // Get size of device l2 cache size in bytes.
+        int l2_size = 0;
+        CUDA_CALL(cudaDeviceGetAttribute(&l2_size, cudaDevAttrL2CacheSize, dev.device_id));
+        *rv = l2_size;
+        return;
     }
     *rv = value;
   }

--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -81,6 +81,8 @@ void MetalWorkspace::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) {
         return;
       case kDriverVersion:
         return;
+      case kL2CacheSizeBytes:
+        return;
     }
   };
 }

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -198,7 +198,8 @@ void OpenCLWorkspace::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) 
       *rv = std::string(value);
       break;
     }
-    case kGlobalMemCacheSizeBytes:
+    case kL2CacheSizeBytes:
+      // NOTE(Zihao): this API cannot reflect the real L2 cache size in both CUDA/AMD GPUs.
       cl_ulong value;
       OPENCL_CALL(clGetDeviceInfo(device_id, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, sizeof(value), &value,
                                   nullptr));

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -198,6 +198,12 @@ void OpenCLWorkspace::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) 
       *rv = std::string(value);
       break;
     }
+    case kGlobalMemCacheSizeBytes:
+      cl_ulong value;
+      OPENCL_CALL(clGetDeviceInfo(device_id, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, sizeof(value), &value,
+                                  nullptr));
+      *rv = static_cast<int64_t>(value);
+      break;
   }
 }
 

--- a/src/runtime/rocm/rocm_device_api.cc
+++ b/src/runtime/rocm/rocm_device_api.cc
@@ -122,7 +122,7 @@ class ROCMDeviceAPI final : public DeviceAPI {
       }
       case kDriverVersion:
         return;
-      case kGlobalMemCacheSizeBytes:
+      case kL2CacheSizeBytes:
         // Get size of device l2 cache size in bytes.
         int l2_size;
         ROCM_CALL(hipDeviceGetAttribute(l2_size, hipDeviceAttributeL2CacheSize, device.device_id));

--- a/src/runtime/rocm/rocm_device_api.cc
+++ b/src/runtime/rocm/rocm_device_api.cc
@@ -122,6 +122,11 @@ class ROCMDeviceAPI final : public DeviceAPI {
       }
       case kDriverVersion:
         return;
+      case kGlobalMemCacheSizeBytes:
+        // Get size of device l2 cache size in bytes.
+        int l2_size;
+        ROCM_CALL(hipDeviceGetAttribute(l2_size, hipDeviceAttributeL2CacheSize, device.device_id));
+        *rv = l2_size;
     }
     *rv = value;
   }

--- a/src/runtime/rocm/rocm_device_api.cc
+++ b/src/runtime/rocm/rocm_device_api.cc
@@ -125,7 +125,7 @@ class ROCMDeviceAPI final : public DeviceAPI {
       case kL2CacheSizeBytes:
         // Get size of device l2 cache size in bytes.
         int l2_size;
-        ROCM_CALL(hipDeviceGetAttribute(l2_size, hipDeviceAttributeL2CacheSize, device.device_id));
+        ROCM_CALL(hipDeviceGetAttribute(&l2_size, hipDeviceAttributeL2CacheSize, device.device_id));
         *rv = l2_size;
     }
     *rv = value;

--- a/src/runtime/vulkan/vulkan_device_api.cc
+++ b/src/runtime/vulkan/vulkan_device_api.cc
@@ -160,6 +160,9 @@ void VulkanDeviceAPI::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) 
       *rv = os.str();
       break;
     }
+
+    case kL2CacheSizeBytes:
+      break;
   }
 }
 

--- a/src/runtime/vulkan/vulkan_device_api.cc
+++ b/src/runtime/vulkan/vulkan_device_api.cc
@@ -160,12 +160,6 @@ void VulkanDeviceAPI::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) 
       *rv = os.str();
       break;
     }
-
-    case kL2CacheSizeBytes:
-      // Vulkan do not have standalone APIs to measure L2 cache size,
-      // and the vkCmdPipelineBarrier will flush L2 texture cache.
-      *rv = 0;
-      break;
   }
 }
 

--- a/src/runtime/vulkan/vulkan_device_api.cc
+++ b/src/runtime/vulkan/vulkan_device_api.cc
@@ -161,8 +161,10 @@ void VulkanDeviceAPI::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) 
       break;
     }
 
-    case kGlobalMemCacheSizeBytes:
-      *rv = 256 * 1024 * 1024;  // return 256mb by default
+    case kL2CacheSizeBytes:
+      // Vulkan do not have standalone APIs to measure L2 cache size,
+      // and the vkCmdPipelineBarrier will flush L2 texture cache.
+      *rv = 0;
       break;
   }
 }

--- a/src/runtime/vulkan/vulkan_device_api.cc
+++ b/src/runtime/vulkan/vulkan_device_api.cc
@@ -160,6 +160,10 @@ void VulkanDeviceAPI::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) 
       *rv = os.str();
       break;
     }
+
+    case kGlobalMemCacheSizeBytes:
+      *rv = 256 * 1024 * 1024;  // return 256mb by default
+      break;
   }
 }
 


### PR DESCRIPTION
Followup of #15305 , this PR creates API to query device L2 cache size in bytes.
Currently, the API-supported devices includes CUDA, OpenCL, and ROCM.

Note that OpenCL's API does not return the accurate device L2 cache size.
I cannot find a Vulkan API that returns L2 texture cache size, but the `vkCmdPipelineBarrier` call will flush the L2 texture cache automatically(https://zeux.io/2020/02/27/writing-an-efficient-vulkan-renderer/), thus we return 0 by default.