### PR TITLE
[Bugfix][Relay][Frontend][Keras] Add a assertion to reject a invalid value for attribute units in RNN layers

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1008,6 +1008,7 @@ def _convert_lstm(
     if keras_layer.go_backwards:
         in_data = _op.reverse(in_data, axis=1)
     units = list(weightList[0].shape)[1]
+    assert units > 0, "The value of units must be a positive integer"
     time_steps = in_shape[1]
     in_data = _op.squeeze(in_data, axis=[0])
     in_data = _op.split(in_data, indices_or_sections=time_steps, axis=0)
@@ -1051,6 +1052,7 @@ def _convert_simple_rnn(
     if keras_layer.use_bias:
         in_bias = etab.new_const(weightList[2])
     units = list(weightList[0].shape)[1]
+    assert units > 0, "The value of units must be a positive integer"
     in_data = _op.nn.batch_flatten(in_data)
     ixh = _op.nn.dense(in_data, kernel_weight, units=units)
     if keras_layer.use_bias:
@@ -1080,6 +1082,7 @@ def _convert_gru(
     if keras_layer.use_bias:
         in_bias = etab.new_const(weightList[2])
     units = list(weightList[0].shape)[1]
+    assert units > 0, "The value of units must be a positive integer"
     in_data = _op.nn.batch_flatten(in_data)
     matrix_x = _op.nn.dense(in_data, kernel_weight, units=units)
     if keras_layer.use_bias:

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -254,6 +254,8 @@ def _convert_dense(
     weightList = keras_layer.get_weights()
     weight = etab.new_const(weightList[0].transpose([1, 0]))
     params = {"weight": weight, "units": weightList[0].shape[1]}
+    units = list(weightList[0].shape)[1]
+    assert units > 0, "The value of units must be a positive integer"
     if input_shape is None:
         input_shape = keras_layer.input_shape
     input_dim = len(input_shape)

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -244,7 +244,7 @@ class TestKeras:
         ):
             act_funcs = [
                 keras_mod.layers.LeakyReLU(alpha=None),
-                keras_mod.layers.LEU(2, 3, 4),
+                keras_mod.layers.ELU(2, 3, 4),
                 keras_mod.layers.ReLU(threshold=None),
             ]
             data = keras_mod.layers.Input(shape=(2, 3, 4))


### PR DESCRIPTION
This PR fixes two types of bugs:
Bug 1. fix a typo about the wrong API name in the test case.
Bug 2-5. add an assertion to reject the invalid model, which can be constructed in the old version of Keras. The attribute `units` in LSTM, RNN, GRU, and Dense must have a positive value. Such invalid values can be used to construct a DL model successfully and can be converted to RelayIR successfully. In this pr, we reject these invalid models containing such layers.


## Steps to reproduce to bug-2 about LSTM: (Keras <= 2.6)
```
import tvm
import tvm.relay as relay
import numpy as np
from tensorflow import keras
from tensorflow.keras import layers, models

input_shape = (1, 2, 4)
input_data = np.random.random(size=input_shape)
dtype = 'float32'

x = layers.Input(shape=input_shape[1:], dtype=dtype)

layer = keras.layers.LSTM(units=0)        # invalid input but can not reject in keras <= 2.4
layer.set_weights(layer.get_weights())

y = layer(x)
model = models.Model(x, y)
res_keras = model.predict(input_data)

print(model.summary())
res_keras2 = model(input_data)

shape_dict = {'input_1': input_shape}
mod, params = relay.frontend.from_keras(model, shape_dict)
print(mod)
```


In the latest version of Keras, the invalid value for units will be rejected. Thus, the test case can be triggered using the Keras <=2.4.
Thus, we cannot new test cases into the unit tests.

cc @echuraev @leandron 