### PR TITLE
[Bugfix][Frontend][Keras]Fix a corner case bug in softmax converter of keras frontend

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -135,10 +135,12 @@ def _convert_advanced_activation(inexpr, keras_layer, etab, data_layout, input_s
         if isinstance(axis, list):
             raise tvm.error.OpAttributeUnImplemented(f"Softmax with axes {axis} is not supported.")
         if data_layout == "NCHW":
-            if input_shape and axis == -1:
+            if dims == 0:
+                axis = 0
+            elif axis == -1:
                 axis = 1
             else:
-                axis = axis + 1 if axis <= dims - 1 else 1
+                axis = axis + 1 if axis < dims - 1 else 1
         return _op.nn.softmax(inexpr, axis=axis)
     if act_type == "ReLU":
         if np.isnan(keras_layer.threshold).any():

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -131,14 +131,14 @@ def _convert_advanced_activation(inexpr, keras_layer, etab, data_layout, input_s
 
     if act_type == "Softmax":
         axis = keras_layer.axis
-        dims = len(input_shape)
+        dims = len(input_shape) if input_shape else 0
         if isinstance(axis, list):
             raise tvm.error.OpAttributeUnImplemented(f"Softmax with axes {axis} is not supported.")
         if data_layout == "NCHW":
-            if axis == -1:
+            if input_shape and axis == -1:
                 axis = 1
             else:
-                axis = axis + 1 if axis < dims - 1 else 1
+                axis = axis + 1 if axis <= dims - 1 else 1
         return _op.nn.softmax(inexpr, axis=axis)
     if act_type == "ReLU":
         if np.isnan(keras_layer.threshold).any():

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -229,6 +229,13 @@ class TestKeras:
             keras_model = keras_mod.models.Model(data, x)
             verify_keras_frontend(keras_model)
             verify_keras_frontend(keras_model, need_transpose=False, layout="NHWC")
+        # Test the input dimension = 1
+        data = keras_mod.layers.Input(shape=(11,))
+        act_func = keras_mod.layers.Softmax()
+        x = act_func(data)
+        keras_model = keras_mod.models.Model(data, x)
+        verify_keras_frontend(keras_model)
+        verify_keras_frontend(keras_model, need_transpose=False, layout="NHWC")
 
     def test_forward_activations_except(self, keras_mod):
         """


### PR DESCRIPTION
This PR fixes a corner bug in the softmax converter in the Keras frontend.
If the input dimension of softmax is 1, TVM will crash unexpectedly.


### StackTrace
```
Traceback (most recent call last):
  File "test.py", line 25, in <module>
    mod, params = relay.frontend.from_keras(model, shape_dict)
  File "/workplace/software/tvm/tvm/python/tvm/relay/frontend/keras.py", line 1565, in from_keras
    _convert_layer(keras_layer, etab)
  File "/workplace/software/tvm/tvm/python/tvm/relay/frontend/keras.py", line 1519, in _convert_layer
    layout,
  File "/workplace/software/tvm/tvm/python/tvm/relay/frontend/keras.py", line 1394, in keras_op_to_relay
    outs = _convert_map[op_name](inexpr, keras_layer, etab, data_layout)
  File "/workplace/software/tvm/tvm/python/tvm/relay/frontend/keras.py", line 134, in _convert_advanced_activation
    dims = len(input_shape)
TypeError: object of type 'NoneType' has no len()
```


### Steps to reproduce
```
import tvm
import tvm.relay as relay
import numpy as np
from tensorflow import keras
from tensorflow.keras import layers, models

input_shape = (11,)
input_data = np.random.random(size=input_shape)
dtype = 'float32'

x = layers.Input(shape=input_shape[1:], dtype=dtype)

layer = keras.layers.Softmax()
layer.set_weights(layer.get_weights())

y = layer(x)
model = models.Model(x, y)
res_keras = model.predict(input_data)
print(model.summary())

res_keras2 = model(input_data)

shape_dict = {'input_1': input_shape}
mod, params = relay.frontend.from_keras(model, shape_dict)
print(mod)
```


cc @echuraev @Hzfengsy @leandron 