### PR TITLE
[CI] Update test to include unique attribute

### DIFF
--- a/tests/python/relay/test_pass_merge_compiler_regions.py
+++ b/tests/python/relay/test_pass_merge_compiler_regions.py
@@ -236,7 +236,7 @@ def test_if_else():
     Avoid O1 merge to O2.
     """
 
-    target = "test_if_else"
+    target = "test_if_else_merge"
 
     @tvm.ir.register_op_attr("sigmoid", "target." + target)
     def sigmoid(expr):  # pylint: disable=unused-variable


### PR DESCRIPTION
The test test_pass_merge_compiler_regions.py reused the same attribute target.test_if_else that was used by another test and caused CI issues.

Adding a unique attribute for now which resolves the test failure.