### PR TITLE
Fix concrete broadcast bug

### DIFF
--- a/src/relay/op/type_relations.cc
+++ b/src/relay/op/type_relations.cc
@@ -72,9 +72,9 @@ TensorType ConcreteBroadcast(const TensorType& t1, const TensorType& t2, DataTyp
   for (; i <= std::min(ndim1, ndim2); ++i) {
     IndexExpr s1 = t1->shape[ndim1 - i];
     IndexExpr s2 = t2->shape[ndim2 - i];
-    if (EqualConstInt(s1, 1)) {
+    if (EqualConstInt(s1, 1) && !s2.as<AnyNode>()) {
       oshape.push_back(s2);
-    } else if (EqualConstInt(s2, 1)) {
+    } else if (EqualConstInt(s2, 1) && !s1.as<AnyNode>()) {
       oshape.push_back(s1);
     } else if (s1.as<AnyNode>()) {
       // s1 == 1 || s1 == s2


### PR DESCRIPTION
Hi there, executing the following code causes a crash:
```
from tvm.meta_schedule.testing.relay_workload import get_network
get_network('bert_base', [1, 128])
```
This issue arises due to a discrepancy in broadcasting dimensions. The code infers the broadcast between dimensions [1,128,512] and [any, any, 512] as [any, 128, 512]. However, the expected output dimensions are [1, 128, 512].