### PR TITLE
Fix Cython compile for v3.0.0 release

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,7 +16,7 @@ runs:
       environment-file: conda/build-environment.yaml
       auto-activate-base: false
       use-only-tar-bz2: true
-      python-version: 3.7
+      python-version: 3.8
       condarc-file: conda/condarc
   - uses: conda-incubator/setup-miniconda@v2
     if: steps.conda1.outcome == 'failure'
@@ -26,7 +26,7 @@ runs:
       environment-file: conda/build-environment.yaml
       auto-activate-base: false
       use-only-tar-bz2: true
-      python-version: 3.7
+      python-version: 3.8
       condarc-file: conda/condarc
   - name: Conda info
     shell: pwsh

--- a/conda/build-environment.yaml
+++ b/conda/build-environment.yaml
@@ -25,7 +25,7 @@ channels:
 
 # The packages to install to the environment
 dependencies:
-  - python=3.7 # or 3.8. See https://github.com/apache/tvm/issues/8577 for more details on >= 3.9
+  - python=3.8  # See https://github.com/apache/tvm/issues/8577 for more details on >= 3.9
   - conda-build
   - git
   - llvmdev >=11

--- a/conda/build-environment.yaml
+++ b/conda/build-environment.yaml
@@ -31,7 +31,7 @@ dependencies:
   - llvmdev >=11
   - numpy
   - pytest
-  - cython
+  - cython>=0.29.31
   - cmake
   - bzip2
   - make

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -25,7 +25,7 @@ pip3 install --upgrade \
     "Pygments>=2.4.0" \
     attrs \
     cloudpickle \
-    cython==0.29.34 \
+    cython \
     decorator \
     mypy \
     numpy==1.21.* \

--- a/python/tvm/_ffi/_cython/ndarray.pxi
+++ b/python/tvm/_ffi/_cython/ndarray.pxi
@@ -21,7 +21,7 @@ cdef const char* _c_str_dltensor = "dltensor"
 cdef const char* _c_str_used_dltensor = "used_dltensor"
 
 
-cdef void _c_dlpack_deleter(object pycaps):
+cdef void _c_dlpack_deleter(object pycaps) noexcept:
     cdef DLManagedTensor* dltensor
     if pycapsule.PyCapsule_IsValid(pycaps, _c_str_dltensor):
         dltensor = <DLManagedTensor*>pycapsule.PyCapsule_GetPointer(pycaps, _c_str_dltensor)


### PR DESCRIPTION
Cython `v3.0.0` was recently released (https://github.com/cython/cython/releases/tag/3.0.0) and is used in newly built docker images. This causes a compilation issue since 3.0.0 expects function definitions to be explicitly declared with the `noexcept` annotation. This change should be backwards compatible to `v0.29.31`. For more details see the discussion here: https://github.com/scipy/scipy/issues/17234#issuecomment-1493423202.