### PR TITLE
[PyTorch] Add aten::view_as

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1622,7 +1622,6 @@ class PyTorchOpConverter:
 
         return _op.transform.reshape(data, new_shape)
 
-
     def view_as(self, inputs, input_types):
         data = inputs[0]
         tensors = inputs[1]
@@ -1634,7 +1633,6 @@ class PyTorchOpConverter:
         shape = self.infer_shape(tensors)
 
         return _op.transform.reshape(data, shape)
-
 
     def reshape(self, inputs, input_types):
         data = inputs[0]

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1622,6 +1622,20 @@ class PyTorchOpConverter:
 
         return _op.transform.reshape(data, new_shape)
 
+
+    def view_as(self, inputs, input_types):
+        data = inputs[0]
+        tensors = inputs[1]
+
+        if not isinstance(tensors, (_expr.Call, _expr.Constant)):
+            msg = f"Data type {type(tensors)} could not be parsed in view_as op"
+            raise AssertionError(msg)
+
+        shape = self.infer_shape(tensors)
+
+        return _op.transform.reshape(data, shape)
+
+
     def reshape(self, inputs, input_types):
         data = inputs[0]
         new_shape = inputs[1]
@@ -3838,6 +3852,7 @@ class PyTorchOpConverter:
             "aten::addmm": self.addmm,
             "aten::size": self.size,
             "aten::view": self.view,
+            "aten::view_as": self.view_as,
             "aten::reshape": self.reshape,
             "aten::reshape_as": self.reshape_as,
             "aten::clone": self.clone,

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -1673,12 +1673,12 @@ def test_forward_view_as():
 
     class ViewAs2(Module):
         def forward(self, *args):
-            t1 = torch.rand(1 * 3 * 10).float()
-            return args[0].view_as(t1)
+            return args[0].view_as(args[1])
 
     input_data = torch.rand(input_shape).float()
+    tensor = torch.rand(1 * 3 * 10).float()
     verify_model(ViewAs1().float().eval(), input_data=input_data)
-    verify_model(ViewAs2().float().eval(), input_data=input_data)
+    verify_model(ViewAs2().float().eval(), input_data=[input_data, tensor])
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -1661,6 +1661,27 @@ def test_forward_view():
 
 
 @tvm.testing.uses_gpu
+def test_forward_view_as():
+    """test_forward_view_as"""
+    torch.set_grad_enabled(False)
+    input_shape = [1, 3, 10]
+
+    class ViewAs1(Module):
+        def forward(self, *args):
+            t1 = torch.ones((1 * 3 * 10))
+            return args[0].view_as(t1)
+
+    class ViewAs2(Module):
+        def forward(self, *args):
+            t1 = torch.rand(1 * 3 * 10).float()
+            return args[0].view_as(t1)
+
+    input_data = torch.rand(input_shape).float()
+    verify_model(ViewAs1().float().eval(), input_data=input_data)
+    verify_model(ViewAs2().float().eval(), input_data=input_data)
+
+
+@tvm.testing.uses_gpu
 def test_forward_select():
     """test_forward_select"""
     torch.set_grad_enabled(False)


### PR DESCRIPTION
support aten::view_as op for the frontend of pytorch. The info of this op is available at this [link](https://pytorch.org/docs/stable/generated/torch.Tensor.view_as.html).