### PR TITLE
[TVMC] Add tvmc flag to print compilation time per pass

### DIFF
--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -460,7 +460,7 @@ def compile_model(
         if timing_inst:
             print("Printing results of timing profile...")
             print(timing_inst.render())
-            
+
         return TVMCPackage(package_path)
 
 

--- a/tests/python/driver/tvmc/test_command_line.py
+++ b/tests/python/driver/tvmc/test_command_line.py
@@ -286,6 +286,6 @@ def test_tvmc_print_pass_times(capsys, keras_simple, tmpdir_factory):
     _main(compile_args)
 
     # Check for timing results output
-    expected_out = "Printing results of timing profile..."
     captured_out = capsys.readouterr().out
-    assert expected_out in captured_out
+    for exp_str in ("Compilation time breakdown by pass:", "sequential:", "us]"):
+        assert exp_str in captured_out

--- a/tests/python/driver/tvmc/test_command_line.py
+++ b/tests/python/driver/tvmc/test_command_line.py
@@ -272,3 +272,20 @@ def test_tvmc_logger_set_basicConfig(monkeypatch, tmpdir_factory, keras_simple):
     _main(compile_args)
 
     mock_basicConfig.assert_called_with(stream=sys.stdout)
+
+
+def test_tvmc_print_pass_times(capsys, keras_simple, tmpdir_factory):
+    pytest.importorskip("tensorflow")
+    tmpdir = tmpdir_factory.mktemp("out")
+    print_cmd = "--print-pass-times"
+
+    # Compile model
+    module_file = os.path.join(tmpdir, "keras-tvm.tar")
+    compile_cmd = f"tvmc compile --target 'llvm' {keras_simple} --output {module_file} {print_cmd}"
+    compile_args = compile_cmd.split(" ")[1:]
+    _main(compile_args)
+
+    # Check for timing results output
+    expected_out = "Printing results of timing profile..."
+    captured_out = capsys.readouterr().out
+    assert expected_out in captured_out


### PR DESCRIPTION
Added a new flag `--print-pass-times` for tvmc compile to provide debugging information for tvmc users using `PassTimingInstrument`.   
Also added a test to check the printing of timing results.  
Example output:  
```
Compilation time breakdown by pass:
sequential: 431498us [48us] (88.48%; 88.48%)
	RemoveUnusedFunctions: 14us [14us] (0.00%; 0.00%)
	ToBasicBlockNormalForm: 66us [66us] (0.01%; 0.02%)
	qnn.Legalize: 2167us [24us] (0.44%; 0.50%)
		InferType: 617us [617us] (0.13%; 28.48%)
```