### PR TITLE
[CI] Make Graviton3 default AArch64 job runner node

### DIFF
--- a/ci/jenkins/generated/arm_jenkinsfile.groovy
+++ b/ci/jenkins/generated/arm_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2023-06-09T15:32:58.342947
+// Generated at 2023-07-18T14:11:39.890668
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -577,17 +577,17 @@ def build(node_type) {
   }
 }
 try {
-    build('ARM-SMALL-SPOT')
+    build('ARM-GRAVITON3-SPOT')
 } catch (Exception ex) {
-    build('ARM-SMALL')
+    build('ARM-GRAVITON3')
 }
 
 
 
-def shard_run_integration_aarch64_1_of_4(node_type='ARM-SMALL-SPOT', on_demand=false) {
+def shard_run_integration_aarch64_1_of_4(node_type='ARM-GRAVITON3-SPOT', on_demand=false) {
   if (!skip_ci && is_docs_only_build != 1) {
     if (on_demand==true || node_type.contains('ARM')) {
-        node_type = 'ARM-SMALL'
+        node_type = 'ARM-GRAVITON3'
     }
     node(node_type) {
       ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/ut-python-arm") {
@@ -633,10 +633,10 @@ def shard_run_integration_aarch64_1_of_4(node_type='ARM-SMALL-SPOT', on_demand=f
   }
 }
 
-def shard_run_integration_aarch64_2_of_4(node_type='ARM-SMALL-SPOT', on_demand=false) {
+def shard_run_integration_aarch64_2_of_4(node_type='ARM-GRAVITON3-SPOT', on_demand=false) {
   if (!skip_ci && is_docs_only_build != 1) {
     if (on_demand==true || node_type.contains('ARM')) {
-        node_type = 'ARM-SMALL'
+        node_type = 'ARM-GRAVITON3'
     }
     node(node_type) {
       ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/ut-python-arm") {
@@ -682,10 +682,10 @@ def shard_run_integration_aarch64_2_of_4(node_type='ARM-SMALL-SPOT', on_demand=f
   }
 }
 
-def shard_run_integration_aarch64_3_of_4(node_type='ARM-SMALL-SPOT', on_demand=false) {
+def shard_run_integration_aarch64_3_of_4(node_type='ARM-GRAVITON3-SPOT', on_demand=false) {
   if (!skip_ci && is_docs_only_build != 1) {
     if (on_demand==true || node_type.contains('ARM')) {
-        node_type = 'ARM-SMALL'
+        node_type = 'ARM-GRAVITON3'
     }
     node(node_type) {
       ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/ut-python-arm") {
@@ -731,10 +731,10 @@ def shard_run_integration_aarch64_3_of_4(node_type='ARM-SMALL-SPOT', on_demand=f
   }
 }
 
-def shard_run_integration_aarch64_4_of_4(node_type='ARM-SMALL-SPOT', on_demand=false) {
+def shard_run_integration_aarch64_4_of_4(node_type='ARM-GRAVITON3-SPOT', on_demand=false) {
   if (!skip_ci && is_docs_only_build != 1) {
     if (on_demand==true || node_type.contains('ARM')) {
-        node_type = 'ARM-SMALL'
+        node_type = 'ARM-GRAVITON3'
     }
     node(node_type) {
       ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/ut-python-arm") {
@@ -782,10 +782,10 @@ def shard_run_integration_aarch64_4_of_4(node_type='ARM-SMALL-SPOT', on_demand=f
 
 
 
-def shard_run_topi_aarch64_1_of_2(node_type='ARM-SMALL-SPOT', on_demand=false) {
+def shard_run_topi_aarch64_1_of_2(node_type='ARM-GRAVITON3-SPOT', on_demand=false) {
   if (!skip_ci && is_docs_only_build != 1) {
     if (on_demand==true || node_type.contains('ARM')) {
-        node_type = 'ARM-SMALL'
+        node_type = 'ARM-GRAVITON3'
     }
     node(node_type) {
       ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/ut-python-arm") {
@@ -836,10 +836,10 @@ def shard_run_topi_aarch64_1_of_2(node_type='ARM-SMALL-SPOT', on_demand=false) {
   }
 }
 
-def shard_run_topi_aarch64_2_of_2(node_type='ARM-SMALL-SPOT', on_demand=false) {
+def shard_run_topi_aarch64_2_of_2(node_type='ARM-GRAVITON3-SPOT', on_demand=false) {
   if (!skip_ci && is_docs_only_build != 1) {
     if (on_demand==true || node_type.contains('ARM')) {
-        node_type = 'ARM-SMALL'
+        node_type = 'ARM-GRAVITON3'
     }
     node(node_type) {
       ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/ut-python-arm") {
@@ -890,10 +890,10 @@ def shard_run_topi_aarch64_2_of_2(node_type='ARM-SMALL-SPOT', on_demand=false) {
 
 
 
-def shard_run_frontend_aarch64_1_of_2(node_type='ARM-SMALL-SPOT', on_demand=false) {
+def shard_run_frontend_aarch64_1_of_2(node_type='ARM-GRAVITON3-SPOT', on_demand=false) {
   if (!skip_ci && is_docs_only_build != 1) {
     if (on_demand==true || node_type.contains('ARM')) {
-        node_type = 'ARM-SMALL'
+        node_type = 'ARM-GRAVITON3'
     }
     node(node_type) {
       ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/frontend-python-arm") {
@@ -938,10 +938,10 @@ def shard_run_frontend_aarch64_1_of_2(node_type='ARM-SMALL-SPOT', on_demand=fals
   }
 }
 
-def shard_run_frontend_aarch64_2_of_2(node_type='ARM-SMALL-SPOT', on_demand=false) {
+def shard_run_frontend_aarch64_2_of_2(node_type='ARM-GRAVITON3-SPOT', on_demand=false) {
   if (!skip_ci && is_docs_only_build != 1) {
     if (on_demand==true || node_type.contains('ARM')) {
-        node_type = 'ARM-SMALL'
+        node_type = 'ARM-GRAVITON3'
     }
     node(node_type) {
       ws("workspace/exec_${env.EXECUTOR_NUMBER}/tvm/frontend-python-arm") {

--- a/ci/jenkins/templates/arm_jenkinsfile.groovy.j2
+++ b/ci/jenkins/templates/arm_jenkinsfile.groovy.j2
@@ -19,7 +19,7 @@
 
 {% call m.invoke_build(
   name='BUILD: arm',
-  node='ARM-SMALL',
+  node='ARM-GRAVITON3',
   condition='!skip_ci && is_docs_only_build != 1',
   ws='tvm/build-arm',
   docker_image='ci_arm',
@@ -40,7 +40,7 @@
 {% call(shard_index, num_shards) m.sharded_test_step(
   name="integration: aarch64",
   num_shards=4,
-  node="ARM-SMALL",
+  node="ARM-GRAVITON3",
   ws="tvm/ut-python-arm",
   platform="arm",
   docker_image="ci_arm",
@@ -57,7 +57,7 @@
 
 {% call(shard_index, num_shards) m.sharded_test_step(
   name="topi: aarch64",
-  node="ARM-SMALL",
+  node="ARM-GRAVITON3",
   ws="tvm/ut-python-arm",
   platform="arm",
   docker_image="ci_arm",
@@ -82,7 +82,7 @@
 
 {% call(shard_index, num_shards) m.sharded_test_step(
   name="frontend: aarch64",
-  node="ARM-SMALL",
+  node="ARM-GRAVITON3",
   ws="tvm/frontend-python-arm",
   platform="arm",
   docker_image="ci_arm",


### PR DESCRIPTION
In order to support SVE testing, migrating the current default AArch64 nodes to Graviton3 based nodes. Using r7g.large instances which have the memory requirements to support the TVM workloads.