### PR TITLE
[CI] Pin cython version to fix cython compilation

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -25,7 +25,7 @@ pip3 install --upgrade \
     "Pygments>=2.4.0" \
     attrs \
     cloudpickle \
-    cython \
+    cython==0.29.34 \
     decorator \
     mypy \
     numpy==1.21.* \


### PR DESCRIPTION
Cython 3.0.0 was recently released, but it is incompatible with the current .pxi definitions in python/tvm/_ffi/_python. Pinning the cython version until a working fix is created.

Posting this PR as an alternative to https://github.com/apache/tvm/pull/15346.