### PR TITLE
Add the ability to differentiate between model loads from remote fetch v/s model loads from cache

### DIFF
--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -22,7 +22,7 @@ export {
   PackedFunc, Module, NDArray,
   TVMArray, TVMObject, VirtualMachine,
   InitProgressCallback, InitProgressReport,
-  ArtifactCache, Instance, instantiate
+  ArtifactCache, Instance, instantiate, hasNDArrayInCache
 } from "./runtime";
 export { Disposable, LibraryProvider } from "./types";
 export { RPCServer } from "./rpc_server";

--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -972,6 +972,7 @@ export interface NDArrayShardEntry {
 export interface InitProgressReport {
   progress: number;
   timeElapsed: number;
+  cacheOnly: boolean;
   text: string;
 }
 
@@ -1002,6 +1003,16 @@ export class ArtifactCache {
       throw Error("Cannot fetch " + url);
     }
     return result;
+  }
+
+  async hasAllKeys(keys: string[]) {
+    if (this.cache === undefined) {
+      return false;
+    }
+    return this.cache.keys()
+      .then(requests => requests.map(request => request.url))
+      .then(cacheKeys => keys.every(key => cacheKeys.includes(key)))
+      .catch(err => false);
   }
 }
 
@@ -1472,6 +1483,8 @@ export class Instance implements Disposable {
     let fetchedBytes = 0;
     let timeElapsed = 0;
 
+    const cacheOnly = await artifactCache.hasAllKeys(list.map(key => new URL(key.dataPath, ndarrayCacheUrl).href))
+
     const reportCallback = (iter: number) => {
       // report
       for (let j = 0; j < this.initProgressCallback.length; ++j) {
@@ -1481,9 +1494,16 @@ export class Instance implements Disposable {
         text += timeElapsed + " secs elapsed.";
         text += " It can take a while when we first visit this page to populate the cache."
         text += " Later refreshes will become faster.";
+        if (cacheOnly) {
+          text = "Loading model from cache[" + iter + "/" + list.length + "]: ";
+          text += Math.ceil(fetchedBytes / (1024 * 1024)).toString() + "MB loaded. "
+          text += Math.floor(fetchedBytes * 100 / totalBytes).toString() + "% completed, "
+          text += timeElapsed + " secs elapsed.";
+        }
         this.initProgressCallback[j]({
           progress: fetchedBytes / totalBytes,
           timeElapsed: timeElapsed,
+          cacheOnly: cacheOnly,
           text: text
         });
       }
@@ -1493,6 +1513,7 @@ export class Instance implements Disposable {
       this.initProgressCallback[j]({
         progress: fetchedBytes / totalBytes,
         timeElapsed: 0,
+        cacheOnly: cacheOnly,
         text: "Start to fetch params",
       });
     }
@@ -1926,6 +1947,7 @@ export class Instance implements Disposable {
           this.initProgressCallback[j]({
             progress: progress,
             timeElapsed: timeElapsed,
+            cacheOnly: false,
             text: text
           });
         }


### PR DESCRIPTION
Upstreamed from https://github.com/mlc-ai/relax/pull/265