### PR TITLE
[Unity][Dlight] Fix matmul schedule when out_dtype = fp32 and bias add is fp32

### DIFF
--- a/python/tvm/dlight/gpu/matmul.py
+++ b/python/tvm/dlight/gpu/matmul.py
@@ -365,5 +365,17 @@ class Matmul(ScheduleRule):
         auto_inline_producers(sch, a_g2s)
         auto_inline_producers(sch, b_g2s)
         auto_inline_consumers(sch, l2g)
+
+        remaining_consumers = sch.get_consumers(l2g)
+
+        if len(remaining_consumers) != 0:
+            for c in remaining_consumers:
+                for p in sch.get_producers(c):
+                    if sch.get(p) != sch.get(l2g):
+                        sch.compute_inline(p)
+
+        auto_inline_consumers(sch, l2g)
+        assert len(sch.get_consumers(l2g)) == 0
+
         sch.decompose_reduction(main_block, ko)
         return sch


### PR DESCRIPTION
Fix the dlight matmul schedule for the following case:

```
matmul(input, self.weight, out_dtype="float32") + astype(self.bias, "float32")
```

The problem is the fp32 cast of bias. The current schedule doesn't recognize such "independent block" besides matmul, so this block hasn't been scheduled when dlight attempts to reverse-inline the "last block" (bias add) into the matmul cache-write stage via `auto_inline_consumers(sch, l2g)`. The bias add block ends up having two producers, which breaks `reverse_compute_inline` and hence leaving some blocks (the last block and the bias cast block) unscheduled for GPU.   

This has been fixed by checking if `reverse_compute_inline` has succeeded (no consumer remaining), and if not, look for unscheduled, "independent" producer blocks (like bias cast) and `compute_inline` them into the last block. Now the last block should only have one producer (cache-write), so doing `reverse_compute_inline` should now succeed.   

@Hzfengsy 