### PR TITLE
[Relax] Macro recfactor, R.macro prototype

### DIFF
--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -437,6 +437,13 @@ def emit_var_binding(value: VarBinding) -> Var:
     return _ffi_api.EmitVarBinding(value)  # type: ignore
 
 
+############################### SeqExpr ###############################
+
+
+def SeqExpr() -> frame.SeqExprFrame:  # pylint: disable=invalid-name
+    return _ffi_api.SeqExpr()
+
+
 ############################# If Then Else #############################
 
 
@@ -562,6 +569,7 @@ def dtype(value: Union[py_str, DataType]) -> Expr:
 __all__ = [
     "Else",
     "If",
+    "SeqExpr",
     "Then",
     "TupleGetItem",
     "abs",

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -441,7 +441,13 @@ def emit_var_binding(value: VarBinding) -> Var:
 
 
 def SeqExpr() -> frame.SeqExprFrame:  # pylint: disable=invalid-name
-    return _ffi_api.SeqExpr()
+    """Create a SeqExpr frame.
+    Returns
+    -------
+    res : frame.SeqExprFrame
+        The result SeqExprFrame
+    """
+    return _ffi_api.SeqExpr()  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
 ############################# If Then Else #############################

--- a/python/tvm/script/parser/_core.py
+++ b/python/tvm/script/parser/_core.py
@@ -18,5 +18,5 @@
 # pylint: disable=unused-import
 from .core import dispatch, doc, utils
 from .core.dispatch import OpMethod, register_op
-from .core.entry import parse, parse_macro
+from .core.entry import parse, scan_macro
 from .core.parser import Parser

--- a/python/tvm/script/parser/core/entry.py
+++ b/python/tvm/script/parser/core/entry.py
@@ -35,14 +35,12 @@ def _default_globals() -> Dict[str, Any]:
     return extra_vars
 
 
-def parse_macro(program: Union[Any, str], extra_vars: Dict[str, Any] = None) -> Any:
+def scan_macro(program: Union[Any, str], extra_vars: Dict[str, Any] = None) -> Any:
     """Generate the AST, and the source code for __repr__."""
     # The AST will be converted into TIR at the time of expansion.
     source = Source(program)
-    source_txt = source.source
-    source_ast = source.as_ast()
     closure_vars = extra_vars or _default_globals()
-    return source_ast, source_txt, closure_vars
+    return source, closure_vars
 
 
 def parse(program: Union[doc.AST, Any, str], extra_vars: Dict[str, Any] = None) -> Any:

--- a/python/tvm/script/parser/core/parser.py
+++ b/python/tvm/script/parser/core/parser.py
@@ -126,8 +126,8 @@ class ScriptMacro(abc.ABC):
 
     def _find_parser_def(self):
         outer_frame_infos = inspect.getouterframes(inspect.currentframe())
-        for fi in outer_frame_infos:
-            parser = fi.frame.f_globals.get(ScriptMacro.parser_object_name)
+        for finfo in outer_frame_infos:
+            parser = finfo.frame.f_globals.get(ScriptMacro.parser_object_name)
             if parser is not None:
                 return parser
         raise RuntimeError(f"{ScriptMacro.parser_object_name} not available")

--- a/python/tvm/script/parser/core/parser.py
+++ b/python/tvm/script/parser/core/parser.py
@@ -16,6 +16,8 @@
 # under the License.
 """The core parser"""
 
+import abc
+import inspect
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Set, Union
@@ -64,6 +66,108 @@ def _deferred(exit_f: Callable[[], None]):
 
 def _do_nothing(*args, **kwargs):  # pylint: disable=unused-argument
     pass
+
+
+class ScriptMacro(abc.ABC):
+    """Representation of a script macro.
+
+    This is a callable object, intended to be called from the expression evaluator.
+    The evaluator is expected to insert the current parser into the environment
+    undef the name given by "parser_object_name".
+
+    Once called, the ScriptMacro object will locate the current parser, and use it
+    to parse the macro's body and produce the result.
+
+    There were two major considerations for this design:
+    1. Implementing hygienic and non-hygienic macros.
+    2. Implementing macros that return values.
+
+    Macro uses in TIR are only allowed at a statement-level, and they don't produce
+    any values. Parsing of such macros could easily be done by intercepting doc.Call
+    nodes in the TIR parser. If a macro is a value-producing expression, then there
+    may not be a direct way to intercept calls to it if it's embedded in a complex
+    expression. Because macros use function-call syntax, the evaluator will try to
+    call the macro object, which this design relies on to parse and evaluate the macro.
+    """
+
+    parser_object_name = "__current_script_parser__"
+
+    def __init__(
+        self,
+        source: Source,
+        closure_vars: Dict[str, Any],
+        func: Callable,
+        hygienic: bool,
+    ) -> None:
+        self.source = source
+        self.closure_vars = closure_vars
+        self.func = func
+        self.hygienic = hygienic
+
+    def __repr__(self):
+        return self.source.source
+
+    @abc.abstractmethod
+    def parse_macro(self, parser: "Parser") -> Any:
+        """The main macro parsing function. Different scripts may have different
+        ways to parse a macro, and to return a value to the evaluator.
+
+        Parameters
+        ----------
+        parser : Parser
+            The parser with the appropriate frame already created and populated depending
+            macro's hygiene settings,
+
+        Returns
+        -------
+            The return value depends on the specifics of the particular script. It can be
+            "None" or any other value or any type.
+        """
+
+    def _find_parser_def(self):
+        outer_frame_infos = inspect.getouterframes(inspect.currentframe())
+        for fi in outer_frame_infos:
+            parser = fi.frame.f_globals.get(ScriptMacro.parser_object_name)
+            if parser is not None:
+                return parser
+        raise RuntimeError(f"{ScriptMacro.parser_object_name} not available")
+
+    def get_macro_def(self):
+        ast_module = self.source.as_ast()
+        for decl in ast_module.body:
+            if isinstance(decl, doc.FunctionDef) and decl.name == self.__name__:
+                return decl
+        raise RuntimeError(f"cannot find macro definition for {self.__name__}")
+
+    def __call__(self, *args, **kwargs):
+        param_binding = inspect.signature(self.func).bind(*args, **kwargs)
+        param_binding.apply_defaults()
+        local_vars = param_binding.arguments
+        parser = self._find_parser_def()
+
+        if self.hygienic:
+            saved_var_table = parser.var_table
+            parser.var_table = VarTable()
+
+            with parser.var_table.with_frame():
+                for k, v in self.closure_vars.items():
+                    parser.var_table.add(k, v)
+                for k, v in local_vars.items():
+                    parser.var_table.add(k, v)
+
+                parse_result = self.parse_macro(parser)
+
+            parser.var_table = saved_var_table
+
+        else:
+            with parser.var_table.with_frame():
+                for k, v in local_vars.items():
+                    parser.var_table.add(k, v)
+
+                print(parser.var_table.get())
+                parse_result = self.parse_macro(parser)
+
+        return parse_result
 
 
 class VarTableFrame:
@@ -336,6 +440,7 @@ class Parser(doc.NodeVisitor):
         if extra_vars is not None:
             for k, v in extra_vars.items():
                 var_values[k] = v
+        var_values[ScriptMacro.parser_object_name] = self
         return eval_expr(self, node, var_values)
 
     def _duplicate_lhs_check(self, target: doc.expr) -> Union[bool, Set[str]]:

--- a/python/tvm/script/parser/relax/__init__.py
+++ b/python/tvm/script/parser/relax/__init__.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     # so most tvmscript won't trigger pylint error here.
     function = staticmethod
 else:
-    from .entry import function
+    from .entry import function, macro
 
 __all__ = (
     _relax.__all__
@@ -45,6 +45,7 @@ __all__ = (
         "Tensor",
         "Tuple",
         "function",
+        "macro",
         "match_cast",
     ]
 )

--- a/python/tvm/script/parser/relax/entry.py
+++ b/python/tvm/script/parser/relax/entry.py
@@ -41,7 +41,7 @@ from .._core import doc, parse, utils
 from ..core.entry import scan_macro
 from ..core.parser import Parser, ScriptMacro
 from ..core.diagnostics import Source
-from ...ir_builder import IRBuilder, relax as R
+from ...ir_builder import relax as R
 
 FType = TypeVar("FType", bound=_Callable)
 
@@ -84,14 +84,7 @@ setattr(function, "dispatch_token", "relax")
 
 
 class RelaxMacro(ScriptMacro):
-    def __init__(
-        self,
-        source: Source,
-        closure_vars: Dict[str, Any],
-        func: _Callable,
-        hygienic: bool,
-    ) -> None:
-        super().__init__(source, closure_vars, func, hygienic)
+    """Specialization of the ScriptMacro class for Relax."""
 
     def parse_macro(self, parser: Parser) -> Expr:
         macro_def = self.get_macro_def()
@@ -110,8 +103,7 @@ class RelaxMacro(ScriptMacro):
                     if idx + 1 != len(macro_def.body):
                         parser.report_error(macro_def, "'return' should be the last statement")
                     break
-                else:
-                    parser.visit(stmt)
+                parser.visit(stmt)
 
         if ret_value is None:
             parser.report_error(macro_def, "Macros must end with a return statement")
@@ -131,7 +123,7 @@ def macro(*args, hygienic: bool = True) -> _Callable:
         will have its symbols resolved to values at the time of the macro's use.
     """
 
-    def _decorator(func: Callable) -> ScriptMacro:
+    def _decorator(func: _Callable) -> ScriptMacro:
         source, closure_vars = scan_macro(func, utils.inspect_function_capture(func))
         obj = RelaxMacro(source, closure_vars, func, hygienic)
         obj.__name__ = func.__name__

--- a/python/tvm/script/parser/relax/entry.py
+++ b/python/tvm/script/parser/relax/entry.py
@@ -40,7 +40,6 @@ from tvm.tir import PrimExpr
 from .._core import doc, parse, utils
 from ..core.entry import scan_macro
 from ..core.parser import Parser, ScriptMacro
-from ..core.diagnostics import Source
 from ...ir_builder import relax as R
 
 FType = TypeVar("FType", bound=_Callable)

--- a/python/tvm/script/parser/relax/entry.py
+++ b/python/tvm/script/parser/relax/entry.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional, Set, TypeVar, Union
 
 from tvm.relax import (
     Expr,
+    SeqExpr,
     ShapeExpr,
     FuncStructInfo,
     Function,
@@ -36,7 +37,11 @@ from tvm.relax.expr import Var
 from tvm.runtime import ObjectGeneric
 from tvm.tir import PrimExpr
 
-from .._core import parse, utils
+from .._core import doc, parse, utils
+from ..core.entry import scan_macro
+from ..core.parser import Parser, ScriptMacro
+from ..core.diagnostics import Source
+from ...ir_builder import IRBuilder, relax as R
 
 FType = TypeVar("FType", bound=_Callable)
 
@@ -73,6 +78,73 @@ def function(
 
 
 setattr(function, "dispatch_token", "relax")
+
+
+############################## R.macro ##############################
+
+
+class RelaxMacro(ScriptMacro):
+    def __init__(
+        self,
+        source: Source,
+        closure_vars: Dict[str, Any],
+        func: _Callable,
+        hygienic: bool,
+    ) -> None:
+        super().__init__(source, closure_vars, func, hygienic)
+
+    def parse_macro(self, parser: Parser) -> Expr:
+        macro_def = self.get_macro_def()
+        ret_value = None
+
+        with R.SeqExpr() as seq:
+            for idx, stmt in enumerate(macro_def.body):
+                # Normally, a "return" statement is only allowed in a R.function. We don't
+                # want to parse the macro's body as if it was a body of a function, because
+                # the latter imposes some constraints that we want to avoid.
+                # At the same time, we want to use "return" to indicate the value of the
+                # macro (since in Relax everything is an expression), so add special handling
+                # of "return".
+                if isinstance(stmt, doc.Return):
+                    ret_value = parser.eval_expr(stmt.value)
+                    if idx + 1 != len(macro_def.body):
+                        parser.report_error(macro_def, "'return' should be the last statement")
+                    break
+                else:
+                    parser.visit(stmt)
+
+        if ret_value is None:
+            parser.report_error(macro_def, "Macros must end with a return statement")
+
+        return SeqExpr(seq.binding_blocks, ret_value)
+
+
+def macro(*args, hygienic: bool = True) -> _Callable:
+    """Decorator for macro definitions.
+
+    Parameters
+    ----------
+    hygienic: bool
+        Specifies whether the macro is hygienic or not.
+        A macro is hygienic if all symbols used in the macro's body are resolved
+        to values from the location of the macro definition. A non-hygienic macro
+        will have its symbols resolved to values at the time of the macro's use.
+    """
+
+    def _decorator(func: Callable) -> ScriptMacro:
+        source, closure_vars = scan_macro(func, utils.inspect_function_capture(func))
+        obj = RelaxMacro(source, closure_vars, func, hygienic)
+        obj.__name__ = func.__name__
+        return obj
+
+    if len(args) == 0:
+        return _decorator
+    if len(args) == 1 and inspect.isfunction(args[0]):
+        return _decorator(args[0])
+
+    raise ValueError(
+        "Invalid use of R.macro. Usage: @R.macro, @R.macro(), @R.macro(hygienic=[True|False])"
+    )
 
 
 ############################# Struct Info ##############################

--- a/python/tvm/script/parser/tir/entry.py
+++ b/python/tvm/script/parser/tir/entry.py
@@ -61,6 +61,7 @@ setattr(prim_func, "dispatch_token", "tir")
 #   the body of the macro, and the body with the substituted values is then
 #   inserted at the point where the call to the macro is located.
 
+
 class TIRMacro(ScriptMacro):
     def __init__(
         self,
@@ -129,7 +130,6 @@ def macro(*args, hygienic: bool = True) -> Callable:
     raise ValueError(
         "Invalid use of T.macro. Usage: @T.macro, @T.macro(), @T.macro(hygienic=[True|False])"
     )
-
 
 
 class BufferProxy:

--- a/python/tvm/script/parser/tir/entry.py
+++ b/python/tvm/script/parser/tir/entry.py
@@ -22,7 +22,7 @@ from tvm.ir.base import deprecated
 from tvm.tir import Buffer, PrimFunc
 
 from ...ir_builder.tir import buffer, ptr
-from .._core import doc, parse, scan_macro, utils
+from .._core import parse, scan_macro, utils
 from ..core.diagnostics import Source
 from ..core.parser import Parser, ScriptMacro
 
@@ -63,14 +63,7 @@ setattr(prim_func, "dispatch_token", "tir")
 
 
 class TIRMacro(ScriptMacro):
-    def __init__(
-        self,
-        source: Source,
-        closure_vars: Dict[str, Any],
-        func: Callable,
-        hygienic: bool,
-    ) -> None:
-        super().__init__(source, closure_vars, func, hygienic)
+    """Specialization of the ScriptMacro class for TIR."""
 
     def parse_macro(self, parser: Parser) -> None:
         macro_def = self.get_macro_def()

--- a/python/tvm/script/parser/tir/entry.py
+++ b/python/tvm/script/parser/tir/entry.py
@@ -22,7 +22,9 @@ from tvm.ir.base import deprecated
 from tvm.tir import Buffer, PrimFunc
 
 from ...ir_builder.tir import buffer, ptr
-from .._core import doc, parse, parse_macro, utils
+from .._core import doc, parse, scan_macro, utils
+from ..core.diagnostics import Source
+from ..core.parser import Parser, ScriptMacro
 
 
 def prim_func(func: Callable) -> Union[PrimFunc, Callable]:
@@ -59,26 +61,19 @@ setattr(prim_func, "dispatch_token", "tir")
 #   the body of the macro, and the body with the substituted values is then
 #   inserted at the point where the call to the macro is located.
 
-
-class TIRMacro:
-    """Representation of T.macro."""
-
+class TIRMacro(ScriptMacro):
     def __init__(
         self,
-        source_ast: doc.AST,
-        source_txt: str,
+        source: Source,
         closure_vars: Dict[str, Any],
         func: Callable,
         hygienic: bool,
     ) -> None:
-        self.source_ast = source_ast
-        self.source_txt = source_txt
-        self.closure_vars = closure_vars
-        self.func = func
-        self.hygienic = hygienic
+        super().__init__(source, closure_vars, func, hygienic)
 
-    def __repr__(self):
-        return self.source_txt
+    def parse_macro(self, parser: Parser) -> None:
+        macro_def = self.get_macro_def()
+        parser.visit_body(macro_def.body)
 
 
 def macro(*args, hygienic: bool = True) -> Callable:
@@ -121,15 +116,9 @@ def macro(*args, hygienic: bool = True) -> Callable:
     """
 
     def _decorator(func: Callable) -> TIRMacro:
-        source_ast, source_txt, closure_vars = parse_macro(
-            func, utils.inspect_function_capture(func)
-        )
-        obj = TIRMacro(source_ast, source_txt, closure_vars, func, hygienic)
+        source, closure_vars = scan_macro(func, utils.inspect_function_capture(func))
+        obj = TIRMacro(source, closure_vars, func, hygienic)
         obj.__name__ = func.__name__
-        # We don't need to explicitly store the return value anywhere.
-        # This function is a decorator, so the return value will replace
-        # the function definition (to which the decorator it is applied)
-        # in that function's name space.
         return obj
 
     if len(args) == 0:
@@ -141,8 +130,6 @@ def macro(*args, hygienic: bool = True) -> Callable:
         "Invalid use of T.macro. Usage: @T.macro, @T.macro(), @T.macro(hygienic=[True|False])"
     )
 
-
-# There is no dispatch_token for macro, because macro doesn't invoke parser.
 
 
 class BufferProxy:

--- a/python/tvm/script/parser/tir/entry.py
+++ b/python/tvm/script/parser/tir/entry.py
@@ -16,14 +16,13 @@
 # under the License.
 """The entry point of TVM parser for tir."""
 import inspect
-from typing import Any, Callable, Dict, Union
+from typing import Callable, Union
 
 from tvm.ir.base import deprecated
 from tvm.tir import Buffer, PrimFunc
 
 from ...ir_builder.tir import buffer, ptr
 from .._core import parse, scan_macro, utils
-from ..core.diagnostics import Source
 from ..core.parser import Parser, ScriptMacro
 
 

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -18,7 +18,7 @@
 
 import contextlib
 from functools import partial
-from typing import Any, Union
+from typing import Any
 
 import tvm
 from tvm.ir import GlobalVar, PrimType
@@ -448,7 +448,6 @@ def visit_expr_stmt(self: Parser, node: doc.Expr) -> None:
         pass
     else:
         self.report_error(node, f"Parsing resulted in unexpected type {type(res)}")
-    return None  # For pylint
 
 
 @dispatch.register(token="tir", type_name="If")

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -17,7 +17,6 @@
 """The base parser for tir"""
 
 import contextlib
-import inspect
 from functools import partial
 from typing import Any, Union
 
@@ -30,8 +29,6 @@ from ...ir_builder import tir as T
 from ...ir_builder.base import IRBuilder
 from ...ir_builder.base import IRBuilderFrame as Frame
 from .._core import Parser, dispatch, doc
-from ..core.parser import VarTable
-from .entry import TIRMacro
 
 
 def bind_with_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> Any:
@@ -431,11 +428,6 @@ def visit_expr_stmt(self: Parser, node: doc.Expr) -> None:
         The doc AST Expr node.
     """
 
-    if isinstance(node.value, doc.Call):
-        callee = self.eval_expr(node.value.func)
-        if isinstance(callee, TIRMacro):
-            return expand_macro(self, callee, node.value)
-
     res = self.eval_expr(node.value)
     if res is None:
         pass
@@ -538,51 +530,3 @@ def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> GlobalVar
     # Only ret_type is needed for func_signature.
     func_signature = tvm.tir.PrimFunc([], None, ret_type=ret_type)
     return I.decl_function(node.name, func_signature)
-
-
-def expand_macro(self: Parser, callee: TIRMacro, call: doc.Call) -> None:
-    """Bind arguments to the macro invocation to the parameters in the macro definition,
-    and pass the macro body for further parsing.
-    """
-
-    assert isinstance(callee, TIRMacro), f"Unexpected macro type {type(callee)}"
-
-    def find_macro_def(name: str, decl_list: doc.AST) -> Union[doc.FunctionDef, Any]:
-        for decl in decl_list:
-            if isinstance(decl, doc.FunctionDef) and decl.name == name:
-                return decl
-        return None
-
-    macro_def = find_macro_def(callee.__name__, callee.source_ast.body)
-    assert macro_def is not None, f"Invalid macro AST for {callee.__name__}"
-    # `macro_def` is the FunctionDef of the macro.
-
-    args = [self.eval_expr(arg) for arg in call.args]
-    kwargs = {kw.arg: self.eval_expr(kw.value) for kw in call.keywords}
-    param_binding = inspect.signature(callee.func).bind(*args, **kwargs)
-    param_binding.apply_defaults()
-    local_vars = param_binding.arguments
-
-    if callee.hygienic:
-        # If the macro was hygienic, construct new var_table with a single frame that
-        # contains the captured environment, and process the macro's body with that
-        # frame.
-        saved_var_table = self.var_table
-        self.var_table = VarTable()
-        with self.var_table.with_frame():
-            for k, v in callee.closure_vars.items():
-                self.var_table.add(k, v)
-            for k, v in local_vars.items():
-                self.var_table.add(k, v)
-
-            self.visit_body(macro_def.body)
-
-        self.var_table = saved_var_table
-
-    else:
-        # Otherwise, dynamically resolve symbols in the macro's body.
-        with self.var_table.with_frame():
-            for k, v in local_vars.items():
-                self.var_table.add(k, v)
-
-            self.visit_body(macro_def.body)

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -221,6 +221,15 @@ TVM_REGISTER_GLOBAL("script.ir_builder.relax.Emit").set_body_typed(Emit);
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitMatchCast").set_body_typed(EmitMatchCast);
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitVarBinding").set_body_typed(EmitVarBinding);
 
+/////////////////////////////// SeqExpr ///////////////////////////////
+
+SeqExprFrame SeqExpr() {
+  ObjectPtr<SeqExprFrameNode> n = make_object<SeqExprFrameNode>();
+  return SeqExprFrame(n);
+}
+
+TVM_REGISTER_GLOBAL("script.ir_builder.relax.SeqExpr").set_body_typed(SeqExpr);
+
 ///////////////////////////// If Then Else /////////////////////////////
 
 IfFrame If(tvm::relax::Expr condition) {


### PR DESCRIPTION
If this is acceptable, I'll break it up into the TIR part and the Relax part, and create PRs in main and unity respectively.

Edit: added description below

-------------------------------
As a background info---the parser (for either dialect, TIR or Relax) works by visiting a "statement" (or top-level expression) at a time.  The expression parts of the statement are evaluated, and then the IR corresponding to the statement is constructed if necessary.

In TIR, macro calls can only occur at the statement level, and they don't produce any values. This means that the statement visitor (`visit_expr_stmt`) can see these calls directly in its `node` parameter.  At this point it could simply visit the body of the macro instead, which is the basis of the existing implementation.

In Relax, on the other hand, there was a need for macros to produce values. This means that macro calls can occur in the middle of complex expressions.  As a result, these calls will not be present at the statement level, and the TIR approach by intercepting them in `visit_expr_stmt` will no longer work.  Instead, Relax macros delay the visiting of the macro body to the evaluation time.  A macro is represented by an `ScriptMacro` (`TIRMacro` in the current implementation) object (created via macro decorator).  When the evaluator evaluates an expression with a macro call, it will call the macro object (since macro calls use function call syntax).  It is in the macro object's `__call__` function where the macro parsing picks up.  The remaining issue was to pass the Parser object to the `__call__` function.  This is done by injecting it into the global dictionary under a reserved name.

It turns out that the same approach also works for TIR, and the macro processing can be generalized, leaving only language-specific details to the language-specific language macro objects.

----------------------------------
Relax macros generate a `SeqExpr` containing the evaluated body of the macro.  A Relax macro should end with a `return` statement with the expression that will become the value of the macro.  A `return` is normally not allowed in a `SeqExpr`, so macro parsing intercepts it to get its argument, after which the `return` statement itself is discarded.  The argument is then set as the "body" of the `SeqExpr`.  Everything preceding the `return` becomes a binding block in the `SeqExpr`.

Example:
```
import tvm
from tvm import relax
from tvm.script import relax as R

@R.macro
def alloc_and_shape(dtype: str):
    alloc = R.builtin.alloc_tensor(R.shape([4, 4]), runtime_device_index=0, dtype=dtype)
    shape = R.shape_of(alloc)
    return shape

@R.function
def foo(x: R.Tensor((4, 4), "float32")):
    shape = alloc_and_shape(dtype="float32")
    return shape


print(alloc_and_shape)
print()
print(foo)
```

Output:

```
@R.macro
def alloc_and_shape(dtype: str):
    alloc = R.builtin.alloc_tensor(R.shape([4, 4]), runtime_device_index=0, dtype=dtype)
    shape = R.shape_of(alloc)
    return shape


# from tvm.script import relax as R

@R.function
def foo(x: R.Tensor((4, 4), dtype="float32")) -> R.Shape([4, 4]):
    alloc: R.Tensor((4, 4), dtype="float32") = R.builtin.alloc_tensor(R.shape([4, 4]), R.dtype("float32"), R.prim_value(0))
    shape: R.Shape([4, 4]) = R.shape_of(alloc)
    shape_1: R.Shape([4, 4]) = shape
    return shape_1
```
