### PR TITLE
[TIR] Finer predicate handling in cross-thread reduction

### DIFF
--- a/tests/python/unittest/test_tir_transform_lower_cross_thread_reduction.py
+++ b/tests/python/unittest/test_tir_transform_lower_cross_thread_reduction.py
@@ -497,6 +497,64 @@ def lowered_single_reduction_loop_with_block_predicate(
 
 
 @T.prim_func
+def spatial_reduction_loop_predicate(A: T.Buffer((2, 32), "float32"), B: T.Buffer((2,), "float32")):
+    for i_0 in range(1):
+        for i_1 in T.thread_binding(16, thread="threadIdx.y"):
+            for k_0 in range(1):
+                for k_1 in T.thread_binding(64, thread="threadIdx.x"):
+                    with T.block("block"):
+                        vi = T.axis.spatial(2, i_0 * 16 + i_1)
+                        vk = T.axis.reduce(32, k_0 * 64 + k_1)
+                        T.where(i_0 * 16 + i_1 < 2 and k_0 * 64 + k_1 < 32)
+                        T.reads(A[vi, vk])
+                        T.writes(B[vi])
+                        with T.init():
+                            B[vi] = T.float32(0)
+                        B[vi] = B[vi] + A[vi, vk]
+
+
+@T.prim_func
+def lowered_reduction_spatial_loop_predicate(
+    A: T.Buffer((2, 32), "float32"), B: T.Buffer((2,), "float32")
+):
+    cross_thread_B = T.alloc_buffer((1,), strides=(1,), scope="local")
+    in_thread_B = T.alloc_buffer((1,), strides=(1,), scope="local")
+    for i_0 in range(1):
+        for i_1 in T.thread_binding(16, thread="threadIdx.y"):
+            for k_1 in T.thread_binding(64, thread="threadIdx.x"):
+                with T.block("block_in_thread_init"):
+                    T.reads()
+                    T.writes(in_thread_B[0])
+                    in_thread_B[0] = T.float32(0)
+                for k_0 in range(1):
+                    with T.block("block_in_thread"):
+                        vi = T.axis.spatial(2, i_0 * 16 + i_1)
+                        vk = T.axis.reduce(32, k_0 * 64 + k_1)
+                        T.where(i_0 * 16 + i_1 < 2 and k_0 * 64 + k_1 < 32)
+                        T.reads(A[vi, vk])
+                        T.writes(in_thread_B[0])
+                        in_thread_B[0] = in_thread_B[0] + A[vi, vk]
+                with T.block("block_cross_thread"):
+                    T.reads(in_thread_B[0])
+                    T.writes(cross_thread_B[0])
+                    T.attr(
+                        T.comm_reducer(lambda x0, y0: x0 + y0, [T.float32(0)]),
+                        "reduce_scope",
+                        T.reinterpret("handle", T.uint64(0)),
+                    )
+                    T.tvm_thread_allreduce(
+                        T.uint32(1), in_thread_B[0], T.bool(True), cross_thread_B[0], k_1
+                    )
+                k_0 = T.int32()
+                with T.block("block_write_back"):
+                    vi = T.axis.spatial(2, i_0 * 16 + i_1)
+                    T.where(i_0 * 16 + i_1 < 2 and k_1 == 0)
+                    T.reads(cross_thread_B[0])
+                    T.writes(B[vi])
+                    B[vi] = cross_thread_B[0]
+
+
+@T.prim_func
 def single_reduction_loop_with_tensorize(
     input_A: T.Buffer((1, 64, 7, 7, 32), "uint8"),
     input_B: T.Buffer((16, 64, 1, 1, 8, 32, 4), "int8"),
@@ -1315,7 +1373,6 @@ def lowered_thread_broadcast_1(A: T.Buffer((256, 256), "float32"), B: T.Buffer((
                 )
             with T.block("sum_write_back"):
                 vi = T.axis.spatial(256, i)
-                T.where(k == 0)
                 T.reads(cross_thread_temp_local[0])
                 T.writes(temp_local[vi])
                 temp_local[vi] = cross_thread_temp_local[0]
@@ -1428,7 +1485,7 @@ def lowered_thread_broadcast_2(lv1605: T.Buffer((T.int64(1), T.int64(32), T.int6
                 with T.block("NT_matmul_write_back"):
                     v0 = T.axis.spatial(T.int64(32), ax0_ax1_fused // n)
                     v1 = T.axis.spatial(n, ax0_ax1_fused % n)
-                    T.where(ax0_fused == T.int64(0))
+                    T.where(T.int64(0) <= ax0_ax1_fused // n and ax0_ax1_fused // n < T.int64(32) and T.int64(0) <= ax0_ax1_fused % n and ax0_ax1_fused % n < n)
                     T.reads(cross_thread_var_NT_matmul_intermediate_local[0])
                     T.writes(var_NT_matmul_intermediate_local[T.int64(0), v0, T.int64(0), v1])
                     var_NT_matmul_intermediate_local[T.int64(0), v0, T.int64(0), v1] = cross_thread_var_NT_matmul_intermediate_local[0]
@@ -1441,6 +1498,72 @@ def lowered_thread_broadcast_2(lv1605: T.Buffer((T.int64(1), T.int64(32), T.int6
                 T.writes(var_compute_intermediate[T.int64(0), v0, T.int64(0), v1])
                 var_compute_intermediate[T.int64(0), v0, T.int64(0), v1] = T.Cast("float32", T.min(T.max(var_NT_matmul_intermediate_local[T.int64(0), v0, T.int64(0), v1] * T.float16(0.088397790055248615), T.float16(-65504)), lv1582[T.int64(0), T.int64(0), T.int64(0), v1]))
 # fmt: on
+
+
+@T.prim_func
+def no_thread_broadcast(A: T.Buffer((256, 256), "float32"), B: T.Buffer((256, 256), "float32")):
+    temp_1_local = T.alloc_buffer((256,), scope="local")
+    temp_2_local = T.alloc_buffer((1,), scope="local")
+    for i in T.thread_binding(256, thread="blockIdx.x"):
+        for k in T.thread_binding(256, thread="threadIdx.x"):
+            with T.block("sum"):
+                vi, vk = T.axis.remap("SR", [i, k])
+                T.reads(A[vi, vk])
+                T.writes(temp_1_local[vi])
+                with T.init():
+                    temp_1_local[vi] = T.float32(0)
+                temp_1_local[vi] = temp_1_local[vi] + A[vi, vk]
+        with T.block("add"):
+            vi = T.axis.spatial(256, i)
+            T.reads(temp_1_local[vi])
+            T.writes(temp_2_local[0])
+            temp_2_local[0] = temp_1_local[vi] + T.float32(1)
+        for j in T.thread_binding(256, thread="threadIdx.x"):
+            with T.block("sum"):
+                vi, vj = T.axis.remap("SR", [i, j])
+                T.reads(temp_2_local[0])
+                T.writes(B[vi, vj])
+                B[vi, vj] = A[vi, vj] + temp_2_local[0]
+
+
+@T.prim_func
+def lowered_no_thread_broadcast(
+    A: T.Buffer((256, 256), "float32"), B: T.Buffer((256, 256), "float32")
+):
+    temp_1_local = T.alloc_buffer((256,), scope="local")
+    temp_2_local = T.alloc_buffer((1,), scope="local")
+    cross_thread_temp_1_local = T.alloc_buffer((1,), strides=(1,), scope="local")
+    for i in T.thread_binding(256, thread="blockIdx.x"):
+        for k in T.thread_binding(256, thread="threadIdx.x"):
+            with T.block("sum_cross_thread"):
+                vi, vk = T.axis.remap("SR", [i, k])
+                T.reads(A[vi, vk])
+                T.writes(cross_thread_temp_1_local[0])
+                T.attr(
+                    T.comm_reducer(lambda x0, y0: x0 + y0, [T.float32(0)]),
+                    "reduce_scope",
+                    T.reinterpret("handle", T.uint64(0)),
+                )
+                T.tvm_thread_allreduce(
+                    T.uint32(1), A[vi, vk], T.bool(True), cross_thread_temp_1_local[0], k
+                )
+            with T.block("sum_write_back"):
+                vi = T.axis.spatial(256, i)
+                T.reads(cross_thread_temp_1_local[0])
+                T.writes(temp_1_local[vi])
+                temp_1_local[vi] = cross_thread_temp_1_local[0]
+        with T.block("add"):
+            vi = T.axis.spatial(256, i)
+            T.reads(temp_1_local[vi])
+            T.writes(temp_2_local[0])
+            temp_2_local[0] = temp_1_local[vi] + T.float32(1)
+        for j in T.thread_binding(256, thread="threadIdx.x"):
+            with T.block("sum"):
+                vi, vj = T.axis.remap("SR", [i, j])
+                T.reads(temp_2_local[0])
+                T.writes(B[vi, vj])
+                B[vi, vj] = A[vi, vj] + temp_2_local[0]
+
 
 # pylint: enable=no-member,invalid-name,unused-variable,unexpected-keyword-arg
 
@@ -1470,6 +1593,10 @@ def test_single_reduction_loop_with_block_predicate():
         single_reduction_loop_with_block_predicate,
         lowered_single_reduction_loop_with_block_predicate,
     )
+
+
+def test_spatial_reduction_loop_predicate():
+    _check(spatial_reduction_loop_predicate, lowered_reduction_spatial_loop_predicate)
 
 
 def test_single_reduction_loop_with_tensorize():
@@ -1532,6 +1659,10 @@ def test_thread_broadcast_rewrite_1():
 
 def test_thread_broadcast_rewrite_2():
     _check(thread_broadcast_2, lowered_thread_broadcast_2)
+
+
+def test_no_thread_broadcast_rewrite():
+    _check(no_thread_broadcast, lowered_no_thread_broadcast)
 
 
 def test_lower_te():


### PR DESCRIPTION
This PR fixes the predicate handling logic of the cross-thread reduction lowering pass.

For the cross-thread reduction write-back block, prior to this PR, its predicate is the conjunction of `t == 0` for each reduction thread dim of the cross-thread reduction. This is problematic when the write-back buffer is stored in local memory, where each thread is supposed to have a copy of the final value, while the final value is only stored by the first thread. In this PR, the predicate is changed to be the conjunction of the clauses from the two parts:

* the clause of the original reduction block's predicate which contains spatial loop var,
* `t == 0` for each reduction thread dim **only when the write-back buffer is global or shared**.

So the first part ensures that the write-back will not go out of bound, and the second part ensures that when the write-back buffer is local, every thread gets a value and when the write-back buffer is non-local, only one thread writes the value out.

Meanwhile, this PR fixes the cross-thread broadcasting detection with the awareness of the storage scope of the write buffer of the broadcasting block. Specifically, for each consumer block of a buffer produced by cross-thread reduction under the same kernel (i.e., same set of `blockIdx`) of the cross-thread reduction block, when the write buffer of this consumer block is in local memory, we do not treat it as broadcasting, and will not add a predicate to it. Otherwise, we will add the predicate according to the broadcasting handling introduced by #15192.