### PR TITLE
[Relay] Generate reduced testcase for compilation failure

### DIFF
--- a/python/tvm/contrib/hexagon/subgraph.py
+++ b/python/tvm/contrib/hexagon/subgraph.py
@@ -1,0 +1,156 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=consider-using-with, unnecessary-ellipsis
+
+"""This module returns the smallest IR test case producing the same error"""
+import logging
+import tvm
+from tvm import relay
+from tvm.relay.expr import Call
+#from tvm.relay.backend import Executor
+#from tvm.contrib.hexagon.pytest_plugin import HEXAGON_AOT_LLVM_TARGET
+#logger = logging.getLogger()
+#logger.setLevel(logging.DEBUG)
+
+
+# maps to store the nodes(callnodes) and their ids and vice-versa
+id_to_node = {}
+node_to_id = {}
+node_id = 0
+def fvisit(expr):
+    global node_id
+    if isinstance(expr, relay.expr.Call):
+        id_to_node[node_id] = expr
+        node_to_id[expr] = node_id
+        node_id += 1
+
+
+op_name_map = {}
+
+"""Function that returns appropriate callnode or a relay variable """
+def give_call_node(call_arg, start_node, new_id_to_node):
+#    global op_name_map
+    if node_to_id[call_arg] < start_node:
+#append a temporary variable tensor of apprpriate shape if the id of the
+#argument node of the current node is outside the given range to the arguments list
+        if call_arg.op.name not in op_name_map:
+            op_name_map[call_arg.op.name] = 1
+        else:
+            op_name_map[call_arg.op.name] += 1
+        return relay.var(
+            call_arg.op.name + str(op_name_map[call_arg.op.name]),
+            type_annotation=relay.transform.InferTypeLocal(call_arg),
+        )
+
+    else:
+        # else just add the new node that must have already been created in previous iterations
+        return new_id_to_node[node_to_id[call_arg]]
+
+
+"""Producing the ir given a starting and ending node of a module(extracting subgraph)"""
+def produce_ir(start_node, end_node):
+    assert start_node <= end_node, "Start node cannot be greater than the end node"
+
+    # temporary map used for storing newnodes created and their ids
+    new_id_to_node = {}
+    used_nodes = []
+    # Traversing the module in the increasing order of ids
+    for call_id in range(start_node, end_node + 1):
+        arguments = []
+        call_node = id_to_node[call_id]
+        for call_arg in call_node.args:
+            if isinstance(call_arg, relay.expr.Call):
+                used_nodes.append(node_to_id[call_arg])
+                arguments.append(give_call_node(call_arg, start_node, new_id_to_node))
+            elif isinstance(call_arg, relay.expr.Tuple):
+                for i in call_arg:
+                    if isinstance(i, relay.expr.Call):
+                        used_nodes.append(node_to_id[i])
+                        arguments.append(give_call_node(i, start_node, new_id_to_node))
+                    else:
+                        arguments.append(i)
+            else:
+                arguments.append(call_arg)
+
+        # creating the whole callnode with the corresponding op,
+        #new arguments, and other attributes.
+        temp = Call(
+            call_node.op,
+            arguments,
+            call_node.attrs,
+            call_node.type_args,
+            call_node.span,
+        )
+        new_id_to_node[call_id] = temp
+
+    op_name_map.clear()
+    output_nodes = []
+    # Finding the output nodes
+    for i in range(start_node, end_node + 1):
+        if i not in used_nodes:
+            output_nodes.append(new_id_to_node[i])
+
+    # creating the IR
+    func = relay.Function(
+        relay.analysis.free_vars(relay.expr.Tuple(output_nodes)), relay.expr.Tuple(output_nodes)
+    )
+    mod = tvm.IRModule.from_expr(func)
+    return mod
+
+
+"""Recursive function to return the smallest test case(IR) that throws the
+error(assuming there is only one error in the module)"""
+def give_test_case(mod, target, func, start_node, end_node):
+    logging.debug(mod)
+    # base case
+    if start_node == end_node:
+        return mod
+    half = (end_node - start_node) // 2
+
+    # getting the first and second halves of the module
+    mod1 = produce_ir(start_node, start_node + half)
+    mod1_stat = func(mod1, target)
+    if not mod1_stat:
+        return give_test_case(mod1, target, func, start_node, start_node + half)
+
+    mod2 = produce_ir(start_node + half + 1, end_node)
+    mod2_stat = func(mod2, target)
+    if not mod2_stat:
+        return give_test_case(mod2, target, func, start_node + half + 1, end_node)
+
+    return mod
+
+
+"""Function that is to be called to get the smallest ir"""
+def smallest_ir(mod, target, func):
+    start_node = 0
+    end_node = int(give_count(mod) - 1)
+# Applying the InferType pass on the module to populate the checked_type
+#attribute of all the callnodes in the module
+
+    # Travesing in a post dfs manner to create the mappings
+    relay.analysis.post_order_visit(mod["main"], fvisit)
+    if func(mod, target):
+        return None
+    else:
+        return give_test_case(mod, target, func, start_node, end_node)
+
+
+# fucntion to calculate the total number of nodes in a module
+def give_count(mod):
+    op_freqs = relay.analysis.list_op_freqs(mod)
+    return sum(op_freqs.values())

--- a/tests/python/contrib/test_hexagon/subgraph_caller.py
+++ b/tests/python/contrib/test_hexagon/subgraph_caller.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=consider-using-with, unnecessary-ellipsis
+
+import tvm
+from tvm.contrib.hexagon.subgraph import smallest_ir
+from tvm import relay
+from tvm.relay.backend import Executor
+from tvm.contrib.hexagon.pytest_plugin import HEXAGON_AOT_LLVM_TARGET
+import sys
+
+#target =(
+#            "llvm -mtriple=hexagon -mcpu=hexagonv68 "
+#            "-mattr=+hvxv68,+hvx-length128b,+hvx-qfloat -keys=hexagon"
+#        )
+
+if len(sys.argv) != 2:
+    raise RuntimeError("You should give a target as an argument to the file")
+
+#choosing the target
+if sys.argv[1] == "hexagon":
+    target = HEXAGON_AOT_LLVM_TARGET
+elif sys.argv[1] == "x86":
+    target = tvm.target.Target("llvm")
+else:
+    raise RuntimeError("The {} target is not supported".format(sys.argv[1]))
+
+
+input = relay.var("data", shape=(1,32,32,128), dtype="float32")
+l1_weights = relay.var("l1_weights", shape=(3,3,128,256), dtype="float32")
+l1_bias = relay.var("bias", shape=(256,), dtype="float32")
+l1_conv = relay.nn.conv2d(input, l1_weights, kernel_size = [3, 3], data_layout = "NHWC", kernel_layout = "HWIO", out_dtype="float32", padding=[1,1], strides=(2,2))
+l1_bias_add = relay.nn.bias_add(l1_conv, l1_bias, axis=3)
+l1_relu = relay.nn.relu(l1_bias_add)
+l2_weights = relay.var("l2_weights", shape=(3,3,256,512), dtype="float32")
+l2_bias = relay.var("bias2", shape=(512,), dtype="float32")
+
+def is_compiled(mod, target):
+    try:
+        params = {}
+        executor = Executor("aot", {"link-params": True})
+        lowered = tvm.relay.build(
+            mod, 
+            tvm.target.Target(target, host=target),
+            executor=executor,
+            params=params,
+        )
+        return True
+    except:
+        return False
+
+#creating test case
+def test_case(boo):
+    if boo:
+        l2_conv = relay.nn.conv2d(l1_relu, l2_weights, kernel_size = [3, 3], data_layout = "CWHN", kernel_layout = "HWIO", out_dtype="float32", padding=[1,1], strides=(2,2))
+    else:
+        l2_conv = relay.nn.conv2d(l1_relu, l2_weights, kernel_size = [3, 3], data_layout = "NHWC", kernel_layout = "HWIO", out_dtype="float32", padding=[1,1], strides=(2,2))
+    l2_bias_add = relay.nn.bias_add(l2_conv, l2_bias, axis=3)
+    l2_relu = relay.nn.relu(l2_bias_add)
+
+    pooling = relay.nn.avg_pool2d(l2_relu, pool_size=(8,8), layout="NHWC")
+    reshape = relay.reshape(pooling, newshape=[1,512])
+
+    dense_weights = relay.var("dense_weights", shape=(10,512), dtype="float32")
+    dense = relay.nn.dense(reshape, dense_weights)
+    softmax = relay.nn.softmax(dense, axis=1)
+    mod = tvm.IRModule.from_expr(softmax)
+    return mod
+
+
+#manually creating expected output
+result = relay.nn.conv2d(relay.var("temp", type_annotation=relay.transform.InferTypeLocal(l1_relu)), relay.var("temp1", type_annotation=relay.transform.InferTypeLocal(l2_weights)), kernel_size = [3, 3], data_layout = "CWHN", kernel_layout = "HWIO", out_dtype="float32", padding=[1,1], strides=(2,2)) 
+print("module read")
+func = relay.Function(relay.analysis.free_vars(relay.expr.Tuple([result])), relay.expr.Tuple([result]))
+mod_result = tvm.IRModule.from_expr(func)
+
+#print(smallest_ir(test_case(True), target, is_compiled))
+#checking if the result is as expected
+print(tvm.ir.structural_equal(mod_result, smallest_ir(test_case(True), target, is_compiled)))
+print(tvm.ir.structural_equal(None, smallest_ir(test_case(False), target, is_compiled)))
+#print(smallest_ir(mod, target))
+#import pdb; pdb.set_trace()


### PR DESCRIPTION
Given a relay graph that fails compilation, this PR automatically generates a small subgraph that reproduces the compilation error. The aim is to create a tool for Relay graphs similar to the Bugpoint tool in LLVM, and this PR is a step in that direction.