### PR TITLE
[Unity][CUTLASS] Support `out_dtype = "float32"` for FasterTransformer kernel

### DIFF
--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -237,7 +237,7 @@ def _check_decode_matmul(ctx):
     if not _check_residual(root, ctx):
         return False
 
-    # out_dtype = "float32" not supported.
+    # out_dtype = "float32" not supported unless matmul is followed by cast to fp16.
     if root.struct_info.dtype == "float32":
         return False
 
@@ -299,6 +299,9 @@ def decode_matmul_patterns():
         )
         matmul = is_op("relax.matmul")(x, w)
 
+        if "cast" in name:
+            matmul = is_op("relax.astype")(matmul)
+
         annotations = {
             "root": matmul,
             "lhs": x,
@@ -321,7 +324,10 @@ def decode_matmul_patterns():
     return [
         _decode_matmul_pattern("cutlass.decode_matmul"),
         _decode_matmul_pattern("cutlass.decode_matmul_bias"),
+        _decode_matmul_pattern("cutlass.decode_matmul_cast"),
+        _decode_matmul_pattern("cutlass.decode_matmul_cast_bias"),
         _decode_matmul_pattern("cutlass.decode_matmul_bias_gelu"),
+        _decode_matmul_pattern("cutlass.decode_matmul_cast_bias_gelu"),
     ]
 
 


### PR DESCRIPTION
The FT kernel requires the output pointer type to be fp16, so we haven't supported offloading `matmul` with `out_dtype="float32"`. But if such matmul is immediately followed by a cast to fp16, we can match and replace the whole `matmul -> cast` with the FT kernel. 

Such case arises if a user wants to do fp32 accum during matmul. It turns out the FT kernel always does fp32 accumulation internally regardless of the output dtype, so we are not losing any precision by offloading `matmul(..., out_dtype = "float32") -> cast` to the fp16 A - int B FT kernel.

@vinx13 @sunggg @yzh119   