### PR TITLE
[Unity] Avoid overloaded-virtual warnings

### DIFF
--- a/src/relax/distributed/transform/propagate_sharding.cc
+++ b/src/relax/distributed/transform/propagate_sharding.cc
@@ -325,6 +325,8 @@ class DistributedIRBuilder : public ExprMutator {
   }
 
  private:
+  using ExprMutator::VisitExpr_;
+
   Expr RewriteInputTensorAndConstant(Expr tensor) {
     const auto* sinfo = GetStructInfoAs<TensorStructInfoNode>(tensor);
     int ndim = sinfo->ndim;

--- a/src/relax/transform/remove_purity_checking.cc
+++ b/src/relax/transform/remove_purity_checking.cc
@@ -30,6 +30,8 @@ namespace relax {
 
 class PurityRemover : public ExprMutator {
  public:
+  using ExprMutator::VisitExpr_;
+
   Function RemovePurity(Function func) {
     bool purity = func->is_pure;
     auto ret = func;


### PR DESCRIPTION
This patch fixes a couple of build warnings `-Woverloaded-virtual` that come up due to the `VisitExpr_` definitions