### PR TITLE
[Relay] add redirecting operation to dataflow pattern graph

### DIFF
--- a/include/tvm/relay/dataflow_pattern.h
+++ b/include/tvm/relay/dataflow_pattern.h
@@ -362,6 +362,10 @@ class WildcardPatternNode : public DFPatternNode {
  public:
   void VisitAttrs(tvm::AttrVisitor* v) {}
 
+  /*! \brief If the wildcard is redirected, then pattern is not nullptr, and the wildcard
+   * redirects to the pattern. */
+  Optional<DFPattern> pattern{nullptr};
+
   static constexpr const char* _type_key = "relay.dataflow_pattern.WildcardPattern";
   TVM_DECLARE_FINAL_OBJECT_INFO(WildcardPatternNode, DFPatternNode);
 };
@@ -372,6 +376,8 @@ class WildcardPatternNode : public DFPatternNode {
 class WildcardPattern : public DFPattern {
  public:
   TVM_DEFINE_OBJECT_REF_METHODS(WildcardPattern, DFPattern, WildcardPatternNode);
+
+  void redirect_to(DFPattern pat) const;
 };
 
 class TypePattern;

--- a/python/tvm/relay/dataflow_pattern/__init__.py
+++ b/python/tvm/relay/dataflow_pattern/__init__.py
@@ -733,7 +733,7 @@ class WildcardPattern(DFPattern):
         pat: relay.dataflow_pattern.DFPattern
             The pattern that wildcard is redirected to.
         """
-        ffi.WildcardPattern_redirect_to(self, pat);
+        ffi.WildcardPattern_redirect_to(self, pat)
 
 
 @register_df_node

--- a/python/tvm/relay/dataflow_pattern/__init__.py
+++ b/python/tvm/relay/dataflow_pattern/__init__.py
@@ -722,6 +722,19 @@ class WildcardPattern(DFPattern):
     def __init__(self):
         self.__init_handle_by_constructor__(ffi.WildcardPattern)
 
+    def redirect_to(
+        self,
+        pat: "DFPattern",
+    ):
+        """Redirect the WildcardPattern to another pattern
+
+        Parameters
+        ----------
+        pat: relay.dataflow_pattern.DFPattern
+            The pattern that wildcard is redirected to.
+        """
+        ffi.WildcardPattern_redirect_to(self, pat);
+
 
 @register_df_node
 class TypePattern(DFPattern):

--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -485,7 +485,11 @@ bool DFPatternMatcher::VisitDFPattern_(const ConstantPatternNode* op, const Expr
 }
 
 bool DFPatternMatcher::VisitDFPattern_(const WildcardPatternNode* op, const Expr& expr) {
-  return true;
+  if (op->pattern) {
+    return VisitDFPattern(op->pattern.value(), expr);
+  } else {
+    return true;
+  }
 }
 
 bool MatchPattern(DFPattern pattern, Expr expr) {

--- a/src/relay/ir/dataflow_pattern.cc
+++ b/src/relay/ir/dataflow_pattern.cc
@@ -344,7 +344,17 @@ TVM_STATIC_IR_FUNCTOR(DFPatternPrinter, vtable)
                        << ")";
     });
 
+void WildcardPattern::redirect_to(DFPattern pat) const {
+  WildcardPatternNode* ptr = static_cast<WildcardPatternNode*>(get_mutable());
+  ptr->pattern = pat;
+}
+
 TVM_REGISTER_NODE_TYPE(WildcardPatternNode);
+
+TVM_REGISTER_GLOBAL("relay.dataflow_pattern.WildcardPattern_redirect_to")
+    .set_body_typed([](WildcardPattern wildcard, DFPattern pat) {
+      return wildcard.redirect_to(pat);
+    });
 
 TVM_REGISTER_GLOBAL("relay.dataflow_pattern.WildcardPattern").set_body_typed([]() {
   auto w = WildcardPattern(make_object<WildcardPatternNode>());

--- a/src/relay/ir/dataflow_pattern_functor.cc
+++ b/src/relay/ir/dataflow_pattern_functor.cc
@@ -105,7 +105,11 @@ void DFPatternVisitor::VisitDFPattern_(const VarPatternNode* op) {}
 
 void DFPatternVisitor::VisitDFPattern_(const ConstantPatternNode* op) {}
 
-void DFPatternVisitor::VisitDFPattern_(const WildcardPatternNode* op) {}
+void DFPatternVisitor::VisitDFPattern_(const WildcardPatternNode* op) {
+  if (op->pattern) {
+    VisitDFPattern(op->pattern.value());
+  }
+}
 
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/ir/indexed_graph.cc
+++ b/src/relay/ir/indexed_graph.cc
@@ -537,7 +537,12 @@ std::unique_ptr<IndexedGraph<DFPattern>> CreateIndexedGraph(const DFPattern& pat
 
     void VisitDFPattern_(const VarPatternNode* op) override {}
 
-    void VisitDFPattern_(const WildcardPatternNode* op) override {}
+    void VisitDFPattern_(const WildcardPatternNode* op) override {
+      if (op->pattern) {
+        auto node = graph_->item_to_node(GetRef<WildcardPattern>(op));
+        AddOutput(op->pattern.value(), node);
+      }
+    }
 
     std::unique_ptr<IndexedGraph<DFPattern>> graph_;
   };


### PR DESCRIPTION
This PR adds the redirecting operation for dataflow pattern, which can redirect a WildcardPattern to any other DFPattern. With the redirecting operation, one can construct recursive dataflow pattern. Some test cases are added.

This PR is part of the [pre-RFC](https://discuss.tvm.apache.org/t/on-the-applications-of-the-composition-of-dataflow-patterns/15344?u=kfeng123)