### PR TITLE
[CI][Docker] Add riscv-gnu-toolchain to ci_riscv

### DIFF
--- a/docker/Dockerfile.ci_riscv
+++ b/docker/Dockerfile.ci_riscv
@@ -91,6 +91,10 @@ COPY install/ubuntu_install_zephyr_sdk.sh /install/ubuntu_install_zephyr_sdk.sh
 RUN bash /install/ubuntu_install_zephyr_sdk.sh /opt/zephyr-sdk
 ENV PATH /opt/zephyr-sdk/sysroots/x86_64-pokysdk-linux/usr/bin:$PATH
 
+# Install RISC-V gcc toolchain with spike and proxy kernel (pk)
+COPY install/ubuntu_install_riscv_gcc_toolchain.sh /install/ubuntu_install_riscv_gcc_toolchain.sh
+RUN bash /install/ubuntu_install_riscv_gcc_toolchain.sh /opt/riscv_gcc_toolchain
+
 # Download RISC-V gcc toolchain (linux)
 COPY install/ubuntu_download_xuantie_gcc_linux.sh /install/ubuntu_download_xuantie_gcc_linux.sh
 RUN bash /install/ubuntu_download_xuantie_gcc_linux.sh /opt/riscv/riscv64-unknown-linux-gnu

--- a/docker/install/ubuntu_install_riscv_gcc_toolchain.sh
+++ b/docker/install/ubuntu_install_riscv_gcc_toolchain.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+function show_usage() {
+    cat <<EOF
+Usage: docker/install/ubuntu_install_riscv_gcc_toolchain.sh <INSTALLATION_PATH>
+INSTALLATION_PATH is the installation path for the toolchain.
+EOF
+}
+
+if [ "$#" -lt 1 -o "$1" == "--help" -o "$1" == "-h" ]; then
+    show_usage
+    exit 1
+fi
+
+INSTALLATION_PATH=$1
+shift
+
+# Create installation path directory
+mkdir -p "${INSTALLATION_PATH}"
+
+# Download and extract RISC-V gcc
+TMPDIR=$(mktemp -d)
+RISCV_GCC_EXT="tar.gz"
+RLS_TAG="2023.07.07"
+RISCV_GCC_URL="https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${RLS_TAG}/riscv64-glibc-ubuntu-22.04-gcc-nightly-${RLS_TAG}-nightly.${RISCV_GCC_EXT}"
+
+DOWNLOAD_PATH="$TMPDIR/${RLS_TAG}.${RISCV_GCC_EXT}"
+
+wget ${RISCV_GCC_URL} -O "${DOWNLOAD_PATH}"
+tar -xf "${DOWNLOAD_PATH}" -C "${INSTALLATION_PATH}" --strip-components=1
+
+export PATH=$INSTALLATION_PATH/bin:$PATH
+
+sudo apt-install-and-clear -y --no-install-recommends device-tree-compiler
+
+# Install spike
+mkdir $TMPDIR/spike
+cd $TMPDIR/spike
+git clone https://github.com/riscv/riscv-isa-sim.git
+pushd riscv-isa-sim
+mkdir build
+cd build
+../configure --prefix=$INSTALLATION_PATH
+make -j`nproc`
+make install
+popd
+
+# Install pk
+git clone https://github.com/riscv/riscv-pk.git
+pushd riscv-pk
+mkdir build
+pushd build
+../configure --prefix=`pwd`/install --host=riscv64-unknown-linux-gnu
+make -j`nproc`
+make install
+cp ./pk $INSTALLATION_PATH/bin/pk
+
+# cleanup
+rm -rf $TMPDIR
+
+echo "SUCCESS"


### PR DESCRIPTION
Currently the ci_riscv docker image uses GNU toolchain for Xuantie RISC-V CPU, which does not contain V-extension instructions. This PR adds GNU toolchain for RISC-V from RISC-V Collaboration. This update is required for the [PR](https://github.com/apache/tvm/pull/14836)