### PR TITLE
[TIR][BugFix]Ensure the Var's scope is correct

### DIFF
--- a/tests/python/unittest/test_tir_transform_bf16_legalize.py
+++ b/tests/python/unittest/test_tir_transform_bf16_legalize.py
@@ -24,7 +24,9 @@ def get_before():
     class Before:
         @T.prim_func
         def main(
-            Aptr: T.handle("bfloat16"), Bptr: T.handle("bfloat16"), Dptr: T.handle("bfloat16")
+            Aptr: T.handle("bfloat16", storage_scope="shared"),
+            Bptr: T.handle("bfloat16", storage_scope="shared"),
+            Dptr: T.handle("bfloat16"),
         ):
             T.func_attr({"global_symbol": "main"})
             A = T.decl_buffer((100,), "bfloat16", data=Aptr)
@@ -65,7 +67,9 @@ def get_after_compute_legalize():
     class After:
         @T.prim_func
         def main(
-            Aptr: T.handle("bfloat16"), Bptr: T.handle("bfloat16"), Dptr: T.handle("bfloat16")
+            Aptr: T.handle("bfloat16", storage_scope="shared"),
+            Bptr: T.handle("bfloat16", storage_scope="shared"),
+            Dptr: T.handle("bfloat16"),
         ):
             T.func_attr({"global_symbol": "main"})
             A = T.decl_buffer((100,), "bfloat16", data=Aptr)
@@ -83,7 +87,11 @@ def get_after_storage_legalize():
     @tvm.script.ir_module
     class After:
         @T.prim_func
-        def main(Aptr: T.handle("uint16"), Bptr: T.handle("uint16"), Dptr: T.handle("uint16")):
+        def main(
+            Aptr: T.handle("uint16", storage_scope="shared"),
+            Bptr: T.handle("uint16", storage_scope="shared"),
+            Dptr: T.handle("uint16"),
+        ):
             T.func_attr({"global_symbol": "main"})
             A = T.decl_buffer((100,), "uint16", data=Aptr)
             B = T.decl_buffer((100,), "uint16", data=Bptr)
@@ -103,7 +111,6 @@ def test_bf16_compute_legalize():
     # with this repeative optimizations
     after = tvm.tir.transform.BF16ComputeLegalize()(before)
     after = tvm.tir.transform.BF16ComputeLegalize()(after)
-
     tvm.ir.assert_structural_equal(after, expected)
 
 

--- a/tests/python/unittest/test_tir_transform_bf16_legalize.py
+++ b/tests/python/unittest/test_tir_transform_bf16_legalize.py
@@ -122,7 +122,7 @@ def test_bf16_storage_scope():
             def main(
                 Aptr: T.handle("bfloat16", storage_scope="shared"),
                 Bptr: T.handle("bfloat16", storage_scope="local"),
-                Dptr: T.handle("bfloat16", storage_scope="global"),
+                Dptr: T.handle("bfloat16"),
             ):
                 T.func_attr({"global_symbol": "main"})
                 A = T.decl_buffer((100,), "bfloat16", data=Aptr)
@@ -142,7 +142,7 @@ def test_bf16_storage_scope():
             def main(
                 Aptr: T.handle("bfloat16", storage_scope="shared"),
                 Bptr: T.handle("bfloat16", storage_scope="local"),
-                Dptr: T.handle("bfloat16", storage_scope="global"),
+                Dptr: T.handle("bfloat16"),
             ):
                 T.func_attr({"global_symbol": "main"})
                 A = T.decl_buffer((100,), "bfloat16", data=Aptr)
@@ -162,7 +162,7 @@ def test_bf16_storage_scope():
             def main(
                 Aptr: T.handle("uint16", storage_scope="shared"),
                 Bptr: T.handle("uint16", storage_scope="local"),
-                Dptr: T.handle("uint16", storage_scope="global"),
+                Dptr: T.handle("uint16"),
             ):
                 T.func_attr({"global_symbol": "main"})
                 A = T.decl_buffer((100,), "uint16", data=Aptr)

--- a/tests/python/unittest/test_tir_transform_bf16_legalize.py
+++ b/tests/python/unittest/test_tir_transform_bf16_legalize.py
@@ -24,9 +24,7 @@ def get_before():
     class Before:
         @T.prim_func
         def main(
-            Aptr: T.handle("bfloat16", storage_scope="shared"),
-            Bptr: T.handle("bfloat16", storage_scope="shared"),
-            Dptr: T.handle("bfloat16"),
+            Aptr: T.handle("bfloat16"), Bptr: T.handle("bfloat16"), Dptr: T.handle("bfloat16")
         ):
             T.func_attr({"global_symbol": "main"})
             A = T.decl_buffer((100,), "bfloat16", data=Aptr)
@@ -67,9 +65,7 @@ def get_after_compute_legalize():
     class After:
         @T.prim_func
         def main(
-            Aptr: T.handle("bfloat16", storage_scope="shared"),
-            Bptr: T.handle("bfloat16", storage_scope="shared"),
-            Dptr: T.handle("bfloat16"),
+            Aptr: T.handle("bfloat16"), Bptr: T.handle("bfloat16"), Dptr: T.handle("bfloat16")
         ):
             T.func_attr({"global_symbol": "main"})
             A = T.decl_buffer((100,), "bfloat16", data=Aptr)
@@ -87,11 +83,7 @@ def get_after_storage_legalize():
     @tvm.script.ir_module
     class After:
         @T.prim_func
-        def main(
-            Aptr: T.handle("uint16", storage_scope="shared"),
-            Bptr: T.handle("uint16", storage_scope="shared"),
-            Dptr: T.handle("uint16"),
-        ):
+        def main(Aptr: T.handle("uint16"), Bptr: T.handle("uint16"), Dptr: T.handle("uint16")):
             T.func_attr({"global_symbol": "main"})
             A = T.decl_buffer((100,), "uint16", data=Aptr)
             B = T.decl_buffer((100,), "uint16", data=Bptr)
@@ -111,6 +103,7 @@ def test_bf16_compute_legalize():
     # with this repeative optimizations
     after = tvm.tir.transform.BF16ComputeLegalize()(before)
     after = tvm.tir.transform.BF16ComputeLegalize()(after)
+
     tvm.ir.assert_structural_equal(after, expected)
 
 
@@ -121,5 +114,74 @@ def test_bf16_storage_legalize():
     tvm.ir.assert_structural_equal(after, expected)
 
 
+def test_bf16_storage_scope():
+    def get_before():
+        @tvm.script.ir_module
+        class Before:
+            @T.prim_func
+            def main(
+                Aptr: T.handle("bfloat16", storage_scope="shared"),
+                Bptr: T.handle("bfloat16", storage_scope="local"),
+                Dptr: T.handle("bfloat16", storage_scope="global"),
+            ):
+                T.func_attr({"global_symbol": "main"})
+                A = T.decl_buffer((100,), "bfloat16", data=Aptr)
+                B = T.decl_buffer((100,), "bfloat16", data=Bptr)
+                D = T.decl_buffer((100,), "bfloat16", data=Dptr)
+                C = T.decl_buffer((100,), "bfloat16")
+                for i in T.grid(100):
+                    C[i] = A[i] + B[i]
+                    D[i] = T.exp(C[i])
+
+        return Before
+
+    def after_compute_legalize():
+        @tvm.script.ir_module
+        class After:
+            @T.prim_func
+            def main(
+                Aptr: T.handle("bfloat16", storage_scope="shared"),
+                Bptr: T.handle("bfloat16", storage_scope="local"),
+                Dptr: T.handle("bfloat16", storage_scope="global"),
+            ):
+                T.func_attr({"global_symbol": "main"})
+                A = T.decl_buffer((100,), "bfloat16", data=Aptr)
+                B = T.decl_buffer((100,), "bfloat16", data=Bptr)
+                D = T.decl_buffer((100,), "bfloat16", data=Dptr)
+                C = T.decl_buffer((100,), "float32")
+                for i in T.grid(100):
+                    C[i] = bf16tof32(A[i]) + bf16tof32(B[i])
+                    D[i] = f32tobf16(T.exp(C[i]))
+
+        return After
+
+    def after_storage_legalize():
+        @tvm.script.ir_module
+        class After:
+            @T.prim_func
+            def main(
+                Aptr: T.handle("uint16", storage_scope="shared"),
+                Bptr: T.handle("uint16", storage_scope="local"),
+                Dptr: T.handle("uint16", storage_scope="global"),
+            ):
+                T.func_attr({"global_symbol": "main"})
+                A = T.decl_buffer((100,), "uint16", data=Aptr)
+                B = T.decl_buffer((100,), "uint16", data=Bptr)
+                D = T.decl_buffer((100,), "uint16", data=Dptr)
+                C = T.decl_buffer((100,), "float32")
+                for i in T.grid(100):
+                    C[i] = u16tof32(A[i]) + u16tof32(B[i])
+                    D[i] = f32tou16(T.exp(C[i]))
+
+        return After
+
+    before = get_before()
+    after_compute = tvm.tir.transform.BF16ComputeLegalize()(before)
+    after_storage = tvm.tir.transform.BF16StorageLegalize()(after_compute)
+    tvm.ir.assert_structural_equal(after_compute, after_compute_legalize())
+    tvm.ir.assert_structural_equal(after_storage, after_storage_legalize())
+
+
 if __name__ == "__main__":
     test_bf16_storage_legalize()
+    test_bf16_storage_scope()


### PR DESCRIPTION
In the previous bf16legalize pass, the `storage_scope` of the original BufferVar was not retained, but all changed to the default value (`global`). The purpose of this PR is to ensure that Var's scope is always correct