### PR TITLE
[TVMScript] Support starred indices in for-loop

### DIFF
--- a/python/tvm/script/ir_builder/tir/ir.py
+++ b/python/tvm/script/ir_builder/tir/ir.py
@@ -1277,6 +1277,9 @@ def buffer_store(
     """
     from tvm.arith import Analyzer  # pylint: disable=import-outside-toplevel
 
+    if not isinstance(indices, (list, tuple, ir.Array)):
+        indices = [indices]
+
     expr_indices = []
     for index in indices:
         if isinstance(index, slice):

--- a/python/tvm/script/parser/core/parser.py
+++ b/python/tvm/script/parser/core/parser.py
@@ -460,6 +460,8 @@ class Parser(doc.NodeVisitor):
             return vars
         elif isinstance(target, doc.Name):
             return {target.id}
+        elif isinstance(target, doc.Starred):
+            return self._duplicate_lhs_check(target.value)
         else:
             self.report_error(target, "Invalid type in assign statement")
             raise NotImplementedError

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -91,7 +91,7 @@ def bind_for_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> A
     res : Any
         The bound value.
     """
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, (list, tuple, tvm.ir.Array)):
         for i, v in enumerate(value):
             bind_for_value(self, node, f"{var_name}_{i}", v)
         return value
@@ -255,7 +255,7 @@ def visit_assign(self: Parser, node: doc.Assign) -> None:
             for index in lhs.slice.elts:
                 indices.append(self.eval_expr(index))
         else:
-            indices = [self.eval_expr(lhs.slice)]
+            indices = self.eval_expr(lhs.slice)
         T.buffer_store(self.eval_expr(lhs.value), rhs, indices)
     else:
         self.eval_assign(target=lhs, source=rhs, bind_value=bind_assign_value)

--- a/tests/python/unittest/test_tvmscript_error_report.py
+++ b/tests/python/unittest/test_tvmscript_error_report.py
@@ -236,11 +236,11 @@ def test_invalid_loop_var():
 
 
 def test_inconsistent_grid():
-    def inconsistent_grid() -> None:
-        for i in T.grid(16, 16):  # error
-            T.evaluate(1.0)
+    def inconsistent_grid(A: T.Buffer(16)) -> None:
+        for i in T.grid(16, 16):  # valid, i is a tuple (iter0, iter1)
+            T.evaluate(A[i])  # error
 
-    check_error(inconsistent_grid, 2)
+    check_error(inconsistent_grid, 3)
 
 
 def test_invalid_match_buffer_region():


### PR DESCRIPTION
An extension of https://github.com/apache/tvm/pull/15404, which allowed starred expressions in the rhs of assignments (e.g. `T.decl_buffer(shape=[*dim, 128])`), this PR also enables starred expressions in the lhs of assignments (e.g. `for *spatial,reduction in T.grid(*A.shape)`).