### PR TITLE
[Unity][Dlight] Avoid too large vectorization factor in caching

### DIFF
--- a/python/tvm/dlight/gpu/gemv.py
+++ b/python/tvm/dlight/gpu/gemv.py
@@ -241,8 +241,13 @@ class GEMV(ScheduleRule):
                 cache = sch.cache_read(rf, index, "shared")
                 sch.compute_at(cache, unit, preserve_unit_loops=True)
                 fused = sch.fuse(*sch.get_loops(cache)[5:])
+                loop: tir.For = sch.get(fused)
+                vec_length = vec_bytes // type_bytes
+                if isinstance(loop.extent, tir.IntImm):
+                    # avoid introducing predicates when vector length is too large
+                    vec_length = min(loop.extent // len_ty // len_tx, vec_length)
                 _, _ty, _tx, _vec = sch.split(
-                    fused, [None, len_ty, len_tx, vec_bytes // type_bytes]
+                    fused, [None, len_ty, len_tx, vec_length]
                 )
                 sch.bind(_ty, "threadIdx.y")
                 sch.bind(_tx, "threadIdx.x")

--- a/python/tvm/dlight/gpu/gemv.py
+++ b/python/tvm/dlight/gpu/gemv.py
@@ -246,9 +246,7 @@ class GEMV(ScheduleRule):
                 if isinstance(loop.extent, tir.IntImm):
                     # avoid introducing predicates when vector length is too large
                     vec_length = min(loop.extent // len_ty // len_tx, vec_length)
-                _, _ty, _tx, _vec = sch.split(
-                    fused, [None, len_ty, len_tx, vec_length]
-                )
+                _, _ty, _tx, _vec = sch.split(fused, [None, len_ty, len_tx, vec_length])
                 sch.bind(_ty, "threadIdx.y")
                 sch.bind(_tx, "threadIdx.x")
                 sch.vectorize(_vec)

--- a/tests/python/dlight/test_gpu_gemv.py
+++ b/tests/python/dlight/test_gpu_gemv.py
@@ -101,13 +101,12 @@ class TestGEMV(BaseBeforeAfter):
                             for ax0_ax1_ax2_ax3_fused_0 in range(1):
                                 for ax0_ax1_ax2_ax3_fused_1 in T.thread_binding(1, thread="threadIdx.y"):
                                     for ax0_ax1_ax2_ax3_fused_2 in T.thread_binding(32, thread="threadIdx.x"):
-                                        for ax0_ax1_ax2_ax3_fused_3 in T.vectorized(8):
+                                        for ax0_ax1_ax2_ax3_fused_3 in T.vectorized(4):
                                             with T.block("lv1637_shared"):
                                                 v0 = T.axis.spatial(1, 0)
                                                 v1 = T.axis.spatial(32, ax0_fused)
                                                 v2 = T.axis.spatial(1, 0)
-                                                v3 = T.axis.spatial(128, ax0_ax1_ax2_ax3_fused_0 * 256 + ax0_ax1_ax2_ax3_fused_1 * 256 + ax0_ax1_ax2_ax3_fused_2 * 8 + ax0_ax1_ax2_ax3_fused_3)
-                                                T.where(((ax0_ax1_ax2_ax3_fused_0 + ax0_ax1_ax2_ax3_fused_1) * 32 + ax0_ax1_ax2_ax3_fused_2) * 8 + ax0_ax1_ax2_ax3_fused_3 < 128)
+                                                v3 = T.axis.spatial(128, ax0_ax1_ax2_ax3_fused_0 * 128 + ax0_ax1_ax2_ax3_fused_1 * 128 + ax0_ax1_ax2_ax3_fused_2 * 4 + ax0_ax1_ax2_ax3_fused_3)
                                                 T.reads(lv1637[v0, v1, v2, v3])
                                                 T.writes(lv1637_shared[v0, v1, v2, v3])
                                                 lv1637_shared[v0, v1, v2, v3] = lv1637[v0, v1, v2, v3]


### PR DESCRIPTION
Sometimes the vector size can be too large and introduces predicates (this happen when reduction length >= 4096, where we use tx == 128). Choosing a smaller vector size can avoid predicates.

Benchmark on 4090 using CUDA target, seq_len = gen_len = 128, results in tok/s

Model | Before | This PR
-- | -- | --
vicuna 7b q0f16 | 62.02 | 62.64
vicuna 7b q4f16_1 | 162.90 | 163.22


cc @Hzfengsy @spectrometerHBH @masahi 