### PR TITLE
[Unity][Op] Support symbolic shape inference for slice op.

### DIFF
--- a/include/tvm/relax/attrs/index.h
+++ b/include/tvm/relax/attrs/index.h
@@ -44,6 +44,7 @@ struct StridedSliceAttrs : public tvm::AttrsNode<StridedSliceAttrs> {
   Array<PrimExpr> begin;
   Array<PrimExpr> end;
   Optional<Array<PrimExpr>> strides;
+  bool assume_inbound;
 
   TVM_DECLARE_ATTRS(StridedSliceAttrs, "relax.attrs.StridedSliceAttrs") {
     TVM_ATTR_FIELD(axes).describe("Axes along which slicing is applied.");
@@ -53,6 +54,11 @@ struct StridedSliceAttrs : public tvm::AttrsNode<StridedSliceAttrs> {
         "Specifies the stride values, it can be negative in that case, the input tensor will be "
         "reversed in that particular axis. If not specified, it by default is an list of ones of "
         "the same length as `axes`.");
+    TVM_ATTR_FIELD(assume_inbound)
+        .set_default(true)
+        .describe(
+            "Whether to assume the indices are in bound. If it is set to false, "
+            "out of bound indices will be clipped to the bound.");
   }
 };  // struct StridedSliceAttrs
 

--- a/python/tvm/relax/op/index.py
+++ b/python/tvm/relax/op/index.py
@@ -58,6 +58,7 @@ def strided_slice(
     begin: List[PrimExprLike],
     end: List[PrimExprLike],
     strides: Optional[List[PrimExprLike]] = None,
+    assume_inbound: bool = False,
 ) -> Expr:
     """Strided slice of a tensor.
 
@@ -80,6 +81,9 @@ def strided_slice(
         the input tensor will be reversed in that particular axis.
         If not specified, it by default is an list of ones of the same length as `axes`.
 
+    assume_inbound : bool
+        Whether to assume the indices are in bound. If it is set to false,
+        out of bound indices will be clipped to the bound.
     Returns
     -------
     ret : relax.Expr
@@ -90,7 +94,7 @@ def strided_slice(
     strided_slice require the input `begin`, `end` and `strides` to have the
     same length as `axes`.
     """
-    return _ffi_api.strided_slice(x, axes, begin, end, strides)  # type: ignore
+    return _ffi_api.strided_slice(x, axes, begin, end, strides, assume_inbound)  # type: ignore
 
 
 def dynamic_strided_slice(
@@ -99,7 +103,7 @@ def dynamic_strided_slice(
     end: Expr,
     strides: Expr,
 ) -> Expr:
-    """Dynamic strided slice of a tensor. `begin`, `end`, `strids` can be computed at runtime.
+    """Dynamic strided slice of a tensor. `begin`, `end`, `strides` can be computed at runtime.
 
     Parameters
     ----------

--- a/src/relax/op/tensor/index.h
+++ b/src/relax/op/tensor/index.h
@@ -51,13 +51,15 @@ Expr take(Expr x, Expr indices, Optional<Integer> axis);
  * \param strides Specifies the stride values, it can be negative in that case,
  * the input tensor will be reversed in that particular axis.
  * If it is `NullOpt`, it by default is an list of ones of the same length as `axes`.
+ * \param assume_inbound Whether to assume the indices are in bound.
  * \return The sliced result
  */
-Expr strided_slice(Expr x,                 //
-                   Array<Integer> axes,    //
-                   Array<PrimExpr> begin,  //
-                   Array<PrimExpr> end,    //
-                   Optional<Array<PrimExpr>> strides);
+Expr strided_slice(Expr x,                             //
+                   Array<Integer> axes,                //
+                   Array<PrimExpr> begin,              //
+                   Array<PrimExpr> end,                //
+                   Optional<Array<PrimExpr>> strides,  //
+                   bool assume_inbound = false);
 
 }  // namespace relax
 }  // namespace tvm


### PR DESCRIPTION
This PR improves two things:
1. Support symbolic `begin` and `end` for slice op.
2. Add a new attribute `assume_inbound` for slice op. If `assume_inbound` is set to True, the slice op will assume the `begin` and `end` are always inbound, which will simplify the shape deduction.

cc @tqchen @MasterJH5574 