### PR TITLE
[Unity] Eslint and TypeScript configuration fix

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -21,7 +21,8 @@
       "rules": {
         "require-jsdoc": 0,
         "@typescript-eslint/no-explicit-any": 0,
-        "@typescript-eslint/no-empty-function": 0
+        "@typescript-eslint/no-empty-function": 0,
+        "@typescript-eslint/ban-types": "off"
       }
     },
     {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "tvmjs",
-  "version": "0.13.0-dev0",
+  "version": "0.14.0-dev0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tvmjs",
-      "version": "0.13.0-dev0",
+      "version": "0.14.0-dev0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^20.0.0",
         "@rollup/plugin-node-resolve": "^13.0.4",
+        "@types/node": "^20.4.5",
         "@typescript-eslint/eslint-plugin": "^5.59.6",
         "@typescript-eslint/parser": "^5.59.6",
         "@webgpu/types": "^0.1.24",
@@ -1523,9 +1524,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "20.4.5",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.4.5.tgz",
+      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {

--- a/web/package.json
+++ b/web/package.json
@@ -22,17 +22,18 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-node-resolve": "^13.0.4",
+    "@types/node": "^20.4.5",
     "@typescript-eslint/eslint-plugin": "^5.59.6",
     "@typescript-eslint/parser": "^5.59.6",
+    "@webgpu/types": "^0.1.24",
     "eslint": "^8.41.0",
-    "rollup": "^2.56.2",
-    "rollup-plugin-typescript2": "^0.34.1",
-    "rollup-plugin-ignore": "^1.0.10",
     "jest": "^26.0.1",
+    "rollup": "^2.56.2",
+    "rollup-plugin-ignore": "^1.0.10",
+    "rollup-plugin-typescript2": "^0.34.1",
     "typedoc": "^0.24.7",
     "typedoc-plugin-missing-exports": "2.0.0",
     "typescript": "^4.9.5",
-    "ws": "^7.2.5",
-    "@webgpu/types": "^0.1.24"
+    "ws": "^7.2.5"
   }
 }

--- a/web/src/rpc_server.ts
+++ b/web/src/rpc_server.ts
@@ -102,8 +102,8 @@ export class RPCServer {
     key: string,
     getImports: () => Record<string, unknown>,
     logger: (msg: string) => void = console.log,
-    ndarrayCacheUrl: string = "",
-    ndarrayCacheDevice: string = "cpu",
+    ndarrayCacheUrl = "",
+    ndarrayCacheDevice = "cpu",
     initProgressCallback: runtime.InitProgressCallback | undefined = undefined,
     asyncOnServerLoad: ((inst: runtime.Instance) => Promise<void>) | undefined = undefined,
   ) {

--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -374,7 +374,7 @@ export class DLDevice {
 /**
  * The data type code in DLDataType
  */
-export const enum DLDataTypeCode {
+export enum DLDataTypeCode {
   Int = 0,
   UInt = 1,
   Float = 2,
@@ -896,7 +896,7 @@ export class TVMString extends TVMObject {
   }
 }
 
-export const enum VMAllocatorKind {
+export enum VMAllocatorKind {
   NAIVE_ALLOCATOR = 1,
   POOLED_ALLOCATOR = 2,
 }
@@ -949,7 +949,7 @@ export class VirtualMachine implements Disposable {
 }
 
 /** Code used as the first argument of the async callback. */
-const enum AyncCallbackCode {
+enum AyncCallbackCode {
   kReturn = 4,
   kException = 5,
 }

--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -949,7 +949,7 @@ export class VirtualMachine implements Disposable {
 }
 
 /** Code used as the first argument of the async callback. */
-enum AyncCallbackCode {
+enum AsyncCallbackCode {
   kReturn = 4,
   kException = 5,
 }
@@ -1886,7 +1886,7 @@ export class Instance implements Disposable {
       const callback = this.detachFromCurrentScope(args[args.length - 1] as PackedFunc);
       const promise: Promise<any> = func(...fargs);
       promise.then((rv: any) => {
-        callback(this.scalar(AyncCallbackCode.kReturn, "int32"), rv);
+        callback(this.scalar(AsyncCallbackCode.kReturn, "int32"), rv);
         callback.dispose();
       });
     };
@@ -1894,10 +1894,10 @@ export class Instance implements Disposable {
   }
 
   /**
-   * Asynchrously load webgpu pipelines when possible.
+   * Asynchronously load webgpu pipelines when possible.
    * @param mod The input module.
    */
-  async asyncLoadWebGPUPiplines(mod: Module): Promise<void> {
+  async asyncLoadWebGPUPipelines(mod: Module): Promise<void> {
     if (this.lib.webGPUContext == undefined) throw Error("WebGPU not initialied");
     const webgpuContext = this.lib.webGPUContext;
 

--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -248,17 +248,17 @@ class RuntimeContext implements Disposable {
 
   detachFromCurrentScope<T extends Disposable>(obj: T): T {
     const currScope = this.autoDisposeScope[this.autoDisposeScope.length - 1];
-    let occurance = 0;
+    let occurrence = 0;
     for (let i = 0; i < currScope.length; ++i) {
       if (currScope[i] === obj) {
-        occurance += 1;
+        occurrence += 1;
         currScope[i] = undefined;
       }
     }
-    if (occurance == 0) {
+    if (occurrence === 0) {
       throw Error("Cannot find obj in the current auto conversion pool");
     }
-    if (occurance > 1) {
+    if (occurrence > 1) {
       throw Error("Value attached to scope multiple times");
     }
     return obj;
@@ -302,7 +302,7 @@ class PackedFuncCell implements Disposable {
     }
   }
 
-  getHandle(requireNotNull: boolean = true): Pointer {
+  getHandle(requireNotNull = true): Pointer {
     if (requireNotNull && this.handle == 0) {
       throw Error("PackedFunc has already been disposed");
     }
@@ -508,7 +508,7 @@ export class NDArray implements Disposable {
    * @param requireNotNull require handle is not null.
    * @returns The handle.
    */
-  getHandle(requireNotNull: boolean = true): Pointer {
+  getHandle(requireNotNull = true): Pointer {
     if (requireNotNull && this.handle == 0) {
       throw Error("NDArray has already been disposed");
     }
@@ -709,7 +709,7 @@ export class Module implements Disposable {
    * @param requireNotNull require handle is not null.
    * @returns The handle.
    */
-  getHandle(requireNotNull: boolean = true): Pointer {
+  getHandle(requireNotNull = true): Pointer {
     if (requireNotNull && this.handle == 0) {
       throw Error("Module has already been disposed");
     }
@@ -722,7 +722,7 @@ export class Module implements Disposable {
    * @param queryImports Whether to also query imports
    * @returns The result function.
    */
-  getFunction(name: string, queryImports: boolean = true): PackedFunc {
+  getFunction(name: string, queryImports = true): PackedFunc {
     if (this.handle == 0) {
       throw Error("Module has already been disposed");
     }
@@ -1304,7 +1304,7 @@ export class Instance implements Disposable {
     return this.getGlobalFuncInternal(name, true);
   }
 
-  private getGlobalFuncInternal(name: string, autoAttachToScope: boolean = true): PackedFunc {
+  private getGlobalFuncInternal(name: string, autoAttachToScope = true): PackedFunc {
     const stack = this.lib.getOrAllocCallStack();
     const nameOffset = stack.allocRawBytes(name.length + 1);
     stack.storeRawBytes(nameOffset, StringToUint8Array(name));
@@ -1419,7 +1419,7 @@ export class Instance implements Disposable {
    * @param name The name of the array.
    * @param arr The content.
    */
-  ndarrayCacheUpdate(name: string, arr: NDArray, override: boolean = false) {
+  ndarrayCacheUpdate(name: string, arr: NDArray, override = false) {
     this.ctx.arrayCacheUpdate(name, arr, this.scalar(override ? 1 : 0, "int32"));
   }
 
@@ -1443,7 +1443,7 @@ export class Instance implements Disposable {
   async fetchNDArrayCache(
     ndarrayCacheUrl: string,
     device: DLDevice,
-    cacheScope: string = "tvmjs"
+    cacheScope = "tvmjs"
   ): Promise<any> {
     const artifactCache = new ArtifactCache(cacheScope);
     const jsonUrl = new URL("ndarray-cache.json", ndarrayCacheUrl).href;
@@ -1474,12 +1474,12 @@ export class Instance implements Disposable {
     artifactCache: ArtifactCache
   ) {
     const perf = compact.getPerformance();
-    let tstart = perf.now();
+    const tstart = perf.now();
 
     let totalBytes = 0;
     for (let i = 0; i < list.length; ++i) {
       totalBytes += list[i].nbytes;
-    };
+    }
     let fetchedBytes = 0;
     let timeElapsed = 0;
 
@@ -1923,7 +1923,7 @@ export class Instance implements Disposable {
     for (const [key, finfo] of fmapEntries) {
       const code = fGetShader(key);
       assert(key == finfo.name);
-      const event = webgpuContext.createShaderAsync(finfo, code).then((func: Function) => {
+      const event = webgpuContext.createShaderAsync(finfo, code).then((func) => {
         this.beginScope();
         fUpdatePrebuild(key, func);
         this.endScope();
@@ -2022,7 +2022,7 @@ export class Instance implements Disposable {
         let absoluteZeroTimes = 0;
         do {
           if (durationMs > 0.0) {
-            let golden_ratio = 1.618;
+            const golden_ratio = 1.618;
             setupNumber = Math.floor(
               Math.max(minRepeatMs / (durationMs / setupNumber) + 1, setupNumber * golden_ratio)
             );
@@ -2374,7 +2374,7 @@ export function instantiate(
 
 export async function hasNDArrayInCache(
   ndarrayCacheUrl: string,
-  cacheScope: string = "tvmjs"
+  cacheScope = "tvmjs"
 ): Promise<boolean> {
   const artifactCache = new ArtifactCache(cacheScope);
   const jsonUrl = new URL("ndarray-cache.json", ndarrayCacheUrl).href;

--- a/web/src/tvmjs_runtime_wasi.d.ts
+++ b/web/src/tvmjs_runtime_wasi.d.ts
@@ -3,6 +3,6 @@ import { LibraryProvider } from "./types";
 export declare class EmccWASI implements LibraryProvider {
   imports: Record<string, any>;
   start: (inst: WebAssembly.Instance) => void;
-};
+}
 
 export default EmccWASI;

--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -44,11 +44,11 @@ export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefin
     }
 
     // more detailed error message
-    const requiedMaxBufferSize = 1 << 30;
-    if (requiedMaxBufferSize > adapter.limits.maxBufferSize) {
+    const requitedMaxBufferSize = 1 << 30;
+    if (requitedMaxBufferSize > adapter.limits.maxBufferSize) {
       throw Error(
         `Cannot initialize runtime because of requested maxBufferSize ` +
-        `exceeds limit. requested=${computeMB(requiedMaxBufferSize)}, ` +
+        `exceeds limit. requested=${computeMB(requitedMaxBufferSize)}, ` +
         `limit=${computeMB(adapter.limits.maxBufferSize)}. ` +
         `This error may be caused by an older version of the browser (e.g. Chrome 112). ` +
         `You can try to upgrade your browser to Chrome 113 or later.`
@@ -73,7 +73,7 @@ export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefin
       );
     }
 
-    let requiredFeatures : GPUFeatureName[] = [];
+    const requiredFeatures : GPUFeatureName[] = [];
     // Always require f16 if available
     if (adapter.features.has("shader-f16")) {
       requiredFeatures.push("shader-f16");
@@ -82,7 +82,7 @@ export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefin
     const adapterInfo = await adapter.requestAdapterInfo();
     const device = await adapter.requestDevice({
       requiredLimits: {
-        maxBufferSize: requiedMaxBufferSize,
+        maxBufferSize: requitedMaxBufferSize,
         maxStorageBufferBindingSize: requiredMaxStorageBufferBindingSize,
         maxComputeWorkgroupStorageSize: requiredMaxComputeWorkgroupStorageSize,
       },
@@ -143,7 +143,7 @@ fn fragment_clear(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
   return vec4(1.0, 1.0, 1.0, 1.0);
 }
 `
-class CanvaRenderManager implements Disposable {
+class CanvasRenderManager implements Disposable {
   private device: GPUDevice;
   private canvasContext: GPUCanvasContext;
   private stagingTexture: GPUTexture;
@@ -326,23 +326,23 @@ export class WebGPUContext {
   private bufferTable: Array<GPUBuffer | undefined> = [undefined];
   private bufferTableFreeId: Array<number> = [];
   private podArgStagingBuffers: Array<GPUBuffer> = [];
-  private canvasRenderManager?: CanvaRenderManager = undefined;
+  private canvasRenderManager?: CanvasRenderManager = undefined;
   // number of pod arg staging buffers
-  private maxNumPodArgsStagingBuffers: number = 2;
+  private maxNumPodArgsStagingBuffers = 2;
   // flags for debugging
   // stats of the runtime.
   // peak allocation
-  private peakAllocatedBytes: number = 0;
+  private peakAllocatedBytes = 0;
   // current allocation
-  private currAllocatedBytes: number = 0;
+  private currAllocatedBytes = 0;
   // all allocation(ignoring free)
-  private allAllocatedBytes: number = 0;
+  private allAllocatedBytes = 0;
   // shader submit counter
-  private shaderSubmitCounter: number = 0;
+  private shaderSubmitCounter = 0;
   // limite number of shaders to be submitted, useful for debugging, default to -1
-  protected debugShaderSubmitLimit: number = -1;
+  protected debugShaderSubmitLimit = -1;
   // log and sync each step
-  protected debugLogFinish: boolean = false;
+  protected debugLogFinish = false;
 
   constructor(memory: Memory, device: GPUDevice) {
     this.memory = memory;
@@ -429,7 +429,7 @@ export class WebGPUContext {
    * @param canvas The HTML canvas/
    */
   bindCanvas(canvas: HTMLCanvasElement) {
-    this.canvasRenderManager = new CanvaRenderManager(this.device, canvas);
+    this.canvasRenderManager = new CanvasRenderManager(this.device, canvas);
   }
 
   /**
@@ -445,7 +445,7 @@ export class WebGPUContext {
   }
 
   /**
-   * Create a PackedFunc that runs the given shader asynchrously
+   * Create a PackedFunc that runs the given shader asynchronously
    * via createComputePipelineAsync
    *
    * @param info The function information already parsed as a record.

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -2,11 +2,12 @@
     "compilerOptions": {
 		"target": "es6",
 		"outDir": "lib",
+		"lib": ["ESNext", "DOM"],
+		"types": ["node", "@webgpu/types"],
 		"rootDir": "src",
 		"declaration": true,
 		"sourceMap": true,
 		"skipLibCheck": true,
-		"typeRoots": [ "./node_modules/@webgpu/types", "./node_modules/@types"]
 	},
     "include": ["src"],
     "exclude": ["**/node_modules/**"]


### PR DESCRIPTION
This PR contains 3 aspects:
1. Surpass the eslint error on banned types. As `runtime.ts` contains `Function` as type extensively and is suitable for FFI
2. Fix errors hinted by the new linter and type cheker, mostly about type inference.
3. Fix the typescript configuration file: