### PR TITLE
[Unity] Implement R.macro for Relax macros

### DIFF
--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -441,6 +441,19 @@ def emit_var_binding(value: VarBinding) -> Var:
     return _ffi_api.EmitVarBinding(value)  # type: ignore
 
 
+############################### SeqExpr ###############################
+
+
+def SeqExpr() -> frame.SeqExprFrame:  # pylint: disable=invalid-name
+    """Create a SeqExpr frame.
+    Returns
+    -------
+    res : frame.SeqExprFrame
+        The result SeqExprFrame
+    """
+    return _ffi_api.SeqExpr()  # type: ignore[attr-defined] # pylint: disable=no-member
+
+
 ############################# If Then Else #############################
 
 
@@ -566,6 +579,7 @@ def dtype(value: Union[py_str, DataType]) -> Expr:
 __all__ = [
     "Else",
     "If",
+    "SeqExpr",
     "Then",
     "TupleGetItem",
     "abs",

--- a/python/tvm/script/parser/relax/__init__.py
+++ b/python/tvm/script/parser/relax/__init__.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     # so most tvmscript won't trigger pylint error here.
     function = staticmethod
 else:
-    from .entry import function
+    from .entry import function, macro
 
 __all__ = (
     _relax.__all__
@@ -45,6 +45,7 @@ __all__ = (
         "Tensor",
         "Tuple",
         "function",
+        "macro",
         "match_cast",
     ]
 )

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -221,6 +221,15 @@ TVM_REGISTER_GLOBAL("script.ir_builder.relax.Emit").set_body_typed(Emit);
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitMatchCast").set_body_typed(EmitMatchCast);
 TVM_REGISTER_GLOBAL("script.ir_builder.relax.EmitVarBinding").set_body_typed(EmitVarBinding);
 
+/////////////////////////////// SeqExpr ///////////////////////////////
+
+SeqExprFrame SeqExpr() {
+  ObjectPtr<SeqExprFrameNode> n = make_object<SeqExprFrameNode>();
+  return SeqExprFrame(n);
+}
+
+TVM_REGISTER_GLOBAL("script.ir_builder.relax.SeqExpr").set_body_typed(SeqExpr);
+
 ///////////////////////////// If Then Else /////////////////////////////
 
 IfFrame If(tvm::relax::Expr condition) {


### PR DESCRIPTION
In the same way as T.macro, R.macro support hygiene (via "hygienic" keyword), but unlike TIR macros, Relax macros produce expressions, and have to return a value: the last statement in R.macro must be "return".