### PR TITLE
[Unity][Frontend][Onnx] Simplify gemm

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -374,18 +374,18 @@ class Gemm(OnnxOpConverter):
 
         # Compute Y = alpha * A X B + beta * C
 
-        if alpha is not None:
-            A = bb.normalize(relax.op.multiply(A, relax.const(alpha, dtype=dtype)))
+        if alpha is not None and alpha != 1.0:
+            A = relax.op.multiply(A, relax.const(alpha, dtype=dtype))
 
         if transA:
             A = relax.op.permute_dims(A, [1, 0])
         if transB:
             B = relax.op.permute_dims(B, [1, 0])
-        Y = bb.normalize(relax.op.matmul(A, B))
+        Y = relax.op.matmul(A, B)
 
         if C is not None:
-            if beta is not None:
-                C = bb.normalize(relax.op.multiply(C, relax.const(beta, dtype=dtype)))
+            if beta is not None and beta != 1.0:
+                C = relax.op.multiply(C, relax.const(beta, dtype=dtype))
             Y = relax.op.add(Y, C)
 
         return Y

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -333,8 +333,8 @@ def test_gather():
     _verify_gather([3, 3], [[0, 2]], [3, 1, 2], 1)
 
 
-@pytest.mark.parametrize("alpha", [None, 0.25])
-@pytest.mark.parametrize("beta", [None, 0.35])
+@pytest.mark.parametrize("alpha", [None, 0.25, 1.0])
+@pytest.mark.parametrize("beta", [None, 0.35, 1.0])
 @pytest.mark.parametrize("useC", [False, True])
 def test_gemm(alpha, beta, useC):
     if useC:


### PR DESCRIPTION
This very small PR adds a check to our gemm importer to prevent inserting useless multiplies with `alpha` or `beta` when their value is `1.0`. This can produce cleaner easier to optimize graphs.