### PR TITLE
[Dlight] Fix Customized Dynamic Shape Sampling

### DIFF
--- a/python/tvm/dlight/benchmark/bench.py
+++ b/python/tvm/dlight/benchmark/bench.py
@@ -81,7 +81,7 @@ def benchmark(
     -------
     input_infos : Tuple[List[Tuple[Tuple[int, ...], str]], int]
         The input tensor information, including shape and dtype, and the total input bytes.
-        E.g., [((1, 32, 1, 64), "float16"), ((1, 32, 64, 128), "float16")], 528384
+        E.g., ([((1, 32, 1, 64), "float16"), ((1, 32, 64, 128), "float16")], 528384)
         where 528384 = 1 * 32 * 1 * 64 * 2 + 1 * 32 * 64 * 128 * 2
     median : float
         The median of the benchmarking results.

--- a/python/tvm/dlight/benchmark/extract.py
+++ b/python/tvm/dlight/benchmark/extract.py
@@ -173,17 +173,21 @@ def extract_func_info_from_prim_func(
     func_args = []
     dym_var = {}
     for param in func.params:
-        buffer = func.buffer_map[param]
-        shape = []
-        for dim in buffer.shape:
-            if isinstance(dim, tvm.tir.IntImm):
-                shape.append(dim.value)
-            elif isinstance(dim, tvm.tir.Var):
-                dym_var[str(dim)] = str(dim.dtype)
-                shape.append(dim)
-            else:
-                raise ValueError(f"Unknown shape: {buffer.shape}")
-        func_args.append((tuple(shape), str(buffer.dtype)))
+        if param in func.buffer_map:
+            buffer = func.buffer_map[param]
+            shape = []
+            for dim in buffer.shape:
+                if isinstance(dim, tvm.tir.IntImm):
+                    shape.append(dim.value)
+                elif isinstance(dim, tvm.tir.Var):
+                    dym_var[str(dim)] = str(dim.dtype)
+                    shape.append(dim)
+                else:
+                    raise ValueError(f"Unknown shape: {buffer.shape}")
+            func_args.append((tuple(shape), str(buffer.dtype)))
+        else:
+            func_args.append(((param,), "scalar"))
+            dym_var[str(param)] = str(param.dtype)
     return func_args, dym_var
 
 

--- a/python/tvm/dlight/benchmark/extract.py
+++ b/python/tvm/dlight/benchmark/extract.py
@@ -38,7 +38,7 @@ RELAX_FUNC_NAME = "{relax_func_name}"
 PRIM_FUNC_NAME = "{prim_func_name}"
 FUNC_HASH = {func_hash}
 WEIGHT = {weight}
-SAMPLE_NUMBER = {sample_number}
+SAMPLE_NUMBER = {sample_num}
 
 DYM_VAR_SAMPLE_FUNC = {dym_var_sample_func}
 
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         args = INPUT_ARGS,
         dym_var_dict = DYM_VAR_DICT,
         dym_var_sample_func = DYM_VAR_SAMPLE_FUNC,
-        sample_number = SAMPLE_NUMBER,
+        sample_num = SAMPLE_NUMBER,
         target = target,
         weight = WEIGHT,
         relax_func_name = RELAX_FUNC_NAME,
@@ -134,7 +134,7 @@ def extract_dynamic_var(
 
 
 def update_records(
-    records: Dict[List[relax.ShapeStructInfo], int], new_args: List[relax.ShapeStructInfo]
+    records: List[Tuple[List[relax.ShapeStructInfo], int]], new_args: List[relax.ShapeStructInfo]
 ) -> None:
     """Update the count of a function input argument config.
 
@@ -154,7 +154,7 @@ def update_records(
 
 def extract_func_info_from_prim_func(
     func: tvm.tir.PrimFunc,
-) -> Tuple[List[Tuple[Tuple[Union[tvm.tir.Var, int], ...], str]], Dict[str, str]]:
+) -> Tuple[List[Tuple[Tuple[Union[str, int], ...], str]], Dict[str, str]]:
     """Extract function input information from a PrimFunc.
 
     Parameters
@@ -165,7 +165,7 @@ def extract_func_info_from_prim_func(
     Returns
     -------
     result : Tuple[
-        List[Tuple[Tuple[Union[tvm.tir.Var, int], ...], str]],
+        List[Tuple[Tuple[Union[str, int], ...], str]],
         Dict[str, str],
     ]
         The function input information and dynamic shape variable dictionary.
@@ -181,7 +181,7 @@ def extract_func_info_from_prim_func(
                     shape.append(dim.value)
                 elif isinstance(dim, tvm.tir.Var):
                     dym_var[str(dim)] = str(dim.dtype)
-                    shape.append(dim)
+                    shape.append(str(dim))
                 else:
                     raise ValueError(f"Unknown shape: {buffer.shape}")
             func_args.append((tuple(shape), str(buffer.dtype)))
@@ -243,7 +243,7 @@ def extract_prim_func(  # pylint: disable=too-many-arguments
     func_args: Optional[List[Tuple[Tuple[Union[tvm.relax.expr.Call, int], ...], str]]] = None,
     dym_var_dict: Optional[Dict[str, str]] = None,
     weight: int = 1,
-    sample_number: int = 5,
+    sample_num: int = 5,
     target: Optional[Union[str, tvm.target.Target]] = None,
 ) -> str:
     """Extract a self-contained PrimFunc test file from a Relax module.
@@ -267,7 +267,7 @@ def extract_prim_func(  # pylint: disable=too-many-arguments
         If not given, the dictionary will be extracted from the PrimFunc.
     weight: int
         The weight of the prim function, by default 1.
-    sample_number: int
+    sample_num: int
         The number of times to sample dynamic shape variables, by default 5.
     target: Optional[Union[str, tvm.target.Target]]
         The target device to run the PrimFunc. If None, will use target from the context.
@@ -297,7 +297,7 @@ def extract_prim_func(  # pylint: disable=too-many-arguments
             "prim_func_name": prim_func_name,
             "func_hash": tvm.ir.structural_hash(func),
             "weight": weight,
-            "sample_number": sample_number,
+            "sample_num": sample_num,
             "dym_var_dict": f"pickle.loads({cloudpickle.dumps(dym_var_dict)})"
             if dym_var_dict is not None
             else "None",

--- a/python/tvm/dlight/benchmark/utils.py
+++ b/python/tvm/dlight/benchmark/utils.py
@@ -16,7 +16,7 @@
 # under the License.
 """Util functions for benchmarking dynamic shape workloads"""
 
-from typing import Dict, List, Tuple, Union, Any, Optional
+from typing import Dict, List, Set, Tuple, Union, Any, Optional
 
 import tvm
 from tvm import relax
@@ -106,39 +106,43 @@ def populuate_input_shape(
     return results
 
 
-def default_dym_var_sample_func(
-    dym_var_dict: Dict[str, str],
+def random_dym_var_sample_func(
+    dym_vars: Set[str],
     sample_idx: int,  # pylint: disable=unused-argument
     sample_num: int,  # pylint: disable=unused-argument
 ) -> Dict[str, int]:
     """
-    Default dynamic shape variable sample function.
+    Random dynamic shape variable sample function.
     Sample a random value for each dynamic shape variable.
 
     Parameters
     ----------
-    dym_var_dict : Dict[str, str]
-        Dynamic shape variable dictionary, e.g., {"n": "int32", "m": "int32"}
+    dym_vars : Set[str]
+        Dynamic shape variables, e.g., {"n", "m"}
     sample_idx : int
         Sample index denotes the index the function is called for the same
         dynamic shape variable dictionary & function.
+
+        Here we ignore this argument since we always sample a random value,
+        but it can be used to sample different values for different sample
+        indices, for example, we can use 2^n for the n-th sample where n is
+        the sample index.
     sample_num : int
         Sample number denotes the total number of samples.
+
+        Here we ignore this argument since we always sample a random value,
+        but it can be used to sample different values for different sample
+        numbers, for example, we can use 2^(n%m) for the n-th sample where n
+        is the sample index and m is the sample number.
 
     Returns
     -------
     result : Dict[str, int]
         Dynamic shape variable sample, e.g., {"n": 64, "m": 128}
     """
-    results = {}
-    for var in dym_var_dict:
-        if dym_var_dict[var] in ["int32", "int64"]:
-            import random  # pylint: disable=import-outside-toplevel
+    import random  # pylint: disable=import-outside-toplevel
 
-            results[var] = random.randint(2, 128)
-        else:
-            raise TypeError("Unsupported dynamic shape variable type: " + dym_var_dict[var])
-    return results
+    return {var: random.randint(2, 128) for var in dym_vars}
 
 
 def print_results(

--- a/python/tvm/dlight/benchmark/utils.py
+++ b/python/tvm/dlight/benchmark/utils.py
@@ -101,7 +101,11 @@ def populuate_input_shape(
     return results
 
 
-def default_dym_var_sample_func(dym_var_dict: Dict[str, str]) -> Dict[str, int]:
+def default_dym_var_sample_func(
+    dym_var_dict: Dict[str, str],
+    sample_idx: int,  # pylint: disable=unused-argument
+    sample_num: int,  # pylint: disable=unused-argument
+) -> Dict[str, int]:
     """
     Default dynamic shape variable sample function.
     Sample a random value for each dynamic shape variable.
@@ -110,6 +114,11 @@ def default_dym_var_sample_func(dym_var_dict: Dict[str, str]) -> Dict[str, int]:
     ----------
     dym_var_dict : Dict[str, str]
         Dynamic shape variable dictionary, e.g., {"n": "int32", "m": "int32"}
+    sample_idx : int
+        Sample index denotes the index the function is called for the same
+        dynamic shape variable dictionary & function.
+    sample_num : int
+        Sample number denotes the total number of samples.
 
     Returns
     -------

--- a/python/tvm/dlight/benchmark/utils.py
+++ b/python/tvm/dlight/benchmark/utils.py
@@ -16,12 +16,36 @@
 # under the License.
 """Util functions for benchmarking dynamic shape workloads"""
 
-from typing import Dict, List, Set, Tuple, Union, Any, Optional
+from typing import Dict, List, Set, Any, Tuple, Union, Optional, NamedTuple
 
 import tvm
 from tvm import relax
 
 INPUT_SHAPE_TYPE = List[Tuple[Tuple[int, ...], str]]  # pylint: disable=invalid-name
+
+
+class DisplayConfig(NamedTuple):
+    """Display configuration.
+
+    Parameters
+    ----------
+    print_out : bool
+        Whether to print out the results.
+    desc : bool
+        Whether to sort results in descending order.
+    sort_by : Optional[str]
+        Sort results by this key, if None, no sorting.
+    hidden_cols : Optional[List[str]]
+        Hidden columns, will not be displayed.
+    display_cols : Optional[List[str]]
+        Display columns only, will not display other columns or hidden columns.
+    """
+
+    print_out: bool = False
+    desc: bool = True
+    sort_by: Optional[str] = None
+    hidden_cols: Optional[List[str]] = None
+    display_cols: Optional[List[str]] = None
 
 
 def get_func_name_from_gv(gv: tvm.ir.GlobalVar) -> str:  # pylint: disable=invalid-name
@@ -145,8 +169,8 @@ def random_dym_var_sample_func(
     return {var: random.randint(2, 128) for var in dym_vars}
 
 
-def print_results(
-    bench_results: List[Dict[str, Any]], sort_by: Optional[str] = None, desc: bool = True
+def display_results(
+    bench_results: List[Dict[str, Any]], display_config: Optional[DisplayConfig] = None
 ):
     """Print benchmark results.
 
@@ -160,6 +184,8 @@ def print_results(
         Whether to sort results in descending order.
     """
     # pylint: disable=invalid-name, import-outside-toplevel
+    if display_config is None:
+        display_config = DisplayConfig()
     try:
         import pandas as pd
 
@@ -169,10 +195,23 @@ def print_results(
                 [df, pd.DataFrame(record, index=[0])],
                 ignore_index=True,
             )
-        if sort_by is not None:
-            if sort_by not in df.columns:
-                raise ValueError(f"sort_by key {sort_by} not in benchmark results")
-            df = df.sort_values(sort_by, ascending=not desc).reset_index().drop("index", axis=1)
+        # filter columns
+        if display_config.display_cols is not None:
+            for col in df.columns:
+                if col not in display_config.display_cols:
+                    df = df.drop(col, axis=1)
+        if display_config.hidden_cols is not None:
+            for col in display_config.hidden_cols:
+                if col in df.columns:
+                    df = df.drop(col, axis=1)
+        if display_config.sort_by is not None:
+            if display_config.sort_by not in df.columns:
+                raise ValueError(f"sort_by key {display_config.sort_by} not in benchmark results")
+            df = (
+                df.sort_values(display_config.sort_by, ascending=not display_config.desc)
+                .reset_index()
+                .drop("index", axis=1)
+            )
         print(df)
     except ModuleNotFoundError:
         print("Pandas not found, printing results in raw format.")

--- a/python/tvm/meta_schedule/testing/tune_utils.py
+++ b/python/tvm/meta_schedule/testing/tune_utils.py
@@ -52,6 +52,8 @@ def generate_input_data(
         "int8": (-128, 127),
         "int32": (0, 10000),
         "int64": (0, 10000),
+        "uint32": (0, 10000),
+        "uint64": (0, 10000),
     }
     if input_dtype in range_map:
         _low, _high = range_map[input_dtype]

--- a/tests/python/dlight/test_benchmark.py
+++ b/tests/python/dlight/test_benchmark.py
@@ -260,7 +260,7 @@ def test_extract_prim_func_full1():
             prim_func_name="full1",
             func=Module["full1"],  # type: ignore
             func_args=[((1, 32, 1, "n"), "float16")],
-            dym_var_dict={"n": "int32"},
+            dym_vars={"n"},
             weight=2,
             sample_num=10,
             target="llvm -num-cores=4",
@@ -295,11 +295,11 @@ def test_extract_from_relax():
 def test_extract_func_info_from_prim_func():
     assert extract_func_info_from_prim_func(cuda_workload) == (
         [((1, "m", 4096), "float32"), ((4096, 4096), "float32"), ((1, "m", 4096), "float32")],
-        {"m": "int64"},
+        {"m"},
     )
     assert extract_func_info_from_prim_func(Module["full1"]) == (  # type: ignore
         [((1, 32, 1, "n"), "float16")],
-        {"n": "int64"},
+        {"n"},
     )
     assert extract_func_info_from_prim_func(Module["matmul1"]) == (  # type: ignore
         [
@@ -307,11 +307,11 @@ def test_extract_func_info_from_prim_func():
             ((1, 32, "n", 128), "float16"),
             ((1, 32, 1, 128), "float16"),
         ],
-        {"n": "int64"},
+        {"n"},
     )
     assert extract_func_info_from_prim_func(Module["full2"]) == (  # type: ignore
         [((1, 32, "n", 128), "float16")],
-        {"n": "int64"},
+        {"n"},
     )
 
 

--- a/tests/python/dlight/test_benchmark.py
+++ b/tests/python/dlight/test_benchmark.py
@@ -169,7 +169,7 @@ def cuda_workload(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(409
 # pylint: enable=no-self-argument,invalid-name,line-too-long,no-method-argument
 
 
-@tvm.testing.requires_cuda
+@tvm.testing.requires_gpu
 def test_benchmark_prim_func_rpc():
     with LocalRPC() as rpc:
         rpc_config = ms.runner.RPCConfig(
@@ -187,7 +187,7 @@ def test_benchmark_prim_func_rpc():
                 ((1, "m", 4096), "float32"),
             ],
             dym_var_sample={"m": 128},
-            target="nvidia/geforce-rtx-3070",
+            target="cuda",
             rpc_config=rpc_config,
         )
         assert input_infos == [
@@ -197,7 +197,7 @@ def test_benchmark_prim_func_rpc():
         ]
 
 
-@tvm.testing.requires_cuda
+@tvm.testing.requires_gpu
 def test_benchmark_prim_func_local():
     input_infos, _, _ = benchmark(
         cuda_workload,
@@ -207,7 +207,7 @@ def test_benchmark_prim_func_local():
             ((1, "m", 4096), "float32"),
         ],
         dym_var_sample={"m": 128},
-        target="nvidia/geforce-rtx-3070",
+        target="cuda",
     )
     assert input_infos == [
         ((1, 128, 4096), "float32"),
@@ -216,15 +216,15 @@ def test_benchmark_prim_func_local():
     ]
 
 
-@tvm.testing.requires_cuda
+@tvm.testing.requires_gpu
 def test_benchmark_prim_func_full_local():
-    with tvm.target.Target("nvidia/geforce-rtx-3070"):
+    with tvm.target.Target("cuda"):
         benchmark_prim_func(
             cuda_workload,
         )
 
 
-@tvm.testing.requires_cuda
+@tvm.testing.requires_gpu
 def test_benchmark_prim_func_full_rpc():
     with LocalRPC() as rpc:
         rpc_config = ms.runner.RPCConfig(
@@ -236,7 +236,7 @@ def test_benchmark_prim_func_full_rpc():
         )
         benchmark_prim_func(
             cuda_workload,
-            target="nvidia/geforce-rtx-3070",
+            target="cuda",
             rpc_config=rpc_config,
             evaluator_config=ms.runner.EvaluatorConfig(
                 number=10,

--- a/tests/python/dlight/test_benchmark.py
+++ b/tests/python/dlight/test_benchmark.py
@@ -66,7 +66,7 @@ class Module:
                 T_full[v_ax0, v_ax1, v_ax2, v_ax3] = T.float16(1.0)
 
     @T.prim_func
-    def matmul1(var_A: T.handle, var_B: T.handle, matmul: T.Buffer((T.int64(1), T.int64(32), T.int64(1), T.int64(128)), "float16")):
+    def matmul1(var_A: T.handle, var_B: T.handle, matmul: T.Buffer((T.int64(1), T.int64(32), T.int64(1), T.int64(128)), "float16")): # type: ignore
         T.func_attr({"op_pattern": 4, "tir.noalias": T.bool(True)})
         n = T.int64()
         A = T.match_buffer(var_A, (T.int64(1), T.int64(32), T.int64(1), n), "float16")
@@ -97,7 +97,7 @@ class Module:
         return lv3
 
 @T.prim_func
-def cuda_workload(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(4096)), "float32"), var_matmul: T.handle):
+def cuda_workload(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(4096)), "float32"), var_matmul: T.handle): # type: ignore
     T.func_attr({"tir.is_scheduled": 1})
     m = T.int64()
     inp0 = T.match_buffer(var_inp0, (T.int64(1), m, T.int64(4096)))
@@ -190,11 +190,14 @@ def test_benchmark_prim_func_rpc():
             target="cuda",
             rpc_config=rpc_config,
         )
-        assert input_infos == [
-            ((1, 128, 4096), "float32"),
-            ((4096, 4096), "float32"),
-            ((1, 128, 4096), "float32"),
-        ]
+        assert input_infos == (
+            [
+                ((1, 128, 4096), "float32"),
+                ((4096, 4096), "float32"),
+                ((1, 128, 4096), "float32"),
+            ],
+            71303168,
+        )
 
 
 @tvm.testing.requires_gpu
@@ -209,11 +212,14 @@ def test_benchmark_prim_func_local():
         dym_var_sample={"m": 128},
         target="cuda",
     )
-    assert input_infos == [
-        ((1, 128, 4096), "float32"),
-        ((4096, 4096), "float32"),
-        ((1, 128, 4096), "float32"),
-    ]
+    assert input_infos == (
+        [
+            ((1, 128, 4096), "float32"),
+            ((4096, 4096), "float32"),
+            ((1, 128, 4096), "float32"),
+        ],
+        71303168,
+    )
 
 
 @tvm.testing.requires_gpu

--- a/tests/python/dlight/test_benchmark.py
+++ b/tests/python/dlight/test_benchmark.py
@@ -17,7 +17,6 @@
 # pylint: disable=missing-docstring
 
 import tempfile
-import pytest
 
 from tvm import meta_schedule as ms
 from tvm.meta_schedule.testing.local_rpc import LocalRPC
@@ -83,7 +82,7 @@ class Module:
                 matmul[v_i0, v_i1, v_i2, v_i3] = matmul[v_i0, v_i1, v_i2, v_i3] + A[v_i0, v_i1, v_i2, v_k] * B[v_i0, v_i1, v_k, v_i3]
 
     @R.function
-    def test():
+    def test(): # type: ignore
         n = T.int64()
         R.func_attr({"tir_var_upper_bound": {"n": 2048}})
         cls = Module
@@ -170,6 +169,7 @@ def cuda_workload(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(409
 # pylint: enable=no-self-argument,invalid-name,line-too-long,no-method-argument
 
 
+@tvm.testing.requires_cuda
 def test_benchmark_prim_func_rpc():
     with LocalRPC() as rpc:
         rpc_config = ms.runner.RPCConfig(
@@ -197,6 +197,7 @@ def test_benchmark_prim_func_rpc():
         ]
 
 
+@tvm.testing.requires_cuda
 def test_benchmark_prim_func_local():
     input_infos, _, _ = benchmark(
         cuda_workload,
@@ -215,6 +216,7 @@ def test_benchmark_prim_func_local():
     ]
 
 
+@tvm.testing.requires_cuda
 def test_benchmark_prim_func_full_local():
     with tvm.target.Target("nvidia/geforce-rtx-3070"):
         benchmark_prim_func(
@@ -222,6 +224,7 @@ def test_benchmark_prim_func_full_local():
         )
 
 
+@tvm.testing.requires_cuda
 def test_benchmark_prim_func_full_rpc():
     with LocalRPC() as rpc:
         rpc_config = ms.runner.RPCConfig(
@@ -294,11 +297,11 @@ def test_extract_func_info_from_prim_func():
         [((1, "m", 4096), "float32"), ((4096, 4096), "float32"), ((1, "m", 4096), "float32")],
         {"m": "int64"},
     )
-    assert extract_func_info_from_prim_func(Module["full1"]) == (
+    assert extract_func_info_from_prim_func(Module["full1"]) == (  # type: ignore
         [((1, 32, 1, "n"), "float16")],
         {"n": "int64"},
     )
-    assert extract_func_info_from_prim_func(Module["matmul1"]) == (
+    assert extract_func_info_from_prim_func(Module["matmul1"]) == (  # type: ignore
         [
             ((1, 32, 1, "n"), "float16"),
             ((1, 32, "n", 128), "float16"),
@@ -306,11 +309,11 @@ def test_extract_func_info_from_prim_func():
         ],
         {"n": "int64"},
     )
-    assert extract_func_info_from_prim_func(Module["full2"]) == (
+    assert extract_func_info_from_prim_func(Module["full2"]) == (  # type: ignore
         [((1, 32, "n", 128), "float16")],
         {"n": "int64"},
     )
 
 
 if __name__ == "__main__":
-    test_extract_func_info_from_prim_func()
+    tvm.testing.main()


### PR DESCRIPTION
This PR is a follow up for #15322 to better support model level workload benchmarking as in https://github.com/mlc-ai/dlight-bench/pull/6

introduces some minor fixes to enable easier dynamic shape sampling for model level workload benchmarking. For example, a dynamic shape sampling function can take `sample_idx` and `sample_num` as input to generate better selection of shapes. It also makes life easier by converting all the dynamic variable to str when parsing from PrimFuncs.

Other than that, this PR includes a few minor changes, including type annotation and supporting customizing the columns in the benchmarking output.