### PR TITLE
[Unity][BYOC] Integrate Flash attention v2 kernel into CUTLASS BYOC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -843,4 +843,8 @@ if(USE_CUDA AND USE_CUTLASS)
   install(TARGETS fpA_intB_gemm EXPORT ${PROJECT_NAME}Targets DESTINATION lib${LIB_SUFFIX})
   target_link_libraries(tvm PRIVATE fpA_intB_gemm)
   target_link_libraries(tvm_runtime PRIVATE fpA_intB_gemm)
+
+  install(TARGETS flash_attn EXPORT ${PROJECT_NAME}Targets DESTINATION lib${LIB_SUFFIX})
+  target_link_libraries(tvm PRIVATE -Wl,--no-as-needed flash_attn)
+  target_link_libraries(tvm_runtime PRIVATE -Wl,--no-as-needed flash_attn)
 endif()

--- a/cmake/modules/contrib/CUTLASS.cmake
+++ b/cmake/modules/contrib/CUTLASS.cmake
@@ -21,6 +21,7 @@ if(USE_CUDA AND USE_CUTLASS)
 
   set(CUTLASS_DIR ${PROJECT_SOURCE_DIR}/3rdparty/cutlass)
   add_subdirectory(${PROJECT_SOURCE_DIR}/3rdparty/cutlass_fpA_intB_gemm)
+  add_subdirectory(${PROJECT_SOURCE_DIR}/3rdparty/libflash_attn)
   list(APPEND RUNTIME_SRCS src/runtime/contrib/cutlass/weight_preprocess.cc)
 
   message(STATUS "Build with CUTLASS")

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -58,6 +58,7 @@ def _get_cutlass_compile_options(sm, threads, use_fast_math=False):
     cutlass_util_include = os.path.join(cutlass_root, "tools/util/include")
     cutlass_attention_include = os.path.join(cutlass_root, "examples/41_fused_multi_head_attention")
     cutlass_fpA_intB_gemm_include = os.path.join(cutlass_root, "../cutlass_fpA_intB_gemm")
+    flash_attn_include = os.path.join(cutlass_root, "../libflash_attn/include")
 
     kwargs = {}
     kwargs["cc"] = "nvcc"
@@ -76,6 +77,7 @@ def _get_cutlass_compile_options(sm, threads, use_fast_math=False):
         f"-I{cutlass_util_include}",
         f"-I{cutlass_attention_include}",
         f"-I{cutlass_fpA_intB_gemm_include}",
+        f"-I{flash_attn_include}",
     ]
     if use_fast_math:
         kwargs["options"].append("-DCUTLASS_USE_TANH_FOR_SIGMOID")

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -754,6 +754,8 @@ def instantiate_template(func_name, annotations, func_args):
             # We have not thoroughly validated flash with causal mask yet, so for now we support
             # only non-causal cases.
             and int(annotations["custom_mask_type"]) == 0
+            # Flash v2 is currently not supported for sm < 80
+            and int(annotations["arch"]) >= 80
         )
 
         if use_flash:

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -29,7 +29,10 @@ from tvm.runtime import Object
 from tvm.tir import IntImm
 
 from . import _ffi_api as ffi
-from .attention_operation import instantiate_attention_template
+from .attention_operation import (
+    instantiate_attention_template,
+    instantiate_flash_attention_template,
+)
 from .conv2d_operation import instantiate_conv2d_template
 from .gemm_operation import instantiate_gemm_template, emit_fp16A_intB_matmul
 from .layer_norm_operation import instantiate_layer_norm_template
@@ -712,7 +715,6 @@ def instantiate_template(func_name, annotations, func_args):
         return CodegenResult(code, headers)
 
     elif "attention" in func_name:
-        headers.append("kernel_forward.h")
         data_type = dtype_map[annotations["arg0_dtype"]]
 
         attrs["qkv_layout"] = annotations["qkv_layout"]
@@ -739,62 +741,84 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["head_dim"] = h = annotations["head_dim"]
         attrs["head_dim_value"] = h_v = annotations["head_dim_value"]
         attrs["kMaxK"] = max(int(attrs["head_dim"]), int(attrs["head_dim_value"]))
-
-        data_type_size = DataTypeSize[data_type]
-        if (data_type_size * h // 8) % 16 == 0 and (data_type_size * h_v // 8) % 16 == 0:
-            attrs["kIsAligned"] = True
-        elif (h % 4 == 0) and (h_v % 4 == 0):
-            attrs["kIsAligned"] = False
-        else:
-            raise NotImplementedError()
-        if h_v > 64:
-            attrs["kQueriesPerBlock"] = 32
-            attrs["kKeysPerBlock"] = 128
-            attrs["kSingleValueIteration"] = h_v <= 128
-        else:
-            attrs["kQueriesPerBlock"] = 64
-            attrs["kKeysPerBlock"] = 64
-            attrs["kSingleValueIteration"] = True
-        attrs["output_size"] = f"{b} * {s} * {n} * {h_v}"
         attrs["scale"] = (
             float(1 / math.sqrt(h.value)) if annotations["scale"] is None else annotations["scale"]
         )
-        attrs["custom_mask_type"] = annotations["custom_mask_type"]
 
-        assert (
-            attrs["scale"] > 0 or attrs["scale"] < 0
-        ), "Cutlass may generate nan occasionally when scale == 0.0"
-        attrs["arch"] = "cutlass::arch::Sm{}".format(annotations["arch"])
-        attrs["kSupportsDropout"] = False
+        use_flash = (
+            annotations["ret_dtype"] == "float16"
+            and "bias" not in attrs
+            and int(attrs["head_dim"]) <= 256
+            and int(attrs["head_dim"]) % 8 == 0
+            and int(attrs["head_dim"]) == int(attrs["head_dim_value"])
+            # for now only support non-causal cases, see
+            # https://github.com/Dao-AILab/flash-attention/issues/282
+            and int(annotations["custom_mask_type"]) == 0
+        )
 
-        for arg in func_args:
-            if "workspace" in arg:
-                attrs["workspace"] = arg
-        if "bias" in attrs:
-            attrs["kSupportsBias"] = True
-            if len(annotations["bias_shape"]) == 4:
-                strides = "p.num_keys"
-                if annotations["bias_shape"][2] == 1:
-                    attrs["bias_strideM"] = 0
-                else:
-                    attrs["bias_strideM"] = strides
-                    strides = f"p.num_queries * {strides}"
-                if annotations["bias_shape"][1] == 1:
-                    attrs["bias_strideH"] = 0
-                else:
-                    attrs["bias_strideH"] = strides
-                    strides = f"p.num_heads * {strides}"
-                if annotations["bias_shape"][0] == 1:
-                    attrs["bias_strideB"] = 0
-                else:
-                    attrs["bias_strideB"] = strides
+        if use_flash:
+            headers.append("flash.h")
+            attrs["is_causal"] = int(annotations["custom_mask_type"]) == 2
+            code = instantiate_flash_attention_template(attrs)
+        else:
+            headers.append("kernel_forward.h")
+
+            data_type_size = DataTypeSize[data_type]
+            if (data_type_size * h // 8) % 16 == 0 and (data_type_size * h_v // 8) % 16 == 0:
+                attrs["kIsAligned"] = True
+            elif (h % 4 == 0) and (h_v % 4 == 0):
+                attrs["kIsAligned"] = False
             else:
                 raise NotImplementedError()
-        else:
-            # To support negative scale in current Cutlass implementation,
-            # kSupportsBias should be set true, or there are nan's as result.
-            attrs["kSupportsBias"] = attrs["scale"] < 0
-        code = instantiate_attention_template(attrs)
+            if h_v > 64:
+                attrs["kQueriesPerBlock"] = 32
+                attrs["kKeysPerBlock"] = 128
+                attrs["kSingleValueIteration"] = h_v <= 128
+            else:
+                attrs["kQueriesPerBlock"] = 64
+                attrs["kKeysPerBlock"] = 64
+                attrs["kSingleValueIteration"] = True
+
+            assert (
+                attrs["scale"] > 0 or attrs["scale"] < 0
+            ), "Cutlass may generate nan occasionally when scale == 0.0"
+            attrs["arch"] = "cutlass::arch::Sm{}".format(annotations["arch"])
+            attrs["kSupportsDropout"] = False
+
+            attrs["output_size"] = f"{b} * {s} * {n} * {h_v}"
+
+            attrs["custom_mask_type"] = annotations["custom_mask_type"]
+
+            for arg in func_args:
+                if "workspace" in arg:
+                    attrs["workspace"] = arg
+            if "bias" in attrs:
+                attrs["kSupportsBias"] = True
+                if len(annotations["bias_shape"]) == 4:
+                    strides = "p.num_keys"
+                    if annotations["bias_shape"][2] == 1:
+                        attrs["bias_strideM"] = 0
+                    else:
+                        attrs["bias_strideM"] = strides
+                        strides = f"p.num_queries * {strides}"
+                    if annotations["bias_shape"][1] == 1:
+                        attrs["bias_strideH"] = 0
+                    else:
+                        attrs["bias_strideH"] = strides
+                        strides = f"p.num_heads * {strides}"
+                    if annotations["bias_shape"][0] == 1:
+                        attrs["bias_strideB"] = 0
+                    else:
+                        attrs["bias_strideB"] = strides
+                else:
+                    raise NotImplementedError()
+            else:
+                # To support negative scale in current Cutlass implementation,
+                # kSupportsBias should be set true, or there are nan's as result.
+                attrs["kSupportsBias"] = attrs["scale"] < 0
+
+            code = instantiate_attention_template(attrs)
+
         return CodegenResult(code, headers)
     elif "layer_norm" in func_name:
         headers.append("cutlass/util/device_layernorm.h")

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -751,14 +751,14 @@ def instantiate_template(func_name, annotations, func_args):
             and int(attrs["head_dim"]) <= 256
             and int(attrs["head_dim"]) % 8 == 0
             and int(attrs["head_dim"]) == int(attrs["head_dim_value"])
-            # for now only support non-causal cases, see
-            # https://github.com/Dao-AILab/flash-attention/issues/282
+            # We have not thoroughly validated flash with causal mask yet, so for now we support
+            # only non-causal cases.
             and int(annotations["custom_mask_type"]) == 0
         )
 
         if use_flash:
             headers.append("flash.h")
-            attrs["is_causal"] = int(annotations["custom_mask_type"]) == 2
+            attrs["is_causal"] = int(annotations["custom_mask_type"]) == 0
             code = instantiate_flash_attention_template(attrs)
         else:
             headers.append("kernel_forward.h")

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -854,7 +854,7 @@ def stacked_attention_size(request):
 
 def test_stacked_attention_split_offload(stacked_attention_size):
     b, s, n, (h, h_v), bias_shape, scale, single_shape = stacked_attention_size
-    qkv, bias, ref = get_numpy_stacked_attention_ref(b, s, n, h, h_v, bias_shape, scale, "float32")
+    qkv, bias, ref = get_numpy_stacked_attention_ref(b, s, n, h, h_v, bias_shape, scale, "float16")
     if scale == "none":
         mod = get_relax_stacked_attention_module(
             qkv, b, s, n, h, h_v, "split", bias, single_shape=single_shape


### PR DESCRIPTION
This PR enables using the flash v2 kernel for offloading the attention op. Flash v2 is implemented in CUTLASS, so it is reasonable to integrate it into our CUTLASS BYOC.  

The flash v2 kernel is used whenever applicable, because it is expected to be faster than the xformer kernel. The xformer repo itself is now [admitting that flash is always faster](https://github.com/facebookresearch/xformers/blob/main/xformers/ops/fmha/dispatch.py#L15-L16). 

For now, flash is disabled for causal attention case, since I haven't validated its correctness thoroughly. 

UPDATE: It seems for a single-token decoding in LLM, the flash v2 kernel with `is_causal = False` is much slower than the xformer kernel. So for LLM inference, it is recommended to always use the causal mask which will disable the flash attn kernel. The flash v2 kernel is non-trivially faster on workloads like SD. 

@cyx-6 @vinx13 @yzh119 @sunggg 
