### PR TITLE
[Relay][Strategy] Fix `arm_cpu` int8 conv2d schedule selection for 32-bit targets

### DIFF
--- a/tests/python/relay/strategy/test_select_implementation.py
+++ b/tests/python/relay/strategy/test_select_implementation.py
@@ -52,5 +52,102 @@ def test_concatenate(target, expected_implementation):
     assert impl.name == expected_implementation
 
 
+@pytest.mark.parametrize(
+    "target,expected_impl",
+    [
+        ("llvm -device=arm_cpu", "conv2d_nhwc_spatial_pack.arm_cpu"),
+        (
+            "llvm -device=arm_cpu -mtriple=aarch64-linux-gnu -mattr=+neon",
+            "conv2d_NHWC_quantized_interleaved.arm_cpu",
+        ),
+        (
+            "llvm -device=arm_cpu -mtriple=armv8l-linux-gnu -mattr=+neon",
+            "conv2d_nhwc_spatial_pack.arm_cpu",
+        ),
+    ],
+)
+def test_int8_conv2d(target, expected_impl):
+    target = tvm.target.Target(target)
+
+    dtype = "int8"
+    data_shape = (1, 1, 1, 4)
+    weight_shape = (1, 1, 4, 4)
+    data_layout = "NHWC"
+    kernel_layout = "HWIO"
+    channels = 4
+    kernel_size = (1, 1)
+
+    out = relay.nn.conv2d(
+        relay.var("data", shape=data_shape, dtype=dtype),
+        relay.var("weight", shape=weight_shape, dtype=dtype),
+        kernel_size=kernel_size,
+        channels=channels,
+        data_layout=data_layout,
+        kernel_layout=kernel_layout,
+    )
+    out = run_infer_type(out)
+
+    with target:
+        impl, _ = relay.backend.te_compiler.select_implementation(
+            out.op,
+            out.attrs,
+            [te.placeholder(data_shape, dtype), te.placeholder(weight_shape, dtype)],
+            out.checked_type,
+            target,
+        )
+
+    assert impl.name == expected_impl
+
+
+@pytest.mark.parametrize(
+    "target,expected_impl",
+    [
+        ("llvm -device=arm_cpu", "depthwise_conv2d_nhwc.generic"),
+        (
+            "llvm -device=arm_cpu -mtriple=aarch64-linux-gnu -mattr=+neon",
+            "depthwise_conv2d_nhwc.arm_cpu",
+        ),
+        (
+            "llvm -device=arm_cpu -mtriple=armv8l-linux-gnu -mattr=+neon",
+            "depthwise_conv2d_nhwc.generic",
+        ),
+        ("c -device=arm_cpu -mcpu=cortex-m55", "depthwise_conv2d_nhwc_dsp.arm_cpu"),
+    ],
+)
+def test_int8_depthwise_conv2d(target, expected_impl):
+    target = tvm.target.Target(target)
+
+    dtype = "int8"
+    out_dtype = "int32"
+    data_shape = (2, 2, 4, 8)
+    weight_shape = (2, 2, 8, 1)
+    data_layout = "NHWC"
+    kernel_layout = "HWOI"
+    groups = 8
+    kernel_size = (2, 2)
+
+    out = relay.nn.conv2d(
+        relay.var("data", shape=data_shape, dtype=dtype),
+        relay.var("weight", shape=weight_shape, dtype=dtype),
+        kernel_size=kernel_size,
+        data_layout=data_layout,
+        kernel_layout=kernel_layout,
+        groups=groups,
+        out_dtype=out_dtype,
+    )
+    out = run_infer_type(out)
+
+    with target:
+        impl, _ = relay.backend.te_compiler.select_implementation(
+            out.op,
+            out.attrs,
+            [te.placeholder(data_shape, dtype), te.placeholder(weight_shape, dtype)],
+            out.checked_type,
+            target,
+        )
+
+    assert impl.name == expected_impl
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
https://github.com/apache/tvm/pull/12455 slightly altered the behaviour when selecting an int8 conv2d schedule. Previously conditions that decide which schedule to select used `is_aarch64` which checks for the existance of `aarch64` in the target triple. However, the conditions now use `has_asimd` which is true if `aarch64` exists in the target triple OR `+neon` is used in the mattr.

Both `conv2d_NHWC_quantized_interleaved.arm_cpu` and `depthwise_conv2d_nhwc.arm_cpu` makes calls to LLVM intrinsics that require both `aarch64` and `+neon`. But in the case of the target `rasp4b`, the updated conditions result in compilation failure since the target has `+neon` but doesn't have `aarch64` in the target triple. The conditions have been updated to fix the compilation failure.

Likewise, the previous behaviour of the condition for `conv2d_nhwc_spatial_pack.arm_cpu` has been restored ensure a program with a 32-bit target can still be compiled.

Finally, we should only select the `depthwise_conv2d_nhwc_dsp.arm_cpu` schedule when a backend that understands `pragma_import_c` has been selected, i.e. "c".

For a more detailed discussion of the issue please see: https://discuss.tvm.apache.org/t/tflite-llvm-llvm-error-when-compiling-tflite-model/15411

cc @Mousius @ashutosh-arm @ekalda @neildhickey 