### PR TITLE
[QNN] add test_float32_to_int16

### DIFF
--- a/tests/python/relay/test_op_qnn_quantize.py
+++ b/tests/python/relay/test_op_qnn_quantize.py
@@ -109,6 +109,27 @@ def test_float32_to_uint16():
         verify_output_data=output,
     )
 
+def test_float32_to_int16():
+    data = (
+        np.array([-6553, -6552.8, -6552.6, -6552.4, -6552.2, 6553.2, 6553.4, 6553.6, 6553.8, 6554])
+        .astype("float32")
+        .reshape((2, 5))
+    )
+    output = (
+        np.array([-32766, -32765, -32764, -32763, -32762, 32765, 32766, 32767, 32767, 32767])
+        .astype("int16")
+        .reshape((2, 5))
+    )
+    quant_args = {"out_zero_point": np.int32(-1), "out_scale": np.float32(0.2)}
+    quantize_test_driver(
+        in_dtype="float32",
+        quant_args=quant_args,
+        axis=-1,
+        out_dtype="int16",
+        in_data=data,
+        verify_output_data=output,
+    )
+
 
 def test_scalar_float32_to_int8():
     data = np.array(-63.5).astype("float32")

--- a/tests/python/relay/test_op_qnn_quantize.py
+++ b/tests/python/relay/test_op_qnn_quantize.py
@@ -221,6 +221,7 @@ if __name__ == "__main__":
     test_float32_to_uint8()
     test_float32_to_int8()
     test_float32_to_uint16()
+    test_float32_to_int16()
     test_scalar_float32_to_int8()
     test_channelwise_axis_0()
     test_channelwise_axis_1()


### PR DESCRIPTION
Since quantize works with int16 as well as uint16, adding a test for int16 (there already is one for uint16)