### PR TITLE
[Unity][BugFix][Op] fix error when calling full_like in masked_fill

### DIFF
--- a/python/tvm/relax/op/mask.py
+++ b/python/tvm/relax/op/mask.py
@@ -16,6 +16,7 @@
 # under the License.
 """Operators with mask."""
 from . import _ffi_api
+from .create import full_like
 from ..expr import Expr
 
 
@@ -34,5 +35,5 @@ def masked_fill(x: Expr, mask: Expr, value: Expr):
     result : relax.Expr
         The filled tensor.
     """
-    values = _ffi_api.full_like(x, value)  # type: ignore
+    values = full_like(x, value)  # type: ignore
     return _ffi_api.where(mask, values, x)  # type: ignore


### PR DESCRIPTION
using python api of full_like instead of _ffi_api.full_like to solve the issue of missing dtype argument.
See also [mlc-ai/relax/pull/279](https://github.com/mlc-ai/relax/pull/279)