### PR TITLE
[Bugfix][TOPI] Fix a bug in arm_cpu int8 conv2d i8mm schedule

### DIFF
--- a/tests/python/topi/python/test_topi_conv2d_int8.py
+++ b/tests/python/topi/python/test_topi_conv2d_int8.py
@@ -57,12 +57,11 @@ devices = [
         topi.arm_cpu.compute_conv2d_NHWC_quantized_native,
         topi.arm_cpu.schedule_conv2d_NHWC_quantized_native,
     ),
-    # TODO(giuseros) We need LLVM-11 in order to compile with +i8mm extension
-    # (
-    # "llvm --device arm_cpu --mtriple aarch64-linux-gnu -mattr=+v8.2a,+i8mm",
-    # topi.arm_cpu.compute_conv2d_NHWC_quantized_interleaved,
-    # topi.arm_cpu.schedule_conv2d_NHWC_quantized_interleaved,
-    # ),
+    (
+        "llvm --device arm_cpu --mtriple aarch64-linux-gnu -mattr=+v8.2a,+i8mm",
+        topi.arm_cpu.compute_conv2d_NHWC_quantized_interleaved,
+        topi.arm_cpu.schedule_conv2d_NHWC_quantized_interleaved,
+    ),
 ]
 
 


### PR DESCRIPTION
`topi.arm_cpu.schedule_conv2d_NHWC_quantized_interleaved` was failing compilation with the `+i8mm` extension enabled (as done in apache/tvm#14888) whenever the output height and output width were both equal to 1, such that OH x OW = 1.

Padding was being removed during the `tir.BufferShapeLegalize` pass, causing an error in the `tir.BufferBindUnwrapper` pass. Some of the removed padding was necessary for tensorize (using the `gemm_acc_2x2_int8_int8_int32` intrinsic), which expects 2x2 output tiles. However, because of the optimisations mentioned above, the output tensor `C_interleaved` was reduced to having 1x2 tiles instead.

e.g. for A = [1x1x1x8], W = [1x1x8x24], C = [1x1x1x24]:
- Before fix: `C_interleaved = T.Buffer((1, 1, 2, 1, 6, 1, 2), "int32”)`
- After fix: `C_interleaved = T.Buffer((1, 1, 2, 1, 6, 2, 2), "int32”)`

To make sure the required padding is left untouched, while the rest of it is still removed, a dummy reference to the needed axis is declared.

In the end, the leftover padding is still disregarded when computing the final output tensor `C`.