### PR TITLE
[CI] Remove cython version pin

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -25,7 +25,7 @@ pip3 install --upgrade \
     "Pygments>=2.4.0" \
     attrs \
     cloudpickle \
-    cython==0.29.34 \
+    cython \
     decorator \
     mypy \
     numpy==1.21.* \


### PR DESCRIPTION
After https://github.com/apache/tvm/pull/15469, we should now be able to remove the cython version pin.