### PR TITLE
[Unity][Dlight] Matmul rule on int32 workloads

### DIFF
--- a/python/tvm/dlight/gpu/matmul.py
+++ b/python/tvm/dlight/gpu/matmul.py
@@ -122,7 +122,7 @@ def make_iter_fusion_index_map(
     fused_iters: Dict[IterKind, PrimExpr] = {}
     input_iters: List[tir.Var] = []
     for i, trait in enumerate(traits):
-        v_i = tir.Var(f"i{i}", "int64")
+        v_i = tir.Var(f"i{i}", trait.extent.dtype)
         input_iters.append(v_i)
         if trait.kind == IterKind.kIter_T:
             continue
@@ -134,7 +134,7 @@ def make_iter_fusion_index_map(
             fused_iters[trait.kind] = v_i
 
     final_indices: List[tir.PrimExpr] = [
-        fused_iters.get(kind, tir.IntImm("int64", 0)) for kind in kind_order
+        fused_iters.get(kind, tir.IntImm(traits[0].extent.dtype, 0)) for kind in kind_order
     ]
 
     return tir.IndexMap(input_iters, final_indices, None)


### PR DESCRIPTION
Prior to this PR, the dlight matmul rule uses hardcoded `int64` as index dtype. When the input workload is `int32` dtyped and has symbolic vars like `n: T.int32`, the PrimFunc generated by the matmul rule may contain PrimExpr like
```python
T.Cast("int32", T.Cast("int64", n))
```
which is not wrong but not 100% correct.

This PR changes the hardcoded `int64` to the dtype of the input block iters in the rule, and resolves the issue above.