### PR TITLE
[TVMScript] Allow use of Python builtins in script

### DIFF
--- a/tests/python/unittest/test_tvmscript_error_report.py
+++ b/tests/python/unittest/test_tvmscript_error_report.py
@@ -85,14 +85,6 @@ def test_undefined_buffer():
     check_error(undefined_buffer, 5)
 
 
-def test_unsupported_stmt():
-    def unsupported_stmt(a: T.int32) -> None:
-        if a > 0:
-            print("I love tvm")  # error
-
-    check_error(unsupported_stmt, 3)
-
-
 def test_unsupported_function_call():
     def unsupported_function_call(a: T.handle) -> None:
         A = T.match_buffer(a, (16, 16), "float32")

--- a/tests/python/unittest/test_tvmscript_parser_tir.py
+++ b/tests/python/unittest/test_tvmscript_parser_tir.py
@@ -308,5 +308,22 @@ def test_tir_empty_tuple_index():
     tvm.ir.assert_structural_equal(func_with_empty_tuple, expected)
 
 
+def test_tir_builtin_expression():
+    dims = (128, 128)
+
+    @T.prim_func(private=True)
+    def with_builtin(a: T.handle) -> None:
+        A = T.match_buffer(a, [len(dims), *dims], "int32")
+        for i, j, k in T.grid(*A.shape):
+            A[i, j, k] = T.int32(1 + len(A.shape))
+
+    @T.prim_func(private=True)
+    def evaluated(A: T.Buffer((2, 128, 128), "int32")):
+        for i, j, k in T.grid(2, 128, 128):
+            A[i, j, k] = 4
+
+    tvm.ir.assert_structural_equal(with_builtin, evaluated)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
The builtins are already supported by `eval` (they are automatically injected in the global scope), but they are not recognized by the evaluator's checks. When the evaluator sees doc.Name, it looks it up in the current `var_table`, and flags an error if it's not there.

Make the evaluator also consult the current builtins before erroring out.