### PR TITLE
[Unity] Add batched A matrix support for FasterTransformer fp16A intB matmul

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -705,6 +705,7 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         lhs_shape = signature[f"{lhs_arg}_shape"]
         rhs_shape = signature[f"{rhs_arg}_shape"]
         ret_shape = signature["ret_shape"]
+
         N = ret_shape[-1]
 
         attrs = {
@@ -713,9 +714,11 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
             "rhs_arg_idx": arg_idx["w_encoded"],
             "scales_arg_idx": arg_idx["scales"],
             "bias_arg_idx": arg_idx.get("bias"),
-            "batch_offset": len(lhs_shape) - 2,
             "activation": "identity",
         }
+
+        attrs["batch_rank"] = len(signature["arg0_shape"][:-1])
+        attrs["M"] = reduce(operator.mul, signature["arg0_shape"][:-1], 1)
 
         attrs["bias_stride"] = 0
 

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -705,7 +705,6 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         lhs_shape = signature[f"{lhs_arg}_shape"]
         rhs_shape = signature[f"{rhs_arg}_shape"]
         ret_shape = signature["ret_shape"]
-
         N = ret_shape[-1]
 
         attrs = {
@@ -717,8 +716,8 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
             "activation": "identity",
         }
 
-        attrs["batch_rank"] = len(signature["arg0_shape"][:-1])
-        attrs["M"] = reduce(operator.mul, signature["arg0_shape"][:-1], 1)
+        attrs["batch_rank"] = len(lhs_shape[:-1])
+        attrs["M"] = reduce(operator.mul, lhs_shape[:-1], 1)
 
         attrs["bias_stride"] = 0
 

--- a/python/tvm/contrib/cutlass/gemm_operation.py
+++ b/python/tvm/contrib/cutlass/gemm_operation.py
@@ -417,7 +417,7 @@ def emit_fp16A_intB_matmul(attrs):
     attrs["template_common"] = substitute_template(
         """
   using namespace fastertransformer;
-  int m = ${A_arg}->shape[${batch_offset}];
+  int m = ${M};
   int n = ${B_arg}->shape[1] * ${float_per_int};
   int k = ${B_arg}->shape[0];
 

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -532,7 +532,7 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["M"] = annotations["M"]
 
         if not isinstance(attrs["M"], tvm.tir.IntImm):
-            attrs["M"] = get_flattened_batch_dim(func_args[0], int(attrs["batch_rank"]))
+            attrs["M"] = get_flattened_batch_dim(func_args[0], int(annotations["batch_rank"]))
 
         if bias_arg_idx is not None:
             attrs["bias_arg"] = func_args[bias_arg_idx]

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -532,7 +532,9 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["M"] = annotations["M"]
 
         if not isinstance(attrs["M"], tvm.tir.IntImm):
-            attrs["M"] = get_flattened_batch_dim(func_args[0], int(annotations["batch_rank"]))
+            attrs["M"] = get_flattened_batch_dim(
+                func_args[lhs_arg_idx], int(annotations["batch_rank"])
+            )
 
         if bias_arg_idx is not None:
             attrs["bias_arg"] = func_args[bias_arg_idx]

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -513,6 +513,9 @@ def instantiate_template(func_name, annotations, func_args):
         dim2 = func_args[arg1_idx] + f"->shape[{arg1_axis_idx}]"
         return dim1 + " * " + dim2
 
+    def get_flattened_batch_dim(arg_name, batch_rank):
+        return " * ".join(["{}->shape[{}]".format(arg_name, i) for i in range(batch_rank)])
+
     if "decode_matmul" in func_name:
         headers.append("cutlass_kernels/fpA_intB_gemm.h")
         lhs_arg_idx = _get_optional_int_annotation(annotations, "lhs_arg_idx", 0)
@@ -524,9 +527,12 @@ def instantiate_template(func_name, annotations, func_args):
         attrs["A_arg"] = func_args[lhs_arg_idx]
         attrs["B_arg"] = func_args[rhs_arg_idx]
         attrs["scales_arg"] = func_args[scales_arg_idx]
-        attrs["batch_offset"] = _get_optional_int_annotation(annotations, "batch_offset", 0)
         attrs["activation"] = annotations.get("activation", "identity")
         attrs["bias_stride"] = annotations["bias_stride"]
+        attrs["M"] = annotations["M"]
+
+        if not isinstance(attrs["M"], tvm.tir.IntImm):
+            attrs["M"] = get_flattened_batch_dim(func_args[0], int(attrs["batch_rank"]))
 
         if bias_arg_idx is not None:
             attrs["bias_arg"] = func_args[bias_arg_idx]
@@ -802,10 +808,8 @@ def instantiate_template(func_name, annotations, func_args):
         attrs = {"input": func_args[0], "gamma": func_args[1], "beta": func_args[2]}
         attrs.update(dict(annotations))
 
-        if isinstance(attrs["M"], tvm.tir.Var):
-            attrs["M"] = " * ".join(
-                ["{}->shape[{}]".format(func_args[0], i) for i in range(int(attrs["batch_rank"]))]
-            )
+        if not isinstance(attrs["M"], tvm.tir.IntImm):
+            attrs["M"] = get_flattened_batch_dim(func_args[0], int(attrs["batch_rank"]))
 
         code = instantiate_layer_norm_template(attrs)
         return CodegenResult(code, headers)
@@ -815,10 +819,8 @@ def instantiate_template(func_name, annotations, func_args):
         attrs = {"input": func_args[0], "weight": func_args[1]}
         attrs.update(dict(annotations))
 
-        if isinstance(attrs["M"], tvm.tir.Var):
-            attrs["M"] = " * ".join(
-                ["{}->shape[{}]".format(func_args[0], i) for i in range(int(attrs["batch_rank"]))]
-            )
+        if not isinstance(attrs["M"], tvm.tir.IntImm):
+            attrs["M"] = get_flattened_batch_dim(func_args[0], int(attrs["batch_rank"]))
 
         code = instantiate_rms_norm_template(attrs)
         return CodegenResult(code, headers)

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1925,10 +1925,7 @@ def test_fp16A_int8B_gemm_batched():
     ex = relax.build(mod_transform, target="llvm")
     vm = relax.vm.VirtualMachine(ex, tvm.cpu(0))
 
-    (
-        packed_weight,
-        scales,
-    ) = vm[
+    (packed_weight, scales,) = vm[
         transform_func_name
     ]((tvm.nd.array(y),))
 

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1805,5 +1805,144 @@ def test_conv2d_cuda_graph():
     tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
 
 
+def test_fp16A_int8B_gemm_batched():
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def decode(
+            A: T.Buffer((T.int64(64), T.int64(64)), "int8"),
+            B: T.Buffer((T.int64(64),), "float16"),
+            decode_1: T.Buffer((T.int64(64), T.int64(64)), "float16"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            for i, j in T.grid(T.int64(64), T.int64(64)):
+                with T.block("decode"):
+                    v_i, v_j = T.axis.remap("SS", [i, j])
+                    T.reads(A[v_i, v_j], B[v_j])
+                    T.writes(decode_1[v_i, v_j])
+                    decode_1[v_i, v_j] = T.Cast("float16", A[v_i, v_j]) * B[v_j]
+
+        @T.prim_func
+        def encode(
+            A: T.Buffer((T.int64(64), T.int64(64)), "float16"),
+            w_gathered: T.Buffer((T.int64(64), T.int64(64)), "int8"),
+            compute: T.Buffer((T.int64(64),), "float16"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            max_abs_value = T.alloc_buffer((T.int64(64),), "float16")
+            scale = T.alloc_buffer((T.int64(64),))
+            for i, k in T.grid(T.int64(64), T.int64(64)):
+                with T.block("max_abs_value"):
+                    v_i, v_k = T.axis.remap("SR", [i, k])
+                    T.reads(A[v_i, v_k])
+                    T.writes(max_abs_value[v_i])
+                    with T.init():
+                        max_abs_value[v_i] = T.float16(-65504)
+                    max_abs_value[v_i] = T.max(max_abs_value[v_i], T.fabs(A[v_i, v_k]))
+            for i in range(T.int64(64)):
+                with T.block("scale"):
+                    v_i = T.axis.spatial(T.int64(64), i)
+                    T.reads(max_abs_value[v_i])
+                    T.writes(scale[v_i])
+                    scale[v_i] = T.max(
+                        T.Cast("float32", max_abs_value[v_i]), T.float32(0.0001)
+                    ) * T.float32(0.0078125)
+            for j, i in T.grid(T.int64(64), T.int64(64)):
+                with T.block("w_gathered"):
+                    v_j, v_i = T.axis.remap("SS", [j, i])
+                    T.reads(A[v_i, v_j], scale[v_i])
+                    T.writes(w_gathered[v_j, v_i])
+                    w_gathered[v_j, v_i] = T.Cast(
+                        "int8",
+                        T.min(
+                            T.max(
+                                T.round(T.Cast("float32", A[v_i, v_j]) / scale[v_i]),
+                                T.float32(-128),
+                            ),
+                            T.float32(127),
+                        ),
+                    )
+            for i0 in range(T.int64(64)):
+                with T.block("compute"):
+                    v_i0 = T.axis.spatial(T.int64(64), i0)
+                    T.reads(scale[v_i0])
+                    T.writes(compute[v_i0])
+                    compute[v_i0] = T.Cast("float16", scale[v_i0])
+
+        @R.function
+        def main(
+            x: R.Tensor(("b", 64, 64), dtype="float16"),
+            y: R.Tensor((64, 64), dtype="float16"),
+        ) -> R.Tensor(("b", 64, 64), dtype="float16"):
+            R.func_attr({"num_input": 1})
+            cls = Module
+            b = T.int64()
+            with R.dataflow():
+                lv = R.call_tir(
+                    cls.encode,
+                    (y,),
+                    out_sinfo=[R.Tensor((64, 64), dtype="int8"), R.Tensor((64,), dtype="float16")],
+                )
+                lv1: R.Tensor((64, 64), dtype="int8") = lv[0]
+                lv2: R.Tensor((64, 64), dtype="int8") = R.call_pure_packed(
+                    "cutlass.ft_preprocess_weight",
+                    lv1,
+                    R.prim_value(80),
+                    R.prim_value(0),
+                    sinfo_args=(R.Tensor((64, 64), dtype="int8"),),
+                )
+                lv3: R.Tensor((64,), dtype="float16") = lv[1]
+                lv4: R.Tensor((64, 64), dtype="int8") = R.builtin.stop_lift_params(lv2)
+                lv5: R.Tensor((64,), dtype="float16") = R.builtin.stop_lift_params(lv3)
+                lv6 = R.call_tir(
+                    cls.decode, (lv4, lv5), out_sinfo=R.Tensor((64, 64), dtype="float16")
+                )
+                lv1_1: R.Tensor((b, 64, 64), dtype="float16") = R.matmul(
+                    x, lv6, out_dtype="float16"
+                )
+                R.output(lv1_1)
+            return lv1_1
+
+    x_shape = (4, 64, 64)
+    y_shape = (64, 64)
+
+    mod = partition_for_cutlass(Module)
+
+    mod = relax.transform.RunCodegen(
+        {"cutlass": {"sm": 80, "find_first_valid": False}},
+    )(mod)
+
+    x = np.random.randn(*x_shape).astype("float16")
+    y = np.random.normal(0, 0.002, size=y_shape).astype("float16")
+
+    mod = relax.pipeline.get_pipeline()(mod)
+    mod = relax.transform.LiftTransformParams()(mod)
+
+    mod_transform, mod_deploy, transform_func_name = split_transform_deploy_mod(mod)
+
+    ex = relax.build(mod_transform, target="llvm")
+    vm = relax.vm.VirtualMachine(ex, tvm.cpu(0))
+
+    (
+        packed_weight,
+        scales,
+    ) = vm[
+        transform_func_name
+    ]((tvm.nd.array(y),))
+
+    dev = tvm.device("cuda", 0)
+    ex = relax.build(mod_deploy, target="cuda")
+    vm = relax.vm.VirtualMachine(ex, dev)
+
+    x_nd = tvm.nd.array(x, dev)
+    params = (packed_weight.copyto(dev), scales.copyto(dev))
+    inp = [x_nd, params]
+    out = vm["main"](*inp).numpy()
+    ref = np.dot(x, y.transpose())
+    tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Similarly to https://github.com/apache/tvm/pull/15499, although the FT kernel does not support batched matmul, we can support batched A by flattening all batch axes into the M axis. 

@vinx13 @yzh119 @Hzfengsy @sunggg 