### PR TITLE
[Unity][Dlight] Matmul tensorization for SM70

### DIFF
--- a/python/tvm/dlight/gpu/matmul.py
+++ b/python/tvm/dlight/gpu/matmul.py
@@ -544,7 +544,7 @@ class Matmul(ScheduleRule):
         sch.transform_block_layout(main_block, matmul_index_map)
 
         block_stmt = sch.get(main_block)
-        if target.kind.name == "cuda" and check_sm_version(target.arch) > 70:
+        if target.kind.name == "cuda" and check_sm_version(target.arch) >= 70:
             apply_tensorization: bool = True
             # the batch dimension is not taken into consideration.
             for item_var in block_stmt.iter_vars[1:]:


### PR DESCRIPTION
Prior to this PR, TensorCore tensorization is not enabled for SM70 while SM70 devices have TensorCore support. This PR enables the tensorization.