### PR TITLE
[Relay][Strategy] Use x86 pool schedules for arm_cpu

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -74,8 +74,7 @@ def schedule_pool_arm_cpu(attrs, outs, target):
             and layout in ("NWC", "NHWC")
         ):
             return topi.arm_cpu.schedule_pool(outs, layout)
-        logger.warning("pool is not optimized for arm cpu.")
-        return topi.generic.schedule_pool(outs, layout)
+        return topi.x86.schedule_pool(outs, layout)
 
 
 def _get_padding_width(padding):


### PR DESCRIPTION
Similar to https://github.com/apache/tvm/pull/15470, x86 schedules are used in place of generic schedules to improve performance.

Since the pooling strategy does not use `OpStrategy`, mocking is used to ensure the relevant `schedule_pool` function is called when lowing a Relay pooling operation with respect to a given target.

cc @ekalda @ashutosh-arm @neildhickey 