### PR TITLE
Remove IRModule Dependency from Target

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -47,6 +47,18 @@ using PassInfoNode = tvm::transform::PassInfoNode;
 using PassContext = tvm::transform::PassContext;
 using PassContextNode = tvm::transform::PassContextNode;
 using Sequential = tvm::transform::Sequential;
+using FTVMRelayToTIR = tvm::transform::Pass;
+/*!
+ * \brief TIRToRuntime conversion specific to a TargetKind
+ *
+ * This function is responsible for scanning an IRModule for appropriate Target-specific functions
+ and generating a Runtime module representing the compiled output
+ *
+ * \param ir_module Unified IRModule
+ * \param target Target to filter on or retrieve arguments from
+ * \return Runtime Module containing compiled functions
+ */
+using FTVMTIRToRuntime = tvm::runtime::TypedPackedFunc<runtime::Module(IRModule, Target)>;
 
 /*
  * \brief Create a function pass.

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -47,18 +47,18 @@ using PassInfoNode = tvm::transform::PassInfoNode;
 using PassContext = tvm::transform::PassContext;
 using PassContextNode = tvm::transform::PassContextNode;
 using Sequential = tvm::transform::Sequential;
-using FTVMRelayToTIR = tvm::transform::Pass;
+
 /*!
- * \brief TIRToRuntime conversion specific to a TargetKind
+ * \brief RelayToTIR tvm::transform::Pass specific to a TargetKind
  *
- * This function is responsible for scanning an IRModule for appropriate Target-specific functions
- and generating a Runtime module representing the compiled output
+ * Called before the default lowering passes.
  *
- * \param ir_module Unified IRModule
- * \param target Target to filter on or retrieve arguments from
- * \return Runtime Module containing compiled functions
+ * \param mod The module that an optimization pass runs on.
+ * \param pass_ctx The pass context that can provide information for the optimization.
+ *
+ * \return The transformed module.
  */
-using FTVMTIRToRuntime = tvm::runtime::TypedPackedFunc<runtime::Module(IRModule, Target)>;
+using FTVMRelayToTIR = tvm::transform::Pass;
 
 /*
  * \brief Create a function pass.

--- a/include/tvm/target/target.h
+++ b/include/tvm/target/target.h
@@ -25,7 +25,6 @@
 #define TVM_TARGET_TARGET_H_
 
 #include <tvm/ir/expr.h>
-#include <tvm/ir/module.h>
 #include <tvm/node/node.h>
 #include <tvm/support/with.h>
 #include <tvm/target/target_kind.h>
@@ -283,15 +282,6 @@ class Target : public ObjectRef {
  * \param host The pointer to a Target typed object for target host to be updated
  */
 void CheckAndUpdateHostConsistency(Target* target, Target* host);
-
-/*!
- * \brief Check and update host field of the given legacy heterogeneous targets and
- *  target host.Note that this function is for legacy target api compatibility issue only,
- *  not recommended for other use.
- * \param ir_modules The pointer to a Map objects with keys being Target objects
- * \param host The Target typed object for target host to be updated
- */
-void CheckAndUpdateHostConsistency(Map<Target, IRModule>* ir_modules, Target* host);
 
 }  // namespace tvm
 #endif  // TVM_TARGET_TARGET_H_

--- a/include/tvm/target/target_kind.h
+++ b/include/tvm/target/target_kind.h
@@ -24,7 +24,6 @@
 #ifndef TVM_TARGET_TARGET_KIND_H_
 #define TVM_TARGET_TARGET_KIND_H_
 
-#include <tvm/ir/transform.h>
 #include <tvm/node/attr_registry_map.h>
 #include <tvm/node/node.h>
 
@@ -50,31 +49,7 @@ using TargetFeatures = Map<String, ObjectRef>;
  * \return The transformed Target JSON object.
  */
 using TargetJSON = Map<String, ObjectRef>;
-using FTVMTargetParser = TypedPackedFunc<TargetJSON(TargetJSON)>;
-
-/*!
- * \brief RelayToTIR tvm::transform::Pass specific to a TargetKind
- *
- * Called before the default lowering passes.
- *
- * \param mod The module that an optimization pass runs on.
- * \param pass_ctx The pass context that can provide information for the optimization.
- *
- * \return The transformed module.
- */
-using FTVMRelayToTIR = transform::Pass;
-
-/*!
- * \brief TIRToRuntime conversion specific to a TargetKind
- *
- * This function is responsible for scanning an IRModule for appropriate Target-specific functions
- and generating a Runtime module representing the compiled output
- *
- * \param ir_module Unified IRModule
- * \param target Target to filter on or retrieve arguments from
- * \return Runtime Module containing compiled functions
- */
-using FTVMTIRToRuntime = runtime::TypedPackedFunc<runtime::Module(IRModule, Target)>;
+using FTVMTargetParser = runtime::TypedPackedFunc<TargetJSON(TargetJSON)>;
 
 namespace detail {
 template <typename, typename, typename>

--- a/include/tvm/tir/usmp/utils.h
+++ b/include/tvm/tir/usmp/utils.h
@@ -27,6 +27,7 @@
 
 #include <tvm/ir/expr.h>
 #include <tvm/ir/memory_pools.h>
+#include <tvm/ir/module.h>
 #include <tvm/runtime/device_api.h>
 #include <tvm/target/target.h>
 #include <tvm/tir/stmt.h>

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -431,6 +431,23 @@ std::pair<IRModule, IRModule> SplitMixedModule(IRModule mod_mixed, const Target&
   return {host_mod, device_mod};
 }
 
+/*!
+ * \brief Check and update host field of the given legacy heterogeneous targets and
+ *  target host.Note that this function is for legacy target api compatibility issue only,
+ *  not recommended for other use.
+ * \param ir_modules The pointer to a Map objects with keys being Target objects
+ * \param host The Target typed object for target host to be updated
+ */
+void CheckAndUpdateHostConsistency(Map<Target, IRModule>* targets, Target* host) {
+  Map<Target, IRModule> new_targets;
+  for (auto& it : *targets) {
+    auto target = it.first;
+    CheckAndUpdateHostConsistency(&target, host);
+    new_targets.Set(target, it.second);
+  }
+  *targets = new_targets;
+}
+
 runtime::Module TIRToRuntime(const Map<Target, IRModule>& inputs_arg,
                              const Target& target_host_arg) {
   std::vector<runtime::Module> device_modules;

--- a/src/relay/backend/contrib/cmsisnn/target.cc
+++ b/src/relay/backend/contrib/cmsisnn/target.cc
@@ -32,13 +32,14 @@ namespace cmsisnn {
 
 tvm::transform::Pass RelayToTIR();
 runtime::Module TIRToRuntime(IRModule mod, Target target);
+using FTVMTIRToRuntime = tvm::runtime::TypedPackedFunc<runtime::Module(IRModule, Target)>;
 
 TVM_REGISTER_TARGET_KIND("cmsis-nn", kDLCPU)
     .add_attr_option<Array<String>>("mattr")
     .add_attr_option<String>("mcpu")
     .add_attr_option<Bool>("debug_last_error")
     .set_attr<relay::transform::FTVMRelayToTIR>(tvm::attr::kRelayToTIR, RelayToTIR())
-    .set_attr<relay::transform::FTVMTIRToRuntime>("TIRToRuntime", TIRToRuntime)
+    .set_attr<FTVMTIRToRuntime>("TIRToRuntime", TIRToRuntime)
     .set_target_parser(tvm::target::parsers::cpu::ParseTarget);
 
 }  // namespace cmsisnn

--- a/src/relay/backend/contrib/cmsisnn/target.cc
+++ b/src/relay/backend/contrib/cmsisnn/target.cc
@@ -37,8 +37,8 @@ TVM_REGISTER_TARGET_KIND("cmsis-nn", kDLCPU)
     .add_attr_option<Array<String>>("mattr")
     .add_attr_option<String>("mcpu")
     .add_attr_option<Bool>("debug_last_error")
-    .set_attr<FTVMRelayToTIR>(tvm::attr::kRelayToTIR, RelayToTIR())
-    .set_attr<FTVMTIRToRuntime>("TIRToRuntime", TIRToRuntime)
+    .set_attr<relay::transform::FTVMRelayToTIR>(tvm::attr::kRelayToTIR, RelayToTIR())
+    .set_attr<relay::transform::FTVMTIRToRuntime>("TIRToRuntime", TIRToRuntime)
     .set_target_parser(tvm::target::parsers::cpu::ParseTarget);
 
 }  // namespace cmsisnn

--- a/src/relay/backend/contrib/codegen_c/target.cc
+++ b/src/relay/backend/contrib/codegen_c/target.cc
@@ -34,7 +34,7 @@ namespace contrib {
  */
 TVM_REGISTER_TARGET_KIND("ccompiler", kDLCPU)
     .set_attr<Bool>(tvm::attr::kIsExternalCodegen, Bool(true))
-    .set_attr<FTVMRelayToTIR>(tvm::attr::kRelayToTIR, CCompilerPass())
+    .set_attr<relay::transform::FTVMRelayToTIR>(tvm::attr::kRelayToTIR, CCompilerPass())
     // Value is prepended to every output CModule.
     .add_attr_option<String>("header", String(""));
 

--- a/src/relay/backend/contrib/cutlass/target.cc
+++ b/src/relay/backend/contrib/cutlass/target.cc
@@ -40,7 +40,7 @@ namespace cutlass {
  */
 TVM_REGISTER_TARGET_KIND("cutlass", kDLCUDA)
     .set_attr<Bool>(tvm::attr::kIsExternalCodegen, Bool(true))
-    .set_attr<FTVMRelayToTIR>("RelayToTIR", CompileForCutlass())
+    .set_attr<tvm::transform::Pass>("RelayToTIR", CompileForCutlass())
     // An integer specifying the compute capability. For example, 75 for Turing and
     // 80 or 86 for Ampere.
     .add_attr_option<Integer>("sm", Integer(80))

--- a/src/relay/backend/contrib/ethosu/codegen.cc
+++ b/src/relay/backend/contrib/ethosu/codegen.cc
@@ -47,6 +47,8 @@ namespace relay {
 namespace contrib {
 namespace ethosu {
 
+using FTVMTIRToRuntime = tvm::runtime::TypedPackedFunc<runtime::Module(IRModule, Target)>;
+
 /*!
  * \brief This mutator outlines functions that are marked with a named
  * "Compiler" attribute. Functions that do not match this condition remain
@@ -321,7 +323,7 @@ runtime::Module TIRToRuntime(IRModule mod, Target target) {
 TVM_REGISTER_TARGET_KIND("ethos-u", kDLCPU)
     .set_attr<Bool>("use_device_api", Bool(true))
     .set_attr<relay::transform::FTVMRelayToTIR>(tvm::attr::kRelayToTIR, RelayToTIR())
-    .set_attr<relay::transform::FTVMTIRToRuntime>("TIRToRuntime", TIRToRuntime);
+    .set_attr<FTVMTIRToRuntime>("TIRToRuntime", TIRToRuntime);
 
 }  // namespace ethosu
 }  // namespace contrib

--- a/src/relay/backend/contrib/ethosu/codegen.cc
+++ b/src/relay/backend/contrib/ethosu/codegen.cc
@@ -320,8 +320,8 @@ runtime::Module TIRToRuntime(IRModule mod, Target target) {
 
 TVM_REGISTER_TARGET_KIND("ethos-u", kDLCPU)
     .set_attr<Bool>("use_device_api", Bool(true))
-    .set_attr<FTVMRelayToTIR>(tvm::attr::kRelayToTIR, RelayToTIR())
-    .set_attr<FTVMTIRToRuntime>("TIRToRuntime", TIRToRuntime);
+    .set_attr<relay::transform::FTVMRelayToTIR>(tvm::attr::kRelayToTIR, RelayToTIR())
+    .set_attr<relay::transform::FTVMTIRToRuntime>("TIRToRuntime", TIRToRuntime);
 
 }  // namespace ethosu
 }  // namespace contrib

--- a/src/relay/backend/contrib/example_target_hooks/target.cc
+++ b/src/relay/backend/contrib/example_target_hooks/target.cc
@@ -22,6 +22,8 @@
 
 namespace tvm {
 
+using FTVMTIRToRuntime = tvm::runtime::TypedPackedFunc<runtime::Module(IRModule, Target)>;
+
 namespace relay {
 namespace contrib {
 namespace example_target_hooks {
@@ -35,8 +37,7 @@ TVM_REGISTER_TARGET_KIND("example_target_hook", kDLCPU)
     .set_attr<Bool>("use_device_api", Bool(true))
     .set_attr<relay::transform::FTVMRelayToTIR>(attr::kRelayToTIR,
                                                 relay::contrib::example_target_hooks::RelayToTIR())
-    .set_attr<relay::transform::FTVMTIRToRuntime>(
-        "TIRToRuntime", relay::contrib::example_target_hooks::TIRToRuntime)
+    .set_attr<FTVMTIRToRuntime>("TIRToRuntime", relay::contrib::example_target_hooks::TIRToRuntime)
     .add_attr_option<Integer>("example_attribute", Integer(0));
 
 }  // namespace tvm

--- a/src/relay/backend/contrib/example_target_hooks/target.cc
+++ b/src/relay/backend/contrib/example_target_hooks/target.cc
@@ -33,8 +33,10 @@ runtime::Module TIRToRuntime(IRModule mod, Target target);
 
 TVM_REGISTER_TARGET_KIND("example_target_hook", kDLCPU)
     .set_attr<Bool>("use_device_api", Bool(true))
-    .set_attr<FTVMRelayToTIR>(attr::kRelayToTIR, relay::contrib::example_target_hooks::RelayToTIR())
-    .set_attr<FTVMTIRToRuntime>("TIRToRuntime", relay::contrib::example_target_hooks::TIRToRuntime)
+    .set_attr<relay::transform::FTVMRelayToTIR>(attr::kRelayToTIR,
+                                                relay::contrib::example_target_hooks::RelayToTIR())
+    .set_attr<relay::transform::FTVMTIRToRuntime>(
+        "TIRToRuntime", relay::contrib::example_target_hooks::TIRToRuntime)
     .add_attr_option<Integer>("example_attribute", Integer(0));
 
 }  // namespace tvm

--- a/src/relay/backend/contrib/tensorrt/target.cc
+++ b/src/relay/backend/contrib/tensorrt/target.cc
@@ -39,7 +39,7 @@ namespace tensorrt {
  */
 TVM_REGISTER_TARGET_KIND("tensorrt", kDLCUDA)
     .set_attr<Bool>(tvm::attr::kIsExternalCodegen, Bool(true))
-    .set_attr<FTVMRelayToTIR>("RelayToTIR", CompileForTensorRT())
+    .set_attr<tvm::transform::Pass>("RelayToTIR", CompileForTensorRT())
     // A array of three integers given the major, minor, and patch numbers for the supported
     // TensorRT compiler version. If empty will be auto-detected from linked library. Default empty.
     .add_attr_option<Array<Integer>>("tensorrt_version", Array<Integer>())

--- a/src/relay/backend/contrib/uma/targets.cc
+++ b/src/relay/backend/contrib/uma/targets.cc
@@ -28,6 +28,8 @@
 
 namespace tvm {
 
+using FTVMTIRToRuntime = tvm::runtime::TypedPackedFunc<runtime::Module(IRModule, Target)>;
+
 namespace relay {
 namespace contrib {
 namespace uma {
@@ -46,20 +48,20 @@ TVM_REGISTER_GLOBAL("relay.backend.contrib.uma.RegisterTarget")
         }
       }
 
-      auto target_kind = TargetKindRegEntry::RegisterOrGet(target_name)
-                             .set_name()
-                             .set_default_device_type(kDLCPU)
-                             .add_attr_option<Array<String>>("keys")
-                             .add_attr_option<String>("tag")
-                             .add_attr_option<String>("device")
-                             .add_attr_option<String>("model")
-                             .add_attr_option<Array<String>>("libs")
-                             .add_attr_option<Target>("host")
-                             .add_attr_option<Integer>("from_device")
-                             .set_attr<relay::transform::FTVMRelayToTIR>(
-                                 attr::kRelayToTIR, relay::contrib::uma::RelayToTIR(target_name))
-                             .set_attr<relay::transform::FTVMTIRToRuntime>(
-                                 "TIRToRuntime", relay::contrib::uma::TIRToRuntime);
+      auto target_kind =
+          TargetKindRegEntry::RegisterOrGet(target_name)
+              .set_name()
+              .set_default_device_type(kDLCPU)
+              .add_attr_option<Array<String>>("keys")
+              .add_attr_option<String>("tag")
+              .add_attr_option<String>("device")
+              .add_attr_option<String>("model")
+              .add_attr_option<Array<String>>("libs")
+              .add_attr_option<Target>("host")
+              .add_attr_option<Integer>("from_device")
+              .set_attr<relay::transform::FTVMRelayToTIR>(
+                  attr::kRelayToTIR, relay::contrib::uma::RelayToTIR(target_name))
+              .set_attr<FTVMTIRToRuntime>("TIRToRuntime", relay::contrib::uma::TIRToRuntime);
 
       // target kind attrs inventory
       auto kind = TargetKind::Get(target_name).value();

--- a/src/relay/backend/contrib/uma/targets.cc
+++ b/src/relay/backend/contrib/uma/targets.cc
@@ -46,20 +46,20 @@ TVM_REGISTER_GLOBAL("relay.backend.contrib.uma.RegisterTarget")
         }
       }
 
-      auto target_kind =
-          TargetKindRegEntry::RegisterOrGet(target_name)
-              .set_name()
-              .set_default_device_type(kDLCPU)
-              .add_attr_option<Array<String>>("keys")
-              .add_attr_option<String>("tag")
-              .add_attr_option<String>("device")
-              .add_attr_option<String>("model")
-              .add_attr_option<Array<String>>("libs")
-              .add_attr_option<Target>("host")
-              .add_attr_option<Integer>("from_device")
-              .set_attr<FTVMRelayToTIR>(attr::kRelayToTIR,
-                                        relay::contrib::uma::RelayToTIR(target_name))
-              .set_attr<FTVMTIRToRuntime>("TIRToRuntime", relay::contrib::uma::TIRToRuntime);
+      auto target_kind = TargetKindRegEntry::RegisterOrGet(target_name)
+                             .set_name()
+                             .set_default_device_type(kDLCPU)
+                             .add_attr_option<Array<String>>("keys")
+                             .add_attr_option<String>("tag")
+                             .add_attr_option<String>("device")
+                             .add_attr_option<String>("model")
+                             .add_attr_option<Array<String>>("libs")
+                             .add_attr_option<Target>("host")
+                             .add_attr_option<Integer>("from_device")
+                             .set_attr<relay::transform::FTVMRelayToTIR>(
+                                 attr::kRelayToTIR, relay::contrib::uma::RelayToTIR(target_name))
+                             .set_attr<relay::transform::FTVMTIRToRuntime>(
+                                 "TIRToRuntime", relay::contrib::uma::TIRToRuntime);
 
       // target kind attrs inventory
       auto kind = TargetKind::Get(target_name).value();

--- a/src/target/codegen.cc
+++ b/src/target/codegen.cc
@@ -38,6 +38,9 @@
 #include <vector>
 
 namespace tvm {
+
+using FTVMTIRToRuntime = runtime::TypedPackedFunc<runtime::Module(IRModule, Target)>;
+
 namespace codegen {
 
 runtime::Module Build(IRModule mod, Target target) {

--- a/src/target/codegen.cc
+++ b/src/target/codegen.cc
@@ -39,9 +39,19 @@
 
 namespace tvm {
 
-using FTVMTIRToRuntime = runtime::TypedPackedFunc<runtime::Module(IRModule, Target)>;
-
 namespace codegen {
+
+/*!
+ * \brief TIRToRuntime conversion specific to a TargetKind
+ *
+ * This function is responsible for scanning an IRModule for appropriate Target-specific functions
+ and generating a Runtime module representing the compiled output
+ *
+ * \param ir_module Unified IRModule
+ * \param target Target to filter on or retrieve arguments from
+ * \return Runtime Module containing compiled functions
+ */
+using FTVMTIRToRuntime = tvm::runtime::TypedPackedFunc<runtime::Module(IRModule, Target)>;
 
 runtime::Module Build(IRModule mod, Target target) {
   if (transform::PassContext::Current()

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -21,6 +21,7 @@
  * \file src/target/target.cc
  */
 #include <dmlc/thread_local.h>
+#include <tvm/ir/transform.h>
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/registry.h>
@@ -89,16 +90,6 @@ Target Target::WithHost(const Target& target, const Target& host) {
 void CheckAndUpdateHostConsistency(Target* target, Target* host) {
   *target = Target(*target, *host);
   *host = (*target)->GetHost().value_or(Target());
-}
-
-void CheckAndUpdateHostConsistency(Map<Target, IRModule>* targets, Target* host) {
-  Map<Target, IRModule> new_targets;
-  for (auto& it : *targets) {
-    auto target = it.first;
-    CheckAndUpdateHostConsistency(&target, host);
-    new_targets.Set(target, it.second);
-  }
-  *targets = new_targets;
 }
 
 static std::vector<String> DeduplicateKeys(const std::vector<String>& keys) {
@@ -614,8 +605,8 @@ Target::Target(TargetKind kind, Optional<ObjectRef> host, String tag, Array<Stri
 bool Target::IsExternalCodegen() const {
   TargetKindAttrMap<Bool> is_external_codegen_map =
       TargetKind::GetAttrMap<Bool>(tvm::attr::kIsExternalCodegen);
-  TargetKindAttrMap<FTVMRelayToTIR> relay_to_tir_map =
-      TargetKind::GetAttrMap<FTVMRelayToTIR>(tvm::attr::kRelayToTIR);
+  TargetKindAttrMap<tvm::transform::Pass> relay_to_tir_map =
+      TargetKind::GetAttrMap<tvm::transform::Pass>(tvm::attr::kRelayToTIR);
   return is_external_codegen_map.get(get()->kind, Bool(false)) ||
          relay_to_tir_map.count(get()->kind);
 }

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -458,7 +458,8 @@ TVM_REGISTER_TARGET_KIND("test_external_codegen_2", kDLMetal)
     .set_attr<Bool>(tvm::attr::kIsExternalCodegen, Bool(true));
 
 TVM_REGISTER_TARGET_KIND("test_external_codegen_3", kDLCPU)
-    .set_attr<FTVMRelayToTIR>(tvm::attr::kRelayToTIR, tvm::relay::transform::InferType());
+    .set_attr<tvm::relay::transform::FTVMRelayToTIR>(tvm::attr::kRelayToTIR,
+                                                     tvm::relay::transform::InferType());
 
 TEST(Target, ExternalCodegen) {
   Target regular("cuda");


### PR DESCRIPTION
There is a dependency of IRModule in the current Target implementation: `target.h -> module.h`. This pull request aims to decouple the dependency."