### PR TITLE
[TOPI] check empty array of x86 injective's iters

### DIFF
--- a/include/tvm/topi/x86/injective.h
+++ b/include/tvm/topi/x86/injective.h
@@ -51,7 +51,7 @@ inline Schedule schedule_injective_from_existing(Schedule sch, const Tensor& out
     auto c = axis[1];
     auto fused = detail::Fuse(sch[out], {n, c});  // for nhwc layout, fuse n and h
     sch[out].parallel(fused);
-  } else {
+  } else if (!axis.empty()) {
     sch[out].parallel(axis[0]);
   }
   return sch;


### PR DESCRIPTION
Just add a missing check, for following simple case:
```
#[version = "0.0.5"]
def @main(%v: float32 /* ty=float32 */) -> float32 {
  %0 = fn (%X: float32 /* ty=float32 */, Primitive=1) -> float32 {
    add(%X, 1f /* ty=float32 */) /* ty=float32 */
  } /* ty=fn (float32) -> float32 */;
  %0(%v) /* ty=float32 */
}
```