### PR TITLE
[Unity] Propagate dynamic begin/end in strided_slice when legalizing

### DIFF
--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -660,14 +660,10 @@ inline Tensor dynamic_strided_slice(const Tensor& x, const Array<PrimExpr>& begi
   const size_t num_slice_axes = begin.size();
   Array<PrimExpr> out_shape;
 
+  arith::Analyzer analyzer;
   for (size_t i = 0; i < num_slice_axes; ++i) {
-    auto d = indexdiv(end[i] - begin[i], strides[i]);
-    if (d->IsInstance<tvm::IntImmNode>()) {
-      // Preserve static dimension if possible
-      out_shape.push_back(d);
-    } else {
-      out_shape.push_back(tvm::tir::Var("dim"));
-    }
+    auto d = analyzer.Simplify(indexdiv(end[i] - begin[i], strides[i]));
+    out_shape.push_back(d);
   }
 
   for (size_t i = num_slice_axes; i < src_tensor_dim; ++i) {


### PR DESCRIPTION
A follow-up to PR #15450, which allowed dynamic begin/end expressions in `relax.op.strided_slice`.  If the shape of the output is static, such as a slice from `index:index+slice_size`, the relax operator will delegate to `topi.strided_slice`, but that may then delegate to `topi.dynamic_strided_slice` due to the dynamic begin/end.  In this case, the topi implementation inserts an additional output variable `"dim"`, without providing a definition.

This behavior works in topi, as the output shape variable may have a definition provided from the calling scope, when the output tensor is passed in.  However, even in topi, this behavior is fragile as it assumes that the Tensor output is the same as the resulting PrimFunc output.

This commit updates the topi implementation of `strided_slice` to propagate the shape information from the inputs.