### PR TITLE
[TEST] Run tests/python/relay/aot tests in ci-cortexm

### DIFF
--- a/tests/python/relay/aot/test_c_device_api.py
+++ b/tests/python/relay/aot/test_c_device_api.py
@@ -143,42 +143,46 @@ def test_device_api_hooks_unpacked_api(device_api_main_func):
 
     # Activate Device
     assert (
-        str(main_func.body[0])
-        == "tir.tvm_check_return(0, -1, tir.call_extern("
-        + '"TVMDeviceEthosUActivate",'
-        + " device_context_ethos_u))\n"
+        str(main_func.body[0].value)
+        == "T.tvm_check_return(0, -1, T.call_extern("
+        + '"int32",'
+        + ' "TVMDeviceEthosUActivate",'
+        + " device_context_ethos_u))"
     )
     # Open Device
     print("main func", repr(main_func.body))
     assert (
-        str(main_func.body[1][0][0][0])
-        == "tir.tvm_check_return(0, -1, tir.call_extern("
-        + '"TVMDeviceEthosUOpen",'
-        + " device_context_ethos_u))\n"
+        str(main_func.body[1].value)
+        == "T.tvm_check_return(0, -1, T.call_extern("
+        + '"int32",'
+        + ' "TVMDeviceEthosUOpen",'
+        + " device_context_ethos_u))"
     )
     # Device Call
     # We dont need to check exact input and output var names in this test.
     # Hence, using a regex to cover any legal I/O name.
     regex = re.compile(
-        r"tir\.tvm_check_return\("
+        r"T\.tvm_check_return\("
         r"0, -1, "
-        r'tir\.call_extern\("tvmgen_default_ethos_u_main_0", '
+        r'T\.call_extern\("int32", "tvmgen_default_ethos_u_main_0", '
         r"\w+, \w+, device_context_ethos_u\)\)"
     )
-    assert regex.match(str(main_func.body[1][0][0][1]))
+    assert regex.match(str(main_func.body[2].value))
     # Close Device
     assert (
-        str(main_func.body[1][0][0][2])
-        == "tir.tvm_check_return(0, -1, tir.call_extern("
-        + '"TVMDeviceEthosUClose",'
-        + " device_context_ethos_u))\n"
+        str(main_func.body[3].value)
+        == "T.tvm_check_return(0, -1, T.call_extern("
+        + '"int32",'
+        + ' "TVMDeviceEthosUClose",'
+        + " device_context_ethos_u))"
     )
     # Deactivate Device
     assert (
-        str(str(main_func.body[2]))
-        == "tir.tvm_check_return(0, -1, tir.call_extern("
-        + '"TVMDeviceEthosUDeactivate",'
-        + " device_context_ethos_u))\n"
+        str(str(main_func.body[4].value))
+        == "T.tvm_check_return(0, -1, T.call_extern("
+        + '"int32",'
+        + ' "TVMDeviceEthosUDeactivate",'
+        + " device_context_ethos_u))"
     )
 
 

--- a/tests/python/relay/aot/test_crt_forward_declarations.py
+++ b/tests/python/relay/aot/test_crt_forward_declarations.py
@@ -111,7 +111,7 @@ def test_external_calls(test_runner):
         main_source.count("TVMBackendAllocWorkspace") == 3
         or main_source.count("TVMBackendAllocWorkspace") == 0
     )
-    assert main_source.count("tvmgen_default_fused_reshape") == 2
+    assert main_source.count("tvmgen_default_fused_reshape") == 3
     assert main_source.count("tvmgen_default_cmsis_nn_main") == 12
     cmsisnn_source = lib_mod.imported_modules[0].get_source()
     assert cmsisnn_source.count("arm_convolve_wrapper") == 1
@@ -243,8 +243,8 @@ def test_tensorized_calls():
 
     lib_mod = compiled_models[0].executor_factory.lib.imported_modules[0]
     main_source = lib_mod.get_source()
-    assert main_source.count("tvmgen_default_fused_nn_conv2d") == 2
-    assert main_source.count("gemm_") == 13
+    assert main_source.count("tvmgen_default_fused_nn_conv2d") == 3
+    assert main_source.count("gemm_") == 15
 
 
 if __name__ == "__main__":

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -64,7 +64,7 @@ run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-integration tests/python/int
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib --ignore=tests/python/contrib/test_ethosu --ignore=tests/python/contrib/test_cmsisnn
 # forked is needed because the global registry gets contaminated
 TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \
-    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relay tests/python/relay
+    run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relay tests/python/relay --ignore=tests/python/relay/aot
 
 # OpenCL texture test. Deselected specific tests that fails  in CI
 TVM_TEST_TARGETS="${TVM_RELAY_OPENCL_TEXTURE_TARGETS:-opencl}" \

--- a/tests/scripts/task_python_microtvm.sh
+++ b/tests/scripts/task_python_microtvm.sh
@@ -66,6 +66,7 @@ python3 gallery/how_to/work_with_microtvm/micro_autotune.py
 python3 gallery/how_to/work_with_microtvm/micro_aot.py
 
 run_pytest ctypes python-relay-strategy-arm_cpu tests/python/relay/strategy/arm_cpu --enable-corstone300-tests
+run_pytest ctypes python-relay-aot tests/python/relay/aot --enable-corstone300-tests
 run_pytest ctypes python-integration-m7-simd tests/python/integration/test_arm_mprofile_dsp.py --enable-corstone300-tests
 run_pytest ctypes python-integration-contrib-test_cmsisnn tests/python/contrib/test_cmsisnn -n auto
 run_pytest ctypes python-integration-contrib-test_ethosu tests/python/contrib/test_ethosu -n auto


### PR DESCRIPTION
The tests in `tests/python/relay/aot` were run as part of `task_python_integration.sh` which is run for `ci-cpu` and `ci-arm`, but some of tests in that folder require CMSIS-NN or FVP, so in practice they were not running anywhere in the upstream CI.

Since all the tests in that folder could run on `ci-cortexm`, change the scripts to run them there.

Also fix some tests that started failing as a result of #15103 (but didn't manifest in upstream CI) and `test_device_api_hooks_unpacked_api` that clearly hasn't been running in any CI for a while.