### PR TITLE
[Unity][Bugfix] Handle assignment of non-dataflow var to a dataflow var in CanonicalizeBindings

### DIFF
--- a/src/relax/transform/canonicalize_bindings.cc
+++ b/src/relax/transform/canonicalize_bindings.cc
@@ -51,7 +51,7 @@ class BindingCanonicalizer : public ExprMutator {
     if (!CanCanonicalizeVar(v)) {
       return Downcast<Expr>(v);
     }
-    return ExprMutator::VisitExpr_(LookupBinding(v).as<DataflowVarNode>());
+    return ExprMutator::VisitExpr_(LookupBinding(v).as<VarNode>());
   }
 
   void VisitBinding_(const VarBindingNode* binding) override {

--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -95,7 +95,7 @@ def test_assign_to_output_indataflow_block():
         @R.function
         def main(x: R.Tensor):
             with R.dataflow():
-                y = x # is not a dataflow var
+                y = x  # is not a dataflow var
                 z = y
                 o = z
                 p = o

--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -89,6 +89,40 @@ def test_dataflow_block():
     assert_structural_equal(new_mod, Expected)
 
 
+def test_assign_to_output_indataflow_block():
+    @tvm.script.ir_module
+    class TestDataflowAssignments:
+        @R.function
+        def main(x: R.Tensor):
+            with R.dataflow():
+                y = x # is not a dataflow var
+                z = y
+                o = z
+                p = o
+                m = p
+                n = m
+                R.output(n)
+            return n
+
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor):
+            with R.dataflow():
+                y = x
+                z = x
+                o = x
+                p = x
+                m = x
+                # we can't get rid of n because it leaves the block
+                n = x
+                R.output(n)
+            return x
+
+    new_mod = relax.transform.CanonicalizeBindings()(TestDataflowAssignments)
+    assert_structural_equal(new_mod, Expected)
+
+
 def test_ops():
     @tvm.script.ir_module
     class TestOps:


### PR DESCRIPTION
Split off from #15474: This is a simple bugfix that corrects a segfault in the `CanonicalizeBindings` pass. Namely, it did not handle the case of a non-dataflow var being bound to a dataflow var (which is permitted) and gave a segfault if it was encountered.