### PR TITLE
[quantize] fix bug of annotate for output of add op

### DIFF
--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -276,7 +276,7 @@ def add_rewrite(ref_call, new_args, ctx):
         assert rhs_kind in [QAnnotateKind.INPUT, QAnnotateKind.ACTIVATION]
         lhs_expr = attach_simulated_quantize(lhs_expr, QAnnotateKind.INPUT)
         expr = _forward_op(ref_call, [lhs_expr, rhs_expr])
-        return QAnnotateExpr(expr, QAnnotateKind.INPUT)
+        return QAnnotateExpr(expr, QAnnotateKind.ACTIVATION)
 
     if lhs_kind is not None and rhs_kind is None:
         if _analysis.check_constant(rhs_expr):
@@ -290,7 +290,7 @@ def add_rewrite(ref_call, new_args, ctx):
     if lhs_kind is not None and rhs_kind is not None:
         if lhs_kind == QAnnotateKind.INPUT and rhs_kind == QAnnotateKind.INPUT:
             expr = _forward_op(ref_call, [lhs_expr, rhs_expr])
-            return QAnnotateExpr(expr, QAnnotateKind.INPUT)
+            return QAnnotateExpr(expr, QAnnotateKind.ACTIVATION)
         if lhs_kind == QAnnotateKind.ACTIVATION and rhs_kind == QAnnotateKind.ACTIVATION:
             rhs_expr = attach_simulated_quantize(rhs_expr, QAnnotateKind.INPUT)
             expr = _forward_op(ref_call, [lhs_expr, rhs_expr])

--- a/tests/python/relay/test_pass_auto_quantize.py
+++ b/tests/python/relay/test_pass_auto_quantize.py
@@ -439,6 +439,68 @@ def test_dense_conv2d_rewrite():
 
     relay.analysis.post_order_visit(qnn_mod["main"], _check_dense)
 
+def test_add_lhs_is_none_annotate():
+    data_conv = relay.var("data_conv", shape=(1, 16, 64, 64))
+    conv2d_w = relay.const(np.random.random((16, 16, 3, 3)))
+    conv2d = relay.nn.conv2d(data_conv, conv2d_w, padding=(1, 1),kernel_size=(3,3))
+    data_add = relay.var("data_add", shape=(16, 1, 1))
+    add = relay.add(data_add, conv2d)
+    global_avg_pool2d = relay.nn.global_avg_pool2d(add)
+    mod = tvm.IRModule.from_expr(global_avg_pool2d)
+    
+    calibrate_data = [{"data_conv": np.random.random((1, 16, 64 ,64)),
+                       "data_add": np.random.random((16, 1, 1))}]
+
+    with tvm.transform.PassContext(opt_level=3):
+        with relay.quantize.qconfig(
+            calibrate_mode="kl_divergence", skip_conv_layers=None
+        ):
+            qmod = relay.quantize.quantize(mod, dataset=calibrate_data)
+    print(qmod)
+    # ensure partitioned and unpartitioned results agree
+    params = [gen_rand_tvm(param.type_annotation, 0, 1) for param in mod["main"].params]
+    # a = 1
+
+    def _eval_mod(mod):
+        return relay.create_executor("vm", device=tvm.cpu(0), target="llvm", mod=mod).evaluate()(
+            *params
+        )
+
+    mod_result = _eval_mod(mod)
+    qmod_result = _eval_mod(qmod)
+    tvm.testing.assert_allclose(mod_result.numpy(), qmod_result.numpy(), rtol=1e-1, atol=1e-1)
+
+def test_add_lhs_rhs_is_input_annotate():
+    data_conv_r = relay.var("data_conv_r", shape=(1, 16, 64, 64))
+    conv2d_r = relay.nn.conv2d(data_conv_r, relay.const(np.random.random((16, 16, 3, 3))), padding=(1, 1),kernel_size=(3,3))
+    data_conv_l = relay.var("data_conv_l", shape=(1, 16, 64, 64))
+    conv2d_l = relay.nn.conv2d(data_conv_l, relay.const(np.random.random((16, 16, 3, 3))), padding=(1, 1),kernel_size=(3,3))
+    add = relay.add(conv2d_l, conv2d_r)
+    global_avg_pool2d = relay.nn.global_avg_pool2d(add)
+    mod = tvm.IRModule.from_expr(global_avg_pool2d)
+    
+    calibrate_data = [{"data_conv_l": np.random.random((1, 16, 64 ,64)),
+                       "data_conv_r": np.random.random((1, 16, 64 ,64)),
+                       "data_add": np.random.random((16, 1, 1))}]
+
+    with tvm.transform.PassContext(opt_level=3):
+        with relay.quantize.qconfig(
+            calibrate_mode="kl_divergence", skip_conv_layers=None
+        ):
+            qmod = relay.quantize.quantize(mod, dataset=calibrate_data)
+    print(qmod)
+    # ensure partitioned and unpartitioned results agree
+    params = [gen_rand_tvm(param.type_annotation, 0, 1) for param in mod["main"].params]
+    # a = 1
+
+    def _eval_mod(mod):
+        return relay.create_executor("vm", device=tvm.cpu(0), target="llvm", mod=mod).evaluate()(
+            *params
+        )
+
+    mod_result = _eval_mod(mod)
+    qmod_result = _eval_mod(qmod)
+    tvm.testing.assert_allclose(mod_result.numpy(), qmod_result.numpy(), rtol=1e-1, atol=1e-1)
 
 if __name__ == "__main__":
     test_mul_rewrite()
@@ -460,3 +522,7 @@ if __name__ == "__main__":
 
     test_skip_conv()
     test_stop_quantize()
+
+    test_add_lhs_is_none_annotate()
+    test_add_lhs_rhs_is_input_annotate()
+

--- a/tests/python/relay/test_pass_auto_quantize.py
+++ b/tests/python/relay/test_pass_auto_quantize.py
@@ -457,9 +457,8 @@ def test_add_lhs_is_none_annotate():
         ):
             qmod = relay.quantize.quantize(mod, dataset=calibrate_data)
     print(qmod)
-    # ensure partitioned and unpartitioned results agree
+    
     params = [gen_rand_tvm(param.type_annotation, 0, 1) for param in mod["main"].params]
-    # a = 1
 
     def _eval_mod(mod):
         return relay.create_executor("vm", device=tvm.cpu(0), target="llvm", mod=mod).evaluate()(
@@ -489,9 +488,8 @@ def test_add_lhs_rhs_is_input_annotate():
         ):
             qmod = relay.quantize.quantize(mod, dataset=calibrate_data)
     print(qmod)
-    # ensure partitioned and unpartitioned results agree
+    
     params = [gen_rand_tvm(param.type_annotation, 0, 1) for param in mod["main"].params]
-    # a = 1
 
     def _eval_mod(mod):
         return relay.create_executor("vm", device=tvm.cpu(0), target="llvm", mod=mod).evaluate()(

--- a/tests/python/relay/test_pass_auto_quantize.py
+++ b/tests/python/relay/test_pass_auto_quantize.py
@@ -443,20 +443,20 @@ def test_dense_conv2d_rewrite():
 def test_add_lhs_is_none_annotate():
     data_conv = relay.var("data_conv", shape=(1, 16, 64, 64))
     conv2d_w = relay.const(np.random.random((16, 16, 3, 3)))
-    conv2d = relay.nn.conv2d(data_conv, conv2d_w, padding=(1, 1), kernel_size=(3,3))
+    conv2d = relay.nn.conv2d(data_conv, conv2d_w, padding=(1, 1), kernel_size=(3, 3))
     data_add = relay.var("data_add", shape=(16, 1, 1))
     add = relay.add(data_add, conv2d)
     global_avg_pool2d = relay.nn.global_avg_pool2d(add)
     mod = tvm.IRModule.from_expr(global_avg_pool2d)
-    
+
     calibrate_data = [
-        {"data_conv": np.random.random((1, 16, 64 ,64)), "data_add": np.random.random((16, 1, 1))}
+        {"data_conv": np.random.random((1, 16, 64, 64)), "data_add": np.random.random((16, 1, 1))}
     ]
 
     with tvm.transform.PassContext(opt_level=3):
         with relay.quantize.qconfig(calibrate_mode="kl_divergence", skip_conv_layers=None):
             qmod = relay.quantize.quantize(mod, dataset=calibrate_data)
-    
+
     params = [gen_rand_tvm(param.type_annotation, 0, 1) for param in mod["main"].params]
 
     def _eval_mod(mod):
@@ -472,32 +472,34 @@ def test_add_lhs_is_none_annotate():
 def test_add_lhs_rhs_is_input_annotate():
     data_conv_r = relay.var("data_conv_r", shape=(1, 16, 64, 64))
     conv2d_r = relay.nn.conv2d(
-        data_conv_r, 
-        relay.const(np.random.random((16, 16, 3, 3))), 
-        padding=(1, 1), 
-        kernel_size=(3,3))
+        data_conv_r,
+        relay.const(np.random.random((16, 16, 3, 3))),
+        padding=(1, 1),
+        kernel_size=(3,3)
+    )
     data_conv_l = relay.var("data_conv_l", shape=(1, 16, 64, 64))
     conv2d_l = relay.nn.conv2d(
-        data_conv_l, 
-        relay.const(np.random.random((16, 16, 3, 3))), 
-        padding=(1, 1), 
-        kernel_size=(3,3))
+        data_conv_l,
+        relay.const(np.random.random((16, 16, 3, 3))),
+        padding=(1, 1),
+        kernel_size=(3,3)
+    )
     add = relay.add(conv2d_l, conv2d_r)
     global_avg_pool2d = relay.nn.global_avg_pool2d(add)
     mod = tvm.IRModule.from_expr(global_avg_pool2d)
-    
+
     calibrate_data = [
         {
-            "data_conv_l": np.random.random((1, 16, 64 ,64)),
-            "data_conv_r": np.random.random((1, 16, 64 ,64)),
-            "data_add": np.random.random((16, 1, 1))
+            "data_conv_l": np.random.random((1, 16, 64, 64)),
+            "data_conv_r": np.random.random((1, 16, 64, 64)),
+            "data_add": np.random.random((16, 1, 1)),
         }
     ]
 
     with tvm.transform.PassContext(opt_level=3):
         with relay.quantize.qconfig(calibrate_mode="kl_divergence", skip_conv_layers=None):
             qmod = relay.quantize.quantize(mod, dataset=calibrate_data)
-    
+
     params = [gen_rand_tvm(param.type_annotation, 0, 1) for param in mod["main"].params]
 
     def _eval_mod(mod):

--- a/tests/python/relay/test_pass_auto_quantize.py
+++ b/tests/python/relay/test_pass_auto_quantize.py
@@ -475,14 +475,14 @@ def test_add_lhs_rhs_is_input_annotate():
         data_conv_r,
         relay.const(np.random.random((16, 16, 3, 3))),
         padding=(1, 1),
-        kernel_size=(3,3)
+        kernel_size=(3, 3)
     )
     data_conv_l = relay.var("data_conv_l", shape=(1, 16, 64, 64))
     conv2d_l = relay.nn.conv2d(
         data_conv_l,
         relay.const(np.random.random((16, 16, 3, 3))),
         padding=(1, 1),
-        kernel_size=(3,3)
+        kernel_size=(3, 3)
     )
     add = relay.add(conv2d_l, conv2d_r)
     global_avg_pool2d = relay.nn.global_avg_pool2d(add)

--- a/tests/python/relay/test_pass_auto_quantize.py
+++ b/tests/python/relay/test_pass_auto_quantize.py
@@ -439,24 +439,23 @@ def test_dense_conv2d_rewrite():
 
     relay.analysis.post_order_visit(qnn_mod["main"], _check_dense)
 
+
 def test_add_lhs_is_none_annotate():
     data_conv = relay.var("data_conv", shape=(1, 16, 64, 64))
     conv2d_w = relay.const(np.random.random((16, 16, 3, 3)))
-    conv2d = relay.nn.conv2d(data_conv, conv2d_w, padding=(1, 1),kernel_size=(3,3))
+    conv2d = relay.nn.conv2d(data_conv, conv2d_w, padding=(1, 1), kernel_size=(3,3))
     data_add = relay.var("data_add", shape=(16, 1, 1))
     add = relay.add(data_add, conv2d)
     global_avg_pool2d = relay.nn.global_avg_pool2d(add)
     mod = tvm.IRModule.from_expr(global_avg_pool2d)
     
-    calibrate_data = [{"data_conv": np.random.random((1, 16, 64 ,64)),
-                       "data_add": np.random.random((16, 1, 1))}]
+    calibrate_data = [
+        {"data_conv": np.random.random((1, 16, 64 ,64)), "data_add": np.random.random((16, 1, 1))}
+    ]
 
     with tvm.transform.PassContext(opt_level=3):
-        with relay.quantize.qconfig(
-            calibrate_mode="kl_divergence", skip_conv_layers=None
-        ):
+        with relay.quantize.qconfig(calibrate_mode="kl_divergence", skip_conv_layers=None):
             qmod = relay.quantize.quantize(mod, dataset=calibrate_data)
-    print(qmod)
     
     params = [gen_rand_tvm(param.type_annotation, 0, 1) for param in mod["main"].params]
 
@@ -469,25 +468,35 @@ def test_add_lhs_is_none_annotate():
     qmod_result = _eval_mod(qmod)
     tvm.testing.assert_allclose(mod_result.numpy(), qmod_result.numpy(), rtol=1e-1, atol=1e-1)
 
+
 def test_add_lhs_rhs_is_input_annotate():
     data_conv_r = relay.var("data_conv_r", shape=(1, 16, 64, 64))
-    conv2d_r = relay.nn.conv2d(data_conv_r, relay.const(np.random.random((16, 16, 3, 3))), padding=(1, 1),kernel_size=(3,3))
+    conv2d_r = relay.nn.conv2d(
+        data_conv_r, 
+        relay.const(np.random.random((16, 16, 3, 3))), 
+        padding=(1, 1), 
+        kernel_size=(3,3))
     data_conv_l = relay.var("data_conv_l", shape=(1, 16, 64, 64))
-    conv2d_l = relay.nn.conv2d(data_conv_l, relay.const(np.random.random((16, 16, 3, 3))), padding=(1, 1),kernel_size=(3,3))
+    conv2d_l = relay.nn.conv2d(
+        data_conv_l, 
+        relay.const(np.random.random((16, 16, 3, 3))), 
+        padding=(1, 1), 
+        kernel_size=(3,3))
     add = relay.add(conv2d_l, conv2d_r)
     global_avg_pool2d = relay.nn.global_avg_pool2d(add)
     mod = tvm.IRModule.from_expr(global_avg_pool2d)
     
-    calibrate_data = [{"data_conv_l": np.random.random((1, 16, 64 ,64)),
-                       "data_conv_r": np.random.random((1, 16, 64 ,64)),
-                       "data_add": np.random.random((16, 1, 1))}]
+    calibrate_data = [
+        {
+            "data_conv_l": np.random.random((1, 16, 64 ,64)),
+            "data_conv_r": np.random.random((1, 16, 64 ,64)),
+            "data_add": np.random.random((16, 1, 1))
+        }
+    ]
 
     with tvm.transform.PassContext(opt_level=3):
-        with relay.quantize.qconfig(
-            calibrate_mode="kl_divergence", skip_conv_layers=None
-        ):
+        with relay.quantize.qconfig(calibrate_mode="kl_divergence", skip_conv_layers=None):
             qmod = relay.quantize.quantize(mod, dataset=calibrate_data)
-    print(qmod)
     
     params = [gen_rand_tvm(param.type_annotation, 0, 1) for param in mod["main"].params]
 
@@ -499,6 +508,7 @@ def test_add_lhs_rhs_is_input_annotate():
     mod_result = _eval_mod(mod)
     qmod_result = _eval_mod(qmod)
     tvm.testing.assert_allclose(mod_result.numpy(), qmod_result.numpy(), rtol=1e-1, atol=1e-1)
+
 
 if __name__ == "__main__":
     test_mul_rewrite()
@@ -523,4 +533,3 @@ if __name__ == "__main__":
 
     test_add_lhs_is_none_annotate()
     test_add_lhs_rhs_is_input_annotate()
-

--- a/tests/python/relay/test_pass_auto_quantize.py
+++ b/tests/python/relay/test_pass_auto_quantize.py
@@ -475,14 +475,14 @@ def test_add_lhs_rhs_is_input_annotate():
         data_conv_r,
         relay.const(np.random.random((16, 16, 3, 3))),
         padding=(1, 1),
-        kernel_size=(3, 3)
+        kernel_size=(3, 3),
     )
     data_conv_l = relay.var("data_conv_l", shape=(1, 16, 64, 64))
     conv2d_l = relay.nn.conv2d(
         data_conv_l,
         relay.const(np.random.random((16, 16, 3, 3))),
         padding=(1, 1),
-        kernel_size=(3, 3)
+        kernel_size=(3, 3),
     )
     add = relay.add(conv2d_l, conv2d_r)
     global_avg_pool2d = relay.nn.global_avg_pool2d(add)


### PR DESCRIPTION
The type of add op`s output is activation, it should annotate by QAnnotateKind.ACTIVATION. If not, the graph will cast int32 into int8 directly without quantized, when quantize resnet. It will product overflow error, and it won`t prompt when infer the model. The resnet18_v1 test case is below.
before fixed
  %703 = add(%701, %702) /* ty=Tensor[(1, 512, 7, 7), int32] */;
  %704 = nn.relu(%703) /* ty=Tensor[(1, 512, 7, 7), int32] */;
  %705 = cast(%704, dtype="int8") /* ty=Tensor[(1, 512, 7, 7), int8] */;
  %706 = annotation.stop_fusion(%705) /* ty=Tensor[(1, 512, 7, 7), int8] */;
after fixed
  %443 = add(%441, %442) /* ty=Tensor[(1, 512, 7, 7), int32] */;
  %444 = nn.relu(%443) /* ty=Tensor[(1, 512, 7, 7), int32] */;
  %445 = cast(%444, dtype="int64") /* ty=Tensor[(1, 512, 7, 7), int64] */;
  %446 = fixed_point_multiply(%445, multiplier=1439683968, shift=-2) /* ty=Tensor[(1, 512, 7, 7), int64] */;
  %447 = clip(%446, a_min=-127f, a_max=127f) /* ty=Tensor[(1, 512, 7, 7), int64] */;
  %448 = cast(%447, dtype="int32") /* ty=Tensor[(1, 512, 7, 7), int32] */;
  %449 = cast(%448, dtype="int8") /* ty=Tensor[(1, 512, 7, 7), int8] */;
  %450 = annotation.stop_fusion(%449) /* ty=Tensor[(1, 512, 7, 7), int8] */;