### PR TITLE
Remove duplicate msg word and condition inside the function doc

### DIFF
--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -1314,7 +1314,7 @@ export class Instance implements Disposable {
   /**
    * Register an object constructor.
    * @param typeKey The name of the function.
-   * @param func function to be registered.
+   * @param func Function to be registered.
    * @param override Whether overwrite function in existing registry.
    */
   registerObjectConstructor(

--- a/web/src/support.ts
+++ b/web/src/support.ts
@@ -46,8 +46,8 @@ export function Uint8ArrayToString(arr: Uint8Array): string {
 
 /**
  * Internal assert helper
- * @param condition condition The condition to fail.
- * @param msg msg The message.
+ * @param condition The condition to fail.
+ * @param msg The message.
  */
 export function assert(condition: boolean, msg?: string): asserts condition {
   if (!condition) {


### PR DESCRIPTION
Hi Apache Team,

I'm thrilled to submit my third contribution to Apache! I've addressed the issue of duplicate word inside function comment in the code. Paying attention to such details is vital for code quality, and I'm committed to enhancing the project.

-- MAX