### PR TITLE
[Unity][DLight] Update GEMV Rule for Mali GPUs

### DIFF
--- a/python/tvm/dlight/gpu/gemv.py
+++ b/python/tvm/dlight/gpu/gemv.py
@@ -447,6 +447,12 @@ class GEMV(ScheduleRule):
                     TS, TR = 4, 32
                 else:
                     TS, TR = 16, 32
+        elif target.kind.name == "opencl" and "mali" in str(target.attrs):
+            VEC_C = 8
+            LOAD_V_SHARED = False
+            LOAD_V_VEC = -1
+            UNROLL = 64
+            TS, TR = 1, 64
         else:
             VEC_C = 1
             LOAD_V_SHARED = False


### PR DESCRIPTION
this PR updates the GEMV rule for Mali GPUs, improving the performance: 

Llama-7B: 2.2 toks/s -> 2.8 toks/s
RedPajama-3B: 4.5 toks/s -> 5.0 toks/s