### PR TITLE
[MetaSchedule] Enable subprocess to stdout for DEBUG level

### DIFF
--- a/python/tvm/meta_schedule/runner/local_runner.py
+++ b/python/tvm/meta_schedule/runner/local_runner.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Local Runner"""
+import logging
 from contextlib import contextmanager
 from typing import Callable, List, Optional, Union
 import subprocess
@@ -273,12 +274,16 @@ class LocalRunner(PyRunner):
         self.f_run_evaluator = f_run_evaluator
         self.f_cleanup = f_cleanup
 
+        err_path = subprocess.DEVNULL
+        if logger.root.level <= logging.DEBUG:
+            err_path = subprocess.STDOUT
+
         logger.info("LocalRunner: max_workers = 1")
         self.pool = PopenPoolExecutor(
             max_workers=1,  # one local worker
             timeout=timeout_sec,
             initializer=initializer,
-            stderr=subprocess.DEVNULL,  # suppress the stderr output
+            stderr=err_path,  # suppress the stderr output
         )
         self._sanity_check()
 


### PR DESCRIPTION
Hi folks, 

Small enhancement for catching error messages from local runners.

---

As needed by #15522, it ease to spot, pin & debug things:

* Rise the logging level:
```
import logging
logging.basicConfig(level=logging.DEBUG)
{...}
```

* Captured message from runners:
```
2023-08-11 14:05:48 [INFO] [task_scheduler.cc:193] Sending 8 sample(s) to builder
2023-08-11 14:05:51 [INFO] [task_scheduler.cc:195] Sending 8 sample(s) to runner
/usr/bin/python3: symbol lookup error: /tmp/tmpqc99dte5/tvm_tmp_mod.tar.so: undefined symbol: VEC_MACC
/usr/bin/python3: symbol lookup error: /tmp/tmpqc99dte5/tvm_tmp_mod.tar.so: undefined symbol: VEC_MACC
{...}
```


Thanks,
~Cristian.