### PR TITLE
[Relay] Disable exception for ADT in mixed precision pass

### DIFF
--- a/src/relay/transforms/to_mixed_precision.cc
+++ b/src/relay/transforms/to_mixed_precision.cc
@@ -350,10 +350,11 @@ class MixedPrecisionPass : public MixedModeMutator {
 
     // TODO(AndrewZhaoLuo): Support ADTs
     // Relay's algebraic data types are not supported yet.
-    ICHECK(!cur_op.as<GlobalVarNode>()       // used to declare functions for recursion
-           && !cur_op.as<ConstructorNode>()  // constructing ADT types
-           && !cur_op.as<VarNode>())         // used for calling recursive functions
-        << "Algebraic Data Types (ADT) are not supported yet for mixed precision pass.";
+    bool isADT = (cur_op.as<GlobalVarNode>()       // used to declare functions for recursion
+                  || cur_op.as<ConstructorNode>()  // constructing ADT types
+                  || cur_op.as<LetNode>()          // used for binding lambdas
+                  || cur_op.as<VarNode>());        // used for calling recursive functions
+    if (isADT) return post;
 
     // Get info on the operation being called:
     // conversion category (int), accumulation dtype (str), output dtype (str)


### PR DESCRIPTION
If topology contains while loop and we want to transform it to mixed precision then we get an exception that "ADT are not supported for mixed precision pass". It happens, because while loop implemented as a lambda which is assigned to a VarNode.

In this commit I changed the behavior of ToMixedPrecision pass and instead of generating exception, it just do nothing.

Correspondent regression test is added.

cc: @AndrewZhaoLuo 