### PR TITLE
[CPP_RPC] export listdir for RPC

### DIFF
--- a/apps/cpp_rpc/rpc_env.cc
+++ b/apps/cpp_rpc/rpc_env.cc
@@ -73,6 +73,13 @@ namespace runtime {
 void CleanDir(const std::string& dirname);
 
 /*!
+ * \brief ListDir get the list of files in a directory
+ * \param dirname The root directory name
+ * \return vector Files in directory.
+ */
+std::vector<std::string> ListDir(const std::string& dirname);
+
+/*!
  * \brief buld a shared library if necessary
  *
  *        This function will automatically call
@@ -121,6 +128,15 @@ RPCEnv::RPCEnv(const std::string& wd) {
 
   TVM_REGISTER_GLOBAL("tvm.rpc.server.workpath").set_body([this](TVMArgs args, TVMRetValue* rv) {
     *rv = this->GetPath(args[0]);
+  });
+
+  TVM_REGISTER_GLOBAL("tvm.rpc.server.listdir").set_body([this](TVMArgs args, TVMRetValue* rv) {
+    std::string dir = this->GetPath(args[0]);
+    std::ostringstream os;
+    for (auto d : ListDir(dir)) {
+      os << d << ",";
+    }
+    *rv = os.str();
   });
 
   TVM_REGISTER_GLOBAL("tvm.rpc.server.load_module").set_body([this](TVMArgs args, TVMRetValue* rv) {

--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -145,6 +145,23 @@ class RPCSession(object):
             self._remote_funcs["remove"] = self.get_function("tvm.rpc.server.remove")
         self._remote_funcs["remove"](path)
 
+    def listdir(self, path):
+        """ls files from remote temp folder.
+
+        Parameters
+        ----------
+        path: str
+            The relative location to remote temp folder.
+
+        Returns
+        -------
+        dirs: str
+            The files in the given directory with split token ','.
+        """
+        if "listdir" not in self._remote_funcs:
+            self._remote_funcs["listdir"] = self.get_function("tvm.rpc.server.listdir")
+        return self._remote_funcs["listdir"](path)
+
     def load_module(self, path):
         """Load a remote module, the file need to be uploaded first.
 


### PR DESCRIPTION
This PR register `tvm.rpc.server.listdir` using `ListDir` and export it in python frontend for PRC use.