### PR TITLE
[Fix] Fix the typo in compile flag

### DIFF
--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -280,7 +280,7 @@ def _linux_compile(output, objects, options, compile_cmd, compile_shared=False):
             cmd += ["-c"]
     else:
         if compile_shared or output.endswith(".so") or output.endswith(".dylib"):
-            cmd += ["--shared"]
+            cmd += ["-shared"]
     cmd += ["-o", output]
     if isinstance(objects, str):
         cmd += [objects]


### PR DESCRIPTION
Fix the typo in function _linux_compile at the file apache/tvm/blob/main/python/tvm/contrib/cc.py. Change from `--shared` to `-shared`