### PR TITLE
[Runtime][Minor] Suppress verbose logging in Metal device API

### DIFF
--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -164,7 +164,7 @@ void MetalWorkspace::Init() {
   for (size_t i = 0; i < devs.count; ++i) {
     id<MTLDevice> d = [devs objectAtIndex:i];
     devices.push_back(d);
-    LOG(INFO) << "Intializing Metal device " << i << ", name=" << [d.name UTF8String];
+    DLOG(INFO) << "Intializing Metal device " << i << ", name=" << [d.name UTF8String];
     warp_size.push_back(GetWarpSize(d));
   }
 #endif


### PR DESCRIPTION
A minor fix to suppress verbose logging in Metal device API.

cc @tqchen 