### PR TITLE
[Unity][Relax][FuseOps] Add MatchCastNode to node_map of IndexedForwardGraph

### DIFF
--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -149,7 +149,11 @@ class GraphCreator : public ExprVisitor {
     // We skip ordinary binding blocks since they might be impure (with side effect or control flow)
   }
 
-  // TODO(tvm-team): how to deal with MatchCast binding here
+  void VisitBinding_(const MatchCastNode* binding) final {
+    IndexedForwardGraph::Node* node = CreateNode(binding->var.get());
+    SetNodePattern(node, OpPatternKind::kOpaque);
+    AddToPostDFSOrder(node, binding->var.get());
+  }
 
   void VisitBinding_(const VarBindingNode* binding) final {
     IndexedForwardGraph::Node* node = CreateNode(binding->var.get());

--- a/tests/python/relax/test_transform_fuse_ops.py
+++ b/tests/python/relax/test_transform_fuse_ops.py
@@ -1398,6 +1398,24 @@ def test_shape_expr_arg():
     _check(Before, Expected)
 
 
+def test_skipping_match_cast():
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor((10, 20), dtype="float32")) -> R.Tensor(dtype="float32", ndim=2):
+            m = T.int64()
+            n = T.int64()
+            with R.dataflow():
+                lv: R.Tensor((m, n), dtype="float32") = R.match_cast(
+                    A, R.Tensor((m, n), dtype="float32")
+                )
+                gv: R.Tensor((m, n), dtype="float32") = lv
+                R.output(gv)
+            return gv
+
+    _check(Module, Module)
+
+
 def test_skipping_primvalue():
     @I.ir_module
     class Module:


### PR DESCRIPTION

* The var of MatchCastNode can be used as the value of subsequent VarBinding

* CollectFuncBindings will traverse the binding(VarBindingNode, MatchCastNode) of DataflowBlockNode to find its group in the OperatorFusor stage