### PR TITLE
[Unity] Fix the ambiguity issue in `vDevice` constructor on Mac with Apple clang version 14.0.3

### DIFF
--- a/include/tvm/relax/struct_info.h
+++ b/include/tvm/relax/struct_info.h
@@ -221,7 +221,8 @@ class TensorStructInfo : public StructInfo {
    * \note shape must already be normalized.
    */
   TVM_DLL TensorStructInfo(Expr shape, DataType dtype,
-                           VDevice vdevice = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {}),
+                           VDevice vdevice = VDevice(/*tgt*/ {}, /*dev_id*/ 0,
+                                                     /*mem_scope*/ "global"),
                            Span span = Span());
 
   /*!
@@ -232,7 +233,8 @@ class TensorStructInfo : public StructInfo {
    * \param span The span of the AST.
    */
   TVM_DLL TensorStructInfo(DataType dtype, int ndim,
-                           VDevice vdevice = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {}),
+                           VDevice vdevice = VDevice(/*tgt*/ {}, /*dev_id*/ 0,
+                                                     /*mem_scope*/ "global"),
                            Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(TensorStructInfo, StructInfo, TensorStructInfoNode);

--- a/include/tvm/relax/struct_info.h
+++ b/include/tvm/relax/struct_info.h
@@ -220,7 +220,8 @@ class TensorStructInfo : public StructInfo {
    *
    * \note shape must already be normalized.
    */
-  TVM_DLL TensorStructInfo(Expr shape, DataType dtype, VDevice vdevice = VDevice(),
+  TVM_DLL TensorStructInfo(Expr shape, DataType dtype,
+                           VDevice vdevice = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {}),
                            Span span = Span());
 
   /*!
@@ -230,7 +231,8 @@ class TensorStructInfo : public StructInfo {
    * \param vdevice The virtual device.
    * \param span The span of the AST.
    */
-  TVM_DLL TensorStructInfo(DataType dtype, int ndim, VDevice vdevice = VDevice(),
+  TVM_DLL TensorStructInfo(DataType dtype, int ndim,
+                           VDevice vdevice = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {}),
                            Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(TensorStructInfo, StructInfo, TensorStructInfoNode);

--- a/python/tvm/relax/struct_info.py
+++ b/python/tvm/relax/struct_info.py
@@ -120,6 +120,8 @@ class TensorStructInfo(StructInfo):
     ) -> None:
         if isinstance(shape, (list, tuple, Array)):
             shape = ShapeExpr(shape)
+        if vdevice is None:
+            vdevice = VDevice(None, 0, "global")
         self.__init_handle_by_constructor__(
             _ffi_api.TensorStructInfo, shape, dtype, ndim, vdevice, span  # type: ignore
         )

--- a/src/ir/global_info.cc
+++ b/src/ir/global_info.cc
@@ -30,7 +30,7 @@ TVM_REGISTER_GLOBAL("ir.DummyGlobalInfo").set_body_typed([]() {
   return n;
 });
 
-VDevice::VDevice(Target tgt = {}, int dev_id = -1, MemoryScope mem_scope = {}) {
+VDevice::VDevice(Target tgt, int dev_id, MemoryScope mem_scope) {
   ObjectPtr<VDeviceNode> n = make_object<VDeviceNode>();
   n->target = std::move(tgt);
   n->vdevice_id = std::move(dev_id);

--- a/src/relax/analysis/struct_info_analysis.cc
+++ b/src/relax/analysis/struct_info_analysis.cc
@@ -149,7 +149,7 @@ class WellDefinedEraser : public StructInfoMutator,
       std::swap(has_undefined_, has_undefined);
     }
 
-    VDevice vdev = VDevice();
+    VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
     if (op->vdevice.defined()) {
       vdev = op->vdevice.value();
     }
@@ -772,7 +772,7 @@ class StructInfoLCAFinder
     // find the target dtype and ndim.
     DataType dtype = lhs->dtype == rhs->dtype ? lhs->dtype : DataType::Void();
     int ndim = lhs->ndim == rhs->ndim ? lhs->ndim : kUnknownNDim;
-    VDevice vdev = VDevice();
+    VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
     if (lhs->vdevice.defined() && rhs->vdevice.defined()) {
       if (lhs->vdevice.value().same_as(lhs->vdevice.value())) {
         vdev = lhs->vdevice.value();

--- a/src/relax/analysis/struct_info_analysis.cc
+++ b/src/relax/analysis/struct_info_analysis.cc
@@ -149,7 +149,7 @@ class WellDefinedEraser : public StructInfoMutator,
       std::swap(has_undefined_, has_undefined);
     }
 
-    VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
+    VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ 0, /*mem_scope*/ "global");
     if (op->vdevice.defined()) {
       vdev = op->vdevice.value();
     }
@@ -772,7 +772,7 @@ class StructInfoLCAFinder
     // find the target dtype and ndim.
     DataType dtype = lhs->dtype == rhs->dtype ? lhs->dtype : DataType::Void();
     int ndim = lhs->ndim == rhs->ndim ? lhs->ndim : kUnknownNDim;
-    VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
+    VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ 0, /*mem_scope*/ "global");
     if (lhs->vdevice.defined() && rhs->vdevice.defined()) {
       if (lhs->vdevice.value().same_as(lhs->vdevice.value())) {
         vdev = lhs->vdevice.value();

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -293,7 +293,7 @@ Constant::Constant(runtime::NDArray data, Optional<StructInfo> struct_info_annot
     n->checked_type_ = GetStaticType(struct_info_annotation.value());
   } else {
     TensorStructInfo tinfo(ShapeExpr(values), n->data.DataType(),
-                           VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {}), span);
+                           VDevice(/*tgt*/ {}, /*dev_id*/ 0, /*mem_scope*/ "global"), span);
     n->struct_info_ = tinfo;
     n->checked_type_ = DynTensorType(tinfo->ndim, tinfo->dtype);
   }

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -292,7 +292,8 @@ Constant::Constant(runtime::NDArray data, Optional<StructInfo> struct_info_annot
     n->struct_info_ = struct_info_annotation.value();
     n->checked_type_ = GetStaticType(struct_info_annotation.value());
   } else {
-    TensorStructInfo tinfo(ShapeExpr(values), n->data.DataType(), VDevice(), span);
+    TensorStructInfo tinfo(ShapeExpr(values), n->data.DataType(),
+                           VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {}), span);
     n->struct_info_ = tinfo;
     n->checked_type_ = DynTensorType(tinfo->ndim, tinfo->dtype);
   }

--- a/src/relax/ir/struct_info_functor.cc
+++ b/src/relax/ir/struct_info_functor.cc
@@ -94,7 +94,7 @@ StructInfo StructInfoMutator::VisitStructInfo_(const TensorStructInfoNode* op) {
     shape = this->VisitStructInfoExprField(op->shape.value());
   }
 
-  VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
+  VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ 0, /*mem_scope*/ "global");
   if (op->vdevice.defined()) {
     vdev = op->vdevice.value();
   }

--- a/src/relax/ir/struct_info_functor.cc
+++ b/src/relax/ir/struct_info_functor.cc
@@ -94,7 +94,7 @@ StructInfo StructInfoMutator::VisitStructInfo_(const TensorStructInfoNode* op) {
     shape = this->VisitStructInfoExprField(op->shape.value());
   }
 
-  VDevice vdev = VDevice();
+  VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
   if (op->vdevice.defined()) {
     vdev = op->vdevice.value();
   }

--- a/src/relax/transform/convert_layout.cc
+++ b/src/relax/transform/convert_layout.cc
@@ -267,7 +267,7 @@ class LayoutConvertMutator : public ExprMutator {
         new_shape.push_back(
             shape->values[from.LeafValue()->layout.IndexOf(to.LeafValue()->layout[i])]);
       }
-      VDevice vdev = VDevice();
+      VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
       if (tsinfo->vdevice.defined()) {
         vdev = tsinfo->vdevice.value();
       }

--- a/src/relax/transform/convert_layout.cc
+++ b/src/relax/transform/convert_layout.cc
@@ -267,7 +267,7 @@ class LayoutConvertMutator : public ExprMutator {
         new_shape.push_back(
             shape->values[from.LeafValue()->layout.IndexOf(to.LeafValue()->layout[i])]);
       }
-      VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
+      VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ 0, /*mem_scope*/ "global");
       if (tsinfo->vdevice.defined()) {
         vdev = tsinfo->vdevice.value();
       }

--- a/src/relax/transform/to_mixed_precision.cc
+++ b/src/relax/transform/to_mixed_precision.cc
@@ -289,7 +289,7 @@ class ToMixedPrecisionRewriter : public ExprMutator {
       if (fp16_input_names_.count(var->name_hint())) {
         auto sinfo = GetStructInfo(var);
         if (auto tensor_sinfo = sinfo.as<TensorStructInfoNode>()) {
-          VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
+          VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ 0, /*mem_scope*/ "global");
           if (tensor_sinfo->vdevice.defined()) {
             vdev = tensor_sinfo->vdevice.value();
           }

--- a/src/relax/transform/to_mixed_precision.cc
+++ b/src/relax/transform/to_mixed_precision.cc
@@ -289,7 +289,7 @@ class ToMixedPrecisionRewriter : public ExprMutator {
       if (fp16_input_names_.count(var->name_hint())) {
         auto sinfo = GetStructInfo(var);
         if (auto tensor_sinfo = sinfo.as<TensorStructInfoNode>()) {
-          VDevice vdev = VDevice();
+          VDevice vdev = VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
           if (tensor_sinfo->vdevice.defined()) {
             vdev = tensor_sinfo->vdevice.value();
           }

--- a/src/script/ir_builder/ir/ir.cc
+++ b/src/script/ir_builder/ir/ir.cc
@@ -136,7 +136,7 @@ VDevice LookupVDevice(String target_kind, int device_index) {
     }
   }
   LOG(WARNING) << "The annotated device was not found, please check your vdevice list.";
-  return VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
+  return VDevice(/*tgt*/ {}, /*dev_id*/ 0, /*mem_scope*/ "global");
 }
 
 TVM_REGISTER_GLOBAL("script.ir_builder.ir.IRModule").set_body_typed(IRModule);

--- a/src/script/ir_builder/ir/ir.cc
+++ b/src/script/ir_builder/ir/ir.cc
@@ -136,7 +136,7 @@ VDevice LookupVDevice(String target_kind, int device_index) {
     }
   }
   LOG(WARNING) << "The annotated device was not found, please check your vdevice list.";
-  return VDevice();
+  return VDevice(/*tgt*/ {}, /*dev_id*/ -1, /*mem_scope*/ {});
 }
 
 TVM_REGISTER_GLOBAL("script.ir_builder.ir.IRModule").set_body_typed(IRModule);

--- a/src/script/printer/relax/struct_info.cc
+++ b/src/script/printer/relax/struct_info.cc
@@ -111,7 +111,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
             kwargs_keys.push_back("ndim");
             kwargs_values.push_back(LiteralDoc::Int(n->ndim, n_p->Attr("ndim")));
           }
-          if (n->vdevice.defined()) {
+          if (n->vdevice.defined() && n->vdevice.value()->target.defined()) {
             kwargs_keys.push_back("vdevice");
             std::string dev_kind = n->vdevice.value()->target->kind->name;
             int dev_index = FindVDeviceIndexByTargetKind(n->vdevice.value(), d);


### PR DESCRIPTION
PR https://github.com/apache/tvm/pull/15447 introduces `vDevice` and currently, it causes compilation failure on my Mac with the following error:
```
sung@spark-mbp build % gcc --version                                          
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: x86_64-apple-darwin22.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```
```
/Users/sung/tvm/src/ir/global_info.cc:33:25: error: addition of default argument on redeclaration makes this constructor a default constructor
VDevice::VDevice(Target tgt = {}, int dev_id = -1, MemoryScope mem_scope = {}) {
                        ^   ~~~~
/Users/sung/tvm/include/tvm/ir/global_info.h:97:20: note: previous declaration is here
  TVM_DLL explicit VDevice(Target tgt, int dev_id, MemoryScope mem_scope);
                   ^
1 error generated.
make[2]: *** [CMakeFiles/tvm_objs.dir/src/ir/global_info.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/tvm_objs.dir/all] Error 2
```
This occurs due to the ambiguity with the default constructor defined within `TVM_DEFINE_OBJECT_REF_METHODS`. 
Therefore, this PR eliminates such ambiguity by explicitly calling the constructor. 
Since it requires explicit passing of the default arguments, I'd like to find a way to support previous usage (e.g., `VDevice()`) without the ambiguity. But I don't have good idea at the moment unfortunately. 
cc. @yongwww 