### PR TITLE
[Unity][ONNX] Improved symbolic handling and reshape functionality

### DIFF
--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -73,6 +73,9 @@ def test_reshape_infer_struct_info():
     )
     _check_inference(bb, relax.op.reshape(x0, (-1,)), relax.TensorStructInfo((120,), "float32"))
     _check_inference(
+        bb, relax.op.reshape(x0, relax.ShapeExpr([-1])), relax.TensorStructInfo((120,), "float32")
+    )
+    _check_inference(
         bb, relax.op.reshape(x1, (3, 8, 5)), relax.TensorStructInfo((3, 8, 5), "float32")
     )
     _check_inference(


### PR DESCRIPTION
While working on SDXL, I found that #15498 introduced a few issues. This PR adds better `PrimValue` handling through the onnx frontend to enable complicated shape computations. I also addressed an issue in `relax.op.reshape` that prevented special values like -1 from being passed via shape expression.