### PR TITLE
[Arith] Fix detect linear equation with uint var

### DIFF
--- a/src/arith/detect_linear_equation.cc
+++ b/src/arith/detect_linear_equation.cc
@@ -100,7 +100,8 @@ class LinearEqDetector : public ExprFunctor<LinearEqEntry(const PrimExpr&, const
   LinearEqEntry VisitExpr_(const VarNode* op, const PrimExpr& e) final {
     LinearEqEntry ret;
     if (op == var_.get()) {
-      ret.coeff = make_const(op->dtype, 1);
+      auto dtype = op->dtype;
+      ret.coeff = make_const(DataType::Int(dtype.bits(), dtype.lanes()), 1);
     } else {
       ret.base = e;
     }

--- a/tests/python/unittest/test_arith_detect_linear_equation.py
+++ b/tests/python/unittest/test_arith_detect_linear_equation.py
@@ -43,6 +43,10 @@ def test_basic():
     assert len(m) == 1
     tvm.testing.assert_prim_expr_equal(m[0], b * 7)
 
+    c = te.var("c", "uint32")
+    m = tvm.arith.detect_linear_equation(128 - c, [c])
+    assert m[0].value == -1
+
 
 def test_multivariate():
     v = [te.var("v%d" % i) for i in range(4)]


### PR DESCRIPTION
Hi, the following code encounters an error while executing
```
c = te.var("c", "uint32")
m = tvm.arith.detect_linear_equation(128 - c, [c])
```
It seems that when creating coefficients for var, it always uses var's dtype, which doesn't seem very reasonable. Even if var itself is uint, its coefficient is likely to be negative.




