### PR TITLE
[Unity][Transform] Track callees from external functions in DeadCodeElimination

### DIFF
--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -992,7 +992,7 @@ def DeadCodeElimination(entry_functions: Optional[List[str]] = None) -> tvm.ir.t
         The registered pass.
     """
     if entry_functions is None:
-        entry_functions = ["main"]
+        entry_functions = []
     return _ffi_api.DeadCodeElimination(entry_functions)  # type: ignore
 
 


### PR DESCRIPTION
Prior to this commit, the DeadCodeElimination pass avoided removing externally-exposed functions, only checked for callees from user-specified functions.  If an external function wasn't specified, the dead-code elimination could remove a callee resulting in a dangling `GlobalVar`.

This commit updates the dead code elimination to treat all externally-exposed functions as potential entry points. User-specified functions can still be provided, and are treated as additional entry points.