### PR TITLE
[Unity] Infer concatenated shape with multiplication where possible

### DIFF
--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -1201,6 +1201,7 @@ def test_concat_infer_struct_info_with_axis_shape_symbolic():
     c = tir.Var("c", "int64")
     x0 = relax.Var("x", R.Tensor((a0, b0, c), "float32"))
     x1 = relax.Var("x", R.Tensor((a1, b0, c), "float32"))
+    x2 = relax.Var("x", R.Tensor((a0, b0, c), "float32"))
     y = relax.Var("y", R.Tensor((a0, b1, c), "float32"))
     z = relax.Var("z", R.Tensor((a0, b2, c), "float32"))
 
@@ -1221,6 +1222,11 @@ def test_concat_infer_struct_info_with_axis_shape_symbolic():
         bb,
         relax.op.concat(relax.Tuple([x0, y, z]), axis=1),
         relax.TensorStructInfo((a0, b0 + b1 + b2, c), "float32"),
+    )
+    _check_inference(
+        bb,
+        relax.op.concat(relax.Tuple([x0, x2]), axis=1),
+        relax.TensorStructInfo((a0, b0 * 2, c), "float32"),
     )
 
 


### PR DESCRIPTION
Prior to this commit, the `relax.concat` operator determined the concatenated dimension by adding together the dimension across all concatenated values.  For shapes involving symbolic variables, this can produce less readable shapes in some cases.  For example, concatenating together four arrays, each of shape `[128 // factor]` would produce an output of `[128 // factor + 128 // factor + 128 // factor + 128 // factor]`.

This commit updates the shape inference of `relax.concat` to check for the common case of equal-sized tensors being concatenated.  In the example above, the shape would instead be inferred as `[(128 // factor) * 4]`.