### PR TITLE
[TVMScript] Use triple-quoted python strings for metadata

### DIFF
--- a/src/script/printer/utils.h
+++ b/src/script/printer/utils.h
@@ -80,10 +80,11 @@ inline std::string Docsify(const ObjectRef& obj, const IRDocsifier& d, const Fra
   std::ostringstream os;
   if (!d->metadata.empty()) {
     if (d->cfg->show_meta) {
-      os << "metadata = tvm.ir.load_json(\""
+      os << "metadata = tvm.ir.load_json(\"\"\""
          << support::StrEscape(
-                SaveJSON(Map<String, ObjectRef>(d->metadata.begin(), d->metadata.end())))
-         << "\")\n";
+                SaveJSON(Map<String, ObjectRef>(d->metadata.begin(), d->metadata.end())), false,
+                false)
+         << "\"\"\")\n";
     } else {
       f->stmts.push_back(
           CommentDoc("Metadata omitted. Use show_meta=True in script() method to show it."));

--- a/src/support/str_escape.h
+++ b/src/support/str_escape.h
@@ -33,44 +33,64 @@ namespace support {
 
 /*!
  * \brief Create a stream with escape.
+ *
  * \param data The data
+ *
  * \param size The size of the string.
+ *
  * \param use_octal_escape True to use octal escapes instead of hex. If producing C
  *      strings, use octal escapes to avoid ambiguously-long hex escapes.
+ *
+ * \param escape_whitespace_special_chars If True (default), escape
+ * any tab, newline, and carriage returns that occur in the string.
+ * If False, do not escape these characters.
+ *
  * \return the Result string.
  */
-inline std::string StrEscape(const char* data, size_t size, bool use_octal_escape = false) {
+inline std::string StrEscape(const char* data, size_t size, bool use_octal_escape = false,
+                             bool escape_whitespace_special_chars = true) {
   std::ostringstream stream;
   for (size_t i = 0; i < size; ++i) {
     unsigned char c = data[i];
     if (c >= ' ' && c <= '~' && c != '\\' && c != '"') {
       stream << c;
     } else {
-      stream << '\\';
       switch (c) {
         case '"':
-          stream << '"';
+          stream << '\\' << '"';
           break;
         case '\\':
-          stream << '\\';
+          stream << '\\' << '\\';
           break;
         case '\t':
-          stream << 't';
+          if (escape_whitespace_special_chars) {
+            stream << '\\' << 't';
+          } else {
+            stream << c;
+          }
           break;
         case '\r':
-          stream << 'r';
+          if (escape_whitespace_special_chars) {
+            stream << '\\' << 'r';
+          } else {
+            stream << c;
+          }
           break;
         case '\n':
-          stream << 'n';
+          if (escape_whitespace_special_chars) {
+            stream << '\\' << 'n';
+          } else {
+            stream << c;
+          }
           break;
         default:
           if (use_octal_escape) {
-            stream << static_cast<unsigned char>('0' + ((c >> 6) & 0x03))
+            stream << '\\' << static_cast<unsigned char>('0' + ((c >> 6) & 0x03))
                    << static_cast<unsigned char>('0' + ((c >> 3) & 0x07))
                    << static_cast<unsigned char>('0' + (c & 0x07));
           } else {
             const char* hex_digits = "0123456789ABCDEF";
-            stream << 'x' << hex_digits[c >> 4] << hex_digits[c & 0xf];
+            stream << '\\' << 'x' << hex_digits[c >> 4] << hex_digits[c & 0xf];
           }
       }
     }
@@ -80,11 +100,23 @@ inline std::string StrEscape(const char* data, size_t size, bool use_octal_escap
 
 /*!
  * \brief Create a stream with escape.
- * \param data The data
- * \param size The size of the string.
+ *
+ * \param val The C++ string
+ *
+ * \param use_octal_escape True to use octal escapes instead of hex. If producing C
+ *      strings, use octal escapes to avoid ambiguously-long hex escapes.
+ *
+ * \param escape_whitespace_special_chars If True (default), escape
+ * any tab, newline, and carriage returns that occur in the string.
+ * If False, do not escape these characters.  If producing python
+ * strings with """triple quotes""", do not escape these characters.
+ *
  * \return the Result string.
  */
-inline std::string StrEscape(const std::string& val) { return StrEscape(val.data(), val.length()); }
+inline std::string StrEscape(const std::string& val, bool use_octal_escape = false,
+                             bool escape_whitespace_special_chars = true) {
+  return StrEscape(val.data(), val.length(), use_octal_escape, escape_whitespace_special_chars);
+}
 
 }  // namespace support
 }  // namespace tvm


### PR DESCRIPTION
Prior to this commit, all metadata was output as a single-quoted python string with escaped newlines.  This single line could become extremely long, which can cause some text editors to run slowly (e.g. emacs).

This commit updates the TVMScript printer to instead output the metadata using a triple-quoted python string with embedded newlines. Because the metadata is a pretty-printed JSON string, it contains frequent newlines that prevent the line length from causing editor lag.