### PR TITLE
[MetaSchedule] Fix metaschedule flop estimation for non-integer loop dimensions

### DIFF
--- a/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
+++ b/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
@@ -122,22 +122,22 @@ def test_estimate_flops_with_decl_buffer():
 @T.prim_func
 def flops_with_nonint_extent(a: T.Buffer(16, "float32")):
     for i in range(4 + 4):
-        a[i] = a[i]
+        a[i] = 2*a[i]
 
 
 def test_flops_with_nonint_extent():
-    estimate_tir_flops(IRModule({"main": flops_with_nonint_extent}))
+    assert estimate_tir_flops(IRModule({"main": flops_with_nonint_extent}))==8
 
 
 @T.prim_func
 def flops_with_variable_extent(a: T.Buffer(16, "float32")):
     for i in range(4 + 4):
         for j in range(i + 8):
-            a[j] = a[i]
+            a[j] = 2*a[i]
 
 
 def test_flops_with_variable_extent():
-    estimate_tir_flops(IRModule({"main": flops_with_variable_extent}))
+    assert estimate_tir_flops(IRModule({"main": flops_with_variable_extent}))==120
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
+++ b/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
@@ -122,22 +122,22 @@ def test_estimate_flops_with_decl_buffer():
 @T.prim_func
 def flops_with_nonint_extent(a: T.Buffer(16, "float32")):
     for i in range(4 + 4):
-        a[i] = 2*a[i]
+        a[i] = 2 * a[i]
 
 
 def test_flops_with_nonint_extent():
-    assert estimate_tir_flops(IRModule({"main": flops_with_nonint_extent}))==8
+    assert estimate_tir_flops(IRModule({"main": flops_with_nonint_extent})) == 8
 
 
 @T.prim_func
 def flops_with_variable_extent(a: T.Buffer(16, "float32")):
     for i in range(4 + 4):
         for j in range(i + 8):
-            a[j] = 2*a[i]
+            a[j] = 2 * a[i]
 
 
 def test_flops_with_variable_extent():
-    assert estimate_tir_flops(IRModule({"main": flops_with_variable_extent}))==120
+    assert estimate_tir_flops(IRModule({"main": flops_with_variable_extent})) == 120
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
+++ b/tests/python/unittest/test_tir_analysis_estimate_tir_flops.py
@@ -91,7 +91,7 @@ def flops_override(A: T.Buffer(16, "float32")):
         A[0] = A[0] + 1
 
 
-def test_estimate_flops_forloop_as_experssion():
+def test_estimate_flops_forloop_as_expression():
     flops = estimate_tir_flops(
         IRModule({"main": flops_with_forloop_as_expression.with_attr("estimated_flops", 32)})
     )
@@ -100,11 +100,6 @@ def test_estimate_flops_forloop_as_experssion():
     # test whether the user estimated flop would over ride
     flops = estimate_tir_flops(IRModule({"main": flops_override}))
     assert flops == 32
-
-
-def test_exception():
-    with pytest.raises(tvm.TVMError):
-        flops = estimate_tir_flops(IRModule({"main": flops_with_forloop_as_expression}))
 
 
 def test_estimate_flops_with_decl_buffer():
@@ -122,6 +117,27 @@ def test_estimate_flops_with_decl_buffer():
     flops_with_decl_buffer = estimate_tir_flops(IRModule.from_expr(make_func(True)))
     flops_without_decl_buffer = estimate_tir_flops(IRModule.from_expr(make_func(True)))
     assert flops_with_decl_buffer == flops_without_decl_buffer
+
+
+@T.prim_func
+def flops_with_nonint_extent(a: T.Buffer(16, "float32")):
+    for i in range(4 + 4):
+        a[i] = a[i]
+
+
+def test_flops_with_nonint_extent():
+    estimate_tir_flops(IRModule({"main": flops_with_nonint_extent}))
+
+
+@T.prim_func
+def flops_with_variable_extent(a: T.Buffer(16, "float32")):
+    for i in range(4 + 4):
+        for j in range(i + 8):
+            a[j] = a[i]
+
+
+def test_flops_with_variable_extent():
+    estimate_tir_flops(IRModule({"main": flops_with_variable_extent}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Estimates the loop range using arith::Analyzer, starting from the outermost loop.
Added appropriate test cases.
This is a code patch for fixing this issue: https://github.com/apache/tvm/issues/12139