### PR TITLE
Fix "to" duplicate word in python and C header file

### DIFF
--- a/python/tvm/relay/backend/contrib/ethosu/codegen.py
+++ b/python/tvm/relay/backend/contrib/ethosu/codegen.py
@@ -359,7 +359,7 @@ class LayoutOptimizer:
 
 
 class PadsWithMultipleConsumersReplicator(ExprMutator):
-    """A pass to to handle the situation when nn.pad operator has
+    """A pass to handle the situation when nn.pad operator has
     more than one qnn.conv2d consumer.
 
              pad

--- a/src/tir/schedule/analysis.h
+++ b/src/tir/schedule/analysis.h
@@ -73,7 +73,7 @@ const PrimFuncNode* GetRootPrimFunc(const IRModule& mod, const StmtNode* root_bl
 StmtSRef GetSRefTreeRoot(const StmtSRef& sref);
 
 /*!
- * \brief Given an arbitrary sref, bind the shape var info of the PrimFunc it belongs to to the
+ * \brief Given an arbitrary sref, bind the shape var info of the PrimFunc it belongs to the
  * given analyzer
  * \param state The schedule state
  * \param sref The given sref


### PR DESCRIPTION
Hi Apache Team,

I'm thrilled to submit my fourth contribution to Apache! I've addressed the issue of duplicate word 'to' inside the code. Paying attention to such details is vital for code quality, and I'm committed to enhancing the project.

-- MAX

