### PR TITLE
Remove duplicate load word inside .cc file

### DIFF
--- a/src/tir/schedule/primitive/layout_transformation.cc
+++ b/src/tir/schedule/primitive/layout_transformation.cc
@@ -1040,7 +1040,7 @@ class TransformationPaddingExpressionError : public ScheduleError {
 
   String FastErrorString() const final {
     std::ostringstream ss;
-    ss << "ScheduleError: Pad value may not contain load load from " << illegal_load_->buffer->name;
+    ss << "ScheduleError: Pad value may not contain load from " << illegal_load_->buffer->name;
     return ss.str();
   }
 


### PR DESCRIPTION
Hi Apache Team,

I'm thrilled to submit my fifth contribution to Apache! I've addressed the issue of duplicate word 'load' inside the error message. Paying attention to such details is vital for code quality, and I'm committed to enhancing the project.

-- MAX