### PR TITLE
Remove duplicate 'from' word inside python script

### DIFF
--- a/tests/python/unittest/test_tir_transform_merge_dynamic_shared_memory_allocations.py
+++ b/tests/python/unittest/test_tir_transform_merge_dynamic_shared_memory_allocations.py
@@ -330,7 +330,7 @@ def test_dyn_shared_more_dtype():
 class TestMatmul(tvm.testing.CompareBeforeAfter):
     """Shared allocations should be merged, preserving DeclBuffer if present
 
-    This test uses a matmul PrimFunc adapted from from
+    This test uses a matmul PrimFunc adapted from
     test_matmul_dyn_shared, using either `T.Buffer` (Allocate without
     DeclBuffer) or `T.decl_buffer` (Allocate followed by DeclBuffer)
     for the replaced allocations.


### PR DESCRIPTION
Hi Apache Team,

I'm thrilled to submit my sixth contribution to Apache! I've addressed the issue of duplicate word 'from' inside the python script. Paying attention to such details is vital for code quality, and I'm committed to enhancing the project.

-- MAX