### PR TITLE
[FFI] Propagate Python errors across FFI boundaries

### DIFF
--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -245,6 +245,13 @@ typedef void* TVMObjectHandle;
 TVM_DLL void TVMAPISetLastError(const char* msg);
 
 /*!
+ * \brief Used for implementing C API function.
+ *  Set last exception before return.
+ * \param py_object The python exception to be set
+ */
+TVM_DLL void TVMAPISetLastPythonError(void* py_object);
+
+/*!
  * \brief return str message of the last error
  *  all function in this file will return 0 when success
  *  and nonzero when an error occurred,

--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -99,8 +99,8 @@ TVM_DLL void EnvCheckSignals();
 
 /*! \brief A class that wraps a Python object and preserves its ownership.
 
- * This class is used to wrap a PyObject* from the Python API and preserve its ownership. 
- * Allows for the creation of strong references to Python objects, which prevent them from being 
+ * This class is used to wrap a PyObject* from the Python API and preserve its ownership.
+ * Allows for the creation of strong references to Python objects, which prevent them from being
  * garbage-collected as long as the wrapper object exists.
  */
 class WrappedPythonObject {

--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -97,7 +97,12 @@ namespace runtime {
  */
 TVM_DLL void EnvCheckSignals();
 
-/*! \brief Preserve a Python object while */
+/*! \brief A class that wraps a Python object and preserves its ownership.
+
+ * This class is used to wrap a PyObject* from the Python API and preserve its ownership. 
+ * Allows for the creation of strong references to Python objects, which prevent them from being 
+ * garbage-collected as long as the wrapper object exists.
+ */
 class WrappedPythonObject {
  public:
   /*! \brief Construct a wrapper that doesn't own anything */

--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -97,6 +97,46 @@ namespace runtime {
  */
 TVM_DLL void EnvCheckSignals();
 
+/*! \brief Preserve a Python object while */
+class WrappedPythonObject {
+ public:
+  /*! \brief Construct a wrapper that doesn't own anything */
+  explicit WrappedPythonObject() : python_obj_(nullptr) {}
+
+  /*! \brief Conversion constructor from nullptr */
+  explicit WrappedPythonObject(std::nullptr_t) : python_obj_(nullptr) {}
+
+  /*! \brief Take ownership of a python object
+   *
+   * A new strong reference is created for the underlying python
+   * object.
+   *
+   * \param python_obj A PyObject* from the Python.h API.  A new
+   * strong reference is created using Py_IncRef.
+   */
+  explicit WrappedPythonObject(void* python_obj);
+
+  /*! \brief Drop ownership of a python object
+   *
+   * Removes the strong reference held by the wrapper.
+   */
+  ~WrappedPythonObject();
+
+  WrappedPythonObject(WrappedPythonObject&&);
+  WrappedPythonObject& operator=(WrappedPythonObject&&);
+
+  WrappedPythonObject(const WrappedPythonObject&);
+  WrappedPythonObject& operator=(const WrappedPythonObject&);
+  WrappedPythonObject& operator=(std::nullptr_t);
+
+  operator bool() { return python_obj_; }
+
+  void* raw_pointer() { return python_obj_; }
+
+ private:
+  void* python_obj_ = nullptr;
+};
+
 /*! \brief Registry for global function */
 class Registry {
  public:

--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -101,7 +101,7 @@ TVM_DLL void EnvCheckSignals();
 class WrappedPythonObject {
  public:
   /*! \brief Construct a wrapper that doesn't own anything */
-  explicit WrappedPythonObject() : python_obj_(nullptr) {}
+  WrappedPythonObject() : python_obj_(nullptr) {}
 
   /*! \brief Conversion constructor from nullptr */
   explicit WrappedPythonObject(std::nullptr_t) : python_obj_(nullptr) {}

--- a/python/tvm/_ffi/_ctypes/packed_func.py
+++ b/python/tvm/_ffi/_ctypes/packed_func.py
@@ -22,7 +22,7 @@ import ctypes
 import traceback
 from numbers import Number, Integral
 
-from ..base import _LIB, get_last_ffi_error, py2cerror, check_call
+from ..base import _LIB, get_last_ffi_error, py2cerror, check_call, raise_last_ffi_error
 from ..base import c_str, string_types
 from ..runtime_ctypes import DataType, TVMByteArray, Device, ObjectRValueRef
 from . import ndarray as _nd
@@ -80,10 +80,16 @@ def convert_to_tvm_func(pyfunc):
         # pylint: disable=broad-except
         try:
             rv = local_pyfunc(*pyargs)
-        except Exception:
+        except Exception as err:
             msg = traceback.format_exc()
             msg = py2cerror(msg)
             _LIB.TVMAPISetLastError(c_str(msg))
+
+            propagate_python_errors = True
+            if propagate_python_errors:
+                err_obj = ctypes.py_object(err)
+                _LIB.TVMAPISetLastPythonError(err_obj)
+
             return -1
 
         if rv is not None:
@@ -94,7 +100,7 @@ def convert_to_tvm_func(pyfunc):
             if not isinstance(ret, TVMRetValueHandle):
                 ret = TVMRetValueHandle(ret)
             if _LIB.TVMCFuncSetReturn(ret, values, tcodes, ctypes.c_int(1)) != 0:
-                raise get_last_ffi_error()
+                raise_last_ffi_error()
             _ = temp_args
             _ = rv
         return 0
@@ -106,7 +112,7 @@ def convert_to_tvm_func(pyfunc):
     pyobj = ctypes.py_object(f)
     ctypes.pythonapi.Py_IncRef(pyobj)
     if _LIB.TVMFuncCreateFromCFunc(f, pyobj, TVM_FREE_PYOBJ, ctypes.byref(handle)) != 0:
-        raise get_last_ffi_error()
+        raise_last_ffi_error()
     return _make_packed_func(handle, False)
 
 
@@ -212,7 +218,7 @@ class PackedFuncBase(object):
     def __del__(self):
         if not self.is_global and _LIB is not None:
             if _LIB.TVMFuncFree(self.handle) != 0:
-                raise get_last_ffi_error()
+                raise_last_ffi_error()
 
     def __call__(self, *args):
         """Call the function with positional arguments
@@ -235,7 +241,7 @@ class PackedFuncBase(object):
             )
             != 0
         ):
-            raise get_last_ffi_error()
+            raise_last_ffi_error()
         _ = temp_args
         _ = args
         return RETURN_SWITCH[ret_tcode.value](ret_val)
@@ -258,7 +264,7 @@ def __init_handle_by_constructor__(fconstructor, args):
         )
         != 0
     ):
-        raise get_last_ffi_error()
+        raise_last_ffi_error()
     _ = temp_args
     _ = args
     assert ret_tcode.value == ArgTypeCode.OBJECT_HANDLE
@@ -333,3 +339,12 @@ def _set_class_object_generic(object_generic_class, func_convert_to_object):
     global _FUNC_CONVERT_TO_OBJECT
     _CLASS_OBJECT_GENERIC = object_generic_class
     _FUNC_CONVERT_TO_OBJECT = func_convert_to_object
+
+
+def _init_pythonapi_inc_def_ref():
+    register_func = _LIB.TVMBackendRegisterEnvCAPI
+    register_func(c_str("Py_IncRef"), ctypes.pythonapi.Py_IncRef)
+    register_func(c_str("Py_DecRef"), ctypes.pythonapi.Py_DecRef)
+
+
+_init_pythonapi_inc_def_ref()

--- a/python/tvm/_ffi/_ctypes/packed_func.py
+++ b/python/tvm/_ffi/_ctypes/packed_func.py
@@ -83,12 +83,7 @@ def convert_to_tvm_func(pyfunc):
         except Exception as err:
             msg = traceback.format_exc()
             msg = py2cerror(msg)
-            _LIB.TVMAPISetLastError(c_str(msg))
-
-            propagate_python_errors = True
-            if propagate_python_errors:
-                err_obj = ctypes.py_object(err)
-                _LIB.TVMAPISetLastPythonError(err_obj)
+            _LIB.TVMAPISetLastPythonError(ctypes.py_object(err))
 
             return -1
 

--- a/python/tvm/_ffi/_cython/base.pxi
+++ b/python/tvm/_ffi/_cython/base.pxi
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from ..base import get_last_ffi_error
+from ..base import raise_last_ffi_error
 from libcpp.vector cimport vector
 from cpython.version cimport PY_MAJOR_VERSION
 from cpython cimport pycapsule
@@ -113,6 +113,7 @@ ctypedef void (*TVMPackedCFuncFinalizer)(void* resource_handle)
 # We mark the possibly long running function as nogil below.
 cdef extern from "tvm/runtime/c_runtime_api.h":
     void TVMAPISetLastError(const char* msg)
+    void TVMAPISetLastPythonError(void* py_object) except +
     const char *TVMGetLastError()
     int TVMFuncGetGlobal(const char* name,
                          TVMPackedFuncHandle* out)
@@ -178,7 +179,7 @@ cdef inline int CHECK_CALL(int ret) except -2:
     if ret == -2:
         return -2
     if ret != 0:
-        raise get_last_ffi_error()
+        raise_last_ffi_error()
     return 0
 
 

--- a/python/tvm/_ffi/_cython/packed_func.pxi
+++ b/python/tvm/_ffi/_cython/packed_func.pxi
@@ -54,10 +54,12 @@ cdef int tvm_callback(TVMValue* args,
             pyargs.append(c_make_array(value.v_handle, True, False))
     try:
         rv = local_pyfunc(*pyargs)
-    except Exception:
+    except Exception as err:
         msg = traceback.format_exc()
         msg = py2cerror(msg)
         TVMAPISetLastError(c_str(msg))
+        TVMAPISetLastPythonError(<void*>err)
+
         return -1
     if rv is not None:
         if isinstance(rv, tuple):
@@ -368,3 +370,17 @@ def _set_class_object_generic(object_generic_class, func_convert_to_object):
     global _FUNC_CONVERT_TO_OBJECT
     _CLASS_OBJECT_GENERIC = object_generic_class
     _FUNC_CONVERT_TO_OBJECT = func_convert_to_object
+
+# Py_INCREF and Py_DECREF are C macros, not function objects.
+# Therefore, providing a wrapper function.
+cdef void _py_incref_wrapper(void* py_object):
+    Py_INCREF(<object>py_object)
+cdef void _py_decref_wrapper(void* py_object):
+    Py_DECREF(<object>py_object)
+
+def _init_pythonapi_inc_def_ref():
+    register_func = TVMBackendRegisterEnvCAPI
+    register_func(c_str("Py_IncRef"), <void*>_py_incref_wrapper)
+    register_func(c_str("Py_DecRef"), <void*>_py_decref_wrapper)
+
+_init_pythonapi_inc_def_ref()

--- a/python/tvm/_ffi/_cython/packed_func.pxi
+++ b/python/tvm/_ffi/_cython/packed_func.pxi
@@ -57,7 +57,6 @@ cdef int tvm_callback(TVMValue* args,
     except Exception as err:
         msg = traceback.format_exc()
         msg = py2cerror(msg)
-        TVMAPISetLastError(c_str(msg))
         TVMAPISetLastPythonError(<void*>err)
 
         return -1

--- a/python/tvm/_ffi/base.py
+++ b/python/tvm/_ffi/base.py
@@ -438,19 +438,20 @@ def raise_last_ffi_error():
     # up to the next FFI handoff.  To have the stacktrace also
     # include the C++ side, we need to adjust the __traceback__
     # before re-throwing.
-    backtrace = py_str(_LIB.TVMGetLastBacktrace())
-    frames = re.split(r"\n\W+\d+:\W+", backtrace)
-    frames = frames[1:]  # Skip "Stack trace: "
+    backtrace = _LIB.TVMGetLastBacktrace()
+    if backtrace:
+        frames = re.split(r"\n\W+\d+:\W+", py_str(backtrace))
+        frames = frames[1:]  # Skip "Stack trace: "
 
-    for frame in frames:
-        if " at " in frame:
-            func_name, frame = frame.split(" at ", 1)
-            filename, lineno = frame.rsplit(":", 1)
-            func_name = func_name.strip()
-            filename = filename.strip()
-            lineno = int(lineno.strip())
+        for frame in frames:
+            if " at " in frame:
+                func_name, frame = frame.split(" at ", 1)
+                filename, lineno = frame.rsplit(":", 1)
+                func_name = func_name.strip()
+                filename = filename.strip()
+                lineno = int(lineno.strip())
 
-            tb = _append_traceback_frame(tb, func_name, filename, lineno)
+                tb = _append_traceback_frame(tb, func_name, filename, lineno)
 
     # Remove stack frames that provide little benefit to
     # debugging.  These are only removed from the stack frames

--- a/python/tvm/_ffi/base.py
+++ b/python/tvm/_ffi/base.py
@@ -348,7 +348,9 @@ def _append_traceback_frame(tb, func_name, filepath, lineno):
     # debugger (e.g. pdb) that catches the exception will use the
     # filepath to show code snippets from that FFI file.
     code = compile(
-        "{}def dummy_func(): raise RuntimeError()".format("\n" * (lineno - 1)), filepath, "exec"
+        "{}def dummy_func(): raise NotImplementedError()".format("\n" * (lineno - 1)),
+        filepath,
+        "exec",
     )
 
     # Replacing the name by updating the bytecode allows the function
@@ -356,13 +358,14 @@ def _append_traceback_frame(tb, func_name, filepath, lineno):
     # syntax.  For example, "operator()".
     code = code.replace(co_consts=(code.co_consts[0].replace(co_name=func_name), func_name, None))
     namespace = {}
-    exec(code, namespace)
+    exec(code, namespace)  # pylint: disable=exec-used
     dummy_func = namespace["dummy_func"]
 
     # Execute the dummy function in order to generate a stack frame.
+    dummy_tb = None
     try:
         dummy_func()
-    except RuntimeError as err:
+    except NotImplementedError as err:
         dummy_tb = err.__traceback__
 
     # Insert the dummy function into the stack trace.

--- a/src/ir/transform.cc
+++ b/src/ir/transform.cc
@@ -182,44 +182,78 @@ Map<String, Map<String, String>> PassContext::ListConfigs() {
 
 PassContext PassContext::Create() { return PassContext(make_object<PassContextNode>()); }
 
+namespace {
+struct ClearOnError {
+  Array<instrument::PassInstrument>* instruments{nullptr};
+
+  ~ClearOnError() {
+    if (instruments) {
+      LOG(INFO) << "Pass instrumentation enter/exti failed.";
+      LOG(INFO) << "Disabling pass instrumentation.";
+      instruments->clear();
+    }
+  }
+};
+struct ExitContextOnError {
+  std::vector<instrument::PassInstrument> successes;
+
+  ~ExitContextOnError() {
+    for (auto it = successes.rbegin(); it != successes.rend(); it++) {
+      LOG(INFO) << (*it)->name << " exiting PassContext ...";
+      (*it)->ExitPassContext();
+      LOG(INFO) << (*it)->name << " exited PassContext.";
+    }
+  }
+};
+}  // namespace
+
 void PassContext::InstrumentEnterPassContext() {
   auto pass_ctx_node = this->operator->();
   if (pass_ctx_node->instruments.defined()) {
-    Array<instrument::PassInstrument> enter_successes;
-    try {
-      for (instrument::PassInstrument pi : pass_ctx_node->instruments) {
-        pi->EnterPassContext();
-        enter_successes.push_back(pi);
-      }
-    } catch (const Error& e) {
-      LOG(INFO) << "Pass instrumentation entering pass context failed.";
-      LOG(INFO) << "Disable pass instrumentation.";
-      pass_ctx_node->instruments.clear();
-
-      for (instrument::PassInstrument pi : enter_successes) {
-        LOG(INFO) << pi->name << " exiting PassContext ...";
-        pi->ExitPassContext();
-        LOG(INFO) << pi->name << " exited PassContext.";
-      }
-      enter_successes.clear();
-
-      throw e;
+    ClearOnError clear_context{&pass_ctx_node->instruments};
+    ExitContextOnError exit_context;
+    for (instrument::PassInstrument pi : pass_ctx_node->instruments) {
+      pi->EnterPassContext();
+      exit_context.successes.push_back(pi);
     }
+    exit_context.successes.clear();
+    clear_context.instruments = nullptr;
   }
 }
+
+namespace {
+
+struct ExitPassSuccesses {
+  ~ExitPassSuccesses() {
+    if (all_initialized) {
+      return;
+    }
+
+    LOG(INFO) << "Pass instrumentation entering pass context failed.";
+    LOG(INFO) << "Disable pass instrumentation.";
+    instruments->clear();
+
+    for (auto it = successes.rbegin(); it != successes.rend(); it++) {
+      LOG(INFO) << (*it)->name << " exiting PassContext ...";
+      (*it)->ExitPassContext();
+      LOG(INFO) << (*it)->name << " exited PassContext.";
+    }
+  }
+
+  bool all_initialized{false};
+  std::vector<instrument::PassInstrument> successes;
+  Array<instrument::PassInstrument>* instruments{nullptr};
+};
+}  // namespace
 
 void PassContext::InstrumentExitPassContext() {
   auto pass_ctx_node = this->operator->();
   if (pass_ctx_node->instruments.defined()) {
-    try {
-      for (instrument::PassInstrument pi : pass_ctx_node->instruments) {
-        pi->ExitPassContext();
-      }
-    } catch (const Error& e) {
-      LOG(INFO) << "Pass instrumentation exiting pass context failed.";
-      pass_ctx_node->instruments.clear();
-      throw e;
+    ClearOnError clear_context{&pass_ctx_node->instruments};
+    for (instrument::PassInstrument pi : pass_ctx_node->instruments) {
+      pi->ExitPassContext();
     }
+    clear_context.instruments = nullptr;
   }
 }
 

--- a/src/relay/analysis/type_solver.cc
+++ b/src/relay/analysis/type_solver.cc
@@ -639,8 +639,6 @@ bool TypeSolver::Solve() {
     } catch (const CompileError& err) {
       this->Emit(Diagnostic::Error(rnode->span) << err.what());
       rnode->resolved = false;
-    } catch (const Error& e) {
-      ICHECK(false) << e.what();
     }
 
     // Mark inqueue as false after the function call

--- a/src/runtime/c_runtime_api.cc
+++ b/src/runtime/c_runtime_api.cc
@@ -372,7 +372,7 @@ using namespace tvm::runtime;
 
 struct WrappedPythonError : Error {
   WrappedPythonError() : Error("") {}
-  WrappedPythonError(WrappedPythonObject obj)
+  explicit WrappedPythonError(WrappedPythonObject obj)
       : Error(""), obj(std::move(obj)), cpp_backtrace(tvm::runtime::Backtrace()) {}
 
   WrappedPythonObject obj;

--- a/src/support/ffi_testing.cc
+++ b/src/support/ffi_testing.cc
@@ -63,6 +63,18 @@ TVM_REGISTER_GLOBAL("testing.test_wrap_callback").set_body([](TVMArgs args, TVMR
   *ret = runtime::TypedPackedFunc<void()>([pf]() { pf(); });
 });
 
+TVM_REGISTER_GLOBAL("testing.test_wrap_callback_suppress_err")
+    .set_body([](TVMArgs args, TVMRetValue* ret) {
+      PackedFunc pf = args[0];
+      auto result = runtime::TypedPackedFunc<void()>([pf]() {
+        try {
+          pf();
+        } catch (std::exception& err) {
+        }
+      });
+      *ret = result;
+    });
+
 TVM_REGISTER_GLOBAL("testing.test_raise_error_callback")
     .set_body([](TVMArgs args, TVMRetValue* ret) {
       std::string msg = args[0];

--- a/tests/python/relay/test_pass_instrument.py
+++ b/tests/python/relay/test_pass_instrument.py
@@ -226,7 +226,7 @@ def test_enter_pass_ctx_exception():
             raise RuntimeError("Just a dummy error")
 
     pass_ctx = tvm.transform.PassContext(instruments=[PI("%1"), PIBroken("%2"), PI("%3")])
-    with pytest.raises(tvm.error.TVMError) as cm:
+    with pytest.raises(RuntimeError) as cm:
         with pass_ctx:
             pass
         assert "Just a dummy error" in str(cm.execption)
@@ -246,7 +246,7 @@ def test_enter_pass_ctx_exception_global():
             raise RuntimeError("Just a dummy error")
 
     cur_pass_ctx = tvm.transform.PassContext.current()
-    with pytest.raises(tvm.error.TVMError) as cm:
+    with pytest.raises(RuntimeError) as cm:
         cur_pass_ctx.override_instruments([PIBroken()])
         assert "Just a dummy error" in str(cm.exception)
     assert not cur_pass_ctx.instruments
@@ -273,7 +273,7 @@ def test_exit_pass_ctx_exception():
             raise RuntimeError("Just a dummy error")
 
     pass_ctx = tvm.transform.PassContext(instruments=[PI("%1"), PIBroken("%2"), PI("%3")])
-    with pytest.raises(tvm.error.TVMError) as cm:
+    with pytest.raises(RuntimeError) as cm:
         with pass_ctx:
             pass
         assert "Just a dummy error" in str(cm.exception)
@@ -293,7 +293,7 @@ def test_exit_pass_ctx_exception_global():
             raise RuntimeError("Just a dummy error")
 
     cur_pass_ctx = tvm.transform.PassContext.current()
-    with pytest.raises(tvm.error.TVMError) as cm:
+    with pytest.raises(RuntimeError) as cm:
         cur_pass_ctx.override_instruments([PIBroken()])
         cur_pass_ctx.override_instruments([PIBroken()])
         assert "Just a dummy error" in str(cm.exception)
@@ -328,7 +328,7 @@ def test_pass_exception():
         return mod
 
     mod = get_test_model()
-    with pytest.raises(tvm.error.TVMError) as cm:
+    with pytest.raises(RuntimeError) as cm:
         with tvm.transform.PassContext(instruments=[PI()]):
             mod = transform(mod)
         assert "Just a dummy error" in str(cm.exception)
@@ -373,7 +373,7 @@ def test_should_run_exception():
         return mod
 
     mod = get_test_model()
-    with pytest.raises(tvm.error.TVMError) as cm:
+    with pytest.raises(RuntimeError) as cm:
         with tvm.transform.PassContext(instruments=[PI("%1"), PI("%2")]):
             mod = transform(mod)
         assert "Just a dummy error" in str(cm.exception)
@@ -418,7 +418,7 @@ def test_run_before_exception():
         return mod
 
     mod = get_test_model()
-    with pytest.raises(tvm.error.TVMError) as cm:
+    with pytest.raises(RuntimeError) as cm:
         with tvm.transform.PassContext(instruments=[PI("%1"), PI("%2")]):
             mod = transform(mod)
         assert "Just a dummy error" in str(cm.exception)
@@ -467,7 +467,7 @@ def test_run_after_exception():
     x, y = [tvm.relay.var(c, shape=(3, 4), dtype="float32") for c in "xy"]
     mod = tvm.IRModule.from_expr(tvm.relay.add(x, y))
 
-    with pytest.raises(tvm.error.TVMError) as cm:
+    with pytest.raises(RuntimeError) as cm:
         with tvm.transform.PassContext(instruments=[PI("%1"), PI("%2")]):
             mod = transform(mod)
         assert "Just a dummy error" in str(cm.exception)

--- a/tests/python/relay/test_type_infer.py
+++ b/tests/python/relay/test_type_infer.py
@@ -541,7 +541,7 @@ def test_custom_op_rel_infer_exception():
     t2 = sb.let("t2", relay.add(t1, x))
     sb.ret(t2)
     f = relay.Function([x], sb.get())
-    with pytest.raises(tvm.error.TVMError) as cm:
+    with pytest.raises(AssertionError) as cm:
         fchecked = infer_expr(f)
         assert "type relation arg number mismatch" in str(cm.execption)
 

--- a/tests/python/unittest/test_meta_schedule_schedule_rule_apply_custom_rule.py
+++ b/tests/python/unittest/test_meta_schedule_schedule_rule_apply_custom_rule.py
@@ -59,7 +59,7 @@ def test_custom_rule():
                 max_trials_global=10,
                 space=space_gen,
             )
-    assert "ValueError: Intended for meta_schedule.cpu.test_apply_custom_rule" in str(e_info.value)
+    assert "Intended for meta_schedule.cpu.test_apply_custom_rule" in str(e_info.value)
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_runtime_error.py
+++ b/tests/python/unittest/test_runtime_error.py
@@ -105,7 +105,10 @@ def test_cpp_frames_in_stack_trace():
     cpp_frames = [
         frame for frame in frames if frame.filename.endswith(".cc") or frame.filename.endswith(".c")
     ]
-    assert len(cpp_frames) >= 1
+    assert len(cpp_frames) >= 1, (
+        f"Traceback through files '{[frame.filename for frame in frames]}'"
+        f" expected to contain C/C++ frames"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_runtime_error.py
+++ b/tests/python/unittest/test_runtime_error.py
@@ -102,7 +102,9 @@ def test_cpp_frames_in_stack_trace():
     except ValueError as err:
         frames = traceback.extract_tb(err.__traceback__)
 
-    cpp_frames = [frame for frame in frames if frame.filename.endswith(".cc")]
+    cpp_frames = [
+        frame for frame in frames if frame.filename.endswith(".cc") or frame.filename.endswith(".c")
+    ]
     assert len(cpp_frames) >= 1
 
 

--- a/tests/python/unittest/test_runtime_error.py
+++ b/tests/python/unittest/test_runtime_error.py
@@ -17,6 +17,7 @@
 """Test runtime error handling"""
 
 import functools
+import platform
 import subprocess
 import traceback
 
@@ -101,7 +102,10 @@ def _has_debug_symbols():
     return ".debug" in headers
 
 
-@pytest.mark.skipif(not _has_debug_symbols(), reason="C++ stack frames require debug symbols")
+@pytest.mark.skipif(
+    not _has_debug_symbols() or platform.machine != "x86_64",
+    reason="C++ stack frames require debug symbols, only implemented for x86",
+)
 def test_cpp_frames_in_stack_trace_from_python_error():
     """A python exception crossing C++ boundaries should have C++ stack frames"""
 
@@ -128,7 +132,10 @@ def test_cpp_frames_in_stack_trace_from_python_error():
         )
 
 
-@pytest.mark.skipif(not _has_debug_symbols(), reason="C++ stack frames require debug symbols")
+@pytest.mark.skipif(
+    not _has_debug_symbols() or platform.machine != "x86_64",
+    reason="C++ stack frames require debug symbols, only implemented for x86",
+)
 def test_stack_trace_from_cpp_error():
     """A python exception originating in C++ should have C++ stack frames"""
     try:

--- a/tests/python/unittest/test_runtime_error.py
+++ b/tests/python/unittest/test_runtime_error.py
@@ -90,5 +90,21 @@ def test_deep_callback():
     assert local_frames == ["test_deep_callback", "flevel3", "flevel2", "error_callback"]
 
 
+def test_cpp_frames_in_stack_trace():
+    def error_callback():
+        raise ValueError("callback error")
+
+    wrapped = tvm.testing.test_wrap_callback(error_callback)
+
+    try:
+        wrapped()
+        assert False
+    except ValueError as err:
+        frames = traceback.extract_tb(err.__traceback__)
+
+    cpp_frames = [frame for frame in frames if frame.filename.endswith(".cc")]
+    assert len(cpp_frames) >= 1
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/unittest/test_runtime_error.py
+++ b/tests/python/unittest/test_runtime_error.py
@@ -116,13 +116,16 @@ def test_cpp_frames_in_stack_trace_from_python_error():
     except ValueError as err:
         frames = traceback.extract_tb(err.__traceback__)
 
-    cpp_frames = [
-        frame for frame in frames if frame.filename.endswith(".cc") or frame.filename.endswith(".c")
-    ]
-    assert len(cpp_frames) >= 1, (
-        f"Traceback through files '{[frame.filename for frame in frames]}'"
-        f" expected to contain C/C++ frames"
-    )
+        cpp_frames = [
+            frame
+            for frame in frames
+            if frame.filename.endswith(".cc") or frame.filename.endswith(".c")
+        ]
+        assert len(cpp_frames) >= 1, (
+            f"Traceback through files '{[frame.filename for frame in frames]}'"
+            f" expected to contain C/C++ frames, "
+            f" but instead caught exception {err}"
+        )
 
 
 @pytest.mark.skipif(not _has_debug_symbols(), reason="C++ stack frames require debug symbols")
@@ -134,13 +137,16 @@ def test_stack_trace_from_cpp_error():
     except ValueError as err:
         frames = traceback.extract_tb(err.__traceback__)
 
-    cpp_frames = [
-        frame for frame in frames if frame.filename.endswith(".cc") or frame.filename.endswith(".c")
-    ]
-    assert len(cpp_frames) >= 1, (
-        f"Traceback through files '{[frame.filename for frame in frames]}'"
-        f" expected to contain C/C++ frames"
-    )
+        cpp_frames = [
+            frame
+            for frame in frames
+            if frame.filename.endswith(".cc") or frame.filename.endswith(".c")
+        ]
+        assert len(cpp_frames) >= 1, (
+            f"Traceback through files '{[frame.filename for frame in frames]}'"
+            f" expected to contain C/C++ frames, "
+            f" but instead caught exception {err}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prior to this commit, if a Python script passes a callback to a C++ function, and that callback raises an exception, the original exception cannot be caught in the outer python script.  As a result, interactive debugging, such as done with `pdb` or `ipdb`, could only inspect stack frames outside the first Python to C++ FFI call.

This commit updates the FFI API to propagate the Python exception through an FFI boundary.  As a result, all Python frames in the stack trace can be inspected.