### PR TITLE
[Unity][Frontend][NN] Add Timesteps layer to NN Module API

### DIFF
--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -375,7 +375,7 @@ struct DropoutAttrs : public tvm::AttrsNode<DropoutAttrs> {
   }
 };  // struct DropoutAttrs
 
-/*! \brief Attributes used in dropout operator */
+/*! \brief Attributes used in Attention operator */
 struct AttentionAttrs : public tvm::AttrsNode<AttentionAttrs> {
   Optional<FloatImm> scale;
   Optional<String> causal_mask;
@@ -387,6 +387,24 @@ struct AttentionAttrs : public tvm::AttrsNode<AttentionAttrs> {
         .describe("The type of the causal mask, i.e. 'TopLeft' and 'BottomRight'.");
   }
 };  // struct AttentionAttrs
+
+/*! \brief Attributes used for the padding operator */
+struct PadAttrs : public tvm::AttrsNode<PadAttrs> {
+  Array<Integer> pad_width;
+  tvm::String pad_mode;
+
+  TVM_DECLARE_ATTRS(PadAttrs, "relay.attrs.PadAttrs") {
+    TVM_ATTR_FIELD(pad_width).describe(
+        "Number of values padded to the edges of each axis, "
+        "in the format of (before_1, after_1, ..., before_N, after_N)");
+    TVM_ATTR_FIELD(pad_mode)
+        .set_default("constant")
+        .describe(
+            "Padding type to use. \"constant\" pads with constant_value, "
+            "\"edge\" pads using the edge values of the input array, "
+            "\"reflect\" pads by reflecting values with respect to the edges.");
+  }
+};
 
 }  // namespace relax
 }  // namespace tvm

--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -363,3 +363,17 @@ class Embedding(Module):
             ),
             shape=[*x.shape, self.dim],  # TODO(@junrushao): revisit and remove self.dim
         )
+
+
+class Timesteps(Module):
+    """
+    Module for HF timesteps layer.
+    """
+
+    def __init__(self, num_channels: int, flip_sin_to_cos: bool, downscale_freq_shift: float):
+        self.num_channels = num_channels
+        self.flip_sin_to_cos = flip_sin_to_cos
+        self.downscale_freq_shift = downscale_freq_shift
+
+    def forward(self, x: Tensor):
+        return

--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -370,10 +370,17 @@ class Timesteps(Module):
     Module for HF timesteps layer.
     """
 
-    def __init__(self, num_channels: int, flip_sin_to_cos: bool, downscale_freq_shift: float):
+    def __init__(
+        self, num_channels: int, flip_sin_to_cos: bool = False, downscale_freq_shift: float = 1
+    ):
         self.num_channels = num_channels
         self.flip_sin_to_cos = flip_sin_to_cos
         self.downscale_freq_shift = downscale_freq_shift
 
     def forward(self, x: Tensor):
-        return
+        return op.get_timestep_embedding(
+            x,
+            embedding_dim=self.num_channels,
+            flip_sin_to_cos=self.flip_sin_to_cos,
+            downscale_freq_shift=self.downscale_freq_shift,
+        )

--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -412,6 +412,21 @@ class TimestepEmbedding(Module):
             self.post_act = SiLU()
 
     def forward(self, sample: Tensor, condition: Optional[Tensor] = None):
+        """
+        Forward method for TimestepEmbedding layer.
+
+        Parameters
+        ----------
+        sample : Tensor
+            The input timestep that should be looked up.
+        condition : Optional[Tensor]
+            Optional additional projection matrix.
+
+        Returns
+        -------
+        ret : Tensor
+            The resulting embedding lookup for the input sample.
+        """
         if condition is not None:
             sample = sample + self.cond_proj(condition)
         sample = self.linear_1(sample)

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -738,9 +738,7 @@ def get_timestep_embedding(
     exponent = rx.const(-math.log(max_period), "float32") * _op.arange(
         start=0, end=half_dim, dtype="float32"
     )
-    exponent = exponent / (
-        rx.const(half_dim - downscale_freq_shift, "float32")
-    )
+    exponent = exponent / (rx.const(half_dim - downscale_freq_shift, "float32"))
 
     emb = _op.exp(exponent)
     emb = _op.expand_dims(timesteps, 1) * _op.expand_dims(emb, 0)

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -708,7 +708,7 @@ def get_timestep_embedding(
     name: str = "get_timestep_embedding",
 ) -> Tensor:
     """
-    This matches the implementation in Denoising Diffusion Probabilistic Models: Create sinusoidal timestep embeddings.
+    Timestep calculation as described in Denoising Diffusion Probabilistic Models.
 
     Parameters
     ----------

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=too-many-lines,invalid-name,protected-access
 """nn.Tensor operators."""
+import math
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from tvm import tir as _tir
@@ -662,12 +663,10 @@ def full(
     result : Tensor
         The result tensor.
     """
-    from tvm import relax  # pylint: disable=import-outside-toplevel
-
     if isinstance(fill_value, (_tir.FloatImm, _tir.IntImm)):
-        fill_value = relax.const(fill_value.value, dtype=dtype)
+        fill_value = rx.const(fill_value.value, dtype=dtype)
     elif isinstance(fill_value, (int, float)):
-        fill_value = relax.const(fill_value, dtype=dtype)
+        fill_value = rx.const(fill_value, dtype=dtype)
     else:
         fill_value = fill_value._expr
     return _wrap_nested(_op.full(shape, fill_value, dtype), name)
@@ -697,6 +696,69 @@ def zeros(
         The result tensor.
     """
     return _wrap_nested(_op.zeros(shape, dtype), name)
+
+
+def get_timestep_embedding(
+    x: Tensor,
+    embedding_dim: int,
+    flip_sin_to_cos: bool = False,
+    downscale_freq_shift: float = 1,
+    scale: float = 1,
+    max_period: int = 10000,
+    name: str = "get_timestep_embedding",
+) -> Tensor:
+    """
+    This matches the implementation in Denoising Diffusion Probabilistic Models: Create sinusoidal timestep embeddings.
+
+    Parameters
+    ----------
+    x : Tensor
+        A 1-D Tensor of N indices.
+    embedding_dim : int
+        The dimension of the output.
+    flip_sin_to_cos : bool
+        If True, change the order of sine and cosine embeddings.
+    downscale_freq_shift : float
+        Adjusts the frequency of the sinusoidal sampling.
+    scale : float
+        Weight adjustment for embedding magnitude.
+    max_period : int
+        Controls the minimum frequency of the embeddings.
+    name : str
+        The name to label this operator with.
+
+    Returns
+    -------
+    result : Tensor
+        [N x dim] Tensor of positional embeddings.
+    """
+    timesteps = _op.astype(x._expr, "float32")
+    # Timesteps input must be a 1-d array.
+    assert len(timesteps.struct_info.shape) == 1, "Timesteps must be a 1D array"
+
+    half_dim = embedding_dim // 2
+    exponent = rx.const(-math.log(max_period), "float32") * _op.arange(
+        start=0, end=half_dim, dtype="float32"
+    )
+    exponent = exponent / (
+        rx.const(half_dim, "float32") - rx.const(downscale_freq_shift, "float32")
+    )
+
+    emb = _op.exp(exponent)
+    emb = _op.expand_dims(timesteps, 1) * _op.expand_dims(emb, 0)
+    # Scale embeddings
+    emb = rx.const(scale, "float32") * emb
+
+    # Concat sine and cosine embeddings.
+    if flip_sin_to_cos:
+        emb = _op.concat([_op.cos(emb), _op.sin(emb)], dim=-1)
+    else:
+        emb = _op.concat([_op.sin(emb), _op.cos(emb)], dim=-1)
+
+    # Zero pad
+    if embedding_dim % 2 == 1:
+        emb = _op.nn.pad(emb, (0, 1, 0, 0))
+    return _wrap_nested(emb, name)
 
 
 def tensor_expr_op(

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -20,7 +20,7 @@ from typing import List, Optional, Tuple, Union
 from tvm import DataType
 from tvm.tir import FloatImm
 
-from ...expr import Expr
+from ...expr import Expr, const
 from . import _ffi_api
 
 
@@ -411,6 +411,35 @@ def conv2d_transpose(
         out_layout,
         out_dtype,
     )
+
+
+def pad(data, pad_width, pad_value=0, pad_mode="constant"):
+    r"""Padding
+
+    This operator takes in a tensor and pads each axis by the specified
+    widths using the specified value.
+
+    Parameters
+    ----------
+    data: relax.Expr
+        The input data to the operator
+    pad_width: tuple of <tuple of <int>>, required
+        Number of values padded to the edges of each axis, in the format
+        of ((before_1, after_1), ..., (before_N, after_N))
+    pad_value: float
+        The value used for padding
+    pad_mode: 'constant', 'edge', 'reflect'
+        'constant' pads with constant_value pad_value
+        'edge' pads using the edge values of the input array
+        'reflect' pads by reflecting values with respect to the edge
+    Returns
+    -------
+    result : relax.Expr
+        The computed result.
+    """
+    if not isinstance(pad_value, Expr):
+        pad_value = const(pad_value)
+    return _ffi_api.pad(data, pad_width, pad_value, pad_mode)
 
 
 def max_pool2d(

--- a/python/tvm/relax/transform/legalize_ops/nn.py
+++ b/python/tvm/relax/transform/legalize_ops/nn.py
@@ -184,6 +184,22 @@ def _nn_conv2d_transpose(bb: BlockBuilder, call: Call) -> Expr:
     )
 
 
+@register_legalize("relax.nn.pad")
+def _nn_pad(bb: BlockBuilder, call: Call) -> Expr:
+    # Unpack pad_width into two separate lists for topi.
+    pad_widths = call.attrs.pad_width
+    pad_before = pad_widths[::2]
+    pad_after = pad_widths[1::2]
+    return bb.call_te(
+        topi.nn.pad,
+        call.args[0],
+        pad_before=pad_before,
+        pad_after=pad_after,
+        pad_value=float(call.args[1].data.numpy()),
+        primfunc_name_hint="pad",
+    )
+
+
 @register_legalize("relax.nn.max_pool2d")
 def _nn_max_pool2d(bb: BlockBuilder, call: Call) -> Expr:
     if call.attrs.out_layout != call.attrs.layout:

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -141,7 +141,7 @@ StructInfo InferStructInfoPad(const Call& call, const BlockBuilder& ctx) {
   const auto* attrs = call->attrs.as<PadAttrs>();
   int ndim = input_sinfo[0]->ndim;
   Array<Integer> pad_width = attrs->pad_width;
-  ICHECK(((int) pad_width.size()) == 2 * ndim) << "Illegal pad_width";
+  ICHECK(((int)pad_width.size()) == 2 * ndim) << "Illegal pad_width";
 
   Array<PrimExpr> out_shape;
   if (input_sinfo[0]->shape.defined()) {
@@ -149,7 +149,7 @@ StructInfo InferStructInfoPad(const Call& call, const BlockBuilder& ctx) {
     const auto* data_shape = input_sinfo[0]->shape.as<ShapeExprNode>();
     for (int i = 0; i < ndim; i++) {
       // Sum pad width for this axis.
-      PrimExpr added_width = pad_width[2*i] + pad_width[(2*i) + 1];
+      PrimExpr added_width = pad_width[2 * i] + pad_width[(2 * i) + 1];
       const PrimExpr current_width = data_shape->values[i];
       out_shape.push_back(current_width + added_width);
     }

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -141,7 +141,7 @@ StructInfo InferStructInfoPad(const Call& call, const BlockBuilder& ctx) {
   const auto* attrs = call->attrs.as<PadAttrs>();
   int ndim = input_sinfo[0]->ndim;
   Array<Integer> pad_width = attrs->pad_width;
-  ICHECK(((int)pad_width.size()) == 2 * ndim) << "Illegal pad_width";
+  ICHECK(static_cast<int>(pad_width.size()) == 2 * ndim) << "Illegal pad_width";
 
   Array<PrimExpr> out_shape;
   if (input_sinfo[0]->shape.defined()) {

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -220,6 +220,45 @@ def test_create():
     tvm.ir.assert_structural_equal(irmodule["test"], test)
 
 
+def test_timestep_embedding():
+    class Model(Module):
+        def test(self, x: Tensor):
+            get_timestep_out = op.get_timestep_embedding(x, 10)
+            return get_timestep_out
+
+    @R.function
+    def test(
+        x: R.Tensor((3,), dtype="float32"), _io: R.Object
+    ) -> R.Tuple(R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Object)):
+        with R.dataflow():
+            lv1: R.Tensor((3,), dtype="float32") = R.astype(x, dtype="float32")
+            lv2: R.Tensor((3, 1), dtype="float32") = R.expand_dims(lv1, axis=[1])
+            lv3: R.Tensor((5,), dtype="float32") = R.arange(
+                R.prim_value(0), R.prim_value(5), R.prim_value(1), dtype="float32"
+            )
+            lv4: R.Tensor((5,), dtype="float32") = R.multiply(
+                R.const(-9.2103404998779297, "float32"), lv3
+            )
+            lv5: R.Tensor((5,), dtype="float32") = R.divide(lv4, R.const(4, "float32"))
+            lv6: R.Tensor((5,), dtype="float32") = R.exp(lv5)
+            lv7: R.Tensor((1, 5), dtype="float32") = R.expand_dims(lv6, axis=[0])
+            lv8: R.Tensor((3, 5), dtype="float32") = R.multiply(lv2, lv7)
+            lv9: R.Tensor((3, 5), dtype="float32") = R.sin(lv8)
+            lv10: R.Tensor((3, 5), dtype="float32") = R.cos(lv8)
+            get_timestep_embedding: R.Tensor((3, 10), dtype="float32") = R.concat(
+                (lv9, lv10), axis=-1
+            )
+            gv1: R.Tuple(
+                R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Object)
+            ) = get_timestep_embedding, (_io,)
+            R.output(gv1)
+        return gv1
+
+    m = Model()
+    irmodule, _ = m.export_tvm(spec={"test": {"x": spec.Tensor([3], "float32")}})
+    tvm.ir.assert_structural_equal(irmodule["test"], test)
+
+
 def test_tensor_expr_op():
     class Model(Module):
         def test(self, x: Tensor):


### PR DESCRIPTION
This PR adds support for the huggingface diffusers `Timesteps` layer. This is useful when constructing stable diffusion like models. The definition of the layer required padding, so I also implemented `relax.op.nn.pad` using semantics as close to pytorch as possible.