### PR TITLE
[Unity][Frontend][NN] Op print_ 

### DIFF
--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -53,7 +53,15 @@ class IOEffect(Effect):
 
     def print_(self, tensor: Tensor) -> None:
         """Encloses the side effect of NDArray printing"""
-        raise NotImplementedError
+        self.effect = rx.BlockBuilder.current().emit(
+            rx.call_pure_packed(
+                rx.extern("effect.print"),
+                self.effect,
+                tensor._expr,  # pylint: disable=protected-access
+                sinfo_args=[rx.ObjectStructInfo()],
+            ),
+            name_hint=self.effect.name_hint,
+        )
 
 
 @register_func("effect.print")

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -25,6 +25,7 @@ from ... import op as _op
 from ...block_builder import BlockBuilder
 from ...struct_info import TensorStructInfo, TupleStructInfo
 from .core import Tensor
+from .spec import SpecBuilder
 
 IntExpr = Union[int, _tir.PrimExpr]
 
@@ -800,3 +801,7 @@ def tensor_expr_op(
         ),
         name=name_hint,
     )
+
+
+def print_(array: Tensor):
+    SpecBuilder.current().io_effect.print_(array)


### PR DESCRIPTION
This pr introduces `op.print_`, which prints runtime tensor value to the screen in one-line code.

Example:

```python
class Model(Module):
    def test(self, x: Tensor):
        z = op.add(x, x)
        op.print_(z) # In the runtime, the value of z would be printed to screen.
        return x
```

cc: @junrushao @cyx-6 @jwfromm 
