### PR TITLE
[Runtime] Expose ModuleGetFunction as PackedFunc

### DIFF
--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -194,6 +194,10 @@ TVM_REGISTER_GLOBAL("runtime.ModuleGetFormat").set_body_typed([](Module mod) {
 });
 
 TVM_REGISTER_GLOBAL("runtime.ModuleLoadFromFile").set_body_typed(Module::LoadFromFile);
+TVM_REGISTER_GLOBAL("runtime.ModuleGetFunction")
+    .set_body_typed([](Module mod, String name, bool query_imports) {
+      return mod->GetFunction(name, query_imports);
+    });
 
 TVM_REGISTER_GLOBAL("runtime.ModuleSaveToFile")
     .set_body_typed([](Module mod, String name, tvm::String fmt) { mod->SaveToFile(name, fmt); });


### PR DESCRIPTION
This PR exposes `Module.GetFunction` as a global PackedFunc. Previously, the only way to access this method is via TVM's C API, but the C++ PackedFunc API is missing. This PR patches this issue.