### PR TITLE
[Unity] Implement relax.Function.bind_params

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -180,7 +180,7 @@ TVM_DLL Pass EliminateCommonSubexpr(bool call_only = false);
  *
  * \return The Pass.
  */
-TVM_DLL Pass BindParams(String func_name, Map<String, runtime::NDArray> params);
+TVM_DLL Pass BindParams(String func_name, Map<ObjectRef, ObjectRef> params);
 
 /*!
  * \brief Bind symbolic vars to constant shape values.

--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -24,7 +24,9 @@
 #ifndef TVM_RELAX_UTILS_H_
 #define TVM_RELAX_UTILS_H_
 
+#include <tvm/arith/analyzer.h>
 #include <tvm/ir/module.h>
+#include <tvm/relax/expr.h>
 #include <tvm/runtime/logging.h>
 
 namespace tvm {
@@ -47,6 +49,26 @@ namespace relax {
  */
 TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds,
                   const tvm::Map<tir::Var, PrimExpr>& symbolic_var_map = {});
+
+/*!
+ * \brief Infer a binding map for symbolic variables
+ *
+ * If a set of relax variables are replaced within an expression, this
+ * may result in removal of the definition site of a symbolic
+ * variable.  This utility function determines the symbolic variable
+ * replacements that can be inferred based on the replaced relax
+ * variables, and can be used alongside the `Bind` utility function to
+ * replace both the relax variables and the implied symbolic
+ * variables.
+ *
+ * \param binds A map of relax variables to relax expressions
+ *
+ * \param analyzer The analyzer to use for simplifications
+ *
+ * \return A map of TIR variables to TIR expressions
+ */
+TVM_DLL tvm::Map<tir::Var, PrimExpr> InferSymbolicVarMap(
+    const tvm::Map<relax::Var, relax::Expr>& binds, arith::Analyzer* analyzer);
 
 /*!
  * \brief Check if the given StructInfo is for a boolean scalar (tensor of rank 0 with a boolean

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -657,6 +657,56 @@ class Function(BaseFunc, Scriptable):
 
         return _ffi_api.FunctionBindSymbolicVars(self, binding_map)  # type: ignore
 
+    def bind_params(
+        self,
+        binding_map: Mapping[
+            Union[str, Var],
+            Union[int, float, PrimExpr, tvm.runtime.NDArray, _np.ndarray, Expr],
+        ],
+    ) -> "Function":
+        """Return a new function with updated symbolic variable
+
+        Parameters
+        ----------
+        binding_map: Mapping[
+                Union[str, Var],
+                Union[int, float, PrimExpr, tvm.runtime.NDArray, _np.ndarray, Expr],
+            ]
+
+            The mapping of values to be replaced.
+
+            Keys may be either a `relax.Var` or a string name of the
+            Relax variable.  If the variables are referred to by name,
+            the name must uniquely identify a parameter in the
+            function.
+
+            Values must be a relax expression, or a value that is
+            convertible into a relax expression.  The value must be
+            compatible with the variable being replaced.
+
+        Returns
+        -------
+        func: Function
+
+            The updated function
+        """
+
+        def _normalize_value(value):
+            # Conversions that must occur prior to the FFI
+            # conversions.
+            if isinstance(value, int):
+                # Relax uses int64 for symbolic variables, but the FFI
+                # converts python integers into int32.
+                return tvm.tir.const(value, "int64")
+            elif isinstance(value, (_np.ndarray, tvm.nd.NDArray)):
+                return tvm.relax.const(value)
+            else:
+                return value
+
+        binding_map = {key: _normalize_value(value) for key, value in binding_map.items()}
+
+        return _ffi_api.FunctionBindParams(self, binding_map)  # type: ignore
+
 
 @tvm._ffi.register_object("relax.expr.ExternFunc")
 class ExternFunc(BaseFunc):

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -387,7 +387,7 @@ def AttachGlobalSymbol() -> tvm.ir.transform.Pass:
 
 def BindParams(
     func_name: str,
-    params: Dict[str, Union[tvm.runtime.NDArray, np.ndarray]],
+    params: Dict[Union[str, Var], Union[tvm.runtime.NDArray, np.ndarray]],
 ) -> tvm.ir.transform.Pass:
     """Bind params of function of the module to constant tensors.
 
@@ -397,8 +397,13 @@ def BindParams(
     func_name: str
         The function name to be bound
 
-    params : Dict[str, Union[tvm.runtime.NDArray, np.ndarray]]
-        The map from param name to constant tensors.
+    params : Dict[
+                Union[str,relax.Var],
+                Union[tvm.runtime.NDArray, np.ndarray],
+             ]
+
+        The map from parameter or parameter name name to constant
+        tensors.
 
     Returns
     -------

--- a/tests/python/relax/test_bind_params.py
+++ b/tests/python/relax/test_bind_params.py
@@ -1,0 +1,156 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import tvm
+import tvm.script
+import tvm.testing
+from tvm import relax, tir
+from tvm.script import relax as R
+
+import numpy as np
+import pytest
+
+param_specification = tvm.testing.parameter("by_string", "by_var")
+param_shape = tvm.testing.parameter("static_shape", "dynamic_shape", "ndim", "arbitrary")
+tensor_param_dtype = tvm.testing.parameter("float32", None)
+
+
+def test_bind_tensor_param(param_specification, param_shape, tensor_param_dtype):
+    if param_shape == "static_shape":
+        shape = [16]
+        ndim = -1
+    elif param_shape == "dynamic_shape":
+        shape = [tir.Var("N", "int64")]
+        ndim = -1
+    elif param_shape == "ndim":
+        shape = None
+        ndim = 1
+    elif param_shape == "arbitrary":
+        shape = None
+        ndim = -1
+    else:
+        raise ValueError(f"Unknown param_shape: {param_shape}")
+
+    @R.function
+    def before(A: R.Tensor(shape, ndim=ndim, dtype=tensor_param_dtype)):
+        R.func_attr({"global_symbol": "main"})
+        B: R.Tensor(shape=shape, ndim=ndim, dtype=tensor_param_dtype) = A
+        out = R.add(B, B)
+        return out
+
+    np_data = np.arange(16).astype("float32")
+    inlined_relax_const = relax.const(np_data)
+
+    @R.function
+    def expected() -> R.Tensor([16], "float32"):
+        R.func_attr({"global_symbol": "main"})
+        B = inlined_relax_const
+        out = R.add(B, B)
+        return out
+
+    if param_specification == "by_string":
+        var = "A"
+    elif param_specification == "by_var":
+        var = before.params[0]
+    else:
+        raise ValueError("Unknown param_specification: {param_specification}")
+
+    after = before.bind_params({var: np.arange(16).astype("float32")})
+
+    tvm.ir.assert_structural_equal(expected, after)
+
+
+def test_bind_shape_param(param_shape):
+    if param_shape == "static_shape":
+        shape = [16]
+        ndim = -1
+    elif param_shape == "dynamic_shape":
+        shape = [tir.Var("N", "int64")]
+        ndim = -1
+    elif param_shape == "ndim":
+        shape = None
+        ndim = 1
+    elif param_shape == "arbitrary":
+        shape = None
+        ndim = -1
+    else:
+        raise ValueError(f"Unknown param_shape: {param_shape}")
+
+    @R.function
+    def before(A: R.Shape(shape, ndim=ndim)):
+        R.func_attr({"global_symbol": "main"})
+        B: R.Shape(shape, ndim=ndim) = A
+        return B
+
+    @R.function
+    def expected() -> R.Shape([16]):
+        R.func_attr({"global_symbol": "main"})
+        B = R.ShapeExpr([16])
+        return B
+
+    after = before.bind_params({"A": relax.ShapeExpr([16])})
+
+    tvm.ir.assert_structural_equal(expected, after)
+
+
+prim_value_dtype = tvm.testing.parameter("int64", "int32", "float32")
+
+
+@pytest.mark.xfail(reason="Depends on relax.PrimValue holding a tir.PrimExpr, PR#15577")
+def test_bind_prim_value(prim_value_dtype):
+    @R.function
+    def before(A: R.Prim(value="N", dtype=prim_value_dtype)):
+        R.func_attr({"global_symbol": "main"})
+        B: R.Prim(value="N", dtype=prim_value_dtype) = A
+        return B
+
+    @R.function
+    def expected() -> R.Prim(value=16, dtype=prim_value_dtype):
+        R.func_attr({"global_symbol": "main"})
+        B = R.PrimValue(value=16, dtype=dtype)
+        return B
+
+    after = before.bind_params({"A": relax.PrimValue(tir.const(16, prim_value_dtype))})
+
+    tvm.ir.assert_structural_equal(expected, after)
+
+
+def test_error_on_unknown_var():
+    @R.function
+    def before(A: R.Tensor([16], dtype="float32")):
+        R.func_attr({"global_symbol": "main"})
+        return A
+
+    unknown_var = relax.Var("unknown_var")
+
+    with pytest.raises(tvm.TVMError):
+        before.bind_params({unknown_var: np.arange(16).astype("float32")})
+
+
+def test_error_on_unknown_var_name():
+    @R.function
+    def before(A: R.Tensor([16], dtype="float32")):
+        R.func_attr({"global_symbol": "main"})
+        return A
+
+    with pytest.raises(tvm.TVMError):
+        before.bind_params({"unknown_var_name": np.arange(16).astype("float32")})
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_relay_translator.py
+++ b/tests/python/relax/test_relay_translator.py
@@ -126,10 +126,14 @@ def test_verify_e2e_translation_gpu(layout, batch_size, image_shape):
 def verify_extracted_tasks(target_str, layout, batch_size, image_shape, module_equality):
     target = Target(target_str)
     relay_mod, params = get_resnet(batch_size, "float32", layout, image_shape)
+    # Parameters can be bound either as part of the `from_relay`
+    # conversion, or as part of the `extract_tasks` method.  However,
+    # they shouldn't be used in both locations, because
+    # `relax.BindParams` validates that there exists an unbound
+    # parameter of the specified name.
     relax_mod = relay_translator.from_relay(
         relay_mod["main"],
         target,
-        params,
         pass_config={
             "relay.backend.use_meta_schedule": True,
             "relay.FuseOps.max_depth": 1,  # Disable relay fusion

--- a/tests/python/relax/test_transform_fold_constant.py
+++ b/tests/python/relax/test_transform_fold_constant.py
@@ -378,8 +378,7 @@ def test_fold_multiple_relax_ops_with_data_dependent_reshape():
     before = gen_mod(Module, "before", {"c0": c0_np, "c1": c1_np})
     assert relax.analysis.well_formed(before)
 
-    c2_np = np.multiply(np.add(c0_np, c0_np), c1_np)
-    expected = gen_mod(Module, "expected", {"c2": c2_np})
+    expected = gen_mod(Module, "expected", {})
 
     after = relax.transform.FoldConstant()(before)
     tvm.ir.assert_structural_equal(after, expected)


### PR DESCRIPTION
Similar to `relax.Function.bind_symbolic_vars`, implemented in https://github.com/apache/tvm/pull/15509, this commit introduces `relax.Function.bind_params` to allow Relax parameters to be manipulated on a per-function basis.  This utility function and the existing `BindParams` transform both use the same underlying implementation.