### PR TITLE
[Unity][Analysis] Improve handling of symbolic variables

### DIFF
--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -1856,6 +1856,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const AndNode* op) {
                      }),
                      cfalse, c2.Eval()->value > c1.Eval()->value);
 
+  TVM_TRY_REWRITE((x == c1) && (x == c2), (x == c1) && (c1 == c2));
   TVM_TRY_REWRITE(matches_one_of(x == c1 && x != c2, x != c2 && x == c1), x == c1 && c1 != c2);
 
   TVM_TRY_RECURSIVE_REWRITE(matches_one_of(floordiv(x, c2) == c1 && floormod(x, c2) == c3,
@@ -2000,6 +2001,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const OrNode* op) {
   TVM_TRY_REWRITE_IF(x <= c1 || c2 <= x, ctrue, c2.Eval()->value <= c1.Eval()->value + 1);
   TVM_TRY_REWRITE_IF(c2 <= x || x <= c1, ctrue, c2.Eval()->value <= c1.Eval()->value + 1);
 
+  TVM_TRY_REWRITE(x != c1 || x != c2, x != c1 || c1 != c2);
   TVM_TRY_REWRITE(x != c1 || x == c2, x != c1 || c1 == c2);
   TVM_TRY_REWRITE(x == c2 || x != c1, x != c1 || c1 == c2);
 

--- a/tests/python/relax/test_analysis_struct_info_analysis.py
+++ b/tests/python/relax/test_analysis_struct_info_analysis.py
@@ -343,6 +343,22 @@ def generate_base_check_test_cases():
     fopaque = rx.FuncStructInfo.opaque_func()
     yield (fopaque, fn_info_shape(1), BR.PASS)
 
+    # Symbolic var tests
+    static_shape = rx.ShapeStructInfo([1, 2, 4])
+    compatible_symbolic_shape = rx.ShapeStructInfo([1, n, n * n])
+    incompatible_symbolic_shape = rx.ShapeStructInfo([1, n, n + 1])
+
+    # Symbolic shapes may occur in multiple locations.  Incompatible
+    # shapes may fail at L0, even if each use of the symbolic variable
+    # would only have failed at L2.
+    yield (rx.ShapeStructInfo([n, n]), rx.ShapeStructInfo([16, 32]), BR.FAIL_L0)
+
+    # If `n==2`, then the shapes are compatible.
+    yield (compatible_symbolic_shape, static_shape, BR.FAIL_L2)
+
+    # There is no value of `n` for which `n==2 and n+1==4`
+    yield (incompatible_symbolic_shape, static_shape, BR.FAIL_L0)
+
 
 base_check_test_case = tvm.testing.parameter(*generate_base_check_test_cases())
 

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -951,6 +951,7 @@ class TestLogical(BaseCompare):
         TestCase(tvm.tir.And(x <= 1, 2 <= x), tvm.tir.const(False, "bool")),
         TestCase(tvm.tir.And(2 <= x, x <= 1), tvm.tir.const(False, "bool")),
         TestCase(tvm.tir.And(x == 1, x != 2), x == 1),
+        TestCase(tvm.tir.And(x == 1, x == 2), tvm.tir.const(False, "bool")),
         TestCase(tvm.tir.Or(tvm.tir.EQ(x, y), tvm.tir.NE(x, y)), tvm.tir.const(True, "bool")),
         TestCase(tvm.tir.Or(tvm.tir.NE(x, y), tvm.tir.EQ(x, y)), tvm.tir.const(True, "bool")),
         TestCase(tvm.tir.Or(x > y, tvm.tir.Not(x > y)), tvm.tir.const(True, "bool")),
@@ -965,6 +966,7 @@ class TestLogical(BaseCompare):
         TestCase(tvm.tir.Or(x <= 1, 2 <= x), tvm.tir.const(True, "bool")),
         TestCase(tvm.tir.Or(2 <= x, x <= 1), tvm.tir.const(True, "bool")),
         TestCase(tvm.tir.Or(x != 1, x == 2), x != 1),
+        TestCase(tvm.tir.Or(x != 1, x != 2), tvm.tir.const(True, "bool")),
         TestCase(
             tvm.tir.Or(x == 1, tvm.tir.Or(y == 1, z == 1)),
             tvm.tir.Or(tvm.tir.Or(x == 1, y == 1), z == 1),


### PR DESCRIPTION
Previously, the struct info analysis returned `kFailL2` (compatible, depending on runtime-inferred symbolic variables) based on each match expression considered in isolation.  This ignored cases such as matching a square tensor `[n,n]` against a static shape `[16,32]`.  While no one dimension is incompatible on its own, the match requires that `(n==16) && (n==32)`.  This this can be statically proven to be false, the `StructInfoBaseChecker` should return `kFailL0` (statically proven to be incompatible) instead.

This commit updates the `StructInfoBaseChecker` to track implied requirements for symbolic variables across multiple matched dimensions.