### PR TITLE
[BugFix][VTA] tvm.tir.Call has no name attribute

### DIFF
--- a/vta/python/vta/transform.py
+++ b/vta/python/vta/transform.py
@@ -988,7 +988,7 @@ def InjectALUIntrin():
                         rhs = loop_body.value.args[1]
                     else:
                         raise RuntimeError(
-                            "Function call not recognized %s" % (loop_body.value.name)
+                            "Function call not recognized %s" % (loop_body.value.op.name)
                         )
                 elif isinstance(loop_body.value, tvm.tir.BufferLoad):
                     alu_opcode = env.dev.ALU_OPCODE_SHR


### PR DESCRIPTION
tvm.tir.Call has no name attribute, this attribute belongs to op. 