### PR TITLE
[Runtime] Fix ICE from Clang

### DIFF
--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -1693,7 +1693,7 @@ inline TVMRetValue PackedFunc::operator()(Args&&... args) const {
   return rv;
 }
 
-template <int i, typename T>
+template <size_t i, typename T>
 struct TVMArgsSetterApply {
   static TVM_ALWAYS_INLINE void F(TVMArgsSetter* setter, T&& value) {
     (*setter)(i, std::forward<T>(value));


### PR DESCRIPTION
This PR fixes an error reporting from Clang on the line below:

```
/.../include/tvm/runtime/packed_func.h:1706:3: error: no matching function for call to 'F'
  detail::parameter_pack::EnumerateWithArg<Args...>::template F<TVMArgsSetterApply>(
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```