### PR TITLE
[Backport][Runtime] Fix ICE from Clang

### DIFF
--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -1693,7 +1693,7 @@ inline TVMRetValue PackedFunc::operator()(Args&&... args) const {
   return rv;
 }
 
-template <int i, typename T>
+template <size_t i, typename T>
 struct TVMArgsSetterApply {
   static TVM_ALWAYS_INLINE void F(TVMArgsSetter* setter, T&& value) {
     (*setter)(i, std::forward<T>(value));


### PR DESCRIPTION
Backported from #15635. This template is never instantiated on `apache:main` yet, but in case of future ICE, I backported the related fix from Unity branch.