### PR TITLE
Do not link LLVM libraries into cpptest binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,7 +713,23 @@ if(GTEST_FOUND)
   # include runtime files for unit testing
   target_link_libraries(cpptest PRIVATE ${TVM_TEST_LIBRARY_NAME} GTest::GTest GTest::Main GTest::gmock pthread dl)
   if(DEFINED LLVM_LIBS)
-    target_link_libraries(cpptest PRIVATE ${LLVM_LIBS})
+    # The TVM library is linked with LLVM libraries. If the LLVM libraries are
+    # static and the symbols are not hidden, then don't link them again into
+    # cpptest since cpptest is itself linked against the TVM library. If static
+    # LLVM libraries are linked in twice, it can cause issues with global
+    # variable initialization (cl::opt).
+    # If the LLVM libraries are dynamic, we have to link them again, since the
+    # TVM library will not contain any LLVM definitions.
+    unset(LLVM_SO)
+    foreach(L IN LISTS LLVM_LIBS)
+      if(L MATCHES "libLLVM.*\.so")
+        set(LLVM_SO TRUE)
+        break()
+      endif()
+    endforeach()
+    if(DEFINED LLVM_SO OR HIDE_PRIVATE_SYMBOLS)
+      target_link_libraries(cpptest PRIVATE ${LLVM_LIBS})
+    endif()
   endif()
   if(DEFINED ETHOSN_RUNTIME_LIBRARY)
     target_link_libraries(cpptest PRIVATE ${ETHOSN_RUNTIME_LIBRARY})


### PR DESCRIPTION
They are already linked into libtvm.so, and cpptests links against libtvm.so, so they are not needed again. On the other hand, linking them twice can lead to the following error:
```
CommandLine Error: Option 'print-summary-global-ids' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
```