### PR TITLE
[Unity][MSC][M0.4 && M0.5] Codegen && Test

### DIFF
--- a/python/tvm/contrib/msc/core/codegen/__init__.py
+++ b/python/tvm/contrib/msc/core/codegen/__init__.py
@@ -14,10 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""tvm.contrib.msc.core.utils"""
+"""tvm.contrib.msc.core.codegen"""
 
-from .expr import *
-from .info import *
-from .file import *
-from .namespace import *
-from .register import *
+from .codegen import *

--- a/python/tvm/contrib/msc/core/codegen/codegen.py
+++ b/python/tvm/contrib/msc/core/codegen/codegen.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.core.codegen.codegen"""
+
+from typing import Dict, List, Optional, Any, Callable
+from tvm.contrib.msc.core.ir import MSCGraph
+from tvm.contrib.msc.core import utils as msc_utils
+
+
+class CodeGen(object):
+    """Manager class to generate codes and load model
+
+    Parameters
+    ----------
+    graph: MSCGraph
+        The reference graph for codegen.
+    source_getter: Callable
+        The method to get sources.
+    codegen_config: dict<string, string>
+        The config to generate code.
+    print_config: dict<string, string>
+        The config to print code.
+    build_folder: MSCDirectory
+        The codegen folder.
+    """
+
+    def __init__(
+        self,
+        graph: MSCGraph,
+        source_getter: Callable[[MSCGraph, str, str], str],
+        codegen_config: Optional[Dict[str, str]] = None,
+        print_config: Optional[Dict[str, str]] = None,
+        build_folder: msc_utils.MSCDirectory = None,
+    ):
+        self._graph = graph
+        self._source_getter = source_getter
+        self._codegen_config = msc_utils.dump_dict(codegen_config)
+        self._print_config = msc_utils.dump_dict(print_config)
+        self._build_folder = build_folder or msc_utils.msc_dir(keep_history=False, cleanup=True)
+
+    def load(
+        self,
+        inputs: Optional[List[Any]] = None,
+        weights_binder: Optional[Callable[[MSCGraph, Any, msc_utils.MSCDirectory], Any]] = None,
+    ) -> Any:
+        """Generate source and load the model
+
+        Parameters
+        -------
+        inputs: list<any>
+            The inputs to build the model.
+        weights_binder: Callable
+            The method for binding weights to the model.
+
+        Returns
+        -------
+        obj: model object
+            The model object for the framework.
+        """
+
+        sources = self._source_getter(self._graph, self._codegen_config, self._print_config)
+        inputs = inputs or []
+        with self._build_folder as folder:
+            for name, source in sources.items():
+                folder.add_file(name, source)
+            builder = msc_utils.load_callable(self._graph.name + ".py:" + self._graph.name)
+            obj = builder(*inputs)
+            # load weights
+            if weights_binder:
+                obj = weights_binder(obj, folder)
+        return obj

--- a/python/tvm/contrib/msc/core/ir/graph.py
+++ b/python/tvm/contrib/msc/core/ir/graph.py
@@ -126,8 +126,8 @@ class MSCJoint(BaseJoint):
         The index of the node.
     name: string
         The name of the node.
-    master: string
-        The master of the node.
+    master_name: string
+        The master name of the node.
     optype: string
         The optype of the node.
     attrs: dict<string, string>
@@ -144,7 +144,7 @@ class MSCJoint(BaseJoint):
         self,
         index: int,
         name: str,
-        master: str,
+        master_name: str,
         optype: str,
         attrs: Dict[str, str],
         inputs: List[Tuple[BaseJoint, int]],
@@ -158,7 +158,7 @@ class MSCJoint(BaseJoint):
             _ffi_api.MSCJoint,
             index,
             name,
-            master,
+            master_name,
             optype,
             attrs,
             parents,
@@ -289,8 +289,8 @@ class WeightJoint(BaseJoint):
         The index of the node.
     name: string
         The name of the node.
-    master: string
-        The master of the node.
+    master_name: string
+        The master name of the node.
     optype: string
         The optype of the node.
     wtype: string
@@ -309,7 +309,7 @@ class WeightJoint(BaseJoint):
         self,
         index: int,
         name: str,
-        master: str,
+        master_name: str,
         optype: str,
         wtype: str,
         attrs: Dict[str, str],
@@ -322,7 +322,7 @@ class WeightJoint(BaseJoint):
             _ffi_api.WeightJoint,
             index,
             name,
-            master,
+            master_name,
             optype,
             wtype,
             attrs,

--- a/python/tvm/contrib/msc/core/ir/translate.py
+++ b/python/tvm/contrib/msc/core/ir/translate.py
@@ -124,7 +124,7 @@ def from_relay(
     Parameters
     ----------
     mod: IRModule
-        The IRModule of relax.
+        The IRModule of relay.
     params: dict of <string:tvm.ndarray>
         The parameters of the IRModule.
     trans_config: dict

--- a/python/tvm/contrib/msc/core/utils/file.py
+++ b/python/tvm/contrib/msc/core/utils/file.py
@@ -1,0 +1,159 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.core.utils.file"""
+
+import os
+import shutil
+import tempfile
+import types
+from typing import List
+from importlib.machinery import SourceFileLoader
+
+from .namespace import MSCFramework
+from .register import get_registered_func
+
+
+class MSCDirectory(object):
+    """Create a directory manager for MSC"""
+
+    def __init__(self, path: str = None, keep_history: bool = True, cleanup: bool = False):
+        self._path = os.path.abspath(path or tempfile.mkdtemp())
+        self._cleanup = cleanup
+        self._cwd = os.getcwd()
+        if os.path.isdir(self._path) and not keep_history:
+            shutil.rmtree(self._path)
+        if not os.path.isdir(self._path):
+            os.mkdir(self._path)
+
+    def __str__(self):
+        return "{}(Cleanup: {}): {} Files".format(self._path, self._cleanup, len(self.listdir()))
+
+    def __enter__(self):
+        os.chdir(self._path)
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        os.chdir(self._cwd)
+        self.clean_up()
+
+    def __del__(self):
+        self.clean_up()
+
+    def clean_up(self):
+        """Clean up the dir"""
+
+        if self._cleanup and os.path.isdir(self._path):
+            shutil.rmtree(self._path)
+
+    def add_file(self, name: str, contains: str):
+        """Add a file under the folder
+
+        Parameters
+        ----------
+        name: str
+            The name of the file.
+        contains: str
+            The contains of the file.
+
+        Returns
+        -------
+        path: str
+            The concatenated path.
+        """
+
+        with open(self.relpath(name), "w") as f:
+            f.write(contains)
+
+    def relpath(self, name: str) -> str:
+        """Relative path in dir
+
+        Parameters
+        ----------
+        name: str
+            The name of the file.
+
+        Returns
+        -------
+        path: str
+            The concatenated path.
+        """
+
+        return os.path.join(self._path, name)
+
+    def listdir(self) -> List[str]:
+        """List contents in the dir.
+
+        Returns
+        -------
+        names: list
+            The content of directory
+        """
+
+        return os.listdir(self._path)
+
+    @property
+    def path(self):
+        return self._path
+
+
+def msc_dir(path: str = None, keep_history: bool = True, cleanup: bool = False) -> MSCDirectory:
+    """Create MSCDirectory
+
+    Parameters
+    ----------
+    path: str
+        The path of the dir.
+    keep_history: bool
+        Whether to remove files before start.
+    cleanup: bool
+        Whether to clean up before exit.
+
+    Returns
+    -------
+    dir: MSCDirectory
+        The created dir.
+    """
+
+    return MSCDirectory(path, keep_history, cleanup)
+
+
+def load_callable(name: str, framework: str = MSCFramework.MSC) -> callable:
+    """Load a callable  object.
+
+    Parameters
+    ----------
+    name: string
+        The name of the registered func or path:f_name str.
+    framework: string
+        Should be from MSCFramework.
+
+    Returns
+    -------
+    func: callable
+        The function.
+    """
+
+    func = get_registered_func(name, framework)
+    if func:
+        return func
+    if ".py:" in name:
+        path, func_name = name.split(":")
+        loader = SourceFileLoader(path.replace(".py", ""), path)
+        mod = types.ModuleType(loader.name)
+        loader.exec_module(mod)
+        return getattr(mod, func_name)
+    raise Exception("Func {} is neighter registered nor path.py:name string")

--- a/python/tvm/contrib/msc/core/utils/namespace.py
+++ b/python/tvm/contrib/msc/core/utils/namespace.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.core.utils.namespace"""
+
+from typing import Any, Optional
+import copy
+
+
+class MSCMap:
+    """Global Namespace map for MSC"""
+
+    MAP = {}
+
+    @classmethod
+    def set(cls, key: str, value: Any):
+        cls.MAP[key] = value
+
+    @classmethod
+    def get(cls, key: str, default: Optional[Any] = None):
+        return cls.MAP.get(key, default)
+
+    @classmethod
+    def clone(cls, key: str, default: Optional[Any] = None):
+        return copy.deepcopy(cls.get(key, default))
+
+    @classmethod
+    def delete(cls, key: str):
+        if key in cls.MAP:
+            return cls.MAP.pop(key)
+        return None
+
+    @classmethod
+    def contains(cls, key: str):
+        return key in cls.MAP
+
+
+class MSCKey:
+    """Keys for the MSCMap"""
+
+    WORKSPACE = "workspace"
+    VERBOSE = "verbose"
+    REGISTERED_FUNCS = "registered_funcs"
+    REGISTERED_TOOLS = "registered_tools"
+
+
+class MSCFramework:
+    """Framework type for the MSC"""
+
+    MSC = "msc"
+    TVM = "tvm"
+    TORCH = "torch"

--- a/python/tvm/contrib/msc/core/utils/register.py
+++ b/python/tvm/contrib/msc/core/utils/register.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.core.utils.register"""
+
+from .namespace import MSCMap, MSCKey, MSCFramework
+
+
+def register_func(name: str, func: callable, framework: str = MSCFramework.MSC):
+    """Register a func for framework.
+
+    Parameters
+    ----------
+    name: string
+        The name for the func.
+    func: callable
+        The function to be registered.
+    framework: string
+        Should be from MSCFramework.
+    """
+
+    funcs = MSCMap.get(MSCKey.REGISTERED_FUNCS, {})
+    if framework not in funcs:
+        funcs[framework] = {}
+    funcs[framework][name] = func
+    MSCMap.set(MSCKey.REGISTERED_FUNCS, funcs)
+
+
+def get_registered_func(name: str, framework: str = MSCFramework.MSC):
+    """Get the registered func of framework.
+
+    Parameters
+    ----------
+    name: string
+        The name for the func.
+    framework: string
+        Should be from MSCFramework.
+
+    Returns
+    -------
+    func: callable
+        The registered function.
+    """
+
+    funcs = MSCMap.get(MSCKey.REGISTERED_FUNCS, {})
+    if framework not in funcs:
+        return None
+    return funcs[framework].get(name)

--- a/python/tvm/contrib/msc/framework/__init__.py
+++ b/python/tvm/contrib/msc/framework/__init__.py
@@ -14,10 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""tvm.contrib.msc.core.utils"""
-
-from .expr import *
-from .info import *
-from .file import *
-from .namespace import *
-from .register import *
+"""tvm.contrib.msc.framework"""

--- a/python/tvm/contrib/msc/framework/tvm/__init__.py
+++ b/python/tvm/contrib/msc/framework/tvm/__init__.py
@@ -14,10 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""tvm.contrib.msc.core.utils"""
-
-from .expr import *
-from .info import *
-from .file import *
-from .namespace import *
-from .register import *
+"""tvm.contrib.msc.framework.tvm"""

--- a/python/tvm/contrib/msc/framework/tvm/_ffi_api.py
+++ b/python/tvm/contrib/msc/framework/tvm/_ffi_api.py
@@ -14,10 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""tvm.contrib.msc.core.utils"""
+"""tvm.contrib.msc.core._ffi_api"""
 
-from .expr import *
-from .info import *
-from .file import *
-from .namespace import *
-from .register import *
+import tvm._ffi
+
+tvm._ffi._init_api("msc.framework.tvm", __name__)

--- a/python/tvm/contrib/msc/framework/tvm/codegen/__init__.py
+++ b/python/tvm/contrib/msc/framework/tvm/codegen/__init__.py
@@ -14,10 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""tvm.contrib.msc.core.utils"""
+"""tvm.contrib.msc.framework.tvm.codegen"""
 
-from .expr import *
-from .info import *
-from .file import *
-from .namespace import *
-from .register import *
+from .codegen import *

--- a/python/tvm/contrib/msc/framework/tvm/codegen/codegen.py
+++ b/python/tvm/contrib/msc/framework/tvm/codegen/codegen.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.framework.tvm.codegen.translate"""
+
+from typing import Dict, Optional
+
+import tvm
+from tvm.relax.transform import BindParams
+from tvm.contrib.msc.core.ir import MSCGraph
+from tvm.contrib.msc.core.codegen import CodeGen
+from tvm.contrib.msc.core import utils as msc_utils
+from tvm.contrib.msc.framework.tvm import _ffi_api
+
+
+def to_relax(
+    graph: MSCGraph,
+    weights: Optional[Dict[str, tvm.nd.array]] = None,
+    codegen_config: Optional[Dict[str, str]] = None,
+    print_config: Optional[Dict[str, str]] = None,
+    build_folder: msc_utils.MSCDirectory = None,
+) -> tvm.IRModule:
+    """Change MSCGraph to IRModule.
+
+    Parameters
+    ----------
+    graph: tvm.contrib.msc.core.ir.MSCGraph
+        The translated graph.
+    weights: dict of <string:tvm.ndarray>
+        The parameters of the IRModule.
+    codegen_config: dict
+        The config for codegen.
+    print_config: dict
+        The config for print.
+    build_folder: MSCDirectory
+        The folder for saving scripts and datas.
+
+    Returns
+    -------
+    mod: IRModule
+        The IRModule of relax.
+    """
+
+    inputs = [
+        tvm.relax.Var(i.alias, tvm.relax.TensorStructInfo(i.get_shape(), i.dtype_name))
+        for i in graph.get_inputs()
+    ]
+
+    def _bind_weights(mod: tvm.IRModule, folder: msc_utils.MSCDirectory) -> tvm.IRModule:
+        if weights:
+            mod = BindParams("main", weights)(mod)
+            with open(folder.relpath(graph.name + "_params.bin"), "wb") as f_params:
+                f_params.write(tvm.runtime.save_param_dict(weights))
+        return mod
+
+    codegen = CodeGen(graph, _ffi_api.GetRelaxSources, codegen_config, print_config, build_folder)
+    return codegen.load(inputs, _bind_weights)

--- a/src/contrib/msc/core/codegen/base_codegen.h
+++ b/src/contrib/msc/core/codegen/base_codegen.h
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/core/codegen/base_codegen.h
+ * \brief Basic CodeGen for MSCGraph and MSCJoint.
+ */
+#ifndef TVM_CONTRIB_MSC_CORE_CODEGEN_BASE_CODEGEN_H_
+#define TVM_CONTRIB_MSC_CORE_CODEGEN_BASE_CODEGEN_H_
+
+#include <dmlc/json.h>
+#include <tvm/script/printer/doc.h>
+
+#include <memory>
+#include <stack>
+#include <string>
+
+#include "../ir/graph.h"
+#include "code_stack.h"
+#include "codegen_utils.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+using namespace tvm::script::printer;
+
+/*!
+ * \brief CodeGen for MSCJoint op
+ */
+template <typename ConfigType>
+class BaseOpCode {
+ public:
+  /*!
+   * \brief The constructor of BaseOpCode
+   * \param func_name the function name for the node.
+   */
+  explicit BaseOpCode(const String& func_name) : func_name_(func_name) {}
+
+  virtual ~BaseOpCode() = default;
+
+  /*! \brief Config the BaseOpCode*/
+  void Config(const MSCJoint& node, const std::shared_ptr<ConfigType> config) {
+    node_ = node;
+    config_ = config;
+  }
+
+  /*! \brief Get return describe for default node*/
+  virtual const String IdxNode(bool as_raw = true) { return IdxNode(node_, as_raw); }
+
+  /*! \brief Get describe for default node input*/
+  virtual const String IdxInput(int idx = 0, bool as_raw = false) {
+    return IdxInput(node_, idx, as_raw);
+  }
+
+  /*! \brief Get describe for default node output*/
+  virtual const String IdxOutput(int idx = 0, bool as_raw = false) {
+    return IdxOutput(node_, idx, as_raw);
+  }
+
+  /*! \brief Get describe for default node weight*/
+  virtual const String IdxWeight(const String& wtype, bool as_raw = false) {
+    return IdxWeight(node_, wtype, as_raw);
+  }
+
+  /*! \brief Get comment for default node*/
+  virtual const String Comment() { return Comment(node_); }
+
+  /*! \brief Get func_name for the default node*/
+  const String func_name() { return func_name_; }
+
+  /*! \brief Get the default node*/
+  const MSCJoint node() { return node_; }
+
+  CODEGEN_MEMBERS;
+
+ private:
+  String func_name_;
+  MSCJoint node_;
+};
+
+/*!
+ * \brief CodeGen for MSCGraph
+ */
+template <typename ConfigType>
+class BaseCodeGen {
+ public:
+  /*!
+   * \brief The constructor of BaseCodeGen
+   * \param graph the graph to be generated.
+   * \param config the options for codegen.
+   */
+  explicit BaseCodeGen(const MSCGraph& graph, const std::string& config = "") {
+    graph_ = graph;
+    config_.reset(new ConfigType());
+    if (config.size() > 0) {
+      std::istringstream is(config);
+      dmlc::JSONReader reader(&is);
+      reader.Read(config_.get());
+    }
+    while (!scopes_.empty()) {
+      scopes_.pop();
+    }
+  }
+
+  virtual ~BaseCodeGen() = default;
+
+  /*! \brief Get sources*/
+  virtual const Map<String, String> GetSources(const std::string& print_options = "") = 0;
+
+  CODEGEN_MEMBERS;
+
+ protected:
+  /*!
+   * \brief Compare node scope with current scope
+   * 0 for same scope, 1 for increase scope, -1 for decrease scope
+   */
+  int CompareScope(const MSCJoint& node) {
+    if (node->scope.size() == 0) {
+      return 0;
+    }
+    if (scopes_.size() == 0) {
+      scopes_.push(node->scope);
+      return 1;
+    }
+    if (node->scope.size() == scopes_.top().size()) {
+      ICHECK(StringUtils::CompareArrays(node->scope, scopes_.top()))
+          << "Scope mismatch, node " << node->scope << " compare to current " << scopes_.top();
+      return 0;
+    } else if (node->scope.size() == scopes_.top().size() + 1) {
+      ICHECK(StringUtils::CompareArrays(node->scope, scopes_.top(), scopes_.top().size()))
+          << "Scope increase mismatch, node " << node->scope << " compare to current "
+          << scopes_.top();
+      scopes_.push(node->scope);
+      return 1;
+    } else if (node->scope.size() == scopes_.top().size() - 1) {
+      ICHECK(StringUtils::CompareArrays(node->scope, scopes_.top(), node->scope.size()))
+          << "Scope decrease mismatch, node " << node->scope << " compare to current "
+          << scopes_.top();
+      scopes_.pop();
+      return -1;
+    } else {
+      LOG(FATAL) << "Unexpected node scope " << node->scope << " with current scope "
+                 << scopes_.top();
+    }
+  }
+
+  /*! \brief Get the docs for the op*/
+  virtual const Array<Doc> GetOpCodes(const MSCJoint& node) = 0;
+
+  /*! \brief Get the graph*/
+  const MSCGraph graph() const { return graph_; }
+
+  /*! \brief Get the scopes*/
+  const std::stack<Array<String>> scopes() const { return scopes_; }
+
+  /*! \brief The stack of codes*/
+  CodeStack stack_;
+
+ private:
+  MSCGraph graph_;
+  std::stack<Array<String>> scopes_;
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_CORE_CODEGEN_BASE_CODEGEN_H_

--- a/src/contrib/msc/core/codegen/code_stack.cc
+++ b/src/contrib/msc/core/codegen/code_stack.cc
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/core/codegen/code_stack.cc
+ */
+
+#include "code_stack.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+const Array<Doc> BaseStack::GetDocs() const {
+  ICHECK(blocks_.size() == 1) << "Has incomplete blocks, please check";
+  return TopBlock();
+}
+
+void BaseStack::Line(const Doc& doc) { PushDoc(doc); }
+
+void BaseStack::Line(const String& line) { Line(IdDoc(line)); }
+
+void BaseStack::Comment(const String& comment) { PushDoc(CommentDoc(comment)); }
+
+void BaseStack::Assign(const String& lhs, const String& rhs, const String& annotation) {
+  if (annotation.size() == 0) {
+    PushDoc(AssignDoc(IdDoc(lhs), IdDoc(rhs), NullOpt));
+  } else {
+    PushDoc(AssignDoc(IdDoc(lhs), IdDoc(rhs), IdDoc(annotation)));
+  }
+}
+
+void BaseStack::AttrAccess(const String& attr) {
+  const auto& host = PopDoc();
+  if (host.as<AssignDoc>()) {
+    const auto& assign = Downcast<AssignDoc>(host);
+    ICHECK(assign->rhs.defined()) << "AttrAccess with assign missing rhs";
+    const auto& access = AttrAccessDoc(assign->rhs.value(), attr);
+    PushDoc(AssignDoc(assign->lhs, access, assign->annotation));
+  } else if (host.as<ExprDocNode>()) {
+    PushDoc(AttrAccessDoc(Downcast<ExprDoc>(host), attr));
+  } else {
+    LOG(FATAL) << "Unexpected attr access host " << host->GetTypeKey();
+  }
+}
+
+void BaseStack::FuncDef(const String& func_name, const String& ret_type) {
+  if (ret_type.size() > 0) {
+    PushDoc(FunctionDoc(IdDoc(func_name), Array<AssignDoc>(), Array<ExprDoc>(), IdDoc(ret_type),
+                        Array<StmtDoc>()));
+  } else {
+    PushDoc(FunctionDoc(IdDoc(func_name), Array<AssignDoc>(), Array<ExprDoc>(), NullOpt,
+                        Array<StmtDoc>()));
+  }
+}
+
+void BaseStack::FuncArg(const String& arg, const String& annotation, const String& value) {
+  const auto& func = PopCheckedDoc<FunctionDoc, FunctionDocNode>();
+  Optional<ExprDoc> value_doc;
+  if (value.size() > 0) {
+    value_doc = IdDoc(value);
+  } else {
+    value_doc = NullOpt;
+  }
+  Optional<ExprDoc> annotation_doc;
+  if (annotation.size() > 0) {
+    annotation_doc = IdDoc(annotation);
+  } else {
+    annotation_doc = NullOpt;
+  }
+  Array<AssignDoc> args = func->args;
+  args.push_back(AssignDoc(IdDoc(arg), value_doc, annotation_doc));
+  PushDoc(FunctionDoc(func->name, args, func->decorators, func->return_type, func->body));
+}
+
+void BaseStack::FuncDecorator(const String& decorator) {
+  const auto& func = PopCheckedDoc<FunctionDoc, FunctionDocNode>();
+  Array<ExprDoc> decorators = func->decorators;
+  decorators.push_back(IdDoc(decorator));
+  PushDoc(FunctionDoc(func->name, func->args, decorators, func->return_type, func->body));
+}
+
+void BaseStack::FuncStart() {
+  ICHECK(TopDoc()->IsInstance<FunctionDocNode>()) << "FunctionDoc is not saved";
+  BlockStart();
+}
+
+void BaseStack::FuncEnd(const String& ret_val) {
+  if (ret_val.size() > 0) {
+    PushDoc(ReturnDoc(IdDoc(ret_val)));
+  }
+  const auto& block = PopBlock();
+  const auto& func = PopCheckedDoc<FunctionDoc, FunctionDocNode>();
+  const auto& body = DocUtils::ToStmts(block);
+  PushDoc(FunctionDoc(func->name, func->args, func->decorators, func->return_type, body));
+}
+
+void BaseStack::CallStart(const String& callee) {
+  PushDoc(CallDoc(IdDoc(callee), Array<ExprDoc>(), Array<String>(), Array<ExprDoc>()));
+}
+
+void BaseStack::CallEnd(const String& assign) {
+  if (assign.size() > 0) {
+    const auto& last_call = PopCheckedDoc<CallDoc, CallDocNode>();
+    PushDoc(AssignDoc(IdDoc(assign), last_call, NullOpt));
+  }
+}
+
+void BaseStack::InplaceStart(const String& callee) {
+  const auto& host = PopDoc();
+  if (host.as<ExprDocNode>()) {
+    const auto& call = AttrAccessDoc(Downcast<ExprDoc>(host), callee);
+    PushDoc(CallDoc(call, Array<ExprDoc>(), Array<String>(), Array<ExprDoc>()));
+  } else if (const auto* a_node = host.as<AssignDocNode>()) {
+    ICHECK(a_node->rhs.defined()) << "Can not find rhs for inplace host";
+    const auto& assign = AssignDoc(a_node->lhs, IdDoc("msc::inplace"), a_node->annotation);
+    assign->comment = "msc::inplace";
+    PushDoc(assign);
+    const auto& call = AttrAccessDoc(a_node->rhs.value(), callee);
+    PushDoc(CallDoc(call, Array<ExprDoc>(), Array<String>(), Array<ExprDoc>()));
+  } else {
+    LOG(FATAL) << "Unexpected host type for inplace " << host->GetTypeKey();
+  }
+}
+
+void BaseStack::InplaceEnd() {
+  const auto& call = PopCheckedDoc<CallDoc, CallDocNode>();
+  if (HasDoc() && TopDoc()->IsInstance<AssignDocNode>() &&
+      Downcast<AssignDoc>(TopDoc())->comment == "msc::inplace") {
+    const auto& assign = PopCheckedDoc<AssignDoc, AssignDocNode>();
+    PushDoc(AssignDoc(assign->lhs, call, assign->annotation));
+  } else {
+    PushDoc(call);
+  }
+}
+
+void BaseStack::CallArgument(const ExprDoc& value, const String& key) {
+  const auto& call = PopCheckedDoc<CallDoc, CallDocNode>();
+  if (key.size() == 0) {
+    Array<ExprDoc> args = call->args;
+    args.push_back(value);
+    PushDoc(CallDoc(call->callee, args, call->kwargs_keys, call->kwargs_values));
+  } else {
+    Array<String> kwargs_keys = call->kwargs_keys;
+    Array<ExprDoc> kwargs_values = call->kwargs_values;
+    kwargs_keys.push_back(key);
+    kwargs_values.push_back(value);
+    PushDoc(CallDoc(call->callee, call->args, kwargs_keys, kwargs_values));
+  }
+}
+
+void BaseStack::CallStrArg(const String& value, const String& key) {
+  if (value.size() > 0) {
+    CallArgument(DocUtils::ToStrDoc(value), key);
+  }
+}
+
+void BaseStack::CallListArg(const Array<ExprDoc>& values, const String& key, bool allow_empty) {
+  if (values.size() > 0 || allow_empty) {
+    CallArgument(ListDoc(values), key);
+  }
+}
+
+void BaseStack::CallInplaceStart(const String& callee) { CallStart(callee); }
+
+void BaseStack::CallInplaceEnd(const String& key) {
+  const auto& inplace = PopCheckedDoc<CallDoc, CallDocNode>();
+  CallArgument(inplace, key);
+}
+
+void BaseStack::ConditionIf(const String& predicate) {
+  Array<StmtDoc> else_branch{ExprStmtDoc(IdDoc("pass"))};
+  PushDoc(IfDoc(IdDoc(predicate), Array<StmtDoc>(), else_branch));
+  BlockStart();
+}
+
+void BaseStack::ConditionElse() {
+  const auto& block = PopBlock();
+  const auto& if_doc = PopCheckedDoc<IfDoc, IfDocNode>();
+  PushDoc(IfDoc(if_doc->predicate, DocUtils::ToStmts(block), Array<StmtDoc>()));
+  BlockStart();
+}
+
+void BaseStack::ConditionEnd() {
+  const auto& block = PopBlock();
+  const auto& if_doc = PopCheckedDoc<IfDoc, IfDocNode>();
+  const auto& branch = DocUtils::ToStmts(block);
+  if (if_doc->then_branch.size() == 0) {
+    PushDoc(IfDoc(if_doc->predicate, branch, Array<StmtDoc>()));
+  } else {
+    PushDoc(IfDoc(if_doc->predicate, if_doc->then_branch, branch));
+  }
+}
+
+void BaseStack::BlockStart() {
+  Array<Doc> block;
+  blocks_.push(block);
+}
+
+void BaseStack::BlockEnd(bool block_docs) {
+  const auto& docs = PopBlock();
+  if (block_docs) {
+    PushDoc(DocUtils::ToStmtBlock(docs));
+  } else {
+    for (const auto& d : docs) {
+      PushDoc(d);
+    }
+  }
+}
+
+void BaseStack::ScopeStart(const String& scope_def, const String& scope_ref) {
+  if (scope_ref.size() > 0) {
+    PushDoc(ScopeDoc(IdDoc(scope_ref), IdDoc(scope_def), Array<StmtDoc>()));
+  } else {
+    PushDoc(ScopeDoc(NullOpt, IdDoc(scope_def), Array<StmtDoc>()));
+  }
+  BlockStart();
+}
+
+void BaseStack::ScopeEnd() {
+  const auto& block = PopBlock();
+  const auto& scope = PopCheckedDoc<ScopeDoc, ScopeDocNode>();
+  PushDoc(ScopeDoc(scope->lhs, scope->rhs, DocUtils::ToStmts(block)));
+}
+
+bool BaseStack::HasBlock() const { return blocks_.size() > 0; }
+
+const Array<Doc> BaseStack::TopBlock() const {
+  ICHECK(HasBlock()) << "No block found";
+  return blocks_.top();
+}
+
+const Array<Doc> BaseStack::PopBlock() {
+  const auto& block = TopBlock();
+  blocks_.pop();
+  return block;
+}
+
+bool BaseStack::HasDoc() {
+  if (!HasBlock()) {
+    return false;
+  }
+  return TopBlock().size() > 0;
+}
+
+const Doc BaseStack::TopDoc() {
+  ICHECK(HasDoc()) << "No doc or block found";
+  return TopBlock().back();
+}
+
+const Doc BaseStack::PopDoc() {
+  const auto& doc = TopDoc();
+  blocks_.top().pop_back();
+  return doc;
+}
+
+template <typename TDoc, typename TDocNode>
+const TDoc BaseStack::PopCheckedDoc() {
+  ICHECK(HasDoc() && TopDoc()->IsInstance<TDocNode>())
+      << "Last doc(" << TopDoc()->GetTypeKey() << ") is not expected type "
+      << TDocNode::TypeIndex2Key(TDocNode::RuntimeTypeIndex());
+  return Downcast<TDoc>(PopDoc());
+}
+
+void BaseStack::PushDoc(const Doc& doc) {
+  ICHECK(HasBlock()) << "No block found";
+  blocks_.top().push_back(doc);
+}
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/msc/core/codegen/code_stack.h
+++ b/src/contrib/msc/core/codegen/code_stack.h
@@ -1,0 +1,465 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/core/codegen/code_stack.h
+ * \brief CodeStack for doc printer.
+ */
+#ifndef TVM_CONTRIB_MSC_CORE_CODEGEN_CODE_STACK_H_
+#define TVM_CONTRIB_MSC_CORE_CODEGEN_CODE_STACK_H_
+
+#include <tvm/script/printer/doc.h>
+
+#include <stack>
+#include <string>
+#include <vector>
+
+#include "../printer/print_utils.h"
+#include "codegen_utils.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+using namespace tvm::script::printer;
+
+/*!
+ * \brief Inner class for doc stack
+ */
+class BaseStack {
+ public:
+  /*!
+   * \brief The constructor of CodeStack
+   */
+  BaseStack() { Reset(); }
+
+  /*! \brief Cleanup blocks*/
+  void Reset() {
+    while (!blocks_.empty()) {
+      blocks_.pop();
+    }
+    BlockStart();
+  }
+
+  /*! \brief Get the docs*/
+  const Array<Doc> GetDocs() const;
+
+ protected:
+  /*! \brief Push Id Doc*/
+  void Line(const Doc& doc);
+  void Line(const String& line = "");
+
+  /*! \brief Push Comment Doc*/
+  void Comment(const String& comment = "");
+
+  /*! \brief Push assign Doc*/
+  void Assign(const String& lhs, const String& rhs, const String& annotation = "");
+
+  /*! \brief Push assign for list Doc*/
+  template <typename T>
+  inline void AssignList(const String& lhs, const std::vector<T>& rhs,
+                         const String& annotation = "") {
+    if (annotation.size() == 0) {
+      PushDoc(AssignDoc(IdDoc(lhs), DocUtils::ToListDoc(rhs), NullOpt));
+    } else {
+      PushDoc(AssignDoc(IdDoc(lhs), DocUtils::ToListDoc(rhs), IdDoc(annotation)));
+    }
+  }
+
+  template <typename T>
+  inline void AssignList(const String& lhs, const Array<T>& rhs, const String& annotation = "") {
+    if (annotation.size() == 0) {
+      PushDoc(AssignDoc(IdDoc(lhs), DocUtils::ToListDoc(rhs), NullOpt));
+    } else {
+      PushDoc(AssignDoc(IdDoc(lhs), DocUtils::ToListDoc(rhs), IdDoc(annotation)));
+    }
+  }
+
+  /*! \brief Push attr access Doc*/
+  void AttrAccess(const String& attr);
+
+  /*! \brief Cache function Doc*/
+  void FuncDef(const String& func_name, const String& ret_type = "");
+
+  /*! \brief Cache func argument*/
+  void FuncArg(const String& arg, const String& annotation = "", const String& value = "");
+
+  /*! \brief Cache func decorator*/
+  void FuncDecorator(const String& decorator);
+
+  /*! \brief Start function body block*/
+  void FuncStart();
+
+  /*! \brief End function body block*/
+  void FuncEnd(const String& ret_val = "");
+
+  /*! \brief Cache call Doc*/
+  void CallStart(const String& callee);
+
+  /*! \brief Push call or/and assign Doc*/
+  void CallEnd(const String& assign = "");
+
+  /*! \brief Cache inplace call Doc*/
+  void InplaceStart(const String& callee);
+
+  /*! \brief Push inplace call or/and assign Doc*/
+  void InplaceEnd();
+
+  /*! \brief Cache call argument*/
+  void CallArgument(const ExprDoc& value, const String& key = "");
+
+  template <typename T>
+  inline void CallArg(T value, const String& key = "") {
+    CallArgument(DocUtils::ToDoc(value), key);
+  }
+
+  void CallStrArg(const String& value, const String& key = "");
+
+  /*! \brief Cache call list argument*/
+  void CallListArg(const Array<ExprDoc>& values, const String& key = "", bool allow_empty = false);
+
+  template <typename T>
+  inline void CallListArg(const std::vector<T>& values, const String& key = "",
+                          bool allow_empty = false) {
+    if (values.size() > 0 || allow_empty) {
+      CallArgument(DocUtils::ToListDoc(values), key);
+    }
+  }
+
+  template <typename T>
+  inline void CallListArg(const Array<T>& values, const String& key = "",
+                          bool allow_empty = false) {
+    if (values.size() > 0 || allow_empty) {
+      CallArgument(DocUtils::ToListDoc(values), key);
+    }
+  }
+
+  /*! \brief Cache call inplace func argument*/
+  void CallInplaceStart(const String& callee);
+
+  /*! \brief Push call inplace func argument*/
+  void CallInplaceEnd(const String& key = "");
+
+  /*! \brief Push if to cache and start if block*/
+  void ConditionIf(const String& predicate);
+
+  /*! \brief Push then branch to cached and start block*/
+  void ConditionElse();
+
+  /*! \brief Push else branch to cached*/
+  void ConditionEnd();
+
+  /*! \brief Start a new block*/
+  void BlockStart();
+
+  /*! \brief End a block*/
+  void BlockEnd(bool block_docs = true);
+
+  /*! \brief Start a new scope*/
+  void ScopeStart(const String& scope_def, const String& scope_ref = "");
+
+  /*! \brief End a scope*/
+  void ScopeEnd();
+
+ private:
+  /*! \brief Check if has block left*/
+  bool HasBlock() const;
+
+  /*! \brief Get the last the block*/
+  const Array<Doc> TopBlock() const;
+
+  /*! \brief Pop last the block*/
+  const Array<Doc> PopBlock();
+
+  /*! \brief Check if doc left*/
+  bool HasDoc();
+
+  /*! \brief Get the last doc*/
+  const Doc TopDoc();
+
+  /*! \brief Pop last doc*/
+  const Doc PopDoc();
+
+  /*! \brief Pop last doc with type checked*/
+  template <typename TDoc, typename TDocNode>
+  const TDoc PopCheckedDoc();
+
+  /*! \brief Push doc*/
+  void PushDoc(const Doc& doc);
+
+  /*! \brief The blocks, each has docs array*/
+  std::stack<Array<Doc>> blocks_;
+};
+
+#define COMMON_WRAPPERS(Stack)                                                                     \
+  Stack& line(const Doc& doc) {                                                                    \
+    Line(doc);                                                                                     \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& line(const String& line = "") {                                                           \
+    Line(line);                                                                                    \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& comment(const String& comment) {                                                          \
+    Comment(comment);                                                                              \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& assign(const String& lhs, const String& rhs, const String& annotation = "") {             \
+    Assign(lhs, rhs, annotation);                                                                  \
+    return *this;                                                                                  \
+  }                                                                                                \
+  template <typename T>                                                                            \
+  Stack& assign_list(const String& lhs, const std::vector<T>& rhs,                                 \
+                     const String& annotation = "") {                                              \
+    AssignList(lhs, rhs, annotation);                                                              \
+    return *this;                                                                                  \
+  }                                                                                                \
+  template <typename T>                                                                            \
+  Stack& assign_list(const String& lhs, const Array<T>& rhs, const String& annotation = "") {      \
+    AssignList(lhs, rhs, annotation);                                                              \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& attr_access(const String& attr) {                                                         \
+    AttrAccess(attr);                                                                              \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& block_start() {                                                                           \
+    BlockStart();                                                                                  \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& block_end(bool block_docs = true) {                                                       \
+    BlockEnd(block_docs);                                                                          \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& scope_start(const String& scope_def, const String& scope_ref = "") {                      \
+    ScopeStart(scope_def, scope_ref);                                                              \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& scope_end() {                                                                             \
+    ScopeEnd();                                                                                    \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& func_def(const String& func_name, const String& ret_type = "") {                          \
+    FuncDef(func_name, ret_type);                                                                  \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& func_arg(const String& arg, const String& annotation = "", const String& value = "") {    \
+    FuncArg(arg, annotation, value);                                                               \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& func_decorator(const String& decorator) {                                                 \
+    FuncDecorator(decorator);                                                                      \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& func_start() {                                                                            \
+    FuncStart();                                                                                   \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& func_end(const String& ret_val = "") {                                                    \
+    FuncEnd(ret_val);                                                                              \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& call_start(const String& callee) {                                                        \
+    CallStart(callee);                                                                             \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& call_end(const String& assign = "") {                                                     \
+    CallEnd(assign);                                                                               \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& inplace_start(const String& callee) {                                                     \
+    InplaceStart(callee);                                                                          \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& inplace_end() {                                                                           \
+    InplaceEnd();                                                                                  \
+    return *this;                                                                                  \
+  }                                                                                                \
+  template <typename T>                                                                            \
+  Stack& call_arg(T value, const String& key = "") {                                               \
+    CallArg(value, key);                                                                           \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& call_str_arg(const String& value, const String& key = "") {                               \
+    CallStrArg(value, key);                                                                        \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& call_list_arg(const Array<ExprDoc>& values, const String& key = "",                       \
+                       bool allow_empty = false) {                                                 \
+    CallListArg(values, key, allow_empty);                                                         \
+    return *this;                                                                                  \
+  }                                                                                                \
+  template <typename T>                                                                            \
+  Stack& call_list_arg(const std::vector<T>& values, const String& key = "",                       \
+                       bool allow_empty = false) {                                                 \
+    CallListArg(values, key, allow_empty);                                                         \
+    return *this;                                                                                  \
+  }                                                                                                \
+  template <typename T>                                                                            \
+  Stack& call_list_arg(const Array<T>& values, const String& key = "", bool allow_empty = false) { \
+    CallListArg(values, key, allow_empty);                                                         \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& call_inplace_start(const String& callee) {                                                \
+    CallInplaceStart(callee);                                                                      \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& call_inplace_end(const String& key = "") {                                                \
+    CallInplaceEnd(key);                                                                           \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& cond_if(const String& predicate) {                                                        \
+    ConditionIf(predicate);                                                                        \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& cond_else() {                                                                             \
+    ConditionElse();                                                                               \
+    return *this;                                                                                  \
+  }                                                                                                \
+  Stack& cond_end() {                                                                              \
+    ConditionEnd();                                                                                \
+    return *this;                                                                                  \
+  }
+
+/*!
+ * \brief Stack Doc for common codegen
+ */
+class CodeStack : public BaseStack {
+ public:
+  /*!
+   * \brief The constructor of CodeStack
+   */
+  CodeStack() : BaseStack() {}
+
+  COMMON_WRAPPERS(CodeStack)
+};
+
+/*!
+ * \brief Stack Doc for codes
+ */
+template <typename OpCodeGenType>
+class OpCodeStack : public BaseStack {
+ public:
+  /*!
+   * \brief The constructor of OpCodeStack
+   */
+  OpCodeStack() : BaseStack() {}
+
+  /*! \brief Set codegen*/
+  void Config(OpCodeGenType* codegen, bool reset = true) {
+    codegen_ = codegen;
+    if (reset) {
+      Reset();
+    }
+  }
+
+  COMMON_WRAPPERS(OpCodeStack<OpCodeGenType>)
+
+  /*! \brief Cache op_call Doc*/
+  OpCodeStack<OpCodeGenType>& op_start(const String& callee = "msc::auto") {
+    const String& v_callee = callee == "msc::auto" ? codegen_->func_name() : callee;
+    return call_start(v_callee);
+  }
+
+  /*! \brief Push op_call Doc*/
+  OpCodeStack<OpCodeGenType>& op_end(const String& assign_str = "msc::auto") {
+    const String& v_assign = assign_str == "msc::auto" ? codegen_->IdxNode(true) : assign_str;
+    return call_end(v_assign);
+  }
+
+  /*! \brief Push op comment Doc*/
+  OpCodeStack<OpCodeGenType>& op_comment(const String& comment_str = "msc::auto") {
+    const String& v_comment = (comment_str == "msc::auto" ? codegen_->Comment() : comment_str);
+    return comment(v_comment);
+  }
+
+  /*! \brief Cache attribute as argument*/
+  template <typename T>
+  OpCodeStack<OpCodeGenType>& op_arg(const String& attr_key, const String& key = "") {
+    T attr_val;
+    if (codegen_->node()->GetAttr(attr_key, &attr_val)) {
+      return call_arg(attr_val, key.size() == 0 ? attr_key : key);
+    }
+    return *this;
+  }
+
+  OpCodeStack<OpCodeGenType>& op_str_arg(const String& attr_key, const String& key = "") {
+    std::string attr_val;
+    if (codegen_->node()->GetAttr(attr_key, &attr_val)) {
+      return call_str_arg(attr_val, key.size() == 0 ? attr_key : key);
+    }
+    return *this;
+  }
+
+  /*! \brief Cache list attribute as argument*/
+  template <typename T>
+  OpCodeStack<OpCodeGenType>& op_list_arg(const String& attr_key, const String& key = "",
+                                          bool allow_empty = false) {
+    std::vector<T> attr_val;
+    if (codegen_->node()->GetAttr(attr_key, &attr_val)) {
+      return call_list_arg(attr_val, key.size() == 0 ? attr_key : key, allow_empty);
+    }
+    return *this;
+  }
+
+  /*! \brief Cache input as argument*/
+  OpCodeStack<OpCodeGenType>& op_input_arg(int idx = 0, const String& key = "") {
+    return call_arg(codegen_->IdxInput(idx, false), key);
+  }
+
+  /*! \brief Cache inputs as argument*/
+  OpCodeStack<OpCodeGenType>& op_inputs_arg(bool as_list = true, const String& key = "") {
+    Array<String> inputs;
+    for (size_t i = 0; i < codegen_->node()->inputs.size(); i++) {
+      inputs.push_back(codegen_->IdxInput(i, false));
+    }
+    if (as_list) {
+      return call_list_arg(inputs, key);
+    }
+    for (const auto& i : inputs) {
+      call_arg(i, key);
+    }
+    return *this;
+  }
+
+  /*! \brief Cache output as argument*/
+  OpCodeStack<OpCodeGenType>& op_output_arg(int idx = 0, const String& key = "") {
+    return call_arg(codegen_->IdxOutput(idx, false), key);
+  }
+
+  /*! \brief Cache weight as argument*/
+  OpCodeStack<OpCodeGenType>& op_weight_arg(const String& wtype, const String& key = "") {
+    if (codegen_->node()->weights.count(wtype)) {
+      return call_arg(codegen_->IdxWeight(wtype, false), key);
+    }
+    return *this;
+  }
+
+  OpCodeStack<OpCodeGenType>& call_dtype_arg(const DataType& dtype, const String& key = "") {
+    return call_arg(codegen_->DType(dtype), key);
+  }
+
+ private:
+  OpCodeGenType* codegen_;
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_CORE_CODEGEN_CODE_STACK_H_

--- a/src/contrib/msc/core/codegen/codegen_utils.cc
+++ b/src/contrib/msc/core/codegen/codegen_utils.cc
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/core/codegen/codegen_utils.cc
+ */
+
+#include "codegen_utils.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+const String CodeGenUtils::IdxNode(const MSCJoint& node, const String& prefix,
+                                   const String& suffix) {
+  return prefix + std::to_string(node->index) + suffix;
+}
+
+const String CodeGenUtils::IdxOutput(const MSCJoint& node, const String& prefix, int idx,
+                                     const String& suffix) {
+  const auto& idx_node = IdxNode(node, prefix, suffix);
+  size_t output_size = node->outputs.size();
+  if (output_size == 1) {
+    return idx_node;
+  }
+  size_t v_index = CommonUtils::GetIndex(idx, output_size);
+  return idx_node + "[" + std::to_string(v_index) + "]";
+}
+
+const String CodeGenUtils::IdxInput(const MSCJoint& node, const String& prefix, int idx,
+                                    const String& suffix) {
+  const auto& pair = node->ProducerAndIdxOf(idx);
+  return IdxOutput(pair.first, prefix, pair.second, suffix);
+}
+
+const String CodeGenUtils::IdxWeight(const MSCJoint& node, const String& wtype,
+                                     const String& suffix) {
+  return wtype + std::to_string(node->index) + suffix;
+}
+
+const String CodeGenUtils::CommentNode(const MSCJoint& node, const String& prefix) {
+  String comment = node->name + "(" + node->optype + "): <";
+  for (size_t i = 0; i < node->inputs.size(); i++) {
+    comment = comment + IdxInput(node, prefix, i) + (i == node->inputs.size() - 1 ? "> -> <" : ",");
+  }
+  for (size_t i = 0; i < node->outputs.size(); i++) {
+    comment = comment + IdxOutput(node, prefix, i) + (i == node->outputs.size() - 1 ? ">" : ",");
+  }
+  return comment;
+}
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/msc/core/codegen/codegen_utils.h
+++ b/src/contrib/msc/core/codegen/codegen_utils.h
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/core/codegen/codegen_utils.h
+ * \brief Common utilities for print.
+ */
+#ifndef TVM_CONTRIB_MSC_CORE_CODEGEN_CODEGEN_UTILS_H_
+#define TVM_CONTRIB_MSC_CORE_CODEGEN_CODEGEN_UTILS_H_
+
+#include <tvm/script/printer/doc.h>
+
+#include <memory>
+#include <string>
+
+#include "../ir/graph.h"
+#include "../utils.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+using namespace tvm::script::printer;
+
+#define CODEGEN_CONFIG_MEMBERS             \
+  bool is_train{false};                    \
+  bool need_prune{false};                  \
+  bool need_quantize{false};               \
+  bool need_collect{false};                \
+  bool need_distill{false};                \
+  bool need_process{false};                \
+  bool need_test{true};                    \
+  std::string test_device{"cpu"};          \
+  std::string prefix{"res_"};              \
+  std::string baseline_folder{"baseline"}; \
+  std::string version;
+
+#define CODEGEN_CONFIG_PARSE                    \
+  if (key == "is_train") {                      \
+    reader->Read(&is_train);                    \
+  } else if (key == "need_prune") {             \
+    reader->Read(&need_prune);                  \
+    need_process |= need_prune;                 \
+  } else if (key == "need_quantize") {          \
+    reader->Read(&need_quantize);               \
+    need_process |= need_quantize;              \
+  } else if (key == "need_collect") {           \
+    reader->Read(&need_collect);                \
+    need_process |= need_collect;               \
+  } else if (key == "need_distill") {           \
+    reader->Read(&need_distill);                \
+    need_process |= need_distill;               \
+  } else if (key == "need_test") {              \
+    reader->Read(&need_test);                   \
+  } else if (key == "test_device") {            \
+    reader->Read(&test_device);                 \
+  } else if (key == "prefix") {                 \
+    reader->Read(&prefix);                      \
+  } else if (key == "version") {                \
+    reader->Read(&version);                     \
+  } else if (key == "baseline_folder") {        \
+    reader->Read(&baseline_folder);             \
+  } else {                                      \
+    LOG(FATAL) << "Do not support key " << key; \
+  }
+
+#define CODEGEN_MEMBERS                                                                            \
+ public:                                                                                           \
+  virtual const Array<Doc> GetDocs() = 0;                                                          \
+                                                                                                   \
+ protected:                                                                                        \
+  const std::shared_ptr<ConfigType> config() { return config_; }                                   \
+  const String GetSuffix(bool as_raw = false) {                                                    \
+    const String& suffix = as_raw && config()->need_process ? "_raw" : "";                         \
+    return suffix;                                                                                 \
+  }                                                                                                \
+  virtual const String IdxNode(const MSCJoint& node, bool as_raw = true) {                         \
+    return CodeGenUtils::IdxNode(node, config()->prefix, GetSuffix(as_raw));                       \
+  }                                                                                                \
+  virtual const String IdxInput(const MSCJoint& node, int idx = 0, bool as_raw = false) {          \
+    return CodeGenUtils::IdxInput(node, config()->prefix, idx, GetSuffix(as_raw));                 \
+  }                                                                                                \
+  virtual const String IdxOutput(const MSCJoint& node, int idx = 0, bool as_raw = false) {         \
+    return CodeGenUtils::IdxOutput(node, config()->prefix, idx, GetSuffix(as_raw));                \
+  }                                                                                                \
+  virtual const String IdxWeight(const MSCJoint& node, const String& wtype, bool as_raw = false) { \
+    return CodeGenUtils::IdxWeight(node, wtype, GetSuffix(as_raw));                                \
+  }                                                                                                \
+  virtual const String DType(const DataType& dtype) { return runtime::DLDataType2String(dtype); }  \
+  virtual const String Comment(const MSCJoint& node) {                                             \
+    return CodeGenUtils::CommentNode(node, config()->prefix);                                      \
+  }                                                                                                \
+                                                                                                   \
+ private:                                                                                          \
+  std::shared_ptr<ConfigType> config_;
+
+/*!
+ * \brief Utils for CodeGen.
+ */
+class CodeGenUtils {
+ public:
+  /*!
+   * \brief Get indexed node string.
+   * \return The String.
+   */
+  TVM_DLL static const String IdxNode(const MSCJoint& node, const String& prefix,
+                                      const String& suffix = "");
+
+  /*!
+   * \brief Get indexed output string.
+   * \return The String.
+   */
+  TVM_DLL static const String IdxOutput(const MSCJoint& node, const String& prefix, int idx = 0,
+                                        const String& suffix = "");
+
+  /*!
+   * \brief Get indexed input string.
+   * \return The String.
+   */
+  TVM_DLL static const String IdxInput(const MSCJoint& node, const String& prefix, int idx = 0,
+                                       const String& suffix = "");
+
+  /*!
+   * \brief Get indexed weight string.
+   * \return The String.
+   */
+  TVM_DLL static const String IdxWeight(const MSCJoint& node, const String& wtype,
+                                        const String& suffix = "");
+
+  /*!
+   * \brief Get comment of a node.
+   * \return The String.
+   */
+  TVM_DLL static const String CommentNode(const MSCJoint& node, const String& prefix);
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_CORE_CODEGEN_CODEGEN_UTILS_H_

--- a/src/contrib/msc/core/codegen/py_codegen.h
+++ b/src/contrib/msc/core/codegen/py_codegen.h
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/core/codegen/py_codegen.h
+ * \brief Python codegen for MSCGraph.
+ */
+#ifndef TVM_CONTRIB_MSC_CORE_CODEGEN_PY_CODEGEN_H_
+#define TVM_CONTRIB_MSC_CORE_CODEGEN_PY_CODEGEN_H_
+
+#include <dmlc/json.h>
+#include <tvm/script/printer/doc.h>
+
+#include <string>
+
+#include "../printer/python_printer.h"
+#include "base_codegen.h"
+#include "code_stack.h"
+#include "codegen_utils.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+using namespace tvm::script::printer;
+
+template <typename ConfigType>
+class PyCodeGen : public BaseCodeGen<ConfigType> {
+ public:
+  /*!
+   * \brief The constructor of PyCodeGen
+   * \param graph the graph to be generated.
+   * \param config the options for codegen.
+   */
+  explicit PyCodeGen(const MSCGraph& graph, const std::string& config = "")
+      : BaseCodeGen<ConfigType>(graph, config) {}
+
+  /*! \brief Stack the docs for the script*/
+  virtual const Array<Doc> GetDocs() {
+    CodeGenHeader();
+    this->stack_.line().comment("Define the helpers");
+    CodeGenHelper();
+    this->stack_.line().comment("Define the graph");
+    CodeGenGraph();
+    if (this->config()->need_test) {
+      this->stack_.line().comment("Define the test");
+      CodeGenTest();
+    }
+    return this->stack_.GetDocs();
+  }
+
+  /*! \brief Get sources*/
+  virtual const Map<String, String> GetSources(const std::string& print_options = "") {
+    Map<String, String> sources;
+    PythonPrinter printer(print_options);
+    for (const auto& d : this->GetDocs()) {
+      printer.Append(d);
+    }
+    sources.Set(this->graph()->name + ".py", printer.GetString());
+    return sources;
+  }
+
+ protected:
+  /*! \brief Stack the docs for the header*/
+  virtual void CodeGenHeader() {
+    this->stack_.line("import os")
+        .line("import numpy as np")
+        .line("from typing import List, Dict")
+        .line("import tvm")
+        .line("from tvm.contrib.msc.core import utils as msir_utils");
+  }
+
+  /*! \brief Stack the docs for the helpers*/
+  virtual void CodeGenHelper() {
+    this->stack_.func_def("process_tensor", TensorType())
+        .func_arg("tensor", TensorType())
+        .func_arg("name", "str")
+        .func_arg("consumer", "str")
+        .func_start()
+        .func_end("tensor");
+    if (this->config()->need_test) {
+      this->stack_.func_def("load_data", "np.ndarray")
+          .func_arg("name", "str")
+          .func_arg("shape", "List[int]")
+          .func_arg("dtype", "str")
+          .func_start()
+          .call_start("os.path.join")
+          .call_str_arg(this->config()->baseline_folder)
+          .call_arg("name + \".bin\"")
+          .call_end("path")
+          .cond_if("os.path.isfile(path)")
+          .call_start("np.fromfile")
+          .call_arg("path")
+          .call_arg("dtype", "dtype")
+          .call_end("data")
+          .inplace_start("reshape")
+          .call_arg("shape")
+          .inplace_end()
+          .cond_else()
+          .call_start("np.ones")
+          .call_arg("(shape)")
+          .call_end("data")
+          .inplace_start("astype")
+          .call_arg("dtype")
+          .inplace_end()
+          .cond_end()
+          .func_end("data");
+    }
+  }
+
+  /*! \brief Stack the docs for the test*/
+  void CodeGenTest() {
+    this->stack_.cond_if("__name__ == \"__main__\"")
+        .comment("Prepare test datas")
+        .assign("inputs", "{}")
+        .assign("golden", "{}");
+    for (const auto& i : this->graph()->input_names) {
+      const auto& input = this->graph()->FindTensor(i);
+      this->stack_.call_start("load_data")
+          .call_str_arg(input->alias)
+          .call_list_arg(input->shape)
+          .call_str_arg(runtime::DLDataType2String(input->dtype))
+          .call_end("inputs[\"" + input->alias + "\"]");
+    }
+    for (const auto& o : this->graph()->output_names) {
+      const auto& output = this->graph()->FindTensor(o);
+      this->stack_.call_start("load_data")
+          .call_str_arg(output->alias)
+          .call_list_arg(output->shape)
+          .call_str_arg(runtime::DLDataType2String(output->dtype))
+          .call_end("golden[\"" + output->alias + "\"]");
+    }
+    this->stack_.comment("Build and inference the graph");
+    CodeGenInference();
+    this->stack_.line("msc_utils.compare_arrays(golden, outputs, verbose=\"detail\")").cond_end();
+  }
+
+  /*! \brief Stack the docs for the node*/
+  virtual void CodeGenNode(const MSCJoint& node) {
+    this->stack_.comment(this->Comment(node));
+    if (this->config()->need_process) {
+      for (size_t i = 0; i < node->inputs.size(); i++) {
+        const auto& input = node->InputAt(i);
+        this->stack_.call_start("process_tensor")
+            .call_arg(this->IdxInput(node, i, true))
+            .call_str_arg(input->name)
+            .call_str_arg(node->name)
+            .call_end(this->IdxInput(node, i, false));
+      }
+      for (const auto& pair : node->weights) {
+        this->stack_.call_start("process_tensor")
+            .call_arg(this->IdxWeight(node, pair.first, true))
+            .call_str_arg(pair.second->name)
+            .call_str_arg(node->name)
+            .call_end(this->IdxWeight(node, pair.first, false));
+      }
+    }
+    for (const auto& d : this->GetOpCodes(node)) {
+      this->stack_.line(d);
+    }
+  }
+
+  /*! \brief Stack the docs for the graph*/
+  virtual void CodeGenGraph() = 0;
+
+  /*! \brief Stack the docs for the graph inference*/
+  virtual void CodeGenInference() = 0;
+
+  /*! \brief Get tensor type of the framework*/
+  virtual const String TensorType() const { return "np.ndarray"; }
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_CORE_CODEGEN_PY_CODEGEN_H_

--- a/src/contrib/msc/core/ir/graph.cc
+++ b/src/contrib/msc/core/ir/graph.cc
@@ -248,14 +248,14 @@ bool BaseJointNode::GetAttr(const String& key, std::vector<float>* val) const {
   return false;
 }
 
-MSCJoint::MSCJoint(int index, const String& name, const String& master, const String& optype,
+MSCJoint::MSCJoint(int index, const String& name, const String& master_name, const String& optype,
                    const Map<String, String>& attrs, const Array<String>& scope,
                    const std::vector<std::pair<BaseJoint, size_t>>& inputs,
                    const Array<MSCTensor>& outputs, const Map<String, MSCTensor>& weights) {
   ObjectPtr<MSCJointNode> n = make_object<MSCJointNode>();
   n->index = index;
   n->name = std::move(name);
-  n->master = std::move(master);
+  n->master_name = std::move(master_name);
   n->optype = std::move(optype);
   n->attrs = std::move(attrs);
   n->scope = std::move(scope);
@@ -301,15 +301,15 @@ MSCJoint::MSCJoint(const std::string& json_str, const Map<String, BaseJoint>& no
 
 const MSCJoint MSCJoint::Clone(const MSCJoint& node,
                                const std::vector<std::pair<BaseJoint, size_t>>& inputs) {
-  return MSCJoint(node->index, node->name, node->master, node->optype, node->attrs, node->scope,
-                  inputs, node->outputs, node->weights);
+  return MSCJoint(node->index, node->name, node->master_name, node->optype, node->attrs,
+                  node->scope, inputs, node->outputs, node->weights);
 }
 
 const JsonMSCJoint MSCJointNode::ToJson() const {
   JsonMSCJoint j_joint;
   j_joint.index = index;
   j_joint.name = name;
-  j_joint.master = master;
+  j_joint.master_name = master_name;
   j_joint.optype = optype;
   for (const auto& pair : attrs) {
     j_joint.attrs[pair.first] = pair.second;
@@ -335,7 +335,7 @@ const JsonMSCJoint MSCJointNode::ToJson() const {
 void MSCJointNode::FromJson(const JsonMSCJoint& j_joint, const Map<String, BaseJoint>& nodes) {
   index = j_joint.index;
   name = j_joint.name;
-  master = j_joint.master;
+  master_name = j_joint.master_name;
   optype = j_joint.optype;
   for (const auto& pair : j_joint.attrs) {
     attrs.Set(pair.first, pair.second);
@@ -453,14 +453,14 @@ const std::pair<MSCJoint, size_t> MSCJointNode::ProducerAndIdxOf(const MSCTensor
   return ProducerAndIdxOf(input->name);
 }
 
-WeightJoint::WeightJoint(int index, const String& name, const String& master, const String& optype,
-                         const String& wtype, const Map<String, String>& attrs,
-                         const MSCTensor& weight, const Array<BaseJoint> parents,
-                         const Array<BaseJoint>& friends) {
+WeightJoint::WeightJoint(int index, const String& name, const String& master_name,
+                         const String& optype, const String& wtype,
+                         const Map<String, String>& attrs, const MSCTensor& weight,
+                         const Array<BaseJoint> parents, const Array<BaseJoint>& friends) {
   ObjectPtr<WeightJointNode> n = make_object<WeightJointNode>();
   n->index = index;
   n->name = std::move(name);
-  n->master = std::move(master);
+  n->master_name = std::move(master_name);
   n->optype = std::move(optype);
   n->wtype = std::move(wtype);
   n->attrs = std::move(attrs);
@@ -823,8 +823,8 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
 
 #define MSC_NODE_BASE_HEAD(Stream, Joint)                                                \
   Stream << "ID_" << Joint->index << " " << Joint->name;                                 \
-  if (Joint->master.size() > 0) {                                                        \
-    Stream << "(M: " << Joint->master << ")";                                            \
+  if (Joint->master_name.size() > 0) {                                                   \
+    Stream << "(M: " << Joint->master_name << ")";                                       \
   }                                                                                      \
   Stream << " <PARENTS: ";                                                               \
   if (Joint->parents.size() > 0) {                                                       \
@@ -946,7 +946,7 @@ TVM_REGISTER_GLOBAL("msc.core.MSCTensor")
     });
 
 TVM_REGISTER_GLOBAL("msc.core.MSCJoint")
-    .set_body_typed([](Integer index, const String& name, const String& master,
+    .set_body_typed([](Integer index, const String& name, const String& master_name,
                        const String& optype, const Map<String, String>& attrs,
                        const Array<String>& scope, const Array<MSCJoint>& parents,
                        const Array<Integer> out_indices, const Array<MSCTensor>& outputs,
@@ -955,11 +955,12 @@ TVM_REGISTER_GLOBAL("msc.core.MSCJoint")
       for (size_t i = 0; i < parents.size(); i++) {
         inputs.push_back(std::make_pair(parents[i], out_indices[i]->value));
       }
-      return MSCJoint(index->value, name, master, optype, attrs, scope, inputs, outputs, weights);
+      return MSCJoint(index->value, name, master_name, optype, attrs, scope, inputs, outputs,
+                      weights);
     });
 
 TVM_REGISTER_GLOBAL("msc.core.WeightJoint")
-    .set_body_typed([](Integer index, const String& name, const String& master,
+    .set_body_typed([](Integer index, const String& name, const String& master_name,
                        const String& optype, const String& wtype, const Map<String, String>& attrs,
                        const MSCTensor& weight, const Array<WeightJoint> parents,
                        const Array<WeightJoint>& friends) -> WeightJoint {
@@ -970,7 +971,7 @@ TVM_REGISTER_GLOBAL("msc.core.WeightJoint")
       for (const auto& f : friends) {
         b_friends.push_back(f);
       }
-      return WeightJoint(index->value, name, master, optype, wtype, attrs, weight, b_parents,
+      return WeightJoint(index->value, name, master_name, optype, wtype, attrs, weight, b_parents,
                          b_friends);
     });
 

--- a/src/contrib/msc/core/ir/graph.h
+++ b/src/contrib/msc/core/ir/graph.h
@@ -91,7 +91,7 @@ struct JsonMSCTensor {
 struct JsonMSCJoint {
   size_t index;
   std::string name;
-  std::string master;
+  std::string master_name;
   std::string optype;
   std::vector<std::string> scope;
   std::vector<std::string> parents;
@@ -104,7 +104,7 @@ struct JsonMSCJoint {
     writer->BeginObject();
     writer->WriteObjectKeyValue("index", index);
     writer->WriteObjectKeyValue("name", name);
-    writer->WriteObjectKeyValue("master", master);
+    writer->WriteObjectKeyValue("master_name", master_name);
     writer->WriteObjectKeyValue("optype", optype);
     writer->WriteObjectKeyValue("parents", parents);
     writer->WriteObjectKeyValue("inputs", inputs);
@@ -125,8 +125,8 @@ struct JsonMSCJoint {
       } else if (key == "name") {
         reader->Read(&name);
         bitmask |= 2;
-      } else if (key == "master") {
-        reader->Read(&master);
+      } else if (key == "master_name") {
+        reader->Read(&master_name);
       } else if (key == "optype") {
         reader->Read(&optype);
         bitmask |= 4;
@@ -288,8 +288,8 @@ class BaseJointNode : public Object {
   mutable int index;
   /*! \brief The name of node. */
   String name;
-  /*! \brief The master of node, can be changed. */
-  String master;
+  /*! \brief The master_name of node, can be changed. */
+  String master_name;
   /*! \brief The op type of node. */
   String optype;
   /*! \brief The attributes of node. */
@@ -332,7 +332,7 @@ class BaseJointNode : public Object {
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("index", &index);
     v->Visit("name", &name);
-    v->Visit("master", &master);
+    v->Visit("master_name", &master_name);
     v->Visit("optype", &optype);
     v->Visit("attrs", &attrs);
     v->Visit("parents", &parents);
@@ -341,14 +341,14 @@ class BaseJointNode : public Object {
 
   bool SEqualReduce(const BaseJointNode* other, SEqualReducer equal) const {
     return equal(name, other->name) &&
-           equal(master, other->master) & equal(optype, other->optype) &&
+           equal(master_name, other->master_name) & equal(optype, other->optype) &&
            equal(attrs, other->attrs) && equal(parents, other->parents) &&
            equal(children, other->children);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
     hash_reduce(name);
-    hash_reduce(master);
+    hash_reduce(master_name);
     hash_reduce(optype);
     hash_reduce(attrs);
     hash_reduce(parents);
@@ -450,14 +450,14 @@ class MSCJoint : public BaseJoint {
    * \brief The constructor.
    * \param index The index of the node.
    * \param name The name of the node.
-   * \param master The master of the node.
+   * \param master_name The master_name of the node.
    * \param optype The op type the node.
    * \param attrs The attributes of the node.
    * \param inputs The inputs of the node.
    * \param outputs The outputs of the node.
    * \param weights The weights of the node.
    */
-  TVM_DLL MSCJoint(int index, const String& name, const String& master, const String& optype,
+  TVM_DLL MSCJoint(int index, const String& name, const String& master_name, const String& optype,
                    const Map<String, String>& attrs, const Array<String>& scope,
                    const std::vector<std::pair<BaseJoint, size_t>>& inputs,
                    const Array<MSCTensor>& outputs, const Map<String, MSCTensor>& weights);
@@ -531,7 +531,7 @@ class WeightJoint : public BaseJoint {
    * \brief The constructor.
    * \param index The index of the node.
    * \param name The name of the node.
-   * \param master The master of the node.
+   * \param master_name The master_name of the node.
    * \param optype The optype of the node.
    * \param wtype The weight type of the node.
    * \param attrs The attributes of the node.
@@ -539,8 +539,8 @@ class WeightJoint : public BaseJoint {
    * \param parents The parents of the node.
    * \param friends The friends of the node.
    */
-  TVM_DLL WeightJoint(int index, const String& name, const String& master, const String& optype,
-                      const String& wtype, const Map<String, String>& attrs,
+  TVM_DLL WeightJoint(int index, const String& name, const String& master_name,
+                      const String& optype, const String& wtype, const Map<String, String>& attrs,
                       const MSCTensor& weight, const Array<BaseJoint> parents,
                       const Array<BaseJoint>& friends);
 

--- a/src/contrib/msc/core/ir/graph_builder.cc
+++ b/src/contrib/msc/core/ir/graph_builder.cc
@@ -103,7 +103,7 @@ const MSCGraph RelaxGraphBuilder::Build(const relax::Function& func) {
 const MSCJoint RelaxGraphBuilder::AddNode(const Expr& expr, const Optional<Expr>& binding_var,
                                           const String& name) {
   const auto& node_name = name.size() > 0 ? name : SpanUtils::GetAttr(expr->span, "name");
-  const auto& master_name = SpanUtils::GetAttr(expr->span, "master");
+  const auto& master_name = SpanUtils::GetAttr(expr->span, "master_name");
   String optype;
   if (expr->IsInstance<relax::VarNode>()) {
     optype = "input";
@@ -419,7 +419,7 @@ MSCGraph RelayGraphBuilder::Build(const relay::Function& func) {
 
 MSCJoint RelayGraphBuilder::AddNode(const Expr& expr, const String& name) {
   const auto& node_name = name.size() > 0 ? name : SpanUtils::GetAttr(expr->span, "name");
-  const auto& master_name = SpanUtils::GetAttr(expr->span, "master");
+  const auto& master_name = SpanUtils::GetAttr(expr->span, "master_name");
   String optype;
   if (expr->IsInstance<relay::VarNode>()) {
     optype = "input";

--- a/src/contrib/msc/core/ir/graph_builder.cc
+++ b/src/contrib/msc/core/ir/graph_builder.cc
@@ -72,18 +72,18 @@ const MSCGraph RelaxGraphBuilder::Build(const relax::Function& func) {
   }
   const auto& graph = MSCGraph(name_, valid_nodes, input_names, output_names);
   // set inputs and outputs alias
-  if (config_.input_aliass.size() == input_names.size()) {
+  if (config_.input_aliases.size() == input_names.size()) {
     for (size_t i = 0; i < input_names.size(); i++) {
-      graph->FindTensor(input_names[i])->alias = config_.input_aliass[i];
+      graph->FindTensor(input_names[i])->alias = config_.input_aliases[i];
     }
   } else {
     for (size_t i = 0; i < input_names.size(); i++) {
       graph->FindTensor(input_names[i])->alias = graph->FindProducer(input_names[i])->name;
     }
   }
-  if (config_.output_aliass.size() == output_names.size()) {
+  if (config_.output_aliases.size() == output_names.size()) {
     for (size_t i = 0; i < output_names.size(); i++) {
-      graph->FindTensor(output_names[i])->alias = config_.output_aliass[i];
+      graph->FindTensor(output_names[i])->alias = config_.output_aliases[i];
     }
   } else {
     for (size_t i = 0; i < output_names.size(); i++) {
@@ -389,18 +389,18 @@ MSCGraph RelayGraphBuilder::Build(const relay::Function& func) {
   }
   const auto& graph = MSCGraph(name_, valid_nodes, input_names, output_names);
   // set inputs and outputs alias
-  if (config_.input_aliass.size() == input_names.size()) {
+  if (config_.input_aliases.size() == input_names.size()) {
     for (size_t i = 0; i < input_names.size(); i++) {
-      graph->FindTensor(input_names[i])->alias = config_.input_aliass[i];
+      graph->FindTensor(input_names[i])->alias = config_.input_aliases[i];
     }
   } else {
     for (size_t i = 0; i < input_names.size(); i++) {
       graph->FindTensor(input_names[i])->alias = graph->FindProducer(input_names[i])->name;
     }
   }
-  if (config_.output_aliass.size() == output_names.size()) {
+  if (config_.output_aliases.size() == output_names.size()) {
     for (size_t i = 0; i < output_names.size(); i++) {
-      graph->FindTensor(output_names[i])->alias = config_.output_aliass[i];
+      graph->FindTensor(output_names[i])->alias = config_.output_aliases[i];
     }
   } else {
     for (size_t i = 0; i < output_names.size(); i++) {

--- a/src/contrib/msc/core/ir/graph_builder.h
+++ b/src/contrib/msc/core/ir/graph_builder.h
@@ -58,8 +58,8 @@ struct MSCRBuildConfig {
   bool prune_graph{false};
   int float_precision = 6;
   std::string sort_by;
-  std::vector<std::string> input_aliass;
-  std::vector<std::string> output_aliass;
+  std::vector<std::string> input_aliases;
+  std::vector<std::string> output_aliases;
   std::unordered_map<std::string, std::vector<std::string>> input_types;
 
   void LoadInputTypes(dmlc::JSONReader* reader) {
@@ -82,10 +82,10 @@ struct MSCRBuildConfig {
         reader->Read(&float_precision);
       } else if (key == "sort_by") {
         reader->Read(&sort_by);
-      } else if (key == "input_aliass") {
-        reader->Read(&input_aliass);
-      } else if (key == "output_aliass") {
-        reader->Read(&output_aliass);
+      } else if (key == "input_aliases") {
+        reader->Read(&input_aliases);
+      } else if (key == "output_aliases") {
+        reader->Read(&output_aliases);
       } else if (key == "input_types") {
         this->LoadInputTypes(reader);
       }

--- a/src/contrib/msc/core/transform/set_expr_name.cc
+++ b/src/contrib/msc/core/transform/set_expr_name.cc
@@ -130,7 +130,7 @@ class RelaxExprNameSetter : public ExprVisitor {
     if (unique_name != SpanUtils::GetAttr(val->span, "name")) {
       val->span = SpanUtils::SetAttr(val->span, "name", unique_name);
     }
-    // set constant consumer && master
+    // set constant consumer && master_name
     Array<String> input_types;
     try {
       input_types = ExprUtils::GetInputTypes(optype, val->args.size(), true);
@@ -145,7 +145,7 @@ class RelaxExprNameSetter : public ExprVisitor {
       if (const auto* c_node = val->args[i].as<ConstantNode>()) {
         const String& const_name = SpanUtils::GetAttr(c_node->span, "name");
         if (constant_consumers_.count(const_name)) {
-          val->span = SpanUtils::SetAttr(val->span, "master", constant_consumers_[const_name]);
+          val->span = SpanUtils::SetAttr(val->span, "master_name", constant_consumers_[const_name]);
         } else {
           constant_consumers_.Set(const_name, unique_name);
         }
@@ -272,7 +272,7 @@ class RelayExprNameSetter : public ExprVisitor {
     if (unique_name != SpanUtils::GetAttr(op->span, "name")) {
       op->span = SpanUtils::SetAttr(op->span, "name", unique_name);
     }
-    // set constant consumer && master
+    // set constant consumer && master_name
     Array<String> input_types;
     try {
       input_types = ExprUtils::GetInputTypes(optype, op->args.size(), false);
@@ -287,7 +287,7 @@ class RelayExprNameSetter : public ExprVisitor {
       if (const auto* c_node = op->args[i].as<ConstantNode>()) {
         const String& const_name = SpanUtils::GetAttr(c_node->span, "name");
         if (constant_consumers_.count(const_name)) {
-          op->span = SpanUtils::SetAttr(op->span, "master", constant_consumers_[const_name]);
+          op->span = SpanUtils::SetAttr(op->span, "master_name", constant_consumers_[const_name]);
         } else {
           constant_consumers_.Set(const_name, unique_name);
         }

--- a/src/contrib/msc/framework/tvm/codegen.cc
+++ b/src/contrib/msc/framework/tvm/codegen.cc
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tvm/codegen.cc
+ */
+#include "codegen.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+void RelaxCodeGen::CodeGenHeader() {
+  PyCodeGen<RelaxCodeGenConfig>::CodeGenHeader();
+  stack_.line("from tvm import relax");
+}
+
+void RelaxCodeGen::CodeGenGraph() {
+  stack_.func_def(graph()->name, "tvm.IRModule");
+  Array<String> idx_inputs;
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& pair = graph()->FindProducerAndIdx(i);
+    const auto& idx_input = IdxOutput(pair.first, pair.second);
+    stack_.func_arg(idx_input, "relax.Var");
+    idx_inputs.push_back(idx_input);
+  }
+  stack_.func_start().assign_list("inputs", idx_inputs);
+  // define weights
+  stack_.comment("Define the weights and constant");
+  for (const auto& n : graph()->node_names) {
+    const auto& node = graph()->FindNode(n);
+    for (const auto& pair : node->weights) {
+      const auto& idx_weight = IdxWeight(node, pair.first);
+      stack_.call_start("relax.Var")
+          .call_str_arg(pair.second->name)
+          .call_inplace_start("relax.TensorStructInfo")
+          .call_list_arg(pair.second->shape, "", true)
+          .call_str_arg(pair.second->DTypeName())
+          .call_inplace_end()
+          .call_end(idx_weight)
+          .call_start("inputs.append")
+          .call_arg(idx_weight)
+          .call_end();
+    }
+    if (node->optype == "constant") {
+      CodeGenNode(node);
+      stack_.call_start("inputs.append").call_arg(IdxNode(node)).call_end();
+    }
+  }
+  stack_.comment("Define the module");
+  stack_.assign("block_builder", "relax.BlockBuilder()")
+      .scope_start("block_builder.function(name=\"" + graph()->name + "\", params=inputs.copy())");
+  for (const auto& n : graph()->node_names) {
+    const auto& node = graph()->FindNode(n);
+    if (node->optype == "input" || node->optype == "constant") {
+      continue;
+    }
+    int scope_level = CompareScope(node);
+    if (scope_level == 1) {
+      stack_.scope_start("block_builder.dataflow()");
+    } else if (scope_level == -1) {
+      stack_.scope_end();
+    }
+    CodeGenNode(node);
+  }
+  if (scopes().size() > 1) {
+    // end left scopes
+    for (size_t i = 0; i < scopes().size() - 1; i++) {
+      stack_.scope_end();
+    }
+  } else if (scopes().size() == 0) {
+    // start dataflow scope for non-scope graph
+    stack_.scope_start("block_builder.dataflow()");
+  }
+  // mark outputs
+  stack_.comment("Emit the outputs");
+  Array<String> idx_exits;
+  for (const auto& e : graph()->GetExits()) {
+    const auto& idx_exit = IdxNode(e, false);
+    stack_.call_start("block_builder.emit_output").call_arg(idx_exit).call_end(idx_exit);
+    idx_exits.push_back(idx_exit);
+  }
+  stack_.scope_end().call_start("block_builder.emit_func_output");
+  if (idx_exits.size() == 1) {
+    stack_.call_arg(idx_exits[0]);
+  } else {
+    stack_.call_list_arg(idx_exits);
+  }
+  stack_.call_end().scope_end().assign("mod", "block_builder.get()").func_end("mod");
+}
+
+void RelaxCodeGen::CodeGenInference() {
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& pair = graph()->FindProducerAndIdx(i);
+    stack_.call_start("relax.Var")
+        .call_str_arg(i->alias)
+        .call_inplace_start("relax.TensorStructInfo")
+        .call_list_arg(i->shape)
+        .call_str_arg(i->DTypeName())
+        .call_inplace_end()
+        .call_end(IdxNode(pair.first));
+  }
+  stack_.comment("Build Module").call_start(graph()->name);
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& pair = graph()->FindProducerAndIdx(i);
+    stack_.call_arg(IdxNode(pair.first));
+  }
+  stack_.call_end("mod");
+  String target, device;
+  if (config()->test_device == "cpu") {
+    target = "llvm";
+    device = "tvm.cpu()";
+  } else if (config()->test_device == "gpu") {
+    target = "cuda";
+    device = "tvm.cuda()";
+  }
+  stack_.comment("Load weights")
+      .scope_start("open(\"" + graph()->name + "_params.bin\", \"rb\")", "f")
+      .call_start("tvm.runtime.load_param_dict")
+      .call_arg("f.read()")
+      .call_end("params")
+      .scope_end()
+      .call_start("tvm.relax.transform.BindParams")
+      .call_str_arg("main")
+      .call_arg("params")
+      .call_end("bind_params")
+      .call_start("bind_params")
+      .call_arg("mod")
+      .call_end("mod")
+      .call_start("tvm.target.Target")
+      .call_str_arg(target)
+      .call_end("target")
+      .call_start("relax.build")
+      .call_arg("mod")
+      .call_arg("target")
+      .call_end("ex")
+      .call_start("relax.VirtualMachine")
+      .call_arg("ex")
+      .call_arg(device)
+      .call_end("vm")
+      .call_start("vm[\"main\"]");
+  for (const auto& i : graph()->GetInputs()) {
+    stack_.call_arg("inputs[\"" + i->alias + "\"]");
+  }
+  stack_.call_end("outputs");
+}
+
+const Array<Doc> RelaxCodeGen::GetOpCodes(const MSCJoint& node) {
+  const auto& ops_map = GetRelaxOpCodes();
+  auto it = ops_map->find(node->optype);
+  ICHECK(it != ops_map->end()) << "Unsupported relax op(" << node->optype << "): " << node;
+  it->second->Config(node, config());
+  try {
+    return it->second->GetDocs();
+  } catch (runtime::InternalError& err) {
+    LOG(WARNING) << "Failed to get docs for " << node << " : " << err.message();
+    throw err;
+  }
+}
+
+TVM_REGISTER_GLOBAL("msc.framework.tvm.GetRelaxSources")
+    .set_body_typed([](const MSCGraph& graph, const String& codegen_config,
+                       const String print_config) -> Map<String, String> {
+      RelaxCodeGen codegen = RelaxCodeGen(graph, codegen_config);
+      return codegen.GetSources(print_config);
+    });
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/msc/framework/tvm/codegen.h
+++ b/src/contrib/msc/framework/tvm/codegen.h
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tvm/codegen.h
+ * \brief Relax codegen for MSCGraph.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TVM_CODEGEN_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TVM_CODEGEN_H_
+
+#include <string>
+
+#include "../../core/codegen/base_codegen.h"
+#include "../../core/codegen/py_codegen.h"
+#include "config.h"
+#include "relax_opcode.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+class RelaxCodeGen : public PyCodeGen<RelaxCodeGenConfig> {
+ public:
+  /*!
+   * \brief The constructor of RelaxCodeGen
+   * \param graph the graph to be generated.
+   * \param config the options for codegen.
+   */
+  explicit RelaxCodeGen(const MSCGraph& graph, const std::string& config = "")
+      : PyCodeGen<RelaxCodeGenConfig>(graph, config) {}
+
+ protected:
+  /*! \brief Stack the docs for the header*/
+  void CodeGenHeader() final;
+
+  /*! \brief Stack the docs for the graph*/
+  void CodeGenGraph() final;
+
+  /*! \brief Stack the docs for the graph inference*/
+  void CodeGenInference() final;
+
+  /*! \brief Get the docs for the op*/
+  const Array<Doc> GetOpCodes(const MSCJoint& node) final;
+
+  /*! \brief Get tensor type of the framework*/
+  const String TensorType() const final { return "relax.Expr"; }
+
+ private:
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TVM_CODEGEN_H_

--- a/src/contrib/msc/framework/tvm/config.h
+++ b/src/contrib/msc/framework/tvm/config.h
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tvm/config.h
+ * \brief Relax codegen for MSCJoint.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TVM_CONFIG_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TVM_CONFIG_H_
+
+#include <string>
+
+#include "../../core/codegen/base_codegen.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+/*!
+ * \brief CodeGen config for tvm codegen
+ */
+struct RelaxCodeGenConfig {
+  bool explicit_name{true};
+  bool from_relay{false};
+  CODEGEN_CONFIG_MEMBERS
+  void Load(dmlc::JSONReader* reader) {
+    std::string key;
+    reader->BeginObject();
+    while (reader->NextObjectItem(&key)) {
+      if (key == "explicit_name") {
+        reader->Read(&explicit_name);
+      } else if (key == "from_relay") {
+        reader->Read(&from_relay);
+      } else {
+        CODEGEN_CONFIG_PARSE
+      }
+    }
+  }
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TVM_CONFIG_H_

--- a/src/contrib/msc/framework/tvm/relax_opcode.cc
+++ b/src/contrib/msc/framework/tvm/relax_opcode.cc
@@ -175,7 +175,7 @@ class RelaxBiasAddCodeGen : public RelaxOpCode {
     int axis = node()->GetTypeAttr<int>("axis");
     Array<Integer> expand_shape;
     for (size_t i = 0; i < node()->InputAt(0)->Ndim(); i++) {
-      if (i == axis) {
+      if (i == static_cast<size_t>(axis)) {
         expand_shape.push_back(node()->InputAt(0)->DimAt(i));
       } else {
         expand_shape.push_back(Integer(1));

--- a/src/contrib/msc/framework/tvm/relax_opcode.cc
+++ b/src/contrib/msc/framework/tvm/relax_opcode.cc
@@ -1,0 +1,707 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tvm/relax_opcode.cc
+ */
+#include "relax_opcode.h"
+
+#include <memory>
+#include <string>
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+const Array<Doc> RelaxOpCode::GetDocs() {
+  stack_.Config(this);
+  CodeGenBuild();
+  bool emit_var = true;
+  if (node()->optype == "input" || node()->optype == "constant" || node()->optype == "shape") {
+    emit_var = false;
+  }
+  if (node()->optype == "tuple" && node()->children.size() == 0) {
+    emit_var = false;
+  }
+  if (emit_var) {
+    const auto& name = config()->explicit_name ? node()->name : "";
+    BuilderEmit(IdxNode(true), name);
+  }
+  return stack_.GetDocs();
+}
+
+void RelaxOpCode::BuilderEmit(const String& ret, const String& name) {
+  stack_.call_start("block_builder.emit").call_arg(ret);
+  if (name.size() > 0) {
+    stack_.call_str_arg(name, "name_hint");
+  }
+  stack_.call_end(ret);
+}
+
+const std::string RelaxOpCode::GetOutDtype(const String& key) {
+  std::string out_dtype;
+  if (!node()->GetAttr(key, &out_dtype) && config()->from_relay) {
+    return node()->OutputAt(0)->DTypeName();
+  }
+  return out_dtype;
+}
+
+const std::vector<int> RelaxOpCode::GetAxes(const String& key) {
+  std::vector<int> axes;
+  int axis;
+  if (!node()->GetAttr(key, &axes) && node()->GetAttr(key, &axis)) {
+    axes.push_back(axis);
+  }
+  return axes;
+}
+
+#define RELAX_OP_CODEGEN_METHODS(TypeName) \
+ public:                                   \
+  TypeName(const String& func_name) : RelaxOpCode(func_name) {}
+
+class RelaxAdaptivePool2dCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxAdaptivePool2dCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .op_input_arg()
+        .op_list_arg<int>("output_size")
+        .op_str_arg("layout")
+        .op_str_arg("out_layout")
+        .op_end();
+  }
+};
+
+class RelaxAstypeCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxAstypeCodeGen)
+ protected:
+  void CodeGenBuild() final { stack_.op_start().op_input_arg().op_str_arg("dtype").op_end(); }
+};
+
+class RelaxAttentionCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxAttentionCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    for (size_t i = 0; i < 3; i++) {
+      const String& axes_key = i == 0 ? "axes" : "axes_" + std::to_string(i);
+      stack_.op_start("relax.op.permute_dims")
+          .op_input_arg(i)
+          .op_list_arg<int>(axes_key, "axes")
+          .op_end(IdxInput(i));
+    }
+    stack_.op_start()
+        .op_inputs_arg(false)
+        .op_arg<float>("scale")
+        .op_str_arg("causal_mask")
+        .op_end();
+  }
+};
+
+class RelaxAxisCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxAxisCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    std::vector<int> axes = GetAxes("axis");
+    stack_.op_start().op_input_arg();
+    if (axes.size() > 0) {
+      stack_.call_arg(axes[0], "axis");
+    }
+    stack_.op_end();
+  }
+};
+
+class RelaxAxesCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxAxesCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    const String& key = node()->HasAttr("axes") ? "axes" : "axis";
+    stack_.op_start().op_input_arg().call_list_arg(GetAxes(key), key).op_end();
+  }
+};
+
+class RelaxBatchMatmulCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxBatchMatmulCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    bool transpose_a = node()->GetTypeAttr<bool>("transpose_a");
+    bool transpose_b = node()->GetTypeAttr<bool>("transpose_b");
+    if (!transpose_a && !transpose_b) {
+      stack_.op_start().op_inputs_arg(false).op_str_arg("out_dtype").op_end();
+    } else {
+      LOG(FATAL) << "Unexpected nn.batch_matmul " << node();
+    }
+  }
+};
+
+class RelaxBatchNormCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxBatchNormCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .op_input_arg()
+        .op_weight_arg("gamma")
+        .op_weight_arg("beta")
+        .op_weight_arg("mean")
+        .op_weight_arg("var")
+        .op_arg<int>("axis")
+        .op_arg<float>("epsilon")
+        .op_arg<bool>("center")
+        .op_arg<bool>("scale")
+        .op_arg<float>("momentum")
+        .op_end();
+  }
+};
+
+class RelaxBiasAddCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxBiasAddCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    int axis = node()->GetTypeAttr<int>("axis");
+    Array<Integer> expand_shape;
+    for (size_t i = 0; i < node()->InputAt(0)->Ndim(); i++) {
+      if (i == axis) {
+        expand_shape.push_back(node()->InputAt(0)->DimAt(i));
+      } else {
+        expand_shape.push_back(Integer(1));
+      }
+    }
+    stack_.op_start("relax.op.reshape")
+        .op_input_arg(1)
+        .call_list_arg(expand_shape, "shape")
+        .call_end(IdxInput(1));
+    BuilderEmit(IdxInput(1));
+    stack_.op_start().op_inputs_arg(false).op_end();
+  }
+};
+
+class RelaxBroadcastToCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxBroadcastToCodeGen)
+ protected:
+  void CodeGenBuild() final { stack_.op_start().op_input_arg().op_list_arg<int>("shape").op_end(); }
+};
+
+class RelaxClipCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxClipCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg();
+    if (config()->from_relay) {
+      stack_.op_arg<float>("a_min", "min").op_arg<float>("a_max", "max");
+    } else {
+      stack_.op_arg<float>("min").op_arg<float>("max");
+    }
+    stack_.op_end();
+  }
+};
+
+class RelaxConstantCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxConstantCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .call_str_arg(node()->name)
+        .call_inplace_start("relax.TensorStructInfo")
+        .call_list_arg(node()->OutputAt(0)->shape, "", true)
+        .call_str_arg(node()->OutputAt(0)->DTypeName())
+        .call_inplace_end()
+        .call_end()
+        .op_end();
+  }
+};
+
+class RelaxConvCodeGen : public RelaxOpCode {
+ public:
+  RelaxConvCodeGen(const String& func_name, bool use_bias)
+      : RelaxOpCode(func_name), use_bias_(use_bias) {}
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .op_input_arg()
+        .op_weight_arg("weight")
+        .op_list_arg<int>("strides")
+        .op_list_arg<int>("padding")
+        .op_list_arg<int>("dilation")
+        .op_arg<int>("groups")
+        .op_str_arg("data_layout")
+        .op_str_arg("kernel_layout")
+        .op_str_arg("out_layout")
+        .call_str_arg(GetOutDtype(), "out_dtype")
+        .op_end();
+    if (use_bias_) {
+      std::string out_layout_str;
+      if (!node()->GetAttr("out_layout", &out_layout_str)) {
+        ICHECK(node()->GetAttr("data_layout", &out_layout_str))
+            << "out_layout or data_layout should be given, get " << node();
+      }
+      const auto& out_layout = tir::Layout(out_layout_str);
+      Array<Integer> expand_shape;
+      for (size_t i = 0; i < node()->OutputAt(0)->Ndim(); i++) {
+        if (out_layout[i].name() == "C") {
+          expand_shape.push_back(node()->OutputAt(0)->DimAt(i));
+        } else {
+          expand_shape.push_back(Integer(1));
+        }
+      }
+      BuilderEmit(IdxNode());
+      stack_.call_start("relax.op.reshape")
+          .call_arg(IdxWeight("bias", true))
+          .call_list_arg(expand_shape, "shape")
+          .call_end("expand_bias");
+      BuilderEmit("expand_bias");
+      stack_.call_start("relax.op.add")
+          .call_arg(IdxNode())
+          .call_arg("expand_bias")
+          .call_end(IdxNode());
+    }
+  }
+
+ private:
+  bool use_bias_;
+};
+
+class RelaxCreateCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxCreateCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_list_arg<int>("shape").op_str_arg("dtype").op_end();
+  }
+};
+
+class RelaxCumsumCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxCumsumCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg().op_arg<int>("axis").op_str_arg("dtype").op_end();
+  }
+};
+
+class RelaxStridedSliceCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxStridedSliceCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    std::vector<int> axes;
+    if (!node()->GetAttr("axes", &axes)) {
+      for (size_t i = 0; i < node()->InputAt(0)->Ndim(); i++) {
+        axes.push_back(i);
+      }
+    }
+    stack_.op_start()
+        .op_input_arg()
+        .call_list_arg(axes, "axes")
+        .op_list_arg<int>("begin")
+        .op_list_arg<int>("end")
+        .op_list_arg<int>("strides")
+        .op_end();
+  }
+};
+
+class RelaxEmbeddingCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxEmbeddingCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    const auto& input = node()->InputAt(0);
+    if (input->DTypeName() != "int32") {
+      stack_.op_start("relax.op.astype").op_input_arg().call_str_arg("int32").op_end(IdxInput());
+      BuilderEmit(IdxInput());
+    }
+    if (input->Ndim() > 1) {
+      stack_.op_start("relax.op.reshape")
+          .op_input_arg()
+          .call_list_arg(std::vector<int>{-1}, "shape")
+          .op_end(IdxInput());
+      BuilderEmit(IdxInput());
+    }
+    stack_.op_start().op_weight_arg("weight").op_input_arg().op_arg<int>("axis").op_end();
+    if (input->Ndim() > 1) {
+      BuilderEmit(IdxNode());
+      stack_.op_start("relax.op.reshape")
+          .op_output_arg()
+          .call_list_arg(node()->OutputAt(0)->shape)
+          .op_end();
+    }
+  }
+};
+
+class RelaxFullCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxFullCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .op_list_arg<int>("shape")
+        .op_input_arg(0, "fill_value")
+        .op_str_arg("dtype")
+        .op_end();
+  }
+};
+
+class RelaxGetItemCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxGetItemCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    const auto& producer = node()->ProducerOf(0);
+    stack_.op_start().call_arg(IdxNode(producer)).op_arg<int>("index").call_end(IdxNode());
+  }
+};
+
+class RelaxGroupNormCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxGroupNormCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg().op_weight_arg("gamma").op_weight_arg("beta").op_arg<int>(
+        "num_groups");
+    if (config()->from_relay) {
+      std::vector<size_t> axes;
+      for (size_t i = 2; i < node()->InputAt(0)->Ndim(); i++) {
+        axes.push_back(i);
+      }
+      stack_.op_arg<int>("axis", "channel_axis").call_list_arg(axes, "axes");
+    } else {
+      stack_.op_arg<int>("channel_axis").op_list_arg<int>("axes");
+    }
+    stack_.op_arg<float>("epsilon").op_arg<bool>("center").op_arg<bool>("scale").op_end();
+  }
+};
+
+class RelaxLayerNormCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxLayerNormCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg().op_weight_arg("gamma").op_weight_arg("beta");
+    if (config()->from_relay) {
+      stack_.op_arg<int>("axis", "axes");
+    } else {
+      stack_.op_list_arg<int>("axes");
+    }
+    stack_.op_arg<float>("epsilon").op_arg<bool>("center").op_arg<bool>("scale").op_end();
+  }
+};
+
+class RelaxLinearCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxLinearCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .op_input_arg()
+        .op_weight_arg("weight")
+        .op_weight_arg("bias")
+        .call_str_arg(GetOutDtype(), "out_dtype")
+        .op_end();
+  }
+};
+
+class RelaxMatmulCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxMatmulCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_inputs_arg(false).call_str_arg(GetOutDtype(), "out_dtype").op_end();
+  }
+};
+
+class RelaxNllLossCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxNllLossCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .op_inputs_arg(false)
+        .op_str_arg("reduction")
+        .op_arg<int>("ignore_index")
+        .op_end();
+  }
+};
+
+class RelaxPool2dCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxPool2dCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .op_input_arg()
+        .op_list_arg<int>("pool_size")
+        .op_list_arg<int>("strides")
+        .op_list_arg<int>("padding")
+        .op_list_arg<int>("dilation")
+        .op_arg<bool>("ceil_mode")
+        .op_str_arg("layout")
+        .op_str_arg("out_layout")
+        .op_end();
+  }
+};
+
+class RelaxReduceAxisCodeGen : public RelaxOpCode {
+ public:
+  RelaxReduceAxisCodeGen(const String& func_name, bool as_list)
+      : RelaxOpCode(func_name), as_list_(as_list) {}
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg();
+    std::vector<int> axes = GetAxes("axis");
+    if (as_list_) {
+      stack_.call_list_arg(axes, "axis");
+    } else if (axes.size() > 0) {
+      stack_.call_arg(axes[0], "axis");
+    }
+    stack_.op_arg<bool>("keepdims").op_end();
+  }
+
+ private:
+  bool as_list_;
+};
+
+class RelaxRepeatCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxRepeatCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg().op_arg<int>("repeats").op_arg<int>("axis").op_end();
+  }
+};
+
+class RelaxReshapeCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxReshapeCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg();
+    if (config()->from_relay) {
+      stack_.op_list_arg<int>("newshape", "shape");
+    } else {
+      stack_.op_list_arg<int>("shape");
+    }
+    stack_.op_end();
+  }
+};
+
+class RelaxResize2dCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxResize2dCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    // roi has forced to be float list
+    Array<String> roi_list;
+    std::vector<float> roi = node()->GetTypeArrayAttr<float>("roi");
+    for (const auto& r : roi) {
+      roi_list.push_back("float(" + std::to_string(r) + ")");
+    }
+    stack_.op_start()
+        .op_input_arg()
+        .call_inplace_start("relax.ShapeExpr")
+        .op_list_arg<int>("size", "values")
+        .call_inplace_end()
+        .call_list_arg(roi_list)
+        .op_str_arg("layout")
+        .op_str_arg("method")
+        .op_str_arg("coordinate_transformation_mode")
+        .op_str_arg("rounding_method")
+        .op_arg<float>("cubic_alpha")
+        .op_arg<int>("cubic_exclude")
+        .op_arg<float>("extrapolation_value")
+        .op_str_arg("out_dtype")
+        .op_end();
+  }
+};
+
+class RelaxShapeCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxShapeCodeGen)
+ protected:
+  void CodeGenBuild() final { stack_.op_start().op_list_arg<int>("shape", "values").op_end(); }
+};
+
+class RelaxSimpleCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxSimpleCodeGen)
+ protected:
+  void CodeGenBuild() final { stack_.op_start().op_inputs_arg(false).op_end(); }
+};
+
+class RelaxSplitCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxSplitCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg();
+    int sections;
+    if (node()->GetAttr("indices_or_sections", &sections)) {
+      stack_.op_arg<int>("indices_or_sections");
+    } else {
+      stack_.op_list_arg<int>("indices_or_sections");
+    }
+    stack_.op_arg<int>("axis").op_end();
+  }
+};
+
+class RelaxTakeCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxTakeCodeGen)
+ protected:
+  void CodeGenBuild() final { stack_.op_start().op_inputs_arg(false).op_arg<int>("axis").op_end(); }
+};
+
+class RelaxTupleCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxTupleCodeGen)
+ protected:
+  void CodeGenBuild() final { stack_.op_start().op_inputs_arg().op_end(); }
+};
+
+class RelaxTriCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxTriCodeGen)
+ protected:
+  void CodeGenBuild() final {
+    if (node()->optype == "trilu") {
+      const String& func_name =
+          node()->GetTypeAttr<bool>("upper") ? "relax.op.triu" : "relax.op.tril";
+      stack_.op_start(func_name).op_input_arg().op_arg<int>("k").op_end();
+    } else {
+      stack_.op_start().op_input_arg().op_arg<int>("k").op_end();
+    }
+  }
+};
+
+const std::shared_ptr<std::unordered_map<String, std::shared_ptr<RelaxOpCode>>> GetRelaxOpCodes() {
+  static auto map = std::make_shared<std::unordered_map<String, std::shared_ptr<RelaxOpCode>>>();
+  if (!map->empty()) return map;
+  // binary && unary ops
+  map->emplace("abs", std::make_shared<RelaxSimpleCodeGen>("relax.op.abs"));
+  map->emplace("acos", std::make_shared<RelaxSimpleCodeGen>("relax.op.acos"));
+  map->emplace("acosh", std::make_shared<RelaxSimpleCodeGen>("relax.op.acosh"));
+  map->emplace("add", std::make_shared<RelaxSimpleCodeGen>("relax.op.add"));
+  map->emplace("asin", std::make_shared<RelaxSimpleCodeGen>("relax.op.asin"));
+  map->emplace("asinh", std::make_shared<RelaxSimpleCodeGen>("relax.op.asinh"));
+  map->emplace("atan", std::make_shared<RelaxSimpleCodeGen>("relax.op.atan"));
+  map->emplace("atanh", std::make_shared<RelaxSimpleCodeGen>("relax.op.atanh"));
+  map->emplace("bitwise_and", std::make_shared<RelaxSimpleCodeGen>("relax.op.bitwise_and"));
+  map->emplace("bitwise_not", std::make_shared<RelaxSimpleCodeGen>("relax.op.bitwise_not"));
+  map->emplace("bitwise_or", std::make_shared<RelaxSimpleCodeGen>("relax.op.bitwise_or"));
+  map->emplace("bitwise_xor", std::make_shared<RelaxSimpleCodeGen>("relax.op.bitwise_xor"));
+  map->emplace("ceil", std::make_shared<RelaxSimpleCodeGen>("relax.op.ceil"));
+  map->emplace("cos", std::make_shared<RelaxSimpleCodeGen>("relax.op.cos"));
+  map->emplace("cosh", std::make_shared<RelaxSimpleCodeGen>("relax.op.cosh"));
+  map->emplace("divide", std::make_shared<RelaxSimpleCodeGen>("relax.op.divide"));
+  map->emplace("exp", std::make_shared<RelaxSimpleCodeGen>("relax.op.exp"));
+  map->emplace("equal", std::make_shared<RelaxSimpleCodeGen>("relax.op.equal"));
+  map->emplace("floor", std::make_shared<RelaxSimpleCodeGen>("relax.op.floor"));
+  map->emplace("floor_divide", std::make_shared<RelaxSimpleCodeGen>("relax.op.floor_divide"));
+  map->emplace("greater", std::make_shared<RelaxSimpleCodeGen>("relax.op.greater"));
+  map->emplace("greater_equal", std::make_shared<RelaxSimpleCodeGen>("relax.op.greater_equal"));
+  map->emplace("less", std::make_shared<RelaxSimpleCodeGen>("relax.op.less"));
+  map->emplace("less_equal", std::make_shared<RelaxSimpleCodeGen>("relax.op.less_equal"));
+  map->emplace("log", std::make_shared<RelaxSimpleCodeGen>("relax.op.log"));
+  map->emplace("logical_and", std::make_shared<RelaxSimpleCodeGen>("relax.op.logical_and"));
+  map->emplace("logical_or", std::make_shared<RelaxSimpleCodeGen>("relax.op.logical_or"));
+  map->emplace("logical_xor", std::make_shared<RelaxSimpleCodeGen>("relax.op.logical_xor"));
+  map->emplace("maximum", std::make_shared<RelaxSimpleCodeGen>("relax.op.maximum"));
+  map->emplace("minimum", std::make_shared<RelaxSimpleCodeGen>("relax.op.minimum"));
+  map->emplace("multiply", std::make_shared<RelaxSimpleCodeGen>("relax.op.multiply"));
+  map->emplace("negative", std::make_shared<RelaxSimpleCodeGen>("relax.op.negative"));
+  map->emplace("not_equal", std::make_shared<RelaxSimpleCodeGen>("relax.op.not_equal"));
+  map->emplace("power", std::make_shared<RelaxSimpleCodeGen>("relax.op.power"));
+  map->emplace("round", std::make_shared<RelaxSimpleCodeGen>("relax.op.round"));
+  map->emplace("rsqrt", std::make_shared<RelaxSimpleCodeGen>("relax.op.rsqrt"));
+  map->emplace("sigmoid", std::make_shared<RelaxSimpleCodeGen>("relax.op.sigmoid"));
+  map->emplace("sign", std::make_shared<RelaxSimpleCodeGen>("relax.op.sign"));
+  map->emplace("sin", std::make_shared<RelaxSimpleCodeGen>("relax.op.sin"));
+  map->emplace("sinh", std::make_shared<RelaxSimpleCodeGen>("relax.op.sinh"));
+  map->emplace("square", std::make_shared<RelaxSimpleCodeGen>("relax.op.square"));
+  map->emplace("sqrt", std::make_shared<RelaxSimpleCodeGen>("relax.op.sqrt"));
+  map->emplace("subtract", std::make_shared<RelaxSimpleCodeGen>("relax.op.subtract"));
+  map->emplace("tan", std::make_shared<RelaxSimpleCodeGen>("relax.op.tan"));
+  map->emplace("tanh", std::make_shared<RelaxSimpleCodeGen>("relax.op.tanh"));
+
+  // reduce axis ops
+  map->emplace("argmax", std::make_shared<RelaxReduceAxisCodeGen>("relax.op.argmax", false));
+  map->emplace("argmin", std::make_shared<RelaxReduceAxisCodeGen>("relax.op.argmin", false));
+  map->emplace("max", std::make_shared<RelaxReduceAxisCodeGen>("relax.op.max", true));
+  map->emplace("min", std::make_shared<RelaxReduceAxisCodeGen>("relax.op.min", true));
+  map->emplace("mean", std::make_shared<RelaxReduceAxisCodeGen>("relax.op.mean", true));
+  map->emplace("sum", std::make_shared<RelaxReduceAxisCodeGen>("relax.op.sum", true));
+  map->emplace("prod", std::make_shared<RelaxReduceAxisCodeGen>("relax.op.prod", true));
+  map->emplace("std", std::make_shared<RelaxReduceAxisCodeGen>("relax.op.std", true));
+
+  // axis ops
+  map->emplace("nn.log_softmax", std::make_shared<RelaxAxisCodeGen>("relax.op.nn.log_softmax"));
+  map->emplace("nn.softmax", std::make_shared<RelaxAxisCodeGen>("relax.op.nn.softmax"));
+
+  // math ops
+  map->emplace("astype", std::make_shared<RelaxAstypeCodeGen>("relax.op.astype"));
+  map->emplace("broadcast_to", std::make_shared<RelaxBroadcastToCodeGen>("relax.op.broadcast_to"));
+  map->emplace("cast", std::make_shared<RelaxAstypeCodeGen>("relax.op.astype"));
+  map->emplace("clip", std::make_shared<RelaxClipCodeGen>("relax.op.clip"));
+  map->emplace("constant", std::make_shared<RelaxConstantCodeGen>("relax.Var"));
+  map->emplace("cumsum", std::make_shared<RelaxCumsumCodeGen>("relax.op.cumsum"));
+  map->emplace("strided_slice",
+               std::make_shared<RelaxStridedSliceCodeGen>("relax.op.strided_slice"));
+  map->emplace("expand_dims", std::make_shared<RelaxAxesCodeGen>("relax.op.expand_dims"));
+  map->emplace("matmul", std::make_shared<RelaxMatmulCodeGen>("relax.op.linear_algebra.matmul"));
+  map->emplace("permute_dims", std::make_shared<RelaxAxesCodeGen>("relax.op.permute_dims"));
+  map->emplace("repeat", std::make_shared<RelaxRepeatCodeGen>("relax.op.repeat"));
+  map->emplace("reshape", std::make_shared<RelaxReshapeCodeGen>("relax.op.reshape"));
+  map->emplace("split", std::make_shared<RelaxSplitCodeGen>("relax.op.split"));
+  map->emplace("squeeze", std::make_shared<RelaxAxesCodeGen>("relax.op.squeeze"));
+  map->emplace("take", std::make_shared<RelaxTakeCodeGen>("relax.op.take"));
+  map->emplace("transpose", std::make_shared<RelaxAxesCodeGen>("relax.op.permute_dims"));
+
+  // create ops
+  map->emplace("full", std::make_shared<RelaxFullCodeGen>("relax.op.full"));
+  map->emplace("ones", std::make_shared<RelaxCreateCodeGen>("relax.op.ones"));
+  map->emplace("tril", std::make_shared<RelaxTriCodeGen>("relax.op.tril"));
+  map->emplace("triu", std::make_shared<RelaxTriCodeGen>("relax.op.triu"));
+  map->emplace("trilu", std::make_shared<RelaxTriCodeGen>(""));
+  map->emplace("zeros", std::make_shared<RelaxCreateCodeGen>("relax.op.zeros"));
+
+  // nn ops
+  map->emplace("nn.adaptive_avg_pool2d",
+               std::make_shared<RelaxAdaptivePool2dCodeGen>("relax.op.nn.adaptive_avg_pool2d"));
+  map->emplace("nn.avg_pool2d", std::make_shared<RelaxPool2dCodeGen>("relax.op.nn.avg_pool2d"));
+  map->emplace("nn.batch_matmul",
+               std::make_shared<RelaxBatchMatmulCodeGen>("relax.op.linear_algebra.matmul"));
+  map->emplace("nn.batch_norm", std::make_shared<RelaxBatchNormCodeGen>("relax.op.nn.batch_norm"));
+  map->emplace("nn.bias_add", std::make_shared<RelaxBiasAddCodeGen>("relax.op.add"));
+  map->emplace("nn.conv1d", std::make_shared<RelaxConvCodeGen>("relax.op.nn.conv1d", false));
+  map->emplace("nn.conv2d", std::make_shared<RelaxConvCodeGen>("relax.op.nn.conv2d", false));
+  map->emplace("nn.gelu", std::make_shared<RelaxSimpleCodeGen>("relax.op.nn.gelu"));
+  map->emplace("nn.group_norm", std::make_shared<RelaxGroupNormCodeGen>("relax.op.nn.group_norm"));
+  map->emplace("nn.layer_norm", std::make_shared<RelaxLayerNormCodeGen>("relax.op.nn.layer_norm"));
+  map->emplace("nn.max_pool2d", std::make_shared<RelaxPool2dCodeGen>("relax.op.nn.max_pool2d"));
+  map->emplace("nn.nll_loss", std::make_shared<RelaxNllLossCodeGen>("relax.op.nn.nll_loss"));
+  map->emplace("nn.relu", std::make_shared<RelaxSimpleCodeGen>("relax.op.nn.relu"));
+  map->emplace("nn.silu", std::make_shared<RelaxSimpleCodeGen>("relax.op.nn.silu"));
+
+  // image ops
+  map->emplace("image.resize2d", std::make_shared<RelaxResize2dCodeGen>("relax.op.image.resize2d"));
+
+  // special op
+  map->emplace("shape", std::make_shared<RelaxShapeCodeGen>("relax.ShapeExpr"));
+  map->emplace("tuple", std::make_shared<RelaxTupleCodeGen>("relax.Tuple"));
+  map->emplace("get_item", std::make_shared<RelaxGetItemCodeGen>("relax.TupleGetItem"));
+
+  // msc ops
+  map->emplace("msc.attention", std::make_shared<RelaxAttentionCodeGen>("relax.op.nn.attention"));
+  map->emplace("msc.conv1d_bias", std::make_shared<RelaxConvCodeGen>("relax.op.nn.conv1d", true));
+  map->emplace("msc.conv2d_bias", std::make_shared<RelaxConvCodeGen>("relax.op.nn.conv2d", true));
+  map->emplace("msc.embedding", std::make_shared<RelaxEmbeddingCodeGen>("relax.op.take"));
+  map->emplace("msc.gelu", std::make_shared<RelaxSimpleCodeGen>("relax.op.nn.gelu"));
+  map->emplace("msc.linear",
+               std::make_shared<RelaxLinearCodeGen>("relax.op.linear_algebra.linear"));
+  map->emplace("msc.linear_bias",
+               std::make_shared<RelaxLinearCodeGen>("relax.op.linear_algebra.linear"));
+  map->emplace("msc.matmul",
+               std::make_shared<RelaxMatmulCodeGen>("relax.op.linear_algebra.matmul"));
+
+  return map;
+}
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/msc/framework/tvm/relax_opcode.h
+++ b/src/contrib/msc/framework/tvm/relax_opcode.h
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tvm/relax_opcode.h
+ * \brief Relax codegen for MSCJoint.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TVM_RELAX_OPCODE_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TVM_RELAX_OPCODE_H_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "../../core/codegen/base_codegen.h"
+#include "config.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+class RelaxOpCode;
+typedef OpCodeStack<RelaxOpCode> RelaxOpCodeStack;
+
+/*!
+ * \brief CodeGen for relax op
+ */
+class RelaxOpCode : public BaseOpCode<RelaxCodeGenConfig> {
+ public:
+  /*!
+   * \brief The constructor of BaseOpDocsifier
+   * \param func_name the function name for the node.
+   * \param config the config json for the node.
+   */
+  explicit RelaxOpCode(const String& func_name) : BaseOpCode<RelaxCodeGenConfig>(func_name) {}
+
+  /*! \brief Convert node to docs*/
+  const Array<Doc> GetDocs() final;
+
+ protected:
+  /*! \brief Convert op build*/
+  virtual void CodeGenBuild() = 0;
+
+  /*! \brief coda stack emit docs*/
+  void BuilderEmit(const String& ret, const String& name = "");
+
+  /*! \brief Get the out_dtype attribute*/
+  const std::string GetOutDtype(const String& key = "out_dtype");
+
+  /*! \brief Get the axes attribute*/
+  const std::vector<int> GetAxes(const String& key = "axes");
+
+  RelaxOpCodeStack stack_;
+};
+
+/*!
+ * \brief Get the map of available RelaxOpCode, use optype as key
+ * \return Map of <string, RelaxOpCode>
+ */
+const std::shared_ptr<std::unordered_map<String, std::shared_ptr<RelaxOpCode>>> GetRelaxOpCodes();
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TVM_RELAX_OPCODE_H_

--- a/tests/python/contrib/test_msc/test_translate_relax.py
+++ b/tests/python/contrib/test_msc/test_translate_relax.py
@@ -1,0 +1,1108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" Test translate from relax. """
+
+import torch
+from torch import fx
+from torch.nn import Module
+
+import tvm.testing
+from tvm.relax.frontend.torch import from_fx
+from tvm.contrib.msc.core.ir import translate
+from tvm.contrib.msc.framework.tvm import codegen as tvm_codegen
+
+
+def verify_model(torch_model, input_info):
+    graph_model = fx.symbolic_trace(torch_model)
+    with torch.no_grad():
+        expected = from_fx(graph_model, input_info)
+    graph, weights = translate.from_relax(expected)
+    mod = tvm_codegen.to_relax(graph, weights, codegen_config={"explicit_name": False})
+    tvm.ir.assert_structural_equal(mod, expected)
+
+
+def test_conv1d():
+    """test relax translator for conv1d"""
+
+    class Conv1D1(Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv1d(3, 6, 7, bias=True)
+
+        def forward(self, data):
+            return self.conv(data)
+
+    class Conv1D2(Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv1d(3, 6, 7, bias=False)
+
+        def forward(self, data):
+            return self.conv(data)
+
+    input_info = [([1, 3, 10], "float32")]
+    verify_model(Conv1D1(), input_info)
+    verify_model(Conv1D2(), input_info)
+
+
+def test_conv2d():
+    """test relax translator for conv2d"""
+
+    class Conv2D1(Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 6, 7, bias=True)
+
+        def forward(self, data):
+            return self.conv(data)
+
+    class Conv2D2(Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 6, 7, bias=False)
+
+        def forward(self, data):
+            return self.conv(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Conv2D1(), input_info)
+    verify_model(Conv2D2(), input_info)
+
+
+def test_linear():
+    """test relax translator for linear"""
+
+    class Dense1(Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 7, bias=True)
+
+        def forward(self, data):
+            return self.linear(data)
+
+    class Dense2(Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 7, bias=False)
+
+        def forward(self, data):
+            return self.linear(data)
+
+    class MatMul1(Module):
+        def forward(self, x, y):
+            return torch.matmul(x, y)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Dense1(), input_info)
+    verify_model(Dense2(), input_info)
+    verify_model(MatMul1(), [([10, 10], "float32"), ([10, 10], "float32")])
+
+
+def test_bmm():
+    """test relax translator for bmm"""
+
+    class BMM(Module):
+        def forward(self, x, y):
+            return torch.bmm(x, y)
+
+    input_info = [((4, 128, 256), "float32"), ((4, 256, 512), "float32")]
+    verify_model(BMM(), input_info)
+
+
+def test_baddbmm():
+    """test relax translator for baddbmm"""
+
+    class BAddBMM1(Module):
+        def forward(self, c, x, y):
+            return torch.baddbmm(c, x, y)
+
+    class BAddBMM2(Module):
+        def forward(self, c, x, y):
+            return torch.baddbmm(c, x, y, alpha=2, beta=0)
+
+    input_info = [
+        ((4, 128, 512), "float32"),
+        ((4, 128, 256), "float32"),
+        ((4, 256, 512), "float32"),
+    ]
+    verify_model(BAddBMM1(), input_info)
+    verify_model(BAddBMM2(), input_info)
+
+
+def test_relu():
+    """test relax translator for relu"""
+
+    class ReLU(Module):
+        def __init__(self):
+            super().__init__()
+            self.relu = torch.nn.ReLU()
+
+        def forward(self, data):
+            return self.relu(data)
+
+    class ReLU1(Module):
+        def forward(self, data):
+            return torch.nn.functional.relu(data)
+
+    input_info = [([10, 10], "float32")]
+    verify_model(ReLU(), input_info)
+    verify_model(ReLU1(), input_info)
+
+
+def test_relu6():
+    """test relax translator for relu6"""
+
+    class ReLU6(Module):
+        def __init__(self):
+            super().__init__()
+            self.relu6 = torch.nn.ReLU6()
+
+        def forward(self, data):
+            return self.relu6(data)
+
+    input_info = [([10, 10], "float32")]
+    verify_model(ReLU6(), input_info)
+
+
+def test_maxpool2d():
+    """test relax translator for maxpool2d"""
+
+    class MaxPool2d(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.MaxPool2d(kernel_size=[1, 1])
+
+        def forward(self, data):
+            return self.pool(data)
+
+    class MaxPool2d2(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.MaxPool2d(kernel_size=[2, 2], dilation=[2, 3])
+
+        def forward(self, data):
+            return self.pool(data)
+
+    class MaxPool2d3(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.MaxPool2d(kernel_size=[4, 4], padding=2, stride=2)
+
+        def forward(self, data):
+            return self.pool(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(MaxPool2d(), input_info)
+    verify_model(MaxPool2d2(), input_info)
+    verify_model(MaxPool2d3(), input_info)
+
+
+def test_avgpool2d():
+    """test relax translator for avgpool2d"""
+
+    class AvgPool2d(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.AvgPool2d(kernel_size=[1, 1])
+
+        def forward(self, data):
+            return self.pool(data)
+
+    class AvgPool2d2(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.AvgPool2d(kernel_size=[4, 4], stride=2, padding=2, ceil_mode=True)
+
+        def forward(self, data):
+            return self.pool(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(AvgPool2d(), input_info)
+    verify_model(AvgPool2d2(), input_info)
+
+
+def test_adaptive_avgpool2d():
+    """test relax translator for adaptive_avgpool2d"""
+
+    class AdaptiveAvgPool2d0(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.AdaptiveAvgPool2d([10, 10])
+
+        def forward(self, data):
+            return self.pool(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(AdaptiveAvgPool2d0(), input_info)
+
+
+def test_flatten():
+    """test relax translator for flatten"""
+
+    class Flatten(Module):
+        def __init__(self):
+            super().__init__()
+            self.f = torch.nn.Flatten(2, -1)
+
+        def forward(self, data):
+            return self.f(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Flatten(), input_info)
+    verify_model(torch.nn.Flatten(2, -1), input_info)
+
+
+def test_batchnorm2d():
+    """test relax translator for batchnorm2d"""
+
+    class BatchNorm2d(Module):
+        def __init__(self):
+            super().__init__()
+            self.batchnorm = torch.nn.BatchNorm2d(3)
+
+        def forward(self, data):
+            return self.batchnorm(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(BatchNorm2d(), input_info)
+
+
+def test_embedding():
+    """test relax translator for embedding"""
+
+    class Embedding(Module):
+        def __init__(self):
+            super().__init__()
+            self.embedding = torch.nn.Embedding(10, 3)
+
+        def forward(self, data):
+            return self.embedding(data)
+
+    verify_model(Embedding(), [([4], "int64")])
+    verify_model(Embedding(), [([4, 5], "int64")])
+
+
+def test_dropout():
+    """test relax translator for dropout"""
+
+    class Dropout1(Module):
+        def __init__(self):
+            super().__init__()
+            self.dropout = torch.nn.Dropout(0.5)
+
+        def forward(self, data):
+            return self.dropout(data)
+
+    class Dropout2(Module):
+        def forward(self, data):
+            return torch.dropout(data, 0.5, train=True)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Dropout1(), input_info)
+    verify_model(Dropout2(), input_info)
+
+
+def test_layernorm():
+    """test relax translator for layernorm"""
+
+    class LayerNorm(Module):
+        def __init__(self):
+            super().__init__()
+            self.layernorm = torch.nn.LayerNorm((10, 10))
+
+        def forward(self, data):
+            return self.layernorm(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(LayerNorm(), input_info)
+
+
+def test_functional_layernorm():
+    """test relax translator for functional_layernorm"""
+
+    class LayerNorm(Module):
+        def __init__(self, shape):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(shape))
+            self.bias = torch.nn.Parameter(torch.zeros(shape))
+
+        def forward(self, data):
+            return torch.nn.functional.layer_norm(
+                data, self.weight.shape, self.weight, self.bias, 1e-5
+            )
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(LayerNorm((10, 10)), input_info)
+
+
+def test_cross_entropy():
+    """test relax translator for cross_entropy"""
+
+    class CrossEntropy1(Module):
+        def __init__(self):
+            super().__init__()
+            self.loss = torch.nn.CrossEntropyLoss()
+
+        def forward(self, logits, targets):
+            return self.loss(logits, targets)
+
+    class CrossEntropy2(Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones((2,)))
+            self.loss = torch.nn.CrossEntropyLoss(weight=self.weight)
+
+        def forward(self, logits, targets):
+            return self.loss(logits, targets)
+
+    class CrossEntropy3(Module):
+        def __init__(self):
+            super().__init__()
+            self.loss = torch.nn.CrossEntropyLoss(ignore_index=1, reduction="sum")
+
+        def forward(self, logits, targets):
+            return self.loss(logits, targets)
+
+    input_info = [([3, 2], "float32"), ([3], "int32")]
+    verify_model(CrossEntropy1(), input_info)
+    verify_model(CrossEntropy2(), input_info)
+    verify_model(CrossEntropy3(), input_info)
+
+
+def test_functional_cross_entropy():
+    """test relax translator for functional_cross_entropy"""
+
+    class CrossEntropy(Module):
+        def forward(self, logits, targets):
+            return torch.nn.functional.cross_entropy(logits, targets)
+
+    input_info = [([3, 10], "float32"), ([3], "int32")]
+    verify_model(CrossEntropy(), input_info)
+
+
+def test_silu():
+    """test relax translator for silu"""
+
+    class SiLU(Module):
+        def __init__(self):
+            super().__init__()
+            self.silu = torch.nn.SiLU()
+
+        def forward(self, data):
+            return self.silu(data)
+
+    class SiLU2(Module):
+        def forward(self, data):
+            return torch.nn.functional.silu(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(SiLU(), input_info)
+    verify_model(SiLU2(), input_info)
+
+
+def test_groupnorm():
+    """test relax translator for groupnorm"""
+
+    class GroupNorm(Module):
+        def __init__(self):
+            super().__init__()
+            self.groupnorm = torch.nn.GroupNorm(3, 3)
+
+        def forward(self, data):
+            return self.groupnorm(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(GroupNorm(), input_info)
+
+
+def test_softmax():
+    """test relax translator for softmax"""
+
+    class Softmax(Module):
+        def __init__(self):
+            super().__init__()
+            self.softmax = torch.nn.Softmax(dim=1)
+
+        def forward(self, data):
+            return self.softmax(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Softmax(), input_info)
+
+
+def test_binary():
+    """test relax translator for binary"""
+
+    input_info1 = [([1, 3, 10, 10], "float32"), ([1, 3, 10, 10], "float32")]
+    input_info2 = [([1, 3, 10, 10], "float32")]
+
+    # Add
+    class Add1(Module):
+        def forward(self, lhs, rhs):
+            return lhs + rhs
+
+    class Add2(Module):
+        def forward(self, lhs):
+            return lhs + 1.0
+
+    verify_model(Add1(), input_info1)
+    verify_model(Add2(), input_info2)
+
+    # Sub
+    class Sub1(Module):
+        def forward(self, lhs, rhs):
+            return lhs - rhs
+
+    class Sub2(Module):
+        def forward(self, lhs):
+            return lhs - 1.0
+
+    verify_model(Sub1(), input_info1)
+    verify_model(Sub2(), input_info2)
+
+    # Mul
+    class Mul1(Module):
+        def forward(self, lhs, rhs):
+            return lhs * rhs
+
+    class Mul2(Module):
+        def forward(self, lhs):
+            return lhs * 1.0
+
+    verify_model(Mul1(), input_info1)
+    verify_model(Mul2(), input_info2)
+
+    # True div
+    class TrueDiv1(Module):
+        def forward(self, lhs, rhs):
+            return lhs / rhs
+
+    class TrueDiv2(Module):
+        def forward(self, lhs):
+            return lhs / 1.0
+
+    verify_model(TrueDiv1(), input_info1)
+    verify_model(TrueDiv2(), input_info2)
+
+    # Floor div
+    class FloorDiv1(Module):
+        def forward(self, lhs, rhs):
+            return lhs // rhs
+
+    class FloorDiv2(Module):
+        def forward(self, lhs):
+            return lhs // 1.0
+
+    verify_model(FloorDiv1(), input_info1)
+    verify_model(FloorDiv2(), input_info2)
+
+    # Power
+    class Power1(Module):
+        def forward(self, lhs, rhs):
+            return lhs**rhs
+
+    class Power2(Module):
+        def forward(self, lhs):
+            return lhs**1.0
+
+    verify_model(Power1(), input_info1)
+    verify_model(Power2(), input_info2)
+
+    # LT
+    class LT1(Module):
+        def forward(self, lhs, rhs):
+            return lhs < rhs
+
+    class LT2(Module):
+        def forward(self, lhs):
+            return lhs < 1.0
+
+    verify_model(LT1(), input_info1)
+    verify_model(LT2(), input_info2)
+
+
+def test_size():
+    """test relax translator for size"""
+
+    class Size(Module):
+        def forward(self, data):
+            return data.size()
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Size(), input_info)
+
+
+def test_squeeze():
+    """test relax translator for squeeze"""
+
+    class Squeeze1(Module):
+        def forward(self, data):
+            return data.squeeze(1)
+
+    class Squeeze2(Module):
+        def forward(self, data):
+            return data.squeeze()
+
+    input_info = [([3, 1, 4, 1], "float32")]
+    verify_model(Squeeze1(), input_info)
+    verify_model(Squeeze2(), input_info)
+
+
+def test_unsqueeze():
+    """test relax translator for unsqueeze"""
+
+    class Unsqueeze1(Module):
+        def forward(self, data):
+            return data.unsqueeze(1)
+
+    class Unsqueeze2(Module):
+        def forward(self, data):
+            return data.unsqueeze(-1)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Unsqueeze1(), input_info)
+    verify_model(Unsqueeze2(), input_info)
+
+
+def test_getattr():
+    """test relax translator for getattr"""
+
+    class GetAttr1(Module):
+        def forward(self, data):
+            return data.shape
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(GetAttr1(), input_info)
+
+
+def test_getitem():
+    """test relax translator for getitem"""
+
+    class Slice1(Module):
+        def forward(self, x):
+            return x[0, 1::2, :, :3]
+
+    class Slice2(Module):
+        def forward(self, x):
+            return x[:, None, None, :, None]
+
+    verify_model(Slice1(), [([1, 3, 10, 10], "float32")])
+    verify_model(Slice2(), [([8, 16], "float32")])
+
+
+def test_unary():
+    """test relax translator for unary"""
+
+    input_info = [([1, 3, 10, 10], "float32")]
+
+    # sin
+    class Sin(Module):
+        def forward(self, data):
+            return torch.sin(data)
+
+    verify_model(Sin(), input_info)
+
+    # cos
+    class Cos(Module):
+        def forward(self, data):
+            return torch.cos(data)
+
+    verify_model(Cos(), input_info)
+
+    # exp
+    class Exp(Module):
+        def forward(self, data):
+            return torch.exp(data)
+
+    verify_model(Exp(), input_info)
+
+    # sqrt
+    class Sqrt(Module):
+        def forward(self, data):
+            return torch.sqrt(data)
+
+    verify_model(Sqrt(), input_info)
+
+    # sigmoid
+    class Sigmoid(Module):
+        def forward(self, data):
+            return torch.sigmoid(data)
+
+    verify_model(Sigmoid(), input_info)
+
+    # round
+    class Round(Module):
+        def forward(self, data):
+            return torch.round(data)
+
+    verify_model(Round(), input_info)
+
+
+def test_gelu():
+    """test relax translator for gelu"""
+
+    class Gelu(Module):
+        def forward(self, data):
+            return torch.nn.functional.gelu(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Gelu(), input_info)
+
+
+def test_tanh():
+    """test relax translator for tanh"""
+
+    class Tanh(Module):
+        def forward(self, data):
+            return torch.tanh(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Tanh(), input_info)
+
+
+def test_clamp():
+    """test relax translator for clamp"""
+
+    class Clamp(Module):
+        def forward(self, data):
+            return torch.clamp(data, min=0.1, max=0.5)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Clamp(), input_info)
+
+
+def test_interpolate():
+    """test relax translator for interpolate"""
+
+    class Interpolate(Module):
+        def forward(self, data):
+            return torch.nn.functional.interpolate(data, (5, 5))
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Interpolate(), input_info)
+
+
+def test_addmm():
+    """test relax translator for addmm"""
+
+    class Addmm(Module):
+        def forward(self, x_1, x_2, x_3):
+            return torch.addmm(x_1, x_2, x_3)
+
+    input_info = [
+        ([10, 10], "float32"),
+        ([10, 10], "float32"),
+        ([10, 10], "float32"),
+    ]
+    verify_model(Addmm(), input_info)
+
+
+def test_split():
+    """test relax translator for split"""
+
+    class Split(Module):
+        def forward(self, data):
+            return torch.split(data, 1, dim=1)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Split(), input_info)
+
+
+def test_cumsum():
+    """test relax translator for cumsum"""
+
+    class Cumsum(Module):
+        def forward(self, data):
+            return torch.cumsum(data, dim=1, dtype=torch.int32)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Cumsum(), input_info)
+
+
+def test_chunk():
+    """test relax translator for chunk"""
+
+    class Chunk(Module):
+        def forward(self, data):
+            return torch.chunk(data, 3, dim=1)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Chunk(), input_info)
+
+
+def test_inplace_fill():
+    """test relax translator for inplace_fill"""
+
+    class InplaceFill(Module):
+        def forward(self, data):
+            data.fill_(1.5)
+            return data
+
+    verify_model(InplaceFill(), [([10, 10], "float32")])
+
+
+def test_arange():
+    """test relax translator for arange"""
+
+    class Arange(Module):
+        def forward(self):
+            return torch.arange(0, 20, dtype=torch.int32)
+
+    verify_model(Arange(), [([10, 10], "float32")])
+
+
+def test_empty():
+    """test relax translator for empty"""
+
+    class Empty(Module):
+        def forward(self):
+            return torch.empty((10, 10), dtype=torch.float32)
+
+    verify_model(Empty(), [([10, 10], "float32")])
+
+
+def test_tensor():
+    """test relax translator for tensor"""
+
+    class Empty1(Module):
+        def forward(self):
+            return torch.tensor(3, dtype=torch.float32)
+
+    class Empty2(Module):
+        def forward(self):
+            return torch.tensor(3)
+
+    verify_model(Empty1(), [([10, 10], "float32")])
+    verify_model(Empty2(), [([10, 10], "float32")])
+
+
+def test_tril():
+    """test relax translator for tril"""
+
+    class Tril(Module):
+        def forward(self, data):
+            return torch.tril(data, 1)
+
+    class InplaceTril(Module):
+        def forward(self, data):
+            data.tril_(1)
+            return data
+
+    input_info = [([10, 10], "float32")]
+    verify_model(Tril(), input_info)
+    verify_model(InplaceTril(), input_info)
+
+
+def test_triu():
+    """test relax translator for triu"""
+
+    class Triu(Module):
+        def forward(self, data):
+            return torch.triu(data, 1)
+
+    class InplaceTriu(Module):
+        def forward(self, data):
+            data.triu_(1)
+            return data
+
+    input_info = [([10, 10], "float32")]
+    verify_model(Triu(), input_info)
+    verify_model(InplaceTriu(), input_info)
+
+
+def test_new_ones():
+    """test relax translator for new_ones"""
+
+    class NewOnes(Module):
+        def forward(self, x):
+            return x.new_ones(1, 2, 3)
+
+    input_info = [([1, 2, 3], "float32")]
+    verify_model(NewOnes(), input_info)
+
+
+def test_expand():
+    """test relax translator for expand"""
+
+    class Expand(Module):
+        def forward(self, x):
+            return x.expand(4, 2, 3, 4)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Expand(), input_info)
+
+
+def test_reduce():
+    """test relax translator for reduce"""
+
+    # sum
+    class Sum(Module):
+        def forward(self, x):
+            return torch.sum(x, (2, 1))
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Sum(), input_info)
+
+
+def test_datatype():
+    """test relax translator for datatype"""
+
+    input_info = [([1, 2, 3, 4], "float32")]
+
+    # float
+    class ToFloat(Module):
+        def forward(self, x):
+            return x.float()
+
+    verify_model(ToFloat(), input_info)
+
+    # half
+    class ToHalf(Module):
+        def forward(self, x):
+            return x.half()
+
+    verify_model(ToHalf(), input_info)
+
+    # type
+    class Type(Module):
+        def forward(self, x):
+            return x.type(torch.float32)
+
+    # type
+    class TypeFromAttr(Module):
+        def forward(self, x):
+            return x.type(x.getattr("dtype"))
+
+    # astype
+    class AsType(Module):
+        def forward(self, x):
+            return x.astype(torch.float32)
+
+    verify_model(Type(), input_info)
+    verify_model(TypeFromAttr(), input_info)
+    verify_model(AsType(), input_info)
+
+
+def test_permute():
+    """test relax translator for permute"""
+
+    class Permute(Module):
+        def forward(self, x):
+            return x.permute(0, 3, 2, 1)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Permute(), input_info)
+
+
+def test_reshape():
+    """test relax translator for reshape"""
+
+    class Reshape(Module):
+        def forward(self, x):
+            return x.reshape(2, 12)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Reshape(), input_info)
+
+
+def test_transpose():
+    """test relax translator for transpose"""
+
+    class Transpose(Module):
+        def forward(self, x):
+            return x.transpose(1, 3)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Transpose(), input_info)
+
+
+def test_view():
+    """test relax translator for view"""
+
+    class View(Module):
+        def forward(self, x):
+            return x.view(2, 12)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(View(), input_info)
+
+
+def test_keep_params():
+    """test relax translator for keep_params"""
+
+    class Conv2D1(Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 6, 7, bias=True)
+
+        def forward(self, data):
+            return self.conv(data)
+
+    verify_model(Conv2D1(), [([1, 3, 10, 10], "float32")])
+
+
+def test_unwrap_unit_return_tuple():
+    """test relax translator for unwrap_unit_return_tuple"""
+
+    class Identity(Module):
+        def forward(self, x):
+            return (x,)
+
+    verify_model(Identity(), [([256, 256], "float32")])
+
+
+def test_no_bind_return_tuple():
+    """test relax translator for no_bind_return_tuple"""
+
+    class Identity(Module):
+        def forward(self, x, y):
+            return (x, y)
+
+    input_info = [([256, 256], "float32"), ([256, 256], "float32")]
+    verify_model(Identity(), input_info)
+
+
+def test_argmax():
+    """test relax translator for argmax"""
+
+    class Argmax1(Module):
+        def forward(self, data):
+            return torch.argmax(data, dim=-1)
+
+    class Argmax2(Module):
+        def forward(self, data):
+            return torch.argmax(data, dim=-1, keepdim=True)
+
+    verify_model(Argmax1(), [([256, 256], "float32")])
+    verify_model(Argmax2(), [([256, 256], "float32")])
+
+
+def test_argmin():
+    """test relax translator for argmin"""
+
+    class Argmin1(Module):
+        def forward(self, data):
+            return torch.argmin(data)
+
+    class Argmin2(Module):
+        def forward(self, data):
+            return torch.argmin(data, keepdim=True)
+
+    verify_model(Argmin1(), [([256, 256], "float32")])
+    verify_model(Argmin2(), [([256, 256], "float32")])
+
+
+def test_to():
+    """test relax translator for to"""
+
+    class To1(Module):
+        def forward(self, data):
+            return data.to(torch.float16)
+
+    class To2(Module):
+        def forward(self, data):
+            return data.to("cpu")
+
+    verify_model(To1(), [([256, 256], "float32")])
+    verify_model(To2(), [([256, 256], "float32")])
+
+
+def test_mean():
+    """test relax translator for mean"""
+
+    class Mean(Module):
+        def forward(self, data):
+            return data.mean(-1)
+
+    class MeanKeepDim(Module):
+        def forward(self, data):
+            return data.mean(-1, keepdim=True)
+
+    verify_model(Mean(), [([256, 256], "float32")])
+    verify_model(MeanKeepDim(), [([256, 256], "float32")])
+
+
+def test_rsqrt():
+    """test relax translator for rsqrt"""
+
+    class Rsqrt(Module):
+        def forward(self, data):
+            return torch.rsqrt(data)
+
+    verify_model(Rsqrt(), [([256, 256], "float32")])
+
+
+def test_neg():
+    """test relax translator for neg"""
+
+    class Neg(Module):
+        def forward(self, data):
+            return -data
+
+    verify_model(Neg(), [([256, 256], "float32")])
+
+
+def test_max():
+    """test relax translator for max"""
+
+    class Max(Module):
+        def forward(self, x, y):
+            return torch.max(x, y)
+
+    verify_model(Max(), [([256, 256], "float32"), ([256, 256], "float32")])
+
+
+def test_attention():
+    """test relax translator for attention"""
+
+    # pylint: disable=import-outside-toplevel
+    import torch.nn.functional as F
+
+    class Attention1(Module):
+        def forward(self, q_data, k_data, v_data):
+            return F.scaled_dot_product_attention(q_data, k_data, v_data)
+
+    class Attention2(Module):
+        def forward(self, q_data, k_data, v_data):
+            return F.scaled_dot_product_attention(q_data, k_data, v_data, is_causal=True)
+
+    input_info = [
+        ([32, 8, 128, 64], "float32"),
+        ([32, 8, 128, 64], "float32"),
+        ([32, 8, 128, 64], "float32"),
+    ]
+    verify_model(Attention1(), input_info)
+    verify_model(Attention2(), input_info)
+
+    class Attention3(Module):
+        def forward(self, q_data, k_data, v_data, mask):
+            return F.scaled_dot_product_attention(q_data, k_data, v_data, mask)
+
+    verify_model(
+        Attention3(),
+        [
+            ([32, 8, 128, 64], "float32"),
+            ([32, 8, 128, 64], "float32"),
+            ([32, 8, 128, 64], "float32"),
+            ([32, 8, 128, 128], "float32"),
+        ],
+    )
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/contrib/test_msc/test_translate_relay.py
+++ b/tests/python/contrib/test_msc/test_translate_relay.py
@@ -1,0 +1,1047 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-argument
+
+""" Test translate from relay. """
+
+import numpy as np
+import torch
+from torch import fx
+from torch.nn import Module
+
+import tvm.testing
+from tvm.relax.frontend.torch import from_fx
+from tvm.relay.frontend import from_pytorch
+from tvm.contrib.msc.core.ir import translate
+from tvm.contrib.msc.framework.tvm import codegen as tvm_codegen
+
+
+def _valid_target(target):
+    if not target:
+        return target
+    if target == "ignore":
+        return None
+    if target == "cuda" and not tvm.cuda().exist:
+        return None
+    if isinstance(target, str):
+        target = tvm.target.Target(target)
+    return target
+
+
+def _run_relax(relax_mod, target, datas):
+    relax_mod = tvm.relax.transform.LegalizeOps()(relax_mod)
+    with tvm.transform.PassContext(opt_level=3):
+        relax_exec = tvm.relax.build(relax_mod, target)
+        runnable = tvm.relax.VirtualMachine(relax_exec, tvm.cpu())
+    res = runnable["main"](*datas)
+    if isinstance(res, tvm.runtime.NDArray):
+        return [res.asnumpy()]
+    return [e.asnumpy() for e in res]
+
+
+def verify_model(torch_model, input_info, opt_config=None, codegen_config=None, build_target=None):
+    """Compare relax with relay"""
+
+    graph_model = fx.symbolic_trace(torch_model)
+    with torch.no_grad():
+        expected = from_fx(graph_model, input_info)
+    # graph from relay
+    datas = [np.random.rand(*i[0]).astype(i[1]) for i in input_info]
+    torch_datas = [torch.from_numpy(i) for i in datas]
+    scripted_model = torch.jit.trace(torch_model, tuple(torch_datas)).eval()  # type: ignore
+    shape_list = [("input" + str(idx), i) for idx, i in enumerate(input_info)]
+    relay_mod, params = from_pytorch(scripted_model, shape_list)
+    graph, weights = translate.from_relay(relay_mod, params, opt_config=opt_config)
+    # to relax
+    codegen_config = codegen_config or {}
+    codegen_config.update({"explicit_name": False, "from_relay": True})
+    mod = tvm_codegen.to_relax(graph, weights, codegen_config)
+    if build_target:
+        build_target = _valid_target(build_target)
+        if not build_target:
+            return
+        tvm_datas = [tvm.nd.array(i) for i in datas]
+        expected_res = _run_relax(expected, build_target, tvm_datas)
+        if not graph.get_inputs():
+            tvm_datas = []
+        res = _run_relax(mod, build_target, tvm_datas)
+        for exp_r, new_r in zip(expected_res, res):
+            tvm.testing.assert_allclose(exp_r, new_r, atol=1e-5, rtol=1e-5)
+    else:
+        tvm.ir.assert_structural_equal(mod, expected)
+
+
+def test_conv1d():
+    """test relay to relax for conv1d"""
+
+    class Conv1D1(Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv1d(3, 6, 7, bias=True)
+
+        def forward(self, data):
+            return self.conv(data)
+
+    class Conv1D2(Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv1d(3, 6, 7, bias=False)
+
+        def forward(self, data):
+            return self.conv(data)
+
+    input_info = [([1, 3, 10], "float32")]
+    verify_model(Conv1D1(), input_info)
+    verify_model(Conv1D2(), input_info)
+
+
+def test_conv2d():
+    """test relay to relax for conv2d"""
+
+    class Conv2D1(Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 6, 7, bias=True)
+
+        def forward(self, data):
+            return self.conv(data)
+
+    class Conv2D2(Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 6, 7, bias=False)
+
+        def forward(self, data):
+            return self.conv(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Conv2D1(), input_info)
+    verify_model(Conv2D2(), input_info)
+
+
+def test_linear():
+    """test relay to relax for linear"""
+
+    class Dense1(Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 7, bias=True)
+
+        def forward(self, data):
+            return self.linear(data)
+
+    class Dense2(Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(10, 7, bias=False)
+
+        def forward(self, data):
+            return self.linear(data)
+
+    class MatMul1(Module):
+        def forward(self, x, y):
+            return torch.matmul(x, y)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Dense1(), input_info)
+    verify_model(Dense2(), input_info)
+    verify_model(MatMul1(), [([10, 10], "float32"), ([10, 10], "float32")])
+
+
+def test_bmm():
+    """test relay to relax for bmm"""
+
+    class BMM(Module):
+        def forward(self, x, y):
+            return torch.bmm(x, y)
+
+    input_info = [((4, 128, 256), "float32"), ((4, 256, 512), "float32")]
+    verify_model(BMM(), input_info, opt_config={"opt_level": 3})
+
+
+def test_baddbmm():
+    """test relay to relax for baddbmm"""
+
+    class BAddBMM1(Module):
+        def forward(self, c, x, y):
+            return torch.baddbmm(c, x, y)
+
+    class BAddBMM2(Module):
+        def forward(self, c, x, y):
+            return torch.baddbmm(c, x, y, alpha=2, beta=0)
+
+    input_info = [
+        ((4, 128, 512), "float32"),
+        ((4, 128, 256), "float32"),
+        ((4, 256, 512), "float32"),
+    ]
+    verify_model(BAddBMM1(), input_info, opt_config={"opt_level": 3}, build_target="llvm")
+    verify_model(BAddBMM2(), input_info, opt_config={"opt_level": 3}, build_target="llvm")
+
+
+def test_relu():
+    """test relay to relax for relu"""
+
+    class ReLU(Module):
+        def __init__(self):
+            super().__init__()
+            self.relu = torch.nn.ReLU()
+
+        def forward(self, data):
+            return self.relu(data)
+
+    class ReLU1(Module):
+        def forward(self, data):
+            return torch.nn.functional.relu(data)
+
+    input_info = [([10, 10], "float32")]
+    verify_model(ReLU(), input_info)
+    verify_model(ReLU1(), input_info)
+
+
+def test_relu6():
+    """test relay to relax for relu6"""
+
+    class ReLU6(Module):
+        def __init__(self):
+            super().__init__()
+            self.relu6 = torch.nn.ReLU6()
+
+        def forward(self, data):
+            return self.relu6(data)
+
+    input_info = [([10, 10], "float32")]
+    verify_model(ReLU6(), input_info)
+
+
+def test_maxpool2d():
+    """test relay to relax for maxpool2d"""
+
+    class MaxPool2d(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.MaxPool2d(kernel_size=[1, 1])
+
+        def forward(self, data):
+            return self.pool(data)
+
+    class MaxPool2d2(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.MaxPool2d(kernel_size=[2, 2], dilation=[2, 3])
+
+        def forward(self, data):
+            return self.pool(data)
+
+    class MaxPool2d3(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.MaxPool2d(kernel_size=[4, 4], padding=2, stride=2)
+
+        def forward(self, data):
+            return self.pool(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(MaxPool2d(), input_info)
+    verify_model(MaxPool2d2(), input_info)
+    verify_model(MaxPool2d3(), input_info)
+
+
+def test_avgpool2d():
+    """test relay to relax for avgpool2d"""
+
+    class AvgPool2d(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.AvgPool2d(kernel_size=[1, 1])
+
+        def forward(self, data):
+            return self.pool(data)
+
+    class AvgPool2d2(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.AvgPool2d(kernel_size=[4, 4], stride=2, padding=2, ceil_mode=True)
+
+        def forward(self, data):
+            return self.pool(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(AvgPool2d(), input_info)
+    verify_model(AvgPool2d2(), input_info)
+
+
+def test_adaptive_avgpool2d():
+    """test relay to relax for adaptive_avgpool2d"""
+
+    class AdaptiveAvgPool2d0(Module):
+        def __init__(self):
+            super().__init__()
+            self.pool = torch.nn.AdaptiveAvgPool2d([10, 10])
+
+        def forward(self, data):
+            return self.pool(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(AdaptiveAvgPool2d0(), input_info)
+
+
+def test_flatten():
+    """test relay to relax for flatten"""
+
+    class Flatten(Module):
+        def __init__(self):
+            super().__init__()
+            self.f = torch.nn.Flatten(2, -1)
+
+        def forward(self, data):
+            return self.f(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Flatten(), input_info, opt_config={"opt_level": 3}, build_target="llvm")
+    verify_model(
+        torch.nn.Flatten(2, -1), input_info, opt_config={"opt_level": 3}, build_target="llvm"
+    )
+
+
+def test_batchnorm2d():
+    """test relay to relax for batchnorm2d"""
+
+    class BatchNorm2d(Module):
+        def __init__(self):
+            super().__init__()
+            self.batchnorm = torch.nn.BatchNorm2d(3)
+
+        def forward(self, data):
+            return self.batchnorm(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(BatchNorm2d(), input_info, build_target="llvm")
+
+
+def test_embedding():
+    """test relay to relax for embedding"""
+
+    class Embedding(Module):
+        def __init__(self):
+            super().__init__()
+            self.embedding = torch.nn.Embedding(10, 3)
+
+        def forward(self, data):
+            return self.embedding(data)
+
+    verify_model(Embedding(), [([4], "int64")])
+    verify_model(Embedding(), [([4, 5], "int64")])
+
+
+def test_layernorm():
+    """test relay to relax for layernorm"""
+
+    class LayerNorm(Module):
+        def __init__(self):
+            super().__init__()
+            self.layernorm = torch.nn.LayerNorm(10)
+
+        def forward(self, data):
+            return self.layernorm(data)
+
+    input_info = [([1, 10, 10], "float32")]
+    verify_model(LayerNorm(), input_info)
+
+
+def test_functional_layernorm():
+    """test relay to relax for functional_layernorm"""
+
+    class LayerNorm(Module):
+        def __init__(self, shape):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(shape))
+            self.bias = torch.nn.Parameter(torch.zeros(shape))
+
+        def forward(self, data):
+            return torch.nn.functional.layer_norm(
+                data, self.weight.shape, self.weight, self.bias, 1e-5
+            )
+
+    input_info = [([1, 10, 10], "float32")]
+    verify_model(LayerNorm((10)), input_info)
+
+
+def test_cross_entropy():
+    """test relay to relax for cross_entropy"""
+
+    class CrossEntropy1(Module):
+        def __init__(self):
+            super().__init__()
+            self.loss = torch.nn.CrossEntropyLoss()
+
+        def forward(self, logits, targets):
+            return self.loss(logits, targets)
+
+    class CrossEntropy3(Module):
+        def __init__(self):
+            super().__init__()
+            self.loss = torch.nn.CrossEntropyLoss(ignore_index=1, reduction="sum")
+
+        def forward(self, logits, targets):
+            return self.loss(logits, targets)
+
+    input_info = [([3, 2], "float32"), ([3], "int64")]
+    verify_model(CrossEntropy1(), input_info, opt_config={"opt_level": 3}, build_target="llvm")
+    verify_model(CrossEntropy3(), input_info, opt_config={"opt_level": 3}, build_target="llvm")
+
+
+def test_functional_cross_entropy():
+    """test relay to relax for functional_cross_entropy"""
+
+    class CrossEntropy(Module):
+        def forward(self, logits, targets):
+            return torch.nn.functional.cross_entropy(logits, targets)
+
+    input_info = [([3, 10], "float32"), ([3], "int64")]
+    verify_model(CrossEntropy(), input_info, opt_config={"opt_level": 3}, build_target="llvm")
+
+
+def test_silu():
+    """test relay to relax for silu"""
+
+    class SiLU(Module):
+        def __init__(self):
+            super().__init__()
+            self.silu = torch.nn.SiLU()
+
+        def forward(self, data):
+            return self.silu(data)
+
+    class SiLU2(Module):
+        def forward(self, data):
+            return torch.nn.functional.silu(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(SiLU(), input_info, build_target="llvm")
+    verify_model(SiLU2(), input_info, build_target="llvm")
+
+
+def test_groupnorm():
+    """test relay to relax for groupnorm"""
+
+    class GroupNorm(Module):
+        def __init__(self):
+            super().__init__()
+            self.groupnorm = torch.nn.GroupNorm(3, 3)
+
+        def forward(self, data):
+            return self.groupnorm(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(GroupNorm(), input_info)
+
+
+def test_softmax():
+    """test relay to relax for softmax"""
+
+    class Softmax(Module):
+        def __init__(self):
+            super().__init__()
+            self.softmax = torch.nn.Softmax(dim=1)
+
+        def forward(self, data):
+            return self.softmax(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Softmax(), input_info)
+
+
+def test_binary():
+    """test relay to relax for binary"""
+
+    input_info1 = [([1, 3, 10, 10], "float32"), ([1, 3, 10, 10], "float32")]
+    input_info2 = [([1, 3, 10, 10], "float32")]
+
+    # Add
+    class Add1(Module):
+        def forward(self, lhs, rhs):
+            return lhs + rhs
+
+    class Add2(Module):
+        def forward(self, lhs):
+            return lhs + 1.0
+
+    verify_model(Add1(), input_info1, opt_config={"opt_level": 3})
+    verify_model(Add2(), input_info2, opt_config={"opt_level": 3})
+
+    # Sub
+    class Sub1(Module):
+        def forward(self, lhs, rhs):
+            return lhs - rhs
+
+    class Sub2(Module):
+        def forward(self, lhs):
+            return lhs - 1.0
+
+    verify_model(Sub1(), input_info1, opt_config={"opt_level": 3})
+    verify_model(Sub2(), input_info2, opt_config={"opt_level": 3})
+
+    # Mul
+    class Mul1(Module):
+        def forward(self, lhs, rhs):
+            return lhs * rhs
+
+    class Mul2(Module):
+        def forward(self, lhs):
+            return lhs * 1.0
+
+    verify_model(Mul1(), input_info1, opt_config={"opt_level": 3})
+    verify_model(Mul2(), input_info2)
+
+    # True div
+    class TrueDiv1(Module):
+        def forward(self, lhs, rhs):
+            return lhs / rhs
+
+    class TrueDiv2(Module):
+        def forward(self, lhs):
+            return lhs / 1.0
+
+    verify_model(TrueDiv1(), input_info1, opt_config={"opt_level": 3})
+    verify_model(TrueDiv2(), input_info2)
+
+    # Floor div
+    class FloorDiv1(Module):
+        def forward(self, lhs, rhs):
+            return lhs // rhs
+
+    class FloorDiv2(Module):
+        def forward(self, lhs):
+            return lhs // 1.0
+
+    verify_model(FloorDiv1(), input_info1, opt_config={"opt_level": 3})
+    verify_model(FloorDiv2(), input_info2, opt_config={"opt_level": 3})
+
+    # Power
+    class Power1(Module):
+        def forward(self, lhs, rhs):
+            return lhs**rhs
+
+    class Power2(Module):
+        def forward(self, lhs):
+            return lhs**1.0
+
+    verify_model(Power1(), input_info1, opt_config={"opt_level": 3})
+    verify_model(Power2(), input_info2, opt_config={"opt_level": 3})
+
+    # LT
+    class LT1(Module):
+        def forward(self, lhs, rhs):
+            return lhs < rhs
+
+    class LT2(Module):
+        def forward(self, lhs):
+            return lhs < 1.0
+
+    verify_model(LT1(), input_info1, opt_config={"opt_level": 3})
+    verify_model(LT2(), input_info2, opt_config={"opt_level": 3})
+
+
+def test_squeeze():
+    """test relay to relax for squeeze"""
+
+    class Squeeze1(Module):
+        def forward(self, data):
+            return data.squeeze(1)
+
+    class Squeeze2(Module):
+        def forward(self, data):
+            return data.squeeze()
+
+    input_info = [([3, 1, 4, 1], "float32")]
+    verify_model(Squeeze1(), input_info)
+    verify_model(Squeeze2(), input_info)
+
+
+def test_unsqueeze():
+    """test relay to relax for unsqueeze"""
+
+    class Unsqueeze1(Module):
+        def forward(self, data):
+            return data.unsqueeze(1)
+
+    class Unsqueeze2(Module):
+        def forward(self, data):
+            return data.unsqueeze(-1)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Unsqueeze1(), input_info)
+    verify_model(Unsqueeze2(), input_info)
+
+
+def test_getitem():
+    """test relay to relax for getitem"""
+
+    class Slice1(Module):
+        def forward(self, x):
+            return x[0, 1::2, :, :3]
+
+    class Slice2(Module):
+        def forward(self, x):
+            return x[:, None, None, :, None]
+
+    verify_model(Slice1(), [([1, 3, 10, 10], "float32")], build_target="ignore")
+    verify_model(Slice2(), [([8, 16], "float32")], build_target="llvm")
+
+
+def test_unary():
+    """test relay to relax for unary"""
+
+    input_info = [([1, 3, 10, 10], "float32")]
+
+    # sin
+    class Sin(Module):
+        def forward(self, data):
+            return torch.sin(data)
+
+    verify_model(Sin(), input_info)
+
+    # cos
+    class Cos(Module):
+        def forward(self, data):
+            return torch.cos(data)
+
+    verify_model(Cos(), input_info)
+
+    # exp
+    class Exp(Module):
+        def forward(self, data):
+            return torch.exp(data)
+
+    verify_model(Exp(), input_info)
+
+    # sqrt
+    class Sqrt(Module):
+        def forward(self, data):
+            return torch.sqrt(data)
+
+    verify_model(Sqrt(), input_info)
+
+    # sigmoid
+    class Sigmoid(Module):
+        def forward(self, data):
+            return torch.sigmoid(data)
+
+    verify_model(Sigmoid(), input_info)
+
+    # round
+    class Round(Module):
+        def forward(self, data):
+            return torch.round(data)
+
+    verify_model(Round(), input_info)
+
+
+def test_gelu():
+    """test relay to relax for gelu"""
+
+    class Gelu(Module):
+        def forward(self, data):
+            return torch.nn.functional.gelu(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Gelu(), input_info)
+
+
+def test_tanh():
+    """test relay to relax for tanh"""
+
+    class Tanh(Module):
+        def forward(self, data):
+            return torch.tanh(data)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Tanh(), input_info)
+
+
+def test_clamp():
+    """test relay to relax for clamp"""
+
+    class Clamp(Module):
+        def forward(self, data):
+            return torch.clamp(data, min=0.1, max=0.5)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Clamp(), input_info)
+
+
+def test_interpolate():
+    """test relay to relax for interpolate"""
+
+    class Interpolate(Module):
+        def forward(self, data):
+            return torch.nn.functional.interpolate(data, (5, 5))
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Interpolate(), input_info, build_target="llvm")
+
+
+def test_addmm():
+    """test relay to relax for addmm"""
+
+    class Addmm(Module):
+        def forward(self, x_1, x_2, x_3):
+            return torch.addmm(x_1, x_2, x_3)
+
+    input_info = [
+        ([10, 10], "float32"),
+        ([10, 10], "float32"),
+        ([10, 10], "float32"),
+    ]
+    verify_model(Addmm(), input_info, build_target="llvm")
+
+
+def test_split():
+    """test relay to relax for split"""
+
+    class Split(Module):
+        def forward(self, data):
+            return torch.split(data, 1, dim=1)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Split(), input_info, build_target="llvm")
+
+
+def test_cumsum():
+    """test relay to relax for cumsum"""
+
+    class Cumsum(Module):
+        def forward(self, data):
+            return torch.cumsum(data, dim=1, dtype=torch.int32)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Cumsum(), input_info)
+
+
+def test_chunk():
+    """test relay to relax for chunk"""
+
+    class Chunk(Module):
+        def forward(self, data):
+            return torch.chunk(data, 3, dim=1)
+
+    input_info = [([1, 3, 10, 10], "float32")]
+    verify_model(Chunk(), input_info, build_target="llvm")
+
+
+def test_inplace_fill():
+    """test relay to relax for inplace_fill"""
+
+    class InplaceFill(Module):
+        def forward(self, data):
+            data.fill_(1.5)
+            return data
+
+    verify_model(InplaceFill(), [([10, 10], "float32")], build_target="llvm")
+
+
+def test_arange():
+    """test relay to relax for arange"""
+
+    class Arange(Module):
+        def forward(self, data):
+            return torch.arange(0, 20, dtype=torch.int32)
+
+    verify_model(
+        Arange(), [([10, 10], "float32")], opt_config={"opt_level": 3}, build_target="llvm"
+    )
+
+
+def test_empty():
+    """test relay to relax for empty"""
+
+    class Empty(Module):
+        def forward(self, data):
+            return torch.empty((10, 10), dtype=torch.float32)
+
+    verify_model(
+        Empty(), [([10, 10], "float32")], opt_config={"opt_level": 3}, build_target="ignore"
+    )
+
+
+def test_tensor():
+    """test relay to relax for tensor"""
+
+    class Empty1(Module):
+        def forward(self, data):
+            return torch.tensor(3, dtype=torch.float32)
+
+    class Empty2(Module):
+        def forward(self, data):
+            return torch.tensor(3)
+
+    verify_model(Empty1(), [([10, 10], "float32")], build_target="llvm")
+    verify_model(Empty2(), [([10, 10], "float32")], build_target="llvm")
+
+
+def test_tril():
+    """test relay to relax for tril"""
+
+    class Tril(Module):
+        def forward(self, data):
+            return torch.tril(data, 1)
+
+    class InplaceTril(Module):
+        def forward(self, data):
+            data.tril_(1)
+            return data
+
+    input_info = [([10, 10], "float32")]
+    verify_model(Tril(), input_info)
+    verify_model(InplaceTril(), input_info)
+
+
+def test_triu():
+    """test relay to relax for triu"""
+
+    class Triu(Module):
+        def forward(self, data):
+            return torch.triu(data, 1)
+
+    class InplaceTriu(Module):
+        def forward(self, data):
+            data.triu_(1)
+            return data
+
+    input_info = [([10, 10], "float32")]
+    verify_model(Triu(), input_info)
+    verify_model(InplaceTriu(), input_info)
+
+
+def test_new_ones():
+    """test relay to relax for new_ones"""
+
+    class NewOnes(Module):
+        def forward(self, x):
+            return x.new_ones(1, 2, 3)
+
+    input_info = [([1, 2, 3], "float32")]
+    verify_model(NewOnes(), input_info, build_target="llvm")
+
+
+def test_expand():
+    """test relay to relax for expand"""
+
+    class Expand(Module):
+        def forward(self, x):
+            return x.expand(4, 2, 3, 4)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Expand(), input_info, build_target="llvm")
+
+
+def test_reduce():
+    """test relay to relax for reduce"""
+
+    # sum
+    class Sum(Module):
+        def forward(self, x):
+            return torch.sum(x, (2, 1))
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Sum(), input_info)
+
+
+def test_datatype():
+    """test relay to relax for datatype"""
+
+    input_info = [([1, 2, 3, 4], "float32")]
+
+    # float
+    class ToFloat(Module):
+        def forward(self, x):
+            return x.float()
+
+    verify_model(ToFloat(), input_info, build_target="llvm")
+
+    # half
+    class ToHalf(Module):
+        def forward(self, x):
+            return x.half()
+
+    verify_model(ToHalf(), input_info)
+
+    # type
+    class Type(Module):
+        def forward(self, x):
+            return x.type(torch.float32)
+
+    verify_model(Type(), input_info, build_target="llvm")
+
+
+def test_permute():
+    """test relay to relax for permute"""
+
+    class Permute(Module):
+        def forward(self, x):
+            return x.permute(0, 3, 2, 1)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Permute(), input_info)
+
+
+def test_reshape():
+    """test relay to relax for reshape"""
+
+    class Reshape(Module):
+        def forward(self, x):
+            return x.reshape(2, 12)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Reshape(), input_info)
+
+
+def test_transpose():
+    """test relay to relax for transpose"""
+
+    class Transpose(Module):
+        def forward(self, x):
+            return x.transpose(1, 3)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(Transpose(), input_info)
+
+
+def test_view():
+    """test relay to relax for view"""
+
+    class View(Module):
+        def forward(self, x):
+            return x.view(2, 12)
+
+    input_info = [([1, 2, 3, 4], "float32")]
+    verify_model(View(), input_info)
+
+
+def test_keep_params():
+    """test relay to relax for keep_params"""
+
+    class Conv2D1(Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 6, 7, bias=True)
+
+        def forward(self, data):
+            return self.conv(data)
+
+    verify_model(Conv2D1(), [([1, 3, 10, 10], "float32")])
+
+
+def test_unwrap_unit_return_tuple():
+    """test relay to relax for unwrap_unit_return_tuple"""
+
+    class Identity(Module):
+        def forward(self, x):
+            return (x,)
+
+    verify_model(Identity(), [([256, 256], "float32")], build_target="llvm")
+
+
+def test_no_bind_return_tuple():
+    """test relay to relax for no_bind_return_tuple"""
+
+    class Identity(Module):
+        def forward(self, x, y):
+            return (x, y)
+
+    input_info = [([256, 256], "float32"), ([256, 256], "float32")]
+    verify_model(Identity(), input_info)
+
+
+def test_argmax():
+    """test relay to relax for argmax"""
+
+    class Argmax1(Module):
+        def forward(self, data):
+            return torch.argmax(data, dim=-1)
+
+    class Argmax2(Module):
+        def forward(self, data):
+            return torch.argmax(data, dim=-1, keepdim=True)
+
+    verify_model(Argmax1(), [([256, 256], "float32")])
+    verify_model(Argmax2(), [([256, 256], "float32")])
+
+
+def test_to():
+    """test relay to relax for to"""
+
+    class To1(Module):
+        def forward(self, data):
+            return data.to(torch.float16)
+
+    class To2(Module):
+        def forward(self, data):
+            return data.to("cpu")
+
+    verify_model(To1(), [([256, 256], "float32")])
+    verify_model(To2(), [([256, 256], "float32")])
+
+
+def test_mean():
+    """test relay to relax for mean"""
+
+    class Mean(Module):
+        def forward(self, data):
+            return data.mean(-1)
+
+    class MeanKeepDim(Module):
+        def forward(self, data):
+            return data.mean(-1, keepdim=True)
+
+    verify_model(Mean(), [([256, 256], "float32")])
+    verify_model(MeanKeepDim(), [([256, 256], "float32")])
+
+
+def test_rsqrt():
+    """test relay to relax for rsqrt"""
+
+    class Rsqrt(Module):
+        def forward(self, data):
+            return torch.rsqrt(data)
+
+    verify_model(Rsqrt(), [([256, 256], "float32")])
+
+
+def test_neg():
+    """test relay to relax for neg"""
+
+    class Neg(Module):
+        def forward(self, data):
+            return -data
+
+    verify_model(Neg(), [([256, 256], "float32")])
+
+
+def test_max():
+    """test relay to relax for max"""
+
+    class Max(Module):
+        def forward(self, x, y):
+            return torch.max(x, y)
+
+    verify_model(Max(), [([256, 256], "float32"), ([256, 256], "float32")])
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This is a pull request for MSC(Multi-System Compile)
RFC: https://discuss.tvm.apache.org/t/rfc-unity-msc-introduction-to-multi-system-compiler/15251/5
Tracking issue: https://github.com/apache/tvm/issues/15233

This is the last part of Milestone 0: Codegen and Translation test

To limit each PR in reviewable size, the Milestone 0 will be split into 5 steps:
M0.1: Passes for set name and layout for expressions (src/contrib/msc/transform)
M0.2: MSCGraph core (src/contrib/msc/core/ir/graph && python/tvm/contrib/msc/core/ir/graph)
M0.3: MSCGraph Builder (src/contrib/msc/core/ir/graph_builder)
M0.4: Codegen (src/contrib/msc/core/codegen, src/contrib/msc/framework/tvm/codegen)
M0.5: Translation test (relax/relay test && related helper modules in python)

CodeGen is used to translate MSCGraph to relax. To use the relay-based features, I also enable the relay -> MSCGraph -> relax process. In this way relay can be translated to relax without loss information. This maybe useful for developers who build their features base on relay, for example using the tensorflow or mxnet frontend with relax.

As relax will be used as the main IR for tvm, support for relay in MSC is very limited. The compression algorithms will be implemented based on relax.

cc @Hzfengsy 