### PR TITLE
[Relay][TOPI] Remove input padding for arm_cpu conv2d int8 native schedule in Legalize pass

### DIFF
--- a/python/tvm/topi/arm_cpu/conv2d_alter_op.py
+++ b/python/tvm/topi/arm_cpu/conv2d_alter_op.py
@@ -517,7 +517,8 @@ def _conv2d_legalize(attrs, inputs, arg_types):
         target,
     )
     workload = autotvm.task.get_workload(outs)
-    topi_tmpl = workload[0]
+    if workload is not None:
+        topi_tmpl = workload[0]
 
     # ARM vector instructions operate on the same dtype for data and kernel, we
     # provide those here and conv2d_alter_int8_common will convert to the

--- a/python/tvm/topi/arm_cpu/conv2d_alter_op.py
+++ b/python/tvm/topi/arm_cpu/conv2d_alter_op.py
@@ -522,7 +522,7 @@ def _conv2d_legalize(attrs, inputs, arg_types):
     # ARM vector instructions operate on the same dtype for data and kernel, we
     # provide those here and conv2d_alter_int8_common will convert to the
     # correct datatype.
-    if is_int8_hw_support(data_dtype, kernel_dtype):
+    if is_int8_hw_support(kernel_dtype, kernel_dtype):
         # ARM intrinsics need the datatypes of data and kernel to be the same
         if (
             attrs["data_layout"] == "NHWC"

--- a/python/tvm/topi/arm_cpu/conv2d_alter_op.py
+++ b/python/tvm/topi/arm_cpu/conv2d_alter_op.py
@@ -25,6 +25,7 @@ import tvm
 from tvm import te
 from tvm import relay
 from tvm import autotvm
+from tvm.target.target import Target
 
 from ..nn import conv2d_alter_layout, conv2d_legalize
 from ..utils import get_const_tuple
@@ -503,12 +504,44 @@ def _conv2d_legalize(attrs, inputs, arg_types):
     # Collect the input exprs.
     data, kernel = inputs
 
+    # Determine conv2d implementation
+    target = Target.current(allow_none=False)
+    _, outs = relay.backend.te_compiler.select_implementation(
+        relay.op.get("nn.conv2d"),
+        attrs,
+        [
+            te.placeholder(data_tensor.shape, data_dtype),
+            te.placeholder(kernel_tensor.shape, kernel_dtype),
+        ],
+        output_tensor,
+        target,
+    )
+    workload = autotvm.task.get_workload(outs)
+    topi_tmpl = workload[0]
+
     # ARM vector instructions operate on the same dtype for data and kernel, we
     # provide those here and conv2d_alter_int8_common will convert to the
     # correct datatype.
-    if is_int8_hw_support(kernel_dtype, kernel_dtype):
+    if is_int8_hw_support(data_dtype, kernel_dtype):
         # ARM intrinsics need the datatypes of data and kernel to be the same
+        if (
+            attrs["data_layout"] == "NHWC"
+            and attrs["kernel_layout"] == "HWIO"
+            and topi_tmpl == "conv2d_NHWC_quantized_native.arm_cpu"
+        ):
+            in_channel_vector_length = data_tensor.shape[3]
+        else:
+            in_channel_vector_length = 8
+
         return conv2d_alter_int8_common(
-            data, data_tensor, kernel, kernel_tensor, output_tensor, attrs, kernel_dtype, 8, 8
+            data,
+            data_tensor,
+            kernel,
+            kernel_tensor,
+            output_tensor,
+            attrs,
+            kernel_dtype,
+            in_channel_vector_length,
+            8,
         )
     return None

--- a/python/tvm/topi/arm_cpu/conv2d_gemm.py
+++ b/python/tvm/topi/arm_cpu/conv2d_gemm.py
@@ -166,8 +166,10 @@ def compute_conv2d_gemm_without_weight_transform(
     pad_before = (0, 0, 0)
     pad_after = (0, pad_M, pad_K)
 
-    if pad_M != 0 or pad_K != 0:
-        A = nn.pad(A, pad_before=pad_before, pad_after=pad_after, name="A_padded")
+    if pad_K != 0:
+        A = nn.pad(A, pad_before=pad_before, pad_after=pad_after, name="A_padded_K")
+    elif pad_M != 0:
+        A = nn.pad(A, pad_before=pad_before, pad_after=pad_after, name="A_padded_M")
 
     idxm = tvm.tir.indexmod
     k = te.reduce_axis((0, K_padded), "k")
@@ -316,7 +318,7 @@ def schedule_conv2d_gemm_interleaved(cfg, s, out, final_out):
 
     # Input transform
     A_interleaved_input = A_interleaved.op.input_tensors[0]
-    if A_interleaved_input.op.name == "A_padded":
+    if A_interleaved_input.op.name == "A_padded_K" or A_interleaved_input.op.name == "A_padded_M":
         s[A_interleaved_input].compute_at(s[A_interleaved], A_interleaved.op.axis[3])
         s[A_interleaved_input].vectorize(A_interleaved_input.op.axis[2])
         s[A_interleaved_input].compute_inline()
@@ -326,7 +328,12 @@ def schedule_conv2d_gemm_interleaved(cfg, s, out, final_out):
 
     b, m, n = data_im2col.op.axis
     if data_im2col.op.name == "data_im2col":
-        n_outer, n_inner = s[data_im2col].split(n, 16)
+        n_size = data_im2col.shape[2]
+        if n_size % 16 == 0:
+            split_factor = 16
+        else:
+            split_factor = 8
+        n_outer, n_inner = s[data_im2col].split(n, split_factor)
         s[data_im2col].unroll(n_outer)
         s[data_im2col].vectorize(n_inner)
         b_m_fused = s[data_im2col].fuse(b, m)
@@ -419,7 +426,7 @@ def schedule_conv2d_gemm_native(cfg, s, out, final_out):
     s[C].parallel(x_outer)
 
     # Input transform
-    if A.op.name == "A_padded":
+    if A.op.name == "A_padded_K" or A.op.name == "A_padded_M":
         padding_A = True
         data_im2col = A.op.input_tensors[0]
     else:
@@ -428,12 +435,29 @@ def schedule_conv2d_gemm_native(cfg, s, out, final_out):
 
     b, m, n = data_im2col.op.axis
     if data_im2col.op.name == "data_im2col":
-        n_outer, n_inner = s[data_im2col].split(n, 16)
+        if A.op.name == "A_padded_K":
+            s[data_im2col].compute_at(s[A], A.op.axis[1])
+            s[A].parallel(A.op.axis[1])
+        elif A.op.name == "A_padded_M":
+            s[data_im2col].parallel(m)
+            s[A].parallel(A.op.axis[1])
+        else:
+            s[data_im2col].parallel(m)
+
+        split_factor = 16
+        n_size = data_im2col.shape[2]
+        if n_size % split_factor != 0:
+            # Split by kernel area (KH * KW) to ensure proper vectorization
+            ic = data_im2col.op.input_tensors[0].shape[3]
+            split_factor = n_size // ic
+
+        n_outer, n_inner = s[data_im2col].split(n, split_factor)
         s[data_im2col].unroll(n_outer)
         s[data_im2col].vectorize(n_inner)
-        s[data_im2col].parallel(m)
     elif padding_A:
         s[data_im2col].compute_inline()
+        _, n_inner = s[A].split(A.op.axis[2], 16)
+        s[A].vectorize(n_inner)
         s[A].compute_at(s[C], x_inner)
     else:
         s[data_im2col].compute_at(s[C], x_inner)


### PR DESCRIPTION
The Legalize pass was unnecessarily padding the input channels for conv2d int8 native implementations. Since the conv2d schedule itself can add padding more efficiently, I skipped padding during the pass and further optimised the schedule to deal with it.  
I also added a test to check whether or not the Legalize pass pads the conv2d input data.  

The benchmark results of a single int8 conv2d operation where input padding along the K axis is necessary, with input = (1 x 224 x 224 x 3), filter = (16 x 3 x 3 x 3), output = (1 x 112 x 112 x 16), tested for the following target `"llvm --device=arm_cpu --mtriple=aarch64-linux-gnu -mattr=+v8.2a,+dotprod"` , before and after the changes, is given below:

|  Before (ms) | After (ms) | Speedup (%) |
|-------------|------------|-------------|
| 0.5186      | 0.0663     | 87.22       |