### PR TITLE
Add output_data_sec section in corstone300.ld

### DIFF
--- a/apps/microtvm/ethosu/corstone300.ld
+++ b/apps/microtvm/ethosu/corstone300.ld
@@ -138,6 +138,7 @@ SECTIONS
   {
     . = ALIGN(16);
     *(ethosu_scratch)
+    *(output_data_sec)
     . = ALIGN (16);
     *(.rodata.tvm)
     . = ALIGN (16);


### PR DESCRIPTION
Fixed output_data_sec section was missing in the corstone300.ld for Ethos-U.

See more detail: https://github.com/apache/tvm/issues/15643