### PR TITLE
[Runtime] Make `export_library` parameters after `file_name` keyword-only

### DIFF
--- a/apps/android_camera/models/prepare_model.py
+++ b/apps/android_camera/models/prepare_model.py
@@ -100,7 +100,7 @@ def main(model_str, output_path):
     with tvm.transform.PassContext(opt_level=3):
         graph, lib, params = relay.build(net, tvm.target.Target(target, target_host), params=params)
     print("dumping lib...")
-    lib.export_library(output_path_str + "/" + "deploy_lib_cpu.so", ndk.create_shared)
+    lib.export_library(output_path_str + "/" + "deploy_lib_cpu.so", fcompile=ndk.create_shared)
     print("dumping graph...")
     with open(output_path_str + "/" + "deploy_graph.json", "w") as f:
         f.write(graph)

--- a/apps/android_rpc/tests/android_rpc_test.py
+++ b/apps/android_rpc/tests/android_rpc_test.py
@@ -64,7 +64,7 @@ def test_rpc_module():
     s[B].pragma(xi, "parallel_barrier_when_finish")
     f = tvm.build(s, [A, B], target, name="myadd_cpu")
     path_dso_cpu = temp.relpath("cpu_lib.so")
-    f.export_library(path_dso_cpu, ndk.create_shared)
+    f.export_library(path_dso_cpu, fcompile=ndk.create_shared)
 
     # Execute the portable graph on cpu target
     print("Run CPU test ...")
@@ -88,7 +88,7 @@ def test_rpc_module():
         # If we don't want to do metal and only use cpu, just set target to be target
         f = tvm.build(s, [A, B], tvm.target.Target("opencl", host=target), name="myadd")
         path_dso_cl = temp.relpath("dev_lib_cl.so")
-        f.export_library(path_dso_cl, ndk.create_shared)
+        f.export_library(path_dso_cl, fcompile=ndk.create_shared)
 
         print("Run GPU(OpenCL Flavor) test ...")
         dev = remote.cl(0)
@@ -111,7 +111,7 @@ def test_rpc_module():
         # If we don't want to do metal and only use cpu, just set target to be target
         f = tvm.build(s, [A, B], tvm.target.Target("vulkan", host=target), name="myadd")
         path_dso_vulkan = temp.relpath("dev_lib_vulkan.so")
-        f.export_library(path_dso_vulkan, ndk.create_shared)
+        f.export_library(path_dso_vulkan, fcompile=ndk.create_shared)
 
         print("Run GPU(Vulkan Flavor) test ...")
         dev = remote.vulkan(0)

--- a/apps/benchmark/adreno/adreno_gpu_bench_clml.py
+++ b/apps/benchmark/adreno/adreno_gpu_bench_clml.py
@@ -224,7 +224,7 @@ def evaluate_network(network, target, target_host, dtype, repeat):
     tmp = tempdir()
 
     filename = "%s.so" % network
-    lib.export_library(tmp.relpath(filename), ndk.create_shared)
+    lib.export_library(tmp.relpath(filename), fcompile=ndk.create_shared)
 
     # upload library and params
     print_progress("%-20s uploading..." % network)

--- a/apps/benchmark/adreno/adreno_gpu_bench_texture.py
+++ b/apps/benchmark/adreno/adreno_gpu_bench_texture.py
@@ -220,7 +220,7 @@ def evaluate_network(network, target, target_host, dtype, repeat):
     tmp = tempdir()
 
     filename = "%s.so" % network
-    lib.export_library(tmp.relpath(filename), ndk.create_shared)
+    lib.export_library(tmp.relpath(filename), fcompile=ndk.create_shared)
 
     # upload library and params
     print_progress("%-20s uploading..." % network)

--- a/apps/benchmark/arm_cpu_imagenet_bench.py
+++ b/apps/benchmark/arm_cpu_imagenet_bench.py
@@ -47,7 +47,7 @@ def evaluate_network(network, target, target_host, repeat):
         from tvm.contrib import ndk
 
         filename = "%s.so" % network
-        lib.export_library(tmp.relpath(filename), ndk.create_shared)
+        lib.export_library(tmp.relpath(filename), fcompile=ndk.create_shared)
     else:
         filename = "%s.tar" % network
         lib.export_library(tmp.relpath(filename))

--- a/apps/benchmark/mobile_gpu_imagenet_bench.py
+++ b/apps/benchmark/mobile_gpu_imagenet_bench.py
@@ -47,7 +47,7 @@ def evaluate_network(network, target, target_host, dtype, repeat):
         from tvm.contrib import ndk
 
         filename = "%s.so" % network
-        lib.export_library(tmp.relpath(filename), ndk.create_shared)
+        lib.export_library(tmp.relpath(filename), fcompile=ndk.create_shared)
     else:
         filename = "%s.tar" % network
         lib.export_library(tmp.relpath(filename))

--- a/apps/hexagon_launcher/README.md
+++ b/apps/hexagon_launcher/README.md
@@ -186,7 +186,7 @@ lowered = tvm.relay.build(
     executor=Executor("aot", {"unpacked-api": False, "interface-api": "packed"}),
 )
 
-lowered.export_library("model-aot.so", tvm.contrib.hexagon.link_shared)
+lowered.export_library("model-aot.so", fcompile=tvm.contrib.hexagon.link_shared)
 ```
 
 

--- a/apps/ios_rpc/tests/ios_rpc_mobilenet.py
+++ b/apps/ios_rpc/tests/ios_rpc_mobilenet.py
@@ -98,7 +98,7 @@ def test_mobilenet(host, port, key, mode):
                 mod, target=tvm.target.Target(target, host=target_host), params=params
             )
         path_dso = temp.relpath("deploy.dylib")
-        lib.export_library(path_dso, xcode.create_dylib, arch=arch, sdk=sdk)
+        lib.export_library(path_dso, fcompile=xcode.create_dylib, arch=arch, sdk=sdk)
 
         # connect to the proxy
         if mode == "tracker":

--- a/apps/ios_rpc/tests/ios_rpc_test.py
+++ b/apps/ios_rpc/tests/ios_rpc_test.py
@@ -58,7 +58,7 @@ def test_rpc_module(host, port, key, mode):
     # If we don't want to do metal and only use cpu, just set target to be target
     f = tvm.build(s, [A, B], tvm.target.Target("metal", host=target), name="myadd")
     path_dso1 = temp.relpath("dev_lib.dylib")
-    f.export_library(path_dso1, xcode.create_dylib, arch=arch, sdk=sdk)
+    f.export_library(path_dso1, fcompile=xcode.create_dylib, arch=arch, sdk=sdk)
 
     s = te.create_schedule(B.op)
     xo, xi = s[B].split(B.op.axis[0], factor=64)
@@ -67,7 +67,7 @@ def test_rpc_module(host, port, key, mode):
     s[B].pragma(xi, "parallel_barrier_when_finish")
     f = tvm.build(s, [A, B], target, name="myadd_cpu")
     path_dso2 = temp.relpath("cpu_lib.dylib")
-    f.export_library(path_dso2, xcode.create_dylib, arch=arch, sdk=sdk)
+    f.export_library(path_dso2, fcompile=xcode.create_dylib, arch=arch, sdk=sdk)
 
     # connect to the proxy
     if mode == "tracker":

--- a/apps/topi_recipe/gemm/android_gemm_square.py
+++ b/apps/topi_recipe/gemm/android_gemm_square.py
@@ -123,7 +123,7 @@ def test_gemm_gpu(N, times, bn, num_block, num_thread):
     f = tvm.build(s, [A, B, C], tvm.target.Target("opencl", host=target), name="gemm_gpu")
     temp = utils.tempdir()
     path_dso = temp.relpath("gemm_gpu.so")
-    f.export_library(path_dso, ndk.create_shared)
+    f.export_library(path_dso, fcompile=ndk.create_shared)
 
     # connect to the proxy
     remote = rpc.connect(proxy_host, proxy_port, key=key)

--- a/docs/how_to/deploy/android.rst
+++ b/docs/how_to/deploy/android.rst
@@ -27,7 +27,7 @@ The code below will save the compilation output which is required on android tar
 
 .. code:: python
 
-    lib.export_library("deploy_lib.so", ndk.create_shared)
+    lib.export_library("deploy_lib.so", fcompile=ndk.create_shared)
     with open("deploy_graph.json", "w") as fo:
         fo.write(graph.json())
     with open("deploy_param.params", "wb") as fo:

--- a/gallery/how_to/deploy_models/deploy_model_on_adreno.py
+++ b/gallery/how_to/deploy_models/deploy_model_on_adreno.py
@@ -420,7 +420,7 @@ temp = utils.tempdir()
 dso_binary = "dev_lib_cl.so"
 dso_binary_path = temp.relpath(dso_binary)
 fcompile = ndk.create_shared if not local_demo else None
-lib.export_library(dso_binary_path, fcompile)
+lib.export_library(dso_binary_path, fcompile=fcompile)
 remote_path = "/data/local/tmp/" + dso_binary
 remote.upload(dso_binary_path)
 rlib = remote.load_module(dso_binary)

--- a/gallery/how_to/deploy_models/deploy_model_on_android.py
+++ b/gallery/how_to/deploy_models/deploy_model_on_android.py
@@ -281,7 +281,7 @@ with tvm.transform.PassContext(opt_level=3):
 tmp = utils.tempdir()
 lib_fname = tmp.relpath("net.so")
 fcompile = ndk.create_shared if not local_demo else None
-lib.export_library(lib_fname, fcompile)
+lib.export_library(lib_fname, fcompile=fcompile)
 
 ######################################################################
 # Deploy the Model Remotely by RPC

--- a/gallery/how_to/tune_with_autoscheduler/tune_network_arm.py
+++ b/gallery/how_to/tune_with_autoscheduler/tune_network_arm.py
@@ -331,7 +331,7 @@ def tune_and_evaluate():
         from tvm.contrib import ndk
 
         filename = "net.so"
-        lib.export_library(tmp.relpath(filename), ndk.create_shared)
+        lib.export_library(tmp.relpath(filename), fcompile=ndk.create_shared)
     else:
         filename = "net.tar"
         lib.export_library(tmp.relpath(filename))

--- a/gallery/how_to/tune_with_autoscheduler/tune_network_mali.py
+++ b/gallery/how_to/tune_with_autoscheduler/tune_network_mali.py
@@ -255,7 +255,7 @@ def tune_and_evaluate():
     temp = utils.tempdir()
     filename = "deploy_lib.so"
     path_lib = temp.relpath(filename)
-    lib.export_library(path_lib, ndk.create_shared)
+    lib.export_library(path_lib, fcompile=ndk.create_shared)
     remote.upload(path_lib)
     loaded_lib = remote.load_module(filename)
     module = graph_executor.GraphModule(loaded_lib["default"](dev))

--- a/gallery/how_to/tune_with_autotvm/tune_relay_arm.py
+++ b/gallery/how_to/tune_with_autotvm/tune_relay_arm.py
@@ -357,7 +357,7 @@ def tune_and_evaluate(tuning_opt):
             from tvm.contrib import ndk
 
             filename = "net.so"
-            lib.export_library(tmp.relpath(filename), ndk.create_shared)
+            lib.export_library(tmp.relpath(filename), fcompile=ndk.create_shared)
         else:
             filename = "net.tar"
             lib.export_library(tmp.relpath(filename))

--- a/gallery/how_to/tune_with_autotvm/tune_relay_mobile_gpu.py
+++ b/gallery/how_to/tune_with_autotvm/tune_relay_mobile_gpu.py
@@ -356,7 +356,7 @@ def tune_and_evaluate(tuning_opt):
             from tvm.contrib import ndk
 
             filename = "net.so"
-            lib.export_library(tmp.relpath(filename), ndk.create_shared)
+            lib.export_library(tmp.relpath(filename), fcompile=ndk.create_shared)
         else:
             filename = "net.tar"
             lib.export_library(tmp.relpath(filename))

--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -631,7 +631,7 @@ def _local_build_worker(inp_serialized, build_func, verbose):
         try:
             with transform.PassContext().current():
                 func = build_module.build(sch, args, target=task.target)
-            func.export_library(filename, build_func)
+            func.export_library(filename, fcompile=build_func)
         # pylint: disable=broad-except
         except Exception:
             error_no = MeasureErrorNo.COMPILE_HOST

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -571,7 +571,7 @@ class _WrappedBuildFunc:
                     raise ImportError("Requires USE_MICRO")
                 micro.export_model_library_format(func, filename)
             else:
-                func.export_library(filename, self.build_func)
+                func.export_library(filename, fcompile=self.build_func)
         except Exception as e:  # pylint: disable=broad-except
             tb = traceback.format_exc()
             return BuildResult(None, None, (tb, e), time.time() - tic)

--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -235,12 +235,12 @@ def cross_compiler(
        # export using arm gcc
        mod = build_runtime_module()
        mod.export_library(path_dso,
-                          cc.cross_compiler("arm-linux-gnueabihf-gcc"))
+                          fcompile=cc.cross_compiler("arm-linux-gnueabihf-gcc"))
        # specialize ndk compilation options.
        specialized_ndk = cc.cross_compiler(
            ndk.create_shared,
            ["--sysroot=/path/to/sysroot", "-shared", "-fPIC", "-lm"])
-       mod.export_library(path_dso, specialized_ndk)
+       mod.export_library(path_dso, fcompile=specialized_ndk)
     """
     base_options = [] if options is None else options
     kwargs = {}

--- a/python/tvm/contrib/pipeline_executor_build.py
+++ b/python/tvm/contrib/pipeline_executor_build.py
@@ -146,7 +146,7 @@ def export_library(factory, directory_path):
         # Get the graph, lib, and parameters from GraphExecutorFactoryModule.
         lib = factory.pipeline_mods[lib_index]["lib"]
         # Export the lib, graph, and parameters to disk.
-        lib.export_library(mconfig["lib_name"], fcompile)
+        lib.export_library(mconfig["lib_name"], fcompile=fcompile)
         with open(mconfig["json_name"], "w") as file_handle:
             file_handle.write(lib.graph_json)
         with open(mconfig["params_name"], "wb") as file_handle:

--- a/python/tvm/driver/tvmc/model.py
+++ b/python/tvm/driver/tvmc/model.py
@@ -263,11 +263,12 @@ class TVMCModel(object):
         else:
             if not cross_options:
                 executor_factory.get_lib().export_library(
-                    path_lib, tvm.contrib.cc.cross_compiler(cross)
+                    path_lib, fcompile=tvm.contrib.cc.cross_compiler(cross)
                 )
             else:
                 executor_factory.get_lib().export_library(
-                    path_lib, tvm.contrib.cc.cross_compiler(cross, options=cross_options.split(" "))
+                    path_lib,
+                    fcompile=tvm.contrib.cc.cross_compiler(cross, options=cross_options.split(" ")),
                 )
         self.lib_path = path_lib
 

--- a/python/tvm/meta_schedule/builder/local_builder.py
+++ b/python/tvm/meta_schedule/builder/local_builder.py
@@ -278,5 +278,5 @@ def default_export(mod: Module) -> str:
     from tvm.contrib.tar import tar  # pylint: disable=import-outside-toplevel
 
     artifact_path = os.path.join(tempfile.mkdtemp(), "tvm_tmp_mod." + tar.output_format)
-    mod.export_library(artifact_path, tar)
+    mod.export_library(artifact_path, fcompile=tar)
     return artifact_path

--- a/python/tvm/meta_schedule/testing/custom_builder_runner.py
+++ b/python/tvm/meta_schedule/testing/custom_builder_runner.py
@@ -161,7 +161,7 @@ def run_module_via_rpc(
         filename = os.path.join(tmp_dir, "tvm_tmp_mod." + tar.output_format)
         if backend == "vm":
             code, lib = lib.save()
-        lib.export_library(filename, tar)
+        lib.export_library(filename, fcompile=tar)
         session = rpc_config.connect_server()
         session.upload(filename)
         _, filename = os.path.split(filename)

--- a/python/tvm/relay/backend/executor_factory.py
+++ b/python/tvm/relay/backend/executor_factory.py
@@ -142,7 +142,7 @@ class AOTExecutorFactoryModule(ExecutorFactoryModule):
         return self.lib
 
     def export_library(self, file_name, fcompile=None, addons=None, **kwargs):
-        return self.module.export_library(file_name, fcompile, addons, **kwargs)
+        return self.module.export_library(file_name, fcompile=fcompile, addons=addons, **kwargs)
 
 
 class GraphExecutorFactoryModule(ExecutorFactoryModule):
@@ -200,7 +200,7 @@ class GraphExecutorFactoryModule(ExecutorFactoryModule):
         self.function_metadata = function_metadata
 
     def export_library(self, file_name, fcompile=None, addons=None, **kwargs):
-        return self.module.export_library(file_name, fcompile, addons, **kwargs)
+        return self.module.export_library(file_name, fcompile=fcompile, addons=addons, **kwargs)
 
     def get_devices(self):
         return []

--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -438,7 +438,9 @@ class Module(object):
     def _collect_dso_modules(self):
         return self._collect_from_import_tree(lambda m: m.is_dso_exportable)
 
-    def export_library(self, file_name, fcompile=None, addons=None, workspace_dir=None, **kwargs):
+    def export_library(
+        self, file_name, *, fcompile=None, addons=None, workspace_dir=None, **kwargs
+    ):
         """
         Export the module and all imported modules into a single device library.
 

--- a/python/tvm/testing/runner.py
+++ b/python/tvm/testing/runner.py
@@ -61,7 +61,7 @@ def _normalize_export_func(export_func, output_format) -> Tuple[Callable, str]:
     from tvm.contrib import ndk, tar
 
     def export_with(func):
-        return lambda mod, path: mod.export_library(path, func)
+        return lambda mod, path: mod.export_library(path, fcompile=func)
 
     if export_func == "tar":
         export_func = export_with(tar.tar)

--- a/tests/python/relay/opencl_texture/utils/adreno_utils.py
+++ b/tests/python/relay/opencl_texture/utils/adreno_utils.py
@@ -103,7 +103,7 @@ def build_run_compare(
         dso_binary = "dev_lib_cl.so"
         dso_binary_path = temp.relpath(dso_binary)
         ctx = remote.cl(0)
-        lib.export_library(dso_binary_path, ndk.create_shared)
+        lib.export_library(dso_binary_path, fcompile=ndk.create_shared)
         remote.upload(dso_binary_path)
         rlib = remote.load_module(dso_binary)
         m = graph_runtime.create(graph, rlib, ctx)
@@ -183,7 +183,7 @@ def build_run_compare_vm(
         dso_binary = "dev_lib_cl.so"
         dso_binary_path = temp.relpath(dso_binary)
         dev = remote.cl(0)
-        vmc.mod.export_library(dso_binary_path, ndk.create_shared)
+        vmc.mod.export_library(dso_binary_path, fcompile=ndk.create_shared)
         remote.upload(dso_binary_path)
         rlib = remote.load_module(dso_binary)
         vm = VirtualMachine(rlib, dev, "naive")

--- a/tests/python/unittest/test_runtime_module_load.py
+++ b/tests/python/unittest/test_runtime_module_load.py
@@ -125,7 +125,7 @@ def test_device_module_dump():
 
         path_dso = temp.relpath("dev_lib.so")
         # test cross compiler function
-        f.export_library(path_dso, cc.cross_compiler("g++"))
+        f.export_library(path_dso, fcompile=cc.cross_compiler("g++"))
 
         def popen_check():
             import tvm

--- a/tests/python/unittest/test_runtime_rpc.py
+++ b/tests/python/unittest/test_runtime_rpc.py
@@ -294,7 +294,7 @@ def test_rpc_remote_module():
         runtime = Runtime("cpp", {"system-lib": True})
         f = tvm.build(s, [A, B], "llvm", name="myadd", runtime=runtime)
         path_minrpc = temp.relpath("dev_lib.minrpc")
-        f.export_library(path_minrpc, rpc.with_minrpc(cc.create_executable))
+        f.export_library(path_minrpc, fcompile=rpc.with_minrpc(cc.create_executable))
 
         with pytest.raises(RuntimeError):
             rpc.PopenSession("filenotexist")

--- a/tests/python/unittest/test_target_codegen_blob.py
+++ b/tests/python/unittest/test_target_codegen_blob.py
@@ -106,8 +106,8 @@ def test_cuda_multi_lib():
     pathAll = temp.relpath("libAll.a")
 
     path_dso = temp.relpath("mylib.so")
-    libA.export_library(pathA, tar.tar)
-    libB.export_library(pathB, tar.tar)
+    libA.export_library(pathA, fcompile=tar.tar)
+    libB.export_library(pathB, fcompile=tar.tar)
     cc.create_staticlib(pathAll, [pathA, pathB])
     # package two static libs together
     cc.create_shared(path_dso, ["-Wl,--whole-archive", pathAll, "-Wl,--no-whole-archive"])

--- a/web/tests/python/prepare_test_libs.py
+++ b/web/tests/python/prepare_test_libs.py
@@ -35,7 +35,7 @@ def prepare_test_libs(base_path):
     fadd = tvm.build(s, [A, B], target, runtime=runtime, name="add_one")
 
     wasm_path = os.path.join(base_path, "test_addone.wasm")
-    fadd.export_library(wasm_path, emcc.create_tvmjs_wasm)
+    fadd.export_library(wasm_path, fcompile=emcc.create_tvmjs_wasm)
 
 
 if __name__ == "__main__":

--- a/web/tests/python/webgpu_rpc_test.py
+++ b/web/tests/python/webgpu_rpc_test.py
@@ -52,7 +52,7 @@ def test_rpc():
     temp = utils.tempdir()
 
     wasm_path = temp.relpath("addone_gpu.wasm")
-    fadd.export_library(wasm_path, emcc.create_tvmjs_wasm)
+    fadd.export_library(wasm_path, fcompile=emcc.create_tvmjs_wasm)
 
     wasm_binary = open(wasm_path, "rb").read()
     remote = rpc.connect(

--- a/web/tests/python/websock_rpc_test.py
+++ b/web/tests/python/websock_rpc_test.py
@@ -48,7 +48,7 @@ def test_rpc():
     temp = utils.tempdir()
 
     wasm_path = temp.relpath("addone.wasm")
-    fadd.export_library(wasm_path, emcc.create_tvmjs_wasm)
+    fadd.export_library(wasm_path, fcompile=emcc.create_tvmjs_wasm)
 
     wasm_binary = open(wasm_path, "rb").read()
 


### PR DESCRIPTION
This makes the code a bit more readable at a little cost.