### PR TITLE
[Unity][DLight] Improve the performance of matmul on Adreno GPU

### DIFF
--- a/tests/python/dlight/test_gpu_matmul.py
+++ b/tests/python/dlight/test_gpu_matmul.py
@@ -64,14 +64,15 @@ class TestMatmul(BaseBeforeAfter):
                     for ax1_1 in T.thread_binding(T.int64(1), thread="vthread.x"):
                         for ax2_2 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
                             for ax1_2 in T.thread_binding(T.int64(8), thread="threadIdx.x", annotations={"pragma_auto_unroll_max_step": 256, "pragma_unroll_explicit": 1}):
-                                for ax2_3_init, ax1_3_init in T.grid(T.int64(4), T.int64(4)):
-                                    with T.block("matmul_init"):
-                                        v0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                        v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_init)
-                                        v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3_init)
-                                        T.reads()
-                                        T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
-                                        matmul_reindex_pad_local[T.int64(0), v1, v2] = T.float32(0)
+                                for ax2_3_init, ax1_3_0_init in T.grid(T.int64(4), T.int64(2)):
+                                    for ax1_3_1_init in T.vectorized(T.int64(2)):
+                                        with T.block("matmul_init"):
+                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                            v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_0_init * T.int64(2) + ax1_3_1_init)
+                                            v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3_init)
+                                            T.reads()
+                                            T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
+                                            matmul_reindex_pad_local[T.int64(0), v1, v2] = T.float32(0)
                                 for ax3_0 in range(T.int64(256)):
                                     for ax0_ax1_ax2_fused_0 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
                                         for ax0_ax1_ax2_fused_1 in T.thread_binding(T.int64(8), thread="threadIdx.x"):
@@ -97,15 +98,16 @@ class TestMatmul(BaseBeforeAfter):
                                                         T.writes(inp1_reindex_shared[v0, v1, v2])
                                                         T.block_attr({"buffer_dim_align": [[0, 1, 8, 2]]})
                                                         inp1_reindex_shared[v0, v1, v2] = inp1[v2, v1]
-                                    for ax3_1, ax2_3, ax1_3 in T.grid(T.int64(16), T.int64(4), T.int64(4)):
-                                        with T.block("matmul_update"):
-                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                            v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3)
-                                            v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3)
-                                            v3 = T.axis.reduce(T.int64(4096), ax3_0 * T.int64(16) + ax3_1)
-                                            T.reads(matmul_reindex_pad_local[T.int64(0), v1, v2], inp0_reindex_pad_shared[T.int64(0), v1, v3], inp1_reindex_shared[T.int64(0), v2, v3])
-                                            T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
-                                            matmul_reindex_pad_local[T.int64(0), v1, v2] = matmul_reindex_pad_local[T.int64(0), v1, v2] + inp0_reindex_pad_shared[T.int64(0), v1, v3] * inp1_reindex_shared[T.int64(0), v2, v3]
+                                    for ax3_1, ax2_3, ax1_3_0 in T.grid(T.int64(16), T.int64(4), T.int64(2)):
+                                        for ax1_3_1 in T.vectorized(T.int64(2)):
+                                            with T.block("matmul_update"):
+                                                v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                                v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_0 * T.int64(2) + ax1_3_1)
+                                                v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3)
+                                                v3 = T.axis.reduce(T.int64(4096), ax3_0 * T.int64(16) + ax3_1)
+                                                T.reads(matmul_reindex_pad_local[T.int64(0), v1, v2], inp0_reindex_pad_shared[T.int64(0), v1, v3], inp1_reindex_shared[T.int64(0), v2, v3])
+                                                T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
+                                                matmul_reindex_pad_local[T.int64(0), v1, v2] = matmul_reindex_pad_local[T.int64(0), v1, v2] + inp0_reindex_pad_shared[T.int64(0), v1, v3] * inp1_reindex_shared[T.int64(0), v2, v3]
                                 for ax0, ax1, ax2_0 in T.grid(T.int64(1), T.int64(4), T.int64(2)):
                                     for ax2_1_1 in T.vectorized(T.int64(2)):
                                         with T.block("matmul_reindex_pad_local"):
@@ -116,6 +118,7 @@ class TestMatmul(BaseBeforeAfter):
                                             T.writes(matmul[T.int64(0), v1, v2])
                                             if v1 < m:
                                                 matmul[T.int64(0), v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
+
     # fmt: on
 
 
@@ -160,14 +163,15 @@ class TestFusedMatmul(BaseBeforeAfter):
                     for ax1_1 in T.thread_binding(T.int64(1), thread="vthread.x"):
                         for ax2_2 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
                             for ax1_2 in T.thread_binding(T.int64(8), thread="threadIdx.x", annotations={"pragma_auto_unroll_max_step": 256, "pragma_unroll_explicit": 1}):
-                                for ax2_3_init, ax1_3_init in T.grid(T.int64(4), T.int64(4)):
-                                    with T.block("matmul_init"):
-                                        v0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                        v1 = T.axis.spatial(T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_init)
-                                        v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3_init)
-                                        T.reads()
-                                        T.writes(var_matmul_intermediate_reindex_local[T.int64(0), v1, v2])
-                                        var_matmul_intermediate_reindex_local[T.int64(0), v1, v2] = T.float32(0)
+                                for ax2_3_init, ax1_3_0_init in T.grid(T.int64(4), T.int64(2)):
+                                    for ax1_3_1_init in T.vectorized(T.int64(2)):
+                                        with T.block("matmul_init"):
+                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                            v1 = T.axis.spatial(T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_0_init * T.int64(2) + ax1_3_1_init)
+                                            v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3_init)
+                                            T.reads()
+                                            T.writes(var_matmul_intermediate_reindex_local[T.int64(0), v1, v2])
+                                            var_matmul_intermediate_reindex_local[T.int64(0), v1, v2] = T.float32(0)
                                 for ax3_0 in range(T.int64(256)):
                                     for ax0_ax1_ax2_fused_0 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
                                         for ax0_ax1_ax2_fused_1 in T.thread_binding(T.int64(8), thread="threadIdx.x"):
@@ -193,15 +197,16 @@ class TestFusedMatmul(BaseBeforeAfter):
                                                         T.writes(var_decode_intermediate_reindex_shared[v0, v1, v2])
                                                         T.block_attr({"buffer_dim_align": [[0, 1, 8, 2]]})
                                                         var_decode_intermediate_reindex_shared[v0, v1, v2] = T.Cast("float32", T.bitwise_and(T.shift_right(W[v2 // T.int64(8), v1], T.Cast("uint32", v2 % T.int64(8) * T.int64(4))), T.uint32(15))) * T.reinterpret("float32", T.shift_left(T.bitwise_and(S[v2 // T.int64(32), v1], T.uint32(65535)), T.uint32(16))) + T.reinterpret("float32", T.shift_left(T.bitwise_and(T.shift_right(S[v2 // T.int64(32), v1], T.uint32(16)), T.uint32(65535)), T.uint32(16)))
-                                    for ax3_1, ax2_3, ax1_3 in T.grid(T.int64(16), T.int64(4), T.int64(4)):
-                                        with T.block("matmul_update"):
-                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                            v1 = T.axis.spatial(T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3)
-                                            v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3)
-                                            v3 = T.axis.reduce(T.int64(4096), ax3_0 * T.int64(16) + ax3_1)
-                                            T.reads(var_matmul_intermediate_reindex_local[T.int64(0), v1, v2], A_reindex_shared[T.int64(0), v1, v3], var_decode_intermediate_reindex_shared[T.int64(0), v2, v3])
-                                            T.writes(var_matmul_intermediate_reindex_local[T.int64(0), v1, v2])
-                                            var_matmul_intermediate_reindex_local[T.int64(0), v1, v2] = var_matmul_intermediate_reindex_local[T.int64(0), v1, v2] + A_reindex_shared[T.int64(0), v1, v3] * var_decode_intermediate_reindex_shared[T.int64(0), v2, v3]
+                                    for ax3_1, ax2_3, ax1_3_0 in T.grid(T.int64(16), T.int64(4), T.int64(2)):
+                                        for ax1_3_1 in T.vectorized(T.int64(2)):
+                                            with T.block("matmul_update"):
+                                                v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                                v1 = T.axis.spatial(T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_0 * T.int64(2) + ax1_3_1)
+                                                v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3)
+                                                v3 = T.axis.reduce(T.int64(4096), ax3_0 * T.int64(16) + ax3_1)
+                                                T.reads(var_matmul_intermediate_reindex_local[T.int64(0), v1, v2], A_reindex_shared[T.int64(0), v1, v3], var_decode_intermediate_reindex_shared[T.int64(0), v2, v3])
+                                                T.writes(var_matmul_intermediate_reindex_local[T.int64(0), v1, v2])
+                                                var_matmul_intermediate_reindex_local[T.int64(0), v1, v2] = var_matmul_intermediate_reindex_local[T.int64(0), v1, v2] + A_reindex_shared[T.int64(0), v1, v3] * var_decode_intermediate_reindex_shared[T.int64(0), v2, v3]
                                 for ax0, ax1, ax2_0 in T.grid(T.int64(1), T.int64(4), T.int64(2)):
                                     for ax2_1_1 in T.vectorized(T.int64(2)):
                                         with T.block("var_matmul_intermediate_reindex_local"):
@@ -211,6 +216,7 @@ class TestFusedMatmul(BaseBeforeAfter):
                                             T.reads(C[T.int64(0), v1, v2], var_matmul_intermediate_reindex_local[v0, v1, v2])
                                             T.writes(Out[T.int64(0), v1, v2])
                                             Out[T.int64(0), v1, v2] = C[T.int64(0), v1, v2] + var_matmul_intermediate_reindex_local[v0, v1, v2]
+
     # fmt: on
 
 
@@ -320,14 +326,15 @@ class TestOutputFP32(BaseBeforeAfter):
                     for ax1_1 in T.thread_binding(T.int64(1), thread="vthread.x"):
                         for ax2_2 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
                             for ax1_2 in T.thread_binding(T.int64(8), thread="threadIdx.x", annotations={"pragma_auto_unroll_max_step": 256, "pragma_unroll_explicit": 1}):
-                                for ax2_3_init, ax1_3_init in T.grid(T.int64(4), T.int64(4)):
-                                    with T.block("matmul_init"):
-                                        v0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                        v1 = T.axis.spatial((n + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_init)
-                                        v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3_init)
-                                        T.reads()
-                                        T.writes(var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2])
-                                        var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2] = T.float32(0)
+                                for ax2_3_init, ax1_3_0_init in T.grid(T.int64(4), T.int64(2)):
+                                    for ax1_3_1_init in T.vectorized(T.int64(2)):
+                                        with T.block("matmul_init"):
+                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                            v1 = T.axis.spatial((n + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_0_init * T.int64(2) + ax1_3_1_init)
+                                            v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3_init)
+                                            T.reads()
+                                            T.writes(var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2])
+                                            var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2] = T.float32(0)
                                 for ax3_0 in range(T.int64(256)):
                                     for ax0_ax1_ax2_fused_0 in T.thread_binding(T.int64(16), thread="threadIdx.y"):
                                         for ax0_ax1_ax2_fused_1 in T.thread_binding(T.int64(8), thread="threadIdx.x"):
@@ -353,15 +360,16 @@ class TestOutputFP32(BaseBeforeAfter):
                                                         T.writes(p_output0_intermediate_1_reindex_shared[v0, v1, v2])
                                                         T.block_attr({"buffer_dim_align": [[0, 1, 8, 2]]})
                                                         p_output0_intermediate_1_reindex_shared[v0, v1, v2] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv13[v2, v1 // T.int64(8)], T.Cast("uint32", v1 % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv14[v2, v1 // T.int64(32)]
-                                    for ax3_1, ax2_3, ax1_3 in T.grid(T.int64(16), T.int64(4), T.int64(4)):
-                                        with T.block("matmul_update"):
-                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                            v1 = T.axis.spatial((n + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3)
-                                            v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3)
-                                            v3 = T.axis.reduce(T.int64(4096), ax3_0 * T.int64(16) + ax3_1)
-                                            T.reads(var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2], lv48_reindex_pad_shared[T.int64(0), v1, v3], p_output0_intermediate_1_reindex_shared[T.int64(0), v2, v3])
-                                            T.writes(var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2])
-                                            var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2] = var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2] + T.Cast("float32", lv48_reindex_pad_shared[T.int64(0), v1, v3]) * T.Cast("float32", p_output0_intermediate_1_reindex_shared[T.int64(0), v2, v3])
+                                    for ax3_1, ax2_3, ax1_3_0 in T.grid(T.int64(16), T.int64(4), T.int64(2)):
+                                        for ax1_3_1 in T.vectorized(T.int64(2)):
+                                            with T.block("matmul_update"):
+                                                v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                                v1 = T.axis.spatial((n + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_1 * T.int64(32) + ax1_2 * T.int64(4) + ax1_3_0 * T.int64(2) + ax1_3_1)
+                                                v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(4) + ax2_3)
+                                                v3 = T.axis.reduce(T.int64(4096), ax3_0 * T.int64(16) + ax3_1)
+                                                T.reads(var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2], lv48_reindex_pad_shared[T.int64(0), v1, v3], p_output0_intermediate_1_reindex_shared[T.int64(0), v2, v3])
+                                                T.writes(var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2])
+                                                var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2] = var_matmul_intermediate_reindex_pad_local[T.int64(0), v1, v2] + T.Cast("float32", lv48_reindex_pad_shared[T.int64(0), v1, v3]) * T.Cast("float32", p_output0_intermediate_1_reindex_shared[T.int64(0), v2, v3])
                                 for ax0, ax1, ax2_0 in T.grid(T.int64(1), T.int64(4), T.int64(2)):
                                     for ax2_1_1 in T.vectorized(T.int64(2)):
                                         with T.block("var_matmul_intermediate_reindex_pad_local"):
@@ -373,6 +381,76 @@ class TestOutputFP32(BaseBeforeAfter):
                                             if v1 < n:
                                                 p_output0_intermediate[T.int64(0), v1, v2] = T.Cast("float16", var_matmul_intermediate_reindex_pad_local[v0, v1, v2] + T.Cast("float32", lv13_1[v2])) + lv3[T.int64(0), v1, v2]
 
+    # fmt: on
+
+
+class AndroidBeforeAfter(tvm.testing.CompareBeforeAfter):
+    @pytest.fixture
+    def transform(self):
+        def transform(mod):
+            with Target("opencl", host="llvm -mtriple=aarch64-linux-android"):
+                return dl.ApplyDefaultSchedule(dl.gpu.Matmul())(mod)
+
+        return transform
+
+
+class TestMatmulAndroid(AndroidBeforeAfter):
+    # fmt: off
+    @T.prim_func
+    def before(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(4096)), "float32"), var_matmul: T.handle):
+        m = T.int64()
+        inp0 = T.match_buffer(var_inp0, (T.int64(1), m, T.int64(4096)))
+        matmul = T.match_buffer(var_matmul, (T.int64(1), m, T.int64(4096)))
+        for i0, i1, i2, k in T.grid(T.int64(1), m, T.int64(4096), T.int64(4096)):
+            with T.block("matmul"):
+                v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+                with T.init():
+                    matmul[v_i0, v_i1, v_i2] = T.float32(0)
+                matmul[v_i0, v_i1, v_i2] = matmul[v_i0, v_i1, v_i2] + inp0[v_i0, v_i1, v_k] * inp1[v_k, v_i2]
+
+    @T.prim_func
+    def expected(var_inp0: T.handle, inp1: T.Buffer((T.int64(4096), T.int64(4096)), "float32"), var_matmul: T.handle):
+        T.func_attr({"global_symbol": "main", "tir.is_scheduled": 1})
+        m = T.int64()
+        inp0 = T.match_buffer(var_inp0, (T.int64(1), m, T.int64(4096)))
+        matmul = T.match_buffer(var_matmul, (T.int64(1), m, T.int64(4096)))
+        # with T.block("root"):
+        matmul_reindex_pad_local = T.alloc_buffer((T.int64(1), (m + T.int64(15)) // T.int64(16) * T.int64(16), T.int64(4096)), scope="local")
+        for ax0_ax1_0_fused in T.thread_binding((m + T.int64(15)) // T.int64(16), thread="blockIdx.y"):
+            for ax2_0 in T.thread_binding(T.int64(64), thread="blockIdx.x"):
+                for ax1_1 in T.thread_binding(T.int64(1), thread="vthread.y"):
+                    for ax2_1 in T.thread_binding(T.int64(1), thread="vthread.x"):
+                        for ax1_2 in T.thread_binding(T.int64(8), thread="threadIdx.y"):
+                            for ax2_2 in T.thread_binding(T.int64(8), thread="threadIdx.x", annotations={"pragma_auto_unroll_max_step": 64, "pragma_unroll_explicit": 1}):
+                                for ax1_3_init, ax2_3_0_init in T.grid(T.int64(2), T.int64(1)):
+                                    for ax2_3_1_init in T.vectorized(T.int64(8)):
+                                        with T.block("matmul_init"):
+                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                            v1 = T.axis.spatial((m + T.int64(15)) // T.int64(16) * T.int64(16), ax0_ax1_0_fused * T.int64(16) + ax1_1 * T.int64(16) + ax1_2 * T.int64(2) + ax1_3_init)
+                                            v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(8) + ax2_3_0_init * T.int64(8) + ax2_3_1_init)
+                                            T.reads()
+                                            T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
+                                            matmul_reindex_pad_local[T.int64(0), v1, v2] = T.float32(0)
+                                for ax3_0, ax3_1, ax1_3, ax2_3_0 in T.grid(T.int64(256), T.int64(16), T.int64(2), T.int64(1)):
+                                    for ax2_3_1 in T.vectorized(T.int64(8)):
+                                        with T.block("matmul_update"):
+                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                            v1 = T.axis.spatial((m + T.int64(15)) // T.int64(16) * T.int64(16), ax0_ax1_0_fused * T.int64(16) + ax1_1 * T.int64(16) + ax1_2 * T.int64(2) + ax1_3)
+                                            v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_1 * T.int64(64) + ax2_2 * T.int64(8) + ax2_3_0 * T.int64(8) + ax2_3_1)
+                                            v3 = T.axis.reduce(T.int64(4096), ax3_0 * T.int64(16) + ax3_1)
+                                            T.reads(matmul_reindex_pad_local[T.int64(0), v1, v2], inp0[T.int64(0), v1, v3], inp1[v3, v2])
+                                            T.writes(matmul_reindex_pad_local[T.int64(0), v1, v2])
+                                            matmul_reindex_pad_local[T.int64(0), v1, v2] = matmul_reindex_pad_local[T.int64(0), v1, v2] + T.if_then_else(v1 < m, inp0[T.int64(0), v1, v3], T.float32(0)) * inp1[v3, v2]
+                                for ax0, ax1, ax2_0_1 in T.grid(T.int64(1), T.int64(2), T.int64(1)):
+                                    for ax2_1_1 in T.vectorized(T.int64(8)):
+                                        with T.block("matmul_reindex_pad_local"):
+                                            v0 = T.axis.spatial(T.int64(1), ax0)
+                                            v1 = T.axis.spatial((m + T.int64(15)) // T.int64(16) * T.int64(16), ax0_ax1_0_fused * T.int64(16) + ax1_2 * T.int64(2) + ax1)
+                                            v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_2 * T.int64(8) + ax2_0_1 * T.int64(8) + ax2_1_1)
+                                            T.reads(matmul_reindex_pad_local[v0, v1, v2])
+                                            T.writes(matmul[T.int64(0), v1, v2])
+                                            if v1 < m:
+                                                matmul[T.int64(0), v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
     # fmt: on
 
 

--- a/tests/python/dlight/test_gpu_matmul_tensorize.py
+++ b/tests/python/dlight/test_gpu_matmul_tensorize.py
@@ -204,14 +204,15 @@ class TestMatmulTensorizeTooSmall(BaseBeforeAfter):
                     for ax1_1 in T.thread_binding(1, thread="vthread.x"):
                         for ax2_2 in T.thread_binding(16, thread="threadIdx.y"):
                             for ax1_2 in T.thread_binding(8, thread="threadIdx.x", annotations={"pragma_auto_unroll_max_step": 256, "pragma_unroll_explicit": 1}):
-                                for ax2_3_init, ax1_3_init in T.grid(4, 4):
-                                    with T.block("compute_init"):
-                                        v0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                        v1 = T.axis.spatial((T.Cast("int32", T.Cast("int64", m)) + 31) // 32 * 32, ax1_0 * 32 + ax1_1 * 32 + ax1_2 * 4 + ax1_3_init)
-                                        v2 = T.axis.spatial(64, ax2_1 * 64 + ax2_2 * 4 + ax2_3_init)
-                                        T.reads()
-                                        T.writes(compute_reindex_pad_local[0, v1, v2])
-                                        compute_reindex_pad_local[0, v1, v2] = T.float32(0)
+                                for ax2_3_init, ax1_3_0_init in T.grid(4, 2):
+                                    for ax1_3_1_init in T.vectorized(2):
+                                        with T.block("compute_init"):
+                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                            v1 = T.axis.spatial((T.Cast("int32", T.Cast("int64", m)) + 31) // 32 * 32, ax1_0 * 32 + ax1_1 * 32 + ax1_2 * 4 + ax1_3_0_init * 2 + ax1_3_1_init)
+                                            v2 = T.axis.spatial(64, ax2_1 * 64 + ax2_2 * 4 + ax2_3_init)
+                                            T.reads()
+                                            T.writes(compute_reindex_pad_local[0, v1, v2])
+                                            compute_reindex_pad_local[0, v1, v2] = T.float32(0)
                                 for ax3_0 in range(16):
                                     for ax0_ax1_ax2_fused_0 in T.thread_binding(16, thread="threadIdx.y"):
                                         for ax0_ax1_ax2_fused_1 in T.thread_binding(8, thread="threadIdx.x"):
@@ -237,15 +238,16 @@ class TestMatmulTensorizeTooSmall(BaseBeforeAfter):
                                                         T.writes(W_reindex_pad_shared[v0, v1, v2])
                                                         T.block_attr({"buffer_dim_align": [[0, 1, 8, 2]]})
                                                         W_reindex_pad_shared[v0, v1, v2] = T.if_then_else(v1 < 15, W[v1, v2], T.float16(0))
-                                    for ax3_1, ax2_3, ax1_3 in T.grid(16, 4, 4):
-                                        with T.block("compute_update"):
-                                            v0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                            v1 = T.axis.spatial((T.Cast("int32", T.Cast("int64", m)) + 31) // 32 * 32, ax1_0 * 32 + ax1_1 * 32 + ax1_2 * 4 + ax1_3)
-                                            v2 = T.axis.spatial(64, ax2_1 * 64 + ax2_2 * 4 + ax2_3)
-                                            v3 = T.axis.reduce(256, ax3_0 * 16 + ax3_1)
-                                            T.reads(compute_reindex_pad_local[0, v1, v2], X_reindex_pad_shared[0, v1, v3], W_reindex_pad_shared[0, v2, v3])
-                                            T.writes(compute_reindex_pad_local[0, v1, v2])
-                                            compute_reindex_pad_local[0, v1, v2] = compute_reindex_pad_local[0, v1, v2] + T.Cast("float32", X_reindex_pad_shared[0, v1, v3]) * T.Cast("float32", W_reindex_pad_shared[0, v2, v3])
+                                    for ax3_1, ax2_3, ax1_3_0 in T.grid(16, 4, 2):
+                                        for ax1_3_1 in T.vectorized(2):
+                                            with T.block("compute_update"):
+                                                v0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                                v1 = T.axis.spatial((T.Cast("int32", T.Cast("int64", m)) + 31) // 32 * 32, ax1_0 * 32 + ax1_1 * 32 + ax1_2 * 4 + ax1_3_0 * 2 + ax1_3_1)
+                                                v2 = T.axis.spatial(64, ax2_1 * 64 + ax2_2 * 4 + ax2_3)
+                                                v3 = T.axis.reduce(256, ax3_0 * 16 + ax3_1)
+                                                T.reads(compute_reindex_pad_local[0, v1, v2], X_reindex_pad_shared[0, v1, v3], W_reindex_pad_shared[0, v2, v3])
+                                                T.writes(compute_reindex_pad_local[0, v1, v2])
+                                                compute_reindex_pad_local[0, v1, v2] = compute_reindex_pad_local[0, v1, v2] + T.Cast("float32", X_reindex_pad_shared[0, v1, v3]) * T.Cast("float32", W_reindex_pad_shared[0, v2, v3])
                                 for ax0, ax1, ax2_0 in T.grid(1, 4, 2):
                                     for ax2_1_1 in T.vectorized(2):
                                         with T.block("compute_reindex_pad_local"):


### PR DESCRIPTION
The current matmul implementation is targeted for NVIDIA GPU, which is not optimized for Adreno GPU (also other edge devices). This patch improves the performance, improving performance from 7170.14ms to 554.57ms for a very large kernel