### PR TITLE
[Unity][Frontend][NN] Add nn.MultiLinear

### DIFF
--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -20,6 +20,7 @@ import math
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
+
 from tvm import tir as _tir
 
 from ... import expr as rx
@@ -32,7 +33,7 @@ from .spec import SpecBuilder
 IntExpr = Union[int, _tir.PrimExpr]
 
 
-def _wrap_nested(expr: rx.Expr, name: str) -> Union[Tensor, Tuple[Tensor]]:
+def _wrap_nested(expr: rx.Expr, name: str) -> Union[Tensor, Tuple[Tensor, ...]]:
     """Wrap the given relax.Expr, emit it using the current BlockBuilder,
     and automatically handle nested cases if the expr represents a Tuple.
 
@@ -1042,6 +1043,33 @@ def zeros(
         The result tensor.
     """
     return _wrap_nested(_op.zeros(shape, dtype), name)
+
+
+def split(
+    ary: Tensor,
+    indices_or_sections: Union[int, Sequence[int]],
+    axis: int = 0,
+    name: str = "split",
+) -> Tuple[Tensor, ...]:
+    """Split an array into multiple sub-arrays.
+
+    Parameters
+    ----------
+    ary : Tensor
+        Input tensor to be split.
+    indices_or_sections : Union[int, Sequence[int]]
+        Indices or sections to split into.
+    axis : int = 0
+        The axis along which to split, default is 0.
+    name : str
+        Name hint.
+
+    Returns
+    -------
+    result : Tuple[Tensor, ...]
+        A list of sub-arrays as the outcome of splitting.
+    """
+    return _wrap_nested(_op.split(ary._expr, indices_or_sections, axis), name)
 
 
 def pad(

--- a/tests/python/relax/test_frontend_nn_modules.py
+++ b/tests/python/relax/test_frontend_nn_modules.py
@@ -83,6 +83,56 @@ def test_linear():
     assert_structural_equal(tvm_mod["forward"], forward, True)
 
 
+def test_multi_linear():
+    @R.function
+    def forward(
+        x: R.Tensor((3, 5, 4), dtype="float32"),
+        weight: R.Tensor((60, 4), dtype="float32"),
+    ) -> R.Tuple(
+        R.Tensor((3, 5, 4), dtype="float32"),
+        R.Tensor((3, 5, 8), dtype="float32"),
+        R.Tensor((3, 5, 16), dtype="float32"),
+        R.Tensor((3, 5, 32), dtype="float32"),
+    ):
+        R.func_attr({"num_input": 1})
+        with R.dataflow():
+            permute_dims: R.Tensor((4, 60), dtype="float32") = R.permute_dims(weight, axes=None)
+            matmul: R.Tensor((3, 5, 60), dtype="float32") = R.matmul(
+                x, permute_dims, out_dtype="void"
+            )
+            split: R.Tuple(
+                R.Tensor((3, 5, 4), dtype="float32"),
+                R.Tensor((3, 5, 8), dtype="float32"),
+                R.Tensor((3, 5, 16), dtype="float32"),
+                R.Tensor((3, 5, 32), dtype="float32"),
+            ) = R.split(matmul, indices_or_sections=[4, 12, 28], axis=-1)
+            split_0: R.Tensor((3, 5, 4), dtype="float32") = split[0]
+            split_1: R.Tensor((3, 5, 8), dtype="float32") = split[1]
+            split_2: R.Tensor((3, 5, 16), dtype="float32") = split[2]
+            split_3: R.Tensor((3, 5, 32), dtype="float32") = split[3]
+            gv: R.Tuple(
+                R.Tensor((3, 5, 4), dtype="float32"),
+                R.Tensor((3, 5, 8), dtype="float32"),
+                R.Tensor((3, 5, 16), dtype="float32"),
+                R.Tensor((3, 5, 32), dtype="float32"),
+            ) = (split_0, split_1, split_2, split_3)
+            R.output(gv)
+        return gv
+
+    mod = modules.MultiLinear(
+        in_features=4,
+        out_features=[4, 8, 16, 32],
+        bias=False,
+    )
+    tvm_mod, _ = mod.export_tvm(
+        spec={
+            "forward": {"x": spec.Tensor((3, 5, 4), "float32")},
+        },
+        debug=False,
+    )
+    assert_structural_equal(tvm_mod["forward"], forward, True)
+
+
 def test_conv1d():
     @R.function
     def forward(


### PR DESCRIPTION
This PR introduces `nn.MultiLinear` as an extension to `nn.Linear` which is arithmetically equivalent to applying multiple `nn.Linear` to the same input.

For example, QKV projection in attention, represented in `nn.Linear` being:

```python
q_proj = nn.Linear(hidden_dim, ...)
k_proj = nn.Linear(hidden_dim, ...)
v_proj = nn.Linear(hidden_dim, ...)

q = q_proj(x)
k = k_proj(x)
v = v_proj(x)
```

could be simplified using `nn.MultiLinear` as:

```python
qkv_proj = nn.MultiLinear((hidden_dim, hidden_dim, hidden_dim), ...)
q, k, v = qkv_proj(x)
```

The underlying implementation, by default, will fuse all the projection matrices into a single one, to allow potentially larger room for optimization.