### PR TITLE
[IR] Use structural equal for Range equality

### DIFF
--- a/python/tvm/ir/expr.py
+++ b/python/tvm/ir/expr.py
@@ -177,3 +177,9 @@ class Range(Node, Scriptable):
             The constructed range.
         """
         return _ffi_api.Range_from_min_extent(min_value, extent, span)
+
+    def __eq__(self, other):
+        return tvm.ir.structural_equal(self, other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)


### PR DESCRIPTION
This PR adds a small change to verify equality of `tvm.ir.Range` as a structural equal. This assumes that in most cases, comparing two `Range`s means to compare its `min` and `extent` as opposed to the actual Range object handle.