### PR TITLE
[Arith] Fix detect non-divisible iteration form like (x % 255) // 16

### DIFF
--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -1897,10 +1897,18 @@ PrimExpr IterMapRewriter::SplitFloorDivConst(IterSplitExpr lhs, PrimExpr base, P
   // = floormod(sc2+t, c2)
   // = floormod(floordiv(y, c1), c2)
   // = floormod(floordiv(iter, lower_factor*c1), c2), where c1=rhs, c2=extent/rhs
-  IterSplitExpr new_split(padded->source,
-                          /* lower_factor = */ padded->lower_factor * rhs,
-                          /* extent = */ analyzer_->Simplify(floordiv(padded->extent, rhs)),
-                          /* scale = */ padded->scale);
+  IterSplitExpr new_split;
+  if (CanProveDivisible(padded->extent, rhs)) {
+    new_split = IterSplitExpr(padded->source,
+                              /* lower_factor = */ padded->lower_factor * rhs,
+                              /* extent = */ analyzer_->Simplify(floordiv(padded->extent, rhs)),
+                              /* scale = */ padded->scale);
+  } else {
+    new_split = IterSplitExpr(IterMark(padded, padded->extent),
+                              /* lower_factor = */ rhs,
+                              /* extent = */ analyzer_->Simplify(ceildiv(padded->extent, rhs)),
+                              /* scale = */ make_const(rhs->dtype, 1));
+  }
 
   auto new_base = analyzer_->Simplify(floordiv(base - left_pad, rhs), 6);
   if (is_zero(new_base)) {

--- a/tests/python/unittest/test_arith_iter_affine_map.py
+++ b/tests/python/unittest/test_arith_iter_affine_map.py
@@ -1051,6 +1051,8 @@ class TestPadding:
         # original extent is smaller than the divident
         # it is not surjective wrt to the region [0, 16)
         ({x: 3}, {flm(x, 16)}),
+        # (x % c1) // c2 is not proved as surjective if c1 % c2 != 0
+        ({x: 255}, {fld(flm(x, 255), 16)}),
     )
 
     def test_padding(self, positive_test_case):

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -605,6 +605,23 @@ class TestFloorModTwo(BaseCompare):
     )
 
 
+class TestFloorModPadded(BaseCompare):
+    """Special-case simplifications for divisibility proof
+    such that (x - x % k) must be divisible by k
+    """
+
+    x, y = te.var("x"), te.var("y")
+    test_case = tvm.testing.parameter(
+        TestCase(flm(x - flm(x, 9), 9), 0),
+        TestCase(flm(x - flm(x, -9), 9), 0),
+        TestCase(flm(x + flm(-x, 9), 9), 0),
+        TestCase(flm(x + flm(8 * x, 9), 9), 0),
+        TestCase(flm(x - flm(x, y), y), 0),
+        TestCase(flm(x - flm(x, -y), y), 0),
+        TestCase(flm(x + flm(-x, y), y), 0),
+    )
+
+
 class TestMinIndex(BaseCompare):
     x, y, z = te.var("x"), te.var("y"), te.var("z")
     test_case = tvm.testing.parameter(

--- a/tests/python/unittest/test_tir_transform_compact_buffer_region.py
+++ b/tests/python/unittest/test_tir_transform_compact_buffer_region.py
@@ -999,7 +999,7 @@ class TestDependentBufferIndicesOfPackedMatmul(BaseCompactTest):
     ) -> None:
         for i0, i1 in T.grid(4, 1):
             with T.block():
-                C_local2 = T.alloc_buffer([1, 1, 15, 1000, 16], dtype="float32", scope="local")
+                C_local2 = T.alloc_buffer([1, 1, 16, 1000, 16], dtype="float32", scope="local")
                 C_local1 = T.alloc_buffer([255, 1000], dtype="float32", scope="local")
                 for ax0, ax1, ax2 in T.grid(255, 1000, 64):
                     with T.block("matmul"):


### PR DESCRIPTION
Previously, the optimization from `floordiv(floormod(..))` to `floormod(floordiv(..))` do not check the divisibility. Which may create wrong  iteration form. The change add a default handling and let it just fail in followup validity checks.

For example, ` (x % 255) // 16` should not get transformed to `(x // 16) % 15`. The change make it as `(x % 255) // 16 % ceildiv(255, 16)`.

It currently could not pass the surjective check though the mapping actually is surjective. We could improve it in the future.