### PR TITLE
[microTVM] Check the output of microNPU demos in CI

### DIFF
--- a/tests/scripts/task_demo_microtvm.sh
+++ b/tests/scripts/task_demo_microtvm.sh
@@ -20,14 +20,21 @@ set -euxo pipefail
 
 source tests/scripts/setup-pytest-env.sh
 
+TMP_LOG_FILE=/tmp/$$.out.log
+
 cleanup()
 {
-    rm -f out.log
+    rm -f $TMP_LOG_FILE
 }
 trap cleanup 0
 
 pushd apps/microtvm/cmsisnn
- timeout 5m ./run_demo.sh
+timeout 5m ./run_demo.sh > $TMP_LOG_FILE
+cat $TMP_LOG_FILE
+if ! grep -q "Person detected." $TMP_LOG_FILE; then
+    echo "The demo returned the wrong result"
+    exit 1
+fi
 popd
 
 # TODO(mehrdadh): disabled due to https://github.com/apache/tvm/issues/13856
@@ -40,16 +47,16 @@ FVP_PATH="/opt/arm/FVP_Corstone_SSE-300_Ethos-U55"
 CMAKE_PATH="/opt/arm/cmake/bin/cmake"
 FREERTOS_PATH="/opt/freertos/FreeRTOSv202112.00"
 
-timeout 5m ./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH > out.log
-cat out.log
-if ! grep -q "The image has been classified as 'tabby'" out.log; then
+timeout 5m ./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH > $TMP_LOG_FILE
+cat $TMP_LOG_FILE
+if ! grep -q "The image has been classified as 'tabby'" $TMP_LOG_FILE; then
     echo "The demo returned the wrong result"
     exit 1
 fi
 
-timeout 5m ./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH --freertos_path $FREERTOS_PATH > out.log
-cat out.log
-if ! grep -q "The image has been classified as 'tabby'" out.log; then
+timeout 5m ./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH --freertos_path $FREERTOS_PATH > $TMP_LOG_FILE
+cat $TMP_LOG_FILE
+if ! grep -q "The image has been classified as 'tabby'" $TMP_LOG_FILE; then
     echo "The demo returned the wrong result"
     exit 1
 fi

--- a/tests/scripts/task_demo_microtvm.sh
+++ b/tests/scripts/task_demo_microtvm.sh
@@ -20,6 +20,12 @@ set -euxo pipefail
 
 source tests/scripts/setup-pytest-env.sh
 
+cleanup()
+{
+    rm -f out.log
+}
+trap cleanup 0
+
 pushd apps/microtvm/cmsisnn
  timeout 5m ./run_demo.sh
 popd
@@ -34,6 +40,18 @@ FVP_PATH="/opt/arm/FVP_Corstone_SSE-300_Ethos-U55"
 CMAKE_PATH="/opt/arm/cmake/bin/cmake"
 FREERTOS_PATH="/opt/freertos/FreeRTOSv202112.00"
 
- timeout 5m ./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH
- timeout 5m ./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH --freertos_path $FREERTOS_PATH
+timeout 5m ./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH > out.log
+cat out.log
+if ! grep -q "The image has been classified as 'tabby'" out.log; then
+    echo "The demo returned the wrong result"
+    exit 1
+fi
+
+timeout 5m ./run_demo.sh --fvp_path $FVP_PATH --cmake_path $CMAKE_PATH --freertos_path $FREERTOS_PATH > out.log
+cat out.log
+if ! grep -q "The image has been classified as 'tabby'" out.log; then
+    echo "The demo returned the wrong result"
+    exit 1
+fi
+
 popd


### PR DESCRIPTION
This is a followup from #15649 which caught a misclassification issue when running the microNPU demo. While #15649 fixes the issue and results in the correct classification, this commit ensures the demo does not regress again in the future.

cc @ashutosh-arm @leandron