### PR TITLE
[CI] Allow Limit CPUs in Docker

### DIFF
--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -38,9 +38,11 @@ set -euo pipefail
 function show_usage() {
     cat <<EOF
 Usage: docker/bash.sh [-i|--interactive] [--net=host] [-t|--tty]
-         [--mount MOUNT_DIR] [--repo-mount-point REPO_MOUNT_POINT]
-         [--dry-run] [--name NAME]
-         <DOCKER_IMAGE_NAME> [--] [COMMAND]
+          [--cpus NUM_CPUS] [--mount MOUNT_DIR]
+          [--repo-mount-point REPO_MOUNT_POINT]
+          [--dry-run] [--name NAME]
+          <DOCKER_IMAGE_NAME> [--] [COMMAND]
+
 
 -h, --help
 
@@ -53,6 +55,10 @@ Usage: docker/bash.sh [-i|--interactive] [--net=host] [-t|--tty]
 -t, --tty
 
     Start the docker session with a pseudo terminal (tty).
+
+--cpus NUM_CPUS
+
+    Limit the number of CPU cores to be used.
 
 --net=host
 
@@ -182,6 +188,11 @@ while (( $# )); do
         -t*|--tty)
             TTY=true
             eval $break_joined_flag
+            ;;
+
+        --cpus)
+            DOCKER_FLAGS+=(--cpus "$2")
+            shift 2
             ;;
 
         --net=host)


### PR DESCRIPTION
This PR adds a new flag `--cpus` in `./docker/bash.sh`, which is passed to docker command that allows limiting the number of CPU cores of a docker container.

Related materials: https://docs.docker.com/config/containers/resource_constraints/#configure-the-default-cfs-scheduler