### PR TITLE
[UNITY][Pass] Optimize redundant layout transform ops

### DIFF
--- a/python/tvm/relax/transform/__init__.py
+++ b/python/tvm/relax/transform/__init__.py
@@ -19,6 +19,7 @@
 
 from .transform import *
 from .lazy_transform_params import LazyTransformParams
+from .optimize_layout_transform import OptimizeLayoutTransform
 
 # Import to register the legalization functions.
 from . import legalize_ops

--- a/python/tvm/relax/transform/optimize_layout_transform.py
+++ b/python/tvm/relax/transform/optimize_layout_transform.py
@@ -1,0 +1,140 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Relax Optimize Layout Transform pass."""
+import tvm
+from tvm import IRModule, relax
+from tvm.ir.transform import module_pass
+from tvm.relax.analysis import remove_all_unused
+from tvm.relax.expr_functor import mutator, PyExprMutator
+from typing import Union
+
+@mutator
+class OptimizeLayoutTranformMutator(PyExprMutator):
+    '''
+    Mutator to iterate over relax functions to
+    remove redundant transform layout operators
+    introduced by AlterOpImpl pass.
+
+    Parameters
+    ----------
+    mod: IRModule
+        The ir module
+
+    '''
+
+    def __init__(self, mod: IRModule) -> None:
+        super().__init__(mod)
+        self.mod_ = mod
+        self.patterns = [
+            [
+                "relax.layout_transform",
+                "relax.layout_transform"
+            ]
+        ]
+
+
+    # Matches the call_node against the pattern layout_transform -> layout_transform.
+    # Based on the pattern matching, returns the updated arguments for call_node.
+    def update_args(self, call_node) -> Union[None, relax.Tuple]:
+        # Helper function to check if the called TIR function is matching
+        # the relax operator name.
+        def check_op_type(call_node: relax.Call, op_name: str) -> bool:
+            if not isinstance(call_node, relax.Call):
+                return False
+            if call_node.op != tvm.ir.Op.get(op_name):
+                return False
+            return True
+
+        new_call_args = []
+
+        # Update args of call_node be checking the pattern 
+        for arg in call_node.args[1]:
+            is_pattern_match = False
+            if not isinstance(arg, relax.expr.Var):
+                new_call_args.append(arg)
+                continue
+
+            for pattern in self.patterns:
+                is_pattern_found = True
+                value = arg
+                for pat in pattern:
+                    if value == None:
+                        break
+                    value = self.lookup_binding(value)
+                    if not check_op_type(value, pat):
+                        is_pattern_found = False
+                        break
+                    value = value.args[0]
+
+                # Check if the shape of value matches the shape of arg to replace
+                if value != None and list(value.struct_info.shape) != list(arg.struct_info.shape):
+                    is_pattern_found = False
+                if is_pattern_found:
+                    arg_to_update = value
+                    break
+
+            if is_pattern_found:
+                new_call_args.append(arg_to_update)
+            else:
+                new_call_args.append(arg)
+
+        return new_call_args
+
+    def transform(self) -> IRModule:
+        # Iterate over all the functions in the IRModule
+        for global_var, func in self.mod_.functions.items():
+            # Skip non-relax functions
+            if not isinstance(func, relax.Function):
+                continue
+            # Skip primitive functions
+            if "Primitive" in func.attrs.keys() and func.attrs["Primitive"] != 0:
+                continue
+            # Update the non-primitive Relax function
+            updated_func = self.visit_expr(func)
+            # Remove any unused bindings in the updated function
+            updated_func = remove_all_unused(updated_func)
+            self.builder_.update_func(global_var, updated_func)
+
+        # At the end of the transformation we return the updated IRModule from the BlockBuilder.
+        return self.builder_.get()
+
+    # We only need to override Call node mutator.
+    # Find out about pattern of interest and if the pattern matches, then
+    # create a new call_node with updated args.
+    def visit_call_(self, call_node: relax.Call) -> relax.Call:
+        # Check if the call node matches our expected pattern
+        if call_node.op != tvm.ir.Op.get("relax.call_tir"):
+            return call_node
+
+        new_args = self.update_args(call_node)
+
+        # Check if new_args are different from original args
+        if new_args == list(call_node.args[1]):
+            return call_node
+
+        # Construct a call to the primitive function
+        return relax.call_tir(call_node.args[0], new_args, call_node.struct_info)
+
+
+@module_pass(opt_level=0, name="OptimizeLayoutTransform")
+class OptimizeLayoutTransform:
+    """The wrapper for the optimization of layout transform pass."""
+
+    def transform_module(self, mod, ctx):
+        return OptimizeLayoutTranformMutator(mod).transform()

--- a/tests/python/relax/test_optimize_layout_transform.py
+++ b/tests/python/relax/test_optimize_layout_transform.py
@@ -21,7 +21,7 @@ import pytest
 import tvm.testing
 from tvm import relax
 from tvm.ir.base import assert_structural_equal
-from tvm.relax.transform import OptimizeLayoutTransform
+from tvm.relax.transform import DeadCodeElimination, FuseTIR, OptimizeLayoutTransform
 from tvm.script import ir as I, tir as T, relax as R
 
 
@@ -30,7 +30,11 @@ def _run_pass_compare_output(Before, Expected):
     if not relax.analysis.well_formed(fused_mod):
         print("IRModule is not well-formed")
 
-    fused_mod = relax.transform.FuseTIR()(fused_mod)
+    fused_mode = DeadCodeElimination()(fused_mod)
+    if not relax.analysis.well_formed(fused_mod):
+        print("IRModule is not well-formed")
+
+    fused_mod = FuseTIR()(fused_mod)
     if not relax.analysis.well_formed(fused_mod):
         print("IRModule is not well-formed")
 

--- a/tests/python/relax/test_optimize_layout_transform.py
+++ b/tests/python/relax/test_optimize_layout_transform.py
@@ -1,4 +1,3 @@
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -39,11 +38,14 @@ def _run_pass_compare_output(Before, Expected):
 
 
 def test_optimize_transform_layout_pass_one_arg():
-
     @I.ir_module
     class Before:
         @T.prim_func(private=True)
-        def relax_add_replacement(arg0: T.Buffer((4, 4), "float32"), arg1: T.Buffer((4, 4), "float32"), output: T.Buffer((4, 4), "float32")):
+        def relax_add_replacement(
+            arg0: T.Buffer((4, 4), "float32"),
+            arg1: T.Buffer((4, 4), "float32"),
+            output: T.Buffer((4, 4), "float32"),
+        ):
             T.func_attr({"operator_name": "relax.add"})
             # with T.block("root"):
             for ax0, ax1 in T.grid(4, 4):
@@ -54,16 +56,38 @@ def test_optimize_transform_layout_pass_one_arg():
                     output[v_ax0, v_ax1] = arg0[v_ax0, v_ax1] + arg1[v_ax0, v_ax1]
 
         @R.function
-        def main(x: R.Tensor((16,), dtype="float32"), y: R.Tensor((16,), dtype="float32")) -> R.Tensor((16,), dtype="float32"):
+        def main(
+            x: R.Tensor((16,), dtype="float32"), y: R.Tensor((16,), dtype="float32")
+        ) -> R.Tensor((16,), dtype="float32"):
             with R.dataflow():
-                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(x, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv2 = R.call_tir(Before.relax_add_replacement, (lv, lv1), out_sinfo=R.Tensor((4, 4), dtype="float32"))
-                lv0: R.Tensor((16,), dtype="float32") = R.layout_transform(lv2, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
-                lv3: R.Tensor((4, 4), dtype="float32") = R.layout_transform(lv0, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv4: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv5 = R.call_tir(Before.relax_add_replacement, (lv4, lv3), out_sinfo=R.Tensor((4, 4), dtype="float32"))
-                lv2_1: R.Tensor((16,), dtype="float32") = R.layout_transform(lv5, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    x, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    y, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv2 = R.call_tir(
+                    Before.relax_add_replacement,
+                    (lv, lv1),
+                    out_sinfo=R.Tensor((4, 4), dtype="float32"),
+                )
+                lv0: R.Tensor((16,), dtype="float32") = R.layout_transform(
+                    lv2, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None
+                )
+                lv3: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    lv0, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv4: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    y, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv5 = R.call_tir(
+                    Before.relax_add_replacement,
+                    (lv4, lv3),
+                    out_sinfo=R.Tensor((4, 4), dtype="float32"),
+                )
+                lv2_1: R.Tensor((16,), dtype="float32") = R.layout_transform(
+                    lv5, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None
+                )
                 gv: R.Tensor((16,), dtype="float32") = lv2_1
                 R.output(gv)
             return gv
@@ -71,7 +95,11 @@ def test_optimize_transform_layout_pass_one_arg():
     @I.ir_module
     class Expected:
         @T.prim_func(private=True)
-        def relax_add_replacement(arg0: T.Buffer((4, 4), "float32"), arg1: T.Buffer((4, 4), "float32"), output: T.Buffer((4, 4), "float32")):
+        def relax_add_replacement(
+            arg0: T.Buffer((4, 4), "float32"),
+            arg1: T.Buffer((4, 4), "float32"),
+            output: T.Buffer((4, 4), "float32"),
+        ):
             T.func_attr({"operator_name": "relax.add"})
             # with T.block("root"):
             for ax0, ax1 in T.grid(4, 4):
@@ -82,14 +110,32 @@ def test_optimize_transform_layout_pass_one_arg():
                     output[v_ax0, v_ax1] = arg0[v_ax0, v_ax1] + arg1[v_ax0, v_ax1]
 
         @R.function
-        def main(x: R.Tensor((16,), dtype="float32"), y: R.Tensor((16,), dtype="float32")) -> R.Tensor((16,), dtype="float32"):
+        def main(
+            x: R.Tensor((16,), dtype="float32"), y: R.Tensor((16,), dtype="float32")
+        ) -> R.Tensor((16,), dtype="float32"):
             with R.dataflow():
-                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(x, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv2 = R.call_tir(Expected.relax_add_replacement, (lv, lv1), out_sinfo=R.Tensor((4, 4), dtype="float32"))
-                lv4: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv5 = R.call_tir(Expected.relax_add_replacement, (lv4, lv2), out_sinfo=R.Tensor((4, 4), dtype="float32"))
-                lv2_1: R.Tensor((16,), dtype="float32") = R.layout_transform(lv5, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    x, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    y, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv2 = R.call_tir(
+                    Expected.relax_add_replacement,
+                    (lv, lv1),
+                    out_sinfo=R.Tensor((4, 4), dtype="float32"),
+                )
+                lv4: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    y, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv5 = R.call_tir(
+                    Expected.relax_add_replacement,
+                    (lv4, lv2),
+                    out_sinfo=R.Tensor((4, 4), dtype="float32"),
+                )
+                lv2_1: R.Tensor((16,), dtype="float32") = R.layout_transform(
+                    lv5, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None
+                )
                 gv: R.Tensor((16,), dtype="float32") = lv2_1
                 R.output(gv)
             return gv
@@ -98,11 +144,14 @@ def test_optimize_transform_layout_pass_one_arg():
 
 
 def test_optimize_transform_layout_pass_two_args():
-
     @I.ir_module
     class Before:
         @T.prim_func(private=True)
-        def relax_add_replacement(arg0: T.Buffer((4, 4), "float32"), arg1: T.Buffer((4, 4), "float32"), output: T.Buffer((4, 4), "float32")):
+        def relax_add_replacement(
+            arg0: T.Buffer((4, 4), "float32"),
+            arg1: T.Buffer((4, 4), "float32"),
+            output: T.Buffer((4, 4), "float32"),
+        ):
             T.func_attr({"operator_name": "relax.add"})
             # with T.block("root"):
             for ax0, ax1 in T.grid(4, 4):
@@ -113,19 +162,51 @@ def test_optimize_transform_layout_pass_two_args():
                     output[v_ax0, v_ax1] = arg0[v_ax0, v_ax1] + arg1[v_ax0, v_ax1]
 
         @R.function
-        def main(x: R.Tensor((16,), dtype="float32"), y: R.Tensor((16,), dtype="float32"), z: R.Tensor((16,), dtype="float32")) -> R.Tensor((16,), dtype="float32"):
+        def main(
+            x: R.Tensor((16,), dtype="float32"),
+            y: R.Tensor((16,), dtype="float32"),
+            z: R.Tensor((16,), dtype="float32"),
+        ) -> R.Tensor((16,), dtype="float32"):
             with R.dataflow():
-                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(x, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv2: R.Tensor((4, 4), dtype="float32") = R.layout_transform(z, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv3 = R.call_tir(Before.relax_add_replacement, (lv, lv1), out_sinfo=R.Tensor((4, 4), dtype="float32"))
-                lv4 = R.call_tir(Before.relax_add_replacement, (lv, lv2), out_sinfo=R.Tensor((4, 4), dtype="float32"))
-                lv5: R.Tensor((16,), dtype="float32") = R.layout_transform(lv3, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
-                lv6: R.Tensor((16,), dtype="float32") = R.layout_transform(lv4, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
-                lv7: R.Tensor((4, 4), dtype="float32") = R.layout_transform(lv5, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv8: R.Tensor((4, 4), dtype="float32") = R.layout_transform(lv6, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv9 = R.call_tir(Before.relax_add_replacement, (lv7, lv8), out_sinfo=R.Tensor((4, 4), dtype="float32"))
-                lv10: R.Tensor((16,), dtype="float32") = R.layout_transform(lv9, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    x, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    y, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv2: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    z, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv3 = R.call_tir(
+                    Before.relax_add_replacement,
+                    (lv, lv1),
+                    out_sinfo=R.Tensor((4, 4), dtype="float32"),
+                )
+                lv4 = R.call_tir(
+                    Before.relax_add_replacement,
+                    (lv, lv2),
+                    out_sinfo=R.Tensor((4, 4), dtype="float32"),
+                )
+                lv5: R.Tensor((16,), dtype="float32") = R.layout_transform(
+                    lv3, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None
+                )
+                lv6: R.Tensor((16,), dtype="float32") = R.layout_transform(
+                    lv4, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None
+                )
+                lv7: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    lv5, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv8: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    lv6, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv9 = R.call_tir(
+                    Before.relax_add_replacement,
+                    (lv7, lv8),
+                    out_sinfo=R.Tensor((4, 4), dtype="float32"),
+                )
+                lv10: R.Tensor((16,), dtype="float32") = R.layout_transform(
+                    lv9, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None
+                )
                 gv: R.Tensor((16,), dtype="float32") = lv10
                 R.output(gv)
             return gv
@@ -133,7 +214,11 @@ def test_optimize_transform_layout_pass_two_args():
     @I.ir_module
     class Expected:
         @T.prim_func(private=True)
-        def relax_add_replacement(arg0: T.Buffer((4, 4), "float32"), arg1: T.Buffer((4, 4), "float32"), output: T.Buffer((4, 4), "float32")):
+        def relax_add_replacement(
+            arg0: T.Buffer((4, 4), "float32"),
+            arg1: T.Buffer((4, 4), "float32"),
+            output: T.Buffer((4, 4), "float32"),
+        ):
             T.func_attr({"operator_name": "relax.add"})
             # with T.block("root"):
             for ax0, ax1 in T.grid(4, 4):
@@ -144,15 +229,39 @@ def test_optimize_transform_layout_pass_two_args():
                     output[v_ax0, v_ax1] = arg0[v_ax0, v_ax1] + arg1[v_ax0, v_ax1]
 
         @R.function
-        def main(x: R.Tensor((16,), dtype="float32"), y: R.Tensor((16,), dtype="float32"), z: R.Tensor((16,), dtype="float32")) -> R.Tensor((16,), dtype="float32"):
+        def main(
+            x: R.Tensor((16,), dtype="float32"),
+            y: R.Tensor((16,), dtype="float32"),
+            z: R.Tensor((16,), dtype="float32"),
+        ) -> R.Tensor((16,), dtype="float32"):
             with R.dataflow():
-                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(x, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv2: R.Tensor((4, 4), dtype="float32") = R.layout_transform(z, index_map=lambda i: (i // 4, i % 4), pad_value=None)
-                lv3 = R.call_tir(Expected.relax_add_replacement, (lv, lv1), out_sinfo=R.Tensor((4, 4), dtype="float32"))
-                lv4 = R.call_tir(Expected.relax_add_replacement, (lv, lv2), out_sinfo=R.Tensor((4, 4), dtype="float32"))
-                lv5 = R.call_tir(Expected.relax_add_replacement, (lv3, lv4), out_sinfo=R.Tensor((4, 4), dtype="float32"))
-                lv6: R.Tensor((16,), dtype="float32") = R.layout_transform(lv5, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    x, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    y, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv2: R.Tensor((4, 4), dtype="float32") = R.layout_transform(
+                    z, index_map=lambda i: (i // 4, i % 4), pad_value=None
+                )
+                lv3 = R.call_tir(
+                    Expected.relax_add_replacement,
+                    (lv, lv1),
+                    out_sinfo=R.Tensor((4, 4), dtype="float32"),
+                )
+                lv4 = R.call_tir(
+                    Expected.relax_add_replacement,
+                    (lv, lv2),
+                    out_sinfo=R.Tensor((4, 4), dtype="float32"),
+                )
+                lv5 = R.call_tir(
+                    Expected.relax_add_replacement,
+                    (lv3, lv4),
+                    out_sinfo=R.Tensor((4, 4), dtype="float32"),
+                )
+                lv6: R.Tensor((16,), dtype="float32") = R.layout_transform(
+                    lv5, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None
+                )
                 gv: R.Tensor((16,), dtype="float32") = lv6
                 R.output(gv)
             return gv

--- a/tests/python/relax/test_optimize_layout_transform.py
+++ b/tests/python/relax/test_optimize_layout_transform.py
@@ -1,0 +1,164 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests to validate relax optimize layout tranform pass."""
+
+import numpy as np
+import pytest
+import tvm.testing
+from tvm import relax
+from tvm.ir.base import assert_structural_equal
+from tvm.relax.transform import OptimizeLayoutTransform
+from tvm.script import ir as I, tir as T, relax as R
+
+
+def _run_pass_compare_output(Before, Expected):
+    fused_mod = OptimizeLayoutTransform()(Before)
+    if not relax.analysis.well_formed(fused_mod):
+        print("IRModule is not well-formed")
+
+    fused_mod = relax.transform.FuseTIR()(fused_mod)
+    if not relax.analysis.well_formed(fused_mod):
+        print("IRModule is not well-formed")
+
+    tvm.ir.assert_structural_equal(Expected, fused_mod)
+
+
+def test_optimize_transform_layout_pass_one_arg():
+
+    @I.ir_module
+    class Before:
+        @T.prim_func(private=True)
+        def relax_add_replacement(arg0: T.Buffer((4, 4), "float32"), arg1: T.Buffer((4, 4), "float32"), output: T.Buffer((4, 4), "float32")):
+            T.func_attr({"operator_name": "relax.add"})
+            # with T.block("root"):
+            for ax0, ax1 in T.grid(4, 4):
+                with T.block("T_add"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(arg0[v_ax0, v_ax1], arg1[v_ax0, v_ax1])
+                    T.writes(output[v_ax0, v_ax1])
+                    output[v_ax0, v_ax1] = arg0[v_ax0, v_ax1] + arg1[v_ax0, v_ax1]
+
+        @R.function
+        def main(x: R.Tensor((16,), dtype="float32"), y: R.Tensor((16,), dtype="float32")) -> R.Tensor((16,), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(x, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv2 = R.call_tir(Before.relax_add_replacement, (lv, lv1), out_sinfo=R.Tensor((4, 4), dtype="float32"))
+                lv0: R.Tensor((16,), dtype="float32") = R.layout_transform(lv2, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                lv3: R.Tensor((4, 4), dtype="float32") = R.layout_transform(lv0, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv4: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv5 = R.call_tir(Before.relax_add_replacement, (lv4, lv3), out_sinfo=R.Tensor((4, 4), dtype="float32"))
+                lv2_1: R.Tensor((16,), dtype="float32") = R.layout_transform(lv5, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                gv: R.Tensor((16,), dtype="float32") = lv2_1
+                R.output(gv)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @T.prim_func(private=True)
+        def relax_add_replacement(arg0: T.Buffer((4, 4), "float32"), arg1: T.Buffer((4, 4), "float32"), output: T.Buffer((4, 4), "float32")):
+            T.func_attr({"operator_name": "relax.add"})
+            # with T.block("root"):
+            for ax0, ax1 in T.grid(4, 4):
+                with T.block("T_add"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(arg0[v_ax0, v_ax1], arg1[v_ax0, v_ax1])
+                    T.writes(output[v_ax0, v_ax1])
+                    output[v_ax0, v_ax1] = arg0[v_ax0, v_ax1] + arg1[v_ax0, v_ax1]
+
+        @R.function
+        def main(x: R.Tensor((16,), dtype="float32"), y: R.Tensor((16,), dtype="float32")) -> R.Tensor((16,), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(x, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv2 = R.call_tir(Expected.relax_add_replacement, (lv, lv1), out_sinfo=R.Tensor((4, 4), dtype="float32"))
+                lv4: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv5 = R.call_tir(Expected.relax_add_replacement, (lv4, lv2), out_sinfo=R.Tensor((4, 4), dtype="float32"))
+                lv2_1: R.Tensor((16,), dtype="float32") = R.layout_transform(lv5, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                gv: R.Tensor((16,), dtype="float32") = lv2_1
+                R.output(gv)
+            return gv
+
+    _run_pass_compare_output(Before, Expected)
+
+
+def test_optimize_transform_layout_pass_two_args():
+
+    @I.ir_module
+    class Before:
+        @T.prim_func(private=True)
+        def relax_add_replacement(arg0: T.Buffer((4, 4), "float32"), arg1: T.Buffer((4, 4), "float32"), output: T.Buffer((4, 4), "float32")):
+            T.func_attr({"operator_name": "relax.add"})
+            # with T.block("root"):
+            for ax0, ax1 in T.grid(4, 4):
+                with T.block("T_add"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(arg0[v_ax0, v_ax1], arg1[v_ax0, v_ax1])
+                    T.writes(output[v_ax0, v_ax1])
+                    output[v_ax0, v_ax1] = arg0[v_ax0, v_ax1] + arg1[v_ax0, v_ax1]
+
+        @R.function
+        def main(x: R.Tensor((16,), dtype="float32"), y: R.Tensor((16,), dtype="float32"), z: R.Tensor((16,), dtype="float32")) -> R.Tensor((16,), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(x, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv2: R.Tensor((4, 4), dtype="float32") = R.layout_transform(z, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv3 = R.call_tir(Before.relax_add_replacement, (lv, lv1), out_sinfo=R.Tensor((4, 4), dtype="float32"))
+                lv4 = R.call_tir(Before.relax_add_replacement, (lv, lv2), out_sinfo=R.Tensor((4, 4), dtype="float32"))
+                lv5: R.Tensor((16,), dtype="float32") = R.layout_transform(lv3, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                lv6: R.Tensor((16,), dtype="float32") = R.layout_transform(lv4, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                lv7: R.Tensor((4, 4), dtype="float32") = R.layout_transform(lv5, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv8: R.Tensor((4, 4), dtype="float32") = R.layout_transform(lv6, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv9 = R.call_tir(Before.relax_add_replacement, (lv7, lv8), out_sinfo=R.Tensor((4, 4), dtype="float32"))
+                lv10: R.Tensor((16,), dtype="float32") = R.layout_transform(lv9, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                gv: R.Tensor((16,), dtype="float32") = lv10
+                R.output(gv)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @T.prim_func(private=True)
+        def relax_add_replacement(arg0: T.Buffer((4, 4), "float32"), arg1: T.Buffer((4, 4), "float32"), output: T.Buffer((4, 4), "float32")):
+            T.func_attr({"operator_name": "relax.add"})
+            # with T.block("root"):
+            for ax0, ax1 in T.grid(4, 4):
+                with T.block("T_add"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(arg0[v_ax0, v_ax1], arg1[v_ax0, v_ax1])
+                    T.writes(output[v_ax0, v_ax1])
+                    output[v_ax0, v_ax1] = arg0[v_ax0, v_ax1] + arg1[v_ax0, v_ax1]
+
+        @R.function
+        def main(x: R.Tensor((16,), dtype="float32"), y: R.Tensor((16,), dtype="float32"), z: R.Tensor((16,), dtype="float32")) -> R.Tensor((16,), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((4, 4), dtype="float32") = R.layout_transform(x, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv1: R.Tensor((4, 4), dtype="float32") = R.layout_transform(y, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv2: R.Tensor((4, 4), dtype="float32") = R.layout_transform(z, index_map=lambda i: (i // 4, i % 4), pad_value=None)
+                lv3 = R.call_tir(Expected.relax_add_replacement, (lv, lv1), out_sinfo=R.Tensor((4, 4), dtype="float32"))
+                lv4 = R.call_tir(Expected.relax_add_replacement, (lv, lv2), out_sinfo=R.Tensor((4, 4), dtype="float32"))
+                lv5 = R.call_tir(Expected.relax_add_replacement, (lv3, lv4), out_sinfo=R.Tensor((4, 4), dtype="float32"))
+                lv6: R.Tensor((16,), dtype="float32") = R.layout_transform(lv5, index_map=lambda axis0, axis1: (axis0 * 4 + axis1,), pad_value=None)
+                gv: R.Tensor((16,), dtype="float32") = lv6
+                R.output(gv)
+            return gv
+
+    _run_pass_compare_output(Before, Expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Relax `AlterOpImpl` pass introduces `layout_transform` operations. If the layouts match for consecutive `layout_transform` operations, they can be cancelled out. This pass tries to optimize redundant `transform_layout` operations.

This is also addressing P4 in https://github.com/apache/tvm/issues/14070 