### PR TITLE
[Relay] Fuse clip operators in yolov5

### DIFF
--- a/src/relay/transforms/simplify_expr.cc
+++ b/src/relay/transforms/simplify_expr.cc
@@ -327,6 +327,56 @@ static std::vector<int> GetTransposeAxisOrder(const Call& call, int ndim) {
 }
 
 /*!
+ * \brief SimplifyClipCastClip matches the pattern clip->cast->clip and fuse clips based on Clip
+ *    min/max values.
+ *
+ * Example:
+ *   %1 = clip(%0, a_min=0f, a_max=255f) [type=int32]
+ *   %2 = cast(%1, dtype="uint8") [type=uint8]
+ *   %3 = clip(%2, a_min=20f, a_max=66f) [type=uint8]
+ *
+ * Optimized to (fuse Clips):
+ *   %1 = clip(%0, a_min=20f, a_max=66f) [type=uint8]
+ *   %2 = cast(%1, dtype="uint8") [type=uint8]
+ */
+class SimplifyClipCastClip : public DFPatternRewrite {
+ public:
+  SimplifyClipCastClip() {
+    data_ = IsWildcard();
+    clip1_ = IsOp("clip")({data_});
+    cast_ = IsOp("cast")({clip1_});
+    pattern_ = IsOp("clip")({cast_});
+  }
+
+  Expr Callback(const Expr& pre, const Expr& post,
+                const Map<DFPattern, Array<Expr>>& node_map) const override {
+    auto clip1 = Downcast<Call>(node_map[clip1_][0]);
+    const CallNode* clip1_node = clip1.as<CallNode>();
+    const ClipAttrs* clip1_attrs = clip1_node->attrs.as<ClipAttrs>();
+
+    auto cast = Downcast<Call>(node_map[cast_][0]);
+    const CallNode* cast_node = cast.as<CallNode>();
+    DataType cast_type = Downcast<TensorType>(cast_node->checked_type())->dtype;
+
+    auto clip2 = Downcast<Call>(post);
+    const CallNode* clip2_node = clip2.as<CallNode>();
+    const ClipAttrs* clip2_attrs = clip2_node->attrs.as<ClipAttrs>();
+
+    auto data = node_map[data_][0];
+    auto clip_fuse_attrs = make_object<ClipAttrs>();
+    clip_fuse_attrs->a_min =
+        (clip1_attrs->a_min < clip2_attrs->a_min) ? clip2_attrs->a_min : clip1_attrs->a_min;
+    clip_fuse_attrs->a_max =
+        (clip1_attrs->a_max < clip2_attrs->a_max) ? clip1_attrs->a_max : clip2_attrs->a_max;
+    Expr clip_fuse = Call(Op::Get("clip"), {data}, Attrs(clip_fuse_attrs), {});
+    return MakeCast(clip_fuse, cast_type);
+  }
+
+ protected:
+  DFPattern data_, clip1_, cast_;
+};
+
+/*!
  * \brief SimplifyTranspose matches the pattern of consecutive transpose op,
  *   and merges or cancels them.
  */
@@ -1120,6 +1170,7 @@ Expr SimplifyExpr(const Expr& expr, const IRModule& mod) {
   composer.AddRewrite<SimplifyDQArgSort>();
   composer.AddRewrite<SimplifyClipAndConsecutiveCast>();
   composer.AddRewrite<SimplifyClip>();
+  composer.AddRewrite<SimplifyClipCastClip>();
   composer.AddRewrite<SimplifyBinomial>();
   return RewritePatterns(composer.MakeCallbacks(), expr, mod);
 }
@@ -1134,6 +1185,7 @@ Expr SimplifyExprPostAlterOp(const Expr& expr, const IRModule& mod) {
   composer.AddRewrite<SimplifyConsecutiveCast>();
   composer.AddRewrite<SimplifyClipAndConsecutiveCast>();
   composer.AddRewrite<SimplifyClip>();
+  composer.AddRewrite<SimplifyClipCastClip>();
   return RewritePatterns(composer.MakeCallbacks(), expr, mod);
 }
 

--- a/src/relay/transforms/simplify_expr.cc
+++ b/src/relay/transforms/simplify_expr.cc
@@ -336,7 +336,7 @@ static std::vector<int> GetTransposeAxisOrder(const Call& call, int ndim) {
  *   %3 = clip(%2, a_min=20f, a_max=66f) [type=uint8]
  *
  * Optimized to (fuse Clips):
- *   %1 = clip(%0, a_min=20f, a_max=66f) [type=uint8]
+ *   %1 = clip(%0, a_min=20f, a_max=66f) [type=int32]
  *   %2 = cast(%1, dtype="uint8") [type=uint8]
  */
 class SimplifyClipCastClip : public DFPatternRewrite {

--- a/tests/python/relay/test_pass_simplify_expr.py
+++ b/tests/python/relay/test_pass_simplify_expr.py
@@ -720,6 +720,25 @@ def test_simplify_dq_argsort():
     after = run_opt_pass(expected(), transform.InferType())
     assert tvm.ir.structural_equal(opt, after)
 
+def test_simplify_clip_cast_clip():
+    x = relay.var("x", shape=(4, 8), dtype="int32")
+    a_min_1 = np.random.randint(low=0, high=127)
+    a_max_1 = np.random.randint(low=128, high=255)
+    a_min_2 = np.random.randint(low=0, high=127)
+    a_max_2 = np.random.randint(low=128, high=255)
+
+    def before():
+        clip = relay.clip(x, a_min=a_min_1, a_max=a_max_1)
+        cast = relay.cast(clip, "uint8")
+        return relay.clip(cast, a_min=a_min_2, a_max=a_max_2)
+
+    def expected():
+        clip = relay.clip(x, a_min=a_min_1 if a_min_1 > a_min_2 else a_min_2,
+                          a_max=a_max_1 if a_max_1 < a_max_1 else a_max_2)
+        return relay.cast(clip, "uint8")
+
+    opt = run_opt_pass(before(), transform.SimplifyExpr())
+    ref = run_infer_type(expected())
 
 def test_simplify_clip_cast():
     def before1():

--- a/tests/python/relay/test_pass_simplify_expr.py
+++ b/tests/python/relay/test_pass_simplify_expr.py
@@ -347,14 +347,12 @@ def test_simplify_full_elementwise():
             for full in full_ops:
                 z = before_left(x, op, full)
                 zz = run_opt_pass(z, transform.SimplifyExpr())
-                after = run_opt_pass(after_left(
-                    x, op, value), transform.InferType())
+                after = run_opt_pass(after_left(x, op, value), transform.InferType())
                 assert tvm.ir.structural_equal(zz, after)
 
                 z = before_right(x, op, full)
                 zz = run_opt_pass(z, transform.SimplifyExpr())
-                after = run_opt_pass(after_right(
-                    x, op, value), transform.InferType())
+                after = run_opt_pass(after_right(x, op, value), transform.InferType())
                 assert tvm.ir.structural_equal(zz, after)
 
         # Test the case in which x is broadcast to full's shape
@@ -369,14 +367,12 @@ def test_simplify_full_elementwise():
             for full in full_ops:
                 z = before_left(x, op, full)
                 zz = run_opt_pass(z, transform.SimplifyExpr())
-                after = run_opt_pass(before_left(
-                    x, op, full), transform.InferType())
+                after = run_opt_pass(before_left(x, op, full), transform.InferType())
                 assert tvm.ir.structural_equal(zz, after)
 
                 z = before_right(x, op, full)
                 zz = run_opt_pass(z, transform.SimplifyExpr())
-                after = run_opt_pass(before_right(
-                    x, op, full), transform.InferType())
+                after = run_opt_pass(before_right(x, op, full), transform.InferType())
                 assert tvm.ir.structural_equal(zz, after)
 
     for shape in [[10], [10, 10], [10, 10, 10]]:
@@ -654,8 +650,7 @@ def test_simplify_mul_add():
         c3 * (c2 + x * c1),
         c3 * (c2 + c1 * x),
     ]
-    expect_expr = x * relay.const(c1_val * c3_val) + \
-        relay.const(c2_val * c3_val)
+    expect_expr = x * relay.const(c1_val * c3_val) + relay.const(c2_val * c3_val)
     check_simple_fold(origin_exprs, expect_expr)
 
 
@@ -739,8 +734,11 @@ def test_simplify_clip_cast_clip():
         return relay.clip(cast, a_min=a_min_2, a_max=a_max_2)
 
     def expected():
-        clip = relay.clip(x, a_min=a_min_1 if a_min_1 > a_min_2 else a_min_2,
-                          a_max=a_max_1 if a_max_1 < a_max_1 else a_max_2)
+        clip = relay.clip(
+            x,
+            a_min=a_min_1 if a_min_1 > a_min_2 else a_min_2,
+            a_max=a_max_1 if a_max_1 < a_max_1 else a_max_2,
+        )
         return relay.cast(clip, "uint8")
 
     opt = run_opt_pass(before(), transform.SimplifyExpr())
@@ -918,10 +916,8 @@ def test_binomials():
         q_val = (b - sqrt(det)) / (2 * a)
         p = relay.const(p_val, dtype=dtype)
         q = relay.const(q_val, dtype=dtype)
-        first_exp = [x + y, y + x] if p_val == 1 else [x +
-                                                       p * y, p * y + x, x + y * p, y * p + x]
-        second_exp = [x + y, y + x] if q_val == 1 else [x +
-                                                        q * y, q * y + x, x + y * q, y * q + x]
+        first_exp = [x + y, y + x] if p_val == 1 else [x + p * y, p * y + x, x + y * p, y * p + x]
+        second_exp = [x + y, y + x] if q_val == 1 else [x + q * y, q * y + x, x + y * q, y * q + x]
         final_exp = []
         for f in first_exp:
             for s in second_exp:

--- a/tests/python/relay/test_pass_simplify_expr.py
+++ b/tests/python/relay/test_pass_simplify_expr.py
@@ -347,12 +347,14 @@ def test_simplify_full_elementwise():
             for full in full_ops:
                 z = before_left(x, op, full)
                 zz = run_opt_pass(z, transform.SimplifyExpr())
-                after = run_opt_pass(after_left(x, op, value), transform.InferType())
+                after = run_opt_pass(after_left(
+                    x, op, value), transform.InferType())
                 assert tvm.ir.structural_equal(zz, after)
 
                 z = before_right(x, op, full)
                 zz = run_opt_pass(z, transform.SimplifyExpr())
-                after = run_opt_pass(after_right(x, op, value), transform.InferType())
+                after = run_opt_pass(after_right(
+                    x, op, value), transform.InferType())
                 assert tvm.ir.structural_equal(zz, after)
 
         # Test the case in which x is broadcast to full's shape
@@ -367,12 +369,14 @@ def test_simplify_full_elementwise():
             for full in full_ops:
                 z = before_left(x, op, full)
                 zz = run_opt_pass(z, transform.SimplifyExpr())
-                after = run_opt_pass(before_left(x, op, full), transform.InferType())
+                after = run_opt_pass(before_left(
+                    x, op, full), transform.InferType())
                 assert tvm.ir.structural_equal(zz, after)
 
                 z = before_right(x, op, full)
                 zz = run_opt_pass(z, transform.SimplifyExpr())
-                after = run_opt_pass(before_right(x, op, full), transform.InferType())
+                after = run_opt_pass(before_right(
+                    x, op, full), transform.InferType())
                 assert tvm.ir.structural_equal(zz, after)
 
     for shape in [[10], [10, 10], [10, 10, 10]]:
@@ -650,7 +654,8 @@ def test_simplify_mul_add():
         c3 * (c2 + x * c1),
         c3 * (c2 + c1 * x),
     ]
-    expect_expr = x * relay.const(c1_val * c3_val) + relay.const(c2_val * c3_val)
+    expect_expr = x * relay.const(c1_val * c3_val) + \
+        relay.const(c2_val * c3_val)
     check_simple_fold(origin_exprs, expect_expr)
 
 
@@ -720,6 +725,7 @@ def test_simplify_dq_argsort():
     after = run_opt_pass(expected(), transform.InferType())
     assert tvm.ir.structural_equal(opt, after)
 
+
 def test_simplify_clip_cast_clip():
     x = relay.var("x", shape=(4, 8), dtype="int32")
     a_min_1 = np.random.randint(low=0, high=127)
@@ -739,6 +745,8 @@ def test_simplify_clip_cast_clip():
 
     opt = run_opt_pass(before(), transform.SimplifyExpr())
     ref = run_infer_type(expected())
+    assert tvm.ir.structural_equal(opt, ref)
+
 
 def test_simplify_clip_cast():
     def before1():
@@ -910,8 +918,10 @@ def test_binomials():
         q_val = (b - sqrt(det)) / (2 * a)
         p = relay.const(p_val, dtype=dtype)
         q = relay.const(q_val, dtype=dtype)
-        first_exp = [x + y, y + x] if p_val == 1 else [x + p * y, p * y + x, x + y * p, y * p + x]
-        second_exp = [x + y, y + x] if q_val == 1 else [x + q * y, q * y + x, x + y * q, y * q + x]
+        first_exp = [x + y, y + x] if p_val == 1 else [x +
+                                                       p * y, p * y + x, x + y * p, y * p + x]
+        second_exp = [x + y, y + x] if q_val == 1 else [x +
+                                                        q * y, q * y + x, x + y * q, y * q + x]
         final_exp = []
         for f in first_exp:
             for s in second_exp:


### PR DESCRIPTION
When I specify the ReLU6 activation function in yolov5， This redundancy occurs.
For example:
![image](https://github.com/apache/tvm/assets/41790911/add17bfa-2f3c-4553-b8fe-7c140e50d847)
It generates this IR：
```
  %233 = nn.conv2d(%231, meta[relay.Constant][54] /* ty=Tensor[(256, 256, 1, 1), int8] */, padding=[0, 0, 0, 0], channels=256, kernel_size=[1, 1], out_dtype="int32") /* ty=Tensor[(1, 256, 16, 16), int32] */;
  %234 = add(%233, meta[relay.Constant][55] /* ty=Tensor[(256, 1, 1), int32] */) /* ty=Tensor[(1, 256, 16, 16), int32] */;
  %235 = fixed_point_multiply(%234, multiplier=2097356939, shift=-6) /* ty=Tensor[(1, 256, 16, 16), int32] */;
  %236 = clip(%235, a_min=-128f, a_max=127f) /* ty=Tensor[(1, 256, 16, 16), int32] */;
  %237 = cast(%236, dtype="int8") /* ty=Tensor[(1, 256, 16, 16), int8] */;
  %238 = clip(%237, a_min=0f, a_max=48f) /* ty=Tensor[(1, 256, 16, 16), int8] */;
```

The redundancy pattern is：
```
 Example:
  %1 = clip(%0, a_min=0f, a_max=255f) [type=int32]
  %2 = cast(%1, dtype="uint8") [type=uint8]
  %3 = clip(%2, a_min=20f, a_max=66f) [type=uint8]
```

It can be optimized to:
```
 %1 = clip(%0, a_min=20f, a_max=66f) [type=int32]
 %2 = cast(%1, dtype="uint8") [type=uint8]
```

This PR is to simplify `clip->cast->clip` to `clip->cast`