### PR TITLE
[Target][TOPI] Use LLVM for x86 CPU feature lookup

### DIFF
--- a/include/tvm/target/target_kind.h
+++ b/include/tvm/target/target_kind.h
@@ -130,10 +130,10 @@ class TargetKind : public ObjectRef {
    */
   TVM_DLL static Optional<TargetKind> Get(const String& target_kind_name);
   TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TargetKind, ObjectRef, TargetKindNode);
-
- private:
   /*! \brief Mutable access to the container class  */
   TargetKindNode* operator->() { return static_cast<TargetKindNode*>(data_.get()); }
+
+ private:
   TVM_DLL static const AttrRegistryMapContainerMap<TargetKind>& GetAttrMapContainer(
       const String& attr_name);
   friend class TargetKindRegEntry;

--- a/python/tvm/relay/qnn/op/legalizations.py
+++ b/python/tvm/relay/qnn/op/legalizations.py
@@ -23,7 +23,7 @@ from tvm import relay
 from tvm._ffi.base import TVMError
 from tvm.relay.qnn.op.canonicalizations import create_integer_lookup_op
 
-from ....target.x86 import target_has_sse42
+from ....target.x86 import target_has_features
 from ....topi.utils import is_target
 from .. import op as reg
 
@@ -457,8 +457,7 @@ def helper_change_dtypes_to_be_same(attrs, inputs, types, relay_op):
 
 def is_fast_int8_on_intel():
     """Checks whether the hardware has support for fast Int8 arithmetic operations."""
-    target = tvm.target.Target.current(allow_none=False)
-    return target_has_sse42(target.mcpu)
+    return target_has_features("sse4.2")
 
 
 # Helper function to align up given value.

--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -27,7 +27,7 @@ from tvm.relay.op.nn.utils import get_pad_tuple2d
 from tvm.runtime import Object
 from tvm.target import Target
 from tvm.topi.nn.qnn import SQNN_DTYPE_TO_CODE
-from tvm.target.x86 import target_has_sse41
+from tvm.target.x86 import target_has_features
 
 from . import _make, _requantize
 
@@ -54,8 +54,9 @@ class RequantizeConfig(Object):
     @staticmethod
     def _get_node_default_compute_dtype():
         target = Target.current(True)
-        if target and str(target.kind) == "llvm" and target_has_sse41(target.mcpu):
-            return "float32"
+        if target and str(target.kind) == "llvm":
+            if target_has_features("sse4.1", target):
+                return "float32"
 
         return "int64"
 

--- a/python/tvm/target/codegen.py
+++ b/python/tvm/target/codegen.py
@@ -71,6 +71,38 @@ def llvm_get_intrinsic_name(intrin_id: int) -> str:
     return _ffi_api.llvm_get_intrinsic_name(intrin_id)
 
 
+def llvm_x86_get_archlist(only64bit=False):
+    """Get X86 CPU name list.
+
+    Parameters
+    ----------
+    only64bit : bool
+        Filter 64bit architectures.
+
+    Returns
+    -------
+    features : list[str]
+        String list of X86 architectures.
+    """
+    return _ffi_api.llvm_x86_get_archlist(only64bit)
+
+
+def llvm_x86_get_features(cpu_name):
+    """Get X86 CPU features.
+
+    Parameters
+    ----------
+    cpu_name : string
+        X86 CPU name (e.g. "skylake").
+
+    Returns
+    -------
+    features : list[str]
+        String list of X86 CPU features.
+    """
+    return _ffi_api.llvm_x86_get_features(cpu_name)
+
+
 def llvm_version_major(allow_none=False):
     """Get the major LLVM version.
 

--- a/python/tvm/topi/x86/batch_matmul.py
+++ b/python/tvm/topi/x86/batch_matmul.py
@@ -21,7 +21,7 @@ import tvm
 from tvm import autotvm, te
 from tvm.autotvm.task.space import SplitEntity
 from tvm.contrib import cblas, mkl
-from tvm.target.x86 import target_has_amx, target_has_avx512
+from tvm.target.x86 import target_has_features
 
 from .. import generic, nn
 from ..transform import layout_transform
@@ -38,8 +38,10 @@ def batch_matmul_int8_compute(cfg, x, y, *_):
     packed_y = layout_transform(y, "BNK", packed_y_layout)
     _, n_o, _, n_i, _ = packed_y.shape
     ak = te.reduce_axis((0, k), name="k")
-    mcpu = tvm.target.Target.current().mcpu
-    if target_has_avx512(mcpu):
+    # avx512f:  llvm.x86.avx512.addpd.w.512 (LLVM auto, added)
+    # avx512bw: llvm.x86.avx512.pmaddubs.w.512" (TVM required)
+    #         + llvm.x86.avx512.pmaddw.d.512"
+    if target_has_features(["avx512bw", "avx512f"]):
         attrs_info = {"schedule_rule": "batch_matmul_int8"}
     else:
         attrs_info = None
@@ -233,14 +235,16 @@ def schedule_batch_matmul(cfg, outs):
 def schedule_batch_matmul_int8(cfg, outs):
     """Schedule for batch_matmul_int8"""
     s = te.create_schedule([x.op for x in outs])
-    mcpu = tvm.target.Target.current().mcpu
 
     def _callback(op):
         if "batch_matmul_int8" in op.tag:
             layout_trans = op.input_tensors[1]
-            if target_has_amx(mcpu):
+            if target_has_features("amx-int8"):
                 batch_matmul_amx_schedule(cfg, s, op.output(0), outs[0], layout_trans)
-            elif target_has_avx512(mcpu):
+            # avx512f:  llvm.x86.avx512.addpd.w.512 (LLVM auto, added)
+            # avx512bw: llvm.x86.avx512.pmaddubs.w.512" (TVM required)
+            #         + llvm.x86.avx512.pmaddw.d.512"
+            elif target_has_features(["avx512bw", "avx512f"]):
                 batch_matmul_int8_schedule(cfg, s, op.output(0), outs[0], layout_trans)
 
     traverse_inline(s, outs[0].op, _callback)

--- a/python/tvm/topi/x86/dense.py
+++ b/python/tvm/topi/x86/dense.py
@@ -23,7 +23,7 @@ import tvm
 from tvm import autotvm, te
 from tvm.autotvm.task.space import SplitEntity
 from tvm.contrib import cblas, dnnl, mkl
-from tvm.target.x86 import get_simd_32bit_lanes, target_has_amx, target_has_avx512
+from tvm.target.x86 import get_simd_32bit_lanes, target_has_features
 
 from .. import generic, tag
 from ..utils import get_const_tuple, traverse_inline
@@ -298,13 +298,15 @@ def dense_int8(cfg, data, weight, bias=None, out_dtype=None):
 def schedule_dense_int8(cfg, outs):
     """Create a schedule for dense__int8"""
     s = te.create_schedule([x.op for x in outs])
-    mcpu = tvm.target.Target.current().mcpu
 
     def _callback(op):
         if "dense_int8" in op.tag:
-            if target_has_amx(mcpu):
+            if target_has_features("amx-int8"):
                 dense_amx_int8_schedule(cfg, s, op.output(0), outs[0])
-            elif target_has_avx512(mcpu):
+            # avx512f:  llvm.x86.avx512.addpd.w.512 (LLVM auto, added)
+            # avx512bw: llvm.x86.avx512.pmaddubs.w.512" (TVM required)
+            #         + llvm.x86.avx512.pmaddw.d.512"
+            elif target_has_features(["avx512bw", "avx512f"]):
                 dense_int8_schedule(cfg, s, op.output(0), outs[0])
 
     traverse_inline(s, outs[0].op, _callback)
@@ -316,8 +318,10 @@ def dense_int8_compute(cfg, X, packed_w, bias=None):
     m, k = X.shape
     n_o, _, n_i, _ = packed_w.shape
     ak = te.reduce_axis((0, k), name="k")
-    mcpu = tvm.target.Target.current().mcpu
-    if target_has_avx512(mcpu):
+    # avx512f:  llvm.x86.avx512.addpd.w.512 (LLVM auto, added)
+    # avx512bw: llvm.x86.avx512.pmaddubs.w.512" (TVM required)
+    #         + llvm.x86.avx512.pmaddw.d.512"
+    if target_has_features(["avx512bw", "avx512f"]):
         target_attr = {"schedule_rule": "meta_schedule.x86.dense_int8"}
     else:
         target_attr = None

--- a/python/tvm/topi/x86/tensor_intrin.py
+++ b/python/tvm/topi/x86/tensor_intrin.py
@@ -19,15 +19,15 @@
 import tvm
 from tvm import te
 import tvm.target.codegen
-from tvm.target.x86 import target_has_sse42, target_has_vnni, get_simd_32bit_lanes
+from tvm.target.x86 import target_has_features, get_simd_32bit_lanes
 
 
 def dot_16x1x16_uint8_int8_int32():
     """Dispatch the most optimized intrin depending on the target"""
-    mcpu = tvm.target.Target.current().mcpu
-
-    assert target_has_sse42(mcpu), "An old Intel machine that does not have fast Int8 support."
-    if target_has_vnni(mcpu):
+    assert target_has_features(
+        "sse4.2"
+    ), "An old Intel machine that does not have fast Int8 support."
+    if target_has_features("avx512vnni") or target_has_features("avxvnni"):
         # VNNI capable platform
         return dot_16x1x16_uint8_int8_int32_cascadelake()
     # vpmaddubsw/vpmaddwd fallback

--- a/src/meta_schedule/space_generator/space_generator.cc
+++ b/src/meta_schedule/space_generator/space_generator.cc
@@ -24,18 +24,21 @@ namespace meta_schedule {
 
 String GetRuleKindFromTarget(const Target& target) {
   if (target->kind->name == "llvm") {
-    static const PackedFunc* f_check_vnni =
-        runtime::Registry::Get("tvm.target.x86.target_has_vnni");
-    ICHECK(f_check_vnni != nullptr) << "The `target_has_vnni` func is not in tvm registry.";
-    if (target->GetAttr<String>("mcpu") &&
-        (*f_check_vnni)(target->GetAttr<String>("mcpu").value())) {
+    static const PackedFunc* llvm_x86_has_feature_fn_ptr =
+        runtime::Registry::Get("target.llvm_x86_has_feature");
+    ICHECK(llvm_x86_has_feature_fn_ptr != nullptr)
+        << "The `target.llvm_x86_has_feature` func is not in tvm registry.";
+    bool have_avx512vnni = (*llvm_x86_has_feature_fn_ptr)("avx512vnni", target);
+    bool have_avxvnni = (*llvm_x86_has_feature_fn_ptr)("avxvnni", target);
+    if (have_avx512vnni || have_avxvnni) {
       return "vnni";
     } else {
-      static const PackedFunc* f_check_avx512 =
-          runtime::Registry::Get("tvm.target.x86.target_has_avx512");
-      ICHECK(f_check_avx512 != nullptr) << "The `target_has_avx512` func is not in tvm registry.";
-      if (target->GetAttr<String>("mcpu") &&
-          (*f_check_avx512)(target->GetAttr<String>("mcpu").value())) {
+      // avx512f:  llvm.x86.avx512.addpd.w.512 (LLVM auto, added)
+      // avx512bw: llvm.x86.avx512.pmaddubs.w.512" (TVM required)
+      //         + llvm.x86.avx512.pmaddw.d.512"
+      bool have_avx512f = (*llvm_x86_has_feature_fn_ptr)("avx512f", target);
+      bool have_avx512bw = (*llvm_x86_has_feature_fn_ptr)("avx512bw", target);
+      if (have_avx512bw && have_avx512f) {
         return "avx512";
       }
     }

--- a/src/relay/qnn/op/requantize.cc
+++ b/src/relay/qnn/op/requantize.cc
@@ -121,12 +121,9 @@ InferCorrectLayoutOutput RequantizeInferCorrectLayout(const Attrs& attrs,
 }
 
 bool has_current_target_sse41_support() {
-  auto target = Target::Current(true);
-  Optional<String> mcpu =
-      target.defined() ? target->GetAttr<String>("mcpu") : Optional<String>(nullptr);
-  auto target_has_sse41_fn_ptr = tvm::runtime::Registry::Get("tvm.target.x86.target_has_sse41");
-  ICHECK(target_has_sse41_fn_ptr) << "Function tvm.target.x86.target_has_sse41 not found";
-  return mcpu && (*target_has_sse41_fn_ptr)(mcpu.value());
+  auto llvm_x86_has_feature_fn_ptr = tvm::runtime::Registry::Get("target.llvm_x86_has_feature");
+  ICHECK(llvm_x86_has_feature_fn_ptr) << "Function target.llvm_x86_has_feature not found";
+  return (*llvm_x86_has_feature_fn_ptr)("sse4.1", Target::Current(true));
 }
 
 /*

--- a/src/relay/qnn/op/requantize_config.h
+++ b/src/relay/qnn/op/requantize_config.h
@@ -61,14 +61,13 @@ class RequantizeConfigNode : public Object {
     // For the x86 architecture, the float32 computation is expected to give significant speedup,
     // with little loss in the accuracy of the requantize operation.
     auto target = Target::Current(true);
-    auto target_has_sse41 = tvm::runtime::Registry::Get("tvm.target.x86.target_has_sse41");
-    ICHECK(target_has_sse41) << "Function tvm.target.x86.target_has_sse41 not found";
-    if (target.defined() && target->kind->name == "llvm" &&
-        (target->GetAttr<String>("mcpu") &&
-         (*target_has_sse41)(target->GetAttr<String>("mcpu").value()))) {
-      return "float32";
+    auto llvm_x86_has_feature_fn_ptr = tvm::runtime::Registry::Get("target.llvm_x86_has_feature");
+    ICHECK(llvm_x86_has_feature_fn_ptr) << "Function target.llvm_x86_has_feature not found";
+    if (target.defined() && target->kind->name == "llvm") {
+      if ((*llvm_x86_has_feature_fn_ptr)("sse4.1", target)) {
+        return "float32";
+      }
     }
-
     return "int64";
   }
 

--- a/tests/python/target/test_x86_features.py
+++ b/tests/python/target/test_x86_features.py
@@ -1,0 +1,176 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+import tvm
+from tvm.target import _ffi_api, codegen, Target
+from tvm.target.x86 import target_has_features
+
+LLVM_VERSION = codegen.llvm_version_major()
+
+min_llvm_version, tvm_target, x86_feature, is_supported = tvm.testing.parameters(
+    # sse4.1
+    (-1, "llvm -mcpu=btver2", "sse4a", True),
+    (-1, "llvm -mcpu=penryn", "sse4.1", True),
+    (-1, "llvm -mcpu=silvermont", "sse4.2", True),
+    (11, "llvm -mcpu=slm", "sse4.2", True),
+    (-1, "llvm -mcpu=goldmont", "sse4.2", True),
+    (-1, "llvm -mcpu=goldmont-plus", "sse4.2", True),
+    (-1, "llvm -mcpu=tremont", "sse4.2", True),
+    (-1, "llvm -mcpu=nehalem", "sse4.2", True),
+    (11, "llvm -mcpu=corei7", "sse4.2", True),
+    (-1, "llvm -mcpu=westmere", "sse4.2", True),
+    (-1, "llvm -mcpu=bdver1", "sse4.2", True),
+    (-1, "llvm -mcpu=bdver2", "sse4.2", True),
+    (-1, "llvm -mcpu=bdver3", "sse4.2", True),
+    (11, "llvm -mcpu=x86-64-v2", "sse4.2", True),
+    # avx
+    (-1, "llvm -mcpu=sandybridge", "avx", True),
+    (11, "llvm -mcpu=corei7-avx", "avx", True),
+    (-1, "llvm -mcpu=ivybridge", "avx", True),
+    (11, "llvm -mcpu=core-avx-i", "avx", True),
+    # avx2
+    (-1, "llvm -mcpu=haswell", "avx2", True),
+    (11, "llvm -mcpu=core-avx2", "avx2", True),
+    (-1, "llvm -mcpu=broadwell", "avx2", True),
+    (-1, "llvm -mcpu=skylake", "avx2", True),
+    (-1, "llvm -mcpu=bdver4", "avx2", True),
+    (-1, "llvm -mcpu=znver1", "avx2", True),
+    (-1, "llvm -mcpu=znver2", "avx2", True),
+    (11, "llvm -mcpu=znver3", "avx2", True),
+    (11, "llvm -mcpu=x86-64-v3", "avx2", True),
+    # avx512bw
+    (-1, "llvm -mcpu=skylake-avx512", "avx512bw", True),
+    (11, "llvm -mcpu=skx", "avx512bw", True),
+    (11, "llvm -mcpu=knl", "avx512bw", False),
+    (-1, "llvm -mcpu=knl", "avx512f", True),
+    (11, "llvm -mcpu=knl", ["avx512bw", "avx512f"], False),
+    (11, "llvm -mcpu=knl", ("avx512bw", "avx512f"), False),
+    (-1, "llvm -mcpu=knl", "avx512cd", True),
+    (11, "llvm -mcpu=knl", ["avx512cd", "avx512f"], True),
+    (11, "llvm -mcpu=knl", ("avx512cd", "avx512f"), True),
+    (-1, "llvm -mcpu=knl", "avx512er", True),
+    (-1, "llvm -mcpu=knl", "avx512pf", True),
+    (11, "llvm -mcpu=knm", "avx512bw", False),
+    (-1, "llvm -mcpu=knm", "avx512f", True),
+    (-1, "llvm -mcpu=knm", "avx512cd", True),
+    (-1, "llvm -mcpu=knm", "avx512er", True),
+    (-1, "llvm -mcpu=knm", "avx512pf", True),
+    (11, "llvm -mcpu=x86-64-v4", "avx512bw", True),
+    (-1, "llvm -mcpu=cannonlake", "avx512bw", True),
+    # explicit enumeration of VNNI capable due to collision with alderlake
+    (11, "llvm -mcpu=alderlake", "avx512bw", False),
+    (-1, "llvm -mcpu=cascadelake", "avx512bw", True),
+    (-1, "llvm -mcpu=icelake-client", "avx512bw", True),
+    (-1, "llvm -mcpu=icelake-server", "avx512bw", True),
+    (11, "llvm -mcpu=rocketlake", "avx512bw", True),
+    (-1, "llvm -mcpu=tigerlake", "avx512bw", True),
+    (-1, "llvm -mcpu=cooperlake", "avx512bw", True),
+    (11, "llvm -mcpu=sapphirerapids", "avx512bw", True),
+    # avx512vnni
+    (11, "llvm -mcpu=alderlake", "avx512vnni", False),
+    (11, "llvm -mcpu=alderlake", "avxvnni", True),
+    (-1, "llvm -mcpu=cascadelake", "avx512vnni", True),
+    (-1, "llvm -mcpu=icelake-client", "avx512vnni", True),
+    (-1, "llvm -mcpu=icelake-server", "avx512vnni", True),
+    (11, "llvm -mcpu=rocketlake", "avx512vnni", True),
+    (-1, "llvm -mcpu=tigerlake", "avx512vnni", True),
+    (-1, "llvm -mcpu=cooperlake", "avx512vnni", True),
+    (11, "llvm -mcpu=sapphirerapids", "avx512vnni", True),
+    # amx-int8
+    (11, "llvm -mcpu=sapphirerapids", "amx-int8", True),
+    # generic CPU (no features) but with extra -mattr
+    (-1, "llvm -mcpu=x86-64 -mattr=+sse4.1,+avx2", "avx2", True),
+    (-1, "llvm -mcpu=x86-64 -mattr=+sse4.1,+avx2", "sse4.1", True),
+    (-1, "llvm -mcpu=x86-64 -mattr=+sse4.1,+avx2", "ssse3", False),
+)
+
+
+def test_x86_target_features(min_llvm_version, tvm_target, x86_feature, is_supported):
+    """Test X86 features support for different targets.
+
+    Parameters
+    ----------
+    min_llvm_version : int
+        Minimal LLVM version.
+    tvm_target : str
+        TVM target.
+    x86_feature : str
+        X86 CPU feature.
+    is_supported : bool
+        Expected result.
+    """
+
+    ##
+    ## no context
+    ##
+
+    # check for feature via the python api (no explicit target, no context target)
+    try:
+        assert target_has_features(x86_feature) == is_supported
+        assert False
+    except tvm.error.InternalError as e:
+        msg = str(e)
+        assert (
+            msg.find(
+                "InternalError: Check failed: (allow_not_defined) is false: Target context required"
+            )
+            != -1
+        )
+
+    if isinstance(x86_feature, str):
+        # check for feature via the ffi llvm api (no explicit target, no context target)
+        try:
+            assert _ffi_api.llvm_x86_has_feature(x86_feature, None) == is_supported
+            assert False
+        except tvm.error.InternalError as e:
+            msg = str(e)
+            assert (
+                msg.find(
+                    "InternalError: Check failed: (allow_not_defined) is false: Target context required"
+                )
+                != -1
+            )
+
+    # skip test on llvm_version
+    if LLVM_VERSION < min_llvm_version:
+        return
+
+    # check for feature via the python api (with explicit target, no context target)
+    assert target_has_features(x86_feature, Target(tvm_target)) == is_supported
+    if isinstance(x86_feature, str):
+        # check for feature via the ffi llvm api (with explicit target, no context target)
+        assert _ffi_api.llvm_x86_has_feature(x86_feature, Target(tvm_target)) == is_supported
+
+    ##
+    ## with context
+    ##
+
+    with Target(tvm_target):
+        mcpu = Target.current(False).mcpu
+        # check for feature via the python api (current context target)
+        assert target_has_features(x86_feature) == is_supported
+        # check for feature via the python api (with explicit target)
+        assert target_has_features(x86_feature, Target(tvm_target)) == is_supported
+        if isinstance(x86_feature, str):
+            # check for feature via the ffi llvm api (current context target)
+            assert _ffi_api.llvm_x86_has_feature(x86_feature, None) == is_supported
+            # check for feature via the ffi llvm api (with explicit target)
+            assert _ffi_api.llvm_x86_has_feature(x86_feature, Target(tvm_target)) == is_supported
+            # check for feature in target's llvm full x86 CPU feature list
+            if not Target(tvm_target).mattr:
+                assert (x86_feature in codegen.llvm_x86_get_features(mcpu)) == is_supported


### PR DESCRIPTION
Hi folks,

This PR leverage LLVM itself for CPU features lookup, replacing hard-coded lists.
In order to keep maintainability with X86 families & features we can rely on LLVM.

---
Changes:

* Introduce a single ```target_has_feature(XXX)``` replacing all ```target_has_XXX()```
* PY+FFI: expose new ```llvm_x86_get_archlist```, ```llvm_x86_get_features``` & ```llvm_x86_has_feature```
* PY:  expose new ```target_has_feature``` wrapper to ```_ffi.llvm_x86_has_feature```

---

There is a test unit for a comprehensive check with the old behaviour.
For better reliability, this way of feature checking can be implemented for other arches.

Thanks,
~Cristian.

Cc: @elvin-n , @vvchernov , @echuraev , @vinx13 , @jcf94 , @masahi 