### PR TITLE
[Unity][Dlight] Fallback rule supporting more spatial workloads

### DIFF
--- a/src/tir/schedule/transform.cc
+++ b/src/tir/schedule/transform.cc
@@ -472,7 +472,11 @@ Optional<ObjectRef> NormalizePrimFunc(Schedule sch) {
     if (index_map_outputs.empty() || !has_spatial_iter) {
       index_map_outputs.insert(index_map_outputs.begin(), tir::make_const(DataType::Int(64), 0));
     }
-    sch->TransformBlockLayout(block, IndexMap(index_map_inputs, index_map_outputs));
+    try {
+      sch->TransformBlockLayout(block, IndexMap(index_map_inputs, index_map_outputs));
+    } catch (tvm::runtime::Error& e) {
+      // Skip layout transformation when not transformable.
+    }
     block_loops.push_back(sch->GetLoops(block));
     block_iters.push_back(sch->Get(block)->iter_vars);
     bool is_reduction = IsReductionBlock(sch->state(),         //


### PR DESCRIPTION
This PR enhances the fallback dlight GPU rule so that it can support more non-trivial spatial workloads.

Particularly, to this end, this PR makes the following changes:

* for function normalization: when a block of a TIR PrimFunc cannot be applied by "TransformLayout", it will now give up layout transformation instead of throwing the error in TransformLayout.
* for the fallback rule, if the return value of the normalization is None, it will directly return, instead of proceeding the inline attempt.
* for the fallback rule, when iterating the blocks in the PrimFunc, if the loops of a block are already bound to GPU threads, the block will be skipped so the loops will not be processed again.