### PR TITLE
[Unity] Delegate DataflowVar visitor to Var by default

### DIFF
--- a/src/relax/analysis/analysis.cc
+++ b/src/relax/analysis/analysis.cc
@@ -94,8 +94,6 @@ class VarVisitor : protected ExprVisitor {
 
   void VisitExpr_(const VarNode* var) final { vars_.Insert(GetRef<Var>(var)); }
 
-  void VisitExpr_(const DataflowVarNode* var) final { vars_.Insert(GetRef<Var>(var)); }
-
   void VisitExpr_(const FunctionNode* op) final {
     for (const auto& param : op->params) {
       MarkBounded(param);

--- a/src/relax/analysis/struct_info_analysis.cc
+++ b/src/relax/analysis/struct_info_analysis.cc
@@ -189,10 +189,6 @@ class WellDefinedEraser : public StructInfoMutator,
     }
   }
 
-  Expr VisitExpr_(const DataflowVarNode* var) final {
-    return VisitExpr_(static_cast<const VarNode*>(var));
-  }
-
   Expr VisitExpr_(const VarNode* var) final {
     Optional<Expr> ret;
     if (f_var_map_ != nullptr) {

--- a/src/relax/analysis/udchain.cc
+++ b/src/relax/analysis/udchain.cc
@@ -56,10 +56,6 @@ class UDChain : public relax::ExprVisitor {
     cur_user_ = nullptr;
     ExprVisitor::VisitExpr_(op);
   }
-
-  void VisitExpr_(const DataflowVarNode* op) override {
-    VisitExpr_(static_cast<const VarNode*>(op));
-  }
 };
 
 std::pair<runtime::Map<Var, runtime::Array<Var>>, runtime::Array<Var>> FunctionUseDef(

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -431,16 +431,6 @@ class WellFormedChecker : public relax::ExprVisitor,
     CheckStructInfo(var);
   }
 
-  void VisitVarDef(const Var& var) final {
-    if (const DataflowVarNode* lv_node = var.as<DataflowVarNode>()) {
-      VisitVarDef_(lv_node);
-    } else if (const VarNode* gv_node = var.as<VarNode>()) {
-      VisitVarDef_(gv_node);
-    } else {
-      LOG(FATAL) << "TypeError: Invalid type: " << var->GetTypeKey();
-    }
-  }
-
   void VisitExpr_(const tir::VarNode* op) final {
     tir::Var var = GetRef<tir::Var>(op);
     // default mode, check defined.

--- a/src/relax/ir/binding_rewrite.cc
+++ b/src/relax/ir/binding_rewrite.cc
@@ -71,10 +71,6 @@ void DataflowBlockRewriteNode::ReplaceAllUses(Var old_var, Var new_var) {
       return (op == old_var.get()) ? new_var : GetRef<Expr>(op);
     }
 
-    Expr VisitExpr_(const DataflowVarNode* op) override {
-      return (op == old_var.get()) ? new_var : GetRef<Expr>(op);
-    }
-
     BindingBlock VisitBindingBlock_(const DataflowBlockNode* op) override {
       BindingBlock res = ExprMutator::VisitBindingBlock_(op);
       if (op == to_catch) caught = Downcast<DataflowBlock>(res);
@@ -136,7 +132,6 @@ std::set<const VarNode*> GetUsedVars(Expr val) {
    public:
     std::set<const VarNode*> used_vars;
     void VisitExpr_(const VarNode* op) override { used_vars.insert(op); }
-    void VisitExpr_(const DataflowVarNode* op) override { used_vars.insert(op); }
   } uvar{};
   uvar.VisitExpr(val);
   return std::move(uvar.used_vars);

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -530,6 +530,8 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
 
   Expr VisitExpr_(const VarNode* var) final { return VisitVar_<Var>(var); }
 
+  Expr VisitExpr_(const DataflowVarNode* var) final { return VisitVar_<DataflowVar>(var); }
+
   Expr VisitExpr(const Expr& expr) final {
     // lookup normalize map
     if (!block_stack_.empty()) {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -530,8 +530,6 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
 
   Expr VisitExpr_(const VarNode* var) final { return VisitVar_<Var>(var); }
 
-  Expr VisitExpr_(const DataflowVarNode* var) final { return VisitVar_<DataflowVar>(var); }
-
   Expr VisitExpr(const Expr& expr) final {
     // lookup normalize map
     if (!block_stack_.empty()) {

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -619,10 +619,6 @@ class MatcherUseDefAnalysis : public relax::ExprVisitor {
 
     caller2callees[cur_user_].push_back(op);
   }
-
-  void VisitExpr_(const DataflowVarNode* op) override {
-    VisitExpr_(static_cast<const VarNode*>(op));
-  }
 };
 
 struct PNode {

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -140,10 +140,7 @@ void ExprVisitor::VisitExpr_(const VarNode* op) {
 
 // Visit the use-site of a defined DataflowVar
 void ExprVisitor::VisitExpr_(const DataflowVarNode* op) {
-  this->VisitSpan(op->span);
-  if (auto* sinfo = op->struct_info_.as<StructInfoNode>()) {
-    this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
-  }
+  VisitExpr_(static_cast<const VarNode*>(op));
 }
 
 void ExprVisitor::VisitExpr_(const FunctionNode* op) {
@@ -275,7 +272,9 @@ void ExprVisitor::VisitBindingBlock_(const DataflowBlockNode* block) {
   }
 }
 
-void ExprVisitor::VisitVarDef_(const DataflowVarNode* var) { this->VisitSpan(var->span); }
+void ExprVisitor::VisitVarDef_(const DataflowVarNode* var) {
+  VisitVarDef_(static_cast<const VarNode*>(var));
+}
 
 void ExprVisitor::VisitVarDef_(const VarNode* var) { this->VisitSpan(var->span); }
 
@@ -400,9 +399,7 @@ Expr ExprMutatorBase::VisitExpr_(const VarNode* op) {
 
 // Visit the use-site of a defined DataflowVar
 Expr ExprMutatorBase::VisitExpr_(const DataflowVarNode* op) {
-  // struct info of var-use should remain stable
-  // or the var itself will get replaced
-  return GetRef<Expr>(op);
+  return VisitExpr_(static_cast<const VarNode*>(op));
 }
 
 Expr ExprMutatorBase::VisitExpr_(const FunctionNode* op) {
@@ -565,13 +562,7 @@ Expr ExprMutator::VisitExpr_(const VarNode* op) {
 
 // Visit the use-site of a defined DataflowVar
 Expr ExprMutator::VisitExpr_(const DataflowVarNode* op) {
-  auto it = var_remap_.find(op->vid);
-  if (it != var_remap_.end()) {
-    return it->second;
-  }
-
-  // default case return self.
-  return GetRef<Expr>(op);
+  return VisitExpr_(static_cast<const VarNode*>(op));
 }
 
 Expr ExprMutator::VisitExpr_(const FunctionNode* op) {
@@ -718,16 +709,7 @@ BindingBlock ExprMutator::VisitBindingBlock_(const DataflowBlockNode* block) {
 }
 
 Var ExprMutator::VisitVarDef_(const DataflowVarNode* var) {
-  if (auto* sinfo = var->struct_info_.as<StructInfoNode>()) {
-    StructInfo struct_info = this->VisitExprDepStructInfoField(GetRef<StructInfo>(sinfo));
-    if (struct_info.same_as(var->struct_info_)) {
-      return GetRef<DataflowVar>(var);
-    } else {
-      return DataflowVar(var->vid, struct_info, var->span);
-    }
-  } else {
-    return GetRef<DataflowVar>(var);
-  }
+  return VisitVarDef_(static_cast<const VarNode*>(var));
 }
 
 Var ExprMutator::VisitVarDef_(const VarNode* var) {

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -709,7 +709,14 @@ BindingBlock ExprMutator::VisitBindingBlock_(const DataflowBlockNode* block) {
 }
 
 Var ExprMutator::VisitVarDef_(const DataflowVarNode* var) {
-  return VisitVarDef_(static_cast<const VarNode*>(var));
+  Var output = VisitVarDef_(static_cast<const VarNode*>(var));
+  // Because we delegate from DataflowVar visitor to Var visitor to
+  // provide default behavior in subclasses, we may produce a Var
+  // where we should produce a DataflowVar.
+  if (!output->IsInstance<DataflowVarNode>()) {
+    output = DataflowVar(output->vid, GetStructInfo(output), output->span);
+  }
+  return output;
 }
 
 Var ExprMutator::VisitVarDef_(const VarNode* var) {

--- a/src/relax/transform/canonicalize_bindings.cc
+++ b/src/relax/transform/canonicalize_bindings.cc
@@ -48,14 +48,6 @@ class BindingCanonicalizer : public ExprMutator {
     return ExprMutator::VisitExpr_(LookupBinding(v).as<VarNode>());
   }
 
-  Expr VisitExpr_(const DataflowVarNode* op) override {
-    Var v = Downcast<Var>(ExprMutator::VisitExpr_(op));
-    if (!CanCanonicalizeVar(v)) {
-      return Downcast<Expr>(v);
-    }
-    return ExprMutator::VisitExpr_(LookupBinding(v).as<VarNode>());
-  }
-
   Expr VisitExpr_(const TupleGetItemNode* tuple_get_item) override {
     if (auto tuple_var = tuple_get_item->tuple.as<Var>()) {
       if (auto tuple_value = LookupBinding(tuple_var.value())) {

--- a/src/relax/transform/convert_layout.cc
+++ b/src/relax/transform/convert_layout.cc
@@ -131,8 +131,6 @@ class LayoutConvertMutator : public ExprMutator {
 
   Expr VisitExpr_(const VarNode* op) final { return VisitVars_(GetRef<Var>(op)); }
 
-  Expr VisitExpr_(const DataflowVarNode* op) final { return VisitVars_(GetRef<Var>(op)); }
-
   bool HasUnknownDimTensor(const NLayout& nlayout) {
     bool find = false;
     auto fvisit = [&](const LayoutDecision& layout) {

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -305,15 +305,6 @@ class ConstantFolder : public ExprMutator {
     return std::move(post_call);
   }
 
-  Expr VisitExpr_(const DataflowVarNode* op) final {
-    Optional<Expr> opt = LookupBinding(GetRef<Var>(op));
-    // `as` check checks if opt is not null and is instance of constant
-    if (opt.as<relax::ConstantNode>()) {
-      return opt.value();
-    }
-    return ExprMutator::VisitExpr_(op);
-  }
-
   Expr VisitExpr_(const VarNode* op) final {
     Optional<Expr> opt = LookupBinding(GetRef<Var>(op));
     // `as` check checks if opt is not null and is instance of constant

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -233,9 +233,6 @@ class CheckpointGenerator : private ExprMutator {
   // Visit the use-site of a defined Var
   Expr VisitExpr_(const VarNode* op) final { return VisitVar(GetRef<Var>(op)); }
 
-  // Visit the use-site of a defined DataflowVar
-  Expr VisitExpr_(const DataflowVarNode* op) final { return VisitVar(GetRef<Var>(op)); }
-
   Expr VisitVar(const Var& var) {
     auto it = checkpoint_map_.find(var);
     if (it != checkpoint_map_.end()) {

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -296,10 +296,6 @@ class TransformParamsLifter : ExprMutator {
     return ExprMutator::VisitExpr_(var);
   }
 
-  Expr VisitExpr_(const DataflowVarNode* var) final {
-    return VisitExpr_(static_cast<const VarNode*>(var));
-  }
-
   // Remap the original parameters to TupleGetItem from the packed tuple of transformed parameters.
   std::unordered_map<Var, Expr, ObjectPtrHash, ObjectPtrEqual> param_remap_;
   // The plan of lifting the transform params

--- a/src/relax/transform/to_mixed_precision.cc
+++ b/src/relax/transform/to_mixed_precision.cc
@@ -190,8 +190,6 @@ class DTypeDecisionCollector : public ExprVisitor {
 
   void VisitExpr_(const VarNode* op) final { VisitVars_(op); }
 
-  void VisitExpr_(const DataflowVarNode* op) final { VisitVars_(op); }
-
   void VisitBinding_(const VarBindingNode* binding, const CallNode* call_node) final {
     auto policy = GetMixedPrecisionInfo(call_node);
     if (policy == -1) {
@@ -450,13 +448,6 @@ class ToMixedPrecisionRewriter : public ExprMutator {
   }
 
   Var VisitVarDef(const Var& var) { return GetRemapped(var); }
-
-  Expr VisitExpr_(const DataflowVarNode* op) final {
-    if (!builder_->CurrentBlockIsDataFlow()) {
-      return ExprMutator::VisitExpr_(op);
-    }
-    return VisitVar_(GetRef<Var>(op));
-  }
 
   void VisitBinding(const Binding& binding) {
     ExprMutator::VisitBinding(binding);

--- a/src/relax/transform/utils.h
+++ b/src/relax/transform/utils.h
@@ -214,12 +214,6 @@ class VarReplacer : public ExprMutator {
     return it == var_remap_.end() ? var : it->second;
   }
 
-  Expr VisitExpr_(const DataflowVarNode* op) final {
-    Var var = GetRef<Var>(op);
-    auto it = var_remap_.find(var->vid);
-    return it == var_remap_.end() ? var : it->second;
-  }
-
   const VarMap& var_remap_;
 };
 
@@ -294,14 +288,6 @@ class FunctionCopier : public ExprMutator {
   Function Copy(Function func) {
     auto new_func = Downcast<Function>(VisitExpr(func));
     return SymbolicVarRenewMutator::Renew(new_func);
-  }
-
-  Var VisitVarDef_(const DataflowVarNode* var) override {
-    Var new_var = ExprMutator::VisitVarDef_(var);
-    Var copied_var = DataflowVar(new_var->name_hint(), GetStructInfo(new_var), new_var->span);
-    var_remap_[var->vid] = copied_var;
-    var_map.Set(GetRef<Var>(var), copied_var);
-    return copied_var;
   }
 
   Var VisitVarDef_(const VarNode* var) override {


### PR DESCRIPTION
Prior to this commit, writing a subclass of `relax::ExprVisitor` or `relax::ExprMutator` required separate overrides for visiting a `relax::DataflowVar` and a `relax::Var`.  In the majority of cases, these two types should be treated identically, and failure to handle a `DataflowVar` equivalently would be a bug.

This commit updates the `relax::ExprVisitor` and `relax::ExprMutator` base classes to visit `DataflowVar` by delegate to the visitor of `relax::Var`.  As a result, any derived class that overrides the `relax::Var` visitor will also update the behavior for `relax::DataflowVar`.  A pass that requires different behavior for `relax::Var` and `relax::DataflowVar` can still explicitly override both methods in order to provide different behavior.