### PR TITLE
[Unity][MSC][special] Change special names

### DIFF
--- a/python/tvm/contrib/msc/core/ir/graph.py
+++ b/python/tvm/contrib/msc/core/ir/graph.py
@@ -126,7 +126,7 @@ class MSCJoint(BaseJoint):
         The index of the node.
     name: string
         The name of the node.
-    master_name: string
+    shared_ref: string
         The master name of the node.
     optype: string
         The optype of the node.
@@ -144,7 +144,7 @@ class MSCJoint(BaseJoint):
         self,
         index: int,
         name: str,
-        master_name: str,
+        shared_ref: str,
         optype: str,
         attrs: Dict[str, str],
         inputs: List[Tuple[BaseJoint, int]],
@@ -158,7 +158,7 @@ class MSCJoint(BaseJoint):
             _ffi_api.MSCJoint,
             index,
             name,
-            master_name,
+            shared_ref,
             optype,
             attrs,
             parents,
@@ -289,7 +289,7 @@ class WeightJoint(BaseJoint):
         The index of the node.
     name: string
         The name of the node.
-    master_name: string
+    shared_ref: string
         The master name of the node.
     optype: string
         The optype of the node.
@@ -309,7 +309,7 @@ class WeightJoint(BaseJoint):
         self,
         index: int,
         name: str,
-        master_name: str,
+        shared_ref: str,
         optype: str,
         wtype: str,
         attrs: Dict[str, str],
@@ -322,7 +322,7 @@ class WeightJoint(BaseJoint):
             _ffi_api.WeightJoint,
             index,
             name,
-            master_name,
+            shared_ref,
             optype,
             wtype,
             attrs,

--- a/python/tvm/contrib/msc/core/ir/graph.py
+++ b/python/tvm/contrib/msc/core/ir/graph.py
@@ -127,7 +127,7 @@ class MSCJoint(BaseJoint):
     name: string
         The name of the node.
     shared_ref: string
-        The master name of the node.
+        The share reference of the node.
     optype: string
         The optype of the node.
     attrs: dict<string, string>
@@ -290,7 +290,7 @@ class WeightJoint(BaseJoint):
     name: string
         The name of the node.
     shared_ref: string
-        The master name of the node.
+        The share reference of the node.
     optype: string
         The optype of the node.
     wtype: string

--- a/src/contrib/msc/core/ir/graph.h
+++ b/src/contrib/msc/core/ir/graph.h
@@ -91,7 +91,7 @@ struct JsonMSCTensor {
 struct JsonMSCJoint {
   size_t index;
   std::string name;
-  std::string master_name;
+  std::string shared_ref;
   std::string optype;
   std::vector<std::string> scope;
   std::vector<std::string> parents;
@@ -104,7 +104,7 @@ struct JsonMSCJoint {
     writer->BeginObject();
     writer->WriteObjectKeyValue("index", index);
     writer->WriteObjectKeyValue("name", name);
-    writer->WriteObjectKeyValue("master_name", master_name);
+    writer->WriteObjectKeyValue("shared_ref", shared_ref);
     writer->WriteObjectKeyValue("optype", optype);
     writer->WriteObjectKeyValue("parents", parents);
     writer->WriteObjectKeyValue("inputs", inputs);
@@ -125,8 +125,8 @@ struct JsonMSCJoint {
       } else if (key == "name") {
         reader->Read(&name);
         bitmask |= 2;
-      } else if (key == "master_name") {
-        reader->Read(&master_name);
+      } else if (key == "shared_ref") {
+        reader->Read(&shared_ref);
       } else if (key == "optype") {
         reader->Read(&optype);
         bitmask |= 4;
@@ -288,8 +288,8 @@ class BaseJointNode : public Object {
   mutable int index;
   /*! \brief The name of node. */
   String name;
-  /*! \brief The master_name of node, can be changed. */
-  String master_name;
+  /*! \brief The shared_ref of node, can be changed. */
+  String shared_ref;
   /*! \brief The op type of node. */
   String optype;
   /*! \brief The attributes of node. */
@@ -332,7 +332,7 @@ class BaseJointNode : public Object {
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("index", &index);
     v->Visit("name", &name);
-    v->Visit("master_name", &master_name);
+    v->Visit("shared_ref", &shared_ref);
     v->Visit("optype", &optype);
     v->Visit("attrs", &attrs);
     v->Visit("parents", &parents);
@@ -341,14 +341,14 @@ class BaseJointNode : public Object {
 
   bool SEqualReduce(const BaseJointNode* other, SEqualReducer equal) const {
     return equal(name, other->name) &&
-           equal(master_name, other->master_name) & equal(optype, other->optype) &&
+           equal(shared_ref, other->shared_ref) & equal(optype, other->optype) &&
            equal(attrs, other->attrs) && equal(parents, other->parents) &&
            equal(children, other->children);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
     hash_reduce(name);
-    hash_reduce(master_name);
+    hash_reduce(shared_ref);
     hash_reduce(optype);
     hash_reduce(attrs);
     hash_reduce(parents);
@@ -450,14 +450,14 @@ class MSCJoint : public BaseJoint {
    * \brief The constructor.
    * \param index The index of the node.
    * \param name The name of the node.
-   * \param master_name The master_name of the node.
+   * \param shared_ref The shared_ref of the node.
    * \param optype The op type the node.
    * \param attrs The attributes of the node.
    * \param inputs The inputs of the node.
    * \param outputs The outputs of the node.
    * \param weights The weights of the node.
    */
-  TVM_DLL MSCJoint(int index, const String& name, const String& master_name, const String& optype,
+  TVM_DLL MSCJoint(int index, const String& name, const String& shared_ref, const String& optype,
                    const Map<String, String>& attrs, const Array<String>& scope,
                    const std::vector<std::pair<BaseJoint, size_t>>& inputs,
                    const Array<MSCTensor>& outputs, const Map<String, MSCTensor>& weights);
@@ -531,7 +531,7 @@ class WeightJoint : public BaseJoint {
    * \brief The constructor.
    * \param index The index of the node.
    * \param name The name of the node.
-   * \param master_name The master_name of the node.
+   * \param shared_ref The shared_ref of the node.
    * \param optype The optype of the node.
    * \param wtype The weight type of the node.
    * \param attrs The attributes of the node.
@@ -539,8 +539,8 @@ class WeightJoint : public BaseJoint {
    * \param parents The parents of the node.
    * \param friends The friends of the node.
    */
-  TVM_DLL WeightJoint(int index, const String& name, const String& master_name,
-                      const String& optype, const String& wtype, const Map<String, String>& attrs,
+  TVM_DLL WeightJoint(int index, const String& name, const String& shared_ref, const String& optype,
+                      const String& wtype, const Map<String, String>& attrs,
                       const MSCTensor& weight, const Array<BaseJoint> parents,
                       const Array<BaseJoint>& friends);
 

--- a/src/contrib/msc/core/ir/graph_builder.cc
+++ b/src/contrib/msc/core/ir/graph_builder.cc
@@ -103,7 +103,7 @@ const MSCGraph RelaxGraphBuilder::Build(const relax::Function& func) {
 const MSCJoint RelaxGraphBuilder::AddNode(const Expr& expr, const Optional<Expr>& binding_var,
                                           const String& name) {
   const auto& node_name = name.size() > 0 ? name : SpanUtils::GetAttr(expr->span, "name");
-  const auto& master_name = SpanUtils::GetAttr(expr->span, "master_name");
+  const auto& shared_ref = SpanUtils::GetAttr(expr->span, "shared_ref");
   String optype;
   if (expr->IsInstance<relax::VarNode>()) {
     optype = "input";
@@ -256,7 +256,7 @@ const MSCJoint RelaxGraphBuilder::AddNode(const Expr& expr, const Optional<Expr>
     LOG(FATAL) << "Unexpected struct info (" << sinfo->GetTypeKey() << ")" << sinfo;
   }
   // Build node
-  const auto& node = MSCJoint(nodes_.size(), node_name, master_name, optype, attrs, scope, inputs,
+  const auto& node = MSCJoint(nodes_.size(), node_name, shared_ref, optype, attrs, scope, inputs,
                               outputs, node_weights);
   Array<String> output_names;
   for (size_t i = 0; i < outputs.size(); i++) {
@@ -419,7 +419,7 @@ MSCGraph RelayGraphBuilder::Build(const relay::Function& func) {
 
 MSCJoint RelayGraphBuilder::AddNode(const Expr& expr, const String& name) {
   const auto& node_name = name.size() > 0 ? name : SpanUtils::GetAttr(expr->span, "name");
-  const auto& master_name = SpanUtils::GetAttr(expr->span, "master_name");
+  const auto& shared_ref = SpanUtils::GetAttr(expr->span, "shared_ref");
   String optype;
   if (expr->IsInstance<relay::VarNode>()) {
     optype = "input";
@@ -570,7 +570,7 @@ MSCJoint RelayGraphBuilder::AddNode(const Expr& expr, const String& name) {
   }
 
   // Build node
-  const auto& node = MSCJoint(nodes_.size(), node_name, master_name, optype, attrs, scope, inputs,
+  const auto& node = MSCJoint(nodes_.size(), node_name, shared_ref, optype, attrs, scope, inputs,
                               outputs, node_weights);
   Array<String> output_names;
   for (size_t i = 0; i < outputs.size(); i++) {

--- a/src/contrib/msc/core/transform/set_expr_name.cc
+++ b/src/contrib/msc/core/transform/set_expr_name.cc
@@ -130,7 +130,7 @@ class RelaxExprNameSetter : public ExprVisitor {
     if (unique_name != SpanUtils::GetAttr(val->span, "name")) {
       val->span = SpanUtils::SetAttr(val->span, "name", unique_name);
     }
-    // set constant consumer && master_name
+    // set constant consumer && shared_ref
     Array<String> input_types;
     try {
       input_types = ExprUtils::GetInputTypes(optype, val->args.size(), true);
@@ -145,7 +145,7 @@ class RelaxExprNameSetter : public ExprVisitor {
       if (const auto* c_node = val->args[i].as<ConstantNode>()) {
         const String& const_name = SpanUtils::GetAttr(c_node->span, "name");
         if (constant_consumers_.count(const_name)) {
-          val->span = SpanUtils::SetAttr(val->span, "master_name", constant_consumers_[const_name]);
+          val->span = SpanUtils::SetAttr(val->span, "shared_ref", constant_consumers_[const_name]);
         } else {
           constant_consumers_.Set(const_name, unique_name);
         }
@@ -272,7 +272,7 @@ class RelayExprNameSetter : public ExprVisitor {
     if (unique_name != SpanUtils::GetAttr(op->span, "name")) {
       op->span = SpanUtils::SetAttr(op->span, "name", unique_name);
     }
-    // set constant consumer && master_name
+    // set constant consumer && shared_ref
     Array<String> input_types;
     try {
       input_types = ExprUtils::GetInputTypes(optype, op->args.size(), false);
@@ -287,7 +287,7 @@ class RelayExprNameSetter : public ExprVisitor {
       if (const auto* c_node = op->args[i].as<ConstantNode>()) {
         const String& const_name = SpanUtils::GetAttr(c_node->span, "name");
         if (constant_consumers_.count(const_name)) {
-          op->span = SpanUtils::SetAttr(op->span, "master_name", constant_consumers_[const_name]);
+          op->span = SpanUtils::SetAttr(op->span, "shared_ref", constant_consumers_[const_name]);
         } else {
           constant_consumers_.Set(const_name, unique_name);
         }


### PR DESCRIPTION
This PR change the names from master_name to shared_ref. The shared_ref is the name of node who share parameters with the current node.

Nothing are changed besides name change.