### PR TITLE
[Runtime] Make `CSourceModule` and `StaticLibraryModule` Binary Serializable

### DIFF
--- a/src/target/codegen.cc
+++ b/src/target/codegen.cc
@@ -84,8 +84,7 @@ class ModuleSerializer {
     // we will not produce import_tree_.
     bool has_import_tree = true;
 
-    if (mod_->IsDSOExportable()) {
-      ICHECK(export_dso) << "`export_dso` should be enabled for DSOExportable modules";
+    if (export_dso) {
       has_import_tree = !mod_->imports().empty();
     }
 

--- a/tests/python/unittest/test_roundtrip_runtime_module.py
+++ b/tests/python/unittest/test_roundtrip_runtime_module.py
@@ -25,12 +25,12 @@ from tvm import relay
 
 
 def test_csource_module():
-    mod = tvm.runtime._ffi_api.CSourceModuleCreate("", "cc", [], None)
-    # source module that is not binary serializable.
-    # Thus, it would raise an error.
-    assert not mod.is_binary_serializable
-    with pytest.raises(TVMError):
-        tvm.ir.load_json(tvm.ir.save_json(mod))
+    mod = tvm.runtime._ffi_api.CSourceModuleCreate("", "cc", [], [])
+    assert mod.type_key == "c"
+    assert mod.is_binary_serializable
+    new_mod = tvm.ir.load_json(tvm.ir.save_json(mod))
+    assert new_mod.type_key == "c"
+    assert new_mod.is_binary_serializable
 
 
 def test_aot_module():

--- a/tests/python/unittest/test_runtime_module_property.py
+++ b/tests/python/unittest/test_runtime_module_property.py
@@ -44,7 +44,7 @@ def create_aot_module():
 def test_property():
     checker(
         create_csource_module(),
-        expected={"is_binary_serializable": False, "is_runnable": False, "is_dso_exportable": True},
+        expected={"is_binary_serializable": True, "is_runnable": False, "is_dso_exportable": True},
     )
 
     checker(


### PR DESCRIPTION
This PR implements `SaveToBinary` and `LoadFromBinary` methods for `CSourceModule` and `StaticLibraryModule`. 
Its new runtime module property and roundtrippablity are tested. 

cc. @tqchen 