### PR TITLE
[Unity] Mark result of LazyTransformParams as impure function

### DIFF
--- a/python/tvm/relax/transform/lazy_transform_params.py
+++ b/python/tvm/relax/transform/lazy_transform_params.py
@@ -164,7 +164,7 @@ class LazyTransformParamsMutator(PyExprMutator):
             relax.ObjectStructInfo(),
             attrs=func.attrs,
             is_pure=False,
-        )
+        ).without_attr("relax.force_pure")
 
     def visit_tuple_getitem_(self, op: relax.TupleGetItem) -> relax.Expr:
         # rewrite get item

--- a/python/tvm/relax/transform/lazy_transform_params.py
+++ b/python/tvm/relax/transform/lazy_transform_params.py
@@ -158,7 +158,13 @@ class LazyTransformParamsMutator(PyExprMutator):
                 if not isinstance(sinfo, relax.TensorStructInfo):
                     params.append(relax.Var("symbolic_var_holder", sinfo))
 
-        return relax.Function(params, new_body, relax.ObjectStructInfo(), attrs=func.attrs)
+        return relax.Function(
+            params,
+            new_body,
+            relax.ObjectStructInfo(),
+            attrs=func.attrs,
+            is_pure=False,
+        )
 
     def visit_tuple_getitem_(self, op: relax.TupleGetItem) -> relax.Expr:
         # rewrite get item

--- a/tests/python/relax/test_transform_lazy_transform_params.py
+++ b/tests/python/relax/test_transform_lazy_transform_params.py
@@ -74,9 +74,8 @@ def test_lazy_transform_params():
                     T.writes(out[o, i, h, w])
                     out[o, i, h, w] = w1[i, o, h, w]
 
-        @R.function
+        @R.function(pure=False)
         def main_transform_params() -> R.Tuple:
-            R.func_attr({"relax.force_pure": True})
             cls = Expected
             lv: R.Object = R.call_packed("get_item", R.prim_value(1), sinfo_args=(R.Object,))
             _: R.Object = R.call_packed("set_item", R.prim_value(0), lv, sinfo_args=(R.Object,))
@@ -137,10 +136,8 @@ def test_lazy_transform_params_with_symbolic_vars():
 
     @I.ir_module
     class Expected:
-        @R.function
+        @R.function(pure=False)
         def main_transform_params(slice_shape_expr: R.Shape(["slice_index"])):
-            # we expect ToNonDataflow and RemovePurityTracking to be invoked first
-            R.func_attr({"relax.force_pure": True})
             cls = Expected
 
             slice_index = T.int64()


### PR DESCRIPTION
The function produced by `LazyTransformParams` has only side effects, through the `"get_item"` and `"set_item"` PackedFunc calls, and should be marked as impure.