### PR TITLE
[Unity][Analysis] Check for usage of DataflowVar in all_vars()

### DIFF
--- a/src/relax/analysis/analysis.cc
+++ b/src/relax/analysis/analysis.cc
@@ -94,6 +94,8 @@ class VarVisitor : protected ExprVisitor {
 
   void VisitExpr_(const VarNode* var) final { vars_.Insert(GetRef<Var>(var)); }
 
+  void VisitExpr_(const DataflowVarNode* var) final { vars_.Insert(GetRef<Var>(var)); }
+
   void VisitExpr_(const FunctionNode* op) final {
     for (const auto& param : op->params) {
       MarkBounded(param);

--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -282,6 +282,15 @@ def test_all_vars():
     assert var_names == {"_", "x", "y", "z", "p", "q", "r", "s"}
 
 
+def test_all_vars_from_expr_using_dataflow():
+    """all_vars() should return all Var, including DataflowVar"""
+    func = VarExample["main"]
+    cls_func_q = func.body.blocks[1].bindings[1].value
+
+    var_names = var_name_set(all_vars(cls_func_q))
+    assert var_names == {"q"}
+
+
 def test_bound_vars():
     vars = bound_vars(VarExample["func"])
     assert len(vars) == 2


### PR DESCRIPTION
Prior to this commit, the `VarVisitor` used in the implementation of `all_vars` and `free_vars` only collected variable usage sites where the variable was a `const VarNode*`, and ignored usage sites of a `const DataflowVarNode*`.  When analyzing an entire function, these variables were found in the `const VisitVarBinding*`, and could pass the existing tests.  However, when analyzing a single expression, these variables would be erroneously excluded.

This commit adds a `VisitExpr_(const DataflowVarNode*)` implementation in `VarVisitor`, to collect variable usage regardless of the type of variable.