### PR TITLE
[Unity] Propagate extra symbolic vars through LiftTransformParams

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -269,6 +269,20 @@ TVM_DLL StructInfo StructInfoLCA(const StructInfo& lhs, const StructInfo& rhs,
 TVM_DLL Array<tir::Var> TIRVarsInStructInfo(const StructInfo& sinfo);
 
 /*!
+ * \brief Get the TIR variables that appear in the input struct info.
+ *
+ * Returns all symbolic variables that are definable based on, and
+ * used within, the StructInfo.
+ *
+ * \param sinfo The struct info object to be analyzed.
+ *
+ * \return A tuple of (definable,used) TIR variables.  Both lists are
+ *   deduplicated, each TIR variable will appear at most once, and in
+ *   order of occurrence.
+ */
+TVM_DLL Array<tir::Var> DefinableTIRVarsInStructInfo(const StructInfo& sinfo);
+
+/*!
  * \brief Get the TIR variables that defined in the input function.
  * The returned list is deduplicated - each TIR variable will appear at most once.
  * \param func The function object to be analyzed.

--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -285,18 +285,18 @@ TVM_DLL Array<tir::Var> DefinableTIRVarsInStructInfo(const StructInfo& sinfo);
 /*!
  * \brief Get the TIR variables that defined in the input function.
  * The returned list is deduplicated - each TIR variable will appear at most once.
- * \param func The function object to be analyzed.
+ * \param expr The relax expression (e.g. a Function) to be analyzed.
  * \return The list of TIR variables that are defined in the input function.
  */
-TVM_DLL Array<tir::Var> DefinedSymbolicVars(const Function& func);
+TVM_DLL Array<tir::Var> DefinedSymbolicVars(const Expr& expr);
 
 /*!
  * \brief Get the TIR variables that are used but not defined in the input function.
  * The returned list is deduplicated - each TIR variable will appear at most once.
- * \param func The function object to be analyzed.
+ * \param expr The relax expression (e.g. a Function) to be analyzed.
  * \return The list of TIR variables that are used but not defined in the input function.
  */
-TVM_DLL Array<tir::Var> FreeSymbolicVars(const Function& func);
+TVM_DLL Array<tir::Var> FreeSymbolicVars(const Expr& expr);
 //-----------------------------------
 // General IR analysis
 //-----------------------------------

--- a/python/tvm/relax/analysis/__init__.py
+++ b/python/tvm/relax/analysis/__init__.py
@@ -22,6 +22,7 @@ from .analysis import (
     all_vars,
     bound_vars,
     contains_impure_call,
+    definable_tir_vars_in_struct_info,
     defined_symbolic_vars,
     derive_call_ret_struct_info,
     detect_recursion,

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -184,6 +184,24 @@ def tir_vars_in_struct_info(sinfo: StructInfo) -> List[tir.Var]:
     return _ffi_api.TIRVarsInStructInfo(sinfo)  # type: ignore
 
 
+def definable_tir_vars_in_struct_info(sinfo: StructInfo) -> List[tir.Var]:
+    """Get the TIR variables that may be defined from input struct info.
+    The returned list is deduplicated - each TIR variable will appear at most once.
+
+    Parameters
+    ----------
+    sinfo : StructInfo
+        The struct info object to be analyzed.
+
+    Returns
+    -------
+    ret : List[tir.Var]
+
+        The list of TIR variables that can be defined from the StructInfo
+    """
+    return _ffi_api.DefinableTIRVarsInStructInfo(sinfo)  # type: ignore
+
+
 def defined_symbolic_vars(func: Function) -> List[Var]:
     """Get the TIR variables that defined in the input function.
     The returned list is deduplicated - each TIR variable will appear at most once.

--- a/src/relax/analysis/struct_info_analysis.cc
+++ b/src/relax/analysis/struct_info_analysis.cc
@@ -993,16 +993,16 @@ class SymbolicVarCollector : public relax::ExprVisitor,
                              public relax::StructInfoVisitor,
                              public tir::ExprVisitor {
  public:
-  static Array<tir::Var> Free(const Function& func) {
+  static Array<tir::Var> Free(const Expr& expr) {
     SymbolicVarCollector collector;
-    collector.VisitExpr(func);
+    collector.VisitExpr(expr);
     Array<tir::Var> ret{collector.free_symbolic_var_.begin(), collector.free_symbolic_var_.end()};
     return ret;
   }
 
-  static Array<tir::Var> Defined(const Function& func) {
+  static Array<tir::Var> Defined(const Expr& expr) {
     SymbolicVarCollector collector;
-    collector.VisitExpr(func);
+    collector.VisitExpr(expr);
     Array<tir::Var> ret{collector.defined_symbolic_var_.begin(),
                         collector.defined_symbolic_var_.end()};
     return ret;
@@ -1129,10 +1129,10 @@ class SymbolicVarCollector : public relax::ExprVisitor,
   std::unordered_set<tir::Var, ObjectPtrHash, ObjectPtrEqual> free_symbolic_var_;
 };
 
-Array<tir::Var> DefinedSymbolicVars(const Function& func) {
-  return SymbolicVarCollector::Defined(func);
+Array<tir::Var> DefinedSymbolicVars(const Expr& expr) {
+  return SymbolicVarCollector::Defined(expr);
 }
-Array<tir::Var> FreeSymbolicVars(const Function& func) { return SymbolicVarCollector::Free(func); }
+Array<tir::Var> FreeSymbolicVars(const Expr& expr) { return SymbolicVarCollector::Free(expr); }
 
 TVM_REGISTER_GLOBAL("relax.analysis.DefinedSymbolicVars").set_body_typed(DefinedSymbolicVars);
 

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -31,6 +31,8 @@
 #include <iostream>
 #include <vector>
 
+#include "../../support/ordered_set.h"
+
 namespace tvm {
 namespace relax {
 
@@ -42,24 +44,6 @@ struct LiftTransformParamsInfoPlan {
   std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>
       lifted_bindings;  // the bindings of the original function that are lifted
 };
-
-namespace {
-template <typename T>
-struct InsertionOrderSet {
-  std::vector<T> values;
-  std::unordered_set<T, ObjectPtrHash, ObjectPtrEqual> lookup;
-
-  void insert(T t) {
-    if (lookup.insert(t).second) {
-      values.push_back(t);
-    }
-  }
-
-  auto begin() const { return values.begin(); }
-  auto end() const { return values.end(); }
-  auto count(const T& t) const { return lookup.count(t); }
-};
-}  // namespace
 
 /*! \brief Builder of the function that transforms the parameters. */
 class TransformParamsFuncBuilder : public ExprMutator {
@@ -211,7 +195,7 @@ class TransformParamsFuncBuilder : public ExprMutator {
    * transformation function.  A binding that depends on a symbolic
    * variable not contained in this set may not be lifted.
    */
-  InsertionOrderSet<tir::Var> known_symbolic_var_during_transform_;
+  support::OrderedSet<tir::Var> known_symbolic_var_during_transform_;
 
   /* Symbolic variables that are known during the runtime
    *
@@ -222,7 +206,7 @@ class TransformParamsFuncBuilder : public ExprMutator {
    * set, causes the Build() function to output an additional
    * R.ShapeExpr in order to propagate the symbolic variables.
    */
-  InsertionOrderSet<tir::Var> known_symbolic_var_during_inference_;
+  support::OrderedSet<tir::Var> known_symbolic_var_during_inference_;
 
   /* Symbolic variables that must be known at runtime
    *
@@ -232,7 +216,7 @@ class TransformParamsFuncBuilder : public ExprMutator {
    * additional R.ShapeExpr parameter from the transform_params
    * function.
    */
-  InsertionOrderSet<tir::Var> required_symbolic_var_during_inference_;
+  support::OrderedSet<tir::Var> required_symbolic_var_during_inference_;
 };
 
 /*!

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -43,19 +43,78 @@ struct LiftTransformParamsInfoPlan {
       lifted_bindings;  // the bindings of the original function that are lifted
 };
 
+namespace {
+template <typename T>
+struct InsertionOrderSet {
+  std::vector<T> values;
+  std::unordered_set<T, ObjectPtrHash, ObjectPtrEqual> lookup;
+
+  void insert(T t) {
+    if (lookup.insert(t).second) {
+      values.push_back(t);
+    }
+  }
+
+  auto begin() const { return values.begin(); }
+  auto end() const { return values.end(); }
+  auto count(const T& t) const { return lookup.count(t); }
+};
+}  // namespace
+
 /*! \brief Builder of the function that transforms the parameters. */
 class TransformParamsFuncBuilder : public ExprMutator {
  public:
   TransformParamsFuncBuilder() { builder_->BeginDataflowBlock(); }
 
   /*! \brief Add a input parameter. */
-  void AddInput(const Var& var) { inputs_.push_back(var); }
+  void AddInput(const Var& var) {
+    inputs_.push_back(var);
+    lifted_binding_lookup_.insert(var);
+  }
+
+  void UpdateBasedOnRuntimeInput(const Var& var) {
+    for (const auto& var : DefinableTIRVarsInStructInfo(GetStructInfo(var))) {
+      known_symbolic_var_during_inference_.insert(var);
+    }
+    for (const auto& var : TIRVarsInStructInfo(GetStructInfo(var))) {
+      required_symbolic_var_during_inference_.insert(var);
+    }
+  }
 
   /*! \brief Add a binding to lift. */
-  void AddBinding(const VarBinding& binding) { bindings_.push_back(binding); }
+  void AddInternalBinding(const VarBinding& binding) {
+    bindings_.push_back(binding);
+    lifted_binding_lookup_.insert(binding->var);
+  }
 
-  /*! \brief Mark a variable as the output of the function. */
-  void MarkOutput(const Var& output) { outputs_.insert(output); }
+  /*! \brief Update based on bindings not being lifted. */
+  void UpdateBasedOnRuntimeBinding(const VarBinding& binding) {
+    for (const auto& producer : FreeVars(binding->value)) {
+      // An external value that uses a lifted binding requires the
+      // lifted binding to be returned as output.
+      if (lifted_binding_lookup_.count(producer)) {
+        outputs_.insert(producer);
+
+        for (const auto& var : DefinableTIRVarsInStructInfo(GetStructInfo(producer))) {
+          known_symbolic_var_during_inference_.insert(var);
+        }
+      }
+    }
+
+    // All TIR variables used in the binding must be available at runtime.
+    for (const auto& var : FreeSymbolicVars(binding->value)) {
+      required_symbolic_var_during_inference_.insert(var);
+    }
+  }
+
+  bool UsesOnlyLiftableProducers(const Expr& expr) {
+    auto producers = FreeVars(expr);
+    bool uses_only_liftable_producers = [&]() {
+      return std::all_of(producers.begin(), producers.end(),
+                         [&](const auto& var) { return lifted_binding_lookup_.count(var); });
+    }();
+    return uses_only_liftable_producers;
+  }
 
   /*!
    * \brief Build the function that transforms the parameters
@@ -63,6 +122,13 @@ class TransformParamsFuncBuilder : public ExprMutator {
    * of the element of the output tuple
    */
   std::pair<Function, std::unordered_map<Var, int, ObjectPtrHash, ObjectPtrEqual>> Build() {
+    Array<PrimExpr> extra_symbolic_vars;
+    for (const auto& var : required_symbolic_var_during_inference_) {
+      if (!known_symbolic_var_during_inference_.count(var)) {
+        extra_symbolic_vars.push_back(var);
+      }
+    }
+
     Array<StructInfo> input_sinfo;
     Array<Expr> output_vars;
     std::unordered_map<Var, int, ObjectPtrHash, ObjectPtrEqual> output_to_index;
@@ -71,6 +137,10 @@ class TransformParamsFuncBuilder : public ExprMutator {
       input_sinfo.push_back(Downcast<StructInfo>(input->struct_info_.value()));
     }
     Var params("params", TupleStructInfo(input_sinfo));
+
+    if (extra_symbolic_vars.size()) {
+      output_vars.push_back(builder_->Emit(ShapeExpr(extra_symbolic_vars), "extra_symbolic_vars"));
+    }
 
     // Helper to add a variable to the output tuple
     // original_var: the binding variable in the original function
@@ -107,7 +177,7 @@ class TransformParamsFuncBuilder : public ExprMutator {
     // Create the function.
     Expr transformed_params = builder_->EmitOutput(Tuple(output_vars));
     BindingBlock block = builder_->EndBlock();
-    Expr body = builder_->Normalize(SeqExpr({block}, transformed_params));
+    Expr body = VisitWithNewScope(SeqExpr({block}, transformed_params), Array<Var>{params});
     Function f_transform_params =
         Function(/*params=*/{params}, /*body=*/body, /*ret_struct_info=*/NullOpt);
     return {f_transform_params, output_to_index};
@@ -130,6 +200,39 @@ class TransformParamsFuncBuilder : public ExprMutator {
   Array<VarBinding> bindings_;
   // The variables that are marked as the output of the function.
   std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> outputs_;
+
+  // The bindings that are lifted
+  std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> lifted_binding_lookup_;
+
+  /* Symbolic variables that are known during the transform_params execution.
+   *
+   * This set is populated based on the variables declared with
+   * AddInput, and contains variables that may appear inside the
+   * transformation function.  A binding that depends on a symbolic
+   * variable not contained in this set may not be lifted.
+   */
+  InsertionOrderSet<tir::Var> known_symbolic_var_during_transform_;
+
+  /* Symbolic variables that are known during the runtime
+   *
+   * This set is populated based on the variables declared with
+   * UpdateBasedOnRuntimeInput, and contains variables that are
+   * defined at runtime.  A variable that present in
+   * required_symbolic_var_during_inference_, but not present in this
+   * set, causes the Build() function to output an additional
+   * R.ShapeExpr in order to propagate the symbolic variables.
+   */
+  InsertionOrderSet<tir::Var> known_symbolic_var_during_inference_;
+
+  /* Symbolic variables that must be known at runtime
+   *
+   * This set is populated based on the variables used in external
+   * bindings.  A variable that is present here, but not present in
+   * known_symbolic_var_during_inference_, must be provided as an
+   * additional R.ShapeExpr parameter from the transform_params
+   * function.
+   */
+  InsertionOrderSet<tir::Var> required_symbolic_var_during_inference_;
 };
 
 /*!
@@ -145,14 +248,17 @@ class TransformParamsFuncBuilder : public ExprMutator {
 class LiftTransformParamsPlanner : public ExprVisitor {
  public:
   LiftTransformParamsInfoPlan Plan(const Function& function, int num_inputs) {
-    for (int i = num_inputs; i < static_cast<int>(function->params.size()); ++i) {
-      builder_.AddInput(function->params[i]);
-      lifted_bindings_.emplace(function->params[i]);
+    for (int i = 0; i < static_cast<int>(function->params.size()); ++i) {
+      if (i < num_inputs) {
+        builder_.UpdateBasedOnRuntimeInput(function->params[i]);
+      } else {
+        builder_.AddInput(function->params[i]);
+      }
     }
     VisitExpr(function->body);
 
     const auto& [f_transform_params, output_to_index] = builder_.Build();
-    return {f_transform_params, output_to_index, std::move(lifted_bindings_)};
+    return {f_transform_params, output_to_index, std::move(builder_.lifted_binding_lookup_)};
   }
 
  private:
@@ -163,7 +269,6 @@ class LiftTransformParamsPlanner : public ExprVisitor {
   }
 
   void VisitBinding_(const VarBindingNode* binding) final {
-    std::vector<const VarNode*> producers;
     bool can_lift = true;
 
     // Cond 1. Do not lift bindings outside dataflow blocks.
@@ -180,34 +285,29 @@ class LiftTransformParamsPlanner : public ExprVisitor {
     }
 
     // Cond 3. Do not lift when involving Vars that are not liftable.
-    PostOrderVisit(binding->value, [&](const ObjectRef& obj) {
-      if (const VarNode* var = obj.as<VarNode>()) {
-        producers.push_back(var);
-        if (!lifted_bindings_.count(GetRef<Var>(var))) {
-          can_lift = false;
-        }
-      }
-    });
+    auto producers = FreeVars(binding->value);
+    bool uses_only_liftable_producers = builder_.UsesOnlyLiftableProducers(binding->value);
+    if (!uses_only_liftable_producers) {
+      can_lift = false;
+    }
 
     // Cond 4. Do not lift when its struct info contains symbolic variables.
     if (!TIRVarsInStructInfo(GetStructInfo(binding->var)).empty()) {
       can_lift = false;
     }
 
+    // Cond 5. Do not lift declarations of external functions
+    if (binding->value.as<relax::ExternFuncNode>()) {
+      can_lift = false;
+    }
+
     if (can_lift) {
-      lifted_bindings_.insert(binding->var);
-      builder_.AddBinding(GetRef<VarBinding>(binding));
+      builder_.AddInternalBinding(GetRef<VarBinding>(binding));
     } else {
-      for (const VarNode* producer : producers) {
-        if (lifted_bindings_.count(GetRef<Var>(producer))) {
-          builder_.MarkOutput(GetRef<Var>(producer));
-        }
-      }
+      builder_.UpdateBasedOnRuntimeBinding(GetRef<VarBinding>(binding));
     }
   }
 
-  // The bindings that are lifted
-  std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> lifted_bindings_;
   // The builder of the function that transforms the parameters
   TransformParamsFuncBuilder builder_;
   // Whether we are in a dataflow block
@@ -256,6 +356,7 @@ class TransformParamsLifter : ExprMutator {
     // Step 3.1: Update the function signature
     Array<StructInfo> param_fields =
         Downcast<TupleStructInfo>(lift_plan_.f_transform_params->ret_struct_info)->fields;
+
     Array<Var> new_params(func->params.begin(), func->params.begin() + num_input);
     for (size_t i = 0; i < param_fields.size(); i++) {
       std::stringstream name;
@@ -320,12 +421,15 @@ Pass LiftTransformParams() {
         }
       }
     }
-    for (const auto& [gvar, transform_func] : mutator.GetTransformParamFunctions()) {
+    for (auto [gvar, transform_func] : mutator.GetTransformParamFunctions()) {
       String name = gvar->name_hint + "_transform_params";
       GlobalVar new_gvar(name);
       new_gvar->struct_info_ = transform_func->struct_info_;
 
-      updates->Add(new_gvar, WithAttr(transform_func, tvm::attr::kGlobalSymbol, name));
+      transform_func = CopyWithNewVars(transform_func);
+      transform_func = WithAttr(transform_func, tvm::attr::kGlobalSymbol, name);
+
+      updates->Add(new_gvar, transform_func);
     }
 
     if (updates->functions.size()) {


### PR DESCRIPTION
Prior to this PR, a symbolic variable could be provided to the `LiftTransformParams`, which could then be used to produce the transformed parameters.  For example, providing the `rank` and `world_size` of a parameter set in a multi-GPU setup.  However, these symbolic variables may be left undefined in the inference function.

This PR updates `LiftTransformParams` to track the symbolic variables that are definable by the inference function, and to propagate any symbolic variables that would otherwise be undefined.