### PR TITLE
[Unity][TVMScript] Produce var = R.ExternFunc("") statements

### DIFF
--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -627,6 +627,7 @@ __all__ = [
     "SeqExpr",
     "Then",
     "TupleGetItem",
+    "ExternFunc",
     "abs",
     "acos",
     "acosh",

--- a/python/tvm/script/parser/ir/parser.py
+++ b/python/tvm/script/parser/ir/parser.py
@@ -71,7 +71,7 @@ def _visit_class_def(self: Parser, node: doc.ClassDef) -> None:
 
 
 @dispatch.register(token="ir", type_name="Assign")
-def _visit_assign(_self: Parser, _node: doc.Assign) -> None:
+def _visit_assign(self: Parser, node: doc.Assign) -> None:
     """The assign visiting method for ir module.
 
     Parameters
@@ -82,6 +82,13 @@ def _visit_assign(_self: Parser, _node: doc.Assign) -> None:
     node : doc.ClassDef
         The doc AST assign node.
     """
+    if len(node.targets) != 1:
+        self.report_error(node, "Consequential assignments like 'a = b = c' are not supported.")
+    lhs = node.targets[0].id
+    rhs = self.eval_expr(node.value)
+
+    I.decl_function(lhs, rhs)
+    I.def_function(lhs, rhs)
 
 
 @dispatch.register(token="ir", type_name="Expr")

--- a/src/script/printer/relax/binding.cc
+++ b/src/script/printer/relax/binding.cc
@@ -59,7 +59,8 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
             Optional<ExprDoc> ann = StructInfoAsAnn(n->var, n_p->Attr("var"), d, n->value);
             ExprDoc lhs = DefineVar(n->var, d->frames.back(), d);
             return PrintIfExpr(GetRef<relax::If>(if_), n_p->Attr("value"), d, lhs, ann);
-          } else if (n->value->IsInstance<tvm::BaseFuncNode>()) {
+          } else if (n->value->IsInstance<tvm::BaseFuncNode>() &&
+                     !n->value->IsInstance<relax::ExternFuncNode>()) {
             IdDoc lhs = DefineVar(n->var, d->frames.back(), d);
             d->cfg->binding_names.push_back(lhs->name);
             Doc ret = d->AsDoc(n->value, n_p->Attr("value"));

--- a/src/script/printer/relax/call.cc
+++ b/src/script/printer/relax/call.cc
@@ -86,7 +86,12 @@ class AttrPrinter : public tvm::AttrVisitor {
 };
 
 ExprDoc PrintCallee(const relax::Expr& n, const ObjectPath& n_p, const IRDocsifier& d) {
-  return d->AsDoc<ExprDoc>(n, n_p);
+  // TODO(@junrushao): handle callee better
+  if (const auto* ext = n.as<relax::ExternFuncNode>()) {
+    return LiteralDoc::Str(ext->global_symbol, n_p);
+  } else {
+    return d->AsDoc<ExprDoc>(n, n_p);
+  }
 }
 
 Optional<ExprDoc> PrintCallTIRDPSPacked(const relax::Call& n, const ObjectPath& n_p,

--- a/src/script/printer/relax/call.cc
+++ b/src/script/printer/relax/call.cc
@@ -86,12 +86,7 @@ class AttrPrinter : public tvm::AttrVisitor {
 };
 
 ExprDoc PrintCallee(const relax::Expr& n, const ObjectPath& n_p, const IRDocsifier& d) {
-  // TODO(@junrushao): handle callee better
-  if (const auto* ext = n.as<relax::ExternFuncNode>()) {
-    return LiteralDoc::Str(ext->global_symbol, n_p);
-  } else {
-    return d->AsDoc<ExprDoc>(n, n_p);
-  }
+  return d->AsDoc<ExprDoc>(n, n_p);
 }
 
 Optional<ExprDoc> PrintCallTIRDPSPacked(const relax::Call& n, const ObjectPath& n_p,

--- a/src/script/printer/relax/function.cc
+++ b/src/script/printer/relax/function.cc
@@ -129,7 +129,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<relax::ExternFunc>(  //
         "", [](relax::ExternFunc n, ObjectPath n_p, IRDocsifier d) -> Doc {
           // TODO(@junrushao): print more information out of extern function.
-          return ExprStmtDoc(LiteralDoc::Str(n->global_symbol, n_p));
+          return Relax(d, "ExternFunc")->Call({LiteralDoc::Str(n->global_symbol, n_p)});
         });
 
 TVM_SCRIPT_REPR(relax::FunctionNode, ReprPrintRelax);

--- a/src/script/printer/relax/struct_info.cc
+++ b/src/script/printer/relax/struct_info.cc
@@ -152,8 +152,27 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<relax::FuncStructInfo>(  //
         "", [](relax::FuncStructInfo n, ObjectPath n_p, IRDocsifier d) -> Doc {
+          auto ret_doc = d->AsDoc<ExprDoc>(n->ret, n_p->Attr("ret"));
+          auto purity_doc = LiteralDoc::Boolean(n->purity, n_p->Attr("purity"));
+
           if (n->IsOpaque()) {
-            return Relax(d, "Callable");
+            Array<String> keys;
+            Array<ExprDoc, void> values;
+
+            if (!n->ret->IsInstance<relax::ObjectStructInfoNode>()) {
+              keys.push_back("ret");
+              values.push_back(ret_doc);
+            }
+            if (n->purity) {
+              keys.push_back("purity");
+              values.push_back(purity_doc);
+            }
+
+            if (keys.size()) {
+              return Relax(d, "Callable")->Call({}, keys, values);
+            } else {
+              return Relax(d, "Callable");
+            }
           }
           // TODO(@junrushao): track symbolic shape relation
           Array<ExprDoc> params_doc;
@@ -162,10 +181,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           for (int i = 0, n_params = params.size(); i < n_params; ++i) {
             params_doc.push_back(d->AsDoc<ExprDoc>(params[i], params_p->ArrayIndex(i)));
           }
-          return Relax(d, "Callable")
-              ->Call({TupleDoc(params_doc),                         //
-                      d->AsDoc<ExprDoc>(n->ret, n_p->Attr("ret")),  //
-                      LiteralDoc::Boolean(n->purity, n_p->Attr("purity"))});
+          return Relax(d, "Callable")->Call({TupleDoc(params_doc), ret_doc, purity_doc});
         });
 
 TVM_SCRIPT_REPR(relax::ObjectStructInfoNode, ReprPrintRelax);

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1772,5 +1772,28 @@ def test_macro_no_variable_leak():
             return x  # Should be undefined here
 
 
+def test_reused_extern_func():
+    """ExternFunc lookups can become bindings in EliminateCommonSubexpr"""
+
+    @R.function(private=True)
+    def parsed(x: R.Tensor((128, 128), "float32")) -> R.Tensor((128, 128), "float32"):
+        func = R.ExternFunc("extern_func")
+        gv0 = R.call_dps_packed(func, x, R.Tensor((128, 128), dtype="float32"))
+        gv1 = R.call_dps_packed(func, gv0, R.Tensor((128, 128), dtype="float32"))
+        return gv1
+
+    x = relax.Var("x", R.Tensor((128, 128), "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("main", [x], private=True):
+        func = bb.emit(relax.ExternFunc("extern_func"))
+        y = bb.emit(relax.call_dps_packed(func, x, out_sinfo=R.Tensor((128, 128), "float32")))
+        z = bb.emit(relax.call_dps_packed(func, y, out_sinfo=R.Tensor((128, 128), "float32")))
+        bb.emit_func_output(z)
+
+    expected = bb.get()["main"]
+
+    _check(parsed, expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1795,5 +1795,25 @@ def test_reused_extern_func():
     _check(parsed, expected)
 
 
+def test_extern_func_in_module():
+    """Module-level parsing may produce function bindings"""
+
+    @I.ir_module
+    class parsed_module:
+        my_ext = R.ExternFunc("my_ext")
+
+        @R.function
+        def func(a: R.Tensor((10, 10))) -> R.Tensor((10, 10)):
+            return a
+
+    @R.function
+    def func(a: R.Tensor((10, 10))) -> R.Tensor((10, 10)):
+        return a
+
+    expected = tvm.IRModule({"my_ext": relax.ExternFunc("my_ext"), "func": func})
+
+    _check(parsed_module, expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_tvmscript_printer_relax.py
+++ b/tests/python/relax/test_tvmscript_printer_relax.py
@@ -88,7 +88,7 @@ def test_extern_func():
 
 @I.ir_module
 class Module:
-    "my_ext"
+    my_ext = R.ExternFunc("my_ext")
     @R.function
     def func(a: R.Tensor((10, 10))) -> R.Tensor((10, 10)):
         return a


### PR DESCRIPTION
Prior to this commit, any `ExternFunc` usage in a relax function would print the string name of the function on its own line, omitting any variable definition, and later use of the variable would occur without a definition.  This commit updates the printing of `R.ExternFunc` to appear as a normal relax variable.