### PR TITLE
[TVMScript][FIX] Disable `show_object_address` in printing by default

### DIFF
--- a/python/tvm/runtime/script_printer.py
+++ b/python/tvm/runtime/script_printer.py
@@ -61,7 +61,7 @@ class PrinterConfig(Object):
         print_line_numbers: bool = False,
         num_context_lines: Optional[int] = None,
         syntax_sugar: bool = True,
-        show_object_address: bool = True,
+        show_object_address: bool = False,
         path_to_underline: Optional[List[ObjectPath]] = None,
         path_to_annotate: Optional[Dict[ObjectPath, str]] = None,
         obj_to_underline: Optional[List[Object]] = None,
@@ -158,7 +158,7 @@ class Scriptable:
         syntax_sugar: bool = True
              Whether to output with syntax sugar, set false for complete printing.
         show_object_address: bool = False
-             Whether to include the object's adddress as part of the TVMScript name
+             Whether to include the object's address as part of the TVMScript name
         path_to_underline : Optional[List[ObjectPath]] = None
             Object path to be underlined
         path_to_annotate : Optional[Dict[ObjectPath, str]] = None
@@ -213,7 +213,7 @@ class Scriptable:
         print_line_numbers: bool = False,
         num_context_lines: int = -1,
         syntax_sugar: bool = True,
-        show_object_address: bool = True,
+        show_object_address: bool = False,
         path_to_underline: Optional[List[ObjectPath]] = None,
         path_to_annotate: Optional[Dict[ObjectPath, str]] = None,
         obj_to_underline: Optional[List[Object]] = None,
@@ -254,7 +254,7 @@ class Scriptable:
         syntax_sugar: bool = True
              Whether to output with syntax sugar, set false for complete printing.
         show_object_address: bool = False
-             Whether to include the object's adddress as part of the TVMScript name
+             Whether to include the object's address as part of the TVMScript name
         path_to_underline : Optional[List[ObjectPath]] = None
             Object path to be underlined
         path_to_annotate : Optional[Dict[ObjectPath, str]] = None


### PR DESCRIPTION
The new feature of printing object addresses is introduced in #15579. It's an excellent feature for debugging, but it should not be turned on by default.

cc @Lunderberg @junrushao 