### PR TITLE
[TVMScript] Disable `black_format` by default

### DIFF
--- a/python/tvm/runtime/script_printer.py
+++ b/python/tvm/runtime/script_printer.py
@@ -199,7 +199,7 @@ class Scriptable:
     def show(
         self,
         style: Optional[str] = None,
-        black_format: bool = True,
+        black_format: bool = False,
         *,
         name: Optional[str] = None,
         show_meta: bool = False,
@@ -227,7 +227,7 @@ class Scriptable:
             Pygmentize printing style, auto-detected if None.  See
             `tvm.script.highlight.cprint` for more details.
         black_format: bool
-            If true (default), use the formatter Black to format the TVMScript
+            If true, use the formatter Black to format the TVMScript
         name : Optional[str] = None
             The name of the object
         show_meta : bool = False

--- a/python/tvm/script/highlight.py
+++ b/python/tvm/script/highlight.py
@@ -26,7 +26,7 @@ from typing import Any, Optional, Union
 def cprint(
     printable: Union[Any, str],
     style: Optional[str] = None,
-    black_format: bool = True,
+    black_format: bool = False,
 ) -> None:
     """Print TVMScript string with Pygments highlight and Black auto-formatting.
 
@@ -42,7 +42,7 @@ def cprint(
 
     black_format: bool
 
-        If true (default), use the formatter Black to format the TVMScript
+        If true, use the formatter Black to format the TVMScript
 
     Notes
     -----

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -268,7 +268,7 @@ class Schedule(Object):
         """
         return _ffi_api.ScheduleForkSeed(self)  # type: ignore # pylint: disable=no-member
 
-    def show(self, style: Optional[str] = None, black_format: bool = True) -> None:
+    def show(self, style: Optional[str] = None, black_format: bool = False) -> None:
         """A sugar for print highlighted TVM script.
 
         Parameters
@@ -280,7 +280,7 @@ class Schedule(Object):
 
         black_format: bool
 
-            If true (default), use the formatter Black to format the TVMScript
+            If true, use the formatter Black to format the TVMScript
         """
         mod = self.mod
         if mod is not None:

--- a/python/tvm/tir/schedule/trace.py
+++ b/python/tvm/tir/schedule/trace.py
@@ -262,7 +262,7 @@ class Trace(Object):
         """
         _ffi_api.TraceApplyJSONToSchedule(json_obj, sch)  # type: ignore # pylint: disable=no-member
 
-    def show(self, style: Optional[str] = None, black_format: bool = True) -> None:
+    def show(self, style: Optional[str] = None, black_format: bool = False) -> None:
         """A sugar for print highlighted TVM script.
 
         Parameters
@@ -274,7 +274,7 @@ class Trace(Object):
 
         black_format: bool
 
-            If true (default), use the formatter Black to format the TVMScript
+            If true, use the formatter Black to format the TVMScript
         """
         from tvm.script.highlight import (  # pylint: disable=import-outside-toplevel
             cprint,


### PR DESCRIPTION
`Black` is a popular code formatter for Python. However, it is not suitable for TVM script. This PR tries to disable it by default.

This would change the default printing behavior, love to hear opinions from the community.

cc @tqchen @Lunderberg @junrushao @cyx-6 