### PR TITLE
[Relay] Simplify Conv->bias_add->mul->add to Conv->bias_add

### DIFF
--- a/python/tvm/relay/transform/SimplifyMulAdd.py
+++ b/python/tvm/relay/transform/SimplifyMulAdd.py
@@ -1,0 +1,110 @@
+# pylint: disable=invalid-name, unused-argument
+
+"""Module providing operator simplification
+from Conv->bias_add->mul->add to Conv->bias_add sequence"""
+
+import tvm
+from tvm import relay
+from tvm.relay.dataflow_pattern import (
+    DFPatternCallback,
+    is_constant,
+    is_op,
+    # is_tuple,
+    rewrite,
+    wildcard,
+)
+
+
+class SimplifyMulAddInFunc(DFPatternCallback):
+    """
+    Simplify Conv->bias_add->mul->add to Conv->bias_add sequence if
+    one of the inputs to Conv, bias_add, mul and add are constants.
+
+    Replace
+    def @main(%q1: Tensor[(1, 3, 224, 224), float32]) {
+        %0 = nn.conv2d(%q1, meta[relay.Constant][0], padding=[3, 3, 3, 3],
+                        channels=64, kernel_size=[7, 7]);
+        %1 = nn.bias_add(%0, meta[relay.Constant][1]);
+        %2 = multiply(%1, meta[relay.Constant][2]);
+        add(%2, meta[relay.Constant][3])
+    }
+
+
+    with
+
+    def @main(%q1: Tensor[(1, 3, 224, 224), float32]) {
+        %0 = reshape(meta[relay.Constant][1], newshape=[64, 1, 1, 1]);
+        %1 = multiply(meta[relay.Constant][0], %0);
+        %2 = reshape(meta[relay.Constant][2], newshape=[64, 1, 1]);
+        %3 = multiply(%2, meta[relay.Constant][1]);
+        %4 = add(%3, meta[relay.Constant][3]);
+        %5 = nn.conv2d(%q1, %1, padding=[3, 3, 3, 3], channels=64, kernel_size=[7, 7]);
+        %6 = reshape(%4, newshape=[64]);
+        nn.bias_add(%5, %6)
+    }
+
+
+    res[p,q,r,s] = ({SUM{i=[0,c-1], j=[0,kh-1], k=[0,kw-1]}
+                    (a[p,i,r+j,s+k] * W[q,i,j,k])} + b[q]) * c1[q] + c2[q]
+
+    res[p,q,r,s] = {SUM{i=[0,c-1], j=[0,kh-1], k=[0,kw-1]}
+                    (a[p,i,r+j,s+k] * W[q,i,j,k])} * c1[q] + b[q]*c1[q] + c2[q]
+
+    res[p,q,r,s] = Conv2d(a, W*c1) + bias_add(b*c1+c2)
+
+    In the above, %1, %3, %4 are constants and can be folded, so we're
+    left with 2 ops, as opposed to the original 4 ops
+    """
+
+    def __init__(self):
+        super(SimplifyMulAddInFunc, self).__init__()
+        self.inp = wildcard()
+        self.weights = is_constant()
+        self.conv2d_op = is_op("nn.conv2d")(self.inp, self.weights).has_attr(
+            {"data_layout": "NCHW", "kernel_layout": "OIHW"}
+        )
+        self.bias = is_op("nn.bias_add")(self.conv2d_op, is_constant())
+        self.mul = is_op("multiply")(self.bias, is_constant())
+        self.pattern = is_op("add")(self.mul, is_constant())
+
+    def reshape_tensor(self, tensor1, tensor2):
+        """Function reshapes tensor1 to the shape of tensor2"""
+        tensor1_shape = tvm.relay.transform.InferTypeLocal(tensor1).shape
+        tensor2_shape = tvm.relay.transform.InferTypeLocal(tensor2).shape
+        if len(tensor1_shape) < len(tensor2_shape):
+            new_shape = []
+            for i in range(len(tensor2_shape)):
+                if i < len(tensor1_shape):
+                    new_shape.append(tensor1_shape[i])
+                else:
+                    new_shape.append(1)
+            new_mul = relay.reshape(tensor1, new_shape)
+            return new_mul
+        else:
+            return tensor1
+
+    def callback(self, pre, post, node_map):
+        """Function performs transformation for Conv->bias_add->mul->add sequence,
+        so that constant folding can reduce it to Conv->bias_add sequence"""
+        new_mul = self.reshape_tensor(node_map[self.mul][0].args[1], node_map[self.weights][0])
+        new_weights = relay.multiply((node_map[self.weights][0]), new_mul)
+        new_conv2d = relay.nn.conv2d(
+            (node_map[self.inp][0]), new_weights, **((node_map[self.conv2d_op][0]).attrs)
+        )
+        new_bias_const = self.reshape_tensor(
+            node_map[self.bias][0].args[1], node_map[self.mul][0].args[1]
+        )
+        new_mul = relay.multiply(new_bias_const, (node_map[self.mul][0].args[1]))
+        summed_const = relay.add(new_mul, (node_map[self.pattern][0].args[1]))
+        final_bias_shape = tvm.relay.transform.InferTypeLocal(summed_const)
+        final_bias = relay.reshape(summed_const, (final_bias_shape.shape[0].value))
+        return relay.nn.bias_add(new_conv2d, final_bias)
+
+
+# Right now context is ignored
+@tvm.transform.module_pass(opt_level=1)
+def simplify_mul_add(mod, _=None):
+    """top level function for conv pattern simplification"""
+    for global_var in mod.functions.keys():
+        mod[global_var] = rewrite(SimplifyMulAddInFunc(), mod[global_var])
+    return mod

--- a/python/tvm/relay/transform/simplify_mul_add.py
+++ b/python/tvm/relay/transform/simplify_mul_add.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 # pylint: disable=invalid-name, unused-argument
 
 """Module providing operator simplification

--- a/tests/python/relay/test_op_simplify_mul_add.py
+++ b/tests/python/relay/test_op_simplify_mul_add.py
@@ -1,0 +1,181 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-wildcard-import, invalid-name
+
+"""
+Test x86 relay transform - Eliminate const_mul and const_add following a conv optimization
+"""
+import numpy as np
+import tvm
+from tvm.runtime import ndarray as nd
+from tvm import relay, testing
+from tvm.relay.transform.SimplifyMulAdd import simplify_mul_add
+from tvm.topi.utils import get_const_tuple
+from tvm.relay.backend import Executor, Runtime
+
+
+def get_test_module_relay_exprs():
+    """
+    Creates relay expressions that can be used both by
+    test module and expected output module
+    """
+
+    act_shape = (1, 3, 224, 224)
+    data_in = np.random.rand(*get_const_tuple(act_shape))
+    data_in_float32 = np.full(data_in.shape, data_in, dtype="float32")
+    kernel_shape = (64, 3, 7, 7)
+
+    scalar_multiplier_shape = (64, 1, 1)
+    bias = np.random.rand(get_const_tuple(kernel_shape)[0])
+    relay_act = relay.var("q1", shape=act_shape, dtype="float32")
+    relay_mul_factor = np.random.rand(*get_const_tuple(scalar_multiplier_shape))
+    relay_mul_factor = relay.Constant(
+        nd.array(np.full(relay_mul_factor.shape, relay_mul_factor, dtype="float32"))
+    )
+    relay_add_term = np.random.rand(*get_const_tuple(scalar_multiplier_shape))
+    relay_add_term = relay.Constant(
+        nd.array(np.full(relay_add_term.shape, relay_add_term, dtype="float32"))
+    )
+
+    weights = np.random.rand(*get_const_tuple(kernel_shape))
+    relay_weights = relay.Constant(nd.array(np.full(weights.shape, weights, dtype="float32")))
+    relay_bias = relay.Constant(nd.array(np.full(bias.shape, bias, dtype="float32")))
+    return (relay_act, relay_mul_factor, relay_add_term, relay_weights, relay_bias, data_in_float32)
+
+
+def get_test_module_graph(relay_act, relay_mul_factor, relay_add_term, relay_weights, relay_bias):
+    """Creates a test relay graph with the specified relay expressions"""
+    v1 = relay.nn.conv2d(
+        relay_act,
+        relay_weights,
+        padding=[3, 3, 3, 3],
+        channels=64,
+        kernel_size=[7, 7],
+    )
+    v2 = relay.nn.bias_add(v1, relay_bias)
+    v3 = relay.multiply(v2, relay_mul_factor)
+    graph = relay.add(v3, relay_add_term)
+    return graph
+
+
+def get_test_module(relay_act, relay_mul_factor, relay_add_term, relay_weights, relay_bias):
+    """Creates a test relay module and returns it."""
+    graph = get_test_module_graph(
+        relay_act, relay_mul_factor, relay_add_term, relay_weights, relay_bias
+    )
+
+    func = relay.Function(relay.analysis.free_vars(graph), graph)
+    mod = tvm.IRModule.from_expr(func)
+    return mod
+
+
+def get_expected_output_module_graph(
+    relay_act, relay_mul_factor, relay_add_term, relay_weights, relay_bias
+):
+    """Creates the relay graph for expected output"""
+    new_mul_factor = relay.reshape(relay_mul_factor, [64, 1, 1, 1])
+    v1 = relay.multiply(relay_weights, new_mul_factor)
+    v2 = relay.nn.conv2d(relay_act, v1, padding=[3, 3, 3, 3], channels=64, kernel_size=[7, 7])
+    new_bias_factor = relay.reshape(relay_bias, [64, 1, 1])
+    v3 = relay.multiply(new_bias_factor, relay_mul_factor)
+    v4 = relay.add(v3, relay_add_term)
+    new_bias = relay.reshape(v4, 64)
+    return relay.nn.bias_add(v2, new_bias)
+
+
+def get_expected_output_module(
+    relay_act, relay_mul_factor, relay_add_term, relay_weights, relay_bias
+):
+    """Returns manually created expected output module."""
+    graph = get_expected_output_module_graph(
+        relay_act, relay_mul_factor, relay_add_term, relay_weights, relay_bias
+    )
+
+    out_func = relay.Function(relay.analysis.free_vars(graph), graph)
+    return tvm.IRModule.from_expr(out_func)
+
+
+def build_module(relay_mod, target):
+    """builds a relay module for a specified target"""
+    params = {}
+    lowered = tvm.relay.build(
+        relay_mod,
+        tvm.target.Target(target, host=target),
+        runtime=Runtime("cpp"),
+        executor=Executor("graph"),
+        params=params,
+    )
+    return lowered
+
+
+def run_module(mod, inputs):
+    """invokes run function of specified module with inputs provided"""
+    mod.set_input(**inputs)
+    mod.run()
+    output = mod.get_output(0).numpy()
+    return output
+
+
+def get_test_modules():
+    """generates test, expected modules and their inputs"""
+    (
+        relay_act,
+        relay_mul_factor,
+        relay_add_term,
+        relay_weights,
+        relay_bias,
+        data_in_float32,
+    ) = get_test_module_relay_exprs()
+    mod = get_test_module(relay_act, relay_mul_factor, relay_add_term, relay_weights, relay_bias)
+    exp_relay_mod = get_expected_output_module(
+        relay_act, relay_mul_factor, relay_add_term, relay_weights, relay_bias
+    )
+
+    return mod, exp_relay_mod, {"q1": data_in_float32}
+
+
+# @tvm.testing.requires_x86
+def test_simplify_mul_add():
+    """A positive test case"""
+
+    (mod, exp_relay_mod, inputs) = get_test_modules()
+
+    with tvm.transform.PassContext(opt_level=3):
+        mod = tvm.relay.transform.InferType()(mod)
+        x86_lowered = build_module(mod, tvm.target.Target("llvm", host="llvm"))
+
+    with tvm.transform.PassContext(opt_level=3):
+        mod = simplify_mul_add(mod)
+        mod = tvm.relay.transform.InferType()(mod)
+        exp_relay_mod = tvm.relay.transform.InferType()(exp_relay_mod)
+        assert tvm.ir.structural_equal(mod["main"], exp_relay_mod["main"], map_free_vars=True)
+        mod = tvm.relay.transform.FoldConstant()(mod)
+        x86_lowered_opt = build_module(mod, tvm.target.Target("llvm", host="llvm"))
+
+    # Run unoptimized llvm module
+    x86_mod = tvm.contrib.graph_executor.GraphModule(x86_lowered["default"](tvm.cpu(0)))
+    expected_output = run_module(x86_mod, inputs)
+
+    # Run optimized llvm module
+    x86_mod_opt = tvm.contrib.graph_executor.GraphModule(x86_lowered_opt["default"](tvm.cpu(0)))
+    actual_output = run_module(x86_mod_opt, inputs)
+
+    tvm.testing.assert_allclose(actual_output, expected_output, rtol=0.00001)
+
+
+if __name__ == "__main__":
+    testing.main()

--- a/tests/python/relay/test_op_simplify_mul_add.py
+++ b/tests/python/relay/test_op_simplify_mul_add.py
@@ -23,7 +23,7 @@ import numpy as np
 import tvm
 from tvm.runtime import ndarray as nd
 from tvm import relay, testing
-from tvm.relay.transform.SimplifyMulAdd import simplify_mul_add
+from tvm.relay.transform.simplify_mul_add import simplify_mul_add
 from tvm.topi.utils import get_const_tuple
 from tvm.relay.backend import Executor, Runtime
 


### PR DESCRIPTION
Simplify Conv->bias_add->mul->add to Conv->bias_add sequence if one of the inputs to Conv, bias_add, mul and add are constant scalars.

def @main(%q1: Tensor[(1, 3, 224, 224), float32]) {
%0 = nn.conv2d(%q1, meta[relay.Constant][0], padding=[3, 3, 3, 3], channels=64, kernel_size=[7, 7]);
%1 = nn.bias_add(%0, meta[relay.Constant][1]);
%2 = multiply(%1, meta[relay.Constant][2]);
add(%2, meta[relay.Constant][3])
}

Replace with
def @main(%q1: Tensor[(1, 3, 224, 224), float32]) {
%0 = reshape(meta[relay.Constant][1], newshape=[64, 1, 1, 1]);
%1 = multiply(meta[relay.Constant][0], %0);
%2 = reshape(meta[relay.Constant][2], newshape=[64, 1, 1]);
%3 = multiply(%2, meta[relay.Constant][1]);
%4 = add(%3, meta[relay.Constant][3]);
%5 = nn.conv2d(%q1, %1, padding=[3, 3, 3, 3], channels=64, kernel_size=[7, 7]);
%6 = reshape(%4, newshape=[64]);
nn.bias_add(%5, %6)
}

res[p,q,r,s] = ({SUM{i=[0,c-1], j=[0,kh-1], k=[0,kw-1]}(a[p,i,r+j,s+k] * W[q,i,j,k])} + b[q]) * c1[q] + c2[q]
res[p,q,r,s] = {SUM{i=[0,c-1], j=[0,kh-1], k=[0,kw-1]}(a[p,i,r+j,s+k] * W[q,i,j,k])} * c1[q] + b[q]c1[q] + c2[q]
res[p,q,r,s] = Conv2d(a, Wc1) + bias_add(b*c1+c2)

In the above, %1, %3, %4 are constants and can be folded, so we're left with 2 ops, as opposed to the original 4 ops.