### PR TITLE
[Relay][Bugfix] Fix the wrong implementation about operator Threshold in oneflow

### DIFF
--- a/python/tvm/relay/frontend/oneflow.py
+++ b/python/tvm/relay/frontend/oneflow.py
@@ -1034,7 +1034,7 @@ class Threshold(OneFlowOpConverter):
         threshold_tensor = _op.full_like(inputs[0], fill_value=_expr.const(threshold))
         value = float(attrs.get("value"))
         value_tensor = _op.full_like(inputs[0], fill_value=_expr.const(value))
-        mask = _op.greater(inputs[0], threshold_tensor).astype("float32")
+        mask = _op.greater(inputs[0], threshold_tensor)
         return _op.where(mask, inputs[0], value_tensor)
 
 

--- a/python/tvm/relay/frontend/oneflow.py
+++ b/python/tvm/relay/frontend/oneflow.py
@@ -1031,10 +1031,10 @@ class Threshold(OneFlowOpConverter):
     @classmethod
     def _impl_v1(cls, inputs, attrs, params):
         threshold = float(attrs.get("threshold_val", 1.0))
-        threshold_tensor = _op.full_like(inputs[0], fill_value=_expr.const(alpha))
+        threshold_tensor = _op.full_like(inputs[0], fill_value=_expr.const(threshold))
         value = float(attrs.get("value"))
         value_tensor = _op.full_like(inputs[0], fill_value=_expr.const(value))
-        mask = _op.greater(inputs[0], alpha_tensor).astype("float32")
+        mask = _op.greater(inputs[0], threshold_tensor).astype("float32")
         return _op.where(mask, inputs[0], value_tensor)
 
 

--- a/python/tvm/relay/frontend/oneflow.py
+++ b/python/tvm/relay/frontend/oneflow.py
@@ -1025,15 +1025,17 @@ class Dropout(OneFlowOpConverter):
         return out
 
 
-class ThresholdedRelu(OneFlowOpConverter):
-    """Operator converter for ThresholdedRelu."""
+class Threshold(OneFlowOpConverter):
+    """Operator converter for Threshold."""
 
     @classmethod
     def _impl_v1(cls, inputs, attrs, params):
-        alpha = float(attrs.get("alpha", 1.0))
-        alpha_tensor = _op.full_like(inputs[0], fill_value=_expr.const(alpha))
+        threshold = float(attrs.get("threshold_val", 1.0))
+        threshold_tensor = _op.full_like(inputs[0], fill_value=_expr.const(alpha))
+        value = float(attrs.get("value"))
+        value_tensor = _op.full_like(inputs[0], fill_value=_expr.const(value))
         mask = _op.greater(inputs[0], alpha_tensor).astype("float32")
-        return inputs[0] * mask
+        return _op.where(mask, inputs[0], value_tensor)
 
 
 class Elu(OneFlowOpConverter):
@@ -1422,6 +1424,7 @@ def get_convert_map():
         "relu": Renamer("relu"),
         "leaky_relu": Renamer("leaky_relu"),
         "prelu": PReLU.get_converter(),
+        "threshold": Threshold.get_converter(),
         "selu": Selu.get_converter(),
         "silu": Silu.get_converter(),
         "gelu": Gelu.get_converter(),

--- a/tests/python/frontend/oneflow/test_forward.py
+++ b/tests/python/frontend/oneflow/test_forward.py
@@ -705,7 +705,7 @@ def test_activation():
     class Threshold(flow.nn.Module):
         def __init__(self):
             super().__init__()
-            self.active = flow.nn.Threshold()
+            self.active = flow.nn.Threshold(0.5, 0.2)
 
         def forward(self, x):
             x = self.active(x)

--- a/tests/python/frontend/oneflow/test_forward.py
+++ b/tests/python/frontend/oneflow/test_forward.py
@@ -24,6 +24,7 @@ import tvm
 import tvm.testing
 import tvm.topi.testing
 from tvm import relay
+from packaging import version as package_version
 
 MODEL_HOME = "test_model"
 
@@ -727,7 +728,6 @@ def test_activation():
     model11 = GELU().eval()
     model12 = HardTanh().eval()
     model13 = TensorSoftmax().eval()
-    model14 = Threshold().eval()
 
     for device in ["llvm"]:
         verify_activation(model1, device=device)
@@ -747,7 +747,11 @@ def test_activation():
             device=device,
             inputs=flow.tensor(np.random.rand(1, 12, 197, 197).astype(np.float32)),
         )
-        verify_activation(model14, device=device)
+
+    # Threshold was introduced in the version 0.8.0 of oneflow
+    if package_version.parse(flow.__version__) >= package_version.parse("0.8.0"):
+        model14 = Threshold().eval()
+        verify_activation(model14, device="llvm")
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/oneflow/test_forward.py
+++ b/tests/python/frontend/oneflow/test_forward.py
@@ -702,6 +702,15 @@ def test_activation():
             x = x.softmax(dim=-1)
             return x
 
+    class Threshold(flow.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.active = flow.nn.Threshold()
+
+        def forward(self, x):
+            x = self.active(x)
+            return x
+
     if os.path.exists(MODEL_HOME):
         rmdir(MODEL_HOME)
 
@@ -718,6 +727,7 @@ def test_activation():
     model11 = GELU().eval()
     model12 = HardTanh().eval()
     model13 = TensorSoftmax().eval()
+    model14 = Threshold().eval()
 
     for device in ["llvm"]:
         verify_activation(model1, device=device)
@@ -737,6 +747,7 @@ def test_activation():
             device=device,
             inputs=flow.tensor(np.random.rand(1, 12, 197, 197).astype(np.float32)),
         )
+        verify_activation(model14, device=device)
 
 
 @tvm.testing.uses_gpu


### PR DESCRIPTION
The implementation logic of Threshold in oneflow is as follows:
![image](https://github.com/apache/tvm/assets/29506758/8087b9df-3945-44cf-bddd-5dfba9020a34)


The detail information can be found [here](https://start.oneflow.org/oneflow-api-cn/nn.html#:~:text=class%20oneflow.nn.Threshold,%EF%BC%8C%E5%90%A6%E5%88%99%E8%BF%94%E5%9B%9E%20value%E3%80%82)

This PR corrects the implementation and adds a corresponding test case.


cc @Hzfengsy @echuraev @vvchernov 