### PR TITLE
[Relay][Bugfix] fix the wrong implementation of Softplus in OneFlow

### DIFF
--- a/python/tvm/relay/frontend/oneflow.py
+++ b/python/tvm/relay/frontend/oneflow.py
@@ -1119,8 +1119,11 @@ class Softplus(OneFlowOpConverter):
     def _impl_v1(cls, inputs, attrs, params):
         data = inputs[0]
         data_dtype = infer_type(data).checked_type.dtype
-        data = _op.exp(data) + _expr.const(1, dtype=data_dtype)
-        return _op.log(data)
+        beta = _expr.const(int(inputs[1]), dtype=data_dtype)
+        threshold = int(inputs[2]) if inputs[2] else 20
+        threshold_ = _op.full_like(data, fill_value=_expr.const(threshold))
+        softplus_value = _op.log(_op.exp(data * beta) + _expr.const(1.0, dtype=data_dtype)) / beta
+        return _op.where(_op.greater(data * beta, threshold_), data, softplus_value)
 
 
 class Softsign(OneFlowOpConverter):

--- a/python/tvm/relay/frontend/oneflow.py
+++ b/python/tvm/relay/frontend/oneflow.py
@@ -1119,8 +1119,8 @@ class Softplus(OneFlowOpConverter):
     def _impl_v1(cls, inputs, attrs, params):
         data = inputs[0]
         data_dtype = infer_type(data).checked_type.dtype
-        beta = _expr.const(int(inputs[1]), dtype=data_dtype)
-        threshold = int(inputs[2]) if inputs[2] else 20
+        beta = _expr.const(float(attrs.get("beta", 1.0)))
+        threshold = float(attrs.get("threshold", 20.0))
         threshold_ = _op.full_like(data, fill_value=_expr.const(threshold))
         softplus_value = _op.log(_op.exp(data * beta) + _expr.const(1.0, dtype=data_dtype)) / beta
         return _op.where(_op.greater(data * beta, threshold_), data, softplus_value)

--- a/tests/python/frontend/oneflow/test_forward.py
+++ b/tests/python/frontend/oneflow/test_forward.py
@@ -721,7 +721,7 @@ def test_activation():
 
     for device in ["llvm"]:
         verify_activation(model1, device=device)
-        # verify_activation(model2, device=device) # NO PASS
+        verify_activation(model2, device=device)
         verify_activation(model3, device=device)
         verify_activation(model4, device=device)
         verify_activation(model5, device=device)


### PR DESCRIPTION
The implementation logic of Softplus in OneFlow in  shown [here](https://start.oneflow.org/oneflow-api-cn/nn.html#:~:text=class%20oneflow.nn.Softplus(beta%3A%20int%20%3D%201%2C%20threshold%3A%20int%20%3D%2020)%C2%B6)

The original implementation of it can pass the existing test case. Thus, it skipped the corresponding test.

In this PR, I fixed the bug and made the test case runnable by canceling the comments.

cc @Hzfengsy @echuraev 