### PR TITLE
fix _convert_simple_rnn

### DIFF
--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -825,7 +825,7 @@ class TestKeras:
         )
         verify_keras_frontend(dense_model, need_transpose=False)
 
-    def test_SimpleRNN_with_InferType(self, keras_mod):
+    def test_simplernn_with_infertype(self, keras_mod):
         """This test case is from https://github.com/apache/tvm/issues/14868"""
         input_shape = (2, 2, 2)
         x = keras_mod.layers.Input(shape=input_shape[1:], dtype="float32")
@@ -877,4 +877,4 @@ if __name__ == "__main__":
         sut.test_forward_repeat_vector(keras_mod=k)
         sut.test_forward_l2_normalize(keras_mod=k)
         sut.test_forward_time_distributed(keras_mod=k)
-        sut.test_SimpleRNN_with_InferType(keras_mod=k)
+        sut.test_simplernn_with_infertype(keras_mod=k)

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -832,7 +832,7 @@ class TestKeras:
         layer = keras_mod.layers.SimpleRNN(units=4)
         y = layer(x)
         model = keras_mod.models.Model(x, y)
-        mod, _ = relay.frontend.from_keras(model, {"input_1": input_shape})
+        mod, _ = relay.frontend.from_keras(model, {model.input_names[0]: input_shape})
         relay.transform.InferType()(mod)
 
 

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -825,6 +825,16 @@ class TestKeras:
         )
         verify_keras_frontend(dense_model, need_transpose=False)
 
+    def test_SimpleRNN_with_InferType(self, keras_mod):
+        """This test case is from https://github.com/apache/tvm/issues/14868"""
+        input_shape = (2, 2, 2)
+        x = keras_mod.layers.Input(shape=input_shape[1:], dtype="float32")
+        layer = keras_mod.layers.SimpleRNN(units=4)
+        y = layer(x)
+        model = keras_mod.models.Model(x, y)
+        mod, _ = relay.frontend.from_keras(model, {"input_1": input_shape})
+        relay.transform.InferType()(mod)
+
 
 if __name__ == "__main__":
     for k in [keras, tf_keras]:
@@ -867,3 +877,4 @@ if __name__ == "__main__":
         sut.test_forward_repeat_vector(keras_mod=k)
         sut.test_forward_l2_normalize(keras_mod=k)
         sut.test_forward_time_distributed(keras_mod=k)
+        sut.test_SimpleRNN_with_InferType(keras_mod=k)


### PR DESCRIPTION
Fix this [issue](https://github.com/apache/tvm/issues/14868)

Just as @echuraev guessed,  `_convert_simple_rnn` has some logical errors. I'm not very sure if I fix it correctly. All in all, after this fix, running the following bug-triggered script will feedback a good compilation result, and `InferType()` can successfully infer all types/shapes in the model and the inference is correct.
```Python
import tvm
import tvm.relay as relay
from tensorflow import keras
from tensorflow.keras import layers, models

input_shape = (2, 2, 2)
x = layers.Input(shape=input_shape[1:], dtype='float32')

layer = keras.layers.SimpleRNN(units=2)
layer.set_weights(layer.get_weights())

y = layer(x)
model = models.Model(x, y)
model.summary()
mod, params = relay.frontend.from_keras(model, {'input_1': input_shape})
mod = relay.transform.InferType()(mod)

print(mod)
with tvm.transform.PassContext(opt_level=3):
    model = relay.build_module.create_executor("vm", mod, tvm.cpu(0), 'llvm', params).evaluate()
```
The compilation result is 
```
Model: "model"
_________________________________________________________________
 Layer (type)                Output Shape              Param #   
=================================================================
 input_1 (InputLayer)        [(None, 2, 2)]            0         
                                                                 
 simple_rnn (SimpleRNN)      (None, 2)                 10        
                                                                 
=================================================================
Total params: 10 (40.00 Byte)
Trainable params: 10 (40.00 Byte)
Non-trainable params: 0 (0.00 Byte)
_________________________________________________________________
def @main(%input_1: Tensor[(2, 2, 2), float32] /* ty=Tensor[(2, 2, 2), float32] */, %v_param_2: Tensor[(2, 4), float32] /* ty=Tensor[(2, 4), float32] */, %v_param_4: Tensor[(2), float32] /* ty=Tensor[(2), float32] */, %v_param_1: Tensor[(1, 2), float32] /* ty=Tensor[(1, 2), float32] */, %v_param_3: Tensor[(2, 2), float32] /* ty=Tensor[(2, 2), float32] */) -> Tensor[(2, 2), float32] {
  %0 = nn.batch_flatten(%input_1) /* ty=Tensor[(2, 4), float32] */;
  %1 = nn.dense(%0, %v_param_2, units=2) /* ty=Tensor[(2, 2), float32] */;
  %2 = nn.bias_add(%1, %v_param_4) /* ty=Tensor[(2, 2), float32] */;
  %3 = split(%2, indices_or_sections=[1], axis=1) /* ty=(Tensor[(2, 1), float32], Tensor[(2, 1), float32]) */;
  %4 = nn.batch_flatten(%v_param_1) /* ty=Tensor[(1, 2), float32] */;
  %5 = %3.0 /* ty=Tensor[(2, 1), float32] */;
  %6 = nn.dense(%4, %v_param_3, units=2) /* ty=Tensor[(1, 2), float32] */;
  %7 = add(%5, %6) /* ty=Tensor[(2, 2), float32] */;
  %8 = %3.0 /* ty=Tensor[(2, 1), float32] */;
  %9 = nn.dense(%7, %v_param_3, units=2) /* ty=Tensor[(2, 2), float32] */;
  add(%8, %9) /* ty=Tensor[(2, 2), float32] */
}

One or more operators have not been tuned. Please tune your model for better performance. Use DEBUG logging level to see more details.
```
