### PR TITLE
[Unity][DLight] Fix outer_reduction for dynamic shape workloads

### DIFF
--- a/python/tvm/dlight/gpu/gemv.py
+++ b/python/tvm/dlight/gpu/gemv.py
@@ -514,7 +514,7 @@ class GEMV(ScheduleRule):
 
         # The config is designed for Adreno
         tx_len = 64
-        vec_len = 4 if len_s > 4096 else 2
+        vec_len = (4 if len_s > 4096 else 2) if isinstance(len_s, int) else 1
         inner_r = 4
 
         bx, tx, vec = sch.split(s, factors=[None, tx_len, vec_len])


### PR DESCRIPTION
The PR https://github.com/apache/tvm/pull/15730 introduced the outer_reduction for adreno gemv. This PR fixes the length issue when applying on dynamic workloads.

cc @spectrometerHBH 