### PR TITLE
[Unity][MSC][M1.2] Add translate && codegen for tensorflow

### DIFF
--- a/python/tvm/contrib/msc/core/codegen/codegen.py
+++ b/python/tvm/contrib/msc/core/codegen/codegen.py
@@ -125,8 +125,7 @@ def relay_to_relax(
         opt_config=opt_config,
     )
     source_getter = tvm.get_global_func("msc.framework.tvm.GetRelaxSources")
-    codegen_config = {"from_relay": True}
-    codegen = CodeGen(graph, source_getter, codegen_config)
+    codegen = CodeGen(graph, source_getter, codegen_config={"from_relay": True})
     inputs = [
         tvm.relax.Var(i.alias, tvm.relax.TensorStructInfo(i.get_shape(), i.dtype_name))
         for i in graph.get_inputs()

--- a/python/tvm/contrib/msc/core/transform/transform.py
+++ b/python/tvm/contrib/msc/core/transform/transform.py
@@ -22,7 +22,7 @@ from tvm.relax.transform import _ffi_api as relax_api
 from tvm.relay.transform import _ffi_api as relay_api
 
 
-def SetExprName(as_relax=True, entry_name="main") -> tvm.ir.transform.Pass:
+def SetExprName(as_relax: bool = True, entry_name: str = "main") -> tvm.ir.transform.Pass:
     """Set name for the call and constant in IRModule.
 
     Parameters
@@ -31,7 +31,6 @@ def SetExprName(as_relax=True, entry_name="main") -> tvm.ir.transform.Pass:
         Whether set names for relax, otherwise for relay.
     entry_name: str
         The entry name
-
 
     Returns
     -------
@@ -43,7 +42,29 @@ def SetExprName(as_relax=True, entry_name="main") -> tvm.ir.transform.Pass:
     return relay_api.SetRelayExprName(entry_name)  # type: ignore
 
 
-def SetExprLayout(allow_missing=True, entry_name="main") -> tvm.ir.transform.Pass:
+def BindExprName(
+    name_key: str = "", seperator: str = ",", entry_name: str = "main"
+) -> tvm.ir.transform.Pass:
+    """Bind name for the call and constant in IRModule.
+
+    Parameters
+    ----------
+    name_key: str
+        The key to find name
+    seperator: str
+        The seperator
+    entry_name: str
+        The entry name
+
+    Returns
+    -------
+    ret: tvm.ir.transform.Pass
+    """
+
+    return relay_api.BindRelayExprName(name_key, seperator, entry_name)  # type: ignore
+
+
+def SetExprLayout(allow_missing: bool = True, entry_name: str = "main") -> tvm.ir.transform.Pass:
     """Set layout for the var and constant in IRModule.
 
     Parameters

--- a/python/tvm/contrib/msc/framework/tensorflow/__init__.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/__init__.py
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.framework.tensorflow"""
+
+import tensorflow as tf
+
+try:
+    tf_v1 = tf.compat.v1
+except (ImportError, AttributeError):
+    tf_v1 = tf

--- a/python/tvm/contrib/msc/framework/tensorflow/_ffi_api.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/_ffi_api.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.framework.tensorflow._ffi_api"""
+
+import tvm._ffi
+
+tvm._ffi._init_api("msc.framework.tensorflow", __name__)

--- a/python/tvm/contrib/msc/framework/tensorflow/codegen/__init__.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/codegen/__init__.py
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.framework.tensorflow.codegen"""
+
+from .codegen import *

--- a/python/tvm/contrib/msc/framework/tensorflow/codegen/codegen.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/codegen/codegen.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.framework.tensorflow.codegen.codegen"""
+
+from typing import Dict, Optional, Union, List
+
+import tvm
+from tvm.contrib.msc.core.ir import MSCGraph
+from tvm.contrib.msc.core.codegen import CodeGen
+from tvm.contrib.msc.core import utils as msc_utils
+from tvm.contrib.msc.framework.tensorflow import tf_v1
+from tvm.contrib.msc.framework.tensorflow import _ffi_api
+
+
+def to_tensorflow(
+    graph: MSCGraph,
+    weights: Optional[Dict[str, tvm.nd.array]] = None,
+    codegen_config: Optional[Dict[str, str]] = None,
+    print_config: Optional[Dict[str, str]] = None,
+    build_folder: msc_utils.MSCDirectory = None,
+) -> tf_v1.Graph:
+    """Change MSCGraph to tensorflow graph.
+
+    Parameters
+    ----------
+    graph: tvm.contrib.msc.core.ir.MSCGraph
+        The translated graph.
+    weights: dict of <string:tvm.ndarray>
+        The parameters of the IRModule.
+    codegen_config: dict
+        The config for codegen.
+    print_config: dict
+        The config for print.
+    build_folder: MSCDirectory
+        The folder for saving scripts and datas.
+
+    Returns
+    -------
+    tf_graph: tf_v1.Graph
+        The tensorflow Graph.
+    """
+
+    def _bind_weights(
+        outs: Union[tf_v1.Tensor, List[tf_v1.Tensor]], folder: msc_utils.MSCDirectory
+    ) -> Union[tf_v1.Tensor, List[tf_v1.Tensor]]:
+        if weights:
+            with open(folder.relpath(graph.name + "_params.bin"), "wb") as f_params:
+                f_params.write(tvm.runtime.save_param_dict(weights))
+        return outs
+
+    inputs = [tf_v1.placeholder(i.dtype_name, i.get_shape(), i.alias) for i in graph.get_inputs()]
+    codegen = CodeGen(
+        graph, _ffi_api.GetTensorflowSources, codegen_config, print_config, build_folder
+    )
+    return codegen.load(inputs + [weights], _bind_weights)

--- a/python/tvm/contrib/msc/framework/tensorflow/frontend/__init__.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/frontend/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.framework.tensorflow.frontend"""

--- a/python/tvm/contrib/msc/framework/tensorflow/frontend/translate.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/frontend/translate.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.framework.torch.frontend.translate"""
+
+from typing import Dict, Optional, Tuple, List
+
+import tvm
+
+from tvm.contrib.msc.core.ir.graph import MSCGraph
+from tvm.contrib.msc.core import transform as msc_transform
+from tvm.contrib.msc.core.ir.translate import from_relax
+from tvm.contrib.msc.core.codegen import relay_to_relax
+from tvm.contrib.msc.framework.tensorflow import tf_v1
+
+
+def from_tensorflow(
+    graph_def: tf_v1.GraphDef,
+    shape_dict: Dict[str, List[int]],
+    outputs: List[str],
+    via_relax: bool = False,
+    trans_config: Optional[Dict[str, str]] = None,
+    build_config: Optional[Dict[str, str]] = None,
+    opt_config: Optional[Dict[str, str]] = None,
+) -> Tuple[MSCGraph, Dict[str, tvm.nd.array]]:
+    """Change tensorflow GraphDef to MSCGraph.
+
+    Parameters
+    ----------
+    graph_def: tf_v1.GraphDef
+        The graph define of tensorflow.
+    shape_dict: dict<str,list<int>>
+        The shape dict of inputs.
+    outputs: list<str>
+        The output names.
+    via_relax: bool
+        Whether translate torch to relax.
+    trans_config: dict
+        The config for transfrorm IRModule.
+    build_config: dict
+        The config for build MSCGraph.
+    opt_config: dict
+        The config for optimize the relay before translate.
+
+    Returns
+    -------
+    graph: tvm.contrib.msc.core.ir.MSCGraph
+        The translated graph.
+    weights: dict of <string:tvm.ndarray>
+        The weights from the IRModule.
+    """
+
+    assert not via_relax, "Relax frontend for tensorflow is not supported"
+    relay_mod, params = tvm.relay.frontend.from_tensorflow(
+        graph_def, shape=shape_dict, outputs=outputs
+    )
+    passes = [msc_transform.BindExprName()]
+    relay_mod = tvm.transform.Sequential(passes)(relay_mod)
+    relax_mod = relay_to_relax(relay_mod, params, trans_config, build_config, opt_config)
+    build_config = build_config or {}
+    build_config["use_var_name"] = True
+    graph, weights = from_relax(relax_mod, trans_config=trans_config, build_config=build_config)
+    return graph, weights

--- a/src/contrib/msc/core/codegen/code_stack.cc
+++ b/src/contrib/msc/core/codegen/code_stack.cc
@@ -198,6 +198,15 @@ void BaseStack::CallArgBase(const ExprDoc& value, const String& key) {
   }
 }
 
+void BaseStack::CallIndexArgBase(const ExprDoc& value, const Array<ExprDoc>& indices,
+                                 const String& key) {
+  Array<Doc> doc_indices;
+  for (const auto& i : indices) {
+    doc_indices.push_back(i);
+  }
+  CallArgBase(IndexDoc(value, doc_indices), key);
+}
+
 void BaseStack::CallStrArg(const String& value, const String& key) {
   if (value.size() > 0) {
     CallArgBase(DocUtils::ToStrDoc(value), key);

--- a/src/contrib/msc/core/codegen/code_stack.h
+++ b/src/contrib/msc/core/codegen/code_stack.h
@@ -152,15 +152,32 @@ class BaseStack {
   /*! \brief Push inplace call or/and assign Doc*/
   void InplaceEnd();
 
-  /*! \brief Cache call argument*/
+  /*! \brief Cache call base argument*/
   void CallArgBase(const ExprDoc& value, const String& key = "");
 
+  /*! \brief Cache call normal argument*/
   template <typename T>
   inline void CallArg(T value, const String& key = "") {
     CallArgBase(DocUtils::ToDoc(value), key);
   }
 
+  /*! \brief Cache call string argument*/
   void CallStrArg(const String& value, const String& key = "");
+
+  /*! \brief Cache call index argument*/
+  void CallIndexArgBase(const ExprDoc& value, const Array<ExprDoc>& indices,
+                        const String& key = "");
+
+  template <typename T>
+  inline void CallIndexArg(const String& value, const std::vector<T>& indices,
+                           const String& key = "") {
+    CallIndexArgBase(IdDoc(value), DocUtils::ToDocList(indices), key);
+  }
+
+  template <typename T>
+  inline void CallIndexArg(const String& value, const Array<T>& indices, const String& key = "") {
+    CallIndexArgBase(IdDoc(value), DocUtils::ToDocList(indices), key);
+  }
 
   /*! \brief Cache call list argument*/
   void CallListArgBase(const Array<ExprDoc>& values, const String& key = "",
@@ -362,6 +379,17 @@ class BaseStack {
     CallStrArg(value, key);                                                                      \
     return *this;                                                                                \
   }                                                                                              \
+  template <typename T>                                                                          \
+  Stack& call_index_arg(const String& value, const std::vector<T>& indices,                      \
+                        const String& key = "") {                                                \
+    CallIndexArg(value, indices, key);                                                           \
+    return *this;                                                                                \
+  }                                                                                              \
+  template <typename T>                                                                          \
+  Stack& call_index_arg(const String& value, const Array<T>& indices, const String& key = "") {  \
+    CallIndexArg(value, indices, key);                                                           \
+    return *this;                                                                                \
+  }                                                                                              \
   Stack& call_list_arg(const Array<ExprDoc>& values, const String& key = "",                     \
                        bool allow_empty = false, bool as_list = true) {                          \
     CallListArg(values, key, allow_empty, as_list);                                              \
@@ -508,6 +536,12 @@ class OpCodeStack : public BaseStack {
     if (codegen_->node()->weights.count(wtype)) {
       return call_arg(codegen_->IdxWeight(wtype, false), key);
     }
+    return *this;
+  }
+
+  /*! \brief Cache name as argument*/
+  OpCodeStack<OpCodeGenType>& op_name_arg(const String& key = "name") {
+    return call_str_arg(codegen_->node()->name, key);
     return *this;
   }
 

--- a/src/contrib/msc/core/ir/graph_builder.h
+++ b/src/contrib/msc/core/ir/graph_builder.h
@@ -56,6 +56,7 @@ using namespace tvm::runtime;
  */
 struct MSCRBuildConfig {
   bool prune_graph{false};
+  bool use_var_name{false};
   int float_precision = 6;
   std::string sort_by;
   std::vector<std::string> input_aliases;
@@ -78,6 +79,8 @@ struct MSCRBuildConfig {
     while (reader->NextObjectItem(&key)) {
       if (key == "prune_graph") {
         reader->Read(&prune_graph);
+      } else if (key == "use_var_name") {
+        reader->Read(&use_var_name);
       } else if (key == "float_precision") {
         reader->Read(&float_precision);
       } else if (key == "sort_by") {

--- a/src/contrib/msc/core/transform/layout_utils.cc
+++ b/src/contrib/msc/core/transform/layout_utils.cc
@@ -49,7 +49,7 @@ bool LayoutUtils::SetLayout(const Expr& expr, const NLayout& layout) {
     }
     expr->span = SpanUtils::SetAttr(expr->span, "layout", l_layout.name());
   } else if (sinfo.as<TupleStructInfoNode>()) {
-    ICHECK(!layout.IsLeaf()) << "Expr has tupple struct, but find non-nested layout " << expr;
+    ICHECK(!layout.IsLeaf()) << "Expr has tuple struct, but find non-nested layout " << expr;
     String layout_str;
     Array<NLayout> nested_layouts = layout.NestedArray();
     for (size_t i = 0; i < nested_layouts.size(); i++) {

--- a/src/contrib/msc/core/transform/set_expr_name.cc
+++ b/src/contrib/msc/core/transform/set_expr_name.cc
@@ -374,7 +374,7 @@ class RelayExprNameBinder : public ExprVisitor {
       expr->span = Span(SourceName::Get(""), expr->span->line, expr->span->end_line,
                         expr->span->column, expr->span->end_column);
     } else {
-      const auto& right = std::get<1>(StringUtils::SplitOnce(name, name_key_));
+      const String& right = std::get<1>(StringUtils::SplitOnce(name, name_key_));
       if (right.size() > 0) {
         valid_name = std::get<0>(StringUtils::SplitOnce(name, seperator_));
         if (valid_name.size() > 0) {

--- a/src/contrib/msc/core/transform/set_expr_name.cc
+++ b/src/contrib/msc/core/transform/set_expr_name.cc
@@ -374,7 +374,7 @@ class RelayExprNameBinder : public ExprVisitor {
       expr->span = Span(SourceName::Get(""), expr->span->line, expr->span->end_line,
                         expr->span->column, expr->span->end_column);
     } else {
-      const String& right = std::get<1>(StringUtils::SplitOnce(name, name_key_));
+      String right = std::get<1>(StringUtils::SplitOnce(name, name_key_));
       if (right.size() > 0) {
         valid_name = std::get<0>(StringUtils::SplitOnce(name, seperator_));
         if (valid_name.size() > 0) {

--- a/src/contrib/msc/core/utils.cc
+++ b/src/contrib/msc/core/utils.cc
@@ -47,6 +47,20 @@ std::vector<size_t> CommonUtils::GetIndices(const std::vector<int>& indices, siz
   return v_indices;
 }
 
+bool StringUtils::Contains(const String& src_string, const String& sub_string) {
+  if (src_string.size() == 0) {
+    return false;
+  }
+  if (sub_string.size() == 0) {
+    return false;
+  }
+
+  const std::string src_cstring = src_string;
+  const std::string& sub_cstring = sub_string;
+  int pos = src_cstring.find(sub_cstring);
+  return pos >= 0;
+}
+
 const Array<String> StringUtils::Split(const String& src_string, const String& sep) {
   Array<String> sub_strings;
   if (src_string.size() == 0) {
@@ -192,7 +206,8 @@ const Span SpanUtils::SetAttr(const Span& span, const String& key, const String&
     const String& source_str = span->source_name->name;
     String left = std::get<0>(StringUtils::SplitOnce(source_str, tokens[0]));
     String right = std::get<1>(StringUtils::SplitOnce(source_str, tokens[1]));
-    if (left.size() > 0) {
+    if (StringUtils::Contains(source_str, tokens[0]) &&
+        StringUtils::Contains(source_str, tokens[1])) {
       new_source = left + tokens[0] + value + tokens[1] + right;
     } else {
       new_source = source_str + tokens[0] + value + tokens[1];

--- a/src/contrib/msc/core/utils.h
+++ b/src/contrib/msc/core/utils.h
@@ -60,6 +60,12 @@ class CommonUtils {
 class StringUtils {
  public:
   /*!
+   * \brief Check if the String contains a substring.
+   * \return Whether substring is contained.
+   */
+  TVM_DLL static bool Contains(const String& src_string, const String& sub_string);
+
+  /*!
    * \brief Split the String into sub Strings.
    * \return The SubStrings.
    */
@@ -159,7 +165,11 @@ class ArrayUtils {
   TVM_DLL static const Array<T> Cast(const Array<PrimExpr>& src_array) {
     Array<T> new_array;
     for (const auto& s : src_array) {
-      new_array.push_back(Downcast<T>(s));
+      if (s->IsInstance<tvm::tir::AnyNode>()) {
+        new_array.push_back(T(-1));
+      } else {
+        new_array.push_back(Downcast<T>(s));
+      }
     }
     return new_array;
   }

--- a/src/contrib/msc/framework/tensorflow/codegen.cc
+++ b/src/contrib/msc/framework/tensorflow/codegen.cc
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/codegen.cc
+ */
+#include "codegen.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+void TensorflowCodeGen::CodeGenHeader() {
+  PyCodeGen<TensorflowCodeGenConfig>::CodeGenHeader();
+  stack_.line("from tensorflow.python import ops")
+      .line("from tvm.contrib.msc.framework.tensorflow import tf_v1");
+}
+
+void TensorflowCodeGen::CodeGenHelper() {
+  PyCodeGen<TensorflowCodeGenConfig>::CodeGenHelper();
+  stack_.func_def("get_variable", TensorType())
+      .func_arg("name", "str")
+      .func_arg("shape", "List[int]")
+      .func_arg("dtype", "str")
+      .func_arg("weights", "Dict[str, tvm.nd.array]")
+      .func_start()
+      .cond_if("name in weights")
+      .call_start("tf_v1.get_variable")
+      .call_arg("name")
+      .call_arg("weights[name].asnumpy()", "initializer")
+      .call_end("var")
+      .cond_else()
+      .call_start("tf_v1.get_variable")
+      .call_arg("name")
+      .call_arg("shape")
+      .call_arg("dtype")
+      .call_end("var")
+      .cond_end()
+      .func_end("var");
+}
+
+void TensorflowCodeGen::CodeGenGraph() {
+  stack_.func_def(graph()->name, "List[tf_v1.Tensor]");
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& pair = graph()->FindProducerAndIdx(i);
+    stack_.func_arg(IdxOutput(pair.first, pair.second), "tf_v1.Tensor");
+  }
+  stack_.func_arg("weights", "Dict[str, tvm.nd.array]").func_start();
+  // define weights
+  stack_.comment("Define the weights and constant");
+  for (const auto& n : graph()->node_names) {
+    const auto& node = graph()->FindNode(n);
+    for (const auto& pair : node->weights) {
+      stack_.call_start("get_variable")
+          .call_str_arg(pair.second->name)
+          .call_list_arg(pair.second->shape, "", true)
+          .call_str_arg(pair.second->DTypeName())
+          .call_arg("weights")
+          .call_end(IdxWeight(node, pair.first));
+    }
+    if (node->optype == "constant") {
+      CodeGenNode(node);
+    }
+  }
+  // define ops
+  stack_.comment("Define the ops");
+  for (const auto& n : graph()->node_names) {
+    const auto& node = graph()->FindNode(n);
+    if (node->optype == "input" || node->optype == "constant") {
+      continue;
+    }
+    CodeGenNode(node);
+  }
+  Array<String> idx_outputs;
+  for (const auto& o : graph()->GetOutputs()) {
+    const auto& pair = graph()->FindProducerAndIdx(o);
+    idx_outputs.push_back(IdxOutput(pair.first, pair.second));
+  }
+  if (idx_outputs.size() == 1) {
+    stack_.assign("outputs", idx_outputs[0]);
+  } else {
+    stack_.assign_list("outputs", idx_outputs);
+  }
+  stack_.func_end("outputs");
+}
+
+void TensorflowCodeGen::CodeGenInference() {
+  stack_.comment("Load weights")
+      .scope_start("open(\"" + graph()->name + "_params.bin\", \"rb\")", "f")
+      .call_start("tvm.runtime.load_param_dict")
+      .call_arg("f.read()")
+      .call_end("params")
+      .scope_end()
+      .comment("Build Graph")
+      .scope_start("tf_v1.Graph().as_default()");
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& producer = graph()->FindProducer(i);
+    stack_.call_start("tf_v1.placeholder")
+        .call_str_arg(i->DTypeName())
+        .call_list_arg(i->shape)
+        .call_str_arg(i->alias)
+        .call_end(IdxNode(producer));
+  }
+  stack_.call_start(graph()->name);
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& producer = graph()->FindProducer(i);
+    stack_.call_arg(IdxNode(producer));
+  }
+  stack_.call_arg("params").call_end("outs").assign("feed_dict", "{}");
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& producer = graph()->FindProducer(i);
+    stack_.assign("feed_dict[" + IdxNode(producer) + "]", "inputs[\"" + i->alias + "\"]");
+  }
+  stack_.scope_start("tf_v1.Session()", "sess")
+      .call_start("sess.run")
+      .call_arg("ops.variables.global_variables_initializer()")
+      .call_end()
+      .call_start("sess.run")
+      .call_arg("outs")
+      .call_arg("feed_dict", "feed_dict")
+      .call_end("outputs")
+      .scope_end()
+      .scope_end();
+}
+
+const Array<Doc> TensorflowCodeGen::GetOpCodes(const MSCJoint& node) {
+  const auto& ops_map = GetTFV1OpCodes();
+  auto it = ops_map->find(node->optype);
+  ICHECK(it != ops_map->end()) << "Unsupported tensorflow op(" << node->optype << "): " << node;
+  it->second->Config(node, config());
+  try {
+    return it->second->GetDocs();
+  } catch (runtime::InternalError& err) {
+    LOG(WARNING) << "Failed to get docs for " << node << " : " << err.message();
+    throw err;
+  }
+}
+
+TVM_REGISTER_GLOBAL("msc.framework.tensorflow.GetTensorflowSources")
+    .set_body_typed([](const MSCGraph& graph, const String& codegen_config,
+                       const String print_config) -> Map<String, String> {
+      TensorflowCodeGen codegen = TensorflowCodeGen(graph, codegen_config);
+      return codegen.GetSources(print_config);
+    });
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/msc/framework/tensorflow/codegen.h
+++ b/src/contrib/msc/framework/tensorflow/codegen.h
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/codegen.h
+ * \brief Tensorflow codegen for MSCGraph.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CODEGEN_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CODEGEN_H_
+
+#include <string>
+
+#include "../../core/codegen/base_codegen.h"
+#include "../../core/codegen/py_codegen.h"
+#include "config.h"
+#include "tf_v1_opcode.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+class TensorflowCodeGen : public PyCodeGen<TensorflowCodeGenConfig> {
+ public:
+  /*!
+   * \brief The constructor of TensorflowCodeGen
+   * \param graph the graph to be generated.
+   * \param config the options for codegen.
+   */
+  explicit TensorflowCodeGen(const MSCGraph& graph, const std::string& config = "")
+      : PyCodeGen<TensorflowCodeGenConfig>(graph, config) {}
+
+ protected:
+  /*! \brief Stack the docs for the header*/
+  void CodeGenHeader() final;
+
+  /*! \brief Stack the docs for the helpers*/
+  void CodeGenHelper() final;
+
+  /*! \brief Stack the docs for the graph*/
+  void CodeGenGraph() final;
+
+  /*! \brief Stack the docs for the graph inference*/
+  void CodeGenInference() final;
+
+  /*! \brief Get the docs for the op*/
+  const Array<Doc> GetOpCodes(const MSCJoint& node) final;
+
+  /*! \brief Get tensor type of the framework*/
+  const String TensorType() const final { return "tf_v1.Tensor"; }
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CODEGEN_H_

--- a/src/contrib/msc/framework/tensorflow/config.h
+++ b/src/contrib/msc/framework/tensorflow/config.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/config.h
+ * \brief Tensorflow config for codegen.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_
+
+#include <string>
+
+#include "../../core/codegen/base_codegen.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+/*!
+ * \brief CodeGen config for torch codegen
+ */
+struct TensorflowCodeGenConfig {
+  bool is_training{false};
+  CODEGEN_CONFIG_MEMBERS
+  void Load(dmlc::JSONReader* reader) {
+    std::string key;
+    reader->BeginObject();
+    while (reader->NextObjectItem(&key)) {
+      if (key == "is_training") {
+        reader->Read(&is_training);
+      } else {
+        CODEGEN_CONFIG_PARSE
+      }
+    }
+  }
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_

--- a/src/contrib/msc/framework/tensorflow/tf_v1_opcode.cc
+++ b/src/contrib/msc/framework/tensorflow/tf_v1_opcode.cc
@@ -1,0 +1,606 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/tf_v1_opcode.cc
+ */
+#include "tf_v1_opcode.h"
+
+#include <memory>
+#include <string>
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+const Array<Doc> TFV1OpCode::GetDocs() {
+  stack_.Config(this);
+  CodeGenBuild();
+  return stack_.GetDocs();
+}
+
+const std::pair<String, Array<String>> TFV1OpCode::GetPadding(const String& strides_key,
+                                                              const String& kernel_key,
+                                                              const String& padding_key) {
+  String pad_mod = "";
+  Array<String> padding;
+  std::vector<int64_t> kernel_size;
+  if (node()->optype == "nn.conv2d" || node()->optype == "msc.conv2d_bias") {
+    const auto& weight = node()->WeightAt("weight");
+    kernel_size.push_back(weight->DimAt("H")->value);
+    kernel_size.push_back(weight->DimAt("W")->value);
+  } else if (node()->optype == "nn.avg_pool2d" || node()->optype == "nn.max_pool2d") {
+    ICHECK(node()->GetAttr(kernel_key, &kernel_size));
+  } else {
+    LOG_FATAL << "Unexpected padding node" << node();
+  }
+  const auto& strides = node()->GetTypeArrayAttr<int64_t>(strides_key);
+  int64_t in_height = node()->InputAt(0)->DimAt("H")->value;
+  int64_t in_width = node()->InputAt(0)->DimAt("W")->value;
+  int64_t out_height = node()->OutputAt(0)->DimAt("H")->value;
+  int64_t out_width = node()->OutputAt(0)->DimAt("W")->value;
+  int64_t same_height = in_height / strides[0] + (in_height % strides[0] == 0 ? 0 : 1);
+  int64_t same_width = in_width / strides[1] + (in_width % strides[1] == 0 ? 0 : 1);
+  int64_t valid_height = (in_height - kernel_size[0] + 1) / strides[0];
+  valid_height += (valid_height % strides[0] == 0 ? 0 : 1);
+  int64_t valid_width = (in_width - kernel_size[1] + 1) / strides[1];
+  valid_width += (valid_width % strides[1] == 0 ? 0 : 1);
+  if (same_height == out_height && same_width == out_width) {
+    pad_mod = "SAME";
+  } else if (valid_height == out_height && valid_width == out_width) {
+    pad_mod = "VALID";
+  } else {
+    const auto& src_padding = node()->GetTypeArrayAttr<int64_t>(padding_key);
+    if (node()->optype == "nn.conv2d" || node()->optype == "msc.conv2d_bias" ||
+        node()->optype == "nn.avg_pool2d" || node()->optype == "nn.max_pool2d") {
+      const auto& out_layout = node()->GetTypeAttr<std::string>("out_layout");
+      if (out_layout == "NHWC") {
+        padding.push_back("[0, 0]");
+      } else if (out_layout == "NCHW") {
+        padding.push_back("[0, 0]");
+        padding.push_back("[0, 0]");
+      } else {
+        LOG_FATAL << "Unexpected layout for padding node" << node();
+      }
+      if (src_padding.size() == 4) {
+        padding.push_back("[" + std::to_string(src_padding[0]) + ", " +
+                          std::to_string(src_padding[2]) + "]");
+        padding.push_back("[" + std::to_string(src_padding[1]) + ", " +
+                          std::to_string(src_padding[3]) + "]");
+      } else {
+        LOG_FATAL << "nn.conv2d/pool2d with unexpected padding " << node();
+      }
+      if (out_layout == "NHWC") {
+        padding.push_back("[0, 0]");
+      }
+    } else {
+      LOG_FATAL << "Unexpected padding node" << node();
+    }
+  }
+  return std::make_pair(pad_mod, padding);
+}
+
+#define TFV1_OP_CODEGEN_METHODS(TypeName) \
+ public:                                  \
+  TypeName(const String& func_name) : TFV1OpCode(func_name) {}
+
+class TFV1ArgMaxMinCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1ArgMaxMinCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .op_input_arg()
+        .op_arg<int>("axis")
+        .call_dtype_arg(node()->OutputAt(0)->dtype, "output_type")
+        .op_name_arg()
+        .op_end();
+  }
+};
+
+class TFV1AstypeCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1AstypeCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    if (node()->InputAt(0)->dtype == node()->OutputAt(0)->dtype) {
+      stack_.op_start("tf_v1.identity").op_input_arg().op_name_arg().op_end();
+    } else {
+      stack_.op_start()
+          .op_input_arg()
+          .call_dtype_arg(node()->OutputAt(0)->dtype)
+          .op_name_arg()
+          .op_end();
+    }
+  }
+};
+
+class TFV1AxesCodeGen : public TFV1OpCode {
+ public:
+  TFV1AxesCodeGen(const String& func_name, const String& attr_name) : TFV1OpCode(func_name) {
+    attr_name_ = attr_name;
+  }
+
+ protected:
+  void CodeGenBuild() final {
+    const String& key = node()->HasAttr("axes") ? "axes" : "axis";
+    stack_.op_start().op_input_arg().op_list_arg<int>(key, attr_name_).op_name_arg().op_end();
+  }
+
+ private:
+  String attr_name_;
+};
+
+class TFV1AxisCodeGen : public TFV1OpCode {
+ public:
+  TFV1AxisCodeGen(const String& func_name, const String& attr_name) : TFV1OpCode(func_name) {
+    attr_name_ = attr_name;
+  }
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg().op_arg<int>("axis", attr_name_).op_name_arg().op_end();
+  }
+
+ private:
+  String attr_name_;
+};
+
+class TFV1BroadcastToCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1BroadcastToCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg().op_list_arg<int>("shape").op_name_arg().op_end();
+  }
+};
+
+class TFV1ConcatCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1ConcatCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_inputs_arg().op_arg<int>("axis").op_name_arg().op_end();
+  }
+};
+
+class TFV1ConstantCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1ConstantCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .call_str_arg(node()->name)
+        .call_list_arg(node()->OutputAt(0)->shape, "", true)
+        .call_str_arg(node()->OutputAt(0)->DTypeName())
+        .call_arg("weights")
+        .op_end();
+  }
+};
+
+class TFV1ConvCodeGen : public TFV1OpCode {
+ public:
+  TFV1ConvCodeGen(const String& func_name, bool use_bias) : TFV1OpCode(func_name) {
+    use_bias_ = use_bias;
+  }
+
+ protected:
+  void CodeGenBuild() final {
+    const auto& pair = GetPadding("strides");
+    const auto& out_layout = node()->GetTypeAttr<std::string>("out_layout");
+    int64_t groups = node()->GetTypeAttr<int64_t>("groups");
+    std::vector<int> strides, dilation;
+    const auto& attr_strides = node()->GetTypeArrayAttr<int>("strides");
+    const auto& attr_dilation = node()->GetTypeArrayAttr<int>("dilation");
+    if (out_layout == "NHWC") {
+      strides = {1, attr_strides[0], attr_strides[1], 1};
+      dilation = {1, attr_dilation[0], attr_dilation[1], 1};
+    } else if (out_layout == "NCHW") {
+      strides = {1, 1, attr_strides[0], attr_strides[1]};
+      dilation = {1, 1, attr_dilation[0], attr_dilation[1]};
+    } else {
+      LOG_FATAL << "Unexpected layout for padding node" << node();
+    }
+    if (groups == 1) {
+      stack_.op_start();
+    } else if (groups == node()->InputAt(0)->DimAt("C")->value) {
+      stack_.op_start("ops.nn_ops.depthwise_conv2d_native");
+    } else {
+      LOG_FATAL << "Unexpected conv with groups " << node();
+    }
+    stack_.op_input_arg()
+        .op_weight_arg("weight")
+        .call_list_arg(strides, "strides")
+        .call_list_arg(dilation, "dilations")
+        .op_str_arg("data_layout", "data_format");
+    if (pair.first.size() > 0) {
+      stack_.call_str_arg(pair.first, "padding");
+    } else if (pair.second.size() > 0) {
+      stack_.call_list_arg(pair.second, "padding");
+    } else {
+      LOG_FATAL << "Can not parse padding for " << node();
+    }
+    stack_.op_name_arg().op_end();
+    if (use_bias_) {
+      stack_.op_start("ops.nn_ops.bias_add")
+          .op_output_arg()
+          .op_weight_arg("bias")
+          .call_str_arg(node()->name + "_bias", "name")
+          .op_end();
+    }
+  }
+
+ private:
+  bool use_bias_;
+};
+
+class TFV1CreateLikeCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1CreateLikeCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg().op_str_arg("dtype").op_name_arg().op_end();
+  }
+};
+
+class TFV1EinsumCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1EinsumCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    const auto& producer = node()->ProducerOf(0);
+    stack_.op_start().op_str_arg("subscripts", "");
+    if (node()->inputs.size() == 1 && producer->optype == "tuple") {
+      stack_.call_index_arg(IdxInput(), std::vector<int>{0});
+    } else {
+      stack_.op_inputs_arg(false);
+    }
+    stack_.op_name_arg().op_end();
+  }
+};
+
+class TFV1FullCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1FullCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_list_arg<int>("shape", "").op_input_arg(0, "value").op_name_arg().op_end();
+  }
+};
+
+class TFV1GetItemCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1GetItemCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.assign(IdxNode(), IdxInput(node()->GetTypeAttr<int>("index")));
+  }
+};
+
+class TFV1PadCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1PadCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    String mode;
+    const auto& attr_mode = node()->GetTypeAttr<std::string>("pad_mode");
+    if (attr_mode == "constant") {
+      mode = "CONSTANT";
+    } else {
+      LOG_FATAL << "Unexpected pad mode " << node();
+    }
+    Array<String> pad_width;
+    const auto& attr_pad_width = node()->GetTypeArrayAttr<int>("pad_width");
+    ICHECK(attr_pad_width.size() % 2 == 0) << "pad_width should be multiple of 2, get " << node();
+    for (size_t i = 0; i < attr_pad_width.size(); i += 2) {
+      const String& cur_pad = "[" + std::to_string(attr_pad_width[i]) + ", " +
+                              std::to_string(attr_pad_width[i + 1]) + "]";
+      pad_width.push_back(cur_pad);
+    }
+    const auto& val_producer = node()->ProducerOf(1);
+    ICHECK(val_producer->optype == "constant" && val_producer->HasAttr("scalar"));
+    stack_.op_start()
+        .op_input_arg()
+        .call_list_arg(pad_width, "paddings")
+        .call_str_arg(mode, "mode")
+        .call_arg(val_producer->GetTypeAttr<float>("scalar"), "constant_values")
+        .op_name_arg()
+        .op_end();
+  }
+};
+
+class TFV1Pool2dCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1Pool2dCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    String pooling_type;
+    if (node()->optype == "nn.avg_pool2d") {
+      pooling_type = "AVG";
+    } else if (node()->optype == "nn.max_pool2d") {
+      pooling_type = "MAX";
+    } else {
+      LOG_FATAL << "Unexpected pool2d node " << node();
+    }
+    const auto& pair = GetPadding("strides", "pool_size");
+    stack_.op_start()
+        .op_input_arg()
+        .op_list_arg<int>("pool_size", "window_shape")
+        .call_str_arg(pooling_type, "pooling_type")
+        .op_list_arg<int>("dilation", "dilation_rate")
+        .op_list_arg<int>("strides");
+    if (pair.first.size() > 0) {
+      stack_.call_str_arg(pair.first, "padding");
+    } else if (pair.second.size() > 0) {
+      stack_.call_list_arg(pair.second, "padding");
+    } else {
+      LOG_FATAL << "Can not parse padding for " << node();
+    }
+    stack_.op_name_arg().op_end();
+  }
+};
+
+class TFV1PermuteDimsCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1PermuteDimsCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    std::vector<int> axes;
+    if (!node()->GetAttr("axes", &axes)) {
+      for (size_t i = node()->InputAt(0)->Ndim(); i > 0; i--) {
+        axes.push_back(i - 1);
+      }
+    }
+    stack_.op_start().op_input_arg().call_list_arg(axes).op_name_arg().op_end();
+  }
+};
+
+class TFV1ReduceAxisCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1ReduceAxisCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .op_input_arg()
+        .op_list_arg<int>("axis")
+        .op_arg<bool>("keepdims")
+        .op_name_arg()
+        .op_end();
+  }
+};
+
+class TFV1ReshapeCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1ReshapeCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg().op_list_arg<int>("shape").op_name_arg().op_end();
+  }
+};
+
+class TFV1Resize2dCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1Resize2dCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    String func_name;
+    const auto& method = node()->GetTypeAttr<std::string>("method");
+    const auto& coordinate_transformation_mode =
+        node()->GetTypeAttr<std::string>("coordinate_transformation_mode");
+    bool align_corners = coordinate_transformation_mode == "align_corners";
+    if (method == "linear") {
+      func_name = "tf_v1.image.resize_bilinear";
+    } else if (method == "nearest_neighbor") {
+      func_name = "tf_v1.image.resize_nearest_neighbor";
+    } else {
+      LOG_FATAL << "Unexpected resize with method " << node();
+    }
+    stack_.op_start(func_name)
+        .op_input_arg()
+        .op_list_arg<int>("size")
+        .call_arg(align_corners, "align_corners")
+        .op_name_arg()
+        .op_end();
+  }
+};
+
+class TFV1SimpleCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1SimpleCodeGen)
+
+ protected:
+  void CodeGenBuild() final { stack_.op_start().op_inputs_arg(false).op_name_arg().op_end(); }
+};
+
+class TFV1SplitCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1SplitCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_input_arg();
+    std::vector<int64_t> indices;
+    int axis = node()->GetTypeAttr<int>("axis");
+    for (size_t i = 0; i < node()->outputs.size(); i++) {
+      indices.push_back(node()->OutputAt(i)->DimAt(axis)->value);
+    }
+    stack_.call_list_arg(indices, "num_or_size_splits").op_arg<int>("axis").op_name_arg().op_end();
+  }
+};
+
+class TFV1StridedSliceCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1StridedSliceCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    std::vector<int> axes;
+    if (!node()->GetAttr("axes", &axes)) {
+      for (size_t i = 0; i < node()->InputAt(0)->Ndim(); i++) {
+        axes.push_back(i);
+      }
+    }
+    stack_.op_start()
+        .op_input_arg()
+        .op_list_arg<int>("begin")
+        .op_list_arg<int>("end")
+        .op_list_arg<int>("strides")
+        .op_name_arg()
+        .op_end();
+  }
+};
+
+class TFV1TakeCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1TakeCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start().op_inputs_arg(false).op_arg<int>("axis").op_name_arg().op_end();
+  }
+};
+
+class TFV1TileCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1TileCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_start()
+        .op_input_arg()
+        .op_list_arg<int>("repeats", "multiples")
+        .op_name_arg()
+        .op_end();
+  }
+};
+
+class TFV1TupleCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1TupleCodeGen)
+
+ protected:
+  void CodeGenBuild() final { stack_.op_start().op_inputs_arg().op_end(); }
+};
+
+const std::shared_ptr<std::unordered_map<String, std::shared_ptr<TFV1OpCode>>> GetTFV1OpCodes() {
+  static auto map = std::make_shared<std::unordered_map<String, std::shared_ptr<TFV1OpCode>>>();
+  if (!map->empty()) return map;
+  // binary && unary ops
+  map->emplace("abs", std::make_shared<TFV1SimpleCodeGen>("tf_v1.abs"));
+  map->emplace("acos", std::make_shared<TFV1SimpleCodeGen>("tf_v1.acos"));
+  map->emplace("acosh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.acosh"));
+  map->emplace("add", std::make_shared<TFV1SimpleCodeGen>("tf_v1.add"));
+  map->emplace("asin", std::make_shared<TFV1SimpleCodeGen>("tf_v1.asin"));
+  map->emplace("asinh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.asinh"));
+  map->emplace("atanh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.atanh"));
+  map->emplace("atan", std::make_shared<TFV1SimpleCodeGen>("tf_v1.atan"));
+  map->emplace("ceil", std::make_shared<TFV1SimpleCodeGen>("tf_v1.ceil"));
+  map->emplace("cos", std::make_shared<TFV1SimpleCodeGen>("tf_v1.cos"));
+  map->emplace("cosh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.cosh"));
+  map->emplace("divide", std::make_shared<TFV1SimpleCodeGen>("tf_v1.divide"));
+  map->emplace("equal", std::make_shared<TFV1SimpleCodeGen>("tf_v1.equal"));
+  map->emplace("erf", std::make_shared<TFV1SimpleCodeGen>("tf_v1.erf"));
+  map->emplace("exp", std::make_shared<TFV1SimpleCodeGen>("tf_v1.exp"));
+  map->emplace("floor", std::make_shared<TFV1SimpleCodeGen>("tf_v1.floor"));
+  map->emplace("floor_divide", std::make_shared<TFV1SimpleCodeGen>("tf_v1.floor_div"));
+  map->emplace("floor_mod", std::make_shared<TFV1SimpleCodeGen>("tf_v1.floormod"));
+  map->emplace("greater", std::make_shared<TFV1SimpleCodeGen>("tf_v1.greater"));
+  map->emplace("greater_equal", std::make_shared<TFV1SimpleCodeGen>("tf_v1.greater_equal"));
+  map->emplace("isfinite", std::make_shared<TFV1SimpleCodeGen>("tf_v1.is_finite"));
+  map->emplace("isinf", std::make_shared<TFV1SimpleCodeGen>("tf_v1.is_inf"));
+  map->emplace("isnan", std::make_shared<TFV1SimpleCodeGen>("tf_v1.is_nan"));
+  map->emplace("less", std::make_shared<TFV1SimpleCodeGen>("tf_v1.less"));
+  map->emplace("less_equal", std::make_shared<TFV1SimpleCodeGen>("tf_v1.less_equal"));
+  map->emplace("log", std::make_shared<TFV1SimpleCodeGen>("tf_v1.log"));
+  map->emplace("log1p", std::make_shared<TFV1SimpleCodeGen>("tf_v1.log1p"));
+  map->emplace("logical_and", std::make_shared<TFV1SimpleCodeGen>("tf_v1.logical_and"));
+  map->emplace("logical_or", std::make_shared<TFV1SimpleCodeGen>("tf_v1.logical_or"));
+  map->emplace("logical_xor", std::make_shared<TFV1SimpleCodeGen>("tf_v1.logical_xor"));
+  map->emplace("logical_not", std::make_shared<TFV1SimpleCodeGen>("tf_v1.logical_not"));
+  map->emplace("maximum", std::make_shared<TFV1SimpleCodeGen>("tf_v1.maximum"));
+  map->emplace("minimum", std::make_shared<TFV1SimpleCodeGen>("tf_v1.minimum"));
+  map->emplace("multiply", std::make_shared<TFV1SimpleCodeGen>("tf_v1.multiply"));
+  map->emplace("negative", std::make_shared<TFV1SimpleCodeGen>("tf_v1.negative"));
+  map->emplace("not_equal", std::make_shared<TFV1SimpleCodeGen>("tf_v1.not_equal"));
+  map->emplace("power", std::make_shared<TFV1SimpleCodeGen>("tf_v1.pow"));
+  map->emplace("round", std::make_shared<TFV1SimpleCodeGen>("tf_v1.round"));
+  map->emplace("rsqrt", std::make_shared<TFV1SimpleCodeGen>("tf_v1.rsqrt"));
+  map->emplace("sigmoid", std::make_shared<TFV1SimpleCodeGen>("ops.math_ops.sigmoid"));
+  map->emplace("sign", std::make_shared<TFV1SimpleCodeGen>("tf_v1.sign"));
+  map->emplace("sin", std::make_shared<TFV1SimpleCodeGen>("tf_v1.sin"));
+  map->emplace("sinh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.sinh"));
+  map->emplace("sqrt", std::make_shared<TFV1SimpleCodeGen>("tf_v1.sqrt"));
+  map->emplace("subtract", std::make_shared<TFV1SimpleCodeGen>("tf_v1.subtract"));
+  map->emplace("tan", std::make_shared<TFV1SimpleCodeGen>("tf_v1.tan"));
+  map->emplace("tanh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.tanh"));
+  map->emplace("where", std::make_shared<TFV1SimpleCodeGen>("tf_v1.where"));
+
+  // reduce axis ops
+  map->emplace("max", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_max"));
+  map->emplace("min", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_min"));
+  map->emplace("mean", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_mean"));
+  map->emplace("sum", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_sum"));
+  map->emplace("prod", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_prod"));
+  map->emplace("std", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_std"));
+
+  // create ops
+  map->emplace("constant", std::make_shared<TFV1ConstantCodeGen>("get_variable"));
+  map->emplace("full", std::make_shared<TFV1FullCodeGen>("tf_v1.fill"));
+  map->emplace("zeros_like", std::make_shared<TFV1CreateLikeCodeGen>("tf_v1.zeros_like"));
+
+  // axis && axes ops
+  map->emplace("expand_dims", std::make_shared<TFV1AxesCodeGen>("tf_v1.expand_dims", "axis"));
+  map->emplace("nn.log_softmax", std::make_shared<TFV1AxisCodeGen>("tf_v1.nn.log_softmax", "axis"));
+  map->emplace("nn.softmax", std::make_shared<TFV1AxisCodeGen>("tf_v1.nn.softmax", "axis"));
+  map->emplace("squeeze", std::make_shared<TFV1AxesCodeGen>("ops.array_ops.squeeze", "axis"));
+
+  // math ops
+  map->emplace("argmax", std::make_shared<TFV1ArgMaxMinCodeGen>("tf_v1.argmax"));
+  map->emplace("argmin", std::make_shared<TFV1ArgMaxMinCodeGen>("tf_v1.argmin"));
+  map->emplace("astype", std::make_shared<TFV1AstypeCodeGen>("tf_v1.cast"));
+  map->emplace("broadcast_to", std::make_shared<TFV1BroadcastToCodeGen>("tf_v1.broadcast_to"));
+  map->emplace("concat", std::make_shared<TFV1ConcatCodeGen>("ops.array_ops.concat_v2"));
+  map->emplace("concatenate", std::make_shared<TFV1ConcatCodeGen>("ops.array_ops.concat_v2"));
+  map->emplace("einsum", std::make_shared<TFV1EinsumCodeGen>("tf_v1.einsum"));
+  map->emplace("matmul", std::make_shared<TFV1SimpleCodeGen>("tf_v1.matmul"));
+  map->emplace("permute_dims", std::make_shared<TFV1PermuteDimsCodeGen>("tf_v1.transpose"));
+  map->emplace("reshape", std::make_shared<TFV1ReshapeCodeGen>("ops.array_ops.reshape"));
+  map->emplace("split", std::make_shared<TFV1SplitCodeGen>("tf_v1.split"));
+  map->emplace("strided_slice", std::make_shared<TFV1StridedSliceCodeGen>("tf_v1.strided_slice"));
+  map->emplace("take", std::make_shared<TFV1TakeCodeGen>("tf_v1.gather"));
+  map->emplace("tile", std::make_shared<TFV1TileCodeGen>("tf_v1.tile"));
+
+  // nn ops
+  map->emplace("nn.avg_pool2d", std::make_shared<TFV1Pool2dCodeGen>("ops.nn_ops.pool"));
+  map->emplace("nn.conv2d", std::make_shared<TFV1ConvCodeGen>("ops.nn_ops.conv2d", false));
+  map->emplace("nn.max_pool2d", std::make_shared<TFV1Pool2dCodeGen>("ops.nn_ops.pool"));
+  map->emplace("nn.pad", std::make_shared<TFV1PadCodeGen>("tf_v1.pad"));
+  map->emplace("nn.relu", std::make_shared<TFV1SimpleCodeGen>("tf_v1.nn.relu"));
+
+  // image ops
+  map->emplace("image.resize2d",
+               std::make_shared<TFV1Resize2dCodeGen>("tf_v1.image.resize_nearest_neighbor"));
+
+  // special op
+  map->emplace("get_item", std::make_shared<TFV1GetItemCodeGen>(""));
+  map->emplace("tuple", std::make_shared<TFV1TupleCodeGen>("tuple"));
+
+  // msc ops
+  map->emplace("msc.conv2d", std::make_shared<TFV1ConvCodeGen>("ops.nn_ops.conv2d", true));
+
+  return map;
+}
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/msc/framework/tensorflow/tf_v1_opcode.h
+++ b/src/contrib/msc/framework/tensorflow/tf_v1_opcode.h
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/tf_v1_opcode.h
+ * \brief Tensorflow codegen for MSCJoint, use v1 format.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_TF_V1_OPCODE_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_TF_V1_OPCODE_H_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "../../core/codegen/base_codegen.h"
+#include "config.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+class TFV1OpCode;
+typedef OpCodeStack<TFV1OpCode> TFV1OpCodeStack;
+
+/*!
+ * \brief CodeGen for tensorflow op
+ */
+class TFV1OpCode : public BaseOpCode<TensorflowCodeGenConfig> {
+ public:
+  /*!
+   * \brief The constructor of BaseOpDocsifier
+   * \param func_name the function name for the node.
+   * \param config the config json for the node.
+   */
+  explicit TFV1OpCode(const String& func_name) : BaseOpCode<TensorflowCodeGenConfig>(func_name) {}
+
+  /*! \brief Convert node to docs*/
+  const Array<Doc> GetDocs() final;
+
+  /*! \brief Get dtype string*/
+  const String DType(const DataType& dtype) final {
+    return "tf_v1." + BaseOpCode<TensorflowCodeGenConfig>::DType(dtype);
+  }
+
+ protected:
+  TFV1OpCodeStack stack_;
+
+  /*! \brief Convert op build*/
+  virtual void CodeGenBuild() = 0;
+
+  /*! \brief Get padding mode or array*/
+  const std::pair<String, Array<String>> GetPadding(const String& strides_key,
+                                                    const String& kernel_key = "",
+                                                    const String& padding_key = "padding");
+};
+
+/*!
+ * \brief Get the map of available TFV1OpCode, use optype as key
+ * \return Map of <string, TFV1OpCode>
+ */
+const std::shared_ptr<std::unordered_map<String, std::shared_ptr<TFV1OpCode>>> GetTFV1OpCodes();
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_TF_V1_OPCODE_H_

--- a/src/contrib/msc/framework/tvm/codegen.cc
+++ b/src/contrib/msc/framework/tvm/codegen.cc
@@ -146,6 +146,10 @@ void RelaxCodeGen::CodeGenInference() {
       .call_start("tvm.target.Target")
       .call_str_arg(target)
       .call_end("target")
+      .call_start("tvm.relax.transform.LegalizeOps()")
+      .call_arg("mod")
+      .call_end("mod")
+      .scope_start("tvm.transform.PassContext(opt_level=3)")
       .call_start("relax.build")
       .call_arg("mod")
       .call_arg("target")
@@ -154,6 +158,7 @@ void RelaxCodeGen::CodeGenInference() {
       .call_arg("ex")
       .call_arg(device)
       .call_end("vm")
+      .scope_end()
       .call_start("vm[\"main\"]");
   for (const auto& i : graph()->GetInputs()) {
     stack_.call_arg("inputs[\"" + i->alias + "\"]");

--- a/tests/python/contrib/test_msc/test_translate_relay.py
+++ b/tests/python/contrib/test_msc/test_translate_relay.py
@@ -158,9 +158,9 @@ def test_linear():
             return torch.matmul(x, y)
 
     input_info = [([1, 3, 10, 10], "float32")]
-    verify_model(Dense1(), input_info)
-    verify_model(Dense2(), input_info)
-    verify_model(MatMul1(), [([10, 10], "float32"), ([10, 10], "float32")])
+    verify_model(Dense1(), input_info, build_target="llvm")
+    verify_model(Dense2(), input_info, build_target="llvm")
+    verify_model(MatMul1(), [([10, 10], "float32"), ([10, 10], "float32")], build_target="llvm")
 
 
 def test_bmm():

--- a/tests/python/contrib/test_msc/test_translate_tensorflow.py
+++ b/tests/python/contrib/test_msc/test_translate_tensorflow.py
@@ -1,0 +1,1775 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=deprecated-module
+
+""" Test translate from tensorflow. """
+
+from distutils.version import LooseVersion
+
+from packaging import version as package_version
+import numpy as np
+
+from tensorflow.python.framework import constant_op
+from tensorflow.python.ops import nn_ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import variables
+
+
+try:
+    import tensorflow.compat.v1 as tf
+
+    tf.disable_v2_behavior()
+except ImportError:
+    import tensorflow as tf
+
+import tvm
+import tvm.testing
+import tvm.relay.testing.tf as tf_testing
+from tvm.contrib.msc.framework.tensorflow.frontend import translate
+from tvm.contrib.msc.framework.tensorflow import codegen
+
+
+def convert_to_list(x):
+    if not isinstance(x, list):
+        x = [x]
+    return x
+
+
+def run_tf_graph(sess, input_data, input_node, output_node):
+    """Generic function to execute tensorflow"""
+
+    input_data = convert_to_list(input_data)
+    input_node = convert_to_list(input_node)
+    output_node = convert_to_list(output_node)
+
+    tensor = [sess.graph.get_tensor_by_name(output_name) for output_name in output_node]
+
+    input_dict = {e: input_data[i] for i, e in enumerate(input_node)}
+    if len(input_node) == 1 and input_node[0] == "":
+        output_data = sess.run(tensor)
+    else:
+        output_data = sess.run(tensor, input_dict)
+    return output_data
+
+
+def get_graph_def(in_data, in_name, out_name):
+    """Get tf.GraphDef for translate"""
+
+    def name_without_num(name):
+        return name.split(":")[0] if ":" in name else name
+
+    out_name = convert_to_list(out_name)
+    out_node = [name_without_num(name) for name in out_name]
+    in_data = convert_to_list(in_data)
+    in_name = convert_to_list(in_name)
+
+    with tf.Session() as sess:
+        sess.run(variables.global_variables_initializer())
+        final_graph_def = tf_testing.AddShapesToGraphDef(sess, out_node)
+        golden = run_tf_graph(sess, in_data, in_name, out_name)
+    return final_graph_def, golden
+
+
+def verify_model(graph_def, golden, in_data, in_name, out_name, use_out_name=True):
+    """Generic function to generate and compare tensorflow and MSC-TFV1 output"""
+
+    out_name = convert_to_list(out_name)
+    in_data = convert_to_list(in_data)
+    in_name = convert_to_list(in_name)
+    shape_dict = {i: d.shape for i, d in zip(in_name, in_data)}
+    graph, weights = translate.from_tensorflow(graph_def, shape_dict, out_name)
+    with tf.Graph().as_default():
+        outputs = codegen.to_tensorflow(graph, weights)
+        with tf.Session() as sess:
+            sess.run(variables.global_variables_initializer())
+            if not use_out_name:
+                out_name = [o.name for o in convert_to_list(outputs)]
+            result = run_tf_graph(sess, in_data, in_name, out_name)
+
+    golden = convert_to_list(golden)
+    result = convert_to_list(result)
+    assert len(golden) == len(result), "golden {} mismatch with result {}".format(
+        len(golden), len(result)
+    )
+    for gol_r, new_r in zip(golden, result):
+        if isinstance(gol_r, np.ndarray):
+            tvm.testing.assert_allclose(gol_r, new_r, atol=1e-5, rtol=1e-5)
+        else:
+            assert gol_r == new_r
+
+
+def _test_pooling(input_shape, **kwargs):
+    """One iteration of pool operation with given shapes and attributes"""
+
+    x = -np.arange(np.prod(input_shape), dtype=np.float32).reshape(input_shape) - 1
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=input_shape, dtype="float32")
+        nn_ops.pool(in_data, **kwargs)
+        out_name = "max_pool:0" if kwargs["pooling_type"] == "MAX" else "avg_pool:0"
+        io_info = {"in_data": x, "in_name": "Placeholder:0", "out_name": out_name}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_pooling():
+    """test tensorflow translator for pooling"""
+
+    for pool_type in ["AVG", "MAX"]:
+        _test_pooling(
+            input_shape=[2, 9, 10, 2],
+            window_shape=[2, 1],
+            padding="SAME",
+            pooling_type=pool_type,
+            dilation_rate=[1, 1],
+            strides=[1, 1],
+        )
+
+        _test_pooling(
+            input_shape=[2, 9, 10, 2],
+            window_shape=[2, 1],
+            padding="VALID",
+            pooling_type=pool_type,
+            dilation_rate=[1, 1],
+            strides=[1, 1],
+        )
+
+        _test_pooling(
+            input_shape=[1, 2, 1],
+            window_shape=[1],
+            padding="VALID",
+            pooling_type=pool_type,
+            dilation_rate=[1],
+        )
+
+    # Explicit padding
+    if package_version.parse(tf.VERSION) >= package_version.parse("2.4.1"):
+        _test_pooling(
+            input_shape=[2, 9, 10, 2],
+            window_shape=[4, 4],
+            padding=[[0, 0], [0, 1], [2, 3], [0, 0]],
+            pooling_type="MAX",
+            dilation_rate=[1, 1],
+            strides=[1, 1],
+        )
+
+
+def _test_convolution(
+    opname,
+    tensor_in_sizes,
+    filter_in_sizes,
+    dilations,
+    strides,
+    padding,
+    data_format,
+):
+    """One iteration of convolution with given shapes and attributes"""
+    total_size_1 = np.prod(tensor_in_sizes)
+    total_size_2 = np.prod(filter_in_sizes)
+    # Initializes the input tensor with array containing incrementing
+    # numbers from 1.
+    data_array = [f * 1.0 for f in range(1, total_size_1 + 1)]
+    filter_array = [f * 1.0 for f in range(1, total_size_2 + 1)]
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=tensor_in_sizes, dtype="float32")
+        in_filter = constant_op.constant(filter_array, shape=filter_in_sizes, dtype="float32")
+        if data_format == "NHWC":
+            strides = [1] + strides + [1]
+            dilations = [1] + dilations + [1]
+        else:
+            strides = [1, 1] + strides
+            dilations = [1, 1] + dilations
+
+        if opname == "conv":
+            nn_ops.conv2d(
+                in_data,
+                in_filter,
+                strides=strides,
+                dilations=dilations,
+                padding=padding,
+                data_format=data_format,
+            )
+            io_info = {
+                "in_data": np.reshape(data_array, tensor_in_sizes).astype("float32"),
+                "in_name": "Placeholder:0",
+                "out_name": "Conv2D:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        else:
+            nn_ops.depthwise_conv2d_native(
+                in_data,
+                in_filter,
+                strides=strides,
+                dilations=dilations,
+                padding=padding,
+                data_format=data_format,
+            )
+            io_info = {
+                "in_data": np.reshape(data_array, tensor_in_sizes).astype("float32"),
+                "in_name": "Placeholder:0",
+                "out_name": "DepthwiseConv2dNative:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+
+def test_convolution():
+    """test tensorflow translator for convolution"""
+
+    _test_convolution("conv", [4, 8, 8, 176], [1, 1, 176, 32], [1, 1], [1, 1], "SAME", "NHWC")
+    _test_convolution("conv", [4, 17, 17, 19], [3, 3, 19, 19], [1, 1], [2, 2], "VALID", "NHWC")
+    _test_convolution("depthwise", [4, 8, 8, 176], [1, 1, 176, 1], [1, 1], [1, 1], "SAME", "NHWC")
+    _test_convolution("depthwise", [4, 17, 17, 19], [3, 3, 19, 1], [1, 1], [2, 2], "VALID", "NHWC")
+
+    # Explicit padding
+    if package_version.parse(tf.VERSION) >= package_version.parse("2.4.1"):
+        _test_convolution(
+            "conv",
+            [4, 8, 8, 16],
+            [1, 1, 16, 32],
+            [1, 1],
+            [1, 1],
+            [[0, 0], [2, 3], [0, 1], [0, 0]],
+            "NHWC",
+        )
+        _test_convolution(
+            "depthwise",
+            [4, 8, 8, 16],
+            [1, 1, 16, 1],
+            [1, 1],
+            [1, 1],
+            [[0, 0], [2, 3], [0, 1], [0, 0]],
+            "NHWC",
+        )
+
+
+def _test_biasadd(tensor_in_sizes, data_format):
+    """One iteration of biasadd with given shapes and attributes"""
+
+    total_size_1 = 1
+    for s in tensor_in_sizes:
+        total_size_1 *= s
+    tensor_bias_sizes = [tensor_in_sizes[1]] if data_format == "NCHW" else [tensor_in_sizes[3]]
+    total_size_2 = tensor_bias_sizes[0]
+    # Initializes the input tensor with array containing incrementing
+    # numbers from 1.
+    data_array = [f * 1.0 for f in range(1, total_size_1 + 1)]
+    bias_array = [f * 1.0 for f in range(1, total_size_2 + 1)]
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=tensor_in_sizes, dtype="float32")
+        in_bias = constant_op.constant(bias_array, shape=tensor_bias_sizes, dtype="float32")
+        nn_ops.bias_add(in_data, in_bias, data_format=data_format)
+        io_info = {
+            "in_data": np.reshape(data_array, tensor_in_sizes).astype("float32"),
+            "in_name": "Placeholder:0",
+            "out_name": "BiasAdd:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_biasadd():
+    """test tensorflow translator for bias_add"""
+
+    _test_biasadd([4, 8, 8, 176], "NHWC")
+
+
+def _test_where_with_broadcast(in_shape, cond_shape):
+    choice_list = list(np.arange(10).astype("float32"))
+    t_1 = np.random.choice(choice_list, size=cond_shape)
+    t_2 = np.random.choice(choice_list, size=cond_shape)
+    x = np.random.choice(choice_list, size=in_shape)
+    y = np.random.choice(choice_list, size=in_shape)
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=cond_shape, dtype="float32", name="in1")
+        in2 = tf.placeholder(shape=cond_shape, dtype="float32", name="in2")
+        condition = math_ops.less(in1, in2, name="less")
+        lhs = tf.placeholder(shape=in_shape, dtype="float32", name="x")
+        rhs = tf.placeholder(shape=in_shape, dtype="float32", name="y")
+        out = tf.where(condition, lhs, rhs)
+        io_info = {
+            "in_data": [t_1, t_2, x, y],
+            "in_name": ["in1:0", "in2:0", "x:0", "y:0"],
+            "out_name": out.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_where_with_broadcast():
+    """test tensorflow translator for where"""
+
+    _test_where_with_broadcast((5, 2), (5,))
+    _test_where_with_broadcast((3, 2, 5), (3,))
+
+
+def _test_reshape(data, out_shape):
+    """One iteration of reshape operation with given data and out shape"""
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        array_ops.reshape(in_data, out_shape)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "Reshape:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_reshape_with_call():
+    """relay.expr.Call as shape"""
+    data = np.zeros((6, 4, 2))
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        out_shape = tf.constant([1, 2, 3], dtype="int32")
+        out_shape = tf.multiply(out_shape, 2)
+        array_ops.reshape(in_data, out_shape)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "Reshape:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_reshape_like(data, shape_like):
+    """A special case for reshape."""
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        in_shape_like = array_ops.placeholder(shape=shape_like.shape, dtype=data.dtype)
+        out_shape = array_ops.shape(in_shape_like)
+        array_ops.reshape(in_data, out_shape)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "Reshape:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_reshape():
+    """test tensorflow translator for reshape"""
+
+    _test_reshape(np.arange(6.0), [2, 3])
+    _test_reshape(np.arange(6), [-1, 2])
+    _test_reshape_with_call()
+    _test_reshape_like(np.zeros((3, 6)), np.zeros((9, 2)))
+
+
+def _test_squeeze(data, squeeze_dims=None):
+    """One iteration of squeeze"""
+
+    if squeeze_dims is None:
+        squeeze_dims = []
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+
+        if squeeze_dims:
+            array_ops.squeeze(in_data, squeeze_dims)
+        else:
+            array_ops.squeeze(in_data)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "Squeeze:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_squeeze():
+    """test tensorflow translator for squeeze"""
+
+    _test_squeeze(np.arange(4).reshape((2, 1, 2)))
+    _test_squeeze(np.arange(6).reshape((1, 2, 1, 3, 1)))
+    _test_squeeze(np.arange(6).reshape((1, 2, 1, 3, 1)), [2, 4])
+    _test_squeeze(np.arange(6).reshape((1, 2, 1, 3, 1)), [-3, -5])
+
+
+def _test_concat_v2(shape1, shape2, dim):
+    """One iteration of ConcatV2"""
+
+    with tf.Graph().as_default():
+        dtype = "float32"
+        in1 = tf.placeholder(shape=shape1, dtype=dtype, name="in1")
+        in2 = tf.placeholder(shape=shape2, dtype=dtype, name="in2")
+        array_ops.concat_v2([in1, in2], dim)
+
+        np_data1 = np.random.uniform(size=shape1).astype(dtype)
+        np_data2 = np.random.uniform(size=shape2).astype(dtype)
+        io_info = {
+            "in_data": [np_data1, np_data2],
+            "in_name": ["in1:0", "in2:0"],
+            "out_name": "ConcatV2:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_concat_v2():
+    """test tensorflow translator for concat"""
+
+    if tf.__version__ < LooseVersion("1.4.1"):
+        return
+
+    _test_concat_v2([10, 3, 5], [2, 3, 5], 0)
+    _test_concat_v2([2, 8, 5], [2, 8, 6], -1)
+
+
+def _test_sigmoid(data):
+    """One iteration of sigmoid"""
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        _ = math_ops.sigmoid(in_data)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "Sigmoid:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_sigmoid():
+    """test tensorflow translator for concat"""
+
+    _test_sigmoid(np.random.uniform(size=(3, 4, 4, 3)).astype("float32"))
+
+
+def _test_argx(func, data, **kwargs):
+
+    with tf.Graph().as_default():
+        inp = array_ops.placeholder(shape=data.shape, dtype=data.dtype, name="c0")
+        func(inp, name="argx", **kwargs)
+        io_info = {"in_data": data, "in_name": "c0:0", "out_name": "argx:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_argx():
+    """test tensorflow translator for argmax/argmin"""
+
+    data = np.random.uniform(size=(8, 4, 9)).astype("float32")
+    for output_type in [tf.int64, tf.int32]:
+        _test_argx(tf.argmax, data=data, axis=1, output_type=output_type)
+        _test_argx(tf.argmin, data=data, axis=1, output_type=output_type)
+
+
+def _test_matmul(i, j, k, transpose_a=False, transpose_b=False):
+    """One iteration of matmul"""
+
+    a_shape_init = [i, j]
+    b_shape_init = [j, k]
+    a_shape = [] + (a_shape_init[::-1] if transpose_a else a_shape_init)
+    b_shape = [] + (b_shape_init[::-1] if transpose_b else b_shape_init)
+
+    with tf.Graph().as_default():
+        a_in = tf.placeholder(shape=a_shape, dtype="float32", name="A")
+        b_in = tf.placeholder(shape=b_shape, dtype="float32", name="B")
+        result = tf.matmul(a_in, b_in, transpose_a=transpose_a, transpose_b=transpose_b)
+
+        a_np = np.random.uniform(high=5.0, size=a_shape).astype("float32")
+        b_np = np.random.uniform(high=5.0, size=b_shape).astype("float32")
+        io_info = {
+            "in_data": [a_np, b_np],
+            "in_name": [a_in.name, b_in.name],
+            "out_name": result.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info, use_out_name=False)
+
+
+def test_matmul():
+    """test tensorflow translator for matmul"""
+
+    _test_matmul(1, 3, 6)
+    _test_matmul(1, 3, 6, True, True)
+    _test_matmul(1, 3, 6, True, False)
+    _test_matmul(1, 3, 6, False, True)
+
+
+def _test_batch_matmul(a_shape, b_shape, adjoint_a=False, adjoint_b=False):
+
+    with tf.Graph().as_default():
+        a_in = tf.placeholder(shape=a_shape, dtype="float32", name="A")
+        b_in = tf.placeholder(shape=b_shape, dtype="float32", name="B")
+        result = tf.matmul(a_in, b_in, adjoint_a=adjoint_a, adjoint_b=adjoint_b, name="batchmatmul")
+
+        a_np = np.random.uniform(high=5.0, size=a_shape).astype("float32")
+        b_np = np.random.uniform(high=5.0, size=b_shape).astype("float32")
+        io_info = {
+            "in_data": [a_np, b_np],
+            "in_name": [a_in.name, b_in.name],
+            "out_name": result.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_batch_matmul():
+    """test tensorflow translator for batch_matmul"""
+
+    _test_batch_matmul((3, 5, 4), (3, 4, 5))
+    _test_batch_matmul((3, 5, 4), (3, 4, 5), True, True)
+    _test_batch_matmul((3, 5, 4), (3, 5, 4), True, False)
+    _test_batch_matmul((3, 5, 4), (3, 5, 4), False, True)
+
+
+def _test_stridedslice(
+    ip_shape,
+    begin,
+    end,
+    stride,
+    begin_mask=0,
+    end_mask=0,
+    new_axis_mask=0,
+    shrink_axis_mask=0,
+    ellipsis_mask=0,
+):
+    """One iteration of a Stridedslice"""
+
+    tf.reset_default_graph()
+    np_data = np.random.uniform(size=ip_shape).astype("float32")
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", ip_shape, name="in_data")
+        tf.strided_slice(
+            in_data,
+            begin,
+            end,
+            stride,
+            begin_mask=begin_mask,
+            end_mask=end_mask,
+            new_axis_mask=new_axis_mask,
+            shrink_axis_mask=shrink_axis_mask,
+            ellipsis_mask=ellipsis_mask,
+            name="strided_slice",
+        )
+        io_info = {"in_data": np_data, "in_name": "in_data:0", "out_name": "strided_slice:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_stridedslice():
+    """test tensorflow translator for stridedslice"""
+
+    _test_stridedslice([2, 3, 4], [0], [1], [1], shrink_axis_mask=8)
+    _test_stridedslice([3, 4, 3], [1, -1, 0], [4, -5, 3], [2, -1, 1])
+    _test_stridedslice([3, 4, 3], [1, 0], [4, 3], [2, 1], ellipsis_mask=8)
+    _test_stridedslice([3, 4, 3], [1, 1, 0], [4, 4, 2], [2, 1, 1], new_axis_mask=5)
+    _test_stridedslice(
+        [3, 4, 5, 4, 5, 6],
+        [0, 0, 1, 2, 1],
+        [2, 3, 4, 5, 3],
+        [1, 1, 2, 2, 1],
+        shrink_axis_mask=5,
+        new_axis_mask=1,
+        ellipsis_mask=2,
+        begin_mask=8,
+        end_mask=8,
+    )
+
+
+def _test_divide(ip_shape, dtype):
+    np_numer = np.random.uniform(-100, 100, size=ip_shape).astype(dtype)
+    np_denomin = np.random.uniform(1, 100, size=ip_shape).astype(dtype)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        numerator = tf.placeholder(dtype, ip_shape, name="numer")
+        denominator = tf.placeholder(dtype, ip_shape, name="denomin")
+        tf.math.divide(numerator, denominator, name="RealDiv")
+        io_info = {
+            "in_data": [np_numer, np_denomin],
+            "in_name": ["numer:0", "denomin:0"],
+            "out_name": "RealDiv:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_floordiv(ip_shape, dtype):
+    np_numer = np.random.uniform(1, 100, size=ip_shape).astype(dtype)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        numerator = tf.placeholder(dtype, ip_shape, name="numer")
+        tf.math.floordiv(numerator, tf.constant(5, dtype=dtype), name="FloorDiv")
+        io_info = {"in_data": [np_numer], "in_name": ["numer:0"], "out_name": "FloorDiv:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_divide():
+    """test tensorflow translator for div"""
+
+    _test_divide((4, 3, 7), "float32")
+    _test_divide((4, 3, 7), "int32")
+    _test_floordiv((4, 3, 7), "float32")
+    _test_floordiv((4, 3, 7), "int32")
+
+
+def _test_gather(ip_shape, indice_shape, indice_value, axis, batch_dims):
+    """One iteration of a GatherV2"""
+
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", ip_shape, name="in_data")
+        indices = tf.placeholder("int32", indice_shape, name="indices")
+        out = tf.gather(in_data, indices, axis=axis, batch_dims=batch_dims)
+        np_data = np.random.uniform(1, 10, size=ip_shape).astype("float32")
+
+        def _fill_indices(indice_value):
+            indices = np.array(ip_shape, dtype="float32")
+            if isinstance(indice_value, int):
+                indices = np.array([indice_value], dtype="int32")
+            else:
+                indices = np.asarray(indice_value, dtype="int32")
+            return indices
+
+        np_indices = _fill_indices(indice_value)
+        io_info = {
+            "in_data": [np_data, np_indices],
+            "in_name": ["in_data:0", "indices:0"],
+            "out_name": out.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_gather():
+    """test tensorflow translator for gather"""
+
+    _test_gather((4,), (1,), 1, 0, 0)
+    _test_gather((2, 2), (1, 2, 2), [[[1, 0], [0, 1]]], 0, 0)
+    _test_gather((4, 3, 5, 6), (1, 4), [[2, 1, 0, 0]], 0, 0)
+
+
+def _test_split(in_shape, axis, num_or_size_splits):
+    """One iteration of a Split"""
+    np_data = np.random.uniform(-5, 5, size=in_shape).astype("float32")
+
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", in_shape, name="in_data")
+        _ = len(num_or_size_splits) if isinstance(num_or_size_splits, list) else num_or_size_splits
+        split = tf.split(in_data, num_or_size_splits, axis=axis)
+        relu = [tf.nn.relu(i) for i in split]
+        io_info = {
+            "in_data": [np_data],
+            "in_name": ["in_data:0"],
+            "out_name": [n.name for n in relu],
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+    # and now test together with concat
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", in_shape, name="in_data")
+        splitted = tf.split(in_data, num_or_size_splits, axis=axis)
+        concat = tf.concat(splitted, axis)
+        io_info = {
+            "in_data": [np_data],
+            "in_name": ["in_data:0"],
+            "out_name": concat.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_split():
+    """test tensorflow translator for split"""
+
+    _test_split((6, 1, 3, 5), 0, 3)
+    _test_split((6, 1, 3, 5), -4, 3)
+    _test_split((3, 6, 4), -2, [1, 4, 1])
+
+
+def _test_unstack(ip_shape, axis):
+    np_data = np.random.uniform(-5, 5, size=ip_shape).astype("float32")
+
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", ip_shape, name="in_data")
+        unstack = tf.unstack(in_data, axis=axis)
+        io_info = {
+            "in_data": np_data,
+            "in_name": "in_data:0",
+            "out_name": [n.name for n in unstack],
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info, use_out_name=False)
+
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", ip_shape, name="in_data")
+        tf.stack(tf.unstack(in_data, axis=axis), axis=axis)
+        io_info = {"in_data": np_data, "in_name": "in_data:0", "out_name": "stack:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_unstack():
+    """test tensorflow translator for unstack"""
+
+    _test_unstack((2, 6), 1)
+    _test_unstack((3, 6, 4), -2)
+
+
+def _test_tile(in_shape, multiples):
+    np_data = np.random.uniform(-5, 5, size=in_shape).astype("float32")
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", in_shape, name="in_data")
+        tf.tile(in_data, multiples=multiples, name="tile")
+        io_info = {"in_data": np_data, "in_name": "in_data:0", "out_name": "tile:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_tile():
+    """test tensorflow translator for tile"""
+
+    _test_tile((2, 2), (2, 3))
+
+
+def _test_clip_by_value(ip_shape, clip_value_min, clip_value_max):
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", ip_shape, name="in_data")
+        tf.clip_by_value(in_data, clip_value_min, clip_value_max, name="ClipByValue")
+        np_data = np.random.uniform(-100, 100, size=ip_shape).astype("float32")
+        io_info = {"in_data": np_data, "in_name": "in_data:0", "out_name": "ClipByValue:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_clip_by_value():
+    """test tensorflow translator for clip"""
+
+    _test_clip_by_value((4,), 0.1, 5.0)
+
+
+def test_multi_input():
+    """test tensorflow translator for multi input"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.int32, shape=[3, 3], name="in1")
+        in2 = tf.placeholder(tf.int32, shape=[3, 3], name="in2")
+        in3 = tf.placeholder(tf.int32, shape=[3, 3], name="in3")
+        in4 = tf.placeholder(tf.int32, shape=[3, 3], name="in4")
+
+        out1 = tf.add(in1, in2, name="out1")
+        out2 = tf.subtract(in3, in4, name="out2")
+        _ = tf.multiply(out1, out2, name="out")
+        in_data = np.arange(9, dtype="int32").reshape([3, 3])
+        io_info = {
+            "in_data": [in_data, in_data, in_data, in_data],
+            "in_name": ["in1:0", "in2:0", "in3:0", "in4:0"],
+            "out_name": "out:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_multi_output():
+    """test tensorflow translator for multi output"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.int32, shape=[3, 3], name="in1")
+        in2 = tf.placeholder(tf.int32, shape=[3, 3], name="in2")
+        in3 = tf.placeholder(tf.int32, shape=[3, 3], name="in3")
+        in4 = tf.placeholder(tf.int32, shape=[3, 3], name="in4")
+
+        _ = tf.add(in1, in2, name="out1")
+        _ = tf.subtract(in3, in4, name="out2")
+        in_data = np.arange(9, dtype="int32").reshape([3, 3])
+        io_info = {
+            "in_data": [in_data] * 4,
+            "in_name": ["in1:0", "in2:0", "in3:0", "in4:0"],
+            "out_name": ["out1:0", "out2:0"],
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_resize_bilinear(in_shape, to_shape, align_corners):
+    """One iteration of resize bilinear"""
+
+    data = np.random.uniform(size=in_shape).astype("float32")
+    shape_data = np.array(to_shape).astype("int32")
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        shape_data = constant_op.constant(
+            shape_data, shape=shape_data.shape, dtype=shape_data.dtype
+        )
+        tf.image.resize_bilinear(in_data, shape_data, align_corners=align_corners)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "ResizeBilinear:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_resize_nearest_neighbor(in_shape, to_shape):
+    """One iteration of resize nearest neighbor"""
+
+    data = np.random.uniform(size=in_shape).astype("float32")
+    shape_data = np.array(to_shape).astype("int32")
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        shape_data = constant_op.constant(
+            shape_data, shape=shape_data.shape, dtype=shape_data.dtype
+        )
+        tf.image.resize_nearest_neighbor(in_data, shape_data, name="resize_nearest_neighbor")
+        io_info = {
+            "in_data": data,
+            "in_name": "Placeholder:0",
+            "out_name": "resize_nearest_neighbor:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_resize():
+    """test tensorflow translator for resize"""
+
+    _test_resize_bilinear((4, 32, 32, 3), [50, 50], False)
+    _test_resize_bilinear((6, 32, 32, 3), [20, 20], True)
+    _test_resize_nearest_neighbor((6, 32, 32, 3), [20, 20])
+
+
+def _test_broadcast_to(in_shape, to_shape):
+    """One iteration of broadcast_to"""
+
+    data = np.random.uniform(size=in_shape).astype("float32")
+    shape_data = np.array(to_shape).astype("int32")
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        shape_data = constant_op.constant(
+            shape_data, shape=shape_data.shape, dtype=shape_data.dtype
+        )
+        tf.broadcast_to(in_data, shape_data)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "BroadcastTo:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_broadcast_to():
+    """test tensorflow translator for broadcast_to"""
+
+    _test_broadcast_to((4, 1, 32, 32), [4, 8, 32, 32])
+
+
+def _test_fill(in_shape):
+    """Use the fill op to create a tensor of ones with non-constant shape."""
+
+    with tf.Graph().as_default():
+        tf.ones(shape=in_shape, dtype="float32")
+        io_info = {"in_data": in_shape, "in_name": [], "out_name": "ones:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_fill():
+    """test tensorflow translator for fill"""
+
+    _test_fill((6, 32, 64, 64))
+
+
+def _test_pack(axis, shape, **kwargs):
+
+    a = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+    b = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+
+    with tf.Graph().as_default():
+        tf_a = array_ops.placeholder(shape=shape, dtype="float32", name="pl_a")
+        tf_b = array_ops.placeholder(shape=shape, dtype="float32", name="pl_b")
+        tf_c = tf.stack([tf_a, tf_b], axis=axis, **kwargs)
+        assert tf_c.op.op_def.name == "Pack", "tf.stack() is expected to produce 'Pack' operation"
+        io_info = {"in_data": [a, b], "in_name": ["pl_a:0", "pl_b:0"], "out_name": "stack:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_pack():
+    """test tensorflow translator for pack"""
+
+    _test_pack(3, [3, 2, 1])
+
+
+def _test_unpack(in_shape, axis):
+    """test operator Unpack"""
+    np_data = np.random.uniform(-100, 100, size=in_shape).astype("float32")
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", in_shape, name="in_data")
+        tf.unstack(in_data, axis=axis, name="Unpack")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "Unpack:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_unpack():
+    """test tensorflow translator for unpack"""
+
+    _test_unpack((21, 23, 3), 2)
+
+
+def _test_einsum(equation, *shape_of_input_tensors):
+    """Test Einsum Op"""
+
+    with tf.Graph().as_default():
+        inputs_placeholders = []
+        input_data = []
+        for idx, shape in enumerate(shape_of_input_tensors):
+            input_name = f"input_{idx}"
+            inputs_placeholders.append(
+                tf.placeholder(shape=shape, dtype="float32", name=input_name)
+            )
+            input_data.append(np.random.normal(size=shape).astype("float32"))
+
+        result = tf.einsum(equation, *inputs_placeholders)
+        io_info = {
+            "in_data": input_data,
+            "in_name": [ph.name for ph in inputs_placeholders],
+            "out_name": result.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info, use_out_name=False)
+
+
+def test_einsum():
+    """test tensorflow translator for einsum"""
+
+    _test_einsum("ij,jk->ik", [2, 3], [3, 5])  # Matmul
+    _test_einsum("ij,jk", [2, 3], [3, 5])  # Matmul
+    _test_einsum("i,i->", [2], [2])  # Dot product
+    _test_einsum("i,j->ij", [3], [5])  # Outer produce
+    _test_einsum("ij->ji", [2, 3])  # Transpose
+    _test_einsum("ii->i", [3, 3])  # Diag
+    _test_einsum("ii", [3, 3])  # Trace of a square matrix
+    _test_einsum("bij,bjk->bik", [7, 5, 3], [7, 3, 2])  # Batch matmul
+
+
+def _test_pad(input_shape, paddings, mode, **kwargs):
+    """One iteration of pad operation with given shape"""
+
+    x = np.arange(np.prod(input_shape), dtype=np.float32).reshape(input_shape)
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=input_shape, dtype="float32")
+        pad_values = constant_op.constant(paddings)
+        _ = tf.pad(in_data, paddings=pad_values, mode=mode, **kwargs)
+
+        if mode == "CONSTANT":
+            if "constant_values" in kwargs:
+                out_name = "PadV2:0"
+            else:
+                out_name = "Pad:0"
+        else:
+            out_name = "MirrorPad:0"
+
+        io_info = {
+            "in_data": x,
+            "in_name": "Placeholder:0",
+            "out_name": out_name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_pad():
+    """test tensorflow translator for pad"""
+
+    _test_pad((2, 3), [[1, 1], [2, 2]], mode="CONSTANT")
+    _test_pad((2, 3), [[1, 1], [2, 2]], mode="CONSTANT", constant_values=1.0)
+
+
+def test_logical_and():
+    """test tensorflow translator for logical_and"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in1")
+        in2 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in2")
+        _ = tf.logical_and(in1, in2, name="out")
+        in_data1 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        in_data2 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        io_info = {
+            "in_data": [in_data1, in_data2],
+            "in_name": ["in1:0", "in2:0"],
+            "out_name": "out:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_logical_or():
+    """test tensorflow translator for logical_or"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in1")
+        in2 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in2")
+        _ = tf.logical_or(in1, in2, name="out")
+        in_data1 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        in_data2 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        io_info = {
+            "in_data": [in_data1, in_data2],
+            "in_name": ["in1:0", "in2:0"],
+            "out_name": "out:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_logical_xor():
+    """test tensorflow translator for logical_xor"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in1")
+        in2 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in2")
+        _ = tf.logical_xor(in1, in2, name="out")
+        in_data1 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        in_data2 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        io_info = {
+            "in_data": [in_data1, in_data2],
+            "in_name": ["in1:0", "in2:0"],
+            "out_name": "out:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_logical_not():
+    """test tensorflow translator for logical_not"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in1")
+        _ = tf.logical_not(in1, name="out")
+        in_data1 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        io_info = {
+            "in_data": [in_data1],
+            "in_name": ["in1:0"],
+            "out_name": "out:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_where():
+    """test tensorflow translator for where"""
+
+    with tf.Graph().as_default():
+        with tf.Session() as _:
+            input1 = tf.placeholder(tf.int32, shape=[1, 4, 4, 3], name="input1")
+            input2 = tf.placeholder(tf.int32, shape=[1, 4, 4, 3], name="input2")
+            mask = input1 > input2
+            tf.where(mask, input1 + 1, input2 * 2)
+            in_data1 = np.random.uniform(0, 10, size=(1, 4, 4, 3)).astype("uint32")
+            in_data2 = np.random.uniform(0, 10, size=(1, 4, 4, 3)).astype("uint32")
+            io_info = {
+                "in_data": [in_data1, in_data2],
+                "in_name": ["input1:0", "input2:0"],
+                "out_name": "Select:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+
+def _test_transpose(ishape, axes=None):
+    data = np.random.uniform(size=ishape).astype(np.float32)
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=data.shape, dtype=data.dtype, name="transpose_data")
+
+        if axes is None:
+            tf.transpose(in1)
+        else:
+            tf.transpose(in1, perm=axes)
+
+        io_info = {
+            "in_data": data,
+            "in_name": "transpose_data:0",
+            "out_name": "transpose:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_tranapose_axes_input(ishape, axes):
+    data = np.random.uniform(size=ishape).astype(np.float32)
+    axes_np = np.array(axes).astype(np.int32)
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=data.shape, dtype=data.dtype, name="transpose_data")
+
+        const1 = tf.constant(axes_np, dtype=tf.int32)
+
+        # make axes an input to tf.transpose, but not an input to the graph,
+        # so it can be extracted with infer_value_simulated
+        axes = tf.reverse(const1, axis=[-1])
+        tf.transpose(in1, axes)
+        io_info = {
+            "in_data": data,
+            "in_name": "transpose_data:0",
+            "out_name": "transpose:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_transpose():
+    """test tensorflow translator for transpose"""
+
+    _test_transpose((2, 3, 4), (1, 2, 0))
+    _test_transpose((2, 3, 4))
+    _test_tranapose_axes_input((2, 3, 4), (1, 2, 0))
+    _test_tranapose_axes_input((2, 3, 4, 5), (3, 0, 1, 2))
+
+
+def _test_slice_operation_input(input_value, begin_value, size_value):
+    input_data = np.array(input_value, dtype=np.float32)
+    with tf.Graph().as_default():
+        input_tensor = tf.placeholder(shape=input_data.shape, dtype=input_data.dtype, name="input")
+        tf.slice(input_tensor, begin_value, size_value, name="slice_output")
+        io_info = {
+            "in_data": input_data,
+            "in_name": "input:0",
+            "out_name": "slice_output:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_slice():
+    """test tensorflow translator for slice"""
+
+    _test_slice_operation_input([1, 1], [0], [2])
+
+
+def test_ceil():
+    """test tensorflow translator for ceil"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.ceil(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Ceil:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_floor():
+    """test tensorflow translator for floor"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.floor(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Floor:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_relu():
+    """test tensorflow translator for relu"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.nn.relu(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Relu:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_elu():
+    """test tensorflow translator for elu"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.nn.elu(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Elu:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_selu():
+    """test tensorflow translator for selu"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.nn.selu(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Selu:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_tanh():
+    """test tensorflow translator for tanh"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.nn.tanh(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Tanh:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_softmax():
+    """test tensorflow translator for softmax"""
+
+    def check_softmax(in_shape, axis, dtype):
+        np_data = np.random.uniform(-100, 100, size=in_shape).astype(dtype)
+        tf.reset_default_graph()
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(dtype, in_shape, name="in_data")
+            tf.nn.softmax(in_data, axis=axis, name="Softmax")
+            io_info = {
+                "in_data": np_data,
+                "in_name": "in_data:0",
+                "out_name": "Softmax:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    check_softmax((2, 3, 5), 2, "float32")
+    check_softmax((2, 3, 5), -1, "float32")
+
+
+def test_round():
+    """test tensorflow translator for round"""
+
+    np_data = np.random.uniform(-10, 10, size=(5, 7)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (5, 7), name="in_data")
+        tf.round(in_data, name="round")
+        io_info = {
+            "in_data": np_data,
+            "in_name": "in_data:0",
+            "out_name": "round:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_abs():
+    """test tensorflow translator for abs"""
+
+    np_data = np.random.uniform(1, 100, size=(9, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (9, 11), name="in_data")
+        tf.math.abs(in_data, name="abs")
+        io_info = {
+            "in_data": np_data,
+            "in_name": "in_data:0",
+            "out_name": "abs:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_squared_difference():
+    """test tensorflow translator for squared_difference"""
+
+    ishape = (1, 3, 10, 14)
+    inp_array_a = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    inp_array_b = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array_a.shape, dtype=inp_array_a.dtype, name="in1")
+        in2 = tf.placeholder(shape=inp_array_b.shape, dtype=inp_array_b.dtype, name="in2")
+        out = tf.math.squared_difference(in1, in2)
+        io_info = {
+            "in_data": [inp_array_a, inp_array_b],
+            "in_name": [in1.name, in2.name],
+            "out_name": out.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_sign():
+    """test tensorflow translator for sign"""
+
+    np_data = np.random.uniform(-10, 10, size=(5, 7, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (5, 7, 11), name="in_data")
+        tf.sign(in_data, name="sign")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "sign:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_square():
+    """test tensorflow translator for square"""
+
+    np_data = np.random.uniform(1, 100, size=(2, 3, 5)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (2, 3, 5), name="in_data")
+        tf.square(in_data, name="square")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "square:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_pow_exp():
+    """test tensorflow translator for pow && exp"""
+
+    np_in1 = np.random.uniform(-2, 2, size=(5, 7, 11)).astype(np.float32)
+    np_in2 = np.random.uniform(-2, 2, size=(5, 7, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.float32, (5, 7, 11), name="in1")
+        in2 = tf.placeholder(tf.float32, (5, 7, 11), name="in2")
+        in3 = tf.pow(in1, in2, name="pow")
+        _ = tf.exp(in3, name="exp")
+        io_info = {"in_data": [np_in1, np_in2], "in_name": ["in1:0", "in2:0"], "out_name": "exp:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_unary():
+    """test tensorflow translator for unary"""
+
+    def _test_unary(op, a_min=1, a_max=5, dtype=np.float32):
+        """test unary operators"""
+        np_data = np.random.uniform(a_min, a_max, size=(2, 3, 5)).astype(dtype)
+        tf.reset_default_graph()
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(dtype, (2, 3, 5), name="in_data")
+            out = op(in_data)
+            io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": out.name}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    _test_unary(tf.acos, -1, 1)
+    _test_unary(tf.asin, -1, 1)
+    _test_unary(tf.atanh, -1, 1)
+    _test_unary(tf.sinh)
+    _test_unary(tf.cosh)
+    _test_unary(tf.acosh)
+    _test_unary(tf.asinh)
+    _test_unary(tf.atan)
+    _test_unary(tf.sin)
+    _test_unary(tf.cos)
+    _test_unary(tf.tan)
+    _test_unary(tf.tanh)
+    _test_unary(tf.erf)
+    _test_unary(tf.log)
+
+
+def test_atan2():
+    """test tensorflow translator for atan2"""
+
+    tf.disable_eager_execution()
+    np_data_1 = np.random.uniform(1, 100, size=(2, 3, 5)).astype(np.float32)
+    np_data_2 = np.random.uniform(1, 100, size=(2, 3, 5)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data_1 = tf.placeholder(tf.float32, (2, 3, 5), name="in_data_1")
+        in_data_2 = tf.placeholder(tf.float32, (2, 3, 5), name="in_data_2")
+        tf.atan2(in_data_1, in_data_2, name="atan2")
+        io_info = {
+            "in_data": [np_data_1, np_data_2],
+            "in_name": ["in_data_1:0", "in_data_2:0"],
+            "out_name": "atan2:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_expm1():
+    """test tensorflow translator for expm1"""
+
+    def _test_expm1(shape):
+        tf.disable_eager_execution()
+        np_data = np.random.uniform(1, 10, size=shape).astype(np.float32)
+        tf.reset_default_graph()
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(tf.float32, shape, name="in_data")
+            tf.expm1(in_data, name="expm1")
+            io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "expm1:0"}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    _test_expm1([2, 5, 2, 5])
+
+
+def test_softsign():
+    """test tensorflow translator for softsign"""
+
+    def _test_softsign(shape):
+        tf.disable_eager_execution()
+        np_data = np.random.uniform(1, 100, size=shape).astype(np.float32)
+        tf.reset_default_graph()
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(tf.float32, shape, name="in_data")
+            tf.nn.softsign(in_data, name="softsign")
+            io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "softsign:0"}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    _test_softsign([2, 5, 2, 5])
+
+
+def test_rint():
+    """test tensorflow translator for rint"""
+
+    def _test_rint(shape):
+        tf.disable_eager_execution()
+        np_data = np.random.uniform(-100, 100, size=shape).astype(np.float32)
+        tf.reset_default_graph()
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(tf.float32, shape, name="in_data")
+            tf.math.rint(in_data, name="rint")
+            io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "rint:0"}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    _test_rint([2, 5, 2, 5])
+
+
+def test_negative():
+    """test tensorflow translator for neg"""
+
+    np_data = np.random.uniform(-100, 255, size=(224, 224, 3)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (224, 224, 3), name="in_data")
+        tf.negative(in_data, name="negative")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "negative:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_log_softmax():
+    """test tensorflow translator for log_softmax"""
+
+    np_data = np.random.uniform(1, 100, size=(9, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (9, 11), name="in_data")
+        tf.math.log_softmax(in_data, name="LogSoftmax")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "LogSoftmax:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_softplus():
+    """test tensorflow translator for softplus"""
+
+    np_data = np.random.uniform(1, 10, size=(2, 3, 5)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (2, 3, 5), name="in_data")
+        tf.nn.softplus(in_data, name="softplus")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "softplus:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_rsqrt():
+    """test tensorflow translator for rsqrt"""
+
+    np_data = np.random.uniform(1, 100, size=(5, 7, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (5, 7, 11), name="in_data")
+        tf.rsqrt(in_data, name="rsqrt")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "rsqrt:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_sqrt():
+    """test tensorflow translator for sqrt"""
+
+    np_data = np.random.uniform(1, 100, size=(5, 7, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (5, 7, 11), name="in_data")
+        tf.sqrt(in_data, name="sqrt")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "sqrt:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_mean():
+    """test tensorflow translator for mean"""
+
+    def check_mean(ishape, **kwargs):
+        inp_array = np.random.uniform(size=ishape).astype(np.float32)
+        with tf.Graph().as_default():
+            in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+            tf.keras.backend.mean(in1, **kwargs)
+            io_info = {"in_data": inp_array, "in_name": "Placeholder:0", "out_name": "Mean:0"}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    check_mean((10, 8, 16, 32))
+    check_mean((10, 8, 16, 32), axis=(2, 3))
+    check_mean((10, 8, 16, 32), axis=(1, 2), keepdims=True)
+
+
+def test_reduce():
+    """test tensorflow translator for reduce"""
+
+    def _check_op(tf_op, ishape, axis, keepdims):
+        tf.reset_default_graph()
+        np_data = np.random.uniform(size=ishape).astype("float32")
+        if tf_op == tf.math.reduce_prod:
+            axis = 1
+            np_data = np_data.reshape(1, -1)
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(shape=np_data.shape, dtype="float32", name="in_data")
+            reduce_op = tf_op(in_data, axis=axis, keepdims=keepdims, name="reduce_op")
+            io_info = {"in_data": np_data, "in_name": "in_data:0", "out_name": reduce_op.name}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    def _test_math_op(op):
+        _check_op(op, (8, 16, 32), axis=(-1), keepdims=False)
+        _check_op(op, (1, 8, 8, 3), axis=(2, 3), keepdims=True)
+
+    _test_math_op(tf.math.reduce_max)
+    _test_math_op(tf.math.reduce_min)
+    _test_math_op(tf.math.reduce_prod)
+    _test_math_op(tf.math.reduce_variance)
+    _test_math_op(tf.math.reduce_std)
+    _test_math_op(tf.math.reduce_logsumexp)
+    if package_version.parse(tf.VERSION) >= package_version.parse("1.15.0"):
+        _test_math_op(tf.math.reduce_euclidean_norm)
+
+
+def _test_rel_op(data, func):
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=data[0].shape, dtype=data[0].dtype, name="in1")
+        in2 = tf.placeholder(shape=data[1].shape, dtype=data[1].dtype, name="in2")
+        op = func(in1, in2, name="op")
+        _ = tf.cast(op, tf.int32, name="out1")
+        io_info = {
+            "in_data": [data[0], data[1]],
+            "in_name": ["in1:0", "in2:0"],
+            "out_name": "out1:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_rel_ops():
+    """test tensorflow translator for relation"""
+
+    t_1 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    t_2 = np.array([[9, 8, 7], [6, 5, 4], [3, 2, 1]])
+    _test_rel_op([t_1, t_2], math_ops.less)
+    _test_rel_op([t_1, t_2], math_ops.greater)
+    _test_rel_op([t_1, t_2], math_ops.less_equal)
+    _test_rel_op([t_1, t_2], math_ops.greater_equal)
+    _test_rel_op([t_1, t_2], math_ops.equal)
+    _test_rel_op([t_1, t_2], math_ops.not_equal)
+
+
+def _test_expand_dims(data, axis):
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=data.shape, dtype=data.dtype, name="in1")
+        out = tf.expand_dims(in1, axis)
+        io_info = {"in_data": data, "in_name": in1.name, "out_name": out.name}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_expand_dims():
+    """test tensorflow translator for expand_dims"""
+
+    _test_expand_dims(np.array([1]), -1)
+    _test_expand_dims(np.array([[1], [2]]), 1)
+
+
+def test_maximum():
+    """test tensorflow translator for maximum"""
+
+    def check_maximum(lh_shape, rh_shape, dtype):
+        tf.reset_default_graph()
+        lh_data = np.random.uniform(size=lh_shape).astype(dtype)
+        rh_data = np.random.uniform(size=rh_shape).astype(dtype)
+        with tf.Graph().as_default():
+            lft_data = tf.placeholder(shape=lh_data.shape, dtype=dtype, name="lft_data")
+            rgt_data = tf.placeholder(shape=rh_data.shape, dtype=dtype, name="rgt_data")
+            tf.math.maximum(lft_data, rgt_data, name="maximum")
+            io_info = {
+                "in_data": [lh_data, rh_data],
+                "in_name": ["lft_data:0", "rgt_data:0"],
+                "out_name": "maximum:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    check_maximum((10, 8, 16, 32), (10, 8, 16, 32), dtype="float32")
+
+
+def test_minimum():
+    """test tensorflow translator for minimum"""
+
+    def check_minimum(lh_shape, rh_shape, dtype):
+        tf.reset_default_graph()
+        lh_data = np.random.uniform(size=lh_shape).astype(dtype)
+        rh_data = np.random.uniform(size=rh_shape).astype(dtype)
+        with tf.Graph().as_default():
+            lft_data = tf.placeholder(shape=lh_data.shape, dtype=dtype, name="lft_data")
+            rgt_data = tf.placeholder(shape=rh_data.shape, dtype=dtype, name="rgt_data")
+            tf.math.minimum(lft_data, rgt_data, name="minimum")
+            io_info = {
+                "in_data": [lh_data, rh_data],
+                "in_name": ["lft_data:0", "rgt_data:0"],
+                "out_name": "minimum:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    check_minimum((10, 8, 16, 32), (10, 8, 16, 32), dtype="float32")
+
+
+def _test_add_n(inputs):
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        temp = []
+        for each in inputs:
+            temp.append(tf.placeholder(shape=each.shape, dtype=each.dtype))
+        output = tf.add_n(temp)
+        io_info = {
+            "in_data": list(inputs),
+            "in_name": [each.name for each in temp],
+            "out_name": output.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_add_n():
+    """test tensorflow translator for add_n"""
+
+    x_in = np.random.randint(1, 100, size=(3, 3, 3), dtype=np.int32)
+    y_in = np.random.randint(1, 100, size=(3, 3, 3), dtype=np.int32)
+    z_in = np.random.randint(1, 100, size=(3, 3, 3), dtype=np.int32)
+    m_dim, n_dim, o_dim = x_in.astype(np.float32), y_in.astype(np.float32), z_in.astype(np.float32)
+    in0 = x_in
+    in1 = [x_in, y_in]
+    in2 = (x_in, y_in, z_in)
+    in3 = m_dim
+    in4 = [m_dim, n_dim]
+    in5 = (m_dim, n_dim, o_dim)
+    _test_add_n(in0)
+    _test_add_n(in1)
+    _test_add_n(in2)
+    _test_add_n(in3)
+    _test_add_n(in4)
+    _test_add_n(in5)
+
+
+def _test_identityn(data_np_list):
+    with tf.Graph().as_default():
+        data_tensors = []
+        data_tensors_name = []
+        for index, data_np in enumerate(data_np_list):
+            tensor_name = f"data_{index}"
+            data_tensors_name.append(tensor_name + ":0")
+            data_tensors.append(
+                tf.placeholder(shape=data_np.shape, dtype=str(data_np.dtype), name=tensor_name)
+            )
+
+        output = tf.identity_n(data_tensors)
+        output_names = [out.name for out in output]
+        io_info = {"in_data": data_np_list, "in_name": data_tensors_name, "out_name": output_names}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info, use_out_name=False)
+
+
+def test_identityn():
+    """test tensorflow translator for identityn"""
+
+    data_np_list = [
+        np.array([[1, 1], [0, 3], [0, 1], [2, 0], [3, 1]], dtype=np.int64),
+        np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        np.array([5, 6], dtype=np.int64),
+    ]
+    _test_identityn(data_np_list)
+    data_np_list = [
+        np.array([[1, 1], [0, 3], [2, 0], [3, 1]], dtype=np.int64),
+        np.array([1, 2, 3, 4], dtype=np.int64),
+        np.array([5, 6], dtype=np.int64),
+        np.array([True, False, True]),
+    ]
+    _test_identityn(data_np_list)
+
+
+def _test_infinity(tf_op, name):
+    """test operator infinity ops"""
+
+    # Only float types are allowed in Tensorflow for isfinite and isinf
+    # float16 is failing on cuda
+    tf_dtypes = ["float32", "float64"]  # pylint: disable=redefined-outer-name
+    for tf_dtype in tf_dtypes:
+        shape = (8, 8)
+        data = np.random.uniform(size=shape).astype(tf_dtype)
+        data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.infty
+        data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.nan
+
+        tf.reset_default_graph()
+        in_data = tf.placeholder(tf_dtype, shape, name="in_data")
+        tf_op(in_data, name=name)
+        io_info = {"in_data": data, "in_name": "in_data:0", "out_name": f"{name}:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_infinity():
+    """test tensorflow translator for infinity"""
+
+    _test_infinity(tf.is_inf, "isinf")
+    _test_infinity(tf.is_finite, "isfinite")
+    _test_infinity(tf.is_nan, "isnan")
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This is a pull request for MSC(Multi-System Compile)
RFC: https://discuss.tvm.apache.org/t/rfc-unity-msc-introduction-to-multi-system-compiler/15251/5
Tracking issue: https://github.com/apache/tvm/issues/15233

This is the 2nd part of Milestone 1: Finish RuntimeManager for frameworks

To limit each PR in reviewable size, the Milestone 1 will be split into some steps:
M1.1 Add translate && codegen for torch
**M1.2 Add translate && codegen for tensorflow**
M1.3 Add codegen for tensorrt
M1.4 Add RuntimeManager and test with relax
M1.5 Add RuntimeManager and test with torch
M1.6 Add RuntimeManager and test with tensorflow
M1.7 Add RuntimeManager and test with tensorrt

Tensorflow GraphDef will be translate to MSCGraph via relay. The codegen for tensorflow follow the same principle with relax codegen, thus generate the model define as well as test.
As mentioned in https://github.com/apache/tvm/pull/15645, MSC enables the relay based features. The test in this PR shows developers how to combine relay.frontend.from_tensorflow and msc.core.codegen.relay_to_relax to "create" a frontend for tensorflow in relax.