### PR TITLE
[Relay][Bugfix] fix the wrong calculate logic of operator flip in PyTorch frontend

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2977,11 +2977,9 @@ class PyTorchOpConverter:
     def flip(self, inputs, input_types):
         data = inputs[0]
         axis = inputs[1]
-        for i, ax in enumerate(axis):
-            if i == 0:
-                out = _op.reverse(data, ax)
-            else:
-                out = _op.reverse(out, ax)
+        out = data
+        for ax in axis:
+            out = _op.reverse(out, ax)
         return out
 
     def bidir_rnn_cell(self, input_seqs, weights_dicts, act=_op.tanh):

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2977,7 +2977,12 @@ class PyTorchOpConverter:
     def flip(self, inputs, input_types):
         data = inputs[0]
         axis = inputs[1]
-        return _op.transform.reverse(data, axis=axis[0])
+        for i, ax in enumerate(axis):
+            if i == 0:
+                out = _op.reverse(data, ax)
+            else:
+                out = _op.reverse(out, ax)
+        return out
 
     def bidir_rnn_cell(self, input_seqs, weights_dicts, act=_op.tanh):
         """

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -4899,13 +4899,14 @@ def test_forward_flip():
             self.axis = axis
 
         def forward(self, x):
-            return x.flip([self.axis])
+            return x.flip(self.axis)
 
     input_t = torch.randn(2, 3, 4)
-    verify_model(Flip(axis=0), input_data=input_t)
-    verify_model(Flip(axis=1), input_data=input_t)
-    verify_model(Flip(axis=2), input_data=input_t)
-    verify_model(Flip(axis=-1), input_data=input_t)
+    verify_model(Flip(axis=[0]), input_data=input_t)
+    verify_model(Flip(axis=[1]), input_data=input_t)
+    verify_model(Flip(axis=[2]), input_data=input_t)
+    verify_model(Flip(axis=[-1]), input_data=input_t)
+    verify_model(Flip(axis=[0, 1]), input_data=input_t)
 
 
 def test_annotate_span():


### PR DESCRIPTION
The original implementation of Flip in PyTorch converter mistaken the type of attribute `axis` in the Flip operator as an integer. Thus, It only parses the first element of the `axis` and will give a wrong calculation result when the length of `axis` is more than one.  According to the PyTorch documentation [here](https://pytorch.org/docs/stable/generated/torch.flip.html), the type of `axis` is a list or tuple.


This PR corrected the incorrect implementation of the algorithm of `torch.flip` converter and added a regression test.

cc @echuraev @Hzfengsy @MasterJH5574 
