### PR TITLE
[BugFix][CPP] Fix cpp deploy bug

### DIFF
--- a/apps/howto_deploy/prepare_test_libs.py
+++ b/apps/howto_deploy/prepare_test_libs.py
@@ -33,7 +33,12 @@ def prepare_test_libs(base_path):
     fadd_dylib.export_library(dylib_path)
 
     # Compile library in system library mode
-    fadd_syslib = tvm.build(s, [A, B], "llvm", name="addonesys")
+    
+    fadd_syslib = tvm.build(s, 
+                            [A, B], 
+                            "llvm", 
+                            name="addonesys", 
+                            runtime=relay.backend.Runtime("cpp", {"system-lib": True}))
     syslib_path = os.path.join(base_path, "test_addone_sys.o")
     fadd_syslib.save(syslib_path)
 

--- a/apps/howto_deploy/prepare_test_libs.py
+++ b/apps/howto_deploy/prepare_test_libs.py
@@ -33,11 +33,13 @@ def prepare_test_libs(base_path):
     fadd_dylib.export_library(dylib_path)
 
     # Compile library in system library mode
-    fadd_syslib = tvm.build(s, 
-                            [A, B], 
-                            "llvm", 
-                            name="addonesys", 
-                            runtime=relay.backend.Runtime("cpp", {"system-lib": True}))
+    fadd_syslib = tvm.build(
+        s,
+        [A, B],
+        "llvm",
+        name="addonesys",
+        runtime=relay.backend.Runtime("cpp", {"system-lib": True}),
+    )
     syslib_path = os.path.join(base_path, "test_addone_sys.o")
     fadd_syslib.save(syslib_path)
 

--- a/apps/howto_deploy/prepare_test_libs.py
+++ b/apps/howto_deploy/prepare_test_libs.py
@@ -33,7 +33,6 @@ def prepare_test_libs(base_path):
     fadd_dylib.export_library(dylib_path)
 
     # Compile library in system library mode
-    
     fadd_syslib = tvm.build(s, 
                             [A, B], 
                             "llvm", 


### PR DESCRIPTION
## Motivation

Fix bug when using `apps/howto_deploy/run_example.sh`, it will cause `core dumped`

![image](https://github.com/apache/tvm/assets/25873202/a55b40ba-0f28-4c75-b216-591c6008734f)

After fixed, all test pass.

![image](https://github.com/apache/tvm/assets/25873202/61db50eb-77a2-43b4-9cf4-1f24aba49b67)


## Modification

Add runtime for `tvm.build`
