### PR TITLE
[TVMC] enable dumping imported modules too

### DIFF
--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -448,7 +448,6 @@ def compile_model(
                 for smod in lib.imported_modules:
                     dumps[smod.type_key] = smod.get_source()
 
-
         # Create a new tvmc model package object from the graph definition.
         package_path = tvmc_model.export_package(
             graph_module, package_path, cross, cross_options, output_format

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -445,6 +445,9 @@ def compile_model(
                 # TODO lib.get_source call have inconsistent behavior for unsupported
                 #      formats (@leandron).
                 dumps[source_type] = lib.get_source(source_type)
+                for smod in lib.imported_modules:
+                    dumps[smod.type_key] = smod.get_source()
+
 
         # Create a new tvmc model package object from the graph definition.
         package_path = tvmc_model.export_package(

--- a/tests/python/driver/tvmc/test_compiler.py
+++ b/tests/python/driver/tvmc/test_compiler.py
@@ -798,6 +798,7 @@ def test_compile_opencl(tflite_mobilenet_v1_0_25_128):
     assert type(tvmc_package.lib_path) is str
     assert type(tvmc_package.params) is bytearray
     assert os.path.exists(dumps_path)
+    assert path.exists("{}.{}".format(tvmc_package.package_path, "opencl"))
 
 
 @tvm.testing.requires_cmsisnn


### PR DESCRIPTION
Now we can dump the imported modules source too like device code.