### PR TITLE
[Unity][BugFix] FuseTIR not keeping ExternFunc in IRModule

### DIFF
--- a/tests/python/relax/test_transform_fuse_tir.py
+++ b/tests/python/relax/test_transform_fuse_tir.py
@@ -1198,5 +1198,13 @@ def test_tuple_input_unused_field():
     _check(Module, Expected)
 
 
+def test_extern_func():
+    bb = relax.BlockBuilder()
+    bb.add_func(relax.extern("extern_func"), "extern_func")
+    mod = bb.get()
+    # FuseTIR should keep the ExternFunc in the IRModule.
+    _check(mod, mod)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR fixes a bug of the FuseTIR pass in Relax.

Prior to this fix, when an IRModule has an ExternFunc in its function table, the ExternFunc will be removed by the pass and does not show up in the output IRModule.

This PR fixes this issue by forcing keeping the ExternFunc.