### PR TITLE
[Unity] Keep num_input attribute after ModelBundleParams

### DIFF
--- a/src/relax/transform/bundle_model_params.cc
+++ b/src/relax/transform/bundle_model_params.cc
@@ -66,7 +66,6 @@ class ModelParamBundler : public ExprMutator {
       var_to_expr_.Set(func->params[i], TupleGetItem(var_param_tuple, i - num_input));
     }
 
-    func = WithoutAttr(func, attr::kNumInput);
     func.CopyOnWrite()->params = params;
 
     return ExprMutator::VisitExpr_(func.get());

--- a/tests/python/relax/test_transform_bundle_model_params.py
+++ b/tests/python/relax/test_transform_bundle_model_params.py
@@ -46,6 +46,7 @@ def test_basic():
             a: R.Tensor([16], "float32"),
             params: R.Tuple(R.Tensor([16], "float32"), R.Tensor([16], "float32")),
         ) -> R.Tensor([16], "float32"):
+            R.func_attr({"num_input": 1})
             expr = a
             b = params[0]
             expr = R.add(expr, b)
@@ -90,6 +91,7 @@ def test_no_model_params():
             c: R.Tensor([16], "float32"),
             params: R.Tuple(),
         ) -> R.Tensor([16], "float32"):
+            R.func_attr({"num_input": 3})
             expr = a
             expr = R.add(expr, b)
             expr = R.add(expr, c)


### PR DESCRIPTION
This very minor change keeps the `num_input` attribute attached to functions after applying `BundleModelParams`. This is very useful in combination with #15736, which uses `num_input` to perform runtime optimization.