### PR TITLE
[Unity] Fix dlight bench when func_name is global var

### DIFF
--- a/python/tvm/dlight/benchmark/bench.py
+++ b/python/tvm/dlight/benchmark/bench.py
@@ -88,6 +88,7 @@ def benchmark(
         mod = mod_or_func
         # assume only one global function
         (func_name,) = mod.get_global_vars()
+        func_name = func_name.name_hint
     # produce input shapes
     if args is None:
         args, _ = extract_func_info_from_prim_func(mod[func_name])


### PR DESCRIPTION
This PR fixed error when func name is global var. `time_evaluator` expects `func_name` to be a string instead of global var.

cc @zxybazh 