### PR TITLE
[SkipCI][Hotfix][TFLite] Disable test of quantized floor mod

### DIFF
--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -2916,7 +2916,11 @@ def test_all_elemwise():
         _test_forward_elemwise(_test_floor_divide)
         _test_forward_elemwise_quantized(_test_floor_divide)
         _test_forward_elemwise(_test_floor_mod)
-        _test_forward_elemwise_quantized(_test_floor_mod)
+        # This test of quantized floor mod is currently disabled due
+        # to flaky CI failures in main, failing approximately 45% of
+        # the time.
+        #
+        # _test_forward_elemwise_quantized(_test_floor_mod)
 
 
 #######################################################################


### PR DESCRIPTION
This unit test is failing on unrelated PRs (e.g. https://github.com/apache/tvm/pull/15762 at [CI link](https://ci.tlcpack.ai/blue/organizations/jenkins/tvm-arm/detail/PR-15762/4/tests)). Local testing resulted in a failed test 44 times out of 100 iterations.