### PR TITLE
[UNITY][Pass] Remove redundant reshape

### DIFF
--- a/python/tvm/relax/transform/__init__.py
+++ b/python/tvm/relax/transform/__init__.py
@@ -20,6 +20,7 @@
 from .transform import *
 from .lazy_transform_params import LazyTransformParams
 from .optimize_layout_transform import OptimizeLayoutTransform
+from .remove_redundant_reshape import RemoveRedundantReshape
 
 # Import to register the legalization functions.
 from . import legalize_ops

--- a/python/tvm/relax/transform/remove_redundant_reshape.py
+++ b/python/tvm/relax/transform/remove_redundant_reshape.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, unused-argument, missing-function-docstring, abstract-method
+
+from tvm.ir.module import IRModule
+from tvm.ir.transform import PassContext
+from tvm.relax import Expr, Function
+from tvm.relax.dpl import is_op, rewrite_call, wildcard
+from . import function_pass
+
+
+@function_pass(opt_level=0)
+class RemoveRedundantReshape:
+    """
+    Transformation pass to remove redundant reshape operator
+    """
+
+    def __init__(self):
+        input = wildcard()
+        shape1 = wildcard()
+        pattern_redundant_reshape = is_op("relax.reshape")(input, shape1)
+        self.pattern = pattern_redundant_reshape
+
+    def transform_function(self, func: Expr, mod: IRModule, ctx: PassContext) -> IRModule:
+        """
+        Tarnsformation function to remove redundant reshape
+        where tensors before and after reshape are of same dimentions.
+
+        Parameters
+        --------------
+        func: Expr
+            The relax function to be optimized
+
+        mod: IRModule
+            The IR module
+
+        ctx: PassContext
+            Relax pass context
+        """
+
+        updated_func = func
+        for _, func in mod.functions.items():
+            # Skip non-relax functions
+            if not isinstance(func, Function):
+                continue
+            # Skip primitive functions
+            if "Primitive" in func.attrs.keys() and func.attrs["Primitive"] != 0:
+                continue
+
+            def rewriter(expr, matches):
+                args = matches[self.pattern]
+                if list(args.args[0].struct_info.shape) == list(args.args[1]):
+                    return args.args[0]
+                else:
+                    return expr
+
+            updated_func = rewrite_call(self.pattern, rewriter, func)
+
+        return updated_func

--- a/tests/python/relax/test_remove_redundant_reshape.py
+++ b/tests/python/relax/test_remove_redundant_reshape.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Test relax transform - Eliminate redundant reshape operations
+"""
+import tvm.testing
+from tvm import relax
+from tvm.relax.transform import DeadCodeElimination
+from tvm.relax.transform import RemoveRedundantReshape
+from tvm.script import ir as I, relax as R
+
+
+def _run_pass_compare_output(Before, Expected):
+    fused_mod = RemoveRedundantReshape()(Before)
+    if not relax.analysis.well_formed(fused_mod):
+        print("IRModule is not well-formed")
+
+    fused_mod = DeadCodeElimination()(fused_mod)
+    if not relax.analysis.well_formed(fused_mod):
+        print("IRModule is not well-formed")
+
+    tvm.ir.assert_structural_equal(Expected, fused_mod)
+
+
+def test_remove_redundant_reshape_pass():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor((1, 1001, 1, 1), dtype="float16")
+        ) -> R.Tensor((1, 1001), dtype="float16"):
+            with R.dataflow():
+                lv: R.Tensor((1, 1001), dtype="float16") = R.reshape(x, R.shape([1, 1001]))
+                lv1: R.Tensor((1, 1001), dtype="float16") = R.reshape(lv, R.shape([1, 1001]))
+                R.output(lv1)
+            return lv1
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor((1, 1001, 1, 1), dtype="float16")
+        ) -> R.Tensor((1, 1001), dtype="float16"):
+            with R.dataflow():
+                lv1: R.Tensor((1, 1001), dtype="float16") = R.reshape(x, R.shape([1, 1001]))
+                R.output(lv1)
+            return lv1
+
+    _run_pass_compare_output(Before, Expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_remove_redundant_reshape.py
+++ b/tests/python/relax/test_remove_redundant_reshape.py
@@ -59,8 +59,9 @@ def test_remove_redundant_reshape_pass_one_arg():
                 lv1: R.Tensor((1, 1001), dtype="float16") = R.reshape(x, R.shape([1, 1001]))
                 R.output(lv1)
             return lv1
-    
+
     _run_pass_compare_output(Before, Expected)
+
 
 def test_remove_redundant_reshape_pass_two_arg():
     @I.ir_module


### PR DESCRIPTION
In Mobilenet float32, we see this sequence of ops:

%179 = squeeze(%178, axis=[2, 3]) /* ty=Tensor[(1, 1001), float16] span=MobilenetEdgeTPU/Logits/Squeeze:0:0 /;
%180 = reshape(%179, newshape=[-1, 1001]) / ty=Tensor[(1, 1001), float16] span=MobilenetEdgeTPU/Predictions/
Reshape:0:0 */;

which later gets transformed to

lv171 = R.call_tir(cls.primfunc_hmx_conv2d26_add20, (lv169, metadata["relax.expr.Constant"][116], metadata["relax.expr.Constant"][117]), out_sinfo=R.Tensor((1, 1001, 1, 1), dtype="float16"))
lv172: R.Tensor((1, 1001), dtype="float16") = R.reshape(lv171, R.shape([1, 1001]))
lv173: R.Tensor((1, 1001), dtype="float16") = R.reshape(lv172, R.shape([1, 1001]))

We can eliminate the redundant reshape.

lv171 = R.call_tir(cls.primfunc_hmx_conv2d26_add20, (lv169, metadata["relax.expr.Constant"][116], metadata["relax.expr.Constant"][117]), out_sinfo=R.Tensor((1, 1001, 1, 1), dtype="float16"))
lv173: R.Tensor((1, 1001), dtype="float16") = R.reshape(lv171, R.shape([1, 1001]))