### PR TITLE
[Unity] Implement LowerAllocTensor to remove R.builtin.alloc_tensor

### DIFF
--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -368,6 +368,26 @@ def StaticPlanBlockMemory() -> tvm.ir.transform.Pass:
     return _ffi_api.StaticPlanBlockMemory()  # type: ignore
 
 
+def LowerAllocTensor() -> tvm.ir.transform.Pass:
+    """Lower remaining instances of R.builtin.alloc_tensor
+
+    The static memory planner removes static instances of
+    `R.builtin.alloc_tensor`, replacing with `R.memory.alloc_storage`
+    and `R.memory.alloc_tensor`.  However, `R.builtin.alloc_tensor`
+    still remains for any dynamic allocations.
+
+    This transform replaces any remaining `R.builtin.alloc_tensor`
+    instances with `R.memory.alloc_storage` and
+    `R.memory.alloc_tensor`.  If no `R.builtin.alloc_tensor` are
+    present, this pass has no effect.
+
+    Returns
+    -------
+    ret : tvm.ir.transform.Pass
+    """
+    return _ffi_api.LowerAllocTensor()  # type: ignore
+
+
 def KillAfterLastUse() -> tvm.ir.transform.Pass:
     """Drop all tensor/storage objects after last use
 

--- a/python/tvm/relax/vm_build.py
+++ b/python/tvm/relax/vm_build.py
@@ -314,8 +314,8 @@ def build(
     if tvm.transform.PassContext.current().config.get("relax.backend.use_cuda_graph", False):
         passes.append(relax.transform.RewriteCUDAGraph())
 
-    passes.append(relax.transform.KillAfterLastUse())
     passes.append(relax.transform.LowerAllocTensor())
+    passes.append(relax.transform.KillAfterLastUse())
 
     passes.append(relax.transform.VMBuiltinLower())
     passes.append(relax.transform.VMShapeLower())

--- a/python/tvm/relax/vm_build.py
+++ b/python/tvm/relax/vm_build.py
@@ -310,10 +310,12 @@ def build(
     passes.append(relax.transform.RemovePurityChecking())
     passes.append(relax.transform.CallTIRRewrite())
     passes.append(relax.transform.StaticPlanBlockMemory())
-    passes.append(relax.transform.KillAfterLastUse())
 
     if tvm.transform.PassContext.current().config.get("relax.backend.use_cuda_graph", False):
         passes.append(relax.transform.RewriteCUDAGraph())
+
+    passes.append(relax.transform.KillAfterLastUse())
+    passes.append(relax.transform.LowerAllocTensor())
 
     passes.append(relax.transform.VMBuiltinLower())
     passes.append(relax.transform.VMShapeLower())

--- a/src/relax/transform/lower_alloc_tensor.cc
+++ b/src/relax/transform/lower_alloc_tensor.cc
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file src/relax/transform/lower_alloc_tensor.cc
+ * \brief Lower any relax.builtin.alloc_tensor remaining after static planning
+ */
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/transform.h>
+
+namespace tvm {
+namespace relax {
+
+namespace {
+class Mutator : public ExprMutator {
+  using ExprMutator::VisitExpr_;
+  Expr VisitExpr_(const CallNode* op) override {
+    static const Op& alloc_tensor_op = Op::Get("relax.builtin.alloc_tensor");
+    static const Op& mem_alloc_storage_op = Op::Get("relax.memory.alloc_storage");
+    static const Op& mem_alloc_tensor_op = Op::Get("relax.memory.alloc_tensor");
+
+    if (op->op.same_as(alloc_tensor_op)) {
+      CHECK_EQ(op->args.size(), 3) << "Op " << op->op << " should have three arguments, "
+                                   << "[shape, dtype, runtime_device_index].  "
+                                   << "However, received " << GetRef<Call>(op);
+
+      auto shape_arg = op->args[0];
+      auto dtype = Downcast<DataTypeImm>(op->args[1]);
+      PrimValue runtime_device_index = Downcast<PrimValue>(op->args[2]);
+      std::string storage_scope = "global";
+
+      auto shape = [&]() -> Array<PrimExpr> {
+        if (auto ptr = shape_arg.as<ShapeExprNode>()) {
+          return ptr->values;
+        }
+
+        auto sinfo = GetStructInfo(shape_arg);
+        if (auto ptr = sinfo.as<ShapeStructInfoNode>()) {
+          if (ptr->values) {
+            return ptr->values.value();
+          }
+        }
+
+        LOG(FATAL) << "Shape argument for " << alloc_tensor_op << " should be a ShapeExpr, "
+                   << "or a variable that holds a ShapeExpr.  "
+                   << "However, received argument " << shape_arg << " with struct info " << sinfo;
+      }();
+
+      PrimExpr nbytes = [&]() -> PrimExpr {
+        PrimExpr nbytes = tir::make_const(DataType::Int(64), dtype->value.bytes());
+        for (const auto& dim : shape) {
+          nbytes *= dim;
+        }
+        return nbytes;
+      }();
+
+      auto offset = PrimValue::Int64(0);
+
+      Expr storage = relax::Call(mem_alloc_storage_op,
+                                 {ShapeExpr({nbytes}), runtime_device_index,
+                                  StringImm(storage_scope), DataTypeImm(DataType::UInt(8))});
+      storage = builder_->Emit(storage, "storage");
+      Expr tensor = relax::Call(mem_alloc_tensor_op, {storage, offset, shape_arg, dtype});
+      return tensor;
+    } else {
+      return ExprMutator::VisitExpr_(op);
+    }
+  }
+};
+}  // namespace
+
+Expr LowerAllocTensor(Expr expr) {
+  Mutator mutator;
+  return mutator(expr);
+}
+
+namespace transform {
+
+Pass LowerAllocTensor() {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
+      [=](Function func, IRModule m, PassContext pc) {
+        return Downcast<Function>(relax::LowerAllocTensor(std::move(func)));
+      };
+  return CreateFunctionPass(pass_func, /*opt_level=*/0, "LowerAllocTensor", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.LowerAllocTensor").set_body_typed(LowerAllocTensor);
+
+}  // namespace transform
+}  // namespace relax
+}  // namespace tvm

--- a/tests/python/relax/test_lower_alloc_tensor.py
+++ b/tests/python/relax/test_lower_alloc_tensor.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+
+from tvm.script import ir as I, relax as R
+
+from tvm.relax.transform import LowerAllocTensor
+
+
+def test_basic():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main():
+            x = R.builtin.alloc_tensor(R.shape([16, 32]), "float32", 0)
+            return x
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main():
+            storage = R.memory.alloc_storage(R.shape([2048]), 0, "global", "uint8")
+            x = R.memory.alloc_tensor(storage, 0, R.shape([16, 32]), "float32")
+            return x
+
+    After = LowerAllocTensor()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_transform_static_plan_block_memory.py
+++ b/tests/python/relax/test_transform_static_plan_block_memory.py
@@ -190,6 +190,7 @@ def test_basic():
 
     mod = relax.transform.StaticPlanBlockMemory()(Module)
     tvm.ir.assert_structural_equal(mod, Expected)
+    mod = relax.transform.LowerAllocTensor()(mod)
     mod = relax.transform.VMBuiltinLower()(mod)
     tvm.ir.assert_structural_equal(mod, ExpectedLowered)
 

--- a/tests/python/relax/test_vm_builtin_lower.py
+++ b/tests/python/relax/test_vm_builtin_lower.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import tvm
+from tvm import relax
+
+import tvm.script
+from tvm.script import ir as I, relax as R, tir as T
+
+
+def test_vm_builtin_lower_mem_alloc_storage():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor:
+            R.func_attr({"relax.force_pure": True})
+            m, n = T.int64(), T.int64()
+
+            storage = R.memory.alloc_storage(R.shape([m * n * 4]), 0, "global", "uint8")
+            alloc = R.memory.alloc_tensor(storage, 0, R.shape([m, n]), "float32")
+            _ = R.call_packed(
+                "test.op.identity", x, alloc, sinfo_args=(R.Tensor(ndim=2, dtype="float32"))
+            )
+            gv0 = alloc
+            return gv0
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor:
+            # we expected RemovePurityChecking to have been called first
+            R.func_attr({"relax.force_pure": True})
+            m, n = T.int64(), T.int64()
+
+            storage = R.vm.alloc_storage(R.shape([m * n * 4]), R.prim_value(0), "uint8", "global")
+            alloc = R.vm.alloc_tensor(storage, R.prim_value(0), R.shape([m, n]), "float32")
+
+            _ = R.call_packed(
+                "test.op.identity", x, alloc, sinfo_args=(R.Tensor(ndim=2, dtype="float32"))
+            )
+            gv0 = alloc
+            return gv0
+
+    After = relax.transform.VMBuiltinLower()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
+
+
+def test_vm_builtin_alloc_tensor_raises_error():
+    """R.builtin.alloc_tensor should be handled earlier"""
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor:
+            R.func_attr({"relax.force_pure": True})
+            m, n = T.int64(), T.int64()
+
+            alloc = R.builtin.alloc_tensor(R.shape([m, n]), runtime_device_index=0, dtype="float32")
+            _ = R.call_packed(
+                "test.op.identity", x, alloc, sinfo_args=(R.Tensor(ndim=2, dtype="float32"))
+            )
+            gv0 = alloc
+            return gv0
+
+    with pytest.raises(tvm.TVMError):
+        relax.transform.VMBuiltinLower()(Before)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
The `StaticPlanBlockMemory` transform is provided a module that expresses all allocations with `R.builtin.alloc_tensor`, and produces a module that uses `R.memory.alloc_storage` and
`R.memory.alloc_tensor` to express static allocations, while dynamic allocations continue to use `R.builtin.alloc_tensor`.

Prior to this commit, this mixed output was handled as part of `VMBuiltinLower`. This commit extracts the lowering of `R.builtin.alloc_tensor` to a new pass, `LowerAllocTensor`.  This pass runs after `StaticPlanBlockMemory`, and replaces any remaining `R.builtin.alloc_tensor` with calls to `R.memory.alloc_storage` and `R.memory.alloc_tensor`.