### PR TITLE
[Unity][Frontend][NN] Switch to always using fp32 for timestep embedding calculation

### DIFF
--- a/tests/python/relax/test_frontend_nn_modules.py
+++ b/tests/python/relax/test_frontend_nn_modules.py
@@ -402,8 +402,9 @@ def test_timesteps():
             lv8: R.Tensor((3, 5), dtype="float32") = R.multiply(lv2, lv7)
             lv9: R.Tensor((3, 5), dtype="float32") = R.sin(lv8)
             lv10: R.Tensor((3, 5), dtype="float32") = R.cos(lv8)
-            get_timestep_embedding: R.Tensor((3, 10), dtype="float32") = R.concat(
-                (lv9, lv10), axis=-1
+            lv11: R.Tensor((3, 10), dtype="float32") = R.concat((lv9, lv10), axis=-1)
+            get_timestep_embedding: R.Tensor((3, 10), dtype="float32") = R.astype(
+                lv11, dtype="float32"
             )
             gv1: R.Tuple(
                 R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Object)

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -386,8 +386,9 @@ def test_timestep_embedding():
             lv8: R.Tensor((3, 5), dtype="float32") = R.multiply(lv2, lv7)
             lv9: R.Tensor((3, 5), dtype="float32") = R.sin(lv8)
             lv10: R.Tensor((3, 5), dtype="float32") = R.cos(lv8)
-            get_timestep_embedding: R.Tensor((3, 10), dtype="float32") = R.concat(
-                (lv9, lv10), axis=-1
+            lv11: R.Tensor((3, 10), dtype="float32") = R.concat((lv9, lv10), axis=-1)
+            get_timestep_embedding: R.Tensor((3, 10), dtype="float32") = R.astype(
+                lv11, dtype="float32"
             )
             gv1: R.Tuple(
                 R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Object)


### PR DESCRIPTION
It turns out that using datatypes besides `float32` when calculating timestep embeddings leads to substantial errors. The diffusers library just hard casts to float32 to avoid this and we should too.