### PR TITLE
[Unity][MSC][pre M1.2] Reconstruct codegen

### DIFF
--- a/python/tvm/contrib/msc/core/codegen/__init__.py
+++ b/python/tvm/contrib/msc/core/codegen/__init__.py
@@ -17,3 +17,4 @@
 """tvm.contrib.msc.core.codegen"""
 
 from .codegen import *
+from .sources import *

--- a/python/tvm/contrib/msc/core/codegen/sources.py
+++ b/python/tvm/contrib/msc/core/codegen/sources.py
@@ -1,0 +1,184 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.core.codegen.sources"""
+
+from typing import Dict
+
+
+def get_base_h_code() -> str:
+    """Create base header file codes
+
+    Returns
+    -------
+    source: str
+        The base header source.
+    """
+
+    return """#ifndef TVM_CONTRIB_MSC_UTILS_BASE_H_
+#define TVM_CONTRIB_MSC_UTILS_BASE_H_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+class FileUtils {
+ public:
+  static inline bool FileExist(const std::string& file);
+
+  template <typename T>
+  static bool ReadToBuffer(const std::string& file, T* buffer, size_t size);
+};
+
+class DatasetReader {
+ public:
+  DatasetReader(const std::string& folder, int max_size = -1);
+
+  void Reset();
+
+  bool ReadNext(void* buffers[], int num_datas = -1);
+
+ private:
+  std::string folder_;
+  size_t max_size_;
+  size_t cur_cnt_;
+  std::vector<std::pair<std::string, size_t>> tensor_info_;
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+
+#endif  // TVM_CONTRIB_MSC_UTILS_BASE_H_
+"""
+
+
+def get_base_cc_code() -> str:
+    """Create base cc file codes
+
+    Returns
+    -------
+    source: str
+        The base cc source.
+    """
+
+    return """#include "base.h"
+
+#include <algorithm>
+#include <fstream>
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+bool FileUtils::FileExist(const std::string& file) {
+  std::ifstream in_file(file, std::ifstream::binary);
+  if (in_file.is_open()) {
+    in_file.close();
+    return true;
+  }
+  return false;
+}
+
+template <typename T>
+bool FileUtils::ReadToBuffer(const std::string& file, T* buffer, size_t size) {
+  std::ifstream in_file(file, std::ifstream::binary);
+  if (!in_file.is_open()) {
+    return false;
+  }
+  try {
+    in_file.read((char*)(&buffer[0]), size * sizeof(T));
+  } catch (std::exception const& e) {
+    in_file.close();
+    return false;
+  }
+  in_file.close();
+  return true;
+}
+
+DatasetReader::DatasetReader(const std::string& folder, int max_size) {
+  folder_ = folder;
+  const std::string info_file = folder_ + "/tensor_info";
+  std::ifstream input(info_file, std::ios::binary);
+  assert(input.is_open() && ("Failed to open file " + info_file).c_str());
+  std::string line;
+  while (getline(input, line)) {
+    int pos = line.find(":");
+    assert(pos > 0 && ("Can not find : in line " + line).c_str());
+    const auto& name = line.substr(0, pos);
+    const auto& byte_size = line.substr(pos + 1, line.size());
+    tensor_info_.push_back(std::make_pair(name, static_cast<size_t>(std::stoi(byte_size))));
+  }
+  size_t file_cnt = 0;
+  while (true) {
+    bool all_exists = true;
+    for (const auto& pair : tensor_info_) {
+      const auto& d_file =
+          folder_ + "/" + pair.first + "/batch_" + std::to_string(file_cnt) + ".bin";
+      if (!FileUtils::FileExist(d_file)) {
+        all_exists = false;
+        break;
+      }
+    }
+    if (!all_exists) {
+      break;
+    }
+    file_cnt++;
+  }
+  max_size_ = max_size > 0 ? static_cast<size_t>(max_size) : file_cnt;
+  max_size_ = std::min(max_size_, file_cnt);
+  Reset();
+}
+
+void DatasetReader::Reset() { cur_cnt_ = 0; }
+
+bool DatasetReader::ReadNext(void* buffers[], int num_datas) {
+  if (cur_cnt_ >= max_size_) {
+    return false;
+  }
+  size_t max_num = num_datas > 0 ? static_cast<size_t>(num_datas) : tensor_info_.size();
+  max_num = std::min(max_num, tensor_info_.size());
+  for (size_t i = 0; i < max_num; i++) {
+    const auto& pair = tensor_info_[i];
+    const auto& d_file = folder_ + "/" + pair.first + "/batch_" + std::to_string(cur_cnt_) + ".bin";
+    if (!FileUtils::ReadToBuffer(d_file, (char*)buffers[i], pair.second)) {
+      return false;
+    }
+  }
+  cur_cnt_++;
+  return true;
+}
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+"""
+
+
+def get_base_sources() -> Dict[str, str]:
+    """Create base sources for cpp codegen
+
+    Returns
+    -------
+    sources: dict<str,str>
+        The base utils sources.
+    """
+
+    return {"base.h": get_base_h_code(), "base.cc": get_base_cc_code()}

--- a/python/tvm/contrib/msc/core/ir/graph.py
+++ b/python/tvm/contrib/msc/core/ir/graph.py
@@ -210,6 +210,22 @@ class MSCJoint(BaseJoint):
 
         return _ffi_api.MSCJointOutputAt(self, idx)
 
+    def weight_at(self, wtype: str) -> MSCTensor:
+        """Get weight from reference.
+
+        Parameters
+        ----------
+        wtype: str
+            The type of weight.
+
+        Returns
+        -------
+        weight: MSCTensor
+            The weight Tensor.
+        """
+
+        return _ffi_api.MSCJointWeightAt(self, wtype)
+
     def get_inputs(self) -> List[MSCTensor]:
         """Get all the inputs.
 
@@ -242,7 +258,7 @@ class MSCJoint(BaseJoint):
         """
 
         src_weights = _ffi_api.MSCJointGetWeights(self)
-        return {ref: src_weights[ref] for ref in src_weights}
+        return {wtype: src_weights[wtype] for wtype in src_weights}
 
     def get_attrs(self) -> Dict[str, str]:
         """Get all the attributes from node
@@ -406,6 +422,22 @@ class MSCGraph(BaseGraph):
             output_names,
         )
 
+    def has_node(self, name: str) -> bool:
+        """Check if node in the graph.
+
+        Parameters
+        ----------
+        name: string
+            The name of the node.
+
+        Returns
+        -------
+        has_node: bool
+            Whether the node is in the graph
+        """
+
+        return bool(_ffi_api.MSCGraphHasNode(self, name))
+
     def find_node(self, name: str) -> MSCJoint:
         """Find node by name.
 
@@ -421,6 +453,22 @@ class MSCGraph(BaseGraph):
         """
 
         return _ffi_api.MSCGraphFindNode(self, name)
+
+    def has_tensor(self, name: str) -> bool:
+        """Check if tensor in the graph.
+
+        Parameters
+        ----------
+        name: string
+            The name of the tensor.
+
+        Returns
+        -------
+        has_tensor: bool
+            Whether the tensor is in the graph
+        """
+
+        return bool(_ffi_api.MSCGraphHasTensor(self, name))
 
     def find_tensor(self, name: str) -> MSCTensor:
         """Find tensor by name.

--- a/python/tvm/contrib/msc/core/transform/transform.py
+++ b/python/tvm/contrib/msc/core/transform/transform.py
@@ -22,7 +22,9 @@ from tvm.relax.transform import _ffi_api as relax_api
 from tvm.relay.transform import _ffi_api as relay_api
 
 
-def SetExprName(as_relax=True, entry_name="main") -> tvm.ir.transform.Pass:
+def SetExprName(
+    as_relax: bool = True, entry_name: str = "main", target: str = ""
+) -> tvm.ir.transform.Pass:
     """Set name for the call and constant in IRModule.
 
     Parameters
@@ -31,7 +33,8 @@ def SetExprName(as_relax=True, entry_name="main") -> tvm.ir.transform.Pass:
         Whether set names for relax, otherwise for relay.
     entry_name: str
         The entry name
-
+    target: str
+        The target prefix for target functions
 
     Returns
     -------
@@ -39,11 +42,33 @@ def SetExprName(as_relax=True, entry_name="main") -> tvm.ir.transform.Pass:
     """
 
     if as_relax:
-        return relax_api.SetRelaxExprName(entry_name)  # type: ignore
+        return relax_api.SetRelaxExprName(entry_name, target)  # type: ignore
     return relay_api.SetRelayExprName(entry_name)  # type: ignore
 
 
-def SetExprLayout(allow_missing=True, entry_name="main") -> tvm.ir.transform.Pass:
+def BindExprName(
+    name_key: str = "", seperator: str = ",", entry_name: str = "main"
+) -> tvm.ir.transform.Pass:
+    """Bind name for the call and constant in IRModule.
+
+    Parameters
+    ----------
+    name_key: str
+        The key to find name
+    seperator: str
+        The seperator
+    entry_name: str
+        The entry name
+
+    Returns
+    -------
+    ret: tvm.ir.transform.Pass
+    """
+
+    return relay_api.BindRelayExprName(name_key, seperator, entry_name)  # type: ignore
+
+
+def SetExprLayout(allow_missing: bool = True, entry_name: str = "main") -> tvm.ir.transform.Pass:
     """Set layout for the var and constant in IRModule.
 
     Parameters

--- a/python/tvm/contrib/msc/core/utils/file.py
+++ b/python/tvm/contrib/msc/core/utils/file.py
@@ -59,7 +59,7 @@ class MSCDirectory(object):
         if self._cleanup and os.path.isdir(self._path):
             shutil.rmtree(self._path)
 
-    def add_file(self, name: str, contains: str):
+    def add_file(self, name: str, contains: str) -> str:
         """Add a file under the folder
 
         Parameters
@@ -72,11 +72,85 @@ class MSCDirectory(object):
         Returns
         -------
         path: str
-            The concatenated path.
+            The abs file path.
         """
 
-        with open(self.relpath(name), "w") as f:
+        file_path = self.relpath(name)
+        with open(file_path, "w") as f:
             f.write(contains)
+        return file_path
+
+    def move_file(self, src_file: str, dst_folder: object, dst_file: str = None):
+        """Move a file to another folder
+
+        Parameters
+        ----------
+        src_file: str
+            The name of the source file.
+        dst_folder: MSCDirectory
+            The target folder.
+        dst_file: str
+            The target file name.
+
+        Returns
+        -------
+        path: str
+            The abs file path.
+        """
+
+        src_path = os.path.join(self.relpath(src_file))
+        assert os.path.isfile(src_path), "Source file {} not exist".format(src_path)
+        dst_path = dst_folder.relpath(dst_file or src_file)
+        os.rename(src_path, dst_path)
+        return dst_path
+
+    def copy_file(self, src_file: str, dst_folder: object, dst_file: str = None):
+        """Copy a file to another folder
+
+        Parameters
+        ----------
+        src_file: str
+            The name of the source file.
+        dst_folder: MSCDirectory
+            The target folder.
+        dst_file: str
+            The target file name.
+
+        Returns
+        -------
+        path: str
+            The abs file path.
+        """
+
+        src_path = os.path.join(self.relpath(src_file))
+        assert os.path.isfile(src_path), "Source file {} not exist".format(src_path)
+        dst_path = dst_folder.relpath(dst_file or src_file)
+        shutil.copy2(src_path, dst_path)
+        return dst_path
+
+    def create_dir(self, name: str, keep_history: bool = True, cleanup: bool = False) -> object:
+        """Add a dir under the folder
+
+        Parameters
+        ----------
+        name: str
+            The name of the file.
+        keep_history: bol
+            Whether to keep history.
+        cleanup: bool
+            Whether to clean up before exit.
+
+
+        Returns
+        -------
+        dir: MSCDirectory
+            The created dir.
+        """
+
+        dir_path = self.relpath(name)
+        if os.path.isfile(dir_path):
+            os.remove(dir_path)
+        return self.__class__(dir_path, keep_history=keep_history, cleanup=cleanup)
 
     def relpath(self, name: str) -> str:
         """Relative path in dir

--- a/python/tvm/contrib/msc/core/utils/info.py
+++ b/python/tvm/contrib/msc/core/utils/info.py
@@ -18,6 +18,11 @@
 
 import os
 import json
+from typing import List
+from distutils.version import LooseVersion
+
+import tvm
+from .namespace import MSCFramework
 
 
 def load_dict(str_dict: str, flavor: str = "json") -> dict:
@@ -96,3 +101,38 @@ def dict_equal(dict_a: dict, dict_b: dict) -> bool:
         if v != dict_b[k]:
             return False
     return True
+
+
+def get_version(framework: str) -> List[int]:
+    """Get the version list of framework.
+
+    Parameters
+    ----------
+    framework: string
+        Should be from MSCFramework.
+
+    Returns
+    -------
+    version: list<int>
+        The version in <major,minor,patch>.
+    """
+
+    try:
+        if framework in (MSCFramework.MSC, MSCFramework.TVM):
+            raw_version = tvm.__version__
+        elif framework == MSCFramework.TORCH:
+            import torch  # pylint: disable=import-outside-toplevel
+
+            raw_version = torch.__version__
+        elif framework == MSCFramework.TENSORFLOW:
+            import tensorflow  # pylint: disable=import-outside-toplevel
+
+            raw_version = tensorflow.__version
+        if framework == MSCFramework.TENSORRT:
+            raw_version = ".".join(tvm.get_global_func("relax.get_tensorrt_version")())
+        else:
+            raw_version = "1.0.0"
+    except:  # pylint: disable=bare-except
+        raw_version = "1.0.0"
+
+    return LooseVersion(raw_version).version

--- a/python/tvm/contrib/msc/core/utils/namespace.py
+++ b/python/tvm/contrib/msc/core/utils/namespace.py
@@ -63,3 +63,5 @@ class MSCFramework:
     MSC = "msc"
     TVM = "tvm"
     TORCH = "torch"
+    TENSORFLOW = "tensorflow"
+    TENSORRT = "tensorrt"

--- a/python/tvm/contrib/msc/framework/torch/codegen/codegen.py
+++ b/python/tvm/contrib/msc/framework/torch/codegen/codegen.py
@@ -69,4 +69,4 @@ def to_torch(
         return model
 
     codegen = CodeGen(graph, _ffi_api.GetTorchSources, codegen_config, print_config, build_folder)
-    return codegen.load([], _bind_weights)
+    return codegen.load([], post_load=_bind_weights)

--- a/python/tvm/contrib/msc/framework/tvm/codegen/codegen.py
+++ b/python/tvm/contrib/msc/framework/tvm/codegen/codegen.py
@@ -67,4 +67,4 @@ def to_relax(
         return mod
 
     codegen = CodeGen(graph, _ffi_api.GetRelaxSources, codegen_config, print_config, build_folder)
-    return codegen.load(inputs, _bind_weights)
+    return codegen.load(inputs, post_load=_bind_weights)

--- a/src/contrib/msc/core/codegen/base_codegen.h
+++ b/src/contrib/msc/core/codegen/base_codegen.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <stack>
 #include <string>
+#include <vector>
 
 #include "../ir/graph.h"
 #include "code_stack.h"
@@ -61,32 +62,38 @@ class BaseOpCode {
     config_ = config;
   }
 
+  /*! \brief Get docs for the node*/
+  virtual const Array<Doc> GetDocs() = 0;
+
   /*! \brief Get return describe for default node*/
-  virtual const String IdxNode(bool as_raw = true) { return IdxNode(node_, as_raw); }
+  virtual const String IdxNode(bool as_raw = true) { return IdxNodeBase(node_, as_raw); }
 
   /*! \brief Get describe for default node input*/
-  virtual const String IdxInput(int idx = 0, bool as_raw = false) {
-    return IdxInput(node_, idx, as_raw);
+  const String IdxInput(int idx = 0, bool as_raw = false) {
+    return IdxInputBase(node_, idx, as_raw);
   }
 
   /*! \brief Get describe for default node output*/
-  virtual const String IdxOutput(int idx = 0, bool as_raw = false) {
-    return IdxOutput(node_, idx, as_raw);
+  const String IdxOutput(int idx = 0, bool as_raw = false) {
+    return IdxOutputBase(node_, idx, as_raw);
   }
 
   /*! \brief Get describe for default node weight*/
-  virtual const String IdxWeight(const String& wtype, bool as_raw = false) {
-    return IdxWeight(node_, wtype, as_raw);
+  const String IdxWeight(const String& wtype, bool as_raw = false) {
+    return IdxWeightBase(node_, wtype, as_raw);
   }
 
   /*! \brief Get comment for default node*/
-  virtual const String Comment() { return Comment(node_); }
+  const String Comment() { return Comment(node_); }
 
   /*! \brief Get func_name for the default node*/
   const String func_name() { return func_name_; }
 
   /*! \brief Get valid func name for the default node*/
   virtual const String callee_name() { return func_name(); }
+
+  /*! \brief Get valid return name for the default node*/
+  virtual const String ret_name() { return IdxNode(true); }
 
   /*! \brief Get the default node*/
   const MSCJoint node() { return node_; }
@@ -162,6 +169,26 @@ class BaseCodeGen {
       LOG(FATAL) << "Unexpected node scope " << node->scope << " with current scope "
                  << scopes_.top();
     }
+  }
+
+  /*!
+   * \brief Compare version with version in config
+   * 0 for same version, 1 for greater version, -1 for less version
+   */
+  int CompareVersion(size_t major, size_t minor, size_t patch) {
+    if (config_->version.size() == 0) {
+      return 0;
+    }
+    ICHECK_EQ(config_->version.size(), 3) << "Version should be in format major,minor,patch";
+    std::vector<size_t> given_version{major, minor, patch};
+    for (size_t i = 0; i < 3; i++) {
+      if (given_version[i] > config_->version[i]) {
+        return 1;
+      } else if (given_version[i] < config_->version[i]) {
+        return -1;
+      }
+    }
+    return 0;
   }
 
   /*! \brief Get the docs for the op*/

--- a/src/contrib/msc/core/codegen/codegen_utils.h
+++ b/src/contrib/msc/core/codegen/codegen_utils.h
@@ -28,6 +28,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "../ir/graph.h"
 #include "../utils.h"
@@ -49,7 +50,7 @@ using namespace tvm::script::printer;
   std::string test_device{"cpu"};          \
   std::string prefix{"res_"};              \
   std::string baseline_folder{"baseline"}; \
-  std::string version;
+  std::vector<size_t> version{0, 0, 0};
 
 #define CODEGEN_CONFIG_PARSE                    \
   if (key == "is_train") {                      \
@@ -80,34 +81,34 @@ using namespace tvm::script::printer;
     LOG(FATAL) << "Do not support key " << key; \
   }
 
-#define CODEGEN_MEMBERS                                                                            \
- public:                                                                                           \
-  virtual const Array<Doc> GetDocs() = 0;                                                          \
-                                                                                                   \
- protected:                                                                                        \
-  const std::shared_ptr<ConfigType> config() { return config_; }                                   \
-  const String GetSuffix(bool as_raw = false) {                                                    \
-    const String& suffix = as_raw && config()->need_process ? "_raw" : "";                         \
-    return suffix;                                                                                 \
-  }                                                                                                \
-  virtual const String IdxNode(const MSCJoint& node, bool as_raw = true) {                         \
-    return CodeGenUtils::IdxNode(node, config()->prefix, GetSuffix(as_raw));                       \
-  }                                                                                                \
-  virtual const String IdxInput(const MSCJoint& node, int idx = 0, bool as_raw = false) {          \
-    return CodeGenUtils::IdxInput(node, config()->prefix, idx, GetSuffix(as_raw));                 \
-  }                                                                                                \
-  virtual const String IdxOutput(const MSCJoint& node, int idx = 0, bool as_raw = false) {         \
-    return CodeGenUtils::IdxOutput(node, config()->prefix, idx, GetSuffix(as_raw));                \
-  }                                                                                                \
-  virtual const String IdxWeight(const MSCJoint& node, const String& wtype, bool as_raw = false) { \
-    return CodeGenUtils::IdxWeight(node, wtype, GetSuffix(as_raw));                                \
-  }                                                                                                \
-  virtual const String DType(const DataType& dtype) { return runtime::DLDataType2String(dtype); }  \
-  virtual const String Comment(const MSCJoint& node) {                                             \
-    return CodeGenUtils::CommentNode(node, config()->prefix);                                      \
-  }                                                                                                \
-                                                                                                   \
- private:                                                                                          \
+#define CODEGEN_MEMBERS                                                                           \
+ public:                                                                                          \
+  virtual const String DType(const DataType& dtype) { return runtime::DLDataType2String(dtype); } \
+                                                                                                  \
+ protected:                                                                                       \
+  const std::shared_ptr<ConfigType> config() { return config_; }                                  \
+  const String GetSuffix(bool as_raw = false) {                                                   \
+    const String& suffix = as_raw && config()->need_process ? "_raw" : "";                        \
+    return suffix;                                                                                \
+  }                                                                                               \
+  virtual const String IdxNodeBase(const MSCJoint& node, bool as_raw = true) {                    \
+    return CodeGenUtils::IdxNode(node, config()->prefix, GetSuffix(as_raw));                      \
+  }                                                                                               \
+  virtual const String IdxInputBase(const MSCJoint& node, int idx = 0, bool as_raw = false) {     \
+    return CodeGenUtils::IdxInput(node, config()->prefix, idx, GetSuffix(as_raw));                \
+  }                                                                                               \
+  virtual const String IdxOutputBase(const MSCJoint& node, int idx = 0, bool as_raw = false) {    \
+    return CodeGenUtils::IdxOutput(node, config()->prefix, idx, GetSuffix(as_raw));               \
+  }                                                                                               \
+  virtual const String IdxWeightBase(const MSCJoint& node, const String& wtype,                   \
+                                     bool as_raw = false) {                                       \
+    return CodeGenUtils::IdxWeight(node, wtype, GetSuffix(as_raw));                               \
+  }                                                                                               \
+  virtual const String Comment(const MSCJoint& node) {                                            \
+    return CodeGenUtils::CommentNode(node, config()->prefix);                                     \
+  }                                                                                               \
+                                                                                                  \
+ private:                                                                                         \
   std::shared_ptr<ConfigType> config_;
 
 /*!

--- a/src/contrib/msc/core/ir/graph.h
+++ b/src/contrib/msc/core/ir/graph.h
@@ -628,6 +628,8 @@ class MSCGraphNode : public BaseGraphNode {
   const Array<MSCJoint> GetEntries() const;
   /*! \brief Get exits from the graph. */
   const Array<MSCJoint> GetExits() const;
+  /*! \brief Check if tensor in the graph. */
+  const bool HasTensor(const String& name) const;
   /*! \brief Find tensor from the graph. */
   const MSCTensor FindTensor(const String& name) const;
   /*! \brief Find producer of tensor from the graph. */

--- a/src/contrib/msc/core/ir/graph_builder.cc
+++ b/src/contrib/msc/core/ir/graph_builder.cc
@@ -57,7 +57,7 @@ void RelaxFuncParamsFinder::VisitExpr_(const relax::CallNode* call_node) {
   relax::Function func;
   if (const auto* v_node = call_node->op.as<GlobalVarNode>()) {
     func = Downcast<relax::Function>(ref_module_->Lookup(v_node->name_hint));
-  } else if (const auto* v_node = call_node->op.as<relax::VarNode>()) {
+  } else if (call_node->op.as<relax::VarNode>()) {
     ICHECK(local_funcs_.count(call_node->op)) << "Can not find local func " << call_node->op;
     func = local_funcs_[call_node->op];
   }
@@ -160,7 +160,7 @@ const MSCJoint RelaxGraphBuilder::AddNode(const Expr& expr, const Optional<Expr>
       const auto& name_opt = func->GetAttr<runtime::String>(relax::attr::kComposite);
       ICHECK(name_opt.defined()) << "Unexpected global func without composite";
       optype = name_opt.value();
-    } else if (const auto* v_node = call_node->op.as<relax::VarNode>()) {
+    } else if (call_node->op.as<relax::VarNode>()) {
       ICHECK(target_funcs_.count(call_node->op)) << "Can not find target func: " << call_node->op;
       const auto& func = target_funcs_[call_node->op];
       const auto& name_opt = func->GetAttr<runtime::String>(relax::attr::kComposite);

--- a/src/contrib/msc/core/ir/graph_builder.cc
+++ b/src/contrib/msc/core/ir/graph_builder.cc
@@ -47,6 +47,32 @@ void RelaxFuncAttrGetter::VisitExpr_(const relax::CallNode* op) {
   }
 }
 
+void RelaxFuncParamsFinder::VisitBinding_(const relax::VarBindingNode* binding,
+                                          const relax::FunctionNode* val) {
+  local_funcs_.Set(binding->var, GetRef<relax::Function>(val));
+}
+
+void RelaxFuncParamsFinder::VisitExpr_(const relax::CallNode* call_node) {
+  RelaxExprVisitor::VisitExpr_(call_node);
+  relax::Function func;
+  if (const auto* v_node = call_node->op.as<GlobalVarNode>()) {
+    func = Downcast<relax::Function>(ref_module_->Lookup(v_node->name_hint));
+  } else if (const auto* v_node = call_node->op.as<relax::VarNode>()) {
+    ICHECK(local_funcs_.count(call_node->op)) << "Can not find local func " << call_node->op;
+    func = local_funcs_[call_node->op];
+  }
+  if (func.defined()) {
+    for (size_t i = 0; i < call_node->args.size(); i++) {
+      const auto& arg = call_node->args[i];
+      if (arg->IsInstance<relax::VarNode>() && params_.count(Downcast<relax::Var>(arg))) {
+        params_.Set(func->params[i], params_[Downcast<relax::Var>(arg)]);
+      } else {
+        params_.Set(func->params[i], arg);
+      }
+    }
+  }
+}
+
 const MSCGraph RelaxGraphBuilder::Build(const relax::Function& func) {
   // Add input nodes and record inputs;
   Array<String> input_names, output_names;
@@ -64,21 +90,32 @@ const MSCGraph RelaxGraphBuilder::Build(const relax::Function& func) {
   }
   // remove const nodes as weights
   Array<MSCJoint> valid_nodes;
+  std::set<String> ignore_inputs;
   for (const auto& n : nodes_) {
-    if (!weights_.count(n->name)) {
+    if (!weights_.count(n->name) && !ignore_nodes_.count(n->name)) {
       n->index = valid_nodes.size();
       valid_nodes.push_back(n);
+    } else if (n->optype == "input") {
+      ignore_inputs.insert(n->OutputAt(0)->name);
     }
   }
-  const auto& graph = MSCGraph(name_, valid_nodes, input_names, output_names);
+  // remove uselese inputs
+  Array<String> valid_inputs;
+  for (const auto& i : input_names) {
+    if (!ignore_inputs.count(i)) {
+      valid_inputs.push_back(i);
+    }
+  }
+  // build graph
+  const auto& graph = MSCGraph(name_, valid_nodes, valid_inputs, output_names);
   // set inputs and outputs alias
-  if (config_.input_aliases.size() == input_names.size()) {
-    for (size_t i = 0; i < input_names.size(); i++) {
-      graph->FindTensor(input_names[i])->alias = config_.input_aliases[i];
+  if (config_.input_aliases.size() == valid_inputs.size()) {
+    for (size_t i = 0; i < valid_inputs.size(); i++) {
+      graph->FindTensor(valid_inputs[i])->alias = config_.input_aliases[i];
     }
   } else {
-    for (size_t i = 0; i < input_names.size(); i++) {
-      graph->FindTensor(input_names[i])->alias = graph->FindProducer(input_names[i])->name;
+    for (size_t i = 0; i < valid_inputs.size(); i++) {
+      graph->FindTensor(valid_inputs[i])->alias = graph->FindProducer(valid_inputs[i])->name;
     }
   }
   if (config_.output_aliases.size() == output_names.size()) {
@@ -123,6 +160,11 @@ const MSCJoint RelaxGraphBuilder::AddNode(const Expr& expr, const Optional<Expr>
       const auto& name_opt = func->GetAttr<runtime::String>(relax::attr::kComposite);
       ICHECK(name_opt.defined()) << "Unexpected global func without composite";
       optype = name_opt.value();
+    } else if (const auto* v_node = call_node->op.as<relax::VarNode>()) {
+      ICHECK(target_funcs_.count(call_node->op)) << "Can not find target func: " << call_node->op;
+      const auto& func = target_funcs_[call_node->op];
+      const auto& name_opt = func->GetAttr<runtime::String>(relax::attr::kComposite);
+      optype = StringUtils::Replace(name_opt.value(), config_.target + ".", "");
     } else if (const auto* f_node = call_node->op.as<relax::FunctionNode>()) {
       const auto& name_opt = f_node->GetAttr<runtime::String>(relax::attr::kComposite);
       ICHECK(name_opt.defined()) << "Unexpected func without composite";
@@ -138,6 +180,10 @@ const MSCJoint RelaxGraphBuilder::AddNode(const Expr& expr, const Optional<Expr>
   if (const auto* call_node = expr.as<relax::CallNode>()) {
     if (const auto* v_node = call_node->op.as<GlobalVarNode>()) {
       const auto& func = Downcast<relax::Function>(ref_module_->Lookup(v_node->name_hint));
+      attrs = RelaxFuncAttrGetter().GetAttrs(func);
+    } else if (call_node->op->IsInstance<relax::VarNode>()) {
+      ICHECK(target_funcs_.count(call_node->op)) << "Can not find target func: " << call_node->op;
+      const auto& func = target_funcs_[call_node->op];
       attrs = RelaxFuncAttrGetter().GetAttrs(func);
     } else if (call_node->op->IsInstance<relax::FunctionNode>()) {
       attrs = RelaxFuncAttrGetter().GetAttrs(call_node->op);
@@ -173,29 +219,67 @@ const MSCJoint RelaxGraphBuilder::AddNode(const Expr& expr, const Optional<Expr>
         attrs.Set(input_types[i], StringUtils::ToString(s_node->values));
         continue;
       }
+      if (func_params_.count(arg) && func_params_[arg]->IsInstance<relax::ShapeExprNode>()) {
+        const auto* s_node = func_params_[arg].as<relax::ShapeExprNode>();
+        attrs.Set(input_types[i], StringUtils::ToString(s_node->values));
+        ignore_nodes_.insert(Downcast<relax::Var>(arg)->name_hint());
+        continue;
+      }
       if (const auto* s_node = arg.as<relax::PrimValueNode>()) {
         ICHECK(input_types[i] != "input") << i << " th PrimValue of " << optype
                                           << " should has special type, get " << input_types;
         attrs.Set(input_types[i], StringUtils::ToString(s_node->value));
         continue;
       }
-      ICHECK(expr_tensor_map_.count(arg)) << "Missing argument " << arg;
+      Array<String> arg_names;
+      if (expr_tensor_map_.count(arg)) {
+        arg_names = expr_tensor_map_[arg];
+      } else if (const auto* tuple_node = arg.as<relax::TupleNode>()) {
+        for (const auto& f : tuple_node->fields) {
+          ICHECK(expr_tensor_map_.count(f)) << "Can not find tuple field " << f;
+          for (const auto& in_name : expr_tensor_map_[f]) {
+            arg_names.push_back(in_name);
+          }
+        }
+      }
+      String weight_name;
       if (input_types[i] != "input" && arg->IsInstance<relax::ConstantNode>()) {
-        const auto& t_name = expr_tensor_map_[arg][0];
-        const auto& w_name = SpanUtils::GetAttr(arg->span, "name");
+        weight_name = SpanUtils::GetAttr(arg->span, "name");
+      } else if (input_types[i] != "input" && func_params_.count(arg) &&
+                 func_params_[arg]->IsInstance<relax::ConstantNode>()) {
+        weight_name = SpanUtils::GetAttr(func_params_[arg]->span, "name");
+        ignore_nodes_.insert(Downcast<relax::Var>(arg)->name_hint());
+      }
+      // set weights or inputs
+      if (weight_name.size() > 0) {
+        const auto& t_name = arg_names[0];
         const auto& pair = tensor_input_map_[t_name];
         const auto& producer = Downcast<MSCJoint>(pair.first);
-        if (!weights_.count(w_name)) {
+        if (!weights_.count(weight_name)) {
           const auto& ref = producer->OutputAt(pair.second);
-          const auto& weight = MSCTensor(w_name, ref->dtype, ref->layout.name(), ref->shape);
-          weights_.Set(w_name, weight);
+          MSCTensor weight;
+          if (input_types[i] == "bias") {
+            weight = MSCTensor(weight_name, ref->dtype, "O", Array<Integer>{ref->GetSize()});
+          } else if (input_types[i] == "weight" &&
+                     (optype == "msc.linear" || optype == "msc.linear_bias")) {
+            if (ref->layout.name() == "IO") {
+              String valid_layout = ref->layout[1].name() + ref->layout[0].name();
+              const auto& valid_shape = Array<Integer>({ref->shape[1], ref->shape[0]});
+              weight = MSCTensor(weight_name, ref->dtype, valid_layout, valid_shape);
+            } else {
+              weight = MSCTensor(weight_name, ref->dtype, ref->layout.name(), ref->shape);
+            }
+          } else {
+            weight = MSCTensor(weight_name, ref->dtype, ref->layout.name(), ref->shape);
+          }
+          weights_.Set(weight_name, weight);
         }
         if (producer->HasAttr("scalar")) {
           attrs.Set(input_types[i], producer->GetTypeAttr<std::string>("scalar"));
         }
-        node_weights.Set(input_types[i], weights_[w_name]);
+        node_weights.Set(input_types[i], weights_[weight_name]);
       } else {
-        for (const auto& in_name : expr_tensor_map_[arg]) {
+        for (const auto& in_name : arg_names) {
           input_names.push_back(in_name);
         }
       }
@@ -280,19 +364,22 @@ void RelaxGraphBuilder::VisitExpr_(const relax::ConstantNode* op) {
 
 void RelaxGraphBuilder::VisitBinding_(const relax::VarBindingNode* binding,
                                       const relax::ConstantNode* val) {
-  AddNode(GetRef<relax::Constant>(val), binding->var);
+  const String& name = config_.use_var_name ? binding->var->name_hint() : "";
+  AddNode(GetRef<relax::Constant>(val), binding->var, name);
 }
 
 void RelaxGraphBuilder::VisitBinding_(const relax::VarBindingNode* binding,
                                       const relax::ShapeExprNode* val) {
-  AddNode(GetRef<relax::ShapeExpr>(val), binding->var);
+  const String& name = config_.use_var_name ? binding->var->name_hint() : "";
+  AddNode(GetRef<relax::ShapeExpr>(val), binding->var, name);
 }
 
 void RelaxGraphBuilder::VisitBinding_(const relax::VarBindingNode* binding,
                                       const relax::CallNode* call_node) {
   RelaxExprVisitor::VisitBinding_(binding, call_node);
+  const String& name = config_.use_var_name ? binding->var->name_hint() : "";
   try {
-    AddNode(GetRef<relax::Call>(call_node), binding->var);
+    AddNode(GetRef<relax::Call>(call_node), binding->var, name);
   } catch (runtime::InternalError& err) {
     LOG(WARNING) << "Failed to add node from " << binding->var << " : " << binding->value
                  << ", reason: " << err.message();
@@ -303,13 +390,15 @@ void RelaxGraphBuilder::VisitBinding_(const relax::VarBindingNode* binding,
 void RelaxGraphBuilder::VisitBinding_(const relax::VarBindingNode* binding,
                                       const relax::TupleNode* val) {
   RelaxExprVisitor::VisitBinding_(binding, val);
-  AddNode(GetRef<relax::Tuple>(val), binding->var);
+  const String& name = config_.use_var_name ? binding->var->name_hint() : "";
+  AddNode(GetRef<relax::Tuple>(val), binding->var, name);
 }
 
 void RelaxGraphBuilder::VisitBinding_(const relax::VarBindingNode* binding,
                                       const relax::TupleGetItemNode* val) {
   RelaxExprVisitor::VisitBinding_(binding, val);
-  AddNode(GetRef<relax::TupleGetItem>(val), binding->var);
+  const String& name = config_.use_var_name ? binding->var->name_hint() : "";
+  AddNode(GetRef<relax::TupleGetItem>(val), binding->var, name);
 }
 
 void RelaxGraphBuilder::VisitBinding_(const relax::VarBindingNode* binding,
@@ -326,6 +415,15 @@ void RelaxGraphBuilder::VisitBinding_(const relax::VarBindingNode* binding,
   const auto& output = GetRef<relax::DataflowVar>(val);
   ICHECK(expr_tensor_map_.count(output)) << "Can not find dataflow var " << output;
   expr_tensor_map_.Set(binding->var, expr_tensor_map_[output]);
+}
+
+void RelaxGraphBuilder::VisitBinding_(const relax::VarBindingNode* binding,
+                                      const relax::FunctionNode* val) {
+  const auto& name_opt = val->GetAttr<runtime::String>(relay::attr::kComposite);
+  ICHECK(name_opt.defined()) << "Unexpected target func without composite";
+  ICHECK(config_.target.size() > 0 && StringUtils::StartsWith(name_opt.value(), config_.target))
+      << "Target should be given for target function";
+  target_funcs_.Set(binding->var, GetRef<relax::Function>(val));
 }
 
 Map<MSCTensor, NDArray> RelaxWeightsExtractor::GetWeights(const relax::Function& func) {
@@ -476,18 +574,23 @@ MSCJoint RelayGraphBuilder::AddNode(const Expr& expr, const String& name) {
       ICHECK(expr_tensor_map_.count(arg)) << "Missing argument " << arg;
       if (input_types[i] != "input" && arg->IsInstance<relay::ConstantNode>()) {
         const auto& t_name = expr_tensor_map_[arg][0];
-        const auto& w_name = SpanUtils::GetAttr(arg->span, "name");
+        const auto& weight_name = SpanUtils::GetAttr(arg->span, "name");
         const auto& pair = tensor_input_map_[t_name];
         const auto& producer = Downcast<MSCJoint>(pair.first);
-        if (!weights_.count(w_name)) {
+        if (!weights_.count(weight_name)) {
           const auto& ref = producer->OutputAt(pair.second);
-          const auto& weight = MSCTensor(w_name, ref->dtype, ref->layout.name(), ref->shape);
-          weights_.Set(w_name, weight);
+          MSCTensor weight;
+          if (input_types[i] == "bias") {
+            weight = MSCTensor(weight_name, ref->dtype, "O", Array<Integer>{ref->GetSize()});
+          } else {
+            weight = MSCTensor(weight_name, ref->dtype, ref->layout.name(), ref->shape);
+          }
+          weights_.Set(weight_name, weight);
         }
         if (producer->HasAttr("scalar")) {
           attrs.Set(input_types[i], producer->GetTypeAttr<std::string>("scalar"));
         }
-        node_weights.Set(input_types[i], weights_[w_name]);
+        node_weights.Set(input_types[i], weights_[weight_name]);
       } else {
         for (const auto& in_name : expr_tensor_map_[arg]) {
           input_names.push_back(in_name);
@@ -606,6 +709,9 @@ void RelayGraphBuilder::VisitExpr_(const relay::CallNode* op) {
     const auto& name_opt = f_node->GetAttr<runtime::String>(relay::attr::kComposite);
     if (name_opt.defined()) {
       for (size_t i = 0; i < op->args.size(); i++) {
+        if (!expr_tensor_map_.count(op->args[i])) {
+          RelayExprVisitor::VisitExpr(op->args[i]);
+        }
         ICHECK(expr_tensor_map_.count(op->args[i]))
             << "Can not find argument " << relay::PrettyPrint(op->args[i]);
         expr_tensor_map_.Set(f_node->params[i], expr_tensor_map_[op->args[i]]);

--- a/src/contrib/msc/core/printer/msc_base_printer.cc
+++ b/src/contrib/msc/core/printer/msc_base_printer.cc
@@ -76,6 +76,12 @@ void MSCBasePrinter::PrintDoc(const Doc& doc, bool new_line) {
     PrintTypedDoc(doc_node.value());
   } else if (auto doc_node = doc.as<CommentDoc>()) {
     PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<DeclareDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<StrictListDoc>()) {
+    PrintTypedDoc(doc_node.value());
+  } else if (auto doc_node = doc.as<PointerDoc>()) {
+    PrintTypedDoc(doc_node.value());
   } else {
     LOG(FATAL) << "Do not know how to print " << doc->GetTypeKey();
     throw;
@@ -103,21 +109,6 @@ void MSCBasePrinter::PrintTypedDoc(const LiteralDoc& doc) {
 }
 
 void MSCBasePrinter::PrintTypedDoc(const IdDoc& doc) { output_ << doc->name; }
-
-void MSCBasePrinter::PrintTypedDoc(const IndexDoc& doc) {
-  PrintDoc(doc->value);
-  if (doc->indices.size() == 0) {
-    output_ << "[()]";
-  } else {
-    for (size_t i = 0; i < doc->indices.size(); i++) {
-      if (i == 0) {
-        output_ << "[";
-      }
-      PrintDoc(doc);
-      output_ << (i == doc->indices.size() - 1 ? "]" : ", ");
-    }
-  }
-}
 
 void MSCBasePrinter::PrintTypedDoc(const ListDoc& doc) {
   output_ << "[";

--- a/src/contrib/msc/core/printer/msc_base_printer.h
+++ b/src/contrib/msc/core/printer/msc_base_printer.h
@@ -30,6 +30,7 @@
 #include <string>
 
 #include "../../../../../src/support/str_escape.h"
+#include "msc_doc.h"
 
 namespace tvm {
 namespace contrib {
@@ -41,7 +42,6 @@ using namespace tvm::script::printer;
  * \brief MSCPrinterConfig is base for config class in MSC
  * \sa Doc
  */
-
 struct MSCPrinterConfig {
   size_t indent{0};
   size_t float_precision{6};
@@ -109,9 +109,6 @@ class MSCBasePrinter {
   /*! \brief Virtual method to print an IdDoc*/
   virtual void PrintTypedDoc(const IdDoc& doc);
 
-  /*! \brief Virtual method to print an IndexDoc*/
-  virtual void PrintTypedDoc(const IndexDoc& doc);
-
   /*! \brief Virtual method to print a ListDoc*/
   virtual void PrintTypedDoc(const ListDoc& doc);
 
@@ -126,6 +123,9 @@ class MSCBasePrinter {
 
   /*! \brief Virtual method to print a ExprStmtDoc*/
   virtual void PrintTypedDoc(const ExprStmtDoc& doc);
+
+  /*! \brief Virtual method to print an IndexDoc*/
+  virtual void PrintTypedDoc(const IndexDoc& doc) { LOG(FATAL) << "Index is not implemented"; }
 
   /*! \brief Virtual method to print a CallDoc*/
   virtual void PrintTypedDoc(const CallDoc& doc) { LOG(FATAL) << "Call is not implemented"; }
@@ -169,6 +169,19 @@ class MSCBasePrinter {
 
   /*! \brief Virtual method to print a CommentDoc*/
   virtual void PrintTypedDoc(const CommentDoc& doc) { LOG(FATAL) << "Comment is not implemented"; }
+
+  /*! \brief Virtual method to print a DeclareDoc*/
+  virtual void PrintTypedDoc(const DeclareDoc& doc) { LOG(FATAL) << "Declare is not implemented"; }
+
+  /*! \brief Virtual method to print a StrictListDoc*/
+  virtual void PrintTypedDoc(const StrictListDoc& doc) {
+    LOG(FATAL) << "StrictList is not implemented";
+  }
+
+  /*! \brief Virtual method to print a PointerDoc*/
+  virtual void PrintTypedDoc(const PointerDoc& doc) {
+    LOG(FATAL) << "PointerDoc is not implemented";
+  }
 
   /*! \brief Print docs to joined doc */
   template <typename DocType>

--- a/src/contrib/msc/core/printer/msc_doc.cc
+++ b/src/contrib/msc/core/printer/msc_doc.cc
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/core/printer/msc_doc.cc
+ */
+
+#include "msc_doc.h"
+
+#include <utility>
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+DeclareDoc::DeclareDoc(Optional<ExprDoc> type, ExprDoc variable, Array<ExprDoc> init_args,
+                       bool use_constructor) {
+  ObjectPtr<DeclareDocNode> n = make_object<DeclareDocNode>();
+  n->type = type;
+  n->variable = variable;
+  n->init_args = init_args;
+  n->use_constructor = use_constructor;
+  this->data_ = std::move(n);
+}
+
+StrictListDoc::StrictListDoc(ListDoc list, bool allow_empty) {
+  ObjectPtr<StrictListDocNode> n = make_object<StrictListDocNode>();
+  n->list = list;
+  n->allow_empty = allow_empty;
+  this->data_ = std::move(n);
+}
+
+PointerDoc::PointerDoc(String name) {
+  ObjectPtr<PointerDocNode> n = make_object<PointerDocNode>();
+  n->name = name;
+  this->data_ = std::move(n);
+}
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/msc/core/printer/msc_doc.h
+++ b/src/contrib/msc/core/printer/msc_doc.h
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/core/printer/msc_doc.h
+ * \brief Extra docs for MSC
+ */
+#ifndef TVM_CONTRIB_MSC_CORE_PRINTER_MSC_DOC_H_
+#define TVM_CONTRIB_MSC_CORE_PRINTER_MSC_DOC_H_
+
+#include <tvm/script/printer/doc.h>
+
+#include <string>
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+using namespace tvm::script::printer;
+
+/*!
+ * \brief Doc that declare a var with type.
+ *
+ * \sa DeclareDoc
+ */
+class DeclareDocNode : public ExprDocNode {
+ public:
+  /*! \brief The type of the variable */
+  Optional<ExprDoc> type;
+  /*! \brief The variable */
+  ExprDoc variable{nullptr};
+  /*! \brief The init arguments for the variable. */
+  Array<ExprDoc> init_args;
+  /*! \brief Whether to use constructor(otherwise initializer) */
+  bool use_constructor{true};
+
+  void VisitAttrs(AttrVisitor* v) {
+    ExprDocNode::VisitAttrs(v);
+    v->Visit("type", &type);
+    v->Visit("variable", &variable);
+    v->Visit("init_args", &init_args);
+    v->Visit("use_constructor", &use_constructor);
+  }
+
+  static constexpr const char* _type_key = "script.printer.DeclareDoc";
+  TVM_DECLARE_FINAL_OBJECT_INFO(DeclareDocNode, ExprDocNode);
+};
+
+/*!
+ * \brief Reference type of DeclareDocNode.
+ *
+ * \sa DeclareDocNode
+ */
+class DeclareDoc : public ExprDoc {
+ public:
+  /*!
+   * \brief Constructor of DeclareDoc.
+   * \param type The type of the variable.
+   * \param variable The variable.
+   * \param init_args The init arguments of the variable.
+   * \param use_constructor Whether to use constructor(otherwise initializer).
+   */
+  explicit DeclareDoc(Optional<ExprDoc> type, ExprDoc variable, Array<ExprDoc> init_args,
+                      bool use_constructor);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(DeclareDoc, ExprDoc, DeclareDocNode);
+};
+
+/*!
+ * \brief Doc that build a strict list, which check the empty.
+ *
+ * \sa StrictListDoc
+ */
+class StrictListDocNode : public ExprDocNode {
+ public:
+  /*! \brief The inner list doc */
+  ListDoc list;
+  /*! \brief Whether to allow empty */
+  bool allow_empty{true};
+
+  void VisitAttrs(AttrVisitor* v) {
+    ExprDocNode::VisitAttrs(v);
+    v->Visit("list", &list);
+    v->Visit("allow_empty", &allow_empty);
+  }
+
+  static constexpr const char* _type_key = "script.printer.StrictListDoc";
+  TVM_DECLARE_FINAL_OBJECT_INFO(StrictListDocNode, ExprDocNode);
+};
+
+/*!
+ * \brief Reference type of StrictListDocNode.
+ *
+ * \sa StrictListDocNode
+ */
+class StrictListDoc : public ExprDoc {
+ public:
+  /*!
+   * \brief Constructor of StrictListDoc.
+   * \param list The inner list doc.
+   * \param allow_empty Whether to allow empty.
+   */
+  explicit StrictListDoc(ListDoc list, bool allow_empty);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(StrictListDoc, ExprDoc, StrictListDocNode);
+};
+
+/*!
+ * \brief Doc that represents pointer.
+ *
+ * \sa PointerDoc
+ */
+class PointerDocNode : public ExprDocNode {
+ public:
+  /*! \brief The name of the identifier */
+  String name;
+
+  void VisitAttrs(AttrVisitor* v) {
+    ExprDocNode::VisitAttrs(v);
+    v->Visit("name", &name);
+  }
+
+  static constexpr const char* _type_key = "script.printer.PointerDoc";
+  TVM_DECLARE_FINAL_OBJECT_INFO(PointerDocNode, ExprDocNode);
+};
+
+/*!
+ * \brief Reference type of PointerDocNode.
+ *
+ * \sa PointerDocNode
+ */
+class PointerDoc : public ExprDoc {
+ public:
+  /*!
+   * \brief Constructor of PointerDoc.
+   * \param name The name of identifier.
+   */
+  explicit PointerDoc(String name);
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(PointerDoc, ExprDoc, PointerDocNode);
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+
+#endif  // TVM_CONTRIB_MSC_CORE_PRINTER_MSC_DOC_H_

--- a/src/contrib/msc/core/printer/print_utils.cc
+++ b/src/contrib/msc/core/printer/print_utils.cc
@@ -50,7 +50,31 @@ const ExprDoc DocUtils::ToDoc(const String& val) { return IdDoc(val); }
 
 const ExprDoc DocUtils::ToDoc(bool val) { return LiteralDoc::Boolean(val, NullOpt); }
 
+const ExprDoc DocUtils::ToDoc(const ExprDoc& val) { return val; }
+
 const ExprDoc DocUtils::ToStrDoc(const String& val) { return LiteralDoc::Str(val, NullOpt); }
+
+const PointerDoc DocUtils::ToPtrDoc(const String& val) { return PointerDoc(val); }
+
+const DeclareDoc DocUtils::ToDeclareDoc(const String& type, const String& variable, size_t len,
+                                        bool use_constructor) {
+  Optional<ExprDoc> type_doc;
+  if (type.size() == 0) {
+    type_doc = NullOpt;
+  } else {
+    type_doc = IdDoc(type);
+  }
+  if (len == 0) {
+    return DeclareDoc(type_doc, IdDoc(variable), Array<ExprDoc>(), use_constructor);
+  }
+  Array<Doc> doc_indices{DocUtils::ToDoc(len)};
+  return DeclareDoc(type_doc, IndexDoc(IdDoc(variable), doc_indices), Array<ExprDoc>(),
+                    use_constructor);
+}
+
+const AttrAccessDoc DocUtils::ToAttrAccessDoc(const String& value, const String& name) {
+  return AttrAccessDoc(IdDoc(value), name);
+}
 
 const Array<StmtDoc> DocUtils::ToStmts(const Array<Doc>& docs) {
   Array<StmtDoc> stmts;

--- a/src/contrib/msc/core/printer/print_utils.h
+++ b/src/contrib/msc/core/printer/print_utils.h
@@ -28,6 +28,8 @@
 
 #include <vector>
 
+#include "msc_doc.h"
+
 namespace tvm {
 namespace contrib {
 namespace msc {
@@ -54,7 +56,23 @@ class DocUtils {
   TVM_DLL static const ExprDoc ToDoc(const char* val);
   TVM_DLL static const ExprDoc ToDoc(const String& val);
   TVM_DLL static const ExprDoc ToDoc(bool val);
+  TVM_DLL static const ExprDoc ToDoc(const ExprDoc& val);
   TVM_DLL static const ExprDoc ToStrDoc(const String& val);
+  TVM_DLL static const PointerDoc ToPtrDoc(const String& val);
+
+  /*!
+   * \brief Change object to DeclareDoc.
+   * \return The DeclareDoc.
+   */
+  TVM_DLL static const DeclareDoc ToDeclareDoc(const String& type, const String& variable,
+                                               size_t len = 0, bool use_constructor = true);
+
+  /*!
+   * \brief Change object to AttrAccessDoc.
+   * \return The AttrAccessDoc.
+   */
+  TVM_DLL static const AttrAccessDoc ToAttrAccessDoc(const String& value, const String& name);
+
   /*!
    * \brief Change object to List of Docs.
    * \return The List of Docs.
@@ -81,12 +99,53 @@ class DocUtils {
    * \return The ListDoc.
    */
   template <typename T>
-  TVM_DLL static const ListDoc ToListDoc(const std::vector<T>& values) {
-    return ListDoc(ToDocList(values));
+  TVM_DLL static const StrictListDoc ToListDoc(const std::vector<T>& values,
+                                               bool allow_empty = false) {
+    if (values.size() > 0 || allow_empty) {
+      return StrictListDoc(ListDoc(ToDocList(values)), allow_empty);
+    }
+    return StrictListDoc(ListDoc(), false);
   }
   template <typename T>
-  TVM_DLL static const ListDoc ToListDoc(const Array<T>& values) {
-    return ListDoc(ToDocList(values));
+  TVM_DLL static const StrictListDoc ToListDoc(const Array<T>& values, bool allow_empty = false) {
+    if (values.size() > 0 || allow_empty) {
+      return StrictListDoc(ListDoc(ToDocList(values)), allow_empty);
+    }
+    return StrictListDoc(ListDoc(), false);
+  }
+
+  /*!
+   * \brief Change object to IndexDoc.
+   * \return The ListDoc.
+   */
+  template <typename T>
+  TVM_DLL static const IndexDoc ToIndexDoc(const String& value, const std::vector<T>& indices) {
+    Array<Doc> doc_indices;
+    for (const auto& i : indices) {
+      doc_indices.push_back(ToDoc(i));
+    }
+    return IndexDoc(IdDoc(value), doc_indices);
+  }
+  template <typename T>
+  TVM_DLL static const IndexDoc ToIndexDoc(const String& value, const Array<T>& indices) {
+    Array<Doc> doc_indices;
+    for (const auto& i : indices) {
+      doc_indices.push_back(ToDoc(i));
+    }
+    return IndexDoc(IdDoc(value), doc_indices);
+  }
+
+  /*!
+   * \brief Change object to AssignDoc.
+   * \return The AssignDoc.
+   */
+  template <typename T>
+  TVM_DLL static const AssignDoc ToAssignDoc(const String& lhs, const T& rhs,
+                                             const String& annotation = "") {
+    if (annotation.size() == 0) {
+      return AssignDoc(IdDoc(lhs), ToDoc(rhs), NullOpt);
+    }
+    return AssignDoc(IdDoc(lhs), ToDoc(rhs), IdDoc(annotation));
   }
 
   /*!

--- a/src/contrib/msc/core/printer/python_printer.cc
+++ b/src/contrib/msc/core/printer/python_printer.cc
@@ -174,6 +174,14 @@ void PythonPrinter::PrintTypedDoc(const CommentDoc& doc) {
   }
 }
 
+void PythonPrinter::PrintTypedDoc(const StrictListDoc& doc) {
+  if (doc->allow_empty || doc->list->elements.size() > 0) {
+    PrintDoc(doc->list, false);
+  } else {
+    output_ << "None";
+  }
+}
+
 void PythonPrinter::PrintIndentedBlock(const Array<StmtDoc>& docs) {
   IncreaseIndent();
   for (const StmtDoc& d : docs) {

--- a/src/contrib/msc/core/printer/python_printer.h
+++ b/src/contrib/msc/core/printer/python_printer.h
@@ -19,7 +19,7 @@
 
 /*!
  * \file src/contrib/msc/core/printer/python_printer.h
- * \brief Prototxt Printer.
+ * \brief Python Printer.
  */
 
 #ifndef TVM_CONTRIB_MSC_CORE_PRINTER_PYTHON_PRINTER_H_
@@ -36,7 +36,7 @@ namespace msc {
 using namespace tvm::script::printer;
 
 /*!
- * \brief PythonPrinter change list of dict to python format
+ * \brief PythonPrinter change list of docs to python format
  * \sa Doc
  */
 class PythonPrinter : public MSCBasePrinter {
@@ -77,6 +77,9 @@ class PythonPrinter : public MSCBasePrinter {
 
   /*! * \brief Print a CommentDoc to python format*/
   void PrintTypedDoc(const CommentDoc& doc) final;
+
+  /*! \brief Virtual method to print a StrictListDoc*/
+  void PrintTypedDoc(const StrictListDoc& doc) final;
 
  private:
   /*! \brief Print block with indent*/

--- a/src/contrib/msc/core/transform/layout_utils.cc
+++ b/src/contrib/msc/core/transform/layout_utils.cc
@@ -49,7 +49,7 @@ bool LayoutUtils::SetLayout(const Expr& expr, const NLayout& layout) {
     }
     expr->span = SpanUtils::SetAttr(expr->span, "layout", l_layout.name());
   } else if (sinfo.as<TupleStructInfoNode>()) {
-    ICHECK(!layout.IsLeaf()) << "Expr has tupple struct, but find non-nested layout " << expr;
+    ICHECK(!layout.IsLeaf()) << "Expr has tuple struct, but find non-nested layout " << expr;
     String layout_str;
     Array<NLayout> nested_layouts = layout.NestedArray();
     for (size_t i = 0; i < nested_layouts.size(); i++) {

--- a/src/contrib/msc/core/transform/set_expr_name.cc
+++ b/src/contrib/msc/core/transform/set_expr_name.cc
@@ -41,7 +41,8 @@ namespace relax {
  */
 class RelaxExprNameSetter : public ExprVisitor {
  public:
-  explicit RelaxExprNameSetter(const IRModule& ref_module) : ref_module_(ref_module) {}
+  explicit RelaxExprNameSetter(const IRModule& ref_module, const String& target)
+      : ref_module_(ref_module), target_{target} {}
 
   void VisitBindingBlock(const BindingBlock& block) final {
     String block_name = SpanUtils::GetAttr(block->span, "name");
@@ -109,6 +110,14 @@ class RelaxExprNameSetter : public ExprVisitor {
     expr_names_.Set(binding->var, unique_name);
   }
 
+  void VisitBinding_(const VarBindingNode* binding, const FunctionNode* val) {
+    ExprVisitor::VisitBinding_(binding, val);
+    const auto& name_opt = val->GetAttr<runtime::String>(attr::kComposite);
+    if (name_opt.defined()) {
+      local_funcs_.Set(binding->var, GetRef<Function>(val));
+    }
+  }
+
   void VisitBinding_(const VarBindingNode* binding, const CallNode* val) {
     ExprVisitor::VisitBinding_(binding, val);
     String name_hint, optype;
@@ -120,38 +129,52 @@ class RelaxExprNameSetter : public ExprVisitor {
     } else if (const auto* v_node = val->op.as<GlobalVarNode>()) {
       const auto& func = Downcast<Function>(ref_module_->Lookup(v_node->name_hint));
       ExprVisitor::VisitExpr(func);
-      const auto& name_opt = func->GetAttr<runtime::String>(attr::kComposite);
-      ICHECK(name_opt.defined()) << "Unexpected global func without composite";
-      name_hint = name_opt.value();
-      optype = name_hint;
-    }
-    // set name
-    const String& unique_name = GetUniqueName(GetRef<Expr>(val), name_hint);
-    if (unique_name != SpanUtils::GetAttr(val->span, "name")) {
-      val->span = SpanUtils::SetAttr(val->span, "name", unique_name);
-    }
-    // set constant consumer && shared_ref
-    Array<String> input_types;
-    try {
-      input_types = ExprUtils::GetInputTypes(optype, val->args.size(), true);
-    } catch (runtime::InternalError& err) {
-      LOG(WARNING) << "Failed to GetInputTypes for " << GetRef<Call>(val) << " : " << err.message();
-      throw err;
-    }
-    for (size_t i = 0; i < input_types.size(); i++) {
-      if (input_types[i] == "input") {
-        continue;
+      optype = GetFuncType(func);
+      if (optype == "extern_func") {
+        name_hint = v_node->name_hint;
+      } else {
+        name_hint = optype;
       }
-      if (const auto* c_node = val->args[i].as<ConstantNode>()) {
-        const String& const_name = SpanUtils::GetAttr(c_node->span, "name");
-        if (constant_consumers_.count(const_name)) {
-          val->span = SpanUtils::SetAttr(val->span, "shared_ref", constant_consumers_[const_name]);
-        } else {
-          constant_consumers_.Set(const_name, unique_name);
+    } else if (local_funcs_.count(val->op)) {
+      optype = GetFuncType(local_funcs_[val->op]);
+      ExprVisitor::VisitExpr(local_funcs_[val->op]);
+      if (optype == "extern_func") {
+        name_hint = Downcast<Var>(val->op)->name_hint();
+      } else {
+        name_hint = optype;
+      }
+    }
+    if (name_hint.size() > 0) {
+      // set name
+      const String& unique_name = GetUniqueName(GetRef<Expr>(val), name_hint);
+      if (unique_name != SpanUtils::GetAttr(val->span, "name")) {
+        val->span = SpanUtils::SetAttr(val->span, "name", unique_name);
+      }
+      // set constant consumer && shared_ref
+      Array<String> input_types;
+      try {
+        input_types = ExprUtils::GetInputTypes(optype, val->args.size(), true);
+      } catch (runtime::InternalError& err) {
+        LOG(WARNING) << "Failed to GetInputTypes for " << GetRef<Call>(val) << " : "
+                     << err.message();
+        throw err;
+      }
+      for (size_t i = 0; i < input_types.size(); i++) {
+        if (input_types[i] == "input") {
+          continue;
+        }
+        if (const auto* c_node = val->args[i].as<ConstantNode>()) {
+          const String& const_name = SpanUtils::GetAttr(c_node->span, "name");
+          if (constant_consumers_.count(const_name)) {
+            val->span =
+                SpanUtils::SetAttr(val->span, "shared_ref", constant_consumers_[const_name]);
+          } else {
+            constant_consumers_.Set(const_name, unique_name);
+          }
         }
       }
+      expr_names_.Set(binding->var, unique_name);
     }
-    expr_names_.Set(binding->var, unique_name);
   }
 
  private:
@@ -179,24 +202,40 @@ class RelaxExprNameSetter : public ExprVisitor {
     return expr_name;
   }
 
+  const String GetFuncType(const Function& func) {
+    String optype;
+    const auto& name_opt = func->GetAttr<runtime::String>(attr::kComposite);
+    if (name_opt.defined()) {
+      optype = name_opt.value();
+      if (target_.size() > 0) {
+        optype = StringUtils::Replace(optype, target_ + ".", "");
+      }
+    } else {
+      optype = "extern_func";
+    }
+    return optype;
+  }
+
   Map<String, Expr> setted_names_;
   Map<String, String> constant_consumers_;
   std::set<String> setted_blocks_;
   Array<String> block_stack_;
   Map<Expr, String> expr_names_;
+  Map<Expr, Function> local_funcs_;
   IRModule ref_module_;
+  String target_;
 };  // class ExprNameSetter
 
-void SetRelaxExprName(const IRModule& ref_module, const Expr& e) {
-  RelaxExprNameSetter(ref_module).VisitExpr(e);
+void SetRelaxExprName(const IRModule& ref_module, const Expr& e, const String& target) {
+  RelaxExprNameSetter(ref_module, target).VisitExpr(e);
 }
 
 namespace transform {
 
-Pass SetRelaxExprName(const String& entry_name) {
+Pass SetRelaxExprName(const String& entry_name, const String& target) {
   runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func = [=](IRModule m,
                                                                             PassContext pc) {
-    relax::SetRelaxExprName(m, m->Lookup(entry_name));
+    relax::SetRelaxExprName(m, m->Lookup(entry_name), target);
     return m;
   };
   return CreateModulePass(pass_func, 0, "SetRelaxExprName", {});
@@ -261,35 +300,42 @@ class RelayExprNameSetter : public ExprVisitor {
       optype = StringUtils::Replace(op_node->name, "relay.", "");
     } else if (const auto* v_node = op->op.as<GlobalVarNode>()) {
       const auto& func = Downcast<Function>(ref_module_->Lookup(v_node->name_hint));
-      ExprVisitor::VisitExpr(func);
       const auto& name_opt = func->GetAttr<runtime::String>(attr::kComposite);
-      ICHECK(name_opt.defined()) << "Unexpected global func without composite";
-      optype = name_opt.value();
-      name_hint = optype;
-    }
-    // set name
-    const String& unique_name = GetUniqueName(GetRef<Expr>(op), name_hint);
-    if (unique_name != SpanUtils::GetAttr(op->span, "name")) {
-      op->span = SpanUtils::SetAttr(op->span, "name", unique_name);
-    }
-    // set constant consumer && shared_ref
-    Array<String> input_types;
-    try {
-      input_types = ExprUtils::GetInputTypes(optype, op->args.size(), false);
-    } catch (runtime::InternalError& err) {
-      LOG(WARNING) << "Failed to GetInputTypes for " << GetRef<Call>(op) << " : " << err.message();
-      throw err;
-    }
-    for (size_t i = 0; i < input_types.size(); i++) {
-      if (input_types[i] == "input") {
-        continue;
+      if (name_opt.defined()) {
+        optype = name_opt.value();
+        name_hint = optype;
+        ExprVisitor::VisitExpr(func);
+      } else {
+        optype = "extern_func";
+        name_hint = v_node->name_hint;
       }
-      if (const auto* c_node = op->args[i].as<ConstantNode>()) {
-        const String& const_name = SpanUtils::GetAttr(c_node->span, "name");
-        if (constant_consumers_.count(const_name)) {
-          op->span = SpanUtils::SetAttr(op->span, "shared_ref", constant_consumers_[const_name]);
-        } else {
-          constant_consumers_.Set(const_name, unique_name);
+    }
+    if (name_hint.size() > 0) {
+      // set name
+      const String& unique_name = GetUniqueName(GetRef<Expr>(op), name_hint);
+      if (unique_name != SpanUtils::GetAttr(op->span, "name")) {
+        op->span = SpanUtils::SetAttr(op->span, "name", unique_name);
+      }
+      // set constant consumer && shared_ref
+      Array<String> input_types;
+      try {
+        input_types = ExprUtils::GetInputTypes(optype, op->args.size(), false);
+      } catch (runtime::InternalError& err) {
+        LOG(WARNING) << "Failed to GetInputTypes for " << GetRef<Call>(op) << " : "
+                     << err.message();
+        throw err;
+      }
+      for (size_t i = 0; i < input_types.size(); i++) {
+        if (input_types[i] == "input") {
+          continue;
+        }
+        if (const auto* c_node = op->args[i].as<ConstantNode>()) {
+          const String& const_name = SpanUtils::GetAttr(c_node->span, "name");
+          if (constant_consumers_.count(const_name)) {
+            op->span = SpanUtils::SetAttr(op->span, "shared_ref", constant_consumers_[const_name]);
+          } else {
+            constant_consumers_.Set(const_name, unique_name);
+          }
         }
       }
     }
@@ -329,6 +375,69 @@ void SetRelayExprName(const IRModule& ref_module, const Expr& e) {
   RelayExprNameSetter(ref_module).VisitExpr(e);
 }
 
+/*!
+ * \brief Name binder for Relay
+ */
+class RelayExprNameBinder : public ExprVisitor {
+ public:
+  explicit RelayExprNameBinder(const String& name_key, const String& seperator)
+      : name_key_(name_key), seperator_(seperator) {}
+
+  void VisitExpr_(const ConstantNode* op) final {
+    if (op->span.defined()) {
+      BindName(GetRef<Constant>(op));
+    }
+  }
+
+  void VisitExpr_(const CallNode* op) final {
+    if (op->span.defined()) {
+      BindName(GetRef<Call>(op));
+    }
+    ExprVisitor::VisitExpr_(op);
+  }
+
+ private:
+  void BindName(const Expr& expr) {
+    const auto& name = expr->span->source_name->name;
+    String valid_name;
+    if (name_key_.size() == 0) {
+      valid_name = name;
+      expr->span = Span(SourceName::Get(""), expr->span->line, expr->span->end_line,
+                        expr->span->column, expr->span->end_column);
+    } else {
+      String right = std::get<1>(StringUtils::SplitOnce(name, name_key_));
+      if (right.size() > 0) {
+        valid_name = std::get<0>(StringUtils::SplitOnce(name, seperator_));
+        if (valid_name.size() > 0) {
+          const auto& new_source = StringUtils::Replace(name, name_key_ + valid_name, "");
+          expr->span = Span(SourceName::Get(new_source), expr->span->line, expr->span->end_line,
+                            expr->span->column, expr->span->end_column);
+        }
+      }
+    }
+    if (valid_name.size() > 0) {
+      if (setted_names_.count(valid_name)) {
+        int cnt = 1;
+        while (setted_names_.count(valid_name + "_" + std::to_string(cnt)) &&
+               setted_names_[valid_name + "_" + std::to_string(cnt)] != expr) {
+          cnt++;
+        }
+        valid_name = valid_name + "_" + std::to_string(cnt);
+      }
+      setted_names_.Set(valid_name, expr);
+      expr->span = SpanUtils::SetAttr(expr->span, "name", valid_name);
+    }
+  }
+
+  Map<String, Expr> setted_names_;
+  String name_key_;
+  String seperator_;
+};  // class ExprNameBinder
+
+void BindRelayExprName(const Expr& e, const String& name_key, const String& seperator) {
+  RelayExprNameBinder(name_key, seperator).VisitExpr(e);
+}
+
 namespace transform {
 
 Pass SetRelayExprName(const String& entry_name) {
@@ -341,6 +450,17 @@ Pass SetRelayExprName(const String& entry_name) {
 }
 
 TVM_REGISTER_GLOBAL("relay._transform.SetRelayExprName").set_body_typed(SetRelayExprName);
+
+Pass BindRelayExprName(const String& name_key, const String& seperator, const String& entry_name) {
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func = [=](IRModule m,
+                                                                            PassContext pc) {
+    relay::BindRelayExprName(m->Lookup(entry_name), name_key, seperator);
+    return m;
+  };
+  return CreateModulePass(pass_func, 0, "BindRelayExprName", {});
+}
+
+TVM_REGISTER_GLOBAL("relay._transform.BindRelayExprName").set_body_typed(BindRelayExprName);
 
 }  // namespace transform
 }  // namespace relay

--- a/src/contrib/msc/core/utils.cc
+++ b/src/contrib/msc/core/utils.cc
@@ -47,6 +47,46 @@ std::vector<size_t> CommonUtils::GetIndices(const std::vector<int>& indices, siz
   return v_indices;
 }
 
+bool StringUtils::Contains(const String& src_string, const String& sub_string) {
+  if (src_string.size() == 0) {
+    return false;
+  }
+  if (sub_string.size() == 0) {
+    return false;
+  }
+
+  const std::string& src_cstring = src_string;
+  const std::string& sub_cstring = sub_string;
+  int pos = src_cstring.find(sub_cstring);
+  return pos >= 0;
+}
+
+bool StringUtils::StartsWith(const String& src_string, const String& sub_string) {
+  if (src_string.size() == 0) {
+    return false;
+  }
+  if (sub_string.size() == 0) {
+    return false;
+  }
+  const std::string& src_cstring = src_string;
+  const std::string& sub_cstring = sub_string;
+  int pos = src_cstring.find(sub_cstring);
+  return pos == 0;
+}
+
+bool StringUtils::EndsWith(const String& src_string, const String& sub_string) {
+  if (src_string.size() == 0) {
+    return false;
+  }
+  if (sub_string.size() == 0) {
+    return false;
+  }
+  const std::string& src_cstring = src_string;
+  const std::string& sub_cstring = sub_string;
+  int pos = src_cstring.rfind(sub_cstring);
+  return pos == src_cstring.size() - sub_cstring.size();
+}
+
 const Array<String> StringUtils::Split(const String& src_string, const String& sep) {
   Array<String> sub_strings;
   if (src_string.size() == 0) {
@@ -192,7 +232,8 @@ const Span SpanUtils::SetAttr(const Span& span, const String& key, const String&
     const String& source_str = span->source_name->name;
     String left = std::get<0>(StringUtils::SplitOnce(source_str, tokens[0]));
     String right = std::get<1>(StringUtils::SplitOnce(source_str, tokens[1]));
-    if (left.size() > 0) {
+    if (StringUtils::Contains(source_str, tokens[0]) &&
+        StringUtils::Contains(source_str, tokens[1])) {
       new_source = left + tokens[0] + value + tokens[1] + right;
     } else {
       new_source = source_str + tokens[0] + value + tokens[1];
@@ -256,28 +297,18 @@ const Array<String> ExprUtils::GetInputTypes(const String& optype, size_t inputs
     input_types.push_back("gamma");
     input_types.push_back("beta");
   } else if (optype == "msc.linear") {
-    if (as_relax) {
-      input_types.push_back("weight");
-      input_types.push_back("input");
-    } else {
-      input_types.push_back("input");
-      input_types.push_back("weight");
-    }
+    input_types.push_back("input");
+    input_types.push_back("weight");
   } else if (optype == "msc.conv1d_bias" || optype == "msc.conv2d_bias") {
     input_types.push_back("input");
     input_types.push_back("weight");
     input_types.push_back("bias");
-    if (as_relax) {
+    if (as_relax && inputs_num > 3) {
       input_types.push_back("expand_bias");
     }
   } else if (optype == "msc.linear_bias") {
-    if (as_relax) {
-      input_types.push_back("weight");
-      input_types.push_back("input");
-    } else {
-      input_types.push_back("input");
-      input_types.push_back("weight");
-    }
+    input_types.push_back("input");
+    input_types.push_back("weight");
     input_types.push_back("bias");
   } else if (optype == "msc.embedding" && inputs_num == 2) {
     input_types.push_back("input");

--- a/src/contrib/msc/core/utils.cc
+++ b/src/contrib/msc/core/utils.cc
@@ -84,7 +84,10 @@ bool StringUtils::EndsWith(const String& src_string, const String& sub_string) {
   const std::string& src_cstring = src_string;
   const std::string& sub_cstring = sub_string;
   int pos = src_cstring.rfind(sub_cstring);
-  return pos == src_cstring.size() - sub_cstring.size();
+  if (pos < 0) {
+    return false;
+  }
+  return static_cast<size_t>(pos) == src_cstring.size() - sub_cstring.size();
 }
 
 const Array<String> StringUtils::Split(const String& src_string, const String& sep) {

--- a/src/contrib/msc/core/utils.h
+++ b/src/contrib/msc/core/utils.h
@@ -60,6 +60,24 @@ class CommonUtils {
 class StringUtils {
  public:
   /*!
+   * \brief Check if the String contains a substring.
+   * \return Whether substring is contained.
+   */
+  TVM_DLL static bool Contains(const String& src_string, const String& sub_string);
+
+  /*!
+   * \brief Check if the String starts with a substring.
+   * \return Whether string starts with substring.
+   */
+  TVM_DLL static bool StartsWith(const String& src_string, const String& sub_string);
+
+  /*!
+   * \brief Check if the String ens with a substring.
+   * \return Whether string endswith substring.
+   */
+  TVM_DLL static bool EndsWith(const String& src_string, const String& sub_string);
+
+  /*!
    * \brief Split the String into sub Strings.
    * \return The SubStrings.
    */
@@ -159,7 +177,11 @@ class ArrayUtils {
   TVM_DLL static const Array<T> Cast(const Array<PrimExpr>& src_array) {
     Array<T> new_array;
     for (const auto& s : src_array) {
-      new_array.push_back(Downcast<T>(s));
+      if (s->IsInstance<tvm::tir::AnyNode>()) {
+        new_array.push_back(T(-1));
+      } else {
+        new_array.push_back(Downcast<T>(s));
+      }
     }
     return new_array;
   }

--- a/src/contrib/msc/framework/torch/torch_opcode.cc
+++ b/src/contrib/msc/framework/torch/torch_opcode.cc
@@ -395,21 +395,6 @@ class TorchPermuteDimsCodeGen : public TorchOpCode {
   }
 };
 
-class TorchPermuteDimsCodeGen : public TorchOpCode {
-  TORCH_OP_CODEGEN_METHODS(TorchPermuteDimsCodeGen)
-
- protected:
-  void CodeGenForward() final {
-    std::vector<int> axes;
-    if (!node()->GetAttr("axes", &axes)) {
-      for (size_t i = node()->InputAt(0)->Ndim(); i > 0; i--) {
-        axes.push_back(i - 1);
-      }
-    }
-    stack_.op_start().op_input_arg().call_list_arg(axes).op_end();
-  }
-};
-
 class TorchReduceAxisCodeGen : public TorchOpCode {
  public:
   TorchReduceAxisCodeGen(const String& module_name, const String& func_name, bool as_list)

--- a/src/contrib/msc/framework/torch/torch_opcode.cc
+++ b/src/contrib/msc/framework/torch/torch_opcode.cc
@@ -42,15 +42,15 @@ const Array<Doc> TorchOpCode::GetDocs() {
 
 void TorchOpCode::CodeGenInit() {
   if (module_name().size() > 0) {
-    stack_.op_start().op_end();
+    stack_.op_call();
   } else {
     stack_.comment("passby: implement by " + func_name());
   }
 }
 
-void TorchOpCode::CodeGenForward() { stack_.op_start().op_inputs_arg(false).op_end(); }
+void TorchOpCode::CodeGenForward() { stack_.op_call().op_inputs_arg(false); }
 
-const std::vector<int> TorchOpCode::GetPadding(const String& key) {
+const StrictListDoc TorchOpCode::GetPadding(const String& key) {
   std::vector<int> padding, src_padding;
   ICHECK(node()->GetAttr(key, &src_padding));
   if (node()->optype == "nn.conv1d" || node()->optype == "msc.conv1d_bias") {
@@ -70,8 +70,10 @@ const std::vector<int> TorchOpCode::GetPadding(const String& key) {
     } else {
       LOG_FATAL << "nn.conv2d/pool2d with unexpected padding " << node();
     }
+  } else {
+    LOG_FATAL << "Unexpected padding node" << node();
   }
-  return padding;
+  return DocUtils::ToListDoc(padding);
 }
 
 #define TORCH_OP_CODEGEN_METHODS(TypeName)                     \
@@ -83,7 +85,7 @@ class TorchAdaptivePoolCodeGen : public TorchOpCode {
   TORCH_OP_CODEGEN_METHODS(TorchAdaptivePoolCodeGen);
 
  protected:
-  void CodeGenInit() final { stack_.op_start().op_list_arg<int>("output_size").op_end(); }
+  void CodeGenInit() final { stack_.op_call().op_list_arg<int>("output_size"); }
 };
 
 class TorchAstypeCodeGen : public TorchOpCode {
@@ -91,10 +93,7 @@ class TorchAstypeCodeGen : public TorchOpCode {
 
  protected:
   void CodeGenForward() final {
-    stack_.assign(IdxNode(), IdxInput())
-        .inplace_start("to")
-        .call_dtype_arg(node()->OutputAt(0)->dtype)
-        .inplace_end();
+    stack_.assign(IdxNode(), IdxInput()).method_call("to").op_dtype_arg(node()->OutputAt(0)->dtype);
   }
 };
 
@@ -104,13 +103,12 @@ class TorchAttentionCodeGen : public TorchOpCode {
  protected:
   void CodeGenForward() final {
     std::string causal_mask;
-    stack_.op_start().op_inputs_arg(false);
+    stack_.op_call().op_inputs_arg(false);
     if (node()->GetAttr("causal_mask", &causal_mask)) {
       if (causal_mask.size() > 0) {
         stack_.call_arg(true, "is_causal");
       }
     }
-    stack_.op_end();
   }
 };
 
@@ -121,7 +119,7 @@ class TorchAxesCodeGen : public TorchOpCode {
   void CodeGenInit() final {
     if (module_name().size() > 0) {
       const String& key = node()->HasAttr("axes") ? "axes" : "axis";
-      stack_.op_start().op_list_arg<int>(key, "").op_end();
+      stack_.op_call().op_list_arg<int>(key, "");
     } else {
       TorchOpCode::CodeGenInit();
     }
@@ -132,7 +130,7 @@ class TorchAxesCodeGen : public TorchOpCode {
       TorchOpCode::CodeGenForward();
     } else {
       const String& key = node()->HasAttr("axes") ? "axes" : "axis";
-      stack_.op_start().op_input_arg().op_list_arg<int>(key, "").op_end();
+      stack_.op_call().op_input_arg().op_list_arg<int>(key, "");
     }
   }
 };
@@ -143,7 +141,7 @@ class TorchAxisCodeGen : public TorchOpCode {
  protected:
   void CodeGenInit() final {
     if (module_name().size() > 0) {
-      stack_.op_start().op_arg<int>("axis", "dim").op_end();
+      stack_.op_call().op_arg<int>("axis", "dim");
     } else {
       TorchOpCode::CodeGenInit();
     }
@@ -153,7 +151,7 @@ class TorchAxisCodeGen : public TorchOpCode {
     if (module_name().size() > 0) {
       TorchOpCode::CodeGenForward();
     } else {
-      stack_.op_start().op_input_arg().op_arg<int>("axis", "dim").op_end();
+      stack_.op_call().op_input_arg().op_arg<int>("axis", "dim");
     }
   }
 };
@@ -166,10 +164,7 @@ class TorchBatchNormCodeGen : public TorchOpCode {
     ICHECK(node()->GetTypeAttr<bool>("center") && node()->GetTypeAttr<bool>("scale"))
         << "Only support center and scale batchnorm, get " << node();
     const auto& gamma = node()->WeightAt("gamma");
-    stack_.op_start()
-        .call_arg(gamma->DimAt(0), "num_features")
-        .op_arg<float>("epsilon", "eps")
-        .op_end();
+    stack_.op_call().call_arg(gamma->DimAt(0), "num_features").op_arg<float>("epsilon", "eps");
   }
 };
 
@@ -178,10 +173,7 @@ class TorchBroadcastToCodeGen : public TorchOpCode {
 
  protected:
   void CodeGenForward() final {
-    stack_.assign(IdxNode(), IdxInput())
-        .inplace_start("expand")
-        .call_list_arg(node()->GetTypeArrayAttr<int>("shape"), "", false, true)
-        .inplace_end();
+    stack_.assign(IdxNode(), IdxInput()).method_call("expand").op_list_arg<int>("shape", "");
   }
 };
 
@@ -190,7 +182,7 @@ class TorchClipCodeGen : public TorchOpCode {
 
  protected:
   void CodeGenForward() final {
-    stack_.op_start().op_input_arg().op_arg<float>("min").op_arg<float>("max").op_end();
+    stack_.op_call().op_input_arg().op_arg<float>("min").op_arg<float>("max");
   }
 };
 
@@ -208,12 +200,10 @@ class TorchConstantCodeGen : public TorchOpCode {
         stack_.assign(module_ref(), node()->GetTypeAttr<float>("scalar"));
       }
     } else {
-      stack_.call_start("torch.Tensor")
-          .call_list_arg(node()->OutputAt(0)->shape, "", false, false)
-          .call_end("data")
-          .op_start()
-          .call_arg("data")
-          .op_end();
+      stack_.func_call("torch.Tensor", "data")
+          .call_arg(DocUtils::ToDocList(node()->OutputAt(0)->shape))
+          .op_call()
+          .call_arg("data");
     }
   }
 
@@ -235,16 +225,15 @@ class TorchConvCodeGen : public TorchOpCode {
       }
       kernel_size.push_back(weight->DimAt(i)->value);
     }
-    stack_.op_start()
+    stack_.op_call()
         .call_arg(weight->DimAt("I"), "in_channels")
         .call_arg(weight->DimAt("O"), "out_channels")
-        .call_list_arg(kernel_size, "kernel_size")
+        .call_arg(DocUtils::ToListDoc(kernel_size), "kernel_size")
         .op_list_arg<int>("strides", "stride")
-        .call_list_arg(GetPadding(), "padding")
+        .call_arg(GetPadding(), "padding")
         .op_list_arg<int>("dilation")
         .op_arg<int>("groups")
-        .call_arg(use_bias_, "bias")
-        .op_end();
+        .call_arg(use_bias_, "bias");
   }
 
  private:
@@ -256,11 +245,10 @@ class TorchCumsumCodeGen : public TorchOpCode {
 
  protected:
   void CodeGenForward() final {
-    stack_.op_start()
+    stack_.op_call()
         .op_input_arg()
         .op_arg<int>("axis", "dim")
-        .call_dtype_arg(node()->OutputAt(0)->dtype, "dtype")
-        .op_end();
+        .op_dtype_arg(node()->OutputAt(0)->dtype, "dtype");
   }
 };
 
@@ -270,10 +258,9 @@ class TorchEmbeddingCodeGen : public TorchOpCode {
  protected:
   void CodeGenInit() final {
     const auto& weight = node()->WeightAt("weight");
-    stack_.op_start()
+    stack_.op_call()
         .call_arg(weight->DimAt("W"), "num_embeddings")
-        .call_arg(weight->DimAt("E"), "embedding_dim")
-        .op_end();
+        .call_arg(weight->DimAt("E"), "embedding_dim");
   }
 };
 
@@ -289,7 +276,7 @@ class TorchExpandDimsCodeGen : public TorchOpCode {
       if (i < axes.size() - 1) {
         idx_out = idx_out + "_" + std::to_string(i);
       }
-      stack_.op_start().call_arg(idx_input).call_arg(axes[i], "dim").op_end();
+      stack_.op_call().call_arg(idx_input).call_arg(axes[i], "dim");
       idx_input = idx_out;
     }
   }
@@ -300,11 +287,10 @@ class TorchFullCodeGen : public TorchOpCode {
 
  protected:
   void CodeGenForward() final {
-    stack_.op_start()
+    stack_.op_call()
         .op_list_arg<int>("shape", "size")
         .op_input_arg(0, "fill_value")
-        .call_dtype_arg(node()->OutputAt(0)->dtype, "dtype")
-        .op_end();
+        .op_dtype_arg(node()->OutputAt(0)->dtype, "dtype");
   }
 };
 
@@ -325,11 +311,10 @@ class TorchGroupNormCodeGen : public TorchOpCode {
     ICHECK(node()->GetTypeAttr<bool>("center") && node()->GetTypeAttr<bool>("scale"))
         << "Only support center and scale batchnorm, get " << node();
     int channel_axis = node()->GetTypeAttr<int>("channel_axis");
-    stack_.op_start()
+    stack_.op_call()
         .op_arg<int>("num_groups")
         .call_arg(node()->InputAt(0)->DimAt(channel_axis), "num_channels")
-        .op_arg<float>("epsilon", "eps")
-        .op_end();
+        .op_arg<float>("epsilon", "eps");
   }
 };
 
@@ -346,10 +331,9 @@ class TorchLayerNormCodeGen : public TorchOpCode {
     for (const auto& a : axes) {
       normalized_shape.push_back(node()->InputAt(0)->DimAt(a));
     }
-    stack_.op_start()
-        .call_list_arg(normalized_shape, "normalized_shape")
-        .op_arg<float>("epsilon", "eps")
-        .op_end();
+    stack_.op_call()
+        .call_arg(DocUtils::ToListDoc(normalized_shape), "normalized_shape")
+        .op_arg<float>("epsilon", "eps");
   }
 };
 
@@ -361,11 +345,10 @@ class TorchLinearCodeGen : public TorchOpCode {
  protected:
   void CodeGenInit() final {
     const auto& weight = node()->WeightAt("weight");
-    stack_.op_start()
+    stack_.op_call()
         .call_arg(weight->DimAt("I"), "in_features")
         .call_arg(weight->DimAt("O"), "out_features")
-        .call_arg(use_bias_, "bias")
-        .op_end();
+        .call_arg(use_bias_, "bias");
   }
 
  private:
@@ -377,11 +360,7 @@ class TorchNllLossCodeGen : public TorchOpCode {
 
  protected:
   void CodeGenForward() final {
-    stack_.op_start()
-        .op_inputs_arg(false)
-        .op_str_arg("reduction")
-        .op_arg<int>("ignore_index")
-        .op_end();
+    stack_.op_call().op_inputs_arg(false).op_str_arg("reduction").op_arg<int>("ignore_index");
   }
 };
 
@@ -390,15 +369,44 @@ class TorchPoolCodeGen : public TorchOpCode {
 
  protected:
   void CodeGenInit() final {
-    stack_.op_start()
+    stack_.op_call()
         .op_list_arg<int>("pool_size", "kernel_size")
         .op_list_arg<int>("strides", "stride")
-        .call_list_arg(GetPadding(), "padding")
+        .call_arg(GetPadding(), "padding")
         .op_arg<bool>("ceil_mode");
     if (node()->optype == "nn.max_pool2d") {
       stack_.op_list_arg<int>("dilation");
     }
-    stack_.op_end();
+  }
+};
+
+class TorchPermuteDimsCodeGen : public TorchOpCode {
+  TORCH_OP_CODEGEN_METHODS(TorchPermuteDimsCodeGen)
+
+ protected:
+  void CodeGenForward() final {
+    std::vector<int> axes;
+    if (!node()->GetAttr("axes", &axes)) {
+      for (size_t i = node()->InputAt(0)->Ndim(); i > 0; i--) {
+        axes.push_back(i - 1);
+      }
+    }
+    stack_.op_call().op_input_arg().call_arg(DocUtils::ToListDoc(axes));
+  }
+};
+
+class TorchPermuteDimsCodeGen : public TorchOpCode {
+  TORCH_OP_CODEGEN_METHODS(TorchPermuteDimsCodeGen)
+
+ protected:
+  void CodeGenForward() final {
+    std::vector<int> axes;
+    if (!node()->GetAttr("axes", &axes)) {
+      for (size_t i = node()->InputAt(0)->Ndim(); i > 0; i--) {
+        axes.push_back(i - 1);
+      }
+    }
+    stack_.op_start().op_input_arg().call_list_arg(axes).op_end();
   }
 };
 
@@ -409,13 +417,13 @@ class TorchReduceAxisCodeGen : public TorchOpCode {
 
  protected:
   void CodeGenForward() final {
-    stack_.op_start().op_input_arg();
+    stack_.op_call().op_input_arg();
     if (as_list_) {
       stack_.op_list_arg<int>("axis", "dim");
     } else {
       stack_.op_arg<int>("axis", "dim");
     }
-    stack_.op_arg<bool>("keepdims", "keepdim").op_end();
+    stack_.op_arg<bool>("keepdims", "keepdim");
   }
 
  private:
@@ -438,9 +446,8 @@ class TorchRepeatCodeGen : public TorchOpCode {
       }
     }
     stack_.assign(IdxNode(), IdxInput())
-        .inplace_start("repeat")
-        .call_list_arg(repeats, "", false, true)
-        .inplace_end();
+        .method_call("repeat")
+        .call_arg(DocUtils::ToListDoc(repeats), "");
   }
 };
 
@@ -457,7 +464,7 @@ class TorchReshapeCodeGen : public TorchOpCode {
         shape[batch_dim] = -1;
       }
     }
-    stack_.op_start().op_input_arg().call_list_arg(shape).op_end();
+    stack_.op_call().op_input_arg().call_arg(DocUtils::ToListDoc(shape));
   }
 };
 
@@ -473,11 +480,8 @@ class TorchResize2dCodeGen : public TorchOpCode {
     } else {
       LOG(FATAL) << "Unexpected resize2d method " << method;
     }
-    stack_.op_start()
-        .op_input_arg()
-        .op_list_arg<int>("size")
-        .call_str_arg(v_method, "mode")
-        .op_end();
+    stack_.op_call().op_input_arg().op_list_arg<int>("size").call_arg(DocUtils::ToStrDoc(v_method),
+                                                                      "mode");
   }
 };
 
@@ -487,9 +491,9 @@ class TorchShapeCodeGen : public TorchOpCode {
  protected:
   void CodeGenForward() final {
     if (node()->inputs.size() == 0) {
-      stack_.op_start().op_list_arg<int>("shape", "").op_end();
+      stack_.op_call().op_list_arg<int>("shape", "");
     } else {
-      stack_.assign(IdxNode(), IdxInput()).inplace_start("size").inplace_end();
+      stack_.assign(IdxNode(), IdxInput()).method_call("size");
     }
   }
 };
@@ -503,13 +507,14 @@ class TorchSplitCodeGen : public TorchOpCode {
 
  protected:
   void CodeGenForward() final {
-    stack_.op_start().op_input_arg();
+    stack_.op_call().op_input_arg();
     std::vector<int64_t> indices;
     int axis = node()->GetTypeAttr<int>("axis");
     for (size_t i = 0; i < node()->outputs.size(); i++) {
       indices.push_back(node()->OutputAt(i)->DimAt(axis)->value);
     }
-    stack_.call_list_arg(indices, "split_size_or_sections").op_arg<int>("axis", "dim").op_end();
+    stack_.call_arg(DocUtils::ToListDoc(indices), "split_size_or_sections")
+        .op_arg<int>("axis", "dim");
   }
 };
 
@@ -536,7 +541,7 @@ class TorchStridedSliceCodeGen : public TorchOpCode {
         slice.push_back(":");
       }
     }
-    stack_.assign_index(IdxNode(), IdxInput(), slice);
+    stack_.assign(IdxNode(), DocUtils::ToIndexDoc(IdxInput(), slice));
   }
 };
 
@@ -544,16 +549,14 @@ class TorchTriCodeGen : public TorchOpCode {
   TORCH_OP_CODEGEN_METHODS(TorchTriCodeGen)
 
  protected:
-  void CodeGenForward() final {
-    stack_.op_start().op_input_arg().op_arg<int>("k", "diagonal").op_end();
-  }
+  void CodeGenForward() final { stack_.op_call().op_input_arg().op_arg<int>("k", "diagonal"); }
 };
 
 class TorchTupleCodeGen : public TorchOpCode {
   TORCH_OP_CODEGEN_METHODS(TorchTupleCodeGen)
 
  protected:
-  void CodeGenForward() final { stack_.op_start().op_inputs_arg().op_end(); }
+  void CodeGenForward() final { stack_.op_call().op_inputs_arg(); }
 };
 
 const std::shared_ptr<std::unordered_map<String, std::shared_ptr<TorchOpCode>>> GetTorchOpCodes() {
@@ -623,7 +626,6 @@ const std::shared_ptr<std::unordered_map<String, std::shared_ptr<TorchOpCode>>> 
                std::make_shared<TorchAxisCodeGen>("nn.LogSoftmax", "functional.log_softmax"));
   map->emplace("nn.softmax",
                std::make_shared<TorchAxisCodeGen>("nn.Softmax", "functional.softmax"));
-  map->emplace("permute_dims", std::make_shared<TorchAxesCodeGen>("", "torch.permute"));
   map->emplace("squeeze", std::make_shared<TorchAxesCodeGen>("", "torch.squeeze"));
 
   // math ops
@@ -632,6 +634,7 @@ const std::shared_ptr<std::unordered_map<String, std::shared_ptr<TorchOpCode>>> 
   map->emplace("clip", std::make_shared<TorchClipCodeGen>("", "torch.clamp"));
   map->emplace("cumsum", std::make_shared<TorchCumsumCodeGen>("", "torch.cumsum"));
   map->emplace("expand_dims", std::make_shared<TorchExpandDimsCodeGen>("", "torch.unsqueeze"));
+  map->emplace("permute_dims", std::make_shared<TorchPermuteDimsCodeGen>("", "torch.permute"));
   map->emplace("repeat", std::make_shared<TorchRepeatCodeGen>("", "repeat"));
   map->emplace("reshape", std::make_shared<TorchReshapeCodeGen>("", "torch.reshape"));
   map->emplace("split", std::make_shared<TorchSplitCodeGen>("", "torch.split"));

--- a/src/contrib/msc/framework/torch/torch_opcode.h
+++ b/src/contrib/msc/framework/torch/torch_opcode.h
@@ -96,7 +96,7 @@ class TorchOpCode : public BaseOpCode<TorchCodeGenConfig> {
   virtual void CodeGenForward();
 
   /*! \brief Get the padding from op*/
-  const std::vector<int> GetPadding(const String& key = "padding");
+  const StrictListDoc GetPadding(const String& key = "padding");
 
   /*! \brief Get the is_init_ of codegen*/
   bool is_init() { return is_init_; }

--- a/src/contrib/msc/framework/tvm/relax_opcode.cc
+++ b/src/contrib/msc/framework/tvm/relax_opcode.cc
@@ -326,13 +326,6 @@ class RelaxCreateLikeCodeGen : public RelaxOpCode {
   void CodeGenBuild() final { stack_.op_call().op_input_arg().op_str_arg("dtype"); }
 };
 
-class RelaxCreateLikeCodeGen : public RelaxOpCode {
-  RELAX_OP_CODEGEN_METHODS(RelaxCreateLikeCodeGen)
-
- protected:
-  void CodeGenBuild() final { stack_.op_start().op_input_arg().op_str_arg("dtype").op_end(); }
-};
-
 class RelaxCumsumCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxCumsumCodeGen)
 
@@ -356,23 +349,6 @@ class RelaxEinsumCodeGen : public RelaxOpCode {
       stack_.op_inputs_arg();
     }
     stack_.op_str_arg(key, "subscripts");
-  }
-};
-
-class RelaxEinsumCodeGen : public RelaxOpCode {
-  RELAX_OP_CODEGEN_METHODS(RelaxEinsumCodeGen)
-
- protected:
-  void CodeGenBuild() final {
-    const String& key = config()->from_relay ? "equation" : "subscripts";
-    const auto& producer = node()->ProducerOf(0);
-    stack_.op_start();
-    if (node()->inputs.size() == 1 && producer->optype == "tuple") {
-      stack_.op_input_arg();
-    } else {
-      stack_.op_inputs_arg();
-    }
-    stack_.op_str_arg(key, "subscripts").op_end();
   }
 };
 
@@ -532,28 +508,6 @@ class RelaxPadCodeGen : public RelaxOpCode {
   }
 };
 
-class RelaxPadCodeGen : public RelaxOpCode {
-  RELAX_OP_CODEGEN_METHODS(RelaxPadCodeGen)
-
- protected:
-  void CodeGenBuild() final {
-    Array<String> pad_width;
-    const auto& attr_pad_width = node()->GetTypeArrayAttr<int>("pad_width");
-    ICHECK(attr_pad_width.size() % 2 == 0) << "pad_width should be multiple of 2, get " << node();
-    for (size_t i = 0; i < attr_pad_width.size(); i += 2) {
-      const String& cur_pad = "[" + std::to_string(attr_pad_width[i]) + ", " +
-                              std::to_string(attr_pad_width[i + 1]) + "]";
-      pad_width.push_back(cur_pad);
-    }
-    stack_.op_start()
-        .op_input_arg()
-        .op_list_arg<int>("pad_width")
-        .op_input_arg(1, "pad_value")
-        .op_str_arg("pad_mode")
-        .op_end();
-  }
-};
-
 class RelaxPool2dCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxPool2dCodeGen)
 
@@ -583,21 +537,6 @@ class RelaxPermuteDimsCodeGen : public RelaxOpCode {
       }
     }
     stack_.op_call().op_input_arg().call_arg(DocUtils::ToListDoc(axes), "axes");
-  }
-};
-
-class RelaxPermuteDimsCodeGen : public RelaxOpCode {
-  RELAX_OP_CODEGEN_METHODS(RelaxPermuteDimsCodeGen)
-
- protected:
-  void CodeGenBuild() final {
-    std::vector<int> axes;
-    if (!node()->GetAttr("axes", &axes)) {
-      for (size_t i = node()->InputAt(0)->Ndim(); i > 0; i--) {
-        axes.push_back(i - 1);
-      }
-    }
-    stack_.op_start().op_input_arg().call_list_arg(axes, "axes").op_end();
   }
 };
 
@@ -717,16 +656,6 @@ class RelaxTileCodeGen : public RelaxOpCode {
   void CodeGenBuild() final {
     const String& key = config()->from_relay ? "reps" : "repeats";
     stack_.op_call().op_input_arg().op_list_arg<int>(key, "repeats");
-  }
-};
-
-class RelaxTileCodeGen : public RelaxOpCode {
-  RELAX_OP_CODEGEN_METHODS(RelaxTileCodeGen)
-
- protected:
-  void CodeGenBuild() final {
-    const String& key = config()->from_relay ? "reps" : "repeats";
-    stack_.op_start().op_input_arg().op_list_arg<int>(key, "repeats").op_end();
   }
 };
 

--- a/src/contrib/msc/framework/tvm/relax_opcode.cc
+++ b/src/contrib/msc/framework/tvm/relax_opcode.cc
@@ -47,19 +47,18 @@ const Array<Doc> RelaxOpCode::GetDocs() {
 }
 
 void RelaxOpCode::BuilderEmit(const String& ret, const String& name) {
-  stack_.call_start("block_builder.emit").call_arg(ret);
+  stack_.func_call("block_builder.emit", ret).call_arg(ret);
   if (name.size() > 0) {
-    stack_.call_str_arg(name, "name_hint");
+    stack_.call_arg(DocUtils::ToStrDoc(name), "name_hint");
   }
-  stack_.call_end(ret);
 }
 
-const std::string RelaxOpCode::GetOutDtype(const String& key) {
+const ExprDoc RelaxOpCode::GetOutDtype(const String& key) {
   std::string out_dtype;
   if (!node()->GetAttr(key, &out_dtype) && config()->from_relay) {
-    return node()->OutputAt(0)->DTypeName();
+    return DocUtils::ToStrDoc(node()->OutputAt(0)->DTypeName());
   }
-  return out_dtype;
+  return DocUtils::ToStrDoc(out_dtype);
 }
 
 const std::vector<int> RelaxOpCode::GetAxes(const String& key) {
@@ -77,83 +76,119 @@ const std::vector<int> RelaxOpCode::GetAxes(const String& key) {
 
 class RelaxAdaptivePool2dCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxAdaptivePool2dCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start()
+    stack_.op_call()
         .op_input_arg()
         .op_list_arg<int>("output_size")
         .op_str_arg("layout")
-        .op_str_arg("out_layout")
-        .op_end();
+        .op_str_arg("out_layout");
   }
 };
 
 class RelaxAstypeCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxAstypeCodeGen)
+
  protected:
-  void CodeGenBuild() final { stack_.op_start().op_input_arg().op_str_arg("dtype").op_end(); }
+  void CodeGenBuild() final { stack_.op_call().op_input_arg().op_str_arg("dtype"); }
 };
 
 class RelaxAttentionCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxAttentionCodeGen)
+
  protected:
   void CodeGenBuild() final {
     for (size_t i = 0; i < 3; i++) {
       const String& axes_key = i == 0 ? "axes" : "axes_" + std::to_string(i);
-      stack_.op_start("relax.op.permute_dims")
+      stack_.op_call("relax.op.permute_dims", IdxInput(i))
           .op_input_arg(i)
-          .op_list_arg<int>(axes_key, "axes")
-          .op_end(IdxInput(i));
+          .op_list_arg<int>(axes_key, "axes");
     }
-    stack_.op_start()
-        .op_inputs_arg(false)
-        .op_arg<float>("scale")
-        .op_str_arg("causal_mask")
-        .op_end();
+    stack_.op_call().op_inputs_arg(false).op_arg<float>("scale").op_str_arg("causal_mask");
   }
 };
 
 class RelaxAxisCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxAxisCodeGen)
+
  protected:
   void CodeGenBuild() final {
     std::vector<int> axes = GetAxes("axis");
-    stack_.op_start().op_input_arg();
+    stack_.op_call().op_input_arg();
     if (axes.size() > 0) {
       stack_.call_arg(axes[0], "axis");
     }
-    stack_.op_end();
   }
 };
 
 class RelaxAxesCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxAxesCodeGen)
+
  protected:
   void CodeGenBuild() final {
     const String& key = node()->HasAttr("axes") ? "axes" : "axis";
-    stack_.op_start().op_input_arg().call_list_arg(GetAxes(key), key).op_end();
+    stack_.op_call().op_input_arg().call_arg(DocUtils::ToListDoc(GetAxes(key)), key);
   }
 };
 
 class RelaxBatchMatmulCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxBatchMatmulCodeGen)
+
  protected:
   void CodeGenBuild() final {
     bool transpose_a = node()->GetTypeAttr<bool>("transpose_a");
     bool transpose_b = node()->GetTypeAttr<bool>("transpose_b");
     if (!transpose_a && !transpose_b) {
-      stack_.op_start().op_inputs_arg(false).op_str_arg("out_dtype").op_end();
+      stack_.op_call().op_inputs_arg(false).op_str_arg("out_dtype");
+    } else if (transpose_a && !transpose_b) {
+      std::vector<size_t> axes;
+      for (size_t i = 0; i < node()->InputAt(0)->Ndim() - 2; i++) {
+        axes.push_back(i);
+      }
+      axes.push_back(node()->InputAt(0)->Ndim() - 1);
+      axes.push_back(node()->InputAt(0)->Ndim() - 2);
+      stack_.op_call("relax.op.permute_dims", IdxInput(0))
+          .op_input_arg()
+          .call_arg(DocUtils::ToListDoc(axes));
+      BuilderEmit(IdxInput(0));
+      stack_.op_call().op_inputs_arg(false).op_str_arg("out_dtype");
+    } else if (!transpose_a && transpose_b) {
+      std::vector<size_t> axes;
+      for (size_t i = 0; i < node()->InputAt(1)->Ndim() - 2; i++) {
+        axes.push_back(i);
+      }
+      axes.push_back(node()->InputAt(1)->Ndim() - 1);
+      axes.push_back(node()->InputAt(1)->Ndim() - 2);
+      stack_.op_call("relax.op.permute_dims", IdxInput(1))
+          .op_input_arg(1)
+          .call_arg(DocUtils::ToListDoc(axes));
+      BuilderEmit(IdxInput(1));
+      stack_.op_call().op_inputs_arg(false).op_str_arg("out_dtype");
     } else {
-      LOG(FATAL) << "Unexpected nn.batch_matmul " << node();
+      for (size_t idx = 0; idx < 2; idx++) {
+        std::vector<size_t> axes;
+        for (size_t i = 0; i < node()->InputAt(idx)->Ndim() - 2; i++) {
+          axes.push_back(i);
+        }
+        axes.push_back(node()->InputAt(idx)->Ndim() - 1);
+        axes.push_back(node()->InputAt(idx)->Ndim() - 2);
+        stack_.op_call("relax.op.permute_dims", IdxInput(idx))
+            .op_input_arg(idx)
+            .call_arg(DocUtils::ToListDoc(axes));
+        BuilderEmit(IdxInput(idx));
+      }
+      stack_.op_call().op_inputs_arg(false).op_str_arg("out_dtype");
     }
   }
 };
 
 class RelaxBatchNormCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxBatchNormCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start()
+    stack_.op_call()
         .op_input_arg()
         .op_weight_arg("gamma")
         .op_weight_arg("beta")
@@ -163,16 +198,16 @@ class RelaxBatchNormCodeGen : public RelaxOpCode {
         .op_arg<float>("epsilon")
         .op_arg<bool>("center")
         .op_arg<bool>("scale")
-        .op_arg<float>("momentum")
-        .op_end();
+        .op_arg<float>("momentum");
   }
 };
 
 class RelaxBiasAddCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxBiasAddCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    int axis = node()->GetTypeAttr<int>("axis");
+    int axis = CommonUtils::GetIndex(node()->GetTypeAttr<int>("axis"), node()->OutputAt(0)->Ndim());
     Array<Integer> expand_shape;
     for (size_t i = 0; i < node()->InputAt(0)->Ndim(); i++) {
       if (i == static_cast<size_t>(axis)) {
@@ -181,47 +216,53 @@ class RelaxBiasAddCodeGen : public RelaxOpCode {
         expand_shape.push_back(Integer(1));
       }
     }
-    stack_.op_start("relax.op.reshape")
+    stack_.op_call("relax.op.reshape", IdxInput(1))
         .op_input_arg(1)
-        .call_list_arg(expand_shape, "shape")
-        .call_end(IdxInput(1));
+        .call_arg(DocUtils::ToListDoc(expand_shape), "shape");
     BuilderEmit(IdxInput(1));
-    stack_.op_start().op_inputs_arg(false).op_end();
+    stack_.op_call().op_inputs_arg(false);
   }
 };
 
 class RelaxBroadcastToCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxBroadcastToCodeGen)
+
  protected:
-  void CodeGenBuild() final { stack_.op_start().op_input_arg().op_list_arg<int>("shape").op_end(); }
+  void CodeGenBuild() final { stack_.op_call().op_input_arg().op_list_arg<int>("shape"); }
 };
 
 class RelaxClipCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxClipCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start().op_input_arg();
+    stack_.op_call().op_input_arg();
     if (config()->from_relay) {
       stack_.op_arg<float>("a_min", "min").op_arg<float>("a_max", "max");
     } else {
       stack_.op_arg<float>("min").op_arg<float>("max");
     }
-    stack_.op_end();
   }
+};
+
+class RelaxConcatCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxConcatCodeGen)
+
+ protected:
+  void CodeGenBuild() final { stack_.op_call().op_inputs_arg().op_arg<int>("axis"); }
 };
 
 class RelaxConstantCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxConstantCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start()
-        .call_str_arg(node()->name)
-        .call_inplace_start("relax.TensorStructInfo")
-        .call_list_arg(node()->OutputAt(0)->shape, "", true)
-        .call_str_arg(node()->OutputAt(0)->DTypeName())
-        .call_inplace_end()
-        .call_end()
-        .op_end();
+    stack_.op_call()
+        .op_name_arg("")
+        .func_call("relax.TensorStructInfo")
+        .call_arg(DocUtils::ToListDoc(node()->OutputAt(0)->shape, true), "")
+        .call_arg(DocUtils::ToStrDoc(node()->OutputAt(0)->DTypeName()))
+        .pop_nest();
   }
 };
 
@@ -232,7 +273,7 @@ class RelaxConvCodeGen : public RelaxOpCode {
 
  protected:
   void CodeGenBuild() final {
-    stack_.op_start()
+    stack_.op_call()
         .op_input_arg()
         .op_weight_arg("weight")
         .op_list_arg<int>("strides")
@@ -242,8 +283,7 @@ class RelaxConvCodeGen : public RelaxOpCode {
         .op_str_arg("data_layout")
         .op_str_arg("kernel_layout")
         .op_str_arg("out_layout")
-        .call_str_arg(GetOutDtype(), "out_dtype")
-        .op_end();
+        .call_arg(GetOutDtype(), "out_dtype");
     if (use_bias_) {
       std::string out_layout_str;
       if (!node()->GetAttr("out_layout", &out_layout_str)) {
@@ -260,15 +300,11 @@ class RelaxConvCodeGen : public RelaxOpCode {
         }
       }
       BuilderEmit(IdxNode());
-      stack_.call_start("relax.op.reshape")
-          .call_arg(IdxWeight("bias", true))
-          .call_list_arg(expand_shape, "shape")
-          .call_end("expand_bias");
+      stack_.func_call("relax.op.reshape", "expand_bias")
+          .op_weight_arg("bias")
+          .call_arg(DocUtils::ToListDoc(expand_shape), "shape");
       BuilderEmit("expand_bias");
-      stack_.call_start("relax.op.add")
-          .call_arg(IdxNode())
-          .call_arg("expand_bias")
-          .call_end(IdxNode());
+      stack_.func_call("relax.op.add", IdxNode()).call_arg(IdxNode()).call_arg("expand_bias");
     }
   }
 
@@ -278,22 +314,71 @@ class RelaxConvCodeGen : public RelaxOpCode {
 
 class RelaxCreateCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxCreateCodeGen)
+
  protected:
-  void CodeGenBuild() final {
-    stack_.op_start().op_list_arg<int>("shape").op_str_arg("dtype").op_end();
-  }
+  void CodeGenBuild() final { stack_.op_call().op_list_arg<int>("shape").op_str_arg("dtype"); }
+};
+
+class RelaxCreateLikeCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxCreateLikeCodeGen)
+
+ protected:
+  void CodeGenBuild() final { stack_.op_call().op_input_arg().op_str_arg("dtype"); }
+};
+
+class RelaxCreateLikeCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxCreateLikeCodeGen)
+
+ protected:
+  void CodeGenBuild() final { stack_.op_start().op_input_arg().op_str_arg("dtype").op_end(); }
 };
 
 class RelaxCumsumCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxCumsumCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start().op_input_arg().op_arg<int>("axis").op_str_arg("dtype").op_end();
+    stack_.op_call().op_input_arg().op_arg<int>("axis").op_str_arg("dtype");
+  }
+};
+
+class RelaxEinsumCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxEinsumCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    const String& key = config()->from_relay ? "equation" : "subscripts";
+    const auto& producer = node()->ProducerOf(0);
+    stack_.op_call();
+    if (node()->inputs.size() == 1 && producer->optype == "tuple") {
+      stack_.op_input_arg();
+    } else {
+      stack_.op_inputs_arg();
+    }
+    stack_.op_str_arg(key, "subscripts");
+  }
+};
+
+class RelaxEinsumCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxEinsumCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    const String& key = config()->from_relay ? "equation" : "subscripts";
+    const auto& producer = node()->ProducerOf(0);
+    stack_.op_start();
+    if (node()->inputs.size() == 1 && producer->optype == "tuple") {
+      stack_.op_input_arg();
+    } else {
+      stack_.op_inputs_arg();
+    }
+    stack_.op_str_arg(key, "subscripts").op_end();
   }
 };
 
 class RelaxStridedSliceCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxStridedSliceCodeGen)
+
  protected:
   void CodeGenBuild() final {
     std::vector<int> axes;
@@ -302,13 +387,12 @@ class RelaxStridedSliceCodeGen : public RelaxOpCode {
         axes.push_back(i);
       }
     }
-    stack_.op_start()
+    stack_.op_call()
         .op_input_arg()
-        .call_list_arg(axes, "axes")
+        .call_arg(DocUtils::ToListDoc(axes), "axes")
         .op_list_arg<int>("begin")
         .op_list_arg<int>("end")
-        .op_list_arg<int>("strides")
-        .op_end();
+        .op_list_arg<int>("strides");
   }
 };
 
@@ -319,119 +403,163 @@ class RelaxEmbeddingCodeGen : public RelaxOpCode {
   void CodeGenBuild() final {
     const auto& input = node()->InputAt(0);
     if (input->DTypeName() != "int32") {
-      stack_.op_start("relax.op.astype").op_input_arg().call_str_arg("int32").op_end(IdxInput());
+      stack_.op_call("relax.op.astype", IdxInput())
+          .op_input_arg()
+          .call_arg(DocUtils::ToStrDoc("int32"));
       BuilderEmit(IdxInput());
     }
     if (input->Ndim() > 1) {
-      stack_.op_start("relax.op.reshape")
+      stack_.op_call("relax.op.reshape", IdxInput())
           .op_input_arg()
-          .call_list_arg(std::vector<int>{-1}, "shape")
-          .op_end(IdxInput());
+          .call_arg(DocUtils::ToListDoc(std::vector<int>{-1}), "shape");
       BuilderEmit(IdxInput());
     }
-    stack_.op_start().op_weight_arg("weight").op_input_arg().op_arg<int>("axis").op_end();
+    stack_.op_call().op_weight_arg("weight").op_input_arg().op_arg<int>("axis");
     if (input->Ndim() > 1) {
       BuilderEmit(IdxNode());
-      stack_.op_start("relax.op.reshape")
+      stack_.op_call("relax.op.reshape")
           .op_output_arg()
-          .call_list_arg(node()->OutputAt(0)->shape)
-          .op_end();
+          .call_arg(DocUtils::ToListDoc(node()->OutputAt(0)->shape));
     }
   }
 };
 
 class RelaxFullCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxFullCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start()
-        .op_list_arg<int>("shape")
-        .op_input_arg(0, "fill_value")
-        .op_str_arg("dtype")
-        .op_end();
+    stack_.op_call().op_list_arg<int>("shape").op_input_arg(0, "fill_value").op_str_arg("dtype");
   }
 };
 
 class RelaxGetItemCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxGetItemCodeGen)
+
  protected:
   void CodeGenBuild() final {
     const auto& producer = node()->ProducerOf(0);
-    stack_.op_start().call_arg(IdxNode(producer)).op_arg<int>("index").call_end(IdxNode());
+    stack_.op_call("msc::auto", IdxNode()).call_arg(IdxNodeBase(producer)).op_arg<int>("index");
   }
 };
 
 class RelaxGroupNormCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxGroupNormCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start().op_input_arg().op_weight_arg("gamma").op_weight_arg("beta").op_arg<int>(
+    stack_.op_call().op_input_arg().op_weight_arg("gamma").op_weight_arg("beta").op_arg<int>(
         "num_groups");
     if (config()->from_relay) {
       std::vector<size_t> axes;
       for (size_t i = 2; i < node()->InputAt(0)->Ndim(); i++) {
         axes.push_back(i);
       }
-      stack_.op_arg<int>("axis", "channel_axis").call_list_arg(axes, "axes");
+      stack_.op_arg<int>("axis", "channel_axis").call_arg(DocUtils::ToListDoc(axes), "axes");
     } else {
       stack_.op_arg<int>("channel_axis").op_list_arg<int>("axes");
     }
-    stack_.op_arg<float>("epsilon").op_arg<bool>("center").op_arg<bool>("scale").op_end();
+    stack_.op_arg<float>("epsilon").op_arg<bool>("center").op_arg<bool>("scale");
   }
 };
 
 class RelaxLayerNormCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxLayerNormCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start().op_input_arg().op_weight_arg("gamma").op_weight_arg("beta");
+    stack_.op_call().op_input_arg().op_weight_arg("gamma").op_weight_arg("beta");
     if (config()->from_relay) {
       stack_.op_arg<int>("axis", "axes");
     } else {
       stack_.op_list_arg<int>("axes");
     }
-    stack_.op_arg<float>("epsilon").op_arg<bool>("center").op_arg<bool>("scale").op_end();
+    stack_.op_arg<float>("epsilon").op_arg<bool>("center").op_arg<bool>("scale");
   }
 };
 
 class RelaxLinearCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxLinearCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start()
-        .op_input_arg()
-        .op_weight_arg("weight")
-        .op_weight_arg("bias")
-        .call_str_arg(GetOutDtype(), "out_dtype")
-        .op_end();
+    stack_.op_call();
+    if (node()->inputs.size() == 1) {
+      stack_.op_input_arg().op_weight_arg("weight").op_weight_arg("bias");
+    } else {
+      stack_.op_inputs_arg(false);
+    }
+    stack_.call_arg(GetOutDtype(), "out_dtype");
   }
 };
 
 class RelaxMatmulCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxMatmulCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start().op_inputs_arg(false).call_str_arg(GetOutDtype(), "out_dtype").op_end();
+    stack_.op_call().op_inputs_arg(false).call_arg(GetOutDtype(), "out_dtype");
   }
 };
 
 class RelaxNllLossCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxNllLossCodeGen)
+
  protected:
   void CodeGenBuild() final {
+    stack_.op_call().op_inputs_arg(false).op_str_arg("reduction").op_arg<int>("ignore_index");
+  }
+};
+
+class RelaxPadCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxPadCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    Array<String> pad_width;
+    const auto& attr_pad_width = node()->GetTypeArrayAttr<int>("pad_width");
+    ICHECK(attr_pad_width.size() % 2 == 0) << "pad_width should be multiple of 2, get " << node();
+    for (size_t i = 0; i < attr_pad_width.size(); i += 2) {
+      const String& cur_pad = "[" + std::to_string(attr_pad_width[i]) + ", " +
+                              std::to_string(attr_pad_width[i + 1]) + "]";
+      pad_width.push_back(cur_pad);
+    }
+    stack_.op_call()
+        .op_input_arg()
+        .op_list_arg<int>("pad_width")
+        .op_input_arg(1, "pad_value")
+        .op_str_arg("pad_mode");
+  }
+};
+
+class RelaxPadCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxPadCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    Array<String> pad_width;
+    const auto& attr_pad_width = node()->GetTypeArrayAttr<int>("pad_width");
+    ICHECK(attr_pad_width.size() % 2 == 0) << "pad_width should be multiple of 2, get " << node();
+    for (size_t i = 0; i < attr_pad_width.size(); i += 2) {
+      const String& cur_pad = "[" + std::to_string(attr_pad_width[i]) + ", " +
+                              std::to_string(attr_pad_width[i + 1]) + "]";
+      pad_width.push_back(cur_pad);
+    }
     stack_.op_start()
-        .op_inputs_arg(false)
-        .op_str_arg("reduction")
-        .op_arg<int>("ignore_index")
+        .op_input_arg()
+        .op_list_arg<int>("pad_width")
+        .op_input_arg(1, "pad_value")
+        .op_str_arg("pad_mode")
         .op_end();
   }
 };
 
 class RelaxPool2dCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxPool2dCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start()
+    stack_.op_call()
         .op_input_arg()
         .op_list_arg<int>("pool_size")
         .op_list_arg<int>("strides")
@@ -439,8 +567,37 @@ class RelaxPool2dCodeGen : public RelaxOpCode {
         .op_list_arg<int>("dilation")
         .op_arg<bool>("ceil_mode")
         .op_str_arg("layout")
-        .op_str_arg("out_layout")
-        .op_end();
+        .op_str_arg("out_layout");
+  }
+};
+
+class RelaxPermuteDimsCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxPermuteDimsCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    std::vector<int> axes;
+    if (!node()->GetAttr("axes", &axes)) {
+      for (size_t i = node()->InputAt(0)->Ndim(); i > 0; i--) {
+        axes.push_back(i - 1);
+      }
+    }
+    stack_.op_call().op_input_arg().call_arg(DocUtils::ToListDoc(axes), "axes");
+  }
+};
+
+class RelaxPermuteDimsCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxPermuteDimsCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    std::vector<int> axes;
+    if (!node()->GetAttr("axes", &axes)) {
+      for (size_t i = node()->InputAt(0)->Ndim(); i > 0; i--) {
+        axes.push_back(i - 1);
+      }
+    }
+    stack_.op_start().op_input_arg().call_list_arg(axes, "axes").op_end();
   }
 };
 
@@ -451,14 +608,14 @@ class RelaxReduceAxisCodeGen : public RelaxOpCode {
 
  protected:
   void CodeGenBuild() final {
-    stack_.op_start().op_input_arg();
+    stack_.op_call().op_input_arg();
     std::vector<int> axes = GetAxes("axis");
     if (as_list_) {
-      stack_.call_list_arg(axes, "axis");
+      stack_.call_arg(DocUtils::ToListDoc(axes), "axis");
     } else if (axes.size() > 0) {
       stack_.call_arg(axes[0], "axis");
     }
-    stack_.op_arg<bool>("keepdims").op_end();
+    stack_.op_arg<bool>("keepdims");
   }
 
  private:
@@ -467,23 +624,24 @@ class RelaxReduceAxisCodeGen : public RelaxOpCode {
 
 class RelaxRepeatCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxRepeatCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start().op_input_arg().op_arg<int>("repeats").op_arg<int>("axis").op_end();
+    stack_.op_call().op_input_arg().op_arg<int>("repeats").op_arg<int>("axis");
   }
 };
 
 class RelaxReshapeCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxReshapeCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start().op_input_arg();
+    stack_.op_call().op_input_arg();
     if (config()->from_relay) {
       stack_.op_list_arg<int>("newshape", "shape");
     } else {
       stack_.op_list_arg<int>("shape");
     }
-    stack_.op_end();
   }
 };
 
@@ -498,12 +656,12 @@ class RelaxResize2dCodeGen : public RelaxOpCode {
     for (const auto& r : roi) {
       roi_list.push_back("float(" + std::to_string(r) + ")");
     }
-    stack_.op_start()
+    stack_.op_call()
         .op_input_arg()
-        .call_inplace_start("relax.ShapeExpr")
+        .func_call("relax.ShapeExpr")
         .op_list_arg<int>("size", "values")
-        .call_inplace_end()
-        .call_list_arg(roi_list)
+        .pop_nest()
+        .call_arg(DocUtils::ToListDoc(roi_list))
         .op_str_arg("layout")
         .op_str_arg("method")
         .op_str_arg("coordinate_transformation_mode")
@@ -511,60 +669,85 @@ class RelaxResize2dCodeGen : public RelaxOpCode {
         .op_arg<float>("cubic_alpha")
         .op_arg<int>("cubic_exclude")
         .op_arg<float>("extrapolation_value")
-        .op_str_arg("out_dtype")
-        .op_end();
+        .op_str_arg("out_dtype");
   }
 };
 
 class RelaxShapeCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxShapeCodeGen)
+
  protected:
-  void CodeGenBuild() final { stack_.op_start().op_list_arg<int>("shape", "values").op_end(); }
+  void CodeGenBuild() final { stack_.op_call().op_list_arg<int>("shape", "values"); }
 };
 
 class RelaxSimpleCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxSimpleCodeGen)
+
  protected:
-  void CodeGenBuild() final { stack_.op_start().op_inputs_arg(false).op_end(); }
+  void CodeGenBuild() final { stack_.op_call().op_inputs_arg(false); }
 };
 
 class RelaxSplitCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxSplitCodeGen)
+
  protected:
   void CodeGenBuild() final {
-    stack_.op_start().op_input_arg();
+    stack_.op_call().op_input_arg();
     int sections;
     if (node()->GetAttr("indices_or_sections", &sections)) {
       stack_.op_arg<int>("indices_or_sections");
     } else {
       stack_.op_list_arg<int>("indices_or_sections");
     }
-    stack_.op_arg<int>("axis").op_end();
+    stack_.op_arg<int>("axis");
   }
 };
 
 class RelaxTakeCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxTakeCodeGen)
+
  protected:
-  void CodeGenBuild() final { stack_.op_start().op_inputs_arg(false).op_arg<int>("axis").op_end(); }
+  void CodeGenBuild() final { stack_.op_call().op_inputs_arg(false).op_arg<int>("axis"); }
+};
+
+class RelaxTileCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxTileCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    const String& key = config()->from_relay ? "reps" : "repeats";
+    stack_.op_call().op_input_arg().op_list_arg<int>(key, "repeats");
+  }
+};
+
+class RelaxTileCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxTileCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    const String& key = config()->from_relay ? "reps" : "repeats";
+    stack_.op_start().op_input_arg().op_list_arg<int>(key, "repeats").op_end();
+  }
 };
 
 class RelaxTupleCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxTupleCodeGen)
+
  protected:
-  void CodeGenBuild() final { stack_.op_start().op_inputs_arg().op_end(); }
+  void CodeGenBuild() final { stack_.op_call().op_inputs_arg(); }
 };
 
 class RelaxTriCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxTriCodeGen)
+
  protected:
   void CodeGenBuild() final {
     if (node()->optype == "trilu") {
       const String& func_name =
           node()->GetTypeAttr<bool>("upper") ? "relax.op.triu" : "relax.op.tril";
-      stack_.op_start(func_name).op_input_arg().op_arg<int>("k").op_end();
+      stack_.op_call(func_name).op_input_arg().op_arg<int>("k");
     } else {
-      stack_.op_start().op_input_arg().op_arg<int>("k").op_end();
+      stack_.op_call().op_input_arg().op_arg<int>("k");
     }
   }
 };
@@ -589,18 +772,23 @@ const std::shared_ptr<std::unordered_map<String, std::shared_ptr<RelaxOpCode>>> 
   map->emplace("cos", std::make_shared<RelaxSimpleCodeGen>("relax.op.cos"));
   map->emplace("cosh", std::make_shared<RelaxSimpleCodeGen>("relax.op.cosh"));
   map->emplace("divide", std::make_shared<RelaxSimpleCodeGen>("relax.op.divide"));
-  map->emplace("exp", std::make_shared<RelaxSimpleCodeGen>("relax.op.exp"));
   map->emplace("equal", std::make_shared<RelaxSimpleCodeGen>("relax.op.equal"));
+  map->emplace("erf", std::make_shared<RelaxSimpleCodeGen>("relax.op.erf"));
+  map->emplace("exp", std::make_shared<RelaxSimpleCodeGen>("relax.op.exp"));
   map->emplace("floor", std::make_shared<RelaxSimpleCodeGen>("relax.op.floor"));
   map->emplace("floor_divide", std::make_shared<RelaxSimpleCodeGen>("relax.op.floor_divide"));
   map->emplace("greater", std::make_shared<RelaxSimpleCodeGen>("relax.op.greater"));
   map->emplace("greater_equal", std::make_shared<RelaxSimpleCodeGen>("relax.op.greater_equal"));
+  map->emplace("isfinite", std::make_shared<RelaxSimpleCodeGen>("relax.op.isfinite"));
+  map->emplace("isinf", std::make_shared<RelaxSimpleCodeGen>("relax.op.isinf"));
+  map->emplace("isnan", std::make_shared<RelaxSimpleCodeGen>("relax.op.isnan"));
   map->emplace("less", std::make_shared<RelaxSimpleCodeGen>("relax.op.less"));
   map->emplace("less_equal", std::make_shared<RelaxSimpleCodeGen>("relax.op.less_equal"));
   map->emplace("log", std::make_shared<RelaxSimpleCodeGen>("relax.op.log"));
   map->emplace("logical_and", std::make_shared<RelaxSimpleCodeGen>("relax.op.logical_and"));
   map->emplace("logical_or", std::make_shared<RelaxSimpleCodeGen>("relax.op.logical_or"));
   map->emplace("logical_xor", std::make_shared<RelaxSimpleCodeGen>("relax.op.logical_xor"));
+  map->emplace("logical_not", std::make_shared<RelaxSimpleCodeGen>("relax.op.logical_not"));
   map->emplace("maximum", std::make_shared<RelaxSimpleCodeGen>("relax.op.maximum"));
   map->emplace("minimum", std::make_shared<RelaxSimpleCodeGen>("relax.op.minimum"));
   map->emplace("multiply", std::make_shared<RelaxSimpleCodeGen>("relax.op.multiply"));
@@ -618,6 +806,7 @@ const std::shared_ptr<std::unordered_map<String, std::shared_ptr<RelaxOpCode>>> 
   map->emplace("subtract", std::make_shared<RelaxSimpleCodeGen>("relax.op.subtract"));
   map->emplace("tan", std::make_shared<RelaxSimpleCodeGen>("relax.op.tan"));
   map->emplace("tanh", std::make_shared<RelaxSimpleCodeGen>("relax.op.tanh"));
+  map->emplace("where", std::make_shared<RelaxSimpleCodeGen>("relax.op.where"));
 
   // reduce axis ops
   map->emplace("argmax", std::make_shared<RelaxReduceAxisCodeGen>("relax.op.argmax", false));
@@ -633,32 +822,38 @@ const std::shared_ptr<std::unordered_map<String, std::shared_ptr<RelaxOpCode>>> 
   map->emplace("nn.log_softmax", std::make_shared<RelaxAxisCodeGen>("relax.op.nn.log_softmax"));
   map->emplace("nn.softmax", std::make_shared<RelaxAxisCodeGen>("relax.op.nn.softmax"));
   map->emplace("expand_dims", std::make_shared<RelaxAxesCodeGen>("relax.op.expand_dims"));
-  map->emplace("permute_dims", std::make_shared<RelaxAxesCodeGen>("relax.op.permute_dims"));
   map->emplace("squeeze", std::make_shared<RelaxAxesCodeGen>("relax.op.squeeze"));
-  map->emplace("transpose", std::make_shared<RelaxAxesCodeGen>("relax.op.permute_dims"));
 
   // math ops
   map->emplace("astype", std::make_shared<RelaxAstypeCodeGen>("relax.op.astype"));
   map->emplace("broadcast_to", std::make_shared<RelaxBroadcastToCodeGen>("relax.op.broadcast_to"));
   map->emplace("cast", std::make_shared<RelaxAstypeCodeGen>("relax.op.astype"));
   map->emplace("clip", std::make_shared<RelaxClipCodeGen>("relax.op.clip"));
+  map->emplace("concat", std::make_shared<RelaxConcatCodeGen>("relax.op.concat"));
+  map->emplace("concatenate", std::make_shared<RelaxConcatCodeGen>("relax.op.concat"));
   map->emplace("cumsum", std::make_shared<RelaxCumsumCodeGen>("relax.op.cumsum"));
+  map->emplace("einsum", std::make_shared<RelaxEinsumCodeGen>("relax.op.einsum"));
   map->emplace("matmul", std::make_shared<RelaxMatmulCodeGen>("relax.op.linear_algebra.matmul"));
+  map->emplace("permute_dims", std::make_shared<RelaxPermuteDimsCodeGen>("relax.op.permute_dims"));
   map->emplace("repeat", std::make_shared<RelaxRepeatCodeGen>("relax.op.repeat"));
   map->emplace("reshape", std::make_shared<RelaxReshapeCodeGen>("relax.op.reshape"));
   map->emplace("split", std::make_shared<RelaxSplitCodeGen>("relax.op.split"));
   map->emplace("strided_slice",
                std::make_shared<RelaxStridedSliceCodeGen>("relax.op.strided_slice"));
   map->emplace("take", std::make_shared<RelaxTakeCodeGen>("relax.op.take"));
+  map->emplace("tile", std::make_shared<RelaxTileCodeGen>("relax.op.tile"));
+  map->emplace("transpose", std::make_shared<RelaxPermuteDimsCodeGen>("relax.op.permute_dims"));
 
   // create ops
   map->emplace("constant", std::make_shared<RelaxConstantCodeGen>("relax.Var"));
   map->emplace("full", std::make_shared<RelaxFullCodeGen>("relax.op.full"));
   map->emplace("ones", std::make_shared<RelaxCreateCodeGen>("relax.op.ones"));
+  map->emplace("ones_like", std::make_shared<RelaxCreateLikeCodeGen>("relax.op.ones_like"));
   map->emplace("tril", std::make_shared<RelaxTriCodeGen>("relax.op.tril"));
   map->emplace("triu", std::make_shared<RelaxTriCodeGen>("relax.op.triu"));
   map->emplace("trilu", std::make_shared<RelaxTriCodeGen>(""));
   map->emplace("zeros", std::make_shared<RelaxCreateCodeGen>("relax.op.zeros"));
+  map->emplace("zeros_like", std::make_shared<RelaxCreateLikeCodeGen>("relax.op.zeros_like"));
 
   // nn ops
   map->emplace("nn.adaptive_avg_pool2d",
@@ -670,11 +865,13 @@ const std::shared_ptr<std::unordered_map<String, std::shared_ptr<RelaxOpCode>>> 
   map->emplace("nn.bias_add", std::make_shared<RelaxBiasAddCodeGen>("relax.op.add"));
   map->emplace("nn.conv1d", std::make_shared<RelaxConvCodeGen>("relax.op.nn.conv1d", false));
   map->emplace("nn.conv2d", std::make_shared<RelaxConvCodeGen>("relax.op.nn.conv2d", false));
+  map->emplace("nn.dense", std::make_shared<RelaxLinearCodeGen>("relax.op.linear_algebra.linear"));
   map->emplace("nn.gelu", std::make_shared<RelaxSimpleCodeGen>("relax.op.nn.gelu"));
   map->emplace("nn.group_norm", std::make_shared<RelaxGroupNormCodeGen>("relax.op.nn.group_norm"));
   map->emplace("nn.layer_norm", std::make_shared<RelaxLayerNormCodeGen>("relax.op.nn.layer_norm"));
   map->emplace("nn.max_pool2d", std::make_shared<RelaxPool2dCodeGen>("relax.op.nn.max_pool2d"));
   map->emplace("nn.nll_loss", std::make_shared<RelaxNllLossCodeGen>("relax.op.nn.nll_loss"));
+  map->emplace("nn.pad", std::make_shared<RelaxPadCodeGen>("relax.op.nn.pad"));
   map->emplace("nn.relu", std::make_shared<RelaxSimpleCodeGen>("relax.op.nn.relu"));
   map->emplace("nn.silu", std::make_shared<RelaxSimpleCodeGen>("relax.op.nn.silu"));
 

--- a/src/contrib/msc/framework/tvm/relax_opcode.h
+++ b/src/contrib/msc/framework/tvm/relax_opcode.h
@@ -64,7 +64,7 @@ class RelaxOpCode : public BaseOpCode<RelaxCodeGenConfig> {
   void BuilderEmit(const String& ret, const String& name = "");
 
   /*! \brief Get the out_dtype attribute*/
-  const std::string GetOutDtype(const String& key = "out_dtype");
+  const ExprDoc GetOutDtype(const String& key = "out_dtype");
 
   /*! \brief Get the axes attribute*/
   const std::vector<int> GetAxes(const String& key = "axes");

--- a/tests/python/contrib/test_msc/test_graph_build.py
+++ b/tests/python/contrib/test_msc/test_graph_build.py
@@ -1416,8 +1416,8 @@ def test_inplace_fill():
 
     expected = {
         "inputs": [{"name": "inp_0", "shape": [10, 10], "dtype": "float32", "layout": ""}],
-        "outputs": [{"name": "full", "shape": [10, 10], "dtype": "float32", "layout": ""}],
-        "nodes": {"total": 3, "input": 1, "constant": 1, "full": 1},
+        "outputs": [{"name": "const", "shape": [10, 10], "dtype": "float32", "layout": ""}],
+        "nodes": {"total": 2, "input": 1, "constant": 1},
     }
 
     verify_model(InplaceFill(), [([10, 10], "float32")], expected)
@@ -1537,8 +1537,8 @@ def test_new_ones():
 
     expected = {
         "inputs": [{"name": "inp_0", "shape": [1, 2, 3], "dtype": "float32", "layout": ""}],
-        "outputs": [{"name": "full", "shape": [1, 2, 3], "dtype": "float32", "layout": ""}],
-        "nodes": {"total": 3, "input": 1, "constant": 1, "full": 1},
+        "outputs": [{"name": "const", "shape": [1, 2, 3], "dtype": "float32", "layout": ""}],
+        "nodes": {"total": 2, "input": 1, "constant": 1},
     }
 
     input_info = [([1, 2, 3], "float32")]

--- a/tests/python/contrib/test_msc/test_translate_relax.py
+++ b/tests/python/contrib/test_msc/test_translate_relax.py
@@ -109,8 +109,8 @@ def test_linear():
 
     input_info = [([1, 3, 10, 10], "float32")]
     verify_model(Dense1(), input_info)
-    # verify_model(Dense2(), input_info)
-    # verify_model(MatMul1(), [([10, 10], "float32"), ([10, 10], "float32")])
+    verify_model(Dense2(), input_info)
+    verify_model(MatMul1(), [([10, 10], "float32"), ([10, 10], "float32")])
 
 
 def test_bmm():

--- a/tests/python/contrib/test_msc/test_translate_relax.py
+++ b/tests/python/contrib/test_msc/test_translate_relax.py
@@ -27,11 +27,11 @@ from tvm.contrib.msc.core.ir import translate
 from tvm.contrib.msc.framework.tvm import codegen as tvm_codegen
 
 
-def verify_model(torch_model, input_info):
+def verify_model(torch_model, input_info, opt_config=None):
     graph_model = fx.symbolic_trace(torch_model)
     with torch.no_grad():
         expected = from_fx(graph_model, input_info)
-    graph, weights = translate.from_relax(expected)
+    graph, weights = translate.from_relax(expected, opt_config=opt_config)
     mod = tvm_codegen.to_relax(graph, weights, codegen_config={"explicit_name": False})
     tvm.ir.assert_structural_equal(mod, expected)
 
@@ -109,8 +109,8 @@ def test_linear():
 
     input_info = [([1, 3, 10, 10], "float32")]
     verify_model(Dense1(), input_info)
-    verify_model(Dense2(), input_info)
-    verify_model(MatMul1(), [([10, 10], "float32"), ([10, 10], "float32")])
+    # verify_model(Dense2(), input_info)
+    # verify_model(MatMul1(), [([10, 10], "float32"), ([10, 10], "float32")])
 
 
 def test_bmm():
@@ -753,7 +753,7 @@ def test_inplace_fill():
             data.fill_(1.5)
             return data
 
-    verify_model(InplaceFill(), [([10, 10], "float32")])
+    verify_model(InplaceFill(), [([10, 10], "float32")], opt_config={"opt_level": 0})
 
 
 def test_arange():
@@ -833,7 +833,7 @@ def test_new_ones():
             return x.new_ones(1, 2, 3)
 
     input_info = [([1, 2, 3], "float32")]
-    verify_model(NewOnes(), input_info)
+    verify_model(NewOnes(), input_info, opt_config={"opt_level": 0})
 
 
 def test_expand():

--- a/tests/python/contrib/test_msc/test_translate_relay.py
+++ b/tests/python/contrib/test_msc/test_translate_relay.py
@@ -158,9 +158,9 @@ def test_linear():
             return torch.matmul(x, y)
 
     input_info = [([1, 3, 10, 10], "float32")]
-    verify_model(Dense1(), input_info)
-    verify_model(Dense2(), input_info)
-    verify_model(MatMul1(), [([10, 10], "float32"), ([10, 10], "float32")])
+    verify_model(Dense1(), input_info, build_target="llvm")
+    verify_model(Dense2(), input_info, build_target="llvm")
+    verify_model(MatMul1(), [([10, 10], "float32"), ([10, 10], "float32")], build_target="llvm")
 
 
 def test_bmm():


### PR DESCRIPTION
This is a pull request for MSC(Multi-System Compile)
RFC: https://discuss.tvm.apache.org/t/rfc-unity-msc-introduction-to-multi-system-compiler/15251/5
Tracking issue: https://github.com/apache/tvm/issues/15233

This is the pre-2nd part of Milestone 1: Finish RuntimeManager for frameworks

To limit each PR in reviewable size, the Milestone 1 will be split into some steps:
M1.1 Add translate && codegen for torch
**pre M1.2 reconstruct codegen**
M1.2 Add translate && codegen for tensorflow
M1.3 Add codegen for tensorrt
M1.4 Add RuntimeManager and test with relax
M1.5 Add RuntimeManager and test with torch
M1.6 Add RuntimeManager and test with tensorflow
M1.7 Add RuntimeManager and test with tensorrt

After I test some cases in tensorrt and tensorflow, I found out that the codegen module need to be reconstructed. To make the development in tensorflow and tensorrt better, This PR change the design of codegen.

@Hzfengsy 
@junrushao 
