### PR TITLE
[Unity] Extend EliminateCommonSubexpr to operate on relax::Expr

### DIFF
--- a/src/relax/transform/utils.h
+++ b/src/relax/transform/utils.h
@@ -388,6 +388,20 @@ inline String GetCodegenName(const std::string& composite_name) {
   return composite_name.substr(0, delim_pos);
 }
 
+/* \brief Eliminate common subexpressions
+ *
+ * Utility for simplifying relax expressions by removing common
+ * subexpressions.
+ *
+ * \param expr The expression to be updated
+ *
+ * \param call_only If true, only eliminate relax::Call nodes.  If
+ * false, eliminate any common subexpressions.
+ *
+ * \ret The updated expression
+ */
+Expr EliminateCommonSubexpr(const Expr& expr, bool call_only = false);
+
 }  // namespace relax
 }  // namespace tvm
 


### PR DESCRIPTION
Prior to this commit, the `EliminateCommonSubexpr` utility could only apply to `relax::Function` instances.  This commit extends the allowed usage to apply to any `relax::Expr` that contains variable bindings. This is only included as an internal utility within the C++ implementation, and is not currently exposed for external use.