### PR TITLE
[TE] Support using tir::Var as CreatePrimFunc args

### DIFF
--- a/python/tvm/te/operation.py
+++ b/python/tvm/te/operation.py
@@ -19,7 +19,7 @@ import inspect
 
 # pylint: disable=invalid-name
 from numbers import Integral as _Integral
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import tvm._ffi
 import tvm.arith._ffi_api
@@ -567,12 +567,12 @@ def reduce_axis(dom, name="rv", thread_tag="", span=None):
 
 
 def create_prim_func(
-    ops: List[_tensor.Tensor], index_dtype_override: Optional[str] = None
+    ops: List[Union[_tensor.Tensor, tvm.tir.Var]], index_dtype_override: Optional[str] = None
 ) -> tvm.tir.PrimFunc:
     """Create a TensorIR PrimFunc from tensor expression
     Parameters
     ----------
-    ops : List[Tensor]
+    ops : List[Union[_tensor.Tensor, tvm.tir.Var]]
         The source expression.
     Example
     -------
@@ -672,4 +672,7 @@ def create_relax_prim_func(
     """
     if not isinstance(ops, (list, tuple, Array)):
         ops = [ops]
-    return _ffi_api.CreateRelaxPrimFunc(ops, tir_var_list, index_dtype_override)
+    arg_list = ops
+    if tir_var_list is not None:
+        arg_list += tir_var_list
+    return _ffi_api.CreatePrimFunc(arg_list, index_dtype_override)

--- a/src/te/operation/create_primfunc.h
+++ b/src/te/operation/create_primfunc.h
@@ -45,8 +45,7 @@ PrimFunc CreatePrimFuncWithConstants(const Array<te::Tensor>& arg_list,
 // Relax version
 // TODO(relax-team) combine with the relay version
 /*! \brief Use Tensor Expression to create a schedulable TensorIR func. */
-PrimFunc CreatePrimFunc(const Array<te::Tensor>& arg_list,
-                        const Optional<Array<tir::Var>> tir_var_list,
+PrimFunc CreatePrimFunc(const Array<ObjectRef>& arg_list,
                         std::optional<DataType> index_dtype_override);
 
 /*! \brief The same as above but create a PrimFunc with AllocateConstNode. If the size of the
@@ -54,10 +53,9 @@ PrimFunc CreatePrimFunc(const Array<te::Tensor>& arg_list,
  * Constant tensors will not be part of the parameters of the created PrimFunc, instead constants
  * will be embedded in the body as AllocateConstNode.
  */
-PrimFunc CreatePrimFuncWithConstants(const Array<te::Tensor>& arg_list,
+PrimFunc CreatePrimFuncWithConstants(const Array<ObjectRef>& arg_list,
                                      const Array<runtime::NDArray>& constants,
-                                     const Optional<Array<tir::Var>>& tir_var_list,
-                                     std::optional<DataType> index_dtype_override = std::nullopt);
+                                     std::optional<DataType> index_dtype_override);
 
 }  // namespace tir
 }  // namespace tvm


### PR DESCRIPTION
- Allow `CreatePrimFunc` args to be a mixture of `te::Tensor` and `tir::Var`.
- Integrate `CreatePrimFunc` and `CreateRelaxPrimFunc` into one function.

```python
idx = te.var("idx", dtype="int64")
m = te.var("m", dtype="int64")
n = te.var("n", dtype="int64")
tensor = te.placeholder((m, n), name="tensor")
slice0 = te.compute((idx, n), lambda i, j: tensor[i, j], name="slice")
# use idx as an arg
te.create_prim_func([tensor, idx, slice])
```

cc: @junrushao @Hzfengsy @yongwww 