### PR TITLE
[Docker] Install oneflow from PyPi

### DIFF
--- a/docker/install/ubuntu_install_oneflow.sh
+++ b/docker/install/ubuntu_install_oneflow.sh
@@ -22,4 +22,4 @@ set -o pipefail
 
 pip3 install flowvision==0.1.0
 
-python3 -m pip install -f https://release.oneflow.info oneflow==0.7.0+cpu
+python3 -m pip install oneflow==0.7.0


### PR DESCRIPTION
Installing oneflow from the current link (https://release.oneflow.info) seems to be broken as reported in #15754, which is impacting other unrelated changes in CI. This commit attempts to fix the install by using a version from PyPi.