### PR TITLE
[Unity][Analysis] Change warning to info for non-affine transform

### DIFF
--- a/src/relax/analysis/layout_transformation.cc
+++ b/src/relax/analysis/layout_transformation.cc
@@ -440,8 +440,8 @@ class BlockAnalyzer : public StmtExprVisitor {
         /*indices=*/indices, /*input_iters*/ spatial_dom_,
         /*predicate*/ 1, /*check_level*/ arith::IterMapLevel::NoCheck, &arith_analyzer_);
     if (result->indices.empty()) {
-      LOG(WARNING) << "[LayoutInference] Failed to analyze indices " << indices
-                   << ", error: " << result->errors;
+      DLOG(INFO) << "[LayoutInference] Failed to analyze indices " << indices
+                 << ", error: " << result->errors;
       return {};
     }
     return GetSpatialLayout(result);


### PR DESCRIPTION
A `PrimFunc` may contain transformations that are not affine, or that are not recognizable as being affine.  Prior to this commit, this produced a `LOG(WARNING)` stating that this was an error in the index analysis.  Because this is the expected behavior for these functions, this commit updates the message to instead write to `DLOG(INFO)`.

The other uses of `LOG(WARNING)` inside `layout_transformation.cc` are kept as-is, as they relate to limitations of the analysis, rather than being a statement about the analyzed `PrimFunc`.