### PR TITLE
[TVMScript] Preserve traceback across TVMScript parsing

### DIFF
--- a/python/tvm/script/parser/core/parser.py
+++ b/python/tvm/script/parser/core/parser.py
@@ -522,7 +522,18 @@ class Parser(doc.NodeVisitor):
             msg = "KeyError: " + str(err)
         else:
             msg = str(err)
-        self.diag.error(node, msg)
+
+        try:
+            self.diag.error(node, msg)
+        except Exception as diag_err:
+            # Calling self.diag.error is guaranteed to throw an
+            # exception.  When shown to a user, this error should
+            # reference the point of error within the provided
+            # TVMScript.  However, when caught in pdb, the full
+            # traceback should be available for debugging.
+            if isinstance(err, Exception):
+                diag_err = diag_err.with_traceback(err.__traceback__)
+            raise diag_err
 
     def visit(self, node: doc.AST) -> None:
         """The general visiting method.


### PR DESCRIPTION
Prior to this commit, exceptions raised during the parsing of TVMScript would be caught and replaced with a new exception.  While this does allow the TVMScript location of the error to be included in the exception, it also removes the stack trace of the original error. This commit updates the `Parser.report_error` function to provide the original stack trace alongside the updated exception object.