### PR TITLE
[Unity] Dtype check in legalization of R.matmul

### DIFF
--- a/python/tvm/relax/transform/legalize_ops/linear_algebra.py
+++ b/python/tvm/relax/transform/legalize_ops/linear_algebra.py
@@ -89,6 +89,14 @@ def _matmul(bb: BlockBuilder, call: Call) -> Expr:
             name="matmul",
         )
 
+    lhs, rhs = call.args
+    lhs_sinfo = call.args[0].struct_info
+    rhs_sinfo = call.args[1].struct_info
+    assert lhs_sinfo.dtype and rhs_sinfo.dtype, (
+        f"To legalize R.matmul into R.call_tir, the dtype of both operands must be known.  "
+        f"However, the LHS {lhs} has struct info {lhs_sinfo} (dtype='{lhs_sinfo.dtype}') "
+        f"and the RHS {rhs} has struct info {rhs_sinfo} (dtype='{rhs_sinfo.dtype}')."
+    )
     return bb.call_te(te_matmul, call.args[0], call.args[1], primfunc_name_hint="matmul")
 
 


### PR DESCRIPTION
Prior to this commit, if `R.matmul` has arguments with an unknown datatype, it would produce an error from within the `R.call_te` implementation of `BlockBuilder.call_te`, stating `TVMError: cannot make const for type handle`.  While true, this is not the most easily interpreted error message.

This error message occurs due to the use of an unknown data type in Relax as a concrete data type in TE/TIR.  While Relax supports unknown datatypes, TIR does not.  When the Relax representation of an unknown datatype, `DataType::Void()`, is passed into TIR, this is interpreted as an opaque handle, which cannot have a scalar constant produced for it.

This commit validates the types being used in Relax, prior to generating the legalized implementation of `R.matmul`.  By catching the error earlier, the error message can be in terms of the Relax objects being used.