### PR TITLE
[Relay][Keras][Bugfix] fix the converters of GRU and SimpleRNN about the go_backwards attribute

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1060,6 +1060,8 @@ def _convert_simple_rnn(
     assert units > 0, "The value of units must be a positive integer"
     if keras_layer.use_bias:
         in_bias = etab.new_const(weightList[2])
+    if keras_layer.go_backwards:
+        in_data = _op.reverse(in_data, axis=1)
     assert len(in_data.type_annotation.shape) == 3
     timeDim = in_data.type_annotation.shape[1].value
     in_data_split = _op.split(in_data, indices_or_sections=timeDim, axis=1)
@@ -1090,6 +1092,8 @@ def _convert_gru(
     recurrent_weight = etab.new_const(weightList[1].transpose([1, 0]))
     if keras_layer.use_bias:
         in_bias = etab.new_const(weightList[2])
+    if keras_layer.go_backwards:
+        in_data = _op.reverse(in_data, axis=1)
     units = list(weightList[0].shape)[1]
     assert units > 0, "The value of units must be a positive integer"
     in_data = _op.nn.batch_flatten(in_data)

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1060,10 +1060,10 @@ def _convert_simple_rnn(
     assert units > 0, "The value of units must be a positive integer"
     if keras_layer.use_bias:
         in_bias = etab.new_const(weightList[2])
-    if keras_layer.go_backwards:
-        in_data = _op.reverse(in_data, axis=1)
     assert len(in_data.type_annotation.shape) == 3
     timeDim = in_data.type_annotation.shape[1].value
+    if keras_layer.go_backwards:
+        in_data = _op.reverse(in_data, axis=1)
     in_data_split = _op.split(in_data, indices_or_sections=timeDim, axis=1)
     for i in range(len(in_data_split)):
         in_data_split_i = _op.nn.batch_flatten(in_data_split[i])

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -568,6 +568,9 @@ class TestKeras:
             keras_mod.layers.SimpleRNN(
                 units=16, return_state=False, activation="tanh", use_bias=False
             ),
+            keras_mod.layers.SimpleRNN(
+                units=16, return_state=False, activation="tanh", go_backwards=True
+            ),
             keras_mod.layers.GRU(
                 units=16,
                 return_state=False,
@@ -582,6 +585,15 @@ class TestKeras:
                 activation="tanh",
                 reset_after=False,
                 use_bias=False,
+            ),
+            keras_mod.layers.GRU(
+                units=16,
+                return_state=False,
+                recurrent_activation="sigmoid",
+                activation="tanh",
+                reset_after=False,
+                use_bias=False,
+                go_backwards=True,
             ),
         ]
         for rnn_func in rnn_funcs:


### PR DESCRIPTION
Two similar bugs with the issue: https://github.com/apache/tvm/issues/15176

For the convert function of GRU and SimpleRNN in the Keras frontend, they overlook the parsing for `go_backwards` attribute.
Thus, they can lead to wrong inference results. 

This PR fixed them and added two corresponding regression tests.


cc @echuraev @Hzfengsy @merrymercy 