### PR TITLE
[Unity][BYOC] Support offloading multi-query attention by Flash Attention

### DIFF
--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -169,10 +169,10 @@ def instantiate_flash_attention_template(attrs):
     int k_head_stride = ${head_dim};
     int v_head_stride = ${head_dim};
     int o_head_stride = ${head_dim};
-    int q_row_stride = q_head_stride * ${num_heads};
-    int k_row_stride = k_head_stride * ${num_heads};
-    int v_row_stride = v_head_stride * ${num_heads};
-    int o_row_stride = o_head_stride * ${num_heads};
+    int q_row_stride = q_head_stride * ${num_q_heads};
+    int k_row_stride = k_head_stride * ${num_kv_heads};
+    int v_row_stride = v_head_stride * ${num_kv_heads};
+    int o_row_stride = o_head_stride * ${num_q_heads};
     int q_batch_stride = q_row_stride * ${num_queries};
     int k_batch_stride = k_row_stride * ${num_keys};
     int v_batch_stride = v_row_stride * ${num_keys};
@@ -190,8 +190,8 @@ def instantiate_flash_attention_template(attrs):
     			    ${num_batches},
     			    ${num_queries},
     			    ${num_keys},
-    			    ${num_heads},
-    			    ${num_heads},
+    			    ${num_q_heads},
+    			    ${num_kv_heads},
     			    ${head_dim},
     			    q_batch_stride,
     			    k_batch_stride,
@@ -215,13 +215,13 @@ def instantiate_flash_attention_template(attrs):
     int k_head_stride = ${head_dim};
     int v_head_stride = ${head_dim};
     int o_head_stride = ${head_dim};
-    int row_stride = q_head_stride * ${num_heads} +
-                     k_head_stride * ${num_heads} +
-                     v_head_stride * ${num_heads};
+    int row_stride = q_head_stride * ${num_q_heads} +
+                     k_head_stride * ${num_kv_heads} +
+                     v_head_stride * ${num_kv_heads};
     int q_row_stride = row_stride;
     int k_row_stride = row_stride;
     int v_row_stride = row_stride;
-    int o_row_stride = o_head_stride * ${num_heads};
+    int o_row_stride = o_head_stride * ${num_q_heads};
 
     int q_batch_stride = q_row_stride * ${num_queries};
     int k_batch_stride = k_row_stride * ${num_keys};
@@ -234,14 +234,14 @@ def instantiate_flash_attention_template(attrs):
 
     flash_attn::flash_attention_forward(
                             static_cast<const cutlass::half_t*>(${qkv}->data),
-    			    static_cast<const cutlass::half_t*>(${qkv}->data) + ${head_dim} * ${num_heads},
-    			    static_cast<const cutlass::half_t*>(${qkv}->data) + ${head_dim} * ${num_heads} * 2,
+    			    static_cast<const cutlass::half_t*>(${qkv}->data) + ${head_dim} * ${num_q_heads},
+    			    static_cast<const cutlass::half_t*>(${qkv}->data) + ${head_dim} * (${num_q_heads} + ${num_kv_heads}),
     			    static_cast<cutlass::half_t*>(out0->data),
     			    ${num_batches},
     			    ${num_queries},
     			    ${num_keys},
-    			    ${num_heads},
-    			    ${num_heads},
+    			    ${num_q_heads},
+    			    ${num_kv_heads},
     			    ${head_dim},
     			    q_batch_stride,
     			    k_batch_stride,

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -939,7 +939,6 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
                 "arch": self.options["sm"],
                 "qkv_layout": qkv_layout,
                 "custom_mask_type": custom_mask_type,
-                "disable_flash": self.options.get("disable_flash", False),
                 **arg,
             }
         )
@@ -984,7 +983,6 @@ def profile_relax_function(functions, options):
     """Tune and annotate CUTLASS composite functions with shape, dtype and generated templates."""
     tmp_dir = options.get("tmp_dir", "./tmp")
     sm = options.get("sm", 80)
-    print(options)
 
     conv2d_profiler = CutlassConv2DProfiler(sm, _get_cutlass_path(), tmp_dir)
     gemm_profiler = CutlassGemmProfiler(sm, _get_cutlass_path(), tmp_dir)

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -983,7 +983,6 @@ def profile_relax_function(functions, options):
     """Tune and annotate CUTLASS composite functions with shape, dtype and generated templates."""
     tmp_dir = options.get("tmp_dir", "./tmp")
     sm = options.get("sm", 80)
-
     conv2d_profiler = CutlassConv2DProfiler(sm, _get_cutlass_path(), tmp_dir)
     gemm_profiler = CutlassGemmProfiler(sm, _get_cutlass_path(), tmp_dir)
 

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -909,8 +909,8 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
 
         out_shape = signature["ret_shape"]
         out_dtype = signature["ret_dtype"]
-        num_batches, num_queries, num_heads, head_dim = q_shape
-        _, num_keys, _, _ = k_shape
+        num_batches, num_queries, num_q_heads, head_dim = q_shape
+        _, num_keys, num_kv_heads, _ = k_shape
         _, _, _, head_dim_value = v_shape
         scale = op_attrs.scale
 
@@ -931,13 +931,15 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
                 "num_batches": num_batches,
                 "num_queries": num_queries,
                 "num_keys": num_keys,
-                "num_heads": num_heads,
+                "num_q_heads": num_q_heads,
+                "num_kv_heads": num_kv_heads,
                 "head_dim": head_dim,
                 "head_dim_value": head_dim_value,
                 "scale": scale,
                 "arch": self.options["sm"],
                 "qkv_layout": qkv_layout,
                 "custom_mask_type": custom_mask_type,
+                "disable_flash": self.options.get("disable_flash", False),
                 **arg,
             }
         )
@@ -982,6 +984,8 @@ def profile_relax_function(functions, options):
     """Tune and annotate CUTLASS composite functions with shape, dtype and generated templates."""
     tmp_dir = options.get("tmp_dir", "./tmp")
     sm = options.get("sm", 80)
+    print(options)
+
     conv2d_profiler = CutlassConv2DProfiler(sm, _get_cutlass_path(), tmp_dir)
     gemm_profiler = CutlassGemmProfiler(sm, _get_cutlass_path(), tmp_dir)
 

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -778,7 +778,10 @@ def instantiate_template(func_name, annotations, func_args):
         else:
             headers.append("kernel_forward.h")
 
-            assert annotations["num_q_heads"] == annotations["num_kv_heads"]
+            assert (
+                annotations["num_q_heads"] == annotations["num_kv_heads"]
+            ), "The number of query and KV heads need to be the same for CUTLASS fMHA."
+
             attrs["num_heads"] = n = annotations["num_q_heads"]
 
             data_type_size = DataTypeSize[data_type]

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -745,7 +745,6 @@ def instantiate_template(func_name, annotations, func_args):
 
         attrs["data_type"] = DataTypeTag[data_type]
         attrs["num_batches"] = b = annotations["num_batches"]
-        attrs["num_heads"] = n = annotations["num_heads"]
         attrs["head_dim"] = h = annotations["head_dim"]
         attrs["head_dim_value"] = h_v = annotations["head_dim_value"]
         attrs["kMaxK"] = max(int(attrs["head_dim"]), int(attrs["head_dim_value"]))
@@ -754,24 +753,28 @@ def instantiate_template(func_name, annotations, func_args):
         )
 
         use_flash = (
-            annotations["ret_dtype"] == "float16"
+            not annotations["disable_flash"]
+            and annotations["ret_dtype"] == "float16"
             and "bias" not in attrs
             and int(attrs["head_dim"]) <= 256
             and int(attrs["head_dim"]) % 8 == 0
             and int(attrs["head_dim"]) == int(attrs["head_dim_value"])
-            # We have not thoroughly validated flash with causal mask yet, so for now we support
-            # only non-causal cases.
-            and int(annotations["custom_mask_type"]) == 0
+            and int(annotations["custom_mask_type"]) in (0, 2)
             # Flash v2 is currently not supported for sm < 80
             and int(annotations["arch"]) >= 80
         )
 
         if use_flash:
             headers.append("flash.h")
-            attrs["is_causal"] = int(annotations["custom_mask_type"]) > 0
+            attrs["is_causal"] = int(annotations["custom_mask_type"]) == 2
+            attrs["num_q_heads"] = annotations["num_q_heads"]
+            attrs["num_kv_heads"] = annotations["num_kv_heads"]
             code = instantiate_flash_attention_template(attrs)
         else:
             headers.append("kernel_forward.h")
+
+            assert annotations["num_q_heads"] == annotations["num_kv_heads"]
+            attrs["num_heads"] = n = annotations["num_q_heads"]
 
             data_type_size = DataTypeSize[data_type]
             if (data_type_size * h // 8) % 16 == 0 and (data_type_size * h_v // 8) % 16 == 0:

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -599,7 +599,9 @@ def partition_for_cutlass(mod, annotate_codegen=True, use_flash_attn=True):
     for func_name, func in mod.functions.items():
         if isinstance(func, Function):
             if use_flash_attn:
-                mqa_pattern, rewriter = make_attention_rewrite_pattern("BSNH", "BSNH", with_bias=False, with_cast=True, with_kv_repeat=True)
+                mqa_pattern, rewriter = make_attention_rewrite_pattern(
+                    "BSNH", "BSNH", with_bias=False, with_cast=True, with_kv_repeat=True
+                )
                 func = rewrite_call(mqa_pattern, rewriter, func)
 
             for pattern, rewriter in _REWRITE_PATTERNS:

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -590,6 +590,10 @@ def partition_for_cutlass(mod, annotate_codegen=True, use_flash_mqa=True):
         body consists only of a call to the composite function. See the doc of FuseOpsByPattern
         for more detail.
 
+    use_flash_mqa: bool
+        Whether to consider a rewrite pattern for multi-query attention, which is supported by
+        the Flash Attention kernel.
+
     Returns
     -------
     mod: tvm.IRModule

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -576,7 +576,7 @@ def annotate_workspace(mod, _):
     return mod
 
 
-def partition_for_cutlass(mod, annotate_codegen=True, use_flash_attn=True):
+def partition_for_cutlass(mod, annotate_codegen=True, use_flash_mqa=True):
     """
     Partition the input module into CUTLASS-supported subgraphs.
 
@@ -598,7 +598,7 @@ def partition_for_cutlass(mod, annotate_codegen=True, use_flash_attn=True):
     """
     for func_name, func in mod.functions.items():
         if isinstance(func, Function):
-            if use_flash_attn:
+            if use_flash_mqa:
                 mqa_pattern, rewriter = make_attention_rewrite_pattern(
                     "BSNH", "BSNH", with_bias=False, with_cast=True, with_kv_repeat=True
                 )

--- a/python/tvm/relax/backend/patterns.py
+++ b/python/tvm/relax/backend/patterns.py
@@ -318,7 +318,7 @@ def make_rms_norm_pattern():
 
 
 def make_attention_rewrite_pattern(
-    qkv_layout: str, out_layout: str, with_bias: bool, with_cast: bool
+        qkv_layout: str, out_layout: str, with_bias: bool, with_cast: bool, with_kv_repeat: bool = False
 ):
     """
     Create pattern for implicit fused multi head attention rewriting.
@@ -350,7 +350,10 @@ def make_attention_rewrite_pattern(
     """
 
     # pylint: disable=invalid-name
-    def handle_input(tensor, layout, transpose):
+    def handle_input(tensor, layout, transpose, repeat=False):
+        if repeat:
+            tensor = is_op("relax.repeat")(tensor)
+
         if layout == "BSNH":
             permuted = is_op("relax.permute_dims")(tensor)
             shape = wildcard()
@@ -434,8 +437,8 @@ def make_attention_rewrite_pattern(
 
     q_raw, k_raw, v_raw = wildcard(), wildcard(), wildcard()
     q, q_rewriter = handle_input(q_raw, qkv_layout, False)
-    k, k_rewriter = handle_input(k_raw, qkv_layout, True)
-    v, v_rewriter = handle_input(v_raw, qkv_layout, False)
+    k, k_rewriter = handle_input(k_raw, qkv_layout, True, repeat=with_kv_repeat)
+    v, v_rewriter = handle_input(v_raw, qkv_layout, False, repeat=with_kv_repeat)
     matmul_1 = is_op("relax.matmul")(q, k)
     scale = is_const()
 

--- a/python/tvm/relax/backend/patterns.py
+++ b/python/tvm/relax/backend/patterns.py
@@ -318,7 +318,7 @@ def make_rms_norm_pattern():
 
 
 def make_attention_rewrite_pattern(
-        qkv_layout: str, out_layout: str, with_bias: bool, with_cast: bool, with_kv_repeat: bool = False
+    qkv_layout: str, out_layout: str, with_bias: bool, with_cast: bool, with_kv_repeat: bool = False
 ):
     """
     Create pattern for implicit fused multi head attention rewriting.

--- a/python/tvm/relax/backend/patterns.py
+++ b/python/tvm/relax/backend/patterns.py
@@ -338,6 +338,10 @@ def make_attention_rewrite_pattern(
         Whether or not rewriting is intended to be applied to a module after the FP16 conversion
         pass.
 
+    with_kv_repeat: bool
+        Whether or not to include the Relax repeat op in the pattern, which is typically used
+        in a Relax module to support multi-query attention.
+
     Returns
     -------
     pattern: DFPattern

--- a/src/relax/op/nn/attention.cc
+++ b/src/relax/op/nn/attention.cc
@@ -80,7 +80,7 @@ StructInfo InferStructInfoAttention(const Call& call, const BlockBuilder& ctx) {
   auto multiple_of = [&](PrimExpr v1, PrimExpr v2, String m1, String m2, String dim) {
     if (analyzer->CanProve(indexmod(v1, v2) != 0)) {
       ctx->ReportFatal(Diagnostic::Error(call)
-                       << "The " << m1 << " " << dim << " should be an multiple of " << m2 << " "
+                       << "The " << m1 << " " << dim << " should be a multiple of " << m2 << " "
                        << dim << ". However, the " << dim << " of " << m1 << " is " << v1
                        << " while the " << dim << " of " << m2 << " is " << v2);
     }

--- a/src/relax/op/nn/attention.cc
+++ b/src/relax/op/nn/attention.cc
@@ -79,8 +79,8 @@ StructInfo InferStructInfoAttention(const Call& call, const BlockBuilder& ctx) {
   };
   diag_equal(num_batches, k_shape->values[0], "query", "key", "batch size");
   diag_equal(num_batches, v_shape->values[0], "query", "value", "batch size");
-  diag_equal(num_heads, k_shape->values[2], "query", "key", "number of heads");
-  diag_equal(num_heads, v_shape->values[2], "query", "value", "number of heads");
+  // diag_equal(num_heads, k_shape->values[2], "query", "key", "number of heads");
+  // diag_equal(num_heads, v_shape->values[2], "query", "value", "number of heads");
   diag_equal(num_keys, v_shape->values[1], "key", "value", "sequence length");
   diag_equal(head_dim, k_shape->values[3], "query", "key", "dimension of heads");
 

--- a/src/relax/op/nn/attention.cc
+++ b/src/relax/op/nn/attention.cc
@@ -77,10 +77,19 @@ StructInfo InferStructInfoAttention(const Call& call, const BlockBuilder& ctx) {
                        << v1 << " while the " << dim << " of " << m2 << " is " << v2);
     }
   };
+  auto multiple_of = [&](PrimExpr v1, PrimExpr v2, String m1, String m2, String dim) {
+    if (analyzer->CanProve(indexmod(v1, v2) != 0)) {
+      ctx->ReportFatal(Diagnostic::Error(call)
+                       << "The " << m1 << " " << dim << " should be an multiple of " << m2 << " "
+                       << dim << ". However, the " << dim << " of " << m1 << " is " << v1
+                       << " while the " << dim << " of " << m2 << " is " << v2);
+    }
+  };
+
   diag_equal(num_batches, k_shape->values[0], "query", "key", "batch size");
   diag_equal(num_batches, v_shape->values[0], "query", "value", "batch size");
-  // diag_equal(num_heads, k_shape->values[2], "query", "key", "number of heads");
-  // diag_equal(num_heads, v_shape->values[2], "query", "value", "number of heads");
+  multiple_of(num_heads, k_shape->values[2], "query", "key", "number of heads");
+  multiple_of(num_heads, v_shape->values[2], "query", "value", "number of heads");
   diag_equal(num_keys, v_shape->values[1], "key", "value", "sequence length");
   diag_equal(head_dim, k_shape->values[3], "query", "key", "dimension of heads");
 

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1931,10 +1931,7 @@ def test_fp16A_int8B_gemm_batched():
     ex = relax.build(mod_transform, target="llvm")
     vm = relax.vm.VirtualMachine(ex, tvm.cpu(0))
 
-    (
-        packed_weight,
-        scales,
-    ) = vm[
+    (packed_weight, scales,) = vm[
         transform_func_name
     ]((tvm.nd.array(y),))
 
@@ -1996,5 +1993,4 @@ def test_attention_rewrite_multi_query():
 
 
 if __name__ == "__main__":
-    # tvm.testing.main()
-    test_attention_rewrite_multi_query()
+    tvm.testing.main()

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -113,7 +113,9 @@ def get_result_with_relax_cutlass_offload(
     if assert_all_bindings_fused:
         assert len(mod["main"].body.blocks[0].bindings) == num_final_bindings
 
-    codegen_pass = relax.transform.RunCodegen({"cutlass": {"sm": 80, "find_first_valid": True, "disable_flash": True}})
+    codegen_pass = relax.transform.RunCodegen(
+        {"cutlass": {"sm": 80, "find_first_valid": True, "disable_flash": True}}
+    )
     mod = codegen_pass(mod)
 
     return build_and_run(mod, args, "cuda")
@@ -1987,7 +1989,9 @@ def test_attention_rewrite_multi_query():
     ref = build_and_run(Module, args, "llvm", legalize=True)
 
     mod = partition_for_cutlass(Module, use_flash_attn=True)
-    codegen_pass = relax.transform.RunCodegen({"cutlass": {"sm": 80, "find_first_valid": True, "disable_flash": False}})
+    codegen_pass = relax.transform.RunCodegen(
+        {"cutlass": {"sm": 80, "find_first_valid": True, "disable_flash": False}}
+    )
     mod = codegen_pass(mod)
 
     out = build_and_run(mod, args, "cuda")


### PR DESCRIPTION
MQA, as used by llama 2 70B and codellama 34B, is a common way to reduce runtime memory bandwidth for big LLMs. So far we haven't been taking advantage of this optimization: We do explicit `repeat` of KV tensors (https://github.com/mlc-ai/mlc-llm/blob/main/mlc_llm/relax_model/llama.py#L384-L385) and use the regular attention, which defeats the purpose of MQA.

While CUTLASS fMHA doesn't support MQA (where `num_q_head != num_kv_head`), flash attention does support it. So I added a new option to `partition_for_cutlass` to enable pattern matching the `repeat` op during attention rewriting: When we detect an attention pattern where KV tensors are first expanded by `repeat`, we recognize it as MQA and dispatch it to flash attention. 

For now this feature is opt-in, since it would force using flash attention for causal inference, but I haven't thoroughly validated its performance against such workloads. For example, even though flash attention v2 supports causal decoding inference where `seq_q_len = 1` as of https://github.com/Dao-AILab/flash-attention/commit/e07aa036db0e6cd251b17d9ee2d1720023da2def, cutlass fMHA can still be faster for such workloads. But based on feedback I can enable MQA offloading by default to avoid introducing another param.

That said, flash is definitely advantageous for MQA. For example, the following nvprof output for codellama 34B with 16k context length, using `repeat` and cutlass fMHA,  shows large overhead from repeat:  

```
 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name            
                                     
 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------
------------------------------------ 
     30.5      21627490775      49152   440012.4   440224.0    420416    454336       3642.8  ampere_h16816gemm_64x64_sliced1x2_ldg8_stages_64x6_tn           
                                     
     22.0      15608458542      98304   158777.5   155791.0     85152    245310      69134.0  ampere_h16816gemm_128x64_sliced1x2_ldg8_relu_stages_64x6_tn     
                                                                               
     12.3       8753808009      99840    87678.4    87809.0     82080    103328       3242.2  repeat_kernel                                                   
                                                                                                                                                              
     11.1       7900613613       2304  3429085.8  1829756.5   1206877   7376321    2590665.8  ampere_h16816gemm_256x128_ldg8_stages_64x3_tn                   
                                                                                                                                                              
      8.1       5772286492      50192   115004.1   110656.0    102752    331968      30345.8  ampere_h16816gemm_64x64_sliced1x2_ldg8_stages_64x5_tn           
                                                                                                                                                              
      7.8       5541100467      49920   110999.6    93888.0     90080   1252571     135536.9  void attention_kernel_batched_impl<AttentionKer
```   

Using flash attn MQA, the repeat overhead is completely gone and I get a few token / sec improvement due to this optimization. Also note that the cutlass fMHA perf above and the flash attn MQA perf below are roughly the same, indicating the relative superiority of the former kernel for this workload. 

```
 Time (%)  Total Time (ns)  Instances  Avg (ns)   Med (ns)   Min (ns)  Max (ns)  StdDev (ns)                                                  Name

 --------  ---------------  ---------  ---------  ---------  --------  --------  -----------  ----------------------------------------------------------------
------------------------------------
     44.7       7950055127       2304  3450544.8  1851210.0   1204583   7478071    2605192.6  ampere_h16816gemm_256x128_ldg8_stages_64x3_tn

     30.8       5464607061      49920   109467.3   100545.0     96961    684644      66473.6  void flash_fwd_kernel<Flash_fwd_kernel_traits<(int)128, (int)128
, (int)64, (int)4, (bool)0, (bool)0…
     15.9       2817276679        768  3668329.0  3675380.5   3196017   3876989      91606.0  ampere_h16816gemm_128x256_ldg8_stages_64x3_tn

      1.9        340279055       1088   312756.5   321794.0    107648    332097      42981.1  ampere_h16816gemm_64x64_sliced1x2_ldg8_stages_64x5_tn
```

@vinx13 @cyx-6 @yzh119 @sunggg 