### PR TITLE
[Unity] Allow FLegalize to produce Relax operations

### DIFF
--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -612,7 +612,17 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
       unchanged &= new_block.same_as(block);
     }
 
-    this->BeginBindingBlock();
+    // Because the input may not be normalized, the SeqExpr may occur
+    // nested within another SeqExpr.  In that case, we want to use
+    // whatever binding-block type the parent uses, so that we any
+    // bindings collected into the prologue will be compatible with
+    // the parent block.
+    if (block_stack_.size() && CurrentBlockIsDataFlow()) {
+      this->BeginDataflowBlock();
+    } else {
+      this->BeginBindingBlock();
+    }
+
     // the body may not be a leaf expression, so check for that
     Expr new_body = this->NormalizeArgument(op->body);
     unchanged &= new_body.same_as(op->body);

--- a/src/relax/transform/legalize_ops.cc
+++ b/src/relax/transform/legalize_ops.cc
@@ -57,10 +57,11 @@ class LegalizeMutator : public ExprMutator {
  public:
   explicit LegalizeMutator(const IRModule& mod, const Optional<Map<String, PackedFunc>>& cmap,
                            bool enable_warning)
-      : ExprMutator(mod),
-        mod_(std::move(mod)),
-        cmap_(std::move(cmap)),
-        enable_warning_(enable_warning) {}
+      : ExprMutator(mod), mod_(std::move(mod)), enable_warning_(enable_warning) {
+    if (cmap) {
+      cmap_ = std::move(cmap.value());
+    }
+  }
 
   IRModule Transform() {
     for (const auto& [gv, func] : mod_->functions) {
@@ -132,36 +133,59 @@ class LegalizeMutator : public ExprMutator {
       return visited_call;
     }
 
-    // Priority: customize > default.
-    // Check if it has customize legalization registered.
-    if (cmap_.defined() && cmap_.value().count(op->name)) {
-      auto ret = cmap_.value()[op->name](this->builder_, visited_call);
-      if (ret.IsObjectRef<Expr>() && WrapPureCondition(op, ret.AsObjectRef<Expr>())) {
-        return WrapPureCall(Downcast<Call>(ret.AsObjectRef<Expr>()));
+    FLegalize legalization_func;
+
+    if (auto opt_custom_legalize = cmap_.Get(op->name)) {
+      // First choice, use a custom legalization function
+      legalization_func = opt_custom_legalize.value();
+    } else if (legalize_map.count(op)) {
+      // Second choice, use a default legalization
+      legalization_func = legalize_map[op];
+    } else {
+      // No legalization.
+      if (enable_warning_ && op != call_tir_op && op != call_dps_packed_op &&
+          op != call_pure_packed_op) {
+        LOG(WARNING) << "No legalization func for " << op->name << " is found.";
       }
-      return ret;
-    }
-    // Check if it has default legalization registered.
-    if (legalize_map.count(op)) {
-      auto ret = legalize_map[op](this->builder_, visited_call);
-      if (WrapPureCondition(op, ret)) {
-        return WrapPureCall(Downcast<Call>(ret));
-      }
-      return ret;
+      return visited_call;
     }
 
-    // No legalization.
-    if (enable_warning_ && op != call_tir_op && op != call_dps_packed_op &&
-        op != call_pure_packed_op) {
-      LOG(WARNING) << "No legalization func for " << op->name << " is found.";
+    // The legalization function may call `builder_->Emit()` as part
+    // of its implementation.  In that case, any operations it emits
+    // must be caught such that they be checked for recursive
+    // legalization.  This is done by wrapping the legalized value in
+    // a SeqExpr, which can first be visited, then unwrapped by the
+    // normalization.
+    if (builder_->CurrentBlockIsDataFlow()) {
+      builder_->BeginDataflowBlock();
+    } else {
+      builder_->BeginBindingBlock();
     }
-    return visited_call;
+    Expr legalized = legalization_func(builder_, visited_call);
+
+    if (WrapPureCondition(op, legalized)) {
+      legalized = WrapPureCall(Downcast<Call>(legalized));
+    }
+
+    BindingBlock prologue = builder_->EndBlock();
+    if (prologue->bindings.size()) {
+      legalized = SeqExpr({prologue}, legalized);
+    }
+
+    // Legalization may have introduced additional operations that
+    // must be legalized as well.  For example, a user-custom
+    // intrinsic whose legalization is implemented in terms of relax
+    // intrinsics.  The base case of the recursion occurs when no
+    // additional legalization steps are found.
+    legalized = VisitExpr(legalized);
+
+    return legalized;
   }
 
   /*! \brief The context IRModule. */
   IRModule mod_;
   /*! \brief The customized legalization function map. */
-  Optional<Map<String, PackedFunc>> cmap_;
+  Map<String, PackedFunc> cmap_;
   /*!
    * \brief A boolean value indicating if to print warnings for CallNode whose op's
    * legalization function is not registered.

--- a/src/relax/transform/legalize_ops.cc
+++ b/src/relax/transform/legalize_ops.cc
@@ -177,7 +177,14 @@ class LegalizeMutator : public ExprMutator {
     // intrinsic whose legalization is implemented in terms of relax
     // intrinsics.  The base case of the recursion occurs when no
     // additional legalization steps are found.
-    legalized = VisitExpr(legalized);
+    //
+    // Only perform recursive legalization when the legalization
+    // function returned a modified expression, as some legalizations
+    // return the original expression if they are unable to produce a
+    // legalized version.
+    if (!legalized.same_as(visited_call)) {
+      legalized = VisitExpr(legalized);
+    }
 
     return legalized;
   }

--- a/src/relax/transform/legalize_ops.cc
+++ b/src/relax/transform/legalize_ops.cc
@@ -162,6 +162,7 @@ class LegalizeMutator : public ExprMutator {
       builder_->BeginBindingBlock();
     }
     Expr legalized = legalization_func(builder_, visited_call);
+    legalized = builder_->Normalize(legalized);
 
     BindingBlock prologue = builder_->EndBlock();
     for (const auto& binding : prologue->bindings) {
@@ -183,7 +184,6 @@ class LegalizeMutator : public ExprMutator {
     // return the original expression if they are unable to produce a
     // legalized version.
     if (!legalized.same_as(visited_call)) {
-      legalized = builder_->Normalize(legalized);
       legalized = VisitExpr(legalized);
     }
 


### PR DESCRIPTION
Prior to this commit, a `FLegalize` function needed to produce an implementation that can be used as input by `relax.transform.AnnotateTIROpPattern`, and could not lower to other relax operations.  This commit allows Relax operations to be included in the output of `FLegalize`, with the result being further legalized if required.