### PR TITLE
[Unity][Relax]fix behaviors for importing torch.cat/concat

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -505,7 +505,8 @@ class TorchFXImporter:
 
     def _cat(self, node: fx.node.Node) -> relax.Var:
         args = self.retrieve_args(node)
-        return self.block_builder.emit(relax.op.concat(args[0], axis=node.kwargs["dim"]))
+        axis = args[1] if len(node.args) > 1 else node.kwargs.get("dim", 0)
+        return self.block_builder.emit(relax.op.concat(args[0], axis=axis))
 
     def _expand(self, node: fx.node.Node) -> relax.Var:
         args = self.retrieve_args(node)
@@ -1331,6 +1332,7 @@ class TorchFXImporter:
             "baddbmm": self._baddbmm,
             "bmm": self._matmul,
             "cat": self._cat,
+            "concat": self._cat,
             "expand": self._expand,
             "flatten": self._flatten,
             "permute": self._permute,

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3073,11 +3073,11 @@ def test_cat():
     class Cat1(Module):
         def forward(self, x, y):
             return torch.cat((x, y), dim=1)
-        
+
     class Cat2(Module):
         def forward(self, x, y):
             return torch.cat((x, y), 1)
-        
+ 
     class Cat3(Module):
         def forward(self, x, y):
             return torch.concat((x, y), dim=0)
@@ -3094,7 +3094,7 @@ def test_cat():
                 gv: R.Tensor((4, 3), dtype="float32") = lv
                 R.output(gv)
             return gv
-        
+
     @I.ir_module
     class Expected2:
         @R.function

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3065,6 +3065,55 @@ def test_rsqrt():
     verify_model(Rsqrt(), [([256, 256], "float32")], {}, Expected1)
 
 
+def test_cat():
+    class Cat0(Module):
+        def forward(self, x, y):
+            return torch.cat((x, y))
+
+    class Cat1(Module):
+        def forward(self, x, y):
+            return torch.cat((x, y), dim=1)
+        
+    class Cat2(Module):
+        def forward(self, x, y):
+            return torch.cat((x, y), 1)
+        
+    class Cat3(Module):
+        def forward(self, x, y):
+            return torch.concat((x, y), dim=0)
+
+    @I.ir_module
+    class Expected1:
+        @R.function
+        def main(
+            inp_0: R.Tensor((2, 3), dtype="float32"),
+            inp_1: R.Tensor((2, 3), dtype="float32"),
+        ) -> R.Tensor((4, 3), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((4, 3), dtype="float32") = R.concat((inp_0, inp_1), axis=0)
+                gv: R.Tensor((4, 3), dtype="float32") = lv
+                R.output(gv)
+            return gv
+        
+    @I.ir_module
+    class Expected2:
+        @R.function
+        def main(
+            inp_0: R.Tensor((2, 3), dtype="float32"),
+            inp_1: R.Tensor((2, 3), dtype="float32"),
+        ) -> R.Tensor((2, 6), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((2, 6), dtype="float32") = R.concat((inp_0, inp_1), axis=1)
+                gv: R.Tensor((2, 6), dtype="float32") = lv
+                R.output(gv)
+            return gv
+
+    verify_model(Cat0(), [([2, 3], "float32"), ([2, 3], "float32")], {}, Expected1)
+    verify_model(Cat1(), [([2, 3], "float32"), ([2, 3], "float32")], {}, Expected2)
+    verify_model(Cat2(), [([2, 3], "float32"), ([2, 3], "float32")], {}, Expected2)
+    verify_model(Cat3(), [([2, 3], "float32"), ([2, 3], "float32")], {}, Expected1)
+
+
 def test_neg():
     class Neg(Module):
         def forward(self, input):

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3077,7 +3077,7 @@ def test_cat():
     class Cat2(Module):
         def forward(self, x, y):
             return torch.cat((x, y), 1)
- 
+
     class Cat3(Module):
         def forward(self, x, y):
             return torch.concat((x, y), dim=0)


### PR DESCRIPTION
Fix behaviors for importing torch.cat/concat
Now we can import Stable Diffusion XL and Real-ESRGAN more smoothly

Before fixing, we only support **torch.cat((x, y), dim=n_dim)**

Add support for importing:
1. **torch.cat((x, y))**        with defualt dim=0
2. **torch.cat((x, y), n_dim)**      when user doesn't explicitly state dim=
3. **torch.concat**       an alias of torch.cat
