### PR TITLE
[Unity][CUTLASS] Fix hardcoded epsilon parameter in RMS norm

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -952,6 +952,7 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         attrs["N"] = signature["arg0_shape"][-1]
         dtype = signature["arg0_dtype"]
         attrs["data_type"] = {"float32": "float", "float16": "cutlass::half_t"}[str(dtype)]
+        attrs["eps"] =self.options.get("norm_eps", 1e-5)
         return f.with_attrs(attrs)
 
     def visit_function_(self, f):

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -943,7 +943,7 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
             }
         )
 
-    def handle_norm(self, f, _):
+    def handle_norm(self, f, op_type):
         """Annotate a layer or rms norm op."""
         signature = _extract_relax_function_signature(f)
         attrs = {}
@@ -952,7 +952,12 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         attrs["N"] = signature["arg0_shape"][-1]
         dtype = signature["arg0_dtype"]
         attrs["data_type"] = {"float32": "float", "float16": "cutlass::half_t"}[str(dtype)]
-        attrs["eps"] =self.options.get("norm_eps", 1e-5)
+
+        if "rms" in op_type:
+            attrs["rms_eps"] = self.options.get("rms_eps", 1e-5)
+        else:
+            attrs["layer_norm_eps"] = self.options.get("layer_nrom_eps", 1e-5)
+
         return f.with_attrs(attrs)
 
     def visit_function_(self, f):

--- a/python/tvm/contrib/cutlass/rms_norm_operation.py
+++ b/python/tvm/contrib/cutlass/rms_norm_operation.py
@@ -42,6 +42,6 @@ def instantiate_rms_norm_template(attrs):
     ICHECK(func != nullptr);
     cudaStream_t stream = static_cast<cudaStream_t>((*func)().operator void*());
 
-    cutlass::rmsnorm(size, _output, _input, _weight, stream);
+    cutlass::rmsnorm(size, _output, _input, _weight, stream, ${eps});
     """
     return substitute_template(template, attrs)

--- a/python/tvm/contrib/cutlass/rms_norm_operation.py
+++ b/python/tvm/contrib/cutlass/rms_norm_operation.py
@@ -42,6 +42,6 @@ def instantiate_rms_norm_template(attrs):
     ICHECK(func != nullptr);
     cudaStream_t stream = static_cast<cudaStream_t>((*func)().operator void*());
 
-    cutlass::rmsnorm(size, _output, _input, _weight, stream, ${eps});
+    cutlass::rmsnorm(size, _output, _input, _weight, stream, ${rms_eps});
     """
     return substitute_template(template, attrs)

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1743,7 +1743,9 @@ def test_rms_norm():
     with tvm.target.Target("cuda"):
         mod = tvm.tir.transform.DefaultGPUSchedule()(mod)
 
-    mod = relax.transform.RunCodegen()(mod)
+    mod = relax.transform.RunCodegen(
+        {"cutlass": {"rms_eps": 1e-6}},
+    )(mod)
 
     inp = np.random.randn(*data_shape).astype(dtype)
     weight = np.random.randn(data_shape[-1]).astype(dtype)


### PR DESCRIPTION
The CUTLASS RMS kernel has been using a hard-coded epsilon value of 1e-6. I learned that recent popular language models such as llama 2 have been trained with eps = 1e-5, and using a slightly different eps can cause accuracy problems for such models on some inputs (see https://github.com/mlc-ai/mlc-llm/issues/923#issuecomment-1735066112). This has been fixed by this PR.

@zxybazh @sunggg @vinx13 

