### PR TITLE
[Unity] Check the PassContext within RewriteCUDAGraph transform

### DIFF
--- a/python/tvm/relax/vm_build.py
+++ b/python/tvm/relax/vm_build.py
@@ -305,24 +305,24 @@ def build(
     if isinstance(target, str):
         target = tvm.target.Target(target)
 
-    passes = []
-    passes.append(relax.transform.RewriteDataflowReshape())
-    passes.append(relax.transform.ToNonDataflow())
-    passes.append(relax.transform.RemovePurityChecking())
-    passes.append(relax.transform.CallTIRRewrite())
-    passes.append(relax.transform.StaticPlanBlockMemory())
+    lowering_passes = tvm.transform.Sequential(
+        [
+            relax.transform.RewriteDataflowReshape(),
+            relax.transform.ToNonDataflow(),
+            relax.transform.RemovePurityChecking(),
+            relax.transform.CallTIRRewrite(),
+            relax.transform.StaticPlanBlockMemory(),
+            relax.transform.RewriteCUDAGraph(),
+            relax.transform.LowerAllocTensor(),
+            relax.transform.KillAfterLastUse(),
+            relax.transform.VMBuiltinLower(),
+            relax.transform.VMShapeLower(),
+            relax.transform.AttachGlobalSymbol(),
+        ],
+        name="relax.lower",
+    )
 
-    if tvm.transform.PassContext.current().config.get("relax.backend.use_cuda_graph", False):
-        passes.append(relax.transform.RewriteCUDAGraph())
-
-    passes.append(relax.transform.LowerAllocTensor())
-    passes.append(relax.transform.KillAfterLastUse())
-
-    passes.append(relax.transform.VMBuiltinLower())
-    passes.append(relax.transform.VMShapeLower())
-    passes.append(relax.transform.AttachGlobalSymbol())
-    seq = tvm.transform.Sequential(passes)
-    new_mod = seq(mod)
+    new_mod = lowering_passes(mod)
 
     # Extract external runtime modules if exist.
     attrs = dict(mod.attrs) if mod.attrs else {}

--- a/src/relax/transform/rewrite_cuda_graph.cc
+++ b/src/relax/transform/rewrite_cuda_graph.cc
@@ -554,7 +554,15 @@ namespace transform {
 
 Pass RewriteCUDAGraph() {
   runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =  //
-      [=](IRModule m, PassContext pc) { return ::tvm::relax::RewriteCUDAGraph(std::move(m)); };
+      [=](IRModule mod, PassContext pc) {
+        bool use_cuda_graph =
+            pc->GetConfig<Bool>("relax.backend.use_cuda_graph").value_or(Bool(false))->value;
+        if (use_cuda_graph) {
+          mod = ::tvm::relax::RewriteCUDAGraph(std::move(mod));
+        }
+
+        return mod;
+      };
   return CreateModulePass(pass_func, 0, "RewriteCUDAGraph", {});
 }
 


### PR DESCRIPTION
Prior to this commit, the `RewriteCUDAGraph` pass would unconditionally rewrite an `IRModule`, and was conditionally included as a lowering pass for used in `relax.build`, based on the current `PassContext`.  This commit moves the check on the `PassContext` from the `relax.build` method to the `RewriteCUDAGraph` pass itself.  This allows the pass to be part of a lowering flow that is constructed once, and is later used when the `PassContext.current()` may have changed.