### PR TITLE
[Docker] Upgrade oneflow to v0.8.0

### DIFF
--- a/docker/install/ubuntu_install_oneflow.sh
+++ b/docker/install/ubuntu_install_oneflow.sh
@@ -22,4 +22,4 @@ set -o pipefail
 
 pip3 install flowvision==0.1.0
 
-python3 -m pip install oneflow==0.7.0
+python3 -m pip install oneflow==0.8.0

--- a/python/tvm/relay/frontend/oneflow.py
+++ b/python/tvm/relay/frontend/oneflow.py
@@ -742,7 +742,6 @@ class ExpandDim(OneFlowOpConverter):
 
     @classmethod
     def _impl_v1(cls, inputs, attrs, params):
-
         return _op.expand_dims(inputs[0], axis=attrs.get("axis", 0))
 
 
@@ -1434,8 +1433,10 @@ def get_convert_map():
         # defs/nn
         "conv2d": Conv2d.get_converter(),
         "deconv2d": ConvTranspose2d.get_converter(),
-        "maxpool_2d": MaxPool2d.get_converter(),
-        "avgpool_2d": AveragePool2d.get_converter(),
+        "max_pool_2d": MaxPool2d.get_converter(),
+        "avg_pool_2d": AveragePool2d.get_converter(),
+        "maxpool_2d": MaxPool2d.get_converter(),  # Maintained for oneflow versions <= "0.7.0"
+        "avgpool_2d": AveragePool2d.get_converter(),  # Maintained for oneflow versions <= "0.7.0"
         "adaptive_avg_pool2d": AdaptiveAvgPool2d.get_converter(),
         "adaptive_max_pool2d": AdaptiveMaxPool2d.get_converter(),
         "dropout": Dropout.get_converter(),
@@ -1909,7 +1910,10 @@ def from_oneflow(graph, model_dir_path):
             size_attr = size_str[0].replace("size=", "")
             if size_attr[-2] == ",":
                 size_attr = size_attr.replace(",", "")
-            data_size = tuple(map(int, size_attr[1:-1].split(", ")))
+            if size_attr == "()":
+                data_size = ()
+            else:
+                data_size = tuple(map(int, size_attr[1:-1].split(", ")))
             node_name = attrs[1]
             shape[node_name] = data_size
             dtype[node_name] = "float32"


### PR DESCRIPTION
The PR #15819 installed oneflow from PyPi in an attempt to unblock CI failing on the gpu docker image build. However, it seems to be a placeholder package. This PR upgrades the version of oneflow to v0.8.0 in a second attempt to unblock CI.