### PR TITLE
[Relay][Bugfix] Fix conv transpose with default strides in ONNX frontend

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -931,6 +931,7 @@ class ConvTranspose(OnnxOpConverter):
         data = inputs[0]
         input_shape = infer_shape(data)
         ndim = len(input_shape)
+        num_spatial_dims = ndim - 2
         if "auto_pad" in attr or "output_shape" in attr:
             if "auto_pad" in attr:
                 attr["auto_pad"] = attr["auto_pad"].decode("utf-8")
@@ -941,7 +942,8 @@ class ConvTranspose(OnnxOpConverter):
                 kndim = len(kernel_shape)
                 dilations = attr.get("dilations", [1] * kndim)
                 output_padding = attr.get("output_padding", [0] * kndim)
-                strides = attr["strides"]
+                # this is meant to handle the field 'strides' being optional for opsets 11+
+                strides = attr.get("strides", [1] * num_spatial_dims)
                 total_pad = [0] * kndim
                 # https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConvTranspose
                 if "output_shape" in attr:

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -3340,6 +3340,15 @@ def test_convtranspose(target, dev):
             repeat(1, dims),
             auto_pad="SAME_UPPER",
         )
+        # Convolution with default stride
+        verify_convtranspose_with_padding(
+            (1, 1) + repeat(5, dims),
+            (1, 1) + repeat(3, dims),
+            2 * repeat(1, dims),
+            repeat(3, dims),
+            None,
+            repeat(1, dims),
+        )
         # Convolution with dilation
         # TODO(mbrookhart): Relay doesn't currently support convtranspose with dilation
         # verify_convtranspose_with_padding(


### PR DESCRIPTION
As the ONNX documentation description [here](https://onnx.ai/onnx/operators/onnx__ConvTranspose.html#:~:text=strides%20%2D%20INTS%20%3A%20Stride%20along%20each%20spatial%20axis.%20If%20not%20present%2C%20the%20stride%20defaults%20to%201%20along%20each%20spatial%20axis.)
The parameter `strides` in ConvTranspose is an optional attribute using '1' as default.

This PR fixed it and added a corresponding regression test.