### PR TITLE
[Unity] [Bugfix] Fix KeyError:'None' in layer_norm implementation

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -981,10 +981,15 @@ class TorchFXImporter:
             dim_num = len(normalized_shape)
             axes = list(range(-dim_num, 0))
 
-            gamma = self.env[node.kwargs["weight"]]
+            gamma = node.kwargs["weight"]
+            if gamma is None:
+                shape_tuple = [int(s) for s in normalized_shape]
+                gamma = relax.const(np.ones(shape_tuple), x.struct_info.dtype)
+            else:
+                gamma = self.env[gamma]
             beta = node.kwargs["bias"]
             if beta is None:
-                shape_tuple = [int(s) for s in normalized_shape.values]
+                shape_tuple = [int(s) for s in normalized_shape]
                 beta = relax.const(np.zeros(shape_tuple), x.struct_info.dtype)
             else:
                 beta = self.env[beta]

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -1073,6 +1073,8 @@ def test_layernorm():
 
 
 def test_functional_layernorm():
+    import numpy as np
+    
     input_info = [([1, 3, 10, 10], "float32")]
 
     class LayerNorm(Module):

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -1138,7 +1138,7 @@ def test_functional_layernorm():
                 lv: R.Tensor((1, 3, 10, 10), dtype="float32") = R.nn.layer_norm(
                     input_1,
                     gamma=relax.const(np.ones((10, 10)), dtype="float32"),
-                    beta=relax.const(np.zeros((10,10)), dtype="float32"),
+                    beta=relax.const(np.zeros((10, 10)), dtype="float32"),
                     axes=[-2, -1],
                     epsilon=1e-05,
                     center=True,

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -1074,7 +1074,7 @@ def test_layernorm():
 
 def test_functional_layernorm():
     import numpy as np
-    
+
     input_info = [([1, 3, 10, 10], "float32")]
 
     class LayerNorm(Module):

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -1124,9 +1124,7 @@ def test_functional_layernorm():
             self.bias = None
 
         def forward(self, input):
-            return torch.nn.functional.layer_norm(
-                input, self.shape, self.weight, self.bias, 1e-5
-            )
+            return torch.nn.functional.layer_norm(input, self.shape, self.weight, self.bias, 1e-5)
 
     @tvm.script.ir_module
     class expected2:

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -1116,6 +1116,42 @@ def test_functional_layernorm():
     }
     verify_model(model, input_info, binding, expected1)
 
+    class LayerNorm2(Module):
+        def __init__(self, shape):
+            super().__init__()
+            self.shape = shape
+            self.weight = None
+            self.bias = None
+
+        def forward(self, input):
+            return torch.nn.functional.layer_norm(
+                input, self.shape, self.weight, self.bias, 1e-5
+            )
+
+    @tvm.script.ir_module
+    class expected2:
+        @R.function
+        def main(
+            input_1: R.Tensor((1, 3, 10, 10), dtype="float32"),
+        ) -> R.Tensor((1, 3, 10, 10), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((1, 3, 10, 10), dtype="float32") = R.nn.layer_norm(
+                    input_1,
+                    gamma=relax.const(np.ones((10, 10)), dtype="float32"),
+                    beta=relax.const(np.zeros((10,10)), dtype="float32"),
+                    axes=[-2, -1],
+                    epsilon=1e-05,
+                    center=True,
+                    scale=True,
+                )
+                gv: R.Tensor((1, 3, 10, 10), dtype="float32") = lv
+                R.output(gv)
+            return gv
+
+    model = LayerNorm2((10, 10))
+    binding = {}
+    verify_model(model, input_info, binding, expected2)
+
 
 def test_cross_entropy():
     input_info = [([3, 2], "float32"), ([3], "int32")]


### PR DESCRIPTION
This PR fixed the KeyError: 'None' in the issue #15758 

The original code assigned `gamma` variable without a conditional check for None. So I added it. Additionally, the `shape_tuple` calculation for `gamma` and `beta` is modified to use normalized_shape directly instead of normalized_shape.values.

Please review and consider merging this PR. Thank you!
@jikechao @Hzfengsy @leandron 