### PR TITLE
[Disco] Add -lrt to TVM runtime for NCCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,8 +895,9 @@ if(USE_CUDA AND USE_NVTX)
 endif()
 
 if(USE_CUDA AND USE_NCCL)
-  target_link_libraries(tvm PRIVATE nccl)
-  target_link_libraries(tvm_runtime PRIVATE nccl)
+  find_library(LIBRT rt)
+  target_link_libraries(tvm PRIVATE nccl ${LIBRT})
+  target_link_libraries(tvm_runtime PRIVATE nccl ${LIBRT})
 endif()
 
 if(USE_ROCM AND USE_RCCL)


### PR DESCRIPTION
This commit adds `-lrt` to TVM runtime when linked against static NCCL. The static NCCL depends on symbol `shm_unlink` which comes from librt.