### PR TITLE
[Relay] fix the conflicted documentation description

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -1426,9 +1426,9 @@ def from_keras(model, shape=None, layout="NCHW"):
         Input shapes of the model, optional
 
     layout: str
-        One of 'NCHW' or 'NHWC', indicates how data should be arranged in
-        the output model. Default layout is 'NCHW' as it in general
-        performs better across TVM.
+        One of 'NWC', 'NCHW', 'NHWC', 'NDHWC' indicates how data should
+        be arranged in the output model. Default layout is 'NCHW' as it
+        in general performs better across TVM.
 
     Returns
     -------


### PR DESCRIPTION
The wrong documentation about attribute layout in relay.from_keras().
By analysis the source code [Here](https://github.com/jikechao/tvm/blob/main_abc/python/tvm/relay/frontend/keras.py#:~:text=assert%20layout%20in,NHWC%20or%20NDHWC%22), we can find that input_layout has 4 valid values (e.g, 'NWC', 'NCHW', NHWC and NDHWC"). However, in the [source code comments](https://github.com/jikechao/tvm/blob/main_abc/python/tvm/relay/frontend/keras.py#:~:text=layout%3A%20str,better%20across%20TVM.) and [official documentation](https://tvm.apache.org/docs/reference/api/python/relay/frontend.html?highlight=from_keras#tvm.relay.frontend.from_keras:~:text=layout%20(str)%20%E2%80%93%20One%20of%20%E2%80%98NCHW%E2%80%99%20or%20%E2%80%98NHWC%E2%80%99%2C%20indicates%20how%20data%20should%20be%20arranged%20in%20the%20output%20model.%20Default%20layout%20is%20%E2%80%98NCHW%E2%80%99%20as%20it%20in%20general%20performs%20better%20across%20TVM.) , it says only 'nchw' and 'nhwc' are supported. They are conflicted.