### PR TITLE
[Unity] Fix wrong variable name in test_optimize_layout_transform

### DIFF
--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -3592,7 +3592,7 @@ class Schedule(Object):
 
             sch = tir.Schedule(before_pad_einsum, debug_mask="all")
             block = sch.get_block("C_shared")
-            sch.pad_einsum(block, [0, 1, 1])
+            sch.pad_einsum(block, [32, 32, 32])
             print(sch.mod["main"].script())
 
         After applying decompose-padding, the IR becomes:

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -3592,7 +3592,7 @@ class Schedule(Object):
 
             sch = tir.Schedule(before_pad_einsum, debug_mask="all")
             block = sch.get_block("C_shared")
-            sch.pad_einsum(block, [32, 32, 32])
+            sch.pad_einsum(block, [0, 1, 1])
             print(sch.mod["main"].script())
 
         After applying decompose-padding, the IR becomes:

--- a/tests/python/relax/test_optimize_layout_transform.py
+++ b/tests/python/relax/test_optimize_layout_transform.py
@@ -30,7 +30,7 @@ def _run_pass_compare_output(Before, Expected):
     if not relax.analysis.well_formed(fused_mod):
         print("IRModule is not well-formed")
 
-    fused_mode = DeadCodeElimination()(fused_mod)
+    fused_mod = DeadCodeElimination()(fused_mod)
     if not relax.analysis.well_formed(fused_mod):
         print("IRModule is not well-formed")
 


### PR DESCRIPTION
In the test file tests/python/relax/test_optimize_layout_transform.py, this **fused_mode** is unused. I think it should be **fused_mod**.