### PR TITLE
[Unity] [Bugfix] Fix KeyError:'None' in layer_norm and correctly use the normalized_shape

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -981,10 +981,15 @@ class TorchFXImporter:
             dim_num = len(normalized_shape)
             axes = list(range(-dim_num, 0))
 
-            gamma = self.env[node.kwargs["weight"]]
+            gamma = node.kwargs["weight"]
+            if gamma is None:
+                shape_tuple = [int(s) for s in normalized_shape]
+                gamma = relax.const(np.ones(shape_tuple), x.struct_info.dtype)
+            else:
+                gamma = self.env[gamma]
             beta = node.kwargs["bias"]
             if beta is None:
-                shape_tuple = [int(s) for s in normalized_shape.values]
+                shape_tuple = [int(s) for s in normalized_shape]
                 beta = relax.const(np.zeros(shape_tuple), x.struct_info.dtype)
             else:
                 beta = self.env[beta]


### PR DESCRIPTION
This PR fixed two bugs:

1. the KeyError: 'None' in the issue #15758
2. nomalized_shape doesn't have the attribute values

The original code assigned `gamma` variable without a conditional check for None. So I added it. Additionally, the `shape_tuple` calculation for `gamma` and `beta` is modified to use `normalized_shape` directly instead of `normalized_shape.values`.

Please review and consider merging this PR. Thank you!
@jikechao @Hzfengsy @leandron