### PR TITLE
[Unity] Ignore R.ExternFunc in EliminateCommonSubexpr

### DIFF
--- a/src/relax/transform/eliminate_common_subexpr.cc
+++ b/src/relax/transform/eliminate_common_subexpr.cc
@@ -94,7 +94,7 @@ class SubexprCounter : public ExprVisitor {
     if (!(e->IsInstance<VarNode>() || e->IsInstance<DataflowVarNode>() ||
           e->IsInstance<GlobalVarNode>() || e->IsInstance<tvm::OpNode>() ||
           e->IsInstance<PrimValueNode>() || e->IsInstance<StringImmNode>() ||
-          e->IsInstance<ShapeExprNode>() ||
+          e->IsInstance<ShapeExprNode>() || e->IsInstance<ExternFuncNode>() ||
           (e.as<ConstantNode>() && (e.as<ConstantNode>()->is_scalar())))) {
       // also if e has an impure subexpression, we will not deduplicate it
       if (!impurity_detector_.Detect(e)) {

--- a/tests/python/relax/test_transform_cse.py
+++ b/tests/python/relax/test_transform_cse.py
@@ -276,5 +276,19 @@ def test_do_not_eliminate_shape_expr():
     verify(Before, Expected)
 
 
+def test_do_not_eliminate_extern_func():
+    @I.ir_module
+    class Before:
+        @R.function(pure=False)
+        def foo(x: R.Tensor((2, 3), dtype="float32")):
+            y = R.call_packed("extern_func_name", x, sinfo_args=R.Tensor([2, 3]))
+            z = R.call_packed("extern_func_name", y, sinfo_args=R.Tensor([2, 3]))
+            return z
+
+    Expected = Before
+
+    verify(Before, Expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Prior to this commit, `relax::ExternFunc` nodes would be de-duplicated as part of the `EliminateCommonSubexpr` pass.  This commit instead ignores the `relax::ExternFunc` nodes, retaining the in-line definitions.