### PR TITLE
[Unity][Schedule] Prototype of peeling tail iterations

### DIFF
--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -355,6 +355,16 @@ class ScheduleNode : public runtime::Object {
   virtual Array<LoopRV> Split(const LoopRV& loop_rv, const Array<Optional<ExprRV>>& factors,
                               bool preserve_unit_iters = true) = 0;
   /*!
+   * \brief Separate a certain number of iterations from the end of a given loop into a tail loop.
+   * The loop can't have annotation or thread binding.
+   * \param loop_rv The loop to peel iterations from.
+   * \param iter_count The number of iterations to separate.
+   * \param preserve_unit_iters Whether or not to preserve unit iterators in block bindings
+   * \return The new loops after peeling.
+   */
+  virtual Array<LoopRV> Peel(const LoopRV& loop_rv, const ExprRV& iter_count,
+                             bool preserve_unit_iters = true) = 0;
+  /*!
    * \brief Reorder a list of loops. It doesn't require the loops to be consecutive.
    * It requires:
    * 1) The loops are in the same chain. That means: the loops can be ordered to [l_1, l_2, ... ,

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -814,6 +814,19 @@ class Schedule(Object):
         )
 
     @type_checked
+    def peel(
+        self,
+        loop: LoopRV,
+        iter_count: Union[int, ExprRV],
+        preserve_unit_iters: bool = True,
+    ) -> List[LoopRV]:
+        return list(
+            _ffi_api.SchedulePeel(  # type: ignore # pylint: disable=no-member
+                self, loop, iter_count, preserve_unit_iters
+            )
+        )
+
+    @type_checked
     def reorder(self, *ordered_loops: List[LoopRV]) -> None:
         """
         Reorder a list of loops. It doesn't require the loops to be consecutive.

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -500,6 +500,17 @@ Array<LoopRV> ConcreteScheduleNode::Split(const LoopRV& loop_rv,
   return CreateRV<LoopRV>(results);
 }
 
+Array<LoopRV> ConcreteScheduleNode::Peel(const LoopRV& loop_rv, const ExprRV& iter_count,
+                                         bool preserve_unit_iters) {
+  StmtSRef loop_sref = GetSRef(loop_rv);
+  PrimExpr iters = Get(iter_count);
+  Array<StmtSRef> results;
+  TVM_TIR_SCHEDULE_BEGIN();
+  results = tir::Peel(state_, loop_sref, iters, preserve_unit_iters);
+  TVM_TIR_SCHEDULE_END("peel", error_render_level_);
+  return CreateRV<LoopRV>(results);
+}
+
 void ConcreteScheduleNode::Reorder(const Array<LoopRV>& ordered_loop_rvs) {
   TVM_TIR_SCHEDULE_BEGIN();
   tir::Reorder(state_, GetSRefs(ordered_loop_rvs));

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -109,6 +109,8 @@ class ConcreteScheduleNode : public ScheduleNode {
   LoopRV Merge(const Array<LoopRV>& loop_rvs) override;
   Array<LoopRV> Split(const LoopRV& loop_rv, const Array<Optional<ExprRV>>& factors,
                       bool preserve_unit_iters) override;
+  Array<LoopRV> Peel(const LoopRV& loop_rv, const ExprRV& iter_count,
+                     bool preserve_unit_iters) override;
   void Reorder(const Array<LoopRV>& ordered_loop_rvs) override;
   void ReorderBlockIterVar(const BlockRV& block_rv, const Array<Integer> new_order) override;
   LoopRV AddUnitLoop(const BlockRV& block_rv) override;

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -210,6 +210,18 @@ TVM_DLL Array<StmtSRef> Split(ScheduleState self, const StmtSRef& loop_sref,
                               const Array<PrimExpr>& factors, bool preserve_unit_iters);
 
 /*!
+ * \brief Separate a certain number of iterations from the end of a given loop into a tail loop.
+ * The loop can't have annotation or thread binding.
+ * \param self The state of the schedule
+ * \param loop_sref The sref to the loop to peel iterations from.
+ * \param iter_count The number of iterations to separate.
+ * \param preserve_unit_iters Whether or not to preserve unit iterators in block bindings
+ * \return An array of srefs to the new loops after peeling.
+ */
+TVM_DLL Array<StmtSRef> Peel(ScheduleState self, const StmtSRef& loop_sref, PrimExpr iter_count,
+                             bool preserve_unit_iters);
+
+/*!
  * \brief Merge a list of loops into one. The loops under their LCA requires:
  * 1) Under the same scope
  * 2) Can't have annotations or thread bindings

--- a/src/tir/schedule/schedule.cc
+++ b/src/tir/schedule/schedule.cc
@@ -162,6 +162,7 @@ TVM_REGISTER_GLOBAL("tir.schedule.ScheduleGetOutputBlocks")
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleMerge").set_body_method<Schedule>(&ScheduleNode::Merge);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleFuse").set_body_method<Schedule>(&ScheduleNode::Fuse);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleSplit").set_body_method<Schedule>(&ScheduleNode::Split);
+TVM_REGISTER_GLOBAL("tir.schedule.SchedulePeel").set_body_method<Schedule>(&ScheduleNode::Peel);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleReorder")
     .set_body_method<Schedule>(&ScheduleNode::Reorder);
 TVM_REGISTER_GLOBAL("tir.schedule.ScheduleReorderBlockIterVar")


### PR DESCRIPTION
If iv is a loop induction variable, then `m, t = sch.peel_tail(iv, 1)` will convert
```
  for iv in T.serial(n):
    blah
```
to
```
  for m in T.serial(n-1):
    blah
  for t in T.serial(1):
    blah
```

This is still wip.