### PR TITLE
[Target][CI] Add LLVM functions for current system info

### DIFF
--- a/python/tvm/target/codegen.py
+++ b/python/tvm/target/codegen.py
@@ -96,6 +96,48 @@ def llvm_get_intrinsic_name(intrin_id: int) -> str:
     return _ffi_api.llvm_get_intrinsic_name(intrin_id)
 
 
+def llvm_get_system_x86_vendor():
+    """Get system x86 vendor info.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    vendor : str
+        The current system's cpu vendor.
+    """
+    return _ffi_api.llvm_get_system_x86_vendor()
+
+
+def llvm_get_system_triple():
+    """Get system host triple.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    triple : str
+        The current system's triple.
+    """
+    return _ffi_api.llvm_get_system_triple()
+
+
+def llvm_get_system_cpu():
+    """Get system host cpu name.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    cpu_name : str
+        The current system's cpu name.
+    """
+    return _ffi_api.llvm_get_system_cpu()
+
+
 def llvm_get_targets():
     """Get LLVM target list.
 

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -41,6 +41,7 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/FileSystem.h>
+#include <llvm/Support/Host.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
@@ -483,6 +484,30 @@ TVM_REGISTER_GLOBAL("target.llvm_get_intrinsic_name").set_body_typed([](int64_t 
   // Nothing to do, just return the intrinsic id number
   return std::to_string(id);
 #endif
+});
+
+TVM_REGISTER_GLOBAL("target.llvm_get_system_x86_vendor").set_body_typed([]() -> String {
+#if TVM_LLVM_VERSION >= 120
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
+  using namespace llvm::sys::detail::x86;
+  const auto x86_sign = getVendorSignature();
+  if (x86_sign == VendorSignatures::GENUINE_INTEL)
+    return "intel";
+  else if (x86_sign == VendorSignatures::AUTHENTIC_AMD)
+    return "amd";
+  else if (x86_sign == VendorSignatures::UNKNOWN)
+    return "unknown";
+#endif
+#endif
+  return "unimplemented";
+});
+
+TVM_REGISTER_GLOBAL("target.llvm_get_system_triple").set_body_typed([]() -> String {
+  return llvm::sys::getDefaultTargetTriple();
+});
+
+TVM_REGISTER_GLOBAL("target.llvm_get_system_cpu").set_body_typed([]() -> String {
+  return llvm::sys::getHostCPUName().str();
 });
 
 TVM_REGISTER_GLOBAL("target.llvm_get_targets").set_body_typed([]() -> Array<String> {

--- a/tests/python/contrib/test_amx.py
+++ b/tests/python/contrib/test_amx.py
@@ -27,8 +27,13 @@ import numpy as np
 import pytest
 
 
-@tvm.testing.requires_llvm
-@pytest.mark.skip("skip due to AMX feature not avaliable yet")
+has_amx_runtime = pytest.mark.skipif(
+    not tvm.get_global_func("runtime.amx_init", True), reason="AMX runtime not available"
+)
+
+
+@has_amx_runtime
+@tvm.testing.requires_x86_amx
 def test_amx_u8s8s32_matmul_tensorize():
     m = 1024
     k = 1024
@@ -113,8 +118,8 @@ def test_amx_u8s8s32_matmul_tensorize():
     tvm.testing.assert_allclose(y.numpy(), np.dot(a.astype("int32"), b.T.astype("int32")), rtol=0)
 
 
-@tvm.testing.requires_llvm
-@pytest.mark.skip("skip due to AMX feature not avaliable yet")
+@has_amx_runtime
+@tvm.testing.requires_x86_amx
 def test_amx_check_support():
     amx_init = tvm.get_global_func("runtime.amx_init")
     amx_tileconfig = tvm.get_global_func("runtime.amx_tileconfig")

--- a/tests/python/contrib/test_gemm_acc32_vnni.py
+++ b/tests/python/contrib/test_gemm_acc32_vnni.py
@@ -97,7 +97,7 @@ def verify_fc_int8_acc32(m=1024, n=1024, k=1024, target="llvm -mcpu=cascadelake"
     # t_func.export_library("tensorize_acc32.o")
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_x86_vnni
 def test_fc_int8_acc32_vnni():
     # For LLVM < 8.0, it shows "'cascadelake' is not a recognized processor for this target
     # (ignoring processor)" error with the following setting. After LLVM 8.0 is enabled in the
@@ -105,7 +105,7 @@ def test_fc_int8_acc32_vnni():
     verify_fc_int8_acc32()
 
 
-@tvm.testing.requires_skylake_avx512
+@tvm.testing.requires_x86_avx512
 def test_fc_int8_acc32_avx512():
     verify_fc_int8_acc32(target="llvm -mcpu=skylake-avx512")
 

--- a/tests/python/integration/test_auto_tensorize.py
+++ b/tests/python/integration/test_auto_tensorize.py
@@ -287,12 +287,12 @@ def _test_bert_int8(relay_mod, params, input_info, target, sch_rules, postprocs)
     print(runtime.benchmark(dev, number=1, repeat=50).mean)
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_x86_vnni
 def test_vnni_dense():
     _test_dense("uint8", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI, CASCADELAKE_VNNI_TARGET)
 
 
-@tvm.testing.requires_skylake_avx512
+@tvm.testing.requires_x86_avx512
 def test_avx512_dense():
     _test_dense("uint8", SCH_RULES_FOR_AVX512, POSTPROCS_FOR_VNNI, SKYLAKE_AVX512_TARGET)
 
@@ -310,12 +310,12 @@ def test_dp4a_dense():
     # )
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_x86_vnni
 def test_vnni_conv2d():
     _test_conv2d("uint8", SCH_RULES_FOR_VNNI, POSTPROCS_FOR_VNNI, CASCADELAKE_VNNI_TARGET)
 
 
-@tvm.testing.requires_skylake_avx512
+@tvm.testing.requires_x86_avx512
 def test_avx512_conv2d():
     _test_conv2d("uint8", SCH_RULES_FOR_AVX512, POSTPROCS_FOR_VNNI, SKYLAKE_AVX512_TARGET)
 
@@ -333,7 +333,7 @@ def test_dp4a_conv2d():
     # )
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_x86_vnni
 @pytest.mark.skipif(tvm.testing.IS_IN_CI, reason="Slow on CI")
 def test_vnni_bert_int8():
     pytest.importorskip("onnx")
@@ -348,7 +348,7 @@ def test_vnni_bert_int8():
     )
 
 
-@tvm.testing.requires_skylake_avx512
+@tvm.testing.requires_x86_avx512
 @pytest.mark.skip("Due to quantized BERT download issue")
 def test_avx512_bert_int8():
     relay_mod, params, input_info = load_quantized_bert_base()

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -846,13 +846,13 @@ def test_dense_amx_int8():
         np.testing.assert_equal(out, ref)
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_x86_vnni
 @pytest.mark.parametrize("m,n,k", [(32, 128, 96), (32, 128, 97)])
 def test_dense_vnni(m, n, k):
     dense_x86_test(m, n, k)
 
 
-@tvm.testing.requires_skylake_avx512
+@tvm.testing.requires_x86_avx512
 @pytest.mark.parametrize("m,n,k", [(32, 128, 96), (32, 128, 97)])
 def test_dense_skylake_avx512(m, n, k):
     dense_x86_test(m, n, k, "llvm -mcpu=skylake-avx512", ["pmaddubs", "pmaddw", "vpaddd"])

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -568,7 +568,7 @@ def test_batch_matmul_amx(b, m, n, k):
         np.testing.assert_equal(out, ref)
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_x86_vnni
 @pytest.mark.parametrize(
     "b,m,n,k",
     [
@@ -581,7 +581,7 @@ def test_batch_matmul_vnni(b, m, n, k):
     batch_matmul_x86_test(b, m, n, k)
 
 
-@tvm.testing.requires_skylake_avx512
+@tvm.testing.requires_x86_avx512
 @pytest.mark.parametrize(
     "b,m,n,k",
     [

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -2237,12 +2237,12 @@ def test_conv2d_int8_alter_dtype_arm():
     )
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_x86_vnni
 def test_conv2d_int8_alter_dtype_vnni():
     _test_conv2d_int8_alter_dtype("int8", "llvm -mcpu=cascadelake", ["vpdpbusd"])
 
 
-@tvm.testing.requires_skylake_avx512
+@tvm.testing.requires_x86_avx512
 def test_conv2d_int8_alter_dtype_avx512():
     _test_conv2d_int8_alter_dtype(
         "int8", "llvm -mcpu=skylake-avx512", ["pmaddubs", "pmaddw", "vpaddd"]

--- a/tests/python/target/test_llvm_features_info.py
+++ b/tests/python/target/test_llvm_features_info.py
@@ -30,7 +30,13 @@ def test_llvm_targets():
 
     # check blank results
     assert len(codegen.llvm_get_targets())
+    assert len(codegen.llvm_get_system_cpu())
+    assert len(codegen.llvm_get_system_triple())
+    assert len(codegen.llvm_get_system_x86_vendor())
     # check ffi vs python
+    assert codegen.llvm_get_system_cpu() == _ffi_api.llvm_get_system_cpu()
+    assert codegen.llvm_get_system_triple() == _ffi_api.llvm_get_system_triple()
+    assert codegen.llvm_get_system_x86_vendor() == _ffi_api.llvm_get_system_x86_vendor()
     assert str(codegen.llvm_get_targets()) == str(_ffi_api.llvm_get_targets())
 
     # check LLVM target -mcpu legality

--- a/tests/python/unittest/test_meta_schedule_cpu_dot_product.py
+++ b/tests/python/unittest/test_meta_schedule_cpu_dot_product.py
@@ -165,13 +165,13 @@ def schedule_16x4_dense_fn_database(target, intrin, m=1024, n=1024, k=1024):
     f_check(lib, dev)
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_x86_vnni
 def test_vnni_schedule_fn_database():
     target = tvm.target.Target("llvm -keys=x86,cpu -mcpu=cascadelake -num-cores=4")
     schedule_16x4_dense_fn_database(target, VNNI_INTRIN)
 
 
-@tvm.testing.requires_skylake_avx512
+@tvm.testing.requires_x86_avx512
 def test_avx512_schedule_fn_database():
     target = tvm.target.Target("llvm -keys=x86,cpu -mcpu=skylake-avx512 -num-cores=4")
     schedule_16x4_dense_fn_database(target, AVX512_INTRIN, 16, 16, 16)
@@ -255,13 +255,13 @@ def schedule_16x4_dense_fn_tune(target, intrin, m=1024, n=1024, k=1024):
     f_check(lib, dev)
 
 
-@tvm.testing.requires_cascadelake
+@tvm.testing.requires_x86_vnni
 def test_vnni_schedule_fn_tune():
     target = tvm.target.Target("llvm -keys=x86,cpu -mcpu=cascadelake -num-cores=4")
     schedule_16x4_dense_fn_tune(target, VNNI_INTRIN)
 
 
-@tvm.testing.requires_skylake_avx512
+@tvm.testing.requires_x86_avx512
 def test_avx512_schedule_fn_tune():
     target = tvm.target.Target("llvm -keys=x86,cpu -mcpu=skylake-avx512 -num-cores=4")
     schedule_16x4_dense_fn_tune(target, AVX512_INTRIN, 16, 16, 16)


### PR DESCRIPTION
This PR adds helper functions to query system info from the LLVM backend.
It  enhances TVM target information handling and extends the CI coverage.

---
#### Changes:

 * Introduces ```llvm_get_system_cpu()```, ```llvm_get_system_triple()``` and ```llvm_get_system_x86_vendor()```
 * Exposes both C/FFI & PY interfaces for all the functions mentioned above with proper test cases.
 * Enhances CI test utils, removes old limiting checks  related to arch/system/cpu/vendor dependencies.

#### Usage example
```
$ cat tvm-system-info.py
#!/usr/bin/python3

import tvm
from tvm.target import codegen, Target

cpu = codegen.llvm_get_system_cpu()
triple = codegen.llvm_get_system_triple()
vendor = codegen.llvm_get_system_x86_vendor()
target = "llvm -mtriple=%s -mcpu=%s" % (triple, cpu)

print("Current system CPU: [%s], VENDOR: [%s] TRIPLE: [%s]" % (cpu, vendor, triple))

with tvm.target.Target(target):
  features = codegen.llvm_get_cpu_features()
  print("TVM target [%s] having features:\n\n{%s}" % (target, features))
```
```
$ ./tvm-system-info.py 
Current system CPU: [skylake], VENDOR: [intel] TRIPLE: [x86_64-redhat-linux-gnu]
TVM target [llvm -mtriple=x86_64-redhat-linux-gnu -mcpu=skylake] having features:

{["64bit", "64bit-mode", "adx", "aes", "allow-light-256-bit", "avx", "avx2", "bmi", "bmi2", "clflushopt",
 "cmov", "crc32", "cx16", "cx8", "ermsb", "f16c", "false-deps-popcnt", "fast-15bytenop", "fast-gather", 
"fast-scalar-fsqrt", "fast-shld-rotate", "fast-variable-crosslane-shuffle", "fast-variable-perlane-shuffle",
 "fast-vector-fsqrt", "fma", "fsgsbase", "fxsr", "idivq-to-divl", "invpcid", "lzcnt", "macrofusion", "mmx",
 "movbe", "no-bypass-delay-blend", "no-bypass-delay-mov", "no-bypass-delay-shuffle", "nopl", "pclmul", 
"popcnt", "prfchw", "rdrnd", "rdseed", "sahf", "slow-3ops-lea", "sse", "sse2", "sse3", "sse4.1", "sse4.2", 
"ssse3", "vzeroupper", "x87", "xsave", "xsavec", "xsaveopt", "xsaves"]}
```
```
$ uname -s -r -v -m -o
Linux 6.5.0-57.fc40.x86_64 #1 SMP PREEMPT_DYNAMIC Mon Aug 28 01:50:08 UTC 2023 x86_64 GNU/Linux
$ cat /proc/cpuinfo  | grep -m1 name 
model name	: Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz
```


Cc: @kparzysz-quic , @vinx13 , @masahi  , @driazati , @junrushao , @tqchen , @elvin-n , @vvchernov , @echuraev

**Notes:** 
 * Could also relate to efforts in #14981
 * Adds ability to lookup pure CPU features instead, regardless the vendor code-names (e.g. AMD vs. Intel)
 * Adds ability to lookup and work with things regardless of platform flavors (e.g.: Darwin, Windows, etc)

