### PR TITLE
[Unity][Transform] Canonicalize and use CSE between pattern matches

### DIFF
--- a/python/tvm/relax/transform/remove_redundant_reshape.py
+++ b/python/tvm/relax/transform/remove_redundant_reshape.py
@@ -66,13 +66,18 @@ class RemoveRedundantReshape:
                 continue
 
             def rewriter(expr, matches):
-                args = matches[self.pattern]
+                arg = matches[self.input1]
+
                 if self.repeated_reshape in matches:
-                    return relax.op.reshape(matches[self.input1], args.args[1])
+                    output_shape = matches[self.repeated_reshape].args[1]
+                    return relax.op.reshape(arg, output_shape)
+
                 elif self.no_op_reshape in matches:
-                    if args.args[0].struct_info.shape:
-                        if structural_equal(args.args[0].struct_info.shape, args.args[1]):
-                            return args.args[0]
+                    output_shape = matches[self.no_op_reshape].args[1]
+                    if arg.struct_info.shape and structural_equal(
+                        arg.struct_info.shape, output_shape
+                    ):
+                        return arg
                 return expr
 
             updated_func = rewrite_call(self.pattern, rewriter, funct)

--- a/tests/python/relax/test_remove_redundant_reshape.py
+++ b/tests/python/relax/test_remove_redundant_reshape.py
@@ -41,9 +41,9 @@ def test_remove_redundant_reshape_pass_one_arg():
             with R.dataflow():
                 lv: R.Tensor((1, 1001), dtype="float16") = R.reshape(x, R.shape([1, 1001]))
                 lv1: R.Tensor((1, 1001), dtype="float16") = R.reshape(lv, R.shape([1, 1001]))
-                lv2: R.Tensor((1, 1001), dtype="float16") = R.reshape(lv1, R.shape([1, 1001]))
-                R.output(lv2)
-            return lv2
+                gv: R.Tensor((1, 1001), dtype="float16") = R.reshape(lv1, R.shape([1, 1001]))
+                R.output(gv)
+            return gv
 
     @I.ir_module
     class Expected:
@@ -52,9 +52,10 @@ def test_remove_redundant_reshape_pass_one_arg():
             x: R.Tensor((1, 1001, 1, 1), dtype="float16")
         ) -> R.Tensor((1, 1001), dtype="float16"):
             with R.dataflow():
-                lv1: R.Tensor((1, 1001), dtype="float16") = R.reshape(x, R.shape([1, 1001]))
-                R.output(lv1)
-            return lv1
+                lv: R.Tensor((1, 1001), dtype="float16") = R.reshape(x, R.shape([1, 1001]))
+                gv: R.Tensor((1, 1001), dtype="float16") = lv
+                R.output(gv)
+            return gv
 
     _run_pass_compare_output(Before, Expected)
 
@@ -106,10 +107,7 @@ def test_remove_redundant_reshape_pass_three_arg():
         def main(
             x: R.Tensor((1, 1001, 1, 1), dtype="float16")
         ) -> R.Tensor((1, 1001, 1, 1), dtype="float16"):
-            with R.dataflow():
-                lv: R.Tensor((1, 1001, 1, 1), dtype="float16") = x
-                R.output(lv)
-            return lv
+            return x
 
     _run_pass_compare_output(Before, Expected)
 


### PR DESCRIPTION
The `PatternRewriter` is intended to iterate until no matching patterns remain, as implemented in #14446 and #15495.  Prior to this commit, this only involved repeating the pattern match rewrite rules.  However, intermediate results produced by pattern replacement could cause the iterative pattern matching to terminate early.

* If two rewrite rules each introduce the same intermediate, there will exist two copies of that intermediate, which can prevent `only_used_by` patterns from matching.  Applying `EliminateCommonSubexpr` allows the pattern matching to continue.

* Applying a rewrite rule may result in dangling intermediates that are no longer used.  These dangling intermediates may prevent the next application of a rewrite rule that uses the `only_used_by` constraint.  Applying `RemoveAllUnused` allows the pattern matching to continue.

* A rewrite rule that returns a `relax::Var` or `relax::TupleGetItem` as the replacement introduces trivial var-to-var rebinding, which are not tracked by `PatternRewriter`.  Applying `CanonicalizeBindings` allows the pattern matching to continue.

While this could be fixed externally by repeatedly applying `rewrite_call`, this would require re-inspecting the entire function, and not just the dataflow block in which the replacement occurred.