### PR TITLE
[Unity][MSC][M1.2] Add translate && codegen for tensorflow

### DIFF
--- a/python/tvm/contrib/msc/core/codegen/codegen.py
+++ b/python/tvm/contrib/msc/core/codegen/codegen.py
@@ -100,9 +100,14 @@ class CodeGen(object):
                 if self._code_format == "cpp":
                     with folder.create_dir("build"):
                         command = "cmake ../ && make && mv {} ../".format(self._graph.name)
-                        process = subprocess.Popen(command, shell=True)
+                        with open("codegen.log", "w") as log_f:
+                            process = subprocess.Popen(
+                                command, stdout=log_f, stderr=log_f, shell=True
+                            )
                         process.wait()
-                        assert process.returncode == 0, "Failed to build {} under {}".format(
+                        assert (
+                            process.returncode == 0
+                        ), "Failed to build {} under {}, check codegen.log for detail".format(
                             self._graph.name, os.getcwd()
                         )
                     obj = self._graph.name

--- a/python/tvm/contrib/msc/core/ir/translate.py
+++ b/python/tvm/contrib/msc/core/ir/translate.py
@@ -112,7 +112,7 @@ def from_relax(
                 tvm.relax.transform.FoldConstant(),
             ]
         )(mod)
-    patterns = get_patterns_with_prefix("msc")
+    patterns = get_patterns_with_prefix("msc.")
     passes = [
         tvm.relax.transform.FuseOpsByPattern(
             patterns, bind_constants=False, annotate_codegen=False
@@ -250,9 +250,7 @@ class BYOCChecker(PyExprVisitor):
             self.visit_expr(expr)
         elif isinstance(expr, tvm.relax.BindingBlock):
             self.visit_binding_block(expr)
-        assert len(self._non_target_exprs) == 0, "Exprs not on target {}".format(
-            self._non_target_exprs
-        )
+        assert len(self._non_target_exprs) == 0, "Some exprs not on target {}".format(expr)
 
     def visit_var_binding_(self, binding) -> None:
         super().visit_var_binding_(binding)
@@ -262,6 +260,8 @@ class BYOCChecker(PyExprVisitor):
                     self._non_target_exprs.append(binding.value)
             else:
                 self._non_target_exprs.append(binding.value)
+        elif not isinstance(binding.value, tvm.relax.DataflowVar):
+            self._non_target_exprs.append(binding.value)
 
 
 def byoc_partition(
@@ -305,31 +305,37 @@ def byoc_partition(
     if params:
         mod = BindParams("main", params)(mod)
 
-    patterns = get_patterns_with_prefix(target)
-    mod = tvm.transform.Sequential(
-        [
-            tvm.relax.transform.FuseOpsByPattern(
-                patterns, bind_constants=False, annotate_codegen=False
-            ),
-            tvm.relax.transform.MergeCompositeFunctions(),
-            msc_transform.SetExprName(target=target),
-            msc_transform.SetExprLayout(trans_config.get("allow_layout_missing", True)),
-        ]
-    )(mod)
+    def _partition_mod(mod, as_msc=True):
+        patterns = get_patterns_with_prefix(target)
+        if as_msc:
+            passes = [tvm.relax.transform.FuseOpsByPattern(patterns, bind_constants=False)]
+        else:
+            passes = [tvm.relax.transform.FuseOpsByPattern(patterns, bind_constants=True)]
+        passes.extend(
+            [
+                msc_transform.BindShape(),
+                tvm.relax.transform.MergeCompositeFunctions(),
+                msc_transform.SetExprName(target=target),
+                msc_transform.SetExprLayout(trans_config.get("allow_layout_missing", True)),
+            ]
+        )
+        return tvm.transform.Sequential(passes)(mod)
 
     def _is_target_func(func):
         if "Codegen" not in func.attrs:
             return False
         return func.attrs["Codegen"] == target
 
-    func_names = [var.name_hint for var, func in mod.functions.items() if _is_target_func(func)]
+    msc_mod = _partition_mod(mod)
+    func_names = [var.name_hint for var, func in msc_mod.functions.items() if _is_target_func(func)]
 
     if not allow_incomplete:
-        BYOCChecker().check(func_names, mod[entry])
+        assert len(func_names) == 1, "More than 1 target func is found: " + str(msc_mod)
+        BYOCChecker().check(func_names, msc_mod[entry])
 
-    graphs_info, all_weights = [], _ffi_api.GetRelaxWeights(mod, entry)
+    graphs_info, all_weights = [], _ffi_api.GetRelaxWeights(msc_mod, entry)
     for idx, name in enumerate(func_names):
-        build_config["graph_name"] = target + "_" + str(idx)
-        graph = _ffi_api.BuildFromRelax(mod, name, msc_utils.dump_dict(build_config))
+        build_config.update({"graph_name": target + "_" + str(idx), "byoc_entry": name})
+        graph = _ffi_api.BuildFromRelax(msc_mod, entry, msc_utils.dump_dict(build_config))
         graphs_info.append((name, graph, normalize_weights(all_weights, graph)))
-    return mod, graphs_info
+    return _partition_mod(mod, False), graphs_info

--- a/python/tvm/contrib/msc/core/transform/transform.py
+++ b/python/tvm/contrib/msc/core/transform/transform.py
@@ -84,3 +84,19 @@ def SetExprLayout(allow_missing: bool = True, entry_name: str = "main") -> tvm.i
     """
 
     return relax_api.SetExprLayout(allow_missing, entry_name)  # type: ignore
+
+
+def BindShape(entry_name: str = "main") -> tvm.ir.transform.Pass:
+    """Bind ShapeExpr to reshape
+
+    Parameters
+    ----------
+    entry_name: str
+        The entry name
+
+    Returns
+    -------
+    ret: tvm.ir.transform.Pass
+    """
+
+    return relax_api.BindShape(entry_name)  # type: ignore

--- a/python/tvm/contrib/msc/core/utils/dataset.py
+++ b/python/tvm/contrib/msc/core/utils/dataset.py
@@ -1,0 +1,207 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.core.utils.dataset"""
+
+import os
+import json
+from typing import List
+import numpy as np
+
+from .info import load_dict
+
+
+class MSCDataLoader(object):
+    """Dataset Loader for MSC
+
+    Parameters
+    ----------
+    folder: string
+        The dataset folder path.
+    start: int
+        The start position.
+    end: int
+        The end position.
+    """
+
+    def __init__(self, folder: str, start: int = 0, end: int = -1):
+        super(MSCDataLoader, self).__init__()
+        self._folder = folder
+        self._start = start
+        self._current = 0
+        assert os.path.isdir(folder), "Dataset {} is not folder".format(folder)
+        self._info = load_dict(os.path.join(folder, "msc_info.json"))
+        if end == -1:
+            self._end = self._info["num_datas"]
+        else:
+            self._end = min(end, self._info["num_datas"])
+
+    def __getitem__(self, idx):
+        if idx + self._start >= self._end:
+            raise StopIteration("Reach End")
+        if "inputs" in self._info:
+            inputs = {n: self._load_data(n, idx, i) for n, i in self._info["inputs"].items()}
+        else:
+            inputs = {}
+        if "outputs" in self._info:
+            outputs = {n: self._load_data(n, idx, i) for n, i in self._info["outputs"].items()}
+        else:
+            outputs = {}
+        return inputs, outputs
+
+    def __next__(self):
+        if self._current + self._start >= self._end:
+            raise StopIteration("Reach End")
+        inputs, outputs = self.__getitem__(self._current)
+        self._current += 1
+        return inputs, outputs
+
+    def __len__(self):
+        return self._end - self._start
+
+    def reset(self):
+        self._current = 0
+
+    def _load_data(self, name: str, index: int, info: dict) -> np.ndarray:
+        """Load data from file.
+
+        Parameters
+        -------
+        name: str
+            The name of the data.
+        index: int
+            The index of the data.
+        info: dict
+            The info of the data.
+
+        Returns
+        -------
+        data: np.ndarray
+           The loaded data.
+        """
+
+        f_path = os.path.join(self._folder, name, "batch_{}.bin".format(self._start + index))
+        assert os.path.isfile(f_path), "Can not find data file " + str(f_path)
+        return np.fromfile(f_path, dtype=info["dtype"]).reshape(info["shape"])
+
+
+class MSCDataSaver(object):
+    """Dataset Saver for MSC
+
+    Parameters
+    ----------
+    folder: string
+        The dataset folder path.
+    input_names: list<string>
+        The input names.
+    output_names: list<string>
+        The output names.
+    start: int
+        The start position.
+    max_size: int
+        The max size for datas.
+    """
+
+    def __init__(
+        self,
+        folder: str,
+        input_names: List[str],
+        output_names: List[str],
+        start: int = 0,
+        max_size: int = -1,
+    ):
+        super(MSCDataSaver, self).__init__()
+        if not os.path.isdir(folder):
+            os.mkdir(folder)
+        self._folder = folder
+        self._input_names = input_names
+        self._output_names = output_names
+        self._start = start
+        self._max_size = max_size
+        self._current = 0
+        assert os.path.isdir(folder), "Dataset {} is not folder".format(folder)
+        self._info = {"inputs": {}, "outputs": {}, "num_datas": 0}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        self._info["num_datas"] = self._current
+        with open(os.path.join(self._folder, "msc_info.json"), "w") as f:
+            f.write(json.dumps(self._info, indent=2))
+
+    def reset(self):
+        self._current = 0
+
+    def save(self, inputs: List[np.ndarray], outputs: List[np.ndarray] = None):
+        """Save 1 batch inputs and outputs.
+
+        Parameters
+        -------
+        inputs: list<np.ndarray>
+            The inputs datas.
+        outputs: list<np.ndarray>
+            The outputs datas.
+        """
+
+        assert len(inputs) == len(
+            self._input_names
+        ), "inputs size {} mismatch with input_names {}".format(len(inputs), self._input_names)
+        for idx, i_data in enumerate(inputs):
+            self._save_data(self._input_names[idx], i_data, True)
+        if outputs:
+            assert len(outputs) == len(
+                self._output_names
+            ), "outputs size {} mismatch with output_names {}".format(
+                len(outputs), self._output_names
+            )
+            for idx, o_data in enumerate(outputs):
+                self._save_data(self._output_names[idx], o_data, False)
+        self._current += 1
+
+    def _save_data(self, name: str, data: np.ndarray, is_input: bool):
+        """Save data to file.
+
+        Parameters
+        -------
+        name: str
+            The name of the data.
+        data: np.ndarray
+           The data to be saved.
+        is_input: bool
+            Whether the data is input.
+        """
+
+        sub_folder = f_path = os.path.join(self._folder, name)
+        if not os.path.isdir(sub_folder):
+            os.mkdir(sub_folder)
+        f_path = os.path.join(sub_folder, "batch_{}.bin".format(self._start + self._current))
+        ref_info = self._info["inputs"] if is_input else self._info["outputs"]
+        # TODO(mengtong): support dynamic datas shape
+        if name in ref_info:
+            assert (
+                ref_info[name]["dtype"] == data.dtype.name
+            ), "dtype {} mismatch with saved {}".format(data.dtype.name, ref_info[name]["dtype"])
+            assert ref_info[name]["shape"] == list(
+                data.shape
+            ), "shape {} mismatch with saved {}".format(data.shape, ref_info[name]["shape"])
+        else:
+            ref_info[name] = {
+                "shape": list(data.shape),
+                "dtype": data.dtype.name,
+                "bytes": data.size * data.itemsize,
+            }
+        data.tofile(f_path)

--- a/python/tvm/contrib/msc/core/utils/expr.py
+++ b/python/tvm/contrib/msc/core/utils/expr.py
@@ -24,6 +24,26 @@ from tvm.relax import PyExprVisitor
 from tvm.contrib.msc.core import _ffi_api
 
 
+def get_expr_name(expr: relax.Expr) -> str:
+    """Get name hint ofr expr
+
+    Parameters
+    ----------
+    expr: Expr
+        The Expr of relax.
+
+    Returns
+    -------
+    name: str
+        The name_hint of expr
+    """
+
+    name = _ffi_api.SpanGetAttr(expr.span, "name")
+    if not name and isinstance(expr, relax.Var):
+        return expr.name_hint
+    return name
+
+
 def get_span_attrs(mod: tvm.IRModule) -> dict:
     """Extract the span attributes from relax.Function.
 
@@ -53,7 +73,7 @@ def get_span_attrs(mod: tvm.IRModule) -> dict:
         def _update_attrs(self, expr: relax.Expr, name: str = "") -> None:
             if not expr.span:
                 return
-            name = name or _ffi_api.SpanGetAttr(expr.span, "name")
+            name = name or get_expr_name(expr)
             if not name:
                 return
             self._span_info[name] = dict(_ffi_api.SpanGetAttrs(expr.span))

--- a/python/tvm/contrib/msc/core/utils/file.py
+++ b/python/tvm/contrib/msc/core/utils/file.py
@@ -179,6 +179,12 @@ class MSCDirectory(object):
 
         return os.listdir(self._path)
 
+    def destory(self):
+        """Destory the dir."""
+
+        if os.path.isdir(self._path):
+            shutil.rmtree(self._path)
+
     @property
     def path(self):
         return self._path

--- a/python/tvm/contrib/msc/core/utils/info.py
+++ b/python/tvm/contrib/msc/core/utils/info.py
@@ -127,9 +127,11 @@ def get_version(framework: str) -> List[int]:
         elif framework == MSCFramework.TENSORFLOW:
             import tensorflow  # pylint: disable=import-outside-toplevel
 
-            raw_version = tensorflow.__version
+            raw_version = tensorflow.__version__
         if framework == MSCFramework.TENSORRT:
-            raw_version = ".".join(tvm.get_global_func("relax.get_tensorrt_version")())
+            raw_version = ".".join(
+                [str(v) for v in tvm.get_global_func("relax.get_tensorrt_version")()]
+            )
         else:
             raw_version = "1.0.0"
     except:  # pylint: disable=bare-except

--- a/python/tvm/contrib/msc/framework/tensorflow/__init__.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/__init__.py
@@ -14,11 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""tvm.contrib.msc.core.utils"""
+"""tvm.contrib.msc.framework.tensorflow"""
 
-from .expr import *
-from .info import *
-from .file import *
-from .namespace import *
-from .register import *
-from .dataset import *
+import tensorflow as tf
+
+try:
+    tf_v1 = tf.compat.v1
+except (ImportError, AttributeError):
+    tf_v1 = tf

--- a/python/tvm/contrib/msc/framework/tensorflow/_ffi_api.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/_ffi_api.py
@@ -14,11 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""tvm.contrib.msc.core.utils"""
+"""tvm.contrib.msc.framework.tensorflow._ffi_api"""
 
-from .expr import *
-from .info import *
-from .file import *
-from .namespace import *
-from .register import *
-from .dataset import *
+import tvm._ffi
+
+tvm._ffi._init_api("msc.framework.tensorflow", __name__)

--- a/python/tvm/contrib/msc/framework/tensorflow/codegen/__init__.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/codegen/__init__.py
@@ -14,11 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""tvm.contrib.msc.core.utils"""
+"""tvm.contrib.msc.framework.tensorflow.codegen"""
 
-from .expr import *
-from .info import *
-from .file import *
-from .namespace import *
-from .register import *
-from .dataset import *
+from .codegen import *

--- a/python/tvm/contrib/msc/framework/tensorflow/codegen/codegen.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/codegen/codegen.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.framework.tensorflow.codegen.codegen"""
+
+from typing import Dict, Optional, Union, List
+
+import tvm
+from tvm.contrib.msc.core.ir import MSCGraph
+from tvm.contrib.msc.core.codegen import CodeGen
+from tvm.contrib.msc.core import utils as msc_utils
+from tvm.contrib.msc.framework.tensorflow import tf_v1
+from tvm.contrib.msc.framework.tensorflow import _ffi_api
+
+
+def to_tensorflow(
+    graph: MSCGraph,
+    weights: Optional[Dict[str, tvm.nd.array]] = None,
+    codegen_config: Optional[Dict[str, str]] = None,
+    print_config: Optional[Dict[str, str]] = None,
+    build_folder: msc_utils.MSCDirectory = None,
+) -> tf_v1.Graph:
+    """Change MSCGraph to tensorflow graph.
+
+    Parameters
+    ----------
+    graph: tvm.contrib.msc.core.ir.MSCGraph
+        The translated graph.
+    weights: dict of <string:tvm.ndarray>
+        The parameters of the IRModule.
+    codegen_config: dict
+        The config for codegen.
+    print_config: dict
+        The config for print.
+    build_folder: MSCDirectory
+        The folder for saving scripts and datas.
+
+    Returns
+    -------
+    tf_graph: tf_v1.Graph
+        The tensorflow Graph.
+    """
+
+    def _bind_weights(
+        outs: Union[tf_v1.Tensor, List[tf_v1.Tensor]], folder: msc_utils.MSCDirectory
+    ) -> Union[tf_v1.Tensor, List[tf_v1.Tensor]]:
+        if weights:
+            with open(folder.relpath(graph.name + "_params.bin"), "wb") as f_params:
+                f_params.write(tvm.runtime.save_param_dict(weights))
+        return outs
+
+    inputs = [tf_v1.placeholder(i.dtype_name, i.get_shape(), i.alias) for i in graph.get_inputs()]
+    codegen = CodeGen(
+        graph, _ffi_api.GetTensorflowSources, codegen_config, print_config, build_folder
+    )
+    return codegen.load(inputs + [weights], post_load=_bind_weights)

--- a/python/tvm/contrib/msc/framework/tensorflow/frontend/__init__.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/frontend/__init__.py
@@ -14,11 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""tvm.contrib.msc.core.utils"""
-
-from .expr import *
-from .info import *
-from .file import *
-from .namespace import *
-from .register import *
-from .dataset import *
+"""tvm.contrib.msc.framework.tensorflow.frontend"""

--- a/python/tvm/contrib/msc/framework/tensorflow/frontend/translate.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/frontend/translate.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.framework.torch.frontend.translate"""
+
+from typing import Dict, Optional, Tuple, List
+
+import tvm
+
+from tvm.contrib.msc.core.ir.graph import MSCGraph
+from tvm.contrib.msc.core import transform as msc_transform
+from tvm.contrib.msc.core.ir.translate import from_relax
+from tvm.contrib.msc.core.codegen import relay_to_relax
+from tvm.contrib.msc.framework.tensorflow import tf_v1
+
+
+def from_tensorflow(
+    graph_def: tf_v1.GraphDef,
+    shape_dict: Dict[str, List[int]],
+    outputs: List[str],
+    via_relax: bool = False,
+    trans_config: Optional[Dict[str, str]] = None,
+    build_config: Optional[Dict[str, str]] = None,
+    opt_config: Optional[Dict[str, str]] = None,
+) -> Tuple[MSCGraph, Dict[str, tvm.nd.array]]:
+    """Change tensorflow GraphDef to MSCGraph.
+
+    Parameters
+    ----------
+    graph_def: tf_v1.GraphDef
+        The graph define of tensorflow.
+    shape_dict: dict<str,list<int>>
+        The shape dict of inputs.
+    outputs: list<str>
+        The output names.
+    via_relax: bool
+        Whether translate torch to relax.
+    trans_config: dict
+        The config for transfrorm IRModule.
+    build_config: dict
+        The config for build MSCGraph.
+    opt_config: dict
+        The config for optimize the relay before translate.
+
+    Returns
+    -------
+    graph: tvm.contrib.msc.core.ir.MSCGraph
+        The translated graph.
+    weights: dict of <string:tvm.ndarray>
+        The weights from the IRModule.
+    """
+
+    assert not via_relax, "Relax frontend for tensorflow is not supported"
+    relay_mod, params = tvm.relay.frontend.from_tensorflow(
+        graph_def, shape=shape_dict, outputs=outputs
+    )
+    passes = [msc_transform.BindExprName()]
+    relay_mod = tvm.transform.Sequential(passes)(relay_mod)
+    relax_mod = relay_to_relax(relay_mod, params, trans_config, build_config, opt_config)
+    build_config = build_config or {}
+    build_config["use_var_name"] = True
+    graph, weights = from_relax(relax_mod, trans_config=trans_config, build_config=build_config)
+    return graph, weights

--- a/src/contrib/msc/core/codegen/base_codegen.h
+++ b/src/contrib/msc/core/codegen/base_codegen.h
@@ -176,19 +176,7 @@ class BaseCodeGen {
    * 0 for same version, 1 for greater version, -1 for less version
    */
   int CompareVersion(size_t major, size_t minor, size_t patch) {
-    if (config_->version.size() == 0) {
-      return 0;
-    }
-    ICHECK_EQ(config_->version.size(), 3) << "Version should be in format major,minor,patch";
-    std::vector<size_t> given_version{major, minor, patch};
-    for (size_t i = 0; i < 3; i++) {
-      if (given_version[i] > config_->version[i]) {
-        return 1;
-      } else if (given_version[i] < config_->version[i]) {
-        return -1;
-      }
-    }
-    return 0;
+    return CommonUtils::CompareVersion({major, minor, patch}, config_->version);
   }
 
   /*! \brief Get the docs for the op*/

--- a/src/contrib/msc/core/ir/graph.cc
+++ b/src/contrib/msc/core/ir/graph.cc
@@ -585,6 +585,10 @@ const String MSCGraphNode::ToPrototxt() const {
   return printer.GetString();
 }
 
+const bool MSCGraphNode::HasNode(const String& name) const {
+  return nodes.count(name) ? true : false;
+}
+
 const MSCJoint MSCGraphNode::FindNode(const String& name) const {
   ICHECK(nodes.count(name)) << "Can not find node " << name;
   return Downcast<MSCJoint>(nodes[name]);
@@ -1003,7 +1007,7 @@ TVM_REGISTER_GLOBAL("msc.core.WeightGraph")
 // Graph APIS
 TVM_REGISTER_GLOBAL("msc.core.MSCGraphHasNode")
     .set_body_typed([](const MSCGraph& graph, const String& name) -> Bool {
-      return Bool(graph->nodes.count(name));
+      return Bool(graph->HasNode(name));
     });
 
 TVM_REGISTER_GLOBAL("msc.core.MSCGraphFindNode")

--- a/src/contrib/msc/core/ir/graph.h
+++ b/src/contrib/msc/core/ir/graph.h
@@ -614,6 +614,8 @@ class MSCGraphNode : public BaseGraphNode {
   void FromJson(const std::string& json_str);
   /*! \brief Export graph to prototxt. */
   const String ToPrototxt() const;
+  /*! \brief Check if node in the graph. */
+  const bool HasNode(const String& name) const;
   /*! \brief Find node in graph. */
   const MSCJoint FindNode(const String& name) const;
   /*! \brief Get input from the graph. */

--- a/src/contrib/msc/core/ir/graph_builder.h
+++ b/src/contrib/msc/core/ir/graph_builder.h
@@ -59,6 +59,7 @@ struct MSCRBuildConfig {
   bool prune_graph{false};
   bool use_var_name{false};
   int float_precision = 6;
+  std::string byoc_entry;
   std::string sort_by;
   std::string target = "";
   std::string graph_name = "";
@@ -86,6 +87,8 @@ struct MSCRBuildConfig {
         reader->Read(&use_var_name);
       } else if (key == "float_precision") {
         reader->Read(&float_precision);
+      } else if (key == "byoc_entry") {
+        reader->Read(&byoc_entry);
       } else if (key == "sort_by") {
         reader->Read(&sort_by);
       } else if (key == "target") {
@@ -157,6 +160,20 @@ class RelaxFuncAttrGetter : public RelaxExprVisitor {
   Map<String, String> attrs_;
 };
 
+class RelaxFuncValueGetter : public RelaxExprVisitor {
+ public:
+  /*! \brief Get the attributes from prim value as Map<String, String>*/
+  Array<String> GetValues(const Expr& expr) {
+    RelaxExprVisitor::VisitExpr(expr);
+    return values_;
+  }
+
+  void VisitExpr_(const relax::CallNode* op) final;
+
+ private:
+  Array<String> values_;
+};
+
 class RelaxFuncParamsFinder : public RelaxExprVisitor {
  public:
   /*!
@@ -201,13 +218,16 @@ class RelaxGraphBuilder : public RelaxExprVisitor {
       reader.Read(&config_);
     }
     name_ = config_.graph_name.size() > 0 ? String(config_.graph_name) : name;
-    if (name != "main") {
-      func_params_ = RelaxFuncParamsFinder(ref_module).FindParams(ref_module->Lookup("main"));
+    if (config_.byoc_entry.size() > 0) {
+      func_params_ = RelaxFuncParamsFinder(ref_module).FindParams(ref_module->Lookup(name));
     }
   }
 
   /*! \brief Build MSCGraph from relax function*/
   const MSCGraph Build(const relax::Function& func);
+
+  /*! \brief Get the config of builder */
+  const MSCRBuildConfig config() { return config_; }
 
   /*! \brief Create and add MSCJoint from expr*/
   const MSCJoint AddNode(const Expr& expr, const Optional<Expr>& binding_var = NullOpt,
@@ -318,6 +338,9 @@ class RelayGraphBuilder : public RelayExprVisitor {
 
   /*! \brief Build MSCGraph from relax function*/
   MSCGraph Build(const relay::Function& func);
+
+  /*! \brief Get the config of builder */
+  const MSCRBuildConfig config() { return config_; }
 
   /*! \brief Create and add MSCJoint from expr*/
   MSCJoint AddNode(const Expr& expr, const String& name = "");

--- a/src/contrib/msc/core/transform/bind_shape.cc
+++ b/src/contrib/msc/core/transform/bind_shape.cc
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/core/transform/fuse_shape.cc
+ * \brief Pass for fuse ShapeExpr.
+ */
+
+#include <tvm/relax/expr.h>
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/transform.h>
+
+#include "../../../../relax/transform/utils.h"
+
+namespace tvm {
+namespace relax {
+
+/*!
+ * \brief Bind ShapeExpr to Reshape
+ */
+class ShapeBinder : public ExprMutator {
+ public:
+  explicit ShapeBinder(IRModule ctx_module, const String& entry_name) : ExprMutator(ctx_module) {
+    mod_ = ctx_module;
+    entry_name_ = entry_name;
+  }
+
+  IRModule Bind() {
+    // update global functions
+    GlobalVar main_var;
+    for (const auto& [gv, func] : mod_->functions) {
+      if (gv->name_hint == entry_name_) {
+        main_var = gv;
+        continue;
+      }
+      if (func->IsInstance<FunctionNode>()) {
+        Array<Var> new_params;
+        for (const auto& p : Downcast<Function>(func)->params) {
+          auto struct_info = GetStructInfo(p);
+          if (struct_info->IsInstance<ShapeStructInfoNode>()) {
+            continue;
+          }
+          new_params.push_back(p);
+        }
+        if (new_params.size() == Downcast<Function>(func)->params.size()) {
+          continue;
+        }
+        const auto& new_func = Downcast<Function>(VisitExpr(func));
+        auto updated_func = Function(new_params, new_func->body, new_func->ret_struct_info,
+                                     new_func->is_pure, new_func->attrs, new_func->span);
+        builder_->UpdateFunction(gv, updated_func);
+      }
+    }
+    // update main
+    ICHECK(main_var.defined()) << "Can not find entry func " << entry_name_;
+    const auto& new_func = Downcast<Function>(VisitExpr(mod_->Lookup(entry_name_)));
+    builder_->UpdateFunction(main_var, new_func);
+    return builder_->GetContextIRModule();
+  }
+
+  void VisitBinding_(const VarBindingNode* binding, const CallNode* call_node) final {
+    Array<Expr> new_args;
+    for (const auto& a : call_node->args) {
+      auto struct_info = GetStructInfo(a);
+      if (a->IsInstance<VarNode>() && struct_info->IsInstance<ShapeStructInfoNode>()) {
+        continue;
+      }
+      if (call_node->op->IsInstance<GlobalVarNode>() && a->IsInstance<ShapeExprNode>()) {
+        continue;
+      }
+      new_args.push_back(a);
+    }
+    if (new_args.size() == call_node->args.size()) {
+      ExprMutator::VisitBinding_(binding, call_node);
+    } else if (const auto* op_node = call_node->op.as<OpNode>()) {
+      ICHECK(op_node->name == "relax.reshape" || op_node->name == "relax.image.resize2d")
+          << "Expect ShapeExpr consumer as reshape or image.resize2d, get "
+          << GetRef<Call>(call_node);
+      const auto& opt_shape = Downcast<ShapeStructInfo>(GetStructInfo(call_node->args[1]))->values;
+      ICHECK(opt_shape.defined()) << "Expected shape defined, get " << call_node->args[1];
+      new_args.push_back(ShapeExpr(opt_shape.value()));
+      const auto& new_call =
+          Call(call_node->op, new_args, call_node->attrs, call_node->sinfo_args, call_node->span);
+      ReEmitBinding(binding, builder_->Normalize(new_call));
+    } else if (const auto* gv_node = call_node->op.as<GlobalVarNode>()) {
+      const auto& func_info = Downcast<FuncStructInfo>(gv_node->struct_info_);
+      Array<StructInfo> params_info;
+      for (const auto& a : new_args) {
+        ICHECK(a->struct_info_.defined())
+            << "Global func argument without defined struct info " << a;
+        params_info.push_back(Downcast<StructInfo>(a->struct_info_.value()));
+      }
+      call_node->op->struct_info_ =
+          FuncStructInfo(params_info, func_info->ret, func_info->purity, func_info->span);
+      const auto& new_call =
+          Call(call_node->op, new_args, call_node->attrs, call_node->sinfo_args, call_node->span);
+      ReEmitBinding(binding, builder_->Normalize(new_call));
+    } else {
+      LOG_FATAL << "Unexpected shape consumer " << GetRef<Call>(call_node);
+    }
+  }
+
+ private:
+  IRModule mod_;
+  String entry_name_;
+};
+
+IRModule BindShape(IRModule mod, const String& entry_name) {
+  return ShapeBinder(mod, entry_name).Bind();
+}
+
+namespace transform {
+
+Pass BindShape(const String& entry_name) {
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =
+      [=](IRModule m, PassContext pc) { return relax::BindShape(m, entry_name); };
+  return CreateModulePass(pass_func, 0, "BindShape", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.BindShape").set_body_typed(BindShape);
+
+}  // namespace transform
+}  // namespace relax
+}  // namespace tvm

--- a/src/contrib/msc/core/transform/layout_utils.cc
+++ b/src/contrib/msc/core/transform/layout_utils.cc
@@ -38,7 +38,7 @@ bool LayoutUtils::LayoutInfered(const Expr& expr) {
 bool LayoutUtils::SetLayout(const Expr& expr, const NLayout& layout) {
   const String& saved_layout = SpanUtils::GetAttr(expr->span, "layout");
   const auto& sinfo = GetStructInfo(expr);
-  if (sinfo.as<TensorStructInfoNode>() || sinfo.as<ShapeStructInfoNode>()) {
+  if (sinfo->IsInstance<TensorStructInfoNode>() || sinfo->IsInstance<ShapeStructInfoNode>()) {
     ICHECK(layout.IsLeaf()) << "Expr has tensor struct, but find nested layout " << expr;
     const auto& l_layout = layout.LeafValue()->layout;
     if (!l_layout.defined()) {
@@ -48,7 +48,7 @@ bool LayoutUtils::SetLayout(const Expr& expr, const NLayout& layout) {
       return false;
     }
     expr->span = SpanUtils::SetAttr(expr->span, "layout", l_layout.name());
-  } else if (sinfo.as<TupleStructInfoNode>()) {
+  } else if (sinfo->IsInstance<TupleStructInfoNode>()) {
     ICHECK(!layout.IsLeaf()) << "Expr has tuple struct, but find non-nested layout " << expr;
     String layout_str;
     Array<NLayout> nested_layouts = layout.NestedArray();
@@ -74,10 +74,10 @@ const NLayout LayoutUtils::GetNLayout(const Expr& expr) {
     return LayoutDecision("");
   }
   auto sinfo = GetStructInfo(expr);
-  if (sinfo.as<TensorStructInfoNode>()) {
+  if (sinfo->IsInstance<TensorStructInfoNode>()) {
     return LayoutDecision(SpanUtils::GetAttr(expr->span, "layout"));
   }
-  if (sinfo.as<TupleStructInfoNode>()) {
+  if (sinfo->IsInstance<TupleStructInfoNode>()) {
     String layout_str = SpanUtils::GetAttr(expr->span, "layout");
     std::vector<NLayout> output_layout;
     for (const auto& l : StringUtils::Split(layout_str, ",")) {

--- a/src/contrib/msc/core/utils.cc
+++ b/src/contrib/msc/core/utils.cc
@@ -47,6 +47,36 @@ std::vector<size_t> CommonUtils::GetIndices(const std::vector<int>& indices, siz
   return v_indices;
 }
 
+int CommonUtils::CompareVersion(const std::vector<size_t>& given_version,
+                                const std::vector<size_t>& target_version) {
+  if (given_version.size() == 0 || target_version.size() == 0) {
+    return 0;
+  }
+  ICHECK_EQ(given_version.size(), 3) << "Version should be in format major,minor,patch";
+  ICHECK_EQ(target_version.size(), 3) << "Target version should be in format major,minor,patch";
+  for (size_t i = 0; i < 3; i++) {
+    if (given_version[i] > target_version[i]) {
+      return -1;
+    } else if (given_version[i] < target_version[i]) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int CommonUtils::CompareVersion(const Array<Integer>& given_version,
+                                const Array<Integer>& target_version) {
+  std::vector<size_t> int_given_version;
+  std::vector<size_t> int_target_version;
+  for (const auto& v : given_version) {
+    int_given_version.push_back(static_cast<size_t>(v->value));
+  }
+  for (const auto& v : target_version) {
+    int_target_version.push_back(static_cast<size_t>(v->value));
+  }
+  return CompareVersion(int_given_version, int_target_version);
+}
+
 bool StringUtils::Contains(const String& src_string, const String& sub_string) {
   if (src_string.size() == 0) {
     return false;
@@ -272,11 +302,15 @@ const Array<String> ExprUtils::GetInputTypes(const String& optype, size_t inputs
   Array<String> input_types;
   if (as_relax && (optype == "broadcast_to" || optype == "reshape")) {
     input_types.push_back("input");
-    input_types.push_back("shape");
+    if (inputs_num > 1) {
+      input_types.push_back("shape");
+    }
   } else if (optype == "clip" && as_relax) {
     input_types.push_back("input");
-    input_types.push_back("min");
-    input_types.push_back("max");
+    if (inputs_num > 1) {
+      input_types.push_back("min");
+      input_types.push_back("max");
+    }
   } else if (optype == "full" && as_relax) {
     input_types.push_back("shape");
     input_types.push_back("input");
@@ -288,34 +322,48 @@ const Array<String> ExprUtils::GetInputTypes(const String& optype, size_t inputs
     input_types.push_back("k");
   } else if (optype == "image.resize2d" && as_relax) {
     input_types.push_back("input");
-    input_types.push_back("size");
+    if (inputs_num > 1) {
+      input_types.push_back("size");
+    }
   } else if (optype == "nn.conv1d" || optype == "nn.conv2d" || optype == "nn.conv3d") {
     input_types.push_back("input");
-    input_types.push_back("weight");
+    if (inputs_num > 1) {
+      input_types.push_back("weight");
+    }
   } else if (optype == "nn.batch_norm") {
     input_types.push_back("input");
-    input_types.push_back("gamma");
-    input_types.push_back("beta");
-    input_types.push_back("mean");
-    input_types.push_back("var");
+    if (inputs_num > 1) {
+      input_types.push_back("gamma");
+      input_types.push_back("beta");
+      input_types.push_back("mean");
+      input_types.push_back("var");
+    }
   } else if (optype == "nn.layer_norm" || optype == "nn.group_norm") {
     input_types.push_back("input");
-    input_types.push_back("gamma");
-    input_types.push_back("beta");
+    if (inputs_num > 1) {
+      input_types.push_back("gamma");
+      input_types.push_back("beta");
+    }
   } else if (optype == "msc.linear") {
     input_types.push_back("input");
-    input_types.push_back("weight");
+    if (inputs_num > 1) {
+      input_types.push_back("weight");
+    }
   } else if (optype == "msc.conv1d_bias" || optype == "msc.conv2d_bias") {
     input_types.push_back("input");
-    input_types.push_back("weight");
-    input_types.push_back("bias");
+    if (inputs_num > 1) {
+      input_types.push_back("weight");
+      input_types.push_back("bias");
+    }
     if (as_relax && inputs_num > 3) {
       input_types.push_back("expand_bias");
     }
   } else if (optype == "msc.linear_bias") {
     input_types.push_back("input");
-    input_types.push_back("weight");
-    input_types.push_back("bias");
+    if (inputs_num > 1) {
+      input_types.push_back("weight");
+      input_types.push_back("bias");
+    }
   } else if (optype == "msc.embedding" && inputs_num == 2) {
     input_types.push_back("input");
     input_types.push_back("weight");

--- a/src/contrib/msc/core/utils.h
+++ b/src/contrib/msc/core/utils.h
@@ -52,6 +52,15 @@ class CommonUtils {
    * \return The valid indices.
    */
   TVM_DLL static std::vector<size_t> GetIndices(const std::vector<int>& indices, size_t max_size);
+
+  /*!
+   * \brief Compare version with version in config
+   * 0 for same version, 1 for greater version, -1 for less version
+   */
+  TVM_DLL static int CompareVersion(const std::vector<size_t>& given_version,
+                                    const std::vector<size_t>& target_version);
+  TVM_DLL static int CompareVersion(const Array<Integer>& given_version,
+                                    const Array<Integer>& target_version);
 };
 
 /*!

--- a/src/contrib/msc/framework/tensorflow/codegen.cc
+++ b/src/contrib/msc/framework/tensorflow/codegen.cc
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/codegen.cc
+ */
+#include "codegen.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+void TensorflowCodeGen::CodeGenHeader() {
+  PyCodeGen<TensorflowCodeGenConfig>::CodeGenHeader();
+  stack_.line("from tensorflow.python import ops")
+      .line("from tvm.contrib.msc.framework.tensorflow import tf_v1");
+}
+
+void TensorflowCodeGen::CodeGenHelper() {
+  PyCodeGen<TensorflowCodeGenConfig>::CodeGenHelper();
+  stack_.func_def("get_variable", TensorType())
+      .func_arg("name", "str")
+      .func_arg("shape", "List[int]")
+      .func_arg("dtype", "str")
+      .func_arg("weights", "Dict[str, tvm.nd.array]")
+      .func_start()
+      .cond_if("name in weights")
+      .func_call("tf_v1.get_variable", "var")
+      .call_arg("name")
+      .call_arg("weights[name].asnumpy()", "initializer")
+      .cond_else()
+      .func_call("tf_v1.get_variable", "var")
+      .call_arg("name")
+      .call_arg("shape")
+      .call_arg("dtype")
+      .cond_end()
+      .func_end("var");
+}
+
+void TensorflowCodeGen::CodeGenGraph() {
+  stack_.func_def(graph()->name, "List[tf_v1.Tensor]");
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& pair = graph()->FindProducerAndIdx(i);
+    stack_.func_arg(IdxOutputBase(pair.first, pair.second), "tf_v1.Tensor");
+  }
+  stack_.func_arg("weights", "Dict[str, tvm.nd.array]").func_start();
+  // define weights
+  stack_.comment("Define the weights");
+  for (const auto& n : graph()->node_names) {
+    const auto& node = graph()->FindNode(n);
+    for (const auto& pair : node->weights) {
+      stack_.func_call("get_variable", IdxWeightBase(node, pair.first))
+          .call_arg(DocUtils::ToStrDoc(pair.second->name))
+          .call_arg(DocUtils::ToListDoc(pair.second->shape, true))
+          .call_arg(DocUtils::ToStrDoc(pair.second->DTypeName()))
+          .call_arg("weights");
+    }
+  }
+  // define ops
+  stack_.comment("Define the ops");
+  for (const auto& n : graph()->node_names) {
+    const auto& node = graph()->FindNode(n);
+    if (node->optype == "input") {
+      continue;
+    }
+    CodeGenNode(node);
+  }
+  Array<String> idx_outputs;
+  for (const auto& o : graph()->GetOutputs()) {
+    const auto& pair = graph()->FindProducerAndIdx(o);
+    idx_outputs.push_back(IdxOutputBase(pair.first, pair.second));
+  }
+  if (idx_outputs.size() == 1) {
+    stack_.assign("outputs", idx_outputs[0]);
+  } else {
+    stack_.assign("outputs", DocUtils::ToListDoc(idx_outputs));
+  }
+  stack_.func_end("outputs");
+}
+
+void TensorflowCodeGen::CodeGenInference() {
+  stack_.comment("Load weights")
+      .scope_start("open(\"" + graph()->name + "_params.bin\", \"rb\")", "f")
+      .func_call("tvm.runtime.load_param_dict", "params")
+      .func_call("f.read")
+      .pop_nest()
+      .scope_end()
+      .comment("Build Graph")
+      .scope_start("tf_v1.Graph().as_default()");
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& producer = graph()->FindProducer(i);
+    stack_.func_call("tf_v1.placeholder", IdxNodeBase(producer))
+        .call_arg(DocUtils::ToStrDoc(i->DTypeName()))
+        .call_arg(DocUtils::ToListDoc(i->shape))
+        .call_arg(DocUtils::ToStrDoc(i->alias));
+  }
+  stack_.func_call(graph()->name, "outs");
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& producer = graph()->FindProducer(i);
+    stack_.call_arg(IdxNodeBase(producer));
+  }
+  stack_.call_arg("params").assign("feed_dict", "{}");
+  for (const auto& i : graph()->GetInputs()) {
+    const auto& producer = graph()->FindProducer(i);
+    stack_.assign("feed_dict[" + IdxNodeBase(producer) + "]", "inputs[\"" + i->alias + "\"]");
+  }
+  stack_.scope_start("tf_v1.Session()", "sess")
+      .func_call("sess.run")
+      .func_call("ops.variables.global_variables_initializer")
+      .pop_nest()
+      .func_call("sess.run", "outputs")
+      .call_arg("outs")
+      .call_arg("feed_dict", "feed_dict")
+      .scope_end()
+      .scope_end();
+}
+
+const Array<Doc> TensorflowCodeGen::GetOpCodes(const MSCJoint& node) {
+  const auto& ops_map = GetTFV1OpCodes();
+  auto it = ops_map->find(node->optype);
+  ICHECK(it != ops_map->end()) << "Unsupported tensorflow op(" << node->optype << "): " << node;
+  it->second->Config(node, config());
+  try {
+    return it->second->GetDocs();
+  } catch (runtime::InternalError& err) {
+    LOG(WARNING) << "Failed to get docs for " << node << " : " << err.message();
+    throw err;
+  }
+}
+
+TVM_REGISTER_GLOBAL("msc.framework.tensorflow.GetTensorflowSources")
+    .set_body_typed([](const MSCGraph& graph, const String& codegen_config,
+                       const String print_config) -> Map<String, String> {
+      TensorflowCodeGen codegen = TensorflowCodeGen(graph, codegen_config);
+      return codegen.GetSources(print_config);
+    });
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/msc/framework/tensorflow/codegen.h
+++ b/src/contrib/msc/framework/tensorflow/codegen.h
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/codegen.h
+ * \brief Tensorflow codegen for MSCGraph.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CODEGEN_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CODEGEN_H_
+
+#include <string>
+
+#include "../../core/codegen/base_codegen.h"
+#include "../../core/codegen/py_codegen.h"
+#include "config.h"
+#include "tf_v1_opcode.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+class TensorflowCodeGen : public PyCodeGen<TensorflowCodeGenConfig> {
+ public:
+  /*!
+   * \brief The constructor of TensorflowCodeGen
+   * \param graph the graph to be generated.
+   * \param config the options for codegen.
+   */
+  explicit TensorflowCodeGen(const MSCGraph& graph, const std::string& config = "")
+      : PyCodeGen<TensorflowCodeGenConfig>(graph, config) {}
+
+ protected:
+  /*! \brief Stack the docs for the header*/
+  void CodeGenHeader() final;
+
+  /*! \brief Stack the docs for the helpers*/
+  void CodeGenHelper() final;
+
+  /*! \brief Stack the docs for the graph*/
+  void CodeGenGraph() final;
+
+  /*! \brief Stack the docs for the graph inference*/
+  void CodeGenInference() final;
+
+  /*! \brief Get the docs for the op*/
+  const Array<Doc> GetOpCodes(const MSCJoint& node) final;
+
+  /*! \brief Get tensor type of the framework*/
+  const String TensorType() const final { return "tf_v1.Tensor"; }
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CODEGEN_H_

--- a/src/contrib/msc/framework/tensorflow/config.h
+++ b/src/contrib/msc/framework/tensorflow/config.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/config.h
+ * \brief Tensorflow config for codegen.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_
+
+#include <string>
+
+#include "../../core/codegen/base_codegen.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+/*!
+ * \brief CodeGen config for tensorflow codegen
+ */
+struct TensorflowCodeGenConfig {
+  bool is_training{false};
+  CODEGEN_CONFIG_MEMBERS
+  void Load(dmlc::JSONReader* reader) {
+    std::string key;
+    reader->BeginObject();
+    while (reader->NextObjectItem(&key)) {
+      if (key == "is_training") {
+        reader->Read(&is_training);
+      } else {
+        CODEGEN_CONFIG_PARSE
+      }
+    }
+  }
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_

--- a/src/contrib/msc/framework/tensorflow/tf_v1_opcode.cc
+++ b/src/contrib/msc/framework/tensorflow/tf_v1_opcode.cc
@@ -1,0 +1,579 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/tf_v1_opcode.cc
+ */
+#include "tf_v1_opcode.h"
+
+#include <memory>
+#include <string>
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+const Array<Doc> TFV1OpCode::GetDocs() {
+  stack_.Config(this);
+  CodeGenBuild();
+  return stack_.GetDocs();
+}
+
+const std::pair<String, Array<String>> TFV1OpCode::GetPadding(const String& strides_key,
+                                                              const String& kernel_key,
+                                                              const String& padding_key) {
+  String pad_mod = "";
+  Array<String> padding;
+  std::vector<int64_t> kernel_size;
+  if (node()->optype == "nn.conv2d" || node()->optype == "msc.conv2d_bias") {
+    const auto& weight = node()->WeightAt("weight");
+    kernel_size.push_back(weight->DimAt("H")->value);
+    kernel_size.push_back(weight->DimAt("W")->value);
+  } else if (node()->optype == "nn.avg_pool2d" || node()->optype == "nn.max_pool2d") {
+    ICHECK(node()->GetAttr(kernel_key, &kernel_size));
+  } else {
+    LOG_FATAL << "Unexpected padding node" << node();
+  }
+  const auto& strides = node()->GetTypeArrayAttr<int64_t>(strides_key);
+  int64_t in_height = node()->InputAt(0)->DimAt("H")->value;
+  int64_t in_width = node()->InputAt(0)->DimAt("W")->value;
+  int64_t out_height = node()->OutputAt(0)->DimAt("H")->value;
+  int64_t out_width = node()->OutputAt(0)->DimAt("W")->value;
+  int64_t same_height = in_height / strides[0] + (in_height % strides[0] == 0 ? 0 : 1);
+  int64_t same_width = in_width / strides[1] + (in_width % strides[1] == 0 ? 0 : 1);
+  int64_t valid_height = (in_height - kernel_size[0] + 1) / strides[0];
+  valid_height += (valid_height % strides[0] == 0 ? 0 : 1);
+  int64_t valid_width = (in_width - kernel_size[1] + 1) / strides[1];
+  valid_width += (valid_width % strides[1] == 0 ? 0 : 1);
+  if (same_height == out_height && same_width == out_width) {
+    pad_mod = "SAME";
+  } else if (valid_height == out_height && valid_width == out_width) {
+    pad_mod = "VALID";
+  } else {
+    const auto& src_padding = node()->GetTypeArrayAttr<int64_t>(padding_key);
+    if (node()->optype == "nn.conv2d" || node()->optype == "msc.conv2d_bias" ||
+        node()->optype == "nn.avg_pool2d" || node()->optype == "nn.max_pool2d") {
+      const auto& out_layout = node()->GetTypeAttr<std::string>("out_layout");
+      if (out_layout == "NHWC") {
+        padding.push_back("[0, 0]");
+      } else if (out_layout == "NCHW") {
+        padding.push_back("[0, 0]");
+        padding.push_back("[0, 0]");
+      } else {
+        LOG_FATAL << "Unexpected layout for padding node" << node();
+      }
+      if (src_padding.size() == 4) {
+        padding.push_back("[" + std::to_string(src_padding[0]) + ", " +
+                          std::to_string(src_padding[2]) + "]");
+        padding.push_back("[" + std::to_string(src_padding[1]) + ", " +
+                          std::to_string(src_padding[3]) + "]");
+      } else {
+        LOG_FATAL << "nn.conv2d/pool2d with unexpected padding " << node();
+      }
+      if (out_layout == "NHWC") {
+        padding.push_back("[0, 0]");
+      }
+    } else {
+      LOG_FATAL << "Unexpected padding node" << node();
+    }
+  }
+  return std::make_pair(pad_mod, padding);
+}
+
+#define TFV1_OP_CODEGEN_METHODS(TypeName) \
+ public:                                  \
+  TypeName(const String& func_name) : TFV1OpCode(func_name) {}
+
+class TFV1ArgMaxMinCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1ArgMaxMinCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_call()
+        .op_input_arg()
+        .op_arg<int>("axis")
+        .op_dtype_arg(node()->OutputAt(0)->dtype, "output_type")
+        .op_name_arg();
+  }
+};
+
+class TFV1AstypeCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1AstypeCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    if (node()->InputAt(0)->dtype == node()->OutputAt(0)->dtype) {
+      stack_.op_call("tf_v1.identity").op_input_arg().op_name_arg();
+    } else {
+      stack_.op_call().op_input_arg().op_dtype_arg(node()->OutputAt(0)->dtype).op_name_arg();
+    }
+  }
+};
+
+class TFV1AxesCodeGen : public TFV1OpCode {
+ public:
+  TFV1AxesCodeGen(const String& func_name, const String& attr_name) : TFV1OpCode(func_name) {
+    attr_name_ = attr_name;
+  }
+
+ protected:
+  void CodeGenBuild() final {
+    const String& key = node()->HasAttr("axes") ? "axes" : "axis";
+    stack_.op_call().op_input_arg().op_list_arg<int>(key, attr_name_).op_name_arg();
+  }
+
+ private:
+  String attr_name_;
+};
+
+class TFV1AxisCodeGen : public TFV1OpCode {
+ public:
+  TFV1AxisCodeGen(const String& func_name, const String& attr_name) : TFV1OpCode(func_name) {
+    attr_name_ = attr_name;
+  }
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_call().op_input_arg().op_arg<int>("axis", attr_name_).op_name_arg();
+  }
+
+ private:
+  String attr_name_;
+};
+
+class TFV1BroadcastToCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1BroadcastToCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_call().op_input_arg().op_list_arg<int>("shape").op_name_arg();
+  }
+};
+
+class TFV1ConcatCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1ConcatCodeGen)
+
+ protected:
+  void CodeGenBuild() final { stack_.op_call().op_inputs_arg().op_arg<int>("axis").op_name_arg(); }
+};
+
+class TFV1ConstantCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1ConstantCodeGen)
+
+ protected:
+  void CodeGenBuild() final { stack_.assign(IdxNode(), IdxWeight("const")); }
+};
+
+class TFV1ConvCodeGen : public TFV1OpCode {
+ public:
+  TFV1ConvCodeGen(const String& func_name, bool use_bias) : TFV1OpCode(func_name) {
+    use_bias_ = use_bias;
+  }
+
+ protected:
+  void CodeGenBuild() final {
+    const auto& pair = GetPadding("strides");
+    const auto& out_layout = node()->GetTypeAttr<std::string>("out_layout");
+    int64_t groups = node()->GetTypeAttr<int64_t>("groups");
+    std::vector<int> strides, dilation;
+    const auto& attr_strides = node()->GetTypeArrayAttr<int>("strides");
+    const auto& attr_dilation = node()->GetTypeArrayAttr<int>("dilation");
+    if (out_layout == "NHWC") {
+      strides = {1, attr_strides[0], attr_strides[1], 1};
+      dilation = {1, attr_dilation[0], attr_dilation[1], 1};
+    } else if (out_layout == "NCHW") {
+      strides = {1, 1, attr_strides[0], attr_strides[1]};
+      dilation = {1, 1, attr_dilation[0], attr_dilation[1]};
+    } else {
+      LOG_FATAL << "Unexpected layout for padding node" << node();
+    }
+    if (groups == 1) {
+      stack_.op_call();
+    } else if (groups == node()->InputAt(0)->DimAt("C")->value) {
+      stack_.op_call("ops.nn_ops.depthwise_conv2d_native");
+    } else {
+      LOG_FATAL << "Unexpected conv with groups " << node();
+    }
+    stack_.op_input_arg()
+        .op_weight_arg("weight")
+        .call_arg(DocUtils::ToListDoc(strides), "strides")
+        .call_arg(DocUtils::ToListDoc(dilation), "dilations")
+        .op_str_arg("data_layout", "data_format");
+    if (pair.first.size() > 0) {
+      stack_.call_arg(DocUtils::ToStrDoc(pair.first), "padding");
+    } else if (pair.second.size() > 0) {
+      stack_.call_arg(DocUtils::ToListDoc(pair.second), "padding");
+    } else {
+      LOG_FATAL << "Can not parse padding for " << node();
+    }
+    stack_.op_name_arg();
+    if (use_bias_) {
+      stack_.op_call("ops.nn_ops.bias_add")
+          .op_output_arg()
+          .op_weight_arg("bias")
+          .op_name_arg("name", node()->name + "_bias");
+    }
+  }
+
+ private:
+  bool use_bias_;
+};
+
+class TFV1CreateLikeCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1CreateLikeCodeGen)
+
+ protected:
+  void CodeGenBuild() final { stack_.op_call().op_input_arg().op_str_arg("dtype").op_name_arg(); }
+};
+
+class TFV1EinsumCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1EinsumCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    const auto& producer = node()->ProducerOf(0);
+    stack_.op_call().op_str_arg("subscripts", "");
+    if (node()->inputs.size() == 1 && producer->optype == "tuple") {
+      stack_.call_arg(DocUtils::ToIndexDoc(IdxInput(), std::vector<int>{0}));
+    } else {
+      stack_.op_inputs_arg(false);
+    }
+    stack_.op_name_arg();
+  }
+};
+
+class TFV1FullCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1FullCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_call().op_list_arg<int>("shape", "").op_input_arg(0, "value").op_name_arg();
+  }
+};
+
+class TFV1GetItemCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1GetItemCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.assign(IdxNode(), IdxInput(node()->GetTypeAttr<int>("index")));
+  }
+};
+
+class TFV1PadCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1PadCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    String mode;
+    const auto& attr_mode = node()->GetTypeAttr<std::string>("pad_mode");
+    if (attr_mode == "constant") {
+      mode = "CONSTANT";
+    } else {
+      LOG_FATAL << "Unexpected pad mode " << node();
+    }
+    Array<String> pad_width;
+    const auto& attr_pad_width = node()->GetTypeArrayAttr<int>("pad_width");
+    ICHECK(attr_pad_width.size() % 2 == 0) << "pad_width should be multiple of 2, get " << node();
+    for (size_t i = 0; i < attr_pad_width.size(); i += 2) {
+      const String& cur_pad = "[" + std::to_string(attr_pad_width[i]) + ", " +
+                              std::to_string(attr_pad_width[i + 1]) + "]";
+      pad_width.push_back(cur_pad);
+    }
+    const auto& val_producer = node()->ProducerOf(1);
+    ICHECK(val_producer->optype == "constant" && val_producer->HasAttr("scalar"));
+    stack_.op_call()
+        .op_input_arg()
+        .call_arg(DocUtils::ToListDoc(pad_width), "paddings")
+        .call_arg(DocUtils::ToStrDoc(mode), "mode")
+        .call_arg(val_producer->GetTypeAttr<float>("scalar"), "constant_values")
+        .op_name_arg();
+  }
+};
+
+class TFV1Pool2dCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1Pool2dCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    String pooling_type;
+    if (node()->optype == "nn.avg_pool2d") {
+      pooling_type = "AVG";
+    } else if (node()->optype == "nn.max_pool2d") {
+      pooling_type = "MAX";
+    } else {
+      LOG_FATAL << "Unexpected pool2d node " << node();
+    }
+    const auto& pair = GetPadding("strides", "pool_size");
+    stack_.op_call()
+        .op_input_arg()
+        .op_list_arg<int>("pool_size", "window_shape")
+        .call_arg(DocUtils::ToStrDoc(pooling_type), "pooling_type")
+        .op_list_arg<int>("dilation", "dilation_rate")
+        .op_list_arg<int>("strides");
+    if (pair.first.size() > 0) {
+      stack_.call_arg(DocUtils::ToStrDoc(pair.first), "padding");
+    } else if (pair.second.size() > 0) {
+      stack_.call_arg(DocUtils::ToListDoc(pair.second), "padding");
+    } else {
+      LOG_FATAL << "Can not parse padding for " << node();
+    }
+    stack_.op_name_arg();
+  }
+};
+
+class TFV1PermuteDimsCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1PermuteDimsCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    std::vector<int> axes;
+    if (!node()->GetAttr("axes", &axes)) {
+      for (size_t i = node()->InputAt(0)->Ndim(); i > 0; i--) {
+        axes.push_back(i - 1);
+      }
+    }
+    stack_.op_call().op_input_arg().call_arg(DocUtils::ToListDoc(axes)).op_name_arg();
+  }
+};
+
+class TFV1ReduceAxisCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1ReduceAxisCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_call().op_input_arg().op_list_arg<int>("axis").op_arg<bool>("keepdims").op_name_arg();
+  }
+};
+
+class TFV1ReshapeCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1ReshapeCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_call().op_input_arg().op_list_arg<int>("shape").op_name_arg();
+  }
+};
+
+class TFV1Resize2dCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1Resize2dCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    String func_name;
+    const auto& method = node()->GetTypeAttr<std::string>("method");
+    const auto& coordinate_transformation_mode =
+        node()->GetTypeAttr<std::string>("coordinate_transformation_mode");
+    bool align_corners = coordinate_transformation_mode == "align_corners";
+    if (method == "linear") {
+      func_name = "tf_v1.image.resize_bilinear";
+    } else if (method == "nearest_neighbor") {
+      func_name = "tf_v1.image.resize_nearest_neighbor";
+    } else {
+      LOG_FATAL << "Unexpected resize with method " << node();
+    }
+    stack_.op_call(func_name)
+        .op_input_arg()
+        .op_list_arg<int>("size")
+        .call_arg(align_corners, "align_corners")
+        .op_name_arg();
+  }
+};
+
+class TFV1SimpleCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1SimpleCodeGen)
+
+ protected:
+  void CodeGenBuild() final { stack_.op_call().op_inputs_arg(false).op_name_arg(); }
+};
+
+class TFV1SplitCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1SplitCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_call().op_input_arg();
+    std::vector<int64_t> indices;
+    int axis = node()->GetTypeAttr<int>("axis");
+    for (size_t i = 0; i < node()->outputs.size(); i++) {
+      indices.push_back(node()->OutputAt(i)->DimAt(axis)->value);
+    }
+    stack_.call_arg(DocUtils::ToListDoc(indices), "num_or_size_splits")
+        .op_arg<int>("axis")
+        .op_name_arg();
+  }
+};
+
+class TFV1StridedSliceCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1StridedSliceCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    std::vector<int> axes;
+    if (!node()->GetAttr("axes", &axes)) {
+      for (size_t i = 0; i < node()->InputAt(0)->Ndim(); i++) {
+        axes.push_back(i);
+      }
+    }
+    stack_.op_call()
+        .op_input_arg()
+        .op_list_arg<int>("begin")
+        .op_list_arg<int>("end")
+        .op_list_arg<int>("strides")
+        .op_name_arg();
+  }
+};
+
+class TFV1TakeCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1TakeCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_call().op_inputs_arg(false).op_arg<int>("axis").op_name_arg();
+  }
+};
+
+class TFV1TileCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1TileCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    stack_.op_call().op_input_arg().op_list_arg<int>("repeats", "multiples").op_name_arg();
+  }
+};
+
+class TFV1TupleCodeGen : public TFV1OpCode {
+  TFV1_OP_CODEGEN_METHODS(TFV1TupleCodeGen)
+
+ protected:
+  void CodeGenBuild() final { stack_.op_call().op_inputs_arg(); }
+};
+
+const std::shared_ptr<std::unordered_map<String, std::shared_ptr<TFV1OpCode>>> GetTFV1OpCodes() {
+  static auto map = std::make_shared<std::unordered_map<String, std::shared_ptr<TFV1OpCode>>>();
+  if (!map->empty()) return map;
+  // binary && unary ops
+  map->emplace("abs", std::make_shared<TFV1SimpleCodeGen>("tf_v1.abs"));
+  map->emplace("acos", std::make_shared<TFV1SimpleCodeGen>("tf_v1.acos"));
+  map->emplace("acosh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.acosh"));
+  map->emplace("add", std::make_shared<TFV1SimpleCodeGen>("tf_v1.add"));
+  map->emplace("asin", std::make_shared<TFV1SimpleCodeGen>("tf_v1.asin"));
+  map->emplace("asinh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.asinh"));
+  map->emplace("atanh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.atanh"));
+  map->emplace("atan", std::make_shared<TFV1SimpleCodeGen>("tf_v1.atan"));
+  map->emplace("ceil", std::make_shared<TFV1SimpleCodeGen>("tf_v1.ceil"));
+  map->emplace("cos", std::make_shared<TFV1SimpleCodeGen>("tf_v1.cos"));
+  map->emplace("cosh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.cosh"));
+  map->emplace("divide", std::make_shared<TFV1SimpleCodeGen>("tf_v1.divide"));
+  map->emplace("equal", std::make_shared<TFV1SimpleCodeGen>("tf_v1.equal"));
+  map->emplace("erf", std::make_shared<TFV1SimpleCodeGen>("tf_v1.erf"));
+  map->emplace("exp", std::make_shared<TFV1SimpleCodeGen>("tf_v1.exp"));
+  map->emplace("floor", std::make_shared<TFV1SimpleCodeGen>("tf_v1.floor"));
+  map->emplace("floor_divide", std::make_shared<TFV1SimpleCodeGen>("tf_v1.floor_div"));
+  map->emplace("floor_mod", std::make_shared<TFV1SimpleCodeGen>("tf_v1.floormod"));
+  map->emplace("greater", std::make_shared<TFV1SimpleCodeGen>("tf_v1.greater"));
+  map->emplace("greater_equal", std::make_shared<TFV1SimpleCodeGen>("tf_v1.greater_equal"));
+  map->emplace("isfinite", std::make_shared<TFV1SimpleCodeGen>("tf_v1.is_finite"));
+  map->emplace("isinf", std::make_shared<TFV1SimpleCodeGen>("tf_v1.is_inf"));
+  map->emplace("isnan", std::make_shared<TFV1SimpleCodeGen>("tf_v1.is_nan"));
+  map->emplace("less", std::make_shared<TFV1SimpleCodeGen>("tf_v1.less"));
+  map->emplace("less_equal", std::make_shared<TFV1SimpleCodeGen>("tf_v1.less_equal"));
+  map->emplace("log", std::make_shared<TFV1SimpleCodeGen>("tf_v1.log"));
+  map->emplace("log1p", std::make_shared<TFV1SimpleCodeGen>("tf_v1.log1p"));
+  map->emplace("logical_and", std::make_shared<TFV1SimpleCodeGen>("tf_v1.logical_and"));
+  map->emplace("logical_or", std::make_shared<TFV1SimpleCodeGen>("tf_v1.logical_or"));
+  map->emplace("logical_xor", std::make_shared<TFV1SimpleCodeGen>("tf_v1.logical_xor"));
+  map->emplace("logical_not", std::make_shared<TFV1SimpleCodeGen>("tf_v1.logical_not"));
+  map->emplace("maximum", std::make_shared<TFV1SimpleCodeGen>("tf_v1.maximum"));
+  map->emplace("minimum", std::make_shared<TFV1SimpleCodeGen>("tf_v1.minimum"));
+  map->emplace("multiply", std::make_shared<TFV1SimpleCodeGen>("tf_v1.multiply"));
+  map->emplace("negative", std::make_shared<TFV1SimpleCodeGen>("tf_v1.negative"));
+  map->emplace("not_equal", std::make_shared<TFV1SimpleCodeGen>("tf_v1.not_equal"));
+  map->emplace("power", std::make_shared<TFV1SimpleCodeGen>("tf_v1.pow"));
+  map->emplace("round", std::make_shared<TFV1SimpleCodeGen>("tf_v1.round"));
+  map->emplace("rsqrt", std::make_shared<TFV1SimpleCodeGen>("tf_v1.rsqrt"));
+  map->emplace("sigmoid", std::make_shared<TFV1SimpleCodeGen>("ops.math_ops.sigmoid"));
+  map->emplace("sign", std::make_shared<TFV1SimpleCodeGen>("tf_v1.sign"));
+  map->emplace("sin", std::make_shared<TFV1SimpleCodeGen>("tf_v1.sin"));
+  map->emplace("sinh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.sinh"));
+  map->emplace("sqrt", std::make_shared<TFV1SimpleCodeGen>("tf_v1.sqrt"));
+  map->emplace("subtract", std::make_shared<TFV1SimpleCodeGen>("tf_v1.subtract"));
+  map->emplace("tan", std::make_shared<TFV1SimpleCodeGen>("tf_v1.tan"));
+  map->emplace("tanh", std::make_shared<TFV1SimpleCodeGen>("tf_v1.tanh"));
+  map->emplace("where", std::make_shared<TFV1SimpleCodeGen>("tf_v1.where"));
+
+  // reduce axis ops
+  map->emplace("max", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_max"));
+  map->emplace("min", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_min"));
+  map->emplace("mean", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_mean"));
+  map->emplace("sum", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_sum"));
+  map->emplace("prod", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_prod"));
+  map->emplace("std", std::make_shared<TFV1ReduceAxisCodeGen>("tf_v1.reduce_std"));
+
+  // create ops
+  map->emplace("constant", std::make_shared<TFV1ConstantCodeGen>("get_variable"));
+  map->emplace("full", std::make_shared<TFV1FullCodeGen>("tf_v1.fill"));
+  map->emplace("zeros_like", std::make_shared<TFV1CreateLikeCodeGen>("tf_v1.zeros_like"));
+
+  // axis && axes ops
+  map->emplace("expand_dims", std::make_shared<TFV1AxesCodeGen>("tf_v1.expand_dims", "axis"));
+  map->emplace("nn.log_softmax", std::make_shared<TFV1AxisCodeGen>("tf_v1.nn.log_softmax", "axis"));
+  map->emplace("nn.softmax", std::make_shared<TFV1AxisCodeGen>("tf_v1.nn.softmax", "axis"));
+  map->emplace("squeeze", std::make_shared<TFV1AxesCodeGen>("ops.array_ops.squeeze", "axis"));
+
+  // math ops
+  map->emplace("argmax", std::make_shared<TFV1ArgMaxMinCodeGen>("tf_v1.argmax"));
+  map->emplace("argmin", std::make_shared<TFV1ArgMaxMinCodeGen>("tf_v1.argmin"));
+  map->emplace("astype", std::make_shared<TFV1AstypeCodeGen>("tf_v1.cast"));
+  map->emplace("broadcast_to", std::make_shared<TFV1BroadcastToCodeGen>("tf_v1.broadcast_to"));
+  map->emplace("concat", std::make_shared<TFV1ConcatCodeGen>("ops.array_ops.concat_v2"));
+  map->emplace("concatenate", std::make_shared<TFV1ConcatCodeGen>("ops.array_ops.concat_v2"));
+  map->emplace("einsum", std::make_shared<TFV1EinsumCodeGen>("tf_v1.einsum"));
+  map->emplace("matmul", std::make_shared<TFV1SimpleCodeGen>("tf_v1.matmul"));
+  map->emplace("permute_dims", std::make_shared<TFV1PermuteDimsCodeGen>("tf_v1.transpose"));
+  map->emplace("reshape", std::make_shared<TFV1ReshapeCodeGen>("ops.array_ops.reshape"));
+  map->emplace("split", std::make_shared<TFV1SplitCodeGen>("tf_v1.split"));
+  map->emplace("strided_slice", std::make_shared<TFV1StridedSliceCodeGen>("tf_v1.strided_slice"));
+  map->emplace("take", std::make_shared<TFV1TakeCodeGen>("tf_v1.gather"));
+  map->emplace("tile", std::make_shared<TFV1TileCodeGen>("tf_v1.tile"));
+
+  // nn ops
+  map->emplace("nn.avg_pool2d", std::make_shared<TFV1Pool2dCodeGen>("ops.nn_ops.pool"));
+  map->emplace("nn.conv2d", std::make_shared<TFV1ConvCodeGen>("ops.nn_ops.conv2d", false));
+  map->emplace("nn.max_pool2d", std::make_shared<TFV1Pool2dCodeGen>("ops.nn_ops.pool"));
+  map->emplace("nn.pad", std::make_shared<TFV1PadCodeGen>("tf_v1.pad"));
+  map->emplace("nn.relu", std::make_shared<TFV1SimpleCodeGen>("tf_v1.nn.relu"));
+
+  // image ops
+  map->emplace("image.resize2d",
+               std::make_shared<TFV1Resize2dCodeGen>("tf_v1.image.resize_nearest_neighbor"));
+
+  // special op
+  map->emplace("get_item", std::make_shared<TFV1GetItemCodeGen>(""));
+  map->emplace("tuple", std::make_shared<TFV1TupleCodeGen>("tuple"));
+
+  // msc ops
+  map->emplace("msc.conv2d", std::make_shared<TFV1ConvCodeGen>("ops.nn_ops.conv2d", true));
+
+  return map;
+}
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm

--- a/src/contrib/msc/framework/tensorflow/tf_v1_opcode.h
+++ b/src/contrib/msc/framework/tensorflow/tf_v1_opcode.h
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/tf_v1_opcode.h
+ * \brief Tensorflow codegen for MSCJoint, use v1 format.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_TF_V1_OPCODE_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_TF_V1_OPCODE_H_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "../../core/codegen/base_codegen.h"
+#include "config.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+class TFV1OpCode;
+typedef OpCodeStack<TFV1OpCode> TFV1OpCodeStack;
+
+/*!
+ * \brief CodeGen for tensorflow op
+ */
+class TFV1OpCode : public BaseOpCode<TensorflowCodeGenConfig> {
+ public:
+  /*!
+   * \brief The constructor of BaseOpDocsifier
+   * \param func_name the function name for the node.
+   * \param config the config json for the node.
+   */
+  explicit TFV1OpCode(const String& func_name) : BaseOpCode<TensorflowCodeGenConfig>(func_name) {}
+
+  /*! \brief Convert node to docs*/
+  const Array<Doc> GetDocs() final;
+
+  /*! \brief Get dtype string*/
+  const String DType(const DataType& dtype) final {
+    return "tf_v1." + BaseOpCode<TensorflowCodeGenConfig>::DType(dtype);
+  }
+
+ protected:
+  TFV1OpCodeStack stack_;
+
+  /*! \brief Convert op build*/
+  virtual void CodeGenBuild() = 0;
+
+  /*! \brief Get padding mode or array*/
+  const std::pair<String, Array<String>> GetPadding(const String& strides_key,
+                                                    const String& kernel_key = "",
+                                                    const String& padding_key = "padding");
+};
+
+/*!
+ * \brief Get the map of available TFV1OpCode, use optype as key
+ * \return Map of <string, TFV1OpCode>
+ */
+const std::shared_ptr<std::unordered_map<String, std::shared_ptr<TFV1OpCode>>> GetTFV1OpCodes();
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_TF_V1_OPCODE_H_

--- a/src/contrib/msc/framework/tvm/codegen.cc
+++ b/src/contrib/msc/framework/tvm/codegen.cc
@@ -42,7 +42,7 @@ void RelaxCodeGen::CodeGenGraph() {
   }
   stack_.func_start().assign("inputs", DocUtils::ToListDoc(idx_inputs, true));
   // define weights
-  stack_.comment("Define the weights and constant");
+  stack_.comment("Define the weights");
   for (const auto& n : graph()->node_names) {
     const auto& node = graph()->FindNode(n);
     for (const auto& pair : node->weights) {
@@ -56,17 +56,13 @@ void RelaxCodeGen::CodeGenGraph() {
           .func_call("inputs.append")
           .call_arg(idx_weight);
     }
-    if (node->optype == "constant") {
-      CodeGenNode(node);
-      stack_.func_call("inputs.append").call_arg(IdxNodeBase(node));
-    }
   }
   stack_.comment("Define the module");
   stack_.assign("block_builder", "relax.BlockBuilder()")
       .scope_start("block_builder.function(name=\"" + graph()->name + "\", params=inputs.copy())");
   for (const auto& n : graph()->node_names) {
     const auto& node = graph()->FindNode(n);
-    if (node->optype == "input" || node->optype == "constant") {
+    if (node->optype == "input") {
       continue;
     }
     int scope_level = CompareScope(node);

--- a/src/contrib/msc/framework/tvm/relax_opcode.cc
+++ b/src/contrib/msc/framework/tvm/relax_opcode.cc
@@ -256,14 +256,7 @@ class RelaxConstantCodeGen : public RelaxOpCode {
   RELAX_OP_CODEGEN_METHODS(RelaxConstantCodeGen)
 
  protected:
-  void CodeGenBuild() final {
-    stack_.op_call()
-        .op_name_arg("")
-        .func_call("relax.TensorStructInfo")
-        .call_arg(DocUtils::ToListDoc(node()->OutputAt(0)->shape, true), "")
-        .call_arg(DocUtils::ToStrDoc(node()->OutputAt(0)->DTypeName()))
-        .pop_nest();
-  }
+  void CodeGenBuild() final { stack_.assign(IdxNode(), IdxWeight("const")); }
 };
 
 class RelaxConvCodeGen : public RelaxOpCode {

--- a/tests/python/contrib/test_msc/test_graph_build.py
+++ b/tests/python/contrib/test_msc/test_graph_build.py
@@ -1306,10 +1306,10 @@ def test_interpolate():
 
     expected = {
         "inputs": [
-            {"name": "inp_0", "shape": [1, 3, 10, 10], "dtype": "float32", "layout": "ABCD"}
+            {"name": "inp_0", "shape": [1, 3, 10, 10], "dtype": "float32", "layout": "NCHW"}
         ],
         "outputs": [
-            {"name": "resize2d", "shape": [1, 3, 5, 5], "dtype": "float32", "layout": "ABCD"}
+            {"name": "resize2d", "shape": [1, 3, 5, 5], "dtype": "float32", "layout": "NCHW"}
         ],
         "nodes": {"total": 2, "input": 1, "image.resize2d": 1},
     }

--- a/tests/python/contrib/test_msc/test_translate_tensorflow.py
+++ b/tests/python/contrib/test_msc/test_translate_tensorflow.py
@@ -1,0 +1,1695 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=deprecated-module
+
+""" Test translate from tensorflow. """
+
+from distutils.version import LooseVersion
+
+from packaging import version as package_version
+import numpy as np
+
+from tensorflow.python.framework import constant_op
+from tensorflow.python.ops import nn_ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import variables
+from tensorflow.python.client import device_lib
+
+
+try:
+    import tensorflow.compat.v1 as tf
+
+    tf.disable_v2_behavior()
+except ImportError:
+    import tensorflow as tf
+
+import tvm
+import tvm.testing
+import tvm.relay.testing.tf as tf_testing
+from tvm.contrib.msc.framework.tensorflow.frontend import translate
+from tvm.contrib.msc.framework.tensorflow import codegen
+
+
+# Only allow TF to run on half the GPU RAM to save the other half
+# For TVM
+gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.5)
+gpu_sess = tf.Session(config=tf.ConfigProto(gpu_options=gpu_options))
+gpu_sess.close()
+
+
+def convert_to_list(x):
+    if not isinstance(x, list):
+        x = [x]
+    return x
+
+
+def run_tf_graph(sess, input_data, input_node, output_node):
+    """Generic function to execute tensorflow"""
+
+    input_data = convert_to_list(input_data)
+    input_node = convert_to_list(input_node)
+    output_node = convert_to_list(output_node)
+
+    tensor = [sess.graph.get_tensor_by_name(output_name) for output_name in output_node]
+
+    input_dict = {e: input_data[i] for i, e in enumerate(input_node)}
+    if len(input_node) == 1 and input_node[0] == "":
+        output_data = sess.run(tensor)
+    else:
+        output_data = sess.run(tensor, input_dict)
+    return output_data
+
+
+def get_graph_def(in_data, in_name, out_name):
+    """Get tf.GraphDef for translate"""
+
+    def name_without_num(name):
+        return name.split(":")[0] if ":" in name else name
+
+    out_name = convert_to_list(out_name)
+    out_node = [name_without_num(name) for name in out_name]
+    in_data = convert_to_list(in_data)
+    in_name = convert_to_list(in_name)
+
+    with tf.Session() as sess:
+        sess.run(variables.global_variables_initializer())
+        final_graph_def = tf_testing.AddShapesToGraphDef(sess, out_node)
+        golden = run_tf_graph(sess, in_data, in_name, out_name)
+    return final_graph_def, golden
+
+
+def verify_model(graph_def, golden, in_data, in_name, out_name, use_out_name=True):
+    """Generic function to generate and compare tensorflow and MSC-TFV1 output"""
+
+    out_name = convert_to_list(out_name)
+    in_data = convert_to_list(in_data)
+    in_name = convert_to_list(in_name)
+    shape_dict = {i: d.shape for i, d in zip(in_name, in_data)}
+    graph, weights = translate.from_tensorflow(graph_def, shape_dict, out_name)
+    with tf.Graph().as_default():
+        outputs = codegen.to_tensorflow(graph, weights)
+        with tf.Session() as sess:
+            sess.run(variables.global_variables_initializer())
+            if not use_out_name:
+                out_name = [o.name for o in convert_to_list(outputs)]
+            result = run_tf_graph(sess, in_data, in_name, out_name)
+
+    golden = convert_to_list(golden)
+    result = convert_to_list(result)
+    assert len(golden) == len(result), "golden {} mismatch with result {}".format(
+        len(golden), len(result)
+    )
+    for gol_r, new_r in zip(golden, result):
+        if isinstance(gol_r, np.ndarray):
+            tvm.testing.assert_allclose(gol_r, new_r, atol=1e-5, rtol=1e-5)
+        else:
+            assert gol_r == new_r
+
+
+def _test_pooling(input_shape, **kwargs):
+    """One iteration of pool operation with given shapes and attributes"""
+
+    x = -np.arange(np.prod(input_shape), dtype=np.float32).reshape(input_shape) - 1
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=input_shape, dtype="float32")
+        nn_ops.pool(in_data, **kwargs)
+        out_name = "max_pool:0" if kwargs["pooling_type"] == "MAX" else "avg_pool:0"
+        io_info = {"in_data": x, "in_name": "Placeholder:0", "out_name": out_name}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_pooling():
+    """test tensorflow translator for pooling"""
+
+    for pool_type in ["AVG", "MAX"]:
+        _test_pooling(
+            input_shape=[2, 9, 10, 2],
+            window_shape=[2, 1],
+            padding="SAME",
+            pooling_type=pool_type,
+            dilation_rate=[1, 1],
+            strides=[1, 1],
+        )
+
+        _test_pooling(
+            input_shape=[2, 9, 10, 2],
+            window_shape=[2, 1],
+            padding="VALID",
+            pooling_type=pool_type,
+            dilation_rate=[1, 1],
+            strides=[1, 1],
+        )
+
+        _test_pooling(
+            input_shape=[1, 2, 1],
+            window_shape=[1],
+            padding="VALID",
+            pooling_type=pool_type,
+            dilation_rate=[1],
+        )
+
+    # Explicit padding
+    if package_version.parse(tf.VERSION) >= package_version.parse("2.4.1"):
+        _test_pooling(
+            input_shape=[2, 9, 10, 2],
+            window_shape=[4, 4],
+            padding=[[0, 0], [0, 1], [2, 3], [0, 0]],
+            pooling_type="MAX",
+            dilation_rate=[1, 1],
+            strides=[1, 1],
+        )
+
+
+def _test_convolution(
+    opname,
+    tensor_in_sizes,
+    filter_in_sizes,
+    dilations,
+    strides,
+    padding,
+    data_format,
+):
+    """One iteration of convolution with given shapes and attributes"""
+    total_size_1 = np.prod(tensor_in_sizes)
+    total_size_2 = np.prod(filter_in_sizes)
+    # Initializes the input tensor with array containing incrementing
+    # numbers from 1.
+    data_array = [f * 1.0 for f in range(1, total_size_1 + 1)]
+    filter_array = [f * 1.0 for f in range(1, total_size_2 + 1)]
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=tensor_in_sizes, dtype="float32")
+        in_filter = constant_op.constant(filter_array, shape=filter_in_sizes, dtype="float32")
+        if data_format == "NHWC":
+            strides = [1] + strides + [1]
+            dilations = [1] + dilations + [1]
+        else:
+            strides = [1, 1] + strides
+            dilations = [1, 1] + dilations
+
+        if opname == "conv":
+            nn_ops.conv2d(
+                in_data,
+                in_filter,
+                strides=strides,
+                dilations=dilations,
+                padding=padding,
+                data_format=data_format,
+            )
+            io_info = {
+                "in_data": np.reshape(data_array, tensor_in_sizes).astype("float32"),
+                "in_name": "Placeholder:0",
+                "out_name": "Conv2D:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        else:
+            nn_ops.depthwise_conv2d_native(
+                in_data,
+                in_filter,
+                strides=strides,
+                dilations=dilations,
+                padding=padding,
+                data_format=data_format,
+            )
+            io_info = {
+                "in_data": np.reshape(data_array, tensor_in_sizes).astype("float32"),
+                "in_name": "Placeholder:0",
+                "out_name": "DepthwiseConv2dNative:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+
+def test_convolution():
+    """test tensorflow translator for convolution"""
+
+    _test_convolution("conv", [4, 8, 8, 176], [1, 1, 176, 32], [1, 1], [1, 1], "SAME", "NHWC")
+    _test_convolution("conv", [4, 17, 17, 19], [3, 3, 19, 19], [1, 1], [2, 2], "VALID", "NHWC")
+    _test_convolution("depthwise", [4, 8, 8, 176], [1, 1, 176, 1], [1, 1], [1, 1], "SAME", "NHWC")
+    _test_convolution("depthwise", [4, 17, 17, 19], [3, 3, 19, 1], [1, 1], [2, 2], "VALID", "NHWC")
+
+    # Explicit padding
+    if package_version.parse(tf.VERSION) >= package_version.parse("2.4.1"):
+        _test_convolution(
+            "conv",
+            [4, 8, 8, 16],
+            [1, 1, 16, 32],
+            [1, 1],
+            [1, 1],
+            [[0, 0], [2, 3], [0, 1], [0, 0]],
+            "NHWC",
+        )
+        _test_convolution(
+            "depthwise",
+            [4, 8, 8, 16],
+            [1, 1, 16, 1],
+            [1, 1],
+            [1, 1],
+            [[0, 0], [2, 3], [0, 1], [0, 0]],
+            "NHWC",
+        )
+
+
+def _test_biasadd(tensor_in_sizes, data_format):
+    """One iteration of biasadd with given shapes and attributes"""
+
+    total_size_1 = 1
+    for s in tensor_in_sizes:
+        total_size_1 *= s
+    tensor_bias_sizes = [tensor_in_sizes[1]] if data_format == "NCHW" else [tensor_in_sizes[3]]
+    total_size_2 = tensor_bias_sizes[0]
+    # Initializes the input tensor with array containing incrementing
+    # numbers from 1.
+    data_array = [f * 1.0 for f in range(1, total_size_1 + 1)]
+    bias_array = [f * 1.0 for f in range(1, total_size_2 + 1)]
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=tensor_in_sizes, dtype="float32")
+        in_bias = constant_op.constant(bias_array, shape=tensor_bias_sizes, dtype="float32")
+        nn_ops.bias_add(in_data, in_bias, data_format=data_format)
+        io_info = {
+            "in_data": np.reshape(data_array, tensor_in_sizes).astype("float32"),
+            "in_name": "Placeholder:0",
+            "out_name": "BiasAdd:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_biasadd():
+    """test tensorflow translator for bias_add"""
+
+    _test_biasadd([4, 8, 8, 176], "NHWC")
+
+
+def _test_where_with_broadcast(in_shape, cond_shape):
+    choice_list = list(np.arange(10).astype("float32"))
+    t_1 = np.random.choice(choice_list, size=cond_shape)
+    t_2 = np.random.choice(choice_list, size=cond_shape)
+    x = np.random.choice(choice_list, size=in_shape)
+    y = np.random.choice(choice_list, size=in_shape)
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=cond_shape, dtype="float32", name="in1")
+        in2 = tf.placeholder(shape=cond_shape, dtype="float32", name="in2")
+        condition = math_ops.less(in1, in2, name="less")
+        lhs = tf.placeholder(shape=in_shape, dtype="float32", name="x")
+        rhs = tf.placeholder(shape=in_shape, dtype="float32", name="y")
+        out = tf.where(condition, lhs, rhs)
+        io_info = {
+            "in_data": [t_1, t_2, x, y],
+            "in_name": ["in1:0", "in2:0", "x:0", "y:0"],
+            "out_name": out.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_where_with_broadcast():
+    """test tensorflow translator for where"""
+
+    _test_where_with_broadcast((5, 2), (5,))
+    _test_where_with_broadcast((3, 2, 5), (3,))
+
+
+def _test_reshape(data, out_shape):
+    """One iteration of reshape operation with given data and out shape"""
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        array_ops.reshape(in_data, out_shape)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "Reshape:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_reshape_with_call():
+    """relay.expr.Call as shape"""
+    data = np.zeros((6, 4, 2))
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        out_shape = tf.constant([1, 2, 3], dtype="int32")
+        out_shape = tf.multiply(out_shape, 2)
+        array_ops.reshape(in_data, out_shape)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "Reshape:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_reshape_like(data, shape_like):
+    """A special case for reshape."""
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        in_shape_like = array_ops.placeholder(shape=shape_like.shape, dtype=data.dtype)
+        out_shape = array_ops.shape(in_shape_like)
+        array_ops.reshape(in_data, out_shape)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "Reshape:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_reshape():
+    """test tensorflow translator for reshape"""
+
+    _test_reshape(np.arange(6.0), [2, 3])
+    _test_reshape(np.arange(6), [-1, 2])
+    _test_reshape_with_call()
+    _test_reshape_like(np.zeros((3, 6)), np.zeros((9, 2)))
+
+
+def _test_sigmoid(data):
+    """One iteration of sigmoid"""
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        _ = math_ops.sigmoid(in_data)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "Sigmoid:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_sigmoid():
+    """test tensorflow translator for concat"""
+
+    _test_sigmoid(np.random.uniform(size=(3, 4, 4, 3)).astype("float32"))
+
+
+def _test_argx(func, data, **kwargs):
+
+    with tf.Graph().as_default():
+        inp = array_ops.placeholder(shape=data.shape, dtype=data.dtype, name="c0")
+        func(inp, name="argx", **kwargs)
+        io_info = {"in_data": data, "in_name": "c0:0", "out_name": "argx:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_argx():
+    """test tensorflow translator for argmax/argmin"""
+
+    data = np.random.uniform(size=(8, 4, 9)).astype("float32")
+    for output_type in [tf.int64, tf.int32]:
+        _test_argx(tf.argmax, data=data, axis=1, output_type=output_type)
+        _test_argx(tf.argmin, data=data, axis=1, output_type=output_type)
+
+
+def _test_matmul(i, j, k, transpose_a=False, transpose_b=False):
+    """One iteration of matmul"""
+
+    a_shape_init = [i, j]
+    b_shape_init = [j, k]
+    a_shape = [] + (a_shape_init[::-1] if transpose_a else a_shape_init)
+    b_shape = [] + (b_shape_init[::-1] if transpose_b else b_shape_init)
+
+    with tf.Graph().as_default():
+        a_in = tf.placeholder(shape=a_shape, dtype="float32", name="A")
+        b_in = tf.placeholder(shape=b_shape, dtype="float32", name="B")
+        result = tf.matmul(a_in, b_in, transpose_a=transpose_a, transpose_b=transpose_b)
+
+        a_np = np.random.uniform(high=5.0, size=a_shape).astype("float32")
+        b_np = np.random.uniform(high=5.0, size=b_shape).astype("float32")
+        io_info = {
+            "in_data": [a_np, b_np],
+            "in_name": [a_in.name, b_in.name],
+            "out_name": result.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info, use_out_name=False)
+
+
+def test_matmul():
+    """test tensorflow translator for matmul"""
+
+    _test_matmul(1, 3, 6)
+    _test_matmul(1, 3, 6, True, True)
+    _test_matmul(1, 3, 6, True, False)
+    _test_matmul(1, 3, 6, False, True)
+
+
+def _test_batch_matmul(a_shape, b_shape, adjoint_a=False, adjoint_b=False):
+
+    with tf.Graph().as_default():
+        a_in = tf.placeholder(shape=a_shape, dtype="float32", name="A")
+        b_in = tf.placeholder(shape=b_shape, dtype="float32", name="B")
+        result = tf.matmul(a_in, b_in, adjoint_a=adjoint_a, adjoint_b=adjoint_b, name="batchmatmul")
+
+        a_np = np.random.uniform(high=5.0, size=a_shape).astype("float32")
+        b_np = np.random.uniform(high=5.0, size=b_shape).astype("float32")
+        io_info = {
+            "in_data": [a_np, b_np],
+            "in_name": [a_in.name, b_in.name],
+            "out_name": result.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_batch_matmul():
+    """test tensorflow translator for batch_matmul"""
+
+    _test_batch_matmul((3, 5, 4), (3, 4, 5))
+    _test_batch_matmul((3, 5, 4), (3, 4, 5), True, True)
+    _test_batch_matmul((3, 5, 4), (3, 5, 4), True, False)
+    _test_batch_matmul((3, 5, 4), (3, 5, 4), False, True)
+
+
+def _test_stridedslice(
+    ip_shape,
+    begin,
+    end,
+    stride,
+    begin_mask=0,
+    end_mask=0,
+    new_axis_mask=0,
+    shrink_axis_mask=0,
+    ellipsis_mask=0,
+):
+    """One iteration of a Stridedslice"""
+
+    tf.reset_default_graph()
+    np_data = np.random.uniform(size=ip_shape).astype("float32")
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", ip_shape, name="in_data")
+        tf.strided_slice(
+            in_data,
+            begin,
+            end,
+            stride,
+            begin_mask=begin_mask,
+            end_mask=end_mask,
+            new_axis_mask=new_axis_mask,
+            shrink_axis_mask=shrink_axis_mask,
+            ellipsis_mask=ellipsis_mask,
+            name="strided_slice",
+        )
+        io_info = {"in_data": np_data, "in_name": "in_data:0", "out_name": "strided_slice:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_stridedslice():
+    """test tensorflow translator for stridedslice"""
+
+    _test_stridedslice([2, 3, 4], [0], [1], [1], shrink_axis_mask=8)
+    _test_stridedslice([3, 4, 3], [1, -1, 0], [4, -5, 3], [2, -1, 1])
+    _test_stridedslice([3, 4, 3], [1, 0], [4, 3], [2, 1], ellipsis_mask=8)
+    _test_stridedslice([3, 4, 3], [1, 1, 0], [4, 4, 2], [2, 1, 1], new_axis_mask=5)
+    _test_stridedslice(
+        [3, 4, 5, 4, 5, 6],
+        [0, 0, 1, 2, 1],
+        [2, 3, 4, 5, 3],
+        [1, 1, 2, 2, 1],
+        shrink_axis_mask=5,
+        new_axis_mask=1,
+        ellipsis_mask=2,
+        begin_mask=8,
+        end_mask=8,
+    )
+
+
+def _test_divide(ip_shape, dtype):
+    np_numer = np.random.uniform(-100, 100, size=ip_shape).astype(dtype)
+    np_denomin = np.random.uniform(1, 100, size=ip_shape).astype(dtype)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        numerator = tf.placeholder(dtype, ip_shape, name="numer")
+        denominator = tf.placeholder(dtype, ip_shape, name="denomin")
+        tf.math.divide(numerator, denominator, name="RealDiv")
+        io_info = {
+            "in_data": [np_numer, np_denomin],
+            "in_name": ["numer:0", "denomin:0"],
+            "out_name": "RealDiv:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_floordiv(ip_shape, dtype):
+    np_numer = np.random.uniform(1, 100, size=ip_shape).astype(dtype)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        numerator = tf.placeholder(dtype, ip_shape, name="numer")
+        tf.math.floordiv(numerator, tf.constant(5, dtype=dtype), name="FloorDiv")
+        io_info = {"in_data": [np_numer], "in_name": ["numer:0"], "out_name": "FloorDiv:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_divide():
+    """test tensorflow translator for div"""
+
+    _test_divide((4, 3, 7), "float32")
+    _test_divide((4, 3, 7), "int32")
+    _test_floordiv((4, 3, 7), "float32")
+    _test_floordiv((4, 3, 7), "int32")
+
+
+def _test_gather(ip_shape, indice_shape, indice_value, axis, batch_dims):
+    """One iteration of a GatherV2"""
+
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", ip_shape, name="in_data")
+        indices = tf.placeholder("int32", indice_shape, name="indices")
+        out = tf.gather(in_data, indices, axis=axis, batch_dims=batch_dims)
+        np_data = np.random.uniform(1, 10, size=ip_shape).astype("float32")
+
+        def _fill_indices(indice_value):
+            indices = np.array(ip_shape, dtype="float32")
+            if isinstance(indice_value, int):
+                indices = np.array([indice_value], dtype="int32")
+            else:
+                indices = np.asarray(indice_value, dtype="int32")
+            return indices
+
+        np_indices = _fill_indices(indice_value)
+        io_info = {
+            "in_data": [np_data, np_indices],
+            "in_name": ["in_data:0", "indices:0"],
+            "out_name": out.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_gather():
+    """test tensorflow translator for gather"""
+
+    _test_gather((4,), (1,), 1, 0, 0)
+    _test_gather((2, 2), (1, 2, 2), [[[1, 0], [0, 1]]], 0, 0)
+    _test_gather((4, 3, 5, 6), (1, 4), [[2, 1, 0, 0]], 0, 0)
+
+
+def _test_split(in_shape, axis, num_or_size_splits):
+    """One iteration of a Split"""
+    np_data = np.random.uniform(-5, 5, size=in_shape).astype("float32")
+
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", in_shape, name="in_data")
+        _ = len(num_or_size_splits) if isinstance(num_or_size_splits, list) else num_or_size_splits
+        split = tf.split(in_data, num_or_size_splits, axis=axis)
+        relu = [tf.nn.relu(i) for i in split]
+        io_info = {
+            "in_data": [np_data],
+            "in_name": ["in_data:0"],
+            "out_name": [n.name for n in relu],
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+    # and now test together with concat
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", in_shape, name="in_data")
+        splitted = tf.split(in_data, num_or_size_splits, axis=axis)
+        concat = tf.concat(splitted, axis)
+        io_info = {
+            "in_data": [np_data],
+            "in_name": ["in_data:0"],
+            "out_name": concat.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_split():
+    """test tensorflow translator for split"""
+
+    _test_split((6, 1, 3, 5), 0, 3)
+    _test_split((6, 1, 3, 5), -4, 3)
+    _test_split((3, 6, 4), -2, [1, 4, 1])
+
+
+def _test_tile(in_shape, multiples):
+    np_data = np.random.uniform(-5, 5, size=in_shape).astype("float32")
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", in_shape, name="in_data")
+        tf.tile(in_data, multiples=multiples, name="tile")
+        io_info = {"in_data": np_data, "in_name": "in_data:0", "out_name": "tile:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_tile():
+    """test tensorflow translator for tile"""
+
+    _test_tile((2, 2), (2, 3))
+
+
+def _test_clip_by_value(ip_shape, clip_value_min, clip_value_max):
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", ip_shape, name="in_data")
+        tf.clip_by_value(in_data, clip_value_min, clip_value_max, name="ClipByValue")
+        np_data = np.random.uniform(-100, 100, size=ip_shape).astype("float32")
+        io_info = {"in_data": np_data, "in_name": "in_data:0", "out_name": "ClipByValue:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_clip_by_value():
+    """test tensorflow translator for clip"""
+
+    _test_clip_by_value((4,), 0.1, 5.0)
+
+
+def test_multi_input():
+    """test tensorflow translator for multi input"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.int32, shape=[3, 3], name="in1")
+        in2 = tf.placeholder(tf.int32, shape=[3, 3], name="in2")
+        in3 = tf.placeholder(tf.int32, shape=[3, 3], name="in3")
+        in4 = tf.placeholder(tf.int32, shape=[3, 3], name="in4")
+
+        out1 = tf.add(in1, in2, name="out1")
+        out2 = tf.subtract(in3, in4, name="out2")
+        _ = tf.multiply(out1, out2, name="out")
+        in_data = np.arange(9, dtype="int32").reshape([3, 3])
+        io_info = {
+            "in_data": [in_data, in_data, in_data, in_data],
+            "in_name": ["in1:0", "in2:0", "in3:0", "in4:0"],
+            "out_name": "out:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_multi_output():
+    """test tensorflow translator for multi output"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.int32, shape=[3, 3], name="in1")
+        in2 = tf.placeholder(tf.int32, shape=[3, 3], name="in2")
+        in3 = tf.placeholder(tf.int32, shape=[3, 3], name="in3")
+        in4 = tf.placeholder(tf.int32, shape=[3, 3], name="in4")
+
+        _ = tf.add(in1, in2, name="out1")
+        _ = tf.subtract(in3, in4, name="out2")
+        in_data = np.arange(9, dtype="int32").reshape([3, 3])
+        io_info = {
+            "in_data": [in_data] * 4,
+            "in_name": ["in1:0", "in2:0", "in3:0", "in4:0"],
+            "out_name": ["out1:0", "out2:0"],
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_resize_bilinear(in_shape, to_shape, align_corners):
+    """One iteration of resize bilinear"""
+
+    data = np.random.uniform(size=in_shape).astype("float32")
+    shape_data = np.array(to_shape).astype("int32")
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        shape_data = constant_op.constant(
+            shape_data, shape=shape_data.shape, dtype=shape_data.dtype
+        )
+        tf.image.resize_bilinear(in_data, shape_data, align_corners=align_corners)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "ResizeBilinear:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_resize_nearest_neighbor(in_shape, to_shape):
+    """One iteration of resize nearest neighbor"""
+
+    data = np.random.uniform(size=in_shape).astype("float32")
+    shape_data = np.array(to_shape).astype("int32")
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        shape_data = constant_op.constant(
+            shape_data, shape=shape_data.shape, dtype=shape_data.dtype
+        )
+        tf.image.resize_nearest_neighbor(in_data, shape_data, name="resize_nearest_neighbor")
+        io_info = {
+            "in_data": data,
+            "in_name": "Placeholder:0",
+            "out_name": "resize_nearest_neighbor:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_resize():
+    """test tensorflow translator for resize"""
+
+    _test_resize_bilinear((4, 32, 32, 3), [50, 50], False)
+    _test_resize_bilinear((6, 32, 32, 3), [20, 20], True)
+    _test_resize_nearest_neighbor((6, 32, 32, 3), [20, 20])
+
+
+def _test_broadcast_to(in_shape, to_shape):
+    """One iteration of broadcast_to"""
+
+    data = np.random.uniform(size=in_shape).astype("float32")
+    shape_data = np.array(to_shape).astype("int32")
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        shape_data = constant_op.constant(
+            shape_data, shape=shape_data.shape, dtype=shape_data.dtype
+        )
+        tf.broadcast_to(in_data, shape_data)
+        io_info = {"in_data": data, "in_name": "Placeholder:0", "out_name": "BroadcastTo:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_broadcast_to():
+    """test tensorflow translator for broadcast_to"""
+
+    _test_broadcast_to((4, 1, 32, 32), [4, 8, 32, 32])
+
+
+def _test_fill(in_shape):
+    """Use the fill op to create a tensor of ones with non-constant shape."""
+
+    with tf.Graph().as_default():
+        tf.ones(shape=in_shape, dtype="float32")
+        io_info = {"in_data": in_shape, "in_name": [], "out_name": "ones:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info, use_out_name=False)
+
+
+def test_fill():
+    """test tensorflow translator for fill"""
+
+    _test_fill((6, 32, 64, 64))
+
+
+def _test_pack(axis, shape, **kwargs):
+
+    a = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+    b = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+
+    with tf.Graph().as_default():
+        tf_a = array_ops.placeholder(shape=shape, dtype="float32", name="pl_a")
+        tf_b = array_ops.placeholder(shape=shape, dtype="float32", name="pl_b")
+        tf_c = tf.stack([tf_a, tf_b], axis=axis, **kwargs)
+        assert tf_c.op.op_def.name == "Pack", "tf.stack() is expected to produce 'Pack' operation"
+        io_info = {"in_data": [a, b], "in_name": ["pl_a:0", "pl_b:0"], "out_name": "stack:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_pack():
+    """test tensorflow translator for pack"""
+
+    _test_pack(3, [3, 2, 1])
+
+
+def _test_unpack(in_shape, axis):
+    """test operator Unpack"""
+    np_data = np.random.uniform(-100, 100, size=in_shape).astype("float32")
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder("float32", in_shape, name="in_data")
+        tf.unstack(in_data, axis=axis, name="Unpack")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "Unpack:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_unpack():
+    """test tensorflow translator for unpack"""
+
+    _test_unpack((21, 23, 3), 2)
+
+
+def _test_einsum(equation, *shape_of_input_tensors):
+    """Test Einsum Op"""
+
+    with tf.Graph().as_default():
+        inputs_placeholders = []
+        input_data = []
+        for idx, shape in enumerate(shape_of_input_tensors):
+            input_name = f"input_{idx}"
+            inputs_placeholders.append(
+                tf.placeholder(shape=shape, dtype="float32", name=input_name)
+            )
+            input_data.append(np.random.normal(size=shape).astype("float32"))
+
+        result = tf.einsum(equation, *inputs_placeholders)
+        io_info = {
+            "in_data": input_data,
+            "in_name": [ph.name for ph in inputs_placeholders],
+            "out_name": result.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info, use_out_name=False)
+
+
+def test_einsum():
+    """test tensorflow translator for einsum"""
+
+    _test_einsum("ij,jk->ik", [2, 3], [3, 5])  # Matmul
+    _test_einsum("ij,jk", [2, 3], [3, 5])  # Matmul
+    _test_einsum("i,i->", [2], [2])  # Dot product
+    _test_einsum("i,j->ij", [3], [5])  # Outer produce
+    _test_einsum("ij->ji", [2, 3])  # Transpose
+    _test_einsum("ii->i", [3, 3])  # Diag
+    _test_einsum("ii", [3, 3])  # Trace of a square matrix
+    _test_einsum("bij,bjk->bik", [7, 5, 3], [7, 3, 2])  # Batch matmul
+
+
+def _test_pad(input_shape, paddings, mode, **kwargs):
+    """One iteration of pad operation with given shape"""
+
+    x = np.arange(np.prod(input_shape), dtype=np.float32).reshape(input_shape)
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=input_shape, dtype="float32")
+        pad_values = constant_op.constant(paddings)
+        _ = tf.pad(in_data, paddings=pad_values, mode=mode, **kwargs)
+
+        if mode == "CONSTANT":
+            if "constant_values" in kwargs:
+                out_name = "PadV2:0"
+            else:
+                out_name = "Pad:0"
+        else:
+            out_name = "MirrorPad:0"
+
+        io_info = {
+            "in_data": x,
+            "in_name": "Placeholder:0",
+            "out_name": out_name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_pad():
+    """test tensorflow translator for pad"""
+
+    _test_pad((2, 3), [[1, 1], [2, 2]], mode="CONSTANT")
+    _test_pad((2, 3), [[1, 1], [2, 2]], mode="CONSTANT", constant_values=1.0)
+
+
+def test_logical_and():
+    """test tensorflow translator for logical_and"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in1")
+        in2 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in2")
+        _ = tf.logical_and(in1, in2, name="out")
+        in_data1 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        in_data2 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        io_info = {
+            "in_data": [in_data1, in_data2],
+            "in_name": ["in1:0", "in2:0"],
+            "out_name": "out:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_logical_or():
+    """test tensorflow translator for logical_or"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in1")
+        in2 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in2")
+        _ = tf.logical_or(in1, in2, name="out")
+        in_data1 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        in_data2 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        io_info = {
+            "in_data": [in_data1, in_data2],
+            "in_name": ["in1:0", "in2:0"],
+            "out_name": "out:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_logical_xor():
+    """test tensorflow translator for logical_xor"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in1")
+        in2 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in2")
+        _ = tf.logical_xor(in1, in2, name="out")
+        in_data1 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        in_data2 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        io_info = {
+            "in_data": [in_data1, in_data2],
+            "in_name": ["in1:0", "in2:0"],
+            "out_name": "out:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_logical_not():
+    """test tensorflow translator for logical_not"""
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.bool, shape=[1, 4, 4, 3], name="in1")
+        _ = tf.logical_not(in1, name="out")
+        in_data1 = np.random.choice(a=[False, True], size=(1, 4, 4, 3)).astype("bool")
+        io_info = {
+            "in_data": [in_data1],
+            "in_name": ["in1:0"],
+            "out_name": "out:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_where():
+    """test tensorflow translator for where"""
+
+    with tf.Graph().as_default():
+        with tf.Session() as _:
+            input1 = tf.placeholder(tf.int32, shape=[1, 4, 4, 3], name="input1")
+            input2 = tf.placeholder(tf.int32, shape=[1, 4, 4, 3], name="input2")
+            mask = input1 > input2
+            tf.where(mask, input1 + 1, input2 * 2)
+            in_data1 = np.random.uniform(0, 10, size=(1, 4, 4, 3)).astype("uint32")
+            in_data2 = np.random.uniform(0, 10, size=(1, 4, 4, 3)).astype("uint32")
+            io_info = {
+                "in_data": [in_data1, in_data2],
+                "in_name": ["input1:0", "input2:0"],
+                "out_name": "Select:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+
+def _test_transpose(ishape, axes=None):
+    data = np.random.uniform(size=ishape).astype(np.float32)
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=data.shape, dtype=data.dtype, name="transpose_data")
+
+        if axes is None:
+            tf.transpose(in1)
+        else:
+            tf.transpose(in1, perm=axes)
+
+        io_info = {
+            "in_data": data,
+            "in_name": "transpose_data:0",
+            "out_name": "transpose:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def _test_tranapose_axes_input(ishape, axes):
+    data = np.random.uniform(size=ishape).astype(np.float32)
+    axes_np = np.array(axes).astype(np.int32)
+
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=data.shape, dtype=data.dtype, name="transpose_data")
+
+        const1 = tf.constant(axes_np, dtype=tf.int32)
+
+        # make axes an input to tf.transpose, but not an input to the graph,
+        # so it can be extracted with infer_value_simulated
+        axes = tf.reverse(const1, axis=[-1])
+        tf.transpose(in1, axes)
+        io_info = {
+            "in_data": data,
+            "in_name": "transpose_data:0",
+            "out_name": "transpose:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_transpose():
+    """test tensorflow translator for transpose"""
+
+    _test_transpose((2, 3, 4), (1, 2, 0))
+    _test_transpose((2, 3, 4))
+    _test_tranapose_axes_input((2, 3, 4), (1, 2, 0))
+    _test_tranapose_axes_input((2, 3, 4, 5), (3, 0, 1, 2))
+
+
+def _test_slice_operation_input(input_value, begin_value, size_value):
+    input_data = np.array(input_value, dtype=np.float32)
+    with tf.Graph().as_default():
+        input_tensor = tf.placeholder(shape=input_data.shape, dtype=input_data.dtype, name="input")
+        tf.slice(input_tensor, begin_value, size_value, name="slice_output")
+        io_info = {
+            "in_data": input_data,
+            "in_name": "input:0",
+            "out_name": "slice_output:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_slice():
+    """test tensorflow translator for slice"""
+
+    _test_slice_operation_input([1, 1], [0], [2])
+
+
+def test_ceil():
+    """test tensorflow translator for ceil"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.ceil(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Ceil:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_floor():
+    """test tensorflow translator for floor"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.floor(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Floor:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_relu():
+    """test tensorflow translator for relu"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.nn.relu(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Relu:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_elu():
+    """test tensorflow translator for elu"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.nn.elu(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Elu:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_selu():
+    """test tensorflow translator for selu"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.nn.selu(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Selu:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_tanh():
+    """test tensorflow translator for tanh"""
+
+    ishape = (1, 3, 10, 10)
+    inp_array = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+        tf.nn.tanh(in1)
+        io_info = {
+            "in_data": inp_array,
+            "in_name": "Placeholder:0",
+            "out_name": "Tanh:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_softmax():
+    """test tensorflow translator for softmax"""
+
+    def check_softmax(in_shape, axis, dtype):
+        np_data = np.random.uniform(-100, 100, size=in_shape).astype(dtype)
+        tf.reset_default_graph()
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(dtype, in_shape, name="in_data")
+            tf.nn.softmax(in_data, axis=axis, name="Softmax")
+            io_info = {
+                "in_data": np_data,
+                "in_name": "in_data:0",
+                "out_name": "Softmax:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    check_softmax((2, 3, 5), 2, "float32")
+    check_softmax((2, 3, 5), -1, "float32")
+
+
+def test_round():
+    """test tensorflow translator for round"""
+
+    np_data = np.random.uniform(-10, 10, size=(5, 7)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (5, 7), name="in_data")
+        tf.round(in_data, name="round")
+        io_info = {
+            "in_data": np_data,
+            "in_name": "in_data:0",
+            "out_name": "round:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_abs():
+    """test tensorflow translator for abs"""
+
+    np_data = np.random.uniform(1, 100, size=(9, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (9, 11), name="in_data")
+        tf.math.abs(in_data, name="abs")
+        io_info = {
+            "in_data": np_data,
+            "in_name": "in_data:0",
+            "out_name": "abs:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_squared_difference():
+    """test tensorflow translator for squared_difference"""
+
+    ishape = (1, 3, 10, 14)
+    inp_array_a = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    inp_array_b = np.random.uniform(-5, 5, size=ishape).astype(np.float32)
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=inp_array_a.shape, dtype=inp_array_a.dtype, name="in1")
+        in2 = tf.placeholder(shape=inp_array_b.shape, dtype=inp_array_b.dtype, name="in2")
+        out = tf.math.squared_difference(in1, in2)
+        io_info = {
+            "in_data": [inp_array_a, inp_array_b],
+            "in_name": [in1.name, in2.name],
+            "out_name": out.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_sign():
+    """test tensorflow translator for sign"""
+
+    np_data = np.random.uniform(-10, 10, size=(5, 7, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (5, 7, 11), name="in_data")
+        tf.sign(in_data, name="sign")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "sign:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_square():
+    """test tensorflow translator for square"""
+
+    np_data = np.random.uniform(1, 100, size=(2, 3, 5)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (2, 3, 5), name="in_data")
+        tf.square(in_data, name="square")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "square:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_pow_exp():
+    """test tensorflow translator for pow && exp"""
+
+    np_in1 = np.random.uniform(-2, 2, size=(5, 7, 11)).astype(np.float32)
+    np_in2 = np.random.uniform(-2, 2, size=(5, 7, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(tf.float32, (5, 7, 11), name="in1")
+        in2 = tf.placeholder(tf.float32, (5, 7, 11), name="in2")
+        in3 = tf.pow(in1, in2, name="pow")
+        _ = tf.exp(in3, name="exp")
+        io_info = {"in_data": [np_in1, np_in2], "in_name": ["in1:0", "in2:0"], "out_name": "exp:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_unary():
+    """test tensorflow translator for unary"""
+
+    def _test_unary(op, a_min=1, a_max=5, dtype=np.float32):
+        """test unary operators"""
+        np_data = np.random.uniform(a_min, a_max, size=(2, 3, 5)).astype(dtype)
+        tf.reset_default_graph()
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(dtype, (2, 3, 5), name="in_data")
+            out = op(in_data)
+            io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": out.name}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    _test_unary(tf.acos, -1, 1)
+    _test_unary(tf.asin, -1, 1)
+    _test_unary(tf.atanh, -1, 1)
+    _test_unary(tf.sinh)
+    _test_unary(tf.cosh)
+    _test_unary(tf.acosh)
+    _test_unary(tf.asinh)
+    _test_unary(tf.atan)
+    _test_unary(tf.sin)
+    _test_unary(tf.cos)
+    _test_unary(tf.tan)
+    _test_unary(tf.tanh)
+    _test_unary(tf.erf)
+    _test_unary(tf.log)
+
+
+def test_atan2():
+    """test tensorflow translator for atan2"""
+
+    tf.disable_eager_execution()
+    np_data_1 = np.random.uniform(1, 100, size=(2, 3, 5)).astype(np.float32)
+    np_data_2 = np.random.uniform(1, 100, size=(2, 3, 5)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data_1 = tf.placeholder(tf.float32, (2, 3, 5), name="in_data_1")
+        in_data_2 = tf.placeholder(tf.float32, (2, 3, 5), name="in_data_2")
+        tf.atan2(in_data_1, in_data_2, name="atan2")
+        io_info = {
+            "in_data": [np_data_1, np_data_2],
+            "in_name": ["in_data_1:0", "in_data_2:0"],
+            "out_name": "atan2:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_expm1():
+    """test tensorflow translator for expm1"""
+
+    def _test_expm1(shape):
+        tf.disable_eager_execution()
+        np_data = np.random.uniform(1, 10, size=shape).astype(np.float32)
+        tf.reset_default_graph()
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(tf.float32, shape, name="in_data")
+            tf.expm1(in_data, name="expm1")
+            io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "expm1:0"}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    _test_expm1([2, 5, 2, 5])
+
+
+def test_softsign():
+    """test tensorflow translator for softsign"""
+
+    def _test_softsign(shape):
+        tf.disable_eager_execution()
+        np_data = np.random.uniform(1, 100, size=shape).astype(np.float32)
+        tf.reset_default_graph()
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(tf.float32, shape, name="in_data")
+            tf.nn.softsign(in_data, name="softsign")
+            io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "softsign:0"}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    _test_softsign([2, 5, 2, 5])
+
+
+def test_rint():
+    """test tensorflow translator for rint"""
+
+    def _test_rint(shape):
+        tf.disable_eager_execution()
+        np_data = np.random.uniform(-100, 100, size=shape).astype(np.float32)
+        tf.reset_default_graph()
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(tf.float32, shape, name="in_data")
+            tf.math.rint(in_data, name="rint")
+            io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "rint:0"}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    _test_rint([2, 5, 2, 5])
+
+
+def test_negative():
+    """test tensorflow translator for neg"""
+
+    np_data = np.random.uniform(-100, 255, size=(224, 224, 3)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (224, 224, 3), name="in_data")
+        tf.negative(in_data, name="negative")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "negative:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_log_softmax():
+    """test tensorflow translator for log_softmax"""
+
+    np_data = np.random.uniform(1, 100, size=(9, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (9, 11), name="in_data")
+        tf.math.log_softmax(in_data, name="LogSoftmax")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "LogSoftmax:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_softplus():
+    """test tensorflow translator for softplus"""
+
+    np_data = np.random.uniform(1, 10, size=(2, 3, 5)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (2, 3, 5), name="in_data")
+        tf.nn.softplus(in_data, name="softplus")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "softplus:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_rsqrt():
+    """test tensorflow translator for rsqrt"""
+
+    np_data = np.random.uniform(1, 100, size=(5, 7, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (5, 7, 11), name="in_data")
+        tf.rsqrt(in_data, name="rsqrt")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "rsqrt:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_sqrt():
+    """test tensorflow translator for sqrt"""
+
+    np_data = np.random.uniform(1, 100, size=(5, 7, 11)).astype(np.float32)
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        in_data = tf.placeholder(tf.float32, (5, 7, 11), name="in_data")
+        tf.sqrt(in_data, name="sqrt")
+        io_info = {"in_data": [np_data], "in_name": ["in_data:0"], "out_name": "sqrt:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_mean():
+    """test tensorflow translator for mean"""
+
+    def check_mean(ishape, **kwargs):
+        inp_array = np.random.uniform(size=ishape).astype(np.float32)
+        with tf.Graph().as_default():
+            in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
+            tf.keras.backend.mean(in1, **kwargs)
+            io_info = {"in_data": inp_array, "in_name": "Placeholder:0", "out_name": "Mean:0"}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    check_mean((10, 8, 16, 32))
+    check_mean((10, 8, 16, 32), axis=(2, 3))
+    check_mean((10, 8, 16, 32), axis=(1, 2), keepdims=True)
+
+
+def test_reduce():
+    """test tensorflow translator for reduce"""
+
+    def _check_op(tf_op, ishape, axis, keepdims):
+        tf.reset_default_graph()
+        np_data = np.random.uniform(size=ishape).astype("float32")
+        if tf_op == tf.math.reduce_prod:
+            axis = 1
+            np_data = np_data.reshape(1, -1)
+        with tf.Graph().as_default():
+            in_data = tf.placeholder(shape=np_data.shape, dtype="float32", name="in_data")
+            reduce_op = tf_op(in_data, axis=axis, keepdims=keepdims, name="reduce_op")
+            io_info = {"in_data": np_data, "in_name": "in_data:0", "out_name": reduce_op.name}
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    def _test_math_op(op):
+        _check_op(op, (8, 16, 32), axis=(-1), keepdims=False)
+        _check_op(op, (1, 8, 8, 3), axis=(2, 3), keepdims=True)
+
+    _test_math_op(tf.math.reduce_max)
+    _test_math_op(tf.math.reduce_min)
+    _test_math_op(tf.math.reduce_prod)
+    _test_math_op(tf.math.reduce_variance)
+    _test_math_op(tf.math.reduce_std)
+    _test_math_op(tf.math.reduce_logsumexp)
+    if package_version.parse(tf.VERSION) >= package_version.parse("1.15.0"):
+        _test_math_op(tf.math.reduce_euclidean_norm)
+
+
+def _test_rel_op(data, func):
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=data[0].shape, dtype=data[0].dtype, name="in1")
+        in2 = tf.placeholder(shape=data[1].shape, dtype=data[1].dtype, name="in2")
+        op = func(in1, in2, name="op")
+        _ = tf.cast(op, tf.int32, name="out1")
+        io_info = {
+            "in_data": [data[0], data[1]],
+            "in_name": ["in1:0", "in2:0"],
+            "out_name": "out1:0",
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_rel_ops():
+    """test tensorflow translator for relation"""
+
+    t_1 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    t_2 = np.array([[9, 8, 7], [6, 5, 4], [3, 2, 1]])
+    _test_rel_op([t_1, t_2], math_ops.less)
+    _test_rel_op([t_1, t_2], math_ops.greater)
+    _test_rel_op([t_1, t_2], math_ops.less_equal)
+    _test_rel_op([t_1, t_2], math_ops.greater_equal)
+    _test_rel_op([t_1, t_2], math_ops.equal)
+    _test_rel_op([t_1, t_2], math_ops.not_equal)
+
+
+def _test_expand_dims(data, axis):
+    with tf.Graph().as_default():
+        in1 = tf.placeholder(shape=data.shape, dtype=data.dtype, name="in1")
+        out = tf.expand_dims(in1, axis)
+        io_info = {"in_data": data, "in_name": in1.name, "out_name": out.name}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_expand_dims():
+    """test tensorflow translator for expand_dims"""
+
+    _test_expand_dims(np.array([1]), -1)
+    _test_expand_dims(np.array([[1], [2]]), 1)
+
+
+def test_maximum():
+    """test tensorflow translator for maximum"""
+
+    def check_maximum(lh_shape, rh_shape, dtype):
+        tf.reset_default_graph()
+        lh_data = np.random.uniform(size=lh_shape).astype(dtype)
+        rh_data = np.random.uniform(size=rh_shape).astype(dtype)
+        with tf.Graph().as_default():
+            lft_data = tf.placeholder(shape=lh_data.shape, dtype=dtype, name="lft_data")
+            rgt_data = tf.placeholder(shape=rh_data.shape, dtype=dtype, name="rgt_data")
+            tf.math.maximum(lft_data, rgt_data, name="maximum")
+            io_info = {
+                "in_data": [lh_data, rh_data],
+                "in_name": ["lft_data:0", "rgt_data:0"],
+                "out_name": "maximum:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    check_maximum((10, 8, 16, 32), (10, 8, 16, 32), dtype="float32")
+
+
+def test_minimum():
+    """test tensorflow translator for minimum"""
+
+    def check_minimum(lh_shape, rh_shape, dtype):
+        tf.reset_default_graph()
+        lh_data = np.random.uniform(size=lh_shape).astype(dtype)
+        rh_data = np.random.uniform(size=rh_shape).astype(dtype)
+        with tf.Graph().as_default():
+            lft_data = tf.placeholder(shape=lh_data.shape, dtype=dtype, name="lft_data")
+            rgt_data = tf.placeholder(shape=rh_data.shape, dtype=dtype, name="rgt_data")
+            tf.math.minimum(lft_data, rgt_data, name="minimum")
+            io_info = {
+                "in_data": [lh_data, rh_data],
+                "in_name": ["lft_data:0", "rgt_data:0"],
+                "out_name": "minimum:0",
+            }
+            graph_def, golden = get_graph_def(**io_info)
+        verify_model(graph_def, golden, **io_info)
+
+    check_minimum((10, 8, 16, 32), (10, 8, 16, 32), dtype="float32")
+
+
+def _test_add_n(inputs):
+    tf.reset_default_graph()
+    with tf.Graph().as_default():
+        temp = []
+        for each in inputs:
+            temp.append(tf.placeholder(shape=each.shape, dtype=each.dtype))
+        output = tf.add_n(temp)
+        io_info = {
+            "in_data": list(inputs),
+            "in_name": [each.name for each in temp],
+            "out_name": output.name,
+        }
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_add_n():
+    """test tensorflow translator for add_n"""
+
+    x_in = np.random.randint(1, 100, size=(3, 3, 3), dtype=np.int32)
+    y_in = np.random.randint(1, 100, size=(3, 3, 3), dtype=np.int32)
+    z_in = np.random.randint(1, 100, size=(3, 3, 3), dtype=np.int32)
+    m_dim, n_dim, o_dim = x_in.astype(np.float32), y_in.astype(np.float32), z_in.astype(np.float32)
+    in0 = x_in
+    in1 = [x_in, y_in]
+    in2 = (x_in, y_in, z_in)
+    in3 = m_dim
+    in4 = [m_dim, n_dim]
+    in5 = (m_dim, n_dim, o_dim)
+    _test_add_n(in0)
+    _test_add_n(in1)
+    _test_add_n(in2)
+    _test_add_n(in3)
+    _test_add_n(in4)
+    _test_add_n(in5)
+
+
+def _test_identityn(data_np_list):
+    with tf.Graph().as_default():
+        data_tensors = []
+        data_tensors_name = []
+        for index, data_np in enumerate(data_np_list):
+            tensor_name = f"data_{index}"
+            data_tensors_name.append(tensor_name + ":0")
+            data_tensors.append(
+                tf.placeholder(shape=data_np.shape, dtype=str(data_np.dtype), name=tensor_name)
+            )
+
+        output = tf.identity_n(data_tensors)
+        output_names = [out.name for out in output]
+        io_info = {"in_data": data_np_list, "in_name": data_tensors_name, "out_name": output_names}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info, use_out_name=False)
+
+
+def test_identityn():
+    """test tensorflow translator for identityn"""
+
+    data_np_list = [
+        np.array([[1, 1], [0, 3], [0, 1], [2, 0], [3, 1]], dtype=np.int64),
+        np.array([1, 2, 3, 4, 5], dtype=np.int64),
+        np.array([5, 6], dtype=np.int64),
+    ]
+    _test_identityn(data_np_list)
+    data_np_list = [
+        np.array([[1, 1], [0, 3], [2, 0], [3, 1]], dtype=np.int64),
+        np.array([1, 2, 3, 4], dtype=np.int64),
+        np.array([5, 6], dtype=np.int64),
+        np.array([True, False, True]),
+    ]
+    _test_identityn(data_np_list)
+
+
+def _test_infinity(tf_op, name):
+    """test operator infinity ops"""
+
+    # Only float types are allowed in Tensorflow for isfinite and isinf
+    # float16 is failing on cuda
+    tf_dtypes = ["float32", "float64"]  # pylint: disable=redefined-outer-name
+    for tf_dtype in tf_dtypes:
+        shape = (8, 8)
+        data = np.random.uniform(size=shape).astype(tf_dtype)
+        data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.infty
+        data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.nan
+
+        tf.reset_default_graph()
+        in_data = tf.placeholder(tf_dtype, shape, name="in_data")
+        tf_op(in_data, name=name)
+        io_info = {"in_data": data, "in_name": "in_data:0", "out_name": f"{name}:0"}
+        graph_def, golden = get_graph_def(**io_info)
+    verify_model(graph_def, golden, **io_info)
+
+
+def test_infinity():
+    """test tensorflow translator for infinity"""
+
+    _test_infinity(tf.is_inf, "isinf")
+    _test_infinity(tf.is_finite, "isfinite")
+    _test_infinity(tf.is_nan, "isnan")
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/contrib/test_msc/test_translate_tensorflow.py
+++ b/tests/python/contrib/test_msc/test_translate_tensorflow.py
@@ -18,8 +18,6 @@
 
 """ Test translate from tensorflow. """
 
-from distutils.version import LooseVersion
-
 from packaging import version as package_version
 import numpy as np
 
@@ -28,7 +26,6 @@ from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variables
-from tensorflow.python.client import device_lib
 
 
 try:


### PR DESCRIPTION
This is a pull request for MSC(Multi-System Compile)
RFC: https://discuss.tvm.apache.org/t/rfc-unity-msc-introduction-to-multi-system-compiler/15251/5
Tracking issue: https://github.com/apache/tvm/issues/15233

This is the 2nd part of Milestone 1: Finish RuntimeManager for frameworks

To limit each PR in reviewable size, the Milestone 1 will be split into some steps:
M1.1 Add translate && codegen for torch
**M1.2 Add translate && codegen for tensorflow**
M1.3 Add codegen for tensorrt
M1.4 Add RuntimeManager and test with relax
M1.5 Add RuntimeManager and test with torch
M1.6 Add RuntimeManager and test with tensorflow
M1.7 Add RuntimeManager and test with tensorrt

Tensorflow GraphDef will be translate to MSCGraph via relay. The codegen for tensorflow follow the same principle with relax codegen, thus generate the model define as well as test.
As mentioned in https://github.com/apache/tvm/pull/15645, MSC enables the relay based features. The test in this PR shows developers how to combine relay.frontend.from_tensorflow and msc.core.codegen.relay_to_relax to "create" a frontend for tensorflow in relax.

@Hzfengsy 
@junrushao 