### PR TITLE
[Unity] [Bugfix] Fix MaxPool TypeError in ONNX frontend

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1424,7 +1424,7 @@ class MaxPool(OnnxOpConverter):
         dilations = attr.get("dilations", [1, 1])
         kernel_shape = attr.get("kernel_shape")
         pads = attr.get("pads", 0)
-        strides = attr.get("strides", 1)
+        strides = attr.get("strides", [1, 1])
 
         assert len(kernel_shape) == 2, "Currently only 2D pooling is supported."
         assert auto_pad in [

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -1590,6 +1590,15 @@ def test_max_pool():
             strides=[2, 2],
         ),
     )
+    verify_unary(
+        "MaxPool",
+        [1, 1, 32, 32],
+        dict(
+            auto_pad="SAME_UPPER",
+            kernel_shape=[3, 3],
+            pads=None,
+        ),
+    )
 
 
 def test_global_average_pool():


### PR DESCRIPTION
As the ONNX documentation description [here](https://onnx.ai/onnx/operators/onnx__MaxPool.html)
The parameter strides in MaxPool2d is an optional attribute using [1, 1] as default.

This PR fixed it and added a corresponding regression test.