### PR TITLE
[IR] Make sure Range types match when binding to Var

### DIFF
--- a/include/tvm/runtime/data_type.h
+++ b/include/tvm/runtime/data_type.h
@@ -119,6 +119,8 @@ class DataType {
   bool is_vector_bool() const { return is_vector() && bits() == 1; }
   /*! \return whether type is a Void type. */
   bool is_void() const { return code() == DataType::kHandle && bits() == 0 && lanes() == 0; }
+  /* ! \return whether type is a signed or an unsigned int. */
+  bool is_integer_type() const { return is_int() || is_uint(); }
   /*!
    * \brief Create a new data type by change lanes to a specified value.
    * \param lanes The target number of lanes.

--- a/src/arith/transitive_comparison_analyzer.cc
+++ b/src/arith/transitive_comparison_analyzer.cc
@@ -594,7 +594,9 @@ void TransitiveComparisonAnalyzer::Impl::Bind(const tir::Var& var, const Range& 
 
 void TransitiveComparisonAnalyzer::Impl::Bind(const tir::Var& var, const PrimExpr& expr,
                                               bool allow_override) {
-  Bind(var, Range::FromMinExtent(expr, 1), allow_override);
+  if (expr.dtype().is_integer_type()) {
+    Bind(var, Range::FromMinExtent(expr, 1), allow_override);
+  }
 }
 
 std::function<void()> TransitiveComparisonAnalyzer::Impl::EnterConstraint(const PrimExpr& expr) {

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -119,10 +119,9 @@ For::For(Var loop_var, PrimExpr min, PrimExpr extent, ForKind kind, Stmt body,
   Optional<PrimExpr> maybe_min = tir::try_reset_expr_dtype(loop_var.dtype(), min);
   Optional<PrimExpr> maybe_extent = tir::try_reset_expr_dtype(loop_var.dtype(), extent);
 
-  CHECK(maybe_min && maybe_extent)
-      << "Incompatible types when binding a loop variable " << loop_var << ':' << loop_var.dtype()
-      << " to a range min=" << min << ':' << min.dtype() << ", extent=" << extent << ':'
-      << extent.dtype();
+  CHECK(maybe_min && maybe_extent) << "Incompatible types when binding a loop variable " << loop_var
+                                   << ':' << loop_var.dtype() << " to a range min=" << min << ':'
+                                   << min.dtype() << ", extent=" << extent << ':' << extent.dtype();
 
   min = maybe_min.value();
   extent = maybe_extent.value();


### PR DESCRIPTION
The values of `min` and `extent` in Range should have the same type, but the usage of convenience may often produce type mismatches, for example `Range(0, dim)` will assume int32 for the min. These mismatches can then cause hard-to-track errors, in particular assertions in the arithmetic simplifier. Such problems are likely to occur when a mismatched range is bound to a variable.

This patch identifies a few occurrences where a Range is bound to a Var, and checks that all types match. In case of a mismatch, types of compile- time immediates can be adjusted, otherwise an error is reported.