### PR TITLE
[Unity][Transform] Handle relax.Var as call_tir args when lowering

### DIFF
--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -278,6 +278,20 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
   virtual void VisitSpan(const Span& span);
   virtual void VisitPrimExpr(const PrimExpr& expr);
 
+  /*!
+   * \brief Look up the value bound to a variable.
+   * \param var The var to be looked up.
+   * \return The value bound to the input \p var.
+   * \note For function parameters, this function returns NullOpt.
+   */
+  inline Optional<Expr> LookupBinding(const Var& var) {
+    if (auto it = binding_table_.find(var->vid); it != binding_table_.end()) {
+      return it->second;
+    } else {
+      return NullOpt;
+    }
+  }
+
  private:
   using TSelf = ExprVisitor;
   using VisitBindingVTable =
@@ -308,6 +322,14 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
   // This visitor is not visible to child classes and only
   // used to supported default visiting behavior.
   DefaultStructInfoFieldVisitor default_struct_info_field_visitor_{this};
+
+  /*! \brief A binding table that maps var to value.
+   *
+   * Unlike ExprMutator, which can rely on the binding table of the
+   * internal BlockBuilder, ExprVisitor needs to track the bindings on
+   * its own.
+   */
+  std::unordered_map<Id, Expr, ObjectPtrHash, ObjectPtrEqual> binding_table_;
 };
 
 void PostOrderVisit(const Expr& node, std::function<void(const Expr&)> fvisit);

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -292,6 +292,23 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
     }
   }
 
+  /*!
+   * \brief Unwrap any known binding
+   * \param expr The expression to be unwrapped.
+   * \return The expression after following any known Var bindings
+   */
+  inline Expr UnwrapBindings(Expr expr) {
+    while (true) {
+      auto as_var = expr.as<Var>();
+      if (!as_var) return expr;
+
+      auto bound_expr = LookupBinding(as_var.value());
+      if (!bound_expr) return expr;
+
+      expr = bound_expr.value();
+    }
+  }
+
  private:
   using TSelf = ExprVisitor;
   using VisitBindingVTable =
@@ -533,6 +550,23 @@ class ExprMutator : public ExprMutatorBase {
    * \note For function parameters, this function returns NullOpt.
    */
   Optional<Expr> LookupBinding(const Var& var);
+
+  /*!
+   * \brief Unwrap any known binding
+   * \param expr The expression to be unwrapped.
+   * \return The expression after following any known Var bindings
+   */
+  inline Expr UnwrapBindings(Expr expr) {
+    while (true) {
+      auto as_var = expr.as<Var>();
+      if (!as_var) return expr;
+
+      auto bound_expr = LookupBinding(as_var.value());
+      if (!bound_expr) return expr;
+
+      expr = bound_expr.value();
+    }
+  }
 
   /*!
    * \brief Post-order rewrite a node and normalize.

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -66,6 +66,18 @@ def null_value() -> Call:
     return _ffi_api.null_value()  # type: ignore
 
 
+def _normalize_arg_tuple(args: Expr) -> Expr:
+    if isinstance(args, RxTuple) or isinstance(args.struct_info_, TupleStructInfo):
+        # A tuple, or a Var bound to a tuple, are kept as-is
+        return args
+    elif isinstance(args, Expr):
+        # A single argument is wrapped into a tuple
+        return RxTuple((args,))
+    else:
+        # Anything else is left for the FFI to handle
+        return args
+
+
 @args_converter.auto
 def call_tir(
     gvar: GlobalVar,
@@ -97,12 +109,7 @@ def call_tir(
     ret: Call
         A call node for the call_tir operator.
     """
-    if (
-        isinstance(args, Expr)
-        and not isinstance(args, RxTuple)
-        and not isinstance(args.struct_info_, TupleStructInfo)
-    ):
-        args = RxTuple((args,))
+    args = _normalize_arg_tuple(args)
 
     if not isinstance(out_sinfo, list):
         out_sinfo = [out_sinfo]
@@ -156,8 +163,7 @@ def call_tir_with_grad(
     ret: Call
         A call node for the call_tir_with_grad operator.
     """
-    if isinstance(args, Expr) and not isinstance(args, RxTuple):  # type: ignore
-        args = RxTuple((args,))
+    args = _normalize_arg_tuple(args)
 
     if not isinstance(out_sinfo, list):
         out_sinfo = [out_sinfo]
@@ -224,8 +230,7 @@ def call_tir_inplace(
     ret: Call
         A call node for the call_tir operator.
     """
-    if isinstance(args, Expr) and not isinstance(args, RxTuple):  # type: ignore
-        args = RxTuple((args,))
+    args = _normalize_arg_tuple(args)
 
     if not isinstance(inplace_indices, list):
         inplace_indices = [inplace_indices]
@@ -279,8 +284,7 @@ def call_dps_packed(
     if isinstance(func, str):
         func = ExternFunc(func)
 
-    if isinstance(args, Expr) and not isinstance(args, RxTuple):  # type: ignore
-        args = RxTuple((args,))
+    args = _normalize_arg_tuple(args)
 
     if not isinstance(out_sinfo, list):
         out_sinfo = [out_sinfo]

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -97,7 +97,11 @@ def call_tir(
     ret: Call
         A call node for the call_tir operator.
     """
-    if isinstance(args, Expr) and not isinstance(args, RxTuple) and not isinstance(args.struct_info_, TupleStructInfo):  # type: ignore
+    if (
+        isinstance(args, Expr)
+        and not isinstance(args, RxTuple)
+        and not isinstance(args.struct_info_, TupleStructInfo)
+    ):
         args = RxTuple((args,))
 
     if not isinstance(out_sinfo, list):

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -25,7 +25,7 @@ from tvm.runtime.object import Object
 from . import _ffi_api
 from ..expr import Expr, StringImm, ShapeExpr, Call, ExternFunc, GlobalVar, Var
 from ..expr import Tuple as RxTuple
-from ..struct_info import StructInfo, TensorStructInfo
+from ..struct_info import StructInfo, TensorStructInfo, TupleStructInfo
 from ...ir import PrimExpr
 from ..utils import args_converter
 
@@ -97,7 +97,7 @@ def call_tir(
     ret: Call
         A call node for the call_tir operator.
     """
-    if isinstance(args, Expr) and not isinstance(args, RxTuple):  # type: ignore
+    if isinstance(args, Expr) and not isinstance(args, RxTuple) and not isinstance(args.struct_info_, TupleStructInfo):  # type: ignore
         args = RxTuple((args,))
 
     if not isinstance(out_sinfo, list):

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -71,6 +71,7 @@
   void ExprVisitor::VisitBinding_(const VarBindingNode* binding, const OP* value) { \
     this->VisitExpr(binding->value);                                                \
     this->VisitVarDef(binding->var);                                                \
+    this->binding_table_.insert({binding->var->vid, binding->value});               \
   }
 
 // functions to be overriden.
@@ -258,6 +259,7 @@ RELAX_EXPR_VISITOR_VISIT_BINDING_IMPL(DataTypeImmNode);
 void ExprVisitor::VisitBinding_(const MatchCastNode* binding) {
   this->VisitExpr(binding->value);
   this->VisitVarDef(binding->var);
+  this->binding_table_.insert({binding->var->vid, binding->value});
 }
 
 void ExprVisitor::VisitBindingBlock_(const BindingBlockNode* block) {

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -263,7 +263,7 @@ RELAY_REGISTER_OP("relax.call_tir")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallTIR)
     .set_attr<Bool>("FPurity", Bool(true));
 
-Expr MakeCallTIR(Expr func, Tuple args, Array<TensorStructInfo> out_sinfo_list,
+Expr MakeCallTIR(Expr func, Expr arg_tuple, Array<TensorStructInfo> out_sinfo_list,
                  Optional<Expr> packed_ints) {
   for (const TensorStructInfo& sinfo : out_sinfo_list) {
     const auto* shape = sinfo->shape.as<ShapeExprNode>();
@@ -283,9 +283,9 @@ Expr MakeCallTIR(Expr func, Tuple args, Array<TensorStructInfo> out_sinfo_list,
   Call call;
   if (!packed_ints) {
     // don't use additional optional argument
-    call = Call(op, {func, args}, {}, {out_sinfo});
+    call = Call(op, {func, arg_tuple}, {}, {out_sinfo});
   } else {
-    call = Call(op, {func, args, packed_ints.value()}, {}, {out_sinfo});
+    call = Call(op, {func, arg_tuple, packed_ints.value()}, {}, {out_sinfo});
   }
   return call;
 }
@@ -307,7 +307,7 @@ RELAY_REGISTER_OP("relax.call_tir_with_grad")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallTIR)
     .set_attr<Bool>("FPurity", Bool(true));
 
-Expr MakeCallTIRWithGrad(Expr func, Tuple args, Array<TensorStructInfo> out_sinfo_list,
+Expr MakeCallTIRWithGrad(Expr func, Expr arg_tuple, Array<TensorStructInfo> out_sinfo_list,
                          String te_grad_name, Map<String, ObjectRef> te_grad_kwargs,
                          Optional<Expr> packed_ints) {
   for (const TensorStructInfo& sinfo : out_sinfo_list) {
@@ -333,9 +333,9 @@ Expr MakeCallTIRWithGrad(Expr func, Tuple args, Array<TensorStructInfo> out_sinf
   Call call;
   if (!packed_ints) {
     // don't use additional optional argument
-    call = Call(op, {func, args}, Attrs(attrs), {out_sinfo});
+    call = Call(op, {func, arg_tuple}, Attrs(attrs), {out_sinfo});
   } else {
-    call = Call(op, {func, args, packed_ints.value()}, Attrs(attrs), {out_sinfo});
+    call = Call(op, {func, arg_tuple, packed_ints.value()}, Attrs(attrs), {out_sinfo});
   }
   return call;
 }
@@ -453,7 +453,7 @@ RELAY_REGISTER_OP("relax.call_tir_inplace")
     // arguments will no longer be live)
     .set_attr<Bool>("FPurity", Bool(true));
 
-Expr MakeCallTIRInplace(Expr func, Tuple args, Array<Integer> inplace_indices,
+Expr MakeCallTIRInplace(Expr func, Expr arg_tuple, Array<Integer> inplace_indices,
                         Array<TensorStructInfo> out_sinfo_list, Optional<Expr> packed_ints) {
   for (const TensorStructInfo& sinfo : out_sinfo_list) {
     const auto* shape = sinfo->shape.as<ShapeExprNode>();
@@ -476,9 +476,9 @@ Expr MakeCallTIRInplace(Expr func, Tuple args, Array<Integer> inplace_indices,
   Call call;
   if (!packed_ints) {
     // don't use additional optional argument
-    call = Call(op, {func, args}, Attrs(attrs), {out_sinfo});
+    call = Call(op, {func, arg_tuple}, Attrs(attrs), {out_sinfo});
   } else {
-    call = Call(op, {func, args, packed_ints.value()}, Attrs(attrs), {out_sinfo});
+    call = Call(op, {func, arg_tuple, packed_ints.value()}, Attrs(attrs), {out_sinfo});
   }
   return call;
 }


### PR DESCRIPTION
Prior to this commit, several transforms assumed that the arguments passed to a `call_tir` builtin were provided as in-line `relax::Tuple` objects.  Because it would be equally valid for the arguments to instead be a `relax::Var` instance that had previously been bound to a `relax::Tuple` object, or had been passed as an input parameter with `relax::TupleStructInfo`, this assumption shouldn't be made.  This PR updates the `CallTIRRewrite`, `FoldConstant`, `FuseOps`, and `RewriteDataflowReshape` passes to handle variables providing the arguments.