### PR TITLE
[Unity][Relax]support torch.arange()+ (int) in torch frontend

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -296,7 +296,7 @@ class TorchFXImporter:
         start_end_step = [
             self.env[x] if isinstance(x, torch.fx.node.Node) else x for x in start_end_step
         ]
-        return relax.op.arange(*start_end_step, dtype=dtype)
+        return self.block_builder.emit(relax.op.arange(*start_end_step, dtype=dtype))
 
     def _empty(self, node: fx.node.Node) -> relax.Var:
         dtype = TorchFXImporter._convert_data_type(str(node.kwargs["dtype"]), self.env)

--- a/tests/python/relax/test_frontend_dynamo.py
+++ b/tests/python/relax/test_frontend_dynamo.py
@@ -525,16 +525,16 @@ def test_arange():
         @R.function
         def main(inp_0: R.Tensor((1, 77), dtype="float32")) -> R.Tensor((77,), dtype="int64"):
             with R.dataflow():
-                lv: R.Tensor((77,), dtype="int64") = R.arange(R.prim_value(0), R.prim_value(77), R.prim_value(1), dtype="int64")
+                lv: R.Tensor((77,), dtype="int64") = R.arange(
+                    R.prim_value(0), R.prim_value(77), R.prim_value(1), dtype="int64"
+                )
                 lv1: R.Tensor((77,), dtype="int64") = R.add(lv, R.const(1, "int64"))
                 gv: R.Tensor((77,), dtype="int64") = lv1
                 R.output(gv)
             return gv
 
 
-    verify_dynamo_model(
-        Arange1(), [([1, 77], "float32")], {}, Expected1
-    )
+    verify_dynamo_model(Arange1(), [([1, 77], "float32")], {}, Expected1)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_frontend_dynamo.py
+++ b/tests/python/relax/test_frontend_dynamo.py
@@ -533,7 +533,6 @@ def test_arange():
                 R.output(gv)
             return gv
 
-
     verify_dynamo_model(Arange1(), [([1, 77], "float32")], {}, Expected1)
 
 


### PR DESCRIPTION
In Stable Diffusion XL,
there are some structures, like
`a = torch.arange(b) +1`

by output the emmited relax.Var, we can support them