### PR TITLE
[TOPI][TIR][TE][x86] Extend x86 SIMD (u)int8 coverage for dense & conv2d

### DIFF
--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -51,6 +51,21 @@ TVM_DLL const Op& ret();
 TVM_DLL const Op& reinterpret();
 
 /*!
+ * \brief Zero extend the value using the target type.
+ */
+TVM_DLL const Op& zextend();
+
+/*!
+ * \brief Sign extend the value using the target type.
+ */
+TVM_DLL const Op& sextend();
+
+/*!
+ * \brief Truncate the value using the target type.
+ */
+TVM_DLL const Op& truncate();
+
+/*!
  * \brief Marks a condition is likely going to happen.
  */
 TVM_DLL const Op& likely();
@@ -769,9 +784,20 @@ TVM_DLL const Op& vectorlow();
 TVM_DLL const Op& vectorcombine();
 
 /*!
- * \brief atomic add instruction, corresponding e.g. to atomicAdd in CUDA
+ * \brief Shuffle two vectors using indices.
+ */
+TVM_DLL const Op& vectorshuffle();
+
+/*!
+ * \brief Permute vector using indices.
+ */
+TVM_DLL const Op& vectorpermute();
+
+/*!
+ * \brief Atomic add instruction.
  */
 TVM_DLL const Op& atomic_add();
+
 /*!
  * \brief Create an Nd memory allocation with storage scope
  */

--- a/include/tvm/tir/expr.h
+++ b/include/tvm/tir/expr.h
@@ -82,6 +82,39 @@ class StringImm : public PrimExpr {
   TVM_DEFINE_OBJECT_REF_COW_METHOD(StringImmNode);
 };
 
+/*! \brief Array of integer constants */
+class ArrayIntImmNode : public PrimExprNode {
+ public:
+  /*! \brief The constant value content. */
+  Array<Integer> data;
+
+  void VisitAttrs(AttrVisitor* v) {
+    v->Visit("dtype", &dtype);
+    v->Visit("data", &data);
+    v->Visit("span", &span);
+  }
+
+  bool SEqualReduce(const ArrayIntImmNode* other, SEqualReducer equal) const {
+    return equal(data, other->data);
+  }
+
+  void SHashReduce(SHashReducer hash_reduce) const { hash_reduce(data); }
+
+  static constexpr const char* _type_key = "tir.ArrayIntImm";
+  TVM_DECLARE_FINAL_OBJECT_INFO(ArrayIntImmNode, PrimExprNode);
+};
+
+/*!
+ * \brief Managed reference to ArrayIntImmNode.
+ * \sa ArrayIntImmNode
+ */
+class ArrayIntImm : public PrimExpr {
+ public:
+  TVM_DLL ArrayIntImm(Array<Integer> data, Span span = Span());
+  TVM_DEFINE_OBJECT_REF_METHODS(ArrayIntImm, PrimExpr, ArrayIntImmNode);
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(ArrayIntImmNode);
+};
+
 /*!
  * \brief Cast value from one data type to another.
  * \note The lanes of value should keep fixed.

--- a/include/tvm/tir/expr_functor.h
+++ b/include/tvm/tir/expr_functor.h
@@ -149,6 +149,7 @@ class ExprFunctor<R(const PrimExpr& n, Args...)> {
   virtual R VisitExpr_(const IntImmNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const FloatImmNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const StringImmNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
+  virtual R VisitExpr_(const ArrayIntImmNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const AnyNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExprDefault_(const Object* op, Args...) {
     LOG(FATAL) << "Do not have a default for " << op->GetTypeKey();
@@ -192,6 +193,7 @@ class ExprFunctor<R(const PrimExpr& n, Args...)> {
     IR_EXPR_FUNCTOR_DISPATCH(IntImmNode);
     IR_EXPR_FUNCTOR_DISPATCH(FloatImmNode);
     IR_EXPR_FUNCTOR_DISPATCH(StringImmNode);
+    IR_EXPR_FUNCTOR_DISPATCH(ArrayIntImmNode);
     IR_EXPR_FUNCTOR_DISPATCH(AnyNode);
     return vtable;
   }
@@ -243,6 +245,7 @@ class TVM_DLL ExprVisitor : public ExprFunctor<void(const PrimExpr&)> {
   void VisitExpr_(const IntImmNode* op) override;
   void VisitExpr_(const FloatImmNode* op) override;
   void VisitExpr_(const StringImmNode* op) override;
+  void VisitExpr_(const ArrayIntImmNode* op) override;
   void VisitExpr_(const AnyNode* op) override;
 };
 
@@ -289,6 +292,7 @@ class TVM_DLL ExprMutator : protected ExprFunctor<PrimExpr(const PrimExpr&)> {
   PrimExpr VisitExpr_(const IntImmNode* op) override;
   PrimExpr VisitExpr_(const FloatImmNode* op) override;
   PrimExpr VisitExpr_(const StringImmNode* op) override;
+  PrimExpr VisitExpr_(const ArrayIntImmNode* op) override;
   PrimExpr VisitExpr_(const AnyNode* op) override;
 };
 

--- a/python/tvm/autotvm/task/task.py
+++ b/python/tvm/autotvm/task/task.py
@@ -65,6 +65,8 @@ def serialize_args(args):
             return x
         if isinstance(x, (expr.StringImm, expr.IntImm, expr.FloatImm)):
             return x.value
+        if isinstance(x, expr.ArrayIntImm):
+            return x.data
         if isinstance(x, runtime.container.String):
             return str(x)
         if x is None:

--- a/python/tvm/ir/json_compact.py
+++ b/python/tvm/ir/json_compact.py
@@ -191,6 +191,7 @@ def create_updater_06_to_07():
         "Variable": [_update_tir_var("tir.Var"), _update_from_std_str("name")],
         "SizeVar": [_update_tir_var("tir.SizeVar"), _update_from_std_str("name")],
         "StringImm": [_rename("tir.StringImm"), _update_from_std_str("value")],
+        "ArrayIntImm": [_rename("tir.ArrayIntImm"), _update_from_std_str("data")],
         "Cast": _rename("tir.Cast"),
         "Add": _rename("tir.Add"),
         "Sub": _rename("tir.Sub"),

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -80,7 +80,7 @@ def legalize_dense(attrs, inputs, types):
     Parameters
     ----------
     attrs : tvm.ir.Attrs
-        Attributes of current convolution
+        Attributes of current dense operation
     inputs : list of tvm.relay.Expr
         The args of the Relay expr to be legalized
     types : list of types

--- a/python/tvm/script/ir_builder/tir/ir.py
+++ b/python/tvm/script/ir_builder/tir/ir.py
@@ -76,6 +76,7 @@ from tvm.tir.expr import (
     Shuffle,
     SizeVar,
     StringImm,
+    ArrayIntImm,
     Sub,
     Var,
 )
@@ -1869,6 +1870,11 @@ def _dtype_forward(func):
 
 
 reinterpret = _dtype_forward(_tir_op.reinterpret)
+sextend = _dtype_forward(_tir_op.sextend)
+zextend = _dtype_forward(_tir_op.zextend)
+truncate = _dtype_forward(_tir_op.truncate)
+vectorpermute = _dtype_forward(_tir_op.vectorpermute)
+vectorshuffle = _dtype_forward(_tir_op.vectorshuffle)
 call_extern = _dtype_forward(_tir_op.call_extern)
 call_intrin = _dtype_forward(_tir_op.call_intrin)
 call_llvm_intrin = _dtype_forward(_tir_op.call_llvm_intrin)
@@ -2072,6 +2078,11 @@ __all__ = [
     "q_multiply_shift_per_axis",
     "ret",
     "reinterpret",
+    "sextend",
+    "zextend",
+    "truncate",
+    "vectorpermute",
+    "vectorshuffle",
     "round",
     "rsqrt",
     "shift_left",
@@ -2155,6 +2166,7 @@ __all__ = [
     "FloatImm",
     "IntImm",
     "StringImm",
+    "ArrayIntImm",
     "Cast",
     "Add",
     "Sub",

--- a/python/tvm/target/x86.py
+++ b/python/tvm/target/x86.py
@@ -19,8 +19,8 @@ from .._ffi import register_func
 from .codegen import target_has_features
 
 
-@register_func("tvm.topi.x86.utils.get_simd_32bit_lanes")
-def get_simd_32bit_lanes():
+@register_func("tvm.topi.x86.utils.get_x86_simd_32bit_lanes")
+def get_x86_simd_32bit_lanes():
     """X86 SIMD optimal vector length lookup.
     Parameters
     ----------
@@ -29,9 +29,13 @@ def get_simd_32bit_lanes():
      vec_len : int
         The optimal vector length of CPU from the global context target.
     """
-    vec_len = 4
-    if target_has_features(["avx512bw", "avx512f"]):
+    vec_len = None
+    if target_has_features("avx512vnni") or target_has_features("avxvnni"):
+        vec_len = 16
+    elif target_has_features(["avx512bw", "avx512f"]):
         vec_len = 16
     elif target_has_features("avx2"):
         vec_len = 8
+    elif target_has_features("ssse3"):
+        vec_len = 4
     return vec_len

--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -21,7 +21,7 @@ from tvm.runtime import const
 
 from .buffer import Buffer, decl_buffer, DataProducer
 from .data_layout import Layout, BijectiveLayout, bijective_layout, layout
-from .expr import Var, SizeVar, Reduce, FloatImm, IntImm, StringImm, Cast
+from .expr import Var, SizeVar, Reduce, FloatImm, IntImm, StringImm, ArrayIntImm, Cast
 from .expr import Add, Sub, Mul, Div, Mod, FloorDiv, FloorMod
 from .expr import Min, Max, EQ, NE, LT, LE, GT, GE, And, Or, Not
 from .expr import Select, BufferLoad, ProducerLoad, Ramp, Broadcast, Shuffle
@@ -73,8 +73,8 @@ from .op import (
     ptx_wait_barrier,
     create_barriers,
 )
-from .op import vectorlow, vectorhigh, vectorcombine
-from .op import infinity, reinterpret
+from .op import vectorlow, vectorhigh, vectorcombine, vectorpermute, vectorshuffle
+from .op import infinity, reinterpret, zextend, sextend, truncate
 from .op import exp, exp2, exp10, log, log2, log10, log1p, ldexp, clz
 from .op import sin, sinh, asin, asinh
 from .op import cos, cosh, acos, acosh
@@ -88,6 +88,7 @@ from .op import comm_reducer, min, max, sum
 from .op import q_multiply_shift, q_multiply_shift_per_axis, shift_left, shift_right
 from .op import TVMBackendAllocWorkspace, TVMBackendFreeWorkspace
 from .op import start_profile_intrinsic, end_profile_intrinsic
+from .op import atomic_add
 from .generic import add, subtract, multiply
 
 from .schedule import StmtSRef, BlockScope, ScheduleState, Schedule, ScheduleError

--- a/python/tvm/tir/expr.py
+++ b/python/tvm/tir/expr.py
@@ -602,6 +602,36 @@ class StringImm(ConstExpr):
         return PrimExpr.__hash__(self)
 
 
+@tvm._ffi.register_object("tir.ArrayIntImm")  # type: ignore
+class ArrayIntImm(ConstExpr):
+    """Array of integer constants.
+
+    Parameters
+    ----------
+    data : list
+        The list with values of the function.
+
+    span : Optional[Span]
+        The location of this itervar in the source code.
+    """
+
+    def __init__(self, data, span=None):
+        self.__init_handle_by_constructor__(_ffi_api.ArrayIntImm, data, span)  # type: ignore
+
+    def __eq__(self, other):
+        if isinstance(other, ConstExpr):
+            return str(self.data) == str(other.data)
+        return str(self.data) == str(other)
+
+    def __ne__(self, other):
+        if isinstance(other, ConstExpr):
+            return str(self.data) != str(other.data)
+        return str(self.data) != str(other)
+
+    def __hash__(self):
+        return PrimExpr.__hash__(self)
+
+
 @tvm._ffi.register_object("tir.Cast")
 class Cast(PrimExprWithOp):
     """Cast expression.

--- a/python/tvm/topi/x86/conv3d.py
+++ b/python/tvm/topi/x86/conv3d.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 import tvm
 from tvm import autotvm, te
 from tvm.autotvm.task.space import OtherOptionEntity, SplitEntity
-from tvm.target.x86 import get_simd_32bit_lanes
+from tvm.target.x86 import get_x86_simd_32bit_lanes
 
 from ..nn.pad import pad
 from ..nn.utils import get_pad_tuple3d, infer_pad3d
@@ -536,7 +536,7 @@ def _get_conv3d_workload(data, kernel, stride, padding, groups, out_dtype, data_
 
 
 def _fallback_schedule(cfg, wkl):
-    simd_width = get_simd_32bit_lanes()
+    simd_width = get_x86_simd_32bit_lanes() if get_x86_simd_32bit_lanes() else 4
     DPAD, HPAD, WPAD = wkl.dpad, wkl.hpad, wkl.wpad
     DSTR, HSTR, WSTR = wkl.dstride, wkl.hstride, wkl.wstride
     out_width = (wkl.width + 2 * WPAD - wkl.wkernel) // WSTR + 1

--- a/python/tvm/topi/x86/depthwise_conv2d.py
+++ b/python/tvm/topi/x86/depthwise_conv2d.py
@@ -20,7 +20,7 @@
 import tvm
 from tvm import autotvm, te
 from tvm.autotvm.task.space import OtherOptionEntity, SplitEntity
-from tvm.target.x86 import get_simd_32bit_lanes
+from tvm.target.x86 import get_x86_simd_32bit_lanes
 
 from ..nn.conv2d import unpack_NCHWc_to_nchw
 from ..nn.depthwise_conv2d import _get_workload, depthwise_conv2d_infer_layout
@@ -39,7 +39,7 @@ def _fallback_schedule(cfg, wkl):
     wkl : topi.nn.depthwise_conv2d.Workload
         Convolution workload
     """
-    simd_width = get_simd_32bit_lanes()
+    simd_width = get_x86_simd_32bit_lanes() if get_x86_simd_32bit_lanes() else 4
 
     pt, pl, pb, pr = wkl.padt, wkl.padl, wkl.padb, wkl.padr
     HSTR, WSTR = wkl.stride_h, wkl.stride_w

--- a/python/tvm/topi/x86/group_conv2d.py
+++ b/python/tvm/topi/x86/group_conv2d.py
@@ -21,7 +21,7 @@
 import tvm
 from tvm import autotvm, te
 from tvm.autotvm.task.space import OtherOptionEntity, SplitEntity
-from tvm.target.x86 import get_simd_32bit_lanes
+from tvm.target.x86 import get_x86_simd_32bit_lanes
 
 from .. import tag
 from ..nn.conv2d import _get_workload as _get_conv2d_workload
@@ -60,7 +60,8 @@ def _get_default_config(
 
 
 def _fallback_schedule(cfg, wkl):
-    simd_width = get_simd_32bit_lanes()
+    simd_width = get_x86_simd_32bit_lanes() if get_x86_simd_32bit_lanes() else 4
+
     pad_left, pad_right = wkl.padl, wkl.padr
     stride_w = wkl.stride_w
     out_width = (wkl.width + pad_left + pad_right - wkl.kernel_w) // stride_w + 1

--- a/python/tvm/topi/x86/sparse.py
+++ b/python/tvm/topi/x86/sparse.py
@@ -19,7 +19,7 @@
 from functools import partial, reduce
 
 from tvm import autotvm, te, tir
-from tvm.target.x86 import get_simd_32bit_lanes
+from tvm.target.x86 import get_x86_simd_32bit_lanes
 
 from ..transform import reshape
 from ..utils import get_const_int, traverse_inline
@@ -30,7 +30,7 @@ def schedule_sparse_dense(outs):
     s = te.create_schedule([x.op for x in outs])
 
     def _callback(op):
-        simd_width = get_simd_32bit_lanes()
+        simd_width = get_x86_simd_32bit_lanes() if get_x86_simd_32bit_lanes() else 4
         if op.tag == "sparse_dense_sp_lhs_csrmm" or op.tag == "sparse_dense_sp_lhs_csrmm":
             (y_o, y_i) = s[op].split(s[op].op.axis[1], 2)
             fused = s[op].fuse(s[op].op.axis[0], y_o)

--- a/python/tvm/utils/roofline/x86.py
+++ b/python/tvm/utils/roofline/x86.py
@@ -62,7 +62,8 @@ def _detect_vec_width_registers(
             and target.keys[0] == "cpu"
         ):
             with target:
-                vec_width = x86.get_simd_32bit_lanes() * 4  # in number of bytes
+                simd_width = x86.get_x86_simd_32bit_lanes() if x86.get_x86_simd_32bit_lanes() else 4
+                vec_width = simd_width * 4  # in number of bytes
         else:
             raise RuntimeError(f"Cannot determine vector width for target {target}")
     if num_vector_registers is None:

--- a/src/ir/attr_functor.h
+++ b/src/ir/attr_functor.h
@@ -79,6 +79,7 @@ class AttrFunctor<R(const ObjectRef& n, Args...)> {
   virtual R VisitAttr_(const tir::IntImmNode* op, Args... args) ATTR_FUNCTOR_DEFAULT;
   virtual R VisitAttr_(const tir::FloatImmNode* op, Args... args) ATTR_FUNCTOR_DEFAULT;
   virtual R VisitAttr_(const tir::StringImmNode* op, Args... args) ATTR_FUNCTOR_DEFAULT;
+  virtual R VisitAttr_(const tir::ArrayIntImmNode* op, Args... args) ATTR_FUNCTOR_DEFAULT;
   // deep comparison of symbolic integer expressions.
   virtual R VisitAttr_(const tir::VarNode* op, Args... args) ATTR_FUNCTOR_DEFAULT;
   virtual R VisitAttr_(const tir::SizeVarNode* op, Args... args) {
@@ -116,6 +117,7 @@ class AttrFunctor<R(const ObjectRef& n, Args...)> {
     ATTR_FUNCTOR_DISPATCH(IntImmNode);
     ATTR_FUNCTOR_DISPATCH(FloatImmNode);
     ATTR_FUNCTOR_DISPATCH(StringImmNode);
+    ATTR_FUNCTOR_DISPATCH(ArrayIntImmNode);
     ATTR_FUNCTOR_DISPATCH(VarNode);
     ATTR_FUNCTOR_DISPATCH(SizeVarNode);
     ATTR_FUNCTOR_DISPATCH(AddNode);

--- a/src/relay/printer/relay_text_printer.cc
+++ b/src/relay/printer/relay_text_printer.cc
@@ -799,6 +799,18 @@ Doc RelayTextPrinter::VisitAttr_(const tir::StringImmNode* op) {
   return Doc::StrLiteral(op->value);
 }
 
+Doc RelayTextPrinter::VisitAttr_(const tir::ArrayIntImmNode* op) {
+  Doc doc;
+  doc << "[";
+  std::vector<Doc> arr_vals;
+  for (const auto& val : op->data) {
+    arr_vals.push_back(PrintAttributeValue(val));
+  }
+  doc << Doc::Concat(arr_vals);
+  doc << "]";
+  return doc;
+}
+
 /*!
  * \brief Attribute printer which prints the attributes in the call.
  */

--- a/src/relay/printer/text_printer.h
+++ b/src/relay/printer/text_printer.h
@@ -190,6 +190,7 @@ class RelayTextPrinter : public ExprFunctor<Doc(const Expr&)>,
   Doc VisitAttr_(const tir::IntImmNode* op) final;
   Doc VisitAttr_(const tir::FloatImmNode* op) final;
   Doc VisitAttr_(const tir::StringImmNode* op) final;
+  Doc VisitAttr_(const tir::ArrayIntImmNode* op) final;
 
  private:
   /*! \brief Whether to print meta data. */
@@ -242,7 +243,7 @@ class MetaCollector : public StmtExprVisitor {
   void Collect(const ObjectRef& n) {
     // these nodes can be print directly(StringLiteral or use identifier to identify)
     if (!n.defined() || n.as<StringImmNode>() || n.as<StringObj>() || n.as<SizeVarNode>() ||
-        n.as<VarNode>() || n.as<BufferNode>() || n.as<IterVarNode>()) {
+        n.as<VarNode>() || n.as<BufferNode>() || n.as<IterVarNode>() || n.as<ArrayIntImmNode>()) {
       return;
     }
     if (n->IsInstance<StmtNode>()) {
@@ -290,6 +291,7 @@ class TIRTextPrinter : public StmtFunctor<Doc(const Stmt&)>,
   Doc VisitExpr_(const IntImmNode* op) override;
   Doc VisitExpr_(const FloatImmNode* op) override;
   Doc VisitExpr_(const StringImmNode* op) override;
+  Doc VisitExpr_(const ArrayIntImmNode* op) override;
   Doc VisitExpr_(const CastNode* op) override;
   Doc VisitExpr_(const tir::VarNode* op) override;
   Doc VisitExpr_(const AddNode* op) override;

--- a/src/relay/printer/tir_text_printer.cc
+++ b/src/relay/printer/tir_text_printer.cc
@@ -296,6 +296,19 @@ Doc TIRTextPrinter::VisitExpr_(const FloatImmNode* op) {
 
 Doc TIRTextPrinter::VisitExpr_(const StringImmNode* op) { return Doc::StrLiteral(op->value); }
 
+Doc TIRTextPrinter::VisitExpr_(const ArrayIntImmNode* op) {
+  Doc doc;
+  doc << "[";
+  for (size_t i = 0; i < op->data.size(); ++i) {
+    doc << Print(op->data[i]);
+    if (i < op->data.size() - 1) {
+      doc << ", ";
+    }
+  }
+  doc << "]";
+  return doc;
+}
+
 Doc TIRTextPrinter::VisitExpr_(const CastNode* op) {
   Doc doc;
   doc << "cast(" << PrintDType(op->dtype) << ", " << Print(op->value) << ")";

--- a/src/relay/printer/tvmscript_printer.cc
+++ b/src/relay/printer/tvmscript_printer.cc
@@ -240,6 +240,7 @@ class TVMScriptPrinter : public StmtFunctor<Doc(const Stmt&)>,
   Doc VisitExpr_(const IntImmNode* op, ExprPrecedence* out_precedence) override;
   Doc VisitExpr_(const FloatImmNode* op, ExprPrecedence* out_precedence) override;
   Doc VisitExpr_(const StringImmNode* op, ExprPrecedence* out_precedence) override;
+  Doc VisitExpr_(const ArrayIntImmNode* op, ExprPrecedence* out_precedence) override;
   Doc VisitExpr_(const ProducerLoadNode* op, ExprPrecedence* out_precedence) override;
   Doc VisitExpr_(const BufferLoadNode* op, ExprPrecedence* out_precedence) override;
   Doc VisitExpr_(const RampNode* op, ExprPrecedence* out_precedence) override;
@@ -782,6 +783,19 @@ Doc TVMScriptPrinter::VisitExpr_(const FloatImmNode* op, ExprPrecedence* out_pre
 Doc TVMScriptPrinter::VisitExpr_(const StringImmNode* op, ExprPrecedence* out_precedence) {
   *out_precedence = ExprPrecedence::kIdentity;
   return Doc::StrLiteral(op->value);
+}
+
+Doc TVMScriptPrinter::VisitExpr_(const ArrayIntImmNode* op, ExprPrecedence* out_precedence) {
+  Doc doc;
+  doc << "[";
+  for (size_t i = 0; i < op->data.size(); ++i) {
+    doc << Print(op->data[i]);
+    if (i < op->data.size() - 1) {
+      doc << ", ";
+    }
+  }
+  doc << "]";
+  return doc;
 }
 
 Doc TVMScriptPrinter::VisitExpr_(const CastNode* op, ExprPrecedence* out_precedence) {
@@ -1559,7 +1573,7 @@ Doc TVMScriptPrinter::VisitStmt_(const BlockRealizeNode* op) {
 }
 
 Doc TVMScriptPrinter::PrintBody(const Stmt& body) {
-  int memo_num_child, memo_current_num;
+  int memo_num_child = 0, memo_current_num = 0;
   std::swap(memo_num_child, num_child_);
   std::swap(memo_current_num, current_num_);
 

--- a/src/script/printer/legacy_repr.cc
+++ b/src/script/printer/legacy_repr.cc
@@ -271,6 +271,19 @@ TVM_STATIC_IR_FUNCTOR(ReprLegacyPrinter, vtable)
     });
 
 TVM_STATIC_IR_FUNCTOR(ReprLegacyPrinter, vtable)
+    .set_dispatch<ArrayIntImmNode>([](const ObjectRef& node, ReprLegacyPrinter* p) {
+      auto* op = static_cast<const ArrayIntImmNode*>(node.get());
+      (*p) << '[';
+      for (size_t i = 0; i < op->data.size(); ++i) {
+        p->Print(op->data[i]);
+        if (i < op->data.size() - 1) {
+          (*p) << ", ";
+        }
+      }
+      (*p) << ']';
+    });
+
+TVM_STATIC_IR_FUNCTOR(ReprLegacyPrinter, vtable)
     .set_dispatch<CastNode>([](const ObjectRef& node, ReprLegacyPrinter* p) {
       auto* op = static_cast<const CastNode*>(node.get());
       (*p) << op->dtype << '(';

--- a/src/script/printer/tir/expr.cc
+++ b/src/script/printer/tir/expr.cc
@@ -116,6 +116,14 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     });
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
+    .set_dispatch<tir::ArrayIntImm>("", [](tir::ArrayIntImm a, ObjectPath p, IRDocsifier d) -> Doc {
+      return TIR(d, "ArrayIntImm")
+          ->Call({
+              d->AsDoc<ExprDoc>(a->data, p->Attr("data")),
+          });
+    });
+
+TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<tir::Cast>("", [](tir::Cast cast, ObjectPath p, IRDocsifier d) -> Doc {
       ExprDoc dtype = LiteralDoc::DataType(cast->dtype, p->Attr("dtype"));
       ExprDoc value = d->AsDoc<ExprDoc>(cast->value, p->Attr("value"));

--- a/src/target/llvm/codegen_arm.cc
+++ b/src/target/llvm/codegen_arm.cc
@@ -55,7 +55,13 @@ class CodeGenARM final : public CodeGenCPU {
 
 llvm::Value* CodeGenARM::CreateIntrinsic(const CallNode* op) {
   if (op->op.same_as(builtin_call_llvm_intrin_) || op->op.same_as(builtin_call_llvm_pure_intrin_)) {
-    llvm::Intrinsic::ID id = static_cast<llvm::Intrinsic::ID>(Downcast<IntImm>(op->args[0])->value);
+    llvm::Intrinsic::ID id = 0;
+    if (op->args[0]->IsInstance<StringImmNode>()) {
+      id = llvm::Function::lookupIntrinsicID(Downcast<StringImm>(op->args[0])->value.c_str());
+    } else if (op->args[0]->IsInstance<IntImmNode>()) {
+      id = static_cast<llvm::Intrinsic::ID>(Downcast<IntImm>(op->args[0])->value);
+    }
+    assert(id != 0);
     if (id == llvm::Intrinsic::ctpop) {
       PrimExpr e = ARMPopcount(op);
       return CodeGenCPU::CreateIntrinsic(e.as<CallNode>());

--- a/src/tir/ir/expr_functor.cc
+++ b/src/tir/ir/expr_functor.cc
@@ -78,6 +78,7 @@ DEFINE_BINOP_VISIT_(OrNode);
 void ExprVisitor::VisitExpr_(const IntImmNode* op) {}
 void ExprVisitor::VisitExpr_(const FloatImmNode* op) {}
 void ExprVisitor::VisitExpr_(const StringImmNode* op) {}
+void ExprVisitor::VisitExpr_(const ArrayIntImmNode* op) {}
 
 void ExprVisitor::VisitExpr_(const ReduceNode* op) {
   VisitArray(op->axis, [this](const IterVar& r) {
@@ -168,6 +169,7 @@ PrimExpr ExprMutator::VisitExpr_(const CallNode* op) {
 DEFINE_OP_RETURN_SELF_EXPR_MUTATE_(IntImmNode)
 DEFINE_OP_RETURN_SELF_EXPR_MUTATE_(FloatImmNode)
 DEFINE_OP_RETURN_SELF_EXPR_MUTATE_(StringImmNode)
+DEFINE_OP_RETURN_SELF_EXPR_MUTATE_(ArrayIntImmNode)
 
 #define DEFINE_BIOP_EXPR_MUTATE_(OP)                     \
   PrimExpr ExprMutator::VisitExpr_(const OP##Node* op) { \

--- a/src/tir/op/builtin.cc
+++ b/src/tir/op/builtin.cc
@@ -44,6 +44,24 @@ TIR_DEFINE_BUILTIN_FUNC(reinterpret)
                                          Integer(ScriptDtypePrintLocation::kFirst))
     .set_num_inputs(1);
 
+TIR_DEFINE_BUILTIN_FUNC(zextend)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
+                                         Integer(ScriptDtypePrintLocation::kFirst))
+    .set_num_inputs(1);
+
+TIR_DEFINE_BUILTIN_FUNC(sextend)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
+                                         Integer(ScriptDtypePrintLocation::kFirst))
+    .set_num_inputs(1);
+
+TIR_DEFINE_BUILTIN_FUNC(truncate)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
+                                         Integer(ScriptDtypePrintLocation::kFirst))
+    .set_num_inputs(1);
+
 TIR_DEFINE_BUILTIN_FUNC(ret)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kControlJump))
     .set_num_inputs(1);
@@ -334,6 +352,16 @@ TIR_DEFINE_BUILTIN_FUNC(vectorlow)
                                          Integer(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(vectorcombine)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
+                                         Integer(ScriptDtypePrintLocation::kFirst));
+
+TIR_DEFINE_BUILTIN_FUNC(vectorpermute)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
+                                         Integer(ScriptDtypePrintLocation::kFirst));
+
+TIR_DEFINE_BUILTIN_FUNC(vectorshuffle)
     .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
                                          Integer(ScriptDtypePrintLocation::kFirst));

--- a/src/tir/transforms/common_subexpr_elim.cc
+++ b/src/tir/transforms/common_subexpr_elim.cc
@@ -85,7 +85,8 @@ bool CommonSubexpressionEliminator::IsEligibleComputation(const PrimExpr& expr) 
   return (
       // In order to be eligible, the given expression should not be a constant
       (expr.as<IntImmNode>() == nullptr) && (expr.as<FloatImmNode>() == nullptr) &&
-      (expr.as<StringImmNode>() == nullptr)
+      (expr.as<StringImmNode>() == nullptr) &&
+      (expr.as<ArrayIntImmNode>() == nullptr)
       // and it should not be a variable
       && (expr.as<VarNode>() == nullptr)
       // and it should not be a forbidden computation (function calls and loads)

--- a/src/tir/transforms/common_subexpr_elim_tools.cc
+++ b/src/tir/transforms/common_subexpr_elim_tools.cc
@@ -269,7 +269,8 @@ ComputationTable ComputationsDoneBy::GetComputationsDoneBy(
   // (We don't want to use a "line of cache" of that, as that would cost an empty table of
   // computations in memory for absolutely no gain)
   if (expr.as<IntImmNode>() != nullptr || expr.as<FloatImmNode>() != nullptr ||
-      expr.as<StringImmNode>() != nullptr || expr.as<VarNode>() != nullptr) {
+      expr.as<StringImmNode>() != nullptr || expr.as<ArrayIntImmNode>() != nullptr ||
+      expr.as<VarNode>() != nullptr) {
     // Return an empty table
     return {};
   }
@@ -346,7 +347,8 @@ void ComputationsDoneBy::VisitExpr(const PrimExpr& expr) {
   // (We don't want to use a "line of cache" of that, as that would cost an empty table of
   // computations in memory for absolutely no gain)
   if (expr.as<IntImmNode>() != nullptr || expr.as<FloatImmNode>() != nullptr ||
-      expr.as<StringImmNode>() != nullptr || expr.as<VarNode>() != nullptr) {
+      expr.as<StringImmNode>() != nullptr || expr.as<VarNode>() != nullptr ||
+      expr.as<ArrayIntImmNode>() != nullptr) {
     return;
   }
 

--- a/src/tir/transforms/install_debug_spans.h
+++ b/src/tir/transforms/install_debug_spans.h
@@ -64,7 +64,8 @@
   X(Shuffle)                                                   \
   X(IntImm)                                                    \
   X(FloatImm)                                                  \
-  X(StringImm)
+  X(StringImm)                                                 \
+  X(ArrayIntImm)
 
 #define TVM_TIR_TRANSFORMS_INSTALL_DEBUG_SPANS_SUPPORTED_STMTS \
   X(AttrStmt)                                                  \

--- a/tests/python/contrib/test_gemm_acc32_simd.py
+++ b/tests/python/contrib/test_gemm_acc32_simd.py
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=import-self, invalid-name, unused-argument, too-many-lines, len-as-condition
+
+import logging
+
+logging.basicConfig(level=logging.ERROR)
+
+import tvm
+from tvm import relay
+from tvm import transform
+from tvm.relay import testing
+from tvm.testing.aot import AOTTestModel, compile_and_run
+from tvm.micro.testing.aot_test_utils import AOT_DEFAULT_RUNNER
+
+
+def benchmark_dense_int8_acc32(tgt, opt):
+
+    m = 1024
+    n = 1024
+    k = 1024
+
+    # Gops for gemm
+    gops_per_mm = 2.0 * (n * m * k) / 1e9
+
+    def verify(tgt, opt):
+
+        target = tvm.target.Target("llvm -mcpu=ivybridge -keys=cpu,fast-math")
+
+        ##
+        ## GRAPH
+        ##
+
+        # network graph
+        dat = relay.var("data", shape=(m, k), dtype="uint8")
+        weight = relay.var("weight", shape=(n, k), dtype="int8")
+        out = relay.nn.dense(dat, weight, out_dtype="int32")
+
+        # convert to relay IR
+        f = relay.Function(relay.analysis.free_vars(out), out)
+        mod, params = testing.create_workload(f)
+
+        ##
+        ## EVAL
+        ##
+
+        with relay.build_config(opt_level=3):
+            with tvm.transform.PassContext(opt_level=opt):
+                # build relay module
+                lib = relay.build(mod, target=target, params=None)
+
+        tensorized = False
+        if "@llvm.x86." in lib.lib.get_source():
+            tensorized = True
+
+        import numpy as np
+
+        np.random.seed(seed=None)
+        d_dtype = dat.type_annotation
+        w_dtype = weight.type_annotation
+        from tvm.topi.utils import get_const_tuple
+
+        X = np.random.randint(
+            low=0, high=127, size=get_const_tuple(d_dtype.shape), dtype=d_dtype.dtype
+        )
+        W = np.random.randint(
+            low=-63, high=63, size=get_const_tuple(w_dtype.shape), dtype=w_dtype.dtype
+        )
+
+        # build runtime module
+        dev = tvm.device(str(target), 0)
+        import tvm.contrib.graph_executor as runtime
+
+        module = runtime.GraphModule(lib["default"](dev))
+        module.set_input("data", tvm.nd.array(X))
+        params = {"weight": tvm.nd.array(W)}
+        module.set_input(**params)
+
+        # evaluate performance
+        ftimer = module.module.time_evaluator("run", dev, number=1, repeat=10)
+        result = np.array(ftimer().results)
+        gops_per_sec = gops_per_mm / np.mean(result)
+        print(
+            "Task tensorized: {%-5s} [%-45s], running time: %.3f ms, %.2f Gops/s"
+            % (tensorized, tgt, np.mean(result) * 1000, gops_per_sec)
+        )
+
+        # evaluate results
+        module.run()
+        module.get_output(0).asnumpy()
+        O = module.get_output(0).asnumpy()
+        tvm.testing.assert_allclose(O, np.dot(X.astype("int32"), W.T.astype("int32")), rtol=0)
+
+        return
+
+    verify(tgt, opt)
+
+
+@tvm.testing.requires_x86_vnni
+def test_fc_int8_acc32_x86_vnni():
+    benchmark_dense_int8_acc32("llvm -mcpu=cascadelake", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=cascadelake", opt=2)
+
+
+@tvm.testing.requires_x86_avx512
+def test_fc_int8_acc32_x86_avx512():
+    benchmark_dense_int8_acc32("llvm -mcpu=skylake-avx512", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=skylake-avx512 -keys=cpu,fast-math", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=skylake-avx512", opt=2)
+
+
+@tvm.testing.requires_x86
+def test_fc_int8_acc32_x86_simd():
+    benchmark_dense_int8_acc32("llvm -mcpu=ivybridge", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=ivybridge -keys=cpu,fast-math", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=haswell", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=haswell -keys=cpu,fast-math", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=ivybridge", opt=2)
+    benchmark_dense_int8_acc32("llvm -mcpu=haswell", opt=2)
+
+
+if __name__ == "__main__":
+    benchmark_dense_int8_acc32("llvm -mcpu=ivybridge", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=ivybridge -keys=cpu,fast-math", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=haswell", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=haswell -keys=cpu,fast-math", opt=3)
+    benchmark_dense_int8_acc32("llvm -mcpu=ivybridge", opt=2)
+    benchmark_dense_int8_acc32("llvm -mcpu=haswell", opt=2)

--- a/tests/python/unittest/test_tir_constructor.py
+++ b/tests/python/unittest/test_tir_constructor.py
@@ -44,6 +44,13 @@ def test_expr_constructor():
     assert isinstance(x, tvm.tir.StringImm)
     assert x.value == "xyza"
 
+    x = tvm.tir.ArrayIntImm([1, 2, 3])
+    assert isinstance(x, tvm.tir.ArrayIntImm)
+    assert x == [1, 2, 3]
+    assert x.data[-1] == 3
+    assert len(x.data) == 3
+    assert str(x.data) == str([1, 2, 3])
+
     x = tvm.tir.Cast("float32", tvm.tir.IntImm("uint32", 1))
     assert isinstance(x, tvm.tir.Cast)
     assert x.dtype == "float32"

--- a/tests/python/unittest/test_tir_nodes.py
+++ b/tests/python/unittest/test_tir_nodes.py
@@ -338,6 +338,13 @@ def test_equality_string_imm():
     x == y
 
 
+def test_equality_array_imm():
+    x = [1, 2, 3]
+    y = tvm.tir.ArrayIntImm(x)
+    x == y.data
+    x == y
+
+
 def test_prim_func():
     x = te.var("x")
     y = te.var("y")

--- a/tests/python/unittest/test_tir_op_types.py
+++ b/tests/python/unittest/test_tir_op_types.py
@@ -57,6 +57,27 @@ def test_tir_op_reinterpret():
     assert expr.op.name == "tir.reinterpret"
 
 
+def test_tir_op_zextend():
+    buffer = tir.decl_buffer((4, 4), "uint8", offset_factor=1)
+    vec = buffer.vload([0, 0], dtype="uint8x16")
+    expr = tir.zextend("uint16x8", vec)
+    assert expr.op.name == "tir.zextend"
+
+
+def test_tir_op_sextend():
+    buffer = tir.decl_buffer((4, 4), "uint8", offset_factor=1)
+    vec = buffer.vload([0, 0], dtype="uint8x16")
+    expr = tir.sextend("int16x8", vec)
+    assert expr.op.name == "tir.sextend"
+
+
+def test_tir_op_truncate():
+    buffer = tir.decl_buffer((4, 4), "uint16", offset_factor=1)
+    vec = buffer.vload([0, 0], dtype="uint16x16")
+    expr = tir.truncate("uint8x32", vec)
+    assert expr.op.name == "tir.truncate"
+
+
 def test_tir_op_isnullptr():
     x = tir.Var("x", dtype="int32")
     expr = tir.isnullptr(x)
@@ -300,6 +321,31 @@ def test_tir_op_vectorcombine():
     vec = buffer.vload([0, 0], dtype="int8x16")
     expr = tir.vectorcombine("int8x8", vec, vec)
     assert expr.op.name == "tir.vectorcombine"
+
+
+def test_tir_op_vectorpermute():
+    buffer = tir.decl_buffer((2, 2), "uint32", offset_factor=1)
+    vec = buffer.vload([0, 0], dtype="uint32x4")
+    expr = tir.vectorpermute("uint32x4", vec, [2, 3, 0, 1])
+    assert expr.op.name == "tir.vectorpermute"
+
+
+def test_tir_op_vectorshuffle():
+    buffer0 = tir.decl_buffer((2, 2), "uint32", offset_factor=1)
+    buffer1 = tir.decl_buffer((2, 2), "uint32", offset_factor=1)
+    vec0 = buffer0.vload([0, 0], dtype="uint32x4")
+    vec1 = buffer1.vload([0, 0], dtype="uint32x4")
+    expr = tir.vectorshuffle("uint32x4", vec0, vec1, [0, 1, 4, 5])
+    assert expr.op.name == "tir.vectorshuffle"
+
+
+def test_tir_op_atomic_add():
+    buffer0 = tir.decl_buffer((2, 2), "uint32", offset_factor=1)
+    buffer1 = tir.decl_buffer((2, 2), "uint32", offset_factor=1)
+    vec0 = buffer0.vload([0, 0], dtype="uint32x4")
+    vec1 = buffer1.vload([0, 0], dtype="uint32x4")
+    expr = tir.atomic_add("uint32x4", vec0, vec1)
+    assert expr.op.name == "tir.atomic_add"
 
 
 def test_tir_op_shift_left():

--- a/tests/python/unittest/test_tvmscript_printer_metadata.py
+++ b/tests/python/unittest/test_tvmscript_printer_metadata.py
@@ -43,5 +43,23 @@ def test_str_metadata():
     )
 
 
+def test_array_metadata():
+    arr_imm = T.ArrayIntImm([1, 2, 3])
+
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def foo() -> None:
+            A = arr_imm
+            B = arr_imm
+
+        @T.prim_func
+        def foo1() -> None:
+            A = arr_imm
+
+    printed_str = Module.script(verbose_expr=True)
+    assert printed_str.count("T.ArrayIntImm([1, 2, 3])") == 3
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/unittest/test_tvmscript_printer_tir.py
+++ b/tests/python/unittest/test_tvmscript_printer_tir.py
@@ -493,6 +493,11 @@ def test_string_imm():
     _assert_print(s, '"str"')
 
 
+def test_array_imm():
+    a = tir.ArrayIntImm([1, 2, 3])
+    _assert_print(a, "[1, 2, 3]")
+
+
 def test_cast():
     obj = tir.Cast("float64", tir.Var("a", "float32"))
     _assert_print(


### PR DESCRIPTION
This PR enhances x86 SIMD (u)int8 coverage for dense and conv2d operators.
It extends current SIMD support with avx2 & ssse3, and adds a new set of non-overflowing SIMD method.

---
#### Tracker:

- [ ] PR for TIR ```call_{pure}_llvm_intrin``` pretty print.
- [ ] PR for new TIR intrinsics
- [ ] PR for ```ArrayIntImm``` node

This PR will hold only the TOPI part.

---

#### Changes:

[x86][TOPI]
  * Extends [current tensorizer set](https://github.com/apache/tvm/blob/dc1b62916f68bf7b7f417eb4ea79bc75e83ec1a5/python/tvm/topi/x86/tensor_intrin.py#L130-L150), now called ```fast-math``` overflowing one, with ```avx2``` and ```ssse3```.
  * Adds a [new tensorizer set](https://github.com/apache/tvm/blob/dc1b62916f68bf7b7f417eb4ea79bc75e83ec1a5/python/tvm/topi/x86/tensor_intrin.py#L151-L198), a "precision" non-overflowing one, supporting: ```avx512```,  ```avx2``` and ```ssse3```.
  * Enable proper operator data alignment to gurantee any data (even smallest) will fit the SIMD vector width.

[TIR][LLVM]
 * Adds new TIR ops mapped to LLVM instrinsics: ```zextend```, ```sextend```, ```truncate``` for type conversions.
 * Adds new TIR ops mapped to LLVM instrinsics: ```vectorpermute```, ```vectorshuffle``` for vector manipulation.
 * The ```call_llvm_pure_intrin``` & ```call_llvm_intrin``` now holds instruction ```StringImm``` instead of ```IntImm``` abstract.
 * Enables TIR op ```atomic_add``` mapped to proper LLVM intrinsic guarnteed (best-effort) to lower to single instruction.


[TE]
 * Introduce new ```ArrayIntImm``` expression for small immediate list of integer constants.

[Target]
* Introduce a flag ```-key=cpu,fast-math``` to switch from the precise SIMD (default) to the overflowing SIMD set.

#### Performance

For the new avx2 & ssse3 the ```fast``` vs. ```precise``` SIMD sets:

```
$ python3 tests/python/contrib/test_gemm_acc32_simd.py
Task tensorized: {True } [llvm -mcpu=ivybridge                     ], running time: 3.655 ms, 587.58 Gops/s
Task tensorized: {True } [llvm -mcpu=ivybridge -keys=cpu,fast-math ], running time: 3.678 ms, 583.86 Gops/s
Task tensorized: {True } [llvm -mcpu=haswell                       ], running time: 3.708 ms, 579.09 Gops/s
Task tensorized: {True } [llvm -mcpu=haswell -keys=cpu,fast-math   ], running time: 3.668 ms, 585.52 Gops/s
Task tensorized: {False} [llvm -mcpu=ivybridge                     ], running time: 41.152 ms, 52.18 Gops/s
Task tensorized: {False} [llvm -mcpu=haswell                       ], running time: 41.194 ms, 52.13 Gops/s
```

#### Notes

* Precision (non ```fast-math```) is the default now.
* x86 ```amx``` and ```vnni``` schedules remains unchanged, their specific intrinsics never overflows.
* The ```zextend```, ```sextend```, ```truncate``` lowers on x86 into single specialized instruction e.g: ```punpcklwd``` & ```punpckhwd```
* The ```vectorpermute```, ```vectorshuffle``` also lowers on x86 into appropriate single specialized instruction.
* ```ArrayIntImm``` is for the new ops: ```tir.vectorpermute("int32x8", whatever_vector, [0, 1, 4, 5, 2, 3, 6, 7])```
* The ```fast-math``` mode will always warn the user: 
    ```Using `fast-math` may overflow, make sure ranges for either data is [0,128] or weight is [-64,+64]```
* TIR printer (for debug purpose) will now list the very name of the instruction, not an abstract IntImm:
    ```{...} T.call_llvm_pure_intrin("int32x4", "llvm.x86.sse2.pmadd.wd", T.uint32(2) {....}```

#### Samples

Lowering results for the ```ssse3``` case.


The ```precise``` one:

```
@I.ir_module
class Module:
    @T.prim_func
    def tvmgen_default_fused_nn_contrib_dense_pack(
                    p0: T.Buffer((4, 4), "uint8"), 
                    p1: T.Buffer((1, 1, 4, 4), "int8"),
                    compute: T.Buffer((4, 4), "int32")):
        T.func_attr({"from_legacy_te_schedule": T.bool(True), "tir.noalias": T.bool(True)})
        for i_inner in range(4):
            compute_1 = T.Buffer((16,), "int32", data=compute.data)
            compute_1[i_inner * 4:i_inner * 4 + 4] = T.Broadcast(0, 4)
            p0_1 = T.Buffer((16,), "uint8", data=p0.data)
            p1_1 = T.Buffer((16,), "int8", data=p1.data)
            compute_1[i_inner * 4:i_inner * 4 + 4] = 
              T.call_llvm_pure_intrin("int32x4", "llvm.x86.ssse3.phadd.d.128", T.uint32(2), 
                T.call_llvm_pure_intrin("int32x4", "llvm.x86.sse2.pmadd.wd", T.uint32(2), 
                  T.vectorlow("void", T.zextend("int16x16", 
                    T.reinterpret("int8x16", T.Broadcast(
                      T.reinterpret("int32", p0_1[i_inner * 4:i_inner * 4 + 4]), 4)))),
                        T.vectorlow("void", T.sextend("int16x16", p1_1[0:16]))),
                          T.call_llvm_pure_intrin("int32x4", "llvm.x86.sse2.pmadd.wd", T.uint32(2),
                            T.vectorhigh("void", T.zextend("int16x16", T.reinterpret("int8x16", 
                              T.Broadcast(T.reinterpret("int32", p0_1[i_inner * 4:i_inner * 4 + 4]), 4)))),
                                T.vectorhigh("void", T.sextend("int16x16", p1_1[0:16])))) 
                                  + compute_1[i_inner * 4:i_inner * 4 + 4]
```

```
000000000001e90 <tvmgen_default_fused_nn_contrib_dense_pack_compute_>:
    1e90:	c4 e2 79 18 16       	vbroadcastss (%rsi),%xmm2
    1e95:	c5 f9 ef c0          	vpxor  %xmm0,%xmm0,%xmm0
    1e99:	c5 e9 68 d8          	vpunpckhbw %xmm0,%xmm2,%xmm3
    1e9d:	c4 e2 79 20 4a 08    	vpmovsxbw 0x8(%rdx),%xmm1
    1ea3:	c4 e2 79 30 e2       	vpmovzxbw %xmm2,%xmm4
    1ea8:	c4 e2 79 20 12       	vpmovsxbw (%rdx),%xmm2
    1ead:	c5 d9 f5 e2          	vpmaddwd %xmm2,%xmm4,%xmm4
    1eb1:	c5 e1 f5 d9          	vpmaddwd %xmm1,%xmm3,%xmm3
    1eb5:	c4 e2 59 02 eb       	vphaddd %xmm3,%xmm4,%xmm5
    {...}

define internal fastcc void @tvmgen_default_fused_nn_contrib_dense_pack_compute {
entry:
  {...}
  %3 = load i32, ptr %1, align 64, !tbaa !310
  %4 = insertelement <4 x i32> undef, i32 %3, i64 0
  %5 = bitcast <4 x i32> %4 to <16 x i8>
  %6 = shufflevector <16 x i8> %5, <16 x i8> poison, <16 x i32> 
           <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3, 
            i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
  %7 = zext <16 x i8> %6 to <16 x i16>
  %8 = shufflevector <16 x i16> %7, <16 x i16> poison, <8 x i32>
           <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
  %9 = load <16 x i8>, ptr %2, align 64, !tbaa !312
  %10 = sext <16 x i8> %9 to <16 x i16>
  %11 = shufflevector <16 x i16> %10, <16 x i16> poison, <8 x i32>
             <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
  %12 = tail call <4 x i32> @llvm.x86.sse2.pmadd.wd(<8 x i16> %8, <8 x i16> %11)
  %13 = shufflevector <16 x i16> %7, <16 x i16> poison, <8 x i32>
              <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
  %14 = shufflevector <16 x i16> %10, <16 x i16> poison, <8 x i32>
             <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
  %15 = tail call <4 x i32> @llvm.x86.sse2.pmadd.wd(<8 x i16> %13, <8 x i16> %14)
  %16 = tail call <4 x i32> @llvm.x86.ssse3.phadd.d.128(<4 x i32> %12, <4 x i32> %15)
  %17 = getelementptr inbounds i8, ptr %1, i64 4
  {...}
```

The ```fast-math``` one:
```
@I.ir_module
class Module:
    @T.prim_func
    def tvmgen_default_fused_nn_contrib_dense_pack(
                  p0: T.Buffer((4, 4), "uint8"), 
                  p1: T.Buffer((1, 1, 4, 4), "int8"), 
                  compute: T.Buffer((4, 4), "int32")):
        T.func_attr({"from_legacy_te_schedule": T.bool(True), "tir.noalias": T.bool(True)})
        for i_inner in range(4):
            compute_1 = T.Buffer((16,), "int32", data=compute.data)
            compute_1[i_inner * 4:i_inner * 4 + 4] = T.Broadcast(0, 4)
            p0_1 = T.Buffer((16,), "uint8", data=p0.data)
            p1_1 = T.Buffer((16,), "int8", data=p1.data)
            compute_1[i_inner * 4:i_inner * 4 + 4] = 
              T.call_llvm_pure_intrin("int32x4", "llvm.x86.sse2.pmadd.wd", T.uint32(2), 
                T.call_llvm_pure_intrin("int16x8", "llvm.x86.ssse3.pmadd.ub.sw.128", T.uint32(2), 
                  T.reinterpret("int8x16", T.Broadcast(
                    T.reinterpret("int32", p0_1[i_inner * 4:i_inner * 4 + 4]), 4)), p1_1[0:16]), 
                      T.Broadcast(T.int16(1), 8)) + compute_1[i_inner * 4:i_inner * 4 + 4]
```

```
0000000000001e90 <tvmgen_default_fused_nn_contrib_dense_pack_compute_>:
    1e90:	c4 e2 79 18 06       	vbroadcastss (%rsi),%xmm0
    1e95:	c5 f9 6f 12          	vmovdqa (%rdx),%xmm2
    1e99:	c5 f9 6f 4a 10       	vmovdqa 0x10(%rdx),%xmm1
    1e9e:	c4 e2 79 04 da       	vpmaddubsw %xmm2,%xmm0,%xmm3
    1ea3:	c4 e2 79 18 05 e4 11 	vbroadcastss 0x11e4(%rip),%xmm0        # 3090 <_fini+0x620>
    1eaa:	00 00 
    1eac:	c5 e1 f5 d8          	vpmaddwd %xmm0,%xmm3,%xmm3

define internal fastcc void @tvmgen_default_fused_nn_contrib_dense_pack_compute_{
entry:
  {...}
  %3 = load i32, ptr %1, align 64, !tbaa !310
  %4 = insertelement <4 x i32> undef, i32 %3, i64 0
  %5 = bitcast <4 x i32> %4 to <16 x i8>
  %6 = shufflevector <16 x i8> %5, <16 x i8> poison, <16 x i32>
            <i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3,
            i32 0, i32 1, i32 2, i32 3, i32 0, i32 1, i32 2, i32 3>
  %7 = load <16 x i8>, ptr %2, align 64, !tbaa !312
  %8 = tail call <8 x i16> @llvm.x86.ssse3.pmadd.ub.sw.128(<16 x i8> %6, <16 x i8> %7)
  %9 = tail call <4 x i32> @llvm.x86.sse2.pmadd.wd(<8 x i16> %8, <8 x i16> 
            <i16 1, i16 1, i16 1, i16 1, i16 1, i16 1, i16 1, i16 1>)
  %10 = getelementptr inbounds i8, ptr %1, i64 4
  {...}
```

#### Credits

There is a compact full x86 SIMD table guide [here](https://www.officedaytime.com/simd512e/).
This work here follows some suggestions from intel's [onednn int8 compute notes](https://oneapi-src.github.io/oneDNN/v1.4/dev_guide_int8_computations.html).


#### Next

(WiP) This work here will be extended to metaschedule auto-tensorization.
(WiP) Will try enable ```int4``` (not native) using best possible SIMD bit manipulation.


---

Cc: @masahi , @anijain2305, @jianyuh, @Qianshui-Jiang, @kparzysz-quic , @junrushao , @tqchen , @elvin-n , @vvchernov , @echuraev

