### PR TITLE
[Unity] Fix bug in onnx_frontend when multi inputs have same symbolic shape

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -114,7 +114,8 @@ def get_info(info_proto: onnx.onnx_ml_pb2.ValueInfoProto, value_dict={}) -> Tupl
     Returns
     -------
     Tuple[str, List, str, List]
-        The name, shape, type, and shape name of the ValueInfoProto.
+        The name, shape, type, and shape name of the ValueInfoProto, and the
+        value_dict.
     """
     shape = []
     shape_name = []
@@ -135,7 +136,7 @@ def get_info(info_proto: onnx.onnx_ml_pb2.ValueInfoProto, value_dict={}) -> Tupl
         dtype = get_type(info_proto.type.tensor_type.elem_type)
     else:
         dtype = None
-    return name, shape, dtype, shape_name
+    return name, shape, dtype, shape_name, value_dict
 
 
 def get_numpy(tensor_proto: onnx.onnx_ml_pb2.TensorProto) -> _np.ndarray:
@@ -2048,7 +2049,7 @@ class ONNXGraphImporter:
         for i in graph.input:
             # from onnx v0.2, GraphProto.input has type ValueInfoProto,
             #  and the name is 'i.name'
-            i_name, i_shape, d_type, i_shape_name = get_info(i, value_dict)
+            i_name, i_shape, d_type, i_shape_name, value_dict = get_info(i, value_dict)
             if i_name not in self._nodes:
                 self._num_input += 1
                 self._input_names.append(i_name)

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -101,8 +101,9 @@ def get_constant(
 
 
 def get_info(
-    info_proto: onnx.onnx_ml_pb2.ValueInfoProto, value_dict={}
-) -> Tuple[str, List, str, List]:
+    info_proto: onnx.onnx_ml_pb2.ValueInfoProto,
+    value_dict: Dict[str, tvm.tir.SizeVar]
+) -> Tuple[str, List, str, List, Dict]:
     """Extract the shape from a ValueInfoProto.
 
     Parameters

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -125,7 +125,7 @@ def get_info(
         name = dim.dim_param
         value = dim.dim_value
         if value is None or value == 0:
-            if name not in value_dict:
+            if name not in value_dict or name == '?':
                 value_dict[name] = tvm.tir.SizeVar(name, "int64")
             value = value_dict[name]
             shape_name.append(name)

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -125,7 +125,7 @@ def get_info(
         name = dim.dim_param
         value = dim.dim_value
         if value is None or value == 0:
-            if name not in value_dict or name == '?':
+            if name not in value_dict or name == "?":
                 value_dict[name] = tvm.tir.SizeVar(name, "int64")
             value = value_dict[name]
             shape_name.append(name)

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -101,8 +101,7 @@ def get_constant(
 
 
 def get_info(
-    info_proto: onnx.onnx_ml_pb2.ValueInfoProto,
-    value_dict: Dict[str, tvm.tir.SizeVar]
+    info_proto: onnx.onnx_ml_pb2.ValueInfoProto, value_dict: Dict[str, tvm.tir.SizeVar]
 ) -> Tuple[str, List, str, List, Dict]:
     """Extract the shape from a ValueInfoProto.
 
@@ -116,7 +115,7 @@ def get_info(
 
     Returns
     -------
-    Tuple[str, List, str, List]
+    Tuple[str, List, str, List, Dict]
         The name, shape, type, and shape name of the ValueInfoProto, and the
         value_dict.
     """

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -100,7 +100,9 @@ def get_constant(
         return var
 
 
-def get_info(info_proto: onnx.onnx_ml_pb2.ValueInfoProto, value_dict={}) -> Tuple[str, List, str, List]:
+def get_info(
+    info_proto: onnx.onnx_ml_pb2.ValueInfoProto, value_dict={}
+) -> Tuple[str, List, str, List]:
     """Extract the shape from a ValueInfoProto.
 
     Parameters

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -1688,5 +1688,21 @@ def test_symbolic_shape_deduction():
     # tvm.ir.assert_structural_equal(expected, tvm_model["main"])
 
 
+def test_multi_inputs_with_same_symbolic_shape():
+    concat_node = helper.make_node("Concat", ["data1", "data2"], ["output"], axis=1)
+
+    graph = helper.make_graph(
+        [concat_node],
+        "test_multi_symbolic_shape_input",
+        inputs=[
+            helper.make_tensor_value_info("data1", TensorProto.FLOAT, ["batch", 1]),
+            helper.make_tensor_value_info("data2", TensorProto.FLOAT, ["batch", 1]),
+        ],
+        outputs=[helper.make_tensor_value_info("output", TensorProto.FLOAT, ["batch", 2])],
+    )
+    model = helper.make_model(graph, producer_name="test_multi_symbolic_shape_input")
+    check_correctness(model)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
When multi inputs have same symbolic shape, the function **from_onnx** will cause  

> AssertionError:` For Expr having ShapeStructInfo, emit_te now only supports ShapeExpr

This PR uses a dictionary mapping from the name of ValueInfoProto to SizeVar when parse_graph_input. ValueInfoProto with same name will map to same SizeVar.