### PR TITLE
[LLVM] Fix for llvm CodeGenOpt API change

### DIFF
--- a/src/target/llvm/codegen_amdgpu.cc
+++ b/src/target/llvm/codegen_amdgpu.cc
@@ -302,9 +302,12 @@ runtime::Module BuildAMDGPU(IRModule mod, Target target) {
 #elif TVM_LLVM_VERSION <= 90
   ICHECK(tm->addPassesToEmitFile(pass, destObj, nullptr, llvm::TargetMachine::CGFT_ObjectFile) == 0)
       << "Cannot emit target CGFT_ObjectFile";
-#else
+#elif TVM_LLVM_VERSION <= 170
   ICHECK(tm->addPassesToEmitFile(pass, destObj, nullptr, llvm::CGFT_ObjectFile) == 0)
       << "Cannot emit target CGFT_ObjectFile";
+#else
+  ICHECK(tm->addPassesToEmitFile(pass, destObj, nullptr, llvm::CodeGenFileType::ObjectFile) == 0)
+      << "Cannot emit target CodeGenFileType::ObjectFile";
 #endif
   pass.run(*mObj);
   std::string obj(dataObj.begin(), dataObj.end());
@@ -317,8 +320,12 @@ runtime::Module BuildAMDGPU(IRModule mod, Target target) {
   ICHECK(tm->addPassesToEmitFile(passAsm, destAsm, nullptr,
                                  llvm::TargetMachine::CGFT_AssemblyFile) == 0)
       << "Cannot emit target CGFT_AssemblyFile";
-#else
+#elif TVM_LLVM_VERSION <= 170
   ICHECK(tm->addPassesToEmitFile(passAsm, destAsm, nullptr, llvm::CGFT_AssemblyFile) == 0)
+      << "Cannot emit target CGFT_AssemblyFile";
+#else
+  ICHECK(tm->addPassesToEmitFile(passAsm, destAsm, nullptr, llvm::CodeGenFileType::AssemblyFile) ==
+         0)
       << "Cannot emit target CGFT_AssemblyFile";
 #endif
   passAsm.run(*mAsm);

--- a/src/target/llvm/codegen_hexagon.cc
+++ b/src/target/llvm/codegen_hexagon.cc
@@ -588,8 +588,11 @@ runtime::Module BuildHexagon(IRModule mod, Target target) {
 #if TVM_LLVM_VERSION <= 90
       auto ft = cgft == Asm ? llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile
                             : llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile;
-#else
+#elif TVM_LLVM_VERSION <= 170
       auto ft = cgft == Asm ? llvm::CGFT_AssemblyFile : llvm::CGFT_ObjectFile;
+#else
+      auto ft =
+          cgft == Asm ? llvm::CodeGenFileType::AssemblyFile : llvm::CodeGenFileType::ObjectFile;
 #endif
 
       llvm::SmallString<16384> ss;  // Will grow on demand.

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -429,6 +429,7 @@ void CodeGenLLVM::Optimize() {
 
   // Construct the default pass pipeline depending on the opt level.
   std::string pipeline;
+#if TVM_LLVM_VERSION <= 170
   switch (llvm_target_->GetOptLevel()) {
     case llvm::CodeGenOpt::Level::None:
       pipeline = "default<O0>";
@@ -444,6 +445,23 @@ void CodeGenLLVM::Optimize() {
       pipeline = "default<O3>";
       break;
   }
+#else
+  switch (llvm_target_->GetOptLevel()) {
+    case llvm::CodeGenOptLevel::None:
+      pipeline = "default<O0>";
+      break;
+    case llvm::CodeGenOptLevel::Less:
+      pipeline = "default<O1>";
+      break;
+    case llvm::CodeGenOptLevel::Default:
+      pipeline = "default<O2>";
+      break;
+    default:
+      // CodeGenOptLevel::Aggressive
+      pipeline = "default<O3>";
+      break;
+  }
+#endif
 
   llvm::StandardInstrumentations si(*llvm_target_->GetContext(), debug_logging, verify_each);
 #if LLVM_VERSION_MAJOR >= 17

--- a/src/target/llvm/codegen_nvptx.cc
+++ b/src/target/llvm/codegen_nvptx.cc
@@ -345,9 +345,12 @@ runtime::Module BuildNVPTX(IRModule mod, Target target) {
   ICHECK(tm->addPassesToEmitFile(pass, dest_ptx, nullptr, llvm::TargetMachine::CGFT_AssemblyFile) ==
          0)
       << "Cannot emit target CGFT_ObjectFile";
-#else
+#elif TVM_LLVM_VERSION <= 170
   ICHECK(tm->addPassesToEmitFile(pass, dest_ptx, nullptr, llvm::CGFT_AssemblyFile) == 0)
       << "Cannot emit target CGFT_ObjectFile";
+#else
+  ICHECK(tm->addPassesToEmitFile(pass, dest_ptx, nullptr, llvm::CodeGenFileType::AssemblyFile) == 0)
+      << "Cannot emit target CodeGenFileType::ObjectFile";
 #endif
   pass.run(*module);
   std::string ptx(data_ptx.begin(), data_ptx.end());

--- a/src/target/llvm/llvm_instance.h
+++ b/src/target/llvm/llvm_instance.h
@@ -216,7 +216,11 @@ class LLVMTargetInfo {
    * \brief Get the LLVM optimization level
    * \return optimization level for this target
    */
+#if TVM_LLVM_VERSION <= 170
   llvm::CodeGenOpt::Level GetOptLevel() const { return opt_level_; }
+#else
+  llvm::CodeGenOptLevel GetOptLevel() const { return opt_level_; }
+#endif
 
   /*!
    * \class Option
@@ -312,7 +316,11 @@ class LLVMTargetInfo {
   std::vector<Option> llvm_options_;
   llvm::TargetOptions target_options_;
   llvm::FastMathFlags fast_math_flags_;
+#if TVM_LLVM_VERSION <= 170
   llvm::CodeGenOpt::Level opt_level_;
+#else
+  llvm::CodeGenOptLevel opt_level_;
+#endif
   llvm::Reloc::Model reloc_model_ = llvm::Reloc::PIC_;
   llvm::CodeModel::Model code_model_ = llvm::CodeModel::Small;
   std::shared_ptr<llvm::TargetMachine> target_machine_;


### PR DESCRIPTION
This patch fixes the errors caused due to recent API change from LLVM for CodeGenOpt made in [this PR](https://github.com/llvm/llvm-project/pull/66295)