### PR TITLE
[Fix][Unity] Fix TVMError when using relax to load model with Trilu operator

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -637,6 +637,11 @@ class Trilu(OnnxOpConverter):
         x = inputs[0]
         k = inputs[1] if len(inputs) > 1 else 0
 
+        if isinstance(k, relax.Var) and k.name_hint in params:
+            k = get_constant(k,params)
+        else:
+            k = 0
+
         if upper:
             return relax.op.triu(x, k)
         else:

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -647,6 +647,8 @@ class Trilu(OnnxOpConverter):
 
         if isinstance(k, relax.Var) and k.name_hint in params:
             k = get_constant(k, params)
+        elif isinstance(k, relax.Constant):
+            k = int(k.data.numpy()[0])
         else:
             k = 0
 

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -638,7 +638,7 @@ class Trilu(OnnxOpConverter):
         k = inputs[1] if len(inputs) > 1 else 0
 
         if isinstance(k, relax.Var) and k.name_hint in params:
-            k = get_constant(k,params)
+            k = get_constant(k, params)
         else:
             k = 0
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5427,7 +5427,7 @@ def test_load_trilu():
             outputs=[helper.make_tensor_value_info("y", onnx.TensorProto.DOUBLE, input_shape)],
         )
         return helper.make_model(graph)
-    
+
     def create_trilu_model_const_k():
         input_shape = [2, 3, 3]
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5427,8 +5427,25 @@ def test_load_trilu():
             outputs=[helper.make_tensor_value_info("y", onnx.TensorProto.DOUBLE, input_shape)],
         )
         return helper.make_model(graph)
+    
+    def create_trilu_model_const_k():
+        input_shape = [2, 3, 3]
+
+        graph = helper.make_graph(
+            [
+                make_constant_node("k", onnx.TensorProto.INT32, [1], [1]),
+                helper.make_node("Trilu", inputs=["x", "k"], outputs=["y"]),
+            ],
+            "trilu_graph",
+            inputs=[
+                helper.make_tensor_value_info("x", onnx.TensorProto.DOUBLE, input_shape),
+            ],
+            outputs=[helper.make_tensor_value_info("y", onnx.TensorProto.DOUBLE, input_shape)],
+        )
+        return helper.make_model(graph)
 
     from_onnx(create_trilu_model())
+    from_onnx(create_trilu_model_const_k())
 
 
 @tvm.testing.parametrize_targets

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -5409,6 +5409,28 @@ def test_load_cumsum():
     from_onnx(create_cumsum_model())
 
 
+def test_load_trilu():
+    """test_load_trilu"""
+
+    def create_trilu_model():
+        input_shape = [2, 3, 3]
+
+        graph = helper.make_graph(
+            [
+                helper.make_node("Trilu", inputs=["x", "k"], outputs=["y"]),
+            ],
+            "trilu_graph",
+            inputs=[
+                helper.make_tensor_value_info("x", onnx.TensorProto.DOUBLE, input_shape),
+                helper.make_tensor_value_info("k", onnx.TensorProto.INT32, [1], "k"),
+            ],
+            outputs=[helper.make_tensor_value_info("y", onnx.TensorProto.DOUBLE, input_shape)],
+        )
+        return helper.make_model(graph)
+
+    from_onnx(create_trilu_model())
+
+
 @tvm.testing.parametrize_targets
 def test_cumsum(target, dev):
     """test_cumsum"""


### PR DESCRIPTION
Sets the default value 0 for the k variable, if the value has not been previously set.
This is a code patch for fixing this issue: https://github.com/apache/tvm/issues/15729