### PR TITLE
[Unity] [Bugfix] Fix bug in interpolate operator's default mode parameter in PyTorch frontend

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1088,7 +1088,7 @@ class TorchFXImporter:
         method = (
             node.args[3]
             if len(node.args) > 3
-            else (node.kwargs["method"] if "method" in node.kwargs else "nearest")
+            else (node.kwargs["mode"] if "mode" in node.kwargs else "nearest")
         )
         align_corners = (
             node.args[4]

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -2336,6 +2336,37 @@ def test_interpolate():
 
     verify_model(Interpolate(), input_info, {}, expected1)
 
+    class Interpolate2(Module):
+        def forward(self, input):
+            return torch.nn.functional.interpolate(input, size=None, scale_factor=2.0, mode='bilinear', align_corners=False,)
+
+    @tvm.script.ir_module
+    class expected2:
+        @R.function
+        def main(
+            input_1: R.Tensor((1, 3, 10, 10), dtype="float32")
+        ) -> R.Tensor((1, 3, 20, 20), dtype="float32"):
+            # block 0
+            with R.dataflow():
+                lv: R.Tensor((1, 3, 20, 20), dtype="float32") = R.image.resize2d(
+                    input_1,
+                    (20, 20),
+                    roi=[0.000000, 0.000000, 0.000000, 0.000000],
+                    layout="NCHW",
+                    method="linear",
+                    coordinate_transformation_mode="half_pixel",
+                    rounding_method="round",
+                    cubic_alpha=-0.5,
+                    cubic_exclude=0,
+                    extrapolation_value=0,
+                    out_dtype="",
+                )
+                gv: R.Tensor((1, 3, 20, 20), dtype="float32") = lv
+                R.output(gv)
+            return gv
+
+    verify_model(Interpolate2(), input_info, {}, expected2)
+
 
 def test_addmm():
     input_info = [

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -2338,7 +2338,13 @@ def test_interpolate():
 
     class Interpolate2(Module):
         def forward(self, input):
-            return torch.nn.functional.interpolate(input, size=None, scale_factor=2.0, mode='bilinear', align_corners=False,)
+            return torch.nn.functional.interpolate(
+                input,
+                size=None,
+                scale_factor=2.0,
+                mode='bilinear',
+                align_corners=False,
+            )
 
     @tvm.script.ir_module
     class expected2:

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -2342,7 +2342,7 @@ def test_interpolate():
                 input,
                 size=None,
                 scale_factor=2.0,
-                mode='bilinear',
+                mode="bilinear",
                 align_corners=False,
             )
 


### PR DESCRIPTION
This PR fixes a bug in the interpolate operator of the PyTorch frontend in TVM. The bug was caused by incorrectly using the `method` keyword instead of the `mode` keyword when retrieving the default value for the mode parameter. This resulted in incorrect computation of `interpolate` results.

This bug can be reproduced by the below script:
```python
import torch
from torch import fx
from torch.nn import Module
import tvm
import tvm.testing
from tvm import relax
from tvm.relax.frontend.torch import from_fx

input_data = torch.randn([1, 2, 4, 4], dtype=torch.float32)
class interpolate(Module):
    def forward(self, input):
        return torch.nn.functional.interpolate(input, size=None, scale_factor=2.0, mode='bilinear', align_corners=False,)

model = interpolate().float()
input_data = [input_data]
input_names = [f"input{idx}" for idx, _ in enumerate(input_data)]
input_info = list(zip([list(inp.shape) for inp in input_data], [str(inp.dtype) for inp in input_data]))
fx_model : torch.fx.GraphModule = fx.symbolic_trace(model)
with torch.no_grad():
    mod = from_fx(fx_model, input_info)

if torch.cuda.is_available():
    model = model.cuda()
    torch_input = [inp.cuda() for inp in input_data]

with torch.no_grad():
    torch_outputs = model(*[input.clone() for input in input_data])
torch_outputs = (torch_outputs.cpu().numpy(),)

compiled_input = dict(zip(input_names, [inp.clone().cpu().numpy() for inp in input_data]))
tvm_input = {}
for name, inp in compiled_input.items():
    tvm_input[name] = tvm.nd.array(inp)
    target = tvm.target.Target("llvm", host="llvm")
    mod = relax.transform.LegalizeOps()(mod)
    ex = relax.build(mod, target)
    vm = relax.VirtualMachine(ex, tvm.cpu())

    tvm_outputs = vm["main"](*[tvm_input[name] for name in input_names])
    tvm_outputs = [tvm_outputs]

for i, torch_output in enumerate(torch_outputs):
    output = tvm_outputs[i].numpy()
    tvm.testing.assert_allclose(torch_output, output, rtol=1e-5, atol=1e-5)
```

And here is the traceback information:
```
Traceback (most recent call last):
...  
    tvm.testing.assert_allclose(torch_output, output, rtol=1e-5, atol=1e-5)
  File "/workplace/software/tvm/tvm/python/tvm/testing/utils.py", line 120, in assert_allclose
    np.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol, verbose=True)
  File "/workplace/software/miniconda3/envs/tflite/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 1527, in assert_allclose
    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
  File "/workplace/software/miniconda3/envs/tflite/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 844, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=1e-05, atol=1e-05

Mismatched elements: 120 / 128 (93.8%)
Max absolute difference: 1.2100129
Max relative difference: 39.08069
 x: array([[[[-0.407674, -0.087851,  0.551796,  0.303579, -0.832501,
          -0.630166,  0.910585,  1.680961],
         [-0.152558, -0.054653,  0.141159, -0.0371  , -0.589427,...
 y: array([[[[-0.407674, -0.407674,  0.871619,  0.871619, -1.400542,
          -1.400542,  1.680961,  1.680961],
         [-0.407674, -0.407674,  0.871619,  0.871619, -1.400542,...
```