### PR TITLE
[Unity] [Bugfix] Fix TypeError in interpolate caused by scale_factor as tuple

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1118,7 +1118,9 @@ class TorchFXImporter:
             assert isinstance(shape, relax.ShapeExpr)
             if isinstance(scale_factor, tuple):
                 assert len(scale_factor) == len(shape) - 2
-                size = tuple(int(shape[i].value * scale_factor[i - 2]) for i in range(2, len(shape)))
+                size = tuple(
+                    int(shape[i].value * scale_factor[i - 2]) for i in range(2, len(shape))
+                )
             else:
                 size = tuple(int(shape[i].value * scale_factor) for i in range(2, len(shape)))
 

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1116,7 +1116,11 @@ class TorchFXImporter:
         if size is None:
             shape = self.shape_of(data)
             assert isinstance(shape, relax.ShapeExpr)
-            size = tuple(int(shape[i].value * scale_factor) for i in range(2, len(shape)))
+            if isinstance(scale_factor, tuple):
+                assert len(scale_factor) == len(shape) - 2
+                size = tuple(int(shape[i].value * scale_factor[i - 2]) for i in range(2, len(shape)))
+            else:
+                size = tuple(int(shape[i].value * scale_factor) for i in range(2, len(shape)))
 
         if method.startswith("nearest"):
             method = "nearest_neighbor"

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -2336,6 +2336,43 @@ def test_interpolate():
 
     verify_model(Interpolate(), input_info, {}, expected1)
 
+    class Interpolate3(Module):
+        def forward(self, input):
+            return torch.nn.functional.interpolate(
+                input,
+                size=None,
+                scale_factor=(2.0, 1.0),
+                mode="bilinear",
+                align_corners=False,
+            )
+
+    @tvm.script.ir_module
+    class expected3:
+        @R.function
+        def main(
+            input_1: R.Tensor((1, 3, 10, 10), dtype="float32")
+        ) -> R.Tensor((1, 3, 20, 10), dtype="float32"):
+            # block 0
+            with R.dataflow():
+                lv: R.Tensor((1, 3, 20, 10), dtype="float32") = R.image.resize2d(
+                    input_1,
+                    (20, 10),
+                    roi=[0.000000, 0.000000, 0.000000, 0.000000],
+                    layout="NCHW",
+                    method="linear",
+                    coordinate_transformation_mode="half_pixel",
+                    rounding_method="round",
+                    cubic_alpha=-0.5,
+                    cubic_exclude=0,
+                    extrapolation_value=0,
+                    out_dtype="",
+                )
+                gv: R.Tensor((1, 3, 20, 10), dtype="float32") = lv
+                R.output(gv)
+            return gv
+
+    verify_model(Interpolate3(), input_info, {}, expected3)
+
 
 def test_addmm():
     input_info = [


### PR DESCRIPTION
This pull request addresses a TypeError that occurs in the interpolate function when the scale_factor parameter is of type tuple. The current implementation fails to handle cases where scale_factor is a tuple, resulting in the error message: "TypeError: int() argument must be a string, a bytes-like object or a number, not 'list'."

This patch allows the interpolate function to handle both scalar and tuple values for the scale_factor parameter without raising a TypeError.

And this bug can be reproduced by the following script:
```python
import torch
from torch import fx
from torch.nn import Module
import tvm
from tvm import relax
from tvm.relax.frontend.torch import from_fx

input_data = torch.randn([1, 2, 4, 4], dtype=torch.float32)
class interpolate(Module):
    def forward(self, input):
        return torch.nn.functional.interpolate(input, size=None, scale_factor=(2.0, 1.0), mode='bilinear', align_corners=False,)

model = interpolate().float()
input_data = [input_data]
input_info = list(zip([list(inp.shape) for inp in input_data], [str(inp.dtype) for inp in input_data]))
fx_model : torch.fx.GraphModule = fx.symbolic_trace(model)
with torch.no_grad():
    mod = from_fx(fx_model, input_info)
```