### PR TITLE
[Unity][MSC][Bugfix] Trilu bugfix && special ops support

### DIFF
--- a/python/tvm/contrib/msc/core/codegen/codegen.py
+++ b/python/tvm/contrib/msc/core/codegen/codegen.py
@@ -142,7 +142,7 @@ def relay_to_relax(
     params: dict of <string:tvm.ndarray>
         The parameters of the IRModule.
     trans_config: dict
-        The config for transfrorm IRModule.
+        The config for transform IRModule.
     build_config: dict
         The config for build MSCGraph.
     opt_config: dict

--- a/python/tvm/contrib/msc/core/ir/translate.py
+++ b/python/tvm/contrib/msc/core/ir/translate.py
@@ -85,7 +85,7 @@ def from_relax(
     params: dict of <string:tvm.ndarray>
         The parameters of the IRModule.
     trans_config: dict
-        The config for transfrorm IRModule.
+        The config for transform IRModule.
     build_config: dict
         The config for build MSCGraph.
     opt_config: dict
@@ -196,7 +196,7 @@ def from_relay(
     params: dict of <string:tvm.ndarray>
         The parameters of the IRModule.
     trans_config: dict
-        The config for transfrorm IRModule.
+        The config for transform IRModule.
     build_config: dict
         The config for build MSCGraph.
     opt_config: dict
@@ -281,7 +281,7 @@ def byoc_partition(
     mod: IRModule
         The IRModule of relax.
     trans_config: dict
-        The config for transfrorm IRModule.
+        The config for transform IRModule.
     params: dict of <string:tvm.ndarray>
         The parameters of the IRModule.
     build_config: dict

--- a/python/tvm/contrib/msc/framework/tensorflow/frontend/translate.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/frontend/translate.py
@@ -49,7 +49,7 @@ def from_tensorflow(
     via_relax: bool
         Whether translate torch to relax.
     trans_config: dict
-        The config for transfrorm IRModule.
+        The config for transform IRModule.
     build_config: dict
         The config for build MSCGraph.
     opt_config: dict

--- a/python/tvm/contrib/msc/framework/torch/frontend/translate.py
+++ b/python/tvm/contrib/msc/framework/torch/frontend/translate.py
@@ -50,7 +50,7 @@ def from_torch(
     via_relax: bool
         Whether translate torch to relax.
     trans_config: dict
-        The config for transfrorm IRModule.
+        The config for transform IRModule.
     build_config: dict
         The config for build MSCGraph.
     opt_config: dict

--- a/src/contrib/msc/core/codegen/base_codegen.h
+++ b/src/contrib/msc/core/codegen/base_codegen.h
@@ -45,7 +45,7 @@ using namespace tvm::script::printer;
 /*!
  * \brief CodeGen for MSCJoint op
  */
-template <typename ConfigType>
+template <typename ConfigType, typename HelperType>
 class BaseOpCode {
  public:
   /*!
@@ -108,7 +108,7 @@ class BaseOpCode {
 /*!
  * \brief CodeGen for MSCGraph
  */
-template <typename ConfigType>
+template <typename ConfigType, typename HelperType>
 class BaseCodeGen {
  public:
   /*!

--- a/src/contrib/msc/core/codegen/codegen_utils.h
+++ b/src/contrib/msc/core/codegen/codegen_utils.h
@@ -91,25 +91,23 @@ using namespace tvm::script::printer;
     const String& suffix = as_raw && config()->need_process ? "_raw" : "";                        \
     return suffix;                                                                                \
   }                                                                                               \
-  virtual const String IdxNodeBase(const MSCJoint& node, bool as_raw = true) {                    \
-    return CodeGenUtils::IdxNode(node, config()->prefix, GetSuffix(as_raw));                      \
+  const String IdxNodeBase(const MSCJoint& node, bool as_raw = true) {                            \
+    return helper_.IdxNodeBase(node, config()->prefix, GetSuffix(as_raw));                        \
   }                                                                                               \
-  virtual const String IdxInputBase(const MSCJoint& node, int idx = 0, bool as_raw = false) {     \
-    return CodeGenUtils::IdxInput(node, config()->prefix, idx, GetSuffix(as_raw));                \
+  const String IdxInputBase(const MSCJoint& node, int idx = 0, bool as_raw = false) {             \
+    return helper_.IdxInputBase(node, config()->prefix, idx, GetSuffix(as_raw));                  \
   }                                                                                               \
-  virtual const String IdxOutputBase(const MSCJoint& node, int idx = 0, bool as_raw = false) {    \
-    return CodeGenUtils::IdxOutput(node, config()->prefix, idx, GetSuffix(as_raw));               \
+  const String IdxOutputBase(const MSCJoint& node, int idx = 0, bool as_raw = false) {            \
+    return helper_.IdxOutputBase(node, config()->prefix, idx, GetSuffix(as_raw));                 \
   }                                                                                               \
-  virtual const String IdxWeightBase(const MSCJoint& node, const String& wtype,                   \
-                                     bool as_raw = false) {                                       \
-    return CodeGenUtils::IdxWeight(node, wtype, GetSuffix(as_raw));                               \
+  const String IdxWeightBase(const MSCJoint& node, const String& wtype, bool as_raw = false) {    \
+    return helper_.IdxWeightBase(node, wtype, GetSuffix(as_raw));                                 \
   }                                                                                               \
-  virtual const String Comment(const MSCJoint& node) {                                            \
-    return CodeGenUtils::CommentNode(node, config()->prefix);                                     \
-  }                                                                                               \
+  const String Comment(const MSCJoint& node) { return helper_.Comment(node, config()->prefix); }  \
                                                                                                   \
  private:                                                                                         \
-  std::shared_ptr<ConfigType> config_;
+  std::shared_ptr<ConfigType> config_;                                                            \
+  HelperType helper_;
 
 /*!
  * \brief Utils for CodeGen.
@@ -149,6 +147,32 @@ class CodeGenUtils {
    * \return The String.
    */
   TVM_DLL static const String CommentNode(const MSCJoint& node, const String& prefix);
+};
+
+/*!
+ * \brief Basic CodeGenHelper
+ */
+class BaseCodeGenHelper {
+ public:
+  virtual const String IdxNodeBase(const MSCJoint& node, const String& prefix = "",
+                                   const String& suffix = "") {
+    return CodeGenUtils::IdxNode(node, prefix, suffix);
+  }
+  virtual const String IdxInputBase(const MSCJoint& node, const String& prefix = "", int idx = 0,
+                                    const String& suffix = "") {
+    return CodeGenUtils::IdxInput(node, prefix, idx, suffix);
+  }
+  virtual const String IdxOutputBase(const MSCJoint& node, const String& prefix = "", int idx = 0,
+                                     const String& suffix = "") {
+    return CodeGenUtils::IdxOutput(node, prefix, idx, suffix);
+  }
+  virtual const String IdxWeightBase(const MSCJoint& node, const String& wtype,
+                                     const String& suffix = "") {
+    return CodeGenUtils::IdxWeight(node, wtype, suffix);
+  }
+  virtual const String Comment(const MSCJoint& node, const String& prefix = "") {
+    return CodeGenUtils::CommentNode(node, prefix);
+  }
 };
 
 }  // namespace msc

--- a/src/contrib/msc/core/codegen/py_codegen.h
+++ b/src/contrib/msc/core/codegen/py_codegen.h
@@ -40,8 +40,8 @@ namespace msc {
 
 using namespace tvm::script::printer;
 
-template <typename ConfigType>
-class PyCodeGen : public BaseCodeGen<ConfigType> {
+template <typename ConfigType, typename HelperType>
+class PyCodeGen : public BaseCodeGen<ConfigType, HelperType> {
  public:
   /*!
    * \brief The constructor of PyCodeGen
@@ -49,7 +49,7 @@ class PyCodeGen : public BaseCodeGen<ConfigType> {
    * \param config the options for codegen.
    */
   explicit PyCodeGen(const MSCGraph& graph, const std::string& config = "")
-      : BaseCodeGen<ConfigType>(graph, config) {}
+      : BaseCodeGen<ConfigType, HelperType>(graph, config) {}
 
   /*! \brief Stack the docs for the script*/
   virtual void CodeGenScript() {

--- a/src/contrib/msc/core/ir/graph_builder.h
+++ b/src/contrib/msc/core/ir/graph_builder.h
@@ -156,6 +156,8 @@ class RelaxFuncAttrGetter : public RelaxExprVisitor {
 
   void VisitExpr_(const relax::CallNode* op) final;
 
+  void VisitExpr_(const relax::TupleGetItemNode* op) final;
+
  private:
   Map<String, String> attrs_;
 };

--- a/src/contrib/msc/core/transform/set_expr_name.cc
+++ b/src/contrib/msc/core/transform/set_expr_name.cc
@@ -102,8 +102,12 @@ class RelaxExprNameSetter : public ExprVisitor {
 
   void VisitBinding_(const VarBindingNode* binding, const TupleGetItemNode* val) {
     ExprVisitor::VisitBinding_(binding, val);
-    ICHECK(expr_names_.count(val->tuple)) << "Can not find tuple of " << GetRef<TupleGetItem>(val);
-    const String& unique_name = expr_names_[val->tuple] + "." + std::to_string(val->index);
+    String unique_name;
+    if (expr_names_.count(val->tuple)) {
+      unique_name = expr_names_[val->tuple] + "." + std::to_string(val->index);
+    } else if (const auto* v_node = val->tuple.as<VarNode>()) {
+      unique_name = v_node->name_hint() + "." + std::to_string(val->index);
+    }
     if (unique_name != SpanUtils::GetAttr(val->span, "name")) {
       val->span = SpanUtils::SetAttr(val->span, "name", unique_name);
     }

--- a/src/contrib/msc/core/utils.cc
+++ b/src/contrib/msc/core/utils.cc
@@ -317,7 +317,7 @@ const Array<String> ExprUtils::GetInputTypes(const String& optype, size_t inputs
   } else if (optype == "triu") {
     input_types.push_back("input");
     input_types.push_back("k");
-  } else if (optype == "tril") {
+  } else if (optype == "tril" || optype == "trilu") {
     input_types.push_back("input");
     input_types.push_back("k");
   } else if (optype == "image.resize2d" && as_relax) {

--- a/src/contrib/msc/framework/tensorflow/codegen.cc
+++ b/src/contrib/msc/framework/tensorflow/codegen.cc
@@ -27,13 +27,13 @@ namespace contrib {
 namespace msc {
 
 void TensorflowCodeGen::CodeGenHeader() {
-  PyCodeGen<TensorflowCodeGenConfig>::CodeGenHeader();
+  PyCodeGen<TensorflowCodeGenConfig, TFV1CodeGenHelper>::CodeGenHeader();
   stack_.line("from tensorflow.python import ops")
       .line("from tvm.contrib.msc.framework.tensorflow import tf_v1");
 }
 
 void TensorflowCodeGen::CodeGenHelper() {
-  PyCodeGen<TensorflowCodeGenConfig>::CodeGenHelper();
+  PyCodeGen<TensorflowCodeGenConfig, TFV1CodeGenHelper>::CodeGenHelper();
   stack_.func_def("get_variable", TensorType())
       .func_arg("name", "str")
       .func_arg("shape", "List[int]")

--- a/src/contrib/msc/framework/tensorflow/codegen.h
+++ b/src/contrib/msc/framework/tensorflow/codegen.h
@@ -28,14 +28,14 @@
 
 #include "../../core/codegen/base_codegen.h"
 #include "../../core/codegen/py_codegen.h"
-#include "config.h"
+#include "codegen_utils.h"
 #include "tf_v1_opcode.h"
 
 namespace tvm {
 namespace contrib {
 namespace msc {
 
-class TensorflowCodeGen : public PyCodeGen<TensorflowCodeGenConfig> {
+class TensorflowCodeGen : public PyCodeGen<TensorflowCodeGenConfig, TFV1CodeGenHelper> {
  public:
   /*!
    * \brief The constructor of TensorflowCodeGen
@@ -43,7 +43,7 @@ class TensorflowCodeGen : public PyCodeGen<TensorflowCodeGenConfig> {
    * \param config the options for codegen.
    */
   explicit TensorflowCodeGen(const MSCGraph& graph, const std::string& config = "")
-      : PyCodeGen<TensorflowCodeGenConfig>(graph, config) {}
+      : PyCodeGen<TensorflowCodeGenConfig, TFV1CodeGenHelper>(graph, config) {}
 
  protected:
   /*! \brief Stack the docs for the header*/

--- a/src/contrib/msc/framework/tensorflow/codegen_utils.h
+++ b/src/contrib/msc/framework/tensorflow/codegen_utils.h
@@ -18,11 +18,11 @@
  */
 
 /*!
- * \file src/contrib/msc/framework/tensorflow/config.h
- * \brief Tensorflow config for codegen.
+ * \file src/contrib/msc/framework/tensorflow/codegen_utils.h
+ * \brief Utils for tensorflow codegen.
  */
-#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_
-#define TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CODEGEN_UTILS_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CODEGEN_UTILS_H_
 
 #include <string>
 
@@ -60,4 +60,4 @@ struct TensorflowCodeGenConfig {
 }  // namespace msc
 }  // namespace contrib
 }  // namespace tvm
-#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CODEGEN_UTILS_H_

--- a/src/contrib/msc/framework/tensorflow/codegen_utils.h
+++ b/src/contrib/msc/framework/tensorflow/codegen_utils.h
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tensorflow/config.h
+ * \brief Tensorflow config for codegen.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_
+
+#include <string>
+
+#include "../../core/codegen/base_codegen.h"
+#include "../../core/codegen/codegen_utils.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+/*!
+ * \brief CodeGen helper for tensorrt codegen
+ */
+class TFV1CodeGenHelper : public BaseCodeGenHelper {};
+
+/*!
+ * \brief CodeGen config for tensorflow codegen
+ */
+struct TensorflowCodeGenConfig {
+  bool is_training{false};
+  CODEGEN_CONFIG_MEMBERS
+  void Load(dmlc::JSONReader* reader) {
+    std::string key;
+    reader->BeginObject();
+    while (reader->NextObjectItem(&key)) {
+      if (key == "is_training") {
+        reader->Read(&is_training);
+      } else {
+        CODEGEN_CONFIG_PARSE
+      }
+    }
+  }
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TENSORFLOW_CONFIG_H_

--- a/src/contrib/msc/framework/tensorflow/tf_v1_opcode.h
+++ b/src/contrib/msc/framework/tensorflow/tf_v1_opcode.h
@@ -31,7 +31,7 @@
 #include <vector>
 
 #include "../../core/codegen/base_codegen.h"
-#include "config.h"
+#include "codegen_utils.h"
 
 namespace tvm {
 namespace contrib {
@@ -43,21 +43,22 @@ typedef OpCodeStack<TFV1OpCode> TFV1OpCodeStack;
 /*!
  * \brief CodeGen for tensorflow op
  */
-class TFV1OpCode : public BaseOpCode<TensorflowCodeGenConfig> {
+class TFV1OpCode : public BaseOpCode<TensorflowCodeGenConfig, TFV1CodeGenHelper> {
  public:
   /*!
    * \brief The constructor of BaseOpDocsifier
    * \param func_name the function name for the node.
    * \param config the config json for the node.
    */
-  explicit TFV1OpCode(const String& func_name) : BaseOpCode<TensorflowCodeGenConfig>(func_name) {}
+  explicit TFV1OpCode(const String& func_name)
+      : BaseOpCode<TensorflowCodeGenConfig, TFV1CodeGenHelper>(func_name) {}
 
   /*! \brief Convert node to docs*/
   const Array<Doc> GetDocs() final;
 
   /*! \brief Get dtype string*/
   const String DType(const DataType& dtype) final {
-    return "tf_v1." + BaseOpCode<TensorflowCodeGenConfig>::DType(dtype);
+    return "tf_v1." + BaseOpCode<TensorflowCodeGenConfig, TFV1CodeGenHelper>::DType(dtype);
   }
 
  protected:

--- a/src/contrib/msc/framework/torch/codegen.cc
+++ b/src/contrib/msc/framework/torch/codegen.cc
@@ -27,7 +27,7 @@ namespace contrib {
 namespace msc {
 
 void TorchCodeGen::CodeGenHeader() {
-  PyCodeGen<TorchCodeGenConfig>::CodeGenHeader();
+  PyCodeGen<TorchCodeGenConfig, TorchCodeGenHelper>::CodeGenHeader();
   stack_.line("import torch");
   stack_.line("from torch import nn");
   stack_.line("from torch.nn import functional");

--- a/src/contrib/msc/framework/torch/codegen.h
+++ b/src/contrib/msc/framework/torch/codegen.h
@@ -28,14 +28,14 @@
 
 #include "../../core/codegen/base_codegen.h"
 #include "../../core/codegen/py_codegen.h"
-#include "config.h"
+#include "codegen_utils.h"
 #include "torch_opcode.h"
 
 namespace tvm {
 namespace contrib {
 namespace msc {
 
-class TorchCodeGen : public PyCodeGen<TorchCodeGenConfig> {
+class TorchCodeGen : public PyCodeGen<TorchCodeGenConfig, TorchCodeGenHelper> {
  public:
   /*!
    * \brief The constructor of TorchCodeGen
@@ -43,7 +43,7 @@ class TorchCodeGen : public PyCodeGen<TorchCodeGenConfig> {
    * \param config the options for codegen.
    */
   explicit TorchCodeGen(const MSCGraph& graph, const std::string& config = "")
-      : PyCodeGen<TorchCodeGenConfig>(graph, config) {}
+      : PyCodeGen<TorchCodeGenConfig, TorchCodeGenHelper>(graph, config) {}
 
  protected:
   /*! \brief Stack the docs for the header*/

--- a/src/contrib/msc/framework/torch/codegen_utils.h
+++ b/src/contrib/msc/framework/torch/codegen_utils.h
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/torch/config.h
+ * \brief Torch config for codegen.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TORCH_CONFIG_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TORCH_CONFIG_H_
+
+#include <string>
+
+#include "../../core/codegen/base_codegen.h"
+#include "../../core/codegen/codegen_utils.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+/*!
+ * \brief CodeGen helper for torch codegen
+ */
+class TorchCodeGenHelper : public BaseCodeGenHelper {
+ public:
+  /*! \brief Get describe for default node input*/
+  const String IdxOutputBase(const MSCJoint& node, const String& prefix = "", int idx = 0,
+                             const String& suffix = "") final {
+    if ((node->optype == "max" || node->optype == "min") && node->OutputAt(0)->Ndim() > 0) {
+      ICHECK(idx == 0) << "max and min op only support 1 outputs, get " << node;
+      return IdxNodeBase(node, prefix, suffix) + ".values";
+    }
+    return BaseCodeGenHelper::IdxOutputBase(node, prefix, idx, suffix);
+  }
+};
+
+/*!
+ * \brief CodeGen config for torch codegen
+ */
+struct TorchCodeGenConfig {
+  bool is_training{false};
+  CODEGEN_CONFIG_MEMBERS
+  void Load(dmlc::JSONReader* reader) {
+    std::string key;
+    reader->BeginObject();
+    while (reader->NextObjectItem(&key)) {
+      if (key == "is_training") {
+        reader->Read(&is_training);
+      } else {
+        CODEGEN_CONFIG_PARSE
+      }
+    }
+  }
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TORCH_CONFIG_H_

--- a/src/contrib/msc/framework/torch/codegen_utils.h
+++ b/src/contrib/msc/framework/torch/codegen_utils.h
@@ -18,11 +18,11 @@
  */
 
 /*!
- * \file src/contrib/msc/framework/torch/config.h
- * \brief Torch config for codegen.
+ * \file src/contrib/msc/framework/torch/codegen_utils.h
+ * \brief Utils for torch codegen.
  */
-#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TORCH_CONFIG_H_
-#define TVM_CONTRIB_MSC_FRAMEWORK_TORCH_CONFIG_H_
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TORCH_CODEGEN_UTILS_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TORCH_CODEGEN_UTILS_H_
 
 #include <string>
 
@@ -71,4 +71,4 @@ struct TorchCodeGenConfig {
 }  // namespace msc
 }  // namespace contrib
 }  // namespace tvm
-#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TORCH_CONFIG_H_
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TORCH_CODEGEN_UTILS_H_

--- a/src/contrib/msc/framework/torch/torch_opcode.h
+++ b/src/contrib/msc/framework/torch/torch_opcode.h
@@ -30,7 +30,7 @@
 #include <vector>
 
 #include "../../core/codegen/base_codegen.h"
-#include "config.h"
+#include "codegen_utils.h"
 
 namespace tvm {
 namespace contrib {
@@ -42,7 +42,7 @@ typedef OpCodeStack<TorchOpCode> TorchOpCodeStack;
 /*!
  * \brief CodeGen for torch op
  */
-class TorchOpCode : public BaseOpCode<TorchCodeGenConfig> {
+class TorchOpCode : public BaseOpCode<TorchCodeGenConfig, TorchCodeGenHelper> {
  public:
   /*!
    * \brief The constructor of BaseOpDocsifier
@@ -50,26 +50,27 @@ class TorchOpCode : public BaseOpCode<TorchCodeGenConfig> {
    * \param config the config json for the node.
    */
   explicit TorchOpCode(const String& module_name, const String& func_name)
-      : BaseOpCode<TorchCodeGenConfig>(func_name) {
+      : BaseOpCode<TorchCodeGenConfig, TorchCodeGenHelper>(func_name) {
     module_name_ = module_name;
   }
 
   /*! \brief Config the TorchOpCode*/
   void Config(const MSCJoint& node, const std::shared_ptr<TorchCodeGenConfig> config,
               bool is_init) {
-    BaseOpCode<TorchCodeGenConfig>::Config(node, config);
+    BaseOpCode<TorchCodeGenConfig, TorchCodeGenHelper>::Config(node, config);
     is_init_ = is_init;
     module_ref_ = "self." + StringUtils::Replace(node->name, ".", "_");
   }
 
   /*! \brief Get return describe for default node*/
   const String IdxNode(bool as_raw = true) final {
-    return is_init_ ? module_ref_ : BaseOpCode<TorchCodeGenConfig>::IdxNode(as_raw);
+    return is_init_ ? module_ref_
+                    : BaseOpCode<TorchCodeGenConfig, TorchCodeGenHelper>::IdxNode(as_raw);
   };
 
   /*! \brief Get dtype string*/
   const String DType(const DataType& dtype) final {
-    return "torch." + BaseOpCode<TorchCodeGenConfig>::DType(dtype);
+    return "torch." + BaseOpCode<TorchCodeGenConfig, TorchCodeGenHelper>::DType(dtype);
   }
 
   /*! \brief Get func_name for the default node*/
@@ -80,7 +81,7 @@ class TorchOpCode : public BaseOpCode<TorchCodeGenConfig> {
     if (module_name_.size() > 0) {
       return module_ref_;
     }
-    return BaseOpCode<TorchCodeGenConfig>::callee_name();
+    return BaseOpCode<TorchCodeGenConfig, TorchCodeGenHelper>::callee_name();
   }
 
   /*! \brief Convert node to docs*/

--- a/src/contrib/msc/framework/tvm/codegen.cc
+++ b/src/contrib/msc/framework/tvm/codegen.cc
@@ -27,7 +27,7 @@ namespace contrib {
 namespace msc {
 
 void RelaxCodeGen::CodeGenHeader() {
-  PyCodeGen<RelaxCodeGenConfig>::CodeGenHeader();
+  PyCodeGen<RelaxCodeGenConfig, RelaxCodeGenHelper>::CodeGenHeader();
   stack_.line("from tvm import relax");
 }
 

--- a/src/contrib/msc/framework/tvm/codegen.h
+++ b/src/contrib/msc/framework/tvm/codegen.h
@@ -28,14 +28,14 @@
 
 #include "../../core/codegen/base_codegen.h"
 #include "../../core/codegen/py_codegen.h"
-#include "config.h"
+#include "codegen_utils.h"
 #include "relax_opcode.h"
 
 namespace tvm {
 namespace contrib {
 namespace msc {
 
-class RelaxCodeGen : public PyCodeGen<RelaxCodeGenConfig> {
+class RelaxCodeGen : public PyCodeGen<RelaxCodeGenConfig, RelaxCodeGenHelper> {
  public:
   /*!
    * \brief The constructor of RelaxCodeGen
@@ -43,7 +43,7 @@ class RelaxCodeGen : public PyCodeGen<RelaxCodeGenConfig> {
    * \param config the options for codegen.
    */
   explicit RelaxCodeGen(const MSCGraph& graph, const std::string& config = "")
-      : PyCodeGen<RelaxCodeGenConfig>(graph, config) {}
+      : PyCodeGen<RelaxCodeGenConfig, RelaxCodeGenHelper>(graph, config) {}
 
  protected:
   /*! \brief Stack the docs for the header*/

--- a/src/contrib/msc/framework/tvm/codegen_utils.h
+++ b/src/contrib/msc/framework/tvm/codegen_utils.h
@@ -18,11 +18,11 @@
  */
 
 /*!
- * \file src/contrib/msc/framework/tvm/config.h
- * \brief Relax config for codegen.
+ * \file src/contrib/msc/framework/tvm/codegen_utils.h
+ * \brief Utils for TVM codegen.
  */
-#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TVM_CONFIG_H_
-#define TVM_CONTRIB_MSC_FRAMEWORK_TVM_CONFIG_H_
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TVM_CODEGEN_UTILS_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TVM_CODEGEN_UTILS_H_
 
 #include <string>
 
@@ -63,4 +63,4 @@ struct RelaxCodeGenConfig {
 }  // namespace msc
 }  // namespace contrib
 }  // namespace tvm
-#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TVM_CONFIG_H_
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TVM_CODEGEN_UTILS_H_

--- a/src/contrib/msc/framework/tvm/codegen_utils.h
+++ b/src/contrib/msc/framework/tvm/codegen_utils.h
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file src/contrib/msc/framework/tvm/config.h
+ * \brief Relax config for codegen.
+ */
+#ifndef TVM_CONTRIB_MSC_FRAMEWORK_TVM_CONFIG_H_
+#define TVM_CONTRIB_MSC_FRAMEWORK_TVM_CONFIG_H_
+
+#include <string>
+
+#include "../../core/codegen/base_codegen.h"
+#include "../../core/codegen/codegen_utils.h"
+
+namespace tvm {
+namespace contrib {
+namespace msc {
+
+/*!
+ * \brief CodeGen helper for relax codegen
+ */
+class RelaxCodeGenHelper : public BaseCodeGenHelper {};
+
+/*!
+ * \brief CodeGen config for tvm codegen
+ */
+struct RelaxCodeGenConfig {
+  bool explicit_name{true};
+  bool from_relay{false};
+  CODEGEN_CONFIG_MEMBERS
+  void Load(dmlc::JSONReader* reader) {
+    std::string key;
+    reader->BeginObject();
+    while (reader->NextObjectItem(&key)) {
+      if (key == "explicit_name") {
+        reader->Read(&explicit_name);
+      } else if (key == "from_relay") {
+        reader->Read(&from_relay);
+      } else {
+        CODEGEN_CONFIG_PARSE
+      }
+    }
+  }
+};
+
+}  // namespace msc
+}  // namespace contrib
+}  // namespace tvm
+#endif  // TVM_CONTRIB_MSC_FRAMEWORK_TVM_CONFIG_H_

--- a/src/contrib/msc/framework/tvm/relax_opcode.h
+++ b/src/contrib/msc/framework/tvm/relax_opcode.h
@@ -30,7 +30,7 @@
 #include <vector>
 
 #include "../../core/codegen/base_codegen.h"
-#include "config.h"
+#include "codegen_utils.h"
 
 namespace tvm {
 namespace contrib {
@@ -42,14 +42,15 @@ typedef OpCodeStack<RelaxOpCode> RelaxOpCodeStack;
 /*!
  * \brief CodeGen for relax op
  */
-class RelaxOpCode : public BaseOpCode<RelaxCodeGenConfig> {
+class RelaxOpCode : public BaseOpCode<RelaxCodeGenConfig, RelaxCodeGenHelper> {
  public:
   /*!
    * \brief The constructor of BaseOpDocsifier
    * \param func_name the function name for the node.
    * \param config the config json for the node.
    */
-  explicit RelaxOpCode(const String& func_name) : BaseOpCode<RelaxCodeGenConfig>(func_name) {}
+  explicit RelaxOpCode(const String& func_name)
+      : BaseOpCode<RelaxCodeGenConfig, RelaxCodeGenHelper>(func_name) {}
 
   /*! \brief Convert node to docs*/
   const Array<Doc> GetDocs() final;

--- a/tests/python/contrib/test_msc/test_translate_relay.py
+++ b/tests/python/contrib/test_msc/test_translate_relay.py
@@ -19,7 +19,6 @@
 """ Test translate from relay. """
 
 import numpy as np
-import pytest
 
 import torch
 from torch import fx

--- a/tests/python/contrib/test_msc/test_translate_relay.py
+++ b/tests/python/contrib/test_msc/test_translate_relay.py
@@ -807,9 +807,6 @@ def test_tensor():
     verify_model(Empty2(), [([10, 10], "float32")], build_target="llvm")
 
 
-@pytest.mark.xfail(
-    reason="Failure to convert from R.PrimValue argument in msc/framework/tvm/codegen.cc"
-)
 def test_tril():
     """test relay to relax for tril"""
 
@@ -827,9 +824,6 @@ def test_tril():
     verify_model(InplaceTril(), input_info)
 
 
-@pytest.mark.xfail(
-    reason="Failure to convert from R.PrimValue argument in msc/framework/tvm/codegen.cc"
-)
 def test_triu():
     """test relay to relax for triu"""
 

--- a/tests/python/contrib/test_msc/test_translate_torch.py
+++ b/tests/python/contrib/test_msc/test_translate_torch.py
@@ -782,31 +782,12 @@ def test_arange():
     verify_model(Arange(), [([10, 10], "float32")])
 
 
-# pylint: disable=redefined-outer-name
-via_relax_param = tvm.testing.parameter(
-    True,
-    pytest.param(
-        False,
-        marks=pytest.mark.xfail(
-            reason="Failure to convert from R.PrimValue argument in msc/framework/tvm/codegen.cc"
-        ),
-    ),
-)
-
-
-def test_tril(via_relax_param):
+def test_tril():
     """test torch translator for tril"""
 
     class Tril(Module):
         def forward(self, data):
             return torch.tril(data, 1)
-
-    input_info = [([10, 10], "float32")]
-    verify_model(Tril(), input_info, via_relax_param)
-
-
-def test_tril_inplace(via_relax_param):
-    """test torch translator for tril"""
 
     class InplaceTril(Module):
         def forward(self, data):
@@ -814,22 +795,17 @@ def test_tril_inplace(via_relax_param):
             return data
 
     input_info = [([10, 10], "float32")]
-    verify_model(InplaceTril(), input_info, via_relax_param)
+    for via_relax in [True, False]:
+        verify_model(Tril(), input_info, via_relax)
+        verify_model(InplaceTril(), input_info, via_relax)
 
 
-def test_triu(via_relax_param):
+def test_triu():
     """test torch translator for triu"""
 
     class Triu(Module):
         def forward(self, data):
             return torch.triu(data, 1)
-
-    input_info = [([10, 10], "float32")]
-    verify_model(Triu(), input_info, via_relax_param)
-
-
-def test_triu_inplace(via_relax_param):
-    """test torch translator for triu"""
 
     class InplaceTriu(Module):
         def forward(self, data):
@@ -837,7 +813,9 @@ def test_triu_inplace(via_relax_param):
             return data
 
     input_info = [([10, 10], "float32")]
-    verify_model(InplaceTriu(), input_info, via_relax_param)
+    for via_relax in [True, False]:
+        verify_model(Triu(), input_info, via_relax)
+        verify_model(InplaceTriu(), input_info, via_relax)
 
 
 def test_new_ones():
@@ -872,9 +850,21 @@ def test_reduce():
         def forward(self, x):
             return torch.sum(x, (2, 1))
 
+    # max
+    class Max(Module):
+        def forward(self, x):
+            return torch.max(x)
+
+    # min
+    class Min(Module):
+        def forward(self, x):
+            return torch.min(x)
+
     input_info = [([1, 2, 3, 4], "float32")]
     for via_relax in [True, False]:
         verify_model(Sum(), input_info, via_relax)
+    verify_model(Max(), input_info, False)
+    verify_model(Min(), input_info, False)
 
 
 def test_datatype():

--- a/tests/python/contrib/test_msc/test_translate_torch.py
+++ b/tests/python/contrib/test_msc/test_translate_torch.py
@@ -18,7 +18,6 @@
 """ Test translate from torch. """
 
 import numpy as np
-import pytest
 
 import torch
 from torch.nn import Module


### PR DESCRIPTION
The trilu test from test_translate_relay.py results in failures(e.g https://github.com/apache/tvm/pull/15783). This PR fix the bugs.
Besides, I use a customized ops map to convert torch.max(x, dim=(1,2)) to relay and test the torch codegen. Neither relay nor relax support this op (when call max with dims, the outputs behavior is different, sa https://pytorch.org/docs/stable/generated/torch.max.html). The customized ops converter is not included in this PR. I may contribute the parser part after MSC, while currently I focus on MSC. To support the special ops like torch.max with dim, I reconstruct codegen a little.

cc @Lunderberg 