### PR TITLE
[Minor] Fix compilation warnings for clang

### DIFF
--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -68,6 +68,10 @@
 #include <utility>
 
 #if TVM_LLVM_VERSION < 180
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-stack-address"
+#endif
 namespace llvm {
 #if TVM_LLVM_VERSION < 170
 // SubtargetSubTypeKV view
@@ -86,6 +90,9 @@ struct FeatViewer {
 template struct FeatViewer<&MCSubtargetInfo::ProcFeatures>;
 ArrayRef<SubtargetFeatureKV>& featViewer(MCSubtargetInfo);
 }  // namespace llvm
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 #endif
 
 namespace tvm {
@@ -809,7 +816,7 @@ const Array<String> LLVMTargetInfo::GetAllLLVMTargetArches() const {
   // get all arches
   llvm::ArrayRef<llvm::SubtargetSubTypeKV> llvm_arches =
 #if TVM_LLVM_VERSION < 170
-      llvm::archViewer(*(llvm::MCSubtargetInfo*)MCInfo);
+      llvm::archViewer(*(const llvm::MCSubtargetInfo*)MCInfo);
 #else
       MCInfo->getAllProcessorDescriptions();
 #endif
@@ -830,7 +837,7 @@ const Array<String> LLVMTargetInfo::GetAllLLVMCpuFeatures() const {
   // get all features for CPU
   llvm::ArrayRef<llvm::SubtargetFeatureKV> llvm_features =
 #if TVM_LLVM_VERSION < 180
-      llvm::featViewer(*(llvm::MCSubtargetInfo*)MCInfo);
+      llvm::featViewer(*(const llvm::MCSubtargetInfo*)MCInfo);
 #else
       MCInfo->getAllProcessorFeatures();
 #endif


### PR DESCRIPTION
Fix compilation warnings for clang.

---

The warnings was:
```
BUILD/tvm/src/target/llvm/llvm_instance.cc:84:81: warning: reference to stack memory associated with parameter 'Obj' returned [-Wreturn-stack-address]
   84 |   friend ArrayRef<SubtargetFeatureKV>& featViewer(MCSubtargetInfo Obj) { return Obj.*Member; }
      |                                                                                 ^~~
BUILD/tvm/src/target/llvm/llvm_instance.cc:833:49: 
 warning: cast from 'const llvm::MCSubtargetInfo *' to 'llvm::MCSubtargetInfo *' drops const qualifier [-Wcast-qual]
  833 |       llvm::featViewer(*(llvm::MCSubtargetInfo*)MCInfo);
      |                                                 ^
BUILD/tvm/src/target/llvm/llvm_instance.cc:84:81: 
 warning: reference to stack memory associated with parameter 'Obj' returned [-Wreturn-stack-address]
   84 |   friend ArrayRef<SubtargetFeatureKV>& featViewer(MCSubtargetInfo Obj) { return Obj.*Member; }
      |                                                                                 ^~~
BUILD/tvm/src/target/llvm/llvm_instance.cc:833:13: note: in instantiation of member function 'llvm::featViewer' requested here
  833 |       llvm::featViewer(*(llvm::MCSubtargetInfo*)MCInfo);
      |           
```
```
$ rpm -q clang
clang-17.0.2-1.fc40.x86_64
```

No warnings was for: gcc (13.2) or vscode (2019) sides.

Cc: @junrushao 