### PR TITLE
[Web] Further increase default EMCC compilation total memory size

### DIFF
--- a/python/tvm/contrib/emcc.py
+++ b/python/tvm/contrib/emcc.py
@@ -46,7 +46,7 @@ def create_tvmjs_wasm(output, objects, options=None, cc="emcc"):
     cmd += ["-s", "ERROR_ON_UNDEFINED_SYMBOLS=0"]
     cmd += ["-s", "STANDALONE_WASM=1"]
     cmd += ["-s", "ALLOW_MEMORY_GROWTH=1"]
-    cmd += ["-s", "TOTAL_MEMORY=40MB"]
+    cmd += ["-s", "TOTAL_MEMORY=80MB"]
 
     objects = [objects] if isinstance(objects, str) else objects
 


### PR DESCRIPTION
As reported by mlc-ai/mlc-llm#1081, the current 40MB memory size is likely still not enough. So we further increase it to 80MB.