### PR TITLE
[Unity][BYOC] Add support for sliding window in attention op

### DIFF
--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -379,12 +379,14 @@ struct DropoutAttrs : public tvm::AttrsNode<DropoutAttrs> {
 struct AttentionAttrs : public tvm::AttrsNode<AttentionAttrs> {
   Optional<FloatImm> scale;
   Optional<String> causal_mask;
+  Optional<IntImm> window_size;
 
   TVM_DECLARE_ATTRS(AttentionAttrs, "relax.attrs.AttentionAttrs") {
     TVM_ATTR_FIELD(scale).describe(
         "The custom scale applied before the softmax. The default value is 1 / sqrt(head_dim).");
     TVM_ATTR_FIELD(causal_mask)
         .describe("The type of the causal mask, i.e. 'TopLeft' and 'BottomRight'.");
+    TVM_ATTR_FIELD(window_size).describe("The size of the window for sliding-window attention.");
   }
 };  // struct AttentionAttrs
 

--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -218,7 +218,7 @@ def instantiate_flash_attention_template(attrs):
     			    o_row_stride,
     			    ${scale},
     			    ${is_causal},
-                            -1, // win_left
+                            ${window_size},
                             -1, // win_right
     			    stream);
     """

--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -218,8 +218,8 @@ def instantiate_flash_attention_template(attrs):
     			    o_row_stride,
     			    ${scale},
     			    ${is_causal},
-                            ${window_size} - 1,
-                            -1, // win_right
+                            ${window_size_left},
+                            ${window_size_right},
     			    stream);
     """
 
@@ -270,8 +270,8 @@ def instantiate_flash_attention_template(attrs):
     			    o_row_stride,
     			    ${scale},
     			    ${is_causal},
-                            ${window_size} - 1,
-                            -1, // win_right
+                            ${window_size_left},
+                            ${window_size_right},
     			    stream);
     """
 

--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -218,7 +218,7 @@ def instantiate_flash_attention_template(attrs):
     			    o_row_stride,
     			    ${scale},
     			    ${is_causal},
-                            ${window_size},
+                            ${window_size} - 1,
                             -1, // win_right
     			    stream);
     """
@@ -270,7 +270,7 @@ def instantiate_flash_attention_template(attrs):
     			    o_row_stride,
     			    ${scale},
     			    ${is_causal},
-                            -1, // win_left
+                            ${window_size} - 1,
                             -1, // win_right
     			    stream);
     """

--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -218,6 +218,8 @@ def instantiate_flash_attention_template(attrs):
     			    o_row_stride,
     			    ${scale},
     			    ${is_causal},
+                            -1, // win_left
+                            -1, // win_right
     			    stream);
     """
 
@@ -268,6 +270,8 @@ def instantiate_flash_attention_template(attrs):
     			    o_row_stride,
     			    ${scale},
     			    ${is_causal},
+                            -1, // win_left
+                            -1, // win_right
     			    stream);
     """
 

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -950,6 +950,9 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
                 if arg in arg_idx:
                     attrs[arg + "_idx"] = arg_idx[arg]
 
+        if op_attrs.window_size:
+            attrs["window_size"] = op_attrs.window_size
+
         return f.with_attrs(attrs)
 
     def handle_norm(self, f, op_type):

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -773,6 +773,7 @@ def instantiate_template(func_name, annotations, func_args):
             and (
                 int(annotations["custom_mask_type"]) == 0
                 or (int(annotations["custom_mask_type"]) == 2 and is_mqa)
+                or (int(annotations["custom_mask_type"]) == 2 and "window_size" in annotations)
             )
             # Flash v2 is currently not supported for sm < 80
             and int(annotations["arch"]) >= 80
@@ -782,6 +783,8 @@ def instantiate_template(func_name, annotations, func_args):
         if "window_size" in annotations:
             assert use_flash, "Sliding-window attention is supported only by Flash Attention."
             attrs["window_size"] = int(annotations["window_size"])
+        else:
+            attrs["window_size"] = -1
 
         if use_flash:
             headers.append("flash.h")

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -779,6 +779,10 @@ def instantiate_template(func_name, annotations, func_args):
             and not is_var_len
         )
 
+        if "window_size" in annotations:
+            assert use_flash, "Sliding-window attention is supported only by Flash Attention."
+            attrs["window_size"] = int(annotations["window_size"])
+
         if use_flash:
             headers.append("flash.h")
             attrs["is_causal"] = int(annotations["custom_mask_type"]) == 2

--- a/python/tvm/relax/op/nn/__init__.py
+++ b/python/tvm/relax/op/nn/__init__.py
@@ -18,6 +18,7 @@
 from .nn import (
     adaptive_avg_pool2d,
     attention,
+    attention_var_len,
     avg_pool2d,
     batch_norm,
     conv1d,

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -1266,6 +1266,8 @@ def attention(
             [[1, 1, 1, 0],
             [1, 1, 1, 1]]
 
+    window_size: Optional[int]
+        The size of the window for sliding-window attention.
 
     Returns
     -------
@@ -1350,6 +1352,8 @@ def attention_var_len(
         [[1, 1, 1, 0],
          [1, 1, 1, 1]]
 
+    window_size: Optional[int]
+        The size of the window for sliding-window attention.
 
     Returns
     -------

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -1194,7 +1194,7 @@ def attention(
     bias: Optional[Expr] = None,
     scale: Optional[FloatImm] = None,
     causal_mask: Optional[str] = None,
-    window_size: Optional[int] = 0,
+    window_size: Optional[int] = None,
 ) -> Expr:
     r"""Computes fused multi head attention.
 
@@ -1286,7 +1286,7 @@ def attention_var_len(
     max_seqlen_k: Optional[Expr] = None,
     scale: Optional[FloatImm] = None,
     causal_mask: Optional[str] = None,
-    window_size: Optional[int] = 0,
+    window_size: Optional[int] = None,
 ) -> Expr:
     r"""Computes fused multi head attention over batched sequences of variable lengths.
 

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -1275,7 +1275,9 @@ def attention(
         The computed result. The layout of the output should be
         (batch_size, seq_len, num_head, head_dim_v).
     """
-    return _ffi_api.attention(query, key, value, bias, scale, causal_mask, window_size)  # type: ignore
+    return _ffi_api.attention(
+        query, key, value, bias, scale, causal_mask, window_size
+    )  # type: ignore
 
 
 def attention_var_len(

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -1194,6 +1194,7 @@ def attention(
     bias: Optional[Expr] = None,
     scale: Optional[FloatImm] = None,
     causal_mask: Optional[str] = None,
+    window_size: Optional[int] = 0,
 ) -> Expr:
     r"""Computes fused multi head attention.
 
@@ -1272,7 +1273,7 @@ def attention(
         The computed result. The layout of the output should be
         (batch_size, seq_len, num_head, head_dim_v).
     """
-    return _ffi_api.attention(query, key, value, bias, scale, causal_mask)  # type: ignore
+    return _ffi_api.attention(query, key, value, bias, scale, causal_mask, window_size)  # type: ignore
 
 
 def attention_var_len(
@@ -1285,6 +1286,7 @@ def attention_var_len(
     max_seqlen_k: Optional[Expr] = None,
     scale: Optional[FloatImm] = None,
     causal_mask: Optional[str] = None,
+    window_size: Optional[int] = 0,
 ) -> Expr:
     r"""Computes fused multi head attention over batched sequences of variable lengths.
 
@@ -1368,4 +1370,5 @@ def attention_var_len(
         max_seqlen_k,
         scale,
         causal_mask,
+        window_size,
     )  # type: ignore

--- a/python/tvm/relax/transform/legalize_ops/nn.py
+++ b/python/tvm/relax/transform/legalize_ops/nn.py
@@ -456,6 +456,9 @@ def _te_attention(
 
 @register_legalize("relax.nn.attention")
 def _nn_attention(bb: BlockBuilder, call: Call) -> Expr:
+    assert (
+        call.attrs.window_size is None
+    ), "Legalization for sliding-window attention is not supported yet."
     return bb.call_te(
         _te_attention,
         call.args[0],
@@ -470,6 +473,9 @@ def _nn_attention(bb: BlockBuilder, call: Call) -> Expr:
 
 @register_legalize("relax.nn.attention_bias")
 def _nn_attention_bias(bb: BlockBuilder, call: Call) -> Expr:
+    assert (
+        call.attrs.window_size is None
+    ), "Legalization for sliding-window attention is not supported yet."
     return bb.call_te(
         _te_attention,
         call.args[0],

--- a/src/relax/op/nn/attention.cc
+++ b/src/relax/op/nn/attention.cc
@@ -29,10 +29,11 @@ namespace relax {
 TVM_REGISTER_NODE_TYPE(AttentionAttrs);
 
 Expr attention(Expr query, Expr key, Expr value, Optional<Expr> bias, Optional<FloatImm> scale,
-               Optional<String> causal_mask) {
+               Optional<String> causal_mask, Optional<IntImm> window_size) {
   ObjectPtr<AttentionAttrs> attrs = make_object<AttentionAttrs>();
   attrs->scale = scale;
   attrs->causal_mask = causal_mask;
+  attrs->window_size = window_size;
 
   if (bias) {
     return Call(Op::Get("relax.nn.attention_bias"),
@@ -45,10 +46,11 @@ Expr attention(Expr query, Expr key, Expr value, Optional<Expr> bias, Optional<F
 
 Expr attention_var_len(Expr query, Expr key, Expr value, Expr seqstart_q, Expr seqstart_k,
                        Expr max_seqlen_q, Expr max_seqlen_k, Optional<FloatImm> scale,
-                       Optional<String> causal_mask) {
+                       Optional<String> causal_mask, Optional<IntImm> window_size) {
   ObjectPtr<AttentionAttrs> attrs = make_object<AttentionAttrs>();
   attrs->scale = scale;
   attrs->causal_mask = causal_mask;
+  attrs->window_size = window_size;
 
   return Call(Op::Get("relax.nn.attention_var_len"),
               {query, key, value, seqstart_q, seqstart_k, max_seqlen_q, max_seqlen_k}, Attrs(attrs),
@@ -139,7 +141,7 @@ StructInfo InferStructInfoAttention(const Call& call, const BlockBuilder& ctx) {
 
 Call InferMixedPrecisionAttention(const Call& call, const DataType& out_dtype) {
   return Downcast<Call>(
-      attention(call->args[0], call->args[1], call->args[2], NullOpt, NullOpt, NullOpt));
+      attention(call->args[0], call->args[1], call->args[2], NullOpt, NullOpt, NullOpt, NullOpt));
 }
 
 TVM_REGISTER_OP("relax.nn.attention")

--- a/src/relax/op/nn/attention.h
+++ b/src/relax/op/nn/attention.h
@@ -34,7 +34,7 @@ namespace relax {
 
 /*! \brief fused multi head attention */
 Expr attention(Expr query, Expr key, Expr value, Optional<Expr> bias, Optional<FloatImm> scale,
-               Optional<String> causal_mask);
+               Optional<String> causal_mask, Optional<IntImm> window_size);
 
 }  // namespace relax
 }  // namespace tvm

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -17,11 +17,6 @@
 import numpy as np
 import pytest
 
-import torch
-import torch.nn as nn
-from xformers import ops as xops
-from xformers.ops.fmha.attn_bias import BlockDiagonalCausalMask
-
 import tvm
 import tvm.testing
 import tvm.topi.testing
@@ -2130,36 +2125,38 @@ def test_sliding_window():
     causal = "BottomRight"
 
     mod = get_relax_attention_module(
-        q_shape, k_shape, v_shape, dtype="float16", causal_mask=causal, window_size=window_size,
+        q_shape,
+        k_shape,
+        v_shape,
+        dtype="float16",
+        causal_mask=causal,
+        window_size=window_size,
     )
 
     q, k, v, _, ref = get_numpy_attention_ref(
         1, 64, 64, 16, 8, 8, "none", "none", causal, "float16", window_size=window_size
     )
 
-    # out = get_result_with_relax_cutlass_offload(mod, q, k, v, num_final_bindings=3)
-
-    out = ref
-
-    # tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
-
-    # return
-    ############# xformer reference for verification #############
-
-    attn_bias = BlockDiagonalCausalMask.from_seqlens([64])
-
-    if window_size > 0:
-        attn_bias = attn_bias.make_local_attention(window_size)
-
-    query = torch.from_numpy(q).to("cuda")
-    key = torch.from_numpy(k).to("cuda")
-    value = torch.from_numpy(v).to("cuda")
-
-    ref = xops.memory_efficient_attention_forward(
-        query, key, value, attn_bias=attn_bias,
-    ).cpu().numpy()
+    out = get_result_with_relax_cutlass_offload(mod, q, k, v, num_final_bindings=3)
 
     tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+
+    ############# xformer reference for verification #############
+
+    # attn_bias = BlockDiagonalCausalMask.from_seqlens([64])
+
+    # if window_size > 0:
+    #     attn_bias = attn_bias.make_local_attention(window_size)
+
+    # query = torch.from_numpy(q).to("cuda")
+    # key = torch.from_numpy(k).to("cuda")
+    # value = torch.from_numpy(v).to("cuda")
+
+    # ref = xops.memory_efficient_attention_forward(
+    #     query, key, value, attn_bias=attn_bias,
+    # ).cpu().numpy()
+
+    # tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1955,7 +1955,10 @@ def test_fp16A_int8B_gemm_batched():
     ex = relax.build(mod_transform, target="llvm")
     vm = relax.vm.VirtualMachine(ex, tvm.cpu(0))
 
-    (packed_weight, scales,) = vm[
+    (
+        packed_weight,
+        scales,
+    ) = vm[
         transform_func_name
     ]((tvm.nd.array(y),))
 
@@ -2160,5 +2163,4 @@ def test_sliding_window():
 
 
 if __name__ == "__main__":
-    # tvm.testing.main()
-    test_sliding_window()
+    tvm.testing.main()

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -611,7 +611,7 @@ def get_relax_attention_module(
     return tvm.IRModule({"main": func})
 
 
-# @memoize("topi.tests.test_codegen_cutlass.test_attention_offload")
+@memoize("topi.tests.test_codegen_cutlass.test_attention_offload")
 def get_numpy_attention_ref(
     b, s, s_kv, n, h, h_v, bias_shape, qk_scale, causal, dtype, window_size=None
 ):
@@ -1955,10 +1955,7 @@ def test_fp16A_int8B_gemm_batched():
     ex = relax.build(mod_transform, target="llvm")
     vm = relax.vm.VirtualMachine(ex, tvm.cpu(0))
 
-    (
-        packed_weight,
-        scales,
-    ) = vm[
+    (packed_weight, scales,) = vm[
         transform_func_name
     ]((tvm.nd.array(y),))
 


### PR DESCRIPTION
This is necessary for Mistral support. A new attribute `window_size` has been added to `nn.attention(...)` op, and such sliding-window attention runs efficiently via flash attention. I updated our flash attention submodule to pick up the support for sliding window in https://github.com/tlc-pack/libflash_attn/pull/4.

@sunggg @yelite @cyx-6 @vinx13  