### PR TITLE
Update ci_arm Docker tag

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -17,7 +17,7 @@
 
 # This data file is read during when Jenkins runs job to determine docker images.
 [jenkins]
-ci_arm: tlcpack/ci-arm:20230615-060132-62a5e7acf
+ci_arm: tlcpack/ci-arm:20231013-060139-71caa19f9
 ci_cortexm: tlcpack/ci-cortexm:20230710-060128-a60cd0fec
 ci_cpu: tlcpack/ci-cpu:20230604-060130-0af9ff90e
 ci_gpu: tlcpack/ci-gpu:20231004-111300-7a1f7d0b


### PR DESCRIPTION
Update ci_arm image to use tag tlcpack/ci-arm:20231013-060139-71caa19f9

 * Update ACL to 23.05 version

Tested at https://github.com/apache/tvm/pull/15930

cc @neildhickey @leandron @ashutosh-arm @tqchen @areusch 