### PR TITLE
[Unity][BYOC] Support variable-length attention by flash attention

### DIFF
--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -279,3 +279,59 @@ def instantiate_flash_attention_template(attrs):
         return substitute_template(template_stacked, attrs)
 
     return substitute_template(template, attrs)
+
+
+def instantiate_flash_attention_var_len_template(attrs):
+    """Return host code for flash attention with variable sequence lengths."""
+
+    template = """
+    int _max_seqlen_q, _max_seqlen_k;
+    cudaMemcpy(&_max_seqlen_q, (int32_t*)${max_seqlen_q}->data, sizeof(int32_t),
+               cudaMemcpyDeviceToHost);
+    cudaMemcpy(&_max_seqlen_k, (int32_t*)${max_seqlen_k}->data, sizeof(int32_t),
+               cudaMemcpyDeviceToHost);
+
+    int batch_size = ${seqstart_q}->shape[0] - 1;
+
+    int q_head_stride = ${head_dim};
+    int k_head_stride = ${head_dim};
+    int v_head_stride = ${head_dim};
+    int o_head_stride = ${head_dim};
+    int q_row_stride = q_head_stride * ${num_q_heads};
+    int k_row_stride = k_head_stride * ${num_kv_heads};
+    int v_row_stride = v_head_stride * ${num_kv_heads};
+    int o_row_stride = o_head_stride * ${num_q_heads};
+
+    auto func = tvm::runtime::Registry::Get("runtime.get_cuda_stream");
+    ICHECK(func != nullptr);
+    cudaStream_t stream = static_cast<cudaStream_t>((*func)().operator void*());
+
+    flash_attn::flash_attention_var_len_forward(
+                            static_cast<const cutlass::half_t*>(${query}->data),
+    			    static_cast<const cutlass::half_t*>(${key}->data),
+    			    static_cast<const cutlass::half_t*>(${value}->data),
+                            static_cast<const int*>(${seqstart_q}->data),
+                            static_cast<const int*>(${seqstart_k}->data),
+    			    static_cast<cutlass::half_t*>(out0->data),
+    			    batch_size,
+    			    _max_seqlen_q,
+    			    _max_seqlen_k,
+    			    ${num_q_heads},
+    			    ${num_kv_heads},
+    			    ${head_dim},
+    			    q_head_stride,
+    			    k_head_stride,
+    			    v_head_stride,
+    			    o_head_stride,
+    			    q_row_stride,
+    			    k_row_stride,
+    			    v_row_stride,
+    			    o_row_stride,
+    			    ${scale},
+    			    ${is_causal},
+                            ${is_causal} ? _max_seqlen_k : -1,
+                            ${window_size_right},
+    			    stream);
+    """
+
+    return substitute_template(template, attrs)

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -1213,6 +1213,7 @@ def test_attention_rewrite_fp16():
             v: R.Tensor((4, 8, 32, 16), dtype="float16"),
             bias: R.Tensor((4, 32, 16, 8), dtype="float16"),
         ) -> R.Tensor((4, 16, 32, 16), dtype="float16"):
+            R.func_attr({"num_input": 4})
             with R.dataflow():
                 lv = R.permute_dims(q, axes=[0, 2, 1, 3])
                 lv1 = R.reshape(lv, R.shape([128, 16, 8]))
@@ -1284,7 +1285,8 @@ def test_attention_rewrite_fp16():
             k: R.Tensor((4, 8, 32, 8), dtype="float16"),
             v: R.Tensor((4, 8, 32, 16), dtype="float16"),
             bias: R.Tensor((4, 32, 16, 8), dtype="float16"),
-        ) -> R.Tensor((4, 16, 32, 16), dtype="float16"):
+        ) -> R.Tensor((4, 16, 32, 16), dtype="float32"):
+            R.func_attr({"num_input": 4})
             cls = Expected
             with R.dataflow():
                 lv = R.vm.alloc_storage(R.shape([65536]), R.prim_value(0), R.dtype("uint8"))
@@ -2119,6 +2121,7 @@ def test_batched_var_len_attention():
             values: R.Tensor(("num_tokens", 4096), dtype="float16"),
             seq_lens: R.Tensor(("num_seq",), dtype="int32"),
         ) -> R.Tensor(("num_tokens", 4096), dtype="float16"):
+            R.func_attr({"num_input": 4})
             cls = Module
             num_tokens = T.int64()
             num_seq = T.int64()
@@ -2163,6 +2166,7 @@ def test_batched_var_len_multi_query_attention():
             values: R.Tensor(("num_tokens", 512), dtype="float16"),
             seq_lens: R.Tensor(("num_seq",), dtype="int32"),
         ) -> R.Tensor(("num_tokens", 4096), dtype="float16"):
+            R.func_attr({"num_input": 4})
             cls = Module
             num_tokens = T.int64()
             num_seq = T.int64()


### PR DESCRIPTION
Recently, I made two PRs on attention:

* https://github.com/apache/tvm/pull/15837 introduced `nn.attention_var_len`, always offloaded to cutlass fMHA
* https://github.com/apache/tvm/pull/15951 Support for sliding-window attention, always offloaded to Flash 

Now, I realized that in practice I need to use `nn.attention_var_len` with sliding-window attention, which is not possible with the two PRs since the two features require different offloading backends. I enabled offloading `nn.attention_var_len` to Flash to resolve this issue. 

@vinx13 @sunggg 