### PR TITLE
[Unity] Update relax_dynamo

### DIFF
--- a/python/tvm/relax/frontend/torch/dynamo.py
+++ b/python/tvm/relax/frontend/torch/dynamo.py
@@ -71,6 +71,8 @@ def relax_dynamo(pipeline: Optional[tvm.transform.Pass] = None):
             real_tensor = torch.randn(torch_tensor.shape, dtype=torch_tensor.dtype)
             return tvm.nd.array(real_tensor.numpy())
 
+        graph_module.graph.eliminate_dead_code()
+
         device = device_from_inputs(example_inputs)
 
         assert len(example_inputs)

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1484,6 +1484,10 @@ class TorchFXImporter:
                 for node in graph.nodes:
                     if node.op == "placeholder":
                         assert len(inputs) > 0, "Provided inputs is less than actual inputs"
+                        if "grapharg" in node.meta and node.meta["grapharg"].fake_tensor is None:
+                            # Ignore sym input
+                            continue
+
                         self.env[node] = inputs.pop(0)
                     elif node.op == "output":
                         args = self.retrieve_args(node)

--- a/tests/python/relax/test_frontend_dynamo.py
+++ b/tests/python/relax/test_frontend_dynamo.py
@@ -137,6 +137,21 @@ def test_relax_dynamo_dynamic():
         opt_model(inp).detach().numpy(), model(inp).detach().numpy(), rtol=1e-5, atol=1e-5
     )
 
+    def Func1(x, y):
+        z = torch.cat([x, y])
+        if z.size(0) > 5:
+            return z.mul(2)
+        else:
+            return z.add(2)
+
+    opt_func = torch.compile(Func1, backend=relax_dynamo(), dynamic=True)
+
+    for s in (2, 4):
+        x = torch.randn(s, 100)
+        y = torch.randn(s, 100)
+        with torch.no_grad():
+            tvm.testing.assert_allclose(opt_func(x, y), opt_func(x, y))
+
 
 def test_subgraph_capture():
     import torch


### PR DESCRIPTION
PyTorch 2.1.0 has switched the calling convention to real tensors (https://github.com/pytorch/pytorch/pull/99320), consequently prompting an update of the `relax_dynamo` with real tensors.

Additionally, there is a new dynamic dynamo test from  [Pytorch Docs](https://pytorch.org/docs/stable/torch.compiler_dynamic_shapes.html#dynamic-shapes)  that generates dead code in the fx graph, requiring the application of `eliminate_dead_code`.

cc @Hzfengsy @MasterJH5574 