### PR TITLE
[Unity][SWA] Overriding windowed cache support

### DIFF
--- a/tests/python/relax/test_runtime_builtin.py
+++ b/tests/python/relax/test_runtime_builtin.py
@@ -212,5 +212,34 @@ def test_ndarray_cache():
         np.testing.assert_allclose(v.numpy(), v_np, atol=1e-6, rtol=1e-6)
 
 
+def test_attention_kv_cache_window_override():
+    fcreate = tvm.get_global_func("vm.builtin.attention_kv_cache_create")
+    foverride = tvm.get_global_func("vm.builtin.attention_kv_cache_window_override")
+    fview = tvm.get_global_func("vm.builtin.attention_kv_cache_view")
+
+    current_pos = 4
+    cache = fcreate(
+        tvm.nd.array(np.full((16, 2), -1).astype("int32")),
+        tvm.runtime.ShapeTuple([16, 2]),
+        current_pos,
+    )
+    np_all_arrays = np.zeros((0, 2)).astype("int32")
+
+    num_steps = 10
+    for i in range(1, num_steps):
+        np_array = i * np.ones((i, 2)).astype("int32")
+        np_all_arrays = np.concatenate((np_all_arrays, np_array), axis=0)
+        cache = foverride(cache, tvm.nd.array(np_array), 16)
+        current_pos = (current_pos + i) % 16
+
+    res = fview(cache, tvm.runtime.ShapeTuple((16, 2))).numpy()
+
+    # unrotate cache and assert cache matches last 16 elements
+    assert (
+        np_all_arrays[np_all_arrays.shape[0] - 16 :, :]
+        == np.concatenate((res[current_pos:], res[:current_pos]))
+    ).all()
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Part of the effort on Sliding Window Attention (SWA) https://github.com/mlc-ai/mlc-llm/issues/1003. Overriding the cache is useful when computing SWA, so we can have a more efficient cache only containing the current window keys and values. Once the cache is full we start overriding the older entries.

cc @tqchen 