### PR TITLE
[CI][BUGFIX] Better to pass the build folder

### DIFF
--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -593,7 +593,7 @@ generated = [
                 "run unit tests",
                 [
                     "./tests/scripts/task_java_unittest.sh",
-                    "./tests/scripts/task_opencl_cpp_unittest.sh",
+                    "./tests/scripts/task_opencl_cpp_unittest.sh {build_dir}",
                     "./tests/scripts/task_python_unittest_gpuonly.sh",
                     "./tests/scripts/task_python_integration_gpuonly.sh",
                 ],


### PR DESCRIPTION
build_dir is not passed to allow custom build folders