### PR TITLE
[UNITY] Fix the symbolic var handling

### DIFF
--- a/python/tvm/relax/transform/lazy_transform_params.py
+++ b/python/tvm/relax/transform/lazy_transform_params.py
@@ -153,8 +153,8 @@ class LazyTransformParamsMutator(PyExprMutator):
         params = []
         symbolic_vars = relax.analysis.defined_symbolic_vars(func)
         if symbolic_vars:
-            for param in self.input_tuple_param:
-                sinfo = param.struct_info
+            # direct iterate over the struct info annotation
+            for sinfo in self.input_tuple_param.struct_info.fields:
                 if not isinstance(sinfo, relax.TensorStructInfo):
                     params.append(relax.Var("symbolic_var_holder", sinfo))
 


### PR DESCRIPTION
This PR fix a bug that only appears on windows on symbolic var handling. For the function parameter var with Tuple struct info, directly iterate over that variable will cause out of bound error(which is properly handled in linux but not necessarily in windows due to how iteration is handled).

Note that the var itself is not iterable and likely it relied on a sugar that var[i] dispatches to tuple_getitem and when it gets out of bound the exception get caught by the python iterator.

This PR fixes it by directly iterate over the struct info array in the annotation.