### PR TITLE
[Unity] Forbid iteration over arbitrary relax.Expr

### DIFF
--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -85,6 +85,42 @@ def test_tuple() -> None:
     with pytest.raises(IndexError, match="Tuple index out of range"):
         t[-3]
 
+    t_iter = iter(t)
+    assert next(t_iter).same_as(v0)
+    assert next(t_iter).same_as(v1)
+    with pytest.raises(StopIteration):
+        next(t_iter)
+
+
+def test_tuple_var():
+    sinfo_a = rx.TensorStructInfo(dtype="float16")
+    sinfo_b = rx.TensorStructInfo(dtype="int32")
+    var = rx.Var("var", rx.TupleStructInfo([sinfo_a, sinfo_b]))
+
+    a = var[0]
+    assert isinstance(a, rx.TupleGetItem)
+    tvm.ir.assert_structural_equal(a.struct_info, sinfo_a)
+
+    b = var[1]
+    assert isinstance(b, rx.TupleGetItem)
+    tvm.ir.assert_structural_equal(b.struct_info, sinfo_b)
+
+    with pytest.raises(IndexError):
+        var[-1]
+
+    with pytest.raises(IndexError):
+        var[2]
+
+    with pytest.raises(TypeError):
+        iter(var)
+
+
+def test_iteration_over_non_tuple_var_is_invalid():
+    var = rx.Var("var", rx.ObjectStructInfo())
+
+    with pytest.raises(TypeError):
+        iter(var)
+
 
 def test_match_cast() -> None:
     # match_cast([16, 8], [m, n])


### PR DESCRIPTION
Prior to this commit, iteration over a `relax.Expr` relied on an exception being thrown from `TupleGetItem`, which was then re-raised as an `IndexError`.  This allowed Python's default implementation of iteration over an object that defines `__getitem__`, but doesn't define `__iter__` or `__len__` to terminate.  However, if the object being iterated over did not have `TupleStructInfo`, it would result in an infinite loop.

This commit adds an explicit implementation of `__iter__`, which raises a `TypeError` when called, preventing the default implementation provided by Python.  This is an intentional breakage of backwards compatibility, as arbitrary `relax.Expr` instances were not intended to be iterable.