### PR TITLE
[Unity] Add fast_pow in FastMathTransform pass

### DIFF
--- a/tests/python/relax/test_fast_math_transform.py
+++ b/tests/python/relax/test_fast_math_transform.py
@@ -16,6 +16,7 @@
 # under the License.
 """Tests to validate relax fast math tranform pass."""
 
+import numpy as np
 import pytest
 import tvm.testing
 from tvm import relax, topi
@@ -53,6 +54,46 @@ def test_optimize_transform_layout_pass_one_arg():
     Expected = bb.get()
 
     _run_pass_compare_output(Before, Expected)
+
+
+@tvm.testing.parametrize_targets("llvm", "cuda")
+def test_fastmath(target, dev):
+    def test_apply(low, high, step, alpha, dtype="float32"):
+        a_np = np.arange(low, high, step).astype(dtype)
+        b_np = np.power(a_np, alpha)
+
+        @I.ir_module
+        class ConstPower:
+            @R.function
+            def main(x: R.Tensor(a_np.shape, dtype=dtype)) -> R.Tensor(a_np.shape, dtype=dtype):
+                lv: R.Tensor(a_np.shape, dtype=dtype) = R.power(x, R.const(alpha, dtype=dtype))
+                return lv
+        fast_mod = FastMathTransform()(ConstPower)
+        ex = relax.build(fast_mod, target=target)
+        vm = relax.VirtualMachine(ex, dev)
+        x_tvm = tvm.nd.array(a_np)
+        tvm_output = vm["main"](x_tvm)
+        
+        tvm.testing.assert_allclose(tvm_output.numpy(), b_np, rtol=1e-5, atol=1e-5)
+
+        @I.ir_module
+        class Power:
+            @R.function
+            def main(x: R.Tensor(a_np.shape, dtype=dtype), y: R.Tensor((), dtype=dtype)) -> R.Tensor(a_np.shape, dtype=dtype):
+                lv: R.Tensor(a_np.shape, dtype=dtype) = R.power(x, y)
+                return lv
+        fast_mod = FastMathTransform()(Power)
+        ex = relax.build(fast_mod, target=target)
+        vm = relax.VirtualMachine(ex, dev)
+        x_tvm = tvm.nd.array(a_np)
+        y_tvm = tvm.nd.array(np.array(alpha).astype(dtype))
+        tvm_output = vm["main"](x_tvm, y_tvm)
+        
+        tvm.testing.assert_allclose(tvm_output.numpy(), b_np, rtol=1e-5, atol=1e-5)
+
+
+    test_apply(low=1, high=88, step=0.01, alpha=0.5)
+    test_apply(low=-88, high=88, step=0.01, alpha=10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR uses fast_exp to convert power op to fast but approximate counterpart.

When y is not an integer, fast_exp(log(x) * y) is much faster than topi.power(x, y). However, if y is not a constant, fast_exp(log(x) * y) will get a wrong anwser when x < 0 and y is an integer. To fix this problem, this PR uses power(x, y) = exp(log(abs(x)) * y) * (log((x / abs(x) - 1) * (ceil(y) - floor(y)) + 1) + (x / abs(x) - 1) * (y % 2) + 1).