### PR TITLE
[Unity] Support symbolic PrimValue arguments

### DIFF
--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -246,10 +246,11 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   Instruction::Arg VisitExpr_(const PrimValueNode* op) final {
     if (auto* int_imm = op->value.as<IntImmNode>()) {
       return builder_->ConvertConstant(int_imm->value);
-    } else {
-      auto* float_imm = op->value.as<FloatImmNode>();
-      ICHECK(float_imm) << "PrimValue can only be IntImm/FloatImm for now";
+    } else if (auto* float_imm = op->value.as<FloatImmNode>()) {
       return builder_->ConvertConstant(float_imm->value);
+    } else {
+      LOG(FATAL) << "PrimValue should only contain constant after  VMShapeLower, "
+                 << "but received " << GetRef<Expr>(op) << " with type " << op->value->GetTypeKey();
     }
   }
 

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -305,7 +305,9 @@ void NDArray::CopyFromTo(const DLTensor* from, DLTensor* to, TVMStreamHandle str
   DeviceAPI::Get(dev)->CopyDataFromTo(const_cast<DLTensor*>(from), to, stream);
 }
 
-ShapeTuple NDArray::Shape() const { return get_mutable()->shape_; }
+ShapeTuple NDArray::Shape() const {
+  return static_cast<const NDArray::Container*>(data_.get())->shape_;
+}
 
 runtime::DataType NDArray::DataType() const {
   return runtime::DataType(get_mutable()->dl_tensor.dtype);

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -67,6 +67,46 @@ NDArray AllocShapeHeap(void* ctx_ptr, int64_t size) {
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_shape_heap").set_body_typed(AllocShapeHeap);
 
 /*!
+ * \brief Builtin match R.Prim function.
+ *
+ * \param input_value The runtime value provided by the user
+ *
+ * \param heap The VM storage for symbolic shapes
+ *
+ * \param code_value The op code, defined in MatchShapeCode,
+ *     indicating how this value should be interpreted.
+ *
+ * \param reg The register, if using kStoreToHeap or
+ *     kAssertEqualToLoad, or a literal value if using kAssertEqualToImm
+ *
+ * \param err_ctx An optional string used in error messages, providing
+ *     additional context
+ *
+ * \sa MatchShape
+ */
+void MatchPrimValue(int64_t input_value, DLTensor* heap, int code_value, int64_t reg,
+                    Optional<String> err_ctx) {
+  int64_t* heap_data = heap == nullptr ? nullptr : static_cast<int64_t*>(heap->data);
+  MatchShapeCode code = static_cast<MatchShapeCode>(code_value);
+
+  if (code == MatchShapeCode::kAssertEqualToImm) {
+    CHECK_EQ(input_value, reg) << "RuntimeError: " << err_ctx.value_or("") << " match_cast error, "
+                               << " PrimValue mismatch to specified constant.";
+  } else if (code == MatchShapeCode::kStoreToHeap) {
+    heap_data[reg] = input_value;
+  } else if (code == MatchShapeCode::kNoOp) {
+  } else if (code == MatchShapeCode::kAssertEqualToLoad) {
+    CHECK_EQ(input_value, heap_data[reg])
+        << "RuntimeError: " << err_ctx.value_or("") << " match_cast error, "
+        << " PrimValue mismatch to a previous populated value.";
+  } else {
+    LOG(FATAL) << "Unknown match shape code: " << static_cast<int>(code);
+  }
+}
+
+TVM_REGISTER_GLOBAL("vm.builtin.match_prim_value").set_body_typed(MatchPrimValue);
+
+/*!
  * \brief Builtin match shape function.
  * \param args The packed function arguments.
  * \param rv The return value.
@@ -116,6 +156,30 @@ void MatchShape(TVMArgs args, TVMRetValue* rv) {
 }
 
 TVM_REGISTER_GLOBAL("vm.builtin.match_shape").set_body(MatchShape);
+
+/*!
+ * \brief Builtin make prim value function.
+ * \param heap The shape heap to use
+ * \param shape_code The shape code of the value
+ * \param rv The return value.
+ *
+ * \sa MakeShape
+ */
+int64_t MakePrimValue(DLTensor* heap, int shape_code, int64_t reg) {
+  // NOTE: heap can be nullptr
+  int64_t* heap_data = heap == nullptr ? nullptr : static_cast<int64_t*>(heap->data);
+
+  MakeShapeCode code = static_cast<MakeShapeCode>(shape_code);
+  if (code == MakeShapeCode::kUseImm) {
+    return reg;
+  } else if (code == MakeShapeCode::kLoadShape) {
+    return heap_data[reg];
+  } else {
+    LOG(FATAL) << "Invalid shape code: " << shape_code;
+  }
+}
+
+TVM_REGISTER_GLOBAL("vm.builtin.make_prim_value").set_body_typed(MakePrimValue);
 
 /*!
  * \brief Builtin make shape function.
@@ -207,6 +271,30 @@ void CheckShapeInfo(ObjectRef arg, int ndim, Optional<String> err_ctx) {
 }
 
 TVM_REGISTER_GLOBAL("vm.builtin.check_shape_info").set_body_typed(CheckShapeInfo);
+
+/*!
+ * \brief Builtin function to check if arg is PrimValue(dtype)
+ * \param arg The input argument.
+ * \param dtype Expected dtype of the PrimValue.  Can be DataType::Void() for unknown dtype.
+ * \param err_ctx Additional context if error occurs.
+ */
+void CheckPrimValueInfo(TVMArgValue arg, DataType dtype, Optional<String> err_ctx) {
+  if (dtype.is_bool()) {
+    arg.operator bool();
+  } else if (dtype.is_int()) {
+    arg.operator int64_t();
+  } else if (dtype.is_uint()) {
+    arg.operator uint64_t();
+  } else if (dtype.is_float()) {
+    arg.operator double();
+  } else if (dtype.is_handle()) {
+    arg.operator void*();
+  } else {
+    LOG(FATAL) << "TypeError: " << err_ctx.value_or("") << ", unsupported dtype " << dtype;
+  }
+}
+
+TVM_REGISTER_GLOBAL("vm.builtin.check_prim_value_info").set_body_typed(CheckPrimValueInfo);
 
 /*!
  * \brief Builtin function to check if arg is Tuple with size elements.


### PR DESCRIPTION
Prior this this commit, all symbolic variables needed to be defined either by tensor shapes, or by an explicit `tvm.runtime.ShapeTuple` argument.  This commit allows arguments `arg: R.Prim(value="n")` to serve as a source of definition for symbolic variables.