### PR TITLE
[Unity][BYOC] Do not use cudaMemcpy for max_seqlen in var len attention

### DIFF
--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -35,9 +35,7 @@ def instantiate_attention_template(attrs):
     var_len_template = """
   p.seqstart_q_ptr = (int32_t*)${seqstart_q}->data;
   p.seqstart_k_ptr = (int32_t*)${seqstart_k}->data;
-  // TODO(masahi): Pass max_seqlen_q as an integer
-  cudaMemcpy(&p.num_queries, (int32_t*)${max_seqlen_q}->data, sizeof(int32_t),
-             cudaMemcpyDeviceToHost);
+  p.num_queries = ((int32_t*)${max_seqlen_q}->data)[0];
   p.num_batches = ${seqstart_q}->shape[0] - 1;
 """
 
@@ -285,11 +283,8 @@ def instantiate_flash_attention_var_len_template(attrs):
     """Return host code for flash attention with variable sequence lengths."""
 
     template = """
-    int _max_seqlen_q, _max_seqlen_k;
-    cudaMemcpy(&_max_seqlen_q, (int32_t*)${max_seqlen_q}->data, sizeof(int32_t),
-               cudaMemcpyDeviceToHost);
-    cudaMemcpy(&_max_seqlen_k, (int32_t*)${max_seqlen_k}->data, sizeof(int32_t),
-               cudaMemcpyDeviceToHost);
+    int _max_seqlen_q = ((int32_t*)${max_seqlen_q}->data)[0];
+    int _max_seqlen_k = ((int32_t*)${max_seqlen_k}->data)[0];
 
     int batch_size = ${seqstart_q}->shape[0] - 1;
 

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -2174,6 +2174,7 @@ def test_batched_var_len_multi_query_attention():
                 ]
             }
         )
+
         @R.function
         def main(
             queries: R.Tensor(("num_tokens", 4096), dtype="float16"),


### PR DESCRIPTION
`max_seqlen` is a parameter required by cutlass and flash batched attention kernels. In practice, we compute this value at runtime via `max_seqlen = relax.op.max(seq_lens)`. Since the result of the max op is `Tensor[(), int32]` on GPU rather than a plain int32, and currently there is no easy way to convert the scalar tensor to a plain scalar, we've been doing `cudaMemcpy` of a single int32 to get a plain int32 from `DLTensor` of shape () in each kernel call. 

To remove unnecessary `cudaMemcpy`, I'm now enforcing the scalar tensor `max_seqlen` to be on CPU, so that in a kernel we can simply do `max_seqlen->data[0]` rather than `cudaMemcpy` to get an int32 value. The test case demonstrates how to do cuda -> cpu copy in a Relax mod - it uses the "virtual device" concept.

@vinx13 @sunggg    