### PR TITLE
[Unity] Move VarBinding's and MatchCast's value to base class

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -722,6 +722,10 @@ class BindingNode : public Object {
  public:
   /*! \brief The return variable to bound to. */
   Var var;
+
+  /*! \brief The binding value. */
+  Expr value;
+
   mutable Span span;
 
   static constexpr const char* _type_key = "relax.expr.Binding";
@@ -751,8 +755,6 @@ class Binding : public ObjectRef {
  */
 class MatchCastNode : public BindingNode {
  public:
-  /*! \brief The input value to match cast. */
-  Expr value;
   /*! \brief The struct info pattern to match to. */
   StructInfo struct_info;
 
@@ -796,9 +798,6 @@ class MatchCast : public Binding {
 
 class VarBindingNode : public BindingNode {
  public:
-  /*! \brief The binding value. */
-  Expr value;
-
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("var", &var);
     v->Visit("value", &value);

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -122,14 +122,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   Instruction::Arg VisitExpr_(const SeqExprNode* op) final {
     for (auto block : op->blocks) {
       for (Binding binding : block->bindings) {
-        Instruction::Arg value;
-        if (auto* var_binding = binding.as<VarBindingNode>()) {
-          value = this->VisitExpr(var_binding->value);
-        } else if (auto* match_cast = binding.as<MatchCastNode>()) {
-          value = this->VisitExpr(match_cast->value);
-        } else {
-          LOG(FATAL) << "Unsupported binding " << binding->GetTypeKey();
-        }
+        Instruction::Arg value = VisitExpr(binding->value);
         this->var_arg_map_.insert({binding->var, value});
       }
     }

--- a/src/relax/backend/vm/codegen_vm_tir.cc
+++ b/src/relax/backend/vm/codegen_vm_tir.cc
@@ -203,14 +203,7 @@ class CodeGenVMTIR : public ExprFunctor<Optional<PrimExpr>(const Expr&)> {
   Optional<PrimExpr> VisitExpr_(const SeqExprNode* op) final {
     for (auto block : op->blocks) {
       for (Binding binding : block->bindings) {
-        Optional<PrimExpr> value;
-        if (auto* var_binding = binding.as<VarBindingNode>()) {
-          value = this->VisitExpr(var_binding->value);
-        } else if (auto* match_cast = binding.as<MatchCastNode>()) {
-          value = this->VisitExpr(match_cast->value);
-        } else {
-          LOG(FATAL) << "Unsupported binding " << binding->GetTypeKey();
-        }
+        Optional<PrimExpr> value = VisitExpr(binding->value);
         this->var_map_.insert({binding->var, value});
       }
     }

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -226,29 +226,18 @@ class BlockBuilderImpl : public BlockBuilderNode {
   void EmitNormalized(Binding binding) final {
     BlockFrame* cur_frame = CurrentBlockFrame();
 
-    if (const auto* var_binding = binding.as<VarBindingNode>()) {
-      if (!cur_frame->is_dataflow) {
-        ICHECK(!var_binding->var.as<DataflowVarNode>())
-            << "Cannot emit dataflow var in non-dataflow block";
-      }
-      // normalized check
-      ICHECK(var_binding->var->struct_info_.defined());
-      ICHECK(var_binding->value->struct_info_.defined());
-      cur_frame->bindings.push_back(binding);
-      binding_table_[var_binding->var->vid] = var_binding->value;
-    } else if (const auto* match_cast = binding.as<MatchCastNode>()) {
-      if (!cur_frame->is_dataflow) {
-        ICHECK(!match_cast->var.as<DataflowVarNode>())
-            << "Cannot emit dataflow var in non-dataflow block";
-      }
-      // normalized check
-      ICHECK(match_cast->var->struct_info_.defined());
-      ICHECK(match_cast->value->struct_info_.defined());
+    if (!cur_frame->is_dataflow) {
+      ICHECK(!binding->var.as<DataflowVarNode>())
+          << "Cannot emit dataflow var in non-dataflow block";
+    }
+    // normalized check
+    ICHECK(binding->var->struct_info_.defined());
+    ICHECK(binding->value->struct_info_.defined());
+    cur_frame->bindings.push_back(binding);
+    if (binding.as<VarBindingNode>()) {
       // NOTE match shape do not follow simple binding rule
       // as a result should not appear in binding table.
-      cur_frame->bindings.push_back(binding);
-    } else {
-      LOG(FATAL) << "Unsupported binding type: " << binding->GetTypeKey();
+      binding_table_[binding->var->vid] = binding->value;
     }
   }
 

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -519,11 +519,10 @@ BindingBlock ExprMutatorBase::VisitBindingBlock(const BindingBlock& block) {
   Array<Binding> bindings;
   if (const auto* node = block.as<BindingBlockNode>()) {
     for (auto binding : node->bindings) {
+      Expr new_value = this->VisitExpr(binding->value);
       if (auto var_binding = binding.as<VarBindingNode>()) {
-        Expr new_value = this->VisitExpr(var_binding->value);
         bindings.push_back(VarBinding(var_binding->var, new_value));
       } else if (auto match_cast = binding.as<MatchCastNode>()) {
-        Expr new_value = this->VisitExpr(match_cast->value);
         bindings.push_back(MatchCast(match_cast->var, new_value, match_cast->struct_info));
       } else {
         LOG(FATAL) << "TypeError: Invalid type: " << binding->GetTypeKey();

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -894,13 +894,7 @@ class OperatorFusor : public ExprMutator {
         }
       };
 
-      if (const auto* var_binding = binding.as<VarBindingNode>()) {
-        PostOrderVisit(var_binding->value, update_boundary);
-      } else {
-        const auto* match_cast = binding.as<MatchCastNode>();
-        ICHECK_NOTNULL(match_cast);
-        PostOrderVisit(match_cast->value, update_boundary);
-      }
+      PostOrderVisit(binding->value, update_boundary);
     }
   }
 

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -229,13 +229,13 @@ bool IsImpureCall(const Call& call) {
 }
 
 Expr GetBoundValue(const Binding& b) {
-  if (auto* var_binding = b.as<VarBindingNode>()) {
-    return var_binding->value;
-  } else if (auto* match_binding = b.as<MatchCastNode>()) {
-    return match_binding->value;
-  } else {
-    CHECK(false) << "Invalid binding (should never happen)";
+  static bool first_usage = true;
+  if (first_usage) {
+    LOG(WARNING) << "Use of the GetBoundValue function is deprecated.  "
+                 << "The bound value can instead be accessed directly "
+                 << "with 'binding->value'.";
   }
+  return b->value;
 }
 
 /*!


### PR DESCRIPTION
Prior to this commit, the `VarBinding` and `MatchCast` had equivalent `Expr value` fields.  For use cases that need the bound value (e.g. collecting known values), this required downcasting to each subclass.  This commit moves the `Expr value` to the base `Binding` class, removing the need for the downcasting.

No impact to either C++ or Python usage is expected.  On the C++ side, all use of `VarBindingNode::value` or `MatchCastNode::value` will now access `BindingNode::value`.  On the Python side, all dynamic access of `binding_obj.value` will access the new field.