### PR TITLE
[WebGPU] Add shuffle support for webgpu

### DIFF
--- a/src/target/source/codegen_webgpu.h
+++ b/src/target/source/codegen_webgpu.h
@@ -67,6 +67,7 @@ class CodeGenWebGPU final : public CodeGenC {
   void VisitExpr_(const SelectNode* op, std::ostream& os) override;   // NOLINT(*)
   void VisitExpr_(const FloatImmNode* op, std::ostream& os) final;    // NOLINT(*)
   void VisitExpr_(const IntImmNode* op, std::ostream& os) final;      // NOLINT(*)
+  void VisitExpr_(const ShuffleNode* op, std::ostream& os) final;     // NOLINT(*)
 
   // stmt printing
   void VisitStmt_(const LetStmtNode* op) final;


### PR DESCRIPTION
This PR adds shuffle support for WebGPU. Following up on the discussion in #15517, the new field `rewrite_scalar_read_to_vector_shuffle` in `PointerTypeRewrite` requires Shuffle to achieve scalar reads.

This resolves the issue described in https://github.com/apache/tvm/pull/15517#issuecomment-1722362012.

cc: @vinx13, @tqchen, @MasterJH5574 