### PR TITLE
[Unity][nn.Module] Support `nn.SourceModule`

### DIFF
--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -15,14 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 """Util to invoke C/C++ compilers in the system."""
-# pylint: disable=invalid-name
-import sys
-import shutil
 import os
+import shutil
 import subprocess
 
-from . import utils as _utils, tar as _tar
+# pylint: disable=invalid-name
+import sys
+
 from .._ffi.base import py_str
+from . import tar as _tar
+from . import utils as _utils
 
 
 def _is_linux_like():
@@ -31,6 +33,10 @@ def _is_linux_like():
         or sys.platform.startswith("linux")
         or sys.platform.startswith("freebsd")
     )
+
+
+def _is_windows_like():
+    return sys.platform == "win32"
 
 
 def get_cc():
@@ -79,7 +85,7 @@ def create_shared(output, objects, options=None, cc=None):
 
     if _is_linux_like():
         _linux_compile(output, objects, options, cc, compile_shared=True)
-    elif sys.platform == "win32":
+    elif _is_windows_like():
         _windows_compile(output, objects, options)
     else:
         raise ValueError("Unsupported platform")
@@ -154,7 +160,7 @@ def create_executable(output, objects, options=None, cc=None):
 
     if _is_linux_like():
         _linux_compile(output, objects, options, cc)
-    elif sys.platform == "win32":
+    elif _is_windows_like():
         _windows_compile(output, objects, options)
     else:
         raise ValueError("Unsupported platform")

--- a/python/tvm/relax/frontend/nn/__init__.py
+++ b/python/tvm/relax/frontend/nn/__init__.py
@@ -16,7 +16,15 @@
 # under the License.
 """A PyTorch-like API to build IRModules."""
 from . import op, spec
-from .core import Effect, ExternModule, Module, ModuleList, Parameter, Tensor
+from .core import (
+    Effect,
+    ExternModule,
+    Module,
+    ModuleList,
+    Parameter,
+    SourceModule,
+    Tensor,
+)
 from .modules import (
     GELU,
     Conv1D,

--- a/tests/python/relax/test_frontend_nn_extern_module.py
+++ b/tests/python/relax/test_frontend_nn_extern_module.py
@@ -14,104 +14,183 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import os
+# pylint: disable=missing-docstring
 import tempfile
 
-import pytest
+import numpy as np
 
 import tvm
-from tvm.script import ir as I, tir as T, relax as R
+import tvm.testing
+from tvm import relax
 from tvm.relax.frontend import nn
 from tvm.relax.frontend.nn import spec
+from tvm.script import ir as I
+from tvm.script import relax as R
+from tvm.script import tir as T
 
+SOURCE_CODE = """
+#include <dlpack/dlpack.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/data_type.h>
 
-def _gen_extern_module(mod_dir, file):
-    src = """#include <dlpack/dlpack.h>
-    #include <tvm/runtime/packed_func.h>
+namespace {
 
-    int f_matmul(DLTensor* a, DLTensor* b, DLTensor* c) { return 0; }
+int _scalar_add(DLTensor* a, DLTensor* b, DLTensor* c) {
+  using namespace tvm::runtime;
+  ICHECK(a->ndim == 0);
+  ICHECK(b->ndim == 0);
+  ICHECK(c->ndim == 0);
+  ICHECK(DataType(a->dtype) == DataType::Float(32));
+  ICHECK(DataType(b->dtype) == DataType::Float(32));
+  ICHECK(DataType(c->dtype) == DataType::Float(32));
+  float* a_data = static_cast<float*>(a->data);
+  float* b_data = static_cast<float*>(b->data);
+  float* c_data = static_cast<float*>(c->data);
+  *c_data = *a_data + *b_data;
+  return 0;
+}
 
-    TVM_DLL_EXPORT_TYPED_FUNC(matmul, f_matmul)"""
-    with open(f"{mod_dir}/{file}.cc", "w") as cc_file:
-        cc_file.write(src)
-    cur_dir = os.path.dirname(os.path.abspath(__file__))
-    os.system(
-        f"gcc -c {mod_dir}/{file}.cc "
-        f"-o {mod_dir}/{file}.o "
-        f"-I{cur_dir}/../../../include "
-        f"-I{cur_dir}/../../../3rdparty/dlpack/include "
-        f"-I{cur_dir}/../../../3rdparty/dmlc-core/include"
-    )
-    return f"{mod_dir}/{file}.o"
+int _test_sym(DLTensor* a, DLTensor* b, DLTensor* c) {
+  using namespace tvm::runtime;
+  ICHECK(a->ndim == 3);
+  ICHECK(b->ndim == 3);
+  ICHECK(c->ndim == 4);
+  ICHECK(DataType(a->dtype) == DataType::Float(32));
+  ICHECK(DataType(b->dtype) == DataType::Float(32));
+  ICHECK(DataType(c->dtype) == DataType::Float(32));
+  int x = a->shape[0];
+  int y = a->shape[1];
+  int z = b->shape[1];
+  ICHECK(a->shape[0] == x);
+  ICHECK(a->shape[1] == y);
+  ICHECK(a->shape[2] == 1);
+  ICHECK(b->shape[0] == y);
+  ICHECK(b->shape[1] == z);
+  ICHECK(b->shape[2] == 5);
+  ICHECK(c->shape[0] == x);
+  ICHECK(c->shape[1] == y);
+  ICHECK(c->shape[2] == z);
+  ICHECK(c->shape[3] == 9);
+  return 0;
+}
+
+}
+TVM_DLL_EXPORT_TYPED_FUNC(ext_scalar_add, _scalar_add);
+TVM_DLL_EXPORT_TYPED_FUNC(ext_test_sym, _test_sym);
+"""
 
 
 def test_extern_module():
-    shape_a = ("a", "b", "c", "d", 1, 2, 3, 4)
-    shape_b = ("c", "d", "e", "f", 5, 6, 7, 8)
-    shape_c = ("a", "b", "c", "d", "e", "f", 9, 10)
+    shape_a = ("x", "y", 1)
+    shape_b = ("y", "z", 5)
+    shape_c = ("x", "y", "z", 9)
     dtype = "float32"
-    tmp_dir = tempfile.mkdtemp()
-    obj_file = _gen_extern_module(tmp_dir, "test")
-    func_name = "matmul"
-    os.system(f"ls {tmp_dir}")
 
-    ext_mod = nn.ExternModule(
-        module_spec=spec.ExternModuleSpec(
-            filename=obj_file,
-            functions=[
-                spec.ExternFunctionSpec(
-                    symbol=func_name,
-                    args=[
-                        spec.Tensor(shape_a, dtype),
-                        spec.Tensor(shape_b, dtype),
-                    ],
-                    ret=spec.Tensor(shape_c, dtype),
-                )
-            ],
-        )
-    )
+    class MyExtMod(nn.SourceModule):
+        def __init__(self):
+            super().__init__(
+                source_code=SOURCE_CODE,
+                source_format="cpp",
+                functions={
+                    "ext_scalar_add": spec.ExternFunctionSpec(
+                        args=[
+                            spec.Tensor((), dtype),
+                            spec.Tensor((), dtype),
+                        ],
+                        ret=spec.Tensor((), dtype),
+                    ),
+                    "ext_test_sym": spec.ExternFunctionSpec(
+                        args=[
+                            spec.Tensor(shape_a, dtype),
+                            spec.Tensor(shape_b, dtype),
+                        ],
+                        ret=spec.Tensor(shape_c, dtype),
+                    ),
+                },
+                compile_options=None,
+                compiler=None,
+                output_format="obj",
+            )
 
-    class MatmulModule(nn.Module):
+        def scalar_add(self, a: nn.Tensor, b: nn.Tensor):  # pylint: disable=invalid-name
+            return self.get_extern_func("ext_scalar_add")(a, b)
+
+        def test_sym(self, a: nn.Tensor, b: nn.Tensor):  # pylint: disable=invalid-name
+            return self.get_extern_func("ext_test_sym")(a, b)
+
+    my_ext_mod = MyExtMod()
+
+    class TestModule(nn.Module):
         def __init__(self) -> None:
-            self.Matmul = ext_mod
+            self.extern_matmul = my_ext_mod
 
-        def forward(self, a: nn.Tensor, b: nn.Tensor):
-            return self.Matmul.get_extern_func(func_name)(a, b)
+        def scalar_add(self, a: nn.Tensor, b: nn.Tensor):  # pylint: disable=invalid-name
+            return self.extern_matmul.scalar_add(a, b)
 
-    matmul_mod = MatmulModule()
-    ir_module, _ = matmul_mod.export_tvm(
+        def test_sym(self, a: nn.Tensor, b: nn.Tensor):  # pylint: disable=invalid-name
+            return self.extern_matmul.test_sym(a, b)
+
+    model = TestModule()
+    ir_module, _ = model.export_tvm(
         spec={
-            "forward": {
+            "scalar_add": {
+                "a": spec.Tensor((), dtype),
+                "b": spec.Tensor((), dtype),
+            },
+            "test_sym": {
                 "a": spec.Tensor(shape_a, dtype),
                 "b": spec.Tensor(shape_b, dtype),
-            }
+            },
         }
     )
 
-    @R.function
-    def forward(
-        a_1: R.Tensor(("a", "b", "c", "d", 1, 2, 3, 4), dtype="float32"),
-        b_1: R.Tensor(("c", "d", "e", "f", 5, 6, 7, 8), dtype="float32"),
-    ) -> R.Tensor(("a", "b", "c", "d", "e", "f", 9, 10), dtype="float32"):
-        a = T.int64()
-        b = T.int64()
-        c = T.int64()
-        d = T.int64()
-        e = T.int64()
-        f = T.int64()
-        R.func_attr({"num_input": 2})
-        with R.dataflow():
-            matmul = R.call_dps_packed(
-                "matmul",
-                (a_1, b_1),
-                out_sinfo=R.Tensor((a, b, c, d, e, f, 9, 10), dtype="float32"),
-            )
-            gv1: R.Tensor((a, b, c, d, e, f, 9, 10), dtype="float32") = matmul
-            R.output(gv1)
-        return gv1
+    @I.ir_module
+    class ExpectedModule:
+        @R.function
+        def scalar_add(
+            a: R.Tensor((), dtype="float32"), b: R.Tensor((), dtype="float32")
+        ) -> R.Tensor((), dtype="float32"):
+            R.func_attr({"num_input": 2})
+            with R.dataflow():
+                ext_scalar_add = R.call_dps_packed(
+                    "ext_scalar_add", (a, b), out_sinfo=R.Tensor((), dtype="float32")
+                )
+                gv: R.Tensor((), dtype="float32") = ext_scalar_add
+                R.output(gv)
+            return gv
 
-    tvm.ir.assert_structural_equal(ir_module["forward"], forward)
+        @R.function
+        def test_sym(
+            a: R.Tensor(("x", "y", 1), dtype="float32"), b: R.Tensor(("y", "z", 5), dtype="float32")
+        ) -> R.Tensor(("x", "y", "z", 9), dtype="float32"):
+            x, y, z = T.int64(), T.int64(), T.int64()
+            R.func_attr({"num_input": 2})
+            with R.dataflow():
+                ext_test_sym = R.call_dps_packed(
+                    "ext_test_sym", (a, b), out_sinfo=R.Tensor((x, y, z, 9), dtype="float32")
+                )
+                gv1: R.Tensor((x, y, z, 9), dtype="float32") = ext_test_sym
+                R.output(gv1)
+            return gv1
+
+    tvm.ir.assert_structural_equal(ir_module["scalar_add"], ExpectedModule["scalar_add"])
+    tvm.ir.assert_structural_equal(ir_module["test_sym"], ExpectedModule["test_sym"])
+    assert len(ir_module.attrs["external_mods"]) == 1
+    assert ir_module.attrs["external_mods"][0].type_key == "static_library"
+
+    scalar_a = tvm.nd.array(np.array(1.0, dtype="float32"))
+    scalar_b = tvm.nd.array(np.array(3.0, dtype="float32"))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = temp_dir + "/lib.so"
+        relax.build(ir_module, target="llvm").export_library(output_path)
+        compiled = tvm.runtime.relax_vm.VirtualMachine(
+            tvm.runtime.load_module(output_path),
+            device=tvm.cpu(),
+        )
+        scalar_c = compiled["scalar_add"](scalar_a, scalar_b)
 
 
 if __name__ == "__main__":
-    tvm.testing.main()
+    test_extern_module()
+    # tvm.testing.main()


### PR DESCRIPTION
Following https://github.com/apache/tvm/pull/15487, this PR introduces `nn.SourceModule` as a subclass of
`nn.ExternModule` to more convenient handling of externally implemented
operators, subgraphs and other components.

**What is `nn.ExternModule` designed for?** It is a generic design that
accepts any object file (`.o` in Linux) and combines the symbols within
into TVM-generated shared/static library. This way, TVM-generated
library will be able to call into the symbols in the object files
provided. For example, calling into `cutlass_fmha` in TVM Relax.

**What is `nn.SourceModule`?** It is a subclass that builds on top of
`nn.ExternModule`, which helps with a specific case where the external
implementation is provided as C++/CUDA source code and `SourceModule`
could conveniently take care of applying a C++/CUDA compiler to convert
it to convert them into object files.

**C++/CUDA Calling Convention.** An exported symbol should be explicitly
declared with macro `TVM_DLL_EXPORT_TYPED_FUNC($SYMBOL, $CPP_FUNC)`,
while it is recommended to always hide the symbols that we don't wish to
export. Multiple files should never define the same symbol, otherwise it
is considered as UB.

**Marks on `nn.Module`.** It is required to define the input/output
shapes and dtypes using `nn.spec.ExternFunctionSpec`. Symbolic/dynamic
shapes are supported, but there are a few limitations to note:

1) Multi-output is currently not supported, meaning the return value has
to be a single `nn.Tensor`. There is no technical challenge we are aware
of, and we could extend the interface to get it supported in the future
if there's any need.
2) Symbolic dtype is not supported. It means one has to export multiple
symbols for multiple dtypes even if the compute is mathematically
identical, e.g. `matmul_f16_f16_f16`, `matmul_f32_f32_f32`. I imagine it
could be alleviated if customization of dtype deduction is introduced.

**Example.** Take the C++ code below as an example:

```C++
\#include <dlpack/dlpack.h>
\#include <tvm/runtime/packed_func.h>
\#include <tvm/runtime/data_type.h>

namespace {

int _scalar_add(DLTensor* a, DLTensor* b, DLTensor* c) {
  using namespace tvm::runtime;
  ICHECK(a->ndim == 0);
  ICHECK(b->ndim == 0);
  ICHECK(c->ndim == 0);
  ICHECK(DataType(a->dtype) == DataType::Float(32));
  ICHECK(DataType(b->dtype) == DataType::Float(32));
  ICHECK(DataType(c->dtype) == DataType::Float(32));
  float* a_data = static_cast<float*>(a->data);
  float* b_data = static_cast<float*>(b->data);
  float* c_data = static_cast<float*>(c->data);
  *c_data = *a_data + *b_data;
  return 0;
}

int _test_sym(DLTensor* a, DLTensor* b, DLTensor* c) {
  using namespace tvm::runtime;
  ICHECK(a->ndim == 3);
  ICHECK(b->ndim == 3);
  ICHECK(c->ndim == 4);
  ICHECK(DataType(a->dtype) == DataType::Float(32));
  ICHECK(DataType(b->dtype) == DataType::Float(32));
  ICHECK(DataType(c->dtype) == DataType::Float(32));
  int x = a->shape[0];
  int y = a->shape[1];
  int z = b->shape[1];
  ICHECK(a->shape[0] == x);
  ICHECK(a->shape[1] == y);
  ICHECK(a->shape[2] == 1);
  ICHECK(b->shape[0] == y);
  ICHECK(b->shape[1] == z);
  ICHECK(b->shape[2] == 5);
  ICHECK(c->shape[0] == x);
  ICHECK(c->shape[1] == y);
  ICHECK(c->shape[2] == z);
  ICHECK(c->shape[3] == 9);
  return 0;
}

}
TVM_DLL_EXPORT_TYPED_FUNC(ext_scalar_add, _scalar_add);
TVM_DLL_EXPORT_TYPED_FUNC(ext_test_sym, _test_sym);
```

It exposes two symbols `ext_scalar_add` and `ext_test_sym`. In
`nn.Module`, their shape/dtype deduction rules could be described as:

```python
dtype = "float32"
functions = {
  "ext_scalar_add": spec.ExternFunctionSpec(
    args=[
      spec.Tensor((), dtype),
      spec.Tensor((), dtype),
    ],
    ret=spec.Tensor((), dtype),
  ),
  "ext_test_sym": spec.ExternFunctionSpec(
    args=[
      spec.Tensor(("x", "y", 1), dtype),
      spec.Tensor(("y", "z", 5), dtype),
    ],
    ret=spec.Tensor(("x", "y", "z", 9), dtype),
  ),
}
```

and thus the external module could be defined as:

```python
class MyExtMod(nn.SourceModule):
    def __init__(self):
        super().__init__(
            source_code=SOURCE_CODE,
            source_format="cpp",
            functions=functions,
        )
    def scalar_add(self, a: nn.Tensor, b: nn.Tensor):  # pylint: disable=invalid-name
        return self.get_extern_func("ext_scalar_add")(a, b)
    def test_sym(self, a: nn.Tensor, b: nn.Tensor):  # pylint: disable=invalid-name
        return self.get_extern_func("ext_test_sym")(a, b)
```

Any `nn.Module` could use this `nn.SourceModule` as part of the computation
and export them into TVM IRModule:

```python
my_ext_mod = MyExtMod()

class TestModule(nn.Module):
    def __init__(self) -> None:
        self.extern_matmul = my_ext_mod

    def scalar_add(self, a: nn.Tensor, b: nn.Tensor):  # pylint: disable=invalid-name
        return self.extern_matmul.scalar_add(a, b)

    def test_sym(self, a: nn.Tensor, b: nn.Tensor):  # pylint: disable=invalid-name
        return self.extern_matmul.test_sym(a, b)

model = TestModule()
ir_module, _ = model.export_tvm(
    spec={
        "scalar_add": {
            "a": spec.Tensor((), dtype),
            "b": spec.Tensor((), dtype),
        },
        "test_sym": {
            "a": spec.Tensor(shape_a, dtype),
            "b": spec.Tensor(shape_b, dtype),
        },
    }
)
```