### PR TITLE
[Unity][nn.Module] Support Parameter Packing

### DIFF
--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -45,8 +45,11 @@ class IOEffect(Effect):
 
     def create(self, name_hint: str) -> List[rx.Var]:
         assert self.effect is None
-        self.effect = rx.Var(f"{name_hint}.io", struct_info=rx.ObjectStructInfo())
-        return [self.effect]
+        effect = rx.Var(f"{name_hint}.io", struct_info=rx.ObjectStructInfo())
+        return [effect]
+
+    def set_state(self, state_vars: List[rx.Var]) -> None:
+        (self.effect,) = state_vars
 
     def finalize(self) -> List[rx.Var]:
         result = self.effect
@@ -575,7 +578,7 @@ class KVCache(Effect):
             )
         ]
 
-    def create(self, name_hint: str) -> rx.Var:
+    def create(self, name_hint: str) -> List[rx.Var]:
         """
         Create the implicit inputs to a relax.Function that represents the KVCache effect.
 
@@ -586,11 +589,14 @@ class KVCache(Effect):
 
         Returns
         -------
-        ret : relax.Var
+        ret : List[relax.Var]
             The relax.Var for KVCache.
         """
-        self.cache = rx.Var(name_hint, struct_info=rx.ObjectStructInfo())
-        return [self.cache]
+        cache = rx.Var(name_hint, struct_info=rx.ObjectStructInfo())
+        return [cache]
+
+    def set_state(self, state_vars: List[rx.Var]) -> None:
+        (self.cache,) = state_vars
 
     def finalize(self) -> List[rx.Var]:
         """

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -1383,7 +1383,7 @@ def interpolate(
 def tensor_expr_op(
     tensor_expr_func: Callable,
     name_hint: str,
-    args: List[Union[Tensor, _tir.Var]],
+    args: List[Union[Tensor, _tir.Var, int]],
     *,
     attrs: Optional[Dict[str, Any]] = None,
 ):

--- a/python/tvm/relax/frontend/nn/torch.py
+++ b/python/tvm/relax/frontend/nn/torch.py
@@ -132,4 +132,4 @@ def _method_spec_from_torch(
     if len(arg_names) != len(args_torch):
         raise TypeError(f"Expected {len(arg_names)} arguments, but got {len(args_torch)} arguments")
     arg_specs = [_as_spec(i) for i in args_torch]
-    return _spec.MethodSpec(method, arg_names, arg_specs)
+    return _spec.MethodSpec(method, arg_names, arg_specs, param_mode="plain", effect_mode="plain")

--- a/tests/python/relax/test_frontend_nn_packing.py
+++ b/tests/python/relax/test_frontend_nn_packing.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name,missing-docstring
+import tvm
+from tvm.relax.frontend import nn
+from tvm.script import ir as I
+from tvm.script import relax as R
+
+
+def main():
+    class TestModule(nn.Module):
+        def __init__(self, in_features: int, out_features: int):
+            super().__init__()
+            self.in_features = in_features
+            self.out_features = out_features
+            self.linear_1 = nn.Linear(in_features, out_features, bias=False)
+            self.linear_2 = nn.Linear(in_features, out_features, bias=False)
+
+        def forward(self, x: nn.Tensor):
+            x1 = self.linear_1(x)
+            x2 = self.linear_2(x)
+            return x1 + x2
+
+    # pylint: disable=line-too-long
+    @I.ir_module
+    class ExpectedModule:  # pylint: disable=too-few-public-methods
+        @R.function
+        def forward(
+            x: R.Tensor((1, 10), dtype="float32"),
+            packed_params: R.Tuple(
+                R.Tensor((20, 10), dtype="float32"), R.Tensor((20, 10), dtype="float32")
+            ),
+        ) -> R.Tensor((1, 20), dtype="float32"):
+            R.func_attr({"num_input": 1})  # type: ignore[attr-defined]
+            with R.dataflow():  # type: ignore[attr-defined]
+                linear_1_weight: R.Tensor((20, 10), dtype="float32") = packed_params[0]  # type: ignore[valid-type]
+                linear_2_weight: R.Tensor((20, 10), dtype="float32") = packed_params[1]  # type: ignore[valid-type]
+                permute_dims: R.Tensor((10, 20), dtype="float32") = R.permute_dims(  # type: ignore[attr-defined,valid-type]
+                    linear_1_weight, axes=None
+                )
+                matmul: R.Tensor((1, 20), dtype="float32") = R.matmul(  # type: ignore[attr-defined,valid-type]
+                    x, permute_dims, out_dtype="void"
+                )
+                permute_dims1: R.Tensor((10, 20), dtype="float32") = R.permute_dims(  # type: ignore[attr-defined,valid-type]
+                    linear_2_weight, axes=None
+                )
+                matmul1: R.Tensor((1, 20), dtype="float32") = R.matmul(  # type: ignore[attr-defined,valid-type]
+                    x, permute_dims1, out_dtype="void"
+                )
+                add: R.Tensor((1, 20), dtype="float32") = R.add(matmul, matmul1)  # type: ignore[attr-defined,valid-type]
+                gv: R.Tensor((1, 20), dtype="float32") = add  # type: ignore[attr-defined,valid-type]
+                R.output(gv)  # type: ignore[attr-defined,valid-type]
+            return gv
+
+    # pylint: enable=line-too-long
+
+    model = TestModule(10, 20)
+    mod, _ = model.export_tvm(
+        spec={
+            "forward": {
+                "x": nn.spec.Tensor([1, model.in_features], "float32"),
+                "$": {
+                    "param_mode": "packed",
+                    "effect_mode": "none",
+                },
+            }
+        }
+    )
+    tvm.ir.assert_structural_equal(mod, ExpectedModule)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces support for parameter/effect packing.

**What is parameter packing?** There are two ways to represent weights
as input(s) of Relax functions.

- Unpacked: each weight is passed in as a separate parameter:

```python
@R.function
def f(
  ...,
  weight_0: R.Tensor(...),
  weight_1: R.Tensor(...),
  ...,
)
```
- Packed: all weights are packed together as a Relax Tuple and passed in
  as a single parameter:

```python
@R.function
def f(
  ...,
  weights: R.Tuple((R.Tensor(...), R.Tensor(...))),
  ...,
)
```

**Why support parameter packing?** First of all, currently MLC LLM uses
packed parameter as the default format in its runtime. To align the new
`nn.Module` frontend with the existing behavior, we allow packing as a
non-default option to be turned on.

Second, having a calling convention where the last argument being
packed parameters and the second last being packed effects could help
simplify many runtime behavior, for example, instructing the generated
code to skip type checking, etc.

**How to enable parameter/effect packing?** We allow an extra argument
`$` when creating `nn.spec.MethodSpec`, which is effectively
fine-grained configuration of exported Relax function:

```python
model.export_tvm(
    spec={
        "forward": {
            "x": nn.spec.Tensor([1, model.in_features], "float32"),
            "$": {
                "param_mode": "packed", // Configure parameter packing
                "effect_mode": "none", // Configure effect packing
            },
        }
    }
)
```
