### PR TITLE
[Unity][Training] Support intermediate vars as require_grads for Gradient pass

### DIFF
--- a/python/tvm/_ffi/base.py
+++ b/python/tvm/_ffi/base.py
@@ -446,7 +446,9 @@ def raise_last_ffi_error():
         for frame in frames:
             if " at " in frame:
                 func_name, frame = frame.split(" at ", 1)
-                filename, lineno = frame.rsplit(":", 1)
+                # filename, lineno = frame.rsplit(":", 1)
+                filename, *lineno = frame.rsplit(":", 1)
+                lineno = lineno[0] if lineno else "1"
                 func_name = func_name.strip()
                 filename = filename.strip()
                 lineno = int(lineno.strip())

--- a/python/tvm/_ffi/base.py
+++ b/python/tvm/_ffi/base.py
@@ -446,9 +446,7 @@ def raise_last_ffi_error():
         for frame in frames:
             if " at " in frame:
                 func_name, frame = frame.split(" at ", 1)
-                # filename, lineno = frame.rsplit(":", 1)
-                filename, *lineno = frame.rsplit(":", 1)
-                lineno = lineno[0] if lineno else "1"
+                filename, lineno = frame.rsplit(":", 1)
                 func_name = func_name.strip()
                 filename = filename.strip()
                 lineno = int(lineno.strip())

--- a/python/tvm/relax/op/_op_gradient.py
+++ b/python/tvm/relax/op/_op_gradient.py
@@ -256,8 +256,8 @@ def maximum_grad(
     y = orig_call.args[1]
     zero = relax.const(0, _get_dtype(x))
     return [
-        where(less(x, y), zero, output_grad),
-        where(greater_equal(x, y), zero, output_grad),
+        _fit_shape(ctx, where(less(x, y), zero, output_grad), x),
+        _fit_shape(ctx, where(greater_equal(x, y), zero, output_grad), y),
     ]
 
 
@@ -280,8 +280,8 @@ def minimum_grad(
     y = orig_call.args[1]
     zero = relax.const(0, _get_dtype(x))
     return [
-        where(greater_equal(x, y), zero, output_grad),
-        where(less(x, y), zero, output_grad),
+        _fit_shape(ctx, where(greater_equal(x, y), zero, output_grad), x),
+        _fit_shape(ctx, where(less(x, y), zero, output_grad), y),
     ]
 
 

--- a/python/tvm/relax/op/manipulate.py
+++ b/python/tvm/relax/op/manipulate.py
@@ -170,7 +170,7 @@ def permute_dims(x: Expr, axes: Optional[List[int]] = None) -> Expr:
         The input data to the operator.
 
     axes : Optional[List[int]]
-        The target axes order, reverse order if not specified.
+        The target axes order. If not specified, permute_dims will reverse the order of all axes.
 
     Returns
     -------

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -617,7 +617,7 @@ class GradientMutator : private ExprMutator {
     if (!require_grads) {
       require_grads = new_func->params;
     } else {
-      require_grads = CheckAndMapRequireGrads(require_grads.value(), copier.var_map, func_name);
+      require_grads = CheckAndMapRequireGrads(require_grads.value(), copier.GetVarMap(), func_name);
     }
 
     // Step 4. Generate the adjoint function, use RemoveAllUnused to simplify it, and then return

--- a/tests/python/relax/test_transform_gradient_checkpoint.py
+++ b/tests/python/relax/test_transform_gradient_checkpoint.py
@@ -16,12 +16,13 @@
 # under the License.
 """Unit tests for gradient with checkpointing."""
 import tvm
-from tvm.relax.block_builder import BlockBuilder
-from tvm.relax.testing.nn import checkpoint, emit_checkpoint, emit_checkpoint_sequential
 import tvm.testing
+
 from tvm import relax
 from tvm.ir.base import assert_structural_equal
-from tvm.script.parser import relax as R, ir as I
+from tvm.relax.block_builder import BlockBuilder
+from tvm.relax.testing import nn
+from tvm.script.parser import ir as I, relax as R
 
 
 def test_sequential():
@@ -47,51 +48,51 @@ def test_sequential():
     @I.ir_module
     class Expected:
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
-                lv2: R.Tensor((3, 3), dtype="float32") = R.power(lv1, R.const(3, "float32"))
-                lv3: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
-                lv4: R.Tensor((3, 3), dtype="float32") = R.power(lv3, R.const(3, "float32"))
-                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
-                gv_1: R.Tensor((), dtype="float32") = gv
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
-                gv_adjoint1: R.Tensor((), dtype="float32") = gv_adjoint
-                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
-                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint1, R.shape([3, 3]))
-                lv: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, R.const(3, "float32"))
-                lv1_1: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
-                lv2_1: R.Tensor((3, 3), dtype="float32") = R.power(lv3_cp, lv1_1)
-                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv, lv2_1)
-                lv6: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, R.const(3, "float32"))
-                lv7: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
-                lv8: R.Tensor((3, 3), dtype="float32") = R.power(lv2, lv7)
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, lv8)
-                lv1_cp: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
-                lv12: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, R.const(3, "float32"))
-                lv13: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
-                lv14: R.Tensor((3, 3), dtype="float32") = R.power(lv1_cp, lv13)
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv12, lv14)
-                lv18: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(3, "float32"))
-                lv19: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
-                lv20: R.Tensor((3, 3), dtype="float32") = R.power(x, lv19)
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv18, lv20)
-                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                lv1: R.Tensor((3, 3), "float32") = R.power(x, R.const(3, "float32"))
+                lv2: R.Tensor((3, 3), "float32") = R.power(lv1, R.const(3, "float32"))
+                lv3: R.Tensor((3, 3), "float32") = R.power(lv2, R.const(3, "float32"))
+                lv4: R.Tensor((3, 3), "float32") = R.power(lv3, R.const(3, "float32"))
+                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_1: R.Tensor((), "float32") = gv
+                gv_adjoint: R.Tensor((), "float32") = R.ones(R.shape([]), "float32")
+                gv_adjoint1: R.Tensor((), "float32") = gv_adjoint
+                lv3_cp: R.Tensor((3, 3), "float32") = R.power(lv2, R.const(3, "float32"))
+                lv4_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint1, R.shape([3, 3]))
+                lv: R.Tensor((3, 3), "float32") = R.multiply(lv4_adjoint, R.const(3, "float32"))
+                lv1_1: R.Tensor((), "float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv2_1: R.Tensor((3, 3), "float32") = R.power(lv3_cp, lv1_1)
+                lv3_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv, lv2_1)
+                lv6: R.Tensor((3, 3), "float32") = R.multiply(lv3_adjoint, R.const(3, "float32"))
+                lv7: R.Tensor((), "float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv8: R.Tensor((3, 3), "float32") = R.power(lv2, lv7)
+                lv2_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv6, lv8)
+                lv1_cp: R.Tensor((3, 3), "float32") = R.power(x, R.const(3, "float32"))
+                lv12: R.Tensor((3, 3), "float32") = R.multiply(lv2_adjoint, R.const(3, "float32"))
+                lv13: R.Tensor((), "float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv14: R.Tensor((3, 3), "float32") = R.power(lv1_cp, lv13)
+                lv1_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv12, lv14)
+                lv18: R.Tensor((3, 3), "float32") = R.multiply(lv1_adjoint, R.const(3, "float32"))
+                lv19: R.Tensor((), "float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv20: R.Tensor((3, 3), "float32") = R.power(x, lv19)
+                x_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv18, lv20)
+                x_adjoint_out: R.Tensor((3, 3), "float32") = x_adjoint
                 R.output(gv_1, x_adjoint_out)
             return (gv_1, (x_adjoint_out,))
 
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
-                x_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(x)
-                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x_scp, R.const(3, "float32"))
-                lv1_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv1)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.power(lv1_ecp, R.const(3, "float32"))
-                lv2_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv2)
-                lv3: R.Tensor((3, 3), dtype="float32") = R.power(lv2_scp, R.const(3, "float32"))
-                lv4: R.Tensor((3, 3), dtype="float32") = R.power(lv3, R.const(3, "float32"))
-                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
-                gv_ecp: R.Tensor((), dtype="float32") = R.grad.end_checkpoint(gv)
+                x_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(x)
+                lv1: R.Tensor((3, 3), "float32") = R.power(x_scp, R.const(3, "float32"))
+                lv1_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv1)
+                lv2: R.Tensor((3, 3), "float32") = R.power(lv1_ecp, R.const(3, "float32"))
+                lv2_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(lv2)
+                lv3: R.Tensor((3, 3), "float32") = R.power(lv2_scp, R.const(3, "float32"))
+                lv4: R.Tensor((3, 3), "float32") = R.power(lv3, R.const(3, "float32"))
+                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_ecp: R.Tensor((), "float32") = R.grad.end_checkpoint(gv)
                 R.output(gv_ecp)
             return gv_ecp
     # fmt: on
@@ -123,49 +124,49 @@ def test_sequential_consecutive():
     @I.ir_module
     class Expected:
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
-                lv2: R.Tensor((3, 3), dtype="float32") = R.power(lv1, R.const(3, "float32"))
-                lv3: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
-                lv4: R.Tensor((3, 3), dtype="float32") = R.power(lv3, R.const(3, "float32"))
-                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
-                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
-                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
-                lv: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, R.const(3, "float32"))
-                lv1_1: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
-                lv2_1: R.Tensor((3, 3), dtype="float32") = R.power(lv3_cp, lv1_1)
-                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv, lv2_1)
-                lv6: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, R.const(3, "float32"))
-                lv7: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
-                lv8: R.Tensor((3, 3), dtype="float32") = R.power(lv2, lv7)
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, lv8)
-                lv1_cp: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
-                lv12: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, R.const(3, "float32"))
-                lv13: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
-                lv14: R.Tensor((3, 3), dtype="float32") = R.power(lv1_cp, lv13)
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv12, lv14)
-                lv18: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(3, "float32"))
-                lv19: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
-                lv20: R.Tensor((3, 3), dtype="float32") = R.power(x, lv19)
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv18, lv20)
-                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                lv1: R.Tensor((3, 3), "float32") = R.power(x, R.const(3, "float32"))
+                lv2: R.Tensor((3, 3), "float32") = R.power(lv1, R.const(3, "float32"))
+                lv3: R.Tensor((3, 3), "float32") = R.power(lv2, R.const(3, "float32"))
+                lv4: R.Tensor((3, 3), "float32") = R.power(lv3, R.const(3, "float32"))
+                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones(R.shape([]), "float32")
+                lv3_cp: R.Tensor((3, 3), "float32") = R.power(lv2, R.const(3, "float32"))
+                lv4_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv: R.Tensor((3, 3), "float32") = R.multiply(lv4_adjoint, R.const(3, "float32"))
+                lv1_1: R.Tensor((), "float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv2_1: R.Tensor((3, 3), "float32") = R.power(lv3_cp, lv1_1)
+                lv3_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv, lv2_1)
+                lv6: R.Tensor((3, 3), "float32") = R.multiply(lv3_adjoint, R.const(3, "float32"))
+                lv7: R.Tensor((), "float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv8: R.Tensor((3, 3), "float32") = R.power(lv2, lv7)
+                lv2_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv6, lv8)
+                lv1_cp: R.Tensor((3, 3), "float32") = R.power(x, R.const(3, "float32"))
+                lv12: R.Tensor((3, 3), "float32") = R.multiply(lv2_adjoint, R.const(3, "float32"))
+                lv13: R.Tensor((), "float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv14: R.Tensor((3, 3), "float32") = R.power(lv1_cp, lv13)
+                lv1_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv12, lv14)
+                lv18: R.Tensor((3, 3), "float32") = R.multiply(lv1_adjoint, R.const(3, "float32"))
+                lv19: R.Tensor((), "float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv20: R.Tensor((3, 3), "float32") = R.power(x, lv19)
+                x_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv18, lv20)
+                x_adjoint_out: R.Tensor((3, 3), "float32") = x_adjoint
                 R.output(gv, x_adjoint_out)
             return (gv, (x_adjoint_out,))
 
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
-                x_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(x)
-                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x_scp, R.const(3, "float32"))
-                lv2: R.Tensor((3, 3), dtype="float32") = R.power(lv1, R.const(3, "float32"))
-                lv2_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv2)
-                lv2_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv2_ecp)
-                lv3: R.Tensor((3, 3), dtype="float32") = R.power(lv2_scp, R.const(3, "float32"))
-                lv4: R.Tensor((3, 3), dtype="float32") = R.power(lv3, R.const(3, "float32"))
-                lv4_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv4)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv4_ecp, axis=None, keepdims=False)
+                x_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(x)
+                lv1: R.Tensor((3, 3), "float32") = R.power(x_scp, R.const(3, "float32"))
+                lv2: R.Tensor((3, 3), "float32") = R.power(lv1, R.const(3, "float32"))
+                lv2_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv2)
+                lv2_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(lv2_ecp)
+                lv3: R.Tensor((3, 3), "float32") = R.power(lv2_scp, R.const(3, "float32"))
+                lv4: R.Tensor((3, 3), "float32") = R.power(lv3, R.const(3, "float32"))
+                lv4_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv4)
+                gv: R.Tensor((), "float32") = R.sum(lv4_ecp, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
@@ -196,49 +197,49 @@ def test_tuple():
     @I.ir_module
     class Expected:
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
-                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x, lv1
-                lv3: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv2
-                lv4: R.Tensor((3, 3), dtype="float32") = lv3[0]
-                lv4_1: R.Tensor((3, 3), dtype="float32") = R.power(lv4, R.const(3, "float32"))
-                gv: R.Tensor((), dtype="float32") = R.sum(lv4_1, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
-                lv1_cp: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
-                lv2_cp: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x, lv1_cp
-                lv3_cp: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv2_cp
-                lv4_cp: R.Tensor((3, 3), dtype="float32") = lv3_cp[0]
-                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
-                lv: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, R.const(3, "float32"))
-                lv1_1: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
-                lv2_1: R.Tensor((3, 3), dtype="float32") = R.power(lv4_cp, lv1_1)
-                lv4_adjoint1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv, lv2_1)
-                lv6: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
-                lv3_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv4_adjoint1, lv6
-                lv2_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3_adjoint
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint[0]
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint[1]
-                lv7: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(3, "float32"))
-                lv8: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
-                lv9: R.Tensor((3, 3), dtype="float32") = R.power(x, lv8)
-                lv12: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7, lv9)
-                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv12)
-                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint1
+                lv1: R.Tensor((3, 3), "float32") = R.power(x, R.const(3, "float32"))
+                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = x, lv1
+                lv3: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv2
+                lv4: R.Tensor((3, 3), "float32") = lv3[0]
+                lv4_1: R.Tensor((3, 3), "float32") = R.power(lv4, R.const(3, "float32"))
+                gv: R.Tensor((), "float32") = R.sum(lv4_1, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones(R.shape([]), "float32")
+                lv1_cp: R.Tensor((3, 3), "float32") = R.power(x, R.const(3, "float32"))
+                lv2_cp: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = x, lv1_cp
+                lv3_cp: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv2_cp
+                lv4_cp: R.Tensor((3, 3), "float32") = lv3_cp[0]
+                lv4_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv: R.Tensor((3, 3), "float32") = R.multiply(lv4_adjoint, R.const(3, "float32"))
+                lv1_1: R.Tensor((), "float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv2_1: R.Tensor((3, 3), "float32") = R.power(lv4_cp, lv1_1)
+                lv4_adjoint1: R.Tensor((3, 3), "float32") = R.multiply(lv, lv2_1)
+                lv6: R.Tensor((3, 3), "float32") = R.zeros(R.shape([3, 3]), "float32")
+                lv3_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv4_adjoint1, lv6
+                lv2_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv3_adjoint
+                x_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint[0]
+                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint[1]
+                lv7: R.Tensor((3, 3), "float32") = R.multiply(lv1_adjoint, R.const(3, "float32"))
+                lv8: R.Tensor((), "float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv9: R.Tensor((3, 3), "float32") = R.power(x, lv8)
+                lv12: R.Tensor((3, 3), "float32") = R.multiply(lv7, lv9)
+                x_adjoint1: R.Tensor((3, 3), "float32") = R.add(x_adjoint, lv12)
+                x_adjoint_out: R.Tensor((3, 3), "float32") = x_adjoint1
                 R.output(gv, x_adjoint_out)
             return (gv, (x_adjoint_out,))
 
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
-                x_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(x)
-                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x_scp, R.const(3, "float32"))
-                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x, lv1
-                lv3: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv2
-                lv4: R.Tensor((3, 3), dtype="float32") = lv3[0]
-                lv4_1: R.Tensor((3, 3), dtype="float32") = R.power(lv4, R.const(3, "float32"))
-                lv4_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv4_1)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv4_ecp, axis=None, keepdims=False)
+                x_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(x)
+                lv1: R.Tensor((3, 3), "float32") = R.power(x_scp, R.const(3, "float32"))
+                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = x, lv1
+                lv3: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv2
+                lv4: R.Tensor((3, 3), "float32") = lv3[0]
+                lv4_1: R.Tensor((3, 3), "float32") = R.power(lv4, R.const(3, "float32"))
+                lv4_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv4_1)
+                gv: R.Tensor((), "float32") = R.sum(lv4_ecp, axis=None, keepdims=False)
                 R.output(gv)
             return gv
     # fmt: on
@@ -272,35 +273,35 @@ def test_tree():
     @I.ir_module
     class Expected1:
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32"), v: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, y)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
-                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
-                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2, lv3)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
-                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
-                lv2_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
-                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, lv3_cp)
-                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, lv2_cp)
-                u_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, v)
-                v_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, u)
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, z)
-                z_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, lv1)
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, y)
-                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, x)
-                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
-                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
-                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
-                u_adjoint_out: R.Tensor((3, 3), dtype="float32") = u_adjoint
-                v_adjoint_out: R.Tensor((3, 3), dtype="float32") = v_adjoint
+                lv1: R.Tensor((3, 3), "float32") = R.multiply(x, y)
+                lv2: R.Tensor((3, 3), "float32") = R.multiply(lv1, z)
+                lv3: R.Tensor((3, 3), "float32") = R.multiply(u, v)
+                lv4: R.Tensor((3, 3), "float32") = R.multiply(lv2, lv3)
+                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones(R.shape([]), "float32")
+                lv4_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv2_cp: R.Tensor((3, 3), "float32") = R.multiply(lv1, z)
+                lv3_cp: R.Tensor((3, 3), "float32") = R.multiply(u, v)
+                lv2_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv4_adjoint, lv3_cp)
+                lv3_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv4_adjoint, lv2_cp)
+                u_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv3_adjoint, v)
+                v_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv3_adjoint, u)
+                lv1_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv2_adjoint, z)
+                z_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv2_adjoint, lv1)
+                x_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv1_adjoint, y)
+                y_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv1_adjoint, x)
+                x_adjoint_out: R.Tensor((3, 3), "float32") = x_adjoint
+                y_adjoint_out: R.Tensor((3, 3), "float32") = y_adjoint
+                z_adjoint_out: R.Tensor((3, 3), "float32") = z_adjoint
+                u_adjoint_out: R.Tensor((3, 3), "float32") = u_adjoint
+                v_adjoint_out: R.Tensor((3, 3), "float32") = v_adjoint
                 R.output(gv, x_adjoint_out, y_adjoint_out, z_adjoint_out, u_adjoint_out, v_adjoint_out)
             return (gv, (x_adjoint_out, y_adjoint_out, z_adjoint_out, u_adjoint_out, v_adjoint_out))
 
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32"), v: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
                 lv1 = x * y
                 lv1_scp = R.grad.start_checkpoint(lv1)
@@ -324,24 +325,24 @@ def test_tree():
     @I.ir_module
     class Expected2:
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32"), v: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, y)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
-                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
-                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2, lv3)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
-                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
-                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, lv3_cp)
-                z_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, lv1)
-                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                lv1: R.Tensor((3, 3), "float32") = R.multiply(x, y)
+                lv2: R.Tensor((3, 3), "float32") = R.multiply(lv1, z)
+                lv3: R.Tensor((3, 3), "float32") = R.multiply(u, v)
+                lv4: R.Tensor((3, 3), "float32") = R.multiply(lv2, lv3)
+                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones(R.shape([]), "float32")
+                lv4_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv3_cp: R.Tensor((3, 3), "float32") = R.multiply(u, v)
+                lv2_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv4_adjoint, lv3_cp)
+                z_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv2_adjoint, lv1)
+                z_adjoint_out: R.Tensor((3, 3), "float32") = z_adjoint
                 R.output(gv, z_adjoint_out)
             return (gv, (z_adjoint_out,))
 
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32"), v: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
                 lv1 = x * y
                 lv1_scp = R.grad.start_checkpoint(lv1)
@@ -387,54 +388,54 @@ def test_dag():
                 lv12 = R.multiply(lv11, R.const(2, "float32"))
                 lv13 = R.grad.end_checkpoint(lv12)
                 lv14 = R.multiply(lv9, lv13)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv14, axis=None, keepdims=False)
+                gv: R.Tensor((), "float32") = R.sum(lv14, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
     @I.ir_module
     class Expected:
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, R.const(2, "float32"))
-                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, R.const(2, "float32"))
-                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(x, lv2)
-                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, R.const(2, "float32"))
-                lv5: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4, R.const(2, "float32"))
-                lv6: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, lv5)
-                lv7: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, R.const(2, "float32"))
-                lv8: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7, R.const(2, "float32"))
-                lv9: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, lv8)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv9, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
-                lv9_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
-                lv7_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, R.const(2, "float32"))
-                lv8_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7_cp, R.const(2, "float32"))
-                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv9_adjoint, lv8_cp)
-                lv8_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv9_adjoint, lv6)
-                lv7_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv8_adjoint, R.const(2, "float32"))
-                lv1_1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7_adjoint, R.const(2, "float32"))
-                lv6_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(lv6_adjoint, lv1_1)
-                lv4_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, R.const(2, "float32"))
-                lv5_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_cp, R.const(2, "float32"))
-                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6_adjoint1, lv5_cp)
-                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6_adjoint1, lv3)
-                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv5_adjoint, R.const(2, "float32"))
-                lv4_1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, R.const(2, "float32"))
-                lv3_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(lv3_adjoint, lv4_1)
-                lv1_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(x, R.const(2, "float32"))
-                lv2_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_cp, R.const(2, "float32"))
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint1, lv2_cp)
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint1, x)
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, R.const(2, "float32"))
-                lv7_1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(2, "float32"))
-                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv7_1)
-                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint1
+                lv1: R.Tensor((3, 3), "float32") = R.multiply(x, R.const(2, "float32"))
+                lv2: R.Tensor((3, 3), "float32") = R.multiply(lv1, R.const(2, "float32"))
+                lv3: R.Tensor((3, 3), "float32") = R.multiply(x, lv2)
+                lv4: R.Tensor((3, 3), "float32") = R.multiply(lv3, R.const(2, "float32"))
+                lv5: R.Tensor((3, 3), "float32") = R.multiply(lv4, R.const(2, "float32"))
+                lv6: R.Tensor((3, 3), "float32") = R.multiply(lv3, lv5)
+                lv7: R.Tensor((3, 3), "float32") = R.multiply(lv6, R.const(2, "float32"))
+                lv8: R.Tensor((3, 3), "float32") = R.multiply(lv7, R.const(2, "float32"))
+                lv9: R.Tensor((3, 3), "float32") = R.multiply(lv6, lv8)
+                gv: R.Tensor((), "float32") = R.sum(lv9, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones(R.shape([]), "float32")
+                lv9_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv7_cp: R.Tensor((3, 3), "float32") = R.multiply(lv6, R.const(2, "float32"))
+                lv8_cp: R.Tensor((3, 3), "float32") = R.multiply(lv7_cp, R.const(2, "float32"))
+                lv6_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv9_adjoint, lv8_cp)
+                lv8_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv9_adjoint, lv6)
+                lv7_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv8_adjoint, R.const(2, "float32"))
+                lv1_1: R.Tensor((3, 3), "float32") = R.multiply(lv7_adjoint, R.const(2, "float32"))
+                lv6_adjoint1: R.Tensor((3, 3), "float32") = R.add(lv6_adjoint, lv1_1)
+                lv4_cp: R.Tensor((3, 3), "float32") = R.multiply(lv3, R.const(2, "float32"))
+                lv5_cp: R.Tensor((3, 3), "float32") = R.multiply(lv4_cp, R.const(2, "float32"))
+                lv3_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv6_adjoint1, lv5_cp)
+                lv5_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv6_adjoint1, lv3)
+                lv4_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv5_adjoint, R.const(2, "float32"))
+                lv4_1: R.Tensor((3, 3), "float32") = R.multiply(lv4_adjoint, R.const(2, "float32"))
+                lv3_adjoint1: R.Tensor((3, 3), "float32") = R.add(lv3_adjoint, lv4_1)
+                lv1_cp: R.Tensor((3, 3), "float32") = R.multiply(x, R.const(2, "float32"))
+                lv2_cp: R.Tensor((3, 3), "float32") = R.multiply(lv1_cp, R.const(2, "float32"))
+                x_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv3_adjoint1, lv2_cp)
+                lv2_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv3_adjoint1, x)
+                lv1_adjoint: R.Tensor((3, 3), "float32") = R.multiply(lv2_adjoint, R.const(2, "float32"))
+                lv7_1: R.Tensor((3, 3), "float32") = R.multiply(lv1_adjoint, R.const(2, "float32"))
+                x_adjoint1: R.Tensor((3, 3), "float32") = R.add(x_adjoint, lv7_1)
+                x_adjoint_out: R.Tensor((3, 3), "float32") = x_adjoint1
                 R.output(gv, x_adjoint_out)
             return (gv, (x_adjoint_out,))
 
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
                 lv = R.grad.start_checkpoint(x)
                 lv1 = R.multiply(lv, R.const(2, "float32"))
@@ -451,7 +452,7 @@ def test_dag():
                 lv12 = R.multiply(lv11, R.const(2, "float32"))
                 lv13 = R.grad.end_checkpoint(lv12)
                 lv14 = R.multiply(lv9, lv13)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv14, axis=None, keepdims=False)
+                gv: R.Tensor((), "float32") = R.sum(lv14, axis=None, keepdims=False)
                 R.output(gv)
             return gv
     # fmt: on
@@ -474,9 +475,9 @@ def test_checkpoint_api():
     x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
     with bb.function("main", [x]):
         with bb.dataflow():
-            lv1 = bb.emit(checkpoint(func1, x))
+            lv1 = bb.emit(nn.checkpoint(func1, x))
             lv2 = bb.emit(relax.op.power(lv1, relax.const(3, "float32")))
-            lv3 = bb.emit_output(checkpoint(func2, lv2))
+            lv3 = bb.emit_output(nn.checkpoint(func2, lv2))
         bb.emit_func_output(lv3)
 
     # fmt: off
@@ -516,7 +517,7 @@ def test_checkpoint_tree():
     with bb.function("main", [x, y, z, u, v]):
         with bb.dataflow():
             lv1 = bb.emit(x * y)
-            cp = checkpoint(func, lv1, z, u, v)
+            cp = nn.checkpoint(func, lv1, z, u, v)
             lv2 = bb.emit(cp[0])
             lv3 = bb.emit(cp[1])
             lv4 = bb.emit(lv2 * lv3)
@@ -559,11 +560,11 @@ def test_checkpoint_dag():
     x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
     with bb.function("main", [x]):
         with bb.dataflow():
-            lv1 = bb.emit(checkpoint(func, x))
+            lv1 = bb.emit(nn.checkpoint(func, x))
             lv2 = bb.emit(x * lv1)
-            lv3 = bb.emit(checkpoint(func, lv2))
+            lv3 = bb.emit(nn.checkpoint(func, lv2))
             lv4 = bb.emit(lv2 * lv3)
-            lv5 = bb.emit(checkpoint(func, lv4))
+            lv5 = bb.emit(nn.checkpoint(func, lv4))
             lv6 = bb.emit(lv4 * lv5)
             gv = bb.emit_output(relax.op.sum(lv6))
         bb.emit_func_output(gv)
@@ -572,7 +573,7 @@ def test_checkpoint_dag():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
                 lv = R.grad.start_checkpoint(x)
                 lv1 = R.multiply(lv, R.const(2, "float32"))
@@ -589,7 +590,7 @@ def test_checkpoint_dag():
                 lv12 = R.multiply(lv11, R.const(2, "float32"))
                 lv13 = R.grad.end_checkpoint(lv12)
                 lv14 = R.multiply(lv9, lv13)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv14, axis=None, keepdims=False)
+                gv: R.Tensor((), "float32") = R.sum(lv14, axis=None, keepdims=False)
                 R.output(gv)
             return gv
     # fmt: on
@@ -605,8 +606,8 @@ def test_checkpoint_sequential():
     x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
     with bb.function("main", [x]):
         with bb.dataflow():
-            lv1 = emit_checkpoint_sequential([func] * 5, 2, x)
-            lv2 = emit_checkpoint_sequential([func] * 4, 2, lv1)
+            lv1 = nn.emit_checkpoint_sequential([func] * 5, 2, x)
+            lv2 = nn.emit_checkpoint_sequential([func] * 4, 2, lv1)
             gv = bb.emit_output(lv2)
         bb.emit_func_output(gv)
 
@@ -614,24 +615,24 @@ def test_checkpoint_sequential():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((3, 3), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((3, 3), "float32"):
             with R.dataflow():
-                x_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(x)
-                lv: R.Tensor((3, 3), dtype="float32") = R.add(x_scp, x_scp)
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(lv, lv)
-                lv1_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv1)
-                lv1_ecp_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv1_ecp)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1_ecp_scp, lv1_ecp_scp)
-                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, lv2)
-                lv3_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv3)
-                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv3_ecp, lv3_ecp)
-                lv4_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv4)
-                lv5: R.Tensor((3, 3), dtype="float32") = R.add(lv4_scp, lv4_scp)
-                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv5, lv5)
-                lv6_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv6)
-                lv7: R.Tensor((3, 3), dtype="float32") = R.add(lv6_ecp, lv6_ecp)
-                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv7, lv7)
-                gv: R.Tensor((3, 3), dtype="float32") = lv8
+                x_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(x)
+                lv: R.Tensor((3, 3), "float32") = R.add(x_scp, x_scp)
+                lv1: R.Tensor((3, 3), "float32") = R.add(lv, lv)
+                lv1_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv1)
+                lv1_ecp_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(lv1_ecp)
+                lv2: R.Tensor((3, 3), "float32") = R.add(lv1_ecp_scp, lv1_ecp_scp)
+                lv3: R.Tensor((3, 3), "float32") = R.add(lv2, lv2)
+                lv3_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv3)
+                lv4: R.Tensor((3, 3), "float32") = R.add(lv3_ecp, lv3_ecp)
+                lv4_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(lv4)
+                lv5: R.Tensor((3, 3), "float32") = R.add(lv4_scp, lv4_scp)
+                lv6: R.Tensor((3, 3), "float32") = R.add(lv5, lv5)
+                lv6_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv6)
+                lv7: R.Tensor((3, 3), "float32") = R.add(lv6_ecp, lv6_ecp)
+                lv8: R.Tensor((3, 3), "float32") = R.add(lv7, lv7)
+                gv: R.Tensor((3, 3), "float32") = lv8
                 R.output(gv)
             return gv
     # fmt: on
@@ -647,8 +648,8 @@ def test_checkpoint_sequential_checkpoint_last():
     x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
     with bb.function("main", [x]):
         with bb.dataflow():
-            lv1 = emit_checkpoint_sequential([func] * 5, 2, x, checkpoint_last=True)
-            lv2 = emit_checkpoint_sequential([func] * 4, 2, lv1, checkpoint_last=True)
+            lv1 = nn.emit_checkpoint_sequential([func] * 5, 2, x, checkpoint_last=True)
+            lv2 = nn.emit_checkpoint_sequential([func] * 4, 2, lv1, checkpoint_last=True)
             gv = bb.emit_output(lv2)
         bb.emit_func_output(gv)
 
@@ -656,33 +657,98 @@ def test_checkpoint_sequential_checkpoint_last():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((3, 3), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((3, 3), "float32"):
             with R.dataflow():
-                x_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(x)
-                lv: R.Tensor((3, 3), dtype="float32") = R.add(x_scp, x_scp)
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(lv, lv)
-                lv1_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv1)
-                lv1_ecp_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv1_ecp)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1_ecp_scp, lv1_ecp_scp)
-                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, lv2)
-                lv3_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv3)
-                lv3_ecp_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv3_ecp)
-                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv3_ecp_scp, lv3_ecp_scp)
-                lv4_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv4)
-                lv4_ecp_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv4_ecp)
-                lv5: R.Tensor((3, 3), dtype="float32") = R.add(lv4_ecp_scp, lv4_ecp_scp)
-                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv5, lv5)
-                lv6_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv6)
-                lv6_ecp_scp: R.Tensor((3, 3), dtype="float32") = R.grad.start_checkpoint(lv6_ecp)
-                lv7: R.Tensor((3, 3), dtype="float32") = R.add(lv6_ecp_scp, lv6_ecp_scp)
-                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv7, lv7)
-                lv8_ecp: R.Tensor((3, 3), dtype="float32") = R.grad.end_checkpoint(lv8)
-                gv: R.Tensor((3, 3), dtype="float32") = lv8_ecp
+                x_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(x)
+                lv: R.Tensor((3, 3), "float32") = R.add(x_scp, x_scp)
+                lv1: R.Tensor((3, 3), "float32") = R.add(lv, lv)
+                lv1_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv1)
+                lv1_ecp_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(lv1_ecp)
+                lv2: R.Tensor((3, 3), "float32") = R.add(lv1_ecp_scp, lv1_ecp_scp)
+                lv3: R.Tensor((3, 3), "float32") = R.add(lv2, lv2)
+                lv3_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv3)
+                lv3_ecp_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(lv3_ecp)
+                lv4: R.Tensor((3, 3), "float32") = R.add(lv3_ecp_scp, lv3_ecp_scp)
+                lv4_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv4)
+                lv4_ecp_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(lv4_ecp)
+                lv5: R.Tensor((3, 3), "float32") = R.add(lv4_ecp_scp, lv4_ecp_scp)
+                lv6: R.Tensor((3, 3), "float32") = R.add(lv5, lv5)
+                lv6_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv6)
+                lv6_ecp_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(lv6_ecp)
+                lv7: R.Tensor((3, 3), "float32") = R.add(lv6_ecp_scp, lv6_ecp_scp)
+                lv8: R.Tensor((3, 3), "float32") = R.add(lv7, lv7)
+                lv8_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv8)
+                gv: R.Tensor((3, 3), "float32") = lv8_ecp
                 R.output(gv)
             return gv
     # fmt: on
 
     assert_structural_equal(bb.get(), Expected)
+
+
+def test_checkpoint_dag():
+    """Comp. graph is a DAG with only one output. Here we only test the simple case: comp. graph
+    is a sequence of sub-graphs, and the checkpoints are the intersections of connected
+    subgraphs."""
+
+    def func(x):
+        return x * relax.const(2, "float32") * relax.const(2, "float32")
+
+    bb = BlockBuilder()
+    x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
+    with bb.function("main", [x]):
+        with bb.dataflow():
+            lv1 = bb.emit(nn.checkpoint(func, x))
+            lv2 = bb.emit(x * lv1)
+            lv3 = bb.emit(nn.checkpoint(func, lv2))
+            lv4 = bb.emit(lv2 * lv3)
+            lv5 = bb.emit(nn.checkpoint(func, lv4))
+            lv6 = bb.emit(lv4 * lv5)
+            gv = bb.emit_output(relax.op.sum(lv6))
+        bb.emit_func_output(gv)
+
+
+def test_checkpoint_with_intermediate_require_grads():
+    def func(x):
+        return x * x * x
+
+    bb = BlockBuilder()
+    x = relax.Var("x", relax.TensorStructInfo((3, 3), "float32"))
+    with bb.function("main", [x]):
+        with bb.dataflow():
+            lv1 = nn.emit_checkpoint(func, x)
+            gv = bb.emit_output(relax.op.sum(lv1))
+        bb.emit_func_output(gv)
+
+    # fmt: off
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
+            with R.dataflow():
+                lv: R.Tensor((3, 3), "float32") = R.multiply(x, x)
+                lv1: R.Tensor((3, 3), "float32") = R.multiply(lv, x)
+                gv: R.Tensor((), "float32") = R.sum(lv1, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones(R.shape([]), "float32")
+                lv1_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv1_adjoint_out: R.Tensor((3, 3), "float32") = lv1_adjoint
+                R.output(gv, lv1_adjoint_out)
+            return (gv, (lv1_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+            with R.dataflow():
+                x_scp: R.Tensor((3, 3), "float32") = R.grad.start_checkpoint(x)
+                lv: R.Tensor((3, 3), "float32") = R.multiply(x_scp, x_scp)
+                lv1: R.Tensor((3, 3), "float32") = R.multiply(lv, x_scp)
+                lv1_ecp: R.Tensor((3, 3), "float32") = R.grad.end_checkpoint(lv1)
+                gv: R.Tensor((), "float32") = R.sum(lv1_ecp, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After = relax.transform.Gradient("main", lv1)(bb.get())
+    assert_structural_equal(After, Expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR supports providing intermediate vars in require_grads argument of the gradient pass.

This is useful for debugging, since users can find the gradient value of intermediate vars.

This PR also fixes a bug when var that requires gradient is wrapped in the checkpointed range (wrapped in start_checkpoint and end_checkpoint pairs). 

cc @yzh119 @MasterJH5574 @tqchen 