### PR TITLE
[Tests] Fix work_dir location used by test_micro_tuning_with_meta_schedule

### DIFF
--- a/tests/python/unittest/test_micro_ms_tuning.py
+++ b/tests/python/unittest/test_micro_ms_tuning.py
@@ -66,7 +66,7 @@ def test_micro_tuning_with_meta_schedule():
                 num_trials_per_iter=2,
                 max_trials_per_task=10,
                 max_trials_global=100,
-                work_dir=str(work_dir),
+                work_dir=str(work_dir.path),
                 module_equality="ignore-ndarray",
             )
 


### PR DESCRIPTION
Converting `work_dir = tvm.contrib.utils.tempdir()` to `str` yields `"<tvm.contrib.utils.TempDirectory object at 0x7fc5322c3790>/"` which creates a so-called file in the current working directory.

This change uses `str(work_dir.path)` instead, resulting in the expected behavior.