### PR TITLE
[Unity] Deterministic Ordering when Iterating IRModule::functions

### DIFF
--- a/python/tvm/dlight/base/transform.py
+++ b/python/tvm/dlight/base/transform.py
@@ -59,7 +59,7 @@ class ApplyDefaultSchedule:  # pylint: disable=too-few-public-methods
     ) -> IRModule:
         target = Target.current(allow_none=False)
         updated_functions = {}
-        for g_var, func in mod.functions.items():
+        for g_var, func in mod.functions_items():
             if isinstance(func, tir.PrimFunc) and not _is_scheduled(func):
                 sch = _apply_rules(func, target, self.rules, tunable=False)
                 if sch is not None:

--- a/python/tvm/dlight/benchmark/extract.py
+++ b/python/tvm/dlight/benchmark/extract.py
@@ -16,13 +16,14 @@
 # under the License.
 """Performance debug tool for dynamic shape workloads"""
 
-from typing import List, Dict, Union, Tuple, Optional
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
 
 import cloudpickle
 
 import tvm
 from tvm import relax
+
 from .utils import default_dym_var_sample_func, get_func_name_from_gv
 
 SKETCH = """import pickle
@@ -215,7 +216,7 @@ def extract_all_func_info_from_relax(
         The function input information and dynamic shape variable dictionary.
     """
     relax_func_dict: Dict[tvm.ir.GlobalVar, Dict[tvm.ir.GlobalVar, List[Tuple[List, int]]]] = {}
-    for gv, func in mod.functions.items():  # pylint: disable=invalid-name,too-many-nested-blocks
+    for gv, func in mod.functions_items():  # pylint: disable=invalid-name,too-many-nested-blocks
         if isinstance(func, tvm.relax.Function):
             for block in func.body.blocks:
                 for binding in block.bindings:

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from typing import Dict, Union
+
 import tvm._ffi
 from tvm._ffi.base import string_types
 from tvm.runtime import Scriptable
@@ -79,6 +80,18 @@ class IRModule(Node, Scriptable):
             attrs,
             global_infos,
         )
+
+    def functions_items(self):
+        """Get items in self.functions.items() in alphabetical order.
+
+        Returns
+        -------
+        items: List[Tuple[GlobalVar, Function]]
+            The functions items.
+        """
+        items = list(self.functions.items())
+        items.sort(key=lambda item: str(item[0].name_hint))
+        return items
 
     def __setitem__(self, var, val):
         """Add a mapping to the module.

--- a/python/tvm/meta_schedule/tir_integration.py
+++ b/python/tvm/meta_schedule/tir_integration.py
@@ -111,7 +111,7 @@ def tune_tir(  # pylint: disable=too-many-locals
         mod = _normalize_mod(mod)
 
     named_tasks: List[Tuple[str, tir.PrimFunc]] = []
-    for gv, func in mod.functions.items():  # pylint: disable=invalid-name
+    for gv, func in mod.functions_items():  # pylint: disable=invalid-name
         if isinstance(func, tir.PrimFunc):
             named_tasks.append((gv.name_hint, func))
     named_tasks.sort(key=lambda x: x[0])

--- a/python/tvm/relax/analysis/estimate_memory_usage.py
+++ b/python/tvm/relax/analysis/estimate_memory_usage.py
@@ -17,12 +17,13 @@
 # pylint: disable=abstract-method,unused-argument
 # pylint: disable=missing-function-docstring,missing-module-docstring
 from typing import Union
+
 import tvm
 from tvm.ir import Op
 from tvm.ir.module import IRModule
 
 from ..expr import Call, Expr, Function, ShapeExpr
-from ..expr_functor import visitor, PyExprVisitor
+from ..expr_functor import PyExprVisitor, visitor
 
 
 def estimate_memory_usage(mod: Union[IRModule, Function]) -> str:
@@ -87,7 +88,7 @@ def estimate_memory_usage(mod: Union[IRModule, Function]) -> str:
 
         def estimate(self, mod: IRModule) -> str:
             estimation: str = ""
-            for global_var, func in mod.functions.items():
+            for global_var, func in mod.functions_items():
                 if not isinstance(func, Function):
                     continue
 

--- a/python/tvm/relax/frontend/common.py
+++ b/python/tvm/relax/frontend/common.py
@@ -41,7 +41,7 @@ def detach_params(mod: tvm.IRModule) -> Tuple[tvm.IRModule, Dict[str, List[tvm.n
     """
     detached_mod = tvm.IRModule()
     params_dict = dict()
-    for gv, func in mod.functions.items():
+    for gv, func in mod.functions_items():
         if func.attrs is not None and "params" in func.attrs:
             params = list(func.attrs["params"])
             if not all([isinstance(param, tvm.nd.NDArray) for param in params]):

--- a/python/tvm/relax/testing/transform.py
+++ b/python/tvm/relax/testing/transform.py
@@ -17,15 +17,14 @@
 # pylint: disable=unused-argument, invalid-name, no-else-return, abstract-method, arguments-differ
 """Relax transformation passes for testing"""
 
-from tvm import ir
-from tvm import relax
+from tvm import ir, relax
+from tvm.ir import transform
 from tvm.ir.module import IRModule
 from tvm.ir.transform import PassContext
-from tvm.target import Target
-from tvm.ir import transform
 from tvm.relax import PyExprMutator
 from tvm.relax.expr import Call
 from tvm.relay.backend.te_compiler import select_implementation
+from tvm.target import Target
 
 
 @ir.transform.module_pass(opt_level=0)
@@ -114,7 +113,7 @@ class LowerWithRelayOpStrategyPass(transform.Pass):
             # TOOD(@team): transform() wapper is necessary to include TIR functions.
             # IMO, this is bit unintuitive. Can we improve this?
             def transform(self):
-                for gv, func in mod.functions.items():
+                for gv, func in mod.functions_items():
                     if isinstance(func, relax.Function):
                         updated_func = self.visit_expr(func)
                         self.builder_.update_func(gv, updated_func)

--- a/python/tvm/relax/transform/lazy_transform_params.py
+++ b/python/tvm/relax/transform/lazy_transform_params.py
@@ -17,9 +17,8 @@
 # pylint: disable=invalid-name, unused-argument, missing-function-docstring, abstract-method
 """Relax LazyTransformParams pass."""
 import tvm
-from tvm import IRModule
-from tvm import relax
-from tvm.relax.expr_functor import visitor, mutator, PyExprMutator, PyExprVisitor
+from tvm import IRModule, relax
+from tvm.relax.expr_functor import PyExprMutator, PyExprVisitor, mutator, visitor
 
 
 @visitor
@@ -228,7 +227,7 @@ class LazyTransformParams:
 
     def transform_module(self, mod: IRModule, ctx: tvm.transform.PassContext) -> IRModule:
         lazy_mutator = LazyTransformParamsMutator(mod)
-        for gv in mod.functions:
+        for gv, _ in mod.functions_items():
             if gv.name_hint.endswith("transform_params"):
                 func = mod[gv]
                 if not isinstance(func, relax.Function):

--- a/python/tvm/relax/transform/optimize_layout_transform.py
+++ b/python/tvm/relax/transform/optimize_layout_transform.py
@@ -20,7 +20,8 @@ from tvm.ir import structural_equal
 from tvm.ir.module import IRModule
 from tvm.ir.transform import PassContext
 from tvm.relax import Expr, Function
-from tvm.relax.dpl import is_op, rewrite_call, wildcard, TuplePattern
+from tvm.relax.dpl import TuplePattern, is_op, rewrite_call, wildcard
+
 from . import function_pass
 
 
@@ -62,7 +63,7 @@ class OptimizeLayoutTransform:
 
         self.mod = mod
         updated_func = func
-        for _, func in mod.functions.items():
+        for _, func in mod.functions_items():
             # Skip non-relax functions
             if not isinstance(func, Function):
                 continue

--- a/python/tvm/relax/transform/remove_redundant_reshape.py
+++ b/python/tvm/relax/transform/remove_redundant_reshape.py
@@ -17,10 +17,11 @@
 # pylint: disable=invalid-name, unused-argument, missing-function-docstring, abstract-method
 """Relax Remove Redundant Reshape ops"""
 from tvm import IRModule, relax
-from tvm.ir.transform import PassContext
 from tvm.ir import structural_equal
+from tvm.ir.transform import PassContext
 from tvm.relax import Expr, Function
 from tvm.relax.dpl import is_op, rewrite_call, wildcard
+
 from . import function_pass
 
 
@@ -57,7 +58,7 @@ class RemoveRedundantReshape:
         """
 
         updated_func = func
-        for _, funct in mod.functions.items():
+        for _, funct in mod.functions_items():
             # Skip non-relax functions
             if not isinstance(funct, Function):
                 continue


### PR DESCRIPTION
Prior to this PR, visiting order of the following for-loop is non-deterministic:

```python
mod: tvm.ir.IRModule
for gv, func in mod.functions.items():
  ...
```

This is because `IRModule` stores those functions inside a hash map `Map<GlobalVar, BaseFunc>`, which is based on pointer equality. This behavior is usually innocent and harmless given many previous workloads only have one "main" function as the primary entry point, e.g. a single Relax Function and a bunch of TIR functions. However, it is not true in LLM usecases where `prefill`, `decoding` are both equally important entrypoints, and in those cases, it is possible that the names of generated TIR functions from LegalizeOps are essentially different from each run, which is, again, harmless in basic usecases, but it does make debugging more challenging.

This PR corrects this behavior by sorting the functions alphabetically by their names.