### PR TITLE
[Unity] Alias IntTuple <= ShapeTuple

### DIFF
--- a/include/tvm/runtime/container/shape_tuple.h
+++ b/include/tvm/runtime/container/shape_tuple.h
@@ -194,9 +194,14 @@ inline std::ostream& operator<<(std::ostream& os, const ShapeTuple& shape) {
   return os;
 }
 
+using IntTuple = ShapeTuple;
+using IntTupleObj = ShapeTupleObj;
+
 }  // namespace runtime
 
 // expose the functions to the root namespace.
+using runtime::IntTuple;
+using runtime::IntTupleObj;
 using runtime::ShapeTuple;
 using runtime::ShapeTupleObj;
 }  // namespace tvm

--- a/include/tvm/runtime/disco/session.h
+++ b/include/tvm/runtime/disco/session.h
@@ -225,7 +225,7 @@ class SessionObj : public Object {
    * \param ccl The name of the communication backend, e.g., nccl, rccl, mpi.
    * \param device_ids The device ids of the workers.
    */
-  virtual void InitCCL(String ccl, ShapeTuple device_ids) = 0;
+  virtual void InitCCL(String ccl, IntTuple device_ids) = 0;
   /*!
    * \brief Get the value of a register from a remote worker.
    * \param reg_id The id of the register to be fetched.

--- a/src/runtime/disco/bcast_session.cc
+++ b/src/runtime/disco/bcast_session.cc
@@ -68,7 +68,7 @@ void BcastSessionObj::Shutdown() {
   BcastSessionObj::Internal::BroadcastUnpacked(this, DiscoAction::kShutDown, 0);
 }
 
-void BcastSessionObj::InitCCL(String ccl, ShapeTuple device_ids) {
+void BcastSessionObj::InitCCL(String ccl, IntTuple device_ids) {
   const auto* pf = runtime::Registry::Get("runtime.disco." + ccl + ".init_ccl");
   CHECK(pf) << "ValueError: Cannot initialize CCL `" << ccl
             << "`, because cannot find function: runtime.disco." << ccl << ".init_ccl";

--- a/src/runtime/disco/bcast_session.h
+++ b/src/runtime/disco/bcast_session.h
@@ -42,7 +42,7 @@ class BcastSessionObj : public SessionObj {
   void CopyToWorker0(const NDArray& host_array, const DRef& remote_array) override;
   void SyncWorker(int worker_id) override;
   void Shutdown() override;
-  void InitCCL(String ccl, ShapeTuple device_ids) override;
+  void InitCCL(String ccl, IntTuple device_ids) override;
   TVMRetValue DebugGetFromRemote(int64_t reg_id, int worker_id) override = 0;
   void DebugSetRegister(int64_t reg_id, TVMArgValue value, int worker_id) override = 0;
 

--- a/src/runtime/disco/nccl/nccl.cc
+++ b/src/runtime/disco/nccl/nccl.cc
@@ -160,7 +160,7 @@ struct CCLThreadLocalContext {
   }
 };
 
-void InitCCL(Session sess, ShapeTuple device_ids) {
+void InitCCL(Session sess, IntTuple device_ids) {
   DRef func = sess->GetGlobalFunc("runtime.disco." TVM_DISCO_CCL_NAME ".init_ccl_per_worker");
   LOG(INFO) << "Initializing " TVM_DISCO_CCL_NAME " with devices: " << device_ids;
   ncclUniqueId id;
@@ -171,7 +171,7 @@ void InitCCL(Session sess, ShapeTuple device_ids) {
   sess->CallPacked(func, device_ids, array);
 }
 
-void InitCCLPerWorker(ShapeTuple device_ids, std::string unique_id_bytes) {
+void InitCCLPerWorker(IntTuple device_ids, std::string unique_id_bytes) {
   CCLThreadLocalContext* ctx = CCLThreadLocalContext::Get();
   DiscoWorker* worker = DiscoWorker::ThreadLocal();
   ICHECK(worker != nullptr);

--- a/src/runtime/disco/process_session.cc
+++ b/src/runtime/disco/process_session.cc
@@ -97,7 +97,7 @@ class ProcessSessionObj final : public BcastSessionObj {
     read_fds.reserve(num_workers - 1);
     write_fds.reserve(num_workers - 1);
     for (int i = 1; i < num_workers; ++i) {
-      ShapeTuple fds = process_pool(i);
+      IntTuple fds = process_pool(i);
       CHECK_EQ(fds.size(), 2) << "ValueError: process_pool(" << i << ") should return a tuple of "
                               << "size 2, but got a tuple of size " << fds.size() << ".";
       read_fds.push_back(fds[0]);


### PR DESCRIPTION
In TVM, ShapeTuple is usually used interchangably as a tuple of integers that are not necessarily a shape. This PR introduces the following aliasing to help it more semantically clear:

```C++
using IntTuple = ShapeTuple;
using IntTupleObj = ShapeTupleObj;
```