### PR TITLE
[Unity][Bugfix] Track variable usage from input to impure functions

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -423,6 +423,40 @@ TVM_DLL Map<Var, Array<Var>> DataflowBlockUseDef(const DataflowBlock& dfb);
  */
 std::pair<Map<Var, Array<Var>>, Array<Var>> FunctionUseDef(const Expr& expr);
 
+/*! \brief A utility struct returned by CollectVarUsage
+ */
+struct VarUsageInfo {
+  /* \brief A map from variables to the bound expression.
+   *
+   * This is equivalent to the output of AnalyzeVar2Value
+   */
+  Map<Var, Expr> bound_values;
+
+  /* \brief The map from variables to downstream usages of the variable
+   *
+   * This is equivalent to the first output of FunctionUseDef.
+   */
+  Map<Var, Array<Var>> downstream_usage;
+
+  /* \brief A list of variables produced as output
+   *
+   * This is equivalent to the second output of FunctionUseDef
+   */
+  Array<Var> outputs;
+};
+
+/*! \brief Collect variable bindings and usage
+ *
+ * This function is equivalent to calling both FunctionUseDef and
+ * AnalyzeVar2Value, but requires only a single traversal of the
+ * expression.
+ *
+ * \param expr The expression to analyze
+ *
+ * \return The collected information
+ */
+VarUsageInfo CollectVarUsage(const Expr& expr);
+
 /*!
  * \brief Remove unused statements inside DataflowBlocks.
  *

--- a/src/support/ordered_set.h
+++ b/src/support/ordered_set.h
@@ -54,6 +54,13 @@ class OrderedSet {
  public:
   OrderedSet() = default;
 
+  template <typename Iter>
+  OrderedSet(Iter begin, Iter end) {
+    for (auto it = begin; it != end; it++) {
+      push_back(*it);
+    }
+  }
+
   void push_back(const T& t) {
     if (!elem_to_iter_.count(t)) {
       elements_.push_back(t);


### PR DESCRIPTION
Prior to this commit, pure arguments to impure functions could be erroneously removed, if the impure function's result is unused.  This commit updates the variable usage tracking in dead-code elimination to consider both function return values and arguments to impure functions as externally-exposed values.