### PR TITLE
[Target] Support obtain l2 cache size from target

### DIFF
--- a/include/tvm/target/tag.h
+++ b/include/tvm/target/tag.h
@@ -109,7 +109,7 @@ class TargetTagRegEntry {
    * \param key The attribute name
    * \param value The attribute value
    */
-  inline TargetTagRegEntry& add_config(String key, ObjectRef value);
+  inline TargetTagRegEntry& with_config(String key, ObjectRef value);
   /*! \brief Set name of the TargetTag to be the same as registry if it is empty */
   inline TargetTagRegEntry& set_name();
   /*!
@@ -137,7 +137,7 @@ inline TargetTagRegEntry& TargetTagRegEntry::set_config(Map<String, ObjectRef> c
   return *this;
 }
 
-inline TargetTagRegEntry& TargetTagRegEntry::add_config(String key, ObjectRef value) {
+inline TargetTagRegEntry& TargetTagRegEntry::with_config(String key, ObjectRef value) {
   tag_->config.Set(key, value);
   return *this;
 }

--- a/include/tvm/target/tag.h
+++ b/include/tvm/target/tag.h
@@ -104,6 +104,12 @@ class TargetTagRegEntry {
    * \param config The config dict for target creation
    */
   inline TargetTagRegEntry& set_config(Map<String, ObjectRef> config);
+  /*!
+   * \brief Add a key-value pair to the config dict
+   * \param key The attribute name
+   * \param value The attribute value
+   */
+  inline TargetTagRegEntry& add_config(String key, ObjectRef value);
   /*! \brief Set name of the TargetTag to be the same as registry if it is empty */
   inline TargetTagRegEntry& set_name();
   /*!
@@ -128,6 +134,11 @@ class TargetTagRegEntry {
 
 inline TargetTagRegEntry& TargetTagRegEntry::set_config(Map<String, ObjectRef> config) {
   tag_->config = std::move(config);
+  return *this;
+}
+
+inline TargetTagRegEntry& TargetTagRegEntry::add_config(String key, ObjectRef value) {
+  tag_->config.Set(key, value);
   return *this;
 }
 

--- a/src/target/tag.cc
+++ b/src/target/tag.cc
@@ -130,7 +130,7 @@ TVM_REGISTER_CUDA_TAG("nvidia/tesla-c2075", "sm_20", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/tesla-c2050", "sm_20", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/tesla-c2070", "sm_20", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a100", "sm_80", 49152, 65536)
-    .add_config("l2_cache_size_bytes", Integer(41943040));
+    .with_config("l2_cache_size_bytes", Integer(41943040));
 TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a40", "sm_86", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a30", "sm_80", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a10", "sm_86", 49152, 65536);
@@ -233,7 +233,7 @@ TVM_REGISTER_CUDA_TAG("nvidia/nvs-5400m", "sm_21", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/nvs-5200m", "sm_21", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/nvs-4200m", "sm_21", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-4090", "sm_89", 49152, 65536)
-    .add_config("l2_cache_size_bytes", Integer(75497472));
+    .with_config("l2_cache_size_bytes", Integer(75497472));
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-3090-ti", "sm_86", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-3090", "sm_86", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-3080-ti", "sm_86", 49152, 65536);

--- a/src/target/tag.cc
+++ b/src/target/tag.cc
@@ -115,7 +115,7 @@ TVM_REGISTER_TARGET_TAG("nvidia/jetson-orin-nano")
       {"max_threads_per_block", Integer(1024)},                   \
       {"thread_warp_size", Integer(32)},                          \
       {"registers_per_block", Integer(RegPerBlock)},              \
-  });
+  })
 
 // Naming convention for CUDA tags see https://developer.nvidia.com/cuda-gpus
 // Parameters see Table 15. Technical Specifications per Compute Capability
@@ -129,7 +129,8 @@ TVM_REGISTER_CUDA_TAG("nvidia/tesla-k20", "sm_35", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/tesla-c2075", "sm_20", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/tesla-c2050", "sm_20", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/tesla-c2070", "sm_20", 49152, 32768);
-TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a100", "sm_80", 49152, 65536);
+TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a100", "sm_80", 49152, 65536)
+    .add_config("l2_cache_size_bytes", Integer(41943040));
 TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a40", "sm_86", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a30", "sm_80", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a10", "sm_86", 49152, 65536);
@@ -231,6 +232,8 @@ TVM_REGISTER_CUDA_TAG("nvidia/nvidia-nvs-310", "sm_21", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/nvs-5400m", "sm_21", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/nvs-5200m", "sm_21", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/nvs-4200m", "sm_21", 49152, 32768);
+TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-4090", "sm_89", 49152, 65536)
+    .add_config("l2_cache_size_bytes", Integer(75497472));
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-3090-ti", "sm_86", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-3090", "sm_86", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-3080-ti", "sm_86", 49152, 65536);

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -334,6 +334,7 @@ TVM_REGISTER_TARGET_KIND("cuda", kDLCUDA)
     .add_attr_option<Integer>("max_threads_per_block")
     .add_attr_option<Integer>("thread_warp_size", Integer(32))
     .add_attr_option<Integer>("registers_per_block")
+    .add_attr_option<Integer>("l2_cache_size_bytes")
     .add_attr_option<Integer>("max_num_threads", Integer(1024))  // TODO(@zxybazh): deprecate it
     .set_default_keys({"cuda", "gpu"})
     .set_target_parser(UpdateCUDAAttrs);

--- a/tests/python/unittest/test_target_target.py
+++ b/tests/python/unittest/test_target_target.py
@@ -478,6 +478,13 @@ def test_target_attr_bool_value():
     assert target3.attrs["supports_float16"] == 0
 
 
+def test_target_attr_l2_cache_size_bytes():
+    target0 = Target("nvidia/nvidia-a100")
+    assert target0.l2_cache_size_bytes == 41943040
+    target1 = Target("nvidia/geforce-rtx-4090")
+    assert target1.l2_cache_size_bytes == 75497472
+
+
 def test_target_features():
     target_no_features = Target("cuda")
     assert target_no_features.features


### PR DESCRIPTION
This PR supports obtain l2 cache size from target. The API is
```
target.l2_cache_size_bytes
```

The l2 cache size is hardcoded in src/target/tag.cc.

This is useful for specializing schedule rules for different targets.

This PR is followup of #15332

cc @yzh119 @zxybazh 