### PR TITLE
[Arith] Support Analyzer.int_set(expr) in python and add RewriteSimplifier rules

### DIFF
--- a/python/tvm/arith/analyzer.py
+++ b/python/tvm/arith/analyzer.py
@@ -195,7 +195,7 @@ class Analyzer:
         """
         return self._canonical_simplify(expr)
 
-    def int_set(self, expr, dom_map):
+    def int_set(self, expr, dom_map=None):
         """Compute a symbolic IntSet that covers expr for all values in dom_map.
 
         Parameters
@@ -203,8 +203,9 @@ class Analyzer:
         expr : PrimExpr
             The expression.
 
-        dom_map : Dict[Var, tvm.arith.IntSet]
-            The domain for variables to be relaxed.
+        dom_map : Optional[Dict[Var, tvm.arith.IntSet]]
+            The domain for variables to be relaxed. If None, use the domain map defined by bound
+            variables.
 
         Returns
         -------

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -290,8 +290,14 @@ TVM_REGISTER_GLOBAL("arith.CreateAnalyzer").set_body([](TVMArgs args, TVMRetValu
       return PackedFunc(
           [self](TVMArgs args, TVMRetValue* ret) { *ret = self->canonical_simplify(args[0]); });
     } else if (name == "int_set") {
-      return PackedFunc(
-          [self](TVMArgs args, TVMRetValue* ret) { *ret = self->int_set(args[0], args[1]); });
+      return PackedFunc([self](TVMArgs args, TVMRetValue* ret) {
+        auto dom_map = args[1].operator Optional<Map<Var, IntSet>>();
+        if (dom_map) {
+          *ret = self->int_set(args[0], dom_map.value());
+        } else {
+          *ret = self->int_set(args[0]);
+        }
+      });
     } else if (name == "bind") {
       return PackedFunc([self](TVMArgs args, TVMRetValue* ret) {
         if (args[1].IsObjectRef<Range>()) {

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -1153,7 +1153,6 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const MinNode* op) {
 
     if (min(x + y, x).Match(ret) || min(x, x + y).Match(ret)) {
       ConstIntBound y_bound = analyzer_->const_int_bound(y.Eval());
-      VLOG(0) << y_bound;
       if (y_bound->min_value >= 0) {
         return x.Eval();
       } else if (y_bound->max_value <= 0) {
@@ -1163,7 +1162,6 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const MinNode* op) {
 
     if (min(x - y, x).Match(ret) || min(x, x - y).Match(ret)) {
       ConstIntBound y_bound = analyzer_->const_int_bound(y.Eval());
-      VLOG(0) << y_bound;
       if (y_bound->min_value >= 0) {
         return (x - y).Eval();
       } else if (y_bound->max_value <= 0) {
@@ -1347,7 +1345,6 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const MaxNode* op) {
 
     if (max(x + y, x).Match(ret) || max(x, x + y).Match(ret)) {
       ConstIntBound y_bound = analyzer_->const_int_bound(y.Eval());
-      VLOG(0) << y_bound;
       if (y_bound->min_value >= 0) {
         return (x + y).Eval();
       } else if (y_bound->max_value <= 0) {
@@ -1357,7 +1354,6 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const MaxNode* op) {
 
     if (max(x - y, x).Match(ret) || max(x, x - y).Match(ret)) {
       ConstIntBound y_bound = analyzer_->const_int_bound(y.Eval());
-      VLOG(0) << y_bound;
       if (y_bound->min_value >= 0) {
         return x.Eval();
       } else if (y_bound->max_value <= 0) {

--- a/tests/python/unittest/test_arith_intset.py
+++ b/tests/python/unittest/test_arith_intset.py
@@ -25,6 +25,9 @@ class IntSetChecker:
     def __init__(self):
         self.analyzer = tvm.arith.Analyzer()
 
+    def bind(self, var, range):
+        self.analyzer.bind(var, range)
+
     def verify(self, data, dmap, expected):
         res = self.analyzer.int_set(data, dmap)
 
@@ -127,6 +130,15 @@ def test_select():
     ck = IntSetChecker()
     x, y = te.var("x"), te.var("y")
     ck.verify(tvm.tir.Select(x > 0, x - 1, x + 1), {x: tvm.arith.IntervalSet(0, 10)}, (-1, 11))
+
+
+def test_dmap_none():
+    ck = IntSetChecker()
+    x, y = te.var("x"), te.var("y")
+    ck.bind(x, tvm.ir.Range(0, 11))
+    ck.bind(y, tvm.ir.Range(1, 12))
+    ck.verify(x + y, None, (1, 21))
+    ck.verify(x - y, None, (-11, 9))
 
 
 def check_region_bound(expect_region, var_dom, mode, predicate=None):

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -20,6 +20,7 @@ import inspect
 import pytest
 
 import tvm
+import tvm.testing
 from tvm import te, tir
 
 from tvm.tir import truncdiv as tdiv, truncmod as tmod, floordiv as fld, floormod as flm
@@ -59,7 +60,6 @@ class BaseCompare:
                 with analyzer.constraint_scope(test_case.constraint):
                     analyzer.rewrite_simplify(test_case.before)
         else:
-
             with analyzer.constraint_scope(test_case.constraint):
                 after = analyzer.rewrite_simplify(test_case.before)
 
@@ -663,6 +663,10 @@ class TestMinIndex(BaseCompare):
         TestCase(tvm.te.min(x + y, x + z), tvm.te.min(y, z) + x),
         TestCase(tvm.te.min(x - y, x - z), x - tvm.te.max(y, z)),
         TestCase(tvm.te.min(y - x, z - x), tvm.te.min(y, z) - x),
+        TestCase(tvm.te.min(x, x + y), x, y >= 0),
+        TestCase(tvm.te.min(x, x + y), x + y, y <= 0),
+        TestCase(tvm.te.min(x, x - y), x - y, y >= 0),
+        TestCase(tvm.te.min(x, x - y), x, y <= 0),
         TestCase(tvm.te.min(tvm.te.min(x, 1), 10), tvm.te.min(x, 1)),
         TestCase(tvm.te.min(tvm.te.min(x, 11), 10), tvm.te.min(x, 10)),
         TestCase(tvm.te.min(x * 3, 9), tvm.te.min(x, 3) * 3),
@@ -734,6 +738,10 @@ class TestMaxIndex(BaseCompare):
         TestCase(tvm.te.max(x + y, x + z), tvm.te.max(y, z) + x),
         TestCase(tvm.te.max(x - y, x - z), x - tvm.te.min(y, z)),
         TestCase(tvm.te.max(y - x, z - x), tvm.te.max(y, z) - x),
+        TestCase(tvm.te.max(x, x + y), x + y, y >= 0),
+        TestCase(tvm.te.max(x, x + y), x, y <= 0),
+        TestCase(tvm.te.max(x, x - y), x, y >= 0),
+        TestCase(tvm.te.max(x, x - y), x - y, y <= 0),
         TestCase(tvm.te.max(tvm.te.max(x, 1), 10), tvm.te.max(x, 10)),
         TestCase(tvm.te.max(tvm.te.max(x, 11), 10), tvm.te.max(x, 11)),
         TestCase(tvm.te.max(x * 3, 9), tvm.te.max(x, 3) * 3),
@@ -840,6 +848,7 @@ class TestComparisons(BaseCompare):
         TestCase(x * (-2) <= -1, tvm.tir.LE(1, x)),
         TestCase(x * (-2) <= -2, tvm.tir.LE(1, x)),
         TestCase(x * (-2) <= -3, tvm.tir.LE(2, x)),
+        TestCase(x // 2 < y, tvm.tir.IntImm("bool", True), x < y * 2),
         # DivMod rules
         # truc div
         TestCase(tdiv(x, 2) < 3, x < 6),

--- a/tests/python/unittest/test_tir_transform_simplify.py
+++ b/tests/python/unittest/test_tir_transform_simplify.py
@@ -245,7 +245,7 @@ class TestNestedVarCondition(BaseBeforeAfter):
                 A[i] = 0.0
 
 
-class TestAlteredBufferContents(BaseBeforeAfter):
+class TestAlteredBufferContentsConst(BaseBeforeAfter):
     """No simplification of data-dependent conditionals.
 
     A literal constraint must not be propagated if the values
@@ -254,11 +254,39 @@ class TestAlteredBufferContents(BaseBeforeAfter):
     may not.
     """
 
+    def before(A: T.Buffer((1,), "int32")):
+        if A[0] == 1:
+            A[0] = A[0] + 1
+            if A[0] == 1:
+                A[0] = 0
+            else:
+                A[0] = 1
+        else:
+            A[0] = A[0] + 1
+            if A[0] == 1:
+                A[0] = 0
+            else:
+                A[0] = 1
+
+    expected = before
+
+
+class TestAlteredBufferContentsVar(BaseBeforeAfter):
+    """Same as TestAlteredBufferContentsConst, but the condition contains a Var."""
+
     def before(A: T.Buffer((1,), "int32"), n: T.int32):
         if A[0] == n:
             A[0] = A[0] + 1
             if A[0] == n:
                 A[0] = 0
+            else:
+                A[0] = 1
+        else:
+            A[0] = A[0] + 1
+            if A[0] == n:
+                A[0] = 0
+            else:
+                A[0] = 1
 
     expected = before
 


### PR DESCRIPTION
This PR:
- Supports `Analyzer.int_set(expr)` from python side. That is, exposing this API from C++ side. Previously we only support `Analyzer.int_set(expr, dom_map)`. 
- Adds some RewriteSimplifier rules for simplifying certain expressions:
    - `min/max(x +- y, x)` where `y>=0` or `y<0`
    - Supporting symbolic analysis in comparision expressions. That enables simplifying `x // 2 < y where x < y * 2` to `True`

cc @spectrometerHBH @tqchen 