### PR TITLE
[Fix] Update mutator name rule

### DIFF
--- a/python/tvm/relax/frontend/nn/visitor.py
+++ b/python/tvm/relax/frontend/nn/visitor.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """The visitor and mutator infra for nn.Module."""
-from typing import Any, Union
+from typing import Any
 
 from . import core as nn
 


### PR DESCRIPTION
When the input `name` is an empty string which means the visitor is at the top level of the module, we should not add a dot to the name of the leaf nodes. 
Before:
```
LlamaForCausalLM
    - .model
    - .lm_head
```
After this update:
```
LlamaForCausalLM
    - model
    - lm_head
```
