### PR TITLE
[Unity] [LiftTransformParams] Treat symbolic var in weight shape as constant

### DIFF
--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -240,7 +240,7 @@ class LiftTransformParamsPlanner : public ExprVisitor {
         builder_.AddInput(function->params[i]);
         if (function->params[i]->struct_info_.defined()) {
           Array<tir::Var> symbolic_vars =
-              TIRVarsInStructInfo(Downcast<StructInfo>(function->params[i]->struct_info_.value()));
+              DefinableTIRVarsInStructInfo(Downcast<StructInfo>(function->params[i]->struct_info_.value()));
           for (const auto& var : symbolic_vars) {
             param_symbolic_vars_.insert(var);
           }

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -239,8 +239,8 @@ class LiftTransformParamsPlanner : public ExprVisitor {
       } else {
         builder_.AddInput(function->params[i]);
         if (function->params[i]->struct_info_.defined()) {
-          Array<tir::Var> symbolic_vars =
-              DefinableTIRVarsInStructInfo(Downcast<StructInfo>(function->params[i]->struct_info_.value()));
+          Array<tir::Var> symbolic_vars = DefinableTIRVarsInStructInfo(
+              Downcast<StructInfo>(function->params[i]->struct_info_.value()));
           for (const auto& var : symbolic_vars) {
             param_symbolic_vars_.insert(var);
           }


### PR DESCRIPTION
In some cases the shape of model weight contains a symbolic var, like vocab size, but it should be treated as if it's constant in LiftTransformParams because the symbolic var does not change in each call of decode/prefill functions.

This PR implements this behavior.