### PR TITLE
[Fix][TIR] Fix dtype issues for match_buffer and ramp node

### DIFF
--- a/python/tvm/script/ir_builder/tir/ir.py
+++ b/python/tvm/script/ir_builder/tir/ir.py
@@ -316,7 +316,8 @@ def match_buffer(
             raise ValueError("Shape must be specified when binding input param")
     shape = (shape,) if isinstance(shape, (PrimExpr, Integral)) else shape
     if strides is not None:
-        strides = [Var(s, "int32") if isinstance(s, str) else s for s in strides]
+        idx_dtype = shape[0].dtype if isinstance(shape[0], PrimExpr) else "int32"
+        strides = [Var(s, idx_dtype) if isinstance(s, str) else s for s in strides]
     else:
         strides = []
     return _ffi_api.MatchBuffer(  # type: ignore[attr-defined] # pylint: disable=no-member

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -1062,7 +1062,6 @@ def ptx_mma(
     saturate : bool
         The optional saturation at the output.
 
-
     operator : Optional[Literal["xor", "and"]]
         The 1-bit operator.
 

--- a/src/tir/ir/expr.cc
+++ b/src/tir/ir/expr.cc
@@ -433,7 +433,9 @@ Ramp::Ramp(PrimExpr base, PrimExpr stride, int lanes, Span span) {
   ICHECK(base.dtype().is_scalar());
   ICHECK(stride.dtype().is_scalar());
   ICHECK_GT(lanes, 1);
-  ICHECK_EQ(stride.dtype(), base.dtype());
+  if (stride.dtype() != base.dtype()) {
+    stride = cast(base.dtype(), stride);
+  }
 
   ObjectPtr<RampNode> node = make_object<RampNode>();
   node->dtype = base.dtype().with_lanes(lanes);

--- a/tests/python/unittest/test_tvmscript_roundtrip.py
+++ b/tests/python/unittest/test_tvmscript_roundtrip.py
@@ -113,7 +113,9 @@ def opt_gemm_lower():
                                 T.ramp((x_c * 32), 1, 32)
                             ] + (
                                 T.broadcast(
-                                    A_1[(((x_outer * 32768) + (x_c * 1024)) + (k_outer * 4)),],
+                                    A_1[
+                                        (((x_outer * 32768) + (x_c * 1024)) + (k_outer * 4)),
+                                    ],
                                     32,
                                 )
                                 * packedB[T.ramp(((y_outer * 32768) + (k_outer * 128)), 1, 32)]


### PR DESCRIPTION
This PR fixes dtype issues for 
- the strides parameter of match_buffer. 
  - When stride is a tir var, it would become a string like `"A_s0"` in the printed script. 
  - If the strides are int64 vars, when we parse the printed script, the dtype of the strides will be set to int32 by default. That causes dtype misalign and effects the structural_equal check. 
  - We will cast the string stride to the dtype of shape (which is always a primexpr)
- ramp node. If the dtypes of base and stride of a ramp node do not match, the dtype of stride will be casted to the dtype of base.