### PR TITLE
[Unity][Relax Frontend] optimize squeeze op converter.

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -757,6 +757,11 @@ class Squeeze(OnnxOpConverter):
 
     @classmethod
     def _impl_v13(cls, bb, inputs, attr, params):
+        # if axes is not none, use it directly.
+        if 'axes' in attr.keys():
+            axis = [x for x in attr['axes']]
+            return relax.op.squeeze(inputs[0], axis)
+        
         axis = get_constant(inputs[1], params)
         if isinstance(axis, relax.Constant):
             axis = [int(x) for x in axis.data.numpy()]


### PR DESCRIPTION
in class Squeeze's _impl_v13()， the attr arg has't been used, if it has explict axis info, try to use it directly.