### PR TITLE
[TIR] Fix pass RenewDefs error in gather/take case

### DIFF
--- a/src/tir/transforms/renew_defs.cc
+++ b/src/tir/transforms/renew_defs.cc
@@ -120,9 +120,11 @@ class RenewDefMutator : public StmtExprMutator {
         std::bind(&RenewDefMutator::VisitMatchBuffer, this, std::placeholders::_1));
 
     // Step 3. Visit body
-    Stmt stmt = StmtExprMutator::VisitStmt_(op);
-    op = stmt.as<BlockNode>();
-    ICHECK(op);
+    Optional<Stmt> init = NullOpt;
+    if (op->init.defined()) {
+      init = this->VisitStmt(op->init.value());
+    }
+    Stmt body = this->VisitStmt(op->body);
 
     // Step 4. Revisit access region
     Array<BufferRegion> reads =
@@ -137,6 +139,8 @@ class RenewDefMutator : public StmtExprMutator {
     n->match_buffers = std::move(match_buffers);
     n->reads = std::move(reads);
     n->writes = std::move(writes);
+    n->body = std::move(body);
+    n->init = std::move(init);
 
     return Stmt(n);
   }


### PR DESCRIPTION
Pervious implementation of RenewDefs pass will fail in the case of the gather/take function. This is because the pass visit and renew the read/write regions twice. This PR fixes it and adds a regression test.

cc @cyx-6 