### PR TITLE
[Unity] Fix FuseTIR pass for gather/take cases 

### DIFF
--- a/src/tir/transforms/renew_defs.cc
+++ b/src/tir/transforms/renew_defs.cc
@@ -120,9 +120,11 @@ class RenewDefMutator : public StmtExprMutator {
         std::bind(&RenewDefMutator::VisitMatchBuffer, this, std::placeholders::_1));
 
     // Step 3. Visit body
-    Stmt stmt = StmtExprMutator::VisitStmt_(op);
-    op = stmt.as<BlockNode>();
-    ICHECK(op);
+    Optional<Stmt> init = NullOpt;
+    if (op->init.defined()) {
+      init = this->VisitStmt(op->init.value());
+    }
+    Stmt body = this->VisitStmt(op->body);
 
     // Step 4. Revisit access region
     Array<BufferRegion> reads =
@@ -137,6 +139,8 @@ class RenewDefMutator : public StmtExprMutator {
     n->match_buffers = std::move(match_buffers);
     n->reads = std::move(reads);
     n->writes = std::move(writes);
+    n->body = std::move(body);
+    n->init = std::move(init);
 
     return Stmt(n);
   }


### PR DESCRIPTION
The current implementation of FuseTIR pass does not handle the buffer access region of the blocks, which may fail when the function is in gather or take pattern. This PR fixes the issue.

Depends on https://github.com/apache/tvm/pull/16063

cc @cyx-6 