### PR TITLE
[Unity][Support] Sample from top-p supports offset

### DIFF
--- a/src/runtime/relax_vm/lm_support.cc
+++ b/src/runtime/relax_vm/lm_support.cc
@@ -379,7 +379,13 @@ int SampleTopPFromLogits(NDArray logits, double temperature, double top_p, doubl
 
 TVM_REGISTER_GLOBAL("vm.builtin.sample_top_p_from_logits").set_body_typed(SampleTopPFromLogits);
 
-int SampleTopPFromProb(NDArray prob, double top_p, double uniform_sample) {
+int SampleTopPFromProb(NDArray prob, int unit_offset, double top_p, double uniform_sample) {
+  // prob: (*, v)
+  // The prob array may have arbitrary ndim and shape.
+  // The last dimension corresponds to the prob distribution size.
+  // We use the `unit_offset` parameter to determine which slice
+  // of the prob array we sample from.
+
   ICHECK(prob.IsContiguous());
   ICHECK(prob.DataType() == DataType::Float(32));
 
@@ -389,16 +395,12 @@ int SampleTopPFromProb(NDArray prob, double top_p, double uniform_sample) {
 
   ICHECK(prob->device.device_type == kDLCPU);
 
-  for (int i = 0; i < prob->ndim - 1; ++i) {
-    ICHECK_EQ(prob->shape[i], 1) << "The leading dimensions of logits must be 1";
-  }
-
   // Key observation: when we are doing top_p sampling
   // usually we only need to preserve some of the elements with
-  // high probablities before we do sort
+  // high probabilities before we do sort
   std::vector<std::pair<float, int>> data;
   int64_t ndata = prob->shape[prob->ndim - 1];
-  const float* p_prob = static_cast<float*>(prob->data);
+  const float* p_prob = static_cast<float*>(prob->data) + (unit_offset * ndata);
 
   auto sample_top_p_with_filter = [&](float cuttoff) -> int64_t {
     data.clear();

--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -1726,7 +1726,7 @@ export class Instance implements Disposable {
    * @returns The sampled index.
    */
   sampleTopPFromLogits(logits: NDArray, temperature: number, top_p: number): number {
-    return this.ctx.sampleTopPFromLogits(logits, temperature, top_p, Math.random());
+    return this.ctx.sampleTopPFromLogits(logits, /*unit_offset=*/0, temperature, top_p, Math.random());
   }
 
   /**


### PR DESCRIPTION
This PR enhances the `SampleTopPFromProb` function, adding a new `unit_offset` parameter. With this PR, the input prob array can contain multiple prob distributions. The offset is used to specify which probability to sample from.

Prior to this PR, this function assumes the input prob array only contains a single probability distribution.
This assumption, though effective, prevents efficient sampling for batching scenarios, since it forces us to split the batched prob array before sampling.

This PR eliminates this issue by introducing the offset.