### PR TITLE
[Bugfix] Compilation Error with Clang

### DIFF
--- a/include/tvm/runtime/memory/memory_manager.h
+++ b/include/tvm/runtime/memory/memory_manager.h
@@ -136,7 +136,7 @@ class StorageObj : public Object {
   Buffer buffer;
 
   /*! \brief Allocate an NDArray from a given piece of storage. */
-  NDArray AllocNDArray(size_t offset, ShapeTuple shape, DLDataType dtype);
+  NDArray AllocNDArray(int64_t offset, ShapeTuple shape, DLDataType dtype);
 
   /*! \brief The deleter for an NDArray when allocated from underlying storage. */
   static void Deleter(Object* ptr);

--- a/src/runtime/memory/memory_manager.cc
+++ b/src/runtime/memory/memory_manager.cc
@@ -82,7 +82,7 @@ inline size_t GetDataAlignment(const DLTensor& arr) {
   return align;
 }
 
-NDArray StorageObj::AllocNDArray(size_t offset, ShapeTuple shape, DLDataType dtype) {
+NDArray StorageObj::AllocNDArray(int64_t offset, ShapeTuple shape, DLDataType dtype) {
   VerifyDataType(dtype);
 
   // crtical zone: allocate header, cannot throw


### PR DESCRIPTION
This PR fixes compilation error from macOS's clang due to recent change.

```
/Users/jshao/Projects/tvm-dev/src/runtime/relax_vm/builtin.cc:357:48: note: in instantiation of function template specialization 'tvm::runtime::Registry::set_body_method<tvm::runtime::memory::Storage, tvm::runtime::memory::StorageObj, tvm::runtime::NDArray, unsigned long, tvm::runtime::ShapeTuple, DLDataType, void>' requested here
  357 | TVM_REGISTER_GLOBAL("vm.builtin.alloc_tensor").set_body_method<Storage>(&StorageObj::AllocNDArray);
      |                                                ^
/Users/jshao/Projects/tvm-dev/include/tvm/runtime/packed_func.h:546:3: note: candidate function
  546 |   operator double() const {
      |   ^
/Users/jshao/Projects/tvm-dev/include/tvm/runtime/packed_func.h:556:3: note: candidate function
  556 |   operator int64_t() const {
      |   ^
/Users/jshao/Projects/tvm-dev/include/tvm/runtime/packed_func.h:560:3: note: candidate function
  560 |   operator uint64_t() const {
      |   ^
/Users/jshao/Projects/tvm-dev/include/tvm/runtime/packed_func.h:564:3: note: candidate function
  564 |   operator int() const {
      |   ^
/Users/jshao/Projects/tvm-dev/include/tvm/runtime/packed_func.h:570:3: note: candidate function
  570 |   operator bool() const {
      |   ^
```