### PR TITLE
Revert "[Unity][Support] Sample from top-p supports offset"

### DIFF
--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -1726,7 +1726,7 @@ export class Instance implements Disposable {
    * @returns The sampled index.
    */
   sampleTopPFromLogits(logits: NDArray, temperature: number, top_p: number): number {
-    return this.ctx.sampleTopPFromLogits(logits, /*unit_offset=*/0, temperature, top_p, Math.random());
+    return this.ctx.sampleTopPFromLogits(logits, temperature, top_p, Math.random());
   }
 
   /**


### PR DESCRIPTION
This PR reverts apache/tvm#16069.

We found that there are more improvements for the sampling function. We would like to implement them and verify the functionality locally first, and upstream when the stability is confirmed.