### PR TITLE
[Fix] Broken Windows Build with LLVM

### DIFF
--- a/cmake/utils/FindLLVM.cmake
+++ b/cmake/utils/FindLLVM.cmake
@@ -118,6 +118,7 @@ macro(find_llvm use_llvm)
     if(NOT "${__llvm_exit_code}" STREQUAL "0")
       message(FATAL_ERROR "Fatal error executing: ${LLVM_CONFIG} --cmakedir")
     endif()
+    cmake_path(SET "__llvm_cmakedir" "${__llvm_cmakedir}")
     message(STATUS "LLVM cmakedir: ${__llvm_cmakedir}")
     # map prefix => $
     # to handle the case when the prefix contains space.


### PR DESCRIPTION
PR #16032 introduces a more stable way of zstd path finding by relying on LLVM's existing Findzstd module, but it turns out that the cmake dir from `llvm-config` is not very compatible with CMake's internal convention, and thus a conversion is required to get rid of the error message below:

```
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD

    D:/a/package/package/tvm/build/CMakeFiles/CMakeScratch/TryCompile-tnlfb1/CMakeLists.txt:2

-- Configuring incomplete, errors occurred!
  when parsing string

    C:\Miniconda\envs\tlcpack-build\Library\lib\cmake\llvm

  Invalid character escape '\M'.
```

CC @lhutton1 