### PR TITLE
[Unity] Support Regular expression matching in globalvar dataflow pattern

### DIFF
--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -33,10 +33,10 @@
 #include <tvm/tir/op.h>
 
 #include <array>
-#include <regex>
 #include <cstddef>
 #include <limits>
 #include <optional>
+#include <regex>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -556,7 +556,7 @@ bool DFPatternMatcher::VisitDFPattern_(const DataflowVarPatternNode* op, const E
 
 bool DFPatternMatcher::VisitDFPattern_(const GlobalVarPatternNode* op, const Expr& expr) {
   // GlobalVarPattern is not inherited from Var, so we need to handle it separately.
-  if (const auto* var_node = expr.as<GlobalVarNode>()){
+  if (const auto* var_node = expr.as<GlobalVarNode>()) {
     std::regex pat{std::string(op->name_hint())};
     return "" == op->name_hint() || std::regex_search(std::string(var_node->name_hint), pat);
   }

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -33,6 +33,7 @@
 #include <tvm/tir/op.h>
 
 #include <array>
+#include <regex>
 #include <cstddef>
 #include <limits>
 #include <optional>
@@ -555,8 +556,10 @@ bool DFPatternMatcher::VisitDFPattern_(const DataflowVarPatternNode* op, const E
 
 bool DFPatternMatcher::VisitDFPattern_(const GlobalVarPatternNode* op, const Expr& expr) {
   // GlobalVarPattern is not inherited from Var, so we need to handle it separately.
-  if (const auto* var_node = expr.as<GlobalVarNode>())
-    return "" == op->name_hint() || op->name_hint() == var_node->name_hint;
+  if (const auto* var_node = expr.as<GlobalVarNode>()){
+    std::regex pat{std::string(op->name_hint())};
+    return "" == op->name_hint() || std::regex_search(std::string(var_node->name_hint), pat);
+  }
   return false;
 }
 

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -97,6 +97,7 @@ def test_dataflow_var_pattern():
 
 def test_global_var_pattern():
     assert is_gv("x").match(rx.GlobalVar("x"))
+    assert is_gv("x.*").match(rx.GlobalVar("x_2"))
     assert is_gv().match(rx.GlobalVar("x"))
     assert not is_gv("x").match(rx.GlobalVar("y"))
     assert not is_gv("x").match(rx.Var("x"))


### PR DESCRIPTION
When matching global var of TIR functions, sometimes we want to use regular expression to match because the TIR functions are often named like matmul_123. This PR implements this behavior.