### PR TITLE
[Unity] support symbolic var in RewriteDataflowReshape

### DIFF
--- a/tests/python/relax/test_transform_rewrite_dataflow_reshape.py
+++ b/tests/python/relax/test_transform_rewrite_dataflow_reshape.py
@@ -582,5 +582,4 @@ def test_reshape_scalar():
 
 
 if __name__ == "__main__":
-    # tvm.testing.main()
-    test_reshape_dynamic_shape()
+    tvm.testing.main()

--- a/tests/python/relax/test_transform_rewrite_dataflow_reshape.py
+++ b/tests/python/relax/test_transform_rewrite_dataflow_reshape.py
@@ -220,6 +220,64 @@ def test_reshape_pattern_detect():
     mod = relax.transform.RewriteDataflowReshape()(Module)
     tvm.ir.assert_structural_equal(mod, Expected)
 
+def test_reshape_dynamic_shape():
+    @tvm.script.ir_module
+    class Module:
+        @T.prim_func(private=True)
+        def reshape(var_A: T.handle, var_T_reshape: T.handle):
+            T.func_attr({"tir.is_scheduled": 1, "tir.noalias": T.bool(True)})
+            n = T.int32()
+            A = T.match_buffer(var_A, (n, 16, 128), "float16")
+            T_reshape = T.match_buffer(var_T_reshape, (1, n, 16, 128), "float16")
+            # with T.block("root"):
+            for ax0_ax1_ax2_fused_0 in T.thread_binding(n * 2, thread="blockIdx.x"):
+                for ax0_ax1_ax2_fused_1 in T.thread_binding(1024, thread="threadIdx.x"):
+                    with T.block("T_reshape"):
+                        v0 = T.axis.spatial(n, (ax0_ax1_ax2_fused_0 * 1024 + ax0_ax1_ax2_fused_1) // 2048)
+                        v1 = T.axis.spatial(16, (ax0_ax1_ax2_fused_0 * 1024 + ax0_ax1_ax2_fused_1) % 2048 // 128)
+                        v2 = T.axis.spatial(128, (ax0_ax1_ax2_fused_0 * 1024 + ax0_ax1_ax2_fused_1) % 128)
+                        T.reads(A[((v2 // 128 + v1) // 32 + v0) % n, (v2 // 128 + v1) % 32, v2 % 128])
+                        T.writes(T_reshape[0, v0, v1, v2])
+                        T_reshape[0, v0, v1, v2] = A[((v2 // 128 + v1) // 32 + v0) % n, (v2 // 128 + v1) % 32, v2 % 128]
+        @R.function
+        def main(x: R.Tensor((8, 3), dtype="float32")) -> R.Tensor((2, 4, 3), dtype="float32"):
+            cls = Module
+            with R.dataflow():
+                y = R.call_tir(cls.reshape, (x,), out_sinfo=R.Tensor((2, 4, 3), dtype="float32"))
+                z = R.add(y, R.const(1, "float32"))
+                R.output(z)
+            return z
+        
+    @tvm.script.ir_module
+    class Expected:   
+        @T.prim_func(private=True)
+        def reshape(var_A: T.handle, var_T_reshape: T.handle):
+            T.func_attr({"tir.is_scheduled": 1, "tir.noalias": T.bool(True)})
+            n = T.int32()
+            A = T.match_buffer(var_A, (n, 16, 128), "float16")
+            T_reshape = T.match_buffer(var_T_reshape, (1, n, 16, 128), "float16")
+            # with T.block("root"):
+            for ax0_ax1_ax2_fused_0 in T.thread_binding(n * 2, thread="blockIdx.x"):
+                for ax0_ax1_ax2_fused_1 in T.thread_binding(1024, thread="threadIdx.x"):
+                    with T.block("T_reshape"):
+                        v0 = T.axis.spatial(n, (ax0_ax1_ax2_fused_0 * 1024 + ax0_ax1_ax2_fused_1) // 2048)
+                        v1 = T.axis.spatial(16, (ax0_ax1_ax2_fused_0 * 1024 + ax0_ax1_ax2_fused_1) % 2048 // 128)
+                        v2 = T.axis.spatial(128, (ax0_ax1_ax2_fused_0 * 1024 + ax0_ax1_ax2_fused_1) % 128)
+                        T.reads(A[((v2 // 128 + v1) // 32 + v0) % n, (v2 // 128 + v1) % 32, v2 % 128])
+                        T.writes(T_reshape[0, v0, v1, v2])
+                        T_reshape[0, v0, v1, v2] = A[((v2 // 128 + v1) // 32 + v0) % n, (v2 // 128 + v1) % 32, v2 % 128]
+
+        @R.function
+        def main(x: R.Tensor((8, 3), dtype="float32")) -> R.Tensor((2, 4, 3), dtype="float32"):
+            with R.dataflow():
+                y: R.Tensor((2, 4, 3), dtype="float32") = R.reshape(x, R.shape([2, 4, 3]))
+                z: R.Tensor((2, 4, 3), dtype="float32") = R.add(y, R.const(1, "float32"))
+                R.output(z)
+            return z
+        
+    assert relax.analysis.has_reshape_pattern(Module["reshape"])
+    mod = relax.transform.RewriteDataflowReshape()(Module)
+    tvm.ir.assert_structural_equal(mod, Expected)
 
 def test_reshape_non_dataflow():
     @tvm.script.ir_module
@@ -501,4 +559,5 @@ def test_reshape_scalar():
 
 
 if __name__ == "__main__":
-    tvm.testing.main()
+    # tvm.testing.main()
+    test_reshape_dynamic_shape()


### PR DESCRIPTION
Current RewriteDataflowReshape pass cannot detect reshape from [n, 16, 128] to [1, n, 16, 128] because of simplifier is not symbolic-var-aware. This PR adds an additional IterMapSimplify to solve the problem.