### PR TITLE
[Unity][BlockBuilder] Depracate `BlockBuilder.get()` and change it to `BlockBuilder.finalize()`

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -83,6 +83,15 @@ class BlockBuilderNode : public Object {
   virtual IRModule GetContextIRModule() const = 0;
 
   /*!
+   * \brief Finalize the building process and return the result IRModule. Possibly rename
+   * GlobalVars in the IRModule to ensure name uniqueness and the invariant:
+   * every public function has the same name as its "global_symbol" attribute.
+   *
+   * \return The IRModule in this BlockBuilder.
+   */
+  virtual IRModule Finalize() = 0;
+
+  /*!
    * \brief Add a Relax function or a TIR PrimFunc to internal context module.
    * \param func The function to be added.
    * \param func_name_hint The name hint of the function to be added.

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -155,6 +155,15 @@ TVM_DLL Pass AttachGlobalSymbol();
 TVM_DLL Pass Normalize();
 
 /*!
+ * \brief Possibly rename the GlobalVar in an IRModule to ensure these properties:
+ * 1. (Invariant) First ensure every public function has the same name as its "global_symbol"
+ *    attribute;
+ * 2. To ensure 1., we may need to rename private functions with conflicting names;
+ * 3. Finally, the name of every GlobalVar is unique in the IRModule.
+ */
+TVM_DLL Pass NormalizeGlobalVar();
+
+/*!
  * \brief Simplify a Relax module by folding var bindings and match shape nodes,
  * as well as tuple indices.
  * Best used alongside constant folding and eliminating unused bindings.

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=no-else-return, invalid-name, unused-argument
+# pylint: disable=no-else-return, invalid-name, unused-argument, import-outside-toplevel
 """Developer API of constructing Relax AST."""
 
 from typing import Dict, List, Optional, Union, Any, Callable, Sequence

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -661,12 +661,20 @@ class BlockBuilder(Object):
     def get(self) -> tvm.IRModule:
         """Return the IRModule being built.
 
+        Note this call may invalidate global vars previously returned by this builder
+        (see tvm.relax.transform.NormalizeGlobalVar), so it is recommended to call this function
+        once at the end of the build process.
+
         Returns
         -------
         ret : tvm.IRModule
             An IRModule with Relax and TIR functions being built.
         """
-        return _ffi_api.BlockBuilderGetContextIRModule(self)  # type: ignore
+        # avoid circular import
+        from .transform import NormalizeGlobalVar
+
+        mod = _ffi_api.BlockBuilderGetContextIRModule(self)  # type: ignore
+        return NormalizeGlobalVar()(mod)
 
     def get_unique_name(self, name_prefix: str) -> str:
         """Generate a unique name with a specified prefix.

--- a/python/tvm/relax/ir/instrument.py
+++ b/python/tvm/relax/ir/instrument.py
@@ -39,7 +39,7 @@ class WellFormedInstrument:
     """
 
     def __init__(self, check_struct_info: bool = True, validate_before_transform: bool = True):
-        self.skip_pass_name = ["Normalize", "ResolveGlobals"]
+        self.skip_pass_name = ["Normalize", "NormalizeGlobalVar", "ResolveGlobals"]
         self.check_struct_info = check_struct_info
         self.validate_before_transform = validate_before_transform
 

--- a/python/tvm/relax/transform/__init__.py
+++ b/python/tvm/relax/transform/__init__.py
@@ -51,6 +51,7 @@ from .transform import (
     MetaScheduleTuneIRMod,
     MetaScheduleTuneTIR,
     Normalize,
+    NormalizeGlobalVar,
     PatternCheckContext,
     RealizeVDevice,
     RemovePurityChecking,

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -284,6 +284,21 @@ def Normalize() -> tvm.ir.transform.Pass:
     return _ffi_api.Normalize()  # type: ignore
 
 
+def NormalizeGlobalVar() -> tvm.ir.transform.Pass:
+    """Possibly rename the GlobalVar in an IRModule to ensure these properties:
+
+    1. (Invariant) First ensure every public function has the same name as its "global_symbol"
+    attribute
+    2. To ensure 1., we may need to rename private functions with conflicting names;
+    3. Finally, the name of every GlobalVar is unique in the IRModule.
+
+    Returns
+    -------
+    ret: tvm.ir.transform.Pass
+    """
+    return _ffi_api.NormalizeGlobalVar()  # type: ignore
+
+
 def CanonicalizeBindings() -> tvm.ir.transform.Pass:
     """
     Canonicalizes variable definitions

--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -26,7 +26,7 @@
  * This pass will check:
  *    1. Each Expr should have `struct_info_` field already populated, when
  *      `check_struct_info` is true.
- *    2. GlobalVars are defined before use.
+ *    2. GlobalVars are defined before use. And all GlobalVars have different names.
  *    3. When a Function has a corresponding GlobalVar and a `global_symbol`
  *       attribute, the name of the GlobalVar must equal the value of the
  *       `global_symbol` attribute value.
@@ -126,6 +126,9 @@ class WellFormedChecker : public relax::ExprVisitor,
   }
 
   void CheckGlobalVarAndGsymbolConsistency(GlobalVar var, Function func) {
+    // the uniqueness of all global vars are ensured by IRModule->global_var_map_, so do not need
+    // to check again
+
     // check name in global var and gsymbol
     Optional<String> gsymbol = func->GetAttr<String>(tvm::attr::kGlobalSymbol);
     if (gsymbol.defined() && gsymbol != var->name_hint) {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -1003,7 +1003,7 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderUpdateFunction")
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderGetContextIRModule")
     .set_body_method<BlockBuilder>(&BlockBuilderNode::GetContextIRModule);
-    
+
 TVM_REGISTER_GLOBAL("relax.BlockBuilderFinalize")
     .set_body_method<BlockBuilder>(&BlockBuilderNode::Finalize);
 

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -27,6 +27,7 @@
 #include <tvm/relax/op_attr_types.h>
 #include <tvm/relax/struct_info.h>
 #include <tvm/relax/struct_info_functor.h>
+#include <tvm/relax/transform.h>
 #include <tvm/relax/type.h>
 #include <tvm/relay/op.h>
 #include <tvm/runtime/registry.h>
@@ -71,6 +72,8 @@ class BlockBuilderImpl : public BlockBuilderNode {
   NameSupply name_supply() final { return name_supply_; }
 
   IRModule GetContextIRModule() const final { return context_mod_; }
+
+  IRModule Finalize() final { return transform::NormalizeGlobalVar()(context_mod_); }
 
   GlobalVar AddFunction(const BaseFunc& func, String func_name_hint) final {
     LazyInitCtxFuncDedupMap();
@@ -1000,6 +1003,9 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderUpdateFunction")
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderGetContextIRModule")
     .set_body_method<BlockBuilder>(&BlockBuilderNode::GetContextIRModule);
+    
+TVM_REGISTER_GLOBAL("relax.BlockBuilderFinalize")
+    .set_body_method<BlockBuilder>(&BlockBuilderNode::Finalize);
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderCurrentBlockIsDataFlow")
     .set_body_method<BlockBuilder>(&BlockBuilderNode::CurrentBlockIsDataFlow);

--- a/tests/python/relax/test_transform_normalize_global_var.py
+++ b/tests/python/relax/test_transform_normalize_global_var.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+import tvm
+import tvm.testing
+from tvm import relax
+from tvm import tir
+from tvm.ir.base import assert_structural_equal
+
+import tvm.script
+from tvm.script import tir as T, relax as R, ir as I
+
+
+@pytest.mark.skip_well_formed_check_before_transform
+def test_normalize_relax_function():
+    @I.ir_module
+    class Before:
+        @R.function(private=True)
+        def f():
+            return R.const(1, "int32")
+
+        @R.function
+        def f1():
+            R.func_attr({"global_symbol": "f"})
+            cls = Before
+            gv: R.Tensor((), dtype="int32") = cls.f()
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def f():
+            cls = Expected
+            gv: R.Tensor((), dtype="int32") = cls.f1()
+            return gv
+
+        @R.function(private=True)
+        def f1():
+            return R.const(1, "int32")
+
+    After = relax.transform.NormalizeGlobalVar()(Before)
+
+    assert not relax.analysis.well_formed(Before)
+    assert relax.analysis.well_formed(After)
+    assert_structural_equal(After, Expected)
+
+
+@pytest.mark.skip_well_formed_check_before_transform
+def test_normalize_tir_function():
+    @I.ir_module
+    class Before:
+        @T.prim_func(private=True)
+        def f(x: T.Buffer((1,), "int32")):
+            x[0] = T.int32(0)
+
+        @R.function
+        def f1():
+            R.func_attr({"global_symbol": "f"})
+            cls = Before
+            gv: R.Tensor((), dtype="int32") = R.call_tir(cls.f, (), R.Tensor((1,), dtype="int32"))
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @T.prim_func(private=True)
+        def f1(x: T.Buffer((1,), "int32")):
+            x[0] = 0
+
+        @R.function
+        def f() -> R.Tensor((1,), dtype="int32"):
+            cls = Expected
+            gv = R.call_tir(cls.f1, R.tuple(), out_sinfo=R.Tensor((1,), dtype="int32"))
+            return gv
+
+    After = relax.transform.NormalizeGlobalVar()(Before)
+
+    assert not relax.analysis.well_formed(Before)
+    assert relax.analysis.well_formed(After)
+    assert_structural_equal(After, Expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Previously BlockBuilder would have a problem about naming of public function if we 
1) emit a private function, and then 
2) emit a public function with the same name. 

Previously, BlockBuilder would rename the latter, i.e. the public function. That led the name of the public function did not match the name of its global_symbol attribute.

To tackle this problem, this PR introduces a new pass NormalizeGlobalVar. This pass will possibly rename the GlobalVar in an IRModule to ensure these properties:
1. (Invariant) First ensure every public function has the same name as its "global_symbol" attribute ;
2. To ensure 1., we may need to rename private functions with conflicting names; 
3. Finally, the name of every GlobalVar is unique in the IRModule.

This PR adds a member function `bb.finalize()` to be used at the end of the building process. It will call NormalizeGlobalVar to ensure the invariant, and returns the final IRModule. It essentially substitutes the functionality of `bb.get()`, so we mark the latter deprecated.

About naming: we can still use the interface `bb.get()` and execute a NormalizeGlobalVar pass in it. But such `bb.get()` can only be called once at the end of the building process. So we rename it to `bb.finalize()` for clearity and alignment with C++ side.

cc @junrushao @tqchen