### PR TITLE
[Smallfix][WEB] Change memory manager import for web

### DIFF
--- a/web/emcc/wasm_runtime.cc
+++ b/web/emcc/wasm_runtime.cc
@@ -53,11 +53,11 @@
 #include "src/runtime/system_library.cc"
 #include "src/runtime/workspace_pool.cc"
 // relax setup
+#include "src/runtime/memory/memory_manager.cc"
 #include "src/runtime/relax_vm/builtin.cc"
 #include "src/runtime/relax_vm/bytecode.cc"
 #include "src/runtime/relax_vm/executable.cc"
 #include "src/runtime/relax_vm/lm_support.cc"
-#include "src/runtime/relax_vm/memory_manager.cc"
 #include "src/runtime/relax_vm/ndarray_cache_support.cc"
 #include "src/runtime/relax_vm/vm.cc"
 


### PR DESCRIPTION
Change import in wasm runtime to reflect new memory manager location.