### PR TITLE
[Unity][WebGPU] Allow lower max storage buffer binding size

### DIFF
--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -55,13 +55,30 @@ export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefin
       );
     }
 
-    const requiredMaxStorageBufferBindingSize = 1 << 30;
+    let requiredMaxStorageBufferBindingSize = 1 << 30;  // 1GB
     if (requiredMaxStorageBufferBindingSize > adapter.limits.maxStorageBufferBindingSize) {
-      throw Error(
-        `Cannot initialize runtime because of requested maxStorageBufferBindingSize ` +
-        `exceeds limit. requested=${computeMB(requiredMaxStorageBufferBindingSize)}, ` +
-        `limit=${computeMB(adapter.limits.maxStorageBufferBindingSize)}. `
+      // If 1GB is too large, try 128MB (default size for Android)
+      const backupRequiredMaxStorageBufferBindingSize = 1 << 27;  // 128MB
+      console.log(
+        `Requested maxStorageBufferBindingSize exceeds limit. \n` +
+        `requested=${computeMB(requiredMaxStorageBufferBindingSize)}, \n` +
+        `limit=${computeMB(adapter.limits.maxStorageBufferBindingSize)}. \n` +
+        `Falling back to ${computeMB(backupRequiredMaxStorageBufferBindingSize)}...`
       );
+      if (backupRequiredMaxStorageBufferBindingSize > adapter.limits.maxStorageBufferBindingSize) {
+        // Fail if 128MB is still too big
+        throw Error(
+          `Cannot initialize runtime because of requested maxStorageBufferBindingSize ` +
+          `exceeds limit. requested=${computeMB(backupRequiredMaxStorageBufferBindingSize)}, ` +
+          `limit=${computeMB(adapter.limits.maxStorageBufferBindingSize)}. `
+        );
+      } else {
+        requiredMaxStorageBufferBindingSize = backupRequiredMaxStorageBufferBindingSize;
+        console.log(
+          `WARNING: this buffer size only works for a limited number of models ` + 
+          `(e.g. Llama2 7B with 1024 context length).`
+        );
+      }
     }
 
     const requiredMaxComputeWorkgroupStorageSize = 32 << 10;

--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -63,20 +63,15 @@ export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefin
         `Requested maxStorageBufferBindingSize exceeds limit. \n` +
         `requested=${computeMB(requiredMaxStorageBufferBindingSize)}, \n` +
         `limit=${computeMB(adapter.limits.maxStorageBufferBindingSize)}. \n` +
-        `Falling back to ${computeMB(backupRequiredMaxStorageBufferBindingSize)}...`
+        `WARNING: Falling back to ${computeMB(backupRequiredMaxStorageBufferBindingSize)}...`
       );
+      requiredMaxStorageBufferBindingSize = backupRequiredMaxStorageBufferBindingSize;
       if (backupRequiredMaxStorageBufferBindingSize > adapter.limits.maxStorageBufferBindingSize) {
         // Fail if 128MB is still too big
         throw Error(
           `Cannot initialize runtime because of requested maxStorageBufferBindingSize ` +
           `exceeds limit. requested=${computeMB(backupRequiredMaxStorageBufferBindingSize)}, ` +
           `limit=${computeMB(adapter.limits.maxStorageBufferBindingSize)}. `
-        );
-      } else {
-        requiredMaxStorageBufferBindingSize = backupRequiredMaxStorageBufferBindingSize;
-        console.log(
-          `WARNING: this buffer size only works for a limited number of models ` + 
-          `(e.g. Llama2 7B with 1024 context length).`
         );
       }
     }


### PR DESCRIPTION
This PR lowers the required `maxStorageBufferBindingSize` from 1GB to 128MB when necessary.

Previously, we required 1GB, which led to errors when running on some devices (e.g. Android's Chrome, since Android has 128MB as its limit).

Now, if the device does not allow 1GB, we lower it to 128MB. We only throw an error when 128MB still exceeds the limit.

cc @tqchen 
