### PR TITLE
[Unity][Support] PagedKVCache support growth control

### DIFF
--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache.py
@@ -160,6 +160,7 @@ def test_paged_attention_kv_cache_append_prefill():
         nhead,
         nfeat,
         tvm.nd.empty((), dtype),
+        True,
     )
 
     operation_seq = [[(0, 6)], [(1, 8)], [(2, 11)], [(3, 16)], [(4, 19), (5, 20)]]
@@ -207,6 +208,7 @@ def test_paged_attention_kv_cache_append_decode():
         nhead,
         nfeat,
         tvm.nd.empty((), dtype),
+        True,
     )
 
     cached_values = []
@@ -260,6 +262,7 @@ def test_paged_attention_kv_cache_remove():
         nhead,
         nfeat,
         tvm.nd.empty((), dtype),
+        True,
     )
 
     cached_values = []
@@ -319,6 +322,7 @@ def test_paged_attention_kv_cache_popn():
         nhead,
         nfeat,
         tvm.nd.empty((), dtype),
+        True,
     )
 
     cached_values = []
@@ -381,6 +385,7 @@ def test_paged_attention_kv_cache_clear():
         nhead,
         nfeat,
         tvm.nd.empty((), dtype),
+        True,
     )
 
     cached_values = []


### PR DESCRIPTION
This PR supports controlling whether KV cache automatic growth is allowed through constructor parameter. Previously we always allow the KV cache to grow whenever it is full and more capacity is demanded.

Although automatic growth can be good, in practice we often want the pre-allocated memory to be static, large enough and not changeable, which will make the memory management more controllable. Hence, this PR supports to specify if growth is allowed, and will throw error when growing in unallowed cases.

This PR also adds an auxiliary function to KV cache to query the number of available pages.