### PR TITLE
[Unity] Improved error message in relax::Normalizer

### DIFF
--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -688,7 +688,8 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
 
     if (!node->struct_info_.defined()) {
       auto opt = MatchStructInfo<TupleStructInfo>(node->tuple);
-      ICHECK(opt) << "The struct info of Tuple must be TupleStructInfo.";
+      ICHECK(opt) << "The struct info of Tuple must be TupleStructInfo, "
+                  << "but expression " << node << " has struct info " << node->struct_info_;
       UpdateStructInfo(node, opt.value()->fields[node->index]);
     }
 


### PR DESCRIPTION
Display the invalid struct info if a `Tuple` has anything other than `TupleStructInfo`.