### PR TITLE
[Unity][Transform] Keep R.ExternFunc in dead-code elimination

### DIFF
--- a/src/relax/transform/dead_code_elimination.cc
+++ b/src/relax/transform/dead_code_elimination.cc
@@ -124,7 +124,7 @@ IRModule DeadCodeElimination(const IRModule& arg_mod, Array<runtime::String> ent
     entry_functions.insert(mod->GetGlobalVar(name));
   }
   for (const auto& [gv, func] : mod->functions) {
-    if (func->GetLinkageType() == LinkageType::kExternal) {
+    if (func.as<ExternFuncNode>() || func->GetLinkageType() == LinkageType::kExternal) {
       entry_functions.insert(gv);
     }
   }

--- a/tests/python/relax/test_transform_dead_code_elimination.py
+++ b/tests/python/relax/test_transform_dead_code_elimination.py
@@ -497,5 +497,15 @@ def test_unused_dfb2():
     verify(Input, Expected)
 
 
+def test_extern_func():
+    """DeadCodeElimination should retain the ExternFunc in the IRModule."""
+
+    builder = tvm.relax.BlockBuilder()
+    builder.add_func(tvm.relax.extern("extern_func"), "extern_func")
+    before = builder.get()
+
+    verify(before, before)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Prior to this commit, the `DeadCodeElimination` and `FuseTIR` passes treated `R.ExternFunc` differently with respect to removal of internal functions: `DeadCodeElimination` treated these functions as internal, to be removed if there are no internal callers, while `FuseTIR` treated these functions as external, to be retained in all cases.

Because the visibility of a function is determined by the `tvm::attr::kGlobalSymbol` attribute; which is present for `PrimFunc` and `relax::Function`, but missing for `relax::ExternFunc`; there is no information in the `IRModule` that can determine whether a `relax::ExternFunc` should be visible externally.

For consistency, and to allow the use of `DeadCodeElimination` in future refactors of `FuseTIR`, this commit updates `DeadCodeElimination` to retain instances of `relax::ExternFunc`.