### PR TITLE
[Unity][Transform] Extract partial-tuple-usage from FuseTIR

### DIFF
--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -403,7 +403,9 @@ class FusedTIRConstructor : public ExprVisitor {
       func_info_.expr2buffers.Set(relax_param, param_buffers);
     }
 
-    // Move all scalar params after buffer params.
+    // Move all scalar params after buffer params.  To ensure that the
+    // order is deterministic and predictable for testing purposes,
+    // std::stable_sort is used instead of std::sort.
     std::stable_sort(prim_func_params.begin(), prim_func_params.end(),
                      [](const auto& a, const auto& b) {
                        bool a_is_var = a.template as<tir::VarNode>();
@@ -733,9 +735,10 @@ class FusedTIRConstructor : public ExprVisitor {
         out->push_back(Downcast<tir::Var>(var));
       }
     } else {
-      ICHECK(false) << "TypeError: The param type of PrimFunc is expected to be Tensor, Tuple or "
-                       "ShapeExpr, but got "
-                    << struct_info->GetTypeKey();
+      LOG(FATAL) << "TypeError: "
+                 << "The param type of PrimFunc is expected to be "
+                 << "Tensor, PrimValue, or ShapeExpr, "
+                 << "but got " << struct_info->GetTypeKey();
     }
   }
 


### PR DESCRIPTION
Prior to this commit, the `FuseTIR` pass explicitly tracked usage of
tuple arguments, to minimize the set of arguments provided to each
kernel.  The additional tgracking and handling of partially-used
tuples makes it difficult to follow the primary changes being made by
`FuseTIR`.

This commit implements the same functionality in terms of the
`ExpandTupleArguments` and `RemoveUnusedParameters` transforms,
introduced in https://github.com/apache/tvm/pull/16115 and
https://github.com/apache/tvm/pull/16116 respectively.  By using these
passes before the main `FuseOps` changes, partial tuple usage is
already handled at that point.

This commit is intended to minimize any changes to user-facing
behavior, and so these pre-process passes are currently used
internally by `FuseTIR`.  This may be avoided in the future by pulling
this internal delegation out into a lowering pipeline.