### PR TITLE
[Unity][DLight] Enhance the inline consumer rule

### DIFF
--- a/python/tvm/dlight/gpu/matmul.py
+++ b/python/tvm/dlight/gpu/matmul.py
@@ -99,6 +99,7 @@ def auto_inline_consumer_chain(
         for c in remaining_consumers:
             for p in sch.get_producers(c):
                 if sch.get(p) != sch.get(block):
+                    auto_inline_producers(sch, p)
                     sch.compute_inline(p)
 
         # Try inlining into the cache-write stage again, this time it should succeed.


### PR DESCRIPTION
The current inline consumer rule failed on the following case, because of the missing inline of the producers of the output stage

```
 A   B   D
  \ /    |
 matmul  C
    \   /
     out
```

Thanks @BBuf for finding this bug