### PR TITLE
Revert "[#15157][Rust][Doc] Re-enable the Rust documentation build (#15213)"

### DIFF
--- a/docs/reference/api/links.rst
+++ b/docs/reference/api/links.rst
@@ -24,4 +24,3 @@ build system.
 * `C++ doyxgen API <doxygen/index.html>`_
 * `Typescript typedoc API <typedoc/index.html>`_
 * `Java Javadoc API <javadoc/index.html>`_
-* `Rust Rustdoc API <rust/index.html>`_

--- a/tests/scripts/task_python_docs.sh
+++ b/tests/scripts/task_python_docs.sh
@@ -163,7 +163,7 @@ cd ..
 # Rust doc
 cd rust
 # Temp disable rust doc build
-cargo doc --workspace --no-deps
+# cargo doc --workspace --no-deps
 cd ..
 
 # Prepare the doc dir
@@ -173,7 +173,7 @@ rm -f _docs/.buildinfo
 mkdir -p _docs/reference/api
 mv docs/doxygen/html _docs/reference/api/doxygen
 mv jvm/core/target/site/apidocs _docs/reference/api/javadoc
-mv rust/target/doc _docs/api/rust
+# mv rust/target/doc _docs/api/rust
 mv web/dist/docs _docs/reference/api/typedoc
 git rev-parse HEAD > _docs/commit_hash
 


### PR DESCRIPTION
As cargo is unstable and breaks the CI, we have to disable the rust docs building until we can find a way to solve that.

cc @tqchen @junrushao 