### PR TITLE
[Unity] Support constant args in `nn.ExternModule`

### DIFF
--- a/python/tvm/relax/frontend/nn/spec.py
+++ b/python/tvm/relax/frontend/nn/spec.py
@@ -87,7 +87,9 @@ class ConstInt:  # pylint: disable=too-few-public-methods
         self.dtype = dtype
 
     def __repr__(self) -> str:
-        return "const.int"
+        if self.dtype is None:
+            return "const.int"
+        return f"const.int({self.dtype})"
 
 
 class ConstFloat:  # pylint: disable=too-few-public-methods
@@ -99,7 +101,9 @@ class ConstFloat:  # pylint: disable=too-few-public-methods
         self.dtype = dtype
 
     def __repr__(self) -> str:
-        return "const.float"
+        if self.dtype is None:
+            return "const.float"
+        return f"const.float({self.dtype})"
 
 
 class ConstString:  # pylint: disable=too-few-public-methods

--- a/python/tvm/relax/frontend/nn/spec.py
+++ b/python/tvm/relax/frontend/nn/spec.py
@@ -78,6 +78,40 @@ class Tuple:  # pylint: disable=too-few-public-methods
         return self.elements.__repr__()
 
 
+class ConstInt:  # pylint: disable=too-few-public-methods
+    """An integer constant"""
+
+    dtype: typing.Optional[str]
+
+    def __init__(self, dtype: str = None) -> None:
+        self.dtype = dtype
+
+    def __repr__(self) -> str:
+        return "const.int"
+
+
+class ConstFloat:  # pylint: disable=too-few-public-methods
+    """A float constant"""
+
+    dtype: typing.Optional[str]
+
+    def __init__(self, dtype: str = None) -> None:
+        self.dtype = dtype
+
+    def __repr__(self) -> str:
+        return "const.float"
+
+
+class ConstString:  # pylint: disable=too-few-public-methods
+    """A string constant"""
+
+    def __init__(self) -> None:
+        pass
+
+    def __repr__(self) -> str:
+        return "const.string"
+
+
 class MethodSpec:
     """A spec for a compiled method"""
 
@@ -298,13 +332,13 @@ class ModuleSpec:
 class ExternFunctionSpec:  # pylint: disable=too-few-public-methods
     """A spec for a compiled external function."""
 
-    args: typing.List[Tensor]
+    args: typing.List[typing.Union[Tensor, ConstInt, ConstFloat, ConstString]]
     ret: typing.Union[Tensor, typing.List[Tensor]]
     symbol: typing.Optional[str]
 
     def __init__(
         self,
-        args: typing.List[Tensor],
+        args: typing.List[typing.Union[Tensor, ConstInt, ConstFloat, ConstString]],
         ret: typing.Union[Tensor, typing.List[Tensor]],
         symbol: typing.Optional[str] = None,
     ) -> None:

--- a/tests/python/relax/test_frontend_nn_extern_module.py
+++ b/tests/python/relax/test_frontend_nn_extern_module.py
@@ -253,6 +253,4 @@ def test_extern_spec():
 
 
 if __name__ == "__main__":
-    test_extern_module()
-    test_extern_spec()
-    # tvm.testing.main()
+    tvm.testing.main()

--- a/tests/python/relax/test_frontend_nn_extern_module.py
+++ b/tests/python/relax/test_frontend_nn_extern_module.py
@@ -191,6 +191,68 @@ def test_extern_module():
         scalar_c = compiled["scalar_add"](scalar_a, scalar_b)
 
 
+def test_extern_spec():
+    class TestModule(nn.Module):
+        def __init__(self) -> None:
+            self.ext_mod = nn.ExternModule(
+                spec.ExternModuleSpec(
+                    library=tvm.runtime.Module(None),
+                    functions=[
+                        spec.ExternFunctionSpec(
+                            args=[
+                                spec.Tensor((2, 4), "float16"),
+                                spec.ConstInt(),
+                                spec.ConstInt("int32"),
+                                spec.ConstFloat(),
+                                spec.ConstFloat("float16"),
+                                spec.ConstString(),
+                            ],
+                            ret=spec.Tensor((2, 4), "float16"),
+                            symbol="test",
+                        )
+                    ],
+                )
+            )
+
+        def forward(self, x: nn.Tensor):
+            return self.ext_mod.get_extern_func("test")(x, 1, 2, 3.0, 4.0, "123")
+
+    @I.ir_module
+    class ExpectedModule:
+        I.module_attrs({"external_mods": [None]})
+
+        @R.function
+        def forward(x: R.Tensor((2, 4), dtype="float16")) -> R.Tensor((2, 4), dtype="float16"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                test = R.call_dps_packed(
+                    "test",
+                    (
+                        x,
+                        R.prim_value(1),
+                        R.prim_value(T.int32(2)),
+                        R.prim_value(T.float32(3)),
+                        R.prim_value(T.float16(4)),
+                        R.str("123"),
+                    ),
+                    out_sinfo=R.Tensor((2, 4), dtype="float16"),
+                )
+                gv: R.Tensor((2, 4), dtype="float16") = test
+                R.output(gv)
+            return gv
+
+    model = TestModule()
+    ir_module, _ = model.export_tvm(
+        spec={
+            "forward": {
+                "x": spec.Tensor((2, 4), "float16"),
+            },
+        }
+    )
+    tvm.ir.assert_structural_equal(ir_module, ExpectedModule)
+
+
 if __name__ == "__main__":
     test_extern_module()
+    test_extern_spec()
     # tvm.testing.main()


### PR DESCRIPTION
This PR introduces `spec.ConstInt`, `spec.ConstFloat` and `spec.ConstString` for the `nn.ExternModule` args. So we will enable the constant input for extern module functions.