### PR TITLE
[Relay][Pytorch] Add support for `aten::unflatten`

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1553,11 +1553,13 @@ class PyTorchOpConverter:
         dshape = get_const_tuple(self.infer_shape_with_prelude(data))
         assert len(dshape) > dim
 
-        mult = 1
-        for s in unflattened_size:
-            if s is not -1:
-                mult *= s
-        assert dshape[dim] % mult == 0
+        assert unflattened_size.count(-1) <= 1
+
+        mult = np.multiply.reduce(unflattened_size)
+        if mult < 0:
+            assert dshape[dim] % mult == 0
+        else:
+            assert dshape[dim] == mult
 
         new_shape = dshape[:dim] + unflattened_size + dshape[dim + 1 :]
         out = _op.reshape(data, new_shape)

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1546,6 +1546,16 @@ class PyTorchOpConverter:
             out = _op.squeeze(out, axis=squeeze_axes)
         return out
 
+    def unflatten(self, inputs, input_types):
+        data = inputs[0]
+        dim = int(inputs[1])
+        unflattened_size = tuple(inputs[2])
+        dshape = get_const_tuple(self.infer_shape_with_prelude(data))
+        assert len(dshape) > dim
+        new_shape = dshape[:dim] + unflattened_size + dshape[dim + 1 :]
+        out = _op.reshape(data, new_shape)
+        return out
+
     def addmm(self, inputs, input_types):
         input_mat = inputs[0]
         mat1 = inputs[1]
@@ -3945,6 +3955,7 @@ class PyTorchOpConverter:
             "aten::t": self.transpose,
             "aten::numpy_T": self.numpy_T,
             "aten::flatten": self.flatten,
+            "aten::unflatten": self.unflatten,
             "aten::addmm": self.addmm,
             "aten::size": self.size,
             "aten::view": self.view,

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1553,7 +1553,7 @@ class PyTorchOpConverter:
         dshape = get_const_tuple(self.infer_shape_with_prelude(data))
 
         dim = dim if dim >= 0 else len(dshape) + dim
-        assert len(dshape) > dim and dim >= 0
+        assert len(dshape) > dim >= 0
 
         assert unflattened_size.count(-1) <= 1
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1551,7 +1551,9 @@ class PyTorchOpConverter:
         dim = int(inputs[1])
         unflattened_size = tuple(inputs[2])
         dshape = get_const_tuple(self.infer_shape_with_prelude(data))
-        assert len(dshape) > dim
+
+        dim = dim if dim >= 0 else len(dshape) + dim
+        assert len(dshape) > dim and dim >= 0
 
         assert unflattened_size.count(-1) <= 1
 

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1552,6 +1552,13 @@ class PyTorchOpConverter:
         unflattened_size = tuple(inputs[2])
         dshape = get_const_tuple(self.infer_shape_with_prelude(data))
         assert len(dshape) > dim
+
+        mult = 1
+        for s in unflattened_size:
+            if s is not -1:
+                mult *= s
+        assert dshape[dim] % mult == 0
+
         new_shape = dshape[:dim] + unflattened_size + dshape[dim + 1 :]
         out = _op.reshape(data, new_shape)
         return out

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -1545,6 +1545,34 @@ def test_flatten():
 
 
 @tvm.testing.uses_gpu
+def test_unflatten():
+    """test_unflatten"""
+
+    def _test_unflatten(dim, unflattened_size):
+        return lambda inp: torch.unflatten(inp, dim, unflattened_size)
+
+    inp = torch.rand(60)
+
+    # [60] -> [3, 5, 2, 2]
+    verify_model(_test_unflatten(0, (3, 5, 2, 2)), inp)
+    verify_model(_test_unflatten(0, (-1, 5, 2, 2)), inp)
+    verify_model(_test_unflatten(0, (3, -1, 2, 2)), inp)
+    verify_model(_test_unflatten(0, (3, 5, -1, 2)), inp)
+    verify_model(_test_unflatten(0, (3, 5, 2, -1)), inp)
+
+    inp = torch.rand(3, 4, 1)
+
+    # [3, 4, 1] -> [3, 2, 2, 1]
+    verify_model(_test_unflatten(1, (2, 2)), inp)
+    verify_model(_test_unflatten(1, (-1, 2)), inp)
+
+    inp = torch.rand(5, 12, 3)
+
+    # [5, 12, 3] -> [5, 2, 2, 3, 1, 1, 3]
+    verify_model(_test_unflatten(-2, (2, 2, 3, 1, 1)), inp)
+
+
+@tvm.testing.uses_gpu
 def test_forward_transpose():
     """test_forward_transpose"""
     torch.set_grad_enabled(False)
@@ -4744,7 +4772,7 @@ def test_masked_fill():
     verify_model(test_fn, [inp.to(torch.float64), inp > 0.5])
 
 
-@pytest.mark.skip(reason="unsupported op: 'aten::scaled_dot_product_attention', 'aten::unflatten'")
+@pytest.mark.skip(reason="unsupported op: 'aten::scaled_dot_product_attention'")
 def test_transformer():
     """test_transformer"""
     model = torch.nn.Transformer(d_model=256, nhead=8, num_encoder_layers=6, num_decoder_layers=6)

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -1559,6 +1559,11 @@ def test_unflatten():
     verify_model(_test_unflatten(0, (3, -1, 2, 2)), inp)
     verify_model(_test_unflatten(0, (3, 5, -1, 2)), inp)
     verify_model(_test_unflatten(0, (3, 5, 2, -1)), inp)
+    verify_model(_test_unflatten(-1, (3, 5, 2, 2)), inp)
+    verify_model(_test_unflatten(-1, (-1, 5, 2, 2)), inp)
+    verify_model(_test_unflatten(-1, (3, -1, 2, 2)), inp)
+    verify_model(_test_unflatten(-1, (3, 5, -1, 2)), inp)
+    verify_model(_test_unflatten(-1, (3, 5, 2, -1)), inp)
 
     inp = torch.rand(3, 4, 1)
 
@@ -1569,6 +1574,7 @@ def test_unflatten():
     inp = torch.rand(5, 12, 3)
 
     # [5, 12, 3] -> [5, 2, 2, 3, 1, 1, 3]
+    verify_model(_test_unflatten(1, (2, 2, 3, 1, 1)), inp)
     verify_model(_test_unflatten(-2, (2, 2, 3, 1, 1)), inp)
 
 


### PR DESCRIPTION
Fix #15663
Support [torch.unflatten](https://pytorch.org/docs/stable/generated/torch.unflatten.html).

cc @jikechao @vvchernov @Hzfengsy @junrushao 