### PR TITLE
Always use int64 in JSON parser

### DIFF
--- a/3rdparty/picojson/picojson.h
+++ b/3rdparty/picojson/picojson.h
@@ -26,6 +26,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #pragma once
+#ifndef PICOJSON_USE_INT64
+#define PICOJSON_USE_INT64
+#define __STDC_FORMAT_MACROS 1
+#endif
 
 #include <algorithm>
 #include <cstddef>
@@ -76,7 +80,6 @@ extern "C" {
 
 // experimental support for int64_t (see README.mkdn for detail)
 #ifdef PICOJSON_USE_INT64
-#define __STDC_FORMAT_MACROS
 #include <errno.h>
 #include <inttypes.h>
 #endif


### PR DESCRIPTION
Existing usecases of picojson parser always require to define a macro `PICOJSON_USE_INT64`, and potentially `__STDC_FORMAT_MACROS` along with it, which could lead to misconfiguration and inconsistency in projects using TVM. To address this issue, this PR adds both flags by default.