### PR TITLE
[Runtime] Allowing Packed Arguments in TVM Module VTable

### DIFF
--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -1163,11 +1163,11 @@ struct PackedFuncValueConverter {
       Helper::Call(rv, self, MemFunc, args, Helper::IndexSeq{});                                  \
     });                                                                                           \
   }
-#define TVM_MODULE_VTABLE_ENTRY_PACKED(Name, Func)                                \
-  if (_name == Name) {                                                            \
-    auto f = (Func);                                                              \
-    using FType = ::tvm::runtime::detail::function_signature<decltype(f)>::FType; \
-    return TypedPackedFunc<FType>(std::move(f)).packed();                         \
+#define TVM_MODULE_VTABLE_ENTRY_PACKED(Name, MemFunc)                  \
+  if (_name == Name) {                                                 \
+    return PackedFunc([_self](TVMArgs args, TVMRetValue* rv) -> void { \
+      (static_cast<SelfPtr>(_self.get())->*(MemFunc))(args, rv);       \
+    });                                                                \
   }
 
 /*!


### PR DESCRIPTION
Prior to this PR, the `TVM_MODULE_VTABLE_*` macros work by detailing the correspondence between the string names and the module methods as part, so that it declares the calling convention of a TVM Module.

For example, in the `Execuable` of `RelayVM`, the convention is specified by [link](https://github.com/apache/tvm/blob/748882aae7be1435f042e22b0fc67cb236705b6c/include/tvm/runtime/vm/executable.h#L60-L76):

```C++
 # Name of the Module
TVM_MODULE_VTABLE_BEGIN("VMExecutable");
 # Bind member methods to string name as the calling convention
TVM_MODULE_VTABLE_ENTRY("get_lib", &Executable::GetLib);
...
TVM_MODULE_VTABLE_END();
```

Note that it supports only "unpacked" member methods so far, i.e., ordinary C++ methods with fixed number of arguments, each of which has a compile-type known type, e.g.

```C++
class MyModule : public tvm::runtime::Module {
  ...
  int UnpackedMethod(int a, double b, std::string c);
};
```

However, TVM's calling convention is actually much more powerful and covers the case for variadic arguments and runtime type dynamism via type erasure and tagged union, e.g.

```C++
class MyModule : public tvm::runtime::Module {
  ...
  int PackedMethod(TVMArgs args, TVMRetValue* rv);
};
```

This PR introduces support for this scenario by a new macro `TVM_MODULE_VTABLE_PACKED`. Example:

```C++
class MLCServingEngine : public tvm::runtime::Module {
  ...
  TVM_MODULE_VTABLE_BEGIN("mlc.serve.engine");
  TVM_MODULE_VTABLE_ENTRY_PACKED("init", &EngineModule::InitPacked);
  TVM_MODULE_VTABLE_ENTRY("add_request", &EngineModule::AddRequest);
  ...
  TVM_MODULE_VTABLE_END();

  void InitPacked(TVMArgs args, TVMRetValue* rv) {}
};
```