### PR TITLE
[Unity][MSC][M2.1] Add Manager for compile pipeline

### DIFF
--- a/python/tvm/contrib/msc/core/utils/file.py
+++ b/python/tvm/contrib/msc/core/utils/file.py
@@ -211,6 +211,8 @@ class MSCDirectory(object):
             The content of directory
         """
 
+        if not os.path.isdir(self._path):
+            return []
         return os.listdir(self._path)
 
     def destory(self):
@@ -285,13 +287,19 @@ def get_workspace() -> MSCDirectory:
     return workspace
 
 
-def get_workspace_subdir(name: str = None) -> MSCDirectory:
+def get_workspace_subdir(
+    name: str = None, keep_history: bool = True, cleanup: bool = False
+) -> MSCDirectory:
     """Create sub dir for workspace
 
     Parameters
     ----------
     name: str
         The sub dir name under workspace.
+    keep_history: bool
+        Whether to remove files before start.
+    cleanup: bool
+        Whether to clean up before exit.
 
     Returns
     -------
@@ -299,11 +307,36 @@ def get_workspace_subdir(name: str = None) -> MSCDirectory:
         The created dir.
     """
 
-    return get_workspace().create_dir(name)
+    return get_workspace().create_dir(name, keep_history, cleanup)
+
+
+def to_abs_path(path: str, root_dir: MSCDirectory = None, keep_history: bool = True) -> str:
+    """Change path to abs path
+
+    Parameters
+    ----------
+    path: str
+        The path of the file.
+    root_dir: MSCDirectory
+        Root dir to save the file.
+    keep_history: bool
+        Whether to remove files before start.
+
+    Returns
+    -------
+    abs_path: str
+        The abspath.
+    """
+
+    root_dir = root_dir or get_workspace()
+    if os.path.abspath(path) == path:
+        return path
+    return root_dir.relpath(path, keep_history)
 
 
 get_build_dir = partial(get_workspace_subdir, name="Build")
-get_output_dir = partial(get_workspace_subdir, name="Output")
-get_dataset_dir = partial(get_workspace_subdir, name="Dataset")
-get_debug_dir = partial(get_workspace_subdir, name="Debug")
 get_cache_dir = partial(get_workspace_subdir, name="Cache")
+get_config_dir = partial(get_workspace_subdir, name="Config")
+get_dataset_dir = partial(get_workspace_subdir, name="Dataset")
+get_output_dir = partial(get_workspace_subdir, name="Output")
+get_visual_dir = partial(get_workspace_subdir, name="Visual")

--- a/python/tvm/contrib/msc/framework/tensorflow/runtime/runner.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/runtime/runner.py
@@ -24,6 +24,8 @@ import numpy as np
 from tensorflow.python.client import device_lib
 from tensorflow.python.ops import variables
 
+import tvm
+from tvm.contrib.msc.core.ir import MSCGraph
 from tvm.contrib.msc.core.runtime import ModelRunner
 from tvm.contrib.msc.core.utils.namespace import MSCFramework
 from tvm.contrib.msc.framework.tensorflow.codegen import to_tensorflow
@@ -58,25 +60,40 @@ class WrapSession(tf_v1.Session):
 class TensorflowRunner(ModelRunner):
     """Runner of Tensorflow"""
 
-    def setup(self):
-        """Setup the runner"""
+    def setup(self) -> dict:
+        """Setup the runner
 
-        super().setup()
+        Returns
+        -------
+        info: dict
+            The setup info.
+        """
+
         self._tf_graph = None
         self._tf_outputs = None
         self._session = None
+        return super().setup()
 
     def destory(self):
         """Destory runner"""
 
         self._session.close()
-        del self._tf_graph
-        del self._tf_outputs
-        del self._session
+        self._tf_graph = None
+        self._tf_outputs = None
+        self._session = None
         super().destory()
 
-    def _generate_model(self) -> Any:
+    def _generate_model(
+        self, graphs: List[MSCGraph] = None, weights: List[Dict[str, tvm.nd.array]] = None
+    ) -> Any:
         """Codegen the model according to framework
+
+        Parameters
+        -------
+        graphs: list<MSCgraph>
+            The msc graphs.
+        weights: list<dic<str, tvm.nd.array>>
+            The weights
 
         Returns
         -------
@@ -88,7 +105,7 @@ class TensorflowRunner(ModelRunner):
             del self._tf_graph
         self._tf_graph = tf_v1.Graph()
         with self._tf_graph.as_default():
-            self._tf_outputs = super()._generate_model()
+            self._tf_outputs = super()._generate_model(graphs, weights)
         return self._tf_graph
 
     def _to_runnable(self, model: Any, device: str, is_training: bool) -> Any:

--- a/python/tvm/contrib/msc/framework/tensorrt/codegen/codegen.py
+++ b/python/tvm/contrib/msc/framework/tensorrt/codegen/codegen.py
@@ -113,6 +113,7 @@ def to_sub_tensorrt(
     engine_file = codegen.load([], pre_load=_create_depends, post_load=_build_engine)
     return {
         "graph_json": graph.to_json(),
+        "graph_name": graph.name,
         "engine": engine_file,
     }
 
@@ -122,6 +123,7 @@ def to_tensorrt(
     graph_infos: List[Tuple[str, MSCGraph, Dict[str, tvm.nd.array]]],
     codegen_config: Optional[Dict[str, str]] = None,
     print_config: Optional[Dict[str, str]] = None,
+    extra_option: Optional[Dict[str, str]] = None,
     build_folder: msc_utils.MSCDirectory = None,
     output_folder: msc_utils.MSCDirectory = None,
 ) -> Dict[str, str]:
@@ -137,6 +139,8 @@ def to_tensorrt(
         The config for codegen.
     print_config: dict
         The config for print.
+    extra_option: dict
+        The extra option for sub engine.
     build_folder: MSCDirectory
         The folder for saving sources and datas.
     export_folder: MSCDirectory
@@ -153,6 +157,8 @@ def to_tensorrt(
         options = to_sub_tensorrt(
             graph, weights, codegen_config, print_config, build_folder, output_folder
         )
+        if extra_option:
+            options.update(extra_option)
         target_options[graph.name] = msc_utils.dump_dict(options)
     mod = tvm.transform.Sequential(
         [

--- a/python/tvm/contrib/msc/framework/tensorrt/runtime/runner.py
+++ b/python/tvm/contrib/msc/framework/tensorrt/runtime/runner.py
@@ -16,21 +16,48 @@
 # under the License.
 """tvm.contrib.msc.framework.tensorrt.runtime.runner"""
 
+import tvm
 from tvm.contrib.msc.core.runtime import BYOCRunner
 from tvm.contrib.msc.core.utils.namespace import MSCFramework
-from tvm.contrib.msc.framework.tensorrt.frontend import partition_for_tensorrt
+from tvm.contrib.msc.framework.tensorrt.frontend import (
+    partition_for_tensorrt,
+    transform_for_tensorrt,
+)
 from tvm.contrib.msc.framework.tensorrt.codegen import to_tensorrt
 
 
 class TensorRTRunner(BYOCRunner):
     """Runner of tensorrt"""
 
-    def setup(self):
-        """Setup the runner"""
+    def setup(self) -> dict:
+        """Setup the runner
 
-        super().setup()
+        Returns
+        -------
+        info: dict
+            The setup info.
+        """
+
         if not self._device.startswith("cuda"):
             self._device = "cuda"
+        return super().setup()
+
+    @classmethod
+    def target_transform(cls, mod: tvm.IRModule):
+        """Transform the mod by target.
+
+        Parameters
+        ----------
+        mod: IRModule
+            The IRModule of relax.
+
+        Returns
+        -------
+        mod: IRModule
+            The IRModule of partitioned relax.
+        """
+
+        return transform_for_tensorrt(mod)
 
     @property
     def codegen_func(self):

--- a/python/tvm/contrib/msc/pipeline/__init__.py
+++ b/python/tvm/contrib/msc/pipeline/__init__.py
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.pipeline"""
+
+from .manager import *

--- a/python/tvm/contrib/msc/pipeline/manager.py
+++ b/python/tvm/contrib/msc/pipeline/manager.py
@@ -1,0 +1,804 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=import-outside-toplevel
+"""tvm.contrib.msc.pipeline.manager"""
+
+import os
+import time
+from typing import Dict, Any
+import traceback
+import numpy as np
+
+import tvm
+from tvm.contrib.msc.core.runtime import BaseRunner
+from tvm.contrib.msc.core.utils.namespace import MSCFramework, MSCMap, MSCKey
+from tvm.contrib.msc.core.utils.message import MSCStage
+from tvm.contrib.msc.core import utils as msc_utils
+
+
+class BaseManager(object):
+    """Base Manager of MSC
+
+    Parameters
+    ----------
+    model: Any
+        The raw model in framwork.
+    config: dict
+        The config for pipeline.
+    """
+
+    def __init__(self, model, config):
+        # check config
+        for stage in ["inputs", "outputs", "dataset", "prepare", "compile"]:
+            assert stage in config, "{} should be given to run the pipeline".format(stage)
+        self._model = model
+        self._workspace = msc_utils.set_workspace(config.get("workspace"))
+        log_path = config.get("log_path") or self._workspace.relpath("MSC_LOG", keep_history=False)
+        if config.get("debug", False) and "verbose" not in config:
+            verbose = "debug"
+        else:
+            verbose = config.get("verbose", "info")
+        self._logger = msc_utils.set_global_logger(verbose, log_path)
+        msc_utils.time_stamp(MSCStage.SETUP)
+        self._logger.info(msc_utils.msg_block("SETUP", self.setup(config)))
+
+    def setup(self, config: dict) -> dict:
+        """Setup the manager
+
+        Parameters
+        ----------
+        config: dict
+            The config for manager.
+
+        Returns
+        -------
+        info: dict
+            The setup info.
+        """
+
+        self._config, self._debug_config = self.update_config(config)
+        self._tools_config = {}
+        self._relax_mod, self._runner = None, None
+        self._data_loader, self._sample_inputs = None, None
+        self._report = {
+            "success": False,
+            "info": {
+                "workspace": self._workspace.path,
+                "model_type": self._config["model_type"],
+            },
+            "duration": {},
+            "profile": {},
+        }
+        return {"workspace": self._workspace.path, "config": config}
+
+    def update_config(self, config: dict) -> dict:
+        """Update config
+
+        Parameters
+        ----------
+        config: dict
+            The config for manager.
+
+        Returns
+        -------
+        config: dict
+            The updated config.
+        """
+
+        # update prepare and parse
+        assert "inputs" in config, "inputs should be given to run manager"
+        assert "outputs" in config, "outputs should be given to run manager"
+        config = msc_utils.copy_dict(config)
+        for stage in ["prepare", "parse"]:
+            if stage not in config:
+                config[stage] = {}
+        config = self._update_prepare_config(config)
+        config = self._update_parse_config(config)
+        for stage in ["baseline", "optimize", "compile"]:
+            config = self._update_runner_config(config, stage)
+        config = self._update_tool_config(config)
+        debug_config = {}
+
+        def _set_debug(stage, stage_config, default=None):
+            if "debug" in stage_config:
+                debug_config[stage] = stage_config.pop("debug")
+            elif default is not None:
+                debug_config[stage] = default
+            return debug_config
+
+        if "debug" in config:
+            for stage in ["baseline", "optimize", "compile"]:
+                if stage not in config:
+                    continue
+                debug_config = _set_debug(stage, config[stage], config["debug"])
+        else:
+            for stage in ["baseline", "optimize", "compile"]:
+                if stage not in config:
+                    continue
+                debug_config = _set_debug(stage, config[stage])
+        ordered_keys = [
+            "model_type",
+            "inputs",
+            "outputs",
+            "dataset",
+            "prepare",
+            "parse",
+            "baseline",
+            "optimize",
+            "compile",
+        ]
+        return {k: config[k] for k in ordered_keys if k in config}, debug_config
+
+    def run_pipe(self) -> dict:
+        """Run the pipeline and return object.
+
+        Returns
+        -------
+        report:
+            The pipeline report.
+        """
+
+        err_msg = None
+        use_cache = self._config.get("use_cache", True)
+        try:
+            self._data_loader, self._sample_inputs = self.prepare(
+                self._config["prepare"], use_cache
+            )
+            self._relax_mod = self.parse(self._config["parse"], use_cache)
+            if "baseline" in self._config:
+                self._runner = self.baseline(self._config["baseline"], use_cache)
+            if "optimize" in self._config:
+                self._runner = self.optimize(self._config["optimize"], use_cache)
+            self._runner = self.compile(self._config["compile"], use_cache)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            err_msg = "Pipeline failed:{}\nTrace: {}".format(exc, traceback.format_exc())
+        report = self.summary(err_msg)
+        self._logger.info(msc_utils.msg_block("SUMMARY", report, 0))
+        return report
+
+    def prepare(self, stage_config: dict, use_cache: bool = False) -> Dict[str, np.ndarray]:
+        """Prepare datas for the pipeline.
+
+        Parameters
+        ----------
+        stage_config: dict
+            The config of this stage.
+        use_cache: bool
+            Whether to use cache.
+
+        Returns
+        -------
+        sample_inputs: dict<str,np.ndarray>
+            The sample inputs.
+        """
+
+        msc_utils.time_stamp(MSCStage.PREPARE)
+
+        # create data loader
+        source_loader = self._config["dataset"].get("loader")
+        max_batch = self._config["dataset"].get("max_batch", 5)
+        assert source_loader, "Dataset loader should be given for msc pipeline"
+        if source_loader.startswith("from_random"):
+
+            def get_random():
+                for _ in range(max_batch):
+                    yield {i[0]: np.random.rand(*i[1]).astype(i[2]) for i in self._config["inputs"]}
+
+            data_loader, source_type = get_random, "Random"
+        elif msc_utils.is_io_dataset(source_loader):
+
+            def load_datas():
+                for inputs, _ in msc_utils.IODataLoader(data_loader, end=max_batch):
+                    yield inputs
+
+            data_loader, source_type = load_datas, "IOData"
+        elif callable(source_loader):
+
+            def get_source():
+                for idx, inputs in enumerate(source_loader()):
+                    if idx >= max_batch:
+                        break
+                    yield inputs
+
+            data_loader, source_type = get_source, "Custom"
+        else:
+            raise TypeError(
+                "Unexpected source loader {}({})".format(source_loader, type(source_loader))
+            )
+        self._logger.info("Create data loader(%s) %s", source_type, data_loader)
+
+        # create golden
+        golden_folder = msc_utils.get_dataset_dir().relpath("Golden", use_cache)
+        input_names, sample_inputs = [i[0] for i in self._config["inputs"]], None
+        report = {"golden_folder": golden_folder}
+        runner_cls = self._get_runner_cls(self._config["model_type"])
+        run_func = runner_cls.run_native if hasattr(runner_cls, "run_native") else None
+        if use_cache and msc_utils.is_io_dataset(golden_folder):
+            golden_loader, source_type = msc_utils.IODataLoader(golden_folder), "Cache"
+            report["datas_info"] = golden_loader.info
+            sample_inputs = golden_loader[0][0]
+            self._logger.debug("Load %d cached golden from %s", len(golden_loader), golden_folder)
+        else:
+            # save golden
+            golden_cnt, max_golden = 0, self._config["dataset"].get("max_golden", 5)
+            saver_options = {"input_names": input_names, "output_names": self._config["outputs"]}
+            if run_func:
+                with msc_utils.IODataSaver(golden_folder, saver_options) as saver:
+                    for inputs in data_loader():
+                        if golden_cnt >= max_golden:
+                            break
+                        if not sample_inputs:
+                            sample_inputs = inputs
+                        outputs, _ = run_func(
+                            self._model, inputs, input_names, self._config["outputs"]
+                        )
+                        golden_cnt = saver.save_batch(inputs, outputs)
+                    report["datas_info"] = saver.info
+            elif isinstance(data_loader, msc_utils.IODataLoader):
+                with msc_utils.IODataSaver(golden_folder, saver_options) as saver:
+                    for inputs, outputs in data_loader():
+                        if golden_cnt >= max_golden:
+                            break
+                        if not sample_inputs:
+                            sample_inputs = inputs
+                        golden_cnt = saver.save_batch(inputs, outputs)
+                    report["datas_info"] = saver.info
+            else:
+                raise Exception("golden or runner should given in prepare to save golden")
+            self._logger.debug("Saved %d golden to %s", golden_cnt, golden_folder)
+
+        def _to_abstract(info: dict) -> dict:
+            def _to_tensor_str(info):
+                return "{},{}".format(";".join([str(s) for s in info["shape"]]), info["dtype"])
+
+            return {
+                "num_datas": info["num_datas"],
+                "inputs": {n: _to_tensor_str(i) for n, i in info["inputs"].items()},
+                "outputs": {n: _to_tensor_str(o) for n, o in info["outputs"].items()},
+            }
+
+        report["datas_info"] = _to_abstract(report["datas_info"])
+        report["sample_inputs"] = sample_inputs
+        self._logger.info(msc_utils.msg_block("GOLDEN({})".format(source_type), report))
+
+        # profile
+        if "profile" in stage_config and run_func:
+            benchmark = stage_config["profile"].get("benchmark", {})
+            repeat = benchmark.get("repeat", 100)
+            self._logger.debug("Prepare profile with %s(%s)", run_func, benchmark)
+            _, avg_time = run_func(
+                self._model, sample_inputs, input_names, self._config["outputs"], **benchmark
+            )
+            self._logger.info("Profile(prepare) {} times -> {:.2f} ms".format(repeat, avg_time))
+            self._report["profile"]["prepare"] = {"latency": "{:.2f} ms".format(avg_time)}
+        return data_loader, sample_inputs
+
+    def parse(self, stage_config: dict, use_cache: bool = False) -> tvm.IRModule:
+        """Parse the model to IRModule.
+
+        Parameters
+        ----------
+        stage_config: dict
+            The config of this stage.
+        use_cache: bool
+            Whether to use cache.
+
+        Returns
+        -------
+        relax_mod: tvm.IRModule
+            The parsed module.
+        """
+
+        msc_utils.time_stamp(MSCStage.PARSE)
+        cache_path = msc_utils.get_cache_dir().relpath("parsed_relax.json") if use_cache else None
+        if cache_path and os.path.isfile(cache_path):
+            with open(cache_path, "r") as f:
+                relax_mod = tvm.ir.load_json(f.read())
+            self._logger.info("Load parsed mod from %s", cache_path)
+        else:
+            parse_config = stage_config.get("parse_config", {})
+            runner_cls = self._get_runner_cls(self._config["compile"]["run_type"])
+            trans_func = (
+                runner_cls.target_transform if hasattr(runner_cls, "target_transform") else None
+            )
+            parse_info = {
+                "parser": stage_config["parser"],
+                "config": parse_config,
+                "trans_func": trans_func,
+            }
+            self._logger.info(msc_utils.msg_block("PARSE", parse_info))
+            relax_mod, _ = stage_config["parser"](self._model, as_msc=False, **parse_config)
+            if trans_func:
+                relax_mod = trans_func(relax_mod)
+            if cache_path:
+                with open(cache_path, "w") as f:
+                    f.write(tvm.ir.save_json(relax_mod))
+                self._logger.debug("Save parsed mod to %s", cache_path)
+        return relax_mod
+
+    def baseline(self, stage_config: dict, use_cache: bool = False) -> BaseRunner:
+        """Run the baseline.
+
+        Parameters
+        ----------
+        stage_config: dict
+            The config of this stage.
+        use_cache: bool
+            Whether to use cache.
+
+        Returns
+        -------
+        runner: BaseRunner
+            The runner.
+        """
+
+        msc_utils.time_stamp(MSCStage.BASELINE)
+        return self._create_runner(MSCStage.BASELINE, stage_config, use_cache=use_cache)
+
+    def optimize(self, stage_config: dict, use_cache: bool = False) -> BaseRunner:
+        """Run the optimize and return object.
+
+        Parameters
+        ----------
+        stage_config: dict
+            The config of this stage.
+        use_cache: bool
+            Whether to use cache.
+
+        Returns
+        -------
+        runner: BaseRunner
+            The runner.
+        """
+
+        # optimize and get the runner
+        msc_utils.time_stamp(MSCStage.OPTIMIZE)
+        return self._create_runner(
+            MSCStage.OPTIMIZE, stage_config, tools_config=self._tools_config, use_cache=use_cache
+        )
+
+    def compile(self, stage_config: dict, use_cache: bool = False) -> BaseRunner:
+        """Run the compile and return object.
+
+        Parameters
+        ----------
+        stage_config: dict
+            The config of this stage.
+        use_cache: bool
+            Whether to use cache.
+        ret_type: str
+            The return type runner| model.
+
+        Returns
+        -------
+        runner: BaseRunner
+            The runner.
+        """
+
+        msc_utils.time_stamp(MSCStage.COMPILE)
+        return self._create_runner(
+            MSCStage.COMPILE, stage_config, tools_config=self._tools_config, use_cache=use_cache
+        )
+
+    def summary(self, err_msg=None):
+        """Summary the pipeline.
+
+        Parameters
+        ----------
+        err_msg: str
+            The error message.
+
+        Returns
+        -------
+        report: dict
+            The report of the pipeline.
+        """
+
+        msc_utils.time_stamp(MSCStage.SUMMARY, False)
+        if err_msg:
+            self._report.update({"success": False, "err_msg": err_msg})
+        else:
+            self._report["success"] = True
+        self._report["duration"] = msc_utils.get_duration()
+        return self._report
+
+    def destory(self, keep_workspace: bool = False):
+        """Destroy the manager
+
+        Parameters
+        ----------
+        keep_workspace: bool
+            Whether to keep workspace.
+        """
+
+        MSCMap.delete(MSCKey.TIME_STAMPS)
+        if self._runner:
+            self._runner.destory()
+        if not keep_workspace:
+            self._workspace.destory()
+
+    def _create_runner(
+        self,
+        stage: str,
+        stage_config: dict,
+        tools_config: dict = None,
+        visualize: bool = True,
+        profile: bool = True,
+        use_cache: bool = True,
+    ) -> BaseRunner:
+        """Create runner.
+
+        Parameters
+        ----------
+        stage: str
+            The stage name
+        stage_config: dict
+            The config of this stage.
+        tools_config: dict
+            The config of the tools
+        visualize: bool
+            Whether to visualize the runner
+        profile: bool
+            Whether to profile the runner.
+        use_cache: bool
+            Whether to use cache.
+
+        Returns
+        -------
+        runner: BaseRunner
+            The runner.
+        """
+
+        if self._runner:
+            self._runner.destory()
+        on_debug = self._debug_config.get(stage, False)
+        cache_dir = msc_utils.get_cache_dir().create_dir(stage) if use_cache else None
+        tools_config = tools_config or {}
+        msc_utils.time_stamp(stage + ".build", False)
+        runner_cls = self._get_runner_cls(stage_config["run_type"])
+        run_config = msc_utils.copy_dict(stage_config.get("run_config"))
+        if "generate_config" not in run_config:
+            run_config["generate_config"] = {}
+        run_config["generate_config"].update(
+            {
+                "build_folder": msc_utils.get_build_dir().create_dir(stage, cleanup=not on_debug),
+            }
+        )
+        self._logger.debug("Create runner(%s) by %s(%s)", stage, runner_cls.__name__, run_config)
+        runner = runner_cls(
+            self._relax_mod,
+            tools_config=tools_config,
+            stage=stage,
+            logger=self._logger,
+            **run_config,
+        )
+        runner.build(cache_dir=cache_dir)
+        self._report["info"][stage + "_by"] = "{}({})".format(runner.framework, runner.device)
+        if visualize:
+            runner.visualize(msc_utils.get_visual_dir().create_dir(stage))
+        if profile and "profile" in stage_config:
+            self._report["profile"][stage] = self._profile_runner(runner, stage_config)
+        if use_cache:
+            runner.save_cache(cache_dir)
+        return runner
+
+    def _create_tool_runner(self, tool_type: str, stage_config: dict) -> BaseRunner:
+        """Create runner with tool.
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type.
+        stage_config: dict
+            The config of this stage.
+
+        Returns
+        -------
+        runner: BaseRunner
+            The runner.
+        """
+
+        t_stage_config = {
+            "run_type": stage_config["run_type"],
+            "run_config": stage_config["run_config"],
+        }
+        return self._create_runner(
+            tool_type,
+            t_stage_config,
+            tools_config=self._tools_config,
+            profile=False,
+            use_cache=False,
+        )
+
+    def _profile_runner(self, runner: BaseRunner, stage_config: str) -> dict:
+        """Profile the runner.
+
+        Parameters
+        ----------
+        runner: BaseRunner
+            The runner to be profiled
+        stage_config: dict
+            The config of this stage.
+
+        Returns
+        -------
+        report: dict
+            The profile report.
+        """
+
+        stage = runner.stage
+        msc_utils.time_stamp(stage + ".profile", False)
+        profile_config = stage_config["profile"]
+        msg, report = "Profile({})".format(stage), {}
+
+        # check accuracy
+        check_config = profile_config.get("check", {})
+        if check_config:
+            loader = msc_utils.IODataLoader(msc_utils.get_dataset_dir().relpath("Golden"))
+            total, passed = 0, 0
+            acc_report = {}
+            for idx, (inputs, outputs) in enumerate(loader):
+                results = runner.run(inputs)
+                iter_report = msc_utils.compare_arrays(outputs, results)
+                total += iter_report["total"]
+                passed += iter_report["passed"]
+                acc_report["iter_" + str(idx)] = iter_report["info"]
+            pass_rate = float(passed) / total
+            report["accuracy"] = "{}/{}({:.2f}%)".format(passed, total, pass_rate * 100)
+            title = "Check({}) pass {}".format(stage, report["accuracy"])
+            self._logger.debug(msc_utils.msg_block(title, acc_report))
+            msg += " acc {} iters -> {}".format(len(loader), report["accuracy"])
+            required_err, err_rate = check_config.get("err_rate", 0), (1 - pass_rate)
+            if err_rate > required_err >= 0:
+                raise Exception(
+                    "Failed to profile the runner({}), err_rate {} > required {}".format(
+                        stage, err_rate, required_err
+                    )
+                )
+
+        # benchmark model
+        benchmark_config = profile_config.get("benchmark", {})
+        if benchmark_config:
+            for _ in range(benchmark_config.get("warm_up", 10)):
+                runner.run(self._sample_inputs)
+            start = time.time()
+            repeat = benchmark_config.get("repeat", 100)
+            for _ in range(repeat):
+                runner.run(self._sample_inputs)
+            avg_time = (time.time() - start) * 1000 / repeat
+            report["latency"] = "{:.2f} ms @ {}".format(avg_time, runner.device)
+            msg += " latency {} times -> {}".format(repeat, report["latency"])
+        self._logger.info(msg)
+        return report
+
+    def _update_prepare_config(self, config: dict) -> dict:
+        """Update prepare in stage config.
+
+        Parameters
+        ----------
+        config: dict
+            The config of a pipeline.
+
+        Returns
+        -------
+        config: dict
+            The updated config.
+        """
+
+        if config["model_type"] == MSCFramework.TORCH:
+            import torch
+
+            assert isinstance(
+                self._model, torch.nn.Module
+            ), "Model for torch should be nn.Module, get {}({})".format(
+                self._model, type(self._model)
+            )
+        elif config["model_type"] == MSCFramework.TENSORFLOW:
+            from tvm.contrib.msc.framework.tensorflow import tf_v1
+
+            assert isinstance(
+                self._model, tf_v1.GraphDef
+            ), "Model for tenosrflow should be tf.GraphDef, get {}({})".format(
+                self._model, type(self._model)
+            )
+        else:
+            raise Exception("Unexpect model_type " + str(config["model_type"]))
+        return config
+
+    def _update_parse_config(self, config: dict) -> dict:
+        """Update parse in stage config.
+
+        Parameters
+        ----------
+        config: dict
+            The config of a pipeline.
+
+        Returns
+        -------
+        config: dict
+            The updated config.
+        """
+
+        if config["model_type"] == MSCFramework.TORCH:
+            from tvm.contrib.msc.framework.torch.frontend import from_torch
+
+            config["parse"]["parser"] = from_torch
+            parse_config = config["parse"].get("parse_config", {})
+            parse_config.update(
+                {
+                    "input_info": [[i[1], i[2]] for i in config["inputs"]],
+                    "input_names": [i[0] for i in config["inputs"]],
+                }
+            )
+            config["parse"]["parse_config"] = parse_config
+        elif config["model_type"] == MSCFramework.TENSORFLOW:
+            from tvm.contrib.msc.framework.tensorflow.frontend import from_tensorflow
+
+            config["parse"]["parser"] = from_tensorflow
+            parse_config = config["parse"].get("parse_config", {})
+            parse_config.update(
+                {
+                    "shape_dict": {i[0]: i[1] for i in config["inputs"]},
+                    "outputs": config["outputs"],
+                }
+            )
+            config["parse"]["parse_config"] = parse_config
+        else:
+            raise Exception("Unexpect model_type " + str(config["model_type"]))
+        return config
+
+    def _update_runner_config(self, config: dict, stage: str) -> dict:
+        """Update runtime stage in stage config.
+
+        Parameters
+        ----------
+        config: dict
+            The config of a pipeline.
+        stage: str
+            The stage to be updated
+        """
+
+        if stage not in config:
+            return config
+        model_type = config["model_type"]
+        if "run_type" not in config[stage]:
+            config[stage]["run_type"] = model_type
+        # update run config
+        run_config = config[stage].get("run_config", {})
+        if "translate_config" not in run_config:
+            run_config["translate_config"] = {}
+        if "build" not in run_config["translate_config"]:
+            run_config["translate_config"]["build"] = {}
+        if "generate_config" not in run_config:
+            run_config["generate_config"] = {}
+        run_config["translate_config"]["build"]["input_aliases"] = [i[0] for i in config["inputs"]]
+        run_config["translate_config"]["build"]["output_aliases"] = config["outputs"]
+        if model_type == MSCFramework.TORCH:
+            parameters = list(self._model.parameters())
+            if parameters:
+                ref_device = parameters[0].device
+                if ref_device.type == "cpu":
+                    device = "cpu"
+                else:
+                    device = "{}:{}".format(ref_device.type, ref_device.index)
+            else:
+                device = "cpu"
+            run_config.update({"device": device, "is_training": self._model.training})
+        if config[stage]["run_type"] == MSCFramework.TENSORRT:
+            if "extra_option" not in run_config["generate_config"]:
+                run_config["generate_config"]["extra_option"] = {}
+            run_config["generate_config"]["extra_option"]["stage"] = stage
+        config[stage]["run_config"] = run_config
+        return config
+
+    def _update_tool_config(self, config: dict) -> dict:
+        """Update tool in stage config.
+
+        Parameters
+        ----------
+        config: dict
+            The config of a pipeline.
+
+        Returns
+        -------
+        config: dict
+            The updated config.
+        """
+
+        if "optimize" not in config:
+            return config
+        return config
+
+    def get_runnable(self, ret_type: str = "runner") -> Any:
+        """Return object by type.
+
+        Parameters
+        ----------
+        ret_type: str
+            The return type runner| model.
+
+        Returns
+        -------
+        runnable:
+            The runner or model.
+        """
+
+        if ret_type == "runner":
+            return self._runner
+        elif ret_type == "runnable":
+            return self._runner.runnable
+        elif ret_type == "model":
+            return self._runner.model
+        raise Exception("Unexpect return type " + str(ret_type))
+
+    def _get_runner_cls(self, run_type: str) -> BaseRunner:
+        """Get the runner cls by type
+
+        Parameters
+        ----------
+        run_type: str
+            The run type.
+
+        Returns
+        -------
+        runner_cls: class
+            The runner class.
+        """
+
+        raise NotImplementedError("_get_runner_cls is not implemented for BaseManager")
+
+    @property
+    def runner(self):
+        return self._runner
+
+
+class MSCManager(BaseManager):
+    """Normal manager in MSC"""
+
+    def _get_runner_cls(self, run_type: str) -> BaseRunner:
+        """Get the runner cls by type
+
+        Parameters
+        ----------
+        run_type: str
+            The run type.
+
+        Returns
+        -------
+        runner_cls: class
+            The runner class.
+        """
+
+        if run_type == MSCFramework.TVM:
+            from tvm.contrib.msc.framework.tvm.runtime import TVMRunner
+
+            runner_cls = TVMRunner
+        elif run_type == MSCFramework.TORCH:
+            from tvm.contrib.msc.framework.torch.runtime import TorchRunner
+
+            runner_cls = TorchRunner
+        elif run_type == MSCFramework.TENSORFLOW:
+            from tvm.contrib.msc.framework.tensorflow.runtime import TensorflowRunner
+
+            runner_cls = TensorflowRunner
+        elif run_type == MSCFramework.TENSORRT:
+            from tvm.contrib.msc.framework.tensorrt.runtime import TensorRTRunner
+
+            runner_cls = TensorRTRunner
+        else:
+            raise Exception("Unexpect run_type " + str(run_type))
+        return runner_cls

--- a/src/contrib/msc/core/codegen/base_codegen.h
+++ b/src/contrib/msc/core/codegen/base_codegen.h
@@ -66,21 +66,19 @@ class BaseOpCode {
   virtual const Array<Doc> GetDocs() = 0;
 
   /*! \brief Get return describe for default node*/
-  virtual const String IdxNode(bool as_raw = true) { return IdxNodeBase(node_, as_raw); }
+  virtual const String IdxNode() { return IdxNodeBase(node_); }
 
   /*! \brief Get describe for default node input*/
-  const String IdxInput(int idx = 0, bool as_raw = false) {
-    return IdxInputBase(node_, idx, as_raw);
+  const String IdxInput(int idx = 0, bool process = true) {
+    return IdxInputBase(node_, idx, process);
   }
 
   /*! \brief Get describe for default node output*/
-  const String IdxOutput(int idx = 0, bool as_raw = false) {
-    return IdxOutputBase(node_, idx, as_raw);
-  }
+  const String IdxOutput(int idx = 0) { return IdxOutputBase(node_, idx); }
 
   /*! \brief Get describe for default node weight*/
-  const String IdxWeight(const String& wtype, bool as_raw = false) {
-    return IdxWeightBase(node_, wtype, as_raw);
+  const String IdxWeight(const String& wtype, bool process = true) {
+    return IdxWeightBase(node_, wtype, process);
   }
 
   /*! \brief Get comment for default node*/
@@ -93,7 +91,7 @@ class BaseOpCode {
   virtual const String callee_name() { return func_name(); }
 
   /*! \brief Get valid return name for the default node*/
-  virtual const String ret_name() { return IdxNode(true); }
+  virtual const String ret_name() { return IdxNode(); }
 
   /*! \brief Get the default node*/
   const MSCJoint node() { return node_; }

--- a/src/contrib/msc/core/codegen/code_stack.h
+++ b/src/contrib/msc/core/codegen/code_stack.h
@@ -447,14 +447,14 @@ class OpCodeStack : public BaseStack {
 
   /*! \brief Cache input as argument*/
   OpCodeStack<OpCodeGenType>& op_input_arg(int idx = 0, const String& key = "") {
-    return call_arg(codegen_->IdxInput(idx, false), key);
+    return call_arg(codegen_->IdxInput(idx, true), key);
   }
 
   /*! \brief Cache inputs as argument*/
   OpCodeStack<OpCodeGenType>& op_inputs_arg(bool as_list = true, const String& key = "") {
     Array<String> inputs;
     for (size_t i = 0; i < codegen_->node()->inputs.size(); i++) {
-      inputs.push_back(codegen_->IdxInput(i, false));
+      inputs.push_back(codegen_->IdxInput(i, true));
     }
     if (as_list) {
       return call_arg(DocUtils::ToListDoc(inputs), key);
@@ -465,13 +465,13 @@ class OpCodeStack : public BaseStack {
 
   /*! \brief Cache output as argument*/
   OpCodeStack<OpCodeGenType>& op_output_arg(int idx = 0, const String& key = "") {
-    return call_arg(codegen_->IdxOutput(idx, false), key);
+    return call_arg(codegen_->IdxOutput(idx), key);
   }
 
   /*! \brief Cache weight as argument*/
   OpCodeStack<OpCodeGenType>& op_weight_arg(const String& wtype, const String& key = "") {
     if (codegen_->node()->weights.count(wtype)) {
-      return call_arg(codegen_->IdxWeight(wtype, false), key);
+      return call_arg(codegen_->IdxWeight(wtype, true), key);
     }
     return *this;
   }

--- a/src/contrib/msc/core/codegen/codegen_utils.cc
+++ b/src/contrib/msc/core/codegen/codegen_utils.cc
@@ -36,7 +36,7 @@ const String CodeGenUtils::IdxOutput(const MSCJoint& node, const String& prefix,
                                      const String& suffix) {
   const auto& idx_node = IdxNode(node, prefix, suffix);
   size_t output_size = node->outputs.size();
-  if (output_size == 1) {
+  if (output_size == 1 && node->optype != "tuple") {
     return idx_node;
   }
   size_t v_index = CommonUtils::GetIndex(idx, output_size);

--- a/src/contrib/msc/core/printer/python_printer.cc
+++ b/src/contrib/msc/core/printer/python_printer.cc
@@ -196,7 +196,7 @@ void PythonPrinter::PrintIndentedBlock(const Array<StmtDoc>& docs) {
 void PythonPrinter::PrintDecorators(const Array<ExprDoc>& decorators) {
   for (const ExprDoc& decorator : decorators) {
     output_ << "@";
-    PrintDoc(decorator);
+    PrintDoc(decorator, false);
     NewLine();
   }
 }

--- a/src/contrib/msc/framework/tensorflow/codegen.cc
+++ b/src/contrib/msc/framework/tensorflow/codegen.cc
@@ -68,7 +68,7 @@ void TensorflowCodeGen::CodeGenGraph() {
       continue;
     }
     for (const auto& pair : node->weights) {
-      stack_.func_call("get_variable", IdxWeightBase(node, pair.first))
+      stack_.func_call("get_variable", IdxWeightBase(node, pair.first, false))
           .call_arg(DocUtils::ToStrDoc(pair.second->name))
           .call_arg(DocUtils::ToListDoc(pair.second->shape, true))
           .call_arg(DocUtils::ToStrDoc(pair.second->DTypeName()))
@@ -82,7 +82,7 @@ void TensorflowCodeGen::CodeGenGraph() {
     if (node->optype == "input") {
       continue;
     }
-    CodeGenNode(node);
+    CodeGenNode(node, config()->use_tools);
   }
   Array<String> idx_outputs;
   for (const auto& o : graph()->GetOutputs()) {

--- a/src/contrib/msc/framework/tensorrt/codegen.cc
+++ b/src/contrib/msc/framework/tensorrt/codegen.cc
@@ -110,9 +110,12 @@ void TensorRTCodeGen::CodeGenClassDefine() {
   // build layers
   for (const auto& n : graph()->node_names) {
     const auto& node = graph()->FindNode(n);
+    CodeGenNode(node, config()->use_tools);
+    /*
     for (const auto& d : GetOpCodes(node)) {
       stack_.line(d);
     }
+    */
   }
   // mark outputs
   stack_.comment("Mark outputs");

--- a/src/contrib/msc/framework/tensorrt/codegen_utils.h
+++ b/src/contrib/msc/framework/tensorrt/codegen_utils.h
@@ -40,7 +40,7 @@ class TensorRTCodeGenHelper : public BaseCodeGenHelper {
  public:
   /*! \brief Get describe for default node input*/
   const String IdxInputBase(const MSCJoint& node, const String& prefix = "", int idx = 0,
-                            const String& suffix = "") final {
+                            const String& suffix = "", bool process = false) final {
     const auto& pair = node->ProducerAndIdxOf(idx);
     if (pair.first->optype == "input") {
       return "*" + IdxNodeBase(pair.first, prefix, suffix);
@@ -53,7 +53,7 @@ class TensorRTCodeGenHelper : public BaseCodeGenHelper {
 
   /*! \brief Get describe for default node output*/
   const String IdxOutputBase(const MSCJoint& node, const String& prefix = "", int idx = 0,
-                             const String& suffix = "") final {
+                             const String& suffix = "", bool mark_exit = false) final {
     if (node->optype == "argmax" || node->optype == "argmin") {
       ICHECK_EQ(idx, 0) << "argmax and argmin only has 1 output, get " << idx;
       return IdxNodeBase(node, prefix, suffix) + "->getOutput(1)";
@@ -69,8 +69,8 @@ class TensorRTCodeGenHelper : public BaseCodeGenHelper {
   }
 
   /*! \brief Get describe for default node weight*/
-  const String IdxWeightBase(const MSCJoint& node, const String& wtype,
-                             const String& suffix = "") final {
+  const String IdxWeightBase(const MSCJoint& node, const String& wtype, const String& suffix = "",
+                             bool process = false) final {
     return "mWeights[\"" + node->WeightAt(wtype)->name + "\"]";
   }
 };

--- a/src/contrib/msc/framework/tensorrt/tensorrt_opcode.h
+++ b/src/contrib/msc/framework/tensorrt/tensorrt_opcode.h
@@ -61,7 +61,7 @@ class TensorRTOpCode : public BaseOpCode<TensorRTCodeGenConfig, TensorRTCodeGenH
   }
 
   /*! \brief Get valid return name for the default node*/
-  const String ret_name() final { return "auto " + IdxNode(true); }
+  const String ret_name() final { return "auto " + IdxNode(); }
 
   /*! \brief Get the dtype from the datatype*/
   const String DType(const DataType& dtype) final;

--- a/src/contrib/msc/framework/torch/codegen_utils.h
+++ b/src/contrib/msc/framework/torch/codegen_utils.h
@@ -40,12 +40,12 @@ class TorchCodeGenHelper : public BaseCodeGenHelper {
  public:
   /*! \brief Get describe for default node input*/
   const String IdxOutputBase(const MSCJoint& node, const String& prefix = "", int idx = 0,
-                             const String& suffix = "") final {
+                             const String& suffix = "", bool mark_exit = false) final {
     if ((node->optype == "max" || node->optype == "min") && node->OutputAt(0)->Ndim() > 0) {
       ICHECK(idx == 0) << "max and min op only support 1 outputs, get " << node;
       return IdxNodeBase(node, prefix, suffix) + ".values";
     }
-    return BaseCodeGenHelper::IdxOutputBase(node, prefix, idx, suffix);
+    return BaseCodeGenHelper::IdxOutputBase(node, prefix, idx, suffix, mark_exit);
   }
 };
 

--- a/src/contrib/msc/framework/torch/torch_opcode.h
+++ b/src/contrib/msc/framework/torch/torch_opcode.h
@@ -63,9 +63,8 @@ class TorchOpCode : public BaseOpCode<TorchCodeGenConfig, TorchCodeGenHelper> {
   }
 
   /*! \brief Get return describe for default node*/
-  const String IdxNode(bool as_raw = true) final {
-    return is_init_ ? module_ref_
-                    : BaseOpCode<TorchCodeGenConfig, TorchCodeGenHelper>::IdxNode(as_raw);
+  const String IdxNode() final {
+    return is_init_ ? module_ref_ : BaseOpCode<TorchCodeGenConfig, TorchCodeGenHelper>::IdxNode();
   };
 
   /*! \brief Get dtype string*/

--- a/src/contrib/msc/framework/tvm/relax_opcode.cc
+++ b/src/contrib/msc/framework/tvm/relax_opcode.cc
@@ -41,7 +41,7 @@ const Array<Doc> RelaxOpCode::GetDocs() {
   }
   if (emit_var) {
     const auto& name = config()->explicit_name ? node()->name : "";
-    BuilderEmit(IdxNode(true), name);
+    BuilderEmit(IdxNode(), name);
   }
   return stack_.GetDocs();
 }
@@ -334,14 +334,7 @@ class RelaxEinsumCodeGen : public RelaxOpCode {
  protected:
   void CodeGenBuild() final {
     const String& key = config()->from_relay ? "equation" : "subscripts";
-    const auto& producer = node()->ProducerOf(0);
-    stack_.op_call();
-    if (node()->inputs.size() == 1 && producer->optype == "tuple") {
-      stack_.op_input_arg();
-    } else {
-      stack_.op_inputs_arg();
-    }
-    stack_.op_str_arg(key, "subscripts");
+    stack_.op_call().op_inputs_arg().op_str_arg(key, "subscripts");
   }
 };
 

--- a/tests/python/contrib/test_msc/test_graph_build.py
+++ b/tests/python/contrib/test_msc/test_graph_build.py
@@ -23,7 +23,7 @@ from torch.nn import Module
 
 import tvm.testing
 from tvm.relax.frontend.torch import from_fx
-from tvm.contrib.msc.core.ir import translate
+from tvm.contrib.msc.core.frontend import translate
 from tvm.contrib.msc.core import utils as msc_utils
 
 
@@ -51,9 +51,7 @@ def test_conv1d():
 
     expected1 = {
         "inputs": [{"name": "inp_0", "shape": [1, 3, 10], "dtype": "float32", "layout": "NCW"}],
-        "outputs": [
-            {"name": "msc.conv1d_bias", "shape": [1, 6, 4], "dtype": "float32", "layout": "NCW"}
-        ],
+        "outputs": [{"name": "conv1d", "shape": [1, 6, 4], "dtype": "float32", "layout": "NCW"}],
         "nodes": {"total": 2, "input": 1, "msc.conv1d_bias": 1},
     }
 
@@ -93,7 +91,7 @@ def test_conv2d():
         ],
         "outputs": [
             {
-                "name": "msc.conv2d_bias",
+                "name": "conv2d",
                 "shape": [1, 6, 4, 4],
                 "dtype": "float32",
                 "layout": "NCHW",
@@ -141,7 +139,7 @@ def test_linear():
         ],
         "outputs": [
             {
-                "name": "msc.linear_bias",
+                "name": "matmul",
                 "shape": [1, 3, 10, 7],
                 "dtype": "float32",
                 "layout": "NCHW",
@@ -163,7 +161,7 @@ def test_linear():
             {"name": "inp_0", "shape": [1, 3, 10, 10], "dtype": "float32", "layout": "NCHW"}
         ],
         "outputs": [
-            {"name": "msc.linear", "shape": [1, 3, 10, 7], "dtype": "float32", "layout": "NCHW"}
+            {"name": "matmul", "shape": [1, 3, 10, 7], "dtype": "float32", "layout": "NCHW"}
         ],
         "nodes": {"total": 2, "input": 1, "msc.linear": 1},
     }
@@ -499,15 +497,13 @@ def test_embedding():
 
     expected1 = {
         "inputs": [{"name": "inp_0", "shape": [4], "dtype": "int64", "layout": "A"}],
-        "outputs": [{"name": "msc.embedding", "shape": [4, 3], "dtype": "float32", "layout": "NA"}],
+        "outputs": [{"name": "take", "shape": [4, 3], "dtype": "float32", "layout": "NA"}],
         "nodes": {"total": 2, "input": 1, "msc.embedding": 1},
     }
 
     expected2 = {
         "inputs": [{"name": "inp_0", "shape": [4, 5], "dtype": "int64", "layout": "AB"}],
-        "outputs": [
-            {"name": "msc.embedding", "shape": [4, 5, 3], "dtype": "float32", "layout": "CNB"}
-        ],
+        "outputs": [{"name": "take", "shape": [4, 5, 3], "dtype": "float32", "layout": "CNB"}],
         "nodes": {"total": 2, "input": 1, "msc.embedding": 1},
     }
 
@@ -1750,7 +1746,7 @@ def test_keep_params():
         ],
         "outputs": [
             {
-                "name": "msc.conv2d_bias",
+                "name": "conv2d",
                 "shape": [1, 6, 4, 4],
                 "dtype": "float32",
                 "layout": "NCHW",
@@ -1982,7 +1978,7 @@ def test_attention():
         ],
         "outputs": [
             {
-                "name": "msc.attention",
+                "name": "attention",
                 "shape": [32, 128, 8, 64],
                 "dtype": "float32",
                 "layout": "ABCD",
@@ -2012,7 +2008,7 @@ def test_attention():
         ],
         "outputs": [
             {
-                "name": "msc.attention",
+                "name": "attention_bias",
                 "shape": [32, 128, 8, 64],
                 "dtype": "float32",
                 "layout": "ABCD",
@@ -2020,7 +2016,6 @@ def test_attention():
         ],
         "nodes": {"total": 5, "input": 4, "msc.attention": 1},
     }
-
     verify_model(
         Attention3(),
         [

--- a/tests/python/contrib/test_msc/test_manager.py
+++ b/tests/python/contrib/test_msc/test_manager.py
@@ -83,7 +83,7 @@ def _get_tf_graph():
             # Call the utility to import the graph definition into default graph.
             graph_def = tf_testing.ProcessGraphDefParam(graph_def)
         return graph_def
-    except:
+    except:  # pylint: disable=bare-except
         print("please install tensorflow package")
         return None
 

--- a/tests/python/contrib/test_msc/test_manager.py
+++ b/tests/python/contrib/test_msc/test_manager.py
@@ -1,0 +1,263 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" Test Managers in MSC. """
+
+import pytest
+import torch
+
+import tvm.testing
+from tvm.contrib.msc.pipeline import MSCManager
+from tvm.contrib.msc.core.utils.namespace import MSCFramework
+from tvm.contrib.msc.core import utils as msc_utils
+
+requires_tensorrt = pytest.mark.skipif(
+    tvm.get_global_func("relax.ext.tensorrt", True) is None,
+    reason="TENSORRT is not enabled",
+)
+
+
+def _get_config(model_type, deploy_type, inputs, outputs, atol=1e-2, rtol=1e-2):
+    """Get msc config"""
+    return {
+        "model_type": model_type,
+        "inputs": inputs,
+        "outputs": outputs,
+        "dataset": {"loader": "from_random", "max_iter": 5},
+        "prepare": {"profile": {"benchmark": {"repeat": 10}}},
+        "baseline": {
+            "run_type": model_type,
+            "profile": {"check": {"atol": atol, "rtol": rtol}, "benchmark": {"repeat": 10}},
+        },
+        "compile": {
+            "run_type": deploy_type,
+            "profile": {"check": {"atol": atol, "rtol": rtol}, "benchmark": {"repeat": 10}},
+        },
+    }
+
+
+def _get_torch_model(name, is_training=False):
+    """Get model from torch vision"""
+    # pylint: disable=import-outside-toplevel
+    try:
+        import torchvision
+
+        model = getattr(torchvision.models, name)(pretrained=True)
+        if is_training:
+            model = model.train()
+        else:
+            model = model.eval()
+        return model
+    except:  # pylint: disable=bare-except
+        print("please install torchvision package")
+        return None
+
+
+def _get_tf_graph():
+    """Get graph from tensorflow"""
+    # pylint: disable=import-outside-toplevel
+    try:
+        from tvm.contrib.msc.framework.tensorflow import tf_v1
+        import tvm.relay.testing.tf as tf_testing
+
+        tf_graph = tf_v1.Graph()
+        with tf_graph.as_default():
+            graph_def = tf_testing.get_workload(
+                "https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.4_224.tgz",
+                "mobilenet_v2_1.4_224_frozen.pb",
+            )
+            # Call the utility to import the graph definition into default graph.
+            graph_def = tf_testing.ProcessGraphDefParam(graph_def)
+        return graph_def
+    except:
+        print("please install tensorflow package")
+        return None
+
+
+def _test_from_torch(deploy_type, expected_info, is_training=False, atol=1e-2, rtol=1e-2):
+    torch_model = _get_torch_model("resnet50", is_training)
+    if torch_model:
+        if torch.cuda.is_available():
+            torch_model = torch_model.to(torch.device("cuda:0"))
+        config = _get_config(
+            MSCFramework.TORCH,
+            deploy_type,
+            inputs=[["input_0", [1, 3, 224, 224], "float32"]],
+            outputs=["output"],
+            atol=atol,
+            rtol=rtol,
+        )
+        manager = MSCManager(torch_model, config)
+        report = manager.run_pipe()
+        assert report["success"], "Failed to run pipe for torch -> {}".format(deploy_type)
+        model_info = manager.runner.model_info
+        assert msc_utils.dict_equal(
+            model_info, expected_info
+        ), "Model info {} mismatch with expected {}".format(model_info, expected_info)
+        manager.destory()
+
+
+def _test_from_tf(deploy_type, expected_info, atol=1e-2, rtol=1e-2):
+    graphdef = _get_tf_graph()
+    if graphdef:
+        config = _get_config(
+            MSCFramework.TENSORFLOW,
+            deploy_type,
+            inputs=[["input", [1, 224, 224, 3], "float32"]],
+            outputs=["MobilenetV2/Predictions/Reshape_1:0"],
+            atol=atol,
+            rtol=rtol,
+        )
+        config["compile"]["profile"]["check"]["err_rate"] = -1
+        manager = MSCManager(graphdef, config)
+        report = manager.run_pipe()
+        assert report["success"], "Failed to run pipe for tensorflow -> {}".format(deploy_type)
+        model_info = manager.runner.model_info
+        assert msc_utils.dict_equal(
+            model_info, expected_info
+        ), "Model info {} mismatch with expected {}".format(model_info, expected_info)
+        manager.destory()
+
+
+def test_tvm_manager():
+    """Test manager for tvm"""
+
+    model_info = {
+        "inputs": [
+            {"name": "input_0", "shape": [1, 3, 224, 224], "dtype": "float32", "layout": "NCHW"}
+        ],
+        "outputs": [{"name": "output", "shape": [1, 1000], "dtype": "float32", "layout": "NC"}],
+        "nodes": {
+            "total": 229,
+            "input": 1,
+            "nn.conv2d": 53,
+            "nn.batch_norm": 53,
+            "get_item": 53,
+            "nn.relu": 49,
+            "nn.max_pool2d": 1,
+            "add": 16,
+            "nn.adaptive_avg_pool2d": 1,
+            "reshape": 1,
+            "msc.linear_bias": 1,
+        },
+    }
+    _test_from_torch(MSCFramework.TVM, model_info, is_training=True)
+
+    model_info = {
+        "inputs": [
+            {"name": "input", "shape": [1, 224, 224, 3], "dtype": "float32", "layout": "NHWC"}
+        ],
+        "outputs": [
+            {
+                "name": "MobilenetV2/Predictions/Reshape_1:0",
+                "shape": [1, 1001],
+                "dtype": "float32",
+                "layout": "NC",
+            }
+        ],
+        "nodes": {
+            "total": 138,
+            "input": 1,
+            "msc.conv2d_bias": 36,
+            "clip": 35,
+            "nn.conv2d": 17,
+            "nn.batch_norm": 17,
+            "get_item": 17,
+            "add": 10,
+            "nn.avg_pool2d": 1,
+            "squeeze": 1,
+            "reshape": 2,
+            "nn.softmax": 1,
+        },
+    }
+    _test_from_tf(MSCFramework.TVM, model_info)
+
+
+def test_torch_manager():
+    """Test manager for torch"""
+
+    model_info = {
+        "inputs": [
+            {"name": "input_0", "shape": [1, 3, 224, 224], "dtype": "float32", "layout": "NCHW"}
+        ],
+        "outputs": [{"name": "output", "shape": [1, 1000], "dtype": "float32", "layout": "NC"}],
+        "nodes": {
+            "total": 229,
+            "input": 1,
+            "nn.conv2d": 53,
+            "nn.batch_norm": 53,
+            "get_item": 53,
+            "nn.relu": 49,
+            "nn.max_pool2d": 1,
+            "add": 16,
+            "nn.adaptive_avg_pool2d": 1,
+            "reshape": 1,
+            "msc.linear_bias": 1,
+        },
+    }
+    _test_from_torch(MSCFramework.TORCH, model_info, is_training=False)
+
+
+def test_tensorflow_manager():
+    """Test manager for tensorflow"""
+
+    model_info = {
+        "inputs": [
+            {"name": "input", "shape": [1, 224, 224, 3], "dtype": "float32", "layout": "NHWC"}
+        ],
+        "outputs": [
+            {
+                "name": "MobilenetV2/Predictions/Reshape_1:0",
+                "shape": [1, 1001],
+                "dtype": "float32",
+                "layout": "NC",
+            }
+        ],
+        "nodes": {
+            "total": 138,
+            "input": 1,
+            "msc.conv2d_bias": 36,
+            "clip": 35,
+            "nn.conv2d": 17,
+            "nn.batch_norm": 17,
+            "get_item": 17,
+            "add": 10,
+            "nn.avg_pool2d": 1,
+            "squeeze": 1,
+            "reshape": 2,
+            "nn.softmax": 1,
+        },
+    }
+    _test_from_tf(MSCFramework.TENSORFLOW, model_info)
+
+
+@requires_tensorrt
+def test_tensorrt_manager():
+    """Test manager for tensorrt"""
+
+    model_info = {
+        "inputs": [
+            {"name": "input_0", "shape": [1, 3, 224, 224], "dtype": "float32", "layout": "NCHW"}
+        ],
+        "outputs": [{"name": "output", "shape": [1, 1000], "dtype": "float32", "layout": ""}],
+        "nodes": {"total": 2, "input": 1, "msc_tensorrt": 1},
+    }
+    _test_from_torch(MSCFramework.TENSORRT, model_info, is_training=False)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/contrib/test_msc/test_runner.py
+++ b/tests/python/contrib/test_msc/test_runner.py
@@ -25,7 +25,6 @@ from torch import fx
 from tvm.contrib.msc.framework.tensorflow import tf_v1
 
 import tvm.testing
-import tvm.relay.testing.tf as tf_testing
 from tvm.relax.frontend.torch import from_fx
 from tvm.contrib.msc.framework.tvm.runtime import TVMRunner
 from tvm.contrib.msc.framework.torch.runtime import TorchRunner
@@ -61,6 +60,8 @@ def _get_tf_graph():
     """Get tensorflow graphdef"""
 
     try:
+        import tvm.relay.testing.tf as tf_testing
+
         tf_graph = tf_v1.Graph()
         with tf_graph.as_default():
             graph_def = tf_testing.get_workload(

--- a/tests/python/contrib/test_msc/test_runner.py
+++ b/tests/python/contrib/test_msc/test_runner.py
@@ -59,6 +59,7 @@ def _get_torch_model(name, is_training=False):
 def _get_tf_graph():
     """Get tensorflow graphdef"""
 
+    # pylint: disable=import-outside-toplevel
     try:
         import tvm.relay.testing.tf as tf_testing
 

--- a/tests/python/contrib/test_msc/test_translate_relax.py
+++ b/tests/python/contrib/test_msc/test_translate_relax.py
@@ -23,7 +23,7 @@ from torch.nn import Module
 
 import tvm.testing
 from tvm.relax.frontend.torch import from_fx
-from tvm.contrib.msc.core.ir import translate
+from tvm.contrib.msc.core.frontend import translate
 from tvm.contrib.msc.framework.tvm import codegen as tvm_codegen
 
 


### PR DESCRIPTION
This is a pull request for MSC(Multi-System Compile)
RFC: https://discuss.tvm.apache.org/t/rfc-unity-msc-introduction-to-multi-system-compiler/15251/5
Tracking issue: https://github.com/apache/tvm/issues/15233

This is the Milestone 2 for MSC: Use msc.runtime.Manager to manage the compiling pipeline && tools.
To limit each PR in reviewable size, the Milestone 2 will be split into some steps:
**M2.1 Add Manager for compile pipeline**
M2.2 Add pruner for model pruning
M2.3 Add tracker for track layer datas
M2.4 Add quantizer for quantize model

Manager can be used as compile pipeline, backend of serving, and the basic for tool chain. The manager controls the compiling via creating runners in different framework and apply different tools. The manager can generate trainable model for optimization as well as finalized model for deploy.

cc @Hzfengsy 
cc @junrushao 