### PR TITLE
[Community] Qiang Zhang -> Committer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,6 +90,7 @@ We do encourage everyone to work anything they are interested in.
 - [Zihao Ye](https://github.com/yzh119): @yzh119 - tir
 - [Hao Yu](https://github.com/comaniac): @comaniac (PMC) - relay, byoc, auto_scheduler
 - [Shuai Yuan](https://github.com/ysh329): @ysh329 - ci
+- [Qiang Zhang](https://github.com/Johnson9009): @Johnson9009 - relay, tvm-script
 - [Lianmin Zheng](https://github.com/merrymercy) (PMC): @merrymercy - autotvm, auto_scheduler, topi, relay
 - [Xiyou Zhou](https://github.com/zxybazh): @zxybazh - relay
 - [wrongtest](https://github.com/wrongtest-intellif) (PMC): @wrongtest-intellif - tir, tvm-script, arith


### PR DESCRIPTION
Sorry for the late update, but please join me to welcome Qiang Zhang (@Johnson9009) as a new committer in TVM.

Qiang has been working on variant parts of TVM, including Relay, TIR, TVMScript, QNN, runtime, and RPC. Also, he has been helping with the recent releases, which are also great contributions beyond coding.

Based on the above observation, I believe he has demonstrated the qualifications to be considered as a committer.

- [Commits History](https://github.com/apache/tvm/pulls?q=+is%3Apr+author%3AJohnson9009+)
- [Code Review](https://github.com/apache/tvm/pulls?utf8=%E2%9C%93&q=reviewed-by:Johnson9009)
- [Community Forum Summary](https://discuss.tvm.apache.org/u/Johnson9009/summary)