### PR TITLE
[Community] Ruihang Lai -> PMC

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,7 +52,7 @@ We do encourage everyone to work anything they are interested in.
 - [Elen Kalda](https://github.com/ekalda): @ekalda - ethos-u, arm
 - [Marisa Kirisame](https://github.com/MarisaKirisame): @MarisaKirisame - relay
 - [Tristan Konolige](https://github.com/tkonolige): @tkonolige - profiling, relay, tir, runtime
-- [Ruihang Lai](https://github.com/MasterJH5574): @MasterJH5574 - tir, tvm-script
+- [Ruihang Lai](https://github.com/MasterJH5574) (PMC): @MasterJH5574 - tir, tvm-script
 - [Wuwei Lin](https://github.com/vinx13) (PMC): @vinx13 - relay, topi, tir, meta_schedule
 - [Yizhi Liu](https://github.com/yzhliu) (PMC): @yzhliu - jvm, topi, relay
 - [Hao Lu](https://github.com/hlu1): @hlu1 - nnpack, frontends


### PR DESCRIPTION
Sorry for the late update, but please join me in welcoming Ruihang Lai (@MasterJH5574 ) as a new PMC member of Apache TVM.

Ruihang has been an invaluable contributor to our community since 2020 and became a committer in 2022. He has consistently demonstrated his dedication and expertise in various aspects. He has led the design of TensorIR and MetaSchedule, and has been actively contributing to areas including arithmetic analysis, and performance on Apple M1 and iOS devices. Besides, he is actively engaged with the community in the discuss forum. This year, he also contributed a talk and a tutorial session in TVMCon. He is also the co-author of [SparseTIR](https://arxiv.org/abs/2207.04606) paper, reflecting his expertise in machine learning compilation and the research interests that align with the vision of TVM.

- [Commit history](https://github.com/apache/tvm/commits?author=MasterJH5574)
- [Code Review](https://github.com/apache/tvm/pulls?utf8=%E2%9C%93&q=reviewed-by:MasterJH5574)
- [Community Forum Summary](https://discuss.tvm.apache.org/u/MasterJH5574/summary)