### PR TITLE
[Community] Bohan Hou -> PMC

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,7 +40,7 @@ We do encourage everyone to work anything they are interested in.
 - [Siyuan Feng](https://github.com/Hzfengsy) (PMC): @Hzfengsy - tir
 - [Josh Fromm](https://github.com/jwfromm) (PMC): @jwfromm - frontends, quantization, topi
 - [Mehrdad Hessar](https://github.com/mehrdadh): @mehrdadh - microTVM, hexagon
-- [Bohan Hou](https://github.com/spectrometerHBH): @spectrometerHBH - tir, arith, tvm-script
+- [Bohan Hou](https://github.com/spectrometerHBH) (PMC): @spectrometerHBH - tir, arith, tvm-script
 - [Yuwei Hu](https://github.com/Huyuwei): @Huyuwei - topi, frontends
 - [Luke Hutton](https://github.com/lhutton1): @lhutton1 - ethos-u, arm
 - [Nick Hynes](https://github.com/nhynes): @nhynes: - sgx, rust


### PR DESCRIPTION
Sorry for the late update, but please join me in welcoming Bohan Hou (@spectrometerHBH ) as a new PMC member of the Apache TVM.

Bohan has been an active TVM contributor for years. He has been leading the design and contributing to several important components of TVM, including:

- TensorIR
- MetaSchedule
- Auto Tensorization
- Arithmetic analysis
- BYOC and CUTLASS integration
- State-of-the-art performance of LLM and diffusion models

Besides he has been actively participating in the discussions in the forum and helping managing PRs and issues.

- [Commits History](https://github.com/apache/tvm/pulls?q=is%3Apr+author%3AspectrometerHBH+)
- [Code Review](https://github.com/apache/tvm/pulls?q=reviewed-by%3AspectrometerHBH+)
- [Community Forum Summary](https://discuss.tvm.apache.org/u/spectrometerhbh/summary)