### PR TITLE
[BugFix] [Relay][Pytorch] Fix missing `.dtype` 

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -847,7 +847,7 @@ class PyTorchOpConverter:
             dtype = _convert_dtype_value(inputs[2])
         else:
             # if dtype is None, use the dtype of the input tensor
-            dtype = self.infer_type(inputs[0])
+            dtype = self.infer_type(inputs[0]).dtype
         return self.full_impl(data, 0, dtype)
 
     def full(self, inputs, input_types):
@@ -898,7 +898,7 @@ class PyTorchOpConverter:
             dtype = _convert_dtype_value(inputs[3])
         else:
             # if dtype is None, use the dtype of the input tensor
-            dtype = self.infer_type(inputs[0])
+            dtype = self.infer_type(inputs[0]).dtype
 
         return self.full_impl(data, fill_value, dtype)
 


### PR DESCRIPTION
`self.infer_type()` returns [tvm.ir.TensorType](https://tvm.apache.org/docs/reference/api/python/ir.html#tvm.ir.TensorType) so we need `.dtype` to get the data type.
Fix #16126
cc @jikechao @vvchernov @Hzfengsy @masahi 