### PR TITLE
[Unity][Web] Fix missing function NVTXScopedRange for web

### DIFF
--- a/web/emcc/wasm_runtime.cc
+++ b/web/emcc/wasm_runtime.cc
@@ -54,6 +54,7 @@
 #include "src/runtime/workspace_pool.cc"
 // relax setup
 #include "src/runtime/memory/memory_manager.cc"
+#include "src/runtime/nvtx.cc"
 #include "src/runtime/relax_vm/builtin.cc"
 #include "src/runtime/relax_vm/bytecode.cc"
 #include "src/runtime/relax_vm/executable.cc"


### PR DESCRIPTION
Import NVTX in wasm runtime to fix missing functions in webgpu.