### PR TITLE
To fix the error of reloading the model library on the ROCm platform: "MIOpen Error: No invoker was registered for convolution forward."

### DIFF
--- a/src/runtime/contrib/miopen/conv_forward.cc
+++ b/src/runtime/contrib/miopen/conv_forward.cc
@@ -113,7 +113,7 @@ TVM_REGISTER_GLOBAL("tvm.contrib.miopen.conv2d.setup").set_body([](TVMArgs args,
       rocm_api->AllocWorkspace(entry_ptr->conv_entry.device, output_size * sizeof(float)));
 
   const int request_algo_count = 4;
-  const bool exhaustive_search = false;
+  const bool exhaustive_search = true;
   void* workspace = entry_ptr->conv_entry.workspace;
   if (workspace_size == 0) workspace = nullptr;
   int returned_algo_count = 0;
@@ -189,8 +189,29 @@ TVM_REGISTER_GLOBAL("tvm.contrib.miopen.conv2d.forward")
                                               entry_ptr->conv_entry.data_type, y->shape[0],
                                               y->shape[1], y->shape[2], y->shape[3]));
 
+      // Set workspace
+      size_t workspace_size = 0;
+      MIOPEN_CALL(miopenConvolutionForwardGetWorkSpaceSize(
+      entry_ptr->handle, entry_ptr->conv_entry.filter_desc, entry_ptr->conv_entry.input_desc,
+      entry_ptr->conv_entry.conv_desc, entry_ptr->conv_entry.output_desc, &workspace_size));
+      entry_ptr->conv_entry.UpdateWorkspace(workspace_size);
+
       const float alpha = 1.f;
       const float beta = 0.f;
+
+      const int request_algo_count = 4;
+      const bool exhaustive_search = true;
+      void* workspace = entry_ptr->conv_entry.workspace;
+      if (workspace_size == 0) workspace = nullptr;
+      int returned_algo_count = 0;
+      miopenConvAlgoPerf_t perfs[4];
+
+      MIOPEN_CALL(miopenFindConvolutionForwardAlgorithm(
+        entry_ptr->handle, entry_ptr->conv_entry.input_desc, x->data,
+        entry_ptr->conv_entry.filter_desc,  w->data, entry_ptr->conv_entry.conv_desc,
+        entry_ptr->conv_entry.output_desc, y->data, request_algo_count, &returned_algo_count,
+        perfs, workspace, workspace_size, exhaustive_search));
+
       MIOPEN_CALL(miopenConvolutionForward(
           entry_ptr->handle, &alpha, entry_ptr->conv_entry.input_desc, x->data,
           entry_ptr->conv_entry.filter_desc, w->data, entry_ptr->conv_entry.conv_desc,
@@ -198,6 +219,8 @@ TVM_REGISTER_GLOBAL("tvm.contrib.miopen.conv2d.forward")
           entry_ptr->conv_entry.workspace, entry_ptr->conv_entry.workspace_size));
     });
 
+      
+
 }  // namespace miopen
 }  // namespace contrib
-}  // namespace tvm
+}  // namespace tvim


### PR DESCRIPTION
My env：AMD RX 7600
I debugged the MIOpen source code for a specific reason. During the model compilation phase, the Python side calls the conv2d.setup interface, invoking MIOpen's findConvForwardAlgorithm interface to find the appropriate algorithm. Subsequently, the corresponding <layer-Problem, Algorithm> pair is registered within the current invokers. Then, without terminating the current process, during the inference stage, the invoker can identify the Algorithm for the corresponding layer-problem and perform direct inference.

However, if the current process is exited and the pre-compiled model is executed without the prior invocation of findConvForwardAlgorithm during the compilation phase, the corresponding <layer-Problem, Algorithm> pair won't be registered within the invokers. As a result, the inference stage will report an error stating "MIOpen Error: No invoker was registered for convolution forward."

Based on the distinction between MIOpen and cuDNN invocation provided by the MIOpen official documentation, the typical sequence for calling Convolution APIs in MIOpen is as follows:

miopenConvolution*GetWorkSpaceSize(): This function returns the workspace size required by the Find() operation.

miopenFindConvolution*Algorithm(): This function returns performance information about various algorithms.

miopenConvolution*(): Actual convolution operation.

The official documentation emphasizes that calling miopenFindConvolution*Algorithm() is mandatory before using any Convolution API.

Additionally, according to the documentation found at https://rocm.docs.amd.com/projects/MIOpen/en/latest/convolution.html#miopenfindconvolutionforwardalgorithm, the last parameter of the miopenFindConvolutionForwardAlgorithm interface, exhaustiveSearch, should be set to 1 (true):

If exhaustiveSearch == 0, MIOpen will seek the first kernel with a configuration match. If no configuration match is found, a default configuration will be returned.

If exhaustiveSearch == 1, MIOpen will search for the best kernel for the provided configuration. If a match is not found, an exhaustive search is performed by running individual algorithms.

For further details refer to this link: https://rocmdocs.amd.com/projects/MIOpen/en/latest/MIOpen_Porting_Guide.html