### PR TITLE
[Device][Metal] Fix metal warp size

### DIFF
--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -55,7 +55,6 @@ void MetalWorkspace::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) {
         break;
       }
       case kWarpSize: {
-// Set warp size to be 1 for safty reason.
 #if defined(__x86_64__)
         *rv = 1;
 #elif defined(__aarch64__)

--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -60,7 +60,8 @@ void MetalWorkspace::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) {
 #elif defined(__aarch64__)
         *rv = 32;
 #else
-        LOG(FATAL) << "Unknown architecture";
+        LOG(WARNING) << "The CPU architecture is neither x86 nor aarch64. Fallback to warp size 1.";
+        *rv = 1;
 #endif
         break;
       }

--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -55,8 +55,14 @@ void MetalWorkspace::GetAttr(Device dev, DeviceAttrKind kind, TVMRetValue* rv) {
         break;
       }
       case kWarpSize: {
-        // Set warp size to be 1 for safty reason.
+// Set warp size to be 1 for safty reason.
+#if defined(__x86_64__)
         *rv = 1;
+#elif defined(__aarch64__)
+        *rv = 32;
+#else
+        LOG(FATAL) << "Unknown architecture";
+#endif
         break;
       }
       case kMaxSharedMemoryPerBlock:


### PR DESCRIPTION
metal warp size should be 1 on x86 device, but 32 on M1/M2 device