### PR TITLE
[Unity] Check usage location when canonicalizing trivial bindings

### DIFF
--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -345,6 +345,41 @@ def test_multiple_outputs():
     verify(Input, Expected)
 
 
+def test_single_output_multiple_nondataflow():
+    """Non-dataflow vars being updated may also be part trivial bindings
+
+    Like `test_multiple_outputs`, but only `n` is used in the return
+    statement.
+    """
+
+    @tvm.script.ir_module
+    class Input:
+        @R.function
+        def main():
+            with R.dataflow():
+                x = R.const(1)
+                y = R.const(1)
+                z = R.const(1)
+                l = x
+                m = y
+                n = z
+                R.output(l, m, n)
+            return n
+
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main():
+            with R.dataflow():
+                l = R.const(1)
+                m = R.const(1)
+                n = R.const(1)
+                R.output(n)
+            return n
+
+    verify(Input, Expected)
+
+
 def test_multiply_used_in_outputs():
     # cannot fold output in this case
     @tvm.script.ir_module


### PR DESCRIPTION
Prior to this commit, the `CanonicalizeBindings` transform handled trivial bindings, including binding of a `DataflowVar` to a `Var`, and usage of `Var` where a `DataflowVar` should be used instead.  However, it did not handle the case where both of these occur at the same time.  That is, a binding of `var_x = dataflow_y`, where `var_x` is only used within the dataflow block.  For these cases, `CanonicalizeBindings` would need to be run repeatedly.

This commit updates `CanonicalizeBindings` to check if a trivial binding is used outside the dataflow block.  This avoids producing output that requires further canonicalization.