### PR TITLE
[Unity] Improved error checking for DataflowBlock in nested SeqExpr

### DIFF
--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -892,8 +892,7 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
                     << "The variable " << binding->var << " is defined within a DataflowBlock, "
                     << "but is bound to a SeqExpr that contains non-dataflow BindingBlocks.  "
                     << "These non-dataflow BindingBlocks use the DataflowVars "
-                    << free_dataflow_vars << ", which is invalid.\n"
-                    << binding;
+                    << free_dataflow_vars << ", which is invalid.";
               }
             }
             ret.push_back(block);


### PR DESCRIPTION
Prior to this commit, the normalizer printed a warning whenever a lowering pass produced a `SeqExpr` containing a non-dataflow `BindingBlock` within a `DataflowBlock`.  This intermediate is only ill-formed if the non-dataflow `BindingBlock` makes use of any `DataflowVar` instances, as the `BindingBlock` can otherwise be hoisted out.

This commit explicitly checks for use of `DataflowVar` in these cases, as this is most likely due to erroneous use of `BindingBlock` where `DataflowBlock` should be used, and changes the severity from `WARNING` to `FATAL`.  If there are no `DataflowVar` instances used in the `BindingBlock`, no warning is required.