### PR TITLE
[Unity] Fix upstream tests that fail on unity branch

### DIFF
--- a/rust/tvm/src/ir/module.rs
+++ b/rust/tvm/src/ir/module.rs
@@ -62,7 +62,7 @@ external! {
     #[name("relay.parser.ParseExpr")]
     fn parse_expression(file_name: TVMString, source: TVMString) -> IRModule;
     #[name("ir.IRModule")]
-    fn module_new(funcs: Map<GlobalVar, BaseFunc>, types: Map<GlobalTypeVar, TypeData>, attrs: Map<TVMString, ObjectRef>) -> IRModule;
+    fn module_new(funcs: Map<GlobalVar, BaseFunc>, types: Map<GlobalTypeVar, TypeData>, attrs: Map<TVMString, ObjectRef>, global_infos: Map<TVMString, Array<ObjectRef>>) -> IRModule;
     // Module methods
     #[name("ir.Module_Add")]
     fn module_add(module: IRModule, type_name: GlobalVar, expr: BaseFunc, update: bool) -> IRModule;
@@ -99,16 +99,18 @@ external! {
 // Note: we don't expose update here as update is going to be removed.
 
 impl IRModule {
-    pub fn new<'a, F, T, A>(funcs: F, types: T, attrs: A) -> Result<IRModule>
+    pub fn new<'a, F, T, A, G>(funcs: F, types: T, attrs: A, global_infos: G) -> Result<IRModule>
     where
         F: IntoIterator<Item = (&'a GlobalVar, &'a BaseFunc)>,
         T: IntoIterator<Item = (&'a GlobalTypeVar, &'a TypeData)>,
         A: IntoIterator<Item = (&'a TVMString, &'a ObjectRef)>,
+        G: IntoIterator<Item = (&'a TVMString, &'a Array<ObjectRef>)>,
     {
         module_new(
             Map::from_iter(funcs),
             Map::from_iter(types),
             Map::from_iter(attrs),
+            Map::from_iter(global_infos),
         )
     }
 
@@ -116,7 +118,13 @@ impl IRModule {
         let funcs = HashMap::<GlobalVar, BaseFunc>::new();
         let types = HashMap::<GlobalTypeVar, TypeData>::new();
         let attrs = HashMap::<TVMString, ObjectRef>::new();
-        IRModule::new(funcs.iter(), types.iter(), attrs.iter())
+        let global_infos = HashMap::<TVMString, Array<ObjectRef>>::new();
+        IRModule::new(
+            funcs.iter(),
+            types.iter(),
+            attrs.iter(),
+            global_infos.iter(),
+        )
     }
 
     pub fn parse<N, S>(file_name: N, source: S) -> Result<IRModule>

--- a/tests/python/relay/test_json_compact.py
+++ b/tests/python/relay/test_json_compact.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import tvm
-from tvm import relay
-from tvm import te
 import json
 
+import tvm
+import tvm.testing
+from tvm import relay
 
 # 0.6 BACKWARDS COMPATIBILITY TESTS
 
@@ -125,7 +125,7 @@ def test_global_var():
         {"type_key": ""},
         {
             "type_key": "relay.GlobalVar",
-            "attrs": {"_checked_type_": "0", "name_hint": "x", "span": "0"},
+            "attrs": {"_checked_type_": "0", "name_hint": "x", "span": "0", "struct_info_": "0"},
         },
     ]
     data = {
@@ -140,7 +140,7 @@ def test_global_var():
         {"type_key": ""},
         {
             "type_key": "GlobalVar",
-            "attrs": {"_checked_type_": "0", "name_hint": "x", "span": "0"},
+            "attrs": {"_checked_type_": "0", "name_hint": "x", "span": "0", "struct_info_": "0"},
         },
     ]
     data = {
@@ -231,6 +231,7 @@ def test_irmodule_attributes():
                 "global_var_map_": "0",
                 "source_map": "0",
                 "type_definitions": "0",
+                "global_infos": "0",
             },
         },
     ]
@@ -277,11 +278,4 @@ def test_virtual_device():
 
 
 if __name__ == "__main__":
-    test_op()
-    test_type_var()
-    test_var()
-    test_incomplete_type()
-    test_func_tuple_type()
-    test_global_var()
-    test_tir_var()
-    test_str_map()
+    tvm.testing.main()

--- a/tests/python/relay/test_py_converter.py
+++ b/tests/python/relay/test_py_converter.py
@@ -15,13 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 import numpy as np
+
 import tvm
-from tvm import te
+import tvm.testing
 from tvm import relay
-from tvm.relay.testing import run_as_python
+from tvm.relay.backend.interpreter import ConstructorValue, RefValue
 from tvm.relay.prelude import Prelude
+from tvm.relay.testing import run_as_python
 from tvm.runtime.container import ADT
-from tvm.relay.backend.interpreter import RefValue, ConstructorValue
+
 
 # helper: uses a dummy let binding to sequence a list
 # of expressions: expr1; expr2; expr3, etc.
@@ -668,7 +670,13 @@ def test_compiling_with_main():
     mod = tvm.IRModule()
     mod["unit"] = unit
     mod["main"] = identity
+    gv_main = mod.get_global_var("main")
+    gv_unit = mod.get_global_var("unit")
 
-    res = run_as_python(mod.get_global_var("main")(mod.get_global_var("unit")()), mod=mod)
+    res = run_as_python(gv_main(relay.Call(gv_unit, ())), mod=mod)
     assert isinstance(res, ADT)
     assert len(res) == 0
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -61,7 +61,7 @@ run_pytest cython ${TVM_INTEGRATION_TESTSUITE_NAME}-dso_plugin_module-1 apps/dso
 run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-integration tests/python/integration
 
 # Ignoring Arm(R) Ethos(TM)-U NPU tests in the collective to run to run them in parallel in the next step.
-run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib --ignore=tests/python/contrib/test_ethosu --ignore=tests/python/contrib/test_cmsisnn
+run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-contrib tests/python/contrib --ignore=tests/python/contrib/test_ethosu --ignore=tests/python/contrib/test_cmsisnn --ignore=tests/python/contrib/test_msc
 # forked is needed because the global registry gets contaminated
 TVM_TEST_TARGETS="${TVM_RELAY_TEST_TARGETS:-llvm;cuda}" \
     run_pytest ctypes ${TVM_INTEGRATION_TESTSUITE_NAME}-relay tests/python/relay --ignore=tests/python/relay/aot


### PR DESCRIPTION
Unity branch does not enable all upstream tests by default. This commit fixes part of the tests on the main branch.