### PR TITLE
[Unity][WebGPU] Get params from cache by name

### DIFF
--- a/src/runtime/relax_vm/ndarray_cache_support.cc
+++ b/src/runtime/relax_vm/ndarray_cache_support.cc
@@ -327,11 +327,19 @@ class ParamModuleNode : public runtime::ModuleNode {
     return Module(n);
   }
 
+  static Module CreateByName(const Array<String>& names) {
+    auto n = make_object<ParamModuleNode>();
+    n->params_ = GetParamByName(names);
+    return Module(n);
+  }
+
  private:
   Array<NDArray> params_;
 };
 
 TVM_REGISTER_GLOBAL("vm.builtin.param_module_from_cache").set_body_typed(ParamModuleNode::Create);
+TVM_REGISTER_GLOBAL("vm.builtin.param_module_from_cache_by_name")
+    .set_body_typed(ParamModuleNode::CreateByName);
 TVM_REGISTER_GLOBAL("vm.builtin.param_array_from_cache").set_body_typed(ParamModuleNode::GetParams);
 TVM_REGISTER_GLOBAL("vm.builtin.param_array_from_cache_by_name")
     .set_body_typed(ParamModuleNode::GetParamByName);

--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -152,6 +152,7 @@ class RuntimeContext implements Disposable {
   arrayCacheClear: PackedFunc;
   arrayDecodeStorage: PackedFunc;
   paramModuleFromCache: PackedFunc;
+  paramModuleFromCacheByName: PackedFunc;
   makeShapeTuple: PackedFunc;
   ndarrayCreateView: PackedFunc;
   sampleTopPFromLogits: PackedFunc;
@@ -173,6 +174,7 @@ class RuntimeContext implements Disposable {
     this.arrayCacheClear = getGlobalFunc("vm.builtin.ndarray_cache.clear");
     this.arrayDecodeStorage = getGlobalFunc("tvmjs.array.decode_storage");
     this.paramModuleFromCache = getGlobalFunc("vm.builtin.param_module_from_cache");
+    this.paramModuleFromCacheByName = getGlobalFunc("vm.builtin.param_module_from_cache_by_name");
     this.makeShapeTuple = getGlobalFunc("runtime.ShapeTuple");
     this.ndarrayCreateView = getGlobalFunc("runtime.TVMArrayCreateView");
     this.sampleTopPFromLogits = getGlobalFunc("vm.builtin.sample_top_p_from_logits");
@@ -194,6 +196,7 @@ class RuntimeContext implements Disposable {
     this.arrayCacheClear.dispose();
     this.arrayDecodeStorage.dispose();
     this.paramModuleFromCache.dispose();
+    this.paramModuleFromCacheByName.dispose();
     this.makeShapeTuple.dispose();
     this.ndarrayCreateView.dispose();
     this.sampleTopPFromLogits.dispose();
@@ -1394,6 +1397,20 @@ export class Instance implements Disposable {
   getParamsFromCache(prefix: string, numParams: number): TVMObject {
     return (this.ctx.paramModuleFromCache(
       prefix, new Scalar(numParams, "int32")) as Module).getFunction("get_params")();
+  }
+
+  /**
+   * Get parameters based on parameter names provided
+   *
+   * @param paramNames Names of the parameters.
+   * @returns Parameters read.
+   */
+  getParamsFromCacheByName(paramNames: Array<string>): TVMObject {
+    // Convert Array<string> to Array<TVMString>
+    const paramNamesTVM: TVMString[] = [];
+    paramNames.forEach(paramName => { paramNamesTVM.push(this.makeString(paramName)) });
+    return (this.ctx.paramModuleFromCacheByName(
+      this.makeTVMArray(paramNamesTVM)) as Module).getFunction("get_params")();
   }
 
   /**


### PR DESCRIPTION
This PR is essentially https://github.com/apache/tvm/pull/16078 but for web runtime.

Add function `getParamsFromCacheByName()` for web runtime, hence creating `CreateByName()` in ndarray cache. `Create()` to `GetParams()` is analogous to `CreateByName()` to `GetParamsByName()`.