### PR TITLE
[Relay][Frontend] Add support for aten::concat

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -4046,6 +4046,7 @@ class PyTorchOpConverter:
             "aten::squeeze": self.squeeze,
             "aten::unsqueeze": self.unsqueeze,
             "aten::cat": self.concatenate,
+            "aten::concat": self.concatenate,
             "aten::slice": self.slice,
             "aten::narrow": self.narrow,
             "aten::split": self.split,

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -719,7 +719,7 @@ def test_forward_concatenate():
             b = (args[0][:, :, 1] + 3) * 11
             c = (args[0][:, :, 2] + 5) * 13
             return torch.cat([t.unsqueeze(2) for t in [a, b, c]], 2)
-    
+
     class Concatenate3(Module):
         def __init__(self):
             super().__init__()

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -721,7 +721,11 @@ def test_forward_concatenate():
             return torch.cat([t.unsqueeze(2) for t in [a, b, c]], 2)
 
     class Concatenate3(Module):
-        # pylint: disable=missing-class-docstring
+        """
+        torch.concat is preserved as aten::concat only when in a nested module.
+        (In the most cases, It is converted to aten::cat instead of aten::concat.)
+        """
+
         def __init__(self):
             super().__init__()
 

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -719,10 +719,27 @@ def test_forward_concatenate():
             b = (args[0][:, :, 1] + 3) * 11
             c = (args[0][:, :, 2] + 5) * 13
             return torch.cat([t.unsqueeze(2) for t in [a, b, c]], 2)
+    
+    class Concatenate3(Module):
+        def __init__(self):
+            super().__init__()
+
+            class _Concatenate(Module):
+                def forward(self, *args):
+                    a = (args[0][:, :, 0] + 2) * 7
+                    b = (args[0][:, :, 1] + 3) * 11
+                    c = (args[0][:, :, 2] + 5) * 13
+                    return torch.concat([t.unsqueeze(2) for t in [a, b, c]], 2)
+
+            self.mod = _Concatenate()
+
+        def forward(self, *args):
+            return self.mod(*args)
 
     input_data = torch.rand(input_shape).float()
     verify_model(Concatenate1().float().eval(), input_data=input_data)
     verify_model(Concatenate2().float().eval(), input_data=input_data)
+    verify_model(Concatenate3().float().eval(), input_data=input_data)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -721,6 +721,7 @@ def test_forward_concatenate():
             return torch.cat([t.unsqueeze(2) for t in [a, b, c]], 2)
 
     class Concatenate3(Module):
+        # pylint: disable=missing-class-docstring
         def __init__(self):
             super().__init__()
 


### PR DESCRIPTION
I think it is a quite simple problem, 

`aten::concat` is just an alias of `aten::cat`, but it is not supported.

https://github.com/pytorch/pytorch/blob/3fbfa8cd0a5cefadb3f116c5cd0d60e96ab8c99e/aten/src/ATen/native/TensorShape.cpp#L667

If needed, I will add a minimal example to reproduce.

```
torch==2.1.1+cpu
numpy==1.23.5
```