### PR TITLE
[Unity] De-duplicate calls to TensorStructInfo constructor

### DIFF
--- a/include/tvm/relax/struct_info.h
+++ b/include/tvm/relax/struct_info.h
@@ -231,7 +231,7 @@ class TensorStructInfo : public StructInfo {
    *
    * \note shape must already be normalized.
    */
-  TVM_DLL TensorStructInfo(Expr shape, DataType dtype, VDevice vdevice = VDevice(),
+  TVM_DLL TensorStructInfo(Expr shape, DataType dtype, Optional<VDevice> vdevice = NullOpt,
                            Span span = Span());
 
   /*!
@@ -241,7 +241,7 @@ class TensorStructInfo : public StructInfo {
    * \param vdevice The virtual device.
    * \param span The span of the AST.
    */
-  TVM_DLL TensorStructInfo(DataType dtype, int ndim, VDevice vdevice = VDevice(),
+  TVM_DLL TensorStructInfo(DataType dtype, int ndim, Optional<VDevice> vdevice = NullOpt,
                            Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(TensorStructInfo, StructInfo, TensorStructInfoNode);

--- a/src/relax/ir/struct_info.cc
+++ b/src/relax/ir/struct_info.cc
@@ -105,7 +105,8 @@ TVM_REGISTER_GLOBAL("relax.ShapeStructInfo")
     });
 
 // Tensor
-TensorStructInfo::TensorStructInfo(Expr shape, DataType dtype, VDevice vdevice, Span span) {
+TensorStructInfo::TensorStructInfo(Expr shape, DataType dtype, Optional<VDevice> vdevice,
+                                   Span span) {
   ObjectPtr<TensorStructInfoNode> n = make_object<TensorStructInfoNode>();
   // assign ndim before move
   Optional<ShapeStructInfo> sinfo = MatchStructInfo<ShapeStructInfo>(shape);
@@ -122,7 +123,7 @@ TensorStructInfo::TensorStructInfo(Expr shape, DataType dtype, VDevice vdevice, 
   data_ = std::move(n);
 }
 
-TensorStructInfo::TensorStructInfo(DataType dtype, int ndim, VDevice vdevice, Span span) {
+TensorStructInfo::TensorStructInfo(DataType dtype, int ndim, Optional<VDevice> vdevice, Span span) {
   ObjectPtr<TensorStructInfoNode> n = make_object<TensorStructInfoNode>();
   CHECK_GE(ndim, -1) << "ndim of TensorStructInfo must be >= -1, but got " << ndim;
   n->ndim = ndim;

--- a/src/relax/op/ccl/ccl.cc
+++ b/src/relax/op/ccl/ccl.cc
@@ -72,11 +72,7 @@ StructInfo InferStructInfoAllGather(const Call& call, const BlockBuilder& ctx) {
   }
   Array<PrimExpr> output_shape = input_shape.value();
   output_shape.Set(0, floor(output_shape[0] * num_workers.value()));
-  VDevice vdevice;
-  if (input_sinfo->vdevice.defined()) {
-    vdevice = input_sinfo->vdevice.value();
-  }
-  return TensorStructInfo(ShapeExpr(output_shape), output_dtype, vdevice);
+  return TensorStructInfo(ShapeExpr(output_shape), output_dtype, input_sinfo->vdevice);
 }
 
 TVM_REGISTER_OP("relax.ccl.allgather")
@@ -141,10 +137,7 @@ StructInfo InferStructInfoScatter(const Call& call, const BlockBuilder& ctx) {
 
   Array<PrimExpr> output_shape = input_shape.value();
   output_shape.Set(attrs->axis, div(output_shape[attrs->axis], num_workers));
-  if (input_sinfo->vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(output_shape), output_dtype, input_sinfo->vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(output_shape), output_dtype);
+  return TensorStructInfo(ShapeExpr(output_shape), output_dtype, input_sinfo->vdevice);
 }
 
 TVM_REGISTER_OP("relax.ccl.scatter_from_worker0")

--- a/src/relax/op/distributed/distributed.cc
+++ b/src/relax/op/distributed/distributed.cc
@@ -165,10 +165,7 @@ StructInfo InferStructInfoRtoS(const Call& call, const BlockBuilder& ctx) {
 
   Array<PrimExpr> output_shape = input_shape.value();
   output_shape.Set(attrs->axis, div(output_shape[attrs->axis], num_workers));
-  if (input_sinfo->vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(output_shape), output_dtype, input_sinfo->vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(output_shape), output_dtype);
+  return TensorStructInfo(ShapeExpr(output_shape), output_dtype, input_sinfo->vdevice);
 }
 
 StructInfo InferDistStructInfoRtoS(const Call& call, const BlockBuilder& ctx) {

--- a/src/relax/op/image/resize.cc
+++ b/src/relax/op/image/resize.cc
@@ -90,10 +90,7 @@ StructInfo InferStructInfoResize2D(const Call& call, const BlockBuilder& ctx) {
   Optional<ShapeExpr> data_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, GetRef<TensorStructInfo>(data_sinfo), data_layout);
   if (!data_shape.defined() || size_value == nullptr) {
-    if (data_sinfo->vdevice.defined()) {
-      return TensorStructInfo(out_dtype, data_layout.ndim(), data_sinfo->vdevice.value());
-    }
-    return TensorStructInfo(out_dtype, data_layout.ndim());
+    return TensorStructInfo(out_dtype, data_layout.ndim(), data_sinfo->vdevice);
   }
 
   Array<PrimExpr> data_NCHW_shape = data2NCHW.ForwardShape(data_shape.value()->values);
@@ -102,10 +99,7 @@ StructInfo InferStructInfoResize2D(const Call& call, const BlockBuilder& ctx) {
   out_NCHW_shape.Set(3, size_value->values[1]);
 
   Array<PrimExpr> out_shape = data2NCHW.BackwardShape(out_NCHW_shape);
-  if (data_sinfo->vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(out_shape), out_dtype, data_sinfo->vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(out_shape), out_dtype);
+  return TensorStructInfo(ShapeExpr(out_shape), out_dtype, data_sinfo->vdevice);
 }
 
 InferLayoutOutput InferLayoutResize2d(const Call& call,

--- a/src/relax/op/nn/attention.cc
+++ b/src/relax/op/nn/attention.cc
@@ -133,10 +133,7 @@ StructInfo InferStructInfoAttention(const Call& call, const BlockBuilder& ctx) {
   }
 
   Array<PrimExpr> output_shape = {num_batches, num_queries, num_heads, head_dim_value};
-  if (q_sinfo->vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(output_shape), q_sinfo->dtype, q_sinfo->vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(output_shape), q_sinfo->dtype);
+  return TensorStructInfo(ShapeExpr(output_shape), q_sinfo->dtype, q_sinfo->vdevice);
 }
 
 Call InferMixedPrecisionAttention(const Call& call, const DataType& out_dtype) {

--- a/src/relax/op/nn/convolution.cc
+++ b/src/relax/op/nn/convolution.cc
@@ -79,10 +79,7 @@ StructInfo InferStructInfoConv1d(const Call& call, const BlockBuilder& ctx) {
                            : attrs->out_dtype;
   Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, data_sinfo, weight_sinfo);
   if (!data_shape.defined() || !weight_shape.defined()) {
-    if (vdevice.defined()) {
-      return TensorStructInfo(out_dtype, out_layout.ndim(), vdevice.value());
-    }
-    return TensorStructInfo(out_dtype, out_layout.ndim());
+    return TensorStructInfo(out_dtype, out_layout.ndim(), vdevice);
   }
 
   Array<PrimExpr> data_NCW_shape = data2NCW.ForwardShape(data_shape.value()->values);
@@ -125,10 +122,7 @@ StructInfo InferStructInfoConv1d(const Call& call, const BlockBuilder& ctx) {
   out_NCW_shape[2] = analyzer->Simplify(floordiv(numerator_w, attrs->strides[0]) + 1);
 
   Array<PrimExpr> out_shape = out2NCW.BackwardShape(out_NCW_shape);
-  if (vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(out_shape), out_dtype);
+  return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
 }
 
 InferLayoutOutput InferLayoutConv1d(const Call& call,
@@ -248,10 +242,7 @@ StructInfo InferStructInfoConv2d(const Call& call, const BlockBuilder& ctx) {
                            : attrs->out_dtype;
   Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, data_sinfo, weight_sinfo);
   if (!data_shape.defined() || !weight_shape.defined()) {
-    if (vdevice.defined()) {
-      return TensorStructInfo(out_dtype, out_layout.ndim(), vdevice.value());
-    }
-    return TensorStructInfo(out_dtype, out_layout.ndim());
+    return TensorStructInfo(out_dtype, out_layout.ndim(), vdevice);
   }
 
   Array<PrimExpr> data_NCHW_shape = data2NCHW.ForwardShape(data_shape.value()->values);
@@ -299,10 +290,7 @@ StructInfo InferStructInfoConv2d(const Call& call, const BlockBuilder& ctx) {
   out_NCHW_shape[3] = analyzer->Simplify(floordiv(numerator_w, attrs->strides[1]) + 1);
 
   Array<PrimExpr> out_shape = out2NCHW.BackwardShape(out_NCHW_shape);
-  if (vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(out_shape), out_dtype);
+  return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
 }
 
 InferLayoutOutput InferLayoutConv2d(const Call& call,
@@ -427,10 +415,7 @@ StructInfo InferStructInfoConv1dTranspose(const Call& call, const BlockBuilder& 
                            : attrs->out_dtype;
   Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, data_sinfo, weight_sinfo);
   if (!data_shape.defined() || !weight_shape.defined()) {
-    if (vdevice.defined()) {
-      return TensorStructInfo(out_dtype, out_layout.ndim(), vdevice.value());
-    }
-    return TensorStructInfo(out_dtype, out_layout.ndim());
+    return TensorStructInfo(out_dtype, out_layout.ndim(), vdevice);
   }
 
   Array<PrimExpr> data_NCW_shape = data2NCW.ForwardShape(data_shape.value()->values);
@@ -483,10 +468,7 @@ StructInfo InferStructInfoConv1dTranspose(const Call& call, const BlockBuilder& 
   out_NCW_shape[2] = analyzer->Simplify(out_w);
 
   Array<PrimExpr> out_shape = out2NCW.BackwardShape(out_NCW_shape);
-  if (vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(out_shape), out_dtype);
+  return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
 }
 
 // TODO(relax-team): implement FInferMixedPrecision and FRelaxInferLayout for conv1d_transpose
@@ -571,10 +553,7 @@ StructInfo InferStructInfoConv2dTranspose(const Call& call, const BlockBuilder& 
                            : attrs->out_dtype;
   Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, data_sinfo, weight_sinfo);
   if (!data_shape.defined() || !weight_shape.defined()) {
-    if (vdevice.defined()) {
-      return TensorStructInfo(out_dtype, out_layout.ndim(), vdevice.value());
-    }
-    return TensorStructInfo(out_dtype, out_layout.ndim());
+    return TensorStructInfo(out_dtype, out_layout.ndim(), vdevice);
   }
 
   Array<PrimExpr> data_NCHW_shape = data2NCHW.ForwardShape(data_shape.value()->values);
@@ -635,10 +614,7 @@ StructInfo InferStructInfoConv2dTranspose(const Call& call, const BlockBuilder& 
   out_NCHW_shape[3] = analyzer->Simplify(out_w);
 
   Array<PrimExpr> out_shape = out2NCHW.BackwardShape(out_NCHW_shape);
-  if (vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(out_shape), out_dtype);
+  return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
 }
 
 // TODO(relax-team): implement FInferMixedPrecision and FRelaxInferLayout for conv2d_transpose

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -266,15 +266,10 @@ StructInfo InferStructInfoBatchNorm(const Call& call, const BlockBuilder& ctx) {
 
   DataType dtype = input_sinfo[0]->dtype;
   if (unknown_shape) {
-    if (input_sinfo[0]->vdevice.defined()) {
-      VDevice vdev = input_sinfo[0]->vdevice.value();
-      return TupleStructInfo({TensorStructInfo(dtype, input_sinfo[0]->ndim, vdev),
-                              TensorStructInfo(dtype, /*ndim=*/1, vdev),
-                              TensorStructInfo(dtype, /*ndim=*/1, vdev)});
-    }
-    return TupleStructInfo({TensorStructInfo(dtype, input_sinfo[0]->ndim),
-                            TensorStructInfo(dtype, /*ndim=*/1),
-                            TensorStructInfo(dtype, /*ndim=*/1)});
+    auto vdev = input_sinfo[0]->vdevice;
+    return TupleStructInfo({TensorStructInfo(dtype, input_sinfo[0]->ndim, vdev),
+                            TensorStructInfo(dtype, /*ndim=*/1, vdev),
+                            TensorStructInfo(dtype, /*ndim=*/1, vdev)});
   } else {
     return TupleStructInfo({input_sinfo[0], input_sinfo[3], input_sinfo[4]});
   }
@@ -337,12 +332,8 @@ StructInfo InferStructInfoLayerNorm(const Call& call, const BlockBuilder& ctx) {
   const auto* attrs = call->attrs.as<LayerNormAttrs>();
   bool unknown_shape = NormCheckDtypeAndShape(call, ctx, input_sinfo, attrs->axes);
 
-  if (input_sinfo[0]->vdevice.defined()) {
-    return unknown_shape ? TensorStructInfo(input_sinfo[0]->dtype, input_sinfo[0]->ndim,
-                                            input_sinfo[0]->vdevice.value())
-                         : input_sinfo[0];
-  }
-  return unknown_shape ? TensorStructInfo(input_sinfo[0]->dtype, input_sinfo[0]->ndim)
+  return unknown_shape ? TensorStructInfo(input_sinfo[0]->dtype, input_sinfo[0]->ndim,
+                                          input_sinfo[0]->vdevice)
                        : input_sinfo[0];
 }
 
@@ -514,12 +505,8 @@ StructInfo InferStructInfoRMSNorm(const Call& call, const BlockBuilder& ctx) {
   const auto* attrs = call->attrs.as<RMSNormAttrs>();
   bool unknown_shape = NormCheckDtypeAndShape(call, ctx, input_sinfo, attrs->axes);
 
-  if (input_sinfo[0]->vdevice.defined()) {
-    return unknown_shape ? TensorStructInfo(input_sinfo[0]->dtype, input_sinfo[0]->ndim,
-                                            input_sinfo[0]->vdevice.value())
-                         : input_sinfo[0];
-  }
-  return unknown_shape ? TensorStructInfo(input_sinfo[0]->dtype, input_sinfo[0]->ndim)
+  return unknown_shape ? TensorStructInfo(input_sinfo[0]->dtype, input_sinfo[0]->ndim,
+                                          input_sinfo[0]->vdevice)
                        : input_sinfo[0];
 }
 
@@ -629,10 +616,7 @@ StructInfo InferStructInfoCrossEntropy(const Call& call, const BlockBuilder& ctx
       }
     }
   }
-  if (vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(Array<PrimExpr>()), dtype, vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(Array<PrimExpr>()), dtype);
+  return TensorStructInfo(ShapeExpr(Array<PrimExpr>()), dtype, vdevice);
 }
 
 Expr cross_entropy_with_logits(Expr predictions, Expr labels) {
@@ -860,24 +844,14 @@ StructInfo InferStructInfoNLLLoss(const Call& call, const BlockBuilder& ctx) {
   if (reduction == "none") {
     // () or (N,) or (N, d1, d2, ..., dk)
     if (pred_sinfo->shape.as<ShapeExprNode>()) {
-      if (vdevice.defined()) {
-        return TensorStructInfo(ShapeExpr(output_shape), output_dtype, vdevice.value());
-      }
-      return TensorStructInfo(ShapeExpr(output_shape), output_dtype);
+      return TensorStructInfo(ShapeExpr(output_shape), output_dtype, vdevice);
     } else {
       int output_ndim = pred_sinfo->ndim == kUnknownNDim ? kUnknownNDim : pred_sinfo->ndim - 1;
-      if (vdevice.defined()) {
-        return TensorStructInfo(output_dtype, /*ndim=*/output_ndim, vdevice.value());
-      }
-      return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
+      return TensorStructInfo(output_dtype, /*ndim=*/output_ndim, vdevice);
     }
   } else {
     // sum or mean. output is scalar
-    if (vdevice.defined()) {
-      return TensorStructInfo(/*shape=*/ShapeExpr(Array<PrimExpr>()), output_dtype,
-                              vdevice.value());
-    }
-    return TensorStructInfo(/*shape=*/ShapeExpr(Array<PrimExpr>()), output_dtype);
+    return TensorStructInfo(/*shape=*/ShapeExpr(Array<PrimExpr>()), output_dtype, vdevice);
   }
 }
 

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -86,10 +86,7 @@ StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
   Optional<ShapeExpr> data_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, data_sinfo, data_layout);
   if (!data_shape.defined()) {
-    if (data_sinfo->vdevice.defined()) {
-      return TensorStructInfo(data_sinfo->dtype, out_layout.ndim(), data_sinfo->vdevice.value());
-    }
-    return TensorStructInfo(data_sinfo->dtype, out_layout.ndim());
+    return TensorStructInfo(data_sinfo->dtype, out_layout.ndim(), data_sinfo->vdevice);
   }
 
   Array<PrimExpr> data_NCHW_shape = data2NCHW.ForwardShape(data_shape.value()->values);
@@ -117,10 +114,7 @@ StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
   out_NCHW_shape[3] = analyzer->Simplify(floordiv(numerator_w, attrs->strides[1]) + 1);
 
   Array<PrimExpr> out_shape = out2NCHW.BackwardShape(out_NCHW_shape);
-  if (data_sinfo->vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype);
+  return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice);
 }
 
 InferLayoutOutput InferLayoutPool2d(const Call& call,
@@ -210,10 +204,7 @@ StructInfo InferStructInfoAdaptiveAvgPool2D(const Call& call, const BlockBuilder
         !attrs->output_size.defined()) {
       return data_sinfo;
     } else {
-      if (data_sinfo->vdevice.defined()) {
-        return TensorStructInfo(data_sinfo->dtype, out_layout.ndim(), data_sinfo->vdevice.value());
-      }
-      return TensorStructInfo(data_sinfo->dtype, out_layout.ndim());
+      return TensorStructInfo(data_sinfo->dtype, out_layout.ndim(), data_sinfo->vdevice);
     }
   }
 
@@ -225,10 +216,7 @@ StructInfo InferStructInfoAdaptiveAvgPool2D(const Call& call, const BlockBuilder
   }
 
   Array<PrimExpr> out_shape = out2NCHW.BackwardShape(out_NCHW_shape);
-  if (data_sinfo->vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype);
+  return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice);
 }
 
 InferLayoutOutput InferLayoutAdaptiveAvgPool2D(const Call& call,

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -58,28 +58,16 @@ StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx,
     Optional<Array<PrimExpr>> output_shape =
         InferBinaryBroadcastShape(call, ctx, x1_shape->values, x2_shape->values);
     if (!output_shape.defined()) {
-      if (vdevice.defined()) {
-        return TensorStructInfo(output_dtype, /*ndim=*/output_ndim, vdevice.value());
-      }
-      return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
+      return TensorStructInfo(output_dtype, /*ndim=*/output_ndim, vdevice);
 
     } else {
       ICHECK_EQ(static_cast<int>(output_shape.value().size()), output_ndim);
-      if (vdevice.defined()) {
-        return TensorStructInfo(ShapeExpr(output_shape.value()), output_dtype, vdevice.value());
-      }
-      return TensorStructInfo(ShapeExpr(output_shape.value()), output_dtype);
+      return TensorStructInfo(ShapeExpr(output_shape.value()), output_dtype, vdevice);
     }
   } else if (x1_sinfo->shape.defined() && x1_sinfo->shape.same_as(x2_sinfo->shape)) {
-    if (vdevice.defined()) {
-      return TensorStructInfo(x1_sinfo->shape.value(), output_dtype, vdevice.value());
-    }
-    return TensorStructInfo(x1_sinfo->shape.value(), output_dtype);
+    return TensorStructInfo(x1_sinfo->shape.value(), output_dtype, vdevice);
   } else {
-    if (vdevice.defined()) {
-      return TensorStructInfo(output_dtype, /*ndim=*/output_ndim, vdevice.value());
-    }
-    return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
+    return TensorStructInfo(output_dtype, /*ndim=*/output_ndim, vdevice);
   }
 }
 

--- a/src/relax/op/tensor/create.cc
+++ b/src/relax/op/tensor/create.cc
@@ -77,10 +77,7 @@ StructInfo InferStructInfoFull(const Call& call, const BlockBuilder& ctx) {
 
   const auto* attrs = call->attrs.as<InitAttrs>();
   DataType out_dtype = attrs->dtype.is_void() ? fill_value_sinfo->dtype : attrs->dtype;
-  if (fill_value_sinfo->vdevice.defined()) {
-    return TensorStructInfo(/*shape=*/call->args[0], out_dtype, fill_value_sinfo->vdevice.value());
-  }
-  return TensorStructInfo(/*shape=*/call->args[0], out_dtype);
+  return TensorStructInfo(/*shape=*/call->args[0], out_dtype, fill_value_sinfo->vdevice);
 }
 
 TVM_REGISTER_OP("relax.full")

--- a/src/relax/op/tensor/search.cc
+++ b/src/relax/op/tensor/search.cc
@@ -161,21 +161,12 @@ StructInfo InferStructInfoArgmaxArgmin(const Call& call, const BlockBuilder& ctx
   const auto* data_shape = data_sinfo->shape.as<ShapeExprNode>();
   if (data_shape == nullptr) {
     if (!attrs->axis.defined() && attrs->keepdims && out_ndim != kUnknownNDim) {
-      if (data_sinfo->vdevice.defined()) {
-        return TensorStructInfo(
-            ShapeExpr(Array<PrimExpr>(out_ndim, IntImm(out_dtype, /*value=*/1))), out_dtype,
-            data_sinfo->vdevice.value());
-      }
       return TensorStructInfo(ShapeExpr(Array<PrimExpr>(out_ndim, IntImm(out_dtype, /*value=*/1))),
-                              out_dtype);
+                              out_dtype, data_sinfo->vdevice);
     } else {
-      if (data_sinfo->vdevice.defined()) {
-        return out_ndim == 0 ? TensorStructInfo(ShapeExpr(Array<PrimExpr>()), out_dtype,
-                                                data_sinfo->vdevice.value())
-                             : TensorStructInfo(out_dtype, out_ndim, data_sinfo->vdevice.value());
-      }
-      return out_ndim == 0 ? TensorStructInfo(ShapeExpr(Array<PrimExpr>()), out_dtype)
-                           : TensorStructInfo(out_dtype, out_ndim);
+      return out_ndim == 0
+                 ? TensorStructInfo(ShapeExpr(Array<PrimExpr>()), out_dtype, data_sinfo->vdevice)
+                 : TensorStructInfo(out_dtype, out_ndim, data_sinfo->vdevice);
     }
   }
 
@@ -193,10 +184,7 @@ StructInfo InferStructInfoArgmaxArgmin(const Call& call, const BlockBuilder& ctx
     }
   }
   ICHECK_EQ(static_cast<int>(out_shape.size()), out_ndim);
-  if (data_sinfo->vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(out_shape), out_dtype, data_sinfo->vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(out_shape), out_dtype);
+  return TensorStructInfo(ShapeExpr(out_shape), out_dtype, data_sinfo->vdevice);
 }
 
 #define RELAX_REGISTER_ARGMAX_ARGMIN_OP(OpName)                                    \

--- a/src/relax/op/tensor/set.cc
+++ b/src/relax/op/tensor/set.cc
@@ -86,45 +86,22 @@ StructInfo InferStructInfoUnique(const Call& call, const BlockBuilder& ctx) {
 
   // unique values
   if (data_sinfo->ndim == 0) {
-    if (data_sinfo->vdevice.defined()) {
-      output_sinfo.push_back(TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}),
-                                              data_sinfo->dtype, data_sinfo->vdevice.value()));
-    } else {
-      output_sinfo.push_back(
-          TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}), data_sinfo->dtype));
-    }
+    output_sinfo.push_back(TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}),
+                                            data_sinfo->dtype, data_sinfo->vdevice));
   } else if (axis.defined()) {
-    if (data_sinfo->vdevice.defined()) {
-      output_sinfo.push_back(
-          TensorStructInfo(data_sinfo->dtype, data_sinfo->ndim, data_sinfo->vdevice.value()));
-    } else {
-      output_sinfo.push_back(TensorStructInfo(data_sinfo->dtype, data_sinfo->ndim));
-    }
+    output_sinfo.push_back(
+        TensorStructInfo(data_sinfo->dtype, data_sinfo->ndim, data_sinfo->vdevice));
   } else {
-    if (data_sinfo->vdevice.defined()) {
-      output_sinfo.push_back(
-          TensorStructInfo(data_sinfo->dtype, /*ndim=*/1, data_sinfo->vdevice.value()));
-    } else {
-      output_sinfo.push_back(TensorStructInfo(data_sinfo->dtype, /*ndim=*/1));
-    }
+    output_sinfo.push_back(TensorStructInfo(data_sinfo->dtype, /*ndim=*/1, data_sinfo->vdevice));
   }
 
   // index, reverse and counts
   TensorStructInfo int_return{nullptr};
   if (data_sinfo->ndim == 0) {
-    if (data_sinfo->vdevice.defined()) {
-      int_return = TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}),
-                                    DataType::Int(64), data_sinfo->vdevice.value());
-    } else {
-      int_return =
-          TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}), DataType::Int(64));
-    }
+    int_return = TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}),
+                                  DataType::Int(64), data_sinfo->vdevice);
   } else {
-    if (data_sinfo->vdevice.defined()) {
-      int_return = TensorStructInfo(DataType::Int(64), /*ndim=*/1, data_sinfo->vdevice.value());
-    } else {
-      int_return = TensorStructInfo(DataType::Int(64), /*ndim=*/1);
-    }
+    int_return = TensorStructInfo(DataType::Int(64), /*ndim=*/1, data_sinfo->vdevice);
   }
   for (int i = 0; i < n_int_return; ++i) {
     output_sinfo.push_back(int_return);

--- a/src/relax/op/tensor/statistical.cc
+++ b/src/relax/op/tensor/statistical.cc
@@ -61,23 +61,13 @@ StructInfo InferStructInfoStatistical(const Call& call, const BlockBuilder& ctx)
   const auto* data_shape = data_sinfo->shape.as<ShapeExprNode>();
   if (data_shape == nullptr) {
     if (!attrs->axis.defined() && attrs->keepdims && out_ndim != kUnknownNDim) {
-      if (data_sinfo->vdevice.defined()) {
-        return TensorStructInfo(
-            ShapeExpr(Array<PrimExpr>(out_ndim, IntImm(DataType::Int(64), /*value=*/1))),
-            data_sinfo->dtype, data_sinfo->vdevice.value());
-      }
       return TensorStructInfo(
           ShapeExpr(Array<PrimExpr>(out_ndim, IntImm(DataType::Int(64), /*value=*/1))),
-          data_sinfo->dtype);
+          data_sinfo->dtype, data_sinfo->vdevice);
     } else {
-      if (data_sinfo->vdevice.defined()) {
-        return out_ndim == 0
-                   ? TensorStructInfo(ShapeExpr(Array<PrimExpr>()), data_sinfo->dtype,
-                                      data_sinfo->vdevice.value())
-                   : TensorStructInfo(data_sinfo->dtype, out_ndim, data_sinfo->vdevice.value());
-      }
-      return out_ndim == 0 ? TensorStructInfo(ShapeExpr(Array<PrimExpr>()), data_sinfo->dtype)
-                           : TensorStructInfo(data_sinfo->dtype, out_ndim);
+      return out_ndim == 0 ? TensorStructInfo(ShapeExpr(Array<PrimExpr>()), data_sinfo->dtype,
+                                              data_sinfo->vdevice)
+                           : TensorStructInfo(data_sinfo->dtype, out_ndim, data_sinfo->vdevice);
     }
   }
 
@@ -91,10 +81,7 @@ StructInfo InferStructInfoStatistical(const Call& call, const BlockBuilder& ctx)
     }
   }
   ICHECK_EQ(static_cast<int>(out_shape.size()), out_ndim);
-  if (data_sinfo->vdevice.defined()) {
-    return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice.value());
-  }
-  return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype);
+  return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice);
 }
 
 InferLayoutOutput InferLayoutStatistical(const Call& call,
@@ -172,33 +159,21 @@ StructInfo InferStructInfoCumsum(const Call& call, const BlockBuilder& ctx) {
     // flattened
     const auto* data_shape = data_sinfo->shape.as<ShapeExprNode>();
     if (data_shape == nullptr) {
-      if (data_sinfo->vdevice.defined()) {
-        return TensorStructInfo(out_type, data_sinfo->ndim, data_sinfo->vdevice.value());
-      }
-      return TensorStructInfo(out_type, data_sinfo->ndim);
+      return TensorStructInfo(out_type, data_sinfo->ndim, data_sinfo->vdevice);
     } else {
       PrimExpr flattened_d = 1;
       for (const auto v : data_shape->values) {
         flattened_d *= v;
       }
-      if (data_sinfo->vdevice.defined()) {
-        return TensorStructInfo(ShapeExpr(Array<PrimExpr>({flattened_d})), out_type,
-                                data_sinfo->vdevice.value());
-      }
-      return TensorStructInfo(ShapeExpr(Array<PrimExpr>({flattened_d})), out_type);
+      return TensorStructInfo(ShapeExpr(Array<PrimExpr>({flattened_d})), out_type,
+                              data_sinfo->vdevice);
     }
   }
 
   if (data_sinfo->shape.defined()) {
-    if (data_sinfo->vdevice.defined()) {
-      return TensorStructInfo(data_sinfo->shape.value(), out_type, data_sinfo->vdevice.value());
-    }
-    return TensorStructInfo(data_sinfo->shape.value(), out_type);
+    return TensorStructInfo(data_sinfo->shape.value(), out_type, data_sinfo->vdevice);
   } else {
-    if (data_sinfo->vdevice.defined()) {
-      return TensorStructInfo(out_type, data_sinfo->ndim, data_sinfo->vdevice.value());
-    }
-    return TensorStructInfo(out_type, data_sinfo->ndim);
+    return TensorStructInfo(out_type, data_sinfo->ndim, data_sinfo->vdevice);
   }
 }
 


### PR DESCRIPTION
Prior to this commit, the `TensorStructInfo` constructor took as input a `VDevice`, with a default value of `VDevice()`, and then assigned it to a member of type `Optional<VDevice>`.  This commit changes the constructor signature to match the member type, which will remove unnecessary type conversions when copying a `TensorStructInfo`.