### PR TITLE
[ONNX][Frontend] Fix ONNX version comparison in test_forward

### DIFF
--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -37,7 +37,7 @@ from tvm import relay
 from tvm.contrib import graph_executor, utils
 from tvm.relay.frontend.common import infer_type
 from tvm.relay.build_module import bind_params_by_name
-from relay.utils.tag_span import _create_span, _set_span, _verify_structural_equal_with_span
+#from relay.utils.tag_span import _create_span, _set_span, _verify_structural_equal_with_span
 
 import onnx
 import onnxruntime.backend
@@ -321,8 +321,8 @@ def make_constant_node(name, data_type, dims, vals):
 
 
 def is_version_greater_than(ver):
-    return "".join(re.findall(r"(\d+\.)(\d+\.)(\d)", onnx.__version__)[0]) > "".join(
-        re.findall(r"(\d+\.)(\d+\.)(\d)", ver)[0]
+    return tuple(map(int, re.match(r"(\d+)\.(\d+)\.(\d+)", onnx.__version__).groups())) > tuple(
+        map(int, re.match(r"(\d+)\.(\d+)\.(\d+)", ver).groups())
     )
 
 

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -37,7 +37,7 @@ from tvm import relay
 from tvm.contrib import graph_executor, utils
 from tvm.relay.frontend.common import infer_type
 from tvm.relay.build_module import bind_params_by_name
-#from relay.utils.tag_span import _create_span, _set_span, _verify_structural_equal_with_span
+from relay.utils.tag_span import _create_span, _set_span, _verify_structural_equal_with_span
 
 import onnx
 import onnxruntime.backend


### PR DESCRIPTION
Fixes the issue in ONNX test_forward.py. The function is_greater_than produces wrong results for certain values. The difference between old and new version is illustrated below.
```
import re
def old_is_version_greater_than(ver1, ver2):
    return "".join(re.findall(r"(\d+\.)(\d+\.)(\d)", ver1)[0]) > "".join(
        re.findall(r"(\d+\.)(\d+\.)(\d)", ver2)[0]
    )

def new_is_version_greater_than(ver1, ver2):
    return tuple(map(int, re.match(r"(\d+)\.(\d+)\.(\d+)", ver1).groups())) > tuple(
        map(int, re.match(r"(\d+)\.(\d+)\.(\d+)", ver2).groups())
    )
    
ver1 = "1.12.0"
ver2 = "1.7.0"

#ver1 is greater than ver2

print(old_is_version_greater_than(ver1,ver2)) #False

print(new_is_version_greater_than(ver1,ver2)) #True 
```