### PR TITLE
[TVMScript] Update evaluator.py to set default slice value

### DIFF
--- a/python/tvm/script/parser/core/evaluator.py
+++ b/python/tvm/script/parser/core/evaluator.py
@@ -387,9 +387,9 @@ class ExprEvaluator:
         """
         lower, upper, step = fields["lower"], fields["upper"], fields["step"]
 
-        lower = self._eval_expr(lower) if lower is not None else None
-        upper = self._eval_expr(upper) if upper is not None else None
-        step = self._eval_expr(step) if step is not None else None
+        lower = self._eval_expr(lower) if lower is not None else 0
+        upper = self._eval_expr(upper) if upper is not None else 0
+        step = self._eval_expr(step) if step is not None else 1
 
         return slice(lower, upper, step)
 


### PR DESCRIPTION
set default slice value 
- lower=0 if None
- upper=0 if None
- step=1 if None

before this commit, this code will raise error `TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'
```
@T.prim_func
def func(A: T.handle):
    a = T.match_buffer(A, shape=(16,))
    va = a[:16]
    a[:16] = va
```
detail error info is
```
/tvm/python/tvm/script/parser/tir/parser.py in visit_assign(self, node)
    259             indices = self.eval_expr(lhs.slice)
--> 260         T.buffer_store(self.eval_expr(lhs.value), rhs, indices)

/tvm/python/tvm/script/ir_builder/tir/ir.py in buffer_store(buffer, value, indices)
   1286             step = 1 if index.step is None else index.step
-> 1287             lanes = Analyzer().simplify((index.stop - index.start + step - 1) // step)
```
 parser for `a[:16]=va` wil get the indice with stop and step None, thus raise error at line 1287 of script/ir_builder/tir/ir.py

this commit will set the default slice value when execute ` indices = self.eval_expr(lhs.slice)`