### PR TITLE
[Unity] Support out dtype for nn.Linear and nn.MultiLinear

### DIFF
--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -132,7 +132,7 @@ class Linear(Module):
         self.out_dtype = out_dtype
         self.weight = Parameter((out_features, in_features), dtype)
         if bias:
-            self.bias = Parameter((out_features,), dtype)
+            self.bias = Parameter((out_features,), dtype=dtype if out_dtype is None else out_dtype)
         else:
             self.bias = None
 
@@ -158,6 +158,18 @@ class Linear(Module):
         if self.bias is not None:
             x = x + self.bias
         return x
+
+    def to(self, dtype: Optional[str] = None) -> None:
+        """
+        Override to() such that we do not convert bias if there is `out_dtype`.
+        Otherwise, we might run into dtype mismatch when computing `x + self.bias`
+        since x is of type `out_dtype` and bias may become `dtype`.
+        """
+        self.weight.to(dtype=dtype)
+        if self.bias is not None and self.out_dtype is None:
+            self.bias.to(dtype=dtype)
+        if dtype is not None and isinstance(getattr(self, "dtype", None), str):
+            self.dtype = dtype  # pylint: disable=attribute-defined-outside-init
 
 
 class MultiLinear(Module):

--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -163,7 +163,7 @@ class Linear(Module):
         """
         Override to() such that we do not convert bias if there is `out_dtype`.
         Otherwise, we might run into dtype mismatch when computing `x + self.bias`
-        since x is of type `out_dtype` and bias may become `dtype`.
+        since x is of type `out_dtype` and bias becomes `dtype`, potentially different.
         """
         self.weight.to(dtype=dtype)
         if self.bias is not None and self.out_dtype is None:
@@ -227,7 +227,7 @@ class MultiLinear(Module):
         """
         Override to() such that we do not convert bias if there is `out_dtype`.
         Otherwise, we might run into dtype mismatch when computing `x + self.bias`
-        since x is of type `out_dtype` and bias may become `dtype`.
+        since x is of type `out_dtype` and bias becomes `dtype`, potentially different.
         """
         self.weight.to(dtype=dtype)
         if self.bias is not None and self.out_dtype is None:


### PR DESCRIPTION
This is motivated by supporting models like GPTNeoX that have the field `ffn_out_dtype` in config, making us set it as `out_dtype`.

After the `matmul`, `x` would have type `out_dtype` (`x = op.matmul(x, w, out_dtype=self.out_dtype`).

When `bias=True`, we want `bias` to be of type `out_dtype`, even if we call `to()`; otherwise, we may have a type mismatch when computing `x + self.bias`.

Same idea applies for `nn.MultiLinear`.