### PR TITLE
remove deprecated np.int in slice converter (pytorch)

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -448,9 +448,7 @@ class PyTorchOpConverter:
         target_begin, is_begin_const = try_infer_value(
             inputs[2], lambda ret: ret.astype(int).item(0)
         )
-        target_end, is_end_const = try_infer_value(
-            inputs[3], lambda ret: ret.astype(int).item(0)
-        )
+        target_end, is_end_const = try_infer_value(inputs[3], lambda ret: ret.astype(int).item(0))
 
         # A fast path when slicing is nop.
         if (

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -446,10 +446,10 @@ class PyTorchOpConverter:
         stride = inputs[4]
 
         target_begin, is_begin_const = try_infer_value(
-            inputs[2], lambda ret: ret.astype(np.int).item(0)
+            inputs[2], lambda ret: ret.astype(int).item(0)
         )
         target_end, is_end_const = try_infer_value(
-            inputs[3], lambda ret: ret.astype(np.int).item(0)
+            inputs[3], lambda ret: ret.astype(int).item(0)
         )
 
         # A fast path when slicing is nop.


### PR DESCRIPTION
By numpy, usage of `np.int` has been deprecated in [1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).

This patch fixes from `np.int` to `int` in pytorch slice converter, makes it compatible with brand-new numpy.