### PR TITLE
[Unity] Fix IndexDataTypeNormalizer so that it correctly handles corner case

### DIFF
--- a/include/tvm/tir/data_type_rewriter.h
+++ b/include/tvm/tir/data_type_rewriter.h
@@ -157,6 +157,9 @@ class IndexDataTypeNormalizer : public IndexDataTypeRewriter {
   virtual bool CanRewriteDType(DataType dtype) const;
 
   DataType target_data_type_ = DataType::Int(64);
+
+ private:
+  int iter_ = 0;
 };
 
 }  // namespace tir

--- a/include/tvm/tir/data_type_rewriter.h
+++ b/include/tvm/tir/data_type_rewriter.h
@@ -84,6 +84,8 @@ class DataTypeLegalizer : public StmtExprMutator {
   std::unordered_map<const IterVarNode*, IterVar> ivmap_;
   // a map from original vars to ones with new dtype
   std::unordered_map<const VarNode*, Var> var_remap_;
+  // number of iterations. The first iteration collects var_remap_,
+  // and the second iteration performs rewrite
   int iter_ = 0;
 };
 

--- a/include/tvm/tir/data_type_rewriter.h
+++ b/include/tvm/tir/data_type_rewriter.h
@@ -84,6 +84,7 @@ class DataTypeLegalizer : public StmtExprMutator {
   std::unordered_map<const IterVarNode*, IterVar> ivmap_;
   // a map from original vars to ones with new dtype
   std::unordered_map<const VarNode*, Var> var_remap_;
+  int iter_ = 0;
 };
 
 /*!
@@ -157,9 +158,6 @@ class IndexDataTypeNormalizer : public IndexDataTypeRewriter {
   virtual bool CanRewriteDType(DataType dtype) const;
 
   DataType target_data_type_ = DataType::Int(64);
-
- private:
-  int iter_ = 0;
 };
 
 }  // namespace tir

--- a/src/tir/ir/data_type_rewriter.cc
+++ b/src/tir/ir/data_type_rewriter.cc
@@ -618,10 +618,15 @@ PrimExpr IndexDataTypeNormalizer::VisitExpr_(const IntImmNode* op) {
 }
 
 PrimExpr IndexDataTypeNormalizer::VisitExpr_(const VarNode* op) {
-  if (is_enabled_ && CanRewriteDType(op->dtype) && op->dtype != target_data_type_ &&
-      !var_remap_.count(op)) {
-    var_remap_[op] = GetRef<Var>(op).copy_with_dtype(target_data_type_);
+  // In the first iteration, collect var_remap_
+  if (iter_ == 0) {
+    if (is_enabled_ && CanRewriteDType(op->dtype) && op->dtype != target_data_type_ &&
+        !var_remap_.count(op)) {
+      var_remap_[op] = GetRef<Var>(op).copy_with_dtype(target_data_type_);
+    }
+    return GetRef<Var>(op);
   }
+  // In the second iteration, rewrite the var
   return DataTypeLegalizer::VisitExpr_(op);
 }
 


### PR DESCRIPTION
There is a corner case: A[i] = i for IndexDataTypeNormalizer. In current implementation, the var in buffer index will be rewritten, but the var in BufferStore value will not, which cases a conflict and produces free var. I change it to two iterations: the first collects var_remap_, and the second rewrites vars, so that in A[i] = i, both var will be rewritten.