### PR TITLE
[TIR] ConvertSSA process entry func first

### DIFF
--- a/src/tir/transforms/ir_utils.cc
+++ b/src/tir/transforms/ir_utils.cc
@@ -715,6 +715,8 @@ Pass ConvertSSA() {
     tir::IRConvertSSA converter;
     Map<GlobalVar, BaseFunc> functions;
     bool made_change = false;
+    // FIXME: This is just a temporal workaround to ensure free vars
+    // in device function have the same pointer as the host function
     for (auto [gvar, base_func] : mod->functions) {
       if (auto* ptr = base_func.as<tir::PrimFuncNode>()) {
         if (!ptr->HasNonzeroAttr(tir::attr::kIsEntryFunc)) {


### PR DESCRIPTION
ConvertSSA is called in SplitHostDevice. The vars which only exists in T.launch_thread extent in device function must be the same as host function, so we need to let ConvertSSA process host function first to avoid var redefine.