### PR TITLE
[Unity] Add runtime debugging method to RelaxVM

### DIFF
--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -22,8 +22,6 @@ import numpy as np
 
 from tvm import relax as rx
 from tvm import tir
-from tvm._ffi import register_func
-from tvm.runtime import NDArray
 
 from . import op
 from .core import Effect, Module, ModuleList, Parameter, Tensor, get_default_dtype
@@ -55,23 +53,6 @@ class IOEffect(Effect):
         result = self.effect
         self.effect = None
         return [result]
-
-    def print_(self, tensor: Tensor) -> None:
-        """Encloses the side effect of NDArray printing"""
-        self.effect = rx.BlockBuilder.current().emit(
-            rx.call_pure_packed(
-                rx.extern("effect.print"),
-                self.effect,
-                tensor._expr,  # pylint: disable=protected-access
-                sinfo_args=[rx.ObjectStructInfo()],
-            ),
-            name_hint=self.effect.name_hint,
-        )
-
-
-@register_func("effect.print")
-def _print(_, array: NDArray) -> None:
-    print(f"effect.print: shape = {array.shape}, dtype = {array.dtype}, data =\n{array}")
 
 
 class ReLU(Module):

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -17,6 +17,7 @@
 # pylint: disable=too-many-lines,invalid-name,protected-access,redefined-outer-name
 # pylint: disable=redefined-builtin
 """nn.Tensor operators."""
+import inspect
 import math
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -1491,7 +1492,73 @@ def tensor_expr_op(
     )
 
 
-def print_(array: Tensor):
+def debug_func(
+    name: str,
+    *args: Union[Tensor, _tir.PrimExpr, int, float, str],
+    _line_info: Optional[str] = None,
+):
+    """Call a debug function during runtime. The debug function must be registered with the
+    following type signature:
+
+    .. code-block:: python
+
+        @tvm.register_func(name_of_debug_func)
+        def debug_func(lineno: str, arg_0, arg_1, ...) -> None:
+            ...
+
+    Parameters
+    ----------
+    name : str
+        The name of the debug function to call.
+
+    *args : Union[Tensor, _tir.PrimExpr, int, float, str]
+        The arguments to pass to the debug function.
+    """
+    # pylint: disable=import-outside-toplevel
+    from tvm import relax as rx
+
+    from .modules import IOEffect
+
+    # pylint: enable=import-outside-toplevel
+
     if SpecBuilder.current().io_effect is None:
-        raise RuntimeError("Printing is only supported when debug mode is on.")
-    SpecBuilder.current().io_effect.print_(array)
+        raise RuntimeError("Debugging is only supported when debug mode is on.")
+    io: IOEffect = SpecBuilder.current().io_effect  # type: ignore
+
+    if _line_info is None:
+        filename, line_number = inspect.getframeinfo(inspect.currentframe().f_back)[:2]
+        _line_info = f"{filename}:{line_number}"
+
+    converted_args = []
+    for arg in args:
+        if isinstance(arg, Tensor):
+            converted_args.append(arg._expr)  # pylint: disable=protected-access
+        elif isinstance(arg, int):
+            converted_args.append(rx.PrimValue(_tir.IntImm("int64", arg)))
+        elif isinstance(arg, float):
+            converted_args.append(rx.PrimValue(_tir.FloatImm("float32", arg)))
+        elif isinstance(arg, _tir.PrimExpr):
+            converted_args.append(rx.PrimValue(arg))
+        elif isinstance(arg, str):
+            converted_args.append(rx.StringImm(arg))
+        else:
+            raise TypeError(f"Unsupported type {type(arg)}")
+
+    io.effect = BlockBuilder.current().emit(
+        rx.call_pure_packed(
+            "vm.builtin.invoke_debug_func",
+            io.effect,
+            rx.StringImm(name),
+            rx.StringImm(_line_info),
+            *converted_args,
+            sinfo_args=[rx.ObjectStructInfo()],
+        ),
+        name_hint=io.effect.name_hint,
+    )
+
+
+def print_(tensor: Tensor):
+    """Debug printing a Tensor during runtime."""
+    filename, line_number = inspect.getframeinfo(inspect.currentframe().f_back)[:2]
+    line_info = f"{filename}:{line_number}"
+    debug_func("vm.builtin.debug_print", tensor, _line_info=line_info)

--- a/python/tvm/runtime/relax_vm.py
+++ b/python/tvm/runtime/relax_vm.py
@@ -16,14 +16,15 @@
 # under the License.
 # pylint: disable=invalid-name, redefined-builtin, no-else-return, consider-using-dict-items
 """The Relax virtual machine."""
-from typing import Callable, List, Optional, Union, Dict, Tuple, Any
 from enum import IntEnum
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
 import numpy as np  # type: ignore
 
 import tvm
 from tvm._ffi import base as _base
-
-from tvm.runtime import Device, PackedFunc, Object
+from tvm._ffi import register_func
+from tvm.runtime import Device, Object, PackedFunc
 from tvm.runtime.profiling import Report
 
 from ..rpc.base import RPC_SESS_MASK
@@ -510,3 +511,8 @@ class VirtualMachine(object):
 
         report_json = self.module["profile"](func_name, *cargs)
         return Report.from_json(report_json)
+
+
+@register_func("vm.builtin.debug_print")
+def _print(lineo: str, array) -> None:
+    print(f"{lineo}: shape = {array.shape}, dtype = {array.dtype}, data =\n{array}")

--- a/tests/python/relax/test_frontend_nn_debug.py
+++ b/tests/python/relax/test_frontend_nn_debug.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=missing-docstring
+import torch
+
+import tvm
+import tvm.testing
+from tvm import tir
+from tvm.relax.frontend import nn
+from tvm.relax.frontend.nn import op, spec
+from tvm.runtime import NDArray
+
+
+def test_debug_print():
+    class Layer(nn.Module):
+        def forward(self, x: nn.Tensor):  # pylint: disable=invalid-name
+            op.print_(x)
+            return x
+
+    model = Layer().jit(
+        spec={
+            "forward": {"x": spec.Tensor([10, 5], dtype="float32")},
+        },
+        debug=True,
+    )
+    x = torch.rand((10, 5), dtype=torch.float32)  # pylint: disable=invalid-name
+    y = model["forward"](x)  # pylint: disable=invalid-name
+    assert isinstance(y, torch.Tensor)
+
+
+def test_debug_func():
+    @tvm.register_func("testing.relax.frontend.nn.test_debug_func")
+    def _debug(  # pylint: disable=too-many-arguments
+        lineno: str,
+        tensor: NDArray,
+        const_int: int,
+        const_float: float,
+        const_str: str,
+        var_int: int,
+    ) -> None:
+        assert "test_frontend_nn_debug.py" in lineno
+        assert tensor.shape == (10, 5)
+        assert const_int == 1
+        assert const_float == 2.0
+        assert const_str == "test"
+        assert var_int == 8
+
+    class Layer(nn.Module):
+        def forward(self, x: nn.Tensor, v: tir.Var):  # pylint: disable=invalid-name
+            op.debug_func("testing.relax.frontend.nn.test_debug_func", x, 1, 2.0, "test", v)
+            return x
+
+    model = Layer().jit(
+        spec={
+            "forward": {
+                "x": spec.Tensor([10, 5], dtype="float32"),
+                "v": "int",
+            },
+        },
+        debug=True,
+    )
+    x = torch.rand((10, 5), dtype=torch.float32)  # pylint: disable=invalid-name
+    y = model["forward"](x, 8)  # pylint: disable=invalid-name
+    assert isinstance(y, torch.Tensor)
+
+
+if __name__ == "__main__":
+    test_debug_print()
+    test_debug_func()

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -508,41 +508,5 @@ def test_tensor_expr_op():
     tvm.ir.assert_structural_equal(irmodule, Expected)
 
 
-def test_print():
-    class Model(Module):
-        def test(self, x: Tensor):
-            z = op.add(x, x)
-            op.print_(z)
-            return x
-
-    # fmt: off
-    @I.ir_module
-    class Expected:
-        @R.function
-        def _initialize_effect() -> R.Tuple(R.Object):
-            with R.dataflow():
-                _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
-                R.output(gv)
-            return gv
-
-        @R.function
-        def test(x: R.Tensor((10, 10), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tuple(R.Object)):
-            R.func_attr({"num_input": 2})
-            with R.dataflow():
-                add: R.Tensor((10, 10), dtype="float32") = R.add(x, x)
-                _io1: R.Object = R.call_pure_packed("effect.print", _io, add, sinfo_args=(R.Object(),))
-                gv1: R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tuple(R.Object)) = x, (_io1,)
-                R.output(gv1)
-            return gv1
-    # fmt: on
-
-    m = Model()
-    irmodule, _ = m.export_tvm(spec={"test": {"x": spec.Tensor([10, 10], "float32")}}, debug=True)
-
-    tvm.ir.assert_structural_equal(irmodule["test"], Expected["test"])
-
-
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This PR enhances `tvm.relax.frontend.nn.op.print_` that allows
one to call debugging methods registered in runtime.

Example:

```python
class Layer(nn.Module):
  def forward(self, x: nn.Tensor):
    op.print_(x)
    return x
```

During runtime, whenever this line is executed, it prints:

```
/workspace/main.py:36: shape = (10, 5), dtype = float32, data =
[[9.1025043e-01 5.6659997e-01 8.7828696e-01 5.5273587e-01 1.8565023e-01]
 [8.0204010e-04 5.5512893e-01 9.7184986e-01 3.2060379e-01 7.5654179e-01]
 [9.5829505e-01 7.7954692e-01 1.3110173e-01 3.7674886e-01 3.3243084e-01]
 [6.4045572e-01 7.4083984e-02 7.2492689e-01 4.4675517e-01 2.1010166e-01]
 [2.7612233e-01 5.7471478e-01 8.5393274e-01 9.1640389e-01 1.5394652e-01]
 [7.7940112e-01 2.3211378e-01 6.0200381e-01 5.9336245e-01 9.2999905e-01]
 [5.0383198e-01 3.3493429e-01 7.8850657e-01 8.7862432e-02 7.7355146e-01]
 [3.2209766e-01 5.7237232e-01 6.4327312e-01 6.4632124e-01 1.5809405e-01]
 [6.7456228e-01 9.3647403e-01 1.0043311e-01 3.3887738e-01 3.0455321e-01]
 [5.2549899e-02 5.5112422e-01 1.0987210e-01 9.8951626e-01 6.2626714e-01]]
```

A new method `op.debug_func(name="func_name_in_reigstry", *args)`
further extends this approach to supporting *arbitrary* debug functions
during runtime. Besides giving runtime values corresponding to its compile-time
arguments passed in by users, it further gives an additional argument `lineno`
which reflects the filename and line number of the compile-time call site.

As an example, the code below

```python
@tvm.register_func("my_test")
def _debug(lineno: str, tensor, int_var) -> None:
  ...

class Layer(nn.Module):
  def forward(self, x: nn.Tensor, v: tir.Var):  # pylint: disable=invalid-name
    op.debug_func("my_test", x, v)
    return x
```

finds the Python function registered as `my_test` during runtime, and
will invoke it with the runtime value of a tensor and a TIR scalar variable.
See `tests/python/relax/test_frontend_nn_debug.py` for more details.