### PR TITLE
[TFLite] Add support for quantized mirror pad

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -2677,12 +2677,6 @@ class OperatorConverter(object):
         except ImportError:
             raise ImportError("The tflite package must be installed")
 
-        # the quantized form MirrorPad is not yet implemented in TFLite.
-        if self.is_quantized(op):
-            raise tvm.error.OpNotImplemented(
-                "TFlite quantized MIRROR_PAD operator is not supported yet."
-            )
-
         input_tensors = self.get_input_tensors(op)
         assert len(input_tensors) == 2, "input tensors length should be 2"
 

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -3436,7 +3436,13 @@ def _test_pad(data, mode="CONSTANT", quantized=False):
                 inq_data[0], ops.convert_to_tensor(data[1], dtype=data[1].dtype), mode=mode
             )
             compare_tflite_with_tvm(
-                [data[0]], ["inq_0:0"], inq_data, [out], quantized=True, input_range=input_range
+                [data[0]],
+                ["inq_0:0"],
+                inq_data,
+                [out],
+                quantized=True,
+                input_range=input_range,
+                experimental_new_converter=True,
             )
         else:
             out = array_ops.pad(
@@ -3505,6 +3511,22 @@ def test_forward_pad():
             np.array([[1, 1], [2, 2]], dtype=np.int32),
         ],
         quantized=True,
+    )
+    _test_pad(
+        [
+            np.arange(0, 256, dtype=np.uint8).reshape((1, 256)),
+            np.array([[1, 1], [2, 2]], dtype=np.int32),
+        ],
+        quantized=True,
+        mode="SYMMETRIC",
+    )
+    _test_pad(
+        [
+            np.arange(0, 256, dtype=np.uint8).reshape((1, 256)),
+            np.array([[0, 0], [2, 2]], dtype=np.int32),
+        ],
+        quantized=True,
+        mode="REFLECT",
     )
 
 


### PR DESCRIPTION
Removes the restriction on converting quantized mirror pad in the front-end and adds tests to support this change.

cc @leandron @neildhickey 