### PR TITLE
[Unity][nn.Module] Refactor `ExternModule`

### DIFF
--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -82,7 +82,7 @@ def create_shared(output, objects, options=None, cc=None, cwd=None, ccache_env=N
         The compiler command.
 
     cwd : Optional[str]
-        The urrent working directory.
+        The current working directory.
 
     ccache_env : Optional[Dict[str, str]]
         The environment variable for ccache. Set `None` to disable ccache by default.

--- a/python/tvm/relax/frontend/nn/__init__.py
+++ b/python/tvm/relax/frontend/nn/__init__.py
@@ -17,15 +17,9 @@
 """A PyTorch-like API to build IRModules."""
 # pylint: disable=redefined-builtin
 from . import op, spec
-from .core import (
-    Effect,
-    ExternModule,
-    Module,
-    ModuleList,
-    Parameter,
-    SourceModule,
-    Tensor,
-)
+from .core import Effect, Module, ModuleList, Parameter, Tensor
+from .exporter import add_extern
+from .extern import ExternModule, ObjectModule, SourceModule
 from .modules import (
     GELU,
     Conv1D,
@@ -35,7 +29,6 @@ from .modules import (
     KVCache,
     LayerNorm,
     Linear,
-    MultiLinear,
     ReLU,
     RMSNorm,
     SiLU,

--- a/python/tvm/relax/frontend/nn/exporter.py
+++ b/python/tvm/relax/frontend/nn/exporter.py
@@ -1,0 +1,314 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Export `nn.Module` to TVM's IRModule."""
+import threading
+import typing
+
+from tvm import tir
+from tvm.ir import IRModule
+
+from ... import expr as rx
+from ...block_builder import BlockBuilder
+from ...struct_info import ShapeStructInfo, TupleStructInfo
+from . import core, extern
+from . import spec as _spec
+from .modules import IOEffect
+
+
+def add_extern(mod: extern.ExternModule) -> None:
+    """Add an external module to the exporter."""
+    try:
+        exporter = Exporter.current()
+    except Exception as exception:
+        raise RuntimeError(
+            "`nn.add_extern` should only be invoked when exporting a module."
+        ) from exception
+    exporter.add_external_module(mod)
+
+
+class Exporter:
+    """Builder of ModuleSpec, which exports an nn.Module to TVM IRModule."""
+
+    _tls = threading.local()
+
+    builder: BlockBuilder
+    io_effect: core.Effect
+    extern_mods: typing.List[extern.ExternModule]
+
+    def __init__(self, debug: bool) -> None:
+        self.builder = BlockBuilder()
+        self.io_effect = IOEffect() if debug else None
+        self.extern_mods = []
+
+    @staticmethod
+    def current() -> "Exporter":
+        """Get the current Exporter under the with scope."""
+        assert hasattr(Exporter._tls, "current")
+        return Exporter._tls.current
+
+    def __enter__(self) -> "Exporter":
+        assert not hasattr(Exporter._tls, "current")
+        Exporter._tls.current = self
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        assert hasattr(Exporter._tls, "current")
+        delattr(Exporter._tls, "current")
+
+    def add_external_module(self, mod: extern.ExternModule) -> None:
+        """Add an external module to the exporter."""
+        # pylint: disable=protected-access
+        all_symbols: typing.List[str] = []
+        for extern_mod in self.extern_mods:
+            all_symbols.extend(extern_mod._symbols.keys())
+        duplicated_symbols = list(set(mod._symbols.keys()) & set(all_symbols))
+        # pylint: enable=protected-access
+        if duplicated_symbols:
+            raise ValueError(f"Duplicate symbols: {duplicated_symbols}")
+        self.extern_mods.append(mod)
+
+    def build(  # pylint: disable=too-many-locals
+        self,
+        spec: _spec.ModuleSpec,
+    ) -> typing.Tuple[
+        IRModule,
+        typing.List[typing.Tuple[str, core.Parameter]],
+        typing.List[extern.ExternModule],
+    ]:
+        """Build the ModuleSpec to TVM IRModule. Returns the IRModule and the parameters."""
+
+        # pylint: disable=protected-access
+        def _params() -> typing.List[typing.Tuple[str, core.Parameter]]:
+            params = []
+            for name, param in core._attribute_finder(
+                spec.module, prefix="", condition_yield=lambda x: isinstance(x, core.Parameter)
+            ):
+                params.append((name, param))
+            return params
+
+        def _effects() -> typing.List[typing.Tuple[str, core.Effect]]:
+            result = []
+            if self.io_effect is not None:
+                result.append(("", self.io_effect))
+            for name, effect in core._attribute_finder(
+                spec.module, "", condition_yield=lambda x: isinstance(x, core.Effect)
+            ):
+                result.append((name, effect))
+            return result
+
+        # pylint: enable=protected-access
+
+        params = _params()
+        effects = _effects()
+        ext_mods = self.extern_mods
+        with self:
+            if effects:
+                with self.builder.function("_initialize_effect"):
+                    with self.builder.dataflow():
+                        outputs = _emit_effect_init(self.builder, effects)
+                    self.builder.emit_func_output(outputs, params=[])
+            for method_name, method_spec in zip(spec.method_names, spec.method_specs):
+                len_args = len(method_spec.arg_specs)
+                len_effects = {
+                    "packed": 1,
+                    "none": 0,
+                    "plain": len(effects),
+                }[method_spec.effect_mode]
+                with self.builder.function(
+                    method_name,
+                    attrs={"num_input": len_args + len_effects},  # type: ignore
+                ):
+                    with self.builder.dataflow():
+                        outputs, inputs = _emit_method(self.builder, method_spec, params, effects)
+                    self.builder.emit_func_output(outputs, inputs)
+        mod = self.builder.finalize()
+        return mod, params, ext_mods
+
+
+def _emit_effect_init(
+    builder: BlockBuilder,
+    effects: typing.List[typing.Tuple[str, core.Effect]],
+):
+    outputs = []
+    for prefix, effect in effects:
+        inits = effect.emit_init(prefix, builder)
+        assert isinstance(inits, list)
+        outputs.extend(inits)
+    outputs = builder.emit_output(builder.emit(rx.Tuple(outputs)))
+    return outputs
+
+
+def _emit_method(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    builder: BlockBuilder,
+    spec: _spec.MethodSpec,
+    params: typing.List[typing.Tuple[str, core.Parameter]],
+    effects: typing.Optional[typing.List[typing.Tuple[str, core.Effect]]],
+):
+    # pylint: disable=protected-access
+    def _unwrap_ret(expr: typing.Any) -> typing.Any:
+        if isinstance(expr, core.Tensor):
+            return expr._expr
+        if isinstance(expr, tuple):
+            return rx.Tuple([_unwrap_ret(x) for x in expr])
+        if isinstance(expr, list):
+            return rx.Tuple([_unwrap_ret(x) for x in expr])
+        raise TypeError(f"Unsupported return type: {type(expr)}")
+
+    def _convert_input(arg):
+        if isinstance(arg, tir.Var):
+            return rx.Var(arg.name, struct_info=ShapeStructInfo(values=[arg]))
+        if isinstance(arg, core.Tensor):
+            return arg._expr  # pylint: disable=protected-access
+        if isinstance(arg, _spec.Tuple):
+            return rx.Var(
+                arg.name,
+                struct_info=TupleStructInfo(
+                    [_convert_input(arg_i).struct_info for arg_i in arg.elements]
+                ),
+            )
+        raise TypeError(f"Unsupported input type: {type(arg)}")
+
+    def _params(mode: str) -> typing.List[rx.Var]:
+        inputs: typing.List[rx.Var] = []
+        for name, param in params:
+            var = core.Tensor.placeholder(param.shape, param.dtype, name)._expr
+            inputs.append(var)
+            param._expr = var
+        if mode == "none":
+            return []
+        if mode == "plain":
+            return inputs
+        if mode == "packed":
+            input_var = rx.Var(
+                "packed_params",
+                TupleStructInfo(fields=[x.struct_info for x in inputs]),
+            )
+            for i, (name, param) in enumerate(params):
+                param._expr = builder.emit(rx.TupleGetItem(input_var, i), name_hint=name)
+            return [input_var]
+        raise ValueError(f"Invalid param_mode: {mode}")
+
+    def _effects(mode: str) -> typing.List[rx.Var]:
+        unflat_inputs: typing.List[typing.List[rx.Var]] = []
+        for name, effect in effects:
+            effect_input = effect.create(name)
+            effect.set_state(effect_input)
+            unflat_inputs.append(effect_input)
+        inputs: typing.List[rx.Var] = sum(unflat_inputs, [])
+        if mode == "none":
+            return []
+        if mode == "plain":
+            return inputs
+        if mode == "packed":
+            input_var = rx.Var(
+                "packed_effects",
+                TupleStructInfo(fields=[x.struct_info for x in inputs]),
+            )
+            i = 0
+            for effect_input, (_, effect) in zip(unflat_inputs, effects):
+                updated_effect_input = []
+                for effect_input_i in effect_input:
+                    updated_effect_input.append(
+                        builder.emit(
+                            rx.TupleGetItem(input_var, i),
+                            name_hint=effect_input_i.name_hint,
+                        )
+                    )
+                    i += 1
+                effect.set_state(updated_effect_input)
+            return [input_var]
+
+        raise ValueError(f"Invalid effect_mode: {mode}")
+
+    # pylint: enable=protected-access
+
+    def _detuple(arg, var: rx.Var, builder: BlockBuilder):
+        if isinstance(arg, _spec.Tuple):
+            ret = []
+            for i, elem in enumerate(arg.elements):
+                field = builder.emit(rx.TupleGetItem(var, i), name_hint=f"{arg.name}_{i}")
+                ret.append(_detuple(elem, field, builder))
+            return type(arg.elements)(ret)
+        if isinstance(arg, core.Tensor):
+            return core.Tensor(_expr=var)
+        if isinstance(arg, tir.Var):
+            return arg
+        raise TypeError(f"Unsupported input type: {type(arg)}")
+
+    # TODO(@junrushao): Warn if params/effects are used when their mode is "none"
+    explicit_inputs = _method_spec_to_inputs(spec)
+    inputs = [_convert_input(x) for x in explicit_inputs]
+    inputs = inputs + _effects(spec.effect_mode)
+    inputs = inputs + _params(spec.param_mode)
+
+    for arg_idx, (arg, var) in enumerate(zip(explicit_inputs, inputs)):
+        if isinstance(arg, _spec.Tuple):
+            explicit_inputs[arg_idx] = _detuple(arg, var, builder)
+
+    outputs = spec.method(*explicit_inputs)
+    effect_outputs = []
+    for _, effect in effects:
+        effect_outputs.extend(effect.finalize())
+    if effect_outputs and spec.effect_mode != "none":
+        outputs = builder.emit_output(rx.Tuple([_unwrap_ret(outputs), rx.Tuple(effect_outputs)]))
+    else:
+        outputs = builder.emit_output(_unwrap_ret(outputs))
+    return outputs, inputs
+
+
+def _method_spec_to_inputs(
+    spec: _spec.MethodSpec,
+) -> typing.List[typing.Union[tir.Var, core.Tensor]]:
+    """Convert the MethodSpec to a list of inputs to Module's method."""
+    str2var: typing.Dict[str, tir.Var] = {}
+
+    def _get_var(name: str) -> tir.Var:
+        if name in str2var:
+            return str2var[name]
+        var = tir.Var(name, "int64")
+        str2var[name] = var
+        return var
+
+    def _convert_input(arg_name, arg_spec):
+        if isinstance(arg_spec, _spec.Int):
+            arg = _get_var(arg_name)
+        elif isinstance(arg_spec, _spec.Tensor):
+            arg = core.Tensor.placeholder(  # pylint: disable=protected-access
+                shape=[_get_var(x) if isinstance(x, str) else x for x in arg_spec.shape],
+                dtype=arg_spec.dtype,
+                name=arg_name,
+            )
+        elif isinstance(arg_spec, _spec.Tuple):
+            elements = type(arg_spec.elements)(
+                [
+                    _convert_input(arg_name=arg_name + f"_{i}", arg_spec=arg_spec.elements[i])
+                    for i in range(len(arg_spec.elements))
+                ]
+            )
+            arg = _spec.Tuple(
+                name=arg_name,
+                elements=elements,
+            )
+        else:
+            raise TypeError(f"Invalid spec for argument {arg_name}: {arg_spec}")
+        return arg
+
+    args = []
+    for arg_name, arg_spec in zip(spec.arg_names, spec.arg_specs):
+        arg = _convert_input(arg_name=arg_name, arg_spec=arg_spec)
+        args.append(arg)
+    return args

--- a/python/tvm/relax/frontend/nn/extern.py
+++ b/python/tvm/relax/frontend/nn/extern.py
@@ -1,0 +1,392 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""External modules to be linked into the exported IRModule."""
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Union
+
+from tvm import tir
+from tvm.contrib import cc as _cc
+from tvm.runtime import Module, load_static_library
+
+from ...op import call_dps_packed
+from . import core
+from .core import wrap_nested
+
+
+class ExternModule:
+    """The abstract base class for external modules. External modules are designed to help
+    incorporate user-provided handcrafted kernels into the exported TVM IRModule.
+    """
+
+    _symbols: Dict[str, Callable]
+
+    def __init__(self, symbols: Dict[str, Callable]) -> None:
+        self._symbols = symbols
+
+    def __getitem__(self, func_name: str) -> Callable:
+        _inference_function = self._symbols[func_name]
+
+        def _call(*input_args):
+            def _convert(arg, name: str):
+                from tvm import relax as rx  # pylint: disable=import-outside-toplevel
+
+                if isinstance(arg, core.Tensor):
+                    return arg._expr  # pylint: disable=protected-access
+                if isinstance(arg, int):
+                    return rx.PrimValue(tir.IntImm("int64", arg))
+                if isinstance(arg, float):
+                    return rx.PrimValue(tir.FloatImm("float64", arg))
+                if isinstance(arg, str):
+                    return rx.StringImm(arg)
+                if isinstance(arg, tir.PrimExpr):
+                    return rx.PrimValue(arg)
+                if isinstance(arg, (tuple, list)):
+                    return rx.Tuple([_convert(e, f"{name}_{i}") for i, e in enumerate(arg)])
+                raise TypeError(f"Unsupported input type: {type(arg)}")
+
+            rx_inputs = _convert(input_args, "input")
+            rx_outputs_sinfo = _convert(_inference_function(*input_args), "dummy").struct_info
+            return wrap_nested(call_dps_packed(func_name, rx_inputs, rx_outputs_sinfo), func_name)
+
+        return _call
+
+    def _load(self, path: Path) -> Module:
+        return load_static_library(str(path), func_names=list(self._symbols.keys()))
+
+    def load(self) -> Module:
+        """Loads the external module into a TVM runtime module."""
+        raise NotImplementedError
+
+
+class ObjectModule(ExternModule):  # pylint: disable=too-few-public-methods
+    """A subclass of `nn.ExternModule`, which allows
+    users to provide an object `.o` file to be linked into compiled
+    artifact;
+    """
+
+    def __init__(
+        self,
+        symbols: Dict[str, Callable],
+        filepath: Path,
+    ) -> None:
+        if not isinstance(filepath, Path):
+            filepath = Path(filepath)
+        if not filepath.is_file():
+            raise ValueError(f"Not a file: {str(filepath)}")
+        self.filepath = filepath
+        super().__init__(symbols)
+
+    def load(self) -> Module:
+        return self._load(self.filepath)
+
+
+class SourceModule(ExternModule):  # pylint: disable=too-few-public-methods
+    """A subclass of `nn.ExternModule`. It compiles C++/CUDA source code and link them into the
+    eventual IRModule.
+
+    **Shape/dtype inference.** The `nn.ExternModule` system requires users to provide additional
+    information to work, namely, `symbols`. It is a dictionary that maps each symbol in the
+    external object file to its shape/dtype inference function. Consider a case where function
+    `my_func` accepts two tensors, `a` of shape `(x, y, 1)`, and `b` of shape `(y, z, 5)`, and
+    produces a tensor `c` of shape `(x, y, z, 9)`, the shape/dtype inference function should look
+    like:
+
+    .. code-block:: python
+
+        def shape_dtype_inference(a, b):
+            x, y, _ = a.shape
+            _, z, _ = b.shape
+            return nn.Tensor.placeholder((x, y, z, 9), dtype="float32")
+
+
+    and the `symbols` dictionary should be provided as:
+
+    .. code-block:: python
+
+        symbols={
+            "my_func": shape_dtype_inference,
+        }
+
+
+    **Calling convention.** All external modules now follows "destination-passing-style" (DPS)
+    calling convention, which means the returned tensors are pre-allocated by the system already
+    and passed in as an argument of the external function.
+
+    Reuse the example above, the implementation of `my_func` should include three parameters in
+    its signature, where tensors are represented using DLTensor from DLPack, the de facto standard
+    of in-memory representation of tensors. More details:
+    https://github.com/dmlc/dlpack/blob/v0.8/include/dlpack/dlpack.h#L163-L206.
+
+    To expose the symbol, `TVM_DLL_EXPORT_TYPED_FUNC(symbol, function)` is guaranteed available:
+
+    .. code-block:: C++
+        // those headers are guaranteed to be available
+        #include <dlpack/dlpack.h>
+        #include <tvm/runtime/data_type.h>
+        #include <tvm/runtime/packed_func.h>
+
+        namespace {
+        // anonymous namespace hides the symbol `_my_func_impl` from other translation units
+        int _my_func_impl(DLTensor* a, DLTensor* b, DLTensor* c) {
+            // `a` and `b` are inputs, and `c` is the output
+        }
+        }
+        // expose symbol `my_func` instead of `_my_func_impl`
+        TVM_DLL_EXPORT_TYPED_FUNC(my_func, _my_func_impl);
+
+
+    **A compiler pass `AttachExternModules`.** It is introduced to attach a list of
+    `nn.ExternModule`s into an IRModule at any stage of the compilation pipeline,
+    and attach the compiled external modules as `runtime.Module`s into IRModule's `external_mods`
+    attribute. It is required by linking in `relax.build`, but with the existence of this pass,
+    source compilation can be deferred to arbitrary stage of TVM compilation.
+
+    **Caveats.** It is required to call `nn.add_extern` to register external modules exactly once
+    during `export_tvm`. Each symbol should be registered exactly once to avoid potential conflicts,
+    and otherwise an error will be raised.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        symbols: Dict[str, Callable],
+        source_code: Union[str, Path],
+        source_format: str,  # "cpp", "cu"
+        compile_options: Optional[List[str]] = None,
+        compiler: Optional[str] = None,
+        output_format: str = "obj",  # "obj", "wasm"
+    ):
+        """Constructs a `nn.SourceModule` from source code.
+
+        Parameters
+        ----------
+        symbols : Dict[str, Callable]
+            The dictionary that maps each symbol in the external object file to its shape/dtype
+            inference function.
+
+        source_code : Union[str, Path]
+            Source code or path to the source code to be compiled.
+
+        source_format : str
+            The source code format. It can be either "cpp" or "cu".
+
+        compile_options : Optional[List[str]]
+            The compile options. If not provided, the default compile options will be used.
+
+        compiler : Optional[str]
+            The compiler. If not provided, the default compiler will be used. On Windows,
+            compilation requires `clang` by default.
+
+        output_format : str
+            The output format. It can be either "obj" or "wasm". "obj" is the default format,
+            which is a shared object file. "wasm" is the WebAssembly format, which is a binary
+            file.
+        """
+
+        def _detect_input_suffix(source_format: str) -> str:
+            if source_format == "cpp":
+                return ".cpp"
+            if source_format == "cu":
+                return ".cu"
+            raise ValueError(f"Invalid source format: {source_format}")
+
+        def _detect_output_suffix(output_format: str) -> str:
+            if output_format == "obj":
+                if _cc._is_linux_like():  # pylint: disable=protected-access
+                    return ".o"
+                if _cc._is_windows_like():  # pylint: disable=protected-access
+                    return ".obj"
+                raise ValueError(f"Unsupported platform: {sys.platform}")
+            if output_format == "wasm":
+                return ".wasm"
+            raise ValueError(f"Invalid output format: {output_format}")
+
+        def _detect_source_code(source_code) -> str:
+            if isinstance(source_code, Path):
+                path = source_code
+                if not path.is_file():
+                    raise ValueError(f"Not a file: {str(path)}")
+            else:
+                try:
+                    path = Path(source_code)
+                except:  # pylint: disable=bare-except
+                    return source_code
+                if not path.is_file():
+                    return source_code
+            with path.open("r", encoding="utf-8") as file:
+                return file.read()
+
+        self.source_code = _detect_source_code(source_code)
+        if compile_options is None:
+            self.compile_options = SourceModule.get_compile_options(source_format=source_format)
+        else:
+            self.compile_options = list(compile_options)
+        self.compiler = compiler
+        self.source_suffix = _detect_input_suffix(source_format)
+        self.output_suffix = _detect_output_suffix(output_format)
+        super().__init__(symbols)
+
+    @staticmethod
+    def tvm_home() -> Path:
+        """Find TVM's home directory. If `TVM_HOME` environment variable is set, use it.
+        Otherwise, use the directory where the `tvm` Python package is installed.
+        As a sanity check, it is required to have `include` and `3rdparty` as direct subdirectories.
+
+        Returns
+        -------
+        tvm_home : pathlib.Path
+            The TVM home directory, and it is guaranteed to have `include` and `3rdparty` as
+            direct subdirectories.
+        """
+        if os.environ.get("TVM_HOME", None):
+            tvm_path = Path(os.environ["TVM_HOME"])
+            assert tvm_path.exists(), (
+                "Using environment variable `TVM_HOME`, "
+                f"but directory not found: {str(tvm_path)}"
+            )
+            assert tvm_path.is_dir(), (
+                "Using environment variable `TVM_HOME`, "
+                f"but it is not a directory: {str(tvm_path)}"
+            )
+        else:
+            import tvm  # pylint: disable=import-outside-toplevel
+
+            tvm_path = Path(tvm.__file__).parent
+            assert tvm_path.is_dir()
+        tvm_path = tvm_path.resolve()
+        while True:
+            exists_include = (tvm_path / "include").is_dir()
+            exists_3rdparty = (tvm_path / "3rdparty").is_dir()
+            if exists_include and exists_3rdparty:
+                return tvm_path.resolve()
+            parent = tvm_path.parent
+            if parent == tvm_path:
+                raise ValueError(
+                    "Cannot detect TVM directory. "
+                    "Please explicitly specify it by setting `TVM_HOME` environment variable, "
+                    "and make sure it contains `include` and `3rdparty` as direct sub-directories."
+                )
+            tvm_path = parent
+        return tvm_path.resolve()
+
+    @staticmethod
+    def get_includes(tvm_pkg: Optional[List[str]] = None) -> List[Path]:
+        """Returns the default include paths according to `tvm_home()`.
+        By default, it includes TVM, DLPack, and DMLC-Core. With `tvm_pkg` provided, it also
+        includes the specified package under `tvm_home/3rdparty`.
+
+        Parameters
+        ----------
+        tvm_pkg : Optional[List[str]]
+            The list of packages to be included under `tvm_home/3rdparty`. Each element should be
+            a relative path to `tvm_home/3rdparty`.
+
+        Returns
+        -------
+        includes : List[pathlib.Path]
+            The list of include paths.
+        """
+        tvm_home = SourceModule.tvm_home()
+        results = [
+            tvm_home / "include",
+            tvm_home / "3rdparty/dlpack/include",
+            tvm_home / "3rdparty/dmlc-core/include",
+        ]
+        if tvm_pkg:
+            for relative in tvm_pkg:
+                results.append(tvm_home / "3rdparty" / relative)
+        for path in results:
+            assert path.exists(), f"Not found: {str(path)}"
+            assert path.is_dir(), f"Not a directory: {str(path)}"
+        return results
+
+    @staticmethod
+    def get_compile_options(
+        source_format: str,
+        tvm_pkg: Optional[List[str]] = None,
+    ) -> List[str]:
+        """Returns the default compile options depending on `source_format`, including the default
+        inlcude paths w.r.t. `tvm_home()`, default flags to configure DMLC-Core, and by default,
+        it uses "-O3" and "-std=c++17".
+
+        Parameters
+        ----------
+        source_format : str
+            The source code format. It can be either "cpp" or "cu".
+
+        tvm_pkg : Optional[List[str]]
+            The list of packages to be included under `tvm_home/3rdparty`. Each element should be
+            a relative path to `tvm_home/3rdparty`.
+
+        Returns
+        -------
+        compile_options : List[str]
+            The list of compilation flags.
+        """
+        include_flags = []
+        for include_path in SourceModule.get_includes(tvm_pkg=tvm_pkg):
+            include_flags += ["-I", str(include_path)]
+        if source_format == "cpp":
+            host_flags = [
+                "-c",  # generate object file
+                "-O3",
+                "-std=c++17",
+                # DMLC default
+                "-DDMLC_USE_FOPEN64=0",
+                "-DDMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>",
+            ]
+        elif source_format == "cu":
+            host_flags = [
+                "-c",  # generate object file
+                "-O3",
+                "-std=c++17",
+                # DMLC default
+                "-DDMLC_USE_FOPEN64=0",
+                "-DDMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>",
+                # Enable `-fPIC` for the host compiler
+                "-Xcompiler=-fPIC",
+            ]
+        else:
+            raise ValueError(f"Invalid source format: {source_format}")
+        return include_flags + host_flags
+
+    def compile(self, output_path: Path) -> None:
+        """Compiles the source code in a provided directory and returns the compiled artifact."""
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            source_path = temp_dir / f"main{self.source_suffix}"
+            object_path = temp_dir / f"main{self.output_suffix}"
+            with source_path.open("w", encoding="utf-8") as file:
+                file.write(self.source_code)
+            _cc.create_shared(
+                output=str(object_path),
+                objects=[str(source_path)],
+                options=self.compile_options,
+                cc=self.compiler,
+                cwd=temp_dir,
+                ccache_env={"CCACHE_COMPILERCHECK": "content"} if shutil.which("ccache") else None,
+            )
+            shutil.move(str(object_path), str(output_path))
+
+    def load(self) -> Module:
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            output_path = Path(temp_dir_str) / f"main{self.output_suffix}"
+            self.compile(output_path)
+            return self._load(output_path)

--- a/python/tvm/relax/frontend/nn/spec.py
+++ b/python/tvm/relax/frontend/nn/spec.py
@@ -16,17 +16,10 @@
 # under the License.
 """Compilation specifications, for example, dynamic shape inputs."""
 import inspect
-import threading
 import typing
 
-from tvm import tir
-from tvm.ir import IRModule
-from tvm.runtime import Module, load_static_library
-
-from ... import expr as rx
-from ...block_builder import BlockBuilder
-from ...struct_info import ShapeStructInfo, TupleStructInfo
-from . import core
+if typing.TYPE_CHECKING:
+    from .core import Module as nn_module_class
 
 ArgSpecType = typing.Union["Int", "Tensor"]
 MethodSpecType = typing.Union["MethodSpec", typing.Dict[str, ArgSpecType]]
@@ -76,44 +69,6 @@ class Tuple:  # pylint: disable=too-few-public-methods
 
     def __repr__(self) -> str:
         return self.elements.__repr__()
-
-
-class ConstInt:  # pylint: disable=too-few-public-methods
-    """An integer constant"""
-
-    dtype: typing.Optional[str]
-
-    def __init__(self, dtype: str = None) -> None:
-        self.dtype = dtype
-
-    def __repr__(self) -> str:
-        if self.dtype is None:
-            return "const.int"
-        return f"const.int({self.dtype})"
-
-
-class ConstFloat:  # pylint: disable=too-few-public-methods
-    """A float constant"""
-
-    dtype: typing.Optional[str]
-
-    def __init__(self, dtype: str = None) -> None:
-        self.dtype = dtype
-
-    def __repr__(self) -> str:
-        if self.dtype is None:
-            return "const.float"
-        return f"const.float({self.dtype})"
-
-
-class ConstString:  # pylint: disable=too-few-public-methods
-    """A string constant"""
-
-    def __init__(self) -> None:
-        pass
-
-    def __repr__(self) -> str:
-        return "const.string"
 
 
 class MethodSpec:
@@ -222,60 +177,17 @@ class MethodSpec:
 
         return _method_spec_from_torch(args, method)
 
-    def as_inputs(self) -> typing.List[typing.Union[tir.Var, core.Tensor]]:
-        """Convert the MethodSpec to a list of inputs to Module's method."""
-        str2var: typing.Dict[str, tir.Var] = {}
-
-        def _get_var(name: str) -> tir.Var:
-            if name in str2var:
-                return str2var[name]
-            var = tir.Var(name, "int64")
-            str2var[name] = var
-            return var
-
-        def _convert_input(arg_name, arg_spec):
-            if isinstance(arg_spec, Int):
-                arg = _get_var(arg_name)
-            elif isinstance(arg_spec, Tensor):
-                arg = core._tensor_placeholder(  # pylint: disable=protected-access
-                    name=arg_name,
-                    shape=[_get_var(x) if isinstance(x, str) else x for x in arg_spec.shape],
-                    dtype=arg_spec.dtype,
-                )
-            elif isinstance(arg_spec, Tuple):
-                elements = type(arg_spec.elements)(
-                    [
-                        _convert_input(
-                            arg_name=arg_name + f"_tmp{i}", arg_spec=arg_spec.elements[i]
-                        )
-                        for i in range(len(arg_spec.elements))
-                    ]
-                )
-                arg = Tuple(
-                    name=arg_name,
-                    elements=elements,
-                )
-            else:
-                raise TypeError(f"Invalid spec for argument {arg_name}: {arg_spec}")
-            return arg
-
-        args = []
-        for arg_name, arg_spec in zip(self.arg_names, self.arg_specs):
-            arg = _convert_input(arg_name=arg_name, arg_spec=arg_spec)
-            args.append(arg)
-        return args
-
 
 class ModuleSpec:
     """A spec for a compiled nn.Module"""
 
-    module: core.Module
+    module: "nn_module_class"
     method_names: typing.List[str]
     method_specs: typing.List[MethodSpec]
 
     def __init__(
         self,
-        module: core.Module,
+        module: "nn_module_class",
         method_names: typing.List[str],
         method_specs: typing.List[MethodSpec],
     ) -> None:
@@ -284,9 +196,8 @@ class ModuleSpec:
         self.method_specs = method_specs
 
     @staticmethod
-    def from_raw(spec: ModuleSpecType, module: core.Module) -> "ModuleSpec":
+    def from_raw(spec: ModuleSpecType, module: "nn_module_class") -> "ModuleSpec":
         """Create ModuleSpec from raw python dictionaries.
-
 
         Examples
         --------
@@ -331,297 +242,3 @@ class ModuleSpec:
                 self.method_specs,
             )
         )
-
-
-class ExternFunctionSpec:  # pylint: disable=too-few-public-methods
-    """A spec for a compiled external function."""
-
-    args: typing.List[typing.Union[Tensor, ConstInt, ConstFloat, ConstString]]
-    ret: typing.Union[Tensor, typing.List[Tensor]]
-    symbol: typing.Optional[str]
-
-    def __init__(
-        self,
-        args: typing.List[typing.Union[Tensor, ConstInt, ConstFloat, ConstString]],
-        ret: typing.Union[Tensor, typing.List[Tensor]],
-        symbol: typing.Optional[str] = None,
-    ) -> None:
-        self.args = args
-        self.ret = ret
-        self.symbol = symbol
-
-    def __repr__(self) -> str:
-        arg_repr = ", ".join(arg.__repr__() for arg in self.args)
-        if isinstance(self.ret, list):
-            ret_repr = "(" + ", ".join(ret.__repr__() for ret in self.ret) + ")"
-        else:
-            ret_repr = self.ret.__repr__()
-        if self.symbol is None:
-            func = f"({arg_repr}) -> {ret_repr}"
-        else:
-            func = f"{self.symbol}({arg_repr}) -> {ret_repr}"
-        return f"ExternFunctionSpec: {func}"
-
-
-class ExternModuleSpec:  # pylint: disable=too-few-public-methods
-    """A spec for a compiled external Module."""
-
-    library: typing.Union[str, Module]
-    functions: typing.List[ExternFunctionSpec]
-
-    def __init__(
-        self,
-        library: typing.Union[str, Module],
-        functions: typing.List[ExternFunctionSpec],
-    ) -> None:
-        self.library = library
-        self.functions = functions
-
-    def load_library(self) -> Module:
-        """Load the external library into Module."""
-        if isinstance(self.library, Module):
-            return self.library
-        return load_static_library(
-            self.library,
-            func_names=[func.symbol for func in self.functions],
-        )
-
-    def __repr__(self) -> str:
-        return f"ExternModuleSpec(library={self.library}):\n" + "\n".join(
-            f"  {func.__repr__()}" for func in self.functions
-        )
-
-
-class SpecBuilder:
-    """Builder of ModuleSpec, which exports an nn.Module to TVM IRModule."""
-
-    _tls = threading.local()
-
-    builder: BlockBuilder
-    io_effect: core.Effect
-
-    def __init__(self) -> None:
-        from .modules import IOEffect  # pylint: disable=import-outside-toplevel
-
-        self.builder = BlockBuilder()
-        self.io_effect = IOEffect()
-
-    @staticmethod
-    def current() -> "SpecBuilder":
-        """Get the current SpecBuilder under the with scope."""
-        assert hasattr(SpecBuilder._tls, "current")
-        return SpecBuilder._tls.current
-
-    def __enter__(self) -> "SpecBuilder":
-        assert not hasattr(SpecBuilder._tls, "current")
-        SpecBuilder._tls.current = self
-        return self
-
-    def __exit__(self, exc_type, exc, traceback) -> None:
-        assert hasattr(SpecBuilder._tls, "current")
-        delattr(SpecBuilder._tls, "current")
-
-    def build(  # pylint: disable=too-many-locals
-        self, spec: ModuleSpec, debug: bool = False
-    ) -> typing.Tuple[IRModule, typing.List[typing.Tuple[str, core.Parameter]]]:
-        """Build the ModuleSpec to TVM IRModule. Returns the IRModule and the parameters."""
-
-        # pylint: disable=protected-access
-        def _params() -> typing.List[typing.Tuple[str, core.Parameter]]:
-            params = []
-            for name, param in core._attribute_finder(
-                spec.module, prefix="", condition_yield=lambda x: isinstance(x, core.Parameter)
-            ):
-                params.append((name, param))
-            return params
-
-        def _effects() -> typing.List[typing.Tuple[str, core.Effect]]:
-            result = []
-            if self.io_effect is not None:
-                result.append(("", self.io_effect))
-            for name, effect in core._attribute_finder(
-                spec.module, "", condition_yield=lambda x: isinstance(x, core.Effect)
-            ):
-                result.append((name, effect))
-            return result
-
-        def _extern_modules() -> typing.List[core.ExternModule]:
-            result = []
-            used = set()
-            for _, extern_module in core._attribute_finder(
-                spec.module, "", condition_yield=lambda x: isinstance(x, core.ExternModule)
-            ):
-                if extern_module not in used:
-                    used.add(extern_module)
-                    result.append(extern_module)
-            return result
-
-        # pylint: enable=protected-access
-
-        # Disable IO effects if not in debug mode.
-        if not debug:
-            self.io_effect = None
-        params = _params()
-        effects = _effects()
-        extern_modules = _extern_modules()
-        with self:
-            if effects:
-                with self.builder.function("_initialize_effect"):
-                    with self.builder.dataflow():
-                        outputs = _emit_effect_init(self.builder, effects)
-                    self.builder.emit_func_output(outputs, params=[])
-            for method_name, method_spec in zip(spec.method_names, spec.method_specs):
-                len_args = len(method_spec.arg_specs)
-                len_effects = {
-                    "packed": 1,
-                    "none": 0,
-                    "plain": len(effects),
-                }[method_spec.effect_mode]
-                with self.builder.function(
-                    method_name,
-                    attrs={"num_input": len_args + len_effects},  # type: ignore
-                ):
-                    with self.builder.dataflow():
-                        outputs, inputs = _emit_method(self.builder, method_spec, params, effects)
-                    self.builder.emit_func_output(outputs, inputs)
-        external_mods = []
-        for extern_module in extern_modules:
-            external_mods.append(extern_module.module_spec.load_library())
-        mod = self.builder.finalize()
-        if extern_modules:
-            original_external_mods = mod.get_attr("external_mods")
-            if original_external_mods is not None:
-                external_mods = original_external_mods + extern_modules
-            mod = mod.with_attr("external_mods", external_mods)
-        return mod, params
-
-
-def _emit_effect_init(
-    builder: BlockBuilder,
-    effects: typing.List[typing.Tuple[str, core.Effect]],
-):
-    outputs = []
-    for prefix, effect in effects:
-        inits = effect.emit_init(prefix, builder)
-        assert isinstance(inits, list)
-        outputs.extend(inits)
-    outputs = builder.emit_output(builder.emit(rx.Tuple(outputs)))
-    return outputs
-
-
-def _emit_method(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-    builder: BlockBuilder,
-    spec: MethodSpec,
-    params: typing.List[typing.Tuple[str, core.Parameter]],
-    effects: typing.Optional[typing.List[typing.Tuple[str, core.Effect]]],
-):
-    # pylint: disable=protected-access
-    def _unwrap_ret(expr: typing.Any) -> typing.Any:
-        if isinstance(expr, core.Tensor):
-            return expr._expr
-        if isinstance(expr, tuple):
-            return rx.Tuple([_unwrap_ret(x) for x in expr])
-        if isinstance(expr, list):
-            return rx.Tuple([_unwrap_ret(x) for x in expr])
-        raise TypeError(f"Unsupported return type: {type(expr)}")
-
-    def _convert_input(arg):
-        if isinstance(arg, tir.Var):
-            return rx.Var(arg.name, struct_info=ShapeStructInfo(values=[arg]))
-        if isinstance(arg, core.Tensor):
-            return arg._expr  # pylint: disable=protected-access
-        if isinstance(arg, Tuple):
-            return rx.Var(
-                arg.name,
-                struct_info=TupleStructInfo(
-                    [_convert_input(arg_i).struct_info for arg_i in arg.elements]
-                ),
-            )
-        raise TypeError(f"Unsupported input type: {type(arg)}")
-
-    def _params(mode: str) -> typing.List[rx.Var]:
-        inputs: typing.List[rx.Var] = []
-        for name, param in params:
-            var = core._tensor_placeholder(name, param.shape, param.dtype)._expr
-            inputs.append(var)
-            param._expr = var
-        if mode == "none":
-            return []
-        if mode == "plain":
-            return inputs
-        if mode == "packed":
-            input_var = rx.Var(
-                "packed_params",
-                TupleStructInfo(fields=[x.struct_info for x in inputs]),
-            )
-            for i, (name, param) in enumerate(params):
-                param._expr = builder.emit(rx.TupleGetItem(input_var, i), name_hint=name)
-            return [input_var]
-        raise ValueError(f"Invalid param_mode: {mode}")
-
-    def _effects(mode: str) -> typing.List[rx.Var]:
-        unflat_inputs: typing.List[typing.List[rx.Var]] = []
-        for name, effect in effects:
-            effect_input = effect.create(name)
-            effect.set_state(effect_input)
-            unflat_inputs.append(effect_input)
-        inputs: typing.List[rx.Var] = sum(unflat_inputs, [])
-        if mode == "none":
-            return []
-        if mode == "plain":
-            return inputs
-        if mode == "packed":
-            input_var = rx.Var(
-                "packed_effects",
-                TupleStructInfo(fields=[x.struct_info for x in inputs]),
-            )
-            i = 0
-            for effect_input, (_, effect) in zip(unflat_inputs, effects):
-                updated_effect_input = []
-                for effect_input_i in effect_input:
-                    updated_effect_input.append(
-                        builder.emit(
-                            rx.TupleGetItem(input_var, i),
-                            name_hint=effect_input_i.name_hint,
-                        )
-                    )
-                    i += 1
-                effect.set_state(updated_effect_input)
-            return [input_var]
-
-        raise ValueError(f"Invalid effect_mode: {mode}")
-
-    # pylint: enable=protected-access
-
-    def _detuple(arg, var: rx.Var, builder: BlockBuilder):
-        if isinstance(arg, Tuple):
-            ret = []
-            for i, elem in enumerate(arg.elements):
-                field = builder.emit(rx.TupleGetItem(var, i), name_hint=f"{arg.name}_{i}")
-                ret.append(_detuple(elem, field, builder))
-            return type(arg.elements)(ret)
-        if isinstance(arg, core.Tensor):
-            return core.Tensor(_expr=var)
-        if isinstance(arg, tir.Var):
-            return arg
-        raise TypeError(f"Unsupported input type: {type(arg)}")
-
-    # TODO(@junrushao): Warn if params/effects are used when their mode is "none"
-    explicit_inputs = spec.as_inputs()
-    inputs = [_convert_input(x) for x in explicit_inputs]
-    inputs = inputs + _effects(spec.effect_mode)
-    inputs = inputs + _params(spec.param_mode)
-
-    for arg_idx, (arg, var) in enumerate(zip(explicit_inputs, inputs)):
-        if isinstance(arg, Tuple):
-            explicit_inputs[arg_idx] = _detuple(arg, var, builder)
-
-    outputs = spec.method(*explicit_inputs)
-    effect_outputs = []
-    for _, effect in effects:
-        effect_outputs.extend(effect.finalize())
-    if effect_outputs and spec.effect_mode != "none":
-        outputs = builder.emit_output(rx.Tuple([_unwrap_ret(outputs), rx.Tuple(effect_outputs)]))
-    else:
-        outputs = builder.emit_output(_unwrap_ret(outputs))
-    return outputs, inputs

--- a/python/tvm/relax/transform/__init__.py
+++ b/python/tvm/relax/transform/__init__.py
@@ -78,6 +78,7 @@ from .lazy_transform_params import LazyTransformParams
 from .optimize_layout_transform import OptimizeLayoutTransform
 from .remove_redundant_reshape import RemoveRedundantReshape
 from .fast_math import FastMathTransform
+from .attach_external_modules import AttachExternModules
 
 # Import to register the legalization functions.
 from . import legalize_ops, tuning_api

--- a/python/tvm/relax/transform/attach_external_modules.py
+++ b/python/tvm/relax/transform/attach_external_modules.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""A pass that attaches external modules to the IRModule.
+
+Note: "external modules" here refers to `relax.frontend.nn.ExternModule`.
+"""
+from typing import TYPE_CHECKING, List
+
+from tvm.ir import IRModule
+from tvm.ir.transform import PassContext, module_pass
+
+if TYPE_CHECKING:
+    from tvm.relax.frontend.nn import ExternModule
+
+
+@module_pass(opt_level=0, name="AttachExternalModules")
+class AttachExternModules:  # pylint: disable=too-few-public-methods
+    """Attach variable bounds to each Relax function, which primarily helps with memory planning."""
+
+    def __init__(self, extern_modules: List["ExternModule"]):
+        self.extern_modules = extern_modules
+
+    def transform_module(self, mod: IRModule, _ctx: PassContext) -> IRModule:
+        """Entrypoint"""
+        from tvm.relax.frontend.nn import (  # pylint: disable=import-outside-toplevel
+            ExternModule,
+        )
+
+        def _load(ext_mod: ExternModule):
+            assert isinstance(ext_mod, ExternModule), f"Expected ExternModule, but got: {ext_mod}"
+            return ext_mod.load()
+
+        mod_attrs = dict(mod.attrs) if mod.attrs else {}
+        external_mods = mod_attrs.get("external_mods", [])
+        for ext in self.extern_modules:
+            external_mods.append(_load(ext))
+        mod = mod.with_attr("external_mods", external_mods)
+        return mod

--- a/python/tvm/relax/vm_build.py
+++ b/python/tvm/relax/vm_build.py
@@ -317,13 +317,12 @@ def build(
     if not params:
         params = {}
 
-    ext_libs, constants = _extract_attrs(mod)
-    params.update(dict(constants))
-
     if pipeline is not None:
         if isinstance(pipeline, str):
             pipeline = relax.get_pipeline(pipeline)
         mod = pipeline(mod)
+    ext_libs, constants = _extract_attrs(mod)
+    params.update(dict(constants))
     builder = relax.ExecBuilder()
     mod = _vmcodegen(builder, mod, exec_mode)
     return _vmlink(

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -18,6 +18,7 @@
 """Runtime NDArray API"""
 import ctypes
 import warnings
+
 import numpy as np
 
 try:
@@ -25,24 +26,38 @@ try:
 except ImportError:
     ml_dtypes = None
 import tvm._ffi
+from tvm._ffi.base import _FFI_MODE, _LIB, c_array, check_call, string_types
+from tvm._ffi.runtime_ctypes import (
+    DataType,
+    DataTypeCode,
+    Device,
+    TVMArray,
+    TVMArrayHandle,
+    tvm_shape_index_t,
+)
 
-from tvm._ffi.base import _LIB, check_call, c_array, string_types, _FFI_MODE
-from tvm._ffi.runtime_ctypes import DataType, Device, TVMArray, TVMArrayHandle
-from tvm._ffi.runtime_ctypes import DataTypeCode, tvm_shape_index_t
 from . import _ffi_api
 
 try:
     # pylint: disable=wrong-import-position
     if _FFI_MODE == "ctypes":
         raise ImportError()
-    from tvm._ffi._cy3.core import _set_class_ndarray, _make_array, _from_dlpack
-    from tvm._ffi._cy3.core import NDArrayBase
+    from tvm._ffi._cy3.core import (
+        NDArrayBase,
+        _from_dlpack,
+        _make_array,
+        _set_class_ndarray,
+    )
 except (RuntimeError, ImportError) as error:
     # pylint: disable=wrong-import-position
     if _FFI_MODE == "cython":
         raise error
-    from tvm._ffi._ctypes.ndarray import _set_class_ndarray, _make_array, _from_dlpack
-    from tvm._ffi._ctypes.ndarray import NDArrayBase
+    from tvm._ffi._ctypes.ndarray import (
+        NDArrayBase,
+        _from_dlpack,
+        _make_array,
+        _set_class_ndarray,
+    )
 
 
 @tvm._ffi.register_object("runtime.NDArray")
@@ -324,6 +339,8 @@ def device(dev_type, dev_id=0):
       assert tvm.device("cpu", 1) == tvm.cpu(1)
       assert tvm.device("cuda", 0) == tvm.cuda(0)
     """
+    if isinstance(dev_type, Device):
+        return dev_type
     if not isinstance(dev_id, int):
         raise ValueError(f"Invalid device id: {dev_id}")
 

--- a/tests/python/relax/frontend_nn_extern_module.cc
+++ b/tests/python/relax/frontend_nn_extern_module.cc
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file test_extern_module.cc
+ * \brief Testing code to be compiled by Relax nn.SourceModule
+ */
+#include <dlpack/dlpack.h>
+#include <tvm/runtime/data_type.h>
+#include <tvm/runtime/packed_func.h>
+
+namespace {
+
+int _scalar_add(DLTensor* a, DLTensor* b, DLTensor* c) {
+  using namespace tvm::runtime;
+  ICHECK(a->ndim == 0);
+  ICHECK(b->ndim == 0);
+  ICHECK(c->ndim == 0);
+  ICHECK(DataType(a->dtype) == DataType::Float(32));
+  ICHECK(DataType(b->dtype) == DataType::Float(32));
+  ICHECK(DataType(c->dtype) == DataType::Float(32));
+  float* a_data = static_cast<float*>(a->data);
+  float* b_data = static_cast<float*>(b->data);
+  float* c_data = static_cast<float*>(c->data);
+  *c_data = *a_data + *b_data;
+  return 0;
+}
+
+int _test_sym(DLTensor* a, DLTensor* b, DLTensor* c) {
+  using namespace tvm::runtime;
+  ICHECK(a->ndim == 3);  // [x, y, 1]
+  ICHECK(b->ndim == 3);  // [y, z, 5]
+  ICHECK(c->ndim == 4);  // [x, y, z, 9]
+  ICHECK(DataType(a->dtype) == DataType::Float(32));
+  ICHECK(DataType(b->dtype) == DataType::Float(32));
+  ICHECK(DataType(c->dtype) == DataType::Float(32));
+  int x = a->shape[0];
+  int y = a->shape[1];
+  int z = b->shape[1];
+  ICHECK(a->shape[0] == x);
+  ICHECK(a->shape[1] == y);
+  ICHECK(a->shape[2] == 1);
+  ICHECK(b->shape[0] == y);
+  ICHECK(b->shape[1] == z);
+  ICHECK(b->shape[2] == 5);
+  ICHECK(c->shape[0] == x);
+  ICHECK(c->shape[1] == y);
+  ICHECK(c->shape[2] == z);
+  ICHECK(c->shape[3] == 9);
+  return 0;
+}
+}  // namespace
+TVM_DLL_EXPORT_TYPED_FUNC(ext_scalar_add, _scalar_add);
+TVM_DLL_EXPORT_TYPED_FUNC(ext_test_sym, _test_sym);


### PR DESCRIPTION
`nn.ExternModule` allows incorporation of handcrafted kernels into the compilation stack and being invoked by Relax just like TIR or any other ordinary operator. This PR simplifies its workflow.

The system consists of the abstract base class `ExternModule` and its two derivatives:
- `.o` (object files) can be linked using `ObjectModule`.
- `.cpp` (C++ files) and `.cu` (CUDA files) can be compiled and linked into the system usung `SourceModule`.

**Symbols, and shape/dtype inference.** To provide the system with sufficient information about the kernels, it is required to provide all symbols of an external module, as well as a method for each symbol that tells the system about the output dtype/shape of this symbol.

Consider a case where function `my_func` accepts two tensors, `a` of shape `(x, y, 1)`, `b` of shape `(y, z, 5)`, and then produces a tensor `c` of shape `(x, y, z, 9)`, the shape/dtype inference function should look like:

```python
def shape_dtype_inference(a, b):
  x, y, _ = a.shape
  _, z, _ = b.shape
  return nn.Tensor.placeholder((x, y, z, 9), dtype="float32")
```

Regarding the interface, the symbols and their corresponding shape/dtype inference function should be provided as a Python dictionary that maps each symbol to the function as below:

```python
symbols={
  "my_func": shape_dtype_inference,
}
```

**Calling convention.** All external modules now follows "destination-passing-style" (DPS) calling convention, which means the returned tensors are pre-allocated by the system already and passed in as an argument of the external
function.

Reuse the example above, the implementation of `my_func` should include three parameters in its signature, where tensors are represented using DLTensor from DLPack, the de facto standard of in-memory representation of tensors. More info on DLPack: https://github.com/dmlc/dlpack/blob/v0.8/include/dlpack/dlpack.h#L163-L206.

To expose the symbol, `TVM_DLL_EXPORT_TYPED_FUNC(symbol, function)` is guaranteed available:

```C++
// those headers are guaranteed to be available
#include <dlpack/dlpack.h>
#include <tvm/runtime/data_type.h>
#include <tvm/runtime/packed_func.h>
namespace {
// anonymous namespace hides the symbol `_my_func_impl` from other TUs
int _my_func_impl(DLTensor* a, DLTensor* b, DLTensor* c) {
// `a` and `b` are inputs, and `c` is the output
}
}
// expose symbol `my_func` instead of `_my_func_impl`
TVM_DLL_EXPORT_TYPED_FUNC(my_func, _my_func_impl);
```

**A compiler pass `AttachExternModules`.** It is introduced to attach a list of `nn.ExternModule`s into an IRModule at any stage of the compilation pipeline, and attach the compiled external modules as `runtime.Module`s into IRModule's `external_mods` attribute. It is required by linking in `relax.build`, but with the existence of this pass, source compilation can be deferred to arbitrary stage of TVM compilation.

**Caveats.** It is required to call `nn.add_extern` to register external modules exactly once during `export_tvm`. Each symbol should be registered exactly once to avoid potential conflicts, and otherwise an error will be raised. This programming model might be a bit of constraint, and we will consider loose it slightly in the future.

Also, for backward compatibility, `ExternModule`s are exported from `export_tvm` only when `allow_extern` flag is turned on. Otherwise, any external module will cause an exception asking to turn on the flag.