### PR TITLE
[Unity] Avoid to use `std::regex`

### DIFF
--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -36,7 +36,7 @@
 #include <cstddef>
 #include <limits>
 #include <optional>
-#include <regex>
+#include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -557,8 +557,9 @@ bool DFPatternMatcher::VisitDFPattern_(const DataflowVarPatternNode* op, const E
 bool DFPatternMatcher::VisitDFPattern_(const GlobalVarPatternNode* op, const Expr& expr) {
   // GlobalVarPattern is not inherited from Var, so we need to handle it separately.
   if (const auto* var_node = expr.as<GlobalVarNode>()) {
-    std::regex pat{std::string(op->name_hint())};
-    return "" == op->name_hint() || std::regex_search(std::string(var_node->name_hint), pat);
+    std::string pat = std::string(op->name_hint());
+    std::string var_name = std::string(var_node->name_hint);
+    return pat.empty() || var_name.find(pat) != std::string::npos;
   }
   return false;
 }

--- a/src/runtime/contrib/cublas/cublas_json_runtime.cc
+++ b/src/runtime/contrib/cublas/cublas_json_runtime.cc
@@ -26,7 +26,6 @@
 #include <tvm/runtime/registry.h>
 
 #include <cstddef>
-#include <regex>
 #include <string>
 #include <vector>
 

--- a/src/runtime/contrib/cudnn/cudnn_json_runtime.cc
+++ b/src/runtime/contrib/cudnn/cudnn_json_runtime.cc
@@ -26,7 +26,6 @@
 #include <tvm/runtime/registry.h>
 
 #include <cstddef>
-#include <regex>
 #include <string>
 #include <vector>
 
@@ -54,7 +53,7 @@ class cuDNNJSONRuntime : public JSONRuntimeBase {
     stream = static_cast<cudaStream_t>((*func)().operator void*());
 
     auto attr_in_name = [](const std::string& op_name, const std::string& attr_name) {
-      return std::regex_search(op_name, std::regex(attr_name));
+      return op_name.find(attr_name) != std::string::npos;
     };
 
     auto vstr2vint = [](const JSONGraphNode& node, const std::string& attrStr) {

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -97,7 +97,9 @@ def test_dataflow_var_pattern():
 
 def test_global_var_pattern():
     assert is_gv("x").match(rx.GlobalVar("x"))
-    assert is_gv("x.*").match(rx.GlobalVar("x_2"))
+    # TODO: disabled as regex is not supported due to
+    # symbol conflict with PyTorch
+    # assert is_gv("x.*").match(rx.GlobalVar("x_2"))
     assert is_gv().match(rx.GlobalVar("x"))
     assert not is_gv("x").match(rx.GlobalVar("y"))
     assert not is_gv("x").match(rx.Var("x"))


### PR DESCRIPTION
`std::regex` in TVM codebase may cause a symbol conflict with PyTorch, we temporarily disable it before we find a better solution, meanwhile the current usage of `std::regex` is not necessary.

cc @tqchen 