### PR TITLE
[TIR] In SplitHostDevice, check for variables in thread extents

### DIFF
--- a/include/tvm/tir/analysis.h
+++ b/include/tvm/tir/analysis.h
@@ -307,12 +307,39 @@ TVM_DLL Map<Buffer, Optional<Stmt>> DetectBufferAccessLCA(const PrimFunc& func);
 
 /*!
  * \brief Verify if the given TIR is well-formed. The verification includes:
- *        - Check if expressions not contain vars that is defined outside the block.
+ *
+ * - All variables are defined prior to their point of use.
+ *
+ * - No variables are used outside of the scope of their definition.
+ *
+ * - Each variable has a single point of definition.
+ *
+ * - Expressions within a tir::Block may not reference variables
+ *   defined outside the block.  For example, for a block with iter
+ *   vars `vi, vj = T.axis.remap('SS', [i,j])`, the statement
+ *   `B[i,j] = A[i,j]` would be ill-formed, because it uses the loop
+ *   variables `i` and `j` instead of the block variables `vi` and
+ *   `vj`.
+ *
  * \param func The PrimFunc to be verified.
  * \param assert_mode The indicator if it raises an error when the function is not well-formed.
  * \return Whether it is a well-formed TIR function.
  */
 TVM_DLL bool VerifyWellFormed(const PrimFunc& func, bool assert_mode = true);
+
+/*!
+ * \brief Verify if the TIR in the given IRMOdule is well-formed.
+ *
+ * In addition to the checks performed for each PrimFunc (see above),
+ * the following checks are performed:
+ *
+ * - The same TIR variable may not be defined in more than one function
+ *
+ * \param mod The IRModule to be verified.
+ * \param assert_mode The indicator if it raises an error when the function is not well-formed.
+ * \return Whether it is a well-formed TIR module.
+ */
+TVM_DLL bool VerifyWellFormed(const IRModule& mod, bool assert_mode = true);
 
 /*!
  * \brief Find the entry function of the given IRModule, i.e, functions marked by

--- a/src/tir/analysis/verify_well_formed.cc
+++ b/src/tir/analysis/verify_well_formed.cc
@@ -26,11 +26,95 @@
 #include <tvm/tir/stmt.h>
 #include <tvm/tir/stmt_functor.h>
 
+#include <exception>
+#include <optional>
+#include <variant>
+
 #include "../ir/functor_common.h"
+#include "../ir/tir_visitor_with_path.h"
 #include "tvm/ir/module.h"
 
 namespace tvm {
 namespace tir {
+
+namespace {
+
+template <typename DerivedVerifier>
+class Verifier : protected TIRVisitorWithPath {
+ public:
+  template <typename TirNodeRef>
+  static bool Verify(const TirNodeRef& node, bool assert_on_error) {
+    DerivedVerifier verifier(assert_on_error);
+    verifier(node);
+    return !verifier.has_error_;
+  }
+
+ protected:
+  Verifier(bool assert_on_error) : assert_on_error_(assert_on_error) {}
+
+  /* \brief Helper class to handle the bool-or-assert handles
+   *
+   * Each verifier can either return a boolean, or assert on failure.
+   * To avoid needing to duplicate this logic at every step, the
+   * Verify() method can be used.  Similar to `LOG(FATAL)` or
+   * `LOG(DEBUG)`, it returns an object that can accept streamed
+   * context information.
+   *
+   * If the error should be raised, then the context is collected
+   * identically to `LOG(FATAL)`.  If a boolean is returned, or if the
+   * condition passes, then the streamed context is discarded.
+   *
+   * Usage:
+   *
+   *     Verify(value == expected_value)
+   *            << "ValueError: " << value
+   *            << " was not the expected value of " << expected_value;
+   */
+  class VerifyStream {
+   public:
+    VerifyStream(bool log_fatal) {
+      if (log_fatal) {
+        log_.emplace();
+      }
+    }
+
+    VerifyStream(const VerifyStream&) = delete;
+    VerifyStream& operator=(const VerifyStream&) = delete;
+    VerifyStream(VerifyStream&& other) { std::swap(log_, other.log_); }
+    VerifyStream& operator=(VerifyStream&& other) {
+      std::swap(log_, other.log_);
+      return *this;
+    }
+
+    template <typename T>
+    VerifyStream& operator<<(T&& t) {
+      if (log_.has_value()) {
+        log_.value() << std::forward<T>(t);
+      }
+      return *this;
+    }
+
+    ~VerifyStream() noexcept(false) {
+      if (log_.has_value()) {
+        LOG(FATAL) << log_->str();
+      }
+    }
+
+    std::optional<std::ostringstream> log_{std::nullopt};
+  };
+
+  // TODO(Lunderberg): Add the filename/linenum with
+  // std::source_location when C++20 is available.
+  VerifyStream Verify(bool condition) {
+    has_error_ = has_error_ || !condition;
+    return VerifyStream(!condition && assert_on_error_);
+  }
+
+  bool assert_on_error_;
+  bool has_error_{false};
+};
+
+}  // namespace
 
 /*! \brief Verify all Expr inside the block does not contain:
  *    1. loop vars outside the current block.
@@ -135,10 +219,70 @@ class BlockVarAccessVerifier : public StmtExprVisitor {
   bool has_error_{false};
 };
 
+class UndefinedVarVerifier : public Verifier<UndefinedVarVerifier> {
+ public:
+  // Until templated-this arrives in C++23, the CRTP can't inject a
+  // constructor into the child class.  Therefore, must explicitly add
+  // the constructor.
+  using Verifier::Verifier;
+
+ private:
+  void EnterDef(const Var& var, ObjectPath path) override {
+    {
+      auto it = currently_defined_.find(var);
+      Verify(it == currently_defined_.end())
+          << "ValueError: "
+          << "TIR is ill-formed, "
+          << "due to multiple nested definitions of variable " << var
+          << ".  It was first defined at " << it->second << ", and was re-defined at " << path;
+    }
+
+    {
+      auto it = previously_defined_.find(var);
+      Verify(it == previously_defined_.end())
+          << "ValueError: "
+          << "TIR is ill-formed, "
+          << "due to multiple definitions of variable " << var << ".  It was first defined at "
+          << it->second << ", and was later re-defined at " << path;
+    }
+
+    currently_defined_.insert({var, path});
+  }
+
+  void ExitDef(const Var& var, ObjectPath path) override {
+    auto active_def = currently_defined_.find(var);
+
+    currently_defined_.erase(active_def);
+    previously_defined_.insert({var, path});
+  }
+
+  void VisitExpr_(const VarNode* op, ObjectPath path) override {
+    auto var = GetRef<Var>(op);
+
+    auto prev_def = previously_defined_.find(var);
+    Verify(prev_def == previously_defined_.end())
+        << "ValueError: "
+        << "Invalid use of variable " << var << " at " << path << ".  "
+        << "While this variable was previously defined at " << prev_def->second
+        << ", this definition is no longer in-scope.";
+
+    auto active_def = currently_defined_.find(var);
+    Verify(active_def != currently_defined_.end())
+        << "ValueError: "
+        << "Invalid use of undefined variable " << var << " at " << path;
+  }
+
+  std::unordered_map<Var, ObjectPath, ObjectPtrHash, ObjectPtrEqual> currently_defined_;
+  std::unordered_map<Var, ObjectPath, ObjectPtrHash, ObjectPtrEqual> previously_defined_;
+};
+
 bool VerifyWellFormed(const PrimFunc& func, bool assert_mode) {
   if (!BlockVarAccessVerifier::Verify(func, assert_mode)) {
     return false;
   }
+
+  if (!UndefinedVarVerifier::Verify(func, assert_mode)) return false;
+
   // TODO(Siyuan): add more checks here.
   return true;
 }
@@ -152,6 +296,9 @@ bool VerifyWellFormed(const IRModule& mod, bool assert_mode) {
       }
     }
   }
+
+  if (!UndefinedVarVerifier::Verify(mod, assert_mode)) return false;
+
   return true;
 }
 

--- a/src/tir/analysis/verify_well_formed.cc
+++ b/src/tir/analysis/verify_well_formed.cc
@@ -50,7 +50,7 @@ class Verifier : protected TIRVisitorWithPath {
   }
 
  protected:
-  Verifier(bool assert_on_error) : assert_on_error_(assert_on_error) {}
+  explicit Verifier(bool assert_on_error) : assert_on_error_(assert_on_error) {}
 
   /* \brief Helper class to handle the bool-or-assert handles
    *
@@ -72,7 +72,7 @@ class Verifier : protected TIRVisitorWithPath {
    */
   class VerifyStream {
    public:
-    VerifyStream(bool log_fatal) {
+    explicit VerifyStream(bool log_fatal) {
       if (log_fatal) {
         log_.emplace();
       }

--- a/src/tir/ir/tir_visitor_with_path.cc
+++ b/src/tir/ir/tir_visitor_with_path.cc
@@ -1,0 +1,431 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tir/ir/tir_visitor_with_path.cc
+ * \brief Provide a TIR visitor that tracks the current location
+ */
+
+#include "tir_visitor_with_path.h"
+
+#include <optional>
+#include <variant>
+
+namespace tvm {
+namespace tir {
+
+void TIRVisitorWithPath::Visit(const IRModule& mod, ObjectPath path) {
+  // To ensure deterministic order of visits, sort the GlobalVar first
+  // by visibility (public then private), then alphabetically by name.
+  std::vector<GlobalVar> gvars;
+  std::unordered_set<GlobalVar, ObjectPtrHash, ObjectPtrEqual> externally_exposed;
+  for (const auto& [gvar, func] : mod->functions) {
+    gvars.push_back(gvar);
+    if (func->GetAttr<String>(tvm::attr::kGlobalSymbol).defined()) {
+      externally_exposed.insert(gvar);
+    }
+  }
+
+  std::sort(gvars.begin(), gvars.end(),
+            [&externally_exposed](const GlobalVar& a, const GlobalVar& b) {
+              bool a_exposed = externally_exposed.count(a);
+              bool b_exposed = externally_exposed.count(b);
+              if (a_exposed != b_exposed) {
+                return a < b;
+              } else {
+                return a->name_hint < b->name_hint;
+              }
+            });
+
+  std::vector<DefContext<GlobalVar>> context;
+
+  for (const auto& gvar : gvars) {
+    context.push_back(WithDef(gvar, path->Attr("global_var_map_")->MapValue(gvar->name_hint)));
+  }
+
+  for (const auto& gvar : gvars) {
+    auto base_func = mod->functions[gvar];
+    if (auto prim_func = base_func.as<PrimFunc>()) {
+      Visit(prim_func.value(), path->Attr("functions")->MapValue(gvar));
+    }
+  }
+
+  while (context.size()) context.pop_back();
+}
+
+void TIRVisitorWithPath::Visit(const PrimFunc& func, ObjectPath path) {
+  // The implicit definitions from a PrimFunc::buffer_map are pretty
+  // weird.  They only apply if no previous definition of that
+  // variable has occurred.  Therefore, to ensure that we only avoid
+  // duplicate calls to VisitVarDef, these semantics need to be
+  // checked.
+  std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> defined_params;
+  std::vector<std::variant<DefContext<Var>, DefContext<Buffer>>> context;
+
+  auto ppath = path->Attr("params");
+  for (size_t i = 0; i < func->params.size(); i++) {
+    context.push_back(WithDef(func->params[i], ppath->ArrayIndex(i)));
+    defined_params.insert(func->params[i]);
+  }
+
+  auto try_visit_implicit_var_def = [this, &defined_params, &context](const PrimExpr& expr,
+                                                                      ObjectPath path) {
+    if (auto opt = expr.as<Var>()) {
+      auto var = opt.value();
+      if (!defined_params.count(var)) {
+        context.push_back(WithDef(var, path));
+        defined_params.insert(var);
+      }
+    }
+  };
+  auto try_visit_implicit_var_def_array = [&try_visit_implicit_var_def](const Array<PrimExpr>& arr,
+                                                                        ObjectPath path) {
+    for (size_t i = 0; i < arr.size(); i++) {
+      try_visit_implicit_var_def(arr[i], path->ArrayIndex(i));
+    }
+  };
+
+  auto buffer_map_path = path->Attr("buffer_map");
+  for (size_t i = 0; i < func->params.size(); i++) {
+    if (auto opt = func->buffer_map.Get(func->params[i])) {
+      auto buf = opt.value();
+      auto buf_path = buffer_map_path->MapValue(ppath->ArrayIndex(i));
+
+      // A buffer in the buffer_map always defines its data pointer
+      context.push_back(WithDef(buf->data, buf_path->Attr("data")));
+
+      // But other implicit definitions only apply if they weren't
+      // provided as explicit parameters, and they weren't defined
+      // implicitly by any previous buffer.
+      try_visit_implicit_var_def_array(buf->shape, buf_path->Attr("shape"));
+      try_visit_implicit_var_def_array(buf->strides, buf_path->Attr("strides"));
+      try_visit_implicit_var_def(buf->elem_offset, buf_path->Attr("elem_offset"));
+    }
+  }
+
+  // Only after all the implicit definitions have been visited can we
+  // visit the buffer definition itself.
+  for (size_t i = 0; i < func->params.size(); i++) {
+    if (auto opt = func->buffer_map.Get(func->params[i])) {
+      auto buf_path = buffer_map_path->MapValue(ppath->ArrayIndex(i));
+      EnterDef(opt.value(), buf_path);
+    }
+  }
+
+  Visit(func->body, path->Attr("body"));
+
+  while (context.size()) context.pop_back();
+}
+
+void TIRVisitorWithPath::EnterDef(const IterVar& iter_var, ObjectPath path) {
+  if (iter_var->dom.defined()) {
+    Visit(iter_var->dom, path->Attr("dom"));
+  }
+  EnterDef(iter_var->var, path->Attr("var"));
+}
+
+void TIRVisitorWithPath::ExitDef(const IterVar& iter_var, ObjectPath path) {
+  ExitDef(iter_var->var, path->Attr("var"));
+}
+
+void TIRVisitorWithPath::EnterDef(const Buffer& buffer, ObjectPath path) {
+  // Defining a buffer counts as using all parameters in the buffer
+  // (e.g. shape/strides).
+  Visit(buffer->data, path->Attr("data"));
+  Visit(buffer->shape, path->Attr("shape"));
+  Visit(buffer->strides, path->Attr("strides"));
+  Visit(buffer->elem_offset, path->Attr("elem_offset"));
+}
+void TIRVisitorWithPath::ExitDef(const Buffer& buffer, ObjectPath path) {}
+
+void TIRVisitorWithPath::Visit(const Buffer& buffer, ObjectPath path) {
+  // Using a buffer *also* counts as using all parameters in the buffer.
+  Visit(buffer->data, path->Attr("data"));
+  Visit(buffer->shape, path->Attr("shape"));
+  Visit(buffer->strides, path->Attr("strides"));
+  Visit(buffer->elem_offset, path->Attr("elem_offset"));
+}
+
+void TIRVisitorWithPath::Visit(const BufferRegion& region, ObjectPath path) {
+  Visit(region->buffer, path->Attr("path"));
+  Visit(region->region, path->Attr("region"));
+}
+
+void TIRVisitorWithPath::Visit(const MatchBufferRegion& match, ObjectPath path) {
+  Visit(match->source, path->Attr("source"));
+
+  // MatchBufferRegion define the match->buffer, but do not own the
+  // body in which the match->buffer is defined.  Therefore, the
+  // definitions are handled in the BlockNode visitor.
+}
+
+void TIRVisitorWithPath::Visit(const IterVar& iter_var, ObjectPath path) {
+  if (iter_var->dom.defined()) {
+    Visit(iter_var->dom, path->Attr("dom"));
+  }
+  Visit(iter_var->var, path->Attr("var"));
+}
+
+void TIRVisitorWithPath::Visit(const Range& range, ObjectPath path) {
+  Visit(range->min, path->Attr("min"));
+  Visit(range->extent, path->Attr("extent"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const LetStmtNode* op, ObjectPath path) {
+  Visit(op->value, path->Attr("value"));
+  auto context = WithDef(op->var, path->Attr("var"));
+  Visit(op->body, path->Attr("body"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const AttrStmtNode* op, ObjectPath path) {
+  Visit(op->value, path->Attr("value"));
+
+  std::optional<DefContext<Var>> context = std::nullopt;
+  if (auto ptr = op->node.as<IterVarNode>(); ptr && op->attr_key == attr::thread_extent) {
+    // Some attributes serve as a source of definition for the
+    // tir::Var they annotate.
+    Visit(ptr->dom, path->Attr("node")->Attr("dom"));
+    context = WithDef(ptr->var, path->Attr("node")->Attr("var"));
+  } else if (auto expr = op->node.as<PrimExpr>()) {
+    Visit(expr.value(), path->Attr("node"));
+  }
+  Visit(op->body, path->Attr("body"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const ForNode* op, ObjectPath path) {
+  Visit(op->min, path->Attr("min"));
+  Visit(op->extent, path->Attr("extent"));
+  auto context = WithDef(op->loop_var, path->Attr("loop_var"));
+  Visit(op->body, path->Attr("body"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const WhileNode* op, ObjectPath path) {
+  Visit(op->condition, path->Attr("condition"));
+  Visit(op->body, path->Attr("body"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const AllocateNode* op, ObjectPath path) {
+  Visit(op->condition, path->Attr("condition"));
+  Visit(op->extents, path->Attr("extents"));
+  auto context = WithDef(op->buffer_var, path->Attr("buffer_var"));
+  Visit(op->body, path->Attr("body"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const AllocateConstNode* op, ObjectPath path) {
+  Visit(op->extents, path->Attr("extents"));
+  auto context = WithDef(op->buffer_var, path->Attr("buffer_var"));
+  Visit(op->body, path->Attr("body"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const DeclBufferNode* op, ObjectPath path) {
+  auto context = WithDef(op->buffer, path->Attr("buffer"));
+  Visit(op->body, path->Attr("body"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const BufferStoreNode* op, ObjectPath path) {
+  Visit(op->value, path->Attr("value"));
+  Visit(op->buffer, path->Attr("buffer"));
+  Visit(op->indices, path->Attr("indices"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const BufferRealizeNode* op, ObjectPath path) {
+  Visit(op->condition, path->Attr("condition"));
+  Visit(op->bounds, path->Attr("bounds"));
+  auto context = WithDef(op->buffer, path->Attr("buffer"));
+  Visit(op->body, path->Attr("body"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const IfThenElseNode* op, ObjectPath path) {
+  Visit(op->condition, path->Attr("condition"));
+  Visit(op->then_case, path->Attr("then_case"));
+  Visit(op->else_case, path->Attr("else_case"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const AssertStmtNode* op, ObjectPath path) {
+  Visit(op->condition, path->Attr("condition"));
+  Visit(op->message, path->Attr("message"));
+  Visit(op->body, path->Attr("body"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const ProducerStoreNode* op, ObjectPath path) {
+  Visit(op->indices, path->Attr("indices"));
+  Visit(op->value, path->Attr("value"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const ProducerRealizeNode* op, ObjectPath path) {
+  Visit(op->bounds, path->Attr("bounds"));
+  Visit(op->body, path->Attr("body"));
+  Visit(op->condition, path->Attr("condition"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const PrefetchNode* op, ObjectPath path) {
+  Visit(op->bounds, path->Attr("bounds"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const SeqStmtNode* op, ObjectPath path) {
+  Visit(op->seq, path->Attr("seq"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const EvaluateNode* op, ObjectPath path) {
+  Visit(op->value, path->Attr("value"));
+}
+
+void TIRVisitorWithPath::VisitStmt_(const BlockNode* op, ObjectPath path) {
+  std::vector<std::variant<DefContext<Var>, DefContext<IterVar>, DefContext<Buffer>>> context;
+
+  {
+    auto iter_path = path->Attr("iter_vars");
+    for (size_t i = 0; i < op->iter_vars.size(); i++) {
+      context.push_back(WithDef(op->iter_vars[i], iter_path->ArrayIndex(i)));
+    }
+  }
+  Visit(op->reads, path->Attr("reads"));
+  Visit(op->writes, path->Attr("writes"));
+
+  {
+    auto alloc_path = path->Attr("alloc_buffers");
+    for (size_t i = 0; i < op->alloc_buffers.size(); i++) {
+      auto buffer_path = alloc_path->ArrayIndex(i);
+      auto buf = op->alloc_buffers[i];
+      context.push_back(WithDef(buf->data, buffer_path->Attr("data")));
+      context.push_back(WithDef(buf, buffer_path));
+    }
+  }
+
+  {
+    auto match_path = path->Attr("match_buffers");
+    Visit(op->match_buffers, match_path);
+
+    for (size_t i = 0; i < op->match_buffers.size(); i++) {
+      auto buf = op->match_buffers[i]->buffer;
+      auto buffer_path = match_path->ArrayIndex(i)->Attr("buffer");
+      context.push_back(WithDef(buf->data, buffer_path->Attr("data")));
+      context.push_back(WithDef(buf, buffer_path));
+    }
+  }
+
+  Visit(op->init, path->Attr("init"));
+  Visit(op->body, path->Attr("body"));
+
+  while (context.size()) context.pop_back();
+}
+
+void TIRVisitorWithPath::VisitStmt_(const BlockRealizeNode* op, ObjectPath path) {
+  Visit(op->iter_values, path->Attr("iter_values"));
+  Visit(op->predicate, path->Attr("predicate"));
+  Visit(op->block, path->Attr("block"));
+}
+
+void TIRVisitorWithPath::VisitExpr_(const VarNode* op, ObjectPath path) {}
+
+void TIRVisitorWithPath::VisitExpr_(const SizeVarNode* op, ObjectPath path) {
+  VisitExpr_(static_cast<const VarNode*>(op), path);
+}
+
+void TIRVisitorWithPath::VisitExpr_(const AnyNode* op, ObjectPath path) {}
+
+void TIRVisitorWithPath::VisitExpr_(const BufferLoadNode* op, ObjectPath path) {
+  Visit(op->buffer, path->Attr("buffer"));
+  Visit(op->indices, path->Attr("indices"));
+}
+
+void TIRVisitorWithPath::VisitExpr_(const ProducerLoadNode* op, ObjectPath path) {
+  Visit(op->indices, path->Attr("indices"));
+}
+
+void TIRVisitorWithPath::VisitExpr_(const LetNode* op, ObjectPath path) {
+  Visit(op->value, path->Attr("value"));
+  auto context = WithDef(op->var, path->Attr("var"));
+  Visit(op->body, path->Attr("body"));
+}
+
+void TIRVisitorWithPath::VisitExpr_(const CallNode* op, ObjectPath path) {
+  if (auto gvar = op->op.as<GlobalVar>()) {
+    Visit(gvar.value(), path->Attr("op"));
+  }
+  Visit(op->args, path->Attr("args"));
+}
+
+#define DEFINE_BINOP_VISIT_(OP)                                        \
+  void TIRVisitorWithPath::VisitExpr_(const OP* op, ObjectPath path) { \
+    Visit(op->a, path->Attr("a"));                                     \
+    Visit(op->b, path->Attr("b"));                                     \
+  }
+
+DEFINE_BINOP_VISIT_(AddNode);
+DEFINE_BINOP_VISIT_(SubNode);
+DEFINE_BINOP_VISIT_(MulNode);
+DEFINE_BINOP_VISIT_(DivNode);
+DEFINE_BINOP_VISIT_(ModNode);
+DEFINE_BINOP_VISIT_(FloorDivNode);
+DEFINE_BINOP_VISIT_(FloorModNode);
+DEFINE_BINOP_VISIT_(MinNode);
+DEFINE_BINOP_VISIT_(MaxNode);
+DEFINE_BINOP_VISIT_(EQNode);
+DEFINE_BINOP_VISIT_(NENode);
+DEFINE_BINOP_VISIT_(LTNode);
+DEFINE_BINOP_VISIT_(LENode);
+DEFINE_BINOP_VISIT_(GTNode);
+DEFINE_BINOP_VISIT_(GENode);
+DEFINE_BINOP_VISIT_(AndNode);
+DEFINE_BINOP_VISIT_(OrNode);
+
+#undef DEFINE_BINOP_VISIT_
+
+void TIRVisitorWithPath::VisitExpr_(const IntImmNode* op, ObjectPath path) {}
+void TIRVisitorWithPath::VisitExpr_(const FloatImmNode* op, ObjectPath path) {}
+void TIRVisitorWithPath::VisitExpr_(const StringImmNode* op, ObjectPath path) {}
+
+void TIRVisitorWithPath::VisitExpr_(const ReduceNode* op, ObjectPath path) {
+  Visit(op->axis, path->Attr("axis"));
+  Visit(op->source, path->Attr("source"));
+  Visit(op->init, path->Attr("init"));
+  Visit(op->condition, path->Attr("condition"));
+}
+
+void TIRVisitorWithPath::VisitExpr_(const CastNode* op, ObjectPath path) {
+  Visit(op->value, path->Attr("value"));
+}
+
+void TIRVisitorWithPath::VisitExpr_(const NotNode* op, ObjectPath path) {
+  Visit(op->a, path->Attr("a"));
+}
+
+void TIRVisitorWithPath::VisitExpr_(const SelectNode* op, ObjectPath path) {
+  Visit(op->condition, path->Attr("condition"));
+  Visit(op->true_value, path->Attr("true_value"));
+  Visit(op->false_value, path->Attr("false_value"));
+}
+
+void TIRVisitorWithPath::VisitExpr_(const RampNode* op, ObjectPath path) {
+  Visit(op->base, path->Attr("base"));
+  Visit(op->stride, path->Attr("stride"));
+}
+
+void TIRVisitorWithPath::VisitExpr_(const ShuffleNode* op, ObjectPath path) {
+  Visit(op->indices, path->Attr("indices"));
+  Visit(op->vectors, path->Attr("vectors"));
+}
+
+void TIRVisitorWithPath::VisitExpr_(const BroadcastNode* op, ObjectPath path) {
+  Visit(op->value, path->Attr("value"));
+}
+
+}  // namespace tir
+}  // namespace tvm

--- a/src/tir/ir/tir_visitor_with_path.cc
+++ b/src/tir/ir/tir_visitor_with_path.cc
@@ -200,12 +200,12 @@ void TIRVisitorWithPath::VisitStmt_(const LetStmtNode* op, ObjectPath path) {
 void TIRVisitorWithPath::VisitStmt_(const AttrStmtNode* op, ObjectPath path) {
   Visit(op->value, path->Attr("value"));
 
-  std::optional<DefContext<Var>> context = std::nullopt;
-  if (auto ptr = op->node.as<IterVarNode>(); ptr && op->attr_key == attr::thread_extent) {
+  std::optional<DefContext<IterVar>> context = std::nullopt;
+  if (auto iter_var = op->node.as<IterVar>();
+      iter_var && (op->attr_key == attr::thread_extent || op->attr_key == attr::virtual_thread)) {
     // Some attributes serve as a source of definition for the
     // tir::Var they annotate.
-    Visit(ptr->dom, path->Attr("node")->Attr("dom"));
-    context = WithDef(ptr->var, path->Attr("node")->Attr("var"));
+    context = WithDef(iter_var.value(), path->Attr("node"));
   } else if (auto expr = op->node.as<PrimExpr>()) {
     Visit(expr.value(), path->Attr("node"));
   }

--- a/src/tir/ir/tir_visitor_with_path.cc
+++ b/src/tir/ir/tir_visitor_with_path.cc
@@ -24,8 +24,12 @@
 
 #include "tir_visitor_with_path.h"
 
+#include <algorithm>
 #include <optional>
+#include <unordered_set>
+#include <utility>
 #include <variant>
+#include <vector>
 
 namespace tvm {
 namespace tir {

--- a/src/tir/ir/tir_visitor_with_path.cc
+++ b/src/tir/ir/tir_visitor_with_path.cc
@@ -27,7 +27,6 @@
 #include <algorithm>
 #include <optional>
 #include <unordered_set>
-#include <utility>
 #include <variant>
 #include <vector>
 

--- a/src/tir/ir/tir_visitor_with_path.cc
+++ b/src/tir/ir/tir_visitor_with_path.cc
@@ -166,7 +166,7 @@ void TIRVisitorWithPath::Visit(const Buffer& buffer, ObjectPath path) {
 }
 
 void TIRVisitorWithPath::Visit(const BufferRegion& region, ObjectPath path) {
-  Visit(region->buffer, path->Attr("path"));
+  Visit(region->buffer, path->Attr("buffer"));
   Visit(region->region, path->Attr("region"));
 }
 

--- a/src/tir/ir/tir_visitor_with_path.h
+++ b/src/tir/ir/tir_visitor_with_path.h
@@ -29,6 +29,7 @@
 #include <tvm/tir/stmt_functor.h>
 
 #include <exception>
+#include <utility>
 
 namespace tvm {
 namespace tir {

--- a/src/tir/ir/tir_visitor_with_path.h
+++ b/src/tir/ir/tir_visitor_with_path.h
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tir/ir/tir_visitor_with_path.h
+ * \brief Provide a TIR visitor that tracks the current location
+ */
+#ifndef TVM_TIR_IR_TIR_VISITOR_WITH_PATH_H_
+#define TVM_TIR_IR_TIR_VISITOR_WITH_PATH_H_
+
+#include <tvm/ir/module.h>
+#include <tvm/tir/expr_functor.h>
+#include <tvm/tir/stmt_functor.h>
+
+#include <exception>
+
+namespace tvm {
+namespace tir {
+
+/*! \brief Visit TIR while tracking the ObjectPath */
+class TIRVisitorWithPath : protected ExprFunctor<void(const PrimExpr&, ObjectPath)>,
+                           protected StmtFunctor<void(const Stmt&, ObjectPath)> {
+ public:
+  template <typename TObjectRef>
+  void operator()(TObjectRef&& obj) {
+    Visit(std::forward<TObjectRef>(obj), ObjectPath::Root());
+  }
+
+ protected:
+  // Delegate to ExprFunctor::VisitExpr for PrimExpr, and any subclasses
+  inline void Visit(const PrimExpr& obj, ObjectPath path) { VisitExpr(obj, path); }
+  // Delegate to ExprFunctor::VisitStmt for Stmt, and any subclasses
+  inline void Visit(const Stmt& obj, ObjectPath path) { VisitStmt(obj, path); }
+
+  // Visitors for TIR constructs that are neither PrimExpr nor Stmt
+  virtual void Visit(const IRModule& obj, ObjectPath path);
+  virtual void Visit(const PrimFunc& obj, ObjectPath path);
+  virtual void Visit(const GlobalVar& obj, ObjectPath path) {}
+  virtual void Visit(const Range& obj, ObjectPath path);
+  virtual void Visit(const Buffer& obj, ObjectPath path);
+  virtual void Visit(const BufferRegion& obj, ObjectPath path);
+  virtual void Visit(const MatchBufferRegion& obj, ObjectPath path);
+  virtual void Visit(const IterVar& obj, ObjectPath path);
+
+  // Called when entering/exiting the scope of a GlobalVar definition.
+  virtual void EnterDef(const GlobalVar& var, ObjectPath path) {}
+  virtual void ExitDef(const GlobalVar& var, ObjectPath path) {}
+
+  // Called when entering/exiting the scope of a tir::Var definition.
+  virtual void EnterDef(const Var& var, ObjectPath path) {}
+  virtual void ExitDef(const Var& var, ObjectPath path) {}
+
+  // Called when entering/exiting the scope of an IterVar definition.
+  // By default, visits the `Range IterVarNode::dom`, then enters the
+  // scope of the internal `tir::Var`.
+  virtual void EnterDef(const IterVar& var, ObjectPath path);
+  virtual void ExitDef(const IterVar& var, ObjectPath path);
+
+  // Called when entering/exiting the scope of a Buffer definition.
+  // By default, visits the buffer's data pointer, shape, strides, and
+  // elem_offset, which must be defined prior to defining the Buffer.
+  virtual void EnterDef(const Buffer& buffer, ObjectPath path);
+  virtual void ExitDef(const Buffer& buffer, ObjectPath path);
+
+  // Utility to visit an array of nodes
+  template <typename T>
+  inline void Visit(const Array<T>& arr, ObjectPath path) {
+    for (size_t i = 0; i < arr.size(); i++) {
+      Visit(arr[i], path->ArrayIndex(i));
+    }
+  }
+
+  // Utility to visit an optional node nodes
+  template <typename T>
+  inline void Visit(const Optional<T>& opt, ObjectPath path) {
+    if (opt) {
+      Visit(opt.value(), path);
+    }
+  }
+
+  using StmtFunctor::VisitStmt;
+  void VisitStmt_(const AttrStmtNode* op, ObjectPath path) override;
+  void VisitStmt_(const IfThenElseNode* op, ObjectPath path) override;
+  void VisitStmt_(const LetStmtNode* op, ObjectPath path) override;
+  void VisitStmt_(const ForNode* op, ObjectPath path) override;
+  void VisitStmt_(const WhileNode* op, ObjectPath path) override;
+  void VisitStmt_(const AllocateNode* op, ObjectPath path) override;
+  void VisitStmt_(const AllocateConstNode* op, ObjectPath path) override;
+  void VisitStmt_(const DeclBufferNode* op, ObjectPath path) override;
+  void VisitStmt_(const BufferStoreNode* op, ObjectPath path) override;
+  void VisitStmt_(const BufferRealizeNode* op, ObjectPath path) override;
+  void VisitStmt_(const AssertStmtNode* op, ObjectPath path) override;
+  void VisitStmt_(const ProducerStoreNode* op, ObjectPath path) override;
+  void VisitStmt_(const ProducerRealizeNode* op, ObjectPath path) override;
+  void VisitStmt_(const PrefetchNode* op, ObjectPath path) override;
+  void VisitStmt_(const SeqStmtNode* op, ObjectPath path) override;
+  void VisitStmt_(const EvaluateNode* op, ObjectPath path) override;
+  void VisitStmt_(const BlockNode* op, ObjectPath path) override;
+  void VisitStmt_(const BlockRealizeNode* op, ObjectPath path) override;
+
+  using ExprFunctor::VisitExpr;
+  void VisitExpr_(const VarNode* op, ObjectPath path) override;
+  void VisitExpr_(const SizeVarNode* op, ObjectPath path) override;
+  void VisitExpr_(const BufferLoadNode* op, ObjectPath path) override;
+  void VisitExpr_(const ProducerLoadNode* op, ObjectPath path) override;
+  void VisitExpr_(const LetNode* op, ObjectPath path) override;
+  void VisitExpr_(const CallNode* op, ObjectPath path) override;
+  void VisitExpr_(const AddNode* op, ObjectPath path) override;
+  void VisitExpr_(const SubNode* op, ObjectPath path) override;
+  void VisitExpr_(const MulNode* op, ObjectPath path) override;
+  void VisitExpr_(const DivNode* op, ObjectPath path) override;
+  void VisitExpr_(const ModNode* op, ObjectPath path) override;
+  void VisitExpr_(const FloorDivNode* op, ObjectPath path) override;
+  void VisitExpr_(const FloorModNode* op, ObjectPath path) override;
+  void VisitExpr_(const MinNode* op, ObjectPath path) override;
+  void VisitExpr_(const MaxNode* op, ObjectPath path) override;
+  void VisitExpr_(const EQNode* op, ObjectPath path) override;
+  void VisitExpr_(const NENode* op, ObjectPath path) override;
+  void VisitExpr_(const LTNode* op, ObjectPath path) override;
+  void VisitExpr_(const LENode* op, ObjectPath path) override;
+  void VisitExpr_(const GTNode* op, ObjectPath path) override;
+  void VisitExpr_(const GENode* op, ObjectPath path) override;
+  void VisitExpr_(const AndNode* op, ObjectPath path) override;
+  void VisitExpr_(const OrNode* op, ObjectPath path) override;
+  void VisitExpr_(const ReduceNode* op, ObjectPath path) override;
+  void VisitExpr_(const CastNode* op, ObjectPath path) override;
+  void VisitExpr_(const NotNode* op, ObjectPath path) override;
+  void VisitExpr_(const SelectNode* op, ObjectPath path) override;
+  void VisitExpr_(const RampNode* op, ObjectPath path) override;
+  void VisitExpr_(const BroadcastNode* op, ObjectPath path) override;
+  void VisitExpr_(const ShuffleNode* op, ObjectPath path) override;
+  void VisitExpr_(const IntImmNode* op, ObjectPath path) override;
+  void VisitExpr_(const FloatImmNode* op, ObjectPath path) override;
+  void VisitExpr_(const StringImmNode* op, ObjectPath path) override;
+  void VisitExpr_(const AnyNode* op, ObjectPath path) override;
+
+  // Utility to call EnterDef/ExitDef.  Used in the implementation of
+  // WithDef.
+  template <typename T>
+  class DefContext {
+   public:
+    DefContext(DefContext&& other) { swap(std::move(other)); }
+    DefContext& operator=(DefContext&& other) {
+      swap(std::move(other));
+      return *this;
+    }
+
+    DefContext(const DefContext&) = delete;
+    DefContext& operator=(const DefContext&) = delete;
+    ~DefContext() noexcept(false) {
+      // Checks performed when a definition goes out of scope may
+      // raise an exception.  If the stack is already being unwound
+      // due to another exception being thrown, this would cause a
+      // segfault and terminate the program.  By checking that no
+      // additional exceptions have been thrown between the
+      // construction of the DefContext and the destruction, we avoid
+      // this case and allow the first error to propagate upward.
+      if (self_ && std::uncaught_exceptions() == uncaught_exceptions_) {
+        self_->ExitDef(obj_, path_);
+      }
+    }
+
+   private:
+    friend class TIRVisitorWithPath;
+
+    DefContext(TIRVisitorWithPath* self, T obj, ObjectPath path)
+        : self_(self), obj_(obj), path_(path), uncaught_exceptions_(std::uncaught_exceptions()) {
+      self_->EnterDef(obj_, path_);
+    }
+
+    void swap(DefContext&& other) {
+      std::swap(this->self_, other.self_);
+      std::swap(this->obj_, other.obj_);
+      std::swap(this->path_, other.path_);
+      std::swap(this->uncaught_exceptions_, other.uncaught_exceptions_);
+    }
+
+    TIRVisitorWithPath* self_{nullptr};
+    T obj_;
+    ObjectPath path_{ObjectPath::Root()};
+    int uncaught_exceptions_{-1};
+  };
+
+  // Utility to track the scope of a node's definition.
+  template <typename T>
+  DefContext<T> WithDef(T obj, ObjectPath path) {
+    return DefContext(this, obj, path);
+  }
+};
+
+}  // namespace tir
+}  // namespace tvm
+#endif  // TVM_TIR_IR_TIR_VISITOR_WITH_PATH_H_

--- a/src/tir/transforms/split_host_device.cc
+++ b/src/tir/transforms/split_host_device.cc
@@ -57,7 +57,7 @@ class HostDeviceSplitter : public StmtMutator {
  private:
   Stmt SplitDeviceFunc(Stmt body, Target device_target) {
     auto [params, buffers_to_declare] = [&]() -> std::tuple<Array<Var>, Array<Buffer>> {
-      VarUseDefAnalyzer use_def(/*defined_vars=*/{}, /*visit_thread_extent=*/false);
+      VarUseDefAnalyzer use_def(/*defined_vars=*/{}, /*visit_thread_extent=*/true);
       use_def(body);
 
       // Sort first by variable type, then by variable name

--- a/tests/python/tir-analysis/test_tir_analysis_verify_well_formed.py
+++ b/tests/python/tir-analysis/test_tir_analysis_verify_well_formed.py
@@ -67,7 +67,9 @@ def test_error_for_out_of_scope_usage():
             T.evaluate(i)
         T.evaluate(i)
 
-    with pytest.raises(ValueError, match="Invalid use of variable i at .* no longer in-scope."):
+    with pytest.raises(
+        ValueError, match="Invalid use of undefined variable i at .* no longer in-scope."
+    ):
         tvm.tir.analysis.verify_well_formed(func)
 
 

--- a/tests/python/tir-analysis/test_tir_analysis_verify_well_formed.py
+++ b/tests/python/tir-analysis/test_tir_analysis_verify_well_formed.py
@@ -123,5 +123,80 @@ def test_error_for_cross_function_reuse():
         tvm.tir.analysis.verify_well_formed(mod)
 
 
+def test_reuse_of_env_thread_in_function_is_well_formed():
+    """An env thread may be reused within a PrimFunc
+
+    The `T.env_thread` has unique semantics, and may be defined at
+    multiple locations without the TIR being considered ill-formed.
+    """
+
+    @T.prim_func
+    def func(A: T.Buffer([256], "float32")):
+        threadIdx_x = T.env_thread("threadIdx.x")
+        with T.launch_thread(threadIdx_x, 256):
+            A[threadIdx_x] = A[threadIdx_x] + 1.0
+
+        with T.launch_thread(threadIdx_x, 256):
+            A[threadIdx_x] = A[threadIdx_x] + 2.0
+
+    tvm.tir.analysis.verify_well_formed(func)
+
+
+def test_reuse_of_env_thread_in_function_is_mandatory():
+    """An env thread may be reused within a PrimFunc
+
+    Not only are environment threads allowed to have multiple
+    definition sites, it is mandatory for them to have multiple
+    definition sites.  If a PrimFunc contains more than one
+    `"thread_extent"` with the same name, but with different `tir.Var`
+    instances, it is ill-formed.
+    """
+
+    @T.prim_func
+    def func(A: T.Buffer([256], "float32")):
+        with T.launch_thread("threadIdx.x", 256) as threadIdx_x:
+            A[threadIdx_x] = A[threadIdx_x] + 1.0
+
+        with T.launch_thread("threadIdx.x", 256) as threadIdx_x:
+            A[threadIdx_x] = A[threadIdx_x] + 2.0
+
+    with pytest.raises(ValueError):
+        tvm.tir.analysis.verify_well_formed(func)
+
+
+def test_reuse_of_env_thread_across_functions_is_ill_formed():
+    """An env thread may not be reused across PrimFunc
+
+    However, each function must have its own `tir.Var` representing
+    the environment thread, and may not share these variables across
+    PrimFuncs.
+    """
+
+    threadIdx_x = tvm.tir.Var("threadIdx_x", "int32")
+
+    @I.ir_module
+    class mod:
+        @T.prim_func
+        def kernel_1(A: T.Buffer([256], "float32")):
+            T.attr(
+                T.iter_var(threadIdx_x, T.Range(0, 256), "ThreadIndex", "threadIdx.x"),
+                "thread_extent",
+                256,
+            )
+            A[threadIdx_x] = A[threadIdx_x] + T.float32(1)
+
+        @T.prim_func
+        def kernel_2(A: T.Buffer([256], "float32")):
+            T.attr(
+                T.iter_var(threadIdx_x, T.Range(0, 256), "ThreadIndex", "threadIdx.x"),
+                "thread_extent",
+                256,
+            )
+            A[threadIdx_x] = A[threadIdx_x] + T.float32(1)
+
+    with pytest.raises(ValueError, match="multiple definitions of variable threadIdx_x"):
+        tvm.tir.analysis.verify_well_formed(mod)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/tir-transform/test_tir_transform_split_host_device.py
+++ b/tests/python/tir-transform/test_tir_transform_split_host_device.py
@@ -308,8 +308,41 @@ def test_dynamic_launch_thread():
                 if blockIdx_x * 128 + threadIdx_x < seq_len:
                     B[blockIdx_x * 128 + threadIdx_x] = A[blockIdx_x * 128 + threadIdx_x]
 
+    @I.ir_module
+    class expected:
+        @T.prim_func
+        def default_function(var_A: T.handle, var_B: T.handle, seq_len: T.int32):
+            T.func_attr({"target": T.target("cuda")})
+            A = T.match_buffer(var_A, (seq_len,), "int32")
+            B = T.match_buffer(var_B, (seq_len,), "int32")
+            num_blocks: T.int32 = (seq_len + 127) // 128
+            expected.default_function_kernel(A.data, B.data, num_blocks, seq_len)
+
+        @T.prim_func(private=True)
+        def default_function_kernel(
+            A_data: T.handle("int32"),
+            B_data: T.handle("int32"),
+            num_blocks: T.int32,
+            seq_len: T.int32,
+        ):
+            T.func_attr(
+                {
+                    "target": T.target("cuda"),
+                    "tir.is_global_func": True,
+                    "tir.noalias": True,
+                }
+            )
+            A = T.decl_buffer(seq_len, "int32", data=A_data)
+            B = T.decl_buffer(seq_len, "int32", data=B_data)
+            blockIdx_x = T.launch_thread("blockIdx.x", num_blocks)
+            threadIdx_x = T.launch_thread("threadIdx.x", 128)
+            if blockIdx_x * 128 + threadIdx_x < seq_len:
+                B[blockIdx_x * 128 + threadIdx_x] = A[blockIdx_x * 128 + threadIdx_x]
+
     after = tvm.tir.transform.SplitHostDevice()(before)
+
     tvm.tir.analysis.verify_well_formed(after)
+    tvm.ir.assert_structural_equal(expected, after)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Otherwise, they would be undefined after being de-duplicated by `ConvertSSA`.