### PR TITLE
[Unity] Enable spot nodes in CI

### DIFF
--- a/ci/jenkins/unity_jenkinsfile.groovy
+++ b/ci/jenkins/unity_jenkinsfile.groovy
@@ -135,60 +135,64 @@ def should_skip_ci(pr_number) {
 
 cancel_previous_build()
 
-def lint() {
-stage('Prepare') {
-  node('CPU-SMALL') {
-    // When something is provided in ci_*_param, use it, otherwise default with ci_*
-    ci_lint = params.ci_lint_param ?: ci_lint
-    ci_cpu = params.ci_cpu_param ?: ci_cpu
-    ci_gpu = params.ci_gpu_param ?: ci_gpu
-    ci_wasm = params.ci_wasm_param ?: ci_wasm
-    ci_i386 = params.ci_i386_param ?: ci_i386
-    ci_qemu = params.ci_qemu_param ?: ci_qemu
-    ci_arm = params.ci_arm_param ?: ci_arm
-    ci_hexagon = params.ci_hexagon_param ?: ci_hexagon
+def lint(node_type) {
+  stage('Prepare') {
+    node(node_type) {
+      // When something is provided in ci_*_param, use it, otherwise default with ci_*
+      ci_lint = params.ci_lint_param ? : ci_lint
+      ci_cpu = params.ci_cpu_param ? : ci_cpu
+      ci_gpu = params.ci_gpu_param ? : ci_gpu
+      ci_wasm = params.ci_wasm_param ? : ci_wasm
+      ci_i386 = params.ci_i386_param ? : ci_i386
+      ci_qemu = params.ci_qemu_param ? : ci_qemu
+      ci_arm = params.ci_arm_param ? : ci_arm
+      ci_hexagon = params.ci_hexagon_param ? : ci_hexagon
 
-    sh (script: """
-      echo "Docker images being used in this build:"
-      echo " ci_lint = ${ci_lint}"
-      echo " ci_cpu  = ${ci_cpu}"
-      echo " ci_gpu  = ${ci_gpu}"
-      echo " ci_wasm = ${ci_wasm}"
-      echo " ci_i386 = ${ci_i386}"
-      echo " ci_qemu = ${ci_qemu}"
-      echo " ci_arm  = ${ci_arm}"
-      echo " ci_hexagon  = ${ci_hexagon}"
-    """, label: 'Docker image names')
+      sh(script: """
+        echo "Docker images being used in this build:"
+        echo " ci_lint = ${ci_lint}"
+        echo " ci_cpu  = ${ci_cpu}"
+        echo " ci_gpu  = ${ci_gpu}"
+        echo " ci_wasm = ${ci_wasm}"
+        echo " ci_i386 = ${ci_i386}"
+        echo " ci_qemu = ${ci_qemu}"
+        echo " ci_arm  = ${ci_arm}"
+        echo " ci_hexagon  = ${ci_hexagon}"
+        """, label: 'Docker image names')
+    }
   }
-}
 
-stage('Sanity Check') {
-  timeout(time: max_time, unit: 'MINUTES') {
-    node('CPU-SMALL') {
-      ws(per_exec_ws('tvm/sanity')) {
-        init_git()
-        is_docs_only_build = sh (
-          returnStatus: true,
-          script: './tests/scripts/git_change_docs.sh',
-          label: 'Check for docs only changes',
-        )
-        skip_ci = should_skip_ci(env.CHANGE_ID)
-        skip_slow_tests = should_skip_slow_tests(env.CHANGE_ID)
-        sh (
-          script: "${docker_run} ${ci_lint}  ./tests/scripts/task_lint.sh",
-          label: 'Run lint',
-        )
-        sh (
-          script: "${docker_run} ${ci_lint}  ./tests/scripts/unity/task_extra_lint.sh",
-          label: 'Run extra lint',
-        )
+  stage('Sanity Check') {
+    timeout(time: max_time, unit: 'MINUTES') {
+      node(node_type) {
+        ws(per_exec_ws('tvm/sanity')) {
+          init_git()
+          is_docs_only_build = sh(
+            returnStatus: true,
+            script: './tests/scripts/git_change_docs.sh',
+            label: 'Check for docs only changes',
+          )
+          skip_ci = should_skip_ci(env.CHANGE_ID)
+          skip_slow_tests = should_skip_slow_tests(env.CHANGE_ID)
+          sh(
+            script: "${docker_run} ${ci_lint}  ./tests/scripts/task_lint.sh",
+            label: 'Run lint',
+          )
+          sh(
+            script: "${docker_run} ${ci_lint}  ./tests/scripts/unity/task_extra_lint.sh",
+            label: 'Run extra lint',
+          )
+        }
       }
     }
   }
 }
-}
 
-lint()
+try {
+  lint('CPU-SMALL-SPOT')
+} catch (Exception ex) {
+  lint('CPU-SMALL')
+}
 
 // Run make. First try to do an incremental make from a previous workspace in hope to
 // accelerate the compilation. If something is wrong, clean the workspace and then
@@ -322,7 +326,7 @@ stage('Build and Test') {
       }
     },
     'BUILD: CPU': {
-      node('CPU-SMALL') {
+      node('CPU-SMALL-SPOT') {
         ws(per_exec_ws('tvm/build-cpu')) {
           init_git()
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_config_build_cpu.sh build"


### PR DESCRIPTION
CPU-SMALL nodes are unstable and often fail to build. This patch enables spot nodes in CI to reduce the cost.

cc @tqchen 