### PR TITLE
[TVMC] Add tvmc flag to print ir before and print ir after named pass 

### DIFF
--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -262,7 +262,7 @@ def compile_model(
     workspace_pools: Optional[WorkspaceMemoryPools] = None,
     print_pass_times: bool = False,
     print_ir_before: Optional[List[str]] = None,
-    print_ir_after: Optional[List[str]]= None,
+    print_ir_after: Optional[List[str]] = None,
     instruments: Optional[Sequence[PassInstrument]] = None,
     desired_layout: Optional[str] = None,
     desired_layout_ops: Optional[List[str]] = None,

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -261,8 +261,8 @@ def compile_model(
     mod_name: Optional[str] = "default",
     workspace_pools: Optional[WorkspaceMemoryPools] = None,
     print_pass_times: bool = False,
-    print_ir_before: List[str] = [],
-    print_ir_after: List[str] = [],
+    print_ir_before: Optional[List[str]] = None,
+    print_ir_after: Optional[List[str]]= None,
     instruments: Optional[Sequence[PassInstrument]] = None,
     desired_layout: Optional[str] = None,
     desired_layout_ops: Optional[List[str]] = None,
@@ -326,9 +326,9 @@ def compile_model(
         compilation.
     print_pass_times: bool
         To enable printing a breakdown of compilation times by pass. Disabled by default.
-    print_ir_before: list[str]
+    print_ir_before: list[str], optional
         To print IR before each named pass of a comma-separated list of passes.
-    print_ir_after: list[str]
+    print_ir_after: list[str], optional
         To print IR after each named pass of a comma-separated list of passes.
     instruments: Optional[Sequence[PassInstrument]]
         The list of pass instrument implementations.

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -261,8 +261,8 @@ def compile_model(
     mod_name: Optional[str] = "default",
     workspace_pools: Optional[WorkspaceMemoryPools] = None,
     print_pass_times: bool = False,
-    print_ir_before: List[str] = "",
-    print_ir_after: List[str] = "",
+    print_ir_before: List[str] = [],
+    print_ir_after: List[str] = [],
     instruments: Optional[Sequence[PassInstrument]] = None,
     desired_layout: Optional[str] = None,
     desired_layout_ops: Optional[List[str]] = None,
@@ -389,19 +389,11 @@ def compile_model(
         timing_inst = PassTimingInstrument()
         instruments = [timing_inst] if instruments is None else [timing_inst] + instruments
 
-    if print_ir_before:
-        print_ir_before_instr = PassPrintingInstrument("before", print_ir_before)
-        instruments = (
-            [print_ir_before_instr]
-            if instruments is None
-            else [print_ir_before_instr] + instruments
+    if print_ir_before or print_ir_after:
+        print_ir_instr = PassPrintingInstrument(
+            print_before_pass_names=print_ir_before, print_after_pass_names=print_ir_after
         )
-
-    if print_ir_after:
-        print_ir_after_instr = PassPrintingInstrument("after", print_ir_after)
-        instruments = (
-            [print_ir_after_instr] if instruments is None else [print_ir_after_instr] + instruments
-        )
+        instruments = [print_ir_instr] if instruments is None else [print_ir_instr] + instruments
 
     with tvm.transform.PassContext(
         opt_level=opt_level,

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -31,7 +31,7 @@ import tvm
 from tvm import autotvm, auto_scheduler
 from tvm import relay
 from tvm.driver.tvmc.registry import generate_registry_args, reconstruct_registry_entity
-from tvm.ir.instrument import PassInstrument, PassTimingInstrument
+from tvm.ir.instrument import PassInstrument, PassTimingInstrument, PassPrintBefore, PassPrintAfter
 from tvm.ir.memory_pools import WorkspaceMemoryPools
 from tvm.target import Target
 from tvm.relay.backend import Executor, Runtime
@@ -162,6 +162,18 @@ def add_compile_parser(subparsers, _, json_params):
         action="store_true",
         help="print compilation time per pass",
     )
+    parser.add_argument(
+        "--print-ir-before",
+        help="print IR before each named pass of a comma-separated list of pass names."
+        "e.g. '--print-ir-before [tir.SplitHostDevice,tir.ConvertSSA]' ",
+        default="",
+    )
+    parser.add_argument(
+        "--print-ir-after",
+        help="print IR after each named pass of a comma-separated list of pass names."
+        "e.g. '--print-ir-after [tir.SplitHostDevice,tir.ConvertSSA]' ",
+        default="",
+    )
     for one_entry in json_params:
         parser.set_defaults(**one_entry)
 
@@ -220,6 +232,8 @@ def drive_compile(args):
             workspace_pools_recombobulate(args, [workspace_pools_target], extra_targets)
         ),
         print_pass_times=args.print_pass_times,
+        print_ir_before=args.print_ir_before,
+        print_ir_after=args.print_ir_after,
         **transform_args,
     )
 
@@ -247,6 +261,8 @@ def compile_model(
     mod_name: Optional[str] = "default",
     workspace_pools: Optional[WorkspaceMemoryPools] = None,
     print_pass_times: bool = False,
+    print_ir_before: List[str] = "",
+    print_ir_after: List[str] = "",
     instruments: Optional[Sequence[PassInstrument]] = None,
     desired_layout: Optional[str] = None,
     desired_layout_ops: Optional[List[str]] = None,
@@ -295,7 +311,7 @@ def compile_model(
         needs to be generated.
     disabled_pass: str, optional
         Comma-separated list of passes which needs to be disabled
-        during compilation
+        during compilation.
     pass_context_configs: list[str], optional
         List of strings containing a set of configurations to be passed to the
         PassContext.
@@ -310,6 +326,10 @@ def compile_model(
         compilation.
     print_pass_times: bool
         To enable printing a breakdown of compilation times by pass. Disabled by default.
+    print_ir_before: list[str]
+        To print ir before each named pass of a comma-separated list of passes.
+    print_ir_after: list[str]
+        To print ir after each named pass of a comma-separated list of passes.
     instruments: Optional[Sequence[PassInstrument]]
         The list of pass instrument implementations.
     desired_layout: str, optional
@@ -368,6 +388,20 @@ def compile_model(
     if print_pass_times:
         timing_inst = PassTimingInstrument()
         instruments = [timing_inst] if instruments is None else [timing_inst] + instruments
+
+    if print_ir_before:
+        print_ir_before_instr = PassPrintBefore(print_ir_before)
+        instruments = (
+            [print_ir_before_instr]
+            if instruments is None
+            else [print_ir_before_instr] + instruments
+        )
+
+    if print_ir_after:
+        print_ir_after_instr = PassPrintAfter(print_ir_after)
+        instruments = (
+            [print_ir_after_instr] if instruments is None else [print_ir_after_instr] + instruments
+        )
 
     with tvm.transform.PassContext(
         opt_level=opt_level,
@@ -581,7 +615,6 @@ def dump_operation_offloads(mod: tvm.ir.IRModule, initial_mod: tvm.ir.IRModule, 
     save_to_file = all([dump_path != "-", dump_path != ""])
 
     if print_to_console or save_to_file:
-
         operations_distribution = analyze_operations_distribution(mod)
 
         def annotate_f(x):

--- a/python/tvm/driver/tvmc/compiler.py
+++ b/python/tvm/driver/tvmc/compiler.py
@@ -31,7 +31,7 @@ import tvm
 from tvm import autotvm, auto_scheduler
 from tvm import relay
 from tvm.driver.tvmc.registry import generate_registry_args, reconstruct_registry_entity
-from tvm.ir.instrument import PassInstrument, PassTimingInstrument, PassPrintBefore, PassPrintAfter
+from tvm.ir.instrument import PassInstrument, PassTimingInstrument, PassPrintingInstrument
 from tvm.ir.memory_pools import WorkspaceMemoryPools
 from tvm.target import Target
 from tvm.relay.backend import Executor, Runtime
@@ -327,9 +327,9 @@ def compile_model(
     print_pass_times: bool
         To enable printing a breakdown of compilation times by pass. Disabled by default.
     print_ir_before: list[str]
-        To print ir before each named pass of a comma-separated list of passes.
+        To print IR before each named pass of a comma-separated list of passes.
     print_ir_after: list[str]
-        To print ir after each named pass of a comma-separated list of passes.
+        To print IR after each named pass of a comma-separated list of passes.
     instruments: Optional[Sequence[PassInstrument]]
         The list of pass instrument implementations.
     desired_layout: str, optional
@@ -390,7 +390,7 @@ def compile_model(
         instruments = [timing_inst] if instruments is None else [timing_inst] + instruments
 
     if print_ir_before:
-        print_ir_before_instr = PassPrintBefore(print_ir_before)
+        print_ir_before_instr = PassPrintingInstrument("before", print_ir_before)
         instruments = (
             [print_ir_before_instr]
             if instruments is None
@@ -398,7 +398,7 @@ def compile_model(
         )
 
     if print_ir_after:
-        print_ir_after_instr = PassPrintAfter(print_ir_after)
+        print_ir_after_instr = PassPrintingInstrument("after", print_ir_after)
         instruments = (
             [print_ir_after_instr] if instruments is None else [print_ir_after_instr] + instruments
         )

--- a/python/tvm/ir/instrument.py
+++ b/python/tvm/ir/instrument.py
@@ -255,3 +255,25 @@ class PassTimingInstrument(tvm.runtime.Object):
                 profiles = timing_inst.render()
         """
         return _ffi_instrument_api.RenderTimePassProfiles()
+
+
+@pass_instrument
+class PassPrintBefore:
+    def __init__(self, print_pass_name):
+        self.print_pass_name = print_pass_name
+
+    def run_before_pass(self, mod, pass_info):
+        if pass_info.name in self.print_pass_name:
+            print("Print ir before:")
+            print(str(pass_info.name) + "\n" + str(mod) + "\n\n")
+
+
+@pass_instrument
+class PassPrintAfter:
+    def __init__(self, print_pass_name):
+        self.print_pass_name = print_pass_name
+
+    def run_after_pass(self, mod, pass_info):
+        if pass_info.name in self.print_pass_name:
+            print("Print ir after:")
+            print(str(pass_info.name) + "\n" + str(mod) + "\n\n")

--- a/python/tvm/ir/instrument.py
+++ b/python/tvm/ir/instrument.py
@@ -259,14 +259,17 @@ class PassTimingInstrument(tvm.runtime.Object):
 
 @pass_instrument
 class PassPrintingInstrument:
-    def __init__(self, print_before_pass_name, print_after_pass_name):
-        self.print_before_pass_name = print_before_pass_name
-        self.print_after_pass_name = print_after_pass_name
+    """A pass instrument to print if before or
+    print ir after each element of a named pass."""
+
+    def __init__(self, print_before_pass_names, print_after_pass_names):
+        self.print_before_pass_names = print_before_pass_names
+        self.print_after_pass_names = print_after_pass_names
 
     def run_before_pass(self, mod, pass_info):
-        if pass_info.name in self.print_before_pass_name:
-            print(f"Print IR before:\n{pass_info.name}\n{mod}\n\n")
+        if pass_info.name in self.print_before_pass_names:
+            print(f"Print IR before: {pass_info.name}\n{mod}\n\n")
 
     def run_after_pass(self, mod, pass_info):
-        if pass_info.name in self.print_after_pass_name:
-            print(f"Print IR after:\n{pass_info.name}\n{mod}\n\n")
+        if pass_info.name in self.print_after_pass_names:
+            print(f"Print IR after: {pass_info.name}\n{mod}\n\n")

--- a/python/tvm/ir/instrument.py
+++ b/python/tvm/ir/instrument.py
@@ -259,14 +259,14 @@ class PassTimingInstrument(tvm.runtime.Object):
 
 @pass_instrument
 class PassPrintingInstrument:
-    def __init__(self, before_after, print_pass_name):
-        self.before_after = before_after
-        self.print_pass_name = print_pass_name
+    def __init__(self, print_before_pass_name, print_after_pass_name):
+        self.print_before_pass_name = print_before_pass_name
+        self.print_after_pass_name = print_after_pass_name
 
     def run_before_pass(self, mod, pass_info):
-        if self.before_after == "before" and pass_info.name in self.print_pass_name:
+        if pass_info.name in self.print_before_pass_name:
             print(f"Print IR before:\n{pass_info.name}\n{mod}\n\n")
 
     def run_after_pass(self, mod, pass_info):
-        if self.before_after == "after" and pass_info.name in self.print_pass_name:
+        if pass_info.name in self.print_after_pass_name:
             print(f"Print IR after:\n{pass_info.name}\n{mod}\n\n")

--- a/python/tvm/ir/instrument.py
+++ b/python/tvm/ir/instrument.py
@@ -258,22 +258,15 @@ class PassTimingInstrument(tvm.runtime.Object):
 
 
 @pass_instrument
-class PassPrintBefore:
-    def __init__(self, print_pass_name):
+class PassPrintingInstrument:
+    def __init__(self, before_after, print_pass_name):
+        self.before_after = before_after
         self.print_pass_name = print_pass_name
 
     def run_before_pass(self, mod, pass_info):
-        if pass_info.name in self.print_pass_name:
-            print("Print ir before:")
-            print(str(pass_info.name) + "\n" + str(mod) + "\n\n")
-
-
-@pass_instrument
-class PassPrintAfter:
-    def __init__(self, print_pass_name):
-        self.print_pass_name = print_pass_name
+        if self.before_after == "before" and pass_info.name in self.print_pass_name:
+            print(f"Print IR before:\n{pass_info.name}\n{mod}\n\n")
 
     def run_after_pass(self, mod, pass_info):
-        if pass_info.name in self.print_pass_name:
-            print("Print ir after:")
-            print(str(pass_info.name) + "\n" + str(mod) + "\n\n")
+        if self.before_after == "after" and pass_info.name in self.print_pass_name:
+            print(f"Print IR after:\n{pass_info.name}\n{mod}\n\n")

--- a/tests/python/driver/tvmc/test_command_line.py
+++ b/tests/python/driver/tvmc/test_command_line.py
@@ -296,21 +296,21 @@ def test_tvmc_print_pass_times(capsys, keras_simple, tmpdir_factory):
         (
             "--print-ir-after=[tir.SplitHostDevice]",
             (
-                "Print IR after:\ntir.SplitHostDevice\n# from tvm.script import ir as I\n",
+                "Print IR after: tir.SplitHostDevice\n# from tvm.script import ir as I\n",
                 "@I.ir_module",
             ),
         ),
         (
             "--print-ir-before=[tir.SplitHostDevice]",
-            ("Print IR before:\ntir.SplitHostDevice\n# from tvm.script import ir as I\n"),
+            ("Print IR before: tir.SplitHostDevice\n# from tvm.script import ir as I\n"),
         ),
         (
             "--print-ir-after=[tir.ThreadSync,tir.SplitHostDevice]",
-            ("tir.ThreadSync\n,tir.SplitHostDevice\n"),
+            ("tir.ThreadSync,tir.SplitHostDevice"),
         ),
         (
             "--print-ir-before=[tir.SplitHostDevice] --print-ir-after=[tir.SplitHostDevice]",
-            ("Print IR before:\ntir.SplitHostDevice\n", "Print IR after:\ntir.SplitHostDevice\n"),
+            ("Print IR before: tir.SplitHostDevice\n", "Print IR after: tir.SplitHostDevice\n"),
         ),
     ],
 )

--- a/tests/python/driver/tvmc/test_command_line.py
+++ b/tests/python/driver/tvmc/test_command_line.py
@@ -201,7 +201,6 @@ def paddle_model(paddle_resnet50):
 @mock.patch.object(compiler, "compile_model")
 # @mock.patch.object(compiler, "compile_model")
 def test_tvmc_compile_input_model(mock_compile_model, tmpdir_factory, model):
-
     output_dir = tmpdir_factory.mktemp("output")
     output_file = output_dir / "model.tar"
 
@@ -288,4 +287,38 @@ def test_tvmc_print_pass_times(capsys, keras_simple, tmpdir_factory):
     # Check for timing results output
     captured_out = capsys.readouterr().out
     for exp_str in ("Compilation time breakdown by pass:", "sequential:", "us]"):
+        assert exp_str in captured_out
+
+
+def test_tvmc_print_ir_before(capsys, keras_simple, tmpdir_factory):
+    pytest.importorskip("tensorflow")
+    tmpdir = tmpdir_factory.mktemp("out")
+    print_cmd = "--print-ir-before=[tir.SplitHostDevice]"
+
+    # Compile model
+    module_file = os.path.join(tmpdir, "keras-tvm.tar")
+    compile_cmd = f"tvmc compile --target 'llvm' {keras_simple} --output {module_file} {print_cmd}"
+    compile_args = compile_cmd.split(" ")[1:]
+    _main(compile_args)
+
+    # Check for timing results output
+    captured_out = capsys.readouterr().out
+    for exp_str in ("Print ir before:\n", "tir.SplitHostDevice\n"):
+        assert exp_str in captured_out
+
+
+def test_tvmc_print_ir_after(capsys, keras_simple, tmpdir_factory):
+    pytest.importorskip("tensorflow")
+    tmpdir = tmpdir_factory.mktemp("out")
+    print_cmd = "--print-ir-after=[tir.SplitHostDevice]"
+
+    # Compile model
+    module_file = os.path.join(tmpdir, "keras-tvm.tar")
+    compile_cmd = f"tvmc compile --target 'llvm' {keras_simple} --output {module_file} {print_cmd}"
+    compile_args = compile_cmd.split(" ")[1:]
+    _main(compile_args)
+
+    # Check for timing results output
+    captured_out = capsys.readouterr().out
+    for exp_str in ("Print ir after:\n", "tir.SplitHostDevice\n"):
         assert exp_str in captured_out


### PR DESCRIPTION
Add `--print-ir-before` and `--print-ir-after` options  to print IR before and after a named pass from the compiler's command line driver.