### PR TITLE
[Unity] Unified KV cache interface and PagedKVCache refactor

### DIFF
--- a/src/runtime/relax_vm/kv_cache.h
+++ b/src/runtime/relax_vm/kv_cache.h
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef TVM_RUNTIME_RELAX_VM_KV_CACHE_H_
+#define TVM_RUNTIME_RELAX_VM_KV_CACHE_H_
+#include <tvm/runtime/device_api.h>
+#include <tvm/runtime/logging.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/registry.h>
+
+namespace tvm {
+namespace runtime {
+namespace relax_vm {
+
+/*!
+ * \brief The base class of attention KV cache for efficient
+ * k/v data management and attention computation.
+ */
+class AttentionKVCache : public Object {
+ public:
+  /*! \brief Reset the KV cache. */
+  virtual void Clear() = 0;
+
+  /************** Sequence Management **************/
+
+  /*!
+   * \brief Add a new sequence with empty K/V data in the cache.
+   * Check if the validity of the input sequence id.
+   * \param seq_id The id of the new sequence to be added.
+   * \throws Error if the given sequence id is not valid.
+   */
+  virtual void AddSequence(int64_t seq_id) = 0;
+
+  /*!
+   * \brief Remove a sequence and its K/V data from the KV cache.
+   * \param seq_id The sequence to remove from cache.
+   * \throws Error if the given sequence id is not valid.
+   */
+  virtual void RemoveSequence(int64_t seq_id) = 0;
+
+  /*!
+   * \brief Fork the K/V data of parent sequence to the child sequence.
+   * After the fork, the child sequence has K/V data of the parent
+   * sequence.
+   * \param parent_seq_id The parent (source) of the fork.
+   * \param child_seq_id The child (destination) of the fork.
+   * The child sequence id should not exist in cache prior to fork.
+   * \throws Error if the given sequence ids are not valid.
+   */
+  virtual void ForkSequence(int64_t parent_seq_id, int64_t child_seq_id) = 0;
+
+  /*!
+   * \brief Pop out the trailing `n` tokens from the KV cache for the
+   * specified sequence.
+   * \param seq_id The sequence whose trailing tokens are to be popped.
+   * \param n The number of tokens to pop from the KV cache.
+   * \throws Error if the given sequence id is not valid.
+   */
+  virtual void PopN(int64_t seq_id, int32_t n) = 0;
+
+  /************** Raw Info Query **************/
+
+  /*!
+   * \brief Get the number of available pages in the KV cache.
+   * When the underlying KV cache implementation is not
+   * paged KV cache, the function falls back to return the
+   * number of remaining size (in terms of number of tokens).
+   */
+  virtual int32_t GetNumAvailablePages() const = 0;
+
+  /************** Attention **************/
+
+  /*!
+   * \brief Mark the start of the forward function with the ids of
+   * the sequences and the sequence length to forward for each
+   * sequence.
+   * For example, if we want to prefill 3 sequences "5", "1", "8"
+   * with prefill length "10", "15", "20", then we pass `[5, 1, 8]`
+   * as the seq_ids and `[10, 15, 20]` as the append_lengths.
+   * This method is invoked right before entering the model forward
+   * function, and contains operations to prepare the the incoming
+   * forward. For instance, this method may send auxiliary KV cache
+   * data structures to GPUs so that they can be operated
+   * in the model forward function.
+   * \param seq_ids The ids of the sequence to run in the incoming model forward.
+   * \param append_lengths The sequence lengths to run forward for for each sequence.
+   */
+  virtual void BeginForward(const IntTuple& seq_ids, const IntTuple& append_lengths) = 0;
+
+  /*!
+   * \brief Mark the start of the forward function.
+   * This method is invoked right after entering the model forward
+   * function, and contains post-processing of the forward.
+   */
+  virtual void EndForward() = 0;
+
+  /*!
+   * \brief Compute attention with the given Q/K/V data at the specified
+   * layer with regard to the previously reserved append lengths.
+   * Q/K/V data are in layout `(total_length, num_heads, head_dim)`,
+   * where `total_length` is the sum of reserved append lengths.
+   * The returned attention result has the same layout as well.
+   * For example, say the KV cache contains 5 sequences. Before
+   * the current model forward, BeginForward is invoked for seq_ids
+   * `[3, 2]` and append_lengths [10, 20]. Then the leading dim of Q/K/V
+   * is 30, where [0, 10) corresponds to seq 3, and [10, 30)
+   * corresponds to seq 2.
+   * This method typically performs the following operations:
+   * - apply positional embeddings to Q/K data,
+   * - append K/V data to cache,
+   * - compute attention with the given Q and all history K/V
+   * for the corresponding sequences.
+   * The function writes attention output to `o_data`, conforming to
+   * the destination-passing style.
+   * \param layer_id The model layer where the attention compute happens.
+   * \param q_data The input Q data, in layout `(total_length, num_qo_heads, head_dim)`.
+   * \param k_data The input K data, in layout `(total_length, num_kv_heads, head_dim)`.
+   * \param v_data The input V data, in layout `(total_length, num_kv_heads, head_dim)`.
+   * \param mask The input mask data, in layout `(total_sqr_length)`.
+   * \param o_data The output O data, in layout `(total_length, num_qo_heads, head_dim)`.
+   */
+  virtual void Attention(int64_t layer_id, NDArray q_data, NDArray k_data, NDArray v_data,
+                         Optional<NDArray> mask, NDArray o_data) = 0;
+
+  /************** Debug Helpers **************/
+
+  /*!
+   * \brief Fetch the compact K/V data of the given sequence.
+   * The results are written into `k_data` and `v_data` passed in,
+   * conforming to the destination-passing style.
+   * `start_pos` (inclusive) and `end_pos` (exclusive) controls the range
+   * of K/V data to fetch.
+   * - `start_pos` defaults to 0 when undefined,
+   * - `end_pos` defaults to the length of sequence when undefined.
+   * This method expects `start_pos < end_pos`.
+   * The k/v data arrays are expected to have layout
+   * `(num_layers, start_pos - end_pos, num_heads, head_dim)`.
+   * \param seq_id The sequence whose K/V data is to be fetched.
+   * \param start_pos The start position (inclusive) of the K/V data to fetch.
+   * \param end_pos The end position (exclusive) of the K/V data to fetch.
+   * \param K_data The output K data of the given sequence in layout elaborated above.
+   * \param V_data The output V data of the given sequence in layout elaborated above.
+   */
+  virtual void DebugGetKV(int64_t seq_id,  //
+                          int64_t start_pos, int64_t end_pos, NDArray k_data, NDArray v_data) = 0;
+
+  /*!
+   * \brief Set the K/V data of the given sequence from input K/V data.
+   * `start_pos` (inclusive) controls starting position of K/V data
+   * to set, and defaults to 0 when undefined.
+   * The input K/V data is in layout `(num_layers, length, num_heads, head_dim)`,
+   * where `length` is the length to set. It implies that the range
+   * of set is `[start_pos, start_pos + length)`.
+   * It is not allowed that `start_pos + length` exceeds the current
+   * length of the given sequence.
+   * \param seq_id The sequence whose K/V data is to be set.
+   * \param start_pos The start position (inclusive) of the K/V data to set.
+   * \param k_data The K data to set in layout elaborated above.
+   * \param v_data The V data to set in layout elaborated above.
+   */
+  virtual void DebugSetKV(int64_t seq_id, int64_t start_pos, NDArray k_data, NDArray v_data) = 0;
+};
+
+}  // namespace relax_vm
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // TVM_RUNTIME_RELAX_VM_KV_CACHE_H_

--- a/src/runtime/relax_vm/paged_kv_cache.cc
+++ b/src/runtime/relax_vm/paged_kv_cache.cc
@@ -25,6 +25,12 @@
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/registry.h>
 
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "kv_cache.h"
+
 namespace tvm {
 namespace runtime {
 namespace relax_vm {
@@ -38,47 +44,149 @@ namespace relax_vm {
 //-------------------------------------------
 
 /*!
+ * \brief The maximum allowed block depth (a.k.a. number of common
+ * prefixes) in paged KV cache.
+ */
+constexpr const int kPagedKVCacheMaxBlockDepth = 5;
+
+/*!
+ * \brief The block structure in paged KV cache with common prefix support.
+ * Each block contains a list of pages for cached KV data.
+ * If a block has `n` pages, the first `n - 1` pages must be
+ * full, and only the last page can be partially filled.
+ *
+ * To support common prefix, each sequence in KV cache is represented
+ * as one or more blocks, where the common prefix is a standalone
+ * block among.
+ *
+ * Each block has a parent block when it uses a prefix.
+ */
+struct Block {
+  /*!
+   * \brief The ids of the pages in the block.
+   * Each page can only be used by a unique block (in other
+   * words, different blocks do not share pages).
+   */
+  std::vector<int32_t> page_ids;
+  /*! \brief The total sequence length in the block. */
+  int32_t seq_length = 0;
+
+  /*! \brief The global index of the block. */
+  const int32_t index;
+  /*!
+   * \brief The global index of the parent block of this block, or -1
+   * if the block does not have a parent. */
+  int32_t parent_idx = -1;
+  /*!
+   * \brief The external reference counter of the block.
+   * When a block is externally referred by some block,
+   * we do not allow appending new KV values to this block.
+   */
+  int external_ref_cnt = 0;
+
+  explicit Block(int32_t index) : index(index) {}
+
+  /*! \brief Reset the block data. */
+  void Reset() {
+    page_ids.clear();
+    seq_length = 0;
+    parent_idx = -1;
+    external_ref_cnt = 0;
+  }
+};
+
+/*!
+ * \brief The sequence structure in paged KV cache with common prefix support.
+ * Each sequence contains one or more blocks to support common prefix.
+ */
+struct Sequence {
+  /*!
+   * \brief The global index of the last block of the sequence.
+   * We only store the last block, since all the blocks can be
+   * tracked with the `parent` field of Block.
+   */
+  int32_t last_block_idx;
+  /*!
+   * \brief The total sequence length of the sequence.
+   * It is the sum of lengths of all its blocks.
+   */
+  int32_t seq_length = 0;
+
+  explicit Sequence(const std::vector<Block>& global_block_pool, int32_t last_block_idx) {
+    this->last_block_idx = last_block_idx;
+    int32_t block_ptr = last_block_idx;
+    // Go through each block in the sequence, sum up the length.
+    int depth = 0;
+    while (true) {
+      const Block& block = global_block_pool[block_ptr];
+      this->seq_length += block.seq_length;
+      ++depth;
+      if (block.parent_idx == -1) {
+        break;
+      }
+      block_ptr = block.parent_idx;
+    }
+    CHECK_LE(depth, kPagedKVCacheMaxBlockDepth)
+        << "Paged KV cache supports one sequence to reuse " << kPagedKVCacheMaxBlockDepth
+        << " prefixes (the fork depth) at most. However, the given sequence has fork depth "
+        << depth;
+  }
+
+  std::vector<int32_t> GetBlockTrace(const std::vector<Block>& global_block_pool) const {
+    std::vector<int32_t> trace;
+    // Get the trace from the last block of the sequence to the root block.
+    int32_t block_ptr = last_block_idx;
+    while (block_ptr != -1) {
+      trace.push_back(block_ptr);
+      block_ptr = global_block_pool[block_ptr].parent_idx;
+    }
+    // Reverse the trace so that it starts from the root block.
+    std::reverse(trace.begin(), trace.end());
+    return trace;
+  }
+};
+
+/*!
  * \brief The paged KV cache for attention.
  * - It supports managing the K/V data of **multiple sequences**.
  * - It manages K/V values by doing paging along the sequence-length
  * dimension with a configured page size.
- * - To add a sequence to the cache, use AddSequence.
+ * - To add a sequence to the cache, use AddSequence with a provided
+ * unique integer sequence id.
  * - The basic example use of the paged KV cache after initialization
  * in each round of model forwarding is the following:
- *   - step 1. use `ResetAppendLengths` to reset the appending information
- *     for preparation,
- *   - step 2. use `ReserveExtraLengthForAppend` to specify the length
- *     of K/V data to be appended for each sequence,
- *   - step 3. use `SyncAuxArrayToDevice` to synchronize auxiliary arrays
- *     to device for append/attention computation,
- *   - step 4. for each layer, use `Append` to append the K/V data to the
- *     cache, and then use `Attention` to compute attention results with
- *     Q data.
+ *   - step 1. use `BeginForward` to specify the list of sequence ids
+ *     together with the lengths of append,
+ *   - step 2. use `Attention` to pass in the q/k/v values regarding
+ *     the sequences and lengths specified in `BeginForward`. The
+ *     attention is computed between input queries and the history
+ *     key/values plus the input key/values. The input key/values
+ *     will be added into the KV cache as well.
+ *   - step 3. use `EndForward` to mark the end of forwarding this round.
+ *     After calling `EndForward`, it is required to call `BeginForward`
+ *     before calling any `Attention`.
  */
-class PagedAttentionKVCacheObj : public Object {
+class PagedAttentionKVCacheObj : public AttentionKVCache {
  private:
-  /*! \brief The total number of sequences managed in the KV cache. */
-  int64_t num_total_seqs_ = 0;
-  /*! \brief The number of pages that are in use by the sequences. */
-  int64_t num_pages_in_use_ = 0;
-  /*!
-   * \brief The number of allocated pages, including the in-use pages
-   * and the pages released due to sequence removal.
-   */
-  int64_t num_pages_allocated_ = 0;
-
   /********************* Configuration *********************/
 
   /*! \brief The page size (the sequence length each page manages) of the cache. */
   const int64_t page_size_;
   /*! \brief The number of layers in the model. */
   const int64_t num_layers_;
-  /*! \brief The number of heads in the model. */
-  const int64_t num_heads_;
+  /*! \brief The number of query/output heads in the model. */
+  const int64_t num_qo_heads_;
+  /*! \brief The number of key/value heads in the model. */
+  const int64_t num_kv_heads_;
   /*! \brief The number of features each head has. */
   const int64_t head_dim_;
-  /*! \brief A boolean denoting if cache automatic growth is allowed. */
-  const bool allow_growth_;
+  /*! \brief The number of total pages allocated in KV cache. */
+  const int64_t num_total_pages_;
+
+  /*! \brief The RoPE scale. */
+  const double rotary_scale_;
+  /*! \brief The RoPE theta. */
+  const double rotary_theta_;
 
   /*! \brief We fix int32 to be the index dtype of auxiliary data. */
   const DLDataType dtype_aux_ = DLDataType(DataType::Int(32, 1));
@@ -87,31 +195,24 @@ class PagedAttentionKVCacheObj : public Object {
 
   /*!
    * \brief The KV data managed by the KV cache.
-   * It has layout (num_pages, num_layers, 2, num_heads, page_size, head_dim).
+   * The array has `num_layers` NDArrays, each of them
+   * has layout (num_pages, 2, num_heads, page_size, head_dim).
    * Along on the "2" dimension, index 0 stands for K and 1 stands for V.
    */
-  NDArray pages_;
+  Array<NDArray> pages_;
   /*! \brief The list of ids of released pages for page reuse. */
   std::vector<int32_t> free_page_ids_;
+  /*! \brief The mapping from sequence ids to sequences. */
+  std::unordered_map<int64_t, Sequence> seq_map_;
 
-  /*! \brief The list of page ids assigned for each sequence in the cache. */
-  std::vector<std::vector<int32_t>> page_table_;
-  /*! \brief The lengths of each sequence in the cache. */
-  std::vector<int32_t> seq_lengths_;
+  /********************* Sequence Block Structures *********************/
 
-  /********************* Current Batch Info *********************/
+  /*! \brief The list of all blocks once allocated. */
+  std::vector<Block> global_block_pool_;
+  /*! \brief The list of free available blocks (in their indices). */
+  std::vector<int32_t> free_block_idx_;
 
-  /*!
-   * \brief The current lengths to append for each sequence.
-   * - The new K/V data appended to the cache must have the same length
-   * as stored in this array.
-   * - The Q data passed in for attention must also have the same length
-   * as stored.
-   * \note Invoke "ResetAppendLengths" to reset this array to all-zero.
-   */
-  std::vector<int64_t> cur_append_lengths_;
-
-  /********************* Auxiliary Arrays on Device *********************/
+  /*********** Current Batch Info & Auxiliary Arrays on Device ***********/
   //-------------------------------------------
   // The following fields are auxiliary arrays on device.
   // All of them are directly derivable from the fields above.
@@ -123,30 +224,37 @@ class PagedAttentionKVCacheObj : public Object {
    * If it is dirty, an explicit "SyncAuxArrayToDevice" should be invoked.
    */
   bool dirty_aux_data_device_ = false;
+  /*! \brief The batch size of the current round of forwarding. */
+  int64_t cur_batch_size_;
+  /*! \brief The append lengths of the sequences in the current round of forwarding. */
+  IntTuple cur_append_lengths_;
+  /*! \brief The indptr array of append lengths after coalescing. (see GetChunkedBlockIds) */
+  std::vector<NDArray> qo_indptr_on_depths_device_;
+  /*! \brief The indptr array of page table. */
+  std::vector<NDArray> page_indptr_on_depths_device_;
+  /*! \brief The indices array of page table. */
+  std::vector<NDArray> page_indices_on_depths_device_;
+  /*! \brief The number of KV slots used in the last page of sequences. */
+  std::vector<NDArray> last_page_len_on_depths_device_;
   /*!
-   * \brief The page table indptr array on device.
-   * \note Since page table is a ragged data structure, we represent it
-   * in CSR format (which uses indptr and values below) on device.
-   */
-  NDArray page_table_indptr_device_;
-  /*! \brief The page table value array on device. */
-  NDArray page_table_values_device_;
-  /*!
-   * \brief The array storing "the number of used slots in the last page
-   * of each sequence" on device. Its values range in (0, page_size_].
-   */
-  NDArray last_page_offset_device_;
-  /*!
-   * \brief The append_length indptr array on device.
+   * \brief The append length indptr array on device.
    * \note Since the Q/K/V data may have raggedness in terms of lengths,
    * we represent the the append lengths in CSR format.
    */
   NDArray cur_append_length_indptr_device_;
+  /*! \brief The position offset of applying RoPE for each sequence. */
+  NDArray cur_rope_offset_device_;
   /*!
-   * \brief The corresponding sequence id for each position along the
-   * length dimension of K/V data. It is used for efficient computation.
+   * \brief The corresponding position in global KV cache (pages)
+   * for each position along the length dimension of K/V data when
+   * appending new K/V data.
    */
-  NDArray cur_pos2seqid_device_;
+  NDArray append_position_map_device_;
+
+  // Temporary arrays to store intermediate attention results.
+  NDArray temp_attn_output_device_;
+  NDArray temp_attn_scores_device_;
+  NDArray merged_attn_scores_device_;
 
   //-------------------------------------------
   // For efficient memory management, the actual sizes of the arrays
@@ -155,359 +263,440 @@ class PagedAttentionKVCacheObj : public Object {
   // after each synchronization and pass these views as input for
   // attention/append.
   //-------------------------------------------
-  NDArray page_table_indptr_view_;
-  NDArray page_table_values_view_;
-  NDArray last_page_offset_view_;
   NDArray cur_append_length_indptr_view_;
-  NDArray cur_pos2seqid_view_;
+  NDArray cur_rope_offset_view_;
+  NDArray append_position_map_view_;
+  NDArray temp_attn_output_view_;
+  NDArray temp_attn_scores_view_;
+  NDArray merged_attn_scores_view_;
+  std::vector<NDArray> qo_indptr_on_depths_view_;
+  std::vector<NDArray> page_indptr_on_depths_view_;
+  std::vector<NDArray> page_indices_on_depths_view_;
+  std::vector<NDArray> last_page_len_on_depths_view_;
+
+  PackedFunc f_transpose_append_;
+  PackedFunc f_attention_prefill_;
+  PackedFunc f_attention_decode_;
+  PackedFunc f_attention_prefill_ragged_;
+  PackedFunc f_attention_prefill_ragged_begin_forward_;
+  PackedFunc f_attention_prefill_ragged_end_forward_;
+  PackedFunc f_attention_prefill_begin_forward_;
+  PackedFunc f_attention_prefill_end_forward_;
+  PackedFunc f_attention_decode_begin_forward_;
+  PackedFunc f_attention_decode_end_forward_;
+  PackedFunc f_rotary_;
+  PackedFunc f_merge_inplace_;
+  Optional<PackedFunc> f_debug_get_kv_;
+
+  /*! \brief Number of fork depth in the current round of forward. */
+  int num_depths_;
+  /*! \brief Whether to use decode kernel for each depth. (see GetChunkedBlockIds) */
+  std::vector<bool> use_decode_kernel_;
+  /*! \brief Whether the attention request is a decode request, set in BeginForwardFunction. */
+  bool is_decode_request_;
 
  public:
   /*! \brief Constructor. Take the cache configuration and initialize the NDArrays. */
-  explicit PagedAttentionKVCacheObj(int64_t page_size, int64_t num_layers, int64_t num_heads,
-                                    int64_t head_dim, int64_t reserved_num_seqs,
-                                    int64_t reserved_num_pages, DLDataType dtype, DLDevice device,
-                                    bool allow_growth)
+  explicit PagedAttentionKVCacheObj(
+      int64_t page_size,  //
+      int64_t num_layers, int64_t num_qo_heads, int64_t num_kv_heads,
+      int64_t head_dim,                                    //
+      int64_t reserved_num_seqs, int64_t num_total_pages,  //
+      double rotary_scale, double rotary_theta,            //
+      DLDataType dtype, DLDevice device, PackedFunc f_transpose_append,
+      PackedFunc f_attention_prefill, PackedFunc f_attention_decode,
+      PackedFunc f_attention_prefill_ragged, PackedFunc f_attention_prefill_ragged_begin_forward,
+      PackedFunc f_attention_prefill_ragged_end_forward,
+      PackedFunc f_attention_prefill_begin_forward, PackedFunc f_attention_prefill_end_forward,
+      PackedFunc f_attention_decode_begin_forward, PackedFunc f_attention_decode_end_forward,
+      PackedFunc f_rotary, PackedFunc f_merge_inplace, Optional<PackedFunc> f_debug_get_kv)
       : page_size_(page_size),
         num_layers_(num_layers),
-        num_heads_(num_heads),
+        num_qo_heads_(num_qo_heads),
+        num_kv_heads_(num_kv_heads),
         head_dim_(head_dim),
-        allow_growth_(allow_growth) {
-    pages_ = NDArray::Empty({reserved_num_pages, num_layers, 2, num_heads, page_size, head_dim},
-                            dtype, device);
-    page_table_indptr_device_ = NDArray::Empty({reserved_num_seqs + 1}, dtype_aux_, device);
-    page_table_values_device_ = NDArray::Empty({reserved_num_pages}, dtype_aux_, device);
-    last_page_offset_device_ = NDArray::Empty({reserved_num_seqs}, dtype_aux_, device);
-    cur_append_length_indptr_device_ = NDArray::Empty({reserved_num_seqs + 1}, dtype_aux_, device);
-    cur_pos2seqid_device_ = NDArray::Empty({reserved_num_pages * page_size}, dtype_aux_, device);
-  }
-
-  /*!
-   * \brief Add a sequence to the KV cache. Returns the sequence id.
-   * \note This method adds a new sequence with **initial length zero**.
-   * Call `ReserveExtraLengthForAppend` and `Append` afterwards to reserve
-   * the append length and append data to the cache.
-   * \returns The id of the new sequence.
-   */
-  int64_t AddSequence() {
-    page_table_.push_back({});
-    seq_lengths_.push_back(0);
-    cur_append_lengths_.push_back(0);
-    int64_t seq_id = num_total_seqs_++;
-    return seq_id;
-  }
-
-  /*!
-   * \brief Given a sequence id and a required extra length, allocate new
-   * new pages for the sequence until the total capacity can cover the
-   * current sequence length plus the required extra length.
-   * \note By reserving extra length for the sequence, the subsequent appended
-   * K/V data for the sequence must have the same length as the input length here.
-   * \param seq_id The id of the sequence to process.
-   * \param extra_length The extra length to reserve for the sequence.
-   */
-  void ReserveExtraLengthForAppend(int64_t seq_id, int64_t extra_length) {
-    CHECK_GE(seq_id, 0) << "Input sequence id should be positive";
-    CHECK_LT(seq_id, num_total_seqs_)
-        << "Invalid input sequence id " << seq_id << ", which is out of the range of [0, "
-        << num_total_seqs_ << ").";
-    CHECK_GT(extra_length, 0) << "The input length should be positive.";
-
-    // The reservation is based on the current sequence length.
-    // If "current sequence + input extra length" does not exceed the
-    // current capacity (number of pages * page size), no action is taken.
-    int64_t cur_npage = page_table_[seq_id].size();
-    int64_t tgt_npage = (seq_lengths_[seq_id] + extra_length + page_size_ - 1) / page_size_;
-    for (int64_t page_idx = cur_npage; page_idx < tgt_npage; ++page_idx) {
-      AllocatePageForSequence(seq_id);
+        num_total_pages_(num_total_pages),
+        rotary_scale_(rotary_scale),
+        rotary_theta_(rotary_theta),
+        f_transpose_append_(std::move(f_transpose_append)),
+        f_attention_prefill_(std::move(f_attention_prefill)),
+        f_attention_decode_(std::move(f_attention_decode)),
+        f_attention_prefill_ragged_(std::move(f_attention_prefill_ragged)),
+        f_attention_prefill_ragged_begin_forward_(
+            std::move(f_attention_prefill_ragged_begin_forward)),
+        f_attention_prefill_ragged_end_forward_(std::move(f_attention_prefill_ragged_end_forward)),
+        f_attention_prefill_begin_forward_(std::move(f_attention_prefill_begin_forward)),
+        f_attention_prefill_end_forward_(std::move(f_attention_prefill_end_forward)),
+        f_attention_decode_begin_forward_(std::move(f_attention_decode_begin_forward)),
+        f_attention_decode_end_forward_(std::move(f_attention_decode_end_forward)),
+        f_rotary_(std::move(f_rotary)),
+        f_merge_inplace_(std::move(f_merge_inplace)),
+        f_debug_get_kv_(std::move(f_debug_get_kv)) {
+    pages_.reserve(num_layers);
+    for (int i = 0; i < num_layers; ++i) {
+      pages_.push_back(
+          NDArray::Empty({num_total_pages, 2, num_kv_heads, page_size, head_dim}, dtype, device));
     }
-    seq_lengths_[seq_id] += extra_length;
-    cur_append_lengths_[seq_id] += extra_length;
+    for (int d = 0; d < kPagedKVCacheMaxBlockDepth; ++d) {
+      qo_indptr_on_depths_device_.push_back(
+          NDArray::Empty({reserved_num_seqs + 1}, dtype_aux_, device));
+      page_indptr_on_depths_device_.push_back(
+          NDArray::Empty({reserved_num_seqs + 1}, dtype_aux_, device));
+      page_indices_on_depths_device_.push_back(
+          NDArray::Empty({num_total_pages}, dtype_aux_, device));
+      last_page_len_on_depths_device_.push_back(
+          NDArray::Empty({reserved_num_seqs}, dtype_aux_, device));
+      qo_indptr_on_depths_view_.push_back(NDArray());
+      page_indptr_on_depths_view_.push_back(NDArray());
+      page_indices_on_depths_view_.push_back(NDArray());
+      last_page_len_on_depths_view_.push_back(NDArray());
+    }
+    cur_append_length_indptr_device_ = NDArray::Empty({reserved_num_seqs + 1}, dtype_aux_, device);
+    cur_rope_offset_device_ = NDArray::Empty({reserved_num_seqs}, dtype_aux_, device);
+    append_position_map_device_ = NDArray::Empty({num_total_pages * page_size}, dtype_aux_, device);
+
+    temp_attn_output_device_ =
+        NDArray::Empty({num_total_pages * page_size, num_qo_heads, head_dim}, dtype, device);
+    temp_attn_scores_device_ =
+        NDArray::Empty({num_total_pages * page_size, num_qo_heads}, DataType::Float(32), device);
+    merged_attn_scores_device_ =
+        NDArray::Empty({num_total_pages * page_size, num_qo_heads}, DataType::Float(32), device);
+    for (int64_t page_id = num_total_pages - 1; page_id >= 0; --page_id) {
+      free_page_ids_.push_back(page_id);
+    }
+  }
+
+  /*! \brief Reset the KV cache. */
+  void Clear() final {
+    seq_map_.clear();
+    ICHECK(pages_.defined());
+    free_page_ids_.clear();
+    for (int64_t page_id = num_total_pages_ - 1; page_id >= 0; --page_id) {
+      free_page_ids_.push_back(page_id);
+    }
+    global_block_pool_.clear();
+    free_block_idx_.clear();
+    dirty_aux_data_device_ = false;
+  }
+
+  /************** Sequence Management **************/
+
+  void AddSequence(int64_t seq_id) final {
+    CHECK(seq_map_.find(seq_id) == seq_map_.end())
+        << "The sequence \"" << seq_id << "\" is already in the KV cache.";
+    int32_t block_idx = GetFreeBlock();
+    seq_map_.insert({seq_id, Sequence(global_block_pool_, block_idx)});
     dirty_aux_data_device_ = true;
   }
 
-  /*!
-   * \brief The entrance of attention. It takes an attention compute
-   * function together with the query data, invokes the attention
-   * function to complete the computation.
-   * \param f_attention The input attention compute function.
-   * \param q_data The query data. We support the following two layout settings:
-   * - in batch decode settings, q_data has layout (num_total_seqs, 1, num_heads, head_dim)
-   *   where num_total_seqs should exactly equal to the number of sequences in the cache.
-   * - in other settings (single-sequence prefill, batch prefill, or speculation
-   *   verification), q_data has the **flattened layout** to handle raggedness:
-   *   (1, total query length, num_heads, head_dim).
-   * \param layer_id The model layer index of the current attention.
-   * \param output The attention output array.
-   * \param apply_rotary A boolean flag indicating if to apply RoPE to Q and K
-   * in attention computation.
-   * \param rotary_scale The RoPE scale if applicable.
-   * \param rotary_theta The RoPE theta if applicable.
-   * \note As a TODO item, we could move the rope related parameters to the
-   * f_attention closure in the future.
-   */
-  void Attention(PackedFunc f_attention, NDArray q_data, int64_t layer_id, NDArray output,
-                 bool apply_rotary = false, double rotary_scale = 1.0f, double rotary_theta = 1e4) {
-    // Check q_data shape validity.
+  void RemoveSequence(int64_t seq_id) final {
+    auto it = seq_map_.find(seq_id);
+    CHECK(it != seq_map_.end()) << "The sequence \"" << seq_id << "\" cannot be found in KV cache.";
+    const Block& block = global_block_pool_[it->second.last_block_idx];
+    CHECK_EQ(block.external_ref_cnt, 0)
+        << "The sequence is currently referenced by other sequence and thus cannot be removed.";
+
+    // - Decrease the external reference of the parent block.
+    if (block.parent_idx != -1) {
+      Block& parent_block = global_block_pool_[block.parent_idx];
+      ICHECK_GT(parent_block.external_ref_cnt, 0);
+      --parent_block.external_ref_cnt;
+    }
+    // - Free pages in the last block.
+    for (int32_t page_id : block.page_ids) {
+      free_page_ids_.push_back(page_id);
+    }
+    // - Remove the sequence from seq_map.
+    free_block_idx_.push_back(it->second.last_block_idx);
+    seq_map_.erase(it);
+    dirty_aux_data_device_ = true;
+  }
+
+  void ForkSequence(int64_t parent_seq_id, int64_t child_seq_id) final {
+    auto parent_it = seq_map_.find(parent_seq_id);
+    CHECK(parent_it != seq_map_.end())
+        << "The parent sequence \"" << parent_seq_id << "\" cannot be found in KV cache.";
+    CHECK(seq_map_.find(child_seq_id) == seq_map_.end())
+        << "The child sequence \"" << child_seq_id << "\" is already in the KV cache.";
+
+    int32_t parent_block_idx = parent_it->second.last_block_idx;
+    // Create a child block with the parent block pointer.
+    int32_t child_block_idx = GetFreeBlock();
+    global_block_pool_[child_block_idx].parent_idx = parent_block_idx;
+    // Create the child sequence with the child block.
+    seq_map_.insert({child_seq_id, Sequence(global_block_pool_, child_block_idx)});
+    dirty_aux_data_device_ = true;
+  }
+
+  void PopN(int64_t seq_id, int32_t n) final {
+    auto it = seq_map_.find(seq_id);
+    CHECK(it != seq_map_.end()) << "The sequence \"" << seq_id << "\" cannot be found in KV cache.";
+
+    Block& block = global_block_pool_[it->second.last_block_idx];
+    CHECK_GE(n, 0) << "The length of popping " << n << " cannot be negative.";
+    CHECK_LT(n, block.seq_length) << "The sequence only has length " << block.seq_length
+                                  << " in the last block, while the length of pop is " << n
+                                  << " which exceeds the last-block sequence length.";
+
+    int64_t cur_npage = block.page_ids.size();
+    int64_t tgt_npage = (block.seq_length - n + page_size_ - 1) / page_size_;
+    while (cur_npage > tgt_npage) {
+      free_page_ids_.push_back(block.page_ids.back());
+      block.page_ids.pop_back();
+      --cur_npage;
+    }
+    it->second.seq_length -= n;
+    block.seq_length -= n;
+    dirty_aux_data_device_ = true;
+  }
+
+  /************** Raw Info Query **************/
+
+  int GetNumAvailablePages() const final { return free_page_ids_.size(); }
+
+  /************** Attention **************/
+
+  void BeginForward(const IntTuple& seq_ids, const IntTuple& append_lengths) final {
+    CHECK_EQ(seq_ids.size(), append_lengths.size())
+        << "The seq_ids size (" << seq_ids.size() << ") and append_lengths size ("
+        << append_lengths.size() << ") mismatch.";
+    cur_batch_size_ = seq_ids.size();
+    cur_append_lengths_ = append_lengths;
+
+    // - Collect sequence/block/page information for attention.
+    std::vector<const Sequence*> sequences;
+    std::vector<int32_t> rope_offset;
+    is_decode_request_ = true;
+    sequences.reserve(cur_batch_size_);
+    rope_offset.reserve(cur_batch_size_);
+    for (int i = 0; i < cur_batch_size_; ++i) {
+      auto it = seq_map_.find(seq_ids[i]);
+      CHECK(it != seq_map_.end()) << "The sequence \"" << seq_ids[i]
+                                  << "\" cannot be found in KV cache.";
+      sequences.push_back(&it->second);
+      rope_offset.push_back(it->second.seq_length);
+      it->second.seq_length += append_lengths[i];
+      if (append_lengths[i] != 1) {
+        is_decode_request_ = false;
+      }
+    }
+
+    std::vector<std::vector<int32_t>> block_ids_on_depths = GetBlockIdsOnDepth(sequences);
+    num_depths_ = block_ids_on_depths.size();
+    ICHECK_LE(num_depths_, kPagedKVCacheMaxBlockDepth);
+
+    if (num_depths_ == 1) {
+      // Right now we use different kernels when depth is 1 or not 1.
+      // For the case where maximum depth is 1, we create the auxiliary
+      // data structure with regard to the page table after appending.
+      for (int i = 0; i < cur_batch_size_; ++i) {
+        ReserveAppendLengthInBlock(sequences[i]->last_block_idx, append_lengths[i]);
+      }
+    }
+
+    std::vector<std::vector<int32_t>> qo_indptr_on_depths;
+    std::vector<std::vector<int32_t>> page_indptr_on_depths;
+    std::vector<std::vector<int32_t>> page_indices_on_depths;
+    std::vector<std::vector<int32_t>> last_page_len_on_depths;
+    use_decode_kernel_.clear();
+    for (int d = 0; d < num_depths_; ++d) {
+      auto [chunked_block_ids, use_decode_kernel] = GetChunkedBlockIds(block_ids_on_depths[d]);
+      use_decode_kernel_.push_back(use_decode_kernel);
+
+      std::vector<int32_t> qo_indptr_h{0};
+      std::vector<int32_t> page_indptr_h{0};
+      std::vector<int32_t> page_indices_h;
+      std::vector<int32_t> last_page_len_h;
+      for (const auto& [block_id, chunk_append_length] : chunked_block_ids) {
+        qo_indptr_h.push_back(qo_indptr_h.back() + chunk_append_length);
+        if (block_id == -1) {
+          page_indptr_h.push_back(page_indptr_h.back());
+          last_page_len_h.push_back(0);
+        } else {
+          const Block& block = global_block_pool_[block_id];
+          page_indptr_h.push_back(page_indptr_h.back() + block.page_ids.size());
+          page_indices_h.insert(page_indices_h.end(), block.page_ids.begin(), block.page_ids.end());
+          last_page_len_h.push_back(
+              block.seq_length == 0 ? 0 : (block.seq_length - 1) % page_size_ + 1);
+        }
+      }
+      qo_indptr_on_depths.push_back(qo_indptr_h);
+      page_indptr_on_depths.push_back(page_indptr_h);
+      page_indices_on_depths.push_back(page_indices_h);
+      last_page_len_on_depths.push_back(last_page_len_h);
+    }
+
+    if (num_depths_ > 1) {
+      // Right now we use different kernels when depth is 1 or not 1.
+      // For the case where maximum depth is not 1, we create the auxiliary
+      // data structure with regard to the page table before appending.
+      for (int i = 0; i < cur_batch_size_; ++i) {
+        ReserveAppendLengthInBlock(sequences[i]->last_block_idx, append_lengths[i]);
+      }
+    }
+
+    // Map each the token position in the input batch to the position
+    // in the global KV cache. The mapping is used in when appending k/v values.
+    std::vector<int32_t> append_position_map;
+    for (int i = 0; i < cur_batch_size_; ++i) {
+      int64_t append_length = append_lengths[i];
+      const Block& block = global_block_pool_[sequences[i]->last_block_idx];
+      for (int64_t pos = 0; pos < append_length; ++pos) {
+        int64_t pos_in_seq = block.seq_length - append_length + pos;
+        append_position_map.push_back(block.page_ids[pos_in_seq / page_size_] * page_size_ +
+                                      pos_in_seq % page_size_);
+      }
+    }
+
+    // - Sync NDArrays to GPU.
+    SyncAuxArrayToDevice(std::move(qo_indptr_on_depths), std::move(page_indptr_on_depths),
+                         std::move(page_indices_on_depths), std::move(last_page_len_on_depths),
+                         std::move(rope_offset), std::move(append_position_map));
+
+    // NOTE(Zihao): This logic is problematic ATM because we need a unique split per depth
+    KernelBeginForward();
+  }
+
+  void EndForward() final {
+    // Mark the dirty flag as true, so that BeginForward is required
+    // to be invoked before the next round of model forward.
+    dirty_aux_data_device_ = true;
+    f_attention_prefill_ragged_end_forward_();
+    for (int d = 0; d < num_depths_; ++d) {
+      f_attention_prefill_end_forward_(d);
+      f_attention_decode_end_forward_(d);
+    }
+  }
+
+  void Attention(int64_t layer_id, NDArray q_data, NDArray k_data, NDArray v_data,
+                 Optional<NDArray> mask, NDArray o_data) final {
+    // Part 1. Shape and dtype check.
+    NDArray pages = pages_[layer_id];
+    CHECK(q_data.DataType() == pages.DataType());
+    CHECK(k_data.DataType() == pages.DataType());
+    CHECK(v_data.DataType() == pages.DataType());
+    CHECK(o_data.DataType() == pages.DataType());
+
+    // Case 1. q/o_data: (cur_batch_size, 1, num_qo_heads, head_dim)
+    //         k/v_data: (cur_batch_size, 1, num_kv_heads, head_dim)
+    // Case 2. q/o_data: (1, num_total_length, num_qo_heads, head_dim)
+    //         k/v_data: (1, num_total_length, num_kv_heads, head_dim)
+
     CHECK_EQ(q_data->ndim, 4);
+    CHECK_EQ(k_data->ndim, 4);
+    CHECK_EQ(v_data->ndim, 4);
+    CHECK_EQ(o_data->ndim, 4);
+    for (int dim = 0; dim < 4; ++dim) {
+      if (dim == 2) {
+        CHECK_EQ(q_data->shape[2], num_qo_heads_);
+        CHECK_EQ(k_data->shape[2], num_kv_heads_);
+        CHECK_EQ(v_data->shape[2], num_kv_heads_);
+        CHECK_EQ(o_data->shape[2], num_qo_heads_);
+      } else {
+        CHECK_EQ(k_data->shape[dim], q_data->shape[dim]);
+        CHECK_EQ(v_data->shape[dim], q_data->shape[dim]);
+        CHECK_EQ(o_data->shape[dim], q_data->shape[dim]);
+      }
+    }
+
     CHECK_GT(q_data->shape[1], 0);
-    CHECK_EQ(q_data->shape[2], num_heads_);
     CHECK_EQ(q_data->shape[3], head_dim_);
-    CHECK(q_data.DataType() == pages_.DataType());
 
     if (q_data->shape[0] > 1) {
-      CHECK_EQ(q_data->shape[0], num_total_seqs_);
+      // Case 1.
+      CHECK_EQ(q_data->shape[0], cur_batch_size_);
       CHECK_EQ(q_data->shape[1], 1);
+    } else {
+      // Case 2.
+      CHECK_EQ(q_data->shape[0], 1);
     }
-    int64_t ntoken = 0;
-    for (int64_t seq_id = 0; seq_id < num_total_seqs_; ++seq_id) {
-      ntoken += cur_append_lengths_[seq_id];
-      CHECK_LE(cur_append_lengths_[seq_id], seq_lengths_[seq_id]);
+
+    int64_t total_seq_length = 0;
+    for (int64_t seq_id = 0; seq_id < cur_batch_size_; ++seq_id) {
+      total_seq_length += cur_append_lengths_[seq_id];
       if (q_data->shape[0] > 1) {
         CHECK_EQ(cur_append_lengths_[seq_id], 1);
       }
     }
-    CHECK_EQ(ntoken, q_data->shape[0] * q_data->shape[1]);
+    CHECK_EQ(total_seq_length, q_data->shape[0] * q_data->shape[1]);
+    q_data =
+        q_data.CreateView({total_seq_length, q_data->shape[2], q_data->shape[3]}, q_data->dtype);
+    k_data =
+        k_data.CreateView({total_seq_length, k_data->shape[2], k_data->shape[3]}, k_data->dtype);
+    v_data =
+        v_data.CreateView({total_seq_length, v_data->shape[2], v_data->shape[3]}, v_data->dtype);
+    o_data =
+        o_data.CreateView({total_seq_length, o_data->shape[2], o_data->shape[3]}, o_data->dtype);
 
     // The auxiliary data structure on device must have been synchronized.
     CHECK(!dirty_aux_data_device_)
         << "The auxiliary arrays are not synchronized to device. Please call "
-           "`SyncAuxArrayToDevice` to synchronize before calling `Attention`.";
+           "`BeginForward` to synchronize before calling `Attention`.";
 
-    f_attention(q_data, pages_,                                          //
-                page_table_indptr_view_, page_table_values_view_,        //
-                last_page_offset_view_, cur_append_length_indptr_view_,  //
-                layer_id, output, apply_rotary, rotary_scale, rotary_theta);
+    // Part 2: apply rotary embedding to q/k data.
+    f_rotary_(q_data, k_data, cur_append_length_indptr_view_, cur_rope_offset_view_,
+              cur_batch_size_, num_qo_heads_, num_kv_heads_, head_dim_, /*qkv_layout=*/0,
+              rotary_scale_, rotary_theta_);
+
+    // Part 3: append k/v data to kv-cache
+    f_transpose_append_(pages_[layer_id], k_data, v_data, append_position_map_view_);
+    // Part 4: perform attention
+    AttentionInternal(layer_id, q_data, k_data, v_data, o_data);
   }
 
-  /*!
-   * \brief Append the k/v data to the cache on the given layer.
-   * Prior to Append, ReserveExtraLengthForAppend should be called to specify
-   * the length of append for each request.
-   * \param f_transpose_append The function that copies the input data to the
-   * cache data. It does a transpose-copy due to the layout difference between
-   * K/V and the cache data.
-   * \param k_data The input k data.
-   * \param v_data The input v data.
-   * \param layer_id The model layer index of the current append.
-   * \note We support the following two layout settings for K/V data:
-   * - in batch decode settings, k/v_data has layout (num_total_seqs, 1, num_heads, head_dim)
-   *   where num_total_seqs should exactly equal to the number of sequences in the cache.
-   * - in other settings (single-sequence prefill, batch prefill, or speculation
-   *   verification), k/v_data has the **flattened layout** to handle raggedness:
-   *   (1, total query length, num_heads, head_dim).
-   */
-  void Append(PackedFunc f_transpose_append, NDArray k_data, NDArray v_data, int64_t layer_id) {
-    // Check k/v_data shape validity
-    CHECK_EQ(k_data->ndim, 4);
-    CHECK_GT(k_data->shape[1], 0);
-    CHECK_EQ(k_data->shape[2], num_heads_);
-    CHECK_EQ(k_data->shape[3], head_dim_);
-    for (int i = 0; i < 4; ++i) {
-      CHECK_EQ(k_data->shape[i], v_data->shape[i]);
-    }
-    CHECK(k_data.DataType() == pages_.DataType());
-    CHECK(v_data.DataType() == pages_.DataType());
+  void DebugGetKV(int64_t seq_id, int64_t start_pos, int64_t end_pos, NDArray k_data,
+                  NDArray v_data) final {
+    CHECK(f_debug_get_kv_.defined())
+        << "PageAttentionKVCache requires the `f_debug_get_kv` to be explicitly passed in when "
+           "initialization. Please construct the KV cache with `f_debug_get_kv`.";
 
-    if (k_data->shape[0] > 1) {
-      CHECK_EQ(k_data->shape[0], num_total_seqs_);
-      CHECK_EQ(k_data->shape[1], 1);
+    const Sequence& seq = seq_map_.at(seq_id);
+    CHECK_GE(start_pos, 0) << "DebugGetKV does not accept negative start_pos " << start_pos;
+    CHECK_LE(end_pos, seq.seq_length) << "DebugGetKV does not accept out-of-range end_pos";
+    CHECK_LT(start_pos, end_pos) << "DebugGetKV does not accept \"start_pos >= end_pos\"";
+
+    // k/v_data: (num_layers, seq_length, num_kv_heads, head_dim)
+    static constexpr const char* error_msg =
+        "DebugGetKV expects the k_data in layout (num_layers, seq_length, num_kv_heads, head_dim).";
+    std::vector<NDArray*> vec_kv_data = {&k_data, &v_data};
+    for (const NDArray* data_ptr : vec_kv_data) {
+      CHECK_EQ((*data_ptr)->ndim, 4) << error_msg;
+      CHECK_EQ((*data_ptr)->shape[0], num_layers_)
+          << error_msg << " The number of layers mismatches.";
+      CHECK_EQ((*data_ptr)->shape[1], end_pos - start_pos)
+          << error_msg << " The sequence length mismatches.";
+      CHECK_EQ((*data_ptr)->shape[2], num_kv_heads_)
+          << error_msg << " The number of heads mismatches.";
+      CHECK_EQ((*data_ptr)->shape[3], head_dim_)
+          << error_msg << " The number of head features mismatches.";
     }
-    int64_t ntoken = 0;
-    for (int64_t seq_id = 0; seq_id < num_total_seqs_; ++seq_id) {
-      ntoken += cur_append_lengths_[seq_id];
-      CHECK_LE(cur_append_lengths_[seq_id], seq_lengths_[seq_id]);
-      if (k_data->shape[0] > 1) {
-        CHECK_EQ(cur_append_lengths_[seq_id], 1);
+
+    std::vector<int32_t> trace = seq.GetBlockTrace(global_block_pool_);
+    std::vector<int32_t> append_position_map;
+    append_position_map.reserve(seq.seq_length);
+    for (int32_t block_id : trace) {
+      const Block& block = global_block_pool_[block_id];
+      for (int i = 0; i < static_cast<int>(block.page_ids.size()); ++i) {
+        int32_t page_offset = i != static_cast<int>(block.page_ids.size()) - 1
+                                  ? page_size_
+                                  : ((block.seq_length - 1) % page_size_ + 1);
+        for (int32_t p = 0; p < page_offset; ++p) {
+          append_position_map.push_back(block.page_ids[i] * page_size_ + p);
+        }
       }
     }
-    CHECK_EQ(ntoken, k_data->shape[0] * k_data->shape[1]);
-    ICHECK_EQ(ntoken, cur_pos2seqid_view_->shape[0]);
-
-    // The auxiliary data structure on device must have been synchronized.
-    CHECK(!dirty_aux_data_device_)
-        << "The auxiliary arrays are not synchronized to device. Please call "
-           "`SyncAuxArrayToDevice` to synchronize before calling `Append`.";
-
-    // Copy data
-    f_transpose_append(pages_,  //
-                       k_data.CreateView({ntoken, num_heads_, head_dim_}, k_data->dtype),
-                       v_data.CreateView({ntoken, num_heads_, head_dim_}, v_data->dtype),
-                       page_table_indptr_view_, page_table_values_view_,  //
-                       last_page_offset_view_, cur_append_length_indptr_view_, cur_pos2seqid_view_,
-                       layer_id);
+    NDArray position_map_device =
+        NDArray::Empty({end_pos - start_pos}, dtype_aux_, cur_append_length_indptr_device_->device);
+    position_map_device.CopyFromBytes(
+        append_position_map.data() + start_pos,
+        (end_pos - start_pos) * ((dtype_aux_.bits * dtype_aux_.lanes + 7) / 8));
+    for (int64_t layer_id = 0; layer_id < num_layers_; ++layer_id) {
+      f_debug_get_kv_.value()(pages_[layer_id], position_map_device, k_data, v_data, layer_id);
+    }
   }
 
-  /*!
-   * \brief Remove the given sequence from the cache.
-   * This includes erasing the sequence from data structures like page table,
-   * seq_lengths, etc.
-   * The id of all sequences on behind of it will be decreased by 1.
-   * \param seq_id The sequence to remove.
-   */
-  void Remove(int64_t seq_id) {
-    CHECK_LT(seq_id, num_total_seqs_);
-    for (int32_t page_id : page_table_[seq_id]) {
-      FreePage(page_id);
-    }
-    page_table_.erase(page_table_.begin() + seq_id);
-    seq_lengths_.erase(seq_lengths_.begin() + seq_id);
-    cur_append_lengths_.erase(cur_append_lengths_.begin() + seq_id);
-    --num_total_seqs_;
-    dirty_aux_data_device_ = true;
-  }
-
-  /*!
-   * \brief Pop the last `n` slots of K/V values for the given sequence.
-   * \param seq_id The sequence to be processed.
-   * \param n The length to pop.
-   */
-  void PopN(int64_t seq_id, int64_t n) {
-    CHECK_LT(seq_id, num_total_seqs_);
-    CHECK_GE(n, 0);
-    CHECK_LE(n, seq_lengths_[seq_id]);
-
-    // NOTE: this method does not free pages.
-    seq_lengths_[seq_id] -= n;
-    dirty_aux_data_device_ = true;
-  }
-
-  /*!
-   * \brief Returning the cached K/V values in the form of "an array of NDArray".
-   * Each returned NDArray has layout (num_layers, 2, seqlen, num_heads, head_dim),
-   * where along on the "2" dimension, index 0 stands for K and 1 stands for V.
-   * \param f_copy_data The function used for copying data out from cache.
-   * \return The cached K/V values, one NDArray per sequence.
-   * \note This method is majorly for debug and testing purpose.
-   */
-  Array<NDArray> DebugGetKV(PackedFunc f_copy_data) {
-    // The auxiliary data structure on device must have been synchronized.
-    CHECK(!dirty_aux_data_device_)
-        << "The auxiliary arrays are not synchronized to device. Please call "
-           "`SyncAuxArrayToDevice` to synchronize before calling `View`.";
-
-    Array<NDArray> kv_values;
-    kv_values.reserve(num_total_seqs_);
-
-    for (int64_t seq_id = 0; seq_id < num_total_seqs_; ++seq_id) {
-      NDArray values = NDArray::Empty({num_layers_, 2, num_heads_, seq_lengths_[seq_id], head_dim_},
-                                      pages_->dtype, pages_->device);
-      f_copy_data(pages_, page_table_indptr_view_, page_table_values_view_, values, seq_id);
-      kv_values.push_back(values);
-    }
-    return kv_values;
-  }
-
-  /*! \brief Reset the values in cur_append_lengths to zeros */
-  void ResetAppendLengths() {
-    ICHECK_EQ(cur_append_lengths_.size(), num_total_seqs_);
-    for (int64_t seq_id = 0; seq_id < num_total_seqs_; ++seq_id) {
-      cur_append_lengths_[seq_id] = 0;
-    }
-    dirty_aux_data_device_ = true;
-  }
-
-  /*!
-   * \brief Synchronize auxiliary arrays to device. The arrays include
-   * - page table (represented in CSR format on device),
-   * - the number of used slots in the last page of each sequence,
-   * - the lengths of append for each sequence,
-   * - the position-to-seqid array of each position in the appended data.
-   * \note This method resets the dirty flag to false, and needs to be
-   * invoked before running any computation on device (attention/append/...).
-   */
-  void SyncAuxArrayToDevice() {
-    int64_t nbyte_aux = (dtype_aux_.bits * dtype_aux_.lanes + 7) / 8;
-
-    // - Invariant checks
-    ICHECK_EQ(page_table_.size(), num_total_seqs_);
-    ICHECK_EQ(seq_lengths_.size(), num_total_seqs_);
-    for (int64_t seq_id = 0; seq_id < num_total_seqs_; ++seq_id) {
-      ICHECK(!page_table_[seq_id].empty());
-    }
-    // - Grow NDArrays when needed.
-    DeviceAuxNDArrayGrow();
-
-    // - Copy page table indptr and values and copy to device.
-    std::vector<int32_t> page_table_indptr_host = {0};
-    std::vector<int32_t> page_table_values_host;
-    int64_t npage_in_use = 0;
-    for (int64_t seq_id = 0; seq_id < num_total_seqs_; ++seq_id) {
-      // NOTE: The page table on host may contain the pages that are not
-      // in use by the sequence.
-      // Here we only copy the pages in use.
-      std::vector<int32_t> seq_page_table = page_table_[seq_id];
-      int64_t npage = (seq_lengths_[seq_id] + page_size_ - 1) / page_size_;
-      ICHECK_LE(npage, static_cast<int64_t>(seq_page_table.size()));
-      page_table_values_host.insert(page_table_values_host.end(), seq_page_table.begin(),
-                                    seq_page_table.begin() + npage);
-      page_table_indptr_host.push_back(page_table_values_host.size());
-      npage_in_use += seq_page_table.size();
-    }
-
-    ICHECK_EQ(npage_in_use, num_pages_in_use_);
-    ICHECK_EQ(page_table_indptr_host.size(), num_total_seqs_ + 1);
-    page_table_indptr_view_ =
-        page_table_indptr_device_.CreateView({num_total_seqs_ + 1}, dtype_aux_);
-    page_table_indptr_view_.CopyFromBytes(page_table_indptr_host.data(),
-                                          (num_total_seqs_ + 1) * nbyte_aux);
-    page_table_values_view_ = page_table_values_device_.CreateView(
-        {static_cast<int64_t>(page_table_values_host.size())}, dtype_aux_);
-    page_table_values_view_.CopyFromBytes(page_table_values_host.data(),
-                                          page_table_values_host.size() * nbyte_aux);
-
-    // - Compute `last_page_offset` from seq_lengths and copy to device.
-    std::vector<int32_t> last_page_offset_host;
-    last_page_offset_host.reserve(num_total_seqs_);
-    for (int32_t len : seq_lengths_) {
-      ICHECK_GT(len, 0);
-      last_page_offset_host.push_back((len - 1) % page_size_ + 1);
-    }
-    last_page_offset_view_ = last_page_offset_device_.CreateView({num_total_seqs_}, dtype_aux_);
-    last_page_offset_view_.CopyFromBytes(last_page_offset_host.data(), num_total_seqs_ * nbyte_aux);
-
-    // - Compute append_length_indptr, pos2seqid and copy to device.
-    std::vector<int32_t> append_length_indptr = {0};
-    std::vector<int32_t> pos2seqid;
-    append_length_indptr.reserve(num_total_seqs_ + 1);
-
-    for (int64_t seq_id = 0; seq_id < num_total_seqs_; ++seq_id) {
-      append_length_indptr.push_back(append_length_indptr.back() + cur_append_lengths_[seq_id]);
-      for (int64_t pos = 0; pos < cur_append_lengths_[seq_id]; ++pos) {
-        pos2seqid.push_back(seq_id);
-      }
-    }
-    CHECK_EQ(append_length_indptr.back(), pos2seqid.size());
-    ICHECK_EQ(append_length_indptr.size(), num_total_seqs_ + 1);
-    cur_append_length_indptr_view_ =
-        cur_append_length_indptr_device_.CreateView({num_total_seqs_ + 1}, dtype_aux_);
-    cur_append_length_indptr_view_.CopyFromBytes(append_length_indptr.data(),
-                                                 (num_total_seqs_ + 1) * nbyte_aux);
-    cur_pos2seqid_view_ =
-        cur_pos2seqid_device_.CreateView({static_cast<int64_t>(pos2seqid.size())}, dtype_aux_);
-    cur_pos2seqid_view_.CopyFromBytes(pos2seqid.data(), pos2seqid.size() * nbyte_aux);
-
-    // - Reset the dirty flag to false.
-    dirty_aux_data_device_ = false;
-  }
-
-  /*! \brief Return the number of remaining pages. */
-  int GetNumAvailablePages() {
-    ICHECK_EQ(num_pages_allocated_, free_page_ids_.size() + num_pages_in_use_);
-    return pages_->shape[0] - num_pages_in_use_;
-  }
-
-  /*! \brief Reset the KV cache. */
-  void Clear() {
-    num_total_seqs_ = 0;
-    num_pages_in_use_ = 0;
-    num_pages_allocated_ = 0;
-
-    free_page_ids_.clear();
-    page_table_.clear();
-    seq_lengths_.clear();
-    cur_append_lengths_.clear();
-
-    dirty_aux_data_device_ = false;
+  void DebugSetKV(int64_t seq_id, int64_t start_pos, NDArray k_data, NDArray v_data) final {
+    ICHECK(false) << "DebugSetKV for PageAttentionKVCache not implemented yet.";
   }
 
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
@@ -515,96 +704,332 @@ class PagedAttentionKVCacheObj : public Object {
   TVM_DECLARE_FINAL_OBJECT_INFO(PagedAttentionKVCacheObj, Object);
 
  private:
-  /*!
-   * \brief Allocate a new page for the given sequence.
-   * This function updates the page table for the given sequence.
-   */
-  void AllocatePageForSequence(int64_t seq_id) {
-    ICHECK_LT(seq_id, num_total_seqs_);
-    int32_t page_id = GetFreePage();
-    page_table_[seq_id].push_back(page_id);
-    ++num_pages_in_use_;
-  }
-
   /*! \brief Get a new free page and return its id. */
   int32_t GetFreePage() {
     // Find a page from the free page pools.
-    if (!free_page_ids_.empty()) {
-      int32_t page_id = free_page_ids_.back();
-      free_page_ids_.pop_back();
-      return page_id;
-    }
-
-    // Allocate a new page.
-    int64_t reserved_num_pages = pages_->shape[0];
-    if (num_pages_allocated_ < reserved_num_pages) {
-      return num_pages_allocated_++;
-    }
-    CHECK(allow_growth_)
-        << "The page KV cache is full and growth is not allowed. Please set a larger "
-           "total token capacity when initialization.";
-    ICHECK_EQ(num_pages_allocated_, reserved_num_pages);
-
-    // Grow the `pages` array by doubling its size.
-    ICHECK_EQ(pages_->ndim, 6);
-    std::vector<int64_t> new_shape(pages_->shape, pages_->shape + 6);
-    new_shape[0] = reserved_num_pages * 2;
-    DLDataType dtype = pages_->dtype;
-    NDArray new_pages = NDArray::Empty(new_shape, dtype, pages_->device);
-    new_pages.CreateView(pages_.Shape(), dtype).CopyFrom(pages_);
-    this->pages_ = new_pages;
-    // Also create a larger pos2seqid
-    this->cur_pos2seqid_device_ = NDArray::Empty({reserved_num_pages * 2 * page_size_}, dtype_aux_,
-                                                 cur_pos2seqid_device_->device);
-
-    return num_pages_allocated_++;
+    CHECK(!free_page_ids_.empty()) << "The KV cache is full. No page can be allocated.";
+    int32_t page_id = free_page_ids_.back();
+    free_page_ids_.pop_back();
+    return page_id;
   }
 
-  /*! \brief Free the given page, putting it to the available free page pool. */
-  void FreePage(int32_t page_id) {
-    free_page_ids_.push_back(page_id);
-    --num_pages_in_use_;
+  /*! \brief Get a new free block and return its index. */
+  int32_t GetFreeBlock() {
+    if (!free_block_idx_.empty()) {
+      int32_t block_idx = free_block_idx_.back();
+      free_block_idx_.pop_back();
+      global_block_pool_[block_idx].Reset();
+      ICHECK_EQ(global_block_pool_[block_idx].index, block_idx);
+      return block_idx;
+    }
+
+    int32_t block_idx = global_block_pool_.size();
+    global_block_pool_.push_back(Block(block_idx));
+    return block_idx;
   }
 
-  /*! \brief Resize the auxiliary arrays on device as they grow. */
-  void DeviceAuxNDArrayGrow() {
-    int64_t reserved_nseq = page_table_indptr_device_->shape[0] - 1;
-    ICHECK_EQ(last_page_offset_device_->shape[0], reserved_nseq);
-    while (num_total_seqs_ > reserved_nseq) {
-      reserved_nseq *= 2;
+  /*!
+   * \brief Reserve extra append length in the given block, as
+   * preparation of the incoming KV cache append.
+   * New pages will be allocated to the block until the total
+   * capacity can cover the current sequence length (before reservation)
+   * plus the required append length.
+   * \param block_idx The index of the block to process.
+   * \param append_length The extra append length to reserve for the block.
+   */
+  void ReserveAppendLengthInBlock(int32_t block_idx, int64_t append_length) {
+    Block& block = global_block_pool_[block_idx];
+    CHECK_GT(append_length, 0) << "Append with length 0 is not allowed.";
+    CHECK_EQ(block.external_ref_cnt, 0)
+        << "The block is " << block.external_ref_cnt
+        << "-time referenced by other blocks, thus cannot accept new KV values.";
+
+    // The reservation is based on the current sequence length.
+    // If "current sequence + append length" does not exceed the
+    // current capacity (number of pages * page size), no action is taken.
+    int64_t cur_npage = block.page_ids.size();
+    int64_t tgt_npage = (block.seq_length + append_length + page_size_ - 1) / page_size_;
+    for (int64_t page_idx = cur_npage; page_idx < tgt_npage; ++page_idx) {
+      block.page_ids.push_back(GetFreePage());
+    }
+    block.seq_length += append_length;
+    dirty_aux_data_device_ = true;
+  }
+
+  /*!
+   * \brief For the given list of sequences, check the block trace of
+   * each sequence, and return the blocks ids used by the sequences
+   * on each depth.
+   * More precisely, the inner returned vector contains the block ids
+   * used by the sequences on a certain depth (or "-1" if a sequence
+   * has fewer depth). The outer returned vector contains the inner
+   * vectors from the lowest depth to the highest depth.
+   */
+  std::vector<std::vector<int32_t>> GetBlockIdsOnDepth(
+      const std::vector<const Sequence*>& sequences) const {
+    // - Get the trace of each sequence.
+    int64_t num_depths = 0;
+    std::vector<std::vector<int32_t>> seq_block_traces;
+    seq_block_traces.reserve(cur_batch_size_);
+    for (int i = 0; i < cur_batch_size_; ++i) {
+      std::vector<int32_t> trace = sequences[i]->GetBlockTrace(global_block_pool_);
+      num_depths = std::max(num_depths, static_cast<int64_t>(trace.size()));
+      seq_block_traces.push_back(std::move(trace));
     }
 
-    DLDevice device = page_table_indptr_device_->device;
-    if (reserved_nseq != page_table_indptr_device_->shape[0] - 1) {
-      CHECK(allow_growth_)
-          << "The page KV cache is full and growth is not allowed. Please set a larger "
-             "sequence capacity when initialization.";
-      page_table_indptr_device_ = NDArray::Empty({reserved_nseq + 1}, dtype_aux_, device);
-      last_page_offset_device_ = NDArray::Empty({reserved_nseq}, dtype_aux_, device);
-      cur_append_length_indptr_device_ = NDArray::Empty({reserved_nseq + 1}, dtype_aux_, device);
+    // "Transpose" the traces, yielding the block ids used on each depth.
+    std::vector<std::vector<int32_t>> block_ids_on_depths;
+    block_ids_on_depths.reserve(num_depths);
+    for (int d = 0; d < num_depths; ++d) {
+      std::vector<int32_t> block_ids;
+      block_ids.reserve(cur_batch_size_);
+      for (int i = 0; i < cur_batch_size_; ++i) {
+        block_ids.push_back(
+            d < static_cast<int>(seq_block_traces[i].size()) ? seq_block_traces[i][d] : -1);
+      }
+      block_ids_on_depths.push_back(std::move(block_ids));
+    }
+    return block_ids_on_depths;
+  }
+
+  /*!
+   * \brief This function considers an optimization which coalesces
+   * adjacent decode attention computations into a single prefill
+   * attention computation if the adjacent decodes attend to the same
+   * k/v values under certain conditions.
+   * If it decides to coalesce on a certain depth, we need to know
+   * the prefill length after coalescing. This function returns
+   * - a vector of block ids together with the prefill/decode lengths
+   * that attend to the blocks.
+   * - a boolean indicating whether to use decode kernel on for the
+   * input blocks.
+   */
+  std::pair<std::vector<std::pair<int32_t, int32_t>>, bool> GetChunkedBlockIds(
+      const std::vector<int32_t>& block_ids) const {
+    std::vector<std::pair<int32_t, int32_t>> uncoalesced_block_ids;
+    std::vector<std::pair<int32_t, int32_t>> coalesced_block_ids;
+
+    // Gather the number of pages before/after coalescing respectively.
+    int cur_block_id = block_ids[0];
+    int chunk_append_length = cur_append_lengths_[0];
+    int page_counter_coalesced = 0;
+    int page_counter_uncoalesced =
+        block_ids[0] != -1 ? global_block_pool_[block_ids[0]].page_ids.size() : 0;
+    for (int i = 1; i < static_cast<int>(block_ids.size()); ++i) {
+      if (block_ids[i] != -1) {
+        page_counter_uncoalesced += global_block_pool_[block_ids[i]].page_ids.size();
+      }
+      uncoalesced_block_ids.emplace_back(block_ids[i - 1], cur_append_lengths_[i - 1]);
+      if (block_ids[i] == cur_block_id) {
+        chunk_append_length += cur_append_lengths_[i];
+      } else {
+        coalesced_block_ids.emplace_back(cur_block_id, chunk_append_length);
+        if (cur_block_id != -1) {
+          page_counter_coalesced += global_block_pool_[cur_block_id].page_ids.size();
+        }
+        cur_block_id = block_ids[i];
+        chunk_append_length = cur_append_lengths_[i];
+      }
+    }
+    uncoalesced_block_ids.emplace_back(block_ids.back(), cur_append_lengths_.back());
+    coalesced_block_ids.emplace_back(cur_block_id, chunk_append_length);
+    if (cur_block_id != -1) {
+      page_counter_coalesced += global_block_pool_[cur_block_id].page_ids.size();
+    }
+    double coalesce_ratio = 1.0 * page_counter_uncoalesced / page_counter_coalesced;
+    // Do not coalesce and use batch decode kernel when coalesce ratio is small.
+    bool use_decode_kernel = is_decode_request_ && coalesce_ratio < 1.1;
+
+    return {use_decode_kernel ? uncoalesced_block_ids : coalesced_block_ids, use_decode_kernel};
+  }
+
+  /*! \brief Invoke the "begin forward" functions of underlying kernels. */
+  void KernelBeginForward() {
+    if (num_depths_ == 1) {
+      if (use_decode_kernel_[0]) {
+        f_attention_decode_begin_forward_(
+            /*depth=*/0, page_indptr_on_depths_view_[0], page_indices_on_depths_view_[0],
+            last_page_len_on_depths_view_[0], /*return_lse=*/true, num_qo_heads_, num_kv_heads_,
+            head_dim_, page_size_, /*rotary_mode=*/true);
+      } else {
+        f_attention_prefill_begin_forward_(/*depth=*/0, qo_indptr_on_depths_view_[0],
+                                           cur_batch_size_, num_qo_heads_, num_kv_heads_);
+      }
+    } else {
+      f_attention_prefill_ragged_begin_forward_(cur_append_length_indptr_view_, cur_batch_size_,
+                                                num_qo_heads_, num_kv_heads_);
+      for (int d = 0; d < num_depths_; ++d) {
+        if (page_indices_on_depths_view_[d]->shape[0] == 0) {
+          continue;
+        }
+        if (use_decode_kernel_[d]) {
+          f_attention_decode_begin_forward_(
+              d, page_indptr_on_depths_view_[d], page_indices_on_depths_view_[d],
+              last_page_len_on_depths_view_[d], /*rotary_mode=*/false, num_qo_heads_, num_kv_heads_,
+              head_dim_, page_size_, /*return_lse=*/true);
+        } else {
+          f_attention_prefill_begin_forward_(/*depth=*/d, qo_indptr_on_depths_view_[d],
+                                             last_page_len_on_depths_view_[d]->shape[0],
+                                             num_qo_heads_, num_kv_heads_);
+        }
+      }
+    }
+  }
+
+  /*!
+   * \brief Compute attention for between the input q data and the
+   * input k/v data and the k/v data in cache on the given layer.
+   */
+  void AttentionInternal(int64_t layer_id, NDArray q_data, NDArray k_data, NDArray v_data,
+                         NDArray output) {
+    CHECK_GE(num_depths_, 1) << "The number of effective depths must be greater or equal to 1.";
+    if (num_depths_ == 1) {
+      if (use_decode_kernel_[0]) {
+        f_attention_decode_(/*depth=*/0, q_data, pages_[layer_id], page_indptr_on_depths_view_[0],
+                            page_indices_on_depths_view_[0], last_page_len_on_depths_view_[0],
+                            output, merged_attn_scores_view_,
+                            /*rotary_mode=*/0, rotary_scale_, rotary_theta_);
+      } else {
+        f_attention_prefill_(/*depth=*/0, q_data, qo_indptr_on_depths_view_[0], pages_[layer_id],
+                             page_indptr_on_depths_view_[0], page_indices_on_depths_view_[0],
+                             last_page_len_on_depths_view_[0], output, merged_attn_scores_view_,
+                             /*causal=*/1,
+                             /*rotary_mode=*/0, rotary_scale_, rotary_theta_);
+      }
+    } else {
+      // Compute appended text self-attention
+      f_attention_prefill_ragged_(q_data, cur_append_length_indptr_view_, k_data, v_data,
+                                  cur_append_length_indptr_view_, output, merged_attn_scores_view_,
+                                  /*causal=*/1,
+                                  /*rotary_mode=*/0, rotary_scale_, rotary_theta_);
+
+      for (int d = 0; d < num_depths_; ++d) {
+        if (page_indices_on_depths_view_[d]->shape[0] == 0) {
+          continue;
+        }
+        if (use_decode_kernel_[d]) {
+          // Use decode kernel for depth d
+          f_attention_decode_(/*depth=*/d, q_data, pages_[layer_id], page_indptr_on_depths_view_[d],
+                              page_indices_on_depths_view_[d], last_page_len_on_depths_view_[d],
+                              temp_attn_output_view_, temp_attn_scores_view_,
+                              /*rotary_mode=*/0, rotary_scale_, rotary_theta_);
+        } else {
+          // Use prefill kernel for depth d
+          f_attention_prefill_(/*depth=*/d, q_data, qo_indptr_on_depths_view_[d], pages_[layer_id],
+                               page_indptr_on_depths_view_[d], page_indices_on_depths_view_[d],
+                               last_page_len_on_depths_view_[d], temp_attn_output_view_,
+                               temp_attn_scores_view_,
+                               /*causal=*/0,
+                               /*rotary_mode=*/0, rotary_scale_, rotary_theta_);
+        }
+        f_merge_inplace_(output, merged_attn_scores_view_, temp_attn_output_view_,
+                         temp_attn_scores_view_);
+      }
+    }
+  }
+
+  /*!
+   * \brief Synchronize auxiliary arrays to device.
+   * \note This method resets the dirty flag to false, and needs to be
+   * invoked before running attention computation on device.
+   */
+  void SyncAuxArrayToDevice(std::vector<std::vector<int32_t>> qo_indptr_on_depths,
+                            std::vector<std::vector<int32_t>> page_indptr_on_depths,
+                            std::vector<std::vector<int32_t>> page_indices_on_depths,
+                            std::vector<std::vector<int32_t>> last_page_len_on_depths,
+                            std::vector<int32_t> rope_offset,
+                            std::vector<int32_t> append_position_map) {
+    ICHECK(dtype_aux_.bits == 32 && dtype_aux_.code == kDLInt);
+    ICHECK_EQ(qo_indptr_on_depths.size(), num_depths_);
+    ICHECK_EQ(page_indptr_on_depths.size(), num_depths_);
+    ICHECK_EQ(page_indices_on_depths.size(), num_depths_);
+    ICHECK_EQ(last_page_len_on_depths.size(), num_depths_);
+    int64_t total_append_length = 0;
+    int num_sequences = cur_append_lengths_.size();
+    std::vector<int32_t> cur_append_lengths_indptr{0};
+    for (int i = 0; i < static_cast<int>(cur_append_lengths_.size()); ++i) {
+      cur_append_lengths_indptr.push_back(cur_append_lengths_indptr.back() +
+                                          cur_append_lengths_[i]);
+    }
+    total_append_length = cur_append_lengths_indptr.back();
+    ICHECK_EQ(total_append_length, append_position_map.size());
+
+    auto fcopy_from_vec = [](NDArray array, int32_t* vec_data) {
+      DLTensor copy_dst = *array.operator->();
+      DLTensor copy_src;
+      copy_src.data = vec_data;
+      copy_src.device = Device{kDLCPU, 0};
+      copy_src.ndim = 1;
+      copy_src.dtype = array->dtype;
+      copy_src.shape = array->shape;
+      copy_src.strides = nullptr;
+      copy_src.byte_offset = 0;
+      NDArray::CopyFromTo(&copy_src, &copy_dst);
+    };
+
+    // 1. qo_indptr_on_depths
+    for (int d = 0; d < num_depths_; ++d) {
+      qo_indptr_on_depths_view_[d] = qo_indptr_on_depths_device_[d].CreateView(
+          {static_cast<int64_t>(qo_indptr_on_depths[d].size())}, dtype_aux_);
+      fcopy_from_vec(qo_indptr_on_depths_view_[d], qo_indptr_on_depths[d].data());
     }
 
-    if (pages_->shape[0] > page_table_values_device_->shape[0]) {
-      CHECK(allow_growth_)
-          << "The page KV cache is full and growth is not allowed. Please set a larger "
-             "total token capacity when initialization.";
-      page_table_values_device_ = NDArray::Empty({pages_->shape[0]}, dtype_aux_, device);
+    // 2. page_indptr_on_depths
+    for (int d = 0; d < num_depths_; ++d) {
+      ICHECK_EQ(page_indptr_on_depths[d].size(), qo_indptr_on_depths[d].size());
+      page_indptr_on_depths_view_[d] = page_indptr_on_depths_device_[d].CreateView(
+          {static_cast<int64_t>(page_indptr_on_depths[d].size())}, dtype_aux_);
+      fcopy_from_vec(page_indptr_on_depths_view_[d], page_indptr_on_depths[d].data());
     }
+
+    // 3. page_indices_on_depths
+    for (int d = 0; d < num_depths_; ++d) {
+      ICHECK_EQ(page_indices_on_depths[d].size(), page_indptr_on_depths[d].back());
+      page_indices_on_depths_view_[d] = page_indices_on_depths_device_[d].CreateView(
+          {static_cast<int64_t>(page_indices_on_depths[d].size())}, dtype_aux_);
+      if (!page_indices_on_depths[d].empty()) {
+        fcopy_from_vec(page_indices_on_depths_view_[d], page_indices_on_depths[d].data());
+      }
+    }
+
+    // 4. last_page_len_on_depths
+    for (int d = 0; d < num_depths_; ++d) {
+      ICHECK_EQ(last_page_len_on_depths[d].size() + 1, qo_indptr_on_depths[d].size());
+      last_page_len_on_depths_view_[d] = last_page_len_on_depths_device_[d].CreateView(
+          {static_cast<int64_t>(last_page_len_on_depths[d].size())}, dtype_aux_);
+      fcopy_from_vec(last_page_len_on_depths_view_[d], last_page_len_on_depths[d].data());
+    }
+
+    // 5. cur_append_lengths_indptr
+    cur_append_length_indptr_view_ =
+        cur_append_length_indptr_device_.CreateView({num_sequences + 1}, dtype_aux_);
+    fcopy_from_vec(cur_append_length_indptr_view_, cur_append_lengths_indptr.data());
+
+    // 6. cur_rope_offset
+    ICHECK_EQ(rope_offset.size(), num_sequences);
+    cur_rope_offset_view_ = cur_rope_offset_device_.CreateView({num_sequences}, dtype_aux_);
+    fcopy_from_vec(cur_rope_offset_view_, rope_offset.data());
+
+    // 7. append_position_map
+    append_position_map_view_ =
+        append_position_map_device_.CreateView({total_append_length}, dtype_aux_);
+    fcopy_from_vec(append_position_map_view_, append_position_map.data());
+
+    // 8. Create view for temporary arrays for attention computation.
+    temp_attn_output_view_ = temp_attn_output_device_.CreateView(
+        {total_append_length, num_qo_heads_, head_dim_}, temp_attn_output_device_->dtype);
+    temp_attn_scores_view_ = temp_attn_scores_device_.CreateView(
+        {total_append_length, num_qo_heads_}, temp_attn_scores_device_->dtype);
+    merged_attn_scores_view_ = merged_attn_scores_device_.CreateView(
+        {total_append_length, num_qo_heads_}, merged_attn_scores_device_->dtype);
+
+    // - Reset the dirty flag to false.
+    dirty_aux_data_device_ = false;
   }
 };
 
 class PagedAttentionKVCache : public ObjectRef {
  public:
-  static PagedAttentionKVCache Create(int64_t reserved_num_seqs, int64_t total_token_capacity,
-                                      int64_t page_size, int64_t num_layers, int64_t num_heads,
-                                      int64_t head_dim, NDArray init, bool allow_growth) {
-    int64_t reserved_num_pages = (total_token_capacity + page_size - 1) / page_size;
-    auto n = make_object<PagedAttentionKVCacheObj>(page_size, num_layers, num_heads, head_dim,
-                                                   reserved_num_seqs, reserved_num_pages,
-                                                   init->dtype, init->device, allow_growth);
-    return PagedAttentionKVCache(n);
-  }
-
   TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(PagedAttentionKVCache, ObjectRef, PagedAttentionKVCacheObj);
 };
 
@@ -615,67 +1040,59 @@ TVM_REGISTER_OBJECT_TYPE(PagedAttentionKVCacheObj);
 //-------------------------------------------------
 
 TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_create")
-    .set_body_typed([](ShapeTuple cache_config, int64_t num_layers_, int64_t num_heads_,
-                       int64_t head_dim_, NDArray init, bool allow_growth) {
+    .set_body_typed([](ShapeTuple cache_config, int64_t num_layers, int64_t num_qo_heads,
+                       int64_t num_kv_heads, int64_t head_dim, double rotary_scale,
+                       double rotary_theta, NDArray init, PackedFunc f_transpose_append,
+                       PackedFunc f_attention_prefill, PackedFunc f_attention_decode,
+                       PackedFunc f_attention_prefill_ragged,
+                       PackedFunc f_attention_prefill_ragged_begin_forward,
+                       PackedFunc f_attention_prefill_ragged_end_forward,
+                       PackedFunc f_attention_prefill_begin_forward,
+                       PackedFunc f_attention_prefill_end_forward,
+                       PackedFunc f_attention_decode_begin_forward,
+                       PackedFunc f_attention_decode_end_forward, PackedFunc f_rotary,
+                       PackedFunc f_merge_inplace, Optional<PackedFunc> f_debug_get_kv) {
       CHECK_EQ(cache_config.size(), 3);
-      return PagedAttentionKVCache::Create(cache_config[0], cache_config[1], cache_config[2],
-                                           num_layers_, num_heads_, head_dim_, init, allow_growth);
+      int64_t reserved_num_seqs = cache_config[0];
+      int64_t total_token_capacity = cache_config[1];
+      int64_t page_size = cache_config[2];
+      int64_t num_total_pages = (total_token_capacity + page_size - 1) / page_size;
+      ObjectPtr<PagedAttentionKVCacheObj> n = make_object<PagedAttentionKVCacheObj>(
+          page_size, num_layers, num_qo_heads, num_kv_heads, head_dim, reserved_num_seqs,
+          num_total_pages, rotary_scale, rotary_theta, init->dtype, init->device,
+          std::move(f_transpose_append), std::move(f_attention_prefill),
+          std::move(f_attention_decode), std::move(f_attention_prefill_ragged),
+          std::move(f_attention_prefill_ragged_begin_forward),
+          std::move(f_attention_prefill_ragged_end_forward),
+          std::move(f_attention_prefill_begin_forward), std::move(f_attention_prefill_end_forward),
+          std::move(f_attention_decode_begin_forward), std::move(f_attention_decode_end_forward),
+          std::move(f_rotary), std::move(f_merge_inplace), std::move(f_debug_get_kv));
+      return PagedAttentionKVCache(std::move(n));
     });
-
-TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_add_sequence")
-    .set_body_typed([](PagedAttentionKVCache cache) { return cache->AddSequence(); });
-
-TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_reserve_extra_length_for_append")
-    .set_body_typed([](PagedAttentionKVCache cache, int seq_id, int extra_length) {
-      cache->ReserveExtraLengthForAppend(seq_id, extra_length);
-    });
-
-TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_append")
-    .set_body_typed([](PagedAttentionKVCache cache, PackedFunc f_transpose_append, NDArray k_data,
-                       NDArray v_data, int64_t layer_id) {
-      cache->Append(f_transpose_append, k_data, v_data, layer_id);
-      return cache;
-    });
-
-TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_remove")
-    .set_body_typed([](PagedAttentionKVCache cache, int64_t seq_id) { cache->Remove(seq_id); });
-
-TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_debug_get_kv")
-    .set_body_typed([](PagedAttentionKVCache cache, PackedFunc f_view) {
-      return cache->DebugGetKV(f_view);
-    });
-
-TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_popn")
-    .set_body_typed([](PagedAttentionKVCache cache, int64_t seq_id, int64_t n) {
-      cache->PopN(seq_id, n);
-    });
-
-TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_reset_append_lengths")
-    .set_body_typed([](PagedAttentionKVCache cache) { cache->ResetAppendLengths(); });
-
-TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_sync_aux_array_to_device")
-    .set_body_typed([](PagedAttentionKVCache cache) { cache->SyncAuxArrayToDevice(); });
 
 TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_clear")
-    .set_body_typed([](PagedAttentionKVCache cache) { cache->Clear(); });
-
+    .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::Clear);
+TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_add_sequence")
+    .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::AddSequence);
+TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_remove_sequence")
+    .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::RemoveSequence);
+TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_fork_sequence")
+    .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::ForkSequence);
+TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_popn")
+    .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::PopN);
 TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_get_num_available_pages")
-    .set_body_typed([](PagedAttentionKVCache cache) { return cache->GetNumAvailablePages(); });
-
+    .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::GetNumAvailablePages);
+TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_begin_forward")
+    .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::BeginForward);
+TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_end_forward")
+    .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::EndForward);
+TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_debug_get_kv")
+    .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::DebugGetKV);
 TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_attention")
-    .set_body([](TVMArgs args, TVMRetValue* rv) {
-      CHECK(args.size() == 5 || args.size() == 8);
-      bool apply_rotary = false;
-      double rotary_scale = 1.0;
-      double rotary_theta = 1e4;
-      if (args.size() == 8) {
-        apply_rotary = args[4];
-        rotary_scale = args[5];
-        rotary_theta = args[6];
-      }
-      PagedAttentionKVCache cache = args[0];
-      cache->Attention(/*f_attention=*/args[1], /*q_data=*/args[2], /*layer_id=*/args[3],
-                       /*output=*/args[args.size() - 1], apply_rotary, rotary_scale, rotary_theta);
+    .set_body_typed([](PagedAttentionKVCache kv_cache, int64_t layer_id, NDArray q_data,
+                       NDArray k_data, NDArray v_data, NDArray o_data) {
+      kv_cache->Attention(layer_id, std::move(q_data), std::move(k_data), std::move(v_data),
+                          NullOpt, std::move(o_data));
     });
 
 }  // namespace relax_vm

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache.py
@@ -14,413 +14,455 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import List
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
+import pytest
+import scipy.special
+
 import tvm
 import tvm.testing
+from tvm import dlight as dl
+from tvm.runtime import ShapeTuple
 from tvm.script import tir as T
 
-
-reserved_nseq = 2
-total_seq_len = 128
-page_size = 8
-nlayer = 4
-nhead = 16
-nfeat = 32
+reserved_nseq = 32
+maximum_total_seq_length = 1024
+page_size = 16
+num_layers = 4
+num_qo_heads = 32
+num_kv_heads = 4
+head_dim = 128
+rope_scale = 1.0
+rope_theta = 1e4
 dtype = "float16"
+device = tvm.cuda()
+
+fclear = None
+fcreate = None
+fadd_sequence = None
+fremove_sequence = None
+ffork_sequence = None
+fpopn = None
+fbegin_forward = None
+fend_forward = None
+fattention = None
+fdebug_get_kv = None
+
+fattention_prefill = None
+fattention_decode = None
+fattention_prefill_ragged = None
+fattention_prefill_begin_forward = None
+fattention_prefill_end_forward = None
+fattention_decode_begin_forward = None
+fattention_decode_end_forward = None
+fattention_prefill_ragged_begin_forward = None
+fattention_prefill_ragged_end_forward = None
+fattention_merge_state = None
+fattention_rotary = None
 
 
-fcreate = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_create")
-fadd_sequence = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_add_sequence")
-freserve = tvm.get_global_func(
-    "vm.builtin.paged_attention_kv_cache_reserve_extra_length_for_append"
-)
-fappend = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_append")
-freset_append_length = tvm.get_global_func(
-    "vm.builtin.paged_attention_kv_cache_reset_append_lengths"
-)
-fsync = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_sync_aux_array_to_device")
-fremove = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_remove")
-fpopn = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_popn")
-fclear = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_clear")
-
-# fmt: off
 @T.prim_func
-def transpose_append(
+def kv_cache_transpose_append(
     var_pages: T.handle,
     var_k_data: T.handle,
     var_v_data: T.handle,
-    var_page_table_indptr: T.handle,
-    var_page_table_values: T.handle,
-    var_last_page_offset: T.handle,
-    var_append_length_indptr: T.handle,
-    var_pos2seqidx: T.handle,
-    layer_id: T.int32,
+    var_position_map: T.handle,
 ):
-    nseq = T.int32()
-    ntoken = T.int32()
-    nhead = T.int32()
-    nfeat = T.int32()
-    nlayer = T.int32()
-    npage = T.int32()
-    page_size = T.int32()
-    num_pages = T.int32()
+    ntoken = T.SizeVar("ntoken", "int64")
+    page_size = T.SizeVar("page_size", "int64")
+    num_pages = T.int64()
 
-    pages = T.match_buffer(var_pages, (num_pages, nlayer, 2, nhead, page_size, nfeat), "float16")
-    k_data = T.match_buffer(var_k_data, (ntoken, nhead, nfeat), "float16")
-    v_data = T.match_buffer(var_v_data, (ntoken, nhead, nfeat), "float16")
-    last_page_offset = T.match_buffer(var_last_page_offset, (nseq,), "int32")
-    page_table_indptr = T.match_buffer(var_page_table_indptr, (nseq + 1,), "int32")
-    page_table_values = T.match_buffer(var_page_table_values, (npage,), "int32")
-    append_length_indptr = T.match_buffer(var_append_length_indptr, (nseq + 1,), "int32")
-    pos2seqidx = T.match_buffer(var_pos2seqidx, (ntoken,), "int32")
+    pages = T.match_buffer(var_pages, (num_pages, 2, num_kv_heads, page_size, head_dim), dtype)
+    k_data = T.match_buffer(var_k_data, (ntoken, num_kv_heads, head_dim), dtype)
+    v_data = T.match_buffer(var_v_data, (ntoken, num_kv_heads, head_dim), dtype)
+    position_map = T.match_buffer(var_position_map, (ntoken,), "int32")
 
-    for global_pos, h, f in T.grid(ntoken, nhead, nfeat):
+    for global_pos, h, f in T.grid(ntoken, num_kv_heads, head_dim):
         with T.block("k_transpose_append"):
             vgpos, vh, vf = T.axis.remap("SSS", [global_pos, h, f])
-            seq_idx = pos2seqidx[vgpos]
-            seqlen: T.int32 = (page_table_indptr[seq_idx + 1] - page_table_indptr[seq_idx] - 1) * page_size + last_page_offset[seq_idx]
+            position: T.int64 = T.Cast("int64", position_map[vgpos])
             pages[
-                page_table_values[page_table_indptr[seq_idx] + T.floordiv(seqlen - (append_length_indptr[seq_idx + 1] - vgpos), page_size)],
-                layer_id,
-                0,
-                vh,
-                T.floormod(seqlen - (append_length_indptr[seq_idx + 1] - vgpos), page_size),
-                vf,
+                T.floordiv(position, page_size), 0, vh, T.floormod(position, page_size), vf
             ] = k_data[vgpos, vh, vf]
         with T.block("v_transpose_append"):
             vgpos, vh, vf = T.axis.remap("SSS", [global_pos, h, f])
-            seq_idx = pos2seqidx[vgpos]
-            seqlen: T.int32 = (page_table_indptr[seq_idx + 1] - page_table_indptr[seq_idx] - 1) * page_size + last_page_offset[seq_idx]
+            position: T.int64 = T.Cast("int64", position_map[vgpos])
             pages[
-                page_table_values[page_table_indptr[seq_idx] + T.floordiv(seqlen - (append_length_indptr[seq_idx + 1] - vgpos), page_size)],
-                layer_id,
-                1,
-                vh,
-                T.floormod(seqlen - (append_length_indptr[seq_idx + 1] - vgpos), page_size),
-                vf,
+                T.floordiv(position, page_size), 1, vh, T.floormod(position, page_size), vf
             ] = v_data[vgpos, vh, vf]
 
 
 @T.prim_func
 def copy_cache(
     var_pages: T.handle,
-    var_page_table_indptr: T.handle,
-    var_page_table_values: T.handle,
-    var_values: T.handle,
-    seq_id: T.int32,
+    var_position_map: T.handle,
+    var_k_data: T.handle,
+    var_v_data: T.handle,
+    layer_id: T.int64,
 ):
-    nhead = T.int32()
-    nfeat = T.int32()
-    nlayer = T.int32()
-    seqlen = T.int32()
-    npage = T.int32()
-    page_size = T.int32()
-    num_pages = T.int32()
-    num_total_seqs_plus_1 = T.int32()
+    num_kv_heads = T.int64()
+    head_dim = T.int64()
+    seqlen = T.SizeVar("seqlen", "int64")
+    page_size = T.int64()
+    num_pages = T.int64()
 
-    pages = T.match_buffer(var_pages, (num_pages, nlayer, 2, nhead, page_size, nfeat), "float16")
-    page_table_indptr = T.match_buffer(var_page_table_indptr, (num_total_seqs_plus_1,), "int32")
-    page_table_values = T.match_buffer(var_page_table_values, (npage,), "int32")
-    values = T.match_buffer(var_values, (nlayer, 2, nhead, seqlen, nfeat), "float16")
+    pages = T.match_buffer(var_pages, (num_pages, 2, num_kv_heads, page_size, head_dim), "float16")
+    position_map = T.match_buffer(var_position_map, (seqlen,), "int32")
+    k_data = T.match_buffer(var_k_data, (num_layers, seqlen, num_kv_heads, head_dim), "float16")
+    v_data = T.match_buffer(var_v_data, (num_layers, seqlen, num_kv_heads, head_dim), "float16")
 
-    for l, kv_idx, h, pos, f in T.grid(nlayer, 2, nhead, seqlen, nfeat):
-        with T.block("view"):
-            vl, vi, vh, vp, vf = T.axis.remap("SSSSS", [l, kv_idx, h, pos, f])
-            values[vl, vi, vh, vp, vf] = pages[
-                page_table_values[page_table_indptr[seq_id] + T.floordiv(vp, page_size)],
-                vl,
-                vi,
-                vh,
-                T.floormod(vp, page_size),
-                vf,
+    for p, h, d in T.grid(seqlen, num_kv_heads, head_dim):
+        with T.block("copy0"):
+            vp, vh, vd = T.axis.remap("SSS", [p, h, d])
+            position: T.int64 = T.Cast("int64", position_map[vp])
+            k_data[layer_id, vp, vh, vd] = pages[
+                T.floordiv(position, page_size), 0, vh, T.floormod(position, page_size), vd
             ]
-# fmt: on
+            v_data[layer_id, vp, vh, vd] = pages[
+                T.floordiv(position, page_size), 1, vh, T.floormod(position, page_size), vd
+            ]
 
 
-def verify_cached_values(cache, expected, f_copy_cache):
-    fview = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_debug_get_kv")
+def set_global_func():
+    global fclear, fcreate, fadd_sequence, fremove_sequence, ffork_sequence, fpopn
+    global fbegin_forward, fend_forward, fattention, fdebug_get_kv
+    global fattention_prefill, fattention_prefill_begin_forward, fattention_prefill_end_forward
+    global fattention_decode, fattention_decode_begin_forward, fattention_decode_end_forward
+    global fattention_prefill_ragged
+    global fattention_prefill_ragged_begin_forward
+    global fattention_prefill_ragged_end_forward
+    global fattention_merge_state, fattention_rotary
 
-    actual = fview(cache, f_copy_cache)
-    assert len(actual) == len(expected)
-    for seq_actual, seq_expected in zip(actual, expected):
-        tvm.testing.assert_allclose(np.transpose(seq_actual.numpy(), [0, 1, 3, 2, 4]), seq_expected)
+    fclear = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_clear")
+    fcreate = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_create")
+    fadd_sequence = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_add_sequence")
+    fremove_sequence = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_remove_sequence")
+    ffork_sequence = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_fork_sequence")
+    fpopn = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_popn")
+    fbegin_forward = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_begin_forward")
+    fend_forward = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_end_forward")
+    fattention = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_attention")
+    fdebug_get_kv = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_debug_get_kv")
 
-
-def build_tir_func(tir_funcs: List[tvm.tir.PrimFunc], target="llvm"):
-    return [tvm.build(tir_func, target=target).entry_func for tir_func in tir_funcs]
-
-
-def test_paged_attention_kv_cache_append_prefill():
-    f_transpose_append, f_copy_cache = build_tir_func([transpose_append, copy_cache])
-    cache = fcreate(
-        tvm.runtime.ShapeTuple([reserved_nseq, total_seq_len, page_size]),
-        nlayer,
-        nhead,
-        nfeat,
-        tvm.nd.empty((), dtype),
-        True,
+    fattention_prefill = tvm.get_global_func("paged_kv_cache.attention_kernel_prefill")
+    fattention_decode = tvm.get_global_func("paged_kv_cache.attention_kernel_decode")
+    fattention_prefill_ragged = tvm.get_global_func(
+        "flashinfer.attention_kernel_prefill_with_ragged_kv_cache"
     )
+    fattention_prefill_begin_forward = tvm.get_global_func(
+        "paged_kv_cache.attention_kernel_prefill_begin_forward"
+    )
+    fattention_prefill_end_forward = tvm.get_global_func(
+        "paged_kv_cache.attention_kernel_prefill_end_forward"
+    )
+    fattention_decode_begin_forward = tvm.get_global_func(
+        "paged_kv_cache.attention_kernel_decode_begin_forward"
+    )
+    fattention_decode_end_forward = tvm.get_global_func(
+        "paged_kv_cache.attention_kernel_decode_end_forward"
+    )
+    fattention_prefill_ragged_begin_forward = tvm.get_global_func(
+        "flashinfer.attention_kernel_prefill_with_ragged_kv_cache_begin_forward"
+    )
+    fattention_prefill_ragged_end_forward = tvm.get_global_func(
+        "flashinfer.attention_kernel_prefill_with_ragged_kv_cache_end_forward"
+    )
+    fattention_merge_state = tvm.get_global_func("flashinfer.merge_state_in_place")
+    fattention_rotary = tvm.get_global_func("flashinfer.batch_qk_apply_rotary_in_place")
 
+
+def create_kv_cache():
+    set_global_func()
+    target = tvm.target.Target("nvidia/geforce-rtx-3090-ti")
+    builts = []
+    for tir_func in [kv_cache_transpose_append, copy_cache]:
+        mod = tvm.IRModule({"main": tir_func})
+        with target:
+            mod = dl.ApplyDefaultSchedule(dl.gpu.Fallback())(mod)
+        f = tvm.build(mod["main"], target=target)
+        builts.append(f.entry_func)
+
+    ftranspose_append, fcopy_cache = builts
+    cache = fcreate(
+        tvm.runtime.ShapeTuple([reserved_nseq, maximum_total_seq_length, page_size]),
+        num_layers,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        rope_scale,
+        rope_theta,
+        tvm.nd.empty((), dtype, device=device),
+        ftranspose_append,
+        fattention_prefill,
+        fattention_decode,
+        fattention_prefill_ragged,
+        fattention_prefill_ragged_begin_forward,
+        fattention_prefill_ragged_end_forward,
+        fattention_prefill_begin_forward,
+        fattention_prefill_end_forward,
+        fattention_decode_begin_forward,
+        fattention_decode_end_forward,
+        fattention_rotary,
+        fattention_merge_state,
+        fcopy_cache,
+    )
+    return cache
+
+
+@pytest.fixture()
+def kv_cache():
+    return create_kv_cache()
+
+
+def verify_cached_kv(kv_cache, seq_ids, expected_k, expected_v):
+    for seq_id in seq_ids:
+        keys_expected = expected_k[seq_id]
+        values_expected = expected_v[seq_id]
+        assert keys_expected.shape == values_expected.shape
+        seq_length = expected_k[seq_id].shape[1]
+        keys = tvm.nd.empty(keys_expected.shape, dtype=dtype, device=device)
+        values = tvm.nd.empty(values_expected.shape, dtype=dtype, device=device)
+        fdebug_get_kv(kv_cache, seq_id, 0, seq_length, keys, values)
+        tvm.testing.assert_allclose(keys.numpy(), keys_expected, rtol=1e-3, atol=1e-3)
+        tvm.testing.assert_allclose(values.numpy(), values_expected, rtol=1e-3, atol=1e-3)
+
+
+def f_apply_rotary(x, offset, scale, theta):
+    # x: (N, H, D)
+    assert len(x.shape) == 3
+    nfeat = x.shape[-1]
+    nfeat_half = x.shape[-1] // 2
+    x = x.astype("float32")
+    y = np.concatenate([-x[:, :, nfeat_half:], x[:, :, :nfeat_half]], axis=-1)
+
+    inv_freq = scale / (theta ** (np.arange(0, nfeat, 2).astype("float32") / nfeat))
+    t = np.arange(offset, offset + x.shape[0], dtype=inv_freq.dtype)
+    freqs = np.einsum("i,j->ij", t, inv_freq)
+    emb = np.concatenate((freqs, freqs), axis=-1)
+    cos_values = np.cos(emb)
+    sin_values = np.sin(emb)
+
+    return np.einsum("ij,ikj->ikj", cos_values, x) + np.einsum("ij,ikj->ikj", sin_values, y)
+
+
+def apply_attention(
+    kv_cache,
+    batch: List[Tuple[Union[int, Tuple[int, int]], int]],
+    cached_k: Dict[int, np.ndarray],
+    cached_v: Dict[int, np.ndarray],
+) -> None:
+    seq_ids = []
+    append_lengths = []
+    for i, (seq_id, append_length) in enumerate(batch):
+        fork_parent_id = None
+        if isinstance(seq_id, tuple):
+            # Fork sequence
+            seq_id, fork_parent_id = seq_id
+            batch[i] = (seq_id, append_length)
+        seq_ids.append(seq_id)
+        append_lengths.append(append_length)
+        if fork_parent_id is not None:
+            assert fork_parent_id in cached_k
+            assert seq_id not in cached_k
+            ffork_sequence(kv_cache, fork_parent_id, seq_id)
+            cached_k[seq_id] = cached_k[fork_parent_id]
+            cached_v[seq_id] = cached_v[fork_parent_id]
+        elif seq_id not in cached_k:
+            fadd_sequence(kv_cache, seq_id)
+            cached_k[seq_id] = np.zeros((num_layers, 0, num_kv_heads, head_dim), dtype)
+            cached_v[seq_id] = np.zeros((num_layers, 0, num_kv_heads, head_dim), dtype)
+
+    use_decode_shape = all(append_length == 1 for _, append_length in batch)
+    fbegin_forward(kv_cache, ShapeTuple(seq_ids), ShapeTuple(append_lengths))
+
+    global_new_q = np.zeros((num_layers, 0, num_qo_heads, head_dim), dtype)
+    global_new_k = np.zeros((num_layers, 0, num_kv_heads, head_dim), dtype)
+    global_new_v = np.zeros((num_layers, 0, num_kv_heads, head_dim), dtype)
+
+    q_array = []
+    for seq_id, append_length in batch:
+        new_q = np.random.rand(num_layers, append_length, num_qo_heads, head_dim).astype(dtype)
+        new_k = np.random.rand(num_layers, append_length, num_kv_heads, head_dim).astype(dtype)
+        new_v = np.random.rand(num_layers, append_length, num_kv_heads, head_dim).astype(dtype)
+        q_array.append(new_q)
+
+        cached_k[seq_id] = np.concatenate(
+            [
+                cached_k[seq_id],
+                np.stack(
+                    [
+                        f_apply_rotary(new_k[l], cached_k[seq_id].shape[1], rope_scale, rope_theta)
+                        for l in range(num_layers)
+                    ],
+                    axis=0,
+                ),
+            ],
+            axis=1,
+        )
+        cached_v[seq_id] = np.concatenate([cached_v[seq_id], new_v], axis=1)
+        global_new_q = np.concatenate([global_new_q, new_q], axis=1)
+        global_new_k = np.concatenate([global_new_k, new_k], axis=1)
+        global_new_v = np.concatenate([global_new_v, new_v], axis=1)
+
+    for layer_id in range(num_layers):
+        queries_np = global_new_q[layer_id : layer_id + 1]
+        keys_np = global_new_k[layer_id : layer_id + 1]
+        values_np = global_new_v[layer_id : layer_id + 1]
+        if use_decode_shape:
+            queries_np = queries_np.transpose(1, 0, 2, 3)
+            keys_np = keys_np.transpose(1, 0, 2, 3)
+            values_np = values_np.transpose(1, 0, 2, 3)
+        queries = tvm.nd.array(queries_np, device=device)
+        keys = tvm.nd.array(keys_np, device=device)
+        values = tvm.nd.array(values_np, device=device)
+        outputs = tvm.nd.empty(queries.shape, dtype, device=device)
+        fattention(kv_cache, layer_id, queries, keys, values, outputs)
+
+        # Compute attention expected results.
+        outputs = outputs.numpy()
+        if use_decode_shape:
+            outputs = outputs.transpose(1, 0, 2, 3)
+        sum_length = 0
+        for i, (seq_id, append_length) in enumerate(batch):
+            assert cached_k[seq_id].shape[1] == cached_v[seq_id].shape[1] >= append_length
+
+            rope_offset = cached_k[seq_id].shape[1] - append_length
+            q_seq = f_apply_rotary(
+                q_array[i][layer_id],
+                rope_offset,
+                rope_scale,
+                rope_theta,
+            ).transpose(1, 0, 2)
+            # Todo(Zihao, Ruihang): fold RoPE into flashinfer attn kernel in multi-level cases.
+            # so that k/v values in cache does not have RoPE applied.
+            # k_seq = f_apply_rotary(cached_k[seq_id][layer_id], 0, rope_scale, rope_theta).transpose(
+            #     1, 2, 0
+            # )
+            k_seq = cached_k[seq_id][layer_id].transpose(1, 2, 0)
+            v_seq = cached_v[seq_id][layer_id].transpose(1, 0, 2)
+
+            k_seq = np.repeat(k_seq, num_qo_heads // num_kv_heads, axis=0)
+            v_seq = np.repeat(v_seq, num_qo_heads // num_kv_heads, axis=0)
+            softmax_input = (q_seq.astype("float32") @ k_seq.astype("float32")) / np.sqrt(head_dim)
+            softmax_shape = softmax_input.shape
+            length_diff = softmax_shape[-1] - softmax_shape[-2]
+            assert length_diff >= 0
+            mask = np.tril(
+                np.full_like(softmax_input, np.finfo("float32").max), k=length_diff
+            ) + np.triu(np.full_like(softmax_input, np.finfo("float32").min), k=length_diff + 1)
+            softmax_input = np.minimum(softmax_input, mask)
+
+            results = np.expand_dims(
+                (scipy.special.softmax(softmax_input, axis=-1) @ v_seq.astype("float32")).transpose(
+                    1, 0, 2
+                ),
+                axis=0,
+            ).astype(dtype)
+
+            tvm.testing.assert_allclose(
+                outputs[:, sum_length : sum_length + append_length, ...],
+                results,
+                rtol=1e-3,
+                atol=1e-3,
+            )
+            sum_length += append_length
+    fend_forward(kv_cache)
+
+    # Verify
+    verify_cached_kv(kv_cache, seq_ids, cached_k, cached_v)
+
+
+@pytest.mark.skip(reason="Require FlashInfer enabled")
+def test_paged_attention_kv_cache_prefill_and_decode(kv_cache):
+    fclear(kv_cache)
+
+    # Prefill.
     operation_seq = [[(0, 6)], [(1, 8)], [(2, 11)], [(3, 16)], [(4, 19), (5, 20)]]
     operation_seq += [[(6, 21), (7, 24)], [(2, 5), (4, 7), (8, 24)]]
     operation_seq += [[(6, 13)], [(8, 19)], [(0, 1)], [(1, 3), (3, 8), (5, 12), (7, 11)]]
-
-    current_nseq = 0
-    cached_values = []
-    for batch in operation_seq:
-        for seq_id, _ in batch:
-            if seq_id >= current_nseq:
-                seq_id_in_cache = fadd_sequence(cache)
-                assert seq_id_in_cache == seq_id
-                assert seq_id == current_nseq
-                current_nseq += 1
-
-        freset_append_length(cache)
-        for seq_id, append_length in batch:
-            freserve(cache, seq_id, append_length)
-        fsync(cache)
-
-        global_new_kv = np.zeros((nlayer, 2, 0, nhead, nfeat), dtype)
-        for seq_id, new_len in batch:
-            if seq_id >= len(cached_values):
-                assert seq_id == len(cached_values)
-                cached_values.append(np.zeros((nlayer, 2, 0, nhead, nfeat), dtype))
-
-            new_kv = np.random.rand(nlayer, 2, new_len, nhead, nfeat).astype(dtype)
-            cached_values[seq_id] = np.concatenate([cached_values[seq_id], new_kv], axis=2)
-            global_new_kv = np.concatenate([global_new_kv, new_kv], axis=2)
-        for layer_id in range(nlayer):
-            keys = tvm.nd.array(np.expand_dims(global_new_kv[layer_id, 0], axis=0))
-            values = tvm.nd.array(np.expand_dims(global_new_kv[layer_id, 1], axis=0))
-            fappend(cache, f_transpose_append, keys, values, layer_id)
-
-        # Verify
-        verify_cached_values(cache, cached_values, f_copy_cache)
-
-
-def test_paged_attention_kv_cache_append_decode():
-    f_transpose_append, f_copy_cache = build_tir_func([transpose_append, copy_cache])
-    cache = fcreate(
-        tvm.runtime.ShapeTuple([reserved_nseq, total_seq_len, page_size]),
-        nlayer,
-        nhead,
-        nfeat,
-        tvm.nd.empty((), dtype),
-        True,
-    )
-
-    cached_values = []
-    initial_lengths = [31, 21, 16, 3, 8, 7, 3]
-    nseq = len(initial_lengths)
-
-    # Initial prefill
-    freset_append_length(cache)
-    for seq_id, append_length in enumerate(initial_lengths):
-        seq_id_in_cache = fadd_sequence(cache)
-        assert seq_id_in_cache == seq_id
-        freserve(cache, seq_id, append_length)
-    fsync(cache)
-
-    global_new_kv = np.zeros((nlayer, 2, 0, nhead, nfeat), dtype)
-    for length in initial_lengths:
-        new_kv = np.random.rand(nlayer, 2, length, nhead, nfeat).astype(dtype)
-        cached_values.append(new_kv)
-        global_new_kv = np.concatenate([global_new_kv, new_kv], axis=2)
-    for layer_id in range(nlayer):
-        keys = tvm.nd.array(np.expand_dims(global_new_kv[layer_id, 0], axis=0))
-        values = tvm.nd.array(np.expand_dims(global_new_kv[layer_id, 1], axis=0))
-        fappend(cache, f_transpose_append, keys, values, layer_id)
-
-    verify_cached_values(cache, cached_values, f_copy_cache)
-
     # Decode
-    for _ in range(16):
-        decode_new_kv = np.random.rand(nlayer, 2, nseq, 1, nhead, nfeat).astype(dtype)
-        freset_append_length(cache)
-        for seq_id in range(nseq):
-            freserve(cache, seq_id, 1)
-        fsync(cache)
-        for seq_id in range(nseq):
-            cached_values[seq_id] = np.concatenate(
-                [cached_values[seq_id], decode_new_kv[:, :, seq_id, ...]], axis=2
-            )
-        for layer_id in range(nlayer):
-            keys = tvm.nd.array(decode_new_kv[layer_id, 0])
-            values = tvm.nd.array(decode_new_kv[layer_id, 1])
-            fappend(cache, f_transpose_append, keys, values, layer_id)
+    operation_seq += [[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1)]]
+    operation_seq += [[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1)]]
+    operation_seq += [[(0, 1), (2, 1), (4, 1), (6, 1), (8, 1)]]
+    operation_seq += [[(4, 1), (5, 1), (6, 1), (7, 1), (8, 1)]]
 
-        verify_cached_values(cache, cached_values, f_copy_cache)
+    cached_k = {}
+    cached_v = {}
+    for batch in operation_seq:
+        apply_attention(kv_cache, batch, cached_k, cached_v)
 
 
-def test_paged_attention_kv_cache_remove():
-    f_transpose_append, f_copy_cache = build_tir_func([transpose_append, copy_cache])
-    cache = fcreate(
-        tvm.runtime.ShapeTuple([reserved_nseq, total_seq_len, page_size]),
-        nlayer,
-        nhead,
-        nfeat,
-        tvm.nd.empty((), dtype),
-        True,
-    )
+@pytest.mark.skip(reason="Require FlashInfer enabled")
+def test_paged_attention_kv_cache_remove_sequence(kv_cache):
+    fclear(kv_cache)
 
-    cached_values = []
-    initial_lengths = [31, 21, 16, 3, 8, 7, 3]
-
-    # Initial prefill
-    freset_append_length(cache)
-    for seq_id, append_length in enumerate(initial_lengths):
-        seq_id_in_cache = fadd_sequence(cache)
-        assert seq_id_in_cache == seq_id
-        freserve(cache, seq_id, append_length)
-    fsync(cache)
-
-    global_new_kv = np.zeros((nlayer, 2, 0, nhead, nfeat), dtype)
-    for length in initial_lengths:
-        new_kv = np.random.rand(nlayer, 2, length, nhead, nfeat).astype(dtype)
-        cached_values.append(new_kv)
-        global_new_kv = np.concatenate([global_new_kv, new_kv], axis=2)
-    for layer_id in range(nlayer):
-        keys = tvm.nd.array(np.expand_dims(global_new_kv[layer_id, 0], axis=0))
-        values = tvm.nd.array(np.expand_dims(global_new_kv[layer_id, 1], axis=0))
-        fappend(cache, f_transpose_append, keys, values, layer_id)
-
-    verify_cached_values(cache, cached_values, f_copy_cache)
-
-    # Remove
-    while len(cached_values) > 2:
-        seq_id = np.random.randint(0, len(cached_values))
-        fremove(cache, seq_id)
-        cached_values.pop(seq_id)
-    fsync(cache)
-    verify_cached_values(cache, cached_values, f_copy_cache)
-
-    # Append after removal
-    seq_id = 2
-    new_len = 29
-    seq_id_in_cache = fadd_sequence(cache)
-    assert seq_id_in_cache == seq_id
-    freset_append_length(cache)
-    freserve(cache, seq_id, new_len)
-    fsync(cache)
-    new_kv = np.random.rand(nlayer, 2, new_len, nhead, nfeat).astype(dtype)
-    cached_values.append(new_kv)
-    for layer_id in range(nlayer):
-        keys = tvm.nd.array(np.expand_dims(new_kv[layer_id, 0], axis=0))
-        values = tvm.nd.array(np.expand_dims(new_kv[layer_id, 1], axis=0))
-        fappend(cache, f_transpose_append, keys, values, layer_id)
-
-    verify_cached_values(cache, cached_values, f_copy_cache)
+    num_sequences = 5
+    batch = [(seq_id, 1) for seq_id in range(num_sequences)]
+    cached_k = {}
+    cached_v = {}
+    for seq_id_to_remove in range(num_sequences):
+        apply_attention(kv_cache, batch, cached_k, cached_v)
+        # Remove sequence.
+        fremove_sequence(kv_cache, seq_id_to_remove)
+        cached_k.pop(seq_id_to_remove)
+        cached_v.pop(seq_id_to_remove)
+        verify_cached_kv(
+            kv_cache,
+            seq_ids=[seq_id for seq_id in range(num_sequences) if seq_id != seq_id_to_remove],
+            expected_k=cached_k,
+            expected_v=cached_v,
+        )
 
 
-def test_paged_attention_kv_cache_popn():
-    f_transpose_append, f_copy_cache = build_tir_func([transpose_append, copy_cache])
-    cache = fcreate(
-        tvm.runtime.ShapeTuple([reserved_nseq, total_seq_len, page_size]),
-        nlayer,
-        nhead,
-        nfeat,
-        tvm.nd.empty((), dtype),
-        True,
-    )
+@pytest.mark.skip(reason="Require FlashInfer enabled")
+def test_paged_attention_kv_cache_fork_sequence(kv_cache):
+    fclear(kv_cache)
 
-    cached_values = []
-    initial_lengths = [20, 24, 26, 27]
-    nseq = len(initial_lengths)
-
-    # Initial prefill
-    freset_append_length(cache)
-    for seq_id, append_length in enumerate(initial_lengths):
-        seq_id_in_cache = fadd_sequence(cache)
-        assert seq_id_in_cache == seq_id
-        freserve(cache, seq_id, append_length)
-    fsync(cache)
-
-    global_new_kv = np.zeros((nlayer, 2, 0, nhead, nfeat), dtype)
-    for length in initial_lengths:
-        new_kv = np.random.rand(nlayer, 2, length, nhead, nfeat).astype(dtype)
-        cached_values.append(new_kv)
-        global_new_kv = np.concatenate([global_new_kv, new_kv], axis=2)
-    for layer_id in range(nlayer):
-        keys = tvm.nd.array(np.expand_dims(global_new_kv[layer_id, 0], axis=0))
-        values = tvm.nd.array(np.expand_dims(global_new_kv[layer_id, 1], axis=0))
-        fappend(cache, f_transpose_append, keys, values, layer_id)
-
-    verify_cached_values(cache, cached_values, f_copy_cache)
-
-    # Pop n
-    for pop_length in [3, 13]:
-        for seq_id in range(nseq):
-            fpopn(cache, seq_id, pop_length)
-            cached_values[seq_id] = cached_values[seq_id][:, :, :-pop_length, ...]
-    fsync(cache)
-    verify_cached_values(cache, cached_values, f_copy_cache)
-
-    # Decode after pop n
-    for _ in range(5):
-        decode_new_kv = np.random.rand(nlayer, 2, nseq, 1, nhead, nfeat).astype(dtype)
-        freset_append_length(cache)
-        for seq_id in range(nseq):
-            freserve(cache, seq_id, 1)
-        fsync(cache)
-
-        for seq_id in range(nseq):
-            cached_values[seq_id] = np.concatenate(
-                [cached_values[seq_id], decode_new_kv[:, :, seq_id, ...]], axis=2
-            )
-        for layer_id in range(nlayer):
-            keys = tvm.nd.array(decode_new_kv[layer_id, 0])
-            values = tvm.nd.array(decode_new_kv[layer_id, 1])
-            fappend(cache, f_transpose_append, keys, values, layer_id)
-
-        verify_cached_values(cache, cached_values, f_copy_cache)
+    cached_k = {}
+    cached_v = {}
+    batch = [(0, 60), (1, 88), (2, 17), (3, 4)]
+    apply_attention(kv_cache, batch, cached_k, cached_v)
+    # Fork existing sequences.
+    apply_attention(kv_cache, [((4, 3), 35)], cached_k, cached_v)
+    apply_attention(kv_cache, [((5, 0), 20)], cached_k, cached_v)
+    apply_attention(kv_cache, [((6, 5), 102)], cached_k, cached_v)
+    apply_attention(kv_cache, [((7, 0), 3)], cached_k, cached_v)
+    apply_attention(kv_cache, [((8, 5), 71)], cached_k, cached_v)
+    apply_attention(kv_cache, [((9, 5), 20)], cached_k, cached_v)
+    # Mixture of decode and prefill.
+    operation_seq = [
+        [(2, 1), (4, 1), (7, 1), (6, 1), (8, 1), (9, 1)],
+        [(7, 1), (6, 1), (8, 1), (9, 1)],
+        [(7, 1), (1, 1), (6, 1), (2, 1), (8, 1), (4, 1), (9, 1)],
+        [(7, 10), (6, 2), (8, 3), (9, 4)],
+    ]
+    for batch in operation_seq:
+        apply_attention(kv_cache, batch, cached_k, cached_v)
 
 
-def test_paged_attention_kv_cache_clear():
-    f_transpose_append, f_copy_cache = build_tir_func([transpose_append, copy_cache])
-    cache = fcreate(
-        tvm.runtime.ShapeTuple([reserved_nseq, total_seq_len, page_size]),
-        nlayer,
-        nhead,
-        nfeat,
-        tvm.nd.empty((), dtype),
-        True,
-    )
+@pytest.mark.skip(reason="Require FlashInfer enabled")
+def test_paged_attention_kv_cache_popn(kv_cache):
+    fclear(kv_cache)
 
-    cached_values = []
-    initial_lengths = [20, 24, 26, 27]
+    cached_k = {}
+    cached_v = {}
+    batch = [(0, 35), (1, 88), (2, 17), (3, 4)]
+    apply_attention(kv_cache, batch, cached_k, cached_v)
+    apply_attention(kv_cache, [((4, 3), 35)], cached_k, cached_v)
 
-    # Initial prefill
-    freset_append_length(cache)
-    for seq_id, append_length in enumerate(initial_lengths):
-        seq_id_in_cache = fadd_sequence(cache)
-        assert seq_id_in_cache == seq_id
-        freserve(cache, seq_id, append_length)
-    fsync(cache)
-
-    global_new_kv = np.zeros((nlayer, 2, 0, nhead, nfeat), dtype)
-    for length in initial_lengths:
-        new_kv = np.random.rand(nlayer, 2, length, nhead, nfeat).astype(dtype)
-        cached_values.append(new_kv)
-        global_new_kv = np.concatenate([global_new_kv, new_kv], axis=2)
-    for layer_id in range(nlayer):
-        keys = tvm.nd.array(np.expand_dims(global_new_kv[layer_id, 0], axis=0))
-        values = tvm.nd.array(np.expand_dims(global_new_kv[layer_id, 1], axis=0))
-        fappend(cache, f_transpose_append, keys, values, layer_id)
-
-    verify_cached_values(cache, cached_values, f_copy_cache)
-
-    # Clear
-    fclear(cache)
-    verify_cached_values(cache, [], f_copy_cache)
+    popn_operations = [(0, 17), (1, 57), (2, 16), (3, 0), (4, 19)]
+    for seq_id, pop_length in popn_operations:
+        fpopn(kv_cache, seq_id, pop_length)
+        if pop_length != 0:
+            cached_k[seq_id] = cached_k[seq_id][:, :-pop_length, ...]
+            cached_v[seq_id] = cached_v[seq_id][:, :-pop_length, ...]
+        verify_cached_kv(kv_cache, seq_ids=list(range(4)), expected_k=cached_k, expected_v=cached_v)
 
 
 if __name__ == "__main__":
-    test_paged_attention_kv_cache_append_prefill()
-    test_paged_attention_kv_cache_append_decode()
-    test_paged_attention_kv_cache_remove()
-    test_paged_attention_kv_cache_popn()
-    test_paged_attention_kv_cache_clear()
-    # Test for attention is not included at this moment
-    # since we do not have TIR attention functions yet.
+    cache = create_kv_cache()
+    test_paged_attention_kv_cache_prefill_and_decode(cache)
+    test_paged_attention_kv_cache_remove_sequence(cache)
+    test_paged_attention_kv_cache_fork_sequence(cache)
+    test_paged_attention_kv_cache_popn(cache)


### PR DESCRIPTION
This PR refactors the previous PagedAttentionKVCache, and provides a common attention KV cache interface `src/runtime/relax_vm/kv_cache.h` for efficient K/V data management and attention computation.

The refactored PagedKVCache supports common prefix caching: if two sequences have a shared prefix (e.g., a system prompt, or a context document), we can first add the prefix into KV cache, and then fork the two child sequences from the prefix, and add their respective exclusive parts to KV cache. In such case, the KV data of the shared prefix is computed only once, and can be reused for multiple times.

This PR adds tests for the refactored PagedKVCache `tests/python/relax/test_runtime_builtin_paged_attention_kv_cache.py`. The tests at this moment depends on FlashInfer
(https://github.com/flashinfer-ai/flashinfer)
for efficient attention computation. Given the CI does not build TVM with FlashInfer enabled, the tests are marked as skipped right now. Tests are passed in my local development environment.

There are remaining works on the PagedKVCache implementation. Right now FlashInfer does not support on-the-fly RoPE application when computing attention in common prefix scenario. Therefore, we fallback to adopt a dedicated RoPE kernel to apply RoPE prior to appending K/V data into the cache. This blocks some applications such as sliding window attention. We will work on this with followup improvements to PagedKVCache in the future.

Co-authored-by: Zihao Ye <expye@outlook.com>
Co-authored-by: Ruihang Lai <ruihangl@cs.cmu.edu>