### PR TITLE
[Unity][Frontend] NNModule `tensor_ir_op` support

### DIFF
--- a/python/tvm/relax/frontend/nn/_tensor_op.py
+++ b/python/tvm/relax/frontend/nn/_tensor_op.py
@@ -47,7 +47,19 @@ class _TensorOp:
         other = _convert_scalar(other, self)
         return _op().add(self, other)
 
+    def __sub__(self, other):
+        other = _convert_scalar(other, self)
+        return _op().subtract(self, other)
+
+    def __rsub__(self, other):
+        other = _convert_scalar(other, self)
+        return _op().subtract(other, self)
+
     def __mul__(self, other):
+        other = _convert_scalar(other, self)
+        return _op().multiply(self, other)
+
+    def __rmul__(self, other):
         other = _convert_scalar(other, self)
         return _op().multiply(self, other)
 

--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -311,7 +311,7 @@ class ConvTranspose1D(Module):
 
     def forward(self, x: Tensor) -> Tensor:
         """
-        Forward method for convtranspose1d layer.
+        Forward method for conv transpose 1d layer.
 
         Parameters
         ----------
@@ -321,7 +321,7 @@ class ConvTranspose1D(Module):
         Returns
         -------
         ret : Tensor
-            The output tensor for the convtranspose1d layer.
+            The output tensor for the conv transpose 1d layer.
         """
         return op.conv1d_transpose(
             x,

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -1461,13 +1461,87 @@ def tensor_expr_op(
 OutType = TypeVar("OutType", bound=Union[Tensor, Sequence[Tensor]])
 
 
+def tensor_ir_op(
+    func: _tir.PrimFunc,
+    name_hint: str,
+    args: Union[Tensor, Sequence[Union[Tensor, _tir.Var]]],
+    out: OutType,
+) -> OutType:
+    """Create a `call_tir` binding with given PrimFunc
+
+    Parameters
+    ----------
+    func : _tir.PrimFunc
+        The PrimFunc to call.
+
+    name_hint : str
+        Name hint.
+
+    args : Union[Tensor, Sequence[Union[Tensor, _tir.Var]]]
+        The arguments to pass to the PrimFunc.
+
+    out : Union[Tensor, List[Tensor]]
+        The output tensors.
+
+    Returns
+    -------
+    result : Tensor
+        The result tensor
+    """
+    from tvm import relax as rx  # pylint: disable=import-outside-toplevel
+
+    call_tir_args, tir_vars = [], []
+    if not isinstance(args, (tuple, list)):
+        args = [args]
+
+    for arg in args:
+        if isinstance(arg, Tensor):
+            call_tir_args.append(arg._expr)
+        elif isinstance(arg, _tir.Var):
+            tir_vars.append(arg)
+        else:
+            raise TypeError(
+                f"Unsupported type: tensor_ir_op args expect Tensor or tir.Var, but got {type(arg)}"
+            )
+
+    if isinstance(out, Tensor):
+        out_sinfo = [out._expr.struct_info]
+    else:
+        out_sinfo = [x._expr.struct_info for x in out]
+
+    bb = BlockBuilder.current()
+    global_var = bb.add_func(func, name_hint)
+
+    return wrap_nested(
+        bb.emit(rx.call_tir(global_var, call_tir_args, out_sinfo, tir_vars=tir_vars)),
+        name=name_hint,
+    )
+
+
 def extern(
     name: str,
     args: Sequence[Union[Tensor, _tir.PrimExpr, int, float, str]],
     out: OutType,
 ) -> OutType:
     """Invoke an extern function during runtime. The extern function must be registered with the "
-    TVM runtime using `TVM_REGISTER_GLOBAL` (C++), or `tvm.register_func` (Python)."""
+    TVM runtime using `TVM_REGISTER_GLOBAL` (C++), or `tvm.register_func` (Python).
+
+    Parameters
+    ----------
+    name : str
+        The name of the extern function to call.
+
+    args : Sequence[Union[Tensor, _tir.PrimExpr, int, float, str]]
+        The arguments to pass to the extern function.
+
+    out : Union[Tensor, List[Tensor]]
+        The output tensors, only
+
+    Returns
+    -------
+    result : Tensor
+        The result
+    """
     from tvm import relax as rx  # pylint: disable=import-outside-toplevel
 
     def _convert(arg, name: str):


### PR DESCRIPTION
This PR adds support for `tensor_ir_op` in NNModule, which enables us to call TensorIR function in NNModule.

Also this PR adds a test case for extern op.

cc @junrushao @MasterJH5574 