### PR TITLE
replace deprecated np.int with int to avoid crash

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2756,7 +2756,7 @@ class PyTorchOpConverter:
             for i in [0, 1]:
                 size, _ = try_infer_value(
                     inputs[1][i],
-                    lambda ret: ret.astype(np.int),
+                    lambda ret: ret.astype(int),
                     lambda: _op.expand_dims(inputs[1][i], axis=0),
                 )
                 out_size.append(size)


### PR DESCRIPTION
Replace the deprecated API `np.int` with `int` to avoid a crash.

In NumPy v1.20.0, the `np.int` has been deprecated as shown in the [documentation](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)