### PR TITLE
[Bugfix][Schedule] Fix AutoScheduler layout string parsing

### DIFF
--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -1637,21 +1637,25 @@ inline void parse_auto_scheduler_layout(const String& layout, Array<PrimExpr>* s
                                         std::vector<std::string>* axes) {
   int32_t factor = 0;
   std::string axis = "";
-  for (char c : std::string(layout)) {
-    if (c >= 'A' && c <= 'z') {
-      axis += c;
+  std::vector<std::string> layout_parts;
+  // Split the layout string by space
+  layout_parts = dmlc::Split(std::string(layout), ' ');
+  for (auto part : layout_parts) {
+    // If the part contains A-Z or a-z, it is an axis
+    if (part.find_first_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz") !=
+        std::string::npos) {
+      axis = part;
       if (factor != 0) {
         shape->push_back(factor);
         factor = 0;
       }
-    } else if (c >= '0' && c <= '9') {
-      factor = factor * 10 + c - '0';
+    } else {
+      // ...or it is a factor
+      factor = std::stoi(part);
       if (!axis.empty()) {
         axes->push_back(axis);
         axis = "";
       }
-    } else {
-      LOG(FATAL) << "Invalid layout " << layout;
     }
   }
   if (!axis.empty()) {

--- a/src/auto_scheduler/compute_dag.cc
+++ b/src/auto_scheduler/compute_dag.cc
@@ -812,7 +812,7 @@ std::string GetOrigLayout(std::set<std::string>* placeholder_axis_names, const t
       }
 
       placeholder_axis_names->insert(axis_name);
-      os << placeholder->shape[i++] << axis_name;
+      os << placeholder->shape[i++] << " " << axis_name << " ";
     }
   }
 
@@ -884,7 +884,7 @@ std::string GetNewLayout(const State& state, const int stage_id, const Stage& st
         // This iter is simplified by InferBound, so it must have a length of one.
         extent = 1;
       }
-      os << extent << ori_iter_name;
+      os << extent << " " << ori_iter_name << " ";
       new_names.push_back(ori_iter_name);
     }
   }

--- a/src/auto_scheduler/utils.h
+++ b/src/auto_scheduler/utils.h
@@ -272,21 +272,25 @@ inline void ParseKernelLayout(const String& layout, Array<PrimExpr>* shape,
                               std::vector<std::string>* axes) {
   int32_t factor = 0;
   std::string axis = "";
-  for (char c : std::string(layout)) {
-    if (c >= 'A' && c <= 'z') {
-      axis += c;
+  std::vector<std::string> layout_parts;
+  // Split the layout string by space
+  layout_parts = dmlc::Split(std::string(layout), ' ');
+  for (auto part : layout_parts) {
+    // If the part contains A-Z or a-z, it is an axis
+    if (part.find_first_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz") !=
+        std::string::npos) {
+      axis = part;
       if (factor != 0) {
         shape->push_back(factor);
         factor = 0;
       }
-    } else if (c >= '0' && c <= '9') {
-      factor = factor * 10 + c - '0';
+    } else {
+      // ...or it is a factor
+      factor = std::stoi(part);
       if (!axis.empty()) {
         axes->push_back(axis);
         axis = "";
       }
-    } else {
-      LOG(FATAL) << "Invalid layout " << layout;
     }
   }
   if (!axis.empty()) {


### PR DESCRIPTION
Add spaces between elements in layout string to sperate factor from axis name. 
Fix layout got parsed incorrectly when axis name includes number.

Fixes https://github.com/apache/tvm/issues/10369 and first issue of https://discuss.tvm.apache.org/t/most-tasks-failed-with-autoscheduler-on-mali-g610-gpu/16139