### PR TITLE
[Unity][Frontend] Introduce StructuredState for State Space modules

### DIFF
--- a/python/tvm/relax/frontend/nn/__init__.py
+++ b/python/tvm/relax/frontend/nn/__init__.py
@@ -32,6 +32,7 @@ from .modules import (
     ReLU,
     RMSNorm,
     SiLU,
+    StructuredState,
 )
 from .op import *
 from .subroutine import SubroutineMixin


### PR DESCRIPTION
We introduce the StateCache to support State Space modules. Unlike KVCache, StateCache does not need the operation `append` but requires the init value.


cc @junrushao @tqchen 