### PR TITLE
[Unity][Transform] Use parameter name in BundleModelParams

### DIFF
--- a/src/relax/transform/bundle_model_params.cc
+++ b/src/relax/transform/bundle_model_params.cc
@@ -74,7 +74,7 @@ class ModelParamBundler : public ExprMutator {
   Expr VisitExpr_(const VarNode* op) override {
     auto var = GetRef<Var>(op);
     if (auto it = var_to_expr_.find(var); it != var_to_expr_.end()) {
-      return (*it).second;
+      return builder_->Emit((*it).second, op->name_hint());
     } else {
       return ExprMutator::VisitExpr_(op);
     }
@@ -83,6 +83,11 @@ class ModelParamBundler : public ExprMutator {
  private:
   Map<Var, Expr> var_to_expr_;
 };
+
+Function BundleModelParams(const Function& func) {
+  ModelParamBundler mutator;
+  return Downcast<Function>(mutator(func));
+}
 
 namespace transform {
 Pass BundleModelParams() {

--- a/src/relax/transform/utils.h
+++ b/src/relax/transform/utils.h
@@ -421,6 +421,18 @@ Expr EliminateCommonSubexpr(const Expr& expr, bool call_only = false);
  */
 Expr CanonicalizeBindings(const Expr& expr);
 
+/* \brief Remove use of trivial bindings
+ *
+ * Utility for converting from individual model parameters to a single
+ * parameter with a tuple of parameters.  If the `kNumInput` attribute
+ * is absent, no model parameters are present, so no updates are made.
+ *
+ * \param func The function to be updated.
+ *
+ * \ret The updated function.
+ */
+Function BundleModelParams(const Function& func);
+
 }  // namespace relax
 }  // namespace tvm
 


### PR DESCRIPTION
Prior to this commit, the `BundleModelParams` would replace model parameters with `param_tuple[index]` within expressions.  These nested expressions would then be normalized, resulting in `gv = param_tuple[index]` or `lv = param_tuple[index]` variable definitions.  These auto-generated `gv` and `lv` names make it quite difficult to determine which model parameter is being used.

This commit updates the `BundleModelParams` transform to explicitly produce the bound variable, `orig_param_name = param_tuple[index]`, preserving human-readable names from the parameters.