### PR TITLE
[Unity] Ensure memory planning cross-function independence

### DIFF
--- a/src/relax/transform/static_plan_block_memory.cc
+++ b/src/relax/transform/static_plan_block_memory.cc
@@ -219,6 +219,12 @@ class TokenAllocator1D {
     available_pool_[token->dtype].insert({token->bytes, token});
   }
 
+  /*! \brief Clear the allocator. */
+  void Clear() {
+    available_pool_.clear();
+    full_pool_.clear();
+  }
+
  private:
   /*! \brief A constant scale representing the token search range. */
   const int match_range_{16};
@@ -569,6 +575,8 @@ class StorageAllocator : public StorageAllocatorBaseVisitor {
       if (func == nullptr) {
         continue;
       }
+      // Clear the allocator to make the planning of different functions independent.
+      allocator_.Clear();
       this->VisitExpr_(func);
     }
   }


### PR DESCRIPTION
Prior to this PR, the memory planning for different Relax functions are not independent -- storage tokens are shared across different Relax functions.

This will incur memory overuse sometimes. For example, tensor `A` in `func1` has 128 bytes, tensor `B` in `func2` has 2048 bytes. If the memory planning decides to share the storage token for `A` and `B`, the shared token will have size 2048 bytes.

Consider the case when at runtime only `func1` is executed, and `func2` is never invoked. In this case, only 128 bytes for tensor `A` is needed, while a total 2048-chunk is allocated in total, which is a 16x memory overuse.

This PR makes the memory planning across different Relax function independent. That means in the example above, when only `func1` is executed, only 128 bytes will be allocated.