### PR TITLE
[Relay] make "ToScalar" support directly obtaining "int64_t"

### DIFF
--- a/src/relay/transforms/simplify_expr.cc
+++ b/src/relay/transforms/simplify_expr.cc
@@ -794,7 +794,7 @@ class EliminateIdentityRewrite : public DFPatternRewrite {
     if (!IsScalar(GetRef<Expr>(constant))) {
       return false;
     }
-    auto value = TryToScalar(constant->data, 0);
+    auto value = TryToScalar<long double>(constant->data, 0);
     if (!value) {
       // unsupported dtype
       return false;


### PR DESCRIPTION
Because on Windows, "long double" is 64 bits instead of 128 bits like on Linux, to avoid overflow from "long double" to "int64_t"