### PR TITLE
[CI] Upgrade cmake version to 3.24.0

### DIFF
--- a/docker/install/ubuntu_install_cmake_source.sh
+++ b/docker/install/ubuntu_install_cmake_source.sh
@@ -20,9 +20,8 @@ set -e
 set -u
 set -o pipefail
 
-# the minimum cmake is 3.20.0 for LLVM 16+
 if [ -z ${1+x} ]; then
-    version=3.20.0
+    version=3.24.0
 else
     version=$1
 fi


### PR DESCRIPTION
This is to enable setting CMAKE_CUDA_ARCHITECTURES to the special value 'native'.

cc @junrushao @tqchen 