### PR TITLE
[Unity][DLight] Introduce Specific Rule for RMSNorm

### DIFF
--- a/python/tvm/dlight/gpu/__init__.py
+++ b/python/tvm/dlight/gpu/__init__.py
@@ -24,3 +24,4 @@ from .matmul import Matmul
 from .reduction import Reduction
 from .transpose import Transpose
 from .general_reduction import GeneralReduction
+from .rmsnorm import RMSNorm

--- a/python/tvm/dlight/gpu/rmsnorm.py
+++ b/python/tvm/dlight/gpu/rmsnorm.py
@@ -107,15 +107,9 @@ class RMSNorm(ScheduleRule):
         if not identify_rsqrt_block(sch.get(rsqrt)):
             return None
 
-        for name in [read, sqr, redsum, norm]:
-            sch.transform_block_layout(
-                block=name,
-                index_map=lambda v_ax0, v_ax1, v_ax2: (
-                    v_ax1,
-                    v_ax2,
-                ),
-            )
-        sch.transform_block_layout(block=rsqrt, index_map=lambda v_ax0, v_ax1: (v_ax1,))
+        for name in [read, sqr, redsum, rsqrt, norm, write]:
+            loops = sch.get_loops(name)
+            sch.fuse(*loops[:-1])
 
         block_loop, loops = sch.get_loops(block=read)
         thread_loop, _, _ = sch.split(

--- a/python/tvm/dlight/gpu/rmsnorm.py
+++ b/python/tvm/dlight/gpu/rmsnorm.py
@@ -113,9 +113,7 @@ class RMSNorm(ScheduleRule):
         sch.transform_block_layout(block=rsqrt, index_map=lambda v_ax0, v_ax1: (v_ax1,))
 
         block_loop, loops = sch.get_loops(block=read)
-        thread_loop, repeated_loop, vec_loop = sch.split(
-            loop=loops, factors=[tx, None, 8], preserve_unit_iters=True
-        )
+        thread_loop, _, _ = sch.split(loop=loops, factors=[tx, None, 8], preserve_unit_iters=True)
         sch.bind(block_loop, thread_axis="blockIdx.x")
         sch.bind(thread_loop, thread_axis="threadIdx.x")
         sch.vectorize(sch.get_loops(block=read)[-1])
@@ -125,9 +123,7 @@ class RMSNorm(ScheduleRule):
         sch.reverse_compute_at(block=rsqrt, loop=block_loop, index=-1)
         sch.reverse_compute_at(block=norm, loop=block_loop, index=-1)
         block_loop, loops = sch.get_loops(block=norm)
-        thread_loop, repeated_loop, vec_loop = sch.split(
-            loop=loops, factors=[tx, None, 8], preserve_unit_iters=True
-        )
+        thread_loop, _, _ = sch.split(loop=loops, factors=[tx, None, 8], preserve_unit_iters=True)
         sch.bind(thread_loop, thread_axis="threadIdx.x")
 
         sch.reverse_compute_at(block=write, loop=thread_loop, index=-1)

--- a/python/tvm/dlight/gpu/rmsnorm.py
+++ b/python/tvm/dlight/gpu/rmsnorm.py
@@ -20,7 +20,7 @@
 import tvm
 from tvm import tir
 from tvm.tir import Block, BufferStore
-from tvm.tir.expr import Cast, BufferLoad
+from tvm.tir.expr import Cast, BufferLoad, Call
 from tvm.target import Target
 
 from ..base import ScheduleRule
@@ -58,10 +58,15 @@ def identify_cast_or_load_block(block: Block) -> bool:
 def identify_rsqrt_block(block: Block) -> bool:
     if len(block.reads) != 1 or len(block.writes) != 1:
         return False
-    try:
-        op = block.body.value.op
-    except Exception:
+
+    if not isinstance(block.body, BufferStore):
         return False
+    store = block.body
+
+    if not isinstance(store.value, Call):
+        return False
+    call = store.value
+    op = call.op
 
     return op == tvm.ir.op.Op.get("tir.rsqrt")
 

--- a/python/tvm/dlight/gpu/rmsnorm.py
+++ b/python/tvm/dlight/gpu/rmsnorm.py
@@ -1,0 +1,141 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=missing-docstring
+"""A RMS norm schedule rule for GPU operators."""
+
+import tvm
+from tvm import tir
+from tvm.tir import Block, BufferStore
+from tvm.tir.expr import Cast, BufferLoad
+from tvm.target import Target
+
+from ..base import ScheduleRule
+
+
+def identify_cast_or_load_block(block: Block) -> bool:
+    if len(block.reads) != 1 or len(block.writes) != 1:
+        return False
+
+    if not isinstance(block.body, BufferStore):
+        return False
+    store = block.body
+
+    # check types
+    if isinstance(store.value, BufferLoad):
+        load = store.value
+    elif isinstance(store.value, Cast):
+        load = store.value.value
+        if not isinstance(load, BufferLoad):
+            return False
+    else:
+        return False
+
+    # check indices
+    if len(load.indices) != len(store.indices):
+        return False
+
+    for lhs, rhs in zip(load.indices, store.indices):
+        if not lhs.same_as(rhs):
+            return False
+
+    return True
+
+
+def identify_rsqrt_block(block: Block) -> bool:
+    if len(block.reads) != 1 or len(block.writes) != 1:
+        return False
+    try:
+        op = block.body.value.op
+    except Exception:
+        return False
+
+    return op == tvm.ir.op.Op.get("tir.rsqrt")
+
+
+class RMSNorm(ScheduleRule):
+    """A rule for RMS norm."""
+
+    def apply(  # pylint: disable=too-many-locals,missing-docstring
+        self,
+        func: tir.PrimFunc,
+        target: Target,
+        _: bool,
+    ) -> tir.Schedule:
+        if target.kind.name == "cuda":
+            tx = 512
+        else:
+            tx = 64
+
+        sch = tir.Schedule(func)
+        root = sch.get_block(name="root", func_name="main")
+
+        blocks = sch.get_child_blocks(root)
+
+        if not any([identify_rsqrt_block(sch.get(block)) for block in blocks]):
+            return None
+
+        read = sch.cache_read(block=blocks[0], read_buffer_index=0, storage_scope="local")
+        write = sch.cache_write(block=blocks[-1], write_buffer_index=0, storage_scope="local")
+
+        for block in blocks:
+            if identify_cast_or_load_block(sch.get(block)):
+                sch.compute_inline(block)
+
+        blocks = sch.get_child_blocks(root)
+
+        read, sqr, redsum, rsqrt, norm, write = blocks
+
+        if not identify_rsqrt_block(sch.get(rsqrt)):
+            return None
+
+        for name in [read, sqr, redsum, norm]:
+            sch.transform_block_layout(
+                block=name,
+                index_map=lambda v_ax0, v_ax1, v_ax2: (
+                    v_ax1,
+                    v_ax2,
+                ),
+            )
+        sch.transform_block_layout(block=rsqrt, index_map=lambda v_ax0, v_ax1: (v_ax1,))
+
+        block_loop, loops = sch.get_loops(block=read)
+        thread_loop, repeated_loop, vec_loop = sch.split(
+            loop=loops, factors=[tx, None, 8], preserve_unit_iters=True
+        )
+        sch.bind(block_loop, thread_axis="blockIdx.x")
+        sch.bind(thread_loop, thread_axis="threadIdx.x")
+        sch.vectorize(sch.get_loops(block=read)[-1])
+        sch.reverse_compute_at(block=sqr, loop=thread_loop)
+        sch.reverse_compute_at(block=redsum, loop=thread_loop)
+
+        sch.reverse_compute_at(block=rsqrt, loop=block_loop, index=-1)
+        sch.reverse_compute_at(block=norm, loop=block_loop, index=-1)
+        block_loop, loops = sch.get_loops(block=norm)
+        thread_loop, repeated_loop, vec_loop = sch.split(
+            loop=loops, factors=[tx, None, 8], preserve_unit_iters=True
+        )
+        sch.bind(thread_loop, thread_axis="threadIdx.x")
+
+        sch.reverse_compute_at(block=write, loop=thread_loop, index=-1)
+        sch.vectorize(sch.get_loops(block=write)[-1])
+
+        sch.set_scope(block=sqr, buffer_index=0, storage_scope="local")
+        sch.set_scope(block=redsum, buffer_index=0, storage_scope="local")
+        sch.set_scope(block=rsqrt, buffer_index=0, storage_scope="shared")
+        sch.set_scope(block=norm, buffer_index=0, storage_scope="local")
+
+        return sch

--- a/tests/python/dlight/test_gpu_rmsnorm.py
+++ b/tests/python/dlight/test_gpu_rmsnorm.py
@@ -1,0 +1,277 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=missing-docstring
+import tvm.testing
+
+from tvm.ir import IRModule, assert_structural_equal
+from tvm import dlight as dl
+from tvm.script import ir as I
+from tvm.target import Target
+from tvm.script import tir as T
+
+
+def _check(mod_before: IRModule, mod_after: IRModule):
+    target = Target("nvidia/geforce-rtx-3090-ti")
+    with target:
+        mod = dl.ApplyDefaultSchedule(  # pylint: disable=not-callable
+            dl.gpu.RMSNorm(),
+        )(mod_before)
+    assert_structural_equal(mod, mod_after)
+
+
+def test_rms_norm_with_casting():
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(var_data: T.handle, weight: T.Buffer((4096,), "float16"), var_T_cast: T.handle):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            n = T.int32()
+            data = T.match_buffer(var_data, (1, n, 4096), "float16")
+            T_cast = T.match_buffer(var_T_cast, (1, n, 4096), "float16")
+            # with T.block("root"):
+            T_cast_1 = T.alloc_buffer((1, n, 4096))
+            T_multiply = T.alloc_buffer((1, n, 4096))
+            T_multiply_red = T.alloc_buffer((1, n))
+            rsqrt = T.alloc_buffer((1, n))
+            T_cast_2 = T.alloc_buffer((4096,))
+            T_rms_norm = T.alloc_buffer((1, n, 4096))
+            for ax0, ax1, ax2 in T.grid(1, n, 4096):
+                with T.block("T_cast"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(data[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_cast_1[v_ax0, v_ax1, v_ax2])
+                    T_cast_1[v_ax0, v_ax1, v_ax2] = T.Cast("float32", data[v_ax0, v_ax1, v_ax2])
+            for ax0, ax1, ax2 in T.grid(1, n, 4096):
+                with T.block("T_multiply"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(T_cast_1[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_multiply[v_ax0, v_ax1, v_ax2])
+                    T_multiply[v_ax0, v_ax1, v_ax2] = T_cast_1[v_ax0, v_ax1, v_ax2] * T_cast_1[v_ax0, v_ax1, v_ax2]
+            for ax0, ax1, k2 in T.grid(1, n, 4096):
+                with T.block("T_multiply_red"):
+                    v_ax0, v_ax1, v_k2 = T.axis.remap("SSR", [ax0, ax1, k2])
+                    T.reads(T_multiply[v_ax0, v_ax1, v_k2])
+                    T.writes(T_multiply_red[v_ax0, v_ax1])
+                    with T.init():
+                        T_multiply_red[v_ax0, v_ax1] = T.float32(0)
+                    T_multiply_red[v_ax0, v_ax1] = T_multiply_red[v_ax0, v_ax1] + T_multiply[v_ax0, v_ax1, v_k2]
+            for ax0, ax1 in T.grid(1, n):
+                with T.block("rsqrt"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(T_multiply_red[v_ax0, v_ax1])
+                    T.writes(rsqrt[v_ax0, v_ax1])
+                    rsqrt[v_ax0, v_ax1] = T.rsqrt(T_multiply_red[v_ax0, v_ax1] * T.float32(0.000244140625) + T.float32(9.9999999999999995e-07))
+            for ax0 in range(4096):
+                with T.block("T_cast_1"):
+                    v_ax0 = T.axis.spatial(4096, ax0)
+                    T.reads(weight[v_ax0])
+                    T.writes(T_cast_2[v_ax0])
+                    T_cast_2[v_ax0] = T.Cast("float32", weight[v_ax0])
+            for ax0, ax1, ax2 in T.grid(1, n, 4096):
+                with T.block("T_rms_norm"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(rsqrt[v_ax0, v_ax1], T_cast_1[v_ax0, v_ax1, v_ax2], T_cast_2[v_ax2])
+                    T.writes(T_rms_norm[v_ax0, v_ax1, v_ax2])
+                    T_rms_norm[v_ax0, v_ax1, v_ax2] = rsqrt[v_ax0, v_ax1] * T_cast_1[v_ax0, v_ax1, v_ax2] * T_cast_2[v_ax2]
+            for ax0, ax1, ax2 in T.grid(1, n, 4096):
+                with T.block("T_cast_2"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(T_rms_norm[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_cast[v_ax0, v_ax1, v_ax2])
+                    T_cast[v_ax0, v_ax1, v_ax2] = T.Cast("float16", T_rms_norm[v_ax0, v_ax1, v_ax2])
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(var_data: T.handle, weight: T.Buffer((4096,), "float16"), var_T_cast: T.handle):
+            T.func_attr({"tir.is_scheduled": 1, "tir.noalias": T.bool(True)})
+            n = T.int32()
+            data = T.match_buffer(var_data, (1, n, 4096), "float16")
+            T_cast = T.match_buffer(var_T_cast, (1, n, 4096), "float16")
+            # with T.block("root"):
+            T_multiply_local = T.alloc_buffer((1, n, 4096), scope="local")
+            T_multiply_red_local = T.alloc_buffer((1, n), scope="local")
+            rsqrt_shared = T.alloc_buffer((1, n), scope="shared")
+            T_rms_norm_local = T.alloc_buffer((1, n, 4096), scope="local")
+            data_local = T.alloc_buffer((1, n, 4096), "float16", scope="local")
+            for ax0 in T.thread_binding(n, thread="blockIdx.x"):
+                for ax1_0 in T.thread_binding(512, thread="threadIdx.x"):
+                    for ax1_1 in range(1):
+                        for ax1_2 in T.vectorized(8):
+                            with T.block("data_local"):
+                                v0 = T.axis.spatial(n, ax0)
+                                v1 = T.axis.spatial(4096, ax1_0 * 8 + ax1_1 * 8 + ax1_2)
+                                T.reads(data[0, v0, v1])
+                                T.writes(data_local[0, v0, v1])
+                                data_local[0, v0, v1] = data[0, v0, v1]
+                    for ax0_1 in range(8):
+                        with T.block("T_multiply"):
+                            v0 = T.axis.spatial(n, ax0)
+                            v1 = T.axis.spatial(4096, ax1_0 * 8 + ax0_1)
+                            T.reads(data_local[0, v0, v1])
+                            T.writes(T_multiply_local[0, v0, v1])
+                            T_multiply_local[0, v0, v1] = T.Cast("float32", data_local[0, v0, v1]) * T.Cast("float32", data_local[0, v0, v1])
+                    for ax0_1 in range(8):
+                        with T.block("T_multiply_red"):
+                            v0 = T.axis.spatial(n, ax0)
+                            v1 = T.axis.reduce(4096, ax1_0 * 8 + ax0_1)
+                            T.reads(T_multiply_local[0, v0, v1])
+                            T.writes(T_multiply_red_local[0, v0])
+                            with T.init():
+                                T_multiply_red_local[0, v0] = T.float32(0)
+                            T_multiply_red_local[0, v0] = T_multiply_red_local[0, v0] + T_multiply_local[0, v0, v1]
+                with T.block("rsqrt"):
+                    v0 = T.axis.spatial(n, ax0)
+                    T.reads(T_multiply_red_local[0, v0])
+                    T.writes(rsqrt_shared[0, v0])
+                    rsqrt_shared[0, v0] = T.rsqrt(T_multiply_red_local[0, v0] * T.float32(0.000244140625) + T.float32(9.9999999999999995e-07))
+                for ax0_0 in T.thread_binding(512, thread="threadIdx.x"):
+                    for ax0_1, ax0_2 in T.grid(1, 8):
+                        with T.block("T_rms_norm"):
+                            v0 = T.axis.spatial(n, ax0)
+                            v1 = T.axis.spatial(4096, ax0_0 * 8 + ax0_1 * 8 + ax0_2)
+                            T.reads(rsqrt_shared[0, v0], data_local[0, v0, v1], weight[v1])
+                            T.writes(T_rms_norm_local[0, v0, v1])
+                            T_rms_norm_local[0, v0, v1] = rsqrt_shared[0, v0] * T.Cast("float32", data_local[0, v0, v1]) * T.Cast("float32", weight[v1])
+                    for ax0_1 in T.vectorized(8):
+                        with T.block("T_cast_local"):
+                            v0 = T.axis.spatial(1, 0)
+                            v1 = T.axis.spatial(n, ax0)
+                            v2 = T.axis.spatial(4096, ax0_0 * 8 + ax0_1)
+                            T.reads(T_rms_norm_local[v0, v1, v2])
+                            T.writes(T_cast[v0, v1, v2])
+                            T_cast[v0, v1, v2] = T.Cast("float16", T_rms_norm_local[v0, v1, v2])
+    # fmt: on
+    _check(Before, After)
+
+
+def test_rms_norm_without_casting():
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(var_data: T.handle, weight: T.Buffer((4096,), "float32"), var_T_cast: T.handle):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            n = T.int32()
+            data = T.match_buffer(var_data, (1, n, 4096))
+            T_cast = T.match_buffer(var_T_cast, (1, n, 4096))
+            # with T.block("root"):
+            T_multiply = T.alloc_buffer((1, n, 4096))
+            T_multiply_red = T.alloc_buffer((1, n))
+            rsqrt = T.alloc_buffer((1, n))
+            T_rms_norm = T.alloc_buffer((1, n, 4096))
+            for ax0, ax1, ax2 in T.grid(1, n, 4096):
+                with T.block("T_multiply"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(data[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_multiply[v_ax0, v_ax1, v_ax2])
+                    T_multiply[v_ax0, v_ax1, v_ax2] = data[v_ax0, v_ax1, v_ax2] * data[v_ax0, v_ax1, v_ax2]
+            for ax0, ax1, k2 in T.grid(1, n, 4096):
+                with T.block("T_multiply_red"):
+                    v_ax0, v_ax1, v_k2 = T.axis.remap("SSR", [ax0, ax1, k2])
+                    T.reads(T_multiply[v_ax0, v_ax1, v_k2])
+                    T.writes(T_multiply_red[v_ax0, v_ax1])
+                    with T.init():
+                        T_multiply_red[v_ax0, v_ax1] = T.float32(0)
+                    T_multiply_red[v_ax0, v_ax1] = T_multiply_red[v_ax0, v_ax1] + T_multiply[v_ax0, v_ax1, v_k2]
+            for ax0, ax1 in T.grid(1, n):
+                with T.block("rsqrt"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(T_multiply_red[v_ax0, v_ax1])
+                    T.writes(rsqrt[v_ax0, v_ax1])
+                    rsqrt[v_ax0, v_ax1] = T.rsqrt(T_multiply_red[v_ax0, v_ax1] * T.float32(0.000244140625) + T.float32(9.9999999999999995e-07))
+            for ax0, ax1, ax2 in T.grid(1, n, 4096):
+                with T.block("T_rms_norm"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(rsqrt[v_ax0, v_ax1], data[v_ax0, v_ax1, v_ax2], weight[v_ax2])
+                    T.writes(T_rms_norm[v_ax0, v_ax1, v_ax2])
+                    T_rms_norm[v_ax0, v_ax1, v_ax2] = rsqrt[v_ax0, v_ax1] * data[v_ax0, v_ax1, v_ax2] * weight[v_ax2]
+            for ax0, ax1, ax2 in T.grid(1, n, 4096):
+                with T.block("T_cast_2"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(T_rms_norm[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_cast[v_ax0, v_ax1, v_ax2])
+                    T_cast[v_ax0, v_ax1, v_ax2] = T_rms_norm[v_ax0, v_ax1, v_ax2]
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(var_data: T.handle, weight: T.Buffer((4096,), "float32"), var_T_cast: T.handle):
+            T.func_attr({"tir.is_scheduled": 1, "tir.noalias": T.bool(True)})
+            n = T.int32()
+            data = T.match_buffer(var_data, (1, n, 4096))
+            T_cast = T.match_buffer(var_T_cast, (1, n, 4096))
+            # with T.block("root"):
+            T_multiply_local = T.alloc_buffer((1, n, 4096), scope="local")
+            T_multiply_red_local = T.alloc_buffer((1, n), scope="local")
+            rsqrt_shared = T.alloc_buffer((1, n), scope="shared")
+            T_rms_norm_local = T.alloc_buffer((1, n, 4096), scope="local")
+            data_local = T.alloc_buffer((1, n, 4096), scope="local")
+            for ax0 in T.thread_binding(n, thread="blockIdx.x"):
+                for ax1_0 in T.thread_binding(512, thread="threadIdx.x"):
+                    for ax1_1 in range(1):
+                        for ax1_2 in T.vectorized(8):
+                            with T.block("data_local"):
+                                v0 = T.axis.spatial(n, ax0)
+                                v1 = T.axis.spatial(4096, ax1_0 * 8 + ax1_1 * 8 + ax1_2)
+                                T.reads(data[0, v0, v1])
+                                T.writes(data_local[0, v0, v1])
+                                data_local[0, v0, v1] = data[0, v0, v1]
+                    for ax0_1 in range(8):
+                        with T.block("T_multiply"):
+                            v0 = T.axis.spatial(n, ax0)
+                            v1 = T.axis.spatial(4096, ax1_0 * 8 + ax0_1)
+                            T.reads(data_local[0, v0, v1])
+                            T.writes(T_multiply_local[0, v0, v1])
+                            T_multiply_local[0, v0, v1] = data_local[0, v0, v1] * data_local[0, v0, v1]
+                    for ax0_1 in range(8):
+                        with T.block("T_multiply_red"):
+                            v0 = T.axis.spatial(n, ax0)
+                            v1 = T.axis.reduce(4096, ax1_0 * 8 + ax0_1)
+                            T.reads(T_multiply_local[0, v0, v1])
+                            T.writes(T_multiply_red_local[0, v0])
+                            with T.init():
+                                T_multiply_red_local[0, v0] = T.float32(0)
+                            T_multiply_red_local[0, v0] = T_multiply_red_local[0, v0] + T_multiply_local[0, v0, v1]
+                with T.block("rsqrt"):
+                    v0 = T.axis.spatial(n, ax0)
+                    T.reads(T_multiply_red_local[0, v0])
+                    T.writes(rsqrt_shared[0, v0])
+                    rsqrt_shared[0, v0] = T.rsqrt(T_multiply_red_local[0, v0] * T.float32(0.000244140625) + T.float32(9.9999999999999995e-07))
+                for ax0_0 in T.thread_binding(512, thread="threadIdx.x"):
+                    for ax0_1, ax0_2 in T.grid(1, 8):
+                        with T.block("T_rms_norm"):
+                            v0 = T.axis.spatial(n, ax0)
+                            v1 = T.axis.spatial(4096, ax0_0 * 8 + ax0_1 * 8 + ax0_2)
+                            T.reads(rsqrt_shared[0, v0], data_local[0, v0, v1], weight[v1])
+                            T.writes(T_rms_norm_local[0, v0, v1])
+                            T_rms_norm_local[0, v0, v1] = rsqrt_shared[0, v0] * data_local[0, v0, v1] * weight[v1]
+                    for ax0_1 in T.vectorized(8):
+                        with T.block("T_cast_local"):
+                            v0 = T.axis.spatial(1, 0)
+                            v1 = T.axis.spatial(n, ax0)
+                            v2 = T.axis.spatial(4096, ax0_0 * 8 + ax0_1)
+                            T.reads(T_rms_norm_local[v0, v1, v2])
+                            T.writes(T_cast[v0, v1, v2])
+                            T_cast[v0, v1, v2] = T_rms_norm_local[v0, v1, v2]
+    # fmt: on
+    _check(Before, After)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR introduces a specific rule for RMS norm in dlight, which allow the norm to now perform on par with CUTLASS standards.

New test case for the rule has also been added.

Below is the performance comparison for Llama-2-7b-chat-hf-q4f16_1.

New:
```
======================= Encoding Profiling =======================
Name                                              Time (ms)   Count   Total time (ms)   Pct (%)   Memory (MB)     Bandwidth (GB/s)  Shape
fused_fused_decode4_NT_matmul3                    0.3117      32      9.9759            33.93     48.67           152.4731          (22016, 512), (22016, 128), (1, 6, 4096), (1, 6, 22016)
fused_fused_decode5_fused_NT_matmul4_add          0.2671      32      8.5482            29.08     24.41           89.2261           (4096, 1376), (4096, 344), (1, 6, 11008), (1, 6, 4096), (1, 6, 4096)
fused_fused_decode2_NT_matmul                     0.2037      32      6.5183            22.17     27.19           130.3419          (12288, 512), (12288, 128), (1, 6, 4096), (1, 6, 12288)
fused_fused_decode3_fused_NT_matmul2_add          0.1013      32      3.2422            11.03     9.14            88.1027           (4096, 512), (4096, 128), (1, 6, 4096), (1, 6, 4096), (1, 6, 4096)
fused_NT_matmul1_divide_maximum_minimum_cast      0.0070      32      0.2245            0.76      0.10            13.6735           (1, 32, 6, 128), (1, 32, 6, 128), (1, 1, 6, 6), (1, 32, 6, 6)
rms_norm                                          0.0027      65      0.1752            0.60      0.10            36.7974           (1, 6, 4096), (4096,), (1, 6, 4096)
matmul4                                           0.0049      32      0.1571            0.53      0.10            19.0895           (1, 32, 6, 6), (1, 32, 6, 128), (1, 32, 6, 128)
transpose4                                        0.0022      64      0.1413            0.48      0.09            41.4662           (1, 6, 32, 128), (1, 32, 6, 128)
fused_fused_decode1_fused_NT_matmul5_cast2        0.1066      1       0.1066            0.36      70.44           645.4770          (32000, 512), (32000, 128), (1, 1, 4096), (1, 1, 32000)
fused_softmax_cast1                               0.0030      32      0.0955            0.32      0.01            2.1578            (1, 32, 6, 6), (1, 32, 6, 6)
transpose5                                        0.0022      32      0.0716            0.24      0.09            40.9420           (1, 32, 6, 128), (1, 6, 32, 128)
fused_transpose4                                  0.0022      32      0.0706            0.24      0.09            41.5244           (1, 6, 32, 128), (1, 32, 6, 128)
fused_split_silu_multiply                         0.0020      32      0.0654            0.22      0.38            180.6251          (1, 6, 22016), (1, 6, 11008)
extend_te                                         0.0022      1       0.0022            0.01      0.00            0.0600            (1, 1, 6, 6), (1, 1, 6, 6)
fused_fused_decode1_take                          0.0019      1       0.0019            0.01      70.36           35502.6806        (32000, 512), (32000, 128), (6,), (6, 4096)
slice                                             0.0019      1       0.0019            0.01      0.05            28.1075           (1, 6, 4096), (1, 1, 4096)
Total time: 29.3983 ms

======================= Decoding Profiling =======================
Name                                              Time (ms)   Count   Total time (ms)   Pct (%)   Memory (MB)     Bandwidth (GB/s)  Shape
fused_fused_decode4_NT_matmul9                    0.0747      32      2.3906            36.75     48.42           633.0044          (22016, 512), (22016, 128), (1, 1, 4096), (1, 1, 22016)
fused_fused_decode5_fused_NT_matmul10_add1        0.0445      32      1.4238            21.89     24.22           531.6822          (4096, 1376), (4096, 344), (1, 1, 11008), (1, 1, 4096), (1, 1, 4096)
fused_fused_decode2_NT_matmul6                    0.0437      32      1.3986            21.50     27.03           603.9670          (12288, 512), (12288, 128), (1, 1, 4096), (1, 1, 12288)
fused_fused_decode3_fused_NT_matmul8_add1         0.0184      32      0.5892            9.06      9.02            478.6109          (4096, 512), (4096, 128), (1, 1, 4096), (1, 1, 4096), (1, 1, 4096)
rms_norm1                                         0.0025      65      0.1618            2.49      0.02            9.1963            (1, 1, 4096), (4096,), (1, 1, 4096)
transpose4                                        0.0022      64      0.1416            2.18      0.11            48.2909           (1, 7, 32, 128), (1, 32, 7, 128)
fused_fused_decode1_fused_NT_matmul5_cast2        0.1066      1       0.1066            1.64      70.44           645.3116          (32000, 512), (32000, 128), (1, 1, 4096), (1, 1, 32000)
matmul10                                          0.0025      32      0.0786            1.21      0.06            25.0127           (1, 32, 1, 7), (1, 32, 7, 128), (1, 32, 1, 128)
fused_softmax2_cast4                              0.0024      32      0.0752            1.16      0.00            0.5324            (1, 32, 1, 7), (1, 32, 1, 7)
fused_NT_matmul7_divide2_maximum1_minimum1_cast3  0.0023      32      0.0744            1.14      0.06            26.6235           (1, 32, 1, 128), (1, 32, 7, 128), (1, 1, 1, 7), (1, 32, 1, 7)
fused_split1_silu1_multiply1                      0.0019      32      0.0606            0.93      0.06            32.4741           (1, 1, 22016), (1, 1, 11008)
full                                              0.0020      1       0.0020            0.03      0.00            0.0066            (1, 1, 1, 7)
fused_fused_decode1_take1                         0.0018      1       0.0018            0.03      70.32           37132.5438        (32000, 512), (32000, 128), (1,), (1, 4096)
Total time: 6.5048 ms
```

Old:
```
======================= Encoding Profiling =======================
Name                                              Time (ms)   Count   Total time (ms)   Pct (%)   Memory (MB)     Bandwidth (GB/s)  Shape
fused_fused_decode4_NT_matmul3                    0.3116      32      9.9706            33.84     48.67           152.5537          (22016, 512), (22016, 128), (1, 6, 4096), (1, 6, 22016)
fused_fused_decode5_fused_NT_matmul4_add          0.2670      32      8.5452            29.00     24.41           89.2574           (4096, 1376), (4096, 344), (1, 6, 11008), (1, 6, 4096), (1, 6, 4096)
fused_fused_decode2_NT_matmul                     0.2037      32      6.5187            22.13     27.19           130.3332          (12288, 512), (12288, 128), (1, 6, 4096), (1, 6, 12288)
fused_fused_decode3_fused_NT_matmul2_add          0.1013      32      3.2421            11.00     9.14            88.1061           (4096, 512), (4096, 128), (1, 6, 4096), (1, 6, 4096), (1, 6, 4096)
rms_norm                                          0.0038      65      0.2440            0.83      0.10            26.4202           (1, 6, 4096), (4096,), (1, 6, 4096)
fused_NT_matmul1_divide1_maximum_minimum_cast     0.0070      32      0.2248            0.76      0.10            13.6538           (1, 32, 6, 128), (1, 32, 6, 128), (1, 1, 6, 6), (1, 32, 6, 6)
matmul                                            0.0049      32      0.1569            0.53      0.10            19.1045           (1, 32, 6, 6), (1, 32, 6, 128), (1, 32, 6, 128)
transpose                                         0.0022      64      0.1413            0.48      0.09            41.4722           (1, 6, 32, 128), (1, 32, 6, 128)
fused_fused_decode1_fused_NT_matmul5_cast2        0.1068      1       0.1068            0.36      70.44           644.0582          (32000, 512), (32000, 128), (1, 1, 4096), (1, 1, 32000)
fused_softmax1_cast1                              0.0029      32      0.0918            0.31      0.01            2.2452            (1, 32, 6, 6), (1, 32, 6, 6)
transpose1                                        0.0023      32      0.0721            0.24      0.09            40.6511           (1, 32, 6, 128), (1, 6, 32, 128)
fused_split_silu_multiply                         0.0022      32      0.0711            0.24      0.38            166.0295          (1, 6, 22016), (1, 6, 11008)
fused_transpose                                   0.0022      32      0.0706            0.24      0.09            41.5205           (1, 6, 32, 128), (1, 32, 6, 128)
extend_te                                         0.0022      1       0.0022            0.01      0.00            0.0600            (1, 1, 6, 6), (1, 1, 6, 6)
fused_fused_decode1_take                          0.0020      1       0.0020            0.01      70.36           34944.1585        (32000, 512), (32000, 128), (6,), (6, 4096)
slice                                             0.0019      1       0.0019            0.01      0.05            28.0399           (1, 6, 4096), (1, 1, 4096)
Total time: 29.4621 ms

======================= Decoding Profiling =======================
Name                                              Time (ms)   Count   Total time (ms)   Pct (%)   Memory (MB)     Bandwidth (GB/s)  Shape
fused_fused_decode4_NT_matmul9                    0.0747      32      2.3900            36.35     48.42           633.1580          (22016, 512), (22016, 128), (1, 1, 4096), (1, 1, 22016)
fused_fused_decode5_fused_NT_matmul10_add1        0.0445      32      1.4231            21.64     24.22           531.9347          (4096, 1376), (4096, 344), (1, 1, 11008), (1, 1, 4096), (1, 1, 4096)
fused_fused_decode2_NT_matmul6                    0.0437      32      1.3984            21.27     27.03           604.0569          (12288, 512), (12288, 128), (1, 1, 4096), (1, 1, 12288)
fused_fused_decode3_fused_NT_matmul8_add1         0.0184      32      0.5898            8.97      9.02            478.0792          (4096, 512), (4096, 128), (1, 1, 4096), (1, 1, 4096), (1, 1, 4096)
rms_norm1                                         0.0036      65      0.2338            3.56      0.02            6.3626            (1, 1, 4096), (4096,), (1, 1, 4096)
transpose                                         0.0022      64      0.1414            2.15      0.11            48.3282           (1, 7, 32, 128), (1, 32, 7, 128)
fused_fused_decode1_fused_NT_matmul5_cast2        0.1069      1       0.1069            1.63      70.44           643.6275          (32000, 512), (32000, 128), (1, 1, 4096), (1, 1, 32000)
matmul3                                           0.0025      32      0.0791            1.20      0.06            24.8680           (1, 32, 1, 7), (1, 32, 7, 128), (1, 32, 1, 128)
fused_softmax2_cast4                              0.0024      32      0.0752            1.14      0.00            0.5324            (1, 32, 1, 7), (1, 32, 1, 7)
fused_NT_matmul7_divide2_maximum1_minimum1_cast3  0.0023      32      0.0743            1.13      0.06            26.6699           (1, 32, 1, 128), (1, 32, 7, 128), (1, 1, 1, 7), (1, 32, 1, 7)
fused_split1_silu1_multiply1                      0.0019      32      0.0596            0.91      0.06            33.0057           (1, 1, 22016), (1, 1, 11008)
fused_fused_decode1_take1                         0.0019      1       0.0019            0.03      70.32           35296.3286        (32000, 512), (32000, 128), (1,), (1, 4096)
full                                              0.0019      1       0.0019            0.03      0.00            0.0067            (1, 1, 1, 7)
Total time: 6.5756 ms
```