### PR TITLE
[Unity][UnitTest] Increase atol to resolve flaky CI failure

### DIFF
--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -1226,6 +1226,8 @@ def test_attention(dynamic):
                 "mask_index": mask_index,
                 "relative_position_bias": relative_position_bias,
             },
+            # Maximum observed delta from 500 iterations was 2e-4.
+            atol=1e-3,
         )
         # "present" output should be nullptr when the "past" input isn't included,
         # but ort requires an output shape to be specified?


### PR DESCRIPTION
The `tests/python/relax/test_frontend_onnx.py::test_attention` unit test currently has sporadic failures (5/200 executions), which can cause failures for unrelated changes
(e.g. [PR#16304](https://github.com/apache/tvm/pull/16304), [CI link](https://ci.tlcpack.ai/blue/organizations/jenkins/tvm-unity/detail/PR-16304/3/pipeline)).

This commit specifies a tolerance to use for comparisons, to avoid these spurious CI failures.