### PR TITLE
[CMake] Use ccache as CMAKE_CUDA_COMPILER_LAUNCHER

### DIFF
--- a/cmake/utils/CCache.cmake
+++ b/cmake/utils/CCache.cmake
@@ -16,12 +16,28 @@
 # under the License.
 
 if(USE_CCACHE) # True for AUTO, ON, /path/to/ccache
-  if(DEFINED CMAKE_CXX_COMPILER_LAUNCHER OR DEFINED CMAKE_C_COMPILER_LAUNCHER)
+
+  if(DEFINED CMAKE_C_COMPILER_LAUNCHER)
     if("${USE_CCACHE}" STREQUAL "AUTO")
-      message(STATUS "CMAKE_CXX_COMPILER_LAUNCHER or CMAKE_C_COMPILER_LAUNCHER already defined, not using ccache")
+      message(STATUS "CMAKE_C_COMPILER_LAUNCHER already defined.  Not using ccache.")
     elseif("${USE_CCACHE}" MATCHES ${IS_TRUE_PATTERN})
-      message(FATAL_ERROR "CMAKE_CXX_COMPILER_LAUNCHER or CMAKE_C_COMPILER_LAUNCHER is already defined, refusing to override with ccache. Either unset or disable ccache.")
+      message(FATAL_ERROR "CMAKE_C_COMPILER_LAUNCHER already defined.  Refusing to override with ccache. Either unset or disable ccache.")
     endif()
+
+  elseif(DEFINED CMAKE_CXX_COMPILER_LAUNCHER)
+    if("${USE_CCACHE}" STREQUAL "AUTO")
+      message(STATUS "CMAKE_CXX_COMPILER_LAUNCHER already defined.  Not using ccache.")
+    elseif("${USE_CCACHE}" MATCHES ${IS_TRUE_PATTERN})
+      message(FATAL_ERROR "CMAKE_CXX_COMPILER_LAUNCHER already defined.  Refusing to override with ccache. Either unset or disable ccache.")
+    endif()
+
+  elseif(DEFINED CMAKE_CUDA_COMPILER_LAUNCHER)
+    if("${USE_CCACHE}" STREQUAL "AUTO")
+      message(STATUS "CMAKE_CUDA_COMPILER_LAUNCHER already defined.  Not using ccache.")
+    elseif("${USE_CCACHE}" MATCHES ${IS_TRUE_PATTERN})
+      message(FATAL_ERROR "CMAKE_CUDA_COMPILER_LAUNCHER already defined.  Refusing to override with ccache. Either unset or disable ccache.")
+    endif()
+
   else()
     if("${USE_CCACHE}" STREQUAL "AUTO") # Auto mode
       find_program(CCACHE_FOUND "ccache")
@@ -47,6 +63,7 @@ if(USE_CCACHE) # True for AUTO, ON, /path/to/ccache
     if(DEFINED PATH_TO_CCACHE)
       set(CMAKE_CXX_COMPILER_LAUNCHER "${PATH_TO_CCACHE}")
       set(CMAKE_C_COMPILER_LAUNCHER "${PATH_TO_CCACHE}")
+      set(CMAKE_CUDA_COMPILER_LAUNCHER "${PATH_TO_CCACHE}")
     endif()
   endif()
 endif(USE_CCACHE)


### PR DESCRIPTION
For older versions of `ccache` that do not support `nvcc`, this has no effect.  For newer versions of `ccache`, this enables caching the compiled `nvcc` outputs.  This was tested using `ccache` versions 3.7.7 (does not cache `nvcc` output) and 4.8.3 (caches `nvcc` output).

This is primarily intended to reduce compilation time of cutlass kernels, which can take several minutes after switching branches.