### PR TITLE
[CMake][MSVC] Disable permissive mode for MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,11 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
   add_compile_options(/bigobj)
 
+  # Use standard-conforming two-phase name resolution for templates.
+  # This minimizes the differences between g++/clang builds on Linux,
+  # and MSVC builds on Windows.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
+
   # MSVC already errors on undefined symbols, no additional flag needed.
   set(TVM_NO_UNDEFINED_SYMBOLS "")
 


### PR DESCRIPTION
The C++ standard requires two-phase name resolution for templates.  By default, MSVC uses a non-standard name resolution, in which all names are looked up when a template is instantiated.  This has caused MSVC-specific compilation errors ([example](https://github.com/apache/tvm/actions/runs/7400684492/job/20134841480?pr=16183)), which are quite difficult to debug.

This commit updates adds the `/permissive-` flag when building TVM with MSVC, disabling the non-standard name resolution.