### PR TITLE
[UMA] Quantized version of Vanilla example in UMA 

### DIFF
--- a/apps/uma/qvanilla/backend.py
+++ b/apps/uma/qvanilla/backend.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""UMA backend for the q_vanilla_accelerator accelerator"""
+from .passes import QVanillaAcceleratorConv2dPass, ConvertLayout
+from tvm.relay.backend.contrib.uma.api.utils import PassPhase
+from tvm.relay.backend.contrib.uma.backend import UMABackend
+from .codegen import gen_includes
+from .patterns import qnn_conv2d_add_pattern
+from .strategies import qnn_conv2d_strategy
+
+
+class QVanillaAcceleratorBackend(UMABackend):
+    """UMA backend for the QVanillaAccelerator accelerator."""
+
+    def __init__(self):
+        print("init!")
+        super().__init__()
+
+        # Target configuration
+        self._register_target_attr("dimension")
+
+        # Relay Pattern registration
+        self._register_pattern("qnn_conv2d_add", qnn_conv2d_add_pattern())
+
+
+        # Relay to Relay function registration
+        self._register_relay_pass(PassPhase.PRE_PARTITIONING, ConvertLayout())
+
+
+        # Relay to TIR function registration
+        self._register_operator_strategy("qnn.conv2d", qnn_conv2d_strategy)
+
+        self._register_tir_pass(PassPhase.TIR_PHASE_0, QVanillaAcceleratorConv2dPass())
+
+
+        # TIR to runtime function registration
+        self._register_codegen(fmt="c", includes=gen_includes)
+
+    @property
+    def target_name(self):
+        return "q_vanilla_accelerator"

--- a/apps/uma/qvanilla/backend.py
+++ b/apps/uma/qvanilla/backend.py
@@ -27,7 +27,7 @@ class QVanillaAcceleratorBackend(UMABackend):
     """UMA backend for the QVanillaAccelerator accelerator."""
 
     def __init__(self):
-        print("init!")
+        
         super().__init__()
 
         # Target configuration

--- a/apps/uma/qvanilla/codegen.py
+++ b/apps/uma/qvanilla/codegen.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""UMA codegen for the q_vanilla_accelerator accelerator"""
+
+import tvm
+import pathlib
+
+
+def gen_includes() -> str:
+    topdir = pathlib.Path(__file__).parent.absolute()
+
+    includes = ""
+    includes += f'#include "{topdir}/conv2dnchw.cc"'
+    return includes

--- a/apps/uma/qvanilla/conv2dnchw.cc
+++ b/apps/uma/qvanilla/conv2dnchw.cc
@@ -1,0 +1,80 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <math.h>
+#include <stdbool.h>
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C"
+#endif
+
+
+int q_vanilla_accelerator_conv2dnchw(int8_t* q_vanilla_accelerator_0_i0, int8_t* q_vanilla_accelerator_0_i1, int32_t* bias_data, int32_t* compute,
+                                      int32_t oc, int32_t iw, int32_t ih, int32_t ic, int32_t kh, int32_t kw, int32_t i_zp, int32_t k_zp) {
+
+
+  int kw_low = kw / 2;
+  int kh_low = kh / 2;
+  int kw_high = iw + kw / 2;
+  int kh_high = ih + kh / 2;
+
+  int padded_iw = iw + 2 * kw_low;
+  int padded_ih = ih + 2 * kh_low;
+
+  int32_t* data_pad_let = (int32_t*)malloc(
+      (((ic * padded_iw * padded_ih) + (padded_ih * padded_iw)) + padded_iw) * sizeof(int32_t));
+
+  int32_t* compute_let = (int32_t*)malloc((oc * ic * kh * kw) * sizeof(int32_t));
+
+
+
+  for (int32_t i1_1 = 0; i1_1 < ic; ++i1_1) {
+    for (int32_t i2_1 = 0; i2_1 < padded_ih; ++i2_1) {
+      for (int32_t i3_1 = 0; i3_1 < padded_iw; ++i3_1) {
+        data_pad_let[(((i1_1 * padded_iw * padded_ih) + (i2_1 * padded_iw)) + i3_1)] = (((((kh_low <= i2_1) && (i2_1 < kh_high)) && (kw_low <= i3_1)) && (i3_1 < kw_high)) 
+        ? ((int32_t)q_vanilla_accelerator_0_i0[(((i1_1 * iw * ih) + ((i2_1 - kh_low) * iw) + i3_1 - kw_low))] - (i_zp)) 
+        : 0);
+        
+      }
+    }
+  }
+  
+
+
+  for (int32_t i0 = 0; i0 < oc; ++i0) {
+    for (int32_t i1_2 = 0; i1_2 < ic; ++i1_2) {
+      for (int32_t i2_2 = 0; i2_2 < kh; ++i2_2) {
+        for (int32_t i3_2 = 0; i3_2 < kw; ++i3_2) {
+          int32_t cse_var_2 = ((((i0 * ic * kh * kw) + (i1_2 * kw * kh)) + (i2_2 * kw)) + i3_2);
+          compute_let[cse_var_2] = (((int32_t)q_vanilla_accelerator_0_i1[cse_var_2]) - k_zp);
+        }
+      }
+    }
+  }
+
+
+  for (int32_t oc_ = 0; oc_ < oc; ++oc_) {
+    for (int32_t oh = 0; oh < ih; ++oh) {
+      for (int32_t ow = 0; ow < iw; ++ow) {
+        int32_t cse_var_3 = (((oc_ * ih * iw) + (oh * iw)) + ow);
+        for (int32_t ic_ = 0; ic_ < ic; ++ic_) {
+          for (int32_t kh_ = 0; kh_ < kh; ++kh_) {
+            for (int32_t kw_ = 0; kw_ < kh; ++kw_) {
+              // int32_t cse_var_3 = (((oc_ * ih * iw) + (oh * iw)) + ow);
+              if (((ic_ == 0) && (kh_ == 0)) && (kw_ == 0)) {
+                compute[cse_var_3] = 0;
+              }
+              compute[cse_var_3] = (compute[cse_var_3] + ((data_pad_let)[(((((ic_ * padded_iw * padded_ih) + (oh * padded_iw)) + (kh_ * padded_iw)) + ow) + kw_)] * (compute_let)[((((oc_ * ic * kh * kw) + (ic_ * kh * kw)) + (kh_ * kw)) + kw_)]));
+            }
+          }
+        }
+        compute[cse_var_3] = compute[cse_var_3] + bias_data[oc_]; //bias_add
+      }
+    }
+  }
+  free(data_pad_let);
+  free(compute_let);
+  return 0;
+}
+

--- a/apps/uma/qvanilla/conv2dnchw.cc
+++ b/apps/uma/qvanilla/conv2dnchw.cc
@@ -61,7 +61,6 @@ int q_vanilla_accelerator_conv2dnchw(int8_t* q_vanilla_accelerator_0_i0, int8_t*
         for (int32_t ic_ = 0; ic_ < ic; ++ic_) {
           for (int32_t kh_ = 0; kh_ < kh; ++kh_) {
             for (int32_t kw_ = 0; kw_ < kh; ++kw_) {
-              // int32_t cse_var_3 = (((oc_ * ih * iw) + (oh * iw)) + ow);
               if (((ic_ == 0) && (kh_ == 0)) && (kw_ == 0)) {
                 compute[cse_var_3] = 0;
               }

--- a/apps/uma/qvanilla/passes.py
+++ b/apps/uma/qvanilla/passes.py
@@ -1,0 +1,216 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Transform passes for the q_vanilla_accelerator accelerator"""
+
+import functools
+import tvm
+from tvm import tir
+from tvm.relay.backend.contrib.uma.api.utils import add_llvm_to_block
+from tvm import relay
+from tvm.tir import buffer
+
+
+@tvm.tir.transform.prim_func_pass(opt_level=2)
+class QVanillaAcceleratorConv2dPass:
+    _EXTERNAL_FUNCTION_NAME = "q_vanilla_accelerator_conv2dnchw"
+    # _TVM_BLOCK_MATCH_NAME = "conv2d_nchw"
+    _TVM_BLOCK_MATCH_NAME = "compute_2"
+    def transform_function(
+        self, func: tvm.tir.PrimFunc, mod: tvm.ir.IRModule, ctx: tvm.ir.transform.PassContext
+    ) -> tvm.tir.PrimFunc:
+        
+        return self._q_vanilla_accelerator_conv2d_pass(func, mod, ctx)
+
+    @classmethod
+    def _q_vanilla_accelerator_conv2d_pass(cls, func, mod, ctx):
+        _loops = dict()
+        _handles = []
+        _entry_node = None
+        zp = []
+        block_idx = 0
+        def _has_block(name: str, func: tvm.tir.PrimFunc) -> bool:
+            """
+            Determine of a tir.block with `name` exists in `func`
+            """
+
+            def _hb(op):
+                if isinstance(op, tvm.tir.Block):
+                    _found_blocks.append(op.name_hint)
+
+            _found_blocks = []
+            tvm.tir.stmt_functor.post_order_visit(func.body, _hb)
+            return name in _found_blocks
+
+        def _detect_and_replace_conv2d(
+            func: tvm.tir.PrimFunc, mod: tvm.ir.IRModule, ctx: tvm.ir.transform.PassContext
+        ) -> tvm.tir.PrimFunc:
+            def _replace_conv2d(op):
+                if op == _entry_node:
+                    irb = tvm.tir.ir_builder.create()
+                    # Collection of buffer address
+                    buffers = [b[1].data for b in _handles]
+                    # extraction of loop offsets
+                    for k, v in _loops.items():
+                        assert v.min.value == 0
+                    offset_order = ["co", "w", "h", "ci", "kh", "kw"]
+                    offsets = [_loops[i].extent.value for i in offset_order]
+
+                    offsets.append(zp[0])
+                    offsets.append(zp[1])
+
+                    args = buffers + offsets
+                    
+                    irb.emit(tir_call(irb, True, cls._EXTERNAL_FUNCTION_NAME, *args))
+                    irb_result = irb.get()
+                   
+                    return irb_result
+                elif isinstance(op, tvm.tir.SeqStmt):
+                    # Remove that pad block of TOPI's conv2DNCHW by only returning the 2nd statement
+                  
+                    return op.seq[block_idx]   # the line that I've changed to replace the compute_2 block
+                
+                return op
+
+            sch = tir.Schedule(func)
+
+            if _has_block(cls._TVM_BLOCK_MATCH_NAME, func):
+
+                #find the zp values
+
+                s1 = []
+                s2 = []
+
+                def _visit(s):
+                    if isinstance(s, tvm.tir.BufferStore):
+                        # stores.append(s.value)
+                        s1.append(s.buffer.data)
+                        s2.append(s.value)
+
+
+                tvm.tir.stmt_functor.post_order_visit(func.body, _visit)
+                
+                for i in range(len(s1)):
+                    
+                    if s1[i].name == "compile_engine_const":
+                        
+                        zp.append(s2[i])
+                block_idx = len(s1) - 3      
+            
+              
+                ###
+                
+                conv2d_block = sch.get_block(cls._TVM_BLOCK_MATCH_NAME)
+                rv_loops = sch.get_loops(conv2d_block)
+                
+                assert len(rv_loops) == 7
+                loops = dict(
+                    n=rv_loops[0],
+                    co=rv_loops[1],
+                    h=rv_loops[2],
+                    w=rv_loops[3],
+                    ci=rv_loops[4],
+                    kh=rv_loops[5],
+                    kw=rv_loops[6],
+                )
+                _entry_node = sch.get(rv_loops[1])
+                
+                _loops = {k: sch.get(v) for k, v in loops.items()}
+                _handles = func.buffer_map.items()
+
+                x = tvm.tir.stmt_functor.ir_transform(
+                    func.body, None, _replace_conv2d, ["tir.For", "tir.SeqStmt"]
+                )
+             
+                return func.with_body(x)
+            else:
+               
+                return func
+
+        r = _detect_and_replace_conv2d(func, mod, ctx)
+        return r
+
+
+def tir_call(ib: tvm.tir.ir_builder, extern: bool, name: str, *args):
+    """
+    ib: ir_builder
+    extern: bool
+        True  --> tvm.tir.call_extern
+        False --> tvm.tir.call_packed
+    name: str
+        function name
+    *args:
+        arguments for function call
+    """
+
+    def buf_from_array(ib, arr, dtype):
+        # Allocate enough memory to store the whole array
+        var = ib.allocate("int32", (len(arr),), scope="global")
+        for i, v in enumerate(arr):
+            var[i] = v
+        # Declare a buffer, which is basically a view on the chunk of memory that we allocated
+        buf = tvm.tir.decl_buffer((len(arr),), dtype, data=var, scope="global")
+        return buf
+
+    if extern:
+        args = [i.data if isinstance(i, tvm.tir.Buffer) else i for i in args]
+        return tvm.tir.call_extern("int32", name, *args)
+    else:
+        args = [
+            buf_from_array(ib, i, "int32")
+            if isinstance(i, (tuple, list, tvm.ir.container.Array))
+            else i
+            for i in args
+        ]
+        return tvm.tir.call_packed(name, *args)
+
+
+@tvm.ir.transform.module_pass(opt_level=0)
+class ConvertLayout:
+    print("relay pass")
+    def transform_module(self, mod, ctx):
+       
+        # My pass functionality...
+        desired_layouts = {'qnn.conv2d': ['NCHW', 'default']}
+        # Convert the layout to NCHW
+        # RemoveUnunsedFunctions is used to clean up the graph.
+        seq = tvm.transform.Sequential([relay.transform.RemoveUnusedFunctions(),
+                                    relay.transform.ConvertLayout(desired_layouts)])
+        with tvm.transform.PassContext(opt_level=3):
+            mod = seq(mod)
+        
+        print("after convert layout")
+        return mod
+
+@tvm.ir.transform.module_pass(opt_level=0)
+class Canonicalize:
+    print("Canonicalize")
+    def transform_module(self, mod, ctx):
+        print("Canonicalize_transform")
+        print(mod)
+        # My pass functionality...
+        
+        # Convert the layout to NCHW
+        # RemoveUnunsedFunctions is used to clean up the graph.
+        seq = tvm.transform.Sequential([relay.transform.RemoveUnusedFunctions(),
+                                    relay.qnn.transform.CanonicalizeOps()])
+        with tvm.transform.PassContext(opt_level=3):
+            mod = seq(mod)
+        
+        print(mod)
+        return mod
+        
+        

--- a/apps/uma/qvanilla/patterns.py
+++ b/apps/uma/qvanilla/patterns.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Relay graph patterns for the q_vanilla_accelerator accelerator"""
+
+from tvm.relay.dataflow_pattern import is_op, wildcard, is_constant
+import tvm
+
+
+def qnn_conv2d_add_pattern():
+    
+    qnn_conv2d = is_op("qnn.conv2d")(wildcard(), wildcard(), is_constant(),
+                         is_constant(), is_constant(), is_constant(),)
+    
+
+    qnn_conv2d = qnn_conv2d.has_attr({"strides": [1, 1], "groups": 1})
+
+    pattern = is_op("add")(qnn_conv2d, wildcard())
+
+
+    return pattern   
+
+
+
+
+

--- a/apps/uma/qvanilla/run.py
+++ b/apps/uma/qvanilla/run.py
@@ -43,7 +43,7 @@ def generate_tflite_file(tflite_filename):
     mnist = tf.keras.datasets.mnist
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
     x_train, x_test = x_train / 255.0, x_test / 255.0
-    print(x_train.shape)
+    
     x_train, x_test = x_train.reshape(-1, 28, 28, 1), x_test.reshape(-1, 28, 28, 1)
     tf_model = tf.keras.models.Sequential(
         [
@@ -96,7 +96,7 @@ def main():
 
     uma_backend = QVanillaAcceleratorBackend()
     uma_backend.register()
-    print("registering done")
+   
     target = tvm.target.Target("q_vanilla_accelerator", host=tvm.target.Target("c"))
     target_c = tvm.target.Target("c")
     
@@ -106,7 +106,7 @@ def main():
     input_list = {str(tf_model_details[0]["name"]): data}
     output_list = generate_ref_data(mod, input_list, params)
 
-    print("before partitioning")
+
     mod = uma_backend.partition(mod)
       
  
@@ -129,8 +129,6 @@ def main():
         test_dir=str(export_directory),
     )
 
-
-    print("compiling")
 
     
 if __name__ == "__main__":

--- a/apps/uma/qvanilla/run.py
+++ b/apps/uma/qvanilla/run.py
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tensorflow as tf
+import os
+import pytest
+
+pytest.importorskip("tflite")
+pytest.importorskip("tensorflow")
+
+from tvm.micro.testing.aot_test_utils import AOT_DEFAULT_RUNNER
+import tvm
+from tvm import relay
+from backend import QVanillaAcceleratorBackend
+from tvm.relay import transform, testing
+from collections import OrderedDict
+import numpy as np
+from tvm.relay.backend import Runtime, Executor
+
+from tvm.testing.aot import (
+    AOTTestModel as AOTModel,
+    AOTTestRunner as AOTRunner,
+    generate_ref_data,
+    compile_and_run,
+    create_relay_module_and_inputs_from_tflite_file,
+)
+
+
+def generate_tflite_file(tflite_filename):
+    mnist = tf.keras.datasets.mnist
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+    x_train, x_test = x_train / 255.0, x_test / 255.0
+    print(x_train.shape)
+    x_train, x_test = x_train.reshape(-1, 28, 28, 1), x_test.reshape(-1, 28, 28, 1)
+    tf_model = tf.keras.models.Sequential(
+        [
+            tf.keras.Input(shape=(28, 28, 1)),
+            tf.keras.layers.Conv2D(4, (1, 1), padding="same", activation="relu"),
+            tf.keras.layers.Flatten(input_shape=(28, 28)),
+            tf.keras.layers.Dense(32, activation="relu"),
+            tf.keras.layers.Dropout(0.2),
+            tf.keras.layers.Dense(10),
+        ]
+    )
+    output = tf_model(x_train[:1])
+    output = output.numpy()
+    loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+    loss(y_train[:1], output).numpy()
+    tf_model.compile(metrics=["accuracy"], optimizer="adam", loss=loss)
+    tf_model.fit(x_train, y_train, epochs=1)
+
+    def representative_dataset():
+        for _ in range(100):
+          data = np.random.rand(1, 28, 28, 1)
+          yield [data.astype(np.float32)]
+
+    converter = tf.lite.TFLiteConverter.from_keras_model(tf_model)
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    converter.representative_dataset = representative_dataset
+    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+    converter.inference_input_type = tf.int8  # or tf.uint8
+    converter.inference_output_type = tf.int8  # or tf.uint8
+    tflite_quant_model = converter.convert()
+    with open(tflite_filename, "wb") as f:
+        f.write(tflite_quant_model)
+
+
+
+def main():
+
+    tflite_file = "/tmp/model.tflite"
+
+    if os.path.exists(tflite_file):
+        os.remove(tflite_file)
+    generate_tflite_file(tflite_file)
+    pytest.importorskip("tflite")
+
+    interpreter = tf.lite.Interpreter(model_path=tflite_file)
+    tf_model_details = interpreter.get_input_details()
+    mod, _, params = create_relay_module_and_inputs_from_tflite_file(
+        tflite_file, bind_params_by_name=False
+    )
+
+    uma_backend = QVanillaAcceleratorBackend()
+    uma_backend.register()
+    print("registering done")
+    target = tvm.target.Target("q_vanilla_accelerator", host=tvm.target.Target("c"))
+    target_c = tvm.target.Target("c")
+    
+    # Generation of test input and output
+    data_shape = [int(x) for x in mod["main"].params[0].type_annotation.shape]
+    data = np.random.uniform(size=data_shape).astype("int8")
+    input_list = {str(tf_model_details[0]["name"]): data}
+    output_list = generate_ref_data(mod, input_list, params)
+
+    print("before partitioning")
+    mod = uma_backend.partition(mod)
+      
+ 
+    
+    export_directory = tvm.contrib.utils.tempdir(keep_for_debug=True).path
+    print(f"Generated files are in {export_directory}")
+
+    aot_test_model = AOTModel(module=mod, inputs=input_list, outputs=output_list, params=params)
+
+    test_runner = AOT_DEFAULT_RUNNER
+
+    compile_and_run(
+        aot_test_model,
+        test_runner,
+        interface_api="c",
+        use_unpacked_api=True,
+        workspace_byte_alignment=1,
+        debug_calculated_workspaces=False,
+        target=[target_c, target],
+        test_dir=str(export_directory),
+    )
+
+
+    print("compiling")
+
+    
+if __name__ == "__main__":
+    main()

--- a/apps/uma/qvanilla/strategies.py
+++ b/apps/uma/qvanilla/strategies.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Strategies for the q_vanilla_accelerator accelerator"""
+
+# Example how to integrate a custom conv1d strategy:
+
+# @relay.op.strategy.override_native_generic_func("custom_conv1d_strategy")
+# def custom_conv1d_strategy(attrs, inputs, out_type, target):
+#     strategy = _op.OpStrategy()
+#     strategy.add_implementation(
+#         wrap_compute_conv1d(custom_conv1d_compute),
+#         wrap_topi_schedule(custom_conv1d_schedule),
+#         name="custom_conv1d.generic",
+#     return strategy
+#
+
+# For further details see:
+# - github.com/apache/tvm-rfcs/blob/main/rfcs/0060_UMA_Unified_Modular_Accelerator_Interface.md
+# - $TVM_HOME/python/tvm/relay/op/strategy/x86.py
+
+from tvm import relay
+from tvm.relay import op as _op
+from tvm.relay.qnn.strategy.hexagon import *
+from tvm import topi
+
+
+
+@relay.op.strategy.override_native_generic_func("qnn_conv2d_strategy")
+def qnn_conv2d_strategy(attrs, inputs, out_type, target):
+    print("qnn strategy")
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_topi_qnn_conv2d(topi.hexagon.qnn_conv2d),
+        wrap_topi_schedule(topi.hexagon.schedule_qnn_conv2d)
+    )
+    
+    return strategy
+

--- a/apps/uma/qvanilla/strategies.py
+++ b/apps/uma/qvanilla/strategies.py
@@ -14,23 +14,25 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Strategies for the q_vanilla_accelerator accelerator"""
+"""Strategies for the q_vanilla_accelerator accelerator
 
-# Example how to integrate a custom conv1d strategy:
+Example how to integrate a custom conv1d strategy:
 
-# @relay.op.strategy.override_native_generic_func("custom_conv1d_strategy")
-# def custom_conv1d_strategy(attrs, inputs, out_type, target):
-#     strategy = _op.OpStrategy()
-#     strategy.add_implementation(
-#         wrap_compute_conv1d(custom_conv1d_compute),
-#         wrap_topi_schedule(custom_conv1d_schedule),
-#         name="custom_conv1d.generic",
-#     return strategy
-#
+@relay.op.strategy.override_native_generic_func("custom_conv1d_strategy")
+def custom_conv1d_strategy(attrs, inputs, out_type, target):
+    strategy = _op.OpStrategy()
+    strategy.add_implementation(
+        wrap_compute_conv1d(custom_conv1d_compute),
+        wrap_topi_schedule(custom_conv1d_schedule),
+        name="custom_conv1d.generic",
+    return strategy
 
-# For further details see:
-# - github.com/apache/tvm-rfcs/blob/main/rfcs/0060_UMA_Unified_Modular_Accelerator_Interface.md
-# - $TVM_HOME/python/tvm/relay/op/strategy/x86.py
+
+For further details see:
+- github.com/apache/tvm-rfcs/blob/main/rfcs/0060_UMA_Unified_Modular_Accelerator_Interface.md
+- $TVM_HOME/python/tvm/relay/op/strategy/x86.py
+
+"""
 
 from tvm import relay
 from tvm.relay import op as _op
@@ -38,10 +40,9 @@ from tvm.relay.qnn.strategy.hexagon import *
 from tvm import topi
 
 
-
 @relay.op.strategy.override_native_generic_func("qnn_conv2d_strategy")
 def qnn_conv2d_strategy(attrs, inputs, out_type, target):
-    print("qnn strategy")
+
     strategy = _op.OpStrategy()
     strategy.add_implementation(
         wrap_topi_qnn_conv2d(topi.hexagon.qnn_conv2d),

--- a/gallery/tutorial/uma.py
+++ b/gallery/tutorial/uma.py
@@ -256,7 +256,7 @@ Making your Hardware Accelerator TVM-ready with UMA
 #
 ######################################################################
 # QVanilla
-===================================================
+# -------------
 # **Author**: Samira Ahmadifarsani
 # **QVanilla** accelerator is a modified version of Vanilla, which can process QNN Conv2D followed by a bias addition operator. We need to deal with QNN operators for this example.
 # To construct the backend for this custom accelerator, the initial step is defining the necessary pattern to annotate and

--- a/gallery/tutorial/uma.py
+++ b/gallery/tutorial/uma.py
@@ -260,36 +260,26 @@ Making your Hardware Accelerator TVM-ready with UMA
 # **Author**: Samira Ahmadifarsani
 # **Vanilla** accelerator is a modified version of Vanilla, which can process
 # QNN Conv2D followed by a bias addition operator.
-# To construct the backend for this custom accelerator, the
-# initial step is defining the necessary pattern to annotate and
+# To construct the backend for this custom accelerator, the initial step is defining the necessary pattern to annotate and
 # partition the supported operators.
-# After the partitioning process, any unsupported Relay and
-# QNN operators are handled using the default TVM flow, which
+#
+# After the partitioning process, any unsupported Relay and QNN operators are handled using the default TVM flow, which
 # includes the canonicalization pass to lower QNN operators to
 # existing Relay operators. Without canonicalizing in UMA pipeline, UMA lower cannot lower down
-# qnn.conv2d to TIR because it has no specified schedules and
-# implementations in TOPI. In other words, TVM requires the
-# user to provide a schedule, which is a description of how the
-# computation should be performed. To address this, we add a
-# strategy that specifies the computation and the schedule to be
-# used. In this case, the strategy is the TOPI implementation
-# for the qnn.conv2d operator, explicitly targeting the Hexagon
-# processor. 
-# Once the lowering process to TIR is completed, the TIR
-# pass is responsible for extracting essential data and parameters
+# qnn.conv2d to TIR because it has no specified schedules and implementations in TOPI. In other words, TVM requires the
+# user to provide a schedule, which is a description of how the computation should be performed. To address this, we add a
+# strategy that specifies the computation and the schedule to be used. In this case, the strategy is the TOPI implementation
+# for the qnn.conv2d operator, explicitly targeting the Hexagon processor. 
+#
+# Once the lowering process to TIR is completed, the TIR pass is responsible for extracting essential data and parameters
 # from the generated TIR representation to interface the generated code and the custom accelerator through the registered
-# C/C++ file in the codegen. This includes information such
-# as input feature, kernel, and bias data pointers, input and
-# kernel dimensions, as well as quantization zero points. In
-# the Vanilla example, the TIR pass is designed to handle
-# the computation block of the nn.conv2d operator. However,
-# for the QNN Conv2D operator, the TIR function depends
-# on the specified strategy, requiring adjustments to the pass.
-# Specifically, modifications are made to the pass to extract
-# data from the computation blocks based on the Hexagon
-# strategy, and provide the zero-point values for the quantized
+# C/C++ file in the codegen. This includes information such as input feature, kernel, and bias data pointers, input and
+# kernel dimensions, as well as quantization zero points. In the Vanilla example, the TIR pass is designed to handle
+# the computation block of the nn.conv2d operator. However, for the QNN Conv2D operator, the TIR function depends
+# on the specified strategy, requiring adjustments to the pass. Specifically, modifications are made to the pass to extract
+# data from the computation blocks based on the Hexagon strategy, and provide the zero-point values for the quantized
 # computation.
-# You can find the code blocks of QVanilla in this directory: 
+# You can find the code blocks of QVanilla in this directory: tvm/apps/uma/qvanilla.
 
 ###########################################################
 # Strawberry

--- a/gallery/tutorial/uma.py
+++ b/gallery/tutorial/uma.py
@@ -258,8 +258,7 @@ Making your Hardware Accelerator TVM-ready with UMA
 # QVanilla
 ===================================================
 # **Author**: Samira Ahmadifarsani
-# **Vanilla** accelerator is a modified version of Vanilla, which can process
-# QNN Conv2D followed by a bias addition operator.
+# **Vanilla** accelerator is a modified version of Vanilla, which can process QNN Conv2D followed by a bias addition operator. We need to deal with QNN operators for this example.
 # To construct the backend for this custom accelerator, the initial step is defining the necessary pattern to annotate and
 # partition the supported operators.
 #

--- a/gallery/tutorial/uma.py
+++ b/gallery/tutorial/uma.py
@@ -263,6 +263,33 @@ Making your Hardware Accelerator TVM-ready with UMA
 # To construct the backend for this custom accelerator, the
 # initial step is defining the necessary pattern to annotate and
 # partition the supported operators.
+# After the partitioning process, any unsupported Relay and
+# QNN operators are handled using the default TVM flow, which
+# includes the canonicalization pass to lower QNN operators to
+# existing Relay operators. Without canonicalizing in UMA pipeline, UMA lower cannot lower down
+# qnn.conv2d to TIR because it has no specified schedules and
+# implementations in TOPI. In other words, TVM requires the
+# user to provide a schedule, which is a description of how the
+# computation should be performed. To address this, we add a
+# strategy that specifies the computation and the schedule to be
+# used. In this case, the strategy is the TOPI implementation
+# for the qnn.conv2d operator, explicitly targeting the Hexagon
+# processor. 
+# Once the lowering process to TIR is completed, the TIR
+# pass is responsible for extracting essential data and parameters
+# from the generated TIR representation to interface the generated code and the custom accelerator through the registered
+# C/C++ file in the codegen. This includes information such
+# as input feature, kernel, and bias data pointers, input and
+# kernel dimensions, as well as quantization zero points. In
+# the Vanilla example, the TIR pass is designed to handle
+# the computation block of the nn.conv2d operator. However,
+# for the QNN Conv2D operator, the TIR function depends
+# on the specified strategy, requiring adjustments to the pass.
+# Specifically, modifications are made to the pass to extract
+# data from the computation blocks based on the Hexagon
+# strategy, and provide the zero-point values for the quantized
+# computation.
+# You can find the code blocks of QVanilla in this directory: 
 
 ###########################################################
 # Strawberry
@@ -282,33 +309,7 @@ Making your Hardware Accelerator TVM-ready with UMA
 # the TVM discuss forum: `Link <https://discuss.tvm.apache.org/t/rfc-uma-universal-modular-accelerator-interface/12039>`_.
 # We are eager to extend this tutorial to provide guidance on making further classes of AI hardware
 # accelerators TVM-ready using the UMA interface.
-# After the partitioning process, any unsupported Relay and
-# QNN operators are handled using the default TVM flow, which
-# includes the canonicalization pass to lower QNN operators to
-# existing Relay operators. Without canonicalizing in UMA pipeline, UMA lower cannot lower down
-# qnn.conv2d to TIR because it has no specified schedules and
-# implementations in TOPI. In other words, TVM requires the
-# user to provide a schedule, which is a description of how the
-# computation should be performed. To address this, we add a
-# strategy that specifies the computation and the schedule to be
-# used. In this case, the strategy is the TOPI implementation
-# for the qnn.conv2d operator, explicitly targeting the Hexagon
-# processor. 
-# Once the lowering process to TIR is completed, the TIR
-# pass is responsible for extracting essential data and parameters
-# from the generated TIR representation to interface the generated code and the custom accelerator through the registered
-C/C++ file in the codegen. This includes information such
-as input feature, kernel, and bias data pointers, input and
-kernel dimensions, as well as quantization zero points. In
-the Vanilla example, the TIR pass is designed to handle
-the computation block of the nn.conv2d operator. However,
-for the QNN Conv2D operator, the TIR function depends
-on the specified strategy, requiring adjustments to the pass.
-Specifically, modifications are made to the pass to extract
-data from the computation blocks based on the Hexagon
-strategy, and provide the zero-point values for the quantized
-computation.
-You can find the code blocks of QVanilla in this directory: 
+
 
 
 ######################################################################

--- a/gallery/tutorial/uma.py
+++ b/gallery/tutorial/uma.py
@@ -258,7 +258,7 @@ Making your Hardware Accelerator TVM-ready with UMA
 # QVanilla
 ===================================================
 # **Author**: Samira Ahmadifarsani
-# **Vanilla** accelerator is a modified version of Vanilla, which can process QNN Conv2D followed by a bias addition operator. We need to deal with QNN operators for this example.
+# **QVanilla** accelerator is a modified version of Vanilla, which can process QNN Conv2D followed by a bias addition operator. We need to deal with QNN operators for this example.
 # To construct the backend for this custom accelerator, the initial step is defining the necessary pattern to annotate and
 # partition the supported operators.
 #


### PR DESCRIPTION
Integration of a simple custom dedicated accelerator based on Vanilla (QVanilla) into TVM using UMA to offload the QNN
convolution operators. 

The main changes include:

1. adding the QVanilla description to gallery/tutorial/uma.py
2. adding the QVanilla backend structure to apps/uma/qvanilla

@MichaelJKlaiber thanks in advance for your support. Please let me know if there is a problem with the context or my request.