### PR TITLE
[Bugfix] Disable SingleEnvThreadVerifier

### DIFF
--- a/src/tir/analysis/verify_well_formed.cc
+++ b/src/tir/analysis/verify_well_formed.cc
@@ -347,7 +347,6 @@ bool VerifyWellFormed(const PrimFunc& func, bool assert_mode) {
   }
 
   if (!UndefinedVarVerifier::Verify(func, assert_mode)) return false;
-  if (!SingleEnvThreadVerifier::Verify(func, assert_mode)) return false;
 
   // TODO(Siyuan): add more checks here.
   return true;
@@ -364,7 +363,6 @@ bool VerifyWellFormed(const IRModule& mod, bool assert_mode) {
   }
 
   if (!UndefinedVarVerifier::Verify(mod, assert_mode)) return false;
-  if (!SingleEnvThreadVerifier::Verify(mod, assert_mode)) return false;
 
   return true;
 }


### PR DESCRIPTION
During TensorIR scheduling, the `IterVar`s that represent environment threads may duplicate, i.e. it is legal to have two env threads with the same name tag, which may fail the `SingleEnvThreadVerifier` check during schedule creation. This PR disables this check in this case. In the future, it may be worthwhile to bring it back against post-scheduling TIR.

It's related to [this commit](https://github.com/apache/tvm/commit/eb15d04c3bff76062e26d5647fb8af0323de1bed). CC: @jinhongyii @Lunderberg 