### PR TITLE
[CI] Upgrade sccache version to 0.7.*

### DIFF
--- a/docker/install/ubuntu_install_boost.sh
+++ b/docker/install/ubuntu_install_boost.sh
@@ -27,7 +27,7 @@ trap cleanup 0
 # NOTE: by default, tvm-venv python is used. Install boost on the system.
 PATH=${PATH/${TVM_VENV}\/bin:/}
 
-curl -LO https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.gz
+curl -LO https://archives.boost.io/release/1.67.0/source/boost_1_67_0.tar.gz
 BOOST_HASH=8c247e040303a97895cee9c9407ef205e2c3ab09f0b8320997835ad6221dff23a87231629498ccfd0acca473f74e9ec27b8bd774707b062228df1e5f72d44c92
 echo "$BOOST_HASH" boost_1_67_0.tar.gz | sha512sum -c
 tar -xf boost_1_67_0.tar.gz

--- a/docker/install/ubuntu_install_sccache.sh
+++ b/docker/install/ubuntu_install_sccache.sh
@@ -20,7 +20,7 @@ set -e
 set -u
 set -o pipefail
 
-cargo install --version 0.3.3 sccache
+cargo install --version 0.7.* sccache
 
 # The docs specifically recommend hard links: https://github.com/mozilla/sccache#known-caveats
 mkdir /opt/sccache


### PR DESCRIPTION
Sccache was previously pinned at version 0.3.3, however, there has recently been an issue when installing some of its dependencies:

```
error[E0277]: expected a `Fn(reqwest::Request, &'a mut task_local_extensions::extensions::Extensions, reqwest_middleware::Next<'a>)` closure, found `RetryAfterMiddleware`
```

Upgrading the version of sccache to the latest seems to resolve this error.

In addition, the JFrog artifactory link for boost has been flaky recently, so changing to an alternative
mirror suggested in https://github.com/boostorg/boost/issues/842.