### PR TITLE
[Unity][TVMScript] Update `call_packed` semantics to support empty sinfo_args

### DIFF
--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -330,7 +330,7 @@ def output(*vars: Tuple[Var]) -> None:
 def call_packed(
     func: py_str,
     *args: Expr,
-    sinfo_args: Union[StructInfo, List[StructInfo]],
+    sinfo_args: Optional[Union[StructInfo, List[StructInfo]]] = None,
     **kwargs: Any,
 ) -> Call:
     """Create a relax Call, which calls a packed function.
@@ -340,7 +340,7 @@ def call_packed(
         The name of extern function.
     *args : Expr
         The arguments.
-    sinfo_args: Union[StructInfo, List[StructInfo]]
+    sinfo_args: Optional[Union[StructInfo, List[StructInfo]]]
         The list of structure info arguments.
     kwargs: Expr
         The keyword arguments.
@@ -352,7 +352,7 @@ def call_packed(
     """
     op = ExternFunc(func)
     if sinfo_args is None:
-        raise ValueError("R.call_packed is required to have type_args")
+        sinfo_args = []
     if isinstance(sinfo_args, py_tuple):  # type: ignore
         sinfo_args = list(sinfo_args)
     elif not isinstance(sinfo_args, list):

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -842,6 +842,28 @@ def test_call_packed():
     _check(foo, bb.get()["foo"])
 
 
+def test_call_packed_without_sinfo_args():
+    @R.function
+    def foo(x: R.Object) -> R.Object:
+        z = R.call_packed("test", x)
+        return z
+
+    x = relax.Var("x", R.Object())
+    bb = relax.BlockBuilder()
+    with bb.function("foo", (x)):
+        z = bb.emit(
+            relax.Call(
+                relax.ExternFunc("test"),
+                (x,),
+                None,
+                sinfo_args=[],
+            )
+        )
+        bb.emit_func_output(z)
+
+    _check(foo, bb.get()["foo"])
+
+
 def test_annotation():
     @R.function
     def foo(


### PR DESCRIPTION
In low-level Relax (after the pass `CallTIRewrite`), the `call_packed` nodes do not always have explicit `sinfo_args`. This PR extends the parser to support this case.