### PR TITLE
[microTVM] Update target in arduino tutorial

### DIFF
--- a/gallery/how_to/work_with_microtvm/micro_train.py
+++ b/gallery/how_to/work_with_microtvm/micro_train.py
@@ -456,7 +456,7 @@ except AttributeError:  # Fall back to TFLite 1.14 method
 mod, params = tvm.relay.frontend.from_tflite(tflite_model)
 
 # Set configuration flags to improve performance
-target = tvm.micro.testing.get_target("zephyr", "nrf5340dk_nrf5340_cpuapp")
+target = tvm.micro.testing.get_target("arduino", "nano33ble")
 runtime = tvm.relay.backend.Runtime("crt")
 executor = tvm.relay.backend.Executor("aot", {"unpacked-api": True})
 


### PR DESCRIPTION
I noticed that the target is set to a different board than is used in that tutorial. This leads the Arduino IDE to fail compiling for the Nano 33 BLE, in my experience.