### PR TITLE
[OpenCL][CMake] Fix OpenCL tests compilation

### DIFF
--- a/cmake/modules/OpenCL.cmake
+++ b/cmake/modules/OpenCL.cmake
@@ -81,7 +81,7 @@ if(USE_OPENCL)
     if(Build_OpenCL_GTests)
         message(STATUS "Building OpenCL-Gtests")
         tvm_file_glob(GLOB_RECURSE OPENCL_TEST_SRCS
-          "${CMAKE_SOURCE_DIR}/tests/cpp-runtime/opencl/*.cc"
+          "tests/cpp-runtime/opencl/*.cc"
         )
         add_executable(opencl-cpptest ${OPENCL_TEST_SRCS})
         target_link_libraries(opencl-cpptest PRIVATE gtest_main tvm_runtime)


### PR DESCRIPTION
Found a problem when you are in a different cmake project (not TVM) and you run TVM build with OpenCL tests, then `CMAKE_SOURCE_DIR` returns the path to the `CMakeList.txt` in the current project (not to the TVM) and in this case we will see the following error: `No SOURCES given to target: opencl-cpptest`.

To be consistent with code style in `OpenCL.cmake`, I removed the usage of `CMAKE_SOURCE_DIR` variable. It also fixes the issue if TVM cmake was called from directory with another cmake project.