### PR TITLE
[Relax][Frontend][ONNX]fix onnx frontend parse

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1983,8 +1983,8 @@ class ONNXGraphImporter:
         with self.bb.function("main"):
             with self.bb.dataflow() as df:  # pylint: disable=invalid-name, unused-variable
                 self.opset = opset
-                self._parse_graph_input(graph)
                 self._parse_graph_initializers(graph)
+                self._parse_graph_input(graph)
                 self._check_for_unsupported_ops(graph)
                 self._construct_nodes(graph)
 


### PR DESCRIPTION
_parse_graph_initializers should be first than _parse_graph_input.
Because the conditional statement in _parse_graph_input requires the use of self._nodes, and self._nodes is parsed and populated in _parse_graph_initializers, otherwise self._nodes will remain empty.