### PR TITLE
[Bugfix][ROCm] Handle tvm_thread_invariant in ROCm backend

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1476,6 +1476,8 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
   } else if (op->op.same_as(builtin::assume())) {
     llvm::Value* cond = MakeValue(op->args[0]);
     return builder_->CreateAssumption(cond);
+  } else if (op->op.same_as(builtin::tvm_thread_invariant())) {
+    return MakeValue(op->args[0]);
   } else {
     LOG(FATAL) << "unknown intrinsic " << op->op;
   }


### PR DESCRIPTION
PR #16345 introduced a TIR intrinsic `tvm_thread_invariant` as a no-op intrinsic that indicates that a condition is an invariant across threads. It is a necessary change to support MoE group GEMM operations.

However, we noticed that the LLVM-ROCm backend has been broken since then because this no-op intrinsic hasn't been properly handled in this particular backend. This PR fixes this behavior by checking this no-op in the LLVM backend.

CC: @spectrometerHBH @yzhliu @tqchen 