### PR TITLE
[TIR] Fix of inter thread reduction with shared memory prefetch

### DIFF
--- a/src/tir/transforms/lower_cross_thread_reduction.cc
+++ b/src/tir/transforms/lower_cross_thread_reduction.cc
@@ -252,7 +252,7 @@ class InThreadReducerMaker : private StmtMutator {
       For res = opt_res.value();
       if (res->thread_binding.defined()) {
         UnderLoopReductionBlockVarCollector collector;
-        if (collector.CheckHasReductionBlocks(res)) {
+        if (!res->body.defined() || collector.CheckHasReductionBlocks(res)) {
           return res->body;
         }
         return std::move(res);

--- a/src/tir/transforms/lower_cross_thread_reduction.cc
+++ b/src/tir/transforms/lower_cross_thread_reduction.cc
@@ -198,6 +198,37 @@ class BufferReplacer : private StmtExprMutator {
  */
 class InThreadReducerMaker : private StmtMutator {
  public:
+  /*!
+   * \brief Visitor class to collect all reduction block variables under a loop.
+   */
+  class UnderLoopReductionBlockVarCollector : public StmtVisitor {
+   public:
+    /*!
+     * \brief Check if the given statement has any reduction blocks.
+     * \param stmt The statement to check.
+     * \return True if the statement has reduction blocks, false otherwise.
+     */
+    static bool CheckHasReductionBlocks(const Stmt& stmt) {
+      UnderLoopReductionBlockVarCollector collector;
+      collector(stmt);
+      return collector.reduction_block_vars_.size() > 0;
+    }
+
+   private:
+    void VisitStmt_(const BlockNode* block) final {
+      Array<IterVar> iter_vars = block->iter_vars;
+      for (const IterVar& iter_var : block->iter_vars) {
+        if (iter_var->iter_type == kCommReduce) {
+          reduction_block_vars_.push_back(iter_var);
+        }
+      }
+      StmtVisitor::VisitStmt_(block);
+    }
+
+    /*! \brief the map from thread tag to its extent */
+    Array<IterVar> reduction_block_vars_;
+  };
+
   static Optional<Stmt> Make(const BlockRealizeNode* src_realize,
                              Optional<BlockRealize> tgt_realize, Stmt stmt) {
     return InThreadReducerMaker(src_realize, std::move(tgt_realize))(std::move(stmt));
@@ -220,7 +251,11 @@ class InThreadReducerMaker : private StmtMutator {
     if (Optional<For> opt_res = Downcast<Optional<For>>(StmtMutator::VisitStmt_(loop))) {
       For res = opt_res.value();
       if (res->thread_binding.defined()) {
-        return res->body;
+        UnderLoopReductionBlockVarCollector collector;
+        if (collector.CheckHasReductionBlocks(res)) {
+          return res->body;
+        }
+        return std::move(res);
       } else {
         return std::move(res);
       }


### PR DESCRIPTION
This is a fix of `LowerCrossThreadReduction`: The pass will remove all the loops with thread bind under the inter thread reduction block, which will introduce some issues when we meet the case where there could be other non-reduction blocks under the reduction thread.

Before removing a thread-bound loop, check if the block(s) under this loop has reduction block var. If the block(s) under have reduction do not have any reduction block var, it means that block is not reduction, and therefore this thread-bound loop should be kept. Otherwise, we remove the thread-bound loop as usual.

related discussion: https://discuss.tvm.apache.org/t/missing-thread-bind-loops-under-block-reduction-when-transformed-with-tir/16232/6

Please CC @MasterJH5574 