### PR TITLE
[RUNTIME][Memory] Implement support for non-zero offset within a storage object in AllocNDArr…

### DIFF
--- a/src/runtime/memory/memory_manager.cc
+++ b/src/runtime/memory/memory_manager.cc
@@ -102,6 +102,14 @@ NDArray StorageObj::AllocNDArray(size_t offset, ShapeTuple shape, DLDataType dty
   // buffer intact.
   container->manager_ctx = reinterpret_cast<void*>(this);
 
+  if (this->buffer.device.device_type == kDLHexagon) {
+    // For Hexagon, non-zero offset support simply requires adjusting the
+    // beginning of data pointer
+    auto offset_ptr = reinterpret_cast<uint8_t*>(this->buffer.data) + offset;
+    container->dl_tensor.data = reinterpret_cast<void*>(offset_ptr);
+    container->dl_tensor.byte_offset = 0;
+  }
+
   NDArray ret(GetObjectPtr<Object>(container));
   // RAII in effect, now run the check.
 


### PR DESCRIPTION
…ay for Hexagon

This is needed for supporting a new static memory planner which allocates a single storage object, and uses non-overlapping offset ranges within the storage object to allocate tensors.

Allocating a storage object is an expensive operation involving OS, whereas tensor allocation (using AllocNDArray) is much less expensive.