### PR TITLE
[Target] Use LLVM target parser for determining Arm(R) A-Profile Architecture features

### DIFF
--- a/python/tvm/target/codegen.py
+++ b/python/tvm/target/codegen.py
@@ -183,7 +183,8 @@ def llvm_get_cpu_features(target=None):
         List of available CPU features.
     """
     assert isinstance(target, Target) or target is None
-    return _ffi_api.llvm_get_cpu_features(target)
+    feature_map = _ffi_api.llvm_get_cpu_features(target)
+    return set(feature_map.keys())
 
 
 def llvm_cpu_has_features(cpu_features, target=None):

--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -262,7 +262,7 @@ LLVMTargetInfo::LLVMTargetInfo(LLVMInstance& instance, const TargetJSON& target)
   }
 
   // LLVM JIT engine options
-  if (const Optional<String>& v = target->GetAttr<String>("jit")) {
+  if (const auto& v = Downcast<Optional<String>>(target.Get("jit"))) {
     String value = v.value();
     if ((value == "mcjit") || (value == "orcjit")) {
       jit_engine_ = value;

--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -225,7 +225,7 @@ LLVMTargetInfo::LLVMTargetInfo(LLVMInstance& instance, const TargetJSON& target)
       // give the code a chance to run with a less-specific target.
       LOG(ERROR) << "LLVM cpu architecture `-mcpu=" << cpu_
                  << "` is not valid in `-mtriple=" << triple_ << "`"
-                 << ", cpu architecture ignored";
+                 << ", using default `-mcpu=" << String(defaults::cpu) << "`";
     }
   }
 

--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -221,8 +221,11 @@ LLVMTargetInfo::LLVMTargetInfo(LLVMInstance& instance, const TargetJSON& target)
     bool has_arch =
         std::any_of(arches.begin(), arches.end(), [&](const auto& var) { return var == cpu_; });
     if (!has_arch) {
-      LOG(FATAL) << "LLVM cpu architecture `-mcpu=" << cpu_
-                 << "` is not valid in `-mtriple=" << triple_ << "`";
+      // Flag an error, but don't abort. This mimicks the behaviour of 'llc' to
+      // give the code a chance to run with a less-specific target.
+      LOG(ERROR) << "LLVM cpu architecture `-mcpu=" << cpu_
+                 << "` is not valid in `-mtriple=" << triple_ << "`"
+                 << ", cpu architecture ignored";
     }
   }
 

--- a/src/target/llvm/llvm_instance.h
+++ b/src/target/llvm/llvm_instance.h
@@ -157,6 +157,14 @@ class LLVMTargetInfo {
   // NOLINTNEXTLINE(runtime/references)
   LLVMTargetInfo(LLVMInstance& scope, const std::string& target_str);
   /*!
+   * \brief Constructs LLVMTargetInfo from `Target`
+   * \param scope LLVMInstance object
+   * \param target TVM JSON Target object for target "llvm"
+   */
+  // NOLINTNEXTLINE(runtime/references)
+  LLVMTargetInfo(LLVMInstance& instance, const TargetJSON& target);
+
+  /*!
    * \brief Destroys LLVMTargetInfo object
    */
   ~LLVMTargetInfo();
@@ -290,11 +298,12 @@ class LLVMTargetInfo {
 
   /*!
    * \brief Get all CPU features from target
-   * \return list with all valid cpu features
+   * \return Map with all valid cpu features as keys and empty string as value. The Map
+   *         is intended to be used as a Set, which TVM does not currently support.
    * \note The features are fetched from the LLVM backend using the target `-mtriple`
    *       and the `-mcpu` architecture, but also consider the `-mattr` attributes.
    */
-  const Array<String> GetAllLLVMCpuFeatures() const;
+  const Map<String, String> GetAllLLVMCpuFeatures() const;
 
   /*!
    * \brief Check the target if has a specific cpu feature

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -697,12 +697,12 @@ TVM_REGISTER_GLOBAL("target.llvm_get_cpu_archlist")
     });
 
 TVM_REGISTER_GLOBAL("target.llvm_get_cpu_features")
-    .set_body_typed([](const Target& target) -> Array<String> {
+    .set_body_typed([](const Target& target) -> Map<String, String> {
       auto use_target = target.defined() ? target : Target::Current(false);
       // ignore non "llvm" target
       if (target.defined()) {
         if (target->kind->name != "llvm") {
-          return Array<String>{};
+          return {};
         }
       }
       auto llvm_instance = std::make_unique<LLVMInstance>();
@@ -722,8 +722,7 @@ TVM_REGISTER_GLOBAL("target.llvm_cpu_has_feature")
       auto llvm_instance = std::make_unique<LLVMInstance>();
       LLVMTargetInfo llvm_backend(*llvm_instance, use_target);
       auto cpu_features = llvm_backend.GetAllLLVMCpuFeatures();
-      bool has_feature = std::any_of(cpu_features.begin(), cpu_features.end(),
-                                     [&](auto& var) { return var == feature; });
+      bool has_feature = cpu_features.find(feature) != cpu_features.end();
       return has_feature;
     });
 

--- a/src/target/parsers/aprofile.cc
+++ b/src/target/parsers/aprofile.cc
@@ -24,9 +24,11 @@
 
 #include "aprofile.h"
 
+#include <memory>
 #include <string>
 
 #include "../../support/utils.h"
+#include "../llvm/llvm_instance.h"
 
 namespace tvm {
 namespace target {
@@ -52,33 +54,6 @@ double GetArchVersion(Optional<Array<String>> attr) {
   return GetArchVersion(attr.value());
 }
 
-static inline bool HasFlag(String attr, std::string flag) {
-  std::string attr_str = attr;
-  return attr_str.find(flag) != std::string::npos;
-}
-
-static inline bool HasFlag(Optional<String> attr, std::string flag) {
-  if (!attr) {
-    return false;
-  }
-  return HasFlag(attr.value(), flag);
-}
-
-static inline bool HasFlag(Optional<Array<String>> attr, std::string flag) {
-  if (!attr) {
-    return false;
-  }
-  Array<String> attr_array = attr.value();
-
-  auto matching_attr = std::find_if(attr_array.begin(), attr_array.end(),
-                                    [flag](String attr_str) { return HasFlag(attr_str, flag); });
-  return matching_attr != attr_array.end();
-}
-
-static bool HasFlag(Optional<String> mcpu, Optional<Array<String>> mattr, std::string flag) {
-  return HasFlag(mcpu, flag) || HasFlag(mattr, flag);
-}
-
 bool IsAArch32(Optional<String> mtriple, Optional<String> mcpu) {
   if (mtriple) {
     bool is_mprofile = mcpu && support::StartsWith(mcpu.value(), "cortex-m");
@@ -102,38 +77,25 @@ bool IsArch(TargetJSON attrs) {
 }
 
 static TargetFeatures GetFeatures(TargetJSON target) {
-  Optional<String> mcpu = Downcast<Optional<String>>(target.Get("mcpu"));
+  String kind = Downcast<String>(target.Get("kind"));
+  ICHECK_EQ(kind, "llvm") << "Expected target kind 'llvm', but got '" << kind << "'";
+
   Optional<String> mtriple = Downcast<Optional<String>>(target.Get("mtriple"));
-  Optional<Array<String>> mattr = Downcast<Optional<Array<String>>>(target.Get("mattr"));
 
-  const double arch_version = GetArchVersion(mattr);
+  auto llvm_instance = std::make_unique<codegen::LLVMInstance>();
+  codegen::LLVMTargetInfo llvm_target(*llvm_instance, target);
+  Map<String, String> features = llvm_target.GetAllLLVMCpuFeatures();
 
-  const bool is_aarch64 = IsAArch64(mtriple);
+  auto has_feature = [features](const String& feature) {
+    return features.find(feature) != features.end();
+  };
 
-  const bool simd_flag = HasFlag(mcpu, mattr, "+neon") || HasFlag(mcpu, mattr, "+simd");
-  const bool has_asimd = is_aarch64 || simd_flag;
-  const bool has_sve = HasFlag(mcpu, mattr, "+sve");
-
-  const bool i8mm_flag = HasFlag(mcpu, mattr, "+i8mm");
-  const bool i8mm_disable = HasFlag(mcpu, mattr, "+noi8mm");
-  const bool i8mm_default = arch_version >= 8.6;
-  const bool i8mm_support = arch_version >= 8.2 && arch_version <= 8.5;
-  const bool has_i8mm = (i8mm_default && !i8mm_disable) || (i8mm_support && i8mm_flag);
-
-  const bool dotprod_flag = HasFlag(mcpu, mattr, "+dotprod");
-  const bool dotprod_disable = HasFlag(mcpu, mattr, "+nodotprod");
-  const bool dotprod_default = arch_version >= 8.4;
-  const bool dotprod_support = arch_version >= 8.2 && arch_version <= 8.3;
-  const bool has_dotprod =
-      (dotprod_default && !dotprod_disable) || (dotprod_support && dotprod_flag);
-
-  const bool fp16_flag = HasFlag(mcpu, mattr, "+fullfp16");
-  const bool fp16_support = arch_version >= 8.2;
-  const bool has_fp16_simd = fp16_support && (fp16_flag || has_sve);
-
-  return {{"is_aarch64", Bool(is_aarch64)},  {"has_asimd", Bool(has_asimd)},
-          {"has_sve", Bool(has_sve)},        {"has_dotprod", Bool(has_dotprod)},
-          {"has_matmul_i8", Bool(has_i8mm)}, {"has_fp16_simd", Bool(has_fp16_simd)}};
+  return {{"is_aarch64", Bool(IsAArch64(mtriple))},
+          {"has_asimd", Bool(has_feature("neon"))},
+          {"has_sve", Bool(has_feature("sve"))},
+          {"has_dotprod", Bool(has_feature("dotprod"))},
+          {"has_matmul_i8", Bool(has_feature("i8mm"))},
+          {"has_fp16_simd", Bool(has_feature("fullfp16"))}};
 }
 
 static Array<String> MergeKeys(Optional<Array<String>> existing_keys) {

--- a/src/target/parsers/aprofile.cc
+++ b/src/target/parsers/aprofile.cc
@@ -82,8 +82,8 @@ static TargetFeatures GetFeatures(TargetJSON target) {
 
   Optional<String> mtriple = Downcast<Optional<String>>(target.Get("mtriple"));
 
-  auto llvm_instance = std::make_unique<codegen::LLVMInstance>();
-  codegen::LLVMTargetInfo llvm_target(*llvm_instance, target);
+  auto llvm_instance = std::make_unique<tvm::codegen::LLVMInstance>();
+  tvm::codegen::LLVMTargetInfo llvm_target(*llvm_instance, target);
   Map<String, String> features = llvm_target.GetAllLLVMCpuFeatures();
 
   auto has_feature = [features](const String& feature) {

--- a/src/target/parsers/aprofile.cc
+++ b/src/target/parsers/aprofile.cc
@@ -90,7 +90,7 @@ static TargetFeatures GetFeatures(TargetJSON target) {
 
   // Check that LLVM has been compiled with the correct target support
   auto llvm_instance = std::make_unique<codegen::LLVMInstance>();
-  codegen::LLVMTargetInfo llvm_backend(*llvm_instance, "llvm");
+  codegen::LLVMTargetInfo llvm_backend(*llvm_instance, {{"kind", String("llvm")}});
   Array<String> targets = llvm_backend.GetAllLLVMTargets();
   if ((IsAArch64(mtriple) && !CheckContains(targets, "aarch64")) ||
       (IsAArch32(mtriple, mcpu) && !CheckContains(targets, "arm"))) {

--- a/tests/cpp/target/parsers/aprofile_test.cc
+++ b/tests/cpp/target/parsers/aprofile_test.cc
@@ -40,6 +40,7 @@ static float defaultDotProd = 8.4;
 static float optionalDotProd[] = {8.2, 8.3};
 
 static bool CheckArchitectureAvailability() {
+#if TVM_LLVM_VERSION > 120
   auto llvm_instance = std::make_unique<codegen::LLVMInstance>();
   codegen::LLVMTargetInfo llvm_backend(*llvm_instance, "llvm");
   Array<String> targets = llvm_backend.GetAllLLVMTargets();
@@ -52,6 +53,7 @@ static bool CheckArchitectureAvailability() {
   if (expected_target_count >= 2) {
     return true;
   }
+#endif
   return false;
 }
 static bool has_aarch64_and_arm_targets = CheckArchitectureAvailability();

--- a/tests/python/relay/strategy/test_select_implementation.py
+++ b/tests/python/relay/strategy/test_select_implementation.py
@@ -27,6 +27,7 @@ from tvm import te
 from tvm.relay.testing import run_infer_type, run_opt_pass
 import tvm.testing
 from tvm import topi
+from tvm.target.codegen import llvm_version_major
 
 
 @pytest.mark.parametrize(
@@ -90,6 +91,9 @@ def _get_conv2d_impl(dtype, target):
     return impl.name
 
 
+@pytest.mark.skipif(
+    llvm_version_major() < 15, reason=f"Requires LLVM 15+, got {llvm_version_major()}"
+)
 @pytest.mark.parametrize(
     "target,expected_impl",
     [
@@ -131,6 +135,9 @@ def test_int8_conv2d(target, expected_impl):
     assert selected_impl == expected_impl
 
 
+@pytest.mark.skipif(
+    llvm_version_major() < 15, reason=f"Requires LLVM 15+, got {llvm_version_major()}"
+)
 @pytest.mark.parametrize(
     "target,expected_impl",
     [
@@ -164,6 +171,9 @@ def test_fp32_conv2d(target, expected_impl):
     assert selected_impl == expected_impl
 
 
+@pytest.mark.skipif(
+    llvm_version_major() < 15, reason=f"Requires LLVM 15+, got {llvm_version_major()}"
+)
 @pytest.mark.parametrize(
     "target,expected_impl",
     [

--- a/tests/python/relay/strategy/test_select_implementation.py
+++ b/tests/python/relay/strategy/test_select_implementation.py
@@ -119,7 +119,7 @@ def _get_conv2d_impl(dtype, target):
         ),
         (
             "llvm --device=arm_cpu --mtriple=aarch64-linux-gnu -mattr=+v9a",
-            "conv2d_NHWC_quantized_interleaved_without_transform.arm_cpu",
+            "conv2d_NHWC_quantized_native_without_transform.arm_cpu",
         ),
     ],
 )

--- a/tests/python/target/test_llvm_features_info.py
+++ b/tests/python/target/test_llvm_features_info.py
@@ -42,8 +42,10 @@ def test_llvm_targets(capfd):
     tvm.target.codegen.llvm_get_cpu_features(
         tvm.target.Target("llvm -mtriple=x86_64-linux-gnu -mcpu=dummy")
     )
-    expected_str = ("Error: LLVM cpu architecture `-mcpu=dummy` is not valid in "
-                    "`-mtriple=x86_64-linux-gnu`, cpu architecture ignored")
+    expected_str = (
+        "Error: LLVM cpu architecture `-mcpu=dummy` is not valid in "
+        "`-mtriple=x86_64-linux-gnu`, using default `-mcpu=generic`"
+    )
     assert expected_str in capfd.readouterr().err
 
 

--- a/tests/python/target/test_llvm_features_info.py
+++ b/tests/python/target/test_llvm_features_info.py
@@ -39,21 +39,6 @@ def test_llvm_targets():
     assert codegen.llvm_get_system_x86_vendor() == _ffi_api.llvm_get_system_x86_vendor()
     assert str(codegen.llvm_get_targets()) == str(_ffi_api.llvm_get_targets())
 
-    # check LLVM target -mcpu legality
-    try:
-        tvm.target.codegen.llvm_get_cpu_features(
-            tvm.target.Target("llvm -mtriple=x86_64-linux-gnu -mcpu=dummy")
-        )
-        assert False
-    except tvm.error.TVMError as e:
-        msg = str(e)
-        assert (
-            msg.find(
-                "TVMError: LLVM cpu architecture `-mcpu=dummy` is not valid in `-mtriple=x86_64-linux-gnu`"
-            )
-            != -1
-        )
-
 
 min_llvm_version, llvm_target, cpu_arch, cpu_features, is_supported = tvm.testing.parameters(
     (-1, "x86_64", "sandybridge", "sse4.1", True),

--- a/tests/python/target/test_llvm_features_info.py
+++ b/tests/python/target/test_llvm_features_info.py
@@ -22,7 +22,7 @@ from tvm.target import _ffi_api, codegen, Target
 LLVM_VERSION = codegen.llvm_version_major()
 
 
-def test_llvm_targets():
+def test_llvm_targets(capfd):
 
     ##
     ## check LLVM backend
@@ -38,6 +38,13 @@ def test_llvm_targets():
     assert codegen.llvm_get_system_triple() == _ffi_api.llvm_get_system_triple()
     assert codegen.llvm_get_system_x86_vendor() == _ffi_api.llvm_get_system_x86_vendor()
     assert str(codegen.llvm_get_targets()) == str(_ffi_api.llvm_get_targets())
+
+    tvm.target.codegen.llvm_get_cpu_features(
+        tvm.target.Target("llvm -mtriple=x86_64-linux-gnu -mcpu=dummy")
+    )
+    expected_str = ("Error: LLVM cpu architecture `-mcpu=dummy` is not valid in "
+                    "`-mtriple=x86_64-linux-gnu`, cpu architecture ignored")
+    assert expected_str in capfd.readouterr().err
 
 
 min_llvm_version, llvm_target, cpu_arch, cpu_features, is_supported = tvm.testing.parameters(


### PR DESCRIPTION
Currently, target features are determined by a set of fixed checks on the target string. This works well for checking support of a small number of simple features, but it doesn't scale. Some problems include:
- There are many non-trivial conditions for which a feature may(not) be available. It is easy to miss these with the current implementation.
- The inclusion of some features in a target string can imply other features. For example, "+sve2" implies "+sve". This currently isn't taken into account.
- The tests in tests/cpp/target/parsers/aprofile_test.c suggest that targets such as "llvm -mcpu=cortex-a+neon" and "llvm -mattr=+noneon" are supported target strings. The features will be correctly parsed in TVM, however, they are not valid in LLVM. Therefore, it's possible that TVM and LLVM have different understanding of the features available.

This commit uses the more robust LLVM target parser to determine support for the features in TVM. It leverages previous infrastructure added to TVM for obtaining a list of all supported features given an input target, and uses this to check the existance of certain features we're interested in. It should be trivial to grow this list over time. As a result of this change, the problems mentioned above are solved.

In the current form, this commit drops support for target strings such as "llvm -mcpu=cortex-a+neon" and "llvm -mattr=+noneon". A scan of the codebase suggests this functionality is not in use (only in test cases). Should we feel the need to support them, or have a smoother migration for downstream users of TVM we can add a translator to the parser to convert these into LLVM compatible targets.

cc @Mousius @cbalint13 @ekalda @neildhickey