### PR TITLE
[Unity][Dlight][Fix] Reduction rule support dyn-shape epilogue

### DIFF
--- a/python/tvm/dlight/gpu/reduction.py
+++ b/python/tvm/dlight/gpu/reduction.py
@@ -281,7 +281,7 @@ class Reduction(GPUScheduleRule):
         # Schedule epilogue
         if epilogue_info is not None:
             epilogue = epilogue_info.block_rv
-            sch.reverse_compute_at(epilogue, bx)
+            sch.reverse_compute_at(epilogue, bx, preserve_unit_loops=True)
             if is_broadcast_epilogue(sch, block, epilogue):
                 sch.set_scope(block, 0, "shared")
                 _, *s = sch.get_loops(epilogue)  # pylint: disable=invalid-name


### PR DESCRIPTION
This PR fixes a bug in the dlight reduction rule, which fails to recognize the pattern of a dynamic-shape epilogue block and therefore errors out when transforming such blocks.

One regression test is provided.