### PR TITLE
[BugFix]Ensure that bf16 arrays are created as expected

### DIFF
--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -176,6 +176,8 @@ class NDArray(NDArrayBase):
         if (not source_array.flags["C_CONTIGUOUS"]) or (
             dtype == "bfloat16" or dtype != np_dtype_str
         ):
+            if dtype == "bfloat16":
+                source_array = np.frombuffer(source_array.tobytes(), "uint16")
             source_array = np.ascontiguousarray(
                 source_array, dtype="uint16" if dtype == "bfloat16" else dtype
             )


### PR DESCRIPTION
If we use the bfloat16 type of ml_dtypes to create an array of tvm.ndarray, the result of the created tvm.ndarray will be wrong.

```python
x = np.random.uniform(low=0.3, high=13.3, size=shape).astype(ml_dtypes.bfloat16)
# The values of x_ndarray and x are inconsistent!
x_ndarray = tvm.nd.array(x)
```

I understand that the reason for this error is that we have not considered that the input passed in is ml_dtypes.bfloat16. The np_float2np_bf16 function that has been used in the past (this function will convert the fp32 type numpy array into a uint16 numpy array)