### PR TITLE
Revert "[Unity] Split DecomposeOpsForTraining into two steps"

### DIFF
--- a/include/tvm/ir/transform.h
+++ b/include/tvm/ir/transform.h
@@ -525,31 +525,6 @@ TVM_DLL Pass CreateModulePass(
     const runtime::TypedPackedFunc<IRModule(IRModule, PassContext)>& pass_func, int opt_level,
     String name, Array<runtime::String> required, bool traceable = false);
 
-/*
- * \brief Utility to apply a pass to specific functions in an IRModule
- *
- * TVM uses IRModule to IRModule transformations at all stages of
- * lowering.  These transformations may be useful when hand-writing an
- * optimized model, or to perform optimizations on specific kernels
- * within an IRModule.  This utility allows a pass to be applied to a
- * specified function, without altering other functions in the module.
- *
- * \param pass The IRModule to IRModule pass to be applied.
- *
- * \param func_name_regex A regex used to select the functions to be
- * updated.  The pass will be applied to all functions whose name
- * matches the regex.
- *
- * \param error_if_no_function_matches_regex Specifies the behavior if
- *     an IRModule does not contain any function matching the provided
- *     regex.  If true, an error will be raised.  If false (default),
- *     the IRModule will be returned unmodified.
- *
- * \return The modified IRModule to IRModule pass.
- */
-TVM_DLL Pass ApplyPassToFunction(Pass pass, String func_name_regex,
-                                 bool error_if_no_function_matches_regex = false);
-
 /*!
  * \brief A special trace pass that prints the header and IR to LOG(INFO).
  * \param header The header to be attached to the output.

--- a/src/ir/transform.cc
+++ b/src/ir/transform.cc
@@ -31,7 +31,6 @@
 
 #include <chrono>
 #include <iomanip>
-#include <regex>
 #include <stack>
 #include <unordered_set>
 
@@ -530,36 +529,6 @@ Pass CreateModulePass(const runtime::TypedPackedFunc<IRModule(IRModule, PassCont
                       int opt_level, String name, tvm::Array<String> required, bool traceable) {
   PassInfo pass_info = PassInfo(opt_level, name, required, traceable);
   return ModulePass(pass_func, pass_info);
-}
-
-Pass ApplyPassToFunction(Pass pass, String func_name_regex,
-                         bool error_if_no_function_matches_regex) {
-  auto pass_name =
-      static_cast<const std::stringstream&>(std::stringstream() << "ApplyPassTo" << func_name_regex)
-          .str();
-  std::regex regex(func_name_regex.operator std::string());
-
-  auto pass_func = [pass, regex](IRModule mod, PassContext) -> IRModule {
-    IRModule subset;
-
-    for (const auto& [gvar, func] : mod->functions) {
-      std::string name = gvar->name_hint;
-      if (std::regex_match(name, regex)) {
-        subset->Add(gvar, func);
-      }
-    }
-
-    if (subset->functions.size()) {
-      IRModule new_subset = pass(subset);
-      if (!new_subset.same_as(subset)) {
-        mod.CopyOnWrite()->Update(new_subset);
-      }
-    }
-
-    return mod;
-  };
-
-  return CreateModulePass(pass_func, 0, pass_name, {});
 }
 
 TVM_REGISTER_NODE_TYPE(PassInfoNode);

--- a/tests/python/relax/test_transform_decompose_ops.py
+++ b/tests/python/relax/test_transform_decompose_ops.py
@@ -137,39 +137,44 @@ def test_batch_norm_training():
             R.Tensor((64,), dtype="float32"),
         ):
             with R.dataflow():
-                # This portion is training-specific, computing the
-                # mean/variance of the dataset.
-                lv = R.mean(x, axis=[0, 2, 3], keepdims=False)
-                lv3 = R.variance(x, axis=[0, 2, 3], keepdims=False)
-
-                # This portion is identical to the batch_norm run during inference
-                lv1 = R.expand_dims(lv, axis=[0, 2, 3])
-                lv2 = R.subtract(x, lv1)
-                lv4 = R.expand_dims(lv3, axis=[0, 2, 3])
-                lv5 = R.add(lv4, R.const(9.9999997473787516e-06, "float32"))
-                lv6 = R.sqrt(lv5)
-                lv7 = R.divide(lv2, lv6)
-                lv8 = R.expand_dims(gamma, axis=[0, 2, 3])
-                lv9 = R.multiply(lv7, lv8)
-                lv10 = R.expand_dims(beta, axis=[0, 2, 3])
-                lv11 = R.add(lv9, lv10)
-                inner_tuple = (lv11, lv, lv3)
-                # This is the result that would be returned from a
-                # batch_norm at inference.
-
-                # However, at training we need to update the moving
-                # mean/variance, and to return those updated values.
-                inner_res = inner_tuple[0]
-                lv12 = R.multiply(R.const(0.89999997615814209, "float32"), moving_mean)
-                lv13 = R.multiply(R.const(0.10000000149011612, "float32"), lv)
-                lv14 = R.add(lv12, lv13)
-                lv15 = R.multiply(R.const(0.89999997615814209, "float32"), moving_var)
-                lv16 = R.multiply(R.const(0.10000000149011612, "float32"), lv3)
-                lv17 = R.add(lv15, lv16)
-                bn = (inner_res, lv14, lv17)
-                gv0 = bn[0]
-                gv1 = bn[1]
-                gv2 = bn[2]
+                lv: R.Tensor((64,), dtype="float32") = R.mean(x, axis=[0, 2, 3], keepdims=False)
+                lv1: R.Tensor((1, 64, 1, 1), dtype="float32") = R.expand_dims(lv, axis=[0, 2, 3])
+                lv2: R.Tensor((1, 64, 112, 112), dtype="float32") = R.subtract(x, lv1)
+                lv3: R.Tensor((64,), dtype="float32") = R.variance(
+                    x, axis=[0, 2, 3], keepdims=False
+                )
+                lv4: R.Tensor((1, 64, 1, 1), dtype="float32") = R.expand_dims(lv3, axis=[0, 2, 3])
+                lv5: R.Tensor((1, 64, 1, 1), dtype="float32") = R.add(
+                    lv4, R.const(9.9999997473787516e-06, "float32")
+                )
+                lv6: R.Tensor((1, 64, 1, 1), dtype="float32") = R.sqrt(lv5)
+                lv7: R.Tensor((1, 64, 112, 112), dtype="float32") = R.divide(lv2, lv6)
+                lv8: R.Tensor((1, 64, 1, 1), dtype="float32") = R.expand_dims(gamma, axis=[0, 2, 3])
+                lv9: R.Tensor((1, 64, 112, 112), dtype="float32") = R.multiply(lv7, lv8)
+                lv10: R.Tensor((1, 64, 1, 1), dtype="float32") = R.expand_dims(beta, axis=[0, 2, 3])
+                lv11: R.Tensor((1, 64, 112, 112), dtype="float32") = R.add(lv9, lv10)
+                lv12: R.Tensor((64,), dtype="float32") = R.multiply(
+                    R.const(0.89999997615814209, "float32"), moving_mean
+                )
+                lv13: R.Tensor((64,), dtype="float32") = R.multiply(
+                    R.const(0.10000000149011612, "float32"), lv
+                )
+                lv14: R.Tensor((64,), dtype="float32") = R.add(lv12, lv13)
+                lv15: R.Tensor((64,), dtype="float32") = R.multiply(
+                    R.const(0.89999997615814209, "float32"), moving_var
+                )
+                lv16: R.Tensor((64,), dtype="float32") = R.multiply(
+                    R.const(0.10000000149011612, "float32"), lv3
+                )
+                lv17: R.Tensor((64,), dtype="float32") = R.add(lv15, lv16)
+                bn: R.Tuple(
+                    R.Tensor((1, 64, 112, 112), dtype="float32"),
+                    R.Tensor((64,), dtype="float32"),
+                    R.Tensor((64,), dtype="float32"),
+                ) = (lv11, lv14, lv17)
+                gv0: R.Tensor((1, 64, 112, 112), dtype="float32") = bn[0]
+                gv1: R.Tensor((64,), dtype="float32") = bn[1]
+                gv2: R.Tensor((64,), dtype="float32") = bn[2]
                 R.output(gv0, gv1, gv2)
             return (gv0, gv1, gv2)
 


### PR DESCRIPTION
Reverts apache/tvm#15954

to avoid use of regex for now