### PR TITLE
[Unity][WEB] Temp disable wasm exception

### DIFF
--- a/python/tvm/contrib/emcc.py
+++ b/python/tvm/contrib/emcc.py
@@ -42,7 +42,9 @@ def create_tvmjs_wasm(output, objects, options=None, cc="emcc"):
     cmd += ["-O3"]
     cmd += ["-std=c++17"]
     cmd += ["--no-entry"]
-    cmd += ["-fwasm-exception"]
+    # temp disable for backward compact
+    # can enable after emsdk updates
+    # cmd += ["-fwasm-exception"]
     cmd += ["-s", "WASM_BIGINT=1"]
     cmd += ["-s", "ERROR_ON_UNDEFINED_SYMBOLS=0"]
     cmd += ["-s", "STANDALONE_WASM=1"]

--- a/web/Makefile
+++ b/web/Makefile
@@ -27,7 +27,9 @@ all: dist/wasm/tvmjs_runtime.wasm dist/wasm/tvmjs_runtime.wasi.js src/tvmjs_runt
 
 EMCC = emcc
 
-EMCC_CFLAGS = $(INCLUDE_FLAGS) -O3 -std=c++17 -Wno-ignored-attributes -fwasm-exceptions
+EMCC_CFLAGS = $(INCLUDE_FLAGS) -O3 -std=c++17 -Wno-ignored-attributes
+
+# -fwasm-exceptions
 
 EMCC_LDFLAGS = --no-entry -s WASM_BIGINT=1 -s ALLOW_MEMORY_GROWTH=1 -s STANDALONE_WASM=1\
  -s ERROR_ON_UNDEFINED_SYMBOLS=0 --pre-js emcc/preload.js

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "build": "rollup -c",
     "lint": "eslint -c .eslintrc.json .",
     "typedoc": "typedoc src/index.ts --plugin typedoc-plugin-missing-exports",
-    "test": "node --experimental-wasm-eh node_modules/.bin/jest",
+    "test": "node node_modules/.bin/jest",
     "bundle": "npm run build && cp lib/index.js dist/index.js && cp lib/index.js dist/tvmjs.bundle.js",
     "example": "npm run bundle && node apps/node/example.js",
     "example:wasi": "npm run bundle && node --experimental-wasi-unstable-preview1 --experimental-wasm-bigint apps/node/wasi_example.js",

--- a/web/tests/node/test_packed_func.js
+++ b/web/tests/node/test_packed_func.js
@@ -126,21 +126,6 @@ test("RegisterGlobal", () => {
   tvm.endScope();
 });
 
-test("ExceptionPassing", () => {
-  tvm.beginScope();
-  tvm.registerFunc("throw_error", function (msg) {
-    throw Error(msg);
-  });
-  let f = tvm.getGlobalFunc("throw_error");
-  try {
-    f("error-xyz");
-    throw Error("error not caught");
-  } catch (error) {
-    assert(error.message.indexOf("error-xyz") != -1);
-  }
-  tvm.endScope();
-});
-
 test("NDArrayCbArg", () => {
   tvm.beginScope();
   let use_count = tvm.getGlobalFunc("testing.object_use_count");


### PR DESCRIPTION
This PR temp disables wasm exception which requires latest version of nodejs. We can re-enable it after the wasm CI env finishes update.