### PR TITLE
[BugTIR] fix thread_sync occurs in letstmt

### DIFF
--- a/src/tir/transforms/storage_access.h
+++ b/src/tir/transforms/storage_access.h
@@ -88,6 +88,7 @@ class StorageAccessVisitor : public StmtExprVisitor {
   void VisitStmt_(const ForNode* op) final;
   void VisitStmt_(const IfThenElseNode* op) final;
   void VisitStmt_(const WhileNode* op) final;
+  void VisitStmt_(const LetStmtNode* op) final;
   void VisitExpr_(const CallNode* op) final;
 
  protected:

--- a/tests/python/tir-transform/test_tir_transform_thread_sync.py
+++ b/tests/python/tir-transform/test_tir_transform_thread_sync.py
@@ -195,7 +195,7 @@ def test_sync_let_stmt():
                 cross_thread_A_temp_1[0],
                 threadIdx_x,
             )
-    print(tvm.__file__)
+
     mod = run_passes(func)
     assert "T.tvm_storage_sync" in str(mod)
 

--- a/tests/python/tir-transform/test_tir_transform_thread_sync.py
+++ b/tests/python/tir-transform/test_tir_transform_thread_sync.py
@@ -160,8 +160,49 @@ def test_sync_shared_dyn():
     tvm.ir.assert_structural_equal(mod["main"], expected)
 
 
+@tvm.testing.requires_cuda
+def test_sync_let_stmt():
+    @T.prim_func(private=True)
+    def func(A: T.Buffer((16 * 512), "float32")):
+        blockIdx_x = T.launch_thread("blockIdx.x", 16)
+        A_shared = T.allocate([512], "float32", "shared")
+        in_thread_A_temp = T.allocate([1], "float32", "local")
+        cross_thread_A_temp = T.allocate([1], "float32", "local")
+        threadIdx_x = T.launch_thread("threadIdx.x", 128)
+        A_shared_1 = T.Buffer((512,), data=A_shared, scope="shared")
+        for ax0 in range(512):
+            A_shared_1[ax0] = A[blockIdx_x * 512 + ax0]
+        in_thread_A_temp_1 = T.Buffer((1,), data=in_thread_A_temp, scope="local")
+        in_thread_A_temp_1[0] = T.float32(0)
+        with T.LetStmt(in_thread_A_temp_1[0] + A_shared_1[threadIdx_x]) as A_temp:
+            in_thread_A_temp_1[0] = A_temp
+        with T.LetStmt(in_thread_A_temp_1[0] + A_shared_1[threadIdx_x + 128]) as A_temp:
+            in_thread_A_temp_1[0] = A_temp
+        with T.LetStmt(in_thread_A_temp_1[0] + A_shared_1[threadIdx_x + 256]) as A_temp:
+            in_thread_A_temp_1[0] = A_temp
+        with T.LetStmt(in_thread_A_temp_1[0] + A_shared_1[threadIdx_x + 384]) as A_temp:
+            in_thread_A_temp_1[0] = A_temp
+        cross_thread_A_temp_1 = T.Buffer((1,), data=cross_thread_A_temp, scope="local")
+        with T.attr(
+            T.comm_reducer(lambda x0, y0: x0 + y0, [T.float32(0)]),
+            "reduce_scope",
+            T.reinterpret("handle", T.uint64(0)),
+        ):
+            T.tvm_thread_allreduce(
+                T.uint32(1),
+                in_thread_A_temp_1[0],
+                T.bool(True),
+                cross_thread_A_temp_1[0],
+                threadIdx_x,
+            )
+    print(tvm.__file__)
+    mod = run_passes(func)
+    assert "T.tvm_storage_sync" in str(mod)
+
+
 if __name__ == "__main__":
     test_thread_storage_sync()
     test_sync_else_branch()
     test_sync_read_thread_id_independent_location()
     test_sync_shared_dyn()
+    test_sync_let_stmt()


### PR DESCRIPTION
[LayerNorm Error in thread_storage_sync when read x into shared memory](https://discuss.tvm.apache.org/t/layernorm-error-in-thread-storage-sync-when-read-x-into-shared-memory/16269)

I try to read x into shared memory to accelerate layernorm, [script here 1](https://gist.github.com/JackWeiw/f873daaff32212b0b19cf91fda463007)

but error occurs in pass thread_sorage_sync pass.I found it is because the error in lower LetStmt ,[lowered script](https://gist.github.com/JackWeiw/6737f4faa1b486b389721cf7f3f4ad4d)

