### PR TITLE
[BugTIR] fix thread_sync occurs in letstmt

### DIFF
--- a/src/tir/transforms/storage_access.cc
+++ b/src/tir/transforms/storage_access.cc
@@ -51,10 +51,6 @@ void StorageAccessVisitor::VisitExpr_(const BufferLoadNode* op) {
   }
   // traverse child
   StmtExprVisitor::VisitExpr_(op);
-  // push to the scope
-  scope_.back().push_back(curr_stmt_);
-  // clear access entry.
-  curr_stmt_.access.clear();
 }
 
 void StorageAccessVisitor::VisitStmt_(const BufferStoreNode* op) {
@@ -103,12 +99,13 @@ void StorageAccessVisitor::VisitStmt_(const LetStmtNode* op) {
   curr_stmt_.access.clear();
   ICHECK_EQ(curr_stmt_.access.size(), 0U);
   curr_stmt_.stmt = op;
-  StmtExprVisitor::VisitStmt_(op);
+  this->VisitExpr(op->value);
   // push to the scope
-  if (curr_stmt_.access.size() != 0) {
-    scope_.back().push_back(curr_stmt_);
-    curr_stmt_.access.clear();
-  }
+  scope_.back().push_back(curr_stmt_);
+  // clear access entry.
+  curr_stmt_.access.clear();
+  // traverse child
+  this->VisitStmt(op->body);
   allow_append_ = false;
 }
 

--- a/src/tir/transforms/storage_access.cc
+++ b/src/tir/transforms/storage_access.cc
@@ -104,9 +104,9 @@ void StorageAccessVisitor::VisitStmt_(const LetStmtNode* op) {
   scope_.back().push_back(curr_stmt_);
   // clear access entry.
   curr_stmt_.access.clear();
-  // traverse child
-  this->VisitStmt(op->body);
   allow_append_ = false;
+  // traverse body block
+  this->VisitStmt(op->body);
 }
 
 void StorageAccessVisitor::VisitStmt_(const AttrStmtNode* op) {

--- a/src/tir/transforms/storage_access.cc
+++ b/src/tir/transforms/storage_access.cc
@@ -96,7 +96,6 @@ void StorageAccessVisitor::VisitStmt_(const EvaluateNode* op) {
 
 void StorageAccessVisitor::VisitStmt_(const LetStmtNode* op) {
   allow_append_ = true;
-  curr_stmt_.access.clear();
   ICHECK_EQ(curr_stmt_.access.size(), 0U);
   curr_stmt_.stmt = op;
   this->VisitExpr(op->value);

--- a/src/tir/transforms/storage_access.h
+++ b/src/tir/transforms/storage_access.h
@@ -84,6 +84,7 @@ class StorageAccessVisitor : public StmtExprVisitor {
   void VisitExpr_(const BufferLoadNode* op) final;
   void VisitStmt_(const BufferStoreNode* op) final;
   void VisitStmt_(const EvaluateNode* op) final;
+  void VisitStmt_(const LetStmtNode* op) final;
   void VisitStmt_(const AttrStmtNode* op) final;
   void VisitStmt_(const ForNode* op) final;
   void VisitStmt_(const IfThenElseNode* op) final;

--- a/tests/python/tir-transform/test_tir_transform_thread_sync.py
+++ b/tests/python/tir-transform/test_tir_transform_thread_sync.py
@@ -160,8 +160,49 @@ def test_sync_shared_dyn():
     tvm.ir.assert_structural_equal(mod["main"], expected)
 
 
+@tvm.testing.requires_cuda
+def test_sync_let_stmt():
+    @T.prim_func(private=True)
+    def func(A: T.Buffer((16 * 512), "float32")):
+        blockIdx_x = T.launch_thread("blockIdx.x", 16)
+        A_shared = T.allocate([512], "float32", "shared")
+        in_thread_A_temp = T.allocate([1], "float32", "local")
+        cross_thread_A_temp = T.allocate([1], "float32", "local")
+        threadIdx_x = T.launch_thread("threadIdx.x", 128)
+        A_shared_1 = T.Buffer((512,), data=A_shared, scope="shared")
+        for ax0 in range(512):
+            A_shared_1[ax0] = A[blockIdx_x * 512 + ax0]
+        in_thread_A_temp_1 = T.Buffer((1,), data=in_thread_A_temp, scope="local")
+        in_thread_A_temp_1[0] = T.float32(0)
+        with T.LetStmt(in_thread_A_temp_1[0] + A_shared_1[threadIdx_x]) as A_temp:
+            in_thread_A_temp_1[0] = A_temp
+        with T.LetStmt(in_thread_A_temp_1[0] + A_shared_1[threadIdx_x + 128]) as A_temp:
+            in_thread_A_temp_1[0] = A_temp
+        with T.LetStmt(in_thread_A_temp_1[0] + A_shared_1[threadIdx_x + 256]) as A_temp:
+            in_thread_A_temp_1[0] = A_temp
+        with T.LetStmt(in_thread_A_temp_1[0] + A_shared_1[threadIdx_x + 384]) as A_temp:
+            in_thread_A_temp_1[0] = A_temp
+        cross_thread_A_temp_1 = T.Buffer((1,), data=cross_thread_A_temp, scope="local")
+        with T.attr(
+            T.comm_reducer(lambda x0, y0: x0 + y0, [T.float32(0)]),
+            "reduce_scope",
+            T.reinterpret("handle", T.uint64(0)),
+        ):
+            T.tvm_thread_allreduce(
+                T.uint32(1),
+                in_thread_A_temp_1[0],
+                T.bool(True),
+                cross_thread_A_temp_1[0],
+                threadIdx_x,
+            )
+
+    mod = run_passes(func)
+    assert "T.tvm_storage_sync" in str(mod)
+
+
 if __name__ == "__main__":
     test_thread_storage_sync()
     test_sync_else_branch()
     test_sync_read_thread_id_independent_location()
     test_sync_shared_dyn()
+    test_sync_let_stmt()


### PR DESCRIPTION
See original discuss
[LayerNorm Error in thread_storage_sync when read x into shared memory](https://discuss.tvm.apache.org/t/layernorm-error-in-thread-storage-sync-when-read-x-into-shared-memory/16269)

I try to read x into shared memory to accelerate layernorm, [script here 1](https://gist.github.com/JackWeiw/f873daaff32212b0b19cf91fda463007)

but error occurs in pass thread_sorage_sync pass.I found it is because the error in lower LetStmt ,[lowered script](https://gist.github.com/JackWeiw/6737f4faa1b486b389721cf7f3f4ad4d)
