### PR TITLE
[Runtime][KVCache] AttentionWithFusedQKV and RoPE mode

### DIFF
--- a/src/runtime/relax_vm/kv_cache.h
+++ b/src/runtime/relax_vm/kv_cache.h
@@ -137,6 +137,19 @@ class AttentionKVCache : public Object {
   virtual void Attention(int64_t layer_id, NDArray q_data, NDArray k_data, NDArray v_data,
                          Optional<NDArray> mask, NDArray o_data) = 0;
 
+  /*!
+   * \brief Compute attention with Q/K/V data which are concatenated along
+   * the head dimension.
+   * \param layer_id The model layer where the attention compute happens.
+   * \param qkv_data The input Q/K/V data, in layout
+   * `(total_length, num_qo_heads + 2 * num_kv_heads, head_dim)`.
+   * \param mask The input mask data, in layout `(total_sqr_length)`.
+   * \param o_data The output O data, in layout `(total_length, num_qo_heads, head_dim)`.
+   * \sa AttentionKVCache::Attention
+   */
+  virtual void AttentionWithFusedQKV(int64_t layer_id, NDArray qkv_data, Optional<NDArray> mask,
+                                     NDArray o_data) = 0;
+
   /************** Debug Helpers **************/
 
   /*!

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_flashinfer.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_flashinfer.py
@@ -23,11 +23,13 @@ import scipy.special
 import tvm
 import tvm.testing
 from tvm import dlight as dl
+from tvm import tir
 from tvm.runtime import ShapeTuple
 from tvm.script import tir as T
 
 reserved_nseq = 32
 maximum_total_seq_length = 1024
+prefill_chunk_size = 512
 page_size = 16
 num_layers = 4
 num_qo_heads = 32
@@ -47,6 +49,7 @@ fpopn = None
 fbegin_forward = None
 fend_forward = None
 fattention = None
+fattention_with_fuse_qkv = None
 fdebug_get_kv = None
 
 fattention_prefill = None
@@ -59,6 +62,11 @@ fattention_decode_end_forward = None
 fattention_prefill_ragged_begin_forward = None
 fattention_prefill_ragged_end_forward = None
 fattention_merge_state = None
+fattention_rotary = None
+
+ftranspose_append = None
+fsplit_rotary = None
+fcopy_cache = None
 
 
 @T.prim_func
@@ -100,6 +108,84 @@ def kv_cache_transpose_append(
             ] = v_data[vgpos, vh, vf]
 
 
+def llama_rope_with_position_map(  # pylint: disable=too-many-arguments
+    theta: float,
+    scale: float,
+    head_dim: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+    dtype: float = "float16",
+    rotary_dim: int = None,
+):
+    fused_heads = num_q_heads + num_kv_heads * 2
+    if rotary_dim is None:
+        rotary_dim = head_dim
+    scale = tir.const(scale, dtype)
+
+    def _rope_freq(s: tir.Var, d: tir.Var, d_range: int, theta: float, dtype: str):
+        freq = s / tir.power(theta, d * 2 % d_range / tir.const(d_range, "float32"))
+        cos_freq = tir.cos(freq).astype(dtype)
+        sin_freq = tir.sin(freq).astype(dtype)
+        return cos_freq, sin_freq
+
+    def _rope(  # pylint: disable=too-many-arguments
+        x: T.Buffer,
+        s: tir.Var,
+        h: tir.Var,
+        d: tir.Var,
+        pos: tir.Var,
+    ):
+        cos_freq, sin_freq = _rope_freq(pos * scale, d, rotary_dim, theta, dtype)
+        cos = cos_freq * x[s, h, d]
+        sin = sin_freq * tir.if_then_else(
+            d < rotary_dim // 2,
+            -x[s, h, d + rotary_dim // 2],
+            x[s, h, d - rotary_dim // 2],
+        )
+        return cos + sin
+
+    @T.prim_func(private=True)
+    def fused_rope(  # pylint: disable=too-many-locals
+        var_qkv: T.handle,
+        var_position_map: T.handle,
+        var_q: T.handle,
+        var_k: T.handle,
+        var_v: T.handle,
+        apply_rope: T.int32,
+    ):
+        T.func_attr(
+            {
+                "op_pattern": 8,  # 2 means injective, 8 means opaque
+                "tir.noalias": T.bool(True),
+            }
+        )
+        seq_len = T.int64()
+        qkv = T.match_buffer(var_qkv, (seq_len, fused_heads, head_dim), dtype)
+        q = T.match_buffer(var_q, (seq_len, num_q_heads, head_dim), dtype)
+        k = T.match_buffer(var_k, (seq_len, num_kv_heads, head_dim), dtype)
+        v = T.match_buffer(var_v, (seq_len, num_kv_heads, head_dim), dtype)
+        position_map = T.match_buffer(var_position_map, (seq_len,), "int32")
+        for iters in T.grid(seq_len, fused_heads, head_dim):
+            with T.block("llama_fused_rope"):
+                s, h, d = T.axis.remap("SSS", iters)
+                if h < num_q_heads:
+                    q[s, h, d] = T.if_then_else(
+                        apply_rope > 0 and d < rotary_dim,
+                        _rope(qkv, s, h, d, position_map[s]),
+                        qkv[s, h, d],
+                    )
+                elif h < num_q_heads + num_kv_heads:
+                    k[s, h - num_q_heads, d] = T.if_then_else(
+                        apply_rope > 0 and d < rotary_dim,
+                        _rope(qkv, s, h, d, position_map[s]),
+                        qkv[s, h, d],
+                    )
+                else:
+                    v[s, h - (num_q_heads + num_kv_heads), d] = qkv[s, h, d]
+
+    return fused_rope
+
+
 @T.prim_func
 def copy_cache(
     var_pages: T.handle,
@@ -138,13 +224,14 @@ def copy_cache(
 
 def set_global_func():
     global fclear, fcreate, fadd_sequence, fremove_sequence, ffork_sequence, fpopn
-    global fbegin_forward, fend_forward, fattention, fdebug_get_kv
+    global fbegin_forward, fend_forward, fattention, fattention_with_fuse_qkv, fdebug_get_kv
     global fattention_prefill, fattention_prefill_begin_forward, fattention_prefill_end_forward
     global fattention_decode, fattention_decode_begin_forward, fattention_decode_end_forward
     global fattention_prefill_ragged
     global fattention_prefill_ragged_begin_forward
     global fattention_prefill_ragged_end_forward
-    global fattention_merge_state
+    global fattention_merge_state, fsplit_rotary, fattention_rotary
+    global ftranspose_append, fcopy_cache
 
     fclear = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_clear")
     fcreate = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_create")
@@ -155,6 +242,9 @@ def set_global_func():
     fbegin_forward = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_begin_forward")
     fend_forward = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_end_forward")
     fattention = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_attention")
+    fattention_with_fuse_qkv = tvm.get_global_func(
+        "vm.builtin.paged_attention_kv_cache_attention_with_fused_qkv"
+    )
     fdebug_get_kv = tvm.get_global_func("vm.builtin.paged_attention_kv_cache_debug_get_kv")
 
     fattention_prefill = tvm.get_global_func("paged_kv_cache.attention_kernel_prefill")
@@ -181,26 +271,36 @@ def set_global_func():
         "flashinfer.attention_kernel_prefill_with_ragged_kv_cache_end_forward"
     )
     fattention_merge_state = tvm.get_global_func("flashinfer.merge_state_in_place")
+    fattention_rotary = tvm.get_global_func("flashinfer.batch_qk_apply_rotary_in_place")
 
-
-def create_kv_cache():
-    set_global_func()
     target = tvm.target.Target("nvidia/geforce-rtx-3090-ti")
     builts = []
-    for tir_func in [kv_cache_transpose_append, copy_cache]:
+    for tir_func in [
+        kv_cache_transpose_append,
+        llama_rope_with_position_map(
+            rope_theta, rope_scale, head_dim, num_qo_heads, num_kv_heads, dtype
+        ),
+        copy_cache,
+    ]:
         mod = tvm.IRModule({"main": tir_func})
         with target:
             mod = dl.ApplyDefaultSchedule(dl.gpu.Fallback())(mod)
         f = tvm.build(mod["main"], target=target)
         builts.append(f.entry_func)
 
-    ftranspose_append, fcopy_cache = builts
+    ftranspose_append, fsplit_rotary, fcopy_cache = builts
+
+
+def create_kv_cache(rope_mode):
     cache = fcreate(
-        tvm.runtime.ShapeTuple([reserved_nseq, maximum_total_seq_length, page_size]),
+        tvm.runtime.ShapeTuple(
+            [reserved_nseq, maximum_total_seq_length, prefill_chunk_size, page_size]
+        ),
         num_layers,
         num_qo_heads,
         num_kv_heads,
         head_dim,
+        rope_mode,
         rope_scale,
         rope_theta,
         tvm.nd.empty((), dtype, device=device),
@@ -215,14 +315,17 @@ def create_kv_cache():
         fattention_decode_begin_forward,
         fattention_decode_end_forward,
         fattention_merge_state,
+        fsplit_rotary,
+        fattention_rotary,
         fcopy_cache,
     )
     return cache
 
 
-@pytest.fixture()
-def kv_cache():
-    return create_kv_cache()
+@pytest.fixture(params=[0, 1])
+def kv_cache_and_rope_mode(request):
+    set_global_func()
+    return create_kv_cache(request.param), request.param
 
 
 def verify_cached_kv(kv_cache, seq_ids, expected_k, expected_v):
@@ -258,9 +361,11 @@ def f_apply_rotary(x, offset, scale, theta):
 
 def apply_attention(
     kv_cache,
+    rope_mode: int,
     batch: List[Tuple[Union[int, Tuple[int, int]], int]],
     cached_k: Dict[int, np.ndarray],
     cached_v: Dict[int, np.ndarray],
+    fuse_qkv: bool,
 ) -> None:
     seq_ids = []
     append_lengths = []
@@ -283,7 +388,6 @@ def apply_attention(
             cached_k[seq_id] = np.zeros((num_layers, 0, num_kv_heads, head_dim), dtype)
             cached_v[seq_id] = np.zeros((num_layers, 0, num_kv_heads, head_dim), dtype)
 
-    use_decode_shape = all(append_length == 1 for _, append_length in batch)
     fbegin_forward(kv_cache, ShapeTuple(seq_ids), ShapeTuple(append_lengths))
 
     global_new_q = np.zeros((num_layers, 0, num_qo_heads, head_dim), dtype)
@@ -300,7 +404,17 @@ def apply_attention(
         cached_k[seq_id] = np.concatenate(
             [
                 cached_k[seq_id],
-                np.stack([new_k[l] for l in range(num_layers)], axis=0),
+                np.stack(
+                    [
+                        new_k[l]
+                        if rope_mode == 1
+                        else f_apply_rotary(
+                            new_k[l], cached_k[seq_id].shape[1], rope_scale, rope_theta
+                        )
+                        for l in range(num_layers)
+                    ],
+                    axis=0,
+                ),
             ],
             axis=1,
         )
@@ -310,23 +424,22 @@ def apply_attention(
         global_new_v = np.concatenate([global_new_v, new_v], axis=1)
 
     for layer_id in range(num_layers):
-        queries_np = global_new_q[layer_id : layer_id + 1]
-        keys_np = global_new_k[layer_id : layer_id + 1]
-        values_np = global_new_v[layer_id : layer_id + 1]
-        if use_decode_shape:
-            queries_np = queries_np.transpose(1, 0, 2, 3)
-            keys_np = keys_np.transpose(1, 0, 2, 3)
-            values_np = values_np.transpose(1, 0, 2, 3)
-        queries = tvm.nd.array(queries_np, device=device)
-        keys = tvm.nd.array(keys_np, device=device)
-        values = tvm.nd.array(values_np, device=device)
-        outputs = tvm.nd.empty(queries.shape, dtype, device=device)
-        fattention(kv_cache, layer_id, queries, keys, values, outputs)
+        queries_np = global_new_q[layer_id]
+        keys_np = global_new_k[layer_id]
+        values_np = global_new_v[layer_id]
+        if not fuse_qkv:
+            queries = tvm.nd.array(queries_np, device=device)
+            keys = tvm.nd.array(keys_np, device=device)
+            values = tvm.nd.array(values_np, device=device)
+            outputs = tvm.nd.empty(queries.shape, dtype, device=device)
+            fattention(kv_cache, layer_id, queries, keys, values, outputs)
+        else:
+            qkv = tvm.nd.array(np.concatenate([queries_np, keys_np, values_np], axis=1), device)
+            outputs = tvm.nd.empty(queries_np.shape, dtype, device=device)
+            fattention_with_fuse_qkv(kv_cache, layer_id, qkv, outputs)
 
         # Compute attention expected results.
-        outputs = outputs.numpy()
-        if use_decode_shape:
-            outputs = outputs.transpose(1, 0, 2, 3)
+        outputs = np.expand_dims(outputs.numpy(), axis=0)
         sum_length = 0
         for i, (seq_id, append_length) in enumerate(batch):
             assert cached_k[seq_id].shape[1] == cached_v[seq_id].shape[1] >= append_length
@@ -338,9 +451,11 @@ def apply_attention(
                 rope_scale,
                 rope_theta,
             ).transpose(1, 0, 2)
-            k_seq = f_apply_rotary(cached_k[seq_id][layer_id], 0, rope_scale, rope_theta).transpose(
-                1, 2, 0
-            )
+            k_seq = (
+                cached_k[seq_id][layer_id]
+                if rope_mode == 0
+                else f_apply_rotary(cached_k[seq_id][layer_id], 0, rope_scale, rope_theta)
+            ).transpose(1, 2, 0)
             v_seq = cached_v[seq_id][layer_id].transpose(1, 0, 2)
 
             k_seq = np.repeat(k_seq, num_qo_heads // num_kv_heads, axis=0)
@@ -375,7 +490,9 @@ def apply_attention(
 
 
 @pytest.mark.skip(reason="Require FlashInfer enabled")
-def test_paged_attention_kv_cache_prefill_and_decode(kv_cache):
+@pytest.mark.parametrize("fuse_qkv", [False, True])
+def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_rope_mode, fuse_qkv):
+    kv_cache, rope_mode = kv_cache_and_rope_mode
     fclear(kv_cache)
 
     # Prefill.
@@ -391,11 +508,13 @@ def test_paged_attention_kv_cache_prefill_and_decode(kv_cache):
     cached_k = {}
     cached_v = {}
     for batch in operation_seq:
-        apply_attention(kv_cache, batch, cached_k, cached_v)
+        apply_attention(kv_cache, rope_mode, batch, cached_k, cached_v, fuse_qkv)
 
 
 @pytest.mark.skip(reason="Require FlashInfer enabled")
-def test_paged_attention_kv_cache_remove_sequence(kv_cache):
+@pytest.mark.parametrize("fuse_qkv", [False, True])
+def test_paged_attention_kv_cache_remove_sequence(kv_cache_and_rope_mode, fuse_qkv):
+    kv_cache, rope_mode = kv_cache_and_rope_mode
     fclear(kv_cache)
 
     num_sequences = 5
@@ -403,7 +522,7 @@ def test_paged_attention_kv_cache_remove_sequence(kv_cache):
     cached_k = {}
     cached_v = {}
     for seq_id_to_remove in range(num_sequences):
-        apply_attention(kv_cache, batch, cached_k, cached_v)
+        apply_attention(kv_cache, rope_mode, batch, cached_k, cached_v, fuse_qkv)
         # Remove sequence.
         fremove_sequence(kv_cache, seq_id_to_remove)
         cached_k.pop(seq_id_to_remove)
@@ -417,20 +536,22 @@ def test_paged_attention_kv_cache_remove_sequence(kv_cache):
 
 
 @pytest.mark.skip(reason="Require FlashInfer enabled")
-def test_paged_attention_kv_cache_fork_sequence(kv_cache):
+@pytest.mark.parametrize("fuse_qkv", [False, True])
+def test_paged_attention_kv_cache_fork_sequence(kv_cache_and_rope_mode, fuse_qkv):
+    kv_cache, rope_mode = kv_cache_and_rope_mode
     fclear(kv_cache)
 
     cached_k = {}
     cached_v = {}
     batch = [(0, 60), (1, 88), (2, 17), (3, 4)]
-    apply_attention(kv_cache, batch, cached_k, cached_v)
+    apply_attention(kv_cache, rope_mode, batch, cached_k, cached_v, fuse_qkv)
     # Fork existing sequences.
-    apply_attention(kv_cache, [((4, 3), 35)], cached_k, cached_v)
-    apply_attention(kv_cache, [((5, 0), 20)], cached_k, cached_v)
-    apply_attention(kv_cache, [((6, 5), 102)], cached_k, cached_v)
-    apply_attention(kv_cache, [((7, 0), 3)], cached_k, cached_v)
-    apply_attention(kv_cache, [((8, 5), 71)], cached_k, cached_v)
-    apply_attention(kv_cache, [((9, 5), 20)], cached_k, cached_v)
+    apply_attention(kv_cache, rope_mode, [((4, 3), 35)], cached_k, cached_v, fuse_qkv)
+    apply_attention(kv_cache, rope_mode, [((5, 0), 20)], cached_k, cached_v, fuse_qkv)
+    apply_attention(kv_cache, rope_mode, [((6, 5), 102)], cached_k, cached_v, fuse_qkv)
+    apply_attention(kv_cache, rope_mode, [((7, 0), 3)], cached_k, cached_v, fuse_qkv)
+    apply_attention(kv_cache, rope_mode, [((8, 5), 71)], cached_k, cached_v, fuse_qkv)
+    apply_attention(kv_cache, rope_mode, [((9, 5), 20)], cached_k, cached_v, fuse_qkv)
     # Mixture of decode and prefill.
     operation_seq = [
         [(2, 1), (4, 1), (7, 1), (6, 1), (8, 1), (9, 1)],
@@ -439,18 +560,20 @@ def test_paged_attention_kv_cache_fork_sequence(kv_cache):
         [(7, 10), (6, 2), (8, 3), (9, 4)],
     ]
     for batch in operation_seq:
-        apply_attention(kv_cache, batch, cached_k, cached_v)
+        apply_attention(kv_cache, rope_mode, batch, cached_k, cached_v, fuse_qkv)
 
 
 @pytest.mark.skip(reason="Require FlashInfer enabled")
-def test_paged_attention_kv_cache_popn(kv_cache):
+@pytest.mark.parametrize("fuse_qkv", [False, True])
+def test_paged_attention_kv_cache_popn(kv_cache_and_rope_mode, fuse_qkv):
+    kv_cache, rope_mode = kv_cache_and_rope_mode
     fclear(kv_cache)
 
     cached_k = {}
     cached_v = {}
     batch = [(0, 35), (1, 88), (2, 17), (3, 4)]
-    apply_attention(kv_cache, batch, cached_k, cached_v)
-    apply_attention(kv_cache, [((4, 3), 35)], cached_k, cached_v)
+    apply_attention(kv_cache, rope_mode, batch, cached_k, cached_v, fuse_qkv)
+    apply_attention(kv_cache, rope_mode, [((4, 3), 35)], cached_k, cached_v, fuse_qkv)
 
     popn_operations = [(0, 17), (1, 57), (2, 16), (3, 0), (4, 19)]
     for seq_id, pop_length in popn_operations:
@@ -462,8 +585,11 @@ def test_paged_attention_kv_cache_popn(kv_cache):
 
 
 if __name__ == "__main__":
-    cache = create_kv_cache()
-    test_paged_attention_kv_cache_prefill_and_decode(cache)
-    test_paged_attention_kv_cache_remove_sequence(cache)
-    test_paged_attention_kv_cache_fork_sequence(cache)
-    test_paged_attention_kv_cache_popn(cache)
+    set_global_func()
+    for rope_mode in [0, 1]:
+        cache = create_kv_cache(rope_mode)
+        for fuse_qkv in [False, True]:
+            test_paged_attention_kv_cache_prefill_and_decode((cache, rope_mode), fuse_qkv)
+            test_paged_attention_kv_cache_remove_sequence((cache, rope_mode), fuse_qkv)
+            test_paged_attention_kv_cache_fork_sequence((cache, rope_mode), fuse_qkv)
+            test_paged_attention_kv_cache_popn((cache, rope_mode), fuse_qkv)


### PR DESCRIPTION
This PR introduces two changes to the (paged) KV cache:

The first is introducing RoPE mode to PagedKVCache. Right now there are two modes: normal/inline. In "normal" mode, RoPE will be applied to input Q/K/V data before appending the K/V data to cache. In "inline" mode, the input K/V data is directly appending to cache, and the RoPE will be on-the-fly applied inside attention kernel. The main purpose of introducing RoPE mode is to balance the need of on-the-fly RoPE (in cases like Mistral where positions can cahnge) and the attention kernel performance.

The second is introducing a new interface `AttentionWithFusedQKV` to KV cache. This function takes the input QKV data that is fused along the head dimension. And the fused QKV will be split into separate Q/K/V internally (note: requiring external workspace passed in). We introduce this function since in practice we note that when RoPE mode is "normal," it offers better performance if we fuse the QKV split and RoPE application.