### PR TITLE
[Draft][Relax] Implement Function.check_for_special_case

### DIFF
--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -738,6 +738,18 @@ class Function(BaseFunc, Scriptable):
         """
         return Call(self, args, None, None)
 
+    @staticmethod
+    def _normalize_value(value):
+        """Conversions that must occur prior to the FFI conversions"""
+        if isinstance(value, int):
+            # Relax uses int64 for symbolic variables, but the FFI
+            # converts python integers into int32.
+            return tvm.tir.const(value, "int64")
+        elif isinstance(value, (_np.ndarray, tvm.nd.NDArray)):
+            return tvm.relax.const(value)
+        else:
+            return value
+
     def bind_symbolic_vars(
         self, binding_map: Mapping[Union[str, tvm.tir.Var], PrimExpr]
     ) -> "Function":
@@ -759,14 +771,35 @@ class Function(BaseFunc, Scriptable):
             The updated function
         """
 
-        # Relax uses int64 for symbolic variables, but the FFI
-        # converts python integers into int32.
-        binding_map = {
-            key: tvm.tir.const(value, "int64") if isinstance(value, int) else value
-            for key, value in binding_map.items()
-        }
+        binding_map = {key: self._normalize_value(value) for key, value in binding_map.items()}
 
         return _ffi_api.FunctionBindSymbolicVars(self, binding_map)  # type: ignore
+
+    def check_for_special_case(
+        self, special_case: Mapping[Union[str, tvm.tir.Var, Var], Union[PrimExpr, Expr]]
+    ) -> "Function":
+        """Return a new function with updated symbolic variable
+
+        Parameters
+        ----------
+        binding_map: Mapping[Union[str, tvm.tir.Var], Union[PrimExpr,Expr]]
+
+            The mapping of values to be replaced.  Keys may be either
+            a `relax.Var, a `tir.Var` or a string providing the name
+            of the variable.  If the variables are referred to by
+            name, the name must uniquely identify the `tir.Var` or
+            `relax.Var` in the function signature.
+
+        Returns
+        -------
+        func: Function
+
+            The updated function
+        """
+
+        special_case = {key: self._normalize_value(value) for key, value in special_case.items()}
+
+        return _ffi_api.FunctionCheckForSpecialCase(self, special_case)  # type: ignore
 
     def bind_params(
         self,
@@ -802,19 +835,7 @@ class Function(BaseFunc, Scriptable):
             The updated function
         """
 
-        def _normalize_value(value):
-            # Conversions that must occur prior to the FFI
-            # conversions.
-            if isinstance(value, int):
-                # Relax uses int64 for symbolic variables, but the FFI
-                # converts python integers into int32.
-                return tvm.tir.const(value, "int64")
-            elif isinstance(value, (_np.ndarray, tvm.nd.NDArray)):
-                return tvm.relax.const(value)
-            else:
-                return value
-
-        binding_map = {key: _normalize_value(value) for key, value in binding_map.items()}
+        binding_map = {key: self._normalize_value(value) for key, value in binding_map.items()}
 
         return _ffi_api.FunctionBindParams(self, binding_map)  # type: ignore
 

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -34,6 +34,7 @@
 #include <tvm/tir/function.h>
 
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -179,7 +180,7 @@ class BlockBuilderImpl : public BlockBuilderNode {
         shape_var_map.Set(shape_var, shape_expr);
       }
     }
-    scope_stack_.emplace_back(ScopeFrame({std::move(shape_var_map)}));
+    scope_stack_.emplace_back(ScopeFrame({params, std::move(shape_var_map)}));
   }
 
   void EndScope() final { scope_stack_.pop_back(); }
@@ -292,6 +293,15 @@ class BlockBuilderImpl : public BlockBuilderNode {
     // Consider impl alternative: merge with block frame if we have more frame kinds.
     //
     // TODO(relax-team) tracks the var defined also through match-cast.
+
+    /*! \brief The parameters used to define this scope
+     *
+     * Can be used to copy the parent scope, for cases that should
+     * inherit definitions from their parent, but not expose new
+     * definitions into the parent.
+     */
+    Optional<Array<Var>> params;
+
     /*! \brief set of defined symbolic vars, value as themself. */
     Map<tir::Var, PrimExpr> shape_var_map;
   };
@@ -674,8 +684,11 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
 
   Expr VisitExpr_(const IfNode* op) final {
     Expr new_cond = this->NormalizeArgument(op->cond);
-    Expr new_true = this->VisitWithNewScope(op->true_branch);
-    Expr new_false = this->VisitWithNewScope(op->false_branch);
+
+    Optional<Array<Var>> scope_params = scope_stack_.size() ? scope_stack_.back().params : NullOpt;
+
+    Expr new_true = this->VisitWithNewScope(op->true_branch, scope_params);
+    Expr new_false = this->VisitWithNewScope(op->false_branch, scope_params);
 
     If if_node;
     if (new_cond.same_as(op->cond) && new_true.same_as(op->true_branch) &&
@@ -685,9 +698,77 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
       if_node = If(new_cond, new_true, new_false, op->span);
     }
     if (!if_node->struct_info_.defined()) {
-      auto true_info = EraseToWellDefinedInScope(GetStructInfo(new_true));
-      auto false_info = EraseToWellDefinedInScope(GetStructInfo(new_false));
-      UpdateStructInfo(if_node, StructInfoLCA(true_info, false_info));
+      StructInfo lca = [&]() -> StructInfo {
+        StructuralEqual struct_equal;
+
+        auto true_info = GetStructInfo(new_true);
+        auto false_info = GetStructInfo(new_false);
+
+        if (struct_equal(true_info, false_info)) {
+          return true_info;
+        }
+
+        auto prim_cond = [&]() -> Optional<PrimExpr> {
+          Expr cond_expr = new_cond;
+          while (true) {
+            if (auto var = cond_expr.as<Var>()) {
+              if (auto value = LookupBinding(var.value())) {
+                cond_expr = value.value();
+              }
+            }
+            break;
+          }
+
+          if (auto prim_value = cond_expr.as<PrimValueNode>()) {
+            return prim_value->value;
+          }
+
+          if (auto prim_sinfo = cond_expr->struct_info_.as<PrimStructInfoNode>()) {
+            if (prim_sinfo->value.defined()) {
+              return prim_sinfo->value.value();
+            }
+          }
+          return NullOpt;
+        }();
+
+        arith::Analyzer* analyzer = GetAnalyzer();
+
+        if (!prim_cond.defined()) {
+          return StructInfoLCA(true_info, false_info, analyzer);
+        }
+
+        // auto true_info = EraseToWellDefinedInScope(GetStructInfo(new_true));
+        // auto false_info = EraseToWellDefinedInScope(GetStructInfo(new_false));
+
+        {
+          // The struct info returned in the "then" branch is a special
+          // case, and the "else" branch returns the general case.
+          std::optional<With<arith::ConstraintContext>> context;
+          if (prim_cond.defined()) {
+            context.emplace(analyzer, prim_cond.value());
+          }
+          auto then_lca = StructInfoLCA(true_info, false_info, GetAnalyzer());
+          if (struct_equal(true_info, then_lca)) {
+            return false_info;
+          }
+        }
+        {
+          // The struct info returned in the "else" branch is a special
+          // case, and the "then" branch returns the general case.
+          std::optional<With<arith::ConstraintContext>> context;
+          if (prim_cond.defined()) {
+            context.emplace(analyzer, !prim_cond.value());
+          }
+          auto else_lca = StructInfoLCA(true_info, false_info, GetAnalyzer());
+          if (struct_equal(false_info, else_lca)) {
+            return true_info;
+          }
+        }
+
+        return StructInfoLCA(true_info, false_info, analyzer);
+      }();
+
+      UpdateStructInfo(if_node, lca);
     }
     return if_node;
   }

--- a/src/relax/transform/check_for_special_case.cc
+++ b/src/relax/transform/check_for_special_case.cc
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <tvm/relax/analysis.h>
+#include <tvm/relax/expr.h>
+#include <tvm/relax/struct_info.h>
+#include <tvm/relax/transform.h>
+#include <tvm/relax/type.h>
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "utils.h"
+
+namespace tvm {
+namespace relax {
+
+Function FunctionCheckForSpecialCase(
+    Function func,
+    Map<Variant<tir::Var, relax::Var, String>, Variant<Expr, PrimExpr>> arg_special_case) {
+  // Early bail-out if no updates need to be made.
+  if (arg_special_case.empty()) {
+    return func;
+  }
+
+  Array<tir::Var> old_symbolic_vars = DefinedSymbolicVars(func);
+
+  // Map from string to the variable(s) with that name.
+  std::unordered_map<std::string, Array<Variant<tir::Var, relax::Var>>> string_lookup;
+  std::unordered_set<const tir::VarNode*> symbolic_var_set;
+  std::unordered_set<const relax::VarNode*> relax_var_set;
+  for (const auto& var : old_symbolic_vars) {
+    string_lookup[var->name_hint].push_back(var);
+    symbolic_var_set.insert(var.get());
+  }
+  for (const auto& param : func->params) {
+    string_lookup[param->name_hint()].push_back(param);
+    relax_var_set.insert(param.get());
+  }
+
+  auto get_tir_expr = [](const tir::Var& var,
+                         const Variant<Expr, PrimExpr>& replacement) -> PrimExpr {
+    if (auto prim = replacement.as<PrimExpr>()) {
+      return prim.value();
+    }
+
+    if (auto prim_value = replacement.as<relax::PrimValue>()) {
+      return prim_value.value()->value;
+    }
+
+    if (auto relax_expr = replacement.as<relax::ExprNode>()) {
+      auto sinfo = relax_expr->struct_info_;
+      auto prim_sinfo = sinfo.as<PrimStructInfoNode>();
+      if (prim_sinfo && prim_sinfo->value.defined()) {
+        return prim_sinfo->value.value();
+      } else if (prim_sinfo) {
+        LOG(FATAL) << "ValueError: "
+                   << "Attempted to replace TIR variable " << var << " with " << replacement
+                   << ".  While this is a relax.PrimValue, is is not bound to a known PrimExpr, "
+                      "and cannot be used to specialize a TIR variable.  "
+                   << "Consider defining the PrimValue with R.Prim(value=tir_var) instead of "
+                      "R.Prim(dtype=dtype)";
+      } else {
+        LOG(FATAL) << "ValueError: "
+                   << "Attempted to replace TIR variable " << var << " with " << replacement
+                   << ", but relax expression of type " << relax_expr->GetTypeKey()
+                   << " with struct info " << sinfo << " cannot be converted to a known PrimExpr.";
+      }
+    }
+
+    LOG(FATAL) << "InternalError: "
+               << "Variant did not contain one of the allowed types";
+  };
+
+  auto get_relax_expr = [](const Variant<Expr, PrimExpr>& replacement) -> Expr {
+    if (auto relax_expr = replacement.as<Expr>()) {
+      return relax_expr.value();
+    } else if (auto tir_expr = replacement.as<PrimExpr>()) {
+      return relax::PrimValue(tir_expr.value());
+    } else {
+      LOG(FATAL) << "InternalError: "
+                 << "Variant did not contain one of the allowed types";
+    }
+  };
+
+  // Replacement maps to be used when rewriting the function.
+  Map<relax::Var, Expr> relax_remap;
+  Map<tir::Var, PrimExpr> tir_remap;
+  for (const auto& [key, replacement] : arg_special_case) {
+    if (auto opt = key.as<String>()) {
+      String string_key = opt.value();
+      auto it = string_lookup.find(string_key);
+      CHECK(it != string_lookup.end())
+          << "The name \"" << string_key << "\" does not correspond to either "
+          << "a parameter or a symbolic variable in the function signature.  "
+          << "The function has parameters named "
+          << func->params.Map([](const relax::Var& var) { return var->name_hint(); })
+          << " and symbolic variables " << old_symbolic_vars;
+
+      CHECK_EQ(it->second.size(), 1)
+          << "The name \"" << string_key << "\" does not uniquely identify "
+          << "a function parameter or symbolic variable.  "
+          << "This name could refer to any of " << it->second.Map([](const auto& var) -> String {
+               std::stringstream ss;
+               ss << var << " (" << var->GetTypeKey() << ")";
+               return ss.str();
+             });
+
+      auto var = it->second[0];
+
+      if (auto opt = var.as<tir::Var>()) {
+        auto tir_var = opt.value();
+        CHECK(!tir_remap.count(tir_var))
+            << "Remap of TIR variable " << tir_var << " was defined multiple times";
+        tir_remap.Set(tir_var, get_tir_expr(tir_var, replacement));
+      } else if (auto opt = var.as<relax::Var>()) {
+        auto relax_var = opt.value();
+        CHECK(!relax_remap.count(relax_var))
+            << "Remap of Relax variable " << relax_var << " was defined multiple times";
+        relax_remap.Set(relax_var, get_relax_expr(replacement));
+      } else {
+        LOG(FATAL) << "InternalError: "
+                   << "Variant did not match any allowed type";
+      }
+    } else if (auto opt = key.as<tir::Var>()) {
+      auto tir_var = opt.value();
+
+      CHECK(!tir_remap.count(tir_var))
+          << "Remap of symbolic variable " << tir_var << " was defined multiple times";
+      CHECK(symbolic_var_set.count(tir_var.get()))
+          << "ValueError: "
+          << "Expected all tir::Var special cases to appear as symbolic variables "
+          << "within the function signature.  "
+          << "Function signature has symbolic variables " << old_symbolic_vars;
+
+      tir_remap.Set(tir_var, get_tir_expr(tir_var, replacement));
+    } else if (auto opt = key.as<relax::Var>()) {
+      auto relax_var = opt.value();
+
+      CHECK(!relax_remap.count(relax_var))
+          << "Remap of variable " << relax_var << " was defined multiple times";
+      CHECK(relax_var_set.count(relax_var.get()))
+          << "ValueError: "
+          << "Expected all relax::Var special cases to appear as function parameters, "
+          << "but variable " << relax_var << " is not one of the function parameters.  "
+          << "Function has parameters " << func->params;
+    } else {
+      LOG(FATAL) << "Expected symbolic variable to be a tir::Var or a string name, "
+                 << "but " << key << " was of type " << key->GetTypeKey();
+    }
+  }
+
+  // The condition for symbolic variable special cases is collected in
+  // order of their occurrence in the function signature.  Generating
+  // `tir_cond` by iterating over `tir_remap` would produce equivalent
+  // expressions, but the order would be unspecified, which would make
+  // it difficult to test.
+  PrimExpr tir_cond = Bool(true);
+  for (auto it = old_symbolic_vars.rbegin(); it != old_symbolic_vars.rend(); it++) {
+    const auto& tir_var = *it;
+    if (auto expr = tir_remap.Get(tir_var)) {
+      tir_cond = tir_cond && (tir_var == expr.value());
+    }
+  }
+  ICHECK(relax_remap.empty()) << "Not yet supported";
+
+  Function general_case = func;
+  Function special_case = Downcast<Function>(Bind(func, relax_remap, tir_remap));
+
+  auto convert_to_lambda = [](Function func) -> Function {
+    func = WithoutAttr(std::move(func), tvm::attr::kGlobalSymbol);
+    func = CopyWithNewVars(std::move(func));
+    return func;
+  };
+  special_case = convert_to_lambda(special_case);
+  general_case = convert_to_lambda(general_case);
+
+  {
+    auto free_symbolic_vars = FreeSymbolicVars(special_case);
+    CHECK(free_symbolic_vars.empty())
+        << "Resulting special case should not have any undefined symbolic variables, "
+        << "but TIR variables " << free_symbolic_vars << " were undefined.";
+  }
+
+  relax::Var general_case_var("general_case", GetStructInfo(general_case));
+  relax::Var special_case_var("special_case", GetStructInfo(special_case));
+  relax::Var output("output", func->ret_struct_info);
+
+  Array<Binding> bindings = {
+      VarBinding(general_case_var, general_case),
+      VarBinding(special_case_var, special_case),
+      VarBinding(output,
+                 relax::If(relax::PrimValue(tir_cond),
+                           relax::Call(special_case_var,
+                                       func->params.Map([](Var var) -> Expr { return var; })),
+                           relax::Call(general_case_var,
+                                       func->params.Map([](Var var) -> Expr { return var; })))),
+  };
+
+  func.CopyOnWrite()->body = SeqExpr({BindingBlock(bindings)}, output);
+
+  func = Normalize(func);
+
+  return func;
+}
+
+TVM_REGISTER_GLOBAL("relax.FunctionCheckForSpecialCase")
+    .set_body_typed(FunctionCheckForSpecialCase);
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/transform/normalize.cc
+++ b/src/relax/transform/normalize.cc
@@ -170,6 +170,10 @@ class NormalizeMutator : public ExprMutatorBase {
 
 Expr Normalize(const Expr& e) { return NormalizeMutator().VisitExpr(e); }
 
+Function Normalize(Function func) {
+  return Downcast<Function>(NormalizeMutator().VisitExpr(std::move(func)));
+}
+
 class GlobalVarNormalizer : private ExprMutator {
  public:
   static IRModule Normalize(const IRModule& m) {

--- a/src/relax/transform/utils.h
+++ b/src/relax/transform/utils.h
@@ -394,6 +394,25 @@ inline int GetDeviceIndex(const IRModule& mod, const VDevice& vdevice) {
   return -1;
 }
 
+/*! Normalize a relax function
+ *
+ * This utility should only be used when there isn't already an
+ * `ExprMutator` in use.  In most cases, when normalization occurs as
+ * part of a `ExprMutator`, it should be invoked using
+ * `block_builder_->Normalize(expr)`.  Using the existing
+ * `BlockBuilder` for normalization is necessary for correct struct
+ * inference of dynamic shapes.
+ *
+ * This requires a `relax::Function` argument, rather than a
+ * `relax::Expr`, to ensure that it receives sufficient context to
+ * correctly normalize dynamic shapes.
+ *
+ * \param func The function to be normalized
+ *
+ * \returns The normalized function
+ */
+Function Normalize(Function func);
+
 /* \brief Eliminate common subexpressions
  *
  * Utility for simplifying relax expressions by removing common

--- a/src/script/ir_builder/relax/utils.h
+++ b/src/script/ir_builder/relax/utils.h
@@ -108,7 +108,13 @@ inline tvm::relax::SeqExpr GetSeqExprForBranch(const SeqExprFrame& frame, String
                                                  last_block->bindings.end() - 1);
   new_blocks.push_back(tvm::relax::BindingBlock(last_block_bindings));
 
-  return tvm::relax::SeqExpr(new_blocks, body);
+  tvm::relax::SeqExpr seq_expr(new_blocks, body);
+
+  // Any user-provided annotations for the SeqExpr's StructInfo must
+  // be propagated to the SeqExpr itself.
+  UpdateStructInfo(seq_expr, tvm::relax::GetStructInfo(body));
+
+  return seq_expr;
 }
 
 }  // namespace relax

--- a/tests/python/relax/test_check_for_special_case.py
+++ b/tests/python/relax/test_check_for_special_case.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import tvm
+import tvm.testing
+from tvm.script import relax as R, tir as T
+
+specialize_by_tir_var = tvm.testing.parameter(
+    by_dict={
+        # "specialize-by-string": False,
+        "specialize-by-tir-var": True,
+    }
+)
+
+
+def test_bind_static_value(specialize_by_tir_var):
+    """Symbolic vars may be specialized
+
+    The specialized variables may be given either as strings, or as
+    TIR variables.
+    """
+
+    @R.function(private=True)
+    def before(
+        A: R.Tensor(("M", "K"), "float16"), B: R.Tensor(("K", "N"), "float16")
+    ) -> R.Tensor(("M", "N"), "float16"):
+        return R.matmul(A, B)
+
+    @R.function(private=True)
+    def expected(
+        A: R.Tensor(("M", "K"), "float16"), B: R.Tensor(("K", "N"), "float16")
+    ) -> R.Tensor(("M", "N"), "float16"):
+        M = T.int64()
+        K = T.int64()
+        N = T.int64()
+
+        @R.function(private=True)
+        def general_case(
+            A: R.Tensor(("M", "K"), "float16"), B: R.Tensor(("K", "N"), "float16")
+        ) -> R.Tensor(("M", "N"), "float16"):
+            return R.matmul(A, B)
+
+        @R.function(private=True)
+        def special_case(
+            A: R.Tensor((128, 64), "float16"), B: R.Tensor((64, 32), "float16")
+        ) -> R.Tensor((128, 32), "float16"):
+            return R.matmul(A, B)
+
+        if R.prim_value(M == 128 and K == 64 and N == 32):
+            lambda_result = special_case(A, B)
+            out: R.Tensor((M, N), "float16") = lambda_result
+        else:
+            lambda_result = general_case(A, B)
+            out: R.Tensor((M, N), "float16") = lambda_result
+        return out
+
+    if specialize_by_tir_var:
+        M, K = before.params[0].struct_info.shape
+        _, N = before.params[1].struct_info.shape
+        symbolic_var_map = {M: 128, K: 64, N: 32}
+    else:
+        symbolic_var_map = {"M": 128, "K": 64, "N": 32}
+
+    before.show(name="before")
+
+    after = before.check_for_special_case(symbolic_var_map)
+
+    expected.show(name="expected")
+    after.show(name="after")
+
+    tvm.ir.assert_structural_equal(expected, after)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
If a dynamic model is frequently called with specific arguments or shapes of arguments, performance may be improved by generating to specialized versions of the model.  Previously, specialized versions of a relax function `func` could be generated using `func.bind_params` and `func.bind_symbolic_vars`.  However, use of these specialized versions requires the calling scope to explicitly check the preconditions of each kernel and call the appropriate one.

This commit implements a new utility, `check_for_special_case`, which handles both the generating of the special case, and checking whether the special case applies.  The function's user-facing signature is unmodified, while internally it delegates to either the original function or the specialized version depending on the result of the check.  This allows optimized kernels for specific static shapes to be introduced solely by changing the optimization pipeline, with no changes required in the calling scope.