### PR TITLE
[Unity] Improved error message in tvm::relax::UpdateStructInfo

### DIFF
--- a/src/relax/ir/struct_info.cc
+++ b/src/relax/ir/struct_info.cc
@@ -209,7 +209,11 @@ TVM_REGISTER_GLOBAL("relax.FuncStructInfoOpaqueFunc")
 // Helper functions
 void UpdateStructInfo(Expr expr, StructInfo struct_info) {
   ICHECK(!expr->struct_info_.defined())
-      << "the struct_info_ of the Expr to be updated must be nullptr for idempotency";
+      << "To ensure idempotency, "
+      << "the expression passed to UpdateStructInfo "
+      << "must not have any prior StructInfo.  "
+      << "However, expression " << expr << " has struct info " << expr->struct_info_
+      << ", which cannot be overwritten with " << struct_info;
   expr->struct_info_ = struct_info;
   // also set checked type
   expr->checked_type_ = GetStaticType(struct_info);


### PR DESCRIPTION
If the struct info cannot be updated, provide the expression, the previous struct info, and the new struct info in the error message.