### PR TITLE
Update flash attention to integrate flash decoding with paged KV cache

### DIFF
--- a/cmake/modules/contrib/CUTLASS.cmake
+++ b/cmake/modules/contrib/CUTLASS.cmake
@@ -26,6 +26,7 @@ if(USE_CUDA AND USE_CUTLASS)
   add_subdirectory(${PROJECT_SOURCE_DIR}/3rdparty/cutlass_fpA_intB_gemm)
   add_subdirectory(${PROJECT_SOURCE_DIR}/3rdparty/libflash_attn)
   list(APPEND RUNTIME_SRCS src/runtime/contrib/cutlass/weight_preprocess.cc)
+  list(APPEND RUNTIME_SRCS src/runtime/contrib/cutlass/flash_decoding.cu)
 
   message(STATUS "Build with CUTLASS")
 endif()

--- a/cmake/modules/contrib/CUTLASS.cmake
+++ b/cmake/modules/contrib/CUTLASS.cmake
@@ -25,6 +25,9 @@ if(USE_CUDA AND USE_CUTLASS)
   set(CUTLASS_DIR ${PROJECT_SOURCE_DIR}/3rdparty/cutlass)
   add_subdirectory(${PROJECT_SOURCE_DIR}/3rdparty/cutlass_fpA_intB_gemm)
   add_subdirectory(${PROJECT_SOURCE_DIR}/3rdparty/libflash_attn)
+
+  include_directories(${PROJECT_SOURCE_DIR}/3rdparty/cutlass/include)
+
   list(APPEND RUNTIME_SRCS src/runtime/contrib/cutlass/weight_preprocess.cc)
   list(APPEND RUNTIME_SRCS src/runtime/contrib/cutlass/flash_decoding.cu)
 

--- a/src/runtime/contrib/cutlass/flash_decoding.cu
+++ b/src/runtime/contrib/cutlass/flash_decoding.cu
@@ -30,15 +30,21 @@
 namespace tvm {
 namespace runtime {
 
+/*
+  query: (batch_size, seqlen_q, num_heads, head_size), fp16
+  key_cache: (num_blocks, page_block_size, num_heads_k, head_size), fp16
+  value_cache: num_blocks, page_block_size, num_heads_k, head_size), fp16
+  block_tables: (batch_size, max_num_blocks_per_seq), int32
+  context_lens: (batch_size,), int32
+  softmax_lse_accum: (max_num_splits, batch_size, num_heads, seqlen_q), fp32
+  output_accum: (max_num_splits, batch_size, num_heads, seqlen_q, head_size), fp32
+  out: (batch_size, seqlen_q, num_heads, head_size), fp16
+*/
 TVM_REGISTER_GLOBAL("tvm.contrib.flash_attn.flash_decoding_with_paged_kvcache")
-  .set_body_typed([](const DLTensor* query,  // (batch_size, seqlen_q, num_heads, head_size), fp16
-		     const DLTensor* key_cache,  // (num_blocks, page_block_size, num_heads_k, head_size), fp16
-                     const DLTensor* value_cache,  // (num_blocks, page_block_size, num_heads_k, head_size), fp16
-		     const DLTensor* block_tables,  // (batch_size, max_num_blocks_per_seq), int32
-                     const DLTensor* context_lens,  // (batch_size,), int32
-		     DLTensor* softmax_lse_accum,  // (max_num_splits, batch_size, num_heads, seqlen_q), fp32
-                     DLTensor* output_accum,  // (max_num_splits, batch_size, num_heads, seqlen_q, head_size), fp32
-		     DLTensor* out) {  // (batch_size, seqlen_q, num_heads, head_size), fp16
+  .set_body_typed([](const DLTensor* query, const DLTensor* key_cache,
+                     const DLTensor* value_cache, const DLTensor* block_tables,
+                     const DLTensor* context_lens, DLTensor* softmax_lse_accum,
+                     DLTensor* output_accum, DLTensor* out) {
       int batch_size = query->shape[0];
       int seqlen_q = query->shape[1];
       int num_heads = query->shape[2];

--- a/src/runtime/contrib/cutlass/flash_decoding.cu
+++ b/src/runtime/contrib/cutlass/flash_decoding.cu
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/runtime/container/shape_tuple.h>
+
+#include "../../../3rdparty/libflash_attn/include/flash.h"
+
+namespace tvm {
+namespace runtime {
+
+TVM_REGISTER_GLOBAL("tvm.contrib.flash_attn.flash_decoding_with_paged_kvcache")
+  .set_body_typed([](const DLTensor* query, const DLTensor* key_cache,
+		     const DLTensor* value_cache, const DLTensor* block_tables,
+		     const DLTensor* context_lens, DLTensor* softmax_lse_accum,
+		     DLTensor* output_accum, DLTensor* out) {
+      int batch_size = query->shape[0];
+      int seqlen_q = query->shape[1];
+      int num_heads = query->shape[2];
+      int head_dim = query->shape[3];
+      int num_heads_k = key_cache->shape[2];
+      int num_blocks = key_cache->shape[0];
+      int block_size = key_cache->shape[1];
+      int max_num_blocks_per_seq = block_tables->shape[1];
+      float softmax_scale = 1.0 / sqrt((float)head_dim);
+
+      auto block_table_ptr = static_cast<int*>(block_tables->data);
+      auto seqlens_k_ptr = static_cast<int*>(context_lens->data);
+
+      using half = ::flash_attn::half;
+
+      auto q_ptr = static_cast<half*>(query->data);
+      auto kcache_ptr = static_cast<half*>(key_cache->data);
+      auto vcache_ptr =static_cast<half*>(value_cache->data);
+      auto softmax_lse_accum_ptr = static_cast<float*>(softmax_lse_accum->data);
+      auto output_accum_ptr = static_cast<float*>(output_accum->data);
+      auto output_ptr = static_cast<half*>(out->data);
+
+      int q_head_stride = head_dim;
+      int k_head_stride = head_dim;
+      int v_head_stride = head_dim;
+      int o_head_stride = head_dim;
+      int q_row_stride = q_head_stride * num_heads;
+      int k_row_stride = k_head_stride * num_heads_k;
+      int v_row_stride = v_head_stride * num_heads_k;
+      int o_row_stride = o_head_stride * num_heads;
+      int q_batch_stride = q_row_stride * seqlen_q;
+      int k_batch_stride = k_row_stride * block_size;
+      int v_batch_stride = v_row_stride * block_size;
+      int o_batch_stride = o_row_stride * seqlen_q;
+      int block_table_batch_stride = max_num_blocks_per_seq;
+
+      ::flash_attn::flash_attention_splitkv_paged_forward(
+          q_ptr, kcache_ptr, vcache_ptr, block_table_ptr, seqlens_k_ptr,
+	  softmax_lse_accum_ptr, output_accum_ptr,
+          output_ptr, batch_size, seqlen_q, num_heads, num_heads_k, head_dim,
+          q_batch_stride,
+          k_batch_stride,
+          v_batch_stride,
+          o_batch_stride,
+          q_head_stride,
+          k_head_stride,
+          v_head_stride,
+          o_head_stride,
+          q_row_stride,
+          k_row_stride,
+          v_row_stride,
+          o_row_stride,
+          num_blocks, block_size, max_num_blocks_per_seq,
+          block_table_batch_stride,
+          softmax_scale,
+	  true // is_causal
+       );
+    });
+
+}  // namespace runtime
+}  // namespace tvm

--- a/src/runtime/contrib/cutlass/flash_decoding.cu
+++ b/src/runtime/contrib/cutlass/flash_decoding.cu
@@ -32,9 +32,9 @@ namespace runtime {
 
 TVM_REGISTER_GLOBAL("tvm.contrib.flash_attn.flash_decoding_with_paged_kvcache")
   .set_body_typed([](const DLTensor* query, const DLTensor* key_cache,
-		     const DLTensor* value_cache, const DLTensor* block_tables,
-		     const DLTensor* context_lens, DLTensor* softmax_lse_accum,
-		     DLTensor* output_accum, DLTensor* out) {
+                     const DLTensor* value_cache, const DLTensor* block_tables,
+                     const DLTensor* context_lens, DLTensor* softmax_lse_accum,
+                     DLTensor* output_accum, DLTensor* out) {
       int batch_size = query->shape[0];
       int seqlen_q = query->shape[1];
       int num_heads = query->shape[2];
@@ -43,7 +43,7 @@ TVM_REGISTER_GLOBAL("tvm.contrib.flash_attn.flash_decoding_with_paged_kvcache")
       int num_blocks = key_cache->shape[0];
       int block_size = key_cache->shape[1];
       int max_num_blocks_per_seq = block_tables->shape[1];
-      float softmax_scale = 1.0 / sqrt((float)head_dim);
+      float softmax_scale = 1.0 / sqrt(static_cast<float>(head_dim));
 
       auto block_table_ptr = static_cast<int*>(block_tables->data);
       auto seqlens_k_ptr = static_cast<int*>(context_lens->data);
@@ -52,7 +52,7 @@ TVM_REGISTER_GLOBAL("tvm.contrib.flash_attn.flash_decoding_with_paged_kvcache")
 
       auto q_ptr = static_cast<half*>(query->data);
       auto kcache_ptr = static_cast<half*>(key_cache->data);
-      auto vcache_ptr =static_cast<half*>(value_cache->data);
+      auto vcache_ptr = static_cast<half*>(value_cache->data);
       auto softmax_lse_accum_ptr = static_cast<float*>(softmax_lse_accum->data);
       auto output_accum_ptr = static_cast<float*>(output_accum->data);
       auto output_ptr = static_cast<half*>(out->data);
@@ -73,7 +73,7 @@ TVM_REGISTER_GLOBAL("tvm.contrib.flash_attn.flash_decoding_with_paged_kvcache")
 
       ::flash_attn::flash_attention_splitkv_paged_forward(
           q_ptr, kcache_ptr, vcache_ptr, block_table_ptr, seqlens_k_ptr,
-	  softmax_lse_accum_ptr, output_accum_ptr,
+          softmax_lse_accum_ptr, output_accum_ptr,
           output_ptr, batch_size, seqlen_q, num_heads, num_heads_k, head_dim,
           q_batch_stride,
           k_batch_stride,
@@ -90,8 +90,7 @@ TVM_REGISTER_GLOBAL("tvm.contrib.flash_attn.flash_decoding_with_paged_kvcache")
           num_blocks, block_size, max_num_blocks_per_seq,
           block_table_batch_stride,
           softmax_scale,
-	  true // is_causal
-       );
+          true /* is_causal*/);
     });
 
 }  // namespace runtime

--- a/tests/python/relax/test_contrib_flash_attn.py
+++ b/tests/python/relax/test_contrib_flash_attn.py
@@ -1,0 +1,136 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import torch
+
+try:
+    from flash_attn import flash_attn_with_kvcache
+
+    has_flash_attn_py = True
+except:
+    has_flash_attn_py = False
+
+import numpy as np
+import pytest
+
+import tvm.testing
+import tvm
+from tvm import relax
+from tvm.script import ir as I
+from tvm.script import relax as R
+from tvm.script import tir as T
+
+
+has_flash = tvm.get_global_func("tvm.contrib.flash_attn.flash_decoding_with_paged_kvcache", True)
+
+flash_attn_enabled = pytest.mark.skipif(
+    not has_flash,
+    reason="Flash attention not enabled.",
+)
+
+pytestmark = [flash_attn_enabled]
+
+
+def test_flash_decoding_with_paged_kvcache():
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(
+            query: R.Tensor(("num_seqs", "seqlen_q", 8, 64), dtype="float16"),
+            key_cache: R.Tensor(("num_blocks", 256, 8, 64), dtype="float16"),
+            value_cache: R.Tensor(("num_blocks", 256, 8, 64), dtype="float16"),
+            block_tables: R.Tensor(("num_seqs", "max_num_blocks_per_seq"), dtype="int32"),
+            context_lens: R.Tensor(("num_seqs",), dtype="int32"),
+        ) -> R.Tensor(("num_seqs", "seqlen_q", 8, 64), dtype="float16"):
+            with R.dataflow():
+                num_seqs = T.int64()
+                seqlen_q = T.int64()
+                # alloc workspace
+                softmax_lse_accum = R.zeros((128, num_seqs, 8, seqlen_q), "float32")
+                output_accum = R.zeros((128, num_seqs, 8, seqlen_q, 64), "float32")
+
+                out = R.call_dps_packed(
+                    "tvm.contrib.flash_attn.flash_decoding_with_paged_kvcache",
+                    [
+                        query,
+                        key_cache,
+                        value_cache,
+                        block_tables,
+                        context_lens,
+                        softmax_lse_accum,
+                        output_accum,
+                    ],
+                    out_sinfo=query.struct_info,
+                )
+                R.output(out)
+            return out
+
+    np.random.seed(0)
+    num_heads = 8
+    head_dim = 64
+    block_size = 256
+    num_seqs = 2
+    num_blocks = 2
+
+    target = "cuda"
+
+    with tvm.target.Target(target):
+        mod = relax.transform.LegalizeOps()(Module)
+        mod = tvm.tir.transform.DefaultGPUSchedule()(mod)
+
+    with tvm.transform.PassContext():
+        ex = relax.build(mod, target)
+
+    key_cache = np.random.randn(num_blocks, block_size, num_heads, head_dim).astype("float16")
+    value_cache = np.random.randn(num_blocks, block_size, num_heads, head_dim).astype("float16")
+
+    for seqlen_q in [1, 5]:
+        query = np.random.randn(num_seqs, seqlen_q, num_heads, head_dim).astype("float16")
+        block_tables = np.array([[0], [1]]).astype("int32")
+        context_lens = np.array([10, 9]).astype("int32")
+
+        inputs_np = [query, key_cache, value_cache, block_tables, context_lens]
+
+        dev = tvm.device(target, 0)
+        vm = relax.VirtualMachine(ex, dev)
+        f = vm["main"]
+        inputs = [tvm.nd.array(inp, dev) for inp in inputs_np]
+
+        out = f(*inputs).numpy()
+
+        if has_flash_attn_py:
+
+            def to_torch(arr):
+                return torch.from_numpy(arr).to("cuda")
+
+            ref = (
+                flash_attn_with_kvcache(
+                    to_torch(query),
+                    to_torch(key_cache),
+                    to_torch(value_cache),
+                    cache_seqlens=to_torch(context_lens),
+                    block_table=to_torch(block_tables),
+                    causal=True,
+                )
+                .cpu()
+                .numpy()
+            )
+
+        assert np.max(np.abs(ref - out)) == 0.0
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Flash attention recently added support for loading from paged KV cache in https://github.com/Dao-AILab/flash-attention/commit/54e80a3829c6d2337570d01e78ebd9529c02d342. The support was added to the [Flash-Decoding kernel](https://pytorch.org/blog/flash-decoding/), which we haven't used so far. 

This PR lets us use Flash Decoding with paged KV cache support from TVM. We already use other kernels from Flash attention via BYOC, but due to the specialized nature of this kernel, it is supported as a contrib kernel (similar to vllm).

See also https://github.com/tlc-pack/libflash_attn/pull/9

@vinx13 @sunggg  