### PR TITLE
[Frontend][PaddlePaddle] Fixed the bug that prevented the model from being successfully converted to microTVM on MacOS

### DIFF
--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -203,7 +203,7 @@ def convert_batch_norm(g, op, block):
     mean_name = op.input("Mean")[0]
     variance_name = op.input("Variance")[0]
     epsilon = op.attr("epsilon")
-    data_layout = op.attr("data_format")
+    data_layout = op.attr("data_layout")
 
     if data_layout == "NCHW":
         axis = 1
@@ -1219,10 +1219,8 @@ def convert_matmul(g, op, block):
 
     # This implemention almost keeps same with ONNX
     # Need to check input shape as batch matmul must be supported.
-    a_shape = shape_of(inputs[0], dtype="int32")
-    a_rank = infer_shape(a_shape)[0]
-    b_shape = shape_of(inputs[1], dtype="int32")
-    b_rank = infer_shape(b_shape)[0]
+    a_rank = len(a_shape)
+    b_rank = len(b_shape)
     # When performing a batch matmul, we need to properly handle N-dim shapes.
     if a_rank > 2 or b_rank > 2:
 

--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -2988,7 +2988,7 @@ class GraphProto:
         if scope is None:
             import paddle
 
-            scope = paddle.fluid.global_scope()
+            scope = paddle.static.global_scope()
         self.check_unsupported_ops(program)
         self.extract_parameters(program, scope)
         self.ops_to_relay(program)


### PR DESCRIPTION
## New Support

* Support BatchNormalize operator for NHWC layout
* Support Pool2D operator for NHWC layout

## Fixed Bug

* The Paddle API version has been updated to 2.6.0, but some API versions in TVM are still at 2.5.0
* When converting the Paddle MatMul operator, a crash occurs on MacOS due to the use of infer_shape to calculate rank