### PR TITLE
[Doc] Fix Docstring in `extern.py` for Sphinx

### DIFF
--- a/python/tvm/relax/frontend/nn/extern.py
+++ b/python/tvm/relax/frontend/nn/extern.py
@@ -138,6 +138,7 @@ class SourceModule(ExternModule):  # pylint: disable=too-few-public-methods
     To expose the symbol, `TVM_DLL_EXPORT_TYPED_FUNC(symbol, function)` is guaranteed available:
 
     .. code-block:: C++
+
         // those headers are guaranteed to be available
         #include <dlpack/dlpack.h>
         #include <tvm/runtime/data_type.h>
@@ -151,7 +152,6 @@ class SourceModule(ExternModule):  # pylint: disable=too-few-public-methods
         }
         // expose symbol `my_func` instead of `_my_func_impl`
         TVM_DLL_EXPORT_TYPED_FUNC(my_func, _my_func_impl);
-
 
     **A compiler pass `AttachExternModules`.** It is introduced to attach a list of
     `nn.ExternModule`s into an IRModule at any stage of the compilation pipeline,


### PR DESCRIPTION
Fix a missing line in the docstring of `extern.py`, which would cause Sphinx to fail to build the documentation.