### PR TITLE
[Runtime] KV cache providing workspace for attn kernel

### DIFF
--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_tir.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_tir.py
@@ -514,9 +514,8 @@ def _inplace_rope(
         _1: T.int32,
         _2: T.int32,
         _3: T.int32,
-        _4: T.int32,
+        _4: T.float32,
         _5: T.float32,
-        _6: T.float32,
     ):
         T.func_attr({"tir.is_scheduled": 1})
         total_len = T.int32()


### PR DESCRIPTION
This PR supports passing pre-allocated workspace to attention kernels, so that runtime repetitive allocation or workspaces can be eliminated.