### PR TITLE
[Unity][MSC][M4.2][Step1] Enable plugin with manager, test plugins in compile pipeline

### DIFF
--- a/python/tvm/contrib/msc/core/tools/prune/pruner.py
+++ b/python/tvm/contrib/msc/core/tools/prune/pruner.py
@@ -82,6 +82,7 @@ class BasePruner(WeightTool):
         def _update_stages(strategy):
             if "stages" not in strategy:
                 strategy["stages"] = [msc_utils.MSCStage.PRUNE]
+            strategy["tensor_types"] = ["weight", "output"]
             return strategy
 
         return super()._parse_strategys([_update_stages(s) for s in strategy_list])

--- a/python/tvm/contrib/msc/core/tools/quantize/quantizer.py
+++ b/python/tvm/contrib/msc/core/tools/quantize/quantizer.py
@@ -114,6 +114,11 @@ class BaseQuantizer(BaseTool):
             Whether to process the tensor.
         """
 
+        if self._calibrated:
+            tensor_id = self.to_tensor_id(name, consumer)
+            if tensor_id not in self._plan:
+                return False
+            return self._plan.get(tensor_id, {}).get("nbits", 8) != -1
         strategys = self._get_tensor_strategys(name, consumer)
         if not strategys:
             return False

--- a/python/tvm/contrib/msc/framework/tensorflow/codegen/codegen.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/codegen/codegen.py
@@ -16,7 +16,7 @@
 # under the License.
 """tvm.contrib.msc.framework.tensorflow.codegen.codegen"""
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 import tvm
 from tvm.contrib.msc.core.ir import MSCGraph
@@ -32,6 +32,7 @@ def to_tensorflow(
     codegen_config: Optional[Dict[str, str]] = None,
     print_config: Optional[Dict[str, str]] = None,
     build_folder: msc_utils.MSCDirectory = None,
+    plugin: Any = None,
 ) -> tf_v1.Graph:
     """Change MSCGraph to tensorflow graph.
 
@@ -47,6 +48,8 @@ def to_tensorflow(
         The config for print.
     build_folder: MSCDirectory
         The folder for saving scripts and datas.
+    plugin: PluginManager
+        The plugin manager.
 
     Returns
     -------
@@ -63,4 +66,7 @@ def to_tensorflow(
     codegen = CodeGen(
         graph, _ffi_api.GetTensorflowSources, codegen_config, print_config, build_folder
     )
-    return codegen.load(inputs + [weights], pre_load=_save_weights)
+    model_args = inputs + [weights]
+    if plugin:
+        model_args = model_args + [plugin]
+    return codegen.load(model_args, pre_load=_save_weights)

--- a/python/tvm/contrib/msc/framework/torch/codegen/codegen.py
+++ b/python/tvm/contrib/msc/framework/torch/codegen/codegen.py
@@ -16,7 +16,7 @@
 # under the License.
 """tvm.contrib.msc.framework.torch.codegen.codegen"""
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 import torch
 
 import tvm
@@ -32,6 +32,7 @@ def to_torch(
     codegen_config: Optional[Dict[str, str]] = None,
     print_config: Optional[Dict[str, str]] = None,
     build_folder: msc_utils.MSCDirectory = None,
+    plugin: Any = None,
 ) -> torch.nn.Module:
     """Change MSCGraph to torch nn.Module.
 
@@ -47,6 +48,8 @@ def to_torch(
         The config for print.
     build_folder: MSCDirectory
         The folder for saving scripts and datas.
+    plugin: PluginManager
+        The plugin manager.
 
     Returns
     -------
@@ -73,4 +76,5 @@ def to_torch(
         return model
 
     codegen = CodeGen(graph, _ffi_api.GetTorchSources, codegen_config, print_config, build_folder)
-    return codegen.load([], pre_load=_save_weights, post_load=_bind_weights)
+    model_args = [plugin] if plugin else []
+    return codegen.load(model_args, pre_load=_save_weights, post_load=_bind_weights)

--- a/python/tvm/contrib/msc/framework/tvm/codegen/codegen.py
+++ b/python/tvm/contrib/msc/framework/tvm/codegen/codegen.py
@@ -16,7 +16,7 @@
 # under the License.
 """tvm.contrib.msc.framework.tvm.codegen.codegen"""
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 import tvm
 from tvm.relax.transform import BindParams
@@ -32,6 +32,7 @@ def to_relax(
     codegen_config: Optional[Dict[str, str]] = None,
     print_config: Optional[Dict[str, str]] = None,
     build_folder: msc_utils.MSCDirectory = None,
+    plugin: Any = None,
 ) -> tvm.IRModule:
     """Change MSCGraph to IRModule.
 
@@ -47,6 +48,8 @@ def to_relax(
         The config for print.
     build_folder: MSCDirectory
         The folder for saving scripts and datas.
+    plugin: PluginManager
+        The plugin manager.
 
     Returns
     -------
@@ -81,4 +84,7 @@ def to_relax(
         )(mod)
 
     codegen = CodeGen(graph, _ffi_api.GetRelaxSources, codegen_config, print_config, build_folder)
-    return codegen.load(inputs, pre_load=_save_weights, post_load=_post_proc)
+    model_args = inputs
+    if plugin:
+        model_args = model_args + [plugin]
+    return codegen.load(model_args, pre_load=_save_weights, post_load=_post_proc)

--- a/python/tvm/contrib/msc/pipeline/__init__.py
+++ b/python/tvm/contrib/msc/pipeline/__init__.py
@@ -17,4 +17,3 @@
 """tvm.contrib.msc.pipeline"""
 
 from .manager import *
-from .wrapper import *

--- a/python/tvm/contrib/msc/pipeline/__init__.py
+++ b/python/tvm/contrib/msc/pipeline/__init__.py
@@ -17,3 +17,4 @@
 """tvm.contrib.msc.pipeline"""
 
 from .manager import *
+from .wrapper import *

--- a/src/contrib/msc/framework/tensorrt/codegen.cc
+++ b/src/contrib/msc/framework/tensorrt/codegen.cc
@@ -27,6 +27,8 @@
 #include <tvm/ir/module.h>
 #include <tvm/relax/expr.h>
 
+#include <set>
+
 #include "../../core/codegen/codegen_json.h"
 
 namespace tvm {
@@ -42,6 +44,17 @@ void TensorRTCodeGen::CodeGenClassDeclare() {
       .line("#include \"utils/trt_common.h\"");
   if (config()->precision == "int8") {
     stack_.line("#include \"utils/trt_quantize.h\"");
+  }
+  // plugin headers
+  if (config()->use_plugin) {
+    std::set<String> plugins;
+    for (const auto& n : graph()->node_names) {
+      const auto& node = graph()->FindNode(n);
+      if (IsPlugin(node->optype) && !plugins.count(node->optype)) {
+        stack_.line("#include \"plugin/" + node->optype + "_op.h\"");
+        plugins.insert(node->optype);
+      }
+    }
   }
   stack_.line().line("using namespace nvinfer1;").line();
   StartNamespace();
@@ -439,6 +452,7 @@ void TensorRTCodeGen::CodeGenCmake() {
   stack_.line("cmake_minimum_required(VERSION " + config()->cmake_version + " FATAL_ERROR)")
       .line("project(" + graph()->name + ")")
       .line("find_package(CUDA)")
+      .line()
       .line("find_path(TRT_INCLUDE_DIR NvInfer.h HINTS " + config()->tensorrt_root +
             " PATH_SUFFIXES include)")
       .line("find_library(TRT_LIBS nvinfer HINTS " + config()->tensorrt_root +
@@ -447,13 +461,23 @@ void TensorRTCodeGen::CodeGenCmake() {
           "message(STATUS \"Build project with TRT_INCLUDE_DIR ${TRT_INCLUDE_DIR} and "
           "TRT_LIBS "
           "${TRT_LIBS}\")")
+      .line()
       .line("add_definitions(-DTRT_MAJOR=" + std::to_string(config()->version[0]) + ")")
       .line("add_definitions(-DTRT_MINOR=" + std::to_string(config()->version[1]) + ")")
       .line("add_definitions(-DTRT_PATCH=" + std::to_string(config()->version[2]) + ")")
-      .line("file(GLOB_RECURSE TRT_SRCS *.cc)")
+      .line();
+  if (config()->use_plugin) {
+    stack_.line("add_definitions(-DPLUGIN_SUPPORT_TENSORRT)").line();
+  }
+  String link_libs = " ${TRT_LIBS}";
+  if (config()->extern_libs.size() > 0) {
+    stack_.line("set(EXTERN_LIBS " + StringUtils::Join(config()->extern_libs, " ") + ")");
+    link_libs = link_libs + " ${EXTERN_LIBS}";
+  }
+  stack_.line("file(GLOB_RECURSE TRT_SRCS *.cc)")
       .line("cuda_add_executable(" + graph()->name + " ${TRT_SRCS})")
       .line("target_include_directories(" + graph()->name + " PUBLIC ${TRT_INCLUDE_DIR})")
-      .line("target_link_libraries(" + graph()->name + " ${TRT_LIBS})");
+      .line("target_link_libraries(" + graph()->name + link_libs + ")");
 }
 
 const String TensorRTCodeGen::IdxTensor(const MSCTensor& tensor) {
@@ -518,7 +542,7 @@ const String TensorRTCodeGen::ToDims(const Array<Integer>& dims, bool use_ndim) 
 
 const Array<Doc> TensorRTCodeGen::GetOpCodes(const MSCJoint& node) {
   const auto& ops_map = GetTensorRTOpCodes();
-  auto it = ops_map->find(node->optype);
+  auto it = ops_map->find(GetOpType(node));
   ICHECK(it != ops_map->end()) << "Unsupported tensorrt op(" << node->optype << "): " << node;
   it->second->Config(node, config());
   try {

--- a/src/contrib/msc/framework/tensorrt/codegen_utils.h
+++ b/src/contrib/msc/framework/tensorrt/codegen_utils.h
@@ -25,6 +25,7 @@
 #define TVM_CONTRIB_MSC_FRAMEWORK_TENSORRT_CODEGEN_UTILS_H_
 
 #include <string>
+#include <vector>
 
 #include "../../core/codegen/base_codegen.h"
 #include "../../core/codegen/codegen_utils.h"
@@ -89,6 +90,7 @@ struct TensorRTCodeGenConfig {
   std::string precision{"float32"};
   std::string precision_mode{"strict"};
   std::string tensorrt_root{"/usr/local/cuda"};
+  std::vector<std::string> extern_libs;
   CODEGEN_CONFIG_MEMBERS
   void Load(dmlc::JSONReader* reader) {
     std::string key;
@@ -114,6 +116,8 @@ struct TensorRTCodeGenConfig {
         reader->Read(&precision_mode);
       } else if (key == "tensorrt_root") {
         reader->Read(&tensorrt_root);
+      } else if (key == "extern_libs") {
+        reader->Read(&extern_libs);
       } else {
         CODEGEN_CONFIG_PARSE
       }

--- a/src/contrib/msc/framework/tvm/relax_opcode.cc
+++ b/src/contrib/msc/framework/tvm/relax_opcode.cc
@@ -668,6 +668,19 @@ class RelaxTriCodeGen : public RelaxOpCode {
   }
 };
 
+class RelaxPluginOpCodeGen : public RelaxOpCode {
+  RELAX_OP_CODEGEN_METHODS(RelaxPluginOpCodeGen)
+
+ protected:
+  void CodeGenBuild() final {
+    const auto& plugin = GetPlugin(node()->optype);
+    stack_.op_call("plugin." + node()->optype).op_inputs_arg(false);
+    for (const auto& a : plugin->attrs) {
+      stack_.call_arg(GetAttrDoc(a->name, a->type), a->name);
+    }
+  }
+};
+
 const std::shared_ptr<std::unordered_map<String, std::shared_ptr<RelaxOpCode>>> GetRelaxOpCodes() {
   static auto map = std::make_shared<std::unordered_map<String, std::shared_ptr<RelaxOpCode>>>();
   if (!map->empty()) return map;
@@ -798,6 +811,7 @@ const std::shared_ptr<std::unordered_map<String, std::shared_ptr<RelaxOpCode>>> 
   map->emplace("get_item", std::make_shared<RelaxGetItemCodeGen>("relax.TupleGetItem"));
   map->emplace("shape", std::make_shared<RelaxShapeCodeGen>("relax.ShapeExpr"));
   map->emplace("tuple", std::make_shared<RelaxTupleCodeGen>("relax.Tuple"));
+  map->emplace("plugin", std::make_shared<RelaxPluginOpCodeGen>("Plugin"));
 
   // msc ops
   map->emplace("msc.attention", std::make_shared<RelaxAttentionCodeGen>("relax.op.nn.attention"));


### PR DESCRIPTION
This is a pull request for MSC(Multi-System Compile)
RFC: https://discuss.tvm.apache.org/t/rfc-unity-msc-introduction-to-multi-system-compiler/15251/5
Tracking issue: https://github.com/apache/tvm/issues/15233

This is the Milestone 4 for MSC: Add plugin builder, enable plugin wrap in different frameworks.
To limit each PR in reviewable size, the Milestone 4 will be split into some steps:
[M4.1] Add plugin && plugin_builder, enable build and test in different frameworks.
**[M4.2] Enable plugin with manager, test plugins in compile pipeline.**

To enable using plugin in compile pipeline, the plugin manager is used together with MSC Manager. Plugin manager handles the converter of plugin from training framework to relax. Codegen parts are also modified for code generation.

This PR add necessary codes in MSC. To enable using plugin in pipeline, relax.frontend.torch.from_fx should also be changed, which will be included in next PR.

cc @Hzfengsy 