### PR TITLE
[Runtime] ParallelFor skipping thread backend for unit extent

### DIFF
--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -203,6 +203,11 @@ inline void parallel_launch_with_threading_backend(T flambda) {
 
 template <typename T>
 inline void parallel_for_with_threading_backend(T flambda, int64_t begin, int64_t end) {
+  if (end - begin == 1) {
+    flambda(begin);
+    return;
+  }
+
   auto flaunch = [begin, end, flambda](int task_id, int num_task) {
     // For each thread, do static division and call into flambda.
     int64_t total_len = end - begin;


### PR DESCRIPTION
This PR skips launching multiple parallel threads in `parallel_for_with_threading_backend` when the input extent is 1, in which case we can just use the current thread to run the given function.