### PR TITLE
[Minor] Fix Clang compilation warning in fuse_tir.cc and codegen_c_host.cc

### DIFF
--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -682,7 +682,7 @@ class FusedTIRConstructor : public ExprVisitor {
       const tir::Var& param = output_params[i];
       const tir::Buffer& buffer = func->buffer_map.at(param);
 
-      auto unify_name_hints = [this, &buffer, &param]() {
+      auto unify_name_hints = [this, &buffer]() {
         String base_name = buffer->name;
         String unique_name = base_name + "_intermediate";
         size_t unique_id = 0;

--- a/src/target/source/codegen_c_host.cc
+++ b/src/target/source/codegen_c_host.cc
@@ -75,6 +75,10 @@ void CodeGenCHost::InitGlobalContext() {
 
 void CodeGenCHost::DefineModuleName() { decl_stream << "void* " << module_name_ << " = NULL;\n"; }
 
+void CodeGenCHost::AddFunction(const GlobalVar& gvar, const PrimFunc& func) {
+  return AddFunction(gvar, func, /*emit_fwd_func_decl=*/false);
+}
+
 void CodeGenCHost::AddFunction(const GlobalVar& gvar, const PrimFunc& func,
                                bool emit_fwd_func_decl) {
   auto global_symbol = func->GetAttr<String>(tvm::attr::kGlobalSymbol);

--- a/src/target/source/codegen_c_host.h
+++ b/src/target/source/codegen_c_host.h
@@ -44,7 +44,8 @@ class CodeGenCHost : public CodeGenC {
             const std::unordered_set<std::string>& devices);
 
   void InitGlobalContext();
-  void AddFunction(const GlobalVar& gvar, const PrimFunc& f, bool emit_fwd_func_decl = false);
+  void AddFunction(const GlobalVar& gvar, const PrimFunc& f) override;
+  void AddFunction(const GlobalVar& gvar, const PrimFunc& f, bool emit_fwd_func_decl);
   /*!
    * \brief Add functions from the (unordered) range to the current module in a deterministic
    * order. This helps with debugging.


### PR DESCRIPTION


The original two warnings are:
```
[build] /Users/syfeng/tvm/src/relax/transform/fuse_tir.cc:685:48: warning: lambda capture 'param' is not used [-Wunused-lambda-capture]
[build]       auto unify_name_hints = [this, &buffer, &param]() {
[build]                                             ~~~^~~~~

[build] /Users/syfeng/tvm/src/target/source/codegen_c_host.h:47:8: warning: 'tvm::codegen::CodeGenCHost::AddFunction' hides overloaded virtual function [-Woverloaded-virtual]
[build]   void AddFunction(const GlobalVar& gvar, const PrimFunc& f, bool emit_fwd_func_decl = false);
[build]        ^
[build] /Users/syfeng/tvm/src/target/source/codegen_c.h:86:16: note: hidden overloaded virtual function 'tvm::codegen::CodeGenC::AddFunction' declared here: different number of parameters (2 vs 3)
[build]   virtual void AddFunction(const GlobalVar& gvar, const PrimFunc& func);
[build]                ^
```