### PR TITLE
[Unity][Doc] Document passes that depend on `DataflowBlock`s and encourage using `ConvertToDataflow`

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -216,6 +216,8 @@ TVM_DLL Pass BindSymbolicVars(Map<ObjectRef, PrimExpr> binding_map,
 /*!
  * \brief Fold constant expressions within dataflow blocks.
  *
+ * \note ConvertToDataflow may need to be called first to provide dataflow blocks.
+ *
  * \return The Pass.
  */
 TVM_DLL Pass FoldConstant();
@@ -458,6 +460,8 @@ class PatternCheckContext : public ObjectRef {
  * of the return value as the target. If it is not specified, the first return value will be the
  * target.
  * \return The Pass.
+ * 
+ * \note ConvertToDataflow may need to be called first to provide dataflow blocks.
  */
 TVM_DLL Pass Gradient(String func_name, Optional<Array<Var>> require_grads = NullOpt,
                       int target_index = 0);
@@ -477,8 +481,8 @@ TVM_DLL Pass Gradient(String func_name, Optional<Array<Var>> require_grads = Nul
  * This must be True if the created composite functions are intended to be offloaded to
  * an external backend without using the MergeCompositeFunctions pass.
  * \return The Pass.
- * 
- * \note Only operates within dataflow blocks.
+ *
+ * \note Only operates within dataflow blocks. ConvertToDataflow may need to be called first.
  */
 TVM_DLL Pass FuseOpsByPattern(const tvm::Array<FusionPattern>& patterns, bool bind_constants = true,
                               bool annotate_codegen = false);
@@ -550,7 +554,7 @@ TVM_DLL Pass AlterOpImpl(const Map<String, tir::PrimFunc>& op_impl_map,
  * \brief Layout conversion pass.
  * \param desired_layouts The desired layouts for some operators.
  * \return The Pass.
- * \note Operates only on dataflow blocks.
+ * \note Operates only on dataflow blocks. ConvertToDataflow may need to be called first.
  */
 TVM_DLL Pass ConvertLayout(Map<String, Array<String>> desired_layouts);
 
@@ -571,9 +575,9 @@ TVM_DLL Pass ConvertToDataflow(int min_size = 2);
  *      (those where the bound var is unused and no impure operation is used).
  *   2. Unused Relax functions in the module.
  *      We detect the call chain from the entry function, and remove all unused functions.
- * 
+ *
  * Any binding blocks that are left empty will be removed by the normalizer.
- * 
+ *
  * \return The Pass.
  */
 TVM_DLL Pass DeadCodeElimination(Array<runtime::String> entry_functions);
@@ -584,6 +588,7 @@ TVM_DLL Pass DeadCodeElimination(Array<runtime::String> entry_functions);
  * Supported operators will be replaced by calls to `call_tir_inplace` that invoke in-place
  * PrimFunc implementations of those operators (which are based on the legalizations of those
  * operators).
+ * \note ConvertToDataflow may need to be called first to provide dataflow blocks.
  * \return The pass.
  */
 TVM_DLL Pass DataflowUseInplaceCalls();
@@ -595,8 +600,8 @@ TVM_DLL Pass DataflowUseInplaceCalls();
  * \param fp16_input_names The names of function parameters whose dtype should become fp16. The
  * function signature would change accordingly.
  * \return The Pass.
- * 
- * \note Mainly operates within dataflow blocks.
+ *
+ * \note Mainly operates within dataflow blocks. ConvertToDataflow may need to be called first.
  */
 TVM_DLL Pass ToMixedPrecision(const DataType& out_dtype,
                               Optional<Array<String>> fp16_input_names = NullOpt);

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -460,7 +460,7 @@ class PatternCheckContext : public ObjectRef {
  * of the return value as the target. If it is not specified, the first return value will be the
  * target.
  * \return The Pass.
- * 
+ *
  * \note ConvertToDataflow may need to be called first to provide dataflow blocks.
  */
 TVM_DLL Pass Gradient(String func_name, Optional<Array<Var>> require_grads = NullOpt,

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -214,7 +214,7 @@ TVM_DLL Pass BindSymbolicVars(Map<ObjectRef, PrimExpr> binding_map,
                               Optional<String> func_name = NullOpt);
 
 /*!
- * \brief Fold constant expressions.
+ * \brief Fold constant expressions within dataflow blocks.
  *
  * \return The Pass.
  */
@@ -477,6 +477,8 @@ TVM_DLL Pass Gradient(String func_name, Optional<Array<Var>> require_grads = Nul
  * This must be True if the created composite functions are intended to be offloaded to
  * an external backend without using the MergeCompositeFunctions pass.
  * \return The Pass.
+ * 
+ * \note Only operates within dataflow blocks.
  */
 TVM_DLL Pass FuseOpsByPattern(const tvm::Array<FusionPattern>& patterns, bool bind_constants = true,
                               bool annotate_codegen = false);
@@ -548,6 +550,7 @@ TVM_DLL Pass AlterOpImpl(const Map<String, tir::PrimFunc>& op_impl_map,
  * \brief Layout conversion pass.
  * \param desired_layouts The desired layouts for some operators.
  * \return The Pass.
+ * \note Operates only on dataflow blocks.
  */
 TVM_DLL Pass ConvertLayout(Map<String, Array<String>> desired_layouts);
 
@@ -564,10 +567,13 @@ TVM_DLL Pass ConvertToDataflow(int min_size = 2);
  * \brief Dead code elimination.
  * \sa RemoveAllUnused
  * Currently it removes:
- *   1. Unused local VarBindings in a DataflowBlock.
- *   2. Unused DataflowBlocks in a function.
- *   3. Unused Relax functions in the module.
+ *   1. Unused local VarBindings
+ *      (those where the bound var is unused and no impure operation is used).
+ *   2. Unused Relax functions in the module.
  *      We detect the call chain from the entry function, and remove all unused functions.
+ * 
+ * Any binding blocks that are left empty will be removed by the normalizer.
+ * 
  * \return The Pass.
  */
 TVM_DLL Pass DeadCodeElimination(Array<runtime::String> entry_functions);
@@ -589,6 +595,8 @@ TVM_DLL Pass DataflowUseInplaceCalls();
  * \param fp16_input_names The names of function parameters whose dtype should become fp16. The
  * function signature would change accordingly.
  * \return The Pass.
+ * 
+ * \note Mainly operates within dataflow blocks.
  */
 TVM_DLL Pass ToMixedPrecision(const DataType& out_dtype,
                               Optional<Array<String>> fp16_input_names = NullOpt);

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -52,7 +52,7 @@ def Gradient(
     """Reverse-mode automatic differentiation.
 
     This pass will differentiate one function in the IRModule. Now the input function must have only
-    one dataflow block.
+    one dataflow block (ConvertToDataflow may need to be called first).
 
     For a given function specified by `func_name`, it generates a new function with the name
     `func_name + "_adjoint"`. The new function computes the gradient of the **differentiation
@@ -260,6 +260,8 @@ def DataflowUseInplaceCalls() -> tvm.ir.transform.Pass:
     in-place PrimFunc implementations of those operators (which are based on the legalizations of
     those operators).
 
+    Note: ConvertToDataflow may need to be called first to provide dataflow blocks.
+
     Returns
     -------
     ret: tvm.ir.transform.Pass
@@ -281,6 +283,8 @@ def LambdaLift() -> tvm.ir.transform.Pass:
 def ConvertToDataflow(min_size: int = 2) -> tvm.ir.transform.Pass:
     """A pass that converts consecutive dataflow operations
     inside binding blocks into dataflow blocks.
+
+    Note: ConvertToDataflow may need to be called first.
 
     Params
     ------
@@ -394,6 +398,8 @@ def RewriteDataflowReshape() -> tvm.ir.transform.Pass:
     The VM reshape operator calls will be further lowered to a CreateView
     operation at runtime, instead of doing real data copy.
     Here "reshape-like" includes reshape, expand_dims, flatten, etc.
+
+    Note: Operates only in dataflow blocks. ConvertToDataflow may need to be called first.
 
     Returns
     -------
@@ -586,6 +592,8 @@ def RunCodegen(
 def FoldConstant() -> tvm.ir.transform.Pass:
     """Fold constant expressions within dataflow blocks.
 
+    Note: ConvertToDataflow may need to be called first to provide dataflow blocks.
+
     Returns
     -------
     ret: tvm.ir.transform.Pass
@@ -650,6 +658,8 @@ def FuseOps(fuse_opt_level=-1) -> tvm.ir.transform.Pass:
     the function being manipulated into function calls to the new grouped function.
 
     A follow-up pass named "FuseTIR" will generate a TIR PrimFunc for each grouped function.
+
+    Note: ConvertToDataflow may need to be called first to provide dataflow blocks.
 
     Parameters
     ----------
@@ -764,7 +774,7 @@ def FuseOpsByPattern(
 
     The end result is similar to FuseOps, but fusion is driven completely by the provided patterns.
 
-    Note: Only operates within dataflow blocks.
+    Note: Only operates within dataflow blocks. ConvertToDataflow may need to be called first.
 
     Parameters
     ----------
@@ -1206,7 +1216,7 @@ def ToMixedPrecision(
     """Automatic mixed precision pass. Currently the pass assumes the input module to be fp32
     only, and will automatically cast fp32 to fp16 for certain ops.
 
-    Note: Mainly operates within dataflow blocks.
+    Note: Mainly operates within dataflow blocks. ConvertToDataflow may need to be called first.
 
     Parameters
     ----------

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -584,7 +584,7 @@ def RunCodegen(
 
 
 def FoldConstant() -> tvm.ir.transform.Pass:
-    """Fold constant expressions.
+    """Fold constant expressions within dataflow blocks.
 
     Returns
     -------
@@ -763,6 +763,8 @@ def FuseOpsByPattern(
     into a new function.
 
     The end result is similar to FuseOps, but fusion is driven completely by the provided patterns.
+
+    Note: Only operates within dataflow blocks.
 
     Parameters
     ----------
@@ -1172,11 +1174,12 @@ def DeadCodeElimination(entry_functions: Optional[List[str]] = None) -> tvm.ir.t
     """Remove dead code in the IRModule.
     Currently it removes:
 
-       1. Unused local VarBindings in a DataflowBlock.
-       2. Unused DataflowBlocks in a function.
-       3. Unused Relax functions in the module.
+       1. Unused local VarBindings
+          (those where the bound var is unused and no impure operation is used).
+       2. Unused Relax functions in the module.
           We detect the call chain from the entry function, and remove all unused functions.
 
+    Any binding blocks that are left empty will be removed by the normalizer.
 
     Notes
     -----
@@ -1202,6 +1205,8 @@ def ToMixedPrecision(
 ) -> tvm.ir.transform.Pass:
     """Automatic mixed precision pass. Currently the pass assumes the input module to be fp32
     only, and will automatically cast fp32 to fp16 for certain ops.
+
+    Note: Mainly operates within dataflow blocks.
 
     Parameters
     ----------

--- a/src/relax/transform/dead_code_elimination.cc
+++ b/src/relax/transform/dead_code_elimination.cc
@@ -24,10 +24,12 @@
  * \sa tvm/relax/ir/binding_rewrite.cc
  *
  * Currently it removes:
- *   1. Unused local VarBindings in a DataflowBlock.
- *   2. Unused DataflowBlocks in a function.
- *   3. Unused Relax functions in the module.
+ *   1. Unused local VarBindings
+ *      (those where the bound var is unused and no impure operation is used).
+ *   2. Unused Relax functions in the module.
  *      We detect the call chain from the entry function, and remove all unused functions.
+ *
+ * Any binding blocks that are left empty will be removed by the normalizer.
  */
 
 #include <tvm/relax/analysis.h>


### PR DESCRIPTION
Many Relax passes that rely on dataflow blocks do not explicitly state that they do. This is relevant for the phase ordering, since `ToNonDataflow` is eventually used. Additionally, if a user did not manually insert dataflow blocks, the pass `ConvertToDataflow` can be used to automatically extract dataflow blocks. This PR adds doc comments for passes that do depend on DF blocks and also adds notes suggesting the use of `ConvertToDataflow` to ensure that there will be DF blocks for these passes (if applicable).