### PR TITLE
Test PR 16512 with Dockerfile changes

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -17,13 +17,13 @@
 
 # This data file is read during when Jenkins runs job to determine docker images.
 [jenkins]
-ci_arm: tlcpack/ci-arm:20240126-070121-8ade9c30e
+ci_arm: 477529581014.dkr.ecr.us-west-2.amazonaws.com/ci_arm:PR-16512-35f44b862-2
 ci_cortexm: tlcpack/ci-cortexm:20240126-070121-8ade9c30e
-ci_cpu: tlcpack/ci-cpu:20240126-070121-8ade9c30e
+ci_cpu: 477529581014.dkr.ecr.us-west-2.amazonaws.com/ci_cpu:PR-16512-d46990f18-2
 ci_gpu: tlcpack/ci-gpu:20240126-070121-8ade9c30e
 ci_hexagon: tlcpack/ci-hexagon:20240126-070121-8ade9c30e
 ci_i386: tlcpack/ci-i386:20240126-070121-8ade9c30e
-ci_lint: tlcpack/ci-lint:20240126-070121-8ade9c30e
+ci_lint: 477529581014.dkr.ecr.us-west-2.amazonaws.com/ci_lint:PR-16512-ccc3c5f37-2
 ci_minimal: tlcpack/ci-minimal:20240126-070121-8ade9c30e
 ci_riscv: tlcpack/ci-riscv:20240126-070121-8ade9c30e
 ci_wasm: tlcpack/ci-wasm:20240126-070121-8ade9c30e

--- a/docker/install/ubuntu2004_install_python_package.sh
+++ b/docker/install/ubuntu2004_install_python_package.sh
@@ -43,5 +43,4 @@ pip3 install --upgrade \
     junitparser==2.4.2 \
     six \
     tornado \
-    pytest-lazy-fixture \
     git+https://github.com/jax-ml/ml_dtypes.git@v0.2.0

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -44,5 +44,4 @@ pip3 install --upgrade \
     junitparser==2.4.2 \
     six \
     tornado \
-    pytest-lazy-fixture \
     ml_dtypes

--- a/tests/python/driver/tvmc/test_command_line.py
+++ b/tests/python/driver/tvmc/test_command_line.py
@@ -21,7 +21,6 @@ import shutil
 import logging
 import sys
 
-from pytest_lazyfixture import lazy_fixture
 from unittest import mock
 
 import tvm
@@ -128,9 +127,10 @@ def fake_directory(tmp_path):
 
 @pytest.mark.parametrize(
     "invalid_input",
-    [lazy_fixture("missing_file"), lazy_fixture("broken_symlink"), lazy_fixture("fake_directory")],
+    ["missing_file", "broken_symlink", "fake_directory"],
 )
-def test_tvmc_compile_file_check(capsys, invalid_input):
+def test_tvmc_compile_file_check(capsys, invalid_input, request):
+    invalid_input = request.getfixturevalue(invalid_input)
     compile_cmd = f"tvmc compile --target 'c' {invalid_input}"
     run_arg = compile_cmd.split(" ")[1:]
 
@@ -147,9 +147,10 @@ def test_tvmc_compile_file_check(capsys, invalid_input):
 
 @pytest.mark.parametrize(
     "invalid_input",
-    [lazy_fixture("missing_file"), lazy_fixture("broken_symlink"), lazy_fixture("fake_directory")],
+    ["missing_file", "broken_symlink", "fake_directory"],
 )
-def test_tvmc_tune_file_check(capsys, invalid_input):
+def test_tvmc_tune_file_check(capsys, invalid_input, request):
+    invalid_input = request.getfixturevalue(invalid_input)
     tune_cmd = f"tvmc tune --target 'llvm' --output output.json {invalid_input}"
     run_arg = tune_cmd.split(" ")[1:]
 
@@ -194,13 +195,15 @@ def paddle_model(paddle_resnet50):
 @pytest.mark.parametrize(
     "model",
     [
-        lazy_fixture("paddle_model"),
+        "paddle_model",
     ],
 )
 # compile_model() can take too long and is tested elsewhere, hence it's mocked below
 @mock.patch.object(compiler, "compile_model")
 # @mock.patch.object(compiler, "compile_model")
-def test_tvmc_compile_input_model(mock_compile_model, tmpdir_factory, model):
+def test_tvmc_compile_input_model(mock_compile_model, tmpdir_factory, model, request):
+
+    model = request.getfixturevalue(model)
     output_dir = tmpdir_factory.mktemp("output")
     output_file = output_dir / "model.tar"
 


### PR DESCRIPTION
Patch includes a Dockerfile based on https://github.com/apache/tvm/pull/16512, as well as the changes we want to test in order to confirm the removal of pytest-lazy-fixtures from the Docker install scripts works with CI.