### PR TITLE
[Relax] Support callback as argument

### DIFF
--- a/include/tvm/runtime/relax_vm/bytecode.h
+++ b/include/tvm/runtime/relax_vm/bytecode.h
@@ -58,6 +58,7 @@ enum class Opcode {
   Ret = 2U,
   Goto = 3U,
   If = 4U,
+  CallFromRegister = 5U,
 };
 
 /*! \brief A single virtual machine instruction.
@@ -183,10 +184,15 @@ struct Instruction {
   /*! \brief The instruction opcode. */
   Opcode op;
   union {
-    struct /* Call */ {
+    struct /* Call, CallFromRegister */ {
       /*! \brief The destination register. */
       RegName dst;
-      /*! \brief The index into the packed function table. */
+      /*! \brief The index of the function.
+       *
+       * For `OpCode::Call`, this is an index into the table of static
+       * functions.  For `OpCode::CallFromRegister`, this is an index
+       * of a register.
+       */
       Index func_idx;
       /*! \brief The number of arguments to the packed function. */
       Index num_args;
@@ -208,27 +214,43 @@ struct Instruction {
       Index false_offset;
     };
   };
+
   /*!
    * \brief Construct a Call instruction.
-   * \param func_idx The index of the function to call.
+   * \param func_idx The index of the function to call within the
+   *                 static function table
    * \param num_args The number of arguments.
    * \param args The input arguments.
    * \param dst The destination register.
    * \return The call instruction.
    */
   static Instruction Call(Index func_idx, Index num_args, Arg* args, RegName dst);
+
+  /*!
+   * \brief Construct a Call instruction.
+   * \param func_idx The index of the function to call within the
+   *                 current stack frame's registers.
+   * \param num_args The number of arguments.
+   * \param args The input arguments.
+   * \param dst The destination register.
+   * \return The call instruction.
+   */
+  static Instruction CallFromRegister(Index func_idx, Index num_args, Arg* args, RegName dst);
+
   /*!
    * \brief Construct a return instruction.
    * \param result The register containing the return value.
    * \return The return instruction.
    */
   static Instruction Ret(RegName result);
+
   /*!
    * \brief Construct a goto instruction.
    * \param pc_offset The register containing the jump offset.
    * \return The goto instruction.
    */
   static Instruction Goto(RegName pc_offset);
+
   /*!
    * \brief Construct an If instruction.
    * \param cond The register containing the cond value.

--- a/src/relax/backend/vm/exec_builder.cc
+++ b/src/relax/backend/vm/exec_builder.cc
@@ -138,10 +138,20 @@ void ExecBuilderNode::EndFunction(const std::string& func_name) {
 
 void ExecBuilderNode::EmitCall(vm::Instruction::Arg func, std::vector<vm::Instruction::Arg> args,
                                vm::RegName dst) {
-  ICHECK(func.kind() == vm::Instruction::ArgKind::kFuncIdx);
+  Opcode op_code;
+  if (func.kind() == vm::Instruction::ArgKind::kFuncIdx) {
+    op_code = Opcode::Call;
+  } else if (func.kind() == vm::Instruction::ArgKind::kRegister) {
+    op_code = Opcode::CallFromRegister;
+  } else {
+    LOG(FATAL) << "VM instruction for a function must be either "
+               << "kFuncIdx (static function ) "
+               << "or kRegister (function passed as parameter), "
+               << "but instead found " << func.kind();
+  }
   // store instruction
   exec_->instr_offset.push_back(exec_->instr_data.size());
-  exec_->instr_data.push_back(static_cast<ExecWord>(Opcode::Call));
+  exec_->instr_data.push_back(static_cast<ExecWord>(op_code));
   exec_->instr_data.push_back(dst);
   exec_->instr_data.push_back(func.value());
   exec_->instr_data.push_back(args.size());
@@ -228,7 +238,8 @@ void ExecBuilderNode::CheckExecutable() {
     for (size_t idx = start_instr; idx < end_instr; ++idx) {
       Instruction instr = exec_->GetInstruction(idx);
       switch (instr.op) {
-        case Opcode::Call: {
+        case Opcode::Call:
+        case Opcode::CallFromRegister: {
           check_func_defined(Instruction::Arg::FuncIdx(instr.func_idx));
           for (int i = 0; i < instr.num_args; ++i) {
             check_reg_defined(instr.args[i]);
@@ -280,7 +291,8 @@ void ExecBuilderNode::Formalize() {
     for (size_t idx = start_instr; idx < end_instr; ++idx) {
       Instruction instr = this->exec_->GetInstruction(idx);
       switch (instr.op) {
-        case Opcode::Call: {
+        case Opcode::Call:
+        case Opcode::CallFromRegister: {
           // rewrite args
           for (int i = 0; i < instr.num_args; ++i) {
             if (instr.args[i].kind() == Instruction::ArgKind::kRegister &&

--- a/src/runtime/relax_vm/bytecode.cc
+++ b/src/runtime/relax_vm/bytecode.cc
@@ -42,6 +42,17 @@ Instruction Instruction::Call(Index func_idx, Index num_args, Instruction::Arg* 
   return instr;
 }
 
+Instruction Instruction::CallFromRegister(Index func_idx, Index num_args, Instruction::Arg* args,
+                                          RegName dst) {
+  Instruction instr;
+  instr.op = Opcode::CallFromRegister;
+  instr.dst = dst;
+  instr.func_idx = func_idx;
+  instr.num_args = num_args;
+  instr.args = args;
+  return instr;
+}
+
 Instruction Instruction::Ret(RegName result) {
   Instruction instr;
   instr.op = Opcode::Ret;

--- a/src/runtime/relax_vm/executable.cc
+++ b/src/runtime/relax_vm/executable.cc
@@ -134,6 +134,14 @@ Instruction Executable::GetInstruction(Index i) const {
       ExecWord* args = const_cast<ExecWord*>(&instr_data[offset + 4]);
       return Instruction::Call(func_idx, num_args, reinterpret_cast<Instruction::Arg*>(args), dst);
     }
+    case Opcode::CallFromRegister: {
+      RegName dst = instr_data[offset + 1];
+      Index func_idx = instr_data[offset + 2];
+      Index num_args = instr_data[offset + 3];
+      ExecWord* args = const_cast<ExecWord*>(&instr_data[offset + 4]);
+      return Instruction::CallFromRegister(func_idx, num_args,
+                                           reinterpret_cast<Instruction::Arg*>(args), dst);
+    }
     case Opcode::Ret: {
       RegName result = instr_data[offset + 1];
       return Instruction::Ret(result);

--- a/tests/python/relax/test_vm_callback_function.py
+++ b/tests/python/relax/test_vm_callback_function.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+
+from tvm.script import relax as R
+
+import numpy as np
+
+exec_mode = tvm.testing.parameter("bytecode", "compiled")
+
+pytestmark = tvm.testing.parametrize_targets("llvm")
+
+
+def test_pass_tensor_to_function(exec_mode, target, dev):
+    @R.function
+    def relax_func(
+        A: R.Tensor([16], "int32"),
+        callback: R.Callable([R.Tensor([16], "int32")], R.Tuple([])),
+    ):
+        B = R.multiply(A, R.const(2))
+        _ = callback(B)
+        return R.tuple()
+
+    ex = tvm.relax.build(tvm.IRModule.from_expr(relax_func), target=target, exec_mode=exec_mode)
+    vm = tvm.relax.VirtualMachine(ex, dev)
+
+    from_callback = None
+
+    def custom_callback(arr):
+        nonlocal from_callback
+        from_callback = arr
+
+    np_A = np.arange(16, dtype="int32")
+    tvm_A = tvm.nd.array(np_A)
+
+    vm["relax_func"](tvm_A, custom_callback)
+
+    assert from_callback is not None
+    np.testing.assert_array_equal(np_A * 2, from_callback.numpy())
+
+
+def test_generate_tensor_in_function(exec_mode, target, dev):
+    @R.function
+    def relax_func(
+        callback: R.Callable([], R.Tensor([16], "int32")),
+    ):
+        A = callback()
+        B = R.multiply(A, R.const(2))
+        return B
+
+    ex = tvm.relax.build(
+        tvm.IRModule.from_expr(relax_func),
+        target=target,
+        exec_mode=exec_mode,
+    )
+    vm = tvm.relax.VirtualMachine(ex, dev)
+
+    np_A = np.arange(16, dtype="int32")
+
+    def custom_callback():
+        return tvm.nd.array(np_A)
+
+    output = vm["relax_func"](custom_callback)
+
+    np.testing.assert_array_equal(np_A * 2, output.numpy())
+
+
+def test_catch_exception_with_full_stack_trace(exec_mode, target, dev):
+    @R.function
+    def relax_func(
+        callback: R.Callable([], R.Tensor([16], "int32")),
+    ):
+        A = callback()
+        return A
+
+    ex = tvm.relax.build(
+        tvm.IRModule.from_expr(relax_func),
+        target=target,
+        exec_mode=exec_mode,
+    )
+    vm = tvm.relax.VirtualMachine(ex, dev)
+
+    def custom_callback():
+        local_var = 42
+        raise RuntimeError("Error thrown from callback")
+
+    try:
+        vm["relax_func"](custom_callback)
+    except RuntimeError as err:
+        stack = err.__traceback__
+        while stack.tb_next is not None:
+            stack = stack.tb_next
+        frame = stack.tb_frame
+
+        assert frame.f_code is custom_callback.__code__, (
+            "Inner-most stack frame should be from Python callback, "
+            "even though that crosses an FFI boundary"
+        )
+        assert frame.f_locals.get("local_var") == 42, (
+            "Python __traceback__ should include local variables, "
+            "even though that crosses an FFI boundary"
+        )
+    else:
+        raise RuntimeError("Exception thrown in callback was not propagated to calling scope")
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Prior to this commit, calls from Relax to external PackedFuncs could only be done through the TVM global registry.  While Relax functions accepting a callback could be written as `callback_arg: R.Callable(arg_struct_info, ret_struct_info)`, attempting to compile these functions would raise an error during the `CodeGenVM` step of `relax.build`.  In addition, the global registry is only queried when initializing the `relax.VirtualMachine`, and so later changes requires restarting the VM.

This commit updates both the `CodeGenVM` lowering pass and the relax VM to support callbacks.  The motivating use case is with the `LazyTransformParams` pass, to improve flexibility by avoiding use of the global registry.