### PR TITLE
[CI] Disable testing that downloads from mxnet

### DIFF
--- a/gallery/how_to/compile_models/from_mxnet.py
+++ b/gallery/how_to/compile_models/from_mxnet.py
@@ -37,6 +37,7 @@ https://mxnet.apache.org/versions/master/install/index.html
 # sphinx_gallery_start_ignore
 # sphinx_gallery_requires_cuda = True
 # sphinx_gallery_end_ignore
+import sys
 import mxnet as mx
 import tvm
 import tvm.relay as relay
@@ -51,7 +52,12 @@ from mxnet.gluon.model_zoo.vision import get_model
 from PIL import Image
 from matplotlib import pyplot as plt
 
-block = get_model("resnet18_v1", pretrained=True)
+try:
+    block = get_model("resnet18_v1", pretrained=True)
+except RuntimeError:
+    print("Downloads from mxnet no longer supported", file=sys.stderr)
+    sys.exit(0)
+
 img_url = "https://github.com/dmlc/mxnet.js/blob/main/data/cat.png?raw=true"
 img_name = "cat.png"
 synset_url = "".join(

--- a/gallery/how_to/deploy_models/deploy_model_on_nano.py
+++ b/gallery/how_to/deploy_models/deploy_model_on_nano.py
@@ -106,12 +106,18 @@ from tvm.contrib.download import download_testdata
 # `MXNet Gluon model zoo <https://mxnet.apache.org/api/python/gluon/model_zoo.html>`_.
 # You can found more details about this part at tutorial :ref:`tutorial-from-mxnet`.
 
+import sys
+
 from mxnet.gluon.model_zoo.vision import get_model
 from PIL import Image
 import numpy as np
 
 # one line to get the model
-block = get_model("resnet18_v1", pretrained=True)
+try:
+    block = get_model("resnet18_v1", pretrained=True)
+except RuntimeError:
+    print("Downloads from mxnet no longer supported", file=sys.stderr)
+    sys.exit(0)
 
 ######################################################################
 # In order to test our model, here we download an image of cat and

--- a/gallery/how_to/deploy_models/deploy_model_on_rasp.py
+++ b/gallery/how_to/deploy_models/deploy_model_on_rasp.py
@@ -99,12 +99,18 @@ from tvm.contrib.download import download_testdata
 # `MXNet Gluon model zoo <https://mxnet.apache.org/api/python/gluon/model_zoo.html>`_.
 # You can found more details about this part at tutorial :ref:`tutorial-from-mxnet`.
 
+import sys
+
 from mxnet.gluon.model_zoo.vision import get_model
 from PIL import Image
 import numpy as np
 
 # one line to get the model
-block = get_model("resnet18_v1", pretrained=True)
+try:
+    block = get_model("resnet18_v1", pretrained=True)
+except RuntimeError:
+    print("Downloads from mxnet no longer supported", file=sys.stderr)
+    sys.exit(0)
 
 ######################################################################
 # In order to test our model, here we download an image of cat and

--- a/gallery/how_to/deploy_models/deploy_quantized.py
+++ b/gallery/how_to/deploy_models/deploy_quantized.py
@@ -27,6 +27,9 @@ In this tutorial, we will import a GluonCV pre-trained model on ImageNet to
 Relay, quantize the Relay model and then perform the inference.
 """
 
+import logging
+import os
+import sys
 
 import tvm
 from tvm import te
@@ -34,8 +37,7 @@ from tvm import relay
 import mxnet as mx
 from tvm.contrib.download import download_testdata
 from mxnet import gluon
-import logging
-import os
+
 
 batch_size = 1
 model_name = "resnet18_v1"
@@ -157,7 +159,11 @@ def run_inference(mod):
 
 
 def main():
-    mod, params = get_model()
+    try:
+        mod, params = get_model()
+    except RuntimeError:
+        print("Downloads from mxnet no longer supported", file=sys.stderr)
+        return
     mod = quantize(mod, params, data_aware=True)
     run_inference(mod)
 

--- a/gallery/how_to/extend_tvm/bring_your_own_datatypes.py
+++ b/gallery/how_to/extend_tvm/bring_your_own_datatypes.py
@@ -58,6 +58,8 @@ If you would like to try this with your own datatype library, first bring the li
 # --------------------
 #
 # We'll begin by writing a simple program in TVM; afterwards, we will re-write it to use custom datatypes.
+import sys
+
 import tvm
 from tvm import relay
 
@@ -253,7 +255,11 @@ def get_cat_image():
     return np.asarray(img, dtype="float32")
 
 
-module, params = get_mobilenet()
+try:
+    module, params = get_mobilenet()
+except RuntimeError:
+    print("Downloads from mxnet no longer supported", file=sys.stderr)
+    sys.exit(0)
 
 ######################################################################
 # It's easy to execute MobileNet with native TVM:

--- a/gallery/how_to/tune_with_autoscheduler/tune_network_arm.py
+++ b/gallery/how_to/tune_with_autoscheduler/tune_network_arm.py
@@ -49,6 +49,7 @@ __name__ == "__main__":` block.
 
 import numpy as np
 import os
+import sys
 
 import tvm
 from tvm import relay, auto_scheduler
@@ -264,9 +265,13 @@ log_file = "%s-%s-B%d-%s.json" % (network, layout, batch_size, target.kind.name)
 
 # Extract tasks from the network
 print("Get model...")
-mod, params, input_shape, output_shape = get_network(
-    network, batch_size, layout, dtype=dtype, use_sparse=use_sparse
-)
+try:
+    mod, params, input_shape, output_shape = get_network(
+        network, batch_size, layout, dtype=dtype, use_sparse=use_sparse
+    )
+except RuntimeError:
+    print("Downloads from mxnet no longer supported", file=sys.stderr)
+    sys.exit(0)
 print("Extract tasks...")
 tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], params, target)
 

--- a/gallery/how_to/tune_with_autoscheduler/tune_network_cuda.py
+++ b/gallery/how_to/tune_with_autoscheduler/tune_network_cuda.py
@@ -44,7 +44,7 @@ get it to run, you will need to wrap the body of this tutorial in a :code:`if
 __name__ == "__main__":` block.
 """
 
-
+import sys
 import numpy as np
 
 import tvm
@@ -152,7 +152,11 @@ log_file = "%s-%s-B%d-%s.json" % (network, layout, batch_size, target.kind.name)
 
 # Extract tasks from the network
 print("Extract tasks...")
-mod, params, input_shape, output_shape = get_network(network, batch_size, layout, dtype=dtype)
+try:
+    mod, params, input_shape, output_shape = get_network(network, batch_size, layout, dtype=dtype)
+except RuntimeError:
+    print("Downloads from mxnet no longer supported", file=sys.stderr)
+    sys.exit(0)
 tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], params, target)
 
 for idx, task in enumerate(tasks):

--- a/gallery/how_to/tune_with_autoscheduler/tune_network_mali.py
+++ b/gallery/how_to/tune_with_autoscheduler/tune_network_mali.py
@@ -44,6 +44,8 @@ get it to run, you will need to wrap the body of this tutorial in a :code:`if
 __name__ == "__main__":` block.
 """
 
+import os
+import sys
 
 import numpy as np
 
@@ -51,7 +53,7 @@ import tvm
 from tvm import relay, auto_scheduler
 import tvm.relay.testing
 from tvm.contrib import graph_executor
-import os
+
 
 #################################################################
 # Define a Network
@@ -169,7 +171,11 @@ device_key = "rk3399"
 
 # Extract tasks from the network
 print("Extract tasks...")
-mod, params, input_shape, output_shape = get_network(network, batch_size, layout, dtype=dtype)
+try:
+    mod, params, input_shape, output_shape = get_network(network, batch_size, layout, dtype=dtype)
+except RuntimeError:
+    print("Downloads from mxnet no longer supported", file=sys.stderr)
+    sys.exit(0)
 tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], params, target)
 
 for idx, task in enumerate(tasks):

--- a/gallery/how_to/tune_with_autoscheduler/tune_network_x86.py
+++ b/gallery/how_to/tune_with_autoscheduler/tune_network_x86.py
@@ -45,6 +45,7 @@ get it to run, you will need to wrap the body of this tutorial in a :code:`if
 __name__ == "__main__":` block.
 """
 
+import sys
 
 import numpy as np
 
@@ -168,13 +169,18 @@ log_file = "%s-%s-B%d-%s.json" % (network, layout, batch_size, target.kind.name)
 
 # Extract tasks from the network
 print("Get model...")
-mod, params, input_shape, output_shape = get_network(
-    network,
-    batch_size,
-    layout,
-    dtype=dtype,
-    use_sparse=use_sparse,
-)
+try:
+    mod, params, input_shape, output_shape = get_network(
+        network,
+        batch_size,
+        layout,
+        dtype=dtype,
+        use_sparse=use_sparse,
+    )
+except RuntimeError:
+    print("Downloads from mxnet no longer supported", file=sys.stderr)
+    sys.exit(0)
+
 print("Extract tasks...")
 tasks, task_weights = auto_scheduler.extract_tasks(mod["main"], params, target)
 

--- a/rust/tvm/examples/resnet/Cargo.toml
+++ b/rust/tvm/examples/resnet/Cargo.toml
@@ -20,8 +20,10 @@ name = "resnet"
 version = "0.0.0"
 authors = ["TVM Contributors"]
 license = "Apache-2.0"
-build = "build.rs"
 edition = "2018"
+# Currently disabled, as it depends on the no-longer-supported
+# mxnet repo to download resnet.
+# build = "build.rs"
 
 [dependencies]
 ndarray = "0.12"

--- a/rust/tvm/examples/resnet/Cargo.toml
+++ b/rust/tvm/examples/resnet/Cargo.toml
@@ -20,10 +20,8 @@ name = "resnet"
 version = "0.0.0"
 authors = ["TVM Contributors"]
 license = "Apache-2.0"
+build = "build.rs"
 edition = "2018"
-# Currently disabled, as it depends on the no-longer-supported
-# mxnet repo to download resnet.
-# build = "build.rs"
 
 [dependencies]
 ndarray = "0.12"

--- a/rust/tvm/examples/resnet/build.rs
+++ b/rust/tvm/examples/resnet/build.rs
@@ -21,6 +21,10 @@ use anyhow::{Context, Result};
 use std::{io::Write, path::Path, process::Command};
 
 fn main() -> Result<()> {
+    // Currently disabled, as it depends on the no-longer-supported
+    // mxnet repo to download resnet.
+
+    /*
     let out_dir = std::env::var("CARGO_MANIFEST_DIR")?;
     let python_script = concat!(env!("CARGO_MANIFEST_DIR"), "/src/build_resnet.py");
     let synset_txt = concat!(env!("CARGO_MANIFEST_DIR"), "/synset.txt");
@@ -52,6 +56,8 @@ fn main() -> Result<()> {
             .unwrap_or("")
     );
     println!("cargo:rustc-link-search=native={}", out_dir);
+
+    */
 
     Ok(())
 }

--- a/rust/tvm/examples/resnet/src/main.rs
+++ b/rust/tvm/examples/resnet/src/main.rs
@@ -31,6 +31,10 @@ use tvm_rt::graph_rt::GraphRt;
 use tvm_rt::*;
 
 fn main() -> anyhow::Result<()> {
+    // Currently disabled, as it depends on the no-longer-supported
+    // mxnet repo to download resnet.
+
+    /*
     let dev = Device::cpu(0);
     println!("{}", concat!(env!("CARGO_MANIFEST_DIR"), "/cat.png"));
 
@@ -134,6 +138,7 @@ fn main() -> anyhow::Result<()> {
         "input image belongs to the class `{}` with probability {}",
         label, max_prob
     );
+    */
 
     Ok(())
 }

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -42,7 +42,10 @@ def verify_mxnet_frontend_impl(
     if gluon_impl:
 
         def get_gluon_output(name, x):
-            net = vision.get_model(name)
+            try:
+                net = vision.get_model(name)
+            except RuntimeError:
+                pytest.skip(reason="mxnet downloads no longer supported")
             net.collect_params().initialize(mx.init.Xavier())
             net_sym = gluon.nn.SymbolBlock(
                 outputs=net(mx.sym.var("data")),

--- a/tests/python/nightly/quantization/test_quantization_accuracy.py
+++ b/tests/python/nightly/quantization/test_quantization_accuracy.py
@@ -14,15 +14,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from collections import namedtuple
-import tvm
-from tvm import relay
-from tvm.relay import quantize as qtz
-import mxnet as mx
-from mxnet import gluon
 import logging
 import os
+
+import mxnet as mx
+from mxnet import gluon
+import pytest
+
+import tvm
 import tvm.testing
+from tvm import relay
+from tvm.relay import quantize as qtz
 
 logging.basicConfig(level=logging.INFO)
 
@@ -69,7 +73,10 @@ def get_val_data(model_name, rec_val, batch_size, num_workers=4):
 
 
 def get_model(model_name, batch_size, qconfig, original=False):
-    gluon_model = gluon.model_zoo.vision.get_model(model_name, pretrained=True)
+    try:
+        gluon_model = gluon.model_zoo.vision.get_model(model_name, pretrained=True)
+    except RuntimeError:
+        pytest.skip(reason="mxnet downloads no longer supported")
     img_size = 299 if model_name == "inceptionv3" else 224
     data_shape = (batch_size, 3, img_size, img_size)
     mod, params = relay.frontend.from_mxnet(gluon_model, {"data": data_shape})

--- a/vta/scripts/tune_resnet.py
+++ b/vta/scripts/tune_resnet.py
@@ -17,7 +17,7 @@
 
 """Perform ResNet autoTVM tuning on VTA using Relay."""
 
-import argparse, os, time
+import argparse, os, sys, time
 from mxnet.gluon.model_zoo import vision
 import numpy as np
 from PIL import Image
@@ -285,7 +285,11 @@ if __name__ == "__main__":
 
     # Compile Relay program
     print("Initial compile...")
-    relay_prog, params = compile_network(opt, env, target)
+    try:
+        relay_prog, params = compile_network(opt, env, target)
+    except RuntimeError:
+        print("Downloads from mxnet no longer supported", file=sys.stderr)
+        sys.exit(0)
 
     # Register VTA tuning tasks
     register_vta_tuning_tasks()

--- a/vta/tutorials/autotvm/tune_alu_vta.py
+++ b/vta/tutorials/autotvm/tune_alu_vta.py
@@ -20,6 +20,7 @@ Auto-tuning a ALU fused op on VTA
 """
 
 import os
+import sys
 from mxnet.gluon.model_zoo import vision
 import numpy as np
 from PIL import Image
@@ -337,4 +338,8 @@ def tune_and_evaluate(tuning_opt):
 
 
 # Run the tuning and evaluate the results
-tune_and_evaluate(tuning_option)
+try:
+    tune_and_evaluate(tuning_option)
+except RuntimeError:
+    print("Downloads from mxnet no longer supported", file=sys.stderr)
+    sys.exit(0)

--- a/vta/tutorials/autotvm/tune_relay_vta.py
+++ b/vta/tutorials/autotvm/tune_relay_vta.py
@@ -54,6 +54,8 @@ log file to get the best knob parameters.
 # Now return to python code. Import packages.
 
 import os
+import sys
+
 from mxnet.gluon.model_zoo import vision
 import numpy as np
 from PIL import Image
@@ -471,7 +473,11 @@ def tune_and_evaluate(tuning_opt):
 
 
 # Run the tuning and evaluate the results
-tune_and_evaluate(tuning_option)
+try:
+    tune_and_evaluate(tuning_option)
+except RuntimeError:
+    print("Downloads from mxnet no longer supported", file=sys.stderr)
+    sys.exit(0)
 
 ######################################################################
 # Sample Output

--- a/vta/tutorials/frontend/deploy_classification.py
+++ b/vta/tutorials/frontend/deploy_classification.py
@@ -43,6 +43,7 @@ from __future__ import absolute_import, print_function
 import argparse, json, os, requests, sys, time
 from io import BytesIO
 from os.path import join, isfile
+import sys
 from PIL import Image
 
 from mxnet.gluon.model_zoo import vision
@@ -163,7 +164,11 @@ with autotvm.tophub.context(target):
     shape_dict = {"data": (env.BATCH, 3, 224, 224)}
 
     # Get off the shelf gluon model, and convert to relay
-    gluon_model = vision.get_model(model, pretrained=True)
+    try:
+        gluon_model = vision.get_model(model, pretrained=True)
+    except RuntimeError:
+        print("Downloads from mxnet no longer supported", file=sys.stderr)
+        sys.exit(0)
 
     # Measure build start time
     build_start = time.time()


### PR DESCRIPTION
The mxnet project was archived in 2023-09 ([link](https://attic.apache.org/projects/mxnet.html)). Downloads from the mxnet AWS
links (e.g. `https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/gluon/models/resnet18_v1-a0666292.zip`) no longer can be performed.  This commit disables TVM CI steps that depend on downloading models from these locations.