### PR TITLE
[RUNTIME][ROCM] Properly align rocm parameter buffer

### DIFF
--- a/src/runtime/rocm/rocm_module.cc
+++ b/src/runtime/rocm/rocm_module.cc
@@ -198,7 +198,7 @@ PackedFunc ROCMModuleNode::GetFunction(const String& name, const ObjectPtr<Objec
   const FunctionInfo& info = it->second;
   ROCMWrappedFunc f;
   f.Init(this, sptr_to_self, name, info.arg_types.size(), info.launch_param_tags);
-  return PackFuncPackedArg(f, info.arg_types);
+  return PackFuncPackedArgAligned(f, info.arg_types);
 }
 
 Module ROCMModuleCreate(std::string data, std::string fmt,


### PR DESCRIPTION
This PR properly aligns rocm param buffer fields to avoid bug in cases like

```c
struct Param {
  void *arg0;
  int32_t arg1;
  int64_t arg2;
};
```

In this case, we need to align arg2 by padding a i32 after arg1.

---

Co-authored-by: Tianqi Chen <tianqi.tchen@gmail.com>