### PR TITLE
[TIR] Fix get_block_access_region for let bindings

### DIFF
--- a/src/tir/analysis/block_access_region_detector.cc
+++ b/src/tir/analysis/block_access_region_detector.cc
@@ -25,6 +25,7 @@
 #include <tvm/arith/analyzer.h>
 #include <tvm/tir/op.h>
 #include <tvm/tir/stmt_functor.h>
+#include <unordered_map>
 
 #include "../transforms/ir_utils.h"
 namespace tvm {
@@ -78,6 +79,8 @@ class BlockReadWriteDetector : public StmtExprVisitor {
   Map<Var, Buffer> buffer_var_map_;
   /*! \brief The target buffer var mapping to its matching */
   std::unordered_map<const VarNode*, MatchBufferRegion> match_buffers_;
+  /*! \brief let bindings inside the block */
+  std::unordered_map<const VarNode*, PrimExpr> let_bindings_;
   /*!\ brief Internal analyzer. */
   arith::Analyzer ana_;
 
@@ -111,6 +114,7 @@ class BlockReadWriteDetector : public StmtExprVisitor {
   void VisitStmt_(const IfThenElseNode* op) override;
   void VisitStmt_(const BlockRealizeNode* op) override;
   void VisitStmt_(const BufferStoreNode* op) override;
+  void VisitStmt_(const LetStmtNode* op) override;
   void VisitExpr_(const BufferLoadNode* op) override;
   void VisitExpr_(const VarNode* op) override;
   void VisitExpr_(const CallNode* op) override;
@@ -149,7 +153,8 @@ void BlockReadWriteDetector::VisitExpr_(const VarNode* op) { UpdateOpaque(GetRef
 void BlockReadWriteDetector::VisitExpr_(const BufferLoadNode* op) {
   std::vector<arith::IntSet> relaxed_region;
   for (const PrimExpr& index : op->indices) {
-    relaxed_region.push_back(arith::EvalSet(arith::IntSet::Vector(index), dom_map_));
+    PrimExpr remapped_index = Substitute(index, let_bindings_);
+    relaxed_region.push_back(arith::EvalSet(arith::IntSet::Vector(remapped_index), dom_map_));
   }
   Update(&read_buffers_, &read_regions_, op->buffer, relaxed_region);
   ExprVisitor::VisitExpr_(op);
@@ -174,6 +179,12 @@ void BlockReadWriteDetector::VisitStmt_(const IfThenElseNode* op) {
     With<ConditionalBoundsContext> ctx(!op->condition, &dom_map_, &hint_map_, &pending_conditions_);
     StmtExprVisitor::VisitStmt(op->else_case.value());
   }
+}
+
+void BlockReadWriteDetector::VisitStmt_(const LetStmtNode* op) {
+  let_bindings_[op->var.get()] = op->value;
+  StmtVisitor::VisitStmt_(op);
+  let_bindings_.erase(op->var.get());
 }
 
 void BlockReadWriteDetector::VisitExpr_(const CallNode* op) {
@@ -225,7 +236,8 @@ void BlockReadWriteDetector::VisitExpr_(const CallNode* op) {
 void BlockReadWriteDetector::VisitStmt_(const BufferStoreNode* op) {
   std::vector<arith::IntSet> relaxed_region;
   for (const PrimExpr& index : op->indices) {
-    relaxed_region.push_back(arith::EvalSet(arith::IntSet::Vector(index), dom_map_));
+    PrimExpr remapped_index = Substitute(index, let_bindings_);
+    relaxed_region.push_back(arith::EvalSet(arith::IntSet::Vector(remapped_index), dom_map_));
   }
   Update(&writes_buffers_, &write_regions_, op->buffer, relaxed_region);
   StmtVisitor::VisitStmt_(op);

--- a/src/tir/analysis/block_access_region_detector.cc
+++ b/src/tir/analysis/block_access_region_detector.cc
@@ -25,6 +25,7 @@
 #include <tvm/arith/analyzer.h>
 #include <tvm/tir/op.h>
 #include <tvm/tir/stmt_functor.h>
+
 #include <unordered_map>
 
 #include "../transforms/ir_utils.h"


### PR DESCRIPTION
The current implementation of `block_access_region_detector` does not consider the let bindings inside the block. To be more specific:

- The let bindings inside the block can be the index of buffer access indices
- The let bindings var is defined inside the block, so the block annotation cannot use those vars.
- We need to substitute the let bindings inside the block to the block annotation.

This PR fixes this problem and can create legal IRs.