### PR TITLE
[Web] Compatibility with PagedKVCache in WebGPU

### DIFF
--- a/src/runtime/relax_vm/lm_support.cc
+++ b/src/runtime/relax_vm/lm_support.cc
@@ -226,18 +226,19 @@ class AttentionKVCacheObj : public Object {
   }
 
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
-  static constexpr const char* _type_key = "relax.vm.AttentionKVCache";
+  static constexpr const char* _type_key = "relax.vm.AttentionKVCacheLegacy";
   TVM_DECLARE_FINAL_OBJECT_INFO(AttentionKVCacheObj, Object);
 };
 
 /*! \brief reference to closure. */
-class AttentionKVCache : public ObjectRef {
+class AttentionKVCacheLegacy : public ObjectRef {
  public:
   /*!
    * \brief Create the attention kv cache.
    * \param init_data The initial reserved.
    */
-  static AttentionKVCache Create(NDArray init_data, ShapeTuple reserve_shape, int init_fill_count) {
+  static AttentionKVCacheLegacy Create(NDArray init_data, ShapeTuple reserve_shape,
+                                       int init_fill_count) {
     auto n = make_object<AttentionKVCacheObj>();
     n->data = NDArray::Empty(reserve_shape, init_data->dtype, init_data->device);
     n->fill_count = 0;
@@ -246,10 +247,10 @@ class AttentionKVCache : public ObjectRef {
       n->fill_count = init_fill_count;
       n->window_attention_current_pos = init_fill_count;  // window attention only
     }
-    return AttentionKVCache(n);
+    return AttentionKVCacheLegacy(n);
   }
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(AttentionKVCache, ObjectRef, AttentionKVCacheObj);
+  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(AttentionKVCacheLegacy, ObjectRef, AttentionKVCacheObj);
 };
 
 TVM_REGISTER_OBJECT_TYPE(AttentionKVCacheObj);
@@ -258,24 +259,24 @@ TVM_REGISTER_OBJECT_TYPE(AttentionKVCacheObj);
 //  Register runtime functions
 //-------------------------------------------------
 TVM_REGISTER_GLOBAL("vm.builtin.attention_kv_cache_create")
-    .set_body_typed(AttentionKVCache::Create);
+    .set_body_typed(AttentionKVCacheLegacy::Create);
 
-AttentionKVCache AttentionKVCacheUpdate(AttentionKVCache cache, NDArray value) {
+AttentionKVCacheLegacy AttentionKVCacheUpdate(AttentionKVCacheLegacy cache, NDArray value) {
   cache->Update(value);
   return cache;
 }
 
 TVM_REGISTER_GLOBAL("vm.builtin.attention_kv_cache_update").set_body_typed(AttentionKVCacheUpdate);
 
-AttentionKVCache AttentionKVCacheAppend(AttentionKVCache cache, NDArray value) {
+AttentionKVCacheLegacy AttentionKVCacheAppend(AttentionKVCacheLegacy cache, NDArray value) {
   cache->Append(value);
   return cache;
 }
 
 TVM_REGISTER_GLOBAL("vm.builtin.attention_kv_cache_append").set_body_typed(AttentionKVCacheAppend);
 
-AttentionKVCache AttentionKVCacheWindowOverride(AttentionKVCache cache, NDArray value,
-                                                int64_t max_cache_size) {
+AttentionKVCacheLegacy AttentionKVCacheWindowOverride(AttentionKVCacheLegacy cache, NDArray value,
+                                                      int64_t max_cache_size) {
   cache->WindowOverride(value, max_cache_size);
   return cache;
 }
@@ -283,9 +284,10 @@ AttentionKVCache AttentionKVCacheWindowOverride(AttentionKVCache cache, NDArray 
 TVM_REGISTER_GLOBAL("vm.builtin.attention_kv_cache_window_override")
     .set_body_typed(AttentionKVCacheWindowOverride);
 
-AttentionKVCache AttentionKVCacheWindowOverrideWithSinks(AttentionKVCache cache, NDArray value,
-                                                         int64_t max_cache_size,
-                                                         int64_t num_attention_sinks) {
+AttentionKVCacheLegacy AttentionKVCacheWindowOverrideWithSinks(AttentionKVCacheLegacy cache,
+                                                               NDArray value,
+                                                               int64_t max_cache_size,
+                                                               int64_t num_attention_sinks) {
   cache->WindowOverride(value, max_cache_size, num_attention_sinks);
   return cache;
 }
@@ -293,7 +295,7 @@ AttentionKVCache AttentionKVCacheWindowOverrideWithSinks(AttentionKVCache cache,
 TVM_REGISTER_GLOBAL("vm.builtin.attention_kv_cache_window_override_with_sinks")
     .set_body_typed(AttentionKVCacheWindowOverrideWithSinks);
 
-NDArray AttentionKVCacheView(AttentionKVCache cache, ShapeTuple shape) {
+NDArray AttentionKVCacheView(AttentionKVCacheLegacy cache, ShapeTuple shape) {
   return cache->View(shape);
 }
 
@@ -302,7 +304,7 @@ TVM_REGISTER_GLOBAL("vm.builtin.attention_kv_cache_view")
       CHECK(args.size() == 1 || args.size() == 2)
           << "ValueError: `vm.builtin.attention_kv_cache_view` expects 1 or 2 arguments, but got "
           << args.size() << ".";
-      AttentionKVCache cache = args[0];
+      AttentionKVCacheLegacy cache = args[0];
       if (args.size() == 2) {
         ShapeTuple shape = args[1];
         *rv = cache->View(shape);
@@ -316,8 +318,8 @@ TVM_REGISTER_GLOBAL("vm.builtin.attention_kv_cache_view")
       }
     });
 
-void AttentionKVCacheArrayPopN(Array<AttentionKVCache> caches, int64_t n) {
-  for (AttentionKVCache cache : caches) {
+void AttentionKVCacheArrayPopN(Array<AttentionKVCacheLegacy> caches, int64_t n) {
+  for (AttentionKVCacheLegacy cache : caches) {
     cache->PopN(static_cast<size_t>(n));
   }
 }
@@ -325,8 +327,8 @@ void AttentionKVCacheArrayPopN(Array<AttentionKVCache> caches, int64_t n) {
 TVM_REGISTER_GLOBAL("vm.builtin.attention_kv_cache_array_popn")
     .set_body_typed(AttentionKVCacheArrayPopN);
 
-void AttentionKVCacheArrayClear(Array<AttentionKVCache> caches) {
-  for (AttentionKVCache cache : caches) {
+void AttentionKVCacheArrayClear(Array<AttentionKVCacheLegacy> caches) {
+  for (AttentionKVCacheLegacy cache : caches) {
     cache->Clear();
   }
 }

--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -636,6 +636,19 @@ void CodeGenWebGPU::VisitStmt_(const AllocateConstNode* op) {
   LOG(FATAL) << "WebGPU: do not support alloc const";
 }
 
+void CodeGenWebGPU::VisitStmt_(const WhileNode* op) {
+  PrintIndent();
+  stream << "while (true) {\n";
+  int while_scope = BeginScope();
+  std::string cond = PrintExpr(op->condition);
+  PrintIndent();
+  stream << "if (!(" << cond << ")) { break; }\n";
+  PrintStmt(op->body);
+  this->EndScope(while_scope);
+  PrintIndent();
+  stream << "}\n";
+}
+
 //-------------------------------------------------
 // WebGPUSourceModule to enable export
 //-------------------------------------------------

--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -599,8 +599,8 @@ void CodeGenWebGPU::VisitStmt_(const AllocateNode* op) {
     PrintType(op->dtype, this->decl_stream);
     this->decl_stream << ", " << constant_size << ">;\n";
   } else if (storage_scope.rank == runtime::StorageRank::kLocal) {
-    // TODO: These code would cause non-uniformity as it introduces variables in module scope rather
-    // than function scope; but it was included for some unknown reasons; kept for now.
+    // TODO(Charlie): These code would cause non-uniformity as it introduces variables in module
+    // scope rather than function scope; but it was included for some unknown reasons; kept for now.
     // this->decl_stream << "var<private> " << vid << " : array<";
     // PrintType(op->dtype, this->decl_stream);
     // this->decl_stream << ", " << constant_size << ">;\n";

--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -599,13 +599,15 @@ void CodeGenWebGPU::VisitStmt_(const AllocateNode* op) {
     PrintType(op->dtype, this->decl_stream);
     this->decl_stream << ", " << constant_size << ">;\n";
   } else if (storage_scope.rank == runtime::StorageRank::kLocal) {
-    this->decl_stream << "var<private> " << vid << " : array<";
-    PrintType(op->dtype, this->decl_stream);
-    this->decl_stream << ", " << constant_size << ">;\n";
-    // this->PrintIndent();
-    // this->stream << "var " << vid << " : array<";
-    // PrintType(op->dtype, this->stream);
-    // this->stream << ", " << constant_size << ">;\n";
+    // TODO: These code would cause non-uniformity as it introduces variables in module scope rather
+    // than function scope; but it was included for some unknown reasons; kept for now.
+    // this->decl_stream << "var<private> " << vid << " : array<";
+    // PrintType(op->dtype, this->decl_stream);
+    // this->decl_stream << ", " << constant_size << ">;\n";
+    this->PrintIndent();
+    this->stream << "var " << vid << " : array<";
+    PrintType(op->dtype, this->stream);
+    this->stream << ", " << constant_size << ">;\n";
   } else {
     LOG(FATAL) << "WebGPU: Do not support storage scope: " << storage_scope.to_string();
   }

--- a/src/target/source/codegen_webgpu.h
+++ b/src/target/source/codegen_webgpu.h
@@ -73,6 +73,7 @@ class CodeGenWebGPU final : public CodeGenC {
   void VisitStmt_(const AllocateNode* op) final;
   void VisitStmt_(const AssertStmtNode* op) final;
   void VisitStmt_(const AllocateConstNode* op) final;
+  void VisitStmt_(const WhileNode* op) final;
 
  private:
   /*!

--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1724,8 +1724,9 @@ Pass StorageRewrite() {
     }
 
     Optional<Target> target = f->GetAttr<Target>("target");
-    if (target.defined() && target.value()->kind->name == "vulkan") {
-      // Require exactly same-dtype matching in smem reuse for Vulkan
+    if (target.defined() &&
+        (target.value()->kind->name == "vulkan" || target.value()->kind->name == "webgpu")) {
+      // Require exactly same-dtype matching in smem reuse for Vulkan and WebGPU
       reuse_require_exact_matched_dtype = true;
     }
     auto* n = f.CopyOnWrite();

--- a/web/emcc/wasm_runtime.cc
+++ b/web/emcc/wasm_runtime.cc
@@ -60,6 +60,7 @@
 #include "src/runtime/relax_vm/executable.cc"
 #include "src/runtime/relax_vm/lm_support.cc"
 #include "src/runtime/relax_vm/ndarray_cache_support.cc"
+#include "src/runtime/relax_vm/paged_kv_cache.cc"
 #include "src/runtime/relax_vm/vm.cc"
 
 // --- Implementations of backend and wasm runtime API. ---

--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -817,23 +817,13 @@ export class WebGPUContext {
       rawBytes.set(rawBytes);
       nbytes = nbytes + toPad;
     }
-    try {
-      this.device.queue.writeBuffer(
-        this.gpuBufferFromPtr(to),
-        toOffset,
-        rawBytes,
-        0,
-        nbytes
-      );
-    } catch (err) {
-      console.log("CHARLIE deviceCopyToGPU ERR");
-      console.log("rawBytes: ", rawBytes);
-      console.log("nbytes: ", nbytes);
-      console.log("toOffset: ", toOffset);
-      console.log(err);
-      throw new Error(err);
-    }
-
+    this.device.queue.writeBuffer(
+      this.gpuBufferFromPtr(to),
+      toOffset,
+      rawBytes,
+      0,
+      nbytes
+    );
   }
 
   private deviceCopyFromGPU(


### PR DESCRIPTION
This PR introduces various WebGPU changes to accommodate the new `PagedKVCache` interface. All changes below are essential for making models that use PagedKVCache runnable under WebGPU:

- Require exactly same-dtype matching for WebGPU smem reuse in `storage_rewrite.cc`
- Rename `AttentionKVCache` to `AttentionKVCacheLegacy` for the old KVcache interface in `lm_support.cc`; include `paged_kv_cache.cc` when making `wasm_runtime` subsequently
- In WebGPU codegen:
  - Declare local variables within the function scope rather than the module scope
  - Generate `while (true)` rather than `while (1)`
- Require 10 `maxStorageBuffersPerShaderStage` rather than the default 8 from the WebGPU device when initializing runtime; this is required for new kernels introduced in PagedKVCache
- In `deviceCopyToCPU()`, when raw bytes to write are not multiples of 4, we pad them, as required by WebGPU's `writeBuffer()`.


Co-authored-by: Rick Zhou <rickzhoucmu@gmail.com>