### PR TITLE
[VM] [Hexagon] Introduce 2D Discontiguous vtcm alloc tensor

### DIFF
--- a/include/tvm/runtime/memory/memory_manager.h
+++ b/include/tvm/runtime/memory/memory_manager.h
@@ -139,6 +139,10 @@ class StorageObj : public Object {
   /*! \brief The index into the VM function table. */
   Buffer buffer;
 
+  /* \brief Common function to create an NDArray container with the provided offset, shape and dtype
+   */
+  NDArray::Container* CreateNDArrayContainer(int64_t offset, ShapeTuple shape, DLDataType dtype);
+
   /*! \brief Allocate an NDArray from a given piece of storage. */
   NDArray AllocNDArray(int64_t offset, ShapeTuple shape, DLDataType dtype);
 

--- a/python/tvm/relax/op/vm/__init__.py
+++ b/python/tvm/relax/op/vm/__init__.py
@@ -16,4 +16,4 @@
 # under the License.
 """Relax vm primitives."""
 
-from .vm import alloc_storage, alloc_tensor, call_tir_dyn, kill_object
+from .vm import alloc_storage, alloc_tensor, call_tir_dyn, copy_tensor_from_to, kill_object

--- a/python/tvm/relax/op/vm/vm.py
+++ b/python/tvm/relax/op/vm/vm.py
@@ -131,3 +131,23 @@ def call_tir_dyn(func: Expr, args: Tuple) -> Call:
         args = Tuple(args)
 
     return _ffi_api.call_tir_dyn(func, args)  # type: ignore
+
+
+@args_converter.auto
+def copy_tensor_from_to(src: Expr, dst: Expr) -> Call:
+    """Construct a call to copy one tensor to another.
+
+    Parameters
+    ----------
+    src : Expr
+        Source tensor for copy.
+
+    dst : Expr
+        Destination tensor for copy.
+
+    Returns
+    -------
+    result : Call
+        A relax Call, which performs the copy.
+    """
+    return _ffi_api.copy_tensor_from_to(src, dst)  # type: ignore

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -169,6 +169,8 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
         EmitAllocStorage(call, dst_reg);
       } else if (call_node->op == alloc_tensor_op_) {
         EmitAllocTensor(call, dst_reg);
+      } else if (call_node->op == copy_tensor_from_to_op_) {
+        EmitCopyTensor(call, dst_reg);
       } else if (call_node->op == kill_object_op_) {
         dst_reg = EmitKillObject(call);
       } else {
@@ -361,6 +363,16 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     builder_->EmitCall("vm.builtin.alloc_tensor", args, dst_reg);
   }
 
+  void EmitCopyTensor(const Call& call_node, RegName dst_reg) {
+    ICHECK_EQ(call_node->args.size(), 2);
+    std::vector<Instruction::Arg> args;
+    args.reserve(2);
+    for (Expr arg : call_node->args) {
+      args.push_back(this->VisitExpr(arg));
+    }
+    builder_->EmitCall("vm.builtin.copy_tensor_from_to", args, dst_reg);
+  }
+
   RegName EmitKillObject(const Call& call_node) {
     ICHECK_EQ(call_node->args.size(), 1);
     Instruction::Arg arg = this->VisitExpr(call_node->args[0]);
@@ -430,6 +442,7 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
   /*! \brief Cache ops that need to be frequently used later to reduce lookup overhead. */
   const Op& alloc_storage_op_ = Op::Get("relax.vm.alloc_storage");
   const Op& alloc_tensor_op_ = Op::Get("relax.vm.alloc_tensor");
+  const Op& copy_tensor_from_to_op_ = Op::Get("relax.vm.copy_tensor_from_to");
   const Op& kill_object_op_ = Op::Get("relax.vm.kill_object");
   const Op& call_builtin_with_ctx_op_ = Op::Get("relax.call_builtin_with_ctx");
   const Op& null_value_op_ = Op::Get("relax.null_value");

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -1004,6 +1004,22 @@ Expr MakeVMAllocTensor(Expr storage, PrimValue offset, Expr shape, DataTypeImm d
 
 TVM_REGISTER_GLOBAL("relax.op.vm.alloc_tensor").set_body_typed(MakeVMAllocTensor);
 
+// vm copy_tensor_from_to
+
+RELAY_REGISTER_OP("relax.vm.copy_tensor_from_to")
+    .set_num_inputs(2)
+    .add_argument("src", "Expr", "The tensor to copy from")
+    .add_argument("dst", "Expr", "The tensor to copy to")
+    .set_attr<FInferStructInfo>("FInferStructInfo", ReturnVoidStructInfo)
+    .set_attr<Bool>("FPurity", Bool(true));
+
+Expr MakeVMCopyTensor(Expr src, Expr dst) {
+  static const Op& op = Op::Get("relax.vm.copy_tensor_from_to");
+  return Call(op, {src, dst}, Attrs(), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.vm.copy_tensor_from_to").set_body_typed(MakeVMCopyTensor);
+
 // vm kill_object
 
 TVM_REGISTER_OP("relax.vm.kill_object")

--- a/src/runtime/hexagon/hexagon_buffer.cc
+++ b/src/runtime/hexagon/hexagon_buffer.cc
@@ -233,9 +233,9 @@ std::vector<MemoryCopy> MemoryCopy::MergeAdjacent(std::vector<MemoryCopy> micro_
   return macro_copies;
 }
 
-void hexagon_buffer_copy_across_regions(const BufferSet& dest, const BufferSet& src,
-                                        size_t bytes_to_copy, bool src_is_hexbuff,
-                                        bool dest_is_hexbuff) {
+void HexagonBufferCopyAcrossRegions(const BufferSet& dest, const BufferSet& src,
+                                    size_t bytes_to_copy, bool src_is_hexbuff,
+                                    bool dest_is_hexbuff) {
   // First, determine all copies that do not cross boundaries in
   // either source or destination region.
   auto micro_copies = BufferSet::MemoryCopies(dest, src, bytes_to_copy);
@@ -268,24 +268,24 @@ void HexagonBuffer::CopyTo(void* data, size_t nbytes) const {
   BufferSet src(allocations_.data(), allocations_.size(), nbytes_per_allocation_);
   BufferSet dest(&data, 1, nbytes);
 
-  hexagon_buffer_copy_across_regions(dest, src, nbytes, true /* src_is_hexbuff */,
-                                     false /* dest_is_hexbuff */);
+  HexagonBufferCopyAcrossRegions(dest, src, nbytes, true /* src_is_hexbuff */,
+                                 false /* dest_is_hexbuff */);
 }
 
 void HexagonBuffer::CopyFrom(void* data, size_t nbytes) {
   BufferSet src(&data, 1, nbytes);
   BufferSet dest(allocations_.data(), allocations_.size(), nbytes_per_allocation_);
 
-  hexagon_buffer_copy_across_regions(dest, src, nbytes, false /* src_is_hexbuff */,
-                                     true /* dest_is_hexbuff */);
+  HexagonBufferCopyAcrossRegions(dest, src, nbytes, false /* src_is_hexbuff */,
+                                 true /* dest_is_hexbuff */);
 }
 
 void HexagonBuffer::CopyFrom(const HexagonBuffer& other, size_t nbytes) {
   BufferSet src(other.allocations_.data(), other.allocations_.size(), other.nbytes_per_allocation_);
   BufferSet dest(allocations_.data(), allocations_.size(), nbytes_per_allocation_);
 
-  hexagon_buffer_copy_across_regions(dest, src, nbytes, true /* src_is_hexbuff */,
-                                     true /* dest_is_hexbuff */);
+  HexagonBufferCopyAcrossRegions(dest, src, nbytes, true /* src_is_hexbuff */,
+                                 true /* dest_is_hexbuff */);
 }
 
 }  // namespace hexagon

--- a/src/runtime/hexagon/hexagon_buffer.h
+++ b/src/runtime/hexagon/hexagon_buffer.h
@@ -195,6 +195,19 @@ struct BufferSet {
   size_t region_size_bytes;
 };
 
+/**
+ * @brief Single function to handle copying potentially discontiguous buffers efficiently
+ *
+ * @param The destination buffer
+ * @param The source buffer
+ * @param Number of bytes to copy. This should be less than both source and dest buffer size
+ * @param Boolean to specify whether the source is a hexagon buffer
+ * @param Boolean to specify whether the destination is a hexagon buffer
+ */
+void HexagonBufferCopyAcrossRegions(const BufferSet& dest, const BufferSet& src,
+                                    size_t bytes_to_copy, bool src_is_hexbuff,
+                                    bool dest_is_hexbuff);
+
 }  // namespace hexagon
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -410,6 +410,10 @@ TVM_REGISTER_GLOBAL("vm.builtin.reshape").set_body_typed([](NDArray data, ShapeT
   return data.CreateView(new_shape, data->dtype);
 });
 
+TVM_REGISTER_GLOBAL("vm.builtin.copy_tensor_from_to").set_body_typed([](NDArray src, NDArray dst) {
+  dst.CopyFrom(src);
+});
+
 TVM_REGISTER_GLOBAL("vm.builtin.null_value").set_body([](TVMArgs args, TVMRetValue* rv) {
   CHECK_EQ(args.size(), 0);
   *rv = nullptr;

--- a/tests/python/contrib/test_hexagon/test_vtcm_alloc_compute_use_offsets.py
+++ b/tests/python/contrib/test_hexagon/test_vtcm_alloc_compute_use_offsets.py
@@ -1,0 +1,425 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-wildcard-import, invalid-name, missing-docstring,no-self-argument
+"""Test Discontiguous allocation for hexagon"""
+
+import numpy as np
+
+import tvm
+import tvm.contrib.hexagon
+import tvm.script
+import tvm.testing
+from tvm import relax
+from tvm.script.parser import ir as I
+from tvm.script.parser import relax as R
+from tvm.script.parser import tir as T
+
+
+@I.ir_module
+class Module:
+    @T.prim_func
+    def compute_add_in_vtcm(a: T.handle, b: T.handle, c: T.handle) -> None:
+        m, n = T.int32(), T.int32()
+        A = T.match_buffer(a, (m, n), "int32", scope="global.vtcm")
+        B = T.match_buffer(b, (m, n), "int32", scope="global.vtcm")
+        C = T.match_buffer(c, (m, n), "int32", scope="global.vtcm")
+        for ax0, ax1 in T.grid(m, n):
+            with T.block("T_add"):
+                v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(A[v_ax0, v_ax1], B[v_ax0, v_ax1])
+                T.writes(C[v_ax0, v_ax1])
+                C[v_ax0, v_ax1] = A[v_ax0, v_ax1] + B[v_ax0, v_ax1]
+
+    @T.prim_func
+    def compute_mul_in_vtcm(a: T.handle, b: T.handle, c: T.handle) -> None:
+        m, n = T.int32(), T.int32()
+        A = T.match_buffer(a, (m, n), "int32", scope="global.vtcm")
+        B = T.match_buffer(b, (m, n), "int32", scope="global.vtcm")
+        C = T.match_buffer(c, (m, n), "int32", scope="global.vtcm")
+        for ax0, ax1 in T.grid(m, n):
+            with T.block("T_add"):
+                v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(A[v_ax0, v_ax1], B[v_ax0, v_ax1])
+                T.writes(C[v_ax0, v_ax1])
+                C[v_ax0, v_ax1] = A[v_ax0, v_ax1] * B[v_ax0, v_ax1]
+
+    @R.function
+    def main(
+        x: R.Tensor((4, 64), "int32"),
+        y: R.Tensor((4, 64), "int32"),
+        z: R.Tensor((4, 64), "int32"),
+    ) -> R.Tensor((4, 64), "int32"):
+        cls = Module
+        vtcm_obj: R.Object = R.vm.alloc_storage(
+            R.shape([4096]), runtime_device_index=0, dtype="uint8", storage_scope="global.vtcm"
+        )
+        a: R.Tensor([4, 64], dtype="int32") = R.vm.alloc_tensor(
+            vtcm_obj, offset=0, shape=R.shape([4, 64]), dtype="int32"
+        )
+        __: R.Tuple = R.vm.copy_tensor_from_to(x, a)
+        b: R.Tensor([4, 64], dtype="int32") = R.vm.alloc_tensor(
+            vtcm_obj, offset=1024, shape=R.shape([4, 64]), dtype="int32"
+        )
+        _: R.Tuple = R.vm.copy_tensor_from_to(y, b)
+        c: R.Tensor([4, 64], dtype="int32") = R.vm.alloc_tensor(
+            vtcm_obj, offset=2048, shape=R.shape([4, 64]), dtype="int32"
+        )
+        ___: R.Tuple = cls.compute_add_in_vtcm(a, b, c)
+        _t1: R.Tuple = R.vm.kill_object(a)
+        _t2: R.Tuple = R.vm.kill_object(b)
+        d: R.Tensor([4, 64], dtype="int32") = R.vm.alloc_tensor(
+            vtcm_obj, offset=0, shape=R.shape([4, 64]), dtype="int32"
+        )
+        ___1: R.Tuple = R.vm.copy_tensor_from_to(z, d)
+        e: R.Tensor([4, 64], dtype="int32") = R.vm.alloc_tensor(
+            vtcm_obj, offset=1024, shape=R.shape([4, 64]), dtype="int32"
+        )
+        ___2: R.Tuple = cls.compute_mul_in_vtcm(c, d, e)
+        _t2: R.Tuple = R.vm.kill_object(c)
+        _t12: R.Tuple = R.vm.kill_object(d)
+        f: R.Tensor([4, 64], dtype="int32") = R.vm.alloc_tensor(
+            vtcm_obj, offset=2048, shape=R.shape([4, 64]), dtype="int32"
+        )
+        _t13: R.Tuple = R.vm.copy_tensor_from_to(e, f)
+        _t14: R.Tuple = R.vm.kill_object(e)
+        ret_val: R.Tensor([4, 64], dtype="int32") = R.builtin.alloc_tensor(
+            R.shape([4, 64]), R.dtype("int32"), R.prim_value(0)
+        )
+        _1: R.Tuple = R.vm.copy_tensor_from_to(f, ret_val)
+        _t15: R.Tuple = R.vm.kill_object(f)
+        _t3: R.Tuple = R.vm.kill_object(vtcm_obj)
+        lv: R.Tensor([4, 64], dtype="int32") = ret_val
+        return lv
+
+
+@I.ir_module
+class Module_2d:
+    @T.prim_func
+    def compute_add_in_vtcm(a: T.handle, b: T.handle, c: T.handle) -> None:
+        m, n = T.int32(), T.int32()
+        A = T.match_buffer(a, (m, n), "int32", scope="global.vtcm", axis_separators=[1])
+        B = T.match_buffer(b, (m, n), "int32", scope="global.vtcm", axis_separators=[1])
+        C = T.match_buffer(c, (m, n), "int32", scope="global.vtcm", axis_separators=[1])
+        for ax0, ax1 in T.grid(m, n):
+            with T.block("T_add"):
+                v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(A[v_ax0, v_ax1], B[v_ax0, v_ax1])
+                T.writes(C[v_ax0, v_ax1])
+                C[v_ax0, v_ax1] = A[v_ax0, v_ax1] + B[v_ax0, v_ax1]
+
+    @T.prim_func
+    def compute_mul_in_vtcm(a: T.handle, b: T.handle, c: T.handle) -> None:
+        m, n = T.int32(), T.int32()
+        A = T.match_buffer(a, (m, n), "int32", scope="global.vtcm", axis_separators=[1])
+        B = T.match_buffer(b, (m, n), "int32", scope="global.vtcm", axis_separators=[1])
+        C = T.match_buffer(c, (m, n), "int32", scope="global.vtcm", axis_separators=[1])
+        for ax0, ax1 in T.grid(m, n):
+            with T.block("T_add"):
+                v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                T.reads(A[v_ax0, v_ax1], B[v_ax0, v_ax1])
+                T.writes(C[v_ax0, v_ax1])
+                C[v_ax0, v_ax1] = A[v_ax0, v_ax1] * B[v_ax0, v_ax1]
+
+    @R.function
+    def main(
+        x: R.Tensor((4, 64), "int32"),
+        y: R.Tensor((4, 64), "int32"),
+        z: R.Tensor((4, 64), "int32"),
+    ) -> R.Tensor((4, 64), "int32"):
+        cls = Module_2d
+        vtcm_obj: R.Object = R.vm.alloc_storage(
+            R.shape([4096]), runtime_device_index=0, dtype="uint8", storage_scope="global.vtcm"
+        )
+        global_obj: R.Object = R.vm.alloc_storage(
+            R.shape([64]), runtime_device_index=0, dtype="uint8", storage_scope="global"
+        )
+        a: R.Tensor([4, 64], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                0,
+                vtcm_obj,
+                R.shape([768, 256, 2304, 3072]),
+                R.shape([4, 64]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        __: R.Tuple = R.vm.copy_tensor_from_to(x, a)
+        b: R.Tensor([4, 64], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                16,
+                vtcm_obj,
+                R.shape([1536, 1280, 3328, 2560]),
+                R.shape([4, 64]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        _: R.Tuple = R.vm.copy_tensor_from_to(y, b)
+
+        c: R.Tensor([4, 64], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                32,
+                vtcm_obj,
+                R.shape([512, 0, 2048, 3840]),
+                R.shape([4, 64]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        ___: R.Tuple = cls.compute_add_in_vtcm(a, b, c)
+        _t1: R.Tuple = R.vm.kill_object(a)
+        _t2: R.Tuple = R.vm.kill_object(b)
+
+        d: R.Tensor([4, 64], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                0,
+                vtcm_obj,
+                R.shape([1536, 1280, 3328, 2560]),
+                R.shape([4, 64]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        ___1: R.Tuple = R.vm.copy_tensor_from_to(z, d)
+        vtcm_2d_obj: R.Object = R.vm.alloc_storage(
+            R.shape([4, 64]), runtime_device_index=0, dtype="int32", storage_scope="global.vtcm"
+        )
+        vtcm_2d_tensor: R.Tensor([4, 64], dtype="int32") = R.vm.alloc_tensor(
+            vtcm_2d_obj, offset=0, shape=R.shape([4, 64]), dtype="int32"
+        )
+        ___2: R.Tuple = cls.compute_mul_in_vtcm(c, d, vtcm_2d_tensor)
+        _t2: R.Tuple = R.vm.kill_object(c)
+        _t12: R.Tuple = R.vm.kill_object(d)
+
+        e: R.Tensor([4, 64], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                16,
+                vtcm_obj,
+                R.shape([768, 256, 2304, 3072]),
+                R.shape([4, 64]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        _t21: R.Tuple = R.vm.copy_tensor_from_to(vtcm_2d_tensor, e)
+        _t22: R.Tuple = R.vm.kill_object(vtcm_2d_tensor)
+        _t23: R.Tuple = R.vm.kill_object(vtcm_2d_obj)
+        f: R.Tensor([4, 64], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                32,
+                vtcm_obj,
+                R.shape([1536, 1280, 3328, 2560]),
+                R.shape([4, 64]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        _t13: R.Tuple = R.vm.copy_tensor_from_to(e, f)
+        _t14: R.Tuple = R.vm.kill_object(e)
+        ret_val: R.Tensor([4, 64], dtype="int32") = R.builtin.alloc_tensor(
+            R.shape([4, 64]), R.dtype("int32"), R.prim_value(0)
+        )
+        _1: R.Tuple = R.vm.copy_tensor_from_to(f, ret_val)
+        _t15: R.Tuple = R.vm.kill_object(f)
+        _t16: R.Tuple = R.vm.kill_object(vtcm_obj)
+        _t17: R.Tuple = R.vm.kill_object(global_obj)
+        lv: R.Tensor([4, 64], dtype="int32") = ret_val
+        return lv
+
+
+@I.ir_module
+class NDLogicalShapesModule:
+    @T.prim_func
+    def compute_add_in_vtcm(a: T.handle, b: T.handle, c: T.handle) -> None:
+        m, n, o, p = T.int32(), T.int32(), T.int32(), T.int32()
+        A = T.match_buffer(a, (m, n, o, p), "int32", scope="global.vtcm", axis_separators=[2])
+        B = T.match_buffer(b, (m, n, o, p), "int32", scope="global.vtcm", axis_separators=[2])
+        C = T.match_buffer(c, (m, n, o, p), "int32", scope="global.vtcm", axis_separators=[2])
+        for ax0, ax1, ax2, ax3 in T.grid(m, n, o, p):
+            with T.block("T_add"):
+                v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(A[v_ax0, v_ax1, v_ax2, v_ax3], B[v_ax0, v_ax1, v_ax2, v_ax3])
+                T.writes(C[v_ax0, v_ax1, v_ax2, v_ax3])
+                C[v_ax0, v_ax1, v_ax2, v_ax3] = (
+                    A[v_ax0, v_ax1, v_ax2, v_ax3] + B[v_ax0, v_ax1, v_ax2, v_ax3]
+                )
+
+    @T.prim_func
+    def compute_mul_in_vtcm(a: T.handle, b: T.handle, c: T.handle) -> None:
+        m, n, o, p = T.int32(), T.int32(), T.int32(), T.int32()
+        A = T.match_buffer(a, (m, n, o, p), "int32", scope="global.vtcm", axis_separators=[2])
+        B = T.match_buffer(b, (m, n, o, p), "int32", scope="global.vtcm", axis_separators=[2])
+        C = T.match_buffer(c, (m, n, o, p), "int32", scope="global.vtcm", axis_separators=[2])
+        for ax0, ax1, ax2, ax3 in T.grid(m, n, o, p):
+            with T.block("T_add"):
+                v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                T.reads(A[v_ax0, v_ax1, v_ax2, v_ax3], B[v_ax0, v_ax1, v_ax2, v_ax3])
+                T.writes(C[v_ax0, v_ax1, v_ax2, v_ax3])
+                C[v_ax0, v_ax1, v_ax2, v_ax3] = (
+                    A[v_ax0, v_ax1, v_ax2, v_ax3] * B[v_ax0, v_ax1, v_ax2, v_ax3]
+                )
+
+    @R.function
+    def main(
+        x: R.Tensor((2, 2, 8, 8), "int32"),
+        y: R.Tensor((2, 2, 8, 8), "int32"),
+        z: R.Tensor((2, 2, 8, 8), "int32"),
+    ) -> R.Tensor((2, 2, 8, 8), "int32"):
+        cls = NDLogicalShapesModule
+        vtcm_obj: R.Object = R.vm.alloc_storage(
+            R.shape([4096]), runtime_device_index=0, dtype="uint8", storage_scope="global.vtcm"
+        )
+        global_obj: R.Object = R.vm.alloc_storage(
+            R.shape([64]), runtime_device_index=0, dtype="uint8", storage_scope="global"
+        )
+        a: R.Tensor([2, 2, 8, 8], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                0,
+                vtcm_obj,
+                R.shape([768, 256, 2304, 3072]),
+                R.shape([2, 2, 8, 8]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        __: R.Tuple = R.vm.copy_tensor_from_to(x, a)
+        b: R.Tensor([2, 2, 8, 8], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                16,
+                vtcm_obj,
+                R.shape([1536, 1280, 3328, 2560]),
+                R.shape([2, 2, 8, 8]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        _: R.Tuple = R.vm.copy_tensor_from_to(y, b)
+        c: R.Tensor([2, 2, 8, 8], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                32,
+                vtcm_obj,
+                R.shape([512, 0, 2048, 3840]),
+                R.shape([2, 2, 8, 8]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        ___: R.Tuple = cls.compute_add_in_vtcm(a, b, c)
+        _t1: R.Tuple = R.vm.kill_object(a)
+        _t2: R.Tuple = R.vm.kill_object(b)
+        d: R.Tensor([2, 2, 8, 8], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                0,
+                vtcm_obj,
+                R.shape([1536, 1280, 3328, 2560]),
+                R.shape([2, 2, 8, 8]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        _: R.Tuple = R.vm.copy_tensor_from_to(z, d)
+        e: R.Tensor([2, 2, 8, 8], dtype="int32") = R.call_builtin_with_ctx(
+            "vm.builtin.hexagon.alloc_discontiguous_tensor",
+            [
+                global_obj,
+                16,
+                vtcm_obj,
+                R.shape([768, 256, 2304, 3072]),
+                R.shape([2, 2, 8, 8]),
+                R.shape([4, 64]),
+                "int32",
+            ],
+            sinfo_args=[],
+        )
+        ___2: R.Tuple = cls.compute_mul_in_vtcm(c, d, e)
+        _t2: R.Tuple = R.vm.kill_object(c)
+        _t12: R.Tuple = R.vm.kill_object(d)
+        ret_val: R.Tensor([2, 2, 8, 8], dtype="int32") = R.builtin.alloc_tensor(
+            R.shape([2, 2, 8, 8]), R.dtype("int32"), R.prim_value(0)
+        )
+        _1: R.Tuple = R.vm.copy_tensor_from_to(e, ret_val)
+        _t14: R.Tuple = R.vm.kill_object(e)
+        _t16: R.Tuple = R.vm.kill_object(vtcm_obj)
+        _t17: R.Tuple = R.vm.kill_object(global_obj)
+        lv: R.Tensor([2, 2, 8, 8], dtype="int32") = ret_val
+        return lv
+
+
+class TestVTCMAlloc:
+    """Tests for VTCM Alloc, Compute and Copy"""
+
+    mode = tvm.testing.parameter("bytecode", "compiled")
+    (module, in_shape) = tvm.testing.parameters(
+        (Module_2d, (4, 64)),
+        (Module, (4, 64)),
+        (NDLogicalShapesModule, (2, 2, 8, 8)),
+    )
+
+    @tvm.testing.requires_hexagon
+    def test_vtcm_alloc_compute(self, hexagon_launcher, mode, module, in_shape):
+        target_hexagon = tvm.target.hexagon("v69")
+        target = tvm.target.Target(target_hexagon, host=target_hexagon)
+        with tvm.transform.PassContext(opt_level=3, config=[], instruments=[]):
+            ex = relax.build(mod=module, target=target, exec_mode=mode)
+
+        with hexagon_launcher.create_session() as session:
+            dev = session.device
+            input_arg0_data = np.random.randint(0, 9, size=in_shape, dtype="int32")
+            input_arg1_data = np.random.randint(0, 9, size=in_shape, dtype="int32")
+            input_arg2_data = np.random.randint(0, 9, size=in_shape, dtype="int32")
+            output_data = np.multiply(np.add(input_arg0_data, input_arg1_data), input_arg2_data)
+            vm_mod = session.get_executor_from_factory(ex)
+            vm_rt = relax.VirtualMachine(
+                vm_mod, dev, "naive"
+            )  # Use naive allocator to exercise VTCM allocation in relax
+            data0 = tvm.nd.array(input_arg0_data, dev)
+            data1 = tvm.nd.array(input_arg1_data, dev)
+            data2 = tvm.nd.array(input_arg2_data, dev)
+            vm_rt.set_input("main", data0, data1, data2)
+            vm_rt.invoke_stateful("main")
+            hexagon_output = vm_rt.get_outputs("main").numpy()
+            tvm.testing.assert_allclose(output_data, hexagon_output)


### PR DESCRIPTION
Adds 2D Discontiguous alloc tensor hexagon builtin to support 2D allocations for hexagon at relax level. This is needed when the ops are implemented to take advantage of 2d indirections and enables memory manager optimizations to try utilize VTCM memory efficiently.

This patch also introduces the `R.vm.copy_tensor` op to support copies between different tensors, specifically planned to be used when copying tensors from one memory scope to another