### PR TITLE
[Bugfix][Relax] Remove call to tvm.build for empty TIR module

### DIFF
--- a/python/tvm/driver/build_module.py
+++ b/python/tvm/driver/build_module.py
@@ -233,6 +233,9 @@ def build(
     elif isinstance(inputs, PrimFunc):
         input_mod = lower(inputs, name=name)
     elif isinstance(inputs, tvm.IRModule):
+        assert (
+            len(inputs.get_global_vars()) > 0
+        ), "Expected a non-empty IRModule, but the IRModule contained no functions."
         input_mod = lower(inputs)
     elif not isinstance(inputs, (dict, container.Map)):
         raise ValueError(

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -451,6 +451,7 @@ void CheckAndUpdateHostConsistency(Map<Target, IRModule>* targets, Target* host)
 
 runtime::Module TIRToRuntime(const Map<Target, IRModule>& inputs_arg,
                              const Target& target_host_arg) {
+  CHECK(inputs_arg.size()) << "TIRToRuntime expects at least one IRModule as input.";
   std::vector<runtime::Module> device_modules;
   Map<Target, IRModule> inputs = inputs_arg;
   Target target_host = target_host_arg;


### PR DESCRIPTION
Prior to this commit, if a lowered `IRModule` does not contain any TIR functions, `tvm.relax.build` provided an empty `tir_mod`, which caused a segfault during TIR compilation.  This could occur when `tvm.relax.build` is called without an explicit target argument, for a module that does not define any virtual devices.

This commit updates the `_filter_tir` utility function to return `None` if there are no TIR functions, rather than an empty `IRModule`.  In addition, checks for an empty `IRModule` are added to `tvm.build` and `TIRToRuntime`, so that a similar failure mode would raise an exception rather than producing a segfault.