### PR TITLE
[Bugfix][TVMScript] Handle R.match_cast as last binding in if/else

### DIFF
--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -263,7 +263,9 @@ void ElseFrameNode::ExitWithScope() {
   IfFrame frame = FindIfFrame("R.Else");
   frame->else_expr = output;
   CHECK(frame->var_name == var_name)
-      << "This last binding of both branches must have the same variable.";
+      << "This last binding of both branches must provide the same variable.  "
+      << "However, the R.Then branch provides variable " << frame->var_name
+      << ", while the R.Else branch provides variable " << var_name;
 }
 
 TVM_REGISTER_NODE_TYPE(FunctionFrameNode);

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1176,6 +1176,47 @@ def test_if_branch():
     check_call(y_bind.value, "relax.add", [w_bind.var, w_bind.var])
 
 
+def test_if_branch_with_match_cast():
+    """The last branch of a relax::If node may be a MatchCast
+
+    This is a regression test.  In previous implementations, using
+    R.match_cast as the last binding would cause a segfault while
+    parsing.
+    """
+
+    @R.function
+    def func(A: R.Tensor([16, 16]), is_bfloat16: R.Prim("bool")):
+        if is_bfloat16:
+            A = R.match_cast(A, R.Tensor([16, 16], "bfloat16"))
+            B = A.astype("float16")
+        else:
+            B = R.match_cast(A, R.Tensor([16, 16], "float16"))
+        return B
+
+    A, is_bfloat16 = func.params
+    (block,) = func.body.blocks
+    (B_binding,) = block.bindings
+
+    B_var = B_binding.var
+    assert isinstance(B_var, relax.Var)
+    assert B_var.name_hint == "B"
+
+    if_then_else = B_binding.value
+    assert isinstance(if_then_else, relax.If)
+    assert isinstance(if_then_else.true_branch, relax.SeqExpr)
+    assert isinstance(if_then_else.false_branch, relax.SeqExpr)
+
+    else_branch = if_then_else.false_branch
+    (else_block,) = else_branch.blocks
+
+    assert isinstance(else_block.bindings[-1], relax.MatchCast)
+
+    # If the `R.match_cast` were removed, the function would infer the
+    # return value as `R.Tensor([16,16])`, with an unknown dtype.
+    # With the `R.match_cast` retained, the output dtype is known.
+    tvm.ir.assert_structural_equal(func.ret_struct_info, R.Tensor([16, 16], "float16"))
+
+
 def test_if_inside_dataflow():
     with pytest.raises(tvm.error.DiagnosticError):
 


### PR DESCRIPTION
Prior to this commit, using `R.match_cast` as the last binding would produce a segfault, as `var_binding->value` was used instead of `match_cast->value`.  In addition, because the last binding of each branch was removed, any changes to the struct info resulting from the match cast were silently discarded.

This commit updates the TVMScript parsing of if/else statements to remove the segfault and maintain the struct info changes produced by the `R.match_cast`.