### PR TITLE
[Bugfix][Transform] Keep private non-primitive functions in FuseTIR

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -578,9 +578,12 @@ TVM_DLL Pass ConvertToDataflow(int min_size = 2);
  *
  * Any binding blocks that are left empty will be removed by the normalizer.
  *
+ * \param entry_functions Names of functions that should be considered
+ *     as entry points, in addition to any externally exposed functions.
+ *
  * \return The Pass.
  */
-TVM_DLL Pass DeadCodeElimination(Array<runtime::String> entry_functions);
+TVM_DLL Pass DeadCodeElimination(Array<runtime::String> entry_functions = {});
 
 /*!
  * \brief Pass that changes calls to operators that can be done in-place


### PR DESCRIPTION
Prior to this commit, private non-primitive relax functions would be discarded by `FuseTIR`.  If any calls to these functions exist, the resulting `IRModule` would be ill-formed.  This commit updates `FuseTIR` so that it only applies updates to functions with `attr::kPrimitive`, and calls into those functions.

To retain backwards compatibility, `DeadCodeElimination` is applied as a post-processing step.