### PR TITLE
[MISC] Fix compile warnings

### DIFF
--- a/include/tvm/node/script_printer.h
+++ b/include/tvm/node/script_printer.h
@@ -86,6 +86,7 @@ class PrinterConfigNode : public Object {
    *
    * Example:
    *
+   * \code{.py}
    *     # func.show(show_all_struct_info=True)
    *     @R.function
    *     def func(
@@ -103,6 +104,7 @@ class PrinterConfigNode : public Object {
    *     ) -> R.Tensor((10, 20), dtype="float32"):
    *         C = R.add(A, B2)
    *         return C
+   * \endcode
    */
   bool show_all_struct_info = true;
 

--- a/src/target/source/codegen_webgpu.h
+++ b/src/target/source/codegen_webgpu.h
@@ -21,7 +21,7 @@
  * \file codegen_webgpu.h
  * \brief Generate WebGPU shaders in WGSL.
  *
- * This module generates WGSL shading langauge.
+ * This module generates WGSL shading language.
  * See https://www.w3.org/TR/WGSL/ for the language reference.
  */
 #ifndef TVM_TARGET_SOURCE_CODEGEN_WEBGPU_H_
@@ -40,7 +40,7 @@ namespace codegen {
  * \brief WebGPU code generator.
  *
  * Note WGSL have a different syntax from normal C.
- * We only leevrage the C for expression generation and
+ * We only leverage the C for expression generation and
  * write most of the language generations.
  */
 class CodeGenWebGPU final : public CodeGenC {
@@ -48,6 +48,7 @@ class CodeGenWebGPU final : public CodeGenC {
   explicit CodeGenWebGPU(Target target);
   // overrides
   std::string Finish() final;
+  using CodeGenC::AddFunction;
   runtime::FunctionInfo AddFunction(const PrimFunc& f, bool skip_readonly_decl);  // NOLINT(*)
   void InitFuncState(const PrimFunc& f) final;
   void PrintStorageSync(const CallNode* op) final;     // NOLINT(*)


### PR DESCRIPTION
This PR fixes the following compile warnings with clang-17:
```
[build] warning: unknown command tag name [-Wdocumentation-unknown-command]
[build]    90 |    *     @R.function
[build]       |          ^~

[build] warning: 'tvm::codegen::CodeGenWebGPU::AddFunction' hides overloaded virtual function [-Woverloaded-virtual]
[build]    52 |   runtime::FunctionInfo AddFunction(const PrimFunc& f, bool skip_readonly_decl);  // NOLINT(*)
[build]       |
```

cc @Lunderberg @tqchen 