### PR TITLE
[Unity] GPU sampling

### DIFF
--- a/python/tvm/relax/frontend/nn/_tensor_op.py
+++ b/python/tvm/relax/frontend/nn/_tensor_op.py
@@ -67,14 +67,6 @@ class _TensorOp:
         other = _convert_scalar(other, self)
         return _op().divide(self, other)
 
-    def __eq__(self, other):
-        other = _convert_scalar(other, self)
-        return _op().equal(self, other)
-
-    def __ne__(self, other):
-        other = _convert_scalar(other, self)
-        return _op().not_equal(self, other)
-
     def __lt__(self, other):
         other = _convert_scalar(other, self)
         return _op().less(self, other)

--- a/python/tvm/relax/frontend/nn/_tensor_op.py
+++ b/python/tvm/relax/frontend/nn/_tensor_op.py
@@ -67,6 +67,30 @@ class _TensorOp:
         other = _convert_scalar(other, self)
         return _op().divide(self, other)
 
+    def __eq__(self, other):
+        other = _convert_scalar(other, self)
+        return _op().equal(self, other)
+
+    def __ne__(self, other):
+        other = _convert_scalar(other, self)
+        return _op().not_equal(self, other)
+
+    def __lt__(self, other):
+        other = _convert_scalar(other, self)
+        return _op().less(self, other)
+
+    def __le__(self, other):
+        other = _convert_scalar(other, self)
+        return _op().less_equal(self, other)
+
+    def __gt__(self, other):
+        other = _convert_scalar(other, self)
+        return _op().greater(self, other)
+
+    def __ge__(self, other):
+        other = _convert_scalar(other, self)
+        return _op().greater_equal(self, other)
+
     def astype(self, dtype):
         return _op().astype(self, dtype)
 

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -2253,7 +2253,7 @@ def sample_top_p_top_k_from_sorted_prob(
     return out_index_in_sorted
 
 
-def renormalize_top_p_top_k_prob(prob, sorted_prob, sorted_index, top_p, top_k):
+def renormalize_top_p_top_k_prob(prob, sorted_prob, top_p, top_k):
     """Renormalizes probabilities after filtering with top_p and top_k, ensuring
     they sum up to 1.
 
@@ -2268,9 +2268,6 @@ def renormalize_top_p_top_k_prob(prob, sorted_prob, sorted_index, top_p, top_k):
 
     sorted_prob : Tensor
         Probabilities sorted in descending order.
-
-    sorted_index : Tensor
-         Indices corresponding to the sorted probabilities.
 
     top_p : Tensor
         The cumulative probability threshold with shape (batch, 1) for nucleus sampling.

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -2023,9 +2023,7 @@ def cumsum(
     return wrap_nested(_op.cumsum(data._expr, axis, dtype, exclusive), name)
 
 
-def multinomial_from_uniform(
-    prob: Tensor, uniform_sample: Tensor, name: str = "multinomial_from_uniform"
-):
+def multinomial_from_uniform(prob: Tensor, uniform_sample: Tensor):
     """Returns a tensor where each row contains the index sampled from the multinomial
     probability distribution located in the corresponding row of tensor prob.
 
@@ -2040,9 +2038,6 @@ def multinomial_from_uniform(
 
     uniform_sample : Tensor
         The uniform sample.
-
-    name : str
-        Name hint.
 
     Returns
     -------

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -2073,8 +2073,9 @@ def multinomial_from_uniform(prob: Tensor, uniform_sample: Tensor):
                     if usample[v_ax0, T.int64(0)] < prob[v_ax0, v_ax1] or v_ax1 + 1 == vocab_size:
                         if v_ax1 == 0:
                             output_index[v_ax0, 0] = 0
-                        elif not (usample[v_ax0, T.int64(0)] < prob[v_ax0, v_ax1 - 1]):
-                            output_index[v_ax0, 0] = v_ax1
+                        else:
+                            if not (usample[v_ax0, T.int64(0)] < prob[v_ax0, v_ax1 - 1]):
+                                output_index[v_ax0, 0] = v_ax1
 
     return tensor_ir_op(
         _get_sample_index,

--- a/src/runtime/relax_vm/lm_support.cc
+++ b/src/runtime/relax_vm/lm_support.cc
@@ -519,7 +519,7 @@ NDArray MultinomialFromUniform(NDArray prob, NDArray uniform_sample) {
   for (int64_t i = 0; i < batch_size; ++i) {
     cum_sum_prob = 0.0f;
     int64_t prob_idx = 0;
-    for (int j = 0; j < vocab_size; ++j) {
+    for (int64_t j = 0; j < vocab_size; ++j) {
       prob_idx = j;
       cum_sum_prob += pprob[i * vocab_size + j];
       if (cum_sum_prob > psample[i]) {

--- a/src/runtime/relax_vm/lm_support.cc
+++ b/src/runtime/relax_vm/lm_support.cc
@@ -515,9 +515,8 @@ NDArray MultinomialFromUniform(NDArray prob, NDArray uniform_sample) {
   const float* psample = static_cast<float*>(uniform_sample->data);
   NDArray new_array = NDArray::Empty({batch_size, 1}, DataType::Int(64), uniform_sample->device);
   int64_t* parray = static_cast<int64_t*>(new_array->data);
-  float cum_sum_prob;
   for (int64_t i = 0; i < batch_size; ++i) {
-    cum_sum_prob = 0.0f;
+    float cum_sum_prob = 0.0f;
     int64_t prob_idx = 0;
     for (int64_t j = 0; j < vocab_size; ++j) {
       prob_idx = j;

--- a/src/runtime/relax_vm/lm_support.cc
+++ b/src/runtime/relax_vm/lm_support.cc
@@ -520,11 +520,11 @@ NDArray MultinomialFromUniform(NDArray prob, NDArray uniform_sample) {
     cum_sum_prob = 0.0f;
     int64_t prob_idx = 0;
     for (int j = 0; j < vocab_size; ++j) {
+      prob_idx = j;
       cum_sum_prob += pprob[i * vocab_size + j];
-      if (cum_sum_prob >= psample[i]) {
+      if (cum_sum_prob > psample[i]) {
         break;
       }
-      prob_idx = j;
     }
     parray[i] = prob_idx;
   }

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -883,7 +883,7 @@ def test_multinomial_from_uniform():
             cls = Expected
             with R.dataflow():
                 cumsum: R.Tensor((4, 5), dtype="float32") = R.cumsum(prob, axis=1, dtype="void", exclusive=True)
-                lv1 = R.call_tir(cls.get_sample_index, (cumsum, uniform_sample), out_sinfo=R.Tensor((4, 1), dtype="int64"), tir_vars=R.shape([]))
+                lv1 = R.call_tir(cls.get_sample_index, (cumsum, uniform_sample), out_sinfo=R.Tensor((4, 1), dtype="int64"))
                 gv1: R.Tuple(R.Tensor((4, 1), dtype="int64"), R.Tuple(R.Object)) = lv1, (_io,)
                 R.output(gv1)
             return gv1

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -290,7 +290,9 @@ def test_chunk():
             return chunk
 
     @R.function
-    def test(x: R.Tensor((8,), dtype="float32"), _io: R.Object) -> R.Tuple(
+    def test(
+        x: R.Tensor((8,), dtype="float32"), _io: R.Object
+    ) -> R.Tuple(
         R.Tuple(
             R.Tensor((2,), dtype="float32"),
             R.Tensor((2,), dtype="float32"),
@@ -479,9 +481,9 @@ def test_scaled_dot_product_attention():
     ) -> R.Tuple(R.Tensor((1, 32, 32, 32), dtype="float32"), R.Tuple(R.Object)):
         R.func_attr({"num_input": 4})
         with R.dataflow():
-            scaled_dot_product_attention: R.Tensor((1, 32, 32, 32), dtype="float32") = (
-                R.nn.attention(query, key, value, scale=None, causal_mask=None)
-            )
+            scaled_dot_product_attention: R.Tensor(
+                (1, 32, 32, 32), dtype="float32"
+            ) = R.nn.attention(query, key, value, scale=None, causal_mask=None)
             gv1: R.Tuple(R.Tensor((1, 32, 32, 32), dtype="float32"), R.Tuple(R.Object)) = (
                 scaled_dot_product_attention,
                 (_io,),

--- a/tests/python/relax/test_vm_builtin.py
+++ b/tests/python/relax/test_vm_builtin.py
@@ -46,7 +46,7 @@ def test_multinomial_from_uniform():
     np_prob = np_rand / np_rand.sum(axis=1, keepdims=True)
     nd_prob = tvm.nd.array(np_prob)
     # special sample to get deterministic results
-    nd_sample = tvm.nd.array(np.array([[1.1], [0], [1.001]]).astype(np.float32))
+    nd_sample = tvm.nd.array(np.array([[1.0], [0], [1]]).astype(np.float32))
 
     vm = relax.VirtualMachine(ex, tvm.cpu())
     res = vm["foo"](nd_prob, nd_sample)

--- a/tests/python/relax/test_vm_builtin.py
+++ b/tests/python/relax/test_vm_builtin.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import numpy as np
+import pytest
+
+import tvm
+import tvm.script
+import tvm.testing
+from tvm import relax
+from tvm.script import relax as R
+
+
+def test_multinomial_from_uniform():
+    @tvm.script.ir_module
+    class CallSample:
+        @R.function
+        def foo(x: R.Tensor((3, 5), "float32"), y: R.Tensor((3, 1), "float32")):
+            z = R.call_pure_packed(
+                "vm.builtin.multinomial_from_uniform",
+                x,
+                y,
+                sinfo_args=(R.Tensor((3, 1), dtype="int64")),
+            )
+            return z
+
+    mod = CallSample
+    target = tvm.target.Target("llvm", host="llvm")
+    ex = relax.build(mod, target)
+    np_rand = np.random.rand(3, 5).astype(np.float32)
+    # normalize it to get the random prob
+    np_prob = np_rand / np_rand.sum(axis=1, keepdims=True)
+    nd_prob = tvm.nd.array(np_prob)
+    # special sample to get deterministic results
+    nd_sample = tvm.nd.array(np.array([[1.1], [0], [1.001]]).astype(np.float32))
+
+    vm = relax.VirtualMachine(ex, tvm.cpu())
+    res = vm["foo"](nd_prob, nd_sample)
+    tvm.testing.assert_allclose(res.numpy(), np.array([[4], [0], [4]]).astype(np.int64))
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR introduces the `multinomial_from_uniform` into nn module for GPU case, and `vm.builtin.multinomial_from_uniform` for CPU. The `multinomial_from_uniform` returns a tensor wherein each row contains an index sampled from a multinomial probability distribution.

[The test case](https://github.com/apache/tvm/pull/16575/commits/abbe733e4af04ac1591066769d269d8c3aa95d56#diff-cd42596733b780d4b3ca6e4e66a002f6175c144821cdeabe8ebaa91bc6c16f67L907-L924) is for testing the build and run, it has been commented out to avoid overloading the nn module op tests.

----
Updated on Feb. 21, 2024

Add `sample_top_p_top_k_from_sorted_prob` and `renormalize_top_p_top_k_prob`

cc: @tqchen @vinx13 @MasterJH5574 