### PR TITLE
[Unity][MSC][M4.2][Step2] Enable plugin with manager, test plugins in compile pipeline

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1459,6 +1459,17 @@ class TorchFXImporter:
             "scaled_dot_product_attention": self._scaled_dot_product_attention,
         }
 
+    def update_convert_map(self, custom_convert_map: dict):
+        """Update self.convert_map with custom convert map
+
+        Parameters
+        ----------
+        custom_convert_map : Dictionary of str to Relax op
+            A custom op conversion map in the same format as self.convert_map
+        """
+
+        self.convert_map.update(custom_convert_map)
+
     def from_fx(
         self,
         model,
@@ -1466,10 +1477,16 @@ class TorchFXImporter:
         keep_params_as_input: bool,
         unwrap_unit_return_tuple: bool,
         no_bind_return_tuple: bool,
+        custom_convert_map: dict = None,
     ) -> tvm.IRModule:
         """Convert a PyTorch FX GraphModule to a Relax program."""
         from torch import fx
 
+        if custom_convert_map:
+            custom_ops = set(custom_convert_map.keys())
+            self.update_convert_map(custom_convert_map)
+        else:
+            custom_ops = set()
         self.named_modules = dict(model.named_modules())
 
         graph: fx.Graph = model.graph
@@ -1548,7 +1565,10 @@ class TorchFXImporter:
                         assert (
                             func_name in self.convert_map
                         ), f"Unsupported function type {func_name}"
-                        self.env[node] = self.convert_map[func_name](node)
+                        if func_name in custom_ops:
+                            self.env[node] = self.convert_map[func_name](node, self)
+                        else:
+                            self.env[node] = self.convert_map[func_name](node)
                     elif node.op == "call_method":
                         assert (
                             node.target in self.convert_map
@@ -1572,6 +1592,7 @@ def from_fx(
     keep_params_as_input: bool = False,
     unwrap_unit_return_tuple: bool = False,
     no_bind_return_tuple: bool = False,
+    custom_convert_map: dict = None,
 ) -> tvm.IRModule:
     """Convert a PyTorch FX GraphModule to a Relax program
 
@@ -1593,6 +1614,9 @@ def from_fx(
     no_bind_return_tuple : bool
         A boolean flag indicating whether to bind the return tuple as a relax var.
         If the flag is true and the return value is a tuple, it will not bind it to a var.
+
+    custom_convert_map : Dictionary of str to Relax op
+        A custom op conversion map in the same format as TorchFXImporter.convert_map
 
     Returns
     -------
@@ -1662,5 +1686,10 @@ def from_fx(
     check the placeholder rows in the beginning of the tabular.
     """
     return TorchFXImporter().from_fx(
-        model, input_info, keep_params_as_input, unwrap_unit_return_tuple, no_bind_return_tuple
+        model,
+        input_info,
+        keep_params_as_input,
+        unwrap_unit_return_tuple,
+        no_bind_return_tuple,
+        custom_convert_map=custom_convert_map,
     )

--- a/tests/python/contrib/test_msc/test_plugin.py
+++ b/tests/python/contrib/test_msc/test_plugin.py
@@ -26,6 +26,7 @@ import tvm.testing
 from tvm import relax
 from tvm.relax.transform import BindParams
 from tvm.script import relax as R
+from tvm.contrib.msc.pipeline import MSCManager
 from tvm.contrib.msc.plugin import build_plugins
 from tvm.contrib.msc.core.utils.namespace import MSCFramework
 from tvm.contrib.msc.core import utils as msc_utils
@@ -287,6 +288,39 @@ def _test_torch_plugin(manager):
     assert outputs.min() >= 0 and outputs.max() <= 0.5
 
 
+def _test_with_manager(plugins, compile_type, expected_info):
+    """Test the plugin with manager"""
+
+    path = "test_plugin_" + compile_type
+    model = _get_torch_model(plugins[MSCFramework.TORCH])
+    if torch.cuda.is_available():
+        model = model.to(torch.device("cuda:0"))
+    config = {
+        "workspace": msc_utils.msc_dir(path),
+        "model_type": MSCFramework.TORCH,
+        "verbose": "critical",
+        "inputs": [["input_0", [1, 3, 224, 224], "float32"]],
+        "outputs": ["output"],
+        "dataset": {"prepare": {"loader": "from_random", "max_iter": 5}},
+        "prepare": {"profile": {"benchmark": {"repeat": 10}}},
+        "baseline": {
+            "profile": {"check": {"atol": 1e-2, "rtol": 1e-2}, "benchmark": {"repeat": 10}},
+        },
+        "compile": {
+            "run_type": compile_type,
+            "profile": {"check": {"atol": 1e-2, "rtol": 1e-2}, "benchmark": {"repeat": 10}},
+        },
+    }
+    manager = MSCManager(model, config, plugins=plugins)
+    report = manager.run_pipe()
+    model_info = manager.runner.model_info
+    manager.destory()
+    assert report["success"], "Failed to run pipe for torch -> {}".format(compile_type)
+    assert msc_utils.dict_equal(
+        model_info, expected_info
+    ), "Model info {} mismatch with expected {}".format(model_info, expected_info)
+
+
 def test_plugin():
     """Test the plugins"""
 
@@ -301,6 +335,30 @@ def test_plugin():
     if tvm.cuda().exist:
         _test_tvm_plugin(managers[MSCFramework.TVM], "cuda")
     _test_torch_plugin(managers[MSCFramework.TORCH])
+
+    # test the plugin with manager
+    model_info = {
+        "inputs": [
+            {"name": "input_0", "shape": [1, 3, 224, 224], "dtype": "float32", "layout": "NCHW"}
+        ],
+        "outputs": [
+            {"name": "output", "shape": [1, 6, 218, 218], "dtype": "float32", "layout": "NCHW"}
+        ],
+        "nodes": {"total": 4, "input": 1, "msc.conv2d_bias": 1, "MyRelu": 1, "nn.max_pool2d": 1},
+    }
+    _test_with_manager(managers, MSCFramework.TORCH, model_info)
+    _test_with_manager(managers, MSCFramework.TVM, model_info)
+    if tvm.get_global_func("relax.ext.tensorrt", True) is not None:
+        byoc_info = {
+            "inputs": [
+                {"name": "input_0", "shape": [1, 3, 224, 224], "dtype": "float32", "layout": "NCHW"}
+            ],
+            "outputs": [
+                {"name": "output", "shape": [1, 6, 218, 218], "dtype": "float32", "layout": ""}
+            ],
+            "nodes": {"total": 2, "input": 1, "msc_tensorrt": 1},
+        }
+        _test_with_manager(managers, MSCFramework.TENSORRT, byoc_info)
 
     plugin_root.destory()
 


### PR DESCRIPTION
This is a pull request for MSC(Multi-System Compile)
RFC: https://discuss.tvm.apache.org/t/rfc-unity-msc-introduction-to-multi-system-compiler/15251/5
Tracking issue: https://github.com/apache/tvm/issues/15233

This is the Milestone 4 for MSC: Add plugin builder, enable plugin wrap in different frameworks.
To limit each PR in reviewable size, the Milestone 4 will be split into some steps:
[M4.1] Add plugin && plugin_builder, enable build and test in different frameworks.
**[M4.2] Enable plugin with manager, test plugins in compile pipeline.**

To enable using plugin in compile pipeline, the plugin manager is used together with MSC Manager. Plugin manager handles the converter of plugin from training framework to relax. Codegen parts are also modified for code generation.

This PR add custom convert map in relax.frontend.torch.from_fx.

cc @Hzfengsy , some changes are needed in relax.frontend.torch.from_fx to support custom ops, could you please help to review this part?