### PR TITLE
[Unity][VM] Recursively visit match bindings in VMShapeLowerMutator

### DIFF
--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -419,7 +419,7 @@ class VMShapeLowerMutator
 
     // These checks are emitted as extra, in codegen
     // match-cast is simply ignored and treated as a normal binding.
-    builder_->EmitNormalized(GetRef<MatchCast>(binding));
+    ExprMutator::VisitBinding_(binding);
   }
 
   // Do not override shape in struct info fields


### PR DESCRIPTION
Prior to this commit, the `MatchBinding` visitor in `VMShapeLowerMutator`.  If the RHS of the `MatchBinding` is a `ShapeExpr` that uses symbolic variables, that RHS must be visited in order to have the symbolic variable updated.