### PR TITLE
[Unity][TIR] Clear struct info when specializing PrimFunc

### DIFF
--- a/src/tir/ir/specialize.cc
+++ b/src/tir/ir/specialize.cc
@@ -109,6 +109,8 @@ class PrimFuncSpecializer : public StmtExprMutator {
       f_ptr->params = std::move(params);
       f_ptr->buffer_map = std::move(buffer_map);
       f_ptr->body = std::move(body);
+      f_ptr->struct_info_ = NullOpt;
+      f_ptr->checked_type_ = Type(nullptr);
     }
     return f;
   }


### PR DESCRIPTION
In rare cases, a `PrimFunc` may be annotated with `StructInfo`, to indicate that it is an impure function with specific shapes for the parameters.  If struct info is present, it is invalidated when specializing a `PrimFunc`, and should be cleared.