### PR TITLE
[Unity][Analysis] Include impure call in VerifyWellFormed errors

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -499,6 +499,21 @@ TVM_DLL bool HasReshapePattern(const tir::PrimFunc& func);
  * \param own_name (Optional.) If we are checking a recursive function body,
  *   the caller can pass the function's name so recursive calls
  *   can be ignored in the check (must be a Var or GlobalVar).
+ * \return The impure expression, if one exists within the given
+ *   expression.  Otherwise, NullOpt.
+ * \note Relies on StructInfo annotations, so ensure that the module has been normalized first.
+ *   Also, an impure call in a *nested* function does *not* mean that the outer expression contains
+ *   an impure call--it only does if the nested function is *later called*.
+ */
+TVM_DLL Optional<Expr> FindImpureCall(const Expr& expr,
+                                      const Optional<Expr>& own_name = Optional<Expr>(nullptr));
+
+/*!
+ * \brief Check if the given expression (likely a function body) contains any impure calls.
+ * \param expr The expression to be examined. If expr is a function, we check the body.
+ * \param own_name (Optional.) If we are checking a recursive function body,
+ *   the caller can pass the function's name so recursive calls
+ *   can be ignored in the check (must be a Var or GlobalVar).
  * \return A boolean indicating if the expression contains any impure calls.
  * \note Relies on StructInfo annotations, so ensure that the module has been normalized first.
  *   Also, an impure call in a *nested* function does *not* mean that the outer expression contains

--- a/src/relax/analysis/analysis.cc
+++ b/src/relax/analysis/analysis.cc
@@ -151,7 +151,7 @@ Optional<Expr> FindImpureCall(const Expr& expr, const Optional<Expr>& own_name) 
     }
 
    private:
-    ImpureCallChecker(const Optional<Expr>& own_name) : own_name_(own_name) {}
+    explicit ImpureCallChecker(const Optional<Expr>& own_name) : own_name_(own_name) {}
 
     void VisitExpr(const Expr& expr) override {
       // Early bail-out if we found an impure expression

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -607,7 +607,7 @@ def test_force_pure_improper():
     assert not rx.analysis.well_formed(mod)
 
 
-def test_impure_in_dataflow_block():
+def test_impure_in_dataflow_block(capfd):
     # even if force_pure is set, an impure operation cannot appear in a dataflow block
     x = rx.Var("x", R.Tensor((), dtype="int32"))
     y = rx.DataflowVar("y")
@@ -617,6 +617,9 @@ def test_impure_in_dataflow_block():
     )
     mod = rx.transform.Normalize()(tvm.IRModule.from_expr(func))
     assert not rx.analysis.well_formed(mod)
+
+    _stdout, stderr = capfd.readouterr()
+    assert "R.print" in stderr
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prior to this commit, `VerifyWellFormed` would state that a dataflow block or pure function contained an impure call, but identifying which call was impure was left to the user.

This commit updates `VerifyWellFormed` to show the impure `relax::Call` as part of the error message.