### PR TITLE
[Relax] Ignore non-relax functions in relax.transform.RunCodegen

### DIFF
--- a/src/relax/transform/run_codegen.cc
+++ b/src/relax/transform/run_codegen.cc
@@ -116,9 +116,9 @@ class CodeGenRunner : ExprMutator {
       auto ret_sinfo = GetStructInfo(call);
       if (auto it = extern_funcs_.find(gvar_node); it != extern_funcs_.end()) {
         return create_call_dps_packed(it->second, ret_sinfo);
-      } else {
+      } else if (auto opt_func = builder_->GetContextIRModule()->Lookup(gvar).as<Function>()) {
         // TODO(@sunggg): Is there any better way to get this func?
-        Function func = Downcast<Function>(builder_->GetContextIRModule()->Lookup(gvar));
+        Function func = opt_func.value();
         Expr new_func = VisitExpr(func);
 
         if (new_func->IsInstance<ExternFuncNode>()) {

--- a/tests/python/relax/test_transform_codegen_pass.py
+++ b/tests/python/relax/test_transform_codegen_pass.py
@@ -40,7 +40,7 @@ has_tensorrt_runtime = pytest.mark.skipif(
 )
 
 # Global variable in pytest that applies markers to all tests.
-# pytestmark = [has_tensorrt_codegen, has_tensorrt_runtime]
+pytestmark = [has_tensorrt_codegen, has_tensorrt_runtime]
 
 # Target gpu
 target_str = "nvidia/nvidia-t4"
@@ -350,7 +350,6 @@ def test_dynamic_shape():
 
     after = relax.transform.RunCodegen()(Before)
     tvm.ir.assert_structural_equal(after["main"], Expected["main"])
-    after.show()
 
 
 def test_no_op_for_call_to_tir():


### PR DESCRIPTION
The `relax.transform.RunCodegen` pass replaces calls to relax functions with the `"Codegen"` attribute with calls into a compiled module. Prior to this commit, while calls to relax functions without the `"Codegen"` attribute were ignored, calls to non-relax functions would raise an error.

This commit updates `relax.transform.RunCodegen` to also ignore calls to non-relax functions.