### PR TITLE
[Debug] Improve error message for codegen pattern mismatches

### DIFF
--- a/src/relax/backend/contrib/utils.cc
+++ b/src/relax/backend/contrib/utils.cc
@@ -38,7 +38,10 @@ Map<String, IntImm> ExtractArgIdx(String pattern_name, Function f) {
   auto bindings = AnalyzeVar2Value(f);
   auto inner_body = Downcast<SeqExpr>(f->body)->body;
   auto matched_expr = relax::ExtractMatchedExpr(pattern.value()->pattern, inner_body, bindings);
-  ICHECK(matched_expr);
+  ICHECK(matched_expr) << "ValueError: "
+                       << "For named pattern \"" << pattern_name
+                       << "\", expected to find a match for " << pattern.value()->pattern
+                       << ".  However, the function did not include this pattern " << f;
 
   auto find_index = [](const Array<Var>& params, Var v) -> std::optional<size_t> {
     for (size_t i = 0; i < params.size(); ++i) {


### PR DESCRIPTION
If there is a mis-match between the pattern used in `FuseOpsByPattern` and the expected relax function used in a relax codegen function (e.g. `"relax.ext.cublas"`), this will raise an error when attempting to unpack the primitive relax function.  This commit improves the error message provided when this occurs, stating what pattern was expected, and what function was expected to match the pattern.