### PR TITLE
[Relax] Handle dynamic arguments in legalization of nn.attention

### DIFF
--- a/python/tvm/relax/transform/legalize_ops/nn.py
+++ b/python/tvm/relax/transform/legalize_ops/nn.py
@@ -486,7 +486,7 @@ def _te_attention(
         if causal_mask == "TopLeft":
             offset = tir.IntImm("int32", 0)
         elif causal_mask == "BottomRight":
-            offset = tir.IntImm("int32", abs(seq_len - seq_len_kv))
+            offset = tir.abs(seq_len - seq_len_kv).astype("int32")
         else:
             raise NotImplementedError()
         p_masked = topi.trilu(p, k=offset, upper=False)


### PR DESCRIPTION
Prior to this commit, when using `causal_mask="BottomRight"` in `R.nn.attention`, the legalization would assume that the query and key/value sequence lengths were static integers.  This commit updates the legalization to allow dynamic shapes.