### PR TITLE
[Transform] Check for zero-param operators in LiftTransformParams

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -169,13 +169,11 @@ class CallNode : public ExprNode {
 
   bool SEqualReduce(const CallNode* other, SEqualReducer equal) const {
     // skip sinfo_args check for primitive ops.
-    equal->MarkGraphNode();
     return equal(op, other->op) && equal(args, other->args) && equal(attrs, other->attrs) &&
            equal(sinfo_args, other->sinfo_args) && equal(struct_info_, other->struct_info_);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
-    hash_reduce->MarkGraphNode();
     hash_reduce(op);
     hash_reduce(args);
     hash_reduce(attrs);

--- a/tests/python/relax/test_utils.py
+++ b/tests/python/relax/test_utils.py
@@ -122,5 +122,28 @@ def test_copy_with_new_vars_on_ir_module_nested_function():
     assert_structural_equal(Actual, Expected)
 
 
+def test_structural_equal_of_call_nodes():
+    """relax.Call must be compared by structural equality, not reference"""
+
+    # Three identical calls to relax.op.zeros
+    calls_to_op_zero = [relax.op.zeros([16], "int32") for _ in range(3)]
+
+    @R.function(private=True)
+    def uses_same_object_twice():
+        A = calls_to_op_zero[0]
+        B = calls_to_op_zero[0]
+        C = R.add(A, B)
+        return C
+
+    @R.function(private=True)
+    def uses_two_different_objects():
+        A = calls_to_op_zero[1]
+        B = calls_to_op_zero[2]
+        C = R.add(A, B)
+        return C
+
+    tvm.ir.assert_structural_equal(uses_same_object_twice, uses_two_different_objects)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Prior to this commit, `LiftTransformParams` would extract out all variable binding that have no runtime dependencies.  As a result, expressions such as `R.zeros([16], "int32")` would be extracted out into the parameter transformation, even though they do not depend on any parameters.

This commit updates `LiftTransformParams` to only output variables that depend on at least one compile-time parameter.

The unit test for this functionality also found that `relax::Call` was erroneously calling `MarkGraphNode` in `SEqualReduce` and `SHashReduce`.  This should only be called for nodes that have have reference equality, such as `relax::Var`, and not for composite objects.  This caused erroneous failures in the unit test when two instances of `R.zeros([16], "int32")` were being compared by reference equality in `StructuralEqual`.  These extra calls to `MarkGraphNode` have been removed.