### PR TITLE
[Transform] Allow explicit name of bundled model parameters

### DIFF
--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -852,7 +852,7 @@ def LiftTransformParams() -> tvm.ir.transform.Pass:
     return _ffi_api.LiftTransformParams()  # type: ignore
 
 
-def BundleModelParams() -> tvm.ir.transform.Pass:
+def BundleModelParams(param_tuple_name: Optional[str] = None) -> tvm.ir.transform.Pass:
     """Bundle several model parameters into a single tuple paramters
 
     For each function, if the function has the attribute "num_input",
@@ -860,13 +860,20 @@ def BundleModelParams() -> tvm.ir.transform.Pass:
     Run-time parameters (e.g. activations) are the first `num_input`
     parameters, and the remainder are compile-time weights.
 
+    Parameters
+    ----------
+    param_tuple_name: Optional[str]
+
+        The name of the tuple parameter.  If unspecified, defaults to
+        "model_params".
+
     Returns
     -------
     ret : tvm.transform.Pass
         The registered pass for lifting transformation of parameters.
 
     """
-    return _ffi_api.BundleModelParams()  # type: ignore
+    return _ffi_api.BundleModelParams(param_tuple_name)  # type: ignore
 
 
 def LegalizeOps(

--- a/src/relax/transform/bundle_model_params.cc
+++ b/src/relax/transform/bundle_model_params.cc
@@ -35,7 +35,8 @@ namespace relax {
 
 class ModelParamBundler : public ExprMutator {
  public:
-  ModelParamBundler(Optional<String> param_tuple_name) : param_tuple_name_(param_tuple_name) {}
+  explicit ModelParamBundler(Optional<String> param_tuple_name)
+      : param_tuple_name_(param_tuple_name) {}
 
   Expr VisitExpr_(const FunctionNode* op) override {
     Function func = GetRef<Function>(op);

--- a/src/relax/transform/utils.h
+++ b/src/relax/transform/utils.h
@@ -429,9 +429,12 @@ Expr CanonicalizeBindings(const Expr& expr);
  *
  * \param func The function to be updated.
  *
+ * \param param_tuple_name The name of the tuple parameter.  If
+ * unspecified, defaults to "model_params"
+ *
  * \ret The updated function.
  */
-Function BundleModelParams(const Function& func);
+Function BundleModelParams(const Function& func, Optional<String> param_tuple_name = NullOpt);
 
 }  // namespace relax
 }  // namespace tvm


### PR DESCRIPTION
In `BundleModelParams`, allow the user to specify a name for the tuple parameters.  If unspecified, defaults to the previous name `"model_params"`.