### PR TITLE
[Transform][Bugfix] Handle non-composite lambda functions in FuseOps

### DIFF
--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -1238,10 +1238,14 @@ class CompositeFunctionAnnotator : public ExprMutator {
 
   Expr VisitExpr_(const FunctionNode* func_node) final {
     Function f_inner = Downcast<Function>(ExprMutator::VisitExpr_(func_node));
-    auto composite_name = func_node->GetAttr<String>(attr::kComposite);
+
+    if (!func_node->GetAttr<String>(attr::kComposite)) {
+      // This lambda function doesn't have `attr::kComposite`, so it
+      // was not produced by FuseOps.
+      return std::move(f_inner);
+    }
 
     f_inner = WithoutAttr(std::move(f_inner), tvm::relax::attr::kPrimitive);
-    ICHECK(composite_name);
 
     Array<Var> param_vars;
     Array<Expr> params;


### PR DESCRIPTION
Prior to this commit, calling `FuseOpsByPattern` with `annotate_codegen=True` would cause an error when encountering a lambda function.  This was caused by the `CompositeFunctionAnnotator` asserting that all `relax::Function` encountered must have the `kComposite` attribute.  While this is true for all lambda functions produced by `FuseOpsByPattern`, the user may have defined other lambda functions as well.

This commit updates `CompositeFunctionAnnotator` to ignore lambda functions that do not have a `kComposite` attribute.