### PR TITLE
[Transform] De-duplicate MatchCast nodes in EliminateCommonSubexpr

### DIFF
--- a/src/relax/transform/eliminate_common_subexpr.cc
+++ b/src/relax/transform/eliminate_common_subexpr.cc
@@ -160,8 +160,8 @@ class CommonSubexprEliminator : public ExprMutator {
 
   Expr VisitExpr_(const IfNode* op) override {
     Expr cond = VisitExpr(op->cond);
-    Expr true_branch = VisitWithCleanScope(op->true_branch);
-    Expr false_branch = VisitWithCleanScope(op->false_branch);
+    Expr true_branch = VisitWithInnerScope(op->true_branch);
+    Expr false_branch = VisitWithInnerScope(op->false_branch);
     if (op->cond.same_as(cond) && op->true_branch.same_as(true_branch) &&
         op->false_branch.same_as(false_branch) &&
         VisitAndCheckStructInfoFieldUnchanged(op->struct_info_)) {
@@ -172,6 +172,15 @@ class CommonSubexprEliminator : public ExprMutator {
   }
 
  private:
+  Expr VisitWithInnerScope(Expr expr) {
+    auto cached_vars = var_remap_;
+    auto cached_exprs = expr_replacements_;
+    auto output = VisitExpr(expr);
+    var_remap_ = cached_vars;
+    expr_replacements_ = cached_exprs;
+    return output;
+  }
+
   Expr VisitWithCleanScope(Expr expr) {
     CommonSubexprEliminator clean_mutator(call_only_);
     return clean_mutator.VisitExpr(expr);

--- a/src/relax/transform/eliminate_common_subexpr.cc
+++ b/src/relax/transform/eliminate_common_subexpr.cc
@@ -20,223 +20,92 @@
 
 /*!
  * \file tvm/relax/transform/eliminate_common_subexpr.cc
- * \brief Eliminrate common subexpression pass.
+ * \brief Eliminate common subexpression pass.
  *
  * Currently it removes common subexpressions within a Function.
  */
+#include <tvm/relax/analysis.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/transform.h>
 #include <tvm/relax/utils.h>
 
-#include "utils.h"
-
 namespace tvm {
 namespace relax {
 
-// Checks if a given expression contains an impure subexpression
-// Caches the results of checks to avoid revisiting subexpressions
-class ImpurityDetector : public ExprVisitor {
- public:
-  bool Detect(const Expr& expr) {
-    impure_found_ = false;
-    VisitExpr(expr);
-    return impure_found_;
-  }
-
-  void VisitExpr(const Expr& expr) {
-    // already checked: do not revisit
-    if (purity_map_.count(expr)) {
-      impure_found_ = impure_found_ || !purity_map_.at(expr);
-      return;
-    }
-
-    // in principle, we could stop checking once we find an impurity,
-    // but not doing so lets us fully populate the cache
-
-    // store the previous state so we could assess the purity of this subexpression alone
-    bool prev_state = impure_found_;
-    impure_found_ = false;
-    ExprVisitor::VisitExpr(expr);
-    // if impure_found_ remains false, then the expression is pure
-    purity_map_[expr] = !impure_found_;
-    impure_found_ = prev_state || impure_found_;
-  }
-
-  void VisitExpr_(const CallNode* call) {
-    // the only possible impurities can come from call nodes
-    bool is_impure = IsImpureCall(GetRef<Call>(call));
-    impure_found_ = impure_found_ || is_impure;
-    ExprVisitor::VisitExpr_(call);
-  }
-
- private:
-  bool impure_found_ = false;
-  std::unordered_map<Expr, bool, StructuralHash, StructuralEqual> purity_map_;
-};
-
-class SubexprCounter : public ExprVisitor {
- public:
-  static std::unordered_map<Expr, int, StructuralHash, StructuralEqual> Count(const Expr& expr) {
-    SubexprCounter visitor;
-    visitor(expr);
-    return visitor.count_map_;
-  }
-
-  // overriding VisitExpr ensures we do this for every subexpression
-  void VisitExpr(const Expr& e) override {
-    // Cases we ignore because we will not substitute them:
-    // 1. Vars of all kinds
-    // 2. Op nodes (nothing we can do)
-    // 3. PrimValue nodes (not much benefit from binding to a var)
-    // 4. StringImm nodes (not much benefit from binding to a var)
-    // 5. Scalar constants (not much benefit from binding to a var)
-    // 6. Shape expressions (exist to hold several PrimValue objects)
-    // 7. DataType nodes (no need to modify dtype nodes)
-    if (!(e->IsInstance<VarNode>() || e->IsInstance<DataflowVarNode>() ||
-          e->IsInstance<GlobalVarNode>() || e->IsInstance<tvm::OpNode>() ||
-          e->IsInstance<PrimValueNode>() || e->IsInstance<StringImmNode>() ||
-          e->IsInstance<ShapeExprNode>() || e->IsInstance<ExternFuncNode>() ||
-          e->IsInstance<ConstantNode>() || e->IsInstance<DataTypeImmNode>())) {
-      // also if e has an impure subexpression, we will not deduplicate it
-      if (!impurity_detector_.Detect(e)) {
-        int count = 0;
-        if (count_map_.count(e)) {
-          count = count_map_.at(e);
-        }
-        count_map_[e] = count + 1;
-      }
-    }
-
-    // Only visit the interior of objects that we might still keep
-    // around.  Otherwise, double-counting these would lead to extra
-    // variable bindings.
-    //
-    // Before:
-    //     y = f(a+b)
-    //     z = f(a+b)
-    //
-    // Expected:
-    //     y = f(a+b)  // De-duped from (y==z)
-    //     z = y
-    //
-    // Erroneous output:
-    //     c = a+b    // Incorrect, a+b only has a single usage.
-    //     y = f(c)   // De-duped from
-    //     z = y
-    //
-    if (auto it = count_map_.find(e); it == count_map_.end() || it->second < 2) {
-      ExprVisitor::VisitExpr(e);
-    }
-  }
-
-  // do not visit inner functions: we will do CSE within those
-  void VisitExpr_(const FunctionNode* func) override {}
-
-  // we are not going to do replacements inside struct info to avoid binding lots of reused shapes
-  void VisitExprDepStructInfoField(const StructInfo& struct_info) override {}
-
- private:
-  std::unordered_map<Expr, int, StructuralHash, StructuralEqual> count_map_;
-  ImpurityDetector impurity_detector_;
-};
-
 class CommonSubexprEliminator : public ExprMutator {
  public:
-  explicit CommonSubexprEliminator(
-      std::unordered_map<Expr, int, StructuralHash, StructuralEqual> count_map,
-      bool call_only = false)
-      : count_map_(std::move(count_map)), call_only_(call_only) {}
+  explicit CommonSubexprEliminator(bool call_only = false) : call_only_(call_only) {}
 
-  // overriding here ensures we visit every subexpression
-  Expr VisitExpr(const Expr& e) override {
-    if (call_only_ && !e->IsInstance<CallNode>()) {
-      return ExprMutator::VisitExpr(e);
-    }
-    if (count_map_.count(e) && count_map_.at(e) > 1) {
-      // if we already have a mapping for it, get it
-      if (replacements_.count(e)) {
-        return replacements_.at(e);
-      }
-      // Otherwise, insert a new binding for the current expression.
-      // Visit before emitting to do inner replacements
-      Expr new_e = ExprMutator::VisitExpr(e);
-      Var v = builder_->Emit(new_e);
-      replacements_[e] = v;
-      return v;
-    }
-    return ExprMutator::VisitExpr(e);
-  }
+  void VisitBinding(const Binding& binding) override {
+    Expr bound_value = VisitExpr(GetBoundValue(binding));
 
-  // we are not going to do replacements inside struct info to avoid binding lots of reused shapes
-  StructInfo VisitExprDepStructInfoField(const StructInfo& struct_info) override {
-    return struct_info;
+    auto it = var_replacements_.find(bound_value);
+
+    if (call_only_ && !bound_value->IsInstance<relax::CallNode>()) {
+      // This type may not be eliminated, so we maintain the new
+      // binding.
+      ExprMutator::VisitBinding(binding);
+
+    } else if (ContainsImpureCall(bound_value)) {
+      // This expression is impure, and must be retained.
+      ExprMutator::VisitBinding(binding);
+    } else if (it == var_replacements_.end()) {
+      // This expression could be de-duplicated, but it is the first
+      // time we've seen this expression.  Remember it in case we see
+      // it again.
+      var_replacements_.insert({bound_value, binding->var});
+      ExprMutator::VisitBinding(binding);
+
+    } else if (!StructuralEqual()(GetStructInfo(binding->var), GetStructInfo(it->second))) {
+      // We've seen this expression before, but it is bound to a
+      // different struct info this time.  This is a MatchCast node,
+      // and the struct info may be required for downstream usage, or to
+      // define symbolic variables.
+      ExprMutator::VisitBinding(binding);
+
+    } else {
+      // We've seen this expression before, and can re-use the first occurrence.
+      var_remap_.insert({binding->var->vid, it->second});
+    }
   }
 
   Expr VisitExpr_(const FunctionNode* op) override {
-    Function func = GetRef<Function>(op);
-
-    auto cache = SubexprCounter::Count(op->body);
-    std::swap(cache, count_map_);
-    Expr output = ExprMutator::VisitExpr_(op);
-    std::swap(cache, count_map_);
-
-    return output;
-  }
-
-  void VisitBinding_(const VarBindingNode* binding) override {
-    // no need to visit var def because the struct info isn't going to change
-    Expr new_value = RegisterBoundValue(binding->var, binding->value);
-
-    if (new_value.same_as(binding->value)) {
-      builder_->EmitNormalized(GetRef<VarBinding>(binding));
+    // If we have accumulated any state, visit the function in a fresh
+    // copy of the mutator, to avoid replacing a child-scope
+    // expression with a parent-scope binding, or vice versa.
+    if (var_replacements_.size() || var_remap_.size()) {
+      return VisitWithCleanScope(GetRef<Expr>(op));
     } else {
-      // no need to renormalize new_value because all replacements are with vars
-      builder_->EmitNormalized(VarBinding(binding->var, new_value, binding->span));
+      return ExprMutator::VisitExpr_(op);
     }
   }
 
-  void VisitBinding_(const MatchCastNode* binding) override {
-    // no need to visit var def because the struct info isn't going to change
-    Expr new_value = RegisterBoundValue(binding->var, binding->value);
-
-    // re-emit old binding if nothing changes
-    if (new_value.same_as(binding->value)) {
-      builder_->EmitNormalized(GetRef<MatchCast>(binding));
+  Expr VisitExpr_(const IfNode* op) override {
+    Expr cond = VisitExpr(op->cond);
+    Expr true_branch = VisitWithCleanScope(op->true_branch);
+    Expr false_branch = VisitWithCleanScope(op->false_branch);
+    if (op->cond.same_as(cond) && op->true_branch.same_as(true_branch) &&
+        op->false_branch.same_as(false_branch) &&
+        VisitAndCheckStructInfoFieldUnchanged(op->struct_info_)) {
+      return GetRef<Expr>(op);
     } else {
-      // no need to renormalize new_value because all replacements are with vars
-      builder_->EmitNormalized(
-          MatchCast(binding->var, new_value, binding->struct_info, binding->span));
+      return If(cond, true_branch, false_branch, op->span);
     }
   }
 
  private:
-  Expr RegisterBoundValue(Var var, Expr bound_value) {
-    // special case: if we are processing a binding
-    // and this is the first time we've encountered it,
-    // we will use the binding's var for the mapping
-    bool newly_replaced = false;
-    if (count_map_.count(bound_value) && count_map_.at(bound_value) > 1 &&
-        !replacements_.count(bound_value)) {
-      replacements_[bound_value] = var;
-      newly_replaced = true;
-    }
-
-    if (newly_replaced) {
-      // If we've just added the mapping, using the overridden visitor will
-      // just return the var, which we don't want, so we will use
-      // the superclass VisitExpr to do inner substitutions
-      return ExprMutator::VisitExpr(bound_value);
-    }
-    return VisitExpr(bound_value);
+  Expr VisitWithCleanScope(Expr expr) {
+    CommonSubexprEliminator clean_mutator(call_only_);
+    return clean_mutator.VisitExpr(expr);
   }
 
-  std::unordered_map<Expr, int, StructuralHash, StructuralEqual> count_map_;
-  std::unordered_map<Expr, Var, StructuralHash, StructuralEqual> replacements_;
   bool call_only_{false};
+
+  std::unordered_map<Expr, Var, StructuralHash, StructuralEqual> var_replacements_;
 };
 
 Expr EliminateCommonSubexpr(const Expr& expr, bool call_only) {
-  CommonSubexprEliminator mutator(SubexprCounter::Count(expr), call_only);
+  CommonSubexprEliminator mutator(call_only);
   return mutator(expr);
 }
 

--- a/tests/python/relax/test_transform_cse.py
+++ b/tests/python/relax/test_transform_cse.py
@@ -319,8 +319,8 @@ def test_no_replacement_across_dataflow_boundary():
                 C = R.multiply(A, A)
                 R.output(B, C)
 
-            D = R.add(x, y)
-            return (B, C, D)
+            D = B
+            return (B, C, B)
 
     verify(Before, Expected)
 


### PR DESCRIPTION
Update the `relax.transform.EliminateCommonSubexpr` pass to handle `R.match_cast` bindings, where the argument of the `R.match_cast` has also been de-duplicated.