### PR TITLE
[Relax] Expose name_hint field for BlockBuilder.match_cast

### DIFF
--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -553,7 +553,12 @@ class BlockBuilder(Object):
         ret : tvm.relax.Var
             A newly created variable that get bounds to be the casted result.
         """
-        return _ffi_api.BlockBuilderEmitMatchCast(self, value, struct_info, name_hint)  # type: ignore
+        return _ffi_api.BlockBuilderEmitMatchCast(
+            self,
+            value,
+            struct_info,
+            name_hint,
+        )  # type: ignore
 
     def emit_output(self, output: Union[Expr, Tuple, List[Expr]], name_hint: str = "") -> Var:
         """Emit output for the current dataflow block or function.

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -534,7 +534,7 @@ class BlockBuilder(Object):
         name_hint = kwargs.pop("name_hint", "")
         return self.emit(self.call_te(func, *args, **kwargs), name_hint=name_hint)
 
-    def match_cast(self, value: Expr, struct_info: StructInfo) -> Var:
+    def match_cast(self, value: Expr, struct_info: StructInfo, name_hint: str = "") -> Var:
         """Emit a MatchCast.
 
         Parameters
@@ -545,12 +545,15 @@ class BlockBuilder(Object):
         struct_info : StructInfo
             The struct info to be matched.
 
+        name_hint : str
+            The name of the match cast
+
         Returns
         -------
         ret : tvm.relax.Var
             A newly created variable that get bounds to be the casted result.
         """
-        return _ffi_api.BlockBuilderEmitMatchCast(self, value, struct_info)  # type: ignore
+        return _ffi_api.BlockBuilderEmitMatchCast(self, value, struct_info, name_hint)  # type: ignore
 
     def emit_output(self, output: Union[Expr, Tuple, List[Expr]], name_hint: str = "") -> Var:
         """Emit output for the current dataflow block or function.

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -1015,8 +1015,8 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderEmit")
     });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitMatchCast")
-    .set_body_typed([](BlockBuilder builder, Expr value, StructInfo struct_info) {
-      return builder->EmitMatchCast(value, struct_info);
+    .set_body_typed([](BlockBuilder builder, Expr value, StructInfo struct_info, String name_hint) {
+      return builder->EmitMatchCast(value, struct_info, name_hint);
     });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitOutput")

--- a/tests/python/relax/test_blockbuilder_core.py
+++ b/tests/python/relax/test_blockbuilder_core.py
@@ -226,7 +226,7 @@ def test_emit_match_cast():
             assert_structural_equal(lv0.struct_info, rx.TensorStructInfo([m, n], "float32"))
 
             # lv1: Shape = match_cast(shape, rx.ShapeStructInfo([m, n]))
-            lv1 = bb.match_cast(y, rx.ShapeStructInfo([m, n]))
+            lv1 = bb.match_cast(y, rx.ShapeStructInfo([m, n]), "var_name")
             assert lv1.struct_info == rx.ShapeStructInfo([m, n])
             gv0 = bb.emit_output(lv1)
 
@@ -244,6 +244,7 @@ def test_emit_match_cast():
     assert b1.value == y
     assert b1.struct_info == rx.ShapeStructInfo([m, n])
     assert b1.var == lv1
+    assert b1.var.name_hint == "var_name"
 
 
 def test_emit_match_cast_binding_in_dataflow_block():


### PR DESCRIPTION
Prior to this commit, while a `relax.VarBinding` created using `BlockBuilder.emit` could have its name explicitly specified by the user, a `relax.MatchCast` created using `BlockBuilder.match_cast` could not.  This commit updates `BlockBuilder.match_cast` to accept an optional `name_hint` parameter, which is then provided to the C++ `BlockBuilder::EmitMatchCast` method.