### PR TITLE
[Relax][Transform] Canonicalize `let var = R.const` bindings

### DIFF
--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -289,33 +289,6 @@ def test_fold_match_cast():
     verify(Input, Expected)
 
 
-def test_unable_to_fold():
-    @I.ir_module
-    class MultipleUse:
-        @R.function
-        def main() -> R.Tensor((), "int32"):
-            with R.dataflow():
-                n = R.const(1)
-                # multiple uses -> cannot coalesce
-                m = R.add(n, n)
-                R.output(n)
-            return n
-
-    @I.ir_module
-    class ComplexExpr:
-        @R.function
-        def main() -> R.Tensor((), "int32"):
-            with R.dataflow():
-                y = R.const(1)
-                # y does not appear by itself -> cannot coalesce
-                n = R.add(y, y)
-                R.output(n)
-            return n
-
-    verify(MultipleUse, MultipleUse)
-    verify(ComplexExpr, ComplexExpr)
-
-
 def test_multiple_outputs():
     @I.ir_module
     class Input:
@@ -380,10 +353,9 @@ def test_single_output_multiple_nondataflow():
     verify(Input, Expected)
 
 
-def test_multiply_used_in_outputs():
-    # cannot fold output in this case
+def test_fold_const_to_output():
     @I.ir_module
-    class UsedInMultipleOutputs:
+    class Before:
         @R.function
         def main() -> R.Tensor((), "int32"):
             with R.dataflow():
@@ -391,7 +363,16 @@ def test_multiply_used_in_outputs():
                 R.output(n)
             return n
 
-    verify(UsedInMultipleOutputs, UsedInMultipleOutputs)
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main() -> R.Tensor((), "int32"):
+            with R.dataflow():
+                n = R.const(1)
+                R.output(n)
+            return R.const(1)
+
+    verify(Before, Expected)
 
 
 def test_canonicalize_var_to_dataflow_var_if_legal():

--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -972,5 +972,29 @@ def test_canonicalization_causes_struct_info_update():
     assert_structural_equal(Expected, after)
 
 
+def test_unwrap_tuple_of_constant():
+    @I.ir_module
+    class TestChainAssignments:
+        @R.function
+        def main():
+            tup = (R.const(0, "int64"), R.const(1, "int64"))
+            x = tup[0]
+            y = tup[1]
+            z = R.add(x, y)
+            return z
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main():
+            tup = (R.const(0, "int64"), R.const(1, "int64"))
+            x = tup[0]
+            y = tup[1]
+            z = R.add(R.const(0, "int64"), R.const(1, "int64"))
+            return z
+
+    verify(TestChainAssignments, Expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_transform_convert_dataflow.py
+++ b/tests/python/relax/test_transform_convert_dataflow.py
@@ -221,7 +221,7 @@ class TestTreatNonCallAsPure(ExtractCompare):
                 t2 = (y, y, x)
                 c = R.const([1, 2, 3], dtype="int32")
                 R.output(c)
-            return c
+            return R.const([1, 2, 3], dtype="int32")
 
         @R.function
         def shapes() -> R.Shape:


### PR DESCRIPTION
Prior to this commit, known tuples could be unwrapped into variables, but any constants would remain.  This commit updates `CanonicalizeBindings` to unwrap tuples containing constants.