### PR TITLE
[Transform] Improvements to LazyTransformParams

### DIFF
--- a/python/tvm/relax/transform/lazy_transform_params.py
+++ b/python/tvm/relax/transform/lazy_transform_params.py
@@ -132,20 +132,22 @@ class LazyTransformParamsFuncCreator:
         self.extra_get_item_params = extra_get_item_params
         self.fset_item = fset_item
         self.extra_set_item_params = extra_set_item_params
-        # the only input param, which should be a Tuple
-        self.input_tuple_param = None
         self.input_params_set = None
         self.out_tuple_map = None
         self.out_tuple_var = None
         self.memory_free_insertion = None
 
     def transform(self, func: relax.Function) -> relax.Function:
-        self.input_tuple_param = func.params[0]
+        if func.attrs is not None and "num_input" in func.attrs:
+            num_input = func.attrs["num_input"].value
+        else:
+            num_input = 0
+
         seq_expr = func.body
         self.out_tuple_var = seq_expr.body
 
         # Step 1. collect out_tuple_map and input_params_set
-        forward_collector = ForwardCollector(self.out_tuple_var, self.input_tuple_param)
+        forward_collector = ForwardCollector(self.out_tuple_var, func.params[num_input])
         forward_collector.visit_expr(func)
         self.out_tuple_map = forward_collector.out_tuple_map
         # input_params_set is the set of binding var for var = params[i]
@@ -157,24 +159,60 @@ class LazyTransformParamsFuncCreator:
         self.memory_free_insertion = liveness.var_liveness_end
 
         # Step 3. rewrite get item and set item
-        new_body = func.body
         if self.fget_item is not None:
-            new_body = LazyInputMutator(self, self.mod).visit_expr(new_body)
+            new_func = LazyInputMutator(self, self.mod).visit_expr(func)
 
+        new_body = new_func.body
         if self.fset_item is not None:
+            leaf_outputs = {
+                expr: indices
+                for expr, indices in self.out_tuple_map.items()
+                if not isinstance(expr, relax.Var)
+            }
+            if leaf_outputs:
+                new_bindings = [
+                    relax.VarBinding(
+                        relax.Var("_", relax.ObjectStructInfo()),
+                        relax.Call(
+                            relax.ExternFunc(self.fset_item),
+                            [*self.extra_set_item_params, index, expr],
+                            None,
+                            [relax.ObjectStructInfo()],
+                        ),
+                    )
+                    for expr, indices in leaf_outputs.items()
+                    for index in indices
+                ]
+                new_body = relax.SeqExpr(
+                    [*new_body.blocks, relax.BindingBlock(new_bindings)], new_body.body
+                )
+
             new_body = LazyOutputMutator(self, self.mod).visit_expr(new_body)
 
         # Step 4. Add parameters of get_item and set_item (except index) to the function.
-        params = [*self.extra_get_item_params, *self.extra_set_item_params]
+        params = [
+            *func.params[:num_input],
+            *self.extra_get_item_params,
+            *self.extra_set_item_params,
+        ]
 
         # Step 5. Find all shape parameters that should be retained as
         # parameters.
         symbolic_vars = relax.analysis.defined_symbolic_vars(func)
         if symbolic_vars:
+
+            def unpack_sinfo(sinfo):
+                if isinstance(sinfo, relax.TupleStructInfo):
+                    for field in sinfo.fields:
+                        yield from unpack_sinfo(field)
+                else:
+                    yield sinfo
+
             # direct iterate over the struct info annotation
-            for sinfo in self.input_tuple_param.struct_info.fields:
-                if not isinstance(sinfo, relax.TensorStructInfo):
-                    params.append(relax.Var("symbolic_var_holder", sinfo))
+            for param in func.params[num_input:]:
+                for sinfo in unpack_sinfo(param.struct_info):
+                    if not isinstance(sinfo, relax.TensorStructInfo):
+                        params.append(relax.Var("symbolic_var_holder", sinfo))
 
         return relax.Function(
             params,
@@ -191,22 +229,67 @@ class LazyInputMutator(PyExprMutator):
         self.func_creator = func_creator
         super().__init__(mod)
 
-    def visit_tuple_getitem_(self, op: relax.TupleGetItem) -> relax.Expr:
-        # rewrite get item
-        tuple_get_item = super().visit_tuple_getitem_(op)
-        if tuple_get_item.tuple_value == self.func_creator.input_tuple_param:
+    def visit_function_(self, func: relax.Function) -> relax.Expr:
+        if func.attrs is not None and "num_input" in func.attrs:
+            num_input = func.attrs["num_input"].value
+        else:
+            num_input = 0
+
+        params = list(func.params)[num_input:]
+        if len(params) == 1 and isinstance(params[0].struct_info_, relax.TupleStructInfo):
+            self.tuple_param = params[0]
+            self.params = {}
+        else:
+            self.tuple_param = None
+            self.params = {var: i for i, var in enumerate(params)}
+        func = relax.Function(
+            func.params[:num_input],
+            func.body,
+            func.ret_struct_info,
+            is_pure=False,
+            attrs=func.attrs,
+            span=func.span,
+        ).without_attr("relax.force_pure")
+        output = super().visit_function_(func)
+        self.tuple_param = None
+        self.params = {}
+        return output
+
+    def visit_var_(self, var: relax.Var) -> relax.Expr:
+        if var in self.params:
+            index = self.params[var]
             get_item_result = self.builder_.emit(
                 relax.Call(
                     relax.ExternFunc(self.func_creator.fget_item),
-                    self.func_creator.extra_get_item_params
-                    + [relax.PrimValue(tuple_get_item.index)],
+                    self.func_creator.extra_get_item_params + [relax.PrimValue(index)],
                     None,
                     [relax.ObjectStructInfo()],
                 )
             )
-            return self.builder_.match_cast(get_item_result, op.struct_info)
+            match_cast = relax.MatchCast(var, get_item_result, var.struct_info)
+            self.builder_.emit_normalized(match_cast)
+
+            del self.params[var]
+
+        return super().visit_var_(var)
+
+    def visit_tuple_getitem_(self, node: relax.TupleGetItem) -> relax.Expr:
+        sinfo = node.struct_info
+
+        node = super().visit_tuple_getitem_(node)
+
+        if self.tuple_param is not None and node.tuple_value.same_as(self.tuple_param):
+            get_item_result = self.builder_.emit(
+                relax.Call(
+                    relax.ExternFunc(self.func_creator.fget_item),
+                    self.func_creator.extra_get_item_params + [relax.PrimValue(node.index)],
+                    None,
+                    [relax.ObjectStructInfo()],
+                )
+            )
+            return self.builder_.match_cast(get_item_result, sinfo)
         else:
-            return tuple_get_item
+            return node
 
 
 @mutator

--- a/python/tvm/relax/transform/lazy_transform_params.py
+++ b/python/tvm/relax/transform/lazy_transform_params.py
@@ -83,7 +83,7 @@ class LivenessAnalysis(PyExprVisitor):
     """
 
     def __init__(self, out_tuple_var: relax.Var) -> None:
-        self.last_appear_in_var_binding = None
+        self.last_appear_in_var_binding = []
         self.out_tuple_var = out_tuple_var
         self.var_liveness_end = {}
         self.ended_vars = set()
@@ -164,6 +164,11 @@ class LazyTransformParamsFuncCreator:
 
         new_body = new_func.body
         if self.fset_item is not None:
+            # The LazyOutputMutator only inspects variable bindings
+            # for replacement.  If the output tuple includes elements
+            # that do not have a variable binding, such as
+            # `relax.Const`, these must still produce a call to the
+            # `"set_item"` function.
             leaf_outputs = {
                 expr: indices
                 for expr, indices in self.out_tuple_map.items()

--- a/tests/python/relax/test_transform_lazy_transform_params.py
+++ b/tests/python/relax/test_transform_lazy_transform_params.py
@@ -191,7 +191,7 @@ def test_get_item_only():
     tvm.ir.assert_structural_equal(after, Expected, map_free_vars=True)
 
 
-def test_extra_params():
+def test_extra_get_item_params():
     @I.ir_module
     class Before:
         @T.prim_func
@@ -278,6 +278,136 @@ def test_extra_params():
         extra_get_item_params=[relax.Var("loader", relax.ObjectStructInfo())]
     )(Before)
     tvm.ir.assert_structural_equal(after, Expected, map_free_vars=True)
+
+
+def test_extra_set_item_params():
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def transform_layout_IOHW_to_OIHW(
+            w1: T.Buffer((3, 16, 3, 3), "float32"), out: T.Buffer((16, 3, 3, 3), "float32")
+        ):
+            for ax0, ax1, ax2, ax3 in T.grid(16, 3, 3, 3):
+                with T.block("layout_transform"):
+                    o, i, h, w = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(w1[i, o, h, w])
+                    T.writes(out[o, i, h, w])
+                    out[o, i, h, w] = w1[i, o, h, w]
+
+        @R.function
+        def main_transform_params(
+            params: R.Tuple(
+                R.Tensor((3, 16, 3, 3), dtype="float32"), R.Tensor((16, 16, 3, 3), dtype="float32")
+            )
+        ) -> R.Tuple(
+            R.Tensor((16, 16, 3, 3), dtype="float32"), R.Tensor((16, 3, 3, 3), dtype="float32")
+        ):
+            # we expect ToNonDataflow and RemovePurityTracking to be invoked first
+            R.func_attr({"relax.force_pure": True})
+            cls = Before
+            lv: R.Tensor((16, 16, 3, 3), dtype="float32") = params[1]
+            lv1: R.Tensor((3, 16, 3, 3), dtype="float32") = params[0]
+            lv2 = R.call_tir(
+                cls.transform_layout_IOHW_to_OIHW,
+                (lv1,),
+                out_sinfo=R.Tensor((16, 3, 3, 3), dtype="float32"),
+            )
+            lv3 = R.add(lv2, R.const(1, "float32"))
+            gv: R.Tuple(
+                R.Tensor((16, 16, 3, 3), dtype="float32"),
+                R.Tensor((16, 3, 3, 3), dtype="float32"),
+            ) = (lv, lv3)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @T.prim_func
+        def transform_layout_IOHW_to_OIHW(
+            w1: T.Buffer((3, 16, 3, 3), "float32"), out: T.Buffer((16, 3, 3, 3), "float32")
+        ):
+            # with T.block("root"):
+            for ax0, ax1, ax2, ax3 in T.grid(16, 3, 3, 3):
+                with T.block("layout_transform"):
+                    o, i, h, w = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+                    T.reads(w1[i, o, h, w])
+                    T.writes(out[o, i, h, w])
+                    out[o, i, h, w] = w1[i, o, h, w]
+
+        @R.function(pure=False)
+        def main_transform_params(setter: R.Object) -> R.Tuple:
+            cls = Expected
+            gv: R.Object = R.call_packed("get_item", R.prim_value(1), sinfo_args=(R.Object,))
+            gv1: R.Tensor((16, 16, 3, 3), dtype="float32") = R.match_cast(
+                gv, R.Tensor((16, 16, 3, 3), dtype="float32")
+            )
+            lv: R.Tensor((16, 16, 3, 3), dtype="float32") = gv1
+            _: R.Object = R.call_packed(
+                "set_item", setter, R.prim_value(0), lv, sinfo_args=(R.Object,)
+            )
+            _1: R.Tuple = R.vm.kill_object(lv)
+            gv2: R.Object = R.call_packed("get_item", R.prim_value(0), sinfo_args=(R.Object,))
+            gv3: R.Tensor((3, 16, 3, 3), dtype="float32") = R.match_cast(
+                gv2, R.Tensor((3, 16, 3, 3), dtype="float32")
+            )
+            lv1: R.Tensor((3, 16, 3, 3), dtype="float32") = gv3
+            lv2 = R.call_tir(
+                cls.transform_layout_IOHW_to_OIHW,
+                (lv1,),
+                out_sinfo=R.Tensor((16, 3, 3, 3), dtype="float32"),
+            )
+            _2: R.Tuple = R.vm.kill_object(lv1)
+            lv3: R.Tensor((16, 3, 3, 3), dtype="float32") = R.add(lv2, R.const(1, "float32"))
+            _3: R.Object = R.call_packed(
+                "set_item", setter, R.prim_value(1), lv3, sinfo_args=(R.Object,)
+            )
+            gv_1: R.Tuple = R.tuple()
+            return gv_1
+
+    after = LazyTransformParams(
+        extra_set_item_params=[relax.Var("setter", relax.ObjectStructInfo())]
+    )(Before)
+    tvm.ir.assert_structural_equal(after, Expected, map_free_vars=True)
+
+
+def test_extra_set_item_params_with_const_output():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main_transform_params(
+            params: R.Tuple(),
+        ) -> R.Tuple(R.Tensor([2], dtype="float32"), R.Tensor([3], dtype="float32")):
+            R.func_attr({"relax.force_pure": True})
+            gv = (
+                R.const(np.array([1, 2]).astype("float32")),
+                R.const(np.array([3, 4]).astype("float32")),
+            )
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function(pure=False)
+        def main_transform_params(setter: R.Object) -> R.Tuple:
+            output = R.tuple()
+            _ = R.call_packed(
+                "set_item",
+                setter,
+                R.prim_value(0),
+                R.const(np.array([1, 2]).astype("float32")),
+                sinfo_args=(R.Object,),
+            )
+            _ = R.call_packed(
+                "set_item",
+                setter,
+                R.prim_value(1),
+                R.const(np.array([3, 4]).astype("float32")),
+                sinfo_args=(R.Object,),
+            )
+            return output
+
+    after = LazyTransformParams(
+        extra_set_item_params=[relax.Var("setter", relax.ObjectStructInfo())]
+    )(Before)
+    tvm.ir.assert_structural_equal(after, Expected)
 
 
 def test_lazy_transform_params_with_symbolic_vars():


### PR DESCRIPTION
* Handle non-bundled parameters in LazyTransformParams.

* Check for `"num_input"` attribute

* Handle relax.Const in LazyTransformParams

  Prior to this commit, `LazyTransformParams` would only output a call to the `fset_item` function if that element of the output had a corresponding `relax.Binding`.  If `relax.Const` appeared in the output, then the call to `fset_item` would be omitted.

  This commit updates `LazyTransformParams` to check for any non-`Var` elements of the output tuple.