### PR TITLE
[KVCache] Support passing in attn_score_scaling_factor into KV cache

### DIFF
--- a/src/runtime/relax_vm/kv_cache.h
+++ b/src/runtime/relax_vm/kv_cache.h
@@ -135,7 +135,8 @@ class AttentionKVCache : public Object {
    * \param o_data The output O data, in layout `(total_length, num_qo_heads, head_dim)`.
    */
   virtual void Attention(int64_t layer_id, NDArray q_data, NDArray k_data, NDArray v_data,
-                         Optional<NDArray> mask, NDArray o_data) = 0;
+                         Optional<NDArray> mask, NDArray o_data,
+                         double attn_score_scaling_factor) = 0;
 
   /*!
    * \brief Compute attention with Q/K/V data which are concatenated along
@@ -148,7 +149,7 @@ class AttentionKVCache : public Object {
    * \sa AttentionKVCache::Attention
    */
   virtual void AttentionWithFusedQKV(int64_t layer_id, NDArray qkv_data, Optional<NDArray> mask,
-                                     NDArray o_data) = 0;
+                                     NDArray o_data, double attn_score_scaling_factor) = 0;
 
   /************** Positions **************/
 

--- a/src/runtime/relax_vm/paged_kv_cache.cc
+++ b/src/runtime/relax_vm/paged_kv_cache.cc
@@ -1248,14 +1248,14 @@ TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_get_query_positions")
 TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_debug_get_kv")
     .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::DebugGetKV);
 TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_attention")
-    .set_body_typed([](PagedAttentionKVCache kv_cache, int64_t layer_id, 
+    .set_body_typed([](PagedAttentionKVCache kv_cache, int64_t layer_id,
                        double attn_score_scaling_factor, NDArray q_data,
                        NDArray k_data, NDArray v_data, NDArray o_data) {
       kv_cache->Attention(layer_id, std::move(q_data), std::move(k_data), std::move(v_data),
                           NullOpt, std::move(o_data), attn_score_scaling_factor);
     });
 TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_attention_with_fused_qkv")
-    .set_body_typed([](PagedAttentionKVCache kv_cache, int64_t layer_id, 
+    .set_body_typed([](PagedAttentionKVCache kv_cache, int64_t layer_id,
                        double attn_score_scaling_factor, NDArray qkv_data,
                        NDArray o_data) {
       kv_cache->AttentionWithFusedQKV(layer_id, std::move(qkv_data), NullOpt, std::move(o_data),

--- a/src/runtime/relax_vm/paged_kv_cache.cc
+++ b/src/runtime/relax_vm/paged_kv_cache.cc
@@ -1003,13 +1003,13 @@ class PagedAttentionKVCacheObj : public AttentionKVCache {
           attn_score_scaling_factor);
     } else {
       // Compute appended text self-attention
-      f_attention_prefill_ragged_.value()(
-          q_data, cur_append_length_indptr_view_, k_data, v_data, cur_append_length_indptr_view_,
-          q_rope_position_map_view_, k_ragged_rope_pos_offset_view_, output,
-          merged_attn_scores_view_,
-          /*causal=*/1,
-          /*rotary_mode=*/rope_mode_ == RoPEMode::kInline, rotary_scale_, rotary_theta_,
-          attn_score_scaling_factor);
+      f_attention_prefill_ragged_.value()(q_data, cur_append_length_indptr_view_, k_data, v_data,
+                                          cur_append_length_indptr_view_, q_rope_position_map_view_,
+                                          k_ragged_rope_pos_offset_view_, output,
+                                          merged_attn_scores_view_,
+                                          /*causal=*/1,
+                                          /*rotary_mode=*/rope_mode_ == RoPEMode::kInline,
+                                          rotary_scale_, rotary_theta_, attn_score_scaling_factor);
 
       for (int d = 0; d < num_depths_; ++d) {
         if (page_indices_on_depths_view_[d]->shape[0] == 0) {
@@ -1249,15 +1249,14 @@ TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_debug_get_kv")
     .set_body_method<PagedAttentionKVCache>(&PagedAttentionKVCacheObj::DebugGetKV);
 TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_attention")
     .set_body_typed([](PagedAttentionKVCache kv_cache, int64_t layer_id,
-                       double attn_score_scaling_factor, NDArray q_data,
-                       NDArray k_data, NDArray v_data, NDArray o_data) {
+                       double attn_score_scaling_factor, NDArray q_data, NDArray k_data,
+                       NDArray v_data, NDArray o_data) {
       kv_cache->Attention(layer_id, std::move(q_data), std::move(k_data), std::move(v_data),
                           NullOpt, std::move(o_data), attn_score_scaling_factor);
     });
 TVM_REGISTER_GLOBAL("vm.builtin.paged_attention_kv_cache_attention_with_fused_qkv")
     .set_body_typed([](PagedAttentionKVCache kv_cache, int64_t layer_id,
-                       double attn_score_scaling_factor, NDArray qkv_data,
-                       NDArray o_data) {
+                       double attn_score_scaling_factor, NDArray qkv_data, NDArray o_data) {
       kv_cache->AttentionWithFusedQKV(layer_id, std::move(qkv_data), NullOpt, std::move(o_data),
                                       attn_score_scaling_factor);
     });

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_flashinfer.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_flashinfer.py
@@ -447,11 +447,11 @@ def apply_attention(
             keys = tvm.nd.array(keys_np, device=device)
             values = tvm.nd.array(values_np, device=device)
             outputs = tvm.nd.empty(queries.shape, dtype, device=device)
-            fattention(kv_cache, layer_id, queries, keys, values, outputs)
+            fattention(kv_cache, layer_id, 1.0, queries, keys, values, outputs)
         else:
             qkv = tvm.nd.array(np.concatenate([queries_np, keys_np, values_np], axis=1), device)
             outputs = tvm.nd.empty(queries_np.shape, dtype, device=device)
-            fattention_with_fuse_qkv(kv_cache, layer_id, qkv, outputs)
+            fattention_with_fuse_qkv(kv_cache, layer_id, 1.0, qkv, outputs)
 
         # Compute attention expected results.
         outputs = np.expand_dims(outputs.numpy(), axis=0)


### PR DESCRIPTION
In GPT-2, attention calculation requires an additional feature `scale_attn_by_inverse_layer_idx`. It provides a scaling factor per attention layer when calculating the attention score, before applying the softmax function.

This PR supports this additional parameter in KV cache.