### PR TITLE
[Doc] Fixed Docstring usage example in `tvm.ir.make_node`

### DIFF
--- a/python/tvm/ir/attrs.py
+++ b/python/tvm/ir/attrs.py
@@ -153,7 +153,7 @@ def make_node(type_key, **kwargs):
 
     .. code-block:: python
 
-       x = tvm.ir.make_node("IntImm", dtype="int32", value=10)
+       x = tvm.ir.make_node("IntImm", dtype=tvm.runtime.String("int32"), value=10, span=None)
        assert isinstance(x, tvm.tir.IntImm)
        assert x.value == 10
     """

--- a/python/tvm/ir/attrs.py
+++ b/python/tvm/ir/attrs.py
@@ -153,7 +153,7 @@ def make_node(type_key, **kwargs):
 
     .. code-block:: python
 
-       x = tvm.ir.make_node("IntImm", dtype=tvm.runtime.String("int32"), value=10, span=None)
+       x = tvm.ir.make_node("IntImm", dtype="int32", value=10, span=None)
        assert isinstance(x, tvm.tir.IntImm)
        assert x.value == 10
     """


### PR DESCRIPTION
The provided usage example for `tvm.ir.make_node` has become outdated. Creating an IR node of type `IntImm` requires the field `span`. 

Compare: [`make_node` Unit Test](https://github.com/apache/tvm/blob/main/tests/python/ir/test_node_reflection.py#L73)