### PR TITLE
[SVE] Add support for scalable data type strings

### DIFF
--- a/src/tir/op/op.cc
+++ b/src/tir/op/op.cc
@@ -342,7 +342,7 @@ PrimExpr cast(const DataType& t, PrimExpr value, Span span) {
   using tir::FloatImmNode;
   if (value.dtype() == t) return value;
   // const fold IntImm as they are used in index computations
-  if (t.lanes() == 1) {
+  if (t.is_scalar()) {
     if (const IntImmNode* op = value.as<IntImmNode>()) {
       return make_const(t, op->value, op->span);
     } else if (const FloatImmNode* op = value.as<FloatImmNode>()) {

--- a/tests/python/tir-base/test_tir_nodes.py
+++ b/tests/python/tir-base/test_tir_nodes.py
@@ -439,21 +439,15 @@ def test_broadcast_to_scalable_vec():
     assert broadcast.lanes.b == 4
 
 
-@pytest.mark.xfail(
-    reason="Support for scalable data type string will be added in P3 of https://github.com/apache/tvm/issues/16455"
-)
 def test_buffer_load_scalable_vec():
     buf = tvm.tir.decl_buffer((24,), "float32")
     index = tvm.tir.expr.Ramp(1, 1, 8 * tvm.tir.vscale())
     load = tvm.tir.BufferLoad(buf, [index])
 
     assert isinstance(load, tvm.tir.BufferLoad)
-    assert load.dtype == "float32x8xvscale"
+    assert load.dtype == "float32xvscalex8"
 
 
-@pytest.mark.xfail(
-    reason="Support for scalable data type string will be added in P3 of https://github.com/apache/tvm/issues/16455"
-)
 def test_buffer_store_scalable_vec():
     b = tvm.tir.decl_buffer((24,), "int32")
     value = tvm.tir.expr.Broadcast(1, 4 * tvm.tir.vscale())
@@ -461,15 +455,12 @@ def test_buffer_store_scalable_vec():
     store = tvm.tir.BufferStore(b, value, [index])
 
     assert isinstance(store, tvm.tir.BufferStore)
-    assert store.value.dtype == "int32x4xvscale"
+    assert store.value.dtype == "int32xvscalex4"
 
 
-@pytest.mark.xfail(
-    reason="Support for scalable data type string will be added in P3 of https://github.com/apache/tvm/issues/16455"
-)
 def test_scalable_vec_cast():
     b = tvm.tir.decl_buffer((24,), "float32")
-    value = tvm.tir.expr.Broadcast(1, 12 * tvm.tir.vscale()).astype("float32x12xvscale")
+    value = tvm.tir.expr.Broadcast(1, 12 * tvm.tir.vscale()).astype("float32xvscalex12")
     index = tvm.tir.expr.Ramp(0, 1, 12 * tvm.tir.vscale())
 
     store = tvm.tir.BufferStore(b, value, [index])

--- a/tests/python/tir-base/test_tir_scalable_datatype.py
+++ b/tests/python/tir-base/test_tir_scalable_datatype.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import tvm
+from tvm import tir
+from tvm.script import tir as T
+
+"""
+Tests for scalable data types.
+"""
+
+
+def test_create_scalable_data_type_python_api():
+    dtype = tvm.DataType("float32xvscalex4")
+    assert str(dtype) == "float32xvscalex4"
+
+
+def test_create_scalable_tir_intrin():
+    intrin = tir.call_llvm_intrin("int32xvscalex4", "llvm.experimental.stepvector")
+    assert intrin.dtype == "int32xvscalex4"
+    assert str(intrin) == 'T.call_llvm_intrin("int32xvscalex4", "llvm.experimental.stepvector")'
+
+
+def test_tvm_script_create_scalable_tir_intrin():
+    @T.prim_func
+    def my_func():
+        T.call_llvm_intrin("int32xvscalex4", "llvm.experimental.stepvector")
+
+    assert (
+        'T.call_llvm_intrin("int32xvscalex4", "llvm.experimental.stepvector")' in my_func.script()
+    )
+
+
+def test_invalid_data_type():
+    err_msg = "Invalid data type. Expected 'vscale' but got '4'"
+    with pytest.raises(AssertionError, match=err_msg):
+        tvm.DataType("float32x4xvscale")
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This commit adds support for representing scalable vectors using the string data type format. For example, "float32xvscalex4" may be used to represent the following scalable type: `DataType(kDLFloat, 32, /*lanes=*/4, /*is_scalable=*/true)`.

Co-authored-by: Elen Kalda <elen.kalda@arm.com>
Co-authored-by: Neil Hickey <neil.hickey@arm.com>