### PR TITLE
[Bugfix][Cutlass] Check if function attributes is None

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -977,7 +977,7 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         return f.with_attrs(attrs)
 
     def visit_function_(self, f):
-        if "Composite" not in f.attrs:
+        if f.attrs is None or "Composite" not in f.attrs:
             body = super().visit_expr(f.body)
             return relax.Function(f.params, body, f.ret_struct_info, f.is_pure, f.attrs, f.span)
 


### PR DESCRIPTION
This commit updates the cutlass annotator to check if `relax.Function.attrs` is `None` before attempting to access it.