### PR TITLE
[Relay][ONNX] fix the wrong default value about dtype in Multinomial converter

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -6021,7 +6021,7 @@ class Multinomial(OnnxOpConverter):
 
     @classmethod
     def _impl_v7(cls, inputs, attr, params):
-        dtype = attr.get("dtype", "int64")
+        dtype = attr.get("dtype", "int32")
         sample_size = attr.get("sample_size", 1)
         seed = attr.get("seed", None)
         if seed is None:


### PR DESCRIPTION
Fix the bug: https://github.com/apache/tvm/issues/16623
the default type of attribute 'dtype' is int32 rather than int64
