### PR TITLE
[BugFix] Fix Crash Cases Caused by "__tvm_meta__ = None"

### DIFF
--- a/python/tvm/script/parser/ir/parser.py
+++ b/python/tvm/script/parser/ir/parser.py
@@ -87,6 +87,9 @@ def _visit_assign(self: Parser, node: doc.Assign) -> None:
     lhs = node.targets[0].id
     rhs = self.eval_expr(node.value)
 
+    if rhs is None:
+        return
+
     I.decl_function(lhs, rhs)
     I.def_function(lhs, rhs)
 

--- a/tests/python/tir-transform/test_tir_transform_merge_dynamic_shared_memory_allocations.py
+++ b/tests/python/tir-transform/test_tir_transform_merge_dynamic_shared_memory_allocations.py
@@ -456,7 +456,7 @@ class TestMatmul(tvm.testing.CompareBeforeAfter):
 class TestSimpleAllocNoReuse(tvm.testing.CompareBeforeAfter):
     """Test alloc and free within the same scope."""
 
-    transform = tvm.tir.transform.MergeDynamicSharedMemoryAllocations()
+    transform = tvm.tir.transform.MergeSharedMemoryAllocations()
 
     def before(self):
         @T.prim_func
@@ -485,7 +485,7 @@ class TestSimpleAllocNoReuse(tvm.testing.CompareBeforeAfter):
 class TestSimpleAllocReuse(tvm.testing.CompareBeforeAfter):
     """Test alloc and free within the same scope with a reuse chance."""
 
-    transform = tvm.tir.transform.MergeDynamicSharedMemoryAllocations()
+    transform = tvm.tir.transform.MergeSharedMemoryAllocations()
 
     def before(self):
         @T.prim_func

--- a/tests/scripts/task_python_unittest.sh
+++ b/tests/scripts/task_python_unittest.sh
@@ -51,7 +51,6 @@ TEST_FILES=(
   "tir-transform"
   "tir-usmp"
   "tvmscript"
-  "usmp"
 )
 
 for TEST_FILE in ${TEST_FILES[@]}; do


### PR DESCRIPTION
Fix https://github.com/apache/tvm/issues/16633

The broken tests are below items of "tests/scripts/task_python_unittest.sh"

"tir-transform"
"tir-usmp"
The crashed cases：
tests/python/tir-transform/test_tir_transform_inject_rolling_buffer.py
tests/python/tir-usmp/test_tir_usmp_algo.py
tests/python/tir-usmp/test_tir_usmp_analysis_extract_bufferinfo.py
tests/python/tir-usmp/test_tir_usmp_transform_convert_pool_allocations_to_offsets.py
tests/python/tir-usmp/test_tir_usmp_utils.py

other failed cases:
tests/python/tir-transform/test_tir_transform_pointer_value_type_rewrite.py::TestRewriteToShuffle::test_compare
tests/python/tir-transform/test_tir_transform_force_narrow_index_to_i32.py::test_thread_axis2
tests/python/tir-transform/test_tir_transform_hoist_if.py::test_hoisting_block_scope_4
tests/python/tir-transform/test_transform_default_gpu_schedule.py::test_add_on_metal