### PR TITLE
[Bugfix][Transform] Preserve symbolic variables in FuseOps

### DIFF
--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -1203,10 +1203,11 @@ class CompositeFunctionAnnotator : public ExprMutator {
             func->GetAttr<String>(attr::kCodegen).defined()) {
           continue;
         }
-        auto new_body = VisitExpr(func->body);
+
+        auto new_body = VisitWithNewScope(func->body, func->params);
         if (!new_body.same_as(func->body)) {
-          auto new_func = Function(func->params, VisitExpr(func->body), func->ret_struct_info,
-                                   func->is_pure, func->attrs, func->span);
+          auto new_func = Function(func->params, new_body, func->ret_struct_info, func->is_pure,
+                                   func->attrs, func->span);
           builder_->UpdateFunction(entry.first, new_func);
         }
       }


### PR DESCRIPTION
Prior to this commit, the `CompositeFunctionAnnotator` visited the body of functions without the parameters being considered in-scope. As a result, `EraseToWellDefined` would remove known shapes from the function body's `StructInfo`.