### PR TITLE
[TVMScript] Represent tir::builtin::ret() using python "return"

### DIFF
--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -520,7 +520,8 @@ def visit_return(self: Parser, node: doc.Return) -> None:
     node : doc.Return
         The doc AST return node.
     """
-    self.report_error(node, "Return is not allowed.")
+    value = self.eval_expr(node.value)
+    T.evaluate(tvm.tir.ret(value))
 
 
 @dispatch.register(token="tir", type_name="tvm_declare_function")

--- a/tests/python/tvmscript/test_tvmscript_printer_tir.py
+++ b/tests/python/tvmscript/test_tvmscript_printer_tir.py
@@ -900,5 +900,22 @@ def test_variable_with_cpp_address():
     assert re.match(expected_regex, script)
 
 
+def test_return_statement():
+    from tvm.script import tir as T
+
+    @T.prim_func
+    def func():
+        T.evaluate(T.ret(5))
+
+    expected_output = """
+# from tvm.script import tir as T
+
+@T.prim_func
+def func():
+    return 5
+    """
+    _assert_print(func, expected_output)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/tvmscript/test_tvmscript_syntax_sugar.py
+++ b/tests/python/tvmscript/test_tvmscript_syntax_sugar.py
@@ -492,5 +492,19 @@ def test_foldable_boolean_in_assert():
     assert_structural_equal_ignore_global_symbol(implicit, explicit)
 
 
+def test_return_statement():
+    """A python `return` statement uses `T.ret`"""
+
+    @T.prim_func
+    def explicit():
+        T.evaluate(T.ret(5))
+
+    @T.prim_func
+    def implicit():
+        return 5
+
+    assert_structural_equal_ignore_global_symbol(implicit, explicit)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
The TIR equivalent of python's `return` statement is the `tir::builtin::ret()` operator.  Prior to this commit, this was printed as `T.ret(value)`, and any use of `return` statement in TVMScript produced an error while parsing.

This commit updates the TVMScript parsing to produce `T.ret(value)` for the python `return value` statement.  If syntax sugar is enabled, the TIR `T.ret(value)` will be printed as `return value`.