### PR TITLE
[Relax] Allow R.Prim('bool') in relax::If and assert_op 

### DIFF
--- a/include/tvm/tir/analysis.h
+++ b/include/tvm/tir/analysis.h
@@ -117,12 +117,25 @@ TVM_DLL Array<Var> UndefinedVars(const PrimExpr& expr);
 TVM_DLL Array<Var> UndefinedVars(const PrimExpr& expr, const Array<Var>& defs);
 
 /*!
- * \brief Analyze the side effect
+ * \brief Analyze the side effect of an expression
  * \param expr The expression to be checked.
  *
  * \return CallEffectKind, can be kPure, kReadState or kUpdateState
  */
 TVM_DLL CallEffectKind SideEffect(const PrimExpr& expr);
+
+/*!
+ * \brief Analyze the side effect of a function
+ *
+ * \param func The expression to be checked.
+ *
+ * \param assert_on_error If true, an error will be thrown for an
+ *    impure function.  If false (default), the purity of the PrimFunc
+ *    will be returned.
+ *
+ * \return The purity of the function
+ */
+TVM_DLL bool IsPureFunction(const PrimFunc& func, bool assert_on_error = false);
 
 /*!
  * \brief Whether the given Stmt uses any var in the given variable set.

--- a/python/tvm/error.py
+++ b/python/tvm/error.py
@@ -54,6 +54,7 @@ register_error("TypeError", TypeError)
 register_error("AttributeError", AttributeError)
 register_error("KeyError", KeyError)
 register_error("IndexError", IndexError)
+register_error("AssertionError", AssertionError)
 
 
 @register_error

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -503,19 +503,26 @@ def relax_assert_op(condition: tvm.Object, format_str: str, *format_args: tvm.Ob
             f"The format string argument to assert must be a string, given {type(format_str)})"
         )
 
-    # should be guaranteed by the type system
-    if not isinstance(condition, tvm.nd.NDArray):
-        raise ValueError(f"The condition must be an NDArray, but given a {type(condition)}.")
+    if isinstance(condition, (bool, int)):
+        val = condition
+    elif isinstance(condition, tvm.nd.NDArray):
+        # may happen if the original program had unknown shape or dtype for the tensor's type
+        dtype = condition.dtype
+        if dtype != "bool":
+            raise ValueError(f"The condition must be a bool scalar, but given a {dtype} tensor")
+        shape = condition.shape
+        if len(shape) != 0:
+            raise ValueError(f"The condition must be a scalar, but it has a shape of {shape}")
 
-    # may happen if the original program had unknown shape or dtype for the tensor's type
-    dtype = condition.dtype
-    if dtype != "bool":
-        raise ValueError(f"The condition must be a bool scalar, but given a {dtype} tensor")
-    shape = condition.shape
-    if len(shape) != 0:
-        raise ValueError(f"The condition must be a scalar, but it has a shape of {shape}")
+        val = condition.numpy()
 
-    val = condition.numpy()
+    else:
+        # should be guaranteed by the type system
+        raise ValueError(
+            f"The condition for relax assert must be a bool, int, or NDArray, "
+            f"but received a {type(condition)}."
+        )
+
     if not val:
         error_message = "Assertion Failed"
         if format_args or format_str != "":
@@ -528,7 +535,7 @@ def relax_assert_op(condition: tvm.Object, format_str: str, *format_args: tvm.Ob
 
 
 def assert_op(
-    condition: Expr,
+    condition: Union[Expr, PrimExpr],
     format_args: Optional[Union[Expr, List[Expr]]] = None,
     format: Union[str, Expr] = "",
 ) -> Expr:
@@ -538,7 +545,7 @@ def assert_op(
 
     Parameters
     ----------
-    condition: Expr
+    condition: Union[Expr, PrimExpr]
         The assertion condition.
 
     format_args: Optional[Union[Expr, List[Expr]]]
@@ -552,12 +559,17 @@ def assert_op(
     result : Expr
         A Call to the Relax assert operation.
     """
+    if not isinstance(condition, Expr):
+        condition = tvm.relax.PrimValue(condition)
+
     if format_args is None:
         format_args = []
-    if isinstance(format_args, Expr):  # type: ignore
+    elif isinstance(format_args, Expr):
         format_args = [format_args]
+
     if isinstance(format, str):
         format = StringImm(format)
+
     return _ffi_api.assert_op(condition, format_args, format)  # type: ignore
 
 

--- a/python/tvm/relax/pipeline.py
+++ b/python/tvm/relax/pipeline.py
@@ -92,6 +92,7 @@ def default_build_pipeline():
                 transform.LowerAllocTensor(),
                 transform.KillAfterLastUse(),
                 transform.VMBuiltinLower(),
+                transform.ComputePrimValue(),
                 transform.VMShapeLower(),
                 transform.AttachGlobalSymbol(),
             ],

--- a/python/tvm/relax/transform/__init__.py
+++ b/python/tvm/relax/transform/__init__.py
@@ -28,6 +28,7 @@ from .transform import (
     CallTIRRewrite,
     CanonicalizeBindings,
     CombineParallelMatmul,
+    ComputePrimValue,
     ConvertLayout,
     ConvertToDataflow,
     DataflowBlockPass,

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -489,9 +489,18 @@ def KillAfterLastUse() -> tvm.ir.transform.Pass:
 def ComputePrimValue() -> tvm.ir.transform.Pass:
     """Compute all R.prim_value instances
 
+    While high-level relax can include expressions in terms of its
+    symbolic variables, these expressions cannot natively be computed
+    within relax.  In order to provide values for symbolic expressions
+    (e.g. `R.prim_value(N*N)`, where `N` is a symbolic variable), this
+    pass generates a PrimFunc in which the expression can be computed.
+    The relax graph is then updated to include a call to that
+    PrimFunc, in place of the original `R.prim_value(expr)`.
+
     Returns
     -------
     ret : tvm.ir.transform.Pass
+
     """
     return _ffi_api.ComputePrimValue()  # type: ignore
 

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -486,6 +486,16 @@ def KillAfterLastUse() -> tvm.ir.transform.Pass:
     return _ffi_api.KillAfterLastUse()  # type: ignore
 
 
+def ComputePrimValue() -> tvm.ir.transform.Pass:
+    """Compute all R.prim_value instances
+
+    Returns
+    -------
+    ret : tvm.ir.transform.Pass
+    """
+    return _ffi_api.ComputePrimValue()  # type: ignore
+
+
 def VMBuiltinLower() -> tvm.ir.transform.Pass:
     """Lowering generic intrinsic to VM intrinsics.
 

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -511,18 +511,25 @@ def SeqExpr() -> frame.SeqExprFrame:  # pylint: disable=invalid-name
 ############################# If Then Else #############################
 
 
-def If(condition: Expr) -> frame.IfFrame:  # pylint: disable=invalid-name
+def If(condition: Union[Expr, PrimExpr]) -> frame.IfFrame:  # pylint: disable=invalid-name
     """Create an if frame.
+
     Parameters
     ----------
-    condition : Expr
-        The condition of if statement, executes the true branch if the condition is true,
-        otherwise jump into the false branch.
+    condition : Union[Expr, PrimExpr]
+
+        The condition of if statement, executes the true branch if the
+        condition is true, otherwise jump into the false branch.
+
     Returns
     -------
     res : frame.IfFrame
         The result IfFrame.
+
     """
+    if not isinstance(condition, Expr):
+        condition = relax.PrimValue(condition)
+
     return _ffi_api.If(condition)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -537,12 +537,31 @@ def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> GlobalVar
         The doc AST return node.
     """
 
-    ret_type = None
-    if node.returns is not None:
-        ret_type = self.eval_expr(node.returns)
-        if callable(ret_type):
-            ret_type = PrimType(ret_type().dtype)
+    supplied_annotation = self.function_annotations
+    func_annotation = supplied_annotation.get(node.name, {})
 
-    # Only ret_type is needed for func_signature.
-    func_signature = tvm.tir.PrimFunc([], None, ret_type=ret_type)
+    ret_type = None
+    with self.var_table.with_frame():
+        if node.returns is not None:
+            ret_type = self.eval_expr(node.returns)
+            if callable(ret_type):
+                ret_type = PrimType(ret_type().dtype)
+
+        arg_annotations = []
+        for arg in node.args.args:
+            if arg.annotation is None:
+                self.report_error(arg, "Type annotation required for function parameters.")
+            try:
+                ann = self.eval_expr(arg.annotation)
+                if callable(ann):
+                    ann = ann()
+            except Exception:  # pylint: disable=broad-except
+                ann = func_annotation.get(arg.arg, None)
+                if ann is None:
+                    raise
+
+            IRBuilder.name(arg.arg, ann)
+            arg_annotations.append(ann)
+
+    func_signature = tvm.tir.PrimFunc(arg_annotations, None, ret_type=ret_type)
     return I.decl_function(node.name, func_signature)

--- a/python/tvm/tir/analysis/analysis.py
+++ b/python/tvm/tir/analysis/analysis.py
@@ -417,3 +417,13 @@ def get_vtcm_compaction_passes() -> List[tvm.transform.Pass]:
         returns list of passes
     """
     return _ffi_api.get_vtcm_compaction_passes()  # type: ignore # pylint: disable=no-member
+
+
+def is_pure_function(func: PrimFunc) -> bool:
+    """Checks if the function is a pure function"""
+    return _ffi_api.is_pure_function(func, False)  # type: ignore # pylint: disable=no-member
+
+
+def assert_pure_function(func: PrimFunc) -> bool:
+    """Asserts that the function is a pure function"""
+    return _ffi_api.is_pure_function(func, True)  # type: ignore # pylint: disable=no-member

--- a/src/relax/analysis/struct_info_analysis.cc
+++ b/src/relax/analysis/struct_info_analysis.cc
@@ -840,8 +840,10 @@ class CallRetStructInfoDeriver : public StructInfoBaseChecker {
     auto params = finfo->params.value();
     if (params.size() != call->args.size()) {
       ctx->ReportFatal(Diagnostic::Error(call->span)
-                       << "number of arguments and parameters mismatch:"
-                       << " expected " << params.size() << ", given " << call->args.size());
+                       << "Number of arguments and parameters mismatch:"
+                       << " Function " << call->op << " has struct info " << finfo
+                       << " and accepts " << params.size() << " parameters, but was called with "
+                       << call->args.size() << " arguments (" << call->args << ")");
     }
     // Visit each param arg pair, check and populate the var map
     for (size_t i = 0; i < params.size(); ++i) {

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -85,6 +85,7 @@ class PrimExprSlotCollector : public ExprVisitor, public StructInfoVisitor {
       collector.VisitExpr(param);
     }
     collector.VisitExpr(func->body);
+    collector.VisitStructInfo(func->ret_struct_info);
   }
 
  private:

--- a/src/relax/op/tensor/inspect.cc
+++ b/src/relax/op/tensor/inspect.cc
@@ -107,7 +107,7 @@ tir::PrimFunc GetDLTensorField(tir::builtin::TVMStructFieldKind field, DataType 
 
   FuncStructInfo sinfo({TensorStructInfo(DataType::Void(), kUnknownNDim)},
                        PrimStructInfo(field_dtype));
-  UpdateStructInfo(func, sinfo);
+  func->struct_info_ = sinfo;
 
   return func;
 }
@@ -338,7 +338,7 @@ Expr LegalizeTensorShape(const BlockBuilder& bb, const Call& call) {
     FuncStructInfo sinfo(
         {TensorStructInfo(DataType::Void(), kUnknownNDim), PrimStructInfo(axis->dtype)},
         PrimStructInfo(field_dtype));
-    UpdateStructInfo(func, sinfo);
+    func->struct_info_ = sinfo;
     return func;
   }();
 

--- a/src/relax/transform/compute_prim_value.cc
+++ b/src/relax/transform/compute_prim_value.cc
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/transform.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/stmt_functor.h>
+
+namespace tvm {
+namespace relax {
+
+namespace {
+
+class PrimValueComputeInjector : public ExprMutator {
+ public:
+  IRModule Finalize() const { return builder_->Finalize(); }
+
+  using ExprMutator::VisitExpr_;
+
+  Expr VisitExpr_(const PrimValueNode* op) override {
+    auto node = Downcast<PrimValue>(ExprMutator::VisitExpr_(op));
+
+    if (node->value->IsInstance<tir::IntImmNode>() || node->value->IsInstance<tir::VarNode>()) {
+      return node;
+    }
+
+    auto ret_dtype = node->value->dtype;
+    auto param_vars = tir::UndefinedVars(node->value);
+    tir::Stmt body = tir::Evaluate(tir::Call(ret_dtype, tir::builtin::ret(), {node->value}));
+
+    tir::PrimFunc func(param_vars, body, PrimType(ret_dtype));
+    func = tir::RenewDefs(func);
+
+    auto callee = builder_->AddFunction(func, "compute_symbolic_expr");
+
+    return relax::Call(callee, param_vars.Map([](const tir::Var& tir_var) -> relax::Expr {
+      return relax::PrimValue(tir_var);
+    }));
+  }
+};
+
+}  // namespace
+
+namespace transform {
+
+Pass ComputePrimValue() {
+  runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =
+      [=](IRModule mod, PassContext pc) -> IRModule {
+    PrimValueComputeInjector mutator;
+
+    IRModule updates;
+    for (const auto& [gvar, base_func] : mod->functions) {
+      if (auto func = base_func.as<Function>()) {
+        auto updated = Downcast<Function>(mutator(func.value()));
+        if (!updates.same_as(base_func)) {
+          updates->Add(gvar, updated);
+        }
+      }
+    }
+
+    if (updates->functions.size()) {
+      auto write_ptr = mod.CopyOnWrite();
+      write_ptr->Update(updates);
+      write_ptr->Update(mutator.Finalize());
+    }
+
+    return mod;
+  };
+  return CreateModulePass(pass_func, 0, "ComputePrimValue", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.ComputePrimValue").set_body_typed(ComputePrimValue);
+
+}  // namespace transform
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -220,12 +220,21 @@ tvm::Map<tir::Var, PrimExpr> InferSymbolicVarMap(
 
 bool IsBoolStructInfo(const StructInfo& sinfo, bool permit_unknown_rank,
                       bool permit_unknown_dtype) {
-  const TensorStructInfoNode* tt = sinfo.as<TensorStructInfoNode>();
-  if (!tt) {
+  DataType dtype;
+  int ndim;
+
+  if (const auto* tensor = sinfo.as<TensorStructInfoNode>()) {
+    dtype = tensor->dtype;
+    ndim = tensor->ndim;
+  } else if (const auto* prim = sinfo.as<PrimStructInfoNode>()) {
+    dtype = prim->dtype;
+    ndim = 0;
+  } else {
     return false;
   }
-  bool correct_dtype = tt->dtype.is_bool() || (permit_unknown_dtype && tt->dtype.is_void());
-  bool correct_rank = tt->ndim == 0 || (permit_unknown_rank && tt->ndim == -1);
+
+  bool correct_dtype = dtype.is_bool() || (permit_unknown_dtype && dtype.is_void());
+  bool correct_rank = ndim == 0 || (permit_unknown_rank && ndim == -1);
   return correct_dtype && correct_rank;
 }
 

--- a/src/tir/analysis/is_pure_function.cc
+++ b/src/tir/analysis/is_pure_function.cc
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file is_pure_function.cc
+ * \brief PrimFunc purity analysis
+ */
+#include <tvm/ir/op.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/stmt_functor.h>
+
+#include "../ir/tir_visitor_with_path.h"
+
+namespace tvm {
+namespace tir {
+
+namespace {
+class PurityChecker : TIRVisitorWithPath {
+ public:
+  static bool Check(const PrimFunc& func, bool assert_on_error) {
+    PurityChecker visitor(assert_on_error);
+    visitor(func);
+    return visitor.is_pure_;
+  }
+
+ private:
+  explicit PurityChecker(bool assert_on_error) : assert_on_error_(assert_on_error) {}
+
+  void VisitStmt_(const AllocateNode* op, ObjectPath path) override {
+    internal_allocations_.insert(op->buffer_var);
+    TIRVisitorWithPath::VisitStmt_(op, path);
+  }
+
+  void VisitStmt_(const BufferStoreNode* op, ObjectPath path) override {
+    TIRVisitorWithPath::VisitStmt_(op, path);
+
+    if (!internal_allocations_.count(op->buffer->data)) {
+      is_pure_ = false;
+      LOG_IF(FATAL, assert_on_error_) << "AssertionError: "
+                                      << "Pure functions must not write to buffers, "
+                                      << ", but function contains store to " << op->buffer
+                                      << op->indices << " of value " << op->value;
+    }
+  }
+
+  void VisitExpr_(const CallNode* call, ObjectPath path) override {
+    TIRVisitorWithPath::VisitExpr_(call, path);
+
+    static auto op_call_effect = Op::GetAttrMap<TCallEffectKind>("TCallEffectKind");
+    CallEffectKind effect = [&]() {
+      if (auto opt = call->op.as<Op>()) {
+        return static_cast<CallEffectKind>(op_call_effect[opt.value()]->value);
+      } else {
+        return CallEffectKind::kOpaque;
+      }
+    }();
+
+    if (effect == CallEffectKind::kUpdateState || effect == CallEffectKind::kOpaque) {
+      is_pure_ = false;
+      LOG_IF(FATAL, assert_on_error_)
+          << "AssertionError: "
+          << "Pure functions must not contain calls to impure operators, "
+          << "but " << GetRef<PrimExpr>(call) << " calls operator " << call->op
+          << ", which has side effect " << effect;
+    }
+  }
+
+  bool assert_on_error_{false};
+  bool is_pure_{true};
+  std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> internal_allocations_;
+};
+}  // namespace
+
+bool IsPureFunction(const PrimFunc& func, bool assert_on_error) {
+  return PurityChecker::Check(func, assert_on_error);
+}
+
+TVM_REGISTER_GLOBAL("tir.analysis.is_pure_function").set_body_typed(IsPureFunction);
+
+}  // namespace tir
+}  // namespace tvm

--- a/src/tir/ir/function.cc
+++ b/src/tir/ir/function.cc
@@ -21,12 +21,52 @@
  * \file src/tir/ir/function.cc
  * \brief The function data structure.
  */
+#include <tvm/relax/struct_info.h>
 #include <tvm/runtime/registry.h>
+#include <tvm/tir/analysis.h>
 #include <tvm/tir/function.h>
 #include <tvm/tir/op.h>
 
 namespace tvm {
 namespace tir {
+namespace {
+relax::StructInfo InferStructInfo(const PrimFunc& prim_func) {
+  Array<relax::StructInfo> params;
+  for (const auto& param : prim_func->params) {
+    relax::StructInfo param_sinfo = [&]() -> relax::StructInfo {
+      if (auto opt_buf = prim_func->buffer_map.Get(param)) {
+        auto buf = opt_buf.value();
+        relax::ShapeExpr shape(
+            buf->shape.Map([](PrimExpr dim) { return cast(DataType::Int(64), dim); }));
+        return relax::TensorStructInfo(shape, buf->dtype);
+      }
+
+      if (auto prim_type = param->type_annotation.as<PrimTypeNode>();
+          prim_type && prim_type->dtype.is_handle()) {
+        return relax::ObjectStructInfo();
+      }
+
+      return relax::PrimStructInfo(param->dtype);
+    }();
+    params.push_back(param_sinfo);
+  }
+
+  relax::StructInfo ret = [&]() -> relax::StructInfo {
+    if (const auto* prim = prim_func->ret_type.as<PrimTypeNode>()) {
+      return relax::PrimStructInfo(prim->dtype);
+    } else if (IsVoidType(prim_func->ret_type)) {
+      return relax::TupleStructInfo(Array<relax::StructInfo>{});
+    } else {
+      return relax::ObjectStructInfo();
+    }
+  }();
+
+  bool purity = prim_func->body.defined() ? IsPureFunction(prim_func) : false;
+
+  return relax::FuncStructInfo(params, ret, purity);
+}
+}  // namespace
+
 // Get the function type of a PrimFunc
 PrimFunc::PrimFunc(Array<tir::Var> params, Stmt body, Type ret_type,
                    Map<tir::Var, Buffer> buffer_map, DictAttrs attrs, Span span) {
@@ -42,8 +82,11 @@ PrimFunc::PrimFunc(Array<tir::Var> params, Stmt body, Type ret_type,
   n->buffer_map = std::move(buffer_map);
   n->attrs = std::move(attrs);
   n->checked_type_ = n->func_type_annotation();
+  n->struct_info_ = relax::FuncStructInfo::OpaqueFunc();
   n->span = std::move(span);
   data_ = std::move(n);
+
+  (*this)->struct_info_ = InferStructInfo(*this);
 }
 
 FuncType PrimFuncNode::func_type_annotation() const {

--- a/src/tir/ir/specialize.cc
+++ b/src/tir/ir/specialize.cc
@@ -105,14 +105,10 @@ class PrimFuncSpecializer : public StmtExprMutator {
     Stmt body = specializer(f->body);
 
     if (param_updated || buffer_map_updated || !f->body.same_as(body)) {
-      PrimFuncNode* f_ptr = f.CopyOnWrite();
-      f_ptr->params = std::move(params);
-      f_ptr->buffer_map = std::move(buffer_map);
-      f_ptr->body = std::move(body);
-      f_ptr->struct_info_ = NullOpt;
-      f_ptr->checked_type_ = Type(nullptr);
+      return PrimFunc(params, body, f->ret_type, buffer_map, f->attrs, f->span);
+    } else {
+      return f;
     }
-    return f;
   }
 
  private:

--- a/src/tir/transforms/renew_defs.cc
+++ b/src/tir/transforms/renew_defs.cc
@@ -76,11 +76,7 @@ class RenewDefMutator : public StmtExprMutator {
     // Visit body
     Stmt body = generator(func->body);
     // Recreate function
-    auto n = make_object<PrimFuncNode>(*func.get());
-    n->params = std::move(params);
-    n->buffer_map = std::move(buffer_map);
-    n->body = std::move(body);
-    return PrimFunc(n);
+    return PrimFunc(params, body, func->ret_type, buffer_map, func->attrs, func->span);
   }
 
  private:

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -22,6 +22,7 @@ from tvm import tir
 from tvm.script import relax as R
 from tvm.script import ir as I
 from tvm.script import tir as T
+from tvm.script import ir as I
 
 m = tir.Var("m", "int64")
 n = tir.Var("n", "int64")
@@ -654,6 +655,50 @@ def test_well_formed_function_referencing_global_var():
     assert rx.analysis.well_formed(Module)
     assert rx.analysis.well_formed(Module["main"])
     assert rx.analysis.well_formed(Module["subroutine"])
+
+def test_pass_dltensor_arg_to_tir():
+    """Relax may pass R.Tensor as DLTensor
+
+    In TIR, a `DLTensor*` argument with unknown shape and dtype is
+    represented as a `tir.Var` with
+    `tvm::PrimType(DataType::Handle())`, and with no entry in the
+    `PrimFuncNode::buffer_map`.  In Relax, this is represented as
+    `R.Tensor`.  Calls from Relax to TIR that pass a tensor of unknown
+    rank/shape are well-formed.
+
+    In the test case below, a TIR function accepts an arbitrary
+    `R.Tensor`, and returns a boolean value based on inspection of the
+    runtime datatype.
+    """
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor) -> R.Prim("bool"):
+            return Module.is_bfloat16_dtype(A)
+
+        @T.prim_func(private=True)
+        def is_bfloat16_dtype(tensor: T.handle) -> T.bool:
+            T.func_attr({"tir.is_scheduled": True, "tir.is_host_func": True})
+
+            # From #include <tvm/tir/builtin.h>
+            kArrTypeCode = T.meta_var(5)
+            kArrTypeBits = T.meta_var(6)
+            kArrTypeLanes = T.meta_var(7)
+
+            # From #include <dlpack/dlpack.h>
+            kDLBfloat = T.meta_var(4)
+
+            type_code = T.tvm_struct_get(tensor, 0, kArrTypeCode, dtype="uint8")
+            type_bits = T.tvm_struct_get(tensor, 0, kArrTypeBits, dtype="uint8")
+            type_lanes = T.tvm_struct_get(tensor, 0, kArrTypeLanes, dtype="uint16")
+
+            is_bfloat16: T.bool = (
+                (type_code == kDLBfloat) and (type_bits == 16) and (type_lanes == 1)
+            )
+            return is_bfloat16
+
+    assert rx.analysis.well_formed(Module)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -656,6 +656,7 @@ def test_well_formed_function_referencing_global_var():
     assert rx.analysis.well_formed(Module["main"])
     assert rx.analysis.well_formed(Module["subroutine"])
 
+
 def test_pass_dltensor_arg_to_tir():
     """Relax may pass R.Tensor as DLTensor
 

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -343,14 +343,18 @@ def test_call_tir_inplace_multiple_args():
     @tvm.script.ir_module
     class Expected:
         @T.prim_func
-        def copy(A: T.Buffer((2, 3), "int32"), B: T.Buffer((2, 3), "int32")):
+        def copy(
+            A: T.Buffer((2, 3), "int32"), B: T.Buffer((2, 3), "int32"), C: T.Buffer((2, 3), "int32")
+        ):
+            # copies the contents of C into A and B
             T.func_attr({"tir.noalias": True})
             for i0, i1 in T.grid(T.int64(2), T.int64(3)):
                 with T.block("T_zeros"):
                     ax0, ax1 = T.axis.remap("SS", [i0, i1])
-                    T.reads(B[ax0, ax1])
-                    T.writes(A[ax0, ax1])
-                    A[ax0, ax1] = B[ax0, ax1]
+                    T.reads(C[ax0, ax1])
+                    T.writes(A[ax0, ax1], B[ax0, ax1])
+                    A[ax0, ax1] = C[ax0, ax1]
+                    B[ax0, ax1] = C[ax0, ax1]
 
         @R.function
         def foo(

--- a/tests/python/relax/test_transform_compute_prim_value.py
+++ b/tests/python/relax/test_transform_compute_prim_value.py
@@ -76,5 +76,29 @@ class TestPrimValueInBranchCondition(BaseCompare):
             T.ret(N % 16 == 0)
 
 
+class TestPrimValueInPureFunction(BaseCompare):
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(_N: R.Prim(value="N"), _M: R.Prim(value="M")) -> R.Prim(value="N*M"):
+            N = T.int64()
+            M = T.int64()
+            out = R.prim_value(N * M)
+            return out
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(_N: R.Prim(value="N"), _M: R.Prim(value="M")) -> R.Prim(value="N*M"):
+            N = T.int64()
+            M = T.int64()
+            out = Expected.compute_symbolic_expr(R.prim_value(N), R.prim_value(M))
+            return out
+
+        @T.prim_func(private=True)
+        def compute_symbolic_expr(N: T.int64, M: T.int64) -> T.int64:
+            T.ret(N * M)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_transform_compute_prim_value.py
+++ b/tests/python/relax/test_transform_compute_prim_value.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+from tvm.script import ir as I, relax as R, tir as T
+
+
+class BaseCompare(tvm.testing.CompareBeforeAfter):
+    transform = tvm.relax.transform.ComputePrimValue()
+
+
+class TestPrimValueInAssertCondition(BaseCompare):
+    @I.ir_module
+    class Before:
+        @R.function(pure=False)
+        def main(A: R.Tensor(["N"])):
+            N = T.int64()
+            _ = R.assert_op(N % 16 == 0)
+            return A
+
+    @I.ir_module
+    class Expected:
+        @R.function(pure=False)
+        def main(A: R.Tensor(["N"])):
+            N = T.int64()
+            condition: R.Prim("bool") = Expected.compute_symbolic_expr(R.prim_value(N))
+            _ = R.assert_op(condition)
+            return A
+
+        @T.prim_func(private=True)
+        def compute_symbolic_expr(N: T.int64) -> T.bool:
+            T.ret(N % 16 == 0)
+
+
+class TestPrimValueInBranchCondition(BaseCompare):
+    @I.ir_module
+    class Before:
+        @R.function(pure=False)
+        def main(A: R.Tensor(["N"])):
+            N = T.int64()
+            if R.prim_value(N % 16 == 0):
+                out = R.call_packed("fast_vectorized_impl", A, sinfo_args=[A.struct_info])
+            else:
+                out = R.call_packed("slow_non_vectorized_impl", A, sinfo_args=[A.struct_info])
+            return out
+
+    @I.ir_module
+    class Expected:
+        @R.function(pure=False)
+        def main(A: R.Tensor(["N"])):
+            N = T.int64()
+            condition: R.Prim("bool") = Expected.compute_symbolic_expr(R.prim_value(N))
+            if condition:
+                out = R.call_packed("fast_vectorized_impl", A, sinfo_args=[A.struct_info])
+            else:
+                out = R.call_packed("slow_non_vectorized_impl", A, sinfo_args=[A.struct_info])
+            return out
+
+        @T.prim_func(private=True)
+        def compute_symbolic_expr(N: T.int64) -> T.bool:
+            T.ret(N % 16 == 0)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_vm_codegen_tir.py
+++ b/tests/python/relax/test_vm_codegen_tir.py
@@ -72,7 +72,7 @@ def test_tir_call():
             H[T.int64(0)] = H[T.int64(0)] + T.int64(1)
 
         @R.function(pure=False)
-        def foo(x: R.Tensor):
+        def foo(x: R.Tensor([4], "int64")):
             R.func_attr({"global_symbol": "foo"})
             _ = Before.shape_func(x)
             return x

--- a/tests/python/tir-analysis/test_tir_analysis_is_pure_function.py
+++ b/tests/python/tir-analysis/test_tir_analysis_is_pure_function.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import tvm.testing
+from tvm.script import tir as T
+
+from tvm.tir.analysis import is_pure_function, assert_pure_function
+
+
+class CheckPureFunction:
+    def test_check_purity(self):
+        assert is_pure_function(self.func)
+
+    def test_assert_purity(self):
+        assert_pure_function(self.func)
+
+
+class CheckImpureFunction:
+    def test_check_purity(self):
+        assert not is_pure_function(self.func)
+
+    def test_assert_purity(self):
+        with pytest.raises(AssertionError):
+            assert_pure_function(self.func)
+
+
+class TestNoOp(CheckPureFunction):
+    @T.prim_func
+    def func():
+        pass
+
+
+class TestReturnValue(CheckPureFunction):
+    @T.prim_func
+    def func() -> T.int32:
+        T.ret(42)
+
+
+class TestComputeValueAndReturn(CheckPureFunction):
+    @T.prim_func
+    def func(N: T.int32, M: T.int32) -> T.int32:
+        T.ret(N * M)
+
+
+class TestReadBufferArgument(CheckPureFunction):
+    @T.prim_func
+    def func(A: T.Buffer(16, "float32")) -> T.float32:
+        T.ret(A[0])
+
+
+class TestWriteToBufferArgument(CheckImpureFunction):
+    @T.prim_func
+    def func(A: T.Buffer(16, "float32"), B: T.Buffer(16, "float32")):
+        for i in range(16):
+            B[i] = A[i]
+
+
+class TestWriteToInternalAllocation(CheckPureFunction):
+    @T.prim_func
+    def func(A: T.Buffer([16, 16], "float32")) -> T.float32:
+        Sum = T.decl_buffer([], "float32")
+        Sum[()] = 0.0
+        for i, j in T.grid(16, 16):
+            Sum[()] = Sum[()] + A[i, j]
+
+        T.ret(Sum[()])
+
+
+class TestCallPureBuiltin(CheckPureFunction):
+    @T.prim_func
+    def func(x: T.float32) -> T.float32:
+        T.ret(T.cos(x))
+
+
+class TestCallPureExtern(CheckPureFunction):
+    @T.prim_func
+    def func():
+        T.call_pure_extern("some_pure_extern_func_name", dtype="void")
+
+
+class TestCallImpureExtern(CheckImpureFunction):
+    @T.prim_func
+    def func():
+        T.call_extern("some_impure_extern_func_name", dtype="void")
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/tir-base/test_tir_specialize.py
+++ b/tests/python/tir-base/test_tir_specialize.py
@@ -330,12 +330,11 @@ def test_specialize_buffer_var_to_expr():
     tvm.ir.assert_structural_equal(expected, after)
 
 
-def test_specialization_removes_struct_info():
-    """Reset struct info in specialization
+def test_specialization_updates_struct_info():
+    """Update struct info in specialization
 
-    While a PrimFunc usually doesn't have a `relax.StructInfo`, the
-    field can be populated in some edge cases.  If that PrimFunc is
-    specialized, the struct info should be reset.
+    A PrimFunc may have a `relax.StructInfo`.  If that PrimFunc is
+    specialized, the struct info should be updated.
     """
 
     @T.prim_func(private=True)
@@ -346,24 +345,20 @@ def test_specialization_removes_struct_info():
     def expected() -> T.int32:
         T.ret(50)
 
-    sinfo = tvm.relax.FuncStructInfo(
+    sinfo_before = tvm.relax.FuncStructInfo(
         [tvm.relax.PrimStructInfo("int32")], tvm.relax.PrimStructInfo("int32")
     )
-    tvm.relax.expr._update_struct_info(before, sinfo)
+    tvm.ir.assert_structural_equal(before.struct_info, sinfo_before)
+
+    sinfo_expected = tvm.relax.FuncStructInfo([], tvm.relax.PrimStructInfo("int32"))
+    tvm.ir.assert_structural_equal(expected.struct_info, sinfo_expected)
 
     n = before.params[0]
     param_map = {n: 5}
     after = before.specialize(param_map)
 
-    tvm.ir.assert_structural_equal(expected, after)
-    assert before.struct_info is not None
-
-    # PrimFuncs do not expose the `struct_info_` field.  Checking the
-    # `struct_info` field when it isn't set raises an exception.  This
-    # is the desired behavior, since the struct info before
-    # specialization is no longer valid.
-    with pytest.raises(tvm.TVMError):
-        after.struct_info
+    tvm.ir.assert_structural_equal(after, expected)
+    tvm.ir.assert_structural_equal(after.struct_info, sinfo_expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prior to this commit, the condition used for `relax::If` node and the `"relax.assert_op"` operator was required to be a scalar tensor.  This made it difficult to alter behavior based on a runtime shape parameter.  For example, delegating to a vectorized implementation based on a whether a tensor shape is divisible by the vector size.

This commit adds support for expressions of type `R.Prim('bool')` as the conditional for `relax::If` and `"relax.assert_op"`, to allow these use cases.