### PR TITLE
[Relax][Frontend][Onnx]fix name supply bug

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -2059,12 +2059,10 @@ class ONNXGraphImporter:
         if name == "":
             return self._name_supply.fresh_name("empty_")
 
-        new_name = name.replace(".", "_")
-        if not new_name[0].isalpha() and new_name[0] != "_":
-            new_name = str(self._name_supply.fresh_name("input_" + new_name))
+        if not name[0].isalpha() and name[0] != "_":
+            new_name = str(self._name_supply.fresh_name("input_" + name))
         else:
-            new_name = str(self._name_supply.fresh_name(new_name))
-
+            new_name = str(self._name_supply.fresh_name(name))
         if new_name != name:
             warnings.warn(("Renaming name %s to %s" % (name, new_name)))
         return new_name

--- a/src/ir/name_supply.cc
+++ b/src/ir/name_supply.cc
@@ -73,8 +73,8 @@ String NameSupplyNode::add_prefix_to_name(const String& name) {
 }
 
 std::string NameSupplyNode::GetUniqueName(std::string name, bool add_underscore) {
-  for (size_t i = 0; i < name.size(); ++i) {
-    if (name[i] == '.') name[i] = '_';
+  if (name.size() >= 1 && name[0] == '.') {
+    name[0] = '_';
   }
   auto it = name_map.find(name);
   if (it != name_map.end()) {


### PR DESCRIPTION
Hi,  tvm:
    From the description of the function of  _sanitize_name:
    ```
        If the name is None, returns a string input_0, input_1, etc.
        If the input is an empty string, returns empty_0, empty_1, etc.
        If the input is a string that does not start with a letter or underscore,
        returns input_<name>. Otherwise, returns an unique input name.
    ```.
   The input to the current model is "input.1".which will be converted into "input_1" by this function.
   This conversion is wrong and does not conform to the three situations described above.
   So I re-modified the relevant conversion conditions according to the above description. I am not sure whether it will affect other cases. @jwfromm @gigiblender @tqchen 
   
