### PR TITLE
[BugFix][FFI] Add a missing default for datatype lanes

### DIFF
--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -140,6 +140,8 @@ class DataType(ctypes.Structure):
             self.lanes = ctypes.c_uint16(-int(arr[2]))
         elif len(arr) > 1:
             self.lanes = ctypes.c_uint16(int(arr[1]))
+        else:
+            self.lanes = 1
         bits = 32
 
         if head.startswith("int"):


### PR DESCRIPTION
A default value for lanes was unintentionally removed in #16612, this PR fixes this which in turn fixes the test failure seen in `test_tensor_dtype_lanes` in CI.

cc @tqchen @Lunderberg @ekalda 