### PR TITLE
[Relax][Frontend][NN] Add support for Conv3D

### DIFF
--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -343,7 +343,7 @@ class Conv3D(Module):
         Returns
         -------
         ret : Tensor
-            The output tensor for the conv2d layer.
+            The output tensor for the conv3d layer.
         """
         return op.conv3d(
             x,

--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -225,6 +225,7 @@ class Conv2D(Module):
         groups: int = 1,
         bias: bool = True,
         dtype: Optional[str] = None,
+        data_layout: str = "NCHW",
     ):
         super().__init__()
         self.in_channels = in_channels
@@ -233,6 +234,7 @@ class Conv2D(Module):
         self.padding = padding
         self.dilation = dilation
         self.groups = groups
+        self.data_layout = data_layout
 
         # Allow dynamic input channels.
         if isinstance(self.in_channels, int):
@@ -270,7 +272,14 @@ class Conv2D(Module):
             The output tensor for the conv2d layer.
         """
         return op.conv2d(
-            x, self.weight, self.bias, self.stride, self.padding, self.dilation, self.groups
+            x,
+            self.weight,
+            self.bias,
+            self.stride,
+            self.padding,
+            self.dilation,
+            self.groups,
+            self.data_layout,
         )
 
 
@@ -290,6 +299,7 @@ class Conv3D(Module):
         groups: int = 1,
         bias: bool = True,
         dtype: Optional[str] = None,
+        data_layout: str = "NCDHW",
     ):
         super().__init__()
         self.in_channels = in_channels
@@ -298,6 +308,7 @@ class Conv3D(Module):
         self.padding = padding
         self.dilation = dilation
         self.groups = groups
+        self.data_layout = data_layout
 
         # Allow dynamic input channels.
         if isinstance(self.in_channels, int):
@@ -335,7 +346,14 @@ class Conv3D(Module):
             The output tensor for the conv2d layer.
         """
         return op.conv3d(
-            x, self.weight, self.bias, self.stride, self.padding, self.dilation, self.groups
+            x,
+            self.weight,
+            self.bias,
+            self.stride,
+            self.padding,
+            self.dilation,
+            self.groups,
+            self.data_layout,
         )
 
 

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -494,7 +494,7 @@ def conv3d(
         elif data_layout == "NDHWC":
             conv_out = _op.add(conv_out, _op.reshape(bias._expr, [1, 1, 1, 1, -1]))
         else:
-            raise NotImplemented(f"Dont know how to handle layout {data_layout}.")
+            raise NotImplementedError(f"Dont know how to handle layout {data_layout}.")
 
     return wrap_nested(conv_out, name)
 
@@ -1574,33 +1574,6 @@ def interpolate(
     )
 
 
-def where(condition: Tensor, input: Tensor, other: Tensor, name: str = "where") -> Tensor:
-    """Return a tensor of elemends selected from input or other based on condition.
-
-    Parameters
-    ----------
-    condition : Tensor
-        When True, yield input, otherwise yield other.
-
-    input : Tensor
-        Value or values selected at indices where condition is True.
-
-    other : Tensor
-        Value or values selected at indices where condition is False.
-
-    name : str
-        Name hint.
-
-    Returns
-    -------
-    result : Tensor
-        The computed result.
-    """
-    # Cast condition to boolean.
-    condition = astype(condition, "bool")
-    return wrap_nested(_op.where(condition._expr, input._expr, other._expr), name)
-
-
 def ccl_allreduce(x: Tensor, op_type: str = "sum", name="ccl_allreduce"):
     """CCL Allreduce operator
 
@@ -2106,6 +2079,8 @@ def where(condition: Tensor, x1: Tensor, x2: Tensor, name: str = "where") -> Ten
     result : Tensor
         The result tensor.
     """
+    # Cast condition to boolean.
+    condition = astype(condition, "bool")
     return wrap_nested(_op.where(condition._expr, x1._expr, x2._expr), name)
 
 

--- a/python/tvm/relax/op/op_attrs.py
+++ b/python/tvm/relax/op/op_attrs.py
@@ -59,6 +59,11 @@ class Conv2DAttrs(Attrs):
     """Attributes for nn.conv2d"""
 
 
+@tvm._ffi.register_object("relax.attrs.Conv3DAttrs")
+class Conv3DAttrs(Attrs):
+    """Attributes for nn.conv3d"""
+
+
 @tvm._ffi.register_object("relax.attrs.Conv2DTransposeAttrs")
 class Conv2DTransposeAttrs(Attrs):
     """Attributes for nn.conv2d_transpose"""

--- a/src/relax/op/image/resize.cc
+++ b/src/relax/op/image/resize.cc
@@ -123,7 +123,8 @@ InferLayoutOutput InferLayoutResize2d(const Call& call,
     data_layout = GetLayoutDecision(var_layout_map, call->args[0]);
     new_attrs->layout = TransposeLike(attrs->layout, InitialLayout(4), data_layout->layout).name();
   }
-  return InferLayoutOutput({data_layout, InitialNLayout(call->args[1])}, {data_layout}, Attrs(new_attrs));
+  return InferLayoutOutput({data_layout, InitialNLayout(call->args[1])}, {data_layout},
+                           Attrs(new_attrs));
 }
 
 TVM_REGISTER_OP("relax.image.resize2d")

--- a/src/relax/op/image/resize.cc
+++ b/src/relax/op/image/resize.cc
@@ -105,14 +105,25 @@ StructInfo InferStructInfoResize2D(const Call& call, const BlockBuilder& ctx) {
 InferLayoutOutput InferLayoutResize2d(const Call& call,
                                       const Map<String, Array<String>>& desired_layouts,
                                       const VarLayoutMap& var_layout_map) {
-  ICHECK(NoDesiredLayout(call, desired_layouts));
+  const auto& it = desired_layouts.find("relax.image.resize2d");
   const auto* attrs = call->attrs.as<Resize2DAttrs>();
   ICHECK(attrs) << "Invalid Call";
 
-  LayoutDecision layout = GetLayoutDecision(var_layout_map, call->args[0]);
+  LayoutDecision data_layout;
   ObjectPtr<Resize2DAttrs> new_attrs = make_object<Resize2DAttrs>(*attrs);
-  new_attrs->layout = TransposeLike(attrs->layout, InitialLayout(4), layout->layout).name();
-  return InferLayoutOutput({layout, InitialNLayout(call->args[1])}, {layout}, Attrs(new_attrs));
+
+  if (it != desired_layouts.end()) {
+    // We have a desired layout for resize2d.
+    Layout desired_data_layout = (*it).second[0];
+    ICHECK_EQ(desired_data_layout.ndim(), desired_data_layout.ndim_primal()) << "Axis swap only";
+    data_layout = TransposeLike(InitialLayout(4), attrs->layout, desired_data_layout);
+    new_attrs->layout = (*it).second[0];
+  } else {
+    // We dont have a desired layout for resize2d, propagate from the input instead.
+    data_layout = GetLayoutDecision(var_layout_map, call->args[0]);
+    new_attrs->layout = TransposeLike(attrs->layout, InitialLayout(4), data_layout->layout).name();
+  }
+  return InferLayoutOutput({data_layout, InitialNLayout(call->args[1])}, {data_layout}, Attrs(new_attrs));
 }
 
 TVM_REGISTER_OP("relax.image.resize2d")

--- a/src/tir/schedule/state.cc
+++ b/src/tir/schedule/state.cc
@@ -384,7 +384,7 @@ ScheduleState::ScheduleState(IRModule mod, int debug_mask, bool enable_check) {
     const BaseFunc& base_func = kv.second;
     if (auto opt = base_func.as<PrimFunc>()) {
       auto func = opt.value();
-      VerifyWellFormed(func);
+      //VerifyWellFormed(func);
       BlockInfoCollector::Collect(self, func->body);
     }
   }

--- a/src/tir/schedule/state.cc
+++ b/src/tir/schedule/state.cc
@@ -384,7 +384,7 @@ ScheduleState::ScheduleState(IRModule mod, int debug_mask, bool enable_check) {
     const BaseFunc& base_func = kv.second;
     if (auto opt = base_func.as<PrimFunc>()) {
       auto func = opt.value();
-      //VerifyWellFormed(func);
+      VerifyWellFormed(func);
       BlockInfoCollector::Collect(self, func->body);
     }
   }

--- a/tests/python/relax/test_frontend_nn_modules.py
+++ b/tests/python/relax/test_frontend_nn_modules.py
@@ -257,11 +257,13 @@ def test_conv3d():
         R.func_attr({"num_input": 2})
         with R.dataflow():
             lv1: R.Tensor((1, 32, 30, 30, 30), dtype="float32") = R.nn.conv3d(x, weight)
-            lv2: R.Tensor((1, 32, 1, 1, 1), dtype="float32") = R.reshape(bias, R.shape([1, 32, 1, 1, 1]))
-            conv3d: R.Tensor((1, 32, 30, 30, 30), dtype="float32") = R.add(lv1, lv2)
-            gv1: R.Tuple(R.Tensor((1, 32, 30, 30, 30), dtype="float32"), R.Tuple(R.Object)) = conv3d, (
-                _io,
+            lv2: R.Tensor((1, 32, 1, 1, 1), dtype="float32") = R.reshape(
+                bias, R.shape([1, 32, 1, 1, 1])
             )
+            conv3d: R.Tensor((1, 32, 30, 30, 30), dtype="float32") = R.add(lv1, lv2)
+            gv1: R.Tuple(
+                R.Tensor((1, 32, 30, 30, 30), dtype="float32"), R.Tuple(R.Object)
+            ) = conv3d, (_io,)
             R.output(gv1)
         return gv1
 

--- a/tests/python/relax/test_frontend_nn_modules.py
+++ b/tests/python/relax/test_frontend_nn_modules.py
@@ -246,6 +246,37 @@ def test_conv2d():
     assert_structural_equal(tvm_mod["forward"], forward, True)
 
 
+def test_conv3d():
+    @R.function
+    def forward(
+        x: R.Tensor((1, 3, 32, 32, 32), dtype="float32"),
+        _io: R.Object,
+        weight: R.Tensor((32, 3, 3, 3, 3), dtype="float32"),
+        bias: R.Tensor((32,), dtype="float32"),
+    ) -> R.Tuple(R.Tensor((1, 32, 30, 30, 30), dtype="float32"), R.Tuple(R.Object)):
+        R.func_attr({"num_input": 2})
+        with R.dataflow():
+            lv1: R.Tensor((1, 32, 30, 30, 30), dtype="float32") = R.nn.conv3d(x, weight)
+            lv2: R.Tensor((1, 32, 1, 1, 1), dtype="float32") = R.reshape(bias, R.shape([1, 32, 1, 1, 1]))
+            conv3d: R.Tensor((1, 32, 30, 30, 30), dtype="float32") = R.add(lv1, lv2)
+            gv1: R.Tuple(R.Tensor((1, 32, 30, 30, 30), dtype="float32"), R.Tuple(R.Object)) = conv3d, (
+                _io,
+            )
+            R.output(gv1)
+        return gv1
+
+    mod = modules.Conv3D(3, 32, 3, bias=True)
+    tvm_mod, _ = mod.export_tvm(
+        spec={
+            "forward": {
+                "x": spec.Tensor([1, 3, 32, 32, 32], "float32"),
+            }
+        },
+        debug=True,
+    )
+    assert_structural_equal(tvm_mod["forward"], forward, True)
+
+
 def test_conv2d_dynamic():
     @R.function
     def forward(


### PR DESCRIPTION
This PR expands Relax's NN frontend with operators needed to support emerging video models like SVD. The main change needed is adding support for Conv3D, but a few other minor changes were found to be helpful as well. Specifically the ability to rewrite resize2D's layout manually was quite helpful for performance, so I expanded it's convertlayout pass to support that. I also added a few more options to Conv2D in the nn frontend such as specifying layout.