### PR TITLE
Simplify Windows CMake Command

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -445,3 +445,9 @@ set(USE_UMA OFF)
 
 # Set custom Alloc Alignment for device allocated memory ndarray points to
 set(USE_KALLOC_ALIGNMENT 64)
+
+# Set Windows Visual Studio default Architecture (equivalent to -A x64)
+SET(CMAKE_VS_PLATFORM_NAME_DEFAULT "x64")
+
+# Set Windows Visual Studio default host (equivalent to -Thost=x64)
+SET(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE "x64")

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -259,7 +259,7 @@ get an activated tvm-build environment. Then you can run the following command t
 
     mkdir build
     cd build
-    cmake -A x64 -Thost=x64 ..
+    cmake ..
     cd ..
 
 The above command generates the solution file under the build directory.


### PR DESCRIPTION
This sets the arguments recommended previously in the docs as the default windows build args for the cmake generate step.

Instead of needing to say:

```bash
cmake -A x64 -Thost=x64 ..
```

Its now the same as linux and mac:

```bash
cmake ..
```