### PR TITLE
[BugFix] add the default value for DFT in ONNX frontend

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4809,7 +4809,7 @@ class DFT(OnnxOpConverter):
     @classmethod
     def _impl_v17(cls, inputs, attr, params):
         # ************************* Read attrs *************************
-        axis = attr.get("axis")
+        axis = attr.get("axis", 1)
         inverse = attr.get("inverse")
         onesided = attr.get("onesided")
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -4810,8 +4810,8 @@ class DFT(OnnxOpConverter):
     def _impl_v17(cls, inputs, attr, params):
         # ************************* Read attrs *************************
         axis = attr.get("axis", 1)
-        inverse = attr.get("inverse")
-        onesided = attr.get("onesided")
+        inverse = attr.get("inverse", 0)
+        onesided = attr.get("onesided", 0)
 
         # ************************* Read inputs ************************
         input_tensor = inputs[0]

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -8237,7 +8237,7 @@ def test_dft(target, dev):
     n = 2
     D = 7
 
-    for axis in list(range(1, n)) + [-2, None]:
+    for axis in list(range(1, n)) + [-2]:
         for inverse, onesided in [(0, 0), (0, 1), (1, 0), (None, None)]:
             for n_fft in [D, D - 1, D + 1]:
                 for c in [1, 2]:

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -8237,8 +8237,8 @@ def test_dft(target, dev):
     n = 2
     D = 7
 
-    for axis in list(range(1, n)) + [-2]:
-        for inverse, onesided in [(0, 0), (0, 1), (1, 0)]:
+    for axis in list(range(1, n)) + [-2, None]:
+        for inverse, onesided in [(0, 0), (0, 1), (1, 0), (None, None)]:
             for n_fft in [D, D - 1, D + 1]:
                 for c in [1, 2]:
                     input_shape = [batch_size] + n * [D] + [c]


### PR DESCRIPTION
For the DFT operator (opset-17), The attribute of `axis`, `inverse`, and `onesided` is optional with a default value as shown in the [ONNX documentation](https://onnx.ai/onnx/operators/onnx__DFT.html). This PR fixed such bugs and added corresponding tests.