### PR TITLE
[Bugfix][TIR] Fix duplicate AllocateConst in CacheReadWrite schedule primitive

### DIFF
--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -483,9 +483,9 @@ Stmt InsertCacheStage(const Stmt& stmt, int pos, const Stmt& stage) {
     seq.insert(seq.begin() + pos, stage);
     body = SeqStmt(seq);
   } else if (pos == 0) {
-    body = SeqStmt({stage, stmt});
+    body = SeqStmt({stage, body});
   } else if (pos == 1) {
-    body = SeqStmt({stmt, stage});
+    body = SeqStmt({body, stage});
   } else {
     LOG(FATAL) << "Cannot insert at position " << pos
                << ".  When inserting adjacent to non-SeqStmt, "

--- a/tests/python/tir-schedule/test_tir_schedule_cache_read_write.py
+++ b/tests/python/tir-schedule/test_tir_schedule_cache_read_write.py
@@ -1387,7 +1387,6 @@ def test_cache_read_allocate_const():
         for i in range(8):
             with T.block("C"):
                 vi = T.axis.spatial(8, i)
-                T.reads(A[vi], B_buf[vi])
                 C[vi] = A[vi] + B_buf[vi]
 
     @T.prim_func
@@ -1403,7 +1402,6 @@ def test_cache_read_allocate_const():
         for ax0 in range(8):
             with T.block("B_buf_global"):
                 v0 = T.axis.spatial(8, ax0)
-                T.reads(B_buf[v0])
                 B_buf_global[v0] = B_buf[v0]
         for i in range(8):
             with T.block("C"):


### PR DESCRIPTION
When inserting a `cache_read` / `cache_write` stage, the `tir.AllocateConst` statement would be duplicated if its body was not a `tir.SeqStmt` node (e.g. `tir.For`), leading to compilation failures. This happened because `tir.AllocateConst` and `tir.DeclBuffer` statements are always re-attached to the statement's body after the `cache_read` / `cache_write` stage is inserted in it, but the stage was being appended to the whole statement (which already contains the `tir.AllocateConst`) and not just its body, causing duplications.

This commit also adds a test where the first `cache_read` stage is inserted into a statement whose body is a `tir.For`, while the second stage is added to a body that is `tir.SeqStmt` to check for regressions.  

cc @Lunderberg @ekalda @lhutton1 