### PR TITLE
[TVMScript] Infer T.reads() for DeclBuffer nodes

### DIFF
--- a/src/tir/ir/script/script_complete.cc
+++ b/src/tir/ir/script/script_complete.cc
@@ -99,6 +99,17 @@ class ScriptCompleter : public StmtMutator {
     }
   }
 
+  Stmt VisitStmt_(const DeclBufferNode* op) final {
+    if (buffer_var_map_->count(op->buffer->data)) {
+      return StmtMutator::VisitStmt_(op);
+    } else {
+      buffer_var_map_->Set(op->buffer->data, op->buffer);
+      auto output = StmtMutator::VisitStmt_(op);
+      buffer_var_map_->erase(op->buffer->data);
+      return output;
+    }
+  }
+
   bool is_root_block_ = true;
 };
 


### PR DESCRIPTION
Prior to this commit, the automatic `T.reads()` and `T.writes()` annotations were only generated for buffers appearing as function arguments, as `T.alloc_buffer` in a `T.block`, or as `T.match_buffer` in a `T.block`.  However, inferred `T.reads()` for a buffer defined by the `"tir.BindParams"` pass would be erroneously missing.  These annotations may be required for correct scheduling (see discussion in [PR#16660](https://github.com/apache/tvm/pull/16660)).

This commit updates the TVMScript parsing to infer `T.reads()` and `T.writes()` annotations for buffers defined with `DeclBuffer` nodes.