### PR TITLE
Fix for assume statement

### DIFF
--- a/src/tir/analysis/control_flow_graph.cc
+++ b/src/tir/analysis/control_flow_graph.cc
@@ -474,9 +474,8 @@ class ControlFlowGraphBuilder final : public IRVisitorWithAnalyzer {
                    PrimExpr known_value_expr) {
     auto& current_block = out_->control_flow_.back();
     PrimExpr current_predicate = CurrentScopePredicate();
-    BufferTouch buffer_touch = current_block.MakeBufferTouch(out_, node->buffer, node->indices,
-                                                             touch_type, known_value_expr, 
-                                                             current_predicate);
+    BufferTouch buffer_touch = current_block.MakeBufferTouch(
+        out_, node->buffer, node->indices, touch_type, known_value_expr, current_predicate);
     current_block.touch_points.push_back(buffer_touch);
   }
 
@@ -639,7 +638,8 @@ class ControlFlowGraphBuilder final : public IRVisitorWithAnalyzer {
 
 std::pair<BufferTouch, Map<Var, Range>> ControlFlowGraph::ControlFlowBlock::MakeBufferTouch(
     const tir::Buffer& buf, Array<Var> index_variables, Array<PrimExpr> indices,
-    BufferTouch::AccessType touch_type, PrimExpr known_value_expr, PrimExpr current_predicate) const {
+    BufferTouch::AccessType touch_type, PrimExpr known_value_expr,
+    PrimExpr current_predicate) const {
   const auto& current_block = *this;
 
   Analyzer local_analyzer;
@@ -807,7 +807,8 @@ std::pair<BufferTouch, Map<Var, Range>> ControlFlowGraph::ControlFlowBlock::Make
   } else {
     scope_additional_predicate = scope_predicate;
   }
-  PrimExpr predicate_expr = local_analyzer.Simplify(transform_predicate && scope_additional_predicate);
+  PrimExpr predicate_expr =
+      local_analyzer.Simplify(transform_predicate && scope_additional_predicate);
   BufferTouch buffer_touch = {buf, predicate_expr, known_value_expr, loop_var_expressions,
                               touch_type};
 
@@ -821,9 +822,9 @@ BufferTouch ControlFlowGraph::ControlFlowBlock::MakeBufferTouch(ControlFlowGraph
                                                                 PrimExpr known_value_expr,
                                                                 PrimExpr current_predicate) const {
   ICHECK(graph);
-  auto [buffer_touch, free_params] = MakeBufferTouch(buf, graph->GetIndexVariables(buf, indices),
-                                                     indices, touch_type, known_value_expr, 
-                                                     current_predicate);
+  auto [buffer_touch, free_params] =
+      MakeBufferTouch(buf, graph->GetIndexVariables(buf, indices), indices, touch_type,
+                      known_value_expr, current_predicate);
   for (const auto& pair : free_params) {
     graph->free_predicate_parameters_.Set(pair.first, pair.second);
   }

--- a/src/tir/analysis/control_flow_graph.cc
+++ b/src/tir/analysis/control_flow_graph.cc
@@ -473,6 +473,7 @@ class ControlFlowGraphBuilder final : public IRVisitorWithAnalyzer {
   void VisitAccess(const BufferAccess& node, BufferTouch::AccessType touch_type,
                    PrimExpr known_value_expr) {
     auto& current_block = out_->control_flow_.back();
+    current_block.current_predicate = CurrentScopePredicate();
     BufferTouch buffer_touch = current_block.MakeBufferTouch(out_, node->buffer, node->indices,
                                                              touch_type, known_value_expr);
     current_block.touch_points.push_back(buffer_touch);
@@ -791,7 +792,7 @@ std::pair<BufferTouch, Map<Var, Range>> ControlFlowGraph::ControlFlowBlock::Make
   // implied by solving for the axis variables, and any additional
   // statements resulting from unpacking the expression contained in
   // builtin::assume().
-  PrimExpr scope_predicate = normalize_expr(current_block.scope_predicate);
+  PrimExpr scope_predicate = normalize_expr(current_block.current_predicate);
   transform_predicate = normalize_expr(transform_predicate);
 
   known_value_expr = local_analyzer.Simplify(normalize_expr(known_value_expr));

--- a/src/tir/analysis/control_flow_graph.cc
+++ b/src/tir/analysis/control_flow_graph.cc
@@ -792,14 +792,14 @@ std::pair<BufferTouch, Map<Var, Range>> ControlFlowGraph::ControlFlowBlock::Make
   // implied by solving for the axis variables, and any additional
   // statements resulting from unpacking the expression contained in
   // builtin::assume().
-  PrimExpr scope_predicate = normalize_expr(current_block.current_predicate);
+  PrimExpr current_predicate = normalize_expr(current_block.current_predicate);
   transform_predicate = normalize_expr(transform_predicate);
 
   known_value_expr = local_analyzer.Simplify(normalize_expr(known_value_expr));
 
   // Deliberately use an analyzer without scope-based information,
-  // to avoid simplifying `scope_predicate` to True.
-  PrimExpr predicate_expr = local_analyzer.Simplify(transform_predicate && scope_predicate);
+  // to avoid simplifying `current_predicate` to True.
+  PrimExpr predicate_expr = local_analyzer.Simplify(transform_predicate && current_predicate);
 
   BufferTouch buffer_touch = {buf, predicate_expr, known_value_expr, loop_var_expressions,
                               touch_type};

--- a/src/tir/analysis/control_flow_graph.h
+++ b/src/tir/analysis/control_flow_graph.h
@@ -530,9 +530,6 @@ class ControlFlowGraph {
     /*! \brief Predicate that must be true to have reached this block */
     PrimExpr scope_predicate{Bool(true)};
 
-    /*! \brief Predicate that are true in this block */
-    PrimExpr current_predicate{Bool(true)};
-
     /*! \brief All known values prior to executing the block */
     BufferState known_at_block_start;
 
@@ -577,11 +574,14 @@ class ControlFlowGraph {
      *
      * \param known_expr_value The value being written to the buffer
      *
+     * \param  current_predicate The aggregate of scope predicate and
+     * additional predicate introduced due to assume statement
+     * 
      * \returns The newly generated BufferTouch
      */
     BufferTouch MakeBufferTouch(ControlFlowGraph* graph, const Buffer& buf,
                                 const Array<PrimExpr>& indices, BufferTouch::AccessType touch_type,
-                                PrimExpr known_value_expr) const;
+                                PrimExpr known_value_expr, PrimExpr current_predicate = Bool(true)) const;
 
     /* \brief Construct a BufferTouch instance as if it occurred in
      * this ControlFlowBlock
@@ -601,6 +601,9 @@ class ControlFlowGraph {
      *
      * \param known_expr_value The value being written to the buffer
      *
+     * \param current_predicate The aggregate of scope predicate and
+     * additional predicate introduced due to assume statement
+     * 
      * \returns The newly generated BufferTouch, and a map specifying
      * all free parameters that may occur in the BufferTouch's
      * predicate.
@@ -609,7 +612,8 @@ class ControlFlowGraph {
                                                             Array<Var> index_variables,
                                                             Array<PrimExpr> indices,
                                                             BufferTouch::AccessType touch_type,
-                                                            PrimExpr known_value_expr) const;
+                                                            PrimExpr known_value_expr,
+                                                            PrimExpr current_predicate = Bool(true)) const;
   };
   friend std::ostream& operator<<(std::ostream& os, const ControlFlowBlock& pattern);
 

--- a/src/tir/analysis/control_flow_graph.h
+++ b/src/tir/analysis/control_flow_graph.h
@@ -530,6 +530,9 @@ class ControlFlowGraph {
     /*! \brief Predicate that must be true to have reached this block */
     PrimExpr scope_predicate{Bool(true)};
 
+    /*! \brief Predicate that are true in this block */
+    PrimExpr current_predicate{Bool(true)};
+
     /*! \brief All known values prior to executing the block */
     BufferState known_at_block_start;
 

--- a/src/tir/analysis/control_flow_graph.h
+++ b/src/tir/analysis/control_flow_graph.h
@@ -576,12 +576,13 @@ class ControlFlowGraph {
      *
      * \param  current_predicate The aggregate of scope predicate and
      * additional predicate introduced due to assume statement
-     * 
+     *
      * \returns The newly generated BufferTouch
      */
     BufferTouch MakeBufferTouch(ControlFlowGraph* graph, const Buffer& buf,
                                 const Array<PrimExpr>& indices, BufferTouch::AccessType touch_type,
-                                PrimExpr known_value_expr, PrimExpr current_predicate = Bool(true)) const;
+                                PrimExpr known_value_expr,
+                                PrimExpr current_predicate = Bool(true)) const;
 
     /* \brief Construct a BufferTouch instance as if it occurred in
      * this ControlFlowBlock
@@ -603,17 +604,15 @@ class ControlFlowGraph {
      *
      * \param current_predicate The aggregate of scope predicate and
      * additional predicate introduced due to assume statement
-     * 
+     *
      * \returns The newly generated BufferTouch, and a map specifying
      * all free parameters that may occur in the BufferTouch's
      * predicate.
      */
-    std::pair<BufferTouch, Map<Var, Range>> MakeBufferTouch(const Buffer& buf,
-                                                            Array<Var> index_variables,
-                                                            Array<PrimExpr> indices,
-                                                            BufferTouch::AccessType touch_type,
-                                                            PrimExpr known_value_expr,
-                                                            PrimExpr current_predicate = Bool(true)) const;
+    std::pair<BufferTouch, Map<Var, Range>> MakeBufferTouch(
+        const Buffer& buf, Array<Var> index_variables, Array<PrimExpr> indices,
+        BufferTouch::AccessType touch_type, PrimExpr known_value_expr,
+        PrimExpr current_predicate = Bool(true)) const;
   };
   friend std::ostream& operator<<(std::ostream& os, const ControlFlowBlock& pattern);
 

--- a/tests/python/tir-transform/test_tir_transform_simplify.py
+++ b/tests/python/tir-transform/test_tir_transform_simplify.py
@@ -17,6 +17,7 @@
 import tvm
 import tvm.testing
 
+import pytest
 from tvm import te
 from tvm.script import tir as T
 
@@ -1650,56 +1651,56 @@ class TestSimplifyUsingPartiallyProvenBufferValueGather(BaseBeforeAfter):
             if i < 3 or 19 <= i:
                 T.evaluate(0)
 
-# This test is not completing and needs to be investigated further.
 
-# class TestSimplifyUsingPartiallyProvenBufferValueScatter(BaseBeforeAfter):
-#     """Propagate known buffer values in part of buffer.
+@pytest.mark.skip("Skipping because this test will hang")
+class TestSimplifyUsingPartiallyProvenBufferValueScatter(BaseBeforeAfter):
+    """Propagate known buffer values in part of buffer.
 
-#     Like TestSimplifyUsingPartiallyProvenBufferValueGather, but the
-#     compute loop is over the input buffer A, rather than the output
-#     buffer B.
-#     """
+    Like TestSimplifyUsingPartiallyProvenBufferValueGather, but the
+    compute loop is over the input buffer A, rather than the output
+    buffer B.
+    """
 
-#     propagate_knowns_to_prove_conditional = True
+    propagate_knowns_to_prove_conditional = True
 
-#     def before(A: T.Buffer(24, "int32"), B: T.Buffer(24, "int32"), F: T.Buffer(3, "int32")):
-#         # A has non-zero values only in the range 3 <= i < 17
-#         for i in T.serial(24):
-#             T.evaluate(T.assume(((3 <= i) and (i < 17)) or A[i] == 0))
+    def before(A: T.Buffer(24, "int32"), B: T.Buffer(24, "int32"), F: T.Buffer(3, "int32")):
+        # A has non-zero values only in the range 3 <= i < 17
+        for i in T.serial(24):
+            T.evaluate(T.assume(((3 <= i) and (i < 17)) or A[i] == 0))
 
-#         for i in T.serial(24):
-#             B[i] = 0
+        for i in T.serial(24):
+            B[i] = 0
 
-#         # After convoluting with F, B has non-zero values only in the
-#         # range 3 <= i < 19.
-#         for i in T.serial(24):
-#             for f in T.serial(3):
-#                 if i + f >= 0 and i + f < 24:
-#                     B[i + f] = B[i + f] + A[i] * F[f]
+        # After convoluting with F, B has non-zero values only in the
+        # range 3 <= i < 19.
+        for i in T.serial(24):
+            for f in T.serial(3):
+                if i + f >= 0 and i + f < 24:
+                    B[i + f] = B[i + f] + A[i] * F[f]
 
-#         # Which means that this loop is unnecessary.  It actually gets
-#         # removed in tir.transform.RemoveNoOp, but here we want to
-#         # test that the simplification works as intended.
-#         for i in T.serial(24):
-#             if i < 3 or 19 <= i:
-#                 if B[i] != 0:
-#                     B[i] = 0
+        # Which means that this loop is unnecessary.  It actually gets
+        # removed in tir.transform.RemoveNoOp, but here we want to
+        # test that the simplification works as intended.
+        for i in T.serial(24):
+            if i < 3 or 19 <= i:
+                if B[i] != 0:
+                    B[i] = 0
 
-#     def expected(A: T.Buffer(24, "int32"), B: T.Buffer(24, "int32"), F: T.Buffer(3, "int32")):
-#         for i in T.serial(24):
-#             T.evaluate(T.assume(((3 <= i) and (i < 17)) or A[i] == 0))
+    def expected(A: T.Buffer(24, "int32"), B: T.Buffer(24, "int32"), F: T.Buffer(3, "int32")):
+        for i in T.serial(24):
+            T.evaluate(T.assume(((3 <= i) and (i < 17)) or A[i] == 0))
 
-#         for i in T.serial(24):
-#             B[i] = 0
+        for i in T.serial(24):
+            B[i] = 0
 
-#         for i in T.serial(24):
-#             for f in T.serial(3):
-#                 if i + f < 24:
-#                     B[i + f] = B[i + f] + A[i] * F[f]
+        for i in T.serial(24):
+            for f in T.serial(3):
+                if i + f < 24:
+                    B[i + f] = B[i + f] + A[i] * F[f]
 
-#         for i in T.serial(24):
-#             if i < 3 or 19 <= i:
-#                 T.evaluate(0)
+        for i in T.serial(24):
+            if i < 3 or 19 <= i:
+                T.evaluate(0)
 
 
 class TestSimplifyBufferStore(BaseBeforeAfter):

--- a/tests/python/tir-transform/test_tir_transform_simplify.py
+++ b/tests/python/tir-transform/test_tir_transform_simplify.py
@@ -1326,7 +1326,7 @@ class TestSimplifyUsingPartiallyKnownBufferExpression(BaseBeforeAfter):
                 A[i] = 42
 
 
-class TestAssume(BaseBeforeAfter):
+class TestAssumeMayContainAdditionalPredicate(BaseBeforeAfter):
     """An assumption about buffer contents may apply to only part of a buffer
     Like TestSimplifyUsingPartiallyKnownBufferConditional, but the
     conditional is expressed as part of T.assume, instead of in the
@@ -1344,15 +1344,7 @@ class TestAssume(BaseBeforeAfter):
                 if A[i] == 0:
                     A[i] = 42
 
-    def expected(A: T.Buffer(16, "int32")):
-        for i in T.serial(16):
-            T.evaluate(T.assume(i < 14 or A[i] == 0))
-
-        for i in T.serial(16):
-            if i < 14:
-                if A[i] == 0:
-                    A[i] = 42
-
+    expected = before
 
 class TestNoSimplificationIfPredicateNotMet(BaseBeforeAfter):
     """Assumptions about buffer contents must apply to all cases to be used

--- a/tests/python/tir-transform/test_tir_transform_simplify.py
+++ b/tests/python/tir-transform/test_tir_transform_simplify.py
@@ -1325,6 +1325,7 @@ class TestSimplifyUsingPartiallyKnownBufferExpression(BaseBeforeAfter):
             if 14 <= i:
                 A[i] = 42
 
+
 class TestAssume(BaseBeforeAfter):
     """An assumption about buffer contents may apply to only part of a buffer
     Like TestSimplifyUsingPartiallyKnownBufferConditional, but the
@@ -1348,9 +1349,10 @@ class TestAssume(BaseBeforeAfter):
             T.evaluate(T.assume(i < 14 or A[i] == 0))
 
         for i in T.serial(16):
-            if i<14:
+            if i < 14:
                 if A[i] == 0:
                     A[i] = 42
+
 
 class TestNoSimplificationIfPredicateNotMet(BaseBeforeAfter):
     """Assumptions about buffer contents must apply to all cases to be used

--- a/tests/python/tir-transform/test_tir_transform_simplify.py
+++ b/tests/python/tir-transform/test_tir_transform_simplify.py
@@ -1346,6 +1346,7 @@ class TestAssumeMayContainAdditionalPredicate(BaseBeforeAfter):
 
     expected = before
 
+
 class TestNoSimplificationIfPredicateNotMet(BaseBeforeAfter):
     """Assumptions about buffer contents must apply to all cases to be used
 


### PR DESCRIPTION
The assume statement was not understanding the complete expression present inside. The predicate was not getting appended along with the buffer access. The additional predicate was added to the conditions list but was not appended while creating the buffer touch . This fix helps to resolve it. 

The issue is that the "TestSimplifyUsingPartiallyProvenBufferValueScatter" test is not completing after the fix. Rest of the tests are passing. I guess the issue is not with the fix but might be somewhere else. 

For reference : https://github.com/apache/tvm/issues/16577

 @Lunderberg, @jverma-quic and @quic-sanirudh Can you please review and point to the possible issue with the above test. 