### PR TITLE
[Relax] Eager free original weights in transform_params

### DIFF
--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -38,6 +38,9 @@
 namespace tvm {
 namespace relax {
 
+constexpr const char* kLiftTransformConsumeParams = "relax.lift_transform_params.consume_params";
+TVM_REGISTER_PASS_CONFIG_OPTION(kLiftTransformConsumeParams, Bool);
+
 namespace {
 
 struct CollectInfo {
@@ -540,7 +543,9 @@ Pass LiftTransformParams() {
         if (ends_with(func_name, "transform_params")) {
           func = WithAttr(func, tvm::attr::kGlobalSymbol, gvar->name_hint);
           func = BundleModelParams(func);
-          func = Downcast<Function>(ConsumeBundledParams()(func));
+          if (pc->GetConfig<Bool>(kLiftTransformConsumeParams).value_or(Bool(false))) {
+            func = Downcast<Function>(ConsumeBundledParams()(func));
+          }
           to_add[gvar] = func;
         } else if (ends_with(func_name, "_runtime")) {
           std::string name(func_name.begin(), func_name.end() - sizeof("_runtime") + 1);

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -449,6 +449,48 @@ inline bool ends_with(const std::string& value, const std::string& ending) {
          std::equal(ending.rbegin(), ending.rend(), value.rbegin());
 }
 
+/*!
+ * \brief A mutator to rewrite the transform_params functions to release the original weight after
+ * use. This is done by using builtin.tuple_reset_item to reset the bundled weight tuple. It
+ * requires `BundleModelParams` to be called before this mutator.
+ */
+class ConsumeBundledParams : public ExprMutator {
+ public:
+  void VisitBinding_(const VarBindingNode* binding, const TupleGetItemNode* tuple_get_item) final {
+    static const auto& call_pure_packed = Op::Get("relax.call_pure_packed");
+    static const auto& builtin_tuple_reset_item = ExternFunc("vm.builtin.tuple_reset_item");
+    if (tuple_get_item->tuple.same_as(params_)) {
+      if (auto it = param_remap_.find(tuple_get_item->index); it != param_remap_.end()) {
+        ReEmitBinding(binding, it->second);
+        return;
+      }
+      ExprMutator::VisitBinding_(binding, tuple_get_item);
+      auto new_var = VisitExpr(binding->var);
+      param_remap_[tuple_get_item->index] = new_var;
+      builder_->Emit(
+          Call(call_pure_packed,
+               {builtin_tuple_reset_item, tuple_get_item->tuple, PrimValue(tuple_get_item->index)},
+               tvm::Attrs(), {TupleStructInfo(Array<StructInfo>{})}));
+    } else {
+      ExprMutator::VisitBinding_(binding, tuple_get_item);
+    }
+  }
+
+  Expr VisitExpr_(const FunctionNode* func) final {
+    auto opt_num_input = func->GetAttr<Integer>(attr::kNumInput);
+    ICHECK(opt_num_input.defined());
+    auto num_input = opt_num_input.value()->value;
+    ICHECK_EQ(func->params.size(), num_input + 1);
+    params_ = func->params.back();
+    ICHECK(params_->struct_info_.as<TupleStructInfoNode>());
+    return ExprMutator::VisitExpr_(func);
+  }
+
+ private:
+  Var params_;
+  std::unordered_map<int, Expr> param_remap_;
+};
+
 }  // namespace
 
 namespace transform {
@@ -498,6 +540,7 @@ Pass LiftTransformParams() {
         if (ends_with(func_name, "transform_params")) {
           func = WithAttr(func, tvm::attr::kGlobalSymbol, gvar->name_hint);
           func = BundleModelParams(func);
+          func = Downcast<Function>(ConsumeBundledParams()(func));
           to_add[gvar] = func;
         } else if (ends_with(func_name, "_runtime")) {
           std::string name(func_name.begin(), func_name.end() - sizeof("_runtime") + 1);

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -499,6 +499,11 @@ TVM_REGISTER_GLOBAL("vm.builtin.invoke_debug_func")
 TVM_REGISTER_GLOBAL("vm.builtin.tuple_getitem")
     .set_body_typed([](runtime::Array<ObjectRef> arr, int64_t index) { return arr[index]; });
 
+TVM_REGISTER_GLOBAL("vm.builtin.tuple_reset_item")
+    .set_body_typed([](runtime::Array<ObjectRef> arr, int64_t index) {
+      arr.Set(index, ObjectRef(nullptr));
+    });
+
 TVM_REGISTER_GLOBAL("vm.builtin.make_tuple").set_body([](TVMArgs args, TVMRetValue* rv) {
   runtime::Array<ObjectRef> arr;
   for (int i = 0; i < args.num_args; ++i) {

--- a/tests/python/relax/test_transform_lift_transform_params.py
+++ b/tests/python/relax/test_transform_lift_transform_params.py
@@ -119,12 +119,24 @@ def test_basic():
             cls = Expected
             with R.dataflow():
                 lv1: R.Tensor((3, 16, 3, 3), dtype="float32") = params[0]
+                _1: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(0)),
+                    sinfo_args=(R.Tuple,),
+                )
                 lv2 = R.call_tir(
                     cls.transform_layout_IOHW_to_OIHW,
                     (lv1,),
                     out_sinfo=R.Tensor((16, 3, 3, 3), dtype="float32"),
                 )
                 lv: R.Tensor((16, 16, 3, 3), dtype="float32") = params[1]
+                _2: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(1)),
+                    sinfo_args=(R.Tuple,),
+                )
                 gv: R.Tuple(
                     R.Tensor((16, 16, 3, 3), dtype="float32"),
                     R.Tensor((16, 3, 3, 3), dtype="float32"),
@@ -207,10 +219,16 @@ def test_tuple():
             R.func_attr({"num_input": 0})
             with R.dataflow():
                 lv = params[0]
+                _1: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(0)),
+                    sinfo_args=(R.Tuple,),
+                )
                 lv0 = (lv,)
                 lv1 = (lv0,)
-                lv2 = params[0]
-                lv3 = params[0]
+                lv2 = lv
+                lv3 = lv
                 gv = (lv2, lv3)
                 R.output(gv)
             return gv
@@ -259,8 +277,26 @@ def test_condition():
             R.func_attr({"num_input": 0})
             with R.dataflow():
                 lv: R.Tensor((16, 16, 3, 3), dtype="float32") = params[0]
+                _1: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(0)),
+                    sinfo_args=(R.Tuple,),
+                )
                 lv1: R.Tensor((16, 16, 3, 3), dtype="float32") = params[1]
+                _2: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(1)),
+                    sinfo_args=(R.Tuple,),
+                )
                 lv2: R.Tensor((), dtype="bool") = params[2]
+                _3: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(2)),
+                    sinfo_args=(R.Tuple,),
+                )
                 gv: R.Tuple(
                     R.Tensor((16, 16, 3, 3), dtype="float32"),
                     R.Tensor((16, 16, 3, 3), dtype="float32"),
@@ -349,6 +385,12 @@ def test_multiple_functions():
             R.func_attr({"num_input": 0})
             with R.dataflow():
                 lv: R.Tensor((256, 256), dtype="float32") = params[0]
+                _1: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(0)),
+                    sinfo_args=(R.Tuple,),
+                )
                 lv1: R.Tensor((256, 256), dtype="float32") = R.permute_dims(lv, axes=[1, 0])
                 gv: R.Tuple(R.Tensor((256, 256), dtype="float32")) = (lv1,)
                 R.output(gv)
@@ -372,6 +414,12 @@ def test_multiple_functions():
             R.func_attr({"num_input": 0})
             with R.dataflow():
                 lv: R.Tensor((128, 256), dtype="float32") = params[0]
+                _1: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(0)),
+                    sinfo_args=(R.Tuple,),
+                )
                 lv1: R.Tensor((256, 128), dtype="float32") = R.permute_dims(lv, axes=[1, 0])
                 gv: R.Tuple(R.Tensor((256, 128), dtype="float32")) = (lv1,)
                 R.output(gv)
@@ -430,6 +478,12 @@ def test_stop_lifting():
             R.func_attr({"num_input": 0})
             with R.dataflow():
                 lv: R.Tensor((256, 256), dtype="float32") = params[0]
+                _1: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(0)),
+                    sinfo_args=(R.Tuple,),
+                )
                 lv1: R.Tensor((256, 256), dtype="float32") = R.permute_dims(lv, axes=[1, 0])
                 gv: R.Tuple(R.Tensor((256, 256), dtype="float32")) = (lv1,)
                 R.output(gv)
@@ -614,6 +668,12 @@ def test_symbolic_var_from_shape():
             cls = Expected
             with R.dataflow():
                 B = params[0]
+                _1: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(0)),
+                    sinfo_args=(R.Tuple,),
+                )
                 # extra_symbolic_vars = params[1]
                 B_slice = R.call_tir(
                     cls.slice,
@@ -679,8 +739,20 @@ def test_symbolic_var_in_param_shape():
             m = T.int64()
             with R.dataflow():
                 lv1: R.Tensor((16, m, 3, 3), dtype="float32") = params[0]
+                _1: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(0)),
+                    sinfo_args=(R.Tuple,),
+                )
                 lv2: R.Tensor((16, m, 3, 3), dtype="float32") = R.add(lv1, R.const(1, "float32"))
                 lv: R.Tensor((16, m, 3, 3), dtype="float32") = params[1]
+                _2: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(1)),
+                    sinfo_args=(R.Tuple,),
+                )
                 gv: R.Tuple(
                     R.Tensor((16, m, 3, 3), dtype="float32"),
                     R.Tensor((16, m, 3, 3), dtype="float32"),
@@ -771,6 +843,12 @@ def test_symbolic_var_defined_in_params_but_used_in_weights():
             k = T.int64()
             with R.dataflow():
                 lv: R.Tensor((k,), dtype="float32") = params[0]
+                _1: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(0)),
+                    sinfo_args=(R.Tuple,),
+                )
                 gv: R.Tuple(R.Tensor((k,), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
@@ -839,6 +917,12 @@ def test_only_lift_when_variable_uses_constants():
             with R.dataflow():
                 offset = R.ones([16], "int32")
                 B = params[0]
+                _1: R.Tuple = R.call_pure_packed(
+                    "vm.builtin.tuple_reset_item",
+                    params,
+                    R.prim_value(T.int32(0)),
+                    sinfo_args=(R.Tuple,),
+                )
                 B_offset = R.add(B, offset)
                 output = (B_offset,)
                 R.output(output)


### PR DESCRIPTION
This updates `LiftTransformParams` to always free original weight in the bundled weights tuple. This prevents the issue that `transform_params` consumes memory with double weight size. See discussion https://discuss.tvm.apache.org/t/inplacetransformparams/16323.

cc @tqchen @MasterJH5574 @Lunderberg 