### PR TITLE
[Relax] Implement StructInfoPattern for dataflow pattern matching

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -250,6 +250,28 @@ TVM_DLL bool IsBaseOf(const StructInfo& base, const StructInfo& derived,
                       arith::Analyzer* ana = nullptr);
 
 /*!
+ * \brief Return the condition for which base is a superset of derived
+ *
+ * This function returns finer-grained conditions for kFailL2 than StructInfoBaseCheck
+ *
+ * If the returned expression is true, or simplifies to true, then
+ * base is a superset of derived.  If the returned expression is
+ * false, or simplifies to false, then base is not a superset of
+ * derived.
+ *
+ * If the returned expression is neither true nor false, it is an
+ * expression in terms of the symbolic variables available in `base`
+ * and `derived`.
+ *
+ * \param base The base struct info.
+ * \param derived The derived struct info.
+ * \return Whether base is a base of derived.
+ *
+ * \sa BaseCheckResult
+ */
+TVM_DLL PrimExpr StructInfoBaseCheckPrecondition(const StructInfo& base, const StructInfo& derived);
+
+/*!
  * \brief Unify the two struct info to their least common ancestor.
  *
  * \param lhs The left operand.

--- a/include/tvm/relax/dataflow_pattern.h
+++ b/include/tvm/relax/dataflow_pattern.h
@@ -54,6 +54,7 @@ class OrPattern;
 class AndPattern;
 class NotPattern;
 class ShapePattern;
+class StructInfoPattern;
 class TypePattern;
 class DataTypePattern;
 class AttrPattern;
@@ -112,6 +113,8 @@ class DFPattern : public ObjectRef {
   TVM_DLL NotPattern operator~() const;
   /*! \brief Syntatic Sugar for creating an AttrPattern */
   TVM_DLL AttrPattern HasAttr(const Map<String, ObjectRef>& attrs) const;
+  /*! \brief Syntatic Sugar for creating a StructInfoPattern */
+  TVM_DLL StructInfoPattern HasStructInfo(const StructInfo& struct_info) const;
   /*! \brief Syntatic Sugar for creating a TypePattern */
   TVM_DLL TypePattern HasType(const Type& type) const;
   /*! \brief Syntatic Sugar for creating a DataTypePattern with a DataType */
@@ -763,6 +766,30 @@ class TypePattern : public DFPattern {
  public:
   TVM_DLL TypePattern(DFPattern pattern, Type type);
   TVM_DEFINE_OBJECT_REF_METHODS(TypePattern, DFPattern, TypePatternNode);
+};
+
+/*!
+ * \brief Pattern for matching a certain struct info.
+ * \sa StructInfoPattern
+ */
+class StructInfoPatternNode : public DFPatternNode {
+ public:
+  DFPattern pattern;      /*!< The pattern to match */
+  StructInfo struct_info; /*!< The type to match */
+
+  void VisitAttrs(tvm::AttrVisitor* v) {
+    v->Visit("pattern", &pattern);
+    v->Visit("struct_info", &struct_info);
+  }
+
+  static constexpr const char* _type_key = "relax.dpl.StructInfoPattern";
+  TVM_DECLARE_FINAL_OBJECT_INFO(StructInfoPatternNode, DFPatternNode);
+};
+
+class StructInfoPattern : public DFPattern {
+ public:
+  TVM_DLL StructInfoPattern(DFPattern pattern, StructInfo struct_info);
+  TVM_DEFINE_OBJECT_REF_METHODS(StructInfoPattern, DFPattern, StructInfoPatternNode);
 };
 
 /*!

--- a/include/tvm/relax/dataflow_pattern_functor.h
+++ b/include/tvm/relax/dataflow_pattern_functor.h
@@ -94,6 +94,8 @@ class DFPatternFunctor<R(const DFPattern& n, Args...)> {
   virtual R VisitDFPattern_(const TupleGetItemPatternNode* op,
                             Args... args) DFPATTERN_FUNCTOR_DEFAULT;
   virtual R VisitDFPattern_(const TuplePatternNode* op, Args... args) DFPATTERN_FUNCTOR_DEFAULT;
+  virtual R VisitDFPattern_(const StructInfoPatternNode* op,
+                            Args... args) DFPATTERN_FUNCTOR_DEFAULT;
   virtual R VisitDFPattern_(const TypePatternNode* op, Args... args) DFPATTERN_FUNCTOR_DEFAULT;
   virtual R VisitDFPattern_(const WildcardPatternNode* op, Args... args) DFPATTERN_FUNCTOR_DEFAULT;
   virtual R VisitDFPattern_(const VarPatternNode* op, Args... args) DFPATTERN_FUNCTOR_DEFAULT;
@@ -129,6 +131,7 @@ class DFPatternFunctor<R(const DFPattern& n, Args...)> {
     RELAX_DFPATTERN_FUNCTOR_DISPATCH(ShapePatternNode);
     RELAX_DFPATTERN_FUNCTOR_DISPATCH(TupleGetItemPatternNode);
     RELAX_DFPATTERN_FUNCTOR_DISPATCH(TuplePatternNode);
+    RELAX_DFPATTERN_FUNCTOR_DISPATCH(StructInfoPatternNode);
     RELAX_DFPATTERN_FUNCTOR_DISPATCH(TypePatternNode);
     RELAX_DFPATTERN_FUNCTOR_DISPATCH(WildcardPatternNode);
     RELAX_DFPATTERN_FUNCTOR_DISPATCH(VarPatternNode);
@@ -163,6 +166,7 @@ class DFPatternVisitor : public DFPatternFunctor<void(const DFPattern&)> {
   void VisitDFPattern_(const ShapePatternNode* op) override;
   void VisitDFPattern_(const TupleGetItemPatternNode* op) override;
   void VisitDFPattern_(const TuplePatternNode* op) override;
+  void VisitDFPattern_(const StructInfoPatternNode* op) override;
   void VisitDFPattern_(const TypePatternNode* op) override;
   void VisitDFPattern_(const WildcardPatternNode* op) override;
   void VisitDFPattern_(const VarPatternNode* op) override;

--- a/python/tvm/relax/dpl/pattern.py
+++ b/python/tvm/relax/dpl/pattern.py
@@ -122,6 +122,9 @@ class DFPattern(Node):
         attrs = make_node("DictAttrs", **attrs)
         return AttrPattern(self, attrs)
 
+    def has_struct_info(self, struct_info: "StructInfo") -> "StructInfoPattern":
+        return StructInfoPattern(self, struct_info)
+
     def has_type(self, ttype: tvm.ir.type.Type) -> "TypePattern":
         """
         Add a type constraint to this pattern
@@ -573,6 +576,27 @@ class WildcardPattern(DFPattern):
 
     def __init__(self):
         self.__init_handle_by_constructor__(ffi.WildcardPattern)  # type: ignore
+
+
+@register_df_node
+class StructInfoPattern(DFPattern):
+    """A pattern that matches another pattern with a certain StructInfo
+
+    Parameters
+    ----------
+    pattern: tvm.relax.dpl.DFPattern
+        The input pattern that needs type annotation.
+
+    struct_info: tvm.relax.StructInfo
+        The struct info to match against
+    """
+
+    def __init__(self, pattern: "DFPattern", struct_info: "StructInfo"):
+        self.__init_handle_by_constructor__(
+            ffi.StructInfoPattern,
+            pattern,
+            struct_info,
+        )  # type: ignore
 
 
 @register_df_node

--- a/python/tvm/relax/frontend/nn/core.py
+++ b/python/tvm/relax/frontend/nn/core.py
@@ -48,7 +48,7 @@ from tvm.runtime import ndarray
 from tvm.runtime.relax_vm import VirtualMachine
 from tvm.target import Target
 
-from ... import expr as rx
+from .... import relax as rx
 from ...block_builder import BlockBuilder
 from ...struct_info import (
     ObjectStructInfo,
@@ -125,6 +125,16 @@ class Tensor(_TensorOp):
     def from_scalar(data: Union[int, float], dtype: str) -> "Tensor":
         """Construct a tensor from a scalar with dtype specified."""
         return Tensor(_expr=rx.const(data, dtype=dtype))
+
+    @staticmethod
+    def from_struct_info(struct_info: rx.TensorStructInfo, name: str = "tensor") -> "Tensor":
+        """Construct a nn.Tensor from relax TensorStructInfo"""
+        return Tensor(
+            _expr=rx.Var(
+                name_hint=name,
+                struct_info=struct_info,
+            )
+        )
 
     @staticmethod
     def placeholder(

--- a/src/relax/ir/dataflow_pattern_functor.cc
+++ b/src/relax/ir/dataflow_pattern_functor.cc
@@ -98,6 +98,10 @@ void DFPatternVisitor::VisitDFPattern_(const UnorderedTuplePatternNode* op) {
 
 void DFPatternVisitor::VisitDFPattern_(const TypePatternNode* op) { VisitDFPattern(op->pattern); }
 
+void DFPatternVisitor::VisitDFPattern_(const StructInfoPatternNode* op) {
+  VisitDFPattern(op->pattern);
+}
+
 // leaf nodes.
 void DFPatternVisitor::VisitDFPattern_(const PrimArrPatternNode* op) {}
 void DFPatternVisitor::VisitDFPattern_(const VarPatternNode* op) {}

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -1720,5 +1720,174 @@ def test_iterative_rewrite_with_removed_intermediates():
     tvm.ir.assert_structural_equal(expected, after)
 
 
+def test_wildcard_with_struct_info_updates_when_matching():
+    """A DFPattern may be restricted to a specific StructInfo"""
+
+    pat_lhs = wildcard().has_struct_info(R.Tensor([2, 3]))
+    pat_rhs = wildcard().has_struct_info(R.Tensor([2, 3]))
+    pat = is_op("relax.add")(pat_lhs, pat_rhs)
+
+    def rewriter(expr, matches):
+        lhs = matches[pat_lhs]
+        rhs = matches[pat_rhs]
+        return rx.op.multiply(lhs, rhs)
+
+    @R.function(private=True)
+    def before():
+        with R.dataflow():
+            A = R.zeros([2, 3], "int32")
+            B = R.ones([2, 3], "int32")
+            C = R.add(A, B)
+
+            R.output(C)
+        return C
+
+    @R.function(private=True)
+    def expected():
+        with R.dataflow():
+            A = R.zeros([2, 3], "int32")
+            B = R.ones([2, 3], "int32")
+            C = R.multiply(A, B)
+
+            R.output(C)
+        return C
+
+    after = rewrite_call(pat, rewriter, before)
+    tvm.ir.assert_structural_equal(expected, after)
+
+
+def test_wildcard_with_struct_info_is_no_op_when_not_matching():
+    """StructInfoPattern requires the StructInfo provided
+
+    Here, the pattern would match, expect that the function has
+    `R.Tensor([16,32])`, and the pattern requires `R.Tensor([2,3])`.
+    """
+
+    pat_lhs = wildcard().has_struct_info(R.Tensor([2, 3]))
+    pat_rhs = wildcard().has_struct_info(R.Tensor([2, 3]))
+    pat = is_op("relax.add")(pat_lhs, pat_rhs)
+
+    def rewriter(expr, matches):
+        lhs = matches[pat_lhs]
+        rhs = matches[pat_rhs]
+        return rx.op.multiply(lhs, rhs)
+
+    @R.function(private=True)
+    def before():
+        with R.dataflow():
+            # This R.add has the same shape as the pattern, and will
+            # be updated.
+            A = R.zeros([16, 32], "int32")
+            B = R.ones([16, 32], "int32")
+            C = R.add(A, B)
+
+            R.output(C)
+        return C
+
+    expected = before
+
+    after = rewrite_call(pat, rewriter, before)
+    tvm.ir.assert_structural_equal(expected, after)
+
+
+def test_wildcard_struct_info_for_unknown_dtype():
+    """TensorStructInfo with unknown dtype allows any dtype"""
+
+    pat_lhs = wildcard().has_struct_info(R.Tensor([2, 3]))
+    pat_rhs = wildcard().has_struct_info(R.Tensor([2, 3]))
+    pat = is_op("relax.add")(pat_lhs, pat_rhs)
+
+    def rewriter(expr, matches):
+        lhs = matches[pat_lhs]
+        rhs = matches[pat_rhs]
+        return rx.op.multiply(lhs, rhs)
+
+    @R.function(private=True)
+    def before():
+        with R.dataflow():
+            A = R.zeros([2, 3], "int32")
+            B = R.ones([2, 3], "int32")
+            C = R.add(A, B)
+
+            D = R.zeros([2, 3], "float32")
+            E = R.ones([2, 3], "float32")
+            F = R.add(D, E)
+
+            output = (C, F)
+            R.output(output)
+        return output
+
+    @R.function(private=True)
+    def expected():
+        with R.dataflow():
+            A = R.zeros([2, 3], "int32")
+            B = R.ones([2, 3], "int32")
+            C = R.multiply(A, B)
+
+            D = R.zeros([2, 3], "float32")
+            E = R.ones([2, 3], "float32")
+            F = R.multiply(D, E)
+
+            output = (C, F)
+            R.output(output)
+        return output
+
+    after = rewrite_call(pat, rewriter, before)
+    tvm.ir.assert_structural_equal(expected, after)
+
+
+def test_wildcard_struct_info_with_symbolic_vars():
+    """StructInfoPattern may define symbolic vars
+
+    This test finds an elementwise `R.add`, while ignoring a
+    broadcasted `R.add`.
+    """
+
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
+
+    pat_lhs = wildcard().has_struct_info(R.Tensor([m, n]))
+    pat_rhs = wildcard().has_struct_info(R.Tensor([m, n]))
+    pat = is_op("relax.add")(pat_lhs, pat_rhs)
+
+    def rewriter(expr, matches):
+        lhs = matches[pat_lhs]
+        rhs = matches[pat_rhs]
+        return rx.op.multiply(lhs, rhs)
+
+    @R.function(private=True)
+    def before():
+        with R.dataflow():
+            A = R.zeros([64, 128], "int32")
+            B = R.ones([64, 128], "int32")
+            C = R.add(A, B)
+
+            D = R.zeros([64, 128], "float32")
+            E = R.ones([1, 128], "float32")
+            F = R.add(D, E)
+
+            output = (C, F)
+            R.output(output)
+        return output
+
+    @R.function(private=True)
+    def expected():
+        with R.dataflow():
+            A = R.zeros([64, 128], "int32")
+            B = R.ones([64, 128], "int32")
+            C = R.multiply(A, B)
+
+            D = R.zeros([64, 128], "float32")
+            E = R.ones([1, 128], "float32")
+            F = R.add(D, E)
+
+            output = (C, F)
+            R.output(output)
+        return output
+
+    after = rewrite_call(pat, rewriter, before)
+    tvm.ir.assert_structural_equal(expected, after)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This commit implements `StructInfoPattern`, which can be applied to any existing `DFPattern`, and requires the expression to have a specific struct info.  Any symbolic variables that occur in the struct info are treated as free parameters, to be defined by the match.