### PR TITLE
[SLM][Bugfix] Output debug functions as impure 

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -994,7 +994,9 @@ class Function : public BaseFunc {
 
   /*!
    * \brief Mimics the constructor but without body Expr.
-   * \note `ret_struct_info` and `is_pure` are required, since it can not deduced by the body.
+   *
+   * \note `ret_struct_info` and `is_pure` are required, since they
+   * cannot be deduced from the body.
    */
   TVM_DLL static Function CreateEmpty(Array<Var> params, StructInfo ret_struct_info, bool is_pure,
                                       DictAttrs attrs = NullValue<DictAttrs>(), Span span = Span());

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -983,16 +983,21 @@ class FunctionNode : public BaseFuncNode {
 class Function : public BaseFunc {
  public:
   TVM_DLL explicit Function(Array<Var> params, Expr body, Optional<StructInfo> ret_struct_info,
-                            bool is_pure = true, DictAttrs attrs = NullValue<DictAttrs>(),
-                            Span span = Span());
+                            bool is_pure, DictAttrs attrs = NullValue<DictAttrs>(),
+                            Span span = Span())
+      : Function(params, body, ret_struct_info, Optional<Bool>(Bool(is_pure)), attrs, span) {}
+
+  TVM_DLL explicit Function(Array<Var> params, Expr body,
+                            Optional<StructInfo> ret_struct_info = NullOpt,
+                            Optional<Bool> is_pure = NullOpt,
+                            DictAttrs attrs = NullValue<DictAttrs>(), Span span = Span());
 
   /*!
    * \brief Mimics the constructor but without body Expr.
-   * \note ret_struct_info is required, since it can not deduced by the body.
+   * \note `ret_struct_info` and `is_pure` are required, since it can not deduced by the body.
    */
-  TVM_DLL static Function CreateEmpty(Array<Var> params, StructInfo ret_struct_info,
-                                      bool is_pure = true, DictAttrs attrs = NullValue<DictAttrs>(),
-                                      Span span = Span());
+  TVM_DLL static Function CreateEmpty(Array<Var> params, StructInfo ret_struct_info, bool is_pure,
+                                      DictAttrs attrs = NullValue<DictAttrs>(), Span span = Span());
 
   TVM_DEFINE_OBJECT_REF_METHODS(Function, BaseFunc, FunctionNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(FunctionNode);

--- a/include/tvm/script/ir_builder/relax/ir.h
+++ b/include/tvm/script/ir_builder/relax/ir.h
@@ -37,7 +37,7 @@ namespace relax {
  * \param is_private Whether the function is annotated as private.
  * \return The created ir_builder Function frame.
  */
-TVM_DLL FunctionFrame Function(const Bool& is_pure, const Bool& is_private);
+TVM_DLL FunctionFrame Function(const Optional<Bool>& is_pure, const Bool& is_private);
 
 /*!
  * \brief Add a parameter to the last function frame.

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -638,8 +638,8 @@ class BlockBuilder(Object):
         finally:
             self.end_scope()
 
-        # do not specify ret_struct_info and let constructor deduce
-        # from seqe.struct_info
+        # Do not specify ret_struct_info or purity, and let the
+        # constructor deduce from seqe.struct_info.
         func = rx.Function(self._func._params, seqe)
         for key, value in self._func._attrs.items():
             func = func.with_attr(key, value)

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -887,7 +887,7 @@ class Function(BaseFunc, Scriptable):
         params: List[Var],
         body: Expr,
         ret_struct_info: Optional[StructInfo] = None,
-        is_pure: Optional[bool] = True,
+        is_pure: Optional[bool] = None,
         attrs: Optional[tvm.ir.DictAttrs] = None,
         span: Optional[Span] = None,
     ) -> None:

--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -888,9 +888,10 @@ class Function(BaseFunc, Scriptable):
         body: Expr,
         ret_struct_info: Optional[StructInfo] = None,
         is_pure: Optional[bool] = None,
-        attrs: Optional[tvm.ir.DictAttrs] = None,
+        attrs: Optional[Union[tvm.ir.DictAttrs, Mapping]] = None,
         span: Optional[Span] = None,
     ) -> None:
+        attrs = Function._normalize_attrs(attrs)
         self.__init_handle_by_constructor__(
             _ffi_api.Function,
             params,
@@ -906,13 +907,22 @@ class Function(BaseFunc, Scriptable):
         params: List[Var],
         ret_struct_info: StructInfo,
         is_pure: Optional[bool] = True,
-        attrs: Optional[tvm.ir.DictAttrs] = None,
+        attrs: Optional[Union[tvm.ir.DictAttrs, Mapping]] = None,
         span: Optional[Span] = None,
     ):
         """Construct a relax.Function but without body"""
+        attrs = Function._normalize_attrs(attrs)
+
         return _ffi_api.FunctionCreateEmpty(
             params, ret_struct_info, is_pure, attrs, span
         )  # type: ignore
+
+    @staticmethod
+    def _normalize_attrs(attrs: Optional[Union[tvm.ir.DictAttrs, Mapping]]) -> tvm.ir.DictAttrs:
+        if attrs is None or isinstance(attrs, tvm.ir.DictAttrs):
+            return attrs
+        else:
+            return tvm.ir.make_node("DictAttrs", **attrs)
 
     def __call__(self, *args):
         """Invoke the global function.

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -1897,15 +1897,14 @@ def debug_func(
         else:
             raise TypeError(f"Unsupported type {type(arg)}")
 
+    func = rx.ExternFunc("vm.builtin.invoke_debug_func")
+    call = rx.Call(
+        func,
+        [io.effect, rx.StringImm(name), rx.StringImm(_line_info), *converted_args],
+        sinfo_args=[rx.ObjectStructInfo()],
+    )
     io.effect = BlockBuilder.current().emit(
-        rx.call_pure_packed(
-            "vm.builtin.invoke_debug_func",
-            io.effect,
-            rx.StringImm(name),
-            rx.StringImm(_line_info),
-            *converted_args,
-            sinfo_args=[rx.ObjectStructInfo()],
-        ),
+        call,
         name_hint=io.effect.name_hint,
     )
 

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -226,10 +226,13 @@ def function(is_pure: Optional[bool] = None, is_private: bool = False) -> frame.
     """Start a function frame.
     Parameters
     ----------
-    is_pure: bool
-        Whether the function is annotated as pure.
+    is_pure: Optional[bool]
+
+        Whether the function is pure.  If not explicitly specified,
+        will be inferred from the function's body.
 
     is_private : bool
+
         Whether the function is annotated as private.
 
     Returns

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -222,7 +222,7 @@ def to_vdevice(data: Expr, dst_vdevice: Union[py_str, VDevice]) -> Expr:
 ############################### Function ################################
 
 
-def function(is_pure: bool = True, is_private: bool = False) -> frame.FunctionFrame:
+def function(is_pure: Optional[bool] = None, is_private: bool = False) -> frame.FunctionFrame:
     """Start a function frame.
     Parameters
     ----------

--- a/python/tvm/script/parser/relax/entry.py
+++ b/python/tvm/script/parser/relax/entry.py
@@ -47,11 +47,12 @@ FType = TypeVar("FType", bound=_Callable)
 
 ############################## R.function ##############################
 
+
 # this formulation allows us to support having @R.function
 # appear as a decorator by itself or to have optional arguments
 # like @R.function(pure=False)
 def function(
-    f: Optional[FType] = None, pure: bool = True, private: bool = False
+    f: Optional[FType] = None, pure: Optional[bool] = None, private: bool = False
 ) -> Union[Function, FType]:
     # pylint: disable=unused-argument
     # (pure and private aren't used here, but are used later in parsing)

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -181,7 +181,7 @@ def visit_function_def(self: Parser, node: doc.FunctionDef) -> None:
         local_func_var = relax.Var(node.name, relax.FuncStructInfo(params_sinfo, ret_sinfo))
         self.var_table.add(node.name, local_func_var)
 
-    purity = find_decorator_annotation(node, "pure")
+    purity = find_decorator_annotation(node, "pure", default=None)
     # treat the function as private if we are inside another function
     # or if it has a privacy annotation
     privacy = is_inner_function or find_decorator_annotation(node, "private", default=False)
@@ -367,7 +367,6 @@ def visit_if(self: Parser, node: doc.If) -> None:
 @dispatch.register(token="relax", type_name="enter_token")
 def enter_token(self: Parser) -> Dict[str, Any]:
     def relax_call(self, *args) -> Expr:
-
         args = [convert_to_expr(arg) if isinstance(arg, tuple) else arg for arg in args]
 
         if all(isinstance(x, Expr) for x in args):

--- a/src/script/ir_builder/relax/frame.cc
+++ b/src/script/ir_builder/relax/frame.cc
@@ -66,7 +66,7 @@ void FunctionFrameNode::ExitWithScope() {
   tvm::relax::Function func(/*params=*/params,
                             /*body=*/body,
                             /*ret_struct_info=*/ret_struct_info,
-                            /*is_pure=*/is_pure.value_or(Bool(true))->value,
+                            /*is_pure=*/is_pure,
                             /*attrs=*/dict_attrs);
   // Step 2: Update IRModule.
   if (builder->frames.empty()) {

--- a/src/script/ir_builder/relax/ir.cc
+++ b/src/script/ir_builder/relax/ir.cc
@@ -52,7 +52,7 @@ TVM_STATIC_IR_FUNCTOR(Namer, vtable)
 
 /////////////////////////////// Function ////////////////////////////////
 
-FunctionFrame Function(const Bool& is_pure, const Bool& is_private) {
+FunctionFrame Function(const Optional<Bool>& is_pure, const Bool& is_private) {
   ObjectPtr<FunctionFrameNode> n = make_object<FunctionFrameNode>();
   const IRBuilder& ir_builder = IRBuilder::Current();
   Optional<tvm::IRModule> mod = NullOpt;

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -430,6 +430,7 @@ def test_inline_prim_func():
             y,
         ),
         R.Tensor(ndim=0, dtype="int32"),
+        is_pure=True,
     ).with_attr("global_symbol", "foo")
     new_mod = tvm.IRModule.from_expr(new_func)
     assert not rx.analysis.well_formed(new_mod, check_struct_info=False)
@@ -563,11 +564,45 @@ def test_unlabeled_impure():
     x = rx.Var("x", R.Tensor((), dtype="int32"))
     y = rx.Var("y")
     block = rx.BindingBlock([rx.VarBinding(y, rx.op.print(x, format="{}"))])
-    # print is impure, but the function is not labeled as impure
+    # Calls to `relax.op.print` are impure, but the function is not
+    # explicitly labeled as impure.  If there is no user-specified
+    # purity annotation, the function's purity is inferred from the
+    # body.
     func = rx.Function([x], rx.SeqExpr([block], x), R.Tensor((), dtype="int32")).with_attr(
         "global_symbol", "foo"
     )
+    assert not func.is_pure
     mod = rx.transform.Normalize()(tvm.IRModule.from_expr(func))
+    assert rx.analysis.well_formed(mod)
+
+
+def test_unlabeled_pure():
+    x = rx.Var("x", R.Tensor((), dtype="int32"))
+    # There are no calls to impure functions, so the `relax::Function`
+    # constructor infers that the function is pure.
+    func = rx.Function([x], rx.SeqExpr([], x), R.Tensor((), dtype="int32")).with_attr(
+        "global_symbol", "foo"
+    )
+    assert func.is_pure
+    mod = rx.transform.Normalize()(tvm.IRModule.from_expr(func))
+    assert rx.analysis.well_formed(mod)
+
+
+def test_labeled_pure():
+    x = rx.Var("x", R.Tensor((), dtype="int32"))
+    y = rx.Var("y")
+    block = rx.BindingBlock([rx.VarBinding(y, rx.op.print(x, format="{}"))])
+    # Calls to `relax.op.print` are impure, but the function is
+    # explicitly labeled as pure.
+    func = rx.Function(
+        [x], rx.SeqExpr([block], x), R.Tensor((), dtype="int32"), is_pure=True
+    ).with_attr("global_symbol", "foo")
+    # The explicit argument is used for the function's purity.
+    assert func.is_pure
+    mod = rx.transform.Normalize()(tvm.IRModule.from_expr(func))
+
+    # The function is ill-formed, as the function's purity does not
+    # match the explicit annotation.
     assert not rx.analysis.well_formed(mod)
 
 
@@ -576,10 +611,11 @@ def test_labeled_impure():
     x = rx.Var("x", R.Tensor((), dtype="int32"))
     y = rx.Var("y")
     block = rx.BindingBlock([rx.VarBinding(y, rx.op.print(x, format="{}"))])
-    # print is impure, but the function is not labeled as impure
+    # print is impure, and the function is labeled as impure.
     func = rx.Function(
         [x], rx.SeqExpr([block], x), R.Tensor((), dtype="int32"), is_pure=False
     ).with_attrs({"global_symbol": "foo"})
+    assert not func.is_pure
     mod = rx.transform.Normalize()(tvm.IRModule.from_expr(func))
     assert rx.analysis.well_formed(mod)
 
@@ -589,9 +625,13 @@ def test_force_pure():
     y = rx.Var("y")
     block = rx.BindingBlock([rx.VarBinding(y, rx.op.print(x, format="{}"))])
     # print is impure, but force_pure overrides the judgment
-    func = rx.Function([x], rx.SeqExpr([block], x), R.Tensor((), dtype="int32")).with_attrs(
-        {"global_symbol": "foo", "relax.force_pure": True}
+    func = rx.Function(
+        [x],
+        rx.SeqExpr([block], x),
+        R.Tensor((), dtype="int32"),
+        attrs={"global_symbol": "foo", "relax.force_pure": True},
     )
+    assert func.is_pure
     mod = rx.transform.Normalize()(tvm.IRModule.from_expr(func))
     assert rx.analysis.well_formed(mod)
 

--- a/tests/python/relax/test_frontend_nn_extern_module.py
+++ b/tests/python/relax/test_frontend_nn_extern_module.py
@@ -91,10 +91,9 @@ def _check_ir_equality(mod):
         ) -> R.Tensor((), dtype="float32"):
             R.func_attr({"num_input": 2})
             with R.dataflow():
-                ext_scalar_add = R.call_dps_packed(
+                gv = R.call_dps_packed(
                     "ext_scalar_add", (a, b), out_sinfo=R.Tensor((), dtype="float32")
                 )
-                gv: R.Tensor((), dtype="float32") = ext_scalar_add
                 R.output(gv)
             return gv
 
@@ -107,10 +106,9 @@ def _check_ir_equality(mod):
             z = T.int64()
             R.func_attr({"num_input": 2})
             with R.dataflow():
-                ext_test_sym = R.call_dps_packed(
+                gv1 = R.call_dps_packed(
                     "ext_test_sym", (a, b), out_sinfo=R.Tensor((x, y, z, 9), dtype="float32")
                 )
-                gv1: R.Tensor((x, y, z, 9), dtype="float32") = ext_test_sym
                 R.output(gv1)
             return gv1
 

--- a/tests/python/relax/test_frontend_nn_modules.py
+++ b/tests/python/relax/test_frontend_nn_modules.py
@@ -491,8 +491,7 @@ def test_kv_cache():
                     R.prim_value(0),
                     sinfo_args=(R.Object,),
                 )
-                lv1 = _io, cache
-                gv = lv1
+                gv = _io, cache
                 R.output(gv)
             return gv
 

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -532,8 +532,7 @@ def test_tensor_expr_op():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -605,8 +604,7 @@ def test_tensor_ir_op():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -693,8 +691,7 @@ def test_tensor_ir_inplace_op():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -711,13 +708,12 @@ def test_tensor_ir_inplace_op():
             R.func_attr({"num_input": 4})
             cls = Expected
             with R.dataflow():
-                lv1 = R.call_tir(
+                gv1 = R.call_tir(
                     cls.inplace_take,
                     (embedding_table, input_ids, embedding_dst),
                     out_sinfo=R.Tensor((total_seq_len, hidden_size), dtype),
                     tir_vars=R.shape([offset_1]),
                 )
-                gv1: R.Tensor((total_seq_len, hidden_size), dtype) = lv1
                 R.output(gv1)
             return gv1
 
@@ -766,8 +762,7 @@ def test_tensor_ir_op_no_tir_var():
             R.func_attr({"num_input": 1})
             cls = Expected
             with R.dataflow():
-                lv = R.call_tir(cls.tir_func, (A,), out_sinfo=R.Tensor((16, 16), dtype="float32"))
-                gv: R.Tensor((16, 16), dtype="float32") = lv
+                gv = R.call_tir(cls.tir_func, (A,), out_sinfo=R.Tensor((16, 16), dtype="float32"))
                 R.output(gv)
             return gv
 
@@ -794,8 +789,7 @@ def test_extern():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -845,7 +839,6 @@ def test_empty():
 
 @tvm.testing.requires_gpu
 def test_multinomial_from_uniform():
-
     prob_shape = (3, 5)
     sample_shape = (6, 1)
 
@@ -882,8 +875,7 @@ def test_multinomial_from_uniform():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -1009,8 +1001,7 @@ def test_sample_top_p_top_k_from_sorted_prob():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -1124,8 +1115,7 @@ def test_renormalize_top_p_top_k_prob():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 

--- a/tests/python/relax/test_frontend_nn_packing.py
+++ b/tests/python/relax/test_frontend_nn_packing.py
@@ -59,8 +59,7 @@ def test_nn_export_to_relax():
                 matmul = R.matmul(x, matmul_1_weight)
                 matmul_2_weight = R.permute_dims(linear_2_weight)
                 matmul1 = R.matmul(x, matmul_2_weight)
-                add = R.add(matmul, matmul1)
-                gv = add
+                gv = R.add(matmul, matmul1)
                 R.output(gv)
             return gv
 

--- a/tests/python/relax/test_frontend_nn_subroutines.py
+++ b/tests/python/relax/test_frontend_nn_subroutines.py
@@ -61,8 +61,7 @@ def test_linear():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
 
             return gv
@@ -75,9 +74,8 @@ def test_linear():
             with R.dataflow():
                 state = R.matmul(state, weights)
                 state = Expected.activation(state)
-                dataflow_output = state
-                R.output(dataflow_output)
-            return dataflow_output
+                R.output(state)
+            return state
 
         @R.function(private=True)
         def activation(
@@ -85,9 +83,8 @@ def test_linear():
         ) -> R.Tensor(("batch_size", 32), dtype="float32"):
             with R.dataflow():
                 state = R.nn.silu(state)
-                dataflow_output = state
-                R.output(dataflow_output)
-            return dataflow_output
+                R.output(state)
+            return state
 
     mod = Layer(64, 32)
     batch_size = tvm.tir.Var("batch_size", "int64")


### PR DESCRIPTION
Prior to this commit, debug functions were generated with `relax.call_pure_packed`.  This resulted in unexpected behavior, as `nn.op.print_` can be optimized away as a pure function.

This commit updates debug functions to be generated as impure functions.  This requires removing the `with bb.dataflow()` blocks in the SLM-to-relax conversions, as impure functions may not be used in a dataflow block.  To restore dataflow blocks when legal, the `ConvertToDataflow` pass is applied.