### PR TITLE
[Bugfix][Thrust] Mark relax.cumsum implementation as scheduled

### DIFF
--- a/python/tvm/relax/backend/dispatch_sort_scan.py
+++ b/python/tvm/relax/backend/dispatch_sort_scan.py
@@ -71,7 +71,9 @@ class SortScanDispatcher(PyExprMutator):
         )
         if sch is not None:
             assert len(sch) == 1
-            self.builder_.update_func(gvar, sch[0].mod["main"].with_attr("tir.is_scheduled", 1))
+            scan_prim_func = sch[0].mod["main"]
+
+        self.builder_.update_func(gvar, scan_prim_func.with_attr("tir.is_scheduled", 1))
 
     def visit_call_(self, call: relax.Call) -> relax.Expr:
         if not isinstance(call.op, Op):


### PR DESCRIPTION
Prior to this commit, the `tests/python/relax/test_frontend_nn_op.py::test_renormalize_top_p_top_k_prob` test is failing on the main branch.  This is due to use of `tir.transform.DefaultGPUSchedule` on a kernel that cannot be scheduled.

This commit updates `relax.backend.DispatchSortScan()` to mark its output `cumsum` function as scheduled.