### PR TITLE
Use target name instead of node name as function name

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1561,7 +1561,7 @@ class TorchFXImporter:
                         ), f"Unsupported module type {type(module)}"
                         self.env[node] = self.convert_map[type(module)](node)
                     elif node.op == "call_function":
-                        func_name = node.name.rstrip("0123456789_")
+                        func_name = node.target.__name__
                         assert (
                             func_name in self.convert_map
                         ), f"Unsupported function type {func_name}"


### PR DESCRIPTION
torch change the description of the graph, function name isn't same as node name, cause can't find function if import torch model. So use target name instead of node name.

fix https://github.com/mlc-ai/web-stable-diffusion/issues/54