### PR TITLE
[Transform] Remove R.Object parameters after LazyTransformParams

### DIFF
--- a/python/tvm/relax/transform/lazy_transform_params.py
+++ b/python/tvm/relax/transform/lazy_transform_params.py
@@ -216,7 +216,7 @@ class LazyTransformParamsFuncCreator:
             # direct iterate over the struct info annotation
             for param in func.params[num_input:]:
                 for sinfo in unpack_sinfo(param.struct_info):
-                    if not isinstance(sinfo, relax.TensorStructInfo):
+                    if isinstance(sinfo, (relax.PrimStructInfo, relax.ShapeStructInfo)):
                         params.append(relax.Var("symbolic_var_holder", sinfo))
 
         return relax.Function(

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -30,7 +30,12 @@ from ...ir_builder import ir as I
 from ...ir_builder import relax as R
 from ...ir_builder.base import IRBuilder
 from .._core import Parser, dispatch, doc
-from .entry import MatchCastPair, StructInfoProxy, TupleProxy
+from .entry import (
+    MatchCastPair,
+    StructInfoProxy,
+    _normalize_struct_info_proxy,
+    _normalize_struct_info,
+)
 
 
 def bind_assign_value(
@@ -91,13 +96,7 @@ def bind_assign_value(
 def eval_struct_info_proxy(self: Parser, node: doc.expr) -> StructInfoProxy:
     try:
         annotation = self.eval_expr(node)
-        if annotation is None:
-            return TupleProxy([])
-        if callable(annotation):
-            annotation = annotation()
-        if isinstance(annotation, StructInfoProxy):
-            return annotation
-        raise TypeError(f"Expected StructInfoProxy but got {type(annotation)}.")
+        return _normalize_struct_info_proxy(annotation)
     except Exception as err:
         self.report_error(node, str(err))
         raise err
@@ -106,7 +105,8 @@ def eval_struct_info_proxy(self: Parser, node: doc.expr) -> StructInfoProxy:
 def eval_struct_info(self: Parser, node: doc.expr, eval_str: bool = False) -> StructInfo:
     var_table = self.var_table.get() if eval_str else None
     try:
-        return eval_struct_info_proxy(self, node).as_struct_info(var_table)
+        struct_info = self.eval_expr(node)
+        return _normalize_struct_info(struct_info, var_table)
     except Exception as err:
         self.report_error(node, str(err))
         raise err
@@ -367,7 +367,6 @@ def visit_if(self: Parser, node: doc.If) -> None:
 @dispatch.register(token="relax", type_name="enter_token")
 def enter_token(self: Parser) -> Dict[str, Any]:
     def relax_call(self, *args) -> Expr:
-
         args = [convert_to_expr(arg) if isinstance(arg, tuple) else arg for arg in args]
 
         if all(isinstance(x, Expr) for x in args):

--- a/tests/python/relax/test_transform_lazy_transform_params.py
+++ b/tests/python/relax/test_transform_lazy_transform_params.py
@@ -804,5 +804,25 @@ def test_retain_before_num_input():
     tvm.ir.assert_structural_equal(After, Expected)
 
 
+def test_params_without_tuple_with_symbolic_var():
+    @I.ir_module
+    class Before:
+        @R.function
+        def transform_params(A: R.Object):
+            return (A,)
+
+    @I.ir_module
+    class Expected:
+        @R.function(pure=False)
+        def transform_params():
+            A = R.call_packed("get_item", R.prim_value(0), sinfo_args=[R.Object])
+            A = R.match_cast(A, R.Object)
+
+            return (A,)
+
+    After = LazyTransformParams(fset_item=None)(Before)
+    tvm.ir.assert_structural_equal(After, Expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Prior to this commit, the output of `relax.transform.LazyTransformParams` would include all parameters that are not `R.Tensor`, in case they defined symbolic variables. However, this added too many unnecessary parameters, such as `R.Object` which cannot define symbolic variables.  This commit updates `relax.transform.LazyTransformParams` to only retain `R.Prim` and `R.Shape` parameters, which can define symbolic variables.