### PR TITLE
[Cutlass][Build] Clean up temporary files after build

### DIFF
--- a/python/tvm/runtime/module.py
+++ b/python/tvm/runtime/module.py
@@ -20,7 +20,7 @@
 import os
 import ctypes
 import struct
-from typing import Sequence
+from typing import Sequence, List, Optional
 import numpy as np
 
 from tvm._ffi.base import _LIB, check_call, c_str, string_types, _RUNTIME_ONLY
@@ -699,11 +699,11 @@ def load_module(path, fmt=""):
     return _ffi_api.ModuleLoadFromFile(path, fmt)
 
 
-def load_static_library(path, func_names):
+def load_static_library(path: str, func_names: List[str], source_code: Optional[str] = None):
     """Load the .o library at path which implements functions with func_names.
     Unlike the generic load_module the result will remain as a static_library
     and will not be relinked on-the-fly into a .so library."""
-    return _ffi_api.ModuleLoadStaticLibrary(path, func_names)
+    return _ffi_api.ModuleLoadStaticLibrary(path, func_names, source_code)
 
 
 def enabled(target):

--- a/src/runtime/static_library.cc
+++ b/src/runtime/static_library.cc
@@ -56,6 +56,14 @@ class StaticLibraryNode final : public runtime::ModuleNode {
     }
   }
 
+  String GetSource(const String& format = "") override {
+    if (source_code_.defined()) {
+      return source_code_.value();
+    } else {
+      return String();
+    }
+  }
+
   void SaveToBinary(dmlc::Stream* stream) final {
     stream->Write(data_);
     std::vector<std::string> func_names;
@@ -114,14 +122,18 @@ class StaticLibraryNode final : public runtime::ModuleNode {
   std::string data_;
   /*! \brief Function names exported by the above. */
   Array<String> func_names_;
+  /*! \brief Source code that generated the object file. */
+  Optional<String> source_code_;
 };
 
 }  // namespace
 
-Module LoadStaticLibrary(const std::string& filename, Array<String> func_names) {
+Module LoadStaticLibrary(const std::string& filename, Array<String> func_names,
+                         Optional<String> source_code) {
   auto node = make_object<StaticLibraryNode>();
   LoadBinaryFromFile(filename, &node->data_);
   node->func_names_ = std::move(func_names);
+  node->source_code_ = std::move(source_code);
   VLOG(0) << "Loaded static library from '" << filename << "' implementing " << node->FuncNames();
   return Module(node);
 }

--- a/src/runtime/static_library.h
+++ b/src/runtime/static_library.h
@@ -42,7 +42,8 @@ namespace runtime {
  * \brief Returns a static library with the contents loaded from filename which exports
  * func_names with the usual packed-func calling convention.
  */
-Module LoadStaticLibrary(const std::string& filename, Array<String> func_names);
+Module LoadStaticLibrary(const std::string& filename, Array<String> func_names,
+                         Optional<String> source_code = NullOpt);
 
 }  // namespace runtime
 }  // namespace tvm


### PR DESCRIPTION
Prior to this commit, compiling cutlass kernels left temporary files in the working directory.  These temporary files are then left on disk after building.  This commit updates the default behavior when building cutlass to produce files in a temporary directory, which is cleaned up on completion.

Since this change on its own would make it difficult to view and debug the generated cutlass code, this commit also maintains a copy of the generated source in the cutlass module.  This can be inspected with `for ext in mod.attrs['external_modules']: print(ext.get_source())`.