### PR TITLE
[MSC][M5.2] Enable quantize && prune with gym by wrapper

### DIFF
--- a/gallery/how_to/work_with_msc/using_tools.py
+++ b/gallery/how_to/work_with_msc/using_tools.py
@@ -58,7 +58,10 @@ parser.add_argument("--test_iter", type=int, default=100, help="The iter for tes
 parser.add_argument("--calibrate_iter", type=int, default=100, help="The iter for calibration")
 parser.add_argument("--train_batch", type=int, default=32, help="The batch size for train")
 parser.add_argument("--train_iter", type=int, default=200, help="The iter for train")
-parser.add_argument("--train_epoch", type=int, default=5, help="The epoch for train")
+parser.add_argument("--train_epoch", type=int, default=100, help="The epoch for train")
+parser.add_argument(
+    "--verbose", type=str, default="info", help="The verbose level, info|debug:1,2,3|critical"
+)
 args = parser.parse_args()
 
 
@@ -86,7 +89,7 @@ def get_config(calib_loader, train_loader):
         dataset=dataset,
         tools=tools,
         skip_config={"all": "check"},
-        verbose="info",
+        verbose=args.verbose,
     )
 
 
@@ -130,3 +133,7 @@ if __name__ == "__main__":
     model.compile()
     acc = eval_model(model, testloader, max_iter=args.test_iter)
     print("Compiled acc: " + str(acc))
+
+    # export the model
+    path = model.export()
+    print("Export model to " + str(path))

--- a/python/tvm/contrib/msc/core/gym/agent/method.py
+++ b/python/tvm/contrib/msc/core/gym/agent/method.py
@@ -18,9 +18,11 @@
 """tvm.contrib.msc.core.gym.agent.method"""
 
 from typing import Any
+from tvm.contrib.msc.core.gym.namespace import GYMObject
 from tvm.contrib.msc.core import utils as msc_utils
 
 
+@msc_utils.register_gym_method
 class AgentMethod(object):
     """Default prune method"""
 
@@ -73,8 +75,9 @@ class AgentMethod(object):
         return reward["reward"]
 
     @classmethod
+    def role(cls):
+        return GYMObject.AGENT
+
+    @classmethod
     def method_type(cls):
-        return "agent.default"
-
-
-msc_utils.register_gym_method(AgentMethod)
+        return "default"

--- a/python/tvm/contrib/msc/core/gym/agent/search_agent.py
+++ b/python/tvm/contrib/msc/core/gym/agent/search_agent.py
@@ -37,10 +37,11 @@ class BaseSearchAgent(BaseAgent):
         return super().setup()
 
     @classmethod
-    def agent_type(cls):
+    def role_type(cls):
         return "search.base"
 
 
+@msc_utils.register_gym_object
 class GridSearchAgent(BaseSearchAgent):
     """GridSearch agent"""
 
@@ -92,10 +93,11 @@ class GridSearchAgent(BaseSearchAgent):
         return best_actions, best_rewards
 
     @classmethod
-    def agent_type(cls):
+    def role_type(cls):
         return "search.grid"
 
 
+@msc_utils.register_gym_object
 class BinarySearchAgent(BaseSearchAgent):
     """BinarySearch agent"""
 
@@ -173,8 +175,5 @@ class BinarySearchAgent(BaseSearchAgent):
         return actions, rewards
 
     @classmethod
-    def agent_type(cls):
+    def role_type(cls):
         return "search.binary"
-
-
-msc_utils.register_gym_agent(GridSearchAgent)

--- a/python/tvm/contrib/msc/core/gym/control/configer.py
+++ b/python/tvm/contrib/msc/core/gym/control/configer.py
@@ -48,6 +48,7 @@ class BaseConfiger(object):
         raise NotImplementedError("update is not implemented in BaseConfiger")
 
 
+@msc_utils.register_gym_configer
 class DefaultConfiger(BaseConfiger):
     """Default configer for gym"""
 
@@ -67,10 +68,10 @@ class DefaultConfiger(BaseConfiger):
 
         config = msc_utils.copy_dict(raw_config)
         assert "env" in config and "agent" in config, "env and agent should be given to run gym"
-        if "env_type" not in config["env"]:
-            config["env"]["env_type"] = self._stage + ".default"
-        if "agent_type" not in config["agent"]:
-            config["agent"]["agent_type"] = "search.grid"
+        if "role_type" not in config["env"]:
+            config["env"]["role_type"] = self._stage + ".default"
+        if "role_type" not in config["agent"]:
+            config["agent"]["role_type"] = "search.grid"
         if "executors" not in config["env"]:
             config["env"]["executors"] = {}
         # update executors
@@ -92,6 +93,3 @@ class DefaultConfiger(BaseConfiger):
     @classmethod
     def config_type(cls):
         return "default"
-
-
-msc_utils.register_gym_configer(DefaultConfiger)

--- a/python/tvm/contrib/msc/core/gym/control/controller.py
+++ b/python/tvm/contrib/msc/core/gym/control/controller.py
@@ -17,9 +17,9 @@
 """tvm.contrib.msc.core.gym.control.controller"""
 
 from typing import Dict, Any
+from tvm.contrib.msc.core.gym.namespace import GYMObject, GYMAction
 from tvm.contrib.msc.core import utils as msc_utils
 from .service import MainService, NodeService
-from .namespace import GYMObject, GYMAction
 
 
 class BaseController(object):
@@ -98,10 +98,8 @@ def create_controller(stage: str, config: dict, extra_config: dict = None):
     return controller_cls(msc_utils.get_gym_dir(), config)
 
 
+@msc_utils.register_gym_controller
 class DefaultController(BaseController):
     @classmethod
     def control_type(cls):
         return "default"
-
-
-msc_utils.register_gym_controller(DefaultController)

--- a/python/tvm/contrib/msc/core/gym/environment/base_env.py
+++ b/python/tvm/contrib/msc/core/gym/environment/base_env.py
@@ -18,7 +18,8 @@
 
 import copy
 import logging
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Union
+from tvm.contrib.msc.core.gym.namespace import GYMObject
 from tvm.contrib.msc.core.runtime import BaseRunner
 from tvm.contrib.msc.core.tools import BaseTool
 from tvm.contrib.msc.core import utils as msc_utils
@@ -43,8 +44,6 @@ class BaseEnv(object):
         The extra options for the environment.
     debug_level: int
         The debug level.
-    verbose: str
-        The verbose level.
     logger: logging.Logger
         The logger
     """
@@ -60,27 +59,19 @@ class BaseEnv(object):
         options: dict = None,
         max_tasks: int = -1,
         debug_level: int = 0,
-        verbose: str = None,
         logger: logging.Logger = None,
     ):
         self._name = name
         self._runner = runner
         self._data_loader = data_loader
         self._workspace = workspace
-        self._knowledge = knowledge
+        self._knowledge = msc_utils.load_dict(knowledge)
         self._executors = self._parse_executors(msc_utils.copy_dict(executors))
         self._options = options or {}
         self._max_tasks = max_tasks
         self._debug_level = debug_level
-        if logger:
-            self._logger = logger
-        else:
-            if not verbose:
-                verbose = "debug" if debug_level > 0 else "info"
-            self._logger = msc_utils.create_file_logger(verbose, workspace.relpath("ENV_LOG"))
-        self._logger.info(
-            msc_utils.msg_block("ENV.SETUP({})".format(self.env_type()), self.setup())
-        )
+        self._logger = logger or msc_utils.get_global_logger()
+        self._logger.info(msc_utils.msg_block(self.env_mark("SETUP"), self.setup()))
 
     def _parse_executors(self, executors_dict: dict) -> Dict[str, Tuple[callable, dict]]:
         """Parse the executors
@@ -99,9 +90,12 @@ class BaseEnv(object):
         executors = {}
         for name, raw_config in executors_dict.items():
             method_type = (
-                raw_config.pop("method_type") if "method_type" in raw_config else "env.default"
+                raw_config.pop("method_type") if "method_type" in raw_config else "default"
             )
-            method_cls = msc_utils.get_registered_gym_method(method_type)
+            method_cls = msc_utils.get_registered_gym_method(GYMObject.ENV, method_type)
+            assert method_cls, "Can not find method cls for {}:{}".format(
+                GYMObject.ENV, method_type
+            )
             assert "method" in raw_config, "method should be given to find enviironment method"
             method_name, method = raw_config.pop("method"), None
             if hasattr(method_cls, method_name):
@@ -122,6 +116,7 @@ class BaseEnv(object):
         """
 
         self._cache_dir = self._workspace.create_dir("Cache")
+        self._tool = None
         self._tasks = []
         return {
             "name": self._name,
@@ -155,11 +150,11 @@ class BaseEnv(object):
             self._tasks = self._tasks[: self._max_tasks]
         # get baseline
         self._tool.disable()
-        self._runner.build(self._cache_dir, force_build=True)
+        self._runner.build(self._cache_dir, force_build=True, disable_tools=[self._tool.tool_type])
         baseline = self._reward_runner(-1)
         self._tool.enable()
         tasks_info = {"tasks_num": len(self._tasks), "tasks": self._tasks}
-        self._logger.info(msc_utils.msg_block("ENV.TASKS", tasks_info, width=0))
+        self._logger.info(msc_utils.msg_block(self.env_mark("TASKS"), tasks_info))
         return len(self._tasks), baseline
 
     def _init_tool(self) -> BaseTool:
@@ -274,7 +269,7 @@ class BaseEnv(object):
         self._logger.info("Env Summary with %d actions, %d rewards", len(actions), len(rewards))
         return self._summary(actions, rewards)
 
-    def _summary(self, actions: List[dict], rewards: List[dict]) -> dict:
+    def _summary(self, actions: List[dict], rewards: List[dict]) -> Union[dict, str]:
         """Summary the final plan
 
         Parameters
@@ -286,11 +281,53 @@ class BaseEnv(object):
 
         Returns
         -------
-        plan: dict
-            The final plan.
+        knowledge: dict| str
+            The learned knowledge or file.
         """
 
         raise NotImplementedError("_summary is not implemented in BaseEnv")
+
+    def _update_strategy(self, strategy: dict, **kwargs) -> dict:
+        """Update startegy
+
+        Parameters
+        ----------
+        startegy: dict
+            The strategy.
+        kwargs: dict
+            The kwargs.
+
+        Returns
+        -------
+        strategy: dict
+            The updated strategy.
+        """
+
+        for t_type, method_def in strategy["methods"].items():
+            if isinstance(method_def, str):
+                strategy["methods"][t_type] = {"method_name": method_def, **kwargs}
+            elif isinstance(method_def, dict):
+                method_def.update(kwargs)
+        return strategy
+
+    def _get_strategy(self, action: dict, task_id: int) -> dict:
+        """Get strategy from task_id
+
+        Parameters
+        ----------
+        action: float
+            The current action.
+        task_id: int
+            The current task id.
+
+        Returns
+        -------
+        strategy: dict
+            The strategy.
+        """
+
+        strategy = msc_utils.copy_dict(self.get_task(task_id))
+        return self._update_strategy(strategy, **action)
 
     def get_task(self, task_id: int) -> dict:
         """Get task according to task_id
@@ -363,6 +400,30 @@ class BaseEnv(object):
         kwargs.update({k: v for k, v in config.items() if k not in kwargs})
         return method(self, *args, **kwargs)
 
+    def env_mark(self, msg: Any) -> str:
+        """Mark the message with env info
+
+        Parameters
+        -------
+        msg: str
+            The message
+
+        Returns
+        -------
+        msg: str
+            The message with mark.
+        """
+
+        return "ENV({}) {}".format(self.role_type(), msg)
+
+    @property
+    def tool(self):
+        return self._tool
+
     @classmethod
-    def env_type(cls):
+    def role(cls):
+        return GYMObject.ENV
+
+    @classmethod
+    def role_type(cls):
         return "base"

--- a/python/tvm/contrib/msc/core/gym/environment/method.py
+++ b/python/tvm/contrib/msc/core/gym/environment/method.py
@@ -20,11 +20,13 @@
 from typing import Any, List
 import numpy as np
 
+from tvm.contrib.msc.core.gym.namespace import GYMObject
 from tvm.contrib.msc.core.runtime import BaseRunner
 from tvm.contrib.msc.core.tools import BaseTool
 from tvm.contrib.msc.core import utils as msc_utils
 
 
+@msc_utils.register_gym_method
 class EnvMethod(object):
     """Default prune method"""
 
@@ -189,14 +191,16 @@ class EnvMethod(object):
         """
 
         task = env.get_task(task_id)
+        plan = env.tool.plan[task["tensor_ids"][0]]
         return [
-            {"scale": task["scale"] * a}
+            {"scale": plan["scale"] * a}
             for a in cls.action_linear_space(env, task_id, start, end, step)
         ]
 
     @classmethod
+    def role(cls):
+        return GYMObject.ENV
+
+    @classmethod
     def method_type(cls):
-        return "env.default"
-
-
-msc_utils.register_gym_method(EnvMethod)
+        return "default"

--- a/python/tvm/contrib/msc/core/gym/environment/prune_env.py
+++ b/python/tvm/contrib/msc/core/gym/environment/prune_env.py
@@ -16,12 +16,13 @@
 # under the License.
 """tvm.contrib.msc.core.gym.prune_env"""
 
-from typing import List
+from typing import List, Union
 from tvm.contrib.msc.core.tools import BaseTool, ToolType
 from tvm.contrib.msc.core import utils as msc_utils
 from .base_env import BaseEnv
 
 
+@msc_utils.register_gym_object
 class PruneEnv(BaseEnv):
     """Environment for prune"""
 
@@ -29,10 +30,11 @@ class PruneEnv(BaseEnv):
         """Get the main tool"""
 
         config = self._runner.get_tool_config(ToolType.PRUNER)
-        self._meta_strategys = config["strategys"]
-        for s in self._meta_strategys:
-            s.update({"density": 1})
-        return self._runner.get_tool(ToolType.PRUNER)
+        self._meta_strategys = msc_utils.copy_dict(config["strategys"])
+        self._meta_strategys = [self._update_strategy(s, density=1) for s in self._meta_strategys]
+        tool = self._runner.get_tool(ToolType.PRUNER)
+        tool.change_strategys(self._meta_strategys)
+        return tool
 
     def _update_tool(self, action: dict, task_id: int):
         """Update the tool
@@ -46,9 +48,9 @@ class PruneEnv(BaseEnv):
         """
 
         task_strategy = self._get_strategy(action, task_id)
-        self._tool.plan_by_strategys(self._meta_strategys + [task_strategy])
+        self._apply_strategys(self._meta_strategys + [task_strategy])
 
-    def _summary(self, actions: List[dict], rewards: List[dict]) -> dict:
+    def _summary(self, actions: List[dict], rewards: List[dict]) -> Union[dict, str]:
         """Summary the final plan
 
         Parameters
@@ -60,36 +62,33 @@ class PruneEnv(BaseEnv):
 
         Returns
         -------
-        plan: dict
-            The final plan.
+        knowledge: dict| str
+            The learned knowledge or file.
         """
 
-        strategys = [self._get_strategy(act, idx) for idx, act in enumerate(actions)]
-        return self._tool.plan_by_strategys(self._meta_strategys + strategys)
+        strategys = self._meta_strategys + [
+            self._get_strategy(act, idx) for idx, act in enumerate(actions)
+        ]
+        return self._apply_strategys(strategys)
 
-    def _get_strategy(self, action: dict, task_id: int) -> dict:
-        """Get strategy from task_id
+    def _apply_strategys(self, strategys: List[dict]) -> str:
+        """Apply the strategys
 
         Parameters
         ----------
-        action: float
-            The current action.
-        task_id: int
-            The current task id.
+        strategys: list<dict>
+            The given strategys
 
         Returns
         -------
-        strategy: dict
-            The strategy.
+        plan_file: str
+            The plan after strategys applied.
         """
 
-        strategy = msc_utils.copy_dict(self.get_task(task_id))
-        strategy.update(**action)
-        return strategy
+        self._tool.change_strategys(strategys)
+        self._runner.build(self._cache_dir, force_build=True)
+        return self._runner.make_plan(self._tool.tool_type(), self._data_loader)
 
     @classmethod
-    def env_type(cls):
+    def role_type(cls):
         return msc_utils.MSCStage.PRUNE + ".default"
-
-
-msc_utils.register_gym_env(PruneEnv)

--- a/python/tvm/contrib/msc/core/gym/environment/quantize_env.py
+++ b/python/tvm/contrib/msc/core/gym/environment/quantize_env.py
@@ -16,22 +16,20 @@
 # under the License.
 """tvm.contrib.msc.core.gym.quantize_env"""
 
-import os
-from typing import List
+from typing import List, Union
 from tvm.contrib.msc.core.tools import BaseTool, ToolType
 from tvm.contrib.msc.core import utils as msc_utils
 from .base_env import BaseEnv
 
 
+@msc_utils.register_gym_object
 class QuantizeEnv(BaseEnv):
     """Environment for quantize"""
 
     def _init_tool(self) -> BaseTool:
         """Get the main tool"""
 
-        plan_file = self._runner.apply_tool(ToolType.QUANTIZER, self._data_loader)
-        self._meta_plan = msc_utils.load_dict(plan_file)
-        os.remove(plan_file)
+        self._runner.make_plan(ToolType.QUANTIZER, self._data_loader)
         return self._runner.get_tool(ToolType.QUANTIZER)
 
     def _update_tool(self, action: dict, task_id: int):
@@ -45,11 +43,9 @@ class QuantizeEnv(BaseEnv):
             The current task id.
         """
 
-        plan = msc_utils.copy_dict(self._meta_plan)
-        plan.update(self._get_plan(action, task_id))
-        self._tool.set_plan(plan)
+        self._tool.change_strategys([self._get_strategy(action, task_id)])
 
-    def _summary(self, actions: List[dict], rewards: List[dict]) -> dict:
+    def _summary(self, actions: List[dict], rewards: List[dict]) -> Union[dict, str]:
         """Summary the final plan
 
         Parameters
@@ -61,39 +57,21 @@ class QuantizeEnv(BaseEnv):
 
         Returns
         -------
-        plan: dict
-            The final plan.
+        knowledge: dict| str
+            The learned knowledge or file.
         """
 
-        plan = msc_utils.copy_dict(self._meta_plan)
-        for idx, act in enumerate(actions):
-            plan.update(self._get_plan(act, idx))
-        return plan
-
-    def _get_plan(self, action: dict, task_id: int) -> dict:
-        """Get plan from task_id
-
-        Parameters
-        ----------
-        action: float
-            The current action.
-        task_id: int
-            The current task id.
-
-        Returns
-        -------
-        plan: dict
-            The plan.
-        """
-
-        plan = msc_utils.copy_dict(self.get_task(task_id))
-        plan.update(**action)
-        name = plan.pop("name")
-        return {name: plan}
+        strategys = self.tool._parse_strategys(
+            [self._get_strategy(act, idx) for idx, act in enumerate(actions)]
+        )
+        plan = self.tool.plan
+        for name, info in plan.items():
+            if name not in strategys:
+                continue
+            info.update(strategys[name].get_executor(msc_utils.MSCStage.QUANTIZE).config)
+        summary_file = msc_utils.get_cache_dir().relpath("gym_summary.json")
+        return msc_utils.dump_dict(plan, summary_file)
 
     @classmethod
-    def env_type(cls):
+    def role_type(cls):
         return msc_utils.MSCStage.QUANTIZE + ".default"
-
-
-msc_utils.register_gym_env(QuantizeEnv)

--- a/python/tvm/contrib/msc/core/gym/namespace.py
+++ b/python/tvm/contrib/msc/core/gym/namespace.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.core.gym.namespace"""
+
+
+class GYMObject(object):
+    """Enum all gym objects"""
+
+    BASE = "base"
+    ENV = "env"
+    AGENT = "agent"
+    SERVICE = "service"
+
+
+class GYMAction(object):
+    """Enum all gym actions"""
+
+    INIT = "init"
+    RESET = "reset"
+    GET_STATE = "get_state"
+    CHOOSE_ACTION = "choose_action"
+    STEP = "step"
+    STORE = "store"
+    LEARN = "learn"
+    SUMMARY = "summary"
+    CLEANUP = "cleanup"

--- a/python/tvm/contrib/msc/core/runtime/hook.py
+++ b/python/tvm/contrib/msc/core/runtime/hook.py
@@ -128,6 +128,7 @@ class CustomizedHook(RunnerHook):
         return "customized"
 
 
+@msc_utils.register_runner_hook
 class UpdateWeightsHook(RunnerHook):
     """Hook for update weights"""
 
@@ -191,6 +192,3 @@ def load_runner_hook(config: dict) -> Any:
     if hook_cls:
         return hook_cls(hook_config)
     return CustomizedHook(hook_ref, hook_config)
-
-
-msc_utils.register_runner_hook(UpdateWeightsHook)

--- a/python/tvm/contrib/msc/core/tools/configer.py
+++ b/python/tvm/contrib/msc/core/tools/configer.py
@@ -45,10 +45,7 @@ class ToolConfiger(object):
             config["tool_config"] = self.update_tool(raw_config)
         else:
             config["tool_config"] = self.config_tool()
-        if self.run_type:
-            config["run_type"] = self.run_type
-        if self.apply_once:
-            config["apply_once"] = self.apply_once
+        config.update(self.config_apply())
         return config
 
     def config_tool(self) -> dict:
@@ -95,13 +92,16 @@ class ToolConfiger(object):
 
         raise NotImplementedError("config_gym is not implemented in ToolConfiger")
 
-    @property
-    def run_type(self):
-        return ""
+    def config_apply(self) -> dict:
+        """Get the config fro apply
 
-    @property
-    def apply_once(self):
-        return False
+        Returns
+        -------
+        config: dict
+            The apply config.
+        """
+
+        return {}
 
     @classmethod
     def tool_type(cls):

--- a/python/tvm/contrib/msc/core/tools/distill/distiller.py
+++ b/python/tvm/contrib/msc/core/tools/distill/distiller.py
@@ -271,10 +271,8 @@ class BaseDistiller(BaseTool):
         return ToolType.DISTILLER
 
 
+@msc_utils.register_tool
 class DefaultDistiller(BaseDistiller):
     @classmethod
     def tool_style(cls):
         return "default"
-
-
-msc_utils.register_tool_cls(DefaultDistiller)

--- a/python/tvm/contrib/msc/core/tools/distill/method.py
+++ b/python/tvm/contrib/msc/core/tools/distill/method.py
@@ -25,6 +25,7 @@ from tvm.contrib.msc.core.utils.namespace import MSCFramework
 from tvm.contrib.msc.core import utils as msc_utils
 
 
+@msc_utils.register_tool_method
 class DistillMethod(object):
     """Default distill method"""
 
@@ -68,5 +69,6 @@ class DistillMethod(object):
     def tool_type(cls):
         return ToolType.DISTILLER
 
-
-msc_utils.register_tool_method(DistillMethod)
+    @classmethod
+    def method_style(cls):
+        return "default"

--- a/python/tvm/contrib/msc/core/tools/execute.py
+++ b/python/tvm/contrib/msc/core/tools/execute.py
@@ -86,7 +86,7 @@ def create_tool(framework: str, tool_type: str, tag: str = "main", **config) -> 
     """
 
     tool_style = config.pop("tool_style") if "tool_style" in config else "default"
-    tool_cls = msc_utils.get_registered_tool_cls(framework, tool_type, tool_style)
+    tool_cls = msc_utils.get_registered_tool(framework, tool_type, tool_style)
     assert tool_cls, "Can not find tool class for {}:{} @ {}".format(
         tool_type, tool_style, framework
     )

--- a/python/tvm/contrib/msc/core/tools/prune/method.py
+++ b/python/tvm/contrib/msc/core/tools/prune/method.py
@@ -25,6 +25,7 @@ from tvm.contrib.msc.core.utils.namespace import MSCFramework
 from tvm.contrib.msc.core import utils as msc_utils
 
 
+@msc_utils.register_tool_method
 class PruneMethod(object):
     """Default prune method"""
 
@@ -114,5 +115,6 @@ class PruneMethod(object):
     def tool_type(cls):
         return ToolType.PRUNER
 
-
-msc_utils.register_tool_method(PruneMethod)
+    @classmethod
+    def method_style(cls):
+        return "default"

--- a/python/tvm/contrib/msc/core/tools/prune/pruner.py
+++ b/python/tvm/contrib/msc/core/tools/prune/pruner.py
@@ -541,10 +541,8 @@ class BasePruner(WeightTool):
         return ToolType.PRUNER
 
 
+@msc_utils.register_tool
 class DefaultPruner(BasePruner):
     @classmethod
     def tool_style(cls):
         return "default"
-
-
-msc_utils.register_tool_cls(DefaultPruner)

--- a/python/tvm/contrib/msc/core/tools/quantize/method.py
+++ b/python/tvm/contrib/msc/core/tools/quantize/method.py
@@ -25,6 +25,7 @@ from tvm.contrib.msc.core.utils.namespace import MSCFramework
 from tvm.contrib.msc.core import utils as msc_utils
 
 
+@msc_utils.register_tool_method
 class QuantizeMethod(object):
     """Default quantize method"""
 
@@ -468,5 +469,6 @@ class QuantizeMethod(object):
     def tool_type(cls):
         return ToolType.QUANTIZER
 
-
-msc_utils.register_tool_method(QuantizeMethod)
+    @classmethod
+    def method_style(cls):
+        return "default"

--- a/python/tvm/contrib/msc/core/tools/quantize/quantizer.py
+++ b/python/tvm/contrib/msc/core/tools/quantize/quantizer.py
@@ -254,10 +254,8 @@ class BaseQuantizer(BaseTool):
         return ToolType.QUANTIZER
 
 
+@msc_utils.register_tool
 class DefaultQuantizer(BaseQuantizer):
     @classmethod
     def tool_style(cls):
         return "default"
-
-
-msc_utils.register_tool_cls(DefaultQuantizer)

--- a/python/tvm/contrib/msc/core/tools/track/configer.py
+++ b/python/tvm/contrib/msc/core/tools/track/configer.py
@@ -25,9 +25,18 @@ from tvm.contrib.msc.core import utils as msc_utils
 class TrackConfiger(ToolConfiger):
     """Configer for track"""
 
-    @property
-    def apply_once(self):
-        return False
+    def config_apply(self) -> dict:
+        """Get the config fro apply
+
+        Returns
+        -------
+        config: dict
+            The apply config.
+        """
+
+        config = super().config_apply()
+        config.update({"apply_once": True})
+        return config
 
     @classmethod
     def tool_type(cls):

--- a/python/tvm/contrib/msc/core/tools/track/method.py
+++ b/python/tvm/contrib/msc/core/tools/track/method.py
@@ -25,6 +25,7 @@ from tvm.contrib.msc.core.utils.namespace import MSCFramework
 from tvm.contrib.msc.core import utils as msc_utils
 
 
+@msc_utils.register_tool_method
 class TrackMethod(object):
     """Default track method"""
 
@@ -95,6 +96,3 @@ class TrackMethod(object):
     @classmethod
     def method_style(cls):
         return "default"
-
-
-msc_utils.register_tool_method(TrackMethod)

--- a/python/tvm/contrib/msc/core/tools/track/tracker.py
+++ b/python/tvm/contrib/msc/core/tools/track/tracker.py
@@ -185,10 +185,8 @@ class BaseTracker(BaseTool):
         return ToolType.TRACKER
 
 
+@msc_utils.register_tool
 class DefaultTracker(BaseTracker):
     @classmethod
     def tool_style(cls):
         return "default"
-
-
-msc_utils.register_tool_cls(DefaultTracker)

--- a/python/tvm/contrib/msc/core/utils/expr.py
+++ b/python/tvm/contrib/msc/core/utils/expr.py
@@ -17,6 +17,7 @@
 """tvm.contrib.msc.core.utils.expr"""
 
 import copy
+from typing import Dict
 
 import tvm
 from tvm import relax
@@ -44,6 +45,28 @@ def get_expr_name(expr: relax.Expr) -> str:
     return name
 
 
+def make_span(kwargs: Dict[str, str], span: relax.Span = None) -> relax.Span:
+    """Change name to span
+
+    Parameters
+    ----------
+    kwargs: dict<str,str>
+        The attrs in span.
+    span: relax.Span
+        The source span.
+
+    Returns
+    -------
+    span: relax.Span
+        The span.
+    """
+
+    span = span or relax.Span(tvm.ir.SourceName(""), 0, 0, 0, 0)
+    for k, v in kwargs.items():
+        span = _ffi_api.SpanSetAttr(span, _ffi_api.ToAttrKey(k), v)
+    return span
+
+
 def set_expr_name(expr: relax.Expr, name: str):
     """Set the name for expr
 
@@ -60,7 +83,7 @@ def set_expr_name(expr: relax.Expr, name: str):
         The expr with name.
     """
 
-    expr.span = _ffi_api.SpanSetAttr(expr.span, _ffi_api.ToAttrKey("name"), name)
+    expr.span = make_span({"name": name}, expr.span)
     return expr
 
 

--- a/python/tvm/contrib/msc/core/utils/log.py
+++ b/python/tvm/contrib/msc/core/utils/log.py
@@ -135,3 +135,11 @@ def get_global_logger() -> logging.Logger:
     if not MSCMap.get(MSCKey.GLOBALE_LOGGER):
         MSCMap.set(MSCKey.GLOBALE_LOGGER, IOLogger())
     return MSCMap.get(MSCKey.GLOBALE_LOGGER)
+
+
+def remove_loggers():
+    """Remove the logger handlers"""
+
+    logger = MSCMap.get(MSCKey.GLOBALE_LOGGER)
+    if logger:
+        logger.handlers.clear()

--- a/python/tvm/contrib/msc/core/utils/message.py
+++ b/python/tvm/contrib/msc/core/utils/message.py
@@ -39,6 +39,7 @@ class MSCStage(object):
     OPTIMIZE = "optimize"
     COMPILE = "compile"
     SUMMARY = "summary"
+    EXPORT = "export"
     ALL = [
         SETUP,
         PREPARE,
@@ -51,6 +52,7 @@ class MSCStage(object):
         OPTIMIZE,
         COMPILE,
         SUMMARY,
+        EXPORT,
     ]
 
     @classmethod

--- a/python/tvm/contrib/msc/core/utils/register.py
+++ b/python/tvm/contrib/msc/core/utils/register.py
@@ -25,13 +25,12 @@ class MSCRegistery:
 
     REGISTERY = {}
     MSC_FUNCS = "msc_funcs"
-    MSC_TOOLS_CLS = "msc_tools_cls"
-    MSC_TOOLS_METHOD = "msc_tools_method"
+    TOOL_CLASSES = "tool_classes"
+    TOOL_METHODS = "tool_methods"
     TOOL_CONFIGERS = "tool_configers"
     GYM_CONFIGERS = "gym_configers"
     GYM_CONTROLLERS = "gym_controllers"
-    GYM_AGENTS = "gym_agents"
-    GYM_ENVS = "gym_envs"
+    GYM_OBJECTS = "gym_objects"
     GYM_METHODS = "gym_agents_method"
     RUNNER_HOOKS = "runner_hooks"
 
@@ -101,29 +100,25 @@ def get_registered_func(name: str, framework: str = MSCFramework.MSC):
     return funcs[framework].get(name)
 
 
-def register_tool_cls(tool_cls: Any):
+def register_tool(tool: Any):
     """Register a tool class.
 
     Parameters
     ----------
-    tool_cls: class
+    tool: class
         The tool class to be registered.
     """
 
-    tools_cls = MSCRegistery.get(MSCRegistery.MSC_TOOLS_CLS, {})
     for key in ["framework", "tool_type", "tool_style"]:
-        assert hasattr(tool_cls, key), "{} should be given to register tool class".format(key)
-    if tool_cls.framework() not in tools_cls:
-        tools_cls[tool_cls.framework()] = {}
-    framework_tools = tools_cls[tool_cls.framework()]
-    if tool_cls.tool_type() not in framework_tools:
-        framework_tools[tool_cls.tool_type()] = {}
-    tools = framework_tools[tool_cls.tool_type()]
-    tools[tool_cls.tool_style()] = tool_cls
-    MSCRegistery.register(MSCRegistery.MSC_TOOLS_CLS, tools_cls)
+        assert hasattr(tool, key), "{} should be given to register tool".format(key)
+    tools_classes = MSCRegistery.get(MSCRegistery.TOOL_CLASSES, {})
+    col = tools_classes.setdefault(tool.framework(), {}).setdefault(tool.tool_type(), {})
+    col[tool.tool_style()] = tool
+    MSCRegistery.register(MSCRegistery.TOOL_CLASSES, tools_classes)
+    return tool
 
 
-def get_registered_tool_cls(framework: str, tool_type: str, tool_style: str) -> Any:
+def get_registered_tool(framework: str, tool_type: str, tool_style: str) -> Any:
     """Get the registered tool class.
 
     Parameters
@@ -137,35 +132,32 @@ def get_registered_tool_cls(framework: str, tool_type: str, tool_style: str) -> 
 
     Returns
     -------
-    tool_cls: class
+    tool: class
         The registered tool class.
     """
 
-    tools_cls = MSCRegistery.get(MSCRegistery.MSC_TOOLS_CLS, {})
+    tools_classes = MSCRegistery.get(MSCRegistery.TOOL_CLASSES, {})
     if tool_style == "all":
-        return tools_cls.get(framework, {}).get(tool_type, {})
-    return tools_cls.get(framework, {}).get(tool_type, {}).get(tool_style)
+        return tools_classes.get(framework, {}).get(tool_type, {})
+    return tools_classes.get(framework, {}).get(tool_type, {}).get(tool_style)
 
 
-def register_tool_method(method_cls: Any, method_style: str = "default"):
+def register_tool_method(method: Any):
     """Register a tool method.
 
     Parameters
     ----------
-    method_cls: class
+    method: class
         The method class.
-    method_style: string
-        The style of the method.
     """
 
-    tools_method = MSCRegistery.get(MSCRegistery.MSC_TOOLS_METHOD, {})
-    for key in ["framework", "tool_type"]:
-        assert hasattr(method_cls, key), "{} should be given to register tool method".format(key)
-    if method_cls.framework() not in tools_method:
-        tools_method[method_cls.framework()] = {}
-    register_name = "{}.{}".format(method_cls.tool_type(), method_style)
-    tools_method[method_cls.framework()][register_name] = method_cls
-    MSCRegistery.register(MSCRegistery.MSC_TOOLS_METHOD, tools_method)
+    for key in ["framework", "tool_type", "method_style"]:
+        assert hasattr(method, key), "{} should be given to register tool method".format(key)
+    tool_methods = MSCRegistery.get(MSCRegistery.TOOL_METHODS, {})
+    col = tool_methods.setdefault(method.framework(), {}).setdefault(method.tool_type(), {})
+    col[method.method_style()] = method
+    MSCRegistery.register(MSCRegistery.TOOL_METHODS, tool_methods)
+    return method
 
 
 def get_registered_tool_method(
@@ -188,9 +180,8 @@ def get_registered_tool_method(
         The method class.
     """
 
-    tools_method = MSCRegistery.get(MSCRegistery.MSC_TOOLS_METHOD, {})
-    register_name = "{}.{}".format(tool_type, method_style)
-    return tools_method.get(framework, {}).get(register_name)
+    tool_methods = MSCRegistery.get(MSCRegistery.TOOL_METHODS, {})
+    return tool_methods.get(framework, {}).get(tool_type, {}).get(method_style)
 
 
 def register_tool_configer(configer: Any):
@@ -240,10 +231,11 @@ def register_gym_configer(configer: Any):
         The configer class.
     """
 
-    configers = MSCRegistery.get(MSCRegistery.GYM_CONFIGERS, {})
     assert hasattr(configer, "config_type"), "config_type should be given to register configer"
-    configers[configer.config_type()] = configer
-    MSCRegistery.register(MSCRegistery.GYM_CONFIGERS, configers)
+    gym_configers = MSCRegistery.get(MSCRegistery.GYM_CONFIGERS, {})
+    gym_configers[configer.config_type()] = configer
+    MSCRegistery.register(MSCRegistery.GYM_CONFIGERS, gym_configers)
+    return configer
 
 
 def get_registered_gym_configer(config_type: str) -> Any:
@@ -260,8 +252,8 @@ def get_registered_gym_configer(config_type: str) -> Any:
         The configer class.
     """
 
-    configers = MSCRegistery.get(MSCRegistery.GYM_CONFIGERS, {})
-    return configers.get(config_type)
+    gym_configers = MSCRegistery.get(MSCRegistery.GYM_CONFIGERS, {})
+    return gym_configers.get(config_type)
 
 
 def register_gym_controller(controller: Any):
@@ -273,12 +265,13 @@ def register_gym_controller(controller: Any):
         The controller class.
     """
 
-    controllers = MSCRegistery.get(MSCRegistery.GYM_CONTROLLERS, {})
     assert hasattr(
         controller, "control_type"
     ), "control_type should be given to register controller"
-    controllers[controller.control_type()] = controller
-    MSCRegistery.register(MSCRegistery.GYM_CONTROLLERS, controllers)
+    gym_controllers = MSCRegistery.get(MSCRegistery.GYM_CONTROLLERS, {})
+    gym_controllers[controller.control_type()] = controller
+    MSCRegistery.register(MSCRegistery.GYM_CONTROLLERS, gym_controllers)
+    return controller
 
 
 def get_registered_gym_controller(control_type: str) -> Any:
@@ -295,74 +288,46 @@ def get_registered_gym_controller(control_type: str) -> Any:
         The controller class.
     """
 
-    controllers = MSCRegistery.get(MSCRegistery.GYM_CONTROLLERS, {})
-    return controllers.get(control_type)
+    gym_controllers = MSCRegistery.get(MSCRegistery.GYM_CONTROLLERS, {})
+    return gym_controllers.get(control_type)
 
 
-def register_gym_agent(agent: Any):
-    """Register a gym agent.
+def register_gym_object(obj: Any):
+    """Register a gym object.
 
     Parameters
     ----------
-    agent: class
-        The agent class.
+    obj: class
+        The object class.
     """
 
-    agents = MSCRegistery.get(MSCRegistery.GYM_AGENTS, {})
-    assert hasattr(agent, "agent_type"), "agent_type should be given to register agent"
-    agents[agent.agent_type()] = agent
-    MSCRegistery.register(MSCRegistery.GYM_AGENTS, agents)
+    for key in ["role", "role_type"]:
+        assert hasattr(obj, key), "{} should be given to register gym object".format(key)
+    gym_objects = MSCRegistery.get(MSCRegistery.GYM_OBJECTS, {})
+    col = gym_objects.setdefault(obj.role(), {})
+    col[obj.role_type()] = obj
+    MSCRegistery.register(MSCRegistery.GYM_OBJECTS, gym_objects)
+    return obj
 
 
-def get_registered_gym_agent(agent_type: str) -> Any:
-    """Get the registered agent.
+def get_registered_gym_object(role: str, role_type: str) -> Any:
+    """Get the registered object.
 
     Parameters
     ----------
-    agent_type: string
-        The type of agent.
+    role: string
+        The role.
+    role_type: string
+        The type of the role.
 
     Returns
     -------
-    agent: class
-        The agent class.
+    object: class
+        The object class.
     """
 
-    agents = MSCRegistery.get(MSCRegistery.GYM_AGENTS, {})
-    return agents.get(agent_type)
-
-
-def register_gym_env(env: Any):
-    """Register a gym env.
-
-    Parameters
-    ----------
-    env: class
-        The env class.
-    """
-
-    envs = MSCRegistery.get(MSCRegistery.GYM_ENVS, {})
-    assert hasattr(env, "env_type"), "env_type should be given to register env"
-    envs[env.env_type()] = env
-    MSCRegistery.register(MSCRegistery.GYM_ENVS, envs)
-
-
-def get_registered_gym_env(env_type: str) -> Any:
-    """Get the registered env.
-
-    Parameters
-    ----------
-    env_type: string
-        The type of agent.
-
-    Returns
-    -------
-    env: class
-        The agent class.
-    """
-
-    envs = MSCRegistery.get(MSCRegistery.GYM_ENVS, {})
-    return envs.get(env_type)
+    gym_objects = MSCRegistery.get(MSCRegistery.GYM_OBJECTS, {})
+    return gym_objects.get(role, {}).get(role_type)
 
 
 def register_gym_method(method: Any):
@@ -374,17 +339,22 @@ def register_gym_method(method: Any):
         The method class.
     """
 
-    methods = MSCRegistery.get(MSCRegistery.GYM_METHODS, {})
-    assert hasattr(method, "method_type"), "method_type should be given to register method"
-    methods[method.method_type()] = method
-    MSCRegistery.register(MSCRegistery.GYM_METHODS, methods)
+    for key in ["role", "method_type"]:
+        assert hasattr(method, key), "{} should be given to register gym method".format(key)
+    gym_methods = MSCRegistery.get(MSCRegistery.GYM_METHODS, {})
+    col = gym_methods.setdefault(method.role(), {})
+    col[method.method_type()] = method
+    MSCRegistery.register(MSCRegistery.GYM_METHODS, gym_methods)
+    return method
 
 
-def get_registered_gym_method(method_type: str) -> Any:
+def get_registered_gym_method(role: str, method_type: str) -> Any:
     """Get the registered gym method.
 
     Parameters
     ----------
+    role: str
+        The role.
     method_type: str
         The type of method.
 
@@ -394,8 +364,8 @@ def get_registered_gym_method(method_type: str) -> Any:
         The method class.
     """
 
-    methods = MSCRegistery.get(MSCRegistery.GYM_METHODS, {})
-    return methods.get(method_type)
+    gym_methods = MSCRegistery.get(MSCRegistery.GYM_METHODS, {})
+    return gym_methods.get(role, {}).get(method_type)
 
 
 def register_runner_hook(hook: Any):
@@ -407,10 +377,11 @@ def register_runner_hook(hook: Any):
         The hook class.
     """
 
-    hooks = MSCRegistery.get(MSCRegistery.RUNNER_HOOKS, {})
     assert hasattr(hook, "name"), "name should be given to register hook"
+    hooks = MSCRegistery.get(MSCRegistery.RUNNER_HOOKS, {})
     hooks[hook.name()] = hook
     MSCRegistery.register(MSCRegistery.RUNNER_HOOKS, hooks)
+    return hook
 
 
 def get_registered_runner_hook(name: str) -> Any:

--- a/python/tvm/contrib/msc/framework/tensorflow/tools/distill/distiller.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/tools/distill/distiller.py
@@ -39,6 +39,7 @@ class TensorflowDistillerFactory(object):
             The distiller class.
         """
 
+        @msc_utils.register_tool
         class Distiller(base_cls):
             """Adaptive distiller for tensorflow"""
 
@@ -50,6 +51,6 @@ class TensorflowDistillerFactory(object):
 
 
 factory = TensorflowDistillerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.DISTILLER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.DISTILLER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tensorflow/tools/prune/pruner.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/tools/prune/pruner.py
@@ -39,6 +39,7 @@ class TensorflowPrunerFactory(object):
             The pruner class.
         """
 
+        @msc_utils.register_tool
         class Pruner(base_cls):
             """Adaptive pruner for tensorflow"""
 
@@ -50,6 +51,6 @@ class TensorflowPrunerFactory(object):
 
 
 factory = TensorflowPrunerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.PRUNER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.PRUNER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tensorflow/tools/quantize/quantizer.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/tools/quantize/quantizer.py
@@ -39,6 +39,7 @@ class TensorflowQuantizerFactory(object):
             The quantizer class.
         """
 
+        @msc_utils.register_tool
         class Quantizer(base_cls):
             """Adaptive quantizer for tensorflow"""
 
@@ -50,6 +51,6 @@ class TensorflowQuantizerFactory(object):
 
 
 factory = TensorflowQuantizerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.QUANTIZER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.QUANTIZER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tensorflow/tools/track/tracker.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/tools/track/tracker.py
@@ -39,6 +39,7 @@ class TensorflowTrackerFactory(object):
             The tracker class.
         """
 
+        @msc_utils.register_tool
         class Tracker(base_cls):
             """Adaptive tracker for tensorflow"""
 
@@ -50,6 +51,6 @@ class TensorflowTrackerFactory(object):
 
 
 factory = TensorflowTrackerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.TRACKER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.TRACKER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tensorrt/runtime/runner.py
+++ b/python/tvm/contrib/msc/framework/tensorrt/runtime/runner.py
@@ -17,6 +17,7 @@
 # pylint: disable=unused-import
 """tvm.contrib.msc.framework.tensorrt.runtime.runner"""
 
+import os
 from typing import Any, List, Dict
 
 import tvm
@@ -101,6 +102,28 @@ class TensorRTRunner(BYOCRunner):
             self._generate_config = tool.config_generate(self._generate_config)
 
         return super()._generate_model(graphs, weights)
+
+    def export_runnable(self, folder: msc_utils.MSCDirectory) -> dict:
+        """Export the runnable
+
+        Parameters
+        -------
+        folder: MSCDirectory
+            The export folder.
+
+        Returns
+        -------
+        info: dict
+            The runnable info.
+        """
+
+        info = super().export_runnable(folder)
+        info["engines"] = {}
+        for graph in self._graphs:
+            engine_file = msc_utils.get_output_dir().relpath(graph.name + ".trt")
+            assert os.path.isfile(engine_file), "Missing engine file " + engine_file
+            info["engines"] = folder.copy(engine_file)
+        return info
 
     @classmethod
     def target_transform(cls, mod: tvm.IRModule):

--- a/python/tvm/contrib/msc/framework/tensorrt/tools/distill/distiller.py
+++ b/python/tvm/contrib/msc/framework/tensorrt/tools/distill/distiller.py
@@ -39,6 +39,7 @@ class TensorRTDistillerFactory(object):
             The distiller class.
         """
 
+        @msc_utils.register_tool
         class Distiller(base_cls):
             """Adaptive distiller for tensorrt"""
 
@@ -50,6 +51,6 @@ class TensorRTDistillerFactory(object):
 
 
 factory = TensorRTDistillerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.DISTILLER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.DISTILLER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tensorrt/tools/prune/pruner.py
+++ b/python/tvm/contrib/msc/framework/tensorrt/tools/prune/pruner.py
@@ -39,6 +39,7 @@ class TensorRTPrunerFactory(object):
             The pruner class.
         """
 
+        @msc_utils.register_tool
         class Pruner(base_cls):
             """Adaptive pruner for tensorrt"""
 
@@ -50,6 +51,6 @@ class TensorRTPrunerFactory(object):
 
 
 factory = TensorRTPrunerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.PRUNER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.PRUNER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tensorrt/tools/quantize/method.py
+++ b/python/tvm/contrib/msc/framework/tensorrt/tools/quantize/method.py
@@ -24,6 +24,7 @@ from tvm.contrib.msc.core.utils.namespace import MSCFramework
 from tvm.contrib.msc.core import utils as msc_utils
 
 
+@msc_utils.register_tool_method
 class TensorRTQuantizeMethod(QuantizeMethod):
     """Default quantize method for tensorrt"""
 
@@ -144,6 +145,3 @@ class TensorRTQuantizeMethod(QuantizeMethod):
     @classmethod
     def framework(cls):
         return MSCFramework.TENSORRT
-
-
-msc_utils.register_tool_method(TensorRTQuantizeMethod)

--- a/python/tvm/contrib/msc/framework/tensorrt/tools/quantize/quantizer.py
+++ b/python/tvm/contrib/msc/framework/tensorrt/tools/quantize/quantizer.py
@@ -45,6 +45,7 @@ class TensorRTQuantizerFactory(object):
             The quantizer class.
         """
 
+        @msc_utils.register_tool
         class Quantizer(base_cls):
             """Adaptive quantizer for tensorrt"""
 
@@ -357,6 +358,6 @@ class TensorRTQuantizerFactory(object):
 
 
 factory = TensorRTQuantizerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.QUANTIZER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.QUANTIZER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tensorrt/tools/track/tracker.py
+++ b/python/tvm/contrib/msc/framework/tensorrt/tools/track/tracker.py
@@ -42,6 +42,7 @@ class TensorRTTrackerFactory(object):
             The tracker class.
         """
 
+        @msc_utils.register_tool
         class Tracker(base_cls):
             """Adaptive tracker for tensorrt"""
 
@@ -154,6 +155,6 @@ class TensorRTTrackerFactory(object):
 
 
 factory = TensorRTTrackerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.TRACKER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.TRACKER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/torch/tools/distill/distiller.py
+++ b/python/tvm/contrib/msc/framework/torch/tools/distill/distiller.py
@@ -43,6 +43,7 @@ class TorchDistillerFactory(object):
             The distiller class.
         """
 
+        @msc_utils.register_tool
         class Distiller(base_cls):
             """Adaptive distiller for torch"""
 
@@ -139,6 +140,6 @@ class TorchDistillerFactory(object):
 
 
 factory = TorchDistillerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.DISTILLER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.DISTILLER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/torch/tools/distill/method.py
+++ b/python/tvm/contrib/msc/framework/torch/tools/distill/method.py
@@ -25,6 +25,7 @@ from tvm.contrib.msc.core.utils.namespace import MSCFramework
 from tvm.contrib.msc.core import utils as msc_utils
 
 
+@msc_utils.register_tool_method
 class TorchDistillMethod(DistillMethod):
     """Default quantize method for torch"""
 
@@ -111,6 +112,3 @@ class TorchDistillMethod(DistillMethod):
     @classmethod
     def framework(cls):
         return MSCFramework.TORCH
-
-
-msc_utils.register_tool_method(TorchDistillMethod)

--- a/python/tvm/contrib/msc/framework/torch/tools/prune/pruner.py
+++ b/python/tvm/contrib/msc/framework/torch/tools/prune/pruner.py
@@ -39,6 +39,7 @@ class TorchPrunerFactory(object):
             The pruner class.
         """
 
+        @msc_utils.register_tool
         class Pruner(base_cls):
             """Adaptive pruner for torch"""
 
@@ -50,6 +51,6 @@ class TorchPrunerFactory(object):
 
 
 factory = TorchPrunerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.PRUNER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.PRUNER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/torch/tools/quantize/method.py
+++ b/python/tvm/contrib/msc/framework/torch/tools/quantize/method.py
@@ -55,6 +55,7 @@ def fake_quantize(func):
     return wrapper
 
 
+@msc_utils.register_tool_method
 class TorchQuantizeMethod(QuantizeMethod):
     """Default quantize method for torch"""
 
@@ -264,6 +265,3 @@ class TorchQuantizeMethod(QuantizeMethod):
     @classmethod
     def framework(cls):
         return MSCFramework.TORCH
-
-
-msc_utils.register_tool_method(TorchQuantizeMethod)

--- a/python/tvm/contrib/msc/framework/torch/tools/quantize/quantizer.py
+++ b/python/tvm/contrib/msc/framework/torch/tools/quantize/quantizer.py
@@ -39,6 +39,7 @@ class TorchQuantizerFactory(object):
             The quantizer class.
         """
 
+        @msc_utils.register_tool
         class Quantizer(base_cls):
             """Adaptive quantizer for torch"""
 
@@ -50,6 +51,6 @@ class TorchQuantizerFactory(object):
 
 
 factory = TorchQuantizerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.QUANTIZER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.QUANTIZER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/torch/tools/track/tracker.py
+++ b/python/tvm/contrib/msc/framework/torch/tools/track/tracker.py
@@ -39,6 +39,7 @@ class TorchTrackerFactory(object):
             The tracker class.
         """
 
+        @msc_utils.register_tool
         class Tracker(base_cls):
             """Adaptive tracker for torch"""
 
@@ -50,6 +51,6 @@ class TorchTrackerFactory(object):
 
 
 factory = TorchTrackerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.TRACKER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.TRACKER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tvm/tools/distill/distiller.py
+++ b/python/tvm/contrib/msc/framework/tvm/tools/distill/distiller.py
@@ -39,6 +39,7 @@ class TVMDistillerFactory(object):
             The distiller class.
         """
 
+        @msc_utils.register_tool
         class Distiller(base_cls):
             """Adaptive distiller for tvm"""
 
@@ -50,6 +51,6 @@ class TVMDistillerFactory(object):
 
 
 factory = TVMDistillerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.DISTILLER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.DISTILLER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tvm/tools/prune/pruner.py
+++ b/python/tvm/contrib/msc/framework/tvm/tools/prune/pruner.py
@@ -39,6 +39,7 @@ class TVMPrunerFactory(object):
             The pruner class.
         """
 
+        @msc_utils.register_tool
         class Pruner(base_cls):
             """Adaptive pruner for tvm"""
 
@@ -50,6 +51,6 @@ class TVMPrunerFactory(object):
 
 
 factory = TVMPrunerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.PRUNER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.PRUNER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tvm/tools/quantize/method.py
+++ b/python/tvm/contrib/msc/framework/tvm/tools/quantize/method.py
@@ -28,6 +28,7 @@ from tvm.contrib.msc.core import utils as msc_utils
 from tvm.contrib.msc.core import _ffi_api
 
 
+@msc_utils.register_tool_method
 class TVMQuantizeMethod(QuantizeMethod):
     """Default quantize method for tvm"""
 
@@ -200,6 +201,3 @@ class TVMQuantizeMethod(QuantizeMethod):
     @classmethod
     def framework(cls):
         return MSCFramework.TVM
-
-
-msc_utils.register_tool_method(TVMQuantizeMethod)

--- a/python/tvm/contrib/msc/framework/tvm/tools/quantize/quantizer.py
+++ b/python/tvm/contrib/msc/framework/tvm/tools/quantize/quantizer.py
@@ -43,6 +43,7 @@ class TVMQuantizerFactory(object):
             The quantizer class.
         """
 
+        @msc_utils.register_tool
         class Quantizer(base_cls):
             """Adaptive quantizer for tvm"""
 
@@ -162,6 +163,6 @@ class TVMQuantizerFactory(object):
 
 
 factory = TVMQuantizerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.QUANTIZER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.QUANTIZER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/framework/tvm/tools/track/tracker.py
+++ b/python/tvm/contrib/msc/framework/tvm/tools/track/tracker.py
@@ -43,6 +43,7 @@ class TVMTrackerFactory(object):
             The tracker class.
         """
 
+        @msc_utils.register_tool
         class Tracker(base_cls):
             """Adaptive tracker for tvm"""
 
@@ -153,6 +154,6 @@ class TVMTrackerFactory(object):
 
 
 factory = TVMTrackerFactory()
-tools = msc_utils.get_registered_tool_cls(MSCFramework.MSC, ToolType.TRACKER, tool_style="all")
+tools = msc_utils.get_registered_tool(MSCFramework.MSC, ToolType.TRACKER, tool_style="all")
 for tool in tools.values():
-    msc_utils.register_tool_cls(factory.create(tool))
+    factory.create(tool)

--- a/python/tvm/contrib/msc/pipeline/config.py
+++ b/python/tvm/contrib/msc/pipeline/config.py
@@ -116,8 +116,8 @@ def create_config(
     baseline_type = baseline_type or model_type
     optimize_type = optimize_type or baseline_type
     compile_type = compile_type or optimize_type
-    if tools:
-        tools = [config_tool(t_type, t_config) for t_type, t_config in tools]
+    tools = tools or []
+    tools = [config_tool(t_type, t_config) for t_type, t_config in tools]
     # basic config
     config = {
         "model_type": model_type,
@@ -133,7 +133,8 @@ def create_config(
     }
 
     # config optimize
-    if tools:
+    opt_tools = [t for t in tools if support_tool(t, MSCStage.OPTIMIZE, optimize_type)]
+    if opt_tools:
         config[MSCStage.OPTIMIZE] = {
             "run_type": optimize_type,
             "profile": {"check": {"atol": 1e-3, "rtol": 1e-3}, "benchmark": {"repeat": -1}},
@@ -144,6 +145,10 @@ def create_config(
         "run_type": compile_type,
         "profile": {"check": {"atol": 1e-3, "rtol": 1e-3}, "benchmark": {"repeat": -1}},
     }
+
+    # update config
+    if extra_config:
+        config = msc_utils.update_dict(config, extra_config)
 
     # skip stages
     skip_config = skip_config or {}
@@ -164,7 +169,4 @@ def create_config(
             else:
                 raise TypeError("Unexpected skip type " + str(skip_config[key]))
 
-    # update config
-    if extra_config:
-        config = msc_utils.update_dict(config, extra_config)
     return config


### PR DESCRIPTION
This is a pull request for MSC(Multi-System Compile)
RFC: https://discuss.tvm.apache.org/t/rfc-unity-msc-introduction-to-multi-system-compiler/15251/5
Tracking issue: https://github.com/apache/tvm/issues/15233

This is the Milestone 5 for MSC: Add MSCWrapper as compression toolchain.
To limit each PR in reviewable size, the Milestone 5 will be split into some steps:
[M5.1] Build wrapper to support compression.
**[M5.2] Enable quantize && prune with gym by wrapper.**
[M5.3] Support torch.dynamo for dynamic models.

Gym for msc works like autotvm to tvm. Gym use environment to evaluate compression strategy and agent will search the best strategy.

This PR:
  1. Refactor the gym system. The example of using gym for auto compression is: https://github.com/apache/tvm/blob/main/gallery/how_to/work_with_msc/using_tools.py, use `python use_tools.py --prune --gym` to test auto compression.
  2. Refactor the register for MSC objects, so that custom tools can be register for optimize the model.
  3. Enable export after run msc pipeline. The exported tar.gz package can be used for loading model
 
cc @Hzfengsy 