### PR TITLE
[CI][AArch64] Enable ONNX and PyTorch tests on AArch64

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -17,13 +17,13 @@
 
 # This data file is read during when Jenkins runs job to determine docker images.
 [jenkins]
-ci_arm: tlcpack/ci-arm:20240126-070121-8ade9c30e
+ci_arm: 477529581014.dkr.ecr.us-west-2.amazonaws.com/ci_arm:PR-16512-35f44b862-2
 ci_cortexm: tlcpack/ci-cortexm:20240126-070121-8ade9c30e
-ci_cpu: tlcpack/ci-cpu:20240126-070121-8ade9c30e
+ci_cpu: 477529581014.dkr.ecr.us-west-2.amazonaws.com/ci_cpu:PR-16512-d46990f18-2
 ci_gpu: tlcpack/ci-gpu:20240126-070121-8ade9c30e
 ci_hexagon: tlcpack/ci-hexagon:20240126-070121-8ade9c30e
 ci_i386: tlcpack/ci-i386:20240126-070121-8ade9c30e
-ci_lint: tlcpack/ci-lint:20240126-070121-8ade9c30e
+ci_lint: 477529581014.dkr.ecr.us-west-2.amazonaws.com/ci_lint:PR-16512-ccc3c5f37-2
 ci_minimal: tlcpack/ci-minimal:20240126-070121-8ade9c30e
 ci_riscv: tlcpack/ci-riscv:20240126-070121-8ade9c30e
 ci_wasm: tlcpack/ci-wasm:20240126-070121-8ade9c30e

--- a/ci/jenkins/generated/arm_jenkinsfile.groovy
+++ b/ci/jenkins/generated/arm_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2024-01-10T13:15:25.226391
+// Generated at 2024-03-01T17:24:13.590653
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -918,7 +918,11 @@ def shard_run_frontend_aarch64_1_of_2(node_type='ARM-GRAVITON3-SPOT', on_demand=
               ci_setup(ci_arm)
               sh (
                 script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
-                label: 'Run Python frontend tests',
+                label: 'Run General Python frontend tests',
+              )
+              sh (
+                script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_aarch64only.sh",
+                label: 'Run AArch64 Python frontend tests',
               )
             })
           }
@@ -966,7 +970,11 @@ def shard_run_frontend_aarch64_2_of_2(node_type='ARM-GRAVITON3-SPOT', on_demand=
               ci_setup(ci_arm)
               sh (
                 script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
-                label: 'Run Python frontend tests',
+                label: 'Run General Python frontend tests',
+              )
+              sh (
+                script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_aarch64only.sh",
+                label: 'Run AArch64 Python frontend tests',
               )
             })
           }

--- a/ci/jenkins/templates/arm_jenkinsfile.groovy.j2
+++ b/ci/jenkins/templates/arm_jenkinsfile.groovy.j2
@@ -93,7 +93,11 @@
   ci_setup(ci_arm)
   sh (
     script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_cpu.sh",
-    label: 'Run Python frontend tests',
+    label: 'Run General Python frontend tests',
+  )
+  sh (
+    script: "${docker_run} ${ci_arm} ./tests/scripts/task_python_frontend_aarch64only.sh",
+    label: 'Run AArch64 Python frontend tests',
   )
 {% endcall %}
 

--- a/tests/scripts/task_python_frontend_aarch64only.sh
+++ b/tests/scripts/task_python_frontend_aarch64only.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euxo pipefail
+
+source tests/scripts/setup-pytest-env.sh
+# to avoid openblas threading error
+export TVM_BIND_THREADS=0
+export OMP_NUM_THREADS=1
+
+export TVM_TEST_TARGETS="llvm"
+
+find . -type f -path "*.pyc" | xargs rm -f
+
+# Rebuild cython
+make cython3
+
+echo "Running relay ONNX frontend test..."
+run_pytest cython python-frontend-onnx tests/python/frontend/onnx
+
+echo "Running relay PyTorch frontend test..."
+run_pytest cython python-frontend-pytorch tests/python/frontend/pytorch


### PR DESCRIPTION
This makes use of work done in enabling PyTorch and ONNX tests to be run
on AArch64 to actually enable the tests to run as part of CI.

Co-Authored-By: Nicola Lancellotti <Nicola.Lancellotti@arm.com>
Co-Authored-By: Leandron <leandron85@gmail.com>

cc @leandron @lhutton1 @NicolaLancellotti @tqchen @yongwww 