### PR TITLE
Enable Shared Function in LiftTransformParam Pass

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -265,12 +265,18 @@ TVM_DLL Pass RealizeVDevice();
  * Users are expected to invoke the `transform_params` function in runtime and pass the transformed
  * parameters to the original function as input.
  *
- * \param shared_transform Whether to share the transformation of the parameters among all functions
- * If true, all functions should have the same parameters and the common part of the transformations
- * will be lifted to a global `transform_params` function that is shared among all functions. If
- * false, each function will have its own `transform_params` function.
- * \param target_functions The list of functions to apply the shared transformation. If empty, the
- * shared transformation will be applied to all functions.
+ * \param shared_transform Indicates how the parameter transformation function will be produced.
+ *    - `False` (default): A separate parameter transformation function will be produced for each
+ *      function with the `"num_input"` attribute.
+ *
+ *    - `True`: A single parameter transformation function will be produced, containing the
+ *      preprocessing steps common across all functions with the `"num_input"` attribute.
+ *
+ *    - List[str]: A single parameter transformation function will be produced, containing the
+ *      preprocessing steps common across each function whose name is in the list. Passing a list of
+ *      all functions with the `"num_input"` attribute or an empty list is equivalent to passing
+ *      `True`.
+ *
  * \return The Pass.
  */
 TVM_DLL Pass LiftTransformParams(Variant<Bool, Array<String>> shared_transform = Bool(false));

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -273,7 +273,7 @@ TVM_DLL Pass RealizeVDevice();
  * shared transformation will be applied to all functions.
  * \return The Pass.
  */
-TVM_DLL Pass LiftTransformParams(bool shared_transform, Array<String> target_functions);
+TVM_DLL Pass LiftTransformParams(Variant<Bool, Array<String>> shared_transform = Bool(false));
 
 /*!
  * \brief Update virtual device.

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -265,9 +265,15 @@ TVM_DLL Pass RealizeVDevice();
  * Users are expected to invoke the `transform_params` function in runtime and pass the transformed
  * parameters to the original function as input.
  *
+ * \param shared_transform Whether to share the transformation of the parameters among all functions
+ * If true, all functions should have the same parameters and the common part of the transformations
+ * will be lifted to a global `transform_params` function that is shared among all functions. If
+ * false, each function will have its own `transform_params` function.
+ * \param target_functions The list of functions to apply the shared transformation. If empty, the
+ * shared transformation will be applied to all functions.
  * \return The Pass.
  */
-TVM_DLL Pass LiftTransformParams();
+TVM_DLL Pass LiftTransformParams(bool shared_transform, Array<String> target_functions);
 
 /*!
  * \brief Update virtual device.

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -832,7 +832,7 @@ def MergeCompositeFunctions() -> tvm.ir.transform.Pass:
     return _ffi_api.MergeCompositeFunctions()  # type: ignore
 
 
-def LiftTransformParams() -> tvm.ir.transform.Pass:
+def LiftTransformParams(shared_transform: Union[bool, List[str]] = False) -> tvm.ir.transform.Pass:
     """Lift transformation of the parameters of a function.
 
     When some inputs of the function is marked as 'parameters' (the model weights), this pass
@@ -844,12 +844,28 @@ def LiftTransformParams() -> tvm.ir.transform.Pass:
     Users are expected to invoke the `transform_params` function in runtime and pass the transformed
     parameters to the original function as input.
 
+    Parameters
+    ----------
+    shared_transform : Union[bool, List[str]]
+        Boolean to indicate whether to share the transformation of the parameters among functions or
+        a list of function names to apply the shared transformation.
+
+        When the shared transformation is enabled, all the target functions should have the same
+        parameters and the common part of the transformations will be lifted to a global
+        `transform_params` function that is shared among all functions.
+        Otherwise, each function will have its own `transform_params` function.
+
     Returns
     -------
     ret : tvm.transform.Pass
         The registered pass for lifting transformation of parameters.
     """
-    return _ffi_api.LiftTransformParams()  # type: ignore
+    if isinstance(shared_transform, bool):
+        target_functions = []
+    else:
+        target_functions = shared_transform
+        shared_transform = True
+    return _ffi_api.LiftTransformParams(shared_transform, target_functions)  # type: ignore
 
 
 def BundleModelParams(param_tuple_name: Optional[str] = None) -> tvm.ir.transform.Pass:

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -854,13 +854,13 @@ def LiftTransformParams(shared_transform: Union[bool, List[str]] = False) -> tvm
         produced for each function with the `"num_input"` attribute.
 
         - `True`: A single parameter transformation function will be produced,
-        containing thepreprocessing steps common across all functions with
+        containing the preprocessing steps common across all functions with
         the `"num_input"` attribute.
 
         - List[str]: A single parameter transformation function will be produced,
         containing the preprocessing steps common across each function whose
         name is in the list.  Passing a list of all functions with the `"num_input"`
-        attribute is equivalent to passing `True`.
+        attribute or an empty list is equivalent to passing `True`.
 
     Returns
     -------

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -846,26 +846,28 @@ def LiftTransformParams(shared_transform: Union[bool, List[str]] = False) -> tvm
 
     Parameters
     ----------
-    shared_transform : Union[bool, List[str]]
-        Boolean to indicate whether to share the transformation of the parameters among functions or
-        a list of function names to apply the shared transformation.
+    shared_transform: Union[bool, List[str]]
 
-        When the shared transformation is enabled, all the target functions should have the same
-        parameters and the common part of the transformations will be lifted to a global
-        `transform_params` function that is shared among all functions.
-        Otherwise, each function will have its own `transform_params` function.
+        Indicates how the parameter transformation function will be produced
+
+        - `False` (default): A separate parameter transformation function will be
+        produced for each function with the `"num_input"` attribute.
+
+        - `True`: A single parameter transformation function will be produced,
+        containing thepreprocessing steps common across all functions with
+        the `"num_input"` attribute.
+
+        - List[str]: A single parameter transformation function will be produced,
+        containing the preprocessing steps common across each function whose
+        name is in the list.  Passing a list of all functions with the `"num_input"`
+        attribute is equivalent to passing `True`.
 
     Returns
     -------
     ret : tvm.transform.Pass
         The registered pass for lifting transformation of parameters.
     """
-    if isinstance(shared_transform, bool):
-        target_functions = []
-    else:
-        target_functions = shared_transform
-        shared_transform = True
-    return _ffi_api.LiftTransformParams(shared_transform, target_functions)  # type: ignore
+    return _ffi_api.LiftTransformParams(shared_transform)  # type: ignore
 
 
 def BundleModelParams(param_tuple_name: Optional[str] = None) -> tvm.ir.transform.Pass:

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -700,38 +700,6 @@ class ConsumeBundledParams : public ExprMutator {
   std::unordered_map<int, Expr> param_remap_;
 };
 
-// std::pair<std::unordered_set<GlobalVar, ObjectPtrHash, ObjectPtrEqual>, std::vector<Function>>
-//  GetTargetFunctions(const IRModule& mod, const Array<String>& target_function_names) {
-//   std::unordered_set<GlobalVar, ObjectPtrHash, ObjectPtrEqual> target_gvars;
-//   std::vector<Function> target_functions;
-//   if (target_function_names.size()) {
-//     for (const auto& name : target_function_names) {
-//       auto gvar = mod->GetGlobalVar(name);
-//       target_gvars.insert(gvar);
-//       target_functions.push_back(Downcast<Function>(mod->Lookup(gvar)));
-//     }
-//   } else {
-//     // Get all the functions that have the `num_input` attribute.
-//     std::vector<GlobalVar> ordered_target_gvars;
-//     for (const auto& [gvar, func] : mod->functions) {
-//       if (func->IsInstance<FunctionNode>()) {
-//         auto opt_num_input = func->GetAttr<Integer>(attr::kNumInput);
-//         if (opt_num_input) {
-//           ordered_target_gvars.push_back(gvar);
-//         }
-//       }
-//     }
-//     std::sort(ordered_target_gvars.begin(), ordered_target_gvars.end(),
-//               [](const GlobalVar& lhs, const GlobalVar& rhs) { return lhs->name_hint <
-//               rhs->name_hint; });
-//     for (const auto& gvar : ordered_target_gvars) {
-//       target_functions.push_back(Downcast<Function>(mod->Lookup(gvar->name_hint)));
-//     }
-//     target_gvars.insert(ordered_target_gvars.begin(), ordered_target_gvars.end());
-//   }
-//   return {target_gvars, target_functions};
-// }
-
 std::vector<std::pair<GlobalVar, Function>> GetTargetFunctions(
     const IRModule& mod, const Array<String>& target_function_names) {
   std::vector<std::pair<GlobalVar, Function>> target_functions;

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -425,7 +425,9 @@ class LocalLiftableBindingCollector : public BaseLiftableBindingCollector {
   }
 
  private:
-  LocalLiftableBindingCollector(GlobalCollectInfo* global_info) { info_.global_info = global_info; }
+  explicit LocalLiftableBindingCollector(GlobalCollectInfo* global_info) {
+    info_.global_info = global_info;
+  }
   void VisitExpr_(const FunctionNode* func) override {
     size_t num_runtime_params = func->params.size();
     if (auto opt = func->attrs.GetAttr<Integer>(attr::kNumInput)) {

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -578,10 +578,12 @@ class GlobalLiftableBindingCollector : public BaseLiftableBindingCollector {
     Array<Var> params(functions[0]->params.begin() +
                           functions[0]->GetAttr<Integer>(attr::kNumInput).value()->value,
                       functions[0]->params.end());
-    GlobalCollectInfo info{.orig_functions = functions,
-                           .params = std::move(params),
-                           .var_remap = var_remap,
-                           .tir_var_remap = tir_var_remap};
+    // todo(@tvm-team): use c++20 designated initializers when windows CI supports it
+    GlobalCollectInfo info = GlobalCollectInfo();
+    info.orig_functions = functions;
+    info.params = std::move(params);
+    info.var_remap = var_remap;
+    info.tir_var_remap = tir_var_remap;
     // Find shared bindings among transform_params. Re-compute var_remap based on the shared
     // bindings as collector.var_remap_ may contain invalid mappings.
     for (const auto& unified_binding : collector.unified_bindings_) {
@@ -641,7 +643,7 @@ class GlobalLiftableBindingCollector : public BaseLiftableBindingCollector {
   // defined in var_remap_.
   std::unordered_map<Expr, std::vector<Binding>, StructuralHash, StructuralEqual>
       original_bindings_;
-};
+};  // namespace
 
 GlobalCollectInfo MakeGlobalLiftPlan(const IRModule& mod,
                                      const std::vector<Function>& target_functions) {

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -701,10 +701,10 @@ class ConsumeBundledParams : public ExprMutator {
 };
 
 std::vector<std::pair<GlobalVar, Function>> GetTargetFunctions(
-    const IRModule& mod, const Array<String>& target_function_names) {
+    const IRModule& mod, const Variant<Bool, Array<String>>& shared_transform) {
   std::vector<std::pair<GlobalVar, Function>> target_functions;
-  if (target_function_names.size()) {
-    for (const auto& name : target_function_names) {
+  if (shared_transform.as<Array<String>>().value_or(Array<String>{}).size()) {
+    for (const auto& name : shared_transform.as<Array<String>>().value()) {
       auto gvar = mod->GetGlobalVar(name);
       target_functions.push_back({gvar, Downcast<Function>(mod->Lookup(gvar))});
     }
@@ -738,8 +738,8 @@ Pass PartitionTransformParams(Variant<Bool, Array<String>> shared_transform) {
     CHECK(shared_transform.defined()) << "shared_transform is not defined";
     CHECK((shared_transform.as<Bool>() || shared_transform.as<Array<String>>()))
         << "shared_transform should be a boolean or an array of function names";
-    auto target_functions =
-        GetTargetFunctions(mod, shared_transform.as<Array<String>>().value_or(Array<String>{}));
+
+    auto target_functions = GetTargetFunctions(mod, shared_transform);
 
     if (shared_transform.as<Bool>().value_or(Bool(true))) {
       std::vector<Function> functions;

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -710,6 +710,7 @@ Pass PartitionTransformParams() {
         return Downcast<Var>(global_collect_info.value().var_remap[var]);
       });
       Array<Binding> bindings = local_collect_info.begin()->second.computable_at_compile_time;
+      LOG(INFO) << "ComputableAtCompileTime: " << bindings;
       // FIXME(wuwei): need to consider non-VarBinding cases
       for (int i = 0; i < bindings.size(); i++) {
         auto binding = bindings[i];

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -760,15 +760,17 @@ Pass PartitionTransformParams(Variant<Bool, Array<String>> shared_transform) {
     for (const auto& [gvar, info] : local_collect_info) {
       auto new_runtime_func = info.MakeRuntimeFunction();
       updates->Add(gvar, new_runtime_func);
-      if (!global_collect_info.has_value()) {
+    }
+
+    if (global_collect_info.has_value()) {
+      auto global_transform = global_collect_info.value().MakeCompileTimeFunc();
+      updates->Add(GlobalVar("transform_params"), global_transform);
+    } else {
+      for (const auto& [gvar, info] : local_collect_info) {
         // transform_params is emitted for each function if global lifting is not enabled
         updates->Add(GlobalVar(gvar->name_hint + "_transform_params"),
                      info.MakeCompileTimeFunction());
       }
-    }
-    if (global_collect_info.has_value()) {
-      auto global_transform = global_collect_info.value().MakeCompileTimeFunc();
-      updates->Add(GlobalVar("transform_params"), global_transform);
     }
 
     if (updates->functions.size()) {

--- a/tests/python/relax/test_transform_lift_transform_params.py
+++ b/tests/python/relax/test_transform_lift_transform_params.py
@@ -482,6 +482,870 @@ def test_multiple_functions():
     tvm.ir.assert_structural_equal(after, Expected)
 
 
+def test_share_identical_transform_across_multiple_functions():
+    """Like test_multiple_functions, but producing a single transform_params
+
+    `func1` and `func2` contain the same values `w1_t` and `w2_t`.
+    When `shared_transform=True`, all eligible publicly-exposed
+    functions must be usable with the same shared transform.
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.multiply(y1, y2)
+                R.output(output)
+            return output
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def transform_params(
+            params: R.Tuple(
+                R.Tensor((256, 256), dtype="float32"),
+                R.Tensor((256, 256), dtype="float32"),
+            )
+        ):
+            R.func_attr({"num_input": 0})
+            with R.dataflow():
+                w1 = params[0]
+                w1_t = R.permute_dims(w1)
+                w2 = params[1]
+                w1_t = R.permute_dims(w1)
+                output = (w2, w1_t)
+                R.output(output)
+            return output
+
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+            w2_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+            w2_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                y2 = R.matmul(x, w2_t)
+                output = R.multiply(y1, y2)
+                R.output(output)
+            return output
+
+    after = relax.transform.LiftTransformParams(shared_transform=True)(Before)
+    tvm.ir.assert_structural_equal(after, Expected)
+
+
+def test_incompatible_weights_in_shared_transform_raises_error():
+    """Model weights must have matched shape for shared_transform
+
+    Here, `func1` accepts one model weight, but `func2` accepts two.
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                output = y1
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.multiply(y1, y2)
+                R.output(output)
+            return output
+
+    with pytest.raises(tvm.TVMError):
+        relax.transform.LiftTransformParams(shared_transform=True)(Before)
+
+
+def test_incompatible_shape_in_shared_transform_raises_error():
+    """Model weights must have matched shape for shared_transform
+
+    Here, `func1` accepts `w1` and `w2` with shape `[256,256]`, but `func2`
+    requires shape `[128, 256]`.
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((128, 256), "float32"),
+            w2: R.Tensor((128, 256), "float32"),
+        ) -> R.Tensor((256, 128), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.multiply(y1, y2)
+                R.output(output)
+            return output
+
+    with pytest.raises(tvm.TVMError):
+        relax.transform.LiftTransformParams(shared_transform=True)(Before)
+
+
+def test_incompatible_dtype_in_shared_transform_raises_error():
+    """Model weights must have matched dtype for shared_transform
+
+    Here, `func1` accepts `w1` and `w2` with "float32" dtype, but
+    `func2` requires "float16".
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float16"),
+            w1: R.Tensor((128, 256), "float16"),
+            w2: R.Tensor((128, 256), "float16"),
+        ) -> R.Tensor((256, 128), "float16"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.multiply(y1, y2)
+                R.output(output)
+            return output
+
+    with pytest.raises(tvm.TVMError):
+        relax.transform.LiftTransformParams(shared_transform=True)(Before)
+
+
+def test_share_transform_across_multiple_functions_has_intersection_of_transforms():
+    """Like test_multiple_functions, but producing a single transform_params
+
+    In `func1`, both `w1_t` and `w2_t` could be lifted out.  In
+    `func2`, only `w1_t` could be lifted out of the function.
+    Therefore, the shared `transform_params` can pre-compute `w1_t`,
+    but must preserve `w2`.
+
+    When `shared_transform=True`, all eligible publicly-exposed
+    functions must be usable with the same shared transform.
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                y2 = Before.fused_permute_dims_matmul(x, w2)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function(private=True)
+        def fused_permute_dims_matmul(
+            x: R.Tensor((256, 256), "float32"),
+            weight: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            with R.dataflow():
+                weight_t = R.permute_dims(weight)
+                y = R.matmul(x, weight_t)
+                R.output(y)
+            return y
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def transform_params(
+            params: R.Tuple(
+                R.Tensor((256, 256), dtype="float32"),
+                R.Tensor((256, 256), dtype="float32"),
+            )
+        ):
+            R.func_attr({"num_input": 0})
+            with R.dataflow():
+                w1 = params[0]
+                w1_t = R.permute_dims(w1)
+                w2 = params[1]
+                output = (w2, w1_t)
+                R.output(output)
+            return output
+
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                y2 = Expected.fused_permute_dims_matmul(x, w2)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function(private=True)
+        def fused_permute_dims_matmul(
+            x: R.Tensor((256, 256), "float32"),
+            weight: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            with R.dataflow():
+                weight_t = R.permute_dims(weight)
+                y = R.matmul(x, weight_t)
+                R.output(y)
+            return y
+
+    after = relax.transform.LiftTransformParams(shared_transform=True)(Before)
+    tvm.ir.assert_structural_equal(after, Expected)
+
+
+def test_share_transforms_with_different_binding_order():
+    """Like test_share_transform_across_multiple_functions, but the
+    lifted bindings are in different order for each function.
+
+    Both `func1` and `func2` compute the same value for `w1_t` and
+    `w2_t`.  However, the bindings occur in different orders.  The
+    shared `transform_params` can pre-compute both `w1_t` and `w2_t`,
+    even though they occur in different orders.
+
+    For consistency in testing and pre-computing weights, the order of
+    `transform_params` should be deterministic.  When lifting from a
+    single function, the bindings in `transform_params` may be
+    determined from the order in that function.  When lifting from
+    multiple functions, the order should be deterministic.  Since
+    `IRModule::functions` has unspecified order, the order in this
+    test assumes that public functions are visited in alphabetical
+    order by name.
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w2_t = R.permute_dims(w2)
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.multiply(y1, y2)
+                R.output(output)
+            return output
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def transform_params(
+            params: R.Tuple(
+                R.Tensor((256, 256), dtype="float32"),
+                R.Tensor((256, 256), dtype="float32"),
+            )
+        ):
+            R.func_attr({"num_input": 0})
+            with R.dataflow():
+                w2 = params[1]
+                w2_t = R.permute_dims(w2)
+                w1 = params[0]
+                w1_t = R.permute_dims(w1)
+
+                output = (w2_t, w1_t)
+                R.output(output)
+            return output
+
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w2_t: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w2_t: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                y2 = R.matmul(x, w2_t)
+                output = R.multiply(y1, y2)
+                R.output(output)
+            return output
+
+    after = relax.transform.LiftTransformParams(shared_transform=True)(Before)
+    tvm.ir.assert_structural_equal(after, Expected)
+
+
+def test_share_transforms_resulting_in_identical_functions():
+    """Functions in the public interface must be preserved
+
+    When lifting functions, the resulting functions may be identical.
+    Even though the `relax.BlockBuilder` de-duplicates identical
+    functions, functions that are part of the IRModule's public
+    interface must be preserved.
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w2_t = R.permute_dims(w2)
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def transform_params(
+            params: R.Tuple(
+                R.Tensor((256, 256), dtype="float32"),
+                R.Tensor((256, 256), dtype="float32"),
+            )
+        ):
+            R.func_attr({"num_input": 0})
+            with R.dataflow():
+                w1 = params[0]
+                w1_t = R.permute_dims(w1)
+                w2 = params[1]
+                output = (w2, w1_t)
+                R.output(output)
+            return output
+
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w2_t: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w2_t: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+    after = relax.transform.LiftTransformParams(shared_transform=True)(Before)
+    tvm.ir.assert_structural_equal(after, Expected)
+
+
+def test_share_transform_across_specified_functions():
+    """Like test_multiple_functions, but producing a single transform_params
+
+    In `func1`, both `w1_t` and `w2_t` could be lifted out.  In
+    `func2`, only `w1_t` could be lifted out of the function.
+    Therefore, the shared `transform_params` can pre-compute `w1_t`,
+    but must preserve `w2`.
+
+    If `func3` were included in the `transform_params`, the same logic
+    would prevent `w1_t` from being computed in the shared
+    `transform_params`.  However, the
+    `shared_transform=['func1','func2']` argument means that `func3`
+    does not have any parameter transformations lifted out.
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                y2 = Before.fused_permute_dims_matmul(x, w2)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func3(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = Before.fused_permute_dims_matmul(x, w1)
+                y2 = Before.fused_permute_dims_matmul(x, w2)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function(private=True)
+        def fused_permute_dims_matmul(
+            x: R.Tensor((256, 256), "float32"),
+            weight: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            with R.dataflow():
+                weight_t = R.permute_dims(weight)
+                y = R.matmul(x, weight_t)
+                R.output(y)
+            return y
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def transform_params(
+            params: R.Tuple(
+                R.Tensor((256, 256), dtype="float32"),
+                R.Tensor((256, 256), dtype="float32"),
+            )
+        ):
+            R.func_attr({"num_input": 0})
+            with R.dataflow():
+                w1 = params[0]
+                w1_t = R.permute_dims(w1)
+                w2 = params[1]
+                output = (w2, w1_t)
+                R.output(output)
+            return output
+
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                y2 = Expected.fused_permute_dims_matmul(x, w2)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function(private=True)
+        def fused_permute_dims_matmul(
+            x: R.Tensor((256, 256), "float32"),
+            weight: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            with R.dataflow():
+                weight_t = R.permute_dims(weight)
+                y = R.matmul(x, weight_t)
+                R.output(y)
+            return y
+
+    after = relax.transform.LiftTransformParams(shared_transform=["func1", "func2"])(Before)
+    tvm.ir.assert_structural_equal(after, Expected)
+
+
+def test_share_transform_with_unused_parameter():
+    """Like test_share_transform_across_specified_functions, but not
+    all functions use every model weight.
+
+    In `func1`, both `w1_t` and `w2_t` could be lifted out.  In
+    `func2`, only `w1_t` could be lifted out of the function.
+    Normally, the `w2` parameter would need to be preserved, as `w2_t`
+    is only generated in one of the functions.  However, `func2`
+    doesn't use `w2` at all, and so `w2_t` can still be pre-computed.
+
+    For example, a `embed_vocab` function would only use the embedding
+    weights.  It could accept the full set of model weights for
+    consistency, but any transformations performed on unused weights
+    in other functions can still be lifted out.
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                R.output(y1)
+            return y1
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def transform_params(
+            params: R.Tuple(
+                R.Tensor((256, 256), dtype="float32"),
+                R.Tensor((256, 256), dtype="float32"),
+            )
+        ):
+            R.func_attr({"num_input": 0})
+            with R.dataflow():
+                w1 = params[0]
+                w1_t = R.permute_dims(w1)
+                w2 = params[1]
+                output = (w2, w1_t)
+                R.output(output)
+            return output
+
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                R.output(y1)
+            return y1
+
+    after = relax.transform.LiftTransformParams(shared_transform=True)(Before)
+    tvm.ir.assert_structural_equal(after, Expected)
+
+
+def test_share_transform_with_no_shared_preprocessing():
+    """Like test_share_transform_with_unused_parameter, but each
+    function uses a single model weight.
+
+    In `func1`, `w2_t` can be lifted out and `w1` is unused.  In
+    `func2`, `w1_t` can be lifted out, and `w2` is unused.  In their
+    shared `transform_params`, both `w1_t` and `w2_t` can be computed.
+
+    For consistency in testing and pre-computing weights, the order of
+    `transform_params` should be deterministic.  When lifting from a
+    single function, the bindings in `transform_params` may be
+    determined from the order in that function.  When lifting from
+    multiple functions, the order should be deterministic.  Since
+    `IRModule::functions` has unspecified order, the order in this
+    test assumes that public functions are visited in alphabetical
+    order by name.
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w2_t = R.permute_dims(w2)
+                y2 = R.matmul(x, w2_t)
+                R.output(y2)
+            return y2
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1)
+                y1 = R.matmul(x, w1_t)
+                R.output(y1)
+            return y1
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def transform_params(
+            params: R.Tuple(
+                R.Tensor((256, 256), dtype="float32"),
+                R.Tensor((256, 256), dtype="float32"),
+            )
+        ):
+            R.func_attr({"num_input": 0})
+            with R.dataflow():
+                w1 = params[0]
+                w1_t = R.permute_dims(w1)
+                w2 = params[1]
+                w2_t = R.permute_dims(w2)
+                output = (w2_t, w1_t)
+                R.output(output)
+            return output
+
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w2_t: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y2 = R.matmul(x, w2_t)
+                R.output(y2)
+            return y2
+
+        @R.function
+        def func2(
+            x: R.Tensor((256, 256), "float32"),
+            w2_t: R.Tensor((256, 256), "float32"),
+            w1_t: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = R.matmul(x, w1_t)
+                R.output(y1)
+            return y1
+
+    after = relax.transform.LiftTransformParams(shared_transform=True)(Before)
+    tvm.ir.assert_structural_equal(after, Expected)
+
+
 def test_stop_lifting():
     @tvm.script.ir_module
     class Before:

--- a/tests/python/relax/test_transform_lift_transform_params.py
+++ b/tests/python/relax/test_transform_lift_transform_params.py
@@ -986,11 +986,12 @@ def test_lift_global():
                 R.Tensor((32, 32), dtype="float32"),
             )
         ):
+            R.func_attr({"num_input": 0})
             with R.dataflow():
                 ones = R.ones([32, 32], "float32")
-                lv1 = params[0]
                 lv2 = params[1]
                 lv3 = R.add(lv2, ones)
+                lv1 = params[0]
                 gv = (lv1, lv3)
                 R.output(gv)
             return gv
@@ -1022,9 +1023,7 @@ def test_lift_global():
             R.func_attr({"num_input": 2})
             with R.dataflow():
                 lv1 = R.matmul(x, param0)
-                ones = R.ones(
-                    R.shape([32, 32]), dtype="float32"
-                )
+                ones = R.ones(R.shape([32, 32]), dtype="float32")
                 lv3 = R.matmul(lv1, param1)
                 gv = R.add(lv3, y)
                 R.output(gv)

--- a/tests/python/relax/test_transform_lift_transform_params.py
+++ b/tests/python/relax/test_transform_lift_transform_params.py
@@ -538,8 +538,8 @@ def test_share_identical_transform_across_multiple_functions():
                 w1 = params[0]
                 w1_t = R.permute_dims(w1)
                 w2 = params[1]
-                w1_t = R.permute_dims(w1)
-                output = (w2, w1_t)
+                w2_t = R.permute_dims(w2)
+                output = (w1_t, w2_t)
                 R.output(output)
             return output
 
@@ -983,10 +983,11 @@ def test_share_transforms_resulting_in_identical_functions():
         ):
             R.func_attr({"num_input": 0})
             with R.dataflow():
+                w2 = params[1]
+                w2_t = R.permute_dims(w2)
                 w1 = params[0]
                 w1_t = R.permute_dims(w1)
-                w2 = params[1]
-                output = (w2, w1_t)
+                output = (w2_t, w1_t)
                 R.output(output)
             return output
 
@@ -1137,6 +1138,20 @@ def test_share_transform_across_specified_functions():
             R.func_attr({"num_input": 1})
             with R.dataflow():
                 y1 = R.matmul(x, w1_t)
+                y2 = Expected.fused_permute_dims_matmul(x, w2)
+                output = R.add(y1, y2)
+                R.output(output)
+            return output
+
+        @R.function
+        def func3(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+            w2: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                y1 = Expected.fused_permute_dims_matmul(x, w1)
                 y2 = Expected.fused_permute_dims_matmul(x, w2)
                 output = R.add(y1, y2)
                 R.output(output)
@@ -1802,100 +1817,6 @@ def test_only_lift_when_variable_uses_constants():
 
     mod = Before
     after = relax.transform.LiftTransformParams()(mod)
-    tvm.ir.assert_structural_equal(after, Expected)
-
-
-def test_lift_global():
-    @tvm.script.ir_module
-    class Before:
-        @R.function
-        def func1(
-            x: R.Tensor((32, 32), "float32"),
-            w1: R.Tensor((32, 32), "float32"),
-            w2: R.Tensor((32, 32), "float32"),
-        ):
-            R.func_attr({"num_input": 1})
-            with R.dataflow():
-                w1_t = R.permute_dims(w1, [1, 0])
-                lv1 = R.matmul(x, w1_t)
-                ones = R.ones([32, 32], "float32")
-                lv2 = R.add(w2, ones)
-                gv = R.matmul(lv1, lv2)
-                R.output(gv)
-            return gv
-
-        @R.function
-        def func2(
-            x: R.Tensor((32, 32), "float32"),
-            y: R.Tensor((32, 32), "float32"),
-            w1a: R.Tensor((32, 32), "float32"),
-            w2a: R.Tensor((32, 32), "float32"),
-        ):
-            R.func_attr({"num_input": 2})
-            with R.dataflow():
-                lv1 = R.matmul(x, w1a)
-                ones = R.ones([32, 32], "float32")
-                lv2 = R.add(w2a, ones)
-                lv3 = R.matmul(lv1, lv2)
-                gv = R.add(lv3, y)
-                R.output(gv)
-            return gv
-
-    @tvm.script.ir_module
-    class Expected:
-        @R.function
-        def transform_params(
-            params: R.Tuple(
-                R.Tensor((32, 32), dtype="float32"),
-                R.Tensor((32, 32), dtype="float32"),
-            )
-        ):
-            R.func_attr({"num_input": 0})
-            with R.dataflow():
-                ones = R.ones([32, 32], "float32")
-                lv2 = params[1]
-                lv3 = R.add(lv2, ones)
-                lv1 = params[0]
-                gv = (lv1, lv3)
-                R.output(gv)
-            return gv
-
-        @R.function
-        def func1(
-            x: R.Tensor((32, 32), dtype="float32"),
-            param0: R.Tensor((32, 32), dtype="float32"),
-            param1: R.Tensor((32, 32), dtype="float32"),
-        ):
-            R.func_attr({"num_input": 1})
-            with R.dataflow():
-                w1_t = R.permute_dims(param0, [1, 0])
-                lv1 = R.matmul(x, w1_t)
-                ones = R.ones(
-                    R.shape([32, 32]), dtype="float32"
-                )  # not used but rely on DeadCodeElimination to remove it
-                gv = R.matmul(lv1, param1)
-                R.output(gv)
-            return gv
-
-        @R.function
-        def func2(
-            x: R.Tensor((32, 32), dtype="float32"),
-            y: R.Tensor((32, 32), dtype="float32"),
-            param0: R.Tensor((32, 32), dtype="float32"),
-            param1: R.Tensor((32, 32), dtype="float32"),
-        ):
-            R.func_attr({"num_input": 2})
-            with R.dataflow():
-                lv1 = R.matmul(x, param0)
-                ones = R.ones(R.shape([32, 32]), dtype="float32")
-                lv3 = R.matmul(lv1, param1)
-                gv = R.add(lv3, y)
-                R.output(gv)
-            return gv
-
-    mod = Before
-    with tvm.transform.PassContext(config={"relax.lift_transform_params.lift_globally": True}):
-        after = relax.transform.LiftTransformParams()(mod)
     tvm.ir.assert_structural_equal(after, Expected)
 
 

--- a/tests/python/relax/test_transform_lift_transform_params.py
+++ b/tests/python/relax/test_transform_lift_transform_params.py
@@ -1268,6 +1268,7 @@ def test_share_transform_with_unused_parameter():
     tvm.ir.assert_structural_equal(after, Expected)
 
 
+@pytest.mark.xfail
 def test_share_transform_with_no_shared_preprocessing():
     """Like test_share_transform_with_unused_parameter, but each
     function uses a single model weight.


### PR DESCRIPTION
This PR enables specifying a list of function names to extract shared transform parameters. A single parameter transformation function will be produced, containing the preprocessing steps common across each function whose name is in a given function name list. 

Unit tests are passing except the one that has no shared prepocessing (transpose), skipping for now, will follow-up in another PR.

Cherry-picked from @vinx13's working branch.