### PR TITLE
[TIR] LowerTVMBuiltin may use device_type from PrimFunc annotation

### DIFF
--- a/src/tir/transforms/lower_tvm_builtin.cc
+++ b/src/tir/transforms/lower_tvm_builtin.cc
@@ -49,7 +49,7 @@ class BuiltinLower : public StmtExprMutator {
     return func;
   }
 
-  BuiltinLower(Optional<PrimExpr> device_type = NullOpt) : device_type_(device_type) {}
+  explicit BuiltinLower(Optional<PrimExpr> device_type = NullOpt) : device_type_(device_type) {}
 
   // NOTE: Right now, we make the following scoping requirement
   // for memory allocated by the following primitives

--- a/tests/python/tir-transform/test_tir_transform_lower_tvm_builtin.py
+++ b/tests/python/tir-transform/test_tir_transform_lower_tvm_builtin.py
@@ -217,7 +217,7 @@ class TestLowerDeviceAllocate(tvm.testing.CompareBeforeAfter):
 
     def before():
         T.func_attr({"target": T.target("llvm")})
-        T.attr("dummy", "device_type", 2)  # kDLCuda
+        T.attr("dummy", "device_type", tvm.runtime.Device.kDLCUDA)
         T.attr("dummy", "device_id", 0)
         ptr = T.allocate([16], "float32")
         buf = T.decl_buffer(16, "float32", data=ptr)
@@ -246,7 +246,7 @@ class TestLowerCPUAllocation(tvm.testing.CompareBeforeAfter):
 
     def before():
         T.func_attr({"target": T.target("llvm")})
-        T.attr("dummy", "device_type", 1)  # kDLCPU
+        T.attr("dummy", "device_type", tvm.runtime.Device.kDLCPU)
         T.attr("dummy", "device_id", 0)
         ptr = T.allocate([16], "float32")
         buf = T.decl_buffer(16, "float32", data=ptr)
@@ -266,7 +266,7 @@ class TestLowerAllocateRequiresDeviceID(tvm.testing.CompareBeforeAfter):
 
     def before():
         T.func_attr({"target": T.target("llvm")})
-        T.attr("dummy", "device_type", 2)  # kDLCuda
+        T.attr("dummy", "device_type", tvm.runtime.Device.kDLCUDA)
         ptr = T.allocate([16], "float32")
         buf = T.decl_buffer(16, "float32", data=ptr)
         buf[0] = 0.0


### PR DESCRIPTION
If an allocation occurs within a host function, it may not have a device/host split, and may just be annotated with `"tir.is_host_func"`.