### PR TITLE
[Relax] Refactor PatternRewriter into separate Block/Expr mutators

### DIFF
--- a/include/tvm/relax/dataflow_matcher.h
+++ b/include/tvm/relax/dataflow_matcher.h
@@ -67,7 +67,9 @@ TVM_DLL Optional<Map<DFPattern, Var>> MatchGraph(const PatternContext& ctx,
  * \param f The function to rewrite
  * \return The rewritten or the input function, depending on the pattern matching result.
  */
-TVM_DLL Function RewriteBindings(const PatternContext& ctx, PackedFunc rewriter, Function f);
+TVM_DLL Function RewriteBindings(
+    const PatternContext& ctx,
+    TypedPackedFunc<Map<Var, Expr>(Map<DFPattern, Var>, Map<Var, Expr>)> rewriter, Function f);
 
 /**
  * \brief Rewrite a function with the given pattern and the rewriter function.


### PR DESCRIPTION
Prior to this commit, the `PatternRewriter` mutator handled pattern rewriting at either the expression level (`rewrite_call`) or the dataflow block level (`rewrite_bindings`).  These two functionalities had different external APIs, defined diffierent member variables, and visited different IR nodes.  In effect, it had two entirely independent implementations, which just happened to be implemented within the same class.

This commit refactors the single `PatternRewriter` mutator into separate `BlockPatternRewriter` and `ExprPatternRewriter` mutators.