### PR TITLE
[Arith][Fixup] Require feature flag for tighter inequality bounds

### DIFF
--- a/python/tvm/arith/__init__.py
+++ b/python/tvm/arith/__init__.py
@@ -24,7 +24,7 @@ from .int_set import (
     estimate_region_strict_bound,
     estimate_region_upper_bound,
 )
-from .analyzer import ModularSet, ConstIntBound, Analyzer, ProofStrength
+from .analyzer import ModularSet, ConstIntBound, Analyzer, ProofStrength, Extension
 from .bound import deduce_bound
 from .pattern import detect_linear_equation, detect_clip_bound, detect_common_subexpr
 from .int_solver import solve_linear_equations, solve_linear_inequalities

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -317,6 +317,16 @@ TVM_REGISTER_GLOBAL("arith.CreateAnalyzer").set_body([](TVMArgs args, TVMRetValu
     } else if (name == "can_prove_equal") {
       return PackedFunc(
           [self](TVMArgs args, TVMRetValue* ret) { *ret = self->CanProveEqual(args[0], args[1]); });
+    } else if (name == "get_enabled_extensions") {
+      return PackedFunc([self](TVMArgs args, TVMRetValue* ret) {
+        *ret = static_cast<std::int64_t>(self->rewrite_simplify.GetEnabledExtensions());
+      });
+    } else if (name == "set_enabled_extensions") {
+      return PackedFunc([self](TVMArgs args, TVMRetValue* ret) {
+        std::int64_t flags = args[0];
+        self->rewrite_simplify.SetEnabledExtensions(
+            static_cast<RewriteSimplifier::Extension>(flags));
+      });
     }
     return PackedFunc();
   };

--- a/src/arith/rewrite_simplify.h
+++ b/src/arith/rewrite_simplify.h
@@ -216,6 +216,7 @@ class RewriteSimplifier::Impl : public IRMutatorWithAnalyzer {
  private:
   CompareResult TryCompareUsingKnownInequalities(const PrimExpr& x, const PrimExpr& y);
   CompareResult TryCompareUsingConstIntBounds(const PrimExpr& x, const PrimExpr y);
+  CompareResult TryComparisonOfProductAndSum(const PrimExpr& x, const PrimExpr& y);
 
   // Whether x >= val
   bool CanProveGreaterEqual(const PrimExpr& x, int64_t val) {

--- a/tests/python/arith/test_arith_const_int_bound.py
+++ b/tests/python/arith/test_arith_const_int_bound.py
@@ -17,6 +17,8 @@
 
 import contextlib
 
+import pytest
+
 import tvm
 import tvm.testing
 
@@ -96,6 +98,7 @@ class TestAddSubBound(BaseCompare):
     )
 
 
+@pytest.mark.xfail(reason="Not currently supported")
 class TestBoundsUsingReciprocals(BaseCompare):
     """Special handling for differences of reciprocals
 

--- a/tests/python/arith/test_arith_rewrite_simplify.py
+++ b/tests/python/arith/test_arith_rewrite_simplify.py
@@ -51,15 +51,17 @@ class TestCase:
 
 
 class BaseCompare:
+    extensions = tvm.arith.Extension.NoExtensions
+
     def test_simplify(self, test_case):
         analyzer = tvm.arith.Analyzer()
+        analyzer.enabled_extensions = self.extensions
 
         if inspect.isclass(test_case.expected) and issubclass(test_case.expected, Exception):
             with pytest.raises(test_case.expected):
                 with analyzer.constraint_scope(test_case.constraint):
                     analyzer.rewrite_simplify(test_case.before)
         else:
-
             with analyzer.constraint_scope(test_case.constraint):
                 after = analyzer.rewrite_simplify(test_case.before)
 
@@ -983,6 +985,15 @@ class TestComparisons(BaseCompare):
         TestCase(y * y >= 0, tvm.tir.const(1, "bool"), y <= 0),
         TestCase(x * 6 <= -3, tvm.tir.const(0, "bool"), x >= 0),
         TestCase(tmod(y - 1, 3) == 0, tmod(y + (-1), 3) == 0),
+    )
+
+
+class TestComparisonOfProductAndSum(BaseCompare):
+    extensions = tvm.arith.Extension.ComparisonOfProductAndSum
+
+    x, y, z = te.var("x"), te.var("y"), te.var("z")
+
+    test_case = tvm.testing.parameter(
         # Special inequality cases
         TestCase(
             x * y < (x + y) * 2048,


### PR DESCRIPTION
This is a follow-up to https://github.com/apache/tvm/pull/16588.  Due to an incorrect rebase, the version that was merged into `main` had the tighter `ConstIntBounds` enabled by default, rather than having them implemented in `RewriteSimplifier`, gated behind a feature flag.