### PR TITLE
[Target][CUDA] Allow non-numeric arch as needed for latest gpu

### DIFF
--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -291,8 +291,14 @@ def get_target_compute_version(target=None):
     # 2. Target.current()
     target = target or Target.current()
     if target and target.arch:
-        major, minor = target.arch.split("_")[1]
-        return major + "." + minor
+        arch = target.arch.split("_")[1]
+        if len(arch) == 2:
+            major, minor = arch
+            return major + "." + minor
+        elif len(arch) == 3:
+            # This is for arch like "sm_90a"
+            major, minor, suffix = arch
+            return major + "." + minor
 
     # 3. GPU compute version
     if tvm.cuda(0).exist:

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -298,7 +298,7 @@ def get_target_compute_version(target=None):
         elif len(arch) == 3:
             # This is for arch like "sm_90a"
             major, minor, suffix = arch
-            return major + "." + minor
+            return major + "." + minor + "." + suffix
 
     # 3. GPU compute version
     if tvm.cuda(0).exist:

--- a/src/target/tag.cc
+++ b/src/target/tag.cc
@@ -155,7 +155,7 @@ TVM_REGISTER_CUDA_TAG("nvidia/tesla-c2050", "sm_20", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/tesla-c2070", "sm_20", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a100", "sm_80", 49152, 65536)
     .with_config("l2_cache_size_bytes", Integer(41943040));
-TVM_REGISTER_CUDA_TAG("nvidia/nvidia-h100", "sm_90", 49152, 65536)
+TVM_REGISTER_CUDA_TAG("nvidia/nvidia-h100", "sm_90a", 49152, 65536)
     .with_config("l2_cache_size_bytes", Integer(52428800));
 TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a40", "sm_86", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/nvidia-a30", "sm_80", 49152, 65536);


### PR DESCRIPTION
Latest GPU like H100 supports `sm_90a` arch, this breaks the previous assumption that the arch can be parsed as an integer.
Also updated the predefined arch for H100.

cc @tqchen 