### PR TITLE
[SLM] Allow TensorStructInfo to specify parameter in export

### DIFF
--- a/python/tvm/relax/frontend/nn/spec.py
+++ b/python/tvm/relax/frontend/nn/spec.py
@@ -18,6 +18,8 @@
 import inspect
 import typing
 
+import tvm
+
 if typing.TYPE_CHECKING:
     from .core import Module as nn_module_class
 
@@ -149,13 +151,16 @@ class MethodSpec:
         arg_specs = []
 
         def _convert_arg_spec(arg_spec, arg_name):
+            if hasattr(arg_spec, "as_struct_info"):
+                arg_spec = arg_spec.as_struct_info()
+
             if arg_spec is Int or arg_spec is int:
                 return Int()
-            if isinstance(arg_spec, str) and arg_spec == "int":
+            elif isinstance(arg_spec, str) and arg_spec == "int":
                 return Int()
-            if isinstance(arg_spec, (Int, Tensor, Object)):
+            elif isinstance(arg_spec, (Int, Tensor, Object, tvm.relax.TensorStructInfo)):
                 return arg_spec
-            if isinstance(arg_spec, (tuple, list, Tuple)):
+            elif isinstance(arg_spec, (tuple, list, Tuple)):
                 return Tuple(
                     arg_name,
                     elements=type(arg_spec)(

--- a/tests/python/relax/test_frontend_nn_exporter.py
+++ b/tests/python/relax/test_frontend_nn_exporter.py
@@ -1,0 +1,221 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import tvm
+import tvm.testing
+
+from tvm import relax, tir
+from tvm.ir import assert_structural_equal
+from tvm.relax.frontend import nn
+from tvm.script import ir as I, relax as R
+
+
+def test_simple():
+    """A module may be exported from nn.Module to Relax"""
+
+    slm_mod = nn.modules.ReLU()
+    exported_mod, _ = slm_mod.export_tvm(
+        spec={"forward": {"x": nn.spec.Tensor((3, 3), "float32")}},
+        debug=False,
+    )
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def forward(x: R.Tensor([3, 3], dtype="float32")):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                relu = R.nn.relu(x)
+                R.output(relu)
+            return relu
+
+    assert_structural_equal(exported_mod, Expected)
+
+
+def test_custom_module():
+    """A module may be exported from nn.Module to Relax"""
+
+    class Before(nn.Module):
+        def forward(self, x: R.Tensor):
+            return nn.op.relu(x)
+
+    slm_mod = Before()
+    exported_mod, _ = slm_mod.export_tvm(
+        spec={"forward": {"x": nn.spec.Tensor((3, 3), "float32")}},
+        debug=False,
+    )
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def forward(x: R.Tensor([3, 3], dtype="float32")):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                relu = R.nn.relu(x)
+                R.output(relu)
+            return relu
+
+    assert_structural_equal(exported_mod, Expected)
+
+
+def test_debug_effect():
+    """Passing debug=True provides an argument for IO effect"""
+
+    slm_mod = nn.modules.ReLU()
+    exported_mod, _ = slm_mod.export_tvm(
+        spec={"forward": {"x": nn.spec.Tensor((3, 3), "float32")}},
+        debug=True,
+    )
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def forward(
+            x: R.Tensor([3, 3], dtype="float32"),
+            _io: R.Object,
+        ):
+            R.func_attr({"num_input": 2})
+            with R.dataflow():
+                relu = R.nn.relu(x)
+                output = relu, (_io,)
+                R.output(output)
+            return output
+
+        @R.function
+        def _initialize_effect():
+            with R.dataflow():
+                _io = R.null_value()
+                output = (_io,)
+                R.output(output)
+            return output
+
+    assert_structural_equal(exported_mod, Expected)
+
+
+def test_struct_info_specification():
+    """An argument may be specified with relax StructInfo"""
+
+    slm_mod = nn.modules.ReLU()
+    exported_mod, _ = slm_mod.export_tvm(
+        spec={"forward": {"x": relax.TensorStructInfo([3, 3], "float32")}},
+        debug=False,
+    )
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def forward(x: R.Tensor([3, 3], dtype="float32")):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                relu = R.nn.relu(x)
+                R.output(relu)
+            return relu
+
+    assert_structural_equal(exported_mod, Expected)
+
+
+def test_tvmscript_struct_info_specification():
+    """An argument may be specified with R.Tensor
+
+    The same syntax used in TVMScript for type annotations may be used
+    when exporting from SLM.
+    """
+
+    slm_mod = nn.modules.ReLU()
+    exported_mod, _ = slm_mod.export_tvm(
+        spec={"forward": {"x": R.Tensor([3, 3], "float32")}},
+        debug=False,
+    )
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def forward(x: R.Tensor([3, 3], dtype="float32")):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                relu = R.nn.relu(x)
+                R.output(relu)
+            return relu
+
+    assert_structural_equal(exported_mod, Expected)
+
+
+def test_dynamic_shape():
+    """An argument may have a dynamic shape"""
+
+    slm_mod = nn.modules.ReLU()
+    exported_mod, _ = slm_mod.export_tvm(
+        spec={"forward": {"x": nn.spec.Tensor([tir.Var("batch_size", "int64"), 8], "float32")}},
+        debug=False,
+    )
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def forward(x: R.Tensor(["batch_size", 8], dtype="float32")):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                relu = R.nn.relu(x)
+                R.output(relu)
+            return relu
+
+    assert_structural_equal(exported_mod, Expected)
+
+
+def test_dynamic_shape_in_multiple_functions():
+    """A dynamic shape may be used in multiple functions"""
+
+    class Before(nn.Module):
+        def forward_relu(self, x: nn.Tensor):
+            return nn.relu(x)
+
+        def forward_silu(self, x: nn.Tensor):
+            return nn.silu(x)
+
+    slm_mod = Before()
+    exported_mod, _ = slm_mod.export_tvm(
+        spec={
+            "forward_relu": {"x": nn.spec.Tensor((tir.Var("batch_size", "int64"), 8), "float32")},
+            "forward_silu": {"x": nn.spec.Tensor((tir.Var("batch_size", "int64"), 8), "float32")},
+        },
+        debug=False,
+    )
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def forward_relu(x: R.Tensor(["batch_size", 8], dtype="float32")):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                relu = R.nn.relu(x)
+                R.output(relu)
+            return relu
+
+        @R.function
+        def forward_silu(x: R.Tensor(["batch_size", 8], dtype="float32")):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                silu = R.nn.silu(x)
+                R.output(silu)
+            return silu
+
+    assert_structural_equal(exported_mod, Expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_frontend_nn_extern_module.py
+++ b/tests/python/relax/test_frontend_nn_extern_module.py
@@ -94,9 +94,8 @@ def _check_ir_equality(mod):
                 ext_scalar_add = R.call_dps_packed(
                     "ext_scalar_add", (a, b), out_sinfo=R.Tensor((), dtype="float32")
                 )
-                gv: R.Tensor((), dtype="float32") = ext_scalar_add
-                R.output(gv)
-            return gv
+                R.output(ext_scalar_add)
+            return ext_scalar_add
 
         @R.function
         def test_sym(
@@ -110,9 +109,8 @@ def _check_ir_equality(mod):
                 ext_test_sym = R.call_dps_packed(
                     "ext_test_sym", (a, b), out_sinfo=R.Tensor((x, y, z, 9), dtype="float32")
                 )
-                gv1: R.Tensor((x, y, z, 9), dtype="float32") = ext_test_sym
-                R.output(gv1)
-            return gv1
+                R.output(ext_test_sym)
+            return ext_test_sym
 
     tvm.ir.assert_structural_equal(ExpectedModule, mod)
 

--- a/tests/python/relax/test_frontend_nn_modules.py
+++ b/tests/python/relax/test_frontend_nn_modules.py
@@ -491,8 +491,7 @@ def test_kv_cache():
                     R.prim_value(0),
                     sinfo_args=(R.Object,),
                 )
-                lv1 = _io, cache
-                gv = lv1
+                gv = _io, cache
                 R.output(gv)
             return gv
 

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -538,8 +538,7 @@ def test_tensor_expr_op():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -611,8 +610,7 @@ def test_tensor_ir_op():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -699,8 +697,7 @@ def test_tensor_ir_inplace_op():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -717,13 +714,12 @@ def test_tensor_ir_inplace_op():
             R.func_attr({"num_input": 4})
             cls = Expected
             with R.dataflow():
-                lv1 = R.call_tir(
+                gv1 = R.call_tir(
                     cls.inplace_take,
                     (embedding_table, input_ids, embedding_dst),
                     out_sinfo=R.Tensor((total_seq_len, hidden_size), dtype),
                     tir_vars=R.shape([offset_1]),
                 )
-                gv1: R.Tensor((total_seq_len, hidden_size), dtype) = lv1
                 R.output(gv1)
             return gv1
 
@@ -772,8 +768,7 @@ def test_tensor_ir_op_no_tir_var():
             R.func_attr({"num_input": 1})
             cls = Expected
             with R.dataflow():
-                lv = R.call_tir(cls.tir_func, (A,), out_sinfo=R.Tensor((16, 16), dtype="float32"))
-                gv: R.Tensor((16, 16), dtype="float32") = lv
+                gv = R.call_tir(cls.tir_func, (A,), out_sinfo=R.Tensor((16, 16), dtype="float32"))
                 R.output(gv)
             return gv
 
@@ -800,8 +795,7 @@ def test_extern():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -888,8 +882,7 @@ def test_multinomial_from_uniform():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
             return gv
 
@@ -1015,8 +1008,7 @@ def test_sample_top_p_top_k_from_sorted_prob():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv: R.Tuple(R.Object) = (_io,)
                 R.output(gv)
             return gv
 
@@ -1130,8 +1122,7 @@ def test_renormalize_top_p_top_k_prob():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv: R.Tuple(R.Object) = (_io,)
                 R.output(gv)
             return gv
 

--- a/tests/python/relax/test_frontend_nn_packing.py
+++ b/tests/python/relax/test_frontend_nn_packing.py
@@ -59,8 +59,7 @@ def test_nn_export_to_relax():
                 matmul = R.matmul(x, matmul_1_weight)
                 matmul_2_weight = R.permute_dims(linear_2_weight)
                 matmul1 = R.matmul(x, matmul_2_weight)
-                add = R.add(matmul, matmul1)
-                gv = add
+                gv = R.add(matmul, matmul1)
                 R.output(gv)
             return gv
 

--- a/tests/python/relax/test_frontend_nn_subroutines.py
+++ b/tests/python/relax/test_frontend_nn_subroutines.py
@@ -61,8 +61,7 @@ def test_linear():
         def _initialize_effect() -> R.Tuple(R.Object):
             with R.dataflow():
                 _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                gv = (_io,)
                 R.output(gv)
 
             return gv
@@ -75,9 +74,8 @@ def test_linear():
             with R.dataflow():
                 state = R.matmul(state, weights)
                 state = Expected.activation(state)
-                dataflow_output = state
-                R.output(dataflow_output)
-            return dataflow_output
+                R.output(state)
+            return state
 
         @R.function(private=True)
         def activation(
@@ -85,9 +83,8 @@ def test_linear():
         ) -> R.Tensor(("batch_size", 32), dtype="float32"):
             with R.dataflow():
                 state = R.nn.silu(state)
-                dataflow_output = state
-                R.output(dataflow_output)
-            return dataflow_output
+                R.output(state)
+            return state
 
     mod = Layer(64, 32)
     batch_size = tvm.tir.Var("batch_size", "int64")


### PR DESCRIPTION
Prior to this commit, the parameter specification for SLM tensor needed to be passed as a `nn.spec.Tensor`.  As this object is only used to construct a `relax.TensorStructInfo`, and has the same fields as a `relax.TensorStructInfo`, this commit allows the parameter specification to be passed as a `relax.TensorStructInfo`.