### PR TITLE
[Refactor][Runtime] Always specify device in allocator interface

### DIFF
--- a/include/tvm/runtime/memory/memory_manager.h
+++ b/include/tvm/runtime/memory/memory_manager.h
@@ -71,19 +71,22 @@ class Allocator {
   /*! \brief Return the allocator type. */
   inline AllocatorType type() const { return type_; }
   /*! \brief Allocate a buffer given a size, alignment and type.
+   *  \param dev The device where the array is allocated.
    *  \param nbytes The size of the buffer.
    *  \param alignment The alignment of the buffer.
    *  \param type_hint A type hint to the allocator.
    *  \return A sized allocation in the form of a buffer.
    */
-  TVM_DLL virtual Buffer Alloc(size_t nbytes, size_t alignment, DLDataType type_hint) = 0;
+  TVM_DLL virtual Buffer Alloc(Device dev, size_t nbytes, size_t alignment,
+                               DLDataType type_hint) = 0;
   /*! \brief Allocate a buffer given a shape and type.
+   *  \param dev The device where the array is allocated.
    *  \param shape The shape of the tensor.
    *  \param type_hint A type hint to the allocator.
    *  \param mem_scope A memory scope of the buffer.
    *  \return A sized allocation in the form of a buffer.
    */
-  TVM_DLL virtual Buffer Alloc(ShapeTuple shape, DLDataType type_hint,
+  TVM_DLL virtual Buffer Alloc(Device dev, ShapeTuple shape, DLDataType type_hint,
                                const std::string& mem_scope = "") = 0;
   /*! \brief Free a buffer allocated by the allocator.
    *  \param buffer The buffer to free.
@@ -95,10 +98,6 @@ class Allocator {
    *  \return The amount of memory currently allocated.
    */
   TVM_DLL virtual size_t UsedMemory() const = 0;
-
- protected:
-  TVM_DLL virtual Buffer Alloc(Device dev, ShapeTuple shape, DLDataType type_hint,
-                               const std::string& mem_scope);
 
  private:
   AllocatorType type_;

--- a/src/runtime/memory/memory_manager.cc
+++ b/src/runtime/memory/memory_manager.cc
@@ -138,12 +138,12 @@ Allocator* MemoryManager::GetOrCreateAllocator(Device dev, AllocatorType type) {
     switch (type) {
       case kNaive: {
         VLOG(1) << "New naive allocator for " << dev;
-        alloc.reset(new NaiveAllocator(dev));
+        alloc.reset(new NaiveAllocator());
         break;
       }
       case kPooled: {
         VLOG(1) << "New pooled allocator for " << dev;
-        alloc.reset(new PooledAllocator(dev));
+        alloc.reset(new PooledAllocator());
         break;
       }
       default:
@@ -194,9 +194,9 @@ NDArray Allocator::Empty(ShapeTuple shape, DLDataType dtype, DLDevice dev,
   size_t alignment = GetDataAlignment(container->dl_tensor);
   Buffer* buffer = new Buffer;
   if (!mem_scope.defined() || mem_scope.value().empty() || mem_scope.value() == "global") {
-    *buffer = this->Alloc(size, alignment, dtype);
+    *buffer = this->Alloc(dev, size, alignment, dtype);
   } else {
-    *buffer = this->Alloc(shape, dtype, mem_scope.value());
+    *buffer = this->Alloc(dev, shape, dtype, mem_scope.value());
   }
   container->manager_ctx = reinterpret_cast<void*>(buffer);
   container->dl_tensor.data = buffer->data;
@@ -210,7 +210,7 @@ Buffer Allocator::Alloc(Device dev, ShapeTuple shape, DLDataType type_hint,
     NDArray::Container container(nullptr, shape, type_hint, dev);
     size_t size = DeviceAPI::Get(dev)->GetDataSize(container.dl_tensor);
     size_t alignment = GetDataAlignment(container.dl_tensor);
-    return Alloc(size, alignment, type_hint);
+    return Alloc(dev, size, alignment, type_hint);
   }
   LOG(FATAL) << "Allocator cannot allocate data space with "
              << "specified memory scope: " << mem_scope;

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -347,7 +347,8 @@ Storage VMAllocStorage(void* ctx_ptr, ShapeTuple buffer_shape, Index device_inde
   auto* alloc = vm->allocators[device_index];
   ICHECK(alloc) << "Did you forget to init the VirtualMachine with devices?";
 
-  storage_obj->buffer = alloc->Alloc(buffer_shape, dtype_hint, mem_scope);
+  storage_obj->buffer =
+      alloc->Alloc(vm->devices[device_index], buffer_shape, dtype_hint, mem_scope);
   Storage storage(storage_obj);
   return storage;
 }

--- a/tests/cpp/runtime/memory/memory_manager_tests.cc
+++ b/tests/cpp/runtime/memory/memory_manager_tests.cc
@@ -52,7 +52,7 @@ TEST_F(TvmVMMemoryManagerTest, NaiveAllocBasic) {
   Device dev = {kDLCPU, 0};
   Allocator* allocator = MemoryManagerWrapper::GetOrCreateAllocator(dev, kNaive);
   EXPECT_EQ(allocator->UsedMemory(), 0);
-  auto buff = allocator->Alloc(64, 32, DataType::Float(32));
+  auto buff = allocator->Alloc(dev, 64, 32, DataType::Float(32));
   EXPECT_EQ(allocator->UsedMemory(), 64);
   allocator->Free(buff);
   EXPECT_EQ(allocator->UsedMemory(), 0);
@@ -65,7 +65,7 @@ TEST_F(TvmVMMemoryManagerTest, PooledAllocBasic) {
   size_t size = ((nbytes + page_size - 1) / page_size) * page_size;
   Allocator* allocator = MemoryManagerWrapper::GetOrCreateAllocator(dev, kPooled);
   EXPECT_EQ(allocator->UsedMemory(), 0);
-  auto buff = allocator->Alloc(nbytes, 32, DataType::Float(32));
+  auto buff = allocator->Alloc(dev, nbytes, 32, DataType::Float(32));
   EXPECT_EQ(allocator->UsedMemory(), size);
   allocator->Free(buff);
   EXPECT_EQ(allocator->UsedMemory(), size);
@@ -108,13 +108,13 @@ TEST_F(TvmVMMemoryManagerTest, NaiveAllocWithShape) {
   auto dt = DataType::Float(32);
   size_t nbytes = 1 * 3 * 6 * 6 * dt.bytes();
   ShapeTuple shape = {1, 3, 6, 6};
-  auto buff = allocator->Alloc(shape, dt);
+  auto buff = allocator->Alloc(dev, shape, dt);
   EXPECT_EQ(allocator->UsedMemory(), nbytes);
   allocator->Free(buff);
   EXPECT_EQ(allocator->UsedMemory(), 0);
 
   try {
-    auto texture = allocator->Alloc(shape, dt, "global.texture");
+    auto texture = allocator->Alloc(dev, shape, dt, "global.texture");
     (void)texture;
     FAIL();
   } catch (std::exception& e) {
@@ -134,13 +134,13 @@ TEST_F(TvmVMMemoryManagerTest, PooledAllocWithShape) {
   size_t page_size = PooledAllocator::kDefaultPageSize;
   size_t size = ((nbytes + page_size - 1) / page_size) * page_size;
   ShapeTuple shape = {1, 3, 6, 6};
-  auto buff = allocator->Alloc(shape, dt);
+  auto buff = allocator->Alloc(dev, shape, dt);
   EXPECT_EQ(allocator->UsedMemory(), size);
   allocator->Free(buff);
   EXPECT_EQ(allocator->UsedMemory(), size);
 
   try {
-    auto texture = allocator->Alloc(shape, dt, "global.texture");
+    auto texture = allocator->Alloc(dev, shape, dt, "global.texture");
     (void)texture;
     FAIL();
   } catch (std::exception& e) {
@@ -162,12 +162,12 @@ TEST_F(TvmVMMemoryManagerTest, NaiveAllocOpenCLTexture) {
   auto dt = DataType::Float(32);
   size_t nbytes = 1 * 3 * 6 * 6 * dt.bytes();
   ShapeTuple shape = {1, 3, 6, 6};
-  auto buff = allocator->Alloc(shape, dt);
+  auto buff = allocator->Alloc(dev, shape, dt);
   EXPECT_EQ(allocator->UsedMemory(), nbytes);
   allocator->Free(buff);
   EXPECT_EQ(allocator->UsedMemory(), 0);
 
-  auto texture = allocator->Alloc(shape, dt, "global.texture");
+  auto texture = allocator->Alloc(dev, shape, dt, "global.texture");
   EXPECT_EQ(allocator->UsedMemory(), nbytes);
   allocator->Free(texture);
   EXPECT_EQ(allocator->UsedMemory(), 0);
@@ -187,13 +187,13 @@ TEST_F(TvmVMMemoryManagerTest, PooledAllocOpenCLTexture) {
   size_t page_size = PooledAllocator::kDefaultPageSize;
   size_t size = ((nbytes + page_size - 1) / page_size) * page_size;
   ShapeTuple shape = {1, 3, 6, 6};
-  auto buff = allocator->Alloc(shape, dt);
+  auto buff = allocator->Alloc(dev, shape, dt);
   EXPECT_EQ(allocator->UsedMemory(), size);
   allocator->Free(buff);
   EXPECT_EQ(allocator->UsedMemory(), size);
 
   try {
-    auto texture = allocator->Alloc(shape, dt, "global.texture");
+    auto texture = allocator->Alloc(dev, shape, dt, "global.texture");
     (void)texture;
     FAIL();
   } catch (std::exception& e) {


### PR DESCRIPTION
Prior to this PR, each allocator is closely tied with a device. To enable using a same allocator across different devices of the same kind when needed, we lift the device to the allocator `Alloc` interface.