### PR TITLE
[BugFix][Ansor] Fixing Ansor Gradient Bug

### DIFF
--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -358,6 +358,12 @@ class TaskScheduler:
         self.best_ct = self.ct
         self.best_score = self.cur_score
 
+        # put task without schedule on warm up to dead state
+        if self.strategy == "gradient":
+            for task_idx in range(len(self.tasks)):
+                if(self.best_costs[task_idx] == 1e10):
+                    self.dead_tasks.add(task_idx)
+
         # use the specific strategy to choose workload to tune
         task_idx = -1
         while self.ct < tune_option.num_measure_trials and len(self.dead_tasks) < len(self.tasks):
@@ -367,9 +373,6 @@ class TaskScheduler:
                     task_idx = (task_idx + 1) % len(self.tasks)
             elif self.strategy == "gradient":
                 gradients = []
-
-                # fix gradient for task without schedule in warm up
-                self.best_costs[(self.best_costs == 1e10)] = 0
 
                 for i in range(len(self.tasks)):
                     if i in self.dead_tasks:
@@ -421,9 +424,6 @@ class TaskScheduler:
                     )
                     assert grad <= 0
                     gradients.append(grad)
-
-                # fix gradient for task without schedule in warm up
-                self.best_costs[(self.best_costs == 0)] = 1e10
 
                 if max(gradients) == min(gradients):
                     task_idx = np.random.choice(len(gradients))

--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -359,10 +359,9 @@ class TaskScheduler:
         self.best_score = self.cur_score
 
         # put task without schedule on warm up to dead state
-        if self.strategy == "gradient":
-            for task_idx in range(len(self.tasks)):
-                if(self.best_costs[task_idx] == 1e10):
-                    self.dead_tasks.add(task_idx)
+        for task_idx, cost in enumerate(self.best_costs):
+            if cost == 1e10:
+                self.dead_tasks.add(task_idx)
 
         # use the specific strategy to choose workload to tune
         task_idx = -1

--- a/python/tvm/auto_scheduler/task_scheduler.py
+++ b/python/tvm/auto_scheduler/task_scheduler.py
@@ -367,6 +367,10 @@ class TaskScheduler:
                     task_idx = (task_idx + 1) % len(self.tasks)
             elif self.strategy == "gradient":
                 gradients = []
+
+                # fix gradient for task without schedule in warm up
+                self.best_costs[(self.best_costs == 1e10)] = 0
+
                 for i in range(len(self.tasks)):
                     if i in self.dead_tasks:
                         gradients.append(0)
@@ -417,6 +421,9 @@ class TaskScheduler:
                     )
                     assert grad <= 0
                     gradients.append(grad)
+
+                # fix gradient for task without schedule in warm up
+                self.best_costs[(self.best_costs == 0)] = 1e10
 
                 if max(gradients) == min(gradients):
                     task_idx = np.random.choice(len(gradients))


### PR DESCRIPTION
When Ansor does not find a schedule for a task in warm up, Ansor gradient gets stuck in this task, because there is no optimized schedule for this task. Hence, Ansor does not optimize any task.

Behavior before correction

![bug](https://github.com/apache/tvm/assets/19735260/881b6882-99dc-42c4-86a0-9204ceb361fe)

Behavior after correction

![bug1](https://github.com/apache/tvm/assets/19735260/455d2c05-bc69-418f-8b62-b903373b8c77)
