### PR TITLE
[Bugfix][TIR] Fix cache_read update buffer region

### DIFF
--- a/src/tir/schedule/primitive/cache_read_write.cc
+++ b/src/tir/schedule/primitive/cache_read_write.cc
@@ -958,9 +958,10 @@ class CacheReadRewriter : public StmtExprMutator {
       // Otherwise, update read regions and match_buffers
       // Only make this change if the block is one of the specified consumers.
       if (is_consumer) {
-        Array<BufferRegion> reads = update_access_regions(block->reads);
-        Array<MatchBufferRegion> match_buffers = update_match_buffers(block->match_buffers);
-        if (!reads.same_as(block->reads) || !match_buffers.same_as(block->match_buffers)) {
+        // Use the updated block stmt
+        Array<BufferRegion> reads = update_access_regions(stmt->reads);
+        Array<MatchBufferRegion> match_buffers = update_match_buffers(stmt->match_buffers);
+        if (!reads.same_as(stmt->reads) || !match_buffers.same_as(stmt->match_buffers)) {
           ObjectPtr<BlockNode> n = make_object<BlockNode>(*stmt.as<BlockNode>());
           n->reads = std::move(reads);
           n->match_buffers = std::move(match_buffers);


### PR DESCRIPTION
Prior to this commit, cache_read primitive may not update the block reads buffer region properly when there is a nested buffer access.  
```python
@T.prim_func
def cache_read_nested_buffer_access(var_A: T.handle, var_B: T.handle, var_C: T.handle):
    for ax0, ax1 in T.grid(T.int64(1), T.int64(512)):
        with T.block("C"):
            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
            T.reads(A[B[v_ax0], v_ax1], B_global[v_ax0])
            T.writes(C[v_ax0, v_ax1])
            C[v_ax0, v_ax1] = A[B_global[v_ax0], v_ax1]
```
`T.reads(A[B[v_ax0], v_ax1])` should be updated as `T.reads(A[B_global[v_ax0], v_ax1])`
cc @Hzfengsy 