### PR TITLE
[Fix] Lazy import of "psutil" in disco process pool

### DIFF
--- a/python/tvm/runtime/disco/process_pool.py
+++ b/python/tvm/runtime/disco/process_pool.py
@@ -20,8 +20,6 @@ import os
 import subprocess
 import sys
 
-import psutil
-
 from tvm._ffi import register_func
 from tvm.runtime import ShapeTuple
 
@@ -158,6 +156,8 @@ def _kill_child_processes(pid):
     pid : int
         The given parameter id.
     """
+    import psutil  # pylint: disable=import-outside-toplevel
+
     try:
         parent = psutil.Process(pid)
         children = parent.children(recursive=True)


### PR DESCRIPTION
Prior to this PR, module "psutil" is imported at the top level of the disco process pool. The pool will try to kill all the processes at the time of destruction (when `__del__` is implicitly invoked). The `__del__` function eventually calls into a function that uses `pstuil`. But it is possible that the top-level `psutil` has already been released by Python, which leads to a KeyError as follows:

```
Exception ignored in: <function DiscoPopenWorker.__del__ at 0x7f2c922bfe20>
Traceback (most recent call last):
  File "/home/ruihangl/Workspace/tvm/python/tvm/runtime/disco/process_pool.py", line 67, in __del__
  File "/home/ruihangl/Workspace/tvm/python/tvm/runtime/disco/process_pool.py", line 81, in kill
  File "/home/ruihangl/Workspace/tvm/python/tvm/runtime/disco/process_pool.py", line 162, in _kill_child_processes
  File "/home/ruihangl/Workspace/miniconda3/envs/python311/lib/python3.11/site-packages/psutil/__init__.py", line 323, in __init__
  File "/home/ruihangl/Workspace/miniconda3/envs/python311/lib/python3.11/site-packages/psutil/__init__.py", line 353, in _init
  File "/home/ruihangl/Workspace/miniconda3/envs/python311/lib/python3.11/site-packages/psutil/_pslinux.py", line 1738, in __init__
  File "/home/ruihangl/Workspace/miniconda3/envs/python311/lib/python3.11/site-packages/psutil/_common.py", line 864, in get_procfs_path
KeyError: 'psutil'
```

This PR fixes the issue by lazily importing `psutil` when needed.