### PR TITLE
[IR][Relax] Improve highlighting in assert_structural_equal

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -782,15 +782,15 @@ class MatchCastNode : public BindingNode {
 
   bool SEqualReduce(const MatchCastNode* other, SEqualReducer equal) const {
     // NOTE: pattern can contain ShapeExpr which defines the vars
-    return equal.DefEqual(var, other->var) && equal.DefEqual(struct_info, other->struct_info) &&
-           equal(value, other->value);
+    return equal(value, other->value) && equal.DefEqual(struct_info, other->struct_info) &&
+           equal.DefEqual(var, other->var);
   }
 
   void SHashReduce(SHashReducer hash_reduce) const {
     // NOTE: pattern can contain ShapeExpr which defines the vars
-    hash_reduce.DefHash(var);
-    hash_reduce.DefHash(struct_info);
     hash_reduce(value);
+    hash_reduce.DefHash(struct_info);
+    hash_reduce.DefHash(var);
   }
 
   static constexpr const char* _type_key = "relax.expr.MatchCast";
@@ -823,11 +823,11 @@ class VarBindingNode : public BindingNode {
   }
 
   bool SEqualReduce(const VarBindingNode* other, SEqualReducer equal) const {
-    return equal.DefEqual(var, other->var) && equal(value, other->value);
+    return equal(value, other->value) && equal.DefEqual(var, other->var);
   }
   void SHashReduce(SHashReducer hash_reduce) const {
-    hash_reduce.DefHash(var);
     hash_reduce(value);
+    hash_reduce.DefHash(var);
   }
   static constexpr const char* _type_key = "relax.expr.VarBinding";
   static constexpr const bool _type_has_method_sequal_reduce = true;

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -780,18 +780,8 @@ class MatchCastNode : public BindingNode {
     v->Visit("span", &span);
   }
 
-  bool SEqualReduce(const MatchCastNode* other, SEqualReducer equal) const {
-    // NOTE: pattern can contain ShapeExpr which defines the vars
-    return equal(value, other->value) && equal.DefEqual(struct_info, other->struct_info) &&
-           equal.DefEqual(var, other->var);
-  }
-
-  void SHashReduce(SHashReducer hash_reduce) const {
-    // NOTE: pattern can contain ShapeExpr which defines the vars
-    hash_reduce(value);
-    hash_reduce.DefHash(struct_info);
-    hash_reduce.DefHash(var);
-  }
+  bool SEqualReduce(const MatchCastNode* other, SEqualReducer equal) const;
+  void SHashReduce(SHashReducer hash_reduce) const;
 
   static constexpr const char* _type_key = "relax.expr.MatchCast";
   static constexpr const bool _type_has_method_sequal_reduce = true;
@@ -822,13 +812,9 @@ class VarBindingNode : public BindingNode {
     v->Visit("span", &span);
   }
 
-  bool SEqualReduce(const VarBindingNode* other, SEqualReducer equal) const {
-    return equal(value, other->value) && equal.DefEqual(var, other->var);
-  }
-  void SHashReduce(SHashReducer hash_reduce) const {
-    hash_reduce(value);
-    hash_reduce.DefHash(var);
-  }
+  bool SEqualReduce(const VarBindingNode* other, SEqualReducer equal) const;
+  void SHashReduce(SHashReducer hash_reduce) const;
+
   static constexpr const char* _type_key = "relax.expr.VarBinding";
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -404,10 +404,7 @@ class SEqualHandlerDefault::Impl {
       auto& entry = task_stack_.back();
 
       if (entry.force_fail) {
-        if (IsPathTracingEnabled() && !first_mismatch_->defined()) {
-          *first_mismatch_ = entry.current_paths;
-        }
-        return false;
+        return CheckResult(false, entry.lhs, entry.rhs, entry.current_paths);
       }
 
       if (entry.children_expanded) {

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -27,6 +27,7 @@
 #include <tvm/node/structural_equal.h>
 #include <tvm/runtime/registry.h>
 
+#include <optional>
 #include <unordered_map>
 
 #include "ndarray_hash_equal.h"
@@ -249,15 +250,30 @@ class SEqualHandlerDefault::Impl {
     // in which case we can use same_as for quick checking,
     // or we have to run deep comparison and avoid to use same_as checks.
     auto run = [=]() {
-      if (!lhs.defined() && !rhs.defined()) return true;
-      if (!lhs.defined() && rhs.defined()) return false;
-      if (!rhs.defined() && lhs.defined()) return false;
-      if (lhs->type_index() != rhs->type_index()) return false;
-      auto it = equal_map_lhs_.find(lhs);
-      if (it != equal_map_lhs_.end()) {
-        return it->second.same_as(rhs);
+      std::optional<bool> early_result = [&]() -> std::optional<bool> {
+        if (!lhs.defined() && !rhs.defined()) return true;
+        if (!lhs.defined() && rhs.defined()) return false;
+        if (!rhs.defined() && lhs.defined()) return false;
+        if (lhs->type_index() != rhs->type_index()) return false;
+        auto it = equal_map_lhs_.find(lhs);
+        if (it != equal_map_lhs_.end()) {
+          return it->second.same_as(rhs);
+        }
+        if (equal_map_rhs_.count(rhs)) return false;
+
+        return std::nullopt;
+      }();
+
+      if (early_result.has_value()) {
+        if (early_result.value()) {
+          return true;
+        } else if (IsPathTracingEnabled() && IsFailDeferralEnabled() && current_paths.defined()) {
+          DeferFail(current_paths.value());
+          return true;
+        } else {
+          return false;
+        }
       }
-      if (equal_map_rhs_.count(rhs)) return false;
 
       // need to push to pending tasks in this case
       pending_tasks_.emplace_back(lhs, rhs, map_free_vars, current_paths);
@@ -530,8 +546,14 @@ bool SEqualHandlerDefault::DispatchSEqualReduce(const ObjectRef& lhs, const Obje
 TVM_REGISTER_GLOBAL("node.StructuralEqual")
     .set_body_typed([](const ObjectRef& lhs, const ObjectRef& rhs, bool assert_mode,
                        bool map_free_vars) {
+      // If we are asserting on failure, then the `defer_fails` option
+      // should be enabled, to provide better error messages.  For
+      // example, if the number of bindings in a `relax::BindingBlock`
+      // differs, highlighting the first difference rather than the
+      // entire block.
+      bool defer_fails = assert_mode;
       Optional<ObjectPathPair> first_mismatch;
-      return SEqualHandlerDefault(assert_mode, &first_mismatch, false)
+      return SEqualHandlerDefault(assert_mode, &first_mismatch, defer_fails)
           .Equal(lhs, rhs, map_free_vars);
     });
 

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -384,6 +384,33 @@ TVM_REGISTER_GLOBAL("relax.MatchCast")
       return MatchCast(var, value, struct_info, span);
     });
 
+bool MatchCastNode::SEqualReduce(const MatchCastNode* other, SEqualReducer equal) const {
+  if (value->IsInstance<FunctionNode>()) {
+    // Recursive function definitions may reference the bound variable
+    // within the value being bound.  In these cases, the
+    // `DefEqual(var, other->var)` must occur first, to ensure it is
+    // defined at point of use.
+    return equal.DefEqual(var, other->var) && equal.DefEqual(struct_info, other->struct_info) &&
+           equal(value, other->value);
+  } else {
+    // In all other cases, visit the bound value before the variable
+    // it is bound to, in order to provide better error messages.
+    return equal(value, other->value) && equal.DefEqual(struct_info, other->struct_info) &&
+           equal.DefEqual(var, other->var);
+  }
+}
+void MatchCastNode::SHashReduce(SHashReducer hash_reduce) const {
+  if (value->IsInstance<FunctionNode>()) {
+    hash_reduce.DefHash(var);
+    hash_reduce.DefHash(struct_info);
+    hash_reduce(value);
+  } else {
+    hash_reduce(value);
+    hash_reduce.DefHash(struct_info);
+    hash_reduce.DefHash(var);
+  }
+}
+
 TVM_REGISTER_NODE_TYPE(VarBindingNode);
 
 VarBinding::VarBinding(Var var, Expr value, Span span) {
@@ -397,6 +424,29 @@ VarBinding::VarBinding(Var var, Expr value, Span span) {
 TVM_REGISTER_GLOBAL("relax.VarBinding").set_body_typed([](Var var, Expr value, Span span) {
   return VarBinding(var, value, span);
 });
+
+bool VarBindingNode::SEqualReduce(const VarBindingNode* other, SEqualReducer equal) const {
+  if (value->IsInstance<FunctionNode>()) {
+    // Recursive function definitions may reference the bound variable
+    // within the value being bound.  In these cases, the
+    // `DefEqual(var, other->var)` must occur first, to ensure it is
+    // defined at point of use.
+    return equal.DefEqual(var, other->var) && equal(value, other->value);
+  } else {
+    // In all other cases, visit the bound value before the variable
+    // it is bound to, in order to provide better error messages.
+    return equal(value, other->value) && equal.DefEqual(var, other->var);
+  }
+}
+void VarBindingNode::SHashReduce(SHashReducer hash_reduce) const {
+  if (value->IsInstance<FunctionNode>()) {
+    hash_reduce.DefHash(var);
+    hash_reduce(value);
+  } else {
+    hash_reduce(value);
+    hash_reduce.DefHash(var);
+  }
+}
 
 TVM_REGISTER_NODE_TYPE(BindingBlockNode);
 


### PR DESCRIPTION
Prior to this commit, `tvm.ir.assert_structural_equal` would highlight an entire `relax::BindingBlock` if the number of elements in the binding block differs.  This can result in the entire Relax function being highlighted, making it difficult to identify the location of the mismatch.

This commit makes the following changes, to improve the error messages that occur when `tvm.ir.assert_structural_equal` raises an exception.

- In `"node.StructuralEqual"`, set `defer_fails = true` when `assert_mode` is true.  This highlights the first mismatch of an `Array<relax::Binding>`, rather than the entire array, in cases where the LHS and RHS have different sizes.

- In the `SHashReduce` for `VarBinding` and `MatchCast`, visit the value first, and then the variable to which it is bound.  This highlights the mismatched expression, rather than mismatches in the resulting struct info.

- In `SEqualHandlerDefault::Impl::SEqualReduce`, defer the failure if enabled.  This highlights the first mismatch, which may also have been deferred, rather than an early return a later mismatch occurs involving `NullOpt`.