### PR TITLE
[AOT][Testing] Improve output mismatch information on test failure

### DIFF
--- a/python/tvm/testing/aot.py
+++ b/python/tvm/testing/aot.py
@@ -483,8 +483,10 @@ def _emit_main_compare(
                 f"\t}}\n"
                 f"}}"
                 f"if (mismatch >= 1) {{\n"
-                f"\tfloat percent_mismatched = ((float) mismatch) / ((float) {data_length_var_name}) * 100;\n"
-                f'\tprintf("\\nMismatched elements: %d / %zu (%.2f%%)\\n", mismatch, {data_length_var_name}, percent_mismatched);\n'
+                f"\tfloat percent_mismatched = ((float) mismatch) /"
+                f"((float) {data_length_var_name}) * 100;\n"
+                f'\tprintf("\\nMismatched elements: %d / %zu (%.2f%%)\\n"'
+                f", mismatch, {data_length_var_name}, percent_mismatched);\n"
                 f'\tprintf("{AOT_FAILURE_TOKEN}\\n");\n'
                 f"\treturn -1;\n"
                 f"}}\n"

--- a/python/tvm/testing/aot.py
+++ b/python/tvm/testing/aot.py
@@ -459,19 +459,35 @@ def _emit_main_compare(
 
         if print_output_on_mismatch:
             main_file.write(
-                f"int mismatch = 0;"
-                f'printf("Actual, Reference\\n");\n'
+                f"{{\n"
+                f"int mismatch = 0;\n"
+                f"int out_ndim = {outputs[key].ndim};\n"
+                f"int out_shape[] = {{{','.join(map(str, outputs[key].shape))}}};\n"
+                f"int out_indices[out_ndim];\n"
+                f'printf("Element [Position]: Actual, Reference\\n");\n'
+                f'printf("-------------------------------------\\n");\n'
                 f"for (int i = 0; i<{data_length_var_name}; i++) {{\n"
                 f"\tif ({comparison_function}({actual_data_name}[i]-"
                 f"{expected_data_name}[i]) > {tolerance}) {{\n"
-                f'\t\tprintf("{value_format_specifier}, {value_format_specifier}\\n"'
+                f"\t\tint flat_index = i;\n"
+                f"\t\tfor (int j = out_ndim - 1; j >= 0; j--){{\n"
+                f"\t\t\tout_indices[j] = flat_index % out_shape[j];\n"
+                f"\t\t\tflat_index /= out_shape[j];\n"
+                f"\t\t}}\n"
+                f'\t\tprintf("Element [%d", out_indices[0]);\n'
+                f"\t\tfor (int j = 1; j < out_ndim; j++)\n"
+                f'\t\t\tprintf(", %d", out_indices[j]);\n'
+                f'\t\tprintf("]: {value_format_specifier}, {value_format_specifier}\\n"'
                 f", {actual_data_name}[i], {expected_data_name}[i]);\n"
-                f"\t\tmismatch = 1;\n"
+                f"\t\tmismatch += 1;\n"
                 f"\t}}\n"
                 f"}}"
-                f"if (mismatch == 1) {{\n"
+                f"if (mismatch >= 1) {{\n"
+                f"\tfloat percent_mismatched = ((float) mismatch) / ((float) {data_length_var_name}) * 100;\n"
+                f'\tprintf("\\nMismatched elements: %d / %zu (%.2f%%)\\n", mismatch, {data_length_var_name}, percent_mismatched);\n'
                 f'\tprintf("{AOT_FAILURE_TOKEN}\\n");\n'
                 f"\treturn -1;\n"
+                f"}}\n"
                 f"}}"
             )
         else:

--- a/python/tvm/testing/aot.py
+++ b/python/tvm/testing/aot.py
@@ -484,7 +484,7 @@ def _emit_main_compare(
                   }}
                 }}
                 if (mismatch >= 1) {{
-                  float percent_mismatched = 
+                  float percent_mismatched =
                       ((float) mismatch) / ((float) {data_length_var_name}) * 100;
                   printf("\\nMismatched elements: %d / %zu (%.2f%%)\\n",
                          mismatch, {data_length_var_name}, percent_mismatched);

--- a/tests/python/relay/aot/test_aot_test_harness.py
+++ b/tests/python/relay/aot/test_aot_test_harness.py
@@ -46,7 +46,57 @@ def test_output_on_mismatch_option():
         ).astype(dtype)
     }
 
-    msg = ".*Actual, Reference\n2.000000, 0.000000\nAOT_TEST_FAILURE.*"
+    msg = ".*Actual, Reference(\n|.)*2.000000, 0.000000(\n|.)*AOT_TEST_FAILURE.*"
+    with pytest.raises(RuntimeError, match=msg):
+        compile_and_run(
+            AOTTestModel(module=tvm.IRModule.from_expr(func), inputs={}, outputs=outputs),
+            test_runner,
+            interface_api,
+            use_unpacked_api,
+            print_output_on_mismatch=True,
+        )
+
+
+def test_output_position_on_mismatch():
+    """
+    Test the mismatch position output for the print_output_on_mismatch option.
+    """
+    interface_api = "packed"
+    use_unpacked_api = True
+    test_runner = AOTTestRunner()
+    dtype = "float32"
+
+    x = np.zeros(shape=(2, 2), dtype=dtype)
+    x[-1, -1] = 1
+    func = relay.Function([], relay.const(x, dtype=dtype))
+    outputs = {"output": np.zeros(shape=(2, 2), dtype=dtype)}
+
+    msg = ".*Element \\[1, 1\\]:.*"
+    with pytest.raises(RuntimeError, match=msg):
+        compile_and_run(
+            AOTTestModel(module=tvm.IRModule.from_expr(func), inputs={}, outputs=outputs),
+            test_runner,
+            interface_api,
+            use_unpacked_api,
+            print_output_on_mismatch=True,
+        )
+
+
+def test_mismatch_percentage():
+    """
+    Test the mismatch percentage for the print_output_on_mismatch option.
+    """
+    interface_api = "packed"
+    use_unpacked_api = True
+    test_runner = AOTTestRunner()
+    dtype = "float32"
+
+    x = np.zeros(shape=(8,), dtype=dtype)
+    x[0] = 1
+    func = relay.Function([], relay.const(x, dtype=dtype))
+    outputs = {"output": np.zeros(shape=(8,), dtype=dtype)}
+
+    msg = ".*Mismatched elements: 1 / 8 \\(12.50%\\).*"
     with pytest.raises(RuntimeError, match=msg):
         compile_and_run(
             AOTTestModel(module=tvm.IRModule.from_expr(func), inputs={}, outputs=outputs),


### PR DESCRIPTION
Enhanced AOT test harness to include overall mismatch percentage and the individual mismatch positions from the output tensor for debugging test failures. Both of these are still gated behind `print_output_on_mismatch == True`.  
I also added tests to check for the presence and correctness of this new debug information.  

Sample output:

```
Element [Position]: Actual, Reference
-------------------------------------
Element [0, 8, 8, 7]: 521.846313, 521.847412
Element [0, 9, 8, 51]: 478.874359, 478.875549
Element [0, 9, 9, 6]: 462.901001, 462.899658

Mismatched elements: 3 / 16384 (0.02%)
...
```

cc @lhutton1 @ekalda 