### PR TITLE
[BugFix][Target] Added null check to fix segfault at ->defined() in cpu.cc DetectSystemTriple()

### DIFF
--- a/src/target/parsers/cpu.cc
+++ b/src/target/parsers/cpu.cc
@@ -29,13 +29,11 @@ namespace parsers {
 namespace cpu {
 
 Optional<String> DetectSystemTriple() {
-  #ifdef TVM_INFO_USE_LLVM
   auto pf = tvm::runtime::Registry::Get("target.llvm_get_system_triple");
-  if (pf->defined()) {
-    return (*pf)();
-  }
-  #endif
-  return {};
+  ICHECK (pf != nullptr) 
+  << "The target llvm_get_system_triple was not found, " 
+  "please compile with USE_LLVM = ON";
+  return (*pf)();
 }
 
 TargetJSON ParseTarget(TargetJSON target) {

--- a/src/target/parsers/cpu.cc
+++ b/src/target/parsers/cpu.cc
@@ -29,10 +29,12 @@ namespace parsers {
 namespace cpu {
 
 Optional<String> DetectSystemTriple() {
+  #ifdef TVM_INFO_USE_LLVM
   auto pf = tvm::runtime::Registry::Get("target.llvm_get_system_triple");
-  if (pf != 0 && pf->defined()) {
+  if (pf->defined()) {
     return (*pf)();
   }
+  #endif
   return {};
 }
 

--- a/src/target/parsers/cpu.cc
+++ b/src/target/parsers/cpu.cc
@@ -29,11 +29,13 @@ namespace parsers {
 namespace cpu {
 
 Optional<String> DetectSystemTriple() {
+#ifdef TVM_LLVM_VERSION
   auto pf = tvm::runtime::Registry::Get("target.llvm_get_system_triple");
-  ICHECK (pf != nullptr) 
-  << "The target llvm_get_system_triple was not found, " 
-  "please compile with USE_LLVM = ON";
+  ICHECK(pf != nullptr) << "The target llvm_get_system_triple was not found, "
+                           "please compile with USE_LLVM = ON";
   return (*pf)();
+#endif
+  return {};
 }
 
 TargetJSON ParseTarget(TargetJSON target) {

--- a/src/target/parsers/cpu.cc
+++ b/src/target/parsers/cpu.cc
@@ -30,7 +30,7 @@ namespace cpu {
 
 Optional<String> DetectSystemTriple() {
   auto pf = tvm::runtime::Registry::Get("target.llvm_get_system_triple");
-  if (pf->defined()) {
+  if (pf != 0 && pf->defined()) {
     return (*pf)();
   }
   return {};

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -457,9 +457,13 @@ TEST(TargetCreation, DetectSystemTriple) {
   Target target = Target(config);
   ICHECK_EQ(target->kind, TargetKind::Get("llvm").value());
 
-  Optional<String> mtriple = target->GetAttr<String>("mtriple");
   auto pf = tvm::runtime::Registry::Get("target.llvm_get_system_triple");
-  ASSERT_TRUE(pf->defined());
+  if (pf == nullptr) {
+    GTEST_SKIP() << "LLVM is not available, skipping test";
+  }
+
+  Optional<String> mtriple = target->GetAttr<String>("mtriple");
+  ASSERT_TRUE(mtriple.value() == String((*pf)()));
 }
 
 #endif

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -290,7 +290,7 @@ TEST(TargetCreation, ProcessStrings) {
   ASSERT_EQ(array7[1][1][0], "fred");
 }
 
-#ifdef TVM_INFO_USE_LLVM
+#ifdef TVM_LLVM_VERSION
 // Checks that malformed options cause an assertion.
 TEST(TargetCreation, LLVMCommandLineParseFatalDashDashDash) {
   tvm::codegen::LLVMInstance inst;

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -448,6 +448,20 @@ TEST(TargetCreation, LLVMCommandLineSaveRestore) {
   // Check that we restored global state.
   ASSERT_FALSE(info.MatchesGlobalState());
 }
+
+TEST(TargetCreation, DetectSystemTriple) {
+  Map<String, ObjectRef> config = {
+      {"kind", String("llvm")},
+  };
+
+  Target target = Target(config);
+  ICHECK_EQ(target->kind, TargetKind::Get("llvm").value());
+
+  Optional<String> mtriple = target->GetAttr<String>("mtriple");
+  auto pf = tvm::runtime::Registry::Get("target.llvm_get_system_triple");
+  ASSERT_TRUE(pf->defined());
+}
+
 #endif
 
 TVM_REGISTER_TARGET_KIND("test_external_codegen_0", kDLCUDA)
@@ -498,21 +512,6 @@ TEST(TargetCreation, DeduplicateKeys) {
   ICHECK_EQ(target->keys[1], "arm_cpu");
   ICHECK_EQ(target->attrs.size(), 2U);
   ICHECK_EQ(target->GetAttr<String>("device"), "arm_cpu");
-}
-
-TEST(TargetCreation, DetectSystemTriple) {
-  Map<String, ObjectRef> config = {
-      {"kind", String("llvm")},
-  };
-
-  Target target = Target(config);
-  ICHECK_EQ(target->kind, TargetKind::Get("llvm").value());
-
-  Optional<String> mtriple = target->GetAttr<String>("mtriple");
-  auto pf = tvm::runtime::Registry::Get("target.llvm_get_system_triple");
-  if (!pf->defined()) {
-    GTEST_SKIP() << "LLVM is not available, skipping test";
-  }
 }
 
 TEST(TargetKindRegistry, ListTargetKinds) {

--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -290,6 +290,7 @@ TEST(TargetCreation, ProcessStrings) {
   ASSERT_EQ(array7[1][1][0], "fred");
 }
 
+#ifdef TVM_INFO_USE_LLVM
 // Checks that malformed options cause an assertion.
 TEST(TargetCreation, LLVMCommandLineParseFatalDashDashDash) {
   tvm::codegen::LLVMInstance inst;
@@ -447,6 +448,7 @@ TEST(TargetCreation, LLVMCommandLineSaveRestore) {
   // Check that we restored global state.
   ASSERT_FALSE(info.MatchesGlobalState());
 }
+#endif
 
 TVM_REGISTER_TARGET_KIND("test_external_codegen_0", kDLCUDA)
     .set_attr<Bool>(tvm::attr::kIsExternalCodegen, Bool(true));

--- a/tests/cpp/tir_scalable_datatype.cc
+++ b/tests/cpp/tir_scalable_datatype.cc
@@ -24,7 +24,7 @@
 #include <tvm/tir/expr.h>
 
 #ifdef TVM_LLVM_VERSION
-  #include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Intrinsics.h>
 #endif
 
 #include "../../src/script/printer/utils.h"

--- a/tests/cpp/tir_scalable_datatype.cc
+++ b/tests/cpp/tir_scalable_datatype.cc
@@ -23,7 +23,7 @@
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/expr.h>
 
-#ifdef TVM_INFO_USE_LLVM
+#ifdef TVM_LLVM_VERSION
   #include <llvm/IR/Intrinsics.h>
 #endif
 

--- a/tests/cpp/tir_scalable_datatype.cc
+++ b/tests/cpp/tir_scalable_datatype.cc
@@ -19,10 +19,13 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <llvm/IR/Intrinsics.h>
 #include <tvm/runtime/data_type.h>
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/expr.h>
+
+#ifdef TVM_INFO_USE_LLVM
+  #include <llvm/IR/Intrinsics.h>
+#endif
 
 #include "../../src/script/printer/utils.h"
 


### PR DESCRIPTION
I ran into a problem running a very simple ONNX compile, i would get a segfault at a FoldConstantExpr() call from TVMC. **This only happens if the compile flag `set(USE_LLVM OFF)` is OFF.**

```
Thread 1 "python3" received signal SIGSEGV, Segmentation fault.
0x00007fffc94ac78c in tvm::runtime::ObjectPtr<tvm::runtime::Object>::operator!=(decltype(nullptr)) const (this=0x0, null=<error reading variable: Attempt to dereference a generic pointer.>) at /home/otto/tvm/include/tvm/runtime/object.h:470
470       bool operator!=(std::nullptr_t null) const { return data_ != null; }
```

I had compiled TVM Using GCC:
```
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/11/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:amdgcn-amdhsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 11.4.0-1ubuntu1~22.04' --with-bugurl=file:///usr/share/doc/gcc-11/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-11 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-werror --enable-cet --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none=/build/gcc-11-XeT9lY/gcc-11-11.4.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/gcc-11-XeT9lY/gcc-11-11.4.0/debian/tmp-gcn/usr --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu --with-build-config=bootstrap-lto-lean --enable-link-serialization=2
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04) 
```

This was caused by a call to defined() from DetectSystemTriple() in cpu.cc that was added in #16513. When the previous call
```
auto pf = tvm::runtime::Registry::Get("target.llvm_get_system_triple");
```
would fail, and return null. The consecutive call to defined() would segfault after trying to dereference the null value. This commit adds a check to see if the function pointer is null. This might not be the best solution, but it worked for me, so it might also help someone else struggling with this. Please suggest a better solution, if you know one.