### PR TITLE
[MSC][M5.3] Support torch.dynamo for dynamic models

### DIFF
--- a/gallery/how_to/work_with_msc/using_tools.py
+++ b/gallery/how_to/work_with_msc/using_tools.py
@@ -57,11 +57,12 @@ parser.add_argument("--test_batch", type=int, default=1, help="The batch size fo
 parser.add_argument("--test_iter", type=int, default=100, help="The iter for test")
 parser.add_argument("--calibrate_iter", type=int, default=100, help="The iter for calibration")
 parser.add_argument("--train_batch", type=int, default=32, help="The batch size for train")
-parser.add_argument("--train_iter", type=int, default=200, help="The iter for train")
-parser.add_argument("--train_epoch", type=int, default=100, help="The epoch for train")
+parser.add_argument("--train_iter", type=int, default=100, help="The iter for train")
+parser.add_argument("--train_epoch", type=int, default=5, help="The epoch for train")
 parser.add_argument(
     "--verbose", type=str, default="info", help="The verbose level, info|debug:1,2,3|critical"
 )
+parser.add_argument("--dynamic", action="store_true", help="Whether to use dynamic wrapper")
 args = parser.parse_args()
 
 
@@ -88,8 +89,8 @@ def get_config(calib_loader, train_loader):
         compile_type=args.compile_type,
         dataset=dataset,
         tools=tools,
-        skip_config={"all": "check"},
         verbose=args.verbose,
+        dynamic=args.dynamic,
     )
 
 
@@ -100,13 +101,13 @@ if __name__ == "__main__":
         for i, (inputs, _) in enumerate(testloader, 0):
             if i >= args.calibrate_iter > 0:
                 break
-            yield {"input": inputs}
+            yield inputs if args.dynamic else {"input": inputs}
 
     def _get_train_datas():
         for i, (inputs, _) in enumerate(trainloader, 0):
             if i >= args.train_iter > 0:
                 break
-            yield {"input": inputs}
+            yield inputs if args.dynamic else {"input": inputs}
 
     model = resnet50(pretrained=args.checkpoint)
     if torch.cuda.is_available():

--- a/python/tvm/contrib/msc/core/gym/environment/method.py
+++ b/python/tvm/contrib/msc/core/gym/environment/method.py
@@ -105,7 +105,7 @@ class EnvMethod(object):
             outputs = runner.run(inputs)
             baseline = loader[idx]
             for name, data in outputs.items():
-                loss += _get_loss(baseline[name], data)
+                loss += _get_loss(baseline[name], msc_utils.cast_array(data))
         return {"loss": loss / len(loader)}
 
     @classmethod

--- a/python/tvm/contrib/msc/core/gym/environment/quantize_env.py
+++ b/python/tvm/contrib/msc/core/gym/environment/quantize_env.py
@@ -70,7 +70,7 @@ class QuantizeEnv(BaseEnv):
                 continue
             info.update(strategys[name].get_executor(msc_utils.MSCStage.QUANTIZE).config)
         summary_file = msc_utils.get_cache_dir().relpath("gym_summary.json")
-        return msc_utils.dump_dict(plan, summary_file)
+        return msc_utils.save_dict(plan, summary_file)
 
     @classmethod
     def role_type(cls):

--- a/python/tvm/contrib/msc/core/runtime/__init__.py
+++ b/python/tvm/contrib/msc/core/runtime/__init__.py
@@ -17,3 +17,4 @@
 """tvm.contrib.msc.core.runtime"""
 
 from .runner import *
+from .jit import *

--- a/python/tvm/contrib/msc/core/runtime/jit.py
+++ b/python/tvm/contrib/msc/core/runtime/jit.py
@@ -1,0 +1,365 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-argument
+"""tvm.contrib.msc.core.runtime.jit_model"""
+
+import logging
+from typing import Any, List, Tuple, Union, Dict
+
+from tvm.contrib.msc.core import utils as msc_utils
+from tvm.contrib.msc.core.tools import ToolType
+from tvm.contrib.msc.core.utils.namespace import MSCFramework
+from .runner import BaseRunner
+
+
+class BaseJIT(object):
+    """Base Just-In-Time compile for msc
+
+    Parameters
+    ----------
+    model:
+        The model to be jit compile.
+    inputs: list<str>
+        The input names.
+    outputs: list<str>
+        The output names.
+    device: str
+        The device to build runnable.
+    training: bool
+        Whether compile model to trainable.
+    hooks: dict
+        The hooks for runners.
+    logger: logging.Logger
+        The logger
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        inputs: List[str],
+        outputs: List[str],
+        device: str = "cpu",
+        training: bool = False,
+        hooks: dict = None,
+        logger: logging.Logger = None,
+    ):
+        self._model = model
+        self._jit_model = model
+        self._inputs = inputs
+        self._outputs = outputs
+        self._device = device if self.support_device(device) else "cpu"
+        self._training, self._trained = training, training
+        self._hooks = hooks or {}
+        self._runner_ctxs = {}
+        self._logger = logger or msc_utils.get_global_logger()
+        self._logger.info(msc_utils.msg_block(self.jit_mark("SETUP"), self.setup()))
+
+    def setup(self) -> dict:
+        """Setup the jit
+
+        Returns
+        -------
+        info: dict
+            The setup info.
+        """
+
+        return {
+            "inputs": self._inputs,
+            "outputs": self._outputs,
+            "device": self._device,
+            "training": self._training,
+            "hooks": self._hooks,
+        }
+
+    def run(
+        self, inputs: Union[List[Any], Dict[str, Any]], ret_type="native"
+    ) -> Union[List[Any], Dict[str, Any]]:
+        """Run the jit to get outputs
+
+        Parameters
+        -------
+        inputs: list<data> or dict<str, data>
+            The inputs in list or dict.
+        ret_type: str
+            The return type list| dict
+
+        Returns
+        -------
+        outputs: dict<str, data>
+            The outputs in dict.
+        """
+
+        inputs = msc_utils.format_datas(inputs, self._inputs, style="dict")
+        outputs = self._call_jit(inputs)
+        if ret_type == "native":
+            return outputs
+        return msc_utils.format_datas(outputs, self._outputs, style=ret_type)
+
+    def _call_jit(self, inputs: Dict[str, Any]) -> Any:
+        """Run the jit model
+
+        Parameters
+        ----------
+        inputs:
+            The inputs of model.
+        """
+
+        raise NotImplementedError("_call_jit is not implemented in " + str(self.__class__))
+
+    def set_runner(self, runner_name: str, runner: BaseRunner):
+        """Set runner in runner ctx
+
+        Parameters
+        ----------
+        runner_name: str
+            The runner name.
+        runner: BaseRunner
+            The runner.
+        """
+
+        self.get_runner_ctx(runner_name)["runner"] = runner
+
+    def build(self):
+        """Build the jit model"""
+
+        self._jit_model = self._build(self._model)
+
+    def _build(self, model: Any) -> Any:
+        """Build the jit model
+
+        Parameters
+        ----------
+        model:
+            The model.
+
+        Returns
+        -------
+        jit_model:
+            The jit model.
+        """
+
+        raise NotImplementedError("_build is not implemented in " + str(self.__class__))
+
+    def make_plan(self, tool_type: str, data_loader: Any = None) -> str:
+        """Execute tool and get plan
+
+        Parameters
+        -------
+        tool_type: str
+            The tool type, should be in ToolType
+        data_loader:
+            The data loader.
+
+        Returns
+        -------
+        plan_file: str
+            The saved plan file.
+        """
+
+        tools = {n: r["runner"].get_tool(tool_type) for n, r in self._runner_ctxs.items()}
+
+        def _finalize_tool(
+            checker: callable, post_batch: callable = None, post_iter: callable = None
+        ):
+            while any(not checker(t) for t in tools.values()):
+                assert data_loader, "data_loader should be given to make plan for " + tool_type
+                for inputs in data_loader():
+                    outputs = self.run(inputs, ret_type="native")
+                    if post_batch:
+                        for t in tools.values():
+                            post_batch(t, outputs)
+                    if all(checker(t) for t in tools.values()):
+                        break
+                if post_iter:
+                    for t in tools.values():
+                        post_iter(t)
+            return {n: t.finalize() for n, t in tools.items()}
+
+        if tool_type == ToolType.PRUNER:
+            plans = _finalize_tool(lambda t: t.pruned)
+        elif tool_type == ToolType.QUANTIZER:
+            plans = _finalize_tool(lambda t: t.calibrated, post_iter=lambda t: t.calibrate())
+        elif tool_type == ToolType.DISTILLER:
+            plans = _finalize_tool(
+                lambda t: t.distilled,
+                post_batch=lambda t, outputs: t.learn(outputs),
+                post_iter=lambda t: t.distill(),
+            )
+        elif tool_type == ToolType.TRACKER:
+            plans = _finalize_tool(lambda t: t.tracked)
+        else:
+            plans = {n: t.finalize() for n, t in tools.items()}
+        plans_info = ", ".join(["{}({})".format(n, len(p)) for n, p in plans.items()])
+        self._logger.debug("Made %s plans for %s", plans_info, tool_type)
+
+    def _redirect_run(self, *args, runner_name: str = "worker", **kwargs) -> Any:
+        """Redirect forward of model
+
+        Parameters
+        ----------
+        args:
+            The arguments.
+        runner_name: str
+            The runner name.
+        kwargs:
+            The kwargs.
+
+        Returns
+        -------
+        outputs:
+            The outputs.
+        """
+
+        assert runner_name in self._runner_ctxs, "Failed to create runner " + runner_name
+        inputs = self._to_msc_inputs(runner_name, *args, **kwargs)
+        for hook in self._hooks.get("pre_forward", []):
+            hook(runner_name, inputs)
+        outputs = self._run_ctx(self.get_runner_ctx(runner_name), inputs)
+        for hook in self._hooks.get("post_forward", []):
+            outputs = hook(runner_name, outputs)
+        return self._from_msc_outputs(runner_name, outputs)
+
+    def _to_msc_inputs(self, runner_name: str, *args, **kwargs) -> List[Tuple[str, Any]]:
+        """Change inputs to msc format
+
+        Parameters
+        ----------
+        runner_name: str
+            The runner name.
+        args:
+            The arguments.
+        kwargs:
+            The kwargs.
+
+        Returns
+        -------
+        inputs:
+            The msc format inputs.
+        """
+
+        raise NotImplementedError("_to_msc_inputs is not implemented in " + str(self.__class__))
+
+    def _from_msc_outputs(self, runner_name: str, outputs: List[Tuple[str, Any]]) -> Any:
+        """Change inputs from msc format
+
+        Parameters
+        ----------
+        runner_name: str
+            The runner name.
+        outputs: list<(str, tensor)>
+            The msc format outputs.
+
+        Returns
+        -------
+        outputs:
+            The framework outputs.
+        """
+
+        raise NotImplementedError("_from_msc_outputs is not implemented in " + str(self.__class__))
+
+    def _run_ctx(self, runner_ctx: dict, inputs: List[Tuple[str, Any]]) -> List[Tuple[str, Any]]:
+        """Forward by runner context
+
+        Parameters
+        ----------
+        runner_ctx: dict
+            The runner context
+        inputs: list<(str, tensor)>
+            The inputs.
+
+        Returns
+        -------
+        outputs: list<(str, tensor)>
+            The outputs.
+        """
+
+        raise NotImplementedError("_run_ctx is not implemented in " + str(self.__class__))
+
+    def get_runner_ctx(self, runner_name: str) -> dict:
+        """Get the runner context
+
+        Parameters
+        ----------
+        runner_name: str
+            The runner name
+
+        Returns
+        -------
+        runner_cts: dict
+            The runner context.
+        """
+
+        assert runner_name in self._runner_ctxs, "Can not finc runner_context " + str(runner_name)
+        return self._runner_ctxs[runner_name]
+
+    def train(self):
+        """Change status to train"""
+
+        if not self._training:
+            self._training = True
+            for runner_ctx in self._runner_ctxs.values():
+                if "runner" in runner_ctx:
+                    runner_ctx["runner"].train()
+
+    def eval(self):
+        """Change status to eval"""
+
+        if self._training:
+            self._training, self._trained = False, True
+            for runner_ctx in self._runner_ctxs.values():
+                if "runner" in runner_ctx:
+                    runner_ctx["runner"].eval()
+
+    def jit_mark(self, msg: str):
+        """Mark the message with jit info
+
+        Parameters
+        -------
+        msg: str
+            The message
+
+        Returns
+        -------
+        msg: str
+            The message with mark.
+        """
+
+        return "JIT({}) {}".format(self.framework, msg)
+
+    @property
+    def trained(self):
+        return self._trained
+
+    @property
+    def jit_model(self):
+        return self._jit_model
+
+    @property
+    def framework(self):
+        return MSCFramework.MSC
+
+    @classmethod
+    def support_device(cls, device: str) -> bool:
+        """Check if the device is enabled
+
+        Returns
+        -------
+        enabled: bool
+            Whether the device is enabled.
+        """
+
+        return True

--- a/python/tvm/contrib/msc/core/tools/configer.py
+++ b/python/tvm/contrib/msc/core/tools/configer.py
@@ -93,7 +93,7 @@ class ToolConfiger(object):
         raise NotImplementedError("config_gym is not implemented in ToolConfiger")
 
     def config_apply(self) -> dict:
-        """Get the config fro apply
+        """Get the config for apply
 
         Returns
         -------

--- a/python/tvm/contrib/msc/core/tools/distill/distiller.py
+++ b/python/tvm/contrib/msc/core/tools/distill/distiller.py
@@ -37,7 +37,7 @@ class BaseDistiller(BaseTool):
             The setup info.
         """
 
-        self._max_iter = self._options.get("max_iter", 5)
+        self._max_iter = self._options.get("max_iter", 1)
         self._save_step = self._options.get("save_step", 50)
         if "weights_folder" in self._options:
             self._weights_folder = msc_utils.msc_dir(self._options["weights_folder"])
@@ -72,7 +72,8 @@ class BaseDistiller(BaseTool):
             with open(self._weights_path, "rb") as f:
                 distilled_weights = tvm.runtime.load_param_dict(f.read())
             weights.update({k: v for k, v in distilled_weights.items() if k in weights})
-            self._logger.info("Update %d distilled weights", len(distilled_weights))
+            msg = "Update {} distilled weights".format(len(distilled_weights))
+            self._logger.info(self.tool_mark(msg))
         return super()._reset(graphs, weights)
 
     def build_model(self, teacher: Any, student: Any) -> Any:
@@ -103,7 +104,8 @@ class BaseDistiller(BaseTool):
         """
 
         if self.on_debug(3, in_forward=False):
-            self._logger.debug("%s start learn[%d]", self.tool_type(), self._current_iter)
+            msg = "Start learn[{}]".format(self._current_iter)
+            self._logger.debug(self.tool_mark(msg))
         self._total_loss += float(self._learn(loss))
 
     def _learn(self, loss: Any):
@@ -134,9 +136,10 @@ class BaseDistiller(BaseTool):
         if self._current_iter >= self._max_iter:
             self._distilled = True
             self._plan = {n: msc_utils.inspect_array(d, False) for n, d in weights.items()}
-        self._logger.info(
-            "Distill[%d] loss(%d batch) %f", self._current_iter, self._forward_cnt, self._total_loss
+        msg = "Distill[{}] loss({} batch) {}".format(
+            self._current_iter, self._forward_cnt, self._total_loss
         )
+        self._logger.info(self.tool_mark(msg))
         self._current_iter += 1
         self._total_loss, self._forward_cnt = 0, 0
         return weights
@@ -165,8 +168,9 @@ class BaseDistiller(BaseTool):
         weights_path = self._weights_folder.relpath("distill_{}.bin".format(self._current_iter))
         with open(weights_path, "wb") as f_params:
             f_params.write(tvm.runtime.save_param_dict(weights))
-        if self.on_debug(2, in_forward=False):
-            self._logger.debug("Save weights[%d] to %s", self._current_iter, weights_path)
+        if self._debug_level >= 2:
+            msg = "Save weights[{}] to {}".format(self._current_iter, weights_path)
+            self._logger.debug(self.tool_mark(msg))
 
     def _support_scope(self, scope: str) -> bool:
         """Check if the scope si supported
@@ -244,24 +248,6 @@ class BaseDistiller(BaseTool):
         self._plan[name][scope] = plan
         return tensor
 
-    def export_config(self, config: dict, folder: msc_utils.MSCDirectory) -> dict:
-        """Export the config for tool
-
-        Parameters
-        -------
-        config: dict
-            The source config.
-        folder: MSCDirectory
-            The export folder.
-
-        Returns
-        -------
-        config: dict
-            The exported config.
-        """
-
-        return {}
-
     @property
     def distilled(self):
         return self._distilled
@@ -269,6 +255,10 @@ class BaseDistiller(BaseTool):
     @classmethod
     def tool_type(cls):
         return ToolType.DISTILLER
+
+    @classmethod
+    def exportable(cls):
+        return False
 
 
 @msc_utils.register_tool

--- a/python/tvm/contrib/msc/core/tools/execute.py
+++ b/python/tvm/contrib/msc/core/tools/execute.py
@@ -70,6 +70,27 @@ def add_tool(tool: BaseTool, tool_type: str, tag: str = "main"):
     return tool
 
 
+def get_tool_cls(framework: str, tool_type: str, config: dict) -> BaseTool:
+    """Get the tool class
+
+    Parameters
+    -------
+    framework: str
+        The framework for implement
+    tool_type: str
+        The type of the tool prune| quantize| distill...
+    config: dict
+        The config of tool.
+    """
+
+    tool_style = config.pop("tool_style") if "tool_style" in config else "default"
+    tool_cls = msc_utils.get_registered_tool(framework, tool_type, tool_style)
+    assert tool_cls, "Can not find tool class for {}:{} @ {}".format(
+        tool_type, tool_style, framework
+    )
+    return tool_cls
+
+
 def create_tool(framework: str, tool_type: str, tag: str = "main", **config) -> BaseTool:
     """Create tool by type, config and tag
 
@@ -85,12 +106,8 @@ def create_tool(framework: str, tool_type: str, tag: str = "main", **config) -> 
         The config of tool.
     """
 
-    tool_style = config.pop("tool_style") if "tool_style" in config else "default"
-    tool_cls = msc_utils.get_registered_tool(framework, tool_type, tool_style)
-    assert tool_cls, "Can not find tool class for {}:{} @ {}".format(
-        tool_type, tool_style, framework
-    )
-    return add_tool(tool_cls(**config), tool_type, tag)
+    tool_cls = get_tool_cls(framework, tool_type, config)
+    return add_tool(tool_cls(tag, **config), tool_type, tag)
 
 
 def get_tool(tool_type: str, tag: str = "main") -> BaseTool:

--- a/python/tvm/contrib/msc/core/tools/prune/pruner.py
+++ b/python/tvm/contrib/msc/core/tools/prune/pruner.py
@@ -123,6 +123,7 @@ class BasePruner(WeightTool):
             The weights.
         """
 
+        self._unpruned_tensors = {}
         self._meta_weights = weights
         graphs, weights = super()._reset(graphs, weights)
         if self._plan and self._enabled:
@@ -423,7 +424,9 @@ class BasePruner(WeightTool):
 
             pruned_tensors = {k: v for k, v in pruned_tensors.items() if _is_pruned(v, graph)}
             if self.on_debug(3, in_forward=False):
-                self._logger.debug(msc_utils.msg_block("Pruned Tensors", pruned_tensors))
+                self._logger.debug(
+                    msc_utils.msg_block(self.tool_mark("Pruned Tensors"), pruned_tensors)
+                )
 
             if pruned_tensors:
                 pruned_graph = _ffi_api.PruneWeights(graph, pruned_tensors)
@@ -439,15 +442,12 @@ class BasePruner(WeightTool):
         # log compress rate
         if pruned_cnt > 0:
             new_size = _flatten_size(pruned_weights)
-            self._logger.info(
-                "Prune %d weights, compress to %.2f%% (%.4f M->%.4f M)",
-                pruned_cnt,
-                new_size * 100 / raw_size,
-                raw_size,
-                new_size,
+            msg = "Prune {} weights, compress to {:.2f}% ({:.4f} M->{:.4f} M)".format(
+                pruned_cnt, new_size * 100 / raw_size, raw_size, new_size
             )
         else:
-            self._logger.info("No weights pruned, size %.4f M", raw_size)
+            msg = "No weights pruned, size {:.4f} M".format(raw_size)
+        self._logger.info(self.tool_mark(msg))
         return pruned_graphs, pruned_weights
 
     def get_meta_data(self, name: str) -> np.ndarray:
@@ -514,24 +514,6 @@ class BasePruner(WeightTool):
         self._plan = {n: c for n, c in self._plan.items() if c["in_indices"] or c["out_indices"]}
         return super().finalize()
 
-    def export_config(self, config: dict, folder: msc_utils.MSCDirectory) -> dict:
-        """Export the config for tool
-
-        Parameters
-        -------
-        config: dict
-            The source config.
-        folder: MSCDirectory
-            The export folder.
-
-        Returns
-        -------
-        config: dict
-            The exported config.
-        """
-
-        return {}
-
     @property
     def pruned(self):
         return len(self._plan) > 0
@@ -539,6 +521,10 @@ class BasePruner(WeightTool):
     @classmethod
     def tool_type(cls):
         return ToolType.PRUNER
+
+    @classmethod
+    def exportable(cls):
+        return False
 
 
 @msc_utils.register_tool

--- a/python/tvm/contrib/msc/core/tools/quantize/quantizer.py
+++ b/python/tvm/contrib/msc/core/tools/quantize/quantizer.py
@@ -76,9 +76,8 @@ class BaseQuantizer(BaseTool):
                 self._plan[name] = {k: v for k, v in plan.items() if k not in ("calibrated")}
             self.change_stage(MSCStage.QUANTIZE)
         calib_type = "calibrate" if self._calibrated else "gather"
-        self._logger.info(
-            "Quantizer %s %d plan after %d batch", calib_type, len(new_plan), self._forward_cnt
-        )
+        msg = "{} {} plan after {} batch".format(calib_type, len(new_plan), self._forward_cnt)
+        self._logger.info(self.tool_mark(msg))
         self._forward_cnt = 0
         return new_plan
 

--- a/python/tvm/contrib/msc/core/tools/track/configer.py
+++ b/python/tvm/contrib/msc/core/tools/track/configer.py
@@ -25,19 +25,6 @@ from tvm.contrib.msc.core import utils as msc_utils
 class TrackConfiger(ToolConfiger):
     """Configer for track"""
 
-    def config_apply(self) -> dict:
-        """Get the config fro apply
-
-        Returns
-        -------
-        config: dict
-            The apply config.
-        """
-
-        config = super().config_apply()
-        config.update({"apply_once": True})
-        return config
-
     @classmethod
     def tool_type(cls):
         return ToolType.TRACKER

--- a/python/tvm/contrib/msc/core/tools/track/tracker.py
+++ b/python/tvm/contrib/msc/core/tools/track/tracker.py
@@ -87,7 +87,7 @@ class BaseTracker(BaseTool):
                 msg += "; ".join(
                     ["{}: {}/{}".format(s, i["passed"], i["total"]) for s, i in passed.items()]
                 )
-            self._logger.info(msg)
+            self._logger.info(self.msg_mark(msg, in_forward=False))
         else:
             self._tracked = True
         return output
@@ -183,6 +183,10 @@ class BaseTracker(BaseTool):
     @classmethod
     def tool_type(cls):
         return ToolType.TRACKER
+
+    @classmethod
+    def apply_once(cls):
+        return True
 
 
 @msc_utils.register_tool

--- a/python/tvm/contrib/msc/core/transform/transform.py
+++ b/python/tvm/contrib/msc/core/transform/transform.py
@@ -22,6 +22,7 @@ from typing import Dict
 import tvm
 from tvm.relax.transform import _ffi_api as relax_api
 from tvm.relay.transform import _ffi_api as relay_api
+from tvm.contrib.msc.core import utils as msc_utils
 
 
 def SetExprName(
@@ -49,12 +50,8 @@ def SetExprName(
     """
 
     if as_relax:
-
-        def _get_name(name):
-            return name.replace("/", "_").replace(".", "_").strip("_")
-
         var_names = var_names or {}
-        var_names = {k: _get_name(v) for k, v in var_names.items()}
+        var_names = {k: msc_utils.legalize_expr_name(v) for k, v in var_names.items()}
         return relax_api.SetRelaxExprName(entry_name, target, var_names)  # type: ignore
     return relay_api.SetRelayExprName(entry_name)  # type: ignore
 

--- a/python/tvm/contrib/msc/core/utils/arguments.py
+++ b/python/tvm/contrib/msc/core/utils/arguments.py
@@ -77,7 +77,7 @@ def save_dict(dict_obj: Any, path: str, indent: int = 2) -> str:
     return path
 
 
-def update_dict(src_dict: dict, new_dict: dict, soft_update: bool = True) -> dict:
+def update_dict(src_dict: dict, new_dict: dict, soft_update: bool = False) -> dict:
     """Update src_dict with new_dict.
 
     Parameters
@@ -95,14 +95,18 @@ def update_dict(src_dict: dict, new_dict: dict, soft_update: bool = True) -> dic
         The updated dict.
     """
 
+    if not new_dict:
+        return src_dict
     assert isinstance(src_dict, dict) and isinstance(
         new_dict, dict
     ), "update_dict only support dict, get src {} and new {}".format(type(src_dict), type(new_dict))
     for k, v in new_dict.items():
-        if isinstance(v, dict):
+        if not src_dict.get(k):
+            src_dict[k] = v
+        elif isinstance(v, dict):
             v = update_dict(src_dict.get(k, {}), v, soft_update)
             src_dict[k] = v
-        elif not soft_update or k not in src_dict:
+        elif not soft_update:
             src_dict[k] = v
     return src_dict
 

--- a/python/tvm/contrib/msc/core/utils/expr.py
+++ b/python/tvm/contrib/msc/core/utils/expr.py
@@ -17,12 +17,36 @@
 """tvm.contrib.msc.core.utils.expr"""
 
 import copy
-from typing import Dict
+from typing import Dict, List
 
 import tvm
 from tvm import relax
 from tvm.relax import PyExprVisitor
 from tvm.contrib.msc.core import _ffi_api
+
+
+def legalize_expr_name(name: str, symbols: List[str] = None, dst: str = "_") -> str:
+    """Legalize expr name
+
+    Parameters
+    ----------
+    name: str
+        The source name.
+    symbols: list<str>
+        The symbols to be replaced.
+    dst: str
+        The symbol for replace.
+
+    Returns
+    -------
+    name: str
+        The legialized name.
+    """
+
+    symbols = symbols or ["::", "/", "."]
+    for sym in symbols:
+        name = name.replace(sym, dst)
+    return name.strip(dst)
 
 
 def get_expr_name(expr: relax.Expr) -> str:
@@ -46,11 +70,11 @@ def get_expr_name(expr: relax.Expr) -> str:
 
 
 def make_span(kwargs: Dict[str, str], span: relax.Span = None) -> relax.Span:
-    """Change name to span
+    """Make a span from kwargs
 
     Parameters
     ----------
-    kwargs: dict<str,str>
+    kwargs: dict<str, str>
         The attrs in span.
     span: relax.Span
         The source span.

--- a/python/tvm/contrib/msc/core/utils/log.py
+++ b/python/tvm/contrib/msc/core/utils/log.py
@@ -137,9 +137,50 @@ def get_global_logger() -> logging.Logger:
     return MSCMap.get(MSCKey.GLOBALE_LOGGER)
 
 
+def get_log_file(logger: logging.Logger) -> str:
+    """Get the log file from logger
+
+    Parameters
+    ----------
+    logger: logging.Logger
+        The logger.
+
+    Returns
+    -------
+    log_file: str
+        The log file.
+    """
+
+    for log_h in logger.handlers:
+        if isinstance(log_h, logging.FileHandler):
+            return log_h.baseFilename
+    return None
+
+
 def remove_loggers():
     """Remove the logger handlers"""
 
     logger = MSCMap.get(MSCKey.GLOBALE_LOGGER)
     if logger:
         logger.handlers.clear()
+
+
+def split_line(msg: str, symbol: str = "#", width: int = 100) -> str:
+    """Mark message to split line
+
+    Parameters
+    ----------
+    msg: str
+        The message.
+    symbol: str
+        The split symbol.
+    width: int
+        The line width.
+
+    Returns
+    -------
+    split_line: str
+        The split line with message.
+    """
+
+    return "\n{0}{1}{0}".format(20 * symbol, msg.center(width - 40))

--- a/python/tvm/contrib/msc/core/utils/message.py
+++ b/python/tvm/contrib/msc/core/utils/message.py
@@ -21,7 +21,7 @@ import logging
 from typing import List, Tuple
 
 from .arguments import dump_dict, map_dict
-from .log import get_global_logger
+from .log import get_global_logger, split_line
 from .namespace import MSCMap, MSCKey
 
 
@@ -69,7 +69,7 @@ def time_stamp(stage: str, log_stage: bool = True, logger: logging.Logger = None
     stage: str
         The stage name.
     log_stage: bool
-        Whether to log the stage
+        Whether to log the stage.
     logger: logging.Logger
         The logger.
     """
@@ -82,14 +82,14 @@ def time_stamp(stage: str, log_stage: bool = True, logger: logging.Logger = None
         if log_stage:
             last_stage = MSCMap.get(MSCKey.MSC_STAGE)
             if last_stage:
-                end_msg = "[MSC] End {}".format(last_stage.upper())
-                logger.info("\n{0} {1} {0}\n".format("#" * 20, end_msg.center(40)))
-            start_msg = "[MSC] Start {}".format(stage.upper())
-            logger.info("\n{0} {1} {0}".format("#" * 20, start_msg.center(40)))
+                end_msg = "End {}".format(last_stage.upper())
+                logger.info("%s\n", split_line(end_msg))
+            start_msg = "Start {}".format(stage.upper())
+            logger.info(split_line(start_msg))
         MSCMap.set(MSCKey.MSC_STAGE, stage.upper())
     elif log_stage:
         start_msg = "Start {}".format(stage)
-        logger.debug("\n{0} {1} {0}".format("+" * 20, start_msg.center(40)))
+        logger.debug(split_line(start_msg, "+"))
 
 
 def get_duration() -> dict:
@@ -163,7 +163,7 @@ def msg_block(title: str, msg: str, width: int = 100, symbol: str = "-"):
 
     if isinstance(msg, dict):
         msg = dump_dict(msg, "table:" + str(width))
-    return "\n{0} {1} {0}\n{2}".format(symbol * 20, title.center(40), msg)
+    return "{}\n{}".format(split_line(title, symbol), msg)
 
 
 def current_stage():

--- a/python/tvm/contrib/msc/framework/tensorflow/runtime/runner.py
+++ b/python/tvm/contrib/msc/framework/tensorflow/runtime/runner.py
@@ -159,22 +159,6 @@ class TensorflowRunner(ModelRunner):
         feed_dict = {i + ":0": msc_utils.cast_array(inputs[i]) for i in input_names}
         return runnable.run(self._tf_outputs, feed_dict)
 
-    def _device_enabled(self, device: str) -> bool:
-        """Check if the device is enabled
-
-        Returns
-        -------
-        enabled: bool
-            Whether the device is enabled.
-        """
-
-        if device == "cpu":
-            return True
-        if device.startswith("cuda"):
-            device_protos = device_lib.list_local_devices()
-            return any(dev.device_type == "GPU" for dev in device_protos)
-        return False
-
     @property
     def codegen_func(self):
         return to_tensorflow
@@ -216,40 +200,6 @@ class TensorflowRunner(ModelRunner):
         else:
             device = "cpu"
         return native_model, device, False
-
-    @classmethod
-    def update_config(cls, stage: str, config: dict, model: Any = None) -> dict:
-        """Update the config for parse
-
-        Parameters
-        -------
-        stage: str
-            The stage to be updated
-        config: dict
-            The config for pipeline.
-        model:
-            The native model.
-
-        Returns
-        -------
-        config: dict
-            The updated config.
-        """
-
-        config = ModelRunner.update_config(stage, config, model)
-        if stage not in config:
-            return config
-        if stage == MSCStage.PARSE:
-            config["parse"]["parser"] = from_tensorflow
-            parse_config = config["parse"].get("parse_config", {})
-            parse_config.update(
-                {
-                    "shape_dict": {i[0]: i[1] for i in config["inputs"]},
-                    "outputs": config["outputs"],
-                }
-            )
-            config["parse"]["parse_config"] = parse_config
-        return config
 
     @classmethod
     def run_native(
@@ -302,3 +252,54 @@ class TensorflowRunner(ModelRunner):
                     avg_time = -1
         outputs = dict(zip(output_names, outputs))
         return outputs, avg_time
+
+    @classmethod
+    def update_config(cls, stage: str, config: dict, model: Any = None) -> dict:
+        """Update the config for parse
+
+        Parameters
+        -------
+        stage: str
+            The stage to be updated
+        config: dict
+            The config for pipeline.
+        model:
+            The native model.
+
+        Returns
+        -------
+        config: dict
+            The updated config.
+        """
+
+        config = ModelRunner.update_config(stage, config, model)
+        if stage not in config:
+            return config
+        if stage == MSCStage.PARSE:
+            config["parse"]["parser"] = from_tensorflow
+            parse_config = config["parse"].get("parse_config", {})
+            parse_config.update(
+                {
+                    "shape_dict": {i[0]: i[1] for i in config["inputs"]},
+                    "outputs": config["outputs"],
+                }
+            )
+            config["parse"]["parse_config"] = parse_config
+        return config
+
+    @classmethod
+    def support_device(cls, device: str) -> bool:
+        """Check if the device is enabled
+
+        Returns
+        -------
+        enabled: bool
+            Whether the device is enabled.
+        """
+
+        if device == "cpu":
+            return True
+        if device.startswith("cuda"):
+            device_protos = device_lib.list_local_devices()
+            return any(dev.device_type == "GPU" for dev in device_protos)
+        return False

--- a/python/tvm/contrib/msc/framework/tensorrt/runtime/runner.py
+++ b/python/tvm/contrib/msc/framework/tensorrt/runtime/runner.py
@@ -117,12 +117,13 @@ class TensorRTRunner(BYOCRunner):
             The runnable info.
         """
 
-        info = super().export_runnable(folder)
-        info["engines"] = {}
-        for graph in self._graphs:
+        def _get_engine(graph: MSCGraph) -> str:
             engine_file = msc_utils.get_output_dir().relpath(graph.name + ".trt")
             assert os.path.isfile(engine_file), "Missing engine file " + engine_file
-            info["engines"] = folder.copy(engine_file)
+            return engine_file
+
+        info = super().export_runnable(folder)
+        info["engines"] = {g.name: _get_engine(g) for g in self._graphs}
         return info
 
     @classmethod

--- a/python/tvm/contrib/msc/framework/torch/runtime/__init__.py
+++ b/python/tvm/contrib/msc/framework/torch/runtime/__init__.py
@@ -17,3 +17,4 @@
 """tvm.contrib.msc.framework.torch.runtime"""
 
 from .runner import *
+from .jit import *

--- a/python/tvm/contrib/msc/framework/torch/runtime/jit.py
+++ b/python/tvm/contrib/msc/framework/torch/runtime/jit.py
@@ -1,0 +1,213 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-import
+"""tvm.contrib.msc.framework.torch.runtime.jit_model"""
+
+from typing import Any, List, Tuple, Dict
+from functools import partial
+
+import torch
+from torch import fx
+from torch import _dynamo as dynamo
+
+from tvm.contrib.msc.core.runtime import BaseJIT
+from tvm.contrib.msc.core.utils.namespace import MSCFramework
+from tvm.contrib.msc.core import utils as msc_utils
+from .runner import TorchRunner
+
+
+class TorchJIT(BaseJIT):
+    """JIT of Torch"""
+
+    def _call_jit(self, inputs: Dict[str, Any]) -> Any:
+        """Run the jit model
+
+        Parameters
+        ----------
+        inputs:
+            The inputs of model.
+        """
+
+        torch_inputs = [
+            msc_utils.cast_array(inputs[i], MSCFramework.TORCH, self._device) for i in self._inputs
+        ]
+        return self._jit_model(*torch_inputs)
+
+    def _build(self, model: Any) -> Any:
+        """Build the jit model
+
+        Parameters
+        ----------
+        model:
+            The model.
+
+        Returns
+        -------
+        jit_model:
+            The jit model.
+        """
+
+        # pylint: disable=unused-argument
+        def _compile(graph_module: fx.GraphModule, example_inputs):
+            graph_module = graph_module.train() if self._training else graph_module.eval()
+            name = "jit_" + str(len(self._runner_ctxs))
+            self._runner_ctxs[name] = {"model": graph_module}
+            return partial(self._redirect_run, runner_name=name)
+
+        dynamo.reset()
+        return torch.compile(self._model, backend=_compile)
+
+    def _to_msc_inputs(self, runner_name: str, *args, **kwargs) -> List[Tuple[str, Any]]:
+        """Change inputs to msc format
+
+        Parameters
+        ----------
+        runner_name: str
+            The runner name.
+        args:
+            The arguments.
+        kwargs:
+            The kwargs.
+
+        Returns
+        -------
+        inputs:
+            The msc format inputs.
+        """
+
+        assert not kwargs, "TorchJIT do not support kwargs"
+        return [("input_" + str(i), d) for i, d in enumerate(args)]
+
+    def _from_msc_outputs(self, runner_name: str, outputs: List[Tuple[str, Any]]) -> Any:
+        """Change inputs from msc format
+
+        Parameters
+        ----------
+        runner_name: str
+            The runner name.
+        outputs: list<(str, tensor)>
+            The msc format outputs.
+
+        Returns
+        -------
+        outputs:
+            The framework outputs.
+        """
+
+        torch_outputs = [o[1] for o in outputs]
+        unpack_outputs = self.get_runner_ctx(runner_name).get("unpack_outputs", True)
+        if not unpack_outputs:
+            return torch_outputs
+        return torch_outputs[0] if len(torch_outputs) == 1 else torch_outputs
+
+    def _run_ctx(self, runner_ctx: dict, inputs: List[Tuple[str, Any]]) -> List[Tuple[str, Any]]:
+        """Forward by runner context
+
+        Parameters
+        ----------
+        runner_ctx: dict
+            The runner context
+        inputs: list<(str, tensor)>
+            The inputs.
+
+        Returns
+        -------
+        outputs: list<(str, tensor)>
+            The outputs.
+        """
+
+        if "runner" in runner_ctx:
+            runner = runner_ctx["runner"]
+            if runner.framework == MSCFramework.TORCH:
+                outputs = runner.run({i[0]: i[1] for i in inputs}, ret_type="native")
+            else:
+                outputs = runner.run({i[0]: i[1] for i in inputs}, ret_type="list")
+                outputs = [
+                    msc_utils.cast_array(o, MSCFramework.TORCH, runner.device) for o in outputs
+                ]
+        else:
+            torch_inputs = [i[1] for i in inputs]
+            outputs = runner_ctx["model"](*torch_inputs)
+            if isinstance(outputs, (list, tuple)) and len(outputs) == 1:
+                runner_ctx["unpack_outputs"] = False
+        if isinstance(outputs, (list, tuple)):
+            return [("output_" + str(i), o) for i, o in enumerate(outputs)]
+        return [("output", outputs)]
+
+    @property
+    def framework(self):
+        return MSCFramework.TORCH
+
+    @classmethod
+    def load_native(cls, model: Any, config: dict) -> Tuple[torch.nn.Module, str, bool]:
+        """Load the native model
+
+        Parameters
+        -------
+        model:
+            The native model.
+        config: dict
+            The config for pipeline.
+
+        Returns
+        -------
+        model: torch.nn.Module
+            The loaded native model.
+        device: str
+            The device of the model.
+        training:
+            Whether the model is for training.
+        """
+
+        return TorchRunner.load_native(model, config)
+
+    @classmethod
+    def dump_nativate(
+        cls, model: torch.nn.Module, folder: msc_utils.MSCDirectory, dump_config: dict = None
+    ) -> str:
+        """Dump the nativate model
+
+        Parameters
+        -------
+        model: torch.nn.Module
+            The runnable model.
+        folder: MSCDirectory
+            The export folder.
+        dump_config: dict
+            The dump config.
+
+        Returns
+        -------
+        export_path: str
+            The exported path
+        """
+
+        dump_config = dump_config or {}
+        assert dump_config.get("mode", "fx") == "fx", "TorchJIT only support dump nativate as fx"
+        return TorchRunner.dump_nativate(model, folder, dump_config)
+
+    @classmethod
+    def support_device(cls, device: str) -> bool:
+        """Check if the device is enabled
+
+        Returns
+        -------
+        enabled: bool
+            Whether the device is enabled.
+        """
+
+        return TorchRunner.support_device(device)

--- a/python/tvm/contrib/msc/framework/tvm/runtime/runner.py
+++ b/python/tvm/contrib/msc/framework/tvm/runtime/runner.py
@@ -17,6 +17,7 @@
 # pylint: disable=unused-import
 """tvm.contrib.msc.framework.runtime.tvm.runner"""
 
+import os
 import time
 from typing import Dict, List, Union, Any, Tuple
 import numpy as np
@@ -139,22 +140,6 @@ class TVMRunner(ModelRunner):
         ]
         return runnable(*tvm_inputs)
 
-    def _device_enabled(self, device: str) -> bool:
-        """Check if the device is enabled
-
-        Returns
-        -------
-        enabled: bool
-            Whether the device is enabled.
-        """
-
-        if device == "cpu":
-            return True
-        if device.startswith("cuda"):
-            dev_id = int(device.split(":")[1]) if ":" in device else 0
-            return tvm.cuda(dev_id).exist
-        return False
-
     def export_runnable(self, folder: msc_utils.MSCDirectory) -> dict:
         """Export the runnable
 
@@ -169,9 +154,14 @@ class TVMRunner(ModelRunner):
             The runnable info.
         """
 
-        export_path = folder.relpath("model.so")
-        self._executable.export_library(export_path)
-        return {"model": export_path}
+        export_lib = folder.relpath("lib.so")
+        self._executable.export_library(export_lib)
+        return {
+            "lib": export_lib,
+            "device": self.device,
+            "model_type": self.framework,
+            "abstract": self.model_info,
+        }
 
     @property
     def codegen_func(self):
@@ -202,8 +192,8 @@ class TVMRunner(ModelRunner):
             Whether the model is for training.
         """
 
-        if isinstance(model, dict) and "model" in model:
-            with open(model["model"], "r") as f:
+        if isinstance(model, str) and os.path.isfile(model):
+            with open(model, "r") as f:
                 native_model = tvm.ir.load_json(f.read())
         elif isinstance(model, tvm.IRModule):
             native_model = model
@@ -216,36 +206,6 @@ class TVMRunner(ModelRunner):
         else:
             device = "cpu"
         return native_model, device, False
-
-    @classmethod
-    def update_config(cls, stage: str, config: dict, model: Any = None) -> dict:
-        """Update the config for parse
-
-        Parameters
-        -------
-        stage: str
-            The stage to be updated
-        config: dict
-            The config for pipeline.
-        model:
-            The native model.
-
-        Returns
-        -------
-        config: dict
-            The updated config.
-        """
-
-        config = ModelRunner.update_config(stage, config, model)
-        if stage not in config:
-            return config
-        if stage == MSCStage.PARSE:
-            # pylint: disable=unused-argument
-            def passby(mod, *args, **kwargs):
-                return mod, None
-
-            config["parse"]["parser"] = passby
-        return config
 
     @classmethod
     def run_native(
@@ -320,3 +280,50 @@ class TVMRunner(ModelRunner):
             o_name: msc_utils.cast_array(o_data) for o_name, o_data in zip(output_names, outputs)
         }
         return outputs, avg_time
+
+    @classmethod
+    def update_config(cls, stage: str, config: dict, model: Any = None) -> dict:
+        """Update the config for parse
+
+        Parameters
+        -------
+        stage: str
+            The stage to be updated
+        config: dict
+            The config for pipeline.
+        model:
+            The native model.
+
+        Returns
+        -------
+        config: dict
+            The updated config.
+        """
+
+        config = ModelRunner.update_config(stage, config, model)
+        if stage not in config:
+            return config
+        if stage == MSCStage.PARSE:
+            # pylint: disable=unused-argument
+            def passby(mod, *args, **kwargs):
+                return mod, None
+
+            config["parse"]["parser"] = passby
+        return config
+
+    @classmethod
+    def support_device(cls, device: str) -> bool:
+        """Check if the device is enabled
+
+        Returns
+        -------
+        enabled: bool
+            Whether the device is enabled.
+        """
+
+        if device == "cpu":
+            return True
+        if device.startswith("cuda"):
+            dev_id = int(device.split(":")[1]) if ":" in device else 0
+            return tvm.cuda(dev_id).exist
+        return False

--- a/python/tvm/contrib/msc/pipeline/dynamic.py
+++ b/python/tvm/contrib/msc/pipeline/dynamic.py
@@ -1,0 +1,492 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-argument
+"""tvm.contrib.msc.pipeline.dynamic"""
+
+from typing import Tuple, Any, List
+
+from tvm.contrib.msc.core.runtime import BaseJIT
+from tvm.contrib.msc.core.utils.message import MSCStage
+from tvm.contrib.msc.core import utils as msc_utils
+from .pipeline import BasePipeline
+from .worker import MSCPipeWorker
+
+
+class MSCDynamic(BasePipeline):
+    """Dynamic of Pipeline, process dynamic model"""
+
+    def setup(self) -> dict:
+        """Setup the pipeline
+
+        Returns
+        -------
+        info: dict
+            The setup info.
+        """
+
+        self._jit, self._jit_caches = None, {}
+        self._worker_ctxs = {}
+        return super().setup()
+
+    def change_stage(self, stage: str, log_stage: bool = True) -> str:
+        """Change stage
+
+        Parameters
+        ----------
+        stage: str
+            The stage name.
+        log_stage: bool
+            Whether to log the stage.
+
+        Returns
+        -------
+        stage: str
+            The stage name.
+        """
+
+        self._jit_caches = {}
+        return super().change_stage(stage, log_stage)
+
+    def _prepare(self, data_loader: Any) -> Tuple[dict, dict]:
+        """Prepare datas for the pipeline.
+
+        Parameters
+        ----------
+        data_loader:
+            The data loader.
+
+        Returns
+        -------
+        info: dict
+            The info of prepare.
+        report: dict
+            The report of prepare.
+        """
+
+        hooks = {"pre_forward": [self.pre_forward], "post_forward": [self.post_forward]}
+        if isinstance(self._model, dict) and "model" in self._model:
+            worker_models = self._model["worker_models"]
+            self._model, device, training = self.jit_cls.load_native(
+                self._model["model"], self._config
+            )
+        else:
+            worker_models = {}
+            self._model, device, training = self.jit_cls.load_native(self._model, self._config)
+        self._jit = self.jit_cls(
+            self._model,
+            inputs=[i[0] for i in self._config["inputs"]],
+            outputs=self._config["outputs"],
+            device=device,
+            training=training,
+            hooks=hooks,
+            logger=self._logger,
+        )
+        self._jit.build()
+        assert MSCStage.PREPARE in self._config["dataset"], "prepare dataset is needed"
+        cnt, max_golden = 0, self._config["dataset"][MSCStage.PREPARE].get("max_golden", 5)
+        for inputs in data_loader():
+            if cnt >= max_golden > 0:
+                break
+            self._jit.run(inputs)
+            cnt += 1
+
+        # create workers
+        def _get_worker_config(name: str, cache: dict):
+            saver = cache.get("saver")
+            assert saver, "Failed to record datas for " + name
+            saver.finalize()
+
+            def _to_input(i_name):
+                i_info = saver.info["inputs"][i_name]
+                return (i_name, i_info["shape"], i_info["dtype"])
+
+            w_config = msc_utils.copy_dict(self._config)
+            w_config.update(
+                {
+                    "inputs": [_to_input(i) for i in saver.info["input_names"]],
+                    "outputs": saver.info["output_names"],
+                }
+            )
+            w_config["dataset"]["golden"] = {"loader": saver.folder}
+            for tool in w_config.get("tools", []):
+                worker_config = tool.get("worker_configs", {}).get(name)
+                if worker_config:
+                    tool["tool_config"] = msc_utils.update_dict(tool["tool_config"], worker_config)
+            return w_config
+
+        info, report = {}, {}
+        for name, cache in self._jit_caches.items():
+            runner_ctx = self._jit.get_runner_ctx(name)
+            w_model = worker_models.get(name, runner_ctx["model"])
+            self._worker_ctxs[name] = {
+                "worker": self.create_worker(w_model, name, _get_worker_config(name, cache)),
+                "workspace": self._workspace.create_dir(name),
+            }
+            with msc_utils.change_workspace(self._worker_ctxs[name]["workspace"]):
+                info[name], report[name] = self._worker_ctxs[name]["worker"].prepare()
+        return info, report
+
+    def _parse(self) -> Tuple[dict, dict]:
+        """Parse relax module for the pipeline.
+
+        Returns
+        -------
+        info: dict
+            The info of parse.
+        report: dict
+            The report of parse.
+        """
+
+        info, report = {}, {}
+        for name, w_ctx in self._worker_ctxs.items():
+            with msc_utils.change_workspace(w_ctx["workspace"]):
+                info[name], report[name] = w_ctx["worker"].parse()
+        return info, report
+
+    def _tool_applied(self, tool_type: str) -> bool:
+        """Check if the tool is applied
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type.
+
+        Returns
+        -------
+        applied: bool
+            Whether the tool is applied.
+        """
+
+        return all(w["worker"].tool_applied(tool_type) for w in self._worker_ctxs.values())
+
+    def _apply_tool(
+        self, tool_type: str, knowledge: dict = None, data_loader: Any = None
+    ) -> Tuple[dict, dict]:
+        """Apply tool with runner
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type to apply.
+        knowledge: dict
+            The pre knowledge.
+        data_loader:
+            The data loader.
+
+        Returns
+        -------
+        info: dict
+            The info of apply tool.
+        report: dict
+            The report of apply tool.
+        """
+
+        if knowledge:
+            raise NotImplementedError("Apply tool with knowledge is not supported")
+
+        self._jit.make_plan(tool_type, data_loader)
+        info, report = {}, {}
+        for name, w_ctx in self._worker_ctxs.items():
+            with msc_utils.change_workspace(w_ctx["workspace"]):
+                info[name], report[name] = w_ctx["worker"].apply_tool(tool_type)
+        return info, report
+
+    def _create_runtime(
+        self,
+        stage: str,
+        tools: List[str] = None,
+        run_type: str = None,
+        run_config: dict = None,
+        visualize: bool = True,
+        profile: bool = True,
+        use_cache: bool = True,
+    ) -> Tuple[dict, dict]:
+        """Create runtime.
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        tools: list<str>
+            The tools to apply.
+        run_type: str
+            The type of runner.
+        run_config: dict
+            The config of runner.
+        visualize: bool
+            Whether to visualize the runner
+        profile: bool
+            Whether to profile the runner.
+        use_cache: bool
+            Whether to use cache.
+
+        Returns
+        -------
+        info: dict
+            The info of stage.
+        report: dict
+            The report of stage.
+        """
+
+        info, report = {}, {}
+        for name, w_ctx in self._worker_ctxs.items():
+            with msc_utils.change_workspace(w_ctx["workspace"]):
+                info[name], report[name] = w_ctx["worker"].create_runner(
+                    stage, tools, run_type, run_config, visualize, profile, use_cache
+                )
+                self._jit.set_runner(name, w_ctx["worker"].runner)
+        return info, report
+
+    def _export_model(self, stage: str, folder: msc_utils.MSCDirectory, dump: bool = True) -> Any:
+        """Export the model
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        folder: MSCDirectory
+            The export folder.
+        dump: bool
+            Whether to dump info.
+
+        Returns
+        -------
+        exported:
+            The exported model.
+        """
+
+        if dump:
+            model = self.jit_cls.dump_nativate(self._model, folder, self._config[MSCStage.EXPORT])
+        else:
+            model = self._model
+        worker_models = {
+            n: w["worker"].export_model(stage, folder.create_dir(n), dump)
+            for n, w in self._worker_ctxs.items()
+        }
+        return {"model": model, "worker_models": worker_models}
+
+    def _export_tool(self, tool_type: str, folder: msc_utils.MSCDirectory) -> dict:
+        """Export the tool
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type.
+        folder: MSCDirectory
+            The export folder.
+
+        Returns
+        -------
+        configs: dict
+            The exported tool configs.
+        """
+
+        configs = {}
+        for name, w_ctx in self._worker_ctxs.items():
+            with msc_utils.change_workspace(w_ctx["workspace"]):
+                configs[name] = w_ctx["worker"].export_tool(tool_type, folder.create_dir(name))
+        assert tool_type in self._tools_config, "Can not find tool_type " + str(tool_type)
+        return msc_utils.update_dict(self._tools_config[tool_type], {"worker_configs": configs})
+
+    def _export_info(self, stage: str, folder: msc_utils.MSCDirectory) -> dict:
+        """Export the info of pipeline
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        folder: MSCDirectory
+            The export folder.
+
+        Returns
+        -------
+        info: dict
+            The info.
+        """
+
+        info = super()._export_info(stage, folder)
+        if stage in (MSCStage.OPTIMIZE, MSCStage.COMPILE):
+            info["worker_infos"] = {}
+            for name, w_ctx in self._worker_ctxs.items():
+                with msc_utils.change_workspace(w_ctx["workspace"]):
+                    info["worker_infos"][name] = w_ctx["worker"].export_info(
+                        stage, folder.create_dir(name)
+                    )
+        return info
+
+    def _destory(self):
+        """Destory the pipeline"""
+
+        for w_ctx in self._worker_ctxs.values():
+            w_ctx["worker"].destory()
+
+    def get_runtime(self, ret_type: str = "runner") -> Any:
+        """Get the runtime of pipeline
+
+        Parameters
+        ----------
+        ret_type: str
+            The return type runner| runnable| model.
+
+        Returns
+        -------
+        runnable:
+            The runnable object.
+        """
+
+        if ret_type == "runner":
+            return self._jit
+        if ret_type in ("model", "runnable"):
+            return self._jit.jit_model
+        raise TypeError("Unexpect return type " + str(ret_type))
+
+    def pre_forward(self, runner_name: str, inputs: List[Tuple[str, Any]]) -> Any:
+        """pre forward hook for jit model
+
+        Parameters
+        ----------
+        runner_name: str
+            The runner name.
+        inputs:
+            The msc format inputs.
+        """
+
+        if self._current_stage == MSCStage.PREPARE:
+            cache = self._jit_caches.setdefault(runner_name, {})
+            cache["inputs"] = inputs
+        self._pre_forward(runner_name, inputs)
+
+    def _pre_forward(self, runner_name: str, inputs: List[Tuple[str, Any]]) -> Any:
+        """pre forward hook for jit model
+
+        Parameters
+        ----------
+        runner_name: str
+            The runner name.
+        inputs:
+            The msc format inputs.
+        """
+
+        return None
+
+    def post_forward(
+        self, runner_name: str, outputs: List[Tuple[str, Any]]
+    ) -> List[Tuple[str, Any]]:
+        """pre forward hook for jit model
+
+        Parameters
+        ----------
+        runner_name: str
+            The runner name.
+        outputs:
+            The outputs.
+
+        Returns
+        -------
+        outputs:
+            The outputs.
+        """
+
+        if self._current_stage == MSCStage.PREPARE:
+            cache = self._jit_caches[runner_name]
+            assert "inputs" in cache, "Failed to record inputs"
+            if "saver" not in cache:
+                golden = (
+                    msc_utils.get_dataset_dir().create_dir(runner_name).relpath("Golden", False)
+                )
+                saver_options = {
+                    "input_names": [i[0] for i in cache["inputs"]],
+                    "output_names": [o[0] for o in outputs],
+                }
+                cache["saver"] = msc_utils.IODataSaver(golden, saver_options)
+            cache["saver"].save_batch([i[1] for i in cache["inputs"]], [o[1] for o in outputs])
+        return self._post_forward(runner_name, outputs)
+
+    def _post_forward(
+        self, runner_name: str, outputs: List[Tuple[str, Any]]
+    ) -> List[Tuple[str, Any]]:
+        """pre forward hook for jit model
+
+        Parameters
+        ----------
+        runner_name: str
+            The runner name.
+        outputs:
+            The outputs.
+
+        Returns
+        -------
+        outputs:
+            The outputs.
+        """
+
+        return outputs
+
+    def _record_stage(self, stage: str, info: dict = None, report: dict = None):
+        """Record the stage
+
+        Parameters
+        -------
+        stage: str
+            The compile stage
+        info: dict
+            The info of stage.
+        report: dict
+            The report of stage.
+        """
+
+        stage_report = {}
+        for name, w_report in report.items():
+            for k, v in w_report.items():
+                stage_report.setdefault(k, {})[name] = v
+        info = {k: v for k, v in info.items() if v}
+        super()._record_stage(stage, info, stage_report)
+
+    def pipe_mark(self, msg: Any) -> str:
+        """Mark the message with pipeline info
+
+        Parameters
+        -------
+        msg: str
+            The message
+
+        Returns
+        -------
+        msg: str
+            The message with mark.
+        """
+
+        return "DYNAMIC " + str(msg)
+
+    @property
+    def jit_cls(self):
+        return BaseJIT
+
+    @property
+    def worker_cls(self):
+        return MSCPipeWorker
+
+
+class TorchDynamic(MSCDynamic):
+    """Dynamic of Pipeline, process torch dynamo"""
+
+    @property
+    def jit_cls(self):
+        # pylint: disable=import-outside-toplevel
+        from tvm.contrib.msc.framework.torch.runtime import TorchJIT
+
+        return TorchJIT

--- a/python/tvm/contrib/msc/pipeline/manager.py
+++ b/python/tvm/contrib/msc/pipeline/manager.py
@@ -14,114 +14,22 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=import-outside-toplevel
 """tvm.contrib.msc.pipeline.manager"""
 
-import os
-import time
-import json
-import logging
-from typing import Dict, Any, Union, List
-import traceback
-import numpy as np
+from typing import Any, List, Tuple
 
-import tvm
-from tvm.contrib.msc.core.runtime import BaseRunner
-from tvm.contrib.msc.core.tools import ToolType
-from tvm.contrib.msc.core.utils.namespace import MSCFramework, MSCMap, MSCKey
+from tvm.contrib.msc.core.gym.control import create_controller
 from tvm.contrib.msc.core.utils.message import MSCStage
 from tvm.contrib.msc.core import utils as msc_utils
-from tvm.contrib.msc.core.gym.control import create_controller
-from tvm.contrib.msc.core import _ffi_api
-from tvm.contrib.msc.plugin.utils import export_plugins, load_plugins
-from .config import support_tool
+from .pipeline import BasePipeline
+from .worker import MSCPipeWorker
 
 
-class BaseManager(object):
-    """Base Manager of MSC
+class MSCManager(BasePipeline):
+    """Manager of Pipeline, process static model"""
 
-    Parameters
-    ----------
-    model: Any
-        The raw model in framwork.
-    config: dict
-        The config for pipeline.
-    plugins: dict
-        The plugins for pipeline.
-    root: str
-        The root path for files.
-    run_optimize: bool
-        Whether to run optimize.
-    run_compile: bool
-        Whether to run compile.
-    """
-
-    def __init__(
-        self,
-        model: Any,
-        config: dict,
-        plugins: dict = None,
-        root: str = None,
-        run_optimize: bool = True,
-        run_compile: bool = True,
-    ):
-        # change path to root path
-        if root:
-
-            def _from_root_mark(val):
-                if isinstance(val, str) and MSCKey.ROOT_MARK in val:
-                    return val.replace(MSCKey.ROOT_MARK, root)
-                return val
-
-            model = _from_root_mark(model)
-            config = msc_utils.map_dict(config, _from_root_mark)
-            plugins = msc_utils.map_dict(plugins, _from_root_mark)
-
-        # check stage
-        for stage in [
-            "inputs",
-            "outputs",
-            "dataset",
-            MSCStage.PREPARE,
-            MSCStage.PARSE,
-            MSCStage.COMPILE,
-            MSCStage.EXPORT,
-        ]:
-            config.setdefault(stage, {})
-
-        MSCMap.reset()
-        use_cache = config.get("use_cache", True)
-        self._workspace = msc_utils.set_workspace(config.get("workspace"), use_cache)
-        self._model_type = config["model_type"]
-        runner_cls = self._get_runner_cls(self._model_type)
-        self._model, self._device, self._training = runner_cls.load_native(model, config)
-        self._plugins = load_plugins(plugins) if plugins else {}
-        self._verbose = config.get("verbose", "info")
-        if "logger" in config:
-            self._logger = config["logger"]
-            MSCMap.set(MSCKey.GLOBALE_LOGGER, self._logger)
-        else:
-            log_path = config.get("log_path") or self._workspace.relpath(
-                "MSC_LOG", keep_history=False
-            )
-            self._logger = msc_utils.set_global_logger(self._verbose, log_path)
-        self._optimized, self._compiled = False, False
-        msc_utils.time_stamp(MSCStage.SETUP)
-        self._logger.info(
-            msc_utils.msg_block("SETUP", self.setup(config, run_optimize, run_compile))
-        )
-
-    def setup(self, config: dict, run_optimize: bool = True, run_compile: bool = True) -> dict:
-        """Setup the manager
-
-        Parameters
-        ----------
-        config: dict
-            The config for manager.
-        run_optimize: bool
-            Whether to run optimize.
-        run_compile: bool
-            Whether to run compile.
+    def setup(self) -> dict:
+        """Setup the pipeline
 
         Returns
         -------
@@ -129,456 +37,160 @@ class BaseManager(object):
             The setup info.
         """
 
-        self._meta_config = config
-        self._optimize_type = config.get(MSCStage.OPTIMIZE, {}).get("run_type", self._model_type)
-        self._compile_type = config.get(MSCStage.COMPILE, {}).get("run_type", self._model_type)
-        # register plugins
-        if self._plugins:
-            for t in [self._model_type, self._optimize_type, self._compile_type]:
-                assert t in self._plugins, "Missing plugin for {}".format(t)
-            for name, plugin in self._plugins[self._model_type].get_ops_info().items():
-                _ffi_api.RegisterPlugin(name, msc_utils.dump_dict(plugin))
-        self._config, self._debug_levels = self.update_config(config)
-        if not run_optimize and MSCStage.OPTIMIZE in self._config:
-            self._config.pop(MSCStage.OPTIMIZE)
-        if not run_compile and MSCStage.COMPILE in self._config:
-            self._config.pop(MSCStage.COMPILE)
-        self._tools_config = []
-        self._relax_mod, self._runner = None, None
-        self._sample_inputs = None
-        self._report = {
-            "success": False,
-            "info": {
-                "workspace": self._workspace.path,
-                "model_type": "{}({})".format(self._model_type, self._device),
-            },
-            "duration": {},
-            "profile": {},
-        }
-        return {"workspace": self._workspace.path, "plugins": self._plugins, "config": self._config}
+        self._worker = self.create_worker(self._model, "main")
+        self._config = self._worker._config
+        return super().setup()
 
-    def update_config(self, config: dict) -> dict:
-        """Update config
-
-        Parameters
-        ----------
-        config: dict
-            The config for manager.
-
-        Returns
-        -------
-        config: dict
-            The updated config.
-        """
-
-        assert "inputs" in config, "inputs should be given to run manager"
-        assert "outputs" in config, "outputs should be given to run manager"
-        config, debug_levels = msc_utils.copy_dict(config), {}
-        config = self._get_runner_cls(self._model_type).update_config(
-            MSCStage.PARSE, config, self._model
-        )
-
-        # update runner config
-        for stage in [MSCStage.BASELINE, MSCStage.OPTIMIZE, MSCStage.COMPILE]:
-            if stage not in config:
-                continue
-            if "run_type" not in config[stage]:
-                config[stage]["run_type"] = self._model_type
-            runner_cls = self._get_runner_cls(config[stage]["run_type"])
-            config = runner_cls.update_config(stage, config, self._model)
-
-        # update tool config
-        if config.get("tools"):
-            config["tools"] = self._update_tools_config(config["tools"])
-
-        # update export config
-        config[MSCStage.EXPORT].update({"inputs": config["inputs"], "outputs": config["outputs"]})
-
-        def _set_debug_level(stage: str, sub_config: dict, default: int = None) -> dict:
-            if "debug_level" in sub_config:
-                debug_levels[stage] = sub_config["debug_level"]
-            elif default is not None:
-                debug_levels[stage] = default
-                sub_config["debug_level"] = default
-            return debug_levels
-
-        if self._verbose.startswith("debug:"):
-            debug_level = int(self._verbose.split(":")[1])
-        else:
-            debug_level = 0
-        for stage in [MSCStage.BASELINE, MSCStage.OPTIMIZE, MSCStage.COMPILE]:
-            if stage not in config:
-                continue
-            debug_levels = _set_debug_level(stage, config[stage]["run_config"], debug_level)
-            for t_config in config.get("tools", []):
-                if not support_tool(t_config, stage, config[stage]["run_type"]):
-                    continue
-                t_stage = stage + "." + self._get_tool_stage(t_config["tool_type"])
-                debug_levels = _set_debug_level(t_stage, t_config["tool_config"], debug_level)
-        ordered_keys = [
-            "model_type",
-            "inputs",
-            "outputs",
-            "dataset",
-            "tools",
-            MSCStage.PREPARE,
-            MSCStage.PARSE,
-            MSCStage.BASELINE,
-            MSCStage.OPTIMIZE,
-            MSCStage.COMPILE,
-            MSCStage.EXPORT,
-        ]
-        return {k: config[k] for k in ordered_keys if k in config}, debug_levels
-
-    def run_pipe(self) -> dict:
-        """Run the pipeline and return object.
-
-        Returns
-        -------
-        report:
-            The pipeline report.
-        """
-
-        err_msg, err_info = None, None
-        try:
-            self.prepare()
-            self.parse()
-            if MSCStage.BASELINE in self._config:
-                self.baseline()
-            if MSCStage.OPTIMIZE in self._config:
-                self.optimize()
-            if MSCStage.COMPILE in self._config:
-                self.compile()
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            err_msg = "Pipeline failed: " + str(exc)
-            err_info = traceback.format_exc()
-        self.summary(err_msg, err_info)
-        self._logger.info(msc_utils.msg_block("SUMMARY", self._report, 0))
-        self._workspace.finalize()
-        return self._report
-
-    def prepare(self) -> Dict[str, np.ndarray]:
+    def _prepare(self, data_loader: Any) -> Tuple[dict, dict]:
         """Prepare datas for the pipeline.
 
-        Returns
-        -------
-        dataloader:
-            The dataloader
-        sample_inputs: dict<str,np.ndarray>
-            The sample inputs.
-        """
-
-        msc_utils.time_stamp(MSCStage.PREPARE)
-        stage_config = self._config[MSCStage.PREPARE]
-        use_cache = self._config.get("use_cache", True)
-        runner_cls = self._get_runner_cls(self._model_type)
-        run_func = runner_cls.run_native if hasattr(runner_cls, "run_native") else None
-        input_names = [i[0] for i in self._config["inputs"]]
-
-        # create golden
-        if "golden" in self._config["dataset"]:
-            golden_folder = self._config["dataset"]["golden"]["loader"]
-        else:
-            golden_folder = msc_utils.get_dataset_dir().relpath("Golden", use_cache)
-        report = {"golden_folder": golden_folder}
-        if msc_utils.is_io_dataset(golden_folder):
-            loader, source_type = msc_utils.IODataLoader(golden_folder), "Cache"
-            self._sample_inputs = loader[0][0]
-            report["datas_info"] = loader.info
-            self._logger.debug("Load %d golden from %s", len(loader), golden_folder)
-        elif run_func:
-            loader, source_type = self._get_loader(MSCStage.PREPARE), "Native"
-            saver_options = {"input_names": input_names, "output_names": self._config["outputs"]}
-            cnt, max_golden = 0, self._config["dataset"][MSCStage.PREPARE].get("max_golden", 5)
-            with msc_utils.IODataSaver(golden_folder, saver_options) as saver:
-                for inputs in loader():
-                    if cnt >= max_golden > 0:
-                        break
-                    if not self._sample_inputs:
-                        self._sample_inputs = {
-                            k: msc_utils.cast_array(v) for k, v in inputs.items()
-                        }
-                    outputs, _ = run_func(self._model, inputs, input_names, self._config["outputs"])
-                    cnt = saver.save_batch(inputs, outputs)
-                report["datas_info"] = saver.info
-            self._logger.debug("Saved %d golden to %s", cnt, golden_folder)
-        else:
-            raise Exception("golden_folder or runner should given to save golden")
-        self._config["dataset"]["golden"] = {"loader": golden_folder, "max_batch": -1}
-
-        def _to_abstract(info: dict) -> dict:
-            def _to_tensor_str(info):
-                return "{},{}".format(";".join([str(s) for s in info["shape"]]), info["dtype"])
-
-            return {
-                "num_datas": info["num_datas"],
-                "inputs": {n: _to_tensor_str(i) for n, i in info["inputs"].items()},
-                "outputs": {n: _to_tensor_str(o) for n, o in info["outputs"].items()},
-            }
-
-        report["datas_info"] = _to_abstract(report["datas_info"])
-        report["sample_inputs"] = self._sample_inputs
-        self._logger.info(msc_utils.msg_block("GOLDEN({})".format(source_type), report))
-
-        # profile
-        if "profile" in stage_config and run_func:
-            benchmark = stage_config["profile"].get("benchmark", {})
-            benchmark["repeat"] = self._get_repeat(benchmark)
-            self._logger.debug("Prepare profile with %s(%s)", run_func.__name__, benchmark)
-            _, avg_time = run_func(
-                self._model, self._sample_inputs, input_names, self._config["outputs"], **benchmark
-            )
-            msg = "{:.2f} ms @ {}".format(avg_time, self._device)
-            self._report["profile"][MSCStage.PREPARE] = {"latency": msg}
-            self._logger.info("Profile(prepare) %d times -> %s", benchmark["repeat"], msg)
-
-        return self._sample_inputs
-
-    def parse(self) -> tvm.IRModule:
-        """Parse the model to IRModule.
-
-        Returns
-        -------
-        relax_mod: tvm.IRModule
-            The parsed module.
-        """
-
-        msc_utils.time_stamp(MSCStage.PARSE)
-        stage_config = self._config[MSCStage.PARSE]
-        if self._config.get("use_cache", True):
-            cache_path = (
-                msc_utils.get_cache_dir().create_dir(MSCStage.PARSE).relpath("parsed_relax.json")
-            )
-        else:
-            cache_path = None
-        if cache_path and os.path.isfile(cache_path):
-            with open(cache_path, "r") as f:
-                self._relax_mod = tvm.ir.load_json(f.read())
-            self._logger.info("Load parsed mod from %s", cache_path)
-        else:
-            parse_config = msc_utils.copy_dict(stage_config.get("parse_config", {}))
-            parse_info = {"parser": stage_config["parser"], "config": parse_config}
-            self._logger.info(msc_utils.msg_block("PARSE", parse_info))
-            parse_config["as_msc"] = False
-            if self._model_type in self._plugins:
-                plugin = self._plugins[self._model_type]
-                parse_config["custom_convert_map"] = plugin.get_convert_map()
-            self._relax_mod, _ = stage_config["parser"](self._model, **parse_config)
-            transformed = set()
-            for stage in [MSCStage.OPTIMIZE, MSCStage.COMPILE]:
-                if stage not in self._config:
-                    continue
-                run_type = self._config[stage]["run_type"]
-                if run_type in transformed:
-                    continue
-                transformed.add(run_type)
-                runner_cls = self._get_runner_cls(run_type)
-                if hasattr(runner_cls, "target_transform"):
-                    self._logger.info("Transform for %s(%s)", run_type, stage)
-                    self._relax_mod = runner_cls.target_transform(self._relax_mod)
-            if cache_path:
-                with open(cache_path, "w") as f:
-                    f.write(tvm.ir.save_json(self._relax_mod))
-                self._logger.debug("Save parsed mod to %s", cache_path)
-        return self._relax_mod
-
-    def _run_stage(self, stage: str) -> BaseRunner:
-        """Run the stage.
-
         Parameters
         ----------
-        stage: str
-            The compile stage.
+        data_loader:
+            The data loader.
 
         Returns
         -------
-        runner: BaseRunner
-            The runner.
-        """
-
-        msc_utils.time_stamp(stage)
-        self.apply_tools(stage)
-        self._runner = self._create_runner(
-            stage,
-            self._config[stage],
-            use_cache=self._config.get("use_cache", True),
-        )
-        return self._runner
-
-    def baseline(self) -> BaseRunner:
-        """Run the baseline.
-
-        Returns
-        -------
-        runner: BaseRunner
-            The runner.
-        """
-
-        return self._run_stage(MSCStage.BASELINE)
-
-    def optimize(self) -> BaseRunner:
-        """Run the optimize and return object.
-
-        Returns
-        -------
-        runner: BaseRunner
-            The runner.
-        """
-
-        runner = self._run_stage(MSCStage.OPTIMIZE)
-        self._optimized = True
-        return runner
-
-    def compile(self) -> BaseRunner:
-        """Run the compile and return object.
-
-        Returns
-        -------
-        runner: BaseRunner
-            The runner.
-        """
-
-        runner = self._run_stage(MSCStage.COMPILE)
-        self._compiled = True
-        return runner
-
-    def apply_tools(self, stage: str):
-        """Apply tools for a stage.
-
-        Parameters
-        ----------
-        stage: str
-            The compile stage.
-        """
-
-        self._tools_config = []
-        for tool in self._config.get("tools", []):
-            run_type = tool.get("run_type", self._config[stage]["run_type"])
-            if not support_tool(tool, stage, run_type):
-                continue
-            self._apply_tool(tool, stage)
-            if tool.get("apply_once", False):
-                self._logger.debug("Remove apply once tool %s", tool["tool_type"])
-                self._tools_config = self._tools_config[:-1]
-
-    def summary(self, err_msg=None, err_info: str = None):
-        """Summary the pipeline.
-
-        Parameters
-        ----------
-        err_msg: str
-            The error message.
-        err_info: str
-            The error info.
-
-        Returns
-        -------
+        info: dict
+            The info of prepare.
         report: dict
-            The report of the pipeline.
+            The report of prepare.
         """
 
-        msc_utils.time_stamp(MSCStage.SUMMARY, False)
-        if err_msg:
-            self._report.update({"success": False, "err_msg": err_msg, "err_info": err_info})
-        else:
-            self._report["success"] = True
-        self._report["duration"] = msc_utils.get_duration()
-        return self._report
+        return self._worker.prepare(data_loader)
 
-    def export(self, path: str = None, dump: bool = True) -> Union[str, dict]:
-        """Export the pipeline
-
-        Parameters
-        ----------
-        path: str
-            The export path.
-        dump: bool
-            Whether to dump the info.
+    def _parse(self) -> Tuple[dict, dict]:
+        """Parse relax module for the pipeline.
 
         Returns
         -------
-        export_path/pipeline: str/dict
-            The exported path/pipeline info.
+        info: dict
+            The info of parse.
+        report: dict
+            The report of parse.
         """
 
-        path = path or "msc_export"
-        if path.endswith(".tar.gz"):
-            folder, dump = msc_utils.msc_dir(path.replace(".tar.gz", ""), keep_history=False), True
-        else:
-            folder = msc_utils.msc_dir(path, keep_history=False)
+        return self._worker.parse()
 
-        def _to_root_mark(val):
-            if isinstance(val, str) and folder.path != val and folder.path in val:
-                return val.replace(folder.path, MSCKey.ROOT_MARK)
-            return val
+    def _tool_applied(self, tool_type: str) -> bool:
+        """Check if the tool is applied
 
-        # export compiled
-        if self._compiled:
-            if not dump:
-                return self._runner.runnable
-            model = self._runner.export_runnable(folder)
-            if self._plugins:
-                plugin = self._plugins[self.compile_type]
-                model["plugins"] = plugin.copy_libs(folder.create_dir("plugins"))
-            model.update(
-                {
-                    "device": self._runner.device,
-                    "model_type": self.compile_type,
-                    "abstract": self._runner.model_info,
-                }
-            )
-            # save golden
-            num_golden = self._config[MSCStage.EXPORT].get("num_golden", 0)
-            if num_golden > 0:
-                saver_options = {
-                    "input_names": [i[0] for i in self._config["inputs"]],
-                    "output_names": self._config["outputs"],
-                }
-                batch_cnt, model["golden"] = 0, folder.create_dir("golden").path
-                with msc_utils.IODataSaver(model["golden"], saver_options) as saver:
-                    for inputs in self._get_loader()():
-                        if batch_cnt >= num_golden:
-                            break
-                        batch_cnt = saver.save_batch(inputs, self._runner.run(inputs))
-            model = msc_utils.map_dict(model, _to_root_mark)
-            with open(folder.relpath("model.json"), "w") as f:
-                f.write(json.dumps(model, indent=2))
-        else:
-            if dump:
-                plugins = export_plugins(self._plugins, folder.create_dir("plugins"))
-            else:
-                plugins = self._plugins
+        Parameters
+        ----------
+        tool_type: str
+            The tool type.
 
-            pipeline = {
-                "model": self.export_model(folder.create_dir("model"), dump),
-                "config": self.export_config(folder, dump),
-                "plugins": plugins,
-                "root": folder.path,
-            }
-            pipeline = msc_utils.map_dict(pipeline, _to_root_mark)
-            if not dump:
-                return pipeline
-            with open(folder.relpath("pipeline.json"), "w") as f:
-                f.write(json.dumps(pipeline, indent=2))
-        # copy common files
-        if self._optimized or self._compiled:
-            stage = MSCStage.COMPILE if self._compiled else MSCStage.OPTIMIZE
-            msc_utils.get_visual_dir().copy(stage, folder.relpath("visualize"))
-            for log_h in self._logger.handlers:
-                if isinstance(log_h, logging.FileHandler):
-                    folder.copy(log_h.baseFilename)
-            with open(folder.relpath("report.json"), "w") as f:
-                f.write(json.dumps(self._report, indent=2))
-        folder.finalize()
-        if path.endswith(".tar.gz"):
-            msc_utils.pack_folder(path.replace(".tar.gz", ""), "tar.gz")
-        return path
+        Returns
+        -------
+        applied: bool
+            Whether the tool is applied.
+        """
 
-    def export_model(self, folder: msc_utils.MSCDirectory, dump: bool = True) -> Any:
+        return self._worker.tool_applied(tool_type)
+
+    def _apply_tool(
+        self, tool_type: str, knowledge: dict = None, data_loader: Any = None
+    ) -> Tuple[dict, dict]:
+        """Apply tool with runner
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type to apply.
+        knowledge: dict
+            The pre knowledge.
+        data_loader:
+            The data loader.
+
+        Returns
+        -------
+        info: dict
+            The info of apply tool.
+        report: dict
+            The report of apply tool.
+        """
+
+        return self._worker.apply_tool(tool_type, knowledge, data_loader)
+
+    def _create_runtime(
+        self,
+        stage: str,
+        tools: List[str] = None,
+        run_type: str = None,
+        run_config: dict = None,
+        visualize: bool = True,
+        profile: bool = True,
+        use_cache: bool = True,
+    ) -> Tuple[dict, dict]:
+        """Create runtime.
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        tools: list<str>
+            The tools to apply.
+        run_type: str
+            The type of runner.
+        run_config: dict
+            The config of runner.
+        visualize: bool
+            Whether to visualize the runner
+        profile: bool
+            Whether to profile the runner.
+        use_cache: bool
+            Whether to use cache.
+
+        Returns
+        -------
+        info: dict
+            The info of stage.
+        report: dict
+            The report of stage.
+        """
+
+        return self._worker.create_runner(
+            stage, tools, run_type, run_config, visualize, profile, use_cache
+        )
+
+    def _run_gym(self, stage: str, config: dict, knowledge: dict, data_loader: Any) -> dict:
+        """Run gym.
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        config: dict
+            The gym config.
+        knowledge: dict
+            The pre knowledge.
+        data_loader:
+            The data loader.
+
+        Returns
+        -------
+        knowledge: dict
+            The learned knowledge.
+        """
+
+        extra_config = {
+            "env": {
+                "runner": self._worker.runner,
+                "data_loader": data_loader,
+                "knowledge": knowledge,
+            },
+            "verbose": self._verbose,
+        }
+        controller = create_controller(stage, config, extra_config)
+        return controller.run()
+
+    def _export_model(self, stage: str, folder: msc_utils.MSCDirectory, dump: bool = True) -> Any:
         """Export the model
 
         Parameters
         ----------
+        stage: str
+            The pipeline stage.
         folder: MSCDirectory
             The export folder.
         dump: bool
@@ -590,511 +202,86 @@ class BaseManager(object):
             The exported model.
         """
 
-        if self._optimized:
-            module = self._runner.export_module(folder)
-            if not dump:
-                return module
-            path = folder.relpath("model.json")
-            with open(path, "w") as f:
-                f.write(tvm.ir.save_json(module))
-            return {"model": path}
-        if not dump:
-            return self._model
-        return self._get_runner_cls(self._model_type).dump_nativate(
-            self._model, folder, **self._config[MSCStage.EXPORT]
-        )
+        return self._worker.export_model(stage, folder, dump)
 
-    def export_config(self, folder: msc_utils.MSCDirectory, dump: bool = True) -> dict:
-        """Export the config
-
-        Parameters
-        ----------
-        folder: MSCDirectory
-            The export folder.
-        dump: bool
-            Whether to dump info.
-
-        Returns
-        -------
-        config: dict
-            The updated config.
-        """
-
-        # dump the dataloader
-        def _save_dataset(name, info, dump: bool):
-            loader, max_batch = info["loader"], info.get("max_batch", -1)
-            data_folder = folder.create_dir("dataset")
-            if isinstance(loader, str) and msc_utils.is_callable(loader):
-                path, func_name = loader.split(":")
-                exp_loader = data_folder.copy(path) + ":" + func_name
-            elif msc_utils.is_io_dataset(loader):
-                exp_loader = data_folder.copy(loader, name)
-            elif callable(loader) and dump:
-                saver_options = {
-                    "input_names": [i[0] for i in self._config["inputs"]],
-                    "output_names": self._config["outputs"],
-                }
-                batch_cnt = 0
-                exp_loader = data_folder.create_dir(name).path
-                with msc_utils.IODataSaver(exp_loader, saver_options) as saver:
-                    for inputs in loader():
-                        if batch_cnt >= max_batch > 0:
-                            break
-                        batch_cnt = saver.save_batch(inputs)
-            else:
-                exp_loader = loader
-            return {"loader": exp_loader, "max_batch": max_batch}
-
-        config = msc_utils.copy_dict(self._meta_config)
-        config["dataset"] = {
-            k: _save_dataset(k, v, dump) for k, v in self._config["dataset"].items()
-        }
-        if self._optimized:
-            config["model_type"] = MSCFramework.TVM
-            for stage in [MSCStage.BASELINE, MSCStage.OPTIMIZE]:
-                if stage in config:
-                    config.pop(stage)
-            if "profile" in config[MSCStage.COMPILE]:
-                config[MSCStage.COMPILE]["profile"].setdefault("check", {})["err_rate"] = -1
-            config["tools"] = []
-            for tool in self._config.get("tools", []):
-                if not support_tool(tool, MSCStage.COMPILE, self._compile_type):
-                    continue
-                run_tool = self.runner.get_tool(tool["tool_type"])
-                tool["tool_config"] = run_tool.export_config(tool["tool_config"], folder)
-                if tool["tool_config"]:
-                    config["tools"].append(tool)
-                else:
-                    self._logger.info(
-                        "Skip compile with tool %s as no config exported", tool["tool_type"]
-                    )
-        # remove not serializable items
-        if dump:
-            remove_keys = {"workspace", "logger"}
-            config = {k: v for k, v in config.items() if k not in remove_keys}
-        return config
-
-    def destory(self, keep_workspace: bool = False):
-        """Destroy the manager
-
-        Parameters
-        ----------
-        keep_workspace: bool
-            Whether to keep workspace.
-        """
-
-        if self._runner:
-            self._runner.destory()
-        if not keep_workspace:
-            self._workspace.destory()
-        msc_utils.remove_loggers()
-
-    def _create_runner(
-        self,
-        stage: str,
-        stage_config: dict,
-        visualize: bool = True,
-        profile: bool = True,
-        use_cache: bool = True,
-    ) -> BaseRunner:
-        """Create runner.
-
-        Parameters
-        ----------
-        stage: str
-            The stage name
-        stage_config: dict
-            The config of this stage.
-        visualize: bool
-            Whether to visualize the runner
-        profile: bool
-            Whether to profile the runner.
-        use_cache: bool
-            Whether to use cache.
-
-        Returns
-        -------
-        runner: BaseRunner
-            The runner.
-        """
-
-        if self._runner:
-            self._runner.destory()
-        cache_dir = msc_utils.get_cache_dir().create_dir(stage) if use_cache else None
-        msc_utils.time_stamp(stage + ".build", False)
-        runner_cls = self._get_runner_cls(stage_config["run_type"])
-        run_config = msc_utils.copy_dict(stage_config.get("run_config"))
-        if "generate_config" not in run_config:
-            run_config["generate_config"] = {}
-        cleanup = self._debug_levels.get(stage, 0) == 0
-        run_config["generate_config"]["build_folder"] = msc_utils.get_build_dir().create_dir(
-            stage, cleanup=cleanup
-        )
-        if "device" not in run_config:
-            run_config["device"] = self._device
-        if "training" not in run_config:
-            run_config["training"] = self._training
-        # Build runner
-        runner = runner_cls(
-            self._relax_mod,
-            tools_config=self._tools_config,
-            plugin=self._plugins.get(stage_config["run_type"]),
-            stage=stage,
-            logger=self._logger,
-            **run_config,
-        )
-        runner.build(cache_dir=cache_dir)
-        self._report["info"][stage + "_type"] = "{}({})".format(runner.framework, runner.device)
-        if visualize:
-            runner.visualize(msc_utils.get_visual_dir().create_dir(stage.split(".")[0]))
-        if profile and "profile" in stage_config:
-            self._report["profile"][stage] = self._profile_runner(runner, stage_config)
-        if use_cache:
-            runner.save_cache(cache_dir)
-        return runner
-
-    def _apply_tool(self, tool: dict, stage: str) -> str:
-        """Apply tool with runner
-
-        Parameters
-        ----------
-        tool: dict
-            The tool config.
-        stage: str
-            The compile stage.
-
-        Returns
-        -------
-        plan_file: str
-            The plan_file path.
-        """
-
-        self._tools_config.append(tool)
-        tool_type, tool_config = tool["tool_type"], tool["tool_config"]
-        tool_stage = self._get_tool_stage(tool_type)
-        plan_file = tool_config["plan_file"]
-        if os.path.isfile(plan_file):
-            self._logger.info("Skip %s with plan %s", tool_type, plan_file)
-            return plan_file
-        t_stage = stage + "." + tool_stage
-        msc_utils.time_stamp(t_stage)
-        stage_config = {
-            "run_type": tool.get("run_type", self._config[stage]["run_type"]),
-            "run_config": self._config[stage]["run_config"],
-        }
-        runner = self._create_runner(
-            t_stage, stage_config, visualize=False, profile=False, use_cache=False
-        )
-        if "gym_configs" in tool:
-            knowledge = None
-            for idx, config in enumerate(tool["gym_configs"]):
-                knowledge_file = msc_utils.get_config_dir().relpath(
-                    "gym_knowledge_{}.json".format(idx)
-                )
-                gym_mark = "GYM[{}/{}]({} @ {}) ".format(
-                    idx, len(tool["gym_configs"]), runner.framework, t_stage
-                )
-                if os.path.isfile(knowledge_file):
-                    knowledge = knowledge_file
-                    self._logger.info("%sLoad from %d", gym_mark, knowledge)
-                else:
-                    msc_utils.time_stamp(t_stage + ".gym_{}".format(idx))
-                    self._logger.info("%sStart search", gym_mark)
-                    extra_config = {
-                        "env": {
-                            "runner": runner,
-                            "data_loader": self._get_loader(tool_stage),
-                            "knowledge": knowledge,
-                        },
-                        "verbose": self._verbose,
-                    }
-                    controller = create_controller(tool_stage, config, extra_config)
-                    knowledge = controller.run()
-                    msc_utils.save_dict(knowledge, knowledge_file)
-            plan = msc_utils.load_dict(knowledge)
-            self._logger.info("%sFound %d plan", gym_mark, len(plan))
-            return msc_utils.save_dict(plan, plan_file)
-        msc_utils.time_stamp(t_stage + ".make_plan", False)
-        plan_file = runner.make_plan(tool_type, self._get_loader(tool_stage))
-        if tool.get("visualize", False):
-            runner.visualize(msc_utils.get_visual_dir().create_dir(stage))
-        return plan_file
-
-    def _profile_runner(self, runner: BaseRunner, stage_config: str) -> dict:
-        """Profile the runner.
-
-        Parameters
-        ----------
-        runner: BaseRunner
-            The runner to be profiled
-        stage_config: dict
-            The config of this stage.
-
-        Returns
-        -------
-        report: dict
-            The profile report.
-        """
-
-        stage = runner.stage
-        msc_utils.time_stamp(stage + ".profile", False)
-        profile_config = stage_config["profile"]
-        msg, report = "Profile({})".format(stage), {}
-
-        # check accuracy
-        check_config = profile_config.get("check", {})
-        if check_config:
-            loader = msc_utils.IODataLoader(self._config["dataset"]["golden"]["loader"])
-            total, passed = 0, 0
-            acc_report = {"config": check_config}
-            for idx, (inputs, outputs) in enumerate(loader):
-                results = runner.run(inputs)
-                iter_report = msc_utils.compare_arrays(
-                    outputs,
-                    results,
-                    atol=check_config.get("atol", 1e-2),
-                    rtol=check_config.get("rtol", 1e-2),
-                )
-                total += iter_report["total"]
-                passed += iter_report["passed"]
-                acc_report["iter_" + str(idx)] = iter_report["info"]
-            pass_rate = float(passed) / total
-            report["accuracy"] = "{}/{}({:.2f}%)".format(passed, total, pass_rate * 100)
-            title = "Check({}) pass {}".format(stage, report["accuracy"])
-            self._logger.debug(msc_utils.msg_block(title, acc_report, width=0))
-            msg += " acc {} iters -> {}".format(len(loader), report["accuracy"])
-            if runner.get_tool(ToolType.PRUNER) or runner.get_tool(ToolType.QUANTIZER):
-                self._logger.debug("Disable accuracy check(%s) by tools", stage)
-            else:
-                required_err, err_rate = check_config.get("err_rate", 0), (1 - pass_rate)
-                if err_rate > required_err >= 0:
-                    raise Exception(
-                        "Failed to profile the runner({}), err_rate {} > required {}".format(
-                            stage, err_rate, required_err
-                        )
-                    )
-
-        # benchmark model
-        if runner.get_tool(ToolType.TRACKER):
-            benchmark_config = None
-            self._logger.debug("Disable benchmark(%s) by tools", stage)
-        else:
-            benchmark_config = profile_config.get("benchmark", {})
-        if benchmark_config:
-            for _ in range(benchmark_config.get("warm_up", 10)):
-                runner.run(self._sample_inputs)
-            start = time.time()
-            repeat = self._get_repeat(benchmark_config, runner.device)
-            for _ in range(repeat):
-                runner.run(self._sample_inputs)
-            avg_time = (time.time() - start) * 1000 / repeat
-            report["latency"] = "{:.2f} ms @ {}".format(avg_time, runner.device)
-            msg += " latency {} times -> {}".format(repeat, report["latency"])
-        self._logger.info(msg)
-        return report
-
-    def _update_tools_config(self, tools: List[dict]) -> List[dict]:
-        """Update tool in stage config.
-
-        Parameters
-        ----------
-        tools: list<dict>
-            The config of tools.
-
-        Returns
-        -------
-        tools: list<dict>
-            The updated config of tools.
-        """
-
-        for tool in tools:
-            tool_config = tool["tool_config"]
-            if "plan_file" not in tool_config:
-                tool_config["plan_file"] = "msc_{}.json".format(tool["tool_type"])
-            tool_config["plan_file"] = msc_utils.to_abs_path(
-                tool_config["plan_file"], msc_utils.get_config_dir()
-            )
-        return tools
-
-    def _get_tool_stage(self, tool_type: str) -> str:
-        """Map the stage according to tool_type
+    def _export_tool(self, tool_type: str, folder: msc_utils.MSCDirectory) -> dict:
+        """Export the tool
 
         Parameters
         ----------
         tool_type: str
             The tool type.
+        folder: MSCDirectory
+            The export folder.
 
         Returns
         -------
-        stage: str
-            The stage.
+        config: dict
+            The exported tool config.
         """
 
-        if tool_type == ToolType.PRUNER:
-            return MSCStage.PRUNE
-        if tool_type == ToolType.QUANTIZER:
-            return MSCStage.QUANTIZE
-        if tool_type == ToolType.DISTILLER:
-            return MSCStage.DISTILL
-        if tool_type == ToolType.TRACKER:
-            return MSCStage.TRACK
-        return tool_type
+        assert tool_type in self._tools_config, "Can not find tool_type " + str(tool_type)
+        exp_config = {"tool_config": self._worker.export_tool(tool_type, folder)}
+        return msc_utils.update_dict(self._tools_config[tool_type], exp_config)
 
-    def get_runnable(self, ret_type: str = "runner") -> Any:
-        """Return object by type.
+    def _export_info(self, stage: str, folder: msc_utils.MSCDirectory) -> dict:
+        """Export the info of pipeline
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        folder: MSCDirectory
+            The export folder.
+
+        Returns
+        -------
+        info: dict
+            The info.
+        """
+
+        info = super()._export_info(stage, folder)
+        if stage in (MSCStage.OPTIMIZE, MSCStage.COMPILE):
+            info.update(self._worker.export_info(stage, folder))
+        return info
+
+    def _destory(self):
+        """Destory the pipeline"""
+
+        self._worker.destory()
+
+    def get_runtime(self, ret_type: str = "runner") -> Any:
+        """Get the runtime of pipeline
 
         Parameters
         ----------
         ret_type: str
-            The return type runner| model.
+            The return type runner| runnable| model.
 
         Returns
         -------
         runnable:
-            The runner or model.
+            The runnable object.
         """
 
-        assert self._runner, "Failed to create runner, call run_pipe first"
-        if ret_type == "runner":
-            return self._runner
-        elif ret_type == "runnable":
-            return self._runner.runnable
-        elif ret_type == "model":
-            return self._runner.model
-        raise Exception("Unexpect return type " + str(ret_type))
+        return self._worker.get_runnable(ret_type)
 
-    def _get_runner_cls(self, run_type: str) -> BaseRunner:
-        """Get the runner cls by type
+    def pipe_mark(self, msg: Any) -> str:
+        """Mark the message with pipeline info
 
         Parameters
-        ----------
-        run_type: str
-            The run type.
+        -------
+        msg: str
+            The message
 
         Returns
         -------
-        runner_cls: class
-            The runner class.
+        msg: str
+            The message with mark.
         """
 
-        raise NotImplementedError("_get_runner_cls is not implemented for BaseManager")
-
-    def _get_loader(self, name: str = MSCStage.PREPARE) -> Any:
-        """Get the data loader"""
-
-        config = self._config["dataset"].get(name, self._config["dataset"][MSCStage.PREPARE])
-        source_loader = config.get("loader")
-        assert source_loader, "Dataset loader should be given for msc pipeline"
-        if source_loader == "from_random":
-            max_batch = config.get("max_batch", 5)
-
-            def get_random():
-                for _ in range(max_batch):
-                    yield {i[0]: np.random.rand(*i[1]).astype(i[2]) for i in self._config["inputs"]}
-
-            loader, source_type = get_random, "Random"
-        elif msc_utils.is_io_dataset(source_loader):
-            max_batch = config.get("max_batch", -1)
-
-            def load_datas():
-                for inputs, _ in msc_utils.IODataLoader(source_loader, end=max_batch):
-                    yield inputs
-
-            loader, source_type = load_datas, "IOData"
-        elif callable(source_loader):
-            max_batch = config.get("max_batch", -1)
-            load_kwargs = config.get("load_kwargs", {})
-
-            def get_source():
-                for idx, inputs in enumerate(source_loader(**load_kwargs)):
-                    if idx >= max_batch > 0:
-                        break
-                    yield inputs
-
-            loader, source_type = get_source, "Custom"
-        else:
-            raise TypeError(
-                "Unexpected source loader {}({})".format(source_loader, type(source_loader))
-            )
-        self._logger.debug("Create data loader(%s) %s(%s)", name, loader.__name__, source_type)
-        return loader
-
-    def _get_repeat(self, benchmark: dict, device: str = None) -> int:
-        """Get the repeat number for benchmark
-
-        Parameters
-        ----------
-        benchmark: dict
-            The benchmark config.
-        device: str
-            The device name
-
-        Returns
-        -------
-        repeat: int
-            The repeat number.
-        """
-
-        device = device or self._device
-        repeat = benchmark.get("repeat", -1)
-        if repeat == -1:
-            repeat = 500 if device.startswith("cuda") else 10
-        return repeat
+        return "MANAGER " + str(msg)
 
     @property
-    def runner(self):
-        return self._runner
-
-    @property
-    def report(self):
-        return self._report
-
-    @property
-    def model_type(self):
-        return self._model_type
-
-    @property
-    def optimize_type(self):
-        return self._optimize_type
-
-    @property
-    def compile_type(self):
-        return self._compile_type
-
-
-class MSCManager(BaseManager):
-    """Normal manager in MSC"""
-
-    def _get_runner_cls(self, run_type: str) -> BaseRunner:
-        """Get the runner cls by type
-
-        Parameters
-        ----------
-        run_type: str
-            The run type.
-
-        Returns
-        -------
-        runner_cls: class
-            The runner class.
-        """
-
-        if run_type == MSCFramework.TVM:
-            from tvm.contrib.msc.framework.tvm.runtime import TVMRunner
-
-            runner_cls = TVMRunner
-        elif run_type == MSCFramework.TORCH:
-            from tvm.contrib.msc.framework.torch.runtime import TorchRunner
-
-            runner_cls = TorchRunner
-        elif run_type == MSCFramework.TENSORFLOW:
-            from tvm.contrib.msc.framework.tensorflow.runtime import TensorflowRunner
-
-            runner_cls = TensorflowRunner
-        elif run_type == MSCFramework.TENSORRT:
-            from tvm.contrib.msc.framework.tensorrt.runtime import TensorRTRunner
-
-            runner_cls = TensorRTRunner
-        else:
-            raise Exception("Unexpect run_type " + str(run_type))
-        return runner_cls
+    def worker_cls(self):
+        return MSCPipeWorker

--- a/python/tvm/contrib/msc/pipeline/pipeline.py
+++ b/python/tvm/contrib/msc/pipeline/pipeline.py
@@ -1,0 +1,845 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-argument
+"""tvm.contrib.msc.pipeline.pipeline"""
+
+import os
+import json
+from typing import Any, Union, List, Tuple
+import traceback
+import numpy as np
+
+from tvm.contrib.msc.core.tools import get_tool_cls, BaseTool
+from tvm.contrib.msc.core.utils.namespace import MSCFramework, MSCMap, MSCKey
+from tvm.contrib.msc.core.utils.message import MSCStage
+from tvm.contrib.msc.plugin.utils import export_plugins, load_plugins
+from tvm.contrib.msc.core import utils as msc_utils
+from tvm.contrib.msc.core import _ffi_api
+from .utils import support_tool, get_tool_stage, map_tools
+from .worker import BasePipeWorker
+
+
+class BasePipeline(object):
+    """Base Pipeline of MSC
+
+    Parameters
+    ----------
+    model: Any
+        The raw model in framwork.
+    config: dict
+        The config for pipeline.
+    plugins: dict
+        The plugins for pipeline.
+    run_optimize: bool
+        Whether to run optimize.
+    run_compile: bool
+        Whether to run compile.
+    root: str
+        The root path for files.
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        config: dict,
+        plugins: dict = None,
+        run_optimize: bool = True,
+        run_compile: bool = True,
+        root: str = None,
+    ):
+        # change path to root path
+        if root:
+
+            def _from_root_mark(val):
+                if isinstance(val, str) and MSCKey.ROOT_MARK in val:
+                    return val.replace(MSCKey.ROOT_MARK, root)
+                return val
+
+            if isinstance(model, dict):
+                model = msc_utils.map_dict(model, _from_root_mark)
+            elif isinstance(model, str):
+                model = _from_root_mark(model)
+            config = msc_utils.map_dict(config, _from_root_mark)
+            plugins = msc_utils.map_dict(plugins, _from_root_mark)
+
+        MSCMap.reset()
+        self._model, self._meta_config = model, config
+        self._config = msc_utils.copy_dict(config)
+        if not run_optimize and MSCStage.OPTIMIZE in self._config:
+            self._config.pop(MSCStage.OPTIMIZE)
+        if not run_compile and MSCStage.COMPILE in self._config:
+            self._config.pop(MSCStage.COMPILE)
+        for stage in [MSCStage.PREPARE, MSCStage.PARSE, MSCStage.EXPORT]:
+            self._config.setdefault(stage, {})
+        self._verbose = self._config.get("verbose", "info")
+        use_cache = self._config.get("use_cache", True)
+        if "workspace" in self._config:
+            self._workspace = msc_utils.set_workspace(self._config.pop("workspace"), use_cache)
+        else:
+            self._workspace = msc_utils.set_workspace("msc_workspace", use_cache)
+        if "logger" in self._config:
+            self._logger = self._config.pop("logger")
+            MSCMap.set(MSCKey.GLOBALE_LOGGER, self._logger)
+        else:
+            if "log_file" in self._config:
+                log_file = self._config.pop("log_file")
+            else:
+                log_file = self._workspace.relpath("MSC_LOG", keep_history=False)
+            self._logger = msc_utils.set_global_logger(self._verbose, log_file)
+        self._plugins = load_plugins(plugins) if plugins else {}
+        self.change_stage(MSCStage.SETUP)
+        self._logger.info(msc_utils.msg_block(self.pipe_mark("SETUP"), self.setup()))
+
+    def setup(self) -> dict:
+        """Setup the pipeline
+
+        Returns
+        -------
+        info: dict
+            The setup info.
+        """
+
+        # define run type
+        self._model_type = self._config["model_type"]
+        self._optimize_type = self._config.get(MSCStage.OPTIMIZE, {}).get(
+            "run_type", self._model_type
+        )
+        self._compile_type = self._config.get(MSCStage.COMPILE, {}).get(
+            "run_type", self._model_type
+        )
+        self._optimized, self._compiled = False, False
+
+        # map tools
+        self._tools_config = map_tools(self._config.get("tools", []))
+
+        # register plugins
+        if self._plugins:
+            for t in [self._model_type, self._optimize_type, self._compile_type]:
+                assert t in self._plugins, "Missing plugin for {}".format(t)
+            for name, plugin in self._plugins[self._model_type].get_ops_info().items():
+                _ffi_api.RegisterPlugin(name, msc_utils.dump_dict(plugin))
+
+        # status
+        self._current_stage = None
+        self._report = {
+            "success": False,
+            "info": {},
+            "duration": {},
+        }
+        return {
+            "workspace": self._workspace.path,
+            "log_file": msc_utils.get_log_file(self._logger),
+            "verbose": self._verbose,
+            "plugins": self._plugins,
+            "config": self._config,
+        }
+
+    def run_pipe(self) -> dict:
+        """Run the pipeline and return object.
+
+        Returns
+        -------
+        report:
+            The pipeline report.
+        """
+
+        err_msg, err_info = None, None
+        try:
+            self.prepare()
+            self.parse()
+            if MSCStage.BASELINE in self._config:
+                self.baseline()
+            if MSCStage.OPTIMIZE in self._config:
+                self.optimize()
+            if MSCStage.COMPILE in self._config:
+                self.compile()
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            err_msg = "Pipeline failed: " + str(exc)
+            err_info = traceback.format_exc()
+        self.summary(err_msg, err_info)
+        self._logger.info(msc_utils.msg_block(self.pipe_mark("SUMMARY"), self._report, 0))
+        self._workspace.finalize()
+        return self._report
+
+    def change_stage(self, stage: str, log_stage: bool = True) -> str:
+        """Change stage
+
+        Parameters
+        ----------
+        stage: str
+            The stage name.
+        log_stage: bool
+            Whether to log the stage.
+
+        Returns
+        -------
+        stage: str
+            The stage name.
+        """
+
+        self._current_stage = stage
+        msc_utils.time_stamp(stage, log_stage)
+        return stage
+
+    def prepare(self):
+        """Prepare datas for the pipeline."""
+
+        self.change_stage(MSCStage.PREPARE)
+        info, report = self._prepare(self._get_loader(MSCStage.PREPARE))
+        self._record_stage(MSCStage.PREPARE, info, report)
+
+    def _prepare(self, data_loader: Any) -> Tuple[dict, dict]:
+        """Prepare datas for the pipeline.
+
+        Parameters
+        ----------
+        data_loader:
+            The data loader.
+
+        Returns
+        -------
+        info: dict
+            The info of prepare.
+        report: dict
+            The report of prepare.
+        """
+
+        raise NotImplementedError("_prepare is not implemented in " + str(self.__class__))
+
+    def parse(self):
+        """Parse relax module for the pipeline."""
+
+        self.change_stage(MSCStage.PARSE)
+        info, report = self._parse()
+        self._record_stage(MSCStage.PARSE, info, report)
+
+    def _parse(self) -> Tuple[dict, dict]:
+        """Parse relax module for the pipeline.
+
+        Returns
+        -------
+        info: dict
+            The info of parse.
+        report: dict
+            The report of parse.
+        """
+
+        raise NotImplementedError("_parse is not implemented in " + str(self.__class__))
+
+    def baseline(self):
+        """Run the baseline."""
+
+        self._run_stage(MSCStage.BASELINE)
+
+    def optimize(self) -> Tuple[dict, dict]:
+        """Run the optimize.
+
+        Returns
+        -------
+        info: dict
+            The info of stage.
+        report: dict
+            The report of stage.
+        """
+
+        self._run_stage(MSCStage.OPTIMIZE)
+        self._optimized = True
+
+    def compile(self) -> Tuple[dict, dict]:
+        """Run the compile.
+
+        Returns
+        -------
+        info: dict
+            The info of stage.
+        report: dict
+            The report of stage.
+        """
+
+        self._run_stage(MSCStage.COMPILE)
+        self._compiled = True
+
+    def _run_stage(self, stage: str) -> Tuple[dict, dict]:
+        """Run the stage.
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+
+        Returns
+        -------
+        info: dict
+            The info of stage.
+        report: dict
+            The report of stage.
+        """
+
+        self.change_stage(stage)
+        tools = []
+        for tool in self._config.get("tools", []):
+            run_type = tool.get("run_type", self._config[stage]["run_type"])
+            if not support_tool(tool, stage, run_type):
+                continue
+            tools.append(tool["tool_type"])
+            tool_cls, tool_stage = self.get_tool_cls(tool, run_type), get_tool_stage(
+                tool["tool_type"]
+            )
+            t_stage = self.change_stage(stage + "." + tool_stage)
+            if self._tool_applied(tool["tool_type"]):
+                if tool_cls.apply_once():
+                    msg = "Remove apply once tool " + str(tool["tool_type"])
+                    self._logger.info(self.pipe_mark(msg))
+                    tools = tools[:-1]
+                else:
+                    self._logger.info(self.pipe_mark("Apply planed tool " + str(tool["tool_type"])))
+                continue
+            self.change_stage(t_stage + ".build", False)
+            info, report = self._create_runtime(
+                t_stage, tools, run_type=run_type, visualize=False, profile=False, use_cache=False
+            )
+            self._record_stage(t_stage, info, report)
+            knowledge, loader = None, self._get_loader(tool_stage)
+            if "gym_configs" in tool:
+                for idx, config in enumerate(tool["gym_configs"]):
+                    knowledge_file = self._workspace.create_dir("Gym").relpath(
+                        "knowledge_{}.json".format(idx)
+                    )
+                    gym_mark = "GYM[{}/{}]({} @ {}) ".format(
+                        idx, len(tool["gym_configs"]), self._config[stage]["run_type"], tool_stage
+                    )
+                    if os.path.isfile(knowledge_file):
+                        knowledge = knowledge_file
+                        msg = "{}Load from {}".format(gym_mark, knowledge)
+                        self._logger.info(self.pipe_mark(msg))
+                    else:
+                        self.change_stage(tool_stage + ".gym_{}".format(idx))
+                        self._logger.info(self.pipe_mark(gym_mark + "Start search"))
+                        knowledge = self._run_gym(tool_stage, config, knowledge, loader)
+                        msc_utils.save_dict(knowledge, knowledge_file)
+                    knowledge = msc_utils.load_dict(knowledge)
+            self.change_stage(t_stage + ".apply", False)
+            info, report = self._apply_tool(tool["tool_type"], knowledge, loader)
+            self._record_stage(t_stage, info, report)
+            if tool_cls.apply_once():
+                msg = "Remove apply once tool " + str(tool["tool_type"])
+                self._logger.info(self.pipe_mark(msg))
+                tools = tools[:-1]
+        self.change_stage(stage + ".build", False)
+        info, report = self._create_runtime(stage, tools)
+        self._record_stage(stage, info, report)
+
+    def _tool_applied(self, tool_type: str) -> bool:
+        """Check if the tool is applied
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type.
+
+        Returns
+        -------
+        applied: bool
+            Whether the tool is applied.
+        """
+
+        return False
+
+    def _apply_tool(
+        self, tool_type: str, knowledge: dict = None, data_loader: Any = None
+    ) -> Tuple[dict, dict]:
+        """Apply tool with runner
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type to apply.
+        knowledge: dict
+            The pre knowledge.
+        data_loader:
+            The data loader.
+
+        Returns
+        -------
+        info: dict
+            The info of apply tool.
+        report: dict
+            The report of apply tool.
+        """
+
+        raise NotImplementedError("_apply_tool is not implemented in " + str(self.__class__))
+
+    def _create_runtime(
+        self,
+        stage: str,
+        tools: List[str] = None,
+        run_type: str = None,
+        run_config: dict = None,
+        visualize: bool = True,
+        profile: bool = True,
+        use_cache: bool = True,
+    ) -> Tuple[dict, dict]:
+        """Create runtime.
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        tools: list<str>
+            The tools to apply.
+        run_type: str
+            The type of runner.
+        run_config: dict
+            The config of runner.
+        visualize: bool
+            Whether to visualize the runner
+        profile: bool
+            Whether to profile the runner.
+        use_cache: bool
+            Whether to use cache.
+
+        Returns
+        -------
+        info: dict
+            The info of stage.
+        report: dict
+            The report of stage.
+        """
+
+        raise NotImplementedError("_create_runtime is not implemented in " + str(self.__class__))
+
+    def _run_gym(self, stage: str, config: dict, knowledge: dict, data_loader: Any) -> dict:
+        """Run gym.
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        config: dict
+            The gym config.
+        knowledge: dict
+            The pre knowledge.
+        data_loader:
+            The data loader.
+
+        Returns
+        -------
+        knowledge: dict
+            The learned knowledge.
+        """
+
+        raise NotImplementedError("_run_gym is not implemented in " + str(self.__class__))
+
+    def summary(self, err_msg: str = None, err_info: str = None) -> dict:
+        """Summary the pipeline.
+
+        Parameters
+        ----------
+        err_msg: str
+            The error message.
+        err_info: str
+            The error info.
+
+        Returns
+        -------
+        report: dict
+            The report of the pipeline.
+        """
+
+        self.change_stage(MSCStage.SUMMARY, False)
+        if err_msg:
+            self._report.update({"success": False, "err_msg": err_msg, "err_info": err_info})
+        else:
+            self._report["success"] = True
+        self._report["duration"] = msc_utils.get_duration()
+        return self._report
+
+    def export(self, path: str = None, dump: bool = True) -> Union[str, dict]:
+        """Export the pipeline
+
+        Parameters
+        ----------
+        path: str
+            The export path.
+        dump: bool
+            Whether to dump the info.
+
+        Returns
+        -------
+        export_path/pipeline: str/dict
+            The exported path/pipeline info.
+        """
+
+        path = path or "msc_export"
+        if path.endswith(".tar.gz"):
+            folder, dump = msc_utils.msc_dir(path.replace(".tar.gz", ""), keep_history=False), True
+        else:
+            folder = msc_utils.msc_dir(path, keep_history=False)
+
+        if self._compiled:
+            stage = MSCStage.COMPILE
+        elif self._optimized:
+            stage = MSCStage.OPTIMIZE
+        else:
+            stage = MSCStage.SETUP
+
+        def _to_root_mark(val):
+            if isinstance(val, str) and folder.path != val and folder.path in val:
+                return val.replace(folder.path, MSCKey.ROOT_MARK)
+            return val
+
+        def _export_plugins(folder: msc_utils.MSCDirectory):
+            if self._compiled:
+                if dump and self.compile_type in self._plugins:
+                    return self._plugins[self.compile_type].copy_libs(folder)
+                return self._plugins.get(self.compile_type)
+            if dump:
+                return export_plugins(self._plugins, folder)
+            return self._plugins
+
+        export = {
+            "logger": folder.copy(msc_utils.get_log_file(self._logger)),
+            "report": self._report,
+            "info": self._export_info(stage, folder.create_dir("info")),
+            "model": self._export_model(stage, folder.create_dir("model"), dump),
+            "plugins": _export_plugins(folder.create_dir("plugins")),
+        }
+        if self._compiled:
+            # save golden
+            num_golden = self._config[MSCStage.EXPORT].get("num_golden", 5)
+            if num_golden > 0:
+                saver_options = {
+                    "input_names": [i[0] for i in self._config["inputs"]],
+                    "output_names": self._config["outputs"],
+                }
+                batch_cnt, export["golden"] = 0, folder.create_dir("golden").path
+                with msc_utils.IODataSaver(export["golden"], saver_options) as saver:
+                    for inputs in self._get_loader()():
+                        if batch_cnt >= num_golden:
+                            break
+                        batch_cnt = saver.save_batch(inputs, self.get_runtime().run(inputs))
+        else:
+            export["config"] = self.export_config(folder, dump)
+        export = msc_utils.map_dict(export, _to_root_mark)
+        if not dump:
+            return export
+        with open(folder.relpath("export.json"), "w") as f:
+            f.write(json.dumps(export, indent=2))
+        folder.finalize()
+        if path.endswith(".tar.gz"):
+            msc_utils.pack_folder(path.replace(".tar.gz", ""), "tar.gz")
+        return path
+
+    def export_config(self, folder: msc_utils.MSCDirectory, dump: bool = True) -> dict:
+        """Export the config
+
+        Parameters
+        ----------
+        folder: MSCDirectory
+            The export folder.
+        dump: bool
+            Whether to dump info.
+
+        Returns
+        -------
+        config: dict
+            The updated config.
+        """
+
+        # dump the dataloader
+        def _export_dataset(name, info, dump: bool):
+            loader, max_batch = info["loader"], info.get("max_batch", -1)
+            data_folder = folder.create_dir("dataset")
+            if isinstance(loader, str) and msc_utils.is_callable(loader):
+                path, func_name = loader.split(":")
+                exp_loader = data_folder.copy(path) + ":" + func_name
+            elif msc_utils.is_io_dataset(loader):
+                exp_loader = data_folder.copy(loader, name)
+            elif callable(loader) and dump:
+                saver_options = {"input_names": [i[0] for i in self._config["inputs"]]}
+                batch_cnt, exp_loader = 0, data_folder.create_dir(name).path
+                with msc_utils.IODataSaver(exp_loader, saver_options) as saver:
+                    for inputs in loader():
+                        if batch_cnt >= max_batch > 0:
+                            break
+                        batch_cnt = saver.save_batch(inputs)
+            else:
+                exp_loader = loader
+            return {"loader": exp_loader, "max_batch": max_batch}
+
+        config = msc_utils.copy_dict(self._meta_config)
+        config["dataset"] = {
+            k: _export_dataset(k, v, dump) for k, v in self._config["dataset"].items()
+        }
+        if self._optimized:
+            config["model_type"] = MSCFramework.TVM
+            for stage in [MSCStage.BASELINE, MSCStage.OPTIMIZE]:
+                if stage in config:
+                    config.pop(stage)
+            if "profile" in config[MSCStage.COMPILE] and self.get_runtime().trained:
+                config[MSCStage.COMPILE]["profile"].setdefault("check", {})["err_rate"] = -1
+            config["tools"] = []
+            for tool in self._config.get("tools", []):
+                tool_type = tool["tool_type"]
+                skip_msg = "Skip export tool " + tool_type
+                if not support_tool(tool, MSCStage.COMPILE, self._compile_type):
+                    self._logger.info(self.pipe_mark(skip_msg + "(unsupported)"))
+                    continue
+                tool_cls = self.get_tool_cls(tool, self._optimize_type)
+                if not tool_cls.exportable():
+                    self._logger.info(self.pipe_mark(skip_msg + "(unexportable)"))
+                    continue
+                config["tools"].append(self._export_tool(tool_type, folder))
+        # remove not serializable items
+        if dump:
+            remove_keys = {"workspace", "logger"}
+            config = {k: v for k, v in config.items() if k not in remove_keys}
+        return config
+
+    def _export_model(self, stage: str, folder: msc_utils.MSCDirectory, dump: bool = True) -> Any:
+        """Export the model
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        folder: MSCDirectory
+            The export folder.
+        dump: bool
+            Whether to dump info.
+
+        Returns
+        -------
+        exported:
+            The exported model.
+        """
+
+        raise NotImplementedError("_export_model is not implemented in " + str(self.__class__))
+
+    def _export_tool(self, tool_type: str, folder: msc_utils.MSCDirectory) -> dict:
+        """Export the tool
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type.
+        folder: MSCDirectory
+            The export folder.
+
+        Returns
+        -------
+        tool: dict
+            The exported tool.
+        """
+
+        raise NotImplementedError("_export_tool is not implemented in " + str(self.__class__))
+
+    def _export_info(self, stage: str, folder: msc_utils.MSCDirectory) -> dict:
+        """Export the info of pipeline
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        folder: MSCDirectory
+            The export folder.
+
+        Returns
+        -------
+        info: dict
+            The info.
+        """
+
+        return {}
+
+    def _get_loader(self, name: str = MSCStage.PREPARE) -> Any:
+        """Get the data loader"""
+
+        config = self._config["dataset"].get(name, self._config["dataset"][MSCStage.PREPARE])
+        source_loader = config.get("loader")
+        assert source_loader, "Dataset loader should be given for msc pipeline"
+        if source_loader == "from_random":
+            max_batch = config.get("max_batch", 5)
+
+            def get_random():
+                for _ in range(max_batch):
+                    yield {i[0]: np.random.rand(*i[1]).astype(i[2]) for i in self._config["inputs"]}
+
+            loader, source_type = get_random, "random"
+        elif msc_utils.is_io_dataset(source_loader):
+            max_batch = config.get("max_batch", -1)
+
+            def load_datas():
+                for inputs, _ in msc_utils.IODataLoader(source_loader, end=max_batch):
+                    yield inputs
+
+            loader, source_type = load_datas, "io_data"
+        elif callable(source_loader):
+            max_batch = config.get("max_batch", -1)
+            load_kwargs = config.get("load_kwargs", {})
+            if max_batch == -1 and not load_kwargs:
+                loader, source_type = source_loader, "custom"
+            else:
+
+                def get_source():
+                    for idx, inputs in enumerate(source_loader(**load_kwargs)):
+                        if idx >= max_batch > 0:
+                            break
+                        yield inputs
+
+                loader, source_type = get_source, "loaded_custom"
+        else:
+            raise TypeError(
+                "Unexpected source loader {}({})".format(source_loader, type(source_loader))
+            )
+        msg = "Create data loader({}) {}({})".format(name, loader.__name__, source_type)
+        self._logger.debug(self.pipe_mark(msg))
+        return loader
+
+    def _record_stage(self, stage: str, info: dict = None, report: dict = None):
+        """Record the stage
+
+        Parameters
+        -------
+        stage: str
+            The compile stage
+        info: dict
+            The info of stage.
+        report: dict
+            The report of stage.
+        """
+
+        if info:
+            self._logger.info(msc_utils.msg_block(self.pipe_mark(stage.upper()), info))
+        if report:
+            self._report["info"].setdefault(stage, {}).update(report)
+
+    def destory(self, keep_workspace: bool = False):
+        """Destroy the pipeline
+
+        Parameters
+        ----------
+        keep_workspace: bool
+            Whether to keep workspace.
+        """
+
+        self._destory()
+        if not keep_workspace:
+            self._workspace.destory()
+        msc_utils.remove_loggers()
+
+    def _destory(self):
+        """Destroy the pipeline."""
+
+        raise NotImplementedError("_destory is not implemented in " + str(self.__class__))
+
+    def get_tool_cls(self, tool: dict, framework: str) -> BaseTool:
+        """Get the tool class from tool config
+
+        Parameters
+        ----------
+        tool: dict
+            The tool config.
+        framework: str
+            The framework.
+
+        Returns
+        -------
+        tool_cls:
+            The tool class.
+        """
+
+        return get_tool_cls(framework, tool["tool_type"], tool["tool_config"])
+
+    def get_runtime(self, ret_type: str = "runner") -> Any:
+        """Get the runtime of pipeline
+
+        Parameters
+        ----------
+        ret_type: str
+            The return type runner| runnable| model.
+
+        Returns
+        -------
+        runnable:
+            The runnable object.
+        """
+
+        raise NotImplementedError("get_runtime is not implemented in " + str(self.__class__))
+
+    def create_worker(self, model: Any, name: str, config: dict = None):
+        """Create pipe worker
+
+        Parameters
+        -------
+        model: Any
+            The raw model in framwork.
+        name: str
+            The name of worker.
+        worker_config: dict
+            The extra config for worker.
+
+        Returns
+        -------
+        worker: str
+            The message with mark.
+        """
+
+        return self.worker_cls(
+            model,
+            config or self._config,
+            self._workspace,
+            self._plugins,
+            self._logger,
+            name=name,
+        )
+
+    def pipe_mark(self, msg: Any) -> str:
+        """Mark the message with pipeline info
+
+        Parameters
+        -------
+        msg: str
+            The message
+
+        Returns
+        -------
+        msg: str
+            The message with mark.
+        """
+
+        return "PIPE " + str(msg)
+
+    @property
+    def worker_cls(self):
+        return BasePipeWorker
+
+    @property
+    def report(self):
+        return self._report
+
+    @property
+    def model_type(self):
+        return self._model_type
+
+    @property
+    def optimize_type(self):
+        return self._optimize_type
+
+    @property
+    def compile_type(self):
+        return self._compile_type

--- a/python/tvm/contrib/msc/pipeline/utils.py
+++ b/python/tvm/contrib/msc/pipeline/utils.py
@@ -1,0 +1,220 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""tvm.contrib.msc.pipeline.config"""
+
+from typing import List, Union, Dict, Tuple
+
+from tvm.contrib.msc.core.tools import ToolType
+from tvm.contrib.msc.core.utils.message import MSCStage
+from tvm.contrib.msc.core import utils as msc_utils
+
+
+def get_tool_stage(tool_type: str) -> str:
+    """Map the stage according to tool_type
+
+    Parameters
+    ----------
+    tool_type: str
+        The tool type.
+
+    Returns
+    -------
+    stage: str
+        The stage.
+    """
+
+    if tool_type == ToolType.PRUNER:
+        return MSCStage.PRUNE
+    if tool_type == ToolType.QUANTIZER:
+        return MSCStage.QUANTIZE
+    if tool_type == ToolType.DISTILLER:
+        return MSCStage.DISTILL
+    if tool_type == ToolType.TRACKER:
+        return MSCStage.TRACK
+    return tool_type
+
+
+def map_tools(tools: List[dict]) -> dict:
+    """Map tools from list
+
+    Parameters
+    ----------
+    tools: list<dict>
+        The tools config,
+
+    Returns
+    -------
+    tools: dict
+        The tools map.
+    """
+
+    tools_map = {t["tool_type"]: t for t in tools}
+    assert len(tools_map) == len(tools), "Duplicate tools: " + str([t["tool_type"] for t in tools])
+    return tools_map
+
+
+def support_tool(tool: dict, stage: str, run_type: str) -> bool:
+    """Check if the tool is supported
+
+    Parameters
+    ----------
+    tool: dict
+        The tool config,
+    stage: str
+        The pipeline stage.
+    run_type: str
+        The runtime type.
+
+    Returns
+    -------
+    supported: bool
+        Whether the tool is supported.
+    """
+
+    run_type = tool.get("run_type", run_type)
+    if stage == MSCStage.BASELINE:
+        return tool["tool_type"] == ToolType.TRACKER
+    return True
+
+
+def config_tool(tool_type: str, raw_config: Union[dict, str]) -> dict:
+    """Config the tool
+
+    Parameters
+    ----------
+    tool_type: str
+        The tool type,
+    raw_config: str| dict
+        The tool config or style.
+
+    Returns
+    -------
+    config: dict
+        The config for tool.
+    """
+
+    if isinstance(raw_config, dict):
+        if "config_style" in raw_config:
+            config_style = raw_config.pop("config_style")
+        else:
+            config_style = "default"
+    else:
+        config_style, raw_config = raw_config, None
+    configer_cls = msc_utils.get_registered_tool_configer(tool_type, config_style)
+    assert configer_cls, "Can not find configer for {}:{}".format(tool_type, config_style)
+    return {"tool_type": tool_type, **configer_cls().config(raw_config)}
+
+
+def create_config(
+    inputs: List[dict],
+    outputs: List[str],
+    model_type: str,
+    baseline_type: str = None,
+    optimize_type: str = None,
+    compile_type: str = None,
+    dataset: Dict[str, dict] = None,
+    tools: List[Tuple[str, Union[dict, str]]] = None,
+    dynamic: bool = False,
+    skip_config: Dict[str, str] = None,
+    **extra_config,
+) -> dict:
+    """Create config for msc pipeline
+
+    Parameters
+    ----------
+    inputs: list<dict>
+        The inputs info,
+    outputs: list<str>
+        The output names.
+    model_type: str
+        The model type.
+    baseline_type: str
+        The baseline type.
+    compile_type: str
+        The compile type.
+    optimize_type: str
+        The optimize type.
+    dataset: dict<str, dict>
+        The datasets for compile pipeline.
+    tools: list<str, str|dict>
+        The tools config.
+    dynamic: bool
+        Whether to config dyanmic mode.
+    skip_config: dict
+        The skip config for compile.
+    extra_config: dict
+        The extra config.
+    """
+
+    baseline_type = baseline_type or model_type
+    optimize_type = optimize_type or baseline_type
+    compile_type = compile_type or optimize_type
+    tools = tools or []
+    tools = [config_tool(t_type, t_config) for t_type, t_config in tools]
+    # basic config
+    config = {
+        "model_type": model_type,
+        "dynamic": dynamic,
+        "inputs": inputs,
+        "outputs": outputs,
+        "dataset": dataset,
+        "tools": tools,
+        MSCStage.PREPARE: {"profile": {"benchmark": {"repeat": -1}}},
+        MSCStage.BASELINE: {
+            "run_type": baseline_type,
+            "profile": {"check": {"atol": 1e-3, "rtol": 1e-3}, "benchmark": {"repeat": -1}},
+        },
+    }
+
+    # config optimize
+    opt_tools = [t for t in tools if support_tool(t, MSCStage.OPTIMIZE, optimize_type)]
+    if opt_tools:
+        config[MSCStage.OPTIMIZE] = {
+            "run_type": optimize_type,
+            "profile": {"check": {"atol": 1e-3, "rtol": 1e-3}, "benchmark": {"repeat": -1}},
+        }
+
+    # config compile
+    config[MSCStage.COMPILE] = {
+        "run_type": compile_type,
+        "profile": {"check": {"atol": 1e-3, "rtol": 1e-3}, "benchmark": {"repeat": -1}},
+    }
+
+    # update config
+    if extra_config:
+        config = msc_utils.update_dict(config, extra_config)
+
+    # skip stages
+    skip_config = skip_config or {}
+    for stage in [MSCStage.BASELINE, MSCStage.OPTIMIZE, MSCStage.COMPILE]:
+        if stage not in config:
+            continue
+        for key in ["all", stage]:
+            if key not in skip_config:
+                continue
+            if skip_config[key] == "stage":
+                config.pop(stage)
+            elif skip_config[key] == "profile":
+                config[stage].pop("profile")
+            elif skip_config[key] == "check":
+                config[stage]["profile"].pop("check")
+            elif skip_config[key] == "benchmark":
+                config[stage]["profile"].pop("benchmark")
+            else:
+                raise TypeError("Unexpected skip type " + str(skip_config[key]))
+
+    return config

--- a/python/tvm/contrib/msc/pipeline/worker.py
+++ b/python/tvm/contrib/msc/pipeline/worker.py
@@ -1,0 +1,786 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=import-outside-toplevel, unused-argument
+"""tvm.contrib.msc.pipeline.worker"""
+
+import os
+import time
+import logging
+from typing import Any, List, Tuple
+
+import tvm
+from tvm.contrib.msc.core.runtime import BaseRunner
+from tvm.contrib.msc.core.tools import ToolType
+from tvm.contrib.msc.core.utils.namespace import MSCFramework
+from tvm.contrib.msc.core.utils.message import MSCStage
+from tvm.contrib.msc.core import utils as msc_utils
+from .utils import support_tool, get_tool_stage, map_tools
+
+
+class BasePipeWorker(object):
+    """Base Worker of MSC pipeline
+
+    Parameters
+    ----------
+    model: Any
+        The raw model in framwork.
+    config: dict
+        The config for pipeline.
+    workspace: MSCDirectory
+        The workspace.
+    plugins: dict
+        The plugins for pipeline.
+    run_optimize: bool
+        Whether to run optimize.
+    run_compile: bool
+        Whether to run compile.
+    logger: logging.Logger
+        The logger.
+    name: str
+        The name of the worker.
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        config: dict,
+        workspace: msc_utils.MSCDirectory,
+        plugins: dict = None,
+        logger: logging.Logger = None,
+        name: str = "main",
+    ):
+        # check/set default stage
+        for key in ["inputs", "outputs", "dataset"]:
+            assert key in config, "Missing {} in config".format(key)
+
+        self._config = msc_utils.copy_dict(config)
+        self._workspace = workspace
+        self._plugins = plugins
+        self._model_type = config["model_type"]
+        self._optimize_type = config.get(MSCStage.OPTIMIZE, {}).get("run_type", self._model_type)
+        self._compile_type = config.get(MSCStage.COMPILE, {}).get("run_type", self._model_type)
+        runner_cls = self._get_runner_cls(self._model_type)
+        self._model, self._device, self._training = runner_cls.load_native(model, config)
+        self._verbose = config.get("verbose", "info")
+        self._logger = logger or msc_utils.get_global_logger()
+        self._name = name
+        self._optimized, self._compiled = False, False
+        self.setup()
+
+    def setup(self) -> dict:
+        """Setup the manager
+
+        Returns
+        -------
+        config: dict
+            The updated config.
+        """
+
+        self._debug_levels = self.update_config()
+        self._tools_config = map_tools(self._config.get("tools", []))
+        self._relax_mod, self._sample_inputs = None, None
+        self._runner = None
+
+    def update_config(self) -> dict:
+        """Update config
+
+        Returns
+        -------
+        debug_levels: dict
+            The debug_levels.
+        """
+
+        debug_levels = {}
+        self._config = self._get_runner_cls(self._model_type).update_config(
+            MSCStage.PARSE, self._config, self._model
+        )
+
+        # update runner config
+        for stage in [MSCStage.BASELINE, MSCStage.OPTIMIZE, MSCStage.COMPILE]:
+            if stage not in self._config:
+                continue
+            if "run_type" not in self._config[stage]:
+                self._config[stage]["run_type"] = self._model_type
+            runner_cls = self._get_runner_cls(self._config[stage]["run_type"])
+            self._config = runner_cls.update_config(stage, self._config, self._model)
+
+        # update tool config
+        if self._config.get("tools"):
+            self._config["tools"] = self._update_tools_config(self._config["tools"])
+
+        # update export config
+        self._config[MSCStage.EXPORT].update(
+            {"inputs": self._config["inputs"], "outputs": self._config["outputs"]}
+        )
+
+        def _set_debug_level(stage: str, sub_config: dict, default: int = None) -> dict:
+            if "debug_level" in sub_config:
+                debug_levels[stage] = sub_config["debug_level"]
+            elif default is not None:
+                debug_levels[stage] = default
+                sub_config["debug_level"] = default
+            return debug_levels
+
+        if self._verbose.startswith("debug:"):
+            debug_level = int(self._verbose.split(":")[1])
+        else:
+            debug_level = 0
+        for stage in [MSCStage.BASELINE, MSCStage.OPTIMIZE, MSCStage.COMPILE]:
+            if stage not in self._config:
+                continue
+            debug_levels = _set_debug_level(stage, self._config[stage]["run_config"], debug_level)
+            for t_config in self._config.get("tools", []):
+                if not support_tool(t_config, stage, self._config[stage]["run_type"]):
+                    continue
+                t_stage = stage + "." + get_tool_stage(t_config["tool_type"])
+                debug_levels = _set_debug_level(t_stage, t_config["tool_config"], debug_level)
+        ordered_keys = [
+            "model_type",
+            "inputs",
+            "outputs",
+            "dataset",
+            "tools",
+            MSCStage.PREPARE,
+            MSCStage.PARSE,
+            MSCStage.BASELINE,
+            MSCStage.OPTIMIZE,
+            MSCStage.COMPILE,
+            MSCStage.EXPORT,
+        ]
+        self._config = {k: self._config[k] for k in ordered_keys if k in self._config}
+        return debug_levels
+
+    def _update_tools_config(self, tools: List[dict]) -> List[dict]:
+        """Update tool in stage config.
+
+        Parameters
+        ----------
+        tools: list<dict>
+            The config of tools.
+
+        Returns
+        -------
+        tools: list<dict>
+            The updated config of tools.
+        """
+
+        for tool in tools:
+            tool_config = tool["tool_config"]
+            if "plan_file" not in tool_config:
+                tool_config["plan_file"] = "msc_{}.json".format(tool["tool_type"])
+            tool_config["plan_file"] = msc_utils.to_abs_path(
+                tool_config["plan_file"], msc_utils.get_config_dir()
+            )
+        return tools
+
+    def prepare(self, data_loader: Any = None) -> Tuple[dict, dict]:
+        """Prepare datas for the pipeline.
+
+        Parameters
+        ----------
+        data_loader:
+            The data loader.
+
+        Returns
+        -------
+        info: dict
+            The info of prepare.
+        report: dict
+            The report of prepare.
+        """
+
+        stage_config = self._config[MSCStage.PREPARE]
+        use_cache = self._config.get("use_cache", True)
+        runner_cls = self._get_runner_cls(self._model_type)
+        run_func = runner_cls.run_native if hasattr(runner_cls, "run_native") else None
+        input_names = [i[0] for i in self._config["inputs"]]
+
+        # create golden
+        if "golden" in self._config["dataset"]:
+            golden_folder = self._config["dataset"]["golden"]["loader"]
+        else:
+            golden_folder = msc_utils.get_dataset_dir().relpath("Golden", use_cache)
+        if msc_utils.is_io_dataset(golden_folder):
+            loader, source_type = msc_utils.IODataLoader(golden_folder), "cache"
+            self._sample_inputs = loader[0][0]
+            datas_info = loader.info
+            msg = "Load {} golden from {}".format(len(loader), golden_folder)
+            self._logger.debug(self.worker_mark(msg))
+        elif run_func:
+            source_type = "native"
+            saver_options = {"input_names": input_names, "output_names": self._config["outputs"]}
+            cnt, max_golden = 0, self._config["dataset"][MSCStage.PREPARE].get("max_golden", 5)
+            with msc_utils.IODataSaver(golden_folder, saver_options) as saver:
+                for inputs in data_loader():
+                    if cnt >= max_golden > 0:
+                        break
+                    if not self._sample_inputs:
+                        self._sample_inputs = {
+                            k: msc_utils.cast_array(v) for k, v in inputs.items()
+                        }
+                    try:
+                        outputs, _ = run_func(
+                            self._model, inputs, input_names, self._config["outputs"]
+                        )
+                    except Exception as exc:  # pylint: disable=broad-exception-caught
+                        if cnt == 0:
+                            msg = "Failed to test native: {}".format(exc)
+                            self._logger.warning(self.worker_mark(msg))
+                        outputs = None
+                    cnt = saver.save_batch(inputs, outputs)
+                datas_info = saver.info
+            msg = "Save {} golden to {}".format(cnt, golden_folder)
+            self._logger.debug(self.worker_mark(msg))
+        else:
+            raise Exception("golden_folder or runner should given to save golden")
+        self._config["dataset"]["golden"] = {"loader": golden_folder, "max_batch": -1}
+
+        def _to_abstract(info: dict) -> dict:
+            def _to_tensor_str(info):
+                return "{},{}".format(";".join([str(s) for s in info["shape"]]), info["dtype"])
+
+            return {
+                "num_datas": info["num_datas"],
+                "inputs": {n: _to_tensor_str(i) for n, i in info["inputs"].items()},
+                "outputs": {n: _to_tensor_str(o) for n, o in info["outputs"].items()},
+            }
+
+        info = {
+            "golden_folder({})".format(source_type): golden_folder,
+            "datas_info": _to_abstract(datas_info),
+            "smaple_inputs": self._sample_inputs,
+        }
+
+        # profile
+        report = {}
+        if "profile" in stage_config and run_func:
+            benchmark = stage_config["profile"].get("benchmark", {})
+            benchmark["repeat"] = self._get_repeat(benchmark)
+            try:
+                _, avg_time = run_func(
+                    self._model,
+                    self._sample_inputs,
+                    input_names,
+                    self._config["outputs"],
+                    **benchmark,
+                )
+                latency = "{:.2f} ms @ {}".format(avg_time, self._device)
+                info["latency"] = latency + " (X{})".format(benchmark["repeat"])
+                report["profile"] = latency
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                msg = "Failed to profile native: {}".format(exc)
+                self._logger.warning(self.worker_mark(msg))
+                report["profile"] = "failed run native"
+        return info, report
+
+    def parse(self) -> Tuple[dict, dict]:
+        """Parse the model to IRModule.
+
+        Returns
+        -------
+        info: dict
+            The info of parse.
+        report: dict
+            The report of parse.
+        """
+
+        stage_config = self._config[MSCStage.PARSE]
+        if self._config.get("use_cache", True):
+            cache_path = (
+                msc_utils.get_cache_dir().create_dir(MSCStage.PARSE).relpath("parsed_relax.json")
+            )
+        else:
+            cache_path = None
+        info = {}
+        if cache_path and os.path.isfile(cache_path):
+            with open(cache_path, "r") as f:
+                self._relax_mod = tvm.ir.load_json(f.read())
+            info["cache"] = cache_path
+        else:
+            info = {"parser": stage_config["parser"], "config": stage_config.get("parse_config")}
+            parse_config = msc_utils.copy_dict(stage_config.get("parse_config", {}))
+            parse_config["as_msc"] = False
+            if self._model_type in self._plugins:
+                plugin = self._plugins[self._model_type]
+                parse_config["custom_convert_map"] = plugin.get_convert_map()
+            self._relax_mod, _ = stage_config["parser"](self._model, **parse_config)
+            transformed = set()
+            for stage in [MSCStage.OPTIMIZE, MSCStage.COMPILE]:
+                if stage not in self._config:
+                    continue
+                run_type = self._config[stage]["run_type"]
+                if run_type in transformed:
+                    continue
+                transformed.add(run_type)
+                runner_cls = self._get_runner_cls(run_type)
+                if hasattr(runner_cls, "target_transform"):
+                    msg = "Transform for {}({})".format(run_type, stage)
+                    self._logger.info(self.worker_mark(msg))
+                    self._relax_mod = runner_cls.target_transform(self._relax_mod)
+            if cache_path:
+                with open(cache_path, "w") as f:
+                    f.write(tvm.ir.save_json(self._relax_mod))
+                msg = "Save parsed mod to " + cache_path
+                self._logger.debug(self.worker_mark(msg))
+        return info, {}
+
+    def get_tool_config(self, tool_type: str, key: str = "tool_config", default: Any = None) -> Any:
+        """Get the tool config
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type.
+        key: str
+            The config key
+
+        Returns
+        -------
+        config:
+            The tool config or info.
+        """
+
+        assert tool_type in self._tools_config, "Can not find tool_type " + str(tool_type)
+        return self._tools_config[tool_type].get(key, default)
+
+    def tool_applied(self, tool_type: str) -> bool:
+        """Check if the tool is applied
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type.
+
+        Returns
+        -------
+        applied: bool
+            Whether the tool is applied.
+        """
+
+        config = self.get_tool_config(tool_type)
+        return os.path.isfile(config["plan_file"])
+
+    def apply_tool(
+        self, tool_type: str, knowledge: dict = None, data_loader: Any = None
+    ) -> Tuple[dict, dict]:
+        """Apply tool with runner
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type to apply.
+        knowledge: dict
+            The pre knowledge.
+        data_loader:
+            The data loader.
+
+        Returns
+        -------
+        info: dict
+            The info of apply tool.
+        report: dict
+            The report of apply tool.
+        """
+
+        plan_file = self.get_tool_config(tool_type)["plan_file"]
+        if knowledge:
+            self._logger.info("Plan by %d knowledge for %s", len(knowledge), tool_type)
+            msc_utils.save_dict(knowledge, plan_file)
+        else:
+            self._runner.make_plan(tool_type, data_loader)
+        if self.get_tool_config(tool_type, "visualize", False):
+            self._runner.visualize(
+                msc_utils.get_visual_dir().create_dir(self._runner.stage.split(".")[0])
+            )
+        report = {}
+        if os.path.isfile(plan_file):
+            report["plan_num"] = len(msc_utils.load_dict(plan_file))
+        return {}, report
+
+    def create_runner(
+        self,
+        stage: str,
+        tools: List[str] = None,
+        run_type: str = None,
+        run_config: dict = None,
+        visualize: bool = True,
+        profile: bool = True,
+        use_cache: bool = True,
+    ) -> Tuple[dict, dict]:
+        """Create runner.
+
+        Parameters
+        ----------
+        stage: str
+            The stage name
+        tools: list<str>
+            The tools to apply.
+        run_type: str
+            The type of runner.
+        run_config: dict
+            The config of runner.
+        visualize: bool
+            Whether to visualize the runner
+        profile: bool
+            Whether to profile the runner.
+        use_cache: bool
+            Whether to use cache.
+
+        Returns
+        -------
+        info: dict
+            The info of create runner.
+        report: dict
+            The report of create runner.
+        """
+
+        if self._runner:
+            self._runner.destory()
+        tools = tools or []
+        assert all(t in self._tools_config for t in tools), "Missing some tools " + str(tools)
+        main_stage = stage.split(".")[0]
+        if not run_type:
+            run_type = self._config[main_stage]["run_type"]
+        if not run_config:
+            run_config = self._config[main_stage].get("run_config", {})
+        runner_cls = self._get_runner_cls(run_type)
+        if "generate_config" not in run_config:
+            run_config["generate_config"] = {}
+        cleanup = self._debug_levels.get(stage, 0) == 0
+        run_config["generate_config"]["build_folder"] = msc_utils.get_build_dir().create_dir(
+            stage, cleanup=cleanup
+        )
+        if "device" not in run_config:
+            run_config["device"] = self._device
+        if "training" not in run_config:
+            run_config["training"] = self._training
+        # Build runner
+        runner = runner_cls(
+            self._relax_mod,
+            tools_config=[self._tools_config[t] for t in tools],
+            plugin=self._plugins.get(run_type),
+            stage=stage,
+            name=self._name,
+            logger=self._logger,
+            **run_config,
+        )
+        cache_dir = msc_utils.get_cache_dir().create_dir(stage) if use_cache else None
+        runner.build(cache_dir=cache_dir)
+        if visualize:
+            runner.visualize(msc_utils.get_visual_dir().create_dir(main_stage))
+        if use_cache:
+            runner.save_cache(cache_dir)
+        info, report = {}, {"runtime": "{} @ {}".format(runner.framework, runner.device)}
+        if profile and "profile" in self._config[main_stage]:
+            profile_config = self._config[main_stage]["profile"]
+            info["profile"], report["profile"] = self._profile_runner(runner, profile_config)
+        self._runner = runner
+        return info, report
+
+    def _profile_runner(self, runner: BaseRunner, profile_config: dict) -> Tuple[dict, str]:
+        """Profile the runner.
+
+        Parameters
+        ----------
+        runner: BaseRunner
+            The runner to be profiled
+        profile_config: dict
+            The config of profile.
+
+        Returns
+        -------
+        info: dict
+            The info of profile.
+        report: str
+            The report of profile.
+        """
+
+        stage = runner.stage
+        info, report = {}, ""
+
+        # check accuracy
+        check_config = profile_config.get("check", {})
+        if check_config:
+            loader = msc_utils.IODataLoader(self._config["dataset"]["golden"]["loader"])
+            acc_info = {"passed": ""}
+            total, passed = 0, 0
+            for idx, (inputs, outputs) in enumerate(loader):
+                results = runner.run(inputs)
+                if outputs:
+                    iter_info = msc_utils.compare_arrays(
+                        outputs,
+                        results,
+                        atol=check_config.get("atol", 1e-2),
+                        rtol=check_config.get("rtol", 1e-2),
+                        report_detail=runner.debug_level >= 2,
+                    )
+                else:
+                    iter_info = {
+                        "total": len(results),
+                        "passed": len(results),
+                        "info": {k: msc_utils.MSCArray(v).abstract() for k, v in results.items()},
+                    }
+                total += iter_info["total"]
+                passed += iter_info["passed"]
+                acc_info["iter_" + str(idx)] = iter_info["info"]
+            pass_rate = float(passed) / total
+            accuracy = "{}/{}({:.2f}%)".format(passed, total, pass_rate * 100)
+            acc_info["passed"] = "{} {}".format(accuracy, check_config)
+            info["accuracy"] = acc_info if runner.debug_level >= 1 else accuracy
+            report = "pass " + accuracy
+            if runner.get_tool(ToolType.PRUNER) or runner.get_tool(ToolType.QUANTIZER):
+                disable_msg = "Disable accuracy check({}) by tools".format(stage)
+                self._logger.debug(self.worker_mark(disable_msg))
+            else:
+                required_err, err_rate = check_config.get("err_rate", 0), (1 - pass_rate)
+                if err_rate > required_err >= 0:
+                    self._logger.error(msc_utils.msg_block(self.worker_mark("ACCURACY"), acc_info))
+                    raise Exception(
+                        "Failed to profile the runner({}), err_rate {} > required {}".format(
+                            stage, err_rate, required_err
+                        )
+                    )
+
+        # benchmark model
+        benchmark_config = profile_config.get("benchmark", {})
+        if benchmark_config:
+            for _ in range(benchmark_config.get("warm_up", 10)):
+                runner.run(self._sample_inputs)
+            start = time.time()
+            repeat = self._get_repeat(benchmark_config, runner.device)
+            for _ in range(repeat):
+                runner.run(self._sample_inputs)
+            avg_time = (time.time() - start) * 1000 / repeat
+            latency = "{:.2f} ms @ {}".format(avg_time, runner.device)
+            info["latency"] = latency + " (X{})".format(repeat)
+            report += (", " if report else "") + latency
+        return info, report
+
+    def export_model(self, stage: str, folder: msc_utils.MSCDirectory, dump: bool = True) -> Any:
+        """Export the model
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        folder: MSCDirectory
+            The export folder.
+        dump: bool
+            Whether to dump info.
+
+        Returns
+        -------
+        exported:
+            The exported model.
+        """
+
+        if stage == MSCStage.COMPILE:
+            if not dump:
+                return self._runner.runnable
+            return self._runner.export_runnable(folder)
+
+        if stage == MSCStage.OPTIMIZE:
+            module = self._runner.export_module(folder)
+            if not dump:
+                return module
+            path = folder.relpath("model.json")
+            with open(path, "w") as f:
+                f.write(tvm.ir.save_json(module))
+            return path
+
+        if not dump:
+            return self._model
+        dump_func = self._get_runner_cls(self._model_type).dump_nativate
+        return dump_func(self._model, folder, self._config[MSCStage.EXPORT])
+
+    def export_tool(self, tool_type: str, folder: msc_utils.MSCDirectory) -> dict:
+        """Export the tool
+
+        Parameters
+        ----------
+        tool_type: str
+            The tool type.
+        folder: MSCDirectory
+            The export folder.
+
+        Returns
+        -------
+        config: dict
+            The exported tool config.
+        """
+
+        run_tool = self._runner.get_tool(tool_type)
+        assert tool_type in self._tools_config, "Can not find tool_type " + str(tool_type)
+        return run_tool.export_config(self._tools_config[tool_type]["tool_config"], folder)
+
+    def export_info(self, stage: str, folder: msc_utils.MSCDirectory) -> dict:
+        """Export the info of worker
+
+        Parameters
+        ----------
+        stage: str
+            The pipeline stage.
+        folder: MSCDirectory
+            The export folder.
+
+        Returns
+        -------
+        info: dict
+            The info.
+        """
+
+        return {
+            "visualize": msc_utils.get_visual_dir().copy_to(folder.relpath("visualize")),
+            "graphs": self._runner.export_graphs(folder.create_dir("graphs")),
+        }
+
+    def get_runnable(self, ret_type: str = "runner") -> Any:
+        """Return object by type.
+
+        Parameters
+        ----------
+        ret_type: str
+            The return type runner| runnable| model.
+
+        Returns
+        -------
+        runnable:
+            The runner or model.
+        """
+
+        assert self._runner, "Failed to create runner, call run_pipe first"
+        if ret_type == "runner":
+            return self._runner
+        if ret_type == "runnable":
+            return self._runner.runnable
+        if ret_type == "model":
+            return self._runner.model
+        raise TypeError("Unexpect return type " + str(ret_type))
+
+    def _get_repeat(self, benchmark: dict, device: str = None) -> int:
+        """Get the repeat number for benchmark
+
+        Parameters
+        ----------
+        benchmark: dict
+            The benchmark config.
+        device: str
+            The device name
+
+        Returns
+        -------
+        repeat: int
+            The repeat number.
+        """
+
+        device = device or self._device
+        repeat = benchmark.get("repeat", -1)
+        if repeat == -1:
+            repeat = 500 if device.startswith("cuda") else 10
+        return repeat
+
+    def _get_runner_cls(self, run_type: str) -> BaseRunner:
+        """Get the runner cls by type
+
+        Parameters
+        ----------
+        run_type: str
+            The run type.
+
+        Returns
+        -------
+        runner_cls: class
+            The runner class.
+        """
+
+        raise NotImplementedError("_get_runner_cls is not implemented in " + str(self.__class__))
+
+    def destory(self):
+        """Destroy the worker"""
+
+        if self._runner:
+            self._runner.destory()
+
+    def worker_mark(self, msg: Any) -> str:
+        """Mark the message with worker info
+
+        Parameters
+        -------
+        msg: str
+            The message
+
+        Returns
+        -------
+        msg: str
+            The message with mark.
+        """
+
+        return "WORKER[{}] {}".format(self._name, msg)
+
+    @property
+    def runner(self):
+        return self._runner
+
+    @property
+    def model_type(self):
+        return self._model_type
+
+    @property
+    def optimize_type(self):
+        return self._optimize_type
+
+    @property
+    def compile_type(self):
+        return self._compile_type
+
+
+class MSCPipeWorker(BasePipeWorker):
+    """Normal manager in MSC"""
+
+    def _get_runner_cls(self, run_type: str) -> BaseRunner:
+        """Get the runner cls by type
+
+        Parameters
+        ----------
+        run_type: str
+            The run type.
+
+        Returns
+        -------
+        runner_cls: class
+            The runner class.
+        """
+
+        if run_type == MSCFramework.TVM:
+            from tvm.contrib.msc.framework.tvm.runtime import TVMRunner
+
+            runner_cls = TVMRunner
+        elif run_type == MSCFramework.TORCH:
+            from tvm.contrib.msc.framework.torch.runtime import TorchRunner
+
+            runner_cls = TorchRunner
+        elif run_type == MSCFramework.TENSORFLOW:
+            from tvm.contrib.msc.framework.tensorflow.runtime import TensorflowRunner
+
+            runner_cls = TensorflowRunner
+        elif run_type == MSCFramework.TENSORRT:
+            from tvm.contrib.msc.framework.tensorrt.runtime import TensorRTRunner
+
+            runner_cls = TensorRTRunner
+        else:
+            raise Exception("Unexpect run_type " + str(run_type))
+        return runner_cls

--- a/python/tvm/contrib/msc/pipeline/wrapper.py
+++ b/python/tvm/contrib/msc/pipeline/wrapper.py
@@ -19,12 +19,12 @@
 import shutil
 from typing import Any, Union, List
 
-from tvm.contrib.msc.core.tools.tool import BaseTool, ToolType
 from tvm.contrib.msc.core.utils.message import MSCStage
 from tvm.contrib.msc.core.utils.namespace import MSCFramework
 from tvm.contrib.msc.core import utils as msc_utils
 from .manager import MSCManager
-from .config import create_config
+from .dynamic import MSCDynamic, TorchDynamic
+from .utils import create_config
 
 
 class BaseWrapper(object):
@@ -41,22 +41,19 @@ class BaseWrapper(object):
     """
 
     def __init__(
-        self,
-        model: Any,
-        config: dict,
-        workspace: str = "msc_workspace",
-        plugins: dict = None,
+        self, model: Any, config: dict, workspace: str = "msc_workspace", plugins: dict = None
     ):
         self._meta_model = model
         self._optimized_model, self._compiled_model = None, None
         self._config = config
         self._plugins = plugins
+        self._dynamic = self._config.get("dynamic", False)
         verbose = config.get("verbose", "info")
         self._debug = verbose.startswith("debug")
         self._workspace = msc_utils.msc_dir(workspace, keep_history=self._debug)
         log_path = self._workspace.relpath("MSC_LOG", keep_history=False)
         self._config["logger"] = msc_utils.create_file_logger(verbose, log_path)
-        self._manager = None
+        self._pipeline, self._report = None, None
         self.setup()
 
     def __str__(self):
@@ -87,18 +84,18 @@ class BaseWrapper(object):
             The workspace.
         """
 
-        self.logger.info("[Wrapper] Start optimize model")
+        self.logger.info(msc_utils.split_line("Start optimize model", "*"))
         config = msc_utils.copy_dict(self._config)
         config["workspace"] = self._workspace.create_dir(workspace)
         if MSCStage.OPTIMIZE not in config:
-            config[MSCStage.OPTIMIZE] = {
-                "run_type": self.model_type(),
-                "profile": {"check": {"atol": 1e-3, "rtol": 1e-3}, "benchmark": {"repeat": -1}},
-            }
-        self._manager = MSCManager(self._meta_model, config, self._plugins, run_compile=False)
-        report = self._manager.run_pipe()
-        if report["success"]:
-            self._optimized_model = self._manager.get_runnable("runnable")
+            config[MSCStage.OPTIMIZE] = {"run_type": self.model_type()}
+            profile = config.get(MSCStage.BASELINE, {}).get("profile")
+            if profile:
+                config[MSCStage.OPTIMIZE]["profile"] = profile
+        self._pipeline = self.pipe_cls(self._meta_model, config, self._plugins, run_compile=False)
+        self._report = self._pipeline.run_pipe()
+        if self._report["success"]:
+            self._optimized_model = self._pipeline.get_runtime("runnable")
         return self
 
     def compile(
@@ -117,27 +114,31 @@ class BaseWrapper(object):
         """
 
         if self._optimized_model:
-            self.logger.info("[Wrapper] Start compile checkpoint")
+            self.logger.info(msc_utils.split_line("Start compile checkpoint", "*"))
             ckpt_path = self._workspace.create_dir(ckpt_path).path
-            pipeline = self.export(ckpt_path, dump=dump)
-            pipeline["config"]["workspace"] = self._workspace.create_dir(workspace)
-            self._manager = MSCManager(**pipeline)
-            report = self._manager.run_pipe()
-            if report["success"]:
-                self._compiled_model = self._manager.get_runnable("runnable")
+            export = self.export(ckpt_path, dump=dump, keep_workspace=True)
+            export["config"]["workspace"] = self._workspace.create_dir(workspace)
+            self._pipeline = self.pipe_cls(
+                export["model"], export["config"], export["plugins"], root=ckpt_path
+            )
+            self._report = self._pipeline.run_pipe()
+            if self._report["success"]:
+                self._compiled_model = self._pipeline.get_runtime("runnable")
             if not self._debug:
                 shutil.rmtree(ckpt_path)
         else:
-            self.logger.info("[Wrapper] Start compile model")
+            self.logger.info(msc_utils.split_line("Start compile model", "*"))
             config = msc_utils.copy_dict(self._config)
             config["workspace"] = self._workspace.create_dir(workspace)
-            self._manager = MSCManager(self._meta_model, config, self._plugins)
-            report = self._manager.run_pipe()
-            if report["success"]:
-                self._compiled_model = self._manager.get_runnable("runnable")
+            self._pipeline = self.pipe_cls(self._meta_model, config, self._plugins)
+            self._report = self._pipeline.run_pipe()
+            if self._report["success"]:
+                self._compiled_model = self._pipeline.get_runtime("runnable")
         return self
 
-    def export(self, path: str = "msc_export", dump: bool = True) -> Union[str, dict]:
+    def export(
+        self, path: str = "msc_export", dump: bool = True, keep_workspace: bool = False
+    ) -> Union[str, dict]:
         """Export compile pipeline
 
         Parameters
@@ -146,6 +147,8 @@ class BaseWrapper(object):
             The export path.
         dump: bool
             Whether to dump the info.
+        keep_workspace: bool
+            Whether to keep workspace.
 
         Returns
         -------
@@ -153,66 +156,26 @@ class BaseWrapper(object):
             The exported path/pipeline info.
         """
 
-        if not self._manager:
-            self._manager = MSCManager(self._meta_model, self._config, self._plugins)
-        exported = self._manager.export(path, dump=dump)
+        if not self._pipeline:
+            self._pipeline = self.pipe_cls(self._meta_model, self._config, self._plugins)
+        exported = self._pipeline.export(path, dump=dump)
         if not self._debug:
-            self._manager.destory()
+            self._pipeline.destory()
+            if not keep_workspace:
+                self._workspace.destory()
         return exported
-
-    def get_tools(self, tool_types: List[str]) -> List[BaseTool]:
-        """Get the tools from manager
-
-        Parameters
-        ----------
-        tool_types: list<str>
-            The tool types.
-
-        Returns
-        -------
-        tools: list<BaseTool>
-            The tools.
-        """
-
-        if not self._manager:
-            return []
-        tool_types = tool_types or ToolType.all_types()
-        tools = []
-        for t in tool_types:
-            tool = self._manager.runner.get_tool(t)
-            if tool:
-                tools.append(tool)
-        return tools
-
-    def disable_tools(self, tool_types: List[str]):
-        """Disable the tools
-
-        Parameters
-        ----------
-        tool_types: list<str>
-            The tool types.
-        """
-
-        for tool in self.get_tools(tool_types):
-            tool.disable()
-
-    def enable_tools(self, tool_types: List[str]):
-        """Enable the tools
-
-        Parameters
-        ----------
-        tool_types: list<str>
-            The tool types.
-        """
-
-        for tool in self.get_tools(tool_types):
-            tool.enable()
 
     def _get_model(self) -> Any:
         return self._compiled_model or self._optimized_model or self._meta_model
 
     def _get_framework(self) -> str:
-        return self._manager.runner.framework if self._manager else self.model_type()
+        return self._pipeline.get_runtime().framework if self._pipeline else self.model_type()
+
+    @property
+    def pipe_cls(self):
+        if self._dynamic:
+            return MSCDynamic
+        return MSCManager
 
     @property
     def optimized(self):
@@ -224,13 +187,17 @@ class BaseWrapper(object):
 
     @property
     def device(self):
-        if self._manager:
-            return self._manager.runner.device
+        if self._pipeline:
+            return self._pipeline.get_runtime().device
         return "cpu"
 
     @property
     def logger(self):
         return self._config["logger"]
+
+    @property
+    def report(self):
+        return self._report
 
     @classmethod
     def create_config(
@@ -252,10 +219,10 @@ class BaseWrapper(object):
             The output names.
         baseline_type: str
             The baseline type.
-        compile_type: str
-            The compile type.
         optimize_type: str
             The optimize type.
+        compile_type: str
+            The compile type.
         kwargs: dict
             The config kwargs.
         """
@@ -281,27 +248,33 @@ class TorchWrapper(BaseWrapper):
             return outputs
         if isinstance(outputs, (tuple, list)):
             return [msc_utils.cast_array(o, MSCFramework.TORCH, self.device) for o in outputs]
-        return msc_utils.cast_array(outputs, MSCFramework.TORCH)
+        return msc_utils.cast_array(outputs, MSCFramework.TORCH, self.device)
 
     def parameters(self):
         framework = self._get_framework()
         if framework == MSCFramework.TORCH:
             return self._get_model().parameters()
-        return self._manager.runner.get_weights(MSCFramework.TORCH)
+        return self._pipeline.get_runtime().get_weights(MSCFramework.TORCH)
 
     def train(self):
-        if self._manager:
-            self._manager.runner.train()
+        if self._pipeline:
+            self._pipeline.get_runtime().train()
         if self._get_framework() == MSCFramework.TORCH:
             return self._get_model().train()
         return self._get_model()
 
     def eval(self):
-        if self._manager:
-            self._manager.runner.eval()
+        if self._pipeline:
+            self._pipeline.get_runtime().eval()
         if self._get_framework() == MSCFramework.TORCH:
             return self._get_model().eval()
         return self._get_model()
+
+    @property
+    def pipe_cls(self):
+        if self._dynamic:
+            return TorchDynamic
+        return MSCManager
 
     @classmethod
     def model_type(cls):

--- a/tests/python/contrib/test_msc/test_plugin.py
+++ b/tests/python/contrib/test_msc/test_plugin.py
@@ -313,7 +313,7 @@ def _test_with_manager(plugins, compile_type, expected_info):
     }
     manager = MSCManager(model, config, plugins=plugins)
     report = manager.run_pipe()
-    model_info = manager.runner.model_info
+    model_info = manager.get_runtime().model_info
     manager.destory()
     assert report["success"], "Failed to run pipe for torch -> {}".format(compile_type)
     assert msc_utils.dict_equal(

--- a/tests/python/contrib/test_msc/test_runner.py
+++ b/tests/python/contrib/test_msc/test_runner.py
@@ -100,7 +100,7 @@ def _test_from_torch(runner_cls, device, training=False, atol=1e-1, rtol=1e-1):
         golden = [msc_utils.cast_array(golden)]
         workspace.destory()
         for gol_r, out_r in zip(golden, outputs):
-            tvm.testing.assert_allclose(gol_r, out_r, atol=atol, rtol=rtol)
+            tvm.testing.assert_allclose(gol_r, msc_utils.cast_array(out_r), atol=atol, rtol=rtol)
 
 
 def test_tvm_runner_cpu():
@@ -162,7 +162,7 @@ def test_tensorflow_runner():
         outputs = runner.run([data], ret_type="list")
         workspace.destory()
         for gol_r, out_r in zip(golden, outputs):
-            tvm.testing.assert_allclose(gol_r, out_r, atol=1e-3, rtol=1e-3)
+            tvm.testing.assert_allclose(gol_r, msc_utils.cast_array(out_r), atol=1e-3, rtol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_msc/test_tools.py
+++ b/tests/python/contrib/test_msc/test_tools.py
@@ -144,7 +144,7 @@ def get_tools(tool_type, use_distill=False, run_type=MSCFramework.MSC):
                 }
             ],
         }
-        tools.append({"tool_type": ToolType.TRACKER, "tool_config": config, "apply_once": True})
+        tools.append({"tool_type": ToolType.TRACKER, "tool_config": config})
     if use_distill:
         config = {
             "plan_file": "msc_distiller.json",
@@ -180,7 +180,7 @@ def _get_torch_model(name, training=False):
 def _check_manager(manager, expected_info):
     """Check the manager results"""
 
-    model_info = manager.runner.model_info
+    model_info = manager.get_runtime().model_info
     passed, err = True, ""
     if not manager.report["success"]:
         passed = False


### PR DESCRIPTION
This is a pull request for MSC(Multi-System Compile)
RFC: https://discuss.tvm.apache.org/t/rfc-unity-msc-introduction-to-multi-system-compiler/15251/5
Tracking issue: https://github.com/apache/tvm/issues/15233

This is the Milestone 5 for MSC: Add MSCWrapper as compression toolchain.
To limit each PR in reviewable size, the Milestone 5 will be split into some steps:
[M5.1] Build wrapper to support compression.
[M5.2] Enable quantize && prune with gym by wrapper.
**[M5.3] Support torch.dynamo for dynamic models.**

JIT Module is designed to support dynamic compiling like torch.dynamo. It compile the model in JIT(Just-in-time) way so that both training and inference can be optimized and compiled.

Test of dynamo is added in test_msc/test_pipeline.py (replace the test_manager.py). And example of using dynamic pipeline is added in gallery/work_with_msc

cc @Hzfengsy 