### PR TITLE
[Contrib] Remove thrust "built but not used" warning

### DIFF
--- a/python/tvm/contrib/thrust.py
+++ b/python/tvm/contrib/thrust.py
@@ -21,8 +21,6 @@ from tvm._ffi import get_global_func
 
 
 def maybe_warn(target, func_name):
-    if get_global_func(func_name, allow_missing=True) and not "thrust" in target.libs:
-        logging.warning("TVM is built with thrust but thrust is not used.")
     if "thrust" in target.libs and get_global_func(func_name, allow_missing=True) is None:
         logging.warning("thrust is requested but TVM is not built with thrust.")
 


### PR DESCRIPTION
There has been a warning saying "Thrust is enabled when building TVM but is not specified in the input target" for years, while it is totally fine that the target does not contain thrust in `libs`, in which case we just do not dispatch.

This PR removes the warning.