### PR TITLE
[Analysis] Allow calls to GlobalVar in @R.function

### DIFF
--- a/include/tvm/relax/analysis.h
+++ b/include/tvm/relax/analysis.h
@@ -547,15 +547,15 @@ TVM_DLL bool ContainsImpureCall(const Expr& expr,
 /*!
  * \brief Check if the IRModule is well formed.
  *
- * \param m the IRModule to check.
+ * \param obj The IRModule or relax::Function to check.
  * \param check_struct_info A boolean flag indicating if the property "every Expr
  * must have defined structure info" will be checked.
- * \return true if the IRModule is well formed, false if not.
+ * \return true if the object is well formed, false if not.
  * \note By default the structure info is always checked. It is only in test cases
  * where `check_struct_info` might be false, so that other well-formed requirements
  * will be well tested and will not be blocked by not having structure info.
  */
-TVM_DLL bool WellFormed(IRModule m, bool check_struct_info = true);
+TVM_DLL bool WellFormed(Variant<IRModule, Function> obj, bool check_struct_info = true);
 
 /*!
  * \brief Using the layout transforms on the outputs, suggest layout transformation on the blocks

--- a/python/tvm/relax/analysis/analysis.py
+++ b/python/tvm/relax/analysis/analysis.py
@@ -434,13 +434,13 @@ def remove_all_unused(func: Function) -> Function:
     return _ffi_api.remove_all_unused(func)  # type: ignore
 
 
-def well_formed(mod: IRModule, check_struct_info: bool = True) -> bool:
+def well_formed(obj: Union[IRModule, Function], check_struct_info: bool = True) -> bool:
     """Check if the IRModule is well formed.
 
     Parameters
     ----------
-    mod : tvm.IRModule
-        The input IRModule.
+    obj : Union[tvm.IRModule, Function]
+        The input IRModule or relax.Function.
 
     check_struct_info : bool
         A boolean flag indicating if the property "every Expr must
@@ -457,7 +457,7 @@ def well_formed(mod: IRModule, check_struct_info: bool = True) -> bool:
     where `check_struct_info` might be false, so that other well-formed requirements
     will be well tested and will not be blocked by not having structure info.
     """
-    return _ffi_api.well_formed(mod, check_struct_info)  # type: ignore
+    return _ffi_api.well_formed(obj, check_struct_info)  # type: ignore
 
 
 def _get_prim_func_default_dtype(func: PrimFunc):

--- a/python/tvm/script/parser/core/entry.py
+++ b/python/tvm/script/parser/core/entry.py
@@ -103,9 +103,12 @@ def parse(
         check_ret = ret
         if not isinstance(check_ret, IRModule):
             check_ret = IRModule.from_expr(ret)
+
         source_ast = source.as_ast()
-        if not relax_well_formed(check_ret):
+
+        if not relax_well_formed(ret):
             parser.report_error(source_ast, err=WELL_FORMED_ERROR_MESSAGE)
+
         try:
             tir_well_formed(check_ret)
         except Exception as err:  # pylint: disable=broad-exception-caught

--- a/python/tvm/script/parser/core/entry.py
+++ b/python/tvm/script/parser/core/entry.py
@@ -35,12 +35,15 @@ WELL_FORMED_ERROR_MESSAGE = (
 
 
 def _default_globals() -> Dict[str, Any]:
-    import tvm  # pylint: disable=import-outside-toplevel
-    from tvm.script.parser import ir  # pylint: disable=import-outside-toplevel
-    from tvm.script.parser import relax  # pylint: disable=import-outside-toplevel
-    from tvm.script.parser import tir  # pylint: disable=import-outside-toplevel
-
-    extra_vars = {"tvm": tvm, "I": ir, "ir": ir, "T": tir, "tir": tir, "R": relax, "relax": relax}
+    extra_vars = {
+        "tvm": tvm,
+        "I": tvm.script.parser.ir,
+        "ir": tvm.script.parser.ir,
+        "T": tvm.script.parser.tir,
+        "tir": tvm.script.parser.tir,
+        "R": tvm.script.parser.relax,
+        "relax": tvm.script.parser.relax,
+    }
     return extra_vars
 
 

--- a/python/tvm/script/parser/core/entry.py
+++ b/python/tvm/script/parser/core/entry.py
@@ -35,14 +35,18 @@ WELL_FORMED_ERROR_MESSAGE = (
 
 
 def _default_globals() -> Dict[str, Any]:
+    from tvm.script.parser import ir  # pylint: disable=import-outside-toplevel
+    from tvm.script.parser import relax  # pylint: disable=import-outside-toplevel
+    from tvm.script.parser import tir  # pylint: disable=import-outside-toplevel
+
     extra_vars = {
         "tvm": tvm,
-        "I": tvm.script.parser.ir,
-        "ir": tvm.script.parser.ir,
-        "T": tvm.script.parser.tir,
-        "tir": tvm.script.parser.tir,
-        "R": tvm.script.parser.relax,
-        "relax": tvm.script.parser.relax,
+        "I": ir,
+        "ir": ir,
+        "T": tir,
+        "tir": tir,
+        "R": relax,
+        "relax": relax,
     }
     return extra_vars
 

--- a/python/tvm/script/parser/core/entry.py
+++ b/python/tvm/script/parser/core/entry.py
@@ -18,6 +18,7 @@
 import inspect
 from typing import Any, Dict, Union
 
+import tvm
 from ....ir.module import IRModule
 from ...ir_builder import IRBuilder
 from . import doc
@@ -95,22 +96,19 @@ def parse(
     ret = builder.get()
     # check well-formedness in both Relax and TIR
     if check_well_formed:
-        # (C0415 = import-outside-toplevel. It is necessary here to avoid a circular dependency,
-        # since importing Relax imports a dependency on the parser)
-        from ....relax.analysis import well_formed as relax_well_formed  # pylint: disable=C0415
-        from ....tir.analysis import verify_well_formed as tir_well_formed  # pylint: disable=C0415
-
         check_ret = ret
         if not isinstance(check_ret, IRModule):
             check_ret = IRModule.from_expr(ret)
 
         source_ast = source.as_ast()
 
-        if not relax_well_formed(ret):
+        if isinstance(ret, (IRModule, tvm.relax.Function)) and not tvm.relax.analysis.well_formed(
+            ret
+        ):
             parser.report_error(source_ast, err=WELL_FORMED_ERROR_MESSAGE)
 
         try:
-            tir_well_formed(check_ret)
+            tvm.tir.analysis.verify_well_formed(check_ret)
         except Exception as err:  # pylint: disable=broad-exception-caught
             parser.report_error(
                 source_ast,


### PR DESCRIPTION
Prior to this commit, the post-parsing well-formed check performed by TVMScript allowed a call to `GlobalVar` in a `@R.function`, but only if it occurred within the context of a `@I.ir_module`.  If `@R.function` appeared on its own, calls to a `GlobalVar` would be treated as calls to an undefined function.