### PR TITLE
[SLM] Provide consistent dynamic shape when specified as python string

### DIFF
--- a/python/tvm/relax/frontend/nn/core.py
+++ b/python/tvm/relax/frontend/nn/core.py
@@ -248,6 +248,24 @@ class Parameter(Tensor):
             dtype = get_default_dtype()
         super().__init__(_expr=Tensor.placeholder(shape, dtype=dtype, name="param")._expr)
         self._data = None
+
+        # Save the original shape, distinct from the shape of
+        # `self._expr`.  This allows correct handling of dynamic
+        # shapes specified as a python string (follows value equality,
+        # should be de-duplicated by name), and dynamic shapes
+        # specified as a TIR variable (follows reference equality,
+        # should not be de-duplicated by name).
+        #
+        # We cannot neither perform the de-duplication at this point
+        # nor can we convert from python strings to TIR variables.
+        # Performing de-duplication would produce one TIR variable for
+        # each name for each `nn.Parameter`, rather than one TIR
+        # variable for each name across all `nn.Parameter`s.
+        # Converting to TIR variables now would require de-duplication
+        # at a later point, which would errorneously merge distinct
+        # TIR variables that have the same name.
+        self._shape = shape
+
         self.attrs = OrderedDict()
 
     @property

--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -106,6 +106,10 @@ class Linear(Module):
         out_dtype: Optional[str] = None,
     ):
         super().__init__()
+
+        if isinstance(out_features, str):
+            out_features = tir.Var(out_features, "int64")
+
         self.in_features = in_features
         self.out_features = out_features
         self.out_dtype = out_dtype

--- a/src/relax/transform/canonicalize_bindings.cc
+++ b/src/relax/transform/canonicalize_bindings.cc
@@ -91,10 +91,12 @@ class CanonicalizePlanner : public ExprVisitor {
         bound_to = opt.value();
       }
 
-      if (bound_var.as<DataflowVarNode>() || !bound_to.as<DataflowVarNode>()) {
+      if (bound_var.as<DataflowVarNode>() || !bound_to.as<DataflowVarNode>() ||
+          !visitor.used_outside_home_dataflow_.count(bound_var)) {
         // Case 1: Var = Var
         // Case 2: DataflowVar = Var
         // Case 3: DataflowVar = DataflowVar
+        // Case 4a: Var = DataflowVar, but used outside this DataflowBlock
         //
         // For these three cases, the trivial binding can be
         // unwrapped, using the bound variable directly at the point
@@ -102,7 +104,7 @@ class CanonicalizePlanner : public ExprVisitor {
         plan.replace_usage.Set(bound_var->vid, bound_to);
         plan.bindings_to_remove.insert(bound_var->vid);
       } else {
-        // Case 4: Var = DataflowVar
+        // Case 4b: Var = DataflowVar, and used outside this DataflowBlock
         //
         // Replacing a Var with a DataflowVar could result in illegal
         // use of a DataflowVar outside of a DataflowBlock.  Instead,

--- a/tests/python/relax/test_frontend_nn_packing.py
+++ b/tests/python/relax/test_frontend_nn_packing.py
@@ -25,7 +25,7 @@ def _iter_binding_names(mod):
     """Helper function to compare the names of relax variables"""
     for block in mod["forward"].body.blocks:
         for binding in block.bindings:
-            yield binding.var.name_hint
+            yield binding.var.name_hint.replace(".", "_")
 
 
 def test_nn_export_to_relax():
@@ -55,10 +55,10 @@ def test_nn_export_to_relax():
             with R.dataflow():
                 linear_1_weight = packed_params[0]
                 linear_2_weight = packed_params[1]
-                matmul_1_weight = R.permute_dims(linear_1_weight)
-                matmul = R.matmul(x, matmul_1_weight)
-                matmul_2_weight = R.permute_dims(linear_2_weight)
-                matmul1 = R.matmul(x, matmul_2_weight)
+                permute_dims = R.permute_dims(linear_1_weight)
+                matmul = R.matmul(x, permute_dims)
+                permute_dims1 = R.permute_dims(linear_2_weight)
+                matmul1 = R.matmul(x, permute_dims1)
                 gv = R.add(matmul, matmul1)
                 R.output(gv)
             return gv


### PR DESCRIPTION
Resolve a breakage introduced in https://github.com/apache/tvm/pull/16757.  Prior to #16757, distinct TIR variables were unified if they had the same name.  This commit avoids using distinct TIR variables to represent the same user input.