### PR TITLE
[Bugfix][Cutlass] Remove a typo in cutlass build

### DIFF
--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -977,7 +977,7 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
         return f.with_attrs(attrs)
 
     def visit_function_(self, f):
-        if b"Composite" not in f.attrs:
+        if "Composite" not in f.attrs:
             body = super().visit_expr(f.body)
             return relax.Function(f.params, body, f.ret_struct_info, f.is_pure, f.attrs, f.span)
 


### PR DESCRIPTION
Introduced in https://github.com/apache/tvm/pull/16745, should be the string `"Composite"`, not the bytes `b"Composite"`.