### PR TITLE
[Fix] Fix build errors with VS2022

### DIFF
--- a/src/runtime/metadata.cc
+++ b/src/runtime/metadata.cc
@@ -118,11 +118,10 @@ class MetadataModuleNode : public ::tvm::runtime::ModuleNode {
               << symbol::tvm_get_c_metadata << " returned nullptr";
 
           metadata_ = runtime::metadata::Metadata(
-              static_cast<const struct ::TVMMetadata*>(ret_value.v_handle));
+              static_cast<const struct TVMMetadata*>(ret_value.v_handle));
         }
 
         *rv = metadata_;
-        return;
       });
     }
 

--- a/src/tir/analysis/identify_memcpy.cc
+++ b/src/tir/analysis/identify_memcpy.cc
@@ -293,7 +293,7 @@ TVM_REGISTER_GLOBAL("tir.analysis._identify_memcpy").set_body_typed([](const Stm
     using IRVisitorWithAnalyzer::VisitStmt_;
     void VisitStmt_(const ForNode* op) override {
       For loop = GetRef<For>(op);
-      auto result = IdentifyMemCpyImpl(loop, &analyzer_);
+      auto result = IdentifyMemCpyImpl(loop, &(Visitor::analyzer_));
       if (auto* ptr = std::get_if<MemCpyDetails>(&result)) {
         output->push_back(Array{ptr->source, ptr->dest});
       } else if (auto* ptr = std::get_if<std::string>(&result)) {

--- a/src/tir/contrib/ethosu/passes.cc
+++ b/src/tir/contrib/ethosu/passes.cc
@@ -81,7 +81,7 @@ FlattenUnwrapResult FlattenUnwrap(const Stmt& stmt) {
       for (const auto& sub_stmt : ptr->seq) {
         flatten_unwrap(sub_stmt);
       }
-    } else if (auto* ptr = stmt.as<EvaluateNode>(); ptr && ptr->value.as<IntImmNode>()) {
+    } else if (auto* ptr1 = stmt.as<EvaluateNode>(); ptr1 && ptr1->value.as<IntImmNode>()) {
       // Skip
     } else {
       seq_stmt.push_back(stmt);


### PR DESCRIPTION
This patch fixes all the build errors from VS2022. With this patch we can build tvm.dll successfully with VS2022.