### PR TITLE
[Doc] Fix set_axis_separator example

### DIFF
--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -3542,7 +3542,7 @@ class Schedule(Object):
         .. code-block:: python
 
             sch = tir.Schedule(before_set_axis_separator)
-            sch.set_axis_separators(sch.get_block("B"), buffer_index=0, buffer_index_type="write",
+            sch.set_axis_separators(sch.get_block("B"), buffer=("write", 0),
                                     axis_separators=[1])
             print(sch.mod["main"].script())
 


### PR DESCRIPTION
Minor fix to update the `set_axis_separator` example to match the definition