### PR TITLE
[Fix] fix for numpy 2.0 compatibility

### DIFF
--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -96,7 +96,7 @@ class DataType(ctypes.Structure):
         np.dtype(np.float32): "float32",
         np.dtype(np.float64): "float64",
     }
-    if np.__version__.startswith("1."):
+    if hasattr(np, "float_"):
         NUMPY2STR[np.dtype(np.float_)] = "float64"
     STR2DTYPE = {
         "void": {"type_code": DataTypeCode.HANDLE, "bits": 0, "lanes": 0},

--- a/python/tvm/relay/frontend/paddlepaddle.py
+++ b/python/tvm/relay/frontend/paddlepaddle.py
@@ -494,7 +494,7 @@ def convert_dist(g, op, block):
     p = op.attr("p")
     if p == np.inf:
         out = _op.reduce.max(z)
-    elif p == np.NINF:
+    elif p == -np.inf:
         out = _op.reduce.min(z)
     elif p == 0.0:
         out = _op.reduce.sum(_op.sign(z))

--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -1864,7 +1864,7 @@ class PyTorchOpConverter:
         order = inputs[1]
         if order == np.inf:
             return _op.reduce.max(_op.abs(data), axis=axis, keepdims=keepdims)
-        elif order == np.NINF:
+        elif order == -np.inf:
             return _op.reduce.min(_op.abs(data), axis=axis, keepdims=keepdims)
         else:
             reci_order = _expr.const(1.0 / order, dtype=dtype)
@@ -3910,7 +3910,7 @@ class PyTorchOpConverter:
             )
         elif ord == np.inf:
             return _op.reduce.max(_op.abs(data), axis=dim, keepdims=keepdim)
-        elif ord == np.NINF:
+        elif ord == -np.inf:
             return _op.reduce.min(_op.abs(data), axis=dim, keepdims=keepdim)
         reci_ord = _expr.const(1.0 / ord, dtype=dtype)
         ord = _expr.const(ord, dtype=dtype)

--- a/tests/python/contrib/test_msc/test_translate_tensorflow.py
+++ b/tests/python/contrib/test_msc/test_translate_tensorflow.py
@@ -1669,7 +1669,7 @@ def _test_infinity(tf_op, name):
     for tf_dtype in tf_dtypes:
         shape = (8, 8)
         data = np.random.uniform(size=shape).astype(tf_dtype)
-        data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.infty
+        data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.inf
         data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.nan
 
         tf.reset_default_graph()

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -5544,7 +5544,7 @@ def test_linalg_vector_norm():
     verify_model(test_fn(order=2), input_data=input_data)
     verify_model(test_fn(order=3.5), input_data=input_data)
     verify_model(test_fn(order=np.inf), input_data=input_data)
-    verify_model(test_fn(order=np.NINF), input_data=input_data)
+    verify_model(test_fn(order=-np.inf), input_data=input_data)
     verify_model(test_fn(order=0), input_data=input_data)
 
     # Also test on double
@@ -5552,7 +5552,7 @@ def test_linalg_vector_norm():
     verify_model(test_fn(order=2), input_data=input_data)
     verify_model(test_fn(order=3.5), input_data=input_data)
     verify_model(test_fn(order=np.inf), input_data=input_data)
-    verify_model(test_fn(order=np.NINF), input_data=input_data)
+    verify_model(test_fn(order=-np.inf), input_data=input_data)
     verify_model(test_fn(order=0), input_data=input_data)
 
 

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -5191,7 +5191,7 @@ def _verify_infiniteness_ops(tf_op, name):
     for tf_dtype in tf_dtypes:
         shape = (8, 8)
         data = np.random.uniform(size=shape).astype(tf_dtype)
-        data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.infty
+        data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.inf
         data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.nan
 
         tf.reset_default_graph()

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -1361,7 +1361,7 @@ def _verify_infiniteness_ops(relay_op, ref_op, target="llvm", dev=None):
         if dtype.startswith("float"):
             data.ravel()[
                 np.random.choice(data.size, int(data.size * 0.5), replace=False)
-            ] = np.infty
+            ] = np.inf
             data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.nan
 
         op_res = create_executor(target=target, device=dev).evaluate(y, {x: data})

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -1359,9 +1359,7 @@ def _verify_infiniteness_ops(relay_op, ref_op, target="llvm", dev=None):
 
         data = np.random.uniform(size=shape).astype(dtype)
         if dtype.startswith("float"):
-            data.ravel()[
-                np.random.choice(data.size, int(data.size * 0.5), replace=False)
-            ] = np.inf
+            data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.inf
             data.ravel()[np.random.choice(data.size, int(data.size * 0.5), replace=False)] = np.nan
 
         op_res = create_executor(target=target, device=dev).evaluate(y, {x: data})

--- a/tests/python/topi/test_topi_math.py
+++ b/tests/python/topi/test_topi_math.py
@@ -154,7 +154,7 @@ def ewise_ref_data(topi_name, dtype):
         if config.get("replace_with_inf", False):
             a_np.ravel()[
                 np.random.choice(a_np.size, int(a_np.size * 0.5), replace=False)
-            ] = np.infty
+            ] = np.inf
 
     # avoid round check too close to boundary
     if topi_name == "round":

--- a/tests/python/topi/test_topi_math.py
+++ b/tests/python/topi/test_topi_math.py
@@ -152,9 +152,7 @@ def ewise_ref_data(topi_name, dtype):
         if config.get("replace_with_nan", False):
             a_np.ravel()[np.random.choice(a_np.size, int(a_np.size * 0.5), replace=False)] = np.nan
         if config.get("replace_with_inf", False):
-            a_np.ravel()[
-                np.random.choice(a_np.size, int(a_np.size * 0.5), replace=False)
-            ] = np.inf
+            a_np.ravel()[np.random.choice(a_np.size, int(a_np.size * 0.5), replace=False)] = np.inf
 
     # avoid round check too close to boundary
     if topi_name == "round":


### PR DESCRIPTION
I checked the entire tvm codebase with `ruff check . --select NPY201` and no other deprecations were detected.
Changes are below.
- use `-np.inf` instead of `np.NINF`
- use `np.inf` instead of `np.infty`
- better attribute existence check #16780 

ref: [NumPy 2.0 migration guide — NumPy v2.1.dev0 Manual](https://numpy.org/devdocs/numpy_2_0_migration_guide.html)