### PR TITLE
[3rdparty] AUTO mode for custom all-reduce strategy

### DIFF
--- a/python/tvm/relax/transform/ipc_allreduce_rewrite.py
+++ b/python/tvm/relax/transform/ipc_allreduce_rewrite.py
@@ -40,8 +40,6 @@ class IPCAllReduceRewrite:
             The all-reduce strategy. Only "1" and "2" are supported.
             "1" stands for one-shot, and "2" stands for two-shot.
         """
-        if allreduce_strategy not in [1, 2]:
-            raise ValueError(f"All-reduce strategy {allreduce_strategy} is not supported.")
         self.allreduce_strategy = allreduce_strategy
 
     def transform_module(self, mod: IRModule, _ctx: tvm.transform.PassContext) -> IRModule:

--- a/tests/python/disco/test_custom_allreduce.py
+++ b/tests/python/disco/test_custom_allreduce.py
@@ -29,15 +29,19 @@ from tvm.runtime.disco import Session
 
 
 class AllReduceStrategyType(enum.IntEnum):
+    RING = 0
     ONESHOT = 1
     TWOSHOT = 2
+    AUTO = 3
 
 
 _shapes = [(2, 3), (3, 4), (128, 128)]
 
 _strategies = [
+    AllReduceStrategyType.RING,
     AllReduceStrategyType.ONESHOT,
     AllReduceStrategyType.TWOSHOT,
+    AllReduceStrategyType.AUTO,
 ]
 
 _ccl = [ccl for ccl in tvm.get_global_func("runtime.disco.compiled_ccl")() if ccl == "nccl"]


### PR DESCRIPTION
This PR adds the automatic mode selection for customized all-reduce kernels, referring TensorRT-LLM.

Meanwhile, this PR fixes a bug that may cause customized all-reduce kernel to hang forever. Prior to this PR, each worker resets its barrier values to 0 *after using all-gather to exchange their barrier handles*. Afterwards, the customized all-reduce kernels update the barriers of all workers. So it is possible that, worker 0 updates worker 1's barrier *before* worker 1 resets its barrier to 0. This lead to the all-reduce kernel hanging forever.

This PR changes the behavior to resetting barriers before all-gather, and forcing a device synchronization after reset.