### PR TITLE
[Runtime][LLVM] Fix errors during loading of target tags

### DIFF
--- a/python/tvm/target/tag.py
+++ b/python/tvm/target/tag.py
@@ -67,9 +67,6 @@ def register_tag(name: str, config: Dict[str, Any], override: bool = False) -> O
     return None
 
 
-# To check the correctness of all registered tags, the call is made in library loading time.
-list_tags()
-
 # We purposely maintain all tags in the C++ side to support pure C++ use cases,
 # and the Python API is only used for fast prototyping.
 register_tag(
@@ -79,3 +76,6 @@ register_tag(
         "arch": "sm_61",
     },
 )
+
+# To check the correctness of all registered tags, the call is made in library loading time.
+list_tags()

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1871,7 +1871,11 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const BroadcastNode* op) {
   value = builder_->CreateInsertElement(undef, value, zero);
 #if TVM_LLVM_VERSION >= 110
   llvm::ElementCount ec =
+#if TVM_LLVM_VERSION >= 120
       llvm::ElementCount::get(dtype.get_lanes_or_vscale_factor(), dtype.is_scalable_vector());
+#else
+      llvm::ElementCount(dtype.get_lanes_or_vscale_factor(), dtype.is_scalable_vector());
+#endif
   llvm::Constant* mask = llvm::ConstantVector::getSplat(ec, zero);
 #else
   ICHECK(!dtype.is_scalable_vector())

--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -223,9 +223,11 @@ LLVMTargetInfo::LLVMTargetInfo(LLVMInstance& instance, const TargetJSON& target)
     if (!has_arch) {
       // Flag an error, but don't abort. This mimicks the behaviour of 'llc' to
       // give the code a chance to run with a less-specific target.
-      LOG(ERROR) << "LLVM cpu architecture `-mcpu=" << cpu_
+      LOG(ERROR) << "Using LLVM " << LLVM_VERSION_STRING << " with `-mcpu=" << cpu_
                  << "` is not valid in `-mtriple=" << triple_ << "`"
                  << ", using default `-mcpu=" << String(defaults::cpu) << "`";
+      // LLVM default cpu fallback
+      cpu_ = String(defaults::cpu);
     }
   }
 

--- a/src/target/tag.cc
+++ b/src/target/tag.cc
@@ -82,6 +82,7 @@ TVM_REGISTER_TARGET_TAG("raspberry-pi/4b-aarch64")
                                                  {"mattr", Array<String>{"+neon"}},
                                                  {"num-cores", Integer(4)}}}});
 
+#if TVM_LLVM_VERSION >= 110
 TVM_REGISTER_TARGET_TAG("nvidia/jetson-agx-xavier")
     .set_config({{"kind", String("cuda")},
                  {"arch", String("sm_72")},
@@ -129,6 +130,7 @@ TVM_REGISTER_TARGET_TAG("nvidia/jetson-agx-orin-64gb")
                                                  {"mtriple", String("aarch64-linux-gnu")},
                                                  {"mcpu", String("cortex-a78")},
                                                  {"num-cores", Integer(12)}}}});
+#endif
 
 #define TVM_REGISTER_CUDA_TAG(Name, Arch, SharedMem, RegPerBlock) \
   TVM_REGISTER_TARGET_TAG(Name).set_config({                      \

--- a/tests/python/target/test_llvm_features_info.py
+++ b/tests/python/target/test_llvm_features_info.py
@@ -43,10 +43,12 @@ def test_llvm_targets(capfd):
         tvm.target.Target("llvm -mtriple=x86_64-linux-gnu -mcpu=dummy")
     )
     expected_str = (
-        "Error: LLVM cpu architecture `-mcpu=dummy` is not valid in "
+        " with `-mcpu=dummy` is not valid in "
         "`-mtriple=x86_64-linux-gnu`, using default `-mcpu=generic`"
     )
-    assert expected_str in capfd.readouterr().err
+    readout_error = capfd.readouterr().err
+    assert "Error: Using LLVM " in readout_error
+    assert expected_str in readout_error
 
 
 min_llvm_version, llvm_target, cpu_arch, cpu_features, is_supported = tvm.testing.parameters(


### PR DESCRIPTION
This PR fixes TVM loading errors when lower LLVM version does not support TVM predefined target tags.

Report and related discussions are here: https://github.com/apache/tvm/pull/16425#issuecomment-2023292845

---

#### Rationale:

 * During tvm load/initialization [list_tags()](https://github.com/apache/tvm/blob/83e7e9b2eb8dbeeb16dcfdbaf3336caa81071877/python/tvm/target/tag.py#L71) checks all ```src/target/tag.cc``` target definitions
 * The target tags **should be protected** against improper LLVM versions at their declaration time

#### Other fixes:

* Enforce the ```mcpu=generic``` [fallback assignment](https://github.com/apache/tvm/pull/16808/files#diff-f13c79368edd27b0c05d044df267746187448906d4310d5617bce89003b8813bR230-R231), so LLVM will not noise us with improper invocation 
* Minor compilation fix for LLVM version ranges: ~~10~~ 11 < llvm < ~~16~~ 13 (introduced by SVE support)
* Add a clear hint with LLVM_VERSION_STRING to the error message for the user


Cc @Lunderberg , @lhutton1 
