### PR TITLE
[LLVM] Fix compilation failure due to minor change

### DIFF
--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -311,7 +311,7 @@ LLVMTargetInfo::LLVMTargetInfo(LLVMInstance& instance, const TargetJSON& target)
   }
 #else
   if (maybe_level.defined()) {
-    int level = maybe_level.value()->value;
+    int level = maybe_level->value;
     if (level <= 0) {
       opt_level_ = llvm::CodeGenOptLevel::None;
     } else if (level == 1) {


### PR DESCRIPTION
This is just a minor fix where the recent [PR #16425](https://github.com/apache/tvm/pull/16425) seems to have missed this change for LLVM 18 and above case, and so we're running into a compilaion failure.