### PR TITLE
[Fix] PAPI docs

### DIFF
--- a/docker/install/ubuntu_install_papi.sh
+++ b/docker/install/ubuntu_install_papi.sh
@@ -27,7 +27,7 @@ apt-install-and-clear -y linux-tools-common linux-tools-generic kmod
 
 cd /
 # Pulling the latest version of this has broken the images before. Checkout the tagged version below for now.
-git clone --branch papi-6-0-0-1-t https://bitbucket.org/icl/papi.git
+git clone --branch papi-6-0-0-1-t https://github.com/icl-utk-edu/papi
 cd papi/src
 export PAPI_CUDA_ROOT=/usr/local/cuda
 export PAPI_ROCM_ROOT=/opt/rocm

--- a/docs/how_to/profile/papi.rst
+++ b/docs/how_to/profile/papi.rst
@@ -102,7 +102,7 @@ You can also change which metrics are collected:
     report = vm.profile(
         data,
         func_name="main",
-        collectors=[tvm.runtime.profiling.PAPIMetricCollector({dev: ["PAPI_FP_OPS"])],
+        collectors=[tvm.runtime.profiling.PAPIMetricCollector({dev: ["PAPI_FP_OPS"]})],
     )
 
 .. code::

--- a/docs/how_to/profile/papi.rst
+++ b/docs/how_to/profile/papi.rst
@@ -32,7 +32,7 @@ Installing PAPI
 
 PAPI can either be installed using your package manager (``apt-get install libpapi-dev``
 on Ubuntu), or from source here:
-https://bitbucket.org/icl/papi/src/master/.
+https://github.com/icl-utk-edu/papi.
 
 Pulling the latest version of PAPI from source has caused build issues before. Therefore, it is recommended to checkout tagged version ``papi-6-0-0-1-t``.
 

--- a/src/runtime/contrib/papi/papi.cc
+++ b/src/runtime/contrib/papi/papi.cc
@@ -91,7 +91,7 @@ int component_for_device(Device dev) {
  * PAPI (Performance Application Programming Interface) collects metrics on a
  * variety of platforms including cpu, cuda and rocm.
  *
- * PAPI is avaliable at https://bitbucket.org/icl/papi/src/master/.
+ * PAPI is avaliable at https://github.com/icl-utk-edu/papi.
  */
 struct PAPIMetricCollectorNode final : public MetricCollectorNode {
   /*! \brief Construct a metric collector that collects a specific set of metrics.


### PR DESCRIPTION
Changes are below
- Change the PAPI repo URL because it has been moved to GitHub
- Add a missing closing curly bracket