### PR TITLE
[Relax] Handle binary operations between Tensor and PrimValue

### DIFF
--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -251,10 +251,10 @@ inline DataType GetElementDType(const StructInfo& sinfo) {
     return prim->dtype;
   } else if (const auto* tensor = sinfo.as<TensorStructInfoNode>()) {
     return tensor->dtype;
-  } else if (sinfo.as<ObjectStructInfoNode>()) {
-    return DataType::Void();
   } else {
     LOG(FATAL) << "TypeError: "
+               << "Only PrimStructInfo and TensorStructInfo "
+               << "have an associated data type.  "
                << "Cannot determine element type of " << sinfo;
   }
 }

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -42,13 +42,22 @@ StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx,
   auto lhs_sinfo = GetStructInfo(call->args[0]);
   auto rhs_sinfo = GetStructInfo(call->args[1]);
 
+  CHECK(lhs_sinfo.as<PrimStructInfoNode>() || lhs_sinfo.as<TensorStructInfoNode>())
+      << "TypeError: "
+      << "Arguments to binary operators must be either R.Tensor or R.Prim types, "
+      << "but expression " << call << " has LHS " << call->args[0] << ", which has StructInfo "
+      << lhs_sinfo;
+  CHECK(rhs_sinfo.as<PrimStructInfoNode>() || rhs_sinfo.as<TensorStructInfoNode>())
+      << "TypeError: "
+      << "Arguments to binary operators must be either R.Tensor or R.Prim types, "
+      << "but expression " << call << " has RHS " << call->args[1] << ", which has StructInfo "
+      << rhs_sinfo;
+
   // DateType
   DataType output_dtype = f_compute_out_dtype(call, ctx, lhs_sinfo, rhs_sinfo);
 
   if (lhs_sinfo.as<PrimStructInfoNode>() && rhs_sinfo.as<PrimStructInfoNode>()) {
     return PrimStructInfo(output_dtype);
-  } else if (lhs_sinfo.as<ObjectStructInfoNode>() && rhs_sinfo.as<ObjectStructInfoNode>()) {
-    return ObjectStructInfo();
   }
 
   // VDevice

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -32,43 +32,94 @@ namespace relax {
 template <typename FType>
 StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx,
                                     FType f_compute_out_dtype) {
-  Array<TensorStructInfo> input_sinfo = GetInputTensorStructInfo(call, ctx);
-  TensorStructInfo x1_sinfo = input_sinfo[0];
-  TensorStructInfo x2_sinfo = input_sinfo[1];
-
-  // DateType
-  DataType output_dtype = f_compute_out_dtype(call, ctx, x1_sinfo, x2_sinfo);
-
-  // VDevice
-  Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, x1_sinfo, x2_sinfo);
-
-  // ndims
-  int output_ndim;
-  if (x1_sinfo->IsUnknownNdim() || x2_sinfo->IsUnknownNdim()) {
-    output_ndim = kUnknownNDim;
-  } else {
-    output_ndim = std::max(x1_sinfo->ndim, x2_sinfo->ndim);
+  Op op = Downcast<Op>(call->op);
+  size_t n_input = op->arguments.size();
+  if (call->args.size() != n_input) {
+    ctx->ReportFatal(Diagnostic::Error(call)
+                     << call->op << " op should have " << n_input << " arguments");
   }
 
-  const auto* x1_shape = x1_sinfo->shape.as<ShapeExprNode>();
-  const auto* x2_shape = x2_sinfo->shape.as<ShapeExprNode>();
-  // Shapes and ndims
-  if (x1_shape && x2_shape) {
-    // If all inputs have shapes, directly infer shapes
-    Optional<Array<PrimExpr>> output_shape =
-        InferBinaryBroadcastShape(call, ctx, x1_shape->values, x2_shape->values);
-    if (!output_shape.defined()) {
-      return TensorStructInfo(output_dtype, /*ndim=*/output_ndim, vdevice);
+  auto lhs_sinfo = GetStructInfo(call->args[0]);
+  auto rhs_sinfo = GetStructInfo(call->args[1]);
 
+  // DateType
+  DataType output_dtype = f_compute_out_dtype(call, ctx, lhs_sinfo, rhs_sinfo);
+
+  if (lhs_sinfo.as<PrimStructInfoNode>() && rhs_sinfo.as<PrimStructInfoNode>()) {
+    return PrimStructInfo(output_dtype);
+  } else if (lhs_sinfo.as<ObjectStructInfoNode>() && rhs_sinfo.as<ObjectStructInfoNode>()) {
+    return ObjectStructInfo();
+  }
+
+  // VDevice
+  Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, lhs_sinfo, rhs_sinfo);
+
+  auto get_ndim = [&](const StructInfo& sinfo) -> int {
+    if (sinfo.as<PrimStructInfoNode>()) {
+      return 1;
+    } else if (const auto* tensor = sinfo.as<TensorStructInfoNode>()) {
+      return tensor->ndim;
     } else {
+      return kUnknownNDim;
+    }
+  };
+
+  // ndims
+  int output_ndim = [&]() {
+    int lhs_ndim = get_ndim(lhs_sinfo);
+    int rhs_ndim = get_ndim(rhs_sinfo);
+    if (lhs_ndim == kUnknownNDim || rhs_ndim == kUnknownNDim) {
+      return kUnknownNDim;
+    } else {
+      return std::max(lhs_ndim, rhs_ndim);
+    }
+  }();
+
+  // Shapes
+
+  auto get_shape = [](const StructInfo& sinfo) -> Optional<Array<PrimExpr>> {
+    if (sinfo.as<PrimStructInfoNode>()) {
+      return Array<PrimExpr>{IntImm(DataType::Int(64), 1)};
+    } else if (const auto* tensor = sinfo.as<TensorStructInfoNode>()) {
+      return tensor->GetShape();
+    } else {
+      return NullOpt;
+    }
+  };
+
+  // If both inputs have a known shape, directly infer the shape of
+  // the output.
+  auto lhs_shape = get_shape(lhs_sinfo);
+  auto rhs_shape = get_shape(rhs_sinfo);
+  if (lhs_shape && rhs_shape) {
+    Optional<Array<PrimExpr>> output_shape =
+        InferBinaryBroadcastShape(call, ctx, lhs_shape.value(), rhs_shape.value());
+    if (output_shape.defined()) {
       ICHECK_EQ(static_cast<int>(output_shape.value().size()), output_ndim);
       return TensorStructInfo(ShapeExpr(output_shape.value()), output_dtype, vdevice);
     }
-  } else if (x1_sinfo->shape.defined() && x1_sinfo->shape.same_as(x2_sinfo->shape)) {
-    return TensorStructInfo(x1_sinfo->shape.value(), output_dtype, vdevice);
-  } else {
-    return TensorStructInfo(output_dtype, /*ndim=*/output_ndim, vdevice);
   }
+
+  auto get_shape_expr = [](const StructInfo& sinfo) -> Optional<Expr> {
+    if (const auto* tensor = sinfo.as<TensorStructInfoNode>()) {
+      return tensor->shape;
+    } else {
+      return NullOpt;
+    }
+  };
+
+  // If the input shape is unknown, but both inputs have the same
+  // `ShapeStructInfo`variable for their shape, then propagate that
+  // variable to the output.
+  auto lhs_shape_expr = get_shape_expr(lhs_sinfo);
+  auto rhs_shape_expr = get_shape_expr(rhs_sinfo);
+  if (lhs_shape_expr.defined() && lhs_shape_expr.same_as(rhs_shape_expr)) {
+    return TensorStructInfo(lhs_shape_expr.value(), output_dtype, vdevice);
+  }
+
+  // If neither of those cases holds, then fall back to an unknown
+  // shape with `output_ndim` dimensionality.
+  return TensorStructInfo(output_dtype, output_ndim, vdevice);
 }
 
 StructInfo InferStructInfoBroadcastArith(const Call& call, const BlockBuilder& ctx) {
@@ -78,8 +129,8 @@ StructInfo InferStructInfoBroadcastArith(const Call& call, const BlockBuilder& c
 StructInfo InferStructInfoBroadcastCMP(const Call& call, const BlockBuilder& ctx) {
   return InferStructInfoBroadcast(
       call, ctx,
-      [](const Call& call, const BlockBuilder& ctx, const TensorStructInfo& x1_sinfo,
-         const TensorStructInfo& x2_sinfo) { return DataType::Bool(); });
+      [](const Call& call, const BlockBuilder& ctx, const StructInfo& lhs_sinfo,
+         const StructInfo& rhs_sinfo) { return DataType::Bool(); });
 }
 
 InferLayoutOutput InferLayoutBinaryEwise(const Call& call,

--- a/src/script/printer/relax/tir.cc
+++ b/src/script/printer/relax/tir.cc
@@ -41,6 +41,10 @@ RelaxFrameNode* GetRelaxFrame(IRDocsifier d) {
 }
 
 Doc PrintTIRVar(tir::Var n, ObjectPath n_p, IRDocsifier d) {
+  ICHECK(n->dtype.is_scalar()) << "TypeError: "
+                               << "Relax only uses scalar TIR variables,"
+                               << "but received TIR variable " << n << " with dtype " << n->dtype;
+
   if (!d->IsVarDefined(n)) {
     RelaxFrameNode* f = GetRelaxFrame(d);
     // There should be at least one Relax frame

--- a/src/script/printer/relax/tir.cc
+++ b/src/script/printer/relax/tir.cc
@@ -41,9 +41,6 @@ RelaxFrameNode* GetRelaxFrame(IRDocsifier d) {
 }
 
 Doc PrintTIRVar(tir::Var n, ObjectPath n_p, IRDocsifier d) {
-  ICHECK(n->dtype.is_int() && n->dtype.is_scalar()) << "TypeError: Relax only uses "
-                                                       "scalar integer TIR variables, but gets: "
-                                                    << n;
   if (!d->IsVarDefined(n)) {
     RelaxFrameNode* f = GetRelaxFrame(d);
     // There should be at least one Relax frame

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -488,7 +488,9 @@ void RewriteStageToBlock(const te::Operation& op, CreateFuncInfo* info, Array<St
     ICHECK_EQ(op->num_outputs(), 1);
     const te::Tensor& tensor = op.output(0);
     // Check op is in op list
-    ICHECK(info->IsArg(tensor));
+    ICHECK(info->IsArg(tensor)) << "The operation " << op << " produces tensor " << tensor
+                                << ", but this tensor does not appear as a function argument.  "
+                                << "The function accepts arguments " << info->arg_list;
     // Declare a buffer for any argument tensors without a pre-existing
     // buffer declaration recorded in the tensor2buffer binds map
     if (info->tensor2buffers.count(tensor) == 0) {

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -581,17 +581,16 @@ PrimFunc GenerateAndCompletePrimFunc(const Array<ObjectRef>& arg_tir_var_list,
                                      const Array<Stmt>& root_stmts, CreateFuncInfo* info) {
   Array<Var> parameters;
   Map<Var, Buffer> buffer_map;
-  for (const ObjectRef& x : arg_tir_var_list) {
-    if (auto n = x.as<te::TensorNode>()) {
-      te::Tensor tensor = GetRef<te::Tensor>(n);
+  for (const ObjectRef& arg : arg_tir_var_list) {
+    if (auto opt_tensor = arg.as<te::Tensor>()) {
+      te::Tensor tensor = opt_tensor.value();
       Var arg("var_" + tensor->GetNameHint(), PrimType(DataType::Handle()));
       parameters.push_back(arg);
       auto it = info->tensor2buffers.find(tensor);
       ICHECK(it != info->tensor2buffers.end());
       buffer_map.Set(arg, it->second);
-    } else if (auto n = x.as<tir::VarNode>()) {
-      tir::Var var = GetRef<tir::Var>(n);
-      parameters.push_back(var);
+    } else if (auto var = arg.as<tir::Var>()) {
+      parameters.push_back(var.value());
     }
   }
   PrimFunc func = WithAttrs(PrimFunc(/*params=*/std::move(parameters),

--- a/tests/python/relax/test_op_binary.py
+++ b/tests/python/relax/test_op_binary.py
@@ -250,10 +250,10 @@ def test_binary_infer_struct_info_shape_var(binary_arith_op: Callable):
     y4 = relax.Var("y", relax.TensorStructInfo(s4, "float32"))
 
     _check_inference(bb, binary_arith_op(x, y0), relax.TensorStructInfo(s0, "float32"))
-    # _check_inference(bb, binary_arith_op(x, y1), relax.TensorStructInfo(dtype="float32", ndim=2))
-    # _check_inference(bb, binary_arith_op(x, y2), relax.TensorStructInfo(dtype="float32", ndim=4))
-    # _check_inference(bb, binary_arith_op(x, y3), relax.TensorStructInfo(dtype="float32", ndim=2))
-    # _check_inference(bb, binary_arith_op(x, y4), relax.TensorStructInfo(dtype="float32"))
+    _check_inference(bb, binary_arith_op(x, y1), relax.TensorStructInfo(dtype="float32", ndim=2))
+    _check_inference(bb, binary_arith_op(x, y2), relax.TensorStructInfo(dtype="float32", ndim=4))
+    _check_inference(bb, binary_arith_op(x, y3), relax.TensorStructInfo(dtype="float32", ndim=2))
+    _check_inference(bb, binary_arith_op(x, y4), relax.TensorStructInfo(dtype="float32"))
 
 
 def test_binary_arith_infer_struct_info_more_input_dtype(binary_arith_op: Callable):

--- a/tests/python/relax/test_op_binary.py
+++ b/tests/python/relax/test_op_binary.py
@@ -282,7 +282,7 @@ def test_binary_arith_infer_struct_info_dtype_mismatch(binary_arith_op: Callable
     bb = relax.BlockBuilder()
     x = relax.Var("x", R.Tensor((2, 3), "float32"))
     y = relax.Var("y", R.Tensor((2, 3), "int32"))
-    with pytest.raises(TVMError):
+    with pytest.raises(TypeError):
         bb.normalize(binary_arith_op(x, y))
 
 
@@ -290,7 +290,7 @@ def test_binary_arith_infer_struct_info_vdevice_mismatch(binary_arith_op: Callab
     bb = relax.BlockBuilder()
     x = relax.Var("x", R.Tensor((2, 3), "float32", VDevice("llvm")))
     y = relax.Var("y", R.Tensor((2, 3), "int32", VDevice("cuda")))
-    with pytest.raises(TVMError):
+    with pytest.raises(TypeError):
         bb.normalize(binary_arith_op(x, y))
 
 

--- a/tests/python/relax/test_op_nn_convolution.py
+++ b/tests/python/relax/test_op_nn_convolution.py
@@ -386,7 +386,7 @@ def test_conv1d_dtype_mismatch():
     x = relax.Var("x", R.Tensor((2, 3, 28), "float32"))
     w = relax.Var("w", R.Tensor((4, 3, 3), "int8"))
 
-    with pytest.raises(TVMError):
+    with pytest.raises(TypeError):
         bb.normalize(relax.op.nn.conv1d(x, w))
 
 
@@ -744,7 +744,7 @@ def test_conv1d_transpose_dtype_mismatch():
     x = relax.Var("x", R.Tensor((2, 3, 28), "float32"))
     w = relax.Var("w", R.Tensor((3, 4, 3), "int8"))
 
-    with pytest.raises(TVMError):
+    with pytest.raises(TypeError):
         bb.normalize(relax.op.nn.conv1d_transpose(x, w))
 
 
@@ -1141,7 +1141,7 @@ def test_conv2d_dtype_mismatch():
     x = relax.Var("x", R.Tensor((2, 3, 28, 28), "float32"))
     w = relax.Var("w", R.Tensor((4, 3, 3, 3), "int8"))
 
-    with pytest.raises(TVMError):
+    with pytest.raises(TypeError):
         bb.normalize(relax.op.nn.conv2d(x, w))
 
 
@@ -1533,7 +1533,7 @@ def test_conv2d_transpose_dtype_mismatch():
     x = relax.Var("x", R.Tensor((2, 3, 28, 28), "float32"))
     w = relax.Var("w", R.Tensor((3, 4, 3, 3), "int8"))
 
-    with pytest.raises(TVMError):
+    with pytest.raises(TypeError):
         bb.normalize(relax.op.nn.conv2d_transpose(x, w))
 
 

--- a/tests/python/relax/test_op_search.py
+++ b/tests/python/relax/test_op_search.py
@@ -262,9 +262,9 @@ def test_where_infer_struct_info_dtype_mismatch():
     x1 = relax.Var("x", R.Tensor((2, 3), "int8"))
     y1 = relax.Var("y", R.Tensor((2, 3), "float32"))
 
-    with pytest.raises(TVMError):
+    with pytest.raises(TypeError):
         bb.normalize(relax.op.where(cond, x0, y0))
-    with pytest.raises(TVMError):
+    with pytest.raises(TypeError):
         bb.normalize(relax.op.where(cond, x1, y1))
 
 

--- a/tests/python/relax/test_transform_legalize_ops_binary.py
+++ b/tests/python/relax/test_transform_legalize_ops_binary.py
@@ -17,7 +17,7 @@
 
 import tvm
 from tvm.relax.transform import LegalizeOps
-from tvm.script import relax as R, tir as T
+from tvm.script import ir as I, relax as R, tir as T
 import tvm.testing
 
 
@@ -164,6 +164,44 @@ def test_add_symbolic():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_add_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.add(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.add, (x, y), R.Tensor([64, 32, 16], dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def add(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = lhs[vi, vj, vk] + rhs
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
+
+
 def test_divide():
     # fmt: off
     @tvm.script.ir_module
@@ -301,6 +339,44 @@ def test_divide_symbolic():
 
     mod = LegalizeOps()(Divide)
     tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_divide_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.divide(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.divide, (x, y), R.Tensor([64, 32, 16], dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def divide(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = lhs[vi, vj, vk] / rhs
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
 
 
 def test_floor_divide():
@@ -442,6 +518,44 @@ def test_floor_divide_symbolic():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_floordiv_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.floor_divide(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.floor_divide, (x, y), R.Tensor([64, 32, 16], dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def floor_divide(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_floordiv"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = T.floor(lhs[vi, vj, vk] / rhs)
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
+
+
 def test_multiply():
     # fmt: off
     @tvm.script.ir_module
@@ -517,6 +631,44 @@ def test_multiply_symbolic():
 
     mod = LegalizeOps()(Multiply)
     tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_multiply_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.multiply(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.multiply, (x, y), R.Tensor([64, 32, 16], dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def multiply(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = lhs[vi, vj, vk] * rhs
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
 
 
 def test_power():
@@ -599,6 +751,44 @@ def test_power_symbolic():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_power_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.power(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.power, (x, y), R.Tensor([64, 32, 16], dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def power(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_power"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = T.pow(lhs[vi, vj, vk], rhs)
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
+
+
 def test_subtract():
     # fmt: off
     @tvm.script.ir_module
@@ -674,6 +864,44 @@ def test_subtract_symbolic():
 
     mod = LegalizeOps()(Subtract)
     tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_subtract_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.subtract(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.subtract, (x, y), R.Tensor([64, 32, 16], dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def subtract(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = lhs[vi, vj, vk] - rhs
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
 
 
 ##################### Binary comparison #####################
@@ -818,6 +1046,44 @@ def test_equal_symbolic():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_equal_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.equal(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.equal, (x, y), R.Tensor([64, 32, 16], dtype="bool"))
+            return gv
+
+        @T.prim_func(private=True)
+        def equal(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "bool"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = lhs[vi, vj, vk] == rhs
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
+
+
 def test_greater():
     # fmt: off
     @tvm.script.ir_module
@@ -957,6 +1223,44 @@ def test_greater_symbolic():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_greater_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.greater(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.greater, (x, y), R.Tensor([64, 32, 16], dtype="bool"))
+            return gv
+
+        @T.prim_func(private=True)
+        def greater(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "bool"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = rhs < lhs[vi, vj, vk]
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
+
+
 def test_greater_equal():
     # fmt: off
     @tvm.script.ir_module
@@ -1034,6 +1338,44 @@ def test_greater_equal_symbolic():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_greater_equal_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.greater_equal(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.greater_equal, (x, y), R.Tensor([64, 32, 16], dtype="bool"))
+            return gv
+
+        @T.prim_func(private=True)
+        def greater_equal(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "bool"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = rhs <= lhs[vi, vj, vk]
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
+
+
 def test_less():
     # fmt: off
     @tvm.script.ir_module
@@ -1109,6 +1451,44 @@ def test_less_symbolic():
 
     mod = LegalizeOps()(Less)
     tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_less_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.less(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.less, (x, y), R.Tensor([64, 32, 16], dtype="bool"))
+            return gv
+
+        @T.prim_func(private=True)
+        def less(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "bool"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = lhs[vi, vj, vk] < rhs
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
 
 
 def test_less_equal():
@@ -1250,6 +1630,44 @@ def test_less_equal_symbolic():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_less_equal_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.less_equal(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.less_equal, (x, y), R.Tensor([64, 32, 16], dtype="bool"))
+            return gv
+
+        @T.prim_func(private=True)
+        def less_equal(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "bool"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = lhs[vi, vj, vk] <= rhs
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
+
+
 def test_not_equal():
     # fmt: off
     @tvm.script.ir_module
@@ -1325,6 +1743,44 @@ def test_not_equal_symbolic():
 
     mod = LegalizeOps()(NotEqual)
     tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_not_equal_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.not_equal(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.not_equal, (x, y), R.Tensor([64, 32, 16], dtype="bool"))
+            return gv
+
+        @T.prim_func(private=True)
+        def not_equal(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "bool"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = lhs[vi, vj, vk] != rhs
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
 
 
 def test_maximum():
@@ -1467,6 +1923,44 @@ def test_maximum_symbolic():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_max_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.maximum(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.maximum, (x, y), R.Tensor([64, 32, 16], dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def maximum(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = T.max(lhs[vi, vj, vk], rhs)
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
+
+
 def test_minimum():
     # fmt: off
     @tvm.script.ir_module
@@ -1605,6 +2099,44 @@ def test_minimum_symbolic():
 
     mod = LegalizeOps()(Minimum)
     tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_min_primvalue():
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            gv = R.minimum(x, y)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor([64, 32, 16], "float32"),
+            y: R.Prim("float32"),
+        ):
+            cls = Expected
+            gv = R.call_tir(cls.minimum, (x, y), R.Tensor([64, 32, 16], dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def minimum(
+            lhs: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+            rhs: T.float32,
+            output: T.Buffer([T.int64(64), T.int64(32), T.int64(16)], "float32"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            for i, j, k in T.grid(*lhs.shape):
+                with T.block("T_add"):
+                    vi, vj, vk = T.axis.remap("SSS", [i, j, k])
+                    output[vi, vj, vk] = T.min(lhs[vi, vj, vk], rhs)
+
+    After = LegalizeOps()(Before)
+    tvm.ir.assert_structural_equal(Expected, After)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prior to this commit, binary operations were only defined between two tensors.  This commit allows binary operations to apply between a tensor and a `relax::PrimValue`.

When inferring the output `StructInfo`, binary operations with a `PrimValue` produce the same output as using a 0-d tensor.  When legalizing operations containing a `PrimValue`, they are lowered to primitive TIR arguments.