### PR TITLE
[Relax][Analysis] Validate FuncStructInfo correctness

### DIFF
--- a/src/relax/testing/well_formed.cc
+++ b/src/relax/testing/well_formed.cc
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/transform.h>
+
+namespace tvm {
+namespace relax {
+namespace testing {
+
+Function IncorrectImplementationOfBindParamForRelaxFunc(Function func) {
+  auto body = Downcast<relax::SeqExpr>(func->body);
+  body.CopyOnWrite()->blocks = {
+      BindingBlock({VarBinding(func->params[0], relax::PrimValue::Int64(0))})};
+
+  auto write_ptr = func.CopyOnWrite();
+  write_ptr->params = {};
+  write_ptr->body = body;
+  return func;
+}
+
+TVM_REGISTER_GLOBAL("relax.testing.IncorrectImplementationOfBindParamForRelaxFunc")
+    .set_body_typed(IncorrectImplementationOfBindParamForRelaxFunc);
+
+tir::PrimFunc IncorrectImplementationOfBindParamForPrimFunc(tir::PrimFunc func) {
+  auto new_body = tir::LetStmt(func->params[0], IntImm(func->params[0]->dtype, 0), func->body);
+
+  auto write_ptr = func.CopyOnWrite();
+  write_ptr->params = {};
+  write_ptr->body = new_body;
+  return func;
+}
+
+TVM_REGISTER_GLOBAL("relax.testing.IncorrectImplementationOfBindParamForPrimFunc")
+    .set_body_typed(IncorrectImplementationOfBindParamForPrimFunc);
+
+}  // namespace testing
+}  // namespace relax
+}  // namespace tvm

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -702,5 +702,35 @@ def test_pass_dltensor_arg_to_tir():
     assert rx.analysis.well_formed(Module)
 
 
+def test_incorrect_relax_func_struct_info():
+    """relax::Function annotations must be correct"""
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def func(x: R.Prim("int64")) -> R.Prim("int64"):
+            return x
+
+    arg_binder = tvm.get_global_func("relax.testing.IncorrectImplementationOfBindParamForRelaxFunc")
+    Module["func"] = arg_binder(Module["func"])
+
+    assert not rx.analysis.well_formed(Module)
+
+
+def test_incorrect_tir_func_struct_info():
+    """If present, PrimFunc annotations must be correct"""
+
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def func(x: T.int64) -> T.int64:
+            return x
+
+    arg_binder = tvm.get_global_func("relax.testing.IncorrectImplementationOfBindParamForPrimFunc")
+    Module["func"] = arg_binder(Module["func"])
+
+    assert not rx.analysis.well_formed(Module)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Prior to this PR, the well-formed checker did not validate the `FuncStructInfo` annotations.  While these `FuncStructInfo` annotations are generated during construction, they can be invalidated by `CopyOnWrite()`.  This commit adds validation of the `FuncStructInfo` to the well-formed checker.