### PR TITLE
[CI] Disable flaky unit test

### DIFF
--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -26,7 +26,16 @@ import tvm.testing
 from test_auto_scheduler_task_extraction import get_network
 
 
-def tune_network(network, target):
+network = tvm.testing.parameter(
+    "mlp",
+    pytest.param("winograd-test", mark=pytest.mark.xfail(reason="Flaky unit test")),
+)
+
+
+@tvm.testing.requires_cuda
+def test_tuning_cuda(network):
+    target = "cuda"
+
     # Extract tasks
     mod, params = get_network(network)
     target = tvm.target.Target(target)
@@ -104,11 +113,5 @@ def tune_network(network, target):
         tvm.testing.assert_allclose(actual_output2, expected_output, rtol=1e-4, atol=1e-4)
 
 
-@tvm.testing.requires_cuda
-def test_tuning_cuda():
-    tune_network("mlp", "cuda")
-    tune_network("winograd-test", "cuda")
-
-
 if __name__ == "__main__":
-    test_tuning_cuda()
+    tvm.testing.main()

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -29,7 +29,7 @@ from test_auto_scheduler_task_extraction import get_network
 
 network = tvm.testing.parameter(
     "mlp",
-    pytest.param("winograd-test", mark=pytest.mark.xfail(reason="Flaky unit test")),
+    pytest.param("winograd-test", marks=pytest.mark.xfail(reason="Flaky unit test")),
 )
 
 

--- a/tests/python/relay/test_auto_scheduler_tuning.py
+++ b/tests/python/relay/test_auto_scheduler_tuning.py
@@ -18,6 +18,7 @@
 import tempfile
 
 import numpy as np
+import pytest
 
 from tvm import auto_scheduler, relay
 from tvm.contrib import graph_executor


### PR DESCRIPTION
The `test_auto_scheduler_tuning.py::test_tuning_cuda` unit test has sporadic failures on unrelated changes.  Seems to be triggered when tuning does not find any valid candidates, and so the "best" candidate of a no-op triggers a "did you forget to bind" error message.