### PR TITLE
[QoL][Relax] Infer StructInfo for relax::Tuple on construction

### DIFF
--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -86,6 +86,25 @@ def test_tuple() -> None:
         t[-3]
 
 
+def test_tuple_sinfo_inferred_on_construction():
+    v0 = rx.Var("v0", rx.ObjectStructInfo())
+    v1 = rx.Var("v1", rx.ObjectStructInfo())
+    tup = rx.Tuple((v0, v1))
+
+    assert tup.struct_info_ is not None
+    tvm.ir.assert_structural_equal(
+        tup.struct_info, rx.TupleStructInfo([rx.ObjectStructInfo(), rx.ObjectStructInfo()])
+    )
+
+
+def test_tuple_sinfo_requires_fields_with_known_sinfo():
+    v0 = rx.Var("v0", rx.ObjectStructInfo())
+    v1 = rx.Var("v1")
+    tup = rx.Tuple((v0, v1))
+
+    assert tup.struct_info_ is None
+
+
 def test_match_cast() -> None:
     # match_cast([16, 8], [m, n])
     m = tir.Var("m", dtype="int64")


### PR DESCRIPTION
Prior to this commit, the `relax::Tuple` constructor left the `struct_info_` field undefined.  This is inconsistent with other Relax leaf nodes, such as `relax::PrimValue`, `relax::Constant`, and `relax::ExternFunc`, which initialize their struct info on construction.

This commit updates the `relax::Tuple` constructor to define `struct_info_` as `TupleStructInfo`, if all fields have a known struct info.  If any field does not have a known struct info, the current behavior is kept, where `struct_info_` is constructed as `NullOpt`, and is later populated by the `relax::BlockBuilder`.