### PR TITLE
[QoL][Relax] Return well-formed IR from relax::Function::CreateEmpty

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -1045,6 +1045,8 @@ class ExternFuncNode : public BaseFuncNode {
 class ExternFunc : public BaseFunc {
  public:
   TVM_DLL ExternFunc(String global_symbol, Span span = Span());
+  TVM_DLL ExternFunc(String global_symbol, StructInfo struct_info, Span span = Span());
+
   TVM_DEFINE_OBJECT_REF_METHODS(ExternFunc, BaseFunc, ExternFuncNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ExternFuncNode);
 };


### PR DESCRIPTION
Prior to this commit, the static method `relax::Function::CreateEmpty` returned a function with a nullptr as the body.  While only intended for use in bookkeeping for TVMScript, allowing nullptr in this location can cause unexpected segfaults while debugging.  For example, adding a print statement

This commit updates the `relax::Function::CreateEmpty` function to contain a placeholder body, consistent with the `ret_struct_info` argument provided.