### PR TITLE
[SVE] Support splitting by vscale in `tir::split` and `te::split`

### DIFF
--- a/include/tvm/te/schedule.h
+++ b/include/tvm/te/schedule.h
@@ -131,10 +131,14 @@ class Stage : public ObjectRef {
    * \param factor The split factor of the loop.
    * \param p_outer The result outer domain
    * \param p_inner The result inner domain.
+   * \param disable_predication If enabled, don't create a predicate for guarding the
+   * loop. This can be useful when splitting with scalable factors that the schedule writer
+   * knows are divisible by the loop bound.
+   * Warning: enabling this feature may result in incorrect code generation if not used carefully.
    * \return reference to self.
    */
-  TVM_DLL Stage& split(IterVar parent, PrimExpr factor, IterVar* p_outer,
-                       IterVar* p_inner);  // NOLINT(*)
+  TVM_DLL Stage& split(IterVar parent, PrimExpr factor, IterVar* p_outer, IterVar* p_inner,
+                       bool disable_predication = false);  // NOLINT(*)
   /*!
    * \brief Split the iteration with given number of parts.
    *
@@ -142,10 +146,14 @@ class Stage : public ObjectRef {
    * \param nparts The number of parts in the outer domain.
    * \param p_outer The result outer domain.
    * \param p_inner The result inner domain.
+   * \param disable_predication If enabled, don't create a predicate for guarding the
+   * loop. This can be useful when splitting with scalable factors that the schedule writer
+   * knows are divisible by the loop bound.
+   * Warning: enabling this feature may result in incorrect code generation if not used carefully.
    * \return reference to self.
    */
   TVM_DLL Stage& split_by_nparts(IterVar parent, PrimExpr nparts, IterVar* p_outer,
-                                 IterVar* p_inner);  // NOLINT(*)
+                                 IterVar* p_inner, bool disable_predication = false);  // NOLINT(*)
   /*!
    * \brief Fuse the inner outer domain to the target
    * \param outer The outer domain to be fused.
@@ -761,6 +769,8 @@ class SplitNode : public IterVarRelationNode {
   PrimExpr factor;
   /*! \brief Number of parts, only factor or nparts can be given */
   PrimExpr nparts;
+  /*! \brief Whether to disable generation of predication. */
+  bool disable_predication;
 
   void VisitAttrs(AttrVisitor* v) {
     v->Visit("parent", &parent);
@@ -768,6 +778,7 @@ class SplitNode : public IterVarRelationNode {
     v->Visit("inner", &inner);
     v->Visit("factor", &factor);
     v->Visit("nparts", &nparts);
+    v->Visit("disable_predication", &disable_predication);
   }
 
   static constexpr const char* _type_key = "Split";
@@ -780,7 +791,8 @@ class SplitNode : public IterVarRelationNode {
  */
 class Split : public IterVarRelation {
  public:
-  TVM_DLL Split(IterVar parent, IterVar outer, IterVar inner, PrimExpr factor, PrimExpr nparts);
+  TVM_DLL Split(IterVar parent, IterVar outer, IterVar inner, PrimExpr factor, PrimExpr nparts,
+                bool disable_predication);
 
   TVM_DEFINE_OBJECT_REF_METHODS(Split, IterVarRelation, SplitNode);
 };

--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -349,11 +349,16 @@ class ScheduleNode : public runtime::Object {
    * \param loop_rv The loop to be split
    * \param factors The positive tiling factors, and at most one of which is `NullOpt`, which means
    * that factor is inferred.
-   * \param preserve_unit_iters Whether or not to preserve unit iterators in block bindings
-   * \return The new loops after split
+   * \param preserve_unit_iters Whether or not to preserve unit iterators in block bindings.
+   * \param disable_predication If enabled, don't create a predicate for guarding the
+   * loop. This can be useful when splitting with scalable factors that the schedule writer
+   * knows are divisible by the loop bound.
+   * Warning: enabling this feature may result in incorrect code generation if not used carefully.
+   * \return The new loops after split.
    */
   virtual Array<LoopRV> Split(const LoopRV& loop_rv, const Array<Optional<ExprRV>>& factors,
-                              bool preserve_unit_iters = true) = 0;
+                              bool preserve_unit_iters = true,
+                              bool disable_predication = false) = 0;
   /*!
    * \brief Partition the loops into sequence of multiple loops
    * 1) The loop can't have annotation or thread binding.

--- a/python/tvm/te/schedule.py
+++ b/python/tvm/te/schedule.py
@@ -201,7 +201,7 @@ class Schedule(Object):
 class Stage(Object):
     """A Stage represents schedule for one operation."""
 
-    def split(self, parent, factor=None, nparts=None):
+    def split(self, parent, factor=None, nparts=None, disable_predication=False):
         """Split the stage either by factor providing outer scope, or both
 
         Parameters
@@ -215,6 +215,14 @@ class Stage(Object):
         nparts : Expr, optional
              The number of outer parts.
 
+        disable_predication : bool, optional
+            If enabled, don't create a predicate for guarding the loop. This can
+            be useful when splitting with scalable factors that the schedule writer
+            knows are divisible by the loop bound.
+
+            Warning: enabling this feature may result in incorrect code generation
+            if not used carefully.
+
         Returns
         -------
         outer : IterVar
@@ -226,11 +234,11 @@ class Stage(Object):
         if nparts is not None:
             if factor is not None:
                 raise ValueError("Do not need to provide both outer and nparts")
-            outer, inner = _ffi_api.StageSplitByNParts(self, parent, nparts)
+            outer, inner = _ffi_api.StageSplitByNParts(self, parent, nparts, disable_predication)
         else:
             if factor is None:
                 raise ValueError("Either nparts or factor need to be provided")
-            outer, inner = _ffi_api.StageSplitByFactor(self, parent, factor)
+            outer, inner = _ffi_api.StageSplitByFactor(self, parent, factor, disable_predication)
         return outer, inner
 
     def fuse(self, *args):

--- a/python/tvm/tir/schedule/schedule.py
+++ b/python/tvm/tir/schedule/schedule.py
@@ -736,6 +736,7 @@ class Schedule(Object):
         loop: LoopRV,
         factors: List[Union[int, ExprRV, None]],
         preserve_unit_iters: bool = True,
+        disable_predication: bool = False,
     ) -> List[LoopRV]:
         """Split a loop into a list of consecutive loops. It requires:
         1) The loop can't have annotation or thread binding.
@@ -758,6 +759,14 @@ class Schedule(Object):
 
         preserve_unit_iters : bool
             Whether or not to preserve unit iterators in block bindings
+
+        disable_predication : bool
+            If enabled, don't create a predicate for guarding the loop. This can
+            be useful when splitting with scalable factors that the schedule writer
+            knows are divisible by the loop bound.
+
+            Warning: enabling this feature may result in incorrect code generation
+            if not used carefully.
 
         Returns
         -------
@@ -809,7 +818,11 @@ class Schedule(Object):
         # that there is at most one None in `factors`
         return list(
             _ffi_api.ScheduleSplit(  # type: ignore # pylint: disable=no-member
-                self, loop, factors, preserve_unit_iters
+                self,
+                loop,
+                factors,
+                preserve_unit_iters,
+                disable_predication,
             )
         )
 

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -238,7 +238,7 @@ bool Analyzer::CanProve(const PrimExpr& expr, ProofStrength strength) {
     Target curr_target = tvm::Target::Current();
     if (curr_target.defined() && curr_target->features.defined() &&
         (curr_target->features.find("has_sve") != curr_target->features.end()) &&
-        bool(curr_target->GetFeature<Bool>("has_sve").value_or(Bool(false)))) {
+        curr_target->GetFeature<Bool>("has_sve").value_or(Bool(false)).operator bool()) {
       return CanProveVscaleExpressionFromKnownValues(this, simplified, kAArch64VScaleValues);
     }
     LOG(WARNING)

--- a/src/arith/scalable_expression.cc
+++ b/src/arith/scalable_expression.cc
@@ -66,8 +66,15 @@ std::optional<int> ExtractVscaleFactor(const PrimExpr& lanes) {
   }
 }
 
+bool IsComparison(const PrimExpr& expr) {
+  return expr->IsInstance<tir::LENode>() || expr->IsInstance<tir::LTNode>() ||
+         expr->IsInstance<tir::GENode>() || expr->IsInstance<tir::GTNode>() ||
+         expr->IsInstance<tir::EQNode>() || expr->IsInstance<tir::NENode>();
+}
+
 bool CanProveVscaleExpressionFromKnownValues(arith::Analyzer* analyzer, const PrimExpr& expr,
                                              const std::vector<unsigned int>& vscale_values) {
+  ICHECK(IsComparison(expr)) << "Expected comparison but got: " << expr;
   bool can_prove_expr = true;
   for (const unsigned int vscale_value : vscale_values) {
     PrimExpr result = SubstituteVScaleWithKnownValue(expr, vscale_value);

--- a/src/arith/scalable_expression.cc
+++ b/src/arith/scalable_expression.cc
@@ -27,6 +27,9 @@
 #include <tvm/tir/expr.h>
 #include <tvm/tir/op.h>
 
+#include <vector>
+
+#include "../tir/transforms/replace_selected_expr.h"
 #include "./pattern_match.h"
 
 namespace tvm {
@@ -39,6 +42,19 @@ bool IsVScaleCall(const PrimExpr& expr) {
   return false;
 }
 
+PrimExpr SubstituteVScaleWithKnownValue(const PrimExpr& expr, unsigned int vscale_value) {
+  std::function<bool(const PrimExpr&)> predicate_selector = [](const PrimExpr& current_expr) {
+    return IsVScaleCall(current_expr);
+  };
+  std::function<bool(const PrimExpr&)> can_replace_inside = [](const PrimExpr& current_expr) {
+    return true;
+  };
+
+  return tir::ReplaceSelectedExpr::ReplaceSelectedExprInExpr(
+      expr, predicate_selector, tir::MakeConstScalar(DataType::Int(32), vscale_value),
+      can_replace_inside);
+}
+
 std::optional<int> ExtractVscaleFactor(const PrimExpr& lanes) {
   PVar<IntImm> multiplier;
   PCallExpr<PVscaleOp> vscale;
@@ -48,6 +64,21 @@ std::optional<int> ExtractVscaleFactor(const PrimExpr& lanes) {
   } else {
     return std::nullopt;
   }
+}
+
+bool CanProveVscaleExpressionFromKnownValues(arith::Analyzer* analyzer, const PrimExpr& expr,
+                                             const std::vector<unsigned int>& vscale_values) {
+  bool can_prove_expr = true;
+  for (const unsigned int vscale_value : vscale_values) {
+    PrimExpr result = SubstituteVScaleWithKnownValue(expr, vscale_value);
+    result = analyzer->Simplify(result);
+    const int64_t* as_int = tir::as_const_int(result);
+    if (!as_int || *as_int == 0) {
+      can_prove_expr = false;
+      break;
+    }
+  }
+  return can_prove_expr;
 }
 
 }  // namespace arith

--- a/src/arith/scalable_expression.h
+++ b/src/arith/scalable_expression.h
@@ -25,12 +25,18 @@
 #ifndef TVM_ARITH_SCALABLE_EXPRESSION_H_
 #define TVM_ARITH_SCALABLE_EXPRESSION_H_
 
+#include <tvm/arith/analyzer.h>
 #include <tvm/ir/expr.h>
 
 #include <optional>
+#include <vector>
 
 namespace tvm {
 namespace arith {
+
+/*! \brief A list of known vscale values to try for an AArch64 SVE target. */
+static const std::vector<unsigned int> kAArch64VScaleValues = {1, 2,  3,  4,  5,  6,  7,  8,
+                                                               9, 10, 11, 12, 13, 14, 15, 16};
 
 /*!
  * \brief Check if an expr is a call to the vscale intrinsic.
@@ -40,11 +46,29 @@ namespace arith {
 bool IsVScaleCall(const PrimExpr& expr);
 
 /*!
+ * \brief Substitute a vscale intrinsic call with a known scalar value.
+ * \param expr The expr to apply substitutions to.
+ * \param vscale_value The scalar value to replace vscale with.
+ * \return A rewritten expression with vscale values replaced with a scalar value.
+ */
+PrimExpr SubstituteVScaleWithKnownValue(const PrimExpr& expr, unsigned int vscale_value);
+
+/*!
  * \brief Returns the vscale multiplier as a nullable type
  * \param lanes The scalable lanes as a PrimExpr
  * \return vscale multiplier as std::optional<int>
  */
 std::optional<int> ExtractVscaleFactor(const PrimExpr& lanes);
+
+/*!
+ * \brief Check if the expression can be proven when evaluating it on all possible values
+           of vscale.
+ * \param analyzer An analyzer instance.
+ * \param expr The expression to try to prove.
+ * \return Whether or not the expression can be proven with this technique.
+ */
+bool CanProveVscaleExpressionFromKnownValues(arith::Analyzer* analyzer, const PrimExpr& expr,
+                                             const std::vector<unsigned int>& vscale_values);
 
 }  // namespace arith
 }  // namespace tvm

--- a/src/arith/scalable_expression.h
+++ b/src/arith/scalable_expression.h
@@ -65,6 +65,7 @@ std::optional<int> ExtractVscaleFactor(const PrimExpr& lanes);
            of vscale.
  * \param analyzer An analyzer instance.
  * \param expr The expression to try to prove.
+ * \param vscale_values A list of values to substitute vscale with.
  * \return Whether or not the expression can be proven with this technique.
  */
 bool CanProveVscaleExpressionFromKnownValues(arith::Analyzer* analyzer, const PrimExpr& expr,

--- a/src/te/schedule/message_passing.cc
+++ b/src/te/schedule/message_passing.cc
@@ -637,7 +637,8 @@ void PassUpBoundCheck(const Stage& s, const Map<IterVar, Range>& dom_map,
         if (outer || inner) {
           state[s->parent] = true;
         } else {
-          if (analyzer->CanProve(dom_map.at(s->parent)->extent == factor * step)) {
+          if (analyzer->CanProve(dom_map.at(s->parent)->extent == factor * step) ||
+              s->disable_predication) {
             state[s->parent] = false;
           } else {
             state[s->parent] = true;

--- a/src/te/schedule/schedule_lang.cc
+++ b/src/te/schedule/schedule_lang.cc
@@ -70,7 +70,7 @@ DataType MatchDataType(std::vector<DataType> dtypes) {
 }
 
 void SplitHelper(StageNode* self, IterVar parent, PrimExpr factor, PrimExpr nparts,
-                 IterVar* p_outer, IterVar* p_inner) {
+                 IterVar* p_outer, IterVar* p_inner, bool disable_predication) {
   // Check if split is valid.
   ICHECK(parent->iter_type == kDataPar || parent->iter_type == kCommReduce ||
          parent->iter_type == kOrdered)
@@ -83,7 +83,7 @@ void SplitHelper(StageNode* self, IterVar parent, PrimExpr factor, PrimExpr npar
   Array<IterVar>& all_vars = self->all_iter_vars;
   Array<IterVar>& leaf_vars = self->leaf_iter_vars;
   size_t pos = FindLeafVar(all_vars.GetArrayNode(), leaf_vars.GetArrayNode(), parent);
-  self->relations.push_back(Split(parent, outer, inner, factor, nparts));
+  self->relations.push_back(Split(parent, outer, inner, factor, nparts, disable_predication));
   // add vars to all vars
   all_vars.push_back(outer);
   all_vars.push_back(inner);
@@ -226,17 +226,17 @@ Stage& Stage::set_store_predicate(PrimExpr predicate) {
   return *this;
 }
 
-Stage& Stage::split(IterVar parent, PrimExpr factor, IterVar* p_outer,
-                    IterVar* p_inner) {  // NOLINT(*)
+Stage& Stage::split(IterVar parent, PrimExpr factor, IterVar* p_outer, IterVar* p_inner,
+                    bool disable_predication) {  // NOLINT(*)
   With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
-  SplitHelper(operator->(), parent, factor, PrimExpr(), p_outer, p_inner);
+  SplitHelper(operator->(), parent, factor, PrimExpr(), p_outer, p_inner, disable_predication);
   return *this;
 }
 
-Stage& Stage::split_by_nparts(IterVar parent, PrimExpr nparts, IterVar* p_outer,
-                              IterVar* p_inner) {  // NOLINT(*)
+Stage& Stage::split_by_nparts(IterVar parent, PrimExpr nparts, IterVar* p_outer, IterVar* p_inner,
+                              bool disable_predication) {  // NOLINT(*)
   With<ScheduleContext> ctx(operator->()->attach_sch, __func__);
-  SplitHelper(operator->(), parent, PrimExpr(), nparts, p_outer, p_inner);
+  SplitHelper(operator->(), parent, PrimExpr(), nparts, p_outer, p_inner, disable_predication);
   return *this;
 }
 
@@ -805,13 +805,15 @@ void ScheduleContext::ExitWithScope() {
   }
 }
 
-Split::Split(IterVar parent, IterVar outer, IterVar inner, PrimExpr factor, PrimExpr nparts) {
+Split::Split(IterVar parent, IterVar outer, IterVar inner, PrimExpr factor, PrimExpr nparts,
+             bool disable_predication) {
   auto n = make_object<SplitNode>();
   n->parent = parent;
   n->outer = outer;
   n->inner = inner;
   n->factor = factor;
   n->nparts = nparts;
+  n->disable_predication = disable_predication;
   data_ = std::move(n);
 }
 
@@ -927,6 +929,8 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
         p->stream << ", nparts=";
         p->Print(op->nparts);
       }
+      p->stream << ", disable_predication=";
+      p->stream << op->disable_predication;
       p->stream << ')';
     })
     .set_dispatch<FuseNode>([](const ObjectRef& node, ReprPrinter* p) {
@@ -973,16 +977,16 @@ TVM_REGISTER_GLOBAL("te.StageSetScope").set_body_method(&Stage::set_scope);
 TVM_REGISTER_GLOBAL("te.StageBind").set_body_method(&Stage::bind);
 
 TVM_REGISTER_GLOBAL("te.StageSplitByFactor")
-    .set_body_typed([](Stage stage, IterVar parent, PrimExpr factor) {
+    .set_body_typed([](Stage stage, IterVar parent, PrimExpr factor, bool disable_predication) {
       IterVar outer, inner;
-      stage.split(parent, factor, &outer, &inner);
+      stage.split(parent, factor, &outer, &inner, disable_predication);
       return Array<IterVar>({outer, inner});
     });
 
 TVM_REGISTER_GLOBAL("te.StageSplitByNParts")
-    .set_body_typed([](Stage stage, IterVar parent, PrimExpr nparts) {
+    .set_body_typed([](Stage stage, IterVar parent, PrimExpr nparts, bool disable_predication) {
       IterVar outer, inner;
-      stage.split_by_nparts(parent, nparts, &outer, &inner);
+      stage.split_by_nparts(parent, nparts, &outer, &inner, disable_predication);
       return Array<IterVar>({outer, inner});
     });
 

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -466,7 +466,7 @@ class NonPositiveFactorError : public ScheduleError {
 
 Array<LoopRV> ConcreteScheduleNode::Split(const LoopRV& loop_rv,
                                           const Array<Optional<ExprRV>>& factor_rvs,
-                                          bool preserve_unit_iters) {
+                                          bool preserve_unit_iters, bool disable_predication) {
   // Prepare for the splitting
   StmtSRef loop_sref = this->GetSRef(loop_rv);
   const ForNode* loop = TVM_SREF_TO_FOR(loop_sref);
@@ -502,7 +502,7 @@ Array<LoopRV> ConcreteScheduleNode::Split(const LoopRV& loop_rv,
   } else if (!this->analyzer_->CanProve(tot_length >= loop->extent)) {
     throw WrongFactorError(state_->mod, GetRef<For>(loop), true);
   }
-  results = tir::Split(state_, loop_sref, factors, preserve_unit_iters);
+  results = tir::Split(state_, loop_sref, factors, preserve_unit_iters, disable_predication);
   TVM_TIR_SCHEDULE_END("split", this->error_render_level_);
   this->state_->DebugVerify();
   return CreateRV<LoopRV>(results);

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -108,7 +108,7 @@ class ConcreteScheduleNode : public ScheduleNode {
   LoopRV Fuse(const Array<LoopRV>& loop_rvs, bool preserve_unit_iters) override;
   LoopRV Merge(const Array<LoopRV>& loop_rvs) override;
   Array<LoopRV> Split(const LoopRV& loop_rv, const Array<Optional<ExprRV>>& factors,
-                      bool preserve_unit_iters) override;
+                      bool preserve_unit_iters, bool disable_predication) override;
   Array<LoopRV> LoopPartition(const LoopRV& loop_rv, const Array<Optional<ExprRV>>& factors,
                               bool preserve_unit_iters) override;
   void Reorder(const Array<LoopRV>& ordered_loop_rvs) override;

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -204,10 +204,15 @@ Array<StmtSRef> GetOutputBlocks(const ScheduleState& self, const StmtSRef& scope
  * \param loop_sref The sref to the loop being split
  * \param factors The splitting factors
  * \param preserve_unit_iters Whether or not to preserve unit iterators in block bindings
- * \return An array of srefs to the loops after splitting
+ * \param disable_predication If enabled, don't create a predicate for guarding the
+ *      loop. This can be useful when splitting with scalable factors that the schedule writer
+ *      knows are divisible by the loop bound.
+ *      Warning: enabling this feature may result in incorrect code generation if not used
+ * carefully. \return An array of srefs to the loops after splitting
  */
 TVM_DLL Array<StmtSRef> Split(ScheduleState self, const StmtSRef& loop_sref,
-                              const Array<PrimExpr>& factors, bool preserve_unit_iters);
+                              const Array<PrimExpr>& factors, bool preserve_unit_iters,
+                              bool disable_predication);
 
 /*!
  * Partition a loop into a list of consecutive loops. It requires:

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -226,8 +226,9 @@ LoopRV TracedScheduleNode::Fuse(const Array<LoopRV>& loop_rvs, bool preserve_uni
 
 Array<LoopRV> TracedScheduleNode::Split(const LoopRV& loop_rv,
                                         const Array<Optional<ExprRV>>& factor_rvs,
-                                        bool preserve_unit_iters) {
-  Array<LoopRV> results = ConcreteScheduleNode::Split(loop_rv, factor_rvs, preserve_unit_iters);
+                                        bool preserve_unit_iters, bool disable_predication) {
+  Array<LoopRV> results =
+      ConcreteScheduleNode::Split(loop_rv, factor_rvs, preserve_unit_iters, disable_predication);
 
   std::vector<ObjectRef> inputs;
   inputs.reserve(1 + factor_rvs.size());
@@ -237,10 +238,11 @@ Array<LoopRV> TracedScheduleNode::Split(const LoopRV& loop_rv,
   }
 
   static const InstructionKind& kind = InstructionKind::Get("Split");
-  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
-                                      /*inputs=*/inputs,
-                                      /*attrs=*/{Integer(preserve_unit_iters)},
-                                      /*outputs=*/{results.begin(), results.end()}));
+  trace_->Append(
+      /*inst=*/Instruction(/*kind=*/kind,
+                           /*inputs=*/inputs,
+                           /*attrs=*/{Integer(preserve_unit_iters), Integer(disable_predication)},
+                           /*outputs=*/{results.begin(), results.end()}));
   return results;
 }
 

--- a/src/tir/schedule/traced_schedule.h
+++ b/src/tir/schedule/traced_schedule.h
@@ -67,7 +67,7 @@ class TracedScheduleNode : public ConcreteScheduleNode {
   LoopRV Fuse(const Array<LoopRV>& loop_rvs, bool preserve_unit_iters) final;
   LoopRV Merge(const Array<LoopRV>& loop_rvs) final;
   Array<LoopRV> Split(const LoopRV& loop_rv, const Array<Optional<ExprRV>>& factor_rvs,
-                      bool preserve_unit_iters) final;
+                      bool preserve_unit_iters, bool disable_predication) final;
   Array<LoopRV> LoopPartition(const LoopRV& loop_rv, const Array<Optional<ExprRV>>& factor_rvs,
                               bool preserve_unit_iters) final;
   void Reorder(const Array<LoopRV>& ordered_loop_rvs) final;

--- a/tests/python/meta_schedule/test_meta_schedule_post_order_apply.py
+++ b/tests/python/meta_schedule/test_meta_schedule_post_order_apply.py
@@ -343,14 +343,20 @@ def test_meta_schedule_post_order_apply_remove_block():
                 '  b2 = sch.get_block(name="C", func_name="main")',
                 "  sch.compute_inline(block=b1)",
                 "  l3, l4 = sch.get_loops(block=b2)",
-                "  l5, l6 = sch.split(loop=l3, factors=" + str(a) + ", preserve_unit_iters=True)",
-                "  l7, l8 = sch.split(loop=l4, factors=" + str(b) + ", preserve_unit_iters=True)",
+                "  l5, l6 = sch.split(loop=l3, factors="
+                + str(a)
+                + ", preserve_unit_iters=True, disable_predication=False)",
+                "  l7, l8 = sch.split(loop=l4, factors="
+                + str(b)
+                + ", preserve_unit_iters=True, disable_predication=False)",
                 "  sch.reorder(l5, l7, l6, l8)",
                 "  l9, l10 = sch.get_loops(block=b0)",
-                "  l11, l12 = sch.split(loop=l9, factors=" + str(c) + ", preserve_unit_iters=True)",
+                "  l11, l12 = sch.split(loop=l9, factors="
+                + str(c)
+                + ", preserve_unit_iters=True, disable_predication=False)",
                 "  l13, l14 = sch.split(loop=l10, factors="
                 + str(d)
-                + ", preserve_unit_iters=True)",
+                + ", preserve_unit_iters=True, disable_predication=False)",
                 "  sch.reorder(l11, l13, l12, l14)",
             ]
         )

--- a/tests/python/tir-schedule/test_tir_schedule_split_fuse.py
+++ b/tests/python/tir-schedule/test_tir_schedule_split_fuse.py
@@ -697,7 +697,7 @@ def test_sve_scalable_split_assume_exact_multiple():
     If the schedule writer knows the extent of the loop to be split will always
     be a multiple of vscale, they may use `disable_predication=True` to ensure
     a predicate is not created. This can be used to ensure predication is not
-    inserted where current analysis is not powerful enough to recognise this.
+    inserted.
     """
 
     @T.prim_func
@@ -761,7 +761,7 @@ def test_sve_split_over_scalable_loop():
     tvm.ir.assert_structural_equal(sch.mod["main"], after)
 
 
-def test_default_scalable_split(capfd):
+def test_unsupported_target_scalable_split(capfd):
     @T.prim_func
     def before(a: T.handle):
         A = T.match_buffer(a, (128,), "float32")

--- a/tests/python/tir-schedule/test_tir_schedule_trace.py
+++ b/tests/python/tir-schedule/test_tir_schedule_trace.py
@@ -88,7 +88,7 @@ def _make_split(inputs, outputs):  # pylint: disable=redefined-builtin
     return Instruction(
         kind=InstructionKind.get("Split"),
         inputs=inputs,
-        attrs=[True],
+        attrs=[True, False],
         outputs=outputs,
     )
 
@@ -304,7 +304,7 @@ def test_trace_simplified_3():
             "def apply_trace(sch: tir.Schedule) -> None:",
             '  b0 = sch.get_block(name="B", func_name="main")',
             "  l1, = sch.get_loops(block=b0)",
-            "  l2, l3 = sch.split(loop=l1, factors=[None, 32], preserve_unit_iters=True)",
+            "  l2, l3 = sch.split(loop=l1, factors=[None, 32], preserve_unit_iters=True, disable_predication=False)",
         )
     )
 


### PR DESCRIPTION
This commit adds support for splitting via the compile-time unknown constant `vscale`. Two main changes are introduced; they are described below.

The split scheduling primitive has a new parameter disable_predication that allows the user to avoid introducing a block-level predicate when splitting with a factor of `vscale`. This feature is useful when schedule writers know that the loop they're splitting is a factor of the scalable vector length for their target. Otherwise, a predicate must be introduced due to the nature of `vscale`.

CanProve has been extended to prove expressions that use multiple instances of `vscale`. Known possible scalar values of the `vscale` intrinsic are iterated over and substituted into the expression. If the expression holds true for each possible value, we can conclude the expression true. Currently only support for an SVE target has been added, but it is possible to extend to other targets as/when needed. If the analyzer becomes more powerful in the future and is able to deal with multiple instances of a symbolic value in an expression, this feature can be removed.

Co-authored-by: Elen Kalda <elen.kalda@arm.com>
Co-authored-by: Neil Hickey <neil.hickey@arm.com>