### PR TITLE
[TVMScript] Optionally use `ruff format` instead of `black`

### DIFF
--- a/python/tvm/script/highlight.py
+++ b/python/tvm/script/highlight.py
@@ -117,7 +117,7 @@ def _get_formatter(formatter: Optional[str] = None):
         try:
             # pylint: disable=import-outside-toplevel
             import black
-        except ImportError as err:
+        except ImportError:
             return None
 
         def formatter(code_str):


### PR DESCRIPTION
The `ruff format` tool is significantly faster than the `black` formatter.  For some particularly long TVMScript modules, using it can reduce the time required to show a formatted module from ~5 minutes to ~1 minute.  This commit updates the `.show()` function to apply the optionally formatting using `ruff format` if available, falling back to `black` otherwise.