### PR TITLE
[CUBLAS] Set fp32 compute and scale dtypes in fp16 matmul

### DIFF
--- a/src/runtime/contrib/cublas/cublas.cc
+++ b/src/runtime/contrib/cublas/cublas.cc
@@ -150,8 +150,6 @@ void CallCublasLt(cublasLtHandle_t hdl, cudaStream_t stream,
   cudaDataType_t c_type = CUDA_R_32F;
   float one_fp32 = 1.0;
   float zero_fp32 = 0.0;
-  auto one_fp16 = __truncXfYf2__<float, uint32_t, 23, uint16_t, uint16_t, 10>(1.0);
-  auto zero_fp16 = __truncXfYf2__<float, uint32_t, 23, uint16_t, uint16_t, 10>(0.0);
   int32_t one_i32 = 1;
   int32_t zero_i32 = 0;
   void* alpha = &one_fp32;
@@ -165,10 +163,6 @@ void CallCublasLt(cublasLtHandle_t hdl, cudaStream_t stream,
 
   if (TypeMatch(C->dtype, kDLFloat, 16)) {
     c_type = CUDA_R_16F;
-    compute_type = CUBLAS_COMPUTE_16F;
-    scale_type = CUDA_R_16F;
-    alpha = &one_fp16;
-    beta = &zero_fp16;
   } else if (TypeMatch(C->dtype, kDLInt, 32)) {
     c_type = CUDA_R_32I;
     compute_type = CUBLAS_COMPUTE_32I;


### PR DESCRIPTION

This commit replaces fp16 compute dtype and scale dtype by fp32 in cublas matmul.

According to cuBLAS [docs](https://docs.nvidia.com/cuda/cublas/index.html#cublasltmatmul) there are two possible options for compute/scale dtype when input/output dtype is fp16:
1. compute dtype is `fp16` and scale dtype is `fp16`
2. compute dtype is `fp32` and scale dtype is `fp32`

By default, we use 1) in apache/tvm and 2) in octoml/tvm. This commit aligns different behaviour and set `fp32` as default.

cc @vinx13 @masahi 