### PR TITLE
[Bugfix][Relax] Raise exception for OOM allocation

### DIFF
--- a/include/tvm/runtime/memory/memory_manager.h
+++ b/include/tvm/runtime/memory/memory_manager.h
@@ -142,7 +142,7 @@ class StorageObj : public Object {
   /*! \brief The index into the VM function table. */
   Buffer buffer;
   /*! \brief The allocator where the storage buffer is allocated from. */
-  Allocator* allocator;
+  Allocator* allocator = nullptr;
 
   /*! \brief Allocate an NDArray from a given piece of storage. */
   TVM_DLL NDArray AllocNDArray(int64_t offset, ShapeTuple shape, DLDataType dtype);
@@ -150,7 +150,11 @@ class StorageObj : public Object {
   /*! \brief The deleter for an NDArray when allocated from underlying storage. */
   static void Deleter(Object* ptr);
 
-  ~StorageObj() { allocator->Free(buffer); }
+  ~StorageObj() {
+    if (allocator) {
+      allocator->Free(buffer);
+    }
+  }
 
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
   static constexpr const char* _type_key = "vm.Storage";

--- a/src/runtime/relax_vm/builtin.cc
+++ b/src/runtime/relax_vm/builtin.cc
@@ -343,15 +343,12 @@ Storage VMAllocStorage(void* ctx_ptr, ShapeTuple buffer_shape, Index device_inde
     device_index = vm->devices.size() - 1;
   }
 
-  auto storage_obj = runtime::SimpleObjAllocator().make_object<StorageObj>();
   auto* alloc = vm->allocators[device_index];
   ICHECK(alloc) << "Did you forget to init the VirtualMachine with devices?";
 
-  storage_obj->buffer =
-      alloc->Alloc(vm->devices[device_index], buffer_shape, dtype_hint, mem_scope);
-  storage_obj->allocator = alloc;
-  Storage storage(storage_obj);
-  return storage;
+  auto buffer = alloc->Alloc(vm->devices[device_index], buffer_shape, dtype_hint, mem_scope);
+
+  return Storage(buffer, alloc);
 }
 
 TVM_REGISTER_GLOBAL("vm.builtin.alloc_storage").set_body_typed(VMAllocStorage);


### PR DESCRIPTION
If the Relax VM attempts to allocate more memory than is available on the GPU, it should raise an exception.  Prior to this commit, an out-of-memory exception instead triggered a segfault within `"vm.builtin.alloc_storage"`.

When an allocation succeeds, the sequence of events is:

1. A `StorageObj` instance is constructed.
2. A call is made to `alloc->Alloc`, which returns the allocated buffer.
3. The allocated buffer is assigned to `StorageObj::buffer`.
4. The allocator is assigned to `StorageObj::allocator`.

However, when the GPU has insufficient memory, the sequence instead is:

1. A `StorageObj` instance is constructed.
2. A call is made to `alloc->Alloc`, which raises an out-of-memory exception.
3. In unwinding the stack, the `StorageObj` destructor is called.
4. The `StorageObj` destructor calls `allocator->Free(buffer)`.  Since neither `allocator` nor `buffer` have been defined, this causes a segfault.

This commit implements two independent fixes for this bug.

First, the `"vm.builtin.alloc_storage"` function is reordered to call `alloc->Alloc(...)` before constructing the `StorageObj` instance.  If an exception is raised during the allocation, there is no `StorageObj` instance whose destructor must be called.

Second, the `StorageObj::allocator` field is initialized to `nullptr` by default, and the destructor only calls `allocator->Free` if the `allocator` is non-null.  This prevents a similar error from occurring at any other callsites that directly construct a `StorageObj`.