### PR TITLE
[Upd] Fixed lld search in rocm

### DIFF
--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -52,7 +52,8 @@ def find_lld(required=True):
     if major is not None:
         lld_list += [f"ld.lld-{major}.0"]
         lld_list += [f"ld.lld-{major}"]
-    lld_list += ["ld.lld", "/opt/rocm/llvm/bin"]
+    lld_list += ["ld.lld"]
+    lld_list += [f"/opt/rocm/llvm/bin/{x}" for x in lld_list]
     valid_list = [utils.which(x) for x in lld_list]
     valid_list = [x for x in valid_list if x]
     if not valid_list and required:


### PR DESCRIPTION
Corrected`lld` search to include `/opt/rocm/llvm/bin` for `rocm` to generate candidates like `['ld.lld-17.0', 'ld.lld-17', 'ld.lld', '/opt/rocm/llvm/bin/ld.lld-17.0', '/opt/rocm/llvm/bin/ld.lld-17', '/opt/rocm/llvm/bin/ld.lld']`

cc @tqchen 