### PR TITLE
Overriding the StructuralEqual() for easy usage

### DIFF
--- a/include/tvm/node/structural_equal.h
+++ b/include/tvm/node/structural_equal.h
@@ -111,7 +111,8 @@ class StructuralEqual : public BaseValueEqual {
    * \param map_free_params Whether or not to map free variables.
    * \return The comparison result.
    */
-  TVM_DLL bool operator()(const ObjectRef& lhs, const ObjectRef& rhs, const bool map_free_params = false) const;
+  TVM_DLL bool operator()(const ObjectRef& lhs, const ObjectRef& rhs,
+                          const bool map_free_params = false) const;
 };
 
 /*!

--- a/include/tvm/node/structural_equal.h
+++ b/include/tvm/node/structural_equal.h
@@ -110,7 +110,7 @@ class StructuralEqual : public BaseValueEqual {
    * \param rhs The right operand.
    * \return The comparison result.
    */
-  TVM_DLL bool operator()(const ObjectRef& lhs, const ObjectRef& rhs) const;
+  TVM_DLL bool operator()(const ObjectRef& lhs, const ObjectRef& rhs, const bool map_free_params = false) const;
 };
 
 /*!

--- a/include/tvm/node/structural_equal.h
+++ b/include/tvm/node/structural_equal.h
@@ -108,6 +108,7 @@ class StructuralEqual : public BaseValueEqual {
    * \brief Compare objects via strutural equal.
    * \param lhs The left operand.
    * \param rhs The right operand.
+   * \param map_free_params Whether or not to map free variables.
    * \return The comparison result.
    */
   TVM_DLL bool operator()(const ObjectRef& lhs, const ObjectRef& rhs, const bool map_free_params = false) const;

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -563,8 +563,8 @@ TVM_REGISTER_GLOBAL("node.GetFirstStructuralMismatch")
       return first_mismatch;
     });
 
-bool StructuralEqual::operator()(const ObjectRef& lhs, const ObjectRef& rhs) const {
-  return SEqualHandlerDefault(false, nullptr, false).Equal(lhs, rhs, false);
+bool StructuralEqual::operator()(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_params) const {
+  return SEqualHandlerDefault(false, nullptr, false).Equal(lhs, rhs, map_free_params);
 }
 
 bool NDArrayEqual(const runtime::NDArray::Container* lhs, const runtime::NDArray::Container* rhs,

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -563,7 +563,8 @@ TVM_REGISTER_GLOBAL("node.GetFirstStructuralMismatch")
       return first_mismatch;
     });
 
-bool StructuralEqual::operator()(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_params) const {
+bool StructuralEqual::operator()(const ObjectRef& lhs, const ObjectRef& rhs,
+                                 bool map_free_params) const {
   return SEqualHandlerDefault(false, nullptr, false).Equal(lhs, rhs, map_free_params);
 }
 


### PR DESCRIPTION
Override the StrucutralEqual operator () to ensure easy usage of the function. 

@jverma-quic and @quic-sanirudh can you please take a look. 