### PR TITLE
[Web] Support string[] in setPackedFunc() and exceptionally long arrays

### DIFF
--- a/src/runtime/container.cc
+++ b/src/runtime/container.cc
@@ -49,23 +49,6 @@ TVM_REGISTER_GLOBAL("runtime.Array").set_body([](TVMArgs args, TVMRetValue* ret)
   *ret = Array<ObjectRef>(data);
 });
 
-// Concatenate n TVMArrays
-TVM_REGISTER_GLOBAL("runtime.ArrayConcat").set_body([](TVMArgs args, TVMRetValue* ret) {
-  std::vector<ObjectRef> data;
-  for (int i = 0; i < args.size(); ++i) {
-    // Get i-th TVMArray
-    ICHECK_EQ(args[i].type_code(), kTVMObjectHandle);
-    Object* ptr = static_cast<Object*>(args[i].value().v_handle);
-    ICHECK(ptr->IsInstance<ArrayNode>());
-    auto* arr_i = static_cast<const ArrayNode*>(ptr);
-    for (int j = 0; j < arr_i->size(); j++) {
-      // Push back each j-th element of the i-th array
-      data.push_back(arr_i->at(j));
-    }
-  }
-  *ret = Array<ObjectRef>(data);
-});
-
 TVM_REGISTER_GLOBAL("runtime.ArrayGetItem").set_body([](TVMArgs args, TVMRetValue* ret) {
   int64_t i = args[1];
   ICHECK_EQ(args[0].type_code(), kTVMObjectHandle);

--- a/src/runtime/container.cc
+++ b/src/runtime/container.cc
@@ -49,6 +49,23 @@ TVM_REGISTER_GLOBAL("runtime.Array").set_body([](TVMArgs args, TVMRetValue* ret)
   *ret = Array<ObjectRef>(data);
 });
 
+// Concatenate n TVMArrays
+TVM_REGISTER_GLOBAL("runtime.ArrayConcat").set_body([](TVMArgs args, TVMRetValue* ret) {
+  std::vector<ObjectRef> data;
+  for (int i = 0; i < args.size(); ++i) {
+    // Get i-th TVMArray
+    ICHECK_EQ(args[i].type_code(), kTVMObjectHandle);
+    Object* ptr = static_cast<Object*>(args[i].value().v_handle);
+    ICHECK(ptr->IsInstance<ArrayNode>());
+    auto* arr_i = static_cast<const ArrayNode*>(ptr);
+    for (int j = 0; j < arr_i->size(); j++) {
+      // Push back each j-th element of the i-th array
+      data.push_back(arr_i->at(j));
+    }
+  }
+  *ret = Array<ObjectRef>(data);
+});
+
 TVM_REGISTER_GLOBAL("runtime.ArrayGetItem").set_body([](TVMArgs args, TVMRetValue* ret) {
   int64_t i = args[1];
   ICHECK_EQ(args[0].type_code(), kTVMObjectHandle);

--- a/web/emcc/wasm_runtime.cc
+++ b/web/emcc/wasm_runtime.cc
@@ -156,5 +156,22 @@ void ArrayDecodeStorage(NDArray cpu_arr, std::string bytes, std::string format, 
 }
 
 TVM_REGISTER_GLOBAL("tvmjs.array.decode_storage").set_body_typed(ArrayDecodeStorage);
+
+// Concatenate n TVMArrays
+TVM_REGISTER_GLOBAL("tvmjs.runtime.ArrayConcat").set_body([](TVMArgs args, TVMRetValue* ret) {
+  std::vector<ObjectRef> data;
+  for (int i = 0; i < args.size(); ++i) {
+    // Get i-th TVMArray
+    ICHECK_EQ(args[i].type_code(), kTVMObjectHandle);
+    Object* ptr = static_cast<Object*>(args[i].value().v_handle);
+    ICHECK(ptr->IsInstance<ArrayNode>());
+    auto* arr_i = static_cast<const ArrayNode*>(ptr);
+    for (size_t j = 0; j < arr_i->size(); ++j) {
+      // Push back each j-th element of the i-th array
+      data.push_back(arr_i->at(j));
+    }
+  }
+  *ret = Array<ObjectRef>(data);
+});
 }  // namespace runtime
 }  // namespace tvm

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tvmjs",
-  "version": "0.16.0-dev0",
+  "version": "0.17.0-dev0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tvmjs",
-      "version": "0.16.0-dev0",
+      "version": "0.17.0-dev0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^20.0.0",

--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -181,7 +181,7 @@ class RuntimeContext implements Disposable {
     this.arrayGetItem = getGlobalFunc("runtime.ArrayGetItem");
     this.arrayGetSize = getGlobalFunc("runtime.ArraySize");
     this.arrayMake = getGlobalFunc("runtime.Array");
-    this.arrayConcat = getGlobalFunc("runtime.ArrayConcat");
+    this.arrayConcat = getGlobalFunc("tvmjs.runtime.ArrayConcat");
     this.stringMake = getGlobalFunc("runtime.String");
     this.getFFIString = getGlobalFunc("runtime.GetFFIString");
     this.getSysLib = getGlobalFunc("runtime.SystemLib");


### PR DESCRIPTION
There are two changes in this PR.

#### Change 1: Support `string[]` in `setPackedFunc()`
Prior to this PR, we cannot pass in `string[]` from typescript to a TVM PackedFunc and need to convert it to `TVMArray<TVMString>` (for instance in `getParamsFromCacheByName()`). This may not be the most convenient if the PackedFunc's caller is not internal to tvmjs. Thus, this PR moves the conversion to `setPackedFunc()` instead.

#### Change 2: Support exceptionally long TVM arrays
The second change is dealing with exceptionally long TVM arrays. In cases like passing in a token table, we need to pass in a long `string[]` (in Llama-3's case, of size 128000), leading to JS error `RangeError: Maximum call stack size exceeded` since we treat each string element as an argument, shown in `this.ctx.arrayMake(...inputs)`. 

This PR sets an empirical call stack limit of 30000 and chunks the array elements in `makeTVMArray()`, converting each chunk to its own TVMArray. Then we concatenate them with the newly implemented `runtime.ArrayConcat` that concatenates N TVMArrays.

Tested end-to-end in WebLLM.