### PR TITLE
[Fix] Fix SSA conversion for SizeVar retention

### DIFF
--- a/src/tir/transforms/ir_utils.cc
+++ b/src/tir/transforms/ir_utils.cc
@@ -435,10 +435,19 @@ class IRConvertSSA final : public StmtExprMutator {
  private:
   struct ScopedRedefine {
     ScopedRedefine(IRConvertSSA* parent, Var old_var) : parent(parent), old_var(old_var) {
+      bool is_size_var = old_var->IsInstance<SizeVarNode>();
       if (old_var->type_annotation.defined()) {
-        new_var = Var(old_var->name_hint, old_var->type_annotation);
+        if (is_size_var) {
+          new_var = SizeVar(old_var->name_hint, old_var->type_annotation);
+        } else {
+          new_var = Var(old_var->name_hint, old_var->type_annotation);
+        }
       } else {
-        new_var = Var(old_var->name_hint, old_var->dtype);
+        if (is_size_var) {
+          new_var = SizeVar(old_var->name_hint, old_var->dtype);
+        } else {
+          new_var = Var(old_var->name_hint, old_var->dtype);
+        }
       }
       parent->scope_[old_var.get()].push_back(new_var);
     }


### PR DESCRIPTION
This PR fixes the var construction in IRConvertSSA, which always casts SizeVar to Var. This behavior leads to expr not being able to get simplified in the LowerIntrin pass later on. Specifically, if not using SizeVar, the LowerIntrin pass loses the information of the non-negative var information, and cannot simply a bunch of FloorDiv/FloorMod expressions.

One regression test for SplitHostDevice is added to ensure the retention of SizeVar. Adding the test in SplitHostDevice because this is where the SSA conversion is used.