### PR TITLE
[UnitTest] Use pytest's scope='session' for tvm.testing.parameter

### DIFF
--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -1447,7 +1447,7 @@ def parameter(*values, ids=None, by_dict=None):
 
     # Optional cls parameter in case a parameter is defined inside a
     # class scope.
-    @pytest.fixture(params=values, ids=ids)
+    @pytest.fixture(params=values, ids=ids, scope="session")
     def as_fixture(*_cls, request):
         return request.param
 

--- a/tests/python/testing/test_tvm_testing_features.py
+++ b/tests/python/testing/test_tvm_testing_features.py
@@ -290,5 +290,16 @@ class TestCacheableTypes:
         pass
 
 
+class TestPytestCache:
+    param = tvm.testing.parameter(1, 2, 3)
+
+    @pytest.fixture(scope="class")
+    def cached_fixture(self, param):
+        return param * param
+
+    def test_uses_cached_fixture(self, param, cached_fixture):
+        assert cached_fixture == param * param
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Prior to this commit, the `tvm.testing.parameter` utility defined a fixture with the default `scope="function"`.  However, this prevents use of these parameters as arguments for other fixtures that are themselves cached using pytest.  Since these are parameters, not large values that would be expensive to compute, there is no downside to caching them at the pytest level.

This commit updates the scope of fixtures generated using `tvm.testing.parameter` to use `scope="session"` instead of the default `scope="function"`.