### PR TITLE
[CI] Use LLVM17 for tests on `ci_cpu`

### DIFF
--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -1750,6 +1750,16 @@ class TestConv2DInt8Intrinsics:
         data_layout,
         kernel_layout,
     ):
+        if (
+            input_channels == 17
+            and output_channels == 29
+            and target == "llvm -mcpu=x86-64"
+            and tvm.target.codegen.llvm_version_major() in [16, 17]
+        ):
+            pytest.skip(
+                "Non divisible dims does not produce vectorized code when 15 < LLVM Version < 18."
+            )
+
         input_dtype, weight_dtype, output_dtype = dtypes
 
         image_size = (64, 64)

--- a/tests/scripts/task_config_build_cpu.sh
+++ b/tests/scripts/task_config_build_cpu.sh
@@ -29,7 +29,7 @@ echo set\(USE_MICRO_STANDALONE_RUNTIME ON\) >> config.cmake
 echo set\(USE_PROFILER ON\) >> config.cmake
 echo set\(USE_DNNL ON\) >> config.cmake
 echo set\(USE_ARM_COMPUTE_LIB ON\) >> config.cmake
-echo set\(USE_LLVM \"/usr/bin/llvm-config-15 --link-static\"\) >> config.cmake
+echo set\(USE_LLVM \"/usr/bin/llvm-config-17 --link-static\"\) >> config.cmake
 echo set\(USE_NNPACK ON\) >> config.cmake
 echo set\(NNPACK_PATH /NNPACK/build/\) >> config.cmake
 echo set\(USE_ANTLR ON\) >> config.cmake


### PR DESCRIPTION
Changes the config script to build TVM with LLVM17. This enables tests for #16921.