### PR TITLE
[Relax] Allow PrimValue as index in relax.op.take

### DIFF
--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -116,7 +116,7 @@ class BlockBuilderNode : public Object {
    * \brief Report an error during transformation construction.
    * \param diagnostic The diagnostic information.
    */
-  virtual void ReportFatal(const Diagnostic& diagnostic) = 0;
+  [[noreturn]] virtual void ReportFatal(const Diagnostic& diagnostic) = 0;
 
   //-------------------------------
   // Scope management

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -1085,7 +1085,7 @@ inline Tensor take(const Tensor& a, Variant<Tensor, PrimExpr> indices, int batch
   for (int i = batch_dims_; i < axis; ++i) {
     out_shape.push_back(a->shape[i]);
   }
-  for (size_t i = static_cast<size_t>(batch_dims_); i < indices_len; ++i) {
+  for (int i = batch_dims_; i < indices_len; ++i) {
     out_shape.push_back(indices_shape[i]);
   }
   for (size_t i = axis + 1; i < a->shape.size(); ++i) {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -149,7 +149,7 @@ class BlockBuilderImpl : public BlockBuilderNode {
     }
   }
 
-  void ReportFatal(const Diagnostic& diagnostic) final {
+  [[noreturn]] void ReportFatal(const Diagnostic& diagnostic) final {
     // TODO(relax-team): Print more context information by looking
     // into the diagnostic->loc and surrounding IRModule.
     // We do not materialzie DiagnosticContext to avoid double referencing to

--- a/src/relax/op/op_common.cc
+++ b/src/relax/op/op_common.cc
@@ -63,6 +63,10 @@ TensorStructInfo GetInputTensorStructInfo(const Call& call, size_t i_arg, const 
                      << "Operator " << op << " requires argument " << i_arg << " ("
                      << op->arguments[i_arg]->name << ") to be a tensor.  "
                      << "However, the argument " << arg << " is instead of type " << sinfo);
+    // Unreachable, but [[noreturn]] attribute on virtual function
+    // `ReportFatal` is insufficient to silence -Wreturn-type, as
+    // child class might not be [[noreturn]].
+    return TensorStructInfo();
   }
 }
 
@@ -71,7 +75,7 @@ Array<TensorStructInfo> GetInputTensorStructInfo(const Call& call, const BlockBu
 
   Op op = Downcast<Op>(call->op);
   Array<TensorStructInfo> input_tensor_sinfo;
-  for (int i = 0; i < call->args.size(); ++i) {
+  for (size_t i = 0; i < call->args.size(); ++i) {
     input_tensor_sinfo.push_back(GetInputTensorStructInfo(call, i, ctx));
   }
   return input_tensor_sinfo;

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -45,6 +45,27 @@ namespace relax {
 /************ Op input struct info getter ************/
 
 /*!
+ * \brief Check that the operator has
+ *
+ * Verify that the number of arguments matches the expected number for
+ * the operator.
+ *
+ * \param call The context Call to the operator.
+ *
+ * \param ctx The error reporting context.
+ */
+void CheckNumArguments(const Call& call, const BlockBuilder& ctx);
+
+/*!
+ * \brief Get the tensor struct info of the operator input.
+ * \param call The context Call to the operator.
+ * \param i_arg The index of the argument to check
+ * \param ctx The error reporting context.
+ * \return The tensor struct info of the argument
+ */
+TensorStructInfo GetInputTensorStructInfo(const Call& call, size_t i_arg, const BlockBuilder& ctx);
+
+/*!
  * \brief Get the tensor struct info of the operator input.
  * \param call The context Call to the operator.
  * \param ctx The error reporting context.

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -61,6 +61,10 @@ StructInfo InferStructInfoTake(const Call& call, const BlockBuilder& ctx) {
                        << "Operator " << call->op << " requires the indices argument to be "
                        << "either a tensor or a scalar value.  "
                        << "However, argument " << arg << " has struct info " << sinfo);
+      // Unreachable, but [[noreturn]] attribute on virtual function
+      // `ReportFatal` is insufficient to silence -Wreturn-type, as
+      // child class might not be [[noreturn]].
+      return TensorStructInfo();
     }
   }();
 

--- a/tests/python/relax/test_op_index.py
+++ b/tests/python/relax/test_op_index.py
@@ -194,6 +194,24 @@ def test_take_infer_struct_info():
     _check_inference(bb, relax.op.take(y3, idx7), relax.TensorStructInfo(dtype="", ndim=2))
 
 
+def test_take_infer_struct_info_scalar_tensor_index():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((4, 10), "float32"))
+    idx = relax.Var("idx", R.Tensor([], "int64"))
+
+    _check_inference(bb, relax.op.take(x0, idx, axis=0), relax.TensorStructInfo([10], "float32"))
+    _check_inference(bb, relax.op.take(x0, idx, axis=1), relax.TensorStructInfo([4], "float32"))
+
+
+def test_take_infer_struct_info_prim_value_index():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((4, 10), "float32"))
+    idx = relax.Var("idx", R.Prim("int64"))
+
+    _check_inference(bb, relax.op.take(x0, idx, axis=0), relax.TensorStructInfo([10], "float32"))
+    _check_inference(bb, relax.op.take(x0, idx, axis=1), relax.TensorStructInfo([4], "float32"))
+
+
 def test_take_infer_struct_info_shape_symbolic():
     bb = relax.BlockBuilder()
     m = tir.Var("m", "int64")

--- a/tests/python/relax/test_op_take.py
+++ b/tests/python/relax/test_op_take.py
@@ -1,0 +1,158 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+from tvm.script import ir as I, relax as R, tir as T
+
+import numpy as np
+
+axis = tvm.testing.parameter(0, 1)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_take_scalar_tensor_as_index(target, dev, axis):
+    """The index of R.take may be a scalar tensor
+
+    Using a scalar tensor as the index reduces the dimension of the
+    output.
+
+    """
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16, 16], "float16")):
+            output = R.take(A, R.const(1), axis=axis)
+            return output
+
+    built = tvm.relax.build(Module, target=target)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    np_input = np.random.random(size=[16, 16]).astype("float16")
+    tvm_input = tvm.nd.array(np_input, dev)
+    tvm_output = vm["main"](tvm_input)
+    np_expected = np_input.take(1, axis=axis)
+
+    tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_take_1d_tensor_as_index(target, dev, axis):
+    """The index of R.take may be a non-scalar tensor
+
+    In general, `R.take` outputs a tensor of dimension
+    `data.ndim + indices.ndim - 1`.
+    """
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16, 16], "float16")):
+            output = R.take(A, R.const([1]), axis=axis)
+            return output
+
+    built = tvm.relax.build(Module, target=target)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    np_input = np.random.random(size=[16, 16]).astype("float16")
+    tvm_input = tvm.nd.array(np_input, dev)
+    tvm_output = vm["main"](tvm_input)
+    np_expected = np_input.take([1], axis=axis)
+
+    tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_take_2d_tensor_as_index(target, dev, axis):
+    """The index of R.take may be a 2-d tensor"""
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16, 16], "float16")):
+            output = R.take(A, R.const([[1, 3], [5, 7]]), axis=axis)
+            return output
+
+    built = tvm.relax.build(Module, target=target)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    np_input = np.random.random(size=[16, 16]).astype("float16")
+    tvm_input = tvm.nd.array(np_input, dev)
+    tvm_output = vm["main"](tvm_input)
+    np_expected = np_input.take([[1, 3], [5, 7]], axis=axis)
+
+    tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_take_constant_prim_value_as_index(target, dev, axis):
+    """The index of R.take may be a R.prim_value
+
+    The `R.prim_value` produces output equivalent to a scalar
+    tensor.
+
+    """
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16, 16], "float16")):
+            output = R.take(A, R.prim_value(1), axis=axis)
+            return output
+
+    built = tvm.relax.build(Module, target=target)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    np_input = np.random.random(size=[16, 16]).astype("float16")
+    tvm_input = tvm.nd.array(np_input, dev)
+    tvm_output = vm["main"](tvm_input)
+    np_expected = np_input.take(1, axis=axis)
+
+    tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_take_dynamic_prim_value_as_index(target, dev, axis):
+    """The index of R.take may be a dynamic R.prim_value
+
+    The `R.prim_value` produces output equivalent to a scalar
+    tensor.
+
+    """
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor(["n", "n"], "float16")):
+            n = T.int64()
+            output = R.take(A, R.prim_value(n - 1), axis=axis)
+            return output
+
+    built = tvm.relax.build(Module, target=target)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    np_input = np.random.random(size=[16, 16]).astype("float16")
+    tvm_input = tvm.nd.array(np_input, dev)
+    tvm_output = vm["main"](tvm_input)
+    np_expected = np_input.take(15, axis=axis)
+
+    tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_transform_legalize_ops_index_linear_algebra.py
+++ b/tests/python/relax/test_transform_legalize_ops_index_linear_algebra.py
@@ -55,6 +55,68 @@ def test_take():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_take_prim_value():
+    # fmt: off
+    @tvm.script.ir_module
+    class Take:
+        @R.function
+        def main(x: R.Tensor((2, 3, 4), "float32"), index: R.Prim("int64")) -> R.Tensor((2, 4), "float32"):
+            gv: R.Tensor((2, 4), "float32") = R.take(x, index, axis=1)
+            return gv
+
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((2, 3, 4), "float32"), index: R.Prim("int64")) -> R.Tensor((2, 4), "float32"):
+            gv = R.call_tir(Expected.take, (x, index), R.Tensor((2, 4), dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def take(rxplaceholder: T.Buffer((T.int64(2), T.int64(3), T.int64(4)), "float32"), index: T.int64, T_take: T.Buffer((T.int64(2), T.int64(4)), "float32")):
+            T.func_attr({"tir.noalias": True})
+            for i0, i2 in T.grid(T.int64(2), T.int64(4)):
+                with T.block("T_take"):
+                    ax0, ax2 = T.axis.remap("SS", [i0, i2])
+                    T.reads(rxplaceholder[ax0, index, ax2])
+                    T.writes(T_take[ax0, ax2])
+                    T_take[ax0, ax2] = rxplaceholder[ax0, index, ax2]
+    # fmt: on
+
+    mod = LegalizeOps()(Take)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_take_const_prim_value():
+    # fmt: off
+    @tvm.script.ir_module
+    class Take:
+        @R.function
+        def main(x: R.Tensor((2, 3, 4), "float32")) -> R.Tensor((2, 4), "float32"):
+            gv: R.Tensor((2, 4), "float32") = R.take(x, R.prim_value(0), axis=1)
+            return gv
+
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((2, 3, 4), "float32")) -> R.Tensor((2, 4), "float32"):
+            gv = R.call_tir(Expected.take, (x,), R.Tensor((2, 4), dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def take(rxplaceholder: T.Buffer((T.int64(2), T.int64(3), T.int64(4)), "float32"), T_take: T.Buffer((T.int64(2), T.int64(4)), "float32")):
+            T.func_attr({"tir.noalias": True})
+            for i0, i2 in T.grid(T.int64(2), T.int64(4)):
+                with T.block("T_take"):
+                    ax0, ax2 = T.axis.remap("SS", [i0, i2])
+                    T.reads(rxplaceholder[ax0, T.int64(0), ax2])
+                    T.writes(T_take[ax0, ax2])
+                    T_take[ax0, ax2] = rxplaceholder[ax0, T.int64(0), ax2]
+    # fmt: on
+
+    mod = LegalizeOps()(Take)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
 def test_take_symbolic():
     # fmt: off
     @tvm.script.ir_module
@@ -90,6 +152,41 @@ def test_take_symbolic():
                     T.reads(rxplaceholder[ax0, rxplaceholder_1[ax1]], rxplaceholder_1[ax1])
                     T.writes(T_take[ax0, ax1])
                     T_take[ax0, ax1] = rxplaceholder[ax0, rxplaceholder_1[ax1]]
+    # fmt: on
+
+    mod = LegalizeOps()(Take)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_take_symbolic_prim_value():
+    # fmt: off
+    @tvm.script.ir_module
+    class Take:
+        @R.function
+        def main(x: R.Tensor((2, "n", 4), "float32")) -> R.Tensor((2, 4), "float32"):
+            n = T.int64()
+            gv: R.Tensor((2, 4), "float32") = R.take(x, R.prim_value(n-1), axis=1)
+            return gv
+
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((2, "n", 4), "float32")) -> R.Tensor((2, 4), "float32"):
+            gv = R.call_tir(Expected.take, (x,), R.Tensor((2, 4), dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True)
+        def take(x_handle: T.handle, T_take: T.Buffer((T.int64(2), T.int64(4)), "float32")):
+            n = T.int64()
+            rxplaceholder = T.match_buffer(x_handle, (T.int64(2), n, T.int64(4)), "float32")
+
+            T.func_attr({"tir.noalias": True})
+            for i0, i2 in T.grid(T.int64(2), T.int64(4)):
+                with T.block("T_take"):
+                    ax0, ax2 = T.axis.remap("SS", [i0, i2])
+                    T.reads(rxplaceholder[ax0, n-1, ax2])
+                    T.writes(T_take[ax0, ax2])
+                    T_take[ax0, ax2] = rxplaceholder[ax0, n-1, ax2]
     # fmt: on
 
     mod = LegalizeOps()(Take)


### PR DESCRIPTION
Prior to this commit, the `relax.op.take` only allowed tensors as the `indices` argument.  This commit extends `R.take` to also allow the index to be a `relax::PrimValue`.