### PR TITLE
[HotFix][CI] Use macOS-12 instead of macOS-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   MacOS:
     if: ${{ github.repository == 'apache/tvm' }}
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The github `macOS-latest` tag is updating from `macOS-12` to `macOS-14` ([github changelog](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/)). While the `macOS-12` environment provided miniconda by default, the `macOS-14` environment does not (default installations for [`macOS-12`](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md) and for [`macOS-14`](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)). This is causing spurious failures across several PRs, as no base environment is found (CI links to recent examples: [link](https://github.com/apache/tvm/actions/runs/8860158060/job/24330642411?pr=16940#step:3:40), [link](https://github.com/apache/tvm/actions/runs/8860112927/job/24330555555?pr=16938#step:3:40), [link](https://github.com/apache/tvm/actions/runs/8852983771/job/24330650551?pr=16930#step:3:40)).

This commit is a temporary fix, replacing the `macOS-latest` tag with `macOS-12`.