### PR TITLE
[SVE] Add codegen support for `vscale_range()` function attribute

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -104,7 +104,6 @@
 #include <vector>
 
 #include "../../arith/pattern_match.h"
-#include "../../arith/scalable_expression.h"
 #include "../build_common.h"
 #include "../func_registry_generator.h"
 #include "codegen_params.h"
@@ -1128,13 +1127,6 @@ void CodeGenLLVM::SetTargetAttributes(llvm::Function* func) {
   if (!features.empty()) {
     func->addFnAttr("target-features", features);
   }
-#if TVM_LLVM_VERSION >= 130
-  // Add vscale_range() function attribute when appropriate.
-  if (llvm_target_->TargetHasCPUFeature("sve") || llvm_target_->TargetHasCPUFeature("sme")) {
-    func->addFnAttr(llvm::Attribute::getWithVScaleRangeArgs(
-        *llvm_target_->GetContext(), 1, tvm::arith::kAArch64VScaleValues.size()));
-  }
-#endif
 }
 
 void CodeGenLLVM::EmitFloat16ConversionBuiltins(bool use_float16_abi) {

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -104,6 +104,7 @@
 #include <vector>
 
 #include "../../arith/pattern_match.h"
+#include "../../arith/scalable_expression.h"
 #include "../build_common.h"
 #include "../func_registry_generator.h"
 #include "codegen_params.h"
@@ -1127,6 +1128,13 @@ void CodeGenLLVM::SetTargetAttributes(llvm::Function* func) {
   if (!features.empty()) {
     func->addFnAttr("target-features", features);
   }
+#if TVM_LLVM_VERSION >= 130
+  // Add vscale_range() function attribute when appropriate.
+  if (llvm_target_->TargetHasCPUFeature("sve") || llvm_target_->TargetHasCPUFeature("sme")) {
+    func->addFnAttr(llvm::Attribute::getWithVScaleRangeArgs(
+        *llvm_target_->GetContext(), 1, tvm::arith::kAArch64VScaleValues.size()));
+  }
+#endif
 }
 
 void CodeGenLLVM::EmitFloat16ConversionBuiltins(bool use_float16_abi) {

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -427,7 +427,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
                                    llvm::ArrayRef<llvm::Type*> arg_types);
   /*!
    * \brief Set target-related attributes on the LLVM function \p func. This
-   *        includes "target-cpu" and "target-features" if present.
+   *        includes "target-cpu", "target-features" and "vscale_range()" if present.
    *
    * \param func The function to set attributes on.
    */

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -427,11 +427,11 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
                                    llvm::ArrayRef<llvm::Type*> arg_types);
   /*!
    * \brief Set target-related attributes on the LLVM function \p func. This
-   *        includes "target-cpu", "target-features" and "vscale_range()" if present.
+   *        includes "target-cpu" and "target-features" if present.
    *
    * \param func The function to set attributes on.
    */
-  void SetTargetAttributes(llvm::Function* func);
+  virtual void SetTargetAttributes(llvm::Function* func);
   /*!
    * \brief Emit LLVM IR for conversion functions __extendhfsf2 and __truncsfhf2
    *        into the current llvm::Module.


### PR DESCRIPTION
This commit adds support for the `vscale_range()` LLVM function attribute to be generated for SVE and SME targets. 

Some LLVM optimisation passes make use of the `vscale_range()` function attribute when scalable vectors are present (e.g. BasicAA llvm/llvm-project/pull/80445), so we include it alongside the "target_cpu" and "target-features" attributes.  

cc @lhutton1 