### PR TITLE
[LLVM] Stringref API deprecation fixes

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -372,7 +372,11 @@ std::unique_ptr<llvm::Module> CodeGenLLVM::Finish() {
 void CodeGenLLVM::HandleImport(const std::string& code) {
   llvm::StringRef code_str(code);
   std::unique_ptr<llvm::Module> mlib;
+#if TVM_LLVM_VERSION >= 180
+  if (code_str.ends_with(".ll") || code_str.ends_with(".bc")) {
+#else
   if (code_str.endswith(".ll") || code_str.endswith(".bc")) {
+#endif
     mlib = llvm_target_->GetInstance().LoadIR(code);
   } else {
     mlib = llvm_target_->GetInstance().ParseIR(code);

--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -916,7 +916,11 @@ std::string LLVMTarget::GetTargetMetadata(const llvm::Module& module) {
   if (llvm::Metadata* tvm_target = module.getModuleFlag("tvm_target")) {
     auto* mdstr = llvm::cast<llvm::MDString>(tvm_target);
     llvm::StringRef meta = mdstr->getString();
+#if TVM_LLVM_VERSION >= 180
+    if (meta.starts_with("llvm")) {
+#else
     if (meta.startswith("llvm")) {
+#endif
       return meta.str();
     }
   }


### PR DESCRIPTION
The `startswith`/`endswith` functions in `StringRef` API were [changed](https://reviews.llvm.org/D136030) to `starts_with` and `ends_with` to be compatible with `std::string` and the older APIs were deprecated and removed.