### PR TITLE
[CI] Enable unittests for disco

### DIFF
--- a/tests/scripts/task_python_unittest.sh
+++ b/tests/scripts/task_python_unittest.sh
@@ -39,6 +39,7 @@ TEST_FILES=(
   "auto_scheduler"
   "autotvm"
   "codegen"
+  "disco"
   "ir"
   "meta_schedule"
   "micro"


### PR DESCRIPTION
The refactor of the unittest folder in #16110 did not include the `tests/python/disco` folder in the list of folders to run in CI.