### PR TITLE
[Unity][BYOC] Use arith.Analyzer to check batch equality of matmul in cublas

### DIFF
--- a/python/tvm/relax/backend/contrib/cublas.py
+++ b/python/tvm/relax/backend/contrib/cublas.py
@@ -119,7 +119,7 @@ def _check_matmul(context: PatternCheckContext) -> bool:
         if not isinstance(bias_batches, (tvm.tir.expr.IntImm, int)) or int(bias_batches) > 1:
             # cuBLAS only supports bias vector
             return False
-        
+
     analyzer = Analyzer()
 
     # cuBLASLt does not seem to support batched GEMM with one of matrices having

--- a/python/tvm/relax/backend/contrib/cublas.py
+++ b/python/tvm/relax/backend/contrib/cublas.py
@@ -21,6 +21,7 @@ from functools import reduce
 
 import tvm
 from tvm import DataType
+from tvm.arith import Analyzer
 from tvm.relax import transform
 from tvm.relax.transform import PatternCheckContext
 
@@ -118,6 +119,8 @@ def _check_matmul(context: PatternCheckContext) -> bool:
         if not isinstance(bias_batches, (tvm.tir.expr.IntImm, int)) or int(bias_batches) > 1:
             # cuBLAS only supports bias vector
             return False
+        
+    analyzer = Analyzer()
 
     # cuBLASLt does not seem to support batched GEMM with one of matrices having
     # one batch (with batch_stride 0). So for batched GEMM, the two batch counts
@@ -126,7 +129,7 @@ def _check_matmul(context: PatternCheckContext) -> bool:
     return (
         isinstance(lhs_batches, tvm.tir.Var)
         or isinstance(rhs_batches, tvm.tir.Var)
-        or (int(lhs_batches) == int(rhs_batches))
+        or (analyzer.can_prove_equal(lhs_batches, rhs_batches))
         or (lhs_batches >= 1 and rhs_batches == 1)
     )
 

--- a/tests/python/relax/test_codegen_cublas.py
+++ b/tests/python/relax/test_codegen_cublas.py
@@ -149,6 +149,8 @@ def get_relax_matmul_dequantize_module(
         ((_vars["a"], 32, 8), (_vars["a"], 8, 10), True, "gelu"),
         # ND x ND
         ((5, 3, 32, 8), (5, 3, 8, 10), True, "relu"),
+        ((_vars["a"], 3, 32, 8), (_vars["a"], 3, 8, 10), True, "relu"),
+        ((_vars["a"], _vars["b"], 32, 8), (_vars["a"], _vars["b"], 8, 10), True, "relu"),
         # ND x 2D
         ((5, 3, 32, 8), (8, 10), False, "none"),
     ],


### PR DESCRIPTION
For workloads with a mixture of symbolic shape and concrete shape as batch sizes, we cannot directly use `int()` to obtain the batch size. Instead, we can use `arith.Analyzer` to check equality.

For example:
```
permute_dims1: R.Tensor((batch_size, 12, seq_len, 64), dtype="float16") = R.permute_dims(split_0, axes=[0, 2, 1, 3])
permute_dims2: R.Tensor((batch_size, 12, seq_len, 64), dtype="float16") = R.permute_dims(split_1, axes=[0, 2, 1, 3])
permute_dims3: R.Tensor((batch_size, 12, seq_len, 64), dtype="float16") = R.permute_dims(split_2, axes=[0, 2, 1, 3])
permute_dims4: R.Tensor((batch_size, 12, 64, seq_len), dtype="float16") = R.permute_dims(permute_dims2, axes=[0, 1, 3, 2])
matmul1: R.Tensor((batch_size, 12, seq_len, seq_len), dtype="float16") = R.matmul(permute_dims1, permute_dims4, out_dtype="float16")
``` 