### PR TITLE
[BugFix][Relay] skip leaf args when matching 'path' part for dominator pattern

### DIFF
--- a/src/relay/ir/dataflow_matcher.cc
+++ b/src/relay/ir/dataflow_matcher.cc
@@ -300,11 +300,17 @@ bool DFPatternMatcher::VisitDFPattern_(const CallPatternNode* op, const Expr& ex
 
 // Recursively find the Dominator parent along all inputs paths.
 bool DFPatternMatcher::MatchesPath(const DominatorPatternNode* op, const Expr& expr) {
+  // utilities
+  auto is_leaf_node = [](const Expr& expr) {
+    return expr.as<ConstantNode>() || expr.as<VarNode>();
+  };
+
+  // logic
   auto call_node = expr.as<CallNode>();
   auto index_node = expr_to_node(expr);
   size_t arg_counter{0};
   for (auto node : index_node->inputs_) {
-    if (!(call_node && node->ref() == call_node->op)) {
+    if (!(call_node && (node->ref() == call_node->op || is_leaf_node(node->ref())))) {
       arg_counter += 1;
       memoize_ = true;
       if (!VisitDFPattern(op->parent, node->ref())) {


### PR DESCRIPTION
This is a patch for PR https://github.com/apache/tvm/pull/15473
That PR tried to solve the issues described in [RFC](https://discuss.tvm.apache.org/t/improving-dataflow-pattern-matching-for-relay/15344), but introduced another issue, probably unintentionally.
The new issue occurs, when there are some leaf args of some OPs along the path during matching 'path' part for dominator pattern. For example, suppose we have a dominator pattern as follows:
```python
    conv2d_pat = is_op("nn.conv2d")(wildcard(), wildcard())
    eltwise_pat = (wildcard().has_attr({"TOpPattern": K_ELEMWISE}))(None)
    broadcast_pat = (wildcard().has_attr({"TOpPattern": K_BROADCAST}))(None)
    path_pat = eltwise_pat | broadcast_pat
    injective_pat = (wildcard().has_attr({"TOpPattern": K_INJECTIVE}))(wildcard())
    pattern = DominatorPattern(conv2d_pat, path_pat, injective_pat)
```

and we want to match the graph:
```text
input  weight
  \     /
   \   /
   conv2d  bias
     \     /
      \   /
    bias_add
        |
      relu
        |
     reshape
```
The pattern should match this graph since `conv2d` dominates `reshape` along `bias_add+relu`, provided that we accept the original definition of "dominator" in TVM. But the change in PR https://github.com/apache/tvm/pull/15473 makes the matching fail because it treats `bias` as an addtional path.

This is fixed by skipping the leaf arguments when matching the 'path' part of the dominator pattern.

The issue may be rooted in some confusion of the definition of "dominator" in TVM, as described in [this post](https://discuss.tvm.apache.org/t/question-on-fuzzy-path-matching-matching-arbitrary-number-and-type-of-nodes-in-path/11493/3). But at present, since the original definition of "dominator" remains unchanged in the real codebase, I think my patch may still make sense. 