### PR TITLE
[Disco] Allow allocation that only exists on worker0

### DIFF
--- a/python/tvm/runtime/disco/session.py
+++ b/python/tvm/runtime/disco/session.py
@@ -120,6 +120,7 @@ class Session(Object):
         shape: Sequence[int],
         dtype: str,
         device: Optional[Device] = None,
+        worker0_only: bool = False,
     ) -> DRef:
         """Create an empty NDArray on all workers and attach them to a DRef.
 
@@ -127,20 +128,27 @@ class Session(Object):
         ----------
         shape : tuple of int
             The shape of the NDArray.
+
         dtype : str
             The data type of the NDArray.
+
         device : Optional[Device] = None
             The device of the NDArray.
+
+        worker0_only: bool
+            If False (default), allocate an array on each worker.  If
+            True, only allocate an array on worker0.
 
         Returns
         -------
         array : DRef
             The created NDArray.
+
         """
         if device is None:
             device = Device(device_type=0, device_id=0)
         func = self._get_cached_method("runtime.disco.empty")
-        return func(ShapeTuple(shape), dtype, device)
+        return func(ShapeTuple(shape), dtype, device, worker0_only)
 
     def get_global_func(self, name: str) -> DRef:
         """Get a global function on workers.

--- a/src/runtime/disco/builtin.cc
+++ b/src/runtime/disco/builtin.cc
@@ -108,7 +108,17 @@ void SyncWorker() {
 }
 
 TVM_REGISTER_GLOBAL("runtime.disco.load_vm_module").set_body_typed(LoadVMModule);
-TVM_REGISTER_GLOBAL("runtime.disco.empty").set_body_typed(DiscoEmptyNDArray);
+
+TVM_REGISTER_GLOBAL("runtime.disco.empty")
+    .set_body_typed([](ShapeTuple shape, DataType dtype, Device device,
+                       bool worker0_only) -> Optional<NDArray> {
+      if (worker0_only && WorkerId()) {
+        return NullOpt;
+      } else {
+        return DiscoEmptyNDArray(shape, dtype, device);
+      }
+    });
+
 TVM_REGISTER_GLOBAL("runtime.disco.allreduce")
     .set_body_typed([](NDArray send, ShapeTuple reduce_kind, NDArray recv) {
       int kind = IntegerFromShapeTuple(reduce_kind);


### PR DESCRIPTION
The `disco.Session.scatter_from_worker0` function expects a `DRef` which an `NDArray` on worker 0, and `NullOpt` on all other workers. Prior to this commit, there was no method in the `disco.Session` that could be used to make such a `DRef`.  As a result, every use of `scatter_from_worker0` generated an error, stating that non-zero workers should have `NullOpt` as their `send` argument.

This commit adds a `worker0_only: bool` argument to `disco.Session.empty`.  This can be used to generate an allocation that only exists on worker zero, suitable for use in `scatter_from_worker0`.