### PR TITLE
[Relay] fixed to make TupleGetItem inherits the previous span

### DIFF
--- a/python/tvm/relay/expr_functor.py
+++ b/python/tvm/relay/expr_functor.py
@@ -251,7 +251,7 @@ class ExprMutator(ExprFunctor):
         new_tuple_value = self.visit(op.tuple_value)
         if new_tuple_value == op.tuple_value:
             return op
-        return TupleGetItem(new_tuple_value, op.index)
+        return TupleGetItem(new_tuple_value, op.index, span=op.span)
 
     def visit_global_var(self, gvar):
         return gvar


### PR DESCRIPTION
[fixed to make TupleGetItem inherits the previous span](https://github.com/apache/tvm/commit/0d14b3cb16c9e0a0087d2c2dc1b82cb6023d93a2)