### PR TITLE
[Runtime][Disco] Restore checks for hangup of disco pipe

### DIFF
--- a/src/support/pipe.h
+++ b/src/support/pipe.h
@@ -92,7 +92,11 @@ class Pipe : public dmlc::Stream {
           RetryCallOnEINTR([&]() { return read(handle_, ptr, size); }, GetLastErrorCode);
       ICHECK_NE(nread_chunk, -1) << "Write Error: " << strerror(errno);
 
-      ICHECK_GT(nread_chunk, 0) << "Was unable to read any data from pipe";
+      if (nread_chunk == 0) {
+        break;
+      }
+
+      ICHECK_GE(nread_chunk, 0);
       ICHECK_LE(nread_chunk, size) << "Read " << nread_chunk << " bytes, "
                                    << "but only expected to read " << size << " bytes";
       size -= nread_chunk;


### PR DESCRIPTION
This resolves a conflict between two recent changes.  In https://github.com/apache/tvm/pull/16989, reads of size zero are used to identify hangups in `ProcessSession`.  In https://github.com/apache/tvm/pull/16992, reads of size zero are treated as an error to avoid infinite loops while waiting for data to be ready.

For a long-term resolution, the `dmlc::Stream` interface will need to be updated, so that the `Write` method returns the number of bytes written, just as the `Read` method currently does.  This will allow the calling scope to verify the number of bytes received.