### PR TITLE
[Runtime] Compatibility with dmlc::Stream API changes

### DIFF
--- a/src/runtime/disco/process_session.cc
+++ b/src/runtime/disco/process_session.cc
@@ -113,10 +113,11 @@ class DiscoPipeMessageQueue : private dmlc::Stream, private DiscoProtocol<DiscoP
     return size;
   }
 
-  void Write(const void* data, size_t size) final {
+  size_t Write(const void* data, size_t size) final {
     size_t cur_size = write_buffer_.size();
     write_buffer_.resize(cur_size + size);
     std::memcpy(write_buffer_.data() + cur_size, data, size);
+    return size;
   }
 
   using dmlc::Stream::Read;

--- a/src/runtime/disco/threaded_session.cc
+++ b/src/runtime/disco/threaded_session.cc
@@ -96,10 +96,11 @@ class DiscoThreadedMessageQueue : private dmlc::Stream,
     return size;
   }
 
-  void Write(const void* data, size_t size) final {
+  size_t Write(const void* data, size_t size) final {
     size_t cur_size = write_buffer_.size();
     write_buffer_.resize(cur_size + size);
     std::memcpy(write_buffer_.data() + cur_size, data, size);
+    return size;
   }
 
   using dmlc::Stream::Read;

--- a/src/runtime/file_utils.h
+++ b/src/runtime/file_utils.h
@@ -149,10 +149,14 @@ struct SimpleBinaryFileStream : public dmlc::Stream {
     CHECK(fp_ != nullptr) << "File is closed";
     return std::fread(ptr, 1, size, fp_);
   }
-  virtual void Write(const void* ptr, size_t size) {
+  virtual size_t Write(const void* ptr, size_t size) {
     CHECK(!read_) << "File opened in read-mode, cannot write.";
     CHECK(fp_ != nullptr) << "File is closed";
-    CHECK(std::fwrite(ptr, 1, size, fp_) == size) << "SimpleBinaryFileStream.Write incomplete";
+    size_t nwrite = std::fwrite(ptr, 1, size, fp_);
+    int err = std::ferror(fp_);
+
+    CHECK_EQ(err, 0) << "SimpleBinaryFileStream.Write incomplete: " << std::strerror(err);
+    return nwrite;
   }
   inline void Close(void) {
     if (fp_ != nullptr) {

--- a/src/runtime/rpc/rpc_endpoint.cc
+++ b/src/runtime/rpc/rpc_endpoint.cc
@@ -666,8 +666,12 @@ class RPCEndpoint::EventHandler : public dmlc::Stream {
     pending_request_bytes_ -= size;
     return size;
   }
-  // wriite the data to the channel.
-  void Write(const void* data, size_t size) final { writer_->Write(data, size); }
+  // write the data to the channel.
+  size_t Write(const void* data, size_t size) final {
+    writer_->Write(data, size);
+    return size;
+  }
+
   // Number of pending bytes requests
   size_t pending_request_bytes_{0};
   // The ring buffer to read data from.

--- a/src/runtime/rpc/rpc_socket_impl.cc
+++ b/src/runtime/rpc/rpc_socket_impl.cc
@@ -159,11 +159,8 @@ class SimpleSockHandler : public dmlc::Stream {
   // Internal supporting.
   // Override methods that inherited from dmlc::Stream.
  private:
-  size_t Read(void* data, size_t size) final {
-    ICHECK_EQ(sock_.RecvAll(data, size), size);
-    return size;
-  }
-  void Write(const void* data, size_t size) final { ICHECK_EQ(sock_.SendAll(data, size), size); }
+  size_t Read(void* data, size_t size) final { return sock_.Recv(data, size); }
+  size_t Write(const void* data, size_t size) final { return sock_.Send(data, size); }
 
   // Things of current class.
  private:

--- a/src/support/base64.h
+++ b/src/support/base64.h
@@ -206,7 +206,7 @@ class Base64InStream : public dmlc::Stream {
     }
     return size - tlen;
   }
-  virtual void Write(const void* ptr, size_t size) {
+  virtual size_t Write(const void* ptr, size_t size) final {
     LOG(FATAL) << "Base64InStream do not support write";
   }
 
@@ -229,7 +229,7 @@ class Base64OutStream : public dmlc::Stream {
 
   using dmlc::Stream::Write;
 
-  void Write(const void* ptr, size_t size) final {
+  size_t Write(const void* ptr, size_t size) final {
     using base64::EncodeTable;
     size_t tlen = size;
     const unsigned char* cptr = static_cast<const unsigned char*>(ptr);
@@ -247,6 +247,7 @@ class Base64OutStream : public dmlc::Stream {
         buf__top_ = 0;
       }
     }
+    return size;
   }
   virtual size_t Read(void* ptr, size_t size) {
     LOG(FATAL) << "Base64OutStream do not support read";

--- a/src/support/base64.h
+++ b/src/support/base64.h
@@ -206,7 +206,7 @@ class Base64InStream : public dmlc::Stream {
     }
     return size - tlen;
   }
-  virtual size_t Write(const void* ptr, size_t size) final {
+  size_t Write(const void* ptr, size_t size) final {
     LOG(FATAL) << "Base64InStream do not support write";
   }
 


### PR DESCRIPTION
This commit updates TVM implementations of `dmlc::Stream`.  With https://github.com/dmlc/dmlc-core/pull/686, this API now requires the `Write` method to return the number of bytes written.  This change allows partial writes to be correctly handled.