### PR TITLE
[USMP] add missing const specifier for global_const_workspace

### DIFF
--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -337,7 +337,7 @@ class CSourceCrtMetadataModuleNode : public runtime::ModuleNode {
       // Pool is RO, form an initialized struct
       code_ << "__attribute__((section(\".rodata.tvm\"), ";
       code_ << "))\n";
-      code_ << "static struct " << pool_info->pool_name << " {\n";
+      code_ << "static const struct " << pool_info->pool_name << " {\n";
       // emit struct field names
       std::vector<ConstantInfo> const_info_vec(pool_info->constant_info_array.begin(),
                                                pool_info->constant_info_array.end());


### PR DESCRIPTION
The `.rodata*` section of any program should not be writable.

The missing `const` specifier in `static struct global_const_workspace {...}` leads to the following `readelf -e` output (shortened):

```
Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .text             PROGBITS        00000000 001000 009fbe 00  AX  0   0 16
  [ 2] .rodata           PROGBITS        00009fc0 00afc0 000e50 00  WA  0   0 16
  [ 3] .srodata          PROGBITS        0000ae10 00be10 000068 08  AM  0   0  8
  ...
```

After this fix, the output looks as follows (`AW -> A`):

```
Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .text             PROGBITS        00000000 001000 00a1be 00  AX  0   0 16
  [ 2] .rodata           PROGBITS        0000a1c0 00b1c0 000e50 00   A  0   0 16
  [ 3] .srodata          PROGBITS        0000b010 00c010 000070 00   A  0   0  8
```

## More context

This bug affects the `default_lib0.c` file generated when using CRT AoT & USMP. See this shortened example:

**Before fix:**
```
__attribute__((section(".rodata.tvm"), ))
static struct global_const_workspace {
  float fused_constant_1_let[256] __attribute__((aligned(16))); // 1024 bytes, aligned offset: 0
  ...
} global_const_workspace = {
  .fused_constant_1_let = {
    0x1.05a71cp-3, 0x1.660c26p-2, 0x1.9765b6p-2, 0x1.dc7fdp-5, 0x1.4f3b88p-4, 0x1.1bdb82p-2, 0x1.f2443cp-3, 0x1.d3f5e4p-3,
    ...
  },
};// of total size 1284 bytes
```

**After fix:**
```
__attribute__((section(".rodata.tvm"), ))
static const struct global_const_workspace {
  float fused_constant_1_let[256] __attribute__((aligned(16))); // 1024 bytes, aligned offset: 0
  ...
} global_const_workspace = {
  .fused_constant_1_let = {
    0x1.05a71cp-3, 0x1.660c26p-2, 0x1.9765b6p-2, 0x1.dc7fdp-5, 0x1.4f3b88p-4, 0x1.1bdb82p-2, 0x1.f2443cp-3, 0x1.d3f5e4p-3,
    ...
  },
};// of total size 1284 bytes
```

**Example on Compiler Explorer:** https://godbolt.org/z/vrs8EnnWf

cc @Lunderberg