### PR TITLE
[BugFix][MSC] split name_string with index by colon from the right

### DIFF
--- a/src/contrib/msc/core/utils.h
+++ b/src/contrib/msc/core/utils.h
@@ -142,7 +142,7 @@ class StringUtils {
    */
   TVM_DLL static const std::tuple<String, String> SplitOnce(const String& src_string,
                                                             const String& sep,
-                                                            bool from_left = true);
+                                                            bool from_left = false);
 
   /*!
    * \brief Get the tokens between left and right.


### PR DESCRIPTION
Fixes a naming mismatch in MSCGraph where tensor_name could formatted as 'string:index:index',and the corresponding node.name is 'string:index'. Splitting tensor_name from the right aligns it correctly.

For example, the TFLite default input name 'serving_default_input:0' becomes 'serving_default_input:0:0' in MSCGraph, while node.name remains 'serving_default_input:0'.