### PR TITLE
[SVE] Use only powers of two as possible vscale values

### DIFF
--- a/src/arith/const_int_bound.cc
+++ b/src/arith/const_int_bound.cc
@@ -371,7 +371,9 @@ class ConstIntBoundAnalyzer::Impl
     } else if (op->op.same_as(tir::builtin::bitwise_and())) {
       return VisitBitwiseAnd(op);
     } else if (op->op.same_as(tir::builtin::vscale()) && TargetHasSVE()) {
-      return MakeBound(1, kAArch64VScaleValues.size());
+      unsigned int max_val =
+          *std::max_element(kAArch64VScaleValues.begin(), kAArch64VScaleValues.end());
+      return MakeBound(1, max_val);
     } else {
       return Everything(op->dtype);
     }

--- a/src/arith/scalable_expression.h
+++ b/src/arith/scalable_expression.h
@@ -35,8 +35,7 @@ namespace tvm {
 namespace arith {
 
 /*! \brief A list of known vscale values to try for an AArch64 SVE target. */
-static const std::vector<unsigned int> kAArch64VScaleValues = {1, 2,  3,  4,  5,  6,  7,  8,
-                                                               9, 10, 11, 12, 13, 14, 15, 16};
+static const std::vector<unsigned int> kAArch64VScaleValues = {1, 2, 4, 8, 16};
 
 /*!
  * \brief Check if an expr is a call to the vscale intrinsic.

--- a/src/target/llvm/codegen_aarch64.cc
+++ b/src/target/llvm/codegen_aarch64.cc
@@ -57,8 +57,10 @@ void CodeGenAArch64::SetTargetAttributes(llvm::Function* func) {
 #if TVM_LLVM_VERSION >= 130
   // Add vscale_range() function attribute when appropriate.
   if (llvm_target_->TargetHasCPUFeature("sve") || llvm_target_->TargetHasCPUFeature("sme")) {
-    func->addFnAttr(llvm::Attribute::getWithVScaleRangeArgs(
-        *llvm_target_->GetContext(), 1, tvm::arith::kAArch64VScaleValues.size()));
+    unsigned int max_val =
+        *std::max_element(arith::kAArch64VScaleValues.begin(), arith::kAArch64VScaleValues.end());
+    func->addFnAttr(
+        llvm::Attribute::getWithVScaleRangeArgs(*llvm_target_->GetContext(), 1, max_val));
   }
 #endif
   CodeGenCPU::SetTargetAttributes(func);


### PR DESCRIPTION
When analyzing scalable expressions, the analyzer will iterate over a series of known vscale values in the range 1-16. However, we can tighten this range to only values that are a power of two, as stated in the [LLVM lang ref](https://llvm.org/docs/LangRef.html#llvm-vscale-intrinsic:~:text=This%20function%20attribute%20indicates%20vscale%20is%20a%20power%2Dof%2Dtwo%20within%20a%20specified%20range) and more generally the [reference manual](https://developer.arm.com/documentation/ddi0487/latest/).

This comes from a discussion in https://github.com/apache/tvm/pull/16921#discussion_r1600048788