### PR TITLE
[SME][TOPI] Add conv2d NHWC SME fp32 schedule

### DIFF
--- a/python/tvm/relay/op/strategy/arm_cpu.py
+++ b/python/tvm/relay/op/strategy/arm_cpu.py
@@ -254,6 +254,18 @@ def conv2d_strategy_arm_cpu(attrs, inputs, out_type, target):
                         )
                 # Non-quantized cases
                 if is_aarch64 and data.dtype in ["float32", "float16"]:
+                    if (
+                        target.features.has_sme
+                        and data.dtype in ["float32"]
+                        and kernel.dtype in ["float32"]
+                        and out_type.dtype in ["float32"]
+                    ):
+                        strategy.add_implementation(
+                            wrap_compute_conv2d(topi.arm_cpu.compute_conv2d_NHWC_hybrid_SME),
+                            lambda: None,
+                            name="conv2d_NHWC_hybrid_SME.arm_cpu",
+                            plevel=12,
+                        )
                     if target.features.has_sve:
                         # This strategy is currently suboptimal because of LLVM's limited support
                         # for scalable vector alias analysis, which causes redundant loads / stores
@@ -800,6 +812,9 @@ def arm_cpu_tir_strategy(sch: tir.Schedule) -> bool:
 
     if current_target.features.has_sme and has_block(sch, "matmul_sme_gemm"):
         topi.arm_cpu.matmul.tir_schedule_matmul_sme(sch)
+        return True
+    elif has_block(sch, "conv2d_gemm_output"):
+        topi.arm_cpu.schedule_conv2d_NHWC_hybrid_TIR(sch)
         return True
 
     # Fallback to TE schedule for operators we have not written a special TIR schedule for

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -1071,6 +1071,13 @@ requires_aarch64_sve = Feature(
 )
 
 
+requires_aarch64_sme = Feature(
+    "arm_sme",
+    "AArch64 SME",
+    run_time_check=lambda: _has_cpu_feat("sme"),
+)
+
+
 requires_x86_vnni = Feature(
     "x86_vnni",
     "x86 VNNI Extensions",

--- a/python/tvm/topi/arm_cpu/arm_utils.py
+++ b/python/tvm/topi/arm_cpu/arm_utils.py
@@ -22,7 +22,7 @@ from tvm.target import Target
 from tvm.tir.expr import PrimExpr
 
 
-def get_tiling_A(interleave_A, in_dtype):
+def get_tiling_A(interleave_A, in_dtype, use_sme=False):
     """Compute the tiling information for matrix A in C=A*B,
     which corresponds to the im2col-transformed input matrix.
 
@@ -42,6 +42,8 @@ def get_tiling_A(interleave_A, in_dtype):
         determines if A is expected to be interleaved
     in_dtype : str
         input datatype
+    use_sme : bool
+        determines if SME operations on scalable vectors are expected
 
     Returns
     ----------
@@ -65,8 +67,11 @@ def get_tiling_A(interleave_A, in_dtype):
             # tile size should be 4x16
             tile_M = 4
             tile_K = 16
+    elif use_sme:
+        tile_M = 2 * 4 * tvm.tir.vscale()
+        tile_K = 2 * 4 * tvm.tir.vscale()
     else:
-        # In non-quantized cases, A is not interleaved.
+        # In non-SME, non-quantized cases, A is not interleaved.
         # We are loading 4 rows from A.
         # Each row will contain 4 elements, along the dimension of reduction
         tile_M = 4
@@ -75,7 +80,7 @@ def get_tiling_A(interleave_A, in_dtype):
     return tile_M, tile_K
 
 
-def get_tiling_B_transformed(interleave_A, in_dtype, use_scalable_vectors=False):
+def get_tiling_B_transformed(interleave_A, in_dtype, use_scalable_vectors=False, use_sme=False):
     """Compute the tiling information for matrix B', where B'
     is the tiled, interleaved (and transposed) version of matrix B in C=A*B.
 
@@ -97,6 +102,8 @@ def get_tiling_B_transformed(interleave_A, in_dtype, use_scalable_vectors=False)
         input datatype
     use_scalable_vectors : bool
         determines if operations on scalable vectors are expected
+    use_sme : bool
+        determines if SME operations on scalable vectors are expected
 
 
     Returns
@@ -131,7 +138,10 @@ def get_tiling_B_transformed(interleave_A, in_dtype, use_scalable_vectors=False)
             # we load 4 rows of B' (i.e., 4 columns of B). Each of them will contain 16 elements
             tile_N = 4
             tile_K = 16
-    # In non-quantized cases, A is not interleaved.
+    elif use_sme:
+        tile_N = 2 * 4 * tvm.tir.vscale()
+        tile_K = 2 * 4 * tvm.tir.vscale()
+    # In non-SME, non-quantized cases, A is not interleaved.
     elif use_scalable_vectors:
         if in_dtype == "float16":
             # Each load from B' contains 32 * vscale elements (i.e. 32 * vscale columns from B)

--- a/python/tvm/topi/arm_cpu/conv2d.py
+++ b/python/tvm/topi/arm_cpu/conv2d.py
@@ -741,6 +741,7 @@ def schedule_conv2d_NHWC_hybrid_TIR(sch: tvm.tir.Schedule):
         b, m, k = sch.get_loops(interleave_t_A_block)
         mo, mi = sch.split(m, factors=(None, tile_M), disable_predication=True)
         ko, ki = sch.split(k, factors=(None, tile_K), disable_predication=True)
+        sch.parallel(b)
         sch.reorder(b, ko, mo, ki, mi)
         sch.tensorize(ki, ARM_SME_2SVLx2SVL_TRANSPOSE_INTERLEAVE)
 
@@ -878,7 +879,7 @@ def schedule_conv2d_NHWC_hybrid_TIR(sch: tvm.tir.Schedule):
         sch.compute_inline(weight_flatten_block)
 
     # Conv2d output block
-    output_block = sch.get_block("conv2d_gemm_output")
+    output_block = func_blocks["conv2d_gemm_output"]
     n, h, w, c = sch.get_loops(output_block)
     n_h_fused = sch.fuse(n, h)
     _, inner = sch.split(c, [None, 4])

--- a/python/tvm/topi/arm_cpu/conv2d_gemm.py
+++ b/python/tvm/topi/arm_cpu/conv2d_gemm.py
@@ -68,6 +68,7 @@ def compute_conv2d_gemm_without_weight_transform(
     output_channels,
     interleave_A,
     use_scalable_vectors=False,
+    use_sme=False,
 ):
     """Compute conv2d by transforming the input,
     executing GEMM and transforming the output back"""
@@ -123,9 +124,12 @@ def compute_conv2d_gemm_without_weight_transform(
         )
 
     # Select the tiling strategy for A and B
-    tile_M, tile_K_A = arm_utils.get_tiling_A(interleave_A, in_dtype)
+    tile_M, tile_K_A = arm_utils.get_tiling_A(interleave_A, in_dtype, use_sme)
     tile_N, tile_K_B = arm_utils.get_tiling_B_transformed(
-        interleave_A, in_dtype, use_scalable_vectors
+        interleave_A,
+        in_dtype,
+        use_scalable_vectors,
+        use_sme,
     )
 
     # Pad to tiles (if necessary)
@@ -285,7 +289,7 @@ def compute_conv2d_gemm_without_weight_transform(
                 tvm.tir.const(1, C.dtype) * C[0, M_padded - 1, N_padded - 1]
                 - tvm.tir.const(1, C.dtype) * C[0, M_padded - 1, N_padded - 1]
             )
-    elif use_scalable_vectors:
+    elif use_scalable_vectors or use_sme:
         assert len(B_interleaved_t.shape) == 2
         C = te.compute(
             (batches, M_padded, N_padded),
@@ -333,7 +337,7 @@ def compute_conv2d_gemm_without_weight_transform(
         out_shape,
         lambda b, x, y, z: (C(b, y + OW * x, z) + zero).astype(out_dtype),
         name="conv2d_gemm_output",
-        attrs={"use_scalable_vectors": use_scalable_vectors},
+        attrs={"use_scalable_vectors": use_scalable_vectors, "use_sme": use_sme},
     )
     return out
 

--- a/python/tvm/topi/nn/conv2d.py
+++ b/python/tvm/topi/nn/conv2d.py
@@ -615,7 +615,7 @@ def conv2d_NCHWc_int8(
     )
 
 
-def conv2d_gemm_weight_transform(kernel, tile_N, tile_K, use_scalable_vectors=False):
+def conv2d_gemm_weight_transform(kernel, tile_N, tile_K, use_scalable_vectors=False, use_sme=False):
     """Weight transformation for winograd
 
     Parameters
@@ -628,6 +628,8 @@ def conv2d_gemm_weight_transform(kernel, tile_N, tile_K, use_scalable_vectors=Fa
         Tile size across K axis of the weight transformation for ConvGemm. (K = KW * KH * IC)
     use_scalable_vectors : bool
         determines if operations on scalable vectors are expected
+    use_sme : bool
+        determines if SME operations on scalable vectors are expected
 
     Returns
     -------
@@ -652,7 +654,7 @@ def conv2d_gemm_weight_transform(kernel, tile_N, tile_K, use_scalable_vectors=Fa
             kernel_flat, pad_before=(0, 0), pad_after=(pad_K, pad_N), name="weight_padding"
         )
 
-    if use_scalable_vectors:
+    if use_sme or use_scalable_vectors:
         return kernel_flat
 
     if kernel.dtype in ["int8", "uint8"]:

--- a/src/arith/scalable_expression.cc
+++ b/src/arith/scalable_expression.cc
@@ -71,15 +71,8 @@ std::optional<int> ExtractVscaleFactor(const PrimExpr& lanes) {
   }
 }
 
-bool IsComparison(const PrimExpr& expr) {
-  return expr->IsInstance<tir::LENode>() || expr->IsInstance<tir::LTNode>() ||
-         expr->IsInstance<tir::GENode>() || expr->IsInstance<tir::GTNode>() ||
-         expr->IsInstance<tir::EQNode>() || expr->IsInstance<tir::NENode>();
-}
-
 bool CanProveVscaleExpressionFromKnownValues(arith::Analyzer* analyzer, const PrimExpr& expr,
                                              const std::vector<unsigned int>& vscale_values) {
-  ICHECK(IsComparison(expr)) << "Expected comparison but got: " << expr;
   bool can_prove_expr = true;
   for (const unsigned int vscale_value : vscale_values) {
     PrimExpr result = SubstituteVScaleWithKnownValue(expr, vscale_value);

--- a/tests/python/arith/test_arith_simplify.py
+++ b/tests/python/arith/test_arith_simplify.py
@@ -90,16 +90,6 @@ def test_simplify_vscale_comparison_without_sve_target(capfd):
     assert warning_msg in capture
 
 
-def test_simplify_vscale_non_comparison():
-    ana = tvm.arith.Analyzer()
-    vs = tvm.tir.vscale()
-
-    err_msg = r".*Expected comparison but got: T.vscale\(\) \* 4"
-    with pytest.raises(tvm.TVMError, match=err_msg):
-        with tvm.target.Target("llvm -mtriple=aarch64-linux-gnu -mattr=+sve"):
-            ana.can_prove(vs * 4)
-
-
 def test_regression_simplify_inf_recursion():
     ana = tvm.arith.Analyzer()
     cond = tir.Var("cond", "int32")

--- a/tests/python/codegen/test_target_codegen_aarch64.py
+++ b/tests/python/codegen/test_target_codegen_aarch64.py
@@ -777,7 +777,7 @@ def test_conv2d_sve(dtype, conv2d_impl):
 
 
 @pytest.mark.skipif(
-    llvm_version_major() < 16, reason="Test requires an LLVM version of at least 16 to target SVE"
+    llvm_version_major() < 16, reason="Test requires an LLVM version of at least 16 to target SME"
 )
 @pytest.mark.parametrize("dtype", ["float32"])
 def test_conv2d_sme(dtype):

--- a/tests/python/relay/strategy/test_select_implementation.py
+++ b/tests/python/relay/strategy/test_select_implementation.py
@@ -161,6 +161,10 @@ def test_int8_conv2d(target, expected_impl):
             "llvm --device=arm_cpu --mtriple=aarch64-linux-gnu -mattr=+v9a",
             "conv2d_NHWC_hybrid_without_transform.arm_cpu",
         ),
+        (
+            "llvm --device=arm_cpu --mtriple=aarch64-linux-gnu -mattr=+v9.2a,+sme",
+            "conv2d_NHWC_hybrid_SME.arm_cpu",
+        ),
     ],
 )
 def test_fp32_conv2d(target, expected_impl):
@@ -195,6 +199,10 @@ def test_fp32_conv2d(target, expected_impl):
         ),
         (
             "llvm -device=arm_cpu -mtriple=aarch64-linux-gnu -mattr=+v9a",
+            "conv2d_NHWC_hybrid_without_transform.arm_cpu",
+        ),
+        (
+            "llvm --device=arm_cpu --mtriple=aarch64-linux-gnu -mattr=+v9.2a,+sme",
             "conv2d_NHWC_hybrid_without_transform.arm_cpu",
         ),
     ],

--- a/tests/python/topi/test_topi_conv2d_nhwc.py
+++ b/tests/python/topi/test_topi_conv2d_nhwc.py
@@ -173,6 +173,9 @@ def test_conv2d_nhwc_gemm(device, ref_data, dtype, stride, padding, dilation):
     if target.features.has_sme and llvm_version_major() < 16:
         pytest.skip(f"LLVM {llvm_version_major()} does not support targetting SME.")
 
+    if target.features.has_sme and dtype == "float16":
+        pytest.skip(f"Conv2d fp16 targetting SME not implemented.")
+
     with target:
         a = tvm.nd.array(a_np, dev)
         w = tvm.nd.array(w_np, dev)


### PR DESCRIPTION
This commit adds a scalable `arm_cpu` conv2d NHWC schedule for fp32 which generates SME instructions by using the tensor intrinsics introduced in #16921.

Alongside the SME schedule, the logic of the TE schedule `schedule_conv2d_gemm_native()` for both non-scalable and scalable vector implementations has also been translated into the new TIR schedule. This means that the TE compute definition `compute_conv2d_NHWC_hybrid()` is now compatible with both the original TE schedules (e.g. `schedule_conv2d_NHWC_hybrid()`) and the newly introduced TIR schedule `schedule_conv2d_NHWC_hybrid_TIR()`. The corresponding TOPI test has been extended to reflect that.

cc @ekalda @lhutton1 