### PR TITLE
Pass default values to target config/options

### DIFF
--- a/python/tvm/driver/tvmc/target.py
+++ b/python/tvm/driver/tvmc/target.py
@@ -69,10 +69,25 @@ def _generate_codegen_args(parser, codegen_name):
             for tvm_type, python_type in INTERNAL_TO_NATIVE_TYPE.items():
                 if field.type_info.startswith(tvm_type):
                     target_option = field.name
+                    default_value = None
+
+                    # Retrieve the default value string from attrs(field) of config node
+                    # Eg: "default=target_cpu_name"
+                    target_option_default_str = field.type_info.split("default=")[1]
+
+                    # Extract the defalut value based on the tvm type
+                    if target_option_default_str and tvm_type == "runtime.String":
+                        default_value = target_option_default_str
+                    elif target_option_default_str and tvm_type == "IntImm":
+                        # Extract the numeric value from the python Int string, Eg: T.int64(8)
+                        str_slice = target_option_default_str.split("(")[1]
+                        default_value = str_slice.split(")")[0]
+
                     target_group.add_argument(
                         f"--target-{codegen_name}-{target_option}",
                         type=python_type,
                         help=field.description,
+                        default=default_value,
                     )
 
 
@@ -129,10 +144,18 @@ def reconstruct_target_args(args):
         if kind_options:
             reconstructed[target_kind] = kind_options
 
+    # Get the user given target list and strip extra white spaces in the string
+    # Eg: --target="llvm, mrvl" | "llvm, bnns " ===> "llvm,mrvl" | "llvm,bnns"
+    target_list = args.target.split(",")
+    for idx, name in enumerate(target_list):
+        target_list[idx] = name.strip()
+
     for codegen_name in get_codegen_names():
-        codegen_options = _reconstruct_codegen_args(args, codegen_name)
-        if codegen_options:
-            reconstructed[codegen_name] = codegen_options
+        # Reconstruct the codgen options only for parsed targets
+        if codegen_name in target_list:
+            codegen_options = _reconstruct_codegen_args(args, codegen_name)
+            if codegen_options:
+                reconstructed[codegen_name] = codegen_options
 
     return reconstructed
 

--- a/tests/python/driver/tvmc/test_target_options.py
+++ b/tests/python/driver/tvmc/test_target_options.py
@@ -72,6 +72,21 @@ def test_target_to_argparse_for_mrvl_hybrid():
     assert parsed.target_mrvl_mcpu == "cnf10kb"
 
 
+@tvm.testing.requires_mrvl
+def test_default_arg_for_mrvl_hybrid():
+    parser = argparse.ArgumentParser()
+    generate_target_args(parser)
+    parsed, _ = parser.parse_known_args(
+        [
+            "--target=mrvl, llvm",
+        ]
+    )
+    assert parsed.target == "mrvl, llvm"
+    assert parsed.target_mrvl_mcpu == "cn10ka"
+    assert parsed.target_mrvl_num_tiles == 8
+
+
+@tvm.testing.requires_cmsisnn
 def test_mapping_target_args():
     parser = argparse.ArgumentParser()
     generate_target_args(parser)
@@ -129,6 +144,7 @@ def test_ethosu_compiler_attrs():
     }
 
 
+@tvm.testing.requires_cmsisnn
 def test_skip_target_from_codegen():
     parser = argparse.ArgumentParser()
     generate_target_args(parser)


### PR DESCRIPTION
BYOC Compiler Config node defines the target compiler's command line options, along with default values. 
This change extract the default values while constructing target options for codegen/target compiler.
Added test case for this feature as well.