### PR TITLE
[Frontend][ArgParse] Pass default values to target compiler(#13264)

### DIFF
--- a/python/tvm/driver/tvmc/composite_target.py
+++ b/python/tvm/driver/tvmc/composite_target.py
@@ -51,34 +51,42 @@ logger = logging.getLogger("TVMC")
 REGISTERED_CODEGEN = {
     "compute-library": {
         "config_key": None,
+        "pass_default": False,
         "pass_pipeline": partition_for_arm_compute_lib,
     },
     "cmsis-nn": {
         "config_key": "relay.ext.cmsisnn.options",
+        "pass_default": False,
         "pass_pipeline": partition_for_cmsisnn,
     },
     "ethos-n": {
         "config_key": "relay.ext.ethos-n.options",
+        "pass_default": False,
         "pass_pipeline": partition_for_ethosn,
     },
     "ethos-u": {
         "config_key": "relay.ext.ethos-u.options",
+        "pass_default": False,
         "pass_pipeline": partition_for_ethosu,
     },
     "bnns": {
         "config_key": None,
+        "pass_default": False,
         "pass_pipeline": partition_for_bnns,
     },
     "vitis-ai": {
         "config_key": "relay.ext.vitis_ai.options",
+        "pass_default": False,
         "pass_pipeline": partition_for_vitis_ai,
     },
     "clml": {
         "config_key": None,
+        "pass_default": False,
         "pass_pipeline": partition_for_clml,
     },
     "mrvl": {
         "config_key": "relay.ext.mrvl.options",
+        "pass_default": True,
         "pass_pipeline": partition_for_mrvl,
     },
 }

--- a/python/tvm/driver/tvmc/target.py
+++ b/python/tvm/driver/tvmc/target.py
@@ -342,7 +342,7 @@ def is_inline_json(target):
         json.loads(target)
         return True
     except json.decoder.JSONDecodeError:
-        return 
+        return False
 
 
 def _combine_target_options(target, additional_target_options=None):

--- a/python/tvm/driver/tvmc/target.py
+++ b/python/tvm/driver/tvmc/target.py
@@ -69,10 +69,28 @@ def _generate_codegen_args(parser, codegen_name):
             for tvm_type, python_type in INTERNAL_TO_NATIVE_TYPE.items():
                 if field.type_info.startswith(tvm_type):
                     target_option = field.name
+                    default_value = None
+
+                    # Retrieve the default value string from attrs(field) of config node
+                    # Eg: "default=target_cpu_name"
+                    target_option_default_str = field.type_info.split("default=")[1]
+
+                    # Extract the defalut value based on the tvm type
+                    if target_option_default_str and tvm_type == "runtime.String":
+                        default_value = target_option_default_str
+                    elif target_option_default_str and tvm_type == "IntImm":
+                        # Extract the numeric value from the python Int string, Eg: T.int64(8)
+                        str_slice = target_option_default_str.split("(")[1]
+                        default_value = str_slice.split(")")[0]
+
+                    if codegen["pass_default"] is False:
+                        default_value = None
+
                     target_group.add_argument(
                         f"--target-{codegen_name}-{target_option}",
                         type=python_type,
                         help=field.description,
+                        default=default_value,
                     )
 
 
@@ -133,7 +151,6 @@ def reconstruct_target_args(args):
         codegen_options = _reconstruct_codegen_args(args, codegen_name)
         if codegen_options:
             reconstructed[codegen_name] = codegen_options
-
     return reconstructed
 
 
@@ -325,7 +342,7 @@ def is_inline_json(target):
         json.loads(target)
         return True
     except json.decoder.JSONDecodeError:
-        return False
+        return 
 
 
 def _combine_target_options(target, additional_target_options=None):

--- a/tests/python/driver/tvmc/test_target_options.py
+++ b/tests/python/driver/tvmc/test_target_options.py
@@ -72,6 +72,21 @@ def test_target_to_argparse_for_mrvl_hybrid():
     assert parsed.target_mrvl_mcpu == "cnf10kb"
 
 
+@tvm.testing.requires_mrvl
+def test_default_arg_for_mrvl_hybrid():
+    parser = argparse.ArgumentParser()
+    generate_target_args(parser)
+    parsed, _ = parser.parse_known_args(
+        [
+            "--target=mrvl, llvm",
+        ]
+    )
+    assert parsed.target == "mrvl, llvm"
+    assert parsed.target_mrvl_mcpu == "cn10ka"
+    assert parsed.target_mrvl_num_tiles == 8
+
+
+@tvm.testing.requires_cmsisnn
 def test_mapping_target_args():
     parser = argparse.ArgumentParser()
     generate_target_args(parser)
@@ -129,6 +144,7 @@ def test_ethosu_compiler_attrs():
     }
 
 
+@tvm.testing.requires_cmsisnn
 def test_skip_target_from_codegen():
     parser = argparse.ArgumentParser()
     generate_target_args(parser)


### PR DESCRIPTION
In BYOC,  Marvell Compiler Config node defines the target compiler's  command line options, along with default values. When the user has not given any explicit command line options, these default values can be extracted from the configuration and passed to the TVM's Argument Parser.  Currently the support for extraction of default values from Config options is not there, this change introduces that support. Also this is done conditionally by interpreting the flag status of target compiler. 