### PR TITLE
[DLight] Update Adreno GEMV Rules

### DIFF
--- a/python/tvm/dlight/gpu/gemv.py
+++ b/python/tvm/dlight/gpu/gemv.py
@@ -706,7 +706,7 @@ class GEMV(GPUScheduleRule):
         if LOAD_V_SHARED is False:
             LOAD_V_TILE = 1
 
-        if not isinstance(len_r, int):
+        if not isinstance(len_r, int) or len_r < LOAD_V_TILE * TR * SCALE_PACK * DEC_PACK:
             return None
 
         if isinstance(len_s, int) and len_s > 32000:


### PR DESCRIPTION
When reduction axis is small, it's not necessary to use rfactor. This PR updates the gemv rule to use rfactor only when the reduction axis is large enough.