### PR TITLE
[Web] Fix string to uint8 array for special characters

### DIFF
--- a/web/src/memory.ts
+++ b/web/src/memory.ts
@@ -375,8 +375,9 @@ export class CachedCallStack implements Disposable {
    * @param data The string content.
    */
   allocThenSetArgString(offset: PtrOffset, data: string): void {
-    const strOffset = this.allocRawBytes(data.length + 1);
-    this.storeRawBytes(strOffset, StringToUint8Array(data));
+    const dataUint8: Uint8Array = StringToUint8Array(data);
+    const strOffset = this.allocRawBytes(dataUint8.length);
+    this.storeRawBytes(strOffset, dataUint8);
     this.addressToSetTargetValue.push([offset, strOffset]);
   }
   /**

--- a/web/src/support.ts
+++ b/web/src/support.ts
@@ -35,12 +35,13 @@ export function isPromise(value: any): boolean {
  * @returns The corresponding Uint8Array.
  */
 export function StringToUint8Array(str: string): Uint8Array {
-  const arr = new Uint8Array(str.length + 1);
-  for (let i = 0; i < str.length; ++i) {
-    arr[i] = str.charCodeAt(i);
+  const arr: Uint8Array = new TextEncoder().encode(str);
+  const resArr = new Uint8Array(arr.length + 1);
+  for (let i = 0; i < arr.length; ++i) {
+    resArr[i] = arr[i];
   }
-  arr[str.length] = 0;
-  return arr;
+  resArr[arr.length] = 0;
+  return resArr;
 }
 
 /**


### PR DESCRIPTION
This PR fixes passing Javascript string with special characters to C for web runtime.

Take the upside-down exclamation mark `¡` as an example. This should encode to `\xC2\xA1` according to https://mothereff.in/utf-8#%C2%A1 and other sources:

```
OldStringToUint8Array("¡") --> [161, 0]
NewStringToUint8Array("¡") --> [194, 161, 0]
```