### PR TITLE
Use adapter.info when available instead of requestAdapterInfo

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^20.4.5",
     "@typescript-eslint/eslint-plugin": "^5.59.6",
     "@typescript-eslint/parser": "^5.59.6",
-    "@webgpu/types": "^0.1.40",
+    "@webgpu/types": "^0.1.42",
     "eslint": "^8.41.0",
     "jest": "^26.0.1",
     "rollup": "^2.56.2",

--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -105,7 +105,7 @@ export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefin
       requiredFeatures.push("shader-f16");
     }
 
-    const adapterInfo = await adapter.requestAdapterInfo();
+    const adapterInfo = adapter.info || await adapter.requestAdapterInfo();
     const device = await adapter.requestDevice({
       requiredLimits: {
         maxBufferSize: requiredMaxBufferSize,


### PR DESCRIPTION
Following on https://github.com/gpuweb/gpuweb/pull/4662, this PR uses synchronous `adapter.info` when available instead of the deprecated `requestAdapterInfo()` method.