### PR TITLE
[SME] Utilize predication in fp32 matmul and conv2d schedules

### DIFF
--- a/python/tvm/topi/arm_cpu/conv2d_gemm.py
+++ b/python/tvm/topi/arm_cpu/conv2d_gemm.py
@@ -143,7 +143,7 @@ def compute_conv2d_gemm_without_weight_transform(
         N_padded = N + pad_N
 
         pad_before = (0, 0, 0)
-        pad_after = (0, 0, 0) if use_sme else (0, pad_M, pad_K)
+        pad_after = (0, pad_M, pad_K)
 
         if pad_K != 0:
             A = nn.pad(A, pad_before=pad_before, pad_after=pad_after, name="A_padded_K")
@@ -151,7 +151,7 @@ def compute_conv2d_gemm_without_weight_transform(
             A = nn.pad(A, pad_before=pad_before, pad_after=pad_after, name="A_padded_M")
 
     idxm = tvm.tir.indexmod
-    k = te.reduce_axis((0, K), "k")
+    k = te.reduce_axis((0, K if use_explicit_predication else K_padded), "k")
 
     # Determine matrix multiplication compute definition
     target = Target.current(allow_none=False)

--- a/tests/python/codegen/test_target_codegen_aarch64.py
+++ b/tests/python/codegen/test_target_codegen_aarch64.py
@@ -530,12 +530,14 @@ def test_matmul_sme(dtype):
         )
         stores = re.findall(r"st1[whdb]\t{\s?za", assembly)
         smstop = re.findall(r"smstop\t(sm|za)", assembly)
+        whilelo = re.findall(r"whilelo\tp[0-9].[shdb]", assembly)
 
         assert len(smstart) > 0
         assert len(loads) > 0
         assert len(mopa) > 0
         assert len(stores) > 0
         assert len(smstop) > 0
+        assert len(whilelo) > 0
 
     check_correct_assembly(dtype=dtype)
 
@@ -819,12 +821,14 @@ def test_conv2d_sme(dtype):
         )
         stores = re.findall(r"st1[whdb]\t{\s?za", assembly)
         smstop = re.findall(r"smstop\t(sm|za)", assembly)
+        whilelo = re.findall(r"whilelo\tp[0-9].[shdb]", assembly)
 
         assert len(smstart) > 0
         assert len(loads) > 0
         assert len(mopa) > 0
         assert len(stores) > 0
         assert len(smstop) > 0
+        assert len(whilelo) > 0
 
     with tvm.target.Target(target):
         check_correct_assembly(dtype=dtype)

--- a/tests/python/topi/test_topi_conv2d_nhwc.py
+++ b/tests/python/topi/test_topi_conv2d_nhwc.py
@@ -168,10 +168,13 @@ def test_conv2d_nhwc_gemm(device, ref_data, dtype, stride, padding, dilation):
     target = tvm.target.Target(target_string)
 
     if target.features.has_sve and llvm_version_major() < 15:
-        pytest.skip(f"LLVM {llvm_version_major()} does not support targetting SVE.")
+        pytest.skip(f"LLVM {llvm_version_major()} does not support targeting SVE.")
 
     if target.features.has_sme and llvm_version_major() < 16:
-        pytest.skip(f"LLVM {llvm_version_major()} does not support targetting SME.")
+        pytest.skip(f"LLVM {llvm_version_major()} does not support targeting SME.")
+
+    if target.features.has_sme and a_np.shape[0] > 1:
+        pytest.skip(f"Conv2d with batches > 1 targeting SME not implemented.")
 
     # SME schedule always outputs float32 results, regardless of input dtype.
     # Otherwise, output dtype is the same as input dtype.

--- a/tests/python/topi/test_topi_conv2d_nhwc.py
+++ b/tests/python/topi/test_topi_conv2d_nhwc.py
@@ -176,6 +176,9 @@ def test_conv2d_nhwc_gemm(device, ref_data, dtype, stride, padding, dilation):
     if target.features.has_sme and a_np.shape[0] > 1:
         pytest.skip(f"Conv2d with batches > 1 targeting SME not implemented.")
 
+    if target.features.has_sme and (a_np.shape[3] * w_np.shape[0] * w_np.shape[1]) <= 1:
+        pytest.skip(f"Conv2d with unit reduction dimension targeting SME not supported.")
+
     # SME schedule always outputs float32 results, regardless of input dtype.
     # Otherwise, output dtype is the same as input dtype.
     out_dtype = "float32" if target.features.has_sme else dtype


### PR DESCRIPTION
Prior to this commit, the matmul and conv2d schedules required padding of the inputs to some multiple of vscale and a final "unpadding" stage.

Instead, we can leverage predicated operations to avoid the the requirement for padding. Both the transpose interleave and outer product fp32 intrinsics are updated to use predication. The `get_active_lane_mask` intrinsic is utilized to generate a variably sized mask of active lanes depending on the global position the tensor intrinsic is operating on.

For now this relies on using `offset_of` and `stride` information from the tensor we're predicating an access on. Likely we will want to build on this in the future with a more intuitive API for determining the current tile location.

Support for batched conv2d was removed since this causes numerical issues which is suspected to be due to how the current tile is determined (paragraph above).

~Note: this should not be merged until after https://github.com/apache/tvm/pull/17048~

cc @ekalda @Anndrey24 