### PR TITLE
[Runtime] Stateless interface of PagedKVCache leaf node commit

### DIFF
--- a/src/runtime/relax_vm/kv_state.h
+++ b/src/runtime/relax_vm/kv_state.h
@@ -151,9 +151,11 @@ class AttentionKVCacheObj : public KVStateObj {
    * The commit will update the KV cache, by compacting the KV data and discard
    * the KV data of rejected tokens.
    * This is a mandatory step when the BeginForward is given with a token tree.
+   * \param seq_ids The ids of the sequences to commit.
    * \param leaf_indices The leaf token tree node index of each sequence.
    */
-  virtual void CommitAcceptedTokenTreeNodes(const IntTuple& leaf_indices) = 0;
+  virtual void CommitAcceptedTokenTreeNodes(const IntTuple& seq_ids,
+                                            const IntTuple& leaf_indices) = 0;
 
   /************** Attention **************/
 


### PR DESCRIPTION
This PR changes the interface of the function
`CommitAcceptedTokenTreeNodeToKVCache` introduced recently for PagedKVCache to a stateless interface. Previously the interace is a stateful one, which makes strong assumption on the caller side. This commit removes the assumption so that the interface becomes less confusing.