### PR TITLE
[Relax][Frontend][Onnx] Cast Op special handling for ShapeExpr input

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -442,6 +442,11 @@ class Cast(OnnxOpConverter):
     @classmethod
     def _impl_v13(cls, bb, inputs, attr, params):
         to_type = get_type(attr["to"])
+        if isinstance(inputs[0], relax.ShapeExpr):
+            shape = inputs[0]
+            if all([isinstance(x, tir.IntImm) for x in shape]):
+                shape = [int(x) for x in shape]
+                return relax.const(shape, to_type)
         if isinstance(inputs[0], relax.Constant):
             output = inputs[0].data.numpy().astype(to_type)
             return relax.const(output, to_type)
@@ -2210,6 +2215,7 @@ class ONNXGraphImporter:
                 "Concat",
                 "Equal",
                 "Where",
+                "Cast",
             ]
             for i, inp in enumerate(inputs):
                 if (


### PR DESCRIPTION
The Onnx model I'm working on has Cast Op with static ShapeExpr as its input. This PR updates Cast Op converter to handle this sepcial case.
<img width="641" alt="image" src="https://github.com/apache/tvm/assets/81693503/44208260-0a99-430e-a9ac-53837622f294">
