### PR TITLE
[BugFix][MetaSchedule] Fix TensorIntrin ‘dot_4x4_i8i8s32_sdot’ is not registered

### DIFF
--- a/python/tvm/tir/tensor_intrin/__init__.py
+++ b/python/tvm/tir/tensor_intrin/__init__.py
@@ -16,3 +16,4 @@
 # under the License.
 # pylint: disable=unused-import
 """Intrinsics for tensorization."""
+from . import arm_cpu, cuda, rocm, x86, hexagon


### PR DESCRIPTION
In PR #16921, an import line ([see here](https://github.com/apache/tvm/pull/16921/files#diff-226678f3b8a1a0f9e7c9e36dc6313b9ae53c88759c70f2c39b7e88d408311b20L19)) was inadvertently omitted, resulting in the following error:

`ValueError: TensorIntrin 'dot_4x4_i8i8s32_sdot' is not registered`

This patch restores the lost import. 