### PR TITLE
[WebGPU] Translate `int8x4` into `u32`

### DIFF
--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -298,6 +298,11 @@ void CodeGenWebGPU::PrintType(DataType t, std::ostream& os) {  // NOLINT(*)
 
   if (lanes != 1) {
     ICHECK(lanes >= 2 && lanes <= 4) << "CodeGenWebGPU: only allows vector with lanes in {2, 3, 4}";
+    // Currently WebGPU doesn't support `i8` and an `int8x4` is represented as a `u32`.
+    if (t.is_int() && t.bits() == 8 && lanes == 4) {
+      os << "u32";
+      return;
+    }
     os << "vec" << lanes << "<";
   }
 


### PR DESCRIPTION
This patch translates an `int8x4` into a `u32` in WGSL shaders as 8-bit integers are not supported in WebGPU right now and the WGSL built-in function `dot4I8Packed()` accepts `u32` as its inputs and each of the `u32` value logically represents a 4-element 8-bit integer vector.

issue: #16627