### PR TITLE
[AOT] Correctly calculate workspace for vector types

### DIFF
--- a/src/tir/usmp/utils.cc
+++ b/src/tir/usmp/utils.cc
@@ -181,7 +181,11 @@ Map<String, PoolAllocation> GetIOPoolAllocations(
 }
 
 static Integer CalculateExtentsSize(const DataType& dtype, const Array<PrimExpr>& extents) {
-  size_t element_size_bytes = dtype.bytes();
+  if (dtype.is_scalable_vector()) {
+    // We cannot statically calculate workspace for scalable types
+    return Integer();
+  }
+  size_t element_size_bytes = dtype.bytes() * dtype.lanes();
   size_t num_elements = 1;
   for (const auto& ext : extents) {
     if (ext->IsInstance<IntImmNode>()) {

--- a/tests/python/tir-analysis/test_tir_analysis_calculate_workspace.py
+++ b/tests/python/tir-analysis/test_tir_analysis_calculate_workspace.py
@@ -123,5 +123,4 @@ def test_vector_type():
 
 
 if __name__ == "__main__":
-    test_global_allocates()
-    test_local_allocates()
+    tvm.testing.main()


### PR DESCRIPTION
When calculating the size of the workspace for a given prim func, the lanes of the data type was not being considered, meaning sizes calculated for dtypes such as "float32x4" were smaller than what they should be. This commit also considers lanes in the calculation.