### PR TITLE
[TVMScript][Relax] Preserve tir.SizeVar through TVMScript round-trip

### DIFF
--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -68,6 +68,13 @@ def bind_assign_value(
                     "Expected the same dtype for TIR vars "
                     f"but got {value.dtype} vs {prev_value.dtype}",
                 )
+            if type(prev_value) != type(value):
+                self.report_error(
+                    node,
+                    f"Expected the same IR type for TIR vars "
+                    f"but existing value {type(value)} is mismatched "
+                    f"to previous {type(prev_value)}",
+                )
             return prev_value
         IRBuilder.name(var_name, value)
         return value
@@ -144,18 +151,46 @@ def is_recursive(node: doc.FunctionDef) -> bool:
     return False
 
 
+def collect_symbolic_var_from_prelude(
+    self: Parser, node: doc.FunctionDef, symbolic_vars: Dict[str, tir.Var]
+) -> Dict[str, tir.Var]:
+    prelude_vars = {}
+    for stmt in node.body:
+        if isinstance(stmt, doc.Assign) and all(
+            isinstance(target, doc.Name) and target.id in symbolic_vars for target in stmt.targets
+        ):
+            values = self.eval_expr(stmt.value)
+
+            try:
+                iter(values)
+            except TypeError:
+                values = [values]
+
+            for target, value in zip(stmt.targets, values, strict=True):
+                name = target.id
+                prelude_vars[name] = value
+
+    return {**symbolic_vars, **prelude_vars}
+
+
 def collect_symbolic_var_from_params(self: Parser, node: doc.FunctionDef) -> None:
     # Collect symbolic vars from parameters
-    symbolic_vars = set()
+    symbolic_vars = {}
     for arg in node.args.args:
         if arg.annotation is None:
             self.report_error(arg, "Type annotation is required for function parameters.")
         param_sinfo_proxy = eval_struct_info_proxy(self, arg.annotation)
-        symbolic_vars.update(param_sinfo_proxy.get_symbolic_vars())
+
+        for var_name in param_sinfo_proxy.get_symbolic_vars():
+            if var_name not in symbolic_vars:
+                symbolic_vars[var_name] = tir.Var(var_name, "int64")
+
+    # Update symbolic vars based on
+    symbolic_vars = collect_symbolic_var_from_prelude(self, node, symbolic_vars)
 
     # Define symbolic vars to the current var_table frame
-    for var_name in symbolic_vars:
-        self.var_table.add(var_name, tir.Var(var_name, "int64"), allow_shadowing=False)
+    for var_name, var in symbolic_vars.items():
+        self.var_table.add(var_name, var, allow_shadowing=False)
 
 
 @dispatch.register(token="relax", type_name="FunctionDef")

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -68,7 +68,7 @@ def bind_assign_value(
                     "Expected the same dtype for TIR vars "
                     f"but got {value.dtype} vs {prev_value.dtype}",
                 )
-            if type(prev_value) != type(value):
+            if not isinstance(value, type(prev_value)):
                 self.report_error(
                     node,
                     f"Expected the same IR type for TIR vars "

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -75,7 +75,7 @@ def bind_assign_value(
                     f"but existing value {type(value)} is mismatched "
                     f"to previous {type(prev_value)}",
                 )
-            return prev_value
+            value = prev_value
         IRBuilder.name(var_name, value)
         return value
 

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -166,7 +166,8 @@ def collect_symbolic_var_from_prelude(
             except TypeError:
                 values = [values]
 
-            for target, value in zip(stmt.targets, values, strict=True):
+            assert len(stmt.targets) == len(values)
+            for target, value in zip(stmt.targets, values):
                 name = target.id
                 prelude_vars[name] = value
 

--- a/src/script/printer/relax/tir.cc
+++ b/src/script/printer/relax/tir.cc
@@ -18,6 +18,7 @@
  */
 #include <tvm/ir/expr.h>
 
+#include "../tir/utils.h"
 #include "./utils.h"
 
 namespace tvm {
@@ -59,7 +60,7 @@ Doc PrintTIRVar(tir::Var n, ObjectPath n_p, IRDocsifier d) {
     }
     IdDoc var = d->Define(n, GetRef<Frame>(f), n->name_hint.empty() ? "v" : n->name_hint);
     var->source_paths.push_back(n_p);
-    f->stmts.push_back(AssignDoc(var, TIR(d, DType2Str(n->dtype))->Call({}), NullOpt));
+    f->stmts.push_back(AssignDoc(var, PrintVarCreation(n, n_p, d), NullOpt));
   }
   if (Optional<ExprDoc> doc = d->GetVarDoc(n)) {
     return doc.value();


### PR DESCRIPTION
Prior to this commit, all symbolic variables were printed identically, regardless of whether the underlying variable was a `tir.Var` or `tir.SizeVar`.  As a result, numeric simplifications that rely on a `tir.SizeVar` being non-negative may be skipped after a round-trip through TVMScript.

This commit updates the TVMScript printing and parsing of Relax functions to use `var = T.int64(is_size_var=True)` for `tir.SizeVar`, matching how `tir.SizeVar` is parsed for TIR functions.  As an added benefit, this also allows Relax functions `R.Prim` arguments other than `int64` to be benefit.  This may be useful in the future, such as to specify the fill value for `R.full`.