### PR TITLE
[Relax][BlockBuilder] Use PrimValue to provide tir_vars

### DIFF
--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -356,7 +356,7 @@ def gen_call_tir_inputs(
     outs = [te_out] if isinstance(te_out, te_Tensor) else list(te_out)
     unbound_tir_vars = _get_unbound_tir_vars([*create_primfunc_args, *outs], extra_tir_args_list)
 
-    inputs = [*create_primfunc_args] + outs + unbound_tir_vars
+    inputs = [*create_primfunc_args, *unbound_tir_vars, *outs]
     tir_func = create_prim_func(inputs, "int64")
 
     if primfunc_attrs:
@@ -377,8 +377,7 @@ def gen_call_tir_inputs(
         for out in outs
     ]
 
-    tir_vars = None
-    if len(unbound_tir_vars) > 0:
-        tir_vars = _shape_with_old_tir_var(unbound_tir_vars, tir_var_inverse_map)
+    for tir_var in unbound_tir_vars:
+        call_tir_args.append(PrimValue(tir.stmt_functor.substitute(tir_var, tir_var_inverse_map)))
 
-    return (tir_func, call_tir_args, output_sinfo, tir_vars)
+    return (tir_func, call_tir_args, output_sinfo, None)

--- a/tests/python/relax/test_blockbuilder_emit_te.py
+++ b/tests/python/relax/test_blockbuilder_emit_te.py
@@ -45,8 +45,8 @@ def test_emit_te_with_symbolic_arg():
         @T.prim_func(private=True)
         def te_func(
             A: T.Buffer((T.int64(10),), "float32"),
-            B: T.Buffer((T.int64(10),), "float32"),
             m: T.int64,
+            B: T.Buffer((T.int64(10),), "float32"),
         ):
             T.func_attr({"tir.noalias": T.bool(True)})
             for i in range(T.int64(10)):
@@ -63,9 +63,8 @@ def test_emit_te_with_symbolic_arg():
             cls = Expected
             gv = R.call_tir(
                 cls.te_func,
-                (x,),
+                [x, R.prim_value(m)],
                 out_sinfo=R.Tensor((10,), dtype="float32"),
-                tir_vars=R.shape([m]),
             )
             return gv
 
@@ -95,8 +94,8 @@ def test_symbolic_shape_in_prim_value():
         @T.prim_func(private=True)
         def te_slice(
             A: T.Buffer([T.int64(16), T.int64(16)], "float32"),
-            Output: T.Buffer(T.int64(16), "float32"),
             row_index: T.int64,
+            Output: T.Buffer(T.int64(16), "float32"),
         ):
             T.func_attr({"tir.noalias": T.bool(True)})
 
@@ -116,8 +115,7 @@ def test_symbolic_shape_in_prim_value():
 
             gv = R.call_tir(
                 cls.te_slice,
-                A,
-                tir_vars=[row_index],
+                [A, R.prim_value(row_index)],
                 out_sinfo=R.Tensor([16], "float32"),
             )
             return gv

--- a/tests/python/relax/test_op_index.py
+++ b/tests/python/relax/test_op_index.py
@@ -989,16 +989,15 @@ def test_legalize_dynamic_begin_end():
             index = T.int64()
             return R.call_tir(
                 expected.strided_slice,
-                (A,),
+                (A, R.prim_value(index)),
                 out_sinfo=R.Tensor((1, 16), "float32"),
-                tir_vars=R.shape([index]),
             )
 
         @T.prim_func(private=True)
         def strided_slice(
             A: T.Buffer((T.int64(16), T.int64(16))),
-            B: T.Buffer((T.int64(1), T.int64(16))),
             index: T.int64,
+            B: T.Buffer((T.int64(1), T.int64(16))),
         ):
             T.func_attr({"tir.noalias": T.bool(True)})
             for iters in T.grid(*B.shape):

--- a/tests/python/relax/test_transform_legalize_ops_distributed.py
+++ b/tests/python/relax/test_transform_legalize_ops_distributed.py
@@ -36,7 +36,7 @@ def test_redistribute_replica_to_shard():
     @I.ir_module
     class Expected:
         @T.prim_func(private=True)
-        def strided_slice(A: T.Buffer((T.int64(10), T.int64(10)), "float32"), redistribute_replica_to_shard: T.Buffer((T.int64(10), T.int64(5)), "float32"), worker_id: T.int64):
+        def strided_slice(A: T.Buffer((T.int64(10), T.int64(10)), "float32"), worker_id: T.int64, redistribute_replica_to_shard: T.Buffer((T.int64(10), T.int64(5)), "float32")):
             T.func_attr({"tir.noalias": T.bool(True)})
             # with T.block("root"):
             for i0, i1 in T.grid(T.int64(10), T.int64(5)):
@@ -52,7 +52,11 @@ def test_redistribute_replica_to_shard():
             cls = Expected
             gv: R.Shape(ndim=-1) = R.call_pure_packed("runtime.disco.worker_id", sinfo_args=(R.Shape(ndim=-1),))
             gv1: R.Shape([worker_id]) = R.match_cast(gv, R.Shape([worker_id]))
-            gv0 = R.call_tir(cls.strided_slice, (x,), out_sinfo=R.Tensor((10, 5), dtype="float32"), tir_vars=R.shape([worker_id]))
+            gv0 = R.call_tir(
+                cls.strided_slice,
+                (x,R.prim_value(worker_id)),
+                out_sinfo=R.Tensor((10, 5), dtype="float32"),
+            )
             return gv0
     # fmt: on
 

--- a/tests/python/relax/test_transform_legalize_ops_nn.py
+++ b/tests/python/relax/test_transform_legalize_ops_nn.py
@@ -2684,22 +2684,46 @@ def test_group_norm_fp16():
 
 
 def test_group_norm_symbolic():
-    # fmt: off
-    @tvm.script.ir_module
+    @I.ir_module
     class GroupNorm:
         @R.function
-        def main(s: R.Shape(["c"]), x: R.Tensor(("n", "4 * c", "h", "w"), "float32"), gamma: R.Tensor(("4 * c",), "float32"), beta: R.Tensor(("4 * c",), "float32")) -> R.Tensor(("n", "4 * c", "h", "w"), "float32"):
+        def main(
+            s: R.Shape(["c"]),
+            x: R.Tensor(("n", "4 * c", "h", "w"), "float32"),
+            gamma: R.Tensor(("4 * c",), "float32"),
+            beta: R.Tensor(("4 * c",), "float32"),
+        ) -> R.Tensor(("n", "4 * c", "h", "w"), "float32"):
+            gv = R.nn.group_norm(x, gamma, beta, num_groups=4, channel_axis=1, axes=[2, 3])
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            s: R.Shape(["c"]),
+            x: R.Tensor(("n", "4 * c", "h", "w"), dtype="float32"),
+            gamma: R.Tensor(("4 * c",), dtype="float32"),
+            beta: R.Tensor(("4 * c",), dtype="float32"),
+        ) -> R.Tensor(("n", "4 * c", "h", "w"), dtype="float32"):
             n = T.int64()
             c = T.int64()
             h = T.int64()
             w = T.int64()
-            gv: R.Tensor((n, 4 * c, h, w), "float32") = R.nn.group_norm(x, gamma, beta, num_groups=4, channel_axis=1, axes=[2, 3])
+            gv = R.call_tir(
+                Expected.group_norm,
+                (x, gamma, beta, R.prim_value(c)),
+                out_sinfo=R.Tensor((n, 4 * c, h, w), dtype="float32"),
+            )
             return gv
 
-    @tvm.script.ir_module
-    class Expected:
         @T.prim_func(private=True)
-        def group_norm(var_rxplaceholder: T.handle, var_rxplaceholder_1: T.handle, var_rxplaceholder_2: T.handle, var_T_reshape: T.handle, c: T.int64):
+        def group_norm(
+            var_rxplaceholder: T.handle,
+            var_rxplaceholder_1: T.handle,
+            var_rxplaceholder_2: T.handle,
+            c: T.int64,
+            var_T_reshape: T.handle,
+        ):
             T.func_attr({"tir.noalias": True})
             n = T.int64()
             h = T.int64()
@@ -2708,7 +2732,7 @@ def test_group_norm_symbolic():
             rxplaceholder_1 = T.match_buffer(var_rxplaceholder_1, (T.int64(4) * c,))
             rxplaceholder_2 = T.match_buffer(var_rxplaceholder_2, (T.int64(4) * c,))
             T_reshape = T.match_buffer(var_T_reshape, (n, T.int64(4) * c, h, w))
-            # with T.block("root"):
+
             T_reshape_1 = T.alloc_buffer((n, T.int64(4), T.int64(4) * c // T.int64(4), h, w))
             rxplaceholder_red_temp_v0 = T.alloc_buffer((n, T.int64(4)))
             rxplaceholder_red_temp_v1 = T.alloc_buffer((n, T.int64(4)))
@@ -2717,56 +2741,97 @@ def test_group_norm_symbolic():
             T_group_norm = T.alloc_buffer((n, T.int64(4), T.int64(4) * c // T.int64(4), h, w))
             for ax0, ax1, ax2, ax3, ax4 in T.grid(n, T.int64(4), c, h, w):
                 with T.block("T_reshape"):
-                    v_ax0, v_ax1, v_ax2, v_ax3, v_ax4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
-                    T.reads(rxplaceholder[((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4) // w // h // (c * T.int64(4)) % n, ((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4) // w // h % (c * T.int64(4)), ((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4) // w % h, ((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4) % w])
-                    T.writes(T_reshape_1[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4])
-                    T_reshape_1[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = rxplaceholder[((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4) // w // h // (c * T.int64(4)) % n, ((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4) // w // h % (c * T.int64(4)), ((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4) // w % h, ((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4) % w]
+                    v_ax0, v_ax1, v_ax2, v_ax3, v_ax4 = T.axis.remap(
+                        "SSSSS", [ax0, ax1, ax2, ax3, ax4]
+                    )
+                    T_reshape_1[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = rxplaceholder[
+                        ((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4)
+                        // w
+                        // h
+                        // (c * T.int64(4))
+                        % n,
+                        ((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4)
+                        // w
+                        // h
+                        % (c * T.int64(4)),
+                        ((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4)
+                        // w
+                        % h,
+                        ((((v_ax0 * T.int64(4) + v_ax1) * c + v_ax2) * h + v_ax3) * w + v_ax4) % w,
+                    ]
             for ax0, ax1, k2, k3, k4 in T.grid(n, T.int64(4), c, h, w):
                 with T.block("rxplaceholder_red_temp"):
                     v_ax0, v_ax1, v_k2, v_k3, v_k4 = T.axis.remap("SSRRR", [ax0, ax1, k2, k3, k4])
-                    T.reads(T_reshape_1[v_ax0, v_ax1, v_k2, v_k3, v_k4])
-                    T.writes(rxplaceholder_red_temp_v0[v_ax0, v_ax1], rxplaceholder_red_temp_v1[v_ax0, v_ax1])
                     with T.init():
                         rxplaceholder_red_temp_v0[v_ax0, v_ax1] = T.float32(0)
                         rxplaceholder_red_temp_v1[v_ax0, v_ax1] = T.float32(0)
-                    v_rxplaceholder_red_temp_v0: T.float32 = rxplaceholder_red_temp_v0[v_ax0, v_ax1] + T_reshape_1[v_ax0, v_ax1, v_k2, v_k3, v_k4]
-                    v_rxplaceholder_red_temp_v1: T.float32 = rxplaceholder_red_temp_v1[v_ax0, v_ax1] + T_reshape_1[v_ax0, v_ax1, v_k2, v_k3, v_k4] * T_reshape_1[v_ax0, v_ax1, v_k2, v_k3, v_k4]
+                    v_rxplaceholder_red_temp_v0: T.float32 = (
+                        rxplaceholder_red_temp_v0[v_ax0, v_ax1]
+                        + T_reshape_1[v_ax0, v_ax1, v_k2, v_k3, v_k4]
+                    )
+                    v_rxplaceholder_red_temp_v1: T.float32 = (
+                        rxplaceholder_red_temp_v1[v_ax0, v_ax1]
+                        + T_reshape_1[v_ax0, v_ax1, v_k2, v_k3, v_k4]
+                        * T_reshape_1[v_ax0, v_ax1, v_k2, v_k3, v_k4]
+                    )
                     rxplaceholder_red_temp_v0[v_ax0, v_ax1] = v_rxplaceholder_red_temp_v0
                     rxplaceholder_red_temp_v1[v_ax0, v_ax1] = v_rxplaceholder_red_temp_v1
             for ax0, ax1 in T.grid(T.int64(4), c):
                 with T.block("T_reshape_1"):
                     v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
-                    T.reads(rxplaceholder_1[(v_ax0 * c + v_ax1) % (c * T.int64(4))])
-                    T.writes(T_reshape_2[v_ax0, v_ax1])
-                    T_reshape_2[v_ax0, v_ax1] = rxplaceholder_1[(v_ax0 * c + v_ax1) % (c * T.int64(4))]
+                    T_reshape_2[v_ax0, v_ax1] = rxplaceholder_1[
+                        (v_ax0 * c + v_ax1) % (c * T.int64(4))
+                    ]
             for ax0, ax1 in T.grid(T.int64(4), c):
                 with T.block("T_reshape_2"):
                     v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
-                    T.reads(rxplaceholder_2[(v_ax0 * c + v_ax1) % (c * T.int64(4))])
-                    T.writes(T_reshape_3[v_ax0, v_ax1])
-                    T_reshape_3[v_ax0, v_ax1] = rxplaceholder_2[(v_ax0 * c + v_ax1) % (c * T.int64(4))]
+                    T_reshape_3[v_ax0, v_ax1] = rxplaceholder_2[
+                        (v_ax0 * c + v_ax1) % (c * T.int64(4))
+                    ]
             for ax0, ax1, ax2, ax3, ax4 in T.grid(n, T.int64(4), c, h, w):
                 with T.block("T_group_norm"):
-                    v_ax0, v_ax1, v_ax2, v_ax3, v_ax4 = T.axis.remap("SSSSS", [ax0, ax1, ax2, ax3, ax4])
-                    T.reads(T_reshape_1[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4], rxplaceholder_red_temp_v0[v_ax0, v_ax1], rxplaceholder_red_temp_v1[v_ax0, v_ax1], T_reshape_2[v_ax1, v_ax2], T_reshape_3[v_ax1, v_ax2])
-                    T.writes(T_group_norm[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4])
-                    T_group_norm[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = (T_reshape_1[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] - rxplaceholder_red_temp_v0[v_ax0, v_ax1] / (T.Cast("float32", c) * T.Cast("float32", h) * T.Cast("float32", w))) * T.rsqrt(rxplaceholder_red_temp_v1[v_ax0, v_ax1] / (T.Cast("float32", c) * T.Cast("float32", h) * T.Cast("float32", w)) - rxplaceholder_red_temp_v0[v_ax0, v_ax1] / (T.Cast("float32", c) * T.Cast("float32", h) * T.Cast("float32", w)) * (rxplaceholder_red_temp_v0[v_ax0, v_ax1] / (T.Cast("float32", c) * T.Cast("float32", h) * T.Cast("float32", w))) + T.float32(1.0000000000000001e-05)) * T_reshape_2[v_ax1, v_ax2] + T_reshape_3[v_ax1, v_ax2]
+                    v_ax0, v_ax1, v_ax2, v_ax3, v_ax4 = T.axis.remap(
+                        "SSSSS", [ax0, ax1, ax2, ax3, ax4]
+                    )
+                    T_group_norm[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4] = (
+                        T_reshape_1[v_ax0, v_ax1, v_ax2, v_ax3, v_ax4]
+                        - rxplaceholder_red_temp_v0[v_ax0, v_ax1]
+                        / (T.Cast("float32", c) * T.Cast("float32", h) * T.Cast("float32", w))
+                    ) * T.rsqrt(
+                        rxplaceholder_red_temp_v1[v_ax0, v_ax1]
+                        / (T.Cast("float32", c) * T.Cast("float32", h) * T.Cast("float32", w))
+                        - rxplaceholder_red_temp_v0[v_ax0, v_ax1]
+                        / (T.Cast("float32", c) * T.Cast("float32", h) * T.Cast("float32", w))
+                        * (
+                            rxplaceholder_red_temp_v0[v_ax0, v_ax1]
+                            / (T.Cast("float32", c) * T.Cast("float32", h) * T.Cast("float32", w))
+                        )
+                        + T.float32(1.0000000000000001e-05)
+                    ) * T_reshape_2[
+                        v_ax1, v_ax2
+                    ] + T_reshape_3[
+                        v_ax1, v_ax2
+                    ]
             for ax0, ax1, ax2, ax3 in T.grid(n, c * T.int64(4), h, w):
                 with T.block("T_reshape_3"):
                     v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
-                    T.reads(T_group_norm[(((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) // w // h // c // T.int64(4) % n, (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) // w // h // c % T.int64(4), (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) // w // h % c, (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) // w % h, (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) % w])
-                    T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
-                    T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = T_group_norm[(((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) // w // h // c // T.int64(4) % n, (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) // w // h // c % T.int64(4), (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) // w // h % c, (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) // w % h, (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) % w]
+                    T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = T_group_norm[
+                        (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3)
+                        // w
+                        // h
+                        // c
+                        // T.int64(4)
+                        % n,
+                        (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3)
+                        // w
+                        // h
+                        // c
+                        % T.int64(4),
+                        (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) // w // h % c,
+                        (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) // w % h,
+                        (((v_ax0 * c * T.int64(4) + v_ax1) * h + v_ax2) * w + v_ax3) % w,
+                    ]
 
-        @R.function
-        def main(s: R.Shape(["c"]), x: R.Tensor(("n", "4 * c", "h", "w"), dtype="float32"), gamma: R.Tensor(("4 * c",), dtype="float32"), beta: R.Tensor(("4 * c",), dtype="float32")) -> R.Tensor(("n", "4 * c", "h", "w"), dtype="float32"):
-            n = T.int64()
-            c = T.int64()
-            h = T.int64()
-            w = T.int64()
-            gv = R.call_tir(Expected.group_norm, (x, gamma, beta), out_sinfo=R.Tensor((n, 4 * c, h, w), dtype="float32"), tir_vars=R.shape([c]))
-            return gv
-    # fmt: on
     mod = LegalizeOps()(GroupNorm)
     tvm.ir.assert_structural_equal(mod, Expected)
 

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -956,7 +956,7 @@ def test_call_tir_empty_tuple_arg():
     _check(bb.get())
 
 
-def test_call_tir_with_tir_var():
+def test_call_tir_with_prim_value():
     @I.ir_module
     class Module:
         @R.function


### PR DESCRIPTION
Prior to this commit, if a TIR variable was required to compute the output of `BlockBuilder.call_te`, but that TIR variable could not be inferred from the shape of any tensor arguments, it would be provided in an optional `tir_vars` argument to `R.call_tir`.  In C++, this would be then be accessed as an optional
`call->args[2].as<ShapeExprNode>()`.

This extra argument can cause unexpected bugs.  For example, the bug that was fixed in https://github.com/apache/tvm/pull/17086 was caused by `RewriteDataflowReshape` identifying the output buffer using `prim_func->buffer_map.Get(prim_func->params.back())`, which is only correct if `tir_vars` is empty.  Rather than fixing these issues as they come up, it would be better to make the general Relax guarantees stronger by removing the `tir_vars` argument altogether.

Use of extra `R.shape` parameter to specify additional `tir_vars` predates the existence of `relax::PrimValue`, and is no longer required.  This commit updates `BlockBuilder.call_te` to use additional `relax.PrimValue` arguments to handle symbolic values that cannot be inferred from tensor shapes, rather than `tir_vars`.