### PR TITLE
[Bugfix] Update FAttrsGetter to return Map<String, ObjectRef>

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -367,7 +367,7 @@ class FusionPatternNode : public Object {
    * \brief The function to get attributes for fused function
    *
    * It should have signature
-   * Map<String, String>(const Map<String, Expr>& context)
+   * Map<String, ObjectRef>(const Map<String, Expr>& context)
    */
   Optional<PackedFunc> attrs_getter;
 

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -1035,7 +1035,7 @@ class PatternBasedPartitioner : ExprVisitor {
   using PatternCheckContext = transform::PatternCheckContext;
   using ExprVisitor::VisitExpr_;
   using FCheckMatch = runtime::TypedPackedFunc<bool(const transform::PatternCheckContext&)>;
-  using FAttrsGetter = runtime::TypedPackedFunc<Map<String, String>(const Map<String, Expr>&)>;
+  using FAttrsGetter = runtime::TypedPackedFunc<Map<String, ObjectRef>(const Map<String, Expr>&)>;
 
   static GroupMap Run(String pattern_name, DFPattern pattern,
                       Map<String, DFPattern> annotation_patterns, FCheckMatch check, Expr expr,


### PR DESCRIPTION
Prior to this commit, `FAttrsGetter` was defined as a function that returned `Map<String, String>`.  However, it is used to define attributes in a `Map<String, ObjectRef>`, and in some cases is used to define attributes whose value is a dictionary (e.g. `msc_attrs_getter` in `python/tvm/contrib/msc/core/transform/pattern.py`).

This commit updates the type signature of `FAttrsGetter` to match its usage, returning a `Map<String, ObjectRef>`.