### PR TITLE
[Bugfix][CRT] Return error code on error from ModuleGetFunction

### DIFF
--- a/src/runtime/crt/common/crt_runtime_api.c
+++ b/src/runtime/crt/common/crt_runtime_api.c
@@ -349,9 +349,21 @@ int ModuleGetFunction(TVMValue* args, int* type_codes, int num_args, TVMValue* r
 
   ret_value[0].v_handle = NULL;
   ret_type_codes[0] = kTVMNullptr;
-  if (num_args != 3 || type_codes[0] != kTVMModuleHandle || type_codes[1] != kTVMStr ||
-      type_codes[2] != kDLInt) {
-    return 0;
+  if (num_args != 3) {
+    TVMAPISetLastError("ModuleGetFunction expects exactly 3 arguments");
+    return kTvmErrorFunctionCallNumArguments;
+  }
+  if (type_codes[0] != kTVMModuleHandle) {
+    TVMAPISetLastError("ModuleGetFunction expects first argument to be a Module");
+    return kTvmErrorFunctionCallWrongArgType;
+  }
+  if (type_codes[1] != kTVMStr) {
+    TVMAPISetLastError("ModuleGetFunction expects second argument to be a string");
+    return kTvmErrorFunctionCallWrongArgType;
+  }
+  if (type_codes[2] != kDLInt) {
+    TVMAPISetLastError("ModuleGetFunction expects third argument to be an integer");
+    return kTvmErrorFunctionCallWrongArgType;
   }
 
   mod = (TVMModuleHandle)args[0].v_handle;


### PR DESCRIPTION
Prior to this commit, `ModuleGetFunction` returned zero if called with an incorrect number of arguments, or with incorrect type codes.  This incorrectly indicated that the module was inspected, and did not contain the requested function.

This commit corrects the implementation of `ModuleGetFunction` to instead call set an error message with `TVMAPISetLastError`, then to return an appropriate error code.