### PR TITLE
[RPC] Raise error if server process terminated

### DIFF
--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -164,6 +164,11 @@ def _serving(sock, addr, opts, load_library):
             # package and maybe hard to be installed on some platforms.
             pass
         server_proc.terminate()
+    elif server_proc.exitcode != 0:
+        raise RuntimeError(
+            f"Child process {server_proc.pid} exited unsuccessfully "
+            f"with error code {server_proc.exitcode}"
+        )
 
     logger.info(f"finish serving {addr}")
     os.chdir(old_cwd)


### PR DESCRIPTION
Prior to this PR, a local RPC server could crash without any indication in the main process.  While typically this crash would cause an error in the main process due to the lack of a `RPCCode::kReturn` from the server, the delayed error can complicate debugging.

This PR updates the local RPC server to raise an exception if the server process returns with a non-zero exit code.