### PR TITLE
[Relax] Apply DefaultGPUSchedule() in default build pipeline

### DIFF
--- a/python/tvm/relax/pipeline.py
+++ b/python/tvm/relax/pipeline.py
@@ -60,6 +60,7 @@ def zero_pipeline(*, enable_warning: bool = False):
         seq = tvm.transform.Sequential(
             [
                 transform.LegalizeOps(enable_warning=enable_warning),
+                tvm.tir.transform.DefaultGPUSchedule(),
                 transform.AnnotateTIROpPattern(),
                 transform.FoldConstant(),
                 transform.FuseOps(),
@@ -84,6 +85,7 @@ def default_build_pipeline():
                 backend.DispatchSampling(),
                 backend.DispatchSortScan(),
                 transform.LegalizeOps(),
+                tvm.tir.transform.DefaultGPUSchedule(),
                 transform.RewriteDataflowReshape(),
                 transform.ToNonDataflow(),
                 transform.RemovePurityChecking(),

--- a/tests/python/ir/test_pass_instrument.py
+++ b/tests/python/ir/test_pass_instrument.py
@@ -14,10 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-""" Instrument test cases.
-"""
+
+""" Instrument test cases. """
 
 import tvm
+
 from tvm import relax
 from tvm.ir.instrument import PrintAfterAll, PrintBeforeAll
 from tvm.script import ir as I
@@ -56,7 +57,8 @@ def test_relax_print_all_passes(capsys):
 
     pipeline = relax.get_pipeline("default_build")
     with tvm.transform.PassContext(opt_level=3, instruments=[PrintBeforeAll(), PrintAfterAll()]):
-        pipeline(Module)
+        with tvm.target.Target("llvm"):
+            pipeline(Module)
     all_passes_output = capsys.readouterr().out
     assert "Before Running Pass:" in all_passes_output
     assert "After Running Pass:" in all_passes_output

--- a/tests/python/relax/test_vm_build.py
+++ b/tests/python/relax/test_vm_build.py
@@ -1309,5 +1309,25 @@ def test_relax_module_with_multiple_targets(exec_mode):
     tvm.testing.assert_allclose(cuda_output.numpy(), np_C)
 
 
+@tvm.testing.requires_cuda(support_required="compile-only")
+def test_relax_default_gpu_scheduling():
+    """Legalization may produce operations that require scheduling
+
+    The default build pipeline legalizes any Relax operators that are
+    not already legalized.  This may produce TIR PrimFuncs that must
+    be scheduled for use on the GPU.
+
+    """
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16, 16], "float32"), B: R.Tensor([16, 16], "float32")):
+            C = R.add(A, B)
+            return C
+
+    tvm.relax.build(Module, target="cuda")
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
This is a follow-up to https://github.com/apache/tvm/pull/15864, which added `LegalizeOps` to the default Relax build pipeline.  Since legalization may produce additional TIR PrimFuncs that require scheduling, the output of `LegalizeOps` typically must also be passed through `tir.transform.DefaultGPUSchedule()`.  This PR adds `DefaultGPUSchedule()` to the relax build pipeline to handle these cases.

Scheduled PrimFunc have the `"tir.is_scheduled"` attribute set to true, and are ignored by `DefaultGPUSchedule()`.  In addition, the `DefaultGPUSchedule` transform has no effect on non-GPU targets. Therefore, this change should only impact `tvm.relax.build` calls that previously resulted in an error due to unscheduled GPU functions, and should not have any impact on existing calls.