### PR TITLE
[Relax][VM] Improved error messages for mismatched parameter count

### DIFF
--- a/src/relax/backend/vm/exec_builder.cc
+++ b/src/relax/backend/vm/exec_builder.cc
@@ -113,6 +113,10 @@ void ExecBuilderNode::EmitFunction(const std::string& func_name, int64_t num_inp
   ICHECK_EQ(vmfunc.num_args, -2) << "Function " << func_name << " already defined";
   vmfunc.num_args = num_inputs;
   if (param_names.defined()) {
+    ICHECK_EQ(num_inputs, param_names.value().size())
+        << "Function " << func_name << " defined with " << num_inputs << " arguments, "
+        << "but the list of parameter names has " << param_names.value().size() << " names ("
+        << param_names << ")";
     std::vector<std::string> names;
     for (auto name : param_names.value()) {
       names.push_back(name);

--- a/src/runtime/relax_vm/vm.cc
+++ b/src/runtime/relax_vm/vm.cc
@@ -678,9 +678,23 @@ RegType VirtualMachineImpl::InvokeBytecode(Index gf_idx, const std::vector<RegTy
   }
 
   // load arguments to the register file
-  ICHECK_EQ(static_cast<size_t>(gfunc.num_args), args.size())
-      << "ValueError: Invoking function " << gfunc.name << " requires " << gfunc.num_args
-      << " inputs but only " << args.size() << " inputs are provided.";
+  ICHECK_EQ(static_cast<size_t>(gfunc.num_args), args.size()) << "ValueError: Invoking function "
+                                                              << gfunc.name << " expects "
+                                                              << gfunc.num_args << " arguments" <<
+      [&]() {
+        std::stringstream ss;
+        if (gfunc.param_names.size()) {
+          ss << " (";
+          for (size_t i = 0; i < gfunc.param_names.size(); i++) {
+            if (i) {
+              ss << ", ";
+            }
+            ss << gfunc.param_names[i];
+          }
+          ss << ")";
+        }
+        return ss.str();
+      }() << ", but " << args.size() << " arguments were provided.";
   for (size_t i = 0; i < args.size(); ++i) {
     WriteRegister(frames_.back().get(), i, args[i]);
   }


### PR DESCRIPTION
This commit improves validation of the parameter names used for a Relax VM function definition, using the parameter names for runtime error messages.