### PR TITLE
[Hexagon] Add support for v75

### DIFF
--- a/apps/hexagon_launcher/README.md
+++ b/apps/hexagon_launcher/README.md
@@ -43,10 +43,10 @@ Create a subdirectory for the build files, and run `cmake` with the
 following variables set:
 
 ```
-cmake -DCMAKE_C_COMPILER=/path/to/hexagon-clang     \
-      -DCMAKE_CXX_COMPILER=/path/to/hexagon-clang++ \
-      -DUSE_HEXAGON_ARCH=v65|v66|v68|v69|v73        \
-      -DUSE_HEXAGON_SDK=/path/to/hexagon/SDK        \
+cmake -DCMAKE_C_COMPILER=/path/to/hexagon-clang         \
+      -DCMAKE_CXX_COMPILER=/path/to/hexagon-clang++     \
+      -DUSE_HEXAGON_ARCH=v65|v66|v68|v69|v73|v75        \
+      -DUSE_HEXAGON_SDK=/path/to/hexagon/SDK            \
       /path/to/apps/hexagon_launcher/cmake/hexagon
 ```
 
@@ -60,10 +60,10 @@ the TVM runtime for Hexagon will be built as a part of the process.
 
 ```
 cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/android-ndk/build/cmake/android.toolchain.cmake \
-      -DANDROID_ABI=arm64-v8a                       \
-      -DANDROID_PLATFORM=android-28                 \
-      -DUSE_HEXAGON_SDK=/p/Hexagon_SDK/4.3.0.0      \
-      -DUSE_HEXAGON_ARCH=v65|v66|v68|v69|v73        \
+      -DANDROID_ABI=arm64-v8a                           \
+      -DANDROID_PLATFORM=android-28                     \
+      -DUSE_HEXAGON_SDK=/p/Hexagon_SDK/4.3.0.0          \
+      -DUSE_HEXAGON_ARCH=v65|v66|v68|v69|v73|v75        \
       /path/to/apps/hexagon_launcher/cmake/android
 ```
 

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -367,7 +367,7 @@ set(USE_HEXAGON_RPC OFF)
 # compiling _by_ TVM). This applies to components like the TVM runtime, but is
 # also used to select correct include/library paths from the Hexagon SDK when
 # building runtime for Android.
-# Valid values are v65, v66, v68, v69, v73.
+# Valid values are v65, v66, v68, v69, v73, v75.
 set(USE_HEXAGON_ARCH "v68")
 
 # Whether use MRVL codegen

--- a/cmake/modules/HexagonSDK.cmake
+++ b/cmake/modules/HexagonSDK.cmake
@@ -109,11 +109,12 @@ function(_get_hexagon_sdk_property_impl
   set(_hexarch_dir_v68 "computev68")
   set(_hexarch_dir_v69 "computev69")
   set(_hexarch_dir_v73 "computev73")
+  set(_hexarch_dir_v75 "computev75")
   set(_hexarch_dir_str "_hexarch_dir_${_hexagon_arch}")
   set(_hexarch_dir "${${_hexarch_dir_str}}")
 
   if(NOT _hexarch_dir)
-    message(SEND_ERROR "Please set Hexagon architecture to one of v65, v66, v68, v69, v73")
+    message(SEND_ERROR "Please set Hexagon architecture to one of v65, v66, v68, v69, v73, v75")
   endif()
 
   if(_property STREQUAL "VERSION")
@@ -160,6 +161,9 @@ function(_get_hexagon_sdk_property_impl
     elseif(_property STREQUAL "QURT_INCLUDE")
       # Set the Hexagon arch directory for runtime linker.
       set(_rtld_dir "hexagon_toolv84_${_hexagon_arch}")
+      if(_hexagon_arch STREQUAL "v75")
+        set(_rtld_dir "hexagon_toolv87_v75") # Use hexagon_toolv87_v75 for v75
+      endif()
       if(_hexagon_arch STREQUAL "v69")
         set(_rtld_dir "hexagon_toolv84_v68") # Use hexagon_toolv84_v68 for v69
       endif()

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -715,7 +715,7 @@ def hexagon(cpu_ver="v68", **kwargs):
         return int(m.group(1))
 
     # Check for valid codegen cpu
-    valid_hex = ["v65", "v66", "v67", "v67t", "v68", "v69", "v71", "v73"]
+    valid_hex = ["v65", "v66", "v67", "v67t", "v68", "v69", "v71", "v73", "v75"]
     try:
         cpu_ver = cpu_ver[cpu_ver.index("v") :].lower()
         assert cpu_ver in valid_hex
@@ -731,6 +731,7 @@ def hexagon(cpu_ver="v68", **kwargs):
             "v68": 4 * one_mb,
             "v69": 8 * one_mb,
             "v73": 8 * one_mb,
+            "v75": 8 * one_mb,
         }
         return default_vtcm_sizes.get(cpu_ver, 0)
 

--- a/src/runtime/hexagon/README.md
+++ b/src/runtime/hexagon/README.md
@@ -54,7 +54,7 @@ ANDROID_ABI=aarch64-v8a
 ANDROID_PLATFORM=android-28
 CMAKE_TOOLCHAIN_FILE=/path/to/android-ndk/build/cmake/android.toolchain.cmake
 USE_HEXAGON=ON
-USE_HEXAGON_ARCH=v65|v66|v68|v69|v73
+USE_HEXAGON_ARCH=v65|v66|v68|v69|v73|v75
 USE_HEXAGON_SDK=/path/to/sdk
 ```
 
@@ -63,7 +63,7 @@ Building for Hexagon requires setting the C/C++ compiler to `hexagon-clang/++`:
 CMAKE_C_COMPILER=hexagon-clang
 CMAKE_CXX_COMPILER=hexagon-clang++
 USE_HEXAGON=ON
-USE_HEXAGON_ARCH=v65|v66|v68|v69|v73
+USE_HEXAGON_ARCH=v65|v66|v68|v69|v73|v75
 USE_HEXAGON_SDK=/path/to/sdk
 USE_RPC=OFF
 USE_LIBBACKTRACE=OFF

--- a/src/runtime/hexagon/rpc/simulator/session.cc
+++ b/src/runtime/hexagon/rpc/simulator/session.cc
@@ -458,6 +458,10 @@ std::string SimulatorRPCChannel::Cpu_::str() const {
     case HEX_CPU_V73:
       return "v73";
 #endif
+#ifdef HEX_CPU_ID_V75NA_1
+    case HEX_CPU_V75:
+      return "v75";
+#endif
     default:
       break;
   }
@@ -574,6 +578,9 @@ std::optional<HEXAPI_Cpu> SimulatorRPCChannel::GetCPU(const detail::MaybeString&
 #endif
 #ifdef HEX_CPU_ID_V73NA_1
       .Case("v73", HEX_CPU_V73)
+#endif
+#ifdef HEX_CPU_ID_V75NA_1
+      .Case("v75", HEX_CPU_V75)
 #endif
       .Default(std::nullopt);
 }

--- a/tests/python/contrib/test_hexagon/README.md
+++ b/tests/python/contrib/test_hexagon/README.md
@@ -49,7 +49,7 @@ cd build
 cmake -DANDROID_ABI=arm64-v8a \
         -DANDROID_PLATFORM=android-28 \
         -DUSE_ANDROID_TOOLCHAIN="path to `android-ndk/build/cmake/android.toolchain.cmake` file" \
-        -DUSE_HEXAGON_ARCH=v65|v66|v68|v69|v73 \
+        -DUSE_HEXAGON_ARCH=v65|v66|v68|v69|v73|v75 \
         -DUSE_HEXAGON_SDK="path to Hexagon SDK" \
         -DUSE_HEXAGON_TOOLCHAIN="path to Hexagon toolchain `Tools` sub-directory which explained above" \
         -DUSE_OUTPUT_BINARY_DIR="path to `build/hexagon_api_output` which is a sub-directory of `tvm`" ..


### PR DESCRIPTION
Add support for executing v75 (Snapdragon 8 gen 3). This PR just adds the support, but to build and execute for v75, the Hexagon SDK used should be 5.4+.