### PR TITLE
[Utils] Define line-length for "ruff format"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,7 @@ exclude = '''
   )/
 )
 '''
+
+[tool.ruff]
+line-length = 100
+indent-width = 4


### PR DESCRIPTION
The `ruff format` tool is an alternative to the `black` formatter, with significantly improved performance.  This commit updates the `pyproject.toml` to include a configuration for `ruff format`, matched to the configuration of `black`.