### PR TITLE
[Compute-inline] Prefer T.where for reverse compute-inlined block with predicate

### DIFF
--- a/tests/python/dlight/test_gpu_matmul.py
+++ b/tests/python/dlight/test_gpu_matmul.py
@@ -113,10 +113,10 @@ class TestMatmul(BaseBeforeAfter):
                                             v0 = T.axis.spatial(T.int64(1), ax0)
                                             v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_2 * T.int64(4) + ax1)
                                             v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_2 * T.int64(4) + ax2_0 * T.int64(2) + ax2_1_1)
+                                            T.where(ax1_0 * T.int64(32) + ax1_2 * T.int64(4) + ax1 < m)
                                             T.reads(matmul_reindex_pad_local[v0, v1, v2])
                                             T.writes(matmul[T.int64(0), v1, v2])
-                                            if v1 < m:
-                                                matmul[T.int64(0), v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
+                                            matmul[T.int64(0), v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
     # fmt: on
 
 
@@ -200,10 +200,10 @@ def test_matmul_int32():
                                             v0 = T.axis.spatial(1, ax0)
                                             v1 = T.axis.spatial((m + 31) // 32 * 32, ax1_0 * 32 + ax1_2 * 4 + ax1)
                                             v2 = T.axis.spatial(4096, ax0_ax2_0_fused * 64 + ax2_2 * 4 + ax2_0 * 2 + ax2_1_1)
+                                            T.where(ax1_0 * 32 + ax1_2 * 4 + ax1 < m)
                                             T.reads(matmul_reindex_pad_local[v0, v1, v2])
                                             T.writes(matmul[0, v1, v2])
-                                            if v1 < m:
-                                                matmul[0, v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
+                                            matmul[0, v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
     # fmt: on
 
     mod = tvm.IRModule({"main": func})
@@ -466,10 +466,10 @@ class TestOutputFP32(BaseBeforeAfter):
                                             v0 = T.axis.spatial(T.int64(1), ax0)
                                             v1 = T.axis.spatial((n + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_2 * T.int64(4) + ax1)
                                             v2 = T.axis.spatial(T.int64(4096), ax0_ax2_0_fused * T.int64(64) + ax2_2 * T.int64(4) + ax2_0 * T.int64(2) + ax2_1_1)
+                                            T.where(ax1_0 * T.int64(32) + ax1_2 * T.int64(4) + ax1 < n)
                                             T.reads(var_matmul_intermediate_reindex_pad_local[v0, v1, v2], lv13_1[v2], lv3[T.int64(0), v1, v2])
                                             T.writes(p_output0_intermediate[T.int64(0), v1, v2])
-                                            if v1 < n:
-                                                p_output0_intermediate[T.int64(0), v1, v2] = T.Cast("float16", var_matmul_intermediate_reindex_pad_local[v0, v1, v2] + T.Cast("float32", lv13_1[v2])) + lv3[T.int64(0), v1, v2]
+                                            p_output0_intermediate[T.int64(0), v1, v2] = T.Cast("float16", var_matmul_intermediate_reindex_pad_local[v0, v1, v2] + T.Cast("float32", lv13_1[v2])) + lv3[T.int64(0), v1, v2]
 
     # fmt: on
 
@@ -596,9 +596,9 @@ class TestInlineConsumerChain(BaseBeforeAfter):
                                             v1 = T.axis.spatial((n + T.int64(31)) // T.int64(32) * T.int64(32), ax1_0 * T.int64(32) + ax1_2 * T.int64(4) + ax1)
                                             v2 = T.axis.spatial(T.int64(2048), ax0_ax2_0_fused * T.int64(64) + ax2_2 * T.int64(4) + ax2_0 * T.int64(2) + ax2_1_1)
                                             T.reads(lv52[T.int64(0), v1, v2], var_NT_matmul_intermediate_reindex_pad_local[v0, v1, v2])
+                                            T.where(ax1_0 * T.int64(32) + ax1_2 * T.int64(4) + ax1 < n)
                                             T.writes(var_T_multiply_intermediate[v1, v2])
-                                            if v1 < n:
-                                                var_T_multiply_intermediate[v1, v2] = T.Cast("float16", lv52[T.int64(0), v1, v2]) * (var_NT_matmul_intermediate_reindex_pad_local[v0, v1, v2] * T.sigmoid(var_NT_matmul_intermediate_reindex_pad_local[v0, v1, v2]))
+                                            var_T_multiply_intermediate[v1, v2] = T.Cast("float16", lv52[T.int64(0), v1, v2]) * (var_NT_matmul_intermediate_reindex_pad_local[v0, v1, v2] * T.sigmoid(var_NT_matmul_intermediate_reindex_pad_local[v0, v1, v2]))
 
     # fmt: on
 
@@ -666,10 +666,10 @@ class TestMatmulAndroid(AndroidBeforeAfter):
                                             v0 = T.axis.spatial(T.int64(1), ax0)
                                             v1 = T.axis.spatial((m + T.int64(31)) // T.int64(32) * T.int64(32), ax0_ax1_0_fused * T.int64(32) + ax1_2 * T.int64(2) + ax1)
                                             v2 = T.axis.spatial(T.int64(4096), ax2_0 * T.int64(64) + ax2_2 * T.int64(8) + ax2_0_1 * T.int64(8) + ax2_1_1)
+                                            T.where(ax0_ax1_0_fused * T.int64(32) + ax1_2 * T.int64(2) + ax1 < m)
                                             T.reads(matmul_reindex_pad_local[v0, v1, v2])
                                             T.writes(matmul[T.int64(0), v1, v2])
-                                            if v1 < m:
-                                                matmul[T.int64(0), v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
+                                            matmul[T.int64(0), v1, v2] = matmul_reindex_pad_local[v0, v1, v2]
     # fmt: on
 
 

--- a/tests/python/dlight/test_gpu_matmul_tensorize.py
+++ b/tests/python/dlight/test_gpu_matmul_tensorize.py
@@ -254,10 +254,10 @@ class TestMatmulTensorizeTooSmall(BaseBeforeAfter):
                                             v0 = T.axis.spatial(1, ax0)
                                             v1 = T.axis.spatial((m + 31) // 32 * 32, ax1_0 * 32 + ax1_2 * 4 + ax1)
                                             v2 = T.axis.spatial(64, ax2_2 * 4 + ax2_0 * 2 + ax2_1_1)
+                                            T.where(ax1_0 * 32 + ax1_2 * 4 + ax1 < m and ax2_2 * 4 + ax2_0 * 2 + ax2_1_1 < 15)
                                             T.reads(compute_reindex_pad_local[v0, v1, v2])
                                             T.writes(compute[v1, v2])
-                                            if v1 < m and v2 < 15:
-                                                compute[v1, v2] = compute_reindex_pad_local[v0, v1, v2]
+                                            compute[v1, v2] = compute_reindex_pad_local[v0, v1, v2]
     # fmt: on
 
 
@@ -417,11 +417,11 @@ class TestMatmulTensorizeEpilogue(BaseBeforeAfter):
                                         v0 = T.axis.spatial(1, 0)
                                         v1 = T.axis.spatial((n + 127) // 128 * 128, ax1_0_0_ax2_0_0_fused * 128 + ax2_0_2_ax1_0_2_fused % 4 * 32 + (ax0_ax1_fused_0 * 128 + ax0_ax1_fused_1 * 4 + ax0_ax1_fused_2) // 32)
                                         v2 = T.axis.spatial(4096, ax1_0_1_ax2_0_1_fused * 128 + ax2_0_2_ax1_0_2_fused // 4 * 32 + (ax0_ax1_fused_0 * 128 + ax0_ax1_fused_1 * 4 + ax0_ax1_fused_2) % 32)
+                                        T.where(ax1_0_0_ax2_0_0_fused * 128 + ax2_0_2_ax1_0_2_fused % 4 * 32 + ((ax0_ax1_fused_0 * 32 + ax0_ax1_fused_1) * 4 + ax0_ax1_fused_2) // 32 < n)
                                         T.reads(lv3[0, v1, v2], var_NT_matmul_intermediate_reindex_pad_shared_dyn[v0, v1, v2])
                                         T.writes(p_output0_intermediate[0, v1, v2])
                                         T.block_attr({"buffer_dim_align": [[0, 1, 16, 4]]})
-                                        if v1 < n:
-                                            p_output0_intermediate[0, v1, v2] = lv3[0, v1, v2] * T.float16(0.5) + var_NT_matmul_intermediate_reindex_pad_shared_dyn[v0, v1, v2]
+                                        p_output0_intermediate[0, v1, v2] = lv3[0, v1, v2] * T.float16(0.5) + var_NT_matmul_intermediate_reindex_pad_shared_dyn[v0, v1, v2]
     # fmt: on
 
 
@@ -690,11 +690,11 @@ class TestMatmulInt8Tensorize3d2dDyn(BaseBeforeAfter):
                                         v0 = T.axis.spatial(1, 0)
                                         v1 = T.axis.spatial((m + 127) // 128 * 128, ax1_0_0_ax2_0_0_fused * 128 + ax2_0_2_ax1_0_2_fused % 4 * 32 + (ax0_ax1_fused_0 * 128 + ax0_ax1_fused_1 * 4 + ax0_ax1_fused_2) // 32)
                                         v2 = T.axis.spatial(4096, ax1_0_1_ax2_0_1_fused * 128 + ax2_0_2_ax1_0_2_fused // 4 * 32 + (ax0_ax1_fused_0 * 128 + ax0_ax1_fused_1 * 4 + ax0_ax1_fused_2) % 32)
+                                        T.where(ax1_0_0_ax2_0_0_fused * 128 + ax2_0_2_ax1_0_2_fused % 4 * 32 + ((ax0_ax1_fused_0 * 32 + ax0_ax1_fused_1) * 4 + ax0_ax1_fused_2) // 32 < m)
                                         T.reads(matmul_1_reindex_pad_shared_dyn[v0, v1, v2])
                                         T.writes(matmul_1[0, v1, v2])
                                         T.block_attr({"buffer_dim_align": [[0, 1, 16, 4]]})
-                                        if v1 < m:
-                                            matmul_1[0, v1, v2] = matmul_1_reindex_pad_shared_dyn[v0, v1, v2]
+                                        matmul_1[0, v1, v2] = matmul_1_reindex_pad_shared_dyn[v0, v1, v2]
     # fmt: on
 
 
@@ -831,10 +831,10 @@ class TestMatmulMetal(MetalBeforeAfter):
                                             v0 = T.axis.spatial(1, ax0_1)
                                             v1 = T.axis.spatial((batch_size + 15) // 16 * 16, ax1_0 * 16 + (ax1_ax2_fused_0 * 512 + ax1_ax2_fused_1 * 128 + ax1_ax2_fused_2 * 128 + ax1_ax2_fused_3 * 4 + ax1_ax2_fused_4) // 64)
                                             v2 = T.axis.spatial(28672, ax2_0 * 64 + (ax1_ax2_fused_0 * 512 + ax1_ax2_fused_1 * 128 + ax1_ax2_fused_2 * 128 + ax1_ax2_fused_3 * 4 + ax1_ax2_fused_4) % 64)
+                                            T.where(ax1_0 * 16 + (((ax1_ax2_fused_0 * 4 + ax1_ax2_fused_1 + ax1_ax2_fused_2) * 32 + ax1_ax2_fused_3) * 4 + ax1_ax2_fused_4) // 64 < batch_size)
                                             T.reads(C_reindex_pad_shared[v0, v1, v2])
                                             T.writes(C[v1, 0, v2])
-                                            if v1 < batch_size:
-                                                C[v1, 0, v2] = C_reindex_pad_shared[v0, v1, v2]
+                                            C[v1, 0, v2] = C_reindex_pad_shared[v0, v1, v2]
     # fmt: on
 
 
@@ -971,10 +971,10 @@ class TestMatmulMetalInt4Quant(MetalBeforeAfter):
                                             v0 = T.axis.spatial(1, ax0_1)
                                             v1 = T.axis.spatial((batch_size + 15) // 16 * 16, ax1_0 * 16 + (ax1_ax2_fused_0 * 512 + ax1_ax2_fused_1 * 128 + ax1_ax2_fused_2 * 128 + ax1_ax2_fused_3 * 4 + ax1_ax2_fused_4) // 64)
                                             v2 = T.axis.spatial(28672, ax2_0 * 64 + (ax1_ax2_fused_0 * 512 + ax1_ax2_fused_1 * 128 + ax1_ax2_fused_2 * 128 + ax1_ax2_fused_3 * 4 + ax1_ax2_fused_4) % 64)
+                                            T.where(ax1_0 * 16 + (((ax1_ax2_fused_0 * 4 + ax1_ax2_fused_1 + ax1_ax2_fused_2) * 32 + ax1_ax2_fused_3) * 4 + ax1_ax2_fused_4) // 64 < batch_size)
                                             T.reads(C_reindex_pad_shared[v0, v1, v2])
                                             T.writes(C[v1, 0, v2])
-                                            if v1 < batch_size:
-                                                C[v1, 0, v2] = C_reindex_pad_shared[v0, v1, v2]
+                                            C[v1, 0, v2] = C_reindex_pad_shared[v0, v1, v2]
 
 
 if __name__ == "__main__":

--- a/tests/python/meta_schedule/test_meta_schedule_schedule_rule_mlt_tc.py
+++ b/tests/python/meta_schedule/test_meta_schedule_schedule_rule_mlt_tc.py
@@ -856,11 +856,11 @@ def test_padded_matmul_relu():
                             v3 = T.axis.spatial(1, 0)
                             v4 = T.axis.spatial(16, ax0_ax1_ax3_ax4_ax5_fused % 256 // 16)
                             v5 = T.axis.spatial(16, ax0_ax1_ax3_ax4_ax5_fused % 16)
+                            T.where(ax0_0_0_ax1_0_0_fused // 2 * 32 + ax2 * 16 + ax0_ax1_ax3_ax4_ax5_fused % 256 // 16 < 127 and ax0_0_0_ax1_0_0_fused % 2 * 64 + ax0_0_1_ax1_0_1_fused * 32 + ax0_ax1_ax3_ax4_ax5_fused // 256 * 16 + ax0_ax1_ax3_ax4_ax5_fused % 16 < 127)
                             T.reads(C_reindex_shared[v0, v1, v2, v3, v4, v5])
                             T.writes(compute[v4 + v2 * 16 + v0 * 32, v5 + v1 * 16])
                             T.block_attr({"meta_schedule.cooperative_fetch": 4})
-                            if v0 * 32 + v2 * 16 + v4 < 127 and v1 * 16 + v5 < 127:
-                                compute[v4 + v2 * 16 + v0 * 32, v5 + v1 * 16] = T.max(C_reindex_shared[v0, v1, v2, v3, v4, v5], T.float32(0))
+                            compute[v4 + v2 * 16 + v0 * 32, v5 + v1 * 16] = T.max(C_reindex_shared[v0, v1, v2, v3, v4, v5], T.float32(0))
     # fmt: on
 
     decision_0 = [


### PR DESCRIPTION
Hi, we found a kind of corner bad cases for reverse inline primitive. Currently we encode predicate produced by inlining as block compute body, like
```python
with T.block():
    if pred:
        body()
```

While other primitives (typically `cache_write`) currently may only respect the predicate of `T.where` for region estimation. The newly created blocks take the risk of region out-of-bound write accesses, lead to segfaults even in cpu target computations.

The change proposes to use equavalent `T.where` when possible to make it more consistent with s-tir system, like
```python
with T.block():
    T.where(pred_on_loop_vars)
    body()
```

