### PR TITLE
GraphExecutor: Fix wild pointer assign when input and output are reshape

### DIFF
--- a/src/runtime/graph_executor/graph_executor.h
+++ b/src/runtime/graph_executor/graph_executor.h
@@ -464,6 +464,8 @@ class TVM_DLL GraphExecutor : public ModuleNode {
   std::vector<std::vector<DLTensor*>> output_dltensors_;
   /*! \brief Used for quick node(both model output and op input) DLTensor* lookup given an eid. */
   std::vector<std::vector<DLTensor*>> both_output_opinput_dltensors_;
+  /*! \brief Used for quick node output DLTensor* lookup given a nop's input eid. */
+  std::unordered_map<int, std::vector<DLTensor*>> node_output_dltensors_;
   /*! \brief Used for quick entry_id lookup given an storage_id. */
   std::vector<std::vector<uint32_t>> sid_to_eid_;
   /*! \brief Used for quick entry indexing. */

--- a/tests/python/runtime/test_runtime_module_based_interface.py
+++ b/tests/python/runtime/test_runtime_module_based_interface.py
@@ -769,6 +769,7 @@ def test_reshape_zero_copy():
 
     def zero_copy():
         from tvm.relay.frontend.common import infer_shape
+
         outshape = infer_shape(_y)
         output_view = tvm.nd.empty(outshape, device=tvm.device("llvm", 0))
         m.set_input_zero_copy(in_name0, data_ndarray0)
@@ -779,7 +780,7 @@ def test_reshape_zero_copy():
 
     golden_out = expected()
     out = zero_copy()
-    np.testing.assert_equal(golden_out, out)
+    tvm.testing.assert_allclose(golden_out, out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is an updated version of #15121 