### PR TITLE
[TVMScript] Print small constant arrays as in-line R.const

### DIFF
--- a/python/tvm/relax/expr.py
+++ b/python/tvm/relax/expr.py
@@ -1152,6 +1152,12 @@ def const(
     - bool maps to "bool"
     - other using the same default rule as numpy.
     """
+    if isinstance(dtype, StructInfo):
+        sinfo = dtype
+        dtype = sinfo.dtype
+    else:
+        sinfo = None
+
     if isinstance(value, (_base.numeric_types, (bool, list))):
         value = _np.array(value, dtype=dtype)
 
@@ -1172,7 +1178,7 @@ def const(
     if not isinstance(value, _nd.NDArray):
         raise ValueError("value has to be scalar or NDArray")
 
-    return Constant(value)
+    return Constant(value, sinfo)
 
 
 def te_tensor(


### PR DESCRIPTION
Prior to this commit, scalar arrays (e.g. `R.const(1, 'int64)`) would be printed inline.  However, small non-scalar
arrays (e.g. `R.const([1], 'int64')`) would be stored in the TVMScript metadata.

This commit updates the TVMScript printer, to show small constants in-line.  Any constant with at most 16 elements and at most 2 dimensions will be printed in-line.  Larger constants will still be stored in the TVMScript metadata.