### PR TITLE
[MetaSchedule] Replace `xgboost.rabit` with `xgboost.collective` because it's deprecated

### DIFF
--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -755,7 +755,7 @@ def _get_custom_call_back(
                     raise ValueError("wrong metric value", value)
 
             import xgboost as xgb
-            from xgboost import rabit  # type: ignore
+            from xgboost import collective  # type: ignore
 
             try:
                 from xgboost.training import aggcv  # type: ignore
@@ -841,7 +841,7 @@ def _get_custom_call_back(
             elif epoch - best_iteration >= self.early_stopping_rounds:
                 best_msg = self.state["best_msg"]
 
-                if self.verbose_eval and rabit.get_rank() == 0:
+                if self.verbose_eval and collective.get_rank() == 0:
                     logger.debug("XGB stopped. Best iteration: %s ", best_msg)
                 # instead of raising EarlyStopException, returning True to end the training
                 return True

--- a/python/tvm/meta_schedule/cost_model/xgb_model.py
+++ b/python/tvm/meta_schedule/cost_model/xgb_model.py
@@ -755,7 +755,12 @@ def _get_custom_call_back(
                     raise ValueError("wrong metric value", value)
 
             import xgboost as xgb
-            from xgboost import collective  # type: ignore
+
+            # make it compatible with xgboost<1.7
+            try:
+                from xgboost import rabit as collective  # type: ignore
+            except ImportError:
+                from xgboost import collective  # type: ignore
 
             try:
                 from xgboost.training import aggcv  # type: ignore


### PR DESCRIPTION
rabit is marked as deprecated since XGBoost v1.7 and removed in v2.0.
https://github.com/dmlc/xgboost/blob/release_1.7.0/python-package/xgboost/rabit.py#L16

cc @tqchen @Hzfengsy @MasterJH5574