### PR TITLE
[Hexagon] [CMake] Fix v66 build issue

### DIFF
--- a/apps/hexagon_api/CMakeLists.txt
+++ b/apps/hexagon_api/CMakeLists.txt
@@ -114,6 +114,11 @@ if(DEFINED USE_HEXAGON_GTEST)
   set(GTEST_FLAG "-DUSE_HEXAGON_GTEST=${USE_HEXAGON_GTEST}")
 endif()
 
+if(NOT DEFINED USE_HEXAGON_QHL)
+  # USE_HEXAGON_QHL defaults to ON for rpc runtime if not explicitly set to OFF
+  set(USE_HEXAGON_QHL ON)
+endif()
+
 ExternalProject_Add(hexagon_tvm_runtime_rpc
   SOURCE_DIR "${TVM_SOURCE_DIR}"
   BUILD_COMMAND $(MAKE) runtime hexagon_rpc_sim
@@ -135,7 +140,7 @@ ExternalProject_Add(hexagon_tvm_runtime_rpc
     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
     "-DUSE_ALTERNATIVE_LINKER=OFF"
     "-DUSE_CUSTOM_LOGGING=ON"
-    "-DUSE_HEXAGON_QHL=ON"
+    "-DUSE_HEXAGON_QHL=${USE_HEXAGON_QHL}"
     "-DUSE_RANDOM=ON"
     "${GTEST_FLAG}"
   INSTALL_COMMAND ""

--- a/cmake/modules/Hexagon.cmake
+++ b/cmake/modules/Hexagon.cmake
@@ -134,11 +134,22 @@ else()
   )
 endif()
 
+set(htp_supported_archs "v68" "v69" "v73" "v75")
+list(FIND htp_supported_archs "${USE_HEXAGON_ARCH}" supported_arch_index)
+if(${supported_arch_index} EQUAL -1)
+  # Exclude User DMA files when building for archs below v68
+  list(REMOVE_ITEM RUNTIME_HEXAGON_SRCS "${TVMRT_SOURCE_DIR}/hexagon/hexagon_user_dma.cc")
+endif()
+
 if(BUILD_FOR_HEXAGON)
   if(DEFINED USE_HEXAGON_GTEST AND EXISTS ${USE_HEXAGON_GTEST})
     file_glob_append(RUNTIME_HEXAGON_SRCS
       "${CMAKE_SOURCE_DIR}/tests/cpp-runtime/hexagon/*.cc"
     )
+    if(${supported_arch_index} EQUAL -1)
+      # Exclude User DMA files when building for archs below v68
+      list(REMOVE_ITEM RUNTIME_HEXAGON_SRCS "${TVMRT_SOURCE_DIR}/hexagon/hexagon_user_dma_tests.cc")
+    endif()
   endif()
   get_hexagon_sdk_property("${USE_HEXAGON_SDK}" "${USE_HEXAGON_ARCH}"
     SDK_INCLUDE   SDK_INCLUDE_DIRS
@@ -176,24 +187,27 @@ if(BUILD_FOR_HEXAGON)
 
   endif()
 
-  # Hand-written ops
-  file_glob_append(RUNTIME_HEXAGON_SRCS
-    "${TVMRT_SOURCE_DIR}/hexagon/ops/*.cc"
-  )
+  # Exclude HVX implementation files when building for archs below v68
+  if(${supported_arch_index} GREATER -1)
+    # Hand-written ops
+    file_glob_append(RUNTIME_HEXAGON_SRCS
+      "${TVMRT_SOURCE_DIR}/hexagon/ops/*.cc"
+    )
 
-  include_directories(
-    "${TVMRT_SOURCE_DIR}/hexagon/ops"
-  )
+    include_directories(
+      "${TVMRT_SOURCE_DIR}/hexagon/ops"
+    )
 
-  set_source_files_properties(
-    "${TVMRT_SOURCE_DIR}/hexagon/ops/conv2d_quant_hvx.cc"
-    PROPERTIES COMPILE_FLAGS "-mhvx"
-  )
+    set_source_files_properties(
+      "${TVMRT_SOURCE_DIR}/hexagon/ops/conv2d_quant_hvx.cc"
+      PROPERTIES COMPILE_FLAGS "-mhvx"
+    )
 
-  set_source_files_properties(
-    "${TVMRT_SOURCE_DIR}/hexagon/ops/conv2d_fp16_hvx.cc"
-    PROPERTIES COMPILE_FLAGS "-mhvx"
-  )
+    set_source_files_properties(
+      "${TVMRT_SOURCE_DIR}/hexagon/ops/conv2d_fp16_hvx.cc"
+      PROPERTIES COMPILE_FLAGS "-mhvx"
+    )
+  endif()
 
   # Include hexagon external library runtime sources
   if(USE_HEXAGON_EXTERNAL_LIBS)


### PR DESCRIPTION
This patch fixes the issue mentioned in #17163.

The issue was because some files that are built into the runtime depend on architecture features that are only available starting from v68. Hence, we should not link them into the runtime if the architecture mentioned is v66 or v65.