### PR TITLE
[Relay][FQ2I]: Use appropriate dtype while quantizing relay.op.nn.pad…

### DIFF
--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -466,7 +466,7 @@ def pad(expr, type_map):
         # If the pad-value is a constant, we need to quantize it
         assert isinstance(pad_value, relay.expr.Constant)
         assert pad_value.checked_type.dtype in ["float32", "float64", "float16", "bfloat16"]
-        pad_value = relay.qnn.op.quantize(pad_value, t.scale, t.zero_point)
+        pad_value = relay.qnn.op.quantize(pad_value, t.scale, t.zero_point, t.axis, t.dtype)
 
     out = relay.op.nn.pad(arg, pad_value=pad_value, **expr.attrs)
     return [out, t]

--- a/python/tvm/relay/transform/fake_quantization_to_integer.py
+++ b/python/tvm/relay/transform/fake_quantization_to_integer.py
@@ -466,7 +466,7 @@ def pad(expr, type_map):
         # If the pad-value is a constant, we need to quantize it
         assert isinstance(pad_value, relay.expr.Constant)
         assert pad_value.checked_type.dtype in ["float32", "float64", "float16", "bfloat16"]
-        pad_value = relay.qnn.op.quantize(pad_value, t.scale, t.zero_point, t.axis, t.dtype)
+        pad_value = relay.qnn.op.quantize(pad_value, t.scale, t.zero_point, out_dtype=t.dtype)
 
     out = relay.op.nn.pad(arg, pad_value=pad_value, **expr.attrs)
     return [out, t]

--- a/tests/python/relay/test_pass_fake_quantization_to_integer.py
+++ b/tests/python/relay/test_pass_fake_quantization_to_integer.py
@@ -814,6 +814,20 @@ def test_fake_quantize_pad():
     compare_fq_to_int(op, [x_np])
 
 
+def test_fake_quantize_pad_with_float_min():
+    in_shape = [1, 383, 128]
+    x = relay.var("x", shape=in_shape, dtype="float32")
+    op = relay.qnn.quantize(x, relay.const(1.0), relay.const(0), out_dtype="uint8")
+    op = relay.qnn.dequantize(op, relay.const(1.0), relay.const(0), out_dtype="float32")
+    op = relay.op.nn.pad(
+        op, pad_width=[[0, 0], [0, 1], [0, 0]], pad_value=relay.const(-3.40282e38, dtype="float32")
+    )
+    op = relay.qnn.op.quantize(op, relay.const(1.0), relay.const(0), out_dtype="uint8")
+    x_np = np.random.randint(0, 256, size=in_shape)
+    x_as_float = x_np.astype("float32")
+    compare_fq_to_int(op, [x_as_float], True)
+
+
 def test_fake_quantize_depth_to_space():
     x = relay.var("x", shape=[1, 3, 224, 224], dtype="int8")
 


### PR DESCRIPTION
…'s constant pad value

The test case fails without this change.

@mbrookhart @tqchen 