### PR TITLE
Remove and replace deprecated `distutils.util.strtobool()`

### DIFF
--- a/python/tvm/auto_scheduler/testing/tune_onnx.py
+++ b/python/tvm/auto_scheduler/testing/tune_onnx.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-docstring
-from distutils.util import strtobool
 import argparse
 import json
 import os
@@ -30,6 +29,7 @@ from tvm.meta_schedule.testing.tune_utils import generate_input_data, create_tim
 from tvm.meta_schedule.utils import cpu_count
 from tvm.relay.frontend import from_onnx
 from tvm.support import describe
+from tvm.testing.utils import strtobool
 
 
 def _parse_args():

--- a/python/tvm/auto_scheduler/testing/tune_relay.py
+++ b/python/tvm/auto_scheduler/testing/tune_relay.py
@@ -18,7 +18,6 @@
 import argparse
 import json
 import os
-from distutils.util import strtobool
 
 import tvm
 from tvm import auto_scheduler
@@ -29,6 +28,7 @@ from tvm.meta_schedule.testing.relay_workload import get_network
 from tvm.meta_schedule.testing.tune_utils import create_timer, generate_input_data
 from tvm.meta_schedule.utils import cpu_count
 from tvm.support import describe
+from tvm.testing.utils import strtobool
 
 
 def _parse_args():

--- a/python/tvm/auto_scheduler/testing/tune_te.py
+++ b/python/tvm/auto_scheduler/testing/tune_te.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-docstring
-from distutils.util import strtobool
 import argparse
 import os
 
@@ -25,6 +24,7 @@ from tvm import meta_schedule as ms
 from tvm.meta_schedule.testing.te_workload import CONFIGS
 from tvm.meta_schedule.utils import cpu_count
 from tvm.support import describe
+from tvm.testing.utils import strtobool
 
 
 def _parse_args():

--- a/python/tvm/autotvm/testing/tune_relay.py
+++ b/python/tvm/autotvm/testing/tune_relay.py
@@ -19,7 +19,6 @@ import argparse
 import json
 import os
 import warnings
-from distutils.util import strtobool
 
 import tvm
 from tvm import autotvm
@@ -31,6 +30,7 @@ from tvm.meta_schedule.testing.custom_builder_runner import run_module_via_rpc
 from tvm.meta_schedule.testing.relay_workload import get_network
 from tvm.meta_schedule.testing.tune_utils import create_timer, generate_input_data
 from tvm.support import describe
+from tvm.testing.utils import strtobool
 
 
 def _parse_args():

--- a/python/tvm/meta_schedule/testing/tune_onnx.py
+++ b/python/tvm/meta_schedule/testing/tune_onnx.py
@@ -18,7 +18,6 @@
 import argparse
 import json
 import logging
-from distutils.util import strtobool
 
 import onnx  # type: ignore
 import tvm
@@ -26,6 +25,7 @@ from tvm import meta_schedule as ms
 from tvm.meta_schedule.testing.custom_builder_runner import run_module_via_rpc
 from tvm.relay.frontend import from_onnx
 from tvm.support import describe
+from tvm.testing.utils import strtobool
 
 from .tune_utils import create_timer, generate_input_data
 

--- a/python/tvm/meta_schedule/testing/tune_relay.py
+++ b/python/tvm/meta_schedule/testing/tune_relay.py
@@ -18,7 +18,6 @@
 import argparse
 import json
 import logging
-from distutils.util import strtobool
 from typing import Dict
 
 import numpy as np  # type: ignore
@@ -28,6 +27,7 @@ from tvm.meta_schedule.testing.custom_builder_runner import run_module_via_rpc
 from tvm.meta_schedule.testing.relay_workload import get_network
 from tvm.meta_schedule.testing.tune_utils import create_timer, generate_input_data
 from tvm.support import describe
+from tvm.testing.utils import strtobool
 
 
 def _parse_args():

--- a/python/tvm/meta_schedule/testing/tune_te.py
+++ b/python/tvm/meta_schedule/testing/tune_te.py
@@ -17,7 +17,6 @@
 # pylint: disable=missing-docstring
 import argparse
 import logging
-from distutils.util import strtobool
 from typing import Optional
 
 import tvm
@@ -25,6 +24,7 @@ from tvm import meta_schedule as ms
 from tvm import tir
 from tvm.meta_schedule.testing.te_workload import create_te_workload
 from tvm.support import describe
+from tvm.testing.utils import strtobool
 
 
 def _parse_args():

--- a/python/tvm/meta_schedule/testing/validate_database.py
+++ b/python/tvm/meta_schedule/testing/validate_database.py
@@ -20,7 +20,6 @@ import logging
 import warnings
 import itertools
 from statistics import mean
-from distutils.util import strtobool
 from typing import Callable, Tuple, Union, List, Any
 import numpy as np  # type: ignore
 
@@ -35,6 +34,7 @@ from tvm.tir.schedule import Trace
 from tvm.meta_schedule.utils import remove_build_dir
 from tvm.meta_schedule.testing.tune_utils import generate_input_data
 from tvm.tir.tensor_intrin import *  # type: ignore # pylint: disable=wildcard-import,unused-wildcard-import
+from tvm.testing.utils import strtobool
 
 DELIMITOR = "\n" + "-" * 30 + "\n"
 

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -1913,6 +1913,21 @@ def skip_parameterizations(*skip_params, reason):
     return _mark_parameterizations(*skip_params, marker_fn=pytest.skip, reason=reason)
 
 
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError(f"invalid truth value {val!r}")
+
+
 def main():
     test_file = inspect.getsourcefile(sys._getframe(1))
     sys.exit(pytest.main([test_file] + sys.argv[1:]))


### PR DESCRIPTION
#17172 

Just copied `strtobool()` into tvm.testing.util. Alternative option is to use `setuptools/_distutils/util.strtobool` as setuptools is already in our dependency.
https://github.com/pypa/setuptools/blob/08bd31115732ece3cca50bd93f338e1b90dead34/setuptools/_distutils/util.py#L334

cc @tqchen @Hzfengsy @MasterJH5574