### PR TITLE
Add `packaging` to `python/gen_requirements.py`

### DIFF
--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -68,6 +68,7 @@ REQUIREMENTS_BY_PIECE: RequirementsByPieceType = [
                 "decorator",
                 "ml_dtypes",
                 "numpy",
+                "packaging",
                 "psutil",
                 "scipy",
                 "tornado",


### PR DESCRIPTION
since our codebase depend on it.
https://github.com/search?q=repo%3Aapache%2Ftvm+packaging&type=code

cc @tqchen @Hzfengsy @MasterJH5574 