### PR TITLE
[Relax][Analysis] Validate global_symbol on non-Relax functions

### DIFF
--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -90,11 +90,11 @@ class WellFormedChecker : public relax::ExprVisitor,
         WellFormedChecker(obj.as<IRModule>(), check_struct_info);
 
     if (const auto* mod = obj.as<IRModuleNode>()) {
-      for (const auto& it : mod->functions) {
+      for (const auto& [gvar, base_func] : mod->functions) {
+        well_formed_checker.CheckGlobalVarAndGsymbolConsistency(gvar, base_func);
         // visit relax.Function
-        if (auto* n = it.second.as<FunctionNode>()) {
-          Function func = GetRef<Function>(n);
-          well_formed_checker.CheckGlobalVarAndGsymbolConsistency(it.first, func);
+        if (auto opt = base_func.as<Function>()) {
+          Function func = opt.value();
           well_formed_checker.VisitExpr(func);
         }
       }
@@ -133,7 +133,7 @@ class WellFormedChecker : public relax::ExprVisitor,
     LOG(WARNING) << "This IR is not well formed: " << diag->message;
   }
 
-  void CheckGlobalVarAndGsymbolConsistency(GlobalVar var, Function func) {
+  void CheckGlobalVarAndGsymbolConsistency(GlobalVar var, BaseFunc func) {
     // the uniqueness of all global vars are ensured by IRModule->global_var_map_, so do not need
     // to check again
 


### PR DESCRIPTION
Prior to this commit, the well-formed checker verified that the `"global_symbol"` attribute, if present, matches the name of the `GlobalVar`.  However, this check was only applied for Relax functions.  As a result, discrepencies between the `"global_symbol"` and the `gvar->name_hint` could result in unexpected bugs.  (For example, https://github.com/apache/tvm/issues/17176.)

This commit updates the well-formed checker to verify `"global_symbol"` on all functions in an `IRModule`.