### PR TITLE
[CI] Update dummy-variable regex for pylint

### DIFF
--- a/tests/lint/pylintrc
+++ b/tests/lint/pylintrc
@@ -252,7 +252,7 @@ init-import=no
 
 # A regular expression matching the name of dummy variables (i.e. expectedly
 # not used).
-dummy-variables-rgx=(_+[a-zA-Z0-9]*?$)|dummy
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.


### PR DESCRIPTION
Prior to this commit, the regex used for pylint to identify dummy variables would correctly identify variables that start with an underscore (e.g. `_scale`), unless they have an underscore elsewhere in the name (e.g. `_scale_factor`).  This leads to false positives from pylint for unused variables, as prefixing a variable with an underscore should mark a variable as intentionally unused.

This commit updates the regex in TVM's `pylintrc` to match the current default value for `dummy-variables-rgx`, to allow unused variables to be named with a leading underscore, even if they also contain another underscore.