### PR TITLE
[Relax] Refactor RealizeVDevice to remove in-place mutation

### DIFF
--- a/tests/python/relax/test_transform_realize_vdevice.py
+++ b/tests/python/relax/test_transform_realize_vdevice.py
@@ -220,12 +220,7 @@ def test_tuple_func_ret():
             x: R.Tensor((2, 3), "float32"),
             y: R.Tensor((2, 3), "float32"),
             z: R.Tensor((2, 3), "float32"),
-        ) -> R.Tuple(
-            [
-                R.Tensor((2, 3), "float32", "cuda"),
-                R.Tensor((2, 3), "float32", "cuda"),
-            ]
-        ):
+        ) -> R.Tuple([R.Tensor((2, 3), "float32", "cuda"), R.Tensor((2, 3), "float32", "cuda")]):
             with R.dataflow():
                 lv0 = R.add(x, y)
                 gv = R.multiply(lv0, z)
@@ -248,12 +243,7 @@ def test_tuple_func_ret():
             x: R.Tensor((2, 3), "float32", "cuda"),
             y: R.Tensor((2, 3), "float32", "cuda"),
             z: R.Tensor((2, 3), "float32", "cuda"),
-        ) -> R.Tuple(
-            [
-                R.Tensor((2, 3), "float32", "cuda"),
-                R.Tensor((2, 3), "float32", "cuda"),
-            ]
-        ):
+        ) -> R.Tuple([R.Tensor((2, 3), "float32", "cuda"), R.Tensor((2, 3), "float32", "cuda")]):
             with R.dataflow():
                 lv0: R.Tensor((2, 3), "float32", "cuda") = R.add(x, y)
                 gv: R.Tensor((2, 3), "float32", "cuda") = R.multiply(lv0, z)

--- a/tests/python/relax/test_transform_realize_vdevice.py
+++ b/tests/python/relax/test_transform_realize_vdevice.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Test eliminate common subexpr pass"""
+
 import tvm
 import tvm.testing
 from tvm.ir import VDevice
@@ -202,6 +203,66 @@ def test_func_ret():
     verify(Input, Expect)
 
 
+def test_tuple_func_ret():
+    @I.ir_module
+    class Input:
+        I.module_attrs({"attr": 10})
+        I.module_global_infos(
+            {
+                "vdevice": [
+                    I.vdevice("cuda"),
+                ]
+            }
+        )
+
+        @R.function
+        def foo(
+            x: R.Tensor((2, 3), "float32"),
+            y: R.Tensor((2, 3), "float32"),
+            z: R.Tensor((2, 3), "float32"),
+        ) -> R.Tuple(
+            [
+                R.Tensor((2, 3), "float32", "cuda"),
+                R.Tensor((2, 3), "float32", "cuda"),
+            ]
+        ):
+            with R.dataflow():
+                lv0 = R.add(x, y)
+                gv = R.multiply(lv0, z)
+                R.output(gv)
+            return (gv, gv)
+
+    @I.ir_module
+    class Expect:
+        I.module_attrs({"attr": 10})
+        I.module_global_infos(
+            {
+                "vdevice": [
+                    I.vdevice("cuda"),
+                ]
+            }
+        )
+
+        @R.function
+        def foo(
+            x: R.Tensor((2, 3), "float32", "cuda"),
+            y: R.Tensor((2, 3), "float32", "cuda"),
+            z: R.Tensor((2, 3), "float32", "cuda"),
+        ) -> R.Tuple(
+            [
+                R.Tensor((2, 3), "float32", "cuda"),
+                R.Tensor((2, 3), "float32", "cuda"),
+            ]
+        ):
+            with R.dataflow():
+                lv0: R.Tensor((2, 3), "float32", "cuda") = R.add(x, y)
+                gv: R.Tensor((2, 3), "float32", "cuda") = R.multiply(lv0, z)
+                R.output(gv)
+            return (gv, gv)
+
+    verify(Input, Expect)
+
+
 def test_multi_device():
     @I.ir_module
     class Input:
@@ -324,6 +385,35 @@ def test_insert_to_vdevice():
             return gv
 
     verify(Input, Expect)
+
+
+def test_input_module_is_unmodified():
+    def make_module():
+        @I.ir_module
+        class Module:
+            I.module_global_infos({"vdevice": [I.vdevice("llvm")]})
+
+            @R.function
+            def foo(
+                x: R.Tensor((2, 3), "float32"),
+                y: R.Tensor((2, 3), "float32"),
+                z: R.Tensor((2, 3), "float32"),
+            ) -> R.Tensor((2, 3), "float32"):
+                x1 = x
+                y1 = y
+                x2 = x1
+                y2 = y1
+                s: R.Tensor((2, 3), "float32", "llvm") = R.add(x2, y2)
+                m = R.multiply(s, z)
+                return m
+
+        return Module
+
+    original = make_module()
+    expected = make_module()
+
+    RealizeVDevice()(original)
+    tvm.ir.assert_structural_equal(original, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prior to this commit, the `relax.transform.RealizeVDevice` pass performed in-place update on expressions appearing in its input `IRModule`, overwriting their struct info.  In-place mutation of TVM's IR types is only legal when the scope has sole ownership of the IR object, such as through the `CopyOnWrite` functionality, and is not allowed when the object is shared.  As a result, applying `RealizeVDevice` would cause unexpected updates in unrelated expressions.  Most noticeably, the `IRModule` used as input to `RealizeVDevice` would have its variable erroneously updated.

This commit refactors the `RealizeVDevice` transform to remove all in-place mutation.  The same propagation rules are followed, with known `VDevice` annotations propagated forward from the output of `R.hint_on_device`, and propagated backwards from the input of `R.hint_on_device` if no such annotation already exists.

Closes https://github.com/apache/tvm/issues/17205.