### PR TITLE
 [Relax] Allow `out_sinfo` to be omitted from `R.call_tir`

### DIFF
--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # pylint: disable=redefined-builtin
 """The base Relax operators."""
+
 from typing import Dict, Union, List, Tuple, Optional, Callable
 
 
@@ -71,11 +72,10 @@ def null_value() -> Call:
 def call_tir(
     gvar: GlobalVar,
     args: Expr,
-    out_sinfo: Union[TensorStructInfo, List[TensorStructInfo]],
+    out_sinfo: Optional[Union[TensorStructInfo, List[TensorStructInfo]]] = None,
     tir_vars: Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]] = None,
 ) -> Call:
-    """
-    Call a tir.prim_func and return the output.
+    """Call a tir.PrimFunc and return the output.
 
     Parameters
     ----------
@@ -85,10 +85,15 @@ def call_tir(
     args : Expr
         The input arguments.
 
-    out_sinfo : Union[TensorStructInfo, List[TensorStructInfo]]
-        The structure info of the call_tir output.
-        It should be a single or a list of TensorStructInfo. Each one denotes the
+    out_sinfo : Optional[Union[TensorStructInfo, List[TensorStructInfo]]]
+        The structure info of the call_tir output.  It should be a
+        single or a list of TensorStructInfo. Each one denotes the
         structure info of a returned tensor.
+
+        If `None`, the `out_sinfo` will be inferred from the signature
+        of `gvar`.  Arguments that are accepted by `gvar`, after
+        `args` and before `tir_vars`, are inferred to be output tensor
+        arguments.
 
     tir_vars : Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]]
         ShapeExpr representing a tuple of integers to unpack when calling func. Is null if not used
@@ -97,11 +102,12 @@ def call_tir(
     -------
     ret: Call
         A call node for the call_tir operator.
+
     """
     if isinstance(args, Expr) and not isinstance(args, RxTuple):  # type: ignore
         args = RxTuple((args,))
 
-    if not isinstance(out_sinfo, list):
+    if out_sinfo is not None and not isinstance(out_sinfo, list):
         out_sinfo = [out_sinfo]
 
     if isinstance(tir_vars, (list, tuple)):

--- a/tests/python/relax/test_op_call_tir.py
+++ b/tests/python/relax/test_op_call_tir.py
@@ -1,0 +1,269 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+import numpy as np
+
+import tvm
+import tvm.testing
+from tvm import relax, tir
+from tvm import TVMError
+from tvm.ir import Op, VDevice
+from tvm.script import ir as I, relax as R, tir as T
+
+exec_mode = tvm.testing.parameter("bytecode", "compiled")
+
+
+def test_basic(exec_mode):
+    """Relax may call into TIR functions with R.call_tir"""
+
+    target = "llvm"
+    dev = tvm.cpu()
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16], "int32")):
+            B = R.call_tir(Module.tir_func, [A], out_sinfo=R.Tensor([16], "int32"))
+            return B
+
+        @T.prim_func
+        def tir_func(A: T.Buffer(16, "int32"), B: T.Buffer(16, "int32")):
+            for i in range(16):
+                B[i] = A[i] * 2
+
+    built = tvm.relax.build(Module, target=target, exec_mode=exec_mode)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    arg = np.arange(16, dtype="int32")
+    expected = 2 * arg
+
+    output = vm["main"](tvm.nd.array(arg)).numpy()
+
+    np.testing.assert_equal(expected, output)
+
+
+def test_tir_var_scalar(exec_mode):
+    """R.call_tir may accept dynamic shape arguments
+
+    R.call_tir may provide TIR variables with the `tir_vars` argument.
+    These appear after the output tensor arguments.
+
+    Because `tir_vars` are stored internally as a `R.Shape`, they only
+    may only define int64 values.
+
+    """
+
+    target = "llvm"
+    dev = tvm.cpu()
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16], "int64"), _: R.Prim(value="scale")):
+            scale = T.int64()
+            B = R.call_tir(
+                Module.tir_func, [A], out_sinfo=R.Tensor([16], "int64"), tir_vars=[scale]
+            )
+            return B
+
+        @T.prim_func
+        def tir_func(
+            A: T.Buffer(16, "int64"),
+            B: T.Buffer(16, "int64"),
+            scale: T.int64,
+        ):
+            for i in range(16):
+                B[i] = A[i] * scale
+
+    built = tvm.relax.build(Module, target=target, exec_mode=exec_mode)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    arg = np.arange(16, dtype="int64")
+    expected = 4 * arg
+
+    output = vm["main"](tvm.nd.array(arg), 4).numpy()
+
+    np.testing.assert_equal(expected, output)
+
+
+@pytest.mark.parametrize("dtype", ["int32", "int64", "float32"])
+def test_prim_value_scalar(exec_mode, dtype):
+    """Relax may pass PrimValue arguments to TIR
+
+    R.call_tir may provide TIR scalars as arguments of type `R.Prim`.
+    These appear in-line with the tensor arguments, before the output
+    arguments.
+
+    Unlike the `tir_vars` parameter, any scalar dtype may be provided
+    as a PrimValue argument.
+
+    """
+
+    target = "llvm"
+    dev = tvm.cpu()
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16], dtype), scale: R.Prim(dtype)):
+            B = R.call_tir(Module.tir_func, [A, scale], out_sinfo=R.Tensor([16], dtype))
+            return B
+
+        @T.prim_func
+        def tir_func(
+            A: T.Buffer(16, dtype),
+            scale: T.var(dtype),
+            B: T.Buffer(16, dtype),
+        ):
+            _ = T.meta_var(dtype)
+            for i in range(16):
+                B[i] = A[i] * scale
+
+    built = tvm.relax.build(Module, target=target, exec_mode=exec_mode)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    arg = np.arange(16, dtype=dtype)
+    expected = 4 * arg
+
+    output = vm["main"](tvm.nd.array(arg), np.int64(4).astype(dtype)).numpy()
+
+    np.testing.assert_equal(expected, output)
+
+
+@pytest.mark.parametrize("dtype", ["int32", "int64", "float32", "float64"])
+def test_prim_value_scalar_computed_in_relax(exec_mode, dtype):
+    """Relax may compute new scalar values and then pass them to TIR"""
+
+    if "float" in dtype:
+        pytest.xfail(
+            reason=(
+                "Computing float values in Relax not yet supported.  "
+                "To add support, ComputePrimValue should use the returned PrimValue in later expressions, "
+                "and should strip the PrimStructInfo::value to prevent VMShapeLower "
+                "from checking non-integer arguments."
+            )
+        )
+
+    target = "llvm"
+    dev = tvm.cpu()
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16], dtype), scale: R.Prim(value="tir_scale")):
+            tir_scale = T.var(dtype)
+            new_scale = R.prim_value(tir_scale * 2)
+            B = R.call_tir(Module.tir_func, [A, new_scale], out_sinfo=R.Tensor([16], dtype))
+            return B
+
+        @T.prim_func
+        def tir_func(
+            A: T.Buffer(16, dtype),
+            scale: T.var(dtype),
+            B: T.Buffer(16, dtype),
+        ):
+            _ = T.meta_var(dtype)
+            for i in range(16):
+                B[i] = A[i] * scale
+
+    built = tvm.relax.build(Module, target=target, exec_mode=exec_mode)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    arg = np.arange(16, dtype=dtype)
+    expected = 8 * arg
+
+    output = vm["main"](tvm.nd.array(arg), np.int64(4).astype(dtype)).numpy()
+
+    np.testing.assert_equal(expected, output)
+
+
+@pytest.mark.xfail(reason="Not yet implemented")
+def test_omit_out_sinfo(exec_mode):
+    """The out_sinfo may be inferred from the PrimFunc signature"""
+
+    target = "llvm"
+    dev = tvm.cpu()
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16], "int32")):
+            B = R.call_tir(Module.tir_func, [A])
+            return B
+
+        @T.prim_func
+        def tir_func(A: T.Buffer(16, "int32"), B: T.Buffer(16, "int32")):
+            for i in range(16):
+                B[i] = A[i] * 2
+
+    built = tvm.relax.build(Module, target=target, exec_mode=exec_mode)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    arg = np.arange(16, dtype="int32")
+    expected = 2 * arg
+
+    output = vm["main"](tvm.nd.array(arg)).numpy()
+
+    np.testing.assert_equal(expected, output)
+
+
+@pytest.mark.xfail(reason="Not yet implemented")
+def test_omit_out_sinfo_with_tir_var_scalar(exec_mode):
+    """The out_sinfo may be inferred when tir_vars are present.
+
+    Because `tir_vars` are stored internally as a `R.Shape`, they only
+    may only define int64 values.  As a result, when `out_sinfo` is
+    omitted, the output should be inferred based on the PrimFunc
+    parameters after `len(call.args)`, but before
+    `len(call.attrs.tir_vars)`.
+
+    """
+
+    target = "llvm"
+    dev = tvm.cpu()
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(A: R.Tensor([16], "int64"), _: R.Prim(value="scale")):
+            scale = T.int64()
+            B = R.call_tir(Module.tir_func, [A], tir_vars=[scale])
+            return B
+
+        @T.prim_func
+        def tir_func(
+            A: T.Buffer(16, "int64"),
+            B: T.Buffer(16, "int64"),
+            scale: T.int64,
+        ):
+            for i in range(16):
+                B[i] = A[i] * scale
+
+    built = tvm.relax.build(Module, target=target, exec_mode=exec_mode)
+    vm = tvm.relax.VirtualMachine(built, dev)
+
+    arg = np.arange(16, dtype="int64")
+    expected = 4 * arg
+
+    output = vm["main"](tvm.nd.array(arg), 4).numpy()
+
+    np.testing.assert_equal(expected, output)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Prior to this commit, the Relax type produced by calling a TIR PrimFunc needed to be explicitly specified using the `out_sinfo` argument.  These output shapes are required in order to allocate output tensors during the `CallTIRRewrite` lowering pass.  However, specifying them explicitly, especially in hand-written functions, duplicates information that is already present in the `PrimFunc` signature, and introduces the potential for inconsistencies.

This commit updates the `MakeCallTIR` function to infer `out_sinfo` if not explicitly specified.  This inference uses the number of relax arguments to identify output parameters in the signature of the `PrimFunc`, which then become the return values from `R.call_tir`.  Currently, this inference of `out_sinfo` occurs when constructing the `relax::Call` object, after which the `out_sinfo` is always present in the Relax IR.