### PR TITLE
[TIR] Validate tir::Buffer axis_separators on construction

### DIFF
--- a/src/tir/ir/buffer.cc
+++ b/src/tir/ir/buffer.cc
@@ -334,24 +334,38 @@ inline Array<PrimExpr> BufferOffset(const BufferNode* n, Array<PrimExpr> index, 
   return offsets;
 }
 
+static void ValidateAxisSeparators(const Array<IntImm>& axis_separators, size_t buffer_dim) {
+  // These checks ensure that all output axes contain at least one
+  // input axis.
+  for (size_t i = 0; (i + 1) < axis_separators.size(); i++) {
+    auto sep = axis_separators[i]->value;
+    auto next_sep = axis_separators[i + 1]->value;
+    CHECK_LT(sep, next_sep) << "ValueError: "
+                            << "Axis separators must be in strictly increasing order, "
+                            << "but axis_separators[" << i << "] = " << sep
+                            << " is greater than or equal to axis_separators[" << (i + 1)
+                            << "] = " << next_sep << ".";
+  }
+  if (axis_separators.size()) {
+    auto first_sep = axis_separators[0]->value;
+    CHECK_GT(first_sep, 0) << "ValueError: "
+                           << "First axis separator must be strictly greater than 0, "
+                           << "so that first output axis contains at least one input axis.  "
+                           << "However, the axis_separators[0] = " << first_sep;
+    auto last_sep = axis_separators[axis_separators.size() - 1]->value;
+    CHECK_LT(last_sep, buffer_dim)
+        << "ValueError: "
+        << "Last output axis must contain at least one input axis.  "
+        << "However, the axis_separators[" << (axis_separators.size() - 1) << "] = " << last_sep
+        << " does not leave any input axes between it and the buffer's dimensionality "
+        << buffer_dim;
+  }
+}
+
 Buffer Buffer::GetFlattenedBuffer() const {
   auto self = operator->();
 
-  // These checks ensure that all output axes contain at least one
-  // input axis.
-  for (size_t i = 0; (i + 1) < self->axis_separators.size(); i++) {
-    auto sep = self->axis_separators[i]->value;
-    auto next_sep = self->axis_separators[i + 1]->value;
-    ICHECK_LT(sep, next_sep) << "Axis separators must be in strictly increasing order.";
-  }
-  if (self->axis_separators.size()) {
-    auto first_sep = self->axis_separators[0]->value;
-    ICHECK_GT(first_sep, 0) << "First axis separator must be strictly greater than 0, "
-                            << "so that first output axis contains at least one input axis";
-    auto last_sep = self->axis_separators[self->axis_separators.size() - 1]->value;
-    ICHECK_LT(last_sep, self->shape.size())
-        << "Last output axis must contain at least one input axis.";
-  }
+  ValidateAxisSeparators(self->axis_separators, self->shape.size());
 
   Array<PrimExpr> output_shape;
   if (self->strides.size()) {
@@ -564,6 +578,8 @@ Buffer::Buffer(Var data, DataType dtype, Array<PrimExpr> shape, Array<PrimExpr> 
       << "Variable " << data->name_hint << " is not a pointer.";
   ICHECK(data->type_annotation.as<PointerTypeNode>()->element_type.as<PrimTypeNode>())
       << "Variable " << data->name_hint << " does not point to a primitive.";
+
+  ValidateAxisSeparators(axis_separators, shape.size());
 
   auto n = make_object<BufferNode>();
   n->data = std::move(data);

--- a/tests/python/tir-base/test_tir_buffer.py
+++ b/tests/python/tir-base/test_tir_buffer.py
@@ -109,9 +109,10 @@ def test_buffer_index_merge_mult_mod():
     A_stride = tvm.tir.decl_buffer((m, n), "float32", strides=(s, 1))
 
     def assert_simplified_equal(index_simplified, index_direct):
-        tvm.ir.assert_structural_equal(
-            index_simplified, index_direct
-        ), "index_simplified=%s, index_direct=%s" % (index_simplified, index_direct)
+        (
+            tvm.ir.assert_structural_equal(index_simplified, index_direct),
+            "index_simplified=%s, index_direct=%s" % (index_simplified, index_direct),
+        )
 
     idxd = tvm.tir.indexdiv
     idxm = tvm.tir.indexmod
@@ -274,6 +275,11 @@ def test_buffer_flatten_uses_axis_separators():
     flat = buf.get_flattened_buffer()
     tvm.ir.assert_structural_equal(flat.axis_separators, [1])
     tvm.ir.assert_structural_equal(flat.shape, [4 * 16, 32])
+
+
+def test_invalid_axis_separators_raises_exception():
+    with pytest.raises(ValueError):
+        tvm.tir.decl_buffer([1], axis_separators=[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prior to this commit, the `axis_separators` field of a TIR buffer wasn't validated until the `tir.FlattenBuffer` legalization pass. Delaying the error until this point makes it difficult to determine where it invalid `axis_separators` were initially defined.

This commit updates the `tir::Buffer` constructor to validate the `axis_separators` field immediately, allowing these invalid values to be caught on construction.

Closes https://github.com/apache/tvm/issues/17215