### PR TITLE
[CI] Reduce logging level when checking if docker image exists

### DIFF
--- a/ci/scripts/jenkins/determine_docker_images.py
+++ b/ci/scripts/jenkins/determine_docker_images.py
@@ -62,11 +62,11 @@ def image_exists(spec: str) -> bool:
     name, tag = spec.split(":")
     try:
         r = docker_api(f"repositories/{name}/tags/{tag}")
-        logging.info(f"Image exists, got response: {json.dumps(r, indent=2)}")
+        logging.debug(f"Image exists, got response: {json.dumps(r, indent=2)}")
         return True
     except urllib.error.HTTPError as e:
         # Image was not found
-        logging.exception(e)
+        logging.debug(e)
         return False
 
 


### PR DESCRIPTION
Prior to this commit, the `image_exists` utility in `determine_docker_images.py` logged the full response for success, and the full HTTP error if an exception is caught.  However, this is the expected behavior when loading a docker image from `tlcpackstaging`, such as the current images tagged with `20240428-060115-0b09ed018`. Logging this fallback as an error makes it difficult to find the first actual error that occurred in CI.

This commit updates these logging statments `logging.info` and `logging.exception` to instead use `logging.debug`.