### PR TITLE
[Relax] Fix segfault in rewrite_bindings for MatchCast node

### DIFF
--- a/src/relax/ir/dataflow_block_rewriter.cc
+++ b/src/relax/ir/dataflow_block_rewriter.cc
@@ -49,7 +49,7 @@ class MatcherUseDefAnalysis : public relax::ExprVisitor {
   // caller -> callee table.
   std::map<const VarNode*, std::vector<const VarNode*>> caller2callees;
 
-  const VarNode* cur_user_;
+  const VarNode* cur_user_ = nullptr;
 
   void VisitBinding_(const VarBindingNode* binding) override {
     // init


### PR DESCRIPTION
Prior to this commit, the `tvm.relax.dpl.rewrite_bindings` utility would segfault if its input contained a `DataflowBlock` whose first binding was a `MatchCast`.

The root cause is use of an unintialized `const VarNode* cur_user_;` when collecting the variable usage.  This variable is only initialized for `VarBinding` nodes, and may be used uninitialized if a `MatchCast` node is encountered before the first `VarBinding`.  This uninitialized value is later dereferenced during while pattern-matching, causing a segfault.

This commit provides a default value of `nullptr` for `MatcherUseDefAnalysis::cur_user_`, preventing the segfault.