### PR TITLE
[Runtime] Allow aborting fetchWithCache through AbortSignal

### DIFF
--- a/web/src/artifact_cache.ts
+++ b/web/src/artifact_cache.ts
@@ -114,10 +114,11 @@ export class ArtifactCache implements ArtifactCacheTemplate {
    * fetch the corresponding url object in response or stored object format
    * @param url url
    * @param storetype the storage type for indexedDB
+   * @param signal an optional abort signal to abort fetching
    * @returns response in json, arraybuffer or pure response format
    */
-  async fetchWithCache(url: string, storetype?: string): Promise<any> {
-    await this.addToCache(url, storetype);
+  async fetchWithCache(url: string, storetype?: string, signal?: AbortSignal): Promise<any> {
+    await this.addToCache(url, storetype, signal);
     const result = await this.cache.match(new Request(url));
     if (result === undefined) {
       // Already called `addToCache()`, should expect the request in cache.
@@ -242,8 +243,8 @@ export class ArtifactIndexedDBCache implements ArtifactCacheTemplate {
     })
   }
 
-  async fetchWithCache(url: string, storetype?: string): Promise<any> {
-    await this.addToCache(url, storetype);
+  async fetchWithCache(url: string, storetype?: string, signal?: AbortSignal): Promise<any> {
+    await this.addToCache(url, storetype, signal);
     let result = await this.asyncGetHelper(url);
     if (result === null) {
       // previously null data in cache or somehow failed to add to cache, delete and retry


### PR DESCRIPTION
This is a follow-up for a previous change https://github.com/apache/tvm/pull/17208.

This Pull Request updates function `fetchWithCache()` in TVM runtime class to accept an optional parameter `signal: AbortSignal`, so that users could use `AbortController` to abort the fetch process if needed.

https://developer.mozilla.org/en-US/docs/Web/API/AbortController

Related issues:
https://github.com/mlc-ai/web-llm/issues/484
https://github.com/mlc-ai/web-llm/issues/499