### PR TITLE
[Draft][FFI] Remove backwards-compatibility unwrapping of IntImm

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -866,28 +866,6 @@ struct PackedFuncValueConverter<tvm::FloatImm> {
   }
 };
 
-/* \brief Backwards compatibility wrapper for IntImm arguments
- *
- * In previous versions of TVM, IntImm was the default FFI type for
- * integer arguments, instead of runtime::Int.  For backwards
- * compatibility where the callee has been updated to expected a
- * runtime::Int, the caller has not been updated to provide a
- * runtime::Int (e.g. relay script parsing), and the auto-unboxing of
- * runtime::Int does not apply (e.g. making an `Array<runtime::Int>`),
- * allow the IntImm to be generated.
- */
-template <>
-struct PackedFuncValueConverter<runtime::Int> {
-  template <typename PODSubclass>
-  static runtime::Int From(const PODSubclass& val) {
-    if (val.template IsObjectRef<tvm::IntImm>()) {
-      return runtime::Int(val.template AsObjectRef<tvm::IntImm>()->value);
-    } else {
-      return val.template AsObjectRef<runtime::Int>();
-    }
-  }
-};
-
 }  // namespace runtime
 }  // namespace tvm
 

--- a/include/tvm/meta_schedule/schedule/cuda/thread_bind.h
+++ b/include/tvm/meta_schedule/schedule/cuda/thread_bind.h
@@ -36,7 +36,7 @@ namespace meta_schedule {
  * \return A sampler that returns a random thread extent.
  */
 std::function<tir::ExprRV(int64_t)> MakeFactorSampler(tir::Schedule sch,
-                                                      Array<Integer> thread_extents);
+                                                      Array<runtime::Int> thread_extents);
 
 /*!
  * \brief Bind blockIdx.x and threadIdx.x to the given loop

--- a/include/tvm/meta_schedule/schedule_rule.h
+++ b/include/tvm/meta_schedule/schedule_rule.h
@@ -154,11 +154,11 @@ class ScheduleRule : public runtime::ObjectRef {
    * ignored  by default. This function should return True for a block that should be tiled.
    * \return The schedule rule created
    */
-  TVM_DLL static ScheduleRule MultiLevelTiling(String structure,                             //
-                                               Optional<Array<String>> tile_binds,           //
-                                               Optional<Integer> max_innermost_factor,       //
-                                               Optional<Array<Integer>> vector_load_lens,    //
-                                               Optional<Map<String, ObjectRef>> reuse_read,  //
+  TVM_DLL static ScheduleRule MultiLevelTiling(String structure,                                //
+                                               Optional<Array<String>> tile_binds,              //
+                                               Optional<runtime::Int> max_innermost_factor,     //
+                                               Optional<Array<runtime::Int>> vector_load_lens,  //
+                                               Optional<Map<String, ObjectRef>> reuse_read,     //
                                                Optional<Map<String, ObjectRef>> reuse_write,
                                                Optional<runtime::PackedFunc> filter_fn = NullOpt);
 
@@ -181,7 +181,7 @@ class ScheduleRule : public runtime::ObjectRef {
    */
   TVM_DLL static ScheduleRule MultiLevelTilingWithIntrin(
       String intrin_name, String structure, Optional<Array<String>> tile_binds,
-      Optional<Integer> max_innermost_factor, Optional<Array<Integer>> vector_load_lens,
+      Optional<runtime::Int> max_innermost_factor, Optional<Array<runtime::Int>> vector_load_lens,
       Optional<Map<String, ObjectRef>> reuse_read, Optional<Map<String, ObjectRef>> reuse_write);
 
   /*!
@@ -206,8 +206,8 @@ class ScheduleRule : public runtime::ObjectRef {
    */
   TVM_DLL static ScheduleRule MultiLevelTilingTensorCore(
       Array<Map<String, String>> intrin_groups, String structure,
-      Optional<Array<String>> tile_binds, Optional<Integer> max_innermost_factor,
-      Optional<Array<Integer>> vector_load_lens, Optional<Map<String, ObjectRef>> reuse_read,
+      Optional<Array<String>> tile_binds, Optional<runtime::Int> max_innermost_factor,
+      Optional<Array<runtime::Int>> vector_load_lens, Optional<Map<String, ObjectRef>> reuse_read,
       Optional<Map<String, ObjectRef>> reuse_write, bool use_software_pipeline);
 
   /*!
@@ -222,8 +222,9 @@ class ScheduleRule : public runtime::ObjectRef {
    * \return The schedule rule created
    */
   TVM_DLL static ScheduleRule MultiLevelTilingWideVector(
-      String structure, Integer vector_length_in_bits, Optional<Integer> max_innermost_factor,
-      Optional<Map<String, ObjectRef>> reuse_read, Optional<Map<String, ObjectRef>> reuse_write);
+      String structure, runtime::Int vector_length_in_bits,
+      Optional<runtime::Int> max_innermost_factor, Optional<Map<String, ObjectRef>> reuse_read,
+      Optional<Map<String, ObjectRef>> reuse_write);
 
   /*!
    * \brief Create a rule: add-rfactor to some blocks if needed
@@ -234,7 +235,7 @@ class ScheduleRule : public runtime::ObjectRef {
    * \return The schedule rule created
    */
   TVM_DLL static ScheduleRule AddRFactor(int max_jobs_per_core,  //
-                                         Optional<Integer> max_innermost_factor);
+                                         Optional<runtime::Int> max_innermost_factor);
   /*!
    * \brief Create a schedule rule which applies cross-thread reduction to some reduction blocks
    * correspondingly when needed
@@ -272,7 +273,7 @@ class ScheduleRule : public runtime::ObjectRef {
    * when this schedule rule is created.
    * \return The schedule rule created
    */
-  TVM_DLL static ScheduleRule AutoBind(int max_threadblocks, Array<Integer> thread_extents,
+  TVM_DLL static ScheduleRule AutoBind(int max_threadblocks, Array<runtime::Int> thread_extents,
                                        int max_threads_per_block = -1);
   /*!
    * \brief Create a schedule rule with customized methods on the python-side.

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -530,6 +530,9 @@ struct MatrixSetDiagAttrs : public tvm::AttrsNode<MatrixSetDiagAttrs> {
   }
 };  // struct MatrixSetDiagAttrs
 
+template <typename U, typename T>
+using Identity = T;
+
 /*! \brief Attributes used in cumsum and cumprod operator */
 struct ScanopAttrs : public tvm::AttrsNode<ScanopAttrs> {
   Integer axis;
@@ -542,7 +545,7 @@ struct ScanopAttrs : public tvm::AttrsNode<ScanopAttrs> {
     // Default is 0 which is "false"
     TVM_ATTR_FIELD(exclusive)
         .describe("The first element is not included")
-        .set_default(Bool(false));
+        .set_default(Identity<FVisit, Bool>(false));
   }
 };  // struct ScanopAttrs
 

--- a/src/meta_schedule/schedule_rule/add_rfactor.cc
+++ b/src/meta_schedule/schedule_rule/add_rfactor.cc
@@ -68,10 +68,10 @@ class AddRFactorNode : public ScheduleRuleNode {
 };
 
 ScheduleRule ScheduleRule::AddRFactor(int max_jobs_per_core,
-                                      Optional<Integer> max_innermost_factor) {
+                                      Optional<runtime::Int> max_innermost_factor) {
   ObjectPtr<AddRFactorNode> n = make_object<AddRFactorNode>();
   n->max_jobs_per_core = max_jobs_per_core;
-  n->max_innermost_factor = max_innermost_factor.value_or(Integer(-1))->value;
+  n->max_innermost_factor = max_innermost_factor.value_or(runtime::Int(-1))->value;
   n->max_parallel_extent_ = -1;
   n->max_parallel_basic_ = -1;
   return ScheduleRule(n);

--- a/src/meta_schedule/schedule_rule/auto_bind.cc
+++ b/src/meta_schedule/schedule_rule/auto_bind.cc
@@ -31,11 +31,11 @@ class AutoBindNode : public ScheduleRuleNode {
   // Inherited from ScheduleRuleNode
   void InitializeWithTuneContext(const TuneContext& context) final {
     CHECK(context->target.defined()) << "ValueError: target is not defined";
-    Optional<Integer> max_threads_per_block =
-        context->target.value()->GetAttr<Integer>("max_threads_per_block");
+    Optional<runtime::Int> max_threads_per_block =
+        context->target.value()->GetAttr<runtime::Int>("max_threads_per_block");
     CHECK(max_threads_per_block.defined())
         << "ValueError: missing attribute `max_threads_per_block` in the target";
-    this->max_threads_per_block_ = max_threads_per_block.value().IntValue();
+    this->max_threads_per_block_ = max_threads_per_block.value();
   }
 
   // Inherited from ScheduleRuleNode
@@ -53,7 +53,7 @@ class AutoBindNode : public ScheduleRuleNode {
   /*! \brief The max number of threadblocks in the cuda device */
   int64_t max_threadblocks_ = -1;
   /*! \brief thread_extents Candidates of thread axis extent. */
-  Array<Integer> thread_extents_;
+  Array<runtime::Int> thread_extents_;
 
   void VisitAttrs(tvm::AttrVisitor* v) {
     // `max_threads_per_block_` is not visited
@@ -72,7 +72,7 @@ Array<tir::Schedule> AutoBindNode::Apply(const tir::Schedule& sch, const tir::Bl
   return {sch};
 }
 
-ScheduleRule ScheduleRule::AutoBind(int max_threadblocks, Array<Integer> thread_extents,
+ScheduleRule ScheduleRule::AutoBind(int max_threadblocks, Array<runtime::Int> thread_extents,
                                     int max_threads_per_block) {
   ObjectPtr<AutoBindNode> n = make_object<AutoBindNode>();
   n->max_threadblocks_ = max_threadblocks;

--- a/src/meta_schedule/schedule_rule/multi_level_tiling.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling.cc
@@ -392,8 +392,8 @@ void MultiLevelTilingNode::AnnotateCooperativeFetching(Schedule* sch,
 // Constructor
 
 ScheduleRule ScheduleRule::MultiLevelTiling(String structure, Optional<Array<String>> tile_binds,
-                                            Optional<Integer> max_innermost_factor,
-                                            Optional<Array<Integer>> vector_load_lens,
+                                            Optional<runtime::Int> max_innermost_factor,
+                                            Optional<Array<runtime::Int>> vector_load_lens,
                                             Optional<Map<String, ObjectRef>> reuse_read,
                                             Optional<Map<String, ObjectRef>> reuse_write,
                                             Optional<runtime::PackedFunc> filter_fn) {

--- a/src/meta_schedule/schedule_rule/multi_level_tiling.h
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling.h
@@ -239,16 +239,16 @@ class MultiLevelTilingNode : public ScheduleRuleNode {
 
 template <typename NodeType>
 ObjectPtr<NodeType> MultiLevelTilingInitCommon(String structure, Optional<Array<String>> tile_binds,
-                                               Optional<Integer> max_innermost_factor,
-                                               Optional<Array<Integer>> vector_load_lens,
+                                               Optional<runtime::Int> max_innermost_factor,
+                                               Optional<Array<runtime::Int>> vector_load_lens,
                                                Optional<Map<String, ObjectRef>> reuse_read,
                                                Optional<Map<String, ObjectRef>> reuse_write) {
   ObjectPtr<NodeType> n = make_object<NodeType>();
   n->structure = structure;
   n->tile_binds = tile_binds.value_or({});
-  n->max_innermost_factor = max_innermost_factor.value_or(Integer(-1))->value;
+  n->max_innermost_factor = max_innermost_factor.value_or(runtime::Int(-1))->value;
   n->vector_load_lens = vector_load_lens.defined()
-                            ? support::AsVector<Integer, int>(vector_load_lens.value())
+                            ? support::AsVector<runtime::Int, int>(vector_load_lens.value())
                             : std::vector<int>();
   n->reuse_read_ = reuse_read.defined() ? ReuseConfig(reuse_read.value()) : ReuseConfig();
   n->reuse_write_ = reuse_write.defined() ? ReuseConfig(reuse_write.value()) : ReuseConfig();

--- a/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
@@ -890,7 +890,7 @@ inline std::vector<State> MultiLevelTilingTensorCoreNode::TransformForTensorizat
 
 ScheduleRule ScheduleRule::MultiLevelTilingTensorCore(
     Array<Map<String, String>> intrin_groups, String structure, Optional<Array<String>> tile_binds,
-    Optional<Integer> max_innermost_factor, Optional<Array<Integer>> vector_load_lens,
+    Optional<runtime::Int> max_innermost_factor, Optional<Array<runtime::Int>> vector_load_lens,
     Optional<Map<String, ObjectRef>> reuse_read, Optional<Map<String, ObjectRef>> reuse_write,
     bool use_software_pipeline) {
   if (tile_binds.defined()) {

--- a/src/meta_schedule/schedule_rule/multi_level_tiling_wide_vector.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_wide_vector.cc
@@ -113,8 +113,9 @@ std::pair<Array<tir::ExprRV>, Array<tir::LoopRV>> MultiLevelTilingWideVectorNode
 }
 
 ScheduleRule ScheduleRule::MultiLevelTilingWideVector(
-    String structure, Integer vector_length_in_bits, Optional<Integer> max_innermost_factor,
-    Optional<Map<String, ObjectRef>> reuse_read, Optional<Map<String, ObjectRef>> reuse_write) {
+    String structure, runtime::Int vector_length_in_bits,
+    Optional<runtime::Int> max_innermost_factor, Optional<Map<String, ObjectRef>> reuse_read,
+    Optional<Map<String, ObjectRef>> reuse_write) {
   auto node = MultiLevelTilingInitCommon<MultiLevelTilingWideVectorNode>(
       structure, NullOpt, max_innermost_factor, NullOpt, reuse_read, reuse_write);
   node->vector_length_in_bits = vector_length_in_bits->value;

--- a/src/meta_schedule/schedule_rule/multi_level_tiling_with_intrin.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_with_intrin.cc
@@ -93,7 +93,7 @@ class MultiLevelTilingWithIntrinNode : public MultiLevelTilingNode {
 
 ScheduleRule ScheduleRule::MultiLevelTilingWithIntrin(
     String intrin_name, String structure, Optional<Array<String>> tile_binds,
-    Optional<Integer> max_innermost_factor, Optional<Array<Integer>> vector_load_lens,
+    Optional<runtime::Int> max_innermost_factor, Optional<Array<runtime::Int>> vector_load_lens,
     Optional<Map<String, ObjectRef>> reuse_read, Optional<Map<String, ObjectRef>> reuse_write) {
   ICHECK(tir::TensorIntrin::Get(intrin_name).defined())
       << "Provided tensor intrinsic " << intrin_name << " is not registered.";

--- a/src/meta_schedule/schedule_rule/schedule_rule.cc
+++ b/src/meta_schedule/schedule_rule/schedule_rule.cc
@@ -65,16 +65,16 @@ Array<ScheduleRule> ScheduleRule::DefaultLLVM() {
           /*disallow_op=*/Array<String>{"tir.exp"}),
       ScheduleRule::AddRFactor(
           /*max_jobs_per_core=*/16,
-          /*max_innermost_factor=*/Integer(64)),
+          /*max_innermost_factor=*/runtime::Int(64)),
       ScheduleRule::MultiLevelTiling(
           /*structure=*/"SSRSRS",
           /*tile_binds=*/NullOpt,
-          /*max_innermost_factor=*/Integer(64),
+          /*max_innermost_factor=*/runtime::Int(64),
           /*vector_load_lens=*/NullOpt,
           /*reuse_read=*/NullOpt,
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("may")},
-                                 {"levels", Array<Integer>{1, 2}},
+                                 {"levels", Array<runtime::Int>{1, 2}},
                                  {"scope", String("global")}}),
       ScheduleRule::ParallelizeVectorizeUnroll(
           /*max_jobs_per_core=*/16,
@@ -101,27 +101,27 @@ Array<ScheduleRule> ScheduleRule::DefaultX86(const String& type) {
           /*disallow_op=*/Array<String>{"tir.exp"}),
       ScheduleRule::AddRFactor(
           /*max_jobs_per_core=*/16,
-          /*max_innermost_factor=*/Integer(64)),
+          /*max_innermost_factor=*/runtime::Int(64)),
       ScheduleRule::MultiLevelTilingWithIntrin(
           /*intrin_name=*/intrins[type],
           /*structure=*/"SSRSRS",
           /*tile_binds=*/NullOpt,
-          /*max_innermost_factor=*/Integer(64),
+          /*max_innermost_factor=*/runtime::Int(64),
           /*vector_load_lens=*/NullOpt,
           /*reuse_read=*/NullOpt,
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("may")},
-                                 {"levels", Array<Integer>{1, 2}},
+                                 {"levels", Array<runtime::Int>{1, 2}},
                                  {"scope", String("global")}}),
       ScheduleRule::MultiLevelTiling(
           /*structure=*/"SSRSRS",
           /*tile_binds=*/NullOpt,
-          /*max_innermost_factor=*/Integer(64),
+          /*max_innermost_factor=*/runtime::Int(64),
           /*vector_load_lens=*/NullOpt,
           /*reuse_read=*/NullOpt,
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("may")},
-                                 {"levels", Array<Integer>{1, 2}},
+                                 {"levels", Array<runtime::Int>{1, 2}},
                                  {"scope", String("global")}}),
       ScheduleRule::ParallelizeVectorizeUnroll(
           /*max_jobs_per_core=*/16,
@@ -138,15 +138,15 @@ Array<ScheduleRule> ScheduleRule::DefaultCUDA() {
       ScheduleRule::MultiLevelTiling(
           /*structure=*/"SSSRRSRS",
           /*tile_binds=*/Array<String>{"blockIdx.x", "vthread.x", "threadIdx.x"},
-          /*max_innermost_factor=*/Integer(64),
-          /*vector_load_lens=*/Array<Integer>{1, 2, 3, 4, 8, 16},
+          /*max_innermost_factor=*/runtime::Int(64),
+          /*vector_load_lens=*/Array<runtime::Int>{1, 2, 3, 4, 8, 16},
           /*reuse_read=*/
           Map<String, ObjectRef>{{"req", String("must")},
-                                 {"levels", Array<Integer>{4}},  //
+                                 {"levels", Array<runtime::Int>{4}},  //
                                  {"scope", String("shared")}},
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("must")},
-                                 {"levels", Array<Integer>{3}},  //
+                                 {"levels", Array<runtime::Int>{3}},  //
                                  {"scope", String("local")}}),
       ScheduleRule::InlineConstantScalars(),
       ScheduleRule::AutoInline(
@@ -166,7 +166,7 @@ Array<ScheduleRule> ScheduleRule::DefaultCUDA() {
           /*unroll_explicit=*/true),
       ScheduleRule::AutoBind(
           /*max_threadblocks=*/256,
-          /*thread_extents*/ Array<Integer>{32, 64, 128, 256, 512, 1024}),
+          /*thread_extents*/ Array<runtime::Int>{32, 64, 128, 256, 512, 1024}),
   };
 }
 
@@ -241,30 +241,30 @@ Array<ScheduleRule> ScheduleRule::DefaultCUDATensorCore() {
           /*intrin_groups=*/wmma_intrin_groups,
           /*structure=*/"SSSRRSRS",
           /*tile_binds=*/Array<String>{"blockIdx.y", "blockIdx.x", "threadIdx.y"},
-          /*max_innermost_factor=*/Integer(4),
-          /*vector_load_lens=*/Array<Integer>{1, 2, 3, 4, 8, 16},
+          /*max_innermost_factor=*/runtime::Int(4),
+          /*vector_load_lens=*/Array<runtime::Int>{1, 2, 3, 4, 8, 16},
           /*reuse_read=*/
           Map<String, ObjectRef>{{"req", String("must")},
-                                 {"levels", Array<Integer>{4}},  //
+                                 {"levels", Array<runtime::Int>{4}},  //
                                  {"scope", String("shared.dyn")}},
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("must")},
-                                 {"levels", Array<Integer>{2}},  //
+                                 {"levels", Array<runtime::Int>{2}},  //
                                  {"scope", String("shared.dyn")}},
           /*use_software_pipeline=*/false),  //
       ScheduleRule::MultiLevelTilingTensorCore(
           /*intrin_groups=*/mma_intrin_groups,
           /*structure=*/"SSSRRSRS",
           /*tile_binds=*/Array<String>{"blockIdx.y", "blockIdx.x", "threadIdx.y"},
-          /*max_innermost_factor=*/Integer(4),
-          /*vector_load_lens=*/Array<Integer>{1, 2, 3, 4, 8, 16},
+          /*max_innermost_factor=*/runtime::Int(4),
+          /*vector_load_lens=*/Array<runtime::Int>{1, 2, 3, 4, 8, 16},
           /*reuse_read=*/
           Map<String, ObjectRef>{{"req", String("must")},
-                                 {"levels", Array<Integer>{4}},  //
+                                 {"levels", Array<runtime::Int>{4}},  //
                                  {"scope", String("shared.dyn")}},
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("no")},
-                                 {"levels", Array<Integer>{2}},  //
+                                 {"levels", Array<runtime::Int>{2}},  //
                                  {"scope", String("shared.dyn")}},
           /*use_software_pipeline=*/true)  //
   };
@@ -288,11 +288,11 @@ Array<ScheduleRule> ScheduleRule::DefaultHexagon() {
       ScheduleRule::MultiLevelTilingWideVector(
           /*structure=*/"SRSRS",
           /*vector_length_in_bits=*/1024,
-          /*max_innermost_factor=*/Integer(128),
+          /*max_innermost_factor=*/runtime::Int(128),
           /*reuse_read=*/NullOpt,
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("may")},
-                                 {"levels", Array<Integer>{1, 2}},
+                                 {"levels", Array<runtime::Int>{1, 2}},
                                  {"scope", String("global")}}),
       ScheduleRule::ParallelizeVectorizeUnroll(
           /*max_jobs_per_core=*/16,
@@ -317,12 +317,12 @@ Array<ScheduleRule> ScheduleRule::DefaultMicro() {
       ScheduleRule::MultiLevelTiling(
           /*structure=*/"SSRSRS",
           /*tile_binds=*/NullOpt,
-          /*max_innermost_factor=*/Integer(64),
+          /*max_innermost_factor=*/runtime::Int(64),
           /*vector_load_lens=*/NullOpt,
           /*reuse_read=*/NullOpt,
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("may")},
-                                 {"levels", Array<Integer>{1, 2}},
+                                 {"levels", Array<runtime::Int>{1, 2}},
                                  {"scope", String("global")}}),
   };
 }
@@ -333,12 +333,12 @@ Array<ScheduleRule> GetARMNeonSpecificRules() {
           /*intrin_name=*/String("dot_4x4_i8i8s32_neon"),
           /*structure=*/"SSRSRS",
           /*tile_binds=*/NullOpt,
-          /*max_innermost_factor=*/Integer(32),
+          /*max_innermost_factor=*/runtime::Int(32),
           /*vector_load_lens=*/NullOpt,
           /*reuse_read=*/NullOpt,
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("may")},
-                                 {"levels", Array<Integer>{1, 2}},
+                                 {"levels", Array<runtime::Int>{1, 2}},
                                  {"scope", String("global")}}),
   };
 }
@@ -349,34 +349,34 @@ Array<ScheduleRule> GetARMDotprodSpecificRules() {
           /*intrin_name=*/String("dot_4x4_i8i8s32_sdot"),
           /*structure=*/"SSRSRS",
           /*tile_binds=*/NullOpt,
-          /*max_innermost_factor=*/Integer(32),
+          /*max_innermost_factor=*/runtime::Int(32),
           /*vector_load_lens=*/NullOpt,
           /*reuse_read=*/NullOpt,
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("may")},
-                                 {"levels", Array<Integer>{1, 2}},
+                                 {"levels", Array<runtime::Int>{1, 2}},
                                  {"scope", String("global")}}),
       ScheduleRule::MultiLevelTilingWithIntrin(
           /*intrin_name=*/String("dot_4x4_u8u8u32_udot"),
           /*structure=*/"SSRSRS",
           /*tile_binds=*/NullOpt,
-          /*max_innermost_factor=*/Integer(32),
+          /*max_innermost_factor=*/runtime::Int(32),
           /*vector_load_lens=*/NullOpt,
           /*reuse_read=*/NullOpt,
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("may")},
-                                 {"levels", Array<Integer>{1, 2}},
+                                 {"levels", Array<runtime::Int>{1, 2}},
                                  {"scope", String("global")}}),
       ScheduleRule::MultiLevelTilingWithIntrin(
           /*intrin_name=*/String("dot_4x4_u8u8i32_hdot"),
           /*structure=*/"SSRSRS",
           /*tile_binds=*/NullOpt,
-          /*max_innermost_factor=*/Integer(32),
+          /*max_innermost_factor=*/runtime::Int(32),
           /*vector_load_lens=*/NullOpt,
           /*reuse_read=*/NullOpt,
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("may")},
-                                 {"levels", Array<Integer>{1, 2}},
+                                 {"levels", Array<runtime::Int>{1, 2}},
                                  {"scope", String("global")}}),
   };
 }
@@ -394,18 +394,18 @@ Array<ScheduleRule> ScheduleRule::DefaultARM(const String& type) {
           /*disallow_op=*/Array<String>{"tir.exp"}),
       ScheduleRule::AddRFactor(
           /*max_jobs_per_core=*/8,
-          /*max_innermost_factor=*/Integer(32)),
+          /*max_innermost_factor=*/runtime::Int(32)),
       "neon" == type ? GetARMNeonSpecificRules() : Array<ScheduleRule>{},
       "dotprod" == type ? GetARMDotprodSpecificRules() : Array<ScheduleRule>{},
       ScheduleRule::MultiLevelTiling(
           /*structure=*/"SSRSRS",
           /*tile_binds=*/NullOpt,
-          /*max_innermost_factor=*/Integer(32),
+          /*max_innermost_factor=*/runtime::Int(32),
           /*vector_load_lens=*/NullOpt,
           /*reuse_read=*/NullOpt,
           /*reuse_write=*/
           Map<String, ObjectRef>{{"req", String("may")},
-                                 {"levels", Array<Integer>{1, 2}},
+                                 {"levels", Array<runtime::Int>{1, 2}},
                                  {"scope", String("global")}}),
       ScheduleRule::ParallelizeVectorizeUnroll(
           /*max_jobs_per_core=*/8,

--- a/src/meta_schedule/trace_apply.cc
+++ b/src/meta_schedule/trace_apply.cc
@@ -242,13 +242,13 @@ void ScheduleUsingAnchorTrace(Schedule sch, const Trace& anchor_trace, const tvm
   } else if (target->kind->name == "llvm" || target->kind->name == "hexagon") {
     sch->Parallel(sch->Fuse(sch->GetLoops(last_block)));
   } else if (IsGPUTarget(target->kind->name)) {
-    auto max_threads_per_block = target->GetAttr<Integer>("max_threads_per_block");
+    auto max_threads_per_block = target->GetAttr<runtime::Int>("max_threads_per_block");
     ICHECK(max_threads_per_block.defined())
         << "ValueError: missing attribute `max_threads_per_block` in the target";
 
     auto auto_bind_rule =
         ScheduleRule::AutoBind(/*max_threadblocks=*/256,
-                               /*thread_extents*/ Array<Integer>{32, 64, 128, 256, 512, 1024},
+                               /*thread_extents*/ Array<runtime::Int>{32, 64, 128, 256, 512, 1024},
                                max_threads_per_block.value()->value);
     auto_bind_rule->Apply(sch, last_block);
   }

--- a/src/relay/parser/parser.cc
+++ b/src/relay/parser/parser.cc
@@ -1352,8 +1352,11 @@ class Parser {
     auto next = Peek();
     switch (next->token_type) {
       case TokenType::kFloat:
+        return runtime::Float(Downcast<FloatImm>(Match(next->token_type)->data)->value);
       case TokenType::kInteger:
+        return runtime::Int(Downcast<IntImm>(Match(next->token_type)->data)->value);
       case TokenType::kBoolean:
+        return runtime::Bool(Downcast<IntImm>(Match(next->token_type)->data)->value);
       case TokenType::kStringLiteral:
         return Match(next->token_type)->data;
       case TokenType::kMetaReference:

--- a/src/relay/parser/parser.cc
+++ b/src/relay/parser/parser.cc
@@ -21,6 +21,10 @@
  * \file parser.cc
  * \brief A parser for TVM IR.
  */
+
+
+#include "./tokenizer.h"
+
 #include <tvm/ir/module.h>
 #include <tvm/node/reflection.h>
 #include <tvm/relay/adt.h>

--- a/src/relay/parser/parser.cc
+++ b/src/relay/parser/parser.cc
@@ -22,9 +22,6 @@
  * \brief A parser for TVM IR.
  */
 
-
-#include "./tokenizer.h"
-
 #include <tvm/ir/module.h>
 #include <tvm/node/reflection.h>
 #include <tvm/relay/adt.h>


### PR DESCRIPTION
This is a follow-up PR to https://github.com/apache/tvm/pull/16183, which updated the FFI with explicit integer types.  As part of that change, many internal functions were updated to accept non-IR types (e.g. `Array<runtime::Int>` instead of `Array<IntImm>`).  For backwards compatibility with callees that provided the IR types, a specialization of `PackedFuncValueConverter` unwrapped the `IntImm` into a `runtime::Int`.

This commit removes the backwards-compatibility specialization of `PackedFuncValueConverter`.  Breakages that are found in CI as a result will then be updated at the caller side, removing the need for the backwards-compatibility handler altogether.