### PR TITLE
[Relax] Avoid wrapping TupleStructInfo into a Tuple for R.call_tir

### DIFF
--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1043,17 +1043,15 @@ def test_call_tir_inplace():
 
     _check(Module)
 
-def test_call_tir_inplace_with_tuple_var_raises_error():
 
+def test_call_tir_inplace_with_tuple_var_raises_error():
 
     with pytest.raises(tvm.error.DiagnosticError):
 
         @tvm.script.ir_module
         class Module:
             @R.function
-            def main(
-                x: R.Tensor((2, 3), "int32"), y: R.Tensor((2, 3), "int32")
-            ) :
+            def main(x: R.Tensor((2, 3), "int32"), y: R.Tensor((2, 3), "int32")):
                 cls = Module
                 args = (x, y)
                 res = R.call_tir_inplace(
@@ -1062,7 +1060,7 @@ def test_call_tir_inplace_with_tuple_var_raises_error():
                     # reference to a tuple.  This error should be
                     # caught and raised during parsing.
                     args,
-                    inplace_indices = [0, -1],
+                    inplace_indices=[0, -1],
                     out_sinfo=[R.Tensor((2, 3), "int32"), R.Tensor((2, 3), "int32")],
                 )
                 return res
@@ -1080,8 +1078,6 @@ def test_call_tir_inplace_with_tuple_var_raises_error():
                         i, j = T.axis.remap("SS", iters)
                         A[i, j] = B[i, j]
                         out1[i, j] = B[i, j]
-
-
 
 
 def test_local_function():


### PR DESCRIPTION
Prior to this commit, the different `R.call_tir*` variations would wrap the arguments into an in-line `relax.Tuple`, if it is not already a `relax.Tuple`.  While this allows a tensor to be passed into these functions as a single argument (`R.call_tir(func, arg, ...)` instead of `R.call_tir(func, [arg], ...)`), the wrapped Relax variable may already refer to a tuple.

This use of a variable to refer to an argument tuple rather than an in-line argument tuple is not allowed by Relax.  (See discussion on https://github.com/apache/tvm/pull/15916 for details.)  However, by wrapping a variable `args: R.Tuple(R.Tensor, R.Tensor, ...)` into a tuple-of-tuples, the error occurs after the expression has already been generated, and refers to an expression `R.Tuple(R.Tuple(R.Tensor, R.Tensor, ...))` that doesn't appear anywhere in the user's input. This can make debugging difficult (see https://github.com/apache/tvm/issues/17239 for an example).

This commit updates the argument-handling in `R.call_tir` to only generate an in-line `relax.Tuple` if the arguments do not already have `relax.TupleStructInfo`.  If the argument was provided as a Relax variable bound to a tuple of arguments, it will still produce an error.  However, that error will occur much earlier, and will explicitly state that the argument must be a `relax.Tuple` instead of a `relax.Var`.