### PR TITLE
[IR] Handle NaN in StructuralEqual and StructuralHash

### DIFF
--- a/include/tvm/node/structural_hash.h
+++ b/include/tvm/node/structural_hash.h
@@ -29,6 +29,7 @@
 
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <string>
 
 namespace tvm {

--- a/include/tvm/node/structural_hash.h
+++ b/include/tvm/node/structural_hash.h
@@ -27,6 +27,7 @@
 #include <tvm/runtime/data_type.h>
 #include <tvm/runtime/ndarray.h>
 
+#include <cmath>
 #include <functional>
 #include <string>
 
@@ -52,7 +53,16 @@ class BaseValueHash {
 
  public:
   uint64_t operator()(const float& key) const { return Reinterpret<float, uint32_t>(key); }
-  uint64_t operator()(const double& key) const { return Reinterpret<double, uint64_t>(key); }
+  uint64_t operator()(const double& key) const {
+    if (std::isnan(key)) {
+      // The IEEE format defines more than one bit-pattern that
+      // represents NaN.  For the purpose of comparing IR
+      // representations, all NaN values are considered equivalent.
+      return Reinterpret<double, uint64_t>(std::numeric_limits<double>::quiet_NaN());
+    } else {
+      return Reinterpret<double, uint64_t>(key);
+    }
+  }
   uint64_t operator()(const int64_t& key) const { return Reinterpret<int64_t, uint64_t>(key); }
   uint64_t operator()(const uint64_t& key) const { return key; }
   uint64_t operator()(const int& key) const { return Reinterpret<int, uint32_t>(key); }


### PR DESCRIPTION
Prior to this commit, `NaN` values did not have any special handling in either `StructuralEqual` or `StructuralHash`.

`StructuralEqual` checked whether the LHS and RHS were within some tolerance of each other.  If the LHS and RHS are both `NaN`, this would evaluate to false.  The updated `StructuralEqual` now checks for this case, and returns true if both sides are `NaN`.

`StructuralHash` used the bit-pattern of a floating-point number to compute the hash.  A `NaN` value may have any non-zero value in its mantissa, and so this could produce distinct hashes for ASTs that differ only by the choice of non-zero value.  The updated `StructuralHash` uses the same `std::numeric_limits<double::quiet_NaN()` value for all `NaN` values.

With these changes, `StructuralEqual` and `StructuralHash` can now compare two IR functions, even if they contain `NaN`.

Closes https://github.com/apache/tvm/issues/17247