### PR TITLE
[WebGPU] Fix unexpected device lost error when intentional dispose

### DIFF
--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -1122,7 +1122,7 @@ export class Instance implements Disposable {
     // ctx release goes back into lib.
     this.ctx.dispose();
     this.lib.dispose();
-    this.deviceLostIsError = true;
+    // Cannot set deviceLostIsError back to true here because GPUDevice.destroy() is asynchronous.
   }
 
   /**
@@ -2122,6 +2122,7 @@ export class Instance implements Disposable {
         this.dispose();
       }
     });
+    this.deviceLostIsError = true;
 
     const webGPUContext = new WebGPUContext(
       this.memory, device


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/apache/tvm/pull/17005. `deviceLostIsError` was introduced to make sure intentional `dispose()` (hence webgpu's `destroy()`) does not cause device lost callback to treat it as an error. However, we cannot set `deviceLostIsError` immediately to true after calling `this.lib.dispose()` (which calls `device.destroy()`) because WebGPU is asynchronous. Otherwise, we would trigger the device lost callback when calling `Instance.dispose()` to destroy device intentionally.