### PR TITLE
[Web] Add TVMArgBool to ArgTypeCode

### DIFF
--- a/web/src/ctypes.ts
+++ b/web/src/ctypes.ts
@@ -171,7 +171,7 @@ export type FTVMBackendPackedCFunc = (
 /**
  * int TVMObjectFree(TVMObjectHandle obj);
  */
- export type FTVMObjectFree = (obj: Pointer) => number;
+export type FTVMObjectFree = (obj: Pointer) => number;
 
 /**
  * int TVMObjectGetTypeIndex(TVMObjectHandle obj, unsigned* out_tindex);
@@ -252,5 +252,6 @@ export const enum ArgTypeCode {
   TVMStr = 11,
   TVMBytes = 12,
   TVMNDArrayHandle = 13,
-  TVMObjectRValueRefArg = 14
+  TVMObjectRValueRefArg = 14,
+  TVMArgBool = 15,
 }

--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -2473,6 +2473,7 @@ export class Instance implements Disposable {
     switch (tcode) {
       case ArgTypeCode.Int:
       case ArgTypeCode.UInt:
+      case ArgTypeCode.TVMArgBool:
         return this.memory.loadI64(rvaluePtr);
       case ArgTypeCode.Float:
         return this.memory.loadF64(rvaluePtr);


### PR DESCRIPTION
In a recent PR https://github.com/apache/tvm/pull/16183, `TVMArgTypeCode` introduced `TVMArgBool`. This PR is needed for the web runtime when a TVM packed function returns a bool.