### PR TITLE
[Relax][Transform] Handle tuple return in RemoveUnusedOutputs

### DIFF
--- a/tests/python/relax/test_transform_remove_unused_outputs.py
+++ b/tests/python/relax/test_transform_remove_unused_outputs.py
@@ -129,9 +129,9 @@ class TestReturnTuple(BaseCompare):
             return out_tuple
 
         @R.function(private=True)
-        def func(B: R.Tensor([16, 16], "int32")) -> R.Tuple(
-            R.Tensor([16, 16], "int32"), R.Tensor([16, 16], "int32")
-        ):
+        def func(
+            B: R.Tensor([16, 16], "int32")
+        ) -> R.Tuple(R.Tensor([16, 16], "int32"), R.Tensor([16, 16], "int32")):
             C = R.multiply(B, B)
             D = R.add(B, B)
             return (C, D)

--- a/tests/python/relax/test_transform_remove_unused_outputs.py
+++ b/tests/python/relax/test_transform_remove_unused_outputs.py
@@ -119,5 +119,25 @@ class TestMultipleCallSites(BaseCompare):
             return (A, C)
 
 
+class TestReturnTuple(BaseCompare):
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(A: R.Tensor([16, 16], "int32")):
+            B = R.add(A, A)
+            out_tuple = Before.func(B)
+            return out_tuple
+
+        @R.function(private=True)
+        def func(B: R.Tensor([16, 16], "int32")) -> R.Tuple(
+            R.Tensor([16, 16], "int32"), R.Tensor([16, 16], "int32")
+        ):
+            C = R.multiply(B, B)
+            D = R.add(B, B)
+            return (C, D)
+
+    Expected = Before
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Prior to this commit, the `relax.transform.RemoveUnusedOutputs` pass only marked a tuple element as used if it occurred in a `TupleGetItem` node.  This ignored use cases where a tuple is used as an aggregate object, such as returning a tuple from a function.  This would collect incorrect results for a Relax function that calls a subroutine, receives a tuple as the return value of the subroutine, then returns that tuple.

This commit updates `RemoveUnusedOutputs` to look for usage of a tuple object, not just for usage in `TupleGetItem`.

Closes https://github.com/apache/tvm/issues/17247