### PR TITLE
[CI] Resolve CI compilation failures on MacOSX

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -33,3 +33,5 @@ runs:
     run: |
       conda info
       conda list
+      conda info --envs
+      conda list --name base

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,7 +15,7 @@ runs:
       channel-priority: strict
       environment-file: conda/build-environment.yaml
       auto-activate-base: false
-      auto-update-conda: true
+      conda-solver: classic
       use-only-tar-bz2: true
       python-version: 3.9
       condarc-file: conda/condarc
@@ -26,7 +26,7 @@ runs:
       channel-priority: strict
       environment-file: conda/build-environment.yaml
       auto-activate-base: false
-      auto-update-conda: true
+      conda-solver: classic
       use-only-tar-bz2: true
       python-version: 3.9
       condarc-file: conda/condarc

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,6 +15,7 @@ runs:
       channel-priority: strict
       environment-file: conda/build-environment.yaml
       auto-activate-base: false
+      auto-update-conda: true
       use-only-tar-bz2: true
       python-version: 3.9
       condarc-file: conda/condarc
@@ -25,6 +26,7 @@ runs:
       channel-priority: strict
       environment-file: conda/build-environment.yaml
       auto-activate-base: false
+      auto-update-conda: true
       use-only-tar-bz2: true
       python-version: 3.9
       condarc-file: conda/condarc

--- a/conda/build-environment.yaml
+++ b/conda/build-environment.yaml
@@ -26,7 +26,6 @@ channels:
 # The packages to install to the environment
 dependencies:
   - python=3.9
-  - conda >= 23.10
   - conda-build
   - git
   - llvmdev >=11

--- a/conda/build-environment.yaml
+++ b/conda/build-environment.yaml
@@ -26,6 +26,7 @@ channels:
 # The packages to install to the environment
 dependencies:
   - python=3.9
+  - conda >= 23.10
   - conda-build
   - git
   - llvmdev >=11

--- a/conda/build_win.bat
+++ b/conda/build_win.bat
@@ -15,4 +15,6 @@
 :: specific language governing permissions and limitations
 :: under the License.
 
-conda build --output-folder=conda/pkg conda/recipe
+echo on
+
+conda build --output-folder=conda/pkg conda/recipe || exit /b

--- a/conda/recipe/bld.bat
+++ b/conda/recipe/bld.bat
@@ -32,7 +32,7 @@ cmake ^
       -DUSE_RANDOM=ON ^
       -DUSE_PROFILER=ON ^
       -DINSTALL_DEV=ON ^
-      %SRC_DIR%
+      %SRC_DIR% || exit /b
 
 cd ..
 :: defer build to install stage to avoid rebuild.

--- a/conda/recipe/install_libtvm.bat
+++ b/conda/recipe/install_libtvm.bat
@@ -15,8 +15,10 @@
 :: specific language governing permissions and limitations
 :: under the License.
 
+echo on
+
 cmake --build build --config Release --target install || exit /b
 
 :: Copy files into library bin so that they can be found
-cp %LIBRARY_LIB%\tvm.dll %LIBRARY_BIN%\tvm.dll
-cp %LIBRARY_LIB%\tvm_runtime.dll %LIBRARY_BIN%\tvm_runtime.dll
+cp %LIBRARY_LIB%\tvm.dll %LIBRARY_BIN%\tvm.dll || exit /b
+cp %LIBRARY_LIB%\tvm_runtime.dll %LIBRARY_BIN%\tvm_runtime.dll || exit /b

--- a/conda/recipe/install_libtvm.bat
+++ b/conda/recipe/install_libtvm.bat
@@ -15,7 +15,7 @@
 :: specific language governing permissions and limitations
 :: under the License.
 
-cmake --build build --config Release --target install
+cmake --build build --config Release --target install || exit /b
 
 :: Copy files into library bin so that they can be found
 cp %LIBRARY_LIB%\tvm.dll %LIBRARY_BIN%\tvm.dll

--- a/conda/recipe/install_tvm_python.bat
+++ b/conda/recipe/install_tvm_python.bat
@@ -16,5 +16,5 @@
 :: under the License.
 echo on
 
-cd %SRC_DIR%\python
-%PYTHON% setup.py install --single-version-externally-managed --record=%SRC_DIR%\record.txt
+cd %SRC_DIR%\python || exit /b
+%PYTHON% setup.py install --single-version-externally-managed --record=%SRC_DIR%\record.txt || exit /b


### PR DESCRIPTION
The build on main failed [link](https://github.com/apache/tvm/actions/runs/10351996240/job/28661217963) with the following error message.  This first occurred in the post-merge build of #17257, but the failure mode (error message below) doesn't appear related to the changes in that commit.

```
conda.exceptions.CondaValueError: You have chosen a non-default solver backend (libmamba) but it was not recognized.
```