### PR TITLE
[CI][Windows] Workaround for error in Findzstd.cmake

### DIFF
--- a/cmake/utils/FindLLVM.cmake
+++ b/cmake/utils/FindLLVM.cmake
@@ -44,6 +44,15 @@ macro(find_llvm use_llvm)
   endif()
 
   if(${LLVM_CONFIG} MATCHES ${IS_TRUE_PATTERN})
+    # This is a workaround for an upstream LLVM issue [0], in which
+    # the `CMAKE_INSTALL_LIBDIR` variable is used before definition.
+    # While there is an LLVM PR to resolve this fix [1], as of
+    # 2024-08-19 it has not yet been merged to LLVM.
+    #
+    # [0] https://github.com/llvm/llvm-project/issues/83802
+    # [1] https://github.com/llvm/llvm-project/pull/83807
+    include(GNUInstallDirs)
+
     find_package(LLVM ${llvm_version_required} REQUIRED CONFIG)
     llvm_map_components_to_libnames(LLVM_LIBS "all")
     if (NOT LLVM_LIBS)


### PR DESCRIPTION
This is a workaround for an upstream LLVM issue [0], which looks to be caused by the `CMAKE_INSTALL_LIBDIR` variable is used before definition.  While there is an LLVM PR to resolve this fix [1], as of 2024-08-19 it has not yet been merged to LLVM.

This change is intended to resolve the following error, which occurs during the CI build of TVM on Windows.

```
The system cannot find the file specified.
CMake Error at C:/Miniconda/envs/tvm-build/conda-bld/tvm-package_1723747883202/_h_env/Library/lib/cmake/llvm/Findzstd.cmake:39 (string):
  string sub-command REGEX, mode REPLACE: regex "$" matched an empty string.
Call Stack (most recent call first):
  C:/Miniconda/envs/tvm-build/conda-bld/tvm-package_1723747883202/_h_env/Library/lib/cmake/llvm/LLVMConfig.cmake:277 (find_package)
  cmake/utils/FindLLVM.cmake:47 (find_package)
  cmake/modules/LLVM.cmake:31 (find_llvm)
  CMakeLists.txt:565 (include)
```

[0] https://github.com/llvm/llvm-project/issues/83802
[1] https://github.com/llvm/llvm-project/pull/83807