### PR TITLE
[Rust] Remove mxnet dependency and re-enable rust example

### DIFF
--- a/rust/tvm/README.md
+++ b/rust/tvm/README.md
@@ -26,7 +26,7 @@ You can find the API Documentation [here](https://tvm.apache.org/docs/api/rust/t
 
 The goal of this crate is to provide bindings to both the TVM compiler and runtime
 APIs. First train your **Deep Learning** model using any major framework such as
-[PyTorch](https://pytorch.org/), [Apache MXNet](https://mxnet.apache.org/) or [TensorFlow](https://www.tensorflow.org/).
+[PyTorch](https://pytorch.org/) or [TensorFlow](https://www.tensorflow.org/).
 Then use **TVM** to build and deploy optimized model artifacts on a supported devices such as CPU, GPU, OpenCL and specialized accelerators.
 
 The Rust bindings are composed of a few crates:

--- a/rust/tvm/examples/resnet/README.md
+++ b/rust/tvm/examples/resnet/README.md
@@ -21,7 +21,7 @@ This end-to-end example shows how to:
 * build `Resnet 18` with `tvm` from Python
 * use the provided Rust frontend API to test for an input image
 
-To run the example with pretrained resnet weights, first `tvm`  and `mxnet` must be installed for the python build. To install mxnet for cpu, run `pip install mxnet`
+To run the example with pretrained resnet weights, first `tvm`  and `torchvision` must be installed for the python build. To install torchvision for cpu, run `pip install torch torchvision`
 and to install `tvm` with `llvm` follow the [TVM installation guide](https://tvm.apache.org/docs/install/index.html).
 
 * **Build the example**: `cargo build

--- a/rust/tvm/examples/resnet/build.rs
+++ b/rust/tvm/examples/resnet/build.rs
@@ -21,10 +21,6 @@ use anyhow::{Context, Result};
 use std::{io::Write, path::Path, process::Command};
 
 fn main() -> Result<()> {
-    // Currently disabled, as it depends on the no-longer-supported
-    // mxnet repo to download resnet.
-
-    /*
     let out_dir = std::env::var("CARGO_MANIFEST_DIR")?;
     let python_script = concat!(env!("CARGO_MANIFEST_DIR"), "/src/build_resnet.py");
     let synset_txt = concat!(env!("CARGO_MANIFEST_DIR"), "/synset.txt");
@@ -56,8 +52,6 @@ fn main() -> Result<()> {
             .unwrap_or("")
     );
     println!("cargo:rustc-link-search=native={}", out_dir);
-
-    */
 
     Ok(())
 }

--- a/rust/tvm/examples/resnet/src/main.rs
+++ b/rust/tvm/examples/resnet/src/main.rs
@@ -31,10 +31,6 @@ use tvm_rt::graph_rt::GraphRt;
 use tvm_rt::*;
 
 fn main() -> anyhow::Result<()> {
-    // Currently disabled, as it depends on the no-longer-supported
-    // mxnet repo to download resnet.
-
-    /*
     let dev = Device::cpu(0);
     println!("{}", concat!(env!("CARGO_MANIFEST_DIR"), "/cat.png"));
 
@@ -138,7 +134,6 @@ fn main() -> anyhow::Result<()> {
         "input image belongs to the class `{}` with probability {}",
         label, max_prob
     );
-    */
 
     Ok(())
 }


### PR DESCRIPTION
Replace mxnet's resnet18 with torchvision.
Clean up import statements in `rust/tvm/examples/resnet/src/build_resnet.py`.
Related PR and Issue:
- #16546 
- #16572 
- #16547 

cc: @Hzfengsy @tqchen @cgerum 