### PR TITLE
[Apps] Remove mxnet dependency from /apps/android_camera/models

### DIFF
--- a/apps/android_camera/models/prepare_model.py
+++ b/apps/android_camera/models/prepare_model.py
@@ -15,18 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
-import pathlib
-from pathlib import Path
-from typing import Union
+import json
 import os
 from os import environ
-import json
+from pathlib import Path
+from typing import Union
 
 import tvm
 import tvm.relay as relay
-from tvm.contrib import utils, ndk, graph_executor as runtime
-from tvm.contrib.download import download_testdata, download
+from tvm.contrib import ndk
+from tvm.contrib.download import download, download_testdata
 
 target = "llvm -mtriple=arm64-linux-android"
 target_host = None

--- a/apps/android_camera/models/requirements.txt
+++ b/apps/android_camera/models/requirements.txt
@@ -1,4 +1,5 @@
 keras==2.9
-mxnet
 scipy
 tensorflow==2.9.3
+torch
+torchvision


### PR DESCRIPTION
As per title.
I'll leave mobilenet_v2 part as it is but we could remove keras dependency since torchvision provides a mobilenet_v2 pretrained model. Not sure which is better.

Related issue and pr:
- #16547 
- #17293 

cc: @Hzfengsy @tqchen 