### PR TITLE
[TVM4J][BugFix] Fix unhandled return type in JNI

### DIFF
--- a/jvm/native/src/main/native/jni_helper_func.h
+++ b/jvm/native/src/main/native/jni_helper_func.h
@@ -188,6 +188,7 @@ jobject tvmRetValueToJava(JNIEnv* env, TVMValue value, int tcode) {
   switch (tcode) {
     case kDLUInt:
     case kDLInt:
+    case kTVMArgBool:
       return newTVMValueLong(env, static_cast<jlong>(value.v_int64));
     case kDLFloat:
       return newTVMValueDouble(env, static_cast<jdouble>(value.v_float64));


### PR DESCRIPTION
Fix crash caused by unhandled return type of `kTVMArgBool`