### PR TITLE
[Relax][Bugfix] Infer TIR values from shapes inside a tuple

### DIFF
--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -253,6 +253,40 @@ def test_replace_symbolic_variable_and_remove_match_cast():
     verify(TestChangeShape, Expected)
 
 
+def test_replace_symbolic_variable_and_remove_match_cast_of_tuple():
+    """Symbolic variables may be defined in R.match_cast of tuple
+
+    This test is similar to
+    `test_replace_symbolic_variable_and_remove_match_cast`, except
+    that the MatchCast is performed on a Relax tuple.
+
+    This is a regression test.  Earlier implementations only inferred
+    TIR variables from `R.match_cast` of tensors, shapes, and prim
+    values, but omitted tuples.
+
+    """
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tuple(R.Tensor(("m", "n")))):
+            y = x
+            o, p = T.int64(), T.int64()
+            z = R.match_cast(x, R.Tuple(R.Tensor((o, p))))
+            w = z
+            q = R.add(w[0], y[0])
+            return R.add(q, w[0])
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tuple(R.Tensor(("m", "n")))):
+            q = R.add(x[0], x[0])
+            return R.add(q, x[0])
+
+    verify(Before, Expected)
+
+
 def test_unwrap_tuple():
     @I.ir_module
     class Before:


### PR DESCRIPTION
If a Relax function contains an `R.match_cast` that defines a symbolic shape, and the value provided to the `R.match_cast` has a known static shape, the `relax.transform.CanoncalizeBindings()` pass can in-line the known static shape.  However, while these known TIR values were only collected if the expression used in `R.match_cast` was a `R.Tensor`, `R.Shape`, and `R.Prim` (Relax types which may contain symbolic TIR values), they were not collected if the `R.match_cast` expression was a `R.Tuple`.

For example, while using `R.match_cast` to convert from `R.Tensor([16])` to `R.Tensor([batch_size])` would identify that `batch_size` must be `16`, using `R.match_cast` to convert from `R.Tuple(R.Tensor([16]))` to `R.Tuple(R.Tensor([batch_size]))` would not.

This commit updates the `InferSymbolicVarMap` to collect all symbolic shapes, even if they occur within a `R.Tuple`.