### PR TITLE
[Test] Skip flaky Relay LSTM test

### DIFF
--- a/tests/python/relay/test_to_mixed_precision.py
+++ b/tests/python/relay/test_to_mixed_precision.py
@@ -98,6 +98,7 @@ def test_lstm(target_precision):
     )
 
 
+@pytest.mark.skip(reason="flaky test")
 def test_lstm_float64():
     """Tests if can handle other mixed precision types.
 


### PR DESCRIPTION
The Relay LSTM test has been flaly for the ARM CI for quite a while. This PR marks this particular test as skipped.