### PR TITLE
[Fix] Remove `tvm.` prefix from image name when `./docker/build.sh`

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -110,7 +110,7 @@ tasks.
 - lint the python codes
 
   ```bash
-  ./docker/build.sh tvm.ci_lint make pylint
+  ./docker/build.sh ci_lint make pylint
   ```
 
 - build codes with CUDA support


### PR DESCRIPTION
As per title.
cc @tqchen @Hzfengsy 