### PR TITLE
[Relax][PyTorch][Bugfix] Update `layer_norm` converter to support `immutable_list` for `normalized_shape`

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1069,6 +1069,7 @@ class TorchFXImporter:
 
     def _layer_norm(self, node: fx.node.Node) -> relax.Var:
         import torch  # type: ignore
+        from torch.fx.immutable_collections import immutable_list
         import numpy as np  # type: ignore
 
         x = self.env[node.args[0]]
@@ -1077,8 +1078,8 @@ class TorchFXImporter:
         if node.target not in self.named_modules:
             # static or symbolic
             arg = node.args[1]
-            if isinstance(arg, tuple):
-                value = arg
+            if isinstance(arg, (immutable_list, tuple)):
+                value = tuple(arg)
             else:
                 try:
                     value = self.env[arg]


### PR DESCRIPTION
With torch==2.4, the `normalized_shape` argument of the `torch.nn.functional.layer_norm` can be `torch.fx.immutable_collections.immutable_list`.
This PR update the layer_norm conveter to cast it to tuple when the `normalized_shape` is `immutable_list`.

```
>       verify_model(model, input_info, binding, expected3)

tests/python/relax/test_frontend_from_fx.py:1323: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/python/relax/test_frontend_from_fx.py:36: in verify_model
    mod = from_fx(graph_model, input_info)
python/tvm/relax/frontend/torch/fx_translator.py:1770: in from_fx
    return TorchFXImporter().from_fx(
python/tvm/relax/frontend/torch/fx_translator.py:1653: in from_fx
    self.env[node] = self.convert_map[func_name](node)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tvm.relax.frontend.torch.fx_translator.TorchFXImporter object at 0x778d11543da0>, node = layer_norm

    def _layer_norm(self, node: fx.node.Node) -> relax.Var:
        import torch  # type: ignore
        import numpy as np  # type: ignore
    
        x = self.env[node.args[0]]
    
        # functional.layer_norm
        if node.target not in self.named_modules:
            # static or symbolic
            arg = node.args[1]
            if isinstance(arg, tuple):
                value = arg
            else:
                try:
>                   value = self.env[arg]
E                   KeyError: [10, 10]

python/tvm/relax/frontend/torch/fx_translator.py:1084: KeyError
```

cc @vinx13 @yongwww @Hzfengsy 