### PR TITLE
[CI] Upgrade PyTorch to 2.4.1

### DIFF
--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -36,6 +36,6 @@ pip3 install \
 pip3 install future
 
 pip3 install \
-    torch==2.0.0 \
-    torchvision==0.15.1 \
+    torch==2.4.1 \
+    torchvision==0.19.1 \
     --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Part of #17346 
PyTorch 2.3 has some changes to the `ExportedProgram` so we would like to update it at least 2.3 or above.
https://github.com/pytorch/pytorch/releases/tag/v2.3.0