### PR TITLE
[relay][qnn]: Fix qnn.avg_pool2d layout inference

### DIFF
--- a/src/relay/qnn/op/avg_pool2d.cc
+++ b/src/relay/qnn/op/avg_pool2d.cc
@@ -132,9 +132,11 @@ InferCorrectLayoutOutput QnnAvgPoolInferCorrectLayout(const Attrs& attrs,
   auto avgpool_new_layouts =
       PoolInferCorrectLayout<AvgPool2DAttrs>(attrs, new_in_layouts, old_in_layouts, old_in_types);
 
-  // Scales and zero points are scalars, use the "undef" layout for them.
-  Array<Layout> input_layouts = {avgpool_new_layouts->input_layouts[0], Layout::Undef(),
-                                 Layout::Undef(), Layout::Undef(), Layout::Undef()};
+  // Scales and zero points are scalars, the layouts of these tensors can be treated as channel
+  // layout.
+  Layout channel_layout = Layout("C");
+  Array<Layout> input_layouts = {avgpool_new_layouts->input_layouts[0], channel_layout,
+                                 channel_layout, channel_layout, channel_layout};
   Array<Layout> output_layouts = avgpool_new_layouts->output_layouts;
   return InferCorrectLayoutOutput(input_layouts, output_layouts, attrs);
 }


### PR DESCRIPTION
**Issue:**
Currently the qnn.avg_pool2d operator does not take the layout specified with the Convert Layout pass.
 
**Cause:**
The layout of the zero point and scale tensors are specified as "undefined". This causes the Convert Layout pass to bail and maintain the original layout.

**Fix:**
The fix updates the layouts for the scale and zero point tensors to be "channel" layout, similar to how it is done for qnn.conv2d.

**Testing:**
Added unit test