### PR TITLE
[LLVM][RUNTIME] Fix RISC-V CodeModel propagation to ORCJIT runtime executor

### DIFF
--- a/src/target/llvm/llvm_instance.h
+++ b/src/target/llvm/llvm_instance.h
@@ -216,6 +216,16 @@ class LLVMTargetInfo {
    */
   const llvm::TargetOptions& GetTargetOptions() const { return target_options_; }
   /*!
+   * \brief Get the LLVM target reloc model
+   * \return `llvm::Reloc::Model` object for this target
+   */
+  const llvm::Reloc::Model& GetTargetRelocModel() const { return reloc_model_; }
+  /*!
+   * \brief Get the LLVM target code model
+   * \return `llvm::CodeModel::Model` object for this target
+   */
+  const llvm::CodeModel::Model& GetTargetCodeModel() const { return code_model_; }
+  /*!
    * \brief Get fast math flags
    * \return `llvm::FastMathFlags` for this target
    */

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -482,6 +482,14 @@ void LLVMModuleNode::InitORCJIT() {
   tm_builder.setCodeGenOptLevel(llvm::CodeGenOptLevel::Aggressive);
 #endif
 
+  // Default is no explicit JIT code & reloc model
+  // Propagate instance code & reloc for RISCV case.
+  auto arch = tm_builder.getTargetTriple().getArch();
+  if (arch == llvm::Triple::riscv32 || arch == llvm::Triple::riscv64) {
+    tm_builder.setRelocationModel(llvm_target->GetTargetRelocModel());
+    tm_builder.setCodeModel(llvm_target->GetTargetCodeModel());
+  }
+
   // create the taget machine
   std::unique_ptr<llvm::TargetMachine> tm = llvm::cantFail(tm_builder.createTargetMachine());
   if (!IsCompatibleWithHost(tm.get())) {


### PR DESCRIPTION
This PR fixes ORCJIT link failures for RISC-V targets by properly setting the code model on the executor.

---

Initial bug report is here: https://discuss.tvm.apache.org/t/run-tvm-software-stack-on-risc-v/17683

#### Rationale

* RISC-V recommended and required code model was set already here, but was ignored: https://github.com/apache/tvm/blob/e468426bfd43fadb555ef0e561b9047a5d89852e/src/target/llvm/llvm_instance.cc#L276-L280
* RISC-V targets will work only with the newer ORCJIT engine as described in [PR#15964]( https://github.com/apache/tvm/pull/15964)
* This PR adds missing code model settings for the ORCJIT engine.

In case of RISC-V, by not setting the code model to explicit ```Medium``` may give ralocation ```R_RISCV_HI20``` errors.

Cc: @Lunderberg , @ekalda , @lhutton1 , @quic-sanirudh ,  @tqchen
Cc: @katebern-grovety , @PhilippvK

---

#### LATER UPDATE (due to unexpected i386 failure):

  * This PR propagates explicit code/reloc model *only* for RISC-V arches.
  * Just as before, by default will leave the ORCJIT to decide the best code/reloc
  * Same JIT setup, and RISCV case handling can be seen in the [Halide ORCJIT](https://github.com/halide/Halide/blob/eb66c06539d623459ea3c3abeea5b7cce111ad5f/src/JITModule.cpp#L342-L344)

