### PR TITLE
Fix the connection between server and tracker when using WSL2

### DIFF
--- a/python/tvm/exec/rpc_server.py
+++ b/python/tvm/exec/rpc_server.py
@@ -19,6 +19,21 @@
 import argparse
 import logging
 from .. import rpc
+import socket
+
+
+def get_local_ip():
+    try:
+        # create UDP socket
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        # connect to a outer server, but we don't send data
+        s.connect(("8.8.8.8", 80))
+        # get local ip
+        local_ip = s.getsockname()[0]
+        s.close()
+        return local_ip
+    except Exception:
+        return None
 
 
 def main(args):
@@ -37,7 +52,13 @@ def main(args):
             raise RuntimeError("Need key to present type of resource when tracker is available")
     else:
         tracker_addr = None
-
+    external_ip = get_local_ip()
+    
+    # 
+    if external_ip and not args.custom_addr:
+        custom_addr = f"{external_ip}"
+    else:
+        custom_addr = args.custom_addr
     server = rpc.Server(
         args.host,
         args.port,
@@ -46,7 +67,7 @@ def main(args):
         key=args.key,
         tracker_addr=tracker_addr,
         load_library=args.load_library,
-        custom_addr=args.custom_addr,
+        custom_addr=custom_addr,
         silent=args.silent,
         no_fork=not args.fork,
     )


### PR DESCRIPTION
There is a bug when we use WSL2 or other virtual machine in NAT mode as host, the host can find the device easily, but when device respond to the host, it will lose the device ip address, in this case, host will just try to find a IP that is used for visiting from virtual machine(e,g, WSL2, 172.xxx.xxx.xxx) to physical host, this IP cannot be used to visit device, this will make the server in device  print"no incoming connections ", because the host cannot find the device

To fix the bug, I just pass the real IP of device to host,which can solve this problem. But this fix need Internet to get device IP, I wonder if there is a better way. 
![image](https://github.com/user-attachments/assets/27c415d8-490f-4d1b-8141-dfa5ee3af749)
