### PR TITLE
TVM pip Installation fix

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -145,8 +145,8 @@ Leaving the build environment ``tvm-build-venv``, there are two ways to install 
 
     conda activate your-own-env
     conda install python # make sure python is installed
-    cd /path-to-tvm/python
-    pip install -e .
+    export TVM_LIBRARY_PATH=/path/to/tvm/build
+    pip install -e /path-to-tvm/python    
 
 Step 4. Validate Installation
 -----------------------------


### PR DESCRIPTION
After successfully building tvm on Apple Silicon, I wasn't able to get `pip install` working. It did not find `libtvm.dylib`. Specifying TVM_LIBRARY_PATH seems to fix the issue

<details class="my-class" id="my-id">
  <summary>Original way (Failed):</summary>

``` fish
> pip install -e /Volumes/code/AI/tvm_experiments/libs/tvm/python/  (tvm-build-venv)

Obtaining file:///Volumes/code/AI/tvm_experiments/libs/tvm/python
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [81 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/Volumes/code/AI/tvm_experiments/libs/tvm/python/setup.py", line 144, in <module>
          LIB_LIST, __version__ = get_lib_path()
                                  ^^^^^^^^^^^^^^
        File "/Volumes/code/AI/tvm_experiments/libs/tvm/python/setup.py", line 51, in get_lib_path
          lib_path = libinfo["find_lib_path"]()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Volumes/code/AI/tvm_experiments/libs/tvm/python/./tvm/_ffi/libinfo.py", line 166, in find_lib_path
          raise RuntimeError(message)
      RuntimeError: Cannot find libraries: ['libtvm.dylib', 'libtvm_runtime.dylib', '3rdparty/cutlass_fpA_intB_gemm/cutlass_kernels/libfpA_intB_gemm.dylib', '3rdparty/libflash_attn/src/libflash_attn.dylib']
      List of candidates:
      /opt/homebrew/Caskroom/miniconda/base/envs/tvm-build-venv/bin/libtvm.dylib
      /opt/homebrew/Caskroom/miniconda/base/condabin/libtvm.dylib
      /Users/viranchee/.cursor/extensions/ms-python.python-2024.12.3-darwin-arm64/python_files/deactivate/fish/libtvm.dylib
      /Volumes/code/AI/tvm_experiments/pipenv/bin/libtvm.dylib
      /Users/viranchee/.modular/pkg/packages.modular.com_max/bin/libtvm.dylib
      /Users/viranchee/.modular/pkg/packages.modular.com_mojo/bin/libtvm.dylib
      /opt/homebrew/Cellar/bison/3.8.2/bin/libtvm.dylib
      /opt/homebrew/Cellar/llvm/18.1.8/bin/libtvm.dylib
      /usr/local/bin/libtvm.dylib
      /System/Volumes/Preboot/Cryptexes/App/usr/bin/libtvm.dylib
      /usr/bin/libtvm.dylib
      /bin/libtvm.dylib
      /usr/sbin/libtvm.dylib
      /sbin/libtvm.dylib
      /Library/Apple/usr/bin/libtvm.dylib
      /opt/homebrew/sbin/libtvm.dylib
      /opt/homebrew/bin/libtvm.dylib
      /Users/viranchee/.modular/pkg/packages.modular.com_max/bin/libtvm.dylib
      /Users/viranchee/.modular/pkg/packages.modular.com_mojo/bin/libtvm.dylib
      /opt/homebrew/Cellar/bison/3.8.2/bin/libtvm.dylib
      /opt/homebrew/Cellar/llvm/18.1.8/bin/libtvm.dylib
      /usr/local/bin/libtvm.dylib
      /System/Volumes/Preboot/Cryptexes/App/usr/bin/libtvm.dylib
      /usr/bin/libtvm.dylib
      /bin/libtvm.dylib
      /usr/sbin/libtvm.dylib
      /sbin/libtvm.dylib
      /Library/Apple/usr/bin/libtvm.dylib
      /Users/viranchee/.cursor/extensions/ms-python.python-2024.12.3-darwin-arm64/python_files/deactivate/fish/libtvm.dylib
      /Volumes/code/AI/tvm_experiments/pipenv/bin/libtvm.dylib
      /opt/homebrew/sbin/libtvm.dylib
      /opt/homebrew/bin/libtvm.dylib
      /Volumes/code/AI/tvm_experiments/libs/tvm/python/tvm/libtvm.dylib
      /Volumes/code/AI/tvm_experiments/libs/libtvm.dylib
      /opt/homebrew/Caskroom/miniconda/base/envs/tvm-build-venv/bin/libtvm_runtime.dylib
      /opt/homebrew/Caskroom/miniconda/base/condabin/libtvm_runtime.dylib
      /Users/viranchee/.cursor/extensions/ms-python.python-2024.12.3-darwin-arm64/python_files/deactivate/fish/libtvm_runtime.dylib
      /Volumes/code/AI/tvm_experiments/pipenv/bin/libtvm_runtime.dylib
      /Users/viranchee/.modular/pkg/packages.modular.com_max/bin/libtvm_runtime.dylib
      /Users/viranchee/.modular/pkg/packages.modular.com_mojo/bin/libtvm_runtime.dylib
      /opt/homebrew/Cellar/bison/3.8.2/bin/libtvm_runtime.dylib
      /opt/homebrew/Cellar/llvm/18.1.8/bin/libtvm_runtime.dylib
      /usr/local/bin/libtvm_runtime.dylib
      /System/Volumes/Preboot/Cryptexes/App/usr/bin/libtvm_runtime.dylib
      /usr/bin/libtvm_runtime.dylib
      /bin/libtvm_runtime.dylib
      /usr/sbin/libtvm_runtime.dylib
      /sbin/libtvm_runtime.dylib
      /Library/Apple/usr/bin/libtvm_runtime.dylib
      /opt/homebrew/sbin/libtvm_runtime.dylib
      /opt/homebrew/bin/libtvm_runtime.dylib
      /Users/viranchee/.modular/pkg/packages.modular.com_max/bin/libtvm_runtime.dylib
      /Users/viranchee/.modular/pkg/packages.modular.com_mojo/bin/libtvm_runtime.dylib
      /opt/homebrew/Cellar/bison/3.8.2/bin/libtvm_runtime.dylib
      /opt/homebrew/Cellar/llvm/18.1.8/bin/libtvm_runtime.dylib
      /usr/local/bin/libtvm_runtime.dylib
      /System/Volumes/Preboot/Cryptexes/App/usr/bin/libtvm_runtime.dylib
      /usr/bin/libtvm_runtime.dylib
      /bin/libtvm_runtime.dylib
      /usr/sbin/libtvm_runtime.dylib
      /sbin/libtvm_runtime.dylib
      /Library/Apple/usr/bin/libtvm_runtime.dylib
      /Users/viranchee/.cursor/extensions/ms-python.python-2024.12.3-darwin-arm64/python_files/deactivate/fish/libtvm_runtime.dylib
      /Volumes/code/AI/tvm_experiments/pipenv/bin/libtvm_runtime.dylib
      /opt/homebrew/sbin/libtvm_runtime.dylib
      /opt/homebrew/bin/libtvm_runtime.dylib
      /Volumes/code/AI/tvm_experiments/libs/tvm/python/tvm/libtvm_runtime.dylib
      /Volumes/code/AI/tvm_experiments/libs/libtvm_runtime.dylib
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

```
</details>

With $`TVM_LIBRARY_PATH` environment variable

``` fish
❯ export TVM_LIBRARY_PATH=/Volumes/code/AI/tvm_experiments/libs/tvm/buildconda/  (tvm-build-venv) 

❯ pip install -e /Volumes/code/AI/tvm_experiments/libs/tvm/python  (tvm-build-venv) 

Obtaining file:///Volumes/code/AI/tvm_experiments/libs/tvm/python
  Preparing metadata (setup.py) ... done
Collecting attrs (from tvm==0.18.dev124+g35fdf8b16)
  Downloading attrs-24.2.0-py3-none-any.whl.metadata (11 kB)
Collecting cloudpickle (from tvm==0.18.dev124+g35fdf8b16)
  Downloading cloudpickle-3.0.0-py3-none-any.whl.metadata (7.0 kB)
Collecting decorator (from tvm==0.18.dev124+g35fdf8b16)
  Using cached decorator-5.1.1-py3-none-any.whl.metadata (4.0 kB)
Collecting ml_dtypes (from tvm==0.18.dev124+g35fdf8b16)
  Using cached ml_dtypes-0.4.0-cp311-cp311-macosx_10_9_universal2.whl.metadata (20 kB)
Collecting numpy (from tvm==0.18.dev124+g35fdf8b16)
  Downloading numpy-2.1.1-cp311-cp311-macosx_14_0_arm64.whl.metadata (60 kB)
Collecting packaging (from tvm==0.18.dev124+g35fdf8b16)
  Using cached packaging-24.1-py3-none-any.whl.metadata (3.2 kB)
Collecting psutil (from tvm==0.18.dev124+g35fdf8b16)
  Using cached psutil-6.0.0-cp38-abi3-macosx_11_0_arm64.whl.metadata (21 kB)
Collecting scipy (from tvm==0.18.dev124+g35fdf8b16)
  Downloading scipy-1.14.1-cp311-cp311-macosx_14_0_arm64.whl.metadata (60 kB)
Collecting tornado (from tvm==0.18.dev124+g35fdf8b16)
  Using cached tornado-6.4.1-cp38-abi3-macosx_10_9_universal2.whl.metadata (2.5 kB)
Collecting typing_extensions (from tvm==0.18.dev124+g35fdf8b16)
  Using cached typing_extensions-4.12.2-py3-none-any.whl.metadata (3.0 kB)
Downloading attrs-24.2.0-py3-none-any.whl (63 kB)
Downloading cloudpickle-3.0.0-py3-none-any.whl (20 kB)
Using cached decorator-5.1.1-py3-none-any.whl (9.1 kB)
Using cached ml_dtypes-0.4.0-cp311-cp311-macosx_10_9_universal2.whl (390 kB)
Downloading numpy-2.1.1-cp311-cp311-macosx_14_0_arm64.whl (5.4 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.4/5.4 MB 9.3 MB/s eta 0:00:00
Using cached packaging-24.1-py3-none-any.whl (53 kB)
Using cached psutil-6.0.0-cp38-abi3-macosx_11_0_arm64.whl (251 kB)
Downloading scipy-1.14.1-cp311-cp311-macosx_14_0_arm64.whl (23.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 23.1/23.1 MB 26.0 MB/s eta 0:00:00
Using cached tornado-6.4.1-cp38-abi3-macosx_10_9_universal2.whl (435 kB)
Using cached typing_extensions-4.12.2-py3-none-any.whl (37 kB)
Installing collected packages: typing_extensions, tornado, psutil, packaging, numpy, decorator, cloudpickle, attrs, scipy, ml_dtypes, tvm
  DEPRECATION: Legacy editable install of tvm==0.18.dev124+g35fdf8b16 from file:///Volumes/code/AI/tvm_experiments/libs/tvm/python (setup.py develop) is deprecated. pip 25.0 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457
  Running setup.py develop for tvm
Successfully installed attrs-24.2.0 cloudpickle-3.0.0 decorator-5.1.1 ml_dtypes-0.4.0 numpy-2.1.1 packaging-24.1 psutil-6.0.0 scipy-1.14.1 tornado-6.4.1 tvm-0.18.dev124+g35fdf8b16 typing_extensions-4.12.2
```