### PR TITLE
[IR] Expose ReplaceGlobalVars utility in the Python API

### DIFF
--- a/include/tvm/ir/replace_global_vars.h
+++ b/include/tvm/ir/replace_global_vars.h
@@ -41,7 +41,7 @@ namespace transform {
  *
  * \return The updated IRModule
  */
-TVM_DLL IRModule ReplaceGlobalVar(IRModule mod, Map<GlobalVar, GlobalVar> replacements);
+TVM_DLL IRModule ReplaceGlobalVars(IRModule mod, Map<GlobalVar, GlobalVar> replacements);
 
 struct GlobalVarReplacer {
   using FType = NodeFunctor<BaseFunc(const ObjectRef&, Map<GlobalVar, GlobalVar>)>;

--- a/include/tvm/ir/replace_global_vars.h
+++ b/include/tvm/ir/replace_global_vars.h
@@ -18,13 +18,13 @@
  */
 
 /*!
- * \file tvm/ir/replace_global_var.h
+ * \file tvm/ir/replace_global_vars.h
  *
  * \brief A utility to replace GlobalVar instances across all TVM IR
  * types in an IRMdoule.
  */
-#ifndef TVM_IR_REPLACE_GLOBAL_VAR_H_
-#define TVM_IR_REPLACE_GLOBAL_VAR_H_
+#ifndef TVM_IR_REPLACE_GLOBAL_VARS_H_
+#define TVM_IR_REPLACE_GLOBAL_VARS_H_
 
 #include <tvm/ir/module.h>
 
@@ -54,4 +54,4 @@ struct GlobalVarReplacer {
 }  // namespace transform
 }  // namespace tvm
 
-#endif  // TVM_IR_REPLACE_GLOBAL_VAR_H_
+#endif  // TVM_IR_REPLACE_GLOBAL_VARS_H_

--- a/python/tvm/ir/module.py
+++ b/python/tvm/ir/module.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """IRModule that holds the functions and type definitions."""
+
 from __future__ import annotations
 
 from typing import Dict, Union
@@ -215,6 +216,33 @@ class IRModule(Node, Scriptable):
             An array of global vars.
         """
         return _ffi_api.Module_GetGlobalVars(self)
+
+    def replace_global_vars(
+        self,
+        replacements: Dict[Union[str, _expr.GlobalVar], Union[str, _expr.GlobalVar]],
+    ) -> "IRModule":
+        """Replace GlobalVar instances within the module
+
+        Replace GlobalVars within the IRModule.  Since the IRModule
+        may contain internal references to a GlobalVar, either in TIR
+        or in Relax, this method should be used whenever replacing or
+        renaming a GlobalVar.
+
+        Parameters
+        ----------
+        replacements: Dict[Union[str, _expr.GlobalVar], Union[str, _expr.GlobalVar]]
+
+            A dictionary where each key is a GlobalVar to be replaced,
+            and the corresponding value is the GlobalVar with which to
+            replace it.
+
+        Returns
+        -------
+        IRModule
+            The updated module
+
+        """
+        return _ffi_api.Module_ReplaceGlobalVars(self, replacements)
 
     def get_global_type_vars(self):
         """Collect all global type vars defined in this module.

--- a/src/relax/transform/attach_global_symbol.cc
+++ b/src/relax/transform/attach_global_symbol.cc
@@ -22,7 +22,7 @@
  */
 
 #include <tvm/ir/module.h>
-#include <tvm/ir/replace_global_var.h>
+#include <tvm/ir/replace_global_vars.h>
 #include <tvm/relax/struct_info.h>
 #include <tvm/relax/transform.h>
 #include <tvm/tir/function.h>
@@ -72,7 +72,7 @@ Pass AttachGlobalSymbol() {
       mod.CopyOnWrite()->Update(updates);
 
       if (gvar_updates.size()) {
-        mod = tvm::transform::ReplaceGlobalVar(mod, gvar_updates);
+        mod = tvm::transform::ReplaceGlobalVars(mod, gvar_updates);
       }
     }
     return mod;

--- a/tests/python/ir/test_transform_replace_global_var.py
+++ b/tests/python/ir/test_transform_replace_global_var.py
@@ -140,9 +140,9 @@ def test_replace_relax_subroutine():
             return D
 
         @R.function(private=True)
-        def relax_subroutine_with_new_name(A: R.Tensor([16], "float32")) -> R.Tensor(
-            [16], "float32"
-        ):
+        def relax_subroutine_with_new_name(
+            A: R.Tensor([16], "float32"),
+        ) -> R.Tensor([16], "float32"):
             B = R.add(A, R.prim_value(T.float32(1.0)))
             return B
 
@@ -282,9 +282,9 @@ def test_simultaneous_replacements():
             return D
 
         @R.function(private=True)
-        def relax_subroutine_with_new_name(A: R.Tensor([16], "float32")) -> R.Tensor(
-            [16], "float32"
-        ):
+        def relax_subroutine_with_new_name(
+            A: R.Tensor([16], "float32"),
+        ) -> R.Tensor([16], "float32"):
             B = R.add(A, R.prim_value(T.float32(1.0)))
             return B
 

--- a/tests/python/ir/test_transform_replace_global_var.py
+++ b/tests/python/ir/test_transform_replace_global_var.py
@@ -1,0 +1,306 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm.testing
+from tvm.script import ir as I, relax as R, tir as T
+
+
+def _get_before_module():
+    @I.ir_module
+    class Module:
+        @R.function
+        def relax_main(A: R.Tensor([16], "float32")) -> R.Tensor([16], "float32"):
+            R.func_attr({"relax.force_pure": True})
+
+            B = Module.relax_subroutine(A)
+            C = R.call_tir(Module.tir_main, B, out_sinfo=R.Tensor([16], "float32"))
+
+            D = R.builtin.alloc_tensor(R.shape([16]), "float32", runtime_device_index=0)
+            Module.tir_main(C, D)
+
+            return D
+
+        @R.function(private=True)
+        def relax_subroutine(A: R.Tensor([16], "float32")) -> R.Tensor([16], "float32"):
+            B = R.add(A, R.prim_value(T.float32(1.0)))
+            return B
+
+        @T.prim_func
+        def tir_main(A: T.Buffer(16, "float32"), B: T.Buffer(16, "float32")):
+            Module.tir_subroutine(A.data, B.data)
+
+        @T.prim_func(private=True)
+        def tir_subroutine(A_data: T.ptr("float32"), B_data: T.ptr("float32")):
+            A = T.decl_buffer(16, "float32", data=A_data)
+            B = T.decl_buffer(16, "float32", data=B_data)
+            for i in range(16):
+                B[i] = A[i] + 1.0
+
+    return Module
+
+
+def test_no_op_if_no_replacements():
+    """If no replacements are performed, the IRModule is unmodified"""
+
+    before = _get_before_module()
+    expected = before
+
+    after = before.replace_global_vars({})
+
+    tvm.ir.assert_structural_equal(expected, after)
+    assert before.same_as(after)
+
+
+def test_replace_relax_main():
+    """An externally-exposed Relax function may be replaced
+
+    In this example, the "relax_main" function is renamed.  This
+    requires changing both the GlobalVar used to refer to the
+    function, and the "global_symbol" attribute of the
+    externally-exposed function.
+
+    """
+
+    before = _get_before_module()
+    after = before.replace_global_vars({"relax_main": "relax_main_with_new_name"})
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def relax_main_with_new_name(A: R.Tensor([16], "float32")) -> R.Tensor([16], "float32"):
+            R.func_attr({"relax.force_pure": True})
+
+            B = Expected.relax_subroutine(A)
+            C = R.call_tir(Expected.tir_main, B, out_sinfo=R.Tensor([16], "float32"))
+
+            D = R.builtin.alloc_tensor(R.shape([16]), "float32", runtime_device_index=0)
+            Expected.tir_main(C, D)
+
+            return D
+
+        @R.function(private=True)
+        def relax_subroutine(A: R.Tensor([16], "float32")) -> R.Tensor([16], "float32"):
+            B = R.add(A, R.prim_value(T.float32(1.0)))
+            return B
+
+        @T.prim_func
+        def tir_main(A: T.Buffer(16, "float32"), B: T.Buffer(16, "float32")):
+            Expected.tir_subroutine(A.data, B.data)
+
+        @T.prim_func(private=True)
+        def tir_subroutine(A_data: T.ptr("float32"), B_data: T.ptr("float32")):
+            A = T.decl_buffer(16, "float32", data=A_data)
+            B = T.decl_buffer(16, "float32", data=B_data)
+            for i in range(16):
+                B[i] = A[i] + 1.0
+
+    tvm.ir.assert_structural_equal(Expected, after)
+
+
+def test_replace_relax_subroutine():
+    """An internal Relax function may be replaced
+
+    In this example, the "relax_subroutine" function is renamed.  This
+    requires changing both the GlobalVar used to refer to the
+    function, and the GlobalVar used to call the subroutine within
+    "relax_main".  The "global_symbol" attribute does not need to be
+    updated, because internal functions do not have this attribute.
+
+    """
+
+    before = _get_before_module()
+    after = before.replace_global_vars({"relax_subroutine": "relax_subroutine_with_new_name"})
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def relax_main(A: R.Tensor([16], "float32")) -> R.Tensor([16], "float32"):
+            R.func_attr({"relax.force_pure": True})
+
+            B = Expected.relax_subroutine_with_new_name(A)
+            C = R.call_tir(Expected.tir_main, B, out_sinfo=R.Tensor([16], "float32"))
+
+            D = R.builtin.alloc_tensor(R.shape([16]), "float32", runtime_device_index=0)
+            Expected.tir_main(C, D)
+
+            return D
+
+        @R.function(private=True)
+        def relax_subroutine_with_new_name(A: R.Tensor([16], "float32")) -> R.Tensor(
+            [16], "float32"
+        ):
+            B = R.add(A, R.prim_value(T.float32(1.0)))
+            return B
+
+        @T.prim_func
+        def tir_main(A: T.Buffer(16, "float32"), B: T.Buffer(16, "float32")):
+            Expected.tir_subroutine(A.data, B.data)
+
+        @T.prim_func(private=True)
+        def tir_subroutine(A_data: T.ptr("float32"), B_data: T.ptr("float32")):
+            A = T.decl_buffer(16, "float32", data=A_data)
+            B = T.decl_buffer(16, "float32", data=B_data)
+            for i in range(16):
+                B[i] = A[i] + 1.0
+
+    tvm.ir.assert_structural_equal(Expected, after)
+
+
+def test_replace_tir_main():
+    """An externally-exposed TIR function may be replaced
+
+    In this example, the "tir_main" function is renamed.  This
+    requires changing both the GlobalVar used to refer to the
+    function, the "global_symbol" attribute of the externally-exposed
+    function.  In addition, calls to the TIR function should be
+    updated to use the new GlobalVar.
+
+    """
+
+    before = _get_before_module()
+    after = before.replace_global_vars({"tir_main": "tir_main_with_new_name"})
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def relax_main(A: R.Tensor([16], "float32")) -> R.Tensor([16], "float32"):
+            R.func_attr({"relax.force_pure": True})
+
+            B = Expected.relax_subroutine(A)
+            C = R.call_tir(Expected.tir_main_with_new_name, B, out_sinfo=R.Tensor([16], "float32"))
+
+            D = R.builtin.alloc_tensor(R.shape([16]), "float32", runtime_device_index=0)
+            Expected.tir_main_with_new_name(C, D)
+
+            return D
+
+        @R.function(private=True)
+        def relax_subroutine(A: R.Tensor([16], "float32")) -> R.Tensor([16], "float32"):
+            B = R.add(A, R.prim_value(T.float32(1.0)))
+            return B
+
+        @T.prim_func
+        def tir_main_with_new_name(A: T.Buffer(16, "float32"), B: T.Buffer(16, "float32")):
+            Expected.tir_subroutine(A.data, B.data)
+
+        @T.prim_func(private=True)
+        def tir_subroutine(A_data: T.ptr("float32"), B_data: T.ptr("float32")):
+            A = T.decl_buffer(16, "float32", data=A_data)
+            B = T.decl_buffer(16, "float32", data=B_data)
+            for i in range(16):
+                B[i] = A[i] + 1.0
+
+    tvm.ir.assert_structural_equal(Expected, after)
+
+
+def test_replace_tir_subroutine():
+    """An internally-exposed TIR function may be replaced
+
+    In this example, the "tir_subroutine" function is renamed.  This
+    requires changing both the GlobalVar used to refer to the
+    function, and the GlobalVar used to refer to it.  Internal
+    functions do not have the "global_symbol" attribute, so it does
+    not need to be updated.
+
+    """
+
+    before = _get_before_module()
+    after = before.replace_global_vars({"tir_subroutine": "tir_subroutine_with_new_name"})
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def relax_main(A: R.Tensor([16], "float32")) -> R.Tensor([16], "float32"):
+            R.func_attr({"relax.force_pure": True})
+
+            B = Expected.relax_subroutine(A)
+            C = R.call_tir(Expected.tir_main, B, out_sinfo=R.Tensor([16], "float32"))
+
+            D = R.builtin.alloc_tensor(R.shape([16]), "float32", runtime_device_index=0)
+            Expected.tir_main(C, D)
+
+            return D
+
+        @R.function(private=True)
+        def relax_subroutine(A: R.Tensor([16], "float32")) -> R.Tensor([16], "float32"):
+            B = R.add(A, R.prim_value(T.float32(1.0)))
+            return B
+
+        @T.prim_func
+        def tir_main(A: T.Buffer(16, "float32"), B: T.Buffer(16, "float32")):
+            Expected.tir_subroutine_with_new_name(A.data, B.data)
+
+        @T.prim_func(private=True)
+        def tir_subroutine_with_new_name(A_data: T.ptr("float32"), B_data: T.ptr("float32")):
+            A = T.decl_buffer(16, "float32", data=A_data)
+            B = T.decl_buffer(16, "float32", data=B_data)
+            for i in range(16):
+                B[i] = A[i] + 1.0
+
+    tvm.ir.assert_structural_equal(Expected, after)
+
+
+def test_simultaneous_replacements():
+    """Multiple replacements may be performed simultaneously"""
+
+    before = _get_before_module()
+    after = before.replace_global_vars(
+        {
+            "relax_main": "relax_main_with_new_name",
+            "relax_subroutine": "relax_subroutine_with_new_name",
+            "tir_main": "tir_main_with_new_name",
+            "tir_subroutine": "tir_subroutine_with_new_name",
+        }
+    )
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def relax_main_with_new_name(A: R.Tensor([16], "float32")) -> R.Tensor([16], "float32"):
+            R.func_attr({"relax.force_pure": True})
+
+            B = Expected.relax_subroutine_with_new_name(A)
+            C = R.call_tir(Expected.tir_main_with_new_name, B, out_sinfo=R.Tensor([16], "float32"))
+
+            D = R.builtin.alloc_tensor(R.shape([16]), "float32", runtime_device_index=0)
+            Expected.tir_main_with_new_name(C, D)
+
+            return D
+
+        @R.function(private=True)
+        def relax_subroutine_with_new_name(A: R.Tensor([16], "float32")) -> R.Tensor(
+            [16], "float32"
+        ):
+            B = R.add(A, R.prim_value(T.float32(1.0)))
+            return B
+
+        @T.prim_func
+        def tir_main_with_new_name(A: T.Buffer(16, "float32"), B: T.Buffer(16, "float32")):
+            Expected.tir_subroutine_with_new_name(A.data, B.data)
+
+        @T.prim_func(private=True)
+        def tir_subroutine_with_new_name(A_data: T.ptr("float32"), B_data: T.ptr("float32")):
+            A = T.decl_buffer(16, "float32", data=A_data)
+            B = T.decl_buffer(16, "float32", data=B_data)
+            for i in range(16):
+                B[i] = A[i] + 1.0
+
+    tvm.ir.assert_structural_equal(Expected, after)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This is a follow-up PR to https://github.com/apache/tvm/pull/17202, which added a general utility to replace `GlobalVar` instances across all TVM IR types.  This PR exposes this new utility through the Python API, and explicitly tests its functionality.