### PR TITLE
[WEBGPU] Update runtime to remove deprecated API

### DIFF
--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -116,7 +116,7 @@ export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefin
       requiredFeatures.push("shader-f16");
     }
 
-    const adapterInfo = adapter.info || await adapter.requestAdapterInfo();
+    const adapterInfo = adapter.info;
     const device = await adapter.requestDevice({
       requiredLimits: {
         maxBufferSize: requiredMaxBufferSize,


### PR DESCRIPTION
This PR updates webgpu runtime code to remove
deprecated API. unblocks the CI.