### PR TITLE
[TVMScript] Avoid segfault from invalid TVMScript

### DIFF
--- a/python/tvm/script/parser/core/evaluator.py
+++ b/python/tvm/script/parser/core/evaluator.py
@@ -465,6 +465,7 @@ def eval_assign(
         return _eval_assign(target, source)
     except Exception as err:  # pylint: disable=broad-except
         parser.report_error(target, err)
+        raise
 
 
 def _eval_expr(

--- a/python/tvm/script/parser/core/evaluator.py
+++ b/python/tvm/script/parser/core/evaluator.py
@@ -267,8 +267,8 @@ class ExprEvaluator:
                 value = self._eval_slice(fields)
             else:
                 value = self._eval_expr(node.__class__(**fields))
-        except Exception as e:  # pylint: disable=broad-except,invalid-name
-            self.parser.report_error(node, e)
+        except Exception as err:  # pylint: disable=broad-except
+            self.parser.report_error(node, err)
         return self._add_intermediate_result(value)
 
     def _eval_lambda(self, node: doc.Lambda) -> Any:
@@ -286,8 +286,8 @@ class ExprEvaluator:
         """
         try:
             value = self._eval_expr(node)
-        except Exception as e:  # pylint: disable=broad-except,invalid-name
-            self.parser.report_error(node, str(e))
+        except Exception as err:  # pylint: disable=broad-except
+            self.parser.report_error(node, err)
         return self._add_intermediate_result(value)
 
     def _eval_bool_op(self, fields: Dict[str, Any]) -> Any:
@@ -463,9 +463,8 @@ def eval_assign(
     """
     try:
         return _eval_assign(target, source)
-    except Exception as e:  # pylint: disable=broad-except,invalid-name
-        parser.report_error(target, f"Failed to evaluate assignment: {str(e)}")
-        raise
+    except Exception as err:  # pylint: disable=broad-except
+        parser.report_error(target, err)
 
 
 def _eval_expr(

--- a/python/tvm/script/parser/core/parser.py
+++ b/python/tvm/script/parser/core/parser.py
@@ -309,6 +309,7 @@ def _dispatch_wrapper(func: dispatch.ParseMethod) -> dispatch.ParseMethod:
             return func(self, node)
         except Exception as err:  # pylint: disable=broad-except
             self.report_error(node, err)
+            raise
 
     return _wrapper
 
@@ -493,6 +494,7 @@ class Parser(doc.NodeVisitor):
             return self._duplicate_lhs_check(target.value)
         else:
             self.report_error(target, "Invalid type in assign statement")
+            raise NotImplementedError
 
     def eval_assign(
         self,

--- a/python/tvm/script/parser/core/parser.py
+++ b/python/tvm/script/parser/core/parser.py
@@ -307,11 +307,8 @@ def _dispatch_wrapper(func: dispatch.ParseMethod) -> dispatch.ParseMethod:
     def _wrapper(self: "Parser", node: doc.AST) -> None:
         try:
             return func(self, node)
-        except DiagnosticError:
-            raise
-        except Exception as e:  # pylint: disable=broad-except,invalid-name
-            self.report_error(node, e)
-            raise
+        except Exception as err:  # pylint: disable=broad-except
+            self.report_error(node, err)
 
     return _wrapper
 
@@ -496,7 +493,6 @@ class Parser(doc.NodeVisitor):
             return self._duplicate_lhs_check(target.value)
         else:
             self.report_error(target, "Invalid type in assign statement")
-            raise NotImplementedError
 
     def eval_assign(
         self,
@@ -547,6 +543,12 @@ class Parser(doc.NodeVisitor):
         err: Union[Exception, str]
             The error to report.
         """
+
+        # If the error is already being raised as a DiagnosticError,
+        # re-raise it without wrapping it in a DiagnosticContext.
+        if isinstance(err, DiagnosticError):
+            raise err
+
         # Only take the last line of the error message
         if isinstance(err, TVMError):
             msg = list(filter(None, str(err).split("\n")))[-1]
@@ -595,11 +597,8 @@ class Parser(doc.NodeVisitor):
             raise NotImplementedError(f"Visitor of AST node is not implemented: {name}")
         try:
             func(node)
-        except DiagnosticError:
-            raise
-        except Exception as e:  # pylint: disable=broad-except,invalid-name
-            self.report_error(node, str(e))
-            raise
+        except Exception as err:  # pylint: disable=broad-except
+            self.report_error(node, err)
 
     def visit_body(self, node: List[doc.stmt]) -> Any:
         """The general body visiting method.

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -104,8 +104,9 @@ def eval_struct_info_proxy(self: Parser, node: doc.expr) -> StructInfoProxy:
     try:
         annotation = self.eval_expr(node)
         return _normalize_struct_info_proxy(annotation)
-    except Exception as err:
+    except Exception as err:  # pylint: disable=broad-except
         self.report_error(node, err)
+        raise
 
 
 def eval_struct_info(self: Parser, node: doc.expr, eval_str: bool = False) -> StructInfo:
@@ -113,8 +114,9 @@ def eval_struct_info(self: Parser, node: doc.expr, eval_str: bool = False) -> St
     try:
         struct_info = self.eval_expr(node)
         return _normalize_struct_info(struct_info, var_table)
-    except Exception as err:
+    except Exception as err:  # pylint: disable=broad-except
         self.report_error(node, err)
+        raise
 
 
 def is_called(node: Any, func_name: str) -> bool:

--- a/python/tvm/script/parser/relax/parser.py
+++ b/python/tvm/script/parser/relax/parser.py
@@ -105,8 +105,7 @@ def eval_struct_info_proxy(self: Parser, node: doc.expr) -> StructInfoProxy:
         annotation = self.eval_expr(node)
         return _normalize_struct_info_proxy(annotation)
     except Exception as err:
-        self.report_error(node, str(err))
-        raise err
+        self.report_error(node, err)
 
 
 def eval_struct_info(self: Parser, node: doc.expr, eval_str: bool = False) -> StructInfo:
@@ -116,7 +115,6 @@ def eval_struct_info(self: Parser, node: doc.expr, eval_str: bool = False) -> St
         return _normalize_struct_info(struct_info, var_table)
     except Exception as err:
         self.report_error(node, err)
-        raise err
 
 
 def is_called(node: Any, func_name: str) -> bool:

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -64,7 +64,6 @@ def bind_with_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> 
         return value
     else:
         self.report_error(node, f"Do not know how to bind type: {type(value)} in with statement")
-        raise NotImplementedError
 
 
 def bind_for_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> Any:
@@ -100,7 +99,6 @@ def bind_for_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> A
         return value
     else:
         self.report_error(node, f"Do not know how to bind type: {type(value)} in for statement")
-        raise NotImplementedError
 
 
 def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> Any:

--- a/python/tvm/script/parser/tir/parser.py
+++ b/python/tvm/script/parser/tir/parser.py
@@ -64,6 +64,7 @@ def bind_with_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> 
         return value
     else:
         self.report_error(node, f"Do not know how to bind type: {type(value)} in with statement")
+        raise NotImplementedError
 
 
 def bind_for_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> Any:
@@ -99,6 +100,7 @@ def bind_for_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> A
         return value
     else:
         self.report_error(node, f"Do not know how to bind type: {type(value)} in for statement")
+        raise NotImplementedError
 
 
 def bind_assign_value(self: Parser, node: doc.expr, var_name: str, value: Any) -> Any:

--- a/src/ir/diagnostic.cc
+++ b/src/ir/diagnostic.cc
@@ -127,7 +127,8 @@ void DiagnosticContext::Render() {
   }
 
   if (errs) {
-    (*this)->renderer = DiagnosticRenderer();
+    (*this)->renderer = DiagnosticRenderer([](DiagnosticContext) {});
+    // (*this)->diagnostics.clear();
     LOG(FATAL) << "DiagnosticError: one or more error diagnostics were "
                << "emitted, please check diagnostic render for output.";
   }

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -179,6 +179,15 @@ def test_unassigned_call_fail():
             return x
 
 
+def test_incorrect_tensor_shape():
+    with pytest.raises(tvm.error.DiagnosticError):
+
+        @R.function
+        def f(x: R.Tensor([16])):
+            y: R.Tensor(16) = R.add(x, x)
+            return y
+
+
 def test_simple_module():
     @I.ir_module
     class TestModule:
@@ -1028,9 +1037,7 @@ def test_call_tir_inplace():
                     out1[ax0, ax1] = B[ax0, ax1]
 
         @R.function
-        def main(
-            x: R.Tensor((2, 3), "int32"), y: R.Tensor((2, 3), "int32")
-        ) -> R.Tuple(
+        def main(x: R.Tensor((2, 3), "int32"), y: R.Tensor((2, 3), "int32")) -> R.Tuple(
             R.Tensor((2, 3), "int32"), R.Tensor((2, 3), "int32"), R.Tensor((2, 3), "int32")
         ):
             res = R.call_tir_inplace(
@@ -1045,7 +1052,6 @@ def test_call_tir_inplace():
 
 
 def test_call_tir_inplace_with_tuple_var_raises_error():
-
     with pytest.raises(tvm.error.DiagnosticError):
 
         @tvm.script.ir_module
@@ -1082,13 +1088,13 @@ def test_call_tir_inplace_with_tuple_var_raises_error():
 
 def test_local_function():
     @R.function
-    def main(
-        x: R.Tensor((2, 3), "float32"), y: R.Tensor((2, 3), "float32")
-    ) -> R.Tensor((2, 3), "float32"):
+    def main(x: R.Tensor((2, 3), "float32"), y: R.Tensor((2, 3), "float32")) -> R.Tensor(
+        (2, 3), "float32"
+    ):
         @R.function
-        def outer_func(
-            c1: R.Tensor((2, 3), "float32")
-        ) -> R.Callable((R.Tensor(None, "float32", ndim=2),), R.Tensor(None, "float32", ndim=2)):
+        def outer_func(c1: R.Tensor((2, 3), "float32")) -> R.Callable(
+            (R.Tensor(None, "float32", ndim=2),), R.Tensor(None, "float32", ndim=2)
+        ):
             @R.function
             def inner_func(x1: R.Tensor((2, 3), "float32")):
                 s: R.Tensor((2, 3), "float32") = R.add(x1, c1)
@@ -1523,9 +1529,9 @@ def test_erase_to_well_defined_infers_from_prim_value():
     class Module:
         # The subroutine's symbolic variables are only in-scope for the subroutine.
         @R.function
-        def subroutine(
-            x: R.Tensor, _m: R.Prim(value="m"), _n: R.Prim(value="n")
-        ) -> R.Tensor(["m", "n"]):
+        def subroutine(x: R.Tensor, _m: R.Prim(value="m"), _n: R.Prim(value="n")) -> R.Tensor(
+            ["m", "n"]
+        ):
             q = x
             m, n = T.int64(), T.int64()
             z = R.match_cast(q, R.Tensor((m, n)))
@@ -1583,9 +1589,9 @@ def test_symbolic_vars_in_tensor_shape_with_definition_first():
     """Second param may use symbolic variable defined in first param"""
 
     @R.function
-    def bar(
-        x: R.Tensor(("m",), "float32"), y: R.Tensor(("T.max(m, 20)",), "float32")
-    ) -> R.Tensor(("T.max(m, 20) + 1",), "float32"):
+    def bar(x: R.Tensor(("m",), "float32"), y: R.Tensor(("T.max(m, 20)",), "float32")) -> R.Tensor(
+        ("T.max(m, 20) + 1",), "float32"
+    ):
         m = T.int64()
         z = R.call_dps_packed("test_intrin", (x, y), R.Tensor((T.max(m, 20) + 1,), dtype="float32"))
         return z
@@ -1838,7 +1844,7 @@ def test_class_normalize():
     _check(InputModule, OutputModule)
 
 
-def test_context_aware_parsing():
+def test_context_aware_parsing(monkeypatch):
     @tvm.script.ir_module
     class Module:
         @T.prim_func
@@ -1863,7 +1869,7 @@ def test_context_aware_parsing():
     def _break_env(self, *args):
         raise RuntimeError("Fail to pass context-aware parsing")
 
-    tvm.ir.GlobalVar.__call__ = _break_env
+    monkeypatch.setattr(tvm.ir.GlobalVar, "__call__", _break_env)
 
     _check(Module)
 
@@ -2050,9 +2056,9 @@ def test_function_with_void_return_type_in_if_else():
     @I.ir_module
     class Unsugared:
         @R.function(pure=False)
-        def conditional(
-            x: R.Tensor((), "int32"), condition: R.Tensor((), "bool")
-        ) -> R.Tensor((), "int32"):
+        def conditional(x: R.Tensor((), "int32"), condition: R.Tensor((), "bool")) -> R.Tensor(
+            (), "int32"
+        ):
             if condition:
                 y = R.print(x, format="True condition: {}")
             else:
@@ -2062,9 +2068,9 @@ def test_function_with_void_return_type_in_if_else():
     @I.ir_module
     class Sugared:
         @R.function(pure=False)
-        def conditional(
-            x: R.Tensor((), "int32"), condition: R.Tensor((), "bool")
-        ) -> R.Tensor((), "int32"):
+        def conditional(x: R.Tensor((), "int32"), condition: R.Tensor((), "bool")) -> R.Tensor(
+            (), "int32"
+        ):
             if condition:
                 R.print(x, format="True condition: {}")
             else:

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1037,7 +1037,9 @@ def test_call_tir_inplace():
                     out1[ax0, ax1] = B[ax0, ax1]
 
         @R.function
-        def main(x: R.Tensor((2, 3), "int32"), y: R.Tensor((2, 3), "int32")) -> R.Tuple(
+        def main(
+            x: R.Tensor((2, 3), "int32"), y: R.Tensor((2, 3), "int32")
+        ) -> R.Tuple(
             R.Tensor((2, 3), "int32"), R.Tensor((2, 3), "int32"), R.Tensor((2, 3), "int32")
         ):
             res = R.call_tir_inplace(
@@ -1088,13 +1090,13 @@ def test_call_tir_inplace_with_tuple_var_raises_error():
 
 def test_local_function():
     @R.function
-    def main(x: R.Tensor((2, 3), "float32"), y: R.Tensor((2, 3), "float32")) -> R.Tensor(
-        (2, 3), "float32"
-    ):
+    def main(
+        x: R.Tensor((2, 3), "float32"), y: R.Tensor((2, 3), "float32")
+    ) -> R.Tensor((2, 3), "float32"):
         @R.function
-        def outer_func(c1: R.Tensor((2, 3), "float32")) -> R.Callable(
-            (R.Tensor(None, "float32", ndim=2),), R.Tensor(None, "float32", ndim=2)
-        ):
+        def outer_func(
+            c1: R.Tensor((2, 3), "float32")
+        ) -> R.Callable((R.Tensor(None, "float32", ndim=2),), R.Tensor(None, "float32", ndim=2)):
             @R.function
             def inner_func(x1: R.Tensor((2, 3), "float32")):
                 s: R.Tensor((2, 3), "float32") = R.add(x1, c1)
@@ -1529,9 +1531,9 @@ def test_erase_to_well_defined_infers_from_prim_value():
     class Module:
         # The subroutine's symbolic variables are only in-scope for the subroutine.
         @R.function
-        def subroutine(x: R.Tensor, _m: R.Prim(value="m"), _n: R.Prim(value="n")) -> R.Tensor(
-            ["m", "n"]
-        ):
+        def subroutine(
+            x: R.Tensor, _m: R.Prim(value="m"), _n: R.Prim(value="n")
+        ) -> R.Tensor(["m", "n"]):
             q = x
             m, n = T.int64(), T.int64()
             z = R.match_cast(q, R.Tensor((m, n)))
@@ -1589,9 +1591,9 @@ def test_symbolic_vars_in_tensor_shape_with_definition_first():
     """Second param may use symbolic variable defined in first param"""
 
     @R.function
-    def bar(x: R.Tensor(("m",), "float32"), y: R.Tensor(("T.max(m, 20)",), "float32")) -> R.Tensor(
-        ("T.max(m, 20) + 1",), "float32"
-    ):
+    def bar(
+        x: R.Tensor(("m",), "float32"), y: R.Tensor(("T.max(m, 20)",), "float32")
+    ) -> R.Tensor(("T.max(m, 20) + 1",), "float32"):
         m = T.int64()
         z = R.call_dps_packed("test_intrin", (x, y), R.Tensor((T.max(m, 20) + 1,), dtype="float32"))
         return z
@@ -2056,9 +2058,9 @@ def test_function_with_void_return_type_in_if_else():
     @I.ir_module
     class Unsugared:
         @R.function(pure=False)
-        def conditional(x: R.Tensor((), "int32"), condition: R.Tensor((), "bool")) -> R.Tensor(
-            (), "int32"
-        ):
+        def conditional(
+            x: R.Tensor((), "int32"), condition: R.Tensor((), "bool")
+        ) -> R.Tensor((), "int32"):
             if condition:
                 y = R.print(x, format="True condition: {}")
             else:
@@ -2068,9 +2070,9 @@ def test_function_with_void_return_type_in_if_else():
     @I.ir_module
     class Sugared:
         @R.function(pure=False)
-        def conditional(x: R.Tensor((), "int32"), condition: R.Tensor((), "bool")) -> R.Tensor(
-            (), "int32"
-        ):
+        def conditional(
+            x: R.Tensor((), "int32"), condition: R.Tensor((), "bool")
+        ) -> R.Tensor((), "int32"):
             if condition:
                 R.print(x, format="True condition: {}")
             else:

--- a/tests/python/tvmscript/test_tvmscript_printer_highlight.py
+++ b/tests/python/tvmscript/test_tvmscript_printer_highlight.py
@@ -21,7 +21,7 @@ import tvm
 import tvm.testing
 from tvm import relay
 from tvm.script import tir as T
-from tvm.script.highlight import cprint
+from tvm.script.highlight import cprint, _format
 
 
 def test_highlight_script():
@@ -58,12 +58,14 @@ def test_cprint():
     # Print nodes with `script` method, e.g. PrimExpr
     cprint(tvm.tir.Var("v", "int32") + 1)
 
-    # Cannot print non-Python-style codes if black installed
+    # Cannot print non-Python-style codes when using the black
+    # formatter.  This error comes from `_format`, used internally by
+    # `cprint`, and doesn't occur when using the `ruff` formatter.
     try:
         import black
 
         with pytest.raises(ValueError):
-            cprint("if (a == 1) { a +=1; }")
+            _format("if (a == 1) { a +=1; }", formatter="black")
     except ImportError:
         pass
 


### PR DESCRIPTION
Prior to this commit, after the `DiagnosticContext` prints its error, it overwrites the `DiagnosticRenderer` with a NULL renderer.  If a second call to `DiagnosticContext::Render` occurs, it will segfault. This appears to be intended to prevent double-printing of error messages, but double-printing error messages is much worse than a segfault.

In addition, `DiagnosticContext::Render` should only be called once. There's a common pattern in the parser where it will wrap exceptions in `DiagnosticError`, but re-raise exceptions that are already a `DiagnosticError`.  This requires every such location to include `except DiagnosticError: raise`, and can easily be missed.

This PR makes two changes: First, the `DiagnosticRenderer` is updated to have a no-op callback rather than a NULL callback.  Second, the re-raising of `DiagnosticError` is moved to `Parser.report_error`, so that it does not need to be handled separately at several independent locations in the TVMScript parser.