### PR TITLE
[DOCS] Link to project-specific security page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -617,7 +617,7 @@ header_dropdown = {
         ("Apache Homepage", "https://apache.org/"),
         ("License", "https://www.apache.org/licenses/"),
         ("Sponsorship", "https://www.apache.org/foundation/sponsorship.html"),
-        ("Security", "https://www.apache.org/security/"),
+        ("Security", "https://tvm.apache.org/docs/reference/security.html"),
         ("Thanks", "https://www.apache.org/foundation/thanks.html"),
         ("Events", "https://www.apache.org/events/current-event"),
     ],


### PR DESCRIPTION
Make the project-specific information more prominent.

This project-specific page already links to the general ASF information at https://apache.org/security/