### PR TITLE
[TIR, TVMScript] Add TIR - Triton integration

### DIFF
--- a/python/tvm/relax/vm_build.py
+++ b/python/tvm/relax/vm_build.py
@@ -243,13 +243,25 @@ def _vmlink(
     if ext_libs is None:
         ext_libs = []
     lib = None
+    relax_ext_libs = []
+    tir_ext_libs = []
     if tir_mod is not None and len(tir_mod.get_global_vars()) > 0:
         lib = tvm.build(
             tir_mod,
             target=target,
             runtime=_autodetect_system_lib_req(target, system_lib),
         )
-    return Executable(_ffi_api.VMLink(builder, target, lib, ext_libs, params))  # type: ignore
+    for ext_mod in ext_libs:
+        if ext_mod.type_key == "cuda":
+            tir_ext_libs.append(ext_mod)
+        else:
+            relax_ext_libs.append(ext_mod)
+    if lib is not None:
+        for mod in tir_ext_libs:
+            lib.import_module(mod)
+    elif len(tir_ext_libs) > 0:
+        print("Warning: No TIR module is found, but external modules for TIR are provided.")
+    return Executable(_ffi_api.VMLink(builder, target, lib, relax_ext_libs, params))  # type: ignore
 
 
 def build(

--- a/python/tvm/script/ir_builder/ir/__init__.py
+++ b/python/tvm/script/ir_builder/ir/__init__.py
@@ -21,6 +21,8 @@ from .ir import (
     def_function,
     ir_module,
     module_attrs,
+    module_get_attr,
+    module_set_attr,
     module_global_infos,
     lookup_vdevice,
     vdevice,

--- a/python/tvm/script/ir_builder/ir/ir.py
+++ b/python/tvm/script/ir_builder/ir/ir.py
@@ -16,7 +16,7 @@
 # under the License.
 """Package tvm.script.ir_builder.ir.ir"""
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from tvm.ir import BaseFunc, GlobalVar, GlobalInfo, VDevice, DummyGlobalInfo
 from tvm.runtime import Object as tvm_Object
@@ -77,14 +77,66 @@ def def_function(func_name: str, func: BaseFunc) -> None:
     return _ffi_api.DefFunction(func_name, func)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
-def module_attrs(attrs: Dict[str, tvm_Object]) -> None:
+def module_attrs(attrs: Dict[str, tvm_Object], allow_overwrite=False) -> None:
     """Specify the attrs of the ir_module frame.
     Parameters
     ----------
     attrs: Dict[str, Object]
         The module attrs.
+    allow_overwrite: bool
+        Whether allow overwrite the existing attrs.
     """
-    return _ffi_api.ModuleAttrs(attrs)  # type: ignore[attr-defined] # pylint: disable=no-member
+    return _ffi_api.ModuleAttrs(attrs, allow_overwrite)  # type: ignore[attr-defined] # pylint: disable=no-member
+
+
+def current_ir_module() -> IRModuleFrame:
+    """Get the current ir_module frame.
+    Returns
+    -------
+    frame: IRModuleFrame
+        The current frame.
+    """
+    return _ffi_api.CurrentIRModule()  # type: ignore[attr-defined] # pylint: disable=no-member
+
+
+def module_get_attrs() -> Dict[str, tvm_Object]:
+    """Get the attrs of the ir_module frame.
+    Returns
+    -------
+    attrs: Dict[str, Object]
+        The module attrs.
+    """
+    return _ffi_api.ModuleGetAttrs()  # type: ignore[attr-defined] # pylint: disable=no-member
+
+
+def module_get_attr(attr_key: str) -> Optional[tvm_Object]:
+    """Get the specified attr of the ir_module frame.
+    Parameters
+    ----------
+    attr_key: str
+        The key of the attr to be retrieved.
+    Returns
+    -------
+    attr: Optional[Object]
+        The specified module attr or None if not found.
+    """
+    return _ffi_api.ModuleGetAttr(attr_key)  # type: ignore[attr-defined] # pylint: disable=no-member
+
+
+def module_set_attr(
+    attr_key: str, attr_value: Optional[tvm_Object], allow_overwrite: bool = False
+) -> None:
+    """Set the specified attr of the ir_module frame.
+    Parameters
+    ----------
+    attr_key: str
+        The key of the attr to be set.
+    attr_value: Optional[Object]
+        The value of the attr to be set.
+    allow_overwrite: bool
+        Whether allow overwrite the existing attr.
+    """
+    return _ffi_api.ModuleSetAttr(attr_key, attr_value, allow_overwrite)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
 def module_global_infos(global_infos: Dict[str, List[GlobalInfo]]) -> None:

--- a/python/tvm/script/ir_builder/tir/external_kernel.py
+++ b/python/tvm/script/ir_builder/tir/external_kernel.py
@@ -1,0 +1,117 @@
+import json
+import tempfile
+from typing import Any, Dict, List, Tuple, Union
+
+from tvm import __version__ as tvm_version
+from tvm import tir
+from tvm.runtime import Module, load_module
+
+
+class BaseKernel:
+    """Base class for external kernels."""
+
+    def compile_to_device_module(self, *args, **kwargs) -> Tuple[str, Module, List[Any]]:
+        """Compile the kernel to a device module."""
+        raise NotImplementedError()
+
+    def _format_tvm_module_metadata(self, kernel_name, arg_types, launch_param_tags):
+        """Format the TVM module metadata."""
+        tvm_metadata = """{{
+            "tvm_version": "{version}",
+            "func_info": {{
+                "{kernel_name}": {{
+                    "name": "",
+                    "arg_types": {arg_types},
+                    "launch_param_tags": {launch_param_tags}
+                }}
+            }}
+        }}""".format_map(
+            {
+                "version": tvm_version,
+                "kernel_name": kernel_name,
+                "arg_types": json.dumps(arg_types),
+                "launch_param_tags": json.dumps(launch_param_tags),
+            }
+        )
+        return tvm_metadata
+
+    def _create_cuda_module(self, ptx, kernel_arg_types, launch_param_tags, kernel_name):
+        """
+        Create a CUDA module from PTX and metadata.
+
+        Parameters
+        ----------
+        ptx : str
+            The PTX code of the kernel.
+
+        kernel_arg_types : List[str]
+            The types of the kernel arguments.
+
+        launch_param_tags : List[str]
+            The tags of the launch parameters.
+
+        kernel_name : str
+            The name of the kernel.
+
+        Returns
+        -------
+        kernel_module : Module
+            The CUDA module.
+        """
+        tvm_metadata = self._format_tvm_module_metadata(
+            kernel_name, kernel_arg_types, launch_param_tags
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            ptx_path = f"{temp_dir}/{kernel_name}.ptx"
+            with open(ptx_path, "w") as f:
+                f.write(ptx)
+            with open(f"{temp_dir}/{kernel_name}.tvm_meta.json", "w") as f:
+                f.write(tvm_metadata)
+            kernel_module = load_module(ptx_path)
+        return kernel_module
+
+
+def call_kernel(
+    kernel,
+    launch_args: List[Union[int, tir.PrimExpr, List[Union[int, tir.PrimExpr]]]],
+    *args: List[Any],
+    **kwargs: Dict[str, Any],
+):
+    """
+    Call an external kernel.
+
+    Parameters
+    ----------
+    kernel : Any
+        The external kernel to call.
+
+    launch_args : List[Union[int, tir.PrimExpr, List[Union[int, tir.PrimExpr]]]]
+        The launch arguments. A list of integers for grid size, block size, and shared memory size.
+        The actual requirements depend on the kernel.
+
+    args : List[tir.PrimExpr]
+        The arguments to pass to the kernel.
+
+    kwargs : Dict[str, Any]
+        Additional keyword arguments to pass to the kernel or compilation.
+    """
+    from ..ir import module_get_attr, module_set_attr
+    from .ir import call_packed
+
+    kernel_type = f"{type(kernel).__module__}.{type(kernel).__qualname__}"
+    if kernel_type == "triton.runtime.jit.JITFunction":
+        from .triton import TritonKernel
+
+        kernel = TritonKernel(kernel)
+    else:
+        raise ValueError("Unsupported kernel type {}".format(kernel_type))
+
+    kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module(
+        launch_args, *args, **kwargs
+    )
+
+    # Attach the kernel module to the current IRModule
+    external_mods = module_get_attr("external_mods") or []
+    external_mods.append(kernel_module)
+    module_set_attr("external_mods", external_mods, True)
+    return call_packed(kernel_name, *runtime_args)

--- a/python/tvm/script/ir_builder/tir/external_kernel.py
+++ b/python/tvm/script/ir_builder/tir/external_kernel.py
@@ -12,7 +12,9 @@ from tvm.runtime import Module, load_module
 class BaseKernel:
     """Base class for external kernels."""
 
-    def compile_to_device_module(self, launch_args, *args, **kwargs) -> Tuple[str, Module, List[Any]]:
+    def compile_to_device_module(
+        self, launch_args, *args, **kwargs
+    ) -> Tuple[str, Module, List[Any]]:
         """Compile the kernel to a device module."""
         raise NotImplementedError()
 

--- a/python/tvm/script/ir_builder/tir/external_kernel.py
+++ b/python/tvm/script/ir_builder/tir/external_kernel.py
@@ -1,17 +1,18 @@
+"""External kernel integration fro TIR"""
 import json
+import logging
 import tempfile
 from typing import Any, Dict, List, Tuple, Union
 
 from tvm import __version__ as tvm_version
 from tvm import tir
 from tvm.runtime import Module, load_module
-import logging
 
 
 class BaseKernel:
     """Base class for external kernels."""
 
-    def compile_to_device_module(self, *args, **kwargs) -> Tuple[str, Module, List[Any]]:
+    def compile_to_device_module(self, launch_args, *args, **kwargs) -> Tuple[str, Module, List[Any]]:
         """Compile the kernel to a device module."""
         raise NotImplementedError()
 
@@ -96,12 +97,12 @@ def call_kernel(
     kwargs : Dict[str, Any]
         Additional keyword arguments to pass to the kernel or compilation.
     """
-    from ..ir import module_get_attr, module_set_attr
-    from .ir import call_packed
+    from ..ir import module_get_attr, module_set_attr  # pylint: disable=import-outside-toplevel
+    from .ir import call_packed  # pylint: disable=import-outside-toplevel
 
     kernel_type = f"{type(kernel).__module__}.{type(kernel).__qualname__}"
     if kernel_type == "triton.runtime.jit.JITFunction":
-        from .triton import TritonKernel
+        from .triton import TritonKernel  # pylint: disable=import-outside-toplevel
 
         kernel = TritonKernel(kernel)
     else:

--- a/python/tvm/script/ir_builder/tir/external_kernel.py
+++ b/python/tvm/script/ir_builder/tir/external_kernel.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 """External kernel integration fro TIR"""
 import json
 import logging

--- a/python/tvm/script/ir_builder/tir/ir.py
+++ b/python/tvm/script/ir_builder/tir/ir.py
@@ -2256,3 +2256,11 @@ __all__ = [
     "vscale",
     "get_active_lane_mask",
 ]
+
+try:
+    import triton
+    from .triton import call_triton
+
+    __all__.append("call_triton")
+except ImportError:
+    pass

--- a/python/tvm/script/ir_builder/tir/ir.py
+++ b/python/tvm/script/ir_builder/tir/ir.py
@@ -83,6 +83,7 @@ from tvm.tir.expr import (
 from tvm.tir.generic import cast
 
 from . import _ffi_api, frame
+from .external_kernel import call_kernel
 
 # pylint: enable=unused-import
 
@@ -1943,7 +1944,6 @@ tvm_call_cpacked = call_cpacked
 tvm_call_packed_lowered = call_packed_lowered
 tvm_call_cpacked_lowered = call_cpacked_lowered
 
-
 # pylint: enable=invalid-name
 
 
@@ -2255,12 +2255,5 @@ __all__ = [
     "Range",
     "vscale",
     "get_active_lane_mask",
+    "call_kernel",
 ]
-
-try:
-    import triton
-    from .triton import call_triton
-
-    __all__.append("call_triton")
-except ImportError:
-    pass

--- a/python/tvm/script/ir_builder/tir/triton.py
+++ b/python/tvm/script/ir_builder/tir/triton.py
@@ -3,128 +3,88 @@ from triton.runtime.jit import type_canonicalisation_dict
 from tvm import tir
 from tvm.topi.utils import get_const_int
 from tvm.runtime import load_module, Module
-import tempfile
-import json
-from tvm._ffi.libinfo import __version__
-
-from typing import Tuple, List, Union, Any
+from typing import Tuple, List, Union, Any, Dict
+from .external_kernel import BaseKernel
 
 
-def _generate_triton_kernel(
-    func, grid, *args, **kwargs
-) -> Union[triton.compiler.CompiledKernel, List[tir.PrimExpr], List[str]]:
-    """Deduce the kernel signature and generate the Triton kernel"""
+class TritonKernel(BaseKernel):
+    """A kernel from Triton JIT function.
 
-    kernel_params = func.params
-    assert len(kernel_params) == len(
-        args
-    ), f"Number of arguments does not match, expected {len(kernel_params)}, got {len(args)}"
-
-    # Step 1: Generate the Triton kernel
-    signature = {}
-    constants = {}
-    # Arguments to invoke the kernel
-    kernel_args = []
-    kernel_arg_types = []
-    for i, arg in enumerate(args):
-        if kernel_params[i].is_constexpr:
-            constants[kernel_params[i].name] = get_const_int(arg)
-            continue
-        if arg.dtype == "handle":
-            assert isinstance(arg, tir.Var)
-            elem_type = arg.type_annotation.element_type.dtype
-            pointer_type = "*" + type_canonicalisation_dict[elem_type]
-            signature[kernel_params[i].name] = pointer_type
-        else:
-            signature[kernel_params[i].name] = type_canonicalisation_dict[arg.dtype]
-        kernel_args.append(arg)
-        kernel_arg_types.append(arg.dtype)
-
-    # TODO: Support default argument in the kernel
-    # TODO: Add specialization for aligned buffer pointers
-    source = triton.compiler.ASTSource(fn=func, constants=constants, signature=signature)
-    compiled = triton.compiler.compile(source)
-    return compiled, kernel_args, kernel_arg_types
-
-
-def _pack_kernel_module(
-    compiled: "triton.compiler.CompiledKernel",
-    grid: List[Union[int, tir.PrimExpr]],
-    kernel_arg_types: List[str],
-) -> Tuple[Module, List[Union[int, tir.PrimExpr]]]:
-    """Pack the compiled kernel into a TVM CUDAModule"""
-    kernel_metadata = compiled.metadata
-    kernel_name = compiled.name
-    ptx = compiled.asm["ptx"]
-    assert kernel_metadata.num_ctas == 1, "Cluster is not supported"
-    num_warps = kernel_metadata.num_warps
-    launch_param_tags = ["threadIdx.x"] + ["blockIdx.x", "blockIdx.y", "blockIdx.z"][: len(grid)]
-    launch_args = [num_warps * 32] + list(grid)
-    if kernel_metadata.shared > 0:
-        # Add shared memory size to the launch arguments
-        launch_param_tags.append("tir.use_dyn_shared_memory")
-        launch_args.append(kernel_metadata.shared)
-    tvm_metadata = """{{
-        "tvm_version": "{version}",
-        "func_info": {{
-            "{kernel_name}": {{
-                "name": "",
-                "arg_types": {arg_types},
-                "launch_param_tags": {launch_param_tags}
-            }}
-        }}
-    }}""".format_map(
-        {
-            "version": __version__,
-            "kernel_name": kernel_name,
-            "arg_types": json.dumps(kernel_arg_types),
-            "launch_param_tags": json.dumps(launch_param_tags),
-        }
-    )
-    with tempfile.TemporaryDirectory() as temp_dir:
-        ptx_path = f"{temp_dir}/{kernel_name}.ptx"
-        with open(ptx_path, "w") as f:
-            f.write(ptx)
-        with open(f"{temp_dir}/{kernel_name}.tvm_meta.json", "w") as f:
-            f.write(tvm_metadata)
-        kernel_module = load_module(ptx_path)
-
-    return kernel_module, launch_args
-
-
-def call_triton(
-    func: "triton.runtime.jit.JITFunction",
-    grid: List[Union[int, tir.PrimExpr]],
-    *args: List[tir.PrimExpr],
-    **kwargs: Any,
-):
-    """Invoke a triton kernel.
-
-    This is a macro that bridges the Triton kernel with TVM runtime. Specifically, it performs the
-    following steps:
+    This class bridges the Triton kernel with TVM runtime. The compilation includes the following steps:
         - Deduce the kernel signature and generate the Triton kernel
         - Embed the compiled kernel into the current IRModule as an external module
         - Generate a call to the Triton kernel following its calling convention via call_packed.
-
-    Parameters
-    ----------
-    func : tt
-        The Triton kernel function to invoke.
-    grid : List[Union[int, tir.PrimExpr]]
-        The grid configuration to launch the kernel.
-    args : List[tir.PrimExpr]
-        The arguments to the Triton kernel.
-    kwargs : Any
-        Additional options for the kernel compilation.
     """
-    compiled, kernel_args, kernel_arg_types = _generate_triton_kernel(func, grid, *args, **kwargs)
-    kernel_module, launch_args = _pack_kernel_module(compiled, grid, kernel_arg_types)
-    from .ir import call_packed
-    from ..ir import module_get_attr, module_set_attr
 
-    kernel_launch = call_packed(compiled.name, *kernel_args, *launch_args)
-    # Attach the kernel module to the current IRModule
-    external_mods = module_get_attr("external_mods") or []
-    external_mods.append(kernel_module)
-    module_set_attr("external_mods", external_mods, True)
-    return kernel_launch
+    def __init__(self, func):
+        self.func = func
+
+    def compile_to_device_module(
+        self, grid: List[Union[int, tir.PrimExpr]], *args: List[Any], **kwargs: Dict[str, Any]
+    ) -> Tuple[str, Module, List[Any]]:
+        """Compile the kernel to a device module.
+
+        Parameters
+        ----------
+        grid : List[int]
+            The grid size of the kernel. A list of one to three expressions, representing the number of
+            "blockIdx.x", "blockIdx.y", and "blockIdx.z" respectively.
+
+        args : List[Any]
+            Arguments to the kernel function.
+
+        kwargs : Dict[str, Any]
+            Additional options for the kernel compilation.
+        """
+        triton_kernel, kernel_args = self._generate_triton_kernel(self.func, grid, *args, **kwargs)
+        kernel_metadata = triton_kernel.metadata
+        ptx = triton_kernel.asm["ptx"]
+        assert kernel_metadata.num_ctas == 1, "Cluster is not supported"
+        num_warps = kernel_metadata.num_warps
+        launch_param_tags = ["threadIdx.x"] + ["blockIdx.x", "blockIdx.y", "blockIdx.z"][
+            : len(grid)
+        ]
+        launch_args = [num_warps * 32] + list(grid)
+        kernel_arg_types = [arg.dtype for arg in kernel_args]
+        if triton_kernel.metadata.shared > 0:
+            # Add shared memory size to the launch arguments
+            launch_param_tags.append("tir.use_dyn_shared_memory")
+            launch_args.append(triton_kernel.metadata.shared)
+
+        kernel_module = self._create_cuda_module(
+            ptx, kernel_arg_types, launch_param_tags, triton_kernel.name
+        )
+
+        return triton_kernel.name, kernel_module, kernel_args + launch_args
+
+    def _generate_triton_kernel(
+        self, func, grid, *args, **kwargs
+    ) -> Tuple["triton.compiler.CompiledKernel", List[tir.PrimExpr]]:
+        """Deduce the kernel signature and generate the Triton kernel"""
+
+        kernel_params = func.params
+        assert len(kernel_params) == len(
+            args
+        ), f"Number of arguments does not match, expected {len(kernel_params)}, got {len(args)}"
+
+        signature = {}
+        constants = {}
+        kernel_args = []  # Arguments to invoke the kernel
+        for i, arg in enumerate(args):
+            if kernel_params[i].is_constexpr:
+                constants[kernel_params[i].name] = get_const_int(arg)
+                continue
+            if arg.dtype == "handle":
+                assert isinstance(arg, tir.Var)
+                elem_type = arg.type_annotation.element_type.dtype
+                pointer_type = "*" + type_canonicalisation_dict[elem_type]
+                signature[kernel_params[i].name] = pointer_type
+            else:
+                signature[kernel_params[i].name] = type_canonicalisation_dict[arg.dtype]
+            kernel_args.append(arg)
+
+        # TODO: Support default argument in the kernel
+        # TODO: Add specialization for aligned buffer pointers
+        source = triton.compiler.ASTSource(fn=func, constants=constants, signature=signature)
+        compiled = triton.compiler.compile(source)
+        return compiled, kernel_args

--- a/python/tvm/script/ir_builder/tir/triton.py
+++ b/python/tvm/script/ir_builder/tir/triton.py
@@ -1,4 +1,5 @@
 """Triton kernel integration with TIR"""
+
 from typing import Tuple, List, Union, Any, Dict
 
 import triton
@@ -23,13 +24,16 @@ class TritonKernel(BaseKernel):
         self.func = func
 
     def compile_to_device_module(
-        self, grid: List[Union[int, tir.PrimExpr]], *args: List[Any], **kwargs: Dict[str, Any]
+        self,
+        launch_args: List[Union[int, tir.PrimExpr]],
+        *args: List[Any],
+        **kwargs: Dict[str, Any],
     ) -> Tuple[str, Module, List[Any]]:
         """Compile the kernel to a device module.
 
         Parameters
         ----------
-        grid : List[int]
+        launch_args : List[int]
             The grid size of the kernel. A list of one to three expressions, representing the number
             of
             "blockIdx.x", "blockIdx.y", and "blockIdx.z" respectively.
@@ -45,6 +49,7 @@ class TritonKernel(BaseKernel):
         ptx = triton_kernel.asm["ptx"]
         assert kernel_metadata.num_ctas == 1, "Cluster is not supported"
         num_warps = kernel_metadata.num_warps
+        grid = launch_args
         launch_param_tags = ["threadIdx.x"] + ["blockIdx.x", "blockIdx.y", "blockIdx.z"][
             : len(grid)
         ]

--- a/python/tvm/script/ir_builder/tir/triton.py
+++ b/python/tvm/script/ir_builder/tir/triton.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 """Triton kernel integration with TIR"""
 
 from typing import Tuple, List, Union, Any, Dict

--- a/python/tvm/script/ir_builder/tir/triton.py
+++ b/python/tvm/script/ir_builder/tir/triton.py
@@ -1,0 +1,130 @@
+import triton
+from triton.runtime.jit import type_canonicalisation_dict
+from tvm import tir
+from tvm.topi.utils import get_const_int
+from tvm.runtime import load_module, Module
+import tempfile
+import json
+from tvm._ffi.libinfo import __version__
+
+from typing import Tuple, List, Union, Any
+
+
+def _generate_triton_kernel(
+    func, grid, *args, **kwargs
+) -> Union[triton.compiler.CompiledKernel, List[tir.PrimExpr], List[str]]:
+    """Deduce the kernel signature and generate the Triton kernel"""
+
+    kernel_params = func.params
+    assert len(kernel_params) == len(
+        args
+    ), f"Number of arguments does not match, expected {len(kernel_params)}, got {len(args)}"
+
+    # Step 1: Generate the Triton kernel
+    signature = {}
+    constants = {}
+    # Arguments to invoke the kernel
+    kernel_args = []
+    kernel_arg_types = []
+    for i, arg in enumerate(args):
+        if kernel_params[i].is_constexpr:
+            constants[kernel_params[i].name] = get_const_int(arg)
+            continue
+        if arg.dtype == "handle":
+            assert isinstance(arg, tir.Var)
+            elem_type = arg.type_annotation.element_type.dtype
+            pointer_type = "*" + type_canonicalisation_dict[elem_type]
+            signature[kernel_params[i].name] = pointer_type
+        else:
+            signature[kernel_params[i].name] = type_canonicalisation_dict[arg.dtype]
+        kernel_args.append(arg)
+        kernel_arg_types.append(arg.dtype)
+
+    # TODO: Support default argument in the kernel
+    # TODO: Add specialization for aligned buffer pointers
+    source = triton.compiler.ASTSource(fn=func, constants=constants, signature=signature)
+    compiled = triton.compiler.compile(source)
+    return compiled, kernel_args, kernel_arg_types
+
+
+def _pack_kernel_module(
+    compiled: "triton.compiler.CompiledKernel",
+    grid: List[Union[int, tir.PrimExpr]],
+    kernel_arg_types: List[str],
+) -> Tuple[Module, List[Union[int, tir.PrimExpr]]]:
+    """Pack the compiled kernel into a TVM CUDAModule"""
+    kernel_metadata = compiled.metadata
+    kernel_name = compiled.name
+    ptx = compiled.asm["ptx"]
+    assert kernel_metadata.num_ctas == 1, "Cluster is not supported"
+    num_warps = kernel_metadata.num_warps
+    launch_param_tags = ["threadIdx.x"] + ["blockIdx.x", "blockIdx.y", "blockIdx.z"][: len(grid)]
+    launch_args = [num_warps * 32] + list(grid)
+    if kernel_metadata.shared > 0:
+        # Add shared memory size to the launch arguments
+        launch_param_tags.append("tir.use_dyn_shared_memory")
+        launch_args.append(kernel_metadata.shared)
+    tvm_metadata = """{{
+        "tvm_version": "{version}",
+        "func_info": {{
+            "{kernel_name}": {{
+                "name": "",
+                "arg_types": {arg_types},
+                "launch_param_tags": {launch_param_tags}
+            }}
+        }}
+    }}""".format_map(
+        {
+            "version": __version__,
+            "kernel_name": kernel_name,
+            "arg_types": json.dumps(kernel_arg_types),
+            "launch_param_tags": json.dumps(launch_param_tags),
+        }
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        ptx_path = f"{temp_dir}/{kernel_name}.ptx"
+        with open(ptx_path, "w") as f:
+            f.write(ptx)
+        with open(f"{temp_dir}/{kernel_name}.tvm_meta.json", "w") as f:
+            f.write(tvm_metadata)
+        kernel_module = load_module(ptx_path)
+
+    return kernel_module, launch_args
+
+
+def call_triton(
+    func: "triton.runtime.jit.JITFunction",
+    grid: List[Union[int, tir.PrimExpr]],
+    *args: List[tir.PrimExpr],
+    **kwargs: Any,
+):
+    """Invoke a triton kernel.
+
+    This is a macro that bridges the Triton kernel with TVM runtime. Specifically, it performs the
+    following steps:
+        - Deduce the kernel signature and generate the Triton kernel
+        - Embed the compiled kernel into the current IRModule as an external module
+        - Generate a call to the Triton kernel following its calling convention via call_packed.
+
+    Parameters
+    ----------
+    func : tt
+        The Triton kernel function to invoke.
+    grid : List[Union[int, tir.PrimExpr]]
+        The grid configuration to launch the kernel.
+    args : List[tir.PrimExpr]
+        The arguments to the Triton kernel.
+    kwargs : Any
+        Additional options for the kernel compilation.
+    """
+    compiled, kernel_args, kernel_arg_types = _generate_triton_kernel(func, grid, *args, **kwargs)
+    kernel_module, launch_args = _pack_kernel_module(compiled, grid, kernel_arg_types)
+    from .ir import call_packed
+    from ..ir import module_get_attr, module_set_attr
+
+    kernel_launch = call_packed(compiled.name, *kernel_args, *launch_args)
+    # Attach the kernel module to the current IRModule
+    external_mods = module_get_attr("external_mods") or []
+    external_mods.append(kernel_module)
+    module_set_attr("external_mods", external_mods, True)
+    return kernel_launch

--- a/tests/python/contrib/test_tir_triton_integration.py
+++ b/tests/python/contrib/test_tir_triton_integration.py
@@ -1,0 +1,79 @@
+import numpy as np
+import sys
+
+import tvm
+from tvm.script import tir as T
+from tvm.script import relax as R
+from tvm.script import ir as I
+from tvm import relax
+from tvm.relax.frontend import nn
+import tvm.testing
+import pytest
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    pytestmark = pytest.skip("Triton is not available", allow_module_level=True)
+
+
+@tvm.testing.requires_cuda
+def test_tir_triton_integration():
+    @triton.jit
+    def add_kernel(
+        x_ptr,  # *Pointer* to first input vector.
+        y_ptr,  # *Pointer* to second input vector.
+        output_ptr,  # *Pointer* to output vector.
+        n_elements,  # Size of the vector.
+        BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
+    ):
+        """Triton vector add kernel from its tutorial."""
+        pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(x_ptr + offsets, mask=mask)
+        y = tl.load(y_ptr + offsets, mask=mask)
+        output = x + y
+        tl.store(output_ptr + offsets, output, mask=mask)
+
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def add(x_handle: T.handle, y_handle: T.handle, output_handle: T.handle) -> None:
+            T.func_attr({"global_symbol": "add"})
+            m = T.int64()
+            x = T.match_buffer(x_handle, (m,), "float32")
+            y = T.match_buffer(y_handle, (m,), "float32")
+            output = T.match_buffer(output_handle, (m,), "float32")
+            with T.block("root"):
+                T.reads(x[0:m], y[0:m])
+                T.writes(output[0:m])
+                BLOCK_SIZE = T.meta_var(64)
+                T.call_triton(
+                    add_kernel,
+                    (T.ceildiv(m, BLOCK_SIZE),),
+                    x.data,
+                    y.data,
+                    output.data,
+                    m,
+                    BLOCK_SIZE,
+                )
+
+        @R.function
+        def main(x: R.Tensor(("m",), "float32"), y: R.Tensor(("m",), "float32")):
+            m = T.int64()
+            with R.dataflow():
+                output = R.call_tir(Module.add, [x, y], relax.TensorStructInfo((m,), "float32"))
+                R.output(output)
+            return output
+
+    device = tvm.cuda(0)
+    x_nd = tvm.nd.array(np.random.rand(256).astype(np.float32), device)
+    y_nd = tvm.nd.array(np.random.rand(256).astype(np.float32), device)
+    output_np = x_nd.numpy() + y_nd.numpy()
+
+    with tvm.target.Target("cuda"):
+        lib = relax.build(Module)
+        output_nd = tvm.runtime.relax_vm.VirtualMachine(lib, device)["main"](x_nd, y_nd)
+        tvm.testing.assert_allclose(output_nd.numpy(), output_np, rtol=1e-5)

--- a/tests/python/contrib/test_tir_triton_integration.py
+++ b/tests/python/contrib/test_tir_triton_integration.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 import numpy as np
 import sys
 


### PR DESCRIPTION
Added a macro `T.call_triton` in TIR script parser, which expands to AOT compilation of the kernel and the host TIR code to launch the kernel.

cc @tqchen @cyx-6 