### PR TITLE
[MetaSchedule]Fix the bug when load database_tuning_record.json if there is pad_einsum primitive.

### DIFF
--- a/src/tir/schedule/primitive/pad_einsum.cc
+++ b/src/tir/schedule/primitive/pad_einsum.cc
@@ -491,13 +491,31 @@ struct PadEinsumTraits : public UnpackedInstTraits<PadEinsumTraits> {
   static constexpr size_t kNumDecisions = 0;
 
   static void UnpackedApplyToSchedule(Schedule sch, BlockRV block, Array<Integer> padding) {
-    sch->PadEinsum(block, padding);
+    Array<Integer> int32_padding;
+    for (const auto& pad : padding) {
+        if (pad.IntValue() <= INT32_MAX) {
+          int32_padding.push_back(Integer(pad.IntValue()));
+        }
+        else {
+          int32_padding.push_back(pad);
+        }
+    }
+    sch->PadEinsum(block, int32_padding);
   }
 
   static String UnpackedAsPython(Array<String> outputs, String block, Array<Integer> padding) {
     PythonAPICall py("pad_einsum");
+    Array<Integer> int32_padding;
+    for (const auto& pad : padding) {
+        if (pad.IntValue() <= INT32_MAX) {
+          int32_padding.push_back(Integer(pad.IntValue()));
+        }
+        else {
+          int32_padding.push_back(pad);
+        }
+    }
     py.Input("block", block);
-    py.Input("padding", padding);
+    py.Input("padding", int32_padding);
     return py.Str();
   }
 


### PR DESCRIPTION
When loading from database_tuning_record.json in Meta Schedule (this line: `B_reindex_pad_shared_dyn[v0, v1] = T.if_then_else(v0 < 1, B[v1, v0], T.float16(0)))`, the parameter dtype of the primitive pad_einsum is read as int64, causing a block iterator v0 that should be int32 to be inferred as int64. This results in an InternalError: Check failed: (ret_ex.dtype() == var.dtype()) is false: substituting v0:int32 -> v0:int64. This commit performs a type conversion within UnpackedApplyToSchedule to fix this bug.
```
for ax0_ax1_fused in range(2048):
    with T.block("B_reindex_pad_shared.dyn"):
        v0 = T.axis.spatial(16, ax0_ax1_fused // 128)
        v1 = T.axis.spatial(4096, ax2_0_0 * 128 + ax0_ax1_fused % 128)
        T.reads(B[v1, v0])
        T.writes(B_reindex_pad_shared_dyn[v0, v1])
        T.block_attr({"buffer_dim_align": [[0, 0, 32, 8]], "meta_schedule.cooperative_fetch": 1})
        B_reindex_pad_shared_dyn[v0, v1] = T.if_then_else(v0 < 1, B[v1, v0], T.float16(0))
```