### PR TITLE
Revert "[FFI] Add python signal handler for ctypes FFI (#17181)"

### DIFF
--- a/python/tvm/_ffi/_ctypes/packed_func.py
+++ b/python/tvm/_ffi/_ctypes/packed_func.py
@@ -200,7 +200,6 @@ class PackedFuncBase(object):
     """Function base."""
 
     __slots__ = ["handle", "is_global"]
-
     # pylint: disable=no-member
     def __init__(self, handle, is_global):
         """Initialize the function with handle
@@ -348,7 +347,6 @@ def _init_pythonapi_inc_def_ref():
     register_func(c_str("Py_DecRef"), ctypes.pythonapi.Py_DecRef)
     register_func(c_str("PyGILState_Ensure"), ctypes.pythonapi.PyGILState_Ensure)
     register_func(c_str("PyGILState_Release"), ctypes.pythonapi.PyGILState_Release)
-    register_func(c_str("PyErr_CheckSignals"), ctypes.pythonapi.PyErr_CheckSignals)
 
 
 _init_pythonapi_inc_def_ref()


### PR DESCRIPTION
This reverts commit 91e9c63b42fcccec196a8ef9ed7a7bc7f82c2e52.

We noticed that the function `ctypes.pythonapi.PyErr_CheckSignals` may unexpectedly run into error and terminate the running process. Therefore, we revert this PR to avoid such termination.