### PR TITLE
[Relax] Introduce static shape tuning pipeline

### DIFF
--- a/docs/how_to/tutorials/e2e_opt_model.py
+++ b/docs/how_to/tutorials/e2e_opt_model.py
@@ -101,21 +101,7 @@ work_dir = "tuning_logs"
 # Skip running in CI environment
 IS_IN_CI = os.getenv("CI", "") == "true"
 if not IS_IN_CI:
-    with target:
-        mod = tvm.ir.transform.Sequential(
-            [
-                # Convert BatchNorm into a sequence of simpler ops for fusion
-                relax.transform.DecomposeOpsForInference(),
-                # Canonicalize the bindings
-                relax.transform.CanonicalizeBindings(),
-                # Run default optimization pipeline
-                relax.get_pipeline("zero"),
-                # Tune the model and store the log to database
-                relax.transform.MetaScheduleTuneIRMod({}, work_dir, TOTAL_TRIALS),
-                # Apply the database
-                relax.transform.MetaScheduleApplyDatabase(work_dir),
-            ]
-        )(mod)
+    mod = relax.get_pipeline("static_shape_tuning", target=target, total_trials=TOTAL_TRIALS)(mod)
 
     # Only show the main function
     mod["main"].show()

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -1020,14 +1020,13 @@ def BundleModelParams(param_tuple_name: Optional[str] = None) -> tvm.ir.transfor
     ----------
     param_tuple_name: Optional[str]
 
-        The name of the tuple parameter.  If unspecified, defaults to
+        The name of the tuple parameter. If unspecified, defaults to
         "model_params".
 
     Returns
     -------
     ret : tvm.transform.Pass
-        The registered pass for lifting transformation of parameters.
-
+        The registered pass for bundling model parameters.
     """
     return _ffi_api.BundleModelParams(param_tuple_name)  # type: ignore
 


### PR DESCRIPTION
This PR introduces a static shape tuning pipeline for Relax. It is designed to work with the MetaSchedule tuning framework to optimize the performance of the model.

Together with a minor typo fix