### PR TITLE
[CI] Update Jenkins image tags to include NNEF

### DIFF
--- a/ci/jenkins/docker-images.ini
+++ b/ci/jenkins/docker-images.ini
@@ -17,13 +17,13 @@
 
 # This data file is read during when Jenkins runs job to determine docker images.
 [jenkins]
-ci_arm: tlcpack/ci-arm:20240917-153130-9f281758
-ci_cortexm: tlcpack/ci-cortexm:20240917-153130-9f281758
-ci_cpu: tlcpack/ci_cpu:20240917-153130-9f281758
-ci_gpu: tlcpack/ci-gpu:20240917-153130-9f281758
-ci_hexagon: tlcpack/ci-hexagon:20240917-153130-9f281758
+ci_arm: tlcpack/ci_arm:20241004-072744-ba0881ef
+ci_cortexm: tlcpack/ci_cortexm:20241004-072744-ba0881ef
+ci_cpu: tlcpack/ci_cpu:20241004-072744-ba0881ef
+ci_gpu: tlcpack/ci_gpu:20241004-072744-ba0881ef
+ci_hexagon: tlcpack/ci_hexagon:20241004-072744-ba0881ef
 ci_i386: tlcpack/ci-i386:20240917-153130-9f281758
 ci_lint: tlcpack/ci-lint:20240917-153130-9f281758
 ci_minimal: tlcpack/ci-minimal:20240917-153130-9f281758
-ci_riscv: tlcpack/ci-riscv:20240917-153130-9f281758
+ci_riscv: tlcpack/ci_riscv:20241004-072744-ba0881ef
 ci_wasm: tlcpack/ci-wasm:20240917-153130-9f281758


### PR DESCRIPTION
Continuing on https://github.com/apache/tvm/pull/17433.
The images changed are arm, cortexm, cpu, gpu, hexagon, riscv.
