### PR TITLE
[TIR] Enhance `LowerThreadAllreduce` pass to automatically infer shared memory scope

### DIFF
--- a/src/tir/transforms/lower_thread_allreduce.cc
+++ b/src/tir/transforms/lower_thread_allreduce.cc
@@ -284,7 +284,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
     // sort according to dim_index
     std::sort(block_threads.begin(), block_threads.end());
     for (auto&& thr_attr : block_threads) {
-      auto[dim_index, extent, is_reduce] = thr_attr;
+      auto [dim_index, extent, is_reduce] = thr_attr;
       (void)dim_index;  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81767
       if (is_reduce) {
         contiguous_reduce_extent *= extent;

--- a/tests/python/tir-transform/test_tir_transform_lower_thread_all_reduce.py
+++ b/tests/python/tir-transform/test_tir_transform_lower_thread_all_reduce.py
@@ -767,5 +767,114 @@ class TestMetalNoMask(BaseCompare):
             B_1[threadIdx_y] = red_result_1[threadIdx_y]
 
 
+class TestAutoInferSharedMemoryScope(BaseCompare):
+    @T.prim_func(private=True)
+    def before(A: T.Buffer((4, 128), "float32"), B: T.Buffer((4,), "float32")):
+        T.func_attr({"target": T.target("cuda", host="llvm")})
+        threadIdx_y = T.launch_thread("threadIdx.y", 4)
+        cross_thread_B = T.allocate([1], "float32", "local")
+        threadIdx_x = T.launch_thread("threadIdx.x", 128)
+        cross_thread_B_1 = T.Buffer((1,), data=cross_thread_B, scope="local")
+
+        A_shared = T.allocate([512], "float32", "shared.dyn")
+        A_shared_1 = T.Buffer((512,), data=A_shared, scope="shared.dyn")
+
+        with T.block("smem_copy"):
+            for i, j in T.grid(4, 128):
+                A_shared_1[i * 128 + j] = A[i, j]
+
+        with T.attr(
+            T.comm_reducer(lambda x0, y0: x0 + y0, [T.float32(0)]),
+            "reduce_scope",
+            T.reinterpret("handle", T.uint64(0)),
+        ):
+            T.tvm_thread_allreduce(
+                T.uint32(1),
+                A_shared_1[threadIdx_y * 128 + threadIdx_x],
+                T.bool(True),
+                cross_thread_B_1[0],
+                threadIdx_x,
+            )
+        if threadIdx_x == 0:
+            B_1 = T.Buffer((4,), data=B.data)
+            B_1[threadIdx_y] = cross_thread_B_1[0]
+
+    @T.prim_func(private=True)
+    def expected(A: T.Buffer((4, 128), "float32"), B: T.Buffer((4,), "float32")):
+        T.func_attr(
+            {
+                "target": T.target(
+                    {
+                        "arch": "sm_80",
+                        "host": {
+                            "keys": ["cpu"],
+                            "kind": "llvm",
+                            "mtriple": "x86_64-unknown-linux-gnu",
+                            "tag": "",
+                        },
+                        "keys": ["cuda", "gpu"],
+                        "kind": "cuda",
+                        "max_num_threads": 1024,
+                        "tag": "",
+                        "thread_warp_size": 32,
+                    }
+                )
+            }
+        )
+
+        threadIdx_y = T.launch_thread("threadIdx.y", 4)
+        red_result = T.allocate([4], "float32", "shared")
+        T.attr(red_result, "volatile_scope", 1)
+        threadIdx_x = T.launch_thread("threadIdx.x", 128)
+        A_shared_1 = T.allocate([512], "float32", "shared.dyn")
+        A_shared_1_1 = T.Buffer((512,), data=A_shared_1, scope="shared.dyn")
+        with T.block("smem_copy"):
+            T.reads(A[0:4, 0:128])
+            T.writes()
+            for i, j in T.grid(4, 128):
+                A_shared_1_1[i * 128 + j] = A[i, j]
+        red_result_1 = T.Buffer((4,), data=red_result, scope="shared")
+        with T.attr(
+            T.comm_reducer(lambda x0, y0: x0 + y0, [T.float32(0)]),
+            "reduce_scope",
+            T.reinterpret("handle", T.uint64(0)),
+        ):
+            red_buf0 = T.decl_buffer((1,), scope="local")
+            mask = T.decl_buffer((1,), "uint32", scope="local")
+            t0 = T.decl_buffer((1,), scope="local")
+            red_buf0_1 = T.decl_buffer((1,), scope="local")
+            mask_1 = T.decl_buffer((1,), "uint32", scope="local")
+            t0_1 = T.decl_buffer((1,), scope="local")
+            red_buf_staging = T.decl_buffer((16,), scope="shared")
+            red_buf0_1[0] = A_shared_1_1[threadIdx_y * 128 + threadIdx_x]
+            mask_1[0] = T.tvm_warp_activemask()
+            t0_1[0] = T.tvm_warp_shuffle_down(mask_1[0], red_buf0_1[0], 16, 32, 32)
+            red_buf0_1[0] = red_buf0_1[0] + t0_1[0]
+            t0_1[0] = T.tvm_warp_shuffle_down(mask_1[0], red_buf0_1[0], 8, 32, 32)
+            red_buf0_1[0] = red_buf0_1[0] + t0_1[0]
+            t0_1[0] = T.tvm_warp_shuffle_down(mask_1[0], red_buf0_1[0], 4, 32, 32)
+            red_buf0_1[0] = red_buf0_1[0] + t0_1[0]
+            t0_1[0] = T.tvm_warp_shuffle_down(mask_1[0], red_buf0_1[0], 2, 32, 32)
+            red_buf0_1[0] = red_buf0_1[0] + t0_1[0]
+            t0_1[0] = T.tvm_warp_shuffle_down(mask_1[0], red_buf0_1[0], 1, 32, 32)
+            red_buf0_1[0] = red_buf0_1[0] + t0_1[0]
+            if threadIdx_x % 32 == 0:
+                red_buf_staging[threadIdx_y * 4 + threadIdx_x // 32] = red_buf0_1[0]
+            T.tvm_storage_sync("shared")
+            if threadIdx_x < 4:
+                red_buf0[0] = red_buf_staging[threadIdx_y * 4 + threadIdx_x]
+            mask[0] = T.tvm_warp_activemask()
+            t0[0] = T.tvm_warp_shuffle_down(mask[0], red_buf0[0], 2, 32, 32)
+            red_buf0[0] = red_buf0[0] + t0[0]
+            t0[0] = T.tvm_warp_shuffle_down(mask[0], red_buf0[0], 1, 32, 32)
+            red_buf0[0] = red_buf0[0] + t0[0]
+            if threadIdx_x == 0:
+                red_result_1[threadIdx_y] = red_buf0[0]
+            T.tvm_storage_sync("shared")
+        if threadIdx_x == 0:
+            B_1 = T.Buffer((4,), data=B.data)
+            B_1[threadIdx_y] = red_result_1[threadIdx_y]
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
The pass `LowerThreadAllreduce` enables efficient block reduction. However, block reduction often requires a large amount of shared memory space. The current implementation of `LowerThreadAllreduce` only enable static shared memory reduce buffer allocation and prevents the shared memory merging when another shared memory scope is defined as `shared.dyn`.

```cpp
A_shared: "shared.dyn"
B_shared: "shared.dyn"
C_shared: "shared.dyn"
red: "shared" (can not be merged into the union shared memory pool)
```

This pull request addresses this issue by first collecting buffer allocations, and then determining the memory scope of the reduction buffer, allowing for memory space fusion in the following `MergeSharedMemoryAllocations` pass.