### PR TITLE
Try to fix windows CI conda build issue

### DIFF
--- a/conda/build-environment.yaml
+++ b/conda/build-environment.yaml
@@ -26,7 +26,8 @@ channels:
 # The packages to install to the environment
 dependencies:
   - python=3.9
-  - conda-build
+  - conda < 24.9.0
+  - conda-build < 24.9.0
   - git
   - llvmdev >=11
   - numpy


### PR DESCRIPTION
This PR fixes the Windows conda build issue on CI by pining conda version `<24.9.0`