### PR TITLE
[MetaSchedule] Fix a multilevel tiling error on dynamic relax workload

### DIFF
--- a/src/tir/schedule/analysis/analysis.cc
+++ b/src/tir/schedule/analysis/analysis.cc
@@ -1581,14 +1581,14 @@ std::pair<int64_t, int64_t> GetCumulativeSpaceAndReductionLength(const tir::Sche
     tir::IterVarType type = GetLoopIterType(loop_sref);
     if (type == tir::kDataPar) {
       const int64_t* extent = GetLoopIntExtent(loop_sref);
-      if (*extent != -1) {
+      if (extent && *extent != -1) {
         cum_space_len *= *extent;
       } else {
         return std::make_pair(-1, -1);
       }
     } else if (type == tir::kCommReduce) {
       const int64_t* extent = GetLoopIntExtent(loop_sref);
-      if (*extent != -1) {
+      if (extent && *extent != -1) {
         cum_reduce_len *= *extent;
       } else {
         return std::make_pair(-1, -1);

--- a/src/tir/schedule/concrete_schedule.cc
+++ b/src/tir/schedule/concrete_schedule.cc
@@ -246,8 +246,10 @@ Array<ExprRV> ConcreteScheduleNode::SamplePerfectTile(const LoopRV& loop_rv, int
                                                       int max_innermost_factor,
                                                       Optional<Array<Integer>> decision) {
   TVM_TIR_SCHEDULE_BEGIN();
+  // use None RV object to denotes auto-infer tile factors.
   return CreateRV(tir::SamplePerfectTile(&this->rand_state_, this->GetSRef(loop_rv), n,
-                                         max_innermost_factor, &decision));
+                                         max_innermost_factor, &decision),
+                  /*convert_negone_to_none=*/true);
   TVM_TIR_SCHEDULE_END("sample-perfect-tile", this->error_render_level_);
   throw;
 }

--- a/src/tir/schedule/concrete_schedule.h
+++ b/src/tir/schedule/concrete_schedule.h
@@ -217,9 +217,12 @@ class ConcreteScheduleNode : public ScheduleNode {
   /*!
    * \brief Add a list of integers as random variables into the symbol table
    * \param value The list of integers to be added to the symbol table
+   * \param convert_negone_to_none Convert negative one to none RV.
+   * Which is convention of certain primitives.
    * \return The new random variables created
    */
-  inline Array<ExprRV> CreateRV(const std::vector<int64_t>& value);
+  inline Array<ExprRV> CreateRV(const std::vector<int64_t>& value,
+                                bool convert_negone_to_none = false);
   /*! \brief Remove a random variable from the symbol table */
   inline void RemoveFromSymbolTable(const ObjectRef& rv);
   /*!
@@ -360,10 +363,15 @@ inline ExprRV ConcreteScheduleNode::CreateRV(int64_t value) {
   return std::move(rv);
 }
 
-inline Array<ExprRV> ConcreteScheduleNode::CreateRV(const std::vector<int64_t>& value) {
+inline Array<ExprRV> ConcreteScheduleNode::CreateRV(const std::vector<int64_t>& value,
+                                                    bool convert_negone_to_none) {
   Array<ExprRV> results;
   results.reserve(value.size());
   for (int64_t v : value) {
+    if (convert_negone_to_none && v == -1) {
+      results.push_back(ExprRV(nullptr));
+      continue;
+    }
     results.push_back(CreateRV(v));
   }
   return results;

--- a/src/tir/schedule/trace.cc
+++ b/src/tir/schedule/trace.cc
@@ -227,7 +227,9 @@ Array<String> TranslateAddOutputRVs(
     ICHECK(!rv_names->count(output))
         << "ValueError: The random variable has been produced once: " << rv_names->at(output);
     String result{ObjectPtr<StringObj>{nullptr}};
-    if (output->IsInstance<BlockRVNode>()) {
+    if (!output.defined()) {
+      result = "_";
+    } else if (output->IsInstance<BlockRVNode>()) {
       result = "b" + std::to_string(i);
     } else if (output->IsInstance<LoopRVNode>()) {
       result = "l" + std::to_string(i);

--- a/src/tir/schedule/traced_schedule.cc
+++ b/src/tir/schedule/traced_schedule.cc
@@ -70,9 +70,11 @@ ExprRV TracedScheduleNode::SampleCategorical(const Array<runtime::Int>& candidat
 Array<ExprRV> TracedScheduleNode::SamplePerfectTile(const LoopRV& loop_rv, int n,
                                                     int max_innermost_factor,
                                                     Optional<Array<Integer>> decision) {
-  Array<ExprRV> results = CreateRV(tir::SamplePerfectTile(
-      &this->rand_state_, this->GetSRef(loop_rv), n, max_innermost_factor, &decision));
-
+  // use None RV object to denotes auto-infer tile factors.
+  Array<ExprRV> results =
+      CreateRV(tir::SamplePerfectTile(&this->rand_state_, this->GetSRef(loop_rv), n,
+                                      max_innermost_factor, &decision),
+               /*convert_negone_to_none=*/true);
   static const InstructionKind& kind = InstructionKind::Get("SamplePerfectTile");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,  //
                                       /*inputs=*/{loop_rv},


### PR DESCRIPTION
Below script would either segfault or report primitive error in `MetaScheduleTuneIRMod` with dynamic dim.

```python
import tvm
from tvm import relax
from tvm.relax.frontend import nn
from tvm.relax.transform import *

class NNModule(nn.Module):
    def __init__(self):
        super().__init__()
        self.fc2 = nn.Linear(784, 128)

    def forward(self, x):
        x = self.fc2(x)
        return x

mod, params = NNModule().export_tvm({"forward": {"x": nn.spec.Tensor(("n", 784), "float32")}})
mod.show()

# with tvm.target.Target("cuda -max_threads_per_block=4096 -max_shared_memory_per_block=8192 -arch=sm_70"):
with tvm.target.Target("llvm -num-cores 32"):
    mod = LegalizeOps()(mod)
    mod = AnnotateTIROpPattern()(mod)
    mod = FoldConstant()(mod)
    mod = FuseOps()(mod)
    mod = FuseTIR()(mod)
    mod = MetaScheduleTuneIRMod({}, "myworkingdir", 3)(mod)
    application_pass = MetaScheduleApplyDatabase( "myworkingdir")
    mod = application_pass(mod)
    
print(mod)
m = relax.build(mod, target="llvm", pipeline="default_build")
```

The change fix two related issues:

1. `GetLoopIntExtent()` would return nullptr on non-const extent, thus the return value should check the nullity.

2. `tir::SamplePerfectTile()` return -1 for dynamic factor part. While the `Split` primitive require None rv to denotes the dynamic dim inference. Thus it should handle this semantic gap in schedule interfaces.