### PR TITLE
[Device][OpenCL] add CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST to …

### DIFF
--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -171,6 +171,8 @@ inline const char* CLGetErrorString(cl_int error) {
       return "CL_INVALID_BUFFER_SIZE";
     case CL_INVALID_MIP_LEVEL:
       return "CL_INVALID_MIP_LEVEL";
+    case CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST:
+      return "CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST";
     default:
       return "Unknown OpenCL error code";
   }


### PR DESCRIPTION
Hello,

I was facing few time problems when TVM says about undefined error -14. But this error is described(https://streamhpc.com/blog/2013-04-28/opencl-error-codes/) as  `CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST`. So I have added it. I think more error should be dedined, e.g. https://discuss.tvm.apache.org/t/rk3399-deploy-compiled-modules-with-c-error/85