### PR TITLE
Pin pytest-profiling==1.7.0

### DIFF
--- a/docker/install/ubuntu2004_install_python_package.sh
+++ b/docker/install/ubuntu2004_install_python_package.sh
@@ -35,7 +35,7 @@ pip3 install --upgrade \
     psutil \
     pytest \
     git+https://github.com/tlc-pack/tlcpack-sphinx-addon.git@768ec1dce349fe4708f6ad68be1ebb3f3dabafa1 \
-    pytest-profiling \
+    pytest-profiling==1.7.0 \
     pytest-xdist \
     pytest-rerunfailures==10.2 \
     requests \

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -35,7 +35,7 @@ pip3 install --upgrade \
     psutil \
     pytest \
     git+https://github.com/tlc-pack/tlcpack-sphinx-addon.git@768ec1dce349fe4708f6ad68be1ebb3f3dabafa1 \
-    pytest-profiling \
+    pytest-profiling!=1.8.0 \
     pytest-xdist \
     pytest-rerunfailures==10.2 \
     requests \


### PR DESCRIPTION
Part of #17451
pytest-profiling==1.8.0 was yanked so we'll pin to 1.7.0
https://pypi.org/project/pytest-profiling/1.8.0/