### PR TITLE
[FIX][ONNX][RELAX] Add support for dynamic ShapeExpr in Slice, Squeeze and Flatten

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1203,18 +1203,19 @@ class Squeeze(OnnxOpConverter):
         axis = get_constant(inputs[1], params)
         if isinstance(axis, relax.Constant):
             axis = [int(x) for x in axis.data.numpy()]
-        # If data is constant, perform computation directly.
-        if isinstance(data, relax.Constant):
-            out_data = _np.squeeze(data.data.numpy(), tuple(axis))
-            return relax.const(out_data, data.struct_info.dtype)
+            
+            # If data is constant, perform computation directly.
+            if isinstance(data, relax.Constant):
+                out_data = _np.squeeze(data.data.numpy(), tuple(axis))
+                return relax.const(out_data, data.struct_info.dtype)
 
-        if isinstance(data, relax.ShapeExpr):
-            if axis == [0]:
-                return relax.PrimValue(data[0])
-            else:
-                raise NotImplementedError(
-                    "Squeeze with symbolic axes and non-zero axes is not supported."
-                )
+            if isinstance(data, relax.ShapeExpr):
+                if axis == [0]:
+                    return relax.PrimValue(data[0])
+                else:
+                    raise NotImplementedError(
+                        "Squeeze with symbolic axes and non-zero axes is not supported."
+                    )
 
         return relax.op.squeeze(data, axis)
 

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1203,7 +1203,7 @@ class Squeeze(OnnxOpConverter):
         axis = get_constant(inputs[1], params)
         if isinstance(axis, relax.Constant):
             axis = [int(x) for x in axis.data.numpy()]
-            
+
             # If data is constant, perform computation directly.
             if isinstance(data, relax.Constant):
                 out_data = _np.squeeze(data.data.numpy(), tuple(axis))
@@ -1622,7 +1622,7 @@ class Slice(OnnxOpConverter):
             steps = [1] * len(axes)
         # If input is a shape tensor, we can directly extract it.
         if isinstance(data, relax.ShapeExpr):
-            shape_data = [dim for dim in data]
+            shape_data = list(data)
             # Starts, ends, and steps must be 1-d for shape operation.
             assert all(len(i) == 1 for i in [starts, ends, steps])
             sliced_values = shape_data[starts[0] : ends[0] : steps[0]]
@@ -2253,7 +2253,7 @@ class Flatten(OnnxOpConverter):
     @classmethod
     def _impl_v13(cls, bb, inputs, attr, params):
         axis = attr.get("axis", 1)
-        data_shape = [i for i in inputs[0].struct_info.shape]
+        data_shape = list(inputs[0].struct_info.shape)
 
         if axis == 0:
             new_shape = (1, -1)
@@ -2262,7 +2262,7 @@ class Flatten(OnnxOpConverter):
 
             if all(shape_flags):
                 data_shape = [x.value for x in data_shape[0:axis]]
-                new_shape = (_np.prod(data_shape[0:axis]).astype("int64"), -1)
+                new_shape = (_np.prod(data_shape).astype("int64"), -1)
             else:
                 batch_size = 1
 

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1570,7 +1570,7 @@ class Split(OnnxOpConverter):
             splits_rank = splits.checked_type.ndim
         if splits is not None and splits_rank > 0:
             if isinstance(splits, relax.Constant):
-                splits = splits.data.asnumpy()
+                splits = splits.data.numpy()
                 indices = []
                 index = 0
                 for i in splits[:-1]:

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1209,7 +1209,6 @@ class Squeeze(OnnxOpConverter):
             return relax.const(out_data, data.struct_info.dtype)
 
         if isinstance(data, relax.ShapeExpr):
-
             if axis == [0]:
                 return relax.PrimValue(data[0])
             else:
@@ -1622,7 +1621,6 @@ class Slice(OnnxOpConverter):
             steps = [1] * len(axes)
         # If input is a shape tensor, we can directly extract it.
         if isinstance(data, relax.ShapeExpr):
-
             shape_data = [dim for dim in data]
             # Starts, ends, and steps must be 1-d for shape operation.
             assert all(len(i) == 1 for i in [starts, ends, steps])

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1209,9 +1209,7 @@ class Squeeze(OnnxOpConverter):
             if isinstance(axis, (tuple, type(None))):
                 out_data = _np.squeeze(data.data.numpy(), axis)
             else:
-                raise NotImplementedError(
-                    "Squeeze with symbolic axes not supported"
-                )
+                raise NotImplementedError("Squeeze with symbolic axes not supported")
 
             return relax.const(out_data, data.struct_info.dtype)
 

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -52,27 +52,34 @@ def generate_random_inputs(
         shape = []
         for dim in i.type.tensor_type.shape.dim:
             shape.append(dim.dim_value)
-
-        # Extract datatype for the input.
-        if i.type.tensor_type.elem_type:
-            dtype = str(onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[i.type.tensor_type.elem_type])
-        else:
-            dtype = "float32"
-
-        # Generate random inputs for each input.
-        if dtype == "bool":
-            # random_value = np.random.choice(a=[False, True], size=shape)
-            random_value = rg.choice(a=[False, True], size=shape)
-        elif dtype.startswith("int"):
-            # Keep non-zero values
-            random_value = rg.integers(low=-63, high=63, size=shape).astype(dtype)
-            random_value[random_value <= 0] -= 1
-        else:
-            random_value = rg.standard_normal(size=shape).astype(dtype)
-        input_values[i.name] = random_value
+        
+        input_values[i.name] = generate_random_value(shape, i.type.tensor_type.elem_type)
 
     return input_values
 
+
+def generate_random_value(
+    shape, elem_type
+) -> np.ndarray:
+    
+    # Extract datatype for the input.
+    if elem_type:
+        dtype = str(onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[elem_type])
+    else:
+        dtype = "float32"
+
+    # Generate random inputs for each input.
+    if dtype == "bool":
+        # random_value = np.random.choice(a=[False, True], size=shape)
+        random_value = rg.choice(a=[False, True], size=shape)
+    elif dtype.startswith("int"):
+        # Keep non-zero values
+        random_value = rg.integers(low=-63, high=63, size=shape).astype(dtype)
+        random_value[random_value <= 0] -= 1
+    else:
+        random_value = rg.standard_normal(size=shape).astype(dtype)
+
+    return random_value
 
 def check_correctness(
     model: ModelProto,
@@ -156,6 +163,8 @@ def check_correctness(
         elif isinstance(tvm_out, tvm.runtime.ShapeTuple) and isinstance(ort_out, np.ndarray):
             shape_out = tvm.nd.array([int(i) for i in tvm_out])
             tvm.testing.assert_allclose(shape_out.numpy(), ort_out, rtol=rtol, atol=atol)
+        elif isinstance(tvm_out, (int, float, bool)) and isinstance(ort_out, np.ndarray):
+            tvm.testing.assert_allclose(np.array(tvm_out), ort_out, rtol=rtol, atol=atol)
         else:
             raise ValueError(f"Unsupported types: {type(tvm_out)}, {type(ort_out)}")
 
@@ -217,6 +226,30 @@ def verify_unary(
 
     model = helper.make_model(graph, producer_name="elemwise_test")
     check_correctness(model, opset=opset)
+
+def verify_unary_dynamic_shape(
+    op_name,
+    shape,
+    shape_instance,
+    attrs={},
+    domain=None,
+    input_dtype=TensorProto.FLOAT,
+    output_dtype=TensorProto.FLOAT,
+    opset=14,
+):
+    test_node = helper.make_node(op_name, ["x"], ["y"], **attrs, domain=domain)
+    graph = helper.make_graph(
+        [test_node],
+        "elemwise_test",
+        inputs=[
+            helper.make_tensor_value_info("x", input_dtype, shape),
+        ],
+        outputs=[helper.make_tensor_value_info("y", output_dtype, shape)],
+    )
+    
+    model = helper.make_model(graph, producer_name="elemwise_test")
+    inputs = {"x": generate_random_value(shape_instance, input_dtype)}
+    check_correctness(model, inputs, opset=opset)
 
 
 def verify_binary(
@@ -1012,6 +1045,81 @@ def test_squeeze(axis):
     model = helper.make_model(graph, producer_name="squeeze_test")
     check_correctness(model, opset=13)
 
+@pytest.mark.parametrize("axis", [[0, 2], None])
+def test_squeeze_constant(axis):
+    shape = [1, 32, 1, 32]
+    constant= make_constant_node("x", onnx.TensorProto.FLOAT, shape, rg.standard_normal(size=shape).astype("float32"))
+    if axis:        
+        squeeze_node = helper.make_node("Squeeze", ["x", "axes"], ["y"])
+    else:
+        squeeze_node = helper.make_node("Squeeze", ["x"], ["y"])
+
+    initializer = (
+        [helper.make_tensor("axes", TensorProto.INT64, [len(axis)], axis)] if axis else None
+    )
+
+    graph = helper.make_graph(
+        [constant, squeeze_node],
+        "squeeze_test",
+        inputs=[],
+        initializer=initializer,
+        outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, [32, 32])],
+    )
+
+    model = helper.make_model(graph, producer_name="squeeze_test")
+    check_correctness(model, opset=13)
+
+@pytest.mark.parametrize("axis", [[0]])
+@pytest.mark.parametrize("A", [8, 16, 32])
+@pytest.mark.parametrize("B", [8, 16, 32])
+def test_dynamic_squeeze(axis, A, B):
+    
+    squeeze_node = helper.make_node("Squeeze", ["x", "axes"], ["y"])
+    shape = [1, "A", "B"]
+
+    initializer = (
+        [helper.make_tensor("axes", TensorProto.INT64, [len(axis)], axis)] if axis else None
+    )
+
+    graph = helper.make_graph(
+        [squeeze_node],
+        "squeeze_test",
+        inputs=[
+            helper.make_tensor_value_info("x", TensorProto.FLOAT, shape),
+        ],
+        initializer=initializer,
+        outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, ["A", "B"])],
+    )
+
+    model = helper.make_model(graph, producer_name="squeeze_test")
+    inputs = {"x": rg.standard_normal(size=[1, A, B]).astype("float32")}     
+    check_correctness(model, inputs, opset=13)
+
+@pytest.mark.parametrize("axis", [[0]])
+@pytest.mark.parametrize("A", [8, 16, 32])
+def test_dynamic_shape_squeeze(axis, A):
+    
+    shape_node = helper.make_node("Shape", ["x"], ["y"])
+    squeeze_node = helper.make_node("Squeeze", ["y", "axes"], ["z"])
+    shape = ["A"]
+
+    initializer = (
+        [helper.make_tensor("axes", TensorProto.INT64, [len(axis)], axis)] if axis else None
+    )
+
+    graph = helper.make_graph(
+        [shape_node, squeeze_node],
+        "squeeze_test",
+        inputs=[
+            helper.make_tensor_value_info("x", TensorProto.FLOAT, shape),
+        ],
+        initializer=initializer,
+        outputs=[helper.make_tensor_value_info("z", TensorProto.INT64, [])],
+    )
+
+    model = helper.make_model(graph, producer_name="squeeze_test")
+    inputs = {"x": rg.standard_normal(size=[A]).astype("float32")}     
+    check_correctness(model, inputs, opset=13)
 
 def test_const():
     shape = [32, 32]
@@ -1547,6 +1655,65 @@ def test_slice():
     #     steps=[-1, -3, -2],
     # )
 
+def test_slice_dynamic_shape():
+    def verify_slice(data_shape, data_instance_shape, output_shape, starts, ends, axes=None, steps=None):
+        if isinstance(starts, list):
+            starts = np.array(starts, "int64")
+        if isinstance(ends, list):
+            ends = np.array(ends, "int64")
+        if isinstance(axes, list):
+            axes = np.array(axes, "int64")
+        if isinstance(steps, list):
+            steps = np.array(steps, "int64")
+
+        slice_inputs = ["y", "starts", "ends"]
+        initializer = [
+            helper.make_tensor("starts", TensorProto.INT64, starts.shape, starts),
+            helper.make_tensor("ends", TensorProto.INT64, ends.shape, ends),
+        ]
+
+        if axes is not None:
+            initializer.append(helper.make_tensor("axes", TensorProto.INT64, axes.shape, axes))
+            slice_inputs.append("axes")
+        if steps is not None:
+            initializer.append(helper.make_tensor("steps", TensorProto.INT64, steps.shape, steps))
+            slice_inputs.append("steps")
+        
+        shape_node = helper.make_node("Shape", inputs=["x"], outputs=["y"])
+        slice_node = helper.make_node("Slice", inputs=slice_inputs, outputs=["z"])
+        
+        graph = helper.make_graph(
+            [shape_node, slice_node],
+            "slice_test",
+            inputs=[
+                helper.make_tensor_value_info("x", TensorProto.FLOAT, data_shape),
+            ],
+            outputs=[helper.make_tensor_value_info("z", TensorProto.INT64, output_shape)],
+            initializer=initializer,
+        )
+
+        model = helper.make_model(graph, producer_name="slice_test")
+        inputs = {"x": rg.standard_normal(size=data_instance_shape).astype("float32")}
+        check_correctness(model, inputs)
+
+    verify_slice([20, 10, 5], [20, 10, 5], [2], starts=[0], ends=[2], axes=[0])
+    verify_slice(["A", 10, 5], [20, 10, 5], [2], starts=[0], ends=[2], axes=[0])
+    verify_slice(["A", "B", 5], [20, 10, 5], [2], starts=[0], ends=[2], axes=[0])
+    verify_slice([20, 10, "C"], [20, 10, 5], [2], starts=[0], ends=[2], axes=[0])
+    verify_slice(["A", "B", "C"], [20, 10, 5], [2], starts=[0], ends=[2], axes=[0])
+
+    verify_slice([20, 10, 5], [20, 10, 5], [1], starts=[1], ends=[2], axes=[0])
+    verify_slice(["A", 10, 5], [20, 10, 5], [1], starts=[1], ends=[2], axes=[0])
+    verify_slice(["A", "B", 5], [20, 10, 5], [1], starts=[1], ends=[2], axes=[0])
+    verify_slice([20, 10, "C"], [20, 10, 5], [1], starts=[1], ends=[2], axes=[0])
+    verify_slice(["A", "B", "C"], [20, 10, 5], [1], starts=[1], ends=[2], axes=[0])
+
+    verify_slice([20, 10, 5], [20, 10, 5], [2], starts=[1], ends=[3], axes=[0])
+    verify_slice(["A", 10, 5], [20, 10, 5], [2], starts=[1], ends=[3], axes=[0])
+    verify_slice(["A", "B", 5], [20, 10, 5], [2], starts=[1], ends=[3], axes=[0])
+    verify_slice([20, 10, "C"], [20, 10, 5], [2], starts=[1], ends=[3], axes=[0])
+    verify_slice(["A", "B", "C"], [20, 10, 5], [2], starts=[1], ends=[3], axes=[0])
+
 
 # TODO Enable dynamism
 @pytest.mark.parametrize("dynamic", [False])
@@ -1795,12 +1962,13 @@ def test_split(fp_arith, dynamic):
             )
         ]
 
+        split_constant = None
         if pass_split:
             if opset >= 13:
                 np_split = np.array(split).astype(np.int64)
-                initializer.append(
-                    helper.make_tensor("split", TensorProto.INT64, list(np_split.shape), np_split)
-                )
+                split_constant= make_constant_node("split", onnx.TensorProto.INT64, list(np_split.shape), np_split)
+                input_names.append("split")
+
         node = helper.make_node(
             "Split",
             inputs=input_names,
@@ -1812,8 +1980,10 @@ def test_split(fp_arith, dynamic):
             split_attr = helper.make_attribute("split", split)
             node.attribute.append(split_attr)
 
+        nodes = [split_constant, node] if split_constant else [node]
+
         graph = helper.make_graph(
-            [node],
+            nodes,
             "split_test",
             inputs=inputs,
             initializer=initializer,
@@ -2224,6 +2394,12 @@ def test_flatten():
     verify_unary("Flatten", [1, 3, 32, 32], attrs={"axis": 0})
     verify_unary("Flatten", [1, 3, 32, 32], attrs={"axis": -1})
     verify_unary("Flatten", [1, 3, 32, 32], attrs={"axis": 2})
+
+
+def test_flatten_dynamic():
+    verify_unary_dynamic_shape("Flatten", [1, "A", "B", 32], [1, 3, 32, 32], attrs={"axis": 0})
+    verify_unary_dynamic_shape("Flatten", [1, "A", "B", 32], [1, 3, 32, 32],  attrs={"axis": -1})
+    verify_unary_dynamic_shape("Flatten", [1, "A", "B", 32], [1, 3, 32, 32],  attrs={"axis": 2})
 
 
 def test_onehot():


### PR DESCRIPTION
# Squeeze
I added a tuple wrapping around axis when sending it to _np.squeeze since it does not support list objects. I added an additional check to see if the data is a ShapeExpr. If this is the case I perform the inverse of the operations done in the Unsqueeze operation. 

# Slice 
I fixed a bug where the dimensions were assumed to be of IntImm data type by adding an additional check to handle the constant and dynamic case separately.

# Flatten
I fixed a bug where the dimensions were assumed to be of IntImm data type by adding an additional check to handle the constant and dynamic case separately.

# Split
I replaced asnumpy with numpy since asnumpy is deprecated. I added a call to .item() to convert from numpy data types to python primitives. 

# Regression Tests
I extracted generate_random_value function from generate_random_inputs.
I added isinstance(tvm_out, (int, float, bool)) in check_correctness since the VM can return python primitive types

## Squeeze
I added a test case for squeeze with constant input since it was missing
I added a test case for squeeze with dynamic input shape
I added a test case for squeeze with dynamic shape expression

## Slice
I added a test case for slice with dynamic shape expression

## Split
I fixed a bug in test_split which caused the constant split case never to occur