### PR TITLE
[FIX][TOPI][strided_slice] Fix topi.strided_slice output shape

### DIFF
--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -813,6 +813,7 @@ inline Tensor dynamic_strided_slice(const Tensor& x, const Array<PrimExpr>& begi
  * \param end Indices indicating end of the slice
  * \param strides Specifies the stride values, it can be negative
  * in that case, the input tensor will be reversed in that particular axis
+ * \param assume_inbound Specifies if all indices are assumed to be inbound
  * \param name The name of the operation
  * \param tag The tag to mark the operation
  *

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -762,7 +762,6 @@ inline Tensor dynamic_strided_slice(const Tensor& x, const Array<PrimExpr>& begi
                                     bool assume_inbound = true,
                                     std::string name = "T_dynamic_strided_slice",
                                     std::string tag = kInjective) {
-  std::cout << "dynamic_strided_slice" << std::endl;
   const size_t src_tensor_dim = x->shape.size();
   ICHECK_LE(begin.size(), src_tensor_dim);
   ICHECK_LE(end.size(), src_tensor_dim);
@@ -855,7 +854,6 @@ inline te::Tensor dynamic_strided_slice(const te::Tensor& x, const te::Tensor& b
 inline Array<PrimExpr> StridedSliceOutputShape(
     const Array<PrimExpr>& ishape, const Array<Integer>& begin, const Array<Integer>& end,
     const Array<Integer>& strides, const Array<Integer>& axes, const std::string& slice_mode) {
-  std::cout << "StridedSliceOutputShape" << std::endl;
   ICHECK(axes.size() == begin.size() && axes.size() == end.size() && axes.size() == strides.size());
   std::vector<int64_t> begin_vec, end_vec, strides_vec;
   std::tie(begin_vec, end_vec, strides_vec) = ConvertToVec(begin, end, strides, slice_mode);

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -639,21 +639,6 @@ inline Array<Tensor> split(const Tensor& x, Array<PrimExpr> split_indices, int a
   return result;
 }
 
-/*!
- * \brief strided_slice of a tensor where begin/end/stride can be mixed static and dynamic
- *
- * \param x The input tensor
- * \param begin The indices to begin with in the slicing
- * \param end Indices indicating end of the slice
- * \param strides Specifies the stride values, it can be negative
- * in that case, the input tensor will be reversed in that particular axis
- * \param axes Specifies which axes will be updated.
- * \param name The name of the operation
- * \param tag The tag to mark the operation
- *
- * \return A Tensor whose op member is the dynamic_strided_slice operation
- */
-
 inline PrimExpr DynamicCanonicalizeIndex(PrimExpr index, PrimExpr extent, PrimExpr stride) {
   auto idx_var = index.as<tvm::tir::VarNode>();
   auto extent_var = extent.as<tvm::tir::VarNode>();
@@ -692,7 +677,7 @@ inline PrimExpr CanonicalizeIndex(PrimExpr index, PrimExpr extent, PrimExpr stri
 }
 
 inline PrimExpr GetLength(PrimExpr begin, PrimExpr end, PrimExpr stride, PrimExpr extent,
-                          bool assume_inbound = false) {
+                          bool assume_inbound = true) {
   if (assume_inbound) {
     return ceildiv(end - begin, stride);
   } else {
@@ -703,9 +688,24 @@ inline PrimExpr GetLength(PrimExpr begin, PrimExpr end, PrimExpr stride, PrimExp
   }
 }
 
+/*!
+ * \brief strided_slice of a tensor where begin/end/stride can be mixed static and dynamic
+ *
+ * \param x The input tensor
+ * \param begin The indices to begin with in the slicing
+ * \param end Indices indicating end of the slice
+ * \param strides Specifies the stride values, it can be negative
+ * in that case, the input tensor will be reversed in that particular axis
+ * \param axes Specifies which axes will be updated.
+ * \param assume_inbound Specifies if all indices are assumed to be inbound
+ * \param name The name of the operation
+ * \param tag The tag to mark the operation
+ *
+ * \return A Tensor whose op member is the dynamic_strided_slice operation
+ */
 inline Tensor dynamic_strided_slice_with_axes(
     const Tensor& x, const Array<PrimExpr>& begin, const Array<PrimExpr>& end,
-    const Array<PrimExpr>& strides, const Array<Integer>& axes, bool assume_inbound = false,
+    const Array<PrimExpr>& strides, const Array<Integer>& axes, bool assume_inbound = true,
     std::string name = "T_dynamic_strided_slice_with_axes", std::string tag = kInjective) {
   const size_t src_tensor_dim = x->shape.size();
   ICHECK_EQ(begin.size(), end.size());
@@ -752,6 +752,7 @@ inline Tensor dynamic_strided_slice_with_axes(
  * \param end Indices indicating end of the slice
  * \param strides Specifies the stride values, it can be negative
  * in that case, the input tensor will be reversed in that particular axis
+ * \param assume_inbound Specifies if all indices are assumed to be inbound
  * \param name The name of the operation
  * \param tag The tag to mark the operation
  *

--- a/python/tvm/relax/transform/legalize_ops/distributed.py
+++ b/python/tvm/relax/transform/legalize_ops/distributed.py
@@ -40,4 +40,5 @@ def _redistribute_replica_to_shard(_bb: BlockBuilder, call: Call) -> Expr:
         axes=[axis],
         begin=[worker_id_symbol * split_axis_size // num_workers],
         end=[(worker_id_symbol + 1) * split_axis_size // num_workers],
+        assume_inbound=True,
     )

--- a/python/tvm/relax/transform/legalize_ops/index.py
+++ b/python/tvm/relax/transform/legalize_ops/index.py
@@ -67,6 +67,7 @@ def _strided_slice(bb: BlockBuilder, call: Call) -> Expr:
         strides,
         axes,
         slice_mode="end",
+        assume_inbound=call.attrs.assume_inbound,
     )
 
 

--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -170,7 +170,7 @@ def reverse_sequence(a, seq_lengths, seq_axis=1, batch_axis=0):
     return cpp.reverse_sequence(a, seq_lengths, seq_axis, batch_axis)
 
 
-def strided_slice(a, begin, end, strides=None, axes=None, slice_mode="end", assume_inbound=False):
+def strided_slice(a, begin, end, strides=None, axes=None, slice_mode="end", assume_inbound=True):
     """Slice of an array.
 
     Parameters

--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -170,7 +170,7 @@ def reverse_sequence(a, seq_lengths, seq_axis=1, batch_axis=0):
     return cpp.reverse_sequence(a, seq_lengths, seq_axis, batch_axis)
 
 
-def strided_slice(a, begin, end, strides=None, axes=None, slice_mode="end"):
+def strided_slice(a, begin, end, strides=None, axes=None, slice_mode="end", assume_inbound = False):
     """Slice of an array.
 
     Parameters
@@ -200,6 +200,9 @@ def strided_slice(a, begin, end, strides=None, axes=None, slice_mode="end"):
         the sizeof a slice starting at the location specified by begin. If end[i]
         is -1, all remaining elements in that dimension are included in the slice.
 
+    assume_inbound: bool, optional
+        A flag to indicate if all indices are assumed to be inbound
+
     Returns
     -------
     ret : tvm.te.Tensor
@@ -223,7 +226,7 @@ def strided_slice(a, begin, end, strides=None, axes=None, slice_mode="end"):
         strides = []
     if axes is None:
         axes = []
-    return cpp.strided_slice(a, begin, end, strides, axes, slice_mode)
+    return cpp.strided_slice(a, begin, end, strides, axes, slice_mode, assume_inbound)
 
 
 def dynamic_strided_slice(a, begin, end, strides, output_shape):

--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -170,7 +170,7 @@ def reverse_sequence(a, seq_lengths, seq_axis=1, batch_axis=0):
     return cpp.reverse_sequence(a, seq_lengths, seq_axis, batch_axis)
 
 
-def strided_slice(a, begin, end, strides=None, axes=None, slice_mode="end", assume_inbound = False):
+def strided_slice(a, begin, end, strides=None, axes=None, slice_mode="end", assume_inbound=False):
     """Slice of an array.
 
     Parameters

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -25,6 +25,7 @@
 #include "index.h"
 
 #include <tvm/relax/analysis.h>
+#include <tvm/topi/transform.h>
 
 #include <algorithm>
 #include <optional>
@@ -170,29 +171,6 @@ Expr strided_slice(Expr x, Expr axes, Expr begin, Expr end, Optional<Expr> strid
 }
 
 TVM_REGISTER_GLOBAL("relax.op.strided_slice").set_body_typed(strided_slice);
-
-inline PrimExpr CanonicalizeIndex(PrimExpr index, PrimExpr extent, PrimExpr stride) {
-  // Handle Python-style negative indices
-  index = if_then_else(index < 0, index + extent, index);
-  // Clamp the result to valid indices
-  PrimExpr lower_bound = tvm::if_then_else(stride < 0, -1, 0);
-  PrimExpr upper_bound = tvm::if_then_else(stride < 0, extent - 1, extent);
-  index = tvm::min(tvm::max(index, lower_bound), upper_bound);
-
-  return index;
-}
-
-PrimExpr GetLength(PrimExpr begin, PrimExpr end, PrimExpr stride, PrimExpr extent,
-                   bool assume_inbound) {
-  if (assume_inbound) {
-    return ceildiv(end - begin, stride);
-  } else {
-    begin = CanonicalizeIndex(begin, extent, stride);
-    end = CanonicalizeIndex(end, extent, stride);
-    return tvm::if_then_else(stride < 0, ceildiv(begin - end, -stride),
-                             ceildiv(end - begin, stride));
-  }
-}
 
 /* \brief Helper function to unpack a relax::Tuple
  *
@@ -424,7 +402,7 @@ StructInfo InferStructInfoStridedSlice(const Call& call, const BlockBuilder& ctx
       PrimExpr end = end_tuple[i];
 
       PrimExpr output_dim =
-          GetLength(begin, end, strides_tuple[i], input_dim, attrs->assume_inbound);
+          topi::GetLength(begin, end, strides_tuple[i], input_dim, attrs->assume_inbound);
 
       arith::Analyzer* analyzer = ctx->GetAnalyzer();
       std::optional<With<arith::ConstraintContext>> context;

--- a/src/topi/transform.cc
+++ b/src/topi/transform.cc
@@ -27,6 +27,10 @@
 #include <tvm/topi/transform.h>
 #include <tvm/topi/utils.h>
 
+#include <iostream>
+
+#include "tvm/ir/expr.h"
+
 namespace tvm {
 namespace topi {
 
@@ -179,6 +183,7 @@ TVM_REGISTER_GLOBAL("topi.strided_slice").set_body([](TVMArgs args, TVMRetValue*
   Array<PrimExpr> end = args[2];
   Array<PrimExpr> strides = args[3];
   Array<Integer> axes = args[4];
+  bool assume_inbound = args[6];
   if (IsConstIntArray(begin) && IsConstIntArray(end) && IsConstIntArray(strides) &&
       IsConstIntArray(x->shape)) {
     Array<Integer> begin_static = args[1];
@@ -192,9 +197,9 @@ TVM_REGISTER_GLOBAL("topi.strided_slice").set_body([](TVMArgs args, TVMRetValue*
     }
   } else {
     if (axes.size()) {
-      *rv = dynamic_strided_slice_with_axes(x, begin, end, strides, axes);
+      *rv = dynamic_strided_slice_with_axes(x, begin, end, strides, axes, assume_inbound);
     } else {
-      *rv = dynamic_strided_slice(x, begin, end, strides);
+      *rv = dynamic_strided_slice(x, begin, end, strides, assume_inbound);
     }
   }
 });

--- a/tests/python/relax/test_op_index.py
+++ b/tests/python/relax/test_op_index.py
@@ -21,6 +21,7 @@ from tvm import relax, tir
 from tvm import TVMError
 from tvm.ir import Op, VDevice
 from tvm.script import ir as I, relax as R, tir as T
+import numpy as np
 
 
 def test_op_correctness():
@@ -1005,6 +1006,43 @@ def test_legalize_dynamic_begin_end():
                 with T.block("T_dynamic_strided_slice"):
                     i, j = T.axis.remap("SS", iters)
                     B[i, j] = A[i + index, j]
+
+    after = tvm.relax.transform.LegalizeOps()(before)
+    tvm.ir.assert_structural_equal(expected, after)
+
+
+def test_legalize_dynamic_begin_inf_end():
+    """relax.op.strided_slice FLegalize must support dynamic begin/end"""
+
+    @I.ir_module
+    class before:
+        @R.function
+        def main(A: R.Tensor((16, 16), "float32"), B: R.Shape(["index"])) -> R.Tensor((1, 16)):
+            index = T.int64()
+            return R.strided_slice(
+                A, [0], [index], [T.int64(np.iinfo(np.int64).max)], assume_inbound=False
+            )
+
+    @I.ir_module
+    class expected:
+        @T.prim_func(private=True)
+        def strided_slice(A: T.Buffer((T.int64(16), T.int64(16)), "float32"), var_T_dynamic_strided_slice_with_axes: T.handle, index: T.int64):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            T_dynamic_strided_slice_with_axes = T.match_buffer(var_T_dynamic_strided_slice_with_axes, (T.max(T.int64(16) - T.max(T.if_then_else(index < T.int64(0), index + T.int64(16), index), T.int64(0)), T.int64(0)), T.int64(16)))
+            # with T.block("root"):
+            for ax0, ax1 in T.grid(T.max(T.int64(16) - T.max(T.if_then_else(index < T.int64(0), index + T.int64(16), index), T.int64(0)), T.int64(0)), T.int64(16)):
+                with T.block("T_dynamic_strided_slice_with_axes"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(A[v_ax0 + index, v_ax1])
+                    T.writes(T_dynamic_strided_slice_with_axes[v_ax0, v_ax1])
+                    T_dynamic_strided_slice_with_axes[v_ax0, v_ax1] = A[v_ax0 + index, v_ax1]
+
+        @R.function
+        def main(A: R.Tensor((16, 16), dtype="float32"), B: R.Shape(["index"])) -> R.Tensor(("T.max(16 - T.max(T.if_then_else(index < 0, index + 16, index), 0), 0)", 16), dtype="float32"):
+            index = T.int64()
+            cls = expected
+            gv = R.call_tir(cls.strided_slice, (A,), out_sinfo=R.Tensor((T.max(16 - T.max(T.if_then_else(index < 0, index + 16, index), 0), 0), 16), dtype="float32"), tir_vars=R.shape([index]))
+            return gv
 
     after = tvm.relax.transform.LegalizeOps()(before)
     tvm.ir.assert_structural_equal(expected, after)

--- a/tests/python/relax/test_op_index.py
+++ b/tests/python/relax/test_op_index.py
@@ -1026,11 +1026,37 @@ def test_legalize_dynamic_begin_inf_end():
     @I.ir_module
     class expected:
         @T.prim_func(private=True)
-        def strided_slice(A: T.Buffer((T.int64(16), T.int64(16)), "float32"), var_T_dynamic_strided_slice_with_axes: T.handle, index: T.int64):
+        def strided_slice(
+            A: T.Buffer((T.int64(16), T.int64(16)), "float32"),
+            var_T_dynamic_strided_slice_with_axes: T.handle,
+            index: T.int64,
+        ):
             T.func_attr({"tir.noalias": T.bool(True)})
-            T_dynamic_strided_slice_with_axes = T.match_buffer(var_T_dynamic_strided_slice_with_axes, (T.max(T.int64(16) - T.max(T.if_then_else(index < T.int64(0), index + T.int64(16), index), T.int64(0)), T.int64(0)), T.int64(16)))
+            T_dynamic_strided_slice_with_axes = T.match_buffer(
+                var_T_dynamic_strided_slice_with_axes,
+                (
+                    T.max(
+                        T.int64(16)
+                        - T.max(
+                            T.if_then_else(index < T.int64(0), index + T.int64(16), index),
+                            T.int64(0),
+                        ),
+                        T.int64(0),
+                    ),
+                    T.int64(16),
+                ),
+            )
             # with T.block("root"):
-            for ax0, ax1 in T.grid(T.max(T.int64(16) - T.max(T.if_then_else(index < T.int64(0), index + T.int64(16), index), T.int64(0)), T.int64(0)), T.int64(16)):
+            for ax0, ax1 in T.grid(
+                T.max(
+                    T.int64(16)
+                    - T.max(
+                        T.if_then_else(index < T.int64(0), index + T.int64(16), index), T.int64(0)
+                    ),
+                    T.int64(0),
+                ),
+                T.int64(16),
+            ):
                 with T.block("T_dynamic_strided_slice_with_axes"):
                     v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
                     T.reads(A[v_ax0 + index, v_ax1])
@@ -1038,10 +1064,23 @@ def test_legalize_dynamic_begin_inf_end():
                     T_dynamic_strided_slice_with_axes[v_ax0, v_ax1] = A[v_ax0 + index, v_ax1]
 
         @R.function
-        def main(A: R.Tensor((16, 16), dtype="float32"), B: R.Shape(["index"])) -> R.Tensor(("T.max(16 - T.max(T.if_then_else(index < 0, index + 16, index), 0), 0)", 16), dtype="float32"):
+        def main(
+            A: R.Tensor((16, 16), dtype="float32"), B: R.Shape(["index"])
+        ) -> R.Tensor(
+            ("T.max(16 - T.max(T.if_then_else(index < 0, index + 16, index), 0), 0)", 16),
+            dtype="float32",
+        ):
             index = T.int64()
             cls = expected
-            gv = R.call_tir(cls.strided_slice, (A,), out_sinfo=R.Tensor((T.max(16 - T.max(T.if_then_else(index < 0, index + 16, index), 0), 0), 16), dtype="float32"), tir_vars=R.shape([index]))
+            gv = R.call_tir(
+                cls.strided_slice,
+                (A,),
+                out_sinfo=R.Tensor(
+                    (T.max(16 - T.max(T.if_then_else(index < 0, index + 16, index), 0), 0), 16),
+                    dtype="float32",
+                ),
+                tir_vars=R.shape([index]),
+            )
             return gv
 
     after = tvm.relax.transform.LegalizeOps()(before)

--- a/tests/python/relax/test_op_index.py
+++ b/tests/python/relax/test_op_index.py
@@ -1023,40 +1023,15 @@ def test_legalize_dynamic_begin_inf_end():
                 A, [0], [index], [T.int64(np.iinfo(np.int64).max)], assume_inbound=False
             )
 
+    # fmt: off
     @I.ir_module
     class expected:
         @T.prim_func(private=True)
-        def strided_slice(
-            A: T.Buffer((T.int64(16), T.int64(16)), "float32"),
-            var_T_dynamic_strided_slice_with_axes: T.handle,
-            index: T.int64,
-        ):
+        def strided_slice(A: T.Buffer((T.int64(16), T.int64(16)), "float32"), var_T_dynamic_strided_slice_with_axes: T.handle, index: T.int64):
             T.func_attr({"tir.noalias": T.bool(True)})
-            T_dynamic_strided_slice_with_axes = T.match_buffer(
-                var_T_dynamic_strided_slice_with_axes,
-                (
-                    T.max(
-                        T.int64(16)
-                        - T.max(
-                            T.if_then_else(index < T.int64(0), index + T.int64(16), index),
-                            T.int64(0),
-                        ),
-                        T.int64(0),
-                    ),
-                    T.int64(16),
-                ),
-            )
+            T_dynamic_strided_slice_with_axes = T.match_buffer(var_T_dynamic_strided_slice_with_axes, (T.max(T.int64(16) - T.max(T.if_then_else(index < T.int64(0), index + T.int64(16), index), T.int64(0)), T.int64(0)), T.int64(16)))
             # with T.block("root"):
-            for ax0, ax1 in T.grid(
-                T.max(
-                    T.int64(16)
-                    - T.max(
-                        T.if_then_else(index < T.int64(0), index + T.int64(16), index), T.int64(0)
-                    ),
-                    T.int64(0),
-                ),
-                T.int64(16),
-            ):
+            for ax0, ax1 in T.grid(T.max(T.int64(16) - T.max(T.if_then_else(index < T.int64(0), index + T.int64(16), index), T.int64(0)), T.int64(0)), T.int64(16)):
                 with T.block("T_dynamic_strided_slice_with_axes"):
                     v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
                     T.reads(A[v_ax0 + index, v_ax1])
@@ -1064,24 +1039,12 @@ def test_legalize_dynamic_begin_inf_end():
                     T_dynamic_strided_slice_with_axes[v_ax0, v_ax1] = A[v_ax0 + index, v_ax1]
 
         @R.function
-        def main(
-            A: R.Tensor((16, 16), dtype="float32"), B: R.Shape(["index"])
-        ) -> R.Tensor(
-            ("T.max(16 - T.max(T.if_then_else(index < 0, index + 16, index), 0), 0)", 16),
-            dtype="float32",
-        ):
+        def main(A: R.Tensor((16, 16), dtype="float32"), B: R.Shape(["index"])) -> R.Tensor(("T.max(16 - T.max(T.if_then_else(index < 0, index + 16, index), 0), 0)", 16), dtype="float32"):
             index = T.int64()
             cls = expected
-            gv = R.call_tir(
-                cls.strided_slice,
-                (A,),
-                out_sinfo=R.Tensor(
-                    (T.max(16 - T.max(T.if_then_else(index < 0, index + 16, index), 0), 0), 16),
-                    dtype="float32",
-                ),
-                tir_vars=R.shape([index]),
-            )
+            gv = R.call_tir(cls.strided_slice, (A,), out_sinfo=R.Tensor((T.max(16 - T.max(T.if_then_else(index < 0, index + 16, index), 0), 0), 16), dtype="float32"), tir_vars=R.shape([index]))
             return gv
+    # fmt: on
 
     after = tvm.relax.transform.LegalizeOps()(before)
     tvm.ir.assert_structural_equal(expected, after)

--- a/tests/python/relax/test_transform_legalize_ops_index_linear_algebra.py
+++ b/tests/python/relax/test_transform_legalize_ops_index_linear_algebra.py
@@ -263,7 +263,7 @@ def test_strided_slice_symbolic_sliced_axis():
         @R.function
         def main(x: R.Tensor(("m", "n"), "float32")) -> R.Tensor((2, "n"), "float32"):
             n = T.int64()
-            gv: R.Tensor((2, n), "float32") = R.strided_slice(x, axes=[0], begin=[1], end=[8], strides=[3])
+            gv: R.Tensor((3, n), "float32") = R.strided_slice(x, axes=[0], begin=[1], end=[8], strides=[3], assume_inbound=True)
             return gv
 
     @I.ir_module


### PR DESCRIPTION
Fixed inconsistency between relax.strided_slice output shape and topi.strided_slice output shape when assume_inbound 
is set to false.

I added an assume_inbound flag to topi.strided_slice. If it is false then the begin and end indices are canonicalized before the dimension length is calculated. To avoid introducing duplicate code i removed the corresponding functions from relax/../index.cc and instead reference the new functions defined in include/tvm/topi/transform.h.

I added a regression test for the case with assume_inbound = false when the end of the slice is at infinity, e.g. v[begin:], which previously caused an incorrect output shape.