### PR TITLE
[CI] Upgrade `oneflow==0.9.0`

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -48,7 +48,6 @@ RUN bash /install/ubuntu_install_python.sh 3.9
 ENV PATH ${TVM_VENV}/bin:$PATH
 ENV PYTHONNOUSERSITE 1  # Disable .local directory from affecting CI.
 
-COPY install/ubuntu_install_cmake_source.sh /install/ubuntu_install_cmake_source.sh
 # Globally disable pip cache
 RUN bash /install/ubuntu_install_cmake_source.sh
 

--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -49,7 +49,7 @@ ENV PATH ${TVM_VENV}/bin:$PATH
 ENV PYTHONNOUSERSITE 1  # Disable .local directory from affecting CI.
 
 # Globally disable pip cache
-RUN bash /install/ubuntu_install_cmake_source.sh
+RUN pip config set global.no-cache-dir false
 
 COPY install/ubuntu2204_install_llvm.sh /install/ubuntu2204_install_llvm.sh
 RUN bash /install/ubuntu2204_install_llvm.sh

--- a/docker/install/ubuntu_install_oneflow.sh
+++ b/docker/install/ubuntu_install_oneflow.sh
@@ -20,6 +20,6 @@ set -e
 set -u
 set -o pipefail
 
-pip3 install flowvision==0.1.0
-
-python3 -m pip install oneflow==0.8.0
+pip3 install \
+    oneflow==0.9.0 \
+    flowvision==0.1.0


### PR DESCRIPTION
Because `oneflow==0.8.0` is incompatible with `numpy==1.24.*`
Also remove the duplicate cmake installation and fix the pip config.

Link: https://github.com/Oneflow-Inc/oneflow/issues/9660