### PR TITLE
[RELAX][ONNX] Add support for dynamic shape expression in Expand

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -909,7 +909,7 @@ class Trilu(OnnxOpConverter):
         if len(inputs) > 1:
             k = get_constant(inputs[1], params)
             if isinstance(k, relax.Constant):
-                k = int(k.data.numpy()[0])
+                k = int(k.data.numpy().item())
             else:
                 raise ValueError("Currently only support constant k for Trilu op.")
         else:
@@ -1588,6 +1588,16 @@ class Split(OnnxOpConverter):
         return bb.emit_te(topi.split, inputs[0], indices, axis=attr.get("axis", 0))
 
 
+def get_prim_value_list(values):
+    new_values = []
+    for v in list(values):
+        if isinstance(v, relax.expr.PrimExpr):
+            new_values.append(relax.PrimValue(v))
+        else:
+            new_values.append(v)
+    return new_values
+
+
 class Slice(OnnxOpConverter):
     """Converts an onnx Splice node into an equivalent Relax expression."""
 
@@ -1641,7 +1651,12 @@ class Slice(OnnxOpConverter):
         assume_inbound = not all(
             [isinstance(param, (tir.IntImm, int)) for param in [*starts, *ends, *steps]]
         )
-        # return relax.op.strided_slice(data, axes, starts, ends, steps)
+
+        # Converting PrimExpr to PrimValue since relax.op.strided_slice does not accept PrimExpr
+        starts = get_prim_value_list(starts)
+        ends = get_prim_value_list(ends)
+        steps = get_prim_value_list(steps)
+
         return relax.op.strided_slice(
             data, axes, starts, ends, steps, assume_inbound=assume_inbound
         )
@@ -1730,9 +1745,21 @@ class Expand(OnnxOpConverter):
     def _impl_v13(cls, bb, inputs, attr, params):
         data = inputs[0]
         shape = inputs[1]
-
         if isinstance(shape, relax.ShapeExpr):
-            return relax.op.broadcast_to(data, shape)
+            data_shape = [dim for dim in data.struct_info.shape]
+            target_shape = [dim for dim in shape.values]
+            data_shape = [1] * (len(target_shape) - len(data_shape)) + data_shape
+            assert len(data_shape) == len(target_shape)
+            # Fix small target shapes
+            for i, s in enumerate(target_shape):
+                if isinstance(s, tvm.tir.IntImm) and (
+                    (isinstance(data_shape[i], tvm.tir.IntImm) and s < data_shape[i])
+                    or s.value == -1
+                ):
+                    target_shape[i] = data_shape[i]
+            if target_shape == data_shape:
+                return data
+            return relax.op.broadcast_to(data, relax.ShapeExpr(target_shape))
 
         # If possible, directly expand to constant shape.
         if isinstance(shape, relax.Constant):
@@ -2688,15 +2715,11 @@ class DepthToSpace(OnnxOpConverter):
         mode = attr.get("mode", b"DCR").decode("utf-8")
         b, c, h, w = inputs[0].struct_info.shape
         if mode == "DCR":
-            x = relax.op.reshape(
-                inputs[0], (b, block_size, block_size, c // (block_size**2), h, w)
-            )
+            x = relax.op.reshape(inputs[0], (b, block_size, block_size, c // (block_size**2), h, w))
             x = relax.op.permute_dims(x, [0, 3, 4, 1, 5, 2])
             return relax.op.reshape(x, (b, c // (block_size**2), h * block_size, w * block_size))
         elif mode == "CRD":
-            x = relax.op.reshape(
-                inputs[0], (b, c // (block_size**2), block_size, block_size, h, w)
-            )
+            x = relax.op.reshape(inputs[0], (b, c // (block_size**2), block_size, block_size, h, w))
             x = relax.op.permute_dims(x, [0, 1, 4, 2, 5, 3])
             return relax.op.reshape(x, (b, c // (block_size**2), h * block_size, w * block_size))
         else:


### PR DESCRIPTION
# Expand
Updated Expand converter in onnx frontend to to handle dynamic shape expressions by matching data and target_shape
dimension lengths and converting any target shape elements assigned to -1 to the data shape dimension.

Added regression test to onnx frontend testing Expand with a dynamic shape 

# Additional small fixes
I replaced int(k.data.numpy()[0]) with int(k.data.numpy().item()) in Trilu since sometimes the data shape is a zero dimensional scalar

I added a function converting from PrimExpr to PrimValue before sending in starts, ends, steps to relax.op.strided_slice since it does not accept PrimeExpr as inputs. 

