### PR TITLE
[Relax] Update ONNX frontend for unique, nonzero and compress

### DIFF
--- a/python/tvm/relax/op/set.py
+++ b/python/tvm/relax/op/set.py
@@ -123,7 +123,7 @@ def nonzero(x: Expr) -> Expr:
     Returns
     -------
     result : relax.Expr
-        A (n+1)-D tensor containing indices of non-zero elements.
+        A 2-D tensor containing indices of non-zero elements.
 
     Note
     ----

--- a/src/relax/op/tensor/set.cc
+++ b/src/relax/op/tensor/set.cc
@@ -148,9 +148,7 @@ TVM_REGISTER_GLOBAL("relax.op.nonzero").set_body_typed(nonzero);
 
 StructInfo InferStructInfoNonzero(const Call& call, const BlockBuilder& ctx) {
   TensorStructInfo data_sinfo = GetInputTensorStructInfo(call, 0, ctx);
-  // Cheat zero dim scalar as 1-dim.
-  int dim = data_sinfo->IsUnknownNdim() ? kUnknownNDim : std::max(1, data_sinfo->ndim) + 1;
-  return TensorStructInfo(DataType::Int(64), dim, data_sinfo->vdevice);
+  return TensorStructInfo(DataType::Int(64), 2, data_sinfo->vdevice);
 }
 
 TVM_REGISTER_OP("relax.nonzero")

--- a/tests/python/relax/test_op_set.py
+++ b/tests/python/relax/test_op_set.py
@@ -875,7 +875,7 @@ def test_nonzero_infer_struct_info(shape):
     _check_inference(
         bb,
         relax.op.nonzero(x0),
-        relax.TensorStructInfo(ndim=len(shape) + 1, dtype="int64"),
+        relax.TensorStructInfo(ndim=2, dtype="int64"),
     )
 
 


### PR DESCRIPTION
This PR updates the ONNX frontend:

- Add match cast for unique and nonzero operators, enabling further import of ONNX models.
- Add support for compress operator.
- Fix the shape of the output tensor for nonzero operator.