### PR TITLE
[DOCS] Fix typo in TensorIR

### DIFF
--- a/docs/deep_dive/tensor_ir/learning.rst
+++ b/docs/deep_dive/tensor_ir/learning.rst
@@ -182,7 +182,7 @@ Block Axis Properties
 ~~~~~~~~~~~~~~~~~~~~~
 Let's delve deeper into the properties of the block axis. These properties signify the axis's
 relationship to the computation in progress. The block comprises three axes ``vi``, ``vj``, and
-``vk``, meanwhile the block reads the buffer ``A[vi, vk]``, ``B[vk, vj]`` and writs the buffer
+``vk``, meanwhile the block reads the buffer ``A[vi, vk]``, ``B[vk, vj]`` and writes the buffer
 ``Y[vi, vj]``. Strictly speaking, the block performs (reduction) updates to Y, which we label
 as write for the time being, as we don't require the value of Y from another block.
 


### PR DESCRIPTION
This pull request provides a fix typo in TensorIR Docs.