### PR TITLE
[BugFix][CUDA] Increase FloatImm precision when printing 64 bit values in CUDA codegen 

### DIFF
--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -1413,6 +1413,7 @@ inline void PrintConst(const FloatImmNode* op, std::ostream& os, CodeGenCUDA* p)
       } else {
         temp << std::scientific << op->value << 'f';
       }
+    }
     case 16: {
       os << "__float2half_rn" << '(';
       FloatImm const_f32 = FloatImm(DataType::Float(32), op->value);

--- a/src/target/source/codegen_cuda.cc
+++ b/src/target/source/codegen_cuda.cc
@@ -1413,6 +1413,9 @@ inline void PrintConst(const FloatImmNode* op, std::ostream& os, CodeGenCUDA* p)
       } else {
         temp << std::scientific << op->value << 'f';
       }
+      p->MarkConst(temp.str());
+      os << temp.str();
+      break;
     }
     case 16: {
       os << "__float2half_rn" << '(';


### PR DESCRIPTION
This bugfix is related to issue #17276. 
The reduced precision when printing floating point constants in source code files, leads to undesired behavior, more noticeable while working with trigonometric functions.