### PR TITLE
[3rdparty] Update Picojson with const `operator[]` function (#327)

### DIFF
--- a/3rdparty/picojson/picojson.h
+++ b/3rdparty/picojson/picojson.h
@@ -273,6 +273,10 @@ class object_with_ordered_keys : private std::unordered_map<std::string, value> 
     return std::unordered_map<std::string, value>::operator[](key);
   }
 
+  const value& operator[](const std::string& key) const {
+    return std::unordered_map<std::string, value>::at(key);
+  }
+
   void clear() {
     std::unordered_map<std::string, value>::clear();
     ordered_keys_.clear();


### PR DESCRIPTION
This PR adds a `const value& operator[](const std::string& key) const` method to picojson object

Co-authored-by: Yixin Dong <ubospica@gmail.com>