### PR TITLE
[LLVM][RUNTIME] Make ORCJIT LLVM executor the default one

### DIFF
--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -269,7 +269,7 @@ LLVMTargetInfo::LLVMTargetInfo(LLVMInstance& instance, const TargetJSON& target)
     if ((value == "mcjit") || (value == "orcjit")) {
       jit_engine_ = value;
     } else {
-      LOG(FATAL) << "invalid jit option " << value << " (can be `mcjit` or `orcjit`).";
+      LOG(FATAL) << "invalid jit option " << value << " (can be `orcjit` or `mcjit`).";
     }
   }
 
@@ -530,7 +530,7 @@ std::string LLVMTargetInfo::str() const {
     os << quote << Join(",", opts) << quote;
   }
 
-  if (jit_engine_ != "mcjit") {
+  if (jit_engine_ != "orcjit") {
     os << " -jit=" << jit_engine_;
   }
 

--- a/src/target/llvm/llvm_instance.h
+++ b/src/target/llvm/llvm_instance.h
@@ -232,7 +232,7 @@ class LLVMTargetInfo {
   llvm::FastMathFlags GetFastMathFlags() const { return fast_math_flags_; }
   /*!
    * \brief Get the LLVM JIT engine type
-   * \return the type name of the JIT engine (default "mcjit" or "orcjit")
+   * \return the type name of the JIT engine (default "orcjit" or "mcjit")
    */
   const std::string GetJITEngine() const { return jit_engine_; }
   /*!
@@ -348,7 +348,7 @@ class LLVMTargetInfo {
   llvm::Reloc::Model reloc_model_ = llvm::Reloc::PIC_;
   llvm::CodeModel::Model code_model_ = llvm::CodeModel::Small;
   std::shared_ptr<llvm::TargetMachine> target_machine_;
-  std::string jit_engine_ = "mcjit";
+  std::string jit_engine_ = "orcjit";
 };
 
 /*!

--- a/tests/python/runtime/test_runtime_module_based_interface.py
+++ b/tests/python/runtime/test_runtime_module_based_interface.py
@@ -54,7 +54,7 @@ def verify(data):
 
 
 @tvm.testing.requires_llvm
-@pytest.mark.parametrize("target", ["llvm", "llvm -jit=orcjit"])
+@pytest.mark.parametrize("target", ["llvm", "llvm -jit=mcjit"])
 def test_legacy_compatibility(target):
     mod, params = relay.testing.synthetic.get_workload()
     with relay.build_config(opt_level=3):
@@ -70,7 +70,7 @@ def test_legacy_compatibility(target):
 
 
 @tvm.testing.requires_llvm
-@pytest.mark.parametrize("target", ["llvm", "llvm -jit=orcjit"])
+@pytest.mark.parametrize("target", ["llvm", "llvm -jit=mcjit"])
 def test_cpu(target):
     mod, params = relay.testing.synthetic.get_workload()
     with relay.build_config(opt_level=3):
@@ -113,7 +113,7 @@ def test_cpu_get_graph_json():
 
 
 @tvm.testing.requires_llvm
-@pytest.mark.parametrize("target", ["llvm", "llvm -jit=orcjit"])
+@pytest.mark.parametrize("target", ["llvm", "llvm -jit=mcjit"])
 def test_cpu_get_graph_params_run(target):
     mod, params = relay.testing.synthetic.get_workload()
     with tvm.transform.PassContext(opt_level=3):
@@ -592,7 +592,7 @@ def test_remove_package_params():
 
 
 @tvm.testing.requires_llvm
-@pytest.mark.parametrize("target", ["llvm", "llvm -jit=orcjit"])
+@pytest.mark.parametrize("target", ["llvm", "llvm -jit=mcjit"])
 def test_debug_graph_executor(target):
     mod, params = relay.testing.synthetic.get_workload()
     with relay.build_config(opt_level=3):

--- a/tests/python/runtime/test_runtime_module_load.py
+++ b/tests/python/runtime/test_runtime_module_load.py
@@ -44,7 +44,7 @@ print("Finish runtime checking...")
 
 
 @tvm.testing.requires_llvm
-@pytest.mark.parametrize("target", ["llvm", "llvm -jit=orcjit"])
+@pytest.mark.parametrize("target", ["llvm", "llvm -jit=mcjit"])
 def test_dso_module_load(target):
     dtype = "int64"
     temp = utils.tempdir()


### PR DESCRIPTION
This PR propose to make ORCJIT the default LLVM runtime executor (engine).

### Notes
  * Currently [ORCJIT](https://llvm.org/docs/ORCv2.html) is a optional executor under ```llvm -jit=orcjit``` flag, introduced [here](https://github.com/apache/tvm/pull/15964).
  * Targets like RISCV, and possible others too, will not work on MCJIT see some discussions [here](https://reviews.llvm.org/D127842) .
 * As a live example, similar project Halide already use ORCJIT completley replacing the old MCJIT engine.

TVM disscussions and recent issues on the subject:

* https://discuss.tvm.apache.org/t/run-tvm-software-stack-on-risc-v/17683/4
* https://github.com/apache/tvm/issues/17508

Since ORCJIT was poorly exposed within TVM until now (being optional) any rising issues will need attention.


