### PR TITLE
[Relax] Fix bug in convert_layout pass

### DIFF
--- a/src/relax/transform/convert_layout.cc
+++ b/src/relax/transform/convert_layout.cc
@@ -90,7 +90,7 @@ class LayoutConvertMutator : public ExprMutator {
   Expr RewriteExpr(const Expr& expr, const NLayout& to) {
     auto fvisitleaf = [&](const Expr& expr, std::array<NLayout, 2> layouts) -> Expr {
       NLayout from = layouts[0], to = layouts[1];
-      if (NLayoutEqual()(from, to) || layouts[0].LeafValue()->layout->name == "") return expr;
+      if (NLayoutEqual()(from, to) || layouts[0].LeafValue()->layout.name() == "") return expr;
       // If not both from and to are unknown, then none of them can be unknown.
       ICHECK(!NLayoutEqual()(from, LayoutDecision::InitUnknownDim()) &&
              !NLayoutEqual()(to, LayoutDecision::InitUnknownDim()))


### PR DESCRIPTION
When using `layouts[0].LeafValue()->layout->name`, I got a segment fault when `layouts[0].LeafValue()->layout` is `__undef__`. `layouts[0].LeafValue()->layout.name()` can judge and handle this case.