### PR TITLE
[Web]Allows setting powerPreference on webgpu

### DIFF
--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -35,7 +35,7 @@ export interface GPUDeviceDetectOutput {
  */
 export async function detectGPUDevice(powerPreference: "low-power" | "high-performance" = "high-performance"): Promise<GPUDeviceDetectOutput | undefined> {
   if (typeof navigator !== "undefined" && navigator.gpu !== undefined) {
-    const adapter = await navigator.gpu.requestAdapter({ "powerPreference": "high-performance" });
+    const adapter = await navigator.gpu.requestAdapter({ powerPreference });
     if (adapter == null) {
       throw Error(
         "Unable to find a compatible GPU. This issue might be because your computer doesn't have a GPU, or your system settings are not configured properly. " +

--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -33,7 +33,7 @@ export interface GPUDeviceDetectOutput {
 /**
  * DetectGPU device in the environment.
  */
-export async function detectGPUDevice(): Promise<GPUDeviceDetectOutput | undefined> {
+export async function detectGPUDevice(powerPreference: "low-power" | "high-performance" = "high-performance"): Promise<GPUDeviceDetectOutput | undefined> {
   if (typeof navigator !== "undefined" && navigator.gpu !== undefined) {
     const adapter = await navigator.gpu.requestAdapter({ "powerPreference": "high-performance" });
     if (adapter == null) {


### PR DESCRIPTION
This PR adds the `powerPreferece` argument to `detetectGPUDevice()`, while keeping the previous functionality as default, without breaking older code.

In hybrid GPU systems (mainly laptops) is sometimes needed to select the low-power integrated GPU in order to test model inference on https://github.com/mlc-ai/web-llm/ for other low-power devices or just to save on battery.


Here's the related line of code on the `web-llm` repository that references this function:
https://github.com/mlc-ai/web-llm/blob/082f04e4941ff4f6ef70731d244c69228948c7a1/src/service_worker.ts#L117