### PR TITLE
[Relax] Expose BlockBuilder's Analyzer instance in Python

### DIFF
--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -779,6 +779,13 @@ class TVM_DLL Analyzer {
    * \note Analyzer will call into sub-analyzers to get the result.
    */
   PrimExpr Simplify(const PrimExpr& expr, int steps = 2);
+
+  /*!
+   * \brief Returns the instance wrapped in a closure, suitable for FFI purposes.
+   *
+   * \return A function that exposes the methods of the underlying Analyzer instance.
+   */
+  runtime::TypedPackedFunc<PackedFunc(std::string)> AsFunc();
 };
 
 }  // namespace arith

--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -780,12 +780,8 @@ class TVM_DLL Analyzer {
    */
   PrimExpr Simplify(const PrimExpr& expr, int steps = 2);
 
-  /*!
-   * \brief Returns the instance wrapped in a closure, suitable for FFI purposes.
-   *
-   * \return A function that exposes the methods of the underlying Analyzer instance.
-   */
-  runtime::TypedPackedFunc<PackedFunc(std::string)> AsFunc();
+  static runtime::TypedPackedFunc<PackedFunc(std::string)> AsFunc(
+      std::shared_ptr<Analyzer> analyzer);
 };
 
 }  // namespace arith

--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -256,6 +256,12 @@ class BlockBuilderNode : public Object {
    */
   virtual arith::Analyzer* GetAnalyzer() = 0;
 
+  /*!
+   * \brief Returns the analyzer wrapped in a closure, suitable for FFI purposes.
+   * \return A function that exposes the methods of the underlying Analyzer instance.
+   */
+  virtual runtime::TypedPackedFunc<PackedFunc(std::string)> GetAnalyzerAsFunc() = 0;
+
   static constexpr const uint32_t _type_index = TypeIndex::kDynamic;
   static constexpr const char* _type_key = "relax.BlockBuilder";
   TVM_DECLARE_BASE_OBJECT_INFO(BlockBuilderNode, Object);

--- a/python/tvm/arith/analyzer.py
+++ b/python/tvm/arith/analyzer.py
@@ -105,8 +105,7 @@ class Analyzer:
     be used to perform various symbolic integer analysis.
     """
 
-    def __init__(self):
-        _mod = _ffi_api.CreateAnalyzer()
+    def __init__(self, _mod=_ffi_api.CreateAnalyzer()):
         self._const_int_bound = _mod("const_int_bound")
         self._const_int_bound_update = _mod("const_int_bound_update")
         self._bind = _mod("bind")

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 import tvm
 from tvm import relax as rx
 from tvm import tir
+from tvm.arith.analyzer import Analyzer
 from tvm.ir.module import IRModule
 from tvm.runtime import Object
 
@@ -163,6 +164,7 @@ class BlockBuilder(Object):
         # Which functions are currently being defined
         self._func_stack: List[FunctionScope] = []
         self.__init_handle_by_constructor__(_ffi_api.BlockBuilderCreate, mod)  # type: ignore
+        self._analyzer = Analyzer(_ffi_api.BlockBuilderGetAnalyzer(self))
 
     def _begin_dataflow_block(self) -> None:
         _ffi_api.BlockBuilderBeginDataflowBlock(self)  # type: ignore
@@ -797,3 +799,6 @@ class BlockBuilder(Object):
         """End the current scope. Please see `begin_scope` for details"""
 
         return _ffi_api.BlockBuilderEndScope(self)  # type: ignore
+
+    def get_analyzer(self) -> Analyzer:
+        return self._analyzer

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -268,10 +268,11 @@ PrimExpr Analyzer::Simplify(const PrimExpr& expr, int steps) {
   return res;
 }
 
-TVM_REGISTER_GLOBAL("arith.CreateAnalyzer").set_body([](TVMArgs args, TVMRetValue* ret) {
+namespace {
+template <typename Ptr>
+TypedPackedFunc<PackedFunc(std::string)> GetAnalyzerFunc(Ptr self) {
   using runtime::PackedFunc;
   using runtime::TypedPackedFunc;
-  auto self = std::make_shared<Analyzer>();
   auto f = [self](std::string name) -> PackedFunc {
     if (name == "const_int_bound") {
       return PackedFunc(
@@ -347,7 +348,23 @@ TVM_REGISTER_GLOBAL("arith.CreateAnalyzer").set_body([](TVMArgs args, TVMRetValu
     }
     return PackedFunc();
   };
-  *ret = TypedPackedFunc<PackedFunc(std::string)>(f);
+  return TypedPackedFunc<PackedFunc(std::string)>(f);
+}
+
+// Duck typed smart pointer interface, allowing us to pass a non-smart ptr to GetAnalyzerFunc
+template <typename T>
+struct Ptr {
+  Ptr(T* ptr) : ptr(ptr) {}
+  T* get() const { return ptr; }
+  T* operator->() const { return this->ptr; }
+  T* ptr;
+};
+}  // namespace
+
+TypedPackedFunc<PackedFunc(std::string)> Analyzer::AsFunc() { return GetAnalyzerFunc(Ptr(this)); }
+
+TVM_REGISTER_GLOBAL("arith.CreateAnalyzer").set_body([](TVMArgs args, TVMRetValue* ret) {
+  *ret = GetAnalyzerFunc(std::make_shared<Analyzer>());
 });
 
 }  // namespace arith

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -268,9 +268,7 @@ PrimExpr Analyzer::Simplify(const PrimExpr& expr, int steps) {
   return res;
 }
 
-namespace {
-template <typename Ptr>
-TypedPackedFunc<PackedFunc(std::string)> GetAnalyzerFunc(Ptr self) {
+TypedPackedFunc<PackedFunc(std::string)> Analyzer::AsFunc(std::shared_ptr<Analyzer> self) {
   using runtime::PackedFunc;
   using runtime::TypedPackedFunc;
   auto f = [self](std::string name) -> PackedFunc {
@@ -351,20 +349,8 @@ TypedPackedFunc<PackedFunc(std::string)> GetAnalyzerFunc(Ptr self) {
   return TypedPackedFunc<PackedFunc(std::string)>(f);
 }
 
-// Duck typed smart pointer interface, allowing us to pass a non-smart ptr to GetAnalyzerFunc
-template <typename T>
-struct Ptr {
-  Ptr(T* ptr) : ptr(ptr) {}
-  T* get() const { return ptr; }
-  T* operator->() const { return this->ptr; }
-  T* ptr;
-};
-}  // namespace
-
-TypedPackedFunc<PackedFunc(std::string)> Analyzer::AsFunc() { return GetAnalyzerFunc(Ptr(this)); }
-
 TVM_REGISTER_GLOBAL("arith.CreateAnalyzer").set_body([](TVMArgs args, TVMRetValue* ret) {
-  *ret = GetAnalyzerFunc(std::make_shared<Analyzer>());
+  *ret = Analyzer::AsFunc(std::make_shared<Analyzer>());
 });
 
 }  // namespace arith

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "../../node/ndarray_hash_equal.h"
+#include "tvm/runtime/packed_func.h"
 
 // Block builder have three categories of logics that are interdependent with each other.
 //
@@ -1096,6 +1097,11 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderGetUniqueName")
       return builder->name_supply()->FreshName(name_hint, /*add_prefix*/ false,
                                                /*add_underscore*/ false);
     });
+
+TVM_REGISTER_GLOBAL("relax.BlockBuilderGetAnalyzer").set_body([](TVMArgs args, TVMRetValue* ret) {
+  BlockBuilder block_builder = args[0];
+  *ret = block_builder->GetAnalyzer()->AsFunc();
+});
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderAddFunction")
     .set_body_method<BlockBuilder>(&BlockBuilderNode::AddFunction);

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -218,11 +218,11 @@ class BlockBuilderImpl : public BlockBuilderNode {
         // of shape inference.  In many cases, knowning that the
         // shape variable is non-negative allows for simpler
         // expressions for dynamic shapes.
-        analyzer_.MarkGlobalNonNegValue(shape_var);
+        analyzer_->MarkGlobalNonNegValue(shape_var);
       } else {
         const PrimExpr& old_shape_expr = (*it).second;
         CHECK(old_shape_expr.same_as(shape_expr) ||
-              analyzer_.CanProveEqual(old_shape_expr, shape_expr))
+              analyzer_->CanProveEqual(old_shape_expr, shape_expr))
             << "Inconsistent shape var " << shape_var << " in scope: " << old_shape_expr << " vs "
             << shape_expr;
       }
@@ -305,7 +305,11 @@ class BlockBuilderImpl : public BlockBuilderNode {
     }
   }
 
-  arith::Analyzer* GetAnalyzer() final { return &analyzer_; }
+  arith::Analyzer* GetAnalyzer() final { return analyzer_.get(); }
+
+  runtime::TypedPackedFunc<PackedFunc(std::string)> GetAnalyzerAsFunc() final {
+    return arith::Analyzer::AsFunc(analyzer_);
+  }
 
  protected:
   /*!
@@ -362,7 +366,7 @@ class BlockBuilderImpl : public BlockBuilderNode {
   IRModule context_mod_;
 
   /*! \brief Internal analzyer */
-  arith::Analyzer analyzer_;
+  std::shared_ptr<arith::Analyzer> analyzer_ = std::make_shared<arith::Analyzer>();
 
   /*!
    * \return The current frame.
@@ -853,7 +857,7 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
       auto opt = MatchStructInfo<FuncStructInfo>(call->op);
       ICHECK(opt) << "Call->op must contains a function struct info";
       FuncStructInfo finfo = opt.value();
-      return DeriveCallRetStructInfo(finfo, call, GetRef<BlockBuilder>(this), &analyzer_);
+      return DeriveCallRetStructInfo(finfo, call, GetRef<BlockBuilder>(this), analyzer_.get());
     }
   }
 
@@ -1100,7 +1104,7 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderGetUniqueName")
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderGetAnalyzer").set_body([](TVMArgs args, TVMRetValue* ret) {
   BlockBuilder block_builder = args[0];
-  *ret = block_builder->GetAnalyzer()->AsFunc();
+  *ret = block_builder->GetAnalyzerAsFunc();
 });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderAddFunction")

--- a/tests/python/relax/test_blockbuilder_core.py
+++ b/tests/python/relax/test_blockbuilder_core.py
@@ -990,5 +990,14 @@ def test_deduplication_when_input_contains_duplicates():
     bb.update_func(gvar_b, subroutine_c)
 
 
+def test_analyzer_ref():
+    bb = rx.BlockBuilder()
+    analyzer = bb.get_analyzer()
+    x, y = te.var("x"), te.var("y")
+    m = analyzer.modular_set(x * 6 + y * 4)
+    assert m.coeff == 2
+    assert m.base == 0
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
It is currently not possible to access a `BlockBuilder`'s `Analyzer` instance from Python code, which would be useful e.g. when converting from front-end representations to Relax.

This PR addresses that by adding a `get_analyzer` method to the Python `BlockBuilder` class. Behind the scenes, it uses the same FFI and code paths as when creating a standalone Python `Analyzer`, the only difference being where the underlying C++ instance originates from. To avoid object lifetime issues in Python code (which would be surprising given that it is a memory managed language), a C++ `BlockBuilder`'s `Analyzer` field is now a shared pointer.