### PR TITLE
[FIX][LLVM] Workaround -mcpu=apple-latest for llvm above 18.0 (#17492)

### DIFF
--- a/src/target/tag.cc
+++ b/src/target/tag.cc
@@ -429,6 +429,17 @@ TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.24xlarge", 48, "cascadelake");
 
 #undef TVM_REGISTER_TAG_AWS_C5
 
+#if TVM_LLVM_VERSION >= 190
+#define TVM_REGISTER_METAL_GPU_TAG(Name, ThreadsPerBlock, SharedMem, WarpSize)   \
+  TVM_REGISTER_TARGET_TAG(Name).set_config(                                      \
+      {{"kind", String("metal")},                                                \
+       {"max_threads_per_block", runtime::Int(ThreadsPerBlock)},                 \
+       {"max_shared_memory_per_block", runtime::Int(SharedMem)},                 \
+       {"thread_warp_size", runtime::Int(WarpSize)},                             \
+       {"host", Map<String, ObjectRef>{{"kind", String("llvm")},                 \
+                                       {"mtriple", String("arm64-apple-macos")}, \
+                                       {"mcpu", String("apple-m4")}}}});
+#else
 #define TVM_REGISTER_METAL_GPU_TAG(Name, ThreadsPerBlock, SharedMem, WarpSize)   \
   TVM_REGISTER_TARGET_TAG(Name).set_config(                                      \
       {{"kind", String("metal")},                                                \
@@ -438,6 +449,7 @@ TVM_REGISTER_TAG_AWS_C5("aws/cpu/c5.24xlarge", 48, "cascadelake");
        {"host", Map<String, ObjectRef>{{"kind", String("llvm")},                 \
                                        {"mtriple", String("arm64-apple-macos")}, \
                                        {"mcpu", String("apple-latest")}}}});
+#endif
 
 #if TVM_LLVM_HAS_AARCH64_TARGET
 TVM_REGISTER_METAL_GPU_TAG("apple/m1-gpu", 1024, 32768, 32);


### PR DESCRIPTION
This PR address a fix for https://github.com/apache/tvm/issues/17492

* It seems that LLVM version >= 19 misses the mcpu ```apple-latest``` in the llvm backend.
* Relevant [LLVM change](https://github.com/llvm/llvm-project/commit/f07d30072ac0dd0e10a4684335d5f464db627049#diff-4d527cab186c06e9ffbbb5c76af64c13394ef424e72b62ee0c807f44895690f4R215-R216) makes this [alias unavailable](https://github.com/llvm/llvm-project/blob/f07d30072ac0dd0e10a4684335d5f464db627049/llvm/utils/TableGen/ARMTargetDefEmitter.cpp#L215-L217), but works from llc/clang higher frontends.


#### Error:
```
llvm_instance.cc:226: Error: Using LLVM 19.1.2 with `-mcpu=apple-latest` is not valid in `-mtriple=arm64-apple-macos`, using default `-mcpu=generic`
llvm_instance.cc:226: Error: Using LLVM 19.1.2 with `-mcpu=apple-latest` is not valid in `-mtriple=arm64-apple-macos`, using default `-mcpu=generic`
llvm_instance.cc:226: Error: Using LLVM 19.1.2 with `-mcpu=apple-latest` is not valid in `-mtriple=arm64-apple-macos`, using default `-mcpu=generic`
```

#### Notes

```
print( "LLVM version = [%s]" % tvm.target.codegen.llvm_version_major() )
print( tvm.target.codegen.llvm_get_cpu_archlist(tvm.target.Target("llvm -mtriple=arm64-apple-macos")) )
```

```
LLVM version = [18]
["a64fx", "ampere1", "ampere1a", "ampere1b", "apple-a10", "apple-a11", "apple-a12", "apple-a13", 
"apple-a14", "apple-a15", "apple-a16", "apple-a17", "apple-a7", "apple-a8", "apple-a9", "apple-latest",
"apple-m1", "apple-m2", "apple-m3", "apple-s4", "apple-s5", "carmel", "cortex-a34", "cortex-a35", 
"cortex-a510", "cortex-a520", "cortex-a53", "cortex-a55", "cortex-a57", "cortex-a65", "cortex-a65ae", 
"cortex-a710", "cortex-a715", "cortex-a72", "cortex-a720", "cortex-a73", "cortex-a75", "cortex-a76", 
"cortex-a76ae", "cortex-a77", "cortex-a78", "cortex-a78c", "cortex-r82", "cortex-x1", "cortex-x1c", 
"cortex-x2", "cortex-x3", "cortex-x4", "cyclone", "exynos-m3", "exynos-m4", "exynos-m5", "falkor",
 "generic", "kryo", "neoverse-512tvb", "neoverse-e1", "neoverse-n1", "neoverse-n2", "neoverse-v1", 
"neoverse-v2", "saphira", "thunderx", "thunderx2t99", "thunderx3t110", "thunderxt81", "thunderxt83",
 "thunderxt88", "tsv110"]
```

```
LLVM version = [19]
["a64fx", "ampere1", "ampere1a", "ampere1b", "apple-a10", "apple-a11", "apple-a12", "apple-a13",
 "apple-a14", "apple-a15", "apple-a16", "apple-a17", "apple-a7", "apple-m4", "carmel", "cortex-a34", 
"cortex-a35", "cortex-a510", "cortex-a520", "cortex-a520ae", "cortex-a53", "cortex-a55", "cortex-a57", 
"cortex-a65", "cortex-a65ae", "cortex-a710", "cortex-a715", "cortex-a72", "cortex-a720", "cortex-a720ae", 
"cortex-a725", "cortex-a73", "cortex-a75", "cortex-a76", "cortex-a76ae", "cortex-a77", "cortex-a78", 
"cortex-a78ae", "cortex-a78c", "cortex-r82", "cortex-r82ae", "cortex-x1", "cortex-x1c", "cortex-x2", 
"cortex-x3", "cortex-x4", "cortex-x925", "exynos-m3", "exynos-m4", "exynos-m5", "falkor", "generic", 
"kryo", "neoverse-512tvb", "neoverse-e1", "neoverse-n1", "neoverse-n2", "neoverse-n3", "neoverse-v1",
 "neoverse-v2", "neoverse-v3", "neoverse-v3ae", "oryon-1", "saphira", "thunderx", "thunderx2t99", 
"thunderx3t110", "thunderxt81", "thunderxt83", "thunderxt88", "tsv110"]
```