### PR TITLE
Update Dockerfile.ci_adreno

### DIFF
--- a/docker/Dockerfile.ci_adreno
+++ b/docker/Dockerfile.ci_adreno
@@ -16,7 +16,7 @@
 # under the License.
 
 # CI docker GPU env
-FROM tlcpack/ci-gpu
+FROM tlcpack/ci_gpu:20241119-020227-6fc0598c
 
 COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 


### PR DESCRIPTION
The image name has a typo and there is no image tagged with latest on the docker hub. This should be fixed and is likely an issue with all the dockerfiles as well. 