### PR TITLE
Fix inconsistent IR when printing R.nn.pad operator

### DIFF
--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -562,12 +562,14 @@ struct AttentionAttrs : public tvm::AttrsNode<AttentionAttrs> {
 /*! \brief Attributes used for the padding operator */
 struct PadAttrs : public tvm::AttrsNode<PadAttrs> {
   Array<Integer> pad_width;
+  FloatImm pad_value;
   tvm::String pad_mode;
 
   TVM_DECLARE_ATTRS(PadAttrs, "relay.attrs.PadAttrs") {
     TVM_ATTR_FIELD(pad_width).describe(
         "Number of values padded to the edges of each axis, "
         "in the format of (before_1, after_1, ..., before_N, after_N)");
+    TVM_ATTR_FIELD(pad_value).describe("The value to fill in padded area with");
     TVM_ATTR_FIELD(pad_mode)
         .set_default("constant")
         .describe(

--- a/python/tvm/relax/transform/legalize_ops/nn.py
+++ b/python/tvm/relax/transform/legalize_ops/nn.py
@@ -231,7 +231,7 @@ def _nn_pad(bb: BlockBuilder, call: Call) -> Expr:
         call.args[0],
         pad_before=pad_before,
         pad_after=pad_after,
-        pad_value=float(call.args[1].data.numpy()),
+        pad_value=call.attrs.pad_value,
         primfunc_name_hint="pad",
     )
 

--- a/python/tvm/relay/frontend/tensorflow_ops.py
+++ b/python/tvm/relay/frontend/tensorflow_ops.py
@@ -2359,7 +2359,7 @@ def _pad(name):
         else:
             paddings = tuple(tuple(l) for l in padlist)
         attr["pad_width"] = paddings
-        attr["pad_value"] = 0
+        attr["pad_value"] = _expr.const(0)
         new_inputs = [inputs[0]]
         if name == "PadV2":
             try:

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -136,12 +136,13 @@ TVM_REGISTER_OP("relax.nn.log_softmax")
 /* relax.nn.pad */
 TVM_REGISTER_NODE_TYPE(PadAttrs);
 
-Expr pad(Expr data, Array<Integer> pad_width, Expr pad_value, String pad_mode) {
+Expr pad(Expr data, Array<Integer> pad_width, FloatImm pad_value, String pad_mode) {
   auto attrs = make_object<PadAttrs>();
   attrs->pad_width = std::move(pad_width);
+  attrs->pad_value = pad_value;
   attrs->pad_mode = std::move(pad_mode);
   static const Op& op = Op::Get("relax.nn.pad");
-  return Call(op, {data, pad_value}, Attrs(attrs), {});
+  return Call(op, {data}, Attrs(attrs), {});
 }
 
 TVM_REGISTER_GLOBAL("relax.op.nn.pad").set_body_typed(pad);
@@ -171,9 +172,8 @@ StructInfo InferStructInfoPad(const Call& call, const BlockBuilder& ctx) {
 }
 
 TVM_REGISTER_OP("relax.nn.pad")
-    .set_num_inputs(2)
+    .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
-    .add_argument("pad_value", "Tensor", "The value to fill in padded area with.")
     .set_attrs_type<PadAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPad)
     .set_attr<Bool>("FPurity", Bool(true));


### PR DESCRIPTION
Hi All,
This is a fix for https://github.com/apache/tvm/issues/17483
the inconsistency caused by pad_width and pad_value being second argument, this PR moves pad_value to the attributes.
Let me know if that is not a proper way to resolve the issue, additionally I am not sure if there is a way to make a test for show, I would appreciate references in this case.

Thank you!