### PR TITLE
Update from_source.rst

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -146,7 +146,7 @@ Leaving the build environment ``tvm-build-venv``, there are two ways to install 
     conda activate your-own-env
     conda install python # make sure python is installed
     export TVM_LIBRARY_PATH=/path-to-tvm/build
-    pip install -e /path-to-tvm/python
+    pip install /path-to-tvm/python
 
 Step 4. Validate Installation
 -----------------------------


### PR DESCRIPTION
The editable option is used but the subsequent docs expect it to be in the site-packages. Since this is meant to be used by users, the editable option is no longer needed in my opinion. However even if it is needed, the tutorial should be consistent either way.