### PR TITLE
[TIR][LoopPartition] enforcement on loop partition control

### DIFF
--- a/include/tvm/tir/builtin.h
+++ b/include/tvm/tir/builtin.h
@@ -970,6 +970,9 @@ TVM_DLL const Op& vscale();
  */
 TVM_DLL const Op& get_active_lane_mask();
 
+/*! \brief Annotate a predicate not be considered as target condition of loop partition. */
+TVM_DLL const Op& ignore_loop_partition();
+
 /*! \brief The kind of structure field info used in intrinsic */
 enum TVMStructFieldKind : int {
   // array head address

--- a/python/tvm/script/ir_builder/tir/ir.py
+++ b/python/tvm/script/ir_builder/tir/ir.py
@@ -1909,6 +1909,7 @@ anylist_resetitem = _op_wrapper(_tir_op.anylist_resetitem)
 anylist_setitem_call_packed = _op_wrapper(_tir_op.anylist_setitem_call_packed)
 anylist_setitem_call_cpacked = _op_wrapper(_tir_op.anylist_setitem_call_cpacked)
 vscale = _op_wrapper(_tir_op.vscale)
+ignore_loop_partition = _op_wrapper(_tir_op.ignore_loop_partition)
 
 
 def _dtype_forward(func):
@@ -2261,4 +2262,5 @@ __all__ = [
     "vscale",
     "get_active_lane_mask",
     "call_kernel",
+    "ignore_loop_partition",
 ]

--- a/python/tvm/tir/__init__.py
+++ b/python/tvm/tir/__init__.py
@@ -97,6 +97,7 @@ from .op import TVMBackendAllocWorkspace, TVMBackendFreeWorkspace
 from .op import start_profile_intrinsic, end_profile_intrinsic
 from .op import vscale, get_active_lane_mask, get_vscale_expr
 from .op import dp4a
+from .op import ignore_loop_partition
 from .generic import add, subtract, multiply
 
 from .schedule import StmtSRef, BlockScope, ScheduleState, Schedule, ScheduleError

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -3581,6 +3581,18 @@ def get_vscale_expr(dtype: Union[str, tvm.DataType], min_size: int = 128) -> Pri
     return min_size // dtype.bits * vscale()
 
 
+def ignore_loop_partition(predicate) -> PrimExpr:
+    """
+    Annotate a predicate not be considered as target condition of loop partition.
+
+    Parameters
+    ----------
+    predicate : PrimExpr
+        The annotated predicate expression.
+    """
+    return call_intrin("bool", "tir.ignore_loop_partition", predicate)
+
+
 # pylint: disable=unnecessary-lambda
 sum = comm_reducer(lambda x, y: x + y, lambda t: const(0, dtype=t), name="sum")
 min = comm_reducer(lambda x, y: _ffi_api._OpMin(x, y, None), max_value, name="min")  # type: ignore

--- a/src/tir/op/builtin.cc
+++ b/src/tir/op/builtin.cc
@@ -422,6 +422,12 @@ TIR_DEFINE_BUILTIN_FUNC(get_active_lane_mask)
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
                                          Integer(ScriptDtypePrintLocation::kFirst));
 
+TIR_DEFINE_BUILTIN_FUNC(ignore_loop_partition)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
+                                         Integer(ScriptDtypePrintLocation::kNone));
+
 }  // namespace builtin
 }  // namespace tir
 }  // namespace tvm


### PR DESCRIPTION
The change wants to merge set of finegrained control improvement on loop partition pass.

1) Add an annotation intrinsic `T.ignore_loop_partition`, which mark the wrapped predicate not to take part in the loop partition phase. Since in sometimes loop partition would enlarge the generated code size and we want to preserve some predicates intentionally.

2) Add patch for EQ predicate partition. Try solve `a <= b && b <= a` instead if solve `a==b` directly failed.

3) Fix `TryPartition`'s return statement. Since the caller handle the return value by
  
    - If undef, try recursive solving.
    - If defined, treat as a successfully partioned result stmt.