### PR TITLE
[skip ci] [CI] Remove legacy CI runners protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,17 +58,13 @@ github:
         contexts:
           - unity/pr-head
           - arm/pr-head
-          - cortexm/pr-head
           - cpu/pr-head
           - docker/pr-head
           - gpu/pr-head
           - hexagon/pr-head
           - i386/pr-head
           - lint/pr-head
-          - minimal/pr-head
-          - riscv/pr-head
           - wasm/pr-head
-          - cross-isa-minimal/pr-head
 
       required_pull_request_reviews:
         required_approving_review_count: 1


### PR DESCRIPTION
This PR changes `.asf.yaml` to remove legacy CI runners protection, including:

- cortexm/pr-head
- riscv/pr-head
- minimal/pr-head
- cross-isa-minimal/pr-head