### PR TITLE
[METASCHEDULE][BUGFIX] Fix potential undefined optional usage

### DIFF
--- a/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
@@ -276,7 +276,7 @@ std::vector<State> MultiLevelTilingTensorCoreNode::ApplySubRules(std::vector<Sta
 void MultiLevelTilingTensorCoreNode::TileAndAnnotateTensorize(
     Schedule* sch, const BlockRV& block_rv, const String& intrin_name,
     const String& permuted_layout_annotate_value) const {
-  Optional<LoopRV> loop = TileWithTensorIntrin(*sch, block_rv, intrin_name).value();
+  Optional<LoopRV> loop = TileWithTensorIntrin(*sch, block_rv, intrin_name);
   ICHECK(loop.defined());
   BlockRV blockized_outer = (*sch)->Blockize(loop.value());
   (*sch)->Annotate(blockized_outer, tir::attr::meta_schedule_auto_tensorize, intrin_name);


### PR DESCRIPTION
Fixed a minor bug where .value() was called before confirming that the loop returned by TileWithTensorIntrin was defined, causing a hard to locate error if the loop was actually undefined