### PR TITLE
Handle vector width (VLEN) for RISCV arches

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -174,18 +174,29 @@ void CodeGenLLVM::InitTarget() {
   data_layout_.reset(new llvm::DataLayout(module_.get()));
 #endif
   if (native_vector_bits_ == 0) {
+    const int vwidth = llvm_target_->GetVectorWidth();
     const auto& arch = tm->getTargetTriple().getArch();
-    if (arch == llvm::Triple::x86_64) {
+    const std::string arch_name = std::string(tm->getTargetTriple().getArchName());
+    if (vwidth > 0) {
+      // override from target options
+      // e.g. llvm -vector-width=xxx
+      native_vector_bits_ = vwidth;
+    } else if (arch == llvm::Triple::x86_64) {
       // for avx512
       native_vector_bits_ = 512;
     } else if (arch == llvm::Triple::x86) {
       native_vector_bits_ = 256;
     } else if (arch == llvm::Triple::arm || arch == llvm::Triple::aarch64) {
       native_vector_bits_ = 128;
+    } else if (arch == llvm::Triple::riscv32 || arch == llvm::Triple::riscv64) {
+      native_vector_bits_ = 256;
+      LOG(WARNING) << "LLVM RVV VLEN inference failed, "
+                   << "using 256 bits, set -vector-width=XXX to override";
+      // fallback default
     } else {
       native_vector_bits_ = 128;
-      std::string arch_name = std::string(tm->getTargetTriple().getArchName());
-      LOG(WARNING) << "Set native vector bits to be 128 for " << arch_name;
+      LOG(WARNING) << "Set native vector bits to be 128 for `" << arch_name
+                   << "`, use -vector-width=XXX to override.";
     }
   }
 

--- a/src/target/llvm/llvm_instance.h
+++ b/src/target/llvm/llvm_instance.h
@@ -243,6 +243,11 @@ class LLVMTargetInfo {
    */
   const std::string GetJITEngine() const { return jit_engine_; }
   /*!
+   * \brief Get the TVM & LLVM vector_width
+   * \return number of bits for vector width
+   */
+  const int GetVectorWidth() const { return vector_width_; }
+  /*!
    * \brief Get the LLVM optimization level
    * \return optimization level for this target
    */
@@ -356,6 +361,7 @@ class LLVMTargetInfo {
   llvm::CodeModel::Model code_model_ = llvm::CodeModel::Small;
   std::shared_ptr<llvm::TargetMachine> target_machine_;
   std::string jit_engine_ = "orcjit";
+  int vector_width_{0};
 };
 
 /*!

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -283,6 +283,8 @@ TVM_REGISTER_TARGET_KIND("llvm", kDLCPU)
     .add_attr_option<Array<String>>("cl-opt")
     // LLVM JIT engine mcjit/orcjit
     .add_attr_option<String>("jit")
+    // TVM & LLVM custom vector bit width
+    .add_attr_option<runtime::Int>("vector-width")
     .set_default_keys({"cpu"})
     // Force the external codegen kind attribute to be registered, even if no external
     // codegen targets are enabled by the TVM build.

--- a/tests/python/target/test_target_target.py
+++ b/tests/python/target/test_target_target.py
@@ -178,6 +178,13 @@ def test_target_llvm_jit_options():
     assert target.attrs["jit"] == "orcjit"
 
 
+def test_target_llvm_vector_width():
+    target = tvm.target.Target("llvm -vector-width=256")
+    assert target.attrs["vector-width"] == 256
+    target = tvm.target.Target("llvm -vector-width=1024")
+    assert target.attrs["vector-width"] == 1024
+
+
 def test_target_create():
     targets = [cuda(), rocm(), mali(), intel_graphics(), arm_cpu("rk3399"), bifrost()]
     for tgt in targets:


### PR DESCRIPTION
This PR address issue https://github.com/apache/tvm/issues/17625 by making llvm codegen backend aware of RVV VLEN.

---

By default this has **no impact** on anything but the RISCV targets.

* Introduces **optional** ```-vector-length``` parameter for any of llvm targets
* For RISCV **infers** from LLVM library the appropiate VLEN based on the tvm target specified
* It **properly warns** on any inference failure with a default value, and suggests the  ```-vector-length``` usage


Cc:  @JieGH , if by chance can get a feedback
Cc: LLVM folks @quic-sanirudh , @srkreddy1238 

----

Snippet of test function used:
```
    m = 4
    n = 4 # multiple of int32_lanes   (2)
    k = 4 # multiple of int8_elements (8) (the common axis)

    # network graph
    dat = relay.var("data", shape=(m, k), dtype="uint8")
    weight = relay.var("weight", shape=(n, k), dtype="int8")
    out = relay.nn.dense(dat, weight, out_dtype="int32")

    # convert to relay IR
    f = relay.Function(relay.analysis.free_vars(out), out)
    mod, params = testing.create_workload(f)
```
Results with default, VLEN = {128,256,512} and without RVV scenarios:
```
# a generic cpu, but no RVV extension enabled
llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m
$ riscv64-linux-gnu-objdump -D lib0.o | grep vsetvli
{nothing}

# a generic cpu w/RVV, unknown VLEN in LLVM (defaults to 256 bit, +warning)
llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v
$ riscv64-linux-gnu-objdump -D lib0.o | grep vsetvli
 a9a:	0c1077d7          	vsetvli	a5,zero,e8,m2,ta,ma
codegen_llvm.cc:193: Warning: LLVM RVV VLEN inference failed, using 256 bits, set -vector-width=XXX to override

# a generic cpu w/RVV, explicit 128 bit for VLEN
llvm -device=riscv_cpu -vector-width=128 -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v
$ riscv64-linux-gnu-objdump -D lib0.o | grep vsetvli
 a96:	0c007557          	vsetvli	a0,zero,e8,m1,ta,ma

# a generic cpu w/RVV, explicit 256 bit for VLEN
llvm -device=riscv_cpu -vector-width=256 -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v
$ riscv64-linux-gnu-objdump -D lib0.o | grep vsetvli
 a9a:	0c1077d7          	vsetvli	a5,zero,e8,m2,ta,ma

# a spacemit-x60 cpu, LLVM-20 infers that this has RVV unit with VLEN 256
llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=spacemit-x60
$ riscv64-linux-gnu-objdump -D lib0.o | grep vsetvli
 a3c:	0c107757          	vsetvli	a4,zero,e8,m2,ta,ma

# a generic cpu w/RVV, explicit 512 bit for VLEN
llvm -device=riscv_cpu -vector-width=512 -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v
$ riscv64-linux-gnu-objdump -D lib0.o | grep vsetvli
 b08:	04307557          	vsetvli	a0,zero,e8,m8,ta,mu
```	

----
Tests here were conducted against LLVM = 20 .
Compilation were tested against LLVM = {10,11,12,13,14,15,16,17,18,19,20} , also revisiting issue https://github.com/apache/tvm/issues/16708 .
