### PR TITLE
[ONNX][RELAX] replace topi.split with relax.op.split in the onnx frontend

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1717,7 +1717,7 @@ class Split(OnnxOpConverter):
         # When splits isnt specified divide evenly over axis.
         else:
             indices = attr["tvm_custom"]["num_outputs"]
-        return bb.emit_te(topi.split, inputs[0], indices, attr.get("axis", 0))
+        return relax.op.split(inputs[0], indices, attr.get("axis", 0))
 
     @classmethod
     def _impl_v13(cls, bb, inputs, attr, params):
@@ -1738,7 +1738,7 @@ class Split(OnnxOpConverter):
         # When splits isnt specified divide evenly over axis.
         else:
             indices = attr["tvm_custom"]["num_outputs"]
-        return bb.emit_te(topi.split, inputs[0], indices, axis=attr.get("axis", 0))
+        return relax.op.split(inputs[0], indices, attr.get("axis", 0))
 
 
 def get_prim_value_list(values):

--- a/python/tvm/relax/transform/legalize_ops/manipulate.py
+++ b/python/tvm/relax/transform/legalize_ops/manipulate.py
@@ -112,12 +112,13 @@ def _split(bb: BlockBuilder, call: Call) -> Expr:
         modulo = tvm.arith.Analyzer().simplify(
             call.args[0].struct_info.shape.values[call.attrs.axis] % indices_or_sections
         )
-        if modulo != 0:
-            logging.info(
-                "Split cannot be legalized by TOPI when the axis being split has "
-                "length that not divisible by the input number of section."
-            )
-            return call
+        if isinstance(modulo, tir.IntImm):
+            if modulo != 0:
+                logging.info(
+                    "Split cannot be legalized by TOPI when the axis being split has "
+                    "length that not divisible by the input number of section."
+                )
+                return call
     else:
         indices_or_sections = call.attrs.indices_or_sections
     return bb.call_te(topi.split, call.args[0], indices_or_sections, call.attrs.axis)

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -864,7 +864,7 @@ StructInfo InferStructInfoSplit(const Call& call, const BlockBuilder& ctx) {
     auto p_indices = opt_indices.value();
     // When there is not index, return the input tensor's struct info.
     if (p_indices.size() == 0) {
-      return TupleStructInfo({data_sinfo});
+      return data_sinfo;
     }
     // Fall back to unknown shape when the input tensor doesn't have ShapeExpr as shape.
     if (data_shape == nullptr) {
@@ -911,7 +911,7 @@ StructInfo InferStructInfoSplit(const Call& call, const BlockBuilder& ctx) {
     int n_section = p_n_section->value;
     // When the number of section is one, return the input tensor's struct info.
     if (n_section == 1) {
-      return TupleStructInfo({data_sinfo});
+      return data_sinfo;
     }
     // Fall back to unknown shape when the input tensor doesn't have ShapeExpr as shape.
     if (data_shape == nullptr) {
@@ -1895,8 +1895,8 @@ StructInfo InferStructInfoOneHot(const Call& call, const BlockBuilder& ctx) {
   PrimValue off_value = Downcast<PrimValue>(call->args[2]);
   // Check if on_value and off_value have the same dtype
   ICHECK(on_value->value->dtype == off_value->value->dtype)
-      << "one_hot: on_value and off_value must have the same dtype, "
-      << "but got " << on_value->value->dtype << " and " << off_value->value->dtype;
+      << "one_hot: on_value and off_value must have the same dtype, " << "but got "
+      << on_value->value->dtype << " and " << off_value->value->dtype;
   DataType dtype = on_value->value->dtype;
 
   // Check if indices has an integer dtype
@@ -1924,8 +1924,8 @@ StructInfo InferStructInfoOneHot(const Call& call, const BlockBuilder& ctx) {
     axis += output_shape.size() + 1;
   }
   ICHECK(0 <= axis && axis <= static_cast<int>(output_shape.size()))
-      << "one_hot: axis must be in the range of [0, " << output_shape.size() << "], "
-      << "but got " << axis;
+      << "one_hot: axis must be in the range of [0, " << output_shape.size() << "], " << "but got "
+      << axis;
   output_shape.insert(output_shape.begin() + axis, attrs->depth);
 
   return TensorStructInfo(ShapeExpr(output_shape), dtype, indices_sinfo->vdevice);

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -1895,8 +1895,8 @@ StructInfo InferStructInfoOneHot(const Call& call, const BlockBuilder& ctx) {
   PrimValue off_value = Downcast<PrimValue>(call->args[2]);
   // Check if on_value and off_value have the same dtype
   ICHECK(on_value->value->dtype == off_value->value->dtype)
-      << "one_hot: on_value and off_value must have the same dtype, " << "but got "
-      << on_value->value->dtype << " and " << off_value->value->dtype;
+      << "one_hot: on_value and off_value must have the same dtype, "
+      << "but got " << on_value->value->dtype << " and " << off_value->value->dtype;
   DataType dtype = on_value->value->dtype;
 
   // Check if indices has an integer dtype
@@ -1924,8 +1924,8 @@ StructInfo InferStructInfoOneHot(const Call& call, const BlockBuilder& ctx) {
     axis += output_shape.size() + 1;
   }
   ICHECK(0 <= axis && axis <= static_cast<int>(output_shape.size()))
-      << "one_hot: axis must be in the range of [0, " << output_shape.size() << "], " << "but got "
-      << axis;
+      << "one_hot: axis must be in the range of [0, " << output_shape.size() << "], "
+      << "but got " << axis;
   output_shape.insert(output_shape.begin() + axis, attrs->depth);
 
   return TensorStructInfo(ShapeExpr(output_shape), dtype, indices_sinfo->vdevice);

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -2108,62 +2108,62 @@ def test_split_infer_struct_info_single_output():
     _check_inference(
         bb,
         relax.op.split(x0, [], axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo((a, b), "float32")]),
+        relax.TensorStructInfo((a, b), "float32"),
     )
     _check_inference(
         bb,
         relax.op.split(x1, [], axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo(dtype="float32", ndim=2)]),
+        relax.TensorStructInfo(dtype="float32", ndim=2),
     )
     _check_inference(
         bb,
         relax.op.split(x2, [], axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo(dtype="float32")]),
+        relax.TensorStructInfo(dtype="float32"),
     )
     _check_inference(
         bb,
         relax.op.split(x3, [], axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo(s0, "float32")]),
+        relax.TensorStructInfo(s0, "float32"),
     )
     _check_inference(
         bb,
         relax.op.split(x4, [], axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo(s1, "float32")]),
+        relax.TensorStructInfo(s1, "float32"),
     )
     _check_inference(
         bb,
         relax.op.split(x5, [], axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo(s2, "float32")]),
+        relax.TensorStructInfo(s2, "float32"),
     )
     _check_inference(
         bb,
         relax.op.split(x0, 1, axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo((a, b), "float32")]),
+        relax.TensorStructInfo((a, b), "float32"),
     )
     _check_inference(
         bb,
         relax.op.split(x1, 1, axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo(dtype="float32", ndim=2)]),
+        relax.TensorStructInfo(dtype="float32", ndim=2),
     )
     _check_inference(
         bb,
         relax.op.split(x2, 1, axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo(dtype="float32")]),
+        relax.TensorStructInfo(dtype="float32"),
     )
     _check_inference(
         bb,
         relax.op.split(x3, 1, axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo(s0, "float32")]),
+        relax.TensorStructInfo(s0, "float32"),
     )
     _check_inference(
         bb,
         relax.op.split(x4, 1, axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo(s1, "float32")]),
+        relax.TensorStructInfo(s1, "float32"),
     )
     _check_inference(
         bb,
         relax.op.split(x5, 1, axis=1),
-        relax.TupleStructInfo([relax.TensorStructInfo(s2, "float32")]),
+       relax.TensorStructInfo(s2, "float32"),
     )
 
 
@@ -2200,9 +2200,7 @@ def test_split_infer_struct_info():
     _check_inference(
         bb,
         relax.op.split(x, 1),
-        R.Tuple(
-            R.Tensor([16, 4]),
-        ),
+        R.Tensor([16, 4]),
     )
     _check_inference(
         bb,

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -2163,7 +2163,7 @@ def test_split_infer_struct_info_single_output():
     _check_inference(
         bb,
         relax.op.split(x5, 1, axis=1),
-       relax.TensorStructInfo(s2, "float32"),
+        relax.TensorStructInfo(s2, "float32"),
     )
 
 


### PR DESCRIPTION
Replaces topi.split with relax.op.split in the ONNX frontend to align with the Relax operator API.

Fixes related ONNX frontend unit tests by:
- Updating InferStructInfoSplit to return a TensorStructInfo instead of a TupleStructInfo if the operator produces only one split, to be consistent with topi.split
- Updating the relax.split legalize callback to only perform the modulo != 0 check when the modulo result is a constant expression

Fixes split unit tests when only one tensor is returned by changing the expected struct info from a TupleStructInfo to a TensorStructInfo.

The reason why it is necessary to update InferStructInfoSplit to return a TensorStructInfo instead of a TupleStructInfo when the  split operator only returns a single tensor is because the MakeCallTIR api will unpack any tuple of struct info containing only one element. See  tvm/src/relax/op/op.cc line 577:

```
Expr MakeCallTIR(Expr func, Tuple args, Array<TensorStructInfo> out_sinfo_list,
                 Optional<Expr> packed_ints) {
  ...
  StructInfo out_sinfo{nullptr};
  if (out_sinfo_list.size() == 1) {
    out_sinfo = out_sinfo_list[0];
  } else {
    out_sinfo = TupleStructInfo({out_sinfo_list.begin(), out_sinfo_list.end()});
  }
```