### PR TITLE
Support subgraph insertion with kill operator

### DIFF
--- a/src/relay/analysis/annotated_region_set.cc
+++ b/src/relay/analysis/annotated_region_set.cc
@@ -119,6 +119,9 @@ class AnnotatedRegionSet::Creator : protected MixedModeVisitor {
       if (end && end->op == end_op_) {  // Ignore closed regions.
         continue;
       }
+      if(arg.as<ConstantNode>()) {  // Ignore ConstantNode
+        continue;
+      }
 
       auto arg_region = region_set_->GetRegion(arg);
       ICHECK_EQ(region.defined(), arg_region.defined())

--- a/src/relay/backend/vm/manifest_lifetimes.cc
+++ b/src/relay/backend/vm/manifest_lifetimes.cc
@@ -255,7 +255,21 @@ Pass ManifestLifetimes() {
   return CreateFunctionPass(pass_func, 0, "ManifestLifetimes", {});
 }
 
+Expr ManifestLifetimes(const Expr& e) {
+  auto f = Downcast<Function>(AliasEliminator().Mutate(e));
+  Arena arena;
+  ControlFlowGraph cfg = ControlFlowGraph: Create(&arena, f);
+  UseDefAnalysis use def = UseDefAnalysis::Analyze(cfg);
+  LivenessAnalysis lva = LivenessAnalysis::Analyze(cfg, use_def);
+  KillInserter ki(&cfg, &lva);
+  Function nf = Downcast<Function>(ki.Mutate(f));
+  return nf;
+}
+
 TVM_REGISTER_GLOBAL("relay._transform.ManifestLifetimes").set_body_typed(ManifestLifetimes);
+TVM REGISTER GLOBAL("nbu. transform.ManifestLifetimesExpr").set_body_typed([](const Expr& e) {
+  return ManifestLifetimes(e);
+});
 
 }  // namespace transform
 }  // namespace relay


### PR DESCRIPTION
When the ConstantNode is included in IR, it does not belong to any region, therefore AddToArgRegion need ignore ConstantNode.
ManifestLifetimes should support subgraph insertion with kill operator.