### PR TITLE
[Refactor] Phase out python dependency attrs

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -86,7 +86,6 @@ outputs:
         - psutil
         - scipy
         - typing_extensions
-        - attrs
         - ml_dtypes
         - tornado
         - cloudpickle

--- a/docker/install/ubuntu2004_install_python_package.sh
+++ b/docker/install/ubuntu2004_install_python_package.sh
@@ -23,7 +23,6 @@ set -o pipefail
 # install libraries for python package on ubuntu
 pip3 install --upgrade \
     "Pygments>=2.4.0" \
-    attrs \
     cloudpickle \
     cython \
     decorator \

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -23,7 +23,6 @@ set -o pipefail
 # install libraries for python package on ubuntu
 pip3 install --upgrade \
     "Pygments>=2.4.0" \
-    attrs \
     cloudpickle \
     cython \
     decorator \

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -209,7 +209,7 @@ The following commands can be used to install the extra Python dependencies:
 
 .. code:: bash
 
-    pip3 install numpy decorator attrs
+    pip3 install numpy decorator
 
 * If you want to use RPC Tracker
 

--- a/python/gen_requirements.py
+++ b/python/gen_requirements.py
@@ -63,7 +63,6 @@ REQUIREMENTS_BY_PIECE: RequirementsByPieceType = [
         (
             "Base requirements needed to install tvm",
             [
-                "attrs",
                 "cloudpickle",
                 "decorator",
                 "ml_dtypes",
@@ -236,7 +235,6 @@ ConstraintsType = typing.List[typing.Tuple[str, typing.Union[None, str]]]
 #    here. Include a comment linking to context or explaining why the constraint is in place.
 CONSTRAINTS = [
     ("astroid", None),
-    ("attrs", None),
     ("autodocsumm", None),
     ("black", "==20.8b1"),
     ("cloudpickle", None),

--- a/python/tvm/relay/transform/memory_plan.py
+++ b/python/tvm/relay/transform/memory_plan.py
@@ -49,6 +49,7 @@ class Region:
     The below pass groups sets of allocations into regions,
     then replaces the region with a single allocation.
     """
+
     var: expr.Var
     size: expr.Expr
     alignment: Optional[expr.Expr]

--- a/python/tvm/relay/transform/memory_plan.py
+++ b/python/tvm/relay/transform/memory_plan.py
@@ -20,7 +20,7 @@ A pass for manifesting explicit memory allocations.
 """
 from typing import Optional, Dict, List, Tuple
 from collections import defaultdict
-import attr
+from dataclasses import dataclass
 
 from ..expr_functor import ExprMutator
 from .. import op, expr
@@ -41,7 +41,7 @@ def is_primitive(call):
     )
 
 
-@attr.s(auto_attribs=True)
+@dataclass
 class Region:
     """
     Represents a control-free allocation region.
@@ -49,7 +49,6 @@ class Region:
     The below pass groups sets of allocations into regions,
     then replaces the region with a single allocation.
     """
-
     var: expr.Var
     size: expr.Expr
     alignment: Optional[expr.Expr]


### PR DESCRIPTION
This pull request includes several changes aimed at removing the `attrs` library and replacing its usage with a python 3.7+ builtin `dataclasses` in the codebase. Additionally, it updates various dependency lists and installation scripts to reflect this removal.

Code refactoring:

* [`python/tvm/relay/transform/memory_plan.py`](diffhunk://#diff-09be5ffb3fcaecb371823a1802185d034f224c41d91c7e257784942b318ad92fL23-R23): Replaced `attr.s` with `dataclass` for defining the `Region` class. [[1]](diffhunk://#diff-09be5ffb3fcaecb371823a1802185d034f224c41d91c7e257784942b318ad92fL23-R23) [[2]](diffhunk://#diff-09be5ffb3fcaecb371823a1802185d034f224c41d91c7e257784942b318ad92fL44-L52)

Dependency updates:

* [`conda/recipe/meta.yaml`](diffhunk://#diff-eba2917991959691cc8fe3f70bcc7a181ec4b806191e3b3ded427f067fcd5a30L89): Removed `attrs` from the list of dependencies.
* [`docker/install/ubuntu2004_install_python_package.sh`](diffhunk://#diff-7e95c1dfcc4947180381cc3a845e3f64367a680cd08b8731924912f836001aa7L26): Removed `attrs` from the list of Python packages to be installed.
* [`docker/install/ubuntu_install_python_package.sh`](diffhunk://#diff-6a76ef512408162f24fa70f390ce27e150c1cef7714c678b3f75b3ba41e4bce2L26): Removed `attrs` from the list of Python packages to be installed.
* [`docs/install/from_source.rst`](diffhunk://#diff-fb60f53a75475f5774d6d0a2ec8c35c89b1b34255c19b2c6bf0a0404775efce8L212-R212): Removed `attrs` from the example command for installing extra Python dependencies.
* [`python/gen_requirements.py`](diffhunk://#diff-e90cbe77cd3691891521000b8c60d3ed4dab7b2c8f7a923fd558bcfe0088c43aL66): Removed `attrs` from the base requirements and constraints. [[1]](diffhunk://#diff-e90cbe77cd3691891521000b8c60d3ed4dab7b2c8f7a923fd558bcfe0088c43aL66) [[2]](diffhunk://#diff-e90cbe77cd3691891521000b8c60d3ed4dab7b2c8f7a923fd558bcfe0088c43aL239)
