### PR TITLE
[Refactor] Improve TargetHasSVE function with optional target handling

### DIFF
--- a/src/arith/scalable_expression.cc
+++ b/src/arith/scalable_expression.cc
@@ -86,10 +86,13 @@ bool CanProveVscaleExpressionFromKnownValues(arith::Analyzer* analyzer, const Pr
   return can_prove_expr;
 }
 
-bool TargetHasSVE(Target current_target) {
+bool TargetHasSVE(Optional<Target> target) {
+  if (!target.defined()) {
+    target = Target::Current();
+  }
   bool has_sve{false};
-  if (current_target.defined()) {
-    has_sve = current_target->GetFeature<Bool>("has_sve").value_or(Bool(false));
+  if (target.defined()) {
+    has_sve = target->GetFeature<Bool>("has_sve").value_or(Bool(false));
   }
   return has_sve;
 }

--- a/src/arith/scalable_expression.cc
+++ b/src/arith/scalable_expression.cc
@@ -90,11 +90,10 @@ bool TargetHasSVE(Optional<Target> target) {
   if (!target.defined()) {
     target = Target::Current();
   }
-  bool has_sve{false};
   if (target.defined()) {
-    has_sve = target->GetFeature<Bool>("has_sve").value_or(Bool(false));
+    return Downcast<Target>(target)->GetFeature<Bool>("has_sve").value_or(Bool(false));
   }
-  return has_sve;
+  return false;
 }
 
 }  // namespace arith

--- a/src/arith/scalable_expression.h
+++ b/src/arith/scalable_expression.h
@@ -83,7 +83,7 @@ bool CanProveVscaleExpressionFromKnownValues(arith::Analyzer* analyzer, const Pr
  * \param target The target to check.
  * \return Whether SVE is supported
  */
-bool TargetHasSVE(Target target);
+bool TargetHasSVE(Optional<Target> target = NullOpt);
 
 }  // namespace arith
 }  // namespace tvm


### PR DESCRIPTION
pull request #16893 refactored the TargetHasSVE function to support target assignment instead of using Target::Current(). This introduces a breaking API change for older projects that rely on TVM. However, the issue can be easily fixed by adding an Optional tag and a default value.