### PR TITLE
[skip ci][CI] Update github tvmbot

### DIFF
--- a/ci/scripts/github/github_tvmbot.py
+++ b/ci/scripts/github/github_tvmbot.py
@@ -532,16 +532,12 @@ class PR:
     def rerun_jenkins_ci(self) -> None:
         job_names = [
             "tvm-arm",
-            "tvm-cortexm",
             "tvm-cpu",
             "tvm-docker",
             "tvm-gpu",
             "tvm-hexagon",
             "tvm-i386",
             "tvm-lint",
-            "tvm-minimal",
-            "tvm-minimal-cross-isa",
-            "tvm-riscv",
             "tvm-wasm",
             "tvm-unity",
         ]


### PR DESCRIPTION
This PR updates github tvmbot to remove the stale pipeline checks.