### PR TITLE
[Docker] Update ml_dtypes to 0.5.1+

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -42,4 +42,4 @@ pip3 install --upgrade \
     junitparser==2.4.2 \
     six \
     tornado \
-    ml_dtypes
+    "ml_dtypes>=0.5.1"


### PR DESCRIPTION
This is follow-up https://github.com/apache/tvm/pull/17643, the cpu and gpu dockers are actually using docker/install/ubuntu_install_python_package.sh. 