### PR TITLE
updated the assert in BindParams to allow tvm.relax.Constant

### DIFF
--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -659,8 +659,8 @@ def BindParams(
         if isinstance(v, np.ndarray):
             v = tvm.nd.array(v)
         assert isinstance(
-            v, tvm.runtime.NDArray
-        ), f"param values are expected to be TVM.NDArray or numpy.ndarray, but got {type(v)}"
+            v, (tvm.runtime.NDArray, tvm.relax.Constant)
+        ), f"param values are expected to be TVM.NDArray, numpy.ndarray or tvm.relax.Constant, but got {type(v)}"
         tvm_params[k] = v
 
     return _ffi_api.BindParams(func_name, tvm_params)  # type: ignore

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -658,9 +658,10 @@ def BindParams(
     for k, v in params.items():
         if isinstance(v, np.ndarray):
             v = tvm.nd.array(v)
-        assert isinstance(
-            v, (tvm.runtime.NDArray, tvm.relax.Constant)
-        ), f"param values are expected to be TVM.NDArray, numpy.ndarray or tvm.relax.Constant, but got {type(v)}"
+        assert isinstance(v, (tvm.runtime.NDArray, tvm.relax.Constant)), (
+            f"param values are expected to be TVM.NDArray,"
+            f"numpy.ndarray or tvm.relax.Constant, but got {type(v)}"
+        )
         tvm_params[k] = v
 
     return _ffi_api.BindParams(func_name, tvm_params)  # type: ignore


### PR DESCRIPTION
The c++ implementation of BindParams can accept tvm.relax.Constants, however the python interface assert only allows ndarrays. I added tvm.relax.Constant to the assert.

By allowing tvm.relax.Constants as input arguments to BindParams it is possible to avoid duplicating weights if there are several functions in the module that are using the same weight as an input parameter, such as prefill and decode in an LLM. 