### PR TITLE
[Fix] Include `<chrono>` for `std::chrono`

### DIFF
--- a/src/meta_schedule/profiler.cc
+++ b/src/meta_schedule/profiler.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <algorithm>
+#include <chrono>
 
 #include "./utils.h"
 


### PR DESCRIPTION
This PR fixes an include problem in profiler.cc, which uses namespace `std::chrono` without including the header. This leads to compilation failure on Windows platform.