### PR TITLE
[WebGPU] Support warp-level shuffle primitives with subgroup

### DIFF
--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -103,6 +103,8 @@ std::string CodeGenWebGPU::Finish() {
   if (enable_fp16_) {
     header_stream << "enable f16;\n\n";
   }
+  // TODO(Charlie): Add enable_subgroups_ to control
+  header_stream << "enable subgroups;\n\n";
   return header_stream.str() + decl_stream.str() + this->fwd_decl_stream.str() + stream.str();
 }
 

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -423,6 +423,8 @@ TVM_REGISTER_TARGET_KIND("vulkan", kDLVulkan)
 
 TVM_REGISTER_TARGET_KIND("webgpu", kDLWebGPU)
     .add_attr_option<runtime::Int>("max_num_threads", runtime::Int(256))
+    // TODO(Charlie): Not all WebGPU supports this, need a control logic
+    .add_attr_option<runtime::Int>("thread_warp_size", runtime::Int(32))
     .set_default_keys({"webgpu", "gpu"});
 
 TVM_REGISTER_TARGET_KIND("hexagon", kDLHexagon)

--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -110,10 +110,16 @@ export async function detectGPUDevice(powerPreference: "low-power" | "high-perfo
       );
     }
 
-    const requiredFeatures: GPUFeatureName[] = [];
+    // TODO(Charlie): cannot type annotate because @webgpu/types
+    // does not have "subgroups" as GPUFeatureName yet
+    // const requiredFeatures: GPUFeatureName[] = [];
+    const requiredFeatures = [];
     // Always require f16 if available
     if (adapter.features.has("shader-f16")) {
       requiredFeatures.push("shader-f16");
+    }
+    if (adapter.features.has("subgroups")) {
+      requiredFeatures.push("subgroups");
     }
 
     // requestAdapterInfo() is deprecated, causing requestAdapterInfo to raise


### PR DESCRIPTION
This PR supports warp-level shuffle primitives using the newly introduce `subgroup` in WebGPU. We then use them in the implementation of allreduce lowering.

The introduced primitives are:
- `subgroupShuffle()`
- `subgroupShuffleUp()`
- `subgroupShuffleDown()`

This PR largely follows the Metal counterpart:
- https://github.com/apache/tvm/pull/15401

Tested with Llama3.2-1B-q4f16_1 E2E with WebLLM. The dumped WebGPU kernel indeed contains subgroup shuffle primitives: https://gist.github.com/CharlieFRuan/cb54a8db0513ecbbc16c5de8df5ab845

Remaining TODOs:
- [ ] Measure speedup
- [ ] Be able to parameterize whether to use subgroup or not when targeting WebGPU, since not all devices support it
- [ ] Check `GPUFeatureName`'s inclusion of `subgroups` in `@webgpu/types`

Resources:
- https://github.com/gpuweb/gpuweb/blob/859fdd4a803a11e7b8de70483aa75c365be18b0e/proposals/subgroups.md
- https://www.w3.org/TR/WGSL/#subgroup-builtin-functions
- https://developer.chrome.com/blog/new-in-webgpu-134?hl=en