### PR TITLE
[Runtime][Target] Add C module for host

### DIFF
--- a/python/tvm/tir/tensor_intrin/__init__.py
+++ b/python/tvm/tir/tensor_intrin/__init__.py
@@ -16,4 +16,11 @@
 # under the License.
 # pylint: disable=unused-import
 """Intrinsics for tensorization."""
-from . import arm_cpu, cuda, rocm, x86, hexagon
+from tvm.target.codegen import llvm_version_major
+
+from . import cuda
+
+if llvm_version_major(allow_none=True) is not None:
+    from . import arm_cpu
+    from . import rocm
+    from . import x86

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -102,6 +102,7 @@ class ConstantFolder : public ExprMutator {
   Optional<PackedFunc> GetCachedBuild(tir::PrimFunc func) {
     // TODO(tvm-team): consider another way of bulk extract and build PrimFunc once
     // would be helpful for future cases where PrimFunc recursively call into each other
+    // TODO(siyuan): support c backend for constant folding
     Target eval_cpu_target{"llvm"};
 
     auto it = func_build_cache_.find(func);

--- a/src/runtime/c_host_module.cc
+++ b/src/runtime/c_host_module.cc
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file c_module.cc
+ * \brief C module. Note this module is used for simple tasks on host machine
+ *        (for example, launch GPU kernels). Performance is not the priority,
+ *        but to allow users to use TVM without llvm dependency.
+ * \note This module is different from source_module and is NOT designed for
+ *       AOT or legacy micro usecases.
+ */
+
+#include <tvm/runtime/c_backend_api.h>
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/registry.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include "file_utils.h"
+#include "library_module.h"
+#include "tvm/runtime/container/optional.h"
+
+namespace tvm {
+namespace runtime {
+
+class CModuleNode : public runtime::ModuleNode {
+ public:
+  explicit CModuleNode(std::string c_source) : c_source_(c_source) {}
+
+  ~CModuleNode() = default;
+
+  const char* type_key() const final { return "c"; }
+
+  String GetSource(const String& format) final { return c_source_; };
+
+  PackedFunc GetFunction(const String& name, const ObjectPtr<Object>& sptr_to_self) final;
+
+  String GetFormat() final { return "c"; }
+
+  void SaveToFile(const String& file_name, const String& format) final;
+
+  int GetPropertyMask() const override {
+    return runtime::ModulePropertyMask::kRunnable | runtime::ModulePropertyMask::kDSOExportable;
+  }
+
+ private:
+  void Compile();
+  /*! \brief The C source code */
+  std::string c_source_;
+  /*! \brief The library module */
+  Optional<Module> compiled_lib_ = NullOpt;
+};
+
+void CModuleNode::SaveToFile(const String& file_name, const String& format) {
+  std::string fmt = runtime::GetFileFormat(file_name, format);
+  std::string meta_file = runtime::GetMetaFilePath(file_name);
+  if (fmt == "c") {
+    SaveBinaryToFile(file_name, c_source_);
+  } else {
+    LOG(FATAL) << "Unsupported format: " << fmt;
+  }
+}
+
+PackedFunc CModuleNode::GetFunction(const String& name, const ObjectPtr<Object>& sptr_to_self) {
+  if (!compiled_lib_.defined()) {
+    Compile();
+  }
+  return compiled_lib_.value()->GetFunction(name, sptr_to_self);
+}
+
+void CModuleNode::Compile() {
+  ICHECK(!compiled_lib_.defined()) << "CModuleNode::Compile() should be called only once";
+  if (const auto* f = Registry::Get("tvm_callback_c_compile")) {
+    std::string binary = (*f)(c_source_, /*target=*/"c").operator std::string();
+    std::string tmp_file_name = std::string(std::tmpnam(nullptr)) + ".so";
+    std::ofstream tmp_file(tmp_file_name, std::ios::binary);
+    tmp_file.write(binary.c_str(), binary.size());
+    tmp_file.close();
+    ObjectPtr<Library> lib = CreateDSOLibraryObject(tmp_file_name);
+    compiled_lib_ = CreateModuleFromLibrary(lib);
+    std::remove(tmp_file_name.c_str());
+  } else {
+    LOG(FATAL) << "tvm_callback_c_compile not found";
+  }
+}
+
+Module CModuleCreate(std::string c_source) {
+  auto n = make_object<CModuleNode>(c_source);
+  return runtime::Module(n);
+}
+
+}  // namespace runtime
+}  // namespace tvm

--- a/src/runtime/c_host_module.h
+++ b/src/runtime/c_host_module.h
@@ -18,36 +18,25 @@
  */
 
 /*!
- * \file cuda_module.h
- * \brief Execution handling of CUDA kernels
+ * \file c_module.h
+ * \brief Execution handling of c kernels
  */
-#ifndef TVM_RUNTIME_CUDA_CUDA_MODULE_H_
-#define TVM_RUNTIME_CUDA_CUDA_MODULE_H_
+#ifndef TVM_RUNTIME_C_HOST_C_MODULE_H_
+#define TVM_RUNTIME_C_HOST_C_MODULE_H_
 
 #include <tvm/runtime/module.h>
 
 #include <string>
-#include <unordered_map>
-
-#include "../meta_data.h"
 
 namespace tvm {
 namespace runtime {
 
-/*! \brief Maximum number of GPU supported in CUDAModule */
-static constexpr const int kMaxNumGPUs = 32;
-
 /*!
- * \brief create a cuda module from data.
- *
- * \param data The module data, can be ptx, cubin
- * \param fmt The format of the data, can be "ptx", "cubin"
- * \param fmap The map function information map of each function.
- * \param cuda_source Optional, cuda source file
+ * \brief create a c module from data.
+ * \param c_source The c source code
  */
-Module CUDAModuleCreate(std::string data, std::string fmt,
-                        std::unordered_map<std::string, FunctionInfo> fmap,
-                        std::string cuda_source);
+Module CModuleCreate(std::string c_source);
+
 }  // namespace runtime
 }  // namespace tvm
-#endif  // TVM_RUNTIME_CUDA_CUDA_MODULE_H_
+#endif  // TVM_RUNTIME_C_HOST_C_MODULE_H_

--- a/src/target/source/source_module.cc
+++ b/src/target/source/source_module.cc
@@ -82,7 +82,7 @@ class CSourceModuleNode : public runtime::ModuleNode {
   CSourceModuleNode(const std::string& code, const std::string& fmt,
                     const Array<String>& func_names, const Array<String>& const_vars)
       : code_(code), fmt_(fmt), const_vars_(const_vars), func_names_(func_names) {}
-  const char* type_key() const final { return "c"; }
+  const char* type_key() const final { return "c-source"; }
 
   PackedFunc GetFunction(const String& name, const ObjectPtr<Object>& sptr_to_self) final {
     // Currently c-source module is used as demonstration purposes with binary metadata module


### PR DESCRIPTION
This PR adds a C host module for simple host tasks without LLVM dependency. LLVM dependency is one of the most troublesome for TVM distribution, while it's not necessary for simple host tasks.

This PR plays a role as the first step towards the goal by supporting the c runtime.

cc @LeiWang1999 @tqchen 