### PR TITLE
[Relax][PyTorch] Add support for gather, flip and take ops

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -936,15 +936,11 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
                 s_shape.append(s)
         return self.block_builder.emit(relax.op.reshape(cat, s_shape))
 
-    def _take(self, node: fx.Node, axis: Optional[int] = None) -> relax.Var:
+    def _take(self, node: fx.Node) -> relax.Var:
         x = self.env[node.args[0]]
         indices = self.env[node.args[1]]
         indices = self.block_builder.emit(relax.op.astype(indices, "int32"))
-        if axis is not None:
-            raise NotImplementedError(
-                "Relax's relax.op.take() does not fully support PyTorch's torch.take()."
-            )
-        return self.block_builder.emit(relax.op.take(x, indices, axis=axis))
+        return self.block_builder.emit(relax.op.take(x, indices))
 
     def _tile(self, node: fx.Node) -> relax.Var:
         import torch  # type: ignore

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -941,7 +941,9 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         indices = self.env[node.args[1]]
         indices = self.block_builder.emit(relax.op.astype(indices, "int32"))
         if axis is not None:
-            raise NotImplementedError("Relax's relax.op.take() does not fully support PyTorch's torch.take().")
+            raise NotImplementedError(
+                "Relax's relax.op.take() does not fully support PyTorch's torch.take()."
+            )
         return self.block_builder.emit(relax.op.take(x, indices, axis=axis))
 
     def _tile(self, node: fx.Node) -> relax.Var:

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -847,6 +847,21 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
                 broadcast_shape.append(i)
         return self.block_builder.emit(relax.op.broadcast_to(args[0], broadcast_shape))
 
+    def _flip(self, node: fx.Node) -> relax.Var:
+        x = self.env[node.args[0]]
+        dims = node.args[1] if len(node.args) > 1 else node.kwargs.get("dims", None)
+        if isinstance(dims, (list, tuple)) and len(dims) > 0:
+            dims = dims[0]
+        elif not isinstance(dims, int):
+            raise TypeError(f"flip expects an integer axis, but got {type(dims)}: {dims}")
+        return self.block_builder.emit(relax.op.flip(x, dims))
+
+    def _gather(self, node: fx.Node) -> relax.Var:
+        x = self.env[node.args[0]]
+        dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim", 0)
+        index = self.env[node.args[2]]
+        return self.block_builder.emit(relax.op.gather_elements(x, index, axis=dim))
+
     def _permute(self, node: fx.Node) -> relax.Var:
         import torch  # type: ignore
 
@@ -920,6 +935,14 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
             else:
                 s_shape.append(s)
         return self.block_builder.emit(relax.op.reshape(cat, s_shape))
+
+    def _take(self, node: fx.Node, axis: Optional[int] = None) -> relax.Var:
+        x = self.env[node.args[0]]
+        indices = self.env[node.args[1]]
+        indices = self.block_builder.emit(relax.op.astype(indices, "int32"))
+        if axis is not None:
+            raise NotImplementedError("Relax's relax.op.take() does not fully support PyTorch's torch.take().")
+        return self.block_builder.emit(relax.op.take(x, indices, axis=axis))
 
     def _tile(self, node: fx.Node) -> relax.Var:
         import torch  # type: ignore

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -733,6 +733,8 @@ class TorchFXImporter(BaseFXGraphImporter):
             "cumsum": self._cumsum,
             "expand": self._expand,
             "flatten": self._flatten,
+            "flip": self._flip,
+            "gather": self._gather,
             "permute": self._permute,
             "repeat": self._repeat,
             "reshape": self._reshape,
@@ -741,6 +743,7 @@ class TorchFXImporter(BaseFXGraphImporter):
             "split": self._split,
             "squeeze": self._squeeze,
             "stack": self._stack,
+            "take": self._take,
             "tile": self._tile,
             "transpose": self._transpose,
             "unsqueeze": lambda node: self.block_builder.emit(

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -4029,7 +4029,7 @@ def test_take():
         ) -> R.Tensor((3,), dtype="float32"):
             with R.dataflow():
                 lv: R.Tensor((3,), dtype="int32") = R.astype(inp_1, "int32")
-                lv1: R.Tensor((3,), dtype="float32") = R.take(inp_0, lv, axis=None)
+                lv1: R.Tensor((3,), dtype="float32") = R.take(inp_0, lv)
                 gv: R.Tensor((3,), dtype="float32") = lv1
                 R.output(gv)
             return gv


### PR DESCRIPTION
This pr supports Pytorch `gather`, `flip` and `take` for Relax.