### PR TITLE
Allow ingesting Upsample module from torch.export either using Size or Scale Factor argument

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -92,7 +92,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
         )
 
     def _upsample_impl(
-        self, x: relax.Expr, size, align_corners: bool, scale_factor, method: str
+        self, x: relax.Expr, size, scale_factor, method: str, align_corners: bool,  
     ) -> relax.Var:
         coord_trans = "align_corners" if align_corners else "half_pixel"
 
@@ -116,21 +116,35 @@ class ExportedProgramImporter(BaseFXGraphImporter):
     def _upsample_bilinear2d(self, node: fx.Node) -> relax.Var:
         x = self.env[node.args[0]]
         size = node.args[1] if len(node.args) > 1 else node.kwargs.get("size", None)
+        # TODO do we need the condition on size like we have in _upsample_nearest2d?
+
+        # TODO HL: I am doubtful that align_corners is args[2]. The pytorch 
+        # arguments go size, scale_factor, mode, align_corner. See changes I 
+        # made to _upsample_nearest2d. Need to test for _upsample_bilinear2d
         align_corners = (
             node.args[2] if len(node.args) > 2 else node.kwargs.get("align_corners", True)
         )
-        scale_factor = node.args[3] if len(node.args) > 3 else node.kwargs.get("scale_factor", None)
-        return self._upsample_impl(x, size, align_corners, scale_factor, "linear")
+        scale_factor = node.args[3] if len(node.args) > 3 else node.kwargs.get("scale_factor", 1) # TODO non-sense to default to 1! Understand why "None" doesn't work!
+        return self._upsample_impl(x, size=size, scale_factor=scale_factor, 
+                                   method="linear", align_corners=align_corners)
 
     def _upsample_nearest2d(self, node: fx.node) -> relax.Var:
         x = self.env[node.args[0]]
         size = node.args[1] if len(node.args) > 1 else node.kwargs.get("size", None)
-        align_corners = (
-            node.args[2] if len(node.args) > 2 else node.kwargs.get("align_corners", True)
-        )
-        scale_factor = node.args[3] if len(node.args) > 3 else node.kwargs.get("scale_factor", None)
-        return self._upsample_impl(x, size, align_corners, scale_factor, "nearest_neighbor")
 
+        if size:
+            scale_factor = None # Can only define size or scale_factor, not both
+            align_corners = node.args[2] if len(node.args) > 2 else node.kwargs.get("align_corners", None) 
+                
+        else:
+            # TODO figure out why pytorch passes a list [scale_factor,scale_factor] instead of just an int. Passing first element for now
+            scale_factor = node.args[2][0] if len(node.args) > 2 else node.kwargs.get("scale_factor", 1) # TODO non-sense to default to 1! Understand why "None" doesn't work!
+            align_corners = node.args[3] if len(node.args) > 3 else node.kwargs.get("align_corners", None) # TODO pytorch defaults to None
+          
+        return self._upsample_impl(x, size=size, scale_factor=scale_factor, 
+                                   method="nearest_neighbor", 
+                                   align_corners=align_corners)
+    
     ########## Manipulation ##########
 
     def _select(self, node: fx.Node) -> relax.Var:

--- a/tests/python/relax/test_from_exported_to_cuda.py
+++ b/tests/python/relax/test_from_exported_to_cuda.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+from tvm import relax
+import tvm.testing
+import numpy as np
+import torch
+from torch.export import export
+from tvm.relax.frontend.torch import from_exported_program
+from torch.nn import Softmax, Upsample
+
+
+def assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module):
+    """
+    This util ensures that a torch module can successfully be exported to TVM 
+    using torch.export and that the resuling IR program gives the same result 
+    as PyTorch when ran on CUDA.
+    """
+    torch_data = torch.from_numpy(raw_data)
+    example_args = (torch_data,)
+
+    with torch.no_grad():
+        exported_program = export(torch_module, example_args)
+        mod_from_torch = from_exported_program(
+            exported_program, keep_params_as_input=True
+        )
+
+    tvm_mod, tvm_params = relax.frontend.detach_params(mod_from_torch)
+    target = tvm.target.Target.from_device(tvm.cuda())
+
+    ex = relax.build(tvm_mod, target=target, 
+                     relax_pipeline=relax.get_default_pipeline(target))
+    dev = tvm.device("cuda", 0)
+    vm = relax.VirtualMachine(ex, dev)
+
+    gpu_data = tvm.nd.array(raw_data, dev)
+    gpu_params = [tvm.nd.array(p, dev) for p in tvm_params["main"]]
+    gpu_out = vm["main"](gpu_data, *gpu_params)
+
+    pytorch_out = torch_module(torch_data).detach().numpy()
+    actual = gpu_out[0].numpy()
+    desired = pytorch_out
+    np.testing.assert_allclose(actual=actual, desired=desired, rtol=1e-5, 
+                               atol=1e-5) 
+
+
+def test_upsample_with_size():
+    """ 
+    The Upsample module can be used with the size arugment or the scale 
+    factor argument but not both. This tests the former.
+    """
+    batch_size = 1
+    channels = 3
+    height, width = 8, 8
+
+    torch_module = Upsample(
+    size=(64, 64),               
+    mode='nearest',             
+    recompute_scale_factor=None)
+
+    raw_data = np.random.rand(
+        batch_size, channels, height, width).astype("float32")
+
+    assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module)
+
+
+def test_upsample_with_scale_factor():
+    """
+    The Upsample module can be used with the size arugment or the scale 
+    factor argument but not both. This tests the latter. 
+    """
+    batch_size = 2  
+    channels = 3
+    height, width = 32, 32
+
+    torch_module = Upsample(size=None, scale_factor = 7, mode = 'nearest',
+                            align_corners=None, recompute_scale_factor=True)
+
+    raw_data = np.random.rand(
+        batch_size, channels, height, width).astype("float32")
+
+    assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
Torch's Upsample module can only accomodate the Size or Scale Factor argument but not both. Regarding that limitation, there was previously a bug regarding the parsing of the arguments (the wrong order of arguments was assume). This PR fixes that and adds a unit test 