### PR TITLE
[FFI] Fix dynamic FFI index to ensure compatibility

### DIFF
--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -77,9 +77,12 @@ struct TypeIndex {
     /*! \brief runtime::RPCObjectRef */
     kRuntimeRPCObjectRef = 9,
     // static assignments that may subject to change.
-    kStaticIndexEnd,
-    /*! \brief Type index is allocated during runtime. */
-    kDynamic = kStaticIndexEnd
+    kStaticIndexEnd = 10,
+    /*!
+     * \brief Type index is allocated during runtime, keeping it as
+     * constant for now to ensure compatibility across versions
+     */
+    kDynamic = 12
   };
 };  // namespace TypeIndex
 


### PR DESCRIPTION
This PR sets the dynamic index to the original value in past versions so we can have stable compatibility when we phase out static objects.