### PR TITLE
[Relax][PyTorch] Add support for lerp, select and clone ops

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -377,12 +377,14 @@ class TorchFXImporter(BaseFXGraphImporter):
         return self._max_pool2d_impl(x, kernel_size, stride, padding, dilation, ceil_mode)
 
     ########## Linear Interpolation ##########
-    
+
     def _lerp(self, node: fx.Node) -> relax.Var:
         start = self.env[node.args[0]]
         end = self.env[node.args[1]]
         weight = self.env[node.args[2]]
-        return self.block_builder.emit(relax.op.add(start, relax.op.multiply(weight, relax.op.subtract(end, start))))
+        return self.block_builder.emit(
+            relax.op.add(start, relax.op.multiply(weight, relax.op.subtract(end, start)))
+        )
 
     ########## Manipulation ##########
 

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -376,6 +376,14 @@ class TorchFXImporter(BaseFXGraphImporter):
 
         return self._max_pool2d_impl(x, kernel_size, stride, padding, dilation, ceil_mode)
 
+    ########## Linear Interpolation ##########
+    
+    def _lerp(self, node: fx.Node) -> relax.Var:
+        start = self.env[node.args[0]]
+        end = self.env[node.args[1]]
+        weight = self.env[node.args[2]]
+        return self.block_builder.emit(relax.op.add(start, relax.op.multiply(weight, relax.op.subtract(end, start))))
+
     ########## Manipulation ##########
 
     def _chunk(self, node: fx.Node) -> relax.Var:
@@ -413,6 +421,12 @@ class TorchFXImporter(BaseFXGraphImporter):
         x = self.env[node.args[0]]
         shape = self.shape_of(x)
         return relax.const(reduce(lambda x, y: x * y, [s.value for s in shape]), "int32")
+
+    def _select(self, node: fx.Node) -> relax.Var:
+        x = self.env[node.args[0]]
+        dim = node.args[1]
+        index = relax.const(node.args[2], "int64")
+        return self.block_builder.emit(relax.op.take(x, index, dim))
 
     def _size(self, node: fx.Node) -> relax.Expr:
         x = self.env[node.args[0]]
@@ -737,6 +751,8 @@ class TorchFXImporter(BaseFXGraphImporter):
             "scaled_dot_product_attention": self._scaled_dot_product_attention,
             "stochastic_depth": lambda node: self.env[node.args[0]],
             "unbind": self._unbind,
+            # linear interpolation
+            "lerp": self._lerp,
             # statistical
             "mean": self._mean,
             "sum": self._sum,
@@ -759,6 +775,7 @@ class TorchFXImporter(BaseFXGraphImporter):
             "repeat": self._repeat,
             "reshape": self._reshape,
             "scatter": self._scatter,
+            "select": self._select,
             "size": self._size,
             "split": self._split,
             "squeeze": self._squeeze,
@@ -772,6 +789,7 @@ class TorchFXImporter(BaseFXGraphImporter):
             "view": self._reshape,
             # tensor creation
             "arange": self._arange,
+            "clone": lambda node: self.env[node.args[0]],
             "empty": self._empty,
             "empty_like": self._empty_like,
             "fill_": self._inplace_fill,

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -4178,12 +4178,16 @@ def test_lerp():
             inp_2: R.Tensor((5, 3), dtype="float32"),
         ) -> R.Tensor((5, 3), dtype="float32"):
             with R.dataflow():
-                lv: R.Tensor((5, 3), dtype="float32") = R.add(inp_0, R.multiply(inp_2, R.subtract(inp_1, inp_0)))
+                lv: R.Tensor((5, 3), dtype="float32") = R.add(
+                    inp_0, R.multiply(inp_2, R.subtract(inp_1, inp_0))
+                )
                 gv: R.Tensor((5, 3), dtype="float32") = lv
                 R.output(gv)
             return gv
 
-    verify_model(Lerp(), [([5, 3], "float32"), ([5, 3], "float32"), ([5, 3], "float32")], {}, Expected)
+    verify_model(
+        Lerp(), [([5, 3], "float32"), ([5, 3], "float32"), ([5, 3], "float32")], {}, Expected
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR supports Pytorch `lerp`, `select` and `clone` ops for Relax