### PR TITLE
[FIX][RELAX] fix fusion of transpose + matmul when constant  weight 

### DIFF
--- a/python/tvm/relax/transform/fuse_transpose_matmul.py
+++ b/python/tvm/relax/transform/fuse_transpose_matmul.py
@@ -41,7 +41,8 @@ class FuseTransposeMatmul:  # pylint: disable=too-few-public-methods
                     "transpose_matmul_fuse",
                     *_pattern(),
                 ),
-            ]
+            ],
+            bind_constants=False,
         )(mod)
         transpose_matmul_codegen = _TransposeMatmulFuser(mod)
         for g_var, func in mod.functions_items():

--- a/tests/python/relax/test_transform_fuse_transpose_matmul.py
+++ b/tests/python/relax/test_transform_fuse_transpose_matmul.py
@@ -22,6 +22,7 @@ from tvm import relax
 from tvm.script import ir as I
 from tvm.script import relax as R
 from tvm.script import tir as T
+import numpy as np
 
 
 def test_transform_fuse_transpose_matmul():
@@ -61,6 +62,59 @@ def test_transform_fuse_transpose_matmul():
         def main(
             x: R.Tensor((128, 256), dtype="float32"), w: R.Tensor((128, 256), dtype="float32")
         ) -> R.Tensor((128, 128), dtype="float32"):
+            cls = Expected
+            with R.dataflow():
+                gv = R.call_tir(
+                    cls.NT_matmul, (x, w), out_sinfo=R.Tensor((128, 128), dtype="float32")
+                )
+                R.output(gv)
+            return gv
+
+    after = tvm.ir.transform.Sequential(
+        [
+            relax.transform.FuseTransposeMatmul(),
+            relax.transform.FuseTIR(),  # Only used for remove unused primitive function
+        ]
+    )(Before)
+    tvm.ir.assert_structural_equal(after, Expected)
+
+
+def test_transform_fuse_transpose_matmul_const():
+    w = relax.const(np.random.uniform(-1e-3, 1e-3, (128, 256)), "float32")
+
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(
+            x: R.Tensor((128, 256), "float32"),
+        ) -> R.Tensor((128, 128), "float32"):
+            with R.dataflow():
+                wT = R.permute_dims(w, [1, 0])
+                o = R.matmul(x, wT)
+                R.output(o)
+            return o
+
+    @I.ir_module
+    class Expected:
+        @T.prim_func(private=True)
+        def NT_matmul(
+            x: T.Buffer((T.int64(128), T.int64(256)), "float32"),
+            w: T.Buffer((T.int64(128), T.int64(256)), "float32"),
+            NT_matmul: T.Buffer((T.int64(128), T.int64(128)), "float32"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            for i0, i1, k in T.grid(T.int64(128), T.int64(128), T.int64(256)):
+                with T.block("NT_matmul"):
+                    v_i0, v_i1, v_k = T.axis.remap("SSR", [i0, i1, k])
+                    T.reads(x[v_i0, v_k], w[v_i1, v_k])
+                    T.writes(NT_matmul[v_i0, v_i1])
+                    with T.init():
+                        NT_matmul[v_i0, v_i1] = T.float32(0)
+                    NT_matmul[v_i0, v_i1] = NT_matmul[v_i0, v_i1] + x[v_i0, v_k] * w[v_i1, v_k]
+
+        @R.function
+        def main(x: R.Tensor((128, 256), dtype="float32")) -> R.Tensor((128, 128), dtype="float32"):
             cls = Expected
             with R.dataflow():
                 gv = R.call_tir(


### PR DESCRIPTION
Applying the FuseTransposeMatmul pass on a matmul with a constant weight  would fail since the bind_constants defaults to true in the FuseOpsByPattern pass . This would lead the constant to be moved in to the fused function instead of being an input param, however on line 168 in /tvm/relax/transform/fuse_transpose_matmul.py

```pyhton
out_dtype = function.ret_struct_info.dtype
                return self.builder_.call_te(
                    te_transposed_matmul,
                    call.args[1],
                    call.args[0],
                    primfunc_name_hint="NT_matmul",
                )
```

, called later in the FuseTransposeMatmul pass, both input and weight are expected to be inputs to the fused function leading to a crash.

I fixed it by explicitly setting bind_constants to false and I added a unit test to verify correct behavior when the weight is a constant. 