### PR TITLE
[Fix] Fix OpenCL header in attention utils

### DIFF
--- a/src/runtime/relax_vm/attn_utils.h
+++ b/src/runtime/relax_vm/attn_utils.h
@@ -30,6 +30,9 @@
 #include <limits>
 #include <utility>
 #include <vector>
+#if defined(OPENCL_ENABLE_HOST_PTR)
+#include "../opencl/opencl_common.h"
+#endif
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/relax_vm/paged_kv_cache.cc
+++ b/src/runtime/relax_vm/paged_kv_cache.cc
@@ -36,9 +36,6 @@
 #include "attn_backend.h"
 #include "attn_utils.h"
 #include "kv_state.h"
-#if defined(OPENCL_ENABLE_HOST_PTR)
-#include "../opencl/opencl_common.h"
-#endif
 
 namespace tvm {
 namespace runtime {


### PR DESCRIPTION
This PR fixes the OpenCL header include for `attn_utils.h`. The include was not moved from `paged_kv_cache.cc` when separating out the file `attn_utils.h`.