### PR TITLE
[Relax] check for tensor_meta in exported_program_translator

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -370,9 +370,6 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             elif spec.kind is torch.export.graph_signature.InputKind.USER_INPUT:
                 for node in exported_program.graph.find_nodes(op="placeholder", target=spec.target):
                     if node.name == name_hint and "tensor_meta" in node.meta:
-                        print("name_hint is ", name_hint)
-                        print("node.meta has type ", type(node.meta))
-                        print("node.meta has the keys", list(node.meta.keys()))
                         shape = node.meta["tensor_meta"].shape
                         torch_dtype = node.meta["tensor_meta"].dtype
                         break

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -369,7 +369,10 @@ class ExportedProgramImporter(BaseFXGraphImporter):
                 torch_dtype = exported_program.tensor_constants[spec.target].dtype
             elif spec.kind is torch.export.graph_signature.InputKind.USER_INPUT:
                 for node in exported_program.graph.find_nodes(op="placeholder", target=spec.target):
-                    if node.name == name_hint:
+                    if node.name == name_hint and "tensor_meta" in node.meta:
+                        print("name_hint is ", name_hint)
+                        print("node.meta has type ", type(node.meta))
+                        print("node.meta has the keys", list(node.meta.keys()))
                         shape = node.meta["tensor_meta"].shape
                         torch_dtype = node.meta["tensor_meta"].dtype
                         break


### PR DESCRIPTION
Ran into an example of a pytorch program for which a user input to the forward() function has a node matching (node.name == name_hint) but that node's meta dict does not have a "tensor_meta" key, hence the translation would crash. Let me know if you think this is worth adding a unit test.  

cc: @MasterJH5574 