### PR TITLE
[Relay][Pytorch] Add RRELU Op Support into Relay Frontend Pipeline in v0.19.0 branch

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -991,7 +991,7 @@ class PyTorchOpConverter:
     def rrelu(self, inputs, input_types):
         """
         Computes the Randomized ReLU (RReLU) activation function.
-        
+
         The RReLU function is defined as:
 
         RReLU(x) =
@@ -1002,7 +1002,7 @@ class PyTorchOpConverter:
         During evaluation, 'a' is fixed and calculated as:
 
         a = (lower + upper) / 2
-        
+
         Args:
             inputs (list): A list containing [data, lower, upper].
                 - data: The input tensor.
@@ -1020,12 +1020,12 @@ class PyTorchOpConverter:
 
         # Compute fixed 'a' as (lower + upper) / 2
         a = _op.divide(_op.add(lower, upper), _expr.const(2.0, dtype=dtype))
-        
+
         # Define zero constant for comparison
         zero = _expr.const(0.0, dtype=dtype)
 
-        # RReLU activation: x if x >= 0 else a * x 
-        return _op.where(_op.greater_equal(data, zero), data, _op.multiply(data, a))    
+        # RReLU activation: x if x >= 0 else a * x
+        return _op.where(_op.greater_equal(data, zero), data, _op.multiply(data, a))
 
     def selu(self, inputs, input_types):
         data = inputs[0]

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -830,14 +830,14 @@ def test_forward_gelu():
     input_shape = [1, 3, 10, 10]
     input_data = torch.rand(input_shape).float()
     verify_model(torch.nn.GELU().eval(), input_data=input_data)
-    
+
 
 @tvm.testing.uses_gpu
 def test_forward_rrelu():
     torch.set_grad_enabled(False)
     input_shape = [10, 10]
     input_data = torch.rand(input_shape).float()
-    verify_model(torch.nn.RReLU(0.1, 0.3).eval(), input_data=input_data)    
+    verify_model(torch.nn.RReLU(0.1, 0.3).eval(), input_data=input_data)
 
 
 @tvm.testing.uses_gpu

--- a/tests/python/frontend/pytorch/test_forward.py
+++ b/tests/python/frontend/pytorch/test_forward.py
@@ -830,6 +830,14 @@ def test_forward_gelu():
     input_shape = [1, 3, 10, 10]
     input_data = torch.rand(input_shape).float()
     verify_model(torch.nn.GELU().eval(), input_data=input_data)
+    
+
+@tvm.testing.uses_gpu
+def test_forward_rrelu():
+    torch.set_grad_enabled(False)
+    input_shape = [10, 10]
+    input_data = torch.rand(input_shape).float()
+    verify_model(torch.nn.RReLU(0.1, 0.3).eval(), input_data=input_data)    
 
 
 @tvm.testing.uses_gpu


### PR DESCRIPTION
This PR adds support for the RReLU (Randomized ReLU) operation in the Relay frontend pipeline for PyTorch in the v0.19.0 branch of TVM. It enables parsing and conversion of torch.nn.RReLU to Relay IR by mapping aten::rrelu correctly. Additionally, test code is added to verify correctness by comparing result with PyTorch.