### PR TITLE
[Install] Fix error during python/tvm installation

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -129,6 +129,12 @@ def _remove_path(path):
 LIB_LIST, __version__ = get_lib_path()
 __version__ = git_describe_version(__version__)
 
+if not CONDA_BUILD and not INPLACE_BUILD:
+    # Wheel cleanup
+    for path in LIB_LIST:
+        libname = os.path.basename(path)
+        _remove_path(f"tvm/{libname}")
+
 
 def config_cython():
     """Try to configure cython and return cython configuration"""
@@ -260,5 +266,5 @@ if not CONDA_BUILD and not INPLACE_BUILD:
     # Wheel cleanup
     os.remove("MANIFEST.in")
     for path in LIB_LIST:
-        _, libname = os.path.split(path)
+        libname = os.path.basename(path)
         _remove_path(f"tvm/{libname}")

--- a/python/tvm/_ffi/libinfo.py
+++ b/python/tvm/_ffi/libinfo.py
@@ -143,8 +143,18 @@ def find_lib_path(name=None, search_path=None, optional=False):
             ]
 
         name = lib_dll_names + runtime_dll_names + ext_lib_dll_names
-        lib_dll_path = [os.path.join(p, name) for name in lib_dll_names for p in dll_path]
-        runtime_dll_path = [os.path.join(p, name) for name in runtime_dll_names for p in dll_path]
+        lib_dll_path = [
+            os.path.join(p, name)
+            for name in lib_dll_names
+            for p in dll_path
+            if not p.endswith("python/tvm")
+        ]
+        runtime_dll_path = [
+            os.path.join(p, name)
+            for name in runtime_dll_names
+            for p in dll_path
+            if not p.endswith("python/tvm")
+        ]
         ext_lib_dll_path = [os.path.join(p, name) for name in ext_lib_dll_names for p in dll_path]
     if not use_runtime:
         # try to find lib_dll_path


### PR DESCRIPTION
# Expected behavior
"pip install -e /path-to-tvm/python" successfully installs the TVM package as documented on https://tvm.apache.org/docs/install/from_source.html#

# Issue
~~If "libtvm.so" and "libtvm_runtime.so" remain in "python/tvm" for some reason,~~
If a previous pip installation was unsuccessful and the cleanup was not performed, running "pip install -e /path-to-tvm/python" fails because shutil.copy() and shutil.copytree() raise exceptions due to the remaining temporary files.

# How I encountered the issue
I ran "pip install" without "sudo" first, and it failed without "sudo". (probably because I was not in a virtual environment)
Here the cleanup code couldn't be executed

# Error log
```
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [21 lines of output]
      Use git describe based version 0.20.dev125+g8ad9bffb1
      Traceback (most recent call last):
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 130, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 162, in get_requires_for_build_wheel
          return self._get_build_requires(
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 143, in _get_build_requires
          self.run_setup()
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 158, in run_setup
          exec(compile(code, __file__, 'exec'), locals())
        File "setup.py", line 197, in <module>
          shutil.copy(path, os.path.join(CURRENT_DIR, "tvm"))
        File "/usr/lib/python3.10/shutil.py", line 417, in copy
          copyfile(src, dst, follow_symlinks=follow_symlinks)
        File "/usr/lib/python3.10/shutil.py", line 234, in copyfile
          raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
      shutil.SameFileError: '/home/youngsik/Documents/open_source/AI/tvm/python/tvm/libtvm.so' and 'tvm/libtvm.so' are the same file
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```