### PR TITLE
[Relax][PyTorch] Delete duplicate converter function `_to`

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -563,19 +563,6 @@ class TorchFXImporter(BaseFXGraphImporter):
             x.struct_info.dtype in ["float16", "float32", "float64", "bfloat16"], "bool"
         )
 
-    def _to(self, node: fx.Node) -> relax.Var:
-        import torch
-
-        x = self.env[node.args[0]]
-        if len(node.args) == 2:
-            if isinstance(node.args[1], torch.dtype):
-                dtype = TorchFXImporter._convert_data_type(node.args[1], self.env)
-                return self.block_builder.emit(relax.op.astype(x, dtype))
-        elif "dtype" in node.kwargs:
-            dtype = TorchFXImporter._convert_data_type(node.kwargs["dtype"], self.env)
-            return self.block_builder.emit(relax.op.astype(x, dtype))
-        return x
-
     def _type(self, node: fx.Node) -> relax.Var:
         x = self.env[node.args[0]]
         dtype = TorchFXImporter._convert_data_type(node.args[1], self.env)


### PR DESCRIPTION
Follow-up PR for #17807 
Just forgot to delete `_to` function from the fx_translater

cc @Hzfengsy  