### PR TITLE
[NFC] Fix `explict` typo

### DIFF
--- a/src/runtime/relax_vm/rnn_state.cc
+++ b/src/runtime/relax_vm/rnn_state.cc
@@ -251,7 +251,7 @@ class RNNStateImpObj : public RNNStateObj {
     }
     // TODO(Siyuan): We need to update history_slot_id_device_ (on device) as well.
     // There are two ways to do this:
-    // 1. Update history_slot_id_device_ on device directly through a explict kernel
+    // 1. Update history_slot_id_device_ on device directly through a explicit kernel
     // 2. Update history_slot_id on host and then sync to device.
     // We choose the second way for now for convenience. But the first way is more efficient.
     dirty_aux_data_device_ = true;

--- a/src/tir/transforms/renew_defs.cc
+++ b/src/tir/transforms/renew_defs.cc
@@ -82,7 +82,7 @@ class RenewDefMutator : public StmtExprMutator {
  private:
   Stmt operator()(Stmt stmt) {
     // override StmtMutator::operator() to disable copy_on_write
-    // Since this pass tries to explict create a new function rather than update the existing one
+    // Since this pass tries to explicit create a new function rather than update the existing one
     allow_copy_on_write_ = false;
     return VisitStmt(stmt);
   }

--- a/tests/python/tir-transform/test_tir_transform_simplify.py
+++ b/tests/python/tir-transform/test_tir_transform_simplify.py
@@ -693,7 +693,7 @@ class TestRewriteAsAndOfOrsWithSimplificationBetweenGroups(BaseBeforeAfter):
     """Apply rewrite rules between OR groups that differ by a single element
 
     The expression `(k==20 and k!=30)` could be rewritten into `(k==20)`.
-    However, by default these two terms must appear as part of an explict part
+    However, by default these two terms must appear as part of an explicit part
     of the simplified expression.  The AndOfOr simplification checks for
     rewrite patterns of the form `(A or B) and (A or C)`, where `(B and C)` can
     simplify to a single expression `D`.  These can be rewritten to `(A or D)`.


### PR DESCRIPTION
This patch only corrects some `explict` typos. No changes visible to the user.