### PR TITLE
[Relax][PyTorch] Improve ExportedProgram frontend by supporting `unflatten.int`, `hardtanh_.default`, `dropout_.default`, `silu_.default`, `add_.Tensor` and `relu_.default`

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -278,6 +278,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "neg.default": self._unary_op(relax.op.negative),
             "reciprocal.default": self._reciprocal,
             "relu.default": self._unary_op(relax.op.nn.relu),
+            "relu_.default": self._unary_op(relax.op.nn.relu),
             "round.default": self._round,
             "rsqrt.default": self._unary_op(relax.op.rsqrt),
             "selu.default": self._unary_op(relax.op.nn.selu),

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -258,6 +258,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "cos.default": self._unary_op(relax.op.cos),
             "cosh.default": self._unary_op(relax.op.cosh),
             "dropout.default": lambda node: self.env[node.args[0]],
+            "dropout_.default": lambda node: self.env[node.args[0]],
             "elu.default": self._elu,
             "erf.default": self._unary_op(relax.op.erf),
             "exp.default": self._unary_op(relax.op.exp),

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -266,6 +266,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "gelu.default": self._gelu,
             "hardsigmoid.default": self._hardsigmoid,
             "hardswish.default": self._hardswish,
+            "hardswish_.default": self._hardswish,
             "hardtanh.default": self._hardtanh,
             "isfinite.default": self._unary_op(relax.op.isfinite),
             "isinf.default": self._unary_op(relax.op.isinf),

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -285,6 +285,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "sigmoid.default": self._unary_op(relax.op.sigmoid),
             "sign.default": self._unary_op(relax.op.sign),
             "silu.default": self._unary_op(relax.op.nn.silu),
+            "silu_.default": self._unary_op(relax.op.nn.silu),
             "sin.default": self._unary_op(relax.op.sin),
             "sinh.default": self._unary_op(relax.op.sinh),
             "softmax.int": self._softmax,

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -297,6 +297,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "triu.default": self._tril_triu(relax.op.triu),
             # binary
             "add.Tensor": self._binary_op(relax.op.add, operator.add),
+            "add_.Tensor": self._binary_op(relax.op.add, operator.add),
             "div.Tensor": self._binary_op(relax.op.divide, operator.truediv),
             "eq.Scalar": self._binary_op(relax.op.equal, operator.eq),
             "eq.Tensor": self._binary_op(relax.op.equal, operator.eq),

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -39,8 +39,8 @@ class ExportedProgramImporter(BaseFXGraphImporter):
     def _hardtanh(self, node: fx.Node) -> relax.Expr:
         args = self.retrieve_args(node)
         x = args[0]
-        min_val = node.args[1] if len(args) > 1 else node.kwargs("min_val", -1.0)
-        max_val = node.args[2] if len(args) > 2 else node.kwargs("max_val", 1.0)
+        min_val = node.args[1] if len(args) > 1 else node.kwargs.get("min_val", -1.0)
+        max_val = node.args[2] if len(args) > 2 else node.kwargs.get("max_val", 1.0)
         return self.block_builder.emit(relax.op.clip(x, min_val, max_val))
 
     def _log2(self, node: fx.Node) -> relax.Var:
@@ -268,6 +268,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "hardswish.default": self._hardswish,
             "hardswish_.default": self._hardswish,
             "hardtanh.default": self._hardtanh,
+            "hardtanh_.default": self._hardtanh,
             "isfinite.default": self._unary_op(relax.op.isfinite),
             "isinf.default": self._unary_op(relax.op.isinf),
             "isnan.default": self._unary_op(relax.op.isnan),

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -226,7 +226,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
         if dim < 0:
             dim += len(x_shape)
 
-        new_shape = x_shape[:dim] + sizes + x_shape[dim + 1:]
+        new_shape = x_shape[:dim] + sizes + x_shape[dim + 1 :]
         return self.block_builder.emit(relax.op.reshape(x, new_shape))
 
     ########## Creation ##########

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -388,6 +388,10 @@ def test_extended_unary_ops():
         def forward(self, input):
             return torch.nn.functional.hardswish(input)
 
+    class Hardswish3(torch.nn.Module):
+        def forward(self, input):
+            return torch.ops.aten.hardswish_(input)
+
     @tvm.script.ir_module
     class expected1:
         @R.function
@@ -407,6 +411,7 @@ def test_extended_unary_ops():
 
     verify_model(Hardswish(), example_args, {}, expected1)
     verify_model(Hardswish2(), example_args, {}, expected1)
+    verify_model(Hardswish3(), example_args, {}, expected1)
 
     # hardtanh
     test_hardtanh()

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -656,6 +656,10 @@ def test_hardtanh():
         def forward(self, input):
             return torch.nn.functional.hardtanh(input)
 
+    class Hardtanh3(torch.nn.Module):
+        def forward(self, input):
+            return torch.ops.aten.hardtanh_(input)
+
     @tvm.script.ir_module
     class expected1:
         @R.function
@@ -673,6 +677,7 @@ def test_hardtanh():
     example_args = (torch.randn(1, 3, 10, 10, dtype=torch.float32),)
     verify_model(Hardtanh(), example_args, {}, expected1)
     verify_model(Hardtanh2(), example_args, {}, expected1)
+    verify_model(Hardtanh3(), example_args, {}, expected1)
 
 
 def test_leakyrelu():

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -511,6 +511,10 @@ def test_extended_unary_ops():
         def forward(self, input):
             return torch.nn.functional.relu(input)
 
+    class ReLU2(Module):
+        def forward(self, input):
+            return torch.ops.aten.relu_(input)
+
     @tvm.script.ir_module
     class expected_relu:
         @R.function
@@ -526,6 +530,7 @@ def test_extended_unary_ops():
 
     verify_model(ReLU0(), example_args, {}, expected_relu)
     verify_model(ReLU1(), example_args, {}, expected_relu)
+    verify_model(ReLU2(), example_args, {}, expected_relu)
 
     # selu
     class Selu1(Module):

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -602,6 +602,10 @@ def test_extended_unary_ops():
         def forward(self, input):
             return torch.nn.functional.silu(input)
 
+    class SiLU3(Module):
+        def forward(self, input):
+            return torch.ops.aten.silu_(input)
+
     @tvm.script.ir_module
     class expected_silu:
         @R.function
@@ -617,6 +621,7 @@ def test_extended_unary_ops():
 
     verify_model(SiLU(), example_args, {}, expected_silu)
     verify_model(SiLU2(), example_args, {}, expected_silu)
+    verify_model(SiLU3(), example_args, {}, expected_silu)
 
     # softmax
     test_softmax()

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -254,6 +254,10 @@ def test_extended_unary_ops():
         def forward(self, input):
             return torch.dropout(input, 0.5, train=True)
 
+    class Dropout3(Module):
+        def forward(self, input):
+            return torch.ops.aten.dropout_(input, 0.5, train=True)
+
     @tvm.script.ir_module
     class expected_dropout:
         @R.function
@@ -268,6 +272,7 @@ def test_extended_unary_ops():
 
     verify_model(Dropout1(), example_args, {}, expected_dropout)
     verify_model(Dropout2(), example_args, {}, expected_dropout)
+    verify_model(Dropout3(), example_args, {}, expected_dropout)
 
     # elu
     class Elu(Module):

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -850,6 +850,7 @@ def test_tril_triu():
 
 operator_binary_1 = [
     (operator.add, R.add),
+    (torch.ops.aten.add_, R.add),
     (operator.sub, R.subtract),
     (operator.mul, R.multiply),
     (operator.truediv, R.divide),


### PR DESCRIPTION
Those ops are required to support classification models from torchvision.
The only remaining unsupported op is `index.Tensor` but I'm leaving it for now since it's a bit complex.

Current coverage
- Supported: 70 / 80
- Not supported yet: 10 / 80
  - Due to the lack of `index.Tensor`: maxvit_t, swin_b, swin_s, swin_t, swin_v2_b, swin_v2_s, swin_v2_t
  - Output mismatch: efficientnet_b7, inception_v3, mobilenet_v3_small

<details><summary>coverage.py</summary>

```python
import torch
import torchvision
import tvm
from termcolor import colored
from torch.export import export
from torchvision.models import get_model, get_model_weights, list_models
from tvm import relax
from tvm.contrib.download import download_testdata
from tvm.relax.frontend.torch import from_exported_program


def check_torch_tvm_result(torch_model, batch):
  example_args = (batch,)

  # PyTorch
  exported_program = export(torch_model, args=example_args)
  expected: torch.Tensor = exported_program.module()(*example_args)

  # Relax
  target = "llvm"
  dev = tvm.cpu()
  mod = from_exported_program(exported_program)
  # return True
  exe = tvm.compile(mod, target=target)
  vm = relax.VirtualMachine(exe, dev)
  tvm_args = [tvm.nd.from_dlpack(x.contiguous()) for x in example_args]
  tvm_output = vm["main"](*tvm_args)[0]
  actual = torch.from_numpy(tvm_output.numpy())

  # check if the outputs match
  return torch.allclose(actual, expected, rtol=1e-5, atol=1e-5, equal_nan=True)


# skip them due to high memory usage
torchvision_models_skip = [
  "regnet_y_128gf",
  "vit_b_32",
  "vit_h_14",
  "vit_l_16",
  "vit_l_32",
]


def main():
  # prepare sample image
  img_url = "https://github.com/dmlc/mxnet.js/blob/main/data/cat.png?raw=true"
  img_name = "cat.png"
  img_path = download_testdata(img_url, img_name, module="data")

  # torchvision classification models
  image_tensor = torchvision.io.decode_image(img_path)
  model_names = list_models(module=torchvision.models)
  length = len(model_names)
  for idx, model_name in enumerate(model_names, 1):
    if model_name in torchvision_models_skip:
      continue
    try:
      # load model from torchvision
      torch_model = get_model(model_name, weights="DEFAULT").eval()
      weights = get_model_weights(model_name).DEFAULT
      transforms = weights.transforms()
      batch = transforms(image_tensor).unsqueeze(0)
      if not check_torch_tvm_result(torch_model, batch):
        print(
          colored(f"[{idx}/{length}] Output mismatch for {model_name}", "yellow")
        )
      else:
        print(colored(f"[{idx}/{length}] Passed {model_name}", "green"))
    except Exception as e:
      print(colored(f"[{idx}/{length}] Error in {model_name}: {e}", "red"))


if __name__ == "__main__":
  main()
```

</details>

cc @MasterJH5574 @Hzfengsy 