### PR TITLE
[Relax] Fix Torch frontends to report all the missing ops

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -513,7 +513,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             with self.block_builder.dataflow():
 
                 # Find all the missing function types
-                missing_func_types = list({node.target.__name__ for node in nodes 
+                missing_func_types = list({node.target.__name__ for node in nodes
                 if node.op == "call_function" and node.target.__name__ not in self.convert_map})
                 assert not missing_func_types, f"Unsupported function types {missing_func_types}"
 

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -513,8 +513,14 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             with self.block_builder.dataflow():
 
                 # Find all the missing function types
-                missing_func_types = list({node.target.__name__ for node in nodes
-                if node.op == "call_function" and node.target.__name__ not in self.convert_map})
+                missing_func_types = list(
+                    {
+                        node.target.__name__
+                        for node in nodes
+                        if node.op == "call_function"
+                        and node.target.__name__ not in self.convert_map
+                    }
+                )
                 assert not missing_func_types, f"Unsupported function types {missing_func_types}"
 
                 # Translate the model.

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -885,9 +885,15 @@ class TorchFXImporter(BaseFXGraphImporter):
             output = None
             with self.block_builder.dataflow():
 
-               # Find all the missing function types
-                missing_func_types = list({node.target.__name__ for node in graph.nodes
-                if node.op == "call_function" and node.target.__name__ not in self.convert_map})
+                # Find all the missing function types
+                missing_func_types = list(
+                    {
+                        node.target.__name__
+                        for node in nodes
+                        if node.op == "call_function"
+                        and node.target.__name__ not in self.convert_map
+                    }
+                )
                 assert not missing_func_types, f"Unsupported function types {missing_func_types}"
 
                 # Translate model parameters.

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -889,7 +889,7 @@ class TorchFXImporter(BaseFXGraphImporter):
                 missing_func_types = list(
                     {
                         node.target.__name__
-                        for node in nodes
+                        for node in graph.nodes
                         if node.op == "call_function"
                         and node.target.__name__ not in self.convert_map
                     }

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -884,6 +884,12 @@ class TorchFXImporter(BaseFXGraphImporter):
         with self.block_builder.function(name=func_name, params=inputs.copy(), attrs=func_attrs):
             output = None
             with self.block_builder.dataflow():
+
+               # Find all the missing function types
+                missing_func_types = list({node.target.__name__ for node in graph.nodes
+                if node.op == "call_function" and node.target.__name__ not in self.convert_map})
+                assert not missing_func_types, f"Unsupported function types {missing_func_types}"
+
                 # Translate model parameters.
                 for _, param in model.named_parameters():
                     shape = param.data.shape
@@ -929,9 +935,6 @@ class TorchFXImporter(BaseFXGraphImporter):
                         self.env[node] = self.convert_map[type(module)](node)
                     elif node.op == "call_function":
                         func_name = node.target.__name__
-                        assert (
-                            func_name in self.convert_map
-                        ), f"Unsupported function type {func_name}"
                         if func_name in custom_ops:
                             self.env[node] = self.convert_map[func_name](node, self)
                         else:


### PR DESCRIPTION
This PR fixes error handling in from_fx and from_exported_program to detect unsupported ops more effectively. Instead of stopping at the first missing op due to an assertion error, it now collects all missing function-type ops first, which helps identify all unsupported operations at once.