### PR TITLE
Add op support for roll op

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1168,7 +1168,7 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         x = args[0]
         dims = args[1] if isinstance(args[1], (torch.Size, tuple, list)) else args[1:]
         return self.block_builder.emit(relax.op.tile(x, dims))
-    
+
     def _roll(self, node: fx.Node) -> relax.Var:
         args = self.retrieve_args(node)
         input_tensor = args[0]
@@ -1183,7 +1183,7 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
                 return int(val.value)
             elif isinstance(val, int):
                 return val
-            elif hasattr(val, '__int__'):
+            elif hasattr(val, "__int__"):
                 return int(val)
             raise TypeError(f"Unsupported type for shift/dim: {type(val)}")
 
@@ -1198,8 +1198,23 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
                 return tensor
 
             split_pos = dim_size_val - shift_mod
-            part1 = self.block_builder.emit(relax.op.strided_slice(tensor,axes=[dim],begin=[0],end=[split_pos],strides=[1],))
-            part2 = self.block_builder.emit(relax.op.strided_slice(tensor,axes=[dim],begin=[split_pos],end=[dim_size_val],strides=[1],))
+            part1 = self.block_builder.emit(
+                relax.op.strided_slice(
+                    tensor,
+                    axes=[dim],
+                    begin=[0],
+                    end=[split_pos],
+                    strides=[1],
+                )
+            )
+            part2 = self.block_builder.emit(
+                relax.op.strided_slice(
+                    tensor,axes=[dim],
+                    begin=[split_pos],
+                    end=[dim_size_val],
+                    strides=[1],
+                )
+            )
             return self.block_builder.emit(relax.op.concat([part2, part1], axis=dim))
 
         # Handle dims=None (flatten -> roll -> reshape)

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -21,14 +21,9 @@
 import abc
 from functools import reduce
 import math
-<<<<<<< HEAD
 from typing import Callable, Dict, Optional, Tuple, Union, List
-=======
-from typing import Callable, Dict, Optional, Tuple, Union
-import tvm
->>>>>>> 20cb5dd08 (add op support for roll op)
 
-from tvm import relax
+from tvm import relax, tir
 
 
 class BaseFXGraphImporter(metaclass=abc.ABCMeta):
@@ -1179,7 +1174,7 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         original_shape = self.shape_of(input_tensor)
 
         def to_int(val):
-            if isinstance(val, tvm.tir.IntImm):
+            if isinstance(val, tir.IntImm):
                 return int(val.value)
             elif isinstance(val, int):
                 return val

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1209,7 +1209,8 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
             )
             part2 = self.block_builder.emit(
                 relax.op.strided_slice(
-                    tensor,axes=[dim],
+                    tensor,
+                    axes=[dim],
                     begin=[split_pos],
                     end=[dim_size_val],
                     strides=[1],

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1172,8 +1172,8 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
     def _roll(self, node: fx.Node) -> relax.Var:
         args = self.retrieve_args(node)
         input_tensor = args[0]
-        shifts = args[1]
-        dims = args[2] if len(args) > 2 else None
+        shifts = args[1] if len(node.args) > 1 else node.kwargs.get("shifts", None)
+        dims = args[2] if len(node.args) > 2 else node.kwargs.get("dims", None)
 
         # Get original shape
         original_shape = self.shape_of(input_tensor)

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -423,7 +423,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "narrow.default": self._narrow,
             "permute.default": self._permute,
             "repeat.default": self._repeat,
-            "roll.default":self._roll,
+            "roll.default": self._roll,
             "select.int": self._select,
             "slice.Tensor": self._slice,
             "split.Tensor": self._split,

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -423,6 +423,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "narrow.default": self._narrow,
             "permute.default": self._permute,
             "repeat.default": self._repeat,
+            "roll.default":self._roll,
             "select.int": self._select,
             "slice.Tensor": self._slice,
             "split.Tensor": self._split,

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -750,6 +750,7 @@ class TorchFXImporter(BaseFXGraphImporter):
             "numel": self._numel,
             "permute": self._permute,
             "repeat": self._repeat,
+            "roll": self._roll,
             "reshape": self._reshape,
             "scatter": self._scatter,
             "select": self._select,

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -2994,7 +2994,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(7)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv2: R.Tensor((1,), dtype="int64") = R.strided_slice(
                     lv,
@@ -3002,7 +3002,7 @@ def test_roll():
                     begin=[R.prim_value(7)],
                     end=[R.prim_value(8)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv3: R.Tensor((8,), dtype="int64") = R.concat((lv2, lv1), axis=0)
                 lv4: R.Tensor((4, 2), dtype="int64") = R.reshape(lv3, R.shape([4, 2]))
@@ -3022,7 +3022,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(1)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv1: R.Tensor((3, 2), dtype="int64") = R.strided_slice(
                     x,
@@ -3030,7 +3030,7 @@ def test_roll():
                     begin=[R.prim_value(1)],
                     end=[R.prim_value(4)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
                 gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv2,)
@@ -3050,7 +3050,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(2)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv1: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
                     x,
@@ -3058,10 +3058,10 @@ def test_roll():
                     begin=[R.prim_value(2)],
                     end=[R.prim_value(4)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
-                
+
                 # Second roll along dim=1 with shift=1
                 lv3: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
                     lv2,
@@ -3069,7 +3069,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(1)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv4: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
                     lv2,
@@ -3077,7 +3077,7 @@ def test_roll():
                     begin=[R.prim_value(1)],
                     end=[R.prim_value(2)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv5: R.Tensor((4, 2), dtype="int64") = R.concat((lv4, lv3), axis=1)
                 gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv5,)

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -2968,6 +2968,131 @@ def test_reshape_as():
     verify_model(ReshapeAs(), example_args, {}, expected1)
 
 
+def test_roll():
+    class Roll1(Module):
+        def forward(self, x):
+            return torch.roll(x, 1)
+
+    class Roll2(Module):
+        def forward(self, x):
+            return torch.roll(x, -1, 0)
+
+    class Roll3(Module):
+        def forward(self, x):
+            return torch.roll(x, shifts=(2, 1), dims=(0, 1))
+
+    # Test case 1: torch.roll(x, 1)
+    @I.ir_module
+    class Expected1:
+        @R.function
+        def main(x: R.Tensor((4, 2), dtype="int64")) -> R.Tuple(R.Tensor((4, 2), dtype="int64")):
+            with R.dataflow():
+                lv: R.Tensor((8,), dtype="int64") = R.reshape(x, R.shape([8]))
+                lv1: R.Tensor((7,), dtype="int64") = R.strided_slice(
+                    lv,
+                    axes=[0],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(7)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv2: R.Tensor((1,), dtype="int64") = R.strided_slice(
+                    lv,
+                    axes=[0],
+                    begin=[R.prim_value(7)],
+                    end=[R.prim_value(8)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv3: R.Tensor((8,), dtype="int64") = R.concat((lv2, lv1), axis=0)
+                lv4: R.Tensor((4, 2), dtype="int64") = R.reshape(lv3, R.shape([4, 2]))
+                gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv4,)
+                R.output(gv)
+            return gv
+
+    # Test case 2: torch.roll(x, -1, 0)
+    @I.ir_module
+    class Expected2:
+        @R.function
+        def main(x: R.Tensor((4, 2), dtype="int64")) -> R.Tuple(R.Tensor((4, 2), dtype="int64")):
+            with R.dataflow():
+                lv: R.Tensor((1, 2), dtype="int64") = R.strided_slice(
+                    x,
+                    axes=[0],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(1)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv1: R.Tensor((3, 2), dtype="int64") = R.strided_slice(
+                    x,
+                    axes=[0],
+                    begin=[R.prim_value(1)],
+                    end=[R.prim_value(4)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
+                gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv2,)
+                R.output(gv)
+            return gv
+
+    # Test case 3: torch.roll(x, shifts=(2,1), dims=(0,1))
+    @I.ir_module
+    class Expected3:
+        @R.function
+        def main(x: R.Tensor((4, 2), dtype="int64")) -> R.Tuple(R.Tensor((4, 2), dtype="int64")):
+            with R.dataflow():
+                # First roll along dim=0 with shift=2
+                lv: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
+                    x,
+                    axes=[0],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(2)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv1: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
+                    x,
+                    axes=[0],
+                    begin=[R.prim_value(2)],
+                    end=[R.prim_value(4)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
+                
+                # Second roll along dim=1 with shift=1
+                lv3: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
+                    lv2,
+                    axes=[1],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(1)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv4: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
+                    lv2,
+                    axes=[1],
+                    begin=[R.prim_value(1)],
+                    end=[R.prim_value(2)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv5: R.Tensor((4, 2), dtype="int64") = R.concat((lv4, lv3), axis=1)
+                gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv5,)
+                R.output(gv)
+            return gv
+
+    # Test inputs
+    example_input = torch.randint(0, 10, (4, 2), dtype=torch.int64)
+
+    # Run verification for each case
+    verify_model(Roll1(), (example_input,), {}, Expected1)
+    verify_model(Roll2(), (example_input,), {}, Expected2)
+    verify_model(Roll3(), (example_input,), {}, Expected3)
+
+
 def test_select_slice():
     class Slice1(Module):
         def forward(self, x):

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3586,7 +3586,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(7)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv2: R.Tensor((1,), dtype="int64") = R.strided_slice(
                     lv,
@@ -3594,7 +3594,7 @@ def test_roll():
                     begin=[R.prim_value(7)],
                     end=[R.prim_value(8)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv3: R.Tensor((8,), dtype="int64") = R.concat((lv2, lv1), axis=0)
                 lv4: R.Tensor((4, 2), dtype="int64") = R.reshape(lv3, R.shape([4, 2]))
@@ -3614,7 +3614,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(1)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv1: R.Tensor((3, 2), dtype="int64") = R.strided_slice(
                     inp_0,
@@ -3622,7 +3622,7 @@ def test_roll():
                     begin=[R.prim_value(1)],
                     end=[R.prim_value(4)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
                 gv: R.Tensor((4, 2), dtype="int64") = lv2
@@ -3641,7 +3641,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(2)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv1: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
                     inp_0,
@@ -3649,7 +3649,7 @@ def test_roll():
                     begin=[R.prim_value(2)],
                     end=[R.prim_value(4)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
                 lv3: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
@@ -3658,7 +3658,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(1)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv4: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
                     lv2,
@@ -3666,7 +3666,7 @@ def test_roll():
                     begin=[R.prim_value(1)],
                     end=[R.prim_value(2)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv5: R.Tensor((4, 2), dtype="int64") = R.concat((lv4, lv3), axis=1)
                 gv: R.Tensor((4, 2), dtype="int64") = lv5

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3586,7 +3586,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(7)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv2: R.Tensor((1,), dtype="int64") = R.strided_slice(
                     lv,
@@ -3594,7 +3594,7 @@ def test_roll():
                     begin=[R.prim_value(7)],
                     end=[R.prim_value(8)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv3: R.Tensor((8,), dtype="int64") = R.concat((lv2, lv1), axis=0)
                 lv4: R.Tensor((4, 2), dtype="int64") = R.reshape(lv3, R.shape([4, 2]))
@@ -3614,7 +3614,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(1)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv1: R.Tensor((3, 2), dtype="int64") = R.strided_slice(
                     x,
@@ -3622,7 +3622,7 @@ def test_roll():
                     begin=[R.prim_value(1)],
                     end=[R.prim_value(4)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
                 gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv2,)
@@ -3642,7 +3642,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(2)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv1: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
                     x,
@@ -3650,10 +3650,10 @@ def test_roll():
                     begin=[R.prim_value(2)],
                     end=[R.prim_value(4)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
-                
+
                 # Second roll along dim=1 with shift=1
                 lv3: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
                     lv2,
@@ -3661,7 +3661,7 @@ def test_roll():
                     begin=[R.prim_value(0)],
                     end=[R.prim_value(1)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv4: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
                     lv2,
@@ -3669,7 +3669,7 @@ def test_roll():
                     begin=[R.prim_value(1)],
                     end=[R.prim_value(2)],
                     strides=[R.prim_value(1)],
-                    assume_inbound=False
+                    assume_inbound=False,
                 )
                 lv5: R.Tensor((4, 2), dtype="int64") = R.concat((lv4, lv3), axis=1)
                 gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv5,)

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3577,28 +3577,20 @@ def test_roll():
     @I.ir_module
     class Expected1:
         @R.function
-        def main(x: R.Tensor((4, 2), dtype="int64")) -> R.Tuple(R.Tensor((4, 2), dtype="int64")):
+        def main(inp_0: R.Tensor((4, 2), dtype="int64")) -> R.Tensor((4, 2), dtype="int64"):
             with R.dataflow():
-                lv: R.Tensor((8,), dtype="int64") = R.reshape(x, R.shape([8]))
+                lv: R.Tensor((8,), dtype="int64") = R.reshape(inp_0, R.shape([8]))
                 lv1: R.Tensor((7,), dtype="int64") = R.strided_slice(
-                    lv,
-                    axes=[0],
-                    begin=[R.prim_value(0)],
-                    end=[R.prim_value(7)],
-                    strides=[R.prim_value(1)],
-                    assume_inbound=False,
+                    lv, axes=[0], begin=[R.prim_value(0)], end=[R.prim_value(7)],
+                    strides=[R.prim_value(1)], assume_inbound=False
                 )
                 lv2: R.Tensor((1,), dtype="int64") = R.strided_slice(
-                    lv,
-                    axes=[0],
-                    begin=[R.prim_value(7)],
-                    end=[R.prim_value(8)],
-                    strides=[R.prim_value(1)],
-                    assume_inbound=False,
+                    lv, axes=[0], begin=[R.prim_value(7)], end=[R.prim_value(8)],
+                    strides=[R.prim_value(1)], assume_inbound=False
                 )
                 lv3: R.Tensor((8,), dtype="int64") = R.concat((lv2, lv1), axis=0)
                 lv4: R.Tensor((4, 2), dtype="int64") = R.reshape(lv3, R.shape([4, 2]))
-                gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv4,)
+                gv: R.Tensor((4, 2), dtype="int64") = lv4
                 R.output(gv)
             return gv
 
@@ -3606,83 +3598,56 @@ def test_roll():
     @I.ir_module
     class Expected2:
         @R.function
-        def main(x: R.Tensor((4, 2), dtype="int64")) -> R.Tuple(R.Tensor((4, 2), dtype="int64")):
+        def main(inp_0: R.Tensor((4, 2), dtype="int64")) -> R.Tensor((4, 2), dtype="int64"):
             with R.dataflow():
                 lv: R.Tensor((1, 2), dtype="int64") = R.strided_slice(
-                    x,
-                    axes=[0],
-                    begin=[R.prim_value(0)],
-                    end=[R.prim_value(1)],
-                    strides=[R.prim_value(1)],
-                    assume_inbound=False,
-                )
+                    inp_0, axes=[0], begin=[R.prim_value(0)], end=[R.prim_value(1)],
+                    strides=[R.prim_value(1)], assume_inbound=False
+                )  # Row 0: [[a, b]]
                 lv1: R.Tensor((3, 2), dtype="int64") = R.strided_slice(
-                    x,
-                    axes=[0],
-                    begin=[R.prim_value(1)],
-                    end=[R.prim_value(4)],
-                    strides=[R.prim_value(1)],
-                    assume_inbound=False,
+                    inp_0, axes=[0], begin=[R.prim_value(1)], end=[R.prim_value(4)],
+                    strides=[R.prim_value(1)], assume_inbound=False
                 )
-                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
-                gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv2,)
+                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)  # [[c, d], [e, f], [g, h], [a, b]]
+                gv: R.Tensor((4, 2), dtype="int64") = lv2
                 R.output(gv)
             return gv
 
-    # Test case 3: torch.roll(x, shifts=(2,1), dims=(0,1))
+    # Test case 3: torch.roll(x, shifts=(2, 1), dims=(0, 1))
     @I.ir_module
     class Expected3:
         @R.function
-        def main(x: R.Tensor((4, 2), dtype="int64")) -> R.Tuple(R.Tensor((4, 2), dtype="int64")):
+        def main(inp_0: R.Tensor((4, 2), dtype="int64")) -> R.Tensor((4, 2), dtype="int64"):
             with R.dataflow():
-                # First roll along dim=0 with shift=2
                 lv: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
-                    x,
-                    axes=[0],
-                    begin=[R.prim_value(0)],
-                    end=[R.prim_value(2)],
-                    strides=[R.prim_value(1)],
-                    assume_inbound=False,
+                    inp_0, axes=[0], begin=[R.prim_value(0)], end=[R.prim_value(2)],
+                    strides=[R.prim_value(1)], assume_inbound=False
                 )
                 lv1: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
-                    x,
-                    axes=[0],
-                    begin=[R.prim_value(2)],
-                    end=[R.prim_value(4)],
-                    strides=[R.prim_value(1)],
-                    assume_inbound=False,
+                    inp_0, axes=[0], begin=[R.prim_value(2)], end=[R.prim_value(4)],
+                    strides=[R.prim_value(1)], assume_inbound=False
                 )
-                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
-
-                # Second roll along dim=1 with shift=1
+                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)  # [[e, f], [g, h], [a, b], [c, d]]
                 lv3: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
-                    lv2,
-                    axes=[1],
-                    begin=[R.prim_value(0)],
-                    end=[R.prim_value(1)],
-                    strides=[R.prim_value(1)],
-                    assume_inbound=False,
+                    lv2, axes=[1], begin=[R.prim_value(0)], end=[R.prim_value(1)],
+                    strides=[R.prim_value(1)], assume_inbound=False
                 )
                 lv4: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
-                    lv2,
-                    axes=[1],
-                    begin=[R.prim_value(1)],
-                    end=[R.prim_value(2)],
-                    strides=[R.prim_value(1)],
-                    assume_inbound=False,
+                    lv2, axes=[1], begin=[R.prim_value(1)], end=[R.prim_value(2)],
+                    strides=[R.prim_value(1)], assume_inbound=False
                 )
-                lv5: R.Tensor((4, 2), dtype="int64") = R.concat((lv4, lv3), axis=1)
-                gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv5,)
+                lv5: R.Tensor((4, 2), dtype="int64") = R.concat((lv4, lv3), axis=1)  # [[f, e], [h, g], [b, a], [d, c]]
+                gv: R.Tensor((4, 2), dtype="int64") = lv5
                 R.output(gv)
             return gv
 
     # Test inputs
-    example_input = torch.randint(0, 10, (4, 2), dtype=torch.int64)
+    input_info = [([4, 2], "int64")]
 
     # Run verification for each case
-    verify_model(Roll1(), (example_input,), {}, Expected1)
-    verify_model(Roll2(), (example_input,), {}, Expected2)
-    verify_model(Roll3(), (example_input,), {}, Expected3)
+    verify_model(Roll1(), input_info, {}, Expected1)
+    verify_model(Roll2(), input_info, {}, Expected2)
+    verify_model(Roll3(), input_info, {}, Expected3)
 
 
 def test_view():

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3560,6 +3560,131 @@ def test_repeat():
     verify_model(Tile2(), [(torch.Size([1, 3]), "float32")], {}, expected2)
 
 
+def test_roll():
+    class Roll1(Module):
+        def forward(self, x):
+            return torch.roll(x, 1)
+
+    class Roll2(Module):
+        def forward(self, x):
+            return torch.roll(x, -1, 0)
+
+    class Roll3(Module):
+        def forward(self, x):
+            return torch.roll(x, shifts=(2, 1), dims=(0, 1))
+
+    # Test case 1: torch.roll(x, 1)
+    @I.ir_module
+    class Expected1:
+        @R.function
+        def main(x: R.Tensor((4, 2), dtype="int64")) -> R.Tuple(R.Tensor((4, 2), dtype="int64")):
+            with R.dataflow():
+                lv: R.Tensor((8,), dtype="int64") = R.reshape(x, R.shape([8]))
+                lv1: R.Tensor((7,), dtype="int64") = R.strided_slice(
+                    lv,
+                    axes=[0],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(7)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv2: R.Tensor((1,), dtype="int64") = R.strided_slice(
+                    lv,
+                    axes=[0],
+                    begin=[R.prim_value(7)],
+                    end=[R.prim_value(8)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv3: R.Tensor((8,), dtype="int64") = R.concat((lv2, lv1), axis=0)
+                lv4: R.Tensor((4, 2), dtype="int64") = R.reshape(lv3, R.shape([4, 2]))
+                gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv4,)
+                R.output(gv)
+            return gv
+
+    # Test case 2: torch.roll(x, -1, 0)
+    @I.ir_module
+    class Expected2:
+        @R.function
+        def main(x: R.Tensor((4, 2), dtype="int64")) -> R.Tuple(R.Tensor((4, 2), dtype="int64")):
+            with R.dataflow():
+                lv: R.Tensor((1, 2), dtype="int64") = R.strided_slice(
+                    x,
+                    axes=[0],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(1)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv1: R.Tensor((3, 2), dtype="int64") = R.strided_slice(
+                    x,
+                    axes=[0],
+                    begin=[R.prim_value(1)],
+                    end=[R.prim_value(4)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
+                gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv2,)
+                R.output(gv)
+            return gv
+
+    # Test case 3: torch.roll(x, shifts=(2,1), dims=(0,1))
+    @I.ir_module
+    class Expected3:
+        @R.function
+        def main(x: R.Tensor((4, 2), dtype="int64")) -> R.Tuple(R.Tensor((4, 2), dtype="int64")):
+            with R.dataflow():
+                # First roll along dim=0 with shift=2
+                lv: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
+                    x,
+                    axes=[0],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(2)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv1: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
+                    x,
+                    axes=[0],
+                    begin=[R.prim_value(2)],
+                    end=[R.prim_value(4)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
+                
+                # Second roll along dim=1 with shift=1
+                lv3: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
+                    lv2,
+                    axes=[1],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(1)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv4: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
+                    lv2,
+                    axes=[1],
+                    begin=[R.prim_value(1)],
+                    end=[R.prim_value(2)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv5: R.Tensor((4, 2), dtype="int64") = R.concat((lv4, lv3), axis=1)
+                gv: R.Tuple(R.Tensor((4, 2), dtype="int64")) = (lv5,)
+                R.output(gv)
+            return gv
+
+    # Test inputs
+    example_input = torch.randint(0, 10, (4, 2), dtype=torch.int64)
+
+    # Run verification for each case
+    verify_model(Roll1(), (example_input,), {}, Expected1)
+    verify_model(Roll2(), (example_input,), {}, Expected2)
+    verify_model(Roll3(), (example_input,), {}, Expected3)
+
+
 def test_view():
     input_info = [([1, 2, 3, 4], "float32")]
 

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3581,12 +3581,20 @@ def test_roll():
             with R.dataflow():
                 lv: R.Tensor((8,), dtype="int64") = R.reshape(inp_0, R.shape([8]))
                 lv1: R.Tensor((7,), dtype="int64") = R.strided_slice(
-                    lv, axes=[0], begin=[R.prim_value(0)], end=[R.prim_value(7)],
-                    strides=[R.prim_value(1)], assume_inbound=False
+                    lv,
+                    axes=[0],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(7)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
                 )
                 lv2: R.Tensor((1,), dtype="int64") = R.strided_slice(
-                    lv, axes=[0], begin=[R.prim_value(7)], end=[R.prim_value(8)],
-                    strides=[R.prim_value(1)], assume_inbound=False
+                    lv,
+                    axes=[0],
+                    begin=[R.prim_value(7)],
+                    end=[R.prim_value(8)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
                 )
                 lv3: R.Tensor((8,), dtype="int64") = R.concat((lv2, lv1), axis=0)
                 lv4: R.Tensor((4, 2), dtype="int64") = R.reshape(lv3, R.shape([4, 2]))
@@ -3601,14 +3609,22 @@ def test_roll():
         def main(inp_0: R.Tensor((4, 2), dtype="int64")) -> R.Tensor((4, 2), dtype="int64"):
             with R.dataflow():
                 lv: R.Tensor((1, 2), dtype="int64") = R.strided_slice(
-                    inp_0, axes=[0], begin=[R.prim_value(0)], end=[R.prim_value(1)],
-                    strides=[R.prim_value(1)], assume_inbound=False
-                )  # Row 0: [[a, b]]
-                lv1: R.Tensor((3, 2), dtype="int64") = R.strided_slice(
-                    inp_0, axes=[0], begin=[R.prim_value(1)], end=[R.prim_value(4)],
-                    strides=[R.prim_value(1)], assume_inbound=False
+                    inp_0,
+                    axes=[0],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(1)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
                 )
-                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)  # [[c, d], [e, f], [g, h], [a, b]]
+                lv1: R.Tensor((3, 2), dtype="int64") = R.strided_slice(
+                    inp_0,
+                    axes=[0],
+                    begin=[R.prim_value(1)],
+                    end=[R.prim_value(4)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
+                )
+                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
                 gv: R.Tensor((4, 2), dtype="int64") = lv2
                 R.output(gv)
             return gv
@@ -3620,31 +3636,45 @@ def test_roll():
         def main(inp_0: R.Tensor((4, 2), dtype="int64")) -> R.Tensor((4, 2), dtype="int64"):
             with R.dataflow():
                 lv: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
-                    inp_0, axes=[0], begin=[R.prim_value(0)], end=[R.prim_value(2)],
-                    strides=[R.prim_value(1)], assume_inbound=False
+                    inp_0,
+                    axes=[0],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(2)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
                 )
                 lv1: R.Tensor((2, 2), dtype="int64") = R.strided_slice(
-                    inp_0, axes=[0], begin=[R.prim_value(2)], end=[R.prim_value(4)],
-                    strides=[R.prim_value(1)], assume_inbound=False
+                    inp_0,
+                    axes=[0],
+                    begin=[R.prim_value(2)],
+                    end=[R.prim_value(4)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
                 )
-                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)  # [[e, f], [g, h], [a, b], [c, d]]
+                lv2: R.Tensor((4, 2), dtype="int64") = R.concat((lv1, lv), axis=0)
                 lv3: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
-                    lv2, axes=[1], begin=[R.prim_value(0)], end=[R.prim_value(1)],
-                    strides=[R.prim_value(1)], assume_inbound=False
+                    lv2,
+                    axes=[1],
+                    begin=[R.prim_value(0)],
+                    end=[R.prim_value(1)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
                 )
                 lv4: R.Tensor((4, 1), dtype="int64") = R.strided_slice(
-                    lv2, axes=[1], begin=[R.prim_value(1)], end=[R.prim_value(2)],
-                    strides=[R.prim_value(1)], assume_inbound=False
+                    lv2,
+                    axes=[1],
+                    begin=[R.prim_value(1)],
+                    end=[R.prim_value(2)],
+                    strides=[R.prim_value(1)],
+                    assume_inbound=False
                 )
-                lv5: R.Tensor((4, 2), dtype="int64") = R.concat((lv4, lv3), axis=1)  # [[f, e], [h, g], [b, a], [d, c]]
+                lv5: R.Tensor((4, 2), dtype="int64") = R.concat((lv4, lv3), axis=1)
                 gv: R.Tensor((4, 2), dtype="int64") = lv5
                 R.output(gv)
             return gv
 
-    # Test inputs
     input_info = [([4, 2], "int64")]
 
-    # Run verification for each case
     verify_model(Roll1(), input_info, {}, Expected1)
     verify_model(Roll2(), input_info, {}, Expected2)
     verify_model(Roll3(), input_info, {}, Expected3)


### PR DESCRIPTION
Added roll operator support in the TVM Relax exported program and fx graph and test script code to validate the relax module.  By adding this support, the following models are now able to run successfully:

    1. facebook/mask2former-swin-tiny-coco-instance
    2. briaai/RMBG-2.0

