### PR TITLE
[Relax] Refactor missing op check into shared utility for Torch frontends

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -21,7 +21,7 @@
 import abc
 from functools import reduce
 import math
-from typing import Callable, Dict, Optional, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, Union, List
 
 from tvm import relax
 
@@ -103,7 +103,7 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         else:
             return node
 
-    def _check_unsupported_func_type(self, nodes):
+    def _check_unsupported_func_type(self, nodes: List[fx.Node]):
         missing_func_types = list(
             {
                 node.target.__name__

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -103,6 +103,17 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         else:
             return node
 
+    def _check_unsupported_func_type(self, nodes):
+        missing_func_types = list(
+            {
+                node.target.__name__
+                for node in nodes
+                if node.op == "call_function"
+                and node.target.__name__ not in self.convert_map
+            }
+        )
+        assert not missing_func_types, f"Unsupported function types {missing_func_types}"
+
     ########## Unary Ops ##########
 
     def _unary_op(self, op: Callable) -> Callable:

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -108,8 +108,7 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
             {
                 node.target.__name__
                 for node in nodes
-                if node.op == "call_function"
-                and node.target.__name__ not in self.convert_map
+                if node.op == "call_function" and node.target.__name__ not in self.convert_map
             }
         )
         assert not missing_func_types, f"Unsupported function types {missing_func_types}"

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -518,14 +518,15 @@ class ExportedProgramImporter(BaseFXGraphImporter):
         func_attrs = {"num_input": len(user_input_vars)} if keep_params_as_input else None
 
         nodes: List[fx.Node] = exported_program.graph.nodes
+
+        # Find all the missing function types
+        self._check_unsupported_func_type(nodes)
+
         with self.block_builder.function(
             name=func_name, params=list(inputs_vars.values()).copy(), attrs=func_attrs
         ):
             output = None
             with self.block_builder.dataflow():
-
-                # Find all the missing function types
-                self._check_unsupported_func_type(nodes)
 
                 # Translate the model.
                 for node in nodes:

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -525,15 +525,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             with self.block_builder.dataflow():
 
                 # Find all the missing function types
-                missing_func_types = list(
-                    {
-                        node.target.__name__
-                        for node in nodes
-                        if node.op == "call_function"
-                        and node.target.__name__ not in self.convert_map
-                    }
-                )
-                assert not missing_func_types, f"Unsupported function types {missing_func_types}"
+                self._check_unsupported_func_type(nodes)
 
                 # Translate the model.
                 for node in nodes:

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -848,12 +848,12 @@ class TorchFXImporter(BaseFXGraphImporter):
         else:
             func_attrs = None
 
+        # Find all the missing function types
+        self._check_unsupported_func_type(graph.nodes)
+
         with self.block_builder.function(name=func_name, params=inputs.copy(), attrs=func_attrs):
             output = None
             with self.block_builder.dataflow():
-
-                # Find all the missing function types
-                self._check_unsupported_func_type(graph.nodes)
 
                 # Translate model parameters.
                 for _, param in model.named_parameters():

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -853,15 +853,7 @@ class TorchFXImporter(BaseFXGraphImporter):
             with self.block_builder.dataflow():
 
                 # Find all the missing function types
-                missing_func_types = list(
-                    {
-                        node.target.__name__
-                        for node in graph.nodes
-                        if node.op == "call_function"
-                        and node.target.__name__ not in self.convert_map
-                    }
-                )
-                assert not missing_func_types, f"Unsupported function types {missing_func_types}"
+                self._check_unsupported_func_type(graph.nodes)
 
                 # Translate model parameters.
                 for _, param in model.named_parameters():


### PR DESCRIPTION
This PR refactors the logic for detecting unsupported ops by moving _check_unsupported_func_type into a shared utility in base_fx_graph_translator.py file. Previously, this logic was implemented separately in both from_fx and from_exported_program. By centralizing this function, we reduce duplication and ensure consistent missing op reporting across Torch frontends.