### PR TITLE
[Relax][Pytorch] Add masked_fill op support in ExportedProgram

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -447,7 +447,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "full_like.default": self._full_like,
             "index_select.default": self._index_select,
             "lift_fresh_copy.default": self._to_copy,
-            "masked_fill.Scalar" : self._masked_fill,
+            "masked_fill.Scalar": self._masked_fill,
             "new_ones.default": self._new_ones,
             "one_hot.default": self._one_hot,
             "ones.default": self._ones,

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -447,6 +447,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "full_like.default": self._full_like,
             "index_select.default": self._index_select,
             "lift_fresh_copy.default": self._to_copy,
+            "masked_fill.Scalar" : self._masked_fill,
             "new_ones.default": self._new_ones,
             "one_hot.default": self._one_hot,
             "ones.default": self._ones,

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -468,23 +468,6 @@ class TorchFXImporter(BaseFXGraphImporter):
         self.env[node.args[0]] = filled
         return filled
 
-    def _inplace_masked_fill(self, node: fx.Node) -> relax.Var:
-        x = self.env[node.args[0]]
-        mask = self.env[node.args[1]]
-        value = node.args[2]
-        rx_value = relax.const(value)
-        values = self.block_builder.emit(relax.op.full_like(x, rx_value))
-        output = self.block_builder.emit(relax.op.where(mask, values, x))
-        self.env[node.args[0]] = output
-        return output
-
-    def _masked_fill(self, node: fx.Node) -> relax.Var:
-        x = self.env[node.args[0]]
-        mask = self.env[node.args[1]]
-        rx_value = relax.const(node.args[2])
-        values = self.block_builder.emit(relax.op.full_like(x, rx_value))
-        return self.block_builder.emit(relax.op.where(mask, values, x))
-
     def _masked_scatter(self, node: fx.Node) -> relax.Var:
         x = self.env[node.args[0]]
         mask = self.env[node.args[1]]

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -3223,27 +3223,30 @@ def test_fill():
     example_args = (torch.randn(10, 10, dtype=torch.float32),)
     verify_model(Fill(), example_args, {}, Expected)
 
+
 def test_masked_fill():
     class Masked_Fill(Module):
         def forward(self, input: torch.Tensor, mask: torch.Tensor):
-            return torch.masked_fill(input,mask,0)
+            return torch.masked_fill(input, mask, 0)
 
     @tvm.script.ir_module
     class Expected:
         @R.function
         def main(
-            input: R.Tensor((128, 128), dtype="float32"),
-            mask: R.Tensor((128, 128), dtype="bool")
+            input: R.Tensor((128, 128), dtype="float32"), mask: R.Tensor((128, 128), dtype="bool")
         ) -> R.Tuple(R.Tensor((128, 128), dtype="float32")):
             with R.dataflow():
-                lv: R.Tensor((128, 128), dtype="float32") = R.full_like(input, R.const(0, "int32"), dtype="void")
+                lv: R.Tensor((128, 128), dtype="float32") = R.full_like(
+                    input, R.const(0, "int32"), dtype="void"
+                )
                 lv1: R.Tensor((128, 128), dtype="float32") = R.where(mask, lv, input)
                 gv: R.Tuple(R.Tensor((128, 128), dtype="float32")) = (lv1,)
                 R.output(gv)
             return gv
 
-    example_args = (torch.randn(128, 128, dtype=torch.float32),torch.rand(128,128) < 0.5 )
+    example_args = (torch.randn(128, 128, dtype=torch.float32), torch.rand(128, 128) < 0.5)
     verify_model(Masked_Fill(), example_args, {}, Expected)
+
 
 def test_new_ones():
     class NewOnes(Module):


### PR DESCRIPTION
This PR adds support for the masked_fill operation in the Exported Program frontend, aligning it with the existing support in the FX graph. With this enhancement, models such as bert-base-uncased (Model type: QuestionAnswering) can now execute successfully.