### PR TITLE
[RISCV] correct the default VLEN to 128

### DIFF
--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -943,9 +943,7 @@ const int LLVMTargetInfo::GetVectorWidth() {
     } else if (arch == llvm::Triple::arm || arch == llvm::Triple::aarch64) {
       vector_width_ = 128;
     } else if (arch == llvm::Triple::riscv32 || arch == llvm::Triple::riscv64) {
-      vector_width_ = 256;
-      LOG(WARNING) << "LLVM RVV VLEN inference failed, "
-                   << "using 256 bits, set -vector-width=XXX to override";
+      vector_width_ = 128;
     } else {
       // fallback default
       vector_width_ = 128;


### PR DESCRIPTION
- From the RISCV ISA spec

> The V vector extension depends upon the Zvl128b and Zve64d extensions.

Reference: https://github.com/riscv/riscv-isa-manual/blob/e5078e55ea977ef197066dcd3f7c8e09032cb348/src/v-st-ext.adoc?plain=1#L5094