### PR TITLE
[Relax][PyTorch] Support eye op for ExportedProgram importer

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1416,6 +1416,19 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         x = self.env[node.args[0]]
         return self.block_builder.emit(relax.op.zeros_like(x))
 
+    def _eye(self, node: fx.Node) -> relax.Var:
+        args = self.retrieve_args(node)
+        if len(args) == 1:
+            n = args[0]
+            m = n
+        elif len(args) == 2:
+            n = args[0]
+            m = args[1]
+        else:
+            raise ValueError("Invalid number of arguments for eye")
+        dtype = self._convert_data_type(str(node.kwargs["dtype"]), self.env)
+        return self.block_builder.emit(relax.op.eye(n, m, dtype=dtype))
+
     def _fill(self, node: fx.Node) -> relax.Var:
         args = self.retrieve_args(node)
         x = args[0]

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1418,14 +1418,8 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
 
     def _eye(self, node: fx.Node) -> relax.Var:
         args = self.retrieve_args(node)
-        if len(args) == 1:
-            n = args[0]
-            m = n
-        elif len(args) == 2:
-            n = args[0]
-            m = args[1]
-        else:
-            raise ValueError("Invalid number of arguments for eye")
+        n = args[0]
+        m = args[1] if len(args) > 1 else n
         dtype = self._convert_data_type(str(node.kwargs["dtype"]), self.env)
         return self.block_builder.emit(relax.op.eye(n, m, dtype=dtype))
 

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -453,6 +453,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "clone.default": lambda node: self.env[node.args[0]],
             "empty.memory_format": self._empty,
             "empty_like.default": self._empty_like,
+            "eye.default": self._eye,
             "eye.m": self._eye,
             "fill.Scalar": self._fill,
             "full.default": self._full,

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -453,6 +453,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "clone.default": lambda node: self.env[node.args[0]],
             "empty.memory_format": self._empty,
             "empty_like.default": self._empty_like,
+            "eye.m": self._eye,
             "fill.Scalar": self._fill,
             "full.default": self._full,
             "full_like.default": self._full_like,

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -4377,5 +4377,26 @@ def test_narrow():
     verify_model(Narrow(), example_args, {}, Expected)
 
 
+def test_eye():
+    class Eye(Module):
+        def forward(self, input):
+            return torch.eye(3, 5, dtype=torch.float32)
+
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main(
+            input: R.Tensor((3, 5), dtype="float32")
+        ) -> R.Tuple(R.Tensor((3, 5), dtype="float32")):
+            with R.dataflow():
+                lv: R.Tensor((3, 5), dtype="float32") = R.eye(3, 5, dtype="float32")
+                gv: R.Tuple(R.Tensor((3, 5), dtype="float32")) = (lv,)
+                R.output(gv)
+            return gv
+
+    example_args = (torch.randn(3, 5, dtype=torch.float32),)
+    verify_model(Eye(), example_args, {}, Expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -4382,7 +4382,6 @@ def test_eye():
         def forward(self, input):
             return torch.eye(3, 5, dtype=torch.float32)
 
-
     @tvm.script.ir_module
     class Expected1:
         @R.function

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -4378,12 +4378,13 @@ def test_narrow():
 
 
 def test_eye():
-    class Eye(Module):
+    class Eye1(Module):
         def forward(self, input):
             return torch.eye(3, 5, dtype=torch.float32)
 
+
     @tvm.script.ir_module
-    class Expected:
+    class Expected1:
         @R.function
         def main(
             input: R.Tensor((3, 5), dtype="float32")
@@ -4394,8 +4395,27 @@ def test_eye():
                 R.output(gv)
             return gv
 
-    example_args = (torch.randn(3, 5, dtype=torch.float32),)
-    verify_model(Eye(), example_args, {}, Expected)
+    class Eye2(Module):
+        def forward(self, input):
+            return torch.eye(5, dtype=torch.float32)
+
+    @tvm.script.ir_module
+    class Expected2:
+        @R.function
+        def main(
+            input: R.Tensor((5,), dtype="float32")
+        ) -> R.Tuple(R.Tensor((5, 5), dtype="float32")):
+            with R.dataflow():
+                lv: R.Tensor((5, 5), dtype="float32") = R.eye(5, dtype="float32")
+                gv: R.Tuple(R.Tensor((5, 5), dtype="float32")) = (lv,)
+                R.output(gv)
+            return gv
+
+    example_args1 = (torch.randn(3, 5, dtype=torch.float32),)
+    verify_model(Eye1(), example_args1, {}, Expected1)
+
+    example_args2 = (torch.randn(5, dtype=torch.float32),)
+    verify_model(Eye2(), example_args2, {}, Expected2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pr supports `eye` op for ExportedProgram importer.