### PR TITLE
[BugFix][Relax][Pytorch] Incorrect Handling of In-Place Ops in FX-Based TVM Frontend

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -161,12 +161,16 @@ class TorchFXImporter(BaseFXGraphImporter):
                 return output
 
             elif isinstance(lhs, relax.expr.Constant):
-                output = call_binary_op(relax_op, lhs, relax.const(rhs, dtype=lhs.struct_info.dtype))
+                output = call_binary_op(
+                    relax_op, lhs, relax.const(rhs, dtype=lhs.struct_info.dtype)
+                )
                 self.env[node.args[0]] = output
                 return output
 
             elif isinstance(rhs, relax.expr.Constant):
-                output = call_binary_op(relax_op, relax.const(lhs, dtype=rhs.struct_info.dtype), rhs)
+                output = call_binary_op(
+                    relax_op, relax.const(lhs, dtype=rhs.struct_info.dtype), rhs
+                )
                 self.env[node.args[0]] = output
                 return output
 

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -159,14 +159,17 @@ class TorchFXImporter(BaseFXGraphImporter):
                 output = call_binary_op(relax_op, lhs, rhs)
                 self.env[node.args[0]] = output
                 return output
+
             elif isinstance(lhs, relax.expr.Constant):
                 output = call_binary_op(relax_op, lhs, relax.const(rhs, dtype=lhs.struct_info.dtype))
                 self.env[node.args[0]] = output
                 return output
+
             elif isinstance(rhs, relax.expr.Constant):
                 output = call_binary_op(relax_op, relax.const(lhs, dtype=rhs.struct_info.dtype), rhs)
                 self.env[node.args[0]] = output
                 return output
+
             output = intrinsic_op(lhs, rhs)
             self.env[node.args[0]] = output
             return output

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -132,6 +132,47 @@ class TorchFXImporter(BaseFXGraphImporter):
 
         return convert
 
+    ########## Binary Ops ##############
+
+    def _binary_op_inplace(self, relax_op: Callable, intrinsic_op: Callable) -> Callable:
+        from torch import fx
+
+        def convert(node: fx.Node) -> relax.Var:
+            def promote_binary_op_args(lhs, rhs):
+                if isinstance(lhs, relax.Expr) and isinstance(rhs, relax.Expr):
+                    return lhs, rhs
+                elif isinstance(lhs, relax.Expr):
+                    assert isinstance(lhs.struct_info, relax.TensorStructInfo)
+                    return lhs, relax.const(rhs, lhs.struct_info.dtype)
+                elif isinstance(rhs, relax.Expr):
+                    assert isinstance(rhs.struct_info, relax.TensorStructInfo)
+                    return relax.const(lhs, rhs.struct_info.dtype), rhs
+                else:
+                    assert False
+
+            def call_binary_op(op, lhs, rhs):
+                lhs, rhs = promote_binary_op_args(lhs, rhs)
+                return self.block_builder.emit(op(lhs, rhs))
+
+            lhs, rhs = self.retrieve_args(node)
+            if isinstance(lhs, relax.Var) or isinstance(rhs, relax.Var):
+                output = call_binary_op(relax_op, lhs, rhs)
+                self.env[node.args[0]] = output
+                return output
+            elif isinstance(lhs, relax.expr.Constant):
+                output = call_binary_op(relax_op, lhs, relax.const(rhs, dtype=lhs.struct_info.dtype))
+                self.env[node.args[0]] = output
+                return output
+            elif isinstance(rhs, relax.expr.Constant):
+                output = call_binary_op(relax_op, relax.const(lhs, dtype=rhs.struct_info.dtype), rhs)
+                self.env[node.args[0]] = output
+                return output
+            output = intrinsic_op(lhs, rhs)
+            self.env[node.args[0]] = output
+            return output
+
+        return convert
+
     ########## Neural Network ##########
 
     def _adaptive_avg_pool2d_module(self, node: fx.Node) -> relax.Var:
@@ -679,7 +720,7 @@ class TorchFXImporter(BaseFXGraphImporter):
             # binary
             "add": self._binary_op(relax.op.add, operator.add),
             "and_": self._binary_op(relax.op.bitwise_and, operator.and_),
-            "bitwise_or_": self._binary_op(relax.op.bitwise_or, operator.or_),
+            "bitwise_or_": self._binary_op_inplace(relax.op.bitwise_or, operator.or_),
             "bitwise_or": self._binary_op(relax.op.bitwise_or, operator.or_),
             "eq": self._binary_op(relax.op.equal, operator.eq),
             "floordiv": self._binary_op(relax.op.floor_divide, operator.floordiv),


### PR DESCRIPTION
This PR resolves #17874. Currently, only one in-place operation (bitwise_or_) is affected, and it has been remapped to use self._binary_op_inplace instead of self._binary_op. Going forward, any additional in-place operations (e.g., bitwise_and_, bitwise_xor_, etc.) should also be explicitly mapped to self._binary_op_inplace to ensure correct handling.