### PR TITLE
Add op support for zeros_like and fill_

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1427,15 +1427,14 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         value = args[1] if isinstance(args[1], relax.Expr) else relax.const(args[1], dtype)
         return self.block_builder.emit(relax.op.full(x.struct_info.shape, value, dtype))
 
-    def _fill_inplace(self, node: fx.Node) -> relax.Var:
-        target_tensor = self.env[node.args[0]]
-        fill_value = relax.const(node.args[1])
-        dtype = target_tensor.struct_info.dtype
-        filled_tensor = self.block_builder.emit(
-            relax.op.full_like(target_tensor, fill_value, dtype)
-        )
-        self.env[node.args[0]] = filled_tensor
-        return filled_tensor
+    def _inplace_fill(self, node: fx.Node) -> relax.Var:
+        args = self.retrieve_args(node)
+        x = args[0]
+        dtype = x.struct_info.dtype
+        value = args[1] if isinstance(args[1], relax.Expr) else relax.const(args[1], dtype)
+        filled = self.block_builder.emit(relax.op.full(x.struct_info.shape, value, dtype))
+        self.env[node.args[0]] = filled
+        return filled
 
     def _full(self, node: fx.Node) -> relax.Var:
         import torch

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1426,12 +1426,14 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         dtype = x.struct_info.dtype
         value = args[1] if isinstance(args[1], relax.Expr) else relax.const(args[1], dtype)
         return self.block_builder.emit(relax.op.full(x.struct_info.shape, value, dtype))
-    
+
     def _fill_inplace(self, node: fx.Node) -> relax.Var:
         target_tensor = self.env[node.args[0]]
         fill_value = relax.const(node.args[1])
         dtype = target_tensor.struct_info.dtype
-        filled_tensor = self.block_builder.emit(relax.op.full_like(target_tensor, fill_value, dtype))
+        filled_tensor = self.block_builder.emit(
+            relax.op.full_like(target_tensor, fill_value, dtype)
+        )
         self.env[node.args[0]] = filled_tensor
         return filled_tensor
 
@@ -1647,7 +1649,7 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         output = self.block_builder.emit(relax.op.zeros_like(x))
         self.env[node.args[0]] = output
         return output
-    
+
     def _zeros_like(self, node: fx.node) -> relax.Var:
         x = self.env[node.args[0]]
         return self.block_builder.emit(relax.op.zeros_like(x))

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1426,6 +1426,14 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         dtype = x.struct_info.dtype
         value = args[1] if isinstance(args[1], relax.Expr) else relax.const(args[1], dtype)
         return self.block_builder.emit(relax.op.full(x.struct_info.shape, value, dtype))
+    
+    def _fill_inplace(self, node: fx.Node) -> relax.Var:
+        target_tensor = self.env[node.args[0]]
+        fill_value = relax.const(node.args[1])
+        dtype = target_tensor.struct_info.dtype
+        filled_tensor = self.block_builder.emit(relax.op.full_like(target_tensor, fill_value, dtype))
+        self.env[node.args[0]] = filled_tensor
+        return filled_tensor
 
     def _full(self, node: fx.Node) -> relax.Var:
         import torch
@@ -1639,6 +1647,10 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         output = self.block_builder.emit(relax.op.zeros_like(x))
         self.env[node.args[0]] = output
         return output
+    
+    def _zeros_like(self, node: fx.node) -> relax.Var:
+        x = self.env[node.args[0]]
+        return self.block_builder.emit(relax.op.zeros_like(x))
 
     @abc.abstractmethod
     def create_convert_map(

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -471,6 +471,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "eye.default": self._eye,
             "eye.m": self._eye,
             "fill.Scalar": self._fill,
+            "fill_.Scalar": self._fill_inplace,
             "full.default": self._full,
             "full_like.default": self._full_like,
             "index_select.default": self._index_select,
@@ -485,6 +486,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             ),
             "zero_.default": self._zeros_inplace,
             "zeros.default": self._zeros,
+            "zeros_like.default": self._zeros_like,
             # datatype
             "to.dtype": self._to,
             "to.dtype_layout": self._to,

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -471,7 +471,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "eye.default": self._eye,
             "eye.m": self._eye,
             "fill.Scalar": self._fill,
-            "fill_.Scalar": self._fill_inplace,
+            "fill_.Scalar": self._inplace_fill,
             "full.default": self._full,
             "full_like.default": self._full_like,
             "index_select.default": self._index_select,

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -820,7 +820,7 @@ class TorchFXImporter(BaseFXGraphImporter):
             "empty": self._empty,
             "empty_like": self._empty_like,
             "fill": self._fill,
-            "fill_": self._fill_inplace,
+            "fill_": self._inplace_fill,
             "full": self._full,
             "index_select": self._index_select,
             "masked_fill_": self._inplace_masked_fill,

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -3661,7 +3661,7 @@ def test_fill_inplace():
         ) -> R.Tuple(R.Tensor((10, 10), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((10, 10), dtype="float32") = R.full_like(
-                    inp_0, R.const(1.5, "float32"), dtype="void"
+                    inp_0, R.const(1.5, "float32"), dtype="float32"
                 )
                 gv: R.Tuple(R.Tensor((10, 10), dtype="float32")) = (lv,)
                 R.output(gv)

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -3661,9 +3661,7 @@ def test_fill_inplace():
         ) -> R.Tuple(R.Tensor((2, 3), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((2, 3), dtype="float32") = R.full(
-                    R.shape([2, 3]),
-                    R.const(42.0, "float32"),
-                    dtype="float32"
+                    R.shape([2, 3]), R.const(42.0, "float32"), dtype="float32"
                 )
                 gv: R.Tuple(R.Tensor((2, 3), dtype="float32")) = (lv,)
                 R.output(gv)

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -3650,24 +3650,26 @@ def test_fill():
 def test_fill_inplace():
     class FillInplace(Module):
         def forward(self, input: torch.Tensor):
-            input.fill_(1.5)  # In-place operation
+            input.fill_(42.0)
             return input
 
     @tvm.script.ir_module
     class Expected:
         @R.function
         def main(
-            inp_0: R.Tensor((10, 10), dtype="float32")
-        ) -> R.Tuple(R.Tensor((10, 10), dtype="float32")):
+            x: R.Tensor((2, 3), dtype="float32")
+        ) -> R.Tuple(R.Tensor((2, 3), dtype="float32")):
             with R.dataflow():
-                lv: R.Tensor((10, 10), dtype="float32") = R.full_like(
-                    inp_0, R.const(1.5, "float32"), dtype="float32"
+                lv: R.Tensor((2, 3), dtype="float32") = R.full(
+                    R.shape([2, 3]),
+                    R.const(42.0, "float32"),
+                    dtype="float32"
                 )
-                gv: R.Tuple(R.Tensor((10, 10), dtype="float32")) = (lv,)
+                gv: R.Tuple(R.Tensor((2, 3), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 
-    example_args = (torch.randn(10, 10, dtype=torch.float32),)
+    example_args = (torch.randn(2, 3, dtype=torch.float32),)
     verify_model(FillInplace(), example_args, {}, Expected)
 
 

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3203,8 +3203,8 @@ def test_inplace_fill():
         @R.function
         def main(inp_0: R.Tensor((10, 10), dtype="float32")) -> R.Tensor((10, 10), dtype="float32"):
             with R.dataflow():
-                lv: R.Tensor((10, 10), dtype="float32") = R.full(
-                    R.shape([10, 10]), R.const(1.5, "float32"), dtype="float32"
+                lv: R.Tensor((10, 10), dtype="float32") = R.full_like(
+                    inp_0, R.const(1.5, "float32"), dtype="void"
                 )
                 gv: R.Tensor((10, 10), dtype="float32") = lv
                 R.output(gv)
@@ -4715,6 +4715,26 @@ def test_zero_inplace():
             return gv
 
     verify_model(ZeroInplace(), [([128, 128], "float32")], {}, Expected)
+
+
+def test_zeros_like():
+    class ZerosLike(Module):
+        def forward(self, data):
+            return torch.zeros_like(data)
+
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main(
+            inp_0: R.Tensor((128, 128), dtype="float32")
+        ) -> R.Tensor((128, 128), dtype="float32"):
+            with R.dataflow():
+                lv: R.Tensor((128, 128), dtype="float32") = R.zeros_like(inp_0, dtype="void")
+                gv: R.Tensor((128, 128), dtype="float32") = lv
+                R.output(gv)
+            return gv
+
+    verify_model(ZerosLike(), [([128, 128], "float32")], {}, Expected)
 
 
 def test_type_as():

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3203,8 +3203,8 @@ def test_inplace_fill():
         @R.function
         def main(inp_0: R.Tensor((10, 10), dtype="float32")) -> R.Tensor((10, 10), dtype="float32"):
             with R.dataflow():
-                lv: R.Tensor((10, 10), dtype="float32") = R.full_like(
-                    inp_0, R.const(1.5, "float32"), dtype="float32"
+                lv: R.Tensor((10, 10), dtype="float32") = R.full(
+                    R.shape([10, 10]), R.const(1.5, "float32"), dtype="float32"
                 )
                 gv: R.Tensor((10, 10), dtype="float32") = lv
                 R.output(gv)

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3204,7 +3204,7 @@ def test_inplace_fill():
         def main(inp_0: R.Tensor((10, 10), dtype="float32")) -> R.Tensor((10, 10), dtype="float32"):
             with R.dataflow():
                 lv: R.Tensor((10, 10), dtype="float32") = R.full_like(
-                    inp_0, R.const(1.5, "float32"), dtype="void"
+                    inp_0, R.const(1.5, "float32"), dtype="float32"
                 )
                 gv: R.Tensor((10, 10), dtype="float32") = lv
                 R.output(gv)


### PR DESCRIPTION
This PR adds support for the following operations in the exported program frontend for TVM Relax: zeros_like and fill_. By adding these ops the following models run successfully.

| Operation   | Supported Models |
|-------------|------------------|
| `zeros_like` | - mdeberta-v3-base <br> - ms-marco-MiniLM-L6-v2 <br> - grammar_error_correcter_v1 <br> - google/byt5-base <br> - google/flan-t5-small <br> - DeBERTa-v3-base-mnli-fever-anli <br> - Political_DEBATE_large_v1.0 <br> - microsoft/table-transformer-detection <br> - facebook/detr-resnet-50 <br> - facebook/mask2former-swin-tiny-coco-instance|
| `fill_`      | - microsoft/beit-base-patch16-224-pt22k-ft22k <br> - google-mt5/small |
