### PR TITLE
[BugFix] Fix off-by-one error in the type index range check within Object::IsInstance()

### DIFF
--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -890,7 +890,7 @@ inline bool Object::IsInstance() const {
       // The condition will be optimized by constant-folding.
       if (TargetType::_type_child_slots != 0) {
         uint32_t end = begin + TargetType::_type_child_slots;
-        if (self->type_index_ >= begin && self->type_index_ < end) return true;
+        if (self->type_index_ >= begin && self->type_index_ <= end) return true;
       } else {
         if (self->type_index_ == begin) return true;
       }

--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -889,8 +889,8 @@ inline bool Object::IsInstance() const {
       uint32_t begin = TargetType::RuntimeTypeIndex();
       // The condition will be optimized by constant-folding.
       if (TargetType::_type_child_slots != 0) {
-        uint32_t end = begin + TargetType::_type_child_slots;
-        if (self->type_index_ >= begin && self->type_index_ <= end) return true;
+        uint32_t end = begin + TargetType::_type_child_slots + 1;
+        if (self->type_index_ >= begin && self->type_index_ < end) return true;
       } else {
         if (self->type_index_ == begin) return true;
       }


### PR DESCRIPTION
This PR fixes an off-by-one error in the type index range check within `Object::IsInstance()`, an example and steps to reproduce it are at Issue https://github.com/apache/tvm/issues/17901.