### PR TITLE
[CI] Install PyTorch 2.7 compatible with CUDA 11.8

### DIFF
--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -45,7 +45,8 @@ if [ "$PYTHON_VERSION" == "3.9" ]; then
     if [ "$DEVICE" == "cuda" ]; then
         pip3 install \
             torch==2.7.0 \
-            torchvision==0.22.0
+            torchvision==0.22.0 \
+            --index-url https://download.pytorch.org/whl/cu118
     else
         pip3 install \
             torch==2.7.0 \
@@ -61,7 +62,8 @@ elif [ "$PYTHON_VERSION" == "3.11" ]; then
     if [ "$DEVICE" == "cuda" ]; then
         pip3 install \
             torch==2.7.0 \
-            torchvision==0.22.0
+            torchvision==0.22.0 \
+            --index-url https://download.pytorch.org/whl/cu118
     else
         pip3 install \
             torch==2.7.0 \


### PR DESCRIPTION
PyTorch 2.7 depends on CUDA 12.6 by default, so we explicitly install PyTorch compatible with CUDA 11.8.
#17891
cc @yongwww @Hzfengsy @MasterJH5574 