### PR TITLE
[Relax][PyTorch] Add support for eye op in fx graph

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -821,6 +821,7 @@ class TorchFXImporter(BaseFXGraphImporter):
             "clone": lambda node: self.env[node.args[0]],
             "empty": self._empty,
             "empty_like": self._empty_like,
+            "eye": self._eye,
             "fill": self._fill,
             "fill_": self._inplace_fill,
             "full": self._full,


### PR DESCRIPTION
This PR supports Pytorch `eye` op for Relax.