### PR TITLE
[RPC] Fix Bug That Change Dict When Iterate The Keys

### DIFF
--- a/python/tvm/rpc/proxy.py
+++ b/python/tvm/rpc/proxy.py
@@ -334,7 +334,7 @@ class ProxyServerHandler(object):
         keyset = set(self._server_pool.keys())
         new_keys = []
         # re-generate the server match key, so old information is invalidated.
-        for key in keys:
+        for key in tuple(keys):
             rpc_key, _ = base.split_random_key(key)
             handle = self._server_pool[key]
             del self._server_pool[key]


### PR DESCRIPTION
The network between our RPC proxy machine and RPC tracker is not very good, when the connect is broken, the RPC proxy will hang with the below error message.
```
RuntimeError: dictionary changed size during iteration
```