### PR TITLE
Add op support for new_zeros op in Exported Program and fx graph frontend

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1534,7 +1534,6 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         values = self.block_builder.emit(relax.op.full_like(x, rx_value))
         return self.block_builder.emit(relax.op.where(mask, values, x))
 
-    #new-zeros op
     def _new_ones(self, node: fx.Node) -> relax.Var:
         args = self.retrieve_args(node)
         self_var = args[0]
@@ -1552,16 +1551,14 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
     
     def _new_zeros(self, node: fx.Node) -> relax.Var:
         args = self.retrieve_args(node)
-        self_var = args[0]
-        size = args[1] if isinstance(args[1], (list, tuple)) else args[1:]
-        if not isinstance(size, (list, tuple)):
-            size = (size,)
+        input_tensor = args[0]
+        size = args[1] if isinstance(args[1], (list, tuple)) else (args[1],) if len(args[1:]) == 1 else args[1:]
         size = relax.ShapeExpr(size)
         return self.block_builder.emit(
             relax.op.full(
                 size,
-                relax.const(0, self_var.struct_info.dtype),
-                self_var.struct_info.dtype,
+                relax.const(0, input_tensor.struct_info.dtype),
+                input_tensor.struct_info.dtype,
             )
         )
 

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1534,6 +1534,7 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         values = self.block_builder.emit(relax.op.full_like(x, rx_value))
         return self.block_builder.emit(relax.op.where(mask, values, x))
 
+    #new-zeros op
     def _new_ones(self, node: fx.Node) -> relax.Var:
         args = self.retrieve_args(node)
         self_var = args[0]

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1548,6 +1548,21 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
                 self_var.struct_info.dtype,
             )
         )
+    
+    def _new_zeros(self, node: fx.Node) -> relax.Var:
+        args = self.retrieve_args(node)
+        self_var = args[0]
+        size = args[1] if isinstance(args[1], (list, tuple)) else args[1:]
+        if not isinstance(size, (list, tuple)):
+            size = (size,)
+        size = relax.ShapeExpr(size)
+        return self.block_builder.emit(
+            relax.op.full(
+                size,
+                relax.const(0, self_var.struct_info.dtype),
+                self_var.struct_info.dtype,
+            )
+        )
 
     def _ones(self, node: fx.Node) -> relax.Var:
         import torch

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1548,11 +1548,17 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
                 self_var.struct_info.dtype,
             )
         )
-    
+
     def _new_zeros(self, node: fx.Node) -> relax.Var:
         args = self.retrieve_args(node)
         input_tensor = args[0]
-        size = args[1] if isinstance(args[1], (list, tuple)) else (args[1],) if len(args[1:]) == 1 else args[1:]
+        size = (
+            args[1]
+            if isinstance(args[1], (list, tuple))
+            else (args[1],)
+            if len(args[1:]) == 1
+            else args[1:]
+        )
         size = relax.ShapeExpr(size)
         return self.block_builder.emit(
             relax.op.full(

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -482,6 +482,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "linspace.default": self._linspace,
             "masked_fill.Scalar": self._masked_fill,
             "new_ones.default": self._new_ones,
+            "new_zeros.default": self._new_zeros,
             "one_hot.default": self._one_hot,
             "ones.default": self._ones,
             "ones_like.default": lambda node: self.block_builder.emit(

--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -829,6 +829,7 @@ class TorchFXImporter(BaseFXGraphImporter):
             "masked_fill": self._masked_fill,
             "masked_scatter": self._masked_scatter,
             "new_ones": self._new_ones,
+            "new_zeros": self._new_zeros,
             "ones": self._ones,
             "one_hot": self._one_hot,
             "ones_like": lambda node: self.block_builder.emit(

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -3751,6 +3751,30 @@ def test_new_ones():
     verify_model(NewOnes(), example_args, {}, expected1)
 
 
+def test_new_zeros():
+    class NewZeros(Module):
+        def forward(self, x):
+            return x.new_zeros(1, 2, 3)
+
+    @tvm.script.ir_module
+    class expected1:
+        @R.function
+        def main(
+            x: R.Tensor((1, 2, 3), dtype="float32")
+        ) -> R.Tuple(R.Tensor((1, 2, 3), dtype="float32")):
+            # block 0
+            with R.dataflow():
+                lv: R.Tensor((1, 2, 3), dtype="float32") = R.full(
+                    (1, 2, 3), R.const(0, "float32"), dtype="float32"  # Changed to 0
+                )
+                gv: R.Tuple(R.Tensor((1, 2, 3), dtype="float32")) = (lv,)
+                R.output(gv)
+            return gv
+
+    example_args = (torch.randn(1, 2, 3, dtype=torch.float32),)
+    verify_model(NewZeros(), example_args, {}, expected1)
+
+
 def test_to_copy():
     # float
     class ToFloat(Module):

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -3752,26 +3752,27 @@ def test_new_ones():
 
 
 def test_new_zeros():
-    class NewZeros(Module):
+    class NewZeros(torch.nn.Module):
         def forward(self, x):
-            return x.new_zeros(1, 2, 3)
+            return x.new_zeros(1, 128, 128)
 
     @tvm.script.ir_module
     class expected1:
         @R.function
         def main(
-            x: R.Tensor((1, 2, 3), dtype="float32")
-        ) -> R.Tuple(R.Tensor((1, 2, 3), dtype="float32")):
-            # block 0
+            x: R.Tensor((1, 128, 128), dtype="float32")
+        ) -> R.Tuple(R.Tensor((1, 128, 128), dtype="float32")):
             with R.dataflow():
-                lv: R.Tensor((1, 2, 3), dtype="float32") = R.full(
-                    (1, 2, 3), R.const(0, "float32"), dtype="float32"  # Changed to 0
+                lv: R.Tensor((1, 128, 128), dtype="float32") = R.full(
+                    R.shape([1, 128, 128]),
+                    R.const(0, "float32"), 
+                    dtype="float32"
                 )
-                gv: R.Tuple(R.Tensor((1, 2, 3), dtype="float32")) = (lv,)
+                gv: R.Tuple(R.Tensor((1, 128, 128), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 
-    example_args = (torch.randn(1, 2, 3, dtype=torch.float32),)
+    example_args = (torch.randn(1, 128, 128, dtype=torch.float32),)
     verify_model(NewZeros(), example_args, {}, expected1)
 
 

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -3764,9 +3764,7 @@ def test_new_zeros():
         ) -> R.Tuple(R.Tensor((1, 128, 128), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((1, 128, 128), dtype="float32") = R.full(
-                    R.shape([1, 128, 128]),
-                    R.const(0, "float32"), 
-                    dtype="float32"
+                    R.shape([1, 128, 128]), R.const(0, "float32"), dtype="float32"
                 )
                 gv: R.Tuple(R.Tensor((1, 128, 128), dtype="float32")) = (lv,)
                 R.output(gv)

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3337,7 +3337,9 @@ def test_new_zeros():
     @tvm.script.ir_module
     class expected:
         @R.function
-        def main(x: R.Tensor((1, 128, 128), dtype="float32")) -> R.Tensor((1, 128, 128), dtype="float32"):
+        def main(
+            x: R.Tensor((1, 128, 128), dtype="float32")
+        ) -> R.Tensor((1, 128, 128), dtype="float32"):
             # block 0
             with R.dataflow():
                 lv: R.Tensor((1, 128, 128), dtype="float32") = R.full(

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3327,6 +3327,29 @@ def test_new_ones():
     verify_model(NewOnes(), input_info, {}, expected1)
 
 
+def test_new_zeros():
+    input_info = [([1, 2, 3], "float32")]
+
+    class NewZeros(Module):
+        def forward(self, x):
+            return x.new_zeros(1, 2, 3)
+
+    @tvm.script.ir_module
+    class expected1:
+        @R.function
+        def main(x: R.Tensor((1, 2, 3), dtype="float32")) -> R.Tensor((1, 2, 3), dtype="float32"):
+            # block 0
+            with R.dataflow():
+                lv: R.Tensor((1, 2, 3), dtype="float32") = R.full(
+                    (1, 2, 3), R.const(0, "float32"), dtype="float32"  # Changed to 0
+                )
+                gv: R.Tensor((1, 2, 3), dtype="float32") = lv
+                R.output(gv)
+            return gv
+
+    verify_model(NewZeros(), input_info, {}, expected1)
+
+
 def test_expand():
     input_info = [([1, 2, 3, 4], "float32")]
 

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3328,26 +3328,26 @@ def test_new_ones():
 
 
 def test_new_zeros():
-    input_info = [([1, 2, 3], "float32")]
+    input_info = [([1, 128, 128], "float32")]
 
     class NewZeros(Module):
         def forward(self, x):
-            return x.new_zeros(1, 2, 3)
+            return x.new_zeros(1, 128, 128)
 
     @tvm.script.ir_module
-    class expected1:
+    class expected:
         @R.function
-        def main(x: R.Tensor((1, 2, 3), dtype="float32")) -> R.Tensor((1, 2, 3), dtype="float32"):
+        def main(x: R.Tensor((1, 128, 128), dtype="float32")) -> R.Tensor((1, 128, 128), dtype="float32"):
             # block 0
             with R.dataflow():
-                lv: R.Tensor((1, 2, 3), dtype="float32") = R.full(
-                    (1, 2, 3), R.const(0, "float32"), dtype="float32"  # Changed to 0
+                lv: R.Tensor((1, 128, 128), dtype="float32") = R.full(
+                    (1, 128, 128), R.const(0.0, "float32"), dtype="float32"
                 )
-                gv: R.Tensor((1, 2, 3), dtype="float32") = lv
+                gv: R.Tensor((1, 128, 128), dtype="float32") = lv
                 R.output(gv)
             return gv
 
-    verify_model(NewZeros(), input_info, {}, expected1)
+    verify_model(NewZeros(), input_info, {}, expected)
 
 
 def test_expand():


### PR DESCRIPTION
This PR adds support for the new_zeros operation in exported program and fx graph translator torch frontend. By adding this support, the following models are now able to run successfully:

1. grammar_error_correcter_v1
2. google/byt5-base
3. facebook/mask2former-swin-tiny-coco-instance
4. google/mt5-small
5. facebook/bart-large-cnn
6. Angel0J/distilbart-multi_news-12-6_2