### PR TITLE
[WebGPU][CodeGen] Override PrintVecElemLoad and Store for WebGPU

### DIFF
--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -348,6 +348,17 @@ void CodeGenWebGPU::PrintSSAAssign(const std::string& target, const std::string&
   stream << " = " << src << ";\n";
 }
 
+void CodeGenWebGPU::PrintVecElemLoad(const std::string& vec, DataType t, int i,
+                                     std::ostream& os) {  // NOLINT(*)
+  os << vec << "[" << i << "]";
+}
+
+void CodeGenWebGPU::PrintVecElemStore(const std::string& vec, DataType t, int i,
+                                      const std::string& value) {
+  this->PrintIndent();
+  stream << vec << "[" << i << "] = " << value << ";\n";
+}
+
 void CodeGenWebGPU::VisitExpr_(const BroadcastNode* op, std::ostream& os) {  // NOLINT(*)
   std::string v = PrintExpr(op->value);
   int lanes = op->dtype.lanes();

--- a/src/target/source/codegen_webgpu.h
+++ b/src/target/source/codegen_webgpu.h
@@ -58,6 +58,10 @@ class CodeGenWebGPU final : public CodeGenC {
   // assignment printing
   void PrintSSAAssign(const std::string& target, const std::string& src, DataType type) final;
 
+  // overload printing vector element load/store
+  void PrintVecElemLoad(const std::string& vec, DataType t, int i, std::ostream& os) final;
+  void PrintVecElemStore(const std::string& vec, DataType t, int i, const std::string& value) final;
+
   // overload visitor
   void VisitExpr_(const BroadcastNode* op, std::ostream& os) final;   // NOLINT(*)
   void VisitExpr_(const CallNode* op, std::ostream& os) final;        // NOLINT(*)


### PR DESCRIPTION
This PR overrides `PrintVecElemLoad()` and `PrintVecElemStore()` for the WebGPU backend.

Otherwise, we would generate things like `(QK_local[0i].s0)` for WebGPU, which is not a valid syntax in WGSL. Instead, we generate `(QK_local[0i][0])` after this PR. `QK_local` here is a `array<vec4<f32>, 1>`. 

This issue prevented WebLLM from generating the correct kernel after https://github.com/apache/tvm/pull/17748