### PR TITLE
[FFI] Variant specialize for all ObjectRef

### DIFF
--- a/ffi/include/tvm/ffi/any.h
+++ b/ffi/include/tvm/ffi/any.h
@@ -425,6 +425,15 @@ struct AnyUnsafe : public ObjectUnsafe {
     }
   }
 
+  template <typename T>
+  static TVM_FFI_INLINE T MoveFromAnyStorageAfterCheck(Any&& ref) {
+    if constexpr (!std::is_same_v<T, Any>) {
+      return TypeTraits<T>::MoveFromAnyStorageAfterCheck(&(ref.data_));
+    } else {
+      return std::move(ref);
+    }
+  }
+
   static TVM_FFI_INLINE Object* ObjectPtrFromAnyAfterCheck(const Any& ref) {
     return reinterpret_cast<Object*>(ref.data_.v_obj);
   }

--- a/ffi/include/tvm/ffi/base_details.h
+++ b/ffi/include/tvm/ffi/base_details.h
@@ -123,9 +123,9 @@
  * This macro is used to clear the padding parts for hash and equality check
  * in 32bit platform.
  */
-#define TVM_FFI_CLEAR_PTR_PADDING_IN_FFI_ANY(result)                \
-  if constexpr (sizeof(result->v_obj) != sizeof(result->v_int64)) { \
-    result->v_int64 = 0;                                            \
+#define TVM_FFI_CLEAR_PTR_PADDING_IN_FFI_ANY(result)                    \
+  if constexpr (sizeof((result)->v_obj) != sizeof((result)->v_int64)) { \
+    (result)->v_int64 = 0;                                              \
   }
 
 namespace tvm {

--- a/ffi/include/tvm/ffi/container/container_details.h
+++ b/ffi/include/tvm/ffi/container/container_details.h
@@ -284,6 +284,14 @@ inline constexpr bool storage_enabled_v = std::is_same_v<T, Any> || TypeTraits<T
 template <typename... T>
 inline constexpr bool all_storage_enabled_v = (storage_enabled_v<T> && ...);
 
+/*!
+ * \brief Check if all T are compatible with Any.
+ *
+ * \tparam T The type to check.
+ * \return True if T is compatible with Any, false otherwise.
+ */
+template <typename... T>
+inline constexpr bool all_object_ref_v = (std::is_base_of_v<ObjectRef, T> && ...);
 /**
  * \brief Check if Any storage of Derived can always be directly used as Base.
  *

--- a/ffi/tests/cpp/test_any.cc
+++ b/ffi/tests/cpp/test_any.cc
@@ -337,6 +337,7 @@ TEST(Any, ObjectMove) {
   auto v0 = std::move(any1).cast<TPrimExpr>();
   EXPECT_EQ(v0->value, 3.14);
   EXPECT_EQ(v0.use_count(), 1);
+  EXPECT_TRUE(any1 == nullptr);
 }
 
 }  // namespace

--- a/ffi/tests/cpp/test_map.cc
+++ b/ffi/tests/cpp/test_map.cc
@@ -243,7 +243,7 @@ TEST(Map, AnyConvertCheck) {
       ::tvm::ffi::Error);
 }
 
-TEST(Map, ffi::FunctionGetItem) {
+TEST(Map, FunctionGetItem) {
   Function f = Function::FromTyped([](const MapObj* n, const Any& k) -> Any { return n->at(k); },
                                    "map_get_item");
   Map<String, int64_t> map{{"x", 1}, {"y", 2}};

--- a/ffi/tests/cpp/test_variant.cc
+++ b/ffi/tests/cpp/test_variant.cc
@@ -134,4 +134,31 @@ TEST(Variant, Upcast) {
   EXPECT_EQ(a1[0].get<int>(), 1);
 }
 
+TEST(Variant, AllObjectRef) {
+  Variant<TInt, Array<TInt>> v0 = TInt(1);
+  EXPECT_EQ(v0.get<TInt>()->value, 1);
+  static_assert(std::is_base_of_v<ObjectRef, decltype(v0)>);
+  Any any0 = v0;
+  EXPECT_EQ(any0.cast<TInt>()->value, 1);
+  auto v2 = any0.cast<Variant<TInt, Array<TInt>>>();
+  EXPECT_TRUE(v0.same_as(v2));
+  // assignment operator
+  v0 = Array<TInt>({TInt(2), TInt(3)});
+  EXPECT_EQ(v0.get<Array<TInt>>().size(), 2);
+  EXPECT_EQ(v0.get<Array<TInt>>()[0]->value, 2);
+  EXPECT_EQ(v0.get<Array<TInt>>()[1]->value, 3);
+  EXPECT_EQ(sizeof(v0), sizeof(ObjectRef));
+}
+
+TEST(Variant, PODSameAs) {
+  Variant<String, int> v0 = 1;
+  Variant<String, int> v1 = 1;
+  EXPECT_TRUE(v0.same_as(v1));
+  String s = String("hello");
+  v0 = s;
+  v1 = s;
+  EXPECT_TRUE(v0.same_as(v1));
+  v1 = String("hello");
+  EXPECT_TRUE(!v0.same_as(v1));
+}
 }  // namespace


### PR DESCRIPTION
This PR specializes Variant when all members are ObjectRef, in such case, Variant<V...> is backed by ObjectRef which saves the storage space of the Object.