### PR TITLE
[Fix][Relax] Fix dangling reference in GetTargetFunctions()

### DIFF
--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -703,7 +703,8 @@ std::vector<std::pair<GlobalVar, Function>> GetTargetFunctions(
     const IRModule& mod, const Variant<Bool, Array<String>>& shared_transform) {
   std::vector<std::pair<GlobalVar, Function>> target_functions;
   if (shared_transform.as<Array<String>>().value_or(Array<String>{}).size()) {
-    for (const auto& name : shared_transform.as<Array<String>>().value()) {
+    auto names = shared_transform.as<Array<String>>().value();
+    for (const auto& name : names) {
       auto gvar = mod->global_var_map_.Get(name);
       CHECK(gvar) << "When LiftTransformParams is called with a list of function names, "
                   << "all function names must occur within the IRModule.  "


### PR DESCRIPTION
This patch fixes a dangling reference issue that can be reproduced locally on macOS.

This root cause is that the rvalue returned by `.as<>()` is destroyed at the end of the full-expression, before the for loop actually begins.

A minimal example that demonstrates this issue: https://godbolt.org/z/99vWrK1rq

Below is the call stack for reference.

Thanks,

```
tests/python/relax/test_transform_lift_transform_params.py Fatal Python error: Segmentation fault

Current thread 0x00000001fc9b4840 (most recent call first):
  File "/***/tvm/python/tvm/ir/transform.py", line 238 in __call__
  File "/***/tvm/tests/python/relax/test_transform_lift_transform_params.py", line 1158 in test_share_transform_across_specified_functions
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/python.py", line 159 in pytest_pyfunc_call
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/python.py", line 1627 in runtest
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/runner.py", line 174 in pytest_runtest_call
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/runner.py", line 242 in <lambda>
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/runner.py", line 341 in from_call
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/runner.py", line 241 in call_and_report
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/runner.py", line 132 in runtestprotocol
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/runner.py", line 113 in pytest_runtest_protocol
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/main.py", line 362 in pytest_runtestloop
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/main.py", line 337 in _main
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/main.py", line 283 in wrap_session
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/main.py", line 330 in pytest_cmdline_main
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_callers.py", line 103 in _multicall
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pluggy/_hooks.py", line 513 in __call__
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/config/__init__.py", line 175 in main
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/_pytest/config/__init__.py", line 201 in console_main
  File "/opt/homebrew/anaconda3/envs/test1/lib/python3.11/site-packages/pytest/__main__.py", line 9 in <module>
  File "<frozen runpy>", line 88 in _run_code
  File "<frozen runpy>", line 198 in _run_module_as_main

[2]    24356 segmentation fault  /opt/homebrew/anaconda3/envs/test1/bin/python -m pytest
```