### PR TITLE
Fix sqrt/rsqrt Compatibility with Integer Data Types

### DIFF
--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -515,6 +515,8 @@ def sqrt(x):
     y : tvm.te.Tensor
         The result.
     """
+    if x.dtype.startswith("int"):
+        x = te.compute(x.shape, lambda *i: x(*i).astype("float32"))
     return te.compute(x.shape, lambda *i: te.sqrt(x(*i)))
 
 
@@ -532,6 +534,8 @@ def rsqrt(x):
     y : tvm.te.Tensor
         The result.
     """
+    if x.dtype.startswith("int"):
+        x = te.compute(x.shape, lambda *i: x(*i).astype("float32"))
     return te.compute(x.shape, lambda *i: te.rsqrt(x(*i)))
 
 


### PR DESCRIPTION
Fix https://github.com/apache/tvm/issues/17952.

Since TVM's LLVM backend does not support sqrt for integer types (e.g., int16), we explicitly cast the input to float32 at the TOPI operator level before computing sqrt. This ensures compatibility with hardware-accelerated floating-point sqrt instructions.




cc @Hzfengsy @tqchen 