### PR TITLE
[FFI][LLVM] Fix compilation errors with clang20

### DIFF
--- a/ffi/include/tvm/ffi/string.h
+++ b/ffi/include/tvm/ffi/string.h
@@ -210,7 +210,7 @@ class Bytes : public ObjectRef {
  */
 class String : public ObjectRef {
  public:
-  String(nullptr_t) = delete;  // NOLINT(*)
+  String(std::nullptr_t) = delete;  // NOLINT(*)
 
   /*!
    * \brief constructor from char [N]

--- a/src/target/llvm/intrin_rule_llvm.cc
+++ b/src/target/llvm/intrin_rule_llvm.cc
@@ -25,6 +25,8 @@
 #include "intrin_rule_llvm.h"
 
 #include <llvm/IR/Intrinsics.h>
+#define _USE_MATH_DEFINES
+#include <math.h>
 #include <tvm/tir/op.h>
 #include <tvm/tir/op_attr_types.h>
 


### PR DESCRIPTION
Small tiny fixes  for the refactored FFI backend & LLVM math macros.

* FFI related compilation error:
```
# make -j8
{...}
In file included from tvm-0.20-build/tvm/ffi/include/tvm/ffi/container/array.h:29:
In file included from tvm-0.20-build/tvm/ffi/include/tvm/ffi/any.h:27:
tvm-0.20-build/tvm/ffi/include/tvm/ffi/string.h:214:10: error: field has incomplete type 'String'
  214 |   String(nullptr_t) = delete;  // NOLINT(*)
{...}
# rpm -q clang
clang-20.1.2-3.fc42.riscv64
```

* Inclusion fix for MSWIN (introduced @ https://github.com/apache/tvm/pull/17945):
```
intrin_rule_llvm.cc(185,48): error C2065: 'M_PI': undeclared identifier
```
