### PR TITLE
[TE] Fix create_prim_func to handle nested list/tuple of Tensors

### DIFF
--- a/python/tvm/te/operation.py
+++ b/python/tvm/te/operation.py
@@ -603,7 +603,13 @@ def create_prim_func(
     """
     if not isinstance(ops, (list, tuple, Array)):
         ops = [ops]
-    return _ffi_api.CreatePrimFunc(ops, index_dtype_override)
+    flatten_ops = []
+    for op in ops:
+        if isinstance(op, (list, tuple)):
+            flatten_ops.extend(op)
+        else:
+            flatten_ops.append(op)
+    return _ffi_api.CreatePrimFunc(flatten_ops, index_dtype_override)
 
 
 AXIS_SEPARATOR = tvm.tir.IndexMap.AXIS_SEPARATOR


### PR DESCRIPTION
Fix https://github.com/apache/tvm/issues/17956.

Fixes `te.create_prim_func` to properly handle nested tensor lists (e.g., [input, [output1, output2]]), enabling correct IR generation for multi-output ops like topk.


After the `te.create_prim_func` can generate correct IR for the test in https://github.com/apache/tvm/issues/17956.
```
@I.ir_module
class Module:
    @T.prim_func
    def main(var_data: T.handle, var_topk_cpu_v0: T.handle, var_topk_cpu_v1: T.handle):
        T.func_attr({"tir.noalias": True})
        data_buf = T.match_buffer(var_data, (128, 64), align=8)
        value_buf = T.match_buffer(var_topk_cpu_v0, (128, 10), align=8)
        indices_buf = T.match_buffer(var_topk_cpu_v1, (128, 10), "int64", align=8)
        with T.block("topk_cpu"):
            T.reads()
            T.writes()
            T.call_packed("tvm.contrib.sort.topk", T.tvm_stack_make_array(data_buf.data, T.tvm_stack_make_shape(128, 64), 0, 2, T.float32(0.0), 0), T.tvm_stack_make_array(value_buf.data, T.tvm_stack_make_shape(128, 10), 0, 2, T.float32(0.0), 0), T.tvm_stack_make_array(indices_buf.data, T.tvm_stack_make_shape(128, 10), 0, 2, T.int64(0), 0), 10, 1, "both", T.bool(False))

```