### PR TITLE
[LLVM] Fix JIT unknown reloc issue for case of RISCV

### DIFF
--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -53,18 +53,6 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
-#if TVM_LLVM_VERSION >= 190
-#include <llvm/TargetParser/RISCVISAInfo.h>
-#else
-#if TVM_LLVM_VERSION >= 140
-#include <llvm/Support/RISCVISAInfo.h>
-#endif
-#endif
-#if TVM_LLVM_VERSION >= 160
-#include <llvm/TargetParser/RISCVTargetParser.h>
-#else
-#include <llvm/Support/TargetParser.h>
-#endif
 #include <tvm/ffi/container/array.h>
 #include <tvm/ffi/container/map.h>
 #include <tvm/ffi/optional.h>
@@ -299,34 +287,25 @@ LLVMTargetInfo::LLVMTargetInfo(LLVMInstance& instance, const TargetJSON& target)
     // code model
     code_model_ = llvm::CodeModel::Medium;
 #if TVM_LLVM_VERSION >= 140
-    // VLEN inference
-    const auto cpu_name = GetOrCreateTargetMachine(false)->getMCSubtargetInfo()->getCPU();
-    const auto canon_arch = llvm::RISCV::getMArchFromMcpu(cpu_name);
-    auto ISAInfo =
-        llvm::RISCVISAInfo::parseArchString(canon_arch, /*EnableExperimentalExtensions=*/true);
-    // infer VLEN from LLVM RISCVInfo parser
-    if (!llvm::errorToBool(ISAInfo.takeError()) && (vector_width_ == 0)) {
-      vector_width_ = (*ISAInfo)->getMinVLen();
-    }
-    // infer VLEN from LLVM options (zvlXXXb override)
-    for (const auto& attr : attrs_) {
-      if (attr.find("zvl") != std::string::npos) {
-        std::string vec;
-        for (char c : attr) {
-          if (std::isdigit(c)) vec += c;
+    // get VLEN from the LLVM backend (zvlXXXb)
+    Map<String, String> features = GetAllLLVMCpuFeatures();
+    // check vector ISA
+    if (features.count("v") > 0) {
+      vector_width_ = 0;
+      int zvlbits = 0;
+      for (const auto& [attr, val] : features) {
+        if (std::string(attr).find("zvl") != std::string::npos) {
+          std::string vec;
+          for (char c : std::string(attr)) {
+            if (std::isdigit(c)) vec += c;
+          }
+          zvlbits = std::stoi(vec);
+          // max of the multiple zvlXXXb
+          if (vector_width_ < zvlbits) vector_width_ = zvlbits;
         }
-        vector_width_ = std::stoi(vec);
       }
     }
 #endif
-    if (vector_width_ > 0) {
-      // push cl-opt to LLVM
-      llvm_options_.push_back(
-          ParseOptionString("-riscv-v-vector-bits-min:int=" + std::to_string(vector_width_)));
-    } else {
-      // fallback default (codegen will warn)
-      llvm_options_.push_back(ParseOptionString("-riscv-v-vector-bits-min:int=256"));
-    }
   }
 
   // Target options
@@ -943,9 +922,7 @@ const int LLVMTargetInfo::GetVectorWidth() {
     } else if (arch == llvm::Triple::arm || arch == llvm::Triple::aarch64) {
       vector_width_ = 128;
     } else if (arch == llvm::Triple::riscv32 || arch == llvm::Triple::riscv64) {
-      vector_width_ = 256;
-      LOG(WARNING) << "LLVM RVV VLEN inference failed, "
-                   << "using 256 bits, set -vector-width=XXX to override";
+      vector_width_ = 128;
     } else {
       // fallback default
       vector_width_ = 128;

--- a/tests/python/target/test_riscv_features.py
+++ b/tests/python/target/test_riscv_features.py
@@ -24,20 +24,16 @@ LLVM_VERSION = codegen.llvm_version_major()
 
 # fmt: off
 min_llvm_version, tvm_target, vec_width = tvm.testing.parameters(
-    # generic, no-vec -> (default 256)
-    (-1, "llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+i,+m", 256),
-    (-1, "llvm -device=riscv_cpu -mtriple=riscv32-linux-gnu -mcpu=generic-rv32 -mattr=+64bit,+a,+c,+d,+f,+m", 256),
-    # generic, with-vec -> (default 256)
-    (-1, "llvm -device=riscv_cpu -mtriple=riscv32-linux-gnu -mcpu=generic-rv32 -mattr=+i,+m,+v", 256),
-    (-1, "llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v", 256),
-    # explicit -vector-width
-    (-1, "llvm -device=riscv_cpu -vector-width=128 -mtriple=riscv32-linux-gnu -mcpu=generic-rv32 -mattr=+i,+m,+v", 128),
-    (-1, "llvm -device=riscv_cpu -vector-width=128 -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v", 128),
-    (-1, "llvm -device=riscv_cpu -vector-width=512 -mtriple=riscv32-linux-gnu -mcpu=generic-rv32 -mattr=+i,+m,+v", 512),
-    (-1, "llvm -device=riscv_cpu -vector-width=512 -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v", 512),
+    # generic, no vector -> (default 128)
+    (-1, "llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+i,+m", 128),
+    (-1, "llvm -device=riscv_cpu -mtriple=riscv32-linux-gnu -mcpu=generic-rv32 -mattr=+64bit,+a,+c,+d,+f,+m", 128),
+    # generic, with vector -> (default zvl128b)
+    (-1, "llvm -device=riscv_cpu -mtriple=riscv32-linux-gnu -mcpu=generic-rv32 -mattr=+i,+m,+v", 128),
+    (-1, "llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v", 128),
     # explicit +zvlXXXb
-    (14, "llvm -device=riscv_cpu -mtriple=riscv32-linux-gnu -mcpu=generic-rv32 -mattr=+i,+m,+v,+zvl64b", 64),
-    (14, "llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v,+zvl64b", 64),
+    (14, "llvm -device=riscv_cpu -mtriple=riscv32-linux-gnu -mcpu=generic-rv32 -mattr=+i,+m,+v,+zvl64b", 128),
+    (14, "llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v,+zvl256b", 256),
+    (14, "llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=generic-rv64 -mattr=+64bit,+a,+c,+d,+f,+m,+v,+zvl512b", 512),
     # vendor CPU
     (17, "llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=sifive-x280", 512),
     (18, "llvm -device=riscv_cpu -mtriple=riscv64-linux-gnu -mcpu=sifive-p670", 128),


### PR DESCRIPTION
This fixes the issue described in https://github.com/apache/tvm/issues/17916

---

* Fall to a standard ORCJIT linker (from RTDyldLinker, introduced by MSWIN case), but still cope with COFF cases.
* Incorporates [#17853](https://github.com/apache/tvm/pull/17853#issuecomment-2816105844), that prior info also allows parser simplification, to just read all infos from LLVM side.

---

The basic **relax** demo now runs fine, tested with llvm = {19,20}:

```
$ git diff docs/get_started/tutorials/quick_start.py
{...}
-target = tvm.target.Target("llvm")
+target = tvm.target.Target("llvm -mattr=+m,+a,+f,+d,+zfh,+v,+c")
{...}

$ python3 docs/get_started/tutorials/quick_start.py
# from tvm.script import ir as I
# from tvm.script import relax as R

@I.ir_module
class Module:
    @R.function
    def forward(x: R.Tensor((1, 784), dtype="float32"), fc1_weight: R.Tensor((256, 784), dtype="float32"), 
fc1_bias: R.Tensor((256,), dtype="float32"), fc2_weight: R.Tensor((10, 256), dtype="float32"),
 fc2_bias: R.Tensor((10,), dtype="float32")) -> R.Tensor((1, 10), dtype="float32"):
        R.func_attr({"num_input": 1})
        with R.dataflow():
            permute_dims: R.Tensor((784, 256), dtype="float32") = R.permute_dims(fc1_weight, axes=None)
            matmul: R.Tensor((1, 256), dtype="float32") = R.matmul(x, permute_dims, out_dtype="void")
            add: R.Tensor((1, 256), dtype="float32") = R.add(matmul, fc1_bias)
            relu: R.Tensor((1, 256), dtype="float32") = R.nn.relu(add)
            permute_dims1: R.Tensor((256, 10), dtype="float32") = R.permute_dims(fc2_weight, axes=None)
            matmul1: R.Tensor((1, 10), dtype="float32") = R.matmul(relu, permute_dims1, out_dtype="void")
            add1: R.Tensor((1, 10), dtype="float32") = R.add(matmul1, fc2_bias)
            gv: R.Tensor((1, 10), dtype="float32") = add1
            R.output(gv)
        return gv

[[25018.53  25440.596 24398.615 22915.344 25457.54  25424.28  25661.27
  24288.602 25659.234 23134.854]]

$ rpm -q llvm-devel
llvm-devel-20.1.2-3.fc42.riscv64

$ uname -a
Linux lpi3a 6.6.87-200.spacemit_bl2.1.fc41.riscv64 #1 SMP PREEMPT_DYNAMIC {..} riscv64 GNU/Linux
```
