### PR TITLE
Fix basic FLOP estimation for WhileNode

### DIFF
--- a/src/tir/analysis/estimate_flops.cc
+++ b/src/tir/analysis/estimate_flops.cc
@@ -174,7 +174,7 @@ class FlopEstimator : private ExprFunctor<TResult(const PrimExpr& n)>,
   }
 
   TResult VisitStmt_(const WhileNode* op) override {
-  // TODO: @jikechao Improve while loop FLOP estimation with loop bound analysis
+  // TODO(jikechao): Improve while loop FLOP estimation with loop bound analysis
   TResult result = VisitExpr(op->condition);
   result += VisitStmt(op->body);
   return result;

--- a/src/tir/analysis/estimate_flops.cc
+++ b/src/tir/analysis/estimate_flops.cc
@@ -173,6 +173,13 @@ class FlopEstimator : private ExprFunctor<TResult(const PrimExpr& n)>,
     return cond;
   }
 
+  TResult VisitStmt_(const WhileNode* op) override {
+  // TODO: @jikechao Improve while loop FLOP estimation with loop bound analysis
+  TResult result = VisitExpr(op->condition);
+  result += VisitStmt(op->body);
+  return result;
+  }
+
   TResult VisitStmt_(const LetStmtNode* let) override {
     TResult value = VisitExpr(let->value);
     value += VisitStmt(let->body);

--- a/src/tir/analysis/estimate_flops.cc
+++ b/src/tir/analysis/estimate_flops.cc
@@ -174,10 +174,10 @@ class FlopEstimator : private ExprFunctor<TResult(const PrimExpr& n)>,
   }
 
   TResult VisitStmt_(const WhileNode* op) override {
-  // TODO(jikechao): Improve while loop FLOP estimation with loop bound analysis
-  TResult result = VisitExpr(op->condition);
-  result += VisitStmt(op->body);
-  return result;
+    // TODO(jikechao): Improve while loop FLOP estimation with loop bound analysis
+    TResult result = VisitExpr(op->condition);
+    result += VisitStmt(op->body);
+    return result;
   }
 
   TResult VisitStmt_(const LetStmtNode* let) override {


### PR DESCRIPTION
Fix https://github.com/apache/tvm/issues/17960.

This PR fixes a bug where MetaSchedule fails on kernels containing `tir.While` due to missing FLOP estimation. The patch adds conservative handling by:

+ Evaluating the loop condition and body once (since static iteration count is unknown)
+ Adding a TODO for future improvements with bounded loop analysis

This unblocks compilation while being transparent about limitations. Future work can enhance accuracy via loop analysis or annotations.


cc @Hzfengsy @tqchen @vinx13 