### PR TITLE
[Doc][Relax][MetaSchedule] Fix errors in the e2e_opt_model.py tutorial

### DIFF
--- a/docs/how_to/tutorials/e2e_opt_model.py
+++ b/docs/how_to/tutorials/e2e_opt_model.py
@@ -119,6 +119,6 @@ if not IS_IN_CI:
     # Need to allocate data and params on GPU device
     gpu_data = tvm.nd.array(np.random.rand(1, 3, 224, 224).astype("float32"), dev)
     gpu_params = [tvm.nd.array(p, dev) for p in params["main"]]
-    gpu_out = vm["main"](gpu_data, *gpu_params).numpy()
+    gpu_out = vm["main"](gpu_data, *gpu_params)[0].numpy()
 
     print(gpu_out.shape)

--- a/python/tvm/meta_schedule/tune_context.py
+++ b/python/tvm/meta_schedule/tune_context.py
@@ -29,6 +29,7 @@ from tvm.runtime import Object
 from tvm.target import Target
 from tvm.tir import PrimFunc, Schedule
 from tvm.script import tir as T
+from tvm.meta_schedule import postproc
 
 from . import _ffi_api
 from .logging import Logger, get_logger, get_logging_func
@@ -120,7 +121,10 @@ class TuneContext(Object):
                 target = Target(target)
         if space_generator is not None:
             if not isinstance(space_generator, SpaceGenerator):
-                space_generator = SpaceGenerator.create(space_generator)
+                if "gpu" in target.keys:
+                    space_generator = SpaceGenerator.create(space_generator, postprocs=[postproc.VerifyGPUCode()])
+                else:
+                    space_generator = SpaceGenerator.create(space_generator)
         if search_strategy is not None:
             if not isinstance(search_strategy, SearchStrategy):
                 search_strategy = SearchStrategy.create(search_strategy)


### PR DESCRIPTION
As I’m new to TVM, I may lack some knowledge. Please excuse any mistakes, and I’d appreciate your feedback.
# Summary
This PR resolves issue [#17899](https://github.com/apache/tvm/issues/17899) where the end-to-end tutorial `e2e_opt_model.py` fails with errors and cannot be executed successfully.

# Bug fixes
- Memory binding error("Did you forget to bind?")
This error occurs when the compiler attempts to use operations that are not properly bound to GPU memory, due to occasionally generated invalid GPU schedules that result in memory misalignment.
	- **Fix**: Added GPU code verification to SpaceGenerator() that filters out schedules involving memory misalignment.
- <class 'tvm.ir.container.Array'> has no attribute numpy
This error occurs because vm["main"]() returns an Array of NDArray
	- **Fix**: Extracted the NDArray out of the returned Array before calling .numpy().