### PR TITLE
Fix FLOP estimation for EvaluateNode by implementing VisitStmt_ handler

### DIFF
--- a/src/tir/analysis/estimate_flops.cc
+++ b/src/tir/analysis/estimate_flops.cc
@@ -200,6 +200,7 @@ class FlopEstimator : private ExprFunctor<TResult(const PrimExpr& n)>,
   TResult VisitStmt_(const AllocateConstNode* op) override { return VisitStmt(op->body); }
   TResult VisitStmt_(const AllocateNode* op) override { return VisitStmt(op->body); }
   TResult VisitStmt_(const DeclBufferNode* op) override { return VisitStmt(op->body); }
+  TResult VisitStmt_(const EvaluateNode* op) override { return TResult(); }
 
   TResult VisitStmt_(const SeqStmtNode* seq) override {
     TResult result;


### PR DESCRIPTION
### issue desription
This pr aimed to fix https://github.com/apache/tvm/issues/17973. MetaSchedule's FLOP estimator fails when encountering EvaluateNode (e.g., from T.call_packed), throwing TVMError: Do not have a default for `tir.Evaluate`. This occurs because FlopEstimator lacked a handler for EvaluateNode, causing tuning to abort.

### Fix strategy

EvaluateNode typically wraps side-effect operations (e.g., T.call_packed for memory copies or external calls) that contribute negligible FLOPs. Returning 0 avoids overcounting while allowing tuning to proceed rather than crash.


cc @Hzfengsy @tqchen @vinx13 
