### PR TITLE
Fix IR generation conflict in topi.nn.simplify by separating Tensor and PrimExpr handling

### DIFF
--- a/python/tvm/topi/utils.py
+++ b/python/tvm/topi/utils.py
@@ -262,7 +262,17 @@ def simplify(expr):
     out : Expr or int
         The simplified output
     """
-    return tvm.arith.Analyzer().simplify(expr) if isinstance(expr, tvm.tir.PrimExpr) else expr
+    if isinstance(expr, te.Tensor):
+        return te.compute(
+            expr.shape,
+            lambda *indices: tvm.arith.Analyzer().simplify(expr[indices]),
+            name="simplify_output",
+            tag="simplify",
+        )
+    elif isinstance(expr, tvm.tir.PrimExpr):
+        return tvm.arith.Analyzer().simplify(expr)
+    else:
+        return expr
 
 
 def ravel_index(indices, shape):


### PR DESCRIPTION
Fix https://github.com/apache/tvm/issues/17847.

As described in https://github.com/apache/tvm/issues/17847, the current topi.nn.simplify function incorrectly reuses input buffer names when simplifying `te.Tensor`, causing IR generation conflicts in storage_rewrite.

This PR modifies simplify to explicitly handle `te.Tensor` inputs by generating a new output tensor (avoiding buffer aliasing), while preserving the original behavior for PrimExpr and scalar inputs.


cc @tqchen @Hzfengsy @vinx13 

