### PR TITLE
[FRONTEND][ONNX] Make bias input optional in LayerNormalization

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -2489,6 +2489,10 @@ class LayerNormalization(OnnxOpConverter):
         axis = attr.get("axis", -1)
         epsilon = attr.get("epsilon", 1e-05)
 
+        if bias is None:
+            seq_len = data.struct_info.shape[1].value
+            bias = relax.const([0.0] * seq_len, dtype="float32")
+
         output = relax.op.nn.layer_norm(data, scale, bias, axis, epsilon)
         # Onnx layernorm has 3 outputs but only the first is used.
         # We construct two empty constants for this.

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -1303,6 +1303,24 @@ def test_layer_norm():
     model = helper.make_model(graph, producer_name="layer_norm_test")
     check_correctness(model)
 
+    # Test case with no bias that is an optional input
+    layer_norm_node = helper.make_node("LayerNormalization", ["a", "b"], ["d"], epsilon=1e-12)
+
+    graph = helper.make_graph(
+        [layer_norm_node],
+        "layer_norm_test",
+        inputs=[
+            helper.make_tensor_value_info("a", TensorProto.FLOAT, [32, 32]),
+            helper.make_tensor_value_info("b", TensorProto.FLOAT, [32]),
+        ],
+        outputs=[
+            helper.make_tensor_value_info("d", TensorProto.FLOAT, [32, 32]),
+        ],
+    )
+
+    model = helper.make_model(graph, producer_name="layer_norm_test")
+    check_correctness(model)
+
 
 # TODO Enable dynamism
 @pytest.mark.parametrize("dynamic", [False])


### PR DESCRIPTION
# Summary
This PR resolves issue [#17899](https://github.com/apache/tvm/issues/17966) where an error occurs converting operator LayerNormalization.

# Reference
According to the [ONNX documentation for the LayerNormalization operator (opset 17)](https://onnx.ai/onnx/operators/onnx__LayerNormalization.html), the operator accepts between 2 and 3 inputs:
- **X**: Input tensor to be normalized.
- **Scale**: Scale tensor.
- **B** (optional): Bias tensor.

This means that the bias input (B) is optional. The operator is designed to function correctly even when the bias is not provided.

# Update
This change updates the LayerNormalization converter to support ONNX models where the optional bias input is not provided. When bias is missing, an empty bias tensor is generated.