### PR TITLE
Fix zero-extent loops in PerStoreFeature to prevent crashes

### DIFF
--- a/src/meta_schedule/feature_extractor/per_store_feature.cc
+++ b/src/meta_schedule/feature_extractor/per_store_feature.cc
@@ -279,6 +279,9 @@ Pass SimplifyForFeatureExtraction() {
     }
 
     Stmt VisitStmt_(const ForNode* loop) final {
+      if (is_zero(loop->extent)) {
+        return Evaluate(0);
+      }
       if (is_zero(loop->min) && is_one(loop->extent) && loop->kind == ForKind::kSerial &&
           loop->annotations.empty()) {
         unit_vars_.insert(loop->loop_var);


### PR DESCRIPTION
The patch gracefully handles zero-extent loops (like those from empty indices in `take()` ops) by returning `Evaluate(0)` in PerStoreFeature, preventing `CHECK(p < n_loops)` crashes.
This restores auto-tuning for empty-input edge cases while perfectly preserving existing feature extraction for normal loops.

Fix https://github.com/apache/tvm/issues/17994



cc @Hzfengsy @tqchen @vinx13 @MasterJH5574 