### PR TITLE
[TOPI] Fix index handling in expand_like operator for axis expansion

### DIFF
--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -96,9 +96,7 @@ def expand_like(a, shape_like, axis):
         axis_index = 0
         for i in range(0, len(idxs)):
             if i not in real_axis:
-                dim = tvm.tir.if_then_else(
-                    a.shape[len(indices)] !=1, idxs[i], 0
-                )
+                dim = tvm.tir.if_then_else(a.shape[len(indices)] != 1, idxs[i], 0)
                 indices.append(dim)
                 axis_index += 1
         return a(*indices)

--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -96,7 +96,8 @@ def expand_like(a, shape_like, axis):
         axis_index = 0
         for i in range(0, len(idxs)):
             if i not in real_axis:
-                indices.append(idxs[i])
+                dim = tvm.tir.if_then_else(idxs[i] < a.shape[len(indices)], idxs[i], a.shape[len(indices)] - 1)
+                indices.append(dim)
                 axis_index += 1
         return a(*indices)
 

--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -96,7 +96,9 @@ def expand_like(a, shape_like, axis):
         axis_index = 0
         for i in range(0, len(idxs)):
             if i not in real_axis:
-                dim = tvm.tir.if_then_else(idxs[i] < a.shape[len(indices)], idxs[i], a.shape[len(indices)] - 1)
+                dim = tvm.tir.if_then_else(
+                    idxs[i] < a.shape[len(indices)], idxs[i], a.shape[len(indices)] - 1
+                )
                 indices.append(dim)
                 axis_index += 1
         return a(*indices)

--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -97,7 +97,7 @@ def expand_like(a, shape_like, axis):
         for i in range(0, len(idxs)):
             if i not in real_axis:
                 dim = tvm.tir.if_then_else(
-                    idxs[i] < a.shape[len(indices)], idxs[i], a.shape[len(indices)] - 1
+                    a.shape[len(indices)] !=1, idxs[i], 0
                 )
                 indices.append(dim)
                 axis_index += 1


### PR DESCRIPTION
Fix https://github.com/apache/tvm/issues/17947


This PR fixes an index calculation bug in `topi.expand_like` where incorrect indexing could lead to out-of-bounds access when expanding along specified axes.

If `a.shape[src_dim] == 1`, we use `indice=0` because broadcasting rules require replicating the single value across the expanded dimension, and indexing with 0 ensures correct behavior without bounds violations.
