### PR TITLE
Fix division truncation in window size calculation for small dtypes in average_pool

### DIFF
--- a/include/tvm/topi/nn/pooling.h
+++ b/include/tvm/topi/nn/pooling.h
@@ -383,7 +383,7 @@ inline Tensor adaptive_pool_impl(const Tensor& x, const Array<PrimExpr>& output_
 
           PrimExpr divide_factor = tvm::cast(x->dtype, 1);
           for (size_t i = 0; i < n_dim; ++i) {
-            divide_factor *= tvm::cast(x->dtype, reduce_axes[i]->dom->extent);
+            divide_factor *= tvm::cast(DataType::Int(32), reduce_axes[i]->dom->extent);
           }
 
           return div(pool_sum(indices), divide_factor);

--- a/tests/python/te/test_te_create_primfunc.py
+++ b/tests/python/te/test_te_create_primfunc.py
@@ -884,8 +884,8 @@ def test_adaptive_pooling_window():
 
 def test_global_pool():
     # fix the issue-17938
-    data = te.placeholder((1, 1, 32, 32), dtype='int8', name='data')
-    op_output = topi.nn.global_pool(data=data, pool_type='avg', layout='NCHW')
+    data = te.placeholder((1, 1, 32, 32), dtype="int8", name="data")
+    op_output = topi.nn.global_pool(data=data, pool_type="avg", layout="NCHW")
     f = te.create_prim_func([data, op_output])
     assert f
 

--- a/tests/python/te/test_te_create_primfunc.py
+++ b/tests/python/te/test_te_create_primfunc.py
@@ -882,6 +882,14 @@ def test_adaptive_pooling_window():
     _check_workload(te_workload, tir_workload)
 
 
+def test_global_pool():
+    # fix the issue-17938
+    data = te.placeholder((1, 1, 32, 32), dtype='int8', name='data')
+    op_output = topi.nn.global_pool(data=data, pool_type='avg', layout='NCHW')
+    f = te.create_prim_func([data, op_output])
+    assert f
+
+
 def test_nested_reduce_domain_dependency():
     @T.prim_func
     def tir_workload(


### PR DESCRIPTION
This PR fixes an issue where pooling window size calculations incorrectly used the input dtype, which could lead to:

- Division truncation artifacts with small integer types (e.g., int8)
- Potential divide-by-zero errors in certain cases

The fix ensures proper window size calculation independent of input type and fixed #17938. In addition, I also added a CI test.
