### PR TITLE
[TOPI] Support integer type input for log10

### DIFF
--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -484,7 +484,6 @@ def log2(x):
     return te.compute(x.shape, lambda *i: te.log2(x(*i)))
 
 
-@tvm.te.tag_scope(tag=tag.ELEMWISE)
 def log10(x):
     """Take logarithm to the base 10 of input x.
 
@@ -498,7 +497,9 @@ def log10(x):
     y : tvm.te.Tensor
         The result.
     """
-    return te.compute(x.shape, lambda *i: te.log10(x(*i)))
+    if x.dtype.startswith("int"):
+        x = te.compute(x.shape, lambda *i: x(*i).astype('float32'))
+    return te.compute(x.shape, lambda *i: te.log10(x(*i)), tag=tag.ELEMWISE)
 
 
 @tvm.te.tag_scope(tag=tag.ELEMWISE)

--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -498,7 +498,7 @@ def log10(x):
         The result.
     """
     if x.dtype.startswith("int"):
-        x = te.compute(x.shape, lambda *i: x(*i).astype('float32'))
+        x = te.compute(x.shape, lambda *i: x(*i).astype("float32"))
     return te.compute(x.shape, lambda *i: te.log10(x(*i)), tag=tag.ELEMWISE)
 
 


### PR DESCRIPTION
Adds support for integer inputs in topi.log10 by automatically converting them to float32, aligning with NumPy's implicit float promotion behavior.

Fix https://github.com/apache/tvm/issues/17996

cc @Hzfengsy @masahi @yongwww @tqchen 