### PR TITLE
[Relax][ONNX] Replace deprecated `mapping.TENSOR_TYPE_TO_NP_TYPE` usage

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -60,13 +60,13 @@ def get_type(elem_type: Union[str, int]) -> str:
         return elem_type
 
     try:
-        from onnx.mapping import (  # pylint: disable=import-outside-toplevel
-            TENSOR_TYPE_TO_NP_TYPE,
+        from onnx.helper import (  # pylint: disable=import-outside-toplevel
+            tensor_dtype_to_np_dtype,
         )
     except ImportError as exception:
         raise ImportError("Unable to import onnx which is required {}".format(exception))
 
-    return str(TENSOR_TYPE_TO_NP_TYPE[elem_type])
+    return str(tensor_dtype_to_np_dtype(elem_type))
 
 
 def get_constant(


### PR DESCRIPTION
Replace `mapping.TENSOR_TYPE_TO_NP_TYPE` with `helper.tensor_dtype_to_np_dtype()` to resolve the deprecation warning below.

```
tvm/python/tvm/relax/frontend/onnx/onnx_frontend.py:69: DeprecationWarning: `mapping.TENSOR_TYPE_TO_NP_TYPE` is now deprecated and will be removed in a future release.To silence this warning, please use `helper.tensor_dtype_to_np_dtype` instead.
    return str(TENSOR_TYPE_TO_NP_TYPE[elem_type])
```

ref: https://github.com/onnx/onnx/issues/4554

cc @Hzfengsy @yongwww 