### PR TITLE
[FFI] More strict tuple constructor checking

### DIFF
--- a/ffi/include/tvm/ffi/container/container_details.h
+++ b/ffi/include/tvm/ffi/container/container_details.h
@@ -199,6 +199,16 @@ class IterAdapter {
 
   IterAdapter operator-(difference_type offset) const { return IterAdapter(iter_ - offset); }
 
+  IterAdapter& operator+=(difference_type offset) {
+    iter_ += offset;
+    return *this;
+  }
+
+  IterAdapter& operator-=(difference_type offset) {
+    iter_ -= offset;
+    return *this;
+  }
+
   template <typename T = IterAdapter>
   typename std::enable_if<std::is_same<iterator_category, std::random_access_iterator_tag>::value,
                           typename T::difference_type>::type inline

--- a/ffi/include/tvm/ffi/container/tuple.h
+++ b/ffi/include/tvm/ffi/container/tuple.h
@@ -55,10 +55,13 @@ class Tuple : public ObjectRef {
   template <typename... UTypes,
             typename = std::enable_if_t<(details::type_contains_v<Types, UTypes> && ...), int>>
   Tuple(Tuple<UTypes...>&& other) : ObjectRef(std::move(other)) {}
-  template <typename... UTypes>
-  explicit Tuple(UTypes&&... args) : ObjectRef(MakeTupleNode(std::forward<UTypes>(args)...)) {
-    static_assert(sizeof...(Types) == sizeof...(UTypes), "Tuple size mismatch");
-  }
+
+  template <typename... UTypes,
+            typename = std::enable_if_t<sizeof...(Types) == sizeof...(UTypes) &&
+                                        !(sizeof...(Types) == 1 &&
+                                          (std::is_same_v<std::remove_cv_t<UTypes>, Tuple<Types>> &&
+                                           ...))>>
+  explicit Tuple(UTypes&&... args) : ObjectRef(MakeTupleNode(std::forward<UTypes>(args)...)) {}
 
   TVM_FFI_INLINE Tuple& operator=(const Tuple<Types...>& other) {
     data_ = other.data_;

--- a/ffi/tests/cpp/test_tuple.cc
+++ b/ffi/tests/cpp/test_tuple.cc
@@ -136,4 +136,32 @@ TEST(Tuple, Upcast) {
   static_assert(details::type_contains_v<Tuple<Any, float>, Tuple<int, float>>);
   static_assert(details::type_contains_v<Tuple<TNumber, float>, Tuple<TInt, float>>);
 }
+
+TEST(Tuple, ArrayIterForwarding) {
+  Tuple<TInt, TInt> t0(1, 2);
+  Tuple<TInt, TInt> t1(3, 4);
+  Array<Tuple<TInt, TInt>> arr0 = {t0, t1};
+  std::vector<Tuple<TInt, TInt>> vec0 = {t0};
+  vec0.insert(vec0.end(), arr0.begin(), arr0.end());
+  EXPECT_EQ(vec0.size(), 3);
+  EXPECT_EQ(vec0[0].get<0>()->value, 1);
+  EXPECT_EQ(vec0[0].get<1>()->value, 2);
+  EXPECT_EQ(vec0[1].get<0>()->value, 1);
+  EXPECT_EQ(vec0[1].get<1>()->value, 2);
+  EXPECT_EQ(vec0[2].get<0>()->value, 3);
+  EXPECT_EQ(vec0[2].get<1>()->value, 4);
+}
+
+TEST(Tuple, ArrayIterForwardSingleElem) {
+  Tuple<TInt> t0(1);
+  Tuple<TInt> t1(2);
+  Array<Tuple<TInt>> arr0 = {t0, t1};
+  std::vector<Tuple<TInt>> vec0 = {t0};
+  vec0.insert(vec0.end(), arr0.begin(), arr0.end());
+  EXPECT_EQ(vec0.size(), 3);
+  EXPECT_EQ(vec0[0].get<0>()->value, 1);
+  EXPECT_EQ(vec0[1].get<0>()->value, 1);
+  EXPECT_EQ(vec0[2].get<0>()->value, 2);
+}
+
 }  // namespace


### PR DESCRIPTION
This PR fixes a case where tuple constructor mismatches during vector forwarding. In this case UType&& was mistakenly matched and used. A testcase is added.