### PR TITLE
[Metal] Fix `GetFunction` of metal runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,7 @@ if(BUILD_STATIC_RUNTIME)
   add_library(tvm_runtime STATIC
     $<TARGET_OBJECTS:tvm_runtime_objs>
     $<TARGET_OBJECTS:tvm_libinfo_objs>
+    $<TARGET_OBJECTS:tvm_ffi_objs>
     ${TVM_RUNTIME_EXT_OBJS}
   )
   set(NOTICE_MULTILINE

--- a/ffi/cmake/Utils/Library.cmake
+++ b/ffi/cmake/Utils/Library.cmake
@@ -16,7 +16,7 @@
 # under the License.
 function(add_dsymutil target_name)
   # running dsymutil on macos to generate debugging symbols for backtraces
-  if(APPLE)
+  if(APPLE AND TVM_FFI_USE_LIBBACKTRACE)
     find_program(DSYMUTIL dsymutil)
     mark_as_advanced(DSYMUTIL)
     add_custom_command(TARGET ${target_name}

--- a/src/runtime/metal/metal_module.mm
+++ b/src/runtime/metal/metal_module.mm
@@ -267,7 +267,7 @@ ffi::Function MetalModuleNode::GetFunction(const String& name,
     auto it = fmap_.find(name);
     if (it == fmap_.end()) {
       ret = ffi::Function();
-      return ret;
+      return;
     }
     const FunctionInfo& info = it->second;
     MetalWrappedFunc f;


### PR DESCRIPTION
This PR fixes a bug in `MetalModuleNode::GetFunction`.

The lambda passed to autoreleasepool is supposed to return nothing. Prior to this PR, it returns a function at an early exit branch, which may cause the error of `EXC_BREAKPOINT` in Metal.