### PR TITLE
[FFI] Enhance FFI Object exception safety during init

### DIFF
--- a/python/tvm/ffi/container.py
+++ b/python/tvm/ffi/container.py
@@ -78,6 +78,9 @@ class Array(core.Object, collections.abc.Sequence):
         return _ffi_api.ArraySize(self)
 
     def __repr__(self):
+        # exception safety handling for chandle=None
+        if self.__chandle__() == 0:
+            return type(self).__name__ + "(chandle=None)"
         return "[" + ", ".join([x.__repr__() for x in self]) + "]"
 
 
@@ -197,4 +200,7 @@ class Map(core.Object, collections.abc.Mapping):
         return self[key] if key in self else default
 
     def __repr__(self):
+        # exception safety handling for chandle=None
+        if self.__chandle__() == 0:
+            return type(self).__name__ + "(chandle=None)"
         return "{" + ", ".join([f"{k.__repr__()}: {v.__repr__()}" for k, v in self.items()]) + "}"

--- a/python/tvm/runtime/ndarray.py
+++ b/python/tvm/runtime/ndarray.py
@@ -164,6 +164,9 @@ class NDArray(tvm.ffi.core.NDArray):
         return self
 
     def __repr__(self):
+        # exception safety handling for chandle=None
+        if self.__chandle__() == 0:
+            return type(self).__name__ + "(chandle=None)"
         res = f"<tvm.nd.NDArray shape={self.shape}, {self.device}>\n"
         res += self.numpy().__repr__()
         return res

--- a/tests/python/ffi/test_container.py
+++ b/tests/python/ffi/test_container.py
@@ -27,6 +27,20 @@ def test_array():
     assert (a_slice[0], a_slice[1]) == (1, 2)
 
 
+def test_bad_constructor_init_state():
+    """Test when error is raised before __init_handle_by_constructor
+
+    This case we need the FFI binding to gracefully handle both repr
+    and dealloc by ensuring the chandle is initialized and there is
+    proper repr code
+    """
+    with pytest.raises(TypeError):
+        tvm_ffi.Array(1)
+
+    with pytest.raises(AttributeError):
+        tvm_ffi.Map(1)
+
+
 def test_array_of_array_map():
     a = tvm_ffi.convert([[1, 2, 3], {"A": 5, "B": 6}])
     assert isinstance(a, tvm_ffi.Array)


### PR DESCRIPTION
This PR enhances the exception safety of FFI Object during init. Specifically, when an error is thrown during init before __init_by_constructor chandle can be in a undefined state. Additionally, tools like pytest may try to call repr to get a string repr the object, causing segfault.

This PR fixes the issue by always first initialize chandle to NULL and provide chandle=None special handling so pytest can be happy in such cases.