### PR TITLE
[FFI][REFACTOR] Update registry to have complete meta-data

### DIFF
--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -25,16 +25,6 @@ project(
 )
 
 option(TVM_FFI_BUILD_TESTS "Adding test targets." OFF)
-
-########## NOTE: all options below are related to dynamic registry #####
-option(TVM_FFI_BUILD_REGISTRY
-  "Support for objects with non-static type indices. When turned on, \
-  targets linked against `tvm_ffi` will allow objects that comes with non-pre-defined type indices, \
-  as well as getting full stacktrace during debugging. \
-  so that the object hierarchy could expand without limitation. \
-  This will require the downstream targets to link against target `tvm_ffi` to be effective."
-  OFF
-)
 option(TVM_FFI_USE_LIBBACKTRACE "Enable libbacktrace" ON)
 option(TVM_FFI_BACKTRACE_ON_SEGFAULT "Set signal handler to print traceback on segfault" ON)
 

--- a/ffi/include/tvm/ffi/base_details.h
+++ b/ffi/include/tvm/ffi/base_details.h
@@ -89,6 +89,13 @@
 #define TVM_FFI_FUNC_SIG __func__
 #endif
 
+#define TVM_FFI_STATIC_INIT_BLOCK_VAR_DEF \
+  static inline TVM_FFI_ATTRIBUTE_UNUSED int __##TVMFFIStaticInitReg
+
+/*! \brief helper macro to run code once during initialization */
+#define TVM_FFI_STATIC_INIT_BLOCK(Body) \
+  TVM_FFI_STR_CONCAT(TVM_FFI_STATIC_INIT_BLOCK_VAR_DEF, __COUNTER__) = []() { Body return 0; }()
+
 /*
  * \brief Define the default copy/move constructor and assign operator
  * \param TypeName The class typename.

--- a/ffi/include/tvm/ffi/cast.h
+++ b/ffi/include/tvm/ffi/cast.h
@@ -146,9 +146,9 @@ template <typename OptionalType, typename = std::enable_if_t<is_optional_type_v<
 inline OptionalType Downcast(const std::optional<Any>& ref) {
   if (ref.has_value()) {
     if constexpr (std::is_same_v<OptionalType, Any>) {
-      return ref.value();
+      return *ref;
     } else {
-      return ref.value().cast<OptionalType>();
+      return (*ref).cast<OptionalType>();
     }
   } else {
     return OptionalType(std::nullopt);

--- a/ffi/include/tvm/ffi/function.h
+++ b/ffi/include/tvm/ffi/function.h
@@ -408,7 +408,7 @@ class Function : public ObjectRef {
     if (!res.has_value()) {
       TVM_FFI_THROW(ValueError) << "Function " << name << " not found";
     }
-    return res.value();
+    return *res;
   }
 
   static Function GetGlobalRequired(const std::string& name) {

--- a/ffi/include/tvm/ffi/optional.h
+++ b/ffi/include/tvm/ffi/optional.h
@@ -271,7 +271,7 @@ class Optional<T, std::enable_if_t<use_ptr_based_optional_v<T>>> : public Object
   template <typename U>
   TVM_FFI_INLINE auto EQToOptional(const U& other) const {
     // support case where sub-class returns a symbolic ref type.
-    using RetType = decltype(value() == other.value());
+    using RetType = decltype(operator*() == *other);
     if (same_as(other)) return RetType(true);
     if (has_value() && other.has_value()) {
       return operator*() == *other;
@@ -284,7 +284,7 @@ class Optional<T, std::enable_if_t<use_ptr_based_optional_v<T>>> : public Object
   template <typename U>
   TVM_FFI_INLINE auto NEToOptional(const U& other) const {
     // support case where sub-class returns a symbolic ref type.
-    using RetType = decltype(value() != other.value());
+    using RetType = decltype(operator*() != *other);
     if (same_as(other)) return RetType(false);
     if (has_value() && other.has_value()) {
       return operator*() != *other;

--- a/ffi/include/tvm/ffi/type_traits.h
+++ b/ffi/include/tvm/ffi/type_traits.h
@@ -566,7 +566,7 @@ template <typename ObjectRefType, typename... FallbackTypes>
 struct ObjectRefWithFallbackTraitsBase : public ObjectRefTypeTraitsBase<ObjectRefType> {
   static TVM_FFI_INLINE std::optional<ObjectRefType> TryCastFromAnyView(const TVMFFIAny* src) {
     if (auto opt_obj = ObjectRefTypeTraitsBase<ObjectRefType>::TryCastFromAnyView(src)) {
-      return opt_obj.value();
+      return *opt_obj;
     }
     // apply fallback types in TryCastFromAnyView
     return TryFallbackTypes<FallbackTypes...>(src);

--- a/ffi/src/ffi/error.cc
+++ b/ffi/src/ffi/error.cc
@@ -54,7 +54,7 @@ class SafeCallContext {
 }  // namespace ffi
 }  // namespace tvm
 
-void TVMFFIErrorSetRaisedByCStr(const char* kind, const char* message) {
+void TVMFFIErrorSetRaisedFromCStr(const char* kind, const char* message) {
   // NOTE: run traceback here to simplify the depth of tracekback
   tvm::ffi::SafeCallContext::ThreadLocal()->SetRaisedByCstr(kind, message, TVM_FFI_TRACEBACK_HERE);
 }

--- a/ffi/src/ffi/function.cc
+++ b/ffi/src/ffi/function.cc
@@ -24,11 +24,11 @@
 #include <tvm/ffi/c_api.h>
 #include <tvm/ffi/cast.h>
 #include <tvm/ffi/container/array.h>
+#include <tvm/ffi/container/map.h>
 #include <tvm/ffi/error.h>
 #include <tvm/ffi/function.h>
+#include <tvm/ffi/memory.h>
 #include <tvm/ffi/string.h>
-
-#include <unordered_map>
 
 namespace tvm {
 namespace ffi {
@@ -47,26 +47,68 @@ namespace ffi {
  */
 class GlobalFunctionTable {
  public:
+  // Note: this class is hidden from the public API, so we just
+  // use it as a private class as ObjectRef
+  class Entry : public Object, public TVMFFIMethodInfo {
+   public:
+    String name_data;
+    String doc_data;
+    String type_schema_data;
+    ffi::Function func_data;
+
+    explicit Entry(const TVMFFIMethodInfo* method_info) {
+      // make copy of the metadata
+      name_data = String(method_info->name.data, method_info->name.size);
+      doc_data = String(method_info->doc.data, method_info->doc.size);
+      type_schema_data = String(method_info->type_schema.data, method_info->type_schema.size);
+      func_data = AnyView::CopyFromTVMFFIAny(method_info->method).cast<ffi::Function>();
+      this->SyncMethodInfo(method_info->flags);
+      // no need to update method pointer as it would remain the same as func and we retained
+    }
+    explicit Entry(String name, ffi::Function func) : name_data(name), func_data(func) {
+      this->SyncMethodInfo(kTVMFFIFieldFlagBitMaskIsStaticMethod);
+    }
+
+   private:
+    void SyncMethodInfo(int64_t flags) {
+      this->flags = flags;
+      this->name = TVMFFIByteArray{name_data.data(), name_data.size()};
+      this->doc = TVMFFIByteArray{doc_data.data(), doc_data.size()};
+      this->type_schema = TVMFFIByteArray{type_schema_data.data(), type_schema_data.size()};
+    }
+  };
+
   void Update(const String& name, Function func, bool can_override) {
     if (table_.count(name)) {
       if (!can_override) {
         TVM_FFI_THROW(RuntimeError) << "Global Function `" << name << "` is already registered";
       }
     }
-    table_[name] = new Function(func);
+    table_.Set(name, ObjectRef(make_object<Entry>(name, func)));
+  }
+
+  void Update(const TVMFFIMethodInfo* method_info, bool can_override) {
+    String name(method_info->name.data, method_info->name.size);
+    if (table_.count(name)) {
+      if (!can_override) {
+        TVM_FFI_THROW(RuntimeError) << "Global Function `" << name << "` is already registered";
+      }
+    }
+    table_.Set(name, ObjectRef(make_object<Entry>(method_info)));
   }
 
   bool Remove(const String& name) {
     auto it = table_.find(name);
     if (it == table_.end()) return false;
-    table_.erase(it);
+    table_.erase(name);
     return true;
   }
 
-  const Function* Get(const String& name) {
+  const Entry* Get(const String& name) {
     auto it = table_.find(name);
     if (it == table_.end()) return nullptr;
-    return it->second;
+    const Object* obj = (*it).second.cast<const Object*>();
+    return static_cast<const Entry*>(obj);
   }
 
   Array<String> ListNames() const {
@@ -89,9 +131,7 @@ class GlobalFunctionTable {
   }
 
  private:
-  // deliberately track function pointer without recycling
-  // to avoid
-  std::unordered_map<String, Function*> table_;
+  Map<String, Any> table_;
 };
 
 /*!
@@ -143,7 +183,7 @@ class EnvCAPIRegistry {
   }
 
   // register environment(e.g. python) specific api functions
-  void Register(const std::string& symbol_name, void* fptr) {
+  void Register(const String& symbol_name, void* fptr) {
     if (symbol_name == "PyErr_CheckSignals") {
       Update(symbol_name, &pyerr_check_signals, fptr);
     } else if (symbol_name == "PyGILState_Ensure") {
@@ -155,7 +195,6 @@ class EnvCAPIRegistry {
     }
   }
 
-  // implementation of tvm::runtime::EnvCheckSignals
   int EnvCheckSignals() {
     // check python signal to see if there are exception raised
     if (pyerr_check_signals != nullptr) {
@@ -225,13 +264,20 @@ int TVMFFIFunctionSetGlobal(const TVMFFIByteArray* name, TVMFFIObjectHandle f, i
   TVM_FFI_SAFE_CALL_END();
 }
 
+int TVMFFIFunctionSetGlobalFromMethodInfo(const TVMFFIMethodInfo* method_info, int override) {
+  using namespace tvm::ffi;
+  TVM_FFI_SAFE_CALL_BEGIN();
+  GlobalFunctionTable::Global()->Update(method_info, override != 0);
+  TVM_FFI_SAFE_CALL_END();
+}
+
 int TVMFFIFunctionGetGlobal(const TVMFFIByteArray* name, TVMFFIObjectHandle* out) {
   using namespace tvm::ffi;
   TVM_FFI_SAFE_CALL_BEGIN();
   String name_str(name->data, name->size);
-  const Function* fp = GlobalFunctionTable::Global()->Get(name_str);
+  const GlobalFunctionTable::Entry* fp = GlobalFunctionTable::Global()->Get(name_str);
   if (fp != nullptr) {
-    tvm::ffi::Function func(*fp);
+    tvm::ffi::Function func(fp->func_data);
     *out = tvm::ffi::details::ObjectUnsafe::MoveObjectRefToTVMFFIObjectPtr(std::move(func));
   } else {
     *out = nullptr;
@@ -256,7 +302,7 @@ int TVMFFIEnvCheckSignals() { return tvm::ffi::EnvCAPIRegistry::Global()->EnvChe
  */
 int TVMFFIEnvRegisterCAPI(const TVMFFIByteArray* name, void* symbol) {
   TVM_FFI_SAFE_CALL_BEGIN();
-  std::string s_name(name->data, name->size);
+  tvm::ffi::String s_name(name->data, name->size);
   tvm::ffi::EnvCAPIRegistry::Global()->Register(s_name, symbol);
   TVM_FFI_SAFE_CALL_END();
 }

--- a/ffi/src/ffi/traceback.cc
+++ b/ffi/src/ffi/traceback.cc
@@ -59,13 +59,14 @@ static backtrace_state* _bt_state = BacktraceCreate();
 std::string DemangleName(std::string name) {
   int status = 0;
   size_t length = name.size();
-  std::unique_ptr<char, void (*)(void* __ptr)> demangled_name = {
-      abi::__cxa_demangle(name.c_str(), nullptr, &length, &status), &std::free};
+  char* demangled_name = abi::__cxa_demangle(name.c_str(), nullptr, &length, &status);
   if (demangled_name && status == 0 && length > 0) {
-    return demangled_name.get();
-  } else {
-    return name;
+    name = demangled_name;
   }
+  if (demangled_name) {
+    std::free(demangled_name);
+  }
+  return name;
 }
 
 void BacktraceErrorCallback(void*, const char*, int) {

--- a/ffi/src/ffi/traceback.h
+++ b/ffi/src/ffi/traceback.h
@@ -84,7 +84,7 @@ inline bool ShouldExcludeFrame(const char* filename, const char* symbol) {
       return true;
     }
   }
-  if (strncmp(symbol, "TVMFFIErrorSetRaisedByCStr", 26) == 0) {
+  if (strncmp(symbol, "TVMFFIErrorSetRaisedFromCStr", 28) == 0) {
     return true;
   }
   // libffi.so stack frames.  These may also show up as numeric

--- a/ffi/tests/cpp/test_reflection.cc
+++ b/ffi/tests/cpp/test_reflection.cc
@@ -25,32 +25,37 @@
 #include "./testing_object.h"
 
 namespace {
+
 using namespace tvm::ffi;
 using namespace tvm::ffi::testing;
-
-TVM_FFI_REFLECTION_DEF(TFloatObj)
-    .def_rw("value", &TFloatObj::value, "float value field", refl::DefaultValue(10.0))
-    .def("sub", [](const TFloatObj* self, double other) -> double { return self->value - other; })
-    .def("add", &TFloatObj::Add, "add method");
-
-TVM_FFI_REFLECTION_DEF(TIntObj)
-    .def_ro("value", &TIntObj::value)
-    .def_static("static_add", &TInt::StaticAdd, "static add method");
-
-TVM_FFI_REFLECTION_DEF(TPrimExprObj)
-    .def_ro("dtype", &TPrimExprObj::dtype, "dtype field", refl::DefaultValue("float"))
-    .def_ro("value", &TPrimExprObj::value, "value field", refl::DefaultValue(0))
-    .def("sub", [](TPrimExprObj* self, double other) -> double {
-      // this is ok because TPrimExprObj is declared asmutable
-      return self->value - other;
-    });
 
 struct A : public Object {
   int64_t x;
   int64_t y;
 };
 
-TVM_FFI_REFLECTION_DEF(A).def_ro("x", &A::x).def_rw("y", &A::y);
+TVM_FFI_STATIC_INIT_BLOCK({
+  namespace refl = tvm::ffi::reflection;
+
+  refl::ObjectDef<TFloatObj>()
+      .def_rw("value", &TFloatObj::value, "float value field", refl::DefaultValue(10.0))
+      .def("sub", [](const TFloatObj* self, double other) -> double { return self->value - other; })
+      .def("add", &TFloatObj::Add, "add method");
+
+  refl::ObjectDef<TIntObj>()
+      .def_ro("value", &TIntObj::value)
+      .def_static("static_add", &TInt::StaticAdd, "static add method");
+
+  refl::ObjectDef<TPrimExprObj>()
+      .def_ro("dtype", &TPrimExprObj::dtype, "dtype field", refl::DefaultValue("float"))
+      .def_ro("value", &TPrimExprObj::value, "value field", refl::DefaultValue(0))
+      .def("sub", [](TPrimExprObj* self, double other) -> double {
+        // this is ok because TPrimExprObj is declared asmutable
+        return self->value - other;
+      });
+
+  refl::ObjectDef<A>().def_ro("x", &A::x).def_rw("y", &A::y);
+});
 
 TEST(Reflection, GetFieldByteOffset) {
   EXPECT_EQ(reflection::GetFieldByteOffsetToObject(&A::x), sizeof(TVMFFIObject));
@@ -77,36 +82,36 @@ TEST(Reflection, FieldSetter) {
 
 TEST(Reflection, FieldInfo) {
   const TVMFFIFieldInfo* info_int = reflection::GetFieldInfo("test.Int", "value");
-  EXPECT_FALSE(info_int->flags & TVMFFIFieldFlagBitMaskHasDefault);
-  EXPECT_FALSE(info_int->flags & TVMFFIFieldFlagBitMaskWritable);
+  EXPECT_FALSE(info_int->flags & kTVMFFIFieldFlagBitMaskHasDefault);
+  EXPECT_FALSE(info_int->flags & kTVMFFIFieldFlagBitMaskWritable);
   EXPECT_EQ(Bytes(info_int->doc).operator std::string(), "");
 
   const TVMFFIFieldInfo* info_float = reflection::GetFieldInfo("test.Float", "value");
   EXPECT_EQ(info_float->default_value.v_float64, 10.0);
-  EXPECT_TRUE(info_float->flags & TVMFFIFieldFlagBitMaskHasDefault);
-  EXPECT_TRUE(info_float->flags & TVMFFIFieldFlagBitMaskWritable);
+  EXPECT_TRUE(info_float->flags & kTVMFFIFieldFlagBitMaskHasDefault);
+  EXPECT_TRUE(info_float->flags & kTVMFFIFieldFlagBitMaskWritable);
   EXPECT_EQ(Bytes(info_float->doc).operator std::string(), "float value field");
 
   const TVMFFIFieldInfo* info_prim_expr_dtype = reflection::GetFieldInfo("test.PrimExpr", "dtype");
   AnyView default_value = AnyView::CopyFromTVMFFIAny(info_prim_expr_dtype->default_value);
   EXPECT_EQ(default_value.cast<String>(), "float");
   EXPECT_EQ(default_value.as<String>().value().use_count(), 2);
-  EXPECT_TRUE(info_prim_expr_dtype->flags & TVMFFIFieldFlagBitMaskHasDefault);
-  EXPECT_FALSE(info_prim_expr_dtype->flags & TVMFFIFieldFlagBitMaskWritable);
+  EXPECT_TRUE(info_prim_expr_dtype->flags & kTVMFFIFieldFlagBitMaskHasDefault);
+  EXPECT_FALSE(info_prim_expr_dtype->flags & kTVMFFIFieldFlagBitMaskWritable);
   EXPECT_EQ(Bytes(info_prim_expr_dtype->doc).operator std::string(), "dtype field");
 }
 
 TEST(Reflection, MethodInfo) {
   const TVMFFIMethodInfo* info_int_static_add = reflection::GetMethodInfo("test.Int", "static_add");
-  EXPECT_TRUE(info_int_static_add->flags & TVMFFIFieldFlagBitMaskIsStaticMethod);
+  EXPECT_TRUE(info_int_static_add->flags & kTVMFFIFieldFlagBitMaskIsStaticMethod);
   EXPECT_EQ(Bytes(info_int_static_add->doc).operator std::string(), "static add method");
 
   const TVMFFIMethodInfo* info_float_add = reflection::GetMethodInfo("test.Float", "add");
-  EXPECT_FALSE(info_float_add->flags & TVMFFIFieldFlagBitMaskIsStaticMethod);
+  EXPECT_FALSE(info_float_add->flags & kTVMFFIFieldFlagBitMaskIsStaticMethod);
   EXPECT_EQ(Bytes(info_float_add->doc).operator std::string(), "add method");
 
   const TVMFFIMethodInfo* info_float_sub = reflection::GetMethodInfo("test.Float", "sub");
-  EXPECT_FALSE(info_float_sub->flags & TVMFFIFieldFlagBitMaskIsStaticMethod);
+  EXPECT_FALSE(info_float_sub->flags & kTVMFFIFieldFlagBitMaskIsStaticMethod);
   EXPECT_EQ(Bytes(info_float_sub->doc).operator std::string(), "");
 }
 

--- a/src/runtime/library_module.cc
+++ b/src/runtime/library_module.cc
@@ -83,7 +83,7 @@ void InitContextFunctions(std::function<void*(const char*)> fgetsymbol) {
   }
   // Initialize the functions
   TVM_INIT_CONTEXT_FUNC(TVMFFIFunctionCall);
-  TVM_INIT_CONTEXT_FUNC(TVMFFIErrorSetRaisedByCStr);
+  TVM_INIT_CONTEXT_FUNC(TVMFFIErrorSetRaisedFromCStr);
   TVM_INIT_CONTEXT_FUNC(TVMBackendGetFuncFromEnv);
   TVM_INIT_CONTEXT_FUNC(TVMBackendAllocWorkspace);
   TVM_INIT_CONTEXT_FUNC(TVMBackendFreeWorkspace);

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -109,7 +109,7 @@ class ParallelLauncher {
         par_errors_[i] = nullptr;
       }
     }
-    TVMFFIErrorSetRaisedByCStr("RuntimeError", os.str().c_str());
+    TVMFFIErrorSetRaisedFromCStr("RuntimeError", os.str().c_str());
     return -1;
   }
   // Signal that one job has finished.

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -119,7 +119,7 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target,
   //                    TVMFFIAny* result);
   ftype_tvm_ffi_func_call_ = ftype_tvm_ffi_c_func_;
   // Defined in include/tvm/ffi/c_api.h:
-  // void TVMFFIErrorSetRaisedByCStr(const char *kind, const char* msg);
+  // void TVMFFIErrorSetRaisedFromCStr(const char *kind, const char* msg);
   ftype_tvm_ffi_error_set_raised_by_c_str_ = llvm::FunctionType::get(
       t_void_, {llvmGetPointerTo(t_char_, 0), llvmGetPointerTo(t_char_, 0)}, false);
   // Defined in include/tvm/runtime/c_backend_api.h:
@@ -158,7 +158,7 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target,
                                "TVMFFIFunctionCall", module_.get());
     f_tvm_ffi_set_raised_by_c_str_ = llvm::Function::Create(
         ftype_tvm_ffi_error_set_raised_by_c_str_, llvm::Function::ExternalLinkage,
-        "TVMFFIErrorSetRaisedByCStr", module_.get());
+        "TVMFFIErrorSetRaisedFromCStr", module_.get());
     f_tvm_get_func_from_env_ =
         llvm::Function::Create(ftype_tvm_get_func_from_env_, llvm::Function::ExternalLinkage,
                                "TVMBackendGetFuncFromEnv", module_.get());
@@ -449,7 +449,7 @@ void CodeGenCPU::InitGlobalContext(bool dynamic_lookup) {
                                                  "__TVMBackendGetFuncFromEnv");
       gv_tvm_ffi_set_last_error_c_str_ =
           InitContextPtr(llvmGetPointerTo(ftype_tvm_ffi_error_set_raised_by_c_str_, 0),
-                         "__TVMFFIErrorSetRaisedByCStr");
+                         "__TVMFFIErrorSetRaisedFromCStr");
       gv_tvm_parallel_launch_ = InitContextPtr(llvmGetPointerTo(ftype_tvm_parallel_launch_, 0),
                                                "__TVMBackendParallelLaunch");
       gv_tvm_parallel_barrier_ = InitContextPtr(llvmGetPointerTo(ftype_tvm_parallel_barrier_, 0),
@@ -937,7 +937,7 @@ llvm::Value* CodeGenCPU::RuntimeTVMGetFuncFromEnv() {
   if (f_tvm_get_func_from_env_ != nullptr) return f_tvm_get_func_from_env_;
   return GetContextPtr(gv_tvm_get_func_from_env_);
 }
-llvm::Value* CodeGenCPU::RuntimeTVMFFIErrorSetRaisedByCStr() {
+llvm::Value* CodeGenCPU::RuntimeTVMFFIErrorSetRaisedFromCStr() {
   if (f_tvm_ffi_set_raised_by_c_str_ != nullptr) return f_tvm_ffi_set_raised_by_c_str_;
   return GetContextPtr(gv_tvm_ffi_set_last_error_c_str_);
 }
@@ -1064,9 +1064,9 @@ void CodeGenCPU::VisitStmt_(const AssertStmtNode* op) {
 
 #if TVM_LLVM_VERSION >= 90
   auto err_callee = llvm::FunctionCallee(ftype_tvm_ffi_error_set_raised_by_c_str_,
-                                         RuntimeTVMFFIErrorSetRaisedByCStr());
+                                         RuntimeTVMFFIErrorSetRaisedFromCStr());
 #else
-  auto err_callee = RuntimeTVMFFIErrorSetRaisedByCStr();
+  auto err_callee = RuntimeTVMFFIErrorSetRaisedFromCStr();
 #endif
   builder_->CreateCall(err_callee, {GetConstString("RuntimeError"), msg});
   builder_->CreateRet(ConstInt32(-1));

--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -117,7 +117,7 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::Value* GetContextPtr(llvm::GlobalVariable* gv);
   llvm::Value* RuntimeTVMFFIFunctionCall();
   llvm::Value* RuntimeTVMGetFuncFromEnv();
-  llvm::Value* RuntimeTVMFFIErrorSetRaisedByCStr();
+  llvm::Value* RuntimeTVMFFIErrorSetRaisedFromCStr();
   llvm::Value* RuntimeTVMParallelLaunch();
   llvm::Value* RuntimeTVMParallelBarrier();
   llvm::Value* CreateStaticHandle();

--- a/src/target/source/codegen_c_host.cc
+++ b/src/target/source/codegen_c_host.cc
@@ -319,7 +319,7 @@ void CodeGenCHost::VisitStmt_(const AssertStmtNode* op) {  // NOLINT(*)
     stream << "if (!(" << cond << ")) {\n";
     int assert_if_scope = this->BeginScope();
     PrintIndent();
-    stream << "TVMFFIErrorSetRaisedByCStr(\"RuntimeError\", \""
+    stream << "TVMFFIErrorSetRaisedFromCStr(\"RuntimeError\", \""
            << op->message.as<StringImmNode>()->value << "\", NULL);\n";
     PrintIndent();
     stream << "return -1;\n";

--- a/web/src/ctypes.ts
+++ b/web/src/ctypes.ts
@@ -153,9 +153,9 @@ export type FTVMFFITypeKeyToIndex = (type_key: Pointer, out_tindex: Pointer) => 
 export type FTVMFFIAnyViewToOwnedAny = (any_view: Pointer, out: Pointer) => number;
 
 /**
- * void TVMFFIErrorSetRaisedByCStr(const char* kind, const char* message);
+ * void TVMFFIErrorSetRaisedFromCStr(const char* kind, const char* message);
  */
-export type FTVMFFIErrorSetRaisedByCStr = (kind: Pointer, message: Pointer) => void;
+export type FTVMFFIErrorSetRaisedFromCStr = (kind: Pointer, message: Pointer) => void;
 
 /**
  * int TVMFFIFunctionSetGlobal(const TVMFFIByteArray* name, TVMFFIObjectHandle f,

--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -2139,7 +2139,7 @@ export class Instance implements Disposable {
         const errMsgOffset = stack.allocRawBytes(errMsg.length + 1);
         stack.storeRawBytes(errMsgOffset, StringToUint8Array(errMsg));
         stack.commitToWasmMemory();
-        (this.lib.exports.FTVMFFIErrorSetRaisedByCStr as ctypes.FTVMFFIErrorSetRaisedByCStr)(
+        (this.lib.exports.FTVMFFIErrorSetRaisedFromCStr as ctypes.FTVMFFIErrorSetRaisedFromCStr)(
           stack.ptrFromOffset(errKindOffset),
           stack.ptrFromOffset(errMsgOffset)
         );


### PR DESCRIPTION
This PR updates the FFI type registry structures and API to be future compatible to reflection needs.

- Introduce TVM_FFI_STATIC_INIT_BLOCK for all registration purposes.
- Updates the MethodInfo and FieldInfo to contain complete ABI information.
- Removes the dependency on unordered_map in the registry.
- Updates TVMFFIErrorSetRaisedByCStr to TVMFFIErrorSetRaisedFromCStr to be more idiomatic