### PR TITLE
[Relax][ONNX] Update ReduceL1 to opset 18

### DIFF
--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -1503,24 +1503,24 @@ def test_embedlayernormalization():
     )
 
 
-def create_reduce_test_parameters():
+def create_reduce_test_parameters_axes_attr():
     output = []
     for value in [True, False]:
-        output.append(("ReduceMax", value))
-        output.append(("ReduceMean", value))
-        output.append(("ReduceMin", value))
-        output.append(("ReduceProd", value))
-        output.append(("ReduceSum", value))
-        output.append(("ReduceSumSquare", value))
-        output.append(("ReduceLogSum", value))
-        output.append(("ReduceLogSumExp", value))
-        output.append(("ReduceL1", value))
-        output.append(("ReduceL2", value))
+        output.append(("ReduceMax", value, 11))
+        output.append(("ReduceMean", value, 13))
+        output.append(("ReduceMin", value, 11))
+        output.append(("ReduceProd", value, 13))
+        output.append(("ReduceSum", value, 11))
+        output.append(("ReduceSumSquare", value, 13))
+        output.append(("ReduceLogSum", value, 13))
+        output.append(("ReduceLogSumExp", value, 13))
+        output.append(("ReduceL1", value, 13))
+        output.append(("ReduceL2", value, 13))
     return output
 
 
-@pytest.mark.parametrize("func, dynamic", create_reduce_test_parameters())
-def test_all_reduce_funcs(func, dynamic):
+@pytest.mark.parametrize("func, dynamic, opset", create_reduce_test_parameters_axes_attr())
+def test_all_reduce_funcs_axes_attr(func, dynamic, opset):
     def verify_reduce_func(func, data, axis, keepdims):
         inshape = data.shape
         outshape = np.sum(data, axis=axis, keepdims=keepdims == 1).shape
@@ -1549,7 +1549,7 @@ def test_all_reduce_funcs(func, dynamic):
 
         inputs_dict = {"x": data}
         # Reduction ops accumulate arithmetic errors, so we use a higher tolerance.
-        check_correctness(model, inputs_dict, opset=11, rtol=1e-4, atol=1e-4)
+        check_correctness(model, inputs_dict, opset=opset, rtol=1e-4, atol=1e-4)
 
     for keepdims in [True, False]:
         verify_reduce_func(
@@ -1574,6 +1574,131 @@ def test_all_reduce_funcs(func, dynamic):
 
         verify_reduce_func(
             func, np.random.randn(1, 3, 4, 1).astype(np.float32), axis=(1,), keepdims=keepdims
+        )
+
+
+def create_reduce_test_parameters_axes_input():
+    output = []
+    for dynamic in [True, False]:
+        # TODO(@vacu9708): Enable the tests after implementing other reduce ops
+        # output.append(("ReduceMax", dynamic, 20))
+        # output.append(("ReduceMean", dynamic, 18))
+        # output.append(("ReduceMin", dynamic, 20))
+        # output.append(("ReduceProd", dynamic, 18))
+        # output.append(("ReduceSum", dynamic, 13))
+        # output.append(("ReduceSumSquare", dynamic, 18))
+        # output.append(("ReduceLogSum", dynamic, 18))
+        # output.append(("ReduceLogSumExp", dynamic, 18))
+        output.append(("ReduceL1", dynamic, 18))
+        # output.append(("ReduceL2", dynamic, 18))
+    return output
+
+
+@pytest.mark.parametrize("func, dynamic, opset", create_reduce_test_parameters_axes_input())
+def test_all_reduce_funcs_axes_input(func, dynamic, opset):
+    def verify_reduce_func(func, data, axes, keepdims, noop_with_empty_axes):
+        inshape = data.shape
+
+        inputs = ["x"]
+        initializers = []
+
+        # Optional `axes` input
+        if axes is not None:
+            axes_name = "reduce_axes"
+            axes_np = np.asarray(axes, dtype=np.int64)
+            axes_init = helper.make_tensor(
+                name=axes_name,
+                data_type=TensorProto.INT64,
+                dims=axes_np.shape,
+                vals=axes_np,
+            )
+            initializers.append(axes_init)
+            inputs.append(axes_name)
+
+        # Determine input and output shapes
+        if not axes and not noop_with_empty_axes:
+            outshape = np.sum(data, axis=None, keepdims=keepdims).shape
+        elif not axes and noop_with_empty_axes:
+            outshape = inshape
+        else:
+            outshape = np.sum(data, axis=axes, keepdims=keepdims).shape
+
+        if dynamic:
+            in_list = ["?"] * len(inshape)
+            out_list = ["?"] * len(outshape)
+        else:
+            in_list = list(inshape)
+            out_list = list(outshape)
+
+        # Make a model node
+        node = helper.make_node(
+            func,
+            inputs=inputs,
+            outputs=["y"],
+            keepdims=keepdims,
+            noop_with_empty_axes=noop_with_empty_axes,
+        )
+
+        # Make a model graph and a model
+        graph = helper.make_graph(
+            [node],
+            "reduce18_test",
+            inputs=[helper.make_tensor_value_info("x", TensorProto.FLOAT, in_list)],
+            initializer=initializers,
+            outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, out_list)],
+        )
+        model = helper.make_model(graph, producer_name="reduce18_test")
+
+        # Run TVM importer vs onnxruntime
+        inputs_dict = {"x": data}
+        check_correctness(model, inputs_dict, opset=opset, rtol=1e-4, atol=1e-4)
+
+    # Verify
+    for keepdims in [True, False]:
+        # no `axes` input && `noop_with_empty_axes` = 0 -> reduce over all dimensions.
+        verify_reduce_func(
+            func,
+            np.random.randn(3, 2, 2).astype(np.float32),
+            axes=[],
+            keepdims=keepdims,
+            noop_with_empty_axes=False,
+        )
+
+        # no `axes` input && `noop_with_empty_axes` = 0 -> reduce over all dimensions.
+        verify_reduce_func(
+            func,
+            np.random.randn(3, 2, 2).astype(np.float32),
+            axes=None,
+            keepdims=keepdims,
+            noop_with_empty_axes=False,
+        )
+
+        # no `axes` input && `noop_with_empty_axes` = 1 -> return the input unchanged.
+        verify_reduce_func(
+            func,
+            np.random.randn(4, 3).astype(np.float32),
+            axes=[],
+            keepdims=keepdims,
+            noop_with_empty_axes=True,
+        )
+
+        # no `axes` input && `noop_with_empty_axes` = 1 -> return the input unchanged.
+        # (onnxruntime bug) Runtime error on the onnxruntime part
+        # verify_reduce_func(
+        #     func,
+        #     np.random.randn(4, 3).astype(np.float32),
+        #     axes=None,
+        #     keepdims=keepdims,
+        #     noop_with_empty_axes=True,
+        # )
+
+        # `axes` provided -> reduce over specified axes.
+        verify_reduce_func(
+            func,
+            np.random.randn(3, 3, 3, 1).astype(np.float32),
+            axes=(1, 2),
+            keepdims=keepdims,
+            noop_with_empty_axes=True,
         )
 
 


### PR DESCRIPTION
# Summary
This PR resolves https://github.com/apache/tvm/issues/18032 where a valid onnx model causes an error in TVM but not in onnxruntime.
**Why the error occurs**
1. Starting in ReduceL1 - 18, `axes` is passed as an input rather than an attribute
2. `ReduceL1-13` receives a `None` axes and reduces all dimensions to size 1.
3. In `DepthToSpace`, dimension size(1) // block size(2) yields zero. As a result `manipulate.cc:860` becomes false and an error is triggered at `manipulate.cc:865`.

Anyway in summary, the error occurs because of the updated ReduceL1.

# Changes
- Update ReduceL1 from opset 13 to opset 18.
- Add corresponding test cases to cover the new behavior.

**Differences vs opset<18:**
- `axes` is now an input instead of an attribute.
- Introduces attribute `noop_with_empty_axes`

| Axes provided? | noop_with_empty_axes | Behavior |
|:-----:|:-----:|:----------------------------------------------:|
| No  | 0     | Reduce over **all** dimensions       |
| No  | 1     | Return the input **unchanged**       |
| Yes | any | Reduce over the **specified** axes |

# To do
- All other reduce ops in the ONNX spec have also been updated in the same way
  - I’ve already updated those reduce ops in TVM and will open a pull request for them once this one is merged
- The reduce ops(`relax.op.max/min/sum`, etc) in TVM currently support only constant axes
  - They need to support dynamic axes for full ONNX spec compliance

# Implementation in TVM
The official [ONNX spec](https://onnx.ai/onnx/operators/onnx__ReduceL1.html) ambiguously describes "empty axes" — it’s unclear whether it refers to `None` or to an empty list `[ ]`. However, the "Inputs" section states there can be one or two inputs and that axes is optional, thus I think interpreting "empty axes" as either `None` or `[ ]` aligns with the specification.

# Notes on a bug in ONNX Runtime
Opened issue https://github.com/microsoft/onnxruntime/issues/25095

| Axes list | noop_with_empty_axes | Behavior | Correct behavior |
|----------:|:----:|:-------------------------------------------:|:-------------------------------------------:|
| `[ ]`       | `1` | Returns the input **unchanged** | |
| `[ ]`       | `0` | Reduces **all** dimensions         | |
| `None` | `1` | Raises a **runtime error**            | Returns the input **unchanged** |
| `None` | `0` | Reduces **all** dimensions          | |
