### PR TITLE
[FFI] Optimize atomic decref in Object

### DIFF
--- a/ffi/include/tvm/ffi/base_details.h
+++ b/ffi/include/tvm/ffi/base_details.h
@@ -139,34 +139,6 @@ namespace tvm {
 namespace ffi {
 namespace details {
 
-/********** Atomic Operations *********/
-
-TVM_FFI_INLINE int32_t AtomicIncrementRelaxed(int32_t* ptr) {
-#ifdef _MSC_VER
-  return _InterlockedIncrement(reinterpret_cast<volatile long*>(ptr)) - 1;  // NOLINT(*)
-#else
-  return __atomic_fetch_add(ptr, 1, __ATOMIC_RELAXED);
-#endif
-}
-
-TVM_FFI_INLINE int32_t AtomicDecrementRelAcq(int32_t* ptr) {
-#ifdef _MSC_VER
-  return _InterlockedDecrement(reinterpret_cast<volatile long*>(ptr)) + 1;  // NOLINT(*)
-#else
-  return __atomic_fetch_sub(ptr, 1, __ATOMIC_ACQ_REL);
-#endif
-}
-
-TVM_FFI_INLINE int32_t AtomicLoadRelaxed(const int32_t* ptr) {
-  int32_t* raw_ptr = const_cast<int32_t*>(ptr);
-#ifdef _MSC_VER
-  // simply load the variable ptr out
-  return (reinterpret_cast<const volatile long*>(raw_ptr))[0];  // NOLINT(*)
-#else
-  return __atomic_load_n(raw_ptr, __ATOMIC_RELAXED);
-#endif
-}
-
 // for each iterator
 template <bool stop, std::size_t I, typename F>
 struct for_each_dispatcher {


### PR DESCRIPTION
This PR optimizations the atomic decref in Object so it only do release instead of release acquire. Acquire is only needed for deleter.