### PR TITLE
[FFI] Update typeinfo to speedup parent reflection

### DIFF
--- a/ffi/include/tvm/ffi/c_api.h
+++ b/ffi/include/tvm/ffi/c_api.h
@@ -437,7 +437,7 @@ typedef struct {
 /*!
  * \brief Runtime type information for object type checking.
  */
-typedef struct {
+typedef struct TVMFFITypeInfo {
   /*!
    *\brief The runtime type index,
    * It can be allocated during runtime if the type is dynamic.
@@ -452,7 +452,7 @@ typedef struct {
    * \note To keep things simple, we do not allow multiple inheritance so the
    *       hieracy stays as a tree
    */
-  const int32_t* type_acenstors;
+  const struct TVMFFITypeInfo** type_acenstors;
   // The following fields are used for reflection
   /*! \brief Cached hash value of the type key, used for consistent structural hashing. */
   uint64_t type_key_hash;

--- a/ffi/include/tvm/ffi/container/tuple.h
+++ b/ffi/include/tvm/ffi/container/tuple.h
@@ -253,8 +253,9 @@ struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types.
     }
     if constexpr (sizeof...(Rest) > 0) {
       return TryConvertElements<I + 1, Rest...>(std::move(arr));
+    } else {
+      return true;
     }
-    return true;
   }
 
   static TVM_FFI_INLINE std::string TypeStr() {

--- a/ffi/include/tvm/ffi/reflection/reflection.h
+++ b/ffi/include/tvm/ffi/reflection/reflection.h
@@ -392,6 +392,31 @@ inline Function GetMethod(std::string_view type_key, const char* method_name) {
   return AnyView::CopyFromTVMFFIAny(info->method).cast<Function>();
 }
 
+/*!
+ * \brief Visit each field info of the type info and run callback.
+ *
+ * \tparam Callback The callback function type.
+ *
+ * \param type_info The type info.
+ * \param callback The callback function.
+ *
+ * \note This function calls both the child and parent type info.
+ */
+template <typename Callback>
+inline void ForEachFieldInfo(const TypeInfo* type_info, Callback callback) {
+  // iterate through acenstors in parent to child order
+  // skip the first one since it is always the root object
+  for (int i = 1; i < type_info->type_depth; ++i) {
+    const TVMFFITypeInfo* parent_info = type_info->type_acenstors[i];
+    for (int j = 0; j < parent_info->num_fields; ++j) {
+      callback(parent_info->fields + j);
+    }
+  }
+  for (int i = 0; i < type_info->num_fields; ++i) {
+    callback(type_info->fields + i);
+  }
+}
+
 }  // namespace reflection
 }  // namespace ffi
 }  // namespace tvm

--- a/ffi/include/tvm/ffi/string.h
+++ b/ffi/include/tvm/ffi/string.h
@@ -255,6 +255,15 @@ class String : public ObjectRef {
    */
   String(std::string&& other)  // NOLINT(*)
       : ObjectRef(make_object<details::BytesObjStdImpl<StringObj>>(std::move(other))) {}
+
+  /*!
+   * \brief constructor from TVMFFIByteArray
+   *
+   * \param other a TVMFFIByteArray.
+   */
+  explicit String(TVMFFIByteArray other)
+      : ObjectRef(details::MakeInplaceBytes<StringObj>(other.data, other.size)) {}
+
   /*!
    * \brief Swap this String with another string
    * \param other The other string

--- a/ffi/tests/cpp/test_object.cc
+++ b/ffi/tests/cpp/test_object.cc
@@ -55,8 +55,8 @@ TEST(Object, TypeInfo) {
   EXPECT_TRUE(info != nullptr);
   EXPECT_EQ(info->type_index, TIntObj::RuntimeTypeIndex());
   EXPECT_EQ(info->type_depth, 2);
-  EXPECT_EQ(info->type_acenstors[0], Object::_type_index);
-  EXPECT_EQ(info->type_acenstors[1], TNumberObj::_type_index);
+  EXPECT_EQ(info->type_acenstors[0]->type_index, Object::_type_index);
+  EXPECT_EQ(info->type_acenstors[1]->type_index, TNumberObj::_type_index);
   EXPECT_GE(info->type_index, TypeIndex::kTVMFFIDynObjectBegin);
 }
 

--- a/ffi/tests/cpp/testing_object.h
+++ b/ffi/tests/cpp/testing_object.h
@@ -22,6 +22,7 @@
 
 #include <tvm/ffi/memory.h>
 #include <tvm/ffi/object.h>
+#include <tvm/ffi/reflection/reflection.h>
 #include <tvm/ffi/string.h>
 
 namespace tvm {
@@ -80,6 +81,15 @@ class TFloatObj : public TNumberObj {
   TFloatObj(double value) : value(value) {}
 
   double Add(double other) const { return value + other; }
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<TFloatObj>()
+        .def_ro("value", &TFloatObj::value, "float value field", refl::DefaultValue(10.0))
+        .def("sub",
+             [](const TFloatObj* self, double other) -> double { return self->value - other; })
+        .def("add", &TFloatObj::Add, "add method");
+  }
 
   static constexpr const char* _type_key = "test.Float";
   TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TFloatObj, TNumberObj);


### PR DESCRIPTION
This PR updates the typeinfo to speedup parent reflection Also optimizes a few if constexpr branches to explicitly place else to eliminate branch early in compilation.