### PR TITLE
[FFI] Provide Field Visit bridge so we can do gradual transition

### DIFF
--- a/ffi/include/tvm/ffi/reflection/reflection.h
+++ b/ffi/include/tvm/ffi/reflection/reflection.h
@@ -404,6 +404,8 @@ inline Function GetMethod(std::string_view type_key, const char* method_name) {
  */
 template <typename Callback>
 inline void ForEachFieldInfo(const TypeInfo* type_info, Callback callback) {
+  using ResultType = decltype(callback(type_info->fields));
+  static_assert(std::is_same_v<ResultType, void>, "Callback must return void");
   // iterate through acenstors in parent to child order
   // skip the first one since it is always the root object
   for (int i = 1; i < type_info->type_depth; ++i) {
@@ -415,6 +417,34 @@ inline void ForEachFieldInfo(const TypeInfo* type_info, Callback callback) {
   for (int i = 0; i < type_info->num_fields; ++i) {
     callback(type_info->fields + i);
   }
+}
+
+/*!
+ * \brief Visit each field info of the type info and run callback which returns bool for early stop.
+ *
+ * \tparam Callback The callback function type, which returns bool for early stop.
+ *
+ * \param type_info The type info.
+ * \param callback_with_early_stop The callback function.
+ * \return true if any of early stop is triggered.
+ *
+ * \note This function calls both the child and parent type info and can be used for searching.
+ */
+template <typename Callback>
+inline bool ForEachFieldInfoWithEarlyStop(const TypeInfo* type_info,
+                                          Callback callback_with_early_stop) {
+  // iterate through acenstors in parent to child order
+  // skip the first one since it is always the root object
+  for (int i = 1; i < type_info->type_depth; ++i) {
+    const TVMFFITypeInfo* parent_info = type_info->type_acenstors[i];
+    for (int j = 0; j < parent_info->num_fields; ++j) {
+      if (callback_with_early_stop(parent_info->fields + j)) return true;
+    }
+  }
+  for (int i = 0; i < type_info->num_fields; ++i) {
+    if (callback_with_early_stop(type_info->fields + i)) return true;
+  }
+  return false;
 }
 
 }  // namespace reflection

--- a/include/tvm/relax/attrs/ccl.h
+++ b/include/tvm/relax/attrs/ccl.h
@@ -24,54 +24,70 @@
 #ifndef TVM_RELAX_ATTRS_CCL_H_
 #define TVM_RELAX_ATTRS_CCL_H_
 
+#include <tvm/ffi/reflection/reflection.h>
 #include <tvm/relax/expr.h>
 
 namespace tvm {
 namespace relax {
 
 /*! \brief Attributes used in allreduce operators */
-struct AllReduceAttrs : public tvm::AttrsNode<AllReduceAttrs> {
+struct AllReduceAttrs : public tvm::AttrsNodeReflAdapter<AllReduceAttrs> {
   String op_type;
   bool in_group;
 
-  TVM_DECLARE_ATTRS(AllReduceAttrs, "relax.attrs.AllReduceAttrs") {
-    TVM_ATTR_FIELD(op_type).describe(
-        "The type of reduction operation to be applied to the input data. Now only sum is "
-        "supported.");
-    TVM_ATTR_FIELD(in_group).describe(
-        "Whether the reduction operation performs in group or globally or in group as default.");
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<AllReduceAttrs>()
+        .def_ro("op_type", &AllReduceAttrs::op_type,
+                "The type of reduction operation to be applied to the input data. Now only sum is "
+                "supported.")
+        .def_ro("in_group", &AllReduceAttrs::in_group,
+                "Whether the reduction operation performs in group or globally or in group as "
+                "default.");
   }
+
+  static constexpr const char* _type_key = "relax.attrs.AllReduceAttrs";
+  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AllReduceAttrs, BaseAttrsNode);
 };  // struct AllReduceAttrs
 
 /*! \brief Attributes used in allgather operators */
-struct AllGatherAttrs : public tvm::AttrsNode<AllGatherAttrs> {
+struct AllGatherAttrs : public tvm::AttrsNodeReflAdapter<AllGatherAttrs> {
   int num_workers;
   bool in_group;
 
-  TVM_DECLARE_ATTRS(AllGatherAttrs, "relax.attrs.AllGatherAttrs") {
-    TVM_ATTR_FIELD(num_workers)
-        .describe(
-            "The number of workers, also the number of parts the given buffer should be chunked "
-            "into.");
-    TVM_ATTR_FIELD(in_group).describe(
-        "Whether the allgather operation performs in group or globally or in group as default.");
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<AllGatherAttrs>()
+        .def_ro("num_workers", &AllGatherAttrs::num_workers,
+                "The number of workers, also the number of parts the given buffer should be "
+                "chunked into.")
+        .def_ro("in_group", &AllGatherAttrs::in_group,
+                "Whether the allgather operation performs in group or globally or in group as "
+                "default.");
   }
+
+  static constexpr const char* _type_key = "relax.attrs.AllGatherAttrs";
+  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AllGatherAttrs, BaseAttrsNode);
 };  // struct AllGatherAttrs
 
 /*! \brief Attributes used in scatter operators */
-struct ScatterCollectiveAttrs : public tvm::AttrsNode<ScatterCollectiveAttrs> {
+struct ScatterCollectiveAttrs : public tvm::AttrsNodeReflAdapter<ScatterCollectiveAttrs> {
   int num_workers;
   int axis;
 
-  TVM_DECLARE_ATTRS(ScatterCollectiveAttrs, "relax.attrs.ScatterCollectiveAttrs") {
-    TVM_ATTR_FIELD(num_workers)
-        .describe(
-            "The number of workers, also the number of parts the given buffer should be chunked "
-            "into.");
-    TVM_ATTR_FIELD(axis).describe(
-        "The axis of the tensor to be scattered. The tensor will be chunked along "
-        "this axis.");
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<ScatterCollectiveAttrs>()
+        .def_ro("num_workers", &ScatterCollectiveAttrs::num_workers,
+                "The number of workers, also the number of parts the given buffer should be "
+                "chunked into.")
+        .def_ro("axis", &ScatterCollectiveAttrs::axis,
+                "The axis of the tensor to be scattered. The tensor will be chunked along "
+                "this axis.");
   }
+
+  static constexpr const char* _type_key = "relax.attrs.ScatterCollectiveAttrs";
+  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ScatterCollectiveAttrs, BaseAttrsNode);
 };  // struct ScatterCollectiveAttrs
 
 }  // namespace relax

--- a/src/contrib/msc/core/ir/graph_builder.cc
+++ b/src/contrib/msc/core/ir/graph_builder.cc
@@ -50,7 +50,7 @@ void FuncAttrGetter::VisitExpr_(const CallNode* op) {
   if (op->attrs.defined()) {
     Map<String, String> attrs;
     AttrGetter getter(&attrs);
-    const_cast<BaseAttrsNode*>(op->attrs.get())->VisitAttrs(&getter);
+    getter(op->attrs);
     for (const auto& pair : attrs) {
       if (attrs_.count(pair.first)) {
         int cnt = 1;
@@ -350,7 +350,7 @@ const MSCJoint GraphBuilder::AddNode(const Expr& expr, const Optional<Expr>& bin
       attrs = FuncAttrGetter().GetAttrs(call_node->op);
     } else if (call_node->attrs.defined()) {
       AttrGetter getter(&attrs);
-      const_cast<BaseAttrsNode*>(call_node->attrs.get())->VisitAttrs(&getter);
+      getter(call_node->attrs);
     }
   } else if (const auto* const_node = expr.as<ConstantNode>()) {
     if (const_node->is_scalar()) {

--- a/src/contrib/msc/core/ir/graph_builder.h
+++ b/src/contrib/msc/core/ir/graph_builder.h
@@ -25,6 +25,7 @@
 #define TVM_CONTRIB_MSC_CORE_IR_GRAPH_BUILDER_H_
 
 #include <dmlc/json.h>
+#include <tvm/ffi/reflection/reflection.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/runtime/ndarray.h>
@@ -106,13 +107,64 @@ struct MSCRBuildConfig {
   }
 };
 
-class AttrGetter : public AttrVisitor {
+class AttrGetter : private AttrVisitor {
  public:
   /*!
    * \brief Get the attributes as Map<String, String>
    * \param attrs the attributes.
    */
   explicit AttrGetter(Map<String, String>* attrs) : attrs_(attrs) {}
+
+  void operator()(const Attrs& attrs) {
+    // dispatch between new reflection and old reflection
+    const TVMFFITypeInfo* attrs_tinfo = TVMFFIGetTypeInfo(attrs->type_index());
+    if (attrs_tinfo->extra_info != nullptr) {
+      tvm::ffi::reflection::ForEachFieldInfo(attrs_tinfo, [&](const TVMFFIFieldInfo* field_info) {
+        Any field_value = tvm::ffi::reflection::FieldGetter(field_info)(attrs);
+        this->VisitAny(String(field_info->name), field_value);
+      });
+    } else {
+      // TODO(tvm-team): remove this once all objects are transitioned to the new reflection
+      const_cast<BaseAttrsNode*>(attrs.get())->VisitAttrs(this);
+    }
+  }
+
+ private:
+  void VisitAny(String key, Any value) {
+    switch (value.type_index()) {
+      case kTVMFFINone: {
+        attrs_->Set(key, "");
+        break;
+      }
+      case kTVMFFIBool: {
+        attrs_->Set(key, std::to_string(value.cast<bool>()));
+        break;
+      }
+      case kTVMFFIInt: {
+        attrs_->Set(key, std::to_string(value.cast<int64_t>()));
+        break;
+      }
+      case kTVMFFIFloat: {
+        attrs_->Set(key, std::to_string(value.cast<double>()));
+        break;
+      }
+      case kTVMFFIDataType: {
+        attrs_->Set(key, runtime::DLDataTypeToString(value.cast<DLDataType>()));
+      }
+      case kTVMFFIStr: {
+        attrs_->Set(key, value.cast<String>());
+        break;
+      }
+      default: {
+        if (value.type_index() >= kTVMFFIStaticObjectBegin) {
+          attrs_->Set(key, StringUtils::ToString(value.cast<ObjectRef>()));
+        } else {
+          LOG(FATAL) << "Unsupported type: " << value.type_index();
+        }
+        break;
+      }
+    }
+  }
 
   void Visit(const char* key, double* value) final { attrs_->Set(key, std::to_string(*value)); }
 

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -193,9 +193,13 @@ bool SEqualReducer::AnyEqual(const ffi::Any& lhs, const ffi::Any& rhs,
     if (paths) {
       return operator()(lhs.cast<ObjectRef>(), rhs.cast<ObjectRef>(), paths.value());
     } else {
-      return operator()(lhs.cast<ObjectRef>(), rhs.cast<ObjectRef>());
+      ObjectRef lhs_obj = lhs.cast<ObjectRef>();
+      ObjectRef rhs_obj = rhs.cast<ObjectRef>();
+      bool result = operator()(lhs_obj, rhs_obj);
+      return result;
     }
   }
+
   if (ffi::details::AnyUnsafe::TVMFFIAnyPtrFromAny(lhs)->v_uint64 ==
       ffi::details::AnyUnsafe::TVMFFIAnyPtrFromAny(rhs)->v_uint64) {
     return true;

--- a/src/relax/op/ccl/ccl.cc
+++ b/src/relax/op/ccl/ccl.cc
@@ -27,6 +27,12 @@ namespace relax {
 /* relax.ccl.allreduce */
 TVM_REGISTER_NODE_TYPE(AllReduceAttrs);
 
+TVM_FFI_STATIC_INIT_BLOCK({
+  AllReduceAttrs::RegisterReflection();
+  AllGatherAttrs::RegisterReflection();
+  ScatterCollectiveAttrs::RegisterReflection();
+});
+
 Expr allreduce(Expr x, String op_type, bool in_group) {
   ObjectPtr<AllReduceAttrs> attrs = make_object<AllReduceAttrs>();
   attrs->op_type = std::move(op_type);

--- a/src/support/ffi_testing.cc
+++ b/src/support/ffi_testing.cc
@@ -23,6 +23,7 @@
  */
 #include <tvm/ffi/container/variant.h>
 #include <tvm/ffi/function.h>
+#include <tvm/ffi/reflection/reflection.h>
 #include <tvm/ir/attrs.h>
 #include <tvm/ir/env_func.h>
 #include <tvm/runtime/module.h>
@@ -34,22 +35,28 @@
 
 namespace tvm {
 // Attrs used to python API
-struct TestAttrs : public AttrsNode<TestAttrs> {
+struct TestAttrs : public AttrsNodeReflAdapter<TestAttrs> {
   int axis;
   String name;
   Array<PrimExpr> padding;
   TypedEnvFunc<int(int)> func;
 
-  TVM_DECLARE_ATTRS(TestAttrs, "attrs.TestAttrs") {
-    TVM_ATTR_FIELD(axis).set_default(10).set_lower_bound(1).set_upper_bound(10).describe(
-        "axis field");
-    TVM_ATTR_FIELD(name).describe("name");
-    TVM_ATTR_FIELD(padding).describe("padding of input").set_default(Array<PrimExpr>({0, 0}));
-    TVM_ATTR_FIELD(func)
-        .describe("some random env function")
-        .set_default(TypedEnvFunc<int(int)>(nullptr));
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<TestAttrs>()
+        .def_ro("axis", &TestAttrs::axis, "axis field", refl::DefaultValue(10))
+        .def_ro("name", &TestAttrs::name, "name")
+        .def_ro("padding", &TestAttrs::padding, "padding of input",
+                refl::DefaultValue(Array<PrimExpr>({0, 0})))
+        .def_ro("func", &TestAttrs::func, "some random env function",
+                refl::DefaultValue(TypedEnvFunc<int(int)>(nullptr)));
   }
+
+  static constexpr const char* _type_key = "attrs.TestAttrs";
+  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TestAttrs, BaseAttrsNode);
 };
+
+TVM_FFI_STATIC_INIT_BLOCK({ TestAttrs::RegisterReflection(); });
 
 TVM_REGISTER_NODE_TYPE(TestAttrs);
 

--- a/tests/python/ir/test_ir_attrs.py
+++ b/tests/python/ir/test_ir_attrs.py
@@ -20,17 +20,21 @@ import tvm.ir._ffi_api
 
 
 def test_make_attrs():
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
         x = tvm.ir.make_node("attrs.TestAttrs", unknown_key=1, name="xx")
-
-    with pytest.raises(AttributeError):
-        x = tvm.ir.make_node("attrs.TestAttrs", axis=100, name="xx")
 
     x = tvm.ir.make_node("attrs.TestAttrs", name="xx", padding=(3, 4))
     assert x.name == "xx"
     assert x.padding[0].value == 3
     assert x.padding[1].value == 4
     assert x.axis == 10
+
+    x = tvm.ir.make_node("attrs.TestAttrs", name="xx", padding=(3, 4))
+    y = tvm.ir.make_node("attrs.TestAttrs", name="xx", padding=(3, 5))
+    z = tvm.ir.make_node("attrs.TestAttrs", name="xx", padding=(3, 5))
+    assert not tvm.ir.structural_equal(x, y)
+    assert tvm.ir.structural_equal(x, x)
+    assert tvm.ir.structural_equal(y, z)
 
 
 def test_dict_attrs():


### PR DESCRIPTION
This PR provides functions that adapts old VisitAttrs reflection utilities to use new reflection mechanism when available.

These adapter would allow us to gradually transition the object def from old VisitAttrs based mechanism to new mechanism.

- For all objects
  - Replace VisitAttrs with static void RegisterReflection() that registers the fields
  - Call T::ReflectionDef() in TVM_STATIC_INIT_BLOCK in cc file
- For subclass of AttrsNode<T>: subclass AttrsNodeReflAdapter<T> instead
  - Do the same steps as above and replace TVM_ATTRS
  - Provide explicit declaration of _type_key and TVM_FFI_DEFINE_FINAL_OBJECT_INFO

We will send followup PRs to do the gradual transition. Once all transition is completed, we will remove AttrsVisitor and only go through the new mechanism.