### PR TITLE
[Fix] Fix ExecBuilderDeclareFunction method name in exec_builder.py

### DIFF
--- a/python/tvm/relax/exec_builder.py
+++ b/python/tvm/relax/exec_builder.py
@@ -87,7 +87,7 @@ class ExecBuilder(Object):
 
     def declare_function(self, func_name: str, kind: VMFuncKind = VMFuncKind.PACKED_FUNC) -> None:
         """Declare a function"""
-        _ffi_api.ExecBuilderDecalreFunction(self, func_name, kind)  # type: ignore
+        _ffi_api.ExecBuilderDeclareFunction(self, func_name, kind)  # type: ignore
 
     def function(
         self, func_name: str, num_inputs: Optional[int] = 0, param_names: List[str] = None


### PR DESCRIPTION
Align it with the backend implementation in https://github.com/apache/tvm/blob/main/src/relax/backend/vm/exec_builder.cc#L349