### PR TITLE
[RELAX] Fix rotary embedding buffer size calculation

### DIFF
--- a/python/tvm/relax/frontend/nn/llm/position_embedding.py
+++ b/python/tvm/relax/frontend/nn/llm/position_embedding.py
@@ -493,7 +493,7 @@ def llama_rope_with_position_map(  # pylint: disable=too-many-arguments
         var_q: T.handle,
         var_k: T.handle,
         var_v: T.handle,
-        ext_factors: T.Buffer((head_dim // 2,), "float32"),  # type: ignore
+        ext_factors: T.Buffer((rotary_dim // 2,), "float32"),  # type: ignore
     ):
         T.func_attr(
             {


### PR DESCRIPTION
- Change head_dim//2 to rotary_dim//2 in LongRope scaling
- Fixes buffer size when rotary_dim differs from head_dim when partial_rotary_factor < 1.0