### PR TITLE
Fixing generated sample init pop size

### DIFF
--- a/src/meta_schedule/search_strategy/evolutionary_search.cc
+++ b/src/meta_schedule/search_strategy/evolutionary_search.cc
@@ -522,7 +522,7 @@ std::vector<Schedule> EvolutionarySearchNode::State::SampleInitPopulation(int nu
     };
     support::parallel_for_dynamic(0, num, self->ctx_->num_threads, f_proc_unmeasured);
     bool found_new = false;
-    for (int i = 0; i < num; i++) {
+    for (int i = static_cast<int>(out_schs.size()); i < num; i++) {
       if (results[i].defined()) {
         found_new = true;
         out_schs.push_back(results[i]);


### PR DESCRIPTION
Before this PR, the randomly generated population size was sometimes wrong.