### PR TITLE
Update scan.py to fix pascal error.

### DIFF
--- a/python/tvm/topi/gpu/scan.py
+++ b/python/tvm/topi/gpu/scan.py
@@ -40,6 +40,8 @@ def _can_use_scan_thrust(binop):
     target = tvm.target.Target.current()
     if target is None:
         return False
+    if target.arch == "sm_60":
+        return False
     # pylint: disable=comparison-with-callable
     return binop == tvm.tir.generic.add and any(
         [


### PR DESCRIPTION
https://github.com/mlc-ai/mlc-llm/issues/3231

When I use mlc-llm, I encounter error in linking.
I solved the problem with this patch.
This patch may not solve the root cause. But for my scene it is suitable, the performance loss is at the noise level.
The root cause may be the lack of relevant instructions in Pascal, or a bug in Nvidia's Thrust library.
This patch is intended as an emergency mitigation. Looking forward to a better way.