### PR TITLE
[FFI] Introduce GlobalDef for function registration

### DIFF
--- a/ffi/src/ffi/container.cc
+++ b/ffi/src/ffi/container.cc
@@ -25,39 +25,10 @@
 #include <tvm/ffi/container/map.h>
 #include <tvm/ffi/container/shape.h>
 #include <tvm/ffi/function.h>
+#include <tvm/ffi/reflection/reflection.h>
 
 namespace tvm {
 namespace ffi {
-
-TVM_FFI_REGISTER_GLOBAL("ffi.Array").set_body_packed([](ffi::PackedArgs args, Any* ret) {
-  *ret = Array<Any>(args.data(), args.data() + args.size());
-});
-
-TVM_FFI_REGISTER_GLOBAL("ffi.ArrayGetItem")
-    .set_body_typed([](const ffi::ArrayObj* n, int64_t i) -> Any { return n->at(i); });
-
-TVM_FFI_REGISTER_GLOBAL("ffi.ArraySize").set_body_typed([](const ffi::ArrayObj* n) -> int64_t {
-  return static_cast<int64_t>(n->size());
-});
-// Map
-TVM_FFI_REGISTER_GLOBAL("ffi.Map").set_body_packed([](ffi::PackedArgs args, Any* ret) {
-  TVM_FFI_ICHECK_EQ(args.size() % 2, 0);
-  Map<Any, Any> data;
-  for (int i = 0; i < args.size(); i += 2) {
-    data.Set(args[i], args[i + 1]);
-  }
-  *ret = data;
-});
-
-TVM_FFI_REGISTER_GLOBAL("ffi.MapSize").set_body_typed([](const ffi::MapObj* n) -> int64_t {
-  return static_cast<int64_t>(n->size());
-});
-
-TVM_FFI_REGISTER_GLOBAL("ffi.MapGetItem")
-    .set_body_typed([](const ffi::MapObj* n, const Any& k) -> Any { return n->at(k); });
-
-TVM_FFI_REGISTER_GLOBAL("ffi.MapCount")
-    .set_body_typed([](const ffi::MapObj* n, const Any& k) -> int64_t { return n->count(k); });
 
 // Favor struct outside function scope as MSVC may have bug for in fn scope struct.
 class MapForwardIterFunctor {
@@ -86,10 +57,33 @@ class MapForwardIterFunctor {
   ffi::MapObj::iterator end_;
 };
 
-TVM_FFI_REGISTER_GLOBAL("ffi.MapForwardIterFunctor")
-    .set_body_typed([](const ffi::MapObj* n) -> ffi::Function {
-      return ffi::Function::FromTyped(MapForwardIterFunctor(n->begin(), n->end()));
-    });
-
+TVM_FFI_STATIC_INIT_BLOCK({
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef()
+      .def_packed("ffi.Array",
+                  [](ffi::PackedArgs args, Any* ret) {
+                    *ret = Array<Any>(args.data(), args.data() + args.size());
+                  })
+      .def("ffi.ArrayGetItem", [](const ffi::ArrayObj* n, int64_t i) -> Any { return n->at(i); })
+      .def("ffi.ArraySize",
+           [](const ffi::ArrayObj* n) -> int64_t { return static_cast<int64_t>(n->size()); })
+      .def_packed("ffi.Map",
+                  [](ffi::PackedArgs args, Any* ret) {
+                    TVM_FFI_ICHECK_EQ(args.size() % 2, 0);
+                    Map<Any, Any> data;
+                    for (int i = 0; i < args.size(); i += 2) {
+                      data.Set(args[i], args[i + 1]);
+                    }
+                    *ret = data;
+                  })
+      .def("ffi.MapSize",
+           [](const ffi::MapObj* n) -> int64_t { return static_cast<int64_t>(n->size()); })
+      .def("ffi.MapGetItem", [](const ffi::MapObj* n, const Any& k) -> Any { return n->at(k); })
+      .def("ffi.MapCount",
+           [](const ffi::MapObj* n, const Any& k) -> int64_t { return n->count(k); })
+      .def("ffi.MapForwardIterFunctor", [](const ffi::MapObj* n) -> ffi::Function {
+        return ffi::Function::FromTyped(MapForwardIterFunctor(n->begin(), n->end()));
+      });
+});
 }  // namespace ffi
 }  // namespace tvm

--- a/ffi/src/ffi/function.cc
+++ b/ffi/src/ffi/function.cc
@@ -28,6 +28,7 @@
 #include <tvm/ffi/error.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/memory.h>
+#include <tvm/ffi/reflection/reflection.h>
 #include <tvm/ffi/string.h>
 
 namespace tvm {
@@ -307,31 +308,30 @@ int TVMFFIEnvRegisterCAPI(const TVMFFIByteArray* name, void* symbol) {
   TVM_FFI_SAFE_CALL_END();
 }
 
-TVM_FFI_REGISTER_GLOBAL("ffi.FunctionRemoveGlobal")
-    .set_body_typed([](const tvm::ffi::String& name) -> bool {
-      return tvm::ffi::GlobalFunctionTable::Global()->Remove(name);
-    });
-
-TVM_FFI_REGISTER_GLOBAL("ffi.FunctionListGlobalNamesFunctor").set_body_typed([]() {
-  // NOTE: we return functor instead of array
-  // so list global function names do not need to depend on array
-  // this is because list global function names usually is a core api that happens
-  // before array ffi functions are available.
-  tvm::ffi::Array<tvm::ffi::String> names = tvm::ffi::GlobalFunctionTable::Global()->ListNames();
-  auto return_functor = [names](int64_t i) -> tvm::ffi::Any {
-    if (i < 0) {
-      return names.size();
-    } else {
-      return names[i];
-    }
-  };
-  return tvm::ffi::Function::FromTyped(return_functor);
-});
-
-TVM_FFI_REGISTER_GLOBAL("ffi.String").set_body_typed([](tvm::ffi::String val) -> tvm::ffi::String {
-  return val;
-});
-
-TVM_FFI_REGISTER_GLOBAL("ffi.Bytes").set_body_typed([](tvm::ffi::Bytes val) -> tvm::ffi::Bytes {
-  return val;
+TVM_FFI_STATIC_INIT_BLOCK({
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef()
+      .def("ffi.FunctionRemoveGlobal",
+           [](const tvm::ffi::String& name) -> bool {
+             return tvm::ffi::GlobalFunctionTable::Global()->Remove(name);
+           })
+      .def("ffi.FunctionListGlobalNamesFunctor",
+           []() {
+             // NOTE: we return functor instead of array
+             // so list global function names do not need to depend on array
+             // this is because list global function names usually is a core api that happens
+             // before array ffi functions are available.
+             tvm::ffi::Array<tvm::ffi::String> names =
+                 tvm::ffi::GlobalFunctionTable::Global()->ListNames();
+             auto return_functor = [names](int64_t i) -> tvm::ffi::Any {
+               if (i < 0) {
+                 return names.size();
+               } else {
+                 return names[i];
+               }
+             };
+             return tvm::ffi::Function::FromTyped(return_functor);
+           })
+      .def("ffi.String", [](tvm::ffi::String val) -> tvm::ffi::String { return val; })
+      .def("ffi.Bytes", [](tvm::ffi::Bytes val) -> tvm::ffi::Bytes { return val; });
 });

--- a/ffi/src/ffi/ndarray.cc
+++ b/ffi/src/ffi/ndarray.cc
@@ -23,23 +23,27 @@
 #include <tvm/ffi/c_api.h>
 #include <tvm/ffi/container/ndarray.h>
 #include <tvm/ffi/function.h>
+#include <tvm/ffi/reflection/reflection.h>
 
 namespace tvm {
 namespace ffi {
 
-// Shape
-TVM_FFI_REGISTER_GLOBAL("ffi.Shape").set_body_packed([](ffi::PackedArgs args, Any* ret) {
-  int64_t* mutable_data;
-  ObjectPtr<ShapeObj> shape = details::MakeEmptyShape(args.size(), &mutable_data);
-  for (int i = 0; i < args.size(); ++i) {
-    if (auto opt_int = args[i].try_cast<int64_t>()) {
-      mutable_data[i] = *opt_int;
-    } else {
-      TVM_FFI_THROW(ValueError) << "Expect shape to take list of int arguments";
+TVM_FFI_STATIC_INIT_BLOCK({
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def_packed("ffi.Shape", [](ffi::PackedArgs args, Any* ret) {
+    int64_t* mutable_data;
+    ObjectPtr<ShapeObj> shape = details::MakeEmptyShape(args.size(), &mutable_data);
+    for (int i = 0; i < args.size(); ++i) {
+      if (auto opt_int = args[i].try_cast<int64_t>()) {
+        mutable_data[i] = *opt_int;
+      } else {
+        TVM_FFI_THROW(ValueError) << "Expect shape to take list of int arguments";
+      }
     }
-  }
-  *ret = Shape(shape);
+    *ret = Shape(shape);
+  });
 });
+
 }  // namespace ffi
 }  // namespace tvm
 

--- a/ffi/src/ffi/object.cc
+++ b/ffi/src/ffi/object.cc
@@ -24,6 +24,7 @@
 #include <tvm/ffi/container/map.h>
 #include <tvm/ffi/error.h>
 #include <tvm/ffi/function.h>
+#include <tvm/ffi/reflection/reflection.h>
 #include <tvm/ffi/string.h>
 
 #include <memory>
@@ -404,7 +405,10 @@ void MakeObjectFromPackedArgs(ffi::PackedArgs args, Any* ret) {
   *ret = ObjectRef(ptr);
 }
 
-TVM_FFI_REGISTER_GLOBAL("ffi.MakeObjectFromPackedArgs").set_body_packed(MakeObjectFromPackedArgs);
+TVM_FFI_STATIC_INIT_BLOCK({
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def_packed("ffi.MakeObjectFromPackedArgs", MakeObjectFromPackedArgs);
+});
 
 }  // namespace ffi
 }  // namespace tvm

--- a/ffi/tests/cpp/test_function.cc
+++ b/ffi/tests/cpp/test_function.cc
@@ -131,7 +131,7 @@ TEST(Func, FromTyped) {
           EXPECT_EQ(error.kind(), "TypeError");
           EXPECT_EQ(error.message(),
                     "Mismatched number of arguments when calling: "
-                    "`fpass_and_return(0: test.Int, 1: int, 2: AnyView) -> object.Function`. "
+                    "`fpass_and_return(0: test.Int, 1: int, 2: AnyView) -> ffi.Function`. "
                     "Expected 3 but got 0 arguments");
           throw;
         }
@@ -236,11 +236,4 @@ TEST(Func, ObjectRefWithFallbackTraits) {
       ::tvm::ffi::Error);
 }
 
-TVM_FFI_REGISTER_GLOBAL("testing.Int_GetValue").set_body_method(&TIntObj::GetValue);
-
-TEST(Func, Register) {
-  Function fget_value = Function::GetGlobalRequired("testing.Int_GetValue");
-  TInt a(12);
-  EXPECT_EQ(fget_value(a).cast<int>(), 12);
-}
 }  // namespace

--- a/ffi/tests/cpp/test_reflection.cc
+++ b/ffi/tests/cpp/test_reflection.cc
@@ -153,4 +153,15 @@ TEST(Reflection, ForEachFieldInfo) {
   EXPECT_EQ(field_name_to_offset["z"], 16 + sizeof(TVMFFIObject));
 }
 
+TVM_FFI_STATIC_INIT_BLOCK({
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def_method("testing.Int_GetValue", &TIntObj::GetValue);
+});
+
+TEST(Reflection, FuncRegister) {
+  Function fget_value = Function::GetGlobalRequired("testing.Int_GetValue");
+  TInt a(12);
+  EXPECT_EQ(fget_value(a).cast<int>(), 12);
+}
+
 }  // namespace


### PR DESCRIPTION
This PR introduces reflection::GlobalDef for function registration, which makes the global function registration API more closely aligned with the new reflection style.

We will send followup PRs to transition some of the existing mechanisms to the new one.