### PR TITLE
[FFI] Replace `__attribute__` with C++ standard attributes

### DIFF
--- a/ffi/include/tvm/ffi/any.h
+++ b/ffi/include/tvm/ffi/any.h
@@ -175,7 +175,7 @@ class AnyView {
    * \return Create an AnyView from TVMFFIAny
    * \param data the underlying ffi data.
    */
-  static TVM_FFI_INLINE AnyView CopyFromTVMFFIAny(TVMFFIAny data) {
+  TVM_FFI_INLINE static AnyView CopyFromTVMFFIAny(TVMFFIAny data) {
     AnyView view;
     view.data_ = data;
     return view;
@@ -482,14 +482,14 @@ struct Type2Str<void> {
 // Extra unsafe method to help any manipulation
 struct AnyUnsafe : public ObjectUnsafe {
   // FFI related operations
-  static TVM_FFI_INLINE TVMFFIAny MoveAnyToTVMFFIAny(Any&& any) {
+  TVM_FFI_INLINE static TVMFFIAny MoveAnyToTVMFFIAny(Any&& any) {
     TVMFFIAny result = any.data_;
     any.data_.type_index = TypeIndex::kTVMFFINone;
     any.data_.v_int64 = 0;
     return result;
   }
 
-  static TVM_FFI_INLINE Any MoveTVMFFIAnyToAny(TVMFFIAny&& data) {
+  TVM_FFI_INLINE static Any MoveTVMFFIAnyToAny(TVMFFIAny&& data) {
     Any any;
     any.data_ = data;
     data.type_index = TypeIndex::kTVMFFINone;
@@ -498,12 +498,12 @@ struct AnyUnsafe : public ObjectUnsafe {
   }
 
   template <typename T>
-  static TVM_FFI_INLINE bool CheckAnyStrict(const Any& ref) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const Any& ref) {
     return TypeTraits<T>::CheckAnyStrict(&(ref.data_));
   }
 
   template <typename T>
-  static TVM_FFI_INLINE T CopyFromAnyViewAfterCheck(const Any& ref) {
+  TVM_FFI_INLINE static T CopyFromAnyViewAfterCheck(const Any& ref) {
     if constexpr (!std::is_same_v<T, Any>) {
       return TypeTraits<T>::CopyFromAnyViewAfterCheck(&(ref.data_));
     } else {
@@ -512,7 +512,7 @@ struct AnyUnsafe : public ObjectUnsafe {
   }
 
   template <typename T>
-  static TVM_FFI_INLINE T MoveFromAnyAfterCheck(Any&& ref) {
+  TVM_FFI_INLINE static T MoveFromAnyAfterCheck(Any&& ref) {
     if constexpr (!std::is_same_v<T, Any>) {
       return TypeTraits<T>::MoveFromAnyAfterCheck(&(ref.data_));
     } else {
@@ -520,16 +520,16 @@ struct AnyUnsafe : public ObjectUnsafe {
     }
   }
 
-  static TVM_FFI_INLINE Object* ObjectPtrFromAnyAfterCheck(const Any& ref) {
+  TVM_FFI_INLINE static Object* ObjectPtrFromAnyAfterCheck(const Any& ref) {
     return reinterpret_cast<Object*>(ref.data_.v_obj);
   }
 
-  static TVM_FFI_INLINE const TVMFFIAny* TVMFFIAnyPtrFromAny(const Any& ref) {
+  TVM_FFI_INLINE static const TVMFFIAny* TVMFFIAnyPtrFromAny(const Any& ref) {
     return &(ref.data_);
   }
 
   template <typename T>
-  static TVM_FFI_INLINE std::string GetMismatchTypeInfo(const Any& ref) {
+  TVM_FFI_INLINE static std::string GetMismatchTypeInfo(const Any& ref) {
     return TypeTraits<T>::GetMismatchTypeInfo(&(ref.data_));
   }
 };

--- a/ffi/include/tvm/ffi/base_details.h
+++ b/ffi/include/tvm/ffi/base_details.h
@@ -49,9 +49,9 @@
 #endif
 
 #if defined(_MSC_VER)
-#define TVM_FFI_INLINE __forceinline
+#define TVM_FFI_INLINE [[msvc::forceinline]] inline
 #else
-#define TVM_FFI_INLINE inline __attribute__((always_inline))
+#define TVM_FFI_INLINE [[gnu::always_inline]] inline
 #endif
 
 /*!
@@ -60,9 +60,9 @@
  * e.g. some logging functions.
  */
 #if defined(_MSC_VER)
-#define TVM_FFI_NO_INLINE __declspec(noinline)
+#define TVM_FFI_NO_INLINE [[msvc::noinline]]
 #else
-#define TVM_FFI_NO_INLINE __attribute__((noinline))
+#define TVM_FFI_NO_INLINE [[gnu::noinline]]
 #endif
 
 #if defined(_MSC_VER)
@@ -72,11 +72,7 @@
 #endif
 
 /*! \brief helper macro to suppress unused warning */
-#if defined(__GNUC__)
-#define TVM_FFI_ATTRIBUTE_UNUSED __attribute__((unused))
-#else
-#define TVM_FFI_ATTRIBUTE_UNUSED
-#endif
+#define TVM_FFI_ATTRIBUTE_UNUSED [[maybe_unused]]
 
 #define TVM_FFI_STR_CONCAT_(__x, __y) __x##__y
 #define TVM_FFI_STR_CONCAT(__x, __y) TVM_FFI_STR_CONCAT_(__x, __y)
@@ -90,7 +86,7 @@
 #endif
 
 #define TVM_FFI_STATIC_INIT_BLOCK_VAR_DEF \
-  static inline TVM_FFI_ATTRIBUTE_UNUSED int __##TVMFFIStaticInitReg
+  TVM_FFI_ATTRIBUTE_UNUSED static inline int __##TVMFFIStaticInitReg
 
 /*! \brief helper macro to run code once during initialization */
 #define TVM_FFI_STATIC_INIT_BLOCK(Body) \

--- a/ffi/include/tvm/ffi/container/array.h
+++ b/ffi/include/tvm/ffi/container/array.h
@@ -1001,7 +1001,7 @@ struct TypeTraits<Array<T>> : public ObjectRefTypeTraitsBase<Array<T>> {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIArray;
   using ObjectRefTypeTraitsBase<Array<T>>::CopyFromAnyViewAfterCheck;
 
-  static TVM_FFI_INLINE std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
     if (src->type_index != TypeIndex::kTVMFFIArray) {
       return TypeTraitsBase::GetMismatchTypeInfo(src);
     }
@@ -1022,7 +1022,7 @@ struct TypeTraits<Array<T>> : public ObjectRefTypeTraitsBase<Array<T>> {
     TVM_FFI_UNREACHABLE();
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     if (src->type_index != TypeIndex::kTVMFFIArray) return false;
     if constexpr (std::is_same_v<T, Any>) {
       return true;
@@ -1036,7 +1036,7 @@ struct TypeTraits<Array<T>> : public ObjectRefTypeTraitsBase<Array<T>> {
     }
   }
 
-  static TVM_FFI_INLINE std::optional<Array<T>> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<Array<T>> TryCastFromAnyView(const TVMFFIAny* src) {
     // try to run conversion.
     if (src->type_index != TypeIndex::kTVMFFIArray) return std::nullopt;
     if constexpr (!std::is_same_v<T, Any>) {
@@ -1069,7 +1069,7 @@ struct TypeTraits<Array<T>> : public ObjectRefTypeTraitsBase<Array<T>> {
     }
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return "Array<" + details::Type2Str<T>::v() + ">"; }
+  TVM_FFI_INLINE static std::string TypeStr() { return "Array<" + details::Type2Str<T>::v() + ">"; }
 };
 
 namespace details {

--- a/ffi/include/tvm/ffi/container/map.h
+++ b/ffi/include/tvm/ffi/container/map.h
@@ -1563,7 +1563,7 @@ struct TypeTraits<Map<K, V>> : public ObjectRefTypeTraitsBase<Map<K, V>> {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIMap;
   using ObjectRefTypeTraitsBase<Map<K, V>>::CopyFromAnyViewAfterCheck;
 
-  static TVM_FFI_INLINE std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
     if (src->type_index != TypeIndex::kTVMFFIMap) {
       return TypeTraitsBase::GetMismatchTypeInfo(src);
     }
@@ -1590,7 +1590,7 @@ struct TypeTraits<Map<K, V>> : public ObjectRefTypeTraitsBase<Map<K, V>> {
     TVM_FFI_UNREACHABLE();
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     if (src->type_index != TypeIndex::kTVMFFIMap) return false;
     if constexpr (std::is_same_v<K, Any> && std::is_same_v<V, Any>) {
       return true;
@@ -1608,7 +1608,7 @@ struct TypeTraits<Map<K, V>> : public ObjectRefTypeTraitsBase<Map<K, V>> {
     }
   }
 
-  static TVM_FFI_INLINE std::optional<Map<K, V>> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<Map<K, V>> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index != TypeIndex::kTVMFFIMap) return std::nullopt;
     if constexpr (!std::is_same_v<K, Any> || !std::is_same_v<V, Any>) {
       const MapObj* n = reinterpret_cast<const MapObj*>(src->v_obj);
@@ -1639,7 +1639,7 @@ struct TypeTraits<Map<K, V>> : public ObjectRefTypeTraitsBase<Map<K, V>> {
     }
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() {
+  TVM_FFI_INLINE static std::string TypeStr() {
     return "Map<" + details::Type2Str<K>::v() + ", " + details::Type2Str<V>::v() + ">";
   }
 };

--- a/ffi/include/tvm/ffi/container/shape.h
+++ b/ffi/include/tvm/ffi/container/shape.h
@@ -210,7 +210,7 @@ inline constexpr bool use_default_type_traits_v<Shape> = false;
 template <>
 struct TypeTraits<Shape> : public ObjectRefWithFallbackTraitsBase<Shape, Array<int64_t>> {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIShape;
-  static TVM_FFI_INLINE Shape ConvertFallbackValue(Array<int64_t> src) { return Shape(src); }
+  TVM_FFI_INLINE static Shape ConvertFallbackValue(Array<int64_t> src) { return Shape(src); }
 };
 
 }  // namespace ffi

--- a/ffi/include/tvm/ffi/container/tuple.h
+++ b/ffi/include/tvm/ffi/container/tuple.h
@@ -175,7 +175,7 @@ template <typename... Types>
 struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types...>> {
   using ObjectRefTypeTraitsBase<Tuple<Types...>>::CopyFromAnyViewAfterCheck;
 
-  static TVM_FFI_INLINE std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
     if (src->type_index != TypeIndex::kTVMFFIArray) {
       return TypeTraitsBase::GetMismatchTypeInfo(src);
     }
@@ -187,7 +187,7 @@ struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types.
   }
 
   template <size_t I, typename T, typename... Rest>
-  static TVM_FFI_INLINE std::string GetMismatchTypeInfoHelper(const Any* arr) {
+  TVM_FFI_INLINE static std::string GetMismatchTypeInfoHelper(const Any* arr) {
     if constexpr (!std::is_same_v<T, Any>) {
       const Any& any_v = arr[I];
       if (!details::AnyUnsafe::CheckAnyStrict<T>(any_v) && !(any_v.try_cast<T>().has_value())) {
@@ -203,7 +203,7 @@ struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types.
     TVM_FFI_UNREACHABLE();
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     if (src->type_index != TypeIndex::kTVMFFIArray) return false;
     const ArrayObj* n = reinterpret_cast<const ArrayObj*>(src->v_obj);
     if (n->size() != sizeof...(Types)) return false;
@@ -212,7 +212,7 @@ struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types.
   }
 
   template <size_t I, typename T, typename... Rest>
-  static TVM_FFI_INLINE bool CheckAnyStrictHelper(const TVMFFIAny* src_arr) {
+  TVM_FFI_INLINE static bool CheckAnyStrictHelper(const TVMFFIAny* src_arr) {
     if constexpr (!std::is_same_v<T, Any>) {
       if (!TypeTraits<T>::CheckAnyStrict(src_arr + I)) {
         return false;
@@ -224,7 +224,7 @@ struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types.
     return true;
   }
 
-  static TVM_FFI_INLINE std::optional<Tuple<Types...>> TryCastFromAnyView(const TVMFFIAny* src  //
+  TVM_FFI_INLINE static std::optional<Tuple<Types...>> TryCastFromAnyView(const TVMFFIAny* src  //
   ) {
     if (src->type_index != TypeIndex::kTVMFFIArray) return std::nullopt;
     const ArrayObj* n = reinterpret_cast<const ArrayObj*>(src->v_obj);
@@ -243,7 +243,7 @@ struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types.
   }
 
   template <size_t I, typename T, typename... Rest>
-  static TVM_FFI_INLINE bool TryConvertElements(Any* arr) {
+  TVM_FFI_INLINE static bool TryConvertElements(Any* arr) {
     if constexpr (!std::is_same_v<T, Any>) {
       if (auto opt_convert = arr[I].try_cast<T>()) {
         arr[I] = *std::move(opt_convert);
@@ -258,7 +258,7 @@ struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types.
     }
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() {
+  TVM_FFI_INLINE static std::string TypeStr() {
     return details::ContainerTypeStr<Types...>("Tuple");
   }
 };

--- a/ffi/include/tvm/ffi/container/variant.h
+++ b/ffi/include/tvm/ffi/container/variant.h
@@ -189,31 +189,31 @@ inline constexpr bool use_default_type_traits_v<Variant<V...>> = false;
 
 template <typename... V>
 struct TypeTraits<Variant<V...>> : public TypeTraitsBase {
-  static TVM_FFI_INLINE void CopyToAnyView(const Variant<V...>& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const Variant<V...>& src, TVMFFIAny* result) {
     *result = src.ToAnyView().CopyToTVMFFIAny();
   }
 
-  static TVM_FFI_INLINE void MoveToAny(Variant<V...> src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(Variant<V...> src, TVMFFIAny* result) {
     *result = details::AnyUnsafe::MoveAnyToTVMFFIAny(std::move(src).MoveToAny());
   }
 
-  static TVM_FFI_INLINE std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
     return TypeTraitsBase::GetMismatchTypeInfo(src);
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     return (TypeTraits<V>::CheckAnyStrict(src) || ...);
   }
 
-  static TVM_FFI_INLINE Variant<V...> CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static Variant<V...> CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return Variant<V...>(Any(AnyView::CopyFromTVMFFIAny(*src)));
   }
 
-  static TVM_FFI_INLINE Variant<V...> MoveFromAnyAfterCheck(TVMFFIAny* src) {
+  TVM_FFI_INLINE static Variant<V...> MoveFromAnyAfterCheck(TVMFFIAny* src) {
     return Variant<V...>(details::AnyUnsafe::MoveTVMFFIAnyToAny(std::move(*src)));
   }
 
-  static TVM_FFI_INLINE std::optional<Variant<V...>> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<Variant<V...>> TryCastFromAnyView(const TVMFFIAny* src) {
     // fast path, storage is already in the right type
     if (CheckAnyStrict(src)) {
       return CopyFromAnyViewAfterCheck(src);
@@ -223,7 +223,7 @@ struct TypeTraits<Variant<V...>> : public TypeTraitsBase {
   }
 
   template <typename VariantType, typename... Rest>
-  static TVM_FFI_INLINE std::optional<Variant<V...>> TryVariantTypes(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<Variant<V...>> TryVariantTypes(const TVMFFIAny* src) {
     if (auto opt_convert = TypeTraits<VariantType>::TryCastFromAnyView(src)) {
       return Variant<V...>(*std::move(opt_convert));
     }
@@ -233,7 +233,7 @@ struct TypeTraits<Variant<V...>> : public TypeTraitsBase {
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return details::ContainerTypeStr<V...>("Variant"); }
+  TVM_FFI_INLINE static std::string TypeStr() { return details::ContainerTypeStr<V...>("Variant"); }
 };
 
 template <typename... V>

--- a/ffi/include/tvm/ffi/dtype.h
+++ b/ffi/include/tvm/ffi/dtype.h
@@ -130,29 +130,29 @@ template <>
 struct TypeTraits<DLDataType> : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIDataType;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const DLDataType& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const DLDataType& src, TVMFFIAny* result) {
     // clear padding part to ensure the equality check can always check the v_uint64 part
     result->v_uint64 = 0;
     result->type_index = TypeIndex::kTVMFFIDataType;
     result->v_dtype = src;
   }
 
-  static TVM_FFI_INLINE void MoveToAny(DLDataType src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(DLDataType src, TVMFFIAny* result) {
     // clear padding part to ensure the equality check can always check the v_uint64 part
     result->v_uint64 = 0;
     result->type_index = TypeIndex::kTVMFFIDataType;
     result->v_dtype = src;
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     return src->type_index == TypeIndex::kTVMFFIDataType;
   }
 
-  static TVM_FFI_INLINE DLDataType CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static DLDataType CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return src->v_dtype;
   }
 
-  static TVM_FFI_INLINE std::optional<DLDataType> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<DLDataType> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIDataType) {
       return src->v_dtype;
     }
@@ -163,7 +163,7 @@ struct TypeTraits<DLDataType> : public TypeTraitsBase {
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return ffi::StaticTypeKey::kTVMFFIDataType; }
+  TVM_FFI_INLINE static std::string TypeStr() { return ffi::StaticTypeKey::kTVMFFIDataType; }
 };
 }  // namespace ffi
 }  // namespace tvm

--- a/ffi/include/tvm/ffi/function.h
+++ b/ffi/include/tvm/ffi/function.h
@@ -279,7 +279,7 @@ class PackedArgs {
    *       destroyed after calling Fill.
    */
   template <typename... Args>
-  static void TVM_FFI_INLINE Fill(AnyView* data, Args&&... args) {
+  TVM_FFI_INLINE static void Fill(AnyView* data, Args&&... args) {
     details::for_each(details::PackedArgsSetter(data), std::forward<Args>(args)...);
   }
 
@@ -727,23 +727,23 @@ template <typename FType>
 struct TypeTraits<TypedFunction<FType>> : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIFunction;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const TypedFunction<FType>& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const TypedFunction<FType>& src, TVMFFIAny* result) {
     TypeTraits<Function>::CopyToAnyView(src.packed(), result);
   }
 
-  static TVM_FFI_INLINE void MoveToAny(TypedFunction<FType> src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(TypedFunction<FType> src, TVMFFIAny* result) {
     TypeTraits<Function>::MoveToAny(std::move(src.packed()), result);
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     return src->type_index == TypeIndex::kTVMFFIFunction;
   }
 
-  static TVM_FFI_INLINE TypedFunction<FType> CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static TypedFunction<FType> CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return TypedFunction<FType>(TypeTraits<Function>::CopyFromAnyViewAfterCheck(src));
   }
 
-  static TVM_FFI_INLINE std::optional<TypedFunction<FType>> TryCastFromAnyView(
+  TVM_FFI_INLINE static std::optional<TypedFunction<FType>> TryCastFromAnyView(
       const TVMFFIAny* src) {
     std::optional<Function> opt = TypeTraits<Function>::TryCastFromAnyView(src);
     if (opt.has_value()) {
@@ -753,7 +753,7 @@ struct TypeTraits<TypedFunction<FType>> : public TypeTraitsBase {
     }
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return details::FunctionInfo<FType>::Sig(); }
+  TVM_FFI_INLINE static std::string TypeStr() { return details::FunctionInfo<FType>::Sig(); }
 };
 
 /*! \brief Registry for global function */
@@ -896,7 +896,7 @@ inline int32_t TypeKeyToIndex(std::string_view type_key) {
 }
 
 #define TVM_FFI_FUNC_REG_VAR_DEF \
-  static inline TVM_FFI_ATTRIBUTE_UNUSED ::tvm::ffi::Function::Registry& __##TVMFFIFuncReg
+  TVM_FFI_ATTRIBUTE_UNUSED static inline ::tvm::ffi::Function::Registry& __##TVMFFIFuncReg
 
 /*!
  * \brief Register a function globally.

--- a/ffi/include/tvm/ffi/function_details.h
+++ b/ffi/include/tvm/ffi/function_details.h
@@ -39,7 +39,7 @@ namespace details {
 template <typename ArgType>
 struct Arg2Str {
   template <size_t i>
-  static TVM_FFI_INLINE void Apply(std::ostream& os) {
+  TVM_FFI_INLINE static void Apply(std::ostream& os) {
     using Arg = std::tuple_element_t<i, ArgType>;
     if constexpr (i != 0) {
       os << ", ";
@@ -47,7 +47,7 @@ struct Arg2Str {
     os << i << ": " << Type2Str<Arg>::v();
   }
   template <size_t... I>
-  static TVM_FFI_INLINE void Run(std::ostream& os, std::index_sequence<I...>) {
+  TVM_FFI_INLINE static void Run(std::ostream& os, std::index_sequence<I...>) {
     using TExpander = int[];
     (void)TExpander{0, (Apply<I>(os), 0)...};
   }
@@ -77,7 +77,7 @@ struct FuncFunctorImpl {
   static constexpr bool unpacked_supported = (ArgSupported<Args> && ...) && (RetSupported<R>);
 #endif
 
-  static TVM_FFI_INLINE std::string Sig() {
+  TVM_FFI_INLINE static std::string Sig() {
     using IdxSeq = std::make_index_sequence<sizeof...(Args)>;
     std::ostringstream ss;
     ss << "(";

--- a/ffi/include/tvm/ffi/object.h
+++ b/ffi/include/tvm/ffi/object.h
@@ -737,18 +737,18 @@ TVM_FFI_INLINE bool IsObjectInstance(int32_t object_type_index) {
  */
 struct ObjectUnsafe {
   // NOTE: get ffi header from an object
-  static TVM_FFI_INLINE TVMFFIObject* GetHeader(const Object* src) {
+  TVM_FFI_INLINE static TVMFFIObject* GetHeader(const Object* src) {
     return const_cast<TVMFFIObject*>(&(src->header_));
   }
 
   template <typename Class>
-  static TVM_FFI_INLINE int64_t GetObjectOffsetToSubclass() {
+  TVM_FFI_INLINE static int64_t GetObjectOffsetToSubclass() {
     return (reinterpret_cast<int64_t>(&(static_cast<Class*>(nullptr)->header_)) -
             reinterpret_cast<int64_t>(&(static_cast<Object*>(nullptr)->header_)));
   }
 
   template <typename T>
-  static TVM_FFI_INLINE ObjectPtr<T> ObjectPtrFromObjectRef(const ObjectRef& ref) {
+  TVM_FFI_INLINE static ObjectPtr<T> ObjectPtrFromObjectRef(const ObjectRef& ref) {
     if constexpr (std::is_same_v<T, Object>) {
       return ref.data_;
     } else {
@@ -757,7 +757,7 @@ struct ObjectUnsafe {
   }
 
   template <typename T>
-  static TVM_FFI_INLINE ObjectPtr<T> ObjectPtrFromObjectRef(ObjectRef&& ref) {
+  TVM_FFI_INLINE static ObjectPtr<T> ObjectPtrFromObjectRef(ObjectRef&& ref) {
     if constexpr (std::is_same_v<T, Object>) {
       return std::move(ref.data_);
     } else {
@@ -766,19 +766,19 @@ struct ObjectUnsafe {
   }
 
   template <typename T>
-  static TVM_FFI_INLINE ObjectPtr<T> ObjectPtrFromOwned(Object* raw_ptr) {
+  TVM_FFI_INLINE static ObjectPtr<T> ObjectPtrFromOwned(Object* raw_ptr) {
     tvm::ffi::ObjectPtr<T> ptr;
     ptr.data_ = raw_ptr;
     return ptr;
   }
 
   template <typename T>
-  static TVM_FFI_INLINE ObjectPtr<T> ObjectPtrFromOwned(TVMFFIObject* obj_ptr) {
+  TVM_FFI_INLINE static ObjectPtr<T> ObjectPtrFromOwned(TVMFFIObject* obj_ptr) {
     return ObjectPtrFromOwned<T>(reinterpret_cast<Object*>(obj_ptr));
   }
 
   template <typename T>
-  static TVM_FFI_INLINE T* RawObjectPtrFromUnowned(TVMFFIObject* obj_ptr) {
+  TVM_FFI_INLINE static T* RawObjectPtrFromUnowned(TVMFFIObject* obj_ptr) {
     // NOTE: this is important to first cast to Object*
     // then cast back to T* because objptr and tptr may not be the same
     // depending on how sub-class allocates the space.
@@ -787,44 +787,44 @@ struct ObjectUnsafe {
 
   // Create ObjectPtr from unowned ptr
   template <typename T>
-  static TVM_FFI_INLINE ObjectPtr<T> ObjectPtrFromUnowned(Object* raw_ptr) {
+  TVM_FFI_INLINE static ObjectPtr<T> ObjectPtrFromUnowned(Object* raw_ptr) {
     return tvm::ffi::ObjectPtr<T>(raw_ptr);
   }
 
   template <typename T>
-  static TVM_FFI_INLINE ObjectPtr<T> ObjectPtrFromUnowned(TVMFFIObject* obj_ptr) {
+  TVM_FFI_INLINE static ObjectPtr<T> ObjectPtrFromUnowned(TVMFFIObject* obj_ptr) {
     return tvm::ffi::ObjectPtr<T>(reinterpret_cast<Object*>(obj_ptr));
   }
 
-  static TVM_FFI_INLINE void DecRefObjectHandle(TVMFFIObjectHandle handle) {
+  TVM_FFI_INLINE static void DecRefObjectHandle(TVMFFIObjectHandle handle) {
     reinterpret_cast<Object*>(handle)->DecRef();
   }
 
-  static TVM_FFI_INLINE void IncRefObjectHandle(TVMFFIObjectHandle handle) {
+  TVM_FFI_INLINE static void IncRefObjectHandle(TVMFFIObjectHandle handle) {
     reinterpret_cast<Object*>(handle)->IncRef();
   }
 
-  static TVM_FFI_INLINE Object* RawObjectPtrFromObjectRef(const ObjectRef& src) {
+  TVM_FFI_INLINE static Object* RawObjectPtrFromObjectRef(const ObjectRef& src) {
     return src.data_.data_;
   }
 
-  static TVM_FFI_INLINE TVMFFIObject* TVMFFIObjectPtrFromObjectRef(const ObjectRef& src) {
+  TVM_FFI_INLINE static TVMFFIObject* TVMFFIObjectPtrFromObjectRef(const ObjectRef& src) {
     return GetHeader(src.data_.data_);
   }
 
   template <typename T>
-  static TVM_FFI_INLINE TVMFFIObject* TVMFFIObjectPtrFromObjectPtr(const ObjectPtr<T>& src) {
+  TVM_FFI_INLINE static TVMFFIObject* TVMFFIObjectPtrFromObjectPtr(const ObjectPtr<T>& src) {
     return GetHeader(src.data_);
   }
 
   template <typename T>
-  static TVM_FFI_INLINE TVMFFIObject* MoveObjectPtrToTVMFFIObjectPtr(ObjectPtr<T>&& src) {
+  TVM_FFI_INLINE static TVMFFIObject* MoveObjectPtrToTVMFFIObjectPtr(ObjectPtr<T>&& src) {
     Object* obj_ptr = src.data_;
     src.data_ = nullptr;
     return GetHeader(obj_ptr);
   }
 
-  static TVM_FFI_INLINE TVMFFIObject* MoveObjectRefToTVMFFIObjectPtr(ObjectRef&& src) {
+  TVM_FFI_INLINE static TVMFFIObject* MoveObjectRefToTVMFFIObjectPtr(ObjectRef&& src) {
     Object* obj_ptr = src.data_.data_;
     src.data_.data_ = nullptr;
     return GetHeader(obj_ptr);

--- a/ffi/include/tvm/ffi/reflection/reflection.h
+++ b/ffi/include/tvm/ffi/reflection/reflection.h
@@ -96,7 +96,7 @@ class ReflectionDefBase {
   }
 
   template <typename T>
-  static TVM_FFI_INLINE void ApplyFieldInfoTrait(TVMFFIFieldInfo* info, const T& value) {
+  TVM_FFI_INLINE static void ApplyFieldInfoTrait(TVMFFIFieldInfo* info, const T& value) {
     if constexpr (std::is_base_of_v<FieldInfoTrait, std::decay_t<T>>) {
       value.Apply(info);
     }
@@ -106,21 +106,21 @@ class ReflectionDefBase {
   }
 
   template <typename T>
-  static TVM_FFI_INLINE void ApplyMethodInfoTrait(TVMFFIMethodInfo* info, const T& value) {
+  TVM_FFI_INLINE static void ApplyMethodInfoTrait(TVMFFIMethodInfo* info, const T& value) {
     if constexpr (std::is_same_v<std::decay_t<T>, char*>) {
       info->doc = TVMFFIByteArray{value, std::char_traits<char>::length(value)};
     }
   }
 
   template <typename T>
-  static TVM_FFI_INLINE void ApplyExtraInfoTrait(TVMFFITypeExtraInfo* info, const T& value) {
+  TVM_FFI_INLINE static void ApplyExtraInfoTrait(TVMFFITypeExtraInfo* info, const T& value) {
     if constexpr (std::is_same_v<std::decay_t<T>, char*>) {
       info->doc = TVMFFIByteArray{value, std::char_traits<char>::length(value)};
     }
   }
 
   template <typename Class, typename R, typename... Args>
-  static TVM_FFI_INLINE Function GetMethod(std::string name, R (Class::*func)(Args...)) {
+  TVM_FFI_INLINE static Function GetMethod(std::string name, R (Class::*func)(Args...)) {
     static_assert(std::is_base_of_v<ObjectRef, Class> || std::is_base_of_v<Object, Class>,
                   "Class must be derived from ObjectRef or Object");
     if constexpr (std::is_base_of_v<ObjectRef, Class>) {
@@ -141,7 +141,7 @@ class ReflectionDefBase {
   }
 
   template <typename Class, typename R, typename... Args>
-  static TVM_FFI_INLINE Function GetMethod(std::string name, R (Class::*func)(Args...) const) {
+  TVM_FFI_INLINE static Function GetMethod(std::string name, R (Class::*func)(Args...) const) {
     static_assert(std::is_base_of_v<ObjectRef, Class> || std::is_base_of_v<Object, Class>,
                   "Class must be derived from ObjectRef or Object");
     if constexpr (std::is_base_of_v<ObjectRef, Class>) {
@@ -162,7 +162,7 @@ class ReflectionDefBase {
   }
 
   template <typename Class, typename Func>
-  static TVM_FFI_INLINE Function GetMethod(std::string name, Func&& func) {
+  TVM_FFI_INLINE static Function GetMethod(std::string name, Func&& func) {
     return ffi::Function::FromTyped(std::forward<Func>(func), name);
   }
 };
@@ -228,17 +228,17 @@ class GlobalDef : public ReflectionDefBase {
 
  private:
   template <typename Func>
-  static TVM_FFI_INLINE Function GetMethod_(std::string name, Func&& func) {
+  TVM_FFI_INLINE static Function GetMethod_(std::string name, Func&& func) {
     return ffi::Function::FromTyped(std::forward<Func>(func), name);
   }
 
   template <typename Class, typename R, typename... Args>
-  static TVM_FFI_INLINE Function GetMethod_(std::string name, R (Class::*func)(Args...) const) {
+  TVM_FFI_INLINE static Function GetMethod_(std::string name, R (Class::*func)(Args...) const) {
     return GetMethod<Class>(std::string(name), func);
   }
 
   template <typename Class, typename R, typename... Args>
-  static TVM_FFI_INLINE Function GetMethod_(std::string name, R (Class::*func)(Args...)) {
+  TVM_FFI_INLINE static Function GetMethod_(std::string name, R (Class::*func)(Args...)) {
     return GetMethod<Class>(std::string(name), func);
   }
 

--- a/ffi/include/tvm/ffi/rvalue_ref.h
+++ b/ffi/include/tvm/ffi/rvalue_ref.h
@@ -92,14 +92,14 @@ template <typename TObjRef>
 struct TypeTraits<RValueRef<TObjRef>> : public TypeTraitsBase {
   static constexpr bool storage_enabled = false;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const RValueRef<TObjRef>& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const RValueRef<TObjRef>& src, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIObjectRValueRef;
     // store the address of the ObjectPtr, which allows us to move the value
     // and set the original ObjectPtr to nullptr
     result->v_ptr = &(src.data_);
   }
 
-  static TVM_FFI_INLINE std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIObjectRValueRef) {
       ObjectPtr<Object>* rvalue_ref = reinterpret_cast<ObjectPtr<Object>*>(src->v_ptr);
       // object type does not match up, we need to try to convert the object
@@ -114,7 +114,7 @@ struct TypeTraits<RValueRef<TObjRef>> : public TypeTraitsBase {
     }
   }
 
-  static TVM_FFI_INLINE std::optional<RValueRef<TObjRef>> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<RValueRef<TObjRef>> TryCastFromAnyView(const TVMFFIAny* src) {
     // first try rvalue conversion
     if (src->type_index == TypeIndex::kTVMFFIObjectRValueRef) {
       ObjectPtr<Object>* rvalue_ref = reinterpret_cast<ObjectPtr<Object>*>(src->v_ptr);
@@ -140,7 +140,7 @@ struct TypeTraits<RValueRef<TObjRef>> : public TypeTraitsBase {
     }
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() {
+  TVM_FFI_INLINE static std::string TypeStr() {
     return "RValueRef<" + TypeTraits<TObjRef>::TypeStr() + ">";
   }
 };

--- a/ffi/include/tvm/ffi/string.h
+++ b/ffi/include/tvm/ffi/string.h
@@ -424,12 +424,12 @@ struct TypeTraits<char[N]> : public TypeTraitsBase {
   // NOTE: only enable implicit conversion into AnyView
   static constexpr bool storage_enabled = false;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const char src[N], TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const char src[N], TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIRawStr;
     result->v_c_str = src;
   }
 
-  static TVM_FFI_INLINE void MoveToAny(const char src[N], TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(const char src[N], TVMFFIAny* result) {
     // when we need to move to any, convert to owned object first
     ObjectRefTypeTraitsBase<String>::MoveToAny(String(src), result);
   }
@@ -439,25 +439,25 @@ template <>
 struct TypeTraits<const char*> : public TypeTraitsBase {
   static constexpr bool storage_enabled = false;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const char* src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const char* src, TVMFFIAny* result) {
     TVM_FFI_ICHECK_NOTNULL(src);
     result->type_index = TypeIndex::kTVMFFIRawStr;
     result->v_c_str = src;
   }
 
-  static TVM_FFI_INLINE void MoveToAny(const char* src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(const char* src, TVMFFIAny* result) {
     // when we need to move to any, convert to owned object first
     ObjectRefTypeTraitsBase<String>::MoveToAny(String(src), result);
   }
   // Do not allow const char* in a container, so we do not need CheckAnyStrict
-  static TVM_FFI_INLINE std::optional<const char*> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<const char*> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIRawStr) {
       return static_cast<const char*>(src->v_c_str);
     }
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return "const char*"; }
+  TVM_FFI_INLINE static std::string TypeStr() { return "const char*"; }
 };
 
 // TVMFFIByteArray, requirement: not nullable, do not retain ownership
@@ -466,25 +466,25 @@ struct TypeTraits<TVMFFIByteArray*> : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIByteArrayPtr;
   static constexpr bool storage_enabled = false;
 
-  static TVM_FFI_INLINE void CopyToAnyView(TVMFFIByteArray* src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(TVMFFIByteArray* src, TVMFFIAny* result) {
     TVM_FFI_ICHECK_NOTNULL(src);
     result->type_index = TypeIndex::kTVMFFIByteArrayPtr;
     TVM_FFI_CLEAR_PTR_PADDING_IN_FFI_ANY(result);
     result->v_ptr = src;
   }
 
-  static TVM_FFI_INLINE void MoveToAny(TVMFFIByteArray* src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(TVMFFIByteArray* src, TVMFFIAny* result) {
     ObjectRefTypeTraitsBase<Bytes>::MoveToAny(Bytes(*src), result);
   }
 
-  static TVM_FFI_INLINE std::optional<TVMFFIByteArray*> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<TVMFFIByteArray*> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIByteArrayPtr) {
       return static_cast<TVMFFIByteArray*>(src->v_ptr);
     }
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return StaticTypeKey::kTVMFFIByteArrayPtr; }
+  TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIByteArrayPtr; }
 };
 
 template <>
@@ -494,7 +494,7 @@ inline constexpr bool use_default_type_traits_v<Bytes> = false;
 template <>
 struct TypeTraits<Bytes> : public ObjectRefWithFallbackTraitsBase<Bytes, TVMFFIByteArray*> {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIBytes;
-  static TVM_FFI_INLINE Bytes ConvertFallbackValue(TVMFFIByteArray* src) { return Bytes(*src); }
+  TVM_FFI_INLINE static Bytes ConvertFallbackValue(TVMFFIByteArray* src) { return Bytes(*src); }
 };
 
 template <>
@@ -504,7 +504,7 @@ inline constexpr bool use_default_type_traits_v<String> = false;
 template <>
 struct TypeTraits<String> : public ObjectRefWithFallbackTraitsBase<String, const char*> {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIStr;
-  static TVM_FFI_INLINE String ConvertFallbackValue(const char* src) { return String(src); }
+  TVM_FFI_INLINE static String ConvertFallbackValue(const char* src) { return String(src); }
 };
 
 template <>
@@ -513,31 +513,31 @@ inline constexpr bool use_default_type_traits_v<std::string> = false;
 template <>
 struct TypeTraits<std::string>
     : public FallbackOnlyTraitsBase<std::string, const char*, TVMFFIByteArray*, Bytes, String> {
-  static TVM_FFI_INLINE void CopyToAnyView(const std::string& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const std::string& src, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIRawStr;
     result->v_c_str = src.c_str();
   }
 
-  static TVM_FFI_INLINE void MoveToAny(std::string src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(std::string src, TVMFFIAny* result) {
     // when we need to move to any, convert to owned object first
     ObjectRefTypeTraitsBase<String>::MoveToAny(String(std::move(src)), result);
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return "std::string"; }
+  TVM_FFI_INLINE static std::string TypeStr() { return "std::string"; }
 
-  static TVM_FFI_INLINE std::string ConvertFallbackValue(const char* src) {
+  TVM_FFI_INLINE static std::string ConvertFallbackValue(const char* src) {
     return std::string(src);
   }
 
-  static TVM_FFI_INLINE std::string ConvertFallbackValue(TVMFFIByteArray* src) {
+  TVM_FFI_INLINE static std::string ConvertFallbackValue(TVMFFIByteArray* src) {
     return std::string(src->data, src->size);
   }
 
-  static TVM_FFI_INLINE std::string ConvertFallbackValue(Bytes src) {
+  TVM_FFI_INLINE static std::string ConvertFallbackValue(Bytes src) {
     return src.operator std::string();
   }
 
-  static TVM_FFI_INLINE std::string ConvertFallbackValue(String src) {
+  TVM_FFI_INLINE static std::string ConvertFallbackValue(String src) {
     return src.operator std::string();
   }
 };

--- a/ffi/include/tvm/ffi/type_traits.h
+++ b/ffi/include/tvm/ffi/type_traits.h
@@ -89,7 +89,7 @@ struct TypeTraitsBase {
   // this function is called after TryCastFromAnyView fails
   // to get more detailed type information in runtime
   // especially when the error involves nested container type
-  static TVM_FFI_INLINE std::string GetMismatchTypeInfo(const TVMFFIAny* source) {
+  TVM_FFI_INLINE static std::string GetMismatchTypeInfo(const TVMFFIAny* source) {
     return TypeIndexToTypeKey(source->type_index);
   }
 };
@@ -119,38 +119,38 @@ template <>
 struct TypeTraits<std::nullptr_t> : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFINone;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const std::nullptr_t&, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const std::nullptr_t&, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFINone;
     // invariant: the pointer field also equals nullptr
     // this will simplify same_as comparisons and hash
     result->v_int64 = 0;
   }
 
-  static TVM_FFI_INLINE void MoveToAny(std::nullptr_t, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(std::nullptr_t, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFINone;
     // invariant: the pointer field also equals nullptr
     // this will simplify same_as comparisons and hash
     result->v_int64 = 0;
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     return src->type_index == TypeIndex::kTVMFFINone;
   }
 
-  static TVM_FFI_INLINE std::nullptr_t CopyFromAnyViewAfterCheck(const TVMFFIAny*) {
+  TVM_FFI_INLINE static std::nullptr_t CopyFromAnyViewAfterCheck(const TVMFFIAny*) {
     return nullptr;
   }
 
-  static TVM_FFI_INLINE std::nullptr_t MoveFromAnyAfterCheck(TVMFFIAny*) { return nullptr; }
+  TVM_FFI_INLINE static std::nullptr_t MoveFromAnyAfterCheck(TVMFFIAny*) { return nullptr; }
 
-  static TVM_FFI_INLINE std::optional<std::nullptr_t> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<std::nullptr_t> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFINone) {
       return nullptr;
     }
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return StaticTypeKey::kTVMFFINone; }
+  TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFINone; }
 };
 
 /**
@@ -171,36 +171,36 @@ template <>
 struct TypeTraits<StrictBool> : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIBool;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const StrictBool& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const StrictBool& src, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIBool;
     result->v_int64 = static_cast<bool>(src);
   }
 
-  static TVM_FFI_INLINE void MoveToAny(StrictBool src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(StrictBool src, TVMFFIAny* result) {
     CopyToAnyView(src, result);
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     return src->type_index == TypeIndex::kTVMFFIBool;
   }
 
-  static TVM_FFI_INLINE StrictBool CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static StrictBool CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return static_cast<bool>(src->v_int64);
   }
 
-  static TVM_FFI_INLINE StrictBool MoveFromAnyAfterCheck(TVMFFIAny* src) {
+  TVM_FFI_INLINE static StrictBool MoveFromAnyAfterCheck(TVMFFIAny* src) {
     // POD type, we can just copy the value
     return CopyFromAnyViewAfterCheck(src);
   }
 
-  static TVM_FFI_INLINE std::optional<StrictBool> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<StrictBool> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIBool) {
       return StrictBool(static_cast<bool>(src->v_int64));
     }
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return StaticTypeKey::kTVMFFIBool; }
+  TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIBool; }
 };
 
 // Bool type, allow implicit casting from int
@@ -208,34 +208,34 @@ template <>
 struct TypeTraits<bool> : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIBool;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const bool& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const bool& src, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIBool;
     result->v_int64 = static_cast<int64_t>(src);
   }
 
-  static TVM_FFI_INLINE void MoveToAny(bool src, TVMFFIAny* result) { CopyToAnyView(src, result); }
+  TVM_FFI_INLINE static void MoveToAny(bool src, TVMFFIAny* result) { CopyToAnyView(src, result); }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     return src->type_index == TypeIndex::kTVMFFIBool;
   }
 
-  static TVM_FFI_INLINE bool CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return static_cast<bool>(src->v_int64);
   }
 
-  static TVM_FFI_INLINE bool MoveFromAnyAfterCheck(TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool MoveFromAnyAfterCheck(TVMFFIAny* src) {
     // POD type, we can just copy the value
     return CopyFromAnyViewAfterCheck(src);
   }
 
-  static TVM_FFI_INLINE std::optional<bool> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<bool> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIInt || src->type_index == TypeIndex::kTVMFFIBool) {
       return static_cast<bool>(src->v_int64);
     }
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return StaticTypeKey::kTVMFFIBool; }
+  TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIBool; }
 };
 
 // Integer POD values
@@ -243,35 +243,35 @@ template <typename Int>
 struct TypeTraits<Int, std::enable_if_t<std::is_integral_v<Int>>> : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIInt;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const Int& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const Int& src, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIInt;
     result->v_int64 = static_cast<int64_t>(src);
   }
 
-  static TVM_FFI_INLINE void MoveToAny(Int src, TVMFFIAny* result) { CopyToAnyView(src, result); }
+  TVM_FFI_INLINE static void MoveToAny(Int src, TVMFFIAny* result) { CopyToAnyView(src, result); }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     // NOTE: CheckAnyStrict is always strict and should be consistent with MoveToAny
     return src->type_index == TypeIndex::kTVMFFIInt;
   }
 
-  static TVM_FFI_INLINE Int CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static Int CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return static_cast<Int>(src->v_int64);
   }
 
-  static TVM_FFI_INLINE Int MoveFromAnyAfterCheck(TVMFFIAny* src) {
+  TVM_FFI_INLINE static Int MoveFromAnyAfterCheck(TVMFFIAny* src) {
     // POD type, we can just copy the value
     return CopyFromAnyViewAfterCheck(src);
   }
 
-  static TVM_FFI_INLINE std::optional<Int> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<Int> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIInt || src->type_index == TypeIndex::kTVMFFIBool) {
       return Int(src->v_int64);
     }
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return StaticTypeKey::kTVMFFIInt; }
+  TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIInt; }
 };
 
 // Enum Integer POD values
@@ -281,37 +281,37 @@ struct TypeTraits<IntEnum, std::enable_if_t<std::is_enum_v<IntEnum> &&
     : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIInt;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const IntEnum& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const IntEnum& src, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIInt;
     result->v_int64 = static_cast<int64_t>(src);
   }
 
-  static TVM_FFI_INLINE void MoveToAny(IntEnum src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(IntEnum src, TVMFFIAny* result) {
     CopyToAnyView(src, result);
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     // NOTE: CheckAnyStrict is always strict and should be consistent with MoveToAny
     return src->type_index == TypeIndex::kTVMFFIInt;
   }
 
-  static TVM_FFI_INLINE IntEnum CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static IntEnum CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return static_cast<IntEnum>(src->v_int64);
   }
 
-  static TVM_FFI_INLINE IntEnum MoveFromAnyAfterCheck(TVMFFIAny* src) {
+  TVM_FFI_INLINE static IntEnum MoveFromAnyAfterCheck(TVMFFIAny* src) {
     // POD type, we can just copy the value
     return CopyFromAnyViewAfterCheck(src);
   }
 
-  static TVM_FFI_INLINE std::optional<IntEnum> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<IntEnum> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIInt || src->type_index == TypeIndex::kTVMFFIBool) {
       return static_cast<IntEnum>(src->v_int64);
     }
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return StaticTypeKey::kTVMFFIInt; }
+  TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIInt; }
 };
 
 // Float POD values
@@ -320,28 +320,28 @@ struct TypeTraits<Float, std::enable_if_t<std::is_floating_point_v<Float>>>
     : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIFloat;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const Float& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const Float& src, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIFloat;
     result->v_float64 = static_cast<double>(src);
   }
 
-  static TVM_FFI_INLINE void MoveToAny(Float src, TVMFFIAny* result) { CopyToAnyView(src, result); }
+  TVM_FFI_INLINE static void MoveToAny(Float src, TVMFFIAny* result) { CopyToAnyView(src, result); }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     // NOTE: CheckAnyStrict is always strict and should be consistent with MoveToAny
     return src->type_index == TypeIndex::kTVMFFIFloat;
   }
 
-  static TVM_FFI_INLINE Float CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static Float CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return static_cast<Float>(src->v_float64);
   }
 
-  static TVM_FFI_INLINE Float MoveFromAnyAfterCheck(TVMFFIAny* src) {
+  TVM_FFI_INLINE static Float MoveFromAnyAfterCheck(TVMFFIAny* src) {
     // POD type, we can just copy the value
     return CopyFromAnyViewAfterCheck(src);
   }
 
-  static TVM_FFI_INLINE std::optional<Float> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<Float> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIFloat) {
       return Float(src->v_float64);
     } else if (src->type_index == TypeIndex::kTVMFFIInt ||
@@ -351,7 +351,7 @@ struct TypeTraits<Float, std::enable_if_t<std::is_floating_point_v<Float>>>
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return StaticTypeKey::kTVMFFIFloat; }
+  TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIFloat; }
 };
 
 // void*
@@ -359,27 +359,27 @@ template <>
 struct TypeTraits<void*> : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIOpaquePtr;
 
-  static TVM_FFI_INLINE void CopyToAnyView(void* src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(void* src, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIOpaquePtr;
     TVM_FFI_CLEAR_PTR_PADDING_IN_FFI_ANY(result);
     result->v_ptr = src;
   }
 
-  static TVM_FFI_INLINE void MoveToAny(void* src, TVMFFIAny* result) { CopyToAnyView(src, result); }
+  TVM_FFI_INLINE static void MoveToAny(void* src, TVMFFIAny* result) { CopyToAnyView(src, result); }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     // NOTE: CheckAnyStrict is always strict and should be consistent with MoveToAny
     return src->type_index == TypeIndex::kTVMFFIOpaquePtr;
   }
 
-  static TVM_FFI_INLINE void* CopyFromAnyViewAfterCheck(const TVMFFIAny* src) { return src->v_ptr; }
+  TVM_FFI_INLINE static void* CopyFromAnyViewAfterCheck(const TVMFFIAny* src) { return src->v_ptr; }
 
-  static TVM_FFI_INLINE void* MoveFromAnyAfterCheck(TVMFFIAny* src) {
+  TVM_FFI_INLINE static void* MoveFromAnyAfterCheck(TVMFFIAny* src) {
     // POD type, we can just copy the value
     return CopyFromAnyViewAfterCheck(src);
   }
 
-  static TVM_FFI_INLINE std::optional<void*> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<void*> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIOpaquePtr) {
       return static_cast<void*>(src->v_ptr);
     }
@@ -389,7 +389,7 @@ struct TypeTraits<void*> : public TypeTraitsBase {
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return StaticTypeKey::kTVMFFIOpaquePtr; }
+  TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIOpaquePtr; }
 };
 
 // Device
@@ -397,37 +397,37 @@ template <>
 struct TypeTraits<DLDevice> : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIDevice;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const DLDevice& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const DLDevice& src, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIDevice;
     result->v_device = src;
   }
 
-  static TVM_FFI_INLINE void MoveToAny(DLDevice src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(DLDevice src, TVMFFIAny* result) {
     result->type_index = TypeIndex::kTVMFFIDevice;
     result->v_device = src;
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     return src->type_index == TypeIndex::kTVMFFIDevice;
   }
 
-  static TVM_FFI_INLINE DLDevice CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static DLDevice CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return src->v_device;
   }
 
-  static TVM_FFI_INLINE DLDevice MoveFromAnyAfterCheck(TVMFFIAny* src) {
+  TVM_FFI_INLINE static DLDevice MoveFromAnyAfterCheck(TVMFFIAny* src) {
     // POD type, we can just copy the value
     return CopyFromAnyViewAfterCheck(src);
   }
 
-  static TVM_FFI_INLINE std::optional<DLDevice> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<DLDevice> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIDevice) {
       return src->v_device;
     }
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return StaticTypeKey::kTVMFFIDevice; }
+  TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIDevice; }
 };
 
 // DLTensor*, requirement: not nullable, do not retain ownership
@@ -436,27 +436,27 @@ struct TypeTraits<DLTensor*> : public TypeTraitsBase {
   static constexpr bool storage_enabled = false;
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIDLTensorPtr;
 
-  static TVM_FFI_INLINE void CopyToAnyView(DLTensor* src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(DLTensor* src, TVMFFIAny* result) {
     TVM_FFI_ICHECK_NOTNULL(src);
     result->type_index = TypeIndex::kTVMFFIDLTensorPtr;
     TVM_FFI_CLEAR_PTR_PADDING_IN_FFI_ANY(result);
     result->v_ptr = src;
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     return src->type_index == TypeIndex::kTVMFFIDLTensorPtr;
   }
 
-  static TVM_FFI_INLINE DLTensor* CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static DLTensor* CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return static_cast<DLTensor*>(src->v_ptr);
   }
 
-  static TVM_FFI_INLINE void MoveToAny(DLTensor*, TVMFFIAny*) {
+  TVM_FFI_INLINE static void MoveToAny(DLTensor*, TVMFFIAny*) {
     TVM_FFI_THROW(RuntimeError)
         << "DLTensor* cannot be held in Any as it does not retain ownership, use NDArray instead";
   }
 
-  static TVM_FFI_INLINE std::optional<DLTensor*> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<DLTensor*> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFIDLTensorPtr) {
       return static_cast<DLTensor*>(src->v_ptr);
     } else if (src->type_index == TypeIndex::kTVMFFINDArray) {
@@ -469,7 +469,7 @@ struct TypeTraits<DLTensor*> : public TypeTraitsBase {
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return "DLTensor*"; }
+  TVM_FFI_INLINE static std::string TypeStr() { return "DLTensor*"; }
 };
 
 // Traits for ObjectRef, None to ObjectRef will always fail.
@@ -479,7 +479,7 @@ struct ObjectRefTypeTraitsBase : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIObject;
   using ContainerType = typename TObjRef::ContainerType;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const TObjRef& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const TObjRef& src, TVMFFIAny* result) {
     if constexpr (TObjRef::_type_is_nullable) {
       if (!src.defined()) {
         TypeTraits<std::nullptr_t>::CopyToAnyView(nullptr, result);
@@ -492,7 +492,7 @@ struct ObjectRefTypeTraitsBase : public TypeTraitsBase {
     result->v_obj = obj_ptr;
   }
 
-  static TVM_FFI_INLINE void MoveToAny(TObjRef src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(TObjRef src, TVMFFIAny* result) {
     if constexpr (TObjRef::_type_is_nullable) {
       if (!src.defined()) {
         TypeTraits<std::nullptr_t>::CopyToAnyView(nullptr, result);
@@ -505,7 +505,7 @@ struct ObjectRefTypeTraitsBase : public TypeTraitsBase {
     result->v_obj = obj_ptr;
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     if constexpr (TObjRef::_type_is_nullable) {
       if (src->type_index == TypeIndex::kTVMFFINone) return true;
     }
@@ -513,7 +513,7 @@ struct ObjectRefTypeTraitsBase : public TypeTraitsBase {
             details::IsObjectInstance<ContainerType>(src->type_index));
   }
 
-  static TVM_FFI_INLINE TObjRef CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static TObjRef CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     if constexpr (TObjRef::_type_is_nullable) {
       if (src->type_index == TypeIndex::kTVMFFINone) {
         return TObjRef(ObjectPtr<Object>(nullptr));
@@ -522,7 +522,7 @@ struct ObjectRefTypeTraitsBase : public TypeTraitsBase {
     return TObjRef(details::ObjectUnsafe::ObjectPtrFromUnowned<Object>(src->v_obj));
   }
 
-  static TVM_FFI_INLINE TObjRef MoveFromAnyAfterCheck(TVMFFIAny* src) {
+  TVM_FFI_INLINE static TObjRef MoveFromAnyAfterCheck(TVMFFIAny* src) {
     if constexpr (TObjRef::_type_is_nullable) {
       if (src->type_index == TypeIndex::kTVMFFINone) {
         return TObjRef(ObjectPtr<Object>(nullptr));
@@ -535,7 +535,7 @@ struct ObjectRefTypeTraitsBase : public TypeTraitsBase {
     return TObjRef(std::move(obj_ptr));
   }
 
-  static TVM_FFI_INLINE std::optional<TObjRef> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<TObjRef> TryCastFromAnyView(const TVMFFIAny* src) {
     if constexpr (TObjRef::_type_is_nullable) {
       if (src->type_index == TypeIndex::kTVMFFINone) {
         return TObjRef(ObjectPtr<Object>(nullptr));
@@ -549,7 +549,7 @@ struct ObjectRefTypeTraitsBase : public TypeTraitsBase {
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return ContainerType::_type_key; }
+  TVM_FFI_INLINE static std::string TypeStr() { return ContainerType::_type_key; }
 };
 
 template <typename TObjRef>
@@ -572,12 +572,12 @@ struct FallbackOnlyTraitsBase : public TypeTraitsBase {
   // disable container for FallbackOnlyTraitsBase
   static constexpr bool storage_enabled = false;
 
-  static TVM_FFI_INLINE std::optional<T> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<T> TryCastFromAnyView(const TVMFFIAny* src) {
     return TryFallbackTypes<FallbackTypes...>(src);
   }
 
   template <typename FallbackType, typename... Rest>
-  static TVM_FFI_INLINE std::optional<T> TryFallbackTypes(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<T> TryFallbackTypes(const TVMFFIAny* src) {
     static_assert(!std::is_same_v<bool, FallbackType>,
                   "Using bool as FallbackType can cause bug because int will be detected as bool, "
                   "use tvm::ffi::StrictBool instead");
@@ -604,7 +604,7 @@ struct FallbackOnlyTraitsBase : public TypeTraitsBase {
  */
 template <typename ObjectRefType, typename... FallbackTypes>
 struct ObjectRefWithFallbackTraitsBase : public ObjectRefTypeTraitsBase<ObjectRefType> {
-  static TVM_FFI_INLINE std::optional<ObjectRefType> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<ObjectRefType> TryCastFromAnyView(const TVMFFIAny* src) {
     if (auto opt_obj = ObjectRefTypeTraitsBase<ObjectRefType>::TryCastFromAnyView(src)) {
       return *opt_obj;
     }
@@ -613,7 +613,7 @@ struct ObjectRefWithFallbackTraitsBase : public ObjectRefTypeTraitsBase<ObjectRe
   }
 
   template <typename FallbackType, typename... Rest>
-  static TVM_FFI_INLINE std::optional<ObjectRefType> TryFallbackTypes(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<ObjectRefType> TryFallbackTypes(const TVMFFIAny* src) {
     static_assert(!std::is_same_v<bool, FallbackType>,
                   "Using bool as FallbackType can cause bug because int will be detected as bool, "
                   "use tvm::ffi::StrictBool instead");
@@ -633,14 +633,14 @@ struct ObjectRefWithFallbackTraitsBase : public ObjectRefTypeTraitsBase<ObjectRe
 template <typename TObject>
 struct TypeTraits<TObject*, std::enable_if_t<std::is_base_of_v<Object, TObject>>>
     : public TypeTraitsBase {
-  static TVM_FFI_INLINE void CopyToAnyView(TObject* src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(TObject* src, TVMFFIAny* result) {
     TVMFFIObject* obj_ptr = details::ObjectUnsafe::GetHeader(src);
     result->type_index = obj_ptr->type_index;
     TVM_FFI_CLEAR_PTR_PADDING_IN_FFI_ANY(result);
     result->v_obj = obj_ptr;
   }
 
-  static TVM_FFI_INLINE void MoveToAny(TObject* src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(TObject* src, TVMFFIAny* result) {
     TVMFFIObject* obj_ptr = details::ObjectUnsafe::GetHeader(src);
     result->type_index = obj_ptr->type_index;
     TVM_FFI_CLEAR_PTR_PADDING_IN_FFI_ANY(result);
@@ -649,19 +649,19 @@ struct TypeTraits<TObject*, std::enable_if_t<std::is_base_of_v<Object, TObject>>
     details::ObjectUnsafe::IncRefObjectHandle(result->v_obj);
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     return src->type_index >= TypeIndex::kTVMFFIStaticObjectBegin &&
            details::IsObjectInstance<TObject>(src->type_index);
   }
 
-  static TVM_FFI_INLINE TObject* CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static TObject* CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     if constexpr (!std::is_const_v<TObject>) {
       static_assert(TObject::_type_mutable, "TObject must be mutable to enable cast from Any");
     }
     return details::ObjectUnsafe::RawObjectPtrFromUnowned<TObject>(src->v_obj);
   }
 
-  static TVM_FFI_INLINE std::optional<TObject*> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<TObject*> TryCastFromAnyView(const TVMFFIAny* src) {
     if constexpr (!std::is_const_v<TObject>) {
       static_assert(TObject::_type_mutable, "TObject must be mutable to enable cast from Any");
     }
@@ -669,7 +669,7 @@ struct TypeTraits<TObject*, std::enable_if_t<std::is_base_of_v<Object, TObject>>
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return TObject::_type_key; }
+  TVM_FFI_INLINE static std::string TypeStr() { return TObject::_type_key; }
 };
 
 template <typename T>
@@ -677,7 +677,7 @@ inline constexpr bool use_default_type_traits_v<Optional<T>> = false;
 
 template <typename T>
 struct TypeTraits<Optional<T>> : public TypeTraitsBase {
-  static TVM_FFI_INLINE void CopyToAnyView(const Optional<T>& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const Optional<T>& src, TVMFFIAny* result) {
     if (src.has_value()) {
       TypeTraits<T>::CopyToAnyView(*src, result);
     } else {
@@ -685,7 +685,7 @@ struct TypeTraits<Optional<T>> : public TypeTraitsBase {
     }
   }
 
-  static TVM_FFI_INLINE void MoveToAny(Optional<T> src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(Optional<T> src, TVMFFIAny* result) {
     if (src.has_value()) {
       TypeTraits<T>::MoveToAny(*std::move(src), result);
     } else {
@@ -693,26 +693,26 @@ struct TypeTraits<Optional<T>> : public TypeTraitsBase {
     }
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFINone) return true;
     return TypeTraits<T>::CheckAnyStrict(src);
   }
 
-  static TVM_FFI_INLINE Optional<T> CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static Optional<T> CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFINone) {
       return Optional<T>(std::nullopt);
     }
     return TypeTraits<T>::CopyFromAnyViewAfterCheck(src);
   }
 
-  static TVM_FFI_INLINE Optional<T> MoveFromAnyAfterCheck(TVMFFIAny* src) {
+  TVM_FFI_INLINE static Optional<T> MoveFromAnyAfterCheck(TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFINone) {
       return Optional<T>(std::nullopt);
     }
     return TypeTraits<T>::MoveFromAnyAfterCheck(src);
   }
 
-  static TVM_FFI_INLINE std::optional<Optional<T>> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<Optional<T>> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index == TypeIndex::kTVMFFINone) return Optional<T>(std::nullopt);
     if (std::optional<T> opt = TypeTraits<T>::TryCastFromAnyView(src)) {
       return Optional<T>(*std::move(opt));
@@ -724,11 +724,11 @@ struct TypeTraits<Optional<T>> : public TypeTraitsBase {
     }
   }
 
-  static TVM_FFI_INLINE std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::string GetMismatchTypeInfo(const TVMFFIAny* src) {
     return TypeTraits<T>::GetMismatchTypeInfo(src);
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() {
+  TVM_FFI_INLINE static std::string TypeStr() {
     return "Optional<" + TypeTraits<T>::TypeStr() + ">";
   }
 };

--- a/ffi/tests/cpp/testing_object.h
+++ b/ffi/tests/cpp/testing_object.h
@@ -132,19 +132,19 @@ template <>
 struct TypeTraits<testing::TPrimExpr>
     : public ObjectRefWithFallbackTraitsBase<testing::TPrimExpr, StrictBool, int64_t, double,
                                              String> {
-  static TVM_FFI_INLINE testing::TPrimExpr ConvertFallbackValue(StrictBool value) {
+  TVM_FFI_INLINE static testing::TPrimExpr ConvertFallbackValue(StrictBool value) {
     return testing::TPrimExpr("bool", static_cast<double>(value));
   }
 
-  static TVM_FFI_INLINE testing::TPrimExpr ConvertFallbackValue(int64_t value) {
+  TVM_FFI_INLINE static testing::TPrimExpr ConvertFallbackValue(int64_t value) {
     return testing::TPrimExpr("int64", static_cast<double>(value));
   }
 
-  static TVM_FFI_INLINE testing::TPrimExpr ConvertFallbackValue(double value) {
+  TVM_FFI_INLINE static testing::TPrimExpr ConvertFallbackValue(double value) {
     return testing::TPrimExpr("float32", static_cast<double>(value));
   }
   // hack into the dtype to store string
-  static TVM_FFI_INLINE testing::TPrimExpr ConvertFallbackValue(String value) {
+  TVM_FFI_INLINE static testing::TPrimExpr ConvertFallbackValue(String value) {
     return testing::TPrimExpr(value, 0);
   }
 };

--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -182,13 +182,13 @@ template <>
 struct TypeTraits<PrimExpr>
     : public ObjectRefWithFallbackTraitsBase<PrimExpr, StrictBool, int64_t, double, String,
                                              PrimExprConvertible> {
-  static TVM_FFI_INLINE PrimExpr ConvertFallbackValue(StrictBool value);
-  static TVM_FFI_INLINE PrimExpr ConvertFallbackValue(int64_t value);
-  static TVM_FFI_INLINE PrimExpr ConvertFallbackValue(double value);
-  static TVM_FFI_INLINE PrimExpr ConvertFallbackValue(String value) {
+  TVM_FFI_INLINE static PrimExpr ConvertFallbackValue(StrictBool value);
+  TVM_FFI_INLINE static PrimExpr ConvertFallbackValue(int64_t value);
+  TVM_FFI_INLINE static PrimExpr ConvertFallbackValue(double value);
+  TVM_FFI_INLINE static PrimExpr ConvertFallbackValue(String value) {
     return PrimExpr::ConvertFallbackValue(value);
   }
-  static TVM_FFI_INLINE PrimExpr ConvertFallbackValue(PrimExprConvertible value) {
+  TVM_FFI_INLINE static PrimExpr ConvertFallbackValue(PrimExprConvertible value) {
     return value->ToPrimExpr();
   }
 };
@@ -750,7 +750,7 @@ inline constexpr bool use_default_type_traits_v<IntImm> = false;
 // specialize to enable implicit conversion from const char*
 template <>
 struct TypeTraits<IntImm> : public ObjectRefWithFallbackTraitsBase<IntImm, int64_t> {
-  static TVM_FFI_INLINE IntImm ConvertFallbackValue(int64_t value) {
+  TVM_FFI_INLINE static IntImm ConvertFallbackValue(int64_t value) {
     auto dtype =
         (value > std::numeric_limits<int>::max() || value < std::numeric_limits<int>::min())
             ? DataType::Int(64)
@@ -764,7 +764,7 @@ inline constexpr bool use_default_type_traits_v<Integer> = false;
 
 template <>
 struct TypeTraits<Integer> : public ObjectRefWithFallbackTraitsBase<Integer, int64_t> {
-  static TVM_FFI_INLINE Integer ConvertFallbackValue(int64_t value) { return Integer(value); }
+  TVM_FFI_INLINE static Integer ConvertFallbackValue(int64_t value) { return Integer(value); }
 };
 
 template <>
@@ -772,7 +772,7 @@ inline constexpr bool use_default_type_traits_v<FloatImm> = false;
 
 template <>
 struct TypeTraits<FloatImm> : public ObjectRefWithFallbackTraitsBase<FloatImm, double> {
-  static TVM_FFI_INLINE FloatImm ConvertFallbackValue(double value) {
+  TVM_FFI_INLINE static FloatImm ConvertFallbackValue(double value) {
     return FloatImm(runtime::DataType::Float(32), value);
   }
 };
@@ -782,7 +782,7 @@ inline constexpr bool use_default_type_traits_v<Bool> = false;
 
 template <>
 struct TypeTraits<Bool> : public ObjectRefWithFallbackTraitsBase<Bool, int64_t> {
-  static TVM_FFI_INLINE Bool ConvertFallbackValue(int64_t value) { return Bool(value != 0); }
+  TVM_FFI_INLINE static Bool ConvertFallbackValue(int64_t value) { return Bool(value != 0); }
 };
 
 // define automatic conversion from bool, int64_t, double to PrimExpr

--- a/include/tvm/runtime/data_type.h
+++ b/include/tvm/runtime/data_type.h
@@ -462,21 +462,21 @@ template <>
 struct TypeTraits<runtime::DataType> : public TypeTraitsBase {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIDataType;
 
-  static TVM_FFI_INLINE void CopyToAnyView(const runtime::DataType& src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void CopyToAnyView(const runtime::DataType& src, TVMFFIAny* result) {
     // clear padding part to ensure the equality check can always check the v_uint64 part
     result->v_uint64 = 0;
     result->type_index = TypeIndex::kTVMFFIDataType;
     result->v_dtype = src;
   }
 
-  static TVM_FFI_INLINE void MoveToAny(runtime::DataType src, TVMFFIAny* result) {
+  TVM_FFI_INLINE static void MoveToAny(runtime::DataType src, TVMFFIAny* result) {
     // clear padding part to ensure the equality check can always check the v_uint64 part
     result->v_uint64 = 0;
     result->type_index = TypeIndex::kTVMFFIDataType;
     result->v_dtype = src;
   }
 
-  static TVM_FFI_INLINE std::optional<runtime::DataType> TryCastFromAnyView(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static std::optional<runtime::DataType> TryCastFromAnyView(const TVMFFIAny* src) {
     auto opt_dtype = TypeTraits<DLDataType>::TryCastFromAnyView(src);
     if (opt_dtype) {
       return runtime::DataType(opt_dtype.value());
@@ -484,15 +484,15 @@ struct TypeTraits<runtime::DataType> : public TypeTraitsBase {
     return std::nullopt;
   }
 
-  static TVM_FFI_INLINE bool CheckAnyStrict(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static bool CheckAnyStrict(const TVMFFIAny* src) {
     return TypeTraits<DLDataType>::CheckAnyStrict(src);
   }
 
-  static TVM_FFI_INLINE runtime::DataType CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
+  TVM_FFI_INLINE static runtime::DataType CopyFromAnyViewAfterCheck(const TVMFFIAny* src) {
     return runtime::DataType(TypeTraits<DLDataType>::CopyFromAnyViewAfterCheck(src));
   }
 
-  static TVM_FFI_INLINE std::string TypeStr() { return ffi::StaticTypeKey::kTVMFFIDataType; }
+  TVM_FFI_INLINE static std::string TypeStr() { return ffi::StaticTypeKey::kTVMFFIDataType; }
 };
 
 }  // namespace ffi

--- a/include/tvm/tir/expr.h
+++ b/include/tvm/tir/expr.h
@@ -1117,7 +1117,7 @@ inline constexpr bool use_default_type_traits_v<tvm::tir::StringImm> = false;
 template <>
 struct TypeTraits<tvm::tir::StringImm>
     : public ObjectRefWithFallbackTraitsBase<tvm::tir::StringImm, String> {
-  static TVM_FFI_INLINE tvm::tir::StringImm ConvertFallbackValue(String value) {
+  TVM_FFI_INLINE static tvm::tir::StringImm ConvertFallbackValue(String value) {
     return tvm::tir::StringImm(value);
   }
 };


### PR DESCRIPTION
Some changes:
- `__attribute__((unused))` is replaced by C++ standard attribute `[[maybe_unused]]` (https://en.cppreference.com/w/cpp/language/attributes/maybe_unused.html)
- `__forceinline` is replaced by `[[msvc::forceinline]]` (MSVC: https://learn.microsoft.com/en-us/cpp/cpp/attributes?view=msvc-170#msvcforceinline, NOTE that `inline` is added which is a slight difference with `__forceinline`)
- `__attribute__((always_inline))` is replaced by `[[gnu::always_inline]]` (Clang: https://clang.llvm.org/docs/AttributeReference.html#always-inline-force-inline, GCC: https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html)
- `__declspec(noinline)` is replaced by `[[msvc::noinline]]` (MSVC: https://learn.microsoft.com/en-us/cpp/cpp/attributes?view=msvc-170#msvcnoinline)
- `__attribute__((noinline))` is replaced by `[[gnu::noinline]]` (Clang: https://clang.llvm.org/docs/AttributeReference.html#noinline, GCC: https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html)

The specifier sequences in many declarations are reordered since:
```c++
[[attr]] static inline int a = 0; // OK
static inline int a [[attr]] = 0; // OK

static [[attr]] inline int a = 0; // NOT OK, mixed specifiers
static inline int [[attr]] a = 0; // NOT OK, attr is applied to the type
```

Reviewers can focus on `ffi/include/tvm/ffi/base_details.h` to avoid being overwhelmed by many trivial changes : )