### PR TITLE
[Fix][Serialization] Add support for NaN value serialization

### DIFF
--- a/src/node/serialization.cc
+++ b/src/node/serialization.cc
@@ -457,6 +457,8 @@ class JSONAttrSetter {
       *value = std::numeric_limits<double>::infinity();
     } else if (is.str() == "-inf") {
       *value = -std::numeric_limits<double>::infinity();
+    } else if (is.str() == "nan") {
+      *value = std::numeric_limits<double>::quiet_NaN();
     } else {
       is >> *value;
       if (is.fail()) {


### PR DESCRIPTION
### Description

Currently, the `JSONAttrSetter::ParseDouble` function in `src/node/serialization.cc` correctly handles infinity (`"inf"`, `"-inf"`) but does not have a case for Not-a-Number (`"nan"`). This can cause errors when serializing TVM objects that contain NaN float values.

This change adds a condition to explicitly check for the string `"nan"` and correctly parse it into `std::numeric_limits<double>::quiet_NaN()`. This aligns the NaN handling with the existing logic for infinity values, making the serialization more robust.
