### PR TITLE
[Test] Fix tuple pattern in unittest `tests/python/relax/test_dataflow_rewriter.py`

### DIFF
--- a/tests/python/relax/test_dataflow_rewriter.py
+++ b/tests/python/relax/test_dataflow_rewriter.py
@@ -1144,9 +1144,11 @@ def test_rewrite_of_implicit_tuple_with_three_elements():
             "rotary_embedding", [k], sinfo_args=R.Tensor([4096], "float32")
         )
 
+        tuple = (q_embed, k_embed, v)
+
         attention = R.call_pure_packed(
             "compute_self_attention",
-            [q_embed, k_embed, v, kv_cache],
+            [tuple[0], tuple[1], tuple[2], kv_cache],
             sinfo_args=R.Tensor([4096]),
         )
 
@@ -1169,9 +1171,9 @@ def test_rewrite_of_implicit_tuple_with_three_elements():
             ],
         )
 
-        v = embedded_qkv_tuple[2]
         q_embed = embedded_qkv_tuple[0]
         k_embed = embedded_qkv_tuple[1]
+        v = embedded_qkv_tuple[2]
 
         attention = R.call_pure_packed(
             "compute_self_attention",


### PR DESCRIPTION
The unit test `test_rewrite_of_implicit_tuple_with_three_elements()` has been failing due to a mismatch between the test IR and the expected pattern structure.

After some investigations, the failure is not caused by an issue in the rewriter implementation, but rather by a mismatch in the return structure of the `before()` pattern function. The pattern defined in the test expects the final expression to be a [tuple](https://github.com/apache/tvm/blob/7bd738a00b08ee5cd89623075f2f692c246881fd/tests/python/relax/test_dataflow_rewriter.py#L1115), but `before()` directly uses [unpacked values](https://github.com/apache/tvm/blob/7bd738a00b08ee5cd89623075f2f692c246881fd/tests/python/relax/test_dataflow_rewriter.py#L1149), causing the pattern match to fail.

To fix the test, we can simply add a tuple to match the pattern. Also, the rewritten function generates a natural indexing order (`0 -> 1 -> 2`), but the test has a different order [(`2 -> 0 -> 1`)](https://github.com/apache/tvm/blob/7bd738a00b08ee5cd89623075f2f692c246881fd/tests/python/relax/test_dataflow_rewriter.py#L1172-L1174) so we should update the indexing order in the test accordingly.

To reproduce:
```
<python> -m pytest -s -v tests/python/relax/test_dataflow_rewriter.py::test_rewrite_of_implicit_tuple_with_three_elements
```

Thanks,