### PR TITLE
[KVCache] Fix kernel dispatch based on attention kinds

### DIFF
--- a/python/tvm/relax/frontend/nn/llm/kv_cache.py
+++ b/python/tvm/relax/frontend/nn/llm/kv_cache.py
@@ -381,12 +381,8 @@ class FlashInferPagedKVCache(PagedKVCache):  # pylint: disable=too-few-public-me
             dtype_q=dtype,
             dtype_kv=dtype,
             dtype_o=dtype,
-            qk_head_dim=(
-                qk_head_dim if attn_kind_single == "mha" else mla_original_qk_head_dim
-            ),
-            v_head_dim=(
-                v_head_dim if attn_kind_single == "mha" else mla_original_v_head_dim
-            ),
+            qk_head_dim=(qk_head_dim if attn_kind_single == "mha" else mla_original_qk_head_dim),
+            v_head_dim=(v_head_dim if attn_kind_single == "mha" else mla_original_v_head_dim),
             target=target,
             enable_inline_rope=rope_mode == RopeMode.INLINE,
         )


### PR DESCRIPTION
This PR fixes a few kernel dispatch issues due to the recent introduction of `mha_sliding` as a new attention kind.

Tested on Qwen3 1.7B with MLC-LLM.