### PR TITLE
[Refactor] Build cython with isolate environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,7 +694,7 @@ if(NOT DEFINED ENV{CONDA_BUILD})
   message(STATUS ${CMAKE_CURRENT_BINARY_DIR})
   add_custom_target(
     tvm_cython ALL
-    ${Python_EXECUTABLE} setup.py build_ext --inplace
+    ${Python_EXECUTABLE} -I setup.py build_ext --inplace
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python
   )
   add_dependencies(tvm_cython tvm)

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,7 +20,6 @@ import os
 import pathlib
 import shutil
 import sys
-import sys
 
 from setuptools import find_packages
 from setuptools.dist import Distribution


### PR DESCRIPTION
this pull request changed the Cython build command in CMakeLists.txt to use the `-I` option because when utilizing TVM as a cmake 3rdparty module, the main environment's Python may pollute sys.path, causing Cython to not be found.

```python
add_custom_target(
  tvm_cython ALL
  ${Python_EXECUTABLE} -I setup.py build_ext --inplace
  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python
)
```