### PR TITLE
[Fix][ONNX] Fix CumSum conversion when loading ONNX model

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1338,9 +1338,16 @@ class CumSum(OnnxOpConverter):
             axis = int(axis.data.numpy())
         elif isinstance(axis, relax.Var):
             axis = 0
-        data = relax.op.cumsum(data, axis)
+
         if attr.get("reverse", 0) != 0:
             data = bb.emit_te(topi.flip, data, axis=axis if axis else 0)
+
+        data = relax.op.cumsum(data, axis)
+        data = bb.normalize(data)
+
+        if attr.get("reverse", 0) != 0:
+            data = bb.emit_te(topi.flip, data, axis=axis if axis else 0)
+
         return data
 
 

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -1099,7 +1099,7 @@ def test_pow():
     verify_binary("Pow", [32, 32], [32, 32], [32, 32])
 
 
-@pytest.mark.parametrize("reverse", [False])
+@pytest.mark.parametrize("reverse", [True, False])
 @pytest.mark.parametrize("exclusive", [False])
 def test_cumsum(reverse, exclusive):
     cumsum_node = helper.make_node(


### PR DESCRIPTION
- Fix the ONNX CumSum converter to properly handle reversed cumsum operations by:
  - Flip the input before cumsum if reverse=True
  - Flip the output back to maintain original dimension order
  - Add proper normalization of the output of relax.op.cumsum (Fix https://github.com/apache/tvm/issues/18135)
  - Add reverse=True test case to verify reversed cumsum operation