### PR TITLE
[BugFix][NNAPI] Fix type mismatch and test_mean annotation

### DIFF
--- a/src/relax/backend/contrib/nnapi/codegen.cc
+++ b/src/relax/backend/contrib/nnapi/codegen.cc
@@ -258,7 +258,9 @@ Array<runtime::Module> NNAPICompiler(Array<Function> functions, Map<String, ffi:
     auto constant_names = serializer.GetConstantNames();
     const auto pf = tvm::ffi::Function::GetGlobalRequired("runtime.nnapi_runtime_create");
     auto func_name = GetExtSymbol(func);
-    compiled_functions.push_back(pf(func_name, graph_json, constant_names));
+    auto result = pf(func_name, graph_json, constant_names);
+    tvm::runtime::Module mod = result.cast<tvm::runtime::Module>();
+    compiled_functions.push_back(mod);
   }
 
   return compiled_functions;

--- a/tests/python/nightly/test_nnapi/test_ops.py
+++ b/tests/python/nightly/test_nnapi/test_ops.py
@@ -272,7 +272,7 @@ def test_mean():
             ) -> R.Tensor((1, 10, 1), "float32"):
                 n = T.int64()
                 with R.dataflow():
-                    t0: R.Tensor((1, 10, 15), "float32") = R.mean(i0, axis=[-1], keepdims=True)
+                    t0: R.Tensor((1, 10, 1), "float32") = R.mean(i0, axis=[-1], keepdims=True)
                     R.output(t0)
                 return t0
 


### PR DESCRIPTION
This PR includes two small fixes for the Relax NNAPI backend introduced in PR #17385:
1. Fix a type mismatch in `NNAPICompiler` by casting `tvm::ffi::Any` to `tvm::runtime::Module`.
2. Correct a mismatched annotation in the Relax IR used in `test_mean`.

Verified locally with successful compilation and test run.

Co-authored-by: HMZ <mzhuang@pllab.cs.nthu.edu.tw>