### PR TITLE
[Test] Use roi_list variable instead of hardcoded values in ROI tensor creation

### DIFF
--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -2396,11 +2396,7 @@ def test_resize(with_roi, roi_list):
         ],
         initializer=[
             helper.make_tensor("scales", TensorProto.FLOAT, [4], [1.0, 1.0, 2.0, 2.0]),
-            *(
-                [helper.make_tensor("roi", TensorProto.FLOAT, [4], [0.0, 0.0, 0.0, 0.0])]
-                if with_roi
-                else []
-            ),
+            *([helper.make_tensor("roi", TensorProto.FLOAT, [4], roi_list)] if with_roi else []),
         ],
         outputs=[
             helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 3, 64, 64]),


### PR DESCRIPTION
This PR replaces the hardcoded [0.0, 0.0, 0.0, 0.0] values with the roi_list variable when creating the ROI tensor, addressing an issue from the previous PR (https://github.com/apache/tvm/pull/18138) where the ROI values weren't properly configurable.