### PR TITLE
[BugFix] Fix NCCL build with GlobalDef registration

### DIFF
--- a/src/runtime/disco/nccl/nccl.cc
+++ b/src/runtime/disco/nccl/nccl.cc
@@ -329,9 +329,9 @@ void SyncWorker() {
 
 TVM_FFI_STATIC_INIT_BLOCK({
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("runtime.disco.compiled_ccl",
-                        []() -> String { return TVM_DISCO_CCL_NAME; });
-  .def("runtime.disco." TVM_DISCO_CCL_NAME ".init_ccl", InitCCL)
+  refl::GlobalDef()
+      .def("runtime.disco.compiled_ccl", []() -> String { return TVM_DISCO_CCL_NAME; })
+      .def("runtime.disco." TVM_DISCO_CCL_NAME ".init_ccl", InitCCL)
       .def("runtime.disco." TVM_DISCO_CCL_NAME ".init_ccl_per_worker", InitCCLPerWorker)
       .def("runtime.disco." TVM_DISCO_CCL_NAME ".allreduce",
            [](NDArray send, int kind, bool in_group, NDArray recv) {


### PR DESCRIPTION
This PR fixes a build failure in nccl.cc due to the recent switch of global function registration.