### PR TITLE
[FFI][REFACTOR] Enable custom s_hash/equal

### DIFF
--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -26,6 +26,7 @@ project(
 
 option(TVM_FFI_BUILD_TESTS "Adding test targets." OFF)
 option(TVM_FFI_USE_LIBBACKTRACE "Enable libbacktrace" ON)
+option(TVM_FFI_USE_EXTRA_CXX_API "Enable extra CXX API in shared lib" ON)
 option(TVM_FFI_BACKTRACE_ON_SEGFAULT "Set signal handler to print traceback on segfault" ON)
 
 include(cmake/Utils/CxxWarning.cmake)
@@ -47,7 +48,8 @@ target_include_directories(tvm_ffi_header INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}
 target_link_libraries(tvm_ffi_header INTERFACE dlpack_header)
 
 ########## Target: `tvm_ffi` ##########
-add_library(tvm_ffi_objs OBJECT
+
+set(tvm_ffi_objs_sources
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/traceback.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/traceback_win.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/object.cc"
@@ -57,10 +59,18 @@ add_library(tvm_ffi_objs OBJECT
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/dtype.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/testing.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/container.cc"
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/reflection/access_path.cc"
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/reflection/structural_equal.cc"
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/reflection/structural_hash.cc"
 )
+
+if (TVM_FFI_USE_EXTRA_CXX_API)
+  list(APPEND tvm_ffi_objs_sources
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/reflection/access_path.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/reflection/structural_equal.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/reflection/structural_hash.cc"
+  )
+endif()
+
+add_library(tvm_ffi_objs OBJECT ${tvm_ffi_objs_sources})
+
 set_target_properties(
   tvm_ffi_objs PROPERTIES
   POSITION_INDEPENDENT_CODE ON

--- a/ffi/include/tvm/ffi/c_api.h
+++ b/ffi/include/tvm/ffi/c_api.h
@@ -424,6 +424,27 @@ typedef enum {
    * is only an unique copy of each value.
    */
   kTVMFFISEqHashKindUniqueInstance = 5,
+  /*!
+   * \brief provide custom __s_equal__ and __s_hash__ functions through TypeAttrColumn.
+   *
+   * The function signatures are(defined via ffi::Function)
+   *
+   * \code
+   * bool __s_equal__(
+   *   ObjectRefType self, ObjectRefType other,
+   *   ffi::TypedFunction<bool(AnyView, AnyView, bool def_region, string field_name)> cmp,
+   * );
+   *
+   * uint64_t __s_hash__(
+   *   ObjectRefType self, uint64_t type_key_hash,
+   *   ffi::TypedFunction<uint64_t(AnyView, bool def_region)> hash
+   * );
+   * \endcode
+   *
+   * Where the extra string field in cmp is the name of the field that is being compared.
+   * The function should be registered through TVMFFITypeRegisterAttr via reflection::TypeAttrDef.
+   */
+  kTVMFFISEqHashKindCustomTreeNode = 6,
 #ifdef __cplusplus
 };
 #else
@@ -539,7 +560,9 @@ typedef struct {
 /*
  * \brief Column array that stores extra attributes about types
  *
- * The attributes stored in column arrays that can be looked up by type index.
+ * The attributes stored in a column array that can be looked up by type index.
+ * Note that the TypeAttr behaves like type_traits so column[T] so not contain
+ * attributes from base classes.
  *
  * \note
  * \sa TVMFFIRegisterTypeAttr

--- a/ffi/src/ffi/object.cc
+++ b/ffi/src/ffi/object.cc
@@ -247,6 +247,8 @@ class TypeTable {
       column_index = type_attr_columns_.size();
       type_attr_columns_.emplace_back(std::make_unique<TypeAttrColumnData>());
       type_attr_name_to_column_index_.Set(name_str, column_index);
+    } else {
+      column_index = (*it).second;
     }
     TypeAttrColumnData* column = type_attr_columns_[column_index].get();
     if (column->data_.size() < static_cast<size_t>(type_index + 1)) {

--- a/ffi/tests/cpp/CMakeLists.txt
+++ b/ffi/tests/cpp/CMakeLists.txt
@@ -1,4 +1,10 @@
 file(GLOB _test_sources "${CMAKE_CURRENT_SOURCE_DIR}/test*.cc")
+file(GLOB _test_extra_sources "${CMAKE_CURRENT_SOURCE_DIR}/extra/test*.cc")
+
+if (TVM_FFI_USE_EXTRA_CXX_API)
+  list(APPEND _test_sources ${_test_extra_sources})
+endif()
+
 add_executable(
   tvm_ffi_tests
   EXCLUDE_FROM_ALL

--- a/ffi/tests/cpp/extra/test_reflection_structural_equal_hash.cc
+++ b/ffi/tests/cpp/extra/test_reflection_structural_equal_hash.cc
@@ -26,7 +26,7 @@
 #include <tvm/ffi/reflection/structural_hash.h>
 #include <tvm/ffi/string.h>
 
-#include "./testing_object.h"
+#include "../testing_object.h"
 
 namespace {
 
@@ -151,6 +151,32 @@ TEST(StructuralEqualHash, FuncDefAndIgnoreField) {
   TFunc fb = TFunc({y}, {TInt(1), y}, "comment b");
 
   TFunc fc = TFunc({x}, {TInt(1), TInt(2)}, "comment c");
+
+  EXPECT_TRUE(refl::StructuralEqual()(fa, fb));
+  EXPECT_EQ(refl::StructuralHash()(fa), refl::StructuralHash()(fb));
+
+  EXPECT_FALSE(refl::StructuralEqual()(fa, fc));
+  auto diff_fa_fc = refl::StructuralEqual::GetFirstMismatch(fa, fc);
+  auto expected_diff_fa_fc = refl::AccessPathPair(refl::AccessPath({
+                                                      refl::AccessStep::ObjectField("body"),
+                                                      refl::AccessStep::ArrayIndex(1),
+                                                  }),
+                                                  refl::AccessPath({
+                                                      refl::AccessStep::ObjectField("body"),
+                                                      refl::AccessStep::ArrayIndex(1),
+                                                  }));
+  EXPECT_TRUE(diff_fa_fc.has_value());
+  EXPECT_TRUE(refl::StructuralEqual()(diff_fa_fc, expected_diff_fa_fc));
+}
+
+TEST(StructuralEqualHash, CustomTreeNode) {
+  TVar x = TVar("x");
+  TVar y = TVar("y");
+  // comment fields are ignored
+  TCustomFunc fa = TCustomFunc({x}, {TInt(1), x}, "comment a");
+  TCustomFunc fb = TCustomFunc({y}, {TInt(1), y}, "comment b");
+
+  TCustomFunc fc = TCustomFunc({x}, {TInt(1), TInt(2)}, "comment c");
 
   EXPECT_TRUE(refl::StructuralEqual()(fa, fb));
   EXPECT_EQ(refl::StructuralHash()(fa), refl::StructuralHash()(fb));

--- a/ffi/tests/cpp/test_reflection_accessor.cc
+++ b/ffi/tests/cpp/test_reflection_accessor.cc
@@ -55,6 +55,7 @@ TVM_FFI_STATIC_INIT_BLOCK({
   TPrimExprObj::RegisterReflection();
   TVarObj::RegisterReflection();
   TFuncObj::RegisterReflection();
+  TCustomFuncObj::RegisterReflection();
 
   refl::ObjectDef<TestObjA>().def_ro("x", &TestObjA::x).def_rw("y", &TestObjA::y);
   refl::ObjectDef<TestObjADerived>().def_ro("z", &TestObjADerived::z);


### PR DESCRIPTION
This PR enables custom shash equal via TypeAttr,
also enhances the Var comparison by checking content so we can precheck type signatures.