### PR TITLE
[FFI][REFACTOR] Migrate StructuralEqual/Hash to new reflection

### DIFF
--- a/ffi/include/tvm/ffi/c_api.h
+++ b/ffi/include/tvm/ffi/c_api.h
@@ -424,27 +424,6 @@ typedef enum {
    * is only an unique copy of each value.
    */
   kTVMFFISEqHashKindUniqueInstance = 5,
-  /*!
-   * \brief provide custom __s_equal__ and __s_hash__ functions through TypeAttrColumn.
-   *
-   * The function signatures are(defined via ffi::Function)
-   *
-   * \code
-   * bool __s_equal__(
-   *   ObjectRefType self, ObjectRefType other,
-   *   ffi::TypedFunction<bool(AnyView, AnyView, bool def_region, string field_name)> cmp,
-   * );
-   *
-   * uint64_t __s_hash__(
-   *   ObjectRefType self, uint64_t type_key_hash,
-   *   ffi::TypedFunction<uint64_t(AnyView, bool def_region)> hash
-   * );
-   * \endcode
-   *
-   * Where the extra string field in cmp is the name of the field that is being compared.
-   * The function should be registered through TVMFFITypeRegisterAttr via reflection::TypeAttrDef.
-   */
-  kTVMFFISEqHashKindCustomTreeNode = 6,
 #ifdef __cplusplus
 };
 #else

--- a/ffi/tests/cpp/testing_object.h
+++ b/ffi/tests/cpp/testing_object.h
@@ -227,10 +227,11 @@ class TCustomFuncObj : public Object {
     return true;
   }
 
-  uint64_t SHash(uint64_t type_key_hash, ffi::TypedFunction<uint64_t(AnyView, bool)> hash) const {
-    uint64_t hash_value = type_key_hash;
-    hash_value = tvm::ffi::details::StableHashCombine(hash_value, hash(params, true));
-    hash_value = tvm::ffi::details::StableHashCombine(hash_value, hash(body, false));
+  uint64_t SHash(uint64_t init_hash,
+                 ffi::TypedFunction<uint64_t(AnyView, uint64_t, bool)> hash) const {
+    uint64_t hash_value = init_hash;
+    hash_value = hash(params, hash_value, true);
+    hash_value = hash(body, hash_value, false);
     return hash_value;
   }
 
@@ -246,7 +247,7 @@ class TCustomFuncObj : public Object {
   }
 
   static constexpr const char* _type_key = "test.CustomFunc";
-  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindCustomTreeNode;
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TCustomFuncObj, Object);
 };
 

--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -106,6 +106,7 @@ class ConstIntBoundNode : public Object {
    */
   static const constexpr int64_t kNegInf = -kPosInf;
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "arith.ConstIntBound";
   TVM_DECLARE_FINAL_OBJECT_INFO(ConstIntBoundNode, Object);
 };
@@ -222,6 +223,7 @@ class ModularSetNode : public Object {
     return equal(coeff, other->coeff) && equal(base, other->base);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "arith.ModularSet";
   TVM_DECLARE_FINAL_OBJECT_INFO(ModularSetNode, Object);
 };

--- a/include/tvm/arith/int_solver.h
+++ b/include/tvm/arith/int_solver.h
@@ -83,6 +83,7 @@ class IntGroupBoundsNode : public Object {
     hash_reduce(upper);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const char* _type_key = "arith.IntGroupBounds";
   TVM_DECLARE_FINAL_OBJECT_INFO(IntGroupBoundsNode, Object);
@@ -173,6 +174,7 @@ class IntConstraintsNode : public Object {
     hash_reduce(relations);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const char* _type_key = "arith.IntConstraints";
   TVM_DECLARE_FINAL_OBJECT_INFO(IntConstraintsNode, Object);
@@ -238,6 +240,7 @@ class IntConstraintsTransformNode : public Object {
     hash_reduce(dst_to_src);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const char* _type_key = "arith.IntConstraintsTransform";
   TVM_DECLARE_FINAL_OBJECT_INFO(IntConstraintsTransformNode, Object);

--- a/include/tvm/arith/iter_affine_map.h
+++ b/include/tvm/arith/iter_affine_map.h
@@ -116,6 +116,7 @@ class IterMarkNode : public Object {
     hash_reduce(extent);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindDAGNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
   static constexpr const char* _type_key = "arith.IterMark";
@@ -176,6 +177,7 @@ class IterSplitExprNode : public IterMapExprNode {
     hash_reduce(scale);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "arith.IterSplitExpr";
   TVM_DECLARE_FINAL_OBJECT_INFO(IterSplitExprNode, IterMapExprNode);
 };
@@ -239,6 +241,7 @@ class IterSumExprNode : public IterMapExprNode {
     hash_reduce(base);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "arith.IterSumExpr";
   TVM_DECLARE_FINAL_OBJECT_INFO(IterSumExprNode, IterMapExprNode);
 };

--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -83,7 +83,7 @@ class AttrFieldInfoNode : public Object {
   }
 
   static constexpr const char* _type_key = "ir.AttrFieldInfo";
-
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr bool _type_has_method_sequal_reduce = false;
   static constexpr bool _type_has_method_shash_reduce = false;
   TVM_DECLARE_FINAL_OBJECT_INFO(AttrFieldInfoNode, Object);
@@ -122,6 +122,7 @@ class BaseAttrsNode : public Object {
   TVM_DLL virtual void InitByPackedArgs(const ffi::PackedArgs& kwargs,
                                         bool allow_unknown = false) = 0;
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
   static constexpr const char* _type_key = "ir.Attrs";

--- a/include/tvm/ir/diagnostic.h
+++ b/include/tvm/ir/diagnostic.h
@@ -79,6 +79,7 @@ class DiagnosticNode : public Object {
            equal(this->message, other->message);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "Diagnostic";
   TVM_DECLARE_FINAL_OBJECT_INFO(DiagnosticNode, Object);
 };
@@ -214,6 +215,7 @@ class DiagnosticContextNode : public Object {
     return equal(module, other->module) && equal(diagnostics, other->diagnostics);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "DiagnosticContext";
   TVM_DECLARE_FINAL_OBJECT_INFO(DiagnosticContextNode, Object);
 };

--- a/include/tvm/ir/env_func.h
+++ b/include/tvm/ir/env_func.h
@@ -51,7 +51,10 @@ class EnvFuncNode : public Object {
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
-    refl::ObjectDef<EnvFuncNode>().def_ro("name", &EnvFuncNode::name);
+    // func do not participate in structural equal and hash.
+    refl::ObjectDef<EnvFuncNode>()
+        .def_ro("name", &EnvFuncNode::name)
+        .def_ro("func", &EnvFuncNode::func, refl::AttachFieldFlag::SEqHashIgnore());
   }
 
   bool SEqualReduce(const EnvFuncNode* other, SEqualReducer equal) const {
@@ -64,6 +67,7 @@ class EnvFuncNode : public Object {
     hash_reduce(name);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "ir.EnvFunc";
   static constexpr bool _type_has_method_sequal_reduce = true;
   static constexpr bool _type_has_method_shash_reduce = true;

--- a/include/tvm/ir/global_info.h
+++ b/include/tvm/ir/global_info.h
@@ -43,6 +43,8 @@ using MemoryScope = String;
 class GlobalInfoNode : public Object {
  public:
   static constexpr const char* _type_key = "ir.GlobalInfo";
+
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
   TVM_DECLARE_BASE_OBJECT_INFO(GlobalInfoNode, Object);

--- a/include/tvm/ir/module.h
+++ b/include/tvm/ir/module.h
@@ -138,11 +138,20 @@ class IRModuleNode : public Object {
         .def_ro("source_map", &IRModuleNode::source_map)
         .def_ro("attrs", &IRModuleNode::attrs)
         .def_ro("global_infos", &IRModuleNode::global_infos);
+    // register custom structural equal and hash.
+    refl::TypeAttrDef<IRModuleNode>()
+        .def("__s_equal__", &IRModuleNode::SEqual)
+        .def("__s_hash__", &IRModuleNode::SHash);
   }
 
   TVM_DLL bool SEqualReduce(const IRModuleNode* other, SEqualReducer equal) const;
 
   TVM_DLL void SHashReduce(SHashReducer hash_reduce) const;
+
+  TVM_DLL bool SEqual(const IRModuleNode* other,
+                      ffi::TypedFunction<bool(AnyView, AnyView, bool, AnyView)> equal) const;
+  TVM_DLL uint64_t SHash(uint64_t init_hash,
+                         ffi::TypedFunction<uint64_t(AnyView, uint64_t, bool)> hash) const;
 
   /*!
    * \brief Add a function to the global environment.
@@ -237,6 +246,7 @@ class IRModuleNode : public Object {
   TVM_OBJECT_ENABLE_SCRIPT_PRINTER();
 
   static constexpr const char* _type_key = "ir.IRModule";
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
   TVM_DECLARE_FINAL_OBJECT_INFO(IRModuleNode, Object);

--- a/include/tvm/ir/op.h
+++ b/include/tvm/ir/op.h
@@ -95,12 +95,12 @@ class OpNode : public RelaxExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<OpNode>()
         .def_ro("name", &OpNode::name)
-        .def_ro("op_type", &OpNode::op_type)
-        .def_ro("description", &OpNode::description)
-        .def_ro("arguments", &OpNode::arguments)
-        .def_ro("attrs_type_key", &OpNode::attrs_type_key)
-        .def_ro("num_inputs", &OpNode::num_inputs)
-        .def_ro("support_level", &OpNode::support_level);
+        .def_ro("op_type", &OpNode::op_type, refl::AttachFieldFlag::SEqHashIgnore())
+        .def_ro("description", &OpNode::description, refl::AttachFieldFlag::SEqHashIgnore())
+        .def_ro("arguments", &OpNode::arguments, refl::AttachFieldFlag::SEqHashIgnore())
+        .def_ro("attrs_type_key", &OpNode::attrs_type_key, refl::AttachFieldFlag::SEqHashIgnore())
+        .def_ro("num_inputs", &OpNode::num_inputs, refl::AttachFieldFlag::SEqHashIgnore())
+        .def_ro("support_level", &OpNode::support_level, refl::AttachFieldFlag::SEqHashIgnore());
   }
 
   bool SEqualReduce(const OpNode* other, SEqualReducer equal) const {
@@ -113,6 +113,7 @@ class OpNode : public RelaxExprNode {
     hash_reduce(name);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindUniqueInstance;
   static constexpr const char* _type_key = "ir.Op";
   TVM_DECLARE_FINAL_OBJECT_INFO(OpNode, RelaxExprNode);
 

--- a/include/tvm/ir/source_map.h
+++ b/include/tvm/ir/source_map.h
@@ -59,6 +59,7 @@ class SourceNameNode : public Object {
     return equal(name, other->name);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "ir.SourceName";
   TVM_DECLARE_FINAL_OBJECT_INFO(SourceNameNode, Object);
 };
@@ -118,6 +119,7 @@ class SpanNode : public Object {
            equal(end_column, other->end_column);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "ir.Span";
   TVM_DECLARE_BASE_OBJECT_INFO(SpanNode, Object);
 };
@@ -233,6 +235,7 @@ class SourceMapObj : public Object {
     return equal(source_map, other->source_map);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "ir.SourceMap";
   TVM_DECLARE_FINAL_OBJECT_INFO(SourceMapObj, Object);
 };

--- a/include/tvm/ir/type.h
+++ b/include/tvm/ir/type.h
@@ -80,6 +80,14 @@ class TypeNode : public Object {
    */
   mutable Span span;
 
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    // span do not participate in structural equal and hash.
+    refl::ObjectDef<TypeNode>().def_ro("span", &TypeNode::span, refl::DefaultValue(Span()),
+                                       refl::AttachFieldFlag::SEqHashIgnore());
+  }
+
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "ir.Type";
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;

--- a/include/tvm/relax/distributed/struct_info.h
+++ b/include/tvm/relax/distributed/struct_info.h
@@ -61,6 +61,7 @@ class PlacementSpecNode : public Object {
   }
 
   static constexpr const char* _type_key = "relax.distributed.PlacementSpec";
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindConstTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
   TVM_DECLARE_BASE_OBJECT_INFO(PlacementSpecNode, Object);
@@ -119,6 +120,7 @@ class PlacementNode : public Object {
 
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindConstTreeNode;
   static constexpr const char* _type_key = "relax.distributed.Placement";
   TVM_DECLARE_FINAL_OBJECT_INFO(PlacementNode, Object);
 };

--- a/include/tvm/relax/struct_info.h
+++ b/include/tvm/relax/struct_info.h
@@ -341,7 +341,7 @@ class FuncStructInfoNode : public StructInfoNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<FuncStructInfoNode>()
-        .def_ro("params", &FuncStructInfoNode::params)
+        .def_ro("params", &FuncStructInfoNode::params, refl::AttachFieldFlag::SEqHashDef())
         .def_ro("ret", &FuncStructInfoNode::ret)
         .def_ro("derive_func", &FuncStructInfoNode::derive_func)
         .def_ro("purity", &FuncStructInfoNode::purity);

--- a/include/tvm/target/target.h
+++ b/include/tvm/target/target.h
@@ -177,7 +177,7 @@ class TargetNode : public Object {
   void SHashReduce(SHashReducer hash_reduce) const;
 
   static constexpr const char* _type_key = "target.Target";
-
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
   TVM_DECLARE_FINAL_OBJECT_INFO(TargetNode, Object);

--- a/include/tvm/target/target_kind.h
+++ b/include/tvm/target/target_kind.h
@@ -81,12 +81,14 @@ class TargetKindNode : public Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<TargetKindNode>()
         .def_ro("name", &TargetKindNode::name)
-        .def_ro("default_device_type", &TargetKindNode::default_device_type)
-        .def_ro("default_keys", &TargetKindNode::default_keys);
+        .def_ro("default_device_type", &TargetKindNode::default_device_type,
+                refl::AttachFieldFlag::SEqHashIgnore())
+        .def_ro("default_keys", &TargetKindNode::default_keys,
+                refl::AttachFieldFlag::SEqHashIgnore());
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindUniqueInstance;
   static constexpr const char* _type_key = "target.TargetKind";
-
   TVM_DECLARE_FINAL_OBJECT_INFO(TargetKindNode, Object);
 
  private:
@@ -134,9 +136,10 @@ class TargetKind : public ObjectRef {
    * \return The TargetKind requested
    */
   TVM_DLL static Optional<TargetKind> Get(const String& target_kind_name);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TargetKind, ObjectRef, TargetKindNode);
   /*! \brief Mutable access to the container class  */
   TargetKindNode* operator->() { return static_cast<TargetKindNode*>(data_.get()); }
+
+  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TargetKind, ObjectRef, TargetKindNode);
 
  private:
   TVM_DLL static const AttrRegistryMapContainerMap<TargetKind>& GetAttrMapContainer(

--- a/include/tvm/te/tensor.h
+++ b/include/tvm/te/tensor.h
@@ -88,6 +88,7 @@ class TensorNode : public DataProducerNode {
   TVM_DLL String GetNameHint() const final;
 
   static constexpr const char* _type_key = "te.Tensor";
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindConstTreeNode;
 
   TVM_DECLARE_FINAL_OBJECT_INFO(TensorNode, DataProducerNode);
 };

--- a/include/tvm/tir/buffer.h
+++ b/include/tvm/tir/buffer.h
@@ -115,13 +115,14 @@ class BufferNode : public Object {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<BufferNode>()
-        .def_ro("data", &BufferNode::data)
+        .def_ro("data", &BufferNode::data, refl::AttachFieldFlag::SEqHashDef())
         .def_ro("dtype", &BufferNode::dtype)
-        .def_ro("shape", &BufferNode::shape)
-        .def_ro("strides", &BufferNode::strides)
-        .def_ro("axis_separators", &BufferNode::axis_separators)
-        .def_ro("elem_offset", &BufferNode::elem_offset)
-        .def_ro("name", &BufferNode::name)
+        .def_ro("shape", &BufferNode::shape, refl::AttachFieldFlag::SEqHashDef())
+        .def_ro("strides", &BufferNode::strides, refl::AttachFieldFlag::SEqHashDef())
+        .def_ro("axis_separators", &BufferNode::axis_separators,
+                refl::AttachFieldFlag::SEqHashDef())
+        .def_ro("elem_offset", &BufferNode::elem_offset, refl::AttachFieldFlag::SEqHashDef())
+        .def_ro("name", &BufferNode::name, refl::AttachFieldFlag::SEqHashIgnore())
         .def_ro("data_alignment", &BufferNode::data_alignment)
         .def_ro("offset_factor", &BufferNode::offset_factor)
         .def_ro("buffer_type", &BufferNode::buffer_type)
@@ -163,6 +164,7 @@ class BufferNode : public Object {
   Array<PrimExpr> ElemOffset(Array<PrimExpr> index) const;
 
   static constexpr const char* _type_key = "tir.Buffer";
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
   TVM_DECLARE_FINAL_OBJECT_INFO(BufferNode, Object);

--- a/include/tvm/tir/expr.h
+++ b/include/tvm/tir/expr.h
@@ -833,7 +833,7 @@ class LetNode : public PrimExprNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<LetNode>()
-        .def_ro("var", &LetNode::var)
+        .def_ro("var", &LetNode::var, refl::AttachFieldFlag::SEqHashDef())
         .def_ro("value", &LetNode::value)
         .def_ro("body", &LetNode::body);
   }
@@ -989,11 +989,11 @@ class CommReducerNode : public Object {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<CommReducerNode>()
-        .def_ro("lhs", &CommReducerNode::lhs)
-        .def_ro("rhs", &CommReducerNode::rhs)
+        .def_ro("lhs", &CommReducerNode::lhs, refl::AttachFieldFlag::SEqHashDef())
+        .def_ro("rhs", &CommReducerNode::rhs, refl::AttachFieldFlag::SEqHashDef())
         .def_ro("result", &CommReducerNode::result)
         .def_ro("identity_element", &CommReducerNode::identity_element)
-        .def_ro("span", &CommReducerNode::span);
+        .def_ro("span", &CommReducerNode::span, refl::AttachFieldFlag::SEqHashIgnore());
   }
 
   bool SEqualReduce(const CommReducerNode* other, SEqualReducer equal) const {
@@ -1009,6 +1009,7 @@ class CommReducerNode : public Object {
   }
 
   static constexpr const char* _type_key = "tir.CommReducer";
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
   TVM_DECLARE_FINAL_OBJECT_INFO(CommReducerNode, Object);

--- a/include/tvm/tir/function.h
+++ b/include/tvm/tir/function.h
@@ -49,8 +49,6 @@ class PrimFuncNode : public BaseFuncNode {
  public:
   /*! \brief Function parameters */
   Array<tir::Var> params;
-  /*! \brief The body of the function */
-  tir::Stmt body;
   /*! \brief The return type of the function. */
   Type ret_type;
   /*!
@@ -99,14 +97,16 @@ class PrimFuncNode : public BaseFuncNode {
    *  flattened alias of the buffer.
    */
   Map<tir::Var, Buffer> buffer_map;
+  /*! \brief The body of the function */
+  tir::Stmt body;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PrimFuncNode>()
-        .def_ro("params", &PrimFuncNode::params)
-        .def_ro("body", &PrimFuncNode::body)
+        .def_ro("params", &PrimFuncNode::params, refl::AttachFieldFlag::SEqHashDef())
         .def_ro("ret_type", &PrimFuncNode::ret_type)
-        .def_ro("buffer_map", &PrimFuncNode::buffer_map);
+        .def_ro("buffer_map", &PrimFuncNode::buffer_map)
+        .def_ro("body", &PrimFuncNode::body);
   }
 
   bool SEqualReduce(const PrimFuncNode* other, SEqualReducer equal) const {
@@ -123,6 +123,7 @@ class PrimFuncNode : public BaseFuncNode {
     hash_reduce(body);
     hash_reduce(attrs);
   }
+
   /*!
    * \brief Return the derived function annotation of this function.
    *

--- a/include/tvm/tir/index_map.h
+++ b/include/tvm/tir/index_map.h
@@ -154,9 +154,11 @@ class IndexMapNode : public Object {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<IndexMapNode>()
-        .def_ro("initial_indices", &IndexMapNode::initial_indices)
+        .def_ro("initial_indices", &IndexMapNode::initial_indices,
+                refl::AttachFieldFlag::SEqHashDef())
         .def_ro("final_indices", &IndexMapNode::final_indices)
-        .def_ro("inverse_index_map", &IndexMapNode::inverse_index_map);
+        .def_ro("inverse_index_map", &IndexMapNode::inverse_index_map,
+                refl::AttachFieldFlag::SEqHashIgnore());
   }
 
   bool SEqualReduce(const IndexMapNode* other, SEqualReducer equal) const {
@@ -169,6 +171,7 @@ class IndexMapNode : public Object {
     hash_reduce(final_indices);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "tir.IndexMap";
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;

--- a/include/tvm/tir/var.h
+++ b/include/tvm/tir/var.h
@@ -64,7 +64,7 @@ class VarNode : public PrimExprNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<VarNode>()
-        .def_ro("name", &VarNode::name_hint)
+        .def_ro("name", &VarNode::name_hint, refl::AttachFieldFlag::SEqHashIgnore())
         .def_ro("type_annotation", &VarNode::type_annotation);
   }
 
@@ -80,6 +80,7 @@ class VarNode : public PrimExprNode {
     hash_reduce.FreeVarHashImpl(this);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindFreeVar;
   static constexpr const char* _type_key = "tir.Var";
   static constexpr const uint32_t _type_child_slots = 1;
   TVM_DECLARE_BASE_OBJECT_INFO(VarNode, PrimExprNode);
@@ -290,7 +291,7 @@ class IterVarNode : public PrimExprConvertibleNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<IterVarNode>()
         .def_ro("dom", &IterVarNode::dom)
-        .def_ro("var", &IterVarNode::var)
+        .def_ro("var", &IterVarNode::var, refl::AttachFieldFlag::SEqHashDef())
         .def_ro("iter_type", &IterVarNode::iter_type)
         .def_ro("thread_tag", &IterVarNode::thread_tag);
   }
@@ -308,6 +309,7 @@ class IterVarNode : public PrimExprConvertibleNode {
   }
 
   static constexpr const char* _type_key = "tir.IterVar";
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
   TVM_DECLARE_FINAL_OBJECT_INFO(IterVarNode, PrimExprConvertibleNode);

--- a/src/contrib/msc/core/ir/graph.h
+++ b/src/contrib/msc/core/ir/graph.h
@@ -400,6 +400,7 @@ class MSCTensorNode : public Object {
     hash_reduce(prims);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "msc.core.MSCTensor";
   TVM_DECLARE_FINAL_OBJECT_INFO(MSCTensorNode, Object);
 };
@@ -514,6 +515,7 @@ class BaseJointNode : public Object {
     hash_reduce(children);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "msc.core.BaseJoint";
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;
@@ -600,6 +602,7 @@ class MSCJointNode : public BaseJointNode {
     hash_reduce(weights);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "msc.core.MSCJoint";
   TVM_DECLARE_FINAL_OBJECT_INFO(MSCJointNode, BaseJointNode);
 };
@@ -833,6 +836,7 @@ class BaseGraphNode : public Object {
     hash_reduce(node_names);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "msc.core.BaseGraph";
   static constexpr const bool _type_has_method_sequal_reduce = true;
   static constexpr const bool _type_has_method_shash_reduce = true;

--- a/src/contrib/msc/core/ir/plugin.h
+++ b/src/contrib/msc/core/ir/plugin.h
@@ -290,6 +290,7 @@ class PluginAttrNode : public Object {
     hash_reduce(describe);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "msc.core.PluginAttr";
   TVM_DECLARE_FINAL_OBJECT_INFO(PluginAttrNode, Object);
 };
@@ -371,6 +372,7 @@ class PluginTensorNode : public Object {
     hash_reduce(describe);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "msc.core.PluginTensor";
   TVM_DECLARE_FINAL_OBJECT_INFO(PluginTensorNode, Object);
 };
@@ -454,6 +456,7 @@ class PluginExternNode : public Object {
     hash_reduce(describe);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "msc.core.PluginExtern";
   TVM_DECLARE_FINAL_OBJECT_INFO(PluginExternNode, Object);
 };
@@ -565,6 +568,7 @@ class PluginNode : public Object {
     hash_reduce(options);
   }
 
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr const char* _type_key = "msc.core.Plugin";
   TVM_DECLARE_FINAL_OBJECT_INFO(PluginNode, Object);
 };

--- a/src/ir/type.cc
+++ b/src/ir/type.cc
@@ -27,6 +27,7 @@
 namespace tvm {
 
 TVM_FFI_STATIC_INIT_BLOCK({
+  TypeNode::RegisterReflection();
   PrimTypeNode::RegisterReflection();
   PointerTypeNode::RegisterReflection();
   TupleTypeNode::RegisterReflection();
@@ -50,8 +51,12 @@ TVM_FFI_STATIC_INIT_BLOCK({
 
 PointerType::PointerType(Type element_type, String storage_scope) {
   ObjectPtr<PointerTypeNode> n = make_object<PointerTypeNode>();
+  if (storage_scope.empty()) {
+    n->storage_scope = "global";
+  } else {
+    n->storage_scope = std::move(storage_scope);
+  }
   n->element_type = std::move(element_type);
-  n->storage_scope = std::move(storage_scope);
   data_ = std::move(n);
 }
 

--- a/src/meta_schedule/module_equality.cc
+++ b/src/meta_schedule/module_equality.cc
@@ -18,6 +18,8 @@
  */
 #include "module_equality.h"
 
+#include <tvm/ffi/reflection/structural_equal.h>
+#include <tvm/ffi/reflection/structural_hash.h>
 #include <tvm/ir/module.h>
 #include <tvm/node/structural_equal.h>
 #include <tvm/node/structural_hash.h>
@@ -37,28 +39,15 @@ class ModuleEqualityStructural : public ModuleEquality {
   String GetName() const { return "structural"; }
 };
 
-class SEqualHandlerIgnoreNDArray : public SEqualHandlerDefault {
- public:
-  SEqualHandlerIgnoreNDArray() : SEqualHandlerDefault(false, nullptr, false) {}
-
- protected:
-  bool DispatchSEqualReduce(const ObjectRef& lhs, const ObjectRef& rhs, bool map_free_vars,
-                            const Optional<ObjectPathPair>& current_paths) {
-    if (auto lhs_ptr = lhs.as<runtime::NDArray::Container>(),
-        rhs_ptr = rhs.as<runtime::NDArray::Container>();
-        lhs_ptr && rhs_ptr) {
-      SEqualReducer reducer(this, nullptr, map_free_vars);
-      return NDArrayEqual(lhs_ptr, rhs_ptr, reducer, false);
-    }
-    return SEqualHandlerDefault::DispatchSEqualReduce(lhs, rhs, map_free_vars, current_paths);
-  }
-};
-
 class ModuleEqualityIgnoreNDArray : public ModuleEquality {
  public:
-  size_t Hash(IRModule mod) const { return SHashHandlerIgnoreNDArray().Hash(mod, false); }
+  size_t Hash(IRModule mod) const {
+    return tvm::ffi::reflection::StructuralHash::Hash(mod, /*map_free_vars=*/false,
+                                                      /*skip_ndarray_content=*/true);
+  }
   bool Equal(IRModule lhs, IRModule rhs) const {
-    return SEqualHandlerIgnoreNDArray().Equal(lhs, rhs, false);
+    return tvm::ffi::reflection::StructuralEqual::Equal(lhs, rhs, /*map_free_vars=*/false,
+                                                        /*skip_ndarray_content=*/true);
   }
   String GetName() const { return "ignore-ndarray"; }
 };
@@ -77,8 +66,10 @@ class ModuleEqualityAnchorBlock : public ModuleEquality {
     auto anchor_block_lhs = tir::FindAnchorBlock(lhs);
     auto anchor_block_rhs = tir::FindAnchorBlock(rhs);
     if (anchor_block_lhs && anchor_block_rhs) {
-      return SEqualHandlerIgnoreNDArray().Equal(GetRef<tir::Block>(anchor_block_lhs),
-                                                GetRef<tir::Block>(anchor_block_rhs), false);
+      return tvm::ffi::reflection::StructuralEqual::Equal(GetRef<tir::Block>(anchor_block_lhs),
+                                                          GetRef<tir::Block>(anchor_block_rhs),
+                                                          /*map_free_vars=*/false,
+                                                          /*skip_ndarray_content=*/true);
     }
     return ModuleEqualityIgnoreNDArray().Equal(lhs, rhs);
   }

--- a/src/node/structural_hash.cc
+++ b/src/node/structural_hash.cc
@@ -22,6 +22,7 @@
 #include <dmlc/memory_io.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
+#include <tvm/ffi/reflection/structural_hash.h>
 #include <tvm/node/functor.h>
 #include <tvm/node/node.h>
 #include <tvm/node/object_path.h>
@@ -296,13 +297,12 @@ TVM_FFI_STATIC_INIT_BLOCK({
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def("node.StructuralHash",
                         [](const Any& object, bool map_free_vars) -> int64_t {
-                          uint64_t hashed_value = SHashHandlerDefault().Hash(object, map_free_vars);
-                          return static_cast<int64_t>(hashed_value);
+                          return ffi::reflection::StructuralHash::Hash(object, map_free_vars);
                         });
 });
 
 uint64_t StructuralHash::operator()(const ObjectRef& object) const {
-  return SHashHandlerDefault().Hash(object, false);
+  return ffi::reflection::StructuralHash::Hash(object, false);
 }
 
 void SHashHandlerIgnoreNDArray::DispatchSHash(const ObjectRef& object, bool map_free_vars) {

--- a/src/relax/ir/struct_info.cc
+++ b/src/relax/ir/struct_info.cc
@@ -31,6 +31,7 @@ namespace tvm {
 namespace relax {
 
 TVM_FFI_STATIC_INIT_BLOCK({
+  StructInfoNode::RegisterReflection();
   ObjectStructInfoNode::RegisterReflection();
   PrimStructInfoNode::RegisterReflection();
   ShapeStructInfoNode::RegisterReflection();

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -23,6 +23,7 @@
  */
 
 #include <tvm/ffi/reflection/registry.h>
+#include <tvm/ffi/reflection/structural_equal.h>
 #include <tvm/relax/analysis.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/expr_functor.h>
@@ -540,8 +541,8 @@ class ParamRemapper : private ExprFunctor<void(const Expr&, const Expr&)> {
     } else {
       var_remap_.Set(GetRef<Var>(lhs_var), rhs_var);
     }
-    CHECK(structural_equal.Equal(lhs_var->struct_info_, rhs_var->struct_info_,
-                                 /*map_free_vars=*/true))
+    CHECK(tvm::ffi::reflection::StructuralEqual::Equal(lhs_var->struct_info_, rhs_var->struct_info_,
+                                                       /*map_free_vars=*/true))
         << "The struct info of the parameters should be the same for all target functions";
     auto lhs_tir_vars = DefinableTIRVarsInStructInfo(GetStructInfo(GetRef<Var>(lhs_var)));
     auto rhs_tir_vars = DefinableTIRVarsInStructInfo(GetStructInfo(rhs_expr));
@@ -555,8 +556,6 @@ class ParamRemapper : private ExprFunctor<void(const Expr&, const Expr&)> {
     }
   }
 
-  SEqualHandlerDefault structural_equal{/*assert_mode=*/false, /*first_mismatch=*/nullptr,
-                                        /*defer_fail=*/false};
   Map<Var, Expr> var_remap_;
   Map<tir::Var, PrimExpr> tir_var_remap_;
 };

--- a/tests/python/ir/test_node_reflection.py
+++ b/tests/python/ir/test_node_reflection.py
@@ -181,6 +181,15 @@ def test_ndarray_dict():
     tvm.ir.assert_structural_equal(m1, m2)
 
 
+def test_free_var_equal():
+    x = tvm.tir.Var("x", dtype="int32")
+    y = tvm.tir.Var("y", dtype="int32")
+    z = tvm.tir.Var("z", dtype="int32")
+    v1 = x + y
+    v1 = y + z
+    tvm.ir.assert_structural_equal(x, z, map_free_vars=True)
+
+
 def test_alloc_const():
     dev = tvm.cpu(0)
     dtype = "float32"

--- a/tests/python/tvmscript/test_tvmscript_printer_structural_equal.py
+++ b/tests/python/tvmscript/test_tvmscript_printer_structural_equal.py
@@ -45,6 +45,9 @@ def test_prim_func_buffer_map():
         A = T.match_buffer(a, (128, 128))
         B = T.match_buffer(b, (128, 256))
 
+    func1 = func1.with_attr("global_symbol", "main")
+    func2 = func2.with_attr("global_symbol", "main")
+
     with pytest.raises(ValueError) as ve:
         assert_structural_equal(func1, func2)
     assert _error_message(ve.value) == _expected_result(
@@ -109,8 +112,12 @@ def test_allocate():
         a_data = T.allocate((256, 128), dtype="float32")
         a = T.decl_buffer((256, 128), dtype="float32", data=a_data)
 
+    func1 = func1.with_attr("global_symbol", "main")
+    func2 = func2.with_attr("global_symbol", "main")
+
     with pytest.raises(ValueError) as ve:
         assert_structural_equal(func1, func2)
+
     assert _error_message(ve.value) == _expected_result(
         func1,
         func2,
@@ -131,6 +138,9 @@ def test_for():
         for i, j, k in T.grid(128, 128, 128):
             with T.block():
                 pass
+
+    func1 = func1.with_attr("global_symbol", "main")
+    func2 = func2.with_attr("global_symbol", "main")
 
     with pytest.raises(ValueError) as ve:
         assert_structural_equal(func1, func2)


### PR DESCRIPTION
This PR migrates the StructuralEqual/Hash to new reflection based approach. The original mechanisms are still kept around and we will phase them out in followup PRs.

The new mechanism unifies the structural equal/hash registration with the normal reflection registeration and also brings cleaner implementation for mismatch detection.