### PR TITLE
[FFI][REFACTOR] Isolate out extra API

### DIFF
--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -59,13 +59,13 @@ set(tvm_ffi_objs_sources
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/dtype.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/testing.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/container.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/reflection/access_path.cc"
 )
 
 if (TVM_FFI_USE_EXTRA_CXX_API)
   list(APPEND tvm_ffi_objs_sources
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/reflection/access_path.cc"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/reflection/structural_equal.cc"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/reflection/structural_hash.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/extra/structural_equal.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/extra/structural_hash.cc"
   )
 endif()
 

--- a/ffi/include/tvm/ffi/c_api.h
+++ b/ffi/include/tvm/ffi/c_api.h
@@ -56,27 +56,6 @@
 #define TVM_FFI_DLL_EXPORT __attribute__((visibility("default")))
 #endif
 
-/*!
- * \brief Marks the API as extra c++ api that is defined in cc files.
- *
- * These APIs are extra features that depend on, but are not required to
- * support essential core functionality, such as function calling and object
- * access.
- *
- * They are implemented in cc files to reduce compile-time overhead.
- * The input/output only uses POD/Any/ObjectRef for ABI stability.
- * However, these extra APIs may have an issue across MSVC/Itanium ABI,
- *
- * Related features are also available through reflection based function
- * that is fully based on C API
- *
- * The project aims to minimize the number of extra C++ APIs and only
- * restrict the use to non-core functionalities.
- */
-#ifndef TVM_FFI_EXTRA_CXX_API
-#define TVM_FFI_EXTRA_CXX_API TVM_FFI_DLL
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/ffi/include/tvm/ffi/extra/base.h
+++ b/ffi/include/tvm/ffi/extra/base.h
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file tvm/ffi/extra/base.h
+ * \brief Base header for Extra API.
+ *
+ * The extra APIs contains a minmal set of extra APIs that are not
+ * required to support essential core functionality.
+ */
+#ifndef TVM_FFI_EXTRA_BASE_H_
+#define TVM_FFI_EXTRA_BASE_H_
+
+#include <tvm/ffi/c_api.h>
+
+/*!
+ * \brief Marks the API as extra c++ api that is defined in cc files.
+ *
+ * They are implemented in cc files to reduce compile-time overhead.
+ * The input/output only uses POD/Any/ObjectRef for ABI stability.
+ * However, these extra APIs may have an issue across MSVC/Itanium ABI,
+ *
+ * Related features are also available through reflection based function
+ * that is fully based on C API
+ *
+ * The project aims to minimize the number of extra C++ APIs to keep things
+ * lightweight and restrict the use to non-core functionalities.
+ */
+#ifndef TVM_FFI_EXTRA_CXX_API
+#define TVM_FFI_EXTRA_CXX_API TVM_FFI_DLL
+#endif
+
+#endif  // TVM_FFI_EXTRA_BASE_H_

--- a/ffi/include/tvm/ffi/extra/structural_equal.h
+++ b/ffi/include/tvm/ffi/extra/structural_equal.h
@@ -17,19 +17,19 @@
  * under the License.
  */
 /*!
- * \file tvm/ffi/reflection/structural_equal.h
+ * \file tvm/ffi/extra/structural_equal.h
  * \brief Structural equal implementation
  */
-#ifndef TVM_FFI_REFLECTION_STRUCTURAL_EQUAL_H_
-#define TVM_FFI_REFLECTION_STRUCTURAL_EQUAL_H_
+#ifndef TVM_FFI_EXTRA_STRUCTURAL_EQUAL_H_
+#define TVM_FFI_EXTRA_STRUCTURAL_EQUAL_H_
 
 #include <tvm/ffi/any.h>
+#include <tvm/ffi/extra/base.h>
 #include <tvm/ffi/optional.h>
 #include <tvm/ffi/reflection/access_path.h>
 
 namespace tvm {
 namespace ffi {
-namespace reflection {
 /*
  * \brief Structural equality comparators
  */
@@ -59,7 +59,7 @@ class StructuralEqual {
    * \return If comparison fails, return the first mismatch AccessPath pair,
    *         otherwise return std::nullopt.
    */
-  TVM_FFI_EXTRA_CXX_API static Optional<AccessPathPair> GetFirstMismatch(
+  TVM_FFI_EXTRA_CXX_API static Optional<reflection::AccessPathPair> GetFirstMismatch(
       const Any& lhs, const Any& rhs, bool map_free_vars = false,
       bool skip_ndarray_content = false);
 
@@ -74,7 +74,6 @@ class StructuralEqual {
   }
 };
 
-}  // namespace reflection
 }  // namespace ffi
 }  // namespace tvm
-#endif  // TVM_FFI_REFLECTION_STRUCTURAL_EQUAL_H_
+#endif  // TVM_FFI_EXTRA_STRUCTURAL_EQUAL_H_

--- a/ffi/include/tvm/ffi/extra/structural_hash.h
+++ b/ffi/include/tvm/ffi/extra/structural_hash.h
@@ -17,17 +17,17 @@
  * under the License.
  */
 /*!
- * \file tvm/ffi/reflection/structural_hash.h
+ * \file tvm/ffi/extra/structural_hash.h
  * \brief Structural hash
  */
-#ifndef TVM_FFI_REFLECTION_STRUCTURAL_HASH_H_
-#define TVM_FFI_REFLECTION_STRUCTURAL_HASH_H_
+#ifndef TVM_FFI_EXTRA_STRUCTURAL_HASH_H_
+#define TVM_FFI_EXTRA_STRUCTURAL_HASH_H_
 
 #include <tvm/ffi/any.h>
+#include <tvm/ffi/extra/base.h>
 
 namespace tvm {
 namespace ffi {
-namespace reflection {
 
 /*
  * \brief Structural hash
@@ -52,7 +52,6 @@ class StructuralHash {
   TVM_FFI_INLINE uint64_t operator()(const Any& value) const { return Hash(value); }
 };
 
-}  // namespace reflection
 }  // namespace ffi
 }  // namespace tvm
-#endif  // TVM_FFI_REFLECTION_STRUCTURAL_HASH_H_
+#endif  // TVM_FFI_EXTRA_STRUCTURAL_HASH_H_

--- a/ffi/include/tvm/ffi/reflection/access_path.h
+++ b/ffi/include/tvm/ffi/reflection/access_path.h
@@ -35,12 +35,12 @@ namespace reflection {
 
 enum class AccessKind : int32_t {
   kObjectField = 0,
-  kArrayIndex = 1,
-  kMapKey = 2,
+  kArrayItem = 1,
+  kMapItem = 2,
   // the following two are used for error reporting when
   // the supposed access field is not available
-  kArrayIndexMissing = 3,
-  kMapKeyMissing = 4,
+  kArrayItemMissing = 3,
+  kMapItemMissing = 4,
 };
 
 /*!
@@ -86,15 +86,15 @@ class AccessStep : public ObjectRef {
     return AccessStep(AccessKind::kObjectField, field_name);
   }
 
-  static AccessStep ArrayIndex(int64_t index) { return AccessStep(AccessKind::kArrayIndex, index); }
+  static AccessStep ArrayItem(int64_t index) { return AccessStep(AccessKind::kArrayItem, index); }
 
-  static AccessStep ArrayIndexMissing(int64_t index) {
-    return AccessStep(AccessKind::kArrayIndexMissing, index);
+  static AccessStep ArrayItemMissing(int64_t index) {
+    return AccessStep(AccessKind::kArrayItemMissing, index);
   }
 
-  static AccessStep MapKey(Any key) { return AccessStep(AccessKind::kMapKey, key); }
+  static AccessStep MapItem(Any key) { return AccessStep(AccessKind::kMapItem, key); }
 
-  static AccessStep MapKeyMissing(Any key) { return AccessStep(AccessKind::kMapKeyMissing, key); }
+  static AccessStep MapItemMissing(Any key) { return AccessStep(AccessKind::kMapItemMissing, key); }
 
   TVM_FFI_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(AccessStep, ObjectRef, AccessStepObj);
 };

--- a/ffi/src/ffi/extra/structural_hash.cc
+++ b/ffi/src/ffi/extra/structural_hash.cc
@@ -25,9 +25,9 @@
 #include <tvm/ffi/container/map.h>
 #include <tvm/ffi/container/ndarray.h>
 #include <tvm/ffi/container/shape.h>
+#include <tvm/ffi/extra/structural_hash.h>
 #include <tvm/ffi/reflection/accessor.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/ffi/reflection/structural_hash.h>
 #include <tvm/ffi/string.h>
 
 #include <cmath>
@@ -37,7 +37,6 @@
 
 namespace tvm {
 namespace ffi {
-namespace reflection {
 /**
  * \brief Internal Handler class for structural hash.
  */
@@ -119,11 +118,11 @@ class StructuralHashHandler {
     uint64_t hash_value = obj->GetTypeKeyHash();
     if (custom_s_hash[type_info->type_index] == nullptr) {
       // go over the content and hash the fields
-      ForEachFieldInfo(type_info, [&](const TVMFFIFieldInfo* field_info) {
+      reflection::ForEachFieldInfo(type_info, [&](const TVMFFIFieldInfo* field_info) {
         // skip fields that are marked as structural eq hash ignore
         if (!(field_info->flags & kTVMFFIFieldFlagBitMaskSEqHashIgnore)) {
           // get the field value from both side
-          FieldGetter getter(field_info);
+          reflection::FieldGetter getter(field_info);
           Any field_value = getter(obj);
           // field is in def region, enable free var mapping
           if (field_info->flags & kTVMFFIFieldFlagBitMaskSEqHashDef) {
@@ -297,10 +296,9 @@ uint64_t StructuralHash::Hash(const Any& value, bool map_free_vars, bool skip_nd
 
 TVM_FFI_STATIC_INIT_BLOCK({
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("ffi.reflection.StructuralHash", StructuralHash::Hash);
+  refl::GlobalDef().def("ffi.StructuralHash", StructuralHash::Hash);
   refl::EnsureTypeAttrColumn("__s_hash__");
 });
 
-}  // namespace reflection
 }  // namespace ffi
 }  // namespace tvm

--- a/src/meta_schedule/module_equality.cc
+++ b/src/meta_schedule/module_equality.cc
@@ -18,8 +18,8 @@
  */
 #include "module_equality.h"
 
-#include <tvm/ffi/reflection/structural_equal.h>
-#include <tvm/ffi/reflection/structural_hash.h>
+#include <tvm/ffi/extra/structural_equal.h>
+#include <tvm/ffi/extra/structural_hash.h>
 #include <tvm/ir/module.h>
 #include <tvm/node/structural_equal.h>
 #include <tvm/node/structural_hash.h>
@@ -40,12 +40,12 @@ class ModuleEqualityStructural : public ModuleEquality {
 class ModuleEqualityIgnoreNDArray : public ModuleEquality {
  public:
   size_t Hash(IRModule mod) const {
-    return tvm::ffi::reflection::StructuralHash::Hash(mod, /*map_free_vars=*/false,
-                                                      /*skip_ndarray_content=*/true);
+    return tvm::ffi::StructuralHash::Hash(mod, /*map_free_vars=*/false,
+                                          /*skip_ndarray_content=*/true);
   }
   bool Equal(IRModule lhs, IRModule rhs) const {
-    return tvm::ffi::reflection::StructuralEqual::Equal(lhs, rhs, /*map_free_vars=*/false,
-                                                        /*skip_ndarray_content=*/true);
+    return tvm::ffi::StructuralEqual::Equal(lhs, rhs, /*map_free_vars=*/false,
+                                            /*skip_ndarray_content=*/true);
   }
   String GetName() const { return "ignore-ndarray"; }
 };
@@ -56,9 +56,9 @@ class ModuleEqualityAnchorBlock : public ModuleEquality {
   size_t Hash(IRModule mod) const {
     auto anchor_block = tir::FindAnchorBlock(mod);
     if (anchor_block) {
-      return ffi::reflection::StructuralHash::Hash(GetRef<tir::Block>(anchor_block),
-                                                   /*map_free_vars=*/false,
-                                                   /*skip_ndarray_content=*/true);
+      return ffi::StructuralHash::Hash(GetRef<tir::Block>(anchor_block),
+                                       /*map_free_vars=*/false,
+                                       /*skip_ndarray_content=*/true);
     }
     return ModuleEqualityIgnoreNDArray().Hash(mod);
   }
@@ -66,10 +66,10 @@ class ModuleEqualityAnchorBlock : public ModuleEquality {
     auto anchor_block_lhs = tir::FindAnchorBlock(lhs);
     auto anchor_block_rhs = tir::FindAnchorBlock(rhs);
     if (anchor_block_lhs && anchor_block_rhs) {
-      return tvm::ffi::reflection::StructuralEqual::Equal(GetRef<tir::Block>(anchor_block_lhs),
-                                                          GetRef<tir::Block>(anchor_block_rhs),
-                                                          /*map_free_vars=*/false,
-                                                          /*skip_ndarray_content=*/true);
+      return tvm::ffi::StructuralEqual::Equal(GetRef<tir::Block>(anchor_block_lhs),
+                                              GetRef<tir::Block>(anchor_block_rhs),
+                                              /*map_free_vars=*/false,
+                                              /*skip_ndarray_content=*/true);
     }
     return ModuleEqualityIgnoreNDArray().Equal(lhs, rhs);
   }

--- a/src/node/structural_equal.cc
+++ b/src/node/structural_equal.cc
@@ -19,10 +19,10 @@
 /*!
  * \file src/node/structural_equal.cc
  */
+#include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/access_path.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/ffi/reflection/structural_equal.h>
 #include <tvm/ir/module.h>
 #include <tvm/node/functor.h>
 #include <tvm/node/node.h>
@@ -64,19 +64,19 @@ Optional<ObjectPathPair> ObjectPathPairFromAccessPathPair(
           result = result->Attr(step->key.cast<String>());
           break;
         }
-        case ffi::reflection::AccessKind::kArrayIndex: {
+        case ffi::reflection::AccessKind::kArrayItem: {
           result = result->ArrayIndex(step->key.cast<int64_t>());
           break;
         }
-        case ffi::reflection::AccessKind::kMapKey: {
+        case ffi::reflection::AccessKind::kMapItem: {
           result = result->MapValue(step->key);
           break;
         }
-        case ffi::reflection::AccessKind::kArrayIndexMissing: {
+        case ffi::reflection::AccessKind::kArrayItemMissing: {
           result = result->MissingArrayElement(step->key.cast<int64_t>());
           break;
         }
-        case ffi::reflection::AccessKind::kMapKeyMissing: {
+        case ffi::reflection::AccessKind::kMapItemMissing: {
           result = result->MissingMapEntry();
           break;
         }
@@ -96,7 +96,7 @@ bool NodeStructuralEqualAdapter(const Any& lhs, const Any& rhs, bool assert_mode
                                 bool map_free_vars) {
   if (assert_mode) {
     auto first_mismatch = ObjectPathPairFromAccessPathPair(
-        ffi::reflection::StructuralEqual::GetFirstMismatch(lhs, rhs, map_free_vars));
+        ffi::StructuralEqual::GetFirstMismatch(lhs, rhs, map_free_vars));
     if (first_mismatch.has_value()) {
       std::ostringstream oss;
       oss << "StructuralEqual check failed, caused by lhs";
@@ -129,7 +129,7 @@ bool NodeStructuralEqualAdapter(const Any& lhs, const Any& rhs, bool assert_mode
     }
     return true;
   } else {
-    return ffi::reflection::StructuralEqual::Equal(lhs, rhs, map_free_vars);
+    return ffi::StructuralEqual::Equal(lhs, rhs, map_free_vars);
   }
 }
 
@@ -147,12 +147,12 @@ TVM_FFI_STATIC_INIT_BLOCK({
               return first_mismatch;
              */
              return ObjectPathPairFromAccessPathPair(
-                 ffi::reflection::StructuralEqual::GetFirstMismatch(lhs, rhs, map_free_vars));
+                 ffi::StructuralEqual::GetFirstMismatch(lhs, rhs, map_free_vars));
            });
 });
 
 bool StructuralEqual::operator()(const ffi::Any& lhs, const ffi::Any& rhs,
                                  bool map_free_params) const {
-  return ffi::reflection::StructuralEqual::Equal(lhs, rhs, map_free_params);
+  return ffi::StructuralEqual::Equal(lhs, rhs, map_free_params);
 }
 }  // namespace tvm

--- a/src/node/structural_hash.cc
+++ b/src/node/structural_hash.cc
@@ -20,9 +20,9 @@
  * \file src/node/structural_hash.cc
  */
 #include <dmlc/memory_io.h>
+#include <tvm/ffi/extra/structural_hash.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/ffi/reflection/structural_hash.h>
 #include <tvm/node/functor.h>
 #include <tvm/node/node.h>
 #include <tvm/node/object_path.h>
@@ -44,12 +44,12 @@ TVM_FFI_STATIC_INIT_BLOCK({
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def("node.StructuralHash",
                         [](const Any& object, bool map_free_vars) -> int64_t {
-                          return ffi::reflection::StructuralHash::Hash(object, map_free_vars);
+                          return ffi::StructuralHash::Hash(object, map_free_vars);
                         });
 });
 
 uint64_t StructuralHash::operator()(const ffi::Any& object) const {
-  return ffi::reflection::StructuralHash::Hash(object, false);
+  return ffi::StructuralHash::Hash(object, false);
 }
 
 struct RefToObjectPtr : public ObjectRef {

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -21,9 +21,9 @@
  * \file src/relax/block_builder.cc
  */
 #include <tvm/arith/analyzer.h>
+#include <tvm/ffi/extra/structural_hash.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/ffi/reflection/structural_hash.h>
 #include <tvm/relax/analysis.h>
 #include <tvm/relax/block_builder.h>
 #include <tvm/relax/expr_functor.h>
@@ -431,8 +431,8 @@ class BlockBuilderImpl : public BlockBuilderNode {
   class StructuralHashIgnoreNDarray {
    public:
     uint64_t operator()(const ObjectRef& key) const {
-      return ffi::reflection::StructuralHash::Hash(key, /*map_free_vars=*/false,
-                                                   /*skip_ndarray_content=*/true);
+      return ffi::StructuralHash::Hash(key, /*map_free_vars=*/false,
+                                       /*skip_ndarray_content=*/true);
     }
   };
 

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -22,8 +22,8 @@
  * \brief Lift local functions into global functions.
  */
 
+#include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/ffi/reflection/structural_equal.h>
 #include <tvm/relax/analysis.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/expr_functor.h>
@@ -541,8 +541,8 @@ class ParamRemapper : private ExprFunctor<void(const Expr&, const Expr&)> {
     } else {
       var_remap_.Set(GetRef<Var>(lhs_var), rhs_var);
     }
-    CHECK(tvm::ffi::reflection::StructuralEqual::Equal(lhs_var->struct_info_, rhs_var->struct_info_,
-                                                       /*map_free_vars=*/true))
+    CHECK(tvm::ffi::StructuralEqual::Equal(lhs_var->struct_info_, rhs_var->struct_info_,
+                                           /*map_free_vars=*/true))
         << "The struct info of the parameters should be the same for all target functions";
     auto lhs_tir_vars = DefinableTIRVarsInStructInfo(GetStructInfo(GetRef<Var>(lhs_var)));
     auto rhs_tir_vars = DefinableTIRVarsInStructInfo(GetStructInfo(rhs_expr));


### PR DESCRIPTION
This PR formalizes the extra API in FFI. The extra APIs are minimal set of APIs that are not required in core mechanism, but still helpful.

Move structural equal/hash to extra API.