### PR TITLE
[FFI] Fix SmallMapInit with duplicated keys

### DIFF
--- a/ffi/tests/cpp/test_map.cc
+++ b/ffi/tests/cpp/test_map.cc
@@ -356,4 +356,11 @@ TEST(Map, EmptyIter) {
   // now m0 is dense map with all empty slots
   EXPECT_EQ(m0.begin(), m0.end());
 }
+
+TEST(Map, DuplicatedKeysInit) {
+  std::vector<std::pair<String, int>> data = {{"a", 1}, {"a", 2}, {"a", 3}};
+  Map<String, int> map(data.begin(), data.end());
+  EXPECT_EQ(map.size(), 1);
+  EXPECT_EQ(map["a"], 3);
+}
 }  // namespace


### PR DESCRIPTION
This PR fixes Small map init when there are duplicated keys