### PR TITLE
[Relax][ONNX] Parse ONNX Upsample to Relax resize2d

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -2856,6 +2856,35 @@ class NonZero(OnnxOpConverter):
         )
 
 
+class Upsample(OnnxOpConverter):
+    """Operator converter for Upsample (nearest mode)."""
+
+    @classmethod
+    def _impl_v9(cls, bb, inputs, attr, params):
+        scales = attr.get("scales")
+        assert len(scales) == 4
+        assert scales[0] == scales[1] == 1
+
+        inp_shape = [int(x) for x in inputs[0].struct_info.shape]
+        assert len(inp_shape) == 4
+        out_shape2d = [int(dim * scale) for dim, scale in zip(inp_shape[2:], scales[2:])]
+
+        mode = attr.get("mode", b"nearest").decode("ascii")
+        if mode == "nearest":
+            mode = "nearest_neighbor"
+        msg = f'Value {mode} in attribute "mode" of operator Upsample is not valid.'
+        assert mode in ("linear", "nearest_neighbor", "cubic"), msg
+
+        return relax.op.image.resize2d(
+            data=inputs[0],
+            roi=None,
+            size=relax.ShapeExpr(out_shape2d),  # (H, W)
+            layout="NCHW",
+            method=mode,
+            coordinate_transformation_mode="asymmetric",  # Align with Upsample
+        )
+
+
 class HardSigmoid(OnnxOpConverter):
     """Converts an onnx HardSigmoid node into an equivalent Relax expression."""
 
@@ -3248,7 +3277,7 @@ def _get_convert_map():
         # "RoiAlign": RoiAlign,
         # "NonMaxSuppression": NonMaxSuppression,
         # "GridSample": GridSample,
-        # "Upsample": Upsample,
+        "Upsample": Upsample,
         # others
         "DepthToSpace": DepthToSpace,
         "SpaceToDepth": SpaceToDepth,


### PR DESCRIPTION
> The `resize2d` operator in Relax already covers the functionality, so there’s no need to introduce a dedicated upsampling op at the Relax level.


1. Model-wise, only YOLO v3 Tiny currently uses this op, and I haven’t seen any other models that require it. The op originates from Darknet.
2. although it becomes an ONNX `Upsample` op during conversion, the node name still ends with `/resize`.
From ONNX version 10 onward, the `Upsample` op is no longer supported (`This version of the operator has been deprecated since version 10`. ref: https://onnx.ai/onnx/operators/onnx__Upsample.html)
3. `resize2d` provides a superset of `upsample` (2-D) capabilities, and end-to-end model results are correct, so `resize2d` fully covers the need. 
4. During ONNX-to-Relay conversion, the old frontend maps the op to either `upsampling` or `upsampling3d` based on the input rank. For the 3-D case, Relax could translate `upsampling3d` to `resize3d` (TOPI already has the resze3d implementation), but Relax currently lacks a `resize3d` operator. 

Therefore, if we ever need `upsampling3d` in the future, the better path would be to add the more capable `resize3d` operator at the Relax op level.