### PR TITLE
[LLVM][CPPTEST] Small fixes for LLVM >= 20

### DIFF
--- a/tests/cpp/target/parsers/aprofile_test.cc
+++ b/tests/cpp/target/parsers/aprofile_test.cc
@@ -317,7 +317,12 @@ TEST_F(AProfileParser, DefaultSVESupportSVESupport) {
   TargetJSON target = ParseTargetWithAttrs("", "aarch64-arm-none-eabi", {arch_attr});
   TargetFeatures features = Downcast<TargetFeatures>(target.at("features"));
   EXPECT_TRUE(IsArch(target));
+#if TVM_LLVM_VERSION >= 190
+  // The generic aarch64 should not have SVE enabled
+  EXPECT_FALSE(Downcast<Bool>(features.at("has_sve")));
+#else
   EXPECT_TRUE(Downcast<Bool>(features.at("has_sve")));
+#endif
 
   // Check that the "has_sve" feature is set when "+sve" is explicitly set as an attribute.
   target = ParseTargetWithAttrs("", "aarch64-arm-none-eabi", {arch_attr, "+sve"});
@@ -359,7 +364,12 @@ TEST_F(AProfileParser, DefaultFP16Support) {
   TargetJSON target = ParseTargetWithAttrs("", "aarch64-arm-none-eabi", {arch_attr});
   TargetFeatures features = Downcast<TargetFeatures>(target.at("features"));
   EXPECT_TRUE(IsArch(target));
+#if TVM_LLVM_VERSION >= 190
+  // The generic aarch64 should not have FP16 enabled
+  EXPECT_FALSE(Downcast<Bool>(features.at("has_fp16_simd")));
+#else
   EXPECT_TRUE(Downcast<Bool>(features.at("has_fp16_simd")));
+#endif
 
   // Check that the "has_fp16_simd" feature is set when "+fullfp16" is explicitly set as an
   // attribute.

--- a/tests/cpp/tir_scalable_datatype.cc
+++ b/tests/cpp/tir_scalable_datatype.cc
@@ -187,12 +187,21 @@ TEST(ScalableDataType, TestScalableUInt) {
 #if TVM_LLVM_VERSION >= 130
 TEST(ScalableDataType, TestScalableIntrinCall) {
   tvm::DataType scalable_type = tvm::DataType(kDLInt, 32, 4, true);
-  tvm::tir::Call call = tvm::tir::Call(
-      scalable_type, tvm::tir::builtin::call_llvm_intrin(),
-      {tvm::IntImm(tvm::DataType::Int(32), ::llvm::Intrinsic::experimental_stepvector)});
+  tvm::tir::Call call =
+      tvm::tir::Call(scalable_type, tvm::tir::builtin::call_llvm_intrin(),
+#if TVM_LLVM_VERSION >= 200
+                     {tvm::IntImm(tvm::DataType::Int(32), ::llvm::Intrinsic::stepvector)});
+#else
+                     {tvm::IntImm(tvm::DataType::Int(32),
+                                  ::llvm::Intrinsic::experimental_stepvector)});
+#endif
   ASSERT_EQ(call->dtype, scalable_type);
   ASSERT_EQ(call->Script(),
+#if TVM_LLVM_VERSION >= 200
+            "T.call_llvm_intrin(\"int32xvscalex4\", \"llvm.stepvector\")");
+#else
             "T.call_llvm_intrin(\"int32xvscalex4\", \"llvm.experimental.stepvector\")");
+#endif
 }
 #endif
 


### PR DESCRIPTION
This PR updates **cpptest** to run on LLVM >= 20.
It also fixes [issue#17823](https://github.com/apache/tvm/issues/17823), and checks [pr#18182](https://github.com/apache/tvm/pull/18182) .

