### PR TITLE
[LLVM] Fixes up to the latest LLVM21

### DIFF
--- a/src/target/llvm/codegen_amdgpu.cc
+++ b/src/target/llvm/codegen_amdgpu.cc
@@ -284,7 +284,11 @@ runtime::Module BuildAMDGPU(IRModule mod, Target target) {
 
   for (auto& bitcode_path : bitcode_files) {
     std::unique_ptr<llvm::Module> mlib = llvm_instance.LoadIR(bitcode_path);
+#if TVM_LLVM_VERSION >= 210
+    mlib->setTargetTriple(llvm::Triple(llvm_target->GetTargetTriple()));
+#else
     mlib->setTargetTriple(llvm_target->GetTargetTriple());
+#endif
     mlib->setDataLayout(tm->createDataLayout());
 
     for (llvm::Function& f : mlib->functions()) {

--- a/src/target/llvm/codegen_blob.cc
+++ b/src/target/llvm/codegen_blob.cc
@@ -69,7 +69,11 @@ std::unique_ptr<llvm::Module> CodeGenBlob(const std::string& data, bool system_l
   llvm::LLVMContext* ctx = llvm_target->GetContext();
   std::string module_name = c_symbol_prefix + "devc";
   auto module = std::make_unique<llvm::Module>(module_name, *ctx);
+#if TVM_LLVM_VERSION >= 210
+  module->setTargetTriple(triple);
+#else
   module->setTargetTriple(triple.str());
+#endif
   llvm_target->SetTargetMetadata(module.get());
   module->setDataLayout(tm->createDataLayout());
   auto* blob_value = llvm::ConstantDataArray::getString(*ctx, data, false);

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -168,7 +168,11 @@ void CodeGenLLVM::SetFastMathFlags(llvm::FastMathFlags fmf) { builder_->setFastM
 
 void CodeGenLLVM::InitTarget() {
   llvm::TargetMachine* tm = llvm_target_->GetOrCreateTargetMachine();
+#if TVM_LLVM_VERSION >= 210
+  module_->setTargetTriple(tm->getTargetTriple());
+#else
   module_->setTargetTriple(tm->getTargetTriple().str());
+#endif
   module_->setDataLayout(tm->createDataLayout());
 #if TVM_LLVM_VERSION >= 200
   data_layout_.reset(new llvm::DataLayout(module_.get()->getDataLayout()));
@@ -374,7 +378,11 @@ void CodeGenLLVM::HandleImport(const std::string& code) {
     mlib = llvm_target_->GetInstance().ParseIR(code);
   }
 
+#if TVM_LLVM_VERSION >= 210
+  mlib->setTargetTriple(llvm::Triple(llvm_target_->GetTargetTriple()));
+#else
   mlib->setTargetTriple(llvm_target_->GetTargetTriple());
+#endif
   mlib->setDataLayout(llvm_target_->GetOrCreateTargetMachine()->createDataLayout());
   // mark all the functions as force inline
   for (llvm::Function& f : mlib->functions()) {

--- a/src/target/llvm/llvm_instance.cc
+++ b/src/target/llvm/llvm_instance.cc
@@ -981,7 +981,11 @@ std::string LLVMTarget::GetTargetMetadata(const llvm::Module& module) {
       return meta.str();
     }
   }
+#if TVM_LLVM_VERSION >= 210
+  return "llvm -mtriple " + module.getTargetTriple().str();
+#else
   return "llvm -mtriple " + module.getTargetTriple();
+#endif
 }
 
 void LLVMTarget::SetTargetMetadata(llvm::Module* module) const {

--- a/tests/cpp/target/parsers/aprofile_test.cc
+++ b/tests/cpp/target/parsers/aprofile_test.cc
@@ -317,7 +317,7 @@ TEST_F(AProfileParser, DefaultSVESupportSVESupport) {
   TargetJSON target = ParseTargetWithAttrs("", "aarch64-arm-none-eabi", {arch_attr});
   TargetFeatures features = Downcast<TargetFeatures>(target.at("features"));
   EXPECT_TRUE(IsArch(target));
-#if TVM_LLVM_VERSION >= 190
+#if TVM_LLVM_VERSION >= 190 || (TVM_LLVM_VERSION / 10) == 13
   // The generic aarch64 should not have SVE enabled
   EXPECT_FALSE(Downcast<Bool>(features.at("has_sve")));
 #else
@@ -364,7 +364,7 @@ TEST_F(AProfileParser, DefaultFP16Support) {
   TargetJSON target = ParseTargetWithAttrs("", "aarch64-arm-none-eabi", {arch_attr});
   TargetFeatures features = Downcast<TargetFeatures>(target.at("features"));
   EXPECT_TRUE(IsArch(target));
-#if TVM_LLVM_VERSION >= 190
+#if TVM_LLVM_VERSION >= 190 || (TVM_LLVM_VERSION / 10) == 13
   // The generic aarch64 should not have FP16 enabled
   EXPECT_FALSE(Downcast<Bool>(features.at("has_fp16_simd")));
 #else


### PR DESCRIPTION
This PR fix TVM use with the latest LLVM version 21. 

* At this time LLVM21 is available as a release candidate.
* Double checks for backward compatibility down to LLVM10.

---

#### Notes (LLVM21):
  *  Explicit conversion of llvm::Triple <-> str() is a requirement, it is not deduced anymore.
  *  As of [llvm#140615](https://github.com/llvm/llvm-project/commit/735209c0688b10a66c24750422b35d8c2ad01bb5) , intrinsic ```llvm.nvvm.barrier0``` is now ```llvm.nvvm.barrier.cta.sync.aligned.all(0)```.
  * ORCJIT's linker requires a ```llvm::Expected``` protection from now.

#### Backward version checks:
```
$ rpm -q gcc-c++
gcc-c++-15.1.1-5.fc43.1.x86_64
```

for llvm = {10,11,12,13,14,15,16,17,18,19,20,21} do ```make; make cpptest; make test```

