### PR TITLE
[FFI][Fix] Update datatype registry calls to the new paths

### DIFF
--- a/python/tvm/target/datatype.py
+++ b/python/tvm/target/datatype.py
@@ -26,6 +26,7 @@ from tvm.tir.expr import (
     BinaryOpExpr as _BinaryOpExpr,
 )
 from tvm.tir.op import call_pure_extern
+from tvm.ffi import get_global_func
 from tvm.ffi import register_func as _register_func
 from tvm.tir import call_intrin
 
@@ -55,7 +56,7 @@ def register(type_name, type_code):
         The type's code, which should be >= kCustomBegin. See
         include/tvm/runtime/data_type.h.
     """
-    tvm.runtime._ffi_api._datatype_register(type_name, type_code)
+    get_global_func("dtype.register_custom_type")(type_name, type_code)
 
 
 def get_type_name(type_code):
@@ -82,7 +83,7 @@ def get_type_name(type_code):
         The name of the custom datatype.
 
     """
-    return tvm.runtime._ffi_api._datatype_get_type_name(type_code)
+    return get_global_func("dtype.get_custom_type_name")(type_code)
 
 
 def get_type_code(type_name):
@@ -108,7 +109,7 @@ def get_type_code(type_name):
     type_code : int
         The type code of the custom datatype.
     """
-    return tvm.runtime._ffi_api._datatype_get_type_code(type_name)
+    return get_global_func("dtype.get_custom_type_code")(type_name)
 
 
 def get_type_registered(type_code):


### PR DESCRIPTION
This updates the python calls to the new registry home.

#### See the new paths: 
https://github.com/apache/tvm/blob/60f5568415f176b9695230af3664b62835481b7b/src/target/datatype/registry.cc#L34-L46

#### Usage errors:
```
  File "/usr/lib64/python3.14/site-packages/tvm/target/datatype.py", line 58, in register
    tvm.runtime._ffi_api._datatype_register(type_name, type_code)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'tvm.runtime._ffi_api' has no attribute '_datatype_register'
```
Cc @tqchen 