### PR TITLE
[TARGET]add target for nvidia rtx 5060ti

### DIFF
--- a/src/target/tag.cc
+++ b/src/target/tag.cc
@@ -271,6 +271,8 @@ TVM_REGISTER_CUDA_TAG("nvidia/nvs-5200m", "sm_21", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/nvs-4200m", "sm_21", 49152, 32768);
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-4090", "sm_89", 49152, 65536)
     .with_config("l2_cache_size_bytes", 75497472);
+TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-5060-ti", "sm_120", 49152, 65536)
+    .with_config("l2_cache_size_bytes", 33554432);
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-3090-ti", "sm_86", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-3090", "sm_86", 49152, 65536);
 TVM_REGISTER_CUDA_TAG("nvidia/geforce-rtx-3080-ti", "sm_86", 49152, 65536);


### PR DESCRIPTION
Added NVIDIA RTX 5060 Ti as a supported target device，so we can use it like the following code
```python
target = tvm.target.Target("nvidia/geforce-rtx-5060-ti")
```