### PR TITLE
[Fix] Resolve deadlock in PopenPoolExecutor and LocalBuilder

### DIFF
--- a/python/tvm/meta_schedule/builder/local_builder.py
+++ b/python/tvm/meta_schedule/builder/local_builder.py
@@ -192,7 +192,7 @@ class LocalBuilder(PyBuilder):
                 )
             else:
                 raise ValueError("Unreachable: unexpected result: {map_result}")
-        del pool
+        pool.shutdown()
         return results
 
     def _sanity_check(self) -> None:
@@ -208,7 +208,7 @@ class LocalBuilder(PyBuilder):
         )
         value = pool.submit(_check, self.f_build, self.f_export)
         value.result()
-        del pool
+        pool.shutdown()
 
 
 def _worker_func(


### PR DESCRIPTION
Fix #18157 by:
- Add explicit shutdown flag in PopenPoolExecutor
- Replace del with explicit shutdown() calls in LocalBuilder

A minimal reproducible example can be found in the original issue.
