### PR TITLE
Removal of unused code that is causing unnecessary issues.

### DIFF
--- a/src/relay/backend/contrib/mrvl/codegen.cc
+++ b/src/relay/backend/contrib/mrvl/codegen.cc
@@ -1171,7 +1171,6 @@ class MrvlJSONSerializer : public backend::contrib::JSONSerializer {
     auto json_node = std::make_shared<JSONGraphNode>(name, "kernel", inputs, 1);
     SetMrvlLayerCommonAttrs(json_node, cn, layer_name_, name, data_layout,
                             "" /* no kernel_layout */, out_layout);
-    SetMrvlQuantAttrs(json_node, nodes.instrument_1, "1");
     return json_node;
   }
 

--- a/tests/python/contrib/test_mrvl/test_mrvl.py
+++ b/tests/python/contrib/test_mrvl/test_mrvl.py
@@ -257,7 +257,7 @@ def test_globalmaxpool2d():
         mod = tvm.IRModule()
         mod["main"] = func
         option_dict = {"num_tiles": 1}
-        verify_codegen(mod, params=params, tvm_ops=2, contains="mrvl.globalmaxpool2d_nhwc2nhwc")
+        verify_codegen(mod, params=params, tvm_ops=1, contains="mrvl.globalmaxpool2d_nhwc2nhwc")
         return func, {"x": (1, 3, 224, 224), "w": (16, 3, 3, 3)}, ["w"], option_dict
 
     run_and_verify_func(get_graph())


### PR DESCRIPTION
[legacy-v0.19.post][mrvl] Remove unused code to improve stability and maintainability
This commit targets the legacy-v0.19.post branch of Apache TVM and removes unused code segments that were causing unintended issues during execution and integration.
The cleanup enhances maintainability and reduces potential sources of error.