### PR TITLE
[LLVM][MSWIN][CI] Fix LLVM module build with latest CI update

### DIFF
--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -515,7 +515,13 @@ void LLVMModuleNode::InitORCJIT() {
           const llvm::Triple& triple) -> std::unique_ptr<llvm::orc::ObjectLayer> {
 #endif
 #if _WIN32
+#if TVM_LLVM_VERSION >= 210
+    auto GetMemMgr = [](const llvm::MemoryBuffer&) {
+      return std::make_unique<llvm::SectionMemoryManager>();
+    };
+#else
     auto GetMemMgr = []() { return std::make_unique<llvm::SectionMemoryManager>(); };
+#endif
     auto ObjLinkingLayer =
         std::make_unique<llvm::orc::RTDyldObjectLinkingLayer>(session, std::move(GetMemMgr));
 #else


### PR DESCRIPTION
This PR fix compile builds on MS-WIN observed during #18243.

---

* CI errors, ~~likely due to MSVC version upgrade~~ llvm upgrade to 21:
```
  llvm_module.cc
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35): error C2665: 'llvm::orc::RTDyldObjectLinkingLayer::RTDyldObjectLinkingLayer': no overloaded function could convert all the argument types [C:\Users\runneradmin\miniconda3\envs\tvm-build\conda-bld\tvm-package_1756327853683\work\build\tvm_objs.vcxproj]
  (compiling source file '../src/target/llvm/llvm_module.cc')
      C:\Users\runneradmin\miniconda3\envs\tvm-build\conda-bld\tvm-package_1756327853683\_h_env\Library\include\llvm\ExecutionEngine\Orc\RTDyldObjectLinkingLayer.h(58,3):
      could be 'llvm::orc::RTDyldObjectLinkingLayer::RTDyldObjectLinkingLayer(llvm::orc::ExecutionSession &,llvm::orc::RTDyldObjectLinkingLayer::GetMemoryManagerFunction)'
          C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35):
          'llvm::orc::RTDyldObjectLinkingLayer::RTDyldObjectLinkingLayer(llvm::orc::ExecutionSession &,llvm::orc::RTDyldObjectLinkingLayer::GetMemoryManagerFunction)': cannot convert argument 2 from '_Ty' to 'llvm::orc::RTDyldObjectLinkingLayer::GetMemoryManagerFunction'
          with
          [
              _Ty=tvm::codegen::LLVMModuleNode::InitORCJIT::<lambda_2>::()::<lambda_1>
          ]
              C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,56):
              No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35):
      while trying to match the argument list '(llvm::orc::ExecutionSession, _Ty)'
          with
          [
              _Ty=tvm::codegen::LLVMModuleNode::InitORCJIT::<lambda_2>::()::<lambda_1>
          ]
      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35):
      the template instantiation context (the oldest one first) is
          C:\Users\runneradmin\miniconda3\envs\tvm-build\conda-bld\tvm-package_1756327853683\work\src\target\llvm\llvm_module.cc(520,14):
          see reference to function template instantiation 'std::unique_ptr<llvm::orc::RTDyldObjectLinkingLayer,std::default_delete<llvm::orc::RTDyldObjectLinkingLayer>> std::make_unique<llvm::orc::RTDyldObjectLinkingLayer,llvm::orc::ExecutionSession&,tvm::codegen::LLVMModuleNode::InitORCJIT::<lambda_2>::()::<lambda_1>,0>(llvm::orc::ExecutionSession &,tvm::codegen::LLVMModuleNode::InitORCJIT::<lambda_2>::()::<lambda_1> &&)' being compiled
```