### PR TITLE
[FFI][CMAKE] Add missing download path for libbacktrace

### DIFF
--- a/ffi/cmake/Utils/AddLibbacktrace.cmake
+++ b/ffi/cmake/Utils/AddLibbacktrace.cmake
@@ -33,6 +33,8 @@ function(_libbacktrace_compile)
 
   ExternalProject_Add(project_libbacktrace
     PREFIX libbacktrace
+    GIT_REPOSITORY "https://github.com/ianlancetaylor/libbacktrace.git"
+    GIT_TAG "793921876c981ce49759114d7bb89bb89b2d3a2d"
     SOURCE_DIR ${_libbacktrace_source}
     BINARY_DIR ${_libbacktrace_prefix}
     CONFIGURE_COMMAND


### PR DESCRIPTION
This PR adds the missing URL for cmake's extrenal project (auto)-builder for ```libbacktrace```.
Not sure about releng FFI intention/migration, but I added ~~the last seen~~ upstream URL ~~in [PR#18226](https://github.com/apache/tvm/pull/18226)~~

---

* The error message, when the local system does not have a pre-installed ```libbacktrace```:
```
-- Git found: /usr/bin/git
-- Found TVM_GIT_COMMIT_HASH=335bc164b2539e18523e82c53f2808f184ec0ae2
-- Found TVM_GIT_COMMIT_TIME=2025-08-27 20:27:50 -0700
-- CMAKC_C_COMPILER="/usr/bin/gcc"
CMake Error at /usr/share/cmake/Modules/ExternalProject/shared_internal_commands.cmake:1323 (message):
  No download info given for 'project_libbacktrace' and its source directory:

   /home/cbalint/rpmbuild/BUILD/tvm-0.21.0-build/tvm/ffi/cmake/Utils/../../3rdparty/libbacktrace

  is not an existing non-empty directory.  Please specify one of:

   * SOURCE_DIR with an existing non-empty directory
   * DOWNLOAD_COMMAND
   * URL
   * GIT_REPOSITORY
   * SVN_REPOSITORY
   * HG_REPOSITORY
   * CVS_REPOSITORY and CVS_MODULE
Call Stack (most recent call first):
  /usr/share/cmake/Modules/ExternalProject.cmake:3041 (_ep_add_download_command)
  ffi/cmake/Utils/AddLibbacktrace.cmake:34 (ExternalProject_Add)
  ffi/cmake/Utils/AddLibbacktrace.cmake:67 (_libbacktrace_compile)
  ffi/CMakeLists.txt:29 (include)

```

#### UPDATE:

Due to MaCOS CI failure, replaced to uptream repo latest instead (repushed this PR).
Seems that upstream libbacktrace already [contain](https://github.com/ianlancetaylor/libbacktrace/blob/793921876c981ce49759114d7bb89bb89b2d3a2d/macho.c#L1273-L1275) the single patch from [tlc-pack](https://github.com/ianlancetaylor/libbacktrace/compare/master...tlc-pack:libbacktrace:master).

```
[ 95%] No patch step for 'project_libbacktrace'
[ 95%] Performing configure step for 'project_libbacktrace'
Invalid configuration `arm64-apple-darwin20.0.0': machine `arm64-apple' not recognized
```
