### PR TITLE
[Python] Update version.py to bump pyproject.toml automatically

### DIFF
--- a/version.py
+++ b/version.py
@@ -21,6 +21,7 @@ This script runs and update all the locations that related to versions
 
 List of affected files:
 - tvm-root/python/tvm/libinfo.py
+- tvm-root/pyproject.toml
 - tvm-root/include/tvm/runtime/base.h
 - tvm-root/conda/recipe/meta.yaml
 - tvm-root/web/package.json
@@ -173,6 +174,13 @@ def sync_version(pub_ver, local_ver, dry_run):
         os.path.join(PROJ_ROOT, "python", "tvm", "libinfo.py"),
         r"(?<=__version__ = \")[.0-9a-z\+]+",
         local_ver,
+        dry_run,
+    )
+    # pyproject.toml
+    update(
+        os.path.join(PROJ_ROOT, "pyproject.toml"),
+        r"(?<=version = \")[.0-9a-z\+]+",
+        pub_ver,
         dry_run,
     )
     # Use public version for other parts for now


### PR DESCRIPTION
This PR updates the `version.py`, so every time when running this file, it also bumps the version number in `pyproject.toml` automatically.