### PR TITLE
[FFI][CMAKE] Revert cmake libbacktrace URL and update submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/agauniyal/rang.git
 [submodule "3rdparty/libbacktrace"]
 	path = ffi/3rdparty/libbacktrace
-	url = https://github.com/tlc-pack/libbacktrace.git
+	url = https://github.com/ianlancetaylor/libbacktrace
 [submodule "3rdparty/cutlass"]
 	path = 3rdparty/cutlass
 	url = https://github.com/NVIDIA/cutlass.git

--- a/ffi/cmake/Utils/AddLibbacktrace.cmake
+++ b/ffi/cmake/Utils/AddLibbacktrace.cmake
@@ -33,8 +33,6 @@ function(_libbacktrace_compile)
 
   ExternalProject_Add(project_libbacktrace
     PREFIX libbacktrace
-    GIT_REPOSITORY "https://github.com/ianlancetaylor/libbacktrace.git"
-    GIT_TAG "793921876c981ce49759114d7bb89bb89b2d3a2d"
     SOURCE_DIR ${_libbacktrace_source}
     BINARY_DIR ${_libbacktrace_prefix}
     CONFIGURE_COMMAND


### PR DESCRIPTION
* Revert the URL out from cmake for libbacktrace
* Switch git submodule to upstream HEAD instead

As per discussed here https://github.com/apache/tvm/pull/18246#issuecomment-3234991244 , this reverts in favour of git submodule way.
As per finding in the same discuss the upstream [already](https://github.com/ianlancetaylor/libbacktrace/blob/793921876c981ce49759114d7bb89bb89b2d3a2d/macho.c#L1273-L1275) incorporates [the one patch](https://github.com/ianlancetaylor/libbacktrace/compare/master...tlc-pack:libbacktrace:master) used, and MacOS works fine.