### PR TITLE
Revert "[FFI][CMAKE] Add missing download path for libbacktrace"

### DIFF
--- a/ffi/cmake/Utils/AddLibbacktrace.cmake
+++ b/ffi/cmake/Utils/AddLibbacktrace.cmake
@@ -33,8 +33,6 @@ function(_libbacktrace_compile)
 
   ExternalProject_Add(project_libbacktrace
     PREFIX libbacktrace
-    GIT_REPOSITORY "https://github.com/ianlancetaylor/libbacktrace.git"
-    GIT_TAG "793921876c981ce49759114d7bb89bb89b2d3a2d"
     SOURCE_DIR ${_libbacktrace_source}
     BINARY_DIR ${_libbacktrace_prefix}
     CONFIGURE_COMMAND


### PR DESCRIPTION
This PR reverts apache/tvm#18246.

As mentioned in https://github.com/apache/tvm/pull/18246#issuecomment-3234991244, it seems that libbacktrace will be re-configured every time and `ffi/src/ffi/traceback.cc` will be compiled when we run `make`, even if there is no changes. This repetitive compilation increases the compilation time by a lot.