### PR TITLE
[FFI] fix two seemingly migration issue

### DIFF
--- a/ffi/python/tvm_ffi/cython/function.pxi
+++ b/ffi/python/tvm_ffi/cython/function.pxi
@@ -186,6 +186,7 @@ cdef inline int make_args(tuple py_args, TVMFFIAny* out, list temp_args,
             temp_args.append(tstr)
         elif arg is None:
             out[i].type_index = kTVMFFINone
+            out[i].v_int64 = 0
         elif isinstance(arg, Real):
             out[i].type_index = kTVMFFIFloat
             out[i].v_float64 = arg

--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -742,7 +742,9 @@ inline constexpr bool use_default_type_traits_v<Integer> = false;
 
 template <>
 struct TypeTraits<Integer> : public ObjectRefWithFallbackTraitsBase<Integer, int64_t> {
-  TVM_FFI_INLINE static Integer ConvertFallbackValue(int64_t value) { return Integer(value); }
+  TVM_FFI_INLINE static Integer ConvertFallbackValue(int64_t value) {
+    return Integer(TypeTraits<IntImm>::ConvertFallbackValue(value));
+  }
 };
 
 template <>


### PR DESCRIPTION
- Allow i64 any value convert to `Integer` of proper bitwidth.
    ```python
    import tvm
    from tvm import relax
    x = relax.Var("x", relax.TensorStructInfo((5, 784), "float32"))
    # just build an object with `Integer` typed field.
    x = relax.op.flip(x, 2**63-1).attrs.axis
    # maybe better to get T.int64(9223372036854775807) rather than -1
    ``` 
 
- Ensure None any value's v_int64=0, since `AnyHash` depends on the repr value.
    ```python
    m = tvm.ir.Map({None: 1})
    assert None in m   # get False if v_int64 not const initialized.
    ```