### PR TITLE
[BugFix][NNAPI] Use kind() instead of type_key() after FFI refactor

### DIFF
--- a/src/runtime/contrib/nnapi/nnapi_runtime.cc
+++ b/src/runtime/contrib/nnapi/nnapi_runtime.cc
@@ -54,7 +54,7 @@ class NNAPIRuntime : public JSONRuntimeBase {
                         const Array<String>& const_names)
       : JSONRuntimeBase(symbol_name, graph_json, const_names) {}
 
-  const char* type_key() const final { return "nnapi"; }
+  const char* kind() const final { return "nnapi"; }
 
 #ifdef TVM_GRAPH_EXECUTOR_NNAPI
   struct CompiledModel {


### PR DESCRIPTION
This PR updates the NNAPI runtime to align with the new FFI interface introduced in commit b8eb80b. It replaces the now-unused `type_key()` method with an override for the new pure virtual method `kind()`.
Verified locally with successful compilation and test run.