### PR TITLE
[FFI] Update torch stream getter to use native torch c api

### DIFF
--- a/ffi/pyproject.toml
+++ b/ffi/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "apache-tvm-ffi"
-version = "0.1.0a6"
+version = "0.1.0a7"
 description = "tvm ffi"
 
 authors = [{ name = "TVM FFI team" }]


### PR DESCRIPTION
This PR updates the torch stream getter to use  _cuda_getCurrentRawStream in the torch C API that is also used by dynamo, saves us from load_inline the custom module.