### PR TITLE
[FFI] Support Opaque PyObject

### DIFF
--- a/ffi/python/tvm_ffi/convert.py
+++ b/ffi/python/tvm_ffi/convert.py
@@ -56,13 +56,13 @@ def convert(value: Any) -> Any:
         return None
     elif hasattr(value, "__dlpack__"):
         return core.from_dlpack(
-            value,
-            required_alignment=core.__dlpack_auto_import_required_alignment__,
+            value, required_alignment=core.__dlpack_auto_import_required_alignment__
         )
     elif isinstance(value, Exception):
         return core._convert_to_ffi_error(value)
     else:
-        raise TypeError(f"don't know how to convert type {type(value)} to object")
+        # in this case, it is an opaque python object
+        return core._convert_to_opaque_object(value)
 
 
 core._set_func_convert_to_object(convert)

--- a/ffi/python/tvm_ffi/cython/base.pxi
+++ b/ffi/python/tvm_ffi/cython/base.pxi
@@ -53,6 +53,7 @@ cdef extern from "tvm/ffi/c_api.h":
         kTVMFFIArray = 71
         kTVMFFIMap = 72
         kTVMFFIModule = 73
+        kTVMFFIOpaquePyObject = 74
 
 
     ctypedef void* TVMFFIObjectHandle
@@ -110,6 +111,9 @@ cdef extern from "tvm/ffi/c_api.h":
     ctypedef struct TVMFFIByteArray:
         const char* data
         size_t size
+
+    ctypedef struct TVMFFIOpaqueObjectCell:
+        void* handle
 
     ctypedef struct TVMFFIShapeCell:
         const int64_t* data
@@ -172,6 +176,8 @@ cdef extern from "tvm/ffi/c_api.h":
         const TVMFFITypeMetadata* metadata
 
     int TVMFFIObjectDecRef(TVMFFIObjectHandle obj) nogil
+    int TVMFFIObjectCreateOpaque(void* handle, int32_t type_index,
+                                 void (*deleter)(void*), TVMFFIObjectHandle* out) nogil
     int TVMFFIObjectGetTypeIndex(TVMFFIObjectHandle obj) nogil
     int TVMFFIFunctionCall(TVMFFIObjectHandle func, TVMFFIAny* args, int32_t num_args,
                            TVMFFIAny* result) nogil
@@ -203,6 +209,7 @@ cdef extern from "tvm/ffi/c_api.h":
     TVMFFIByteArray TVMFFISmallBytesGetContentByteArray(const TVMFFIAny* value) nogil
     TVMFFIByteArray* TVMFFIBytesGetByteArrayPtr(TVMFFIObjectHandle obj) nogil
     TVMFFIErrorCell* TVMFFIErrorGetCellPtr(TVMFFIObjectHandle obj) nogil
+    TVMFFIOpaqueObjectCell* TVMFFIOpaqueObjectGetCellPtr(TVMFFIObjectHandle obj) nogil
     TVMFFIShapeCell* TVMFFIShapeGetCellPtr(TVMFFIObjectHandle obj) nogil
     DLTensor* TVMFFINDArrayGetDLTensorPtr(TVMFFIObjectHandle obj) nogil
     DLDevice TVMFFIDLDeviceFromIntPair(int32_t device_type, int32_t device_id) nogil

--- a/ffi/python/tvm_ffi/cython/object.pxi
+++ b/ffi/python/tvm_ffi/cython/object.pxi
@@ -194,6 +194,17 @@ cdef class Object:
         (<Object>other).chandle = NULL
 
 
+cdef class OpaquePyObject(Object):
+    """Opaque PyObject container"""
+    def pyobject(self):
+        """Get the underlying python object"""
+        cdef object obj
+        cdef PyObject* py_handle
+        py_handle = <PyObject*>(TVMFFIOpaqueObjectGetCellPtr(self.chandle).handle)
+        obj = <object>py_handle
+        return obj
+
+
 class PyNativeObject:
     """Base class of all TVM objects that also subclass python's builtin types."""
     __slots__ = []
@@ -250,6 +261,12 @@ cdef inline str _type_index_to_key(int32_t tindex):
         return "<unknown>"
     type_key = &(info.type_key)
     return py_str(PyBytes_FromStringAndSize(type_key.data, type_key.size))
+
+
+cdef inline object make_ret_opaque_object(TVMFFIAny result):
+    obj = OpaquePyObject.__new__(OpaquePyObject)
+    (<Object>obj).chandle = result.v_obj
+    return obj.pyobject()
 
 
 cdef inline object make_ret_object(TVMFFIAny result):

--- a/ffi/tests/python/test_container.py
+++ b/ffi/tests/python/test_container.py
@@ -66,6 +66,28 @@ def test_int_map():
     assert tuple(amap.values()) == (2, 3)
 
 
+def test_array_map_of_opaque_object():
+    class MyObject:
+        def __init__(self, value):
+            self.value = value
+
+    a = tvm_ffi.convert([MyObject("hello"), MyObject(1)])
+    assert isinstance(a, tvm_ffi.Array)
+    assert len(a) == 2
+    assert isinstance(a[0], MyObject)
+    assert a[0].value == "hello"
+    assert isinstance(a[1], MyObject)
+    assert a[1].value == 1
+
+    y = tvm_ffi.convert({"a": MyObject(1), "b": MyObject("hello")})
+    assert isinstance(y, tvm_ffi.Map)
+    assert len(y) == 2
+    assert isinstance(y["a"], MyObject)
+    assert y["a"].value == 1
+    assert isinstance(y["b"], MyObject)
+    assert y["b"].value == "hello"
+
+
 def test_str_map():
     data = []
     for i in reversed(range(10)):

--- a/ffi/tests/python/test_object.py
+++ b/ffi/tests/python/test_object.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import pytest
+import sys
 
 import tvm_ffi
 
@@ -68,3 +69,23 @@ def test_derived_object():
 
     obj0.v_i64 = 21
     assert obj0.v_i64 == 21
+
+
+class MyObject:
+    def __init__(self, value):
+        self.value = value
+
+
+def test_opaque_object():
+    obj0 = MyObject("hello")
+    assert sys.getrefcount(obj0) == 2
+    obj0_converted = tvm_ffi.convert(obj0)
+    assert sys.getrefcount(obj0) == 3
+    assert isinstance(obj0_converted, tvm_ffi.core.OpaquePyObject)
+    obj0_cpy = obj0_converted.pyobject()
+    assert obj0_cpy is obj0
+    assert sys.getrefcount(obj0) == 4
+    obj0_converted = None
+    assert sys.getrefcount(obj0) == 3
+    obj0_cpy = None
+    assert sys.getrefcount(obj0) == 2


### PR DESCRIPTION
This PR adds support of Opaque PyObject.
When a type in python is not natively supported by ffi, it will now be converted to an Opaque PyObject on the backend, such opaque object will retain their lifecycle automatically and can still be used by registering python callbacks or store in container and return to the frontend.