### PR TITLE
[FFI] Relax default alignment and continguous requirement

### DIFF
--- a/ffi/python/tvm_ffi/_convert.py
+++ b/ffi/python/tvm_ffi/_convert.py
@@ -61,9 +61,7 @@ def convert(value: Any) -> Any:
     elif value is None:
         return None
     elif hasattr(value, "__dlpack__"):
-        return core.from_dlpack(
-            value, required_alignment=core.__dlpack_auto_import_required_alignment__
-        )
+        return core.from_dlpack(value)
     elif isinstance(value, Exception):
         return core._convert_to_ffi_error(value)
     else:

--- a/ffi/python/tvm_ffi/cython/function.pxi
+++ b/ffi/python/tvm_ffi/cython/function.pxi
@@ -109,8 +109,7 @@ cdef inline int make_args(tuple py_args, TVMFFIAny* out, list temp_args,
             out[i].v_ptr = (<Object>arg).chandle
         elif torch is not None and isinstance(arg, torch.Tensor):
             is_cuda = arg.is_cuda
-            arg = from_dlpack(torch.utils.dlpack.to_dlpack(arg),
-                              required_alignment=__dlpack_auto_import_required_alignment__)
+            arg = from_dlpack(torch.utils.dlpack.to_dlpack(arg))
             out[i].type_index = kTVMFFITensor
             out[i].v_ptr = (<Tensor>arg).chandle
             temp_dltensor = TVMFFITensorGetDLTensorPtr((<Tensor>arg).chandle)
@@ -123,7 +122,7 @@ cdef inline int make_args(tuple py_args, TVMFFIAny* out, list temp_args,
                 ctx_stream[0] = <TVMFFIStreamHandle>temp_ptr
             temp_args.append(arg)
         elif hasattr(arg, "__dlpack__"):
-            arg = from_dlpack(arg, required_alignment=__dlpack_auto_import_required_alignment__)
+            arg = from_dlpack(arg)
             out[i].type_index = kTVMFFITensor
             out[i].v_ptr = (<Tensor>arg).chandle
             temp_args.append(arg)

--- a/python/tvm/runtime/_tensor.py
+++ b/python/tvm/runtime/_tensor.py
@@ -44,16 +44,18 @@ def from_dlpack(ext_tensor):
     ext_tensor : object
         The external tensor to convert.
 
-    required_alignment : int
+    require_alignment : int
         The minimum required alignment to check for the tensor.
 
-    required_contiguous : bool
+    require_contiguous : bool
         Whether to check for contiguous memory.
     """
+    # TODO(tvm-team): change to require_alignment=0 and require_contiguous=False
+    # once we update the compiler generated code to guard against misaligned access.
     return tvm_ffi.from_dlpack(
         ext_tensor,
-        required_alignment=64,
-        required_contiguous=True,
+        require_alignment=64,
+        require_contiguous=True,
     )
 
 

--- a/src/tir/ir/stmt.cc
+++ b/src/tir/ir/stmt.cc
@@ -603,8 +603,8 @@ MatchBufferRegion::MatchBufferRegion(Buffer buffer, BufferRegion source) {
   // Check data_alignment
   CHECK(source_buffer->data_alignment % buffer->data_alignment == 0)
       << "Trying to match buffer to another one with lower alignment requirement "
-      << " required_alignment=" << buffer->data_alignment
-      << ", provided_alignment=" << source_buffer->data_alignment;
+      << " required alignment=" << buffer->data_alignment
+      << ", provided alignment=" << source_buffer->data_alignment;
 
   // Check BufferType. AutoBroadcast is not allowed for now.
   CHECK(buffer->buffer_type == BufferType::kDefault &&

--- a/src/tir/transforms/arg_binder.cc
+++ b/src/tir/transforms/arg_binder.cc
@@ -93,8 +93,8 @@ void ArgBinder::BindBuffer(const Buffer& arg, const Buffer& value, const std::st
       << "Argument " << arg_name << " Buffer bind data type mismatch";
   if (value->data_alignment % arg->data_alignment != 0) {
     LOG(WARNING) << "Trying to bind buffer to another one with lower alignment requirement "
-                 << " required_alignment=" << arg->data_alignment
-                 << ", provided_alignment=" << value->data_alignment;
+                 << " required alignment=" << arg->data_alignment
+                 << ", provided alignment=" << value->data_alignment;
   }
 
   if (value->elem_offset.defined()) {

--- a/src/tir/transforms/lower_match_buffer.cc
+++ b/src/tir/transforms/lower_match_buffer.cc
@@ -152,8 +152,8 @@ class MatchBufferLower : public StmtExprMutator {
     // Step.1.2. Check data alignment
     if (source_buffer->data_alignment % buffer->data_alignment != 0) {
       LOG(WARNING) << "Trying to bind buffer to another one with lower alignment requirement "
-                   << " required_alignment=" << buffer->data_alignment
-                   << ", provided_alignment=" << source_buffer->data_alignment;
+                   << " required alignment=" << buffer->data_alignment
+                   << ", provided alignment=" << source_buffer->data_alignment;
     }
     if (is_zero(buffer->elem_offset)) {
       ICHECK(is_zero(source_buffer->elem_offset))

--- a/tests/python/relax/test_op_inspect.py
+++ b/tests/python/relax/test_op_inspect.py
@@ -171,7 +171,7 @@ def test_strides_of_non_compact_tensor():
     expected_strides = [1, 4]
     # use transpose to make strides non-compact
     x = np.zeros([4, 4], "int32").T
-    y = tvm_ffi.from_dlpack(x, required_alignment=4, required_contiguous=False)
+    y = tvm_ffi.from_dlpack(x, require_alignment=4, require_contiguous=False)
     res = [vm["main"](y, i) for i, _ in enumerate(view_shape)]
     tvm.ir.assert_structural_equal(res, expected_strides)
 


### PR DESCRIPTION
This PR relax default alignment and continguous requirement in dlpack import. This allows the ffi to be useful in most settings. We also provide utility for users to check these requirements themselves.