### PR TITLE
[FFI][REFACTOR] Streamline Object Declare Macros

### DIFF
--- a/docs/arch/pass_infra.rst
+++ b/docs/arch/pass_infra.rst
@@ -451,7 +451,7 @@ Multiple ``PassInstrument`` instances can be registed into a single
 
     class PassInstrument : public ObjectRef {
      public:
-      TVM_DEFINE_OBJECT_REF_METHODS(PassInstrument, ObjectRef, PassInstrumentNode);
+      TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PassInstrument, ObjectRef, PassInstrumentNode);
     };
 
     }  // namespace instrument

--- a/docs/arch/runtime.rst
+++ b/docs/arch/runtime.rst
@@ -227,9 +227,7 @@ Each ``Object`` subclass will override this to register its members. Here is an 
       namespace refl = tvm::ffi::reflection;
       refl::ObjectDef<IntImmNode>().def_ro("value", &IntImmNode::value);
     }
-
-    static constexpr const char* _type_key = "ir.IntImm";
-    TVM_DECLARE_FINAL_OBJECT_INFO(IntImmNode, PrimExprNode);
+    TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.IntImm", IntImmNode, PrimExprNode);
   };
   // in cc file
   TVM_FFI_STATIC_INIT_BLOCK({ IntImmNode::RegisterReflection(); });

--- a/ffi/docs/guides/cpp_guide.md
+++ b/ffi/docs/guides/cpp_guide.md
@@ -105,9 +105,7 @@ class MyIntPairObj : public tvm::ffi::Object {
 
   // Required: declare type information
   // to register a dynamic type index through the system
-  static constexpr const char* _type_key = "example.MyIntPair";
-  // This macro registers the class with the FFI system to set up the right type index
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(MyIntPairObj, tvm::ffi::Object);
+TVM_FFI_DECLARE_OBJECT_INFO_FINAL("example.MyIntPair", MyIntPairObj, tvm::ffi::Object);
 };
 
 void ExampleObjectPtr() {
@@ -138,7 +136,7 @@ class MyIntPair : public tvm::ffi::ObjectRef {
 
   // Required: define object reference methods
   // This macro provides the necessary methods for ObjectRef functionality
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(MyIntPair, tvm::ffi::ObjectRef, MyIntPairObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MyIntPair, tvm::ffi::ObjectRef, MyIntPairObj);
 };
 
 void ExampleObjectRef() {

--- a/ffi/docs/guides/python_guide.md
+++ b/ffi/docs/guides/python_guide.md
@@ -188,8 +188,7 @@ public:
   TestIntPairObj(int64_t a, int64_t b) : a(a), b(b) {}
 
   // Required: declare type information
-  static constexpr const char* _type_key = "testing.TestIntPair";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TestIntPairObj, tvm::ffi::Object);
+TVM_FFI_DECLARE_OBJECT_INFO_FINAL("testing.TestIntPair", TestIntPairObj, tvm::ffi::Object);
 };
 
 // Step 2: Define the reference wrapper (user-facing interface)
@@ -201,7 +200,7 @@ public:
   }
 
   // Required: define object reference methods
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(TestIntPair, tvm::ffi::ObjectRef, TestIntPairObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TestIntPair, tvm::ffi::ObjectRef, TestIntPairObj);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({

--- a/ffi/include/tvm/ffi/container/array.h
+++ b/ffi/include/tvm/ffi/container/array.h
@@ -157,9 +157,8 @@ class ArrayObj : public Object, public details::InplaceArrayBase<ArrayObj, TVMFF
 
   /// \cond Doxygen_Suppress
   static constexpr const int32_t _type_index = TypeIndex::kTVMFFIArray;
-  static constexpr const char* _type_key = StaticTypeKey::kTVMFFIArray;
   static const constexpr bool _type_final = true;
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(ArrayObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC(StaticTypeKey::kTVMFFIArray, ArrayObj, Object);
   /// \endcond
 
  private:

--- a/ffi/include/tvm/ffi/container/map.h
+++ b/ffi/include/tvm/ffi/container/map.h
@@ -73,9 +73,8 @@ class MapObj : public Object {
 
   /// \cond Doxygen_Suppress
   static constexpr const int32_t _type_index = TypeIndex::kTVMFFIMap;
-  static constexpr const char* _type_key = StaticTypeKey::kTVMFFIMap;
   static const constexpr bool _type_final = true;
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(MapObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC(StaticTypeKey::kTVMFFIMap, MapObj, Object);
   /// \endcond
 
   /*!

--- a/ffi/include/tvm/ffi/container/shape.h
+++ b/ffi/include/tvm/ffi/container/shape.h
@@ -53,8 +53,7 @@ class ShapeObj : public Object, public TVMFFIShapeCell {
 
   /// \cond Doxygen_Suppress
   static constexpr const uint32_t _type_index = TypeIndex::kTVMFFIShape;
-  static constexpr const char* _type_key = StaticTypeKey::kTVMFFIShape;
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(ShapeObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC(StaticTypeKey::kTVMFFIShape, ShapeObj, Object);
   /// \endcond
 };
 
@@ -212,7 +211,7 @@ class Shape : public ObjectRef {
   int64_t Product() const { return get()->Product(); }
 
   /// \cond Doxygen_Suppress
-  TVM_FFI_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(Shape, ObjectRef, ShapeObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Shape, ObjectRef, ShapeObj);
   /// \endcond
 
  private:

--- a/ffi/include/tvm/ffi/container/tensor.h
+++ b/ffi/include/tvm/ffi/container/tensor.h
@@ -121,8 +121,7 @@ class TensorObj : public Object, public DLTensor {
  public:
   /// \cond Doxygen_Suppress
   static constexpr const uint32_t _type_index = TypeIndex::kTVMFFITensor;
-  static constexpr const char* _type_key = StaticTypeKey::kTVMFFITensor;
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(TensorObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC(StaticTypeKey::kTVMFFITensor, TensorObj, Object);
   /// \endcond
 
   /*!
@@ -363,7 +362,7 @@ class Tensor : public ObjectRef {
   DLManagedTensorVersioned* ToDLPackVersioned() const { return get_mutable()->ToDLPackVersioned(); }
 
   /// \cond Doxygen_Suppress
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(Tensor, ObjectRef, TensorObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Tensor, ObjectRef, TensorObj);
   /// \endcond
 
  protected:

--- a/ffi/include/tvm/ffi/error.h
+++ b/ffi/include/tvm/ffi/error.h
@@ -87,8 +87,7 @@ class ErrorObj : public Object, public TVMFFIErrorCell {
  public:
   /// \cond Doxygen_Suppress
   static constexpr const int32_t _type_index = TypeIndex::kTVMFFIError;
-  static constexpr const char* _type_key = "ffi.Error";
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(ErrorObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC("ffi.Error", ErrorObj, Object);
   /// \endcond
 };
 
@@ -196,7 +195,7 @@ class Error : public ObjectRef, public std::exception {
   }
 
   /// \cond Doxygen_Suppress
-  TVM_FFI_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(Error, ObjectRef, ErrorObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Error, ObjectRef, ErrorObj);
   /// \endcond
 };
 

--- a/ffi/include/tvm/ffi/extra/module.h
+++ b/ffi/include/tvm/ffi/extra/module.h
@@ -146,9 +146,9 @@ class TVM_FFI_EXTRA_CXX_API ModuleObj : public Object {
 
   /// \cond Doxygen_Suppress
   static constexpr const int32_t _type_index = TypeIndex::kTVMFFIModule;
-  static constexpr const char* _type_key = StaticTypeKey::kTVMFFIModule;
+  static constexpr const bool _type_mutable = true;
   static const constexpr bool _type_final = true;
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(ModuleObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC(StaticTypeKey::kTVMFFIModule, ModuleObj, Object);
   /// \endcond
 
  protected:
@@ -234,7 +234,7 @@ class Module : public ObjectRef {
       const ffi::TypedFunction<void(String, void*)>& callback);
 
   /// \cond Doxygen_Suppress
-  TVM_FFI_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(Module, ObjectRef, ModuleObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Module, ObjectRef, ModuleObj);
   /// \endcond
 };
 

--- a/ffi/include/tvm/ffi/function.h
+++ b/ffi/include/tvm/ffi/function.h
@@ -116,8 +116,7 @@ class FunctionObj : public Object, public TVMFFIFunctionCell {
   }
   /// \cond Doxygen_Suppress
   static constexpr const uint32_t _type_index = TypeIndex::kTVMFFIFunction;
-  static constexpr const char* _type_key = StaticTypeKey::kTVMFFIFunction;
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(FunctionObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC(StaticTypeKey::kTVMFFIFunction, FunctionObj, Object);
   /// \endcond
 
  protected:
@@ -594,7 +593,7 @@ class Function : public ObjectRef {
   TVM_FFI_INLINE bool operator!=(std::nullptr_t) const { return data_ != nullptr; }
 
   /// \cond Doxygen_Suppress
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(Function, ObjectRef, FunctionObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Function, ObjectRef, FunctionObj);
   /// \endcond
 
   class Registry;

--- a/ffi/include/tvm/ffi/reflection/access_path.h
+++ b/ffi/include/tvm/ffi/reflection/access_path.h
@@ -92,9 +92,8 @@ class AccessStepObj : public Object {
   inline bool StepEqual(const AccessStep& other) const;
 
   /// \cond Doxygen_Suppress
-  static constexpr const char* _type_key = "ffi.reflection.AccessStep";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindConstTreeNode;
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AccessStepObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ffi.reflection.AccessStep", AccessStepObj, Object);
   /// \endcond
 };
 
@@ -162,7 +161,7 @@ class AccessStep : public ObjectRef {
   }
 
   /// \cond Doxygen_Suppress
-  TVM_FFI_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(AccessStep, ObjectRef, AccessStepObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AccessStep, ObjectRef, AccessStepObj);
   /// \endcond
 };
 
@@ -286,9 +285,8 @@ class AccessPathObj : public Object {
   inline bool IsPrefixOf(const AccessPath& other) const;
 
   /// \cond Doxygen_Suppress
-  static constexpr const char* _type_key = "ffi.reflection.AccessPath";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindConstTreeNode;
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AccessPathObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ffi.reflection.AccessPath", AccessPathObj, Object);
   /// \endcond
 
  private:
@@ -358,7 +356,7 @@ class AccessPath : public ObjectRef {
   }
 
   /// \cond Doxygen_Suppress
-  TVM_FFI_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(AccessPath, ObjectRef, AccessPathObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AccessPath, ObjectRef, AccessPathObj);
   /// \endcond
 
  private:

--- a/ffi/include/tvm/ffi/string.h
+++ b/ffi/include/tvm/ffi/string.h
@@ -61,18 +61,16 @@ class BytesObjBase : public Object, public TVMFFIByteArray {};
 class BytesObj : public BytesObjBase {
  public:
   static constexpr const uint32_t _type_index = TypeIndex::kTVMFFIBytes;
-  static constexpr const char* _type_key = StaticTypeKey::kTVMFFIBytes;
   static const constexpr bool _type_final = true;
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(BytesObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC(StaticTypeKey::kTVMFFIBytes, BytesObj, Object);
 };
 
 /*! \brief An object representing string. This is a POD type. */
 class StringObj : public BytesObjBase {
  public:
   static constexpr const uint32_t _type_index = TypeIndex::kTVMFFIStr;
-  static constexpr const char* _type_key = StaticTypeKey::kTVMFFIStr;
   static const constexpr bool _type_final = true;
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(StringObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC(StaticTypeKey::kTVMFFIStr, StringObj, Object);
 };
 
 // String moved from std::string

--- a/ffi/src/ffi/extra/testing.cc
+++ b/ffi/src/ffi/extra/testing.cc
@@ -40,8 +40,7 @@ class TestIntPairObj : public tvm::ffi::Object {
   TestIntPairObj(int64_t a, int64_t b) : a(a), b(b) {}
 
   // Required: declare type information
-  static constexpr const char* _type_key = "testing.TestIntPair";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TestIntPairObj, tvm::ffi::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("testing.TestIntPair", TestIntPairObj, tvm::ffi::Object);
 };
 
 // Step 2: Define the reference wrapper (user-facing interface)
@@ -53,7 +52,7 @@ class TestIntPair : public tvm::ffi::ObjectRef {
   }
 
   // Required: define object reference methods
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(TestIntPair, tvm::ffi::ObjectRef, TestIntPairObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TestIntPair, tvm::ffi::ObjectRef, TestIntPairObj);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({
@@ -76,8 +75,7 @@ class TestObjectBase : public Object {
   // declare as one slot, with float as overflow
   static constexpr bool _type_mutable = true;
   static constexpr uint32_t _type_child_slots = 1;
-  static constexpr const char* _type_key = "testing.TestObjectBase";
-  TVM_FFI_DECLARE_BASE_OBJECT_INFO(TestObjectBase, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("testing.TestObjectBase", TestObjectBase, Object);
 };
 
 class TestObjectDerived : public TestObjectBase {
@@ -86,8 +84,7 @@ class TestObjectDerived : public TestObjectBase {
   Array<Any> v_array;
 
   // declare as one slot, with float as overflow
-  static constexpr const char* _type_key = "testing.TestObjectDerived";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TestObjectDerived, TestObjectBase);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("testing.TestObjectDerived", TestObjectDerived, TestObjectBase);
 };
 
 TVM_FFI_NO_INLINE void TestRaiseError(String kind, String msg) {

--- a/ffi/tests/cpp/test_example.cc
+++ b/ffi/tests/cpp/test_example.cc
@@ -243,8 +243,7 @@ class MyIntPairObj : public tvm::ffi::Object {
   MyIntPairObj(int64_t a, int64_t b) : a(a), b(b) {}
 
   // Required: declare type information
-  static constexpr const char* _type_key = "example.MyIntPair";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(MyIntPairObj, tvm::ffi::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("example.MyIntPair", MyIntPairObj, tvm::ffi::Object);
 };
 
 // Step 2: Define the reference wrapper (user-facing interface)
@@ -254,7 +253,7 @@ class MyIntPair : public tvm::ffi::ObjectRef {
   explicit MyIntPair(int64_t a, int64_t b) { data_ = tvm::ffi::make_object<MyIntPairObj>(a, b); }
 
   // Required: define object reference methods
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(MyIntPair, tvm::ffi::ObjectRef, MyIntPairObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MyIntPair, tvm::ffi::ObjectRef, MyIntPairObj);
 };
 
 void ExampleObjectPtr() {

--- a/ffi/tests/cpp/test_reflection.cc
+++ b/ffi/tests/cpp/test_reflection.cc
@@ -37,16 +37,13 @@ struct TestObjA : public Object {
   int64_t x;
   int64_t y;
 
-  static constexpr const char* _type_key = "test.TestObjA";
   static constexpr bool _type_mutable = true;
-  TVM_FFI_DECLARE_BASE_OBJECT_INFO(TestObjA, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("test.TestObjA", TestObjA, Object);
 };
 
 struct TestObjADerived : public TestObjA {
   int64_t z;
-
-  static constexpr const char* _type_key = "test.TestObjADerived";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TestObjADerived, TestObjA);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("test.TestObjADerived", TestObjADerived, TestObjA);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({

--- a/ffi/tests/cpp/testing_object.h
+++ b/ffi/tests/cpp/testing_object.h
@@ -46,13 +46,12 @@ class TNumberObj : public BasePad, public Object {
   // declare as one slot, with float as overflow
   static constexpr uint32_t _type_child_slots = 1;
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "test.Number";
-  TVM_FFI_DECLARE_BASE_OBJECT_INFO(TNumberObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("test.Number", TNumberObj, Object);
 };
 
 class TNumber : public ObjectRef {
  public:
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(TNumber, ObjectRef, TNumberObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TNumber, ObjectRef, TNumberObj);
 };
 
 class TIntObj : public TNumberObj {
@@ -64,11 +63,9 @@ class TIntObj : public TNumberObj {
 
   int64_t GetValue() const { return value; }
 
-  static constexpr const char* _type_key = "test.Int";
-
   inline static void RegisterReflection();
 
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TIntObj, TNumberObj);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("test.Int", TIntObj, TNumberObj);
 };
 
 class TInt : public TNumber {
@@ -77,7 +74,7 @@ class TInt : public TNumber {
 
   static TInt StaticAdd(TInt lhs, TInt rhs) { return TInt(lhs->value + rhs->value); }
 
-  TVM_FFI_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TInt, TNumber, TIntObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TInt, TNumber, TIntObj);
 };
 
 inline void TIntObj::RegisterReflection() {
@@ -117,15 +114,14 @@ class TFloatObj : public TNumberObj {
         .def("add", &TFloatObj::Add, "add method");
   }
 
-  static constexpr const char* _type_key = "test.Float";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TFloatObj, TNumberObj);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("test.Float", TFloatObj, TNumberObj);
 };
 
 class TFloat : public TNumber {
  public:
   explicit TFloat(double value) { data_ = make_object<TFloatObj>(value); }
 
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(TFloat, TNumber, TFloatObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TFloat, TNumber, TFloatObj);
 };
 
 class TPrimExprObj : public Object {
@@ -146,10 +142,9 @@ class TPrimExprObj : public Object {
         });
   }
 
-  static constexpr const char* _type_key = "test.PrimExpr";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
   static constexpr bool _type_mutable = true;
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TPrimExprObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("test.PrimExpr", TPrimExprObj, Object);
 };
 
 class TPrimExpr : public ObjectRef {
@@ -158,7 +153,7 @@ class TPrimExpr : public ObjectRef {
     data_ = make_object<TPrimExprObj>(dtype, value);
   }
 
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(TPrimExpr, ObjectRef, TPrimExprObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TPrimExpr, ObjectRef, TPrimExprObj);
 };
 
 class TVarObj : public Object {
@@ -175,16 +170,15 @@ class TVarObj : public Object {
                                       refl::AttachFieldFlag::SEqHashIgnore());
   }
 
-  static constexpr const char* _type_key = "test.Var";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindFreeVar;
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TVarObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("test.Var", TVarObj, Object);
 };
 
 class TVar : public ObjectRef {
  public:
   explicit TVar(std::string name) { data_ = make_object<TVarObj>(name); }
 
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(TVar, ObjectRef, TVarObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TVar, ObjectRef, TVarObj);
 };
 
 class TFuncObj : public Object {
@@ -206,9 +200,8 @@ class TFuncObj : public Object {
         .def_ro("comment", &TFuncObj::comment, refl::AttachFieldFlag::SEqHashIgnore());
   }
 
-  static constexpr const char* _type_key = "test.Func";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TFuncObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("test.Func", TFuncObj, Object);
 };
 
 class TFunc : public ObjectRef {
@@ -217,7 +210,7 @@ class TFunc : public ObjectRef {
     data_ = make_object<TFuncObj>(params, body, comment);
   }
 
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(TFunc, ObjectRef, TFuncObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TFunc, ObjectRef, TFuncObj);
 };
 
 class TCustomFuncObj : public Object {
@@ -259,9 +252,8 @@ class TCustomFuncObj : public Object {
         .def("__s_hash__", &TCustomFuncObj::SHash);
   }
 
-  static constexpr const char* _type_key = "test.CustomFunc";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TCustomFuncObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("test.CustomFunc", TCustomFuncObj, Object);
 };
 
 class TCustomFunc : public ObjectRef {
@@ -270,7 +262,7 @@ class TCustomFunc : public ObjectRef {
     data_ = make_object<TCustomFuncObj>(params, body, comment);
   }
 
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS(TCustomFunc, ObjectRef, TCustomFuncObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TCustomFunc, ObjectRef, TCustomFuncObj);
 };
 
 }  // namespace testing

--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -103,8 +103,7 @@ class ConstIntBoundNode : public Object {
   static const constexpr int64_t kNegInf = -kPosInf;
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "arith.ConstIntBound";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ConstIntBoundNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.ConstIntBound", ConstIntBoundNode, Object);
 };
 
 /*!
@@ -122,7 +121,7 @@ class ConstIntBound : public ObjectRef {
 
   static const constexpr int64_t kPosInf = ConstIntBoundNode::kPosInf;
   static const constexpr int64_t kNegInf = ConstIntBoundNode::kNegInf;
-  TVM_DEFINE_OBJECT_REF_METHODS(ConstIntBound, ObjectRef, ConstIntBoundNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ConstIntBound, ObjectRef, ConstIntBoundNode);
 };
 
 /*!
@@ -216,8 +215,7 @@ class ModularSetNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "arith.ModularSet";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ModularSetNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.ModularSet", ModularSetNode, Object);
 };
 
 /*!
@@ -228,7 +226,7 @@ class ModularSet : public ObjectRef {
  public:
   TVM_DLL ModularSet(int64_t coeff, int64_t base);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ModularSet, ObjectRef, ModularSetNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ModularSet, ObjectRef, ModularSetNode);
 };
 
 /*!

--- a/include/tvm/arith/int_set.h
+++ b/include/tvm/arith/int_set.h
@@ -56,9 +56,7 @@ enum SignType { kPositive, kNegative, kZero, kUnknown };
  */
 class IntSetNode : public Object {
  public:
-  static constexpr const char* _type_key = "ir.IntSet";
-
-  TVM_DECLARE_BASE_OBJECT_INFO(IntSetNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.IntSet", IntSetNode, Object);
 };
 
 /*!
@@ -163,7 +161,7 @@ class IntSet : public ObjectRef {
    */
   static IntSet Interval(PrimExpr min, PrimExpr max);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IntSet, ObjectRef, IntSetNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntSet, ObjectRef, IntSetNode);
 };
 
 //-----------------------------------------------

--- a/include/tvm/arith/int_solver.h
+++ b/include/tvm/arith/int_solver.h
@@ -72,9 +72,7 @@ class IntGroupBoundsNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-
-  static constexpr const char* _type_key = "arith.IntGroupBounds";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IntGroupBoundsNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.IntGroupBounds", IntGroupBoundsNode, Object);
 };
 
 /*!
@@ -123,7 +121,7 @@ class IntGroupBounds : public ObjectRef {
    */
   IntGroupBounds operator+(const Range& r);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IntGroupBounds, ObjectRef, IntGroupBoundsNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntGroupBounds, ObjectRef, IntGroupBoundsNode);
 };
 
 /*!
@@ -152,9 +150,7 @@ class IntConstraintsNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-
-  static constexpr const char* _type_key = "arith.IntConstraints";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IntConstraintsNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.IntConstraints", IntConstraintsNode, Object);
 };
 
 /*!
@@ -173,7 +169,7 @@ class IntConstraints : public ObjectRef {
   TVM_DLL IntConstraints(ffi::Array<Var> variables, ffi::Map<Var, Range> ranges,
                          ffi::Array<PrimExpr> relations);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IntConstraints, ObjectRef, IntConstraintsNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntConstraints, ObjectRef, IntConstraintsNode);
 };
 
 /*!
@@ -207,9 +203,8 @@ class IntConstraintsTransformNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-
-  static constexpr const char* _type_key = "arith.IntConstraintsTransform";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IntConstraintsTransformNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.IntConstraintsTransform", IntConstraintsTransformNode,
+                                    Object);
 };
 
 /*!
@@ -241,7 +236,8 @@ class IntConstraintsTransform : public ObjectRef {
    */
   IntConstraintsTransform operator+(const IntConstraintsTransform& other) const;
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IntConstraintsTransform, ObjectRef, IntConstraintsTransformNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntConstraintsTransform, ObjectRef,
+                                             IntConstraintsTransformNode);
 };
 
 typedef std::pair<ffi::Map<Var, IntGroupBounds>, ffi::Array<PrimExpr>> PartialSolvedInequalities;

--- a/include/tvm/arith/iter_affine_map.h
+++ b/include/tvm/arith/iter_affine_map.h
@@ -66,9 +66,8 @@ namespace arith {
  */
 class IterMapExprNode : public PrimExprNode {
  public:
-  static constexpr const char* _type_key = "arith.IterMapExpr";
   static constexpr const uint32_t _type_child_slots = 2;
-  TVM_DECLARE_BASE_OBJECT_INFO(IterMapExprNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("arith.IterMapExpr", IterMapExprNode, PrimExprNode);
 };
 
 /*!
@@ -77,7 +76,7 @@ class IterMapExprNode : public PrimExprNode {
  */
 class IterMapExpr : public PrimExpr {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(IterMapExpr, PrimExpr, IterMapExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IterMapExpr, PrimExpr, IterMapExprNode);
 };
 
 /*!
@@ -106,9 +105,7 @@ class IterMarkNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindDAGNode;
-
-  static constexpr const char* _type_key = "arith.IterMark";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IterMarkNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.IterMark", IterMarkNode, Object);
 };
 
 /*!
@@ -124,7 +121,7 @@ class IterMark : public ObjectRef {
    */
   TVM_DLL IterMark(PrimExpr source, PrimExpr extent);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IterMark, ObjectRef, IterMarkNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IterMark, ObjectRef, IterMarkNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(IterMarkNode);
 };
 
@@ -154,8 +151,7 @@ class IterSplitExprNode : public IterMapExprNode {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "arith.IterSplitExpr";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IterSplitExprNode, IterMapExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.IterSplitExpr", IterSplitExprNode, IterMapExprNode);
 };
 
 /*!
@@ -185,7 +181,7 @@ class IterSplitExpr : public IterMapExpr {
   TVM_DLL explicit IterSplitExpr(IterMark source, PrimExpr lower_factor, PrimExpr extent,
                                  PrimExpr scale);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IterSplitExpr, IterMapExpr, IterSplitExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IterSplitExpr, IterMapExpr, IterSplitExprNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(IterSplitExprNode);
 };
 
@@ -209,8 +205,7 @@ class IterSumExprNode : public IterMapExprNode {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "arith.IterSumExpr";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IterSumExprNode, IterMapExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.IterSumExpr", IterSumExprNode, IterMapExprNode);
 };
 
 /*!
@@ -226,7 +221,7 @@ class IterSumExpr : public IterMapExpr {
    */
   TVM_DLL IterSumExpr(ffi::Array<IterSplitExpr> args, PrimExpr base);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IterSumExpr, IterMapExpr, IterSumExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IterSumExpr, IterMapExpr, IterSumExprNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(IterSumExprNode);
 };
 
@@ -269,9 +264,7 @@ class IterMapResultNode : public Object {
         .def_ro("errors", &IterMapResultNode::errors)
         .def_ro("padding_predicate", &IterMapResultNode::padding_predicate);
   }
-
-  static constexpr const char* _type_key = "arith.IterMapResult";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IterMapResultNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.IterMapResult", IterMapResultNode, Object);
 };
 
 /*!

--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -82,16 +82,15 @@ class AttrFieldInfoNode : public Object {
         .def_ro("description", &AttrFieldInfoNode::description);
   }
 
-  static constexpr const char* _type_key = "ir.AttrFieldInfo";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
 
-  TVM_DECLARE_FINAL_OBJECT_INFO(AttrFieldInfoNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.AttrFieldInfo", AttrFieldInfoNode, Object);
 };
 
 /*! \brief AttrFieldInfo */
 class AttrFieldInfo : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(AttrFieldInfo, ObjectRef, AttrFieldInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(AttrFieldInfo, ObjectRef, AttrFieldInfoNode);
 };
 
 /*!
@@ -122,9 +121,7 @@ class BaseAttrsNode : public Object {
                                         bool allow_unknown = false) = 0;
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-
-  static constexpr const char* _type_key = "ir.Attrs";
-  TVM_DECLARE_BASE_OBJECT_INFO(BaseAttrsNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.Attrs", BaseAttrsNode, Object);
 };
 
 /*!
@@ -133,7 +130,7 @@ class BaseAttrsNode : public Object {
  */
 class Attrs : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(Attrs, ObjectRef, BaseAttrsNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Attrs, ObjectRef, BaseAttrsNode);
 };
 
 /*!
@@ -155,8 +152,7 @@ class DictAttrsNode : public BaseAttrsNode {
   void InitByPackedArgs(const ffi::PackedArgs& args, bool allow_unknown) final;
 
   // type info
-  static constexpr const char* _type_key = "ir.DictAttrs";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DictAttrsNode, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.DictAttrs", DictAttrsNode, BaseAttrsNode);
 };
 
 /*!
@@ -238,7 +234,8 @@ class DictAttrs : public Attrs {
     return GetAttr<Integer>(attr_key, 0).value_or(0).IntValue() != 0;
   }
 
-  TVM_DEFINE_OBJECT_REF_METHODS_WITHOUT_DEFAULT_CONSTRUCTOR(DictAttrs, Attrs, DictAttrsNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE_WITHOUT_DEFAULT_CONSTRUCTOR(DictAttrs, Attrs,
+                                                                         DictAttrsNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(DictAttrsNode);
 };
 

--- a/include/tvm/ir/diagnostic.h
+++ b/include/tvm/ir/diagnostic.h
@@ -75,8 +75,7 @@ class DiagnosticNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "Diagnostic";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DiagnosticNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("Diagnostic", DiagnosticNode, Object);
 };
 
 class Diagnostic : public ObjectRef {
@@ -101,7 +100,7 @@ class Diagnostic : public ObjectRef {
   static DiagnosticBuilder Note(const Object* loc);
   static DiagnosticBuilder Help(const Object* loc);
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(Diagnostic, ObjectRef, DiagnosticNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Diagnostic, ObjectRef, DiagnosticNode);
 };
 
 /*!
@@ -167,9 +166,7 @@ class DiagnosticRendererNode : public Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<DiagnosticRendererNode>().def_ro("renderer", &DiagnosticRendererNode::renderer);
   }
-
-  static constexpr const char* _type_key = "DiagnosticRenderer";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DiagnosticRendererNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("DiagnosticRenderer", DiagnosticRendererNode, Object);
 };
 
 class DiagnosticRenderer : public ObjectRef {
@@ -185,7 +182,8 @@ class DiagnosticRenderer : public ObjectRef {
     return static_cast<DiagnosticRendererNode*>(get_mutable());
   }
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(DiagnosticRenderer, ObjectRef, DiagnosticRendererNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(DiagnosticRenderer, ObjectRef,
+                                                DiagnosticRendererNode);
 };
 
 class DiagnosticContextNode : public Object {
@@ -207,8 +205,7 @@ class DiagnosticContextNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "DiagnosticContext";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DiagnosticContextNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("DiagnosticContext", DiagnosticContextNode, Object);
 };
 
 class DiagnosticContext : public ObjectRef {
@@ -238,7 +235,8 @@ class DiagnosticContext : public ObjectRef {
     return static_cast<DiagnosticContextNode*>(get_mutable());
   }
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(DiagnosticContext, ObjectRef, DiagnosticContextNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(DiagnosticContext, ObjectRef,
+                                                DiagnosticContextNode);
 };
 
 DiagnosticRenderer TerminalRenderer(std::ostream& ostream);

--- a/include/tvm/ir/env_func.h
+++ b/include/tvm/ir/env_func.h
@@ -58,9 +58,7 @@ class EnvFuncNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "ir.EnvFunc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(EnvFuncNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.EnvFunc", EnvFuncNode, Object);
 };
 
 /*!

--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -61,12 +61,10 @@ class BaseExprNode : public Object {
                                            refl::AttachFieldFlag::SEqHashIgnore());
   }
 
-  static constexpr const char* _type_key = "ir.BaseExpr";
-
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
 
   static constexpr const uint32_t _type_child_slots = 64;
-  TVM_DECLARE_BASE_OBJECT_INFO(BaseExprNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.BaseExpr", BaseExprNode, Object);
 };
 
 /*!
@@ -75,7 +73,7 @@ class BaseExprNode : public Object {
  */
 class BaseExpr : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(BaseExpr, ObjectRef, BaseExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BaseExpr, ObjectRef, BaseExprNode);
 };
 
 /*!
@@ -115,9 +113,8 @@ class PrimExprNode : public BaseExprNode {
 
   TVM_OBJECT_ENABLE_SCRIPT_PRINTER();
 
-  static constexpr const char* _type_key = "ir.PrimExpr";
   static constexpr const uint32_t _type_child_slots = 40;
-  TVM_DECLARE_BASE_OBJECT_INFO(PrimExprNode, BaseExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.PrimExpr", PrimExprNode, BaseExprNode);
 };
 
 /*!
@@ -140,7 +137,7 @@ class PrimExpr : public BaseExpr {
   /*! \return the data type of this expression. */
   DataType dtype() const { return static_cast<const PrimExprNode*>(get())->dtype; }
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PrimExpr, BaseExpr, PrimExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PrimExpr, BaseExpr, PrimExprNode);
 
   /*!
    * \brief construct from string to form a StringImm.
@@ -158,9 +155,7 @@ class PrimExprConvertibleNode : public Object {
  public:
   virtual ~PrimExprConvertibleNode() {}
   virtual PrimExpr ToPrimExpr() const = 0;
-
-  static constexpr const char* _type_key = "ir.PrimExprConvertible";
-  TVM_DECLARE_BASE_OBJECT_INFO(PrimExprConvertibleNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.PrimExprConvertible", PrimExprConvertibleNode, Object);
 };
 
 /*!
@@ -169,7 +164,8 @@ class PrimExprConvertibleNode : public Object {
  */
 class PrimExprConvertible : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(PrimExprConvertible, ObjectRef, PrimExprConvertibleNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PrimExprConvertible, ObjectRef,
+                                             PrimExprConvertibleNode);
 };
 
 namespace ffi {
@@ -432,9 +428,8 @@ class RelaxExprNode : public BaseExprNode {
                                             refl::AttachFieldFlag::SEqHashIgnore());
   }
 
-  static constexpr const char* _type_key = "ir.RelaxExpr";
   static constexpr const uint32_t _type_child_slots = 22;
-  TVM_DECLARE_BASE_OBJECT_INFO(RelaxExprNode, BaseExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.RelaxExpr", RelaxExprNode, BaseExprNode);
 };
 
 /*!
@@ -443,7 +438,7 @@ class RelaxExprNode : public BaseExprNode {
  */
 class RelaxExpr : public BaseExpr {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(RelaxExpr, BaseExpr, RelaxExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(RelaxExpr, BaseExpr, RelaxExprNode);
 };
 
 class GlobalVar;
@@ -476,8 +471,7 @@ class GlobalVarNode : public RelaxExprNode {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindFreeVar;
-  static constexpr const char* _type_key = "ir.GlobalVar";
-  TVM_DECLARE_FINAL_OBJECT_INFO(GlobalVarNode, RelaxExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.GlobalVar", GlobalVarNode, RelaxExprNode);
 };
 
 /*!
@@ -488,7 +482,7 @@ class GlobalVar : public RelaxExpr {
  public:
   TVM_DLL explicit GlobalVar(ffi::String name_hint, Span span = {});
 
-  TVM_DEFINE_OBJECT_REF_METHODS(GlobalVar, RelaxExpr, GlobalVarNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(GlobalVar, RelaxExpr, GlobalVarNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(GlobalVarNode);
 };
 
@@ -505,9 +499,7 @@ class IntImmNode : public PrimExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<IntImmNode>().def_ro("value", &IntImmNode::value);
   }
-
-  static constexpr const char* _type_key = "ir.IntImm";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IntImmNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.IntImm", IntImmNode, PrimExprNode);
 };
 
 /*!
@@ -525,7 +517,7 @@ class IntImm : public PrimExpr {
    */
   TVM_DLL IntImm(DataType dtype, int64_t value, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IntImm, PrimExpr, IntImmNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntImm, PrimExpr, IntImmNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(IntImmNode);
 };
 
@@ -542,9 +534,7 @@ class FloatImmNode : public PrimExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<FloatImmNode>().def_ro("value", &FloatImmNode::value);
   }
-
-  static constexpr const char* _type_key = "ir.FloatImm";
-  TVM_DECLARE_FINAL_OBJECT_INFO(FloatImmNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.FloatImm", FloatImmNode, PrimExprNode);
 };
 
 /*!
@@ -562,7 +552,7 @@ class FloatImm : public PrimExpr {
    */
   TVM_DLL FloatImm(DataType dtype, double value, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(FloatImm, PrimExpr, FloatImmNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(FloatImm, PrimExpr, FloatImmNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(FloatImmNode);
 };
 
@@ -578,7 +568,7 @@ class Bool : public IntImm {
   Bool operator!() const { return Bool((*this)->value == 0); }
   operator bool() const { return (*this)->value != 0; }
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(Bool, IntImm, IntImmNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Bool, IntImm, IntImmNode);
 };
 
 // Overload operators to make sure we have the most fine grained types.
@@ -690,10 +680,9 @@ class RangeNode : public Object {
         .def_ro("span", &RangeNode::span, refl::AttachFieldFlag::SEqHashIgnore());
   }
 
-  static constexpr const char* _type_key = "ir.Range";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
 
-  TVM_DECLARE_FINAL_OBJECT_INFO(RangeNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.Range", RangeNode, Object);
 };
 
 /*! \brief Range container  */
@@ -718,7 +707,7 @@ class Range : public ObjectRef {
    */
   static Range FromMinExtent(PrimExpr min, PrimExpr extent, Span span = Span());
   // declare range.
-  TVM_DEFINE_OBJECT_REF_METHODS(Range, ObjectRef, RangeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Range, ObjectRef, RangeNode);
 };
 
 namespace ffi {

--- a/include/tvm/ir/function.h
+++ b/include/tvm/ir/function.h
@@ -222,9 +222,8 @@ class BaseFuncNode : public RelaxExprNode {
     refl::ObjectDef<BaseFuncNode>().def_ro("attrs", &BaseFuncNode::attrs);
   }
 
-  static constexpr const char* _type_key = "ir.BaseFunc";
   static constexpr const uint32_t _type_child_slots = 2;
-  TVM_DECLARE_BASE_OBJECT_INFO(BaseFuncNode, RelaxExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.BaseFunc", BaseFuncNode, RelaxExprNode);
 };
 
 /*!
@@ -233,7 +232,7 @@ class BaseFuncNode : public RelaxExprNode {
  */
 class BaseFunc : public RelaxExpr {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(BaseFunc, RelaxExpr, BaseFuncNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BaseFunc, RelaxExpr, BaseFuncNode);
 };
 
 }  // namespace tvm

--- a/include/tvm/ir/global_info.h
+++ b/include/tvm/ir/global_info.h
@@ -42,11 +42,9 @@ using MemoryScope = ffi::String;
  */
 class GlobalInfoNode : public Object {
  public:
-  static constexpr const char* _type_key = "ir.GlobalInfo";
-
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
 
-  TVM_DECLARE_BASE_OBJECT_INFO(GlobalInfoNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.GlobalInfo", GlobalInfoNode, Object);
 };
 
 /*!
@@ -55,7 +53,7 @@ class GlobalInfoNode : public Object {
  */
 class GlobalInfo : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(GlobalInfo, ObjectRef, GlobalInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(GlobalInfo, ObjectRef, GlobalInfoNode);
 };
 
 /*!
@@ -79,8 +77,7 @@ class VDeviceNode : public GlobalInfoNode {
         .def_ro("memory_scope", &VDeviceNode::memory_scope);
   }
 
-  static constexpr const char* _type_key = "ir.VDevice";
-  TVM_DECLARE_FINAL_OBJECT_INFO(VDeviceNode, GlobalInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.VDevice", VDeviceNode, GlobalInfoNode);
 };
 
 /*!
@@ -90,7 +87,7 @@ class VDeviceNode : public GlobalInfoNode {
 class VDevice : public GlobalInfo {
  public:
   TVM_DLL explicit VDevice(Target tgt, int dev_id, MemoryScope mem_scope);
-  TVM_DEFINE_OBJECT_REF_METHODS(VDevice, GlobalInfo, VDeviceNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(VDevice, GlobalInfo, VDeviceNode);
 };
 
 /*!
@@ -103,8 +100,7 @@ class DummyGlobalInfoNode : public GlobalInfoNode {
     refl::ObjectDef<DummyGlobalInfoNode>();
   }
 
-  static constexpr const char* _type_key = "ir.DummyGlobalInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DummyGlobalInfoNode, GlobalInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.DummyGlobalInfo", DummyGlobalInfoNode, GlobalInfoNode);
 };
 
 /*!
@@ -113,7 +109,7 @@ class DummyGlobalInfoNode : public GlobalInfoNode {
  */
 class DummyGlobalInfo : public GlobalInfo {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(DummyGlobalInfo, GlobalInfo, DummyGlobalInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DummyGlobalInfo, GlobalInfo, DummyGlobalInfoNode);
 };
 
 }  // namespace tvm

--- a/include/tvm/ir/global_var_supply.h
+++ b/include/tvm/ir/global_var_supply.h
@@ -84,9 +84,8 @@ class GlobalVarSupplyNode : public Object {
   /*! \brief The NameSupply used to generate unique name hints to GlobalVars. */
   NameSupply name_supply_;
 
-  static constexpr const char* _type_key = "ir.GlobalVarSupply";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(GlobalVarSupplyNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.GlobalVarSupply", GlobalVarSupplyNode, Object);
 
  private:
   std::unordered_map<std::string, GlobalVar> name_to_var_map_;
@@ -120,8 +119,7 @@ class GlobalVarSupply : public ObjectRef {
    */
   TVM_DLL explicit GlobalVarSupply(const IRModule module);
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(GlobalVarSupply, ObjectRef,
-                                                    GlobalVarSupplyNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(GlobalVarSupply, ObjectRef, GlobalVarSupplyNode);
 };
 
 }  // namespace tvm

--- a/include/tvm/ir/instrument.h
+++ b/include/tvm/ir/instrument.h
@@ -141,9 +141,7 @@ class PassInstrumentNode : public Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PassInstrumentNode>().def_ro("name", &PassInstrumentNode::name);
   }
-
-  static constexpr const char* _type_key = "instrument.PassInstrument";
-  TVM_DECLARE_BASE_OBJECT_INFO(PassInstrumentNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("instrument.PassInstrument", PassInstrumentNode, Object);
 };
 
 /*!
@@ -152,7 +150,7 @@ class PassInstrumentNode : public Object {
  */
 class PassInstrument : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(PassInstrument, ObjectRef, PassInstrumentNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PassInstrument, ObjectRef, PassInstrumentNode);
 };
 
 }  // namespace instrument

--- a/include/tvm/ir/module.h
+++ b/include/tvm/ir/module.h
@@ -241,10 +241,9 @@ class IRModuleNode : public Object {
 
   TVM_OBJECT_ENABLE_SCRIPT_PRINTER();
 
-  static constexpr const char* _type_key = "ir.IRModule";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
 
-  TVM_DECLARE_FINAL_OBJECT_INFO(IRModuleNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.IRModule", IRModuleNode, Object);
 
  private:
   friend class IRModule;

--- a/include/tvm/ir/name_supply.h
+++ b/include/tvm/ir/name_supply.h
@@ -85,8 +85,8 @@ class NameSupplyNode : public Object {
   // Prefix for all GlobalVar names. It can be empty.
   std::string prefix_;
 
-  static constexpr const char* _type_key = "ir.NameSupply";
-  TVM_DECLARE_FINAL_OBJECT_INFO(NameSupplyNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.NameSupply", NameSupplyNode, Object);
 
  private:
   /*! \brief Helper function to add the NameSupply prefix to the name. */
@@ -128,7 +128,7 @@ class NameSupply : public ObjectRef {
   TVM_DLL explicit NameSupply(Iter begin, Iter end, Lambda f)
       : NameSupply("", GetNameMap(begin, end, f)) {}
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(NameSupply, ObjectRef, NameSupplyNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(NameSupply, ObjectRef, NameSupplyNode);
 
  private:
   template <typename Iter, typename Lambda>

--- a/include/tvm/ir/op.h
+++ b/include/tvm/ir/op.h
@@ -104,8 +104,7 @@ class OpNode : public RelaxExprNode {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindUniqueInstance;
-  static constexpr const char* _type_key = "ir.Op";
-  TVM_DECLARE_FINAL_OBJECT_INFO(OpNode, RelaxExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.Op", OpNode, RelaxExprNode);
 
  private:
   /*! \return the internal attr registry index. */
@@ -154,7 +153,7 @@ class Op : public RelaxExpr {
    */
   TVM_DLL static const Op& Get(const ffi::String& op_name);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Op, RelaxExpr, OpNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Op, RelaxExpr, OpNode);
 
  private:
   /*!

--- a/include/tvm/ir/source_map.h
+++ b/include/tvm/ir/source_map.h
@@ -54,8 +54,7 @@ class SourceNameNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "ir.SourceName";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SourceNameNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.SourceName", SourceNameNode, Object);
 };
 
 /*!
@@ -72,7 +71,7 @@ class SourceName : public ObjectRef {
    */
   TVM_DLL static SourceName Get(const ffi::String& name);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(SourceName, ObjectRef, SourceNameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(SourceName, ObjectRef, SourceNameNode);
 };
 
 /*!
@@ -106,8 +105,7 @@ class SpanNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "ir.Span";
-  TVM_DECLARE_BASE_OBJECT_INFO(SpanNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.Span", SpanNode, Object);
 };
 
 class Span : public ObjectRef {
@@ -117,7 +115,7 @@ class Span : public ObjectRef {
   /*! \brief Merge two spans into one which captures the combined regions. */
   TVM_DLL Span Merge(const Span& other) const;
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Span, ObjectRef, SpanNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Span, ObjectRef, SpanNode);
 };
 
 /*!
@@ -132,9 +130,7 @@ class SequentialSpanNode : public SpanNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<SequentialSpanNode>().def_ro("spans", &SequentialSpanNode::spans);
   }
-
-  static constexpr const char* _type_key = "ir.SequentialSpan";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SequentialSpanNode, SpanNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.SequentialSpan", SequentialSpanNode, SpanNode);
 };
 
 /*!
@@ -147,7 +143,7 @@ class SequentialSpan : public Span {
 
   TVM_DLL SequentialSpan(std::initializer_list<Span> init);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(SequentialSpan, Span, SequentialSpanNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(SequentialSpan, Span, SequentialSpanNode);
 };
 
 /*! \brief A program source in any language.
@@ -174,9 +170,7 @@ class SourceNode : public Object {
         .def_ro("source_name", &SourceNode::source_name)
         .def_ro("source", &SourceNode::source);
   }
-
-  static constexpr const char* _type_key = "ir.Source";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SourceNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.Source", SourceNode, Object);
 };
 
 class Source : public ObjectRef {
@@ -184,7 +178,7 @@ class Source : public ObjectRef {
   TVM_DLL Source(SourceName src_name, std::string source);
   TVM_DLL tvm::ffi::String GetLine(int line);
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(Source, ObjectRef, SourceNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Source, ObjectRef, SourceNode);
 };
 
 /*!
@@ -205,8 +199,7 @@ class SourceMapObj : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "ir.SourceMap";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SourceMapObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.SourceMap", SourceMapObj, Object);
 };
 
 class SourceMap : public ObjectRef {
@@ -225,7 +218,7 @@ class SourceMap : public ObjectRef {
     return static_cast<SourceMapObj*>(get_mutable());
   }
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(SourceMap, ObjectRef, SourceMapObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(SourceMap, ObjectRef, SourceMapObj);
 };
 
 }  // namespace tvm

--- a/include/tvm/ir/transform.h
+++ b/include/tvm/ir/transform.h
@@ -134,10 +134,7 @@ class PassContextNode : public Object {
         .def_ro("config", &PassContextNode::config)
         .def_ro("diag_ctx", &PassContextNode::diag_ctx);
   }
-
-  static constexpr const char* _type_key = "transform.PassContext";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(PassContextNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("transform.PassContext", PassContextNode, Object);
 };
 
 /*!
@@ -343,10 +340,7 @@ class PassInfoNode : public Object {
         .def_ro("required", &PassInfoNode::required)
         .def_ro("traceable", &PassInfoNode::traceable);
   }
-
-  static constexpr const char* _type_key = "transform.PassInfo";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(PassInfoNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("transform.PassInfo", PassInfoNode, Object);
 };
 
 /*!
@@ -365,7 +359,7 @@ class PassInfo : public ObjectRef {
   TVM_DLL PassInfo(int opt_level, ffi::String name, ffi::Array<ffi::String> required,
                    bool traceable);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PassInfo, ObjectRef, PassInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PassInfo, ObjectRef, PassInfoNode);
 };
 
 /*!
@@ -400,9 +394,7 @@ class PassNode : public Object {
    * \return The transformed module.
    */
   virtual IRModule operator()(IRModule mod, const PassContext& pass_ctx) const = 0;
-
-  static constexpr const char* _type_key = "transform.Pass";
-  TVM_DECLARE_BASE_OBJECT_INFO(PassNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("transform.Pass", PassNode, Object);
 };
 
 class Pass : public ObjectRef {
@@ -434,7 +426,7 @@ class Pass : public ObjectRef {
    */
   IRModule operator()(IRModule mod, const PassContext& pass_ctx) const;
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Pass, ObjectRef, PassNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Pass, ObjectRef, PassNode);
 
  private:
   IRModule static AssertImmutableModule(const IRModule& mod, const PassNode* node,
@@ -493,9 +485,7 @@ class SequentialNode : public PassNode {
    * \return Return the updated module.
    */
   IRModule operator()(IRModule mod, const PassContext& pass_ctx) const final;
-
-  static constexpr const char* _type_key = "transform.Sequential";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SequentialNode, PassNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("transform.Sequential", SequentialNode, PassNode);
 };
 
 class Sequential : public Pass {

--- a/include/tvm/ir/type.h
+++ b/include/tvm/ir/type.h
@@ -88,10 +88,9 @@ class TypeNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "ir.Type";
 
   static constexpr const uint32_t _type_child_slots = 14;
-  TVM_DECLARE_BASE_OBJECT_INFO(TypeNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.Type", TypeNode, Object);
 };
 
 /*!
@@ -100,7 +99,7 @@ class TypeNode : public Object {
  */
 class Type : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(Type, ObjectRef, TypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Type, ObjectRef, TypeNode);
 };
 
 /*!
@@ -122,9 +121,7 @@ class PrimTypeNode : public TypeNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PrimTypeNode>().def_ro("dtype", &PrimTypeNode::dtype);
   }
-
-  static constexpr const char* _type_key = "ir.PrimType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PrimTypeNode, TypeNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.PrimType", PrimTypeNode, TypeNode);
 };
 
 /*
@@ -140,7 +137,7 @@ class PrimType : public Type {
    */
   TVM_DLL explicit PrimType(runtime::DataType dtype, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PrimType, Type, PrimTypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PrimType, Type, PrimTypeNode);
 };
 
 /*!
@@ -170,9 +167,7 @@ class PointerTypeNode : public TypeNode {
         .def_ro("element_type", &PointerTypeNode::element_type)
         .def_ro("storage_scope", &PointerTypeNode::storage_scope);
   }
-
-  static constexpr const char* _type_key = "ir.PointerType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PointerTypeNode, TypeNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.PointerType", PointerTypeNode, TypeNode);
 };
 
 /*
@@ -188,7 +183,7 @@ class PointerType : public Type {
    */
   TVM_DLL explicit PointerType(Type element_type, ffi::String storage_scope = "");
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PointerType, Type, PointerTypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PointerType, Type, PointerTypeNode);
 };
 
 /*!
@@ -208,9 +203,7 @@ class TupleTypeNode : public TypeNode {
         .def_ro("fields", &TupleTypeNode::fields)
         .def_ro("span", &TupleTypeNode::span);
   }
-
-  static constexpr const char* _type_key = "ir.TupleType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TupleTypeNode, TypeNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.TupleType", TupleTypeNode, TypeNode);
 };
 
 /*!
@@ -232,7 +225,7 @@ class TupleType : public Type {
    */
   TVM_DLL TupleType static Empty();
 
-  TVM_DEFINE_OBJECT_REF_METHODS(TupleType, Type, TupleTypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TupleType, Type, TupleTypeNode);
 };
 
 /*!
@@ -271,9 +264,7 @@ class FuncTypeNode : public TypeNode {
         .def_ro("ret_type", &FuncTypeNode::ret_type)
         .def_ro("span", &FuncTypeNode::span);
   }
-
-  static constexpr const char* _type_key = "ir.FuncType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(FuncTypeNode, TypeNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.FuncType", FuncTypeNode, TypeNode);
 };
 
 /*!
@@ -291,7 +282,7 @@ class FuncType : public Type {
    */
   TVM_DLL FuncType(ffi::Array<Type> arg_types, Type ret_type, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(FuncType, Type, FuncTypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(FuncType, Type, FuncTypeNode);
 };
 
 /*!
@@ -304,9 +295,7 @@ class TensorMapTypeNode : public TypeNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<TensorMapTypeNode>().def_ro("span", &TensorMapTypeNode::span);
   }
-
-  static constexpr const char* _type_key = "ir.TensorMapType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TensorMapTypeNode, TypeNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.TensorMapType", TensorMapTypeNode, TypeNode);
 };
 
 /*!
@@ -317,7 +306,8 @@ class TensorMapType : public Type {
  public:
   TVM_DLL TensorMapType(Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS_WITHOUT_DEFAULT_CONSTRUCTOR(TensorMapType, Type, TensorMapTypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE_WITHOUT_DEFAULT_CONSTRUCTOR(TensorMapType, Type,
+                                                                         TensorMapTypeNode);
 };
 
 }  // namespace tvm

--- a/include/tvm/meta_schedule/arg_info.h
+++ b/include/tvm/meta_schedule/arg_info.h
@@ -33,8 +33,7 @@ namespace meta_schedule {
 /*! \brief The argument information. */
 class ArgInfoNode : public runtime::Object {
  public:
-  static constexpr const char* _type_key = "meta_schedule.ArgInfo";
-  TVM_DECLARE_BASE_OBJECT_INFO(ArgInfoNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.ArgInfo", ArgInfoNode, runtime::Object);
 
  public:
   /*! \brief Default destructor. */
@@ -69,7 +68,7 @@ class ArgInfo : public runtime::ObjectRef {
    */
   TVM_DLL static ffi::Array<ArgInfo, void> FromEntryFunc(const IRModule& mod, bool remove_preproc);
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(ArgInfo, runtime::ObjectRef, ArgInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ArgInfo, runtime::ObjectRef, ArgInfoNode);
 
  protected:
   ArgInfo() = default;
@@ -89,9 +88,7 @@ class TensorInfoNode : public ArgInfoNode {
         .def_ro("dtype", &TensorInfoNode::dtype)
         .def_ro("shape", &TensorInfoNode::shape);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.TensorInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TensorInfoNode, ArgInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.TensorInfo", TensorInfoNode, ArgInfoNode);
 
  public:
   ObjectRef AsJSON() const;
@@ -115,7 +112,7 @@ class TensorInfo : public ArgInfo {
    * \return The argument information parsed.
    */
   TVM_DLL static TensorInfo FromJSON(const ObjectRef& json_obj);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TensorInfo, ArgInfo, TensorInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TensorInfo, ArgInfo, TensorInfoNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/builder.h
+++ b/include/tvm/meta_schedule/builder.h
@@ -50,9 +50,8 @@ class BuilderInputNode : public runtime::Object {
         .def_ro("target", &BuilderInputNode::target)
         .def_ro("params", &BuilderInputNode::params);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.BuilderInput";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BuilderInputNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.BuilderInput", BuilderInputNode,
+                                    runtime::Object);
 };
 
 /*!
@@ -70,7 +69,7 @@ class BuilderInput : public runtime::ObjectRef {
   TVM_DLL explicit BuilderInput(
       IRModule mod, Target target,
       ffi::Optional<ffi::Map<ffi::String, runtime::Tensor>> params = std::nullopt);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(BuilderInput, runtime::ObjectRef, BuilderInputNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(BuilderInput, runtime::ObjectRef, BuilderInputNode);
 };
 
 /*! \brief The builder's output, containing the artifact path or error message if any. */
@@ -87,9 +86,8 @@ class BuilderResultNode : public runtime::Object {
         .def_ro("artifact_path", &BuilderResultNode::artifact_path)
         .def_ro("error_msg", &BuilderResultNode::error_msg);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.BuilderResult";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BuilderResultNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.BuilderResult", BuilderResultNode,
+                                    runtime::Object);
 };
 
 /*!
@@ -105,7 +103,8 @@ class BuilderResult : public runtime::ObjectRef {
    */
   TVM_DLL explicit BuilderResult(ffi::Optional<ffi::String> artifact_path,
                                  ffi::Optional<ffi::String> error_msg);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(BuilderResult, runtime::ObjectRef, BuilderResultNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(BuilderResult, runtime::ObjectRef,
+                                                BuilderResultNode);
 };
 
 /*! \brief The abstract builder interface. */
@@ -126,8 +125,8 @@ class BuilderNode : public runtime::Object {
    */
   using FBuild = ffi::TypedFunction<ffi::Array<BuilderResult>(const ffi::Array<BuilderInput>&)>;
 
-  static constexpr const char* _type_key = "meta_schedule.Builder";
-  TVM_DECLARE_BASE_OBJECT_INFO(BuilderNode, runtime::Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.Builder", BuilderNode, runtime::Object);
 };
 
 /*!
@@ -149,7 +148,7 @@ class Builder : public runtime::ObjectRef {
    * \return The Builder created.
    */
   static Builder PyBuilder(BuilderNode::FBuild f_build);
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(Builder, runtime::ObjectRef, BuilderNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Builder, runtime::ObjectRef, BuilderNode);
 };
 
 /*! \brief An abstract builder with customized build method on the python-side. */
@@ -167,9 +166,7 @@ class PyBuilderNode : public BuilderNode {
     ICHECK(f_build != nullptr) << "PyBuilder's Build method not implemented!";
     return f_build(build_inputs);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.PyBuilder";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyBuilderNode, BuilderNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PyBuilder", PyBuilderNode, BuilderNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/cost_model.h
+++ b/include/tvm/meta_schedule/cost_model.h
@@ -73,8 +73,8 @@ class CostModelNode : public runtime::Object {
   virtual std::vector<double> Predict(const TuneContext& context,
                                       const ffi::Array<MeasureCandidate>& candidates) = 0;
 
-  static constexpr const char* _type_key = "meta_schedule.CostModel";
-  TVM_DECLARE_BASE_OBJECT_INFO(CostModelNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.CostModel", CostModelNode, Object);
 };
 
 /*! \brief The cost model with customized methods on the python-side. */
@@ -130,9 +130,7 @@ class PyCostModelNode : public CostModelNode {
               const ffi::Array<RunnerResult>& results);
   std::vector<double> Predict(const TuneContext& context,
                               const ffi::Array<MeasureCandidate>& candidates);
-
-  static constexpr const char* _type_key = "meta_schedule.PyCostModel";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyCostModelNode, CostModelNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PyCostModel", PyCostModelNode, CostModelNode);
 };
 
 /*!
@@ -155,7 +153,7 @@ class CostModel : public runtime::ObjectRef {
                                        PyCostModelNode::FUpdate f_update,    //
                                        PyCostModelNode::FPredict f_predict,  //
                                        PyCostModelNode::FAsString f_as_string);
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(CostModel, ObjectRef, CostModelNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(CostModel, ObjectRef, CostModelNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/database.h
+++ b/include/tvm/meta_schedule/database.h
@@ -52,10 +52,7 @@ class WorkloadNode : public runtime::Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<WorkloadNode>().def_ro("mod", &WorkloadNode::mod);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.Workload";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(WorkloadNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.Workload", WorkloadNode, runtime::Object);
 
   /*!
    * \brief Export the workload to a JSON string.
@@ -90,7 +87,7 @@ class Workload : public runtime::ObjectRef {
    */
   TVM_DLL static Workload FromJSON(const ObjectRef& json_obj);
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(Workload, runtime::ObjectRef, WorkloadNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Workload, runtime::ObjectRef, WorkloadNode);
 };
 
 /*! \brief The hash method for Workload */
@@ -135,10 +132,8 @@ class TuningRecordNode : public runtime::Object {
         .def_ro("target", &TuningRecordNode::target)
         .def_ro("args_info", &TuningRecordNode::args_info);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.TuningRecord";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(TuningRecordNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.TuningRecord", TuningRecordNode,
+                                    runtime::Object);
 
   /*! \brief Construct the measure candidate given the initial IR module and trace
    * stored in the tuning record. */
@@ -181,7 +176,7 @@ class TuningRecord : public runtime::ObjectRef {
    * \return The tuning record created.
    */
   TVM_DLL static TuningRecord FromJSON(const ObjectRef& json_obj, const Workload& workload);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TuningRecord, runtime::ObjectRef, TuningRecordNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TuningRecord, runtime::ObjectRef, TuningRecordNode);
 };
 
 class Database;
@@ -277,8 +272,8 @@ class DatabaseNode : public runtime::Object {
     return *mod_eq_;
   }
 
-  static constexpr const char* _type_key = "meta_schedule.Database";
-  TVM_DECLARE_BASE_OBJECT_INFO(DatabaseNode, runtime::Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.Database", DatabaseNode, runtime::Object);
 
  private:
   /*! \brief The module equality testing and hashing method */
@@ -457,8 +452,8 @@ class PyDatabaseNode : public DatabaseNode {
     return f_size();
   }
 
-  static constexpr const char* _type_key = "meta_schedule.PyDatabase";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyDatabaseNode, DatabaseNode);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PyDatabase", PyDatabaseNode, DatabaseNode);
 };
 
 /*!
@@ -543,7 +538,7 @@ class Database : public runtime::ObjectRef {
   /*! \brief Exiting the scope of the context manager */
   void ExitWithScope();
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(Database, runtime::ObjectRef, DatabaseNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Database, runtime::ObjectRef, DatabaseNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/extracted_task.h
+++ b/include/tvm/meta_schedule/extracted_task.h
@@ -62,9 +62,9 @@ class ExtractedTaskNode : public runtime::Object {
         .def_ro("weight", &ExtractedTaskNode::weight);
   }
 
-  static constexpr const char* _type_key = "meta_schedule.ExtractedTask";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(ExtractedTaskNode, runtime::Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.ExtractedTask", ExtractedTaskNode,
+                                    runtime::Object);
 };
 
 /*!
@@ -75,8 +75,8 @@ class ExtractedTask : public runtime::ObjectRef {
  public:
   explicit ExtractedTask(ffi::String task_name, IRModule mod, Target target,
                          ffi::Array<IRModule> dispatched, int weight);
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(ExtractedTask, runtime::ObjectRef,
-                                                    ExtractedTaskNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ExtractedTask, runtime::ObjectRef,
+                                                ExtractedTaskNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/feature_extractor.h
+++ b/include/tvm/meta_schedule/feature_extractor.h
@@ -51,9 +51,7 @@ class FeatureExtractorNode : public runtime::Object {
    */
   virtual ffi::Array<tvm::runtime::Tensor> ExtractFrom(
       const TuneContext& context, const ffi::Array<MeasureCandidate>& candidates) = 0;
-
-  static constexpr const char* _type_key = "meta_schedule.FeatureExtractor";
-  TVM_DECLARE_BASE_OBJECT_INFO(FeatureExtractorNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.FeatureExtractor", FeatureExtractorNode, Object);
 };
 
 /*! \brief The feature extractor with customized methods on the python-side. */
@@ -85,9 +83,8 @@ class PyFeatureExtractorNode : public FeatureExtractorNode {
 
   ffi::Array<tvm::runtime::Tensor> ExtractFrom(
       const TuneContext& context, const ffi::Array<MeasureCandidate>& candidates) final;
-
-  static constexpr const char* _type_key = "meta_schedule.PyFeatureExtractor";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyFeatureExtractorNode, FeatureExtractorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PyFeatureExtractor", PyFeatureExtractorNode,
+                                    FeatureExtractorNode);
 };
 
 /*!
@@ -119,7 +116,7 @@ class FeatureExtractor : public runtime::ObjectRef {
   TVM_DLL static FeatureExtractor PyFeatureExtractor(
       PyFeatureExtractorNode::FExtractFrom f_extract_from,
       PyFeatureExtractorNode::FAsString f_as_string);
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(FeatureExtractor, ObjectRef, FeatureExtractorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(FeatureExtractor, ObjectRef, FeatureExtractorNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/measure_callback.h
+++ b/include/tvm/meta_schedule/measure_callback.h
@@ -60,8 +60,8 @@ class MeasureCallbackNode : public runtime::Object {
                      const ffi::Array<BuilderResult>& builder_results,        //
                      const ffi::Array<RunnerResult>& runner_results) = 0;
 
-  static constexpr const char* _type_key = "meta_schedule.MeasureCallback";
-  TVM_DECLARE_BASE_OBJECT_INFO(MeasureCallbackNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.MeasureCallback", MeasureCallbackNode, Object);
 };
 
 /*! \brief The measure callback with customized methods on the python-side. */
@@ -102,9 +102,8 @@ class PyMeasureCallbackNode : public MeasureCallbackNode {
              const ffi::Array<MeasureCandidate>& measure_candidates,  //
              const ffi::Array<BuilderResult>& builds,                 //
              const ffi::Array<RunnerResult>& results);
-
-  static constexpr const char* _type_key = "meta_schedule.PyMeasureCallback";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyMeasureCallbackNode, MeasureCallbackNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PyMeasureCallback", PyMeasureCallbackNode,
+                                    MeasureCallbackNode);
 };
 
 /*!
@@ -138,7 +137,7 @@ class MeasureCallback : public runtime::ObjectRef {
                                                    PyMeasureCallbackNode::FAsString f_as_string);
   /*! \brief The default list of measure callbacks. */
   TVM_DLL static ffi::Array<MeasureCallback, void> Default();
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(MeasureCallback, ObjectRef, MeasureCallbackNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MeasureCallback, ObjectRef, MeasureCallbackNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/measure_candidate.h
+++ b/include/tvm/meta_schedule/measure_candidate.h
@@ -43,9 +43,7 @@ class MeasureCandidateNode : public runtime::Object {
         .def_ro("sch", &MeasureCandidateNode::sch)
         .def_ro("args_info", &MeasureCandidateNode::args_info);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.MeasureCandidate";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MeasureCandidateNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.MeasureCandidate", MeasureCandidateNode, Object);
 };
 
 /*!
@@ -60,7 +58,7 @@ class MeasureCandidate : public runtime::ObjectRef {
    * \param args_info The argument information, e.g., (shape, dtype) for tensors.
    */
   TVM_DLL MeasureCandidate(tir::Schedule sch, ffi::Array<ArgInfo> args_info);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(MeasureCandidate, ObjectRef, MeasureCandidateNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(MeasureCandidate, ObjectRef, MeasureCandidateNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/mutator.h
+++ b/include/tvm/meta_schedule/mutator.h
@@ -66,8 +66,8 @@ class MutatorNode : public runtime::Object {
    */
   virtual Mutator Clone() const = 0;
 
-  static constexpr const char* _type_key = "meta_schedule.Mutator";
-  TVM_DECLARE_BASE_OBJECT_INFO(MutatorNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.Mutator", MutatorNode, Object);
 };
 
 /*!
@@ -140,7 +140,7 @@ class Mutator : public runtime::ObjectRef {
   /*! \brief Create default mutators for Hexagon */
   TVM_DLL static ffi::Map<Mutator, FloatImm, void> DefaultHexagon();
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Mutator, ObjectRef, MutatorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Mutator, ObjectRef, MutatorNode);
 };
 
 /*! \brief The mutator with customized methods on the python-side. */
@@ -170,9 +170,7 @@ class PyMutatorNode : public MutatorNode {
   ffi::Optional<tir::Trace> Apply(const tir::Trace& trace,
                                   support::LinearCongruentialEngine::TRandState* rand_state) final;
   Mutator Clone() const final;
-
-  static constexpr const char* _type_key = "meta_schedule.PyMutator";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyMutatorNode, MutatorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PyMutator", PyMutatorNode, MutatorNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/postproc.h
+++ b/include/tvm/meta_schedule/postproc.h
@@ -63,8 +63,8 @@ class PostprocNode : public runtime::Object {
    */
   virtual Postproc Clone() const = 0;
 
-  static constexpr const char* _type_key = "meta_schedule.Postproc";
-  TVM_DECLARE_BASE_OBJECT_INFO(PostprocNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.Postproc", PostprocNode, Object);
 };
 
 /*!
@@ -175,7 +175,7 @@ class Postproc : public runtime::ObjectRef {
   /*! \brief Create default postprocessors for Hexagon */
   TVM_DLL static ffi::Array<Postproc, void> DefaultHexagon();
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Postproc, ObjectRef, PostprocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Postproc, ObjectRef, PostprocNode);
 };
 
 /*! \brief The postprocessor with customized methods on the python-side. */
@@ -204,9 +204,7 @@ class PyPostprocNode : public PostprocNode {
   void InitializeWithTuneContext(const TuneContext& context) final;
   bool Apply(const tir::Schedule& sch) final;
   Postproc Clone() const final;
-
-  static constexpr const char* _type_key = "meta_schedule.PyPostproc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyPostprocNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PyPostproc", PyPostprocNode, PostprocNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/profiler.h
+++ b/include/tvm/meta_schedule/profiler.h
@@ -64,8 +64,8 @@ class ProfilerNode : public runtime::Object {
     // `total_timer` is not registered
   }
 
-  static constexpr const char* _type_key = "meta_schedule.Profiler";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ProfilerNode, runtime::Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.Profiler", ProfilerNode, runtime::Object);
 
  public:
   /*! \brief Get the internal stats of the running time */
@@ -81,7 +81,7 @@ class ProfilerNode : public runtime::Object {
 class Profiler : public runtime::ObjectRef {
  public:
   Profiler();
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(Profiler, runtime::ObjectRef, ProfilerNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Profiler, runtime::ObjectRef, ProfilerNode);
 
   /*! \brief Entering the scope of the context manager */
   void EnterWithScope();

--- a/include/tvm/meta_schedule/runner.h
+++ b/include/tvm/meta_schedule/runner.h
@@ -48,10 +48,7 @@ class RunnerInputNode : public runtime::Object {
         .def_ro("device_type", &RunnerInputNode::device_type)
         .def_ro("args_info", &RunnerInputNode::args_info);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RunnerInput";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(RunnerInputNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RunnerInput", RunnerInputNode, runtime::Object);
 };
 
 /*!
@@ -68,7 +65,7 @@ class RunnerInput : public runtime::ObjectRef {
    */
   TVM_DLL explicit RunnerInput(ffi::String artifact_path, ffi::String device_type,
                                ffi::Array<ArgInfo> args_info);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(RunnerInput, runtime::ObjectRef, RunnerInputNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(RunnerInput, runtime::ObjectRef, RunnerInputNode);
 };
 
 /*! \brief Runner's output containing measurement result of MeasureCandidate or error msg if any. */
@@ -85,10 +82,8 @@ class RunnerResultNode : public runtime::Object {
         .def_ro("run_secs", &RunnerResultNode::run_secs)
         .def_ro("error_msg", &RunnerResultNode::error_msg);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RunnerResult";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(RunnerResultNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RunnerResult", RunnerResultNode,
+                                    runtime::Object);
 };
 
 /*!
@@ -104,7 +99,7 @@ class RunnerResult : public runtime::ObjectRef {
    */
   TVM_DLL explicit RunnerResult(ffi::Optional<ffi::Array<FloatImm>> run_secs,
                                 ffi::Optional<ffi::String> error_msg);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(RunnerResult, runtime::ObjectRef, RunnerResultNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(RunnerResult, runtime::ObjectRef, RunnerResultNode);
 };
 
 /*!
@@ -151,9 +146,8 @@ class RunnerFutureNode : public runtime::Object {
     ICHECK(f_result != nullptr) << "PyRunnerFuture's Result method not implemented!";
     return f_result();
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RunnerFuture";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RunnerFutureNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RunnerFuture", RunnerFutureNode,
+                                    runtime::Object);
 };
 
 /*!
@@ -171,8 +165,7 @@ class RunnerFuture : public runtime::ObjectRef {
    * \param f_result The packed function to fetch runner output if it is ready.
    */
   TVM_DLL explicit RunnerFuture(FDone f_done, FResult f_result);
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(RunnerFuture, runtime::ObjectRef,
-                                                    RunnerFutureNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(RunnerFuture, runtime::ObjectRef, RunnerFutureNode);
 };
 
 /*! \brief The abstract runner interface. */
@@ -196,8 +189,8 @@ class RunnerNode : public runtime::Object {
    */
   virtual ffi::Array<RunnerFuture> Run(ffi::Array<RunnerInput> runner_inputs) = 0;
 
-  static constexpr const char* _type_key = "meta_schedule.Runner";
-  TVM_DECLARE_BASE_OBJECT_INFO(RunnerNode, runtime::Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.Runner", RunnerNode, runtime::Object);
 };
 
 /*!
@@ -218,7 +211,7 @@ class Runner : public runtime::ObjectRef {
    * \return The runner created.
    */
   TVM_DLL static Runner PyRunner(FRun f_run);
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(Runner, runtime::ObjectRef, RunnerNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Runner, runtime::ObjectRef, RunnerNode);
 };
 
 /*! \brief An abstract runner with customized build method on the python-side. */
@@ -235,9 +228,7 @@ class PyRunnerNode : public RunnerNode {
     ICHECK(f_run != nullptr) << "PyRunner's Run method not implemented!";
     return f_run(runner_inputs);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.PyRunner";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyRunnerNode, RunnerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PyRunner", PyRunnerNode, RunnerNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/schedule_rule.h
+++ b/include/tvm/meta_schedule/schedule_rule.h
@@ -67,8 +67,8 @@ class ScheduleRuleNode : public runtime::Object {
    */
   virtual ScheduleRule Clone() const = 0;
 
-  static constexpr const char* _type_key = "meta_schedule.ScheduleRule";
-  TVM_DECLARE_BASE_OBJECT_INFO(ScheduleRuleNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.ScheduleRule", ScheduleRuleNode, Object);
 };
 
 /*!
@@ -312,7 +312,7 @@ class ScheduleRule : public runtime::ObjectRef {
   /*! \brief Create default schedule rules for RISCV CPU (RVV) */
   TVM_DLL static ffi::Array<ScheduleRule, void> DefaultRISCV(int vlen);
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(ScheduleRule, ObjectRef, ScheduleRuleNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ScheduleRule, ObjectRef, ScheduleRuleNode);
 };
 
 /*! \brief The schedule rule with customized methods on the python-side. */
@@ -342,9 +342,8 @@ class PyScheduleRuleNode : public ScheduleRuleNode {
   void InitializeWithTuneContext(const TuneContext& context) final;
   ffi::Array<tir::Schedule> Apply(const tir::Schedule& sch, const tir::BlockRV& block) final;
   ScheduleRule Clone() const final;
-
-  static constexpr const char* _type_key = "meta_schedule.PyScheduleRule";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyScheduleRuleNode, ScheduleRuleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PyScheduleRule", PyScheduleRuleNode,
+                                    ScheduleRuleNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/search_strategy.h
+++ b/include/tvm/meta_schedule/search_strategy.h
@@ -129,8 +129,8 @@ class SearchStrategyNode : public runtime::Object {
    */
   virtual SearchStrategy Clone() const = 0;
 
-  static constexpr const char* _type_key = "meta_schedule.SearchStrategy";
-  TVM_DECLARE_BASE_OBJECT_INFO(SearchStrategyNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.SearchStrategy", SearchStrategyNode, Object);
 };
 
 /*!
@@ -216,7 +216,7 @@ class SearchStrategy : public runtime::ObjectRef {
                                                    int genetic_max_fail_count,  //
                                                    double eps_greedy);
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(SearchStrategy, ObjectRef, SearchStrategyNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(SearchStrategy, ObjectRef, SearchStrategyNode);
 };
 
 /*! \brief The python side customizable class for measure candidate generation */
@@ -261,9 +261,8 @@ class PySearchStrategyNode : public SearchStrategyNode {
   void NotifyRunnerResults(const ffi::Array<MeasureCandidate>& measure_candidates,
                            const ffi::Array<RunnerResult>& results);
   SearchStrategy Clone() const final;
-
-  static constexpr const char* _type_key = "meta_schedule.PySearchStrategy";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PySearchStrategyNode, SearchStrategyNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PySearchStrategy", PySearchStrategyNode,
+                                    SearchStrategyNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/space_generator.h
+++ b/include/tvm/meta_schedule/space_generator.h
@@ -113,8 +113,8 @@ class SpaceGeneratorNode : public runtime::Object {
    */
   virtual SpaceGenerator Clone() const = 0;
 
-  static constexpr const char* _type_key = "meta_schedule.SpaceGenerator";
-  TVM_DECLARE_BASE_OBJECT_INFO(SpaceGeneratorNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.SpaceGenerator", SpaceGeneratorNode, Object);
 };
 
 /*!
@@ -207,7 +207,7 @@ class SpaceGenerator : public runtime::ObjectRef {
       ffi::Function f_block_filter, ffi::Optional<ffi::Array<ScheduleRule>> sch_rules,
       ffi::Optional<ffi::Array<Postproc>> postprocs,
       ffi::Optional<ffi::Map<Mutator, FloatImm>> mutator_probs);
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(SpaceGenerator, ObjectRef, SpaceGeneratorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(SpaceGenerator, ObjectRef, SpaceGeneratorNode);
 };
 
 /*! \brief The design space generator with customized methods on the python-side. */
@@ -232,9 +232,8 @@ class PySpaceGeneratorNode : public SpaceGeneratorNode {
   void InitializeWithTuneContext(const TuneContext& context) final;
   ffi::Array<tir::Schedule> GenerateDesignSpace(const IRModule& mod) final;
   SpaceGenerator Clone() const final;
-
-  static constexpr const char* _type_key = "meta_schedule.PySpaceGenerator";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PySpaceGeneratorNode, SpaceGeneratorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PySpaceGenerator", PySpaceGeneratorNode,
+                                    SpaceGeneratorNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/task_scheduler.h
+++ b/include/tvm/meta_schedule/task_scheduler.h
@@ -74,8 +74,8 @@ class TaskRecordNode : public runtime::Object {
         .def_ro("runner_futures", &TaskRecordNode::runner_futures);
   }
 
-  static constexpr const char* _type_key = "meta_schedule.TaskRecord";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TaskRecordNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.TaskRecord", TaskRecordNode, Object);
 };
 
 /*!
@@ -87,7 +87,7 @@ class TaskRecord : public runtime::ObjectRef {
   /*! \brief Constructor */
   explicit TaskRecord(TuneContext task, double task_weight);
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(TaskRecord, ObjectRef, TaskRecordNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TaskRecord, ObjectRef, TaskRecordNode);
 };
 
 /*!
@@ -201,8 +201,8 @@ class TaskSchedulerNode : public runtime::Object {
   /*! \brief Print out a human-readable format of the tuning statistics. */
   void PrintTuningStatistics();
 
-  static constexpr const char* _type_key = "meta_schedule.TaskScheduler";
-  TVM_DECLARE_BASE_OBJECT_INFO(TaskSchedulerNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.TaskScheduler", TaskSchedulerNode, Object);
 };
 
 class TaskScheduler;
@@ -250,9 +250,8 @@ class PyTaskSchedulerNode : public TaskSchedulerNode {
             int max_trials_per_task, int num_trials_per_iter, Builder builder, Runner runner,
             ffi::Array<MeasureCallback> measure_callbacks, ffi::Optional<Database> database,
             ffi::Optional<CostModel> cost_model) final;
-
-  static constexpr const char* _type_key = "meta_schedule.PyTaskScheduler";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PyTaskSchedulerNode, TaskSchedulerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PyTaskScheduler", PyTaskSchedulerNode,
+                                    TaskSchedulerNode);
 };
 
 /*!
@@ -291,7 +290,7 @@ class TaskScheduler : public runtime::ObjectRef {
   TVM_DLL static TaskScheduler PyTaskScheduler(
       ffi::Function logger, PyTaskSchedulerNode::FNextTaskId f_next_task_id,
       PyTaskSchedulerNode::FJoinRunningTask f_join_running_task, PyTaskSchedulerNode::FTune f_tune);
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(TaskScheduler, ObjectRef, TaskSchedulerNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TaskScheduler, ObjectRef, TaskSchedulerNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/meta_schedule/tune_context.h
+++ b/include/tvm/meta_schedule/tune_context.h
@@ -87,8 +87,8 @@ class TuneContextNode : public runtime::Object {
    */
   TuneContext Clone() const;
 
-  static constexpr const char* _type_key = "meta_schedule.TuneContext";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TuneContextNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.TuneContext", TuneContextNode, Object);
 };
 
 /*!
@@ -121,7 +121,7 @@ class TuneContext : public runtime::ObjectRef {
                                ffi::Optional<SearchStrategy> search_strategy,
                                ffi::Optional<ffi::String> task_name, int num_threads,
                                TRandState rand_state, ffi::Function logger);
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(TuneContext, ObjectRef, TuneContextNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TuneContext, ObjectRef, TuneContextNode);
 };
 
 }  // namespace meta_schedule

--- a/include/tvm/node/script_printer.h
+++ b/include/tvm/node/script_printer.h
@@ -148,8 +148,8 @@ class PrinterConfigNode : public ffi::Object {
 
   ffi::Array<ffi::String> GetBuiltinKeywords();
 
-  static constexpr const char* _type_key = "script.PrinterConfig";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PrinterConfigNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.PrinterConfig", PrinterConfigNode, Object);
 };
 
 class PrinterConfig : public ObjectRef {
@@ -157,8 +157,8 @@ class PrinterConfig : public ObjectRef {
   explicit PrinterConfig(
       ffi::Map<ffi::String, ffi::Any> config_dict = ffi::Map<ffi::String, ffi::Any>());
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(PrinterConfig, runtime::ObjectRef,
-                                                    PrinterConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(PrinterConfig, runtime::ObjectRef,
+                                                PrinterConfigNode);
 };
 
 /*! \brief Legacy behavior of ReprPrinter. */

--- a/include/tvm/relax/attrs/ccl.h
+++ b/include/tvm/relax/attrs/ccl.h
@@ -45,9 +45,7 @@ struct AllReduceAttrs : public tvm::AttrsNodeReflAdapter<AllReduceAttrs> {
                 "Whether the reduction operation performs in group or globally or in group as "
                 "default.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.AllReduceAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AllReduceAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.AllReduceAttrs", AllReduceAttrs, BaseAttrsNode);
 };  // struct AllReduceAttrs
 
 /*! \brief Attributes used in allgather operators */
@@ -65,9 +63,7 @@ struct AllGatherAttrs : public tvm::AttrsNodeReflAdapter<AllGatherAttrs> {
                 "Whether the allgather operation performs in group or globally or in group as "
                 "default.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.AllGatherAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AllGatherAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.AllGatherAttrs", AllGatherAttrs, BaseAttrsNode);
 };  // struct AllGatherAttrs
 
 /*! \brief Attributes used in scatter operators */
@@ -85,9 +81,8 @@ struct ScatterCollectiveAttrs : public tvm::AttrsNodeReflAdapter<ScatterCollecti
                 "The axis of the tensor to be scattered. The tensor will be chunked along "
                 "this axis.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.ScatterCollectiveAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ScatterCollectiveAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ScatterCollectiveAttrs", ScatterCollectiveAttrs,
+                                    BaseAttrsNode);
 };  // struct ScatterCollectiveAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/create.h
+++ b/include/tvm/relax/attrs/create.h
@@ -38,9 +38,7 @@ struct InitAttrs : public AttrsNodeReflAdapter<InitAttrs> {
     refl::ObjectDef<InitAttrs>().def_ro("dtype", &InitAttrs::dtype,
                                         "The data type of the created tensor.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.InitAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(InitAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.InitAttrs", InitAttrs, BaseAttrsNode);
 };  // struct InitAttrs
 
 /*! \brief Attributes used in tril and triu operator */
@@ -53,9 +51,7 @@ struct TriluAttrs : public AttrsNodeReflAdapter<TriluAttrs> {
         "k", &TriluAttrs::k,
         "The number of diagonals above or below the main diagonal to exclude or include.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.TriluAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TriluAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.TriluAttrs", TriluAttrs, BaseAttrsNode);
 };  // struct TriluAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/datatype.h
+++ b/include/tvm/relax/attrs/datatype.h
@@ -37,9 +37,7 @@ struct AstypeAttrs : public AttrsNodeReflAdapter<AstypeAttrs> {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<AstypeAttrs>().def_ro("dtype", &AstypeAttrs::dtype, "Target data type");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.AstypeAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AstypeAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.AstypeAttrs", AstypeAttrs, BaseAttrsNode);
 };  // struct AstypeAttrs.
 
 /*! \brief Attributes used in wrap_param operator */
@@ -50,9 +48,7 @@ struct WrapParamAttrs : public AttrsNodeReflAdapter<WrapParamAttrs> {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<WrapParamAttrs>().def_ro("dtype", &WrapParamAttrs::dtype, "Target data type");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.WrapParamAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(WrapParamAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.WrapParamAttrs", WrapParamAttrs, BaseAttrsNode);
 };  // struct WrapParamAttrs.
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/distributed.h
+++ b/include/tvm/relax/attrs/distributed.h
@@ -44,9 +44,8 @@ struct DistributionAttrs : public AttrsNodeReflAdapter<DistributionAttrs> {
         .def_ro("placement", &DistributionAttrs::placement,
                 "The placement of a tensor's distribution plan");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.DistributionAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(DistributionAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.DistributionAttrs", DistributionAttrs,
+                                    BaseAttrsNode);
 };  // struct DistributionAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/image.h
+++ b/include/tvm/relax/attrs/image.h
@@ -75,9 +75,7 @@ struct Resize2DAttrs : public AttrsNodeReflAdapter<Resize2DAttrs> {
             "The dtype of the output tensor. It it is not specified, the output will have the same "
             "dtype as input if not specified.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.Resize2DAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(Resize2DAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.Resize2DAttrs", Resize2DAttrs, BaseAttrsNode);
 };  // struct Resize2dAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/index.h
+++ b/include/tvm/relax/attrs/index.h
@@ -41,9 +41,7 @@ struct TakeAttrs : public AttrsNodeReflAdapter<TakeAttrs> {
         .def_ro("mode", &TakeAttrs::mode, "The mode for handling out-of-bounds indices.",
                 refl::DefaultValue("fast"));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.TakeAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TakeAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.TakeAttrs", TakeAttrs, BaseAttrsNode);
 };  // struct TakeAttrs
 
 /*! \brief Attributes used in strided_slice operator */
@@ -58,9 +56,8 @@ struct StridedSliceAttrs : public AttrsNodeReflAdapter<StridedSliceAttrs> {
         "out of bound indices will be clipped to the bound.",
         refl::DefaultValue(true));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.StridedSliceAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(StridedSliceAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.StridedSliceAttrs", StridedSliceAttrs,
+                                    BaseAttrsNode);
 };  // struct StridedSliceAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/linear_algebra.h
+++ b/include/tvm/relax/attrs/linear_algebra.h
@@ -38,9 +38,7 @@ struct MatmulAttrs : public AttrsNodeReflAdapter<MatmulAttrs> {
     refl::ObjectDef<MatmulAttrs>().def_ro("out_dtype", &MatmulAttrs::out_dtype,
                                           "The data type of the output tensor");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.MatmulAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(MatmulAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.MatmulAttrs", MatmulAttrs, BaseAttrsNode);
 };  // struct MatmulAttrs
 
 /*! \brief Attributes used in einsum operator */
@@ -52,9 +50,7 @@ struct EinsumAttrs : public AttrsNodeReflAdapter<EinsumAttrs> {
     refl::ObjectDef<EinsumAttrs>().def_ro("subscripts", &EinsumAttrs::subscripts,
                                           "The einsum expression string");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.EinsumAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(EinsumAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.EinsumAttrs", EinsumAttrs, BaseAttrsNode);
 };  // struct EinsumAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/manipulate.h
+++ b/include/tvm/relax/attrs/manipulate.h
@@ -40,9 +40,7 @@ struct ConcatAttrs : public AttrsNodeReflAdapter<ConcatAttrs> {
                                           "The axis at which the input arrays are concatenated."
                                           "Should lie in range `[-ndim, ndim)`.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.ConcatAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ConcatAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ConcatAttrs", ConcatAttrs, BaseAttrsNode);
 };  // struct ConcatAttrs
 
 /*! \brief Attributes used in expand_dims operators */
@@ -57,9 +55,7 @@ struct ExpandDimsAttrs : public AttrsNodeReflAdapter<ExpandDimsAttrs> {
         "All values are required to lie in range `[-data.ndim - 1, data.ndim]`, "
         "with the convention of negative indexing.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.ExpandDimsAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ExpandDimsAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ExpandDimsAttrs", ExpandDimsAttrs, BaseAttrsNode);
 };  // struct ExpandDimsAttrs
 
 /*! \brief Attributes used in layout_transform operator */
@@ -96,9 +92,8 @@ struct LayoutTransformAttrs : public AttrsNodeReflAdapter<LayoutTransformAttrs> 
         .def_ro("input_axis_separators", &LayoutTransformAttrs::input_axis_separators,
                 "The separators between axes to regenerate output");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.LayoutTransformAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(LayoutTransformAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.LayoutTransformAttrs", LayoutTransformAttrs,
+                                    BaseAttrsNode);
 };  // struct LayoutTransformAttrs
 
 /*! \brief Attributes used in permute_dims operator */
@@ -110,9 +105,8 @@ struct PermuteDimsAttrs : public AttrsNodeReflAdapter<PermuteDimsAttrs> {
     refl::ObjectDef<PermuteDimsAttrs>().def_ro(
         "axes", &PermuteDimsAttrs::axes, "The target axes order, reverse order if not specified.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.PermuteDimsAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(PermuteDimsAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.PermuteDimsAttrs", PermuteDimsAttrs,
+                                    BaseAttrsNode);
 };  // struct PermuteDimsAttrs
 
 /*! \brief Attributes used in split operator */
@@ -127,9 +121,7 @@ struct SplitAttrs : public AttrsNodeReflAdapter<SplitAttrs> {
                 "The input array of indices or the number of split sections.")
         .def_ro("axis", &SplitAttrs::axis, "The axis to be splitted");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.SplitAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(SplitAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.SplitAttrs", SplitAttrs, BaseAttrsNode);
 };  // struct SplitAttrs
 
 /*! \brief Attributes used in squeeze operators */
@@ -144,9 +136,7 @@ struct SqueezeAttrs : public AttrsNodeReflAdapter<SqueezeAttrs> {
                                            "Else, the dimension in axes get squeezed."
                                            "It is an error if an axis does not has dimension 1.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.SqueezeAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(SqueezeAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.SqueezeAttrs", SqueezeAttrs, BaseAttrsNode);
 };  // struct SqueezeAttrs
 
 /*! \brief Attributes used in stack operators */
@@ -162,9 +152,7 @@ struct StackAttrs : public AttrsNodeReflAdapter<StackAttrs> {
         "so it must be in range [-ndim-1, ndim] where ndim is the "
         "number of dimensions of the input tensors.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.StackAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(StackAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.StackAttrs", StackAttrs, BaseAttrsNode);
 };  // struct StackAttrs
 
 /*! \brief Attributes used in repeat operators */
@@ -181,9 +169,7 @@ struct RepeatAttrs : public AttrsNodeReflAdapter<RepeatAttrs> {
                 "counting from the backward. By default, use the flattened input array, and "
                 "return a flat output array.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.RepeatAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(RepeatAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.RepeatAttrs", RepeatAttrs, BaseAttrsNode);
 };  // struct RepeatAttrs
 
 /*! \brief Attributes used in tile operators */
@@ -195,9 +181,7 @@ struct TileAttrs : public AttrsNodeReflAdapter<TileAttrs> {
     refl::ObjectDef<TileAttrs>().def_ro("repeats", &TileAttrs::repeats,
                                         "The number of repetitions of data along each axis.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.TileAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TileAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.TileAttrs", TileAttrs, BaseAttrsNode);
 };  // struct TileAttrs
 
 /*! \brief Attributes used in flip operators */
@@ -210,9 +194,7 @@ struct FlipAttrs : public AttrsNodeReflAdapter<FlipAttrs> {
                                         "The axis along which to flip over.",
                                         refl::DefaultValue(NullValue<Integer>()));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.FlipAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(FlipAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.FlipAttrs", FlipAttrs, BaseAttrsNode);
 };  // struct FlipAttrs
 
 /*! \brief Attributes used in gather_elements operators */
@@ -225,9 +207,8 @@ struct GatherElementsAttrs : public AttrsNodeReflAdapter<GatherElementsAttrs> {
                                                   "The axis along which to index.",
                                                   refl::DefaultValue(0));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.GatherElementsAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(GatherElementsAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.GatherElementsAttrs", GatherElementsAttrs,
+                                    BaseAttrsNode);
 };  // struct GatherElementsAttrs
 
 /*! \brief Attributes used in gather_nd operators */
@@ -239,9 +220,7 @@ struct GatherNDAttrs : public AttrsNodeReflAdapter<GatherNDAttrs> {
     refl::ObjectDef<GatherNDAttrs>().def_ro("batch_dims", &GatherNDAttrs::batch_dims,
                                             "The number of batch dims.", refl::DefaultValue(0));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.GatherNDAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(GatherNDAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.GatherNDAttrs", GatherNDAttrs, BaseAttrsNode);
 };  // struct GatherNDAttrs
 
 /*! \brief Attributes used in index_put operator */
@@ -257,9 +236,7 @@ struct IndexPutAttrs : public AttrsNodeReflAdapter<IndexPutAttrs> {
         "otherwise performs tensor[indices] = values.",
         refl::DefaultValue(false));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.IndexPutAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(IndexPutAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.IndexPutAttrs", IndexPutAttrs, BaseAttrsNode);
 };  // struct IndexPutAttrs
 
 /*! \brief Attribute used in meshgrid operator */
@@ -271,9 +248,7 @@ struct MeshgridAttrs : public AttrsNodeReflAdapter<MeshgridAttrs> {
     refl::ObjectDef<MeshgridAttrs>().def_ro("indexing", &MeshgridAttrs::indexing,
                                             "Specifies how the grid dimensions are ordered.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.MeshgridAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(MeshgridAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.MeshgridAttrs", MeshgridAttrs, BaseAttrsNode);
 };
 
 /*! \brief Attributes used in scatter_elements operators */
@@ -291,9 +266,8 @@ struct ScatterElementsAttrs : public AttrsNodeReflAdapter<ScatterElementsAttrs> 
                 "either \"update\", \"add\", \"mul\", \"mean\", \"min\" or \"max\".",
                 refl::DefaultValue("update"));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.ScatterElementsAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ScatterElementsAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ScatterElementsAttrs", ScatterElementsAttrs,
+                                    BaseAttrsNode);
 };  // struct ScatterElementsAttrs
 
 /*! \brief Attributes used in scatter_nd operators */
@@ -308,9 +282,7 @@ struct ScatterNDAttrs : public AttrsNodeReflAdapter<ScatterNDAttrs> {
         "either \"update\", \"add\", \"mul\", \"min\" or \"max\".",
         refl::DefaultValue("update"));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.ScatterNDAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ScatterNDAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ScatterNDAttrs", ScatterNDAttrs, BaseAttrsNode);
 };  // struct ScatterNDAttrs
 
 /*! \brief Attributes used in slice_scatter operator */
@@ -323,9 +295,8 @@ struct SliceScatterAttrs : public AttrsNodeReflAdapter<SliceScatterAttrs> {
                                                 "the dimension to insert the slice into ",
                                                 refl::DefaultValue(0));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.SliceScatterAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(SliceScatterAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.SliceScatterAttrs", SliceScatterAttrs,
+                                    BaseAttrsNode);
 };  // struct SliceScatterAttrs
 
 /*! \brief Attributes used in one_hot operator */
@@ -339,9 +310,7 @@ struct OneHotAttrs : public AttrsNodeReflAdapter<OneHotAttrs> {
         .def_ro("depth", &OneHotAttrs::depth, "Depth of the one hot dimension.")
         .def_ro("axis", &OneHotAttrs::axis, "Axis to fill.", refl::DefaultValue(-1));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.OneHotAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(OneHotAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.OneHotAttrs", OneHotAttrs, BaseAttrsNode);
 };  // struct OneHotAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -70,9 +70,7 @@ struct Conv1DAttrs : public AttrsNodeReflAdapter<Conv1DAttrs> {
         .def_ro("out_dtype", &Conv1DAttrs::out_dtype,
                 "Output data type, set to explicit type under mixed precision setting");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.Conv1DAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(Conv1DAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.Conv1DAttrs", Conv1DAttrs, BaseAttrsNode);
 };  // struct Conv1dAttrs
 
 /*! \brief Attributes used in Conv2d operator */
@@ -118,9 +116,7 @@ struct Conv2DAttrs : public AttrsNodeReflAdapter<Conv2DAttrs> {
         .def_ro("out_dtype", &Conv2DAttrs::out_dtype,
                 "Output data type, set to explicit type under mixed precision setting");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.Conv2DAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(Conv2DAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.Conv2DAttrs", Conv2DAttrs, BaseAttrsNode);
 };  // struct Conv2dAttrs
 
 /*! \brief Attributes used in Conv3d operator */
@@ -168,9 +164,7 @@ struct Conv3DAttrs : public AttrsNodeReflAdapter<Conv3DAttrs> {
         .def_ro("out_dtype", &Conv3DAttrs::out_dtype,
                 "Output data type, set to explicit type under mixed precision setting");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.Conv3DAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(Conv3DAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.Conv3DAttrs", Conv3DAttrs, BaseAttrsNode);
 };  // struct Conv3dAttrs
 
 /*! \brief Attributes used in Conv1DTranspose operator */
@@ -218,9 +212,8 @@ struct Conv1DTransposeAttrs : public AttrsNodeReflAdapter<Conv1DTransposeAttrs> 
         .def_ro("out_dtype", &Conv1DTransposeAttrs::out_dtype,
                 "Output data type, set to explicit type under mixed precision setting");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.Conv1DTransposeAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(Conv1DTransposeAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.Conv1DTransposeAttrs", Conv1DTransposeAttrs,
+                                    BaseAttrsNode);
 };  // struct Conv1DTransposeAttrs
 
 /*! \brief Attributes used in Conv2d operator */
@@ -270,9 +263,8 @@ struct Conv2DTransposeAttrs : public AttrsNodeReflAdapter<Conv2DTransposeAttrs> 
         .def_ro("out_dtype", &Conv2DTransposeAttrs::out_dtype,
                 "Output data type, set to explicit type under mixed precision setting");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.Conv2DTransposeAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(Conv2DTransposeAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.Conv2DTransposeAttrs", Conv2DTransposeAttrs,
+                                    BaseAttrsNode);
 };  // struct Conv2DTransposeAttrs
 
 /*! \brief Attributes used in max_pool1d and avg_pool1d operator */
@@ -313,9 +305,7 @@ struct Pool1DAttrs : public AttrsNodeReflAdapter<Pool1DAttrs> {
                 "'N', 'C', 'W' stands for batch, channel, and width"
                 "dimensions respectively. Pooling is applied on the 'W' dimensions.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.Pool1DAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(Pool1DAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.Pool1DAttrs", Pool1DAttrs, BaseAttrsNode);
 };  // struct Pool1dAttrs
 
 /*! \brief Attributes used in max_pool2d and avg_pool2d operator */
@@ -358,9 +348,7 @@ struct Pool2DAttrs : public AttrsNodeReflAdapter<Pool2DAttrs> {
                 "dimensions respectively. Pooling is applied on the 'H' and"
                 "'W' dimensions.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.Pool2DAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(Pool2DAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.Pool2DAttrs", Pool2DAttrs, BaseAttrsNode);
 };  // struct Pool2dAttrs
 
 /*! \brief Attributes used in max_pool3d and avg_pool3d operator */
@@ -403,9 +391,7 @@ struct Pool3DAttrs : public AttrsNodeReflAdapter<Pool3DAttrs> {
                 "dimensions respectively. Pooling is applied on the 'D', 'H' and"
                 "'W' dimensions.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.Pool3DAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(Pool3DAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.Pool3DAttrs", Pool3DAttrs, BaseAttrsNode);
 };  // struct Pool3dAttrs
 
 /*! \brief Attributes for 1d adaptive pool operator */
@@ -429,9 +415,8 @@ struct AdaptivePool1DAttrs : public AttrsNodeReflAdapter<AdaptivePool1DAttrs> {
                 "dimensions respectively. Pooling is applied on the"
                 "'W' dimensions.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.AdaptivePool1DAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AdaptivePool1DAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.AdaptivePool1DAttrs", AdaptivePool1DAttrs,
+                                    BaseAttrsNode);
 };  // struct AdaptivePool1DAttrs
 
 /*! \brief Attributes for 2d adaptive pool operator */
@@ -455,9 +440,8 @@ struct AdaptivePool2DAttrs : public AttrsNodeReflAdapter<AdaptivePool2DAttrs> {
                 "dimensions respectively. Pooling is applied on the 'H' and"
                 "'W' dimensions.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.AdaptivePool2DAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AdaptivePool2DAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.AdaptivePool2DAttrs", AdaptivePool2DAttrs,
+                                    BaseAttrsNode);
 };  // struct AdaptivePool2DAttrs
 
 /*! \brief Attributes for 3d adaptive pool operator */
@@ -481,9 +465,8 @@ struct AdaptivePool3DAttrs : public AttrsNodeReflAdapter<AdaptivePool3DAttrs> {
                 "dimensions respectively. Pooling is applied on 'D', 'H' and"
                 "'W' dimensions.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.AdaptivePool3DAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AdaptivePool3DAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.AdaptivePool3DAttrs", AdaptivePool3DAttrs,
+                                    BaseAttrsNode);
 };  // struct AdaptivePool3DAttrs
 
 /*! \brief Attributes used in softmax operators */
@@ -495,9 +478,7 @@ struct SoftmaxAttrs : public AttrsNodeReflAdapter<SoftmaxAttrs> {
     refl::ObjectDef<SoftmaxAttrs>().def_ro("axis", &SoftmaxAttrs::axis,
                                            "The axis to sum over when computing softmax.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.SoftmaxAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(SoftmaxAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.SoftmaxAttrs", SoftmaxAttrs, BaseAttrsNode);
 };
 
 /*! \brief Attributes used in softmax operators */
@@ -509,9 +490,7 @@ struct LeakyReluAttrs : public AttrsNodeReflAdapter<LeakyReluAttrs> {
     refl::ObjectDef<LeakyReluAttrs>().def_ro("alpha", &LeakyReluAttrs::alpha,
                                              "The slope of the negative part.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.LeakyReluAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(LeakyReluAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.LeakyReluAttrs", LeakyReluAttrs, BaseAttrsNode);
 };
 
 /*! \brief Attributes used in softplus operators */
@@ -527,9 +506,7 @@ struct SoftplusAttrs : public AttrsNodeReflAdapter<SoftplusAttrs> {
         .def_ro("threshold", &SoftplusAttrs::threshold,
                 "Value determining when to use linear approximation for numerical stability.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.SoftplusAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(SoftplusAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.SoftplusAttrs", SoftplusAttrs, BaseAttrsNode);
 };
 
 /*! \brief Attributes used in PReLU operator */
@@ -541,9 +518,7 @@ struct PReluAttrs : public AttrsNodeReflAdapter<PReluAttrs> {
     refl::ObjectDef<PReluAttrs>().def_ro("axis", &PReluAttrs::axis,
                                          "The axis along which the alpha values are applied.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.PReluAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(PReluAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.PReluAttrs", PReluAttrs, BaseAttrsNode);
 };
 
 /*! \brief Attributes used in batch_norm operator */
@@ -570,9 +545,7 @@ struct BatchNormAttrs : public AttrsNodeReflAdapter<BatchNormAttrs> {
         .def_ro("training", &BatchNormAttrs::training,
                 "Whether we are training (i.e., not in eval mode).");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.BatchNormAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(BatchNormAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.BatchNormAttrs", BatchNormAttrs, BaseAttrsNode);
 };  // struct BatchNormAttrs
 
 /*! \brief Attributes used in layer_norm operator */
@@ -594,9 +567,7 @@ struct LayerNormAttrs : public AttrsNodeReflAdapter<LayerNormAttrs> {
         .def_ro("scale", &LayerNormAttrs::scale,
                 "Indicating if the gamma scale will be multiplied.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.LayerNormAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(LayerNormAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.LayerNormAttrs", LayerNormAttrs, BaseAttrsNode);
 };  // struct LayerNormAttrs
 
 /*! \brief Attributes used in group_norm operator */
@@ -625,9 +596,7 @@ struct GroupNormAttrs : public AttrsNodeReflAdapter<GroupNormAttrs> {
         .def_ro("scale", &GroupNormAttrs::scale,
                 "Indicating if the gamma scale will be multiplied.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.GroupNormAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(GroupNormAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.GroupNormAttrs", GroupNormAttrs, BaseAttrsNode);
 };  // struct GroupNormAttrs
 
 /*! \brief Attributes used in instance_norm operator */
@@ -652,9 +621,8 @@ struct InstanceNormAttrs : public AttrsNodeReflAdapter<InstanceNormAttrs> {
         .def_ro("scale", &InstanceNormAttrs::scale,
                 "Indicating if the gamma scale will be multiplied.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.InstanceNormAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(InstanceNormAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.InstanceNormAttrs", InstanceNormAttrs,
+                                    BaseAttrsNode);
 };  // struct InstanceNormAttrs
 
 /*! \brief Attributes used in rms_norm operator */
@@ -670,9 +638,7 @@ struct RMSNormAttrs : public AttrsNodeReflAdapter<RMSNormAttrs> {
         .def_ro("epsilon", &RMSNormAttrs::epsilon,
                 "Small float added to variance to avoid dividing by zero");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.RMSNormAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(RMSNormAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.RMSNormAttrs", RMSNormAttrs, BaseAttrsNode);
 };  // struct RMSNormAttrs
 
 /*! \brief Attributes used in nll_loss operator */
@@ -689,9 +655,7 @@ struct NLLLossAttrs : public AttrsNodeReflAdapter<NLLLossAttrs> {
                 refl::DefaultValue("mean"))
         .def_ro("ignore_index", &NLLLossAttrs::ignore_index, "The target value to ignore.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.NLLLossAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(NLLLossAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.NLLLossAttrs", NLLLossAttrs, BaseAttrsNode);
 };  // struct NLLLossAttrs
 
 /*! \brief Attributes used in dropout operator */
@@ -704,9 +668,7 @@ struct DropoutAttrs : public AttrsNodeReflAdapter<DropoutAttrs> {
         "rate", &DropoutAttrs::rate,
         "Fraction of the input that gets dropped out during training time");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.DropoutAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(DropoutAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.DropoutAttrs", DropoutAttrs, BaseAttrsNode);
 };  // struct DropoutAttrs
 
 /*! \brief Attributes used in Attention operator */
@@ -726,9 +688,7 @@ struct AttentionAttrs : public AttrsNodeReflAdapter<AttentionAttrs> {
         .def_ro("window_size", &AttentionAttrs::window_size,
                 "The size of the window for sliding-window attention.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.AttentionAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(AttentionAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.AttentionAttrs", AttentionAttrs, BaseAttrsNode);
 };  // struct AttentionAttrs
 
 /*! \brief Attributes used for the padding operator */
@@ -751,9 +711,7 @@ struct PadAttrs : public AttrsNodeReflAdapter<PadAttrs> {
                 "\"reflect\" pads by reflecting values with respect to the edges.",
                 refl::DefaultValue("constant"));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.PadAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(PadAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.PadAttrs", PadAttrs, BaseAttrsNode);
 };
 
 /*! \brief Attributes used for the pixel shuffle operator */
@@ -766,9 +724,8 @@ struct PixelShuffleAttrs : public AttrsNodeReflAdapter<PixelShuffleAttrs> {
                                                 &PixelShuffleAttrs::upscale_factor,
                                                 "Scale factor for spatial upsampling.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.PixelShuffleAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(PixelShuffleAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.PixelShuffleAttrs", PixelShuffleAttrs,
+                                    BaseAttrsNode);
 };
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/op.h
+++ b/include/tvm/relax/attrs/op.h
@@ -44,9 +44,8 @@ struct CallTIRWithGradAttrs : public AttrsNodeReflAdapter<CallTIRWithGradAttrs> 
         .def_ro("te_grad_kwargs", &CallTIRWithGradAttrs::te_grad_kwargs,
                 "The keyword arguments passed to the te gradient function.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.CallTIRWithGradAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(CallTIRWithGradAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.CallTIRWithGradAttrs", CallTIRWithGradAttrs,
+                                    BaseAttrsNode);
 };  // struct CallTIRAttrs
 
 /*! \brief Attributes used in call_tir_inplace */
@@ -65,9 +64,8 @@ struct CallTIRInplaceAttrs : public AttrsNodeReflAdapter<CallTIRInplaceAttrs> {
     refl::ObjectDef<CallTIRInplaceAttrs>().def_ro("inplace_indices",
                                                   &CallTIRInplaceAttrs::inplace_indices);
   }
-
-  static constexpr const char* _type_key = "relax.attrs.CallTIRInplaceAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(CallTIRInplaceAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.CallTIRInplaceAttrs", CallTIRInplaceAttrs,
+                                    BaseAttrsNode);
 };  // struct CallTIRInplaceAttrs
 
 /*! \brief Attributes used in call_inplace_packed */
@@ -86,9 +84,8 @@ struct CallInplacePackedAttrs : public AttrsNodeReflAdapter<CallInplacePackedAtt
     refl::ObjectDef<CallInplacePackedAttrs>().def_ro("inplace_indices",
                                                      &CallInplacePackedAttrs::inplace_indices);
   }
-
-  static constexpr const char* _type_key = "relax.attrs.CallInplacePackedAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(CallInplacePackedAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.CallInplacePackedAttrs", CallInplacePackedAttrs,
+                                    BaseAttrsNode);
 };  // struct CallInplacePackedAttrs
 
 /*! \brief Attributes used in to_vdevice */
@@ -100,9 +97,7 @@ struct ToVDeviceAttrs : public AttrsNodeReflAdapter<ToVDeviceAttrs> {
     refl::ObjectDef<ToVDeviceAttrs>().def_ro("dst_vdevice", &ToVDeviceAttrs::dst_vdevice,
                                              "The destination device where the data is copied to.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.ToVDeviceAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ToVDeviceAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ToVDeviceAttrs", ToVDeviceAttrs, BaseAttrsNode);
 };  // struct ToVDeviceAttrs
 
 /*! \brief Attributes used in hint_on_device */
@@ -117,9 +112,8 @@ struct HintOnDeviceAttrs : public AttrsNodeReflAdapter<HintOnDeviceAttrs> {
                 "The device type where the data is supposed to be executed.")
         .def_ro("index", &HintOnDeviceAttrs::index, "The device id.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.HintOnDeviceAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(HintOnDeviceAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.HintOnDeviceAttrs", HintOnDeviceAttrs,
+                                    BaseAttrsNode);
 };  // struct HintOnDeviceAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/qdq.h
+++ b/include/tvm/relax/attrs/qdq.h
@@ -43,9 +43,7 @@ struct QuantizeAttrs : public AttrsNodeReflAdapter<QuantizeAttrs> {
                 "Default value is -1, which corresponds to the last axis.",
                 refl::DefaultValue(-1));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.QuantizeAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(QuantizeAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.QuantizeAttrs", QuantizeAttrs, BaseAttrsNode);
 };  // QuantizeAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/sampling.h
+++ b/include/tvm/relax/attrs/sampling.h
@@ -39,9 +39,8 @@ struct MultinomialFromUniformAttrs : public AttrsNodeReflAdapter<MultinomialFrom
         "dtype", &MultinomialFromUniformAttrs::dtype, "Data type of the output indices.",
         refl::DefaultValue(DataType::Int(64)));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.MultinomialFromUniformAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(MultinomialFromUniformAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.MultinomialFromUniformAttrs",
+                                    MultinomialFromUniformAttrs, BaseAttrsNode);
 };  // struct MultinomialFromUniformAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/search.h
+++ b/include/tvm/relax/attrs/search.h
@@ -44,9 +44,8 @@ struct ArgmaxArgminAttrs : public AttrsNodeReflAdapter<ArgmaxArgminAttrs> {
                 "with size "
                 "one.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.ArgmaxArgminAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ArgmaxArgminAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ArgmaxArgminAttrs", ArgmaxArgminAttrs,
+                                    BaseAttrsNode);
 };  // struct ArgmaxArgminAttrs
 
 /*! \brief Attributes for bucketize operator */
@@ -62,9 +61,7 @@ struct BucketizeAttrs : public tvm::AttrsNodeReflAdapter<BucketizeAttrs> {
         .def_ro("right", &BucketizeAttrs::right,
                 "Determines the behavior for values in boundaries");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.BucketizeAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(BucketizeAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.BucketizeAttrs", BucketizeAttrs, BaseAttrsNode);
 };  // struct BucketizeAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/sorting.h
+++ b/include/tvm/relax/attrs/sorting.h
@@ -47,9 +47,7 @@ struct SortAttrs : public AttrsNodeReflAdapter<SortAttrs> {
                 "If it is not specified, it defaults to the ascending order.",
                 refl::DefaultValue(false));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.SortAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(SortAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.SortAttrs", SortAttrs, BaseAttrsNode);
 };  // struct SortAttrs
 
 /*! \brief Attributes used in argsort operator */
@@ -72,9 +70,7 @@ struct ArgsortAttrs : public AttrsNodeReflAdapter<ArgsortAttrs> {
         .def_ro("dtype", &ArgsortAttrs::dtype, "DType of the output indices.",
                 refl::DefaultValue(NullValue<DataType>()));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.ArgsortAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ArgsortAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ArgsortAttrs", ArgsortAttrs, BaseAttrsNode);
 };  // struct ArgsortAttrs
 
 /*! \brief Attributes used in topk operator */
@@ -104,9 +100,7 @@ struct TopKAttrs : public AttrsNodeReflAdapter<TopKAttrs> {
         .def_ro("dtype", &TopKAttrs::dtype, "Data type of the output indices.",
                 refl::DefaultValue(NullValue<DataType>()));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.TopKAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TopKAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.TopKAttrs", TopKAttrs, BaseAttrsNode);
 };  // struct TopKAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/attrs/statistical.h
+++ b/include/tvm/relax/attrs/statistical.h
@@ -44,9 +44,8 @@ struct StatisticalAttrs : public AttrsNodeReflAdapter<StatisticalAttrs> {
                 "with size "
                 "one.");
   }
-
-  static constexpr const char* _type_key = "relax.attrs.StatisticalAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(StatisticalAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.StatisticalAttrs", StatisticalAttrs,
+                                    BaseAttrsNode);
 };  // struct StatisticalAttrs
 
 /*! \brief Attributes used in scan operators like cumsum, cumprod */
@@ -67,9 +66,7 @@ struct ScanopAttrs : public AttrsNodeReflAdapter<ScanopAttrs> {
         .def_ro("exclusive", &ScanopAttrs::exclusive, "The first element is not included",
                 refl::DefaultValue(Bool(false)));
   }
-
-  static constexpr const char* _type_key = "relax.attrs.ScanopAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ScanopAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ScanopAttrs", ScanopAttrs, BaseAttrsNode);
 };  // struct ScanopAttrs
 
 }  // namespace relax

--- a/include/tvm/relax/binding_rewrite.h
+++ b/include/tvm/relax/binding_rewrite.h
@@ -74,9 +74,7 @@ class DataflowBlockRewriteNode : public Object {
         .def_ro("dfb", &DataflowBlockRewriteNode::dfb_)
         .def_ro("root_fn", &DataflowBlockRewriteNode::root_fn_);
   }
-
-  static constexpr const char* _type_key = "relax.DataflowBlockRewrite";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DataflowBlockRewriteNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.DataflowBlockRewrite", DataflowBlockRewriteNode, Object);
 
  protected:
   friend class DataflowBlockRewrite;
@@ -108,7 +106,8 @@ class DataflowBlockRewrite : public ObjectRef {
     return static_cast<DataflowBlockRewriteNode*>(get_mutable());
   }
 
-  TVM_DEFINE_OBJECT_REF_METHODS(DataflowBlockRewrite, ObjectRef, DataflowBlockRewriteNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DataflowBlockRewrite, ObjectRef,
+                                             DataflowBlockRewriteNode);
 };
 
 }  // namespace relax

--- a/include/tvm/relax/block_builder.h
+++ b/include/tvm/relax/block_builder.h
@@ -257,8 +257,8 @@ class BlockBuilderNode : public Object {
    */
   virtual arith::Analyzer* GetAnalyzer() = 0;
 
-  static constexpr const char* _type_key = "relax.BlockBuilder";
-  TVM_DECLARE_BASE_OBJECT_INFO(BlockBuilderNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.BlockBuilder", BlockBuilderNode, Object);
 };
 
 class BlockBuilder : public ObjectRef {
@@ -318,7 +318,7 @@ class BlockBuilder : public ObjectRef {
   TVM_DLL static BlockBuilder Create(ffi::Optional<IRModule> ctx_mod,
                                      DisableOperatorSpecificNormalizationForTVMScript tag);
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(BlockBuilder, ObjectRef, BlockBuilderNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BlockBuilder, ObjectRef, BlockBuilderNode);
 };
 
 }  // namespace relax

--- a/include/tvm/relax/dataflow_pattern.h
+++ b/include/tvm/relax/dataflow_pattern.h
@@ -90,9 +90,8 @@ TVM_DLL PatternSeq operator>>(const PatternSeq& lhs, const PatternSeq& rhs);
  */
 class DFPatternNode : public Object {
  public:
-  static constexpr const char* _type_key = "DFPatternNode";
   static constexpr const uint32_t _type_child_slots = 21;
-  TVM_DECLARE_BASE_OBJECT_INFO(DFPatternNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.dpl.DFPattern", DFPatternNode, Object);
 };
 
 /*!
@@ -130,7 +129,7 @@ class DFPattern : public ObjectRef {
   /*! \brief Implicit conversion from DFPattern to PatternSeq */
   TVM_DLL operator PatternSeq() const;
 
-  TVM_DEFINE_OBJECT_REF_METHODS(DFPattern, ObjectRef, DFPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DFPattern, ObjectRef, DFPatternNode);
 };
 
 /*! \brief Constraint of a DFPattern edge (producer -> consumer) in graph-level matching */
@@ -197,14 +196,13 @@ class DFConstraintNode : public Object {
   virtual std::tuple<PrimExpr, bool> AsPrimExpr(
       std::function<ffi::Optional<Var>(const DFPatternNode*)> match_state) const = 0;
 
-  static constexpr const char* _type_key = "DFConstraintNode";
   static constexpr const uint32_t _type_child_slots = 1;
-  TVM_DECLARE_BASE_OBJECT_INFO(DFConstraintNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.dpl.DFConstraint", DFConstraintNode, Object);
 };
 
 class DFConstraint : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(DFConstraint, ObjectRef, DFConstraintNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DFConstraint, ObjectRef, DFConstraintNode);
 };
 
 /*!
@@ -220,9 +218,7 @@ class PatternSeqNode final : public Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PatternSeqNode>().def_ro("patterns", &PatternSeqNode::patterns);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.PatternSeq";
-  TVM_DECLARE_BASE_OBJECT_INFO(PatternSeqNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.dpl.PatternSeq", PatternSeqNode, Object);
 };
 
 /*!
@@ -244,7 +240,7 @@ class PatternSeq final : public ObjectRef {
   friend PatternSeq UsedBy(const PatternSeq& lhs, const PatternSeq& rhs, int index);
   friend PatternSeq OnlyUsedBy(const PatternSeq& lhs, const PatternSeq& rhs, int index);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PatternSeq, ObjectRef, PatternSeqNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PatternSeq, ObjectRef, PatternSeqNode);
 };
 
 /*!
@@ -269,9 +265,7 @@ class PatternContextNode : public Object {
 
   // Non-edge constraints
   std::vector<DFConstraint> validation_constraints;
-
-  static constexpr const char* _type_key = "relax.dpl.PatternContext";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PatternContextNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.PatternContext", PatternContextNode, Object);
 };
 
 /*!
@@ -353,9 +347,7 @@ class ExprPatternNode : public DFPatternNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ExprPatternNode>().def_ro("expr", &ExprPatternNode::expr);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.ExprPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ExprPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.ExprPattern", ExprPatternNode, DFPatternNode);
 };
 
 /*!
@@ -365,7 +357,7 @@ class ExprPatternNode : public DFPatternNode {
 class ExprPattern : public DFPattern {
  public:
   TVM_DLL explicit ExprPattern(Expr expr);
-  TVM_DEFINE_OBJECT_REF_METHODS(ExprPattern, DFPattern, ExprPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ExprPattern, DFPattern, ExprPatternNode);
 };
 
 /*!
@@ -383,9 +375,8 @@ class VarPatternNode : public DFPatternNode {
     refl::ObjectDef<VarPatternNode>().def_ro("name", &VarPatternNode::name);
   }
 
-  static constexpr const char* _type_key = "relax.dpl.VarPattern";
   static constexpr const uint32_t _type_child_slots = 1;
-  TVM_DECLARE_BASE_OBJECT_INFO(VarPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.dpl.VarPattern", VarPatternNode, DFPatternNode);
 };
 
 /*!
@@ -400,7 +391,7 @@ class VarPattern : public DFPattern {
    * \param name_hint Variable name to match. Any if empty ("").
    */
   TVM_DLL VarPattern(ffi::String name_hint);
-  TVM_DEFINE_OBJECT_REF_METHODS(VarPattern, DFPattern, VarPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(VarPattern, DFPattern, VarPatternNode);
 };
 
 /*!
@@ -413,9 +404,8 @@ class DataflowVarPatternNode : public VarPatternNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<DataflowVarPatternNode>();
   }
-
-  static constexpr const char* _type_key = "relax.dpl.DataflowVarPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DataflowVarPatternNode, VarPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.DataflowVarPattern", DataflowVarPatternNode,
+                                    VarPatternNode);
 };
 
 /*!
@@ -426,7 +416,7 @@ class DataflowVarPattern : public DFPattern {
  public:
   /*! \sa VarPattern::VarPattern */
   TVM_DLL DataflowVarPattern(ffi::String name_hint);
-  TVM_DEFINE_OBJECT_REF_METHODS(DataflowVarPattern, DFPattern, DataflowVarPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DataflowVarPattern, DFPattern, DataflowVarPatternNode);
 };
 
 /*!
@@ -435,8 +425,8 @@ class DataflowVarPattern : public DFPattern {
  */
 class GlobalVarPatternNode : public VarPatternNode {
  public:
-  static constexpr const char* _type_key = "relax.dpl.GlobalVarPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(GlobalVarPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.GlobalVarPattern", GlobalVarPatternNode,
+                                    DFPatternNode);
 };
 
 /*!
@@ -446,7 +436,7 @@ class GlobalVarPatternNode : public VarPatternNode {
 class GlobalVarPattern : public DFPattern {
  public:
   TVM_DLL GlobalVarPattern(ffi::String name_hint);
-  TVM_DEFINE_OBJECT_REF_METHODS(GlobalVarPattern, DFPattern, GlobalVarPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(GlobalVarPattern, DFPattern, GlobalVarPatternNode);
 };
 
 /*!
@@ -459,9 +449,8 @@ class ConstantPatternNode : public DFPatternNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ConstantPatternNode>();
   }
-
-  static constexpr const char* _type_key = "relax.dpl.ConstantPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ConstantPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.ConstantPattern", ConstantPatternNode,
+                                    DFPatternNode);
 };
 
 /*!
@@ -470,7 +459,7 @@ class ConstantPatternNode : public DFPatternNode {
  */
 class ConstantPattern : public DFPattern {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(ConstantPattern, DFPattern, ConstantPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ConstantPattern, DFPattern, ConstantPatternNode);
 };
 
 /*!
@@ -502,15 +491,13 @@ class CallPatternNode : public DFPatternNode {
         .def_ro("op", &CallPatternNode::op)
         .def_ro("args", &CallPatternNode::args);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.CallPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(CallPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.CallPattern", CallPatternNode, DFPatternNode);
 };
 
 class CallPattern : public DFPattern {
  public:
   TVM_DLL CallPattern(DFPattern op, ffi::Array<DFPattern> args, bool varg_default_wildcard = false);
-  TVM_DEFINE_OBJECT_REF_METHODS(CallPattern, DFPattern, CallPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(CallPattern, DFPattern, CallPatternNode);
 };
 
 /*!
@@ -526,9 +513,7 @@ class PrimArrPatternNode : public DFPatternNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PrimArrPatternNode>().def_ro("fields", &PrimArrPatternNode::fields);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.PrimArrPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PrimArrPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.PrimArrPattern", PrimArrPatternNode, DFPatternNode);
 };
 
 /*!
@@ -538,7 +523,7 @@ class PrimArrPatternNode : public DFPatternNode {
 class PrimArrPattern : public DFPattern {
  public:
   TVM_DLL PrimArrPattern(ffi::Array<PrimExpr> arr);
-  TVM_DEFINE_OBJECT_REF_METHODS(PrimArrPattern, DFPattern, PrimArrPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PrimArrPattern, DFPattern, PrimArrPatternNode);
 };
 
 /*!
@@ -563,9 +548,8 @@ class FunctionPatternNode : public DFPatternNode {
         .def_ro("params", &FunctionPatternNode::params)
         .def_ro("body", &FunctionPatternNode::body);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.FunctionPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(FunctionPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.FunctionPattern", FunctionPatternNode,
+                                    DFPatternNode);
 };
 
 /*!
@@ -581,7 +565,7 @@ class FunctionPattern : public DFPattern {
    */
   TVM_DLL FunctionPattern(tvm::ffi::Array<DFPattern> params, DFPattern body);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(FunctionPattern, DFPattern, FunctionPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(FunctionPattern, DFPattern, FunctionPatternNode);
 };
 
 /*!
@@ -596,9 +580,7 @@ class TuplePatternNode : public DFPatternNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<TuplePatternNode>().def_ro("fields", &TuplePatternNode::fields);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.TuplePattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TuplePatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.TuplePattern", TuplePatternNode, DFPatternNode);
 };
 
 /*!
@@ -608,7 +590,7 @@ class TuplePatternNode : public DFPatternNode {
 class TuplePattern : public DFPattern {
  public:
   TVM_DLL explicit TuplePattern(tvm::ffi::Array<DFPattern> fields);
-  TVM_DEFINE_OBJECT_REF_METHODS(TuplePattern, DFPattern, TuplePatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TuplePattern, DFPattern, TuplePatternNode);
 };
 
 /*!
@@ -624,9 +606,8 @@ class UnorderedTuplePatternNode : public DFPatternNode {
     refl::ObjectDef<UnorderedTuplePatternNode>().def_ro("fields",
                                                         &UnorderedTuplePatternNode::fields);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.UnorderedTuplePattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(UnorderedTuplePatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.UnorderedTuplePattern", UnorderedTuplePatternNode,
+                                    DFPatternNode);
 };
 
 /*!
@@ -636,7 +617,8 @@ class UnorderedTuplePatternNode : public DFPatternNode {
 class UnorderedTuplePattern : public DFPattern {
  public:
   TVM_DLL explicit UnorderedTuplePattern(tvm::ffi::Array<DFPattern> fields);
-  TVM_DEFINE_OBJECT_REF_METHODS(UnorderedTuplePattern, DFPattern, UnorderedTuplePatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(UnorderedTuplePattern, DFPattern,
+                                             UnorderedTuplePatternNode);
 };
 
 /*!
@@ -655,9 +637,8 @@ class TupleGetItemPatternNode : public DFPatternNode {
         .def_ro("tuple", &TupleGetItemPatternNode::tuple)
         .def_ro("index", &TupleGetItemPatternNode::index);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.TupleGetItemPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TupleGetItemPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.TupleGetItemPattern", TupleGetItemPatternNode,
+                                    DFPatternNode);
 };
 
 /*!
@@ -667,7 +648,8 @@ class TupleGetItemPatternNode : public DFPatternNode {
 class TupleGetItemPattern : public DFPattern {
  public:
   TVM_DLL TupleGetItemPattern(DFPattern tuple, int index);
-  TVM_DEFINE_OBJECT_REF_METHODS(TupleGetItemPattern, DFPattern, TupleGetItemPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TupleGetItemPattern, DFPattern,
+                                             TupleGetItemPatternNode);
 };
 
 /*!
@@ -685,9 +667,7 @@ class AndPatternNode : public DFPatternNode {
         .def_ro("left", &AndPatternNode::left)
         .def_ro("right", &AndPatternNode::right);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.AndPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AndPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.AndPattern", AndPatternNode, DFPatternNode);
 };
 
 /*!
@@ -697,7 +677,7 @@ class AndPatternNode : public DFPatternNode {
 class AndPattern : public DFPattern {
  public:
   TVM_DLL AndPattern(DFPattern lhs, DFPattern rhs);
-  TVM_DEFINE_OBJECT_REF_METHODS(AndPattern, DFPattern, AndPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(AndPattern, DFPattern, AndPatternNode);
 };
 
 /*!
@@ -715,9 +695,7 @@ class OrPatternNode : public DFPatternNode {
         .def_ro("left", &OrPatternNode::left)
         .def_ro("right", &OrPatternNode::right);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.OrPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(OrPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.OrPattern", OrPatternNode, DFPatternNode);
 };
 
 /*!
@@ -727,7 +705,7 @@ class OrPatternNode : public DFPatternNode {
 class OrPattern : public DFPattern {
  public:
   TVM_DLL OrPattern(DFPattern left, DFPattern right);
-  TVM_DEFINE_OBJECT_REF_METHODS(OrPattern, DFPattern, OrPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(OrPattern, DFPattern, OrPatternNode);
 };
 
 /*!
@@ -742,9 +720,7 @@ class NotPatternNode : public DFPatternNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<NotPatternNode>().def_ro("reject", &NotPatternNode::reject);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.NotPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(NotPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.NotPattern", NotPatternNode, DFPatternNode);
 };
 
 /*!
@@ -754,7 +730,7 @@ class NotPatternNode : public DFPatternNode {
 class NotPattern : public DFPattern {
  public:
   TVM_DLL NotPattern(DFPattern reject);
-  TVM_DEFINE_OBJECT_REF_METHODS(NotPattern, DFPattern, NotPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(NotPattern, DFPattern, NotPatternNode);
 };
 
 /*!
@@ -767,9 +743,8 @@ class WildcardPatternNode : public DFPatternNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<WildcardPatternNode>();
   }
-
-  static constexpr const char* _type_key = "relax.dpl.WildcardPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(WildcardPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.WildcardPattern", WildcardPatternNode,
+                                    DFPatternNode);
 };
 
 /*!
@@ -789,7 +764,7 @@ class WildcardPattern : public DFPattern {
   // nullptr`.  This allows a zero-parameter constructor to be
   // declared here, to create a valid wildcard instance.
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(WildcardPattern, DFPattern, WildcardPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(WildcardPattern, DFPattern, WildcardPatternNode);
 };
 
 /*!
@@ -807,15 +782,14 @@ class StructInfoPatternNode : public DFPatternNode {
         .def_ro("pattern", &StructInfoPatternNode::pattern)
         .def_ro("struct_info", &StructInfoPatternNode::struct_info);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.StructInfoPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(StructInfoPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.StructInfoPattern", StructInfoPatternNode,
+                                    DFPatternNode);
 };
 
 class StructInfoPattern : public DFPattern {
  public:
   TVM_DLL StructInfoPattern(DFPattern pattern, StructInfo struct_info);
-  TVM_DEFINE_OBJECT_REF_METHODS(StructInfoPattern, DFPattern, StructInfoPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(StructInfoPattern, DFPattern, StructInfoPatternNode);
 };
 
 /*!
@@ -833,9 +807,7 @@ class ShapePatternNode : public DFPatternNode {
         .def_ro("pattern", &ShapePatternNode::pattern)
         .def_ro("shape", &ShapePatternNode::shape);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.ShapePattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ShapePatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.ShapePattern", ShapePatternNode, DFPatternNode);
 };
 
 /*!
@@ -845,7 +817,7 @@ class ShapePatternNode : public DFPatternNode {
 class ShapePattern : public DFPattern {
  public:
   TVM_DLL ShapePattern(DFPattern pattern, ffi::Array<PrimExpr> type);
-  TVM_DEFINE_OBJECT_REF_METHODS(ShapePattern, DFPattern, ShapePatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ShapePattern, DFPattern, ShapePatternNode);
 };
 
 /*!
@@ -865,9 +837,8 @@ class SameShapeConstraintNode : public DFConstraintNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<SameShapeConstraintNode>().def_ro("args", &SameShapeConstraintNode::args);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.SameShapeConstraint";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SameShapeConstraintNode, DFConstraintNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.SameShapeConstraint", SameShapeConstraintNode,
+                                    DFConstraintNode);
 };
 
 /*!
@@ -877,7 +848,8 @@ class SameShapeConstraintNode : public DFConstraintNode {
 class SameShapeConstraint : public DFConstraint {
  public:
   TVM_DLL SameShapeConstraint(ffi::Array<DFPattern> args);
-  TVM_DEFINE_OBJECT_REF_METHODS(SameShapeConstraint, DFConstraint, SameShapeConstraintNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(SameShapeConstraint, DFConstraint,
+                                             SameShapeConstraintNode);
 };
 
 /*!
@@ -895,9 +867,8 @@ class DataTypePatternNode : public DFPatternNode {
         .def_ro("pattern", &DataTypePatternNode::pattern)
         .def_ro("dtype", &DataTypePatternNode::dtype);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.DataTypePattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DataTypePatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.DataTypePattern", DataTypePatternNode,
+                                    DFPatternNode);
 };
 
 /*!
@@ -907,7 +878,7 @@ class DataTypePatternNode : public DFPatternNode {
 class DataTypePattern : public DFPattern {
  public:
   TVM_DLL DataTypePattern(DFPattern pattern, DataType dtype);
-  TVM_DEFINE_OBJECT_REF_METHODS(DataTypePattern, DFPattern, DataTypePatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DataTypePattern, DFPattern, DataTypePatternNode);
 };
 
 /*!
@@ -925,9 +896,7 @@ class AttrPatternNode : public DFPatternNode {
         .def_ro("pattern", &AttrPatternNode::pattern)
         .def_ro("attrs", &AttrPatternNode::attrs);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.AttrPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AttrPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.AttrPattern", AttrPatternNode, DFPatternNode);
 };
 
 /*!
@@ -937,7 +906,7 @@ class AttrPatternNode : public DFPatternNode {
 class AttrPattern : public DFPattern {
  public:
   TVM_DLL AttrPattern(DFPattern pattern, DictAttrs attrs);
-  TVM_DEFINE_OBJECT_REF_METHODS(AttrPattern, DFPattern, AttrPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(AttrPattern, DFPattern, AttrPatternNode);
 };
 
 /*!
@@ -957,9 +926,8 @@ class ExternFuncPatternNode : public DFPatternNode {
     refl::ObjectDef<ExternFuncPatternNode>().def_ro("global_symbol",
                                                     &ExternFuncPatternNode::global_symbol_);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.ExternFuncPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ExternFuncPatternNode, DFPatternNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.ExternFuncPattern", ExternFuncPatternNode,
+                                    DFPatternNode);
 };
 
 /*!
@@ -969,7 +937,7 @@ class ExternFuncPatternNode : public DFPatternNode {
 class ExternFuncPattern : public DFPattern {
  public:
   TVM_DLL ExternFuncPattern(ffi::String global_symbol);
-  TVM_DEFINE_OBJECT_REF_METHODS(ExternFuncPattern, DFPattern, ExternFuncPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ExternFuncPattern, DFPattern, ExternFuncPatternNode);
 };
 
 /*! \brief Syntatic Sugar for creating a VarPattern with a name */

--- a/include/tvm/relax/distributed/global_info.h
+++ b/include/tvm/relax/distributed/global_info.h
@@ -52,9 +52,7 @@ class DeviceMeshNode : public GlobalInfoNode {
         .def_ro("device_ids", &DeviceMeshNode::device_ids)
         .def_ro("device_range", &DeviceMeshNode::device_range);
   }
-
-  static constexpr const char* _type_key = "relax.distributed.DeviceMesh";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DeviceMeshNode, GlobalInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.distributed.DeviceMesh", DeviceMeshNode, GlobalInfoNode);
 };
 
 /*!
@@ -65,7 +63,7 @@ class DeviceMesh : public GlobalInfo {
  public:
   TVM_DLL DeviceMesh(ffi::Shape shape, ffi::Array<Integer> device_ids);
   TVM_DLL DeviceMesh(ffi::Shape shape, Range device_range);
-  TVM_DEFINE_OBJECT_REF_METHODS(DeviceMesh, GlobalInfo, DeviceMeshNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DeviceMesh, GlobalInfo, DeviceMeshNode);
 };
 
 }  // namespace distributed

--- a/include/tvm/relax/distributed/struct_info.h
+++ b/include/tvm/relax/distributed/struct_info.h
@@ -51,9 +51,8 @@ class PlacementSpecNode : public Object {
         .def_ro("kind", &PlacementSpecNode::kind);
   }
 
-  static constexpr const char* _type_key = "relax.distributed.PlacementSpec";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindConstTreeNode;
-  TVM_DECLARE_BASE_OBJECT_INFO(PlacementSpecNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.distributed.PlacementSpec", PlacementSpecNode, Object);
 };
 
 /*!
@@ -66,7 +65,7 @@ class PlacementSpec : public ObjectRef {
 
   TVM_DLL static PlacementSpec Replica();
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PlacementSpec, ObjectRef, PlacementSpecNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PlacementSpec, ObjectRef, PlacementSpecNode);
 };
 
 class ShardingNode : public PlacementSpecNode {
@@ -79,7 +78,7 @@ class ShardingNode : public PlacementSpecNode {
     refl::ObjectDef<ShardingNode>().def_ro("sharding_dim", &ShardingNode::sharding_dim);
   }
 
-  TVM_DECLARE_FINAL_OBJECT_INFO(ShardingNode, PlacementSpecNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.distributed.Sharding", ShardingNode, PlacementSpecNode);
 };
 
 /*! \brief Describes how data is distributed in each dimension of the device mesh*/
@@ -96,8 +95,7 @@ class PlacementNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindConstTreeNode;
-  static constexpr const char* _type_key = "relax.distributed.Placement";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PlacementNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.distributed.Placement", PlacementNode, Object);
 };
 
 /*!
@@ -109,7 +107,7 @@ class Placement : public ObjectRef {
   TVM_DLL explicit Placement(ffi::Array<PlacementSpec> dim_specs);
   /*! \brief replica dim is printed as "R" and sharding dim is printed as "S[i]".]*/
   static Placement FromText(ffi::String text_repr);
-  TVM_DEFINE_OBJECT_REF_METHODS(Placement, ObjectRef, PlacementNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Placement, ObjectRef, PlacementNode);
 };
 
 /*!
@@ -137,9 +135,8 @@ class DTensorStructInfoNode : public StructInfoNode {
         .def_ro("placement", &DTensorStructInfoNode::placement)
         .def_ro("tensor_sinfo", &DTensorStructInfoNode::tensor_sinfo);
   }
-
-  static constexpr const char* _type_key = "relax.DTensorStructInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DTensorStructInfoNode, StructInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.DTensorStructInfo", DTensorStructInfoNode,
+                                    StructInfoNode);
 };
 
 /*!
@@ -158,7 +155,7 @@ class DTensorStructInfo : public StructInfo {
   TVM_DLL DTensorStructInfo(TensorStructInfo tensor_sinfo, DeviceMesh device_mesh,
                             Placement placement, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(DTensorStructInfo, StructInfo, DTensorStructInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DTensorStructInfo, StructInfo, DTensorStructInfoNode);
 };
 
 }  // namespace distributed

--- a/include/tvm/relax/exec_builder.h
+++ b/include/tvm/relax/exec_builder.h
@@ -142,8 +142,8 @@ class ExecBuilderNode : public Object {
     refl::ObjectDef<ExecBuilderNode>();
   }
 
-  static constexpr const char* _type_key = "relax.ExecBuilder";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ExecBuilderNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ExecBuilder", ExecBuilderNode, Object);
 
  private:
   /*!
@@ -174,7 +174,7 @@ class ExecBuilderNode : public Object {
 
 class ExecBuilder : public ObjectRef {
  public:
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(ExecBuilder, ObjectRef, ExecBuilderNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ExecBuilder, ObjectRef, ExecBuilderNode);
 };
 
 }  // namespace relax

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -62,9 +62,7 @@ class IdNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindFreeVar;
-  static constexpr const char* _type_key = "relax.Id";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(IdNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.Id", IdNode, Object);
 };
 
 class Id : public ObjectRef {
@@ -75,7 +73,7 @@ class Id : public ObjectRef {
    */
   TVM_DLL explicit Id(ffi::String name_hint);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Id, ObjectRef, IdNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Id, ObjectRef, IdNode);
 };
 
 /*!
@@ -122,10 +120,9 @@ class StructInfoNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "ir.StructInfo";
 
   static constexpr const uint32_t _type_child_slots = 7;
-  TVM_DECLARE_BASE_OBJECT_INFO(StructInfoNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("ir.StructInfo", StructInfoNode, Object);
 };
 
 /*!
@@ -134,7 +131,7 @@ class StructInfoNode : public Object {
  */
 class StructInfo : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(StructInfo, ObjectRef, StructInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(StructInfo, ObjectRef, StructInfoNode);
 };
 
 /*!
@@ -173,9 +170,7 @@ class CallNode : public ExprNode {
         .def_ro("attrs", &CallNode::attrs)
         .def_ro("sinfo_args", &CallNode::sinfo_args);
   }
-
-  static constexpr const char* _type_key = "relax.expr.Call";
-  TVM_DECLARE_FINAL_OBJECT_INFO(CallNode, ExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.Call", CallNode, ExprNode);
 };
 
 class Call : public Expr {
@@ -191,7 +186,7 @@ class Call : public Expr {
   TVM_DLL Call(Expr op, ffi::Array<Expr> args, Attrs attrs = Attrs(),
                ffi::Array<StructInfo> sinfo_args = ffi::Array<StructInfo>(), Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Call, Expr, CallNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Call, Expr, CallNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(CallNode);
 };
 
@@ -217,9 +212,7 @@ class TupleNode : public ExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<TupleNode>().def_ro("fields", &TupleNode::fields);
   }
-
-  static constexpr const char* _type_key = "relax.expr.Tuple";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TupleNode, ExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.Tuple", TupleNode, ExprNode);
 };
 
 class Tuple : public Expr {
@@ -249,7 +242,7 @@ class Tuple : public Expr {
   TVM_DLL explicit Tuple(tvm::ffi::Array<RelaxExpr> fields, Span span = Span())
       : Tuple(fields.Map([](const RelaxExpr& expr) -> Expr { return expr; }), span) {}
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Tuple, Expr, TupleNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Tuple, Expr, TupleNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(TupleNode);
 };
 
@@ -276,9 +269,7 @@ class TupleGetItemNode : public ExprNode {
         .def_ro("tuple_value", &TupleGetItemNode::tuple)
         .def_ro("index", &TupleGetItemNode::index);
   }
-
-  static constexpr const char* _type_key = "relax.expr.TupleGetItem";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TupleGetItemNode, ExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.TupleGetItem", TupleGetItemNode, ExprNode);
 };
 
 class TupleGetItem : public Expr {
@@ -291,7 +282,7 @@ class TupleGetItem : public Expr {
    */
   TVM_DLL TupleGetItem(Expr tuple, int index, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(TupleGetItem, Expr, TupleGetItemNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TupleGetItem, Expr, TupleGetItemNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(TupleGetItemNode);
 };
 
@@ -311,9 +302,8 @@ TupleGetItem WithFields(TupleGetItem tuple_get_item,
  */
 class LeafExprNode : public ExprNode {
  public:
-  static constexpr const char* _type_key = "relax.expr.LeafExpr";
   static constexpr const uint32_t _type_child_slots = 7;
-  TVM_DECLARE_BASE_OBJECT_INFO(LeafExprNode, ExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.expr.LeafExpr", LeafExprNode, ExprNode);
 };
 
 /*!
@@ -322,7 +312,7 @@ class LeafExprNode : public ExprNode {
  */
 class LeafExpr : public Expr {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(LeafExpr, Expr, LeafExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(LeafExpr, Expr, LeafExprNode);
 };
 
 /*! \brief A shape expression which allows users to construct a shape containing PrimExpr.
@@ -336,15 +326,13 @@ class ShapeExprNode : public LeafExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ShapeExprNode>().def_ro("values", &ShapeExprNode::values);
   }
-
-  static constexpr const char* _type_key = "relax.expr.ShapeExpr";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ShapeExprNode, LeafExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.ShapeExpr", ShapeExprNode, LeafExprNode);
 };
 
 class ShapeExpr : public LeafExpr {
  public:
   TVM_DLL explicit ShapeExpr(ffi::Array<PrimExpr> values, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(ShapeExpr, LeafExpr, ShapeExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ShapeExpr, LeafExpr, ShapeExprNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ShapeExprNode);
 };
 
@@ -382,9 +370,8 @@ class VarNode : public LeafExprNode {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindDAGNode;
-  static constexpr const char* _type_key = "relax.expr.Var";
   static constexpr const uint32_t _type_child_slots = 1;
-  TVM_DECLARE_BASE_OBJECT_INFO(VarNode, LeafExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.expr.Var", VarNode, LeafExprNode);
 };
 
 class Var : public LeafExpr {
@@ -395,7 +382,7 @@ class Var : public LeafExpr {
 
   TVM_DLL explicit Var(Id vid, ffi::Optional<StructInfo> struct_info_annotation,
                        Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Var, LeafExpr, VarNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Var, LeafExpr, VarNode);
 
   VarNode* CopyOnWrite();
 };
@@ -411,8 +398,7 @@ class DataflowVarNode : public VarNode {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindDAGNode;
-  static constexpr const char* _type_key = "relax.expr.DataflowVar";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DataflowVarNode, VarNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.DataflowVar", DataflowVarNode, VarNode);
 };
 
 class DataflowVar : public Var {
@@ -424,7 +410,7 @@ class DataflowVar : public Var {
   TVM_DLL explicit DataflowVar(Id vid, ffi::Optional<StructInfo> struct_info_annotation,
                                Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(DataflowVar, Var, DataflowVarNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DataflowVar, Var, DataflowVarNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(DataflowVarNode);
 };
 
@@ -448,9 +434,7 @@ class ConstantNode : public LeafExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ConstantNode>().def_ro("data", &ConstantNode::data);
   }
-
-  static constexpr const char* _type_key = "relax.expr.Constant";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ConstantNode, LeafExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.Constant", ConstantNode, LeafExprNode);
 };
 
 class Constant : public LeafExpr {
@@ -466,7 +450,7 @@ class Constant : public LeafExpr {
                             ffi::Optional<StructInfo> struct_info_annotation = std::nullopt,
                             Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Constant, LeafExpr, ConstantNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Constant, LeafExpr, ConstantNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ConstantNode);
 };
 
@@ -484,9 +468,7 @@ class PrimValueNode : public LeafExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PrimValueNode>().def_ro("value", &PrimValueNode::value);
   }
-
-  static constexpr const char* _type_key = "relax.expr.PrimValue";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PrimValueNode, LeafExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.PrimValue", PrimValueNode, LeafExprNode);
 };
 
 /*!
@@ -510,7 +492,7 @@ class PrimValue : public LeafExpr {
    */
   TVM_DLL static PrimValue Int64(int64_t value, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PrimValue, LeafExpr, PrimValueNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PrimValue, LeafExpr, PrimValueNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(PrimValueNode);
 };
 
@@ -526,9 +508,7 @@ class StringImmNode : public LeafExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<StringImmNode>().def_ro("value", &StringImmNode::value);
   }
-
-  static constexpr const char* _type_key = "relax.expr.StringImm";
-  TVM_DECLARE_FINAL_OBJECT_INFO(StringImmNode, LeafExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.StringImm", StringImmNode, LeafExprNode);
 };
 
 /*!
@@ -544,7 +524,7 @@ class StringImm : public LeafExpr {
    */
   TVM_DLL explicit StringImm(ffi::String value, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(StringImm, LeafExpr, StringImmNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(StringImm, LeafExpr, StringImmNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(StringImmNode);
 };
 
@@ -560,9 +540,7 @@ class DataTypeImmNode : public LeafExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<DataTypeImmNode>().def_ro("value", &DataTypeImmNode::value);
   }
-
-  static constexpr const char* _type_key = "relax.expr.DataTypeImm";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DataTypeImmNode, LeafExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.DataTypeImm", DataTypeImmNode, LeafExprNode);
 };
 
 /*!
@@ -578,7 +556,7 @@ class DataTypeImm : public LeafExpr {
    */
   TVM_DLL explicit DataTypeImm(DataType value, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(DataTypeImm, LeafExpr, DataTypeImmNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DataTypeImm, LeafExpr, DataTypeImmNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(DataTypeImmNode);
 };
 
@@ -596,10 +574,9 @@ class BindingNode : public Object {
         .def_ro("var", &BindingNode::var, refl::AttachFieldFlag::SEqHashDef());
   }
 
-  static constexpr const char* _type_key = "relax.expr.Binding";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
 
-  TVM_DECLARE_BASE_OBJECT_INFO(BindingNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.expr.Binding", BindingNode, Object);
 };
 
 class Binding : public ObjectRef {
@@ -635,9 +612,7 @@ class MatchCastNode : public BindingNode {
         .def_ro("value", &MatchCastNode::value)
         .def_ro("struct_info", &MatchCastNode::struct_info, refl::AttachFieldFlag::SEqHashDef());
   }
-
-  static constexpr const char* _type_key = "relax.expr.MatchCast";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MatchCastNode, BindingNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.MatchCast", MatchCastNode, BindingNode);
 };
 
 /*!
@@ -648,7 +623,7 @@ class MatchCast : public Binding {
  public:
   TVM_DLL explicit MatchCast(Var var, Expr value, StructInfo struct_info, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(MatchCast, Binding, MatchCastNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MatchCast, Binding, MatchCastNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(MatchCastNode);
 };
 
@@ -670,16 +645,13 @@ class VarBindingNode : public BindingNode {
               ffi::TypedFunction<bool(AnyView, AnyView, bool, AnyView)> equal) const;
   uint64_t SHash(uint64_t init_hash,
                  ffi::TypedFunction<uint64_t(AnyView, uint64_t, bool)> hash) const;
-
-  static constexpr const char* _type_key = "relax.expr.VarBinding";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(VarBindingNode, BindingNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.VarBinding", VarBindingNode, BindingNode);
 };
 
 class VarBinding : public Binding {
  public:
   TVM_DLL explicit VarBinding(Var var, Expr value, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(VarBinding, Binding, VarBindingNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(VarBinding, Binding, VarBindingNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(VarBindingNode);
 };
 
@@ -697,15 +669,13 @@ class BindingBlockNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "relax.expr.BindingBlock";
-
-  TVM_DECLARE_BASE_OBJECT_INFO(BindingBlockNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.expr.BindingBlock", BindingBlockNode, Object);
 };
 
 class BindingBlock : public ObjectRef {
  public:
   TVM_DLL explicit BindingBlock(ffi::Array<Binding> bindings, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(BindingBlock, ObjectRef, BindingBlockNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BindingBlock, ObjectRef, BindingBlockNode);
 
   BindingBlockNode* CopyOnWrite();
 };
@@ -716,16 +686,14 @@ class DataflowBlockNode : public BindingBlockNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<DataflowBlockNode>();
   }
-
-  static constexpr const char* _type_key = "relax.expr.DataflowBlock";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(DataflowBlockNode, BindingBlockNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.DataflowBlock", DataflowBlockNode,
+                                    BindingBlockNode);
 };
 
 class DataflowBlock : public BindingBlock {
  public:
   TVM_DLL explicit DataflowBlock(ffi::Array<Binding> bindings, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(DataflowBlock, BindingBlock, DataflowBlockNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DataflowBlock, BindingBlock, DataflowBlockNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(DataflowBlockNode);
 };
 
@@ -744,10 +712,7 @@ class SeqExprNode : public ExprNode {
         .def_ro("blocks", &SeqExprNode::blocks)
         .def_ro("body", &SeqExprNode::body);
   }
-
-  static constexpr const char* _type_key = "relax.expr.SeqExpr";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(SeqExprNode, ExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.SeqExpr", SeqExprNode, ExprNode);
 };
 
 class SeqExpr : public Expr {
@@ -766,7 +731,7 @@ class SeqExpr : public Expr {
   TVM_DLL SeqExpr(Expr body);  // NOLINT(*)
 
   TVM_DLL explicit SeqExpr(ffi::Array<BindingBlock> blocks, Expr body, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(SeqExpr, Expr, SeqExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(SeqExpr, Expr, SeqExprNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(SeqExprNode);
 };
 
@@ -799,8 +764,7 @@ class IfNode : public ExprNode {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindDAGNode;
-  static constexpr const char* _type_key = "relax.expr.If";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IfNode, ExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.If", IfNode, ExprNode);
 };
 
 class If : public Expr {
@@ -824,7 +788,7 @@ class If : public Expr {
    */
   TVM_DLL If(Expr cond, Expr true_branch, Expr false_branch, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(If, Expr, IfNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(If, Expr, IfNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(IfNode);
 };
 
@@ -860,8 +824,7 @@ class FunctionNode : public BaseFuncNode {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindDAGNode;
-  static constexpr const char* _type_key = "relax.expr.Function";
-  TVM_DECLARE_FINAL_OBJECT_INFO(FunctionNode, BaseFuncNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.Function", FunctionNode, BaseFuncNode);
 };
 
 class Function : public BaseFunc {
@@ -899,7 +862,7 @@ class Function : public BaseFunc {
                                       bool is_pure = true, DictAttrs attrs = DictAttrs(),
                                       Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Function, BaseFunc, FunctionNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Function, BaseFunc, FunctionNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(FunctionNode);
 };
 
@@ -944,9 +907,7 @@ class ExternFuncNode : public BaseFuncNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ExternFuncNode>().def_ro("global_symbol", &ExternFuncNode::global_symbol);
   }
-
-  static constexpr const char* _type_key = "relax.expr.ExternFunc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ExternFuncNode, BaseFuncNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.ExternFunc", ExternFuncNode, BaseFuncNode);
 };
 
 class ExternFunc : public BaseFunc {
@@ -954,7 +915,7 @@ class ExternFunc : public BaseFunc {
   TVM_DLL ExternFunc(ffi::String global_symbol, Span span = Span());
   TVM_DLL ExternFunc(ffi::String global_symbol, StructInfo struct_info, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ExternFunc, BaseFunc, ExternFuncNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ExternFunc, BaseFunc, ExternFuncNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ExternFuncNode);
 };
 

--- a/include/tvm/relax/struct_info.h
+++ b/include/tvm/relax/struct_info.h
@@ -41,9 +41,7 @@ class ObjectStructInfoNode : public StructInfoNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ObjectStructInfoNode>();
   }
-
-  static constexpr const char* _type_key = "relax.ObjectStructInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ObjectStructInfoNode, StructInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ObjectStructInfo", ObjectStructInfoNode, StructInfoNode);
 };
 
 /*!
@@ -54,7 +52,7 @@ class ObjectStructInfo : public StructInfo {
  public:
   TVM_DLL ObjectStructInfo(Span span = Span());
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ObjectStructInfo, StructInfo, ObjectStructInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ObjectStructInfo, StructInfo, ObjectStructInfoNode);
 };
 
 /*!
@@ -74,9 +72,7 @@ class PrimStructInfoNode : public StructInfoNode {
         .def_ro("value", &PrimStructInfoNode::value)
         .def_ro("dtype", &PrimStructInfoNode::dtype);
   }
-
-  static constexpr const char* _type_key = "relax.PrimStructInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PrimStructInfoNode, StructInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.PrimStructInfo", PrimStructInfoNode, StructInfoNode);
 };
 
 /*!
@@ -91,7 +87,7 @@ class PrimStructInfo : public StructInfo {
   /* Construct a PrimStructInfo with a known value */
   TVM_DLL PrimStructInfo(PrimExpr value, Span span = Span());
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(PrimStructInfo, StructInfo, PrimStructInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(PrimStructInfo, StructInfo, PrimStructInfoNode);
 };
 
 /*!
@@ -116,9 +112,7 @@ class ShapeStructInfoNode : public StructInfoNode {
         .def_ro("values", &ShapeStructInfoNode::values)
         .def_ro("ndim", &ShapeStructInfoNode::ndim);
   }
-
-  static constexpr const char* _type_key = "relax.ShapeStructInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ShapeStructInfoNode, StructInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ShapeStructInfo", ShapeStructInfoNode, StructInfoNode);
 };
 
 /*!
@@ -140,7 +134,7 @@ class ShapeStructInfo : public StructInfo {
    */
   TVM_DLL ShapeStructInfo(int ndim, Span span = Span());
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ShapeStructInfo, StructInfo, ShapeStructInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ShapeStructInfo, StructInfo, ShapeStructInfoNode);
 };
 
 /*!
@@ -186,9 +180,7 @@ class TensorStructInfoNode : public StructInfoNode {
         .def_ro("vdevice", &TensorStructInfoNode::vdevice)
         .def_ro("ndim", &TensorStructInfoNode::ndim);
   }
-
-  static constexpr const char* _type_key = "relax.TensorStructInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TensorStructInfoNode, StructInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.TensorStructInfo", TensorStructInfoNode, StructInfoNode);
 };
 
 /*!
@@ -219,7 +211,7 @@ class TensorStructInfo : public StructInfo {
   TVM_DLL TensorStructInfo(DataType dtype, int ndim, ffi::Optional<VDevice> vdevice = std::nullopt,
                            Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(TensorStructInfo, StructInfo, TensorStructInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TensorStructInfo, StructInfo, TensorStructInfoNode);
 };
 
 /*!
@@ -234,9 +226,7 @@ class TupleStructInfoNode : public StructInfoNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<TupleStructInfoNode>().def_ro("fields", &TupleStructInfoNode::fields);
   }
-
-  static constexpr const char* _type_key = "relax.TupleStructInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TupleStructInfoNode, StructInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.TupleStructInfo", TupleStructInfoNode, StructInfoNode);
 };
 
 /*!
@@ -252,7 +242,7 @@ class TupleStructInfo : public StructInfo {
    */
   TVM_DLL TupleStructInfo(ffi::Array<StructInfo> fields, Span span = Span());
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TupleStructInfo, StructInfo, TupleStructInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TupleStructInfo, StructInfo, TupleStructInfoNode);
 };
 
 /*!
@@ -308,9 +298,7 @@ class FuncStructInfoNode : public StructInfoNode {
         .def_ro("derive_func", &FuncStructInfoNode::derive_func)
         .def_ro("purity", &FuncStructInfoNode::purity);
   }
-
-  static constexpr const char* _type_key = "relax.FuncStructInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(FuncStructInfoNode, StructInfoNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.FuncStructInfo", FuncStructInfoNode, StructInfoNode);
 };
 
 /*!
@@ -364,7 +352,7 @@ class FuncStructInfo : public StructInfo {
   TVM_DLL static FuncStructInfo OpaqueFunc(StructInfo ret = ObjectStructInfo(), bool purity = false,
                                            Span span = Span());
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(FuncStructInfo, StructInfo, FuncStructInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(FuncStructInfo, StructInfo, FuncStructInfoNode);
 };
 
 /*!

--- a/include/tvm/relax/tir_pattern.h
+++ b/include/tvm/relax/tir_pattern.h
@@ -52,9 +52,7 @@ class MatchResultNode : public Object {
         .def_ro("symbol_values", &MatchResultNode::symbol_values)
         .def_ro("matched_buffers", &MatchResultNode::matched_buffers);
   }
-
-  static constexpr const char* _type_key = "relax.MatchResult";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MatchResultNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.MatchResult", MatchResultNode, Object);
 };
 
 /*!
@@ -71,7 +69,7 @@ class MatchResult : public ObjectRef {
   TVM_DLL explicit MatchResult(TIRPattern pattern, ffi::Array<PrimExpr> symbol_values,
                                ffi::Array<tir::Buffer> matched_buffers);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(MatchResult, ObjectRef, MatchResultNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MatchResult, ObjectRef, MatchResultNode);
 };
 
 using FCodegen = ffi::TypedFunction<ffi::Array<ffi::Any>(ffi::Array<MatchResult> match_results)>;

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -406,9 +406,7 @@ class FusionPatternNode : public Object {
         .def_ro("check", &FusionPatternNode::check)
         .def_ro("attrs_getter", &FusionPatternNode::attrs_getter);
   }
-
-  static constexpr const char* _type_key = "relax.transform.FusionPattern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(FusionPatternNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.transform.FusionPattern", FusionPatternNode, Object);
 };
 
 class FusionPattern : public ObjectRef {
@@ -420,7 +418,7 @@ class FusionPattern : public ObjectRef {
   FusionPattern(ffi::String name, DFPattern pattern)
       : FusionPattern(name, pattern, {}, std::nullopt, std::nullopt) {}
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(FusionPattern, ObjectRef, FusionPatternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(FusionPattern, ObjectRef, FusionPatternNode);
 };
 
 /*!
@@ -466,9 +464,8 @@ class PatternCheckContextNode : public Object {
         .def_ro("var_usages", &PatternCheckContextNode::var_usages)
         .def_ro("value_to_bound_var", &PatternCheckContextNode::value_to_bound_var);
   }
-
-  static constexpr const char* _type_key = "relax.transform.PatternCheckContext";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PatternCheckContextNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.transform.PatternCheckContext", PatternCheckContextNode,
+                                    Object);
 };
 
 class PatternCheckContext : public ObjectRef {
@@ -478,8 +475,8 @@ class PatternCheckContext : public ObjectRef {
                       ffi::Map<Var, ffi::Array<Var>> var_usages,
                       ffi::Map<Expr, Var> value_to_bound_var);
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(PatternCheckContext, ObjectRef,
-                                            PatternCheckContextNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(PatternCheckContext, ObjectRef,
+                                                PatternCheckContextNode);
 };
 
 /*!

--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -48,9 +48,7 @@ class ShapeTypeNode : public TypeNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ShapeTypeNode>().def_ro("ndim", &ShapeTypeNode::ndim);
   }
-
-  static constexpr const char* _type_key = "relax.ShapeType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ShapeTypeNode, TypeNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ShapeType", ShapeTypeNode, TypeNode);
 };
 
 class ShapeType : public Type {
@@ -58,7 +56,7 @@ class ShapeType : public Type {
   // TODO(relax-team): remove the default value later.
   TVM_DLL ShapeType(int ndim = kUnknownNDim, Span span = Span());
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ShapeType, Type, ShapeTypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ShapeType, Type, ShapeTypeNode);
 };
 
 /*!
@@ -86,9 +84,7 @@ class TensorTypeNode : public TypeNode {
   inline bool IsUnknownNdim() const { return ndim == kUnknownNDim; }
 
   inline bool IsUnknownDtype() const { return dtype.is_void(); }
-
-  static constexpr const char* _type_key = "relax.DynTensorType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TensorTypeNode, TypeNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.DynTensorType", TensorTypeNode, TypeNode);
 };
 
 /*!
@@ -110,7 +106,7 @@ class TensorType : public Type {
    */
   TVM_DLL static TensorType CreateUnknownNDim(DataType dtype, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(TensorType, Type, TensorTypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TensorType, Type, TensorTypeNode);
 };
 
 using TensorTypeNode = TensorTypeNode;
@@ -122,16 +118,14 @@ class ObjectTypeNode : public TypeNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ObjectTypeNode>();
   }
-
-  static constexpr const char* _type_key = "relax.ObjectType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ObjectTypeNode, TypeNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ObjectType", ObjectTypeNode, TypeNode);
 };
 
 class ObjectType : public Type {
  public:
   TVM_DLL ObjectType(Span span = Span());
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ObjectType, Type, ObjectTypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ObjectType, Type, ObjectTypeNode);
 };
 
 class PackedFuncTypeNode : public TypeNode {
@@ -140,16 +134,14 @@ class PackedFuncTypeNode : public TypeNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PackedFuncTypeNode>();
   }
-
-  static constexpr const char* _type_key = "relax.PackedFuncType";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PackedFuncTypeNode, TypeNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.PackedFuncType", PackedFuncTypeNode, TypeNode);
 };
 
 class PackedFuncType : public Type {
  public:
   TVM_DLL PackedFuncType(Span span = Span());
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(PackedFuncType, Type, PackedFuncTypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(PackedFuncType, Type, PackedFuncTypeNode);
 };
 
 }  // namespace relax

--- a/include/tvm/runtime/disco/cuda_ipc_memory.h
+++ b/include/tvm/runtime/disco/cuda_ipc_memory.h
@@ -69,9 +69,7 @@ class CUDAIPCMemoryObj : public Object {
   std::vector<void*> barrier_out;
   /*! \brief The integer buffer flag for all-reduce. */
   int barrier_flag;
-
-  static constexpr const char* _type_key = "tvm.runtime.disco.cuda_ipc_memory";
-  TVM_DECLARE_BASE_OBJECT_INFO(CUDAIPCMemoryObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("tvm.runtime.disco.cuda_ipc_memory", CUDAIPCMemoryObj, Object);
 };
 
 /*!
@@ -90,7 +88,7 @@ class CUDAIPCMemory : public ObjectRef {
    */
   TVM_DLL static CUDAIPCMemory GetIPCMemoryFromDevicePtr(void* ptr);
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(CUDAIPCMemory, ObjectRef, CUDAIPCMemoryObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(CUDAIPCMemory, ObjectRef, CUDAIPCMemoryObj);
 };
 
 }  // namespace cuda_ipc

--- a/include/tvm/runtime/disco/session.h
+++ b/include/tvm/runtime/disco/session.h
@@ -149,10 +149,9 @@ class DRefObj : public Object {
    */
   inline void DebugCopyFrom(int worker_id, ffi::AnyView source);
 
-  static constexpr const char* _type_key = "runtime.disco.DRef";
   static constexpr const uint32_t _type_index = TypeIndex::kRuntimeDiscoDRef;
   static const constexpr bool _type_final = true;
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(DRefObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC("runtime.disco.DRef", DRefObj, Object);
 
   /*! \brief The id of the register */
   int64_t reg_id;
@@ -171,7 +170,7 @@ class DRefObj : public Object {
 class DRef : public ObjectRef {
  public:
   explicit DRef(ObjectPtr<DRefObj> data) : ObjectRef(data) { TVM_FFI_ICHECK(data != nullptr); }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(DRef, ObjectRef, DRefObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(DRef, ObjectRef, DRefObj);
 };
 
 /*!
@@ -255,8 +254,9 @@ class SessionObj : public Object {
   struct FFI;
   friend struct SessionObj::FFI;
   friend class DRefObj;
-  static constexpr const char* _type_key = "runtime.disco.Session";
-  TVM_DECLARE_BASE_OBJECT_INFO(SessionObj, Object);
+
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("runtime.disco.Session", SessionObj, Object);
 
  protected:
   /*! \brief Deallocate a register id, kill it on all workers, and append it to `free_regs_`. */
@@ -290,7 +290,7 @@ class Session : public ObjectRef {
   TVM_DLL static Session ProcessSession(int num_workers, int num_groups,
                                         ffi::String process_pool_creator, ffi::String entrypoint);
 
-  TVM_FFI_DEFINE_MUTABLE_OBJECT_REF_METHODS(Session, ObjectRef, SessionObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Session, ObjectRef, SessionObj);
 };
 
 /*!

--- a/include/tvm/runtime/memory/memory_manager.h
+++ b/include/tvm/runtime/memory/memory_manager.h
@@ -176,8 +176,8 @@ class StorageObj : public Object {
     }
   }
 
-  static constexpr const char* _type_key = "vm.Storage";
-  TVM_DECLARE_FINAL_OBJECT_INFO(StorageObj, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("vm.Storage", StorageObj, Object);
 };
 
 /*! \brief reference to storage. */
@@ -185,7 +185,7 @@ class Storage : public ObjectRef {
  public:
   TVM_DLL explicit Storage(Buffer buffer, Allocator* allocator);
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Storage, ObjectRef, StorageObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Storage, ObjectRef, StorageObj);
 };
 
 }  // namespace memory

--- a/include/tvm/runtime/object.h
+++ b/include/tvm/runtime/object.h
@@ -106,18 +106,18 @@ static_assert(static_cast<int>(TypeIndex::kCustomStaticIndex) >=
  *
  * \endcode
  */
-#define TVM_DEFINE_OBJECT_REF_COW_METHOD(ObjectName)                 \
-  static_assert(ObjectName::_type_final,                             \
-                "TVM's CopyOnWrite may only be used for "            \
-                "Object types that are declared as final, "          \
-                "using the TVM_DECLARE_FINAL_OBJECT_INFO macro.");   \
-  ObjectName* CopyOnWrite() {                                        \
-    ICHECK(data_ != nullptr);                                        \
-    if (!data_.unique()) {                                           \
-      auto n = ::tvm::ffi::make_object<ObjectName>(*(operator->())); \
-      ObjectPtr<Object>(std::move(n)).swap(data_);                   \
-    }                                                                \
-    return static_cast<ObjectName*>(data_.get());                    \
+#define TVM_DEFINE_OBJECT_REF_COW_METHOD(ObjectName)                   \
+  static_assert(ObjectName::_type_final,                               \
+                "TVM's CopyOnWrite may only be used for "              \
+                "Object types that are declared as final, "            \
+                "using the TVM_FFI_DECLARE_OBJECT_INFO_FINAL macro."); \
+  ObjectName* CopyOnWrite() {                                          \
+    ICHECK(data_ != nullptr);                                          \
+    if (!data_.unique()) {                                             \
+      auto n = ::tvm::ffi::make_object<ObjectName>(*(operator->()));   \
+      ObjectPtr<Object>(std::move(n)).swap(data_);                     \
+    }                                                                  \
+    return static_cast<ObjectName*>(data_.get());                      \
   }
 
 /*
@@ -126,22 +126,13 @@ static_assert(static_cast<int>(TypeIndex::kCustomStaticIndex) >=
  * \param ParentType The parent type of the objectref
  * \param ObjectName The type name of the object.
  */
-#define TVM_DEFINE_OBJECT_REF_METHODS_WITHOUT_DEFAULT_CONSTRUCTOR(TypeName, ParentType,        \
-                                                                  ObjectName)                  \
+#define TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE_WITHOUT_DEFAULT_CONSTRUCTOR(                \
+    TypeName, ParentType, ObjectName)                                                          \
   explicit TypeName(::tvm::ffi::ObjectPtr<ObjectName> n) : ParentType(n) {}                    \
   TVM_DEFINE_DEFAULT_COPY_MOVE_AND_ASSIGN(TypeName);                                           \
   const ObjectName* operator->() const { return static_cast<const ObjectName*>(data_.get()); } \
   const ObjectName* get() const { return operator->(); }                                       \
   using ContainerType = ObjectName;
-
-#define TVM_DECLARE_BASE_OBJECT_INFO TVM_FFI_DECLARE_BASE_OBJECT_INFO
-#define TVM_DECLARE_FINAL_OBJECT_INFO TVM_FFI_DECLARE_FINAL_OBJECT_INFO
-#define TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS TVM_FFI_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS
-
-#define TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS TVM_FFI_DEFINE_MUTABLE_OBJECT_REF_METHODS
-#define TVM_DEFINE_OBJECT_REF_METHODS TVM_FFI_DEFINE_OBJECT_REF_METHODS
-#define TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS \
-  TVM_FFI_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS
 
 #define TVM_STR_CONCAT_(__x, __y) __x##__y
 #define TVM_STR_CONCAT(__x, __y) TVM_STR_CONCAT_(__x, __y)

--- a/include/tvm/runtime/profiling.h
+++ b/include/tvm/runtime/profiling.h
@@ -75,8 +75,8 @@ class TimerNode : public Object {
 
   virtual ~TimerNode() {}
 
-  static constexpr const char* _type_key = "runtime.TimerNode";
-  TVM_DECLARE_BASE_OBJECT_INFO(TimerNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("runtime.TimerNode", TimerNode, Object);
 };
 
 /*! \brief Timer for a specific device.
@@ -126,7 +126,7 @@ class Timer : public ObjectRef {
    *    virtual ~CPUTimerNode() {}
    *
    *    static constexpr const char* _type_key = "runtime.CPUTimerNode";
-   *    TVM_DECLARE_FINAL_OBJECT_INFO(CPUTimerNode, TimerNode);
+   *    TVM_FFI_DECLARE_OBJECT_INFO_FINAL(CPUTimerNode, TimerNode);
    *
    *   private:
    *    std::chrono::high_resolution_clock::time_point start_;
@@ -144,7 +144,7 @@ class Timer : public ObjectRef {
    */
   static TVM_DLL Timer Start(Device dev);
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Timer, ObjectRef, TimerNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Timer, ObjectRef, TimerNode);
 };
 
 /*!
@@ -166,16 +166,14 @@ struct DeviceWrapperNode : public Object {
 
   /*! Constructor */
   explicit DeviceWrapperNode(Device device) : device(device) {}
-
-  static constexpr const char* _type_key = "runtime.profiling.DeviceWrapper";
-  TVM_DECLARE_BASE_OBJECT_INFO(DeviceWrapperNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("runtime.profiling.DeviceWrapper", DeviceWrapperNode, Object);
 };
 
 /*! \brief Wrapper for `Device`. */
 class DeviceWrapper : public ObjectRef {
  public:
   explicit DeviceWrapper(Device dev) { data_ = ffi::make_object<DeviceWrapperNode>(dev); }
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(DeviceWrapper, ObjectRef, DeviceWrapperNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DeviceWrapper, ObjectRef, DeviceWrapperNode);
 };
 
 /*! \brief Data collected from a profiling run. Includes per-call metrics and per-device metrics.
@@ -256,9 +254,7 @@ class ReportNode : public Object {
    * \endcode
    */
   ffi::String AsJSON() const;
-
-  static constexpr const char* _type_key = "runtime.profiling.Report";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ReportNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.profiling.Report", ReportNode, Object);
 };
 
 class Report : public ObjectRef {
@@ -277,7 +273,7 @@ class Report : public ObjectRef {
    * \returns A Report.
    */
   static Report FromJSON(ffi::String json);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(Report, ObjectRef, ReportNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Report, ObjectRef, ReportNode);
 };
 
 /*! \brief Interface for user defined profiling metric collection.
@@ -321,14 +317,14 @@ class MetricCollectorNode : public Object {
 
   virtual ~MetricCollectorNode() {}
 
-  static constexpr const char* _type_key = "runtime.profiling.MetricCollector";
-  TVM_DECLARE_BASE_OBJECT_INFO(MetricCollectorNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("runtime.profiling.MetricCollector", MetricCollectorNode, Object);
 };
 
 /*! \brief Wrapper for `MetricCollectorNode`. */
 class MetricCollector : public ObjectRef {
  public:
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(MetricCollector, ObjectRef, MetricCollectorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MetricCollector, ObjectRef, MetricCollectorNode);
 };
 
 /*! Information about a single function or operator call. */
@@ -440,9 +436,7 @@ class DurationNode : public Object {
    * \param a The duration in microseconds.
    */
   explicit DurationNode(double a) : microseconds(a) {}
-
-  static constexpr const char* _type_key = "runtime.profiling.Duration";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DurationNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.profiling.Duration", DurationNode, Object);
 };
 
 /* A percentage of something */
@@ -455,9 +449,7 @@ class PercentNode : public Object {
    * \param a The percentage out of 100.
    */
   explicit PercentNode(double a) : percent(a) {}
-
-  static constexpr const char* _type_key = "runtime.profiling.Percent";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PercentNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.profiling.Percent", PercentNode, Object);
 };
 
 /* A count of something */
@@ -470,9 +462,7 @@ class CountNode : public Object {
    * \param a The count.
    */
   explicit CountNode(int64_t a) : value(a) {}
-
-  static constexpr const char* _type_key = "runtime.profiling.Count";
-  TVM_DECLARE_FINAL_OBJECT_INFO(CountNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.profiling.Count", CountNode, Object);
 };
 
 /* \brief A ratio of two things. */
@@ -485,9 +475,7 @@ class RatioNode : public Object {
    * \param a The ratio.
    */
   explicit RatioNode(double a) : ratio(a) {}
-
-  static constexpr const char* _type_key = "runtime.profiling.Ratio";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RatioNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.profiling.Ratio", RatioNode, Object);
 };
 
 /*! \brief ffi::String representation of an array of Tensor shapes

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -77,16 +77,14 @@ class VMClosureObj : public Object {
    *       the same arguments as the normal function call.
    */
   ffi::Function impl;
-
-  static constexpr const char* _type_key = "relax.vm.Closure";
-  TVM_DECLARE_FINAL_OBJECT_INFO(VMClosureObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.vm.Closure", VMClosureObj, Object);
 };
 
 /*! \brief reference to closure. */
 class VMClosure : public ObjectRef {
  public:
   VMClosure(ffi::String func_name, ffi::Function impl);
-  TVM_DEFINE_OBJECT_REF_METHODS(VMClosure, ObjectRef, VMClosureObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(VMClosure, ObjectRef, VMClosureObj);
 
   /*!
    * \brief Create another ffi::Function with last arguments already bound to last_args.
@@ -109,14 +107,13 @@ class VMClosure : public ObjectRef {
  */
 class VMExtensionNode : public Object {
  protected:
-  static constexpr const char* _type_key = "runtime.VMExtension";
-  TVM_DECLARE_BASE_OBJECT_INFO(VMExtensionNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("runtime.VMExtension", VMExtensionNode, Object);
 };
 
 /*! \brief Managed reference to VM extension. */
 class VMExtension : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(VMExtension, ObjectRef, VMExtensionNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(VMExtension, ObjectRef, VMExtensionNode);
 };
 
 /*!

--- a/include/tvm/script/ir_builder/base.h
+++ b/include/tvm/script/ir_builder/base.h
@@ -73,8 +73,9 @@ class IRBuilderFrameNode : public runtime::Object {
     // `callbacks` is not registered as it's not visited.
   }
 
-  static constexpr const char* _type_key = "script.ir_builder.IRBuilderFrame";
-  TVM_DECLARE_BASE_OBJECT_INFO(IRBuilderFrameNode, runtime::Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("script.ir_builder.IRBuilderFrame", IRBuilderFrameNode,
+                              runtime::Object);
 
  public:
   /*! \brief Default destructor. */
@@ -102,7 +103,7 @@ class IRBuilderFrameNode : public runtime::Object {
  */
 class IRBuilderFrame : public runtime::ObjectRef {
  public:
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(IRBuilderFrame, ObjectRef, IRBuilderFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(IRBuilderFrame, ObjectRef, IRBuilderFrameNode);
 
  protected:
   /*! \brief Disallow direct construction of this object. */
@@ -169,8 +170,8 @@ class IRBuilderNode : public runtime::Object {
         .def_ro("result", &IRBuilderNode::result);
   }
 
-  static constexpr const char* _type_key = "script.ir_builder.IRBuilder";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IRBuilderNode, runtime::Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.IRBuilder", IRBuilderNode, runtime::Object);
 
  public:
   /*!
@@ -205,7 +206,7 @@ class IRBuilder : public runtime::ObjectRef {
  public:
   /*! \brief Creates an IRBuilder. */
   IRBuilder();
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(IRBuilder, ObjectRef, IRBuilderNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(IRBuilder, ObjectRef, IRBuilderNode);
 
  public:
   /*!

--- a/include/tvm/script/ir_builder/ir/frame.h
+++ b/include/tvm/script/ir_builder/ir/frame.h
@@ -60,9 +60,8 @@ class IRModuleFrameNode : public IRBuilderFrameNode {
         .def_ro("attrs", &IRModuleFrameNode::attrs)
         .def_ro("global_infos", &IRModuleFrameNode::global_infos);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.IRModuleFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IRModuleFrameNode, IRBuilderFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.IRModuleFrame", IRModuleFrameNode,
+                                    IRBuilderFrameNode);
 
  public:
   void ExitWithScope() final;
@@ -78,8 +77,7 @@ class IRModuleFrame : public IRBuilderFrame {
   explicit IRModuleFrame(ObjectPtr<IRModuleFrameNode> data) : IRBuilderFrame(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(IRModuleFrame, IRBuilderFrame,
-                                                    IRModuleFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(IRModuleFrame, IRBuilderFrame, IRModuleFrameNode);
 };
 
 }  // namespace ir

--- a/include/tvm/script/ir_builder/relax/frame.h
+++ b/include/tvm/script/ir_builder/relax/frame.h
@@ -40,9 +40,8 @@ class RelaxFrameNode : public IRBuilderFrameNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<RelaxFrameNode>();
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.relax.RelaxFrame";
-  TVM_DECLARE_BASE_OBJECT_INFO(RelaxFrameNode, IRBuilderFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("script.ir_builder.relax.RelaxFrame", RelaxFrameNode,
+                              IRBuilderFrameNode);
 };
 
 class RelaxFrame : public IRBuilderFrame {
@@ -51,7 +50,7 @@ class RelaxFrame : public IRBuilderFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(RelaxFrame, IRBuilderFrame, RelaxFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(RelaxFrame, IRBuilderFrame, RelaxFrameNode);
 
  protected:
   RelaxFrame() = default;
@@ -73,9 +72,8 @@ class SeqExprFrameNode : public RelaxFrameNode {
         .def_ro("binding_blocks", &SeqExprFrameNode::binding_blocks)
         .def_ro("output", &SeqExprFrameNode::output);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.relax.SeqExprFrame";
-  TVM_DECLARE_BASE_OBJECT_INFO(SeqExprFrameNode, RelaxFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("script.ir_builder.relax.SeqExprFrame", SeqExprFrameNode,
+                              RelaxFrameNode);
 
  public:
   void EnterWithScope() override;
@@ -87,7 +85,7 @@ class SeqExprFrame : public RelaxFrame {
   explicit SeqExprFrame(ObjectPtr<SeqExprFrameNode> data) : RelaxFrame(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(SeqExprFrame, RelaxFrame, SeqExprFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(SeqExprFrame, RelaxFrame, SeqExprFrameNode);
 };
 
 /*! \brief The ir_builder frame for the relax function. */
@@ -132,9 +130,8 @@ class FunctionFrameNode : public SeqExprFrameNode {
         .def_ro("output", &FunctionFrameNode::output);
     // `block_builder` is not registered as it's not visited.
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.relax.FunctionFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(FunctionFrameNode, SeqExprFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.relax.FunctionFrame", FunctionFrameNode,
+                                    SeqExprFrameNode);
 
  public:
   void EnterWithScope() final;
@@ -146,7 +143,7 @@ class FunctionFrame : public SeqExprFrame {
   explicit FunctionFrame(ObjectPtr<FunctionFrameNode> data) : SeqExprFrame(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(FunctionFrame, SeqExprFrame, FunctionFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(FunctionFrame, SeqExprFrame, FunctionFrameNode);
 };
 
 /*! \brief The ir_builder frame for relax binding blocks. */
@@ -176,9 +173,8 @@ class BlockFrameNode : public RelaxFrameNode {
         .def_ro("output_vars", &BlockFrameNode::output_vars);
     // `block_ended` is not registered as it's not visited.
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.relax.BlockFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BlockFrameNode, RelaxFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.relax.BlockFrame", BlockFrameNode,
+                                    RelaxFrameNode);
 
  public:
   void EnterWithScope() final;
@@ -190,7 +186,7 @@ class BlockFrame : public RelaxFrame {
   explicit BlockFrame(ObjectPtr<BlockFrameNode> data) : RelaxFrame(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(BlockFrame, RelaxFrame, BlockFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(BlockFrame, RelaxFrame, BlockFrameNode);
 };
 
 /*!
@@ -220,9 +216,7 @@ class IfFrameNode : public RelaxFrameNode {
         .def_ro("var", &IfFrameNode::var)
         .def_ro("var_name", &IfFrameNode::var_name);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.relax.IfFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IfFrameNode, RelaxFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.relax.IfFrame", IfFrameNode, RelaxFrameNode);
 
  public:
   /*!
@@ -247,7 +241,7 @@ class IfFrame : public RelaxFrame {
   explicit IfFrame(ObjectPtr<IfFrameNode> data) : RelaxFrame(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(IfFrame, RelaxFrame, IfFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(IfFrame, RelaxFrame, IfFrameNode);
 };
 
 /*!
@@ -261,9 +255,8 @@ class ThenFrameNode : public SeqExprFrameNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ThenFrameNode>();
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.relax.ThenFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ThenFrameNode, SeqExprFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.relax.ThenFrame", ThenFrameNode,
+                                    SeqExprFrameNode);
 
  public:
   /*!
@@ -288,7 +281,7 @@ class ThenFrame : public SeqExprFrame {
   explicit ThenFrame(ObjectPtr<ThenFrameNode> data) : SeqExprFrame(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(ThenFrame, SeqExprFrame, ThenFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ThenFrame, SeqExprFrame, ThenFrameNode);
 };
 
 /*!
@@ -302,9 +295,8 @@ class ElseFrameNode : public SeqExprFrameNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ElseFrameNode>();
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.relax.ElseFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ElseFrameNode, SeqExprFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.relax.ElseFrame", ElseFrameNode,
+                                    SeqExprFrameNode);
 
  public:
   /*!
@@ -329,7 +321,7 @@ class ElseFrame : public SeqExprFrame {
   explicit ElseFrame(ObjectPtr<ElseFrameNode> data) : SeqExprFrame(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(ElseFrame, SeqExprFrame, ElseFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ElseFrame, SeqExprFrame, ElseFrameNode);
 };
 
 }  // namespace relax

--- a/include/tvm/script/ir_builder/tir/frame.h
+++ b/include/tvm/script/ir_builder/tir/frame.h
@@ -44,9 +44,7 @@ class TIRFrameNode : public IRBuilderFrameNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<TIRFrameNode>().def_ro("stmts", &TIRFrameNode::stmts);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.TIRFrame";
-  TVM_DECLARE_BASE_OBJECT_INFO(TIRFrameNode, IRBuilderFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("script.ir_builder.tir.TIRFrame", TIRFrameNode, IRBuilderFrameNode);
 };
 
 /*!
@@ -56,7 +54,7 @@ class TIRFrameNode : public IRBuilderFrameNode {
  */
 class TIRFrame : public IRBuilderFrame {
  public:
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(TIRFrame, IRBuilderFrame, TIRFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TIRFrame, IRBuilderFrame, TIRFrameNode);
 
  protected:
   TIRFrame() = default;
@@ -99,9 +97,8 @@ class PrimFuncFrameNode : public TIRFrameNode {
         .def_ro("env_threads", &PrimFuncFrameNode::env_threads)
         .def_ro("root_alloc_buffers", &PrimFuncFrameNode::root_alloc_buffers);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.PrimFuncFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PrimFuncFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.PrimFuncFrame", PrimFuncFrameNode,
+                                    TIRFrameNode);
 
  public:
   /*!
@@ -122,7 +119,7 @@ class PrimFuncFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(PrimFuncFrame, TIRFrame, PrimFuncFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(PrimFuncFrame, TIRFrame, PrimFuncFrameNode);
 };
 
 /*!
@@ -173,9 +170,8 @@ class BlockFrameNode : public TIRFrameNode {
         .def_ro("predicate", &BlockFrameNode::predicate)
         .def_ro("no_realize", &BlockFrameNode::no_realize);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.BlockFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BlockFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.BlockFrame", BlockFrameNode,
+                                    TIRFrameNode);
 
  public:
   /*!
@@ -197,7 +193,7 @@ class BlockFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(BlockFrame, TIRFrame, BlockFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(BlockFrame, TIRFrame, BlockFrameNode);
 };
 
 /*!
@@ -211,9 +207,8 @@ class BlockInitFrameNode : public TIRFrameNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<BlockInitFrameNode>();
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.BlockInitFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BlockInitFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.BlockInitFrame", BlockInitFrameNode,
+                                    TIRFrameNode);
 
  public:
   /*!
@@ -239,7 +234,7 @@ class BlockInitFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(BlockInitFrame, TIRFrame, BlockInitFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(BlockInitFrame, TIRFrame, BlockInitFrameNode);
 };
 
 /*!
@@ -273,9 +268,7 @@ class ForFrameNode : public TIRFrameNode {
         .def_ro("doms", &ForFrameNode::doms);
     // `f_make_for_loop` is not registered as it's not visited.
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.ForFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ForFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.ForFrame", ForFrameNode, TIRFrameNode);
 
  public:
   /*!
@@ -296,7 +289,7 @@ class ForFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(ForFrame, TIRFrame, ForFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ForFrame, TIRFrame, ForFrameNode);
 };
 
 /*!
@@ -318,9 +311,8 @@ class AssertFrameNode : public TIRFrameNode {
         .def_ro("condition", &AssertFrameNode::condition)
         .def_ro("message", &AssertFrameNode::message);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.AssertFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AssertFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.AssertFrame", AssertFrameNode,
+                                    TIRFrameNode);
 
  public:
   /*!
@@ -341,7 +333,7 @@ class AssertFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(AssertFrame, TIRFrame, AssertFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AssertFrame, TIRFrame, AssertFrameNode);
 };
 
 /*!
@@ -362,9 +354,7 @@ class LetFrameNode : public TIRFrameNode {
         .def_ro("var", &LetFrameNode::var)
         .def_ro("value", &LetFrameNode::value);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.LetFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(LetFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.LetFrame", LetFrameNode, TIRFrameNode);
 
  public:
   /*!
@@ -385,7 +375,7 @@ class LetFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(LetFrame, TIRFrame, LetFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(LetFrame, TIRFrame, LetFrameNode);
 };
 
 /*!
@@ -408,9 +398,8 @@ class LaunchThreadFrameNode : public TIRFrameNode {
         .def_ro("attr_key", &LaunchThreadFrameNode::attr_key)
         .def_ro("iter_var", &LaunchThreadFrameNode::iter_var);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.LaunchThreadFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(LaunchThreadFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.LaunchThreadFrame",
+                                    LaunchThreadFrameNode, TIRFrameNode);
 
  public:
   /*!
@@ -431,8 +420,7 @@ class LaunchThreadFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(LaunchThreadFrame, TIRFrame,
-                                                    LaunchThreadFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(LaunchThreadFrame, TIRFrame, LaunchThreadFrameNode);
 };
 
 /*!
@@ -456,9 +444,8 @@ class RealizeFrameNode : public TIRFrameNode {
         .def_ro("storage_scope", &RealizeFrameNode::storage_scope)
         .def_ro("condition", &RealizeFrameNode::condition);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.RealizeFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RealizeFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.RealizeFrame", RealizeFrameNode,
+                                    TIRFrameNode);
 
  public:
   /*!
@@ -479,7 +466,7 @@ class RealizeFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(RealizeFrame, TIRFrame, RealizeFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(RealizeFrame, TIRFrame, RealizeFrameNode);
 };
 
 /*!
@@ -512,9 +499,8 @@ class AllocateFrameNode : public TIRFrameNode {
         .def_ro("annotations", &AllocateFrameNode::annotations)
         .def_ro("buffer_var", &AllocateFrameNode::buffer_var);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.AllocateFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AllocateFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.AllocateFrame", AllocateFrameNode,
+                                    TIRFrameNode);
 
  public:
   /*!
@@ -535,7 +521,7 @@ class AllocateFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(AllocateFrame, TIRFrame, AllocateFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AllocateFrame, TIRFrame, AllocateFrameNode);
 };
 
 /*!
@@ -565,9 +551,8 @@ class AllocateConstFrameNode : public TIRFrameNode {
         .def_ro("buffer_var", &AllocateConstFrameNode::buffer_var)
         .def_ro("annotations", &AllocateConstFrameNode::annotations);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.AllocateConstFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AllocateConstFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.AllocateConstFrame",
+                                    AllocateConstFrameNode, TIRFrameNode);
 
  public:
   /*!
@@ -589,8 +574,8 @@ class AllocateConstFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(AllocateConstFrame, TIRFrame,
-                                                    AllocateConstFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AllocateConstFrame, TIRFrame,
+                                                AllocateConstFrameNode);
 };
 /*!
  * \brief A frame that represents attribute node.
@@ -613,9 +598,7 @@ class AttrFrameNode : public TIRFrameNode {
         .def_ro("attr_key", &AttrFrameNode::attr_key)
         .def_ro("value", &AttrFrameNode::value);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.AttrFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AttrFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.AttrFrame", AttrFrameNode, TIRFrameNode);
 
  public:
   /*!
@@ -636,7 +619,7 @@ class AttrFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(AttrFrame, TIRFrame, AttrFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AttrFrame, TIRFrame, AttrFrameNode);
 };
 
 /*!
@@ -653,9 +636,8 @@ class WhileFrameNode : public TIRFrameNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<WhileFrameNode>().def_ro("condition", &WhileFrameNode::condition);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.WhileFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(WhileFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.WhileFrame", WhileFrameNode,
+                                    TIRFrameNode);
 
  public:
   /*!
@@ -676,7 +658,7 @@ class WhileFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
     data_ = std::move(data);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(WhileFrame, TIRFrame, WhileFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(WhileFrame, TIRFrame, WhileFrameNode);
 };
 
 /*!
@@ -700,9 +682,7 @@ class IfFrameNode : public TIRFrameNode {
         .def_ro("then_stmts", &IfFrameNode::then_stmts)
         .def_ro("else_stmts", &IfFrameNode::else_stmts);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.IfFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IfFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.IfFrame", IfFrameNode, TIRFrameNode);
 
  public:
   /*!
@@ -722,7 +702,7 @@ class IfFrame : public TIRFrame {
   explicit IfFrame(ObjectPtr<IfFrameNode> data) : TIRFrame(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(IfFrame, TIRFrame, IfFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(IfFrame, TIRFrame, IfFrameNode);
 };
 
 /*!
@@ -736,9 +716,7 @@ class ThenFrameNode : public TIRFrameNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ThenFrameNode>();
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.ThenFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ThenFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.ThenFrame", ThenFrameNode, TIRFrameNode);
 
  public:
   /*!
@@ -763,7 +741,7 @@ class ThenFrame : public TIRFrame {
   explicit ThenFrame(ObjectPtr<ThenFrameNode> data) : TIRFrame(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(ThenFrame, TIRFrame, ThenFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ThenFrame, TIRFrame, ThenFrameNode);
 };
 
 /*!
@@ -777,9 +755,7 @@ class ElseFrameNode : public TIRFrameNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ElseFrameNode>();
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.ElseFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ElseFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.ElseFrame", ElseFrameNode, TIRFrameNode);
 
  public:
   /*!
@@ -805,7 +781,7 @@ class ElseFrame : public TIRFrame {
     TVM_FFI_ICHECK(data != nullptr);
   }
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(ElseFrame, TIRFrame, ElseFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ElseFrame, TIRFrame, ElseFrameNode);
 };
 
 class DeclBufferFrameNode : public TIRFrameNode {
@@ -821,9 +797,8 @@ class DeclBufferFrameNode : public TIRFrameNode {
         .def_ro("buffer", &DeclBufferFrameNode::buffer)
         .def_ro("allocated", &DeclBufferFrameNode::allocated);
   }
-
-  static constexpr const char* _type_key = "script.ir_builder.tir.DeclBufferFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DeclBufferFrameNode, TIRFrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.ir_builder.tir.DeclBufferFrame", DeclBufferFrameNode,
+                                    TIRFrameNode);
 
  public:
   void ExitWithScope() final;
@@ -834,7 +809,7 @@ class DeclBufferFrame : public TIRFrame {
   explicit DeclBufferFrame(ObjectPtr<DeclBufferFrameNode> data) : TIRFrame(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(DeclBufferFrame, TIRFrame, DeclBufferFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(DeclBufferFrame, TIRFrame, DeclBufferFrameNode);
 };
 
 }  // namespace tir

--- a/include/tvm/script/printer/doc.h
+++ b/include/tvm/script/printer/doc.h
@@ -71,10 +71,9 @@ class DocNode : public Object {
     refl::ObjectDef<DocNode>().def_rw("source_paths", &DocNode::source_paths);
   }
 
-  static constexpr const char* _type_key = "script.printer.Doc";
   static constexpr bool _type_mutable = true;
 
-  TVM_DECLARE_BASE_OBJECT_INFO(DocNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("script.printer.Doc", DocNode, Object);
 
  public:
   virtual ~DocNode() = default;
@@ -91,7 +90,7 @@ class Doc : public ObjectRef {
   explicit Doc(ObjectPtr<DocNode> data) : ObjectRef(data) {}
 
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(Doc, ObjectRef, DocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Doc, ObjectRef, DocNode);
 };
 
 class ExprDoc;
@@ -135,10 +134,7 @@ class ExprDocNode : public DocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ExprDocNode>();
   }
-
-  static constexpr const char* _type_key = "script.printer.ExprDoc";
-
-  TVM_DECLARE_BASE_OBJECT_INFO(ExprDocNode, DocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("script.printer.ExprDoc", ExprDocNode, DocNode);
 };
 
 /*!
@@ -159,7 +155,7 @@ class ExprDoc : public Doc {
 
   explicit ExprDoc(ObjectPtr<ExprDocNode> data) : Doc(data) { TVM_FFI_ICHECK(data != nullptr); }
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ExprDoc, Doc, ExprDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ExprDoc, Doc, ExprDocNode);
 };
 
 /*!
@@ -183,10 +179,7 @@ class StmtDocNode : public DocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<StmtDocNode>().def_rw("comment", &StmtDocNode::comment);
   }
-
-  static constexpr const char* _type_key = "script.printer.StmtDoc";
-
-  TVM_DECLARE_BASE_OBJECT_INFO(StmtDocNode, DocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("script.printer.StmtDoc", StmtDocNode, DocNode);
 };
 
 /*!
@@ -199,7 +192,7 @@ class StmtDoc : public Doc {
   StmtDoc() = default;
 
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(StmtDoc, Doc, StmtDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(StmtDoc, Doc, StmtDocNode);
 };
 
 /*!
@@ -217,10 +210,7 @@ class StmtBlockDocNode : public DocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<StmtBlockDocNode>().def_ro("stmts", &StmtBlockDocNode::stmts);
   }
-
-  static constexpr const char* _type_key = "script.printer.StmtBlockDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(StmtBlockDocNode, DocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.StmtBlockDoc", StmtBlockDocNode, DocNode);
 };
 
 /*!
@@ -234,7 +224,7 @@ class StmtBlockDoc : public Doc {
    * \param stmts The list of statements.
    */
   explicit StmtBlockDoc(ffi::Array<StmtDoc> stmts);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(StmtBlockDoc, Doc, StmtBlockDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(StmtBlockDoc, Doc, StmtBlockDocNode);
 };
 
 /*!
@@ -259,10 +249,7 @@ class LiteralDocNode : public ExprDocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<LiteralDocNode>().def_ro("value", &LiteralDocNode::value);
   }
-
-  static constexpr const char* _type_key = "script.printer.LiteralDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(LiteralDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.LiteralDoc", LiteralDocNode, ExprDocNode);
 };
 
 /*!
@@ -334,7 +321,7 @@ class LiteralDoc : public ExprDoc {
     return LiteralDoc::Str(os.str(), p);
   }
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(LiteralDoc, ExprDoc, LiteralDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(LiteralDoc, ExprDoc, LiteralDocNode);
 };
 
 /*!
@@ -351,10 +338,7 @@ class IdDocNode : public ExprDocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<IdDocNode>().def_ro("name", &IdDocNode::name);
   }
-
-  static constexpr const char* _type_key = "script.printer.IdDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(IdDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.IdDoc", IdDocNode, ExprDocNode);
 };
 
 /*!
@@ -370,7 +354,7 @@ class IdDoc : public ExprDoc {
    */
   explicit IdDoc(ffi::String name);
   explicit IdDoc(std::nullptr_t) : ExprDoc(nullptr) {}
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(IdDoc, ExprDoc, IdDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(IdDoc, ExprDoc, IdDocNode);
 };
 
 /*!
@@ -391,10 +375,7 @@ class AttrAccessDocNode : public ExprDocNode {
         .def_ro("value", &AttrAccessDocNode::value)
         .def_ro("name", &AttrAccessDocNode::name);
   }
-
-  static constexpr const char* _type_key = "script.printer.AttrAccessDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(AttrAccessDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.AttrAccessDoc", AttrAccessDocNode, ExprDocNode);
 };
 
 /*!
@@ -410,7 +391,7 @@ class AttrAccessDoc : public ExprDoc {
    * \param name The name of attribute to access.
    */
   explicit AttrAccessDoc(ExprDoc value, ffi::String name);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(AttrAccessDoc, ExprDoc, AttrAccessDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AttrAccessDoc, ExprDoc, AttrAccessDocNode);
 };
 
 /*!
@@ -437,10 +418,7 @@ class IndexDocNode : public ExprDocNode {
         .def_ro("value", &IndexDocNode::value)
         .def_ro("indices", &IndexDocNode::indices);
   }
-
-  static constexpr const char* _type_key = "script.printer.IndexDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(IndexDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.IndexDoc", IndexDocNode, ExprDocNode);
 };
 
 /*!
@@ -456,7 +434,7 @@ class IndexDoc : public ExprDoc {
    * \param indices The indices to access.
    */
   explicit IndexDoc(ExprDoc value, ffi::Array<Doc> indices);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(IndexDoc, ExprDoc, IndexDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(IndexDoc, ExprDoc, IndexDocNode);
 };
 
 /*!
@@ -488,10 +466,7 @@ class CallDocNode : public ExprDocNode {
         .def_ro("kwargs_keys", &CallDocNode::kwargs_keys)
         .def_ro("kwargs_values", &CallDocNode::kwargs_values);
   }
-
-  static constexpr const char* _type_key = "script.printer.CallDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(CallDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.CallDoc", CallDocNode, ExprDocNode);
 };
 
 /*!
@@ -510,7 +485,7 @@ class CallDoc : public ExprDoc {
    */
   CallDoc(ExprDoc callee, ffi::Array<ExprDoc> args, ffi::Array<ffi::String> kwargs_keys,
           ffi::Array<ExprDoc> kwargs_values);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(CallDoc, ExprDoc, CallDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(CallDoc, ExprDoc, CallDocNode);
 };
 
 /*!
@@ -572,10 +547,7 @@ class OperationDocNode : public ExprDocNode {
         .def_ro("kind", &OperationDocNode::kind)
         .def_ro("operands", &OperationDocNode::operands);
   }
-
-  static constexpr const char* _type_key = "script.printer.OperationDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(OperationDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.OperationDoc", OperationDocNode, ExprDocNode);
 };
 
 /*!
@@ -591,7 +563,7 @@ class OperationDoc : public ExprDoc {
    * \param operands Operands of this expression.
    */
   explicit OperationDoc(OperationDocNode::Kind kind, ffi::Array<ExprDoc> operands);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(OperationDoc, ExprDoc, OperationDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(OperationDoc, ExprDoc, OperationDocNode);
 };
 
 /*!
@@ -615,10 +587,7 @@ class LambdaDocNode : public ExprDocNode {
         .def_ro("args", &LambdaDocNode::args)
         .def_ro("body", &LambdaDocNode::body);
   }
-
-  static constexpr const char* _type_key = "script.printer.LambdaDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(LambdaDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.LambdaDoc", LambdaDocNode, ExprDocNode);
 };
 
 /*!
@@ -634,7 +603,7 @@ class LambdaDoc : public ExprDoc {
    * \param body Body expression of this function.
    */
   explicit LambdaDoc(ffi::Array<IdDoc> args, ExprDoc body);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(LambdaDoc, ExprDoc, LambdaDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(LambdaDoc, ExprDoc, LambdaDocNode);
 };
 
 /*!
@@ -651,10 +620,7 @@ class TupleDocNode : public ExprDocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<TupleDocNode>().def_ro("elements", &TupleDocNode::elements);
   }
-
-  static constexpr const char* _type_key = "script.printer.TupleDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(TupleDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.TupleDoc", TupleDocNode, ExprDocNode);
 };
 
 /*!
@@ -673,7 +639,7 @@ class TupleDoc : public ExprDoc {
    * \param elements Elements of tuple.
    */
   explicit TupleDoc(ffi::Array<ExprDoc> elements);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TupleDoc, ExprDoc, TupleDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TupleDoc, ExprDoc, TupleDocNode);
 };
 
 /*!
@@ -690,10 +656,7 @@ class ListDocNode : public ExprDocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ListDocNode>().def_ro("elements", &ListDocNode::elements);
   }
-
-  static constexpr const char* _type_key = "script.printer.ListDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(ListDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.ListDoc", ListDocNode, ExprDocNode);
 };
 
 /*!
@@ -712,7 +675,7 @@ class ListDoc : public ExprDoc {
    * \param elements Elements of list.
    */
   explicit ListDoc(ffi::Array<ExprDoc> elements);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ListDoc, ExprDoc, ListDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ListDoc, ExprDoc, ListDocNode);
 };
 
 /*!
@@ -738,10 +701,7 @@ class DictDocNode : public ExprDocNode {
         .def_ro("keys", &DictDocNode::keys)
         .def_ro("values", &DictDocNode::values);
   }
-
-  static constexpr const char* _type_key = "script.printer.DictDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(DictDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.DictDoc", DictDocNode, ExprDocNode);
 };
 
 /*!
@@ -761,7 +721,7 @@ class DictDoc : public ExprDoc {
    * \param values Values of dictionary, must have same length as `keys`.
    */
   explicit DictDoc(ffi::Array<ExprDoc> keys, ffi::Array<ExprDoc> values);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(DictDoc, ExprDoc, DictDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(DictDoc, ExprDoc, DictDocNode);
 };
 
 /*!
@@ -787,10 +747,7 @@ class SliceDocNode : public DocNode {
         .def_ro("stop", &SliceDocNode::stop)
         .def_ro("step", &SliceDocNode::step);
   }
-
-  static constexpr const char* _type_key = "script.printer.SliceDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(SliceDocNode, DocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.SliceDoc", SliceDocNode, DocNode);
 };
 
 /*!
@@ -808,7 +765,7 @@ class SliceDoc : public Doc {
    */
   explicit SliceDoc(ffi::Optional<ExprDoc> start, ffi::Optional<ExprDoc> stop,
                     ffi::Optional<ExprDoc> step);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(SliceDoc, Doc, SliceDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(SliceDoc, Doc, SliceDocNode);
 };
 
 /*!
@@ -836,10 +793,7 @@ class AssignDocNode : public StmtDocNode {
         .def_ro("rhs", &AssignDocNode::rhs)
         .def_ro("annotation", &AssignDocNode::annotation);
   }
-
-  static constexpr const char* _type_key = "script.printer.AssignDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(AssignDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.AssignDoc", AssignDocNode, StmtDocNode);
 };
 
 /*!
@@ -856,7 +810,7 @@ class AssignDoc : public StmtDoc {
    * \param annotation The type annotation of this assignment.
    */
   explicit AssignDoc(ExprDoc lhs, ffi::Optional<ExprDoc> rhs, ffi::Optional<ExprDoc> annotation);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(AssignDoc, StmtDoc, AssignDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AssignDoc, StmtDoc, AssignDocNode);
 };
 
 /*!
@@ -880,10 +834,7 @@ class IfDocNode : public StmtDocNode {
         .def_ro("then_branch", &IfDocNode::then_branch)
         .def_ro("else_branch", &IfDocNode::else_branch);
   }
-
-  static constexpr const char* _type_key = "script.printer.IfDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(IfDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.IfDoc", IfDocNode, StmtDocNode);
 };
 
 /*!
@@ -901,7 +852,7 @@ class IfDoc : public StmtDoc {
    */
   explicit IfDoc(ExprDoc predicate, ffi::Array<StmtDoc> then_branch,
                  ffi::Array<StmtDoc> else_branch);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(IfDoc, StmtDoc, IfDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(IfDoc, StmtDoc, IfDocNode);
 };
 
 /*!
@@ -922,10 +873,7 @@ class WhileDocNode : public StmtDocNode {
         .def_ro("predicate", &WhileDocNode::predicate)
         .def_ro("body", &WhileDocNode::body);
   }
-
-  static constexpr const char* _type_key = "script.printer.WhileDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(WhileDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.WhileDoc", WhileDocNode, StmtDocNode);
 };
 
 /*!
@@ -941,7 +889,7 @@ class WhileDoc : public StmtDoc {
    * \param body The body of the while statement.
    */
   explicit WhileDoc(ExprDoc predicate, ffi::Array<StmtDoc> body);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(WhileDoc, StmtDoc, WhileDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(WhileDoc, StmtDoc, WhileDocNode);
 };
 
 /*!
@@ -969,10 +917,7 @@ class ForDocNode : public StmtDocNode {
         .def_ro("rhs", &ForDocNode::rhs)
         .def_ro("body", &ForDocNode::body);
   }
-
-  static constexpr const char* _type_key = "script.printer.ForDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(ForDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.ForDoc", ForDocNode, StmtDocNode);
 };
 
 /*!
@@ -989,7 +934,7 @@ class ForDoc : public StmtDoc {
    * \param body The body of the for statement.
    */
   explicit ForDoc(ExprDoc lhs, ExprDoc rhs, ffi::Array<StmtDoc> body);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ForDoc, StmtDoc, ForDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ForDoc, StmtDoc, ForDocNode);
 };
 
 /*!
@@ -1018,10 +963,7 @@ class ScopeDocNode : public StmtDocNode {
         .def_ro("rhs", &ScopeDocNode::rhs)
         .def_ro("body", &ScopeDocNode::body);
   }
-
-  static constexpr const char* _type_key = "script.printer.ScopeDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(ScopeDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.ScopeDoc", ScopeDocNode, StmtDocNode);
 };
 
 /*!
@@ -1046,7 +988,7 @@ class ScopeDoc : public StmtDoc {
    */
   explicit ScopeDoc(ExprDoc rhs, ffi::Array<StmtDoc> body);
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ScopeDoc, StmtDoc, ScopeDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ScopeDoc, StmtDoc, ScopeDocNode);
 };
 
 /*!
@@ -1063,10 +1005,7 @@ class ExprStmtDocNode : public StmtDocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ExprStmtDocNode>().def_ro("expr", &ExprStmtDocNode::expr);
   }
-
-  static constexpr const char* _type_key = "script.printer.ExprStmtDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(ExprStmtDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.ExprStmtDoc", ExprStmtDocNode, StmtDocNode);
 };
 
 /*!
@@ -1081,7 +1020,7 @@ class ExprStmtDoc : public StmtDoc {
    * \param expr The expression represented by this doc.
    */
   explicit ExprStmtDoc(ExprDoc expr);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ExprStmtDoc, StmtDoc, ExprStmtDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ExprStmtDoc, StmtDoc, ExprStmtDocNode);
 };
 
 /*!
@@ -1102,10 +1041,7 @@ class AssertDocNode : public StmtDocNode {
         .def_ro("test", &AssertDocNode::test)
         .def_ro("msg", &AssertDocNode::msg);
   }
-
-  static constexpr const char* _type_key = "script.printer.AssertDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(AssertDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.AssertDoc", AssertDocNode, StmtDocNode);
 };
 
 /*!
@@ -1121,7 +1057,7 @@ class AssertDoc : public StmtDoc {
    * \param msg The optional error message when assertion failed.
    */
   explicit AssertDoc(ExprDoc test, ffi::Optional<ExprDoc> msg = std::nullopt);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(AssertDoc, StmtDoc, AssertDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AssertDoc, StmtDoc, AssertDocNode);
 };
 
 /*!
@@ -1138,10 +1074,7 @@ class ReturnDocNode : public StmtDocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ReturnDocNode>().def_ro("value", &ReturnDocNode::value);
   }
-
-  static constexpr const char* _type_key = "script.printer.ReturnDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(ReturnDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.ReturnDoc", ReturnDocNode, StmtDocNode);
 };
 
 /*!
@@ -1156,7 +1089,7 @@ class ReturnDoc : public StmtDoc {
    * \param value The value to return.
    */
   explicit ReturnDoc(ExprDoc value);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ReturnDoc, StmtDoc, ReturnDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ReturnDoc, StmtDoc, ReturnDocNode);
 };
 
 /*!
@@ -1192,10 +1125,7 @@ class FunctionDocNode : public StmtDocNode {
         .def_ro("return_type", &FunctionDocNode::return_type)
         .def_ro("body", &FunctionDocNode::body);
   }
-
-  static constexpr const char* _type_key = "script.printer.FunctionDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(FunctionDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.FunctionDoc", FunctionDocNode, StmtDocNode);
 };
 
 /*!
@@ -1215,7 +1145,7 @@ class FunctionDoc : public StmtDoc {
    */
   explicit FunctionDoc(IdDoc name, ffi::Array<AssignDoc> args, ffi::Array<ExprDoc> decorators,
                        ffi::Optional<ExprDoc> return_type, ffi::Array<StmtDoc> body);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(FunctionDoc, StmtDoc, FunctionDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(FunctionDoc, StmtDoc, FunctionDocNode);
 };
 
 /*!
@@ -1239,10 +1169,7 @@ class ClassDocNode : public StmtDocNode {
         .def_ro("decorators", &ClassDocNode::decorators)
         .def_ro("body", &ClassDocNode::body);
   }
-
-  static constexpr const char* _type_key = "script.printer.ClassDoc";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(ClassDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.ClassDoc", ClassDocNode, StmtDocNode);
 };
 
 /*!
@@ -1259,7 +1186,7 @@ class ClassDoc : public StmtDoc {
    * \param body The body of class.
    */
   explicit ClassDoc(IdDoc name, ffi::Array<ExprDoc> decorators, ffi::Array<StmtDoc> body);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ClassDoc, StmtDoc, ClassDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ClassDoc, StmtDoc, ClassDocNode);
 };
 
 /*!
@@ -1273,9 +1200,7 @@ class CommentDocNode : public StmtDocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<CommentDocNode>();
   }
-
-  static constexpr const char* _type_key = "script.printer.CommentDoc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(CommentDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.CommentDoc", CommentDocNode, StmtDocNode);
 };
 
 /*!
@@ -1286,7 +1211,7 @@ class CommentDocNode : public StmtDocNode {
 class CommentDoc : public StmtDoc {
  public:
   explicit CommentDoc(ffi::String comment);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(CommentDoc, StmtDoc, CommentDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(CommentDoc, StmtDoc, CommentDocNode);
 };
 
 /*!
@@ -1300,9 +1225,7 @@ class DocStringDocNode : public StmtDocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<DocStringDocNode>();
   }
-
-  static constexpr const char* _type_key = "script.printer.DocStringDoc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DocStringDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.DocStringDoc", DocStringDocNode, StmtDocNode);
 };
 
 /*!
@@ -1313,7 +1236,7 @@ class DocStringDocNode : public StmtDocNode {
 class DocStringDoc : public StmtDoc {
  public:
   explicit DocStringDoc(ffi::String docs);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(DocStringDoc, StmtDoc, DocStringDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(DocStringDoc, StmtDoc, DocStringDocNode);
 };
 
 }  // namespace printer

--- a/include/tvm/script/printer/ir_docsifier.h
+++ b/include/tvm/script/printer/ir_docsifier.h
@@ -61,9 +61,8 @@ class FrameNode : public Object {
     refl::ObjectDef<FrameNode>().def_ro("stmts", &FrameNode::stmts);
   }
 
-  static constexpr const char* _type_key = "script.printer.Frame";
-
-  TVM_DECLARE_BASE_OBJECT_INFO(FrameNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("script.printer.Frame", FrameNode, Object);
 
  public:
   virtual ~FrameNode() = default;
@@ -109,7 +108,7 @@ class Frame : public ObjectRef {
   /*! \brief Method that's called when Frame exits the scope. */
   void ExitWithScope() { get()->ExitWithScope(); }
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(Frame, ObjectRef, FrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Frame, ObjectRef, FrameNode);
 };
 
 //////////////////////// IRDocsifier ////////////////////////
@@ -165,9 +164,8 @@ class IRDocsifierNode : public Object {
         .def_ro("dispatch_tokens", &IRDocsifierNode::dispatch_tokens);
   }
 
-  static constexpr const char* _type_key = "script.printer.IRDocsifier";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(IRDocsifierNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.IRDocsifier", IRDocsifierNode, Object);
 
  public:
   /*!
@@ -252,7 +250,7 @@ class IRDocsifier : public ObjectRef {
   /*! \brief The registration table for IRDocsifier. */
   TVM_DLL static FType& vtable();
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(IRDocsifier, ObjectRef, IRDocsifierNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(IRDocsifier, ObjectRef, IRDocsifierNode);
 };
 
 //////////////////////// Implementation ////////////////////////

--- a/include/tvm/target/tag.h
+++ b/include/tvm/target/tag.h
@@ -47,10 +47,7 @@ class TargetTagNode : public Object {
         .def_ro("name", &TargetTagNode::name)
         .def_ro("config", &TargetTagNode::config);
   }
-
-  static constexpr const char* _type_key = "target.TargetTag";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(TargetTagNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("target.TargetTag", TargetTagNode, Object);
 
  private:
   /*! \brief Return the index stored in attr registry */
@@ -93,7 +90,7 @@ class TargetTag : public ObjectRef {
    */
   TVM_DLL static Target AddTag(ffi::String name, ffi::Map<ffi::String, Any> config, bool override);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(TargetTag, ObjectRef, TargetTagNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TargetTag, ObjectRef, TargetTagNode);
 
  private:
   /*! \brief Mutable access to the container class  */

--- a/include/tvm/target/target.h
+++ b/include/tvm/target/target.h
@@ -175,9 +175,8 @@ class TargetNode : public Object {
   /*! \brief Get the keys for this target as an unordered_set of string */
   TVM_DLL std::unordered_set<std::string> GetLibs() const;
 
-  static constexpr const char* _type_key = "target.Target";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  TVM_DECLARE_FINAL_OBJECT_INFO(TargetNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("target.Target", TargetNode, Object);
 
  private:
   /*! \brief Internal string repr. */
@@ -219,7 +218,7 @@ class Target : public ObjectRef {
    * \param host The Target typed object for target host
    */
   TVM_DLL explicit Target(Target target, Target host);
-  TVM_DEFINE_OBJECT_REF_METHODS(Target, ObjectRef, TargetNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Target, ObjectRef, TargetNode);
   /*!
    * \brief Create a new Target object with given target (w.o host) and target host.
    * \param target The current Target typed object target, with or without host field.

--- a/include/tvm/target/target_info.h
+++ b/include/tvm/target/target_info.h
@@ -57,16 +57,13 @@ class MemoryInfoNode : public Object {
         .def_ro("max_simd_bits", &MemoryInfoNode::max_simd_bits)
         .def_ro("head_address", &MemoryInfoNode::head_address);
   }
-
-  static constexpr const char* _type_key = "target.MemoryInfo";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(MemoryInfoNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("target.MemoryInfo", MemoryInfoNode, Object);
 };
 
 /*! \brief Defines memory info */
 class MemoryInfo : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(MemoryInfo, ObjectRef, MemoryInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MemoryInfo, ObjectRef, MemoryInfoNode);
 };
 
 /*!

--- a/include/tvm/target/target_kind.h
+++ b/include/tvm/target/target_kind.h
@@ -88,8 +88,7 @@ class TargetKindNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindUniqueInstance;
-  static constexpr const char* _type_key = "target.TargetKind";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TargetKindNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("target.TargetKind", TargetKindNode, Object);
 
  private:
   /*! \brief Return the index stored in attr registry */
@@ -142,7 +141,7 @@ class TargetKind : public ObjectRef {
   /*! \brief Mutable access to the container class  */
   TargetKindNode* operator->() { return static_cast<TargetKindNode*>(data_.get()); }
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TargetKind, ObjectRef, TargetKindNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TargetKind, ObjectRef, TargetKindNode);
 
  private:
   TVM_DLL static const AttrRegistryMapContainerMap<TargetKind>& GetAttrMapContainer(

--- a/include/tvm/target/virtual_device.h
+++ b/include/tvm/target/virtual_device.h
@@ -257,9 +257,7 @@ class VirtualDeviceNode : public AttrsNodeReflAdapter<VirtualDeviceNode> {
                 "The area of memory w.r.t. the virtual device where data is stored.",
                 refl::DefaultValue(""));
   }
-
-  static constexpr const char* _type_key = "target.VirtualDevice";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(VirtualDeviceNode, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("target.VirtualDevice", VirtualDeviceNode, BaseAttrsNode);
 
   friend class VirtualDevice;
 };
@@ -341,7 +339,7 @@ class VirtualDevice : public ObjectRef {
    */
   static VirtualDevice Default(const VirtualDevice& lhs, const VirtualDevice& rhs);
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(VirtualDevice, ObjectRef, VirtualDeviceNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(VirtualDevice, ObjectRef, VirtualDeviceNode);
 
   friend class VirtualDeviceCache;  // Private implementation helper.
 };

--- a/include/tvm/te/operation.h
+++ b/include/tvm/te/operation.h
@@ -90,10 +90,7 @@ class TVM_DLL OperationNode : public Object {
         .def_ro("tag", &OperationNode::tag)
         .def_ro("attrs", &OperationNode::attrs);
   }
-
-  static constexpr const char* _type_key = "te.Operation";
-
-  TVM_DECLARE_BASE_OBJECT_INFO(OperationNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("te.Operation", OperationNode, Object);
 };
 
 /*!
@@ -117,10 +114,7 @@ class PlaceholderOpNode : public OperationNode {
         .def_ro("shape", &PlaceholderOpNode::shape)
         .def_ro("dtype", &PlaceholderOpNode::dtype);
   }
-
-  static constexpr const char* _type_key = "te.PlaceholderOp";
-
-  TVM_DECLARE_BASE_OBJECT_INFO(PlaceholderOpNode, OperationNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("te.PlaceholderOp", PlaceholderOpNode, OperationNode);
 };
 
 /*!
@@ -131,7 +125,7 @@ class PlaceholderOp : public Operation {
  public:
   TVM_DLL PlaceholderOp(std::string name, ffi::Array<PrimExpr> shape, DataType dtype);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PlaceholderOp, Operation, PlaceholderOpNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PlaceholderOp, Operation, PlaceholderOpNode);
 };
 
 /*!
@@ -153,10 +147,7 @@ class TVM_DLL BaseComputeOpNode : public OperationNode {
         .def_ro("axis", &BaseComputeOpNode::axis)
         .def_ro("reduce_axis", &BaseComputeOpNode::reduce_axis);
   }
-
-  static constexpr const char* _type_key = "te.BaseComputeOp";
-
-  TVM_DECLARE_BASE_OBJECT_INFO(BaseComputeOpNode, OperationNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("te.BaseComputeOp", BaseComputeOpNode, OperationNode);
 };
 
 /*!
@@ -177,10 +168,7 @@ class TVM_DLL ComputeOpNode : public BaseComputeOpNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ComputeOpNode>().def_ro("body", &ComputeOpNode::body);
   }
-
-  static constexpr const char* _type_key = "te.ComputeOp";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(ComputeOpNode, BaseComputeOpNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("te.ComputeOp", ComputeOpNode, BaseComputeOpNode);
 };
 
 /*!
@@ -192,7 +180,7 @@ class ComputeOp : public Operation {
   TVM_DLL ComputeOp(std::string name, std::string tag, ffi::Map<ffi::String, ffi::Any> attrs,
                     ffi::Array<IterVar> axis, ffi::Array<PrimExpr> body);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ComputeOp, Operation, ComputeOpNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ComputeOp, Operation, ComputeOpNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ComputeOpNode);
 };
 
@@ -242,10 +230,7 @@ class ScanOpNode : public OperationNode {
         .def_ro("inputs", &ScanOpNode::inputs)
         .def_ro("spatial_axis_", &ScanOpNode::spatial_axis_);
   }
-
-  static constexpr const char* _type_key = "te.ScanOp";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(ScanOpNode, OperationNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("te.ScanOp", ScanOpNode, OperationNode);
 };
 
 /*!
@@ -259,7 +244,7 @@ class ScanOp : public Operation {
                  ffi::Array<Tensor> init, ffi::Array<Tensor> update,
                  ffi::Array<Tensor> state_placeholder, ffi::Array<Tensor> input);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ScanOp, Operation, ScanOpNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ScanOp, Operation, ScanOpNode);
 };
 
 /*!
@@ -292,10 +277,7 @@ class ExternOpNode : public OperationNode {
         .def_ro("output_placeholders", &ExternOpNode::output_placeholders)
         .def_ro("body", &ExternOpNode::body);
   }
-
-  static constexpr const char* _type_key = "te.ExternOp";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(ExternOpNode, OperationNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("te.ExternOp", ExternOpNode, OperationNode);
 };
 
 /*!
@@ -308,7 +290,7 @@ class ExternOp : public Operation {
                    ffi::Array<Tensor> inputs, ffi::Array<Buffer> input_placeholders,
                    ffi::Array<Buffer> output_placeholders, Stmt body);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ExternOp, Operation, ExternOpNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ExternOp, Operation, ExternOpNode);
 };
 
 /*!

--- a/include/tvm/te/tensor.h
+++ b/include/tvm/te/tensor.h
@@ -88,10 +88,9 @@ class TensorNode : public DataProducerNode {
 
   TVM_DLL ffi::String GetNameHint() const final;
 
-  static constexpr const char* _type_key = "te.Tensor";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindConstTreeNode;
 
-  TVM_DECLARE_FINAL_OBJECT_INFO(TensorNode, DataProducerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("te.Tensor", TensorNode, DataProducerNode);
 };
 
 /*!
@@ -206,7 +205,7 @@ class Tensor : public DataProducer {
    */
   inline Slice operator[](PrimExpr i) const { return Slice(*this, {i}); }
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Tensor, DataProducer, TensorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Tensor, DataProducer, TensorNode);
 };
 
 // Implementations of inline functions

--- a/include/tvm/tir/block_dependence_info.h
+++ b/include/tvm/tir/block_dependence_info.h
@@ -65,9 +65,7 @@ class BlockDependenceInfoNode : public Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<BlockDependenceInfoNode>();
   }
-
-  static constexpr const char* _type_key = "tir.BlockDependenceInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BlockDependenceInfoNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.BlockDependenceInfo", BlockDependenceInfoNode, Object);
 
   /*!
    * \brief Get the BlockScope corresponding to the sref of scope root block
@@ -97,8 +95,8 @@ class BlockDependenceInfo : public ObjectRef {
    */
   TVM_DLL BlockDependenceInfo(IRModule mod);
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(BlockDependenceInfo, ObjectRef,
-                                                    BlockDependenceInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(BlockDependenceInfo, ObjectRef,
+                                                BlockDependenceInfoNode);
 };
 
 }  // namespace tir

--- a/include/tvm/tir/block_scope.h
+++ b/include/tvm/tir/block_scope.h
@@ -72,8 +72,8 @@ class StmtSRefNode : public Object {
     refl::ObjectDef<StmtSRefNode>().def_ro("seq_index", &StmtSRefNode::seq_index);
   }
 
-  static constexpr const char* _type_key = "tir.StmtSRef";
-  TVM_DECLARE_FINAL_OBJECT_INFO(StmtSRefNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.StmtSRef", StmtSRefNode, Object);
 
   /*! \brief Reset the object inplace to the invalid state */
   void Reset() {
@@ -114,10 +114,7 @@ class StmtSRef : public ObjectRef {
    */
   TVM_DLL explicit StmtSRef(const StmtNode* stmt, StmtSRefNode* parent, int64_t seq_index);
 
-  /*! \return The mutable pointer to the StmtSRefNode */
-  StmtSRefNode* get() const { return static_cast<StmtSRefNode*>(data_.get()); }
-
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(StmtSRef, ObjectRef, StmtSRefNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(StmtSRef, ObjectRef, StmtSRefNode);
 
  public:
   /*!
@@ -226,9 +223,7 @@ class DependencyNode : public Object {
         .def_ro("dst", &DependencyNode::dst)
         .def_ro("kind", &DependencyNode::kind);
   }
-
-  static constexpr const char* _type_key = "tir.Dependency";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DependencyNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Dependency", DependencyNode, Object);
 };
 
 /*!
@@ -239,7 +234,7 @@ class Dependency : public ObjectRef {
  public:
   /*! \brief Constructor */
   TVM_DLL explicit Dependency(StmtSRef src, StmtSRef dst, DepKind kind);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(Dependency, ObjectRef, DependencyNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Dependency, ObjectRef, DependencyNode);
 };
 
 /*!
@@ -271,9 +266,7 @@ class BlockScopeNode : public Object {
   static void RegisterReflection() {
     // No fields to register as they are not visited
   }
-
-  static constexpr const char* _type_key = "tir.BlockScope";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BlockScopeNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.BlockScope", BlockScopeNode, Object);
 
  public:
   /******** Dependency ********/
@@ -314,7 +307,7 @@ class BlockScope : public ObjectRef {
    */
   TVM_DLL explicit BlockScope(const ffi::Array<StmtSRef>& child_block_srefs);
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(BlockScope, ObjectRef, BlockScopeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(BlockScope, ObjectRef, BlockScopeNode);
 };
 
 }  // namespace tir

--- a/include/tvm/tir/buffer.h
+++ b/include/tvm/tir/buffer.h
@@ -142,10 +142,9 @@ class BufferNode : public Object {
    */
   ffi::Array<PrimExpr> ElemOffset(ffi::Array<PrimExpr> index) const;
 
-  static constexpr const char* _type_key = "tir.Buffer";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
 
-  TVM_DECLARE_FINAL_OBJECT_INFO(BufferNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Buffer", BufferNode, Object);
   TVM_OBJECT_ENABLE_SCRIPT_PRINTER();
 };
 
@@ -226,7 +225,7 @@ class Buffer : public ObjectRef {
    */
   TVM_DLL ffi::String scope() const;
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Buffer, ObjectRef, BufferNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Buffer, ObjectRef, BufferNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BufferNode);
 };
 
@@ -277,9 +276,7 @@ class DataProducerNode : public PrimExprConvertibleNode {
    * \return The data type.
    */
   virtual ffi::String GetNameHint() const = 0;
-
-  static constexpr const char* _type_key = "tir.DataProducer";
-  TVM_DECLARE_BASE_OBJECT_INFO(DataProducerNode, PrimExprConvertibleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("tir.DataProducer", DataProducerNode, PrimExprConvertibleNode);
 };
 
 /*!
@@ -288,7 +285,7 @@ class DataProducerNode : public PrimExprConvertibleNode {
  */
 class DataProducer : public PrimExprConvertible {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(DataProducer, PrimExprConvertible, DataProducerNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DataProducer, PrimExprConvertible, DataProducerNode);
 };
 
 /*!

--- a/include/tvm/tir/data_layout.h
+++ b/include/tvm/tir/data_layout.h
@@ -114,9 +114,7 @@ class LayoutNode : public Object {
         .def_ro("name", &LayoutNode::name)
         .def_ro("axes", &LayoutNode::axes);
   }
-
-  static constexpr const char* _type_key = "tir.Layout";
-  TVM_DECLARE_FINAL_OBJECT_INFO(LayoutNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Layout", LayoutNode, Object);
 };
 
 /*!
@@ -291,7 +289,7 @@ class Layout : public ObjectRef {
     return os;
   }
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Layout, ObjectRef, LayoutNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Layout, ObjectRef, LayoutNode);
 };
 
 // Internal node container BijectiveLayout
@@ -323,9 +321,7 @@ class BijectiveLayoutNode : public Object {
         .def_ro("shape_forward_rule", &BijectiveLayoutNode::shape_forward_rule)
         .def_ro("shape_backward_rule", &BijectiveLayoutNode::shape_backward_rule);
   }
-
-  static constexpr const char* _type_key = "tir.BijectiveLayout";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BijectiveLayoutNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.BijectiveLayout", BijectiveLayoutNode, Object);
 };
 
 /*!
@@ -352,7 +348,7 @@ class BijectiveLayout : public ObjectRef {
   // Given the destination indices, recover the source indices.
   TVM_DLL ffi::Array<PrimExpr> BackwardIndex(const ffi::Array<PrimExpr>& dst_index) const;
 
-  TVM_DEFINE_OBJECT_REF_METHODS(BijectiveLayout, ObjectRef, BijectiveLayoutNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BijectiveLayout, ObjectRef, BijectiveLayoutNode);
 };
 
 }  // namespace tir

--- a/include/tvm/tir/expr.h
+++ b/include/tvm/tir/expr.h
@@ -59,9 +59,7 @@ class StringImmNode : public PrimExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<StringImmNode>().def_ro("value", &StringImmNode::value);
   }
-
-  static constexpr const char* _type_key = "tir.StringImm";
-  TVM_DECLARE_FINAL_OBJECT_INFO(StringImmNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.StringImm", StringImmNode, PrimExprNode);
 };
 
 /*!
@@ -71,7 +69,7 @@ class StringImmNode : public PrimExprNode {
 class StringImm : public PrimExpr {
  public:
   TVM_DLL StringImm(ffi::String value, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(StringImm, PrimExpr, StringImmNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(StringImm, PrimExpr, StringImmNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(StringImmNode);
 };
 
@@ -88,9 +86,7 @@ class CastNode : public PrimExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<CastNode>().def_ro("value", &CastNode::value);
   }
-
-  static constexpr const char* _type_key = "tir.Cast";
-  TVM_DECLARE_FINAL_OBJECT_INFO(CastNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Cast", CastNode, PrimExprNode);
 };
 
 /*!
@@ -100,7 +96,7 @@ class CastNode : public PrimExprNode {
 class Cast : public PrimExpr {
  public:
   TVM_DLL Cast(DataType dtype, PrimExpr value, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Cast, PrimExpr, CastNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Cast, PrimExpr, CastNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(CastNode);
 };
 
@@ -121,7 +117,9 @@ class BinaryOpNode : public PrimExprNode {
     refl::ObjectDef<T>().def_ro("a", &T::a).def_ro("b", &T::b);
   }
 
-  TVM_DECLARE_FINAL_OBJECT_INFO(T, PrimExprNode);
+  static const constexpr int _type_child_slots [[maybe_unused]] = 0;
+  static const constexpr bool _type_final [[maybe_unused]] = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_PREDEFINED_TYPE_KEY(T, PrimExprNode);
 };
 
 /*! \brief a + b */
@@ -137,7 +135,7 @@ class AddNode : public BinaryOpNode<AddNode> {
 class Add : public PrimExpr {
  public:
   TVM_DLL Add(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Add, PrimExpr, AddNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Add, PrimExpr, AddNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(AddNode);
 };
 
@@ -155,7 +153,7 @@ class Sub : public PrimExpr {
  public:
   TVM_DLL Sub(PrimExpr a, PrimExpr b, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Sub, PrimExpr, SubNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Sub, PrimExpr, SubNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(SubNode);
 };
 
@@ -172,7 +170,7 @@ class MulNode : public BinaryOpNode<MulNode> {
 class Mul : public PrimExpr {
  public:
   TVM_DLL Mul(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Mul, PrimExpr, MulNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Mul, PrimExpr, MulNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(MulNode);
 };
 
@@ -192,7 +190,7 @@ class DivNode : public BinaryOpNode<DivNode> {
 class Div : public PrimExpr {
  public:
   TVM_DLL Div(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Div, PrimExpr, DivNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Div, PrimExpr, DivNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(DivNode);
 };
 
@@ -212,7 +210,7 @@ class ModNode : public BinaryOpNode<ModNode> {
 class Mod : public PrimExpr {
  public:
   TVM_DLL Mod(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Mod, PrimExpr, ModNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Mod, PrimExpr, ModNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ModNode);
 };
 
@@ -229,7 +227,7 @@ class FloorDivNode : public BinaryOpNode<FloorDivNode> {
 class FloorDiv : public PrimExpr {
  public:
   TVM_DLL FloorDiv(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(FloorDiv, PrimExpr, FloorDivNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(FloorDiv, PrimExpr, FloorDivNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(FloorDivNode);
 };
 
@@ -246,7 +244,7 @@ class FloorModNode : public BinaryOpNode<FloorModNode> {
 class FloorMod : public PrimExpr {
  public:
   TVM_DLL FloorMod(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(FloorMod, PrimExpr, FloorModNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(FloorMod, PrimExpr, FloorModNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(FloorModNode);
 };
 
@@ -263,7 +261,7 @@ class MinNode : public BinaryOpNode<MinNode> {
 class Min : public PrimExpr {
  public:
   TVM_DLL Min(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Min, PrimExpr, MinNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Min, PrimExpr, MinNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(MinNode);
 };
 
@@ -280,7 +278,7 @@ class MaxNode : public BinaryOpNode<MaxNode> {
 class Max : public PrimExpr {
  public:
   TVM_DLL Max(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Max, PrimExpr, MaxNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Max, PrimExpr, MaxNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(MaxNode);
 };
 
@@ -301,7 +299,9 @@ class CmpOpNode : public PrimExprNode {
     refl::ObjectDef<T>().def_ro("a", &T::a).def_ro("b", &T::b);
   }
 
-  TVM_DECLARE_FINAL_OBJECT_INFO(T, PrimExprNode);
+  static const constexpr int _type_child_slots [[maybe_unused]] = 0;
+  static const constexpr bool _type_final [[maybe_unused]] = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_PREDEFINED_TYPE_KEY(T, PrimExprNode);
 };
 
 /*! \brief a == b */
@@ -317,7 +317,7 @@ class EQNode : public CmpOpNode<EQNode> {
 class EQ : public PrimExpr {
  public:
   TVM_DLL EQ(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(EQ, PrimExpr, EQNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(EQ, PrimExpr, EQNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(EQNode);
 };
 
@@ -334,7 +334,7 @@ class NENode : public CmpOpNode<NENode> {
 class NE : public PrimExpr {
  public:
   TVM_DLL NE(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(NE, PrimExpr, NENode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(NE, PrimExpr, NENode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(NENode);
 };
 
@@ -351,7 +351,7 @@ class LTNode : public CmpOpNode<LTNode> {
 class LT : public PrimExpr {
  public:
   TVM_DLL LT(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(LT, PrimExpr, LTNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(LT, PrimExpr, LTNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(LTNode);
 };
 
@@ -368,7 +368,7 @@ struct LENode : public CmpOpNode<LENode> {
 class LE : public PrimExpr {
  public:
   TVM_DLL LE(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(LE, PrimExpr, LENode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(LE, PrimExpr, LENode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(LENode);
 };
 
@@ -385,7 +385,7 @@ class GTNode : public CmpOpNode<GTNode> {
 class GT : public PrimExpr {
  public:
   TVM_DLL GT(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(GT, PrimExpr, GTNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(GT, PrimExpr, GTNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(GTNode);
 };
 
@@ -402,7 +402,7 @@ class GENode : public CmpOpNode<GENode> {
 class GE : public PrimExpr {
  public:
   TVM_DLL GE(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(GE, PrimExpr, GENode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(GE, PrimExpr, GENode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(GENode);
 };
 
@@ -418,9 +418,7 @@ class AndNode : public PrimExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<AndNode>().def_ro("a", &AndNode::a).def_ro("b", &AndNode::b);
   }
-
-  static constexpr const char* _type_key = "tir.And";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AndNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.And", AndNode, PrimExprNode);
 };
 
 /*!
@@ -430,7 +428,7 @@ class AndNode : public PrimExprNode {
 class And : public PrimExpr {
  public:
   TVM_DLL And(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(And, PrimExpr, AndNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(And, PrimExpr, AndNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(AndNode);
 };
 
@@ -446,9 +444,7 @@ class OrNode : public PrimExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<OrNode>().def_ro("a", &OrNode::a).def_ro("b", &OrNode::b);
   }
-
-  static constexpr const char* _type_key = "tir.Or";
-  TVM_DECLARE_FINAL_OBJECT_INFO(OrNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Or", OrNode, PrimExprNode);
 };
 
 /*!
@@ -458,7 +454,7 @@ class OrNode : public PrimExprNode {
 class Or : public PrimExpr {
  public:
   TVM_DLL Or(PrimExpr a, PrimExpr b, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Or, PrimExpr, OrNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Or, PrimExpr, OrNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(OrNode);
 };
 
@@ -472,9 +468,7 @@ class NotNode : public PrimExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<NotNode>().def_ro("a", &NotNode::a);
   }
-
-  static constexpr const char* _type_key = "tir.Not";
-  TVM_DECLARE_FINAL_OBJECT_INFO(NotNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Not", NotNode, PrimExprNode);
 };
 
 /*!
@@ -484,7 +478,7 @@ class NotNode : public PrimExprNode {
 class Not : public PrimExpr {
  public:
   TVM_DLL Not(PrimExpr a, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Not, PrimExpr, NotNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Not, PrimExpr, NotNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(NotNode);
 };
 
@@ -511,9 +505,7 @@ class SelectNode : public PrimExprNode {
         .def_ro("true_value", &SelectNode::true_value)
         .def_ro("false_value", &SelectNode::false_value);
   }
-
-  static constexpr const char* _type_key = "tir.Select";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SelectNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Select", SelectNode, PrimExprNode);
 };
 
 /*!
@@ -524,7 +516,7 @@ class Select : public PrimExpr {
  public:
   TVM_DLL Select(PrimExpr condition, PrimExpr true_value, PrimExpr false_value, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Select, PrimExpr, SelectNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Select, PrimExpr, SelectNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(SelectNode);
 };
 
@@ -554,9 +546,7 @@ class BufferLoadNode : public PrimExprNode {
         .def_ro("indices", &BufferLoadNode::indices)
         .def_ro("predicate", &BufferLoadNode::predicate);
   }
-
-  static constexpr const char* _type_key = "tir.BufferLoad";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BufferLoadNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.BufferLoad", BufferLoadNode, PrimExprNode);
 
  private:
   /*! \brief Set the dtype based on the buffer/indices
@@ -583,7 +573,7 @@ class BufferLoad : public PrimExpr {
  public:
   TVM_DLL explicit BufferLoad(Buffer buffer, ffi::Array<PrimExpr> indices,
                               ffi::Optional<PrimExpr> predicate = std::nullopt, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(BufferLoad, PrimExpr, BufferLoadNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BufferLoad, PrimExpr, BufferLoadNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BufferLoadNode);
 };
 
@@ -609,9 +599,7 @@ class ProducerLoadNode : public PrimExprNode {
         .def_ro("producer", &ProducerLoadNode::producer)
         .def_ro("indices", &ProducerLoadNode::indices);
   }
-
-  static constexpr const char* _type_key = "tir.ProducerLoad";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ProducerLoadNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.ProducerLoad", ProducerLoadNode, PrimExprNode);
 };
 
 /*!
@@ -623,7 +611,7 @@ class ProducerLoad : public PrimExpr {
   TVM_DLL explicit ProducerLoad(DataProducer producer, ffi::Array<PrimExpr> indices,
                                 Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ProducerLoad, PrimExpr, ProducerLoadNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ProducerLoad, PrimExpr, ProducerLoadNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ProducerLoadNode);
 };
 
@@ -652,9 +640,7 @@ class RampNode : public PrimExprNode {
         .def_ro("stride", &RampNode::stride)
         .def_ro("lanes", &RampNode::lanes);
   }
-
-  static constexpr const char* _type_key = "tir.Ramp";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RampNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Ramp", RampNode, PrimExprNode);
 };
 
 /*!
@@ -664,7 +650,7 @@ class RampNode : public PrimExprNode {
 class Ramp : public PrimExpr {
  public:
   TVM_DLL Ramp(PrimExpr base, PrimExpr stride, PrimExpr lanes, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Ramp, PrimExpr, RampNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Ramp, PrimExpr, RampNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(RampNode);
 };
 
@@ -682,9 +668,7 @@ class BroadcastNode : public PrimExprNode {
         .def_ro("value", &BroadcastNode::value)
         .def_ro("lanes", &BroadcastNode::lanes);
   }
-
-  static constexpr const char* _type_key = "tir.Broadcast";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BroadcastNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Broadcast", BroadcastNode, PrimExprNode);
 };
 
 /*!
@@ -694,7 +678,7 @@ class BroadcastNode : public PrimExprNode {
 class Broadcast : public PrimExpr {
  public:
   TVM_DLL Broadcast(PrimExpr value, PrimExpr lanes, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Broadcast, PrimExpr, BroadcastNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Broadcast, PrimExpr, BroadcastNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BroadcastNode);
 };
 
@@ -717,9 +701,7 @@ class LetNode : public PrimExprNode {
         .def_ro("value", &LetNode::value)
         .def_ro("body", &LetNode::body);
   }
-
-  static constexpr const char* _type_key = "tir.Let";
-  TVM_DECLARE_FINAL_OBJECT_INFO(LetNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Let", LetNode, PrimExprNode);
 };
 
 /*!
@@ -729,7 +711,7 @@ class LetNode : public PrimExprNode {
 class Let : public PrimExpr {
  public:
   TVM_DLL Let(Var var, PrimExpr value, PrimExpr body, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Let, PrimExpr, LetNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Let, PrimExpr, LetNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(LetNode);
 };
 
@@ -753,9 +735,7 @@ class CallNode : public PrimExprNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<CallNode>().def_ro("op", &CallNode::op).def_ro("args", &CallNode::args);
   }
-
-  static constexpr const char* _type_key = "tir.Call";
-  TVM_DECLARE_FINAL_OBJECT_INFO(CallNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Call", CallNode, PrimExprNode);
 };
 
 /*!
@@ -765,7 +745,7 @@ class CallNode : public PrimExprNode {
 class Call : public PrimExpr {
  public:
   TVM_DLL Call(DataType dtype, RelaxExpr op, ffi::Array<PrimExpr> args, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(Call, PrimExpr, CallNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Call, PrimExpr, CallNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(CallNode);
 };
 
@@ -787,9 +767,7 @@ class ShuffleNode : public PrimExprNode {
         .def_ro("vectors", &ShuffleNode::vectors)
         .def_ro("indices", &ShuffleNode::indices);
   }
-
-  static constexpr const char* _type_key = "tir.Shuffle";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ShuffleNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Shuffle", ShuffleNode, PrimExprNode);
 };
 
 /*!
@@ -802,7 +780,7 @@ class Shuffle : public PrimExpr {
   TVM_DLL static PrimExpr Concat(ffi::Array<PrimExpr> vectors, Span span = Span());
   TVM_DLL static PrimExpr ExtractElement(PrimExpr vector, int index, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Shuffle, PrimExpr, ShuffleNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Shuffle, PrimExpr, ShuffleNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ShuffleNode);
 };
 
@@ -843,9 +821,8 @@ class CommReducerNode : public Object {
         .def_ro("span", &CommReducerNode::span, refl::AttachFieldFlag::SEqHashIgnore());
   }
 
-  static constexpr const char* _type_key = "tir.CommReducer";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  TVM_DECLARE_FINAL_OBJECT_INFO(CommReducerNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.CommReducer", CommReducerNode, Object);
 };
 
 /*!
@@ -857,7 +834,7 @@ class CommReducer : public ObjectRef {
   TVM_DLL CommReducer(ffi::Array<Var> lhs, ffi::Array<Var> rhs, ffi::Array<PrimExpr> result,
                       ffi::Array<PrimExpr> identity_element, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(CommReducer, ObjectRef, CommReducerNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(CommReducer, ObjectRef, CommReducerNode);
 };
 
 /*! \brief Reduction operator */
@@ -889,9 +866,7 @@ class ReduceNode : public PrimExprNode {
         .def_ro("condition", &ReduceNode::condition)
         .def_ro("value_index", &ReduceNode::value_index);
   }
-
-  static constexpr const char* _type_key = "tir.Reduce";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ReduceNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Reduce", ReduceNode, PrimExprNode);
 };
 
 /*!
@@ -904,7 +879,7 @@ class Reduce : public PrimExpr {
                  PrimExpr condition, int value_index, ffi::Array<PrimExpr> init,
                  Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Reduce, PrimExpr, ReduceNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Reduce, PrimExpr, ReduceNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ReduceNode);
 };
 

--- a/include/tvm/tir/function.h
+++ b/include/tvm/tir/function.h
@@ -119,9 +119,7 @@ class PrimFuncNode : public BaseFuncNode {
   TVM_DLL FuncType func_type_annotation() const;
 
   TVM_OBJECT_ENABLE_SCRIPT_PRINTER();
-
-  static constexpr const char* _type_key = "tir.PrimFunc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PrimFuncNode, BaseFuncNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.PrimFunc", PrimFuncNode, BaseFuncNode);
 };
 
 /*!
@@ -152,7 +150,7 @@ class PrimFunc : public BaseFunc {
                    ffi::Map<tir::Var, Buffer> buffer_map = ffi::Map<tir::Var, Buffer>(),
                    DictAttrs attrs = DictAttrs(), Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PrimFunc, BaseFunc, PrimFuncNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PrimFunc, BaseFunc, PrimFuncNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(PrimFuncNode);
 };
 
@@ -172,9 +170,7 @@ class TensorIntrinNode : public Object {
         .def_ro("desc", &TensorIntrinNode::desc)
         .def_ro("impl", &TensorIntrinNode::impl);
   }
-
-  static constexpr const char* _type_key = "tir.TensorIntrin";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TensorIntrinNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.TensorIntrin", TensorIntrinNode, Object);
 };
 
 /*!
@@ -211,7 +207,7 @@ class TensorIntrin : public ObjectRef {
    */
   TVM_DLL static ffi::Optional<TensorIntrin> Get(ffi::String name, bool allow_missing = false);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(TensorIntrin, ObjectRef, TensorIntrinNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TensorIntrin, ObjectRef, TensorIntrinNode);
 };
 
 /*!

--- a/include/tvm/tir/index_map.h
+++ b/include/tvm/tir/index_map.h
@@ -163,8 +163,7 @@ class IndexMapNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "tir.IndexMap";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IndexMapNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.IndexMap", IndexMapNode, Object);
 };
 
 class IndexMap : public ObjectRef {
@@ -221,7 +220,7 @@ class IndexMap : public ObjectRef {
   std::pair<IndexMap, PrimExpr> NonSurjectiveInverse(ffi::Array<Range> initial_ranges,
                                                      arith::Analyzer* analyzer) const;
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IndexMap, ObjectRef, IndexMapNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IndexMap, ObjectRef, IndexMapNode);
 };
 
 /*! \brief Substitute variables in an index map.

--- a/include/tvm/tir/schedule/instruction.h
+++ b/include/tvm/tir/schedule/instruction.h
@@ -121,9 +121,7 @@ class InstructionKindNode : public runtime::Object {
 
   /*! \brief Checks if the instruction kind is EnterPostproc */
   bool IsPostproc() const;
-
-  static constexpr const char* _type_key = "tir.InstructionKind";
-  TVM_DECLARE_FINAL_OBJECT_INFO(InstructionKindNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.InstructionKind", InstructionKindNode, runtime::Object);
 };
 
 /*!
@@ -138,7 +136,8 @@ class InstructionKind : public runtime::ObjectRef {
    * \return The InstructionKind retrieved
    */
   static InstructionKind Get(const ffi::String& name);
-  TVM_DEFINE_OBJECT_REF_METHODS(InstructionKind, runtime::ObjectRef, InstructionKindNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(InstructionKind, runtime::ObjectRef,
+                                             InstructionKindNode);
 };
 
 /*! \brief Schedule instructions each corresponds to a schedule primitive */
@@ -180,9 +179,7 @@ class InstructionNode : public runtime::Object {
         .def_ro("attrs", &InstructionNode::attrs)
         .def_ro("outputs", &InstructionNode::outputs);
   }
-
-  static constexpr const char* _type_key = "tir.Instruction";
-  TVM_DECLARE_FINAL_OBJECT_INFO(InstructionNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Instruction", InstructionNode, runtime::Object);
 };
 
 /*!
@@ -201,7 +198,7 @@ class Instruction : public runtime::ObjectRef {
   explicit Instruction(InstructionKind kind, ffi::Array<Any> inputs, ffi::Array<Any> attrs,
                        ffi::Array<Any> outputs);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Instruction, runtime::ObjectRef, InstructionNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Instruction, runtime::ObjectRef, InstructionNode);
 };
 
 /*!

--- a/include/tvm/tir/schedule/schedule.h
+++ b/include/tvm/tir/schedule/schedule.h
@@ -53,9 +53,7 @@ class BlockRVNode : public runtime::Object {
   static void RegisterReflection() {
     // No fields to register as they are not visited
   }
-
-  static constexpr const char* _type_key = "tir.BlockRV";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BlockRVNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.BlockRV", BlockRVNode, runtime::Object);
 };
 
 /*!
@@ -66,7 +64,7 @@ class BlockRV : public runtime::ObjectRef {
  public:
   /*! \brief Constructor */
   TVM_DLL BlockRV();
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(BlockRV, runtime::ObjectRef, BlockRVNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(BlockRV, runtime::ObjectRef, BlockRVNode);
 };
 
 /**************** Random variable: LoopRV ****************/
@@ -77,9 +75,7 @@ class LoopRVNode : public runtime::Object {
   static void RegisterReflection() {
     // No fields to register as they are not visited
   }
-
-  static constexpr const char* _type_key = "tir.LoopRV";
-  TVM_DECLARE_FINAL_OBJECT_INFO(LoopRVNode, runtime::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.LoopRV", LoopRVNode, runtime::Object);
 };
 
 /*!
@@ -90,7 +86,7 @@ class LoopRV : public runtime::ObjectRef {
  public:
   /*! \brief Constructor */
   TVM_DLL LoopRV();
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(LoopRV, runtime::ObjectRef, LoopRVNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(LoopRV, runtime::ObjectRef, LoopRVNode);
 };
 
 /**************** Random variable: ExprRV ****************/
@@ -111,8 +107,8 @@ class ScheduleNode : public runtime::Object {
  public:
   virtual ~ScheduleNode() = default;
 
-  static constexpr const char* _type_key = "tir.Schedule";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ScheduleNode, runtime::Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Schedule", ScheduleNode, runtime::Object);
 
  public:
   /*! \brief Get the IRModule associated with this schedule. */
@@ -921,7 +917,7 @@ class Schedule : public runtime::ObjectRef {
   TVM_DLL static Schedule Traced(IRModule mod, support::LinearCongruentialEngine::TRandState seed,
                                  int debug_mask, ScheduleErrorRenderLevel error_render_level,
                                  bool enable_check = true);
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(Schedule, runtime::ObjectRef, ScheduleNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Schedule, runtime::ObjectRef, ScheduleNode);
 };
 
 }  // namespace tir

--- a/include/tvm/tir/schedule/state.h
+++ b/include/tvm/tir/schedule/state.h
@@ -156,8 +156,8 @@ class ScheduleStateNode : public Object {
    */
   TVM_DLL void DebugVerify() const;
 
-  static constexpr const char* _type_key = "tir.ScheduleState";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ScheduleStateNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.ScheduleState", ScheduleStateNode, Object);
 
   /******** Property of blocks ********/
   /*! \brief Returns the BlockInfo correpsonding to the block sref */
@@ -218,10 +218,7 @@ class ScheduleState : public ObjectRef {
    */
   TVM_DLL explicit ScheduleState(IRModule mod, int debug_mask = 0, bool enable_check = true);
 
-  /*! \return The mutable pointer to the ScheduleStateNode */
-  ScheduleStateNode* get() const { return static_cast<ScheduleStateNode*>(data_.get()); }
-
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(ScheduleState, ObjectRef, ScheduleStateNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ScheduleState, ObjectRef, ScheduleStateNode);
 };
 
 }  // namespace tir

--- a/include/tvm/tir/schedule/trace.h
+++ b/include/tvm/tir/schedule/trace.h
@@ -69,8 +69,8 @@ class TraceNode : public runtime::Object {
         .def_ro("decisions", &TraceNode::decisions);
   }
 
-  static constexpr const char* _type_key = "tir.Trace";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TraceNode, runtime::Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Trace", TraceNode, runtime::Object);
 
  public:
   /*!
@@ -157,7 +157,7 @@ class Trace : public runtime::ObjectRef {
    */
   static void ApplyJSONToSchedule(ObjectRef json, Schedule sch);
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(Trace, runtime::ObjectRef, TraceNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Trace, runtime::ObjectRef, TraceNode);
 };
 
 }  // namespace tir

--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -53,17 +53,16 @@ class StmtNode : public Object {
 
   TVM_OBJECT_ENABLE_SCRIPT_PRINTER();
 
-  static constexpr const char* _type_key = "tir.Stmt";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
 
   static constexpr const uint32_t _type_child_slots = 15;
-  TVM_DECLARE_BASE_OBJECT_INFO(StmtNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("tir.Stmt", StmtNode, Object);
 };
 
 /*! \brief Container of all statements */
 class Stmt : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(Stmt, ObjectRef, StmtNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Stmt, ObjectRef, StmtNode);
 };
 
 /*!
@@ -85,9 +84,7 @@ class LetStmtNode : public StmtNode {
         .def_ro("value", &LetStmtNode::value)
         .def_ro("body", &LetStmtNode::body);
   }
-
-  static constexpr const char* _type_key = "tir.LetStmt";
-  TVM_DECLARE_FINAL_OBJECT_INFO(LetStmtNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.LetStmt", LetStmtNode, StmtNode);
 };
 
 /*!
@@ -98,7 +95,7 @@ class LetStmt : public Stmt {
  public:
   TVM_DLL LetStmt(Var var, PrimExpr value, Stmt body, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(LetStmt, Stmt, LetStmtNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(LetStmt, Stmt, LetStmtNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(LetStmtNode);
 };
 
@@ -131,9 +128,7 @@ class AttrStmtNode : public StmtNode {
         .def_ro("value", &AttrStmtNode::value)
         .def_ro("body", &AttrStmtNode::body);
   }
-
-  static constexpr const char* _type_key = "tir.AttrStmt";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AttrStmtNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.AttrStmt", AttrStmtNode, StmtNode);
 };
 
 /*!
@@ -145,7 +140,7 @@ class AttrStmt : public Stmt {
   TVM_DLL AttrStmt(ffi::Any node, ffi::String attr_key, PrimExpr value, Stmt body,
                    Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(AttrStmt, Stmt, AttrStmtNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(AttrStmt, Stmt, AttrStmtNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(AttrStmtNode);
 };
 
@@ -171,9 +166,7 @@ class AssertStmtNode : public StmtNode {
         .def_ro("message", &AssertStmtNode::message)
         .def_ro("body", &AssertStmtNode::body);
   }
-
-  static constexpr const char* _type_key = "tir.AssertStmt";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AssertStmtNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.AssertStmt", AssertStmtNode, StmtNode);
 };
 
 /*!
@@ -184,7 +177,7 @@ class AssertStmt : public Stmt {
  public:
   TVM_DLL AssertStmt(PrimExpr condition, PrimExpr message, Stmt body, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(AssertStmt, Stmt, AssertStmtNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(AssertStmt, Stmt, AssertStmtNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(AssertStmtNode);
 };
 
@@ -217,9 +210,7 @@ class BufferStoreNode : public StmtNode {
         .def_ro("indices", &BufferStoreNode::indices)
         .def_ro("predicate", &BufferStoreNode::predicate);
   }
-
-  static constexpr const char* _type_key = "tir.BufferStore";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BufferStoreNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.BufferStore", BufferStoreNode, StmtNode);
 };
 
 /*!
@@ -232,7 +223,7 @@ class BufferStore : public Stmt {
                                ffi::Optional<PrimExpr> predicate = std::nullopt,
                                Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(BufferStore, Stmt, BufferStoreNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BufferStore, Stmt, BufferStoreNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BufferStoreNode);
 };
 
@@ -271,9 +262,7 @@ class BufferRealizeNode : public StmtNode {
   BufferRealizeNode(Buffer buffer, ffi::Array<Range> bounds, PrimExpr condition, Stmt body,
                     Span span = Span())
       : StmtNode(span), buffer(buffer), bounds(bounds), condition(condition), body(body) {}
-
-  static constexpr const char* _type_key = "tir.BufferRealize";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BufferRealizeNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.BufferRealize", BufferRealizeNode, StmtNode);
 };
 
 /*!
@@ -285,7 +274,7 @@ class BufferRealize : public Stmt {
   TVM_DLL explicit BufferRealize(Buffer buffer, ffi::Array<Range> bounds, PrimExpr condition,
                                  Stmt body, Span span = Span());
 
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(BufferRealize, Stmt, BufferRealizeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(BufferRealize, Stmt, BufferRealizeNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BufferRealizeNode);
 };
 
@@ -336,10 +325,7 @@ class AllocateNode : public StmtNode {
    * \return The result.
    */
   TVM_DLL static int64_t ConstantAllocationSize(const ffi::Array<PrimExpr>& extents);
-
-  static constexpr const char* _type_key = "tir.Allocate";
-
-  TVM_DECLARE_FINAL_OBJECT_INFO(AllocateNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Allocate", AllocateNode, StmtNode);
 };
 
 /*!
@@ -353,7 +339,7 @@ class Allocate : public Stmt {
                    ffi::Map<ffi::String, ffi::Any> annotations = ffi::Map<ffi::String, ffi::Any>(),
                    Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Allocate, Stmt, AllocateNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Allocate, Stmt, AllocateNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(AllocateNode);
 };
 
@@ -411,9 +397,7 @@ class AllocateConstNode : public StmtNode {
    * \return The result.
    */
   TVM_DLL static int64_t ConstantAllocationSize(const ffi::Array<PrimExpr>& extents);
-
-  static constexpr const char* _type_key = "tir.AllocateConst";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AllocateConstNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.AllocateConst", AllocateConstNode, StmtNode);
 };
 
 /*!
@@ -430,7 +414,7 @@ class AllocateConst : public Stmt {
       Var buffer_var, DataType dtype, ffi::Array<PrimExpr> extents, ObjectRef data_or_idx,
       Stmt body, ffi::Map<ffi::String, ffi::Any> annotations = ffi::Map<ffi::String, ffi::Any>(),
       Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(AllocateConst, Stmt, AllocateConstNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(AllocateConst, Stmt, AllocateConstNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(AllocateConstNode);
 };
 
@@ -448,16 +432,14 @@ class DeclBufferNode : public StmtNode {
         .def_ro("buffer", &DeclBufferNode::buffer)
         .def_ro("body", &DeclBufferNode::body);
   }
-
-  static constexpr const char* _type_key = "tir.DeclBuffer";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DeclBufferNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.DeclBuffer", DeclBufferNode, StmtNode);
 };
 
 /*! \brief Managed reference to DeclBufferNode */
 class DeclBuffer : public Stmt {
  public:
   TVM_DLL DeclBuffer(Buffer buffer, Stmt body, Span span = Span());
-  TVM_DEFINE_OBJECT_REF_METHODS(DeclBuffer, Stmt, DeclBufferNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DeclBuffer, Stmt, DeclBufferNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(DeclBufferNode);
 };
 
@@ -481,9 +463,7 @@ class SeqStmtNode : public StmtNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<SeqStmtNode>().def_ro("seq", &SeqStmtNode::seq);
   }
-
-  static constexpr const char* _type_key = "tir.SeqStmt";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SeqStmtNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.SeqStmt", SeqStmtNode, StmtNode);
 };
 
 /*!
@@ -501,9 +481,7 @@ class EvaluateNode : public StmtNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<EvaluateNode>().def_ro("value", &EvaluateNode::value);
   }
-
-  static constexpr const char* _type_key = "tir.Evaluate";
-  TVM_DECLARE_FINAL_OBJECT_INFO(EvaluateNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Evaluate", EvaluateNode, StmtNode);
 };
 
 /*!
@@ -516,7 +494,7 @@ class Evaluate : public Stmt {
 
   explicit Evaluate(int value, Span span = Span()) : Evaluate(PrimExpr(value), span) {}
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Evaluate, Stmt, EvaluateNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Evaluate, Stmt, EvaluateNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(EvaluateNode);
 };
 
@@ -667,7 +645,7 @@ class SeqStmt : public Stmt {
     ffi::Array<Stmt>* seq_;
   };
 
-  TVM_DEFINE_OBJECT_REF_METHODS(SeqStmt, Stmt, SeqStmtNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(SeqStmt, Stmt, SeqStmtNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(SeqStmtNode);
 };
 
@@ -690,9 +668,7 @@ class IfThenElseNode : public StmtNode {
         .def_ro("then_case", &IfThenElseNode::then_case)
         .def_ro("else_case", &IfThenElseNode::else_case);
   }
-
-  static constexpr const char* _type_key = "tir.IfThenElse";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IfThenElseNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.IfThenElse", IfThenElseNode, StmtNode);
 };
 
 /*!
@@ -704,7 +680,7 @@ class IfThenElse : public Stmt {
   TVM_DLL IfThenElse(PrimExpr condition, Stmt then_case,
                      ffi::Optional<Stmt> else_case = std::nullopt, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IfThenElse, Stmt, IfThenElseNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IfThenElse, Stmt, IfThenElseNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(IfThenElseNode);
 };
 
@@ -784,9 +760,7 @@ class ForNode : public StmtNode {
         .def_ro("thread_binding", &ForNode::thread_binding)
         .def_ro("annotations", &ForNode::annotations);
   }
-
-  static constexpr const char* _type_key = "tir.For";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ForNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.For", ForNode, StmtNode);
 };
 
 /*!
@@ -800,7 +774,7 @@ class For : public Stmt {
               ffi::Map<ffi::String, ffi::Any> annotations = ffi::Map<ffi::String, ffi::Any>(),
               Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(For, Stmt, ForNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(For, Stmt, ForNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(ForNode);
 };
 
@@ -827,9 +801,7 @@ class WhileNode : public StmtNode {
         .def_ro("condition", &WhileNode::condition)
         .def_ro("body", &WhileNode::body);
   }
-
-  static constexpr const char* _type_key = "tir.While";
-  TVM_DECLARE_FINAL_OBJECT_INFO(WhileNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.While", WhileNode, StmtNode);
 };
 
 /*!
@@ -840,7 +812,7 @@ class While : public Stmt {
  public:
   TVM_DLL While(PrimExpr condition, Stmt body, Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(While, Stmt, WhileNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(While, Stmt, WhileNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(WhileNode);
 };
 
@@ -863,9 +835,8 @@ class BufferRegionNode : public PrimExprConvertibleNode {
 
   TVM_DLL PrimExpr ToPrimExpr() const final;
 
-  static constexpr const char* _type_key = "tir.BufferRegion";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  TVM_DECLARE_FINAL_OBJECT_INFO(BufferRegionNode, PrimExprConvertibleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.BufferRegion", BufferRegionNode, PrimExprConvertibleNode);
 };
 
 /*!
@@ -891,7 +862,7 @@ class BufferRegion : public PrimExprConvertible {
    */
   TVM_DLL static BufferRegion FromPoint(Buffer buffer, ffi::Array<PrimExpr> indices);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(BufferRegion, PrimExprConvertible, BufferRegionNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BufferRegion, PrimExprConvertible, BufferRegionNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BufferRegionNode);
 };
 
@@ -918,9 +889,8 @@ class MatchBufferRegionNode : public Object {
         .def_ro("source", &MatchBufferRegionNode::source);
   }
 
-  static constexpr const char* _type_key = "tir.MatchBufferRegion";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  TVM_DECLARE_FINAL_OBJECT_INFO(MatchBufferRegionNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.MatchBufferRegion", MatchBufferRegionNode, Object);
 };
 
 /*!
@@ -931,7 +901,7 @@ class MatchBufferRegion : public ObjectRef {
  public:
   TVM_DLL explicit MatchBufferRegion(Buffer buffer, BufferRegion source);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(MatchBufferRegion, ObjectRef, MatchBufferRegionNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MatchBufferRegion, ObjectRef, MatchBufferRegionNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(MatchBufferRegionNode);
 };
 
@@ -996,9 +966,7 @@ class BlockNode : public StmtNode {
         .def_ro("init", &BlockNode::init)
         .def_ro("body", &BlockNode::body);
   }
-
-  static constexpr const char* _type_key = "tir.Block";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BlockNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.Block", BlockNode, StmtNode);
 };
 
 /*!
@@ -1016,7 +984,7 @@ class Block : public Stmt {
       ffi::Map<ffi::String, ffi::Any> annotations = ffi::Map<ffi::String, ffi::Any>(),
       Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Block, Stmt, BlockNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Block, Stmt, BlockNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BlockNode);
 };
 
@@ -1042,9 +1010,7 @@ class BlockRealizeNode : public StmtNode {
         .def_ro("predicate", &BlockRealizeNode::predicate)
         .def_ro("block", &BlockRealizeNode::block);
   }
-
-  static constexpr const char* _type_key = "tir.BlockRealize";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BlockRealizeNode, StmtNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.BlockRealize", BlockRealizeNode, StmtNode);
 };
 
 /*!
@@ -1056,7 +1022,7 @@ class BlockRealize : public Stmt {
   TVM_DLL explicit BlockRealize(ffi::Array<PrimExpr> iter_values, PrimExpr predicate, Block block,
                                 Span span = Span());
 
-  TVM_DEFINE_OBJECT_REF_METHODS(BlockRealize, Stmt, BlockRealizeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BlockRealize, Stmt, BlockRealizeNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BlockRealizeNode);
 };
 

--- a/include/tvm/tir/var.h
+++ b/include/tvm/tir/var.h
@@ -69,9 +69,8 @@ class VarNode : public PrimExprNode {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindFreeVar;
-  static constexpr const char* _type_key = "tir.Var";
   static constexpr const uint32_t _type_child_slots = 1;
-  TVM_DECLARE_BASE_OBJECT_INFO(VarNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("tir.Var", VarNode, PrimExprNode);
 };
 
 /*! \brief a named variable in TIR */
@@ -137,8 +136,7 @@ class SizeVarNode : public VarNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<SizeVarNode>();
   }
-  static constexpr const char* _type_key = "tir.SizeVar";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SizeVarNode, VarNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.SizeVar", SizeVarNode, VarNode);
 };
 
 /*! \brief a named variable represents a tensor index size */
@@ -286,9 +284,8 @@ class IterVarNode : public PrimExprConvertibleNode {
         .def_ro("thread_tag", &IterVarNode::thread_tag);
   }
 
-  static constexpr const char* _type_key = "tir.IterVar";
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  TVM_DECLARE_FINAL_OBJECT_INFO(IterVarNode, PrimExprConvertibleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.IterVar", IterVarNode, PrimExprConvertibleNode);
 };
 
 /*!
@@ -306,7 +303,7 @@ class IterVar : public PrimExprConvertible {
    */
   inline operator PrimExpr() const;
 
-  TVM_DEFINE_OBJECT_REF_METHODS(IterVar, PrimExprConvertible, IterVarNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IterVar, PrimExprConvertible, IterVarNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(IterVarNode);
 };
 

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -251,9 +251,10 @@ def get_cuda_version(cuda_path=None):
 def find_nvshmem_paths() -> Tuple[str, str]:
     """
     Searches for the NVSHMEM include and library directories.
-    Returns:
-        A tuple containing the path to the include directory and the library directory.
-        (include_path, lib_path)
+
+    Returns
+    -------
+    A tuple containing the path to the include directory and the library directory.
     """
     candidate_roots = []
 

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -52,9 +52,8 @@ class CanonicalExprNode : public PrimExprNode {
    */
   virtual PrimExpr Normalize() const = 0;
 
-  static constexpr const char* _type_key = "arith.CanonicalExpr";
   static constexpr const uint32_t _type_child_slots = 2;
-  TVM_DECLARE_BASE_OBJECT_INFO(CanonicalExprNode, PrimExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("arith.CanonicalExpr", CanonicalExprNode, PrimExprNode);
 };
 
 inline PrimExpr ModImpl(PrimExpr a, PrimExpr b, DivMode mode) {
@@ -204,13 +203,12 @@ class SplitExprNode : public CanonicalExprNode {
 
   /*! \brief positive infty */
   static const constexpr int64_t kPosInf = ConstIntBoundNode::kPosInf;
-  static constexpr const char* _type_key = "arith.SplitExpr";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SplitExprNode, CanonicalExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.SplitExpr", SplitExprNode, CanonicalExprNode);
 };
 
 class SplitExpr : public PrimExpr {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(SplitExpr, PrimExpr, SplitExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(SplitExpr, PrimExpr, SplitExprNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(SplitExprNode);
 };
 
@@ -390,9 +388,7 @@ class SumExprNode : public CanonicalExprNode {
     }
     this->dtype = dtype;
   }
-
-  static constexpr const char* _type_key = "arith.SumExpr";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SumExprNode, CanonicalExprNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.SumExpr", SumExprNode, CanonicalExprNode);
 
  private:
   /*!
@@ -524,7 +520,7 @@ class SumExprNode : public CanonicalExprNode {
 
 class SumExpr : public PrimExpr {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(SumExpr, PrimExpr, SumExprNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(SumExpr, PrimExpr, SumExprNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(SumExprNode);
 };
 

--- a/src/arith/interval_set.h
+++ b/src/arith/interval_set.h
@@ -75,9 +75,7 @@ class IntervalSetNode : public IntSetNode {
   }
   /*! \return whether interval represent everything */
   bool IsEverything() const { return is_neg_inf(min_value) && is_pos_inf(max_value); }
-
-  static constexpr const char* _type_key = "arith.IntervalSet";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IntervalSetNode, IntSetNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.IntervalSet", IntervalSetNode, IntSetNode);
 };
 
 /*!
@@ -113,7 +111,7 @@ class IntervalSet : public IntSet {
   static IntervalSet Empty() { return IntervalSet(pos_inf(), neg_inf()); }
 
   TVM_DEFINE_OBJECT_REF_COW_METHOD(IntervalSetNode);
-  TVM_DEFINE_OBJECT_REF_METHODS(IntervalSet, IntSet, IntervalSetNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntervalSet, IntSet, IntervalSetNode);
 };
 
 /*!

--- a/src/arith/presburger_set.h
+++ b/src/arith/presburger_set.h
@@ -116,9 +116,7 @@ class PresburgerSetNode : public IntSetNode {
     return std::all_of(disjuncts.begin(), disjuncts.end(),
                        std::mem_fn(&IntegerRelation::isIntegerEmpty));
   }
-
-  static constexpr const char* _type_key = "arith.PresburgerSet";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PresburgerSetNode, IntSetNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.PresburgerSet", PresburgerSetNode, IntSetNode);
 
  private:
   ffi::Array<Var> vars;
@@ -146,7 +144,7 @@ class PresburgerSet : public IntSet {
   TVM_DLL PresburgerSet(const PrimExpr& constraint);
 
   TVM_DEFINE_OBJECT_REF_COW_METHOD(PresburgerSetNode);
-  TVM_DEFINE_OBJECT_REF_METHODS(PresburgerSet, IntSet, PresburgerSetNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PresburgerSet, IntSet, PresburgerSetNode);
 };
 #endif  // TVM_MLIR_VERSION >= 150
 #else   // TVM_MLIR_VERSION
@@ -158,9 +156,7 @@ class PresburgerSetNode : public IntSetNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PresburgerSetNode>();
   }
-
-  static constexpr const char* _type_key = "arith.PresburgerSet";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PresburgerSetNode, IntSetNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.PresburgerSet", PresburgerSetNode, IntSetNode);
 };
 
 class PresburgerSet : public IntSet {

--- a/src/arith/rewrite_simplify.h
+++ b/src/arith/rewrite_simplify.h
@@ -64,9 +64,8 @@ struct RewriteSimplifierStatsNode : Object {
         .def_ro("max_recursive_depth", &RewriteSimplifierStatsNode::max_recursive_depth)
         .def_ro("num_recursive_rewrites", &RewriteSimplifierStatsNode::num_recursive_rewrites);
   }
-
-  static constexpr const char* _type_key = "arith.RewriteSimplifierStats";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RewriteSimplifierStatsNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("arith.RewriteSimplifierStats", RewriteSimplifierStatsNode,
+                                    Object);
 };
 
 struct RewriteSimplifierStats : ObjectRef {
@@ -74,7 +73,8 @@ struct RewriteSimplifierStats : ObjectRef {
     data_ = ffi::make_object<RewriteSimplifierStatsNode>(data);
   }
 
-  TVM_DEFINE_OBJECT_REF_METHODS(RewriteSimplifierStats, ObjectRef, RewriteSimplifierStatsNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(RewriteSimplifierStats, ObjectRef,
+                                             RewriteSimplifierStatsNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(RewriteSimplifierStatsNode);
 };
 

--- a/src/contrib/msc/core/ir/graph.h
+++ b/src/contrib/msc/core/ir/graph.h
@@ -388,8 +388,7 @@ class MSCTensorNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "msc.core.MSCTensor";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MSCTensorNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.core.MSCTensor", MSCTensorNode, Object);
 };
 
 /*!
@@ -423,7 +422,7 @@ class MSCTensor : public ObjectRef {
    */
   TVM_DLL MSCTensor(const std::string& json_str);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(MSCTensor, ObjectRef, MSCTensorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MSCTensor, ObjectRef, MSCTensorNode);
 };
 
 /*!
@@ -489,9 +488,8 @@ class BaseJointNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "msc.core.BaseJoint";
   static constexpr const uint32_t _type_child_slots = 2;
-  TVM_DECLARE_BASE_OBJECT_INFO(BaseJointNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("msc.core.BaseJoint", BaseJointNode, Object);
 };
 
 /*!
@@ -500,7 +498,7 @@ class BaseJointNode : public Object {
  */
 class BaseJoint : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(BaseJoint, ObjectRef, BaseJointNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BaseJoint, ObjectRef, BaseJointNode);
 };
 
 /*!
@@ -559,8 +557,7 @@ class MSCJointNode : public BaseJointNode {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "msc.core.MSCJoint";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MSCJointNode, BaseJointNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.core.MSCJoint", MSCJointNode, BaseJointNode);
 };
 
 /*!
@@ -603,7 +600,7 @@ class MSCJoint : public BaseJoint {
   TVM_DLL static const MSCJoint Clone(const MSCJoint& node,
                                       const std::vector<std::pair<BaseJoint, size_t>>& inputs);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(MSCJoint, BaseJoint, MSCJointNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MSCJoint, BaseJoint, MSCJointNode);
 };
 
 /*!
@@ -629,9 +626,7 @@ class MSCPrimNode : public BaseJointNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<MSCPrimNode>().def_ro("optype", &MSCPrimNode::optype);
   }
-
-  static constexpr const char* _type_key = "msc.core.MSCPrim";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MSCPrimNode, BaseJointNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.core.MSCPrim", MSCPrimNode, BaseJointNode);
 };
 
 /*!
@@ -665,7 +660,7 @@ class MSCPrim : public BaseJoint {
    */
   TVM_DLL MSCPrim(const std::string& json_str, const ffi::Map<ffi::String, BaseJoint>& prims);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(MSCPrim, BaseJoint, MSCPrimNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MSCPrim, BaseJoint, MSCPrimNode);
 };
 
 /*!
@@ -698,9 +693,7 @@ class WeightJointNode : public BaseJointNode {
         .def_ro("weight", &WeightJointNode::weight)
         .def_ro("friends", &WeightJointNode::friends);
   }
-
-  static constexpr const char* _type_key = "msc.core.WeightJoint";
-  TVM_DECLARE_FINAL_OBJECT_INFO(WeightJointNode, BaseJointNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.core.WeightJoint", WeightJointNode, BaseJointNode);
 };
 
 /*!
@@ -739,7 +732,7 @@ class WeightJoint : public BaseJoint {
    */
   TVM_DLL WeightJoint(const std::string& json_str, const ffi::Map<ffi::String, BaseJoint>& nodes);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(WeightJoint, BaseJoint, WeightJointNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(WeightJoint, BaseJoint, WeightJointNode);
 };
 
 /*!
@@ -765,10 +758,9 @@ class BaseGraphNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "msc.core.BaseGraph";
 
   static constexpr const uint32_t _type_child_slots = 2;
-  TVM_DECLARE_BASE_OBJECT_INFO(BaseGraphNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("msc.core.BaseGraph", BaseGraphNode, Object);
 };
 
 /*!
@@ -777,7 +769,7 @@ class BaseGraphNode : public Object {
  */
 class BaseGraph : public ObjectRef {
  public:
-  TVM_DEFINE_OBJECT_REF_METHODS(BaseGraph, ObjectRef, BaseGraphNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BaseGraph, ObjectRef, BaseGraphNode);
 };
 
 /*!
@@ -856,9 +848,7 @@ class MSCGraphNode : public BaseGraphNode {
         .def_ro("output_names", &MSCGraphNode::output_names)
         .def_ro("weight_holders", &MSCGraphNode::weight_holders);
   }
-
-  static constexpr const char* _type_key = "msc.core.MSCGraph";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MSCGraphNode, BaseGraphNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.core.MSCGraph", MSCGraphNode, BaseGraphNode);
 };
 
 /*!
@@ -892,7 +882,7 @@ class MSCGraph : public BaseGraph {
    */
   TVM_DLL MSCGraph(const std::string& json_str);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(MSCGraph, BaseGraph, MSCGraphNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MSCGraph, BaseGraph, MSCGraphNode);
 };
 
 /*!
@@ -919,9 +909,7 @@ class WeightGraphNode : public BaseGraphNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<WeightGraphNode>();
   }
-
-  static constexpr const char* _type_key = "msc.core.WeightGraph";
-  TVM_DECLARE_FINAL_OBJECT_INFO(WeightGraphNode, BaseGraphNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.core.WeightGraph", WeightGraphNode, BaseGraphNode);
 };
 
 /*!
@@ -952,7 +940,7 @@ class WeightGraph : public BaseGraph {
    */
   TVM_DLL WeightGraph(const std::string& json_str);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(WeightGraph, BaseGraph, WeightGraphNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(WeightGraph, BaseGraph, WeightGraphNode);
 };
 
 MSCGraph PruneWeights(const MSCGraph& graph,

--- a/src/contrib/msc/core/ir/plugin.h
+++ b/src/contrib/msc/core/ir/plugin.h
@@ -279,8 +279,7 @@ class PluginAttrNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "msc.core.PluginAttr";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PluginAttrNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.core.PluginAttr", PluginAttrNode, Object);
 };
 
 /*!
@@ -311,7 +310,7 @@ class PluginAttr : public ObjectRef {
    */
   TVM_DLL PluginAttr(const std::string& json_str);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PluginAttr, ObjectRef, PluginAttrNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PluginAttr, ObjectRef, PluginAttrNode);
 };
 
 /*!
@@ -348,8 +347,7 @@ class PluginTensorNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "msc.core.PluginTensor";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PluginTensorNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.core.PluginTensor", PluginTensorNode, Object);
 };
 
 /*!
@@ -381,7 +379,7 @@ class PluginTensor : public ObjectRef {
    */
   TVM_DLL PluginTensor(const std::string& json_str);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PluginTensor, ObjectRef, PluginTensorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PluginTensor, ObjectRef, PluginTensorNode);
 };
 
 /*!
@@ -418,8 +416,7 @@ class PluginExternNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "msc.core.PluginExtern";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PluginExternNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.core.PluginExtern", PluginExternNode, Object);
 };
 
 /*!
@@ -452,7 +449,7 @@ class PluginExtern : public ObjectRef {
    */
   TVM_DLL PluginExtern(const std::string& json_str);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PluginExtern, ObjectRef, PluginExternNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PluginExtern, ObjectRef, PluginExternNode);
 };
 
 /*!
@@ -509,8 +506,7 @@ class PluginNode : public Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
-  static constexpr const char* _type_key = "msc.core.Plugin";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PluginNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.core.Plugin", PluginNode, Object);
 };
 
 /*!
@@ -551,7 +547,7 @@ class Plugin : public ObjectRef {
    */
   TVM_DLL Plugin(const std::string& json_str);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(Plugin, ObjectRef, PluginNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Plugin, ObjectRef, PluginNode);
 };
 
 class PluginRegistry {

--- a/src/contrib/msc/core/printer/msc_doc.h
+++ b/src/contrib/msc/core/printer/msc_doc.h
@@ -59,9 +59,7 @@ class DeclareDocNode : public ExprDocNode {
         .def_ro("init_args", &DeclareDocNode::init_args)
         .def_ro("use_constructor", &DeclareDocNode::use_constructor);
   }
-
-  static constexpr const char* _type_key = "msc.script.printer.DeclareDoc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DeclareDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.script.printer.DeclareDoc", DeclareDocNode, ExprDocNode);
 };
 
 /*!
@@ -80,7 +78,7 @@ class DeclareDoc : public ExprDoc {
    */
   explicit DeclareDoc(ffi::Optional<ExprDoc> type, ExprDoc variable, ffi::Array<ExprDoc> init_args,
                       bool use_constructor);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(DeclareDoc, ExprDoc, DeclareDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(DeclareDoc, ExprDoc, DeclareDocNode);
 };
 
 /*!
@@ -101,9 +99,8 @@ class StrictListDocNode : public ExprDocNode {
         .def_ro("list", &StrictListDocNode::list)
         .def_ro("allow_empty", &StrictListDocNode::allow_empty);
   }
-
-  static constexpr const char* _type_key = "msc.script.printer.StrictListDoc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(StrictListDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.script.printer.StrictListDoc", StrictListDocNode,
+                                    ExprDocNode);
 };
 
 /*!
@@ -119,7 +116,7 @@ class StrictListDoc : public ExprDoc {
    * \param allow_empty Whether to allow empty.
    */
   explicit StrictListDoc(ListDoc list, bool allow_empty);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(StrictListDoc, ExprDoc, StrictListDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(StrictListDoc, ExprDoc, StrictListDocNode);
 };
 
 /*!
@@ -136,9 +133,7 @@ class PointerDocNode : public ExprDocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PointerDocNode>().def_ro("name", &PointerDocNode::name);
   }
-
-  static constexpr const char* _type_key = "msc.script.printer.PointerDoc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PointerDocNode, ExprDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.script.printer.PointerDoc", PointerDocNode, ExprDocNode);
 };
 
 /*!
@@ -153,7 +148,7 @@ class PointerDoc : public ExprDoc {
    * \param name The name of identifier.
    */
   explicit PointerDoc(ffi::String name);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(PointerDoc, ExprDoc, PointerDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(PointerDoc, ExprDoc, PointerDocNode);
 };
 
 /*!
@@ -177,9 +172,7 @@ class StructDocNode : public StmtDocNode {
         .def_ro("decorators", &StructDocNode::decorators)
         .def_ro("body", &StructDocNode::body);
   }
-
-  static constexpr const char* _type_key = "msc.script.printer.StructDoc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(StructDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.script.printer.StructDoc", StructDocNode, StmtDocNode);
 };
 
 /*!
@@ -196,7 +189,7 @@ class StructDoc : public StmtDoc {
    * \param body The body of class.
    */
   explicit StructDoc(IdDoc name, ffi::Array<ExprDoc> decorators, ffi::Array<StmtDoc> body);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(StructDoc, StmtDoc, StructDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(StructDoc, StmtDoc, StructDocNode);
 };
 
 /*!
@@ -226,9 +219,8 @@ class ConstructorDocNode : public StmtDocNode {
         .def_ro("args", &ConstructorDocNode::args)
         .def_ro("body", &ConstructorDocNode::body);
   }
-
-  static constexpr const char* _type_key = "msc.script.printer.ConstructorDoc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ConstructorDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.script.printer.ConstructorDoc", ConstructorDocNode,
+                                    StmtDocNode);
 };
 
 /*!
@@ -245,7 +237,7 @@ class ConstructorDoc : public StmtDoc {
    * \param body The body of function.
    */
   explicit ConstructorDoc(IdDoc name, ffi::Array<AssignDoc> args, ffi::Array<StmtDoc> body);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ConstructorDoc, StmtDoc, ConstructorDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ConstructorDoc, StmtDoc, ConstructorDocNode);
 };
 
 /*!
@@ -269,9 +261,7 @@ class SwitchDocNode : public StmtDocNode {
         .def_ro("branchs", &SwitchDocNode::branchs)
         .def_ro("default_branch", &SwitchDocNode::default_branch);
   }
-
-  static constexpr const char* _type_key = "msc.script.printer.SwitchDoc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SwitchDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.script.printer.SwitchDoc", SwitchDocNode, StmtDocNode);
 };
 
 /*!
@@ -289,7 +279,7 @@ class SwitchDoc : public StmtDoc {
    */
   explicit SwitchDoc(ffi::Array<ExprDoc> predicates, ffi::Array<ffi::Array<StmtDoc>> branchs,
                      ffi::Array<StmtDoc> default_branch);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(SwitchDoc, StmtDoc, SwitchDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(SwitchDoc, StmtDoc, SwitchDocNode);
 };
 
 /*!
@@ -322,9 +312,7 @@ class LambdaDocNode : public StmtDocNode {
         .def_ro("refs", &LambdaDocNode::refs)
         .def_ro("body", &LambdaDocNode::body);
   }
-
-  static constexpr const char* _type_key = "msc.script.printer.LambdaDoc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(LambdaDocNode, StmtDocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("msc.script.printer.LambdaDoc", LambdaDocNode, StmtDocNode);
 };
 
 /*!
@@ -343,7 +331,7 @@ class LambdaDoc : public StmtDoc {
    */
   explicit LambdaDoc(IdDoc name, ffi::Array<AssignDoc> args, ffi::Array<ExprDoc> refs,
                      ffi::Array<StmtDoc> body);
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(LambdaDoc, StmtDoc, LambdaDocNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(LambdaDoc, StmtDoc, LambdaDocNode);
 };
 
 }  // namespace msc

--- a/src/ir/instrument.cc
+++ b/src/ir/instrument.cc
@@ -83,9 +83,8 @@ class BasePassInstrumentNode : public PassInstrumentNode {
    * \param info The pass information.
    */
   void RunAfterPass(const IRModule& mod, const transform::PassInfo& info) const final;
-
-  static constexpr const char* _type_key = "instrument.PassInstrument";
-  TVM_DECLARE_FINAL_OBJECT_INFO(BasePassInstrumentNode, PassInstrumentNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("instrument.PassInstrument", BasePassInstrumentNode,
+                                    PassInstrumentNode);
 };
 
 /*!
@@ -118,7 +117,8 @@ class BasePassInstrument : public PassInstrument {
       ffi::TypedFunction<void(const IRModule&, const transform::PassInfo&)>
           run_after_pass_callback);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(BasePassInstrument, PassInstrument, BasePassInstrumentNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BasePassInstrument, PassInstrument,
+                                             BasePassInstrumentNode);
 };
 
 BasePassInstrument::BasePassInstrument(

--- a/src/ir/transform.cc
+++ b/src/ir/transform.cc
@@ -368,16 +368,14 @@ class ModulePassNode : public PassNode {
    * \brief Get the pass information/meta data.
    */
   PassInfo Info() const override { return pass_info; }
-
-  static constexpr const char* _type_key = "transform.ModulePass";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ModulePassNode, PassNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("transform.ModulePass", ModulePassNode, PassNode);
 };
 
 class ModulePass : public Pass {
  public:
   ModulePass(std::function<IRModule(IRModule, PassContext)> pass_func, PassInfo pass_info);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ModulePass, Pass, ModulePassNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ModulePass, Pass, ModulePassNode);
 };
 
 PassInfo::PassInfo(int opt_level, ffi::String name, tvm::ffi::Array<ffi::String> required,

--- a/src/meta_schedule/database/json_database.cc
+++ b/src/meta_schedule/database/json_database.cc
@@ -89,9 +89,7 @@ class JSONDatabaseNode : public DatabaseNode {
         .def_ro("path_workload", &JSONDatabaseNode::path_workload)
         .def_ro("path_tuning_record", &JSONDatabaseNode::path_tuning_record);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.JSONDatabase";
-  TVM_DECLARE_FINAL_OBJECT_INFO(JSONDatabaseNode, DatabaseNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.JSONDatabase", JSONDatabaseNode, DatabaseNode);
 
  public:
   bool HasWorkload(const IRModule& mod) {

--- a/src/meta_schedule/database/memory_database.cc
+++ b/src/meta_schedule/database/memory_database.cc
@@ -37,9 +37,8 @@ class MemoryDatabaseNode : public DatabaseNode {
         .def_ro("records", &MemoryDatabaseNode::records)
         .def_ro("workloads", &MemoryDatabaseNode::workloads);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.MemoryDatabase";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MemoryDatabaseNode, DatabaseNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.MemoryDatabase", MemoryDatabaseNode,
+                                    DatabaseNode);
 
  public:
   bool HasWorkload(const IRModule& mod) final {

--- a/src/meta_schedule/database/ordered_union_database.cc
+++ b/src/meta_schedule/database/ordered_union_database.cc
@@ -32,9 +32,8 @@ class OrderedUnionDatabaseNode : public DatabaseNode {
     refl::ObjectDef<OrderedUnionDatabaseNode>().def_ro("databases",
                                                        &OrderedUnionDatabaseNode::databases);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.OrderedUnionDatabase";
-  TVM_DECLARE_FINAL_OBJECT_INFO(OrderedUnionDatabaseNode, DatabaseNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.OrderedUnionDatabase", OrderedUnionDatabaseNode,
+                                    DatabaseNode);
 
  public:
   ffi::Optional<TuningRecord> QueryTuningRecord(const IRModule& mod, const Target& target,

--- a/src/meta_schedule/database/schedule_fn_database.cc
+++ b/src/meta_schedule/database/schedule_fn_database.cc
@@ -35,9 +35,8 @@ class ScheduleFnDatabaseNode : public DatabaseNode {
     refl::ObjectDef<ScheduleFnDatabaseNode>().def_ro("schedule_fn",
                                                      &ScheduleFnDatabaseNode::schedule_fn);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.ScheduleFnDatabase";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ScheduleFnDatabaseNode, DatabaseNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.ScheduleFnDatabase", ScheduleFnDatabaseNode,
+                                    DatabaseNode);
 
  public:
   ffi::Optional<TuningRecord> QueryTuningRecord(const IRModule& mod, const Target& target,

--- a/src/meta_schedule/database/union_database.cc
+++ b/src/meta_schedule/database/union_database.cc
@@ -31,9 +31,7 @@ class UnionDatabaseNode : public DatabaseNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<UnionDatabaseNode>().def_ro("databases", &UnionDatabaseNode::databases);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.UnionDatabase";
-  TVM_DECLARE_FINAL_OBJECT_INFO(UnionDatabaseNode, DatabaseNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.UnionDatabase", UnionDatabaseNode, DatabaseNode);
 
  public:
   ffi::Optional<TuningRecord> QueryTuningRecord(const IRModule& mod, const Target& target,

--- a/src/meta_schedule/feature_extractor/per_store_feature.cc
+++ b/src/meta_schedule/feature_extractor/per_store_feature.cc
@@ -1423,9 +1423,8 @@ class PerStoreFeatureNode : public FeatureExtractorNode {
     support::parallel_for_dynamic(0, candidates.size(), tune_context->num_threads, f);
     return results;
   }
-
-  static constexpr const char* _type_key = "meta_schedule.PerStoreFeature";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PerStoreFeatureNode, FeatureExtractorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PerStoreFeature", PerStoreFeatureNode,
+                                    FeatureExtractorNode);
 };
 
 FeatureExtractor FeatureExtractor::PerStoreFeature(int buffers_per_store,

--- a/src/meta_schedule/measure_callback/add_to_database.cc
+++ b/src/meta_schedule/measure_callback/add_to_database.cc
@@ -56,9 +56,8 @@ class AddToDatabaseNode : public MeasureCallbackNode {
           /*args_info=*/candidate->args_info));
     }
   }
-
-  static constexpr const char* _type_key = "meta_schedule.AddToDatabase";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AddToDatabaseNode, MeasureCallbackNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.AddToDatabase", AddToDatabaseNode,
+                                    MeasureCallbackNode);
 };
 
 MeasureCallback MeasureCallback::AddToDatabase() {

--- a/src/meta_schedule/measure_callback/remove_build_artifact.cc
+++ b/src/meta_schedule/measure_callback/remove_build_artifact.cc
@@ -37,9 +37,8 @@ class RemoveBuildArtifactNode : public MeasureCallbackNode {
       }
     }
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RemoveBuildArtifact";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RemoveBuildArtifactNode, MeasureCallbackNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RemoveBuildArtifact", RemoveBuildArtifactNode,
+                                    MeasureCallbackNode);
 };
 
 MeasureCallback MeasureCallback::RemoveBuildArtifact() {

--- a/src/meta_schedule/measure_callback/update_cost_model.cc
+++ b/src/meta_schedule/measure_callback/update_cost_model.cc
@@ -54,9 +54,8 @@ class UpdateCostModelNode : public MeasureCallbackNode {
     }
     cost_model->Update(task->ctx, pruned_candidate, pruned_runner_result);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.UpdateCostModel";
-  TVM_DECLARE_FINAL_OBJECT_INFO(UpdateCostModelNode, MeasureCallbackNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.UpdateCostModel", UpdateCostModelNode,
+                                    MeasureCallbackNode);
 };
 
 MeasureCallback MeasureCallback::UpdateCostModel() {

--- a/src/meta_schedule/mutator/mutate_compute_location.cc
+++ b/src/meta_schedule/mutator/mutate_compute_location.cc
@@ -37,9 +37,8 @@ class MutateComputeLocationNode : public MutatorNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<MutateComputeLocationNode>();
   }
-
-  static constexpr const char* _type_key = "meta_schedule.MutateComputeLocation";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MutateComputeLocationNode, MutatorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.MutateComputeLocation",
+                                    MutateComputeLocationNode, MutatorNode);
 
  public:
   // Inherit from `MutatorNode`

--- a/src/meta_schedule/mutator/mutate_parallel.cc
+++ b/src/meta_schedule/mutator/mutate_parallel.cc
@@ -176,9 +176,8 @@ class MutateParallelNode : public MutatorNode {
     refl::ObjectDef<MutateParallelNode>().def_ro("max_jobs_per_core",
                                                  &MutateParallelNode::max_jobs_per_core);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.MutateParallel";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MutateParallelNode, MutatorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.MutateParallel", MutateParallelNode,
+                                    MutatorNode);
 
  public:
   struct Candidate;

--- a/src/meta_schedule/mutator/mutate_thread_binding.cc
+++ b/src/meta_schedule/mutator/mutate_thread_binding.cc
@@ -37,9 +37,8 @@ class MutateThreadBindingNode : public MutatorNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<MutateThreadBindingNode>();
   }
-
-  static constexpr const char* _type_key = "meta_schedule.MutateThreadBinding";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MutateThreadBindingNode, MutatorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.MutateThreadBinding", MutateThreadBindingNode,
+                                    MutatorNode);
 
  public:
   // Inherit from `MutatorNode`

--- a/src/meta_schedule/mutator/mutate_tile_size.cc
+++ b/src/meta_schedule/mutator/mutate_tile_size.cc
@@ -60,9 +60,8 @@ class MutateTileSizeNode : public MutatorNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<MutateTileSizeNode>();
   }
-
-  static constexpr const char* _type_key = "meta_schedule.MutateTileSize";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MutateTileSizeNode, MutatorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.MutateTileSize", MutateTileSizeNode,
+                                    MutatorNode);
 
  public:
   // Inherit from `MutatorNode`

--- a/src/meta_schedule/mutator/mutate_unroll.cc
+++ b/src/meta_schedule/mutator/mutate_unroll.cc
@@ -56,9 +56,7 @@ class MutateUnrollNode : public MutatorNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<MutateUnrollNode>();
   }
-
-  static constexpr const char* _type_key = "meta_schedule.MutateUnroll";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MutateUnrollNode, MutatorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.MutateUnroll", MutateUnrollNode, MutatorNode);
 
  public:
   struct Candidate;

--- a/src/meta_schedule/postproc/disallow_async_strided_mem_copy.cc
+++ b/src/meta_schedule/postproc/disallow_async_strided_mem_copy.cc
@@ -173,9 +173,8 @@ class DisallowAsyncStridedMemCopyNode : public PostprocNode {
         ffi::make_object<DisallowAsyncStridedMemCopyNode>(*this);
     return Postproc(n);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.DisallowAsyncStridedMemCopy";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DisallowAsyncStridedMemCopyNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.DisallowAsyncStridedMemCopy",
+                                    DisallowAsyncStridedMemCopyNode, PostprocNode);
 
  private:
   tvm::Target target;

--- a/src/meta_schedule/postproc/disallow_dynamic_loop.cc
+++ b/src/meta_schedule/postproc/disallow_dynamic_loop.cc
@@ -74,9 +74,8 @@ class DisallowDynamicLoopNode : public PostprocNode {
     ObjectPtr<DisallowDynamicLoopNode> n = ffi::make_object<DisallowDynamicLoopNode>(*this);
     return Postproc(n);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.DisallowDynamicLoop";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DisallowDynamicLoopNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.DisallowDynamicLoop", DisallowDynamicLoopNode,
+                                    PostprocNode);
 };
 
 Postproc Postproc::DisallowDynamicLoop() {

--- a/src/meta_schedule/postproc/rewrite_cooperative_fetch.cc
+++ b/src/meta_schedule/postproc/rewrite_cooperative_fetch.cc
@@ -139,9 +139,8 @@ class RewriteCooperativeFetchNode : public PostprocNode {
     ObjectPtr<RewriteCooperativeFetchNode> n = ffi::make_object<RewriteCooperativeFetchNode>(*this);
     return Postproc(n);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RewriteCooperativeFetch";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RewriteCooperativeFetchNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RewriteCooperativeFetch",
+                                    RewriteCooperativeFetchNode, PostprocNode);
 
  private:
   int thread_warp_size_ = -1;

--- a/src/meta_schedule/postproc/rewrite_layout.cc
+++ b/src/meta_schedule/postproc/rewrite_layout.cc
@@ -264,9 +264,7 @@ class RewriteLayoutNode : public PostprocNode {
     ObjectPtr<RewriteLayoutNode> n = ffi::make_object<RewriteLayoutNode>(*this);
     return Postproc(n);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RewriteLayout";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RewriteLayoutNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RewriteLayout", RewriteLayoutNode, PostprocNode);
 };
 
 Postproc Postproc::RewriteLayout() {

--- a/src/meta_schedule/postproc/rewrite_parallel_vectorize_unroll.cc
+++ b/src/meta_schedule/postproc/rewrite_parallel_vectorize_unroll.cc
@@ -455,9 +455,8 @@ class RewriteParallelVectorizeUnrollNode : public PostprocNode {
         ffi::make_object<RewriteParallelVectorizeUnrollNode>(*this);
     return Postproc(n);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RewriteParallelVectorizeUnroll";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RewriteParallelVectorizeUnrollNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RewriteParallelVectorizeUnroll",
+                                    RewriteParallelVectorizeUnrollNode, PostprocNode);
 };
 
 Postproc Postproc::RewriteParallelVectorizeUnroll() {

--- a/src/meta_schedule/postproc/rewrite_reduction_block.cc
+++ b/src/meta_schedule/postproc/rewrite_reduction_block.cc
@@ -125,9 +125,8 @@ class RewriteReductionBlockNode : public PostprocNode {
     ObjectPtr<RewriteReductionBlockNode> n = ffi::make_object<RewriteReductionBlockNode>(*this);
     return Postproc(n);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RewriteReductionBlock";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RewriteReductionBlockNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RewriteReductionBlock",
+                                    RewriteReductionBlockNode, PostprocNode);
 };
 
 bool RewriteReductionBlockNode::Apply(const tir::Schedule& sch) {

--- a/src/meta_schedule/postproc/rewrite_tensorize.cc
+++ b/src/meta_schedule/postproc/rewrite_tensorize.cc
@@ -78,9 +78,8 @@ class RewriteTensorizeNode : public PostprocNode {
   }
 
   bool vectorize_init_loop = false;
-
-  static constexpr const char* _type_key = "meta_schedule.RewriteTensorize";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RewriteTensorizeNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RewriteTensorize", RewriteTensorizeNode,
+                                    PostprocNode);
 };
 
 bool RewriteTensorizeNode::Apply(const tir::Schedule& sch) {

--- a/src/meta_schedule/postproc/rewrite_unbound_block.cc
+++ b/src/meta_schedule/postproc/rewrite_unbound_block.cc
@@ -114,9 +114,8 @@ class RewriteUnboundBlockNode : public PostprocNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<RewriteUnboundBlockNode>();
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RewriteUnboundBlock";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RewriteUnboundBlockNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RewriteUnboundBlock", RewriteUnboundBlockNode,
+                                    PostprocNode);
 };
 
 bool RewriteUnboundBlockNode::Apply(const tir::Schedule& sch) {

--- a/src/meta_schedule/postproc/verify_gpu_code.cc
+++ b/src/meta_schedule/postproc/verify_gpu_code.cc
@@ -206,9 +206,7 @@ class VerifyGPUCodeNode : public PostprocNode {
     n->target_constraints_ = this->target_constraints_;
     return Postproc(n);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.VerifyGPUCode";
-  TVM_DECLARE_FINAL_OBJECT_INFO(VerifyGPUCodeNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.VerifyGPUCode", VerifyGPUCodeNode, PostprocNode);
 };
 
 Postproc Postproc::VerifyGPUCode() {

--- a/src/meta_schedule/postproc/verify_vtcm_limit.cc
+++ b/src/meta_schedule/postproc/verify_vtcm_limit.cc
@@ -59,9 +59,8 @@ class VerifyVTCMLimitNode : public PostprocNode {
     ObjectPtr<VerifyVTCMLimitNode> n = ffi::make_object<VerifyVTCMLimitNode>(*this);
     return Postproc(n);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.VerifyVTCMLimit";
-  TVM_DECLARE_FINAL_OBJECT_INFO(VerifyVTCMLimitNode, PostprocNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.VerifyVTCMLimit", VerifyVTCMLimitNode,
+                                    PostprocNode);
 };
 
 Postproc Postproc::VerifyVTCMLimit() {

--- a/src/meta_schedule/schedule_rule/add_rfactor.cc
+++ b/src/meta_schedule/schedule_rule/add_rfactor.cc
@@ -64,9 +64,7 @@ class AddRFactorNode : public ScheduleRuleNode {
         .def_ro("max_jobs_per_core", &AddRFactorNode::max_jobs_per_core)
         .def_ro("max_innermost_factor", &AddRFactorNode::max_innermost_factor);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.AddRFactor";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AddRFactorNode, ScheduleRuleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.AddRFactor", AddRFactorNode, ScheduleRuleNode);
 };
 
 ScheduleRule ScheduleRule::AddRFactor(int max_jobs_per_core,

--- a/src/meta_schedule/schedule_rule/apply_custom_rule.cc
+++ b/src/meta_schedule/schedule_rule/apply_custom_rule.cc
@@ -78,9 +78,8 @@ class ApplyCustomRuleNode : public ScheduleRuleNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ApplyCustomRuleNode>().def_ro("target_", &ApplyCustomRuleNode::target_);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.ApplyCustomRule";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ApplyCustomRuleNode, ScheduleRuleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.ApplyCustomRule", ApplyCustomRuleNode,
+                                    ScheduleRuleNode);
 };
 
 ScheduleRule ScheduleRule::ApplyCustomRule() {

--- a/src/meta_schedule/schedule_rule/auto_bind.cc
+++ b/src/meta_schedule/schedule_rule/auto_bind.cc
@@ -60,9 +60,7 @@ class AutoBindNode : public ScheduleRuleNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<AutoBindNode>();
   }
-
-  static constexpr const char* _type_key = "meta_schedule.AutoBind";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AutoBindNode, ScheduleRuleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.AutoBind", AutoBindNode, ScheduleRuleNode);
 };
 
 ffi::Array<tir::Schedule> AutoBindNode::Apply(const tir::Schedule& sch,

--- a/src/meta_schedule/schedule_rule/auto_inline.cc
+++ b/src/meta_schedule/schedule_rule/auto_inline.cc
@@ -95,9 +95,7 @@ class AutoInlineNode : public ScheduleRuleNode {
         .def_ro("require_ordered", &AutoInlineNode::require_ordered)
         .def_ro("disallow_op", &AutoInlineNode::disallow_op);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.AutoInline";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AutoInlineNode, ScheduleRuleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.AutoInline", AutoInlineNode, ScheduleRuleNode);
 };
 
 inline InlineType AutoInlineNode::CheckInline(const tir::Schedule& sch,
@@ -234,9 +232,8 @@ class InlineConstantScalarsNode : public ScheduleRuleNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<InlineConstantScalarsNode>();
   }
-
-  static constexpr const char* _type_key = "meta_schedule.InlineConstantScalars";
-  TVM_DECLARE_FINAL_OBJECT_INFO(InlineConstantScalarsNode, ScheduleRuleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.InlineConstantScalars",
+                                    InlineConstantScalarsNode, ScheduleRuleNode);
 };
 
 ScheduleRule ScheduleRule::InlineConstantScalars() {

--- a/src/meta_schedule/schedule_rule/cross_thread_reduction.cc
+++ b/src/meta_schedule/schedule_rule/cross_thread_reduction.cc
@@ -282,9 +282,8 @@ class CrossThreadReductionNode : public ScheduleRuleNode {
         .def_ro("warp_size", &CrossThreadReductionNode::warp_size)
         .def_ro("thread_extents", &CrossThreadReductionNode::thread_extents);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.CrossThreadReduction";
-  TVM_DECLARE_FINAL_OBJECT_INFO(CrossThreadReductionNode, ScheduleRuleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.CrossThreadReduction", CrossThreadReductionNode,
+                                    ScheduleRuleNode);
 };
 
 ScheduleRule ScheduleRule::CrossThreadReduction(ffi::Array<Integer> thread_extents) {

--- a/src/meta_schedule/schedule_rule/multi_level_tiling.h
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling.h
@@ -123,8 +123,8 @@ class StateNode : public Object {
    */
   virtual State Copy() const;
 
-  static constexpr const char* _type_key = "meta_schedule.State";
-  TVM_DECLARE_BASE_OBJECT_INFO(StateNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.State", StateNode, Object);
 };
 
 /*! \brief Managed reference to StateNode */
@@ -133,7 +133,7 @@ class State : public ObjectRef {
   /*! \brief Default constructor */
   explicit State(tir::Schedule sch, tir::BlockRV block_rv,
                  ffi::Array<ffi::Array<tir::LoopRV>> tiles = {});
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(State, ObjectRef, StateNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(State, ObjectRef, StateNode);
 };
 
 /*!
@@ -227,9 +227,8 @@ class MultiLevelTilingNode : public ScheduleRuleNode {
         .def_ro("tile_binds", &MultiLevelTilingNode::tile_binds)
         .def_ro("max_innermost_factor", &MultiLevelTilingNode::max_innermost_factor);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.MultiLevelTiling";
-  TVM_DECLARE_BASE_OBJECT_INFO(MultiLevelTilingNode, ScheduleRuleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("meta_schedule.MultiLevelTiling", MultiLevelTilingNode,
+                              ScheduleRuleNode);
 };
 
 template <typename NodeType>

--- a/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
@@ -90,9 +90,8 @@ class TensorCoreStateNode : public StateNode {
   bool use_async;
 
   State Copy() const final;
-
-  static constexpr const char* _type_key = "meta_schedule.TensorCoreState";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TensorCoreStateNode, StateNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.TensorCoreState", TensorCoreStateNode,
+                                    StateNode);
 };
 
 class TensorCoreState : public State {
@@ -102,7 +101,7 @@ class TensorCoreState : public State {
                            BlockRV block_rv, bool use_async,
                            ffi::Array<ffi::Array<tir::LoopRV>> tiles = {});
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(TensorCoreState, State, TensorCoreStateNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TensorCoreState, State, TensorCoreStateNode);
 };
 
 TensorCoreState::TensorCoreState(TensorCoreIntrinGroup intrin_group,
@@ -192,8 +191,8 @@ class MultiLevelTilingTensorCoreNode : public MultiLevelTilingNode {
   std::vector<TensorCoreIntrinGroup> intrin_groups;
   /*! \brief Whether to use software pipeline */
   bool use_software_pipeline = false;
-  static constexpr const char* _type_key = "meta_schedule.MultiLevelTilingTensorCore";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MultiLevelTilingTensorCoreNode, MultiLevelTilingNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.MultiLevelTilingTensorCore",
+                                    MultiLevelTilingTensorCoreNode, MultiLevelTilingNode);
 
  private:
 };

--- a/src/meta_schedule/schedule_rule/multi_level_tiling_wide_vector.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_wide_vector.cc
@@ -39,9 +39,8 @@ using tir::Schedule;
 class MultiLevelTilingWideVectorNode : public MultiLevelTilingNode {
  public:
   size_t vector_length_in_bits;
-
-  static constexpr const char* _type_key = "meta_schedule.MultiLevelTilingWideVector";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MultiLevelTilingWideVectorNode, MultiLevelTilingNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.MultiLevelTilingWideVector",
+                                    MultiLevelTilingWideVectorNode, MultiLevelTilingNode);
 
  protected:
   ScheduleRule Clone() const final {

--- a/src/meta_schedule/schedule_rule/multi_level_tiling_with_intrin.cc
+++ b/src/meta_schedule/schedule_rule/multi_level_tiling_with_intrin.cc
@@ -88,9 +88,8 @@ class MultiLevelTilingWithIntrinNode : public MultiLevelTilingNode {
  public:
   /*! \brief The name of a tensor intrinsic. */
   ffi::String intrin_name;
-
-  static constexpr const char* _type_key = "meta_schedule.MultiLevelTilingWithIntrin";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MultiLevelTilingWithIntrinNode, MultiLevelTilingNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.MultiLevelTilingWithIntrin",
+                                    MultiLevelTilingWithIntrinNode, MultiLevelTilingNode);
 };
 
 ScheduleRule ScheduleRule::MultiLevelTilingWithIntrin(

--- a/src/meta_schedule/schedule_rule/parallel_vectorize_unroll.cc
+++ b/src/meta_schedule/schedule_rule/parallel_vectorize_unroll.cc
@@ -118,9 +118,8 @@ class ParallelizeVectorizeUnrollNode : public ScheduleRuleNode {
         .def_ro("unroll_max_steps", &ParallelizeVectorizeUnrollNode::unroll_max_steps)
         .def_ro("unroll_explicit", &ParallelizeVectorizeUnrollNode::unroll_explicit);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.ParallelizeVectorizeUnroll";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ParallelizeVectorizeUnrollNode, ScheduleRuleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.ParallelizeVectorizeUnroll",
+                                    ParallelizeVectorizeUnrollNode, ScheduleRuleNode);
 };
 
 ScheduleRule ScheduleRule::ParallelizeVectorizeUnroll(int max_jobs_per_core,

--- a/src/meta_schedule/schedule_rule/random_compute_location.cc
+++ b/src/meta_schedule/schedule_rule/random_compute_location.cc
@@ -117,9 +117,8 @@ class RandomComputeLocationNode : public ScheduleRuleNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<RandomComputeLocationNode>();
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RandomComputeLocation";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RandomComputeLocationNode, ScheduleRuleNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RandomComputeLocation",
+                                    RandomComputeLocationNode, ScheduleRuleNode);
 };
 
 ScheduleRule ScheduleRule::RandomComputeLocation() {

--- a/src/meta_schedule/search_strategy/evolutionary_search.cc
+++ b/src/meta_schedule/search_strategy/evolutionary_search.cc
@@ -395,9 +395,8 @@ class EvolutionarySearchNode : public SearchStrategyNode {
         .def_ro("genetic_max_fail_count", &EvolutionarySearchNode::genetic_max_fail_count)
         .def_ro("eps_greedy", &EvolutionarySearchNode::eps_greedy);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.EvolutionarySearch";
-  TVM_DECLARE_FINAL_OBJECT_INFO(EvolutionarySearchNode, SearchStrategyNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.EvolutionarySearch", EvolutionarySearchNode,
+                                    SearchStrategyNode);
 
   void InitializeWithTuneContext(const TuneContext& ctx) final {
     CHECK(ctx->num_threads > 0) << "ValueError: `TuneContext.num_threads` must be > 0";
@@ -776,8 +775,8 @@ SearchStrategy SearchStrategy::EvolutionarySearch(int population_size,         /
 
 class EvolutionarySearch : public SearchStrategy {
  public:
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(EvolutionarySearch, SearchStrategy,
-                                                    EvolutionarySearchNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(EvolutionarySearch, SearchStrategy,
+                                                EvolutionarySearchNode);
 };
 
 ffi::Array<Schedule> EvolutionarySearchSampleInitPopulation(EvolutionarySearch self, int num) {

--- a/src/meta_schedule/search_strategy/replay_func.cc
+++ b/src/meta_schedule/search_strategy/replay_func.cc
@@ -65,9 +65,7 @@ class ReplayFuncNode : public SearchStrategyNode {
   static void RegisterReflection() {
     // No fields to register
   }
-
-  static constexpr const char* _type_key = "meta_schedule.ReplayFunc";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ReplayFuncNode, SearchStrategyNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.ReplayFunc", ReplayFuncNode, SearchStrategyNode);
 
   void InitializeWithTuneContext(const TuneContext& ctx) final {
     CHECK(ctx->mod.defined()) << "ValueError: TuneContext.mod is not defined";

--- a/src/meta_schedule/search_strategy/replay_trace.cc
+++ b/src/meta_schedule/search_strategy/replay_trace.cc
@@ -81,9 +81,8 @@ class ReplayTraceNode : public SearchStrategyNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ReplayTraceNode>().def_ro("max_fail_count", &ReplayTraceNode::max_fail_count);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.ReplayTrace";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ReplayTraceNode, SearchStrategyNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.ReplayTrace", ReplayTraceNode,
+                                    SearchStrategyNode);
 
   void InitializeWithTuneContext(const TuneContext& ctx) final {
     CHECK(ctx->mod.defined()) << "ValueError: TuneContext.mod is not defined";

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -99,8 +99,8 @@ class PostOrderApplyNode : public SpaceGeneratorNode {
     CloneRules(this, n.get());
     return SpaceGenerator(n);
   }
-  static constexpr const char* _type_key = "meta_schedule.PostOrderApply";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PostOrderApplyNode, SpaceGeneratorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.PostOrderApply", PostOrderApplyNode,
+                                    SpaceGeneratorNode);
 };
 
 SpaceGenerator SpaceGenerator::PostOrderApply(

--- a/src/meta_schedule/space_generator/schedule_fn.cc
+++ b/src/meta_schedule/space_generator/schedule_fn.cc
@@ -80,9 +80,7 @@ class ScheduleFnNode : public SpaceGeneratorNode {
     CloneRules(this, n.get());
     return SpaceGenerator(n);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.ScheduleFn";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ScheduleFnNode, SpaceGeneratorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.ScheduleFn", ScheduleFnNode, SpaceGeneratorNode);
 };
 
 SpaceGenerator SpaceGenerator::ScheduleFn(

--- a/src/meta_schedule/space_generator/space_generator_union.cc
+++ b/src/meta_schedule/space_generator/space_generator_union.cc
@@ -62,9 +62,8 @@ class SpaceGeneratorUnionNode : public SpaceGeneratorNode {
     CloneRules(this, n.get());
     return SpaceGenerator(n);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.SpaceGeneratorUnion";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SpaceGeneratorUnionNode, SpaceGeneratorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.SpaceGeneratorUnion", SpaceGeneratorUnionNode,
+                                    SpaceGeneratorNode);
 };
 
 /*!

--- a/src/meta_schedule/task_scheduler/gradient_based.cc
+++ b/src/meta_schedule/task_scheduler/gradient_based.cc
@@ -39,9 +39,8 @@ class GradientBasedNode final : public TaskSchedulerNode {
         .def_ro("alpha", &GradientBasedNode::alpha)
         .def_ro("window_size", &GradientBasedNode::window_size);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.GradientBased";
-  TVM_DECLARE_FINAL_OBJECT_INFO(GradientBasedNode, TaskSchedulerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.GradientBased", GradientBasedNode,
+                                    TaskSchedulerNode);
 
  public:
   void Tune(ffi::Array<TuneContext> tasks, ffi::Array<FloatImm> task_weights, int max_trials_global,

--- a/src/meta_schedule/task_scheduler/round_robin.cc
+++ b/src/meta_schedule/task_scheduler/round_robin.cc
@@ -33,9 +33,7 @@ class RoundRobinNode final : public TaskSchedulerNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<RoundRobinNode>().def_ro("task_id", &RoundRobinNode::task_id);
   }
-
-  static constexpr const char* _type_key = "meta_schedule.RoundRobin";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RoundRobinNode, TaskSchedulerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("meta_schedule.RoundRobin", RoundRobinNode, TaskSchedulerNode);
 
  protected:
   int NextTaskId() final {

--- a/src/relax/backend/contrib/clml/codegen.cc
+++ b/src/relax/backend/contrib/clml/codegen.cc
@@ -48,15 +48,14 @@ struct OpenCLMLCompilerConfigNode : public AttrsNodeReflAdapter<OpenCLMLCompiler
         "clml_version", &OpenCLMLCompilerConfigNode::clml_version,
         "OpenCLML version as (major, minor, patch).", refl::DefaultValue(Integer(3)));
   }
-
-  static constexpr const char* _type_key = "relax.ext.attrs.OpenCLMLCompilerConfig";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(OpenCLMLCompilerConfigNode, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ext.attrs.OpenCLMLCompilerConfig",
+                                    OpenCLMLCompilerConfigNode, BaseAttrsNode);
 };
 
 class OpenCLMLCompilerConfig : public Attrs {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(OpenCLMLCompilerConfig, Attrs,
-                                            OpenCLMLCompilerConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(OpenCLMLCompilerConfig, Attrs,
+                                                OpenCLMLCompilerConfigNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ OpenCLMLCompilerConfigNode::RegisterReflection(); });

--- a/src/relax/backend/contrib/cutlass/codegen.cc
+++ b/src/relax/backend/contrib/cutlass/codegen.cc
@@ -86,9 +86,7 @@ class CodegenResultNode : public Object {
         .def_ro("code", &CodegenResultNode::code)
         .def_ro("headers", &CodegenResultNode::headers);
   }
-
-  static constexpr const char* _type_key = "contrib.cutlass.CodegenResult";
-  TVM_DECLARE_FINAL_OBJECT_INFO(CodegenResultNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("contrib.cutlass.CodegenResult", CodegenResultNode, Object);
 };
 
 class CodegenResult : public ObjectRef {
@@ -100,7 +98,7 @@ class CodegenResult : public ObjectRef {
     data_ = std::move(n);
   }
 
-  TVM_DEFINE_OBJECT_REF_METHODS(CodegenResult, ObjectRef, CodegenResultNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(CodegenResult, ObjectRef, CodegenResultNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ CodegenResultNode::RegisterReflection(); });

--- a/src/relax/backend/contrib/tensorrt/codegen.cc
+++ b/src/relax/backend/contrib/tensorrt/codegen.cc
@@ -70,15 +70,14 @@ struct TensorRTCompilerConfigNode : public AttrsNodeReflAdapter<TensorRTCompiler
         .def_ro("use_uint8", &TensorRTCompilerConfigNode::use_uint8, "Use uint8",
                 refl::DefaultValue(false));
   }
-
-  static constexpr const char* _type_key = "relax.ext.attrs.TensorRTCompilerConfig";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TensorRTCompilerConfigNode, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ext.attrs.TensorRTCompilerConfig",
+                                    TensorRTCompilerConfigNode, BaseAttrsNode);
 };
 
 class TensorRTCompilerConfig : public Attrs {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TensorRTCompilerConfig, Attrs,
-                                            TensorRTCompilerConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TensorRTCompilerConfig, Attrs,
+                                                TensorRTCompilerConfigNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ TensorRTCompilerConfigNode::RegisterReflection(); });

--- a/src/relax/ir/dataflow_block_rewriter.cc
+++ b/src/relax/ir/dataflow_block_rewriter.cc
@@ -385,9 +385,8 @@ class PatternContextRewriterNode : public PatternMatchingRewriterNode {
         .def_ro("pattern", &PatternContextRewriterNode::pattern)
         .def_ro("rewriter_func", &PatternContextRewriterNode::rewriter_func);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.PatternContextRewriter";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PatternContextRewriterNode, PatternMatchingRewriterNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.dpl.PatternContextRewriter", PatternContextRewriterNode,
+                                    PatternMatchingRewriterNode);
 
  private:
   ffi::Optional<ffi::Map<Var, Expr>> MatchBindings(const ffi::Array<Binding>& bindings) const {
@@ -414,8 +413,8 @@ class PatternContextRewriter : public PatternMatchingRewriter {
       ffi::TypedFunction<ffi::Map<Var, Expr>(ffi::Map<DFPattern, Var>, ffi::Map<Var, Expr>)>
           rewriter_func);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PatternContextRewriter, PatternMatchingRewriter,
-                                PatternContextRewriterNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PatternContextRewriter, PatternMatchingRewriter,
+                                             PatternContextRewriterNode);
 };
 
 RewriteSpec PatternContextRewriterNode::RewriteBindings(const ffi::Array<Binding>& bindings) const {

--- a/src/relax/ir/dataflow_rewriter.h
+++ b/src/relax/ir/dataflow_rewriter.h
@@ -60,9 +60,8 @@ class PatternMatchingRewriterNode : public tvm::transform::PassNode {
 
   IRModule operator()(IRModule mod, const tvm::transform::PassContext& pass_ctx) const override;
   tvm::transform::PassInfo Info() const override;
-
-  static constexpr const char* _type_key = "relax.dpl.PatternMatchingRewriter";
-  TVM_DECLARE_BASE_OBJECT_INFO(PatternMatchingRewriterNode, PassNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.dpl.PatternMatchingRewriter", PatternMatchingRewriterNode,
+                              PassNode);
 };
 
 class PatternMatchingRewriter : public tvm::transform::Pass {
@@ -78,7 +77,8 @@ class PatternMatchingRewriter : public tvm::transform::Pass {
   Expr operator()(Expr expr);
   using Pass::operator();
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PatternMatchingRewriter, Pass, PatternMatchingRewriterNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PatternMatchingRewriter, Pass,
+                                             PatternMatchingRewriterNode);
 };
 
 class ExprPatternRewriterNode : public PatternMatchingRewriterNode {
@@ -98,9 +98,8 @@ class ExprPatternRewriterNode : public PatternMatchingRewriterNode {
         .def_ro("pattern", &ExprPatternRewriterNode::pattern)
         .def_ro("func", &ExprPatternRewriterNode::func);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.ExprPatternRewriter";
-  TVM_DECLARE_BASE_OBJECT_INFO(ExprPatternRewriterNode, PatternMatchingRewriterNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.dpl.ExprPatternRewriter", ExprPatternRewriterNode,
+                              PatternMatchingRewriterNode);
 };
 
 class ExprPatternRewriter : public PatternMatchingRewriter {
@@ -110,8 +109,8 @@ class ExprPatternRewriter : public PatternMatchingRewriter {
                       ffi::Optional<ffi::Array<DFPattern>> additional_bindings = std::nullopt,
                       ffi::Map<GlobalVar, BaseFunc> new_subroutines = {});
 
-  TVM_DEFINE_OBJECT_REF_METHODS(ExprPatternRewriter, PatternMatchingRewriter,
-                                ExprPatternRewriterNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ExprPatternRewriter, PatternMatchingRewriter,
+                                             ExprPatternRewriterNode);
 };
 
 class OrRewriterNode : public PatternMatchingRewriterNode {
@@ -127,16 +126,14 @@ class OrRewriterNode : public PatternMatchingRewriterNode {
         .def_ro("lhs", &OrRewriterNode::lhs)
         .def_ro("rhs", &OrRewriterNode::rhs);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.OrRewriter";
-  TVM_DECLARE_BASE_OBJECT_INFO(OrRewriterNode, PatternMatchingRewriterNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.dpl.OrRewriter", OrRewriterNode, PatternMatchingRewriterNode);
 };
 
 class OrRewriter : public PatternMatchingRewriter {
  public:
   OrRewriter(PatternMatchingRewriter lhs, PatternMatchingRewriter rhs);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(OrRewriter, PatternMatchingRewriter, OrRewriterNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(OrRewriter, PatternMatchingRewriter, OrRewriterNode);
 };
 
 class TupleRewriterNode : public PatternMatchingRewriterNode {
@@ -154,9 +151,8 @@ class TupleRewriterNode : public PatternMatchingRewriterNode {
         .def_ro("patterns", &TupleRewriterNode::patterns)
         .def_ro("func", &TupleRewriterNode::func);
   }
-
-  static constexpr const char* _type_key = "relax.dpl.TupleRewriter";
-  TVM_DECLARE_BASE_OBJECT_INFO(TupleRewriterNode, PatternMatchingRewriterNode);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.dpl.TupleRewriter", TupleRewriterNode,
+                              PatternMatchingRewriterNode);
 
  private:
   struct VarInfo {
@@ -180,7 +176,8 @@ class TupleRewriter : public PatternMatchingRewriter {
                 ffi::Optional<ffi::Array<DFPattern>> additional_bindings = std::nullopt,
                 ffi::Map<GlobalVar, BaseFunc> new_subroutines = {});
 
-  TVM_DEFINE_OBJECT_REF_METHODS(TupleRewriter, PatternMatchingRewriter, TupleRewriterNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TupleRewriter, PatternMatchingRewriter,
+                                             TupleRewriterNode);
 };
 
 }  // namespace relax

--- a/src/relax/ir/emit_te.h
+++ b/src/relax/ir/emit_te.h
@@ -51,9 +51,8 @@ class RXPlaceholderOpNode : public te::PlaceholderOpNode {
         .def_ro("shape", &RXPlaceholderOpNode::shape)
         .def_ro("dtype", &RXPlaceholderOpNode::dtype);
   }
-
-  static constexpr const char* _type_key = "relax.TEPlaceholderOp";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RXPlaceholderOpNode, te::PlaceholderOpNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.TEPlaceholderOp", RXPlaceholderOpNode,
+                                    te::PlaceholderOpNode);
 };
 
 /*!

--- a/src/relax/ir/py_expr_functor.cc
+++ b/src/relax/ir/py_expr_functor.cc
@@ -142,8 +142,8 @@ class PyExprVisitorNode : public Object, public ExprVisitor {
     // PyExprVisitorNode has no fields to register
   }
 
-  static constexpr const char* _type_key = "expr_functor.PyExprVisitor";
-  TVM_DECLARE_BASE_OBJECT_INFO(PyExprVisitorNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("expr_functor.PyExprVisitor", PyExprVisitorNode, Object);
 
  private:
   // initialize the vtable.
@@ -262,7 +262,7 @@ class PyExprVisitor : public ObjectRef {
     return PyExprVisitor(n);
   }
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(PyExprVisitor, ObjectRef, PyExprVisitorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(PyExprVisitor, ObjectRef, PyExprVisitorNode);
 };
 
 /*!
@@ -405,8 +405,8 @@ class PyExprMutatorNode : public Object, public ExprMutator {
     refl::ObjectDef<PyExprMutatorNode>().def_ro("builder_", &PyExprMutatorNode::builder_);
   }
 
-  static constexpr const char* _type_key = "expr_functor.PyExprMutator";
-  TVM_DECLARE_BASE_OBJECT_INFO(PyExprMutatorNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("expr_functor.PyExprMutator", PyExprMutatorNode, Object);
 
  private:
   // initialize the vtable.
@@ -549,7 +549,7 @@ class PyExprMutator : public ObjectRef {
     n->f_visit_span = f_visit_span;
     return PyExprMutator(n);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(PyExprMutator, ObjectRef, PyExprMutatorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(PyExprMutator, ObjectRef, PyExprMutatorNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({

--- a/src/relax/ir/transform.cc
+++ b/src/relax/ir/transform.cc
@@ -81,9 +81,7 @@ class FunctionPassNode : public tvm::transform::PassNode {
    * \brief Get the pass information/meta data.
    */
   PassInfo Info() const override { return pass_info; }
-
-  static constexpr const char* _type_key = "relax.FunctionPass";
-  TVM_DECLARE_FINAL_OBJECT_INFO(FunctionPassNode, PassNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.FunctionPass", FunctionPassNode, PassNode);
 
  private:
 };
@@ -98,7 +96,7 @@ class FunctionPass : public Pass {
   TVM_DLL FunctionPass(std::function<Function(Function, IRModule, PassContext)> pass_func,
                        PassInfo pass_info);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(FunctionPass, Pass, FunctionPassNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(FunctionPass, Pass, FunctionPassNode);
 };
 
 FunctionPass::FunctionPass(std::function<Function(Function, IRModule, PassContext)> pass_func,
@@ -219,9 +217,7 @@ class DataflowBlockPassNode : public tvm::transform::PassNode {
   IRModule operator()(IRModule mod, const PassContext& pass_ctx) const final;
 
   PassInfo Info() const override { return pass_info; }
-
-  static constexpr const char* _type_key = "relax.DataflowBlockPass";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DataflowBlockPassNode, PassNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.DataflowBlockPass", DataflowBlockPassNode, PassNode);
 };
 
 /*! \brief Helper to apply the passed function to dataflow blocks.*/
@@ -320,7 +316,7 @@ class DataflowBlockPass : public Pass {
       std::function<DataflowBlock(DataflowBlock, IRModule, PassContext)> pass_func,
       PassInfo pass_info);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(DataflowBlockPass, Pass, DataflowBlockPassNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DataflowBlockPass, Pass, DataflowBlockPassNode);
 };
 
 DataflowBlockPass::DataflowBlockPass(

--- a/src/relax/transform/dataflow_inplace.cc
+++ b/src/relax/transform/dataflow_inplace.cc
@@ -531,9 +531,7 @@ class InplaceOpportunityNode : public Object {
         .def_ro("binding_idx", &InplaceOpportunityNode::binding_idx)
         .def_ro("arg_idxs", &InplaceOpportunityNode::arg_idxs);
   }
-
-  static constexpr const char* _type_key = "relax.transform.InplaceOpportunity";
-  TVM_DECLARE_BASE_OBJECT_INFO(InplaceOpportunityNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.transform.InplaceOpportunity", InplaceOpportunityNode, Object);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ InplaceOpportunityNode::RegisterReflection(); });
@@ -547,7 +545,7 @@ class InplaceOpportunity : public ObjectRef {
     data_ = std::move(node);
   }
 
-  TVM_DEFINE_OBJECT_REF_METHODS(InplaceOpportunity, ObjectRef, InplaceOpportunityNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(InplaceOpportunity, ObjectRef, InplaceOpportunityNode);
 };
 
 // Check for in-place eligibility:

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -69,9 +69,7 @@ class LayoutDecisionNode : public Object {
         .def_ro("is_unknown_dim", &LayoutDecisionNode::is_unknown_dim);
   }
 
-  TVM_DECLARE_BASE_OBJECT_INFO(LayoutDecisionNode, Object);
-
-  static constexpr const char* _type_key = "relax.transform.LayoutDecision";
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.transform.LayoutDecision", LayoutDecisionNode, Object);
 };
 
 class LayoutDecision : public ObjectRef {
@@ -92,7 +90,7 @@ class LayoutDecision : public ObjectRef {
     return operator->()->layout.name();
   }
 
-  TVM_DEFINE_OBJECT_REF_METHODS(LayoutDecision, ObjectRef, LayoutDecisionNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(LayoutDecision, ObjectRef, LayoutDecisionNode);
 };
 
 using NLayout = NestedMsg<LayoutDecision>;
@@ -119,9 +117,7 @@ class InferLayoutOutputNode : public Object {
         .def_ro("new_args", &InferLayoutOutputNode::new_args);
   }
 
-  TVM_DECLARE_BASE_OBJECT_INFO(InferLayoutOutputNode, Object);
-
-  static constexpr const char* _type_key = "relax.transform.InferLayoutOutput";
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.transform.InferLayoutOutput", InferLayoutOutputNode, Object);
 };
 
 class InferLayoutOutput : public ObjectRef {
@@ -135,7 +131,7 @@ class InferLayoutOutput : public ObjectRef {
     n->new_args = std::move(new_args);
     data_ = n;
   }
-  TVM_DEFINE_OBJECT_REF_METHODS(InferLayoutOutput, ObjectRef, InferLayoutOutputNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(InferLayoutOutput, ObjectRef, InferLayoutOutputNode);
 };
 
 struct NLayoutEqual {

--- a/src/relax/transform/static_plan_block_memory.cc
+++ b/src/relax/transform/static_plan_block_memory.cc
@@ -119,8 +119,8 @@ class StorageTokenNode : public Object {
     }
   }
 
-  static constexpr const char* _type_key = "relax.transform.StorageToken";
-  TVM_DECLARE_BASE_OBJECT_INFO(StorageTokenNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.transform.StorageToken", StorageTokenNode, Object);
 };
 
 /*!
@@ -148,7 +148,7 @@ class StorageToken : public ObjectRef {
     n->storage_scope = std::move(storage_scope);
     data_ = std::move(n);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(StorageToken, ObjectRef, StorageTokenNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(StorageToken, ObjectRef, StorageTokenNode);
 };
 
 // We use NestedMsg to store the tokens used by each Expr.

--- a/src/runtime/contrib/cudnn/cudnn_frontend/attention.h
+++ b/src/runtime/contrib/cudnn/cudnn_frontend/attention.h
@@ -73,8 +73,8 @@ class CuDNNSDPARunner : public tvm::runtime::ObjectRef {
     return CuDNNSDPARunner(n);
   }
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(CuDNNSDPARunner, tvm::runtime::ObjectRef,
-                                        CuDNNSDPARunnerNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(CuDNNSDPARunner, tvm::runtime::ObjectRef,
+                                             CuDNNSDPARunnerNode);
 };
 
 }  // namespace contrib

--- a/src/runtime/contrib/papi/papi.cc
+++ b/src/runtime/contrib/papi/papi.cc
@@ -51,9 +51,7 @@ struct PAPIEventSetNode : public Object {
 
   explicit PAPIEventSetNode(std::vector<long_long> start_values, Device dev)
       : start_values(start_values), dev(dev) {}
-
-  static constexpr const char* _type_key = "PAPIEventSetNode";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PAPIEventSetNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("PAPIEventSetNode", PAPIEventSetNode, Object);
 };
 
 /* Get the PAPI component id for the given device.
@@ -269,9 +267,8 @@ struct PAPIMetricCollectorNode final : public MetricCollectorNode {
   /*! \brief Device-specific metric names. Order of names matches the order in the corresponding
    * `event_set`. */
   std::unordered_map<Device, std::vector<std::string>> papi_metric_names;
-
-  static constexpr const char* _type_key = "runtime.profiling.PAPIMetricCollector";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PAPIMetricCollectorNode, MetricCollectorNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.profiling.PAPIMetricCollector",
+                                    PAPIMetricCollectorNode, MetricCollectorNode);
 };
 
 /*! \brief Wrapper for `PAPIMetricCollectorNode`. */
@@ -280,8 +277,8 @@ class PAPIMetricCollector : public MetricCollector {
   explicit PAPIMetricCollector(ffi::Map<DeviceWrapper, ffi::Array<ffi::String>> metrics) {
     data_ = ffi::make_object<PAPIMetricCollectorNode>(metrics);
   }
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(PAPIMetricCollector, MetricCollector,
-                                        PAPIMetricCollectorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PAPIMetricCollector, MetricCollector,
+                                             PAPIMetricCollectorNode);
 };
 
 MetricCollector CreatePAPIMetricCollector(

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -323,9 +323,7 @@ class CUDATimerNode : public TimerNode {
     CUDA_CALL(cudaEventCreate(&start_));
     CUDA_CALL(cudaEventCreate(&stop_));
   }
-
-  static constexpr const char* _type_key = "runtime.cuda.CUDATimerNode";
-  TVM_DECLARE_FINAL_OBJECT_INFO(CUDATimerNode, TimerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.cuda.CUDATimerNode", CUDATimerNode, TimerNode);
 
  private:
   cudaEvent_t start_;

--- a/src/runtime/disco/bcast_session.h
+++ b/src/runtime/disco/bcast_session.h
@@ -102,7 +102,7 @@ class BcastSessionObj : public SessionObj {
  */
 class BcastSession : public Session {
  public:
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(BcastSession, Session, BcastSessionObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BcastSession, Session, BcastSessionObj);
 };
 
 }  // namespace runtime

--- a/src/runtime/disco/distributed/socket_session.cc
+++ b/src/runtime/disco/distributed/socket_session.cc
@@ -196,9 +196,8 @@ class SocketSessionObj : public BcastSessionObj {
   }
 
   ~SocketSessionObj() { Shutdown(); }
-
-  static constexpr const char* _type_key = "runtime.disco.SocketSession";
-  TVM_DECLARE_FINAL_OBJECT_INFO(SocketSessionObj, BcastSessionObj);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.disco.SocketSession", SocketSessionObj,
+                                    BcastSessionObj);
   int num_nodes_;
   int num_workers_per_node_;
   TCPSocket socket_;

--- a/src/runtime/disco/loader.cc
+++ b/src/runtime/disco/loader.cc
@@ -137,9 +137,7 @@ class ShardLoaderObj : public Object {
 
   /*! \brief Slice the given tensor at a specific dimension */
   Tensor Shard(Tensor source, int dim, int num_slices) const;
-
-  static constexpr const char* _type_key = "runtime.disco.ShardLoader";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ShardLoaderObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.disco.ShardLoader", ShardLoaderObj, Object);
 
  public:
   /*! \brief Information of how each weight is stored and sharded */

--- a/src/runtime/disco/process_session.cc
+++ b/src/runtime/disco/process_session.cc
@@ -168,9 +168,7 @@ class ProcessSessionObj final : public BcastSessionObj {
   ffi::Function process_pool_;
   std::unique_ptr<DiscoWorkerThread> worker_0_;
   std::vector<std::unique_ptr<DiscoProcessChannel>> workers_;
-
-  static constexpr const char* _type_key = "runtime.disco.ProcessSession";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ProcessSessionObj, SessionObj);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.disco.ProcessSession", ProcessSessionObj, SessionObj);
 };
 
 Session Session::ProcessSession(int num_workers, int num_group, ffi::String process_pool_creator,

--- a/src/runtime/disco/protocol.h
+++ b/src/runtime/disco/protocol.h
@@ -116,9 +116,7 @@ struct DiscoDebugObject : public Object {
   inline uint64_t GetFFIAnyProtocolBytes() const {
     return sizeof(uint64_t) + this->SaveToStr().size();
   }
-
-  static constexpr const char* _type_key = "runtime.disco.DiscoDebugObject";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DiscoDebugObject, SessionObj);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.disco.DiscoDebugObject", DiscoDebugObject, SessionObj);
 };
 
 template <class SubClassType>

--- a/src/runtime/disco/threaded_session.cc
+++ b/src/runtime/disco/threaded_session.cc
@@ -180,9 +180,8 @@ class ThreadedSessionObj final : public BcastSessionObj {
   ffi::PackedArgs RecvReplyPacked(int worker_id) final {
     return this->workers_.at(worker_id).channel->RecvReply();
   }
-
-  static constexpr const char* _type_key = "runtime.disco.ThreadedSession";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ThreadedSessionObj, SessionObj);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.disco.ThreadedSession", ThreadedSessionObj,
+                                    SessionObj);
 
   std::vector<DiscoWorkerThread> workers_;
 };

--- a/src/runtime/hexagon/hexagon_common.cc
+++ b/src/runtime/hexagon/hexagon_common.cc
@@ -46,9 +46,8 @@ class HexagonTimerNode : public TimerNode {
   virtual void Stop() { end = HAP_perf_get_time_us(); }
   virtual int64_t SyncAndGetElapsedNanos() { return (end - start) * 1e3; }
   virtual ~HexagonTimerNode() {}
-
-  static constexpr const char* _type_key = "runtime.hexagon.HexagonTimerNode";
-  TVM_DECLARE_FINAL_OBJECT_INFO(HexagonTimerNode, TimerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.hexagon.HexagonTimerNode", HexagonTimerNode,
+                                    TimerNode);
 
  private:
   uint64_t start, end;

--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -380,9 +380,7 @@ class MetalTimerNode : public TimerNode {
     [mtl_dev_ sampleTimestamps:&stop_cpu_time_ gpuTimestamp:&stop_gpu_time_];
   }
   virtual int64_t SyncAndGetElapsedNanos() { return stop_gpu_time_ - start_gpu_time_; }
-
-  static constexpr const char* _type_key = "runtime.metal.MetalTimerNode";
-  TVM_DECLARE_FINAL_OBJECT_INFO(MetalTimerNode, TimerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.metal.MetalTimerNode", MetalTimerNode, TimerNode);
 
  private:
   Device dev_;

--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -590,10 +590,9 @@ class OpenCLTimerNode : public TimerNode {
   OpenCLTimerNode() {}
   explicit OpenCLTimerNode(Device dev) : dev_(dev) {}
 
-  static constexpr const char* _type_key = "runtime.opencl.OpenCLTimerNode";
   static size_t count_timer_execs;
   static std::vector<size_t> event_start_idxs;
-  TVM_DECLARE_FINAL_OBJECT_INFO(OpenCLTimerNode, TimerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.opencl.OpenCLTimerNode", OpenCLTimerNode, TimerNode);
 
  private:
   int64_t duration;

--- a/src/runtime/profiling.cc
+++ b/src/runtime/profiling.cc
@@ -55,8 +55,7 @@ class DefaultTimerNode : public TimerNode {
   virtual ~DefaultTimerNode() {}
 
   explicit DefaultTimerNode(Device dev) : device_(dev) {}
-  static constexpr const char* _type_key = "runtime.DefaultTimerNode";
-  TVM_DECLARE_FINAL_OBJECT_INFO(DefaultTimerNode, TimerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.DefaultTimerNode", DefaultTimerNode, TimerNode);
 
  private:
   std::chrono::high_resolution_clock::time_point start_;
@@ -72,9 +71,7 @@ class CPUTimerNode : public TimerNode {
   virtual void Stop() { duration_ = std::chrono::high_resolution_clock::now() - start_; }
   virtual int64_t SyncAndGetElapsedNanos() { return duration_.count(); }
   virtual ~CPUTimerNode() {}
-
-  static constexpr const char* _type_key = "runtime.CPUTimerNode";
-  TVM_DECLARE_FINAL_OBJECT_INFO(CPUTimerNode, TimerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.CPUTimerNode", CPUTimerNode, TimerNode);
 
  private:
   std::chrono::high_resolution_clock::time_point start_;

--- a/src/runtime/rocm/rocm_device_api.cc
+++ b/src/runtime/rocm/rocm_device_api.cc
@@ -286,9 +286,7 @@ class ROCMTimerNode : public TimerNode {
     ROCM_CALL(hipEventCreate(&start_));
     ROCM_CALL(hipEventCreate(&stop_));
   }
-
-  static constexpr const char* _type_key = "runtime.rocm.ROCMTimerNode";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ROCMTimerNode, TimerNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("runtime.rocm.ROCMTimerNode", ROCMTimerNode, TimerNode);
 
  private:
   hipEvent_t start_;

--- a/src/runtime/rpc/rpc_session.h
+++ b/src/runtime/rpc/rpc_session.h
@@ -315,9 +315,8 @@ class RPCObjectRefObj : public Object {
   void* object_handle() const { return object_handle_; }
 
   static constexpr const uint32_t _type_index = TypeIndex::kRuntimeRPCObjectRef;
-  static constexpr const char* _type_key = "runtime.RPCObjectRef";
   static const constexpr bool _type_final = true;
-  TVM_FFI_DECLARE_STATIC_OBJECT_INFO(RPCObjectRefObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC("runtime.RPCObjectRef", RPCObjectRefObj, Object);
 
  private:
   // The object handle
@@ -336,7 +335,7 @@ class RPCObjectRef : public ObjectRef {
   explicit RPCObjectRef(ObjectPtr<RPCObjectRefObj> data) : ObjectRef(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(RPCObjectRef, ObjectRef, RPCObjectRefObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(RPCObjectRef, ObjectRef, RPCObjectRefObj);
 };
 
 /*!

--- a/src/runtime/vm/cuda/cuda_graph_builtin.cc
+++ b/src/runtime/vm/cuda/cuda_graph_builtin.cc
@@ -140,8 +140,6 @@ class CUDACaptureStream {
 /*! \brief The VM extension of CUDA graph. */
 class CUDAGraphExtensionNode : public VMExtensionNode {
  public:
-  TVM_DECLARE_FINAL_OBJECT_INFO(CUDAGraphExtensionNode, VMExtensionNode);
-
   /*!
    * \brief Launch the cuda graph if it has been cached, otherwise execute it in capture mode.
    * \param vm The virtual machine.
@@ -220,7 +218,9 @@ class CUDAGraphExtensionNode : public VMExtensionNode {
     return alloc_result;
   }
 
-  static constexpr const char* _type_key = "vm.CUDAGraphExtension";
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("vm.CUDAGraphExtension", CUDAGraphExtensionNode,
+                                    VMExtensionNode);
 
  private:
   /*!
@@ -240,7 +240,8 @@ class CUDAGraphExtensionNode : public VMExtensionNode {
 /*! Managed reference to CUDAGraphExtensionNode */
 class CUDAGraphExtension : public VMExtension {
  public:
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(CUDAGraphExtension, VMExtension, CUDAGraphExtensionNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(CUDAGraphExtension, VMExtension,
+                                             CUDAGraphExtensionNode);
   static CUDAGraphExtension Create() {
     auto data_ = ffi::make_object<CUDAGraphExtensionNode>();
     return CUDAGraphExtension(std::move(data_));

--- a/src/runtime/vm/kv_state.h
+++ b/src/runtime/vm/kv_state.h
@@ -105,13 +105,13 @@ class KVStateObj : public Object {
    */
   virtual void EndForward() = 0;
 
-  static constexpr const char* _type_key = "relax.vm.KVState";
-  TVM_DECLARE_BASE_OBJECT_INFO(KVStateObj, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.vm.KVState", KVStateObj, Object);
 };
 
 class KVState : public ObjectRef {
  public:
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(KVState, ObjectRef, KVStateObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(KVState, ObjectRef, KVStateObj);
 };
 
 /*!
@@ -294,13 +294,13 @@ class AttentionKVCacheObj : public KVStateObj {
    */
   virtual void DebugSetKV(int64_t seq_id, int64_t start_pos, Tensor k_data, Tensor v_data) = 0;
 
-  static constexpr const char* _type_key = "relax.vm.AttentionKVCache";
-  TVM_DECLARE_BASE_OBJECT_INFO(AttentionKVCacheObj, KVStateObj);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.vm.AttentionKVCache", AttentionKVCacheObj, KVStateObj);
 };
 
 class AttentionKVCache : public KVState {
  public:
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(AttentionKVCache, KVState, AttentionKVCacheObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(AttentionKVCache, KVState, AttentionKVCacheObj);
 };
 
 /*!
@@ -337,13 +337,13 @@ class RNNStateObj : public KVStateObj {
    */
   virtual Tensor DebugGet(int64_t layer_id, int64_t state_id, int64_t seq_id) = 0;
 
-  static constexpr const char* _type_key = "relax.vm.RNNState";
-  TVM_DECLARE_BASE_OBJECT_INFO(RNNStateObj, KVStateObj);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("relax.vm.RNNState", RNNStateObj, KVStateObj);
 };
 
 class RNNState : public KVState {
  public:
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(RNNState, KVState, RNNStateObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(RNNState, KVState, RNNStateObj);
 };
 
 }  // namespace vm

--- a/src/runtime/vm/lm_support.cc
+++ b/src/runtime/vm/lm_support.cc
@@ -227,8 +227,9 @@ class AttentionKVCacheLegacyObj : public Object {
     this->fill_count += value->shape[0];
   }
 
-  static constexpr const char* _type_key = "relax.vm.AttentionKVCacheLegacy";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AttentionKVCacheLegacyObj, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.vm.AttentionKVCacheLegacy", AttentionKVCacheLegacyObj,
+                                    Object);
 };
 
 /*! \brief reference to closure. */
@@ -251,8 +252,8 @@ class AttentionKVCacheLegacy : public ObjectRef {
     return AttentionKVCacheLegacy(n);
   }
 
-  TVM_DEFINE_MUTABLE_OBJECT_REF_METHODS(AttentionKVCacheLegacy, ObjectRef,
-                                        AttentionKVCacheLegacyObj);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(AttentionKVCacheLegacy, ObjectRef,
+                                             AttentionKVCacheLegacyObj);
 };
 
 //-------------------------------------------------

--- a/src/runtime/vm/paged_kv_cache.cc
+++ b/src/runtime/vm/paged_kv_cache.cc
@@ -1691,9 +1691,8 @@ class PagedAttentionKVCacheObj : public AttentionKVCacheObj {
   void DebugSetKV(int64_t seq_id, int64_t start_pos, Tensor k_data, Tensor v_data) final {
     ICHECK(false) << "DebugSetKV for PageAttentionKVCache not implemented yet.";
   }
-
-  static constexpr const char* _type_key = "relax.vm.PagedAttentionKVCache";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PagedAttentionKVCacheObj, AttentionKVCacheObj);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.vm.PagedAttentionKVCache", PagedAttentionKVCacheObj,
+                                    AttentionKVCacheObj);
 
  private:
   /*! \brief Get a new free page and return its id. */

--- a/src/runtime/vm/rnn_state.cc
+++ b/src/runtime/vm/rnn_state.cc
@@ -458,8 +458,7 @@ class RNNStateImpObj : public RNNStateObj {
   }
 
  public:
-  static constexpr const char* _type_key = "relax.vm.RNNStateImp";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RNNStateImpObj, RNNStateObj);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.vm.RNNStateImp", RNNStateImpObj, RNNStateObj);
 };
 
 //-------------------------------------------------

--- a/src/script/printer/ir/utils.h
+++ b/src/script/printer/ir/utils.h
@@ -43,9 +43,7 @@ class IRFrameNode : public FrameNode {
     namespace refl = tvm::ffi::reflection;
     // global infos is not exposed
   }
-
-  static constexpr const char* _type_key = "script.printer.IRFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(IRFrameNode, FrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.IRFrame", IRFrameNode, FrameNode);
 };
 
 class IRFrame : public Frame {
@@ -58,7 +56,7 @@ class IRFrame : public Frame {
     data_ = std::move(n);
   }
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(IRFrame, Frame, IRFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(IRFrame, Frame, IRFrameNode);
 };
 
 /*! \brief Redirected method for the ReprPrinter */

--- a/src/script/printer/relax/utils.h
+++ b/src/script/printer/relax/utils.h
@@ -50,9 +50,7 @@ class RelaxFrameNode : public FrameNode {
         .def_ro("is_func", &RelaxFrameNode::is_func)
         .def_ro("module_alias_printed", &RelaxFrameNode::module_alias_printed);
   }
-
-  static constexpr const char* _type_key = "script.printer.RelaxFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(RelaxFrameNode, FrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.RelaxFrame", RelaxFrameNode, FrameNode);
 };
 
 class RelaxFrame : public Frame {
@@ -66,7 +64,7 @@ class RelaxFrame : public Frame {
     data_ = std::move(n);
   }
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(RelaxFrame, Frame, RelaxFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(RelaxFrame, Frame, RelaxFrameNode);
 };
 
 /*! \brief Redirected method for the ReprPrinter */

--- a/src/script/printer/tir/utils.h
+++ b/src/script/printer/tir/utils.h
@@ -55,9 +55,7 @@ class TIRFrameNode : public FrameNode {
         .def_ro("tir", &TIRFrameNode::tir)
         .def_ro("allow_concise_scoping", &TIRFrameNode::allow_concise_scoping);
   }
-
-  static constexpr const char* _type_key = "script.printer.TIRFrame";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TIRFrameNode, FrameNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("script.printer.TIRFrame", TIRFrameNode, FrameNode);
 };
 
 /*! \brief Managed reference to TIRFrameNode */
@@ -72,7 +70,7 @@ class TIRFrame : public Frame {
     data_ = std::move(n);
   }
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(TIRFrame, Frame, TIRFrameNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TIRFrame, Frame, TIRFrameNode);
 };
 
 /*!

--- a/src/support/ffi_testing.cc
+++ b/src/support/ffi_testing.cc
@@ -51,9 +51,7 @@ struct TestAttrs : public AttrsNodeReflAdapter<TestAttrs> {
         .def_ro("func", &TestAttrs::func, "some random env function",
                 refl::DefaultValue(TypedEnvFunc<int(int)>(nullptr)));
   }
-
-  static constexpr const char* _type_key = "attrs.TestAttrs";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(TestAttrs, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("attrs.TestAttrs", TestAttrs, BaseAttrsNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ TestAttrs::RegisterReflection(); });

--- a/src/tir/ir/py_functor.cc
+++ b/src/tir/ir/py_functor.cc
@@ -218,8 +218,8 @@ class PyStmtExprVisitorNode : public Object, public StmtExprVisitor {
     // No fields to register as they are not visited
   }
 
-  static constexpr const char* _type_key = "tir.PyStmtExprVisitor";
-  TVM_DECLARE_BASE_OBJECT_INFO(PyStmtExprVisitorNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("tir.PyStmtExprVisitor", PyStmtExprVisitorNode, Object);
 
  private:
   // Statement functions
@@ -451,8 +451,8 @@ class PyStmtExprVisitor : public ObjectRef {
     return PyStmtExprVisitor(n);
   }
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(PyStmtExprVisitor, ObjectRef,
-                                                    PyStmtExprVisitorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(PyStmtExprVisitor, ObjectRef,
+                                                PyStmtExprVisitorNode);
 };
 
 /*! \brief The python interface of StmtExprMutator. */
@@ -584,8 +584,8 @@ class PyStmtExprMutatorNode : public Object, public StmtExprMutator {
     // No fields to register as they are not visited
   }
 
-  static constexpr const char* _type_key = "tir.PyStmtExprMutator";
-  TVM_DECLARE_BASE_OBJECT_INFO(PyStmtExprMutatorNode, Object);
+  static constexpr const bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("tir.PyStmtExprMutator", PyStmtExprMutatorNode, Object);
 
  private:
   // Statement functions
@@ -818,8 +818,8 @@ class PyStmtExprMutator : public ObjectRef {
     return PyStmtExprMutator(n);
   }
 
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(PyStmtExprMutator, ObjectRef,
-                                                    PyStmtExprMutatorNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(PyStmtExprMutator, ObjectRef,
+                                                PyStmtExprMutatorNode);
 };
 
 // ================================================

--- a/src/tir/ir/transform.cc
+++ b/src/tir/ir/transform.cc
@@ -82,9 +82,7 @@ class PrimFuncPassNode : public PassNode {
    * \brief Get the pass information/meta data.
    */
   PassInfo Info() const override { return pass_info; }
-
-  static constexpr const char* _type_key = "tir.PrimFuncPass";
-  TVM_DECLARE_FINAL_OBJECT_INFO(PrimFuncPassNode, PassNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.PrimFuncPass", PrimFuncPassNode, PassNode);
 };
 
 class PrimFuncPass : public Pass {
@@ -97,7 +95,7 @@ class PrimFuncPass : public Pass {
   TVM_DLL PrimFuncPass(std::function<PrimFunc(PrimFunc, IRModule, PassContext)> pass_func,
                        PassInfo pass_info);
 
-  TVM_DEFINE_OBJECT_REF_METHODS(PrimFuncPass, Pass, PrimFuncPassNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(PrimFuncPass, Pass, PrimFuncPassNode);
 };
 
 PrimFuncPass::PrimFuncPass(std::function<PrimFunc(PrimFunc, IRModule, PassContext)> pass_func,

--- a/src/tir/schedule/analysis.h
+++ b/src/tir/schedule/analysis.h
@@ -754,9 +754,7 @@ class TensorizeInfoNode : public Object {
         .def_ro("desc_loop_indexer", &TensorizeInfoNode::desc_loop_indexer)
         .def_ro("block_iter_paddings", &TensorizeInfoNode::block_iter_paddings);
   }
-
-  static constexpr const char* _type_key = "tir.schedule.TensorizeInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(TensorizeInfoNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.schedule.TensorizeInfo", TensorizeInfoNode, Object);
 };
 
 class TensorizeInfo : public ObjectRef {
@@ -764,7 +762,7 @@ class TensorizeInfo : public ObjectRef {
   explicit TensorizeInfo(ObjectPtr<TensorizeInfoNode> data) : ObjectRef(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(TensorizeInfo, ObjectRef, TensorizeInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TensorizeInfo, ObjectRef, TensorizeInfoNode);
 };
 
 /*!
@@ -806,9 +804,8 @@ class AutoTensorizeMappingInfoNode : public Object {
         .def_ro("lhs_iters", &AutoTensorizeMappingInfoNode::lhs_iters)
         .def_ro("rhs_iters", &AutoTensorizeMappingInfoNode::rhs_iters);
   }
-
-  static constexpr const char* _type_key = "tir.schedule.AutoTensorizeMappingInfo";
-  TVM_DECLARE_FINAL_OBJECT_INFO(AutoTensorizeMappingInfoNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.schedule.AutoTensorizeMappingInfo",
+                                    AutoTensorizeMappingInfoNode, Object);
 };
 
 class AutoTensorizeMappingInfo : public ObjectRef {
@@ -817,8 +814,8 @@ class AutoTensorizeMappingInfo : public ObjectRef {
       : ObjectRef(data) {
     TVM_FFI_ICHECK(data != nullptr);
   }
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(AutoTensorizeMappingInfo, ObjectRef,
-                                            AutoTensorizeMappingInfoNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AutoTensorizeMappingInfo, ObjectRef,
+                                                AutoTensorizeMappingInfoNode);
 };
 
 /*!

--- a/src/tir/transforms/hoist_expression.cc
+++ b/src/tir/transforms/hoist_expression.cc
@@ -81,9 +81,8 @@ struct HoistExpressionConfigNode : public AttrsNodeReflAdapter<HoistExpressionCo
   bool FlagSet(HoistedLetBindings flag) const {
     return static_cast<int>(flag) & hoisted_let_bindings;
   }
-
-  static constexpr const char* _type_key = "tir.transform.HoistExpressionConfig";
-  TVM_DECLARE_FINAL_OBJECT_INFO(HoistExpressionConfigNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.transform.HoistExpressionConfig",
+                                    HoistExpressionConfigNode, Object);
 };
 
 class HoistExpressionConfig : public Attrs {
@@ -94,8 +93,8 @@ class HoistExpressionConfig : public Attrs {
     node->hoisted_let_bindings = hoisted_let_bindings;
     data_ = std::move(node);
   }
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(HoistExpressionConfig, Attrs,
-                                            HoistExpressionConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(HoistExpressionConfig, Attrs,
+                                                HoistExpressionConfigNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ HoistExpressionConfigNode::RegisterReflection(); });
@@ -111,15 +110,14 @@ struct HoistIfThenElseConfigNode : public AttrsNodeReflAdapter<HoistIfThenElseCo
         "support_block_scope_hoisting", &HoistIfThenElseConfigNode::support_block_scope_hoisting,
         "Hoist if cond with block scope variables", refl::DefaultValue(false));
   }
-
-  static constexpr const char* _type_key = "tir.transform.HoistIfThenElseConfig";
-  TVM_DECLARE_FINAL_OBJECT_INFO(HoistIfThenElseConfigNode, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.transform.HoistIfThenElseConfig",
+                                    HoistIfThenElseConfigNode, Object);
 };
 
 class HoistIfThenElseConfig : public Attrs {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(HoistIfThenElseConfig, Attrs,
-                                            HoistIfThenElseConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(HoistIfThenElseConfig, Attrs,
+                                                HoistIfThenElseConfigNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ HoistIfThenElseConfigNode::RegisterReflection(); });

--- a/src/tir/transforms/inject_double_buffer.cc
+++ b/src/tir/transforms/inject_double_buffer.cc
@@ -41,15 +41,14 @@ struct InjectDoubleBufferConfigNode : public AttrsNodeReflAdapter<InjectDoubleBu
         "split_loop", &InjectDoubleBufferConfigNode::split_loop, "Split loop factors",
         refl::DefaultValue(1));
   }
-
-  static constexpr const char* _type_key = "tir.transform.InjectDoubleBufferConfig";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(InjectDoubleBufferConfigNode, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.transform.InjectDoubleBufferConfig",
+                                    InjectDoubleBufferConfigNode, BaseAttrsNode);
 };
 
 class InjectDoubleBufferConfig : public Attrs {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(InjectDoubleBufferConfig, Attrs,
-                                            InjectDoubleBufferConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(InjectDoubleBufferConfig, Attrs,
+                                                InjectDoubleBufferConfigNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ InjectDoubleBufferConfigNode::RegisterReflection(); });

--- a/src/tir/transforms/loop_partition.cc
+++ b/src/tir/transforms/loop_partition.cc
@@ -59,16 +59,16 @@ struct LoopPartitionConfigNode : public AttrsNodeReflAdapter<LoopPartitionConfig
                 "Unroll loops with pragma_loop_partition_hint and no interval",
                 refl::DefaultValue(false));
   }
-
-  static constexpr const char* _type_key = "tir.transform.LoopPartitionConfig";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(LoopPartitionConfigNode, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.transform.LoopPartitionConfig", LoopPartitionConfigNode,
+                                    BaseAttrsNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ LoopPartitionConfigNode::RegisterReflection(); });
 
 class LoopPartitionConfig : public Attrs {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(LoopPartitionConfig, Attrs, LoopPartitionConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(LoopPartitionConfig, Attrs,
+                                                LoopPartitionConfigNode);
 };
 
 TVM_REGISTER_PASS_CONFIG_OPTION("tir.LoopPartition", LoopPartitionConfig);

--- a/src/tir/transforms/reduce_branching_through_overcompute.cc
+++ b/src/tir/transforms/reduce_branching_through_overcompute.cc
@@ -51,15 +51,14 @@ struct ReduceBranchingThroughOvercomputeConfigNode
         "to statically prove that overcompute is valid.",
         refl::DefaultValue(false));
   }
-
-  static constexpr const char* _type_key = "tir.transform.ReduceBranchingThroughOvercomputeConfig";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(ReduceBranchingThroughOvercomputeConfigNode, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.transform.ReduceBranchingThroughOvercomputeConfig",
+                                    ReduceBranchingThroughOvercomputeConfigNode, BaseAttrsNode);
 };
 
 class ReduceBranchingThroughOvercomputeConfig : public Attrs {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(ReduceBranchingThroughOvercomputeConfig, Attrs,
-                                            ReduceBranchingThroughOvercomputeConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ReduceBranchingThroughOvercomputeConfig, Attrs,
+                                                ReduceBranchingThroughOvercomputeConfigNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ ReduceBranchingThroughOvercomputeConfigNode::RegisterReflection(); });

--- a/src/tir/transforms/remove_no_op.cc
+++ b/src/tir/transforms/remove_no_op.cc
@@ -59,14 +59,13 @@ struct RemoveNoOpConfigNode : public AttrsNodeReflAdapter<RemoveNoOpConfigNode> 
                 "For use in debug and testing purposes.",
                 refl::DefaultValue(0));
   }
-
-  static constexpr const char* _type_key = "tir.transform.RemoveNoOpConfig";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(RemoveNoOpConfigNode, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.transform.RemoveNoOpConfig", RemoveNoOpConfigNode,
+                                    BaseAttrsNode);
 };
 
 class RemoveNoOpConfig : public Attrs {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(RemoveNoOpConfig, Attrs, RemoveNoOpConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(RemoveNoOpConfig, Attrs, RemoveNoOpConfigNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ RemoveNoOpConfigNode::RegisterReflection(); });

--- a/src/tir/transforms/simplify.cc
+++ b/src/tir/transforms/simplify.cc
@@ -77,9 +77,8 @@ struct SimplifyConfigNode : public AttrsNodeReflAdapter<SimplifyConfigNode> {
                 "branch",
                 refl::DefaultValue(false));
   }
-
-  static constexpr const char* _type_key = "tir.transform.SimplifyConfig";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(SimplifyConfigNode, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.transform.SimplifyConfig", SimplifyConfigNode,
+                                    BaseAttrsNode);
 
   RewriteSimplifier::Extension GetEnabledExtensions() const {
     RewriteSimplifier::Extension flags = RewriteSimplifier::kNone;
@@ -140,7 +139,7 @@ std::unordered_set<const VarNode*> CollectVarsUsedInBufferDefinition(const Stmt&
 
 class SimplifyConfig : public Attrs {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(SimplifyConfig, Attrs, SimplifyConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(SimplifyConfig, Attrs, SimplifyConfigNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ SimplifyConfigNode::RegisterReflection(); });

--- a/src/tir/transforms/unroll_loop.cc
+++ b/src/tir/transforms/unroll_loop.cc
@@ -64,14 +64,13 @@ struct UnrollLoopConfigNode : public AttrsNodeReflAdapter<UnrollLoopConfigNode> 
         .def_ro("unroll_local_access", &UnrollLoopConfigNode::unroll_local_access,
                 "Whether to always unroll local access", refl::DefaultValue(false));
   }
-
-  static constexpr const char* _type_key = "tir.transform.UnrollLoopConfig";
-  TVM_FFI_DECLARE_FINAL_OBJECT_INFO(UnrollLoopConfigNode, BaseAttrsNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tir.transform.UnrollLoopConfig", UnrollLoopConfigNode,
+                                    BaseAttrsNode);
 };
 
 class UnrollLoopConfig : public Attrs {
  public:
-  TVM_DEFINE_NOTNULLABLE_OBJECT_REF_METHODS(UnrollLoopConfig, Attrs, UnrollLoopConfigNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(UnrollLoopConfig, Attrs, UnrollLoopConfigNode);
 };
 
 TVM_FFI_STATIC_INIT_BLOCK({ UnrollLoopConfigNode::RegisterReflection(); });

--- a/tests/cpp/object_protocol_test.cc
+++ b/tests/cpp/object_protocol_test.cc
@@ -31,28 +31,24 @@ class ObjBase : public Object {
  public:
   // dynamically allocate slow
   static constexpr const uint32_t _type_child_slots = 1;
-  static constexpr const char* _type_key = "test.ObjBase";
-  TVM_DECLARE_BASE_OBJECT_INFO(ObjBase, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO("test.ObjBase", ObjBase, Object);
 };
 
 class ObjA : public ObjBase {
  public:
   static constexpr const uint32_t _type_child_slots = 0;
-  static constexpr const char* _type_key = "test.ObjA";
-  TVM_DECLARE_BASE_OBJECT_INFO(ObjA, ObjBase);
+  TVM_FFI_DECLARE_OBJECT_INFO("test.ObjA", ObjA, ObjBase);
 };
 
 class ObjB : public ObjBase {
  public:
   static constexpr const uint32_t _type_child_slots = 0;
-  static constexpr const char* _type_key = "test.ObjB";
-  TVM_DECLARE_BASE_OBJECT_INFO(ObjB, ObjBase);
+  TVM_FFI_DECLARE_OBJECT_INFO("test.ObjB", ObjB, ObjBase);
 };
 
 class ObjAA : public ObjA {
  public:
-  static constexpr const char* _type_key = "test.ObjAA";
-  TVM_DECLARE_FINAL_OBJECT_INFO(ObjAA, ObjA);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("test.ObjAA", ObjAA, ObjA);
 };
 
 }  // namespace test


### PR DESCRIPTION
This PR streamlines the macros related to object and ref declaration.

- TVM_FFI_DECLARE_BASE_OBJECT_INFO => TVM_FFI_DECLARE_OBJECT_INFO
- TVM_FFI_DECLARE_FINAL_OBJECT_INFO => TVM_FFI_DECLARE_OBJECT_INFO_FINAL
- Move mutable annotation as field in the object
- Auto detect mutablity in object ref getter and operator ptr