### PR TITLE
[Metal] Fix MetalModuleCreate

### DIFF
--- a/src/runtime/metal/metal_module.mm
+++ b/src/runtime/metal/metal_module.mm
@@ -270,7 +270,7 @@ ffi::Optional<ffi::Function> MetalModuleNode::GetFunction(const ffi::String& nam
     ICHECK_EQ(sptr_to_self.get(), this);
     auto it = fmap_.find(name);
     if (it == fmap_.end()) {
-      return std::nullopt;
+      return;
     }
     const FunctionInfo& info = it->second;
     MetalWrappedFunc f;
@@ -285,7 +285,7 @@ ffi::Optional<ffi::Function> MetalModuleNode::GetFunction(const ffi::String& nam
 ffi::Module MetalModuleCreate(std::unordered_map<std::string, std::string> smap,
                               std::unordered_map<std::string, FunctionInfo> fmap, std::string fmt,
                               std::string source) {
-  ObjectPtr<Object> n;
+  ObjectPtr<MetalModuleNode> n;
   AUTORELEASEPOOL { n = ffi::make_object<MetalModuleNode>(smap, fmap, fmt, source); };
   return ffi::Module(n);
 }


### PR DESCRIPTION
This PR fixes a type mismatch in MetalModuleCreate when initializing a MetalModule.  The error does not show up until the recent ObjectRef null safety enhancement.