### PR TITLE
[CI] Enable Metal support in TVM build process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install scikit-build-core
-          export CMAKE_ARGS="-DUSE_LLVM=ON -DBUILD_TESTING=OFF"
+          export CMAKE_ARGS="-DUSE_LLVM=ON -DUSE_METAL=ON -DBUILD_TESTING=OFF"
           pip wheel --no-deps -w dist . -v
       - name: Install TVM from wheel
         shell: bash -l {0}

--- a/tests/python/codegen/test_gpu_codegen_allreduce.py
+++ b/tests/python/codegen/test_gpu_codegen_allreduce.py
@@ -14,12 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import numpy as np
+import pytest
+import tvm_ffi
+
 import tvm
 import tvm.testing
-import numpy as np
 from tvm.script import tir as T
-
-import pytest
 
 
 @T.prim_func
@@ -96,7 +97,11 @@ def optional_metal_compile_callback(define_metal_compile_callback):
 
         @tvm.register_global_func(name, override=True)
         def compile_metal(src, target):
-            return tvm.contrib.xcode.compile_metal(src, sdk="macosx")
+            from tvm.contrib.xcode import (  # pylint: disable=import-outside-toplevel
+                compile_metal,
+            )
+
+            return compile_metal(src, sdk="macosx")
 
     yield
 

--- a/tests/python/codegen/test_target_codegen_metal.py
+++ b/tests/python/codegen/test_target_codegen_metal.py
@@ -187,7 +187,7 @@ def test_func_with_trailing_pod_params():
     mod = tvm.IRModule({"main": func})
 
     f = tvm.compile(mod, target="metal")
-    src: str = f.imports[0].inspect_source()
+    src: str = f.mod.imports[0].inspect_source()
     occurrences = src.count("struct func_kernel_args_t")
     assert occurrences == 1, occurrences
 


### PR DESCRIPTION
This PR enables `USE_METAL=ON` in the MacOS test, so that it will report errors in metal runtime in time.

The PR also fixes a test that was broken but was not revealed since the Mac CI wasn't effectively run.