### PR TITLE
[Fix] Add libxml2 dependency to fix Windows CI build failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install LLVM dependencies
         shell: cmd /C call {0}
         run: |
-          conda install -c conda-forge llvmdev cmake ninja zlib
+          conda install -c conda-forge llvmdev cmake ninja zlib libxml2
       - name: Install TVM
         shell: cmd /C call {0}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,10 +111,6 @@ jobs:
         shell: cmd /C call {0}
         run: |
           conda install -c conda-forge llvmdev cmake ninja zlib libxml2-devel
-      - name: Create xml2.lib symlink for LLVM
-        shell: cmd /C call {0}
-        run: |
-          copy "%CONDA_PREFIX%\Library\lib\libxml2.lib" "%CONDA_PREFIX%\Library\lib\xml2.lib"
       - name: Install TVM
         shell: cmd /C call {0}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,11 @@ jobs:
       - name: Install LLVM dependencies
         shell: cmd /C call {0}
         run: |
-          conda install -c conda-forge llvmdev cmake ninja zlib libxml2
+          conda install -c conda-forge llvmdev cmake ninja zlib libxml2-devel
+      - name: Create xml2.lib symlink for LLVM
+        shell: cmd /C call {0}
+        run: |
+          copy "%CONDA_PREFIX%\Library\lib\libxml2.lib" "%CONDA_PREFIX%\Library\lib\xml2.lib"
       - name: Install TVM
         shell: cmd /C call {0}
         run: |

--- a/cmake/utils/FindLLVM.cmake
+++ b/cmake/utils/FindLLVM.cmake
@@ -219,6 +219,10 @@ macro(find_llvm use_llvm)
         # If the library file ends in .lib try to also search the llvm_libdir
         message(STATUS "LLVM linker flag under LLVM libdir: ${__llvm_libdir}/${__flag}")
         list(APPEND LLVM_LIBS "${__llvm_libdir}/${__flag}")
+      elseif((__flag MATCHES ".lib$") AND (EXISTS "${__llvm_libdir}/lib${__flag}"))
+        # If the library file ends in .lib try to also search the llvm_libdir with lib prefix
+        message(STATUS "LLVM linker flag under LLVM libdir: ${__llvm_libdir}/lib${__flag}")
+        list(APPEND LLVM_LIBS "${__llvm_libdir}/lib${__flag}")
       else()
         message(STATUS "LLVM linker flag: ${__flag}")
         list(APPEND LLVM_LIBS "${__flag}")

--- a/cmake/utils/FindLLVM.cmake
+++ b/cmake/utils/FindLLVM.cmake
@@ -211,23 +211,7 @@ macro(find_llvm use_llvm)
         endif()
       elseif("${__flag}" STREQUAL "-lxml2")
         message(STATUS "LLVM links against xml2")
-        if(WIN32)
-          find_library(XML2_LIBRARY 
-            NAMES xml2 libxml2
-            PATHS ${CMAKE_PREFIX_PATH}/Library/lib
-                  ${CMAKE_PREFIX_PATH}/lib
-            NO_DEFAULT_PATH
-          )
-          if(XML2_LIBRARY)
-            list(APPEND LLVM_LIBS "${XML2_LIBRARY}")
-            message(STATUS "Found libxml2: ${XML2_LIBRARY}")
-          else()
-            message(WARNING "libxml2 not found, LLVM linking may fail")
-            list(APPEND LLVM_LIBS "-lxml2")
-          endif()
-        else()
-          list(APPEND LLVM_LIBS "-lxml2")
-        endif()
+        list(APPEND LLVM_LIBS "-lxml2")
       elseif("${__flag}" STREQUAL "zstd.dll.lib")
         message(STATUS "LLVM linker flag under LLVM libdir: ${__llvm_libdir}/zstd.lib")
         list(APPEND LLVM_LIBS "${__llvm_libdir}/zstd.lib")

--- a/cmake/utils/FindLLVM.cmake
+++ b/cmake/utils/FindLLVM.cmake
@@ -211,7 +211,23 @@ macro(find_llvm use_llvm)
         endif()
       elseif("${__flag}" STREQUAL "-lxml2")
         message(STATUS "LLVM links against xml2")
-        list(APPEND LLVM_LIBS "-lxml2")
+        if(WIN32)
+          find_library(XML2_LIBRARY 
+            NAMES xml2 libxml2
+            PATHS ${CMAKE_PREFIX_PATH}/Library/lib
+                  ${CMAKE_PREFIX_PATH}/lib
+            NO_DEFAULT_PATH
+          )
+          if(XML2_LIBRARY)
+            list(APPEND LLVM_LIBS "${XML2_LIBRARY}")
+            message(STATUS "Found libxml2: ${XML2_LIBRARY}")
+          else()
+            message(WARNING "libxml2 not found, LLVM linking may fail")
+            list(APPEND LLVM_LIBS "-lxml2")
+          endif()
+        else()
+          list(APPEND LLVM_LIBS "-lxml2")
+        endif()
       elseif("${__flag}" STREQUAL "zstd.dll.lib")
         message(STATUS "LLVM linker flag under LLVM libdir: ${__llvm_libdir}/zstd.lib")
         list(APPEND LLVM_LIBS "${__llvm_libdir}/zstd.lib")

--- a/conda/build-environment.yaml
+++ b/conda/build-environment.yaml
@@ -37,3 +37,4 @@ dependencies:
   - numpy
   - scipy
   - cython
+  - libxml2

--- a/conda/build-environment.yaml
+++ b/conda/build-environment.yaml
@@ -37,4 +37,4 @@ dependencies:
   - numpy
   - scipy
   - cython
-  - libxml2
+  - libxml2-devel


### PR DESCRIPTION
This pr add libxml2 dependency to fix Windows CI LNK1181 linking error.