### PR TITLE
[FFI] Fix system library symbol lookup

### DIFF
--- a/ffi/src/ffi/extra/library_module_system_lib.cc
+++ b/ffi/src/ffi/extra/library_module_system_lib.cc
@@ -69,12 +69,25 @@ class SystemLibrary final : public Library {
   explicit SystemLibrary(const String& symbol_prefix) : symbol_prefix_(symbol_prefix) {}
 
   void* GetSymbol(const String& name) final {
+    // The `name` might or might not already contain the symbol prefix.
+    // Therefore, we check both with and without the prefix.
     String name_with_prefix = symbol_prefix_ + name;
-    return reg_->GetSymbol(name_with_prefix);
+    void* symbol = reg_->GetSymbol(name_with_prefix);
+    if (symbol != nullptr) {
+      return symbol;
+    }
+    return reg_->GetSymbol(name);
   }
 
   void* GetSymbolWithSymbolPrefix(const String& name) final {
+    // The `name` might or might not already contain the symbol prefix.
+    // Therefore, we check both with and without the prefix.
     String name_with_prefix = symbol::tvm_ffi_symbol_prefix + symbol_prefix_ + name;
+    void* symbol = reg_->GetSymbol(name_with_prefix);
+    if (symbol != nullptr) {
+      return symbol;
+    }
+    name_with_prefix = symbol::tvm_ffi_symbol_prefix + name;
     return reg_->GetSymbol(name_with_prefix);
   }
 


### PR DESCRIPTION
This PR fixes a bug in the current system library symbol lookup.

Prior to this PR, the lookup key always concatenates `symbol_prefix_` and `name`. However, the `name` may or may not have already contained the symbol prefix. And when it does contain the symbol prefix, the concantenated string will have duplicate symbol prefix, which leads to the lookup failure, because in the compiled library the symbol prefix only appears once.

This PR changes the lookup behavior to check both cases.