### PR TITLE
[Python] Fix runtime tensor import

### DIFF
--- a/python/tvm/exec/disco_worker.py
+++ b/python/tvm/exec/disco_worker.py
@@ -24,7 +24,7 @@ from typing import Callable
 import tvm
 from tvm_ffi import get_global_func, register_global_func
 from tvm.runtime import Tensor, ShapeTuple, String
-from tvm.runtime.tensor import tensor
+from tvm.runtime import tensor
 
 
 @register_global_func("tests.disco.add_one", override=True)

--- a/python/tvm/testing/runner.py
+++ b/python/tvm/testing/runner.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 def _args_to_device(args, device):
     import numpy as np
 
-    from tvm.runtime.tensor import Tensor, empty
+    from tvm.runtime import Tensor, empty
 
     uploaded_args = []
     for arg in args:
@@ -46,7 +46,7 @@ def _args_to_device(args, device):
 
 
 def _args_to_numpy(args):
-    from tvm.runtime.tensor import Tensor
+    from tvm.runtime import Tensor
 
     downloaded_args = []
     for arg in args:


### PR DESCRIPTION
This PR fixes a few places where the python import of runtime tensor is incorrect.  The error wasn't revealed in the previous NDArray->Tensor rename PR since these imports are not at the top level.