### PR TITLE
[FFI][ABI] Better String and Nested Container handling

### DIFF
--- a/ffi/include/tvm/ffi/c_api.h
+++ b/ffi/include/tvm/ffi/c_api.h
@@ -555,6 +555,25 @@ TVM_FFI_DLL int TVMFFITensorFromDLPackVersioned(DLManagedTensorVersioned* from,
  */
 TVM_FFI_DLL int TVMFFITensorToDLPackVersioned(TVMFFIObjectHandle from,
                                               DLManagedTensorVersioned** out);
+//---------------------------------------------------------------
+// Section: string/bytes support APIs.
+// These APIs are used to simplify the string/bytes construction
+//---------------------------------------------------------------
+/*!
+ * \brief Reinterpret the content of TVMFFIByteArray to String.
+ * \param input The TVMFFIByteArray to convert.
+ * \param out The output String owned by the caller, maybe a SmallStr or a Str object.
+ * \return 0 on success, nonzero on failure.
+ */
+TVM_FFI_DLL int TVMFFIStringFromByteArray(const TVMFFIByteArray* input, TVMFFIAny* out);
+
+/*!
+ * \brief Reinterpret the content of TVMFFIByteArray to Bytes.
+ * \param input The TVMFFIByteArray to convert.
+ * \param out The output Bytes owned by the caller, maybe a SmallBytes or a Bytes object.
+ * \return 0 on success, nonzero on failure.
+ */
+TVM_FFI_DLL int TVMFFIBytesFromByteArray(const TVMFFIByteArray* input, TVMFFIAny* out);
 
 //---------------------------------------------------------------
 // Section: dtype string support APIs.

--- a/ffi/pyproject.toml
+++ b/ffi/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "apache-tvm-ffi"
-version = "0.1.0a12"
+version = "0.1.0a13"
 description = "tvm ffi"
 
 authors = [{ name = "TVM FFI team" }]

--- a/ffi/python/tvm_ffi/_convert.py
+++ b/ffi/python/tvm_ffi/_convert.py
@@ -40,13 +40,9 @@ def convert(value: Any) -> Any:
     automatically converted. So this function is mainly
     only used in internal or testing scenarios.
     """
-    if isinstance(value, core.Object):
+    if isinstance(value, (core.Object, core.PyNativeObject, bool, Number)):
         return value
-    elif isinstance(value, core.PyNativeObject):
-        return value
-    elif isinstance(value, (bool, Number)):
-        return value
-    elif isinstance(value, (list, tuple)):
+    elif isinstance(value, (tuple, list)):
         return container.Array(value)
     elif isinstance(value, dict):
         return container.Map(value)
@@ -67,6 +63,3 @@ def convert(value: Any) -> Any:
     else:
         # in this case, it is an opaque python object
         return core._convert_to_opaque_object(value)
-
-
-core._set_func_convert_to_object(convert)

--- a/ffi/python/tvm_ffi/_optional_torch_c_dlpack.py
+++ b/ffi/python/tvm_ffi/_optional_torch_c_dlpack.py
@@ -384,7 +384,6 @@ int64_t TorchDLPackTensorAllocatorPtr() {
             ],
             extra_cflags=["-O3"],
             extra_include_paths=libinfo.include_paths() + cpp_extension.include_paths("cuda"),
-            verbose=True,
         )
         # set the dlpack related flags
         torch.Tensor.__c_dlpack_from_pyobject__ = mod.TorchDLPackFromPyObjectPtr()

--- a/ffi/python/tvm_ffi/cython/base.pxi
+++ b/ffi/python/tvm_ffi/cython/base.pxi
@@ -212,6 +212,8 @@ cdef extern from "tvm/ffi/c_api.h":
                                          TVMFFIByteArray* traceback) nogil
 
     int TVMFFITypeKeyToIndex(TVMFFIByteArray* type_key, int32_t* out_tindex) nogil
+    int TVMFFIStringFromByteArray(TVMFFIByteArray* input_, TVMFFIAny* out) nogil
+    int TVMFFIBytesFromByteArray(TVMFFIByteArray* input_, TVMFFIAny* out) nogil
     int TVMFFIDataTypeFromString(TVMFFIByteArray* str, DLDataType* out) nogil
     int TVMFFIDataTypeToString(const DLDataType* dtype, TVMFFIAny* out) nogil
     const TVMFFIByteArray* TVMFFITraceback(
@@ -282,6 +284,15 @@ cdef extern from "tvm_ffi_python_helpers.h":
         int* c_api_ret_code,
         int release_gil,
         DLPackToPyObject* out_dlpack_importer
+    ) except -1
+
+    int TVMFFIPyConstructorCall(
+        TVMFFIPyArgSetterFactory setter_factory,
+        void* chandle,
+        PyObject* py_arg_tuple,
+        TVMFFIAny* result,
+        int* c_api_ret_code,
+        TVMFFIPyCallContext* parent_ctx
     ) except -1
 
     int TVMFFIPyCallFieldSetter(

--- a/ffi/python/tvm_ffi/cython/object.pxi
+++ b/ffi/python/tvm_ffi/cython/object.pxi
@@ -17,16 +17,11 @@
 import warnings
 
 _CLASS_OBJECT = None
-_FUNC_CONVERT_TO_OBJECT = None
 
 
 def _set_class_object(cls):
     global _CLASS_OBJECT
     _CLASS_OBJECT = cls
-
-def _set_func_convert_to_object(func):
-    global _FUNC_CONVERT_TO_OBJECT
-    _FUNC_CONVERT_TO_OBJECT = func
 
 
 def __object_repr__(obj):
@@ -37,10 +32,6 @@ def __object_repr__(obj):
 def _new_object(cls):
     """Helper function for pickle"""
     return cls.__new__(cls)
-
-
-_OBJECT_FROM_JSON_GRAPH_STR = None
-_OBJECT_TO_JSON_GRAPH_STR = None
 
 
 class ObjectConvertible:
@@ -144,7 +135,7 @@ cdef class Object:
         self.chandle = NULL
         cdef void* chandle
         ConstructorCall(
-            (<Object>fconstructor).chandle, args, &chandle)
+            (<Object>fconstructor).chandle, <PyObject*>args, &chandle, NULL)
         self.chandle = chandle
 
     def same_as(self, other):

--- a/ffi/python/tvm_ffi/cython/string.pxi
+++ b/ffi/python/tvm_ffi/cython/string.pxi
@@ -78,8 +78,3 @@ class Bytes(bytes, PyNativeObject):
 
 
 _register_object_by_index(kTVMFFIBytes, Bytes)
-
-# We special handle str/bytes constructor in cython to avoid extra cyclic deps
-# as the str/bytes construction must be done in the inner loop of function call
-_STR_CONSTRUCTOR = None
-_BYTES_CONSTRUCTOR = None

--- a/ffi/src/ffi/object.cc
+++ b/ffi/src/ffi/object.cc
@@ -493,3 +493,21 @@ const TVMFFITypeInfo* TVMFFIGetTypeInfo(int32_t type_index) {
   return tvm::ffi::TypeTable::Global()->GetTypeEntry(type_index);
   TVM_FFI_LOG_EXCEPTION_CALL_END(TVMFFIGetTypeInfo);
 }
+
+// string APIs, we blend into object.cc to keep things simple
+int TVMFFIStringFromByteArray(const TVMFFIByteArray* input, TVMFFIAny* out) {
+  TVM_FFI_SAFE_CALL_BEGIN();
+  // must set to none first
+  out->type_index = kTVMFFINone;
+  tvm::ffi::TypeTraits<tvm::ffi::String>::MoveToAny(tvm::ffi::String(input->data, input->size),
+                                                    out);
+  TVM_FFI_SAFE_CALL_END();
+}
+
+int TVMFFIBytesFromByteArray(const TVMFFIByteArray* input, TVMFFIAny* out) {
+  TVM_FFI_SAFE_CALL_BEGIN();
+  // must set to none first
+  out->type_index = kTVMFFINone;
+  tvm::ffi::TypeTraits<tvm::ffi::Bytes>::MoveToAny(tvm::ffi::Bytes(input->data, input->size), out);
+  TVM_FFI_SAFE_CALL_END();
+}

--- a/src/runtime/disco/protocol.h
+++ b/src/runtime/disco/protocol.h
@@ -49,7 +49,7 @@ struct DiscoProtocol {
 
   /*! \brief Recycle all the memory used in the arena */
   inline void RecycleAll() {
-    this->object_arena_.clear();
+    this->any_arena_.clear();
     this->arena_.RecycleAll();
   }
 
@@ -81,7 +81,7 @@ struct DiscoProtocol {
   }
 
   support::Arena arena_;
-  std::vector<Any> object_arena_;
+  std::vector<Any> any_arena_;
   friend struct RPCReference;
 };
 
@@ -213,7 +213,7 @@ inline void DiscoProtocol<SubClassType>::ReadFFIAny(TVMFFIAny* out) {
                << Object::TypeIndex2Key(type_index) << " (type_index = " << type_index << ")";
   }
   *reinterpret_cast<ffi::AnyView*>(out) = result;
-  object_arena_.push_back(result);
+  any_arena_.push_back(result);
 }
 
 inline std::string DiscoDebugObject::SaveToStr() const {

--- a/src/runtime/minrpc/rpc_reference.h
+++ b/src/runtime/minrpc/rpc_reference.h
@@ -472,7 +472,9 @@ struct RPCReference {
           break;
         }
         default: {
-          if (type_index >= ffi::TypeIndex::kTVMFFIStaticObjectBegin) {
+          if (type_index >= ffi::TypeIndex::kTVMFFIStaticObjectBegin ||
+              type_index == ffi::TypeIndex::kTVMFFISmallStr ||
+              type_index == ffi::TypeIndex::kTVMFFISmallBytes) {
             channel->ReadFFIAny(&(packed_args[i]));
           } else {
             channel->ThrowError(RPCServerStatus::kUnknownTypeIndex);


### PR DESCRIPTION
This PR improves the overall String/Bytes and nested container handling
It also fixes a bug for temp object recycling when temp object.

- Introduce formal API for string/bytes creation
- Updates the tuple/dict conversion to also preserve the torch stream
   - So if a function takes a list of torch.Tensor, stream will be setup in context
- Optimizes recursive argument conversion by moving most logic into c++