### PR TITLE
[Relax] Introduce R.call_py_func operator for calling Python functions from Relax IR

### DIFF
--- a/python/tvm/relax/base_py_module.py
+++ b/python/tvm/relax/base_py_module.py
@@ -238,8 +238,6 @@ class BasePyModule:
         if func_name not in self.pyfuncs:
             raise ValueError(f"Python function '{func_name}' not found in module pyfuncs")
         py_func = self.pyfuncs[func_name]
-        # args 已经是 PyTorch 张量，不需要转换
-        # py_func 是绑定到 self 的方法，需要传递 self 作为第一个参数
         return py_func(self, *args)
 
     def _create_output_tensors(self, out_sinfo, in_args=None):

--- a/python/tvm/relax/base_py_module.py
+++ b/python/tvm/relax/base_py_module.py
@@ -234,12 +234,13 @@ class BasePyModule:
         return out[0] if len(out) == 1 else out
 
     def call_py_func(self, func_name: str, args):
-        """Call a Python function stored in the IRModule's pyfuncs."""
-        if func_name not in self.ir_mod.pyfuncs:
-            raise ValueError(f"Python function '{func_name}' not found in IRModule pyfuncs")
-        py_func = self.ir_mod.pyfuncs[func_name]
-        converted_args = self._convert_tvm_to_pytorch(args)
-        return py_func(*converted_args)
+        """Call a Python function stored in the module's pyfuncs."""
+        if func_name not in self.pyfuncs:
+            raise ValueError(f"Python function '{func_name}' not found in module pyfuncs")
+        py_func = self.pyfuncs[func_name]
+        # args 已经是 PyTorch 张量，不需要转换
+        # py_func 是绑定到 self 的方法，需要传递 self 作为第一个参数
+        return py_func(self, *args)
 
     def _create_output_tensors(self, out_sinfo, in_args=None):
         # pylint: disable=import-outside-toplevel

--- a/python/tvm/relax/op/__init__.py
+++ b/python/tvm/relax/op/__init__.py
@@ -27,6 +27,7 @@ from .base import (
     call_dps_packed,
     call_inplace_packed,
     call_pure_packed,
+    call_py_func,
     call_tir,
     call_tir_inplace,
     call_tir_with_grad,

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -305,6 +305,42 @@ def call_dps_packed(
 
 
 @args_converter.auto
+def call_py_func(
+    func_name: str,
+    args: Expr,
+    out_sinfo: Union[TensorStructInfo, List[TensorStructInfo]],
+) -> Call:
+    """
+    Call a Python function and return the output.
+
+    Parameters
+    ----------
+    func_name : str
+        The name of the Python function to call. This should correspond to a function
+        in the IRModule's pyfuncs attribute.
+
+    args : Expr
+        The input arguments.
+
+    out_sinfo : Union[TensorStructInfo, List[TensorStructInfo]]
+        The structure info of the call_py_func output.
+        It should be a single or a list of TensorStructInfo. Each one denotes the
+        structure info of a returned tensor.
+
+    Returns
+    -------
+    ret: Call
+        A call node for the call_py_func operator.
+    """
+    args = _wrap_inline_arg_tuple(args)
+
+    if not isinstance(out_sinfo, list):
+        out_sinfo = [out_sinfo]
+
+    return _ffi_api.call_py_func(func_name, args, out_sinfo)  # type: ignore
+
+
+@args_converter.auto
 def call_builtin_with_ctx(
     func: Union[str, Expr],
     args: Expr,

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -30,6 +30,7 @@ from tvm.relax import (
     Expr,
     ExternFunc,
     ShapeExpr,
+    StringImm,
     TupleGetItem,
     Var,
     VarBinding,
@@ -64,6 +65,7 @@ from tvm.relax.op import (
     call_dps_packed,
     call_inplace_packed,
     call_pure_packed,
+    call_py_func as _call_py_func,
     call_tir,
     call_tir_inplace,
     call_tir_with_grad,
@@ -453,15 +455,15 @@ def call_packed(
 
 @args_converter.auto
 def call_py_func(
-    func_name: py_str,
+    py_func_name: py_str,
     *args: Expr,
     out_sinfo: Union[StructInfo, List[StructInfo]],
 ) -> Call:
     """Create a relax Call, which calls a Python function.
-    
+
     Parameters
     ----------
-    func_name: str
+    py_func_name: str
         The name of the Python function to call. This should correspond to a function
         in the IRModule's pyfuncs attribute.
     *args : Expr
@@ -476,9 +478,6 @@ def call_py_func(
     call: Call
         The created Relax Call for call_py_func operator.
     """
-    from tvm.relax.op import call_py_func as _call_py_func
-    from tvm.relax.expr import StringImm
-    
     if isinstance(out_sinfo, py_tuple):  # type: ignore
         out_sinfo = list(out_sinfo)
     elif not isinstance(out_sinfo, list):
@@ -497,9 +496,9 @@ def call_py_func(
 
     # Convert string to StringImm
     try:
-        func_name_imm = StringImm(func_name) if hasattr(func_name, 'strip') else func_name
-    except:
-        func_name_imm = StringImm(func_name)
+        func_name_imm = StringImm(py_func_name) if hasattr(py_func_name, "strip") else py_func_name
+    except Exception:
+        func_name_imm = StringImm(py_func_name)
     return _call_py_func(func_name_imm, args, out_sinfo)
 
 

--- a/tests/python/relax/test_base_py_module_printer.py
+++ b/tests/python/relax/test_base_py_module_printer.py
@@ -758,3 +758,207 @@ def test_python_functions_in_irmodule():
         assert pyfuncs["multiply"].__name__ == "multiply"
     else:
         pytest.fail("pyfuncs attribute not found in IRModule")
+
+
+def test_call_py_func_operator():
+    """Test R.call_py_func operator functionality."""
+    import torch
+
+    @I.ir_module
+    class CallPyFuncTestModule(BasePyModule):
+        """Test module with call_py_func usage."""
+
+        @I.pyfunc
+        def pytorch_add(self, x, y):
+            """Simple PyTorch addition."""
+            return x + y
+
+        @I.pyfunc
+        def pytorch_multiply(self, x, y):
+            """Simple PyTorch multiplication."""
+            return x * y
+
+        @R.function
+        def test_call_py_func(
+            x: R.Tensor((5,), "float32"), y: R.Tensor((5,), "float32")
+        ) -> R.Tensor((5,), "float32"):
+            # Test calling Python function from Relax
+            result = R.call_py_func("pytorch_add", (x, y), out_sinfo=R.Tensor((5,), "float32"))
+            return result
+
+        @R.function
+        def test_call_py_func_chain(
+            x: R.Tensor((5,), "float32"), y: R.Tensor((5,), "float32")
+        ) -> R.Tensor((5,), "float32"):
+            # First call
+            intermediate = R.call_py_func("pytorch_add", (x, y), out_sinfo=R.Tensor((5,), "float32"))
+            # Second call
+            result = R.call_py_func("pytorch_multiply", (intermediate, y), out_sinfo=R.Tensor((5,), "float32"))
+            return result
+
+    # Test basic functionality
+    device = tvm.cpu()
+    module = CallPyFuncTestModule(device)
+
+    # Create test tensors
+    x = torch.randn(5, dtype=torch.float32)
+    y = torch.randn(5, dtype=torch.float32)
+
+    # Test direct Python function calls
+    expected_add = x + y
+    expected_multiply = x * y
+
+    # Test through BasePyModule
+    result_add = module.call_py_func("pytorch_add", [x, y])
+    result_multiply = module.call_py_func("pytorch_multiply", [x, y])
+
+    assert torch.allclose(result_add, expected_add, atol=1e-5)
+    assert torch.allclose(result_multiply, expected_multiply, atol=1e-5)
+
+    # Test that the module has the pyfuncs
+    assert hasattr(module, "pyfuncs")
+    assert "pytorch_add" in module.pyfuncs
+    assert "pytorch_multiply" in module.pyfuncs
+
+
+def test_call_py_func_validation():
+    """Test call_py_func validation and error handling."""
+    import torch
+
+    @I.ir_module
+    class ValidationTestModule(BasePyModule):
+        """Test module for validation."""
+
+        @I.pyfunc
+        def valid_func(self, x):
+            """Valid Python function."""
+            return x * 2
+
+        @R.function
+        def test_invalid_call(
+            x: R.Tensor((5,), "float32")
+        ) -> R.Tensor((5,), "float32"):
+            # This should cause a validation error
+            result = R.call_py_func("non_existent_func", (x,), out_sinfo=R.Tensor((5,), "float32"))
+            return result
+
+    device = tvm.cpu()
+    module = ValidationTestModule(device)
+
+    # Test that calling non-existent function raises error
+    x = torch.randn(5, dtype=torch.float32)
+    
+    with pytest.raises(ValueError, match="Python function 'non_existent_func' not found"):
+        module.call_py_func("non_existent_func", [x])
+
+
+def test_call_py_func_in_relax_function():
+    """Test using call_py_func within Relax functions."""
+    import torch
+
+    @I.ir_module
+    class RelaxCallPyFuncModule(BasePyModule):
+        """Test module with call_py_func in Relax functions."""
+
+        @I.pyfunc
+        def torch_relu(self, x):
+            """PyTorch ReLU implementation."""
+            return torch.relu(x)
+
+        @I.pyfunc
+        def torch_softmax(self, x, dim=0):
+            """PyTorch softmax implementation."""
+            return torch.softmax(x, dim=dim)
+
+        @R.function
+        def mixed_computation(
+            x: R.Tensor((10,), "float32")
+        ) -> R.Tensor((10,), "float32"):
+            # Use Python function for ReLU
+            relu_result = R.call_py_func("torch_relu", (x,), out_sinfo=R.Tensor((10,), "float32"))
+            # Use Python function for softmax
+            final_result = R.call_py_func("torch_softmax", (relu_result,), out_sinfo=R.Tensor((10,), "float32"))
+            return final_result
+
+    device = tvm.cpu()
+    module = RelaxCallPyFuncModule(device)
+
+    # Test the mixed computation
+    x = torch.randn(10, dtype=torch.float32)
+    
+    expected = torch.softmax(torch.relu(x), dim=0)
+    
+    relu_result = module.call_py_func("torch_relu", [x])
+    final_result = module.call_py_func("torch_softmax", [relu_result])
+    
+    assert torch.allclose(final_result, expected, atol=1e-5)
+
+
+def test_call_py_func_operator_creation():
+    """Test R.call_py_func operator creation and basic properties."""
+    from tvm.relax.op import call_py_func
+    from tvm.relax.expr import StringImm
+    from tvm.relax import Var, TensorStructInfo
+    
+    # Create variables
+    x = Var("x", TensorStructInfo((5,), "float32"))
+    y = Var("y", TensorStructInfo((5,), "float32"))
+    
+    # Create call_py_func call
+    call_expr = call_py_func(StringImm("test_func"), (x, y), out_sinfo=R.Tensor((5,), "float32"))
+    
+    # Verify operator properties
+    assert call_expr.op.name == "relax.call_py_func"
+    assert call_expr.args[0].value == "test_func"
+    assert len(call_expr.args) == 2
+
+
+def test_call_py_func_compilation_validation():
+    """Test call_py_func compilation validation."""
+    from tvm.relax.op import call_py_func
+    from tvm.relax import Var, TensorStructInfo
+    
+    # Test operator parameter validation
+    try:
+        call_py_func("invalid", (Var("x", TensorStructInfo((5,), "float32")),), out_sinfo=R.Tensor((5,), "float32"))
+        assert False, "Should raise type error"
+    except Exception as e:
+        assert "Mismatched type" in str(e) or "Expected" in str(e)
+
+
+def test_call_py_func_runtime_execution():
+    """Test call_py_func runtime execution with complex operations."""
+    import torch
+    
+    @I.ir_module
+    class RuntimeTestModule(BasePyModule):
+        """Test module for runtime execution"""
+        
+        @I.pyfunc
+        def pytorch_add(self, x, y):
+            """PyTorch addition function"""
+            return x + y
+        
+        @I.pyfunc
+        def pytorch_relu(self, x):
+            """PyTorch ReLU function"""
+            return torch.relu(x)
+    
+    # Create module instance
+    device = tvm.cpu()
+    module = RuntimeTestModule(device)
+    
+    # Create test tensors
+    x = torch.randn(5, dtype=torch.float32)
+    y = torch.randn(5, dtype=torch.float32)
+    
+    # Test direct Python function calls
+    result_add = module.call_py_func("pytorch_add", [x, y])
+    result_relu = module.call_py_func("pytorch_relu", [x])
+    
+    expected_add = x + y
+    expected_relu = torch.relu(x)
+    
+    # Verify results
+    assert torch.allclose(result_add, expected_add, atol=1e-5)
+    assert torch.allclose(result_relu, expected_relu, atol=1e-5)


### PR DESCRIPTION
This PR allows calling Python functions directly from Relax IR, where integration between Relax computations and Python/PyTorch operations can be supported.

### Usage Example
```python
@I.ir_module
class MyModule(BasePyModule):
    @I.pyfunc
    def pytorch_add(self, x, y):
        return x + y
    
    @R.function
    def compute(x: R.Tensor((5,), "float32"), y: R.Tensor((5,), "float32")) -> R.Tensor((5,), "float32"):
        result = R.call_py_func("pytorch_add", (x, y), out_sinfo=R.Tensor((5,), "float32"))
        return result
```

**THIS PR** represents the final milestone in the Relax Python integration design, and completes the full feature set for Python/Relax interoperability. The complete Relax-Python integration ecosystem has been built upon the following key design principles:

### Cross-level Calls
- **Two-way interoperability**: Python functions can invoke Relax/TIR/packed functions, and Relax functions can invoke Python functions via `R.call_py_func`
- **Seamless data conversion**: DLPack enables efficient conversion between TVM Tensors and PyTorch Tensors with minimal overhead

### Just-in-time (JIT) Compilation  
- **Delayed compilation**: TIR and Relax functions are compiled only when the IRModule is instantiated
- **Flexible integration**: Allows late-stage modifications and seamless integration with the Python runtime
- **Relax VM execution**: Compiled Relax functions are executed using a Relax VM created at instantiation time

### Conversion between Relax and Python Functions
- **IRModule printer**: Converts Relax functions into executable Python code for debugging and deployment
- **Operator mapping**: High-level Relax operators (e.g., `R.nn.relu`) are mapped to corresponding PyTorch APIs (e.g., `F.relu`)
- **Multi-stage conversion**: Can happen at any stage of compilation, from early Relax functions to fully lowered TIR modules
- **DLPack integration**: Handles `call_tir` and `call_dps_packed` by converting PyTorch tensors to/from DLPack format