### PR TITLE
[TIR] Refactor division simplification in RewriteSimplifier

### DIFF
--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -774,13 +774,6 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const DivNode* op) {
   // Pattern var for lanes in broadcast and ramp
   PVar<PrimExpr> lanes;
 
-  // x / 2.0 = x * 0.5
-  if (const FloatImmNode* ptr = op->b.as<FloatImmNode>()) {
-    ICHECK(op->dtype.is_float() || op->dtype.is_bfloat16() ||
-           datatype::Registry::Global()->GetTypeRegistered(op->dtype.code()));
-    return op->a * make_const(op->b.dtype(), 1.0 / ptr->value);
-  }
-
   // Vector rules
   if (op->dtype.is_scalable_or_fixed_length_vector()) {
     // NOTE: use div as the pattern also works for float.

--- a/tests/python/arith/test_arith_simplify.py
+++ b/tests/python/arith/test_arith_simplify.py
@@ -21,6 +21,7 @@ import tvm
 import tvm.testing
 from tvm import tir
 from tvm.script import tir as T
+import tvm.ir
 
 
 def test_simplify_reshape_flattened_index():
@@ -142,6 +143,17 @@ def test_simplify_floor_mod_with_linear_offset():
     assert ana.can_prove_equal(tvm.tir.floormod(expr1, divisor1), 0)
     divisor2 = 32 * (past_decoder_sequence_length + 1)
     assert ana.can_prove_equal(tvm.tir.floormod(expr1, divisor2), 0)
+
+
+def test_simplify_float_division():
+    # Test for the discussion:
+    # https://discuss.tvm.apache.org/t/discuss-is-constant-division-to-multiplication-rewrite-in-tvm-necessary/18615
+    ana = tvm.arith.Analyzer()
+    x = tir.Var("x", "float32")
+    ry = x / 27
+    # in old version, the division will be rewritten into x * T.float32(1 / 27)
+    sy = ana.rewrite_simplify(ry)
+    tvm.ir.assert_structural_equal(ry, sy)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For example:

```python
x = tir.Var("x", "float32")
ry = x / 27
sy = ana.rewrite_simplify(ry)
```

In previous versions, the division would be rewritten as `x * T.float32(1 / 27)`, which could lead to unexpected behavior.

This commit removes the special-case rule for rewriting division by a constant float in `RewriteSimplifier`.  
Additionally, it adds a new test to verify the behavior of float-division simplification, ensuring divisions are preserved as-is instead of being rewritten into multiplications.

Related discussion: https://discuss.tvm.apache.org/t/discuss-is-constant-division-to-multiplication-rewrite-in-tvm-necessary/18615