### PR TITLE
[BugFix] Fixing binding for bert

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -716,10 +716,10 @@ class ExportedProgramImporter(BaseFXGraphImporter):
                     bind_name = spec.arg.name
                     break
             try:
-                binding[bind_name] = tvm.nd.from_dlpack(tensor_value.detach())
+                binding[bind_name] = tvm.runtime.from_dlpack(tensor_value.detach())
             except RuntimeError:
                 tensor_cpu = tensor_value.detach().cpu().contiguous()
-                binding[bind_name] = tvm.nd.array(tensor_cpu.numpy())
+                binding[bind_name] = tvm.runtime.tensor(tensor_cpu.numpy())
 
         mod = self.block_builder.get()
         mod = relax.transform.BindParams("main", binding)(mod)


### PR DESCRIPTION
Before this PR I was getting the following error:

`
Traceback (most recent call last):
  File "/home/thais/Dev/TVM-LLM-Bench/test-export.py", line 36, in <module>
    mod: tvm.IRModule = from_exported_program(exported_program)
  File "/home/thais/Dev/new-tvm/tvm/python/tvm/relax/frontend/torch/exported_program_translator.py", line 806, in from_exported_program
    return ExportedProgramImporter().from_exported_program(
  File "/home/thais/Dev/new-tvm/tvm/python/tvm/relax/frontend/torch/exported_program_translator.py", line 718, in from_exported_program
    binding[bind_name] = tvm.nd.from_dlpack(tensor_value.detach())
  File "/home/thais/Dev/new-tvm/tvm/python/tvm/runtime/ndarray.py", line 66, in from_dlpack
    return tvm.ffi.from_dlpack(
  File "tvm/ffi/cython/./ndarray.pxi", line 112, in tvm.ffi.core.from_dlpack
  File "tvm/ffi/cython/./ndarray.pxi", line 60, in tvm.ffi.core._from_dlpack
  File "tvm/ffi/cython/./error.pxi", line 171, in tvm.ffi.core.CHECK_CALL
  File "tvm/ffi/cython/core.cpp", line 19568, in __pyx_pw_3tvm_3ffi_4core_35from_dlpack
  File "tvm/ffi/cython/core.cpp", line 19691, in __pyx_pf_3tvm_3ffi_4core_34from_dlpack
  File "tvm/ffi/cython/core.cpp", line 19179, in __pyx_f_3tvm_3ffi_4core__from_dlpack
RuntimeError: FromDLPack: Data is not aligned to 64 bytes.
`