### PR TITLE
[CMake][Web] Install `web/` directory in cmake for Python package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -885,6 +885,9 @@ if(TVM_BUILD_PYTHON_MODULE)
     PATTERN "*.h"
   )
 
+  # Install web package
+  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/web/" DESTINATION "web/")
+
   # Install essential configuration files
   install(
     DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/configs/"


### PR DESCRIPTION
This PR updates the CMakeLists to install the web subdirectory when building Python package, so that people do not need to clone TVM source code to build web package.