### PR TITLE
Fixing datatype error for gpt-2

### DIFF
--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -319,7 +319,7 @@ inline DataType InferBinaryArithOpOutDtype(const Call& call, const BlockBuilder&
 
   if (lhs_dtype.is_void() || rhs_dtype.is_void()) {
     return DataType::Void();
-  } else if (lhs_dtype != rhs_dtype) {
+  } else if (lhs_dtype != rhs_dtype && !lhs_dtype.is_bool() && !rhs_dtype.is_bool()) {
     ctx->ReportFatal(Diagnostic::Error(call)
                      << "TypeError: "
                      << "Binary operators must have the same datatype for both operands.  "


### PR DESCRIPTION
Before this PR I was getting the following error:

`Traceback (most recent call last):
  File "/home/thais/Dev/TVM-LLM-Bench/test-export-gpt.py", line 35, in <module>
    mod: tvm.IRModule = from_exported_program(exported_program)
  File "/home/thais/Dev/new-tvm/tvm/python/tvm/relax/frontend/torch/exported_program_translator.py", line 806, in from_exported_program
    return ExportedProgramImporter().from_exported_program(
  File "/home/thais/Dev/new-tvm/tvm/python/tvm/relax/frontend/torch/exported_program_translator.py", line 697, in from_exported_program
    self.env[node] = self.convert_map[func_name](node)
  File "/home/thais/Dev/new-tvm/tvm/python/tvm/relax/frontend/torch/base_fx_graph_translator.py", line 409, in convert
    return call_binary_op(relax_op, lhs, rhs)
  File "/home/thais/Dev/new-tvm/tvm/python/tvm/relax/frontend/torch/base_fx_graph_translator.py", line 405, in call_binary_op
    return self.block_builder.emit(op(lhs, rhs))
  File "/home/thais/Dev/new-tvm/tvm/python/tvm/relax/block_builder.py", line 323, in emit
    return _ffi_api.BlockBuilderEmit(self, expr, name_hint)  # type: ignore
  File "tvm/ffi/cython/./function.pxi", line 228, in tvm.ffi.core.Function.__call__
  File "tvm/ffi/cython/core.cpp", line 24315, in __pyx_pw_3tvm_3ffi_4core_8Function_1__call__
  File "tvm/ffi/cython/core.cpp", line 24369, in __pyx_pf_3tvm_3ffi_4core_8Function___call__
  File "tvm/ffi/cython/core.cpp", line 23995, in __pyx_f_3tvm_3ffi_4core_FuncCall
  File "tvm/ffi/cython/core.cpp", line 23890, in __pyx_f_3tvm_3ffi_4core_FuncCall3
TypeError: Binary operators must have the same datatype for both operands.  However, R.multiply(lv15, lv18) uses datatype float32 on the LHS (StructInfo of R.Tensor((14, 14), dtype="float32")), and datatype bool on the RHS (StructInfo of R.Tensor((14, 14), dtype="bool")).
`