### PR TITLE
[TIR] Support sequence comparisons in TVMScript

### DIFF
--- a/tests/python/tvmscript/test_tvmscript_parser_tir.py
+++ b/tests/python/tvmscript/test_tvmscript_parser_tir.py
@@ -626,5 +626,25 @@ def test_ifexp():
     tvm.ir.assert_structural_equal(func, expected)
 
 
+def test_sequence_compare():
+    @T.prim_func(private=True)
+    def tir_func(A: T.Buffer((128, 128), "float32")):
+        for i, j in T.grid(128, 128):
+            if 0 < i < 128 and 0 < j < 128:
+                A[i, j] = 1
+            else:
+                A[i, j] = 0
+
+    @T.prim_func(private=True)
+    def expected(A: T.buffer((128, 128), "float32")):
+        for i, j in T.grid(128, 128):
+            if (0 < i and i < 128) and (0 < j and j < 128):
+                A[i, j] = 1
+            else:
+                A[i, j] = 0
+
+    tvm.ir.assert_structural_equal(tir_func, expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Implement proper parsing and evaluation of chained comparison operators (e.g., `0 < i < 128`) in TVMScript. The sequence comparisons are now correctly expanded to their logical equivalents (e.g., `(0 < i and i < 128)`).

cc @LeiWang1999 