### PR TITLE
[Relax][PyTorch] Support MatrixMultiply op for ExportedProgram importer

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -434,6 +434,9 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "matmul.default": self._binary_op(
                 partial(relax.op.linear_algebra.matmul, out_dtype="float32"), operator.matmul
             ),
+            "mm.default": self._binary_op(
+                partial(relax.op.linear_algebra.matmul, out_dtype="float32"), operator.matmul
+            ),
             "max.other": self._binary_op(relax.op.maximum, max),
             "min.other": self._binary_op(relax.op.minimum, min),
             "max.default": self._unary_op(relax.op.max),


### PR DESCRIPTION
This pr supports `mm.default` for ExportedProgram importer.
Related issue: #18339 