### PR TITLE
[Python] Add library lookup path for tvm installed as a pakcage

### DIFF
--- a/python/tvm/libinfo.py
+++ b/python/tvm/libinfo.py
@@ -66,6 +66,7 @@ def get_dll_directories():
 
     # Pip lib directory
     dll_path.append(ffi_dir)
+    dll_path.append(os.path.join(ffi_dir, "lib"))
     # Default cmake build directory
     dll_path.append(os.path.join(source_dir, "build"))
     dll_path.append(os.path.join(source_dir, "build", "Release"))


### PR DESCRIPTION
As per title.

repro:
```
git clone https://github.com/apache/tvm --recursive
cd tvm
uv venv && source .venv/bin/activate
uv pip install ninja
uv pip install . --config-settings=cmake.args="-G Ninja"
rm -rf build/
python -c "import tvm"
```

we get
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/ubuntu/tmp/tvm/.venv/lib/python3.11/site-packages/tvm/__init__.py", line 27, in <module>
    from .base import TVMError, __version__, _RUNTIME_ONLY
  File "/home/ubuntu/tmp/tvm/.venv/lib/python3.11/site-packages/tvm/base.py", line 58, in <module>
    _LIB, _LIB_NAME = _load_lib()
                      ^^^^^^^^^^^
  File "/home/ubuntu/tmp/tvm/.venv/lib/python3.11/site-packages/tvm/base.py", line 40, in _load_lib
    lib_path = libinfo.find_lib_path()
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/tmp/tvm/.venv/lib/python3.11/site-packages/tvm/libinfo.py", line 173, in find_lib_path
    raise RuntimeError(message)
RuntimeError: Cannot find libraries: ['libtvm.so', 'libtvm_runtime.so', '3rdparty/cutlass_fpA_intB_gemm/cutlass_kernels/libfpA_intB_gemm.so', '3rdparty/libflash_attn/src/libflash_attn.so']
List of candidates:
/home/ubuntu/tmp/tvm/.venv/bin/libtvm.so
/usr/local/cuda-12.8/bin/libtvm.so
/home/ubuntu/.cargo/bin/libtvm.so
/usr/local/sbin/libtvm.so
/usr/local/bin/libtvm.so
/usr/sbin/libtvm.so
/usr/bin/libtvm.so
/usr/sbin/libtvm.so
/usr/bin/libtvm.so
/usr/games/libtvm.so
/usr/local/games/libtvm.so
/snap/bin/libtvm.so
/home/ubuntu/.fzf/bin/libtvm.so
/home/ubuntu/tmp/tvm/.venv/lib/python3.11/site-packages/tvm/libtvm.so
/home/ubuntu/tmp/tvm/.venv/lib/libtvm.so
/home/ubuntu/tmp/tvm/.venv/bin/libtvm_runtime.so
/usr/local/cuda-12.8/bin/libtvm_runtime.so
/home/ubuntu/.cargo/bin/libtvm_runtime.so
/usr/local/sbin/libtvm_runtime.so
/usr/local/bin/libtvm_runtime.so
/usr/sbin/libtvm_runtime.so
/usr/bin/libtvm_runtime.so
/usr/sbin/libtvm_runtime.so
/usr/bin/libtvm_runtime.so
/usr/games/libtvm_runtime.so
/usr/local/games/libtvm_runtime.so
/snap/bin/libtvm_runtime.so
/home/ubuntu/.fzf/bin/libtvm_runtime.so
/home/ubuntu/tmp/tvm/.venv/lib/python3.11/site-packages/tvm/libtvm_runtime.so
/home/ubuntu/tmp/tvm/.venv/lib/libtvm_runtime.so
```