### PR TITLE
[Relax][PyTorch] Fix the segfault in from_exported_program when model returns (Tensor, None) tuple

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -102,6 +102,9 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
             return [self._retrieve_args(x) for x in node]
         elif isinstance(node, dict):
             return {self._retrieve_args(k): self._retrieve_args(v) for k, v in node.items()}
+        elif node is None:
+            # Convert None to a Relax null_value expression
+            return relax.op.null_value()
         else:
             return node
 

--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -103,7 +103,6 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         elif isinstance(node, dict):
             return {self._retrieve_args(k): self._retrieve_args(v) for k, v in node.items()}
         elif node is None:
-            # Convert None to a Relax null_value expression
             return relax.op.null_value()
         else:
             return node


### PR DESCRIPTION
As per title, this PR resolves the issue #18337