### PR TITLE
[TIR] Adjust the syntax of `tir::Or()`

### DIFF
--- a/src/target/llvm/intrin_rule_llvm.cc
+++ b/src/target/llvm/intrin_rule_llvm.cc
@@ -181,7 +181,7 @@ TVM_REGISTER_OP("tir.asin")
       /* --- domain limit check --- */
       PrimExpr lower = make_const(x.dtype(), -1.0);
       PrimExpr upper = make_const(x.dtype(), 1.0);
-      PrimExpr out_range = tir::Or(x<lower, x> upper);
+      PrimExpr out_range = tir::Or(x<lower, x>upper);
       // Use a quiet NaN constant
       PrimExpr nan_const = make_const(x.dtype(), std::numeric_limits<double>::quiet_NaN());
       // select: if out of [-1,1] → NaN, else → series


### PR DESCRIPTION
This PR is trying to fix issues https://github.com/apache/tvm/issues/18017. 
Any suggestions and review comments would be appreciated.