### PR TITLE
[Relax][PyTorch] Add run_ep_decomposition flag to control PyTorch decomposition

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -907,8 +907,6 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "pow.Scalar": self._binary_op(relax.op.power, operator.pow),
             "pow.Tensor_Scalar": self._binary_op(relax.op.power, operator.pow),
             "pow.Tensor_Tensor": self._binary_op(relax.op.power, operator.pow),
-            # Decomposed operators
-            "mul.Tensor": self._binary_op(relax.op.multiply, operator.mul),
             "sub.Tensor": self._binary_op(relax.op.subtract, operator.sub),
             "__and__.Tensor": self._binary_op(relax.op.bitwise_and, operator.and_),
             "__and__.Scalar": self._binary_op(relax.op.bitwise_and, operator.and_),


### PR DESCRIPTION
This PR adds a new `run_ep_decomposition` flag to the `from_exported_program` function to control whether PyTorch's decomposition should be run before translation. This enables gradual migration from non-decomposed to decomposed operator support. This flag will be a temporary one and will be removed until everything is fixed.

## Motivation
Currently, when `run_decompositions()` is called on an ExportedProgram, high-level operators are decomposed into their constituent parts (e.g., `torch.square` → `torch.pow(x, 2)`). However, the current translator expects the original high-level operators, causing ~40% of tests to fail when decomposition is enabled. Previously, we couldn't enable decomposition because `run_decompositions()` is not an in-place operation so that it cannot be used.

This flag allows us to:
1. Keep existing tests passing (default behavior)
2. Gradually add support for decomposed operators
3. Eventually migrate all tests to use decomposition
4. Remove the flag once migration is complete

## Future Work
This PR sets up the foundation for:
- Adding support for decomposed operators (e.g., `pow.Tensor_Scalar`, `mul.Tensor`)
- Gradually migrating tests to use decomposition
- Eventually removing the flag once migration is complete

## Example Usage
```python
# Current behavior (no decomposition)
mod = from_exported_program(exported_program)

# New behavior (with decomposition)
mod = from_exported_program(exported_program, run_ep_decomposition=True)
```