### PR TITLE
[Relax][PyTorch] Add support for decomposed operators and fix IR of ops tests(6)

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1725,7 +1725,7 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         # Support both "dim" and "dims" parameters
         if dim is None:
             dim = node.kwargs.get("dims", None)
-        
+
         # If dims is a list, filter out axes where dimension is not 1
         # This is needed because PyTorch decomposition may pass all axes
         if isinstance(dim, (list, tuple)) and len(dim) > 0:
@@ -1738,7 +1738,7 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
                     valid_dims.append(d)
             # If no valid dims, use None to squeeze all size-1 dimensions
             dim = valid_dims if valid_dims else None
-        
+
         return self.block_builder.emit(relax.op.squeeze(x, dim))
 
     def _stack(self, node: fx.Node) -> relax.Var:

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -701,11 +701,23 @@ class ExportedProgramImporter(BaseFXGraphImporter):
         return self.block_builder.emit(relax.op.take(x, index, dim))
 
     def _slice(self, node: fx.Node) -> relax.Var:
+        import sys
+
         x = self.env[node.args[0]]
-        axes = [node.args[1]]
-        begin = [node.args[2]]
-        end = [node.args[3]]
-        stride = [node.args[4] if len(node.args) > 4 else 1]
+        dim = node.args[1] if len(node.args) > 1 else 0
+        start = node.args[2] if len(node.args) > 2 else None
+        end_val = node.args[3] if len(node.args) > 3 else None
+        step = node.args[4] if len(node.args) > 4 else 1
+
+        if start is None:
+            start = 0
+        if end_val is None:
+            end_val = sys.maxsize
+
+        axes = [dim]
+        begin = [start]
+        end = [end_val]
+        stride = [step]
         return self.block_builder.emit(relax.op.strided_slice(x, axes, begin, end, stride))
 
     def _unflatten(self, node: fx.Node) -> relax.Var:


### PR DESCRIPTION
This pr fixes ops like `roll`, `select_slice`, and `squeeze`.