### PR TITLE
Support integer type input for log and log2

### DIFF
--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -450,7 +450,6 @@ def round(x):
     return te.compute(x.shape, lambda *i: te.round(x(*i)))
 
 
-@tvm.te.tag_scope(tag=tag.ELEMWISE)
 def log(x):
     """Take logarithm of input x.
 
@@ -466,10 +465,9 @@ def log(x):
     """
     if x.dtype.startswith("int"):
         x = te.compute(x.shape, lambda *i: x(*i).astype("float32"))
-    return te.compute(x.shape, lambda *i: te.log(x(*i)))
+    return te.compute(x.shape, lambda *i: te.log(x(*i)), tag=tag.ELEMWISE)
 
 
-@tvm.te.tag_scope(tag=tag.ELEMWISE)
 def log2(x):
     """Take logarithm to the base 2 of input x.
 
@@ -485,7 +483,7 @@ def log2(x):
     """
     if x.dtype.startswith("int"):
         x = te.compute(x.shape, lambda *i: x(*i).astype("float32"))
-    return te.compute(x.shape, lambda *i: te.log2(x(*i)))
+    return te.compute(x.shape, lambda *i: te.log2(x(*i)), tag=tag.ELEMWISE)
 
 
 def log10(x):


### PR DESCRIPTION
Adds support for integer inputs in `topi.log` and `topi.log2` by automatically converting them to float32, aligning with NumPy's implicit float promotion behavior.



Fix https://github.com/apache/tvm/issues/18425