### PR TITLE
[Relax][PyTorch] Add decomposed operator support for Conv

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -969,6 +969,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "conv1d.default": self._conv1d,
             "conv2d.default": self._conv2d,
             "conv3d.default": self._conv3d,
+            "convolution.default": self._convolution,
             "cross_entropy_loss.default": self._cross_entropy_default,
             "einsum.default": self._einsum,
             "embedding.default": lambda node: self._embedding_impl(

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -5254,7 +5254,9 @@ def test_keep_params():
     example_args = (torch.randn(1, 3, 10, 10, dtype=torch.float32),)
     model = Conv2D1()
     exported_program = torch.export.export(model, example_args)
-    mod = from_exported_program(exported_program, keep_params_as_input=True)
+    mod = from_exported_program(
+        exported_program, keep_params_as_input=True, run_ep_decomposition=True
+    )
     mod, params = detach_params(mod)
     tvm.ir.assert_structural_equal(mod, expected1)
     func = mod["main"]


### PR DESCRIPTION
## Related Issue

https://github.com/apache/tvm/pull/18401

## Why
- When `run_ep_decomposition=True` is enabled, PyTorch decomposes high-level operators like conv2d.default into
lower-level `convolution.default`, which is not supported yet.

## How

- Added _convolution() method in base_fx_graph_translator.py to handle the generic aten.convolution.default operator
- Updated test_keep_params to use run_ep_decomposition=True