### PR TITLE
[Relax][PyTorch] Add lower bound support for range constraints

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -125,18 +125,19 @@ TVM_DLL Pass RewriteDataflowReshape();
  * The pass will reuse allocated memory to its best effort, in order to
  * reduce the total amount of allocated memory size.
  *
- * The pass "supports" dynamic shape in the way of TIR variable upper bound
- * annotation. We can optionally annotate the attribute "tir_var_upper_bound"
- * to Relax functions. The attribute value is a dict from strings to integers,
- * denoting the name of TIR variables to the upper bound values of the TIR vars.
- * Note: The annotated upper bound attribute only applies to TIR vars in the
+ * The pass "supports" dynamic shape in the way of TIR variable bound
+ * annotations. We can optionally annotate the attributes "tir_var_upper_bound"
+ * and "tir_var_lower_bound" to Relax functions. The attribute values are dicts
+ * from strings to integers, denoting the name of TIR variables to the bound
+ * values of the TIR vars.
+ * Note: The annotated bound attributes only apply to TIR vars in the
  * function signature for clarity.
  *
  * For example, we can annotate a Relax function with
- *   `R.func_attr({"tir_var_upper_bound": {"n": 1024}})`.
- * It means the maximum value of variable that names "n" in the function
- * signature will have upper bound 1024. And we will use 1024 as its value
- * during memory planning.
+ *   `R.func_attr({"tir_var_lower_bound": {"n": 1}, "tir_var_upper_bound": {"n": 1024}})`.
+ * It means the variable that names "n" in the function signature will have
+ * range [1, 1024]. And we will use these bounds during memory planning.
+ * If lower bound is not specified, it defaults to 0.
  *
  * \return The pass.
  */

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -1181,10 +1181,12 @@ class ExportedProgramImporter(BaseFXGraphImporter):
         if range_constraints:
             if func_attrs is None:
                 func_attrs = {}
-            tir_var_upper_bound = {
+            func_attrs["tir_var_lower_bound"] = {
+                var_name: lower for var_name, (lower, _) in range_constraints.items()
+            }
+            func_attrs["tir_var_upper_bound"] = {
                 var_name: upper for var_name, (_, upper) in range_constraints.items()
             }
-            func_attrs["tir_var_upper_bound"] = tir_var_upper_bound
 
         nodes: List[fx.Node] = exported_program.graph.nodes
 

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -6747,7 +6747,7 @@ def test_dynamic_shape_with_range_constraints():
             x1: R.Tensor(("s0", 4), dtype="float32"), x2: R.Tensor(("s0", 4), dtype="float32")
         ) -> R.Tuple(R.Tensor(("s0", 4), dtype="float32")):
             s0 = T.int64(is_size_var=True)
-            R.func_attr({"tir_var_upper_bound": {"s0": 64}})
+            R.func_attr({"tir_var_lower_bound": {"s0": 1}, "tir_var_upper_bound": {"s0": 64}})
             with R.dataflow():
                 lv: R.Tensor((s0, 4), dtype="float32") = R.add(x1, x2)
                 gv: R.Tuple(R.Tensor((s0, 4), dtype="float32")) = (lv,)

--- a/tests/python/relax/test_transform_static_plan_block_memory.py
+++ b/tests/python/relax/test_transform_static_plan_block_memory.py
@@ -1347,6 +1347,18 @@ def test_invalid_tir_var_upper_bound():
         relax.transform.StaticPlanBlockMemory()(Module)
 
 
+def test_invalid_tir_var_lower_bound():
+    @tvm.script.ir_module
+    class Module:
+        @R.function
+        def main(x: R.Tensor((2, "n"), dtype="float32")):
+            R.func_attr({"tir_var_lower_bound": {"n": [4]}, "relax.force_pure": True})
+            return x
+
+    with pytest.raises((TVMError, TypeError)):
+        relax.transform.StaticPlanBlockMemory()(Module)
+
+
 def test_add():
     @I.ir_module
     class Module:


### PR DESCRIPTION
## Related
- #18429

## Why

- Previously only extracted upper bounds, discarding lower bound information
- Enables better memory planning and optimization with full range [min, max]

## How

- Extract both tir_var_lower_bound and tir_var_upper_bound from PyTorch `ExportedProgram.range_constraints`
- Update C++ transforms (static_plan_block_memory.cc, adjust_matmul_order.cc) to use lower bounds
- Default: lower=0 if not specified, upper=INT64_MAX if not specified