### PR TITLE
[CI] Update pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,20 +32,20 @@
 #
 
 default_language_version:
-    python: python3.6
+    python: python3.9
 fail_fast: True
-default_stages: [push]
+default_stages: [pre-push]
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.3.0
+      rev: v6.0.0
       hooks:
         - id: check-added-large-files
         - id: check-merge-conflict
         - id: check-yaml
         - id: end-of-file-fixer
-          stages: [push]
+          stages: [pre-push]
         - id: trailing-whitespace
-          stages: [push]
+          stages: [pre-push]
     - repo: local
       hooks:
         -   id: run-black


### PR DESCRIPTION
## Why

pre-commit file seems outdated and not updated for a while

## How

- upgrade Python version to 3.9 since current ci run on 3.9 and 3.6 is EOL
- update pre-commit hooks to newest version [6.0.0](https://github.com/pre-commit/pre-commit-hooks/releases/tag/v6.0.0)
- change default stages to `pre-push` (`push` is deprecated)