### PR TITLE
[Web] Fix progress reporting when loading from cache

### DIFF
--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -1359,7 +1359,7 @@ export class Instance implements Disposable {
         }
         timeElapsed = Math.ceil((perf.now() - tstart) / 1000);
         fetchedBytes += shard.nbytes;
-        reportCallback(fetchedShards++, /*loading=*/false);
+        reportCallback(++fetchedShards, /*loading=*/false);
       }
     }
     // We launch 4 parallel for loops to limit the max concurrency to 4 download
@@ -1372,6 +1372,10 @@ export class Instance implements Disposable {
         downloadCache(3 * loopSize, list.length)
       ]);
     }
+
+    // Reset for the loading phase to avoid double counting with download phase
+    fetchedBytes = 0;
+    fetchedShards = 0;
 
     // Then iteratively, load the shard from cache
     for (let i = 0; i < list.length; ++i) {
@@ -1421,13 +1425,9 @@ export class Instance implements Disposable {
           throw err;
         }
       }
-      if (i === 0) {
-        // Reset for the loading phase to avoid double counting with download phase.
-        fetchedBytes = 0;
-      }
       fetchedBytes += shard.nbytes;
       timeElapsed = Math.ceil((perf.now() - tstart) / 1000);
-      reportCallback(i + 1, /*loading=*/true);
+      reportCallback(++fetchedShards, /*loading=*/true);
     }
   }
 


### PR DESCRIPTION
## Problem

When loading model shards from cache (not network), the progress indicator 
always showed 0% because `fetchedBytes` was not incremented during the cache 
loading phase in `fetchTensorCacheInternal()`. 

The `reportCallback` function calculates progress as `fetchedBytes * 100 / totalBytes`, 
but `fetchedBytes` was only updated during the network download phase (line 1361), 
not during the cache loading phase (lines 1377-1427). This caused the progress 
to remain at 0% until completion when loading from cache.

## Solution

This fix increments `fetchedBytes` and updates `timeElapsed` after processing 
each cached shard (matching the behavior of the network download phase). The 
progress callback now correctly reports:
- Percentage completed (`fetchedBytes * 100 / totalBytes`)
- MB loaded
- Time elapsed

## Changes

- Added `fetchedBytes += shard.nbytes;` after processing each cache shard
- Added `timeElapsed` update to ensure accurate time reporting
- Matches the pattern used in the download phase (lines 1360-1361)
