### PR TITLE
[Relax][PyTorch] Enable decomposition in all tests

### DIFF
--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -6414,7 +6414,14 @@ def test_dynamic_shape():
     batch = torch.export.Dim("batch")
     dynamic_shapes = {"x1": {0: batch}, "x2": {0: batch}}
 
-    verify_model(DynamicModel(), example_args, {}, Expected, dynamic_shapes=dynamic_shapes)
+    verify_model(
+        DynamicModel(),
+        example_args,
+        {},
+        Expected,
+        dynamic_shapes=dynamic_shapes,
+        run_ep_decomposition=True,
+    )
 
 
 def test_broadcast_to():
@@ -6898,7 +6905,7 @@ def test_tensor_none_tuple():
                 R.output(gv)
             return gv
 
-    verify_model(TensorNoneModel(), example_args, {}, Expected)
+    verify_model(TensorNoneModel(), example_args, {}, Expected, run_ep_decomposition=True)
 
 
 def test_gru():


### PR DESCRIPTION
## Why

This is the last part of the migration. After this one, we could set `run_ep_decomposition` default to true in our test

## How

Check and update the remaining tests