### PR TITLE
[Web] Replace string with TVMFFIByteArray* to avoid memory issues

### DIFF
--- a/web/emcc/wasm_runtime.cc
+++ b/web/emcc/wasm_runtime.cc
@@ -125,7 +125,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       });
 }
 
-void ArrayDecodeStorage(Tensor cpu_arr, TVMFFIByteArray* bytes, std::string format, std::string dtype) {
+void ArrayDecodeStorage(Tensor cpu_arr, TVMFFIByteArray* bytes, const std::string& format,
+                        const std::string& dtype) {
   ICHECK_NE(bytes, nullptr);
   const char* byte_data = bytes->data;
   const size_t byte_size = bytes->size;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1992,9 +1992,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001755",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001755.tgz",
-      "integrity": "sha512-44V+Jm6ctPj7R52Na4TLi3Zri4dWUljJd+RDm+j8LtNCc/ihLCT+X1TzoOAkRETEWqjuLnh9581Tl80FvK7jVA==",
+      "version": "1.0.30001756",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001756.tgz",
+      "integrity": "sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==",
       "dev": true,
       "funding": [
         {
@@ -2415,9 +2415,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.255",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.255.tgz",
-      "integrity": "sha512-Z9oIp4HrFF/cZkDPMpz2XSuVpc1THDpT4dlmATFlJUIBVCy9Vap5/rIXsASP1CscBacBqhabwh8vLctqBwEerQ==",
+      "version": "1.5.258",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.258.tgz",
+      "integrity": "sha512-rHUggNV5jKQ0sSdWwlaRDkFc3/rRJIVnOSe9yR4zrR07m3ZxhP4N27Hlg8VeJGGYgFTxK5NqDmWI4DSH72vIJg==",
       "dev": true
     },
     "node_modules/emittery": {


### PR DESCRIPTION
Passing in a string to `ArrayDecodeStorage` via the packed function definition led to memory issues for larger models (such as `gemma-2-9b-it-q4f32_1-MLC`). Replacing string with TVMFFIByteArray* fixes this issue and also alleviates the stack pollution issue discussed in an earlier PR (https://github.com/apache/tvm/pull/18415). Note that this does not completely fix generation for q0f32 models.