### PR TITLE
[Contrib] Update RandomFill to use StreamSync for CUDA synchronization

### DIFF
--- a/src/runtime/contrib/curand/curand.cc
+++ b/src/runtime/contrib/curand/curand.cc
@@ -110,7 +110,7 @@ void RandomFill(DLTensor* tensor) {
   } else {
     LOG(FATAL) << "ValueError: Unsupported dtype: " << tensor->dtype;
   }
-  TVMSynchronize(tensor->device.device_type, tensor->device.device_type, nullptr);
+  cuda_api->StreamSync(tensor->device, nullptr);
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {


### PR DESCRIPTION
## Related Issue

https://github.com/apache/tvm/issues/18468

## Why

`TVMSynchronize` is a C API function that wasn't included/declared in this file, and it was also called with incorrect arguments

## How

Changed to `cuda_api->StreamSync(tensor->device, nullptr)`