### PR TITLE
[CI] Enhance python linting scripts to support revision-based checks

### DIFF
--- a/docker/lint.sh
+++ b/docker/lint.sh
@@ -55,10 +55,18 @@ function run_lint_step() {
             cmd=( tests/lint/cpplint.sh )
             ;;
         flake8)
-            cmd=( tests/lint/flake8.sh )
+            if [ $inplace_fix -eq 0 ]; then
+                cmd=( tests/lint/flake8.sh )
+            else
+                cmd=( tests/lint/flake8.sh --rev origin/main )
+            fi
             ;;
         pylint)
-            cmd=( tests/lint/pylint.sh )
+            if [ $inplace_fix -eq 0 ]; then
+                cmd=( tests/lint/pylint.sh )
+            else
+                cmd=( tests/lint/pylint.sh --rev origin/main )
+            fi
             ;;
         python_format)
             if [ $inplace_fix -eq 0 ]; then

--- a/tests/lint/flake8.sh
+++ b/tests/lint/flake8.sh
@@ -16,6 +16,40 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
+set -euo pipefail
 
-python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics --exclude 3rdparty
+LINT_ALL_FILES=true
+REVISION=
+
+while (( $# )); do
+    case "$1" in
+        --rev)
+            LINT_ALL_FILES=false
+            REVISION=$2
+            shift 2
+            ;;
+        *)
+            echo "Usage: tests/lint/flake8.sh [--rev <commit>]"
+            echo ""
+            echo "Run flake8 on Python files that changed since <commit> or on all files in the repo"
+            echo "Examples:"
+            echo "- Compare last one commit: tests/lint/flake8.sh --rev HEAD~1"
+            echo "- Compare against upstream/main: tests/lint/flake8.sh --rev upstream/main"
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$LINT_ALL_FILES" == "true" ]]; then
+    echo "Running flake8 on all files"
+    python3 -m flake8 . --count --select=E9,F63,F7 --show-source --statistics --exclude 3rdparty
+else
+    # Get changed Python files, excluding 3rdparty
+    IFS=$'\n' read -a FILES -d'\n' < <(git diff --name-only --diff-filter=ACMRTUX $REVISION -- "*.py" "*.pyi" | grep -v "^3rdparty/") || true
+    if [ -z ${FILES+x} ] || [ ${#FILES[@]} -eq 0 ]; then
+        echo "No changes in Python files"
+        exit 0
+    fi
+    echo "Running flake8 on changed files: ${FILES[@]}"
+    python3 -m flake8 ${FILES[@]} --count --select=E9,F63,F7 --show-source --statistics
+fi

--- a/tests/lint/pylint.sh
+++ b/tests/lint/pylint.sh
@@ -15,6 +15,40 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-set -euxo pipefail
+set -euo pipefail
 
-python3 -m pylint python/tvm --rcfile="$(dirname "$0")"/pylintrc
+LINT_ALL_FILES=true
+REVISION=
+
+while (( $# )); do
+    case "$1" in
+        --rev)
+            LINT_ALL_FILES=false
+            REVISION=$2
+            shift 2
+            ;;
+        *)
+            echo "Usage: tests/lint/pylint.sh [--rev <commit>]"
+            echo ""
+            echo "Run pylint on Python files that changed since <commit> or on all files in python/tvm"
+            echo "Examples:"
+            echo "- Compare last one commit: tests/lint/pylint.sh --rev HEAD~1"
+            echo "- Compare against upstream/main: tests/lint/pylint.sh --rev upstream/main"
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$LINT_ALL_FILES" == "true" ]]; then
+    echo "Running pylint on all files in python/tvm"
+    python3 -m pylint python/tvm --rcfile="$(dirname "$0")"/pylintrc
+else
+    # Get changed Python files in python/tvm directory
+    IFS=$'\n' read -a FILES -d'\n' < <(git diff --name-only --diff-filter=ACMRTUX $REVISION -- "python/tvm/*.py" "python/tvm/**/*.py") || true
+    if [ -z ${FILES+x} ] || [ ${#FILES[@]} -eq 0 ]; then
+        echo "No changes in Python files under python/tvm"
+        exit 0
+    fi
+    echo "Running pylint on changed files: ${FILES[@]}"
+    python3 -m pylint ${FILES[@]} --rcfile="$(dirname "$0")"/pylintrc
+fi


### PR DESCRIPTION
## How

support revision-based checks like `python_format` for `flake8` and `pylint`

