### PR TITLE
[Web] Bump web runtime version 0.23.0-dev1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tvmjs",
-  "version": "0.23.0-dev0",
+  "version": "0.23.0-dev1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tvmjs",
-      "version": "0.23.0-dev0",
+      "version": "0.23.0-dev1",
       "license": "Apache-2.0",
       "dependencies": {
         "audit": "^0.0.6",
@@ -1844,9 +1844,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.29.tgz",
-      "integrity": "sha512-sXdt2elaVnhpDNRDz+1BDx1JQoJRuNk7oVlAlbGiFkLikHCAQiccexF/9e91zVi6RCgqspl04aP+6Cnl9zRLrA==",
+      "version": "2.8.30",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.30.tgz",
+      "integrity": "sha512-aTUKW4ptQhS64+v2d6IkPzymEzzhw+G0bA1g3uBRV3+ntkH+svttKseW5IOR4Ed6NUVKqnY7qT3dKvzQ7io4AA==",
       "dev": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -2415,9 +2415,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.258",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.258.tgz",
-      "integrity": "sha512-rHUggNV5jKQ0sSdWwlaRDkFc3/rRJIVnOSe9yR4zrR07m3ZxhP4N27Hlg8VeJGGYgFTxK5NqDmWI4DSH72vIJg==",
+      "version": "1.5.259",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.259.tgz",
+      "integrity": "sha512-I+oLXgpEJzD6Cwuwt1gYjxsDmu/S/Kd41mmLA3O+/uH2pFRO/DvOjUyGozL8j3KeLV6WyZ7ssPwELMsXCcsJAQ==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "description": "TVM WASM/WebGPU runtime for JS/TS",
   "license": "Apache-2.0",
   "homepage": "https://github.com/apache/tvm/tree/main/web",
-  "version": "0.23.0-dev0",
+  "version": "0.23.0-dev1",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
Bump web runtime version to 0.23.0-dev1. npm package compiled from https://github.com/apache/tvm/commit/c8515e1ddfaf4d1afff916c484e68e1513631dd6. 