### PR TITLE
[CI] Update file patterns for specific linting hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@
 default_language_version:
     python: python3.9
 fail_fast: True
-default_stages: [pre-push]
+default_stages: [pre-push, pre-commit]
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v6.0.0
@@ -49,9 +49,9 @@ repos:
       hooks:
         -   id: run-black
             name: Running Black...
-            entry: docker/lint.sh python_format
+            entry: docker/lint.sh python_format -i
             language: system
-            always_run: true
+            files: \.py$
             pass_filenames: false
         -   id: run-file-checks
             name: Checking File Types....
@@ -61,25 +61,25 @@ repos:
             pass_filenames: false
         -   id: run-headers-check
             name: Checking ASF License Headers ...
-            entry: docker/lint.sh asf
+            entry: docker/lint.sh asf -i
             language: system
             always_run: true
             pass_filenames: false
-        -   id: run-headers-check
+        -   id: run-cpplint
             name: Linting the C++ code ...
             entry: docker/lint.sh cpplint
             language: system
-            always_run: true
+            files: \.(c|cc|cpp|h|hpp)$
             pass_filenames: false
         -   id: run-clang-format
             name: Checking Clang format ...
-            entry: docker/lint.sh clang_format
+            entry: docker/lint.sh clang_format -i
             language: system
-            always_run: true
+            files: \.(c|cc|cpp|h|hpp)$
             pass_filenames: false
         -   id: run-mypy
             name: Type Checking with MyPY ...
             entry: docker/lint.sh mypy
             language: system
-            always_run: true
+            files: \.py$
             pass_filenames: false

--- a/docker/lint.sh
+++ b/docker/lint.sh
@@ -90,7 +90,11 @@ function run_lint_step() {
     shift
 
     if [ $validate_only -eq 0 ]; then
-        run_docker -it "ci_lint" "${cmd[@]}"
+        if [ -t 0 ]; then
+            run_docker -it "ci_lint" "${cmd[@]}"
+        else
+            run_docker "ci_lint" "${cmd[@]}"
+        fi
     fi
 }
 


### PR DESCRIPTION
## How

- Updat file patterns for specific linting hooks to ensure they only run on relevant file types.

**minor update**

- Fix linting commands to handle interactive and non-interactive modes
- Add 'pre-commit' to default stages in .pre-commit-config.yaml.
- Add inplace fix flags