### PR TITLE
Fix BufferError when converting PyTorch models with sparse tensors

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -37,12 +37,12 @@ class ExportedProgramImporter(BaseFXGraphImporter):
     @staticmethod
     def _convert_pytorch_tensor_to_tvm(tensor_value: torch.Tensor) -> tvm.runtime.Tensor:
         """Convert a PyTorch tensor to TVM tensor, handling sparse tensors.
-        
+
         Parameters
         ----------
         tensor_value : torch.Tensor
             The PyTorch tensor to convert.
-            
+
         Returns
         -------
         tvm.runtime.Tensor
@@ -54,7 +54,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
         else:
             tensor_to_convert = tensor_value
         tensor_detached = tensor_to_convert.detach()
-        
+
         # Try DLPack conversion first (faster)
         try:
             return tvm.runtime.from_dlpack(tensor_detached)


### PR DESCRIPTION
This commit fixes issue #18474 by adding support for sparse tensor conversion in the PyTorch ExportedProgram importer. The fix automatically detects sparse tensors (non-strided layout) and converts them to dense tensors before DLPack conversion.

Changes:
- Add _convert_pytorch_tensor_to_tvm() static method to handle sparse tensor detection and conversion
- Automatically convert sparse tensors to dense using .to_dense() before DLPack conversion
- Update parameter/buffer/constant binding to use the new conversion method
- Update parameter handling to use the new conversion method

The fix ensures that PyTorch models containing sparse tensors can be successfully converted to TVM Relax modules without raising BufferError.

Fixes #18474