### PR TITLE
[CI] Update `actions/cache` to v4 in setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,7 +1,7 @@
 runs:
  using: "composite"
  steps:
-  - uses: actions/cache@v3
+  - uses: actions/cache@v4
     env:
       CACHE_NUMBER: 2
     with:


### PR DESCRIPTION
Fixes ther recent macOS CI error.
https://github.com/apache/tvm/actions/runs/19608185293/job/56150023835