### PR TITLE
[CI] Use glob for `conda/build-environment.yaml` in cache key

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
       CACHE_NUMBER: 2
     with:
       path: ~/conda_pkgs_dir
-      key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda/build-environment.yaml') }}
+      key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('**/conda/build-environment.yaml') }}
   - uses: conda-incubator/setup-miniconda@v3
     continue-on-error: true
     id: conda1


### PR DESCRIPTION
The previous cache key used `conda/build-environment.yaml` and caused macOS CI errors.
Switching to `**/conda/build-environment.yaml` to see if it works.