### PR TITLE
[MISC] Fix compilation warnings

### DIFF
--- a/include/tvm/ir/transform.h
+++ b/include/tvm/ir/transform.h
@@ -557,10 +557,9 @@ TVM_DLL Pass ApplyPassToFunction(Pass pass, ffi::String func_name_regex,
 /*!
  * \brief A special trace pass that prints the header and IR to LOG(INFO).
  * \param header The header to be attached to the output.
- * \param show_meta_data Whether should we show meta data.
  * \return The pass.
  */
-TVM_DLL Pass PrintIR(ffi::String header = "", bool show_meta_data = false);
+TVM_DLL Pass PrintIR(ffi::String header = "");
 
 }  // namespace transform
 }  // namespace tvm

--- a/python/tvm/ir/transform.py
+++ b/python/tvm/ir/transform.py
@@ -348,7 +348,7 @@ def module_pass(pass_func=None, opt_level=None, name=None, required=None, tracea
     return create_module_pass
 
 
-def PrintIR(header="", show_meta_data=False):
+def PrintIR(header=""):
     """A special trace pass that prints the header and IR.
 
     Parameters
@@ -356,14 +356,11 @@ def PrintIR(header="", show_meta_data=False):
     header : str
         The header to be displayed along with the dump.
 
-    show_meta_data : bool
-        A boolean flag to indicate if meta data should be printed.
-
     Returns
     --------
     The pass
     """
-    return _ffi_transform_api.PrintIR(header, show_meta_data)
+    return _ffi_transform_api.PrintIR(header)
 
 
 def ApplyPassToFunction(

--- a/src/ir/transform.cc
+++ b/src/ir/transform.cc
@@ -642,8 +642,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            });
 }
 
-Pass PrintIR(ffi::String header, bool show_meta_data) {
-  auto pass_func = [header, show_meta_data](IRModule mod, const PassContext& ctx) {
+Pass PrintIR(ffi::String header) {
+  auto pass_func = [header](IRModule mod, const PassContext& ctx) {
     LOG(INFO) << "PrintIR(" << header << "):\n" << mod;
     return mod;
   };

--- a/src/relax/transform/alter_op_impl.cc
+++ b/src/relax/transform/alter_op_impl.cc
@@ -194,7 +194,7 @@ class AlterOpImplMutator : public ExprMutator {
     // We want to avoid two layout_transform ops to share the same index map even if they are
     // identical. The scope of vars used in index map initial indices is local to the op. Not doing
     // so would confuse the structural equality check.
-    attrs->index_map = std::move(DeepCopyIndexMap(index_map));
+    attrs->index_map = DeepCopyIndexMap(index_map);
     attrs->axis_separators = std::move(axis_separators);
     attrs->input_axis_separators = std::move(input_axis_separators);
     return Call(layout_transform_op_, {expr}, Attrs{std::move(attrs)}, {});

--- a/src/tir/schedule/primitive/compute_inline.cc
+++ b/src/tir/schedule/primitive/compute_inline.cc
@@ -992,11 +992,10 @@ class ReductionEpilogueFuser : public BaseInliner {
  public:
   explicit ReductionEpilogueFuser(const Buffer& reduction_buffer, const BlockNode* reduction_block,
                                   const BlockRealize& epilogue_block_realize,
-                                  const StmtSRef& scope_root_sref, const IRModule& mod)
+                                  const StmtSRef& scope_root_sref)
       : BaseInliner(reduction_buffer, epilogue_block_realize->block, scope_root_sref),
         reduction_block_(reduction_block),
-        epilogue_block_(epilogue_block_realize->block.get()),
-        mod_(mod) {}
+        epilogue_block_(epilogue_block_realize->block.get()) {}
 
   bool BodyPatternAllowFusion(const BlockRealize& epilogue_block_realize);
 
@@ -1031,7 +1030,6 @@ class ReductionEpilogueFuser : public BaseInliner {
 
   const BlockNode* reduction_block_;
   const BlockNode* epilogue_block_;
-  const IRModule& mod_;
   PrimExpr epilogue_addend_{nullptr};                      // C[vi, vj] in D = temp + C
   Buffer epilogue_output_buffer_{nullptr};                 // Output buffer D
   ffi::Array<PrimExpr> epilogue_output_indices_{nullptr};  // Indices of D[vi, vj]
@@ -1412,7 +1410,7 @@ void FuseReductionEpilogueImpl(ScheduleState self, const StmtSRef& reduction_blo
 
   // Step 4. Analyze the epilogue pattern
   ReductionEpilogueFuser fuser(reduction_buffer, _reduction_block, epilogue_block_realize,
-                               scope_root_sref, self->mod);
+                               scope_root_sref);
   if (!fuser.BodyPatternAllowFusion(epilogue_block_realize)) {
     throw BodyAnalysisError(true, self->mod, epilogue_block);
   }


### PR DESCRIPTION
This commit addresses various compilation warnings across the codebase:

- Fixed warnings in IR transform infrastructure (transform.h, transform.cc)
- Updated Python bindings to resolve type-related warnings (transform.py)
- Addressed warnings in Relax alter_op_impl transformation
- Fixed compilation warnings in TIR schedule compute_inline primitive

These changes improve code quality and ensure clean compilation across different compilers and platforms.