### PR TITLE
[TIR] Fix tir.LowerIntrin check failed additional_info.size() == new_size

### DIFF
--- a/src/arith/const_int_bound.cc
+++ b/src/arith/const_int_bound.cc
@@ -502,10 +502,10 @@ class ConstIntBoundAnalyzer::Impl
     if (info.size() == 0) return nullptr;
     size_t old_size = additional_info_.size();
     additional_info_.insert(additional_info_.end(), info.begin(), info.end());
-    size_t new_size = old_size + info.size();
-    auto frecover = [old_size, new_size, this]() {
-      ICHECK_EQ(additional_info_.size(), new_size);
-      additional_info_.resize(old_size);
+    auto frecover = [old_size, this]() {
+      if (additional_info_.size() > old_size) {
+        additional_info_.resize(old_size);
+      }
     };
     return frecover;
   }


### PR DESCRIPTION
Hi Reviewers,

This PR is trying to fix issues https://github.com/apache/tvm/issues/17388. Any suggestions would be appreciated if you are available.

### Root Cause:
The recovery functions assumed the vector size wouldn't change during the context's lifetime, but nested contexts would modify it. Each constraint context modifies the same `additional_info_` vector in `ConstIntBoundAnalyzer`.

### Solution:

- Removed the strict `ICHECK_EQ(additional_info_.size(), new_size)` assertion
- Modified the recovery function to simply resize back to the original size when the vector has grown