### PR TITLE
[Relax][PyTorch] Handle unknown output shapes for _sym_size_int

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -2507,6 +2507,11 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         shape = self.shape_of(x)
         dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim", 0)
 
+        # Handle case where shape is unknown (None) - this can happen for operations
+        # with dynamic output shapes.
+        if shape is None:
+            return self.block_builder.emit(relax.const(0, "int64"))
+
         shape_dim = shape[dim]
         if hasattr(shape_dim, "value"):
             return self.block_builder.emit(relax.const(shape_dim.value, dtype="int32"))


### PR DESCRIPTION
## Why 

Handle case where shape is unknown (None). This can happen for operations with dynamic output shapes.

## How

- Update to handle with placeholder
- Update test case