### PR TITLE
[Schedule] Fix LocalBuilder Check failed: (index_map_func.has_value()) is false

### DIFF
--- a/python/tvm/meta_schedule/builder/local_builder.py
+++ b/python/tvm/meta_schedule/builder/local_builder.py
@@ -254,7 +254,7 @@ def default_build(mod: IRModule, target: Target, _params: Optional[Dict[str, Ten
     """
     # pylint: disable=import-outside-toplevel
     from tvm.driver import build as tvm_build
-    import tvm.tir.tensor_intrin
+    import tvm.tir.tensor_intrin  # pylint: disable=unused-import
     from tvm.tir.transform import RemoveWeightLayoutRewriteBlock
 
     # pylint: enable=import-outside-toplevel


### PR DESCRIPTION
This commit fixes tvm.error.InternalError: Check failed: (index_map_func.has_value()) is false in [#18472](https://github.com/apache/tvm/issues/18472) 

**Why**
When using mma for MultiLevelTilingTensorCore, users must manually pass tvm.tir.tensor_intrin as an initializer to register it in LocalBuilder. This is inconsistent with the wmma workflow, where tvm.tir.tensor_intrin is imported by default in [tune_context.py](https://github.com/apache/tvm/blob/main/python/tvm/meta_schedule/tune_context.py#L109) to ensure that the TensorIntrin required by wmma is registered in advance. Additionally, the corresponding error message is not straightforward, which can be confusing for new users who are not familiar with TVM.

**How**
by adding import tensor_intrin in the default_build