### PR TITLE
[ARITH] Fix InternalError: Check failed: (eval_vec_) is false

### DIFF
--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -532,7 +532,10 @@ class IntervalSetEvaluator : public ExprFunctor<IntervalSet(const PrimExpr&)> {
   }
 
   IntervalSet VisitExpr_(const BroadcastNode* op) final {
-    ICHECK(eval_vec_);
+    if (!eval_vec_) {
+      DLOG(WARNING) << "cannot evaluate set on expression " << ffi::GetRef<PrimExpr>(op);
+      return IntervalSet::Everything();
+    }
     return VisitExpr(op->value);
   }
 


### PR DESCRIPTION
Hi Commiters,

This PR is trying to fix issues https://github.com/apache/tvm/issues/17936. Any suggestions would be appreciated if you are available.

### Root Cause

Code paths that expected vector evaluation but encounter the scalar-only evaluation `eval_vec_ = false`

### Solution

`BroadcastNode` just replicates the same scalar value and the evaluation might not requires special vector-aware handling