### PR TITLE
[Docs] Fix e2e_opt_model tutorial for GPU deployment

### DIFF
--- a/docs/how_to/tutorials/e2e_opt_model.py
+++ b/docs/how_to/tutorials/e2e_opt_model.py
@@ -113,12 +113,14 @@ if not IS_IN_CI:
 # We skip this step in the CI environment.
 
 if not IS_IN_CI:
+    with target:
+        mod = tvm.tir.transform.DefaultGPUSchedule()(mod)
     ex = tvm.compile(mod, target="cuda")
     dev = tvm.device("cuda", 0)
     vm = relax.VirtualMachine(ex, dev)
     # Need to allocate data and params on GPU device
     gpu_data = tvm.runtime.tensor(np.random.rand(1, 3, 224, 224).astype("float32"), dev)
     gpu_params = [tvm.runtime.tensor(p, dev) for p in params["main"]]
-    gpu_out = vm["main"](gpu_data, *gpu_params).numpy()
+    gpu_out = vm["main"](gpu_data, *gpu_params)[0].numpy()
 
     print(gpu_out.shape)


### PR DESCRIPTION
This PR is to resolve the issue , which fixes two bugs in the end-to-end optimization tutorial (`docs/how_to/tutorials/e2e_opt_model.py`) that prevented it from running correctly on GPU devices.

### Changes

1. **Added DefaultGPUSchedule transformation**
   - Apply `DefaultGPUSchedule` to ensure all GPU functions have proper thread binding. This fixes the memory verification error: "`Variable is directly accessed by host memory... Did you forget to bind?`"
  

2. **Fixed VM output handling**
   - Updated to correctly extract tensor from VM output. This fixes the AttributeError: "'Array' object has no attribute 'numpy'"
