### PR TITLE
[Docs] Fix e2e_opt_model tutorial for GPU deployment

### DIFF
--- a/docs/how_to/tutorials/e2e_opt_model.py
+++ b/docs/how_to/tutorials/e2e_opt_model.py
@@ -115,7 +115,7 @@ if not IS_IN_CI:
 if not IS_IN_CI:
     with target:
         mod = tvm.tir.transform.DefaultGPUSchedule()(mod)
-    ex = tvm.compile(mod, target="cuda")
+    ex = tvm.compile(mod, target=target)
     dev = tvm.device("cuda", 0)
     vm = relax.VirtualMachine(ex, dev)
     # Need to allocate data and params on GPU device


### PR DESCRIPTION
This PR is to resolve the issue #18481 , which fixes two bugs in the end-to-end optimization tutorial (`docs/how_to/tutorials/e2e_opt_model.py`) that prevented it from running correctly on GPU devices.

### Changes

1. **Added DefaultGPUSchedule transformation**
   - Apply `DefaultGPUSchedule` to ensure all GPU functions have proper thread binding. This fixes the memory verification error: "`Variable is directly accessed by host memory... Did you forget to bind?`"
  

2. **Fixed VM output handling**
   - Updated to correctly extract tensor from VM output.
