### PR TITLE
[Docs] Improve static shape tuning parameter configuration (follow-up to commit c71aefc)

### DIFF
--- a/docs/how_to/tutorials/e2e_opt_model.py
+++ b/docs/how_to/tutorials/e2e_opt_model.py
@@ -104,16 +104,14 @@ if not IS_IN_CI:
 #   to at least ``320 (20 tasks * 16 trials)`` ensures every task receives one full iteration
 #   of tuning. We set it to 512 in our configuration to allow for several more iterations,
 #   aiming to explore a wider parameter space and potentially achieve better performance.
-# - If ``MAX_TRIALS_PER_TASK == None``, the system defaults to ``min(max_trials_per_iter=64,
-#   TOTAL_TRIALS)`` trials per task per iteration. This may lead to undersubscribed tuning when
-#   ``TOTAL_TRIALS`` is insufficient (e.g., ``64 < TOTAL_TRIALS < 20 * 64``), potentially skipping
-#   some tasks entirely, leaving critical operators unoptimized or missing thread binding for
-#   untuned tasks. Explicitly setting both parameters avoids this issue and provides deterministic
-#   resource allocation across all tasks.
+# - If ``MAX_TRIALS_PER_TASK == None``, the system defaults to ``TOTAL_TRIALS`` trials per
+#   task per iteration. An insufficient ``TOTAL_TRIALS`` setting may lead to undersubscribed
+#   tuning, potentially skipping some tasks entirely. Explicitly setting both parameters
+#   avoids this issue and provides deterministic resource allocation across all tasks.
 #
 # Note: These parameter settings are optimized for quick tutorial demonstration. For production
-# deployments requiring higher performance, we recommend adjusting both MAX_TRIALS_PER_TASK
-# and TOTAL_TRIALS to larger values. This allows more extensive search space exploration
+# deployments requiring higher performance, we recommend adjusting both ``MAX_TRIALS_PER_TASK``
+# and ``TOTAL_TRIALS`` to larger values. This allows more extensive search space exploration
 # and typically yields better performance outcomes.
 
 TOTAL_TRIALS = 512  # Change to 20000 for better performance if needed

--- a/python/tvm/relax/pipeline.py
+++ b/python/tvm/relax/pipeline.py
@@ -131,8 +131,10 @@ def static_shape_tuning_pipeline(
 
     max_trials_per_task : Optional[int]
         The maximum number of trials to run per task.
-        If not specified, MetaSchedule will use a default value of 64
-        trials per task during the tuning process.
+        If not specified, it defaults to the value of `total_trials`, and this
+        may lead to undersubscribed tuning, potentially skipping some tasks
+        entirely. Explicitly setting both parameters avoids this issue and
+        provides deterministic resource allocation across all tasks.
         For optimal tuning, set `total_trials` to at least
         `max_trials_per_task * number_of_tuning_tasks` to ensure
         each task receives adequate tuning resources in one iteration.


### PR DESCRIPTION
- Expose max_trials_per_task parameter to static_shape_tuning_pipeline
- Adjust default TOTAL_TRIALS from 8000 to 80 for tutorial demonstration purposes
- Add documentation for tuning parameters in tutorial, clarifying relationship between MAX_TRIALS_PER_TASK and TOTAL_TRIALS