### PR TITLE
[MISC] Fix duplicate `PresburgerSetNode` registration when `USE_MLIR=ON` and MLIR >= 15.0

### DIFF
--- a/src/arith/presburger_set.cc
+++ b/src/arith/presburger_set.cc
@@ -43,8 +43,7 @@
 namespace tvm {
 namespace arith {
 
-#ifdef TVM_MLIR_VERSION
-#if TVM_MLIR_VERSION >= 150
+#if defined(TVM_MLIR_VERSION) && TVM_MLIR_VERSION >= 150
 
 TVM_FFI_STATIC_INIT_BLOCK() { PresburgerSetNode::RegisterReflection(); }
 using namespace tir;
@@ -270,8 +269,7 @@ TVM_STATIC_IR_FUNCTOR(ReprPrinter, vtable)
       p->stream << "}";
     });
 
-#endif  // TVM_MLIR_VERSION >= 150
-#endif  // TVM_MLIR_VERSION
+#else  // defined(TVM_MLIR_VERSION) && TVM_MLIR_VERSION >= 150
 
 PresburgerSet MakePresburgerSet(const PrimExpr& constraint) { return PresburgerSet(constraint); }
 
@@ -280,6 +278,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   PresburgerSetNode::RegisterReflection();
   refl::GlobalDef().def("arith.PresburgerSet", MakePresburgerSet);
 }
+
+#endif  // defined(TVM_MLIR_VERSION) && TVM_MLIR_VERSION >= 150
 
 }  // namespace arith
 }  // namespace tvm


### PR DESCRIPTION
Fix a runtime error that occurs when TVM built with `USE_MLIR=ON` and MLIR >= 15.0, as shown below.

```
Traceback (most recent call last):
  File "<unknown>", line 0, in tvm::arith::__TVMFFIStaticInitFunc2()
  File "<unknown>", line 0, in tvm::ffi::reflection::ObjectDef<tvm::arith::PresburgerSetNode>::ObjectDef<>()
  File "<unknown>", line 0, in void tvm::ffi::reflection::ObjectDef<tvm::arith::PresburgerSetNode>::RegisterExtraInfo<>()
  File "build/src/ffi/object.cc", line 500, in TVMFFITypeRegisterMetadata
  File "src/ffi/object.cc", line 240, in void tvm::ffi::TypeTable::RegisterTypeMetadata(int32_t, const TVMFFITypeMetadata *)
RuntimeError: Overriding arith.PresburgerSet, possible causes:
- two ObjectDef<T>() calls for the same T 
- when we forget to assign _type_key to ObjectRef<Y> that inherits from T
- another type with the same key is already registered
Cross check the reflection registration.
libc++abi: terminating due to uncaught exception of type tvm::ffi::Error
```