### PR TITLE
[Relax][Torch] AssertionError: Unsupported function types ['mean.default']

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -1371,7 +1371,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "any.dim": self._any,
             "any.dims": self._any,
             "mean.dim": self._mean,
-            "mean.default": self._mean,           
+            "mean.default": self._mean,
             "prod.default": self._prod,
             "std.correction": self._std,
             "sum.default": self._sum,

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -4910,7 +4910,7 @@ def test_mean():
     class MeanKeepDim(Module):
         def forward(self, input: torch.Tensor):
             return input.mean(-1, keepdim=True)
-        
+
     class MeanWithoutDim(Module):
         def forward(self, input: torch.Tensor):
             return input.mean()
@@ -4938,7 +4938,7 @@ def test_mean():
                 gv: R.Tuple(R.Tensor((256, 1), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
-          
+
     @I.ir_module
     class Expected3:
         @R.function


### PR DESCRIPTION


## Summary
Happen error when create module from exported_program have torch.mean without dim.
## Reproduce
- Module:
```
class MeanModule(nn.Module):
    def forward(self, x):
        return torch.mean(x)
...
# Export → Relax
ep = torch_export(m, (x,))
mod = from_exported_program(ep)
```
- Error log:
```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In[2], line 13
     11 # Export → Relax
     12 ep = torch_export(m, (x,))
---> 13 mod = from_exported_program(ep)
     15 mod.show()
     17 target = "llvm"

File ~/Programming/tvm/python/tvm/relax/frontend/torch/exported_program_translator.py:1783, in from_exported_program(exported_program, keep_params_as_input, unwrap_unit_return_tuple, no_bind_return_tuple, run_ep_decomposition)
   1780 if run_ep_decomposition:
   1781     exported_program = exported_program.run_decompositions()
-> 1783 return ExportedProgramImporter().from_exported_program(
   1784     exported_program,
   1785     keep_params_as_input,
   1786     unwrap_unit_return_tuple,
   1787     no_bind_return_tuple,
   1788 )

File ~/Programming/tvm/python/tvm/relax/frontend/torch/exported_program_translator.py:1642, in ExportedProgramImporter.from_exported_program(self, exported_program, keep_params_as_input, unwrap_unit_return_tuple, no_bind_return_tuple)
   1639 nodes: List[fx.Node] = exported_program.graph.nodes
   1641 # Find all the missing function types
-> 1642 self._check_unsupported_func_type(nodes)
   1644 with self.block_builder.function(
   1645     name=func_name, params=list(inputs_vars.values()).copy(), attrs=func_attrs
   1646 ):
   1647     output = None

File ~/Programming/tvm/python/tvm/relax/frontend/torch/base_fx_graph_translator.py:182, in BaseFXGraphImporter._check_unsupported_func_type(self, nodes)
    174 def _check_unsupported_func_type(self, nodes: List[fx.Node]):
    175     missing_func_types = list(
    176         {
    177             node.target.__name__
   (...)    180         }
    181     )
--> 182     assert not missing_func_types, f"Unsupported function types {missing_func_types}"

AssertionError: Unsupported function types ['mean.default']
```

## Resolve: 
- Add "mean.default" into create_convert_map in class ExportedProgramImporter.