### PR TITLE
[CUDA][FFI] Extend kernel launch config to support Programmatic Dependent Launch and cuLaunchCooperativeKernel

### DIFF
--- a/src/runtime/cuda/cuda_module.cc
+++ b/src/runtime/cuda/cuda_module.cc
@@ -220,6 +220,10 @@ class CUDAWrappedFunc {
       config.sharedMemBytes = wl.dyn_shmem_size;
 
       result = cuLaunchKernelEx(&config, fcache_[device_id], void_args, nullptr);
+    } else if (launch_param_config_.use_cooperative_launch()) {
+      result = cuLaunchCooperativeKernel(fcache_[device_id], wl.grid_dim(0), wl.grid_dim(1),
+                                         wl.grid_dim(2), wl.block_dim(0), wl.block_dim(1),
+                                         wl.block_dim(2), wl.dyn_shmem_size, strm, void_args);
     } else {
       result = cuLaunchKernel(fcache_[device_id], wl.grid_dim(0), wl.grid_dim(1), wl.grid_dim(2),
                               wl.block_dim(0), wl.block_dim(1), wl.block_dim(2), wl.dyn_shmem_size,

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -50,6 +50,8 @@ namespace launch_param {
 constexpr const char* kUseDynamicSharedMemoryTag = "tir.use_dyn_shared_memory";
 /*! \brief A tag to specify whether or not use programatic dependent launch */
 constexpr const char* kUseProgramaticDependentLaunch = "tir.use_programtic_dependent_launch";
+/*! \brief A tag to specify whether or not use cooperative launch */
+constexpr const char* kUseCooperativeLaunch = "tir.use_cooperative_launch";
 
 }  // namespace launch_param
 

--- a/src/runtime/thread_storage_scope.h
+++ b/src/runtime/thread_storage_scope.h
@@ -249,6 +249,8 @@ class LaunchParamConfig {
         use_dyn_shared_memory_ = true;
       } else if (tag == launch_param::kUseProgramaticDependentLaunch) {
         use_programmatic_dependent_launch_ = true;
+      } else if (tag == launch_param::kUseCooperativeLaunch) {
+        use_cooperative_launch_ = true;
       } else {
         ThreadScope ts = ThreadScope::Create(tag);
         arg_index_map_.push_back(ts.rank * 3 + ts.dim_index);
@@ -285,6 +287,8 @@ class LaunchParamConfig {
 
   bool use_programtic_dependent_launch() const { return use_programmatic_dependent_launch_; }
 
+  bool use_cooperative_launch() const { return use_cooperative_launch_; }
+
  private:
   /*! \brief base axis */
   size_t base_;
@@ -296,6 +300,8 @@ class LaunchParamConfig {
   bool use_dyn_shared_memory_{false};
   /*! \brief Whether or not use programmatic dependent launch. */
   bool use_programmatic_dependent_launch_{false};
+  /*! \brief Whether or not use cooperative launch. */
+  bool use_cooperative_launch_{false};
 };
 
 }  // namespace runtime


### PR DESCRIPTION
This patch adds support for **Programmatic Dependent Kernel Launch (PDL)** in the TVM CUDA FFI layer. PDL enables launching dependent kernels on the GPU without host intervention, improving performance and expressiveness for dynamic CUDA workloads.

Refer to NVIDIA documentation for PDL semantics:  
https://docs.nvidia.com/cuda/cuda-programming-guide/03-advanced/advanced-host-programming.html#programmatic-dependent-kernel-launch

In addition, this patch extends the CUDA FFI layer to support cooperative kernel launches via cuLaunchCooperativeKernel. Cooperative kernels allow grid-wide synchronization and are required for certain multi-stage or producer–consumer GPU workloads. When a kernel is marked for cooperative launch, it will be dispatched using cuLaunchCooperativeKernel instead of the standard cuLaunchKernel.

Refer to NVIDIA documentation for cooperative kernel usage:
https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/cooperative-groups.html#when-to-use-cudalaunchcooperativekernel
