### PR TITLE
[Relax] Remove duplicated test case: test_if_branch_var_scope

### DIFF
--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -1289,20 +1289,6 @@ def test_var_if_scoping_fail():
             return w  # error: The w is not defined in the outer scope
 
 
-def test_if_branch_var_scope():
-    with pytest.raises(tvm.error.DiagnosticError):
-
-        @R.function
-        def foo(cond: R.Tensor((), "bool"), x: R.Tensor((1,), "float32")):
-            if cond:
-                w = R.add(x, x)
-                y = R.multiply(w, w)
-            else:
-                w = R.multiply(x, x)
-                y = R.add(w, w)
-            return w
-
-
 def test_scalar_tensor_as_branch_condition():
     """Branch condition can be 0-d tensor"""
 


### PR DESCRIPTION
Hi Commiters,

This PR is trying to remove duplicated test case `test_if_branch_var_scope`. Any suggestions would be appreciated if you are available.

### Root Cause

Both tests `test_var_if_scoping_fail` and `test_if_branch_var_scope`  verify that returning a variable `w` that's only defined within if/else branches raises an error. They're duplicates and should probably be consolidated into a single test.

<img width="1388" height="306" alt="image" src="https://github.com/user-attachments/assets/8e6defd4-fe83-419d-8793-67454ccb561f" />

### Solution
Remove duplicated test case `test_if_branch_var_scope` 