### PR TITLE
[Relax] Add gpu-generic fallback for unrecognized GPU targets

### DIFF
--- a/python/tvm/relax/pipeline.py
+++ b/python/tvm/relax/pipeline.py
@@ -27,6 +27,7 @@ import tvm
 from tvm import meta_schedule as ms
 
 from . import backend, transform
+from .backend.utils import BackendDispatcher
 
 
 def zero_pipeline(*, enable_warning: bool = False):
@@ -270,7 +271,8 @@ def library_dispatch_passes(target: tvm.target.Target):
         return backend.cpu_generic.library_dispatch_passes(target)
     if target.kind.name == "opencl" and "adreno" in target.keys:
         return backend.adreno.library_dispatch_passes(target)
-    # Todo(tvm-team): support gpu-generic
+    if BackendDispatcher.is_gpu_target(target):
+        return backend.gpu_generic.library_dispatch_passes(target)
     raise ValueError(f"Target {target} is not yet supported by library dispatch passes.")
 
 
@@ -286,8 +288,9 @@ def legalize_passes(target: tvm.target.Target):
         return backend.cpu_generic.legalize_passes(target)
     if target.kind.name == "opencl" and "adreno" in target.keys:
         return backend.adreno.legalize_passes(target)
-    # Todo(tvm-team): support gpu-generic
-    raise ValueError(f"Target {target} is not yet supported by library dispatch passes.")
+    if BackendDispatcher.is_gpu_target(target):
+        return backend.gpu_generic.legalize_passes(target)
+    raise ValueError(f"Target {target} is not yet supported by legalize passes.")
 
 
 def dataflow_lower_passes(target: tvm.target.Target):
@@ -302,7 +305,8 @@ def dataflow_lower_passes(target: tvm.target.Target):
         return backend.cpu_generic.dataflow_lower_passes(target)
     if target.kind.name == "opencl" and "adreno" in target.keys:
         return backend.adreno.dataflow_lower_passes(target)
-    # Todo(tvm-team): support gpu-generic
+    if BackendDispatcher.is_gpu_target(target):
+        return backend.gpu_generic.dataflow_lower_passes(target)
     raise ValueError(f"Target {target} is not yet supported by dataflow lowering passes.")
 
 
@@ -318,7 +322,8 @@ def finalize_passes(target: tvm.target.Target):
         return backend.cpu_generic.finalize_passes(target)
     if target.kind.name == "opencl" and "adreno" in target.keys:
         return backend.adreno.finalize_passes(target)
-    # Todo(tvm-team): support gpu-generic
+    if BackendDispatcher.is_gpu_target(target):
+        return backend.gpu_generic.finalize_passes(target)
     raise ValueError(f"Target {target} is not yet supported by finalization passes.")
 
 
@@ -334,7 +339,8 @@ def get_default_pipeline(target: tvm.target.Target):
         return backend.cpu_generic.get_default_pipeline(target)
     if target.kind.name == "opencl" and "adreno" in target.keys:
         return backend.adreno.get_default_pipeline(target)
-    # Todo(tvm-team): support gpu-generic
+    if BackendDispatcher.is_gpu_target(target):
+        return backend.gpu_generic.get_default_pipeline(target)
     raise ValueError(
         f"Target {target} is not yet supported by default pipeline. "
         "Please lower and build the IRModule manually."


### PR DESCRIPTION
## Why

- Resolve todo in `python/tvm/relax/pipeline.py`

## How

- Check specific GPU targets first (cuda/rocm/metal/adreno)
- If not matched, use BackendDispatcher.is_gpu_target() to detect GPU
- Fall back to gpu_generic for unrecognized GPUs (vulkan, webgpu, etc.)
- Raise error only for non-GPU unsupported targets