### PR TITLE
[Relax] Add test case for op attributes in AST printer

### DIFF
--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -419,7 +419,8 @@ def test_op_attrs():
     x = rx.Var("x", R.Tensor((10,), "float32"))
     # Manually create a Call with attributes to test printer support for Op attributes
     op = tvm.ir.Op.get("relax.add")
-    call_node = rx.Call(op, [x, x], attrs={"my_attr": "my_value"})
+    attrs = tvm.ir.make_node("ir.DictAttrs", my_attr="my_value")
+    call_node = rx.Call(op, [x, x], attrs=attrs)
 
     call_str = dump_ast(call_node, include_call_attrs=True)
     assert_fields(


### PR DESCRIPTION
## Why

Resolve todo in `tests/python/relax/test_ast_printer.py`

## How

- Added a new test function `test_op_attrs` in `tests/python/relax/test_ast_printer.py`.
- Removed the TODO comment.