### PR TITLE
[Relax] Fix flaky test_conv2d gradient numeric test

### DIFF
--- a/tests/python/relax/test_op_gradient_numeric.py
+++ b/tests/python/relax/test_op_gradient_numeric.py
@@ -781,8 +781,9 @@ def test_nll_loss_no_batch(target, dev, nll_reduction1, nll_weighted1, nll_ignor
 
 @tvm.testing.parametrize_targets("llvm")
 def test_conv2d(target, dev, c2d_shape1, c2d_shape2, c2d_kwargs):
-    data1_numpy = np.random.uniform(0, 3, c2d_shape1).astype(np.float32)
-    data2_numpy = np.random.uniform(0, 3, c2d_shape2).astype(np.float32)
+    # Use smaller range to reduce numerical errors in gradient check
+    data1_numpy = np.random.uniform(0, 2, c2d_shape1).astype(np.float32)
+    data2_numpy = np.random.uniform(0, 2, c2d_shape2).astype(np.float32)
     relax_check_gradients(
         relax.op.nn.conv2d,
         [data1_numpy, data2_numpy],


### PR DESCRIPTION
## Why

Flaky in CI due to numerical precision errors in gradient checks.
ref: https://github.com/apache/tvm/pull/18575

## How

- Reduce input range from (0, 3) to (0, 2) to minimize floating-point errors