### PR TITLE
[Relax] Fix HardSigmoid returns 1.0 for NaN input

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -3350,7 +3350,13 @@ class HardSigmoid(OnnxOpConverter):
         alpha = relax.const(alpha, dtype=dtype)
         beta = float(attr.get("beta", 0.5))
         beta = relax.const(beta, dtype=dtype)
-        return relax.op.clip(relax.op.add(relax.op.multiply(alpha, x), beta), 0, 1)
+
+        is_nan = bb.emit_te(topi.isnan, x)
+        transformed = bb.emit(relax.op.add(relax.op.multiply(alpha, x), beta))
+        clamped = bb.emit_te(topi.maximum, transformed, 0.0)
+        clamped = bb.emit_te(topi.minimum, clamped, 1.0)
+
+        return bb.emit_te(topi.where, is_nan, x, clamped)
 
 
 class HardSwish(OnnxOpConverter):

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -1089,6 +1089,31 @@ def test_hardsigmoid():
     verify_unary("HardSigmoid", [1, 3, 20, 20], attrs={"alpha": 0.5, "beta": 0.6})
 
 
+def test_hardsigmoid_nan():
+    """Test that HardSigmoid preserves NaN values in output."""
+    test_node = helper.make_node("HardSigmoid", ["x"], ["y"])
+    graph = helper.make_graph(
+        [test_node],
+        "hardsigmoid_nan_test",
+        inputs=[helper.make_tensor_value_info("x", TensorProto.FLOAT, [3, 4])],
+        outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, [3, 4])],
+    )
+
+    model = helper.make_model(graph, producer_name="hardsigmoid_nan_test")
+
+    # Create input with NaN values
+    input_data = np.array(
+        [
+            [np.nan, 0.5, -0.5, 1.0],
+            [0.0, np.nan, 2.0, -2.0],
+            [0.3, 0.7, np.nan, np.nan],
+        ],
+        dtype=np.float32,
+    )
+
+    check_correctness(model, inputs={"x": input_data})
+
+
 def test_shrink():
     verify_unary("Shrink", [32, 32])
     verify_unary("Shrink", [32, 32], attrs={"lambd": 0.2, "bias": 0.1})


### PR DESCRIPTION
Hi Commiters,

This PR is trying to fix issues https://github.com/apache/tvm/issues/17999. Any suggestions would be appreciated if you are available.

### Root Cause
The implementation applied clipping/comparisons without preserving NaN, which caused NaN inputs to be coerced to the clipped upper bound instead of remaining NaN.

### Solutions:
- Update the HardSigmoid implementation to explicitly preserve NaN inputs. The implementation now computes the usual linear expression and clipped result, but returns NaN when input is NaN.
- Add a unit test that verifies: input = NaN -> output = NaN