### PR TITLE
[Relax] Add FRelaxInferLayout and TMixedPrecisionPolicy for dynamic_strided_slice

### DIFF
--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -5231,5 +5231,57 @@ def test_conv2d_tile_repeats_large_value():
     verify(Input, Expected)
 
 
+def test_conv2d_dynamic_strided_slice():
+    @I.ir_module
+    class Input:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"),
+            w: R.Tensor((4, 3, 3, 3), "float32"),
+            begin: R.Tensor((4,), "int64"),
+            end: R.Tensor((4,), "int64"),
+            strides: R.Tensor((4,), "int64"),
+        ) -> R.Tensor(None, "float32", ndim=4):
+            with R.dataflow():
+                gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(x, w, out_dtype="float32")
+                gv2 = R.dynamic_strided_slice(gv, begin, end, strides)
+                R.output(gv2)
+            return gv2
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), dtype="float32"),
+            w: R.Tensor((4, 3, 3, 3), dtype="float32"),
+            begin: R.Tensor((4,), dtype="int64"),
+            end: R.Tensor((4,), dtype="int64"),
+            strides: R.Tensor((4,), dtype="int64"),
+        ) -> R.Tensor(None, dtype="float32", ndim=4):
+            with R.dataflow():
+                lv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.permute_dims(x, axes=[0, 2, 3, 1])
+                lv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.permute_dims(w, axes=[0, 2, 3, 1])
+                gv: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+                    lv,
+                    lv1,
+                    strides=[1, 1],
+                    padding=[0, 0, 0, 0],
+                    dilation=[1, 1],
+                    groups=1,
+                    data_layout="NHWC",
+                    kernel_layout="OHWI",
+                    out_layout="NHWC",
+                    out_dtype="float32",
+                )
+                lv2: R.Tensor((2, 4, 26, 26), dtype="float32") = R.permute_dims(
+                    gv, axes=[0, 3, 1, 2]
+                )
+                gv2 = R.dynamic_strided_slice(lv2, begin, end, strides)
+                R.output(gv2)
+            return gv2
+
+    verify(Input, Expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
## Why

The dynamic_strided_slice operator was missing FRelaxInferLayout and TMixedPrecisionPolicy attributes, preventing it from participating in layout transformations and mixed precision optimizations.

## How
- Add `TMixedPrecisionPolicy` attribute with `kFollow` policy and 
- Add `InferLayoutDynStridedSlice` function that falls back to initial layout (since begin/end/strides are dynamic tensors that cannot be transformed at compile time)
