### PR TITLE
[Relax] Remove obsolete TODO comments

### DIFF
--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -260,7 +260,6 @@ class ASTPrinter(ExprFunctor):
                 "FuncType",
                 arg_types=self.build_list(map(self.visit_type_, type_node.arg_types)),
                 ret_type=self.visit_type_(type_node.ret_type),
-                # TODO: skipping type params and type constraints
             )
         raise ValueError(f"Invalid Relax Type {type_node} ({type(type_node)})")
 

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -84,8 +84,7 @@ StructInfo InferStructInfoTake(const Call& call, const BlockBuilder& ctx) {
   }();
 
   if (indices_sinfo->IsUnknownDtype()) {
-    // TODO(tvm-team): Do we have an equivalent of `ctx->ReportFatal` for warning?
-    LOG(WARNING) << "Data type of indice has not been specified. Assume it has an integer type.";
+    LOG(WARNING) << "Data type of indices has not been specified. Assume it has an integer type.";
   } else if (!(indices_sinfo->dtype.is_int() || indices_sinfo->dtype.is_uint())) {
     ctx->ReportFatal(Diagnostic::Error(call)
                      << "Take op requires the input indices to have integer dtype. However, the "

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -2617,7 +2617,7 @@ StructInfo InferStructInfoScatterElements(const Call& call, const BlockBuilder& 
   }
 
   if (indices_sinfo->IsUnknownDtype()) {
-    LOG(WARNING) << "Data type of indice has not been specified. Assume it has an integer type.";
+    LOG(WARNING) << "Data type of indices has not been specified. Assume it has an integer type.";
   } else if (!(indices_sinfo->dtype.is_int() || indices_sinfo->dtype.is_uint())) {
     ctx->ReportFatal(
         Diagnostic::Error(call)


### PR DESCRIPTION
- Remove TODO about `ctx->ReportWarning()` since LOG(WARNING) is the standard pattern
- Remove TODO about skipping type params/constraints since the current FuncType implementation only contains arg_types and ret_type fields. `type_params` and `type_constraints` don't exist in the codebase.
- Fixed typo in warning message