### PR TITLE
[Relax][ONNX] add support for unique optional outputs

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -3249,12 +3249,10 @@ class Unique(OnnxOpConverter):
             tuple_idx += 1
 
         if return_inverse:
-            # When axis is None, inverse_indices is flattened (1D)
-            # When axis is specified, inverse_indices has the same shape as input
-            if axis is None:
-                inverse_shape = (tir.Var("inverse_numbers", "int64"),)
-            else:
-                inverse_shape = input_shape
+            # ONNX spec: inverse_indices is always 1D
+            # When axis is None: shape is [X.size]
+            # When axis is specified: shape is [X.shape[axis]]
+            inverse_shape = (tir.Var("inverse_numbers", "int64"),)
             inverse_sinfo = relax.TensorStructInfo(inverse_shape, "int64")
             outputs.append(bb.match_cast(unique[tuple_idx], inverse_sinfo))
             tuple_idx += 1

--- a/python/tvm/relax/op/set.py
+++ b/python/tvm/relax/op/set.py
@@ -160,20 +160,10 @@ def numpy_unique(
             inverse_mapping = np.empty_like(sort_order)
             inverse_mapping[sort_order] = np.arange(len(sort_order))
             inverse_indices = inverse_mapping[inverse_indices]
-        # ONNX spec: inverse_indices shape depends on axis
-        if axis is None:
-            # When axis is None, flatten to 1D
-            inverse_indices = inverse_indices.flatten()
-        else:
-            # When axis is specified, reshape to input shape
-            # numpy returns 1D inverse_indices with length = input.shape[axis]
-            # We need to reshape it to have the same shape as input
-            new_shape = list(x_numpy.shape)
-            new_shape[axis] = 1
-            inverse_indices = np.broadcast_to(
-                inverse_indices.reshape([-1 if i == axis else 1 for i in range(len(new_shape))]),
-                x_numpy.shape,
-            )
+        # ONNX spec: inverse_indices is always 1D
+        # When axis is None, it has length X.size (flattened)
+        # When axis is specified, it has length X.shape[axis]
+        # numpy.unique already returns 1D inverse_indices, so no reshaping needed
         output_list.append(tvm.runtime.tensor(inverse_indices))
         result_idx += 1
 

--- a/src/relax/op/tensor/set.cc
+++ b/src/relax/op/tensor/set.cc
@@ -114,17 +114,13 @@ StructInfo InferStructInfoUnique(const Call& call, const BlockBuilder& ctx) {
     output_sinfo.push_back(index_sinfo);
   }
 
-  // inverse_indices: 1D when axis is None, same ndim as input when axis is specified
+  // inverse_indices: always 1D per ONNX spec
   if (f_convert_to_int64(return_inverse->value)) {
     TensorStructInfo inverse_sinfo{nullptr};
     if (data_sinfo->ndim == 0) {
       inverse_sinfo = TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}),
                                        DataType::Int(64), data_sinfo->vdevice);
-    } else if (axis.defined()) {
-      // When axis is specified, inverse_indices has the same ndim as input
-      inverse_sinfo = TensorStructInfo(DataType::Int(64), data_sinfo->ndim, data_sinfo->vdevice);
     } else {
-      // When axis is None, inverse_indices is 1D (flattened)
       inverse_sinfo = TensorStructInfo(DataType::Int(64), /*ndim=*/1, data_sinfo->vdevice);
     }
     output_sinfo.push_back(inverse_sinfo);

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -2903,10 +2903,8 @@ def test_unique(axis: Optional[int], sorted: int, num_outputs: int):
     if num_outputs > 1:
         outputs.append(helper.make_tensor_value_info("indices", TensorProto.INT64, [-1]))
     if num_outputs > 2:
-        inverse_shape = [-1] if axis is None else input_shape
-        outputs.append(
-            helper.make_tensor_value_info("inverse_indices", TensorProto.INT64, inverse_shape)
-        )
+        # ONNX spec: inverse_indices is always 1D
+        outputs.append(helper.make_tensor_value_info("inverse_indices", TensorProto.INT64, [-1]))
     if num_outputs > 3:
         outputs.append(helper.make_tensor_value_info("counts", TensorProto.INT64, [-1]))
 


### PR DESCRIPTION
## Why

The ONNX Unique operator supports four optional outputs (unique values, indices, inverse_indices, and counts), but the TVM ONNX frontend only returned the unique values output.

## How

- Updated `Unique._impl_v11` to check the number of expected outputs via `attr["tvm_custom"]["num_outputs"]`
- Pass `return_index`, `return_inverse`, and `return_counts` parameters to `relax.op.unique`
- Return a `relax.Tuple` containing all requested outputs
