### PR TITLE
Put options before objects when compiling

### DIFF
--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -348,12 +348,12 @@ def _linux_compile(
         if compile_shared or output.endswith(".so") or output.endswith(".dylib"):
             cmd += ["-shared"]
     cmd += ["-o", output]
+    if options:
+        cmd += options
     if isinstance(objects, str):
         cmd += [objects]
     else:
         cmd += objects
-    if options:
-        cmd += options
     env = None
     if ccache_env is not None:
         if shutil.which("ccache"):


### PR DESCRIPTION
This change is part of https://github.com/tile-ai/tvm/pull/21.

On darwin platform, when trying to compile a `.c` file as objective-c, `-x objective-c++` needs to be prior to source files in command line arguments. Without this PR, it's not straightforward to do so.