### PR TITLE
[RELAX][LAYOUT] Support multiple axis packing

### DIFF
--- a/python/tvm/s_tir/data_layout.py
+++ b/python/tvm/s_tir/data_layout.py
@@ -41,7 +41,8 @@ class Layout(Object):
         return _ffi_api.LayoutNdim(self)  # type: ignore
 
     def __contains__(self, axis):
-        return len(axis) == 1 and axis[0].isalpha() and axis[0] in self.name
+        # Note: We do a weaker check for packed axis assuming layout is valid
+        return not any(bkt in axis for bkt in "[]") and axis in self.name
 
     def __getitem__(self, index):
         if index >= len(self):
@@ -54,7 +55,7 @@ class Layout(Object):
         Parameters
         ----------
         axis : str
-            The axis name, need to be [a-z,A-Z]
+            The axis name, needs to be [a-z,A-Z] or a packed axis
 
         Returns
         -------


### PR DESCRIPTION
Like OIHW[4o4i] where we can pack multiple axis.
Helpful while handling complex target layouts.
This PR covers layout representation and transforms for these.

In implementation the ```IterVar``` which was holding one axis till now.  With this it will hold a packed axis as ```name=4o4i``` and ```range=16```. The new helpers can be used to retrieve individual axis ```4o``` and ```4c``` when ever needed. The forwards and backwards are enhanced accordingly.