### PR TITLE
[Relax] Replace topi.take with relax.op.take

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -3322,11 +3322,15 @@ class DepthToSpace(OnnxOpConverter):
         mode = attr.get("mode", b"DCR").decode("utf-8")
         b, c, h, w = inputs[0].struct_info.shape
         if mode == "DCR":
-            x = relax.op.reshape(inputs[0], (b, block_size, block_size, c // (block_size**2), h, w))
+            x = relax.op.reshape(
+                inputs[0], (b, block_size, block_size, c // (block_size**2), h, w)
+            )
             x = relax.op.permute_dims(x, [0, 3, 4, 1, 5, 2])
             return relax.op.reshape(x, (b, c // (block_size**2), h * block_size, w * block_size))
         elif mode == "CRD":
-            x = relax.op.reshape(inputs[0], (b, c // (block_size**2), block_size, block_size, h, w))
+            x = relax.op.reshape(
+                inputs[0], (b, c // (block_size**2), block_size, block_size, h, w)
+            )
             x = relax.op.permute_dims(x, [0, 1, 4, 2, 5, 3])
             return relax.op.reshape(x, (b, c // (block_size**2), h * block_size, w * block_size))
         else:


### PR DESCRIPTION
## Why

TODO comment indicated that topi.take should be replaced with relax.op.take once it has better support. The relax take operator is now mature enough to replace the TOPI external call.

## How

- Replace bb.emit_te(topi.take, ...) with relax.op.take(..., axis=0) in EmbedLayerNormalization converter