### PR TITLE
[Relax] Implement dynamic output trimming for NMS

### DIFF
--- a/python/tvm/relax/op/vision/nms.py
+++ b/python/tvm/relax/op/vision/nms.py
@@ -54,12 +54,10 @@ def all_class_non_max_suppression(
         `num_total_detection` of shape `(1,)` representing the total number of selected
         boxes. The three values in `indices` encode batch, class, and box indices.
         Rows of `indices` are ordered such that selected boxes from batch 0, class 0 come
-        first, in descending of scores, followed by boxes from batch 0, class 1 etc. Out of
-        `batch_size * num_class* num_boxes` rows of indices, only the first `num_total_detection`
-        rows are valid.
+        first, in descending of scores, followed by boxes from batch 0, class 1 etc.
+        The output uses dynamic_strided_slice to trim to only valid detections,
+        so the first tensor has shape (num_total_detection, 3) containing only valid rows.
 
-        TODO: Implement true dynamic output shapes to match ONNX Runtime behavior exactly.
-        This would eliminate the need for manual trimming and improve memory efficiency.
         If `output_format` is "tensorflow", the output is three tensors, the first
         is `indices` of size `(batch_size, num_class * num_boxes , 2)`, the second is `scores` of
         size `(batch_size, num_class * num_boxes)`, and the third is `num_total_detection` of size

--- a/tests/python/relax/test_op_vision.py
+++ b/tests/python/relax/test_op_vision.py
@@ -15,12 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import numpy as np
 import pytest
+
 import tvm
 import tvm.testing
-from tvm import relax, tir
-from tvm import TVMError
-from tvm.ir import Op, VDevice
+from tvm import TVMError, relax, tir
+from tvm.relax.transform import LegalizeOps
 from tvm.script import relax as R
 
 
@@ -53,7 +54,6 @@ def test_all_class_non_max_suppression_infer_struct_info():
 
 
 def test_all_class_non_max_suppression_wrong_input_number():
-    bb = relax.BlockBuilder()
     boxes = relax.Var("boxes", R.Tensor((1, 5, 4), "float32"))
     scores = relax.Var("scores", R.Tensor((1, 3, 5), "float32"))
 
@@ -84,6 +84,96 @@ def test_all_class_non_max_suppression_infer_struct_info_shape_var():
             ]
         ),
     )
+
+
+def test_all_class_non_max_suppression_legalize_dynamic_trim():
+    @tvm.script.ir_module
+    class NMSModule:
+        @R.function
+        def main(
+            boxes: R.Tensor((1, 5, 4), "float32"),
+            scores: R.Tensor((1, 2, 5), "float32"),
+        ) -> R.Tuple(R.Tensor(dtype="int64", ndim=2), R.Tensor((1,), "int64")):
+            max_output_boxes_per_class = R.const(3, "int64")
+            iou_threshold = R.const(0.5, "float32")
+            score_threshold = R.const(0.1, "float32")
+            return R.vision.all_class_non_max_suppression(
+                boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold, "onnx"
+            )
+
+    mod = LegalizeOps()(NMSModule)
+
+    # Check legalized function has dynamic output (uses dynamic_strided_slice)
+    assert "dynamic_strided_slice" in str(mod)
+
+    ret_sinfo = mod["main"].ret_struct_info
+    tvm.ir.assert_structural_equal(
+        ret_sinfo,
+        relax.TupleStructInfo(
+            [
+                relax.TensorStructInfo(ndim=2, dtype="int64"),
+                relax.TensorStructInfo((1,), "int64"),
+            ]
+        ),
+    )
+
+
+def test_all_class_non_max_suppression_legalize_e2e():
+    @tvm.script.ir_module
+    class NMSModule:
+        @R.function
+        def main(
+            boxes: R.Tensor((1, 5, 4), "float32"),
+            scores: R.Tensor((1, 2, 5), "float32"),
+        ) -> R.Tuple(R.Tensor(dtype="int64", ndim=2), R.Tensor((1,), "int64")):
+            max_output_boxes_per_class = R.const(3, "int64")
+            iou_threshold = R.const(0.5, "float32")
+            score_threshold = R.const(0.1, "float32")
+            return R.vision.all_class_non_max_suppression(
+                boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold, "onnx"
+            )
+
+    boxes_data = np.array(
+        [
+            [
+                [0.0, 0.0, 1.0, 1.0],
+                [0.1, 0.1, 1.1, 1.1],
+                [2.0, 2.0, 3.0, 3.0],
+                [4.0, 4.0, 5.0, 5.0],
+                [6.0, 6.0, 7.0, 7.0],
+            ]
+        ],
+        dtype=np.float32,
+    )
+    scores_data = np.array(
+        [[[0.9, 0.8, 0.7, 0.6, 0.5], [0.85, 0.75, 0.65, 0.55, 0.45]]],
+        dtype=np.float32,
+    )
+
+    mod = LegalizeOps()(NMSModule)
+
+    # Check struct info
+    tvm.ir.assert_structural_equal(
+        mod["main"].ret_struct_info,
+        relax.TupleStructInfo(
+            [
+                relax.TensorStructInfo(ndim=2, dtype="int64"),
+                relax.TensorStructInfo((1,), "int64"),
+            ]
+        ),
+    )
+
+    # Check runtime execution
+    exe = tvm.compile(mod, target="llvm")
+    vm = relax.VirtualMachine(exe, tvm.cpu())
+    result = vm["main"](
+        tvm.runtime.tensor(boxes_data, tvm.cpu()),
+        tvm.runtime.tensor(scores_data, tvm.cpu()),
+    )
+
+    selected_indices = result[0].numpy()
+    num_total_detections = int(result[1].numpy()[0])
+    tvm.testing.assert_allclose(selected_indices.shape, (num_total_detections, 3))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why                                                                                                                      
                                                                                                                         
NMS operator returns fixed-size output with trailing garbage data, wasting memory and requiring manual trimming for ONNX 
compatibility.                                                                                                           
                                                                                                                         
## How                                                                                                                      
                                                                                                                         
- Add dynamic_strided_slice to trim NMS output to valid detections only                                                  
- Build slice parameters using TE compute to avoid legalization issues                                                                                                                