### PR TITLE
[Relax][NN] Add batch_flatten operator

### DIFF
--- a/python/tvm/relax/backend/metal/coreml.py
+++ b/python/tvm/relax/backend/metal/coreml.py
@@ -142,11 +142,10 @@ register_patterns(
         *default_unary_patterns(op_name="nn.relu"),
         *default_unary_patterns(op_name="expand_dims"),
         *default_unary_patterns(op_name="nn.avg_pool2d"),
+        *default_unary_patterns(op_name="nn.batch_flatten"),
         *conv2d_patterns(),
         *clip_patterns(),
         *matmul_patterns(),
-        # TODO(@tvm-team): enable when relax op is implemented
-        # ("coreml.nn.batch_flatten", is_op("relax.nn.batch_flatten")(wildcard())),
     ]
 )
 
@@ -271,7 +270,7 @@ _convert_map = {
     "clip": _convert_clip,
     "expand_dims": _convert_expand_dims,
     "nn.relu": _convert_relu,
-    # "nn.batch_flatten": _convert_batch_flatten,
+    "nn.batch_flatten": _convert_batch_flatten,
     "nn.softmax": _convert_softmax,
     "nn.conv2d": _convert_conv2d,
     "nn.avg_pool2d": _convert_avg_pool2d,

--- a/python/tvm/relax/op/nn/__init__.py
+++ b/python/tvm/relax/op/nn/__init__.py
@@ -25,6 +25,7 @@ from .nn import (
     avg_pool1d,
     avg_pool2d,
     avg_pool3d,
+    batch_flatten,
     batch_norm,
     conv1d,
     conv1d_transpose,

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -2249,3 +2249,22 @@ def attention_var_len(
         causal_mask,
         window_size,
     )  # type: ignore
+
+
+def batch_flatten(data: Expr) -> Expr:
+    """Flatten all dimensions except the first (batch) dimension.
+
+    This operation flattens a tensor of shape `(N, C, H, W, ...)` into
+    a 2D tensor of shape `(N, C*H*W*...)`.
+
+    Parameters
+    ----------
+    data : relax.Expr
+        The input data to the operator.
+
+    Returns
+    -------
+    result : relax.Expr
+        The flattened result with shape `(batch_size, flattened_features)`.
+    """
+    return _ffi_api.batch_flatten(data)  # type: ignore

--- a/python/tvm/relax/transform/legalize_ops/nn.py
+++ b/python/tvm/relax/transform/legalize_ops/nn.py
@@ -775,3 +775,10 @@ def _nn_nll_loss(bb: BlockBuilder, call: Call) -> Expr:
         reduction=call.attrs.reduction,
         ignore_index=call.attrs.ignore_index,
     )
+
+
+@register_legalize("relax.nn.batch_flatten")
+def _nn_batch_flatten(bb: BlockBuilder, call: Call) -> Expr:
+    if call.struct_info.shape is None:
+        return call
+    return bb.call_te(topi.reshape, call.args[0], call.struct_info.shape.values)

--- a/src/relax/op/nn/nn.h
+++ b/src/relax/op/nn/nn.h
@@ -114,6 +114,9 @@ Expr cross_entropy_with_logits(Expr predictions, Expr labels);
 Expr nll_loss(Expr predictions, Expr targets, ffi::Optional<Expr> weights, ffi::String reduction,
               int ignore_index);
 
+/*! \brief Batch flatten: flatten all dimensions except the first (batch) dimension. */
+Expr batch_flatten(Expr data);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/tests/python/relax/test_codegen_coreml.py
+++ b/tests/python/relax/test_codegen_coreml.py
@@ -198,7 +198,6 @@ def test_relu():
     verify(mod, [x_data])
 
 
-@pytest.mark.skip("`batch_flatten` is not implemented yet.")
 def test_batch_flatten():
     x = relax.Var("x", relax.TensorStructInfo([10, 10, 10], "float32"))
     bb = relax.BlockBuilder()


### PR DESCRIPTION
## Why                                                                                                                   
                                                                                                                           
The `batch_flatten` operator was needed for CoreML backend support but was not implemented in Relax, causing the CoreML pattern and converter to be commented out.                                                                               
                                                                                                                         
## How                                                                                                                   
                                                                                                                         
- Add C++ operator `relax.nn.batch_flatten` with struct info inference                                                   
- Add Python wrapper in `relax.op.nn`                                                                                    
- Add legalization via `topi.reshape`                                                                                    
- Enable CoreML pattern and converter for `nn.batch_flatten`                                                             
- Add unit tests for operator, struct info inference, and legalization