### PR TITLE
[Web] Fix RPC argument parsing for new FFI string/bytes types

### DIFF
--- a/web/src/rpc_server.ts
+++ b/web/src/rpc_server.ts
@@ -234,7 +234,14 @@ export class RPCServer {
         if (typeIndex === TypeIndex.kTVMFFIRawStr) {
           const str = Uint8ArrayToString(reader.readByteArray());
           args.push(str);
+        } else if (typeIndex === TypeIndex.kTVMFFIStr) {
+          reader.readU32(); // skip duplicate type_index
+          const str = Uint8ArrayToString(reader.readByteArray());
+          args.push(str);
         } else if (typeIndex === TypeIndex.kTVMFFIByteArrayPtr) {
+          args.push(reader.readByteArray());
+        } else if (typeIndex === TypeIndex.kTVMFFIBytes) {
+          reader.readU32(); // skip duplicate type_index
           args.push(reader.readByteArray());
         } else {
           throw new Error("cannot support type index " + typeIndex);


### PR DESCRIPTION
## Why                                                                                                      
Recent FFI refactoring added new type indices kTVMFFIStr (65) and kTVMFFIBytes (66). The RPC server didn't  
handle these, causing "cannot support type index 65/66" errors when Python sends string/bytes arguments via 
RPC.                                                                                                        
                                                                                                            
## How
`WriteFFIAny` in C++ writes the `type_index` twice for these types. The fix adds handlers that read and discard the duplicate type_index before reading the actual data.