### PR TITLE
[Web] Fix incorrect FFI export name in runtime.ts

### DIFF
--- a/web/src/runtime.ts
+++ b/web/src/runtime.ts
@@ -2146,7 +2146,7 @@ export class Instance implements Disposable {
         const errMsgOffset = stack.allocRawBytes(errMsg.length + 1);
         stack.storeRawBytes(errMsgOffset, StringToUint8Array(errMsg));
         stack.commitToWasmMemory();
-        (this.lib.exports.FTVMFFIErrorSetRaisedFromCStr as ctypes.FTVMFFIErrorSetRaisedFromCStr)(
+        (this.lib.exports.TVMFFIErrorSetRaisedFromCStr as ctypes.FTVMFFIErrorSetRaisedFromCStr)(
           stack.ptrFromOffset(errKindOffset),
           stack.ptrFromOffset(errMsgOffset)
         );


### PR DESCRIPTION
## Why

The code was using the TypeScript type name `FTVMFFIErrorSetRaisedFromCStr` instead of the actual C function export name `TVMFFIErrorSetRaisedFromCStr`. The  F prefix is a naming convention for TypeScript function types, not the actual export names, which would make RPC run into error in my local test.                                                     
                                                                                                                                                                
## How

`lib.exports.FTVMFFIErrorSetRaisedFromCStr` -->  `lib.exports.TVMFFIErrorSetRaisedFromCStr` to match the C function name defined in ctypes.ts.