### PR TITLE
docs: update http to https in license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!--- "License"); you may not use this file except in compliance -->
 <!--- with the License.  You may obtain a copy of the License at -->
 
-<!---   https://www.apache.org/licenses/LICENSE-2.0 -->
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
 
 <!--- Unless required by applicable law or agreed to in writing, -->
 <!--- software distributed under the License is distributed on an -->


### PR DESCRIPTION
First-time contributed to Apache TVM.

Changes:
- Updated HTTP to HTTPS in license link in README.md for better security

Why:
- HTTPS provides encryption and integrity
- Apache Foundation recommends HTTPS
- Minor improvement but follows best practices

Signed-off-by: Ashwini Bokka 