### PR TITLE
[Relax] Add NN operator attributes include to TensorRT codegen

### DIFF
--- a/src/relax/backend/contrib/tensorrt/codegen.cc
+++ b/src/relax/backend/contrib/tensorrt/codegen.cc
@@ -24,8 +24,7 @@
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/module.h>
 #include <tvm/ir/transform.h>
-// TODO(sunggg): add operator attribute when it's ready
-// #include <tvm/relax/attrs/nn.h>
+#include <tvm/relax/attrs/nn.h>
 #include <tvm/relax/type.h>
 
 #include <memory>


### PR DESCRIPTION
## Why                                                                                                                 
                                                                                                                      
The header now exists and provides operator attribute definitions needed for TensorRT codegen.                                     
                                                                                                                    
## How                                                                                                                 
                                                                                                                    
Add #include <tvm/relax/attrs/nn.h> to TensorRT codegen