### PR TITLE
[Relax][Onnx][Resize] Fix ROI values when tensor ROI is Empty pass node Constant

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -2257,6 +2257,8 @@ class Resize(OnnxOpConverter):
                 roi = roi.data.numpy().tolist()
                 if len(roi) == 2 * ndims:
                     roi = roi[2:ndims] + roi[ndims + 2 : 2 * ndims]
+                elif len(roi) == 0:
+                    roi = [0.0] * (2 * (ndims - 2))
             else:
                 roi = relax.op.concat(
                     [
@@ -2289,7 +2291,7 @@ class Resize(OnnxOpConverter):
             elif isinstance(sizes, relax.expr.ShapeExpr):
                 sizes = [int(val.value) for val in sizes.values][2:]
             else:
-                assert f"Type {type(size)} for size is currently unsupported."
+                assert f"Type {type(sizes)} for size is currently unsupported."
 
         if ndims == 3:
             return bb.emit_te(


### PR DESCRIPTION
This PR fix ROI values when tensor ROI is Empty pass Constant node in Resize Operator
### Description: 
- Fix ROI values when tensor ROI is Empty pass Constant node
- Create test with Constant and Tensor ROI is Empty
	
### Step to Reproduce:
- Deploy yolov5n.onnx using TVM. When executing relax.transform.LegalizeOps() is happen error: "IndexError: list index out of range" at roi array, because roi = []
- Error log:
>  	"File ~/Contributes/tvm/python/tvm/topi/image/resize.py:615, in _resize_2d()
>     608     in_x = x1 * (image_width - 1) + w_scale * x
>     609 else:
>     610     in_x = get_inx(
>     611         x,
>     612         image_width,
>     613         target_width,
>     614         coordinate_transformation_mode,
> --> 615         roi[1],
>     616         roi[3],
>     617         width_use_int_div,
>     618     )
>     619     in_y = get_inx(
>     620         y,
>     621         image_height,
>    (...)    626         height_use_int_div,
>     627     )
>     629 if method == "nearest_neighbor":
> IndexError: list index out of range"
- Graph:
<img width="1000" height="500" alt="PR" src="https://github.com/user-attachments/assets/e112511a-43a4-4555-afc6-e22d62ec095e" />


### Resolve:
- On the Frontend, when encountering a case where ROI is constant and ROI is empty, the handling is the same as when ROI = None (fill in the ROI tensor with 0.0).