### PR TITLE
[CI] Fix NameError in nightly docker update workflow

### DIFF
--- a/ci/scripts/jenkins/open_docker_update_pr.py
+++ b/ci/scripts/jenkins/open_docker_update_pr.py
@@ -17,16 +17,17 @@
 # under the License.
 
 import argparse
-import logging
 import datetime
-import os
 import json
+import logging
+import os
 import re
 import shlex
+from typing import Any, Callable, Dict, List, Optional
 from urllib import error
-from typing import List, Dict, Any, Optional, Callable
-from git_utils import git, parse_remote, GitHubRepo
-from cmd_utils import REPO_ROOT, init_log
+
+from cmd_utils import REPO_ROOT, Sh, init_log
+from git_utils import GitHubRepo, git, parse_remote
 from should_rebuild_docker import docker_api
 
 JENKINS_DIR = REPO_ROOT / "ci" / "jenkins"


### PR DESCRIPTION
## Why
The Nightly Docker Update CI workflow fails with NameError: name 'Sh' is not defined because Sh is used but not imported.                                               

https://github.com/apache/tvm/actions/workflows/nightly_docker_update.yml
                                                                                                                                                                        
## How                                                                                                                                                                                                                                                                                                                                     
- Add Sh to the import from cmd_utils
- Sort the import with ruff