### PR TITLE
[BugFix][TIR] Fix incorrect optimization when lowering floordiv and f…

### DIFF
--- a/tests/python/tir-transform/test_tir_transform_lower_intrin.py
+++ b/tests/python/tir-transform/test_tir_transform_lower_intrin.py
@@ -92,6 +92,12 @@ def test_lower_floordiv():
         # const power of two
         res = lower_intrin([x, y], tvm.te.floordiv(x, tvm.tir.const(8, dtype=dtype)))
         check_value(res, x, y, [(a, b) for a, b in data if b == 8], lambda a, b: a // b)
+        # floordiv(x + m, k), m and k are positive constant. 2 <= m <= k-1.
+        res = lower_intrin(
+            [x, y],
+            tvm.te.floordiv(x + tvm.tir.const(4, dtype=dtype), tvm.tir.const(5, dtype=dtype)),
+        )
+        check_value(res, x, y, [(a, b) for a, b in data if b == 5], lambda a, b: (a + 4) // b)
 
 
 @tvm.testing.requires_llvm
@@ -115,6 +121,12 @@ def test_lower_floormod():
         # const power of two
         res = lower_intrin([x, y], tvm.te.floormod(x, tvm.tir.const(8, dtype=dtype)))
         check_value(res, x, y, [(a, b) for a, b in data if b == 8], lambda a, b: a % b)
+        # floormod(x + m, k), m and k are positive constant. 2 <= m <= k-1.
+        res = lower_intrin(
+            [x, y],
+            tvm.te.floormod(x + tvm.tir.const(4, dtype=dtype), tvm.tir.const(5, dtype=dtype)),
+        )
+        check_value(res, x, y, [(a, b) for a, b in data if b == 5], lambda a, b: (a + 4) % b)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…loormod

This patch fixes an issue in the LowerIntrin pass where incorrect optimizations were applied to floordiv and floormod operations.

The root cause is that the pass attempts to find an equivalent representation for floordiv(a, b) by calculating the expression (op->b - 1) - a_min. This expression, when subjected to constant folding, can potentially overflow the range of int32 or int16. When this overflow occurs, the transformation becomes invalid and no longer equivalent to the original operation.

To fix this, we enhanced the condition under which the transformation is applied. The new condition ensures that the transformation is only performed when (b_max - a_min) is less than INT_MAX + 2. If this condition is not met, the transformation is skipped and the common lowering steps are followed to ensure correctness.

A regression test has been added to cover this case.

Fixes #18684