### PR TITLE
[Relax][Onnx][BatchNorm] Pass momentum and training_mode into BatchNorm Operator

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -2435,8 +2435,18 @@ class BatchNormalization(OnnxOpConverter):
         mean = inputs[3]
         var = inputs[4]
         epsilon = attr.get("epsilon", 1e-05)
+        momentum = attr.get("momentum", 0.9)
+        training_mode = attr.get("training_mode", 0)
         return relax.op.nn.batch_norm(
-            data, gamma=scale, beta=bias, moving_mean=mean, moving_var=var, epsilon=epsilon, axis=1
+            data,
+            gamma=scale,
+            beta=bias,
+            moving_mean=mean,
+            moving_var=var,
+            axis=1,
+            epsilon=epsilon,
+            momentum=momentum,
+            training=training_mode,
         )
 
 


### PR DESCRIPTION
### Description
- Onnx model have training_mode atrr = False, but Relax model after convert have training = True
- Momentum values ​​in Relax module are not the same as onnx model

### Steps to Reproduce
<img width="600" height="400" alt="BatchNorm" src="https://github.com/user-attachments/assets/2f0ca26b-e83b-4ab8-ab06-a537802af6de" />

- Relax model:
```
class Module:
    def main(X: R.Tensor((2, 3, 4, 4), dtype="float32")) -> R.Tensor((2, 3, 4, 4), dtype="float32"):
        R.func_attr({"num_input": 1})
        with R.dataflow():
            lv: R.Tuple(R.Tensor((2, 3, 4, 4), dtype="float32"), R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.nn.batch_norm(X, metadata["relax.expr.Constant"][0], metadata["relax.expr.Constant"][1], metadata["relax.expr.Constant"][2], metadata["relax.expr.Constant"][3], axis=1, epsilon=9.9999997473787516e-06, center=True, scale=True, momentum=0.10000000000000001, training=True)
            lv1: R.Tensor((2, 3, 4, 4), dtype="float32") = lv[0]
            lv2: R.Tensor((3,), dtype="float32") = lv[1]
            lv3: R.Tensor((3,), dtype="float32") = lv[2]
            gv: R.Tensor((2, 3, 4, 4), dtype="float32") = lv1
            R.output(gv)
        return gv
```

### Resolved
- Get Attributes and Pass momentum/training_mode with default value into BatchNorm Operator
- Fixed: #18703