### PR TITLE
[LLVM] Fix insertDbgValueIntrinsic for Metal backend

### DIFF
--- a/tests/python/codegen/test_gpu_codegen_allreduce.py
+++ b/tests/python/codegen/test_gpu_codegen_allreduce.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
+import tvm_ffi
 import tvm.testing
 import numpy as np
 from tvm.script import tir as T
@@ -96,7 +97,9 @@ def optional_metal_compile_callback(define_metal_compile_callback):
 
         @tvm.register_global_func(name, override=True)
         def compile_metal(src, target):
-            return tvm.contrib.xcode.compile_metal(src, sdk="macosx")
+            from tvm.contrib.xcode import compile_metal  # pylint: disable=import-outside-toplevel
+
+            return compile_metal(src, sdk="macosx")
 
     yield
 

--- a/tests/python/codegen/test_target_codegen_metal.py
+++ b/tests/python/codegen/test_target_codegen_metal.py
@@ -186,7 +186,7 @@ def test_func_with_trailing_pod_params():
 
     mod = tvm.IRModule({"main": func})
 
-    f = tvm.compile(mod, target="metal")
+    f = tvm.tir.build(mod, target="metal")
     src: str = f.imports[0].inspect_source()
     occurrences = src.count("struct func_kernel_args_t")
     assert occurrences == 1, occurrences


### PR DESCRIPTION
Some TIR code could not be compiled to Metal due to an LLVM issue, as described in #18585.  This PR fixes the issue according to the Option 2 in
https://github.com/apache/tvm/issues/18585#issuecomment-3649857591.

Unit tests are updated, though they are not enabled in CI for now.