### PR TITLE
[CI] Fix double newlines in nightly docker update

### DIFF
--- a/ci/scripts/jenkins/open_docker_update_pr.py
+++ b/ci/scripts/jenkins/open_docker_update_pr.py
@@ -144,13 +144,13 @@ if __name__ == "__main__":
                 logging.info(f"No new image found")
             else:
                 logging.info(f"Using new image {new_image}")
-                new_line = f'        "tag": "{new_image}",'
+                new_line = f'        "tag": "{new_image}",\n'
                 replacements[line] = new_line
 
     # Re-generate the Jenkinsfiles
     command = f"python3 {shlex.quote(str(GENERATE_SCRIPT))}"
 
-    content = "\n".join(content)
+    content = "".join(content)
     for old_line, new_line in replacements.items():
         content = content.replace(old_line, new_line)
 


### PR DESCRIPTION
## Related PR

https://github.com/apache/tvm/pull/18710

## Why

- f.readlines() returns lines that already have \n at the end                                      
- Script then does "\n".join(content), which adds another \n between each line
- Result: every line gets a blank line after it → file becomes malformed → lint fails              

## How

- "\n".join(content) to "".join(content)