### PR TITLE
Revert "[ci][docker] Nightly Docker image update"

### DIFF
--- a/ci/jenkins/data.py
+++ b/ci/jenkins/data.py
@@ -51,31 +51,31 @@ aws_ecr_url = "dkr.ecr." + aws_default_region + ".amazonaws.com"
 # Docker Images
 docker_images = {
     "ci_arm": {
-        "tag": "tlcpack/ci-arm:20251130-061900-c429a2b1",
+        "tag": "tlcpack/ci-arm:20221013-060115-61c9742ea",
         "platform": "ARM",
     },
     "ci_cpu": {
-        "tag": "tlcpack/ci-cpu:20251130-061900-c429a2b1",
+        "tag": "tlcpack/ci-cpu:20221013-060115-61c9742ea",
         "platform": "CPU",
     },
     "ci_gpu": {
-        "tag": "tlcpack/ci-gpu:20251130-061900-c429a2b1",
+        "tag": "tlcpack/ci-gpu:20221019-060125-0b4836739",
         "platform": "GPU",
     },
     "ci_hexagon": {
-        "tag": "tlcpack/ci-hexagon:20251130-061900-c429a2b1",
+        "tag": "tlcpack/ci-hexagon:20221013-060115-61c9742ea",
         "platform": "CPU",
     },
     "ci_i386": {
-        "tag": "tlcpack/ci-i386:20251130-061900-c429a2b1",
+        "tag": "tlcpack/ci-i386:20221013-060115-61c9742ea",
         "platform": "CPU",
     },
     "ci_lint": {
-        "tag": "tlcpack/ci-lint:20251130-061900-c429a2b1",
+        "tag": "tlcpack/ci-lint:20221013-060115-61c9742ea",
         "platform": "CPU",
     },
     "ci_wasm": {
-        "tag": "tlcpack/ci-wasm:20251130-061900-c429a2b1",
+        "tag": "tlcpack/ci-wasm:20221013-060115-61c9742ea",
         "platform": "CPU",
     },
 }


### PR DESCRIPTION
Reverts apache/tvm#18710

Seems there is some issue in terms of the images, i think perhaps we should disable docker auto-updates, and instead relies on manual bump, we will need use https://github.com/apache/tvm/blob/main/ci/jenkins/docker-images.ini as ground truth