### PR TITLE
fix: correct typos in Python docstrings

### DIFF
--- a/python/tvm/contrib/mrvl.py
+++ b/python/tvm/contrib/mrvl.py
@@ -207,7 +207,7 @@ def get_nodes_json_string(graph_json):
 
 @tvm_ffi.register_global_func("tvm.mrvl.ModifyConstNames")
 def modify_const_names(nodes_json_str, consts_json_str):
-    """This takes the graph module returned by build an generates nodes and constant
+    """This takes the graph module returned by build and generates nodes and constant
        meta data suitable for compilation by the back end.
 
     Parameters
@@ -222,7 +222,7 @@ def modify_const_names(nodes_json_str, consts_json_str):
     -------
     modified_nodes_consts: string
         This returns a concatenated string of the nodes_json and modified
-        consts json file, seperated by a delimiter |. The modification to the
+        consts json file, separated by a delimiter |. The modification to the
         consts file is necessary since we have added the Merge Compiler Pass
         which names the constants in a form unsuitable for the backend.
     """

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -1618,13 +1618,13 @@ def AllocateWorkspace() -> tvm.ir.transform.Pass:
 
 def SpecializePrimFuncBasedOnCallSite() -> tvm.ir.transform.Pass:
     """This pass updates the var_buffer mapping of PrimFunctions from the call_tir info.
-    Primarily used to update the VDevice information if any changes occured from the caller.
+    Primarily used to update the VDevice information if any changes occurred from the caller.
     This pass recreates the buffers and updates the map.
 
     Returns
     -------
     ret: tvm.ir.transform.Pass
-        The registered pass for allocating workspace.
+        The registered pass for specializing PrimFuncs based on call site.
     """
     return _ffi_api.SpecializePrimFuncBasedOnCallSite()  # type: ignore
 


### PR DESCRIPTION
Fixed 'occured' to 'occurred' in transform.py and 'seperated' to 'separated' in mrvl.py.