### PR TITLE
[DOC] Fix RST syntax

### DIFF
--- a/docs/how_to/tutorials/export_and_load_executable.py
+++ b/docs/how_to/tutorials/export_and_load_executable.py
@@ -274,11 +274,13 @@ if RUN_EXAMPLE:
 # To run on GPU instead of CPU, make the following changes:
 #
 # 1. **Compile for GPU** (earlier in the tutorial, around line 112):
+#
 #    .. code-block:: python
 #
 #       TARGET = tvm.target.Target("cuda")  # Change from "llvm" to "cuda"
 #
 # 2. **Use GPU device in the script**:
+#
 #    .. code-block:: python
 #
 #       device = tvm.cuda(0)  # Use CUDA device instead of CPU


### PR DESCRIPTION
Fix RST syntax in 'export_and_load_executable.py'

---

The code is not correctly rendered here:
- https://tvm.apache.org/docs/how_to/tutorials/export_and_load_executable.html

See the `code-block` parts:

<img width="880" height="390" alt="Screenshot from 2026-02-08 11-11-23" src="https://github.com/user-attachments/assets/7549c93d-f453-48c6-bbbd-bf7d2549c072" />