### PR TITLE
fix: correct typos 'recieve' and 'occurence'

### DIFF
--- a/python/tvm/ir/base.py
+++ b/python/tvm/ir/base.py
@@ -260,7 +260,7 @@ def structural_hash(node, map_free_vars=False):
 
     - Normal node: the hash value is defined by its content and type only.
     - Graph node: each graph node will be assigned a unique index ordered by the
-      first occurence during the visit. The hash value of a graph node is
+      first occurrence during the visit. The hash value of a graph node is
       combined from the hash values of its contents and the index.
 
     structural_hash is made to be concistent with structural_equal.

--- a/python/tvm/tir/op.py
+++ b/python/tvm/tir/op.py
@@ -50,7 +50,7 @@ def call_packed_lowered(*args, span=None):
     The argument to packed function can be Expr or Buffer.
     The argument is the corresponding POD type when Expr is presented.
     When the argument is Buffer, the corresponding PackedFunc
-    will recieve an TVMArrayHandle whose content is valid during the callback period.
+    will receive an TVMArrayHandle whose content is valid during the callback period.
     If the PackedFunc is a python callback, then the corresponding argument is Tensor.
 
     Parameters


### PR DESCRIPTION
Fixed typos in Python code: 'recieve' to 'receive' and 'occurence' to 'occurrence'.