### PR TITLE
fix: correct typo 'occuring' to 'occurring'

### DIFF
--- a/python/tvm/tir/transform/transform.py
+++ b/python/tvm/tir/transform/transform.py
@@ -671,10 +671,10 @@ class HoistedLetBindings(enum.Flag):
     """ Bindings that are used by a hoisted conditional """
 
     LetStmt = 2
-    """ Bindings occuring in LetStmt """
+    """ Bindings occurring in LetStmt """
 
     LetExpr = 4
-    """ Bindings occuring in Let expressions """
+    """ Bindings occurring in Let expressions """
 
     All = RequiredByConditional | LetStmt | LetExpr
     """ Enable all hoisting of let bindings """


### PR DESCRIPTION
Fixed typo in Python docstrings: 'occuring' to 'occurring'.