### PR TITLE
fix: correct additional typos identified in review

### DIFF
--- a/include/tvm/node/structural_hash.h
+++ b/include/tvm/node/structural_hash.h
@@ -17,7 +17,7 @@
  * under the License.
  */
 /*!
- * \file tvm/node/structural_equal.h
+ * \file tvm/node/structural_hash.h
  * \brief Structural hash class.
  */
 #ifndef TVM_NODE_STRUCTURAL_HASH_H_

--- a/python/tvm/ir/base.py
+++ b/python/tvm/ir/base.py
@@ -188,7 +188,7 @@ def structural_equal(lhs, rhs, map_free_vars=False):
     See Also
     --------
     structural_hash
-    assert_strucural_equal
+    assert_structural_equal
     """
     lhs = tvm.runtime.convert(lhs)
     rhs = tvm.runtime.convert(rhs)
@@ -289,7 +289,7 @@ def structural_hash(node, map_free_vars=False):
 
     See Also
     --------
-    structrual_equal
+    structural_equal
     """
     return _ffi_node_api.StructuralHash(node, map_free_vars)  # type: ignore # pylint: disable=no-member
 


### PR DESCRIPTION
## Summary

This PR fixes additional typos identified by Gemini Code Assist during the review of PR #18739.

## Changes

1. **python/tvm/ir/base.py** (line 191): `assert_strucural_equal` → `assert_structural_equal` (in docstring "See Also" section)

2. **python/tvm/ir/base.py** (line 292): `structrual_equal` → `structural_equal` (in docstring "See Also" section)

3. **include/tvm/node/structural_hash.h** (line 20): Fixed `\\file` comment path from `structural_equal.h` to `structural_hash.h` (matching actual filename)

4. **tests/python/tir-base/test_tir_structural_equal_hash.py**: Changed `sequal` to `struct_equal` in error messages and `get_sequal_mismatch` to `get_struct_equal_mismatch` for consistency with the variable names used in the code (`struct_equal0`, `struct_equal1`)

## Context

These typos were identified by the AI code reviewer on our existing PR and are follow-up fixes to keep the codebase consistent.

---

*Typo fix PR - automated detection via AI code review*