### PR TITLE
[Fix][libbacktrace] Fix build failure with spaces in path

### DIFF
--- a/cmake/libs/Libbacktrace.cmake
+++ b/cmake/libs/Libbacktrace.cmake
@@ -1,4 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one
+﻿# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -35,10 +35,10 @@ endif()
 
 ExternalProject_Add(project_libbacktrace
   PREFIX libbacktrace
-  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../3rdparty/libbacktrace
-  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libbacktrace
+  SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../3rdparty/libbacktrace"
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/libbacktrace"
   CONFIGURE_COMMAND "${CMAKE_CURRENT_LIST_DIR}/../../3rdparty/libbacktrace/configure"
-                    "--prefix=${CMAKE_CURRENT_BINARY_DIR}/libbacktrace"
+                    "--prefix=\"${CMAKE_CURRENT_BINARY_DIR}/libbacktrace\""
                     --with-pic
                     "CC=${c_compiler}"
                     "CFLAGS=${CMAKE_C_FLAGS}"
@@ -59,8 +59,8 @@ tvm_file_glob(GLOB LIBBACKTRACE_SRCS "${CMAKE_CURRENT_LIST_DIR}/../../3rdparty/l
 ExternalProject_Add_Step(project_libbacktrace checkout
   DEPENDERS configure
   DEPENDEES download
-  DEPENDS ${LIBBACKTRACE_SRCS}
+  DEPENDS ${LIBBACKTRACE_SRcs}
 )
 
 # create include directory so cmake doesn't complain
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/libbacktrace/include)
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/libbacktrace/include")


### PR DESCRIPTION
## Fix libbacktrace build failure with spaces in path

Fixes #17416

### Problem
When building TVM in directories with spaces, libbacktrace build fails with: