### PR TITLE
[CI] Remove i386 and hexagon from `.asf.yaml`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,8 +63,6 @@ github:
           - cpu/pr-head
           - docker/pr-head
           - gpu/pr-head
-          - hexagon/pr-head
-          - i386/pr-head
           - lint/pr-head
           - wasm/pr-head
 


### PR DESCRIPTION
Part of #18682