### PR TITLE
[Relax] Remove TODO comment for moving code in fuse_tir.cc

### DIFF
--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -32,7 +32,6 @@
 namespace tvm {
 namespace tir {
 
-// TODO(Siyuan): move it to somewhere under tir folder
 /*!
  * \brief Match symbolic vars according to the given PrimExpr, and update the var_remap.
  * Will throw errors if there is a mismatch.


### PR DESCRIPTION
## Why

It is only used in one place and relax specific

## How

- Remove TODO comment for moving code in fuse_tir.cc