### PR TITLE
Fix infinite recursion in get_const_tuple when passed non-tuple input

### DIFF
--- a/python/tvm/topi/utils.py
+++ b/python/tvm/topi/utils.py
@@ -189,10 +189,7 @@ def get_const_tuple(in_tuple):
         if hasattr(in_tuple, "shape"):
             in_tuple = in_tuple.shape
         else:
-            raise TypeError(
-                "get_const_tuple expects a tuple/list of Expr, "
-                f"but got type {type(in_tuple)}"
-            )
+            raise ValueError("Expects a tuple/list of Expr.")
     ret = []
     ana = None
     for elem in in_tuple:


### PR DESCRIPTION
Fix https://github.com/apache/tvm/issues/18765.

This PR fixes an infinite recursion bug in `topi.utils.get_const_tuple` when the function is called with a non-tuple input (e.g., `te.Tensor`, `tvm.tir.PrimExpr`).


I added a type check at function entry to handle non-tuple/list inputs.