### PR TITLE
support integer types in fast_tanh and fast_exp

### DIFF
--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -783,8 +783,8 @@ def fast_exp(x):
     y : tvm.te.Tensor
         The result.
     """
-    if x.dtype.startswith('int') or x.dtype.startswith('uint'):
-        x = cast(x, 'float32')
+    if x.dtype.startswith("int") or x.dtype.startswith("uint"):
+        x = cast(x, "float32")
     return cpp.fast_exp(x, x.dtype, tag.ELEMWISE)
 
 
@@ -801,8 +801,8 @@ def fast_tanh(x):
     y : tvm.te.Tensor
         The result.
     """
-    if x.dtype.startswith('int') or x.dtype.startswith('uint'):
-        x = cast(x, 'float32')
+    if x.dtype.startswith("int") or x.dtype.startswith("uint"):
+        x = cast(x, "float32")
     return cpp.fast_tanh(x, x.dtype, tag.ELEMWISE)
 
 


### PR DESCRIPTION
Fix https://github.com/apache/tvm/issues/18767.

This PR fixes the issue by adding explicit type casting in `fast_tanh` and `fast_exp` to convert integer inputs to float32.


