### PR TITLE
[DOC] Fix PYTHONPATH in "Install from Source"

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -145,7 +145,7 @@ Leaving the build environment ``tvm-build-venv``, there are two ways to install 
 .. code-block:: bash
 
     export TVM_HOME=/path-to-tvm
-    export PYTHONPATH=$TVM_HOME/python:$TVM_HOME/ffi/python:$PYTHONPATH
+    export PYTHONPATH=$TVM_HOME/python:$PYTHONPATH
 
 - Install via pip local project
 


### PR DESCRIPTION
Since 'tvm-ffi' package is installed by 'pip install' in a separate step, there is no need to add '$TVM_HOME/ffi/python' to PYTHONPATH