### PR TITLE
[LLVM][Codegen] Cast NaN to bool gives true

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -928,7 +928,7 @@ llvm::Value* CodeGenLLVM::CreateCast(DataType from, DataType to, llvm::Value* va
   } else if (to.is_bool()) {
     if (from.is_float()) {
       llvm::Constant* zero = llvm::ConstantFP::get(DTypeToLLVMType(from), 0.);
-      return builder_->CreateFCmpONE(value, zero);
+      return builder_->CreateFCmpUNE(value, zero);
     } else {
       llvm::Constant* zero = llvm::ConstantInt::get(DTypeToLLVMType(from), 0);
       return builder_->CreateICmpNE(value, zero);


### PR DESCRIPTION
Due to some recent changes to CI, PR #18646 will be closed and a new PR created. This PR was created by opening a new pull request on the main branch.
- Update test code: using tvmscript instead of schedule te.

### Summary
Cast NaN to bool gives true to ensure consistency with the existing framework (C, C++, Python, Torch, NumPy, OnnxRuntime, ...).

### Steps to Reproduce
- Python:
```
bool(float('nan'))
```
> True

- Torch:
```
torch.tensor(float("nan"), dtype=torch.float32).to(torch.bool)
```
> tensor(True)

- Numpy:
```
import numpy as np
bool(np.nan)
```
> True

- TVM:
```
class Module:
    def main(x: R.Tensor((), dtype="float32")) -> R.Tensor((), dtype="bool"):
        with R.dataflow():
            gv: R.Tensor((), dtype="bool") = R.astype(x, dtype="bool")
            R.output(gv)
        return gv
x = np.array(float("nan"), dtype="float32")
```
> False

### Expected
- TVM:
```
class Module:
    def main(x: R.Tensor((), dtype="float32")) -> R.Tensor((), dtype="bool"):
        with R.dataflow():
            gv: R.Tensor((), dtype="bool") = R.astype(x, dtype="bool")
            R.output(gv)
        return gv
x = np.array(float("nan"), dtype="float32")
```
> True

### Resolved
- Replace the instruction `fcmp one` with `fcmp une` in LLVM.
- Citation: https://releases.llvm.org/20.1.0/docs/LangRef.html#fcmp-instruction
<img width="400" height="200" alt="PR1-18605" src="https://github.com/user-attachments/assets/cffeebd8-dfe6-436e-9c4c-61e1e84d5439" />

- Related:
  + https://stackoverflow.com/questions/9158567/nan-to-bool-conversion-true-or-false
  + https://stackoverflow.com/questions/15686318/why-do-not-a-number-values-equal-true-when-cast-as-boolean-in-python-numpy

- Fixed: #18605