### PR TITLE
[CI] Remove unity from tvm-bot

### DIFF
--- a/ci/scripts/github/github_tvmbot.py
+++ b/ci/scripts/github/github_tvmbot.py
@@ -537,7 +537,6 @@ class PR:
             "tvm-gpu",
             "tvm-lint",
             "tvm-wasm",
-            "tvm-unity",
         ]
         for name in job_names:
             url = JENKINS_URL + f"job/{name}/job/PR-{self.number}/buildWithParameters"


### PR DESCRIPTION
Follow-up for #18755

tvm-bot rerun fails due to remaining tvm-unity
https://github.com/apache/tvm/pull/18775#issuecomment-3904314624