### PR TITLE
[S-TIR][FIX] Remove redundant std::move() to itself

### DIFF
--- a/src/s_tir/transform/lower_cross_thread_reduction.cc
+++ b/src/s_tir/transform/lower_cross_thread_reduction.cc
@@ -353,7 +353,6 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
     // otherwise, directly remove given BlockRealize
     if (it_buffers.defined()) {
       ObjectPtr<SBlockNode> new_block = ffi::make_object<SBlockNode>(*block);
-      new_block->reads = std::move(new_block->reads);
       new_block->writes = it_buffer_regions.value();
       new_block->name_hint = new_block->name_hint + "_in_thread";
       new_block->body =


### PR DESCRIPTION
I tiny fix shown up by gcc 16

```
tvm-0.24.0-build/tvm/src/s_tir/transform/lower_cross_thread_reduction.cc: 
    In function ‘tvm::tir::Stmt tvm::s_tir::TransformReductionBlock(const tvm::tir::SBlockRealizeNode*, const tvm::ffi::Optional<tvm::ffi::Array<tvm::tir::Buffer> >&, const tvm::ffi::Array<tvm::tir::Buffer>&, const tvm::ffi::Array<tvm::tir::Buffer>&, const tvm::ffi::Array<tvm::PrimExpr>&, const tvm::tir::CommReducer&, const tvm::ffi::Array<tvm::PrimExpr>&, const std::vector<const tvm::tir::ForNode*>&)’:
tvm-0.24.0-build/tvm/src/s_tir/transform/lower_cross_thread_reduction.cc:356:24: 
    warning: moving ‘new_block.tvm::ffi::ObjectPtr<tvm::tir::SBlockNode>::operator->()->tvm::tir::SBlockNode::reads’ 
    of type ‘tvm::ffi::Array<tvm::tir::BufferRegion>’ to itself [-Wself-move]
  356 |       new_block->reads = std::move(new_block->reads);
      |       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
$ rpm -q gcc-c++
gcc-c++-16.0.1-0.7.fc45.x86_64
```

---

This is an old leftover from here: 
https://github.com/apache/tvm/commit/421ff76e3e02e0d97018623fc1a42f202fe202bc#diff-ee18021834f82219782c8bbad32b35f73671e6ee498cf3187738c8104611649fL285

```
- new_block->reads = RemoveBufferFromBufferRegions(std::move(new_block->reads), wb_buffer);
+ new_block->reads = std::move(new_block->reads);
```
