### PR TITLE
[CI] Update system cuda version 12.4->12.8

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -17,7 +17,7 @@
 
 # CI docker GPU env
 # tag: v0.60
-FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
 
 COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
 


### PR DESCRIPTION
Fix cudnn errors due to version mismatch between system and torch dependency

link to the jenkins log: https://ci.tlcpack.ai/blue/organizations/jenkins/tvm-gpu/detail/PR-18775/11/pipeline
```
tests/python/relax/test_codegen_cudnn.py::test_conv2d_offload[data_shape1-weight_shape1-float32-True-none] Could not load symbol cudnnGetLibConfig. Error: /usr/lib/x86_64-linux-gnu/libcudnn_graph.so.9: undefined symbol: cudnnGetLibConfig
```

validated the fix with the following local ci script
```bash
python3 tests/scripts/ci.py gpu -d tvm.ci_gpu --tests tests/python/relax/test_codegen_cudnn.py::test_conv2d_offload
```