### PR TITLE
[DOC] Unify GitHub naming

### DIFF
--- a/.github/CODEOWNERSHIP
+++ b/.github/CODEOWNERSHIP
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Github code owners file
+# GitHub code owners file
 # This file is used as a convenient tool to map
 # committers' areas of expertise and faciliate the review process.
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,13 @@ tvm_option(USE_OPENCL_GTEST "Path to OpenCL specific gtest version for runtime c
 tvm_option(USE_VULKAN "Build with Vulkan" OFF)
 
 
-# Whether to use spirv-tools.and SPIRV-Headers from Khronos github or gitlab.
+# Whether to use spirv-tools and SPIRV-Headers from Khronos GitHub or GitLab.
 #
 # Possible values:
 # - OFF: not to use
 # - /path/to/install: path to your khronis spirv-tools and SPIRV-Headers installation directory
 #
-tvm_option(USE_KHRONOS_SPIRV "Whether to use spirv-tools.and SPIRV-Headers from Khronos github or gitlab" OFF)
+tvm_option(USE_KHRONOS_SPIRV "Whether to use spirv-tools and SPIRV-Headers from Khronos GitHub or GitLab" OFF)
 tvm_option(USE_SPIRV_KHR_INTEGER_DOT_PRODUCT "whether enable SPIRV_KHR_DOT_PRODUCT" OFF)
 tvm_option(USE_METAL "Build with Metal" OFF)
 tvm_option(USE_ROCM "Build with ROCM" OFF)

--- a/ci/scripts/github/__init__.py
+++ b/ci/scripts/github/__init__.py
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Package to enable testing of Github scripts"""
+"""Package to enable testing of GitHub scripts"""
 
 from . import github_skipped_tests_comment, github_pr_comment, github_tag_teams, github_docs_comment

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -103,7 +103,7 @@ set(USE_METAL OFF)
 # - /path/to/vulkan-sdk: use specific path to vulkan-sdk
 set(USE_VULKAN OFF)
 
-# Whether to use spirv-tools.and SPIRV-Headers from Khronos github or gitlab.
+# Whether to use spirv-tools and SPIRV-Headers from Khronos GitHub or GitLab.
 #
 # Possible values:
 # - OFF: not to use

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -508,7 +508,7 @@ header_links = [
     ("Community", "https://tvm.apache.org/community"),
     ("Download", "https://tvm.apache.org/download"),
     ("Docs", "https://tvm.apache.org/docs"),
-    ("Github", "https://github.com/apache/tvm/"),
+    ("GitHub", "https://github.com/apache/tvm/"),
 ]
 
 header_dropdown = {

--- a/docs/contribute/document.rst
+++ b/docs/contribute/document.rst
@@ -247,7 +247,7 @@ Image files created for TVM documentation should reside in the `<https://github.
 repository, while the `.rst` files *using* those images should reside in the main TVM repostitory
 (`<https://github.com/apache/tvm>`_).
 
-This will require two Github Pull Requests, one for the image files and another for the `.rst` files.
+This will require two GitHub Pull Requests, one for the image files and another for the `.rst` files.
 Discussion between the contributor and reviewers may be necessary to coordinate the review process.
 
 *IMPORTANT NOTE:* When using two Pull Requests as described above, please merge the

--- a/docs/contribute/pull_request.rst
+++ b/docs/contribute/pull_request.rst
@@ -80,7 +80,7 @@ Guidelines
 Commit Message Guideline
 ------------------------
 
-Apache TVM uses the Github (GH) platform for patch submission and code review
+Apache TVM uses the GitHub (GH) platform for patch submission and code review
 via Pull Requests (PRs). The final commit (title and body) that is merged into
 the Apache TVM main tree is composed of the PR's title and body and must be kept
 updated and reflecting the new changes in the code as per the reviews and
@@ -101,7 +101,7 @@ allowing fast log searches, bisecting, and so on.
 *PR/commit title*:
 
  - Guarantee a title exists (enforced);
- - Don’t use Github usernames in the title, like @username (enforced);
+ - Don’t use GitHub usernames in the title, like @username (enforced);
  - A tag must be present as a hint about what component(s) of the code
    the PRs / commits “touch” (enforced). For example [BugFix], [CI], [microTVM],
    and [TVMC]. Tags go between square brackets and appear first in the title. If
@@ -123,7 +123,7 @@ allowing fast log searches, bisecting, and so on.
 *PR/commit body*:
 
  - Guarantee a body exists (enforced);
- - Don’t use Github usernames in body text, like @username (enforced);
+ - Don’t use GitHub usernames in body text, like @username (enforced);
  - Avoid “bullet” commit message bodies: “bullet” commit message bodies are not
    bad per se, but “bullet” commit messages without any description or
    explanation is likely as bad as commits without any description, rationale,

--- a/docs/contribute/release_process.rst
+++ b/docs/contribute/release_process.rst
@@ -51,7 +51,7 @@ Prepare the Release Notes
 
 Release note contains new features, improvement, bug fixes, known issues and deprecation, etc. TVM provides `monthly dev report <https://discuss.tvm.ai/search?q=TVM%20Monthly%20%23Announcement>`_ collects developing progress each month. It could be helpful to who writes the release notes.
 
-It is recommended to open a Github issue to collect feedbacks for the release note draft before cutting the release branch. See the scripts in ``tests/scripts/release`` for some starting points.
+It is recommended to open a GitHub issue to collect feedbacks for the release note draft before cutting the release branch. See the scripts in ``tests/scripts/release`` for some starting points.
 
 
 Prepare the Release Candidate
@@ -180,7 +180,7 @@ number.
 Upload the Release Candidate
 ----------------------------
 
-Edit the release page on Github and upload the artifacts created by the previous steps.
+Edit the release page on GitHub and upload the artifacts created by the previous steps.
 
 The release manager also needs to upload the artifacts to ASF SVN,
 
@@ -232,7 +232,7 @@ After the vote passes, to upload the binaries to Apache mirrors, you move the bi
 	curl "https://dist.apache.org/repos/dist/dev/tvm/KEYS" > svn-tvm/KEYS
 	(cd svn-tvm && svn ci --username $ASF_USERNAME --password "$ASF_PASSWORD" -m"Update KEYS")
 
-Remember to create a new release TAG (v0.6.0 in this case) on Github and remove the pre-release candidate TAG.
+Remember to create a new release TAG (v0.6.0 in this case) on GitHub and remove the pre-release candidate TAG.
 
  .. code-block:: bash
 

--- a/docs/install/docker.rst
+++ b/docs/install/docker.rst
@@ -24,7 +24,7 @@ They are also helpful run through TVM demo and tutorials.
 We need `docker <https://docs.docker.com/engine/installation/>`_ and
 `nvidia-docker <https://github.com/NVIDIA/nvidia-docker/>`_ if we want to use cuda.
 
-Get a tvm source distribution or clone the github repo to get the auxiliary scripts
+Get a tvm source distribution or clone the GitHub repo to get the auxiliary scripts
 
 .. code:: bash
 

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -61,9 +61,9 @@ one may simply use:
     conda activate tvm-build-venv
 
 
-Step 2. Get Source from Github
+Step 2. Get Source from GitHub
 ------------------------------
-You can also choose to clone the source repo from github.
+You can also choose to clone the source repo from GitHub.
 
 .. code:: bash
 

--- a/tests/python/arith/test_arith_solve_linear_equations.py
+++ b/tests/python/arith/test_arith_solve_linear_equations.py
@@ -26,7 +26,7 @@ def test_solution_consistency():
     seed = random.randrange(sys.maxsize)
     print(
         "\nThis test is intentionally non-deterministic, "
-        "if it fails please report it in github issue together with this seed {}\n".format(seed)
+        "if it fails please report it in GitHub issue together with this seed {}\n".format(seed)
     )
     random.seed(seed)
 

--- a/tests/python/arith/test_arith_solve_linear_inequality.py
+++ b/tests/python/arith/test_arith_solve_linear_inequality.py
@@ -27,7 +27,7 @@ def test_solution_consistency():
     seed = random.randrange(sys.maxsize)
     print(
         "\nThis test is intentionally non-deterministic, "
-        "if it fails please report it in github issue together with this seed {}\n".format(seed)
+        "if it fails please report it in GitHub issue together with this seed {}\n".format(seed)
     )
     random.seed(seed)
 

--- a/tests/python/tir-base/test_tir_imm_values.py
+++ b/tests/python/tir-base/test_tir_imm_values.py
@@ -237,7 +237,7 @@ def check_tir_const_fold(
     flaky_msg = (
         f"{dtype} ({x}, {y}, {expect}) const folding check failed.\n"
         + "This test is intentionally non-deterministic, "
-        + f"if it fails please report it in github issue together with this seed {seed}\n"
+        + f"if it fails please report it in GitHub issue together with this seed {seed}\n"
     )
     if dtype.startswith("float"):
         compare_float_value(calc_res, fold_res.value, flaky_msg)

--- a/tests/scripts/release/README.md
+++ b/tests/scripts/release/README.md
@@ -36,7 +36,7 @@ Once done, you can download the csv file assuming with name `out_pr_gathered_cor
 # Export monthly report on forum:
 python make_notes.py --notes out_pr_gathered_corrected.csv --is-pr-with-link true > monthly_report.md
 
-# Export release report on Github:
+# Export release report on GitHub:
 python make_notes.py --notes out_pr_gathered_corrected.csv --is-pr-with-link true > release_report.md
 
 # If release report exported but forget set `--is-pr-with-link true`,
@@ -57,7 +57,7 @@ Finally, combine `rfc.md` and `out.md` along with some prose to create the final
 
 # Test release packages
 
-After uploading release (candidate) packages to apache.org or github release page, you can validate packages step-by-step from downloading, verification and compiling use script below, but don't forget edit the `version` and `rc` number in script.
+After uploading release (candidate) packages to apache.org or GitHub release page, you can validate packages step-by-step from downloading, verification and compiling use script below, but don't forget edit the `version` and `rc` number in script.
 
 ```bash
 test_release_package.sh


### PR DESCRIPTION
Fix GitHub naming in documentation and comments

- Github -> GitHub
- github -> GitHub