### PR TITLE
[REFACTOR][TEST] Remove unused te imports from test files

### DIFF
--- a/tests/python/all-platform-minimal-test/test_runtime_ndarray.py
+++ b/tests/python/all-platform-minimal-test/test_runtime_ndarray.py
@@ -23,7 +23,6 @@ import numpy as np
 
 import tvm
 import tvm.testing
-from tvm import te
 
 dtype = tvm.testing.parameter("uint8", "int8", "uint16", "int16", "uint32", "int32", "float32")
 

--- a/tests/python/all-platform-minimal-test/test_runtime_packed_func.py
+++ b/tests/python/all-platform-minimal-test/test_runtime_packed_func.py
@@ -20,7 +20,6 @@ import gc
 import numpy as np
 
 import tvm
-from tvm import te
 import tvm.testing
 from tvm.script import tir as T
 

--- a/tests/python/arith/test_arith_domain_touched.py
+++ b/tests/python/arith/test_arith_domain_touched.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
-from tvm import te
 from tvm.script import tir as T
 
 

--- a/tests/python/codegen/test_target_codegen_llvm_vla.py
+++ b/tests/python/codegen/test_target_codegen_llvm_vla.py
@@ -23,7 +23,6 @@ import re
 import pytest
 
 import tvm
-from tvm import te
 from tvm.script import tir as T
 from tvm.target.codegen import llvm_version_major
 

--- a/tests/python/codegen/test_target_codegen_static_init.py
+++ b/tests/python/codegen/test_target_codegen_static_init.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
-from tvm import te
 from tvm.script import ir as I, tir as T
 import ctypes
 import numpy as np

--- a/tests/python/s_tir/transform/test_s_tir_transform_compact_buffer_region.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_compact_buffer_region.py
@@ -16,7 +16,6 @@
 # under the License.
 import tvm
 import tvm.testing
-from tvm import te
 from tvm import tir, s_tir
 from tvm.script import tir as T
 

--- a/tests/python/s_tir/transform/test_s_tir_transform_decorate_device_scope.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_decorate_device_scope.py
@@ -15,11 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
-from tvm import te
 
 
 def test_decorate_device():
-    x = te.var("x")
+    x = tvm.tir.Var("x", "int32")
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([x], tvm.tir.Evaluate(x)))
 
     stmt = tvm.s_tir.transform.DecorateDeviceScope()(mod)["main"].body

--- a/tests/python/s_tir/transform/test_s_tir_transform_hoist_if.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_hoist_if.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
-from tvm import te, s_tir
+from tvm import s_tir
 from tvm.script import tir as T, ir as I
 import numpy as np
 import pytest

--- a/tests/python/s_tir/transform/test_s_tir_transform_loop_partition.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_loop_partition.py
@@ -17,7 +17,6 @@
 import pytest
 import tvm
 import tvm.testing
-from tvm import te
 from tvm.ir.module import IRModule
 from tvm.script import tir as T
 import numpy

--- a/tests/python/s_tir/transform/test_s_tir_transform_lower_cross_thread_reduction.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_lower_cross_thread_reduction.py
@@ -20,7 +20,7 @@ import sys
 import pytest
 import tvm
 import tvm.testing
-from tvm import te, s_tir
+from tvm import s_tir
 from tvm.script import tir as T
 
 # pylint: disable=no-member,invalid-name,unused-variable,unexpected-keyword-arg

--- a/tests/python/s_tir/transform/test_s_tir_transform_lower_init_block.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_lower_init_block.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
-from tvm import te, s_tir
+from tvm import s_tir
 from tvm.script import tir as T
 
 # pylint: disable=no-self-argument

--- a/tests/python/s_tir/transform/test_s_tir_transform_lower_opaque_block.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_lower_opaque_block.py
@@ -17,7 +17,6 @@
 import tvm
 import tvm.testing
 import tvm.s_tir
-from tvm import te
 from tvm.script import tir as T
 
 

--- a/tests/python/s_tir/transform/test_s_tir_transform_memhammer_lower_auto_copy.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_memhammer_lower_auto_copy.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import tvm
-from tvm import te, s_tir
+from tvm import s_tir
 from tvm.script import tir as T
 import sys
 import pytest

--- a/tests/python/s_tir/transform/test_s_tir_transform_merge_dynamic_shared_memory_allocations.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_merge_dynamic_shared_memory_allocations.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import tvm
 import tvm.testing
-from tvm import te, s_tir
+from tvm import s_tir
 from tvm.topi.math import cast
 from tvm.script import ir as I, tir as T
 

--- a/tests/python/s_tir/transform/test_s_tir_transform_plan_update_buffer_allocation_location.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_plan_update_buffer_allocation_location.py
@@ -18,7 +18,6 @@ import numpy as np
 
 import tvm
 import tvm.testing
-from tvm import te
 from tvm.script import tir as T
 from tvm import tir, s_tir
 from tvm.s_tir.tensor_intrin.hexagon import VRMPY_u8u8i32_INTRIN

--- a/tests/python/s_tir/transform/test_s_tir_transform_profiling_instr.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_profiling_instr.py
@@ -17,7 +17,7 @@
 
 import tvm
 import tvm.testing
-from tvm import te, s_tir
+from tvm import s_tir
 from tvm.ir.module import IRModule
 from tvm.script import tir as T
 import numpy

--- a/tests/python/s_tir/transform/test_s_tir_transform_thread_sync.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_thread_sync.py
@@ -16,7 +16,7 @@
 # under the License.
 import tvm
 import tvm.testing
-from tvm import te, s_tir
+from tvm import s_tir
 from tvm.script import tir as T
 
 

--- a/tests/python/s_tir/transform/test_s_tir_transform_unify_thread_binding.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_unify_thread_binding.py
@@ -19,7 +19,7 @@ import sys
 
 import tvm
 import tvm.testing
-from tvm import te, s_tir
+from tvm import s_tir
 from tvm.script import tir as T
 
 

--- a/tests/python/testing/test_testing.py
+++ b/tests/python/testing/test_testing.py
@@ -16,7 +16,6 @@
 # under the License.
 import numpy as np
 import tvm
-from tvm import te
 import tvm.testing
 
 

--- a/tests/python/tir-transform/test_tir_transform_convert_ssa.py
+++ b/tests/python/tir-transform/test_tir_transform_convert_ssa.py
@@ -435,12 +435,11 @@ def test_track_forward_declarations_in_attr_stmt():
 
     # Generate the PrimFunc, which is already SSA
     #
-    # This is constructed directly, rather than using TVMScript or
-    # the `tvm.tir.ir_builder`.  This test case requires a
-    # `tir.AttrStmt` that references a variable, followed by the
-    # `tir.For` defining that variable.  This is not expressible in
-    # either TVMScript or `tvm.tir.ir_builder`, as they only provide
-    # the loop iterator within the body of the loop.
+    # This is constructed directly, rather than using TVMScript.
+    # This test case requires a `tir.AttrStmt` that references a
+    # variable, followed by the `tir.For` defining that variable.
+    # This is not expressible in TVMScript, as it only provides the
+    # loop iterator within the body of the loop.
     i0_outer_outer = tir.Var("i0_outer_outer", "int32")
     i0_outer_inner = tir.Var("i0_outer_inner", "int32")
     i0_inner = tir.Var("i0_inner", "int32")

--- a/tests/python/tir-transform/test_tir_transform_flatten_buffer.py
+++ b/tests/python/tir-transform/test_tir_transform_flatten_buffer.py
@@ -16,7 +16,6 @@
 # under the License.
 import tvm
 import tvm.testing
-from tvm import te
 from tvm.script import ir as I, tir as T
 
 

--- a/tests/python/tir-transform/test_tir_transform_make_packed_api.py
+++ b/tests/python/tir-transform/test_tir_transform_make_packed_api.py
@@ -19,7 +19,7 @@ import pytest
 import numpy as np
 import tvm
 import tvm.testing
-from tvm import te, tir
+from tvm import tir
 from tvm.script import tir as T, ir as I
 
 

--- a/tests/python/tir-transform/test_tir_transform_narrow_datatype.py
+++ b/tests/python/tir-transform/test_tir_transform_narrow_datatype.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import tvm
-from tvm import te
 from tvm.script import tir as T
 from tvm.tir import const
 import tvm.testing

--- a/tests/python/tir-transform/test_tir_transform_split_host_device.py
+++ b/tests/python/tir-transform/test_tir_transform_split_host_device.py
@@ -16,7 +16,6 @@
 # under the License.
 import tvm
 import tvm.testing
-from tvm import te
 from tvm.script import ir as I
 from tvm.script import tir as T
 

--- a/tests/python/tir-transform/test_tir_transform_storage_rewrite.py
+++ b/tests/python/tir-transform/test_tir_transform_storage_rewrite.py
@@ -20,7 +20,6 @@ import pytest
 
 import tvm
 import tvm.testing
-from tvm import te
 from tvm.script import tir as T, ir as I
 
 


### PR DESCRIPTION
This PR removes unused `from tvm import te` imports from 25 test files across the codebase, continuing the ongoing TE → TVMScript migration cleanup.

Changes:
- Remove unused `from tvm import te` from 24 test files in tir-transform/, s_tir/transform/, codegen/, arith/, all-platform-minimal-test/, and testing/
- Replace `te.var("x")` with `tvm.tir.Var("x", "int32")` in `test_s_tir_transform_decorate_device_scope.py` (the only file where te was actually used)
- Clean up stale `tvm.tir.ir_builder` comment references in `test_tir_transform_convert_ssa.py`