### PR TITLE
[Refactor][Metal] Update ICHECK to TVM_FFI_ICHECK in Metal runtime

### DIFF
--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -234,7 +234,8 @@ void MetalWorkspace::CopyDataFromTo(const void* from, size_t from_offset, void* 
     int to_dev_type = static_cast<int>(dev_to.device_type);
 
     if (from_dev_type == kDLMetal && to_dev_type == kDLMetal) {
-      TVM_FFI_ICHECK_EQ(dev_from.device_id, dev_to.device_id) << "Metal disallow cross device copy.";
+      TVM_FFI_ICHECK_EQ(dev_from.device_id, dev_to.device_id)
+          << "Metal disallow cross device copy.";
       id<MTLBlitCommandEncoder> encoder = [cb blitCommandEncoder];
       [encoder copyFromBuffer:(id<MTLBuffer>)(from)
                  sourceOffset:from_offset

--- a/src/runtime/metal/metal_module.mm
+++ b/src/runtime/metal/metal_module.mm
@@ -136,8 +136,8 @@ class MetalModuleNode final : public ffi::ModuleObj {
     id<MTLComputePipelineState> state =
         [w->devices[device_id] newComputePipelineStateWithFunction:f error:&err_msg];
     TVM_FFI_ICHECK(state != nil) << "cannot get state:"
-                         << " for function " << func_name
-                         << [[err_msg localizedDescription] UTF8String];
+                                 << " for function " << func_name
+                                 << [[err_msg localizedDescription] UTF8String];
     [f release];
     [lib release];
     // The state.threadExecutionWidth can change dynamically according


### PR DESCRIPTION
This commit updates all ICHECK macros to TVM_FFI_ICHECK in the Metal runtime implementation to align with the new FFI refactoring.

The changes include updating ICHECK, ICHECK_LT, ICHECK_EQ macros to their TVM_FFI_ICHECK equivalents across the following files:
- src/runtime/metal/metal_device_api.mm
- src/runtime/metal/metal_module.mm

This refactoring ensures consistency with the new TVM FFI interface and maintains the same error checking behavior while using the updated macro names.