### PR TITLE
fix: replace 6 bare except clauses with except Exception

### DIFF
--- a/python/tvm/relax/frontend/torch/fx_translator.py
+++ b/python/tvm/relax/frontend/torch/fx_translator.py
@@ -1232,7 +1232,7 @@ def from_fx(
         # Use the dynamo.export() to export the PyTorch model to FX.
         try:
             graph_module = dynamo.export(torch_model, *input_tensors)
-        except:
+        except Exception:
             raise RuntimeError("Failed to export the PyTorch model to FX.")
 
         # Use the importer to import the PyTorch model to Relax.

--- a/python/tvm/runtime/_tensor.py
+++ b/python/tvm/runtime/_tensor.py
@@ -111,7 +111,7 @@ class Tensor(tvm_ffi.core.Tensor):
         if not isinstance(source_array, np.ndarray):
             try:
                 source_array = np.array(source_array, dtype=self.dtype)
-            except:
+            except Exception:
                 raise TypeError(
                     f"array must be an array_like data, type {type(source_array)} is not supported"
                 )

--- a/python/tvm/s_tir/dlight/analysis/common_analysis.py
+++ b/python/tvm/s_tir/dlight/analysis/common_analysis.py
@@ -377,7 +377,7 @@ def get_max_shared_memory_per_block(target: Target) -> int:
 def get_root_block(sch: Schedule, func_name: str = "main") -> SBlockRV:
     try:
         block = sch.mod[func_name].body.block
-    except:
+    except Exception:
         raise ValueError(
             f"The function body is expected to be the root block, but got:\n"
             f"{sch.mod[func_name].body}"

--- a/tests/python/contrib/test_hexagon/test_run_unit_tests.py
+++ b/tests/python/contrib/test_hexagon/test_run_unit_tests.py
@@ -151,7 +151,7 @@ def test_run_unit_tests(hexagon_session: Session, gtest_args, unit_test_name):
     """Try running gtest unit tests and capture output and error code"""
     try:
         func = hexagon_session._rpc.get_function("hexagon.run_unit_tests")
-    except:
+    except Exception:
         print(
             "This test requires TVM Runtime to be built with a Hexagon gtest"
             "version using Hexagon API cmake flag"

--- a/tests/python/relax/test_group_gemm_flashinfer.py
+++ b/tests/python/relax/test_group_gemm_flashinfer.py
@@ -58,7 +58,7 @@ def has_cutlass():
         handle = pynvml.nvmlDeviceGetHandleByIndex(0)
         major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
         return major >= 9  # SM90+
-    except:
+    except Exception:
         return False
 
 

--- a/tests/scripts/release/make_notes.py
+++ b/tests/scripts/release/make_notes.py
@@ -218,7 +218,7 @@ if __name__ == "__main__":
         try:
             title = pr_dict[int(number)]["title"]
             title = strip_header(title, heading)
-        except:
+        except Exception:
             sprint("The out.pkl file is not match with csv file.")
             exit(1)
         return title


### PR DESCRIPTION
## What
Replace 6 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.