### PR TITLE
[Runtime][Builtin] Handle mismatched type on argument #0 when calling Builtin Runtime Operators

### DIFF
--- a/src/runtime/vm/builtin.cc
+++ b/src/runtime/vm/builtin.cc
@@ -552,7 +552,6 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                tmp->manager_ctx = nullptr;
                tmp->deleter = nullptr;
                Tensor data = Tensor::FromDLPack(tmp.release());
-               
                return data.CreateView(new_shape, data->dtype);
              } else {
                TVM_FFI_THROW(TypeError)


### PR DESCRIPTION
This PR handle mismatched type on argument #0 when calling: Builtin Runtime Operators (ex: `vm.builtin.shape_of`, `vm.builtin.reshape`, ...) (Expected `ffi.Tensor` but got `DLTensor*`)

### Summary
 - Handle mismatched type on argument #0 when calling Builtin runtime operators (Expected `ffi.Tensor` but got `DLTensor*`)

### Description
 - Builtin runtime operators have argument #0 currently accept `Tensor`. But some case has argument #0 is `DLTensor*`.
 - Then raise exception "Mismatched type on argument #0 ... Expected `ffi.Tensor` but got `DLTensor*`".

### Resolve
 - Change parameter #0 to `ffi:Any` to cover all cases.
 - Use `try_cast` to convert data types.
 - Handle the following input types: `Tensor` or `DLTensor*`.

### Reference
- This PR have related to #18546
- Fixed: #18824