### PR TITLE
[TIR][FEAT] Require DeclBuffer before use in verify_well_formed

### DIFF
--- a/src/tir/analysis/verify_well_formed.cc
+++ b/src/tir/analysis/verify_well_formed.cc
@@ -307,6 +307,100 @@ class UndefinedVarVerifier : public Verifier<UndefinedVarVerifier> {
   std::unordered_set<Var> redefine_allowed_within_function_;
 };
 
+/*! \brief Verify that buffers with a declaration are not used outside their declared scope.
+ *
+ * When a buffer is declared via one of the following sites:
+ *   - PrimFunc buffer_map (function parameter buffers)
+ *   - DeclBuffer statement
+ *   - SBlock::alloc_buffers
+ *   - SBlock::match_buffers
+ *   - AttrStmt with key "buffer_bind_scope"
+ *
+ * it must not appear in a BufferLoad, BufferStore, or BufferRegion outside that declaration's
+ * scope.
+ *
+ * Additionally, in schedule-level TIR (functions containing SBlock nodes), all buffers that
+ * appear in BufferLoad or BufferStore must have a prior declaration.
+ *
+ * \note This check is intentionally conservative for lowered TIR, where buffers may be
+ *       constructed inline without an explicit DeclBuffer.  The stricter check (requiring
+ *       all buffers to be declared) is only applied when the function contains SBlock nodes.
+ */
+class UndefinedBufferVerifier : public Verifier<UndefinedBufferVerifier> {
+ public:
+  using Verifier::Verifier;
+
+ private:
+  using Verifier::Visit;
+
+  void Visit(const PrimFunc& prim_func, AccessPath path) override {
+    // Detect if this function uses schedule-level TIR (has SBlock nodes).
+    // In schedule-level TIR, all buffers must be declared before use.
+    // In lowered TIR, buffers may appear inline without a DeclBuffer node.
+    is_schedulable_ = HasBlock(prim_func->body);
+    Verifier::Visit(prim_func, path);
+    // Clear per-function state (buffers should not cross function boundaries).
+    currently_defined_.clear();
+    previously_defined_.clear();
+    is_schedulable_ = false;
+  }
+
+  void EnterDef(const Buffer& buffer, AccessPath path) override {
+    // Call the base class to visit buffer's internal vars (shape, strides, etc.)
+    Verifier::EnterDef(buffer, path);
+    currently_defined_.insert({buffer, path});
+  }
+
+  void ExitDef(const Buffer& buffer, AccessPath path) override {
+    auto active_def = currently_defined_.find(buffer);
+    if (active_def != currently_defined_.end()) {
+      currently_defined_.erase(active_def);
+    }
+    previously_defined_.insert({buffer, path});
+  }
+
+  void Visit(const Buffer& buffer, AccessPath path) override {
+    bool is_declared = currently_defined_.count(buffer);
+    bool was_declared = previously_defined_.count(buffer);
+
+    if (was_declared && !is_declared) {
+      // Buffer was previously declared but is now out of scope — always an error.
+      auto prev_def = previously_defined_.find(buffer);
+      Verify(false) << "TIR is ill-formed: buffer " << buffer->name << " is used at " << path
+                    << " but its declaration is no longer in-scope. "
+                    << "It was declared at " << prev_def->second << ".";
+    } else if (!is_declared && !was_declared && is_schedulable_) {
+      // Buffer was never declared, and we are in schedule-level TIR — error.
+      Verify(false) << "TIR is ill-formed: buffer " << buffer->name << " is used at " << path
+                    << " without a prior DeclBuffer or other declaration.";
+    }
+    // Still visit the buffer's internal vars so variable usage is tracked.
+    Verifier::Visit(buffer, path);
+  }
+
+  /*! \brief Recursively check if a statement contains any SBlock nodes. */
+  static bool HasBlock(const Stmt& stmt) {
+    struct BlockFinder : public StmtVisitor {
+      bool found{false};
+      void VisitStmt_(const SBlockNode* op) final { found = true; }
+      // Short-circuit: stop once we find a block.
+      void VisitStmt(const Stmt& stmt) final {
+        if (!found) StmtVisitor::VisitStmt(stmt);
+      }
+    };
+    BlockFinder finder;
+    finder(stmt);
+    return finder.found;
+  }
+
+  // Whether the current PrimFunc contains SBlock nodes (schedule-level TIR).
+  bool is_schedulable_{false};
+  // Buffers defined in the currently-visited scope.
+  std::unordered_map<Buffer, AccessPath, ObjectPtrHash, ObjectPtrEqual> currently_defined_;
+  // Buffers that were previously defined and are now out of scope.
+  std::unordered_map<Buffer, AccessPath, ObjectPtrHash, ObjectPtrEqual> previously_defined_;
+};
+
 /* \brief Verify unique tir::Var for each environment thread
  *
  * Environment threads, such as CUDA's `threadIdx.x`, are defined in
@@ -354,6 +448,8 @@ bool VerifyWellFormed(const PrimFunc& func, bool assert_mode) {
 
   if (!UndefinedVarVerifier::Verify(func, assert_mode)) return false;
 
+  if (!UndefinedBufferVerifier::Verify(func, assert_mode)) return false;
+
   // TODO(Siyuan): add more checks here.
   return true;
 }
@@ -369,6 +465,8 @@ bool VerifyWellFormed(const IRModule& mod, bool assert_mode) {
   }
 
   if (!UndefinedVarVerifier::Verify(mod, assert_mode)) return false;
+
+  if (!UndefinedBufferVerifier::Verify(mod, assert_mode)) return false;
 
   return true;
 }

--- a/src/tir/ir/tir_visitor_with_path.cc
+++ b/src/tir/ir/tir_visitor_with_path.cc
@@ -177,7 +177,7 @@ void TIRVisitorWithPath::VisitStmt_(const LetStmtNode* op, AccessPath path) {
 void TIRVisitorWithPath::VisitStmt_(const AttrStmtNode* op, AccessPath path) {
   Visit(op->value, path->Attr("value"));
 
-  std::vector<std::variant<DefContext<IterVar>, DefContext<Var>>> context;
+  std::vector<std::variant<DefContext<IterVar>, DefContext<Var>, DefContext<Buffer>>> context;
   if (auto iter_var = op->node.as<IterVar>();
       iter_var && (op->attr_key == attr::thread_extent || op->attr_key == attr::virtual_thread)) {
     // Some attributes serve as a source of definition for the
@@ -202,6 +202,7 @@ void TIRVisitorWithPath::VisitStmt_(const AttrStmtNode* op, AccessPath path) {
     for (auto& var : WithMatchBufferDefs(buffer_view, path->Attr("node")->ArrayItem(0))) {
       context.push_back(std::move(var));
     }
+    context.push_back(WithDef(buffer_view, path->Attr("node")->ArrayItem(0)));
 
   } else if (auto expr = op->node.as<PrimExpr>()) {
     Visit(expr.value(), path->Attr("node"));
@@ -296,6 +297,7 @@ void TIRVisitorWithPath::VisitStmt_(const SBlockNode* op, AccessPath path) {
       for (auto& def : WithMatchBufferDefs(buf, buffer_path)) {
         context.push_back(std::move(def));
       }
+      context.push_back(WithDef(buf, buffer_path));
     }
   }
 

--- a/tests/python/tir-analysis/test_tir_analysis_verify_well_formed.py
+++ b/tests/python/tir-analysis/test_tir_analysis_verify_well_formed.py
@@ -399,5 +399,144 @@ def test_sequential_redefinition_with_location():
     assert "later re-defined at" in error_msg
 
 
+def test_buffer_in_buffer_map_is_well_formed():
+    """Buffers defined via function parameter buffer_map are in scope for the body."""
+
+    @T.prim_func
+    def func(A: T.Buffer((128,), "float32"), B: T.Buffer((128,), "float32")):
+        for i in T.grid(128):
+            B[i] = A[i] * 2.0
+
+    tvm.tir.analysis.verify_well_formed(func)
+
+
+def test_decl_buffer_is_well_formed():
+    """A DeclBuffer statement introduces a buffer into scope for its body."""
+
+    @T.prim_func
+    def func(A: T.Buffer((128,), "float32")):
+        B_data = T.allocate([128], "float32", "global")
+        B = T.decl_buffer([128], "float32", data=B_data)
+        for i in T.grid(128):
+            B[i] = A[i] * 2.0
+
+    tvm.tir.analysis.verify_well_formed(func)
+
+
+def test_alloc_buffer_in_block_is_well_formed():
+    """SBlock::alloc_buffers introduces a buffer into scope for the block body."""
+
+    @I.ir_module
+    class mod:
+        @T.prim_func
+        def func(A: T.Buffer((128,), "float32")):
+            with T.sblock("root"):
+                B = T.alloc_buffer([128], "float32")
+                for i in T.grid(128):
+                    with T.sblock("write_B"):
+                        vi = T.axis.remap("S", [i])
+                        B[vi] = A[vi] * 2.0
+
+    tvm.tir.analysis.verify_well_formed(mod)
+
+
+def test_match_buffer_in_block_is_well_formed():
+    """SBlock::match_buffers introduces a buffer into scope for the block body."""
+
+    @I.ir_module
+    class mod:
+        @T.prim_func
+        def func(A: T.Buffer((128, 128), "float32")):
+            for iters in T.grid(8, 8, 16, 16):
+                with T.sblock("compute"):
+                    ti, tj, i, j = T.axis.remap("SSSS", iters)
+                    A_tile = T.match_buffer(
+                        A[ti * 16 : (ti + 1) * 16, tj * 16 : (tj + 1) * 16],
+                        dtype="float32",
+                    )
+                    A_tile[i, j] = A_tile[i, j] * 2.0
+
+    tvm.tir.analysis.verify_well_formed(mod)
+
+
+def test_error_buffer_used_out_of_decl_scope():
+    """A buffer may not be used after its DeclBuffer scope ends.
+
+    This test manually constructs TIR where a buffer's DeclBuffer scope ends
+    before it is referenced, verifying that the out-of-scope use is detected.
+    """
+    # Manually build TIR:
+    #   DeclBuffer(B, body=Evaluate(B[0])),  # B is in scope here
+    #   BufferStore(A, B[0], [0]),            # B is OUT of scope here
+    n = 128
+    A = tvm.tir.decl_buffer([n], "float32", name="A")
+    B = tvm.tir.decl_buffer([n], "float32", name="B")
+
+    # B is used within the DeclBuffer body (valid).
+    b_use_inside = tvm.tir.Evaluate(tvm.tir.BufferLoad(B, [0]))
+    decl_b = tvm.tir.DeclBuffer(B, body=b_use_inside)
+
+    # B is referenced AFTER the DeclBuffer scope has ended (invalid).
+    b_use_outside = tvm.tir.BufferStore(A, tvm.tir.BufferLoad(B, [0]), [0])
+
+    body = tvm.tir.SeqStmt([decl_b, b_use_outside])
+
+    prim_func = tvm.tir.PrimFunc(
+        params=[A.data, B.data],
+        body=body,
+        buffer_map={A.data: A},
+    )
+
+    with pytest.raises(
+        ValueError, match="buffer B.*declaration is no longer in-scope"
+    ):
+        tvm.tir.analysis.verify_well_formed(prim_func)
+
+
+def test_error_undeclared_buffer_in_schedulable_tir():
+    """In schedule-level TIR (with SBlock nodes), all buffers must be declared."""
+    # Manually construct a BufferStore that uses a buffer without any declaration
+    # inside a block context.
+    n = tvm.tir.SizeVar("n", "int32")
+    A = tvm.tir.decl_buffer([n], "float32", name="A")
+    i = tvm.tir.Var("i", "int32")
+
+    # Create an undeclared buffer using an explicit data pointer that is NOT
+    # in the buffer_map and NOT wrapped with DeclBuffer.
+    B_data = tvm.tir.Var("B_data", tvm.ir.PointerType(tvm.ir.PrimType("float32")))
+    B = tvm.tir.decl_buffer([n], "float32", name="B", data=B_data)
+
+    # Build a block that writes to B without any declaration of B.
+    bi = tvm.tir.SizeVar("bi", "int32")
+    block = tvm.tir.SBlock(
+        iter_vars=[tvm.tir.IterVar(tvm.ir.Range(0, n), bi, 0)],  # 0 = kDataPar
+        reads=[tvm.tir.BufferRegion(A, [tvm.ir.Range(bi, bi + 1)])],
+        writes=[tvm.tir.BufferRegion(B, [tvm.ir.Range(bi, bi + 1)])],
+        body=tvm.tir.BufferStore(B, tvm.tir.BufferLoad(A, [bi]), [bi]),
+        name_hint="write_B",
+    )
+    block_realize = tvm.tir.SBlockRealize(
+        iter_values=[i],
+        predicate=tvm.tir.const(True),
+        block=block,
+    )
+
+    prim_func = tvm.tir.PrimFunc(
+        params=[A.data, B_data],
+        body=tvm.tir.For(
+            i, 0, n, tvm.tir.ForKind.SERIAL, block_realize
+        ),
+        buffer_map={A.data: A},
+        # Note: B is NOT in buffer_map, so its declaration scope is only
+        # within a DeclBuffer node (which we intentionally omit here).
+    )
+
+    # B is used in the block but was never declared — should fail.
+    with pytest.raises(
+        ValueError, match="buffer B.*without a prior DeclBuffer"
+    ):
+        tvm.tir.analysis.verify_well_formed(prim_func)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
## Summary

- Add `UndefinedBufferVerifier` to `verify_well_formed` that checks buffer-scope invariants: buffers declared via `buffer_map`, `DeclBuffer`, `alloc_buffers`, `match_buffers`, or `buffer_bind_scope` must not be used outside their declaration scope
- In schedule-level TIR (functions with `SBlock` nodes), all buffers in `BufferLoad`/`BufferStore` must have a prior declaration
- Fix `TIRVisitorWithPath` to call `WithDef` for `Buffer` at two previously missing sites: `SBlock::match_buffers` and `AttrStmt::buffer_bind_scope`

Follows up on the concept from draft PR #14778 (RFC#70). The check is gated to schedule-level TIR only, since `FlattenBuffer` strips `DeclBuffer` statements.

## Test plan

- [x] 6 new tests in `test_tir_analysis_verify_well_formed.py` (buffer_map, decl_buffer, alloc_buffer, match_buffer, error_out_of_scope, error_undeclared)
- [x] All 23 existing + new tests pass
- [ ] CI checks