### PR TITLE
[DOCKER] Refactor bash.sh: auto-detect rootless, add --shell, TVM_DEV_MOUNTS

### DIFF
--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -170,7 +170,7 @@ COMMAND
 
 Environment Variables:
 
-TVM_DEV_MOUNTS
+TVM_DEV_DOCKER_MOUNTS
 
     Space-separated list of additional mount specifications.
     Each entry is either:
@@ -455,10 +455,10 @@ for MOUNT_DIR in ${MOUNT_DIRS[@]+"${MOUNT_DIRS[@]}"}; do
     DOCKER_MOUNT+=( --volume "${MOUNT_DIR}:${MOUNT_DIR}" )
 done
 
-# Parse TVM_DEV_MOUNTS env var: space-separated mount specs
+# Parse TVM_DEV_DOCKER_MOUNTS env var: space-separated mount specs
 # Each entry is either /path (same path) or /src:/dst
-if [[ -n "${TVM_DEV_MOUNTS:-}" ]]; then
-    for mount_spec in ${TVM_DEV_MOUNTS}; do
+if [[ -n "${TVM_DEV_DOCKER_MOUNTS:-}" ]]; then
+    for mount_spec in ${TVM_DEV_DOCKER_MOUNTS}; do
         if [[ "$mount_spec" == *:* ]]; then
             # src:dst format
             mount_src="${mount_spec%%:*}"


### PR DESCRIPTION
## Summary

Refactor `docker/bash.sh` incorporating lessons from tdev's `docker/run_container.sh`:

- **Auto-detect rootless**: Replace `$DOCKER_IS_ROOTLESS` env var with `docker info` query (env var kept as CI override)
- **`--shell <name>`**: New flag to specify interactive shell (e.g., `--shell zsh`)
- **`TVM_DEV_MOUNTS`**: New env var for declarative mount configuration (space-separated paths)
- **GPU cleanup**: Remove legacy `nvidia-docker` detection and Vulkan ICD mounting; use `--gpus all`
- **Code organization**: Extract `detect_rootless()`, `validate_mount()` helpers; organize into labeled sections

All existing flags and CI behavior preserved. Backwards compatible.

## Test plan

- [x] `bash -n docker/bash.sh` — no syntax errors
- [x] `bash docker/bash.sh --help` — shows updated usage
- [ ] Manual test in CI-compatible container