### PR TITLE
fix: Use T.decl_buffer instead of T.Buffer for aliased buffers in LongRoPE

### DIFF
--- a/python/tvm/relax/frontend/nn/llm/position_embedding.py
+++ b/python/tvm/relax/frontend/nn/llm/position_embedding.py
@@ -587,8 +587,8 @@ def llama_rope_with_position_map(  # pylint: disable=too-many-arguments
             var_position_map, (seq_len,), "int32", elem_offset=position_map_elem_offset
         )
         # long factors is the first half, short factors is the second half
-        long_factors = T.Buffer((rotary_dim // 2,), "float32", data=ext_factors.data)
-        short_factors = T.Buffer(
+        long_factors = T.decl_buffer((rotary_dim // 2,), "float32", data=ext_factors.data)
+        short_factors = T.decl_buffer(
             (rotary_dim // 2,),
             "float32",
             data=ext_factors.data,
@@ -814,8 +814,8 @@ def llama4_rope_with_position_map(  # pylint: disable=too-many-arguments
             var_position_map, (seq_len,), "int32", elem_offset=position_map_elem_offset
         )
         # long factors is the first half, short factors is the second half
-        long_factors = T.Buffer((rotary_dim // 2,), "float32", data=ext_factors.data)
-        short_factors = T.Buffer(
+        long_factors = T.decl_buffer((rotary_dim // 2,), "float32", data=ext_factors.data)
+        short_factors = T.decl_buffer(
             (rotary_dim // 2,),
             "float32",
             data=ext_factors.data,


### PR DESCRIPTION
T.Buffer used as a local variable does not emit a DeclBuffer IR node, causing well-formedness check failures. Replace with T.decl_buffer.