### PR TITLE
[TOPI] Reject non-float inputs for inverse unary math ops

### DIFF
--- a/python/tvm/topi/math.py
+++ b/python/tvm/topi/math.py
@@ -235,6 +235,7 @@ def acosh(x):
     y : tvm.te.Tensor
         The result.
     """
+    x = _require_float_tensor("acosh", x)
     return te.compute(x.shape, lambda *i: te.acosh(x(*i)))
 
 
@@ -270,6 +271,7 @@ def asinh(x):
     y : tvm.te.Tensor
         The result.
     """
+    x = _require_float_tensor("asinh", x)
     return te.compute(x.shape, lambda *i: te.asinh(x(*i)))
 
 
@@ -304,6 +306,7 @@ def atanh(x):
     y : tvm.te.Tensor
         The result.
     """
+    x = _require_float_tensor("atanh", x)
     return te.compute(x.shape, lambda *i: te.atanh(x(*i)))
 
 

--- a/tests/python/te/test_te_create_primfunc.py
+++ b/tests/python/te/test_te_create_primfunc.py
@@ -359,7 +359,7 @@ def test_constant():
     tvm.testing.assert_allclose(a_np + 2, c.numpy())
 
 
-@pytest.mark.parametrize("op_name", ["acos", "asin"])
+@pytest.mark.parametrize("op_name", ["acos", "acosh", "asin", "asinh", "atanh"])
 def test_topi_float_unary_rejects_integer_input(op_name):
     x = te.placeholder((1, 8), dtype="int16", name="x")
     op = getattr(topi, op_name)
@@ -371,9 +371,10 @@ def test_topi_float_unary_rejects_integer_input(op_name):
         op(x)
 
 
-@pytest.mark.parametrize("op_name", ["acos", "asin"])
-def test_topi_float_unary_accepts_float_input(op_name):
-    x = te.placeholder((1, 8), dtype="float32", name="x")
+@pytest.mark.parametrize("op_name", ["acos", "acosh", "asin", "asinh", "atanh"])
+@pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
+def test_topi_float_unary_accepts_float_input(op_name, dtype):
+    x = te.placeholder((1, 8), dtype=dtype, name="x")
     op = getattr(topi, op_name)
     out = op(x)
 


### PR DESCRIPTION
## Summary

Reject non-float inputs for inverse trigonometric and hyperbolic unary ops in TOPI.

## Changes

- add a shared floating-point dtype check for inverse unary math ops in TOPI
- apply the check to `topi.acos`, `topi.acosh`, `topi.asin`, `topi.asinh`, and `topi.atanh`
- add TE tests covering integer-input rejection for these ops
- add regression tests covering successful LLVM build for both `float32` and `bfloat16`

## Validation

- `tests/python/te/test_te_create_primfunc.py -k 'topi_float_unary'`
- local repro now fails early with a clear `TypeError` for integer inputs
- local regression check confirms the valid `float32` and `bfloat16` paths still compile with LLVM

## Issue

Fixes #18729