### PR TITLE
[FIX][Adreno] Replace AllocBuffer with Bind in texture alloc injection

### DIFF
--- a/src/s_tir/backend/adreno/inject_texture_alloc.cc
+++ b/src/s_tir/backend/adreno/inject_texture_alloc.cc
@@ -82,11 +82,8 @@ class TextureAllocInjector : public arith::IRMutatorWithAnalyzer {
       args.push_back(Call(DataType::Handle(), builtin::tvm_stack_make_shape(),
                           {texture.width, texture.height, texture.depth}));
       args.push_back(IntImm(DataType::Int(64), channel_size));
-      ffi::Array<Stmt> seq;
-      seq.push_back(stmt);
-      seq.push_back(Bind(op->buffer->data,
-                         Call(op->buffer->data.dtype(), builtin::nd_mem_alloc_with_scope(), args)));
-      stmt = SeqStmt(seq);
+      stmt = Bind(op->buffer->data,
+                  Call(op->buffer->data.dtype(), builtin::nd_mem_alloc_with_scope(), args));
     }
     return stmt;
   }


### PR DESCRIPTION
## Summary

- Fix `inject_texture_alloc.cc` to replace `AllocBuffer` with just a `Bind(nd_mem_alloc_with_scope)`, consistent with `LowerVtcmAlloc`
- Previously kept a redundant `AllocBuffer` alongside the `Bind` in a `SeqStmt`

Follow-up to #18876.