### PR TITLE
[Relax][ONNX] Fix get_converter edge case for unsupported low opset

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -303,7 +303,10 @@ class OnnxOpConverter:
         """
         versions = [int(d.replace("_impl_v", "")) for d in dir(cls) if "_impl_v" in d]
         versions = sorted(versions + [opset])
-        version = versions[max([i for i, v in enumerate(versions) if v == opset]) - 1]
+        opset_idx = max([i for i, v in enumerate(versions) if v == opset])
+        if opset_idx == 0:
+            raise NotImplementedError(f"opset version {opset} of {cls.__name__} not implemented")
+        version = versions[opset_idx - 1]
         if hasattr(cls, f"_impl_v{version}"):
             return getattr(cls, f"_impl_v{version}")
         raise NotImplementedError(f"opset version {version} of {cls.__name__} not implemented")


### PR DESCRIPTION
This PR fixes an edge case in OnnxOpConverter.get_converter in python/tvm/relax/frontend/onnx/onnx_frontend.py.

Previously, when the requested opset was lower than the minimum supported _impl_v* version, the python list index logic could select an invalid previous element (via negative indexing) instead of failing clearly.

This change keeps the existing converter-selection logic and adds a guard:

compute the index of opset in the sorted version list (including opset)
if opset is at index 0, raise NotImplementedError
otherwise continue with existing behavior
This ensures unsupported low opset versions fail fast with an explicit error instead of potentially selecting an incorrect converter.
