### PR TITLE
[TVMScript] Remove T.Bind backward-compat alias

### DIFF
--- a/python/tvm/script/ir_builder/tir/ir.py
+++ b/python/tvm/script/ir_builder/tir/ir.py
@@ -1024,9 +1024,6 @@ def Let(  # pylint: disable=invalid-name
     return tir.Let(var, value, expr)
 
 
-Bind = bind  # backward-compat alias
-
-
 def let(
     v: Var,
     value: PrimExpr,
@@ -2317,7 +2314,6 @@ __all__ = float_types + [
     "Call",
     "CallEffectKind",
     "let",
-    "Bind",
     "bind",
     "Let",
     "IterVar",


### PR DESCRIPTION
## Summary
- Remove `Bind = bind` backward-compat alias from `ir.py`
- Remove `"Bind"` from `__all__` exports
- Follows #18889 which renamed `T.Bind` → `T.bind`

## Test plan
- [x] tvmscript roundtrip/printer/ir_builder tests pass (232 passed)
- [x] pre-commit lint passes