### PR TITLE
[Build] Fix version regex to anchor at line start in pyproject.toml

### DIFF
--- a/version.py
+++ b/version.py
@@ -180,7 +180,7 @@ def sync_version(pub_ver, local_ver, dry_run):
     # pyproject.toml
     update(
         os.path.join(PROJ_ROOT, "pyproject.toml"),
-        r"(?<=version = \")[.0-9a-z\+]+",
+        r"(?<=^version = \")[.0-9a-z\+]+",
         pub_ver,
         dry_run,
     )


### PR DESCRIPTION
Add ^ anchor to the version regex so it matches only the top-level `version = "..."` instead of all three occurrences, which caused hit_count == 3 and a RuntimeError in sync_version.