### PR TITLE
[Docs] Update outdated references from recent refactors  

### DIFF
--- a/docs/arch/pass_infra.rst
+++ b/docs/arch/pass_infra.rst
@@ -162,10 +162,6 @@ Python APIs to create a compilation pipeline using pass context.
       }
     };
 
-    /*! \brief The thread-local store to hold the pass context. */
-    typedef dmlc::ThreadLocalStore<PassContextThreadLocalEntry>
-         PassContextThreadLocalStore;
-
 Pass Constructs
 ^^^^^^^^^^^^^^^
 

--- a/docs/arch/runtime.rst
+++ b/docs/arch/runtime.rst
@@ -48,7 +48,7 @@ function call whose caller and callee may be in different languages.
 
 The following code block provides an example in C++
 
-.. _PackedFunc: https://github.com/apache/tvm/blob/main/include/tvm/runtime/packed_func.h
+.. _PackedFunc: https://github.com/apache/tvm/blob/main/3rdparty/tvm-ffi/include/tvm/ffi/function.h
 
 .. code:: c
 
@@ -138,7 +138,7 @@ which allows us to embed the PackedFunc into any languages. Besides python, so f
 `java`_ and `javascript`_.
 This philosophy of embedded API is very like Lua, except that we don't have a new language but use C++.
 
-.. _minimum C API: https://github.com/apache/tvm/blob/main/include/tvm/runtime/base.h
+.. _minimum C API: https://github.com/apache/tvm/blob/main/3rdparty/tvm-ffi/include/tvm/ffi/c_api.h
 .. _java: https://github.com/apache/tvm/tree/main/jvm
 .. _javascript: https://github.com/apache/tvm/tree/main/web
 
@@ -257,20 +257,18 @@ Each argument in PackedFunc contains a union value `TVMValue`_
 and a type code. This design allows the dynamically typed language to convert to the corresponding type directly, and statically typed language to
 do runtime type checking during conversion.
 
-.. _TVMValue: https://github.com/apache/tvm/blob/main/include/tvm/runtime/base.h#L135
+.. _TVMValue: https://github.com/apache/tvm/blob/main/3rdparty/tvm-ffi/include/tvm/ffi/c_api.h
 
 The relevant files are
 
-- `packed_func.h`_ for C++ API
-- `c_runtime_api.cc`_ for C API and how to provide callback.
+- `function.h`_ for C++ PackedFunc API
+- `c_api.h`_ for C API.
 
-.. _packed_func.h: https://github.com/apache/tvm/blob/main/include/tvm/runtime/packed_func.h
-.. _c_runtime_api.cc: https://github.com/apache/tvm/blob/main/src/runtime/c_runtime_api.cc#L262
+.. _function.h: https://github.com/apache/tvm/blob/main/3rdparty/tvm-ffi/include/tvm/ffi/function.h
+.. _c_api.h: https://github.com/apache/tvm/blob/main/3rdparty/tvm-ffi/include/tvm/ffi/c_api.h
 
 To support extension types, we used a registry system to register type related information, like support of any
-in C++, see `Extension types`_ for more details.
-
-.. _Extension types: https://github.com/apache/tvm/tree/main/apps/extension
+in C++. See the ``tvm-ffi`` subproject under ``3rdparty/tvm-ffi/`` for more details on the FFI type system.
 
 
 Runtime-Specific Information

--- a/docs/contribute/code_guide.rst
+++ b/docs/contribute/code_guide.rst
@@ -41,15 +41,15 @@ C++ Code Styles
 We use ``clang-format`` to enforce the code style. Because different version
 of clang-format might change by its version, it is recommended to use the same
 version of the clang-format as the main one.
-You can also use the following command via docker.
+You can use pre-commit hooks to run formatting checks:
 
 .. code:: bash
 
-    # Run a specific file through clang-format
-    docker/bash.sh ci_lint clang-format-10 [path-to-file]
+    # Run clang-format on all files
+    pre-commit run clang-format --all-files
 
-    # Run all linters, including clang-format
-    python tests/scripts/ci.py lint
+    # Run all linters (Python + C++ + custom checks)
+    pre-commit run --all-files
 
 
 clang-format is also not perfect, when necessary, you can use disble clang-format on certain code regions.
@@ -86,8 +86,8 @@ Because clang-format may not recognize macros, it is recommended to use macro li
 Python Code Styles
 ------------------
 - The functions and classes are documented in `numpydoc <https://numpydoc.readthedocs.io/en/latest/>`_ format.
-- Check your code style using ``python tests/scripts/ci.py lint``
-- Stick to language features in ``python 3.7``
+- Check your code style using ``pre-commit run --all-files``
+- Stick to language features in ``python 3.10``
 
 - For functions with early returns, prefer ``if``/``elif``/``else``
   chains for functions with parallel and short bodies to the

--- a/docs/contribute/error_handling.rst
+++ b/docs/contribute/error_handling.rst
@@ -55,43 +55,13 @@ The following code gives an example on how to do so.
     }
   }
 
-The above function is registered as PackedFunc into the python frontend,
-under the name ``tvm._api_internal._ErrorTest``.
-Here is what will happen if we call the registered function:
+When a C++ function registered via the FFI raises an error with a typed prefix,
+the TVM FFI system will automatically map it to the corresponding Python exception
+class. For example, a ``ValueError:`` prefix in the error message will raise a Python
+``ValueError``, and an ``InternalError:`` prefix will raise ``tvm.error.InternalError``.
 
-.. code::
-
-  >>> import tvm
-  >>> tvm.testing.ErrorTest(0, 1)
-  Traceback (most recent call last):
-    File "<stdin>", line 1, in <module>
-    File "/path/to/tvm/python/tvm/_ffi/_ctypes/function.py", line 190, in __call__
-      raise get_last_ffi_error()
-  ValueError: Traceback (most recent call last):
-    [bt] (3) /path/to/tvm/build/libtvm.so(TVMFuncCall+0x48) [0x7fab500b8ca8]
-    [bt] (2) /path/to/tvm/build/libtvm.so(+0x1c4126) [0x7fab4f7f5126]
-    [bt] (1) /path/to/tvm/build/libtvm.so(+0x1ba2f8) [0x7fab4f7eb2f8]
-    [bt] (0) /path/to/tvm/build/libtvm.so(+0x177d12) [0x7fab4f7a8d12]
-    File "/path/to/tvm/src/api/api_test.cc", line 80
-  ValueError: Check failed: x == y (0 vs. 1) : expect x and y to be equal.
-  >>>
-  >>> tvm.testing.ErrorTest(1, 1)
-  Traceback (most recent call last):
-    File "<stdin>", line 1, in <module>
-    File "/path/to/tvm/python/tvm/_ffi/_ctypes/function.py", line 190, in __call__
-      raise get_last_ffi_error()
-  tvm.error.InternalError: Traceback (most recent call last):
-    [bt] (3) /path/to/tvm/build/libtvm.so(TVMFuncCall+0x48) [0x7fab500b8ca8]
-    [bt] (2) /path/to/tvm/build/libtvm.so(+0x1c4126) [0x7fab4f7f5126]
-    [bt] (1) /path/to/tvm/build/libtvm.so(+0x1ba35c) [0x7fab4f7eb35c]
-    [bt] (0) /path/to/tvm/build/libtvm.so(+0x177d12) [0x7fab4f7a8d12]
-    File "/path/to/tvm/src/api/api_test.cc", line 83
-  InternalError: cannot reach here
-  TVM hint: You hit an internal error. Please open a thread on https://discuss.tvm.ai/ to report it.
-
-As you can see in the above example, TVM's ffi system combines
-both the python and c++'s stacktrace into a single message, and generate the
-corresponding error class automatically.
+TVM's FFI system combines both the Python and C++ stacktraces into a single message,
+and generates the corresponding error class automatically.
 
 
 How to choose an Error Type

--- a/docs/contribute/pull_request.rst
+++ b/docs/contribute/pull_request.rst
@@ -39,25 +39,13 @@ Guidelines
 
     .. code:: bash
 
-      # While the lint commands used should be identical to those run in CI, this command reproduces
-      # the CI lint procedure exactly (typically helpful for debugging lint script errors or
-      # to avoid installing tools manually)
-      python tests/scripts/ci.py lint
+      # Run all lint checks via pre-commit hooks
+      pre-commit run --all-files
 
-      # Run all lint steps.
-      docker/lint.sh
-
-      # To run steps individually, specify their step names on the command-line. An incorrectly
-      # spelled step name causes the tool to print all available steps.
-      docker/lint.sh <step_name> ...
-
-    If the clang-format lint check fails, run git-clang-format as follows to automatically reformat
-    your code:
-
-    .. code:: bash
-
-      # Run clang-format check for all the files that changed since upstream/main
-      docker/bash.sh ci_lint ./tests/lint/git-clang-format.sh --rev upstream/main
+      # Run specific linters individually
+      pre-commit run ruff-check --all-files    # Python lint
+      pre-commit run ruff-format --all-files   # Python format
+      pre-commit run clang-format --all-files  # C++ format
 
 - Add test-cases to cover the new features or bugfix the patch introduces.
 - Document the code you wrote, see more at :ref:`doc_guide`
@@ -260,8 +248,8 @@ If you want to run all tests:
 
 .. code:: bash
 
-  # build tvm
-  make
+  # build tvm (see install-from-source for CMake build instructions)
+  cd build && cmake .. && cmake --build . --parallel $(nproc) && cd ..
 
   ./tests/scripts/task_python_unittest.sh
 
@@ -269,14 +257,11 @@ If you want to run a single test:
 
 .. code:: bash
 
-  # build tvm
-  make
-
   # let python know where to find tvm related libraries
   export PYTHONPATH=python
   rm -rf python/tvm/*.pyc python/tvm/*/*.pyc python/tvm/*/*/*.pyc
 
-  TVM_FFI=ctypes python -m pytest -v tests/python/unittest/test_pass_storage_rewrite.py
+  python -m pytest -v tests/python/tir-transform/test_tir_transform_storage_rewrite.py
 
   # Additionally if you want to run a single test, for example test_all_elemwise inside a file.
-  TVM_FFI=ctypes python -m pytest -v -k "test_all_elemwise" tests/python/frontend/tflite/test_forward.py
+  python -m pytest -v -k "test_all_elemwise" tests/python/frontend/tflite/test_forward.py

--- a/docs/how_to/tutorials/cross_compilation_and_rpc.py
+++ b/docs/how_to/tutorials/cross_compilation_and_rpc.py
@@ -52,7 +52,9 @@ and the Firefly-RK3399 for an OpenCL example.
 #
 #   git clone --recursive https://github.com/apache/tvm tvm
 #   cd tvm
-#   make runtime -j2
+#   mkdir build && cd build
+#   cp ../cmake/config.cmake .
+#   cmake .. && cmake --build . --parallel $(nproc)
 #
 # After building the runtime successfully, we need to set environment variables
 # in :code:`~/.bashrc` file. We can edit :code:`~/.bashrc`
@@ -215,9 +217,10 @@ print(f"{cost:g} secs/op")
 #
 # .. code-block:: bash
 #
-#    cp cmake/config.cmake .
+#    mkdir -p build && cd build
+#    cp ../cmake/config.cmake .
 #    sed -i "s/USE_OPENCL OFF/USE_OPENCL ON/" config.cmake
-#    make runtime -j4
+#    cmake .. && cmake --build . --parallel $(nproc)
 #
 # The following function shows how we run an OpenCL kernel remotely
 

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -40,7 +40,7 @@ Apache TVM requires the following dependencies:
     - Clang 5.0
     - Apple Clang 9.3
     - Visual Studio 2019 (v16.7)
-- Python (>= 3.8)
+- Python (>= 3.10)
 - (Optional) Conda (Strongly Recommended)
 
 System Dependencies (Non-Conda)
@@ -339,4 +339,4 @@ tests in TVM. The easiest way to install GTest is from source.
     make
     sudo make install
 
-After installing GTest, the C++ tests can be built and started with ``./tests/scripts/task_cpp_unittest.sh`` or just built with ``make cpptest``.
+After installing GTest, the C++ tests can be built and started with ``./tests/scripts/task_cpp_unittest.sh``, or built via CMake with ``-DUSE_GTEST=ON`` and then running ``./build/cpptest``.


### PR DESCRIPTION
  - Update Python version requirement from 3.7/3.8 to 3.10 in docs
  - Migrate lint commands from `docker/lint.sh` / `docker/bash.sh ci_lint` to `pre-commit` (#18807)
  - Replace `make` / `make runtime` with CMake commands (root Makefile removed in #18828)
  - Remove `dmlc::ThreadLocalStore` reference in pass_infra (dmlc phased out in #18779)
  - Update FFI header links in runtime.rst (`packed_func.h` → `tvm/ffi/function.h`)
  - Remove stale `tvm.testing.ErrorTest` example in error_handling.rst
  - Remove dead `apps/extension` link in runtime.rst