### PR TITLE
[Relax][Frontend][Torch] Fix squeeze to return no-op for non-unit dims

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -2133,18 +2133,34 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         if dim is None:
             dim = node.kwargs.get("dims", None)
 
-        # If dims is a list, filter out axes where dimension is not 1
-        # This is needed because PyTorch decomposition may pass all axes
+        shape = self.shape_of(x)
+        ndim = len(shape)
+
         if isinstance(dim, list | tuple) and len(dim) > 0:
-            shape = self.shape_of(x)
-            # Filter to only include axes where the dimension is 1
+            # PyTorch decomposition may pass all axes. Filter to only include axes
+            # where the dimension is statically known to be 1, or is symbolic (dynamic).
+            # Axes where the dimension is statically known to be != 1 are silently
+            # ignored, matching PyTorch's behavior.
             valid_dims = []
             for d in dim:
-                axis = d if d >= 0 else len(shape) + d
-                if axis < len(shape):
-                    valid_dims.append(d)
-            # If no valid dims, use None to squeeze all size-1 dimensions
-            dim = valid_dims if valid_dims else None
+                axis = d if d >= 0 else ndim + d
+                if 0 <= axis < ndim:
+                    dim_val = shape[axis]
+                    # Include axis if it's dynamic (not a static integer) or is size 1
+                    if not isinstance(dim_val, tir.IntImm) or dim_val.value == 1:
+                        valid_dims.append(d)
+            # If no axes will actually be squeezed, return the original tensor (PyTorch no-op)
+            if not valid_dims:
+                return x
+            dim = valid_dims
+        elif dim is not None:
+            # Single-dim case: mimic PyTorch behavior — if the dimension is statically
+            # known to not be 1, squeezing is a no-op, so return the original tensor.
+            axis = dim if dim >= 0 else ndim + dim
+            if 0 <= axis < ndim:
+                dim_val = shape[axis]
+                if isinstance(dim_val, tir.IntImm) and dim_val.value != 1:
+                    return x
 
         return self.block_builder.emit(relax.op.squeeze(x, dim))
 

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -5799,7 +5799,8 @@ def test_squeeze():
             R.Tensor((3, 4), dtype="float32")
         ):
             with R.dataflow():
-                lv: R.Tensor((3, 4), dtype="float32") = R.squeeze(input, axis=[0, 1, 2, 3])
+                # Only axes 1 and 3 have size 1; axes 0 (size 3) and 2 (size 4) are filtered out
+                lv: R.Tensor((3, 4), dtype="float32") = R.squeeze(input, axis=[1, 3])
                 gv: R.Tuple(R.Tensor((3, 4), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
@@ -5808,6 +5809,9 @@ def test_squeeze():
         def forward(self, input):
             return input.squeeze(2)
 
+    # When the specified dim is statically known to not be 1, the squeeze is a no-op
+    # in PyTorch. The frontend should return the original tensor without emitting a
+    # squeeze op. (Regression test for https://github.com/apache/tvm/issues/18442)
     @I.ir_module
     class Expected3:
         @R.function
@@ -5815,8 +5819,24 @@ def test_squeeze():
             R.Tensor((3, 1, 4, 1), dtype="float32")
         ):
             with R.dataflow():
-                lv: R.Tensor((3, 1, 4, 1), dtype="float32") = R.squeeze(inp_0, axis=[2])
-                gv: R.Tuple(R.Tensor((3, 1, 4, 1), dtype="float32")) = (lv,)
+                gv: R.Tuple(R.Tensor((3, 1, 4, 1), dtype="float32")) = (inp_0,)
+                R.output(gv)
+            return gv
+
+    # Issue #18442: squeeze on a dimension that is statically != 1 should be a no-op,
+    # matching PyTorch behavior, rather than raising an InternalError.
+    class Squeeze4(Module):
+        def forward(self, input):
+            return input.squeeze(1)
+
+    @I.ir_module
+    class Expected4:
+        @R.function
+        def main(inp_0: R.Tensor((32, 10, 5), dtype="float32")) -> R.Tuple(
+            R.Tensor((32, 10, 5), dtype="float32")
+        ):
+            with R.dataflow():
+                gv: R.Tuple(R.Tensor((32, 10, 5), dtype="float32")) = (inp_0,)
                 R.output(gv)
             return gv
 
@@ -5825,6 +5845,9 @@ def test_squeeze():
     verify_model(Squeeze1(), example_args, {}, Expected1)
     verify_model(Squeeze2(), example_args, {}, Expected2)
     verify_model(Squeeze3(), example_args, {}, Expected3)
+    verify_model(
+        Squeeze4(), (torch.randn(32, 10, 5, dtype=torch.float32),), {}, Expected4
+    )
 
 
 def test_stack():


### PR DESCRIPTION
### What problem does this PR solve?

Fixes #18442

When using `squeeze(dim)` with a dimension that is not size 1, PyTorch silently returns the original tensor unchanged (a no-op). The TVM Relax PyTorch frontend was not replicating this behavior — it forwarded `dim` unconditionally to `relax.op.squeeze`, which raised an `InternalError` in TVM ≤ 0.23 and still emits a redundant no-op squeeze op on the current main branch.

**Reproduction:**
\`\`\`python
import torch, torch.nn as nn
from tvm.relax.frontend.torch import from_exported_program

class SqueezeModel(nn.Module):
    def forward(self, x):
        return x.squeeze(1)  # dim=1 has size 10, not 1

x = torch.randn(32, 10, 5)
ep = torch.export.export(SqueezeModel().eval(), (x,))
mod = from_exported_program(ep)  # previously: InternalError
\`\`\`

Two bugs fixed in `BaseFXGraphImporter._squeeze`:
1. **Single-dim case**: no check on the actual dimension size before passing to `relax.op.squeeze`
2. **List/tuple dims case**: existing filter only checked array bounds, not whether each axis is actually size 1

**Fix**: for statically-known non-unit dimensions, return the input tensor directly. Dynamic/symbolic dimensions pass through conservatively as before.

### Tests

- `Squeeze2` (no-arg `squeeze()`): expected axis filter corrected from `[0,1,2,3]` to `[1,3]`
- `Squeeze3` (`squeeze(2)` on non-unit dim): now expects no squeeze op emitted
- `Squeeze4` (new): exact repro of #18442 — `squeeze(1)` on shape `(32,10,5)`

### Checklist
- [x] PR title starts with a category tag
- [x] All existing and new tests pass
- [x] Fixes a confirmed bug (linked issue: #18442)