### PR TITLE
[Relax][PyTorch] Support bare operator.add and operator.sub in PyTorch ExportedProgram frontend

### DIFF
--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -1506,6 +1506,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "triu.default": self._tril_triu(relax.op.triu),
             "trunc.default": self._unary_op(relax.op.trunc),
             # binary
+            "add": self._binary_op(relax.op.add, operator.add),
             "add.Tensor": self._binary_op(relax.op.add, operator.add),
             "add.Scalar": self._binary_op(relax.op.add, operator.add),
             "add_.Tensor": self._binary_op(relax.op.add, operator.add),
@@ -1560,6 +1561,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
             "pow.Scalar": self._binary_op(relax.op.power, operator.pow),
             "pow.Tensor_Scalar": self._binary_op(relax.op.power, operator.pow),
             "pow.Tensor_Tensor": self._binary_op(relax.op.power, operator.pow),
+            "sub": self._binary_op(relax.op.subtract, operator.sub),
             "sub.Tensor": self._binary_op(relax.op.subtract, operator.sub),
             "sub.Scalar": self._binary_op(relax.op.subtract, operator.sub),
             "__and__.Tensor": self._binary_op(relax.op.bitwise_and, operator.and_),

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -1654,7 +1654,57 @@ def test_binary3():
     verify_model(RSub2(), example_args2, {}, expected_rsub2)
 
 
-# IsIn
+def test_dynamic_shape_bare_add_sub():
+    """Test that bare 'add' and 'sub' ops (from operator.add/sub in dynamic shape arithmetic)."""
+
+    class AddModel(torch.nn.Module):
+        def forward(self, x):
+            # With dynamic shapes, torch.export may emit operator.add nodes
+            # for shape arithmetic. We test that the model imports successfully.
+            return x + x
+
+    class SubModel(torch.nn.Module):
+        def forward(self, x):
+            return x - x
+
+    @I.ir_module
+    class ExpectedAdd:
+        @R.function
+        def main(x: R.Tensor(("s0", 4), dtype="float32")) -> R.Tuple(
+            R.Tensor(("s0", 4), dtype="float32")
+        ):
+            s0 = T.int64(is_size_var=True)
+            R.func_attr({"tir_var_lower_bound": {"s77": 2}})
+            with R.dataflow():
+                lv: R.Tensor((s0, 4), dtype="float32") = R.add(x, x)
+                gv: R.Tuple(R.Tensor((s0, 4), dtype="float32")) = (lv,)
+                R.output(gv)
+            return gv
+
+    @I.ir_module
+    class ExpectedSub:
+        @R.function
+        def main(x: R.Tensor(("s0", 4), dtype="float32")) -> R.Tuple(
+            R.Tensor(("s0", 4), dtype="float32")
+        ):
+            s0 = T.int64(is_size_var=True)
+            R.func_attr({"tir_var_lower_bound": {"s77": 2}})
+            with R.dataflow():
+                lv: R.Tensor((s0, 4), dtype="float32") = R.subtract(x, x)
+                gv: R.Tuple(R.Tensor((s0, 4), dtype="float32")) = (lv,)
+                R.output(gv)
+            return gv
+
+    example_args = (torch.randn(8, 4),)
+    batch = torch.export.Dim("batch", min=2)
+    dynamic_shapes = {"x": {0: batch}}
+
+    verify_model(
+        AddModel(), example_args, {}, ExpectedAdd, dynamic_shapes=dynamic_shapes, map_free_vars=True
+    )
+    verify_model(
+        SubModel(), example_args, {}, ExpectedSub, dynamic_shapes=dynamic_shapes, map_free_vars=True
+    )
 
 
 def test_isin():


### PR DESCRIPTION
Added `"add"` and `"sub"` entries to the ExportedProgram frontend `convert_map`.

When `operator.add` or `operator.sub` appears in an FX graph, its `__name__` is `"add"` or `"sub"` (without suffix), which wasn't matched by existing entries like `"add.Tensor"`.