### PR TITLE
[Docs] Fix duplicate license headers and incorrect module paths after tirx rename

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,22 +15,6 @@
 <!--- specific language governing permissions and limitations -->
 <!--- under the License. -->
 
-<!--- or more contributor license agreements.  See the NOTICE file -->
-<!--- distributed with this work for additional information -->
-<!--- regarding copyright ownership.  The ASF licenses this file -->
-<!--- to you under the Apache License, Version 2.0 (the -->
-<!--- "License"); you may not use this file except in compliance -->
-<!--- with the License.  You may obtain a copy of the License at -->
-
-<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
-
-<!--- Unless required by applicable law or agreed to in writing, -->
-<!--- software distributed under the License is distributed on an -->
-<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
-<!--- KIND, either express or implied.  See the License for the -->
-<!--- specific language governing permissions and limitations -->
-<!--- under the License. -->
-
 # TVM Documentation
 
 This folder contains the source of TVM's documentation, hosted at https://tvm.apache.org/docs

--- a/docs/arch/index.rst
+++ b/docs/arch/index.rst
@@ -306,13 +306,13 @@ in the IRModule. Please refer to the :ref:`Relax Deep Dive <relax-deep-dive>` fo
 tvm/tirx
 --------
 
-tirx contains the definition of the low-level program representations. We use `tirx::PrimFunc` to represent functions that can be transformed by tirx passes.
+tirx contains the definition of the low-level program representations. We use ``tirx::PrimFunc`` to represent functions that can be transformed by tirx passes.
 Besides the IR data structures, the tirx module also includes:
 
-- A set of schedule primitives to control the generated code in ``tirx/schedule``.
-- A set of builtin intrinsics in ``tirx/tensor_intrin``.
 - A set of analysis passes to analyze the tirx functions in ``tirx/analysis``.
 - A set of transformation passes to lower or optimize the tirx functions in ``tirx/transform``.
+
+The schedule primitives and tensor intrinsics are in ``s_tir/schedule`` and ``s_tir/tensor_intrin`` respectively.
 
 Please refer to the :ref:`TensorIR Deep Dive <tensor-ir-deep-dive>` for more details.
 

--- a/docs/get_started/overview.rst
+++ b/docs/get_started/overview.rst
@@ -15,22 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.
-
 Overview
 ========
 


### PR DESCRIPTION
- Remove duplicate Apache license blocks in `docs/get_started/overview.rst` and `docs/README.md` introduced by #18913, which render as visible garbage text in built documentation                                                                             
- Fix incorrect `tirx/schedule` and `tirx/tensor_intrin` paths in `docs/arch/index.rst` — these modules are in `s_tir/`, not `tirx/` 