### PR TITLE
[Relax][ONNX] Add Optional and MatMulInteger16 frontend support

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -4431,7 +4431,18 @@ class ONNXGraphImporter:
                 self._check_for_unsupported_ops(graph)
                 self._construct_nodes(graph)
 
-                outputs = [self._nodes[self._parse_value_proto(i)] for i in graph.output]
+                # now return the outputs
+                output_names = [self._parse_value_proto(output) for output in graph.output]
+                outputs = []
+                for output_name in output_names:
+                    output_value = self._nodes[output_name]
+                    if _is_empty_optional(output_value):
+                        raise ValueError(
+                            "ONNX graph output "
+                            f"{output_name} is an empty optional. Empty optional graph outputs "
+                            "are not supported by the Relax ONNX frontend."
+                        )
+                    outputs.append(output_value)
                 outputs = outputs[0] if len(outputs) == 1 else relax.Tuple(outputs)
 
                 if has_if:
@@ -4630,8 +4641,6 @@ class ONNXGraphImporter:
                 raise err
 
             if op_name in return_tuple_ops:
-                outputs_num = 1
-            elif _is_empty_optional(op):
                 outputs_num = 1
             elif not isinstance(op, relax.Tuple):
                 if isinstance(op.struct_info, relax.TupleStructInfo):

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -3579,6 +3579,23 @@ def test_optional_without_input_requires_type_attr():
         from_onnx(model, opset=18, keep_params_in_input=True)
 
 
+def test_empty_optional_graph_output_raises():
+    tensor_type = helper.make_tensor_type_proto(TensorProto.FLOAT, [2, 3])
+    optional_type = helper.make_optional_type_proto(tensor_type)
+    optional_node = helper.make_node("Optional", [], ["optional"], type=tensor_type)
+    graph = helper.make_graph(
+        [optional_node],
+        "test_empty_optional_graph_output_raises",
+        inputs=[],
+        outputs=[helper.make_value_info("optional", optional_type)],
+    )
+    model = helper.make_model(graph, producer_name="test_empty_optional_graph_output_raises")
+    model.opset_import[0].version = 18
+
+    with pytest.raises(ValueError, match="Empty optional graph outputs are not supported"):
+        from_onnx(model, opset=18, keep_params_in_input=True)
+
+
 def test_optional_has_element_requires_one_input():
     has_element_node = helper.make_node("OptionalHasElement", [], ["output"])
     graph = helper.make_graph(


### PR DESCRIPTION
## Summary

This PR adds Relax ONNX frontend support for:
- `Optional`
- `OptionalHasElement`
- `OptionalGetElement`
- `MatMulInteger16` from the `com.microsoft` domain

The implementation follows existing TVM ONNX frontend patterns and keeps Optional handling explicit through an empty-Optional sentinel during import.

## Changes

- add ONNX frontend converters for `Optional`, `OptionalHasElement`, and `OptionalGetElement`
- add ONNX frontend converter for `MatMulInteger16`
- extend ONNX attribute parsing to handle `TYPE_PROTO`
- preserve empty Optional values during import and unwrap them consistently
- register Optional-related ops and `MatMulInteger16` in the ONNX converter map
- handle Optional outputs correctly in importer output counting and normalization
- tighten converter docstrings and input validation for better consistency with nearby TVM code

## Tests

Added or updated tests in `tests/python/relax/test_frontend_onnx.py` to cover:
- numerical correctness for `MatMulInteger16`
- structural IR checks for `MatMulInteger16`
- invalid dtype rejection for `MatMulInteger16`
- tensor and sequence Optional round-trips
- empty Optional behavior for `OptionalHasElement`
- structural IR checks ensuring Optional ops are erased as expected
- missing `type` attribute rejection for empty `Optional`
- empty `OptionalGetElement` rejection

## Validation

Validated with:
- `python -m ruff check python/tvm/relax/frontend/onnx/onnx_frontend.py tests/python/relax/test_frontend_onnx.py`
- `python -m pytest -n 1 tests/python/relax/test_frontend_onnx.py -k "optional or matmulinteger16" -v`

Result:
- `13 passed`

This PR completes the ONNX `MatMulInteger16` and `Optional` work tracked in https://github.com/apache/tvm/issues/18945.