### PR TITLE
[FIX] Inline ceil_log2 in gpu_2d_continuous_cumsum to fix MakePackedAPI error

### DIFF
--- a/python/tvm/relax/backend/gpu_generic/cumsum.py
+++ b/python/tvm/relax/backend/gpu_generic/cumsum.py
@@ -159,8 +159,7 @@ def gpu_2d_continuous_cumsum(
         A = T.match_buffer(var_a, [m, n], dtype=in_dtype)
         Out = T.match_buffer(var_out, [m, n], dtype=out_dtype)
         Tmp = T.alloc_buffer([m, n], dtype=out_dtype)
-        ceil_log2 = T.Cast("int64", T.ceil(T.log2(T.Cast("float32", n))))
-        total_rounds = ceil_log2 // LOG_BLOCK_N
+        total_rounds = T.Cast("int64", T.ceil(T.log2(T.Cast("float32", n)))) // LOG_BLOCK_N
 
         block_inclusive_inside_block(
             m, n, A, Out, Tmp, src_offset=T.int64(0), tmp_offset=T.int64(0)


### PR DESCRIPTION
## Summary
- The intermediate variable `ceil_log2` in `gpu_2d_continuous_cumsum` created a `LetStmt`-bound `Var` in the TIR function
- When `MakePackedAPI` processed the function, it reported `ceil_log2` as an undefined variable not passed as an API argument
- Inline the expression directly into `total_rounds` to avoid the intermediate `Var` — the computation is identical

## Test plan
- Compile a model that uses GPU sampling (e.g. any LLM with top-p sampling on Metal) and verify compilation succeeds
- The error this fixes: `Check failed: undefined.size() == 0: In PrimFunc gpu_2d_continuous_cumsum variables [ceil_log2] are used, but are not passed in as API arguments`