### PR TITLE
[WebGPU] Reserve additional keywords to avoid WGSL identifier collisions

### DIFF
--- a/src/target/source/codegen_webgpu.cc
+++ b/src/target/source/codegen_webgpu.cc
@@ -130,6 +130,13 @@ runtime::FunctionInfo CodeGenWebGPU::AddFunction(const PrimFunc& f, bool skip_re
   name_supply_->ReserveName("let");
   name_supply_->ReserveName("const");
   name_supply_->ReserveName("std");
+  name_supply_->ReserveName("storage");
+  name_supply_->ReserveName("uniform");
+  name_supply_->ReserveName("workgroup");
+  name_supply_->ReserveName("private");
+  name_supply_->ReserveName("function");
+  name_supply_->ReserveName("read");
+  name_supply_->ReserveName("read_write");
 
   // skip the first underscore, so SSA variable starts from
   name_supply_->FreshName("v_");


### PR DESCRIPTION
Compiling Qwen3.5 yielded WGSL of the following form: `var<storage, read_write> storage : array<f32>;
`. This led to a 'cyclic dependency' error due to the identifier collision. This PR reserves keywords such as storage to avoid parsing errors.