### PR TITLE
[Web] Pre-allocate TypedArray views for pod args in WebGPU dispatch

### DIFF
--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -698,8 +698,8 @@ export class WebGPUContext {
     });
 
     // Pre-allocate typed array views for pod args (reused across dispatches)
-    const maxPodArgs = podArgIndices.length + 1; // +1 for packDimX
-    const podArgBytes = maxPodArgs * Int32Array.BYTES_PER_ELEMENT;
+    const numPodSlots = podArgIndices.length + 1; // +1 for packDimX
+    const podArgBytes = numPodSlots * Int32Array.BYTES_PER_ELEMENT;
     const podArgsArrayBuffer = new ArrayBuffer(podArgBytes);
     const i32ViewCached = new Int32Array(podArgsArrayBuffer);
     const u32ViewCached = new Uint32Array(podArgsArrayBuffer);
@@ -779,6 +779,7 @@ export class WebGPUContext {
             throw Error("Unknown pod dtype " + dtype);
           }
         }
+        // Pass the original grid X dimension so the shader can recover blockIdx.x from the z-split
         u32ViewCached[podArgIndices.length] = packDimX;
         this.device.queue.writeBuffer(podArgBuffer, 0, podArgsArrayBuffer);
 


### PR DESCRIPTION
## Summary

- Hoists `Int32Array`/`Uint32Array`/`Float32Array` allocation out of the per-dispatch `submitShader` closure into the per-shader `createShaderFunc` scope, eliminating 3 typed array allocations + 1 `ArrayBuffer` per GPU kernel dispatch.
- `podArgIndices.length` is fixed per shader, so the cached views have the correct size for every invocation. Every slot `0..podArgIndices.length` is unconditionally written before `writeBuffer` copies the data out, so no stale values can leak between dispatches.
- Builds on top of the batched dispatch architecture from #18871 — the uniform buffer pool already gives each dispatch its own GPU-side buffer, so reusing the CPU-side staging array is safe.

## Motivation

In workloads with many small dispatches (e.g. LLM token generation), the per-dispatch typed array allocations become a measurable source of GC pressure. Pre-allocating and reusing the views avoids this overhead.

## Test plan

- [ ] Verify `npm run lint` passes in `web/`
- [ ] Run WebGPU model inference (e.g. via MLC-LLM web demo) and confirm correct output
- [ ] Profile dispatch-heavy workload to confirm reduced allocation rate