### PR TITLE
[Relax][ONNX] Support Resize dynamic ROI via TOPI

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -2643,6 +2643,19 @@ def _onnx_resize_spatial_roi_vector(roi_full: relax.Expr, rank: int) -> relax.Ex
     )
 
 
+def _topi_resize3d_roi_from_onnx_ncdhw_spatial(roi_spatial: list[float]) -> list[float]:
+    """Reorder spatial ROI for NCDHW ONNX layout to TOPI resize3d convention.
+
+    ONNX spatial slice after dropping N/C is ordered (D, H, W) for starts then ends.
+    TOPI ``resize3d`` with layout NCDHW expects
+    ``(start_w, start_h, start_d, end_w, end_h, end_d)`` (see topi/image/resize.py).
+    """
+    if len(roi_spatial) != 6:
+        return roi_spatial
+    d0, h0, w0, d1, h1, w1 = roi_spatial
+    return [w0, h0, d0, w1, h1, d1]
+
+
 def _emit_resize_topi_dynamic_roi(
     bb: relax.BlockBuilder,
     data: relax.Expr,
@@ -2694,9 +2707,10 @@ def _emit_resize_topi_dynamic_roi(
         return bb.emit_te(resize2d_dyn, data, roi_spatial_vec, sizes_spatial[0], sizes_spatial[1])
 
     def resize3d_dyn(d, r, s0, s1, s2):
+        # r is ONNX order (D,H,W) x2; TOPI expects (W,H,D) x2.
         return topi.image.resize3d(
             d,
-            (r[0], r[1], r[2], r[3], r[4], r[5]),
+            (r[2], r[1], r[0], r[5], r[4], r[3]),
             (s0, s1, s2),
             layout="NCDHW",
             method=topi_mode,
@@ -2780,7 +2794,7 @@ class Resize(OnnxOpConverter):
             elif isinstance(scales, relax.expr.ShapeExpr):
                 scales = [int(val.value) for val in scales.values]
             else:
-                assert f"Type {type(scales)} for scale is currently unsupported."
+                raise ValueError(f"Type {type(scales)} for scale is currently unsupported.")
             sizes = []
 
             for i, dim in enumerate(x.struct_info.shape):
@@ -2792,7 +2806,7 @@ class Resize(OnnxOpConverter):
             elif isinstance(sizes, relax.expr.ShapeExpr):
                 sizes = [int(val.value) for val in sizes.values][2:]
             else:
-                assert f"Type {type(sizes)} for size is currently unsupported."
+                raise ValueError(f"Type {type(sizes)} for size is currently unsupported.")
 
         if use_dynamic_roi:
             return _emit_resize_topi_dynamic_roi(
@@ -2837,10 +2851,11 @@ class Resize(OnnxOpConverter):
                 extrapolation_value=extrapolation_value,
             )
         else:  # ndims == 5
+            roi3d = _topi_resize3d_roi_from_onnx_ncdhw_spatial(roi_static)
             return relax.op.image.resize3d(
                 x,
                 size=relax.ShapeExpr(sizes),
-                roi=roi_static,
+                roi=roi3d,
                 layout="NCDHW",
                 method=relax_mode,
                 coordinate_transformation_mode=coord_mode,

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -3295,6 +3295,37 @@ def test_resize_dynamic_roi_tf_crop_and_resize():
     check_correctness(model, atol=1e-5)
 
 
+def test_resize_dynamic_roi_3d_tf_crop_and_resize():
+    """5-D NCDHW: ROI is a graph input; covers dynamic-ROI TOPI resize3d path."""
+    resize_node = helper.make_node(
+        "Resize",
+        ["X", "roi", "scales"],
+        ["Y"],
+        mode="linear",
+        coordinate_transformation_mode="tf_crop_and_resize",
+    )
+    graph = helper.make_graph(
+        [resize_node],
+        "resize_dynamic_roi_3d",
+        inputs=[
+            helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 1, 3, 4, 5]),
+            helper.make_tensor_value_info("roi", TensorProto.FLOAT, [10]),
+        ],
+        initializer=[
+            helper.make_tensor("scales", TensorProto.FLOAT, [5], [1.0, 1.0, 2.0, 2.0, 2.0]),
+        ],
+        outputs=[
+            helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 1, 6, 8, 10]),
+        ],
+    )
+    model = helper.make_model(graph, producer_name="resize_dynamic_roi_3d")
+    # Use a valid full-tensor ROI so ORT and TOPI agree on tf_crop_and_resize (random ROI
+    # can hit extrapolation / numerical differences across runtimes).
+    x_np = rg.standard_normal((1, 1, 3, 4, 5)).astype(np.float32)
+    roi_np = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1], dtype=np.float32)
+    check_correctness(model, opset=18, atol=1e-5, inputs={"X": x_np, "roi": roi_np})
+
+
 def test_resize_nd_sizes():
     cases = [
         ("resize1d", [1, 1, 4], [1, 1, 7]),


### PR DESCRIPTION
The ONNX Resize converter previously rejected non-constant ROI inputs, which blocked models where ROI is provided at runtime. This change adds a dynamic-ROI path lowered through TOPI resize kernels while preserving the existing relax.image.resize* path for static ROI.

Specifically:
- add reusable helper to convert ONNX full ROI ([starts..., ends...]) into spatial ROI vector
- add reusable helper to emit topi.image.resize1d/2d/3d for dynamic ROI
- keep static ROI fast path for relax.image.resize2d/resize3d
- normalize dynamic ROI expr before emit_te to ensure struct_info is populated
- handle optional Resize inputs (roi/scales/sizes) more defensively
- add frontend test coverage with graph-input ROI: test_resize_dynamic_roi_tf_crop_and_resize

Ref: apache/tvm#18945