### PR TITLE
[Web] Fix static init order in WASM runtime to prevent GetKwargsObject crash

### DIFF
--- a/web/emcc/wasm_runtime.cc
+++ b/web/emcc/wasm_runtime.cc
@@ -33,6 +33,26 @@
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/runtime/logging.h>
 
+// FFI core must come first: object.cc registers ffi.GetKwargsObject which is
+// needed by ObjectDef destructors (AutoRegisterInit) in later translation units.
+// Without this ordering, WASM static initialization fails because constructor
+// functions run in source order within a single compilation unit.
+#include "3rdparty/tvm-ffi/src/ffi/backtrace.cc"
+#include "3rdparty/tvm-ffi/src/ffi/container.cc"
+#include "3rdparty/tvm-ffi/src/ffi/dtype.cc"
+#include "3rdparty/tvm-ffi/src/ffi/error.cc"
+#include "3rdparty/tvm-ffi/src/ffi/function.cc"
+#include "3rdparty/tvm-ffi/src/ffi/object.cc"
+#include "3rdparty/tvm-ffi/src/ffi/tensor.cc"
+#include "3rdparty/tvm-ffi/src/ffi/extra/env_c_api.cc"
+#include "3rdparty/tvm-ffi/src/ffi/extra/env_context.cc"
+#include "3rdparty/tvm-ffi/src/ffi/extra/json_parser.cc"
+#include "3rdparty/tvm-ffi/src/ffi/extra/json_writer.cc"
+#include "3rdparty/tvm-ffi/src/ffi/extra/library_module.cc"
+#include "3rdparty/tvm-ffi/src/ffi/extra/library_module_system_lib.cc"
+#include "3rdparty/tvm-ffi/src/ffi/extra/module.cc"
+#include "3rdparty/tvm-ffi/src/ffi/testing/testing.cc"
+// Runtime files (some use ObjectDef whose destructor depends on ffi.GetKwargsObject)
 #include "src/runtime/contrib/sort/sort.cc"
 #include "src/runtime/cpu_device_api.cc"
 #include "src/runtime/device_api.cc"
@@ -47,22 +67,6 @@
 #include "src/runtime/rpc/rpc_session.cc"
 #include "src/runtime/tensor.cc"
 #include "src/runtime/workspace_pool.cc"
-// relax setup
-#include "3rdparty/tvm-ffi/src/ffi/backtrace.cc"
-#include "3rdparty/tvm-ffi/src/ffi/container.cc"
-#include "3rdparty/tvm-ffi/src/ffi/dtype.cc"
-#include "3rdparty/tvm-ffi/src/ffi/error.cc"
-#include "3rdparty/tvm-ffi/src/ffi/extra/env_c_api.cc"
-#include "3rdparty/tvm-ffi/src/ffi/extra/env_context.cc"
-#include "3rdparty/tvm-ffi/src/ffi/extra/json_parser.cc"
-#include "3rdparty/tvm-ffi/src/ffi/extra/json_writer.cc"
-#include "3rdparty/tvm-ffi/src/ffi/extra/library_module.cc"
-#include "3rdparty/tvm-ffi/src/ffi/extra/library_module_system_lib.cc"
-#include "3rdparty/tvm-ffi/src/ffi/extra/module.cc"
-#include "3rdparty/tvm-ffi/src/ffi/function.cc"
-#include "3rdparty/tvm-ffi/src/ffi/object.cc"
-#include "3rdparty/tvm-ffi/src/ffi/tensor.cc"
-#include "3rdparty/tvm-ffi/src/ffi/testing/testing.cc"
 #include "src/runtime/memory/memory_manager.cc"
 #include "src/runtime/nvtx.cc"
 #include "src/runtime/vm/attn_backend.cc"


### PR DESCRIPTION
## Summary

After tvm-ffi v0.1.9 (`6b39efb`), `ObjectDef::~ObjectDef()` calls `AutoRegisterInit()` which eagerly resolves `ffi.GetKwargsObject` via `GetGlobalRequired()`. In the WASM build, all `.cc` files are `#include`'d into a single translation unit (`wasm_runtime.cc`), so `__attribute__((constructor))` functions run in deterministic source order.

Runtime files like `file_utils.cc`, `profiling.cc`, and `rpc_session.cc` (which use `ObjectDef` in their static init blocks) were included **before** `object.cc` (which registers `ffi.GetKwargsObject`). This caused a fatal `ValueError: Function ffi.GetKwargsObject not found` during WASM `_initialize`, crashing before the module could load.

**Fix:** Move all tvm-ffi core includes before the runtime files so that `ffi.GetKwargsObject` is registered before any `ObjectDef` destructor needs it.

## Error reproduced

```
ValueError: Function ffi.GetKwargsObject not found
  at $_initialize
  at callMain
  at doRun
```

This affects all WebGPU model compilation since the tvm-ffi bump in #18938.

## Test plan

- [x] Compiled Qwen3.5-4B model to WASM with the reordered includes
- [x] Verified WASM loads and runs correctly in browser via web-llm