### PR TITLE
[BugFix][TOPI] Fix get_const_tuple hanging indefinitely when passed a te.Tensor

### DIFF
--- a/python/tvm/topi/utils.py
+++ b/python/tvm/topi/utils.py
@@ -186,6 +186,11 @@ def get_const_tuple(in_tuple):
     out_tuple : tuple of int
         The output.
     """
+    if isinstance(in_tuple, te.tensor.Tensor):
+        raise TypeError(
+            f"get_const_tuple expects a tuple-like shape (e.g., tensor.shape), "
+            f"but got a te.Tensor. Did you mean get_const_tuple(tensor.shape)?"
+        )
     ret = []
     ana = None
     for elem in in_tuple:


### PR DESCRIPTION
This pr fixes #18765: `topi.get_const_tuple` hangs indefinitely when passed a `te.Tensor` instead  of a shape tuple and adds a type check to raise a clear `TypeError` with a helpful message suggesting `get_const_tuple(tensor.shape)` instead   