### PR TITLE
[BugFix][TIRx] Fix VerifyMemory crash for PrimFuncs without target attribute

### DIFF
--- a/src/tirx/analysis/verify_memory.cc
+++ b/src/tirx/analysis/verify_memory.cc
@@ -168,7 +168,9 @@ class MemoryAccessVerifier final : protected StmtExprVisitor {
 /// Interface of VerifyMemory pass
 std::vector<ffi::String> VerifyMemory_(const PrimFunc& func) {
   auto target = func->GetAttr<Target>(tvm::attr::kTarget);
-  TVM_FFI_ICHECK(target.defined()) << "VerifyMemory: Require the target attribute";
+  // Skip verification for functions without a target attribute, as they are
+  // typically host-only helper functions that do not have device-memory constraints.
+  if (!target.defined()) return {};
 
   VLOG(1) << "verifying memory for target '" << target.value()->str()
           << "' for primitive:" << std::endl


### PR DESCRIPTION
## Problem

`VerifyMemory_` called `TVM_FFI_ICHECK(target.defined())` unconditionally. When Relax lowers a model it generates host-side helper PrimFuncs (e.g. for `reshape`, `mean`) that carry no `kTarget` attribute. These functions hit the ICHECK and abort:

```
Check failed: (target.defined()) is false: Require the target attribute
```

This surfaces whenever `tvm.compile` is called on a Relax module targeting CUDA, because the Relax lowering pipeline produces target-less CPU helper functions alongside the GPU kernels.

## Fix

Return `{}` (no errors) when `target` is absent. This is semantically correct: `MemoryAccessVerifier::Run()` is already gated on `IsGPUDevice(dev_type_)`, so host-only functions carry no GPU memory access constraints and require no verification. The same early-exit pattern is already used for non-default calling conventions (line 184–186).