### PR TITLE
[Docs] Add PyModule tutorial to How-To toctree

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,7 @@ driving its costs down.
    how_to/tutorials/optimize_llm
    how_to/tutorials/cross_compilation_and_rpc
    how_to/tutorials/export_and_load_executable
+   how_to/tutorials/mix_python_and_tvm_with_pymodule
    how_to/dev/index
 
 .. The Deep Dive content is comprehensive


### PR DESCRIPTION
as per title, fixing with add a new link