### PR TITLE
[relax] fix 'occured' -> 'occurred' in transform.h doc comment

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -675,7 +675,7 @@ TVM_DLL Pass RewriteCUDAGraph();
 
 /*!
  * \brief This pass updates the var_buffer mapping of PrimFunctions from the call_tir info.
- * Primarily used to update the VDevice information if any changes occured from the caller.
+ * Primarily used to update the VDevice information if any changes occurred from the caller.
  * This pass recreates the buffers and updates the map.
  */
 TVM_DLL Pass SpecializePrimFuncBasedOnCallSite();


### PR DESCRIPTION
Doc comment in `include/tvm/relax/transform.h` line 678 reads `any changes occured from`. Fixed to `occurred`. Comment-only change.