### PR TITLE
[Docs] Fix stale tvm.tirx exclude list and add missing legalize_ops.unary entry

### DIFF
--- a/docs/reference/api/python/relax/transform.rst
+++ b/docs/reference/api/python/relax/transform.rst
@@ -112,6 +112,12 @@ tvm.relax.transform.legalize_ops.statistical
    :members:
    :no-index:
 
+tvm.relax.transform.legalize_ops.unary
+=======================================
+.. automodule:: tvm.relax.transform.legalize_ops.unary
+   :members:
+   :no-index:
+
 tvm.relax.transform.legalize_ops.vision
 ========================================
 .. automodule:: tvm.relax.transform.legalize_ops.vision

--- a/docs/reference/api/python/tirx/tirx.rst
+++ b/docs/reference/api/python/tirx/tirx.rst
@@ -20,4 +20,4 @@ tvm.tirx
 .. automodule:: tvm.tirx
    :members:
    :imported-members:
-   :exclude-members: PrimExpr, const, StmtSRef, SBlockScope, ScheduleState, Schedule, ScheduleError
+   :exclude-members: PrimExpr, const


### PR DESCRIPTION
as per title