### PR TITLE
[WebGPU] Fix UI jank caused by compositor starvation in batched dispatch

### DIFF
--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -423,6 +423,7 @@ export class WebGPUContext {
   private uniformBufferPool: Array<GPUBuffer> = [];
   private uniformBufferPoolSizes: Array<number> = [];
   private pendingDispatchCount = 0;
+  maxDispatchesPerFlush = 32;
   // flags for debugging
   // stats of the runtime.
   // peak allocation
@@ -798,6 +799,11 @@ export class WebGPUContext {
 
         compute.dispatchWorkgroups(workDim[0], workDim[1], workDim[2]);
         compute.end();
+
+        if (this.maxDispatchesPerFlush > 0 &&
+            this.pendingDispatchCount >= this.maxDispatchesPerFlush) {
+          this.flushCommands();
+        }
 
         // In debug mode, flush immediately so we can observe each submission.
         if (this.debugLogFinish) {

--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -800,7 +800,7 @@ export class WebGPUContext {
         compute.dispatchWorkgroups(workDim[0], workDim[1], workDim[2]);
         compute.end();
 
-        if (this.maxDispatchesPerFlush > 0 &&
+        if (this.maxDispatchesPerFlush <= 0 ||
             this.pendingDispatchCount >= this.maxDispatchesPerFlush) {
           this.flushCommands();
         }


### PR DESCRIPTION
Batching all dispatches into a single command buffer (introduced in #18871) blocks the browser compositor from interleaving its rendering work, causing visible frame drops and laggy scrolling during LLM inference. This adds a `maxDispatchesPerFlush` field (default 32) to `WebGPUContext` that flushes the encoder periodically, giving the compositor regular breathing room while preserving most of the batching throughput gains. Setting it to 0 restores the old per-dispatch behavior. Fixes #19342