### PR TITLE
[FIX] Skip metal target tag registration for unsupported LLVM CPUs

### DIFF
--- a/python/tvm/target/codegen.py
+++ b/python/tvm/target/codegen.py
@@ -229,6 +229,24 @@ def llvm_get_vector_width(target=None):
     return _ffi_api.llvm_get_vector_width(target)
 
 
+def llvm_is_valid_cpu(cpu, triple):
+    """Check if a CPU name is valid for the given LLVM triple.
+
+    Parameters
+    ----------
+    cpu : str
+        The CPU name to check (e.g. "apple-m1").
+    triple : str
+        The LLVM target triple (e.g. "arm64-apple-macos").
+
+    Returns
+    -------
+    is_valid : bool
+        True if the CPU name is recognized by LLVM for the given triple.
+    """
+    return _ffi_api.llvm_is_valid_cpu(cpu, triple)
+
+
 def llvm_version_major(allow_none=False):
     """Get the major LLVM version.
 

--- a/python/tvm/target/tag_registry/metal.py
+++ b/python/tvm/target/tag_registry/metal.py
@@ -18,8 +18,17 @@
 
 from .registry import register_tag
 
+_METAL_HOST_TRIPLE = "arm64-apple-macos"
+
 
 def _register_metal_tag(name, max_threads, shared_mem, warp_size, mcpu):
+    try:
+        from ..codegen import llvm_is_valid_cpu
+
+        if not llvm_is_valid_cpu(mcpu, _METAL_HOST_TRIPLE):
+            return
+    except Exception:  # pylint: disable=broad-except
+        pass  # LLVM not available; register unconditionally
     register_tag(
         name,
         {
@@ -29,7 +38,7 @@ def _register_metal_tag(name, max_threads, shared_mem, warp_size, mcpu):
             "thread_warp_size": warp_size,
             "host": {
                 "kind": "llvm",
-                "mtriple": "arm64-apple-macos",
+                "mtriple": _METAL_HOST_TRIPLE,
                 "mcpu": mcpu,
             },
         },

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -743,6 +743,15 @@ static void LLVMReflectionRegister() {
              LLVMTargetInfo llvm_target(*llvm_instance, use_target);
              return llvm_target.TargetHasCPUFeature(feature);
            })
+      .def("target.llvm_is_valid_cpu",
+           [](ffi::String cpu, ffi::String triple) -> bool {
+             auto llvm_instance = std::make_unique<LLVMInstance>();
+             ffi::Map<ffi::String, ffi::Any> target_map;
+             target_map.Set("kind", ffi::String("llvm"));
+             target_map.Set("mtriple", triple);
+             LLVMTargetInfo llvm_backend(*llvm_instance, target_map);
+             return llvm_backend.IsValidCPU(std::string(cpu));
+           })
       .def("target.llvm_version_major", []() -> int { return TVM_LLVM_VERSION / 10; })
       .def("ffi.Module.load_from_file.ll",
            [](std::string filename, std::string fmt) -> ffi::Module {

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -749,7 +749,7 @@ static void LLVMReflectionRegister() {
              ffi::Map<ffi::String, ffi::Any> target_map;
              target_map.Set("kind", ffi::String("llvm"));
              target_map.Set("mtriple", triple);
-             LLVMTargetInfo llvm_backend(*llvm_instance, target_map);
+             LLVMTargetInfo llvm_backend(*llvm_instance, Target(target_map));
              return llvm_backend.IsValidCPU(std::string(cpu));
            })
       .def("target.llvm_version_major", []() -> int { return TVM_LLVM_VERSION / 10; })


### PR DESCRIPTION
## Summary

- Add `target.llvm_is_valid_cpu(cpu, triple)` FFI function to check if a CPU name is recognized by the installed LLVM version
- Guard metal target tag registration with CPU validity check
- Silently skip tags with unrecognized CPUs instead of emitting `LOG(ERROR)` on every import

## Motivation

On LLVM 15, `import tvm` emits a noisy error:
```
Error: Using LLVM 15.0.7 with -mcpu=apple-m2 is not valid in -mtriple=arm64-apple-macos
```
This happens because `_register_metal_tag` registers `apple/m2-gpu` with `mcpu=apple-m2`, which LLVM 15 doesn't recognize.

## Changes

- `src/target/llvm/llvm_module.cc` -- Register `target.llvm_is_valid_cpu` in `LLVMReflectionRegister()`
- `python/tvm/target/codegen.py` -- Add `llvm_is_valid_cpu()` Python wrapper
- `python/tvm/target/tag_registry/metal.py` -- Skip registration for invalid CPUs

## Test plan

- [x] `import tvm` produces no LOG(ERROR) about invalid CPU
- [x] On LLVM 15: apple-m1 valid, apple-m2 invalid (silently skipped)
- [x] Metal tags registered: apple/m1-gpu, apple/m1-gpu-restricted
- [x] pre-commit passes