### PR TITLE
[Relax][FRONTEND][ONNX] Support Softmax, LogSoftmax and Hardmax when opset version ≤12

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -804,6 +804,10 @@ class Softmax(OnnxOpConverter):
         axis = attr.get("axis", 1)
         prepared = _legacy_softmax_prepare(inputs[0], axis, "Softmax")
         if prepared is None:
+            warnings.warn(
+                "Softmax opset<=12 fallback: static rank/shape is unavailable, "
+                "falling back to axis-based softmax semantics."
+            )
             return relax.op.nn.softmax(inputs[0], axis=axis)
 
         flattened, original_shape = prepared
@@ -826,6 +830,10 @@ class LogSoftmax(OnnxOpConverter):
         axis = attr.get("axis", 1)
         prepared = _legacy_softmax_prepare(inputs[0], axis, "LogSoftmax")
         if prepared is None:
+            warnings.warn(
+                "LogSoftmax opset<=12 fallback: static rank/shape is unavailable, "
+                "falling back to axis-based log_softmax semantics."
+            )
             return relax.op.nn.log_softmax(inputs[0], axis=axis)
 
         flattened, original_shape = prepared
@@ -857,6 +865,10 @@ class Hardmax(OnnxOpConverter):
         axis = attr.get("axis", 1)
         prepared = _legacy_softmax_prepare(inputs[0], axis, "Hardmax")
         if prepared is None:
+            warnings.warn(
+                "Hardmax opset<=12 fallback: static rank/shape is unavailable, "
+                "falling back to axis-based hardmax semantics."
+            )
             return cls._hardmax_impl(inputs[0], axis)
 
         flattened, original_shape = prepared

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -721,8 +721,96 @@ class Sigmoid(OnnxOpConverter):
         return relax.op.sigmoid(inputs[0])
 
 
+def _normalize_legacy_softmax_axis(axis: int, rank: int, op_name: str) -> int:
+    """Normalize axis for ONNX Softmax/LogSoftmax/Hardmax opset <= 12 semantics.
+
+    Legacy semantics allow axis in [-rank, rank], where axis == rank means the
+    last dimension after flattening has extent 1.
+    """
+
+    if axis < -rank or axis > rank:
+        raise ValueError(f"{op_name} axis {axis} is out of range for rank {rank}.")
+    if axis < 0:
+        axis += rank
+    return axis
+
+
+def _shape_product(dims: list[int | tirx.PrimExpr]) -> int | tirx.PrimExpr:
+    """Compute product of a list of shape dims (supports symbolic dims)."""
+
+    prod = 1
+    for dim in dims:
+        if isinstance(dim, tirx.IntImm):
+            dim = int(dim.value)
+        prod = prod * dim
+    return prod
+
+
+def _legacy_softmax_prepare(
+    data: relax.Expr, axis: int, op_name: str
+) -> tuple[relax.Expr, tuple[int | tirx.PrimExpr, ...]] | None:
+    """Build legacy 2D view for Softmax-family opset <= 12 semantics.
+
+    Returns (reshaped_data, original_shape). If rank/shape isn't statically
+    available, returns None so caller can choose a permissive fallback.
+    """
+
+    rank = _get_known_tensor_rank(data)
+    if rank is None:
+        return None
+
+    axis = _normalize_legacy_softmax_axis(axis, rank, op_name)
+    struct_info = data.struct_info
+    if not isinstance(struct_info, relax.TensorStructInfo):
+        return None
+    if not isinstance(struct_info.shape, relax.ShapeExpr):
+        return None
+
+    original_shape = list(struct_info.shape.values)
+    if len(original_shape) != rank:
+        return None
+
+    dim0 = _shape_product(original_shape[:axis])
+    dim1 = _shape_product(original_shape[axis:])
+    flattened = relax.op.reshape(data, (dim0, dim1))
+    return flattened, tuple(original_shape)
+
+
+def _get_axis_extent(
+    data: relax.Expr, axis: int, op_name: str
+) -> tuple[int, int | tirx.PrimExpr]:
+    """Return normalized axis and axis extent when rank/shape are known."""
+
+    rank = _get_known_tensor_rank(data)
+    if rank is None:
+        raise ValueError(f"{op_name} requires a statically known input rank.")
+
+    normalized_axis = _normalize_constant_axes([axis], rank, op_name)[0]
+    struct_info = data.struct_info
+    if isinstance(struct_info, relax.TensorStructInfo) and isinstance(struct_info.shape, relax.ShapeExpr):
+        axis_extent = struct_info.shape.values[normalized_axis]
+        if isinstance(axis_extent, tirx.IntImm):
+            axis_extent = int(axis_extent.value)
+        return normalized_axis, axis_extent
+
+    raise ValueError(f"{op_name} requires a statically known axis extent.")
+
+
 class Softmax(OnnxOpConverter):
     """Converts an onnx Softmax node into an equivalent Relax expression."""
+
+    @classmethod
+    def _impl_v1(cls, bb, inputs, attr, params):
+        axis = attr.get("axis", 1)
+        prepared = _legacy_softmax_prepare(inputs[0], axis, "Softmax")
+        if prepared is None:
+            return relax.op.nn.softmax(inputs[0], axis=axis)
+
+        flattened, original_shape = prepared
+        out = relax.op.nn.softmax(flattened, axis=-1)
+        return relax.op.reshape(out, original_shape)
+
+    _impl_v11 = _impl_v1
 
     @classmethod
     def _impl_v13(cls, bb, inputs, attr, params):
@@ -734,6 +822,19 @@ class LogSoftmax(OnnxOpConverter):
     """Converts an onnx LogSoftmax node into an equivalent Relax expression."""
 
     @classmethod
+    def _impl_v1(cls, bb, inputs, attr, params):
+        axis = attr.get("axis", 1)
+        prepared = _legacy_softmax_prepare(inputs[0], axis, "LogSoftmax")
+        if prepared is None:
+            return relax.op.nn.log_softmax(inputs[0], axis=axis)
+
+        flattened, original_shape = prepared
+        out = relax.op.nn.log_softmax(flattened, axis=-1)
+        return relax.op.reshape(out, original_shape)
+
+    _impl_v11 = _impl_v1
+
+    @classmethod
     def _impl_v13(cls, bb, inputs, attr, params):
         axis = attr.get("axis", -1)
         return relax.op.nn.log_softmax(inputs[0], axis=axis)
@@ -743,17 +844,31 @@ class Hardmax(OnnxOpConverter):
     """Converts an onnx Hardmax node into an equivalent Relax expression."""
 
     @classmethod
-    def _impl_v13(cls, bb, inputs, attr, params):
-        axis = attr.get("axis", -1)
-        indices = inputs[0]
-        dtype = indices.struct_info.dtype
-        axis_len = int(inputs[0].struct_info.shape[axis])
-        argmax = relax.op.argmax(indices, axis=axis)
+    def _hardmax_impl(cls, data: relax.Expr, axis: int):
+        normalized_axis, axis_extent = _get_axis_extent(data, axis, "Hardmax")
+        dtype = data.struct_info.dtype
+        argmax = relax.op.argmax(data, axis=normalized_axis)
         on_value = relax.PrimValue(tvm.tirx.const(1.0, dtype))
         off_value = relax.PrimValue(tvm.tirx.const(0.0, dtype))
+        return relax.op.one_hot(argmax, on_value, off_value, axis_extent, normalized_axis)
 
-        one_hot = relax.op.one_hot(argmax, on_value, off_value, axis_len, axis)
-        return one_hot
+    @classmethod
+    def _impl_v1(cls, bb, inputs, attr, params):
+        axis = attr.get("axis", 1)
+        prepared = _legacy_softmax_prepare(inputs[0], axis, "Hardmax")
+        if prepared is None:
+            return cls._hardmax_impl(inputs[0], axis)
+
+        flattened, original_shape = prepared
+        out = cls._hardmax_impl(flattened, -1)
+        return relax.op.reshape(out, original_shape)
+
+    _impl_v11 = _impl_v1
+
+    @classmethod
+    def _impl_v13(cls, bb, inputs, attr, params):
+        axis = attr.get("axis", -1)
+        return cls._hardmax_impl(inputs[0], axis)
 
 
 class Transpose(OnnxOpConverter):

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -852,7 +852,23 @@ class Hardmax(OnnxOpConverter):
     """Converts an onnx Hardmax node into an equivalent Relax expression."""
 
     @classmethod
-    def _hardmax_impl(cls, bb: relax.BlockBuilder | None, data: relax.Expr, axis: int):
+    def _hardmax_impl(cls, *args):
+        """Hardmax core implementation.
+
+        Compatibility note:
+        - New signature: _hardmax_impl(bb, data, axis)
+        - Legacy signature: _hardmax_impl(data, axis)
+        """
+        if len(args) == 3:
+            bb, data, axis = args
+        elif len(args) == 2:
+            bb = None
+            data, axis = args
+        else:
+            raise TypeError(
+                "Hardmax._hardmax_impl expects (bb, data, axis) or (data, axis)."
+            )
+
         if bb is not None:
             data = bb.normalize(data)
         normalized_axis, axis_extent = _get_axis_extent(data, axis, "Hardmax")
@@ -871,18 +887,22 @@ class Hardmax(OnnxOpConverter):
                 "Hardmax opset<=12 fallback: static rank/shape is unavailable, "
                 "falling back to axis-based hardmax semantics."
             )
-            return cls._hardmax_impl(inputs[0], axis)
+            hardmax_input = inputs[0]
+            hardmax_axis = axis
+            original_shape = None
+        else:
+            hardmax_input, original_shape = prepared
+            hardmax_axis = -1
 
-        flattened, original_shape = prepared
-        out = cls._hardmax_impl(flattened, -1)
-        return relax.op.reshape(out, original_shape)
+        out = cls._hardmax_impl(bb, hardmax_input, hardmax_axis)
+        return out if original_shape is None else relax.op.reshape(out, original_shape)
 
     _impl_v11 = _impl_v1
 
     @classmethod
     def _impl_v13(cls, bb, inputs, attr, params):
         axis = attr.get("axis", -1)
-        return cls._hardmax_impl(inputs[0], axis)
+        return cls._hardmax_impl(bb, inputs[0], axis)
 
 
 class Transpose(OnnxOpConverter):

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -852,7 +852,9 @@ class Hardmax(OnnxOpConverter):
     """Converts an onnx Hardmax node into an equivalent Relax expression."""
 
     @classmethod
-    def _hardmax_impl(cls, data: relax.Expr, axis: int):
+    def _hardmax_impl(cls, bb: relax.BlockBuilder | None, data: relax.Expr, axis: int):
+        if bb is not None:
+            data = bb.normalize(data)
         normalized_axis, axis_extent = _get_axis_extent(data, axis, "Hardmax")
         dtype = data.struct_info.dtype
         argmax = relax.op.argmax(data, axis=normalized_axis)

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -34,7 +34,6 @@ import tvm
 import tvm.testing
 from tvm import relax
 from tvm.relax.frontend.onnx import from_onnx
-from tvm.relax.frontend.onnx_frontend import Hardmax, LogSoftmax, Softmax
 from tvm.script import ir as I
 from tvm.script import relax as R
 from tvm.script import tirx as T
@@ -749,27 +748,6 @@ def test_softmax_family_opset1_legacy_ir_semantics(op_name: str, expected_core_o
 
     assert expected_core_op in call_ops
     assert call_ops.count("relax.reshape") >= 2
-
-
-def test_softmax_fallback_warns_with_unknown_rank():
-    x = relax.Var("x", relax.TensorStructInfo(ndim=-1, dtype="float32"))
-    with pytest.warns(UserWarning, match="Softmax opset<=12 fallback"):
-        out = Softmax._impl_v1(None, [x], {}, None)
-    assert isinstance(out, relax.Call)
-
-
-def test_logsoftmax_fallback_warns_with_unknown_rank():
-    x = relax.Var("x", relax.TensorStructInfo(ndim=-1, dtype="float32"))
-    with pytest.warns(UserWarning, match="LogSoftmax opset<=12 fallback"):
-        out = LogSoftmax._impl_v1(None, [x], {}, None)
-    assert isinstance(out, relax.Call)
-
-
-def test_hardmax_fallback_warns_with_unknown_rank():
-    x = relax.Var("x", relax.TensorStructInfo(ndim=-1, dtype="float32"))
-    with pytest.warns(UserWarning, match="Hardmax opset<=12 fallback"):
-        with pytest.raises(ValueError, match="Hardmax requires a statically known input rank"):
-            Hardmax._impl_v1(None, [x], {}, None)
 
 
 def test_round_ties_to_even():

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -725,6 +725,53 @@ def test_softmax_family_opset13_default_axis_semantics(op_name: str):
     verify_unary(op_name, [2, 3, 4], opset=13)
 
 
+@pytest.mark.parametrize(
+    "op_name, expected_core_op",
+    [
+        ("Softmax", "relax.nn.softmax"),
+        ("LogSoftmax", "relax.nn.log_softmax"),
+        ("Hardmax", "relax.one_hot"),
+    ],
+)
+def test_softmax_family_opset1_legacy_ir_semantics(op_name: str, expected_core_op: str):
+    node = helper.make_node(op_name, ["x"], ["y"])
+    graph = helper.make_graph(
+        [node],
+        "softmax_family_opset1_ir_test",
+        inputs=[helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 3, 4])],
+        outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 3, 4])],
+    )
+    model = helper.make_model(
+        graph, producer_name="softmax_family_opset1_ir_test", opset_imports=[helper.make_opsetid("", 1)]
+    )
+    tvm_model = from_onnx(model, opset=1, keep_params_in_input=True)
+    call_ops = collect_relax_call_ops(tvm_model["main"])
+
+    assert expected_core_op in call_ops
+    assert call_ops.count("relax.reshape") >= 2
+
+
+def test_softmax_fallback_warns_with_unknown_rank():
+    x = relax.Var("x", relax.TensorStructInfo(ndim=-1, dtype="float32"))
+    with pytest.warns(UserWarning, match="Softmax opset<=12 fallback"):
+        out = Softmax._impl_v1(None, [x], {}, None)
+    assert isinstance(out, relax.Call)
+
+
+def test_logsoftmax_fallback_warns_with_unknown_rank():
+    x = relax.Var("x", relax.TensorStructInfo(ndim=-1, dtype="float32"))
+    with pytest.warns(UserWarning, match="LogSoftmax opset<=12 fallback"):
+        out = LogSoftmax._impl_v1(None, [x], {}, None)
+    assert isinstance(out, relax.Call)
+
+
+def test_hardmax_fallback_warns_with_unknown_rank():
+    x = relax.Var("x", relax.TensorStructInfo(ndim=-1, dtype="float32"))
+    with pytest.warns(UserWarning, match="Hardmax opset<=12 fallback"):
+        with pytest.raises(ValueError, match="Hardmax requires a statically known input rank"):
+            Hardmax._impl_v1(None, [x], {}, None)
+
+
 def test_round_ties_to_even():
     """ONNX Round must use ties-to-even (banker's rounding), not ties-away-from-zero.
 

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -34,6 +34,7 @@ import tvm
 import tvm.testing
 from tvm import relax
 from tvm.relax.frontend.onnx import from_onnx
+from tvm.relax.frontend.onnx_frontend import Hardmax, LogSoftmax, Softmax
 from tvm.script import ir as I
 from tvm.script import relax as R
 from tvm.script import tirx as T
@@ -707,6 +708,16 @@ def test_softmax_family_opset11_default_axis_semantics(op_name: str):
 @pytest.mark.parametrize("op_name", ["Softmax", "LogSoftmax", "Hardmax"])
 def test_softmax_family_opset11_negative_axis_semantics(op_name: str):
     verify_unary(op_name, [2, 3, 4], attrs={"axis": -2}, opset=11)
+
+
+@pytest.mark.parametrize("op_name", ["Softmax", "LogSoftmax", "Hardmax"])
+def test_softmax_family_opset11_positive_axis_semantics(op_name: str):
+    verify_unary(op_name, [2, 3, 4], attrs={"axis": 0}, opset=11)
+
+
+@pytest.mark.parametrize("op_name", ["Softmax", "LogSoftmax", "Hardmax"])
+def tes_softmax_family_opset11_axis_equals_rank_semantics(op_name: str):
+    verify_unary(op_name, [2, 3, 4], attrs={"axis": 3}, opset=11)
 
 
 @pytest.mark.parametrize("op_name", ["Softmax", "LogSoftmax", "Hardmax"])

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -699,6 +699,21 @@ def test_unary(op_name: str):
     verify_unary(op_name, [8, 8, 8], input_dtype=input_dtype, output_dtype=output_dtype)
 
 
+@pytest.mark.parametrize("op_name", ["Softmax", "LogSoftmax", "Hardmax"])
+def test_softmax_family_opset11_default_axis_semantics(op_name: str):
+    verify_unary(op_name, [2, 3, 4], opset=11)
+
+
+@pytest.mark.parametrize("op_name", ["Softmax", "LogSoftmax", "Hardmax"])
+def test_softmax_family_opset11_negative_axis_semantics(op_name: str):
+    verify_unary(op_name, [2, 3, 4], attrs={"axis": -2}, opset=11)
+
+
+@pytest.mark.parametrize("op_name", ["Softmax", "LogSoftmax", "Hardmax"])
+def test_softmax_family_opset13_default_axis_semantics(op_name: str):
+    verify_unary(op_name, [2, 3, 4], opset=13)
+
+
 def test_round_ties_to_even():
     """ONNX Round must use ties-to-even (banker's rounding), not ties-away-from-zero.
 


### PR DESCRIPTION
Hi Commiters,

This PR is going to fix Softmax-family legacy semantics for opset<=12 and harden Hardmax fallback.

### Summary:
- Implement legacy ONNX semantics for Softmax / LogSoftmax / Hardmax in opset <= 12, including flatten-to-2D + reshape-back behavior.
- Keep opset >= 13 behavior unchanged (_impl_v13 axis-based path).
- Add compatibility-first fallback warnings for unknown rank/shape paths.
- Harden Hardmax internals: normalize input before struct_info access and add backward-compatible helper signature handling.
- Extend regression coverage for softmax-family across opset 1/11/13 and key axis scenarios.