### PR TITLE
[REFACTOR][NODE] Use fn_repr inside kRepr lambdas, not ffi::ReprPrint

### DIFF
--- a/src/relax/ir/dataflow_pattern.cc
+++ b/src/relax/ir/dataflow_pattern.cc
@@ -62,22 +62,27 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 // Helper used inside RELAX_PATTERN_PRINTER_DEF lambdas.
 // Mimics the ReprPrinter interface (p->stream, p->Print) so that existing
 // REPR_LAMBDA bodies compile without modification.
+// fn_repr is the canonical dispatch callback from the kRepr machinery; Print
+// routes through it rather than calling ffi::ReprPrint directly so that any
+// recursion context threaded by the printer is preserved.
 struct PatternReprPrinterHelper {
   std::ostringstream stream;
-  void Print(const ObjectRef& x) { stream << ffi::ReprPrint(ffi::Any(x)); }
+  ffi::Function fn_repr;
+  explicit PatternReprPrinterHelper(ffi::Function fn_repr_) : fn_repr(std::move(fn_repr_)) {}
+  void Print(const ObjectRef& x) { stream << fn_repr(ffi::AnyView(x)).cast<ffi::String>(); }
 };
 
-#define RELAX_PATTERN_PRINTER_DEF(NODE_TYPE, REPR_LAMBDA)                                       \
-  TVM_FFI_STATIC_INIT_BLOCK() {                                                                 \
-    namespace refl = tvm::ffi::reflection;                                                      \
-    refl::TypeAttrDef<NODE_TYPE>().def(refl::type_attr::kRepr,                                  \
-                                       [](ffi::ObjectRef ref, ffi::Function) -> ffi::String {   \
-                                         auto* node = static_cast<const NODE_TYPE*>(ref.get()); \
-                                         PatternReprPrinterHelper printer;                      \
-                                         auto* p = &printer;                                    \
-                                         REPR_LAMBDA(p, node);                                  \
-                                         return printer.stream.str();                           \
-                                       });                                                      \
+#define RELAX_PATTERN_PRINTER_DEF(NODE_TYPE, REPR_LAMBDA)                                      \
+  TVM_FFI_STATIC_INIT_BLOCK() {                                                                \
+    namespace refl = tvm::ffi::reflection;                                                     \
+    refl::TypeAttrDef<NODE_TYPE>().def(                                                        \
+        refl::type_attr::kRepr, [](ffi::ObjectRef ref, ffi::Function fn_repr) -> ffi::String { \
+          auto* node = static_cast<const NODE_TYPE*>(ref.get());                               \
+          PatternReprPrinterHelper printer(fn_repr);                                           \
+          auto* p = &printer;                                                                  \
+          REPR_LAMBDA(p, node);                                                                \
+          return printer.stream.str();                                                         \
+        });                                                                                    \
   }
 
 ExternFuncPattern::ExternFuncPattern(ffi::String global_symbol) {

--- a/src/s_tir/meta_schedule/arg_info.cc
+++ b/src/s_tir/meta_schedule/arg_info.cc
@@ -158,7 +158,7 @@ TensorInfo TensorInfo::FromJSON(const ObjectRef& json_obj) {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::TypeAttrDef<TensorInfoNode>().def(refl::type_attr::kRepr,
-                                          [](TensorInfo ti, ffi::Function) -> ffi::String {
+                                          [](TensorInfo ti, ffi::Function fn_repr) -> ffi::String {
                                             std::ostringstream os;
                                             os << "TensorInfo(\"" << ti->dtype << "\", [";
                                             bool first = true;

--- a/src/target/virtual_device.cc
+++ b/src/target/virtual_device.cc
@@ -35,7 +35,7 @@ TVM_FFI_STATIC_INIT_BLOCK() { VirtualDeviceNode::RegisterReflection(); }
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::TypeAttrDef<VirtualDeviceNode>().def(
-      refl::type_attr::kRepr, [](VirtualDevice vd, ffi::Function) -> ffi::String {
+      refl::type_attr::kRepr, [](VirtualDevice vd, ffi::Function fn_repr) -> ffi::String {
         auto* node = vd.get();
         std::ostringstream os;
         os << "VirtualDevice(";
@@ -54,7 +54,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           }
           if (node->target.defined()) {
             if (need_sep) os << ", ";
-            os << "target=" << node->target->str();
+            os << "target=" << fn_repr(ffi::AnyView(node->target)).cast<ffi::String>();
             need_sep = true;
           }
           if (!node->memory_scope.empty()) {


### PR DESCRIPTION
Inside a `kRepr` lambda, `fn_repr` is the canonical dispatch. Threading it through to sub-element dispatch preserves recursion context and matches the repr migration's design intent (where `fn_repr` is the core abstraction for repr delegation). This applies the recommendation from code review of #19461 to three sites.

- `src/relax/ir/dataflow_pattern.cc` — helper threads `fn_repr`
- `src/s_tir/meta_schedule/arg_info.cc` — lambda parameter named
- `src/target/virtual_device.cc` — `fn_repr(target)` replaces `target->str()`