### PR TITLE
[REFACTOR][IR] Move tvm/support/with.h → tvm/ir/with_context.h

### DIFF
--- a/include/tvm/arith/analyzer.h
+++ b/include/tvm/arith/analyzer.h
@@ -27,7 +27,7 @@
 #include <tvm/arith/int_set.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/expr.h>
-#include <tvm/support/with.h>
+#include <tvm/ir/with_context.h>
 
 #include <limits>
 #include <memory>

--- a/include/tvm/ir/transform.h
+++ b/include/tvm/ir/transform.h
@@ -63,7 +63,7 @@
 #include <tvm/ir/diagnostic.h>
 #include <tvm/ir/instrument.h>
 #include <tvm/ir/module.h>
-#include <tvm/support/with.h>
+#include <tvm/ir/with_context.h>
 
 #include <string>
 #include <utility>

--- a/include/tvm/ir/with_context.h
+++ b/include/tvm/ir/with_context.h
@@ -18,12 +18,12 @@
  */
 
 /*!
- * \file tvm/support/with.h
+ * \file tvm/ir/with_context.h
  * \brief RAII wrapper function to enter and exit a context object
  *        similar to python's with syntax.
  */
-#ifndef TVM_SUPPORT_WITH_H_
-#define TVM_SUPPORT_WITH_H_
+#ifndef TVM_IR_WITH_CONTEXT_H_
+#define TVM_IR_WITH_CONTEXT_H_
 
 #include <exception>
 #include <functional>
@@ -165,4 +165,4 @@ class WithGroup {
 };
 
 }  // namespace tvm
-#endif  // TVM_SUPPORT_WITH_H_
+#endif  // TVM_IR_WITH_CONTEXT_H_

--- a/include/tvm/relax/dataflow_pattern.h
+++ b/include/tvm/relax/dataflow_pattern.h
@@ -28,9 +28,9 @@
 #include <tvm/ffi/optional.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/expr.h>
+#include <tvm/ir/with_context.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/type.h>
-#include <tvm/support/with.h>
 
 #include <cstdint>
 #include <functional>

--- a/include/tvm/target/target.h
+++ b/include/tvm/target/target.h
@@ -28,8 +28,8 @@
 #include <tvm/ir/cast.h>
 #include <tvm/ir/expr.h>
 #include <tvm/ir/function.h>
+#include <tvm/ir/with_context.h>
 #include <tvm/runtime/device_api.h>
-#include <tvm/support/with.h>
 #include <tvm/target/target_kind.h>
 
 #include <string>

--- a/src/arith/ir_mutator_with_analyzer.h
+++ b/src/arith/ir_mutator_with_analyzer.h
@@ -26,7 +26,7 @@
 
 #include <tvm/arith/analyzer.h>
 #include <tvm/ir/scope_stack.h>
-#include <tvm/support/with.h>
+#include <tvm/ir/with_context.h>
 #include <tvm/tirx/analysis.h>
 #include <tvm/tirx/stmt_functor.h>
 

--- a/src/arith/ir_visitor_with_analyzer.h
+++ b/src/arith/ir_visitor_with_analyzer.h
@@ -27,7 +27,7 @@
 
 #include <tvm/arith/analyzer.h>
 #include <tvm/ir/scope_stack.h>
-#include <tvm/support/with.h>
+#include <tvm/ir/with_context.h>
 #include <tvm/tirx/expr.h>
 #include <tvm/tirx/stmt_functor.h>
 

--- a/src/script/printer/ir/utils.h
+++ b/src/script/printer/ir/utils.h
@@ -23,8 +23,8 @@
 #include <tvm/ir/expr.h>
 #include <tvm/ir/function.h>
 #include <tvm/ir/op.h>
+#include <tvm/ir/with_context.h>
 #include <tvm/script/printer/ir_docsifier.h>
-#include <tvm/support/with.h>
 
 #include <string>
 #include <utility>

--- a/src/target/llvm/llvm_module.cc
+++ b/src/target/llvm/llvm_module.cc
@@ -61,9 +61,9 @@
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/string.h>
 #include <tvm/ir/module.h>
+#include <tvm/ir/with_context.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/runtime/object.h>
-#include <tvm/support/with.h>
 #include <tvm/target/codegen.h>
 #include <tvm/target/target.h>
 

--- a/src/tirx/transform/ir_utils.h
+++ b/src/tirx/transform/ir_utils.h
@@ -27,9 +27,9 @@
 #include <tvm/arith/int_set.h>
 #include <tvm/arith/int_solver.h>
 #include <tvm/ffi/container/tuple.h>
+#include <tvm/ir/with_context.h>
 #include <tvm/runtime/device_api.h>
 #include <tvm/s_tir/stmt.h>
-#include <tvm/support/with.h>
 #include <tvm/tirx/builtin.h>
 #include <tvm/tirx/expr.h>
 #include <tvm/tirx/function.h>


### PR DESCRIPTION
## Summary

`with.h`'s home in `tvm/support/` overstated its scope: every `With<T>` consumer is an IR/compiler context object — `PassContext`, `Target`, `Analyzer`, `DFPatternContext`. `tvm/support/` is for genuinely cross-cutting utilities (`io.h`, `parallel_for.h`, `random_engine.h`, `serializer.h`); `with.h` was the odd one out. The new filename `with_context.h` also communicates what the file actually contains — a RAII context-manager template — where the old `with.h` was too thin.

- `git mv include/tvm/support/with.h → include/tvm/ir/with_context.h`
- Header guard and `\file` doc updated to match new path
- 9 consumer `#include` lines updated; class name `With<T>` unchanged