### PR TITLE
[FFI][ABI] Bump tvm-ffi to 0.1.11rc2

### DIFF
--- a/include/tvm/ir/type.h
+++ b/include/tvm/ir/type.h
@@ -198,9 +198,7 @@ class TupleTypeNode : public TypeNode {
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
-    refl::ObjectDef<TupleTypeNode>()
-        .def_ro("fields", &TupleTypeNode::fields)
-        .def_ro("span", &TupleTypeNode::span);
+    refl::ObjectDef<TupleTypeNode>().def_ro("fields", &TupleTypeNode::fields);
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.TupleType", TupleTypeNode, TypeNode);
 };
@@ -260,8 +258,7 @@ class FuncTypeNode : public TypeNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<FuncTypeNode>()
         .def_ro("arg_types", &FuncTypeNode::arg_types)
-        .def_ro("ret_type", &FuncTypeNode::ret_type)
-        .def_ro("span", &FuncTypeNode::span);
+        .def_ro("ret_type", &FuncTypeNode::ret_type);
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.FuncType", FuncTypeNode, TypeNode);
 };
@@ -292,7 +289,7 @@ class TensorMapTypeNode : public TypeNode {
  public:
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
-    refl::ObjectDef<TensorMapTypeNode>().def_ro("span", &TensorMapTypeNode::span);
+    refl::ObjectDef<TensorMapTypeNode>();
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.TensorMapType", TensorMapTypeNode, TypeNode);
 };

--- a/python/tvm/relax/frontend/torch/dynamo.py
+++ b/python/tvm/relax/frontend/torch/dynamo.py
@@ -58,6 +58,11 @@ def relax_dynamo(pipeline: tvm.transform.Pass | None = None):
 
         def to_torch_tensor(nd_tensor):
             """A helper function to transfer a Tensor to torch.tensor."""
+            if isinstance(nd_tensor, torch.Tensor):
+                # tvm-ffi #517 (Recursive DLPack container conversion) auto-converts
+                # ffi::Tensor items returned in containers back to torch.Tensor when
+                # the call site passed torch.Tensor inputs.
+                return nd_tensor
             if isinstance(nd_tensor, tvm.runtime.Tensor):
                 return torch.from_numpy(nd_tensor.numpy())
             elif isinstance(nd_tensor, tvm_ffi.Array):


### PR DESCRIPTION
## Summary

Bumps `3rdparty/tvm-ffi` from `1fed0ae` (0.1.10) to `3c35034` (0.1.11rc2).
Two TVM-side fixes are needed for the bump:

- `include/tvm/ir/type.h`: drop redundant `span` field registration
  from `TupleTypeNode`, `FuncTypeNode`, and `TensorMapTypeNode`.
  tvm-ffi now warns when a child re-registers an ancestor field;
  `span` is already registered on `TypeNode` with `SEqHashIgnore`.
- `python/tvm/relax/frontend/torch/dynamo.py`: short-circuit
  `to_torch_tensor` for `torch.Tensor` items. [tvm-ffi #517](https://github.com/apache/tvm-ffi/pull/517) added
  recursive DLPack container conversion so `torch.Tensor` inputs
  auto-promote `Array` elements to `torch.Tensor` on iteration; the
  helper previously only handled `tvm.runtime.Tensor` / `tvm_ffi.Array`.

