### PR TITLE
[Relax][ONNX] Prevent `Div` divide-by-zero crashes

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -555,6 +555,7 @@ class Div(BinaryBase):
 
         return cls.base_impl(bb, inputs, attr, params)
 
+
 class Pow(BinaryBase):
     """Converts an onnx Pow node into an equivalent Relax expression."""
 

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -554,23 +554,12 @@ class Div(BinaryBase):
 
         rhs_has_zero = _const_integer_expr_has_zero(inputs[1])
         if rhs_has_zero:
-            return ValueError("ONNX Div with integer inputs encountered divisor value 0.")
+            raise ValueError("ONNX Div with integer inputs encountered divisor value 0.")
 
         if rhs_has_zero is False:
             return cls.base_impl(bb, inputs, attr, params)
 
-        rhs_is_zero = bb.normalize(relax.op.equal(inputs[1], relax.const(0, rhs_dtype)))
-        rhs_is_zero_i64 = bb.normalize(relax.op.astype(rhs_is_zero, "int64"))
-        zero_count = bb.normalize(relax.op.sum(rhs_is_zero_i64, axis=None, keepdims=False))
-        no_zero_divisor = bb.normalize(relax.op.equal(zero_count, relax.const(0, "int64")))
-        bb.emit(
-            relax.op.assert_op(
-                no_zero_divisor,
-                format="ONNX Div with integer inputs encountered divisor value 0.",
-            )
-        )
-        return cls.relax_op(inputs[0], inputs[1]) # pylint: disable=not-callable
-
+        return cls.base_impl(bb, inputs, attr, params)
 
 class Pow(BinaryBase):
     """Converts an onnx Pow node into an equivalent Relax expression."""

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -556,9 +556,6 @@ class Div(BinaryBase):
         if rhs_has_zero:
             raise ValueError("ONNX Div with integer inputs encountered divisor value 0.")
 
-        if rhs_has_zero is False:
-            return cls.base_impl(bb, inputs, attr, params)
-
         return cls.base_impl(bb, inputs, attr, params)
 
 class Pow(BinaryBase):

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -72,6 +72,18 @@ def _relax_dtype_is_floating_point(dtype: str) -> bool:
     )
 
 
+def _const_integer_expr_has_zero(expr: relax.Expr) -> bool | None:
+    """Return whether a constant integer expression contains a zero value.
+
+    Returns None when expression is not statically inspectable.
+    """
+
+    if isinstance(expr, relax.Constant):
+        return bool(_np.any(expr.data.numpy() == 0))
+
+    return None
+
+
 def get_type(elem_type: str | int) -> str:
     """Converts onnx integer datatype to numpy datatype"""
     # If a string was passed instead of a tensor type, it does not need
@@ -526,7 +538,38 @@ class Div(BinaryBase):
 
     @classmethod
     def _impl_v7(cls, bb, inputs, attr, params):
-        return cls.base_impl(bb, inputs, attr, params)
+        lhs_dtype = inputs[0].struct_info.dtype
+        rhs_dtype = inputs[1].struct_info.dtype
+
+        try:
+            lhs_code = DataType(lhs_dtype).type_code
+            rhs_code = DataType(rhs_dtype).type_code
+        except (ValueError, TypeError, TVMError):
+            return cls.base_impl(bb, inputs, attr, params)
+
+        lhs_is_integer = lhs_code == DataTypeCode.INT or lhs_code == DataTypeCode.UINT
+        rhs_is_integer = rhs_code == DataTypeCode.INT or rhs_code == DataTypeCode.UINT
+        if not (lhs_is_integer and rhs_is_integer):
+            return cls.base_impl(bb, inputs, attr, params)
+
+        rhs_has_zero = _const_integer_expr_has_zero(inputs[1])
+        if rhs_has_zero:
+            return ValueError("ONNX Div with integer inputs encountered divisor value 0.")
+
+        if rhs_has_zero is False:
+            return cls.base_impl(bb, inputs, attr, params)
+
+        rhs_is_zero = bb.normalize(relax.op.equal(inputs[1], relax.const(0, rhs_dtype)))
+        rhs_is_zero_i64 = bb.normalize(relax.op.astype(rhs_is_zero, "int64"))
+        zero_count = bb.normalize(relax.op.sum(rhs_is_zero_i64, axis=None, keepdims=False))
+        no_zero_divisor = bb.normalize(relax.op.equal(zero_count, relax.const(0, "int64")))
+        bb.emit(
+            relax.op.assert_op(
+                no_zero_divisor,
+                format="ONNX Div with integer inputs encountered divisor value 0.",
+            )
+        )
+        return cls.relax_op(inputs[0], inputs[1]) # pylint: disable=not-callable
 
 
 class Pow(BinaryBase):

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -72,18 +72,6 @@ def _relax_dtype_is_floating_point(dtype: str) -> bool:
     )
 
 
-def _const_integer_expr_has_zero(expr: relax.Expr) -> bool | None:
-    """Return whether a constant integer expression contains a zero value.
-
-    Returns None when expression is not statically inspectable.
-    """
-
-    if isinstance(expr, relax.Constant):
-        return bool(_np.any(expr.data.numpy() == 0))
-
-    return None
-
-
 def get_type(elem_type: str | int) -> str:
     """Converts onnx integer datatype to numpy datatype"""
     # If a string was passed instead of a tensor type, it does not need
@@ -549,8 +537,9 @@ class Div(BinaryBase):
         if not (lhs_is_integer and rhs_is_integer):
             return cls.base_impl(bb, inputs, attr, params)
 
-        rhs_has_zero = _const_integer_expr_has_zero(inputs[1])
-        if rhs_has_zero:
+        if isinstance(inputs[1], relax.Constant) and bool(
+            _np.any(inputs[1].data.numpy() == 0)
+        ):
             raise ValueError("ONNX Div with integer inputs encountered divisor value 0.")
 
         return cls.base_impl(bb, inputs, attr, params)

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -537,9 +537,7 @@ class Div(BinaryBase):
         if not (lhs_is_integer and rhs_is_integer):
             return cls.base_impl(bb, inputs, attr, params)
 
-        if isinstance(inputs[1], relax.Constant) and bool(
-            _np.any(inputs[1].data.numpy() == 0)
-        ):
+        if isinstance(inputs[1], relax.Constant) and bool(_np.any(inputs[1].data.numpy() == 0)):
             raise ValueError("ONNX Div with integer inputs encountered divisor value 0.")
 
         return cls.base_impl(bb, inputs, attr, params)

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -538,13 +538,10 @@ class Div(BinaryBase):
 
     @classmethod
     def _impl_v7(cls, bb, inputs, attr, params):
-        lhs_dtype = inputs[0].struct_info.dtype
-        rhs_dtype = inputs[1].struct_info.dtype
-
         try:
-            lhs_code = DataType(lhs_dtype).type_code
-            rhs_code = DataType(rhs_dtype).type_code
-        except (ValueError, TypeError, TVMError):
+            lhs_code = DataType(inputs[0].struct_info.dtype).type_code
+            rhs_code = DataType(inputs[1].struct_info.dtype).type_code
+        except (AttributeError, ValueError, TypeError, TVMError):
             return cls.base_impl(bb, inputs, attr, params)
 
         lhs_is_integer = lhs_code == DataTypeCode.INT or lhs_code == DataTypeCode.UINT

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -591,6 +591,25 @@ def test_binary(op_name: str):
     verify_binary_scalar(op_name)
 
 
+def test_div_integer_constant_zero_divisor_raises_valueerror():
+    b_init = numpy_helper.from_array(np.array([3, 0, -2, 1], dtype=np.int32), name="b")
+    node = helper.make_node("Div", ["a", "b"], ["y"])
+    graph = helper.make_graph(
+        [node],
+        "div_const_zero",
+        [helper.make_tensor_value_info("a", TensorProto.INT32, [4])],
+        [helper.make_tensor_value_info("y", TensorProto.INT32, [4])],
+        initializer=[b_init],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+    model.ir_version = 9
+
+    with pytest.raises(
+        ValueError, match="ONNX Div with integer inputs encountered divisor value 0"
+    ):
+        from_onnx(model, opset=18, keep_params_in_input=False)
+
+
 @pytest.mark.parametrize("int_mode", [True, False])
 def test_mod(int_mode: bool):
     if int_mode:

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -610,32 +610,6 @@ def test_div_integer_constant_zero_divisor_raises_valueerror():
         from_onnx(model, opset=18, keep_params_in_input=False)
 
 
-def test_div_integer_dynamic_nonzero_matches_ort():
-    node = helper.make_node("Div", ["a", "b"], ["y"])
-    graph = helper.make_graph(
-        [node],
-        "div_dynamic_nonzero",
-        [
-            helper.make_tensor_value_info("a", TensorProto.INT32, [4]),
-            helper.make_tensor_value_info("b", TensorProto.INT32, [4]),
-        ],
-        [helper.make_tensor_value_info("y", TensorProto.INT32, [4])],
-    )
-    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
-    model.ir_version = 9
-
-    check_correctness(
-        model,
-        inputs={
-            "a": np.array([42, 99, -50, 7], dtype=np.int32),
-            "b": np.array([3, -2, 5, 1], dtype=np.int32),
-        },
-        ir_version=9,
-        opset=18,
-        check_dtypes=True,
-    )
-
-
 @pytest.mark.parametrize("int_mode", [True, False])
 def test_mod(int_mode: bool):
     if int_mode:

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -610,6 +610,32 @@ def test_div_integer_constant_zero_divisor_raises_valueerror():
         from_onnx(model, opset=18, keep_params_in_input=False)
 
 
+def test_div_integer_dynamic_nonzero_matches_ort():
+    node = helper.make_node("Div", ["a", "b"], ["y"])
+    graph = helper.make_graph(
+        [node],
+        "div_dynamic_nonzero",
+        [
+            helper.make_tensor_value_info("a", TensorProto.INT32, [4]),
+            helper.make_tensor_value_info("b", TensorProto.INT32, [4]),
+        ],
+        [helper.make_tensor_value_info("y", TensorProto.INT32, [4])],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+    model.ir_version = 9
+
+    check_correctness(
+        model,
+        inputs={
+            "a": np.array([42, 99, -50, 7], dtype=np.int32),
+            "b": np.array([3, -2, 5, 1], dtype=np.int32),
+        },
+        ir_version=9,
+        opset=18,
+        check_dtypes=True,
+    )
+
+
 @pytest.mark.parametrize("int_mode", [True, False])
 def test_mod(int_mode: bool):
     if int_mode:

--- a/tests/python/relax/test_frontend_onnx_backend.py
+++ b/tests/python/relax/test_frontend_onnx_backend.py
@@ -77,9 +77,9 @@ class TVMRelaxBackendRep(BackendRep):
         self._vm.invoke_stateful("main")
         output = self._vm.get_outputs("main")
 
-        if isinstance(output, (tvm.runtime.Tensor, np.ndarray)):
+        if isinstance(output, tvm.runtime.Tensor | np.ndarray):
             return (output.numpy() if hasattr(output, "numpy") else output,)
-        if isinstance(output, (tuple, list)):
+        if isinstance(output, tuple | list):
             return tuple(o.numpy() if hasattr(o, "numpy") else np.array(o) for o in output)
         return (np.array(output),)
 

--- a/tests/python/relax/test_frontend_onnx_backend.py
+++ b/tests/python/relax/test_frontend_onnx_backend.py
@@ -80,9 +80,7 @@ class TVMRelaxBackendRep(BackendRep):
         if isinstance(output, (tvm.runtime.Tensor, np.ndarray)):
             return (output.numpy() if hasattr(output, "numpy") else output,)
         if isinstance(output, (tuple, list)):
-            return tuple(
-                o.numpy() if hasattr(o, "numpy") else np.array(o) for o in output
-            )
+            return tuple(o.numpy() if hasattr(o, "numpy") else np.array(o) for o in output)
         return (np.array(output),)
 
 
@@ -110,9 +108,7 @@ class TVMRelaxBackend(Backend):
         func_param_names = [p.name_hint for p in func.params]
         graph_input_names = [inp.name for inp in model.graph.input]
 
-        return TVMRelaxBackendRep(
-            tvm_model, params, func_param_names, graph_input_names
-        )
+        return TVMRelaxBackendRep(tvm_model, params, func_param_names, graph_input_names)
 
     @classmethod
     def supports_device(cls, device: str) -> bool:
@@ -133,32 +129,77 @@ backend_test = onnx.backend.test.BackendTest(TVMRelaxBackend, __name__)
 # validated against the ONNX Backend Test Suite.  They can be added
 # incrementally as the importer improves.
 _INCLUDE_OPS = [
-    "abs", "acos", "acosh", "add", "and", "argmax", "argmin",
-    "averagepool", "bitshift",
-    "bitwise_and", "bitwise_not", "bitwise_or", "bitwise_xor",
-    "ceil", "clip", "compress", "concat",
-    "conv", "cos", "cosh",
-    "depthtospace", "div",
-    "einsum", "erf", "exp",
-    "flatten", "floor",
-    "gathernd", "gemm",
-    "globalaveragepool", "globalmaxpool", "greater", "greater_equal",
-    "hardmax", "hardswish",
+    "abs",
+    "acos",
+    "acosh",
+    "add",
+    "and",
+    "argmax",
+    "argmin",
+    "averagepool",
+    "bitshift",
+    "bitwise_and",
+    "bitwise_not",
+    "bitwise_or",
+    "bitwise_xor",
+    "ceil",
+    "clip",
+    "compress",
+    "concat",
+    "conv",
+    "cos",
+    "cosh",
+    "depthtospace",
+    "div",
+    "einsum",
+    "erf",
+    "exp",
+    "flatten",
+    "floor",
+    "gathernd",
+    "gemm",
+    "globalaveragepool",
+    "globalmaxpool",
+    "greater",
+    "greater_equal",
+    "hardmax",
+    "hardswish",
     "isnan",
-    "less", "less_equal", "lrn",
-    "matmul", "matmulinteger", "mean", "min", "mod", "mul", "neg",
-    "nonzero", "not",
+    "less",
+    "less_equal",
+    "lrn",
+    "matmul",
+    "matmulinteger",
+    "mean",
+    "min",
+    "mod",
+    "mul",
+    "neg",
+    "nonzero",
+    "not",
     "or",
     "reciprocal",
     "round",
     "scatternd",
-    "sigmoid", "sign",
-    "sin", "sinh", "size", "slice",
+    "sigmoid",
+    "sign",
+    "sin",
+    "sinh",
+    "size",
+    "slice",
     "spacetodepth",
-    "sqrt", "squeeze", "sub", "sum",
-    "tan", "tanh", "tile", "transpose",
-    "unique", "unsqueeze",
-    "where", "xor",
+    "sqrt",
+    "squeeze",
+    "sub",
+    "sum",
+    "tan",
+    "tanh",
+    "tile",
+    "transpose",
+    "unique",
+    "unsqueeze",
+    "where",
+    "xor",
 ]
 
 for _op in _INCLUDE_OPS:


### PR DESCRIPTION
Hi Committers,

This PR is trying to fix issues #19541. Any suggestions would be appreciated if you are available.

### Root cause:
The ONNX `Div` path in the Relax frontend did not separate two integer-divisor cases: constant zero divisors and dynamic/unknown divisors. As a result, constant integer zero divisors were not rejected during import, and dynamic integer divisors could reach runtime without a guard. When the divisor became zero at runtime, execution could trigger SIGFPE and terminate the process instead of raising a controlled error.

### Solution:
This PR applies a minimal, targeted fix in the ONNX frontend `Div` conversion path. It introduces: import-time validation for constant integer divisors containing zero, raising ValueError early.