### PR TITLE
[TVMScript] Handle undefined functions when dumping IRModule

### DIFF
--- a/src/script/printer/ir/ir.cc
+++ b/src/script/printer/ir/ir.cc
@@ -35,15 +35,24 @@ struct SortableFunction {
       : priority(0), gv(obj.first), func(obj.second) {
     if (gv->name_hint == "main") {
       priority = 1000;
-    } else if (obj.second->GetTypeKey() == "tirx.PrimFunc") {
-      priority = 1;
-    } else if (obj.second->GetTypeKey() == "relax.expr.ExternFunc") {
-      priority = 2;
-    } else if (obj.second->GetTypeKey() == "relax.expr.Function") {
-      priority = 3;
+    } else if (func.defined()) {
+      if (func->GetTypeKey() == "tirx.PrimFunc") {
+        priority = 1;
+      } else if (func->GetTypeKey() == "relax.expr.ExternFunc") {
+        priority = 2;
+      } else if (func->GetTypeKey() == "relax.expr.Function") {
+        priority = 3;
+      } else {
+        TVM_FFI_THROW(TypeError) << "TVMScript cannot print functions of type: "
+                                 << func->GetTypeKey();
+      }
     } else {
-      TVM_FFI_THROW(TypeError) << "TVMScript cannot print functions of type: "
-                               << obj.second->GetTypeKey();
+      // PrimFuncPass may leave undefined GlobalVar slots when transforming
+      // this function (see tirx/ir/transform.cc); this transient state may
+      // be encountered during the internal call Dump(mod) executed in
+      // PrimFuncPass during debugging.
+      priority = 999;
+      LOG(INFO) << "Function " << gv->name_hint << " is undefined";
     }
   }
 


### PR DESCRIPTION
PrimFuncPass temporarily clears the module slot for the function being transformed before calling pass_func. Dumping the IRModule mid-pass can therefore see undefined BaseFuncs and crash in SortableFunction when calling tvm::Dump(). Guard with func.defined(), assign a fallback sort priority, and log instead of dereferencing.