### PR TITLE
[TIR] Fixup max/min with input containing NAN

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1599,7 +1599,12 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const MinNode* op) {
   llvm::Value* a = MakeValue(op->a);
   llvm::Value* b = MakeValue(op->b);
   if (op->a.dtype().is_float()) {
-    return builder_->CreateMinimum(a, b);
+    llvm::Value* nan_a = builder_->CreateFCmpUNO(a, a);
+    llvm::Value* nan_b = builder_->CreateFCmpUNO(b, b);
+    return builder_->CreateSelect(
+        nan_a, a,
+        builder_->CreateSelect(nan_b, b,
+                               builder_->CreateSelect(CreateLT(op->a.dtype(), a, b), a, b)));
   } else {
     return builder_->CreateSelect(CreateLT(op->a.dtype(), a, b), a, b);
   }
@@ -1609,7 +1614,12 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const MaxNode* op) {
   llvm::Value* a = MakeValue(op->a);
   llvm::Value* b = MakeValue(op->b);
   if (op->a.dtype().is_float()) {
-    return builder_->CreateMaximum(a, b);
+    llvm::Value* nan_a = builder_->CreateFCmpUNO(a, a);
+    llvm::Value* nan_b = builder_->CreateFCmpUNO(b, b);
+    return builder_->CreateSelect(
+        nan_a, a,
+        builder_->CreateSelect(nan_b, b,
+                               builder_->CreateSelect(CreateGT(op->a.dtype(), a, b), a, b)));
   } else {
     return builder_->CreateSelect(CreateGT(op->a.dtype(), a, b), a, b);
   }

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1599,22 +1599,20 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const MinNode* op) {
   llvm::Value* a = MakeValue(op->a);
   llvm::Value* b = MakeValue(op->b);
   if (op->a.dtype().is_float()) {
-#if TVM_LLVM_VERSION >= 120
     return builder_->CreateMinimum(a, b);
-#endif
+  } else {
+    return builder_->CreateSelect(CreateLT(op->a.dtype(), a, b), a, b);
   }
-  return builder_->CreateSelect(CreateLT(op->a.dtype(), a, b), a, b);
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const MaxNode* op) {
   llvm::Value* a = MakeValue(op->a);
   llvm::Value* b = MakeValue(op->b);
   if (op->a.dtype().is_float()) {
-#if TVM_LLVM_VERSION >= 120
     return builder_->CreateMaximum(a, b);
-#endif
+  } else {
+    return builder_->CreateSelect(CreateGT(op->a.dtype(), a, b), a, b);
   }
-  return builder_->CreateSelect(CreateGT(op->a.dtype(), a, b), a, b);
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const EQNode* op) {

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1598,21 +1598,23 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const ModNode* op) {
 llvm::Value* CodeGenLLVM::VisitExpr_(const MinNode* op) {
   llvm::Value* a = MakeValue(op->a);
   llvm::Value* b = MakeValue(op->b);
-  if (op->a.dtype().is_int() || op->a.dtype().is_uint()) {
-    return builder_->CreateSelect(CreateLT(op->a.dtype(), a, b), a, b);
-  } else {
+  if (op->a.dtype().is_float()) {
+#if TVM_LLVM_VERSION >= 120
     return builder_->CreateMinimum(a, b);
+#endif
   }
+  return builder_->CreateSelect(CreateLT(op->a.dtype(), a, b), a, b);
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const MaxNode* op) {
   llvm::Value* a = MakeValue(op->a);
   llvm::Value* b = MakeValue(op->b);
-  if (op->a.dtype().is_int() || op->a.dtype().is_uint()) {
-    return builder_->CreateSelect(CreateGT(op->a.dtype(), a, b), a, b);
-  } else {
+  if (op->a.dtype().is_float()) {
+#if TVM_LLVM_VERSION >= 120
     return builder_->CreateMaximum(a, b);
+#endif
   }
+  return builder_->CreateSelect(CreateGT(op->a.dtype(), a, b), a, b);
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const EQNode* op) {

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1598,13 +1598,21 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const ModNode* op) {
 llvm::Value* CodeGenLLVM::VisitExpr_(const MinNode* op) {
   llvm::Value* a = MakeValue(op->a);
   llvm::Value* b = MakeValue(op->b);
-  return builder_->CreateSelect(CreateLT(op->a.dtype(), a, b), a, b);
+  if (op->a.dtype().is_int() || op->a.dtype().is_uint()) {
+    return builder_->CreateSelect(CreateLT(op->a.dtype(), a, b), a, b);
+  } else {
+    return builder_->CreateMinimum(a, b);
+  }
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const MaxNode* op) {
   llvm::Value* a = MakeValue(op->a);
   llvm::Value* b = MakeValue(op->b);
-  return builder_->CreateSelect(CreateGT(op->a.dtype(), a, b), a, b);
+  if (op->a.dtype().is_int() || op->a.dtype().is_uint()) {
+    return builder_->CreateSelect(CreateGT(op->a.dtype(), a, b), a, b);
+  } else {
+    return builder_->CreateMaximum(a, b);
+  }
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const EQNode* op) {

--- a/tests/python/codegen/test_target_codegen_aarch64.py
+++ b/tests/python/codegen/test_target_codegen_aarch64.py
@@ -226,7 +226,7 @@ def test_max(dtype):
     )
 
     assert len(loads) > 1
-    assert (len(compare) > 1 and len(select) == len(compare)) or len(max_instr) > 1
+    assert (len(compare) > 1 and len(select) == 3 * len(compare)) or len(max_instr) > 1
 
 
 @pytest.mark.skipif(
@@ -269,7 +269,7 @@ def test_min(dtype):
     )
 
     assert len(loads) > 1
-    assert (len(compare) > 1 and len(select) == len(compare)) or len(min_instr) > 1
+    assert (len(compare) > 1 and len(select) == 3 * len(compare)) or len(min_instr) > 1
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
llvm.minimum and llvm.maximum: Return NaN if one the arguments is NaN.
refs: https://llvm.org/docs/LangRef.html#floating-point-min-max-intrinsics-comparison

fixed #19579