### PR TITLE
[RPC][Tracker] Reject invalid tracker message sizes and consume frame header

### DIFF
--- a/python/tvm/rpc/tracker.py
+++ b/python/tvm/rpc/tracker.py
@@ -237,8 +237,12 @@ class TCPEventHandler(tornado_util.TCPHandler):
             msg = py_str(bytes(self._data[: self._msg_size]))
             del self._data[: self._msg_size]
             self._msg_size = 0
-            self.call_handler(json.loads(msg))
-
+            try:
+                self.call_handler(json.loads(msg))
+            except (json.JSONDecodeError, Exception) as e:
+                logger.warning("Error processing message from %s: %s", self.name(), e)
+                self.close()
+                return
 
     def ret_value(self, data):
         """return value to the output"""

--- a/python/tvm/rpc/tracker.py
+++ b/python/tvm/rpc/tracker.py
@@ -77,6 +77,8 @@ logger.addHandler(console_handler)
 logger.setLevel(logging.INFO)
 logger.propagate = False
 
+MAX_TRACKER_MSG_BYTES = 1 << 20
+
 
 class Scheduler:
     """Abstract interface of scheduler."""
@@ -222,18 +224,21 @@ class TCPEventHandler(tornado_util.TCPHandler):
 
         while True:
             if self._msg_size == 0:
-                if len(self._data) >= 4:
-                    self._msg_size = struct.unpack("<i", self._data[:4])[0]
-                else:
+                if len(self._data) < 4:
                     return
-            if self._msg_size != 0 and len(self._data) >= self._msg_size + 4:
-                msg = py_str(bytes(self._data[4 : 4 + self._msg_size]))
-                del self._data[: 4 + self._msg_size]
-                self._msg_size = 0
-                # pylint: disable=broad-except
-                self.call_handler(json.loads(msg))
-            else:
+                self._msg_size = struct.unpack("<i", self._data[:4])[0]
+                del self._data[:4]
+                if self._msg_size <= 0 or self._msg_size > MAX_TRACKER_MSG_BYTES:
+                    logger.warning("Invalid message size %d from %s", self._msg_size, self.name())
+                    self.close()
+                    return
+            if len(self._data) < self._msg_size:
                 return
+            msg = py_str(bytes(self._data[: self._msg_size]))
+            del self._data[: self._msg_size]
+            self._msg_size = 0
+            self.call_handler(json.loads(msg))
+
 
     def ret_value(self, data):
         """return value to the output"""


### PR DESCRIPTION
Hi Committers,

This PR fixes https://github.com/apache/tvm/issues/19585.

### Root Cause
- `TCPEventHandler.on_message` parsed the 4-byte int 32 length header directly from the accumulated buffer without limits and left the header bytes in the buffer until the full payload arrived.
- If the header decoded to 0 or to an extremely large (e.g., 0x7FFFFFFF) value, self._data could grow without bound (or the header would be repeatedly re-read without being consumed), leading to OOM or denial-of-service.

### Solution
- Introduce `MAX_TRACKER_MSG_BYTES = 1 << 20` (1MiB).
- After detecting at least 4 bytes in the buffer, read and immediately delete the 4-byte header.