### PR TITLE
Fix PytestUnknownMarkWarning: Unknown pytest.mark.adreno_clml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,10 @@ addopts = "-v --tb=short"
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+markers = [
+  "adreno_clml: Mark a test as using adreno_clml",
+  "adreno_opencl_vulkan: Mark a test as using adreno_opencl_vulkan",
+]
 
 [tool.ruff]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,9 @@ python_functions = ["test_*"]
 markers = [
   "adreno_clml: Mark a test as using adreno_clml",
   "adreno_opencl_vulkan: Mark a test as using adreno_opencl_vulkan",
+  "adreno_vulkan: Mark a test as using adreno_vulkan",
+  "adreno_opencl: Mark a test as using adreno_opencl",
+  "adreno_opencl_real: Mark a test as using adreno_opencl_real",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Hi Commiters,

This PR fixs `PytestUnknownMarkWarning: Unknown pytest.mark.adreno_clml - is this a typo?`

>[2026-05-25T07:10:30.746Z] =============================== warnings summary ===============================
[2026-05-25T07:10:30.746Z] python/tvm/testing/utils.py:651
[2026-05-25T07:10:30.746Z]   /workspace/python/tvm/testing/utils.py:651: PytestUnknownMarkWarning: Unknown pytest.mark.adreno_clml - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
[2026-05-25T07:10:30.746Z]     yield getattr(pytest.mark, self.name)
[2026-05-25T07:10:30.746Z] 
[2026-05-25T07:10:30.746Z] python/tvm/testing/utils.py:651
[2026-05-25T07:10:30.746Z]   /workspace/python/tvm/testing/utils.py:651: PytestUnknownMarkWarning: Unknown pytest.mark.adreno_opencl_vulkan - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
[2026-05-25T07:10:30.746Z]     yield getattr(pytest.mark, self.name)
[2026-05-25T07:10:30.746Z