### PR TITLE
[REFACTOR][IR] Phase out class Integer and class Bool in Attrs and PassConfig

### DIFF
--- a/include/tvm/ir/attrs.h
+++ b/include/tvm/ir/attrs.h
@@ -151,7 +151,7 @@ class DictAttrs : public Attrs {
    * \code
    *
    *  void GetAttrExample(const BaseFunc& f) {
-   *    auto value = f->attrs.GetAttr<Integer>("AttrKey", 0);
+   *    auto value = f->attrs.GetAttr<int64_t>("AttrKey", 0);
    *  }
    *
    * \endcode
@@ -194,7 +194,7 @@ class DictAttrs : public Attrs {
    * \endcode
    */
   bool HasNonzeroAttr(const std::string& attr_key) const {
-    return GetAttr<Integer>(attr_key, 0).value_or(0).IntValue() != 0;
+    return GetAttr<int64_t>(attr_key, 0).value_or(0) != 0;
   }
 
   explicit DictAttrs(::tvm::ffi::ObjectPtr<DictAttrsNode> n) : Attrs(n) {}

--- a/include/tvm/ir/function.h
+++ b/include/tvm/ir/function.h
@@ -172,7 +172,7 @@ class BaseFuncNode : public RelaxExprNode {
    * \code
    *
    *  void GetAttrExample(const BaseFunc& f) {
-   *    auto value = f->GetAttr<Integer>("AttrKey", 0);
+   *    auto value = f->GetAttr<int64_t>("AttrKey", 0);
    *  }
    *
    * \endcode

--- a/include/tvm/ir/module.h
+++ b/include/tvm/ir/module.h
@@ -86,7 +86,7 @@ class IRModuleNode : public ffi::Object {
    * \code
    *
    *  void GetAttrExample(const IRModule& mod) {
-   *    auto value = f->GetAttr<Integer>("AttrKey", 0);
+   *    auto value = f->GetAttr<int64_t>("AttrKey", 0);
    *  }
    *
    * \endcode

--- a/include/tvm/relax/attrs/manipulate.h
+++ b/include/tvm/relax/attrs/manipulate.h
@@ -45,7 +45,7 @@ struct ConcatAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used in expand_dims operators */
 struct ExpandDimsAttrs : public BaseAttrsNode {
-  ffi::Array<Integer> axis;
+  ffi::Array<int64_t> axis;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -98,7 +98,7 @@ struct LayoutTransformAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used in permute_dims operator */
 struct PermuteDimsAttrs : public BaseAttrsNode {
-  ffi::Optional<ffi::Array<Integer>> axes;
+  ffi::Optional<ffi::Array<int64_t>> axes;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -126,7 +126,7 @@ struct SplitAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used in squeeze operators */
 struct SqueezeAttrs : public BaseAttrsNode {
-  ffi::Optional<ffi::Array<Integer>> axis;
+  ffi::Optional<ffi::Array<int64_t>> axis;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -141,7 +141,7 @@ struct SqueezeAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used in stack operators */
 struct StackAttrs : public BaseAttrsNode {
-  ffi::Optional<Integer> axis;
+  ffi::Optional<int64_t> axis;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -174,7 +174,7 @@ struct RepeatAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used in tile operators */
 struct TileAttrs : public BaseAttrsNode {
-  ffi::Array<Integer> repeats;
+  ffi::Array<int64_t> repeats;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -198,7 +198,7 @@ struct FlipAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used in gather_elements operators */
 struct GatherElementsAttrs : public BaseAttrsNode {
-  Integer axis;
+  int64_t axis;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -212,7 +212,7 @@ struct GatherElementsAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used in gather_nd operators */
 struct GatherNDAttrs : public BaseAttrsNode {
-  Integer batch_dims;
+  int64_t batch_dims;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -252,7 +252,7 @@ struct MeshgridAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used in scatter_elements operators */
 struct ScatterElementsAttrs : public BaseAttrsNode {
-  Integer axis;
+  int64_t axis;
   ffi::String reduction;
 
   static void RegisterReflection() {

--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -603,7 +603,7 @@ struct BatchNormAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used in layer_norm operator */
 struct LayerNormAttrs : public BaseAttrsNode {
-  ffi::Array<Integer> axes;
+  ffi::Array<int64_t> axes;
   double epsilon;
   bool center;
   bool scale;
@@ -627,7 +627,7 @@ struct LayerNormAttrs : public BaseAttrsNode {
 struct GroupNormAttrs : public BaseAttrsNode {
   int num_groups;
   int channel_axis;
-  ffi::Array<Integer> axes;
+  ffi::Array<int64_t> axes;
   double epsilon;
   bool center;
   bool scale;
@@ -655,7 +655,7 @@ struct GroupNormAttrs : public BaseAttrsNode {
 /*! \brief Attributes used in instance_norm operator */
 struct InstanceNormAttrs : public BaseAttrsNode {
   int channel_axis;
-  ffi::Array<Integer> axes;
+  ffi::Array<int64_t> axes;
   double epsilon;
   bool center;
   bool scale;
@@ -680,7 +680,7 @@ struct InstanceNormAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used in rms_norm operator */
 struct RMSNormAttrs : public BaseAttrsNode {
-  ffi::Array<Integer> axes;
+  ffi::Array<int64_t> axes;
   double epsilon;
 
   static void RegisterReflection() {
@@ -746,7 +746,7 @@ struct AttentionAttrs : public BaseAttrsNode {
 
 /*! \brief Attributes used for the padding operator */
 struct PadAttrs : public BaseAttrsNode {
-  ffi::Array<Integer> pad_width;
+  ffi::Array<int64_t> pad_width;
   double pad_value = 0.0;
   tvm::ffi::String pad_mode;
 

--- a/include/tvm/relax/attrs/op.h
+++ b/include/tvm/relax/attrs/op.h
@@ -57,7 +57,7 @@ struct CallTIRInplaceAttrs : public BaseAttrsNode {
    * store the `i`th output. If an element has the value -1, that means a new tensor should be
    * allocated for that output.
    */
-  ffi::Array<Integer> inplace_indices;
+  ffi::Array<int64_t> inplace_indices;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -77,7 +77,7 @@ struct CallInplacePackedAttrs : public BaseAttrsNode {
    * store the `i`th output. If an element has the value -1, that means the output will be newly
    * allocated.
    */
-  ffi::Array<Integer> inplace_indices;
+  ffi::Array<int64_t> inplace_indices;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;

--- a/include/tvm/relax/attrs/statistical.h
+++ b/include/tvm/relax/attrs/statistical.h
@@ -31,7 +31,7 @@ namespace relax {
 
 /*! \brief Attributes for statistical operators */
 struct StatisticalAttrs : public BaseAttrsNode {
-  ffi::Optional<ffi::Array<Integer>> axis;
+  ffi::Optional<ffi::Array<int64_t>> axis;
   bool keepdims;
 
   static void RegisterReflection() {
@@ -52,7 +52,7 @@ struct StatisticalAttrs : public BaseAttrsNode {
 struct ScanopAttrs : public BaseAttrsNode {
   ffi::Optional<int64_t> axis;
   DataType dtype;
-  Bool exclusive = Bool(false);
+  bool exclusive = false;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -64,7 +64,7 @@ struct ScanopAttrs : public BaseAttrsNode {
                 "The output data type."
                 "If dtype is not specified, it defaults to the dtype of input data.")
         .def_ro("exclusive", &ScanopAttrs::exclusive, "The first element is not included",
-                refl::DefaultValue(Bool(false)));
+                refl::DefaultValue(false));
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ScanopAttrs", ScanopAttrs, BaseAttrsNode);
 };  // struct ScanopAttrs

--- a/include/tvm/relax/distributed/global_info.h
+++ b/include/tvm/relax/distributed/global_info.h
@@ -40,7 +40,7 @@ class DeviceMeshNode : public GlobalInfoNode {
   ffi::Shape shape;
 
   /*! \brief device ids in the mesh*/
-  ffi::Array<Integer> device_ids;
+  ffi::Array<int64_t> device_ids;
 
   /*! \brief Optionally use range to represent device_ids*/
   ffi::Optional<Range> device_range;
@@ -61,7 +61,7 @@ class DeviceMeshNode : public GlobalInfoNode {
  */
 class DeviceMesh : public GlobalInfo {
  public:
-  TVM_DLL DeviceMesh(ffi::Shape shape, ffi::Array<Integer> device_ids);
+  TVM_DLL DeviceMesh(ffi::Shape shape, ffi::Array<int64_t> device_ids);
   TVM_DLL DeviceMesh(ffi::Shape shape, Range device_range);
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(DeviceMesh, GlobalInfo, DeviceMeshNode);
 };

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -297,7 +297,7 @@ class TupleGetItem : public Expr {
  */
 TupleGetItem WithFields(TupleGetItem tuple_get_item,
                         ffi::Optional<Expr> opt_tuple = ffi::Optional<Expr>(),
-                        ffi::Optional<Integer> opt_index = ffi::Optional<Integer>(),
+                        ffi::Optional<int64_t> opt_index = ffi::Optional<int64_t>(),
                         ffi::Optional<Span> opt_span = ffi::Optional<Span>());
 
 /*!

--- a/include/tvm/relax/script/builder/frame.h
+++ b/include/tvm/relax/script/builder/frame.h
@@ -110,9 +110,9 @@ class FunctionFrameNode : public SeqExprFrameNode {
    */
   ffi::Optional<tvm::relax::StructInfo> ret_struct_info;
   /*! \brief Whether the function is annotated as pure */
-  ffi::Optional<Bool> is_pure;
+  ffi::Optional<bool> is_pure;
   /*! \brief Whether the function is annotated as private */
-  ffi::Optional<Bool> is_private;
+  ffi::Optional<bool> is_private;
   /*! \brief The function attributes. */
   ffi::Map<ffi::String, Any> attrs;
   /*! \brief The block builder to create Relax function. */

--- a/include/tvm/relax/script/builder/ir.h
+++ b/include/tvm/relax/script/builder/ir.h
@@ -37,7 +37,7 @@ namespace relax {
  * \param is_private Whether the function is annotated as private.
  * \return The created ir_builder Function frame.
  */
-TVM_DLL FunctionFrame Function(const Bool& is_pure, const Bool& is_private);
+TVM_DLL FunctionFrame Function(bool is_pure, bool is_private);
 
 /*!
  * \brief Add a parameter to the last function frame.

--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -309,7 +309,7 @@ TVM_DLL Pass SplitLayoutRewritePreproc();
  * \return The Pass.
  */
 TVM_DLL Pass
-LiftTransformParams(ffi::Variant<Bool, ffi::Array<ffi::String>> shared_transform = Bool(false));
+LiftTransformParams(ffi::Variant<bool, ffi::Array<ffi::String>> shared_transform = false);
 
 /*!
  * \brief Update virtual device.

--- a/include/tvm/s_tir/analysis.h
+++ b/include/tvm/s_tir/analysis.h
@@ -145,7 +145,7 @@ TVM_DLL std::optional<MemCpyDetails> IdentifyMemCpy(const For& loop, arith::Anal
  * \param func The TIR PrimFunc for which the allocated memory size to be calculated
  * \return Allocated memory size per scope in bytes.
  */
-TVM_DLL ffi::Map<ffi::String, ffi::Map<ffi::String, Integer>> CalculateAllocatedBytes(
+TVM_DLL ffi::Map<ffi::String, ffi::Map<ffi::String, int64_t>> CalculateAllocatedBytes(
     const PrimFunc& func);
 
 /*!
@@ -153,7 +153,7 @@ TVM_DLL ffi::Map<ffi::String, ffi::Map<ffi::String, Integer>> CalculateAllocated
  * \param mod The IRModule for which the allocated memory size has to be calculated
  * \return Allocated memory size per scope in bytes for each function.
  */
-TVM_DLL ffi::Map<ffi::String, ffi::Map<ffi::String, Integer>> CalculateAllocatedBytes(
+TVM_DLL ffi::Map<ffi::String, ffi::Map<ffi::String, int64_t>> CalculateAllocatedBytes(
     const IRModule& mod);
 
 /**
@@ -168,7 +168,7 @@ TVM_DLL ffi::Array<tvm::transform::Pass> GetVTCMCompactionPasses();
  * \param limit The limit to check.
  * \return true if the VTCM usage is within the provided limit.
  */
-TVM_DLL bool VerifyVTCMLimit(const IRModule& mod, Integer limit);
+TVM_DLL bool VerifyVTCMLimit(const IRModule& mod, int64_t limit);
 
 /*!
  * \brief Verifies that the VTCM usage of the given prim_func is within the provided limit.
@@ -176,7 +176,7 @@ TVM_DLL bool VerifyVTCMLimit(const IRModule& mod, Integer limit);
  * \param limit The limit to check.
  * \return true if the VTCM usage is within the provided limit.
  */
-TVM_DLL bool VerifyVTCMLimit(const PrimFunc& func, Integer limit);
+TVM_DLL bool VerifyVTCMLimit(const PrimFunc& func, int64_t limit);
 
 namespace transform {
 

--- a/include/tvm/s_tir/meta_schedule/schedule/cuda/thread_bind.h
+++ b/include/tvm/s_tir/meta_schedule/schedule/cuda/thread_bind.h
@@ -37,7 +37,7 @@ namespace meta_schedule {
  * \return A sampler that returns a random thread extent.
  */
 std::function<s_tir::ExprRV(int64_t)> MakeFactorSampler(s_tir::Schedule sch,
-                                                        ffi::Array<Integer> thread_extents);
+                                                        ffi::Array<int64_t> thread_extents);
 
 /*!
  * \brief Bind blockIdx.x and threadIdx.x to the given loop

--- a/include/tvm/s_tir/meta_schedule/schedule_rule.h
+++ b/include/tvm/s_tir/meta_schedule/schedule_rule.h
@@ -160,8 +160,8 @@ class ScheduleRule : public ffi::ObjectRef {
   TVM_DLL static ScheduleRule MultiLevelTiling(
       ffi::String structure,                                      //
       ffi::Optional<ffi::Array<ffi::String>> tile_binds,          //
-      ffi::Optional<Integer> max_innermost_factor,                //
-      ffi::Optional<ffi::Array<Integer>> vector_load_lens,        //
+      ffi::Optional<int64_t> max_innermost_factor,                //
+      ffi::Optional<ffi::Array<int64_t>> vector_load_lens,        //
       ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,  //
       ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write,
       ffi::Optional<ffi::Function> filter_fn = std::nullopt);
@@ -186,8 +186,8 @@ class ScheduleRule : public ffi::ObjectRef {
   TVM_DLL static ScheduleRule MultiLevelTilingWithIntrin(
       ffi::String intrin_name, ffi::String structure,
       ffi::Optional<ffi::Array<ffi::String>> tile_binds,
-      ffi::Optional<Integer> max_innermost_factor,
-      ffi::Optional<ffi::Array<Integer>> vector_load_lens,
+      ffi::Optional<int64_t> max_innermost_factor,
+      ffi::Optional<ffi::Array<int64_t>> vector_load_lens,
       ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,
       ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write);
 
@@ -214,8 +214,8 @@ class ScheduleRule : public ffi::ObjectRef {
   TVM_DLL static ScheduleRule MultiLevelTilingTensorCore(
       ffi::Array<ffi::Map<ffi::String, ffi::String>> intrin_groups, ffi::String structure,
       ffi::Optional<ffi::Array<ffi::String>> tile_binds,
-      ffi::Optional<Integer> max_innermost_factor,
-      ffi::Optional<ffi::Array<Integer>> vector_load_lens,
+      ffi::Optional<int64_t> max_innermost_factor,
+      ffi::Optional<ffi::Array<int64_t>> vector_load_lens,
       ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,
       ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write, bool use_software_pipeline);
 
@@ -232,7 +232,7 @@ class ScheduleRule : public ffi::ObjectRef {
    */
   TVM_DLL static ScheduleRule MultiLevelTilingWideVector(
       ffi::String structure, Integer vector_length_in_bits,
-      ffi::Optional<Integer> max_innermost_factor,
+      ffi::Optional<int64_t> max_innermost_factor,
       ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,
       ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write);
 
@@ -245,14 +245,14 @@ class ScheduleRule : public ffi::ObjectRef {
    * limit \return The schedule rule created
    */
   TVM_DLL static ScheduleRule AddRFactor(int max_jobs_per_core,  //
-                                         ffi::Optional<Integer> max_innermost_factor);
+                                         ffi::Optional<int64_t> max_innermost_factor);
   /*!
    * \brief Create a schedule rule which applies cross-thread reduction to some reduction blocks
    * correspondingly when needed
    * \param thread_extents Candidates of thread axis extent (values are required to be positive).
    * \return The schedule rule created
    */
-  TVM_DLL static ScheduleRule CrossThreadReduction(ffi::Array<Integer> thread_extents);
+  TVM_DLL static ScheduleRule CrossThreadReduction(ffi::Array<int64_t> thread_extents);
   /*!
    * \brief A rule that randomly select a compute-at location for a free block
    * \return The schedule rule created
@@ -273,7 +273,7 @@ class ScheduleRule : public ffi::ObjectRef {
    */
   TVM_DLL static ScheduleRule ParallelizeVectorizeUnroll(int max_jobs_per_core,                 //
                                                          int max_vectorize_extent,              //
-                                                         ffi::Array<Integer> unroll_max_steps,  //
+                                                         ffi::Array<int64_t> unroll_max_steps,  //
                                                          bool unroll_explicit);
   /*!
    * \brief Auto bind loops around the block to BlockIdx and ThreadIdx
@@ -283,7 +283,7 @@ class ScheduleRule : public ffi::ObjectRef {
    * when this schedule rule is created.
    * \return The schedule rule created
    */
-  TVM_DLL static ScheduleRule AutoBind(int max_threadblocks, ffi::Array<Integer> thread_extents,
+  TVM_DLL static ScheduleRule AutoBind(int max_threadblocks, ffi::Array<int64_t> thread_extents,
                                        int max_threads_per_block = -1);
   /*!
    * \brief Create a schedule rule with customized methods on the python-side.

--- a/include/tvm/s_tir/schedule/schedule.h
+++ b/include/tvm/s_tir/schedule/schedule.h
@@ -229,9 +229,9 @@ class ScheduleNode : public ffi::Object {
    * \param decision The sampling decision
    * \return The random variable sampled from candidates
    */
-  virtual ExprRV SampleCategorical(const ffi::Array<Integer>& candidates,
+  virtual ExprRV SampleCategorical(const ffi::Array<int64_t>& candidates,
                                    const ffi::Array<FloatImm>& probs,
-                                   ffi::Optional<Integer> decision = std::nullopt) = 0;
+                                   ffi::Optional<int64_t> decision = std::nullopt) = 0;
   /*!
    * \brief Sample the factors to perfect tile a specific loop
    * \param loop_rv The loop to be tiled
@@ -242,7 +242,7 @@ class ScheduleNode : public ffi::Object {
    */
   virtual ffi::Array<ExprRV> SamplePerfectTile(
       const LoopRV& loop_rv, int n, int max_innermost_factor,
-      ffi::Optional<ffi::Array<Integer>> decision = std::nullopt) = 0;
+      ffi::Optional<ffi::Array<int64_t>> decision = std::nullopt) = 0;
   /*!
    * \brief Sample the factors to a partitioned tile for a specific loop
    *
@@ -260,7 +260,7 @@ class ScheduleNode : public ffi::Object {
    */
   virtual ffi::Array<ExprRV> SamplePartitionedTile(
       const LoopRV& loop_rv, int n, int partition_pos, int innerpart_factor,
-      ffi::Optional<ffi::Array<Integer>> decision = std::nullopt) = 0;
+      ffi::Optional<ffi::Array<int64_t>> decision = std::nullopt) = 0;
   /*!
    * \brief Sample a compute-at location of the given block
    * \param block_rv The block whose compute-at location is to be sampled
@@ -268,7 +268,7 @@ class ScheduleNode : public ffi::Object {
    * \return The sampled loop where the input block is to be computed at
    */
   virtual LoopRV SampleComputeLocation(const SBlockRV& block_rv,
-                                       ffi::Optional<Integer> decision = std::nullopt) = 0;
+                                       ffi::Optional<int64_t> decision = std::nullopt) = 0;
 
   /******** Schedule: Get blocks & loops ********/
   /*!
@@ -397,7 +397,7 @@ class ScheduleNode : public ffi::Object {
    * \param new_order The new itervar order.
    */
   virtual void ReorderBlockIterVar(const SBlockRV& block_rv,
-                                   const ffi::Array<Integer> new_order) = 0;
+                                   const ffi::Array<int64_t> new_order) = 0;
   /*!
    * \brief Create a new unit loop on top of the specific block.
    * \param block_rv The block above which the new loop is created
@@ -835,7 +835,7 @@ class ScheduleNode : public ffi::Object {
    * The size of the producer buffers are infered from the padding size of the Einsum computation.
    * The producer buffers are padded by the initial value of the corresponding reduction.
    */
-  virtual void PadEinsum(const SBlockRV& block_rv, const ffi::Array<Integer>& padding) = 0;
+  virtual void PadEinsum(const SBlockRV& block_rv, const ffi::Array<int64_t>& padding) = 0;
 
   /******** Schedule: Buffer transformation ********/
   /*!

--- a/include/tvm/target/virtual_device.h
+++ b/include/tvm/target/virtual_device.h
@@ -295,8 +295,8 @@ class VirtualDevice : public ffi::ObjectRef {
   static VirtualDevice ForDeviceType(int device_type, int virtual_device_id = -1) {
     return ForDeviceType(static_cast<DLDeviceType>(device_type), virtual_device_id);
   }
-  static VirtualDevice ForDeviceType(const Integer& device_type, int virtual_device_id = -1) {
-    return ForDeviceType(static_cast<int>(device_type->value), virtual_device_id);
+  static VirtualDevice ForDeviceType(int64_t device_type, int virtual_device_id = -1) {
+    return ForDeviceType(static_cast<int>(device_type), virtual_device_id);
   }
 
   /*! \brief Returns the \p VirtualDevice for \p device. */

--- a/include/tvm/tirx/op_attr_types.h
+++ b/include/tvm/tirx/op_attr_types.h
@@ -80,7 +80,7 @@ enum class ScriptDtypePrintLocation : int {
   kLast = 2,
 };
 
-using TScriptDtypePrintLocation = Integer;
+using TScriptDtypePrintLocation = int64_t;
 
 /*!
  * \brief The effect type of the call.
@@ -149,7 +149,7 @@ inline std::ostream& operator<<(std::ostream& os, CallEffectKind side_effect) {
 }
 
 /*! \brief Use integer to record the kind. */
-using TCallEffectKind = Integer;
+using TCallEffectKind = int64_t;
 
 }  // namespace tirx
 }  // namespace tvm

--- a/python/tvm/relax/transform/legalize_ops/manipulate.py
+++ b/python/tvm/relax/transform/legalize_ops/manipulate.py
@@ -139,7 +139,7 @@ def _stack(bb: BlockBuilder, call: Call) -> Expr:
         t.fields if isinstance(t, Tuple) else [bb.emit(TupleGetItem(t, i)) for i in range(n_field)]
     )
 
-    return bb.call_te(topi.stack, fields, 0 if call.attrs.axis is None else call.attrs.axis.value)
+    return bb.call_te(topi.stack, fields, 0 if call.attrs.axis is None else call.attrs.axis)
 
 
 @register_legalize("relax.repeat")

--- a/python/tvm/relax/transform/legalize_ops/statistical.py
+++ b/python/tvm/relax/transform/legalize_ops/statistical.py
@@ -31,21 +31,21 @@ def _statistical(te_func: TEFunc) -> LegalizeFunc:
     return statistical_call_te
 
 
-def _compute_shape_prod(x: te.Tensor, axis: list[tirx.IntImm]) -> tirx.PrimExpr:
+def _compute_shape_prod(x: te.Tensor, axis: list[int]) -> tirx.PrimExpr:
     shape_prod = tirx.const(1, "int32")
-    axes = [_axis.value for _axis in axis] if axis is not None else range(0, len(x.shape))
+    axes = list(axis) if axis is not None else range(0, len(x.shape))
     for dim in axes:
         shape_prod = shape_prod * x.shape[dim]
     return shape_prod
 
 
-def _te_mean(x: te.Tensor, axis: list[tirx.IntImm], keepdims: bool) -> te.Tensor:
+def _te_mean(x: te.Tensor, axis: list[int], keepdims: bool) -> te.Tensor:
     shape_prod = _compute_shape_prod(x, axis)
     res_sum = topi.sum(x, axis, keepdims)
     return topi.divide(res_sum, shape_prod)
 
 
-def _te_variance(x: te.Tensor, axis: list[tirx.IntImm], keepdims: bool) -> te.Tensor:
+def _te_variance(x: te.Tensor, axis: list[int], keepdims: bool) -> te.Tensor:
     dev = x - _te_mean(x, axis, True)
     return _te_mean(dev * dev, axis, keepdims)
     # This version has better memory locality and performance
@@ -55,7 +55,7 @@ def _te_variance(x: te.Tensor, axis: list[tirx.IntImm], keepdims: bool) -> te.Te
 
 
 def _te_median(
-    x: te.Tensor, axis: list[tirx.IntImm], keepdims: bool
+    x: te.Tensor, axis: list[int], keepdims: bool
 ) -> te.Tensor | tuple[te.Tensor, te.Tensor]:
     # currently only supports one axis or no axis ~ same pytorch
     # todo: support multiple axis ~ same numpy
@@ -63,10 +63,10 @@ def _te_median(
     mid_index = (shape_prod - 1) // 2
 
     if axis is None or len(axis) == 0:
-        x = topi.reshape(x, [shape_prod.value])
+        x = topi.reshape(x, [shape_prod])
         ax = -1
     else:
-        ax = axis[0].value
+        ax = axis[0]
     index_sorted = topi.argsort(x, axis=ax, is_ascend=True, dtype="int64")
     x_sorted = topi.gather(x, axis=ax, indices=index_sorted)
 
@@ -97,7 +97,7 @@ def _mean(bb: BlockBuilder, call: Call) -> Expr:
 
 @register_legalize("relax.std")
 def _std(bb: BlockBuilder, call: Call) -> Expr:
-    def te_std(x: te.Tensor, axis: list[tirx.IntImm], keepdims: bool) -> te.Tensor:
+    def te_std(x: te.Tensor, axis: list[int], keepdims: bool) -> te.Tensor:
         return topi.sqrt(_te_variance(x, axis, keepdims))
 
     return bb.call_te(

--- a/src/arith/scalable_expression.cc
+++ b/src/arith/scalable_expression.cc
@@ -93,7 +93,7 @@ bool TargetHasVLA(ffi::Optional<Target> target) {
   bool has_vla{false};
   if (target.defined()) {
     // aarch64
-    has_vla = Downcast<Target>(target)->GetAttr<Bool>("feature.has_sve").value_or(Bool(false));
+    has_vla = Downcast<Target>(target)->GetAttr<bool>("feature.has_sve").value_or(Bool(false));
     // riscv{32,64}
     static auto target_has_feature_fn =
         tvm::ffi::Function::GetGlobalRequired("target.target_has_feature");

--- a/src/arith/scalable_expression.cc
+++ b/src/arith/scalable_expression.cc
@@ -93,7 +93,7 @@ bool TargetHasVLA(ffi::Optional<Target> target) {
   bool has_vla{false};
   if (target.defined()) {
     // aarch64
-    has_vla = Downcast<Target>(target)->GetAttr<bool>("feature.has_sve").value_or(Bool(false));
+    has_vla = Downcast<Target>(target)->GetAttr<bool>("feature.has_sve").value_or(false);
     // riscv{32,64}
     static auto target_has_feature_fn =
         tvm::ffi::Function::GetGlobalRequired("target.target_has_feature");

--- a/src/ir/transform.cc
+++ b/src/ir/transform.cc
@@ -38,7 +38,7 @@ namespace transform {
 
 using tvm::ffi::Any;
 
-TVM_REGISTER_PASS_CONFIG_OPTION("testing.immutable_module", Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("testing.immutable_module", bool);
 
 struct PassContextThreadLocalEntry {
   /*! \brief The default pass context. */
@@ -301,7 +301,7 @@ IRModule Pass::operator()(IRModule mod, const PassContext& pass_ctx) const {
     return mod;
   }
   IRModule ret;
-  if (pass_ctx->GetConfig<Bool>("testing.immutable_module", Bool(false)).value()) {
+  if (pass_ctx->GetConfig<bool>("testing.immutable_module", false).value()) {
     ret = Pass::AssertImmutableModule(mod, node, pass_ctx);
   } else {
     ret = node->operator()(std::move(mod), pass_ctx);

--- a/src/relax/analysis/computable_at_compile_time.cc
+++ b/src/relax/analysis/computable_at_compile_time.cc
@@ -43,8 +43,8 @@ class CompileTimeCollector : ExprVisitor {
 
  private:
   void VisitExpr_(const FunctionNode* func) override {
-    if (auto opt_num_input = func->attrs.GetAttr<Integer>(attr::kNumInput)) {
-      size_t num_input = opt_num_input.value()->value;
+    if (auto opt_num_input = func->attrs.GetAttr<int64_t>(attr::kNumInput)) {
+      size_t num_input = opt_num_input.value();
       for (size_t i = num_input; i < func->params.size(); i++) {
         MarkAsKnown(func->params[i]);
       }

--- a/src/relax/backend/adreno/annotate_custom_storage.cc
+++ b/src/relax/backend/adreno/annotate_custom_storage.cc
@@ -338,7 +338,7 @@ class CollectConsumerScopeInfo : public ExprVisitor {
     static const Op& call_tir_op = Op::Get("relax.call_tir");
     GlobalVar gv;
     ffi::Array<Attrs> op_attrs;
-    ffi::Optional<Integer> op_pattern = Integer(static_cast<int>(OpPatternKind::kOpaque));
+    ffi::Optional<int64_t> op_pattern = static_cast<int64_t>(OpPatternKind::kOpaque);
     Tuple func_args;
 
     if (call->op == call_tir_op) {
@@ -349,7 +349,7 @@ class CollectConsumerScopeInfo : public ExprVisitor {
       func_args = Downcast<Tuple>(call->args[1]);
     } else {
       op_attrs = {call->attrs};
-      op_pattern = Integer(static_cast<int>(OpPatternKind::kOpaque));
+      op_pattern = static_cast<int64_t>(OpPatternKind::kOpaque);
       func_args = Tuple(call->args);
     }
 
@@ -392,13 +392,13 @@ class CollectConsumerScopeInfo : public ExprVisitor {
   }
 
   template <typename T>
-  ffi::Optional<Integer> ExtractPattern(const T& func) {
-    ffi::Optional<Integer> op_pat = func->template GetAttr<Integer>("op_pattern");
+  ffi::Optional<int64_t> ExtractPattern(const T& func) {
+    ffi::Optional<int64_t> op_pat = func->template GetAttr<int64_t>("op_pattern");
     return op_pat;
   }
 
-  std::vector<bool> SupportsTexture(const ffi::Array<Attrs>& op_attrs, Integer op_pattern) {
-    if (op_pattern.IntValue() < OpPatternKind::kCommReduce) return {true};
+  std::vector<bool> SupportsTexture(const ffi::Array<Attrs>& op_attrs, int64_t op_pattern) {
+    if (op_pattern < OpPatternKind::kCommReduce) return {true};
 
     for (auto attr : op_attrs) {
       if (auto conv_attr = attr.as<Conv2DAttrs>()) {
@@ -435,9 +435,9 @@ class CollectConsumerScopeInfo : public ExprVisitor {
       }
       std::map<int, std::string> diffs;
       int spatial_limit =
-          target_->GetAttr<Integer>("texture_spatial_limit").value_or(Integer(16384))->value;
+          static_cast<int>(target_->GetAttr<int64_t>("texture_spatial_limit").value_or(16384));
       int depth_limit =
-          target_->GetAttr<Integer>("texture_depth_limit").value_or(Integer(2048))->value;
+          static_cast<int>(target_->GetAttr<int64_t>("texture_depth_limit").value_or(2048));
       int a0 = shape[0].as<IntImmNode>()->value;
       int a1 = shape[1].as<IntImmNode>()->value;
       int a2 = shape[2].as<IntImmNode>()->value;

--- a/src/relax/backend/contrib/clml/codegen.cc
+++ b/src/relax/backend/contrib/clml/codegen.cc
@@ -254,10 +254,7 @@ class OpenCLMLJSONSerializer : public JSONSerializer {
       auto p = pad_attr->pad_width;
       // Pad layout for TVM: dimension wise pre and post padding.
       // CLML takes dimension wise pre-padding followed by dimension wise post-padding for W, H.
-      json_node->SetAttr(
-          "padding",
-          ffi::Array<int64_t>{p[4].as<IntImmNode>()->value, p[6].as<IntImmNode>()->value,
-                              p[5].as<IntImmNode>()->value, p[7].as<IntImmNode>()->value});
+      json_node->SetAttr("padding", ffi::Array<int64_t>{p[4], p[6], p[5], p[7]});
     }
 
     if (nodes.activation) {

--- a/src/relax/backend/contrib/nnapi/codegen.cc
+++ b/src/relax/backend/contrib/nnapi/codegen.cc
@@ -58,7 +58,7 @@ class CollectFromCompositeFunctionBody : public ExprVisitor {
     if (permute_dims_attr->axes) {
       ffi::Array<int64_t> axes;
       for (auto axis : permute_dims_attr->axes.value()) {
-        axes.push_back(axis.IntValue());
+        axes.push_back(axis);
       }
       node_->SetAttr("axes", std::move(axes));
     }
@@ -78,7 +78,7 @@ class CollectFromCompositeFunctionBody : public ExprVisitor {
     {
       ffi::Array<int64_t> axis;
       for (auto dim : mean_attrs->axis.value()) {
-        axis.push_back(dim->value);
+        axis.push_back(dim);
       }
       node_->SetAttr("axis", std::move(axis));
     }

--- a/src/relax/backend/contrib/tensorrt/codegen.cc
+++ b/src/relax/backend/contrib/tensorrt/codegen.cc
@@ -183,9 +183,9 @@ class TensorRTJSONSerializer : public JSONSerializer {
       cfg = AttrsWithDefaultValues<TensorRTCompilerConfig>();
     }
     TVM_FFI_ICHECK_EQ(cfg.value()->tensorrt_version.size(), 3);
-    ffi::Array<int64_t> tensorrt_version = {cfg.value()->tensorrt_version[0].IntValue(),
-                                            cfg.value()->tensorrt_version[1].IntValue(),
-                                            cfg.value()->tensorrt_version[2].IntValue()};
+    ffi::Array<int64_t> tensorrt_version = {cfg.value()->tensorrt_version[0],
+                                            cfg.value()->tensorrt_version[1],
+                                            cfg.value()->tensorrt_version[2]};
     node->SetAttr("tensorrt_version", std::move(tensorrt_version));
     node->SetAttr("use_implicit_batch", static_cast<int64_t>(cfg.value()->use_implicit_batch));
     node->SetAttr("max_workspace_size", static_cast<int64_t>(cfg.value()->max_workspace_size));

--- a/src/relax/backend/contrib/tensorrt/codegen.cc
+++ b/src/relax/backend/contrib/tensorrt/codegen.cc
@@ -257,7 +257,7 @@ inline constexpr bool IsTensorRTRuntimeEnabled() {
  */
 ffi::Array<int64_t> GetTensorRTVersion() {
 #if TVM_GRAPH_EXECUTOR_TENSORRT
-  return {Integer(NV_TENSORRT_MAJOR), Integer(NV_TENSORRT_MINOR), Integer(NV_TENSORRT_PATCH)};
+  return {NV_TENSORRT_MAJOR, NV_TENSORRT_MINOR, NV_TENSORRT_PATCH};
 #else
   return {};
 #endif  // TVM_GRAPH_EXECUTOR_TENSORRT

--- a/src/relax/backend/contrib/tensorrt/codegen.cc
+++ b/src/relax/backend/contrib/tensorrt/codegen.cc
@@ -47,7 +47,7 @@ namespace contrib {
 
 /*! \brief Attributes to store the compiler options for TensorRT. */
 struct TensorRTCompilerConfigNode : public ffi::Object {
-  ffi::Array<Integer> tensorrt_version;
+  ffi::Array<int64_t> tensorrt_version;
   bool use_implicit_batch;
   size_t max_workspace_size;
   bool remove_no_mac_subgraphs;
@@ -59,7 +59,7 @@ struct TensorRTCompilerConfigNode : public ffi::Object {
     refl::ObjectDef<TensorRTCompilerConfigNode>()
         .def_ro("tensorrt_version", &TensorRTCompilerConfigNode::tensorrt_version,
                 "TensorRT version as (major, minor, patch).",
-                refl::DefaultValue(ffi::Array<Integer>({6, 0, 1})))
+                refl::DefaultValue(ffi::Array<int64_t>({6, 0, 1})))
         .def_ro("use_implicit_batch", &TensorRTCompilerConfigNode::use_implicit_batch,
                 "Use implicit batch", refl::DefaultValue(true))
         .def_ro("max_workspace_size", &TensorRTCompilerConfigNode::max_workspace_size,
@@ -255,7 +255,7 @@ inline constexpr bool IsTensorRTRuntimeEnabled() {
  * \return Array of three integers for major, minor, and patch, or empty array if TensorRT graph
  * runtime is not enabled.
  */
-ffi::Array<Integer> GetTensorRTVersion() {
+ffi::Array<int64_t> GetTensorRTVersion() {
 #if TVM_GRAPH_EXECUTOR_TENSORRT
   return {Integer(NV_TENSORRT_MAJOR), Integer(NV_TENSORRT_MINOR), Integer(NV_TENSORRT_PATCH)};
 #else

--- a/src/relax/backend/vm/codegen_vm_tir.cc
+++ b/src/relax/backend/vm/codegen_vm_tir.cc
@@ -197,7 +197,7 @@ class CodeGenVMTIR : public ExprFunctor<ffi::Optional<PrimExpr>(const Expr&)> {
     ffi::String tir_func_name = system_lib_prefix_.value_or("") + "__vmtir__" + gsymbol.value();
     tirx::PrimFunc tir_func(tir_params, body, ret_type, {});
     tir_func = WithAttr(tir_func, "global_symbol", tir_func_name);
-    tir_func = WithAttr(tir_func, tvm::attr::kSTir, tvm::Bool(true));
+    tir_func = WithAttr(tir_func, tvm::attr::kSTir, true);
     registers_num_ = 0;
     var_map_.clear();
     stmt_stack_.clear();

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -246,10 +246,10 @@ class VMShapeLowerMutator
       this->builder_->EmitNormalized(shape_heap_binding);
       std::vector<MatchShapeTodoItem> match_todos;
       size_t num_input = func->params.size();
-      if (auto opt_num_input = func->attrs.GetAttr<Integer>(attr::kNumInput)) {
+      if (auto opt_num_input = func->attrs.GetAttr<int64_t>(attr::kNumInput)) {
         // If the function has the attribute 'num_input', do shape checking on for the real inputs
         // and skip weights.
-        num_input = static_cast<size_t>(opt_num_input.value()->value);
+        num_input = static_cast<size_t>(opt_num_input.value());
       }
       for (size_t i = 0; i < func->params.size(); ++i) {
         StructInfo sinfo = GetStructInfo(func->params[i]);

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -596,7 +596,7 @@ class VMShapeLowerMutator
     // the shape_func to indicate that this is a host function
     // This could require us to attach target to the relax function here.
     tirx::PrimFunc shape_func(params, body, ret_type, buffer_map);
-    shape_func = WithAttr(std::move(shape_func), tvm::attr::kSTir, tvm::Bool(true));
+    shape_func = WithAttr(std::move(shape_func), tvm::attr::kSTir, true);
     if (!shape_func->attrs.GetAttr<tvm::Target>(tvm::attr::kTarget).has_value()) {
       // kTarget and kIsHostFunc are mutually exclusive
       shape_func =

--- a/src/relax/distributed/axis_group_graph.cc
+++ b/src/relax/distributed/axis_group_graph.cc
@@ -164,7 +164,7 @@ void BuildAxisGraphBinary(const Var& output_var, const Call& call,
 void BuildAxisGraphReduce(const Var& output_var, const Call& call,
                           distributed::AxisGroupGraph* axis_group_graph) {
   Expr input_tensor = call->args[0];
-  ffi::Array<Integer> axes;
+  ffi::Array<int64_t> axes;
   bool keepdims;
   if (const auto* attrs = call->attrs.as<StatisticalAttrs>()) {
     if (attrs->axis.defined()) {

--- a/src/relax/distributed/global_info.cc
+++ b/src/relax/distributed/global_info.cc
@@ -26,7 +26,7 @@ namespace distributed {
 
 TVM_FFI_STATIC_INIT_BLOCK() { DeviceMeshNode::RegisterReflection(); }
 
-DeviceMesh::DeviceMesh(ffi::Shape shape, ffi::Array<Integer> device_ids) {
+DeviceMesh::DeviceMesh(ffi::Shape shape, ffi::Array<int64_t> device_ids) {
   int prod = 1;
   for (int i = 0; i < static_cast<int>(shape.size()); i++) {
     prod *= shape[i];
@@ -41,7 +41,7 @@ DeviceMesh::DeviceMesh(ffi::Shape shape, ffi::Array<Integer> device_ids) {
 
 DeviceMesh::DeviceMesh(ffi::Shape shape, Range device_range) {
   ffi::ObjectPtr<DeviceMeshNode> n = ffi::make_object<DeviceMeshNode>();
-  ffi::Array<Integer> device_ids;
+  ffi::Array<int64_t> device_ids;
   int range_start = device_range->min.as<IntImmNode>()->value;
   int range_extent = device_range->extent.as<IntImmNode>()->value;
   for (int i = range_start; i < range_start + range_extent; i++) {
@@ -63,7 +63,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def(
       "relax.distributed.DeviceMesh",
-      [](ffi::Shape shape, ffi::Array<Integer> device_ids, ffi::Optional<Range> device_range) {
+      [](ffi::Shape shape, ffi::Array<int64_t> device_ids, ffi::Optional<Range> device_range) {
         if (device_range.defined())
           return DeviceMesh(shape, device_range.value());
         else

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -229,7 +229,7 @@ TupleGetItem::TupleGetItem(Expr tuple, int index, Span span) {
 }
 
 TupleGetItem WithFields(TupleGetItem tuple_get_item, ffi::Optional<Expr> opt_tuple,
-                        ffi::Optional<Integer> opt_index, ffi::Optional<Span> opt_span) {
+                        ffi::Optional<int64_t> opt_index, ffi::Optional<Span> opt_span) {
   Expr tuple = opt_tuple.value_or(tuple_get_item->tuple);
   Integer index = opt_index.value_or(tuple_get_item->index);
   Span span = opt_span.value_or(tuple_get_item->span);

--- a/src/relax/op/ccl/ccl.cc
+++ b/src/relax/op/ccl/ccl.cc
@@ -59,7 +59,7 @@ TVM_REGISTER_OP("relax.ccl.allreduce")
     .add_argument("x", "Tensor", "Input to which allreduce will be applied.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAllReduce)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutUnaryEwise)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.ccl.allgather */
 
@@ -98,7 +98,7 @@ TVM_REGISTER_OP("relax.ccl.allgather")
     .add_argument("x", "Tensor", "Input to which allgather will be applied.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAllGather)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutUnaryEwise)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.ccl.broadcast_from_worker0 */
 Expr broadcast_from_worker0(Expr x) {
@@ -121,7 +121,7 @@ TVM_REGISTER_OP("relax.ccl.broadcast_from_worker0")
     .add_argument("x", "Tensor", "Input to be broadcast.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoBroadcastFromZero)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutUnaryEwise)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.ccl.scatter_from_worker0 */
 
@@ -170,7 +170,7 @@ TVM_REGISTER_OP("relax.ccl.scatter_from_worker0")
                   "The buffer to be divided into equal parts and sent to each worker accordingly.")
     .set_attrs_type<ScatterCollectiveAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoScatter)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/distributed/distributed.cc
+++ b/src/relax/op/distributed/distributed.cc
@@ -65,7 +65,7 @@ TVM_REGISTER_OP("relax.dist.annotate_sharding")
     .add_argument("input", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAnnotateSharding)
     .set_attr<FInferStructInfo>("dist.FInferStructInfo", InferStructInfoAnnotateSharding)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.dist.redistribute */
 
@@ -95,7 +95,7 @@ TVM_REGISTER_OP("relax.dist.redistribute")
     .set_num_inputs(1)
     .add_argument("input", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("dist.FInferStructInfo", InferDistStructInfoRedistribute)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 StructInfo InferStructInfoCallTIRLocalView(const Call& call, const BlockBuilder& ctx) {
   if (call->sinfo_args.size() != 1) {
@@ -117,7 +117,7 @@ TVM_REGISTER_OP("relax.dist.call_tir_local_view")
                   "ShapeExpr representing a tuple of ints to unpack during runtime. Omitted from "
                   "args if unused")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallTIRLocalView)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeCallTIRLocalView(Expr func, Tuple args,
                           ffi::Array<distributed::DTensorStructInfo> out_sinfo_list,
@@ -232,7 +232,7 @@ TVM_REGISTER_OP("relax.dist.redistribute_replica_to_shard")
     .set_attrs_type<ScatterCollectiveAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoRtoS)
     .set_attr<FInferStructInfo>("dist.FInferStructInfo", InferDistStructInfoRtoS)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/image/resize.cc
+++ b/src/relax/op/image/resize.cc
@@ -148,7 +148,7 @@ TVM_REGISTER_OP("relax.image.resize2d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoResize2D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutResize2d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.resize3d */
 
@@ -261,7 +261,7 @@ TVM_REGISTER_OP("relax.image.resize3d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoResize3D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutResize3d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.grid_sample */
 
@@ -339,7 +339,7 @@ TVM_REGISTER_OP("relax.image.grid_sample")
     .add_argument("grid", "Tensor", "The grid tensor for sampling.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoGridSample)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.image.affine_grid */
 
@@ -431,7 +431,7 @@ TVM_REGISTER_OP("relax.image.affine_grid")
     .add_argument("size", "Shape", "The target output shape (H, W).")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAffineGrid)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/memory/view.cc
+++ b/src/relax/op/memory/view.cc
@@ -359,9 +359,9 @@ TVM_REGISTER_OP("relax.memory.view")
     .add_argument("dtype", "DataType", "The view's data type.")
     .add_argument("relative_byte_offset", "Prim(\"int64\")",
                   "The view's byte offset, relative to the input tensor's byte offset.")
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
+    .set_attr<bool>("RequiresArgumentShapes", false)
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoView)
-    .set_attr<Bool>("FPurity", Bool(true))
+    .set_attr<bool>("FPurity", true)
     .set_attr<FLowerBuiltin>("FLowerBuiltin", LowerBuiltinView);
 
 Expr ensure_zero_offset(const Expr& x) {
@@ -391,9 +391,9 @@ Expr LowerBuiltinEnsureZeroOffset(const BlockBuilder& bb, const Call& call) {
 TVM_REGISTER_OP("relax.memory.ensure_zero_offset")
     .set_num_inputs(1)
     .add_argument("x", "Tensor", "The input tensor.")
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
+    .set_attr<bool>("RequiresArgumentShapes", false)
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoEnsureZeroOffset)
-    .set_attr<Bool>("FPurity", Bool(true))
+    .set_attr<bool>("FPurity", true)
     .set_attr<FLowerBuiltin>("FLowerBuiltin", LowerBuiltinEnsureZeroOffset);
 
 }  // namespace relax

--- a/src/relax/op/nn/attention.cc
+++ b/src/relax/op/nn/attention.cc
@@ -157,7 +157,7 @@ TVM_REGISTER_OP("relax.nn.attention")
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
     .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionAttention)
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAttention)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 TVM_REGISTER_OP("relax.nn.attention_bias")
     .set_attrs_type<AttentionAttrs>()
@@ -169,7 +169,7 @@ TVM_REGISTER_OP("relax.nn.attention_bias")
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
     .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionAttention)
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAttention)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 TVM_REGISTER_OP("relax.nn.attention_var_len")
     .set_attrs_type<AttentionAttrs>()
@@ -184,7 +184,7 @@ TVM_REGISTER_OP("relax.nn.attention_var_len")
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
     .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionAttention)
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAttention)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 TVM_FFI_STATIC_INIT_BLOCK() { AttentionAttrs::RegisterReflection(); }
 

--- a/src/relax/op/nn/convolution.cc
+++ b/src/relax/op/nn/convolution.cc
@@ -202,7 +202,7 @@ TVM_REGISTER_OP("relax.nn.conv1d")
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutConv1d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
     .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionConv1d)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.conv2d */
 
@@ -410,7 +410,7 @@ TVM_REGISTER_OP("relax.nn.conv2d")
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutConv2d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
     .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionConv2d)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.conv3d */
 
@@ -592,7 +592,7 @@ TVM_REGISTER_OP("relax.nn.conv3d")
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutConv3d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
     .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionConv3d)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr conv1d_transpose(Expr data, Expr weight, ffi::Array<int64_t> strides,
                       ffi::Array<int64_t> padding, ffi::Array<int64_t> output_padding,
@@ -774,7 +774,7 @@ TVM_REGISTER_OP("relax.nn.conv1d_transpose")
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutConv1dTranspose)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
     .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionConv1dTranspose)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.conv2d_transpose */
 
@@ -1005,7 +1005,7 @@ TVM_REGISTER_OP("relax.nn.conv2d_transpose")
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutConv2dTranspose)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
     .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionConv2dTranspose)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.conv3d_transpose */
 
@@ -1247,7 +1247,7 @@ TVM_REGISTER_OP("relax.nn.conv3d_transpose")
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutConv3dTranspose)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
     .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionConv3dTranspose)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -79,7 +79,7 @@ TVM_REGISTER_OP("relax.nn.leakyrelu")
     .set_attrs_type<LeakyReluAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo",
                                 InferStructInfoUnaryArith</*require_float_dtype=*/true>)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.softplus */
 
@@ -102,7 +102,7 @@ TVM_REGISTER_OP("relax.nn.softplus")
     .set_attrs_type<SoftplusAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo",
                                 InferStructInfoUnaryArith</*require_float_dtype=*/true>)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.prelu */
 
@@ -166,7 +166,7 @@ TVM_REGISTER_OP("relax.nn.prelu")
     .set_attrs_type<PReluAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPRelu)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPRelu)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.softmax */
 
@@ -228,7 +228,7 @@ TVM_REGISTER_OP("relax.nn.softmax")
     .set_attrs_type<SoftmaxAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoSoftmax)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutSoftmax)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.log_softmax */
 Expr log_softmax(Expr data, int axis) {
@@ -248,11 +248,11 @@ TVM_REGISTER_OP("relax.nn.log_softmax")
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attrs_type<SoftmaxAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoSoftmax)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.pad */
 
-Expr pad(Expr data, ffi::Array<Integer> pad_width, ffi::String pad_mode, double pad_value) {
+Expr pad(Expr data, ffi::Array<int64_t> pad_width, ffi::String pad_mode, double pad_value) {
   auto attrs = ffi::make_object<PadAttrs>();
   attrs->pad_width = std::move(pad_width);
   attrs->pad_mode = std::move(pad_mode);
@@ -270,7 +270,7 @@ StructInfo InferStructInfoPad(const Call& call, const BlockBuilder& ctx) {
   ffi::Array<TensorStructInfo> input_sinfo = GetInputTensorStructInfo(call, ctx);
   const auto* attrs = call->attrs.as<PadAttrs>();
   int ndim = input_sinfo[0]->ndim;
-  ffi::Array<Integer> pad_width = attrs->pad_width;
+  ffi::Array<int64_t> pad_width = attrs->pad_width;
   TVM_FFI_ICHECK(static_cast<int>(pad_width.size()) == 2 * ndim) << "Illegal pad_width";
 
   ffi::Array<PrimExpr> out_shape;
@@ -279,7 +279,7 @@ StructInfo InferStructInfoPad(const Call& call, const BlockBuilder& ctx) {
     const auto* data_shape = input_sinfo[0]->shape.as<ShapeExprNode>();
     for (int i = 0; i < ndim; i++) {
       // Sum pad width for this axis.
-      PrimExpr added_width = pad_width[2 * i] + pad_width[(2 * i) + 1];
+      PrimExpr added_width = IntImm(DataType::Int(64), pad_width[2 * i] + pad_width[(2 * i) + 1]);
       const PrimExpr current_width = data_shape->values[i];
       out_shape.push_back(current_width + added_width);
     }
@@ -295,7 +295,7 @@ TVM_REGISTER_OP("relax.nn.pad")
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attrs_type<PadAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPad)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.pixel_shuffle */
 
@@ -367,12 +367,12 @@ TVM_REGISTER_OP("relax.nn.pixel_shuffle")
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attrs_type<PixelShuffleAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPixelShuffle)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.batchnorm */
 bool NormCheckDtypeAndShape(const Call& call, const BlockBuilder& ctx,
                             const ffi::Array<TensorStructInfo>& input_sinfo,
-                            ffi::Array<Integer> axes) {
+                            ffi::Array<int64_t> axes) {
   Op op = Downcast<Op>(call->op);
   int n_input = op->arguments.size();
 
@@ -521,11 +521,11 @@ TVM_REGISTER_OP("relax.nn.batch_norm")
     .add_argument("moving_var", "Tensor", "Running variance of input.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoBatchNorm)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutBatchNorm)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.layer_norm */
 
-Expr layer_norm(Expr data, Expr gamma, Expr beta, ffi::Array<Integer> axes, double epsilon,
+Expr layer_norm(Expr data, Expr gamma, Expr beta, ffi::Array<int64_t> axes, double epsilon,
                 bool center, bool scale) {
   ffi::ObjectPtr<LayerNormAttrs> attrs = ffi::make_object<LayerNormAttrs>();
   attrs->axes = std::move(axes);
@@ -571,11 +571,11 @@ InferLayoutOutput InferLayoutLayerNorm(
   ffi::ObjectPtr<LayerNormAttrs> new_attrs = ffi::make_object<LayerNormAttrs>(*attrs);
   const auto* input_sinfo = GetStructInfoAs<TensorStructInfoNode>(call->args[0]);
   int ndim = input_sinfo->ndim;
-  std::vector<Integer> new_axis;
-  for (const auto& axis : attrs->axes) {
-    new_axis.push_back(FindAxis(layout->layout, (axis->value + ndim) % ndim));
+  std::vector<int64_t> new_axis;
+  for (int64_t axis : attrs->axes) {
+    new_axis.push_back(FindAxis(layout->layout, (axis + ndim) % ndim));
   }
-  new_attrs->axes = std::move(new_axis);
+  new_attrs->axes = ffi::Array<int64_t>(new_axis.begin(), new_axis.end());
   return InferLayoutOutput({layout, initial_layouts[1], initial_layouts[2]}, {layout},
                            Attrs(new_attrs));
 }
@@ -589,12 +589,12 @@ TVM_REGISTER_OP("relax.nn.layer_norm")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoLayerNorm)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutLayerNorm)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.group_norm */
 
 Expr group_norm(Expr data, Expr gamma, Expr beta, int num_groups, int channel_axis,
-                ffi::Array<Integer> axes, double epsilon, bool center, bool scale) {
+                ffi::Array<int64_t> axes, double epsilon, bool center, bool scale) {
   ffi::ObjectPtr<GroupNormAttrs> attrs = ffi::make_object<GroupNormAttrs>();
   attrs->num_groups = num_groups;
   attrs->channel_axis = channel_axis;
@@ -684,11 +684,11 @@ InferLayoutOutput InferLayoutGroupNorm(
 
   LayoutDecision layout = GetLayoutDecision(var_layout_map, call->args[0]);
   ffi::ObjectPtr<GroupNormAttrs> new_attrs = ffi::make_object<GroupNormAttrs>(*attrs);
-  std::vector<Integer> new_axes;
-  for (const auto& axis : attrs->axes) {
-    new_axes.push_back(FindAxis(layout->layout, axis->value));
+  std::vector<int64_t> new_axes;
+  for (int64_t axis : attrs->axes) {
+    new_axes.push_back(FindAxis(layout->layout, axis));
   }
-  new_attrs->axes = std::move(new_axes);
+  new_attrs->axes = ffi::Array<int64_t>(new_axes.begin(), new_axes.end());
   new_attrs->channel_axis = FindAxis(layout->layout, attrs->channel_axis);
   return InferLayoutOutput({layout, initial_layouts[1], initial_layouts[2]}, {layout},
                            Attrs(new_attrs));
@@ -703,11 +703,11 @@ TVM_REGISTER_OP("relax.nn.group_norm")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoGroupNorm)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutGroupNorm)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.instance_norm */
 
-Expr instance_norm(Expr data, Expr gamma, Expr beta, int channel_axis, ffi::Array<Integer> axes,
+Expr instance_norm(Expr data, Expr gamma, Expr beta, int channel_axis, ffi::Array<int64_t> axes,
                    double epsilon, bool center, bool scale) {
   ffi::ObjectPtr<InstanceNormAttrs> attrs = ffi::make_object<InstanceNormAttrs>();
   attrs->channel_axis = std::move(channel_axis);
@@ -787,11 +787,11 @@ InferLayoutOutput InferLayoutInstanceNorm(
 
   LayoutDecision layout = GetLayoutDecision(var_layout_map, call->args[0]);
   ffi::ObjectPtr<InstanceNormAttrs> new_attrs = ffi::make_object<InstanceNormAttrs>(*attrs);
-  std::vector<Integer> new_axes;
-  for (const auto& axis : attrs->axes) {
-    new_axes.push_back(FindAxis(layout->layout, (axis->value)));
+  std::vector<int64_t> new_axes;
+  for (int64_t axis : attrs->axes) {
+    new_axes.push_back(FindAxis(layout->layout, axis));
   }
-  new_attrs->axes = std::move(new_axes);
+  new_attrs->axes = ffi::Array<int64_t>(new_axes.begin(), new_axes.end());
   new_attrs->channel_axis = FindAxis(layout->layout, attrs->channel_axis);
   return InferLayoutOutput({layout, initial_layouts[1], initial_layouts[2]}, {layout},
                            Attrs(new_attrs));
@@ -806,10 +806,10 @@ TVM_REGISTER_OP("relax.nn.instance_norm")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoInstanceNorm)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutInstanceNorm)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 /* relax.nn.rms_norm */
 
-Expr rms_norm(Expr data, Expr weight, ffi::Array<Integer> axes, double epsilon) {
+Expr rms_norm(Expr data, Expr weight, ffi::Array<int64_t> axes, double epsilon) {
   ffi::ObjectPtr<RMSNormAttrs> attrs = ffi::make_object<RMSNormAttrs>();
   attrs->axes = std::move(axes);
   attrs->epsilon = epsilon;
@@ -850,11 +850,11 @@ InferLayoutOutput InferLayoutRMSNorm(
 
   LayoutDecision layout = GetLayoutDecision(var_layout_map, call->args[0]);
   ffi::ObjectPtr<RMSNormAttrs> new_attrs = ffi::make_object<RMSNormAttrs>(*attrs);
-  std::vector<Integer> new_axes;
-  for (const auto& axis : attrs->axes) {
-    new_axes.push_back(FindAxis(layout->layout, axis->value));
+  std::vector<int64_t> new_axes;
+  for (int64_t axis : attrs->axes) {
+    new_axes.push_back(FindAxis(layout->layout, axis));
   }
-  new_attrs->axes = std::move(new_axes);
+  new_attrs->axes = ffi::Array<int64_t>(new_axes.begin(), new_axes.end());
   return InferLayoutOutput({layout, initial_layouts[1]}, {layout}, Attrs(new_attrs));
 }
 
@@ -866,7 +866,7 @@ TVM_REGISTER_OP("relax.nn.rms_norm")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoRMSNorm)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutRMSNorm)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.dropout */
 
@@ -895,7 +895,7 @@ TVM_REGISTER_OP("relax.nn.dropout")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoDropout)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutUnaryEwise)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.cross_entropy_with_logits */
 StructInfo InferStructInfoCrossEntropy(const Call& call, const BlockBuilder& ctx) {
@@ -959,7 +959,7 @@ TVM_REGISTER_OP("relax.nn.cross_entropy_with_logits")
     .add_argument("predictions", "Tensor", "The predictions.")
     .add_argument("labels", "Tensor", "The labels.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCrossEntropy)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.nll_loss */
 
@@ -1191,7 +1191,7 @@ TVM_REGISTER_OP("relax.nn.nll_loss")
     .add_argument("targets", "Tensor", "The target tensor.")
     .add_argument("weights", "ffi::Optional<Tensor>", "The weight of each target values.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoNLLLoss)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.batch_flatten */
 
@@ -1241,7 +1241,7 @@ TVM_REGISTER_OP("relax.nn.batch_flatten")
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoBatchFlatten)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/nn/nn.h
+++ b/src/relax/op/nn/nn.h
@@ -83,19 +83,19 @@ Expr batch_norm(Expr data, Expr gamma, Expr beta, Expr moving_mean, Expr moving_
                 int axis, double epsilon, bool center, bool scale, double momentum, bool training);
 
 /*! \brief Compute layer normalization. */
-Expr layer_norm(Expr data, Expr gamma, Expr beta, ffi::Array<Integer> axes, double epsilon,
+Expr layer_norm(Expr data, Expr gamma, Expr beta, ffi::Array<int64_t> axes, double epsilon,
                 bool center, bool scale);
 
 /*! \brief Compute group normalization. */
 Expr group_norm(Expr data, Expr gamma, Expr beta, int num_groups, int channel_axis,
-                ffi::Array<Integer> axes, double epsilon, bool center, bool scale);
+                ffi::Array<int64_t> axes, double epsilon, bool center, bool scale);
 
 /*! \brief Compute instance normalization. */
-Expr instance_norm(Expr data, Expr gamma, Expr beta, int channel_axis, ffi::Array<Integer> axes,
+Expr instance_norm(Expr data, Expr gamma, Expr beta, int channel_axis, ffi::Array<int64_t> axes,
                    double epsilon, bool center, bool scale);
 
 /*! \brief Compute root mean square normalization. */
-Expr rms_norm(Expr data, Expr weight, ffi::Array<Integer> axes, double epsilon);
+Expr rms_norm(Expr data, Expr weight, ffi::Array<int64_t> axes, double epsilon);
 
 /*!
  * \brief Applies the dropout operation to the input tensor.

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -149,7 +149,7 @@ TVM_REGISTER_OP("relax.nn.max_pool1d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPool1D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPool1d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.max_pool2d */
 
@@ -300,7 +300,7 @@ TVM_REGISTER_OP("relax.nn.max_pool2d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPool2D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPool2d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.max_pool3d */
 
@@ -446,7 +446,7 @@ TVM_REGISTER_OP("relax.nn.max_pool3d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPool3D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPool3d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.avg_pool1d */
 Expr avg_pool1d(Expr data, ffi::Array<int64_t> pool_size, ffi::Array<int64_t> strides,
@@ -468,7 +468,7 @@ TVM_REGISTER_OP("relax.nn.avg_pool1d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPool1D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPool1d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.avg_pool2d */
 Expr avg_pool2d(Expr data, ffi::Array<int64_t> pool_size, ffi::Array<int64_t> strides,
@@ -490,7 +490,7 @@ TVM_REGISTER_OP("relax.nn.avg_pool2d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPool2D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPool2d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.avg_pool3d */
 Expr avg_pool3d(Expr data, ffi::Array<int64_t> pool_size, ffi::Array<int64_t> strides,
@@ -512,7 +512,7 @@ TVM_REGISTER_OP("relax.nn.avg_pool3d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPool3D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPool3d)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.adaptive_avg_pool1d */
 
@@ -594,7 +594,7 @@ TVM_REGISTER_OP("relax.nn.adaptive_avg_pool1d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAdaptiveAvgPool1D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutAdaptiveAvgPool1D)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.adaptive_avg_pool2d */
 
@@ -696,7 +696,7 @@ TVM_REGISTER_OP("relax.nn.adaptive_avg_pool2d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAdaptiveAvgPool2D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutAdaptiveAvgPool2D)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nn.adaptive_avg_pool3d */
 
@@ -783,7 +783,7 @@ TVM_REGISTER_OP("relax.nn.adaptive_avg_pool3d")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAdaptiveAvgPool3D)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutAdaptiveAvgPool3D)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -119,7 +119,7 @@ TVM_REGISTER_OP("relax.call_pure_packed")
                   "The first argument is the function being called. The rest are the "
                   "arguments to that function.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallPurePacked)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeCallPurePacked(const Expr& callee, ffi::Array<Expr> args, const Attrs& attrs,
                         ffi::Array<StructInfo> sinfo_args) {
@@ -162,7 +162,7 @@ StructInfo InferStructInfoCallInplacePacked(const Call& call, const BlockBuilder
   size_t num_args = call->args.size() - 1;
   std::unordered_set<int> encountered;
   for (size_t i = 0; i < attrs->inplace_indices.size(); i++) {
-    int index = attrs->inplace_indices[i].IntValue();
+    int index = attrs->inplace_indices[i];
     if (index < -1 || index >= static_cast<int>(num_args)) {
       ctx->ReportFatal(Diagnostic::Error(call)
                        << "In-place index " << i << " is out of range (must be between -1 and "
@@ -195,7 +195,7 @@ StructInfo InferStructInfoCallInplacePacked(const Call& call, const BlockBuilder
   // make sure that the derived return struct info matches that of the in-place args
   // (note: arg 0 is the packed func, so we add 1 to the arg index)
   if (attrs->inplace_indices.size() == 1) {
-    auto arg_idx = attrs->inplace_indices[0].IntValue() + 1;
+    auto arg_idx = attrs->inplace_indices[0] + 1;
     auto arg_sinfo = GetStructInfo(call->args[arg_idx]);
     if (!IsBaseOf(ret, arg_sinfo, ctx->GetAnalyzer())) {
       ctx->ReportFatal(Diagnostic::Error(call)
@@ -213,7 +213,7 @@ StructInfo InferStructInfoCallInplacePacked(const Call& call, const BlockBuilder
       if (attrs->inplace_indices[i] == -1) {
         continue;
       }
-      auto arg_idx = attrs->inplace_indices[i].IntValue() + 1;
+      auto arg_idx = attrs->inplace_indices[i] + 1;
       auto arg_sinfo = GetStructInfo(call->args[arg_idx]);
       auto ret_sinfo = tup_info->fields[i];
       if (!IsBaseOf(ret_sinfo, arg_sinfo, ctx->GetAnalyzer())) {
@@ -239,12 +239,12 @@ TVM_REGISTER_OP("relax.call_inplace_packed")
     // This should only be used if it has been *checked* that it is safe (no aliases, in-place
     // arguments will no longer be live) and the user believes the packed func to have no
     // side effects other than modifying the arguments specified as "inplace"
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
-Expr MakeCallInplacePacked(Expr func, ffi::Array<Expr> args, ffi::Array<Integer> inplace_indices,
+Expr MakeCallInplacePacked(Expr func, ffi::Array<Expr> args, ffi::Array<int64_t> inplace_indices,
                            ffi::Array<StructInfo> sinfo_args) {
   ffi::ObjectPtr<CallInplacePackedAttrs> attrs = ffi::make_object<CallInplacePackedAttrs>();
-  attrs->inplace_indices = ffi::Array<Integer>(inplace_indices.begin(), inplace_indices.end());
+  attrs->inplace_indices = ffi::Array<int64_t>(inplace_indices.begin(), inplace_indices.end());
 
   static const Op& op = Op::Get("relax.call_inplace_packed");
   ffi::Array<Expr> call_args = {func};
@@ -291,7 +291,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
  */
 static ffi::Optional<StructInfo> InferCallTIROutputStructInfoFromArguments(
     StructInfo func_sinfo, StructInfo arg_sinfo, ffi::Optional<StructInfo> packed_ints_sinfo,
-    ffi::Optional<ffi::Array<Integer>> opt_inplace_indices) {
+    ffi::Optional<ffi::Array<int64_t>> opt_inplace_indices) {
   auto opt_callee_sinfo = func_sinfo.as<FuncStructInfo>();
   TVM_FFI_CHECK(opt_callee_sinfo, TypeError)
       << "The first argument to `R.call_tir` must be a function, "
@@ -388,7 +388,7 @@ static ffi::Optional<StructInfo> InferCallTIROutputStructInfoFromArguments(
       // `out_sinfo`.
       auto inplace_indices = opt_inplace_indices.value();
       for (size_t i = 0; i < inplace_indices.size(); i++) {
-        auto inplace_input_index = inplace_indices[i]->value;
+        int64_t inplace_input_index = inplace_indices[i];
         if (inplace_input_index >= 0) {
           dummy_ret.insert(dummy_ret.begin() + i, callee_params[inplace_input_index]);
         }
@@ -555,7 +555,7 @@ void ValidateCallTIR(Call call) {
     }
   }();
 
-  auto opt_inplace_indices = [&]() -> ffi::Optional<ffi::Array<Integer>> {
+  auto opt_inplace_indices = [&]() -> ffi::Optional<ffi::Array<int64_t>> {
     if (const auto* attrs = call->attrs.as<CallTIRInplaceAttrs>()) {
       return attrs->inplace_indices;
     } else {
@@ -584,7 +584,7 @@ TVM_REGISTER_OP("relax.call_tir")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallTIR)
     .set_attr<FNormalize>("FNormalize", NormalizeCallTIR)
     .set_attr<FValidate>("FValidate", ValidateCallTIR)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeCallTIR(Expr func, Tuple args, ffi::Array<TensorStructInfo> out_sinfo_list,
                  ffi::Optional<Expr> packed_ints) {
@@ -632,7 +632,7 @@ TVM_REGISTER_OP("relax.call_tir_with_grad")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallTIR)
     .set_attr<FNormalize>("FNormalize", NormalizeCallTIR)
     .set_attr<FValidate>("FValidate", ValidateCallTIR)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeCallTIRWithGrad(Expr func, Tuple args, ffi::Array<TensorStructInfo> out_sinfo_list,
                          ffi::String te_grad_name, ffi::Map<ffi::String, ffi::Any> te_grad_kwargs,
@@ -701,7 +701,7 @@ Expr NormalizeCallTIRInPlace(const BlockBuilder& ctx, Call call) {
   size_t num_args = Downcast<Tuple>(call->args[1])->fields.size();
   std::unordered_set<int> encountered;
   for (size_t i = 0; i < attrs->inplace_indices.size(); i++) {
-    int index = attrs->inplace_indices[i].IntValue();
+    int index = attrs->inplace_indices[i];
     if (index < -1 || index >= static_cast<int>(num_args)) {
       ctx->ReportFatal(Diagnostic::Error(call)
                        << "In-place index " << i << " is out of range (must be between -1 and "
@@ -728,7 +728,7 @@ Expr NormalizeCallTIRInPlace(const BlockBuilder& ctx, Call call) {
   Tuple call_args = Downcast<Tuple>(call->args[1]);
 
   for (size_t i_output = 0; i_output < attrs->inplace_indices.size(); i_output++) {
-    auto i_input = attrs->inplace_indices[i_output].IntValue();
+    auto i_input = attrs->inplace_indices[i_output];
     if (i_input == -1) {
       continue;
     }
@@ -777,9 +777,9 @@ TVM_REGISTER_OP("relax.call_tir_inplace")
     // Warning: considered pure, but it has the potential to create visible effects!
     // This should only be used if it has been *checked* that it is safe (no aliases, in-place
     // arguments will no longer be live)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
-Expr MakeCallTIRInplace(Expr func, Tuple args, ffi::Array<Integer> inplace_indices,
+Expr MakeCallTIRInplace(Expr func, Tuple args, ffi::Array<int64_t> inplace_indices,
                         ffi::Array<TensorStructInfo> out_sinfo_list,
                         ffi::Optional<Expr> packed_ints) {
   for (const TensorStructInfo& sinfo : out_sinfo_list) {
@@ -791,7 +791,7 @@ Expr MakeCallTIRInplace(Expr func, Tuple args, ffi::Array<Integer> inplace_indic
   }
 
   ffi::ObjectPtr<CallTIRInplaceAttrs> attrs = ffi::make_object<CallTIRInplaceAttrs>();
-  attrs->inplace_indices = ffi::Array<Integer>(inplace_indices.begin(), inplace_indices.end());
+  attrs->inplace_indices = ffi::Array<int64_t>(inplace_indices.begin(), inplace_indices.end());
 
   StructInfo out_sinfo{nullptr};
   if (out_sinfo_list.size() == 1) {
@@ -833,7 +833,7 @@ TVM_REGISTER_OP("relax.call_dps_packed")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallDPSPacked)
     // technically, an impure op could be used with this, but there is
     // little reason to use DPS with an impure op
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeCallDPSPacked(Expr func, Tuple args, ffi::Array<TensorStructInfo> out_sinfo_list) {
   for (const TensorStructInfo& sinfo : out_sinfo_list) {
@@ -898,7 +898,7 @@ TVM_REGISTER_OP("relax.call_py_func")
     .add_argument("args", "Tuple", "The input arguments.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallPyFunc)
     .set_attr<FValidate>("FValidate", ValidateCallPyFunc)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeCallPyFunc(StringImm func_name, Tuple args, ffi::Array<TensorStructInfo> out_sinfo_list) {
   for (const TensorStructInfo& sinfo : out_sinfo_list) {
@@ -942,7 +942,7 @@ TVM_REGISTER_OP("relax.call_builtin_with_ctx")
     .add_argument("args", "Tuple", "The input arguments.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallBuiltinWithCtx)
     // Most builtins are pure, but some are not, like `vm.builtin.attention_kv_cache_append`
-    .set_attr<Bool>("FPurity", Bool(false));
+    .set_attr<bool>("FPurity", false);
 
 Expr MakeCallBuiltinWithCtx(Expr func, Tuple args, ffi::Array<StructInfo> sinfo_args) {
   static const Op& op = Op::Get("relax.call_builtin_with_ctx");
@@ -957,7 +957,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 TVM_REGISTER_OP("relax.null_value")
     .set_num_inputs(0)
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnObjectStructInfo)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeCallNullValue() {
   static const Op& op = Op::Get("relax.null_value");
@@ -978,7 +978,7 @@ TVM_REGISTER_OP("relax.print")
                   "are values to print")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnVoidStructInfo)
     .set_attr<FCallPacked>("FCallPacked", "relax.run.print")
-    .set_attr<Bool>("FPurity", Bool(false));
+    .set_attr<bool>("FPurity", false);
 
 Expr MakePrint(ffi::Array<Expr> vals, StringImm format) {
   ffi::Array<Expr> params;
@@ -1024,7 +1024,7 @@ TVM_REGISTER_OP("relax.assert_op")
                   "assert fails. The others are used as format arguments if there is an error.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferAssertStructInfo)
     .set_attr<FCallPacked>("FCallPacked", "relax.run.assert_op")
-    .set_attr<Bool>("FPurity", Bool(false));
+    .set_attr<bool>("FPurity", false);
 
 Expr MakeAssertOp(Expr condition, ffi::Array<Expr> vals, StringImm format) {
   static const Op& op = Op::Get("relax.assert_op");
@@ -1048,7 +1048,7 @@ TVM_REGISTER_OP("relax.make_closure")
     .add_argument("func", "Expr", "The closure.")
     .add_argument("args", "Tuple", "The captured variables.")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnObjectStructInfo)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeClosure(Expr func, Tuple args) {
   static const Op& op = Op::Get("relax.make_closure");
@@ -1078,7 +1078,7 @@ TVM_REGISTER_OP("relax.invoke_closure")
     .add_argument("args", "Tuple", "The captured variables.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoInvokeClosure)
     // Not all closures are pure. Use invoke_pure_closure for specifying purity
-    .set_attr<Bool>("FPurity", Bool(false));
+    .set_attr<bool>("FPurity", false);
 
 Expr InvokeClosure(Expr closure, Tuple args, ffi::Array<StructInfo> sinfo_args) {
   static const Op& op = Op::Get("relax.invoke_closure");
@@ -1097,7 +1097,7 @@ TVM_REGISTER_OP("relax.invoke_pure_closure")
     .add_argument("closure", "Expr", "The VMClosure.")
     .add_argument("args", "Tuple", "The captured variables.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoInvokeClosure)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr InvokePureClosure(Expr closure, Tuple args, ffi::Array<StructInfo> sinfo_args) {
   static const Op& op = Op::Get("relax.invoke_pure_closure");
@@ -1115,7 +1115,7 @@ TVM_REGISTER_OP("relax.shape_of")
     .set_num_inputs(1)
     .add_argument("input", "Expr", "The input expression")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoShapeOf)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeShapeOf(Expr expr) {
   static const Op& op = Op::Get("relax.shape_of");
@@ -1141,7 +1141,7 @@ TVM_REGISTER_OP("relax.size")
     .set_num_inputs(1)
     .add_argument("input", "Expr", "The input tensor")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoSize)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeSize(Expr expr) {
   static const Op& op = Op::Get("relax.size");
@@ -1178,7 +1178,7 @@ TVM_REGISTER_OP("relax.tensor_to_shape")
     .set_num_inputs(1)
     .add_argument("input", "Expr", "The input expression")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnTensorToShapeStructInfo)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeTensorToShape(Expr expr) {
   static const Op& op = Op::Get("relax.tensor_to_shape");
@@ -1205,7 +1205,7 @@ TVM_REGISTER_OP("relax.shape_to_tensor")
     .add_argument("input", "Expr", "The input expression")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnShapeToTensorStructInfo)
     .set_attr<FCallPacked>("FCallPacked", "relax.run.shape_to_tensor")
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeShapeToTensor(Expr expr) {
   static const Op& op = Op::Get("relax.shape_to_tensor");
@@ -1252,8 +1252,8 @@ TVM_REGISTER_OP("relax.builtin.alloc_tensor")
                   "The storage scope of the storage to allocate. Default is global.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAllocateTensor)
     // memory allocation isn't considered a "visible effect" as far as purity is concerned
-    .set_attr<Bool>("FPurity", Bool(true))
-    .set_attr<Bool>("TAllocator", Bool(true));
+    .set_attr<bool>("FPurity", true)
+    .set_attr<bool>("TAllocator", true);
 
 Expr MakeAllocTensor(Expr shape, DataTypeImm dtype, PrimValue runtime_device_index,
                      StringImm storage_scope) {
@@ -1280,8 +1280,8 @@ TVM_REGISTER_OP("relax.memory.alloc_storage")
     .add_argument("dtype", "DataTypeImm", "The dtype of the tensor to allocate.")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnObjectStructInfo)
     // memory allocation isn't considered a "visible effect" as far as purity is concerned
-    .set_attr<Bool>("FPurity", Bool(true))
-    .set_attr<Bool>("TAllocator", Bool(true));
+    .set_attr<bool>("FPurity", true)
+    .set_attr<bool>("TAllocator", true);
 
 Expr MakeAllocStorage(Expr size, PrimValue virtual_device_index, StringImm storage_scope,
                       DataTypeImm dtype) {
@@ -1330,8 +1330,8 @@ TVM_REGISTER_OP("relax.memory.alloc_tensor")
                   "allocated at runtime. Index -1 is reserved for the host device.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoMemAllocTensor)
     // memory allocation isn't considered a "visible effect" as far as purity is concerned
-    .set_attr<Bool>("FPurity", Bool(true))
-    .set_attr<Bool>("TAllocator", Bool(true));
+    .set_attr<bool>("FPurity", true)
+    .set_attr<bool>("TAllocator", true);
 
 Expr MakeMemAllocTensor(Expr storage, PrimValue offset, Expr shape, DataTypeImm dtype,
                         PrimValue virtual_device_index) {
@@ -1362,7 +1362,7 @@ TVM_REGISTER_OP("relax.memory.kill_storage")
     .add_argument("storage", "Expr", "The storage to be killed.")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnVoidStructInfo)
     // We mark this as impure so it wouldn't be removed by "remove_all_unused"
-    .set_attr<Bool>("FPurity", Bool(false));
+    .set_attr<bool>("FPurity", false);
 
 Expr MakeMemKillStorage(Expr storage) {
   static const Op& op = Op::Get("relax.memory.kill_storage");
@@ -1381,7 +1381,7 @@ TVM_REGISTER_OP("relax.memory.kill_tensor")
     .add_argument("tensor", "Expr", "The tensor to be killed.")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnVoidStructInfo)
     // We mark this as impure so it wouldn't be removed by "remove_all_unused"
-    .set_attr<Bool>("FPurity", Bool(false));
+    .set_attr<bool>("FPurity", false);
 
 Expr MakeMemKillTensor(Expr tensor) {
   static const Op& op = Op::Get("relax.memory.kill_tensor");
@@ -1406,8 +1406,8 @@ TVM_REGISTER_OP("relax.vm.alloc_storage")
                   "The storage scope of the storage to allocate. Default is global.")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnObjectStructInfo)
     // memory allocation isn't considered a "visible effect" as far as purity is concerned
-    .set_attr<Bool>("FPurity", Bool(true))
-    .set_attr<Bool>("TAllocator", Bool(true));
+    .set_attr<bool>("FPurity", true)
+    .set_attr<bool>("TAllocator", true);
 
 Expr MakeVMAllocStorage(Expr size, PrimValue runtime_device_index, DataTypeImm dtype,
                         StringImm storage_scope) {
@@ -1457,8 +1457,8 @@ TVM_REGISTER_OP("relax.vm.alloc_tensor")
                   "to be allocated at runtime.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoVMAllocTensor)
     // memory allocation isn't considered a "visible effect" as far as purity is concerned
-    .set_attr<Bool>("FPurity", Bool(true))
-    .set_attr<Bool>("TAllocator", Bool(true));
+    .set_attr<bool>("FPurity", true)
+    .set_attr<bool>("TAllocator", true);
 
 Expr MakeVMAllocTensor(Expr storage, PrimValue offset, Expr shape, DataTypeImm dtype,
                        PrimValue runtime_device_index) {
@@ -1487,7 +1487,7 @@ TVM_REGISTER_OP("relax.vm.kill_object")
     .add_argument("obj", "Expr", "The object to be killed.")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnVoidStructInfo)
     // We mark this as impure so it wouldn't be removed by "remove_all_unused"
-    .set_attr<Bool>("FPurity", Bool(false));
+    .set_attr<bool>("FPurity", false);
 
 Expr MakeVMKillObject(Expr obj) {
   static const Op& op = Op::Get("relax.vm.kill_object");
@@ -1508,7 +1508,7 @@ TVM_REGISTER_OP("relax.vm.call_tir_dyn")
                   "The input arguments (list of tensors and last argument is ShapeExpr)")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnVoidStructInfo)
     // "relax.vm.call_tir_dyn" works in an in-place way, which is impure.
-    .set_attr<Bool>("FPurity", Bool(false));
+    .set_attr<bool>("FPurity", false);
 
 Expr MakeCallTIRDyn(Expr func, Tuple args) {
   static const Op& op = Op::Get("relax.vm.call_tir_dyn");
@@ -1529,7 +1529,7 @@ TVM_REGISTER_OP("relax.builtin.stop_lift_params")
     .set_num_inputs(1)
     .add_argument("x", "Expr", "The input data")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoStopLiftParams)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeStopLiftParams(Expr x) {
   static const Op& op = Op::Get("relax.builtin.stop_lift_params");
@@ -1560,7 +1560,7 @@ TVM_REGISTER_OP("relax.to_vdevice")
     .set_attrs_type<ToVDeviceAttrs>()
     .add_argument("data", "Expr", "The input expression to be copied")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferToVDeviceStructInfo)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeToVDevice(Expr data, VDevice dst_vdev) {
   static const Op& op = Op::Get("relax.to_vdevice");
@@ -1588,7 +1588,7 @@ TVM_REGISTER_OP("relax.hint_on_device")
     .set_attrs_type<HintOnDeviceAttrs>()
     .add_argument("data", "Expr", "The input expression")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferHintOnDeviceStructInfo)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr MakeHintOnDevice(Expr data, Device device, ffi::String memory_scope = "global") {
   static const Op& op = Op::Get("relax.hint_on_device");

--- a/src/relax/op/op_common.cc
+++ b/src/relax/op/op_common.cc
@@ -149,14 +149,14 @@ ffi::Optional<ffi::Array<PrimExpr>> InferBinaryBroadcastShape(
 }
 
 std::vector<int> NormalizeAxes(const Call& call, const BlockBuilder& ctx, int ndim,
-                               const ffi::Array<Integer>& axes) {
+                               const ffi::Array<int64_t>& axes) {
   TVM_FFI_ICHECK_NE(ndim, kUnknownNDim) << "The ndim is required to be known for this function.";
   std::vector<bool> appeared_dims_set;
   std::vector<int> axes_non_neg;
   appeared_dims_set.resize(ndim, /*value=*/false);
   axes_non_neg.reserve(axes.size());
-  for (const Integer& axis : axes) {
-    int _axis = axis->value;
+  for (int64_t axis : axes) {
+    int _axis = static_cast<int>(axis);
     if (_axis < -ndim || _axis >= ndim) {
       ctx->ReportFatal(Diagnostic::Error(call) << "In " << call->op << ", the input axis " << _axis
                                                << " is out of range. The input tensor has " << ndim

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -169,7 +169,7 @@ std::tuple<ArgTypes...> GetArgStructInfo(const Call& call, const BlockBuilder& c
       .add_argument("x", "Tensor", "The input tensor.")                                            \
       .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutUnaryEwise)                     \
       .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow) \
-      .set_attr<Bool>("FPurity", Bool(true))
+      .set_attr<bool>("FPurity", true)
 
 /*!
  * \brief Quick helper macro to expose a make-function to construct the operator.
@@ -412,7 +412,7 @@ ffi::Optional<ffi::Array<PrimExpr>> InferBinaryBroadcastShape(const Call& call,
  * \throw Throw exception if there exists out-of-range axis index or repetitive indices.
  */
 std::vector<int> NormalizeAxes(const Call& call, const BlockBuilder& ctx, int ndim,
-                               const ffi::Array<Integer>& axes);
+                               const ffi::Array<int64_t>& axes);
 
 /*!
  * \brief Convert the given axis to non-negative index. Meanwhile check if the axis is in range

--- a/src/relax/op/tensor/binary.h
+++ b/src/relax/op/tensor/binary.h
@@ -51,7 +51,7 @@ namespace relax {
       .add_argument("x2", "Tensor", "The second input tensor.")                                    \
       .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutBinaryEwise)                    \
       .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow) \
-      .set_attr<Bool>("FPurity", Bool(true))
+      .set_attr<bool>("FPurity", true)
 
 #define RELAX_REGISTER_BINARY_BROADCAST_OP_AND_IMPL(OpName)             \
   RELAX_REGISTER_BINARY_OP_AND_IMPL(OpName).set_attr<FInferStructInfo>( \

--- a/src/relax/op/tensor/create.cc
+++ b/src/relax/op/tensor/create.cc
@@ -97,10 +97,10 @@ TVM_REGISTER_OP("relax.full")
     .add_argument("shape", "Shape", "The shape of the created tensor.")
     .add_argument("fill_value", "Tensor", "The scalar tensor, denoting the value to fill.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoFull)
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
-    .set_attr<Bool>("FDataDependent", Bool(true))
+    .set_attr<bool>("RequiresArgumentShapes", false)
+    .set_attr<bool>("FDataDependent", true)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.full_like */
 Expr full_like(Expr x, Expr fill_value, ffi::Optional<DataType> dtype) {
@@ -142,7 +142,7 @@ TVM_REGISTER_OP("relax.full_like")
     .add_argument("fill_value", "Tensor", "The scalar value to fill.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoFullLike)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 // Structure info inference for ones and zeros
 StructInfo InferStructInfoOnesZeros(const Call& call, const BlockBuilder& ctx) {
@@ -202,14 +202,14 @@ TVM_REGISTER_OP("relax.ones")
     .add_argument("shape", "Shape", "The shape of the created tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoOnesZeros)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 TVM_REGISTER_OP("relax.ones_like")
     .set_attrs_type<InitAttrs>()
     .set_num_inputs(1)
     .add_argument("x", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoOnesLikeZerosLike)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.zeros & relax.zeros_like */
 Expr zeros(Expr shape, DataType dtype) {
@@ -239,14 +239,14 @@ TVM_REGISTER_OP("relax.zeros")
     .add_argument("shape", "Shape", "The shape of the created tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoOnesZeros)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 TVM_REGISTER_OP("relax.zeros_like")
     .set_attrs_type<InitAttrs>()
     .set_num_inputs(1)
     .add_argument("x", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoOnesLikeZerosLike)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.eye & relax.eye_like */
 Expr eye(PrimValue n, PrimValue m, PrimValue k, DataType dtype) {
@@ -324,7 +324,7 @@ TVM_REGISTER_OP("relax.eye")
     .add_argument("k", "PrimValue", "Index of the diagonal.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoEye)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 TVM_REGISTER_OP("relax.eye_like")
     .set_attrs_type<InitAttrs>()
@@ -332,7 +332,7 @@ TVM_REGISTER_OP("relax.eye_like")
     .add_argument("x", "Tensor", "The input tensor.")
     .add_argument("k", "PrimValue", "Index of the diagonal.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoEyeLike)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.arange */
 Expr arange(PrimValue start, PrimValue stop, PrimValue step, DataType dtype) {
@@ -387,7 +387,7 @@ TVM_REGISTER_OP("relax.arange")
     .add_argument("step", "PrimValue", "The gap between each pair of adjacent points.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoArange)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.hamming_window */
 Expr hamming_window(PrimValue window_size, PrimValue periodic, PrimValue alpha, PrimValue beta,
@@ -441,7 +441,7 @@ TVM_REGISTER_OP("relax.hamming_window")
     .add_argument("beta", "PrimValue", "The coefficient beta")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoHammingWindow)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.tril & relax.triu */
 
@@ -483,14 +483,14 @@ TVM_REGISTER_OP("relax.tril")
     .add_argument("x", "Tensor", "The input tensor.")
     .add_argument("k", "PrimValue", "The offset of the diagonal.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTrilTriu)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 TVM_REGISTER_OP("relax.triu")
     .set_num_inputs(2)
     .add_argument("x", "Tensor", "The input tensor.")
     .add_argument("k", "PrimValue", "The offset of the diagonal.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTrilTriu)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/datatype.cc
+++ b/src/relax/op/tensor/datatype.cc
@@ -67,7 +67,7 @@ TVM_REGISTER_OP("relax.astype")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAstype)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutUnaryEwise)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.wrap_param */
 
@@ -98,7 +98,7 @@ TVM_REGISTER_OP("relax.wrap_param")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoWrapParam)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/grad.cc
+++ b/src/relax/op/tensor/grad.cc
@@ -50,7 +50,7 @@ TVM_REGISTER_OP("relax.grad.no_grad")
     .set_num_inputs(1)
     .add_argument("x", "Expr", "The corresponding input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoNoGrad)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.grad.start_checkpoint */
 Expr start_checkpoint(Expr input) {
@@ -75,7 +75,7 @@ TVM_REGISTER_OP("relax.grad.start_checkpoint")
     .set_num_inputs(1)
     .add_argument("x", "Expr", "The tensor marking the input of the checkpoint stage.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoStartCheckpoint)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.grad.end_checkpoint */
 Expr end_checkpoint(Expr input) {
@@ -100,7 +100,7 @@ TVM_REGISTER_OP("relax.grad.end_checkpoint")
     .set_num_inputs(1)
     .add_argument("x", "Expr", "The output of the checkpoint stage.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoEndCheckpoint)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.grad.nll_loss_backward */
 Expr nll_loss_backward(Expr output_grad, Expr predictions, Expr targets,
@@ -138,7 +138,7 @@ TVM_REGISTER_OP("relax.grad.nll_loss_backward")
     .add_argument("targets", "Tensor", "The target tensor.")
     .add_argument("weights", "ffi::Optional<Tensor>", "The weight of each target values.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoNLLLossBackward)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.grad.max_pool2d_backward */
 Expr max_pool2d_backward(Expr output_grad, Expr data, ffi::Array<int64_t> pool_size,
@@ -173,7 +173,7 @@ TVM_REGISTER_OP("relax.grad.max_pool2d_backward")
     .add_argument("data", "Tensor", "The input tensor")
     .set_attrs_type<Pool2DAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoMaxPool2DBackward)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.grad.avg_pool2d_backward */
 Expr avg_pool2d_backward(Expr output_grad, Expr data, ffi::Array<int64_t> pool_size,
@@ -208,7 +208,7 @@ TVM_REGISTER_OP("relax.grad.avg_pool2d_backward")
     .add_argument("data", "Tensor", "The input tensor")
     .set_attrs_type<Pool2DAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAvgPool2DBackward)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.grad.take_backward */
 
@@ -236,7 +236,7 @@ TVM_REGISTER_OP("relax.grad.take_backward")
     .add_argument("x", "Tensor", "The source tensor.")
     .add_argument("indices", "Tensor", "The indices of the values to extract.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTakeBackward)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -133,7 +133,7 @@ TVM_REGISTER_OP("relax.take")
     .add_argument("x", "Tensor", "The source tensor.")
     .add_argument("indices", "Tensor", "The indices of the values to extract.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTake)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.strided_slice */
 
@@ -198,7 +198,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
  * a tuple from a `TensorStructInfo`.)
  *
  * \tparam PrimType The subtype of PrimExpr to extract.  For example,
- *     extracting an `ffi::Array<Integer>`
+ *     extracting an `ffi::Array<int64_t>`
  *
  * \param sinfo The StructInfo to inspect
  *
@@ -256,7 +256,7 @@ ffi::Optional<ffi::Array<PrimType>> UnpackTupleOfPrimValue(ffi::Optional<StructI
  * a tuple from a `TensorStructInfo`.)
  *
  * \tparam PrimType The subtype of PrimExpr to extract.  For example,
- *     extracting an `ffi::Array<Integer>`
+ *     extracting an `ffi::Array<int64_t>`
  *
  * \param expr The `relax::Expr` to inspect
  *
@@ -355,7 +355,7 @@ StructInfo InferStructInfoStridedSlice(const Call& call, const BlockBuilder& ctx
     if (!data_sinfo) return std::nullopt;
     if (!data_sinfo->shape) return std::nullopt;
 
-    auto opt_axes_tuple = UnpackTupleOfPrimValue<Integer>(axes);
+    auto opt_axes_tuple = UnpackTupleOfPrimValue<IntImm>(axes);
     if (!opt_axes_tuple) return std::nullopt;
     auto axes_tuple = opt_axes_tuple.value();
 
@@ -404,7 +404,10 @@ StructInfo InferStructInfoStridedSlice(const Call& call, const BlockBuilder& ctx
       return std::nullopt;
     }
 
-    std::vector<int> axes = NormalizeAxes(call, ctx, data_sinfo->ndim, axes_tuple);
+    ffi::Array<int64_t> axes_tuple_i64;
+    axes_tuple_i64.reserve(axes_tuple.size());
+    for (const IntImm& v : axes_tuple) axes_tuple_i64.push_back(v->value);
+    std::vector<int> axes = NormalizeAxes(call, ctx, data_sinfo->ndim, axes_tuple_i64);
     auto attrs = call->attrs.as<StridedSliceAttrs>();
 
     ffi::Array<PrimExpr> output_shape = data_sinfo->GetShape().value();
@@ -457,12 +460,12 @@ InferLayoutOutput InferLayoutStridedSlice(
     existing_layout = LayoutDecision(InitialLayout(tensor_sinfo->ndim));
   }
 
-  auto opt_axes_tuple = UnpackTupleOfPrimValue<Integer>(GetStructInfo(call->args[1]));
+  auto opt_axes_tuple = UnpackTupleOfPrimValue<IntImm>(GetStructInfo(call->args[1]));
   TVM_FFI_ICHECK(opt_axes_tuple) << "Layout inference of " << call->op
                                  << " requires slices to be along static axes.  "
                                  << "However, expression " << call
                                  << " slices along non-static axes " << call->args[1];
-  ffi::Array<Integer> axes_tuple = opt_axes_tuple.value();
+  ffi::Array<IntImm> axes_tuple = opt_axes_tuple.value();
 
   ffi::Array<Expr> new_axes;
   for (const auto& axis : axes_tuple) {
@@ -481,7 +484,7 @@ TVM_REGISTER_OP("relax.strided_slice")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoStridedSlice)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutStridedSlice)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.dynamic_strided_slice */
 Expr dynamic_strided_slice(Expr x,      //
@@ -579,8 +582,8 @@ TVM_REGISTER_OP("relax.dynamic_strided_slice")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoDynStridedSlice)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutDynStridedSlice)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true))
-    .set_attr<Bool>("FDataDependent", Bool(true));
+    .set_attr<bool>("FPurity", true)
+    .set_attr<bool>("FDataDependent", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/inspect.cc
+++ b/src/relax/op/tensor/inspect.cc
@@ -153,9 +153,9 @@ TVM_REGISTER_OP("relax.inspect.tensor_dtype_code")
     .add_argument("tensor", "Tensor", "The tensor to be inspected")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTensorDtypeCode)
     .set_attr<FLegalize>("FLegalize", LegalizeTensorDtypeCode)
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
+    .set_attr<bool>("RequiresArgumentShapes", false)
     .set_attr<FNormalize>("FNormalize", NormalizeToKnownPrimValue)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 //// relax.tensor_dtype_bits
 
@@ -191,9 +191,9 @@ TVM_REGISTER_OP("relax.inspect.tensor_dtype_bits")
     .add_argument("tensor", "Tensor", "The tensor to be inspected")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTensorDtypeBits)
     .set_attr<FLegalize>("FLegalize", LegalizeTensorDtypeBits)
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
+    .set_attr<bool>("RequiresArgumentShapes", false)
     .set_attr<FNormalize>("FNormalize", NormalizeToKnownPrimValue)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 //// relax.tensor_dtype_lanes
 
@@ -229,9 +229,9 @@ TVM_REGISTER_OP("relax.inspect.tensor_dtype_lanes")
     .add_argument("tensor", "Tensor", "The tensor to be inspected")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTensorDtypeLanes)
     .set_attr<FLegalize>("FLegalize", LegalizeTensorDtypeLanes)
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
+    .set_attr<bool>("RequiresArgumentShapes", false)
     .set_attr<FNormalize>("FNormalize", NormalizeToKnownPrimValue)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 //// relax.tensor_ndim
 
@@ -267,9 +267,9 @@ TVM_REGISTER_OP("relax.inspect.tensor_ndim")
     .add_argument("tensor", "Tensor", "The tensor to be inspected")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTensorNDim)
     .set_attr<FLegalize>("FLegalize", LegalizeTensorNDim)
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
+    .set_attr<bool>("RequiresArgumentShapes", false)
     .set_attr<FNormalize>("FNormalize", NormalizeToKnownPrimValue)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 //// relax.tensor_shape_i
 
@@ -346,9 +346,9 @@ TVM_REGISTER_OP("relax.inspect.tensor_shape_i")
     .add_argument("axis", "Prim(int64)", "The axis whose extent should be returned")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTensorShape)
     .set_attr<FLegalize>("FLegalize", LegalizeTensorShape)
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
+    .set_attr<bool>("RequiresArgumentShapes", false)
     .set_attr<FNormalize>("FNormalize", NormalizeToKnownPrimValue)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 //// relax.tensor_stride_i
 
@@ -394,9 +394,9 @@ TVM_REGISTER_OP("relax.inspect.tensor_stride_i")
     .add_argument("tensor", "Tensor", "The tensor to be inspected")
     .add_argument("axis", "Prim(int64)", "The axis whose extent should be returned")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTensorStride)
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
+    .set_attr<bool>("RequiresArgumentShapes", false)
     .set_attr<FNormalize>("FNormalize", NormalizeToKnownPrimValue)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 //// relax.tensor_byte_offset
 
@@ -425,9 +425,9 @@ TVM_REGISTER_OP("relax.inspect.tensor_byte_offset")
     .set_num_inputs(1)
     .add_argument("tensor", "Tensor", "The tensor to be inspected")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTensorByteOffset)
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
+    .set_attr<bool>("RequiresArgumentShapes", false)
     .set_attr<FNormalize>("FNormalize", NormalizeToKnownPrimValue)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 //// relax.tensor_elem_offset
 
@@ -456,9 +456,9 @@ TVM_REGISTER_OP("relax.inspect.tensor_elem_offset")
     .set_num_inputs(1)
     .add_argument("tensor", "Tensor", "The tensor to be inspected")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTensorElemOffset)
-    .set_attr<Bool>("RequiresArgumentShapes", Bool(false))
+    .set_attr<bool>("RequiresArgumentShapes", false)
     .set_attr<FNormalize>("FNormalize", NormalizeToKnownPrimValue)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace inspect
 }  // namespace relax

--- a/src/relax/op/tensor/linear_algebra.cc
+++ b/src/relax/op/tensor/linear_algebra.cc
@@ -171,7 +171,7 @@ TVM_REGISTER_OP("relax.matmul")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoMatmul)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
     .set_attr<FInferMixedPrecision>("FInferMixedPrecision", InferMixedPrecisionMatmul)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.einsum */
 
@@ -259,7 +259,7 @@ TVM_REGISTER_OP("relax.einsum")
     .set_num_inputs(1)
     .add_argument("operands", "Tensor", "The input tensors.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoEinsum)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.outer */
 
@@ -300,7 +300,7 @@ TVM_REGISTER_OP("relax.outer")
     .add_argument("x2", "Tensor", "The second input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoOuter)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kAlways)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -139,7 +139,7 @@ TVM_REGISTER_OP("relax.broadcast_to")
     .add_argument("shape", "Shape", "The target shape.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoBroadcastTo)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.concat */
 
@@ -402,11 +402,11 @@ TVM_REGISTER_OP("relax.concat")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoConcat)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutConcat)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.expand_dims */
 
-Expr expand_dims(Expr x, ffi::Array<Integer> axis) {
+Expr expand_dims(Expr x, ffi::Array<int64_t> axis) {
   ffi::ObjectPtr<ExpandDimsAttrs> attrs = ffi::make_object<ExpandDimsAttrs>();
   attrs->axis = std::move(axis);
 
@@ -478,7 +478,7 @@ InferLayoutOutput InferLayoutExpandDims(
   int output_ndim = ndim + n_new_dim;
   std::vector<bool> is_new_dim(output_ndim, false);
   for (const auto& axis : attrs->axis) {
-    is_new_dim[(axis->value + output_ndim) % output_ndim] = true;
+    is_new_dim[(axis + output_ndim) % output_ndim] = true;
   }
   std::string new_layout;
   for (int i = 0; i < output_ndim; ++i) {
@@ -506,7 +506,7 @@ TVM_REGISTER_OP("relax.expand_dims")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoExpandDims)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutExpandDims)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 // Helper function for flatten and reshape.
 PrimExpr ComputeShapeProduct(const ffi::Array<PrimExpr>& shape_values) {
@@ -552,7 +552,7 @@ TVM_REGISTER_OP("relax.flatten")
     .add_argument("x", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoFlatten)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.index_tensor */
 
@@ -701,7 +701,7 @@ TVM_REGISTER_OP("relax.index_tensor")
     .add_argument("data", "Tensor", "The input data.")
     .add_argument("indices", "List of Tensors", "The indices used to index.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoIndexTensor)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.layout_transform */
 
@@ -775,11 +775,11 @@ TVM_REGISTER_OP("relax.layout_transform")
     .add_argument("x", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoLayoutTransform)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.permute_dims */
 
-Expr permute_dims(Expr x, ffi::Optional<ffi::Array<Integer>> axes) {
+Expr permute_dims(Expr x, ffi::Optional<ffi::Array<int64_t>> axes) {
   ffi::ObjectPtr<PermuteDimsAttrs> attrs = ffi::make_object<PermuteDimsAttrs>();
   attrs->axes = std::move(axes);
 
@@ -865,24 +865,24 @@ InferLayoutOutput InferLayoutPermuteDims(
     existing_layout = LayoutDecision(InitialLayout(ndim));
   }
 
-  ffi::Array<Integer> order;
+  ffi::Array<int64_t> order;
   if (attrs->axes.defined()) {
     order = attrs->axes.value();
   } else {
     order.reserve(ndim);
     for (int i = 0; i < ndim; ++i) {
-      order.push_back(Integer(ndim - i - 1));
+      order.push_back(ndim - i - 1);
     }
   }
   std::string order_str;
-  for (const auto& axis : order) {
-    order_str.push_back(axis->value + 'A');
+  for (int64_t axis : order) {
+    order_str.push_back(static_cast<char>(axis + 'A'));
   }
   ffi::String new_axes =
       TransposeStrLike(InitialLayout(ndim).name(), existing_layout->layout, order_str);
-  ffi::Array<Integer> new_order;
+  ffi::Array<int64_t> new_order;
   for (size_t i = 0; i < new_axes.size(); ++i) {
-    new_order.push_back(Integer(new_axes.at(i) - 'A'));
+    new_order.push_back(new_axes.at(i) - 'A');
   }
   ffi::ObjectPtr<PermuteDimsAttrs> new_attrs = ffi::make_object<PermuteDimsAttrs>(*attrs);
   new_attrs->axes = new_order;
@@ -896,7 +896,7 @@ TVM_REGISTER_OP("relax.permute_dims")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoPermuteDims)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutPermuteDims)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.reshape */
 Expr ConvertNewShapeToExpr(const Expr& data,
@@ -1059,7 +1059,7 @@ TVM_REGISTER_OP("relax.reshape")
     .add_argument("shape", "Shape", "The input new shape.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoReshape)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.split */
 
@@ -1238,11 +1238,11 @@ TVM_REGISTER_OP("relax.split")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoSplit)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutSplit)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.squeeze */
 
-Expr squeeze(Expr x, ffi::Optional<ffi::Array<Integer>> axis) {
+Expr squeeze(Expr x, ffi::Optional<ffi::Array<int64_t>> axis) {
   ffi::ObjectPtr<SqueezeAttrs> attrs = ffi::make_object<SqueezeAttrs>();
   attrs->axis = std::move(axis);
 
@@ -1346,21 +1346,21 @@ InferLayoutOutput InferLayoutSqueeze(
   const auto* shape = tensor_sinfo->shape.as<ShapeExprNode>();
   TVM_FFI_ICHECK(shape != nullptr) << "Only support static shape for now";
 
-  ffi::Array<Integer> axis;
+  ffi::Array<int64_t> axis;
   if (attrs->axis.defined()) {
     axis = attrs->axis.value();
   } else {
     axis.reserve(ndim);
     for (int i = 0; i < ndim; ++i) {
       if (tirx::is_one(shape->values[i])) {
-        axis.push_back(Integer(i));
+        axis.push_back(i);
       }
     }
   }
 
   std::string axis_str(ndim, '0');
-  for (const auto& iter : axis) {
-    axis_str[iter->value] = '1';
+  for (int64_t iter : axis) {
+    axis_str[iter] = '1';
   }
   for (int i = 0, j = 0; i < ndim; ++i) {
     if (axis_str[i] != '1') {
@@ -1375,10 +1375,10 @@ InferLayoutOutput InferLayoutSqueeze(
   }
   ffi::String new_axis_str =
       TransposeStrLike(axis_str, InitialLayout(ndim), existing_layout->layout);
-  ffi::Array<Integer> new_axis;
+  ffi::Array<int64_t> new_axis;
   for (size_t i = 0; i < new_axis_str.size(); ++i) {
     if (new_axis_str.at(i) == '1') {
-      new_axis.push_back(Integer(i));
+      new_axis.push_back(static_cast<int64_t>(i));
     }
   }
   std::string output_layout = new_axis_str;
@@ -1398,7 +1398,7 @@ TVM_REGISTER_OP("relax.squeeze")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoSqueeze)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutSqueeze)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 void CheckCollapseShape(const Call& call, const BlockBuilder& ctx,
                         const ffi::Array<PrimExpr>& data_shape,
@@ -1441,7 +1441,7 @@ void CheckCollapseShape(const Call& call, const BlockBuilder& ctx,
 
 /* relax.stack */
 
-Expr stack(Expr tensors, ffi::Optional<Integer> axis) {
+Expr stack(Expr tensors, ffi::Optional<int64_t> axis) {
   ffi::ObjectPtr<StackAttrs> attrs = ffi::make_object<StackAttrs>();
   attrs->axis = std::move(axis);
 
@@ -1565,8 +1565,9 @@ StructInfo InferStructInfoStack(const Call& call, const BlockBuilder& ctx) {
   if (vdevice_unknown) vdev = std::nullopt;
 
   // Normalize axis (default to 0 if not specified)
-  int axis =
-      attrs->axis.defined() ? NormalizeAxis(call, ctx, output_ndim, attrs->axis.value()->value) : 0;
+  int axis = attrs->axis.has_value()
+                 ? NormalizeAxis(call, ctx, output_ndim, static_cast<int>(attrs->axis.value()))
+                 : 0;
 
   // Single tensor case
   if (tensor_sinfo.size() == 1) {
@@ -1633,13 +1634,13 @@ InferLayoutOutput InferLayoutStack(
 
   // For stack, we need to adjust the output layout by inserting a new axis
   std::string layout_str = layout->layout.name();
-  int axis = attrs->axis.defined() ? attrs->axis.value()->value : 0;
+  int axis = attrs->axis.has_value() ? static_cast<int>(attrs->axis.value()) : 0;
   layout_str.insert(static_cast<size_t>(axis), "S");  // Add stack dimension
   SLayout output_layout = SLayout(layout_str);
   output_layouts.push_back(LayoutDecision(output_layout));
 
   ffi::ObjectPtr<StackAttrs> new_attrs = ffi::make_object<StackAttrs>(*attrs);
-  new_attrs->axis = Integer(FindAxis(layout->layout, axis));
+  new_attrs->axis = static_cast<int64_t>(FindAxis(layout->layout, axis));
   return InferLayoutOutput({NLayout(input_layouts)}, output_layouts, Attrs(new_attrs));
 }
 
@@ -1650,7 +1651,7 @@ TVM_REGISTER_OP("relax.stack")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoStack)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutStack)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.collapse_sum_like */
 Expr collapse_sum_like(Expr data, Expr collapse_target) {
@@ -1699,7 +1700,7 @@ TVM_REGISTER_OP("relax.collapse_sum_like")
     .add_argument("collapse_target", "Tensor",
                   "The tensor whose shape is the shape to collapse to.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCollapseSumLike)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.collapse_sum_to */
 Expr collapse_sum_to(Expr data, Expr shape) {
@@ -1751,7 +1752,7 @@ TVM_REGISTER_OP("relax.collapse_sum_to")
     .add_argument("data", "Tensor", "The input tensor.")
     .add_argument("shape", "Shape", "The shape to collapse to.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCollapseSumTo)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.repeat */
 
@@ -1877,11 +1878,11 @@ TVM_REGISTER_OP("relax.repeat")
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoRepeat)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutRepeat)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.tile */
 
-Expr tile(Expr data, ffi::Array<Integer> repeats) {
+Expr tile(Expr data, ffi::Array<int64_t> repeats) {
   auto attrs = ffi::make_object<TileAttrs>();
   attrs->repeats = std::move(repeats);
 
@@ -1909,8 +1910,8 @@ StructInfo InferStructInfoTile(const Call& call, const BlockBuilder& ctx) {
     if (l > ndim) {
       return TensorStructInfo(data_sinfo->dtype, l, data_sinfo->vdevice);
     } else {
-      for (auto i : attrs->repeats) {
-        if (!analyzer->CanProveEqual(i, 1)) {
+      for (int64_t i : attrs->repeats) {
+        if (i != 1) {
           return TensorStructInfo(data_sinfo->dtype, data_sinfo->ndim, data_sinfo->vdevice);
         }
       }
@@ -1927,10 +1928,11 @@ StructInfo InferStructInfoTile(const Call& call, const BlockBuilder& ctx) {
     if (i < l_delta) {
       out_shape.push_back(data_shape->values[i - ndim_delta]);
     } else if (i < ndim_delta) {
-      out_shape.push_back(attrs->repeats[i - l_delta]);
+      out_shape.push_back(IntImm(DataType::Int(64), attrs->repeats[i - l_delta]));
     } else {
       out_shape.push_back(
-          analyzer->Simplify(data_shape->values[i - ndim_delta] * attrs->repeats[i - l_delta]));
+          analyzer->Simplify(data_shape->values[i - ndim_delta] *
+                             IntImm(DataType::Int(64), attrs->repeats[i - l_delta])));
     }
   }
 
@@ -1970,7 +1972,7 @@ InferLayoutOutput InferLayoutTile(
   // - If len(repeats) > ndim: first (len(repeats) - ndim) elements are new dimensions,
   //   remaining elements correspond to input dimensions.
   //   e.g., ndim=4, repeats=[2, 1, 2, 1, 1] means new dims [2, 1] + input dims [2, 1, 1]
-  ffi::Array<Integer> new_repeats;
+  ffi::Array<int64_t> new_repeats;
 
   if (out_ndim == ndim) {
     // Same dimension: reorder repeats according to layout transformation.
@@ -1984,7 +1986,7 @@ InferLayoutOutput InferLayoutTile(
       if (pos_in_initial >= ndim - l) {
         new_repeats.push_back(attrs->repeats[pos_in_initial - (ndim - l)]);
       } else {
-        new_repeats.push_back(Integer(1));
+        new_repeats.push_back(1);
       }
     }
   } else {
@@ -2021,7 +2023,7 @@ TVM_REGISTER_OP("relax.tile")
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTile)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutTile)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.flip */
 
@@ -2093,13 +2095,13 @@ TVM_REGISTER_OP("relax.flip")
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoFlip)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutFlip)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.gather_elements */
 
 Expr gather_elements(Expr data, Expr indices, int axis) {
   auto attrs = ffi::make_object<GatherElementsAttrs>();
-  attrs->axis = Integer(axis);
+  attrs->axis = axis;
   static const Op& op = Op::Get("relax.gather_elements");
   return Call(op, {data, indices}, Attrs(attrs), {});
 }
@@ -2138,7 +2140,7 @@ StructInfo InferStructInfoGatherElements(const Call& call, const BlockBuilder& c
     return TensorStructInfo(data_sinfo->dtype, kUnknownNDim, data_sinfo->vdevice);
   }
 
-  int axis = attrs->axis.IntValue();
+  int axis = static_cast<int>(attrs->axis);
   if (axis < -data_sinfo->ndim || axis >= data_sinfo->ndim) {
     ctx->ReportFatal(Diagnostic::Error(call)
                      << "GatherElements requires axis to be within the input dimension range ["
@@ -2187,7 +2189,7 @@ InferLayoutOutput InferLayoutGatherElements(
   }
 
   ffi::ObjectPtr<GatherElementsAttrs> new_attrs = ffi::make_object<GatherElementsAttrs>(*attrs);
-  new_attrs->axis = FindAxis(layout->layout, attrs->axis->value);
+  new_attrs->axis = FindAxis(layout->layout, attrs->axis);
   return InferLayoutOutput({layout, layout}, {layout}, Attrs(new_attrs));
 }
 
@@ -2198,13 +2200,13 @@ TVM_REGISTER_OP("relax.gather_elements")
     .add_argument("indices", "Tensor", "The indices tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoGatherElements)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutGatherElements)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.gather_nd */
 
 Expr gather_nd(Expr data, Expr indices, int batch_dims) {
   auto attrs = ffi::make_object<GatherNDAttrs>();
-  attrs->batch_dims = Integer(batch_dims);
+  attrs->batch_dims = batch_dims;
   static const Op& op = Op::Get("relax.gather_nd");
   return Call(op, {data, indices}, Attrs(attrs), {});
 }
@@ -2231,8 +2233,8 @@ StructInfo InferStructInfoGatherND(const Call& call, const BlockBuilder& ctx) {
         << "GatherND requires the input indices to be a Tensor. However, the given one is "
         << call->args[1]->struct_info_->GetTypeKey());
   }
-  TVM_FFI_ICHECK_GE(attrs->batch_dims.IntValue(), 0);
-  int batch_dims = attrs->batch_dims.IntValue();
+  TVM_FFI_ICHECK_GE(attrs->batch_dims, 0);
+  int batch_dims = static_cast<int>(attrs->batch_dims);
   int input_dims = data_sinfo->ndim;
   if (!indices_sinfo->IsUnknownDtype() && indices_sinfo->dtype != DataType::Int(64)) {
     ctx->ReportFatal(Diagnostic::Error(call)
@@ -2294,7 +2296,7 @@ TVM_REGISTER_OP("relax.gather_nd")
     .add_argument("data", "Tensor", "The input tensor.")
     .add_argument("indices", "Tensor", "The indices tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoGatherND)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.index_put */
 
@@ -2443,7 +2445,7 @@ TVM_REGISTER_OP("relax.index_put")
     .add_argument("indices", "Tensor", "The indices tensor(s).")
     .add_argument("values", "Tensor", "The values to put.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoIndexPut)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.meshgrid */
 
@@ -2548,7 +2550,7 @@ TVM_REGISTER_OP("relax.meshgrid")
     .add_argument("tensors", "Tuple of Tensors", "The input list of tensors.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoMeshgrid)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.scatter_elements */
 
@@ -2680,7 +2682,7 @@ InferLayoutOutput InferLayoutScatterElements(
   }
 
   ffi::ObjectPtr<ScatterElementsAttrs> new_attrs = ffi::make_object<ScatterElementsAttrs>(*attrs);
-  new_attrs->axis = FindAxis(layout->layout, attrs->axis->value);
+  new_attrs->axis = FindAxis(layout->layout, attrs->axis);
   return InferLayoutOutput({layout, layout, layout}, {layout}, Attrs(new_attrs));
 }
 
@@ -2692,7 +2694,7 @@ TVM_REGISTER_OP("relax.scatter_elements")
     .add_argument("updates", "Tensor", "The input tensor of updates.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoScatterElements)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutScatterElements)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.scatter_nd */
 
@@ -2869,7 +2871,7 @@ TVM_REGISTER_OP("relax.scatter_nd")
     .add_argument("updates", "Tensor", "The input tensor of updates.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoScatterND)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutScatterND)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.scatter_nd */
 
@@ -3026,7 +3028,7 @@ TVM_REGISTER_OP("relax.slice_scatter")
     .add_argument("end", "PrimValue", "The ending index of the slice (exclusive).")
     .add_argument("step", "PrimValue", "The step of the slice.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoSliceScatter)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.one_hot */
 
@@ -3103,7 +3105,7 @@ TVM_REGISTER_OP("relax.one_hot")
     .add_argument("on_value", "PrimValue", "The value to fill at specified indices.")
     .add_argument("off_value", "PrimValue", "The value to fill at other indices.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoOneHot)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/manipulate.h
+++ b/src/relax/op/tensor/manipulate.h
@@ -52,7 +52,7 @@ Expr concat(Expr tensors, ffi::Optional<int64_t> axis);
  * \param axis The axes at which the input array are expanded.
  * \return The transformed result.
  */
-Expr expand_dims(Expr x, ffi::Array<Integer> axis);
+Expr expand_dims(Expr x, ffi::Array<int64_t> axis);
 
 /*!
  * \brief Flatten all the tensor dimensions into one.
@@ -82,7 +82,7 @@ Expr layout_transform(Expr x, tirx::IndexMap index_map, ffi::Optional<PrimValue>
  * \param axes The target axes order, reverse order if not specified.
  * \return The transposed result.
  */
-Expr permute_dims(Expr x, ffi::Optional<ffi::Array<Integer>> axes);
+Expr permute_dims(Expr x, ffi::Optional<ffi::Array<int64_t>> axes);
 
 /*!
  * \brief Reshape the input array, supporting `-1` inference in the new
@@ -117,14 +117,14 @@ Expr split(Expr x, ffi::Variant<IntImm, ffi::Array<IntImm>> indices_or_sections,
  * If any specified axis has dimension that does not equal 1, it is an error.
  * \return The squeezed result.
  */
-Expr squeeze(Expr x, ffi::Optional<ffi::Array<Integer>> axis);
+Expr squeeze(Expr x, ffi::Optional<ffi::Array<int64_t>> axis);
 /*!
  * \brief Stack tensors along the specified axis.
  * \param tensors The input tensors to be stacked.
  * \param axis The axis along which the tensors will be stacked.
  * \return The stacked result.
  */
-Expr stack(Expr tensors, ffi::Optional<Integer> axis);
+Expr stack(Expr tensors, ffi::Optional<int64_t> axis);
 /*!
  * \brief Return a summation of data to the shape of collapse_target.
  * For details, please see the operator `relax.collapse_sum_to`.
@@ -171,7 +171,7 @@ Expr repeat(Expr data, int repeats, ffi::Optional<int64_t> axis = std::nullopt);
  * \param repeats The number of repetitions of data along each axis.
  * \return The computed result.
  */
-Expr tile(Expr data, ffi::Array<Integer> repeats);
+Expr tile(Expr data, ffi::Array<int64_t> repeats);
 
 /*!
  * \brief Reverses the order of elements along given axis.

--- a/src/relax/op/tensor/qdq.cc
+++ b/src/relax/op/tensor/qdq.cc
@@ -139,7 +139,7 @@ TVM_REGISTER_OP("relax.quantize")
     .add_argument("scale", "Tensor", "The quantization scale of the output tensor.")
     .add_argument("zero_point", "Tensor", "The quantization zero_point of the output tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoQuantize)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.dequantize */
 
@@ -246,7 +246,7 @@ TVM_REGISTER_OP("relax.dequantize")
     .add_argument("scale", "Tensor", "The quantization scale of the input tensor.")
     .add_argument("zero_point", "Tensor", "The quantization zero_point of the input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoDequantize)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/sampling.cc
+++ b/src/relax/op/tensor/sampling.cc
@@ -143,7 +143,7 @@ TVM_REGISTER_OP("relax.multinomial_from_uniform")
     .add_argument("uniform_sample", "Tensor", "The uniform sample tensor.")
     .add_argument("sample_indices", "Tensor", "The sample indices tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoMultinomialFromUniform)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/search.cc
+++ b/src/relax/op/tensor/search.cc
@@ -85,7 +85,7 @@ TVM_REGISTER_OP("relax.bucketize")
                   "1-D tensor, must contain a strictly increasing sequence, or the return value is "
                   "undefined.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoBucketize)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.where */
 Expr where(Expr condition, Expr x1, Expr x2) {
@@ -184,7 +184,7 @@ TVM_REGISTER_OP("relax.where")
     .add_argument("x1", "Tensor", "The first input tensor.")
     .add_argument("x2", "Tensor", "The second input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoWhere)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.argmax & relax.argmin */
 
@@ -262,7 +262,7 @@ StructInfo InferStructInfoArgmaxArgmin(const Call& call, const BlockBuilder& ctx
       .set_num_inputs(1)                                                             \
       .add_argument("x", "Tensor", "The input data tensor")                          \
       .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoArgmaxArgmin)   \
-      .set_attr<Bool>("FPurity", Bool(true));
+      .set_attr<bool>("FPurity", true);
 
 RELAX_REGISTER_ARGMAX_ARGMIN_OP(argmax);
 RELAX_REGISTER_ARGMAX_ARGMIN_OP(argmin);

--- a/src/relax/op/tensor/set.cc
+++ b/src/relax/op/tensor/set.cc
@@ -167,7 +167,7 @@ TVM_REGISTER_OP("relax.unique")
                   "are returned.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoUnique)
     .set_attr<FCallPacked>("FCallPacked", "relax.run.unique")
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.nonzero */
 Expr nonzero(Expr x) {
@@ -190,7 +190,7 @@ TVM_REGISTER_OP("relax.nonzero")
     .add_argument("x", "Tensor", "The input tensor")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoNonzero)
     .set_attr<FCallPacked>("FCallPacked", "relax.run.nonzero")
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/sorting.cc
+++ b/src/relax/op/tensor/sorting.cc
@@ -62,7 +62,7 @@ TVM_REGISTER_OP("relax.sort")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoSort)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.argsort */
 
@@ -96,7 +96,7 @@ TVM_REGISTER_OP("relax.argsort")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoArgsort)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.topk */
 
@@ -164,7 +164,7 @@ TVM_REGISTER_OP("relax.topk")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoTopK)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/statistical.cc
+++ b/src/relax/op/tensor/statistical.cc
@@ -103,19 +103,19 @@ InferLayoutOutput InferLayoutStatistical(
   TVM_FFI_ICHECK(!tensor_sinfo->IsUnknownNdim()) << "Only support known ndim";
   int ndim = tensor_sinfo->ndim;
 
-  ffi::Array<Integer> axis;
+  ffi::Array<int64_t> axis;
   if (attrs->axis.defined()) {
     axis = attrs->axis.value();
   } else {
     axis.reserve(ndim);
     for (int i = 0; i < ndim; ++i) {
-      axis.push_back(Integer(i));
+      axis.push_back(i);
     }
   }
 
   std::string axis_str(ndim, '0');
-  for (const auto& iter : axis) {
-    axis_str[(iter->value + ndim) % ndim] = '#';
+  for (int64_t iter : axis) {
+    axis_str[(iter + ndim) % ndim] = '#';
   }
   for (int i = 0, j = 0; i < ndim; ++i) {
     if (axis_str[i] != '#') {
@@ -131,10 +131,10 @@ InferLayoutOutput InferLayoutStatistical(
                                     [](unsigned char c) { return std::isdigit(c); }),
                      new_axis_str.end());
 
-  ffi::Array<Integer> new_axis;
+  ffi::Array<int64_t> new_axis;
   for (size_t i = 0; i < new_axis_str.size(); ++i) {
     if (new_axis_str.at(i) == '#') {
-      new_axis.push_back(Integer(i));
+      new_axis.push_back(static_cast<int64_t>(i));
     }
   }
   std::string output_layout;
@@ -244,11 +244,11 @@ StructInfo InferStructInfoStatisticalExtension(const Call& call, const BlockBuil
 
 /* relax.cumprod */
 Expr cumprod(Expr data, ffi::Optional<int64_t> axis, ffi::Optional<DataType> dtype,
-             Bool exclusive) {
+             bool exclusive) {
   auto attrs = ffi::make_object<ScanopAttrs>();
   attrs->axis = std::move(axis);
   attrs->dtype = std::move(dtype.value_or(DataType::Void()));
-  attrs->exclusive = std::move(exclusive);
+  attrs->exclusive = exclusive;
 
   static const Op& op = Op::Get("relax.cumprod");
   return Call(op, {std::move(data)}, Attrs{attrs}, {});
@@ -264,14 +264,14 @@ TVM_REGISTER_OP("relax.cumprod")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoScan)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.cumsum */
-Expr cumsum(Expr data, ffi::Optional<int64_t> axis, ffi::Optional<DataType> dtype, Bool exclusive) {
+Expr cumsum(Expr data, ffi::Optional<int64_t> axis, ffi::Optional<DataType> dtype, bool exclusive) {
   auto attrs = ffi::make_object<ScanopAttrs>();
   attrs->axis = std::move(axis);
   attrs->dtype = std::move(dtype.value_or(DataType::Void()));
-  attrs->exclusive = std::move(exclusive);
+  attrs->exclusive = exclusive;
 
   static const Op& op = Op::Get("relax.cumsum");
   return Call(op, {std::move(data)}, Attrs{attrs}, {});
@@ -287,10 +287,10 @@ TVM_REGISTER_OP("relax.cumsum")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoScan)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.median */
-Expr median(Expr data, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims) {
+Expr median(Expr data, ffi::Optional<ffi::Array<int64_t>> axis, bool keepdims) {
   ffi::ObjectPtr<StatisticalAttrs> attrs = ffi::make_object<StatisticalAttrs>();
   attrs->axis = std::move(axis);
   attrs->keepdims = keepdims;
@@ -307,7 +307,7 @@ TVM_REGISTER_OP("relax.median")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoStatisticalExtension)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 RELAX_REGISTER_STATISTICAL_OP_INTERFACE(max);
 RELAX_REGISTER_STATISTICAL_OP_INTERFACE(mean);

--- a/src/relax/op/tensor/statistical.h
+++ b/src/relax/op/tensor/statistical.h
@@ -43,7 +43,7 @@ namespace relax {
  *  2. be prepended with a prefix "relax." as the identifier string in the operator registry.
  */
 #define RELAX_REGISTER_STATISTICAL_OP_INTERFACE(OpName)                            \
-  Expr OpName(Expr x, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims) {    \
+  Expr OpName(Expr x, ffi::Optional<ffi::Array<int64_t>> axis, bool keepdims) {    \
     ffi::ObjectPtr<StatisticalAttrs> attrs = ffi::make_object<StatisticalAttrs>(); \
     attrs->axis = std::move(axis);                                                 \
     attrs->keepdims = keepdims;                                                    \
@@ -58,7 +58,7 @@ namespace relax {
       .add_argument("x", "Tensor", "The input data tensor")                        \
       .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoStatistical)  \
       .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutStatistical)    \
-      .set_attr<Bool>("FPurity", Bool(true))
+      .set_attr<bool>("FPurity", true)
 
 /*!
  * \brief Computes the maximum value of tensor elements over given axes.
@@ -68,22 +68,22 @@ namespace relax {
  * reduced are left in the result as dimensions with size one. With this option, the result will
  * broadcast correctly against the input tensor. \return The result after reduction.
  */
-Expr max(Expr x, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims);
+Expr max(Expr x, ffi::Optional<ffi::Array<int64_t>> axis, bool keepdims);
 
 /*! \brief Computes the mean of tensor elements over given axes. */
-Expr mean(Expr x, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims);
+Expr mean(Expr x, ffi::Optional<ffi::Array<int64_t>> axis, bool keepdims);
 
 /*! \brief Computes the min of tensor elements over given axes. */
-Expr min(Expr x, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims);
+Expr min(Expr x, ffi::Optional<ffi::Array<int64_t>> axis, bool keepdims);
 
 /*! \brief Computes the product of tensor elements over given axes. */
-Expr prod(Expr x, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims);
+Expr prod(Expr x, ffi::Optional<ffi::Array<int64_t>> axis, bool keepdims);
 
 /*! \brief Computes the standard deviation of tensor elements over given axes. */
-Expr std(Expr x, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims);
+Expr std(Expr x, ffi::Optional<ffi::Array<int64_t>> axis, bool keepdims);
 
 /*! \brief Computes the sum of tensor elements over given axes. */
-Expr sum(Expr x, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims);
+Expr sum(Expr x, ffi::Optional<ffi::Array<int64_t>> axis, bool keepdims);
 
 /*!
  * \brief Numpy style cumprod op. Return the cumulative inclusive product of the elements along
@@ -99,7 +99,7 @@ Expr sum(Expr x, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims);
  * result.
  */
 Expr cumprod(Expr data, ffi::Optional<int64_t> axis = std::nullopt,
-             ffi::Optional<DataType> dtype = std::nullopt, Bool exclusive = Bool(false));
+             ffi::Optional<DataType> dtype = std::nullopt, bool exclusive = false);
 
 /*!
  * \brief Numpy style cumsum op. Return the cumulative inclusive sum of the elements along
@@ -114,13 +114,13 @@ Expr cumprod(Expr data, ffi::Optional<int64_t> axis = std::nullopt,
  * \return The computed result.
  */
 Expr cumsum(Expr data, ffi::Optional<int64_t> axis = std::nullopt,
-            ffi::Optional<DataType> dtype = std::nullopt, Bool exclusive = Bool(false));
+            ffi::Optional<DataType> dtype = std::nullopt, bool exclusive = false);
 
 /*! \brief Computes the variance of tensor elements over given axes. */
-Expr variance(Expr x, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims);
+Expr variance(Expr x, ffi::Optional<ffi::Array<int64_t>> axis, bool keepdims);
 
 /*! \brief Computes the median of tensor elements over given axes. */
-Expr median(Expr x, ffi::Optional<ffi::Array<Integer>> axis, bool keepdims);
+Expr median(Expr x, ffi::Optional<ffi::Array<int64_t>> axis, bool keepdims);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/ternary.cc
+++ b/src/relax/op/tensor/ternary.cc
@@ -138,7 +138,7 @@ TVM_REGISTER_OP("relax.ewise_fma")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoEwiseFMA)
     .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutEwiseFMA)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr ewise_fma(Expr x1, Expr x2, Expr x3) {
   static const Op& op = Op::Get("relax.ewise_fma");

--- a/src/relax/op/tensor/unary.cc
+++ b/src/relax/op/tensor/unary.cc
@@ -74,7 +74,7 @@ TVM_REGISTER_OP("relax.clip")
     .add_argument("min", "PrimValue", "The lower-bound of the range to be clipped to")
     .add_argument("max", "PrimValue", "The upper-bound of the range to be clipped to")
     .set_attr<FInferStructInfo>("FInferStructInfo", ReturnStructInfoFromArg<0>)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 Expr clip(Expr x, Expr min, Expr max) {
   TVM_FFI_ICHECK(min->IsInstance<PrimValueNode>())

--- a/src/relax/op/vision/multibox_transform_loc.cc
+++ b/src/relax/op/vision/multibox_transform_loc.cc
@@ -199,7 +199,7 @@ TVM_REGISTER_OP("relax.vision.multibox_transform_loc")
                   "[B,4*N] box encodings (x,y,w,h); TFLite yxhw order remapped to xywh.")
     .add_argument("anchor", "Tensor", "[1,N,4] priors as ltrb (left,top,right,bottom).")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoMultiboxTransformLoc)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/vision/nms.cc
+++ b/src/relax/op/vision/nms.cc
@@ -113,7 +113,7 @@ TVM_REGISTER_OP("relax.vision.all_class_non_max_suppression")
     .add_argument("score_threshold", "Tensor",
                   "The score threshold to filter out low score boxes early.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAllClassNMS)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.vision.get_valid_counts */
 
@@ -189,7 +189,7 @@ TVM_REGISTER_OP("relax.vision.get_valid_counts")
     .add_argument("data", "Tensor",
                   "Input data, 3-D tensor [batch_size, num_anchors, elem_length].")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoGetValidCounts)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 /* relax.vision.non_max_suppression */
 
@@ -371,7 +371,7 @@ TVM_REGISTER_OP("relax.vision.non_max_suppression")
     .add_argument("valid_count", "Tensor", "1-D tensor for valid number of boxes.")
     .add_argument("indices", "Tensor", "2-D tensor with shape [batch_size, num_anchors].")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoNMS)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/vision/roi_align.cc
+++ b/src/relax/op/vision/roi_align.cc
@@ -135,7 +135,7 @@ TVM_REGISTER_OP("relax.vision.roi_align")
                   "The input rois with shape (num_roi, 5) in [batch_idx, x1, y1, x2, y2] format.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoROIAlign)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/vision/roi_pool.cc
+++ b/src/relax/op/vision/roi_pool.cc
@@ -122,7 +122,7 @@ TVM_REGISTER_OP("relax.vision.roi_pool")
                   "The input rois with shape (num_roi, 5) in [batch_idx, x1, y1, x2, y2] format.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoROIPool)
     .set_attr<TMixedPrecisionPolicy>("TMixedPrecisionPolicy", MixedPrecisionPolicyKind::kFollow)
-    .set_attr<Bool>("FPurity", Bool(true));
+    .set_attr<bool>("FPurity", true);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/script/builder/frame.cc
+++ b/src/relax/script/builder/frame.cc
@@ -75,15 +75,14 @@ void FunctionFrameNode::ExitWithScope() {
 
   Expr body = this->block_builder->Normalize(tvm::relax::SeqExpr(binding_blocks, output.value()));
   // if the function is not private, add a global symbol to its attributes
-  if (!is_private.value_or(Bool(false))->value && name.has_value() &&
-      !attrs.count(tvm::attr::kGlobalSymbol)) {
+  if (!is_private.value_or(false) && name.has_value() && !attrs.count(tvm::attr::kGlobalSymbol)) {
     attrs.Set(tvm::attr::kGlobalSymbol, name.value());
   }
   this->block_builder->EndScope();
   tvm::relax::Function func(/*params=*/params,
                             /*body=*/body,
                             /*ret_struct_info=*/ret_struct_info,
-                            /*is_pure=*/is_pure.value_or(Bool(true))->value,
+                            /*is_pure=*/is_pure.value_or(true),
                             /*attrs=*/DictAttrs(attrs));
   // Step 2: Update IRModule.
   if (builder->frames.empty()) {

--- a/src/relax/script/builder/ir.cc
+++ b/src/relax/script/builder/ir.cc
@@ -54,7 +54,7 @@ TVM_STATIC_IR_FUNCTOR(Namer, vtable)
 
 /////////////////////////////// Function ////////////////////////////////
 
-FunctionFrame Function(const Bool& is_pure, const Bool& is_private) {
+FunctionFrame Function(bool is_pure, bool is_private) {
   ffi::ObjectPtr<FunctionFrameNode> n = ffi::make_object<FunctionFrameNode>();
   const IRBuilder& ir_builder = IRBuilder::Current();
   ffi::Optional<tvm::IRModule> mod = std::nullopt;
@@ -90,7 +90,7 @@ void FuncName(const ffi::String& name) {
 void FuncAttrs(ffi::Map<ffi::String, ffi::Any> attrs) {
   FunctionFrame frame = FindFunctionFrame("R.func_attr");
   for (const auto& [key, value] : attrs) {
-    if (key == tvm::attr::kGlobalSymbol && frame->is_private.value_or(Bool(false))->value) {
+    if (key == tvm::attr::kGlobalSymbol && frame->is_private.value_or(false)) {
       TVM_FFI_THROW(ValueError) << "A private function may not have the kGlobalSymbol (\""
                                 << tvm::attr::kGlobalSymbol << "\") attribute.  "
                                 << "However, a private function specified the global symbol as "

--- a/src/relax/script/printer/call.cc
+++ b/src/relax/script/printer/call.cc
@@ -117,9 +117,9 @@ ffi::Optional<ExprDoc> PrintCallTIRDPSPacked(const relax::Call& n, const AccessP
     kwargs_keys.push_back("inplace_indices");
     ffi::Array<ExprDoc> index_fields;
     if (auto* call_tir_inplace_attrs = n->attrs.as<relax::CallTIRInplaceAttrs>()) {
-      for (auto inplace_index : call_tir_inplace_attrs->inplace_indices) {
+      for (int64_t inplace_index : call_tir_inplace_attrs->inplace_indices) {
         index_fields.push_back(
-            LiteralDoc::Int(inplace_index.IntValue(), n_p->Attr("attrs")->Attr("inplace_indices")));
+            LiteralDoc::Int(inplace_index, n_p->Attr("attrs")->Attr("inplace_indices")));
       }
     }
     kwargs_values.push_back(ListDoc(index_fields));

--- a/src/relax/transform/allocate_workspace.cc
+++ b/src/relax/transform/allocate_workspace.cc
@@ -45,7 +45,7 @@ class ExternFunctionRewriter : ExprMutator {
   std::unordered_map<const GlobalVarNode*, Function> Run() {
     std::unordered_map<const GlobalVarNode*, Function> ret;
     for (const auto& [gvar, f] : builder_->GetContextIRModule()->functions) {
-      if (f->GetAttr<Integer>(attr::kWorkspaceSize)) {
+      if (f->GetAttr<int64_t>(attr::kWorkspaceSize)) {
         ret[gvar.get()] = Downcast<Function>(VisitExpr(f));
       }
     }
@@ -57,7 +57,7 @@ class ExternFunctionRewriter : ExprMutator {
         !func_node->GetAttr<ffi::String>(attr::kComposite)) {
       return ExprMutator::VisitExpr_(func_node);
     }
-    if (auto workspace = func_node->GetAttr<Integer>(attr::kWorkspaceSize)) {
+    if (auto workspace = func_node->GetAttr<int64_t>(attr::kWorkspaceSize)) {
       // Append the workspace parameter to this function.
       ffi::Array<Var> new_params = func_node->params;
 
@@ -109,8 +109,8 @@ class WorkspaceProvider : ExprMutator {
 
   IRModule Run() {
     for (const auto& [gvar, f] : mod_->functions) {
-      if (auto workspace = f->GetAttr<Integer>(relax::attr::kWorkspaceSize)) {
-        max_workspace_size_ = std::max<size_t>(max_workspace_size_, workspace.value()->value);
+      if (auto workspace = f->GetAttr<int64_t>(relax::attr::kWorkspaceSize)) {
+        max_workspace_size_ = std::max<size_t>(max_workspace_size_, workspace.value());
       }
     }
 

--- a/src/relax/transform/attach_attr_layout_free_buffers.cc
+++ b/src/relax/transform/attach_attr_layout_free_buffers.cc
@@ -49,10 +49,10 @@ class AttrAttacher : public ExprMutator {
 
   using ExprMutator::VisitExpr_;
   Expr VisitExpr_(const FunctionNode* op) final {
-    if (auto opt_num_input = op->attrs.GetAttr<Integer>(attr::kNumInput)) {
+    if (auto opt_num_input = op->attrs.GetAttr<int64_t>(attr::kNumInput)) {
       TVM_FFI_ICHECK(layout_free_exprs_.empty())
           << "meet a non-global function with num_input attr";
-      size_t num_input = opt_num_input.value()->value;
+      size_t num_input = opt_num_input.value();
       for (size_t i = num_input; i < op->params.size(); i++) {
         layout_free_exprs_.insert(op->params[i].get());
       }

--- a/src/relax/transform/bundle_model_params.cc
+++ b/src/relax/transform/bundle_model_params.cc
@@ -42,9 +42,9 @@ class ModelParamBundler : public ExprMutator {
 
   Expr VisitExpr_(const FunctionNode* op) override {
     Function func = ffi::GetRef<Function>(op);
-    auto opt_num_input = func->attrs.GetAttr<Integer>(attr::kNumInput);
+    auto opt_num_input = func->attrs.GetAttr<int64_t>(attr::kNumInput);
     if (!opt_num_input) return func;
-    auto signed_num_input = opt_num_input.value()->value;
+    auto signed_num_input = opt_num_input.value();
 
     TVM_FFI_ICHECK_GE(signed_num_input, 0);
     TVM_FFI_ICHECK_LE(signed_num_input, func->params.size())

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -99,11 +99,10 @@ class CallTIRMutator : public ExprMutator {
                                         "alloc"));
         } else {
           // if there is only one output, it must be an in-place argument, but check anyway
-          TVM_FFI_ICHECK(inplace_attrs->inplace_indices[0].IntValue() != -1)
+          TVM_FFI_ICHECK(inplace_attrs->inplace_indices[0] != -1)
               << "If calling call_tir_inplace and there is one output, its in-place index must not"
                  " be -1.";
-          outs.push_back(
-              Downcast<Tuple>(call->args[1])->fields[inplace_attrs->inplace_indices[0].IntValue()]);
+          outs.push_back(Downcast<Tuple>(call->args[1])->fields[inplace_attrs->inplace_indices[0]]);
         }
       } else if (const auto& _tuple_sinfo = MatchStructInfo<TupleStructInfo>(expr)) {
         // multiple output case
@@ -126,7 +125,7 @@ class CallTIRMutator : public ExprMutator {
             scope = field_tensor->vdevice.value()->memory_scope;
           }
 
-          if (!is_inplace || inplace_attrs->inplace_indices[i].IntValue() == -1) {
+          if (!is_inplace || inplace_attrs->inplace_indices[i] == -1) {
             outs.push_back(builder_->Emit(Call(alloc_tensor_op,
                                                {Downcast<ShapeExpr>(field_tensor->shape.value()),
                                                 DataTypeImm(field_tensor->dtype),
@@ -134,8 +133,8 @@ class CallTIRMutator : public ExprMutator {
                                                Attrs(), {field_tensor}),
                                           "alloc"));
           } else {
-            outs.push_back(Downcast<Tuple>(call->args[1])
-                               ->fields[inplace_attrs->inplace_indices[i].IntValue()]);
+            outs.push_back(
+                Downcast<Tuple>(call->args[1])->fields[inplace_attrs->inplace_indices[i]]);
           }
         }
       } else {
@@ -152,7 +151,7 @@ class CallTIRMutator : public ExprMutator {
           args.insert(args.end(), outs.begin(), outs.end());
         } else {
           for (size_t i = 0; i < outs.size(); i++) {
-            if (inplace_attrs->inplace_indices[i].IntValue() == -1) {
+            if (inplace_attrs->inplace_indices[i] == -1) {
               args.push_back(outs[i]);
             }
           }

--- a/src/relax/transform/compute_prim_value.cc
+++ b/src/relax/transform/compute_prim_value.cc
@@ -47,9 +47,8 @@ class PrimValueComputeInjector : public ExprMutator {
     auto param_vars = tirx::UndefinedVars(node->value);
     tirx::Stmt body = tirx::Evaluate(tirx::Call(ret_dtype, tirx::builtin::ret(), {node->value}));
 
-    tirx::PrimFunc func(
-        param_vars, body, PrimType(ret_dtype), {},
-        DictAttrs({{tirx::attr::kIsHostFunc, true}, {tvm::attr::kSTir, tvm::Bool(true)}}));
+    tirx::PrimFunc func(param_vars, body, PrimType(ret_dtype), {},
+                        DictAttrs({{tirx::attr::kIsHostFunc, true}, {tvm::attr::kSTir, true}}));
     func = s_tir::RenewDefs(func);
 
     auto callee = builder_->AddFunction(func, "compute_symbolic_expr");

--- a/src/relax/transform/convert_layout.cc
+++ b/src/relax/transform/convert_layout.cc
@@ -85,11 +85,11 @@ class LayoutConvertMutator : public ExprMutator {
       : desired_layouts_(desired_layouts), layout_cb_(layout_cb) {}
 
  private:
-  ffi::Array<Integer> LayoutToIntegers(const SLayout& layout) {
-    ffi::Array<Integer> ret;
+  ffi::Array<int64_t> LayoutToIntegers(const SLayout& layout) {
+    ffi::Array<int64_t> ret;
     LayoutDecision src = InitialLayoutDecision(layout.ndim());
     for (size_t i = 0; i < layout.ndim(); ++i) {
-      ret.push_back(Integer(src->layout.IndexOf(layout[i])));
+      ret.push_back(static_cast<int64_t>(src->layout.IndexOf(layout[i])));
     }
     return ret;
   }

--- a/src/relax/transform/dataflow_inplace.cc
+++ b/src/relax/transform/dataflow_inplace.cc
@@ -522,9 +522,8 @@ bool OpSupportsInplace(const Op& op) { return SUPPORTED_OPS.count(op->name); }
  */
 class InplaceOpportunityNode : public ffi::Object {
  public:
-  // need to use Array for the benefit of the FFI
-  Integer binding_idx;
-  ffi::Array<Integer> arg_idxs;
+  int64_t binding_idx;
+  ffi::Array<int64_t> arg_idxs;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -540,7 +539,7 @@ TVM_FFI_STATIC_INIT_BLOCK() { InplaceOpportunityNode::RegisterReflection(); }
 
 class InplaceOpportunity : public ffi::ObjectRef {
  public:
-  TVM_DLL InplaceOpportunity(const Integer& binding_idx, const ffi::Array<Integer>& arg_idxs) {
+  TVM_DLL InplaceOpportunity(int64_t binding_idx, const ffi::Array<int64_t>& arg_idxs) {
     auto node = ffi::make_object<InplaceOpportunityNode>();
     node->binding_idx = binding_idx;
     node->arg_idxs = arg_idxs;
@@ -670,24 +669,25 @@ FindInplaceOpportunities(const DataflowBlock& block, const ffi::Array<Var>& inpu
         }
 
         // produce a list of candidates for this index
-        ffi::Array<Integer> size_candidate_list;
+        ffi::Array<int64_t> size_candidate_list;
         for (auto candidate : candidates) {
-          size_candidate_list.push_back(Integer(candidate));
+          size_candidate_list.push_back(static_cast<int64_t>(candidate));
         }
-        size_match_list.push_back(InplaceOpportunity(Integer(i), size_candidate_list));
+        size_match_list.push_back(InplaceOpportunity(static_cast<int64_t>(i), size_candidate_list));
 
         // also gather up the exact match candidates if there are any
-        ffi::Array<Integer> exact_candidate_list;
+        ffi::Array<int64_t> exact_candidate_list;
         for (auto candidate : candidates) {
           if (!exact_match_candidates.count(candidate)) {
             continue;
           }
-          exact_candidate_list.push_back(Integer(candidate));
+          exact_candidate_list.push_back(static_cast<int64_t>(candidate));
         }
         if (exact_candidate_list.empty()) {
           continue;
         }
-        exact_match_list.push_back(InplaceOpportunity(Integer(i), exact_candidate_list));
+        exact_match_list.push_back(
+            InplaceOpportunity(static_cast<int64_t>(i), exact_candidate_list));
       }
     }
   }
@@ -819,9 +819,9 @@ class ModuleInplaceTransformer : public ExprMutator {
     // Note: Not passing any input values for now, as we can't make any assumptions
     // about them.
     auto matches_found = FindInplaceOpportunities(block, {}, builder_);
-    ffi::Map<Binding, ffi::Array<Integer>> new_idxs;
+    ffi::Map<Binding, ffi::Array<int64_t>> new_idxs;
     for (auto match : matches_found.second) {
-      new_idxs.Set(block->bindings[match->binding_idx.IntValue()], match->arg_idxs);
+      new_idxs.Set(block->bindings[match->binding_idx], match->arg_idxs);
     }
 
     inplace_idxs = new_idxs;
@@ -863,7 +863,7 @@ class ModuleInplaceTransformer : public ExprMutator {
   // Given the call and indices of arguments that could be done in-place,
   // replace the call with a call to an in-place PrimFunc.
   // (Made public for testing.)
-  Call CreateInplaceCall(const Call& call, const ffi::Array<Integer>& inplace_indices) {
+  Call CreateInplaceCall(const Call& call, const ffi::Array<int64_t>& inplace_indices) {
     static const auto& legalize_map = Op::GetAttrMap<FLegalize>("FLegalize");
     static const auto& call_tir_inplace_op = Op::Get("relax.call_tir_inplace");
 
@@ -897,7 +897,7 @@ class ModuleInplaceTransformer : public ExprMutator {
     for (size_t i = 0; i < num_outs; i++) {
       // we will substitute output i with the corresponding param indicated by inplace indices
       auto output_var = old_primfunc->params[num_params - num_outs + i];
-      auto inplace_var = old_primfunc->params[inplace_indices[i].IntValue()];
+      auto inplace_var = old_primfunc->params[inplace_indices[i]];
       var_subst_map.Set(output_var, inplace_var);
 
       // also do the same with the buffer vars
@@ -960,14 +960,14 @@ class ModuleInplaceTransformer : public ExprMutator {
   // (we are assuming good behavior on the user's part).
   ffi::Array<Var> func_params;
   // map of eligible bindings to indices of arguments that can be used as the in-place target
-  ffi::Map<Binding, ffi::Array<Integer>> inplace_idxs;
+  ffi::Map<Binding, ffi::Array<int64_t>> inplace_idxs;
 };
 
 namespace transform {
 
-ffi::Map<Var, ffi::Array<Integer>> DataflowLivenessAnalysis(const DataflowBlock& block) {
+ffi::Map<Var, ffi::Array<int64_t>> DataflowLivenessAnalysis(const DataflowBlock& block) {
   auto liveness_ranges = AnalyzeLiveness(block);
-  ffi::Map<Var, ffi::Array<Integer>> ret;
+  ffi::Map<Var, ffi::Array<int64_t>> ret;
   for (auto kv : liveness_ranges) {
     ret.Set(kv.first, {kv.second.first, kv.second.second});
   }
@@ -980,19 +980,19 @@ ffi::Array<ffi::ObjectRef> DataflowAliasAnalysis(const DataflowBlock& block,
   auto res = analyzer.Analyze(block, inputs);
   auto alias_sets = res.first;
   auto tuple_map = res.second;
-  ffi::Map<Var, ffi::Array<Integer>> new_alias_sets;
-  ffi::Map<Integer, ffi::Array<ffi::Array<Integer>>> new_tuple_map;
+  ffi::Map<Var, ffi::Array<int64_t>> new_alias_sets;
+  ffi::Map<Integer, ffi::Array<ffi::Array<int64_t>>> new_tuple_map;
   for (auto kv : alias_sets) {
-    ffi::Array<Integer> aliases;
+    ffi::Array<int64_t> aliases;
     for (auto alias : kv.second) {
       aliases.push_back(alias);
     }
     new_alias_sets.Set(kv.first, aliases);
   }
   for (auto kv : tuple_map) {
-    ffi::Array<ffi::Array<Integer>> elem_aliases;
+    ffi::Array<ffi::Array<int64_t>> elem_aliases;
     for (auto alias_set : kv.second) {
-      ffi::Array<Integer> dim_aliases;
+      ffi::Array<int64_t> dim_aliases;
       for (auto alias : alias_set) {
         dim_aliases.push_back(alias);
       }
@@ -1031,7 +1031,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("relax.testing.transform.DataflowInplaceAnalysis", DataflowInplaceAnalysis)
       .def("relax.testing.transform.SingleInplaceCall",
            [](const IRModule& mod, const Call& call,
-              const ffi::Array<Integer>& inplace_indices) -> ffi::Array<ffi::ObjectRef> {
+              const ffi::Array<int64_t>& inplace_indices) -> ffi::Array<ffi::ObjectRef> {
              ModuleInplaceTransformer transformer(mod);
              auto ret_call = transformer.CreateInplaceCall(call, inplace_indices);
              return ffi::Array<ffi::ObjectRef>{ret_call, transformer.CurrentMod()};

--- a/src/relax/transform/decompose_ops.cc
+++ b/src/relax/transform/decompose_ops.cc
@@ -40,11 +40,11 @@ TensorStructInfo MatchTensorStructInfo(Expr data) {
   return _sinfo.value();
 }
 
-Expr ExpandToMatchInput(Expr data, int ndim, ffi::Array<Integer> axes) {
+Expr ExpandToMatchInput(Expr data, int ndim, ffi::Array<int64_t> axes) {
   axes = GetOrderedPositiveAxes(axes, ndim);
-  ffi::Array<Integer> expand_axes;
+  ffi::Array<int64_t> expand_axes;
   for (int i = 0, j = 0; i < ndim; ++i) {
-    if (j < static_cast<int>(axes.size()) && i == axes[j]->value) {
+    if (j < static_cast<int>(axes.size()) && i == axes[j]) {
       ++j;
     } else {
       expand_axes.push_back(i);
@@ -93,7 +93,7 @@ Expr MutateBatchNormForTraining(Call call) {
 
   TensorStructInfo sinfo = MatchTensorStructInfo(data);
 
-  ffi::Array<Integer> reduce_axes;
+  ffi::Array<int64_t> reduce_axes;
   for (int i = 0; i < sinfo->ndim; ++i) {
     if (i != attrs->axis) {
       reduce_axes.push_back(i);

--- a/src/relax/transform/eliminate_common_subexpr.cc
+++ b/src/relax/transform/eliminate_common_subexpr.cc
@@ -194,10 +194,10 @@ class CommonSubexprEliminator : public ExprMutator {
   }
 
   bool IsAllocatorCall(const Expr& expr) {
-    static const auto& allocator_attr_map = Op::GetAttrMap<Bool>("TAllocator");
+    static const auto& allocator_attr_map = Op::GetAttrMap<bool>("TAllocator");
     if (const auto* call = expr.as<CallNode>()) {
       if (const auto* op = call->op.as<OpNode>()) {
-        bool is_allocator = allocator_attr_map.get(ffi::GetRef<Op>(op), Bool(false))->value;
+        bool is_allocator = allocator_attr_map.get(ffi::GetRef<Op>(op), false);
         if (is_allocator) {
           return true;
         }

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -386,11 +386,11 @@ class ConstantFolder : public ExprMutator {
         Expr arg = post_call->args[0];
         ShapeExpr shape = Downcast<ShapeExpr>(arg);
         ffi::Array<PrimExpr> values = shape->values;
-        ffi::Array<Integer> arr;
+        ffi::Array<int64_t> arr;
         bool is_known = true;
         for (size_t i = 0; i < values.size(); i++) {
           PrimExpr val = values[i];
-          arr.push_back(ffi::GetRef<IntImm>(val.as<IntImmNode>()));
+          arr.push_back(val.as<IntImmNode>()->value);
           is_known &= (val.dtype() == DataType::Int(64));
         }
         if (is_known) {

--- a/src/relax/transform/fuse_ops.cc
+++ b/src/relax/transform/fuse_ops.cc
@@ -99,7 +99,7 @@ using support::LinkNode;
 
 constexpr uint32_t kMaxFusedOps = 256;
 
-TVM_REGISTER_PASS_CONFIG_OPTION("relax.FuseOps.max_depth", Integer);
+TVM_REGISTER_PASS_CONFIG_OPTION("relax.FuseOps.max_depth", int64_t);
 
 class GraphCreator : public ExprVisitor {
  public:
@@ -151,8 +151,8 @@ class GraphCreator : public ExprVisitor {
       SetNodePattern(param_node, OpPatternKind::kOpaque);
       AddToPostDFSOrder(param_node, param.get());
     }
-    if (auto opt_num_input = func->GetAttr<Integer>(attr::kNumInput)) {
-      for (int i = static_cast<int>(opt_num_input.value()->value);
+    if (auto opt_num_input = func->GetAttr<int64_t>(attr::kNumInput)) {
+      for (int i = static_cast<int>(opt_num_input.value());
            i < static_cast<int>(func->params.size()); ++i) {
         input_params_.insert(func->params[i].get());
       }
@@ -211,9 +211,9 @@ class GraphCreator : public ExprVisitor {
       // Override args for call_tir
       args = Downcast<Tuple>(call->args[1])->fields;
 
-      ffi::Optional<Integer> opt_pattern = func->GetAttr<Integer>("op_pattern");
-      if (opt_pattern.defined()) {
-        pattern = static_cast<OpPatternKind>(Downcast<IntImm>(opt_pattern)->value);
+      ffi::Optional<int64_t> opt_pattern = func->GetAttr<int64_t>("op_pattern");
+      if (opt_pattern.has_value()) {
+        pattern = static_cast<OpPatternKind>(opt_pattern.value());
       } else {
         pattern = OpPatternKind::kOpaque;
       }
@@ -1443,8 +1443,8 @@ Pass FuseOps(int fuse_opt_level) {
   auto pass_func =  //
       [=](IRModule m, PassContext pc) {
         int opt_level = fuse_opt_level == -1 ? pc->opt_level : fuse_opt_level;
-        auto max_fuse_depth = pc->GetConfig("relax.FuseOps.max_depth", Integer(kMaxFusedOps));
-        return relax::FuseOps(m, opt_level, max_fuse_depth.value().IntValue());
+        auto max_fuse_depth = pc->GetConfig<int64_t>("relax.FuseOps.max_depth", kMaxFusedOps);
+        return relax::FuseOps(m, opt_level, static_cast<size_t>(max_fuse_depth.value()));
       };
   return CreateModulePass(/*pass_function=*/pass_func,  //
                           /*opt_level=*/0,              //

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -1005,7 +1005,7 @@ class FusedTIRConstructor : public ExprVisitor {
   tirx::PrimFunc ConstructFunc() {
     ffi::Map<ffi::String, Any> attr_map;
     attr_map.Set(tirx::attr::kNoAlias, true);
-    attr_map.Set(tvm::attr::kSTir, tvm::Bool(true));
+    attr_map.Set(tvm::attr::kSTir, true);
     tirx::FuseTIRBufferSubstitutor subst(func_info_.buffer_subst_map,
                                          func_info_.symbolic_var_remap);
     TVM_FFI_ICHECK(func_info_.global_name != "fused");

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -414,18 +414,17 @@ class SBlockNameDeduplicator : public tirx::StmtMutator {
 
 namespace relax {
 
-static ffi::Array<Integer> GetInplaceOutputIndices(const ffi::Array<Integer>& inplace_indices,
+static ffi::Array<int64_t> GetInplaceOutputIndices(const ffi::Array<int64_t>& inplace_indices,
                                                    int num_inputs) {
-  ffi::Array<Integer> ret;
+  ffi::Array<int64_t> ret;
   int last_idx = num_inputs;
-  for (auto idx : inplace_indices) {
-    int i = idx.IntValue();
+  for (int64_t i : inplace_indices) {
     if (i >= 0) {
-      ret.push_back(Integer(i));
+      ret.push_back(i);
     } else {
       TVM_FFI_ICHECK_EQ(i, -1)
           << "The only negative index expected in inplace_indices is -1, but got " << i;
-      ret.push_back(Integer(last_idx));
+      ret.push_back(last_idx);
       last_idx++;
     }
   }
@@ -478,7 +477,7 @@ class RelaxToTIRVarMapCollector : public ExprVisitor {
     size_t num_inputs = relax_args.size();
     size_t num_outputs = relax_results.size();
 
-    ffi::Array<Integer> output_idxs;
+    ffi::Array<int64_t> output_idxs;
     if (in_place) {
       const auto* attrs = call->attrs.as<CallTIRInplaceAttrs>();
       TVM_FFI_ICHECK(attrs) << "Must have CallTIRInplaceAttrs for an in-place call";
@@ -532,7 +531,7 @@ class FusedTIRConstructor : public ExprVisitor {
    * \param gv The global var of relax subfunction to be fused into one PrimFunc
    * \return The fused TIR PrimFunc and the in-place indices (non-empty for an in-place call)
    */
-  static std::pair<tirx::PrimFunc, ffi::Array<Integer>> GetFusedTIR(const IRModule& mod,
+  static std::pair<tirx::PrimFunc, ffi::Array<int64_t>> GetFusedTIR(const IRModule& mod,
                                                                     const GlobalVar& gv) {
     FusedTIRConstructor visitor(mod, gv->name_hint);
     BaseFunc f = mod->Lookup(gv);
@@ -541,9 +540,9 @@ class FusedTIRConstructor : public ExprVisitor {
     TVM_FFI_ICHECK(f->HasNonzeroAttr(relax::attr::kPrimitive))
         << "Expected a function with attr `kPrimitive`";
     visitor(Downcast<relax::Function>(f));
-    ffi::Array<Integer> inplace_indices;
+    ffi::Array<int64_t> inplace_indices;
     for (size_t idx : visitor.inplace_indices_) {
-      inplace_indices.push_back(Integer(idx));
+      inplace_indices.push_back(static_cast<int64_t>(idx));
     }
     return {visitor.fused_tir_, inplace_indices};
   }
@@ -848,15 +847,15 @@ class FusedTIRConstructor : public ExprVisitor {
   }
 
   static ffi::Array<tirx::Var> GetPrimFuncOutputParams(const tirx::PrimFunc& func,
-                                                       const ffi::Array<Integer>& output_indices) {
+                                                       const ffi::Array<int64_t>& output_indices) {
     size_t n = func->params.size();
     int symbolic_var_index = -1;
     size_t output_size = output_indices.size();
     TVM_FFI_ICHECK_GE(n, output_size);
 
     ffi::Array<tirx::Var> ret;
-    for (auto idx : output_indices) {
-      int i = idx.IntValue();
+    for (int64_t idx : output_indices) {
+      int i = static_cast<int>(idx);
       const tirx::Var& param = func->params[static_cast<size_t>(i)];
       if (param->dtype.is_int() || param->dtype.is_uint()) {
         if (symbolic_var_index == -1) symbolic_var_index = i;
@@ -893,7 +892,7 @@ class FusedTIRConstructor : public ExprVisitor {
     size_t output_size = output_shapes.size();
     TVM_FFI_ICHECK_GE(n, output_size);
     ffi::Array<tirx::Buffer> output_buffers;
-    ffi::Array<Integer> output_idxs;
+    ffi::Array<int64_t> output_idxs;
     if (is_inplace) {
       const auto* attrs = call->attrs.as<CallTIRInplaceAttrs>();
       TVM_FFI_ICHECK(attrs) << "Must have CallTIRInplaceAttrs for an in-place call";
@@ -911,10 +910,10 @@ class FusedTIRConstructor : public ExprVisitor {
       const tirx::Buffer& buffer = func->buffer_map.at(param);
 
       // if this is an inplace output, do not do an intermediate allocation
-      if (output_idxs[i].IntValue() < num_inputs) {
+      if (output_idxs[i] < num_inputs) {
         TVM_FFI_ICHECK(input_buffers.has_value())
             << "Inplace functions must have some defined input";
-        output_buffers.push_back(input_buffers.value()[output_idxs[i].IntValue()]);
+        output_buffers.push_back(input_buffers.value()[output_idxs[i]]);
         continue;
       }
 
@@ -1185,7 +1184,7 @@ class TIRFuseMutator : public ExprMutator {
   struct Replacement {
     GlobalVar fused_tir_gvar;
     Function original_function;
-    ffi::Array<Integer> inplace_indices;
+    ffi::Array<int64_t> inplace_indices;
   };
 
   explicit TIRFuseMutator(std::unordered_map<GlobalVar, Replacement> replacements)

--- a/src/relax/transform/gradient_simplifier.cc
+++ b/src/relax/transform/gradient_simplifier.cc
@@ -113,7 +113,7 @@ class GradientSimplifier : private ExprMutator {
     if (ndim == 1) {
       return expr;
     }
-    auto axes = ffi::Array<Integer>();
+    auto axes = ffi::Array<int64_t>();
     for (int i = 0; i < ndim - 2; ++i) {
       axes.push_back(i);
     }

--- a/src/relax/transform/lambda_lift.cc
+++ b/src/relax/transform/lambda_lift.cc
@@ -372,8 +372,8 @@ class LambdaLifter : public ExprMutator {
         Call orig_call = Downcast<Call>(builder_->LookupBinding(var));
         bool is_pure = [&]() -> bool {
           if (auto op = orig_call->op.as<Op>()) {
-            static const auto& purity_map = Op::GetAttrMap<Bool>("FPurity");
-            return purity_map.get(op.value(), Bool(false))->value;
+            static const auto& purity_map = Op::GetAttrMap<bool>("FPurity");
+            return purity_map.get(op.value(), false);
           } else if (const auto* func_sinfo =
                          orig_call->op->struct_info_.as<FuncStructInfoNode>()) {
             return func_sinfo->purity;

--- a/src/relax/transform/legalize_ops.cc
+++ b/src/relax/transform/legalize_ops.cc
@@ -38,7 +38,7 @@
 namespace tvm {
 namespace relax {
 
-TVM_REGISTER_PASS_CONFIG_OPTION("relax.transform.apply_legalize_ops", Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("relax.transform.apply_legalize_ops", bool);
 
 /*!
  * \brief Check if a given Tensor/Shape/TupleStructInfo contains shapes whose
@@ -109,7 +109,7 @@ class LegalizeMutator : public ExprMutator {
   using ExprMutator::VisitExpr_;
 
   bool WrapPureCondition(const Op& op, const Expr& legalized) {
-    static const auto& purity_map = Op::GetAttrMap<Bool>("FPurity");
+    static const auto& purity_map = Op::GetAttrMap<bool>("FPurity");
 
     const CallNode* call = legalized.as<CallNode>();
 
@@ -120,10 +120,10 @@ class LegalizeMutator : public ExprMutator {
       return false;
     }
 
-    bool pure_original_op = purity_map.get(op, Bool(false))->value;
+    bool pure_original_op = purity_map.get(op, false);
     bool pure_legalized_op = [&]() -> bool {
       if (auto legalized_op = call->op.as<Op>()) {
-        return purity_map.get(legalized_op.value(), Bool(false))->value;
+        return purity_map.get(legalized_op.value(), false);
       } else if (auto func_sinfo = call->op->struct_info_.as<FuncStructInfoNode>()) {
         return func_sinfo->purity;
       } else {
@@ -237,7 +237,7 @@ class LegalizeMutator : public ExprMutator {
     Call visited_call = Downcast<Call>(this->VisitExprPostOrder_(call));
     static const auto& legalize_map = Op::GetAttrMap<FLegalize>("FLegalize");
     static const auto& call_packed_map = Op::GetAttrMap<FCallPacked>("FCallPacked");
-    static const auto& requires_arg_shapes_map = Op::GetAttrMap<Bool>("RequiresArgumentShapes");
+    static const auto& requires_arg_shapes_map = Op::GetAttrMap<bool>("RequiresArgumentShapes");
     static const Op& call_pure_packed_op = Op::Get("relax.call_pure_packed");
     static const Op& call_tir_op = Op::Get("relax.call_tir");
     static const Op& call_dps_packed_op = Op::Get("relax.call_dps_packed");
@@ -254,7 +254,7 @@ class LegalizeMutator : public ExprMutator {
     }
 
     bool shapes_are_known_if_required = [&]() -> bool {
-      bool requires_arg_shapes = requires_arg_shapes_map.get(op, Bool(true))->value;
+      bool requires_arg_shapes = requires_arg_shapes_map.get(op, true);
       if (!requires_arg_shapes) {
         // This operator does not require its arguments to have a
         // known shape/dtype.  For example, the "relax.tensor_ndim"
@@ -291,9 +291,9 @@ class LegalizeMutator : public ExprMutator {
 
       bool is_data_dependent_op = [&]() -> bool {
         if (Op::HasAttrMap("FDataDependent")) {
-          auto op_map = Op::GetAttrMap<Bool>("FDataDependent");
+          auto op_map = Op::GetAttrMap<bool>("FDataDependent");
           if (op_map.count(op)) {
-            return op_map[op]->value;
+            return op_map[op];
           }
         }
         return false;
@@ -416,7 +416,7 @@ Pass LegalizeOps(ffi::Optional<ffi::Map<ffi::String, ffi::Function>> cmap,
                  ffi::Optional<ffi::Array<ffi::String>> skip_ops, bool enable_warning) {
   auto pass_func = [=](IRModule mod, PassContext pc) {
     bool apply_legalize_ops =
-        pc->GetConfig<Bool>("relax.transform.apply_legalize_ops").value_or(Bool(true))->value;
+        pc->GetConfig<bool>("relax.transform.apply_legalize_ops").value_or(true);
     if (apply_legalize_ops) {
       mod = LegalizeMutator(mod, cmap, skip_ops, enable_warning).Transform();
     }

--- a/src/relax/transform/lift_transform_params.cc
+++ b/src/relax/transform/lift_transform_params.cc
@@ -43,7 +43,7 @@ namespace tvm {
 namespace relax {
 
 constexpr const char* kLiftTransformConsumeParams = "relax.lift_transform_params.consume_params";
-TVM_REGISTER_PASS_CONFIG_OPTION(kLiftTransformConsumeParams, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kLiftTransformConsumeParams, bool);
 
 namespace {
 struct BaseCollectInfo {
@@ -436,8 +436,8 @@ class LocalLiftableBindingCollector : public BaseLiftableBindingCollector {
   }
   void VisitExpr_(const FunctionNode* func) override {
     size_t num_runtime_params = func->params.size();
-    if (auto opt = func->attrs.GetAttr<Integer>(attr::kNumInput)) {
-      num_runtime_params = opt.value()->value;
+    if (auto opt = func->attrs.GetAttr<int64_t>(attr::kNumInput)) {
+      num_runtime_params = opt.value();
     }
 
     info_.num_runtime_params = num_runtime_params;
@@ -517,10 +517,10 @@ class ParamRemapper : private ExprFunctor<void(const Expr&, const Expr&)> {
       const ffi::Array<Function>& functions) {
     ParamRemapper mapper;
     if (functions.size()) {
-      auto num_inputs_0 = functions[0]->GetAttr<Integer>(attr::kNumInput).value()->value;
+      auto num_inputs_0 = functions[0]->GetAttr<int64_t>(attr::kNumInput).value();
       int num_params = static_cast<int>(functions[0]->params.size()) - num_inputs_0;
       for (int i = 0; i < static_cast<int>(functions.size()); i++) {
-        auto num_inputs_i = functions[i]->GetAttr<Integer>(attr::kNumInput).value()->value;
+        auto num_inputs_i = functions[i]->GetAttr<int64_t>(attr::kNumInput).value();
         TVM_FFI_ICHECK_EQ(num_params, static_cast<int>(functions[i]->params.size()) - num_inputs_i)
             << "The number of parameters should be the same for all target functions";
 
@@ -573,15 +573,15 @@ class GlobalLiftableBindingCollector : public BaseLiftableBindingCollector {
     GlobalLiftableBindingCollector collector(var_remap, tir_var_remap);
     TVM_FFI_ICHECK(functions.size());
     for (const auto& func : functions) {
-      int num_inputs = func->GetAttr<Integer>(attr::kNumInput).value()->value;
+      int num_inputs = func->GetAttr<int64_t>(attr::kNumInput).value();
       for (int i = num_inputs; i < static_cast<int>(func->params.size()); i++) {
         collector.liftable_vars_.insert(func->params[i]);
       }
       collector(func);
     }
-    ffi::Array<Var> params(functions[0]->params.begin() +
-                               functions[0]->GetAttr<Integer>(attr::kNumInput).value()->value,
-                           functions[0]->params.end());
+    ffi::Array<Var> params(
+        functions[0]->params.begin() + functions[0]->GetAttr<int64_t>(attr::kNumInput).value(),
+        functions[0]->params.end());
     // todo(@tvm-team): use c++20 designated initializers when windows CI supports it
     GlobalCollectInfo info = GlobalCollectInfo();
     info.orig_functions = functions;
@@ -691,9 +691,9 @@ class ConsumeBundledParams : public ExprMutator {
   }
 
   Expr VisitExpr_(const FunctionNode* func) final {
-    auto opt_num_input = func->GetAttr<Integer>(attr::kNumInput);
-    TVM_FFI_ICHECK(opt_num_input.defined());
-    auto num_input = opt_num_input.value()->value;
+    auto opt_num_input = func->GetAttr<int64_t>(attr::kNumInput);
+    TVM_FFI_ICHECK(opt_num_input.has_value());
+    auto num_input = opt_num_input.value();
     TVM_FFI_ICHECK_EQ(func->params.size(), num_input + 1);
     params_ = func->params.back();
     TVM_FFI_ICHECK(params_->struct_info_.as<TupleStructInfoNode>());
@@ -706,7 +706,7 @@ class ConsumeBundledParams : public ExprMutator {
 };
 
 std::vector<std::pair<GlobalVar, Function>> GetTargetFunctions(
-    const IRModule& mod, const ffi::Variant<Bool, ffi::Array<ffi::String>>& shared_transform) {
+    const IRModule& mod, const ffi::Variant<bool, ffi::Array<ffi::String>>& shared_transform) {
   std::vector<std::pair<GlobalVar, Function>> target_functions;
   if (shared_transform.as<ffi::Array<ffi::String>>().value_or(ffi::Array<ffi::String>{}).size()) {
     auto names = shared_transform.as<ffi::Array<ffi::String>>().value();
@@ -728,7 +728,7 @@ std::vector<std::pair<GlobalVar, Function>> GetTargetFunctions(
                            << "only functions in the list must be relax functions.  "
                            << "However, the function " << name << " is of type "
                            << base_func.value()->GetTypeKey();
-      TVM_FFI_ICHECK(func.value()->GetAttr<Integer>(attr::kNumInput))
+      TVM_FFI_ICHECK(func.value()->GetAttr<int64_t>(attr::kNumInput))
           << "When LiftTransformParams is called with a list of function names, "
           << "all functions in the list must have the kNumInput ('" << attr::kNumInput
           << "') attribute.  "
@@ -741,7 +741,7 @@ std::vector<std::pair<GlobalVar, Function>> GetTargetFunctions(
     // are not already the result of `LiftTransformParams`.
     for (const auto& [gvar, func] : mod->functions) {
       if (func->IsInstance<FunctionNode>()) {
-        auto opt_num_input = func->GetAttr<Integer>(attr::kNumInput);
+        auto opt_num_input = func->GetAttr<int64_t>(attr::kNumInput);
         if (opt_num_input && !ends_with(gvar->name_hint, "transform_params")) {
           target_functions.emplace_back(gvar, Downcast<Function>(func));
         }
@@ -759,16 +759,16 @@ std::vector<std::pair<GlobalVar, Function>> GetTargetFunctions(
 
 namespace transform {
 
-Pass PartitionTransformParams(ffi::Variant<Bool, ffi::Array<ffi::String>> shared_transform) {
+Pass PartitionTransformParams(ffi::Variant<bool, ffi::Array<ffi::String>> shared_transform) {
   auto pass_func = [=](IRModule mod, PassContext pc) {
     std::optional<GlobalCollectInfo> global_collect_info;
 
-    TVM_FFI_ICHECK((shared_transform.as<Bool>() || shared_transform.as<ffi::Array<ffi::String>>()))
+    TVM_FFI_ICHECK((shared_transform.as<bool>() || shared_transform.as<ffi::Array<ffi::String>>()))
         << "shared_transform should be a boolean or an array of function names";
 
     auto target_functions = GetTargetFunctions(mod, shared_transform);
 
-    if (shared_transform.as<Bool>().value_or(Bool(true))) {
+    if (shared_transform.as<bool>().value_or(true)) {
       std::vector<Function> functions;
       for (const auto& [_, func] : target_functions) {
         functions.push_back(func);
@@ -825,7 +825,7 @@ Pass PartitionTransformParams(ffi::Variant<Bool, ffi::Array<ffi::String>> shared
   return tvm::transform::CreateModulePass(pass_func, 1, "PartitionTransformParams", {});
 }
 
-Pass LiftTransformParams(ffi::Variant<Bool, ffi::Array<ffi::String>> shared_transform) {
+Pass LiftTransformParams(ffi::Variant<bool, ffi::Array<ffi::String>> shared_transform) {
   // A post-proc utility as as the third step in LiftTransformParams
   //
   // 1. PartitionTransformParams: Partition each function into a
@@ -845,7 +845,7 @@ Pass LiftTransformParams(ffi::Variant<Bool, ffi::Array<ffi::String>> shared_tran
         std::string func_name = gvar->name_hint;
         if (ends_with(func_name, "transform_params")) {
           func = WithAttr(func, tvm::attr::kGlobalSymbol, gvar->name_hint);
-          if (pc->GetConfig<Bool>(kLiftTransformConsumeParams).value_or(Bool(false))) {
+          if (pc->GetConfig<bool>(kLiftTransformConsumeParams).value_or(false)) {
             func = Downcast<Function>(ConsumeBundledParams()(func));
           }
           to_add[gvar] = func;

--- a/src/relax/transform/meta_schedule.cc
+++ b/src/relax/transform/meta_schedule.cc
@@ -37,8 +37,8 @@ namespace transform {
 
 class MetaScheduleTuner {
  public:
-  explicit MetaScheduleTuner(Target target, ffi::String work_dir, Integer max_trials_global,
-                             Integer max_trials_per_task,
+  explicit MetaScheduleTuner(Target target, ffi::String work_dir, int64_t max_trials_global,
+                             int64_t max_trials_per_task,
                              ffi::Optional<ffi::Array<ffi::String>> op_names,
                              ffi::Map<ffi::String, runtime::Tensor> params = {})
       : target_(target),
@@ -69,8 +69,8 @@ class MetaScheduleTuner {
  private:
   Target target_;
   ffi::String work_dir_;
-  Integer max_trials_global_;
-  Integer max_trials_per_task_;
+  int64_t max_trials_global_;
+  int64_t max_trials_per_task_;
   ffi::Optional<ffi::Array<ffi::String>> op_names_;
   ffi::Map<ffi::String, runtime::Tensor> params_;
   tvm::ffi::Function normalize_mod_func_;
@@ -153,8 +153,8 @@ Pass MetaScheduleApplyDatabase(ffi::Optional<ffi::String> work_dir, bool enable_
 }
 
 Pass MetaScheduleTuneIRMod(ffi::Map<ffi::String, runtime::Tensor> params, ffi::String work_dir,
-                           Integer max_trials_global,
-                           ffi::Optional<Integer> max_trials_per_task = std::nullopt,
+                           int64_t max_trials_global,
+                           ffi::Optional<int64_t> max_trials_per_task = std::nullopt,
                            ffi::Optional<ffi::Array<ffi::String>> op_names = std::nullopt) {
   Target target = Target::Current(false);
   auto pass_func = [=](IRModule m, PassContext ctx) {
@@ -168,7 +168,7 @@ Pass MetaScheduleTuneIRMod(ffi::Map<ffi::String, runtime::Tensor> params, ffi::S
                           /*traceable*/ true);
 }
 
-Pass MetaScheduleTuneTIR(ffi::String work_dir, Integer max_trials_global) {
+Pass MetaScheduleTuneTIR(ffi::String work_dir, int64_t max_trials_global) {
   Target target = Target::Current(false);
   ffi::TypedFunction<tirx::PrimFunc(tirx::PrimFunc, IRModule, PassContext)> pass_func =
       [=](tirx::PrimFunc f, IRModule mod, PassContext ctx) {

--- a/src/relax/transform/reorder_permute_dims_after_concat.cc
+++ b/src/relax/transform/reorder_permute_dims_after_concat.cc
@@ -82,7 +82,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
     pat_concat = pat_concat | make_pattern_with_num_concat(i);
   }
 
-  auto get_permute_dims_optional_axes = [](const Expr& expr) -> ffi::Optional<ffi::Array<Integer>> {
+  auto get_permute_dims_optional_axes = [](const Expr& expr) -> ffi::Optional<ffi::Array<int64_t>> {
     auto call = expr.as<CallNode>();
     TVM_FFI_ICHECK(call);
     auto attrs = call->attrs.as<PermuteDimsAttrs>();
@@ -92,12 +92,12 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
   };
 
   auto get_permute_dims_axes =
-      [get_permute_dims_optional_axes](const Expr& expr) -> ffi::Array<Integer> {
+      [get_permute_dims_optional_axes](const Expr& expr) -> ffi::Array<int64_t> {
     if (auto opt_axes = get_permute_dims_optional_axes(expr)) {
       return opt_axes.value();
     } else {
       auto call = Downcast<Call>(expr);
-      ffi::Array<Integer> permutation;
+      ffi::Array<int64_t> permutation;
       auto arg_sinfo = call->args[0]->struct_info_.as<TensorStructInfoNode>();
       TVM_FFI_ICHECK(arg_sinfo) << "Expected permute_dims to have a single tensor argument, "
                                 << "but argument " << call->args[0] << " has struct info "
@@ -105,7 +105,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
       TVM_FFI_ICHECK_GE(arg_sinfo->ndim, 0);
       size_t ndim = arg_sinfo->ndim;
       for (size_t i = 0; i < ndim; i++) {
-        permutation.push_back(Integer(ndim - i - 1));
+        permutation.push_back(static_cast<int64_t>(ndim - i - 1));
       }
       return permutation;
     }
@@ -119,7 +119,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
         return false;
       }
       for (size_t i_axis = 0; i_axis < first_axes.size(); i_axis++) {
-        if (i_axes[i_axis]->value != first_axes[i_axis]->value) {
+        if (i_axes[i_axis] != first_axes[i_axis]) {
           return false;
         }
       }
@@ -144,7 +144,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
     if (!permute_dims_axes_are_compatible(all_permute_dims)) {
       return expr;
     }
-    ffi::Optional<ffi::Array<Integer>> permute_axes =
+    ffi::Optional<ffi::Array<int64_t>> permute_axes =
         get_permute_dims_optional_axes(all_permute_dims[0]);
 
     Call concat_call = Downcast<Call>(matches[pat_concat]);

--- a/src/relax/transform/reorder_take_after_matmul.cc
+++ b/src/relax/transform/reorder_take_after_matmul.cc
@@ -112,7 +112,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
       // indices.shape = [batch1]
 
       // reordered_weight.shape = [infeatures, table_size, outfeatures]
-      auto reordered_weight = permute_dims(weights, ffi::Array{Integer(1), Integer(0), Integer(2)});
+      auto reordered_weight = permute_dims(weights, ffi::Array<int64_t>{1, 0, 2});
       // fused_weight.shape = [infeatures, table_size * outfeatures]
       auto fused_weight = reshape(reordered_weight,
                                   ShapeExpr({weight_shape[1], weight_shape[0] * weight_shape[2]}));

--- a/src/relax/transform/rewrite_cuda_graph.cc
+++ b/src/relax/transform/rewrite_cuda_graph.cc
@@ -67,7 +67,7 @@
 namespace tvm {
 namespace relax {
 
-TVM_REGISTER_PASS_CONFIG_OPTION("relax.backend.use_cuda_graph", Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("relax.backend.use_cuda_graph", bool);
 
 /*! \brief The rewriting plan of lifting a region for either allocation or capturing for cuda graph
  * execution
@@ -247,13 +247,13 @@ class CUDAGraphRewritePlanner : public ExprVisitor {
         // 'relax.rewrite_cuda_graph.capture_symbolic_vars' annotation, the actual variables with
         // these names are extracted from the struct info for the capturing.
         const auto& func = Downcast<Function>(pair.second);
-        auto num_inputs =
-            func->attrs.GetAttr<Integer>(attr::kNumInput).value_or(Integer(func->params.size()));
+        int64_t num_inputs =
+            func->attrs.GetAttr<int64_t>(attr::kNumInput).value_or(func->params.size());
         auto capture_symbolic_var_name_hints = ExtractSymbolicVarHints(func);
         for (int i = 0; i < static_cast<int>(func->params.size()); ++i) {
           ffi::Array<tirx::Var> symbolic_vars = DefinableTIRVarsInStructInfo(
               Downcast<StructInfo>(func->params[i]->struct_info_.value()));
-          if (i < num_inputs.IntValue()) {
+          if (i < num_inputs) {
             for (const auto& symbolic_var : symbolic_vars) {
               if (capture_symbolic_var_name_hints.count(symbolic_var->name_hint)) {
                 capture_symbolic_vars_.insert(symbolic_var.get());
@@ -891,8 +891,7 @@ namespace transform {
 Pass RewriteCUDAGraph() {
   auto pass_func =  //
       [=](IRModule mod, PassContext pc) {
-        bool use_cuda_graph =
-            pc->GetConfig<Bool>("relax.backend.use_cuda_graph").value_or(Bool(false))->value;
+        bool use_cuda_graph = pc->GetConfig<bool>("relax.backend.use_cuda_graph").value_or(false);
         if (use_cuda_graph) {
           mod = ::tvm::relax::RewriteCUDAGraph(std::move(mod));
         }

--- a/src/relax/transform/specialize_primfunc_based_on_callsite.cc
+++ b/src/relax/transform/specialize_primfunc_based_on_callsite.cc
@@ -144,7 +144,7 @@ class SpecializeTIRCallArgs : ExprMutator {
       auto* ptr = buffer->data->type_annotation.as<PointerTypeNode>();
       TVM_FFI_ICHECK(ptr) << "Buffer Var's type annotation must be of PointerType";
     }
-    auto new_prim_func = WithAttr(new_pfunc, "scoped", Integer(1));
+    auto new_prim_func = WithAttr(new_pfunc, "scoped", static_cast<int64_t>(1));
     updates_->Add(gv, new_prim_func);
     return call;
   }

--- a/src/relax/transform/split_call_tir_by_pattern.cc
+++ b/src/relax/transform/split_call_tir_by_pattern.cc
@@ -452,7 +452,7 @@ class FunctionPartitioner : public StmtExprVisitor {
   /*! \brief alloc_buffers for the second function */
   std::unordered_set<Buffer, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> allocs2;
   /*! \brief whether the current block is in the first function */
-  ffi::Map<SBlock, Bool> block_partition;
+  ffi::Map<SBlock, bool> block_partition;
   /*! \brief input buffers for the first function */
   std::unordered_set<Buffer, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> input1;
   /*! \brief input buffers for the second function */
@@ -493,7 +493,7 @@ class FunctionPartitioner : public StmtExprVisitor {
         input2.insert(write->buffer);
       }
     }
-    block_partition.Set(ffi::GetRef<SBlock>(op), Bool(is_matching_));
+    block_partition.Set(ffi::GetRef<SBlock>(op), is_matching_);
   }
   // The number of matched ops in the function
   size_t num_matched_ops_;
@@ -504,7 +504,7 @@ class FunctionPartitioner : public StmtExprVisitor {
 class BlockRemover : public StmtExprMutator {
  public:
   static Stmt RemoveBlockByPartition(
-      Stmt stmt, const ffi::Map<SBlock, Bool>& block_partition,
+      Stmt stmt, const ffi::Map<SBlock, bool>& block_partition,
       const std::unordered_set<Buffer, ffi::ObjectPtrHash, ffi::ObjectPtrEqual>& allocs,
       bool is_library_part) {
     BlockRemover remover(block_partition, allocs, is_library_part);
@@ -512,7 +512,7 @@ class BlockRemover : public StmtExprMutator {
   }
 
  private:
-  BlockRemover(const ffi::Map<SBlock, Bool>& block_partition,
+  BlockRemover(const ffi::Map<SBlock, bool>& block_partition,
                const std::unordered_set<Buffer, ffi::ObjectPtrHash, ffi::ObjectPtrEqual>& allocs,
                bool is_library_part)
       : block_partition(block_partition), allocs_(allocs), is_library_part_(is_library_part) {}
@@ -522,7 +522,7 @@ class BlockRemover : public StmtExprMutator {
     ffi::ObjectPtr<SBlockNode> n = ffi::make_object<SBlockNode>(*block.operator->());
     if (op->name_hint != "root") {
       TVM_FFI_ICHECK(block_partition.count(ffi::GetRef<SBlock>(op)));
-      bool block_is_library = block_partition[ffi::GetRef<SBlock>(op)]->value;
+      bool block_is_library = block_partition[ffi::GetRef<SBlock>(op)];
       if (!(is_library_part_ ^ block_is_library)) {
         n->body = block->body;
       } else {
@@ -553,7 +553,7 @@ class BlockRemover : public StmtExprMutator {
   }
 
   bool erased_ = false;
-  ffi::Map<SBlock, Bool> block_partition;
+  ffi::Map<SBlock, bool> block_partition;
   std::unordered_set<Buffer, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> allocs_;
   bool is_library_part_ = false;
 };
@@ -593,7 +593,7 @@ std::pair<PrimFunc, ffi::Optional<PrimFunc>> SplitFunctions(
   }
   bool has_second_func = false;
   for (const auto& pr : partitioner.block_partition) {
-    if (!pr.second->value) {
+    if (!pr.second) {
       has_second_func = true;
       break;
     }

--- a/src/relax/transform/static_plan_block_memory.cc
+++ b/src/relax/transform/static_plan_block_memory.cc
@@ -1041,9 +1041,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
 PrimExpr GetTextureMemorySizeFromVDevice(ffi::Array<PrimExpr> pshape, DataType dtype,
                                          VDevice vdevice) {
-  int image_row_align = vdevice->target->GetAttr<Integer>("image_base_address_alignment")
-                            .value_or(Integer(64))
-                            ->value;
+  int image_row_align = static_cast<int>(
+      vdevice->target->GetAttr<int64_t>("image_base_address_alignment").value_or(64));
 
   struct Shape {
     const ffi::Array<PrimExpr>& shape;

--- a/src/relax/transform/utils.h
+++ b/src/relax/transform/utils.h
@@ -361,23 +361,22 @@ inline Constant MakeConstantScalar(T value, DataType dtype) {
   return Constant(arr);
 }
 
-inline ffi::Array<Integer> GetOrderedPositiveAxes(const ffi::Array<Integer>& axes, int ndim) {
+inline ffi::Array<int64_t> GetOrderedPositiveAxes(const ffi::Array<int64_t>& axes, int ndim) {
   std::vector<int64_t> ret;
   ret.reserve(axes.size());
-  for (const auto& axis : axes) {
-    int64_t axis_val = axis->value;
+  for (int64_t axis_val : axes) {
     if (axis_val < 0) {
       axis_val += ndim;
     }
     TVM_FFI_ICHECK(axis_val >= 0 && axis_val < ndim)
-        << "axis " << axis << " is out of bounds for array of "
+        << "axis " << axis_val << " is out of bounds for array of "
         << "dimension " << ndim;
     ret.push_back(axis_val);
   }
   std::sort(ret.begin(), ret.end());
-  ffi::Array<Integer> result;
+  ffi::Array<int64_t> result;
   result.reserve(ret.size());
-  for (int64_t x : ret) result.push_back(Integer(x));
+  for (int64_t x : ret) result.push_back(x);
   return result;
 }
 

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -221,10 +221,10 @@ bool IsLeafOrTuple(const Expr& expr) {
 bool IsImpureCall(const Call& call) {
   if (auto op_ptr = call->op.as<OpNode>()) {
     auto op = ffi::GetRef<Op>(op_ptr);
-    static auto purity_map = Op::GetAttrMap<Bool>("FPurity");
+    static auto purity_map = Op::GetAttrMap<bool>("FPurity");
     TVM_FFI_ICHECK(purity_map.count(op))
         << "Cannot find the registered purity of this op: " << op->name;
-    return !(purity_map[op]->value);
+    return !(purity_map[op]);
   }
   // the StructInfo must be FuncStructInfo
   auto func_struct_info = GetStructInfoAs<FuncStructInfoNode>(call->op);

--- a/src/s_tir/analysis/calculate_allocated_memory.cc
+++ b/src/s_tir/analysis/calculate_allocated_memory.cc
@@ -50,11 +50,11 @@ std::string GetStorageScope(const Var& var) {
  */
 class AllocBufferCalculator : public StmtExprVisitor {
  public:
-  tvm::ffi::Map<ffi::String, Integer> operator()(const PrimFunc& func) {
+  tvm::ffi::Map<ffi::String, int64_t> operator()(const PrimFunc& func) {
     this->VisitStmt(func->body);
-    tvm::ffi::Map<ffi::String, Integer> res;
+    tvm::ffi::Map<ffi::String, int64_t> res;
     for (auto [k, v] : _max_size) {
-      res.Set(ffi::String(k), Integer(v));
+      res.Set(ffi::String(k), v);
     }
     return res;
   }
@@ -100,17 +100,17 @@ class AllocBufferCalculator : public StmtExprVisitor {
   std::unordered_map<std::string, int64_t> _current_size;
 };
 
-tvm::ffi::Map<ffi::String, tvm::ffi::Map<ffi::String, Integer> > CalculateAllocatedBytes(
+tvm::ffi::Map<ffi::String, tvm::ffi::Map<ffi::String, int64_t> > CalculateAllocatedBytes(
     const PrimFunc& func) {
-  tvm::ffi::Map<ffi::String, tvm::ffi::Map<ffi::String, Integer> > results;
+  tvm::ffi::Map<ffi::String, tvm::ffi::Map<ffi::String, int64_t> > results;
   auto alloc_buffer_result = AllocBufferCalculator()(func);
   results.Set("main", alloc_buffer_result);
   return results;
 }
 
-tvm::ffi::Map<ffi::String, tvm::ffi::Map<ffi::String, Integer> > CalculateAllocatedBytes(
+tvm::ffi::Map<ffi::String, tvm::ffi::Map<ffi::String, int64_t> > CalculateAllocatedBytes(
     const IRModule& mod) {
-  tvm::ffi::Map<ffi::String, tvm::ffi::Map<ffi::String, Integer> > results;
+  tvm::ffi::Map<ffi::String, tvm::ffi::Map<ffi::String, int64_t> > results;
   for (const auto& kv : mod->functions) {
     if (auto prim_func = kv.second.as<tirx::PrimFunc>()) {
       ffi::String func_name = kv.first->name_hint;
@@ -125,7 +125,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def(
       "s_tir.analysis.calculate_allocated_bytes",
-      [](ffi::ObjectRef obj) -> tvm::ffi::Map<ffi::String, tvm::ffi::Map<ffi::String, Integer> > {
+      [](ffi::ObjectRef obj) -> tvm::ffi::Map<ffi::String, tvm::ffi::Map<ffi::String, int64_t> > {
         if (auto func = obj.as<PrimFunc>()) {
           return CalculateAllocatedBytes(func.value());
         } else if (auto mod = obj.as<IRModule>()) {
@@ -139,22 +139,22 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       });
 }
 
-bool VerifyVTCMLimit(const IRModule& mod, Integer limit) {
+bool VerifyVTCMLimit(const IRModule& mod, int64_t limit) {
   auto all_sizes = CalculateAllocatedBytes(mod);
   for (const auto& kv : all_sizes) {
     auto sizes = kv.second;
     const auto vtcm_allocated = sizes.Get("global.vtcm").value_or(0);
-    if (limit.IntValue() > 0 && vtcm_allocated.IntValue() > limit.IntValue()) {
+    if (limit > 0 && vtcm_allocated > limit) {
       return false;
     }
   }
   return true;
 }
 
-bool VerifyVTCMLimit(const PrimFunc& func, Integer limit) {
+bool VerifyVTCMLimit(const PrimFunc& func, int64_t limit) {
   auto sizes = CalculateAllocatedBytes(func)["main"];
   const auto vtcm_allocated = sizes.Get("global.vtcm").value_or(0);
-  if (limit.IntValue() > 0 && vtcm_allocated.IntValue() > limit.IntValue()) {
+  if (limit > 0 && vtcm_allocated > limit) {
     return false;
   }
   return true;
@@ -163,10 +163,10 @@ bool VerifyVTCMLimit(const PrimFunc& func, Integer limit) {
 int64_t GetVTCMCapacity(Target target, const tvm::transform::PassContext& pass_ctx) {
   if (!target.defined()) target = Target::Current(/*allow_not_defined=*/true);
   if (target.defined() && target->kind->name == "hexagon") {
-    auto value = target->GetAttr<Integer>("vtcm-capacity").value()->value;
+    auto value = target->GetAttr<int64_t>("vtcm-capacity").value();
     if (value > 0) return value;
   }
-  return pass_ctx->GetConfig<Integer>("tirx.vtcm_capacity", Integer(0)).value()->value;
+  return pass_ctx->GetConfig<int64_t>("tirx.vtcm_capacity", 0).value();
 }
 
 ffi::Array<tvm::transform::Pass> GetVTCMCompactionPasses() {
@@ -209,7 +209,7 @@ Pass VerifyVTCMLimit(ffi::Optional<Target> default_target) {
         if (limit.has_value() && limit.value() > 0) {
           auto sizes = CalculateAllocatedBytes(func)["main"];
           const auto vtcm_allocated = sizes.Get("global.vtcm").value_or(0);
-          if (vtcm_allocated.IntValue() > limit.value()) {
+          if (vtcm_allocated > limit.value()) {
             TVM_FFI_THROW(RuntimeError)
                 << "The global.vtcm memory allocation limit has been exceeded "
                 << "(allocated: " << vtcm_allocated << ", limit: " << limit.value() << ").\n"

--- a/src/s_tir/analysis/estimate_flops.cc
+++ b/src/s_tir/analysis/estimate_flops.cc
@@ -243,8 +243,8 @@ double EstimateTIRFlops(const IRModule& mod) {
   TResult result;
   double cached_result = 0;
   VisitPrimFuncs(mod, [&result, &counter, &cached_result](const PrimFuncNode* f) {
-    if (auto cached = f->attrs.GetAttr<Integer>("estimated_flops")) {
-      cached_result += cached.value()->value;
+    if (auto cached = f->attrs.GetAttr<int64_t>("estimated_flops")) {
+      cached_result += cached.value();
     } else {
       result += counter.VisitStmt(f->body);  //
     }

--- a/src/s_tir/analysis/is_pure_function.cc
+++ b/src/s_tir/analysis/is_pure_function.cc
@@ -69,7 +69,7 @@ class PurityChecker : TIRVisitorWithPath {
     static auto op_call_effect = Op::GetAttrMap<TCallEffectKind>("TCallEffectKind");
     CallEffectKind effect = [&]() {
       if (auto opt = call->op.as<Op>()) {
-        return static_cast<CallEffectKind>(op_call_effect[opt.value()]->value);
+        return static_cast<CallEffectKind>(op_call_effect[opt.value()]);
       } else {
         return CallEffectKind::kOpaque;
       }

--- a/src/s_tir/meta_schedule/arg_info.cc
+++ b/src/s_tir/meta_schedule/arg_info.cc
@@ -127,13 +127,13 @@ TensorInfo::TensorInfo(runtime::DataType dtype, ffi::Shape shape) {
 ffi::ObjectRef TensorInfoNode::AsJSON() const {
   static ffi::String tag = "TENSOR";
   ffi::String dtype = ffi::DLDataTypeToString(this->dtype);
-  ffi::Array<Integer> shape = support::AsArray(this->shape);
+  ffi::Array<int64_t> shape = support::AsArray(this->shape);
   return ffi::Array<ffi::Any>{tag, dtype, shape};
 }
 
 TensorInfo TensorInfo::FromJSON(const ffi::ObjectRef& json_obj) {
   DLDataType dtype;
-  ffi::Array<Integer> shape;
+  ffi::Array<int64_t> shape;
   try {
     const ffi::ArrayObj* json_array = json_obj.as<ffi::ArrayObj>();
     TVM_FFI_ICHECK(json_array && json_array->size() == 3);

--- a/src/s_tir/meta_schedule/feature_extractor/per_store_feature.cc
+++ b/src/s_tir/meta_schedule/feature_extractor/per_store_feature.cc
@@ -584,7 +584,8 @@ Feature::ArithOps::ArithOps(const BufferStoreNode* store, int64_t prod_loop_exte
 
     void VisitExpr_(const CallNode* op) final {
       static auto op_call_effect_ = Op::GetAttrMap<TCallEffectKind>("TCallEffectKind");
-      TCallEffectKind effect_kind = op_call_effect_[Downcast<Op>(op->op)];
+      CallEffectKind effect_kind =
+          static_cast<CallEffectKind>(op_call_effect_[Downcast<Op>(op->op)]);
       bool is_pure =
           effect_kind == CallEffectKind::kPure || effect_kind == CallEffectKind::kExprAnnotation;
       if (is_pure) {

--- a/src/s_tir/meta_schedule/mutator/mutate_compute_location.cc
+++ b/src/s_tir/meta_schedule/mutator/mutate_compute_location.cc
@@ -97,7 +97,9 @@ std::vector<MutateComputeLocationNode::Candidate> MutateComputeLocationNode::Fin
       // Step 1. Extract the instruction input and the old decision.
       TVM_FFI_ICHECK_EQ(inputs.size(), 1);
       tirx::StmtSRef block_sref = sch->GetSRef(Downcast<s_tir::SBlockRV>(inputs[0]));
-      int old_decision = Downcast<Integer>(decision)->value;
+      // SampleComputeLocation decision is Optional<int64_t> after the
+      // Integer phase-out.
+      int old_decision = decision.cast<int64_t>();
 
       // Step 2. Collect all the compute_at locations.
       auto [location_srefs, location_indices] = CollectComputeLocation(sch->state(), block_sref);
@@ -128,7 +130,7 @@ ffi::Optional<Trace> MutateComputeLocationNode::Apply(const Trace& trace, TRandS
   }
   const Candidate& candidate = candidates[s_tir::SampleInt(rand_state, 0, candidates.size())];
   int loc = candidate.locs[s_tir::SampleInt(rand_state, 0, candidate.locs.size())];
-  return trace->WithDecision(candidate.inst, Integer(loc), /*remove_postproc=*/true);
+  return trace->WithDecision(candidate.inst, static_cast<int64_t>(loc), /*remove_postproc=*/true);
 }
 
 Mutator Mutator::MutateComputeLocation() {

--- a/src/s_tir/meta_schedule/mutator/mutate_thread_binding.cc
+++ b/src/s_tir/meta_schedule/mutator/mutate_thread_binding.cc
@@ -146,7 +146,8 @@ std::vector<MutateThreadBindingNode::Candidate> MutateThreadBindingNode::FindCan
     TVM_FFI_ICHECK(sample_it != sample_insts.end());
     const InstructionNode* sample_inst = sample_it->second;
 
-    int decision = Downcast<IntImm>(trace->decisions[ffi::GetRef<Instruction>(sample_inst)])->value;
+    // SampleCategorical decision is Optional<int64_t> after the Integer phase-out.
+    int decision = trace->decisions[ffi::GetRef<Instruction>(sample_inst)].cast<int64_t>();
 
     std::vector<double> probs =
         support::AsVector<FloatImm, double>(Downcast<ffi::Array<FloatImm>>(sample_inst->attrs[1]));
@@ -168,7 +169,8 @@ ffi::Optional<Trace> MutateThreadBindingNode::Apply(const Trace& trace, TRandSta
   if (result >= candidate.decision) {
     result += 1;
   }
-  return trace->WithDecision(candidate.inst, Integer(result), /*remove_postproc=*/true);
+  return trace->WithDecision(candidate.inst, static_cast<int64_t>(result),
+                             /*remove_postproc=*/true);
 }
 
 Mutator Mutator::MutateThreadBinding() {

--- a/src/s_tir/meta_schedule/mutator/mutate_tile_size.cc
+++ b/src/s_tir/meta_schedule/mutator/mutate_tile_size.cc
@@ -141,10 +141,10 @@ void FindSampleVectorize(const Trace& trace, std::vector<Instruction>* inst,
           // Skip mutating the sampling instructions who have only single candidate.
           continue;
         }
-        const ffi::ObjectRef& decision = kv.second.cast<ffi::ObjectRef>();
-        const auto* d = TVM_TYPE_AS(decision, IntImmNode);
+        // SampleCategorical decision is Optional<int64_t> after the
+        // Integer phase-out, so the Any holds a bare POD int.
         instructions.push_back(inst);
-        decisions.push_back(d->value);
+        decisions.push_back(kv.second.cast<int64_t>());
       }
     }
   }
@@ -232,7 +232,7 @@ ffi::Optional<Trace> MutateSampleTileSize(const Trace& trace, Instruction inst,
     }
     tiles[x] /= divide_factor;
     tiles[y] *= divide_factor;
-    return trace->WithDecision(inst, support::AsArray<int64_t, IntImm>(tiles),
+    return trace->WithDecision(inst, ffi::Array<int64_t>(tiles.begin(), tiles.end()),
                                /*remove_postproc=*/true);
   }
 }
@@ -247,7 +247,7 @@ ffi::Optional<Trace> MutateSampleVectorize(const Trace& trace, Instruction inst,
   if (result >= original_decision) {
     result += 1;
   }
-  return trace->WithDecision(inst, Integer(result), /*remove_postproc=*/true);
+  return trace->WithDecision(inst, static_cast<int64_t>(result), /*remove_postproc=*/true);
 }
 
 ffi::Optional<Trace> MutateTileSizeNode::Apply(const Trace& trace, TRandState* rand_state) {

--- a/src/s_tir/meta_schedule/mutator/mutate_unroll.cc
+++ b/src/s_tir/meta_schedule/mutator/mutate_unroll.cc
@@ -122,8 +122,8 @@ bool FindUnrollDecision(const Trace& trace, TRandState* rand_state,
   const InstructionNode* sample_inst = sample_insts.at(var_rv);
   TVM_FFI_ICHECK_EQ(sample_inst->attrs.size(), 2);
   candidate->inst = ffi::GetRef<Instruction>(sample_inst);
-  candidate->decision =
-      Downcast<IntImm>(trace->decisions[ffi::GetRef<Instruction>(sample_inst)])->value;
+  // SampleCategorical decision is Optional<int64_t> after the Integer phase-out.
+  candidate->decision = trace->decisions[ffi::GetRef<Instruction>(sample_inst)].cast<int64_t>();
   candidate->probs =
       support::AsVector<FloatImm, double>(Downcast<ffi::Array<FloatImm>>(sample_inst->attrs[1]));
   return true;
@@ -142,7 +142,8 @@ ffi::Optional<Trace> MutateUnrollNode::Apply(const Trace& trace, TRandState* ran
   if (result >= candidate.decision) {
     result += 1;
   }
-  return trace->WithDecision(candidate.inst, Integer(result), /*remove_postproc=*/true);
+  return trace->WithDecision(candidate.inst, static_cast<int64_t>(result),
+                             /*remove_postproc=*/true);
 }
 
 Mutator Mutator::MutateUnroll() { return Mutator(ffi::make_object<MutateUnrollNode>()); }

--- a/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
@@ -32,7 +32,7 @@ using namespace tvm::tirx;
  * \param axis The axis name expected
  * \return std::nullopt if parsing fails; Otherwise, the extent of thread axis
  */
-ffi::Optional<Integer> ParseThreadBinding(const Schedule& sch, const Instruction& inst,
+ffi::Optional<int64_t> ParseThreadBinding(const Schedule& sch, const Instruction& inst,
                                           ffi::String axis) {
   static InstructionKind inst_kind_bind = InstructionKind::Get("Bind");
   if (!inst->kind.same_as(inst_kind_bind)) {
@@ -44,7 +44,7 @@ ffi::Optional<Integer> ParseThreadBinding(const Schedule& sch, const Instruction
   if (thread_axis != axis) {
     return std::nullopt;
   }
-  return Downcast<Integer>(sch->Get(Downcast<LoopRV>(inst->inputs[0]))->extent);
+  return Downcast<IntImm>(sch->Get(Downcast<LoopRV>(inst->inputs[0]))->extent)->value;
 }
 
 /*!
@@ -128,8 +128,8 @@ class RewriteCooperativeFetchNode : public PostprocNode {
 
   // Inherited from PostprocNode
   void InitializeWithTuneContext(const TuneContext& context) final {
-    if (ffi::Optional<Integer> v = context->target.value()->GetAttr<Integer>("thread_warp_size")) {
-      this->thread_warp_size_ = v.value()->value;
+    if (ffi::Optional<int64_t> v = context->target.value()->GetAttr<int64_t>("thread_warp_size")) {
+      this->thread_warp_size_ = v.value();
     } else {
       TVM_PY_LOG(INFO, context->logger) << "'thread_warp_size' is not defined in the target";
     }
@@ -158,14 +158,14 @@ bool RewriteCooperativeFetchNode::Apply(const s_tir::Schedule& sch) {
   int64_t vector_lane = 1;
   std::vector<std::function<void()>> tasks;
   for (const s_tir::Instruction& inst : trace->insts) {
-    if (ffi::Optional<Integer> new_thread_extent =
+    if (ffi::Optional<int64_t> new_thread_extent =
             s_tir::ParseThreadBinding(sch, inst, "threadIdx.x")) {
-      thread_extent_x = new_thread_extent.value()->value;
+      thread_extent_x = new_thread_extent.value();
       continue;
     }
-    if (ffi::Optional<Integer> new_thread_extent =
+    if (ffi::Optional<int64_t> new_thread_extent =
             s_tir::ParseThreadBinding(sch, inst, "threadIdx.y")) {
-      thread_extent_y = new_thread_extent.value()->value;
+      thread_extent_y = new_thread_extent.value();
       continue;
     }
     if (s_tir::ParseWarpExecutionAnn(sch, inst)) {

--- a/src/s_tir/meta_schedule/postproc/rewrite_layout.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_layout.cc
@@ -122,8 +122,8 @@ class LayoutFreeBufferCollector : public StmtVisitor {
 
 ffi::Array<Buffer> CollectLayoutFreeBuffers(const PrimFuncNode* func) {
   // Only rewrite PrimFuncs with attr "layout_free_buffers"
-  ffi::Array<Integer> layout_free_buffer_index =
-      func->GetAttr(s_tir::attr::layout_free_buffers, ffi::Array<Integer>()).value();
+  ffi::Array<int64_t> layout_free_buffer_index =
+      func->GetAttr(s_tir::attr::layout_free_buffers, ffi::Array<int64_t>()).value();
 
   ffi::Array<Buffer> layout_free_buffers;
   for (const Integer& index : layout_free_buffer_index) {

--- a/src/s_tir/meta_schedule/postproc/rewrite_unbound_block.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_unbound_block.cc
@@ -91,11 +91,11 @@ class RewriteUnboundBlockNode : public PostprocNode {
   // Inherited from PostprocNode
   void InitializeWithTuneContext(const TuneContext& context) final {
     TVM_FFI_CHECK(context->target.defined(), ValueError) << "target is not defined";
-    ffi::Optional<Integer> max_threads_per_block =
-        context->target.value()->GetAttr<Integer>("max_threads_per_block");
-    TVM_FFI_CHECK(max_threads_per_block.defined(), ValueError)
+    ffi::Optional<int64_t> max_threads_per_block =
+        context->target.value()->GetAttr<int64_t>("max_threads_per_block");
+    TVM_FFI_CHECK(max_threads_per_block.has_value(), ValueError)
         << "missing attribute `max_threads_per_block` in the target";
-    this->max_threads_per_block_ = max_threads_per_block.value().IntValue();
+    this->max_threads_per_block_ = max_threads_per_block.value();
   }
 
   // Inherited from PostprocNode

--- a/src/s_tir/meta_schedule/postproc/verify_gpu_code.cc
+++ b/src/s_tir/meta_schedule/postproc/verify_gpu_code.cc
@@ -77,12 +77,12 @@ class ThreadExtentChecker : private StmtVisitor {
     if (block->annotations.count(s_tir::attr::warp_execution)) {
       thread_idx_x = thread_warp_size_;
     }
-    if (ffi::Optional<Integer> low_inclusive =
-            GetAnn<Integer>(block, s_tir::attr::meta_schedule_thread_extent_low_inclusive)) {
-      if (ffi::Optional<Integer> high_inclusive =
-              GetAnn<Integer>(block, s_tir::attr::meta_schedule_thread_extent_high_inclusive)) {
-        int64_t low = low_inclusive.value()->value;
-        int64_t high = high_inclusive.value()->value;
+    if (ffi::Optional<int64_t> low_inclusive =
+            GetAnn<int64_t>(block, s_tir::attr::meta_schedule_thread_extent_low_inclusive)) {
+      if (ffi::Optional<int64_t> high_inclusive =
+              GetAnn<int64_t>(block, s_tir::attr::meta_schedule_thread_extent_high_inclusive)) {
+        int64_t low = low_inclusive.value();
+        int64_t high = high_inclusive.value();
         int64_t thread_extent_product = thread_idx_x * thread_idx_y * thread_idx_z;
         if (!(low <= thread_extent_product && thread_extent_product <= high)) {
           throw std::runtime_error("Thread extent");
@@ -109,7 +109,7 @@ namespace meta_schedule {
 /*! \brief Extract attribute from a target. */
 Integer Extract(const Target& target, const char* name) {
   TVM_FFI_ICHECK(target.defined());
-  if (ffi::Optional<Integer> v = target->GetAttr<Integer>(name)) {
+  if (ffi::Optional<int64_t> v = target->GetAttr<int64_t>(name)) {
     return v.value();
   }
   TVM_FFI_THROW(AttributedError) << "\"" << name << "\" is not defined in the target";

--- a/src/s_tir/meta_schedule/postproc/verify_vtcm_limit.cc
+++ b/src/s_tir/meta_schedule/postproc/verify_vtcm_limit.cc
@@ -27,14 +27,14 @@ namespace meta_schedule {
 
 class VerifyVTCMLimitNode : public PostprocNode {
  public:
-  Integer vtcm_capacity;
+  int64_t vtcm_capacity = 0;
 
   void InitializeWithTuneContext(const TuneContext& context) final {
     TVM_FFI_ICHECK(context->target.defined());
     Target target = context->target.value();
     TVM_FFI_ICHECK(target->kind->name == "hexagon");
     // The value of 0 will disable VTCM verification.
-    vtcm_capacity = target->GetAttr<Integer>("vtcm-capacity").value_or(0);
+    vtcm_capacity = target->GetAttr<int64_t>("vtcm-capacity").value_or(0);
   }
 
   bool Verify(const IRModule& mod) const {

--- a/src/s_tir/meta_schedule/schedule/cuda/thread_bind.cc
+++ b/src/s_tir/meta_schedule/schedule/cuda/thread_bind.cc
@@ -43,22 +43,22 @@ using s_tir::LoopRV;
 using s_tir::SBlockRV;
 using s_tir::Schedule;
 
-std::function<ExprRV(int64_t)> MakeFactorSampler(Schedule sch, ffi::Array<Integer> thread_extents) {
+std::function<ExprRV(int64_t)> MakeFactorSampler(Schedule sch, ffi::Array<int64_t> thread_extents) {
   return [sch = std::move(sch),
           thread_extents = std::move(thread_extents)](int64_t max_extent) -> ExprRV {
-    ffi::Array<Integer> extents;
+    ffi::Array<int64_t> extents;
     extents.reserve(thread_extents.size());
-    for (const Integer extent : thread_extents) {
-      if (extent->value <= max_extent) {
-        extents.push_back(Integer(extent->value));
+    for (int64_t extent : thread_extents) {
+      if (extent <= max_extent) {
+        extents.push_back(extent);
       }
     }
     int n = extents.size();
     if (n == 0) {
-      return Integer(max_extent);
+      return IntImm(DataType::Int(32), max_extent);
     }
     if (n == 1) {
-      return Integer(extents[0]);
+      return IntImm(DataType::Int(32), extents[0]);
     }
     ffi::Array<FloatImm> probs(n, FloatImm(DataType::Float(32), 1.0 / n));
     return sch->SampleCategorical(extents, probs);

--- a/src/s_tir/meta_schedule/schedule_rule/add_rfactor.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/add_rfactor.cc
@@ -71,10 +71,10 @@ class AddRFactorNode : public ScheduleRuleNode {
 };
 
 ScheduleRule ScheduleRule::AddRFactor(int max_jobs_per_core,
-                                      ffi::Optional<Integer> max_innermost_factor) {
+                                      ffi::Optional<int64_t> max_innermost_factor) {
   ffi::ObjectPtr<AddRFactorNode> n = ffi::make_object<AddRFactorNode>();
   n->max_jobs_per_core = max_jobs_per_core;
-  n->max_innermost_factor = max_innermost_factor.value_or(Integer(-1))->value;
+  n->max_innermost_factor = max_innermost_factor.value_or(-1);
   n->max_parallel_extent_ = -1;
   n->max_parallel_basic_ = -1;
   return ScheduleRule(n);

--- a/src/s_tir/meta_schedule/schedule_rule/auto_bind.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/auto_bind.cc
@@ -33,11 +33,11 @@ class AutoBindNode : public ScheduleRuleNode {
   // Inherited from ScheduleRuleNode
   void InitializeWithTuneContext(const TuneContext& context) final {
     TVM_FFI_CHECK(context->target.defined(), ValueError) << "target is not defined";
-    ffi::Optional<Integer> max_threads_per_block =
-        context->target.value()->GetAttr<Integer>("max_threads_per_block");
-    TVM_FFI_CHECK(max_threads_per_block.defined(), ValueError)
+    ffi::Optional<int64_t> max_threads_per_block =
+        context->target.value()->GetAttr<int64_t>("max_threads_per_block");
+    TVM_FFI_CHECK(max_threads_per_block.has_value(), ValueError)
         << "missing attribute `max_threads_per_block` in the target";
-    this->max_threads_per_block_ = max_threads_per_block.value().IntValue();
+    this->max_threads_per_block_ = max_threads_per_block.value();
   }
 
   // Inherited from ScheduleRuleNode
@@ -56,7 +56,7 @@ class AutoBindNode : public ScheduleRuleNode {
   /*! \brief The max number of threadblocks in the CUDA device */
   int64_t max_threadblocks_ = -1;
   /*! \brief thread_extents Candidates of thread axis extent. */
-  ffi::Array<Integer> thread_extents_;
+  ffi::Array<int64_t> thread_extents_;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -73,7 +73,7 @@ ffi::Array<s_tir::Schedule> AutoBindNode::Apply(const s_tir::Schedule& sch,
   return {sch};
 }
 
-ScheduleRule ScheduleRule::AutoBind(int max_threadblocks, ffi::Array<Integer> thread_extents,
+ScheduleRule ScheduleRule::AutoBind(int max_threadblocks, ffi::Array<int64_t> thread_extents,
                                     int max_threads_per_block) {
   ffi::ObjectPtr<AutoBindNode> n = ffi::make_object<AutoBindNode>();
   n->max_threadblocks_ = max_threadblocks;

--- a/src/s_tir/meta_schedule/schedule_rule/cross_thread_reduction.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/cross_thread_reduction.cc
@@ -31,22 +31,22 @@ class CrossThreadReductionNode : public ScheduleRuleNode {
     TVM_FFI_ICHECK(context->target.defined());
     Target target = context->target.value();
 
-    ffi::Optional<Integer> opt_max_threads_per_block =
-        target->GetAttr<Integer>("max_threads_per_block");
-    ffi::Optional<Integer> opt_warp_size = target->GetAttr<Integer>("thread_warp_size");
+    ffi::Optional<int64_t> opt_max_threads_per_block =
+        target->GetAttr<int64_t>("max_threads_per_block");
+    ffi::Optional<int64_t> opt_warp_size = target->GetAttr<int64_t>("thread_warp_size");
 
-    if (!opt_max_threads_per_block.defined()) {
+    if (!opt_max_threads_per_block.has_value()) {
       TVM_PY_LOG(WARNING, context->logger)
           << "Target does not have attribute \"max_threads_per_block\", therefore the "
              "rule CrossThreadReduction will not be applied";
     }
-    if (!opt_warp_size.defined()) {
+    if (!opt_warp_size.has_value()) {
       TVM_PY_LOG(WARNING, context->logger)
           << "Target does not have attribute \"thread_warp_size\", therefore the rule "
              "CrossThreadReduction will not be applied";
     }
-    max_threads_per_block = opt_max_threads_per_block.value_or(Integer(-1))->value;
-    warp_size = opt_warp_size.value_or(Integer(-1))->value;
+    max_threads_per_block = opt_max_threads_per_block.value_or(-1);
+    warp_size = opt_warp_size.value_or(-1);
   }
 
   // Inherited from ScheduleRuleNode
@@ -277,7 +277,7 @@ class CrossThreadReductionNode : public ScheduleRuleNode {
   /*! \brief The number of threads per warp */
   int warp_size;
   /*! \brief Candidates of thread axis extent (values are required to be positive). */
-  ffi::Array<Integer> thread_extents;
+  ffi::Array<int64_t> thread_extents;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -290,10 +290,9 @@ class CrossThreadReductionNode : public ScheduleRuleNode {
                                     CrossThreadReductionNode, ScheduleRuleNode);
 };
 
-ScheduleRule ScheduleRule::CrossThreadReduction(ffi::Array<Integer> thread_extents) {
-  for (const auto& extent : thread_extents) {
-    TVM_FFI_CHECK(extent->value > 0, ValueError)
-        << "The candidates of thread extent must be positive";
+ScheduleRule ScheduleRule::CrossThreadReduction(ffi::Array<int64_t> thread_extents) {
+  for (int64_t extent : thread_extents) {
+    TVM_FFI_CHECK(extent > 0, ValueError) << "The candidates of thread extent must be positive";
   }
   ffi::ObjectPtr<CrossThreadReductionNode> n = ffi::make_object<CrossThreadReductionNode>();
   n->thread_extents = std::move(thread_extents);

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling.cc
@@ -80,11 +80,11 @@ State StateNode::Copy() const {
 
 // Do nothing; Inherited from ScheduleRuleNode
 void MultiLevelTilingNode::InitializeWithTuneContext(const TuneContext& context) {
-  if (ffi::Optional<Integer> v =
-          context->target.value()->GetAttr<Integer>("max_threads_per_block")) {
-    this->max_threads_per_block_ = v.value()->value;
-    if (ffi::Optional<Integer> v = context->target.value()->GetAttr<Integer>("thread_warp_size")) {
-      this->thread_warp_size_ = v.value()->value;
+  if (ffi::Optional<int64_t> v =
+          context->target.value()->GetAttr<int64_t>("max_threads_per_block")) {
+    this->max_threads_per_block_ = v.value();
+    if (ffi::Optional<int64_t> v = context->target.value()->GetAttr<int64_t>("thread_warp_size")) {
+      this->thread_warp_size_ = v.value();
     } else {
       TVM_PY_LOG(INFO, context->logger) << "'thread_warp_size' is not defined in the target";
     }
@@ -146,12 +146,12 @@ std::vector<State> MultiLevelTilingNode::AddWriteReuse(State state) const {
   }
   std::vector<int> levels = config.levels;
   ReuseType req = config.req;
-  if (ffi::Optional<ffi::Array<Integer>> ann = s_tir::GetAnn<ffi::Array<Integer>>(
+  if (ffi::Optional<ffi::Array<int64_t>> ann = s_tir::GetAnn<ffi::Array<int64_t>>(
           state->sch->GetSRef(state->block_rv), "s_tir.meta_schedule.write_cache_level")) {
     req = ReuseType::kMustReuse;
     levels.clear();
     std::transform(ann.value().begin(), ann.value().end(), std::back_inserter(levels),
-                   [](auto&& v) { return v.IntValue(); });
+                   [](int64_t v) { return static_cast<int>(v); });
   }
   std::vector<State> results;
   if (req == ReuseType::kMayReuse) {
@@ -354,11 +354,11 @@ std::vector<State> MultiLevelTilingNode::AddAsyncPipeline(State state) const {
     State new_state = state->Copy();
     LoopRV r_loop_fused = new_state->sch->Fuse(new_state->tiles[r_indices_[0]]);
     new_state->sch->Annotate(r_loop_fused, s_tir::attr::software_pipeline_stage,
-                             ffi::Array<Integer>{0, 0, stage - 2});
+                             ffi::Array<int64_t>{0, 0, stage - 2});
     new_state->sch->Annotate(r_loop_fused, s_tir::attr::software_pipeline_order,
-                             ffi::Array<Integer>{0, 1, 2});
+                             ffi::Array<int64_t>{0, 1, 2});
     new_state->sch->Annotate(r_loop_fused, s_tir::attr::software_pipeline_async_stages,
-                             ffi::Array<Integer>{0});
+                             ffi::Array<int64_t>{0});
     ret.push_back(std::move(new_state));
   }
   return ret;
@@ -392,9 +392,11 @@ void MultiLevelTilingNode::AnnotateCooperativeFetching(Schedule* sch,
   if (!valid_vector_lens.empty()) {
     int n = valid_vector_lens.size();
     double prob = 1.0 / n;
-    s_tir::ExprRV vector_load_len =
-        (*sch)->SampleCategorical(support::AsArray<int, Integer>(valid_vector_lens),
-                                  ffi::Array<FloatImm>(n, FloatImm(DataType::Float(32), prob)));
+    ffi::Array<int64_t> valid_vector_lens_arr;
+    valid_vector_lens_arr.reserve(valid_vector_lens.size());
+    for (int v : valid_vector_lens) valid_vector_lens_arr.push_back(static_cast<int64_t>(v));
+    s_tir::ExprRV vector_load_len = (*sch)->SampleCategorical(
+        valid_vector_lens_arr, ffi::Array<FloatImm>(n, FloatImm(DataType::Float(32), prob)));
     (*sch)->Annotate(block, s_tir::attr::meta_schedule_cooperative_fetch, vector_load_len);
   }
 }
@@ -403,8 +405,8 @@ void MultiLevelTilingNode::AnnotateCooperativeFetching(Schedule* sch,
 
 ScheduleRule ScheduleRule::MultiLevelTiling(
     ffi::String structure, ffi::Optional<ffi::Array<ffi::String>> tile_binds,
-    ffi::Optional<Integer> max_innermost_factor,
-    ffi::Optional<ffi::Array<Integer>> vector_load_lens,
+    ffi::Optional<int64_t> max_innermost_factor,
+    ffi::Optional<ffi::Array<int64_t>> vector_load_lens,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write,
     ffi::Optional<ffi::Function> filter_fn) {

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling.h
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling.h
@@ -94,7 +94,13 @@ struct ReuseConfig {
   /*! \brief Construct from a configuration dictionary */
   explicit ReuseConfig(const ffi::Map<ffi::String, ffi::Any>& config)
       : req(Str2ReuseType(Downcast<ffi::String>(config.at("req")))),
-        levels(support::AsVector<Integer, int>(Downcast<ffi::Array<Integer>>(config.at("levels")))),
+        levels([&]() {
+          auto arr = Downcast<ffi::Array<int64_t>>(config.at("levels"));
+          std::vector<int> r;
+          r.reserve(arr.size());
+          for (int64_t v : arr) r.push_back(static_cast<int>(v));
+          return r;
+        }()),
         scope(Downcast<ffi::String>(config.at("scope"))) {
     TVM_FFI_ICHECK_EQ(config.size(), 3);
   }
@@ -237,17 +243,22 @@ class MultiLevelTilingNode : public ScheduleRuleNode {
 template <typename NodeType>
 ffi::ObjectPtr<NodeType> MultiLevelTilingInitCommon(
     ffi::String structure, ffi::Optional<ffi::Array<ffi::String>> tile_binds,
-    ffi::Optional<Integer> max_innermost_factor,
-    ffi::Optional<ffi::Array<Integer>> vector_load_lens,
+    ffi::Optional<int64_t> max_innermost_factor,
+    ffi::Optional<ffi::Array<int64_t>> vector_load_lens,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write) {
   ffi::ObjectPtr<NodeType> n = ffi::make_object<NodeType>();
   n->structure = structure;
   n->tile_binds = tile_binds.value_or({});
-  n->max_innermost_factor = max_innermost_factor.value_or(Integer(-1))->value;
-  n->vector_load_lens = vector_load_lens.defined()
-                            ? support::AsVector<Integer, int>(vector_load_lens.value())
-                            : std::vector<int>();
+  n->max_innermost_factor = max_innermost_factor.value_or(-1);
+  n->vector_load_lens = [&]() {
+    if (!vector_load_lens.has_value()) return std::vector<int>();
+    auto arr = vector_load_lens.value();
+    std::vector<int> r;
+    r.reserve(arr.size());
+    for (int64_t v : arr) r.push_back(static_cast<int>(v));
+    return r;
+  }();
   n->reuse_read_ = reuse_read.defined() ? ReuseConfig(reuse_read.value()) : ReuseConfig();
   n->reuse_write_ = reuse_write.defined() ? ReuseConfig(reuse_write.value()) : ReuseConfig();
   for (int i = 0, len = structure.size(); i < len; ++i) {

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
@@ -708,16 +708,16 @@ std::vector<State> MultiLevelTilingTensorCoreNode::AddSoftwarePipeline(
   //   compute matmul with fragment K1 - 1
   //
   sch->Annotate(state->tiles[r_indices_[1]].back(), s_tir::attr::software_pipeline_stage,
-                ffi::Array<Integer>{0, 0, 1});
+                ffi::Array<int64_t>{0, 0, 1});
   sch->Annotate(state->tiles[r_indices_[1]].back(), s_tir::attr::software_pipeline_order,
-                ffi::Array<Integer>{0, 1, 2});
+                ffi::Array<int64_t>{0, 1, 2});
   if (state->is_mma && state->use_async) {
     sch->Annotate(state->tiles[r_indices_[0]].back(), s_tir::attr::software_pipeline_async_stages,
-                  ffi::Array<Integer>{0});
+                  ffi::Array<int64_t>{0});
     sch->Annotate(state->tiles[r_indices_[0]].back(), s_tir::attr::software_pipeline_stage,
-                  ffi::Array<Integer>{0, 0, 1, 2, 2});
+                  ffi::Array<int64_t>{0, 0, 1, 2, 2});
     sch->Annotate(state->tiles[r_indices_[0]].back(), s_tir::attr::software_pipeline_order,
-                  ffi::Array<Integer>{0, 1, 3, 2, 4});
+                  ffi::Array<int64_t>{0, 1, 3, 2, 4});
   } else {
     // Outer software pipeline: Interleave the outer loop with the (pipelined) inner loop.
     // The prefetching stage of the inner pipeline is executed by one iteration in the outer loop.
@@ -760,9 +760,9 @@ std::vector<State> MultiLevelTilingTensorCoreNode::AddSoftwarePipeline(
     //   compute matmul with fragment K1 - 1 of tile K0 - 1
     //
     sch->Annotate(state->tiles[r_indices_[0]].back(), s_tir::attr::software_pipeline_stage,
-                  ffi::Array<Integer>{0, 0, 0, 0, 0, 1, 1});
+                  ffi::Array<int64_t>{0, 0, 0, 0, 0, 1, 1});
     sch->Annotate(state->tiles[r_indices_[0]].back(), s_tir::attr::software_pipeline_order,
-                  ffi::Array<Integer>{0, 3, 1, 4, 5, 2, 6});
+                  ffi::Array<int64_t>{0, 3, 1, 4, 5, 2, 6});
   }
 
   return {state};
@@ -914,8 +914,8 @@ inline std::vector<State> MultiLevelTilingTensorCoreNode::TransformForTensorizat
 
 ScheduleRule ScheduleRule::MultiLevelTilingTensorCore(
     ffi::Array<ffi::Map<ffi::String, ffi::String>> intrin_groups, ffi::String structure,
-    ffi::Optional<ffi::Array<ffi::String>> tile_binds, ffi::Optional<Integer> max_innermost_factor,
-    ffi::Optional<ffi::Array<Integer>> vector_load_lens,
+    ffi::Optional<ffi::Array<ffi::String>> tile_binds, ffi::Optional<int64_t> max_innermost_factor,
+    ffi::Optional<ffi::Array<int64_t>> vector_load_lens,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write, bool use_software_pipeline) {
   if (tile_binds.defined()) {

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_wide_vector.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_wide_vector.cc
@@ -126,7 +126,7 @@ MultiLevelTilingWideVectorNode::SplitLoop(const Schedule& sch, SBlockRV block_rv
 
 ScheduleRule ScheduleRule::MultiLevelTilingWideVector(
     ffi::String structure, Integer vector_length_in_bits,
-    ffi::Optional<Integer> max_innermost_factor,
+    ffi::Optional<int64_t> max_innermost_factor,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write) {
   auto node = MultiLevelTilingInitCommon<MultiLevelTilingWideVectorNode>(

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_with_intrin.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_with_intrin.cc
@@ -102,8 +102,8 @@ class MultiLevelTilingWithIntrinNode : public MultiLevelTilingNode {
 
 ScheduleRule ScheduleRule::MultiLevelTilingWithIntrin(
     ffi::String intrin_name, ffi::String structure,
-    ffi::Optional<ffi::Array<ffi::String>> tile_binds, ffi::Optional<Integer> max_innermost_factor,
-    ffi::Optional<ffi::Array<Integer>> vector_load_lens,
+    ffi::Optional<ffi::Array<ffi::String>> tile_binds, ffi::Optional<int64_t> max_innermost_factor,
+    ffi::Optional<ffi::Array<int64_t>> vector_load_lens,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write) {
   TVM_FFI_ICHECK(tirx::TensorIntrin::Get(intrin_name).defined())

--- a/src/s_tir/meta_schedule/schedule_rule/parallel_vectorize_unroll.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/parallel_vectorize_unroll.cc
@@ -108,7 +108,7 @@ class ParallelizeVectorizeUnrollNode : public ScheduleRuleNode {
    * \brief The options of the maximum number of unroll steps to be done.
    * Use an empty array to disable unroll.
    */
-  ffi::Array<Integer> unroll_max_steps;
+  ffi::Array<int64_t> unroll_max_steps;
   /*! \brief Whether to explicitly unroll the loop, or just add an "unroll" pragma. */
   bool unroll_explicit;
   /*! \brief The number of maximum available jobs in CPU. */
@@ -128,7 +128,7 @@ class ParallelizeVectorizeUnrollNode : public ScheduleRuleNode {
 
 ScheduleRule ScheduleRule::ParallelizeVectorizeUnroll(int max_jobs_per_core,
                                                       int max_vectorize_extent,
-                                                      ffi::Array<Integer> unroll_max_steps,
+                                                      ffi::Array<int64_t> unroll_max_steps,
                                                       bool unroll_explicit) {
   ffi::ObjectPtr<ParallelizeVectorizeUnrollNode> n =
       ffi::make_object<ParallelizeVectorizeUnrollNode>();

--- a/src/s_tir/meta_schedule/schedule_rule/schedule_rule.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/schedule_rule.cc
@@ -69,21 +69,21 @@ ffi::Array<ScheduleRule> ScheduleRule::DefaultLLVM() {
           /*disallow_op=*/ffi::Array<ffi::String>{"tirx.exp"}),
       ScheduleRule::AddRFactor(
           /*max_jobs_per_core=*/16,
-          /*max_innermost_factor=*/Integer(64)),
+          /*max_innermost_factor=*/static_cast<int64_t>(64)),
       ScheduleRule::MultiLevelTiling(
           /*structure=*/"SSRSRS",
           /*tile_binds=*/std::nullopt,
-          /*max_innermost_factor=*/Integer(64),
+          /*max_innermost_factor=*/static_cast<int64_t>(64),
           /*vector_load_lens=*/std::nullopt,
           /*reuse_read=*/std::nullopt,
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                          {"levels", ffi::Array<Integer>{1, 2}},
+                                          {"levels", ffi::Array<int64_t>{1, 2}},
                                           {"scope", ffi::String("global")}}),
       ScheduleRule::ParallelizeVectorizeUnroll(
           /*max_jobs_per_core=*/16,
           /*max_vectorize_extent=*/64,
-          /*unroll_max_steps=*/ffi::Array<Integer>{0, 16, 64, 512},
+          /*unroll_max_steps=*/ffi::Array<int64_t>{0, 16, 64, 512},
           /*unroll_explicit=*/true),
       ScheduleRule::RandomComputeLocation(),
   };
@@ -105,32 +105,32 @@ ffi::Array<ScheduleRule> ScheduleRule::DefaultX86(const ffi::String& type) {
           /*disallow_op=*/ffi::Array<ffi::String>{"tirx.exp"}),
       ScheduleRule::AddRFactor(
           /*max_jobs_per_core=*/16,
-          /*max_innermost_factor=*/Integer(64)),
+          /*max_innermost_factor=*/static_cast<int64_t>(64)),
       ScheduleRule::MultiLevelTilingWithIntrin(
           /*intrin_name=*/intrins[type],
           /*structure=*/"SSRSRS",
           /*tile_binds=*/std::nullopt,
-          /*max_innermost_factor=*/Integer(64),
+          /*max_innermost_factor=*/static_cast<int64_t>(64),
           /*vector_load_lens=*/std::nullopt,
           /*reuse_read=*/std::nullopt,
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                          {"levels", ffi::Array<Integer>{1, 2}},
+                                          {"levels", ffi::Array<int64_t>{1, 2}},
                                           {"scope", ffi::String("global")}}),
       ScheduleRule::MultiLevelTiling(
           /*structure=*/"SSRSRS",
           /*tile_binds=*/std::nullopt,
-          /*max_innermost_factor=*/Integer(64),
+          /*max_innermost_factor=*/static_cast<int64_t>(64),
           /*vector_load_lens=*/std::nullopt,
           /*reuse_read=*/std::nullopt,
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                          {"levels", ffi::Array<Integer>{1, 2}},
+                                          {"levels", ffi::Array<int64_t>{1, 2}},
                                           {"scope", ffi::String("global")}}),
       ScheduleRule::ParallelizeVectorizeUnroll(
           /*max_jobs_per_core=*/16,
           /*max_vectorize_extent=*/64,
-          /*unroll_max_steps=*/ffi::Array<Integer>{0, 16, 64, 512},
+          /*unroll_max_steps=*/ffi::Array<int64_t>{0, 16, 64, 512},
           /*unroll_explicit=*/true),
       ScheduleRule::RandomComputeLocation(),
   };
@@ -142,15 +142,15 @@ ffi::Array<ScheduleRule> ScheduleRule::DefaultCUDA() {
       ScheduleRule::MultiLevelTiling(
           /*structure=*/"SSSRRSRS",
           /*tile_binds=*/ffi::Array<ffi::String>{"blockIdx.x", "vthread.x", "threadIdx.x"},
-          /*max_innermost_factor=*/Integer(64),
-          /*vector_load_lens=*/ffi::Array<Integer>{1, 2, 3, 4, 8, 16},
+          /*max_innermost_factor=*/static_cast<int64_t>(64),
+          /*vector_load_lens=*/ffi::Array<int64_t>{1, 2, 3, 4, 8, 16},
           /*reuse_read=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("must")},
-                                          {"levels", ffi::Array<Integer>{4}},  //
+                                          {"levels", ffi::Array<int64_t>{4}},  //
                                           {"scope", ffi::String("shared")}},
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("must")},
-                                          {"levels", ffi::Array<Integer>{3}},  //
+                                          {"levels", ffi::Array<int64_t>{3}},  //
                                           {"scope", ffi::String("local")}}),
       ScheduleRule::InlineConstantScalars(),
       ScheduleRule::AutoInline(
@@ -162,15 +162,15 @@ ffi::Array<ScheduleRule> ScheduleRule::DefaultCUDA() {
           /*require_ordered=*/false,
           /*disallow_op=*/ffi::Array<ffi::String>{}),
       ScheduleRule::CrossThreadReduction(
-          /*thread_extents=*/ffi::Array<Integer>{4, 8, 16, 32, 64, 128, 256, 512}),
+          /*thread_extents=*/ffi::Array<int64_t>{4, 8, 16, 32, 64, 128, 256, 512}),
       ScheduleRule::ParallelizeVectorizeUnroll(
           /*max_jobs_per_core=*/-1,
           /*max_vectorize_extent=*/-1,
-          /*unroll_max_steps=*/ffi::Array<Integer>{0, 16, 32, 64, 128, 256, 512, 1024},
+          /*unroll_max_steps=*/ffi::Array<int64_t>{0, 16, 32, 64, 128, 256, 512, 1024},
           /*unroll_explicit=*/true),
       ScheduleRule::AutoBind(
           /*max_threadblocks=*/256,
-          /*thread_extents*/ ffi::Array<Integer>{32, 64, 128, 256, 512, 1024}),
+          /*thread_extents*/ ffi::Array<int64_t>{32, 64, 128, 256, 512, 1024}),
   };
 }
 
@@ -245,30 +245,30 @@ ffi::Array<ScheduleRule> ScheduleRule::DefaultCUDATensorCore() {
           /*intrin_groups=*/wmma_intrin_groups,
           /*structure=*/"SSSRRSRS",
           /*tile_binds=*/ffi::Array<ffi::String>{"blockIdx.y", "blockIdx.x", "threadIdx.y"},
-          /*max_innermost_factor=*/Integer(4),
-          /*vector_load_lens=*/ffi::Array<Integer>{1, 2, 3, 4, 8, 16},
+          /*max_innermost_factor=*/static_cast<int64_t>(4),
+          /*vector_load_lens=*/ffi::Array<int64_t>{1, 2, 3, 4, 8, 16},
           /*reuse_read=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("must")},
-                                          {"levels", ffi::Array<Integer>{4}},  //
+                                          {"levels", ffi::Array<int64_t>{4}},  //
                                           {"scope", ffi::String("shared.dyn")}},
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("must")},
-                                          {"levels", ffi::Array<Integer>{2}},  //
+                                          {"levels", ffi::Array<int64_t>{2}},  //
                                           {"scope", ffi::String("shared.dyn")}},
           /*use_software_pipeline=*/false),  //
       ScheduleRule::MultiLevelTilingTensorCore(
           /*intrin_groups=*/mma_intrin_groups,
           /*structure=*/"SSSRRSRS",
           /*tile_binds=*/ffi::Array<ffi::String>{"blockIdx.y", "blockIdx.x", "threadIdx.y"},
-          /*max_innermost_factor=*/Integer(4),
-          /*vector_load_lens=*/ffi::Array<Integer>{1, 2, 3, 4, 8, 16},
+          /*max_innermost_factor=*/static_cast<int64_t>(4),
+          /*vector_load_lens=*/ffi::Array<int64_t>{1, 2, 3, 4, 8, 16},
           /*reuse_read=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("must")},
-                                          {"levels", ffi::Array<Integer>{4}},  //
+                                          {"levels", ffi::Array<int64_t>{4}},  //
                                           {"scope", ffi::String("shared.dyn")}},
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("no")},
-                                          {"levels", ffi::Array<Integer>{2}},  //
+                                          {"levels", ffi::Array<int64_t>{2}},  //
                                           {"scope", ffi::String("shared.dyn")}},
           /*use_software_pipeline=*/true)  //
   };
@@ -292,16 +292,16 @@ ffi::Array<ScheduleRule> ScheduleRule::DefaultHexagon() {
       ScheduleRule::MultiLevelTilingWideVector(
           /*structure=*/"SRSRS",
           /*vector_length_in_bits=*/1024,
-          /*max_innermost_factor=*/Integer(128),
+          /*max_innermost_factor=*/static_cast<int64_t>(128),
           /*reuse_read=*/std::nullopt,
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                          {"levels", ffi::Array<Integer>{1, 2}},
+                                          {"levels", ffi::Array<int64_t>{1, 2}},
                                           {"scope", ffi::String("global")}}),
       ScheduleRule::ParallelizeVectorizeUnroll(
           /*max_jobs_per_core=*/16,
           /*max_vectorize_extent=*/128,
-          /*unroll_max_steps=*/ffi::Array<Integer>{0, 16, 64, 512},
+          /*unroll_max_steps=*/ffi::Array<int64_t>{0, 16, 64, 512},
           /*unroll_explicit=*/true),
   };
 }
@@ -320,7 +320,7 @@ ffi::Array<ScheduleRule> ScheduleRule::DefaultRISCV(const int vlen) {
       /*disallow_op=*/ffi::Array<ffi::String>{"tirx.exp"}));
   rules.push_back(ScheduleRule::AddRFactor(
       /*max_jobs_per_core=*/16,
-      /*max_innermost_factor=*/Integer(64)));
+      /*max_innermost_factor=*/static_cast<int64_t>(64)));
   auto current_target = tvm::Target::Current();
   const auto reg_rvv_intrinsics =
       tvm::ffi::Function::GetGlobalRequired("tirx.tensor_intrin.register_rvv_isa_intrinsics");
@@ -335,28 +335,28 @@ ffi::Array<ScheduleRule> ScheduleRule::DefaultRISCV(const int vlen) {
         /*intrin_name=*/intrin.first,
         /*structure=*/"SSRSRS",
         /*tile_binds=*/std::nullopt,
-        /*max_innermost_factor=*/Integer(intrin.second),
+        /*max_innermost_factor=*/static_cast<int64_t>(intrin.second),
         /*vector_load_lens=*/std::nullopt,
         /*reuse_read=*/std::nullopt,
         /*reuse_write=*/
         ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                        {"levels", ffi::Array<Integer>{1, 2}},
+                                        {"levels", ffi::Array<int64_t>{1, 2}},
                                         {"scope", ffi::String("global")}}));
   }
   rules.push_back(ScheduleRule::MultiLevelTiling(
       /*structure=*/"SSRSRS",
       /*tile_binds=*/std::nullopt,
-      /*max_innermost_factor=*/Integer(64),
+      /*max_innermost_factor=*/static_cast<int64_t>(64),
       /*vector_load_lens=*/std::nullopt,
       /*reuse_read=*/std::nullopt,
       /*reuse_write=*/
       ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                      {"levels", ffi::Array<Integer>{1, 2}},
+                                      {"levels", ffi::Array<int64_t>{1, 2}},
                                       {"scope", ffi::String("global")}}));
   rules.push_back(ScheduleRule::ParallelizeVectorizeUnroll(
       /*max_jobs_per_core=*/16,
       /*max_vectorize_extent=*/64,
-      /*unroll_max_steps=*/ffi::Array<Integer>{0, 16, 64, 512},
+      /*unroll_max_steps=*/ffi::Array<int64_t>{0, 16, 64, 512},
       /*unroll_explicit=*/true));
   rules.push_back(ScheduleRule::RandomComputeLocation());
 
@@ -369,12 +369,12 @@ ffi::Array<ScheduleRule> GetARMNeonSpecificRules() {
           /*intrin_name=*/ffi::String("dot_4x4_i8i8s32_neon"),
           /*structure=*/"SSRSRS",
           /*tile_binds=*/std::nullopt,
-          /*max_innermost_factor=*/Integer(32),
+          /*max_innermost_factor=*/static_cast<int64_t>(32),
           /*vector_load_lens=*/std::nullopt,
           /*reuse_read=*/std::nullopt,
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                          {"levels", ffi::Array<Integer>{1, 2}},
+                                          {"levels", ffi::Array<int64_t>{1, 2}},
                                           {"scope", ffi::String("global")}}),
   };
 }
@@ -385,34 +385,34 @@ ffi::Array<ScheduleRule> GetARMDotprodSpecificRules() {
           /*intrin_name=*/ffi::String("dot_4x4_i8i8s32_sdot"),
           /*structure=*/"SSRSRS",
           /*tile_binds=*/std::nullopt,
-          /*max_innermost_factor=*/Integer(32),
+          /*max_innermost_factor=*/static_cast<int64_t>(32),
           /*vector_load_lens=*/std::nullopt,
           /*reuse_read=*/std::nullopt,
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                          {"levels", ffi::Array<Integer>{1, 2}},
+                                          {"levels", ffi::Array<int64_t>{1, 2}},
                                           {"scope", ffi::String("global")}}),
       ScheduleRule::MultiLevelTilingWithIntrin(
           /*intrin_name=*/ffi::String("dot_4x4_u8u8u32_udot"),
           /*structure=*/"SSRSRS",
           /*tile_binds=*/std::nullopt,
-          /*max_innermost_factor=*/Integer(32),
+          /*max_innermost_factor=*/static_cast<int64_t>(32),
           /*vector_load_lens=*/std::nullopt,
           /*reuse_read=*/std::nullopt,
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                          {"levels", ffi::Array<Integer>{1, 2}},
+                                          {"levels", ffi::Array<int64_t>{1, 2}},
                                           {"scope", ffi::String("global")}}),
       ScheduleRule::MultiLevelTilingWithIntrin(
           /*intrin_name=*/ffi::String("dot_4x4_u8u8i32_hdot"),
           /*structure=*/"SSRSRS",
           /*tile_binds=*/std::nullopt,
-          /*max_innermost_factor=*/Integer(32),
+          /*max_innermost_factor=*/static_cast<int64_t>(32),
           /*vector_load_lens=*/std::nullopt,
           /*reuse_read=*/std::nullopt,
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                          {"levels", ffi::Array<Integer>{1, 2}},
+                                          {"levels", ffi::Array<int64_t>{1, 2}},
                                           {"scope", ffi::String("global")}}),
   };
 }
@@ -430,23 +430,23 @@ ffi::Array<ScheduleRule> ScheduleRule::DefaultARM(const ffi::String& type) {
           /*disallow_op=*/ffi::Array<ffi::String>{"tirx.exp"}),
       ScheduleRule::AddRFactor(
           /*max_jobs_per_core=*/8,
-          /*max_innermost_factor=*/Integer(32)),
+          /*max_innermost_factor=*/static_cast<int64_t>(32)),
       "neon" == type ? GetARMNeonSpecificRules() : ffi::Array<ScheduleRule>{},
       "dotprod" == type ? GetARMDotprodSpecificRules() : ffi::Array<ScheduleRule>{},
       ScheduleRule::MultiLevelTiling(
           /*structure=*/"SSRSRS",
           /*tile_binds=*/std::nullopt,
-          /*max_innermost_factor=*/Integer(32),
+          /*max_innermost_factor=*/static_cast<int64_t>(32),
           /*vector_load_lens=*/std::nullopt,
           /*reuse_read=*/std::nullopt,
           /*reuse_write=*/
           ffi::Map<ffi::String, ffi::Any>{{"req", ffi::String("may")},
-                                          {"levels", ffi::Array<Integer>{1, 2}},
+                                          {"levels", ffi::Array<int64_t>{1, 2}},
                                           {"scope", ffi::String("global")}}),
       ScheduleRule::ParallelizeVectorizeUnroll(
           /*max_jobs_per_core=*/8,
           /*max_vectorize_extent=*/32,
-          /*unroll_max_steps=*/ffi::Array<Integer>{0, 8, 32, 256},
+          /*unroll_max_steps=*/ffi::Array<int64_t>{0, 8, 32, 256},
           /*unroll_explicit=*/true),
       ScheduleRule::RandomComputeLocation());
 }

--- a/src/s_tir/meta_schedule/trace_apply.cc
+++ b/src/s_tir/meta_schedule/trace_apply.cc
@@ -256,14 +256,14 @@ void ScheduleUsingAnchorTrace(Schedule sch, const Trace& anchor_trace, const tvm
   } else if (target->kind->name == "llvm" || target->kind->name == "hexagon") {
     sch->Parallel(sch->Fuse(sch->GetLoops(last_block)));
   } else if (IsGPUTarget(target->kind->name)) {
-    auto max_threads_per_block = target->GetAttr<Integer>("max_threads_per_block");
-    TVM_FFI_CHECK(max_threads_per_block.defined(), ValueError)
+    auto max_threads_per_block = target->GetAttr<int64_t>("max_threads_per_block");
+    TVM_FFI_CHECK(max_threads_per_block.has_value(), ValueError)
         << "missing attribute `max_threads_per_block` in the target";
 
     auto auto_bind_rule =
         ScheduleRule::AutoBind(/*max_threadblocks=*/256,
-                               /*thread_extents*/ ffi::Array<Integer>{32, 64, 128, 256, 512, 1024},
-                               max_threads_per_block.value()->value);
+                               /*thread_extents*/ ffi::Array<int64_t>{32, 64, 128, 256, 512, 1024},
+                               max_threads_per_block.value());
     auto_bind_rule->Apply(sch, last_block);
   }
 }

--- a/src/s_tir/meta_schedule/utils.h
+++ b/src/s_tir/meta_schedule/utils.h
@@ -416,7 +416,7 @@ struct ThreadedTraceApply {
  * \return The number of cores.
  */
 inline int GetTargetNumCores(const Target& target) {
-  int num_cores = target->GetAttr<Integer>("num-cores").value_or(-1).IntValue();
+  int num_cores = target->GetAttr<int64_t>("num-cores").value_or(-1);
   if (num_cores == -1) {
     static const auto f_cpu_count = tvm::ffi::Function::GetGlobal("s_tir.meta_schedule.cpu_count");
     TVM_FFI_CHECK(f_cpu_count.has_value(), ValueError)
@@ -484,10 +484,10 @@ inline ffi::Array<FloatImm> AsFloatArray(const ffi::ObjectRef& obj) {
  * \param obj The object to be converted
  * \return The array of integers
  */
-inline ffi::Array<Integer> AsIntArray(const ffi::ObjectRef& obj) {
+inline ffi::Array<int64_t> AsIntArray(const ffi::ObjectRef& obj) {
   const ffi::ArrayObj* arr = obj.as<ffi::ArrayObj>();
   TVM_FFI_CHECK(arr, TypeError) << "Expect an array, but gets: " << obj->GetTypeKey();
-  ffi::Array<Integer> results;
+  ffi::Array<int64_t> results;
   results.reserve(arr->size());
   for (Any val : *arr) {
     auto int_value = [&]() -> int64_t {
@@ -498,7 +498,7 @@ inline ffi::Array<Integer> AsIntArray(const ffi::ObjectRef& obj) {
         TVM_FFI_UNREACHABLE();
       }
     }();
-    results.push_back(Integer(int_value));
+    results.push_back(int_value);
   }
   return results;
 }

--- a/src/s_tir/schedule/analysis.h
+++ b/src/s_tir/schedule/analysis.h
@@ -742,11 +742,11 @@ class TensorizeInfoNode : public ffi::Object {
   /*! \brief Maps loops in a target block to the ones in an intrinsic description */
   ffi::Map<tirx::StmtSRef, tirx::For> loop_map;
   /*! \brief Maps loops in an intrinsic description to its index, outer to inner */
-  ffi::Map<tirx::For, Integer> desc_loop_indexer;
+  ffi::Map<tirx::For, int64_t> desc_loop_indexer;
   /*! \brief Optional padded extents of the block iters when padding is needed to match the
    * intrinsic description
    */
-  ffi::Optional<ffi::Array<Integer>> block_iter_paddings;
+  ffi::Optional<ffi::Array<int64_t>> block_iter_paddings;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;

--- a/src/s_tir/schedule/analysis/analysis.cc
+++ b/src/s_tir/schedule/analysis/analysis.cc
@@ -1894,19 +1894,18 @@ ffi::Optional<TensorizeInfo> GetTensorizeLoopMapping(const s_tir::ScheduleState&
   }
 
   for (int i = 0, n = desc_loops.size(); i < n; ++i) {
-    ret->desc_loop_indexer.Set(ffi::GetRef<tirx::For>(desc_loops[i]), Integer(i));
+    ret->desc_loop_indexer.Set(ffi::GetRef<tirx::For>(desc_loops[i]), static_cast<int64_t>(i));
   }
   if (!block_index_to_padding.empty()) {
     if (!allow_padding) {
       return std::nullopt;
     }
-    ffi::Array<Integer> paddings;
+    ffi::Array<int64_t> paddings;
     for (int i = 0, n = block->block->iter_vars.size(); i < n; ++i) {
-      const IterVar& iter_var = block->block->iter_vars[i];
       if (auto it = block_index_to_padding.find(i); it != block_index_to_padding.end()) {
-        paddings.push_back(IntImm(iter_var->var.dtype(), it->second));
+        paddings.push_back(static_cast<int64_t>(it->second));
       } else {
-        paddings.push_back(IntImm(iter_var->var.dtype(), 1));
+        paddings.push_back(1);
       }
     }
     ret->block_iter_paddings = std::move(paddings);

--- a/src/s_tir/schedule/concrete_schedule.cc
+++ b/src/s_tir/schedule/concrete_schedule.cc
@@ -236,9 +236,9 @@ LinearCongruentialEngine::TRandState ConcreteScheduleNode::ForkSeed() {
   return LinearCongruentialEngine(&rand_state_).ForkSeed();
 }
 
-ExprRV ConcreteScheduleNode::SampleCategorical(const ffi::Array<Integer>& candidates,
+ExprRV ConcreteScheduleNode::SampleCategorical(const ffi::Array<int64_t>& candidates,
                                                const ffi::Array<FloatImm>& probs,
-                                               ffi::Optional<Integer> decision) {
+                                               ffi::Optional<int64_t> decision) {
   TVM_TIR_SCHEDULE_BEGIN();
   return CreateRV(s_tir::SampleCategorical(&this->rand_state_, candidates, probs, &decision));
   TVM_TIR_SCHEDULE_END("sample-categorical", this->error_render_level_);
@@ -247,7 +247,7 @@ ExprRV ConcreteScheduleNode::SampleCategorical(const ffi::Array<Integer>& candid
 
 ffi::Array<ExprRV> ConcreteScheduleNode::SamplePerfectTile(
     const LoopRV& loop_rv, int n, int max_innermost_factor,
-    ffi::Optional<ffi::Array<Integer>> decision) {
+    ffi::Optional<ffi::Array<int64_t>> decision) {
   TVM_TIR_SCHEDULE_BEGIN();
   // use None RV object to denotes auto-infer tile factors.
   return CreateRV(s_tir::SamplePerfectTile(&this->rand_state_, this->GetSRef(loop_rv), n,
@@ -259,7 +259,7 @@ ffi::Array<ExprRV> ConcreteScheduleNode::SamplePerfectTile(
 
 ffi::Array<ExprRV> ConcreteScheduleNode::SamplePartitionedTile(
     const LoopRV& loop_rv, int n, int partition_pos, int innerpart_factor,
-    ffi::Optional<ffi::Array<Integer>> decision) {
+    ffi::Optional<ffi::Array<int64_t>> decision) {
   TVM_TIR_SCHEDULE_BEGIN();
   return CreateRV(s_tir::SamplePartitionedTile(&this->rand_state_, this->GetSRef(loop_rv), n,
                                                partition_pos, innerpart_factor, &decision));
@@ -268,7 +268,7 @@ ffi::Array<ExprRV> ConcreteScheduleNode::SamplePartitionedTile(
 }
 
 LoopRV ConcreteScheduleNode::SampleComputeLocation(const SBlockRV& block_rv,
-                                                   ffi::Optional<Integer> decision) {
+                                                   ffi::Optional<int64_t> decision) {
   TVM_TIR_SCHEDULE_BEGIN();
   return CreateRV<LoopRV>(
       s_tir::SampleComputeLocation(state_, &this->rand_state_, this->GetSRef(block_rv), &decision));
@@ -600,7 +600,7 @@ void ConcreteScheduleNode::Reorder(const ffi::Array<LoopRV>& ordered_loop_rvs) {
 }
 
 void ConcreteScheduleNode::ReorderBlockIterVar(const SBlockRV& block_rv,
-                                               const ffi::Array<Integer> new_order) {
+                                               const ffi::Array<int64_t> new_order) {
   TVM_TIR_SCHEDULE_BEGIN();
   s_tir::ReorderBlockIterVar(state_, GetSRef(block_rv), new_order);
   TVM_TIR_SCHEDULE_END("reorder_block_iter_var", this->error_render_level_);
@@ -1070,7 +1070,7 @@ SBlockRV ConcreteScheduleNode::DecomposePadding(const SBlockRV& block_rv, const 
   return CreateRV<SBlockRV>(result);
 }
 
-void ConcreteScheduleNode::PadEinsum(const SBlockRV& block_rv, const ffi::Array<Integer>& padding) {
+void ConcreteScheduleNode::PadEinsum(const SBlockRV& block_rv, const ffi::Array<int64_t>& padding) {
   TVM_TIR_SCHEDULE_BEGIN();
   s_tir::PadEinsum(state_, this->GetSRef(block_rv), padding);
   TVM_TIR_SCHEDULE_END("pad-einsum", this->error_render_level_);

--- a/src/s_tir/schedule/concrete_schedule.h
+++ b/src/s_tir/schedule/concrete_schedule.h
@@ -86,16 +86,16 @@ class ConcreteScheduleNode : public ScheduleNode {
 
  public:
   /******** Schedule: Sampling ********/
-  ExprRV SampleCategorical(const ffi::Array<Integer>& candidates, const ffi::Array<FloatImm>& probs,
-                           ffi::Optional<Integer> decision = std::nullopt) override;
+  ExprRV SampleCategorical(const ffi::Array<int64_t>& candidates, const ffi::Array<FloatImm>& probs,
+                           ffi::Optional<int64_t> decision = std::nullopt) override;
   ffi::Array<ExprRV> SamplePerfectTile(
       const LoopRV& loop_rv, int n, int max_innermost_factor,
-      ffi::Optional<ffi::Array<Integer>> decision = std::nullopt) override;
+      ffi::Optional<ffi::Array<int64_t>> decision = std::nullopt) override;
   ffi::Array<ExprRV> SamplePartitionedTile(
       const LoopRV& loop_rv, int n, int partition_pos, int innerpart_factor,
-      ffi::Optional<ffi::Array<Integer>> decision = std::nullopt) override;
+      ffi::Optional<ffi::Array<int64_t>> decision = std::nullopt) override;
   LoopRV SampleComputeLocation(const SBlockRV& block_rv,
-                               ffi::Optional<Integer> decision = std::nullopt) override;
+                               ffi::Optional<int64_t> decision = std::nullopt) override;
   /******** Schedule: Get blocks & loops ********/
   SBlockRV GetSBlock(const ffi::String& name, const ffi::Optional<ffi::String>& func_name) override;
   ffi::Array<LoopRV> GetLoops(const SBlockRV& block_rv) override;
@@ -113,7 +113,7 @@ class ConcreteScheduleNode : public ScheduleNode {
                                    const ffi::Array<ffi::Optional<ExprRV>>& factors,
                                    bool preserve_unit_iters) override;
   void Reorder(const ffi::Array<LoopRV>& ordered_loop_rvs) override;
-  void ReorderBlockIterVar(const SBlockRV& block_rv, const ffi::Array<Integer> new_order) override;
+  void ReorderBlockIterVar(const SBlockRV& block_rv, const ffi::Array<int64_t> new_order) override;
   LoopRV AddUnitLoop(const SBlockRV& block_rv) override;
   LoopRV AddUnitLoop(const LoopRV& loop_rv) override;
   /******** Schedule: Manipulate ForKind ********/
@@ -155,7 +155,7 @@ class ConcreteScheduleNode : public ScheduleNode {
   /******** Schedule: Reduction ********/
   SBlockRV RFactor(const LoopRV& loop_rv, int factor_axis) override;
   SBlockRV DecomposeReduction(const SBlockRV& block_rv, const LoopRV& loop_rv) override;
-  void PadEinsum(const SBlockRV& block_rv, const ffi::Array<Integer>& padding) override;
+  void PadEinsum(const SBlockRV& block_rv, const ffi::Array<int64_t>& padding) override;
   /******** Schedule: SBlock annotation ********/
   void StorageAlign(const SBlockRV& block_rv, int buffer_index, int axis, int factor,
                     int offset) override;

--- a/src/s_tir/schedule/instruction_traits.h
+++ b/src/s_tir/schedule/instruction_traits.h
@@ -114,7 +114,7 @@ using namespace tvm::tirx;
  *      LoopRV loop_rv,
  *      Integer n,
  *      Integer max_innermost_factor,
- *      ffi::Optional<ffi::Array<Integer>> decision) {
+ *      ffi::Optional<ffi::Array<int64_t>> decision) {
  *     return sch->SamplePerfectTile(loop_rv, n->value, max_innermost_factor->value, decision);
  *   }
  *
@@ -129,7 +129,7 @@ using namespace tvm::tirx;
  *      ffi::String loop_rv,
  *      Integer n,
  *      Integer max_innermost_factor,
- *      ffi::Optional<ffi::Array<Integer>> decision) {
+ *      ffi::Optional<ffi::Array<int64_t>> decision) {
  *     PythonAPICall py("sample_perfect_tile");
  *     py.Input("loop", loop_rv);
  *     py.Input("n", n->value);

--- a/src/s_tir/schedule/primitive.h
+++ b/src/s_tir/schedule/primitive.h
@@ -56,9 +56,9 @@ std::vector<int32_t> SampleWithoutReplacement(LinearCongruentialEngine::TRandSta
  * \return The random variable sampled from candidates
  */
 TVM_DLL int64_t SampleCategorical(LinearCongruentialEngine::TRandState* rand_state,
-                                  const ffi::Array<Integer>& candidates,
+                                  const ffi::Array<int64_t>& candidates,
                                   const ffi::Array<FloatImm>& probs,
-                                  ffi::Optional<Integer>* decision);
+                                  ffi::Optional<int64_t>* decision);
 /*!
  * \brief Create a sampling function that does multinomial sampling.
  * \param rand_state The random state.
@@ -99,7 +99,7 @@ TVM_DLL std::vector<int64_t> SamplePerfectTile(LinearCongruentialEngine::TRandSt
 TVM_DLL std::vector<int64_t> SamplePerfectTile(LinearCongruentialEngine::TRandState* rand_state,  //
                                                const tirx::StmtSRef& loop_sref, int32_t n_split,
                                                int32_t max_innermost_factor,
-                                               ffi::Optional<ffi::Array<Integer>>* decision);
+                                               ffi::Optional<ffi::Array<int64_t>>* decision);
 /*!
  * \brief Sample the factors to a partitioned tile for a specific loop
  *
@@ -137,7 +137,7 @@ TVM_DLL std::vector<int64_t> SamplePartitionedTile(
 TVM_DLL std::vector<int64_t> SamplePartitionedTile(
     LinearCongruentialEngine::TRandState* rand_state,  //
     const tirx::StmtSRef& loop_sref, int32_t n_split, int32_t partition_pos,
-    int32_t innerpart_factor, ffi::Optional<ffi::Array<Integer>>* decision);
+    int32_t innerpart_factor, ffi::Optional<ffi::Array<int64_t>>* decision);
 /*!
  * \brief Sample a compute-at location of the given block
  * \param self The schedule state
@@ -149,7 +149,7 @@ TVM_DLL std::vector<int64_t> SamplePartitionedTile(
 TVM_DLL tirx::StmtSRef SampleComputeLocation(s_tir::ScheduleState self,
                                              LinearCongruentialEngine::TRandState* rand_state,
                                              const tirx::StmtSRef& block_sref,
-                                             ffi::Optional<Integer>* decision);
+                                             ffi::Optional<int64_t>* decision);
 
 /******** Schedule: Get blocks & loops ********/
 /*!
@@ -277,7 +277,7 @@ TVM_DLL void Reorder(ScheduleState self, const ffi::Array<StmtSRef>& ordered_loo
  * \param new_order The new itervar order.
  */
 TVM_DLL void ReorderBlockIterVar(ScheduleState self, const StmtSRef& block_sref,
-                                 const ffi::Array<Integer>& new_order);
+                                 const ffi::Array<int64_t>& new_order);
 
 /*!
  * \brief Create a new unit loop on top of the specific block or loop.
@@ -702,7 +702,7 @@ TVM_DLL StmtSRef DecomposePadding(ScheduleState self, const StmtSRef& block_sref
  * \param padding The padding for each block iter.
  */
 TVM_DLL void PadEinsum(ScheduleState self, const StmtSRef& block_sref,
-                       const ffi::Array<Integer>& padding);
+                       const ffi::Array<int64_t>& padding);
 /******** Schedule: Buffer transformation ********/
 /*!
  * \brief Compute the target buffer via rolling buffering.

--- a/src/s_tir/schedule/primitive/annotate_buffer_access.cc
+++ b/src/s_tir/schedule/primitive/annotate_buffer_access.cc
@@ -57,21 +57,21 @@ class AnnotateRegionRewriter : public StmtExprMutator {
                                      ? s_tir::attr::explicit_write_region
                                      : s_tir::attr::explicit_read_region;
     if (new_annotations.count(annotation_key)) {
-      ffi::Array<Integer> buffer_indices =
-          Downcast<ffi::Array<Integer>>(new_annotations[annotation_key]);
+      ffi::Array<int64_t> buffer_indices =
+          Downcast<ffi::Array<int64_t>>(new_annotations[annotation_key]);
       bool found = false;
-      for (const Integer& index : buffer_indices) {
-        if (index->value == buffer_index_) {
+      for (int64_t index : buffer_indices) {
+        if (index == buffer_index_) {
           found = true;
           break;
         }
       }
       if (!found) {
-        buffer_indices.push_back(Integer(buffer_index_));
+        buffer_indices.push_back(static_cast<int64_t>(buffer_index_));
         new_annotations.Set(annotation_key, buffer_indices);
       }
     } else {
-      new_annotations.Set(annotation_key, ffi::Array<Integer>{Integer(buffer_index_)});
+      new_annotations.Set(annotation_key, ffi::Array<int64_t>{static_cast<int64_t>(buffer_index_)});
     }
     n->annotations = std::move(new_annotations);
 

--- a/src/s_tir/schedule/primitive/pad_einsum.cc
+++ b/src/s_tir/schedule/primitive/pad_einsum.cc
@@ -69,7 +69,7 @@ ffi::Optional<ffi::Array<Var>> CheckTrivialBufferAccess(const BufferRegion& buff
 /*! \brief The schedule error class when the padding size is invalid. */
 class InvalidPaddingError : public ScheduleError {
  public:
-  InvalidPaddingError(IRModule mod, SBlock block, ffi::Array<Integer> padding)
+  InvalidPaddingError(IRModule mod, SBlock block, ffi::Array<int64_t> padding)
       : mod_(std::move(mod)), block_(std::move(block)), padding_(std::move(padding)) {}
   IRModule mod() const final { return mod_; }
   ffi::Array<ffi::ObjectRef> LocationsOfInterest() const final { return {block_}; }
@@ -83,12 +83,12 @@ class InvalidPaddingError : public ScheduleError {
     return os.str();
   }
 
-  static void Check(const ScheduleState& self, const SBlock& block, ffi::Array<Integer> padding) {
+  static void Check(const ScheduleState& self, const SBlock& block, ffi::Array<int64_t> padding) {
     if (padding.size() != block->iter_vars.size()) {
       throw InvalidPaddingError(self->mod, block, padding);
     }
-    for (const auto& pad : padding) {
-      if (pad->value <= 0) {
+    for (int64_t pad : padding) {
+      if (pad <= 0) {
         throw InvalidPaddingError(self->mod, block, padding);
       }
     }
@@ -97,7 +97,7 @@ class InvalidPaddingError : public ScheduleError {
  private:
   IRModule mod_;
   SBlock block_;
-  ffi::Array<Integer> padding_;
+  ffi::Array<int64_t> padding_;
 };
 
 /*! \brief The schedule error class when the block body is not an Einsum pattern. */
@@ -374,7 +374,7 @@ class PadEinsumBufferReplacer : public StmtExprMutator {
   ffi::Map<SBlock, SBlock> block_sref_reuse_;
 };
 
-void PadEinsum(ScheduleState self, const StmtSRef& block_sref, const ffi::Array<Integer>& padding) {
+void PadEinsum(ScheduleState self, const StmtSRef& block_sref, const ffi::Array<int64_t>& padding) {
   arith::Analyzer analyzer;
   // Step 1: Input checking and error handling
   const SBlockNode* block = TVM_SREF_TO_SBLOCK(block_sref);
@@ -389,7 +389,8 @@ void PadEinsum(ScheduleState self, const StmtSRef& block_sref, const ffi::Array<
   for (int i = 0, n = padding.size(); i < n; ++i) {
     const IterVar& iter = block->iter_vars[i];
     PrimExpr dom = iter->dom->extent;
-    PrimExpr new_dom = analyzer.Simplify(ceildiv(dom, padding[i]) * padding[i]);
+    PrimExpr new_dom = analyzer.Simplify(ceildiv(dom, IntImm(DataType::Int(64), padding[i])) *
+                                         IntImm(DataType::Int(64), padding[i]));
     if (!analyzer.CanProveEqual(new_dom, dom)) {
       replacer.iter2padded_extents.Set(iter->var, new_dom);
       if (const auto* loop_var = realize->iter_values[i].as<VarNode>()) {
@@ -495,12 +496,12 @@ struct PadEinsumTraits : public UnpackedInstTraits<PadEinsumTraits> {
   static constexpr size_t kNumAttrs = 1;
   static constexpr size_t kNumDecisions = 0;
 
-  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block, ffi::Array<Integer> padding) {
+  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block, ffi::Array<int64_t> padding) {
     sch->PadEinsum(block, padding);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
-                                      ffi::Array<Integer> padding) {
+                                      ffi::Array<int64_t> padding) {
     PythonAPICall py("pad_einsum");
     py.Input("block", block);
     py.Input("padding", padding);

--- a/src/s_tir/schedule/primitive/pad_einsum.cc
+++ b/src/s_tir/schedule/primitive/pad_einsum.cc
@@ -389,8 +389,8 @@ void PadEinsum(ScheduleState self, const StmtSRef& block_sref, const ffi::Array<
   for (int i = 0, n = padding.size(); i < n; ++i) {
     const IterVar& iter = block->iter_vars[i];
     PrimExpr dom = iter->dom->extent;
-    PrimExpr new_dom = analyzer.Simplify(ceildiv(dom, IntImm(DataType::Int(64), padding[i])) *
-                                         IntImm(DataType::Int(64), padding[i]));
+    PrimExpr pad_imm = IntImm(dom->dtype, padding[i]);
+    PrimExpr new_dom = analyzer.Simplify(ceildiv(dom, pad_imm) * pad_imm);
     if (!analyzer.CanProveEqual(new_dom, dom)) {
       replacer.iter2padded_extents.Set(iter->var, new_dom);
       if (const auto* loop_var = realize->iter_values[i].as<VarNode>()) {

--- a/src/s_tir/schedule/primitive/reorder_block_iter_var.cc
+++ b/src/s_tir/schedule/primitive/reorder_block_iter_var.cc
@@ -32,7 +32,7 @@ using namespace tvm::tirx;
  */
 class InvalidReorderIndex : public ScheduleError {
  public:
-  explicit InvalidReorderIndex(IRModule mod, SBlock block, ffi::Array<Integer> new_order)
+  explicit InvalidReorderIndex(IRModule mod, SBlock block, ffi::Array<int64_t> new_order)
       : mod_(mod), block_(block), new_order_(new_order) {}
   IRModule mod() const final { return mod_; }
   ffi::String FastErrorString() const final {
@@ -49,7 +49,7 @@ class InvalidReorderIndex : public ScheduleError {
  private:
   IRModule mod_;
   SBlock block_;
-  ffi::Array<Integer> new_order_;
+  ffi::Array<int64_t> new_order_;
 };
 
 class BlockIterVarRewriter : public StmtMutator {
@@ -85,7 +85,7 @@ class BlockIterVarRewriter : public StmtMutator {
 };
 
 void ReorderBlockIterVar(ScheduleState self, const StmtSRef& block_sref,
-                         const ffi::Array<Integer>& new_order) {
+                         const ffi::Array<int64_t>& new_order) {
   const SBlockNode* block_n = TVM_SREF_TO_SBLOCK(block_sref);
   std::vector<int> new_order_vec;
   for (const Integer& x : new_order) {
@@ -132,12 +132,12 @@ struct ReorderBlockIterVarTraits : public UnpackedInstTraits<ReorderBlockIterVar
   static constexpr size_t kNumAttrs = 0;
   static constexpr size_t kNumDecisions = 0;
 
-  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block, ffi::Array<Integer> new_order) {
+  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block, ffi::Array<int64_t> new_order) {
     sch->ReorderBlockIterVar(block, new_order);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
-                                      ffi::Array<Integer> new_order) {
+                                      ffi::Array<int64_t> new_order) {
     PythonAPICall py("reorder_block_iter_var");
     py.Input("block", block);
     py.Input("new_order", new_order);

--- a/src/s_tir/schedule/primitive/sampling.cc
+++ b/src/s_tir/schedule/primitive/sampling.cc
@@ -164,14 +164,14 @@ std::vector<int32_t> SampleWithoutReplacement(LinearCongruentialEngine::TRandSta
 }
 
 int64_t SampleCategorical(LinearCongruentialEngine::TRandState* rand_state,
-                          const ffi::Array<Integer>& candidates, const ffi::Array<FloatImm>& probs,
-                          ffi::Optional<Integer>* decision) {
+                          const ffi::Array<int64_t>& candidates, const ffi::Array<FloatImm>& probs,
+                          ffi::Optional<int64_t>* decision) {
   TVM_FFI_CHECK(candidates.size() == probs.size(), ValueError)
       << "number of candidates does not match number of probabilities.";
   int32_t i = -1;
   int32_t n = candidates.size();
-  if (decision->defined()) {
-    i = decision->value()->value;
+  if (decision->has_value()) {
+    i = static_cast<int32_t>(decision->value());
     TVM_FFI_CHECK(0 <= i && i < n, ValueError)
         << "Wrong decision value, where n = " << n << ", but decision is: " << i;
   } else {
@@ -183,8 +183,8 @@ int64_t SampleCategorical(LinearCongruentialEngine::TRandState* rand_state,
         << "Unexpected decision generated, where n = " << n << ", but decision is: " << i;
   }
 
-  *decision = Integer(i);  // decision is guaranteed not to be nullptr.
-  return candidates[i]->value;
+  *decision = static_cast<int64_t>(i);  // decision is guaranteed not to be nullptr.
+  return candidates[i];
 }
 
 std::function<int32_t()> MakeMultinomialSampler(LinearCongruentialEngine::TRandState* rand_state,
@@ -310,7 +310,7 @@ std::vector<int64_t> SamplePerfectTile(LinearCongruentialEngine::TRandState* ran
 std::vector<int64_t> SamplePerfectTile(LinearCongruentialEngine::TRandState* rand_state,  //
                                        const tirx::StmtSRef& loop_sref, int32_t n_splits,
                                        int32_t max_innermost_factor,
-                                       ffi::Optional<ffi::Array<Integer>>* decision) {
+                                       ffi::Optional<ffi::Array<int64_t>>* decision) {
   const ForNode* loop = TVM_SREF_TO_FOR(loop_sref);
   const int64_t* extent = GetLoopIntExtent(loop);
   std::vector<int64_t> result;
@@ -318,9 +318,9 @@ std::vector<int64_t> SamplePerfectTile(LinearCongruentialEngine::TRandState* ran
     // Case 1. Handle loops with non-constant length
     result = std::vector<int64_t>(n_splits, 1);
     result[0] = -1;
-  } else if (decision->defined()) {
+  } else if (decision->has_value()) {
     // Case 2. Use previous decision
-    result = support::AsVector<Integer, int64_t>(decision->value());
+    result = std::vector<int64_t>(decision->value().begin(), decision->value().end());
     int n = result.size();
     TVM_FFI_ICHECK_GE(n, 2);
     int64_t len = *extent;
@@ -342,7 +342,7 @@ std::vector<int64_t> SamplePerfectTile(LinearCongruentialEngine::TRandState* ran
       TVM_FFI_ICHECK_LE(result.back(), max_innermost_factor);
     }
   }
-  *decision = support::AsArray<int64_t, Integer>(result);
+  *decision = ffi::Array<int64_t>(result.begin(), result.end());
   return result;
 }
 
@@ -371,7 +371,7 @@ TVM_DLL std::vector<int64_t> SamplePartitionedTile(
 std::vector<int64_t> SamplePartitionedTile(LinearCongruentialEngine::TRandState* rand_state,  //
                                            const tirx::StmtSRef& loop_sref, int32_t n_splits,
                                            int32_t partition_pos, int32_t innerpart_factor,
-                                           ffi::Optional<ffi::Array<Integer>>* decision) {
+                                           ffi::Optional<ffi::Array<int64_t>>* decision) {
   const ForNode* loop = TVM_SREF_TO_FOR(loop_sref);
   const int64_t* extent = GetLoopIntExtent(loop);
   std::vector<int64_t> result;
@@ -379,9 +379,9 @@ std::vector<int64_t> SamplePartitionedTile(LinearCongruentialEngine::TRandState*
     // Case 1. Handle loops with non-constant length or non-divisible innerpart_factor
     result = std::vector<int64_t>(n_splits, 1);
     result[0] = -1;
-  } else if (decision->defined()) {
+  } else if (decision->has_value()) {
     // Case 2. Use previous decision
-    result = support::AsVector<Integer, int64_t>(decision->value());
+    result = std::vector<int64_t>(decision->value().begin(), decision->value().end());
     int n = result.size();
     TVM_FFI_ICHECK_GE(n, 2);
     int innerpart_prod = 1;
@@ -414,13 +414,13 @@ std::vector<int64_t> SamplePartitionedTile(LinearCongruentialEngine::TRandState*
     // Case 3. Use fresh new sampling result
     result = SamplePartitionedTile(rand_state, *extent, n_splits, partition_pos, innerpart_factor);
   }
-  *decision = support::AsArray<int64_t, Integer>(result);
+  *decision = ffi::Array<int64_t>(result.begin(), result.end());
   return result;
 }
 
 tirx::StmtSRef SampleComputeLocation(s_tir::ScheduleState self,
                                      LinearCongruentialEngine::TRandState* rand_state,
-                                     const StmtSRef& block_sref, ffi::Optional<Integer>* decision) {
+                                     const StmtSRef& block_sref, ffi::Optional<int64_t>* decision) {
   // Step 1. Collect all possible compute-at locations.
   auto [location_srefs, location_indices] = CollectComputeLocation(self, block_sref);
   TVM_FFI_ICHECK_EQ(location_srefs.size(), location_indices.size());
@@ -428,24 +428,24 @@ tirx::StmtSRef SampleComputeLocation(s_tir::ScheduleState self,
   // Step 2. If there was a previous decision, keep the decision unchanged if it exists in the
   // location candidates. Otherwise, pick the location before the previous decision.
   // Step 3. If there was not a previous decision, sample a decision from the collected locations.
-  if (decision->defined()) {
-    int64_t old_decision = Downcast<Integer>(*decision)->value;
+  if (decision->has_value()) {
+    int64_t old_decision = decision->value();
     auto it = std::lower_bound(location_indices.begin(), location_indices.end(), old_decision);
     int idx = it - location_indices.begin();
 
     if (it != location_indices.end() && *it == old_decision) {
-      *decision = Integer(old_decision);
+      *decision = old_decision;
       return location_srefs[idx];
     } else if (it != location_indices.begin()) {
-      *decision = Integer(location_indices[idx - 1]);
+      *decision = static_cast<int64_t>(location_indices[idx - 1]);
       return location_srefs[idx - 1];
     } else {
-      *decision = Integer(-1);
+      *decision = static_cast<int64_t>(-1);
       return StmtSRef::RootMark();
     }
   } else {
     int sampled_idx = SampleInt(rand_state, 0, location_indices.size());
-    *decision = Integer(location_indices[sampled_idx]);
+    *decision = static_cast<int64_t>(location_indices[sampled_idx]);
     return location_srefs[sampled_idx];
   }
 }
@@ -462,16 +462,16 @@ struct SampleCategoricalTraits : public UnpackedInstTraits<SampleCategoricalTrai
   static constexpr size_t kNumDecisions = 1;
 
   static ExprRV UnpackedApplyToSchedule(Schedule sch,                    //
-                                        ffi::Array<Integer> candidates,  //
+                                        ffi::Array<int64_t> candidates,  //
                                         ffi::Array<FloatImm> probs,      //
-                                        ffi::Optional<Integer> decision) {
+                                        ffi::Optional<int64_t> decision) {
     return sch->SampleCategorical(candidates, probs, decision);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs,  //
-                                      ffi::Array<Integer> candidates,   //
+                                      ffi::Array<int64_t> candidates,   //
                                       ffi::Array<FloatImm> probs,       //
-                                      ffi::Optional<Integer> decision) {
+                                      ffi::Optional<int64_t> decision) {
     PythonAPICall py("sample_categorical");
     py.Input("candidates", candidates);
     py.Input("probs", probs);
@@ -495,13 +495,13 @@ struct SamplePerfectTileTraits : public UnpackedInstTraits<SamplePerfectTileTrai
 
   static ffi::Array<ExprRV> UnpackedApplyToSchedule(Schedule sch, LoopRV loop_rv, Integer n,
                                                     Integer max_innermost_factor,
-                                                    ffi::Optional<ffi::Array<Integer>> decision) {
+                                                    ffi::Optional<ffi::Array<int64_t>> decision) {
     return sch->SamplePerfectTile(loop_rv, n->value, max_innermost_factor->value, decision);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String loop_rv,
                                       Integer n, Integer max_innermost_factor,
-                                      ffi::Optional<ffi::Array<Integer>> decision) {
+                                      ffi::Optional<ffi::Array<int64_t>> decision) {
     PythonAPICall py("sample_perfect_tile");
     py.Input("loop", loop_rv);
     py.Input("n", n->value);
@@ -526,14 +526,14 @@ struct SamplePartitionedTileTraits : public UnpackedInstTraits<SamplePartitioned
 
   static ffi::Array<ExprRV> UnpackedApplyToSchedule(Schedule sch, LoopRV loop_rv, Integer n,
                                                     Integer partition_pos, Integer innerpart_factor,
-                                                    ffi::Optional<ffi::Array<Integer>> decision) {
+                                                    ffi::Optional<ffi::Array<int64_t>> decision) {
     return sch->SamplePartitionedTile(loop_rv, n->value, partition_pos->value,
                                       innerpart_factor->value, decision);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String loop_rv,
                                       Integer n, Integer partition_pos, Integer innerpart_factor,
-                                      ffi::Optional<ffi::Array<Integer>> decision) {
+                                      ffi::Optional<ffi::Array<int64_t>> decision) {
     PythonAPICall py("sample_partitioned_tile");
     py.Input("loop", loop_rv);
     py.Input("n", n->value);
@@ -559,13 +559,13 @@ struct SampleComputeLocationTraits : public UnpackedInstTraits<SampleComputeLoca
 
   static LoopRV UnpackedApplyToSchedule(Schedule sch,       //
                                         SBlockRV block_rv,  //
-                                        ffi::Optional<Integer> decision) {
+                                        ffi::Optional<int64_t> decision) {
     return sch->SampleComputeLocation(block_rv, decision);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs,  //
                                       ffi::String block_rv,             //
-                                      ffi::Optional<Integer> decision) {
+                                      ffi::Optional<int64_t> decision) {
     PythonAPICall py("sample_compute_location");
     py.Input("block", block_rv);
     py.Decision(decision);

--- a/src/s_tir/schedule/trace.cc
+++ b/src/s_tir/schedule/trace.cc
@@ -226,6 +226,54 @@ ffi::Array<Any> TranslateInputRVs(
   return results;
 }
 
+/**************** NormalizeJSONIntegers  ****************/
+
+/*!
+ * \brief Normalize integer-typed values inside an Any soup produced by JSON
+ *        deserialization so it matches the post-Integer-phaseout trait signatures.
+ *
+ * After the phase-out of `class Integer`, several schedule-instruction trait
+ * signatures expect bare `int64_t` / `Array<int64_t>` / `Optional<int64_t>` /
+ * `Optional<Array<int64_t>>` for sample-instruction attrs and decisions (e.g.
+ * `SampleCategorical::candidates`, `SamplePerfectTile::decision`). The FFI
+ * layer can unbox a top-level `IntImm` Any into `int64_t` via the
+ * `IntImm` <-> `int64_t` fallback, but it does NOT recursively unbox
+ * `Array<IntImm>` into `Array<int64_t>`. JSON deserialization that came in
+ * with `IntImm` leaves (e.g. produced by `Trace::AsJSON` over an in-memory
+ * `Array<IntImm>`) therefore fails dispatch.
+ *
+ * This helper recursively walks `value`, replacing every `IntImm` it sees
+ * with the equivalent `int64_t`. Recursion descends into `Array<Any>` but
+ * stops at any object that isn't `IntImm` or `Array<Any>` (e.g. `FloatImm`,
+ * `IndexMap`, RVs, strings stay as-is). The reverse `int64_t -> IntImm`
+ * conversion (where a trait still wants `Integer` / `IntImm`) is handled
+ * automatically by the FFI fallback in `TypeTraits<IntImm>`.
+ */
+Any NormalizeJSONIntegers(const Any& value) {
+  if (auto opt_int = value.try_cast<IntImm>()) {
+    return opt_int.value()->value;
+  }
+  if (auto opt_arr = value.try_cast<ffi::Array<Any>>()) {
+    const ffi::Array<Any>& arr = opt_arr.value();
+    ffi::Array<Any> result;
+    result.reserve(arr.size());
+    for (const Any& elem : arr) {
+      result.push_back(NormalizeJSONIntegers(elem));
+    }
+    return result;
+  }
+  return value;
+}
+
+ffi::Array<Any> NormalizeJSONIntegers(const ffi::Array<Any>& values) {
+  ffi::Array<Any> result;
+  result.reserve(values.size());
+  for (const Any& value : values) {
+    result.push_back(NormalizeJSONIntegers(value));
+  }
+  return result;
+}
+
 /**************** TranslateAddOutputRVs  ****************/
 
 void TranslateAddOutputRVs(const ffi::Array<Any>& old_outputs, const ffi::Array<Any>& new_outputs,
@@ -351,10 +399,14 @@ ffi::ObjectRef TraceNode::AsJSON(bool remove_postproc) const {
                                                             : ffi::ObjectRef(inst->attrs),
         /* 3: outputs   */ TranslateAddOutputRVs(inst->outputs, &rv_names),
     });
-    if (auto decision = this->GetDecision(inst).cast<ffi::Optional<ffi::ObjectRef>>()) {
-      json_decisions.push_back(ffi::Array<ffi::ObjectRef>{
+    // Decisions may now hold POD types (e.g. int64_t for SampleCategorical /
+    // SampleComputeLocation, or Array<int64_t> for SamplePerfectTile) after
+    // the Integer phase-out. Treat them uniformly as Any.
+    Any decision = this->GetDecision(inst);
+    if (decision != nullptr) {
+      json_decisions.push_back(ffi::Array<ffi::Any>{
           /* 0: index    */ Integer(i),
-          /* 1: decision */ decision.value(),
+          /* 1: decision */ decision,
       });
     }
     ++i;
@@ -420,7 +472,9 @@ void Trace::ApplyJSONToSchedule(ffi::ObjectRef json, Schedule sch) {
       auto arr0 = arr->at(0).try_cast<IntImm>();
       TVM_FFI_ICHECK(arr0);
       index = arr0.value()->value;
-      decision = arr->at(1);
+      // Unbox any IntImm into int64_t so decisions whose trait expects
+      // Optional<int64_t> or Optional<Array<int64_t>> dispatch correctly.
+      decision = NormalizeJSONIntegers(arr->at(1));
     } catch (const tvm::ffi::Error& e) {
       TVM_FFI_THROW(ValueError) << "Each entry of a json decision should be a tuple [index, "
                                    "decision], but gets: "
@@ -457,6 +511,12 @@ void Trace::ApplyJSONToSchedule(ffi::ObjectRef json, Schedule sch) {
     // Parse attrs
     if (kind->f_attrs_from_json != nullptr) {
       attrs = kind->f_attrs_from_json(attrs);
+    } else {
+      // Unbox any IntImm into int64_t so attrs whose trait expects
+      // Array<int64_t> (e.g. SampleCategorical::candidates) dispatch
+      // correctly. The reverse int64_t -> IntImm conversion is handled
+      // automatically by the FFI fallback in TypeTraits<IntImm>.
+      attrs = NormalizeJSONIntegers(attrs);
     }
     // Apply to the schedule
     ffi::Array<Any> new_outputs = kind->f_apply_to_schedule(sch, inputs, attrs, decisions[i]);

--- a/src/s_tir/schedule/traced_schedule.cc
+++ b/src/s_tir/schedule/traced_schedule.cc
@@ -53,9 +53,9 @@ Schedule TracedScheduleNode::Copy() {
 
 /******** Schedule: Sampling ********/
 
-ExprRV TracedScheduleNode::SampleCategorical(const ffi::Array<Integer>& candidates,
+ExprRV TracedScheduleNode::SampleCategorical(const ffi::Array<int64_t>& candidates,
                                              const ffi::Array<FloatImm>& probs,
-                                             ffi::Optional<Integer> decision) {
+                                             ffi::Optional<int64_t> decision) {
   ExprRV result =
       CreateRV(::tvm::s_tir::SampleCategorical(&this->rand_state_, candidates, probs, &decision));
   static const InstructionKind& kind = InstructionKind::Get("SampleCategorical");
@@ -69,7 +69,7 @@ ExprRV TracedScheduleNode::SampleCategorical(const ffi::Array<Integer>& candidat
 
 ffi::Array<ExprRV> TracedScheduleNode::SamplePerfectTile(
     const LoopRV& loop_rv, int n, int max_innermost_factor,
-    ffi::Optional<ffi::Array<Integer>> decision) {
+    ffi::Optional<ffi::Array<int64_t>> decision) {
   // use None RV object to denotes auto-infer tile factors.
   ffi::Array<ExprRV> results =
       CreateRV(::tvm::s_tir::SamplePerfectTile(&this->rand_state_, this->GetSRef(loop_rv), n,
@@ -86,7 +86,7 @@ ffi::Array<ExprRV> TracedScheduleNode::SamplePerfectTile(
 
 ffi::Array<ExprRV> TracedScheduleNode::SamplePartitionedTile(
     const LoopRV& loop_rv, int n, int partition_pos, int innerpart_factor,
-    ffi::Optional<ffi::Array<Integer>> decision) {
+    ffi::Optional<ffi::Array<int64_t>> decision) {
   ffi::Array<ExprRV> results = CreateRV(::tvm::s_tir::SamplePartitionedTile(
       &this->rand_state_, this->GetSRef(loop_rv), n, partition_pos, innerpart_factor, &decision));
 
@@ -101,7 +101,7 @@ ffi::Array<ExprRV> TracedScheduleNode::SamplePartitionedTile(
 }
 
 LoopRV TracedScheduleNode::SampleComputeLocation(const SBlockRV& block_rv,
-                                                 ffi::Optional<Integer> decision) {
+                                                 ffi::Optional<int64_t> decision) {
   LoopRV result = CreateRV<LoopRV>(::tvm::s_tir::SampleComputeLocation(
       this->state_, &this->rand_state_, this->GetSRef(block_rv), &decision));
 
@@ -282,7 +282,7 @@ void TracedScheduleNode::Reorder(const ffi::Array<LoopRV>& ordered_loop_rvs) {
 }
 
 void TracedScheduleNode::ReorderBlockIterVar(const SBlockRV& block_rv,
-                                             const ffi::Array<Integer> new_order) {
+                                             const ffi::Array<int64_t> new_order) {
   ConcreteScheduleNode::ReorderBlockIterVar(block_rv, new_order);
   static const InstructionKind& kind = InstructionKind::Get("ReorderBlockIterVar");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
@@ -744,7 +744,7 @@ SBlockRV TracedScheduleNode::DecomposePadding(const SBlockRV& block_rv, const Lo
   return new_block;
 }
 
-void TracedScheduleNode::PadEinsum(const SBlockRV& block_rv, const ffi::Array<Integer>& padding) {
+void TracedScheduleNode::PadEinsum(const SBlockRV& block_rv, const ffi::Array<int64_t>& padding) {
   ConcreteScheduleNode::PadEinsum(block_rv, padding);
   static const InstructionKind& kind = InstructionKind::Get("PadEinsum");
   trace_->Append(/*inst=*/Instruction(

--- a/src/s_tir/schedule/traced_schedule.h
+++ b/src/s_tir/schedule/traced_schedule.h
@@ -45,16 +45,16 @@ class TracedScheduleNode : public ConcreteScheduleNode {
 
  public:
   /******** Schedule: Sampling ********/
-  ExprRV SampleCategorical(const ffi::Array<Integer>& candidates, const ffi::Array<FloatImm>& probs,
-                           ffi::Optional<Integer> decision = std::nullopt) final;
+  ExprRV SampleCategorical(const ffi::Array<int64_t>& candidates, const ffi::Array<FloatImm>& probs,
+                           ffi::Optional<int64_t> decision = std::nullopt) final;
   ffi::Array<ExprRV> SamplePerfectTile(
       const LoopRV& loop_rv, int n, int max_innermost_factor,
-      ffi::Optional<ffi::Array<Integer>> decision = std::nullopt) final;
+      ffi::Optional<ffi::Array<int64_t>> decision = std::nullopt) final;
   ffi::Array<ExprRV> SamplePartitionedTile(
       const LoopRV& loop_rv, int n, int partition_pos, int innerpart_factor,
-      ffi::Optional<ffi::Array<Integer>> decision = std::nullopt) final;
+      ffi::Optional<ffi::Array<int64_t>> decision = std::nullopt) final;
   LoopRV SampleComputeLocation(const SBlockRV& block_rv,
-                               ffi::Optional<Integer> decision = std::nullopt) final;
+                               ffi::Optional<int64_t> decision = std::nullopt) final;
   /******** Schedule: Get blocks & loops ********/
   SBlockRV GetSBlock(const ffi::String& name, const ffi::Optional<ffi::String>& func_name) final;
   ffi::Array<LoopRV> GetLoops(const SBlockRV& block_rv) final;
@@ -73,7 +73,7 @@ class TracedScheduleNode : public ConcreteScheduleNode {
                                    const ffi::Array<ffi::Optional<ExprRV>>& factor_rvs,
                                    bool preserve_unit_iters) final;
   void Reorder(const ffi::Array<LoopRV>& ordered_loop_rvs) final;
-  void ReorderBlockIterVar(const SBlockRV& block_rv, const ffi::Array<Integer> new_order) final;
+  void ReorderBlockIterVar(const SBlockRV& block_rv, const ffi::Array<int64_t> new_order) final;
   LoopRV AddUnitLoop(const SBlockRV& block_rv) final;
   LoopRV AddUnitLoop(const LoopRV& loop_rv) final;
   /******** Schedule: Manipulate ForKind ********/
@@ -141,7 +141,7 @@ class TracedScheduleNode : public ConcreteScheduleNode {
                         const ffi::Array<IntImm>& axis_separators) final;
   /******** Schedule: Padding ********/
   SBlockRV DecomposePadding(const SBlockRV& block_rv, const LoopRV& loop_rv) final;
-  void PadEinsum(const SBlockRV& block_rv, const ffi::Array<Integer>& padding) final;
+  void PadEinsum(const SBlockRV& block_rv, const ffi::Array<int64_t>& padding) final;
   /******** Schedule: Buffer transformation ********/
   void RollingBuffer(const SBlockRV& block_rv, int write_buffer_index) final;
   /******** Schedule: Misc ********/

--- a/src/s_tir/schedule/transform.cc
+++ b/src/s_tir/schedule/transform.cc
@@ -411,7 +411,8 @@ ffi::Optional<LoopRV> TileWithTensorIntrin(const s_tir::Schedule& sch,
     TVM_FFI_ICHECK_EQ(split.size(), 2);
     inner_loops.insert(sch->GetSRef(split[1]).operator->());
     // The inner split will be reordered to the loop domain that is tensorized
-    int desc_loop_index = info->desc_loop_indexer.at(ffi::GetRef<tirx::For>(desc_loop)).IntValue();
+    int desc_loop_index =
+        static_cast<int>(info->desc_loop_indexer.at(ffi::GetRef<tirx::For>(desc_loop)));
     reorder_suffix[desc_loop_index] = split[1];
   }
   // Reorder the loops

--- a/src/s_tir/schedule/utils.h
+++ b/src/s_tir/schedule/utils.h
@@ -261,7 +261,7 @@ inline ffi::Optional<TObjectRef> GetAnn(const TStmtNode* stmt, const ffi::String
   const ffi::Map<ffi::String, ffi::Any>* annotations = &stmt->annotations;
   for (const auto& ann : *annotations) {
     if (ann.first == ann_key) {
-      return Downcast<TObjectRef>(ann.second);
+      return ann.second.cast<TObjectRef>();
     }
   }
   return std::nullopt;
@@ -306,8 +306,8 @@ inline bool HasAnn(const StmtSRef& sref, const ffi::String& ann_key, const ffi::
  * \return Whether a Block/For has a specific pair of annotation key and values
  */
 inline bool HasAnn(const StmtSRef& sref, const ffi::String& ann_key, bool ann_val) {
-  ffi::Optional<Bool> result = GetAnn<Bool>(sref, ann_key);
-  return result.defined() && result.value() == ann_val;
+  ffi::Optional<bool> result = GetAnn<bool>(sref, ann_key);
+  return result.has_value() && result.value() == ann_val;
 }
 
 /********** Helper Functions for RuleAddRFactor and RuleCrossThreadReduction **********/

--- a/src/s_tir/support/array_utils.h
+++ b/src/s_tir/support/array_utils.h
@@ -116,11 +116,11 @@ inline ffi::Array<T> AsArray(const std::list<T>& list) {
  * \param shape The shape tuple
  * \return An array of the shape tuple
  */
-inline ffi::Array<Integer> AsArray(const ffi::Shape& shape) {
-  ffi::Array<Integer> result;
+inline ffi::Array<int64_t> AsArray(const ffi::Shape& shape) {
+  ffi::Array<int64_t> result;
   result.reserve(shape->size);
   for (ffi::Shape::index_type i : shape) {
-    result.push_back(Integer(i));
+    result.push_back(i);
   }
   return result;
 }

--- a/src/s_tir/transform/compact_buffer_region.cc
+++ b/src/s_tir/transform/compact_buffer_region.cc
@@ -256,9 +256,9 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
     auto record_explicit_region = [&](const ffi::String& attr_key, BufferIndexType index_type) {
       auto it = op->annotations.find(attr_key);
       if (it != op->annotations.end()) {
-        ffi::Array<Integer> buffer_indices = Downcast<ffi::Array<Integer>>((*it).second);
-        for (const auto& index : buffer_indices) {
-          int buffer_index = index->value;
+        ffi::Array<int64_t> buffer_indices = Downcast<ffi::Array<int64_t>>((*it).second);
+        for (int64_t index : buffer_indices) {
+          int buffer_index = static_cast<int>(index);
           if (buffer_index >= 0 && buffer_index < static_cast<int>(op->reads.size())) {
             const BufferRegion& explicit_region = index_type == BufferIndexType::kRead
                                                       ? op->reads[buffer_index]

--- a/src/s_tir/transform/default_gpu_schedule.cc
+++ b/src/s_tir/transform/default_gpu_schedule.cc
@@ -212,11 +212,11 @@ Pass DefaultGPUSchedule() {
                 << "The target is missing either in the current context or in "
                    "the prim_func's attribute.";
             // get the max thread per block from target.
-            ffi::Optional<Integer> opt_max_thread_per_block =
-                target->GetAttr<Integer>("max_num_threads");
-            TVM_FFI_ICHECK(opt_max_thread_per_block.defined())
+            ffi::Optional<int64_t> opt_max_thread_per_block =
+                target->GetAttr<int64_t>("max_num_threads");
+            TVM_FFI_ICHECK(opt_max_thread_per_block.has_value())
                 << "max_num_threads is not set for target " << target;
-            int64_t max_thread_per_block = opt_max_thread_per_block.value().IntValue();
+            int64_t max_thread_per_block = opt_max_thread_per_block.value();
 
             sch->WorkOn(gv->name_hint);
             ffi::Array<s_tir::SBlockRV> blocks =

--- a/src/s_tir/transform/hoist_expression.cc
+++ b/src/s_tir/transform/hoist_expression.cc
@@ -593,8 +593,8 @@ static Pass HoistIfThenElseImpl() {
   auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
     auto* n = f.CopyOnWrite();
     auto cfg = ctx->GetConfig<HoistIfThenElseConfig>("s_tir.HoistIfThenElse");
-    auto flag = f->GetAttr<Integer>("tirx.HoistIfThenElseExprWithBlock");
-    if (flag && flag.value().IntValue() == 1) {
+    auto flag = f->GetAttr<int64_t>("tirx.HoistIfThenElseExprWithBlock");
+    if (flag && flag.value() == 1) {
       HoistExpressionConfig config(static_cast<int>(HoistedConditionals::kUsingBlockVar) |
                                        static_cast<int>(HoistedConditionals::kIfElseExpr),
                                    static_cast<int>(HoistedLetBindings::kNone));

--- a/src/s_tir/transform/inject_software_pipeline.cc
+++ b/src/s_tir/transform/inject_software_pipeline.cc
@@ -1141,9 +1141,9 @@ class PipelineInjector : private StmtExprMutator {
     }
 
     auto pipeline_stages =
-        Downcast<ffi::Array<Integer>>(op->annotations.at(s_tir::attr::software_pipeline_stage));
+        Downcast<ffi::Array<int64_t>>(op->annotations.at(s_tir::attr::software_pipeline_stage));
     auto pipeline_orders =
-        Downcast<ffi::Array<Integer>>(op->annotations.at(s_tir::attr::software_pipeline_order));
+        Downcast<ffi::Array<int64_t>>(op->annotations.at(s_tir::attr::software_pipeline_order));
     TVM_FFI_ICHECK_EQ(pipeline_stages.size(), original_order.size())
         << "PrimFunc " << global_symbol_ << " has original order "
         << original_order.Map([](const auto& block) { return block->name_hint; })
@@ -1155,8 +1155,8 @@ class PipelineInjector : private StmtExprMutator {
 
     std::unordered_set<int> pipeline_async_stages;
     if (auto annot = op->annotations.Get(s_tir::attr::software_pipeline_async_stages)) {
-      for (auto s : Downcast<ffi::Array<Integer>>(annot.value())) {
-        pipeline_async_stages.insert(s->value);
+      for (int64_t s : Downcast<ffi::Array<int64_t>>(annot.value())) {
+        pipeline_async_stages.insert(static_cast<int>(s));
       }
     }
 
@@ -1171,11 +1171,10 @@ class PipelineInjector : private StmtExprMutator {
     }
 
     for (size_t i = 0; i < pipeline_stages.size(); i++) {
-      int stage = static_cast<int>(pipeline_stages[i]->value);
+      int stage = static_cast<int>(pipeline_stages[i]);
       bool is_async = pipeline_async_stages.find(stage) != pipeline_async_stages.end();
       PipelineAnnotation stage_order{stage,
-                                     /*order=*/static_cast<int>(pipeline_orders[i]->value),
-                                     is_async};
+                                     /*order=*/static_cast<int>(pipeline_orders[i]), is_async};
       pipeline_info.emplace(original_order[i], stage_order);
     }
 

--- a/src/s_tir/transform/lower_async_dma.cc
+++ b/src/s_tir/transform/lower_async_dma.cc
@@ -175,7 +175,7 @@ Pass LowerAsyncDMA() {
     auto fptr = f.CopyOnWrite();
     arith::Analyzer analyzer;
     bool dma_bypass_cache =
-        ctx->GetConfig<Bool>("tirx.experimental_dma_bypass_cache", Bool(false)).value();
+        ctx->GetConfig<bool>("tirx.experimental_dma_bypass_cache", false).value();
     fptr->body = AsyncDMALowerer(dma_bypass_cache, &analyzer)(std::move(fptr->body));
     return f;
   };

--- a/src/s_tir/transform/lower_thread_allreduce.cc
+++ b/src/s_tir/transform/lower_thread_allreduce.cc
@@ -102,7 +102,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
     cow->buffer = replacement;
     if (replacement.scope() == "shared") {
       auto annotations = cow->annotations;
-      annotations.Set(tirx::attr::kVolatile, Bool(true));
+      annotations.Set(tirx::attr::kVolatile, true);
       cow->annotations = annotations;
     }
     return node;
@@ -864,7 +864,7 @@ class DeferredRemapper : public StmtExprMutator {
         cow->buffer = replacement;
         if (replacement.scope() == "shared") {
           auto annotations = cow->annotations;
-          annotations.Set(tirx::attr::kVolatile, Bool(true));
+          annotations.Set(tirx::attr::kVolatile, true);
           cow->annotations = annotations;
         }
       }

--- a/src/s_tir/transform/lower_thread_allreduce.cc
+++ b/src/s_tir/transform/lower_thread_allreduce.cc
@@ -45,8 +45,8 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
  public:
   explicit ThreadAllreduceBuilder(const TargetNode* target)
       : target_(target),
-        warp_size_(target->GetAttr<Integer>("thread_warp_size", 1).value().IntValue()),
-        max_num_threads_(target->GetAttr<Integer>("max_num_threads", -1).value().IntValue()) {}
+        warp_size_(target->GetAttr<int64_t>("thread_warp_size", 1).value()),
+        max_num_threads_(target->GetAttr<int64_t>("max_num_threads", -1).value()) {}
 
   Stmt VisitStmt_(const AttrStmtNode* op) final {
     if (op->attr_key == tirx::attr::thread_extent) {

--- a/src/s_tir/transform/memhammer_coalesce.cc
+++ b/src/s_tir/transform/memhammer_coalesce.cc
@@ -75,20 +75,20 @@ Stmt SplitBindVectorize(const Stmt& stmt, const ConstraintSet& constraints) {
   // generate thread binding loops
   std::vector<int> factors{-1};
   std::vector<std::string> thread_axis;
-  if (ffi::Optional<Integer> o_t = constraints.thread_extent.Get("threadIdx.z")) {
-    int t = o_t.value()->value;
+  if (ffi::Optional<int64_t> o_t = constraints.thread_extent.Get("threadIdx.z")) {
+    int t = o_t.value();
     tot_threads *= t;
     factors.push_back(t);
     thread_axis.push_back("threadIdx.z");
   }
-  if (ffi::Optional<Integer> o_t = constraints.thread_extent.Get("threadIdx.y")) {
-    int t = o_t.value()->value;
+  if (ffi::Optional<int64_t> o_t = constraints.thread_extent.Get("threadIdx.y")) {
+    int t = o_t.value();
     tot_threads *= t;
     factors.push_back(t);
     thread_axis.push_back("threadIdx.y");
   }
-  if (ffi::Optional<Integer> o_t = constraints.thread_extent.Get("threadIdx.x")) {
-    int t = o_t.value()->value;
+  if (ffi::Optional<int64_t> o_t = constraints.thread_extent.Get("threadIdx.x")) {
+    int t = o_t.value();
     tot_threads *= t;
     factors.push_back(t);
     thread_axis.push_back("threadIdx.x");

--- a/src/s_tir/transform/memhammer_lower_auto_copy.cc
+++ b/src/s_tir/transform/memhammer_lower_auto_copy.cc
@@ -117,7 +117,7 @@ class AutoPadder {
         }
         PrimExpr stride = 1;
         ffi::Array<PrimExpr> reverse_strides;
-        int pad_min = padding_min_.Get(buffer).value_or(Integer(1)).IntValue();
+        int pad_min = static_cast<int>(padding_min_.Get(buffer).value_or(1));
         // Step 2. For each dimension, select a padding that has minimal bank conflict
         for (int k = n - 2; k >= 0; k--) {  // dims
           int max_pad_size =
@@ -454,7 +454,7 @@ class AutoPadder {
   class IterSpaceAnalyzer : public StmtExprVisitor {
    public:
     IterSpaceAnalyzer(const ffi::Map<Var, PrimExpr>& substitute_map, AutoPadder* self,
-                      int data_bits, const ffi::Map<ffi::String, Integer> warp_thread_extent)
+                      int data_bits, const ffi::Map<ffi::String, int64_t> warp_thread_extent)
         : substitute_map_(substitute_map),
           self(self),
           data_bits_(data_bits),
@@ -522,8 +522,8 @@ class AutoPadder {
         }
         if (vector_length_ != -1 &&
             CheckVarContiguous(op->indices.back(), vector_var, substitute_map_)) {
-          Integer m = self->padding_min_.Get(op->buffer).value_or(1);
-          self->padding_min_.Set(op->buffer, Downcast<Integer>(max(vector_length_, m)));
+          int64_t m = self->padding_min_.Get(op->buffer).value_or(1);
+          self->padding_min_.Set(op->buffer, std::max(static_cast<int64_t>(vector_length_), m));
         }
       }
       StmtExprVisitor::VisitStmt_(op);
@@ -550,8 +550,8 @@ class AutoPadder {
         }
         if (vector_length_ != -1 &&
             CheckVarContiguous(substitued_indices.back(), vector_var, substitute_map_)) {
-          Integer m = self->padding_min_.Get(op->buffer).value_or(1);
-          self->padding_min_.Set(op->buffer, Downcast<Integer>(max(vector_length_, m)));
+          int64_t m = self->padding_min_.Get(op->buffer).value_or(1);
+          self->padding_min_.Set(op->buffer, std::max(static_cast<int64_t>(vector_length_), m));
         }
       }
       StmtExprVisitor::VisitExpr_(op);
@@ -600,7 +600,7 @@ class AutoPadder {
     ffi::Map<Var, PrimExpr> substitute_map_;
     AutoPadder* self;
     int data_bits_;
-    ffi::Map<ffi::String, Integer> warp_thread_extent_;
+    ffi::Map<ffi::String, int64_t> warp_thread_extent_;
     ffi::Map<Var, Range> var_range_;
     int vector_length_ = -1;
     Var vector_var;
@@ -615,19 +615,19 @@ class AutoPadder {
    */
   void AnalyzeSharedMemoryAccess(const Stmt& stmt, const ffi::Array<For>& outer_loops,
                                  int data_bits,
-                                 const ffi::Map<ffi::String, Integer>& thread_extent) {
-    ffi::Map<ffi::String, Integer> warp_thread_extent;
-    Integer prod = 1;
+                                 const ffi::Map<ffi::String, int64_t>& thread_extent) {
+    ffi::Map<ffi::String, int64_t> warp_thread_extent;
+    int64_t prod = 1;
     ffi::Array<ffi::String> thread_tags{"threadIdx.x", "threadIdx.y", "threadIdx.z"};
-    arith::Analyzer analyzer;
     for (int i = 0; i < 3; i++) {
-      Integer extent = thread_extent.Get(thread_tags[i]).value_or(1);
-      if (analyzer.CanProve(prod * extent >= 32)) {
-        warp_thread_extent.Set(thread_tags[i], Downcast<Integer>(floordiv(32, prod)));
-        prod *= floordiv(32, prod);
+      int64_t extent = thread_extent.Get(thread_tags[i]).value_or(1);
+      if (prod * extent >= 32) {
+        int64_t warp_part = 32 / prod;
+        warp_thread_extent.Set(thread_tags[i], warp_part);
+        prod *= warp_part;
         break;
       } else {
-        warp_thread_extent.Set(thread_tags[i], Downcast<Integer>(extent));
+        warp_thread_extent.Set(thread_tags[i], extent);
         prod *= extent;
       }
     }
@@ -645,7 +645,7 @@ class AutoPadder {
   /*! \brief A map from each buffer to the iteration spaces of the accesses*/
   std::unordered_map<const BufferNode*, std::vector<std::vector<std::vector<int>>>> iter_spaces_;
   /*! \brief A map from each buffer to their minimal padding size */
-  ffi::Map<Buffer, Integer> padding_min_;
+  ffi::Map<Buffer, int64_t> padding_min_;
   /*! \brief max padding size in relative to the original shape*/
   const double max_pad_factor_ = 0.25;
 
@@ -654,7 +654,7 @@ class AutoPadder {
 
 class AutoCopyMutator : public StmtExprMutator {
  public:
-  explicit AutoCopyMutator(ffi::Map<ffi::String, Integer> thread_extent)
+  explicit AutoCopyMutator(ffi::Map<ffi::String, int64_t> thread_extent)
       : thread_extent_(thread_extent) {}
   /**
    * \brief Replace old buffers with padded buffers in the stmt
@@ -703,8 +703,8 @@ class AutoCopyMutator : public StmtExprMutator {
       n->alloc_buffers.push_back(buffer);
     }
     for (const auto& p : outputs.padding_min) {
-      Integer m = padder.padding_min_.Get(p.first).value_or(1);
-      padder.padding_min_.Set(p.first, Downcast<Integer>(max(p.second, m)));
+      int64_t m = padder.padding_min_.Get(p.first).value_or(1);
+      padder.padding_min_.Set(p.first, std::max(p.second, m));
     }
     padder.AnalyzeSharedMemoryAccess(block->body, outer_loops_, data_bits, thread_extent_);
     n->alloc_buffers = padder.PadSharedMemory(std::move(n->alloc_buffers));
@@ -719,7 +719,7 @@ class AutoCopyMutator : public StmtExprMutator {
   }
 
   /*! \brief Thread extents collected. */
-  ffi::Map<ffi::String, Integer> thread_extent_;
+  ffi::Map<ffi::String, int64_t> thread_extent_;
   /*! \brief The outer loops during recursive visit */
   ffi::Array<For> outer_loops_;
   /*! \brief Calculating optimal padding size */
@@ -740,7 +740,7 @@ class AutoCopyMutator : public StmtExprMutator {
  */
 class ThreadExtentCollector : public StmtVisitor {
  public:
-  static ffi::Map<ffi::String, Integer> CollectThreadExtent(const Stmt& stmt) {
+  static ffi::Map<ffi::String, int64_t> CollectThreadExtent(const Stmt& stmt) {
     ThreadExtentCollector collector;
     collector(stmt);
     return collector.thread_extent_;
@@ -748,9 +748,9 @@ class ThreadExtentCollector : public StmtVisitor {
 
  private:
   void VisitStmt_(const SBlockNode* op) final {
-    if (ffi::Optional<Integer> warp_execution = GetAnn<Integer>(op, "warp_execution")) {
-      if (warp_execution.value()->value != 0) {
-        thread_extent_.Set("threadIdx.x", Integer(32));
+    if (ffi::Optional<int64_t> warp_execution = GetAnn<int64_t>(op, "warp_execution")) {
+      if (warp_execution.value() != 0) {
+        thread_extent_.Set("threadIdx.x", 32);
       }
     }
     StmtVisitor::VisitStmt_(op);
@@ -758,14 +758,14 @@ class ThreadExtentCollector : public StmtVisitor {
   void VisitStmt_(const ForNode* op) final {
     if (op->thread_binding.defined() && op->thread_binding.value()->iter_type == kThreadIndex) {
       if (const auto* extent = op->extent.as<IntImmNode>()) {
-        thread_extent_.Set(op->thread_binding.value()->thread_tag, ffi::GetRef<Integer>(extent));
+        thread_extent_.Set(op->thread_binding.value()->thread_tag, extent->value);
       }
     }
     StmtVisitor::VisitStmt_(op);
   }
 
   /*! \brief the map from thread tag to its extent */
-  ffi::Map<ffi::String, Integer> thread_extent_;
+  ffi::Map<ffi::String, int64_t> thread_extent_;
 };
 
 namespace transform {

--- a/src/s_tir/transform/memhammer_rewrite_rule.h
+++ b/src/s_tir/transform/memhammer_rewrite_rule.h
@@ -38,7 +38,7 @@ using namespace tvm::tirx;
 /*! \brief The set containing all possible constraints of a data copy */
 struct ConstraintSet {
   /*! \brief The extents of the thread binding loops */
-  ffi::Map<ffi::String, Integer> thread_extent;
+  ffi::Map<ffi::String, int64_t> thread_extent;
   /*! \brief The outer loops surrounding the data copy */
   ffi::Array<For> outer_loops;
   /*! \brief The read region of the data copy */
@@ -52,7 +52,7 @@ struct ConstraintSet {
   /*! \brief The vectorization length in bytes */
   int vector_bytes = 1;
 
-  explicit ConstraintSet(ffi::Map<ffi::String, Integer> thread_extent,  //
+  explicit ConstraintSet(ffi::Map<ffi::String, int64_t> thread_extent,  //
                          ffi::Array<For> outer_loops,                   //
                          BufferRegion read_region,                      //
                          BufferRegion write_region,                     //
@@ -77,7 +77,7 @@ struct OutputSet {
   /*! \brief New buffers allocated after rewrite */
   ffi::Array<Buffer> alloc_buffer;
   /*! \brief The minimal padding size of a buffer in base 2 logarithm */
-  ffi::Map<Buffer, Integer> padding_min;
+  ffi::Map<Buffer, int64_t> padding_min;
 };
 
 /*!

--- a/src/s_tir/transform/merge_shared_memory_allocations.cc
+++ b/src/s_tir/transform/merge_shared_memory_allocations.cc
@@ -738,7 +738,7 @@ namespace transform {
 
 Pass MergeSharedMemoryAllocations() {
   auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
-    bool merge_static_smem = ctx->GetConfig<Bool>("tirx.merge_static_smem", Bool(false)).value();
+    bool merge_static_smem = ctx->GetConfig<bool>("tirx.merge_static_smem", false).value();
     auto* n = f.CopyOnWrite();
     n->body = s_tir::MergeSharedMemoryAllocations(std::move(n->body), merge_static_smem);
     return f;

--- a/src/s_tir/transform/merge_shared_memory_allocations.cc
+++ b/src/s_tir/transform/merge_shared_memory_allocations.cc
@@ -353,7 +353,7 @@ class SharedMemoryRewriter : public StmtExprMutator {
       Stmt visited_body = StmtExprMutator::VisitStmt(op->body);
       ffi::Map<ffi::String, ffi::Any> annotations;
       if (has_volatile_alloc_) {
-        annotations.Set(tirx::attr::kVolatile, Bool(true));
+        annotations.Set(tirx::attr::kVolatile, true);
       }
       Stmt alloc_stmt = AllocBuffer(merged_buf, annotations);
       Stmt new_body = SeqStmt::Flatten(alloc_stmt, visited_body);

--- a/src/s_tir/transform/profile_instrumentation.cc
+++ b/src/s_tir/transform/profile_instrumentation.cc
@@ -36,11 +36,11 @@ namespace s_tir {
 using namespace tvm::tirx;
 namespace lwp {
 
-TVM_REGISTER_PASS_CONFIG_OPTION("s_tir.lwp_disable_func_prof", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("s_tir.lwp_max_depth", Integer);
-TVM_REGISTER_PASS_CONFIG_OPTION("s_tir.lwp_min_height", Integer);
-TVM_REGISTER_PASS_CONFIG_OPTION("s_tir.instr_siblings", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("s_tir.reset_start_id", Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("s_tir.lwp_disable_func_prof", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("s_tir.lwp_max_depth", int64_t);
+TVM_REGISTER_PASS_CONFIG_OPTION("s_tir.lwp_min_height", int64_t);
+TVM_REGISTER_PASS_CONFIG_OPTION("s_tir.instr_siblings", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("s_tir.reset_start_id", bool);
 
 static int32_t start_id = 0;
 
@@ -267,19 +267,18 @@ Pass InstrumentProfileIntrinsics() {
     // In addition, loops with siblings are also instrumented provided
     // their loop depth is >= min_instr_height. This is done to avoid
     // instrumenting inner-most loops.
-    auto max_instr_depth = ctx->GetConfig<Integer>("s_tir.lwp_max_depth", Integer(0)).value();
-    auto min_instr_height = ctx->GetConfig<Integer>("s_tir.lwp_min_height", Integer(1)).value();
-    bool instr_siblings = ctx->GetConfig<Bool>("s_tir.instr_siblings", Bool(true)).value();
+    auto max_instr_depth = ctx->GetConfig<int64_t>("s_tir.lwp_max_depth", 0).value();
+    auto min_instr_height = ctx->GetConfig<int64_t>("s_tir.lwp_min_height", 1).value();
+    bool instr_siblings = ctx->GetConfig<bool>("s_tir.instr_siblings", true).value();
     bool disable_func_instrumentation =
-        ctx->GetConfig<Bool>("s_tir.lwp_disable_func_prof", Bool(false)).value();
-    bool reset_start_id = ctx->GetConfig<Bool>("s_tir.reset_start_id", Bool(false)).value();
+        ctx->GetConfig<bool>("s_tir.lwp_disable_func_prof", false).value();
+    bool reset_start_id = ctx->GetConfig<bool>("s_tir.reset_start_id", false).value();
     if (reset_start_id) lwp::start_id = 0;
     std::vector<std::pair<GlobalVar, PrimFunc>> updates;
     for (const auto& kv : mptr->functions) {
       if (auto func = kv.second.as<PrimFunc>()) {
-        auto updated_func = lwp::AddProfileBuiltins(func.value(), max_instr_depth.IntValue(),
-                                                    min_instr_height.IntValue(), instr_siblings,
-                                                    disable_func_instrumentation);
+        auto updated_func = lwp::AddProfileBuiltins(func.value(), max_instr_depth, min_instr_height,
+                                                    instr_siblings, disable_func_instrumentation);
         updates.push_back({kv.first, updated_func});
       }
     }

--- a/src/s_tir/transform/rewrite_unsafe_select.cc
+++ b/src/s_tir/transform/rewrite_unsafe_select.cc
@@ -52,7 +52,7 @@ class UnsafeExprDetector : public ExprFunctor<bool(const PrimExpr& n)> {
       }
       return false;
     } else if (auto opt = op->op.as<Op>()) {
-      auto effect_kind = op_call_effect_[opt.value()];
+      auto effect_kind = static_cast<CallEffectKind>(op_call_effect_[opt.value()]);
       if (effect_kind == CallEffectKind::kPure || effect_kind == CallEffectKind::kExprAnnotation) {
         for (PrimExpr e : op->args) {
           if (VisitExpr(e)) return true;

--- a/src/s_tir/transform/using_assume_to_reduce_branches.cc
+++ b/src/s_tir/transform/using_assume_to_reduce_branches.cc
@@ -366,11 +366,11 @@ Pass UseAssumeToReduceBranches() {
     // The pass runs & eliminates pad branch with overcompute only if,
     // the primfunc has op_pattern defined and is an elementwise op.
     // AnnotateTIROpPattern pass will set op_pattern in op attributes of the primfunc.
-    if (n->attrs.GetAttr<Integer>("op_pattern").defined()) {
-      ffi::Optional<Integer> opt_pattern = f->GetAttr<Integer>("op_pattern");
-      if (opt_pattern.defined()) {
+    if (n->attrs.GetAttr<int64_t>("op_pattern").has_value()) {
+      ffi::Optional<int64_t> opt_pattern = f->GetAttr<int64_t>("op_pattern");
+      if (opt_pattern.has_value()) {
         relax::OpPatternKind pattern;
-        pattern = static_cast<relax::OpPatternKind>(Downcast<IntImm>(opt_pattern)->value);
+        pattern = static_cast<relax::OpPatternKind>(opt_pattern.value());
 
         if (pattern == relax::OpPatternKind::kElemWise ||
             pattern == relax::OpPatternKind::kBroadcast) {

--- a/src/target/codegen.cc
+++ b/src/target/codegen.cc
@@ -46,9 +46,7 @@ namespace tvm {
 namespace codegen {
 
 ffi::Module Build(IRModule mod, Target target) {
-  if (transform::PassContext::Current()
-          ->GetConfig<Bool>("tirx.disable_assert", Bool(false))
-          .value()) {
+  if (transform::PassContext::Current()->GetConfig<bool>("tirx.disable_assert", false).value()) {
     mod = tirx::transform::SkipAssert()(mod);
   }
 

--- a/src/target/cuda/codegen_cuda.cc
+++ b/src/target/cuda/codegen_cuda.cc
@@ -153,11 +153,12 @@ void CodeGenCUDA::Init(bool output_ssa) {
 
 void CodeGenCUDA::PrintFunctionSignature(const ffi::String& function_name, const PrimFunc& func,
                                          std::ostream& os) {
-  auto calling_conv =
-      func->GetAttr<Integer>(tvm::attr::kCallingConv, Integer(tvm::CallingConv::kDefault));
-  if (calling_conv == CallingConv::kDeviceKernelLaunch) {
+  int64_t calling_conv = func->GetAttr<int64_t>(tvm::attr::kCallingConv,
+                                                static_cast<int64_t>(tvm::CallingConv::kDefault))
+                             .value();
+  if (calling_conv == static_cast<int64_t>(CallingConv::kDeviceKernelLaunch)) {
     os << "extern \"C\" __global__ ";
-  } else if (calling_conv == CallingConv::kDefault) {
+  } else if (calling_conv == static_cast<int64_t>(CallingConv::kDefault)) {
     os << "extern \"C\" __device__ ";
   } else {
     TVM_FFI_THROW(InternalError) << "Unsupported calling convention for cuda codegen: "
@@ -2095,10 +2096,12 @@ ffi::Module BuildCUDA(IRModule mod, Target target) {
   for (auto [gvar, base_func] : mod->functions) {
     TVM_FFI_ICHECK(base_func->IsInstance<PrimFuncNode>()) << "CodeGenCUDA: Can only take PrimFunc";
     auto prim_func = Downcast<PrimFunc>(base_func);
-    auto calling_conv =
-        prim_func->GetAttr<Integer>(tvm::attr::kCallingConv, Integer(tvm::CallingConv::kDefault));
-    TVM_FFI_ICHECK(calling_conv == CallingConv::kDeviceKernelLaunch ||
-                   calling_conv == CallingConv::kDefault)
+    int64_t calling_conv = prim_func
+                               ->GetAttr<int64_t>(tvm::attr::kCallingConv,
+                                                  static_cast<int64_t>(tvm::CallingConv::kDefault))
+                               .value();
+    TVM_FFI_ICHECK(calling_conv == static_cast<int64_t>(CallingConv::kDeviceKernelLaunch) ||
+                   calling_conv == static_cast<int64_t>(CallingConv::kDefault))
         << "CodeGenCUDA: expect calling_conv equals CallingConv::kDeviceKernelLaunch or "
            "CallingConv::kDefault";
     functions.Set(gvar, prim_func);

--- a/src/target/cuda/intrin_rule_cuda.cc
+++ b/src/target/cuda/intrin_rule_cuda.cc
@@ -267,7 +267,7 @@ TVM_REGISTER_OP("tirx.cuda.__shfl_sync")
     .add_argument("lane", "Expr", "The source thread id.")
     .add_argument("width", "Expr", "The warp thread width, must be a power of 2.")
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "__shfl_sync")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<bool>("cuda.need_warp_shuffle", true);
 
 TVM_REGISTER_OP("tirx.cuda.__shfl_up_sync")
@@ -277,7 +277,7 @@ TVM_REGISTER_OP("tirx.cuda.__shfl_up_sync")
     .add_argument("delta", "Expr", "The source lane id offset to be added.")
     .add_argument("width", "Expr", "The warp thread width, must be a power of 2.")
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "__shfl_up_sync")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<bool>("cuda.need_warp_shuffle", true);
 
 TVM_REGISTER_OP("tirx.cuda.__shfl_down_sync")
@@ -287,7 +287,7 @@ TVM_REGISTER_OP("tirx.cuda.__shfl_down_sync")
     .add_argument("delta", "Expr", "The source lane id offset to be subtracted.")
     .add_argument("width", "Expr", "The warp thread width, must be a power of 2.")
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "__shfl_down_sync")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<bool>("cuda.need_warp_shuffle", true);
 
 TVM_REGISTER_OP("tirx.cuda.__shfl_xor_sync")
@@ -297,13 +297,13 @@ TVM_REGISTER_OP("tirx.cuda.__shfl_xor_sync")
     .add_argument("lane_mask", "Expr", "The lane mask.")
     .add_argument("width", "Expr", "The warp thread width, must be a power of 2.")
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "__shfl_xor_sync")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<bool>("cuda.need_warp_shuffle", true);
 
 TVM_REGISTER_OP("tirx.cuda.__activemask")
     .set_num_inputs(0)
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "__activemask")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<bool>("cuda.need_warp_shuffle", true);
 
 }  // namespace intrin

--- a/src/target/metal/codegen_metal.cc
+++ b/src/target/metal/codegen_metal.cc
@@ -90,7 +90,7 @@ void CodeGenMetal::AddFunction(const GlobalVar& gvar, const PrimFunc& func) {
 
   // Buffer arguments
   size_t num_buffer = 0;
-  size_t limit = target_->GetAttr<Integer>("max_function_args").value().IntValue();
+  size_t limit = target_->GetAttr<int64_t>("max_function_args").value();
   if (func->params.size() > limit) {
     LOG(WARNING) << "Probably you won't be able to execute your kernel due to high number of "
                     "buffers in the kernel";
@@ -468,8 +468,9 @@ ffi::Module BuildMetal(IRModule mod, Target target) {
     CodeGenMetal cg(target);
     cg.Init(output_ssa);
     auto f = Downcast<PrimFunc>(kv.second);
-    auto calling_conv = f->GetAttr<Integer>(tvm::attr::kCallingConv);
-    TVM_FFI_ICHECK(calling_conv == CallingConv::kDeviceKernelLaunch)
+    auto calling_conv = f->GetAttr<int64_t>(tvm::attr::kCallingConv);
+    TVM_FFI_ICHECK(calling_conv.has_value() &&
+                   calling_conv.value() == static_cast<int64_t>(CallingConv::kDeviceKernelLaunch))
         << "CodeGenMetal: expect calling_conv equals CallingConv::kDeviceKernelLaunch";
 
     cg.AddFunction(kv.first, f);

--- a/src/target/metal/intrin_rule_metal.cc
+++ b/src/target/metal/intrin_rule_metal.cc
@@ -144,21 +144,21 @@ TVM_REGISTER_OP("tirx.metal.simd_shuffle")
     .add_argument("var", "Expr", "The variable to sync.")
     .add_argument("lane", "Expr", "The source thread id.")
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "simd_shuffle")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TVM_REGISTER_OP("tirx.metal.simd_shuffle_up")
     .set_num_inputs(2)
     .add_argument("var", "Expr", "The variable to sync.")
     .add_argument("delta", "Expr", "The source lane id offset to be added.")
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "simd_shuffle_up")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TVM_REGISTER_OP("tirx.metal.simd_shuffle_down")
     .set_num_inputs(2)
     .add_argument("var", "Expr", "The variable to sync.")
     .add_argument("delta", "Expr", "The source lane id offset to be subtracted.")
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "simd_shuffle_down")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 }  // namespace intrin
 }  // namespace codegen

--- a/src/target/opencl/codegen_opencl.cc
+++ b/src/target/opencl/codegen_opencl.cc
@@ -689,8 +689,9 @@ ffi::Module BuildOpenCL(IRModule mod, Target target) {
     TVM_FFI_ICHECK(base_func->IsInstance<PrimFuncNode>())
         << "CodeGenOpenCL: Can only take PrimFunc";
     auto prim_func = Downcast<PrimFunc>(base_func);
-    auto calling_conv = prim_func->GetAttr<Integer>(tvm::attr::kCallingConv);
-    TVM_FFI_ICHECK(calling_conv == CallingConv::kDeviceKernelLaunch)
+    auto calling_conv = prim_func->GetAttr<int64_t>(tvm::attr::kCallingConv);
+    TVM_FFI_ICHECK(calling_conv.has_value() &&
+                   calling_conv.value() == static_cast<int64_t>(CallingConv::kDeviceKernelLaunch))
         << "CodeGenOpenCL: expect calling_conv equals CallingConv::kDeviceKernelLaunch";
     functions.Set(gvar, prim_func);
   }

--- a/src/target/source/codegen_c_host.cc
+++ b/src/target/source/codegen_c_host.cc
@@ -381,10 +381,10 @@ ffi::Module BuildCHost(IRModule mod, Target target) {
 
   CodeGenCHost cg;
   cg.Init(output_ssa, emit_asserts, emit_fwd_func_decl, target->str(), devices);
-  cg.SetConstantsByteAlignment(target->GetAttr<Integer>("constants-byte-alignment").value_or(16));
+  cg.SetConstantsByteAlignment(target->GetAttr<int64_t>("constants-byte-alignment").value_or(16));
 
   auto is_aot_executor_fn = [](const PrimFunc& func) -> bool {
-    return func->GetAttr<Bool>("runner_function", Bool(false)).value();
+    return func->GetAttr<bool>("runner_function", false).value();
   };
 
   std::vector<std::pair<GlobalVar, PrimFunc>> funcs;

--- a/src/target/source/codegen_trn.cc
+++ b/src/target/source/codegen_trn.cc
@@ -104,7 +104,7 @@ void CodeGenTrainium::AddFunction(const GlobalVar& gvar, const PrimFunc& func) {
   this->stream << "def " << static_cast<std::string>(global_symbol.value()) << "(";
 
   // Buffer arguments
-  auto num_inputs = func->GetAttr<Integer>(tvm::attr::kNumInputs);
+  auto num_inputs = func->GetAttr<int64_t>(tvm::attr::kNumInputs);
   TVM_FFI_ICHECK(num_inputs.has_value());
   std::vector<std::string> output_vids;
   size_t num_buffer = 0;
@@ -114,7 +114,7 @@ void CodeGenTrainium::AddFunction(const GlobalVar& gvar, const PrimFunc& func) {
       LOG(FATAL) << "Trainium codegen currently only support buffer arguments";
     };
     std::string vid = AllocVarID(v.get());
-    if (i >= static_cast<size_t>(num_inputs.value()->value)) {
+    if (i >= static_cast<size_t>(num_inputs.value())) {
       this->stream << vid << ": nt.mutable_tensor, ";
       output_vids.push_back(vid);
     } else {

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -176,7 +176,7 @@ Target Target::WithoutHost() const {
 }
 
 int TargetNode::GetTargetDeviceType() const {
-  if (ffi::Optional<Integer> device_type = GetAttr<Integer>("target_device_type")) {
+  if (ffi::Optional<int64_t> device_type = GetAttr<int64_t>("target_device_type")) {
     return Downcast<Integer>(device_type)->value;
   }
   return kind->default_device_type;

--- a/src/target/vulkan/spirv_support.cc
+++ b/src/target/vulkan/spirv_support.cc
@@ -36,62 +36,58 @@ SPIRVSupport::SPIRVSupport(tvm::Target target) {
   TVM_FFI_ICHECK(device_type == kDLVulkan || device_type == kDLOpenCL || device_type == kDLWebGPU)
       << "Unsupported device type for SPIRV codegen:" << device_type;
 
-  if (target->GetAttr<Integer>("vulkan_api_version")) {
-    vulkan_api_version = target->GetAttr<Integer>("vulkan_api_version").value().IntValue();
+  if (target->GetAttr<int64_t>("vulkan_api_version")) {
+    vulkan_api_version = target->GetAttr<int64_t>("vulkan_api_version").value();
   }
 
-  if (target->GetAttr<Integer>("supported_subgroup_operations")) {
+  if (target->GetAttr<int64_t>("supported_subgroup_operations")) {
     supported_subgroup_operations =
-        target->GetAttr<Integer>("supported_subgroup_operations").value().IntValue();
+        target->GetAttr<int64_t>("supported_subgroup_operations").value();
   }
-  if (target->GetAttr<Integer>("max_push_constants_size")) {
-    max_push_constants_size =
-        target->GetAttr<Integer>("max_push_constants_size").value().IntValue();
+  if (target->GetAttr<int64_t>("max_push_constants_size")) {
+    max_push_constants_size = target->GetAttr<int64_t>("max_push_constants_size").value();
   }
-  if (target->GetAttr<Integer>("max_uniform_buffer_range")) {
-    max_uniform_buffer_range =
-        target->GetAttr<Integer>("max_uniform_buffer_range").value().IntValue();
+  if (target->GetAttr<int64_t>("max_uniform_buffer_range")) {
+    max_uniform_buffer_range = target->GetAttr<int64_t>("max_uniform_buffer_range").value();
   }
-  if (target->GetAttr<Integer>("max_storage_buffer_range")) {
-    max_storage_buffer_range =
-        target->GetAttr<Integer>("max_storage_buffer_range").value().IntValue();
+  if (target->GetAttr<int64_t>("max_storage_buffer_range")) {
+    max_storage_buffer_range = target->GetAttr<int64_t>("max_storage_buffer_range").value();
   }
-  if (target->GetAttr<Integer>("max_shared_memory_per_block")) {
-    max_shared_memory_per_block =
-        target->GetAttr<Integer>("max_shared_memory_per_block").value().IntValue();
+  if (target->GetAttr<int64_t>("max_shared_memory_per_block")) {
+    max_shared_memory_per_block = target->GetAttr<int64_t>("max_shared_memory_per_block").value();
   }
-  if (target->GetAttr<Integer>("max_per_stage_descriptor_storage_buffer")) {
+  if (target->GetAttr<int64_t>("max_per_stage_descriptor_storage_buffer")) {
     max_per_stage_descriptor_storage_buffers =
-        target->GetAttr<Integer>("max_per_stage_descriptor_storage_buffer").value().IntValue();
+        target->GetAttr<int64_t>("max_per_stage_descriptor_storage_buffer").value();
   }
-  if (target->GetAttr<Bool>("supports_storage_buffer_storage_class")) {
+  if (target->GetAttr<bool>("supports_storage_buffer_storage_class")) {
     supports_storage_buffer_storage_class =
-        target->GetAttr<Bool>("supports_storage_buffer_storage_class").value();
+        target->GetAttr<bool>("supports_storage_buffer_storage_class").value();
   }
-  if (target->GetAttr<Bool>("supports_8bit_buffer")) {
-    supports_storage_buffer_8bit_access = target->GetAttr<Bool>("supports_8bit_buffer").value();
+  if (target->GetAttr<bool>("supports_8bit_buffer")) {
+    supports_storage_buffer_8bit_access = target->GetAttr<bool>("supports_8bit_buffer").value();
   }
-  if (target->GetAttr<Bool>("supports_16bit_buffer")) {
-    supports_storage_buffer_16bit_access = target->GetAttr<Bool>("supports_16bit_buffer").value();
+  if (target->GetAttr<bool>("supports_16bit_buffer")) {
+    supports_storage_buffer_16bit_access = target->GetAttr<bool>("supports_16bit_buffer").value();
   }
-  if (target->GetAttr<Bool>("supports_float16")) {
-    supports_float16 = target->GetAttr<Bool>("supports_float16").value();
+  if (target->GetAttr<bool>("supports_float16")) {
+    supports_float16 = target->GetAttr<bool>("supports_float16").value();
   }
-  if (target->GetAttr<Bool>("supports_float64")) {
-    supports_float64 = target->GetAttr<Bool>("supports_float64").value();
+  if (target->GetAttr<bool>("supports_float64")) {
+    supports_float64 = target->GetAttr<bool>("supports_float64").value();
   }
-  if (target->GetAttr<Bool>("supports_int8")) {
-    supports_int8 = target->GetAttr<Bool>("supports_int8").value();
+  if (target->GetAttr<bool>("supports_int8")) {
+    supports_int8 = target->GetAttr<bool>("supports_int8").value();
   }
-  if (target->GetAttr<Bool>("supports_int16")) {
-    supports_int16 = target->GetAttr<Bool>("supports_int16").value();
+  if (target->GetAttr<bool>("supports_int16")) {
+    supports_int16 = target->GetAttr<bool>("supports_int16").value();
   }
-  if (target->GetAttr<Bool>("supports_int64")) {
-    supports_int64 = target->GetAttr<Bool>("supports_int64").value();
+  if (target->GetAttr<bool>("supports_int64")) {
+    supports_int64 = target->GetAttr<bool>("supports_int64").value();
   }
   // Check whether integer dot product is enabled in the target string.
-  if (target->GetAttr<Bool>("supports_integer_dot_product")) {
-    supports_integer_dot_product = target->GetAttr<Bool>("supports_integer_dot_product").value();
+  if (target->GetAttr<bool>("supports_integer_dot_product")) {
+    supports_integer_dot_product = target->GetAttr<bool>("supports_integer_dot_product").value();
   }
   // Check whether integer dot product is enabled in mattr.
   if (const ffi::Optional<ffi::Array<ffi::String>>& v =
@@ -104,8 +100,8 @@ SPIRVSupport::SPIRVSupport(tvm::Target target) {
     }
   }
   // Check whether cooperative matrix is enabled in the target string.
-  if (target->GetAttr<Bool>("supports_cooperative_matrix")) {
-    supports_cooperative_matrix = target->GetAttr<Bool>("supports_cooperative_matrix").value();
+  if (target->GetAttr<bool>("supports_cooperative_matrix")) {
+    supports_cooperative_matrix = target->GetAttr<bool>("supports_cooperative_matrix").value();
   }
 }
 

--- a/src/target/vulkan/spirv_support.cc
+++ b/src/target/vulkan/spirv_support.cc
@@ -36,59 +36,35 @@ SPIRVSupport::SPIRVSupport(tvm::Target target) {
   TVM_FFI_ICHECK(device_type == kDLVulkan || device_type == kDLOpenCL || device_type == kDLWebGPU)
       << "Unsupported device type for SPIRV codegen:" << device_type;
 
-  if (target->GetAttr<int64_t>("vulkan_api_version")) {
-    vulkan_api_version = target->GetAttr<int64_t>("vulkan_api_version").value();
-  }
-
-  if (target->GetAttr<int64_t>("supported_subgroup_operations")) {
-    supported_subgroup_operations =
-        target->GetAttr<int64_t>("supported_subgroup_operations").value();
-  }
-  if (target->GetAttr<int64_t>("max_push_constants_size")) {
-    max_push_constants_size = target->GetAttr<int64_t>("max_push_constants_size").value();
-  }
-  if (target->GetAttr<int64_t>("max_uniform_buffer_range")) {
-    max_uniform_buffer_range = target->GetAttr<int64_t>("max_uniform_buffer_range").value();
-  }
-  if (target->GetAttr<int64_t>("max_storage_buffer_range")) {
-    max_storage_buffer_range = target->GetAttr<int64_t>("max_storage_buffer_range").value();
-  }
-  if (target->GetAttr<int64_t>("max_shared_memory_per_block")) {
-    max_shared_memory_per_block = target->GetAttr<int64_t>("max_shared_memory_per_block").value();
-  }
-  if (target->GetAttr<int64_t>("max_per_stage_descriptor_storage_buffer")) {
-    max_per_stage_descriptor_storage_buffers =
-        target->GetAttr<int64_t>("max_per_stage_descriptor_storage_buffer").value();
-  }
-  if (target->GetAttr<bool>("supports_storage_buffer_storage_class")) {
-    supports_storage_buffer_storage_class =
-        target->GetAttr<bool>("supports_storage_buffer_storage_class").value();
-  }
-  if (target->GetAttr<bool>("supports_8bit_buffer")) {
-    supports_storage_buffer_8bit_access = target->GetAttr<bool>("supports_8bit_buffer").value();
-  }
-  if (target->GetAttr<bool>("supports_16bit_buffer")) {
-    supports_storage_buffer_16bit_access = target->GetAttr<bool>("supports_16bit_buffer").value();
-  }
-  if (target->GetAttr<bool>("supports_float16")) {
-    supports_float16 = target->GetAttr<bool>("supports_float16").value();
-  }
-  if (target->GetAttr<bool>("supports_float64")) {
-    supports_float64 = target->GetAttr<bool>("supports_float64").value();
-  }
-  if (target->GetAttr<bool>("supports_int8")) {
-    supports_int8 = target->GetAttr<bool>("supports_int8").value();
-  }
-  if (target->GetAttr<bool>("supports_int16")) {
-    supports_int16 = target->GetAttr<bool>("supports_int16").value();
-  }
-  if (target->GetAttr<bool>("supports_int64")) {
-    supports_int64 = target->GetAttr<bool>("supports_int64").value();
-  }
+  vulkan_api_version = target->GetAttr<int64_t>("vulkan_api_version").value_or(vulkan_api_version);
+  supported_subgroup_operations = target->GetAttr<int64_t>("supported_subgroup_operations")
+                                      .value_or(supported_subgroup_operations);
+  max_push_constants_size =
+      target->GetAttr<int64_t>("max_push_constants_size").value_or(max_push_constants_size);
+  max_uniform_buffer_range =
+      target->GetAttr<int64_t>("max_uniform_buffer_range").value_or(max_uniform_buffer_range);
+  max_storage_buffer_range =
+      target->GetAttr<int64_t>("max_storage_buffer_range").value_or(max_storage_buffer_range);
+  max_shared_memory_per_block =
+      target->GetAttr<int64_t>("max_shared_memory_per_block").value_or(max_shared_memory_per_block);
+  max_per_stage_descriptor_storage_buffers =
+      target->GetAttr<int64_t>("max_per_stage_descriptor_storage_buffer")
+          .value_or(max_per_stage_descriptor_storage_buffers);
+  supports_storage_buffer_storage_class =
+      target->GetAttr<bool>("supports_storage_buffer_storage_class")
+          .value_or(supports_storage_buffer_storage_class);
+  supports_storage_buffer_8bit_access =
+      target->GetAttr<bool>("supports_8bit_buffer").value_or(supports_storage_buffer_8bit_access);
+  supports_storage_buffer_16bit_access =
+      target->GetAttr<bool>("supports_16bit_buffer").value_or(supports_storage_buffer_16bit_access);
+  supports_float16 = target->GetAttr<bool>("supports_float16").value_or(supports_float16);
+  supports_float64 = target->GetAttr<bool>("supports_float64").value_or(supports_float64);
+  supports_int8 = target->GetAttr<bool>("supports_int8").value_or(supports_int8);
+  supports_int16 = target->GetAttr<bool>("supports_int16").value_or(supports_int16);
+  supports_int64 = target->GetAttr<bool>("supports_int64").value_or(supports_int64);
   // Check whether integer dot product is enabled in the target string.
-  if (target->GetAttr<bool>("supports_integer_dot_product")) {
-    supports_integer_dot_product = target->GetAttr<bool>("supports_integer_dot_product").value();
-  }
+  supports_integer_dot_product =
+      target->GetAttr<bool>("supports_integer_dot_product").value_or(supports_integer_dot_product);
   // Check whether integer dot product is enabled in mattr.
   if (const ffi::Optional<ffi::Array<ffi::String>>& v =
           target->GetAttr<ffi::Array<ffi::String>>("mattr")) {
@@ -100,9 +76,8 @@ SPIRVSupport::SPIRVSupport(tvm::Target target) {
     }
   }
   // Check whether cooperative matrix is enabled in the target string.
-  if (target->GetAttr<bool>("supports_cooperative_matrix")) {
-    supports_cooperative_matrix = target->GetAttr<bool>("supports_cooperative_matrix").value();
-  }
+  supports_cooperative_matrix =
+      target->GetAttr<bool>("supports_cooperative_matrix").value_or(supports_cooperative_matrix);
 }
 
 }  // namespace codegen

--- a/src/target/vulkan/spirv_utils.cc
+++ b/src/target/vulkan/spirv_utils.cc
@@ -49,9 +49,8 @@ class SPIRVTools {
  public:
   explicit SPIRVTools(Target target) {
     uint32_t vulkan_version =
-        target->GetAttr<Integer>("vulkan_api_version").value_or(VK_API_VERSION_1_0).IntValue();
-    uint32_t spirv_version =
-        target->GetAttr<Integer>("max_spirv_version").value_or(0x10000).IntValue();
+        target->GetAttr<int64_t>("vulkan_api_version").value_or(VK_API_VERSION_1_0);
+    uint32_t spirv_version = target->GetAttr<int64_t>("max_spirv_version").value_or(0x10000);
 
     spv_target_env validation_version;
     if (target->kind->name == "opencl") {
@@ -125,8 +124,9 @@ std::pair<std::unordered_map<std::string, runtime::SPIRVShader>, std::string> Lo
   for (auto kv : mod->functions) {
     TVM_FFI_ICHECK(kv.second->IsInstance<PrimFuncNode>()) << "CodeGenSPIRV: Can only take PrimFunc";
     auto f = Downcast<PrimFunc>(kv.second);
-    auto calling_conv = f->GetAttr<Integer>(tvm::attr::kCallingConv);
-    TVM_FFI_ICHECK(calling_conv == CallingConv::kDeviceKernelLaunch)
+    auto calling_conv = f->GetAttr<int64_t>(tvm::attr::kCallingConv);
+    TVM_FFI_ICHECK(calling_conv.has_value() &&
+                   calling_conv.value() == static_cast<int64_t>(CallingConv::kDeviceKernelLaunch))
         << "CodeGenSPIRV: expect calling_conv equals CallingConv::kDeviceKernelLaunch";
     auto global_symbol = f->GetAttr<ffi::String>(tvm::attr::kGlobalSymbol);
     TVM_FFI_ICHECK(global_symbol.has_value())

--- a/src/target/webgpu/codegen_webgpu.cc
+++ b/src/target/webgpu/codegen_webgpu.cc
@@ -126,7 +126,7 @@ void CodeGenWebGPU::InitFuncState(const PrimFunc& f) {
 }
 
 CodeGenWebGPU::CodeGenWebGPU(Target target) : target_(target) {
-  enable_subgroups_ = target_->GetAttr<Bool>("supports_subgroups").value_or(Bool(false));
+  enable_subgroups_ = target_->GetAttr<bool>("supports_subgroups").value_or(Bool(false));
 }
 
 runtime::FunctionInfo CodeGenWebGPU::AddFunction(const PrimFunc& f, bool skip_readonly_decl) {
@@ -760,8 +760,9 @@ ffi::Module BuildWebGPU(IRModule mod, Target target) {
     TVM_FFI_ICHECK(kv.second->IsInstance<PrimFuncNode>())
         << "CodeGenWebGPU: Can only take PrimFunc";
     auto f = Downcast<PrimFunc>(kv.second);
-    auto calling_conv = f->GetAttr<Integer>(tvm::attr::kCallingConv);
-    TVM_FFI_ICHECK(calling_conv == CallingConv::kDeviceKernelLaunch)
+    auto calling_conv = f->GetAttr<int64_t>(tvm::attr::kCallingConv);
+    TVM_FFI_ICHECK(calling_conv.has_value() &&
+                   calling_conv.value() == static_cast<int64_t>(CallingConv::kDeviceKernelLaunch))
         << "CodeGenWebGPU: expect calling_conv equals CallingConv::kDeviceKernelLaunch";
     auto global_symbol = f->GetAttr<ffi::String>(tvm::attr::kGlobalSymbol);
     TVM_FFI_ICHECK(global_symbol.has_value())

--- a/src/target/webgpu/codegen_webgpu.cc
+++ b/src/target/webgpu/codegen_webgpu.cc
@@ -126,7 +126,7 @@ void CodeGenWebGPU::InitFuncState(const PrimFunc& f) {
 }
 
 CodeGenWebGPU::CodeGenWebGPU(Target target) : target_(target) {
-  enable_subgroups_ = target_->GetAttr<bool>("supports_subgroups").value_or(Bool(false));
+  enable_subgroups_ = target_->GetAttr<bool>("supports_subgroups").value_or(false);
 }
 
 runtime::FunctionInfo CodeGenWebGPU::AddFunction(const PrimFunc& f, bool skip_readonly_decl) {

--- a/src/target/webgpu/intrin_rule_webgpu.cc
+++ b/src/target/webgpu/intrin_rule_webgpu.cc
@@ -164,21 +164,21 @@ TVM_REGISTER_OP("tirx.webgpu.subgroup_shuffle")
     .add_argument("var", "Expr", "The variable to sync.")
     .add_argument("lane", "Expr", "The source thread id.")
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "subgroupShuffle")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TVM_REGISTER_OP("tirx.webgpu.subgroup_shuffle_up")
     .set_num_inputs(2)
     .add_argument("var", "Expr", "The variable to sync.")
     .add_argument("delta", "Expr", "The source lane id offset to be added.")
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "subgroupShuffleUp")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TVM_REGISTER_OP("tirx.webgpu.subgroup_shuffle_down")
     .set_num_inputs(2)
     .add_argument("var", "Expr", "The variable to sync.")
     .add_argument("delta", "Expr", "The source lane id offset to be subtracted.")
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "subgroupShuffleDown")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 }  // namespace intrin
 }  // namespace codegen

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -746,13 +746,12 @@ PrimFunc GenerateAndCompletePrimFunc(const ffi::Array<te::Tensor>& arg_list,
     TVM_FFI_ICHECK(it != info->tensor2buffers.end());
     buffer_map.Set(arg, it->second);
   }
-  PrimFunc func = WithAttrs(PrimFunc(/*params=*/std::move(parameters),
-                                     /*body=*/SeqStmt::Flatten(root_stmts),
-                                     /*ret_type=*/VoidType(),
-                                     /*buffer_map=*/std::move(buffer_map)),
-                            {{"global_symbol", ffi::String("main")},
-                             {"tirx.noalias", true},
-                             {tvm::attr::kSTir, tvm::Bool(true)}});
+  PrimFunc func = WithAttrs(
+      PrimFunc(/*params=*/std::move(parameters),
+               /*body=*/SeqStmt::Flatten(root_stmts),
+               /*ret_type=*/VoidType(),
+               /*buffer_map=*/std::move(buffer_map)),
+      {{"global_symbol", ffi::String("main")}, {"tirx.noalias", true}, {tvm::attr::kSTir, true}});
   const auto fcomplete = tvm::ffi::Function::GetGlobal("script.Complete");
   TVM_FFI_ICHECK(fcomplete.has_value());
   func = (*fcomplete)(std::move(func), info->root_alloc, true).cast<PrimFunc>();
@@ -818,13 +817,12 @@ PrimFunc GenerateAndCompletePrimFunc(const ffi::Array<ffi::ObjectRef>& arg_tir_v
       parameters.push_back(var.value());
     }
   }
-  PrimFunc func = WithAttrs(PrimFunc(/*params=*/std::move(parameters),
-                                     /*body=*/SeqStmt::Flatten(root_stmts),
-                                     /*ret_type=*/VoidType(),
-                                     /*buffer_map=*/std::move(buffer_map)),
-                            {{"global_symbol", ffi::String("main")},
-                             {"tirx.noalias", true},
-                             {tvm::attr::kSTir, tvm::Bool(true)}});
+  PrimFunc func = WithAttrs(
+      PrimFunc(/*params=*/std::move(parameters),
+               /*body=*/SeqStmt::Flatten(root_stmts),
+               /*ret_type=*/VoidType(),
+               /*buffer_map=*/std::move(buffer_map)),
+      {{"global_symbol", ffi::String("main")}, {"tirx.noalias", true}, {tvm::attr::kSTir, true}});
   const auto fcomplete = tvm::ffi::Function::GetGlobal("script.Complete");
   TVM_FFI_ICHECK(fcomplete.has_value());
   func = (*fcomplete)(std::move(func), info->root_alloc, true).cast<PrimFunc>();

--- a/src/tirx/analysis/side_effect.cc
+++ b/src/tirx/analysis/side_effect.cc
@@ -46,7 +46,7 @@ class ExprSideEffect : public ExprVisitor {
     static auto op_call_effect = Op::GetAttrMap<TCallEffectKind>("TCallEffectKind");
 
     if (auto opt = op->op.as<Op>()) {
-      this->UpdateEffect(static_cast<CallEffectKind>(op_call_effect[opt.value()]->value));
+      this->UpdateEffect(static_cast<CallEffectKind>(op_call_effect[opt.value()]));
     } else {
       this->UpdateEffect(CallEffectKind::kOpaque);
     }

--- a/src/tirx/analysis/verify_memory.cc
+++ b/src/tirx/analysis/verify_memory.cc
@@ -177,8 +177,8 @@ std::vector<ffi::String> VerifyMemory_(const PrimFunc& func) {
           << "' for primitive:" << std::endl
           << func;
 
-  if (func->GetAttr<Integer>(tvm::attr::kCallingConv, Integer(CallingConv::kDefault)) ==
-      CallingConv::kDefault) {
+  if (func->GetAttr<int64_t>(tvm::attr::kCallingConv, static_cast<int64_t>(CallingConv::kDefault))
+          .value() == static_cast<int64_t>(CallingConv::kDefault)) {
     MemoryAccessVerifier v(func, target.value()->GetTargetDeviceType());
     v.Run();
     return v.Errors();

--- a/src/tirx/analysis/verify_tirx_well_formed.cc
+++ b/src/tirx/analysis/verify_tirx_well_formed.cc
@@ -62,7 +62,7 @@ class ExecScopeVerifier : public Verifier<ExecScopeVerifier> {
 
   void VisitStmt_(const tirx::TilePrimitiveCallNode* op,
                   ffi::reflection::AccessPath path) override {
-    static const tvm::OpAttrMap<Bool>& tirx_op_map_ = Op::GetAttrMap<Bool>("TIsTIRxOp");
+    static const tvm::OpAttrMap<bool>& tirx_op_map_ = Op::GetAttrMap<bool>("TIsTIRxOp");
     Verify(tirx_op_map_.count(op->op))
         << "TIRxError: TilePrimitiveCall at " << path << " has unknown TIRX op " << op->op;
   }

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -678,9 +678,9 @@ PrimExpr TypeAnnotation(DataType dtype, Span span) {
 }
 
 TVM_TIRX_REGISTER_OP("type_annotation")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 }  // namespace tirx
 }  // namespace tvm

--- a/src/tirx/ir/tirx_stmt.cc
+++ b/src/tirx/ir/tirx_stmt.cc
@@ -37,7 +37,7 @@ TilePrimitiveCall::TilePrimitiveCall(tvm::Op op, ffi::Array<ffi::Any> args,
                                      ffi::Map<ffi::String, ffi::Any> config,
                                      ffi::Optional<ffi::String> dispatch) {
   // Check if the op is a TIRX op.
-  static const auto& tirx_op_map = Op::GetAttrMap<Bool>("TIsTIRxOp");
+  static const auto& tirx_op_map = Op::GetAttrMap<bool>("TIsTIRxOp");
   TVM_FFI_ICHECK_EQ(tirx_op_map.count(op), 1)
       << "Only TIRX ops can be used in tirx::TilePrimitiveCall";
   // Construct the TilePrimitiveCall.

--- a/src/tirx/ir/transform.cc
+++ b/src/tirx/ir/transform.cc
@@ -32,23 +32,23 @@ namespace tirx {
 namespace transform {
 
 // Register build pipeline related options
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.noalias", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.instrument_bound_checkers", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.disable_assert", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.disable_vectorize", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.enable_buffer_level_predication", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.disable_cse_tir", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.enable_debug", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.disable_storage_rewrite", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.is_entry_func", Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.noalias", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.instrument_bound_checkers", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.disable_assert", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.disable_vectorize", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.enable_buffer_level_predication", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.disable_cse_tir", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.enable_debug", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.disable_storage_rewrite", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.is_entry_func", bool);
 TVM_REGISTER_PASS_CONFIG_OPTION("tirx.add_lower_pass", ffi::Array<ffi::Array<ffi::ObjectRef>>);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.debug_keep_trivial_loop", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.use_async_copy", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.merge_static_smem", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.instrument_lwp", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.vtcm_capacity", Integer);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.ptx_ldg32", Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION("tirx.enable_fast_math", Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.debug_keep_trivial_loop", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.use_async_copy", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.merge_static_smem", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.instrument_lwp", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.vtcm_capacity", int64_t);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.ptx_ldg32", bool);
+TVM_REGISTER_PASS_CONFIG_OPTION("tirx.enable_fast_math", bool);
 
 /*!
  * \brief Function level pass that applies transformations to all

--- a/src/tirx/op/builtin.cc
+++ b/src/tirx/op/builtin.cc
@@ -39,459 +39,468 @@ namespace builtin {
   TVM_TIRX_REGISTER_OP(#OpName)
 
 TIR_DEFINE_BUILTIN_FUNC(reinterpret)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst))
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst))
     .set_num_inputs(1);
 
 TIR_DEFINE_BUILTIN_FUNC(ret)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kControlJump))
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               static_cast<int64_t>(CallEffectKind::kControlJump))
     .set_num_inputs(1);
 
 TIR_DEFINE_BUILTIN_FUNC(thread_return)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kControlJump))
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               static_cast<int64_t>(CallEffectKind::kControlJump))
     .set_num_inputs(0);
 
 TIR_DEFINE_BUILTIN_FUNC(continue_loop)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kControlJump))
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               static_cast<int64_t>(CallEffectKind::kControlJump))
     .set_num_inputs(0);
 
 TIR_DEFINE_BUILTIN_FUNC(break_loop)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kControlJump))
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               static_cast<int64_t>(CallEffectKind::kControlJump))
     .set_num_inputs(0);
 
 TIR_DEFINE_BUILTIN_FUNC(likely)
     .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kExprAnnotation))
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               static_cast<int64_t>(CallEffectKind::kExprAnnotation))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 // tirx.filter: thread-set filter predicate used as IfThenElse condition.
 // Variadic: (var, lo, hi) range form or (var, cond) predicate form; multi-var
 // conjunctions are desugared into nested IfThenElse at parse time.
-TIR_DEFINE_BUILTIN_FUNC(filter).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                          Integer(CallEffectKind::kPure));
+TIR_DEFINE_BUILTIN_FUNC(filter).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(selector).set_num_inputs(2).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(bitwise_and)
     .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(bitwise_or)
     .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(bitwise_xor)
     .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(bitwise_not)
     .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(shift_left)
     .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(shift_right)
     .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(large_uint_imm)
     .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(address_of)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_num_inputs(1);
 
 TIR_DEFINE_BUILTIN_FUNC(if_then_else)
     .set_num_inputs(3)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(q_multiply_shift)
     .set_num_inputs(3)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(q_multiply_shift_per_axis)
     .set_num_inputs(7)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(isnullptr).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(isnan).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(popcount)
     .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(fma)
     .set_num_inputs(3)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(call_extern)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(call_pure_extern)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(call_llvm_intrin)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(call_llvm_pure_intrin)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst))
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst))
     .set_attr<TVectorizable>("TVectorizable", true);
 
 TIR_DEFINE_BUILTIN_FUNC(call_spirv_pure_glsl450)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
-TIR_DEFINE_BUILTIN_FUNC(prefetch).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                            Integer(CallEffectKind::kOpaque));
+TIR_DEFINE_BUILTIN_FUNC(prefetch).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_access_ptr)
     .set_num_inputs(5)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kSpecialCallArg));
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               static_cast<int64_t>(CallEffectKind::kSpecialCallArg));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_static_handle)
     .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kSpecialCallArg));
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               static_cast<int64_t>(CallEffectKind::kSpecialCallArg));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_context_id)
     .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kReadState));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kReadState));
 
-TIR_DEFINE_BUILTIN_FUNC(tvm_tuple).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                             Integer(CallEffectKind::kEmbedInfo));
+TIR_DEFINE_BUILTIN_FUNC(tvm_tuple).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kEmbedInfo));
 
 TIR_DEFINE_BUILTIN_FUNC(handle_add_byte_offset)
     .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_struct_get)
     .set_num_inputs(3)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kReadState))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kReadState))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kLast));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kLast));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_struct_set)
     .set_num_inputs(4)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kUpdateState));
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               static_cast<int64_t>(CallEffectKind::kUpdateState));
 
 TIR_DEFINE_BUILTIN_FUNC(lookup_param)
     .set_num_inputs(4)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kUpdateState));
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               static_cast<int64_t>(CallEffectKind::kUpdateState));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_throw_last_error)
     .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_stack_alloca)
     .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_stack_make_shape)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_stack_make_array)
     .set_num_inputs(6)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 // When num_inputs are not set, the function is assumed to be variable length.
 TIR_DEFINE_BUILTIN_FUNC(tvm_call_packed)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptPrinterName>("TScriptPrinterName", ffi::String("call_packed"), /*plevel=*/20);
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_call_cpacked)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptPrinterName>("TScriptPrinterName", ffi::String("call_cpacked"), /*plevel=*/20);
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_call_trace_packed)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_thread_invariant)
     .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_call_packed_lowered)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptPrinterName>("TScriptPrinterName", ffi::String("call_packed_lowered"),
                                   /*plevel=*/20);
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_call_cpacked_lowered)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptPrinterName>("TScriptPrinterName", ffi::String("call_cpacked_lowered"),
                                   /*plevel=*/20);
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_call_trace_packed_lowered)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 // TODO(tvm-team) revisit storage sync once we have a good memory hierachy structure.
 TIR_DEFINE_BUILTIN_FUNC(tvm_storage_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_warp_shuffle)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_warp_shuffle_up)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_warp_shuffle_down)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_warp_shuffle_xor)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_warp_activemask)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_global_barrier_kinit)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(tvm_thread_allreduce)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(make_filled_simdgroup_matrix)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(simdgroup_load)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(simdgroup_store)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(simdgroup_multiply_accumulate)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cooperative_tensor_fill)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cooperative_tensor_load)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cooperative_tensor_store)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cooperative_tensor_multiply_accumulate)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(vectorhigh)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(vectorlow)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(vectorcombine)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(dp4a)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(atomic_add)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(nd_mem_alloc_with_scope)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(texture2d_store)
     .set_attr<TVectorizable>("TVectorizable", true)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(texture2d_load)
     .set_attr<TVectorizable>("TVectorizable", true)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
-TIR_DEFINE_BUILTIN_FUNC(dma_copy).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                            Integer(CallEffectKind::kOpaque));
+TIR_DEFINE_BUILTIN_FUNC(dma_copy).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
-TIR_DEFINE_BUILTIN_FUNC(dma_wait).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                            Integer(CallEffectKind::kOpaque));
+TIR_DEFINE_BUILTIN_FUNC(dma_wait).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(dma_start_group)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(dma_end_group)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(assume)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kEmbedInfo))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kEmbedInfo))
     .set_num_inputs(1);
 
 TIR_DEFINE_BUILTIN_FUNC(undef)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kReadState))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kReadState))
     .set_num_inputs(0);
 
 TIR_DEFINE_BUILTIN_FUNC(start_profile_intrinsic)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(end_profile_intrinsic)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(anylist_getitem)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kReadState));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kReadState));
 
 TIR_DEFINE_BUILTIN_FUNC(anylist_resetitem)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "TVMBackendAnyListResetItem");
 
 TIR_DEFINE_BUILTIN_FUNC(anylist_setitem_call_packed)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(anylist_setitem_call_cpacked)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
-TIR_DEFINE_BUILTIN_FUNC(vscale).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                          Integer(CallEffectKind::kPure));
+TIR_DEFINE_BUILTIN_FUNC(vscale).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(get_active_lane_mask)
     .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(ignore_loop_partition)
     .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kNone));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kNone));
 TIR_DEFINE_BUILTIN_FUNC(buffer_offset)
     .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(print_buffer)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(timer_init_cuda)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(timer_start_cuda)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(timer_end_cuda)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(timer_finalize_cuda)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_atomic_add)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_thread_fence)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_warpgroup_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_warp_reduce)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_cta_reduce)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_copy_bytes)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_warp_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_cta_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_grid_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_thread_rank)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 // Cluster-wide sync (CUDA thread block clusters)
 TIR_DEFINE_BUILTIN_FUNC(cuda_cluster_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_half2float)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_bfloat162float)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_float22half2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_trap_when_assert_failed)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_runtime_instr_desc)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_half8tofloat8)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_float8tohalf8)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_syncthreads_and)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_syncthreads_or)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_nano_sleep)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_atomic_cas)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_printf)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_ldg)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_num_inputs(2);
 
 TIR_DEFINE_BUILTIN_FUNC(cuda_get_tmem_addr)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
-TIR_DEFINE_BUILTIN_FUNC(ptx_exp2).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                            Integer(CallEffectKind::kPure));
+TIR_DEFINE_BUILTIN_FUNC(ptx_exp2).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
-TIR_DEFINE_BUILTIN_FUNC(ptx_rcp).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                           Integer(CallEffectKind::kPure));
+TIR_DEFINE_BUILTIN_FUNC(ptx_rcp).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(ptx_any_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(ptx_reduce3_max_f32)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIR_DEFINE_BUILTIN_FUNC(ptx_reduce3_min_f32)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 // PTX scalar / packed floating-point arithmetic, DPS form (writes to *d_addr).
 //   add/sub/mul: 2 sources, 1 destination.
@@ -499,36 +508,36 @@ TIR_DEFINE_BUILTIN_FUNC(ptx_reduce3_min_f32)
 //   Modifiers (rounding / ftz / sat) are codegen attrs.
 // kOpaque because all four kinds write through the destination pointer.
 TIR_DEFINE_BUILTIN_FUNC(ptx_add_f32)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 TIR_DEFINE_BUILTIN_FUNC(ptx_add_f32x2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 TIR_DEFINE_BUILTIN_FUNC(ptx_add_f64)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(ptx_sub_f32)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 TIR_DEFINE_BUILTIN_FUNC(ptx_sub_f32x2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 TIR_DEFINE_BUILTIN_FUNC(ptx_sub_f64)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(ptx_mul_f32)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 TIR_DEFINE_BUILTIN_FUNC(ptx_mul_f32x2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 TIR_DEFINE_BUILTIN_FUNC(ptx_mul_f64)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIR_DEFINE_BUILTIN_FUNC(ptx_fma_f32)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 TIR_DEFINE_BUILTIN_FUNC(ptx_fma_f32x2)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 TIR_DEFINE_BUILTIN_FUNC(ptx_fma_f64)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 // max stays value-returning + kPure (no .sat, not in the add/sub/mul/fma family).
 TIR_DEFINE_BUILTIN_FUNC(ptx_max_f32)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 }  // namespace builtin
 }  // namespace tirx
 }  // namespace tvm

--- a/src/tirx/op/op.cc
+++ b/src/tirx/op/op.cc
@@ -44,12 +44,12 @@ using namespace tirx;
 // macro to register an unary op
 #define TVM_TIR_REGISTER_PURE_UNARY_OP(OpName)                             \
   TVM_TIR_REGISTER_OP(OpName).set_num_inputs(1).set_attr<TCallEffectKind>( \
-      "TCallEffectKind", Integer(CallEffectKind::kPure))
+      "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
 
 // macro to register an binary op
 #define TVM_TIR_REGISTER_PURE_BINARY_OP(OpName)                            \
   TVM_TIR_REGISTER_OP(OpName).set_num_inputs(2).set_attr<TCallEffectKind>( \
-      "TCallEffectKind", Integer(CallEffectKind::kPure))
+      "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))
 
 runtime::DataType GetRuntimeDataType(const Type& type) {
   if (auto* n = type.as<PrimTypeNode>()) {
@@ -1167,12 +1167,12 @@ TVM_TIR_REGISTER_PURE_BINARY_OP("ldexp");
 TVM_TIR_REGISTER_OP("TVMBackendAllocWorkspace")
     .set_num_inputs(5)
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "TVMBackendAllocWorkspace")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TVM_TIR_REGISTER_OP("TVMBackendFreeWorkspace")
     .set_num_inputs(3)
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "TVMBackendFreeWorkspace")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 // expose basic functions to node namespace
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/tirx/op/runtime.cc
+++ b/src/tirx/op/runtime.cc
@@ -30,12 +30,12 @@ namespace tirx {
 TVM_REGISTER_OP("tirx.TVMBackendAnyListSetPackedArg")
     .set_num_inputs(5)
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "TVMBackendAnyListSetPackedArg")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TVM_REGISTER_OP("tirx.TVMBackendAnyListMoveFromPackedReturn")
     .set_num_inputs(3)
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "TVMBackendAnyListMoveFromPackedReturn")
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 }  // namespace tirx
 }  // namespace tvm

--- a/src/tirx/op/target_builtin/cuda.cc
+++ b/src/tirx/op/target_builtin/cuda.cc
@@ -39,24 +39,24 @@ namespace builtin {
   TVM_TIRX_REGISTER_OP(#OpName)
 
 TIRX_DEFINE_BUILTIN_FUNC(tvm_load_matrix_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kReadState));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kReadState));
 
 TIRX_DEFINE_BUILTIN_FUNC(tvm_mma_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(tvm_bmma_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(tvm_fill_fragment)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(tvm_store_matrix_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_mma)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 // Siblings of ptx_mma / ptx_ldmatrix / mma_store / mma_fill that accept
 // (ptr_var, offset) pairs. Codegen emits `ptr + offset` C-pointer
@@ -64,276 +64,276 @@ TIRX_DEFINE_BUILTIN_FUNC(ptx_mma)
 // to its thread-local index. Used by the s_tir tensor_intrin tensorize
 // path so per-thread fragment offsets stay element-accurate.
 TIRX_DEFINE_BUILTIN_FUNC(ptx_mma_legacy)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_ldmatrix_legacy)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIRX_DEFINE_BUILTIN_FUNC(mma_store_legacy)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(mma_fill_legacy)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_ldg32).set_num_inputs(4).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_mma_sp)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_ldmatrix)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_bulk)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_bulk_shared_to_cluster)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_commit_group)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_wait_group)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_mbarrier_arrive)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
-TIRX_DEFINE_BUILTIN_FUNC(ptx_fence).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                              Integer(CallEffectKind::kOpaque));
+TIRX_DEFINE_BUILTIN_FUNC(ptx_fence).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_fence_proxy_async)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_mbarrier_init)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_mbarrier_arrive)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_mbarrier_arrive_expect_tx)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_mbarrier_try_wait)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_bar_arrive)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_bar_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_bulk_tensor_global_to_cluster)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_bulk_tensor_tile_gather4_global_to_cluster)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_bulk_tensor_shared_to_global)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_bulk_tensor_global_to_cluster_prefetch)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_bulk_tensor_shared_to_global_reduce)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_bulk_commit_group)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_cp_async_bulk_wait_group)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_barrier_cluster_arrive)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_barrier_cluster_wait)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_elect_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_fence_mbarrier_init)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_fetch_register)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kPure));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure));
 
 // griddepcontrol — programmatic dependent launch synchronization (sm_90+).
 // Both are memory barriers; mark kOpaque to prevent CSE/reordering.
 TIRX_DEFINE_BUILTIN_FUNC(ptx_griddepcontrol_wait)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_griddepcontrol_launch_dependents)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(mma_store)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIRX_DEFINE_BUILTIN_FUNC(mma_fill)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque))
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque))
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
-                                         Integer(ScriptDtypePrintLocation::kFirst));
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_wgmma_encode_matrix_descriptor)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_wgmma_noop_barrier)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_wgmma_mma_async_ss)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_wgmma_mma_async_rs)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_wgmma_fence)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_wgmma_commit_group)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_wgmma_wait_group)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_stmatrix)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_setmaxnreg)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_ld_global_acquire)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_alloc)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_dealloc)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_relinquish_alloc_permit)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_fence_before_thread_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_fence_after_thread_sync)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_ld)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_st)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_wait_ld)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_wait_st)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_encode_matrix_descriptor)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_encode_instr_descriptor)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_encode_instr_descriptor_block_scaled)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_mma)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_mma_block_scale)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_mma_sp)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_mma_sp_block_scale)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_commit)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_cp)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_tcgen05_shift)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(ptx_map_shared_rank)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(cuda_func_call)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_my_pe)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_n_pes)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_getmem_nbi)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_putmem_nbi)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_getmem_nbi_warp)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_putmem_nbi_warp)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_getmem_nbi_block)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_putmem_nbi_block)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_signal_op)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_wait_until)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_quiet)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_putmem_signal_nbi)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_putmem_signal_nbi_warp)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_putmem_signal_nbi_block)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_fence)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nvshmem_barrier_all)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 }  // namespace builtin
 }  // namespace tirx

--- a/src/tirx/op/target_builtin/trn.cc
+++ b/src/tirx/op/target_builtin/trn.cc
@@ -38,53 +38,53 @@ namespace builtin {
   }                                                 \
   TVM_TIRX_REGISTER_OP(#OpName)
 
-TIRX_DEFINE_BUILTIN_FUNC(nki_load).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                             Integer(CallEffectKind::kOpaque));
+TIRX_DEFINE_BUILTIN_FUNC(nki_load).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
-TIRX_DEFINE_BUILTIN_FUNC(nki_store).set_attr<TCallEffectKind>("TCallEffectKind",
-                                                              Integer(CallEffectKind::kOpaque));
+TIRX_DEFINE_BUILTIN_FUNC(nki_store).set_attr<TCallEffectKind>(
+    "TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_tensor_copy)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_matmul)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_activation)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_reciprocal)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_tensortensor)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_tensorscalar)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_memset)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_tensorreduce)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_activation_reduce)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_tensorscalar_reduce)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_identity)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_scalar_tensor_tensor)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_scalar_tensor_scalar)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 TIRX_DEFINE_BUILTIN_FUNC(nki_affine_select)
-    .set_attr<TCallEffectKind>("TCallEffectKind", Integer(CallEffectKind::kOpaque));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kOpaque));
 
 }  // namespace builtin
 }  // namespace tirx

--- a/src/tirx/op/tirx.cc
+++ b/src/tirx/op/tirx.cc
@@ -44,8 +44,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   TVM_REGISTER_OP("tirx." #OpName)                  \
       .set_attr<TScriptPrinterName>("TScriptPrinterName", ffi::String(#OpName), /*plevel=*/9)
 
-#define TIRX_DEFINE_OP(OpName) \
-  TIRX_DEFINE_BUILTIN_FUNC(OpName).set_attr<Bool>("TIsTIRxOp", Bool(true))
+#define TIRX_DEFINE_OP(OpName) TIRX_DEFINE_BUILTIN_FUNC(OpName).set_attr<bool>("TIsTIRxOp", true)
 
 /********************* ScheduleContext **********************/
 template <typename Key, typename Value>
@@ -185,8 +184,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 }
 
 /********************* Dispatch Ops **********************/
-#define TIRX_DEFINE_DISPATCH_OP(OpName) \
-  TIRX_DEFINE_OP(OpName).set_attr<Bool>("TIsDispatchOp", Bool(true))
+#define TIRX_DEFINE_DISPATCH_OP(OpName) TIRX_DEFINE_OP(OpName).set_attr<bool>("TIsDispatchOp", true)
 
 TIRX_DEFINE_DISPATCH_OP(zero);
 TIRX_DEFINE_DISPATCH_OP(sqrt);
@@ -217,13 +215,12 @@ TIRX_DEFINE_DISPATCH_OP(silu);
 TIRX_DEFINE_DISPATCH_OP(permute_dims);
 
 /********************* Compose Ops **********************/
-#define TIRX_DEFINE_COMPOSE_OP(OpName) \
-  TIRX_DEFINE_OP(OpName).set_attr<Bool>("TIsComposeOp", Bool(true))
+#define TIRX_DEFINE_COMPOSE_OP(OpName) TIRX_DEFINE_OP(OpName).set_attr<bool>("TIsComposeOp", true)
 
 TIRX_DEFINE_COMPOSE_OP(compose_op);
 
 /********************* Async Ops **********************/
-#define TIRX_DEFINE_ASYNC_OP(OpName) TIRX_DEFINE_OP(OpName).set_attr<Bool>("TIsAsyncOp", Bool(true))
+#define TIRX_DEFINE_ASYNC_OP(OpName) TIRX_DEFINE_OP(OpName).set_attr<bool>("TIsAsyncOp", true)
 
 TIRX_DEFINE_ASYNC_OP(copy_async);
 TIRX_DEFINE_ASYNC_OP(gemm_async);

--- a/src/tirx/script/builder/frame.cc
+++ b/src/tirx/script/builder/frame.cc
@@ -106,10 +106,10 @@ void PrimFuncFrameNode::ExitWithScope() {
     insert_attr(tvm::attr::kGlobalSymbol, name.value());
   }
   if (s_tir) {
-    insert_attr(tvm::attr::kSTir, tvm::Bool(true));
+    insert_attr(tvm::attr::kSTir, true);
   }
   if (persistent) {
-    insert_attr(tvm::tirx::attr::kPersistentKernel, tvm::Bool(true));
+    insert_attr(tvm::tirx::attr::kPersistentKernel, true);
   }
   // s_tir-mode normalization: drop stale default layouts (see comment on
   // STirBufferLayoutNormalizer above) and rewrite body references coherently.

--- a/src/tirx/script/printer/expr.cc
+++ b/src/tirx/script/printer/expr.cc
@@ -286,8 +286,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
         }
         prefix = TIR(d, name);
         if (dtype_locations.count(op)) {
-          dtype_print_location =
-              static_cast<tirx::ScriptDtypePrintLocation>(dtype_locations[op].IntValue());
+          dtype_print_location = static_cast<tirx::ScriptDtypePrintLocation>(dtype_locations[op]);
         }
         if (name == "call_llvm_pure_intrin" || name == "call_llvm_intrin") {
           int n_args = call->args.size();

--- a/src/tirx/script/printer/stmt.cc
+++ b/src/tirx/script/printer/stmt.cc
@@ -90,15 +90,14 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
             LOG(WARNING) << "No TScriptPrinterName attribute for " << op->name;
           }
 
-          static const auto& tirx_op_map = Op::GetAttrMap<Bool>("TIsTIRxOp");
-          static const auto& dispatch_op_map = Op::GetAttrMap<Bool>("TIsDispatchOp");
-          static const auto& compose_op_map = Op::GetAttrMap<Bool>("TIsComposeOp");
-          static const auto& async_op_map = Op::GetAttrMap<Bool>("TIsAsyncOp");
-          TVM_FFI_ICHECK(bool(tirx_op_map.get(op, tvm::Bool(false))))
+          static const auto& tirx_op_map = Op::GetAttrMap<bool>("TIsTIRxOp");
+          static const auto& dispatch_op_map = Op::GetAttrMap<bool>("TIsDispatchOp");
+          static const auto& compose_op_map = Op::GetAttrMap<bool>("TIsComposeOp");
+          static const auto& async_op_map = Op::GetAttrMap<bool>("TIsAsyncOp");
+          TVM_FFI_ICHECK(tirx_op_map.get(op, false))
               << "Only TIRX ops can be used in tirx::TilePrimitiveCall";
           ffi::String name = op_names.get(op, op->name);
-          if (bool(dispatch_op_map.get(op, tvm::Bool(false))) ||
-              bool(async_op_map.get(op, tvm::Bool(false)))) {
+          if (dispatch_op_map.get(op, false) || async_op_map.get(op, false)) {
             // Dispatch ops
             // Trim trailing None args (e.g. optional bias=None, scale=None)
             size_t n_args = op_call->args.size();
@@ -130,7 +129,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
             return OpCallDoc(TIRx(d, name), args,
                              d->AsDoc<DictDoc>(op_call->workspace, p->Attr("workspace")),
                              d->AsDoc<DictDoc>(op_call->config, p->Attr("config")), disp);
-          } else if (bool(compose_op_map.get(op, tvm::Bool(false)))) {
+          } else if (compose_op_map.get(op, false)) {
             // Compose ops
             With<TIRFrame> f(d, op_call);
             ffi::Array<tirx::Stmt> stmts;

--- a/src/tirx/transform/lower_intrin.cc
+++ b/src/tirx/transform/lower_intrin.cc
@@ -364,9 +364,8 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
 
 Stmt LowerIntrinStmt(Stmt stmt, const std::string& target) {
   arith::Analyzer analyzer;
-  bool enable_fast_math = transform::PassContext::Current()
-                              ->GetConfig<Bool>("tirx.enable_fast_math", Bool(false))
-                              .value();
+  bool enable_fast_math =
+      transform::PassContext::Current()->GetConfig<bool>("tirx.enable_fast_math", false).value();
   return IntrinInjecter(&analyzer, Target(ffi::String(target)), enable_fast_math)(std::move(stmt));
 }
 
@@ -378,7 +377,7 @@ Pass LowerIntrin() {
     auto target = f->GetAttr<Target>(tvm::attr::kTarget);
     TVM_FFI_ICHECK(target.defined()) << "LowerIntrin: Require the target attribute";
     arith::Analyzer analyzer;
-    bool enable_fast_math = ctx->GetConfig<Bool>("tirx.enable_fast_math", Bool(false)).value();
+    bool enable_fast_math = ctx->GetConfig<bool>("tirx.enable_fast_math", false).value();
     n->body = IntrinInjecter(&analyzer, target.value(), enable_fast_math)(std::move(n->body));
     return f;
   };

--- a/src/tirx/transform/lower_warp_memory.cc
+++ b/src/tirx/transform/lower_warp_memory.cc
@@ -526,7 +526,7 @@ Pass LowerWarpMemory() {
     auto* n = f.CopyOnWrite();
     auto target = f->GetAttr<Target>(tvm::attr::kTarget);
     TVM_FFI_ICHECK(target.defined()) << "LowerWarpMemory: Require the target attribute";
-    int warp_size = target.value()->GetAttr<Integer>("thread_warp_size", 1).value().IntValue();
+    int warp_size = target.value()->GetAttr<int64_t>("thread_warp_size", 1).value();
     WarpMemoryRewriter warp_memory_rewriter(warp_size);
     auto stmt = warp_memory_rewriter.Rewrite(std::move(n->body));
     n->body = UpdatePointerStorageScope(warp_memory_rewriter.new_storage_scopes_)(stmt);

--- a/src/tirx/transform/make_packed_api.cc
+++ b/src/tirx/transform/make_packed_api.cc
@@ -178,8 +178,8 @@ class SubroutineCallRewriter : public StmtExprMutator {
 ffi::Optional<ffi::String> RequiresPackedAPI(const PrimFunc& func) {
   // A function with an explicit calling convention has already been
   // lowered, and should not be modified.
-  if (auto opt = func->GetAttr<Integer>(tvm::attr::kCallingConv)) {
-    if (CallingConv(opt.value()->value) != CallingConv::kDefault) {
+  if (auto opt = func->GetAttr<int64_t>(tvm::attr::kCallingConv)) {
+    if (CallingConv(opt.value()) != CallingConv::kDefault) {
       return std::nullopt;
     }
   }

--- a/src/tirx/transform/split_host_device.cc
+++ b/src/tirx/transform/split_host_device.cc
@@ -115,16 +115,16 @@ class HostDeviceSplitter : public StmtMutator {
     if (cur_func_->attrs.defined() && cur_func_->attrs->dict.count(tvm::attr::kSTir)) {
       device_func = WithAttr(std::move(device_func), tvm::attr::kSTir, tvm::Bool(true));
     }
-    auto num_inputs = cur_func_->GetAttr<Integer>(tvm::attr::kNumInputs);
-    if (num_inputs.defined()) {
+    auto num_inputs = cur_func_->GetAttr<int64_t>(tvm::attr::kNumInputs);
+    if (num_inputs.has_value()) {
       device_func = WithAttr(std::move(device_func), tvm::attr::kNumInputs, num_inputs);
     }
-    auto persistent = cur_func_->GetAttr<Bool>(tirx::attr::kPersistentKernel);
-    if (persistent.defined()) {
+    auto persistent = cur_func_->GetAttr<bool>(tirx::attr::kPersistentKernel);
+    if (persistent.has_value()) {
       device_func = WithAttr(std::move(device_func), tirx::attr::kPersistentKernel, persistent);
     }
-    auto entry_cluster_sync = cur_func_->GetAttr<Bool>(kEntryClusterSyncAttr);
-    if (entry_cluster_sync.defined()) {
+    auto entry_cluster_sync = cur_func_->GetAttr<bool>(kEntryClusterSyncAttr);
+    if (entry_cluster_sync.has_value()) {
       device_func = WithAttr(std::move(device_func), kEntryClusterSyncAttr, entry_cluster_sync);
     }
     GlobalVar kernel_symbol_global = var_supply_();

--- a/src/tirx/transform/split_host_device.cc
+++ b/src/tirx/transform/split_host_device.cc
@@ -113,7 +113,7 @@ class HostDeviceSplitter : public StmtMutator {
                                                      {tirx::attr::kNoAlias, true},
                                                      {tirx::attr::kIsGlobalFunc, true}});
     if (cur_func_->attrs.defined() && cur_func_->attrs->dict.count(tvm::attr::kSTir)) {
-      device_func = WithAttr(std::move(device_func), tvm::attr::kSTir, tvm::Bool(true));
+      device_func = WithAttr(std::move(device_func), tvm::attr::kSTir, true);
     }
     auto num_inputs = cur_func_->GetAttr<int64_t>(tvm::attr::kNumInputs);
     if (num_inputs.has_value()) {

--- a/src/tirx/transform/stmt_simplify.cc
+++ b/src/tirx/transform/stmt_simplify.cc
@@ -169,8 +169,8 @@ class StmtSimplifier : public IRMutatorWithAnalyzer {
   }
 
   Stmt VisitStmt_(const IfThenElseNode* op) override {
-    if (ffi::Optional<Bool> cond = ProveCondition(op->condition)) {
-      if (cond.value()->value) {
+    if (ffi::Optional<bool> cond = ProveCondition(op->condition)) {
+      if (cond.value()) {
         return this->VisitStmt(op->then_case);
       } else if (op->else_case) {
         return this->VisitStmt(op->else_case.value());
@@ -184,8 +184,8 @@ class StmtSimplifier : public IRMutatorWithAnalyzer {
 
   PrimExpr VisitExpr_(const CallNode* op) override {
     if (op->op.same_as(builtin::if_then_else())) {
-      if (ffi::Optional<Bool> cond = ProveCondition(op->args[0])) {
-        if (cond.value()->value) {
+      if (ffi::Optional<bool> cond = ProveCondition(op->args[0])) {
+        if (cond.value()) {
           return this->VisitExpr(op->args[1]);
         } else {
           return this->VisitExpr(op->args[2]);
@@ -229,11 +229,11 @@ class StmtSimplifier : public IRMutatorWithAnalyzer {
    *
    * Substitutes any known Bind values and then simplifies with the analyzer.
    */
-  ffi::Optional<Bool> ProveCondition(PrimExpr condition) const {
+  ffi::Optional<bool> ProveCondition(PrimExpr condition) const {
     condition = Substitute(condition, non_inlined_bindings_);
     condition = analyzer_->Simplify(condition);
     if (const int64_t* as_int = as_const_int(condition)) {
-      return Bool(*as_int);
+      return *as_int != 0;
     } else {
       return std::nullopt;
     }

--- a/src/tirx/transform/storage_rewrite.cc
+++ b/src/tirx/transform/storage_rewrite.cc
@@ -1754,7 +1754,7 @@ Pass StorageRewrite() {
   auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
     bool enable_reuse = true;
     bool reuse_require_exact_matched_dtype = false;
-    bool merge_static_smem = ctx->GetConfig<Bool>("tirx.merge_static_smem", Bool(false)).value();
+    bool merge_static_smem = ctx->GetConfig<bool>("tirx.merge_static_smem", false).value();
     if (merge_static_smem) {
       // When `merge_static_smem` is true, we will reuse and merge shared
       // memory in a dedicated pass `MergeSharedMemoryAllocations`.

--- a/src/tirx/transform/storage_rewrite.cc
+++ b/src/tirx/transform/storage_rewrite.cc
@@ -674,7 +674,7 @@ class StoragePlanRewriter : public StmtExprMutator {
           Buffer buf = RemapBuffer(e->allocs[0]->buffer, e->alloc_var);
           ffi::Map<ffi::String, ffi::Any> annotations;
           if (e->is_volatile) {
-            annotations.Set(attr::kVolatile, Bool(true));
+            annotations.Set(attr::kVolatile, true);
           }
           e->alloc_nest.push_back(AllocBuffer(buf, annotations));
           continue;
@@ -711,7 +711,7 @@ class StoragePlanRewriter : public StmtExprMutator {
           Buffer buf = RemapBuffer(e->allocs[0]->buffer, e->alloc_var);
           ffi::Map<ffi::String, ffi::Any> annotations;
           if (e->is_volatile) {
-            annotations.Set(attr::kVolatile, Bool(true));
+            annotations.Set(attr::kVolatile, true);
           }
           e->alloc_nest.push_back(AllocBuffer(buf, annotations));
         } else {
@@ -756,7 +756,7 @@ class StoragePlanRewriter : public StmtExprMutator {
                      e->alloc_var->name_hint, 0, 0, BufferType::kDefault);
           ffi::Map<ffi::String, ffi::Any> annotations;
           if (e->is_volatile) {
-            annotations.Set(attr::kVolatile, Bool(true));
+            annotations.Set(attr::kVolatile, true);
           }
           e->alloc_nest.push_back(AllocBuffer(buf, annotations));
         }
@@ -798,7 +798,7 @@ class StoragePlanRewriter : public StmtExprMutator {
     }
     ffi::Map<ffi::String, ffi::Any> annotations;
     if (any_volatile) {
-      annotations.Set(attr::kVolatile, Bool(true));
+      annotations.Set(attr::kVolatile, true);
     }
     e->alloc_nest.push_back(AllocBuffer(buf, annotations));
   }

--- a/src/tirx/transform/vectorize_loop.cc
+++ b/src/tirx/transform/vectorize_loop.cc
@@ -79,9 +79,9 @@ inline PrimExpr BroadcastTo(PrimExpr e, int lanes, bool is_scalable) {
 
 bool EnableBufferLevelPredication(Target target) {
   transform::PassContext pass_ctx = transform::PassContext::Current();
-  ffi::Optional<Bool> enable_buffer_predication =
-      pass_ctx->GetConfig<Bool>("tirx.enable_buffer_level_predication");
-  if (enable_buffer_predication.defined()) {
+  ffi::Optional<bool> enable_buffer_predication =
+      pass_ctx->GetConfig<bool>("tirx.enable_buffer_level_predication");
+  if (enable_buffer_predication.has_value()) {
     return enable_buffer_predication.value();
   }
 

--- a/tests/python/s_tir/schedule/test_tir_schedule_annotate_buffer_access.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_annotate_buffer_access.py
@@ -161,9 +161,7 @@ def test_annotate_buffer_access_read_and_write():
                 vi, vj = T.axis.remap("SS", [i, j])
                 T.reads(A[vi - 1 : vi + 2, vj - 1 : vj + 2])
                 T.writes(B[vi : vi + 2, vj : vj + 2])
-                T.sblock_attr(
-                    {"explicit_read_region": [0], "explicit_write_region": [0]}
-                )
+                T.sblock_attr({"explicit_read_region": [0], "explicit_write_region": [0]})
                 B[vi, vj] = A[vi, vj] * 2.0
         for i, j in T.grid(128, 128):
             with T.sblock("C"):

--- a/tests/python/s_tir/schedule/test_tir_schedule_annotate_buffer_access.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_annotate_buffer_access.py
@@ -47,7 +47,7 @@ def test_annotate_read_buffer_access():
                 vi, vj = T.axis.remap("SS", [i, j])
                 T.reads(A[vi - 1 : vi - 1 + 2, vj - 1 : vj - 1 + 2])
                 T.writes(B[vi, vj])
-                T.sblock_attr({"explicit_read_region": [T.int32(0)]})
+                T.sblock_attr({"explicit_read_region": [0]})
                 B[vi, vj] = A[vi, vj] * 2.0
         for i, j in T.grid(128, 128):
             with T.sblock("C"):
@@ -84,7 +84,7 @@ def test_annotate_write_buffer_access():
                 vi, vj = T.axis.remap("SS", [i, j])
                 T.reads(A[vi, vj])
                 T.writes(B[vi : vi + 2, vj : vj + 2])
-                T.sblock_attr({"explicit_write_region": [T.int32(0)]})
+                T.sblock_attr({"explicit_write_region": [0]})
                 B[vi, vj] = A[vi, vj] * 2.0
         for i, j in T.grid(128, 128):
             with T.sblock("C"):
@@ -116,7 +116,7 @@ def test_annotate_buffer_access_for_resize():
                 v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
                 T.reads(x[v_i0, v_i1, v_i2 * 2 - 3:v_i2 * 2 + 3, v_i3 * 2 - 3:v_i3 * 2 + 3])
                 T.writes(resize[v_i0, v_i1, v_i2, v_i3])
-                T.sblock_attr({"explicit_read_region": [T.int32(0)]})
+                T.sblock_attr({"explicit_read_region": [0]})
                 resize[v_i0, v_i1, v_i2, v_i3] = T.Cast("float16", T.Cast("float32", x[v_i0, v_i1, T.max(T.min(T.Cast("int32", T.floor((T.Cast("float32", v_i2) + T.float32(0.5)) * T.float32(2) - T.float32(0.5) + T.float32(1.0000000000000001e-05))), 31), 0), T.max(T.min(T.Cast("int32", T.floor((T.Cast("float32", v_i3) + T.float32(0.5)) * T.float32(2) - T.float32(0.5) + T.float32(1.0000000000000001e-05))), 31), 0)]))
     # fmt: on
     sch = tvm.s_tir.Schedule(resize_before, debug_mask="all")
@@ -162,7 +162,7 @@ def test_annotate_buffer_access_read_and_write():
                 T.reads(A[vi - 1 : vi + 2, vj - 1 : vj + 2])
                 T.writes(B[vi : vi + 2, vj : vj + 2])
                 T.sblock_attr(
-                    {"explicit_read_region": [T.int32(0)], "explicit_write_region": [T.int32(0)]}
+                    {"explicit_read_region": [0], "explicit_write_region": [0]}
                 )
                 B[vi, vj] = A[vi, vj] * 2.0
         for i, j in T.grid(128, 128):
@@ -210,7 +210,7 @@ def test_double_annotate_buffer_access_read():
                 vi, vj = T.axis.remap("SS", [i, j])
                 T.reads(A[vi - 2 : vi + 3, vj - 2 : vj + 3])
                 T.writes(B[vi, vj])
-                T.sblock_attr({"explicit_read_region": [T.int32(0)]})
+                T.sblock_attr({"explicit_read_region": [0]})
                 B[vi, vj] = A[vi, vj] * 2.0
         for i, j in T.grid(128, 128):
             with T.sblock("C"):
@@ -269,7 +269,7 @@ def test_annotate_buffer_access_with_compute_at_for_resize():
                     v_i3 = T.axis.spatial(100, i3_0 * 10 + i3_1)
                     T.reads(x_global[v_i0, v_i1, v_i2 * 2 - 3:v_i2 * 2 - 3 + 6, v_i3 * 2 - 3:v_i3 * 2 - 3 + 6])
                     T.writes(y[v_i0, v_i1, v_i2, v_i3])
-                    T.sblock_attr({"explicit_read_region": [T.int32(0)]})
+                    T.sblock_attr({"explicit_read_region": [0]})
                     y[v_i0, v_i1, v_i2, v_i3] = x_global[v_i0, v_i1, T.Cast("int32", T.floor(T.Cast("float32", v_i2 * 2) + T.float32(0.5))), T.Cast("int32", T.floor(T.Cast("float32", v_i3 * 2) + T.float32(0.5)))]
 
     @T.prim_func(s_tir=True)

--- a/tests/python/s_tir/schedule/test_tir_schedule_sampling.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_sampling.py
@@ -146,7 +146,7 @@ def test_sample_categorical_serialize():
         decisions.append(rv)
     new_sch = verify_trace_roundtrip(sch, mod=elementwise)
     for i, new_inst in enumerate(new_sch.trace.insts):
-        assert decisions[i] == candidates[new_sch.trace.decisions[new_inst].value]
+        assert decisions[i] == candidates[new_sch.trace.decisions[new_inst]]
 
 
 def test_sample_perfect_tile_power_of_two():

--- a/tests/python/tirx-base/test_tir_stmt_functor_substitute.py
+++ b/tests/python/tirx-base/test_tir_stmt_functor_substitute.py
@@ -29,7 +29,7 @@ def _apply_substitute(mod):
     new_func = (
         tvm.tirx.PrimFunc(params=[], body=substitute(func.body, vmap))
         .with_attr("global_symbol", func.attrs["global_symbol"])
-        .with_attr("s_tir", tvm.tirx.IntImm("bool", 1))
+        .with_attr("s_tir", True)
     )
     return tvm.IRModule.from_expr(new_func)
 

--- a/tests/python/tirx-transform/test_tir_transform_convert_ssa.py
+++ b/tests/python/tirx-transform/test_tir_transform_convert_ssa.py
@@ -38,7 +38,7 @@ def test_reuse_in_sequential_bind():
             tirx.Evaluate(var),
         ]
     )
-    before = tirx.PrimFunc([], sequential_bindings).with_attr("s_tir", tirx.IntImm("bool", 1))
+    before = tirx.PrimFunc([], sequential_bindings).with_attr("s_tir", True)
 
     @T.prim_func(private=True, s_tir=True)
     def expected():

--- a/tests/python/tvmscript/test_tvmscript_ir_builder_tir.py
+++ b/tests/python/tvmscript/test_tvmscript_ir_builder_tir.py
@@ -44,7 +44,7 @@ def test_ir_builder_tir_primfunc_base():
         body=tirx.Evaluate(0),
         ret_type=None,
         buffer_map=None,
-        attrs=tvm.ir.make_node("ir.DictAttrs", s_tir=tirx.IntImm("bool", 1)),
+        attrs=tvm.ir.make_node("ir.DictAttrs", s_tir=True),
     )
 
     # Check if the generated ir is expected
@@ -91,7 +91,7 @@ def test_ir_builder_tir_primfunc_complete():
         body=tirx.Evaluate(0),
         ret_type=tvm.ir.PrimType("int64"),
         buffer_map={c_handle: c_buffer, d_handle: d_buffer, e_handle: e_buffer},
-        attrs=tvm.ir.make_node("ir.DictAttrs", key="value", s_tir=tirx.IntImm("bool", 1)),
+        attrs=tvm.ir.make_node("ir.DictAttrs", key="value", s_tir=True),
     )
 
     # Check if the generated ir is expected
@@ -349,7 +349,7 @@ def test_ir_builder_tir_thread():
     # the expected prim_func
     iter_var = tirx.IterVar((0, 1), "v", iter_type=1, thread_tag="blockIdx.y")
     attr_stmt = tirx.AttrStmt(iter_var, "thread_extent", 1, tirx.Evaluate(0))
-    func = tirx.PrimFunc([], attr_stmt).with_attr("s_tir", tirx.IntImm("bool", 1))
+    func = tirx.PrimFunc([], attr_stmt).with_attr("s_tir", True)
 
     # Check if the generated ir is expected
     assert_structural_equal(ir_actual, func, map_free_vars=True)


### PR DESCRIPTION
## Summary

Now that the ffi container machinery (Array, Optional, Map, Variant) accepts bare int64_t and bool, the Integer/Bool ObjectRef wrappers add no value in attribute fields, pass-config options, function-attr flags, and OpAttrMap registries — every reader paid an extra .IntValue() / ->value unbox per access for no information gain. This PR is the first stage of phasing out class Integer and class Bool: migrate the bulk of those sites at the field-declaration and call-site level. A follow-up will rewrite the remaining IR-position `Integer(N)` / `Bool(b)` constructors to `IntImm(...)` / `const_true()` / `const_false()` and delete the two classes entirely.

- Relax Attrs fields and their container forms (`Array<Integer>` / `Optional<Array<Integer>>` / `Optional<Integer>` / `Optional<Bool>`) migrated to bare `int64_t` / `bool` (manipulate.h, nn.h, op.h, statistical.h, script/builder/frame.h, target/virtual_device.h, distributed/global_info.h, relax/expr.h).
- OpAttrMap registry (`set_attr<Bool>("FPurity", Bool(true))` ↔ `GetAttrMap<Bool>("FPurity")`) migrated to `bool` across ~38 files.
- PassContext config registrations + `GetConfig<Bool>` / `GetConfig<Integer>` readers, and function-attr `GetAttr<Bool>` / `GetAttr<Integer>` readers (~42 files), all migrated; `HasNonzeroAttr` in `ir/attrs.h` dropped its `.IntValue()` unbox.
- Schedule decision arrays (SampleCategorical candidates, perfect-tile factors, autobind thread_extents, multi-level-tiling levels) migrated to `Array<int64_t>` / `Optional<int64_t>` — this is a virtual-signature change on `ConcreteScheduleNode::SampleCategorical` and related methods, acceptable per the phase-out intent.
- `Variant<Bool, Array<String>>` for `LiftTransformParams.shared_transform` migrated to `Variant<bool, Array<String>>`.