### PR TITLE
[REFACTOR][IR] Delete class Bool and class Integer boxed-type wrappers

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -557,108 +557,6 @@ class FloatImm : public PrimExpr {
   TVM_DEFINE_OBJECT_REF_COW_METHOD(FloatImmNode);
 };
 
-/*!
- * \brief Boolean constant.
- *
- *  This reference type is useful to add additional compile-time
- *  type checks and helper functions for Integer equal comparisons.
- */
-class Bool : public IntImm {
- public:
-  explicit Bool(bool value, Span span = Span()) : IntImm(DataType::Bool(), value, span) {}
-  Bool operator!() const { return Bool((*this)->value == 0); }
-  operator bool() const { return (*this)->value != 0; }
-
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Bool, IntImm, IntImmNode);
-};
-
-// Overload operators to make sure we have the most fine grained types.
-inline Bool operator||(const Bool& a, bool b) { return Bool(a.operator bool() || b); }
-inline Bool operator||(bool a, const Bool& b) { return Bool(a || b.operator bool()); }
-inline Bool operator||(const Bool& a, const Bool& b) {
-  return Bool(a.operator bool() || b.operator bool());
-}
-inline Bool operator&&(const Bool& a, bool b) { return Bool(a.operator bool() && b); }
-inline Bool operator&&(bool a, const Bool& b) { return Bool(a && b.operator bool()); }
-inline Bool operator&&(const Bool& a, const Bool& b) {
-  return Bool(a.operator bool() && b.operator bool());
-}
-
-inline bool operator==(const Bool& a, bool b) { return a.operator bool() == b; }
-inline bool operator==(bool a, const Bool& b) { return a == b.operator bool(); }
-inline bool operator==(const Bool& a, const Bool& b) {
-  return a.operator bool() == b.operator bool();
-}
-
-/*!
- * \brief Container of constant int that adds more constructors.
- *
- * This is used to store and automate type check
- * attributes that must be constant integer.
- *
- * \sa IntImm
- */
-class Integer : public IntImm {
- public:
-  Integer() {}
-  /*!
-   * \brief constructor from node.
-   */
-  explicit Integer(ffi::ObjectPtr<IntImmNode> node) : IntImm(node) {}
-  /*!
-   * \brief constructor with UnsafeInit
-   */
-  explicit Integer(ffi::UnsafeInit tag) : IntImm(tag) {}
-  /*!
-   * \brief Construct integer from int value.
-   */
-  Integer(int value, Span span = Span()) : IntImm(DataType::Int(32), value, span) {}  // NOLINT(*)
-  /*!
-   * \brief Construct integer from int imm.
-   * \param other The other value.
-   */
-  Integer(IntImm other) : IntImm(std::move(other)) {}  // NOLINT(*)
-  /*!
-   * \brief Constructor from enum
-   * \tparam Enum The enum type.
-   * \param value The enum value.
-   */
-  template <typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type>
-  explicit Integer(Enum value) : Integer(static_cast<int>(value)) {
-    static_assert(std::is_same<int, typename std::underlying_type<Enum>::type>::value,
-                  "declare enum to be enum int to use visitor");
-  }
-  /*!
-   * \brief Assign an expression to integer.
-   * \param other another expression.
-   */
-  Integer& operator=(const IntImm& other) {
-    data_ = ffi::details::ObjectUnsafe::ObjectPtrFromObjectRef<ffi::Object>(other);
-    return *this;
-  }
-  /*!
-   * \brief convert to int64_t
-   */
-  int64_t IntValue() const {
-    TVM_FFI_ICHECK(data_ != nullptr) << " Trying to reference a null Integer";
-    return (*this)->value;
-  }
-  // comparators
-  Bool operator==(int other) const {
-    if (data_ == nullptr) return Bool(false);
-    return Bool((*this)->value == other);
-  }
-  Bool operator!=(int other) const { return !(*this == other); }
-  template <typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type>
-  Bool operator==(Enum other) const {
-    return *this == static_cast<int>(other);
-  }
-  template <typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type>
-  Bool operator!=(Enum other) const {
-    return *this != static_cast<int>(other);
-  }
-};
-
 /*! \brief range over one dimension */
 class RangeNode : public ffi::Object {
  public:
@@ -730,16 +628,6 @@ struct TypeTraits<IntImm> : public ObjectRefWithFallbackTraitsBase<IntImm, int64
 };
 
 template <>
-inline constexpr bool use_default_type_traits_v<Integer> = false;
-
-template <>
-struct TypeTraits<Integer> : public ObjectRefWithFallbackTraitsBase<Integer, int64_t> {
-  TVM_FFI_INLINE static Integer ConvertFallbackValue(int64_t value) {
-    return Integer(TypeTraits<IntImm>::ConvertFallbackValue(value));
-  }
-};
-
-template <>
 inline constexpr bool use_default_type_traits_v<FloatImm> = false;
 
 template <>
@@ -747,14 +635,6 @@ struct TypeTraits<FloatImm> : public ObjectRefWithFallbackTraitsBase<FloatImm, d
   TVM_FFI_INLINE static FloatImm ConvertFallbackValue(double value) {
     return FloatImm(runtime::DataType::Float(32), value);
   }
-};
-
-template <>
-inline constexpr bool use_default_type_traits_v<Bool> = false;
-
-template <>
-struct TypeTraits<Bool> : public ObjectRefWithFallbackTraitsBase<Bool, int64_t> {
-  TVM_FFI_INLINE static Bool ConvertFallbackValue(int64_t value) { return Bool(value != 0); }
 };
 
 // define automatic conversion from bool, int64_t, double to PrimExpr

--- a/include/tvm/ir/function.h
+++ b/include/tvm/ir/function.h
@@ -89,7 +89,7 @@ namespace attr {
 /*!
  * \brief Indicates the special calling convention.
  *
- * Type: Integer
+ * Type: IntImm
  *
  * \sa tvm::CallingConv
  */
@@ -131,7 +131,7 @@ constexpr const char* kGlobalSymbol = "global_symbol";
  *        and printer emits `s_tir=True` on the decorator.
  *        Default (attr absent or False) is tirx semantics.
  *
- * Type: Bool
+ * Type: IntImm (bool dtype)
  */
 constexpr const char* kSTir = "s_tir";
 

--- a/include/tvm/relax/distributed/struct_info.h
+++ b/include/tvm/relax/distributed/struct_info.h
@@ -71,7 +71,7 @@ class PlacementSpec : public ffi::ObjectRef {
 class ShardingNode : public PlacementSpecNode {
  public:
   /*! \brief The dimension of tensor we shard*/
-  Integer sharding_dim;
+  int64_t sharding_dim;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;

--- a/include/tvm/relax/nested_msg.h
+++ b/include/tvm/relax/nested_msg.h
@@ -157,7 +157,7 @@ class NestedMsg {
   }
 
   // delete the int constructor
-  // since NestedMsg<Integer>(0) is ambiguous
+  // since NestedMsg<IntImm>(0) is ambiguous
   // 0 can be implicitly casted to nullptr_t
   explicit NestedMsg(int val) = delete;
   NestedMsg<T>& operator=(int val) = delete;

--- a/include/tvm/s_tir/meta_schedule/schedule_rule.h
+++ b/include/tvm/s_tir/meta_schedule/schedule_rule.h
@@ -231,7 +231,7 @@ class ScheduleRule : public ffi::ObjectRef {
    * \return The schedule rule created
    */
   TVM_DLL static ScheduleRule MultiLevelTilingWideVector(
-      ffi::String structure, Integer vector_length_in_bits,
+      ffi::String structure, int64_t vector_length_in_bits,
       ffi::Optional<int64_t> max_innermost_factor,
       ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,
       ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write);

--- a/include/tvm/tirx/analysis.h
+++ b/include/tvm/tirx/analysis.h
@@ -160,7 +160,7 @@ TVM_DLL size_t CalculateExprComplexity(const PrimExpr& expr);
  * \param func The TIR PrimFunc for which the constants size to be calculated
  * \param constant_byte_alignment The byte alignment required for each constant allocated
  */
-TVM_DLL size_t CalculateConstantBytes(const PrimFunc& func, const Integer& constant_byte_alignment);
+TVM_DLL size_t CalculateConstantBytes(const PrimFunc& func, int64_t constant_byte_alignment);
 
 /*!
  * \brief Calculate the workspace size in bytes needed by the TIR allocates inside the TIR PrimFunc
@@ -168,8 +168,7 @@ TVM_DLL size_t CalculateConstantBytes(const PrimFunc& func, const Integer& const
  * \param workspace_byte_alignment The byte alignment required for each tensor allocated in this
  * workspace
  */
-TVM_DLL size_t CalculateWorkspaceBytes(const PrimFunc& func,
-                                       const Integer& workspace_byte_alignment);
+TVM_DLL size_t CalculateWorkspaceBytes(const PrimFunc& func, int64_t workspace_byte_alignment);
 
 /*!
  * \brief Verify if the given TIR is well-formed. The verification includes:

--- a/include/tvm/tirx/function.h
+++ b/include/tvm/tirx/function.h
@@ -310,7 +310,7 @@ constexpr const char* kKernelLaunchParams = "tirx.kernel_launch_params";
 /*!
  * \brief Whether to set noalias rule on the function arguments.
  *
- * Type: Integer
+ * Type: IntImm
  */
 constexpr const char* kNoAlias = "tirx.noalias";
 
@@ -318,7 +318,7 @@ constexpr const char* kNoAlias = "tirx.noalias";
  * \brief Mark the function as the entry function of
  *        the final generated runtime module.
  *
- * Type: Integer
+ * Type: IntImm
  *
  * \note There can only be one entry function per module.
  */
@@ -327,21 +327,21 @@ constexpr const char* kIsEntryFunc = "tirx.is_entry_func";
 /*!
  * \brief Mark the function as the global function called from the host.
  *
- * Type: Integer
+ * Type: IntImm
  */
 constexpr const char* kIsGlobalFunc = "tirx.is_global_func";
 
 /*!
  * \brief Mark the function as run on the host, mutually exclusive with kTarget.
  *
- * Type: Integer
+ * Type: IntImm
  */
 constexpr const char* kIsHostFunc = "tirx.is_host_func";
 
 /*!
  * \brief Mark the function as scheduled, so the default schedule will pass will skip it.
  *
- * Type: Integer
+ * Type: IntImm
  */
 constexpr const char* kIsScheduled = "tirx.is_scheduled";
 

--- a/include/tvm/topi/detail/strided_slice.h
+++ b/include/tvm/topi/detail/strided_slice.h
@@ -50,30 +50,38 @@ inline int64_t CanonicalizeIndex(int64_t index, int64_t extent, int64_t stride) 
 }
 
 inline std::tuple<std::vector<int64_t>, std::vector<int64_t>, std::vector<int64_t>> ConvertToVec(
-    const ffi::Array<int64_t>& begin, const ffi::Array<int64_t>& end,
-    const ffi::Array<int64_t>& strides, std::string slice_mode) {
+    const ffi::Array<ffi::Optional<IntImm>>& begin, const ffi::Array<ffi::Optional<IntImm>>& end,
+    const ffi::Array<IntImm>& strides, std::string slice_mode) {
   std::vector<int64_t> stride_vec(strides.size(), 1);
   if (slice_mode == "end") {
     for (size_t i = 0; i < strides.size(); ++i) {
-      stride_vec[i] = strides[i];
+      stride_vec[i] = strides[i]->value;
     }
   }
   const int64_t max_range = std::numeric_limits<int64_t>::max();
   std::vector<int64_t> begin_vec;
   for (size_t i = 0; i < begin.size(); ++i) {
-    begin_vec.push_back(begin[i]);
+    if (!begin[i].defined()) {
+      // value=None
+      begin_vec.push_back(stride_vec[i] > 0 ? 0 : max_range);
+    } else {
+      begin_vec.push_back(begin[i].value()->value);
+    }
   }
   std::vector<int64_t> end_vec;
   for (size_t i = 0; i < end.size(); ++i) {
-    if (slice_mode == "size") {
-      int64_t end_val = end[i];
+    // allow end to be None
+    if (!end[i].defined()) {
+      end_vec.push_back(stride_vec[i] < 0 ? 0 : max_range);
+    } else if (slice_mode == "size") {
+      int64_t end_val = end[i].value()->value;
       if (end_val < 0) {
         end_vec.push_back(stride_vec[i] < 0 ? 0 : max_range);
       } else {
         end_vec.push_back(begin_vec[i] + end_val);
       }
     } else {
-      end_vec.push_back(end[i]);
+      end_vec.push_back(end[i].value()->value);
     }
   }
   return std::make_tuple(begin_vec, end_vec, stride_vec);

--- a/include/tvm/topi/detail/strided_slice.h
+++ b/include/tvm/topi/detail/strided_slice.h
@@ -50,39 +50,30 @@ inline int64_t CanonicalizeIndex(int64_t index, int64_t extent, int64_t stride) 
 }
 
 inline std::tuple<std::vector<int64_t>, std::vector<int64_t>, std::vector<int64_t>> ConvertToVec(
-    const ffi::Array<Integer>& begin, const ffi::Array<Integer>& end,
-    const ffi::Array<Integer>& strides, std::string slice_mode) {
+    const ffi::Array<int64_t>& begin, const ffi::Array<int64_t>& end,
+    const ffi::Array<int64_t>& strides, std::string slice_mode) {
   std::vector<int64_t> stride_vec(strides.size(), 1);
   if (slice_mode == "end") {
     for (size_t i = 0; i < strides.size(); ++i) {
-      TVM_FFI_ICHECK(strides[i].defined());
-      stride_vec[i] = GetConstInt(strides[i]);
+      stride_vec[i] = strides[i];
     }
   }
   const int64_t max_range = std::numeric_limits<int64_t>::max();
   std::vector<int64_t> begin_vec;
   for (size_t i = 0; i < begin.size(); ++i) {
-    if (!begin[i].defined()) {
-      // value=None
-      begin_vec.push_back(stride_vec[i] > 0 ? 0 : max_range);
-    } else {
-      begin_vec.push_back(GetConstInt(begin[i]));
-    }
+    begin_vec.push_back(begin[i]);
   }
   std::vector<int64_t> end_vec;
   for (size_t i = 0; i < end.size(); ++i) {
-    // allow end to be None
-    if (!end[i].defined()) {
-      end_vec.push_back(stride_vec[i] < 0 ? 0 : max_range);
-    } else if (slice_mode == "size") {
-      int64_t end_val = GetConstInt(end[i]);
+    if (slice_mode == "size") {
+      int64_t end_val = end[i];
       if (end_val < 0) {
         end_vec.push_back(stride_vec[i] < 0 ? 0 : max_range);
       } else {
         end_vec.push_back(begin_vec[i] + end_val);
       }
     } else {
-      end_vec.push_back(GetConstInt(end[i]));
+      end_vec.push_back(end[i]);
     }
   }
   return std::make_tuple(begin_vec, end_vec, stride_vec);
@@ -91,17 +82,18 @@ inline std::tuple<std::vector<int64_t>, std::vector<int64_t>, std::vector<int64_
 inline ffi::Array<PrimExpr> StridedSliceCanonicalizeBegin(const ffi::Array<PrimExpr>& ishape,
                                                           const std::vector<int64_t>& begin,
                                                           const std::vector<int64_t>& strides,
-                                                          const ffi::Array<Integer>& axes,
+                                                          const ffi::Array<int64_t>& axes,
                                                           DataType dtype,
                                                           std::string slice_mode = "end") {
   ffi::Array<PrimExpr> begin_expr;
   for (size_t i = 0; i < axes.size(); ++i) {
-    if (ishape[axes[i].IntValue()]->IsInstance<tvm::IntImmNode>()) {
-      int64_t dim_i = GetConstInt(ishape[axes[i].IntValue()]);
+    int64_t ax = axes[i];
+    if (ishape[ax]->IsInstance<tvm::IntImmNode>()) {
+      int64_t dim_i = GetConstInt(ishape[ax]);
       int64_t begin_i = CanonicalizeIndex(begin[i], dim_i, strides[i]);
       begin_expr.push_back(make_const(dtype, begin_i));
     } else {
-      auto idim = ishape[axes[i].IntValue()];
+      auto idim = ishape[ax];
       auto b_expr = make_const(dtype, begin[i]);
       PrimExpr b = begin[i] < 0 ? b_expr + idim : b_expr;
       auto s = strides[i];
@@ -119,7 +111,7 @@ inline ffi::Array<PrimExpr> StridedSliceCanonicalizeBegin(const ffi::Array<PrimE
 inline ffi::Array<PrimExpr> StridedSliceOutputShape(
     const ffi::Array<PrimExpr>& ishape, const std::vector<int64_t>& begin,
     const std::vector<int64_t>& end, const std::vector<int64_t>& strides,
-    const ffi::Array<Integer>& axes, std::string slice_mode,
+    const ffi::Array<int64_t>& axes, std::string slice_mode,
     const ffi::Array<PrimExpr>& begin_canonicalized, bool use_any = false) {
   TVM_FFI_ICHECK(!use_any) << "StridedSliceOutputShape does not legacy use_any";
   const size_t src_tensor_dim = ishape.size();
@@ -129,8 +121,9 @@ inline ffi::Array<PrimExpr> StridedSliceOutputShape(
   }
 
   for (size_t i = 0; i < axes.size(); ++i) {
-    if (ishape[axes[i].IntValue()]->IsInstance<tvm::IntImmNode>()) {
-      const int64_t dim_i = GetConstInt(ishape[axes[i].IntValue()]);
+    int64_t ax = axes[i];
+    if (ishape[ax]->IsInstance<tvm::IntImmNode>()) {
+      const int64_t dim_i = GetConstInt(ishape[ax]);
       TVM_FFI_ICHECK(begin_canonicalized[i]->IsInstance<tvm::IntImmNode>());
       int64_t begin_i = GetConstInt(begin_canonicalized[i]);
       int64_t end_i = CanonicalizeIndex(end[i], dim_i, strides[i]);
@@ -139,9 +132,9 @@ inline ffi::Array<PrimExpr> StridedSliceOutputShape(
           static_cast<int>((interval + std::abs(strides[i]) - 1) / std::abs(strides[i]));
       TVM_FFI_ICHECK(strides[i] < 0 ? (end_i <= begin_i) : (begin_i <= end_i))
           << ": Input [Begin=" << begin[i] << ", End=" << end[i] << "] is invalid for axis=" << i;
-      out_shape.Set(axes[i].IntValue(), cast(out_shape[i].dtype(), PrimExpr(slice_size)));
+      out_shape.Set(ax, cast(out_shape[i].dtype(), PrimExpr(slice_size)));
     } else {
-      out_shape.Set(axes[i].IntValue(), tvm::tirx::Var("dim", out_shape[i]->dtype));
+      out_shape.Set(ax, tvm::tirx::Var("dim", out_shape[i]->dtype));
     }
   }
 

--- a/include/tvm/topi/nn.h
+++ b/include/tvm/topi/nn.h
@@ -537,7 +537,7 @@ inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
     r_shape.push_back(div(padded_shape[i], block_shape[i - 1]));
     r_shape.push_back(block_shape[i - 1]);
     block_shape_prod *= block_shape[i - 1];
-    axis.push_back(Integer(r_shape.size() - 1));  // index of block_shape[i - 1]
+    axis.push_back(IntImm(DataType::Int(32), r_shape.size() - 1));  // index of block_shape[i - 1]
   }
 
   size_t n = axis.size();
@@ -553,7 +553,7 @@ inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
   // append remaining shape
   for (size_t i = num_block_dims + 1; i < input_shape.size(); i++) {
     r_shape.push_back(input_shape[i]);
-    axis.push_back(Integer(r_shape.size() - 1));  // index of remaining shape in r_shape
+    axis.push_back(IntImm(DataType::Int(32), r_shape.size() - 1));  // index of remaining shape in r_shape
     o_shape.push_back(input_shape[i]);
   }
 
@@ -595,13 +595,13 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
     r_shape.push_back(block_shape[i]);
     block_shape_prod *= block_shape[i];
   }
-  axis.push_back(Integer(r_shape.size()));  // axis of (batch / block_shape_prod)
+  axis.push_back(IntImm(DataType::Int(32), r_shape.size()));  // axis of (batch / block_shape_prod)
   r_shape.push_back(batch / block_shape_prod);
 
   for (size_t i = 1; i < num_input_dims; i++) {
-    axis.push_back(Integer(r_shape.size()));  // axis of in_shape[i]
+    axis.push_back(IntImm(DataType::Int(32), r_shape.size()));  // axis of in_shape[i]
     if (axis.size() < (num_block_dims + num_input_dims)) {
-      axis.push_back(Integer(r_shape.size() - (num_block_dims + 1)));  // axis of block_shape[i]
+      axis.push_back(IntImm(DataType::Int(32), r_shape.size() - (num_block_dims + 1)));  // axis of block_shape[i]
     }
     r_shape.push_back(in_shape[i]);
   }
@@ -623,7 +623,7 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
   // Crop the start and end of dimensions of out
   ffi::Array<Integer> begin_idx, end_idx, strides;
   for (size_t i = 0; i < r_p_shape.size(); ++i) {
-    strides.push_back(Integer(1));
+    strides.push_back(IntImm(DataType::Int(32), 1));
     if (i > 0 && i <= num_block_dims) {
       // prepare begin and end index for spatial dimensions
       int begin_i = static_cast<int>(GetConstInt(crop_begin_list[i - 1]));
@@ -636,7 +636,7 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
       end_idx.push_back(out_i - end_i);
     } else {
       // ignore the batch and remaining dimension
-      begin_idx.push_back(Integer(0));
+      begin_idx.push_back(IntImm(DataType::Int(32), 0));
       end_idx.push_back(static_cast<int>(GetConstInt(r_p_shape[i])));
     }
   }

--- a/include/tvm/topi/nn.h
+++ b/include/tvm/topi/nn.h
@@ -555,7 +555,8 @@ inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
   // append remaining shape
   for (size_t i = num_block_dims + 1; i < input_shape.size(); i++) {
     r_shape.push_back(input_shape[i]);
-    axis.push_back(static_cast<int64_t>(r_shape.size() - 1));  // index of remaining shape in r_shape
+    axis.push_back(
+        static_cast<int64_t>(r_shape.size() - 1));  // index of remaining shape in r_shape
     o_shape.push_back(input_shape[i]);
   }
 
@@ -604,7 +605,8 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
   for (size_t i = 1; i < num_input_dims; i++) {
     axis.push_back(static_cast<int64_t>(r_shape.size()));  // axis of in_shape[i]
     if (axis.size() < (num_block_dims + num_input_dims)) {
-      axis.push_back(static_cast<int64_t>(r_shape.size() - (num_block_dims + 1)));  // axis of block_shape[i]
+      axis.push_back(
+          static_cast<int64_t>(r_shape.size() - (num_block_dims + 1)));  // axis of block_shape[i]
     }
     r_shape.push_back(in_shape[i]);
   }

--- a/include/tvm/topi/nn.h
+++ b/include/tvm/topi/nn.h
@@ -627,9 +627,11 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
   out = reshape(out, r_p_shape);
 
   // Crop the start and end of dimensions of out
-  ffi::Array<int64_t> begin_idx, end_idx, strides;
+  ffi::Array<ffi::Optional<IntImm>> begin_idx, end_idx;
+  ffi::Array<IntImm> strides;
+  DataType index_dtype = DataType::Int(64);
   for (size_t i = 0; i < r_p_shape.size(); ++i) {
-    strides.push_back(int64_t(1));
+    strides.push_back(IntImm(index_dtype, 1));
     if (i > 0 && i <= num_block_dims) {
       // prepare begin and end index for spatial dimensions
       int64_t begin_i = GetConstInt(crop_begin_list[i - 1]);
@@ -638,12 +640,12 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
       TVM_FFI_ICHECK_GT(out_i, (begin_i + end_i))
           << "Incorrect crop sizes for (" << i << ")th dim, can not crop more than"
           << " output size" << out_i << " vs " << (begin_i + end_i);
-      begin_idx.push_back(begin_i);
-      end_idx.push_back(out_i - end_i);
+      begin_idx.push_back(IntImm(index_dtype, begin_i));
+      end_idx.push_back(IntImm(index_dtype, out_i - end_i));
     } else {
       // ignore the batch and remaining dimension
-      begin_idx.push_back(int64_t(0));
-      end_idx.push_back(GetConstInt(r_p_shape[i]));
+      begin_idx.push_back(IntImm(index_dtype, 0));
+      end_idx.push_back(IntImm(index_dtype, GetConstInt(r_p_shape[i])));
     }
   }
 

--- a/include/tvm/topi/nn.h
+++ b/include/tvm/topi/nn.h
@@ -481,7 +481,7 @@ inline tvm::te::Tensor group_conv2d_ngchw(const tvm::te::Tensor& I, const tvm::t
  * \return A Tensor whose op member is the space_to_batch_nd operation
  */
 inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
-                                         const tvm::ffi::Array<Integer>& block_shape,
+                                         const tvm::ffi::Array<int64_t>& block_shape,
                                          const tvm::ffi::Array<tvm::PrimExpr>& pad_before,
                                          const tvm::ffi::Array<tvm::PrimExpr>& pad_after,
                                          PrimExpr pad_value = PrimExpr(),
@@ -516,7 +516,7 @@ inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
 
   // infer shapes
   tvm::ffi::Array<PrimExpr> r_shape;
-  tvm::ffi::Array<Integer> axis;
+  tvm::ffi::Array<int64_t> axis;
   tvm::ffi::Array<PrimExpr> o_shape;
 
   size_t num_block_dims = block_shape.size();
@@ -526,7 +526,7 @@ inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
 
   for (size_t i = 1; i <= num_block_dims; i++) {
     int padded_input = static_cast<int>(GetConstInt(padded_shape[i]));
-    int block_size = static_cast<int>(GetConstInt(block_shape[i - 1]));
+    int block_size = static_cast<int>(block_shape[i - 1]);
     TVM_FFI_ICHECK_EQ((padded_input % block_size), 0)
         << "(" << i
         << ")th "
@@ -534,26 +534,28 @@ inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
         << padded_input << ")"
         << " must be divisible by its block size (" << block_size << ")";
 
-    r_shape.push_back(div(padded_shape[i], block_shape[i - 1]));
-    r_shape.push_back(block_shape[i - 1]);
-    block_shape_prod *= block_shape[i - 1];
-    axis.push_back(IntImm(DataType::Int(32), r_shape.size() - 1));  // index of block_shape[i - 1]
+    PrimExpr bs = IntImm(DataType::Int(64), block_shape[i - 1]);
+    r_shape.push_back(div(padded_shape[i], bs));
+    r_shape.push_back(bs);
+    block_shape_prod *= bs;
+    axis.push_back(static_cast<int64_t>(r_shape.size() - 1));  // index of block_shape[i - 1]
   }
 
   size_t n = axis.size();
   axis.push_back(0);  // batch is at index 0
   // index of (padded_shape[i] / block_shape[i - 1]) in r_shape
   for (size_t i = 0; i < n; i++) {
-    axis.push_back(static_cast<int>(GetConstInt(axis[i] - 1)));
+    axis.push_back(axis[i] - 1);
   }
   o_shape.push_back(tvm::PrimExpr(batch) * block_shape_prod);
   for (size_t i = 1; i <= num_block_dims; i++) {
-    o_shape.push_back(div(padded_shape[i], block_shape[i - 1]));
+    PrimExpr bs = IntImm(DataType::Int(64), block_shape[i - 1]);
+    o_shape.push_back(div(padded_shape[i], bs));
   }
   // append remaining shape
   for (size_t i = num_block_dims + 1; i < input_shape.size(); i++) {
     r_shape.push_back(input_shape[i]);
-    axis.push_back(IntImm(DataType::Int(32), r_shape.size() - 1));  // index of remaining shape in r_shape
+    axis.push_back(static_cast<int64_t>(r_shape.size() - 1));  // index of remaining shape in r_shape
     o_shape.push_back(input_shape[i]);
   }
 
@@ -577,7 +579,7 @@ inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
  * \return A Tensor whose op member is the batch_to_space_nd operation
  */
 inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
-                                         const tvm::ffi::Array<Integer>& block_shape,
+                                         const tvm::ffi::Array<int64_t>& block_shape,
                                          const tvm::ffi::Array<tvm::PrimExpr>& crop_begin_list,
                                          const tvm::ffi::Array<tvm::PrimExpr>& crop_end_list,
                                          std::string name = "batch_to_space_nd",
@@ -585,23 +587,24 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
   // Construct shapes for reshape and transpose operation
   ffi::Array<PrimExpr> in_shape = data->shape;
   ffi::Array<PrimExpr> r_shape;
-  ffi::Array<Integer> axis;
+  ffi::Array<int64_t> axis;
   size_t num_block_dims = block_shape.size();
   size_t num_input_dims = in_shape.size();
   tvm::PrimExpr block_shape_prod(1);
   int batch = static_cast<int>(GetConstInt(in_shape[0]));
 
   for (size_t i = 0; i < num_block_dims; i++) {
-    r_shape.push_back(block_shape[i]);
-    block_shape_prod *= block_shape[i];
+    PrimExpr bs = IntImm(DataType::Int(64), block_shape[i]);
+    r_shape.push_back(bs);
+    block_shape_prod *= bs;
   }
-  axis.push_back(IntImm(DataType::Int(32), r_shape.size()));  // axis of (batch / block_shape_prod)
+  axis.push_back(static_cast<int64_t>(r_shape.size()));  // axis of (batch / block_shape_prod)
   r_shape.push_back(batch / block_shape_prod);
 
   for (size_t i = 1; i < num_input_dims; i++) {
-    axis.push_back(IntImm(DataType::Int(32), r_shape.size()));  // axis of in_shape[i]
+    axis.push_back(static_cast<int64_t>(r_shape.size()));  // axis of in_shape[i]
     if (axis.size() < (num_block_dims + num_input_dims)) {
-      axis.push_back(IntImm(DataType::Int(32), r_shape.size() - (num_block_dims + 1)));  // axis of block_shape[i]
+      axis.push_back(static_cast<int64_t>(r_shape.size() - (num_block_dims + 1)));  // axis of block_shape[i]
     }
     r_shape.push_back(in_shape[i]);
   }
@@ -609,7 +612,8 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
   ffi::Array<PrimExpr> r_p_shape;
   r_p_shape.push_back(batch / block_shape_prod);
   for (size_t i = 1; i <= num_block_dims; i++) {
-    r_p_shape.push_back(in_shape[i] * block_shape[i - 1]);
+    PrimExpr bs = IntImm(DataType::Int(64), block_shape[i - 1]);
+    r_p_shape.push_back(in_shape[i] * bs);
   }
   for (size_t i = num_block_dims + 1; i < num_input_dims; i++) {
     r_p_shape.push_back(in_shape[i]);
@@ -621,14 +625,14 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
   out = reshape(out, r_p_shape);
 
   // Crop the start and end of dimensions of out
-  ffi::Array<Integer> begin_idx, end_idx, strides;
+  ffi::Array<int64_t> begin_idx, end_idx, strides;
   for (size_t i = 0; i < r_p_shape.size(); ++i) {
-    strides.push_back(IntImm(DataType::Int(32), 1));
+    strides.push_back(int64_t(1));
     if (i > 0 && i <= num_block_dims) {
       // prepare begin and end index for spatial dimensions
-      int begin_i = static_cast<int>(GetConstInt(crop_begin_list[i - 1]));
-      int end_i = static_cast<int>(GetConstInt(crop_end_list[i - 1]));
-      int out_i = static_cast<int>(GetConstInt(r_p_shape[i]));
+      int64_t begin_i = GetConstInt(crop_begin_list[i - 1]);
+      int64_t end_i = GetConstInt(crop_end_list[i - 1]);
+      int64_t out_i = GetConstInt(r_p_shape[i]);
       TVM_FFI_ICHECK_GT(out_i, (begin_i + end_i))
           << "Incorrect crop sizes for (" << i << ")th dim, can not crop more than"
           << " output size" << out_i << " vs " << (begin_i + end_i);
@@ -636,8 +640,8 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
       end_idx.push_back(out_i - end_i);
     } else {
       // ignore the batch and remaining dimension
-      begin_idx.push_back(IntImm(DataType::Int(32), 0));
-      end_idx.push_back(static_cast<int>(GetConstInt(r_p_shape[i])));
+      begin_idx.push_back(int64_t(0));
+      end_idx.push_back(GetConstInt(r_p_shape[i]));
     }
   }
 
@@ -710,10 +714,10 @@ inline Tensor nll_loss(const Tensor& predictions, const Tensor& targets, const T
                                    tvm::tirx::make_const(predictions->dtype, 0));
         },
         name, tag);
-    return topi::divide(topi::sum(T, tvm::ffi::Array<Integer>(nullptr)),
-                        topi::sum(W, tvm::ffi::Array<Integer>(nullptr)));
+    return topi::divide(topi::sum(T, tvm::ffi::Array<int64_t>(nullptr)),
+                        topi::sum(W, tvm::ffi::Array<int64_t>(nullptr)));
   } else if (reduction == "sum") {
-    return topi::sum(T, tvm::ffi::Array<Integer>(nullptr));
+    return topi::sum(T, tvm::ffi::Array<int64_t>(nullptr));
   } else {  // reduction == "none"
     return T;
   }

--- a/include/tvm/topi/nn/group_norm.h
+++ b/include/tvm/topi/nn/group_norm.h
@@ -37,7 +37,7 @@ namespace nn {
 using namespace tvm::te;
 
 inline Tensor group_norm(const Tensor& data, const Tensor& gamma, const Tensor& beta,
-                         int num_groups, int channel_axis, const ffi::Array<Integer>& axes,
+                         int num_groups, int channel_axis, const ffi::Array<int64_t>& axes,
                          double epsilon, std::string name = "T_group_norm",
                          std::string tag = kInjective) {
   const auto& data_type = data->dtype;
@@ -50,7 +50,7 @@ inline Tensor group_norm(const Tensor& data, const Tensor& gamma, const Tensor& 
   bool is_float16 = data_type == DataType::Float(16);
   // reshape data C -> G, C/G
   int ndim = data->shape.size();
-  channel_axis = GetRealAxis(static_cast<int>(ndim), ffi::Array<Integer>({channel_axis}))[0];
+  channel_axis = GetRealAxis(static_cast<int>(ndim), ffi::Array<int64_t>({channel_axis}))[0];
 
   auto shape = data->shape;
   auto group_size = floordiv(shape[channel_axis], num_groups);
@@ -82,7 +82,7 @@ inline Tensor group_norm(const Tensor& data, const Tensor& gamma, const Tensor& 
   // get the new axes to normalize after reshape
   std::vector<int> new_axes{channel_axis + 1};
   for (auto axis : axes) {
-    int new_axis = GetRealAxis(static_cast<int>(ndim), ffi::Array<Integer>({axis}))[0];
+    int new_axis = GetRealAxis(static_cast<int>(ndim), ffi::Array<int64_t>({axis}))[0];
     if (new_axis < channel_axis) {
       new_axes.push_back(new_axis);
     } else if (new_axis > channel_axis) {

--- a/include/tvm/topi/nn/instance_norm.h
+++ b/include/tvm/topi/nn/instance_norm.h
@@ -51,7 +51,7 @@ using namespace tvm::te;
  * \return The normalized tensor, with the same shape as data.
  */
 inline Tensor instance_norm(const Tensor& data, const Tensor& gamma, const Tensor& beta,
-                            int channel_axis, const ffi::Array<Integer>& axis, double epsilon,
+                            int channel_axis, const ffi::Array<int64_t>& axis, double epsilon,
                             std::string name = "T_instance_norm", std::string tag = kInjective) {
   const auto& data_type = data->dtype;
   const auto& gamma_type = gamma.defined() ? gamma->dtype : data_type;

--- a/include/tvm/topi/nn/layer_norm.h
+++ b/include/tvm/topi/nn/layer_norm.h
@@ -49,7 +49,7 @@ using namespace tvm::te;
  * \return The normalized tensor, with the same shape as data.
  */
 inline Tensor layer_norm(const Tensor& data, const Tensor& gamma, const Tensor& beta,
-                         const ffi::Array<Integer>& axis, double epsilon,
+                         const ffi::Array<int64_t>& axis, double epsilon,
                          std::string name = "T_layer_norm", std::string tag = kInjective) {
   const auto& data_type = data->dtype;
   const auto& gamma_type = gamma.defined() ? gamma->dtype : data_type;

--- a/include/tvm/topi/nn/rms_norm.h
+++ b/include/tvm/topi/nn/rms_norm.h
@@ -47,7 +47,7 @@ using namespace tvm::te;
  * \param tag The tag to mark the operation.
  * \return The normalized tensor, with the same shape as data.
  */
-inline Tensor rms_norm(const Tensor& data, const Tensor& weight, const ffi::Array<Integer>& axis,
+inline Tensor rms_norm(const Tensor& data, const Tensor& weight, const ffi::Array<int64_t>& axis,
                        double epsilon, std::string name = "T_rms_norm",
                        std::string tag = kInjective) {
   const auto& data_type = data->dtype;

--- a/include/tvm/topi/nn/softmax.h
+++ b/include/tvm/topi/nn/softmax.h
@@ -61,7 +61,7 @@ inline Tensor softmax(const Tensor& x, int axis = -1, std::string name = "tensor
   auto reduced_shape = MakeReduceTargetShape({axis}, x, false, false);
 
   tvm::ffi::Map<ffi::String, ffi::Any> attrs;
-  attrs.Set("axis", Integer(axis));
+  attrs.Set("axis", IntImm(DataType::Int(32), axis));
 
   auto insert_reduce_index = [axis, ndim](const ffi::Array<Var>& indices,
                                           const IterVar& reduce_index) {

--- a/include/tvm/topi/reduction.h
+++ b/include/tvm/topi/reduction.h
@@ -62,7 +62,7 @@ using FCommReduce = std::function<ffi::Array<PrimExpr>(
  * If any input element is negative, it will be treated as an offset from the
  * last dimension (same as python indexing rules).
  */
-inline std::vector<int> GetRealAxis(int ndim, const ffi::Optional<ffi::Array<Integer>>& axis) {
+inline std::vector<int> GetRealAxis(int ndim, const ffi::Optional<ffi::Array<int64_t>>& axis) {
   std::vector<int> real_axis;
   if (!axis.has_value()) {
     for (int i = 0; i < ndim; ++i) {
@@ -70,8 +70,8 @@ inline std::vector<int> GetRealAxis(int ndim, const ffi::Optional<ffi::Array<Int
     }
   } else {
     // Use a set so duplicates are removed and the dims are sorted
-    for (auto elem : axis.value()) {
-      int64_t val = elem->value;
+    for (int64_t elem : axis.value()) {
+      int64_t val = elem;
       if (val < 0) {
         val += ndim;
       }
@@ -181,7 +181,7 @@ inline Tensor DoCommReduce(const Tensor& data, FReduce func,
  *
  * \return The result tensor.
  */
-inline Tensor CommReduce(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& axis,
+inline Tensor CommReduce(const Tensor& data, const ffi::Optional<ffi::Array<int64_t>>& axis,
                          FReduce func, bool keepdims, bool atleast1d) {
   auto ndim = data->shape.size();
   TVM_FFI_ICHECK_NE(ndim, 0) << "Cannot reduce a 0 dim Tensor";
@@ -204,7 +204,7 @@ inline Tensor CommReduce(const Tensor& data, const ffi::Optional<ffi::Array<Inte
  *
  * \return The result tensor.
  */
-inline Tensor CommReduceIdx(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& axis,
+inline Tensor CommReduceIdx(const Tensor& data, const ffi::Optional<ffi::Array<int64_t>>& axis,
                             FCommReduce func, bool keepdims, bool atleast1d) {
   auto ndim = data->shape.size();
   TVM_FFI_ICHECK_NE(ndim, 0) << "Cannot reduce a 0 dim Tensor";
@@ -325,7 +325,7 @@ inline PrimExpr ProdOp(PrimExpr source, ffi::Array<IterVar> axis, ffi::Array<Pri
  *
  * \return A Tensor whose op member is the sum operation
  */
-inline Tensor sum(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& axis,
+inline Tensor sum(const Tensor& data, const ffi::Optional<ffi::Array<int64_t>>& axis,
                   bool keepdims = false, bool atleast1d = false) {
   if (data->dtype.is_bool()) {
     return CommReduce(data, axis, tvm::any, keepdims, atleast1d);
@@ -382,7 +382,7 @@ inline Tensor collapse_sum(const Tensor& data, ffi::Array<PrimExpr> target_shape
  *
  * \return A Tensor whose op member is the all operation
  */
-inline Tensor all(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& axis,
+inline Tensor all(const Tensor& data, const ffi::Optional<ffi::Array<int64_t>>& axis,
                   bool keepdims = false, bool atleast1d = false) {
   return CommReduce(data, axis, tvm::all, keepdims, atleast1d);
 }
@@ -401,7 +401,7 @@ inline Tensor all(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& 
  *
  * \return A Tensor whose op member is the all operation
  */
-inline Tensor any(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& axis,
+inline Tensor any(const Tensor& data, const ffi::Optional<ffi::Array<int64_t>>& axis,
                   bool keepdims = false, bool atleast1d = false) {
   return CommReduce(data, axis, tvm::any, keepdims, atleast1d);
 }
@@ -420,7 +420,7 @@ inline Tensor any(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& 
  *
  * \return A Tensor whose op member is the min operation
  */
-inline Tensor min(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& axis,
+inline Tensor min(const Tensor& data, const ffi::Optional<ffi::Array<int64_t>>& axis,
                   bool keepdims = false, bool atleast1d = false) {
   return CommReduce(data, axis, MinOp, keepdims, atleast1d);
 }
@@ -439,7 +439,7 @@ inline Tensor min(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& 
  *
  * \return A Tensor whose op member is the max operation
  */
-inline Tensor max(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& axis,
+inline Tensor max(const Tensor& data, const ffi::Optional<ffi::Array<int64_t>>& axis,
                   bool keepdims = false, bool atleast1d = false) {
   return CommReduce(data, axis, MaxOp, keepdims, atleast1d);
 }
@@ -499,7 +499,7 @@ inline FCommReduce MakeArgminReducer(bool select_last_index = false) {
  *
  * \return A Tensor whose op member is the argmin operation
  */
-inline Tensor argmin(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& axis,
+inline Tensor argmin(const Tensor& data, const ffi::Optional<ffi::Array<int64_t>>& axis,
                      bool keepdims = false, bool atleast1d = false,
                      bool select_last_index = false) {
   auto reducer = MakeArgminReducer(select_last_index);
@@ -560,7 +560,7 @@ inline FCommReduce MakeArgmaxReducer(bool select_last_index = false) {
  * appears multiple times, else select the first index.
  * \return A Tensor whose op member is the argmax operation
  */
-inline Tensor argmax(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& axis,
+inline Tensor argmax(const Tensor& data, const ffi::Optional<ffi::Array<int64_t>>& axis,
                      bool keepdims = false, bool atleast1d = false,
                      bool select_last_index = false) {
   auto reducer = MakeArgmaxReducer(select_last_index);
@@ -580,7 +580,7 @@ inline Tensor argmax(const Tensor& data, const ffi::Optional<ffi::Array<Integer>
  *
  * \return A Tensor whose op member is the prod operation
  */
-inline Tensor prod(const Tensor& data, const ffi::Optional<ffi::Array<Integer>>& axis,
+inline Tensor prod(const Tensor& data, const ffi::Optional<ffi::Array<int64_t>>& axis,
                    bool keepdims = false, bool atleast1d = false) {
   return CommReduce(data, axis, ProdOp, keepdims, atleast1d);
 }

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -865,17 +865,19 @@ inline te::Tensor dynamic_strided_slice(const te::Tensor& x, const te::Tensor& b
  * \return The output shape of strided_slice using the arguments above
  */
 inline ffi::Array<PrimExpr> StridedSliceOutputShape(const ffi::Array<PrimExpr>& ishape,
-                                                    const ffi::Array<int64_t>& begin,
-                                                    const ffi::Array<int64_t>& end,
-                                                    const ffi::Array<int64_t>& strides,
+                                                    const ffi::Array<ffi::Optional<IntImm>>& begin,
+                                                    const ffi::Array<ffi::Optional<IntImm>>& end,
+                                                    const ffi::Array<IntImm>& strides,
                                                     const ffi::Array<int64_t>& axes,
                                                     const std::string& slice_mode) {
   TVM_FFI_ICHECK(axes.size() == begin.size() && axes.size() == end.size() &&
                  axes.size() == strides.size());
   std::vector<int64_t> begin_vec, end_vec, strides_vec;
   std::tie(begin_vec, end_vec, strides_vec) = ConvertToVec(begin, end, strides, slice_mode);
-  auto begin_canonicalized = StridedSliceCanonicalizeBegin(ishape, begin_vec, strides_vec, axes,
-                                                           DataType::Int(64), slice_mode);
+  DataType index_dtype =
+      (begin.size() > 0 && begin[0].defined()) ? begin[0].value()->dtype : DataType::Int(64);
+  auto begin_canonicalized =
+      StridedSliceCanonicalizeBegin(ishape, begin_vec, strides_vec, axes, index_dtype, slice_mode);
   return StridedSliceOutputShape(ishape, begin_vec, end_vec, strides_vec, axes, slice_mode,
                                  begin_canonicalized, true);
 }
@@ -896,13 +898,11 @@ inline ffi::Array<PrimExpr> StridedSliceOutputShape(const ffi::Array<PrimExpr>& 
  *
  * \return A Tensor whose op member is the sstrided_slice operation
  */
-inline Tensor strided_slice_with_axes(const Tensor& x, const ffi::Array<int64_t>& begin,
-                                      const ffi::Array<int64_t>& end,
-                                      const ffi::Array<int64_t>& strides,
-                                      const ffi::Array<int64_t>& axes,
-                                      std::string slice_mode = "end",
-                                      std::string name = "T_strided_slice_with_axes",
-                                      std::string tag = kInjective) {
+inline Tensor strided_slice_with_axes(
+    const Tensor& x, const ffi::Array<ffi::Optional<IntImm>>& begin,
+    const ffi::Array<ffi::Optional<IntImm>>& end, const ffi::Array<IntImm>& strides,
+    const ffi::Array<int64_t>& axes, std::string slice_mode = "end",
+    std::string name = "T_strided_slice_with_axes", std::string tag = kInjective) {
   const int64_t src_tensor_dim = static_cast<int64_t>(x->shape.size());
   TVM_FFI_ICHECK(static_cast<int64_t>(axes.size()) <= src_tensor_dim);
   TVM_FFI_ICHECK(axes.size() == begin.size() && axes.size() == end.size() &&
@@ -924,7 +924,8 @@ inline Tensor strided_slice_with_axes(const Tensor& x, const ffi::Array<int64_t>
   std::vector<int64_t> begin_vec, end_vec, strides_vec;
   std::tie(begin_vec, end_vec, strides_vec) = ConvertToVec(begin, end, strides, slice_mode);
 
-  DataType index_dtype = begin.size() > 0 ? DataType::Int(64) : DataType::Int(64);
+  DataType index_dtype =
+      (begin.size() > 0 && begin[0].defined()) ? begin[0].value()->dtype : DataType::Int(64);
   auto begin_expr = StridedSliceCanonicalizeBegin(x->shape, begin_vec, strides_vec, normalized_axes,
                                                   index_dtype, slice_mode);
   auto out_shape = StridedSliceOutputShape(x->shape, begin_vec, end_vec, strides_vec,
@@ -937,7 +938,7 @@ inline Tensor strided_slice_with_axes(const Tensor& x, const ffi::Array<int64_t>
         for (size_t i = 0; i < out_shape.size(); ++i) real_indices.push_back(indices[i]);
         for (size_t i = 0; i < normalized_axes.size(); ++i) {
           int64_t ax = normalized_axes[i];
-          auto stride = make_const(DataType::Int(64), strides_vec[i]);
+          auto stride = make_const(strides[i]->dtype, strides_vec[i]);
           PrimExpr ind = indices[ax] * stride + begin_expr[i];
           real_indices.Set(ax, ind);
         }
@@ -960,29 +961,31 @@ inline Tensor strided_slice_with_axes(const Tensor& x, const ffi::Array<int64_t>
  *
  * \return A Tensor whose op member is the strided_slice operation
  */
-inline Tensor strided_slice(const Tensor& x, const ffi::Array<int64_t>& begin,
-                            const ffi::Array<int64_t>& end, const ffi::Array<int64_t>& strides,
-                            std::string slice_mode = "end", std::string name = "T_strided_slice",
-                            std::string tag = kInjective) {
+inline Tensor strided_slice(const Tensor& x, const ffi::Array<ffi::Optional<IntImm>>& begin,
+                            const ffi::Array<ffi::Optional<IntImm>>& end,
+                            const ffi::Array<IntImm>& strides, std::string slice_mode = "end",
+                            std::string name = "T_strided_slice", std::string tag = kInjective) {
   size_t src_tensor_dim = static_cast<size_t>(x->shape.size());
   ffi::Array<int64_t> axes;
   for (size_t i = 0; i < src_tensor_dim; ++i) axes.push_back(i);
-  ffi::Array<int64_t> begin_full(begin);
-  ffi::Array<int64_t> end_full(end);
-  ffi::Array<int64_t> strides_full(strides);
+  ffi::Array<ffi::Optional<IntImm>> begin_full(begin);
+  ffi::Array<ffi::Optional<IntImm>> end_full(end);
+  ffi::Array<IntImm> strides_full(strides);
 
-  constexpr int64_t one = 1;
-  constexpr int64_t zero = 0;
-  const int64_t max_range = std::numeric_limits<int64_t>::max();
+  DataType index_dtype =
+      (begin.size() > 0 && begin[0].defined()) ? begin[0].value()->dtype : DataType::Int(64);
+  const IntImm one = IntImm(index_dtype, 1);
+  const IntImm zero = IntImm(index_dtype, 0);
+  const IntImm max_range = Downcast<IntImm>(max_value(index_dtype));
 
   for (size_t i = strides.size(); i < src_tensor_dim; ++i) {
     strides_full.push_back(one);
   }
   for (size_t i = begin.size(); i < src_tensor_dim; ++i) {
-    begin_full.push_back(strides_full[i] > 0 ? zero : max_range);
+    begin_full.push_back(strides_full[i]->value > 0 ? zero : max_range);
   }
   for (size_t i = end.size(); i < src_tensor_dim; ++i) {
-    end_full.push_back(strides_full[i] < 0 ? zero : max_range);
+    end_full.push_back(strides_full[i]->value < 0 ? zero : max_range);
   }
 
   return strided_slice_with_axes(x, begin_full, end_full, strides_full, axes, slice_mode, name,

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -919,7 +919,7 @@ inline Tensor strided_slice_with_axes(const Tensor& x, const ffi::Array<Integer>
     TVM_FFI_ICHECK(axis >= 0 && axis < src_tensor_dim)
         << "Axis " << axes[i].IntValue() << " is out of bounds for tensor with " << src_tensor_dim
         << " dimensions";
-    normalized_axes.push_back(Integer(axis));
+    normalized_axes.push_back(IntImm(DataType::Int(32), axis));
   }
 
   std::vector<int64_t> begin_vec, end_vec, strides_vec;
@@ -2044,7 +2044,7 @@ inline Tensor one_hot(const Tensor& indices, const PrimExpr on_value, const Prim
     int indices_index = 0;
     for (int i = 0; i < ndim; i++) {
       if (i == true_axis) {
-        oshape.push_back(Integer(depth));
+        oshape.push_back(IntImm(DataType::Int(32), depth));
       } else {
         oshape.push_back(indices->shape[indices_index++]);
       }

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -225,8 +225,7 @@ inline Tensor transpose(const Tensor& x, ffi::Optional<ffi::Array<int64_t>> opt_
 
     for (size_t j = 0; j < axes.size(); ++j) {
       if (i != j) {
-        TVM_FFI_ICHECK(new_axis != static_cast<int>(axes[j]))
-            << "repeated axis in transpose";
+        TVM_FFI_ICHECK(new_axis != static_cast<int>(axes[j])) << "repeated axis in transpose";
       }
     }
     new_shape.push_back(x->shape[new_axis]);

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -73,8 +73,8 @@ using namespace topi::detail;
  *
  * \return A Tensor whose op member is the sliding_window operation
  */
-inline Tensor sliding_window(const Tensor& x, int axis, ffi::Array<Integer> window_shape,
-                             ffi::Array<Integer> strides, std::string name = "T_sliding_window",
+inline Tensor sliding_window(const Tensor& x, int axis, ffi::Array<int64_t> window_shape,
+                             ffi::Array<int64_t> strides, std::string name = "T_sliding_window",
                              std::string tag = "") {
   TVM_FFI_ICHECK_GE(axis, 0);
   auto _axis = size_t(axis);
@@ -98,16 +98,16 @@ inline Tensor sliding_window(const Tensor& x, int axis, ffi::Array<Integer> wind
     // Length of the shape along this dimension.
     auto dim_len = x->shape[_axis + i];
     // Length of the window along this dimension.
-    auto window_len = window_shape[i];
+    PrimExpr window_len = IntImm(DataType::Int(64), window_shape[i]);
     // Strides along this dimension.
-    auto stride = strides[i];
+    PrimExpr stride = IntImm(DataType::Int(64), strides[i]);
 
     new_shape.push_back(floordiv(dim_len - (window_len - 1) + stride - 1, stride));
   }
 
   // Dimensions comprising the window.
   for (size_t i = 0; i < window_shape.size(); ++i) {
-    new_shape.push_back(window_shape[i]);
+    new_shape.push_back(IntImm(DataType::Int(64), window_shape[i]));
   }
 
   TVM_FFI_ICHECK(new_shape.size() == _axis + 2 * window_shape.size());
@@ -129,7 +129,7 @@ inline Tensor sliding_window(const Tensor& x, int axis, ffi::Array<Integer> wind
           // Which index within the window we are indexing.
           auto idx_within_window = indices[_axis + window_shape.size() + i];
           // Stride value for this dimension.
-          auto stride = strides[i];
+          PrimExpr stride = IntImm(DataType::Int(64), strides[i]);
 
           idx.push_back(window_idx * stride + idx_within_window);
         }
@@ -202,9 +202,9 @@ inline Tensor expand_dims(const Tensor& x, int axis, int num_newaxis = 1,
  *
  * \return A Tensor whose op member is the transpose operation
  */
-inline Tensor transpose(const Tensor& x, ffi::Optional<ffi::Array<Integer>> opt_axes,
+inline Tensor transpose(const Tensor& x, ffi::Optional<ffi::Array<int64_t>> opt_axes,
                         std::string name = "T_transpose", std::string tag = kInjective) {
-  ffi::Array<Integer> axes = opt_axes.value_or({});
+  ffi::Array<int64_t> axes = opt_axes.value_or({});
   if (axes.size() == 0) {
     for (int i = static_cast<int>(x->shape.size()) - 1; i >= 0; --i) {
       axes.push_back(i);
@@ -213,7 +213,7 @@ inline Tensor transpose(const Tensor& x, ffi::Optional<ffi::Array<Integer>> opt_
 
   ffi::Array<PrimExpr> new_shape;
   for (size_t i = 0; i < axes.size(); ++i) {
-    int axis = static_cast<int>(axes[i]->value);
+    int axis = static_cast<int>(axes[i]);
     int new_axis = axis;
     if (axis < 0) {
       new_axis = static_cast<int>(x->shape.size()) + axis;
@@ -225,7 +225,7 @@ inline Tensor transpose(const Tensor& x, ffi::Optional<ffi::Array<Integer>> opt_
 
     for (size_t j = 0; j < axes.size(); ++j) {
       if (i != j) {
-        TVM_FFI_ICHECK(new_axis != static_cast<int>(axes[j]->value))
+        TVM_FFI_ICHECK(new_axis != static_cast<int>(axes[j]))
             << "repeated axis in transpose";
       }
     }
@@ -240,7 +240,7 @@ inline Tensor transpose(const Tensor& x, ffi::Optional<ffi::Array<Integer>> opt_
           idx.push_back(1);
         }
         for (size_t i = 0; i < axes.size(); ++i) {
-          int axis = static_cast<int>(axes[i]->value);
+          int axis = static_cast<int>(axes[i]);
           idx[axis] = indices[i];
         }
         return x(idx);
@@ -412,7 +412,7 @@ inline Tensor unravel_index(const Tensor& x, const Tensor& shape, std::string na
  *
  * \return A Tensor whose op member is the squeeze operation
  */
-inline Tensor squeeze(const Tensor& x, ffi::Optional<ffi::Array<Integer>> opt_axes,
+inline Tensor squeeze(const Tensor& x, ffi::Optional<ffi::Array<int64_t>> opt_axes,
                       bool atleast1d = false, std::string name = "T_squeeze",
                       std::string tag = kInjective) {
   auto ndim = x->shape.size();
@@ -424,9 +424,9 @@ inline Tensor squeeze(const Tensor& x, ffi::Optional<ffi::Array<Integer>> opt_ax
       }
     }
   } else {
-    ffi::Array<Integer> axis = *std::move(opt_axes);
+    ffi::Array<int64_t> axis = *std::move(opt_axes);
     for (size_t i = 0; i < axis.size(); ++i) {
-      int64_t val = axis[i]->value;
+      int64_t val = axis[i];
       if (val < 0) {
         val += static_cast<int>(x->shape.size());
       }
@@ -715,7 +715,7 @@ inline PrimExpr GetLength(PrimExpr begin, PrimExpr end, PrimExpr stride, PrimExp
  */
 inline te::Tensor dynamic_strided_slice_with_axes(
     const te::Tensor& x, const ffi::Array<PrimExpr>& begin, const ffi::Array<PrimExpr>& end,
-    const ffi::Array<PrimExpr>& strides, const ffi::Array<Integer>& axes,
+    const ffi::Array<PrimExpr>& strides, const ffi::Array<int64_t>& axes,
     bool assume_inbound = true, std::string name = "T_dynamic_strided_slice_with_axes",
     std::string tag = kInjective) {
   const size_t src_tensor_dim = x->shape.size();
@@ -725,7 +725,7 @@ inline te::Tensor dynamic_strided_slice_with_axes(
   TVM_FFI_ICHECK_LE(begin.size(), src_tensor_dim);
 
   for (const auto& axis_imm : axes) {
-    int axis = axis_imm->value;
+    int axis = static_cast<int>(axis_imm);
     TVM_FFI_ICHECK_LT(axis, src_tensor_dim);
   }
 
@@ -733,7 +733,7 @@ inline te::Tensor dynamic_strided_slice_with_axes(
 
   ffi::Array<PrimExpr> out_shape = x->shape;
   for (size_t i = 0; i < begin.size(); i++) {
-    int axis = axes[i]->value;
+    int axis = static_cast<int>(axes[i]);
     PrimExpr new_shape =
         analyzer.Simplify(GetLength(begin[i], end[i], strides[i], out_shape[axis], assume_inbound));
     out_shape.Set(axis, new_shape);
@@ -746,7 +746,7 @@ inline te::Tensor dynamic_strided_slice_with_axes(
             indices.Map([](const auto& var) -> PrimExpr { return var; });
 
         for (size_t i = 0; i < begin.size(); i++) {
-          int axis = axes[i]->value;
+          int axis = static_cast<int>(axes[i]);
           PrimExpr new_index = indices[axis] * strides[i] + begin[i];
           real_indices.Set(axis, new_index);
         }
@@ -866,17 +866,17 @@ inline te::Tensor dynamic_strided_slice(const te::Tensor& x, const te::Tensor& b
  * \return The output shape of strided_slice using the arguments above
  */
 inline ffi::Array<PrimExpr> StridedSliceOutputShape(const ffi::Array<PrimExpr>& ishape,
-                                                    const ffi::Array<Integer>& begin,
-                                                    const ffi::Array<Integer>& end,
-                                                    const ffi::Array<Integer>& strides,
-                                                    const ffi::Array<Integer>& axes,
+                                                    const ffi::Array<int64_t>& begin,
+                                                    const ffi::Array<int64_t>& end,
+                                                    const ffi::Array<int64_t>& strides,
+                                                    const ffi::Array<int64_t>& axes,
                                                     const std::string& slice_mode) {
   TVM_FFI_ICHECK(axes.size() == begin.size() && axes.size() == end.size() &&
                  axes.size() == strides.size());
   std::vector<int64_t> begin_vec, end_vec, strides_vec;
   std::tie(begin_vec, end_vec, strides_vec) = ConvertToVec(begin, end, strides, slice_mode);
   auto begin_canonicalized = StridedSliceCanonicalizeBegin(ishape, begin_vec, strides_vec, axes,
-                                                           begin[0]->dtype, slice_mode);
+                                                           DataType::Int(64), slice_mode);
   return StridedSliceOutputShape(ishape, begin_vec, end_vec, strides_vec, axes, slice_mode,
                                  begin_canonicalized, true);
 }
@@ -897,10 +897,10 @@ inline ffi::Array<PrimExpr> StridedSliceOutputShape(const ffi::Array<PrimExpr>& 
  *
  * \return A Tensor whose op member is the sstrided_slice operation
  */
-inline Tensor strided_slice_with_axes(const Tensor& x, const ffi::Array<Integer>& begin,
-                                      const ffi::Array<Integer>& end,
-                                      const ffi::Array<Integer>& strides,
-                                      const ffi::Array<Integer>& axes,
+inline Tensor strided_slice_with_axes(const Tensor& x, const ffi::Array<int64_t>& begin,
+                                      const ffi::Array<int64_t>& end,
+                                      const ffi::Array<int64_t>& strides,
+                                      const ffi::Array<int64_t>& axes,
                                       std::string slice_mode = "end",
                                       std::string name = "T_strided_slice_with_axes",
                                       std::string tag = kInjective) {
@@ -910,23 +910,24 @@ inline Tensor strided_slice_with_axes(const Tensor& x, const ffi::Array<Integer>
                  axes.size() == strides.size());
 
   // Normalize negative axes
-  ffi::Array<Integer> normalized_axes;
+  ffi::Array<int64_t> normalized_axes;
   for (size_t i = 0; i < axes.size(); ++i) {
-    int64_t axis = axes[i].IntValue();
+    int64_t axis = axes[i];
     if (axis < 0) {
       axis += src_tensor_dim;
     }
     TVM_FFI_ICHECK(axis >= 0 && axis < src_tensor_dim)
-        << "Axis " << axes[i].IntValue() << " is out of bounds for tensor with " << src_tensor_dim
+        << "Axis " << axes[i] << " is out of bounds for tensor with " << src_tensor_dim
         << " dimensions";
-    normalized_axes.push_back(IntImm(DataType::Int(32), axis));
+    normalized_axes.push_back(axis);
   }
 
   std::vector<int64_t> begin_vec, end_vec, strides_vec;
   std::tie(begin_vec, end_vec, strides_vec) = ConvertToVec(begin, end, strides, slice_mode);
 
+  DataType index_dtype = begin.size() > 0 ? DataType::Int(64) : DataType::Int(64);
   auto begin_expr = StridedSliceCanonicalizeBegin(x->shape, begin_vec, strides_vec, normalized_axes,
-                                                  begin[0]->dtype, slice_mode);
+                                                  index_dtype, slice_mode);
   auto out_shape = StridedSliceOutputShape(x->shape, begin_vec, end_vec, strides_vec,
                                            normalized_axes, slice_mode, begin_expr);
 
@@ -936,9 +937,10 @@ inline Tensor strided_slice_with_axes(const Tensor& x, const ffi::Array<Integer>
         ffi::Array<PrimExpr> real_indices;
         for (size_t i = 0; i < out_shape.size(); ++i) real_indices.push_back(indices[i]);
         for (size_t i = 0; i < normalized_axes.size(); ++i) {
-          auto stride = make_const(strides[i].dtype(), strides_vec[i]);
-          PrimExpr ind = indices[normalized_axes[i].IntValue()] * stride + begin_expr[i];
-          real_indices.Set(normalized_axes[i].IntValue(), ind);
+          int64_t ax = normalized_axes[i];
+          auto stride = make_const(DataType::Int(64), strides_vec[i]);
+          PrimExpr ind = indices[ax] * stride + begin_expr[i];
+          real_indices.Set(ax, ind);
         }
         return x(real_indices);
       },
@@ -959,30 +961,29 @@ inline Tensor strided_slice_with_axes(const Tensor& x, const ffi::Array<Integer>
  *
  * \return A Tensor whose op member is the strided_slice operation
  */
-inline Tensor strided_slice(const Tensor& x, const ffi::Array<Integer>& begin,
-                            const ffi::Array<Integer>& end, const ffi::Array<Integer>& strides,
+inline Tensor strided_slice(const Tensor& x, const ffi::Array<int64_t>& begin,
+                            const ffi::Array<int64_t>& end, const ffi::Array<int64_t>& strides,
                             std::string slice_mode = "end", std::string name = "T_strided_slice",
                             std::string tag = kInjective) {
   size_t src_tensor_dim = static_cast<size_t>(x->shape.size());
-  ffi::Array<Integer> axes;
+  ffi::Array<int64_t> axes;
   for (size_t i = 0; i < src_tensor_dim; ++i) axes.push_back(i);
-  ffi::Array<Integer> begin_full(begin);
-  ffi::Array<Integer> end_full(end);
-  ffi::Array<Integer> strides_full(strides);
+  ffi::Array<int64_t> begin_full(begin);
+  ffi::Array<int64_t> end_full(end);
+  ffi::Array<int64_t> strides_full(strides);
 
-  DataType index_dtype = begin.size() > 0 ? begin[0]->dtype : DataType::Int(64);
-  const IntImm one = IntImm(index_dtype, 1);
-  const IntImm zero = IntImm(index_dtype, 0);
-  const IntImm max_range = Downcast<IntImm>(max_value(index_dtype));
+  constexpr int64_t one = 1;
+  constexpr int64_t zero = 0;
+  const int64_t max_range = std::numeric_limits<int64_t>::max();
 
   for (size_t i = strides.size(); i < src_tensor_dim; ++i) {
     strides_full.push_back(one);
   }
   for (size_t i = begin.size(); i < src_tensor_dim; ++i) {
-    begin_full.push_back(GetConstInt(strides_full[i]) > 0 ? zero : max_range);
+    begin_full.push_back(strides_full[i] > 0 ? zero : max_range);
   }
   for (size_t i = end.size(); i < src_tensor_dim; ++i) {
-    end_full.push_back(GetConstInt(strides_full[i]) < 0 ? zero : max_range);
+    end_full.push_back(strides_full[i] < 0 ? zero : max_range);
   }
 
   return strided_slice_with_axes(x, begin_full, end_full, strides_full, axes, slice_mode, name,
@@ -1414,7 +1415,7 @@ inline Tensor repeat(const Tensor& x, int repeats, int axis, std::string name = 
  *
  * \return A Tensor whose op member is the tile operation
  */
-inline Tensor tile(const Tensor& x, ffi::Array<Integer> reps, std::string name = "T_tile",
+inline Tensor tile(const Tensor& x, ffi::Array<int64_t> reps, std::string name = "T_tile",
                    std::string tag = kBroadcast) {
   size_t ndim = x->shape.size();
   size_t rdim = reps.size();
@@ -1425,16 +1426,16 @@ inline Tensor tile(const Tensor& x, ffi::Array<Integer> reps, std::string name =
   if (ndim == rdim) {
     for (size_t i = 0; i < ndim; ++i) {
       data_shape.push_back(x->shape[i]);
-      reps_shape.push_back(reps[i]);
+      reps_shape.push_back(IntImm(DataType::Int(64), reps[i]));
     }
   } else if (ndim > rdim) {
     for (size_t i = 0; i < ndim; ++i) data_shape.push_back(x->shape[i]);
     for (size_t i = 0; i < (ndim - rdim); ++i) reps_shape.push_back(1);
-    for (size_t i = 0; i < rdim; ++i) reps_shape.push_back(reps[i]);
+    for (size_t i = 0; i < rdim; ++i) reps_shape.push_back(IntImm(DataType::Int(64), reps[i]));
   } else {
     for (size_t i = 0; i < (rdim - ndim); ++i) data_shape.push_back(1);
     for (size_t i = 0; i < ndim; ++i) data_shape.push_back(x->shape[i]);
-    for (size_t i = 0; i < rdim; ++i) reps_shape.push_back(reps[i]);
+    for (size_t i = 0; i < rdim; ++i) reps_shape.push_back(IntImm(DataType::Int(64), reps[i]));
   }
   for (size_t i = 0; i < tdim; ++i) new_shape.push_back(data_shape[i] * reps_shape[i]);
 

--- a/include/tvm/topi/utils.h
+++ b/include/tvm/topi/utils.h
@@ -33,16 +33,16 @@ namespace topi {
 using namespace tvm::runtime;
 
 /*! \brief Canonicalize an argument that may be ffi::Array<Expr> or int to ffi::Array<Expr> */
-inline ffi::Optional<ffi::Array<Integer>> ArrayOrInt(AnyView arg) {
+inline ffi::Optional<ffi::Array<int64_t>> ArrayOrInt(AnyView arg) {
   if (arg == nullptr) {
     return std::nullopt;
   }
   if (auto opt_int = arg.try_cast<int>()) {
-    ffi::Array<Integer> result;
+    ffi::Array<int64_t> result;
     result.push_back(opt_int.value());
     return result;
   } else {
-    return arg.cast<ffi::Array<Integer>>();
+    return arg.cast<ffi::Array<int64_t>>();
   }
 }
 }  // namespace topi

--- a/python/tvm/topi/transform.py
+++ b/python/tvm/topi/transform.py
@@ -229,6 +229,9 @@ def strided_slice(a, begin, end, strides=None, axes=None, slice_mode="end", assu
         strides = []
     if axes is None:
         axes = []
+    # axes is a list of host integers on the C++ side (Array<int64_t>); unwrap any
+    # IntImm entries that callers may pass through (e.g. relax legalize pipeline).
+    axes = [int(v) if isinstance(v, tvm.tirx.IntImm) else v for v in axes]
     return cpp.strided_slice(a, begin, end, strides, axes, slice_mode, assume_inbound)
 
 

--- a/src/arith/conjunctive_normal_form.cc
+++ b/src/arith/conjunctive_normal_form.cc
@@ -147,7 +147,8 @@ class AndOfOrs {
 };
 
 AndOfOrs::AndOfOrs(const PrimExpr& expr)
-    : key_true_(GetKey(IntImm(DataType::Bool(), 1))), key_false_(GetKey(IntImm(DataType::Bool(), 0))) {
+    : key_true_(GetKey(IntImm(DataType::Bool(), 1))),
+      key_false_(GetKey(IntImm(DataType::Bool(), 0))) {
   VisitAndExpressions(expr, [&](const PrimExpr& outer_expr) {
     std::vector<Key> or_components;
     VisitOrExpressions(outer_expr, [&](const PrimExpr& inner_expr) {

--- a/src/arith/conjunctive_normal_form.cc
+++ b/src/arith/conjunctive_normal_form.cc
@@ -25,6 +25,7 @@
 
 #include <tvm/arith/analyzer.h>
 #include <tvm/tirx/expr.h>
+#include <tvm/tirx/op.h>
 
 #include <optional>
 #include <unordered_map>
@@ -138,15 +139,15 @@ class AndOfOrs {
   /*! \brief Mapping from PrimExpr to internal Key */
   std::unordered_map<PrimExpr, Key, ffi::StructuralHash, ffi::StructuralEqual> expr_to_key_;
 
-  /*! \brief Cached key representing tirx::Bool(true) */
+  /*! \brief Cached key representing tirx::IntImm(DataType::Bool(), 1) */
   Key key_true_;
 
-  /*! \brief Cached key representing tirx::Bool(false) */
+  /*! \brief Cached key representing tirx::IntImm(DataType::Bool(), 0) */
   Key key_false_;
 };
 
 AndOfOrs::AndOfOrs(const PrimExpr& expr)
-    : key_true_(GetKey(Bool(true))), key_false_(GetKey(Bool(false))) {
+    : key_true_(GetKey(IntImm(DataType::Bool(), 1))), key_false_(GetKey(IntImm(DataType::Bool(), 0))) {
   VisitAndExpressions(expr, [&](const PrimExpr& outer_expr) {
     std::vector<Key> or_components;
     VisitOrExpressions(outer_expr, [&](const PrimExpr& inner_expr) {
@@ -233,9 +234,9 @@ PrimExpr AndOfOrs::GetExpr(AndOfOrs::Key key) const {
 }
 
 PrimExpr AndOfOrs::AsPrimExpr() const {
-  PrimExpr expr = Bool(true);
+  PrimExpr expr = IntImm(DataType::Bool(), 1);
   for (const auto& chunk : chunks_) {
-    PrimExpr chunk_expr = Bool(false);
+    PrimExpr chunk_expr = IntImm(DataType::Bool(), 0);
     for (Key j : chunk) {
       chunk_expr = chunk_expr || GetExpr(j);
     }
@@ -366,7 +367,7 @@ void AndOfOrs::SimplifyAcrossChunks(Analyzer* analyzer) {
           // When attempting to simplify (B and C), the analyzer may
           // assume that A is false.
           PrimExpr known = [&]() {
-            PrimExpr known = Bool(true);
+            PrimExpr known = IntImm(DataType::Bool(), 1);
             for (const auto& key : i_chunk) {
               if (&key != &key_i) {
                 known = known && analyzer->Simplify(!GetExpr(key));

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -1711,7 +1711,7 @@ PrimExpr ApproxLeastCommonMultiple(const PrimExpr& a, const PrimExpr& b, Analyze
   };
   auto p1 = fsplit(a);
   auto p2 = fsplit(b);
-  auto const_lcm = Integer(LeastCommonMultiple(p1.second, p2.second));
+  auto const_lcm = IntImm(DataType::Int(32), LeastCommonMultiple(p1.second, p2.second));
   if (analyzer->CanProveEqual(p1.first, p2.first)) {
     return p1.first * const_lcm;
   } else if (analyzer->CanProveEqual(floormod(p1.first, p2.first), 0)) {
@@ -2479,7 +2479,7 @@ class SubspaceDivider {
   std::unordered_map<IterSplitExpr, DivisionResult, ffi::ObjectPtrHash, ffi::ObjectPtrEqual>
       split_map_;
   // predicate of outer space and inner space;
-  PrimExpr outer_preds_{Bool(true)}, inner_preds_{Bool(true)};
+  PrimExpr outer_preds_{const_true()}, inner_preds_{const_true()};
 };
 
 ffi::Array<ffi::Array<IterMark>> SubspaceDivide(const ffi::Array<PrimExpr>& bindings,
@@ -2540,7 +2540,7 @@ class InverseAffineIterMapTransformer {
 
     // initialize back propagation accumulator
     for (const IterMapExprNode* node : post_dfs_order) {
-      backprop_.Set(ffi::GetRef<IterMapExpr>(node), Integer(0));
+      backprop_.Set(ffi::GetRef<IterMapExpr>(node), IntImm(DataType::Int(32), 0));
     }
     for (size_t i = 0; i < iter_map.size(); i++) {
       backprop_.Set(iter_map[i], outputs[i]);

--- a/src/arith/modular_set.cc
+++ b/src/arith/modular_set.cc
@@ -303,7 +303,7 @@ class ModularSetAnalyzer::Impl : public ExprFunctor<ModularSetAnalyzer::Entry(co
     Entry b = VisitExpr(op->args[1]);
     if (b.is_const()) {
       int shift;
-      if (is_const_power_of_two_integer(Integer(b.base + 1), &shift)) {
+      if (is_const_power_of_two_integer(IntImm(DataType::Int(32), b.base + 1), &shift)) {
         return ModByConst(op->args[0], static_cast<int64_t>(1) << shift, true);
       }
     }

--- a/src/arith/presburger_set.cc
+++ b/src/arith/presburger_set.cc
@@ -126,9 +126,9 @@ void PresburgerSetNode::UpdateConstraint(const PrimExpr& constraint, const ffi::
 }
 
 PrimExpr PresburgerSetNode::GenerateConstraint() const {
-  PrimExpr constraint = Bool(0);
+  PrimExpr constraint = const_false();
   for (const IntegerRelation& disjunct : disjuncts) {
-    PrimExpr union_entry = Bool(1);
+    PrimExpr union_entry = const_true();
     for (unsigned i = 0, e = disjunct.getNumEqualities(); i < e; ++i) {
       PrimExpr linear_eq = IntImm(DataType::Int(64), 0);
       if (disjunct.getNumCols() > 1) {

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -211,7 +211,7 @@ CompareResult RewriteSimplifier::Impl::TryComparisonOfProductAndSum(const PrimEx
                    (B * A) + (A + B) * C,
                }
                    .Match(diff)) {
-      return std::tuple{A.Eval(), B.Eval(), C.Eval(), Integer(-1)};
+      return std::tuple{A.Eval(), B.Eval(), C.Eval(), IntImm(DataType::Int(32), -1)};
     } else {
       return std::nullopt;
     }
@@ -1063,7 +1063,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
         floordiv(y + x * c1, c2).Match(ret)) {
       int64_t c1val = c1.Eval()->value;
       int64_t c2val = c2.Eval()->value;
-      PrimExpr yval = y.EvalOr(Integer(0));
+      PrimExpr yval = y.EvalOr(IntImm(DataType::Int(32), 0));
       if (c2val == 0) return ret;
 
       // try eliminate residue part
@@ -1072,7 +1072,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
       PrimExpr y_div = CanProveEqual(floordiv(yval, c2val), 0) ? 0 : floordiv(yval, c2val);
       auto bound = analyzer_->const_int_bound(residue);
       if (bound.defined() && bound->max_value == bound->min_value) {
-        return x.Eval() * floordiv(c1val, c2.Eval()) + (y_div + Integer(bound->max_value));
+        return x.Eval() * floordiv(c1val, c2.Eval()) + (y_div + IntImm(DataType::Int(32), bound->max_value));
       }
 
       // try simplify divisor

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -1072,7 +1072,8 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
       PrimExpr y_div = CanProveEqual(floordiv(yval, c2val), 0) ? 0 : floordiv(yval, c2val);
       auto bound = analyzer_->const_int_bound(residue);
       if (bound.defined() && bound->max_value == bound->min_value) {
-        return x.Eval() * floordiv(c1val, c2.Eval()) + (y_div + IntImm(DataType::Int(32), bound->max_value));
+        return x.Eval() * floordiv(c1val, c2.Eval()) +
+               (y_div + IntImm(DataType::Int(32), bound->max_value));
       }
 
       // try simplify divisor

--- a/src/relax/analysis/struct_info_analysis.cc
+++ b/src/relax/analysis/struct_info_analysis.cc
@@ -30,6 +30,7 @@
 #include <tvm/relax/struct_info_functor.h>
 #include <tvm/tirx/analysis.h>
 #include <tvm/tirx/expr_functor.h>
+#include <tvm/tirx/op.h>
 
 namespace tvm {
 namespace relax {
@@ -632,97 +633,97 @@ class StructInfoBasePreconditionCollector
   PrimExpr VisitStructInfo(const StructInfo& lhs, const StructInfo& other) override {
     if (lhs.same_as(other)) {
       // Early bail-out if the StructInfo has reference equality.
-      return Bool(true);
+      return IntImm(DataType::Bool(), 1);
     } else {
       return StructInfoFunctor::VisitStructInfo(lhs, other);
     }
   }
 
   PrimExpr VisitStructInfo_(const ObjectStructInfoNode* lhs, const StructInfo& other) final {
-    return Bool(true);
+    return IntImm(DataType::Bool(), 1);
   }
 
   PrimExpr VisitStructInfo_(const PrimStructInfoNode* lhs, const StructInfo& other) final {
     auto* rhs = other.as<PrimStructInfoNode>();
     if (rhs == nullptr) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     if (lhs->dtype != rhs->dtype) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     if (lhs->value.defined() && rhs->value.defined()) {
       return lhs->value.value() == rhs->value.value();
     } else if (lhs->value.defined() && !rhs->value.defined()) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     } else {
-      return Bool(true);
+      return IntImm(DataType::Bool(), 1);
     }
   }
 
   PrimExpr VisitStructInfo_(const ShapeStructInfoNode* lhs, const StructInfo& other) final {
     auto* rhs = other.as<ShapeStructInfoNode>();
     if (rhs == nullptr) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
     // lhs have unknown ndim
     if (lhs->IsUnknownNdim()) {
-      return Bool(true);
+      return IntImm(DataType::Bool(), 1);
     }
 
     // ndim must match
     if (lhs->ndim != rhs->ndim) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     if (lhs->values.defined() && rhs->values.defined()) {
       return ArrayCheck(lhs->values.value(), rhs->values.value());
     } else if (lhs->values.defined() && !rhs->values.defined()) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     } else {
-      return Bool(true);
+      return IntImm(DataType::Bool(), 1);
     }
   }
 
   PrimExpr VisitStructInfo_(const TensorStructInfoNode* lhs, const StructInfo& other) final {
     auto* rhs = other.as<TensorStructInfoNode>();
     if (rhs == nullptr) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
     // dtype mismatch
     if (!lhs->IsUnknownDtype() && lhs->dtype != rhs->dtype) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     // ndim mismatch
     if (!lhs->IsUnknownNdim() && lhs->ndim != rhs->ndim) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     // vdevice mismatch
     if (lhs->vdevice.defined() && !rhs->vdevice.defined()) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
     if (lhs->vdevice.defined() && rhs->vdevice.defined()) {
       VDevice lhs_vdevice = lhs->vdevice.value();
       VDevice rhs_vdevice = rhs->vdevice.value();
       if (lhs_vdevice->target.defined() && !rhs_vdevice->target.defined()) {
-        return Bool(false);
+        return IntImm(DataType::Bool(), 0);
       }
       // mismatch in either the target, vdevice_id, or memory_scope
       if ((lhs_vdevice->target.defined() && rhs_vdevice->target.defined()) &&
           (lhs_vdevice->target != rhs_vdevice->target ||
            lhs_vdevice->vdevice_id != rhs_vdevice->vdevice_id ||
            lhs_vdevice->memory_scope != rhs_vdevice->memory_scope)) {
-        return Bool(false);
+        return IntImm(DataType::Bool(), 0);
       }
     }
 
     if (lhs->shape.same_as(rhs->shape)) {
-      return Bool(true);
+      return IntImm(DataType::Bool(), 1);
     } else if (lhs->shape.defined() && !rhs->shape.defined()) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     auto* lhs_shape = lhs->shape.as<ShapeExprNode>();
@@ -730,23 +731,23 @@ class StructInfoBasePreconditionCollector
     if (lhs_shape && rhs_shape) {
       return ArrayCheck(lhs_shape->values, rhs_shape->values);
     } else if (lhs_shape && !rhs_shape) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
-    return Bool(true);
+    return IntImm(DataType::Bool(), 1);
   }
 
   PrimExpr VisitStructInfo_(const distributed::DTensorStructInfoNode* lhs,
                             const StructInfo& other) final {
     auto* rhs = other.as<distributed::DTensorStructInfoNode>();
     if (rhs == nullptr) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     ffi::StructuralEqual struct_equal;
     if (!struct_equal(lhs->device_mesh, rhs->device_mesh) ||
         !struct_equal(lhs->placement, rhs->placement)) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     return this->VisitStructInfo(lhs->tensor_sinfo, rhs->tensor_sinfo);
@@ -755,7 +756,7 @@ class StructInfoBasePreconditionCollector
   PrimExpr VisitStructInfo_(const TupleStructInfoNode* lhs, const StructInfo& other) final {
     auto* rhs = other.as<TupleStructInfoNode>();
     if (rhs == nullptr) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
     return ArrayCheck(lhs->fields, rhs->fields);
   }
@@ -763,19 +764,19 @@ class StructInfoBasePreconditionCollector
   PrimExpr VisitStructInfo_(const FuncStructInfoNode* lhs, const StructInfo& other) override {
     auto* rhs = other.as<FuncStructInfoNode>();
     if (rhs == nullptr) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     // Check purity: Pure functions are a subtype of impure functions
     if (lhs->purity && !rhs->purity) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     if (lhs->derive_func.defined() && !lhs->derive_func.same_as(rhs->derive_func)) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
     if (lhs->params.defined() && !rhs->params.defined()) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
     PrimExpr all_match = VisitStructInfo(lhs->ret, rhs->ret);
@@ -784,7 +785,7 @@ class StructInfoBasePreconditionCollector
     if (lhs->params.defined()) {
       param_check = ArrayCheck(lhs->params.value(), rhs->params.value());
     } else {
-      param_check = Bool(true);
+      param_check = IntImm(DataType::Bool(), 1);
     }
 
     PrimExpr ret_check = VisitStructInfo(lhs->ret, rhs->ret);
@@ -795,10 +796,10 @@ class StructInfoBasePreconditionCollector
  private:
   PrimExpr ArrayCheck(const ffi::Array<PrimExpr>& lhs, const ffi::Array<PrimExpr>& rhs) {
     if (lhs.size() != rhs.size()) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
-    PrimExpr all_equal = Bool(true);
+    PrimExpr all_equal = IntImm(DataType::Bool(), 1);
     for (size_t i = 0; i < lhs.size(); i++) {
       all_equal = all_equal && (lhs[i] == rhs[i]);
     }
@@ -807,10 +808,10 @@ class StructInfoBasePreconditionCollector
 
   PrimExpr ArrayCheck(const ffi::Array<StructInfo>& lhs, const ffi::Array<StructInfo>& rhs) {
     if (lhs.size() != rhs.size()) {
-      return Bool(false);
+      return IntImm(DataType::Bool(), 0);
     }
 
-    PrimExpr all_pass = Bool(true);
+    PrimExpr all_pass = IntImm(DataType::Bool(), 1);
 
     for (size_t i = 0; i < lhs.size(); ++i) {
       all_pass = all_pass && VisitStructInfo(lhs[i], rhs[i]);

--- a/src/relax/analysis/struct_info_analysis.cc
+++ b/src/relax/analysis/struct_info_analysis.cc
@@ -633,7 +633,7 @@ class StructInfoBasePreconditionCollector
   PrimExpr VisitStructInfo(const StructInfo& lhs, const StructInfo& other) override {
     if (lhs.same_as(other)) {
       // Early bail-out if the StructInfo has reference equality.
-      return IntImm(DataType::Bool(), 1);
+      return tirx::const_true();
     } else {
       return StructInfoFunctor::VisitStructInfo(lhs, other);
     }

--- a/src/relax/analysis/tir_op_pattern_kind.cc
+++ b/src/relax/analysis/tir_op_pattern_kind.cc
@@ -25,8 +25,8 @@
 #include <tvm/tirx/analysis.h>
 #include <tvm/tirx/expr_functor.h>
 #include <tvm/tirx/function.h>
-#include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt_functor.h>
 
 namespace tvm {
 namespace relax {

--- a/src/relax/analysis/tir_op_pattern_kind.cc
+++ b/src/relax/analysis/tir_op_pattern_kind.cc
@@ -26,6 +26,7 @@
 #include <tvm/tirx/expr_functor.h>
 #include <tvm/tirx/function.h>
 #include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/op.h>
 
 namespace tvm {
 namespace relax {
@@ -444,7 +445,7 @@ bool HasReshapePattern(const PrimFunc& func) {
         return arith::IterMapSimplify(
             /*indices=*/{idx},
             /*input_iters=*/var_range,
-            /*input_pred=*/Bool(true),
+            /*input_pred=*/const_true(),
             /*check_level=*/arith::IterMapLevel::Surjective,
             /*analyzer=*/&ana_,
             /*simplify_trivial_iterators=*/true)[0];
@@ -494,7 +495,7 @@ bool HasReshapePattern(const PrimFunc& func) {
         ffi::Array<PrimExpr> simplify_res = arith::IterMapSimplify(
             /*indices=*/{flattened_idx},
             /*input_iters=*/{{fused_var, Range(IntImm(dtype, /*value=*/0), stride)}},
-            /*input_pred=*/Bool(true),
+            /*input_pred=*/const_true(),
             /*check_level=*/arith::IterMapLevel::Surjective,
             /*analyzer=*/&this->ana_,
             /*simplify_trivial_iterators=*/true);

--- a/src/relax/backend/contrib/clml/codegen.cc
+++ b/src/relax/backend/contrib/clml/codegen.cc
@@ -48,7 +48,8 @@ struct OpenCLMLCompilerConfigNode : public ffi::Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<OpenCLMLCompilerConfigNode>().def_ro(
         "clml_version", &OpenCLMLCompilerConfigNode::clml_version,
-        "OpenCLML version as (major, minor, patch).", refl::DefaultValue(IntImm(DataType::Int(32), 3)));
+        "OpenCLML version as (major, minor, patch).",
+        refl::DefaultValue(IntImm(DataType::Int(32), 3)));
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ext.attrs.OpenCLMLCompilerConfig",
                                     OpenCLMLCompilerConfigNode, ffi::Object);

--- a/src/relax/backend/contrib/clml/codegen.cc
+++ b/src/relax/backend/contrib/clml/codegen.cc
@@ -42,7 +42,7 @@ namespace contrib {
 
 /*! \brief Attributes to store the compiler options for OpenCLML. */
 struct OpenCLMLCompilerConfigNode : public ffi::Object {
-  Integer clml_version;
+  IntImm clml_version;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -269,7 +269,7 @@ class OpenCLMLJSONSerializer : public JSONSerializer {
     if (!cfg.defined()) {
       cfg = transform::PassConfigWithDefaults<OpenCLMLCompilerConfig>();
     }
-    node->SetAttr("clml_version", static_cast<int64_t>(cfg.value()->clml_version.IntValue()));
+    node->SetAttr("clml_version", static_cast<int64_t>(cfg.value()->clml_version->value));
   }
 
  private:
@@ -332,7 +332,7 @@ inline constexpr bool IsOpenCLMLRuntimeEnabled() {
  * \brief Get OpenCLML version that TVM is built against.
  * \return The OpenCLML SDK version.
  */
-Integer GetOpenCLMLVersion() {
+IntImm GetOpenCLMLVersion() {
 #if TVM_GRAPH_EXECUTOR_CLML
   return IntImm(DataType::Int(32), TVM_CLML_VERSION);
 #else

--- a/src/relax/backend/contrib/clml/codegen.cc
+++ b/src/relax/backend/contrib/clml/codegen.cc
@@ -48,7 +48,7 @@ struct OpenCLMLCompilerConfigNode : public ffi::Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<OpenCLMLCompilerConfigNode>().def_ro(
         "clml_version", &OpenCLMLCompilerConfigNode::clml_version,
-        "OpenCLML version as (major, minor, patch).", refl::DefaultValue(Integer(3)));
+        "OpenCLML version as (major, minor, patch).", refl::DefaultValue(IntImm(DataType::Int(32), 3)));
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ext.attrs.OpenCLMLCompilerConfig",
                                     OpenCLMLCompilerConfigNode, ffi::Object);
@@ -334,9 +334,9 @@ inline constexpr bool IsOpenCLMLRuntimeEnabled() {
  */
 Integer GetOpenCLMLVersion() {
 #if TVM_GRAPH_EXECUTOR_CLML
-  return Integer(TVM_CLML_VERSION);
+  return IntImm(DataType::Int(32), TVM_CLML_VERSION);
 #else
-  return Integer(3);
+  return IntImm(DataType::Int(32), 3);
 #endif  // TVM_GRAPH_EXECUTOR_CLML
 }
 

--- a/src/relax/distributed/axis_group_graph.cc
+++ b/src/relax/distributed/axis_group_graph.cc
@@ -181,8 +181,8 @@ void BuildAxisGraphReduce(const Var& output_var, const Call& call,
   int ndim = GetTensorStructInfo(input_tensor)->ndim;
 
   std::unordered_set<int> normalized_axes;
-  for (const Integer& i : axes) {
-    int val = i->value;
+  for (int64_t i : axes) {
+    int val = static_cast<int>(i);
     TVM_FFI_ICHECK(val < ndim && val >= -ndim);
     if (val < 0) {
       val = ndim + val;
@@ -289,8 +289,8 @@ void BuildAxisGraphPermuteDims(const Var& output_var, const Call& call,
   int ndim = GetTensorStructInfo(input_tensor)->ndim;
   std::vector<int> normalized_axes;
   if (attrs->axes.defined()) {
-    for (const Integer& i : attrs->axes.value()) {
-      int val = i->value;
+    for (int64_t i : attrs->axes.value()) {
+      int val = static_cast<int>(i);
       TVM_FFI_ICHECK(val < ndim && val >= -ndim);
       if (val < 0) {
         val = ndim + val;

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -471,7 +471,7 @@ PrimExpr DFPatternMatcher::SimplifyCondition(PrimExpr condition) {
       constraints.begin(), constraints.end(),
       [&sort_key](const PrimExpr& a, const PrimExpr& b) { return sort_key(a) < sort_key(b); });
 
-  PrimExpr sorted_condition = Bool(true);
+  PrimExpr sorted_condition = IntImm(DataType::Bool(), 1);
   for (const PrimExpr& constraint : constraints) {
     sorted_condition = sorted_condition && constraint;
   }
@@ -504,7 +504,7 @@ std::tuple<PrimExpr, bool> SameShapeConstraintNode::AsPrimExpr(
   bool all_shapes_defined = true;
 
   // The expression that must be true in order
-  PrimExpr all_dimensions_equal = Bool(true);
+  PrimExpr all_dimensions_equal = IntImm(DataType::Bool(), 1);
 
   for (const auto& arg : args) {
     if (auto opt_var = match_state(arg.get())) {
@@ -523,7 +523,7 @@ std::tuple<PrimExpr, bool> SameShapeConstraintNode::AsPrimExpr(
       if (!opt_var_shape.defined()) {
         // The pattern has matched to something without a shape.
         // Therefore, it cannot have the same shape as something else.
-        return {PrimExpr(Bool(false)), true};
+        return {PrimExpr(IntImm(DataType::Bool(), 0)), true};
       }
       auto var_shape = opt_var_shape.value();
 
@@ -540,7 +540,7 @@ std::tuple<PrimExpr, bool> SameShapeConstraintNode::AsPrimExpr(
           // The shapes have different dimensionality.  No need to
           // perform potentially-expensive simplifications, because
           // the dimensions do not match.
-          return {PrimExpr(Bool(false)), true};
+          return {PrimExpr(IntImm(DataType::Bool(), 0)), true};
         }
 
       } else {

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -471,7 +471,7 @@ PrimExpr DFPatternMatcher::SimplifyCondition(PrimExpr condition) {
       constraints.begin(), constraints.end(),
       [&sort_key](const PrimExpr& a, const PrimExpr& b) { return sort_key(a) < sort_key(b); });
 
-  PrimExpr sorted_condition = IntImm(DataType::Bool(), 1);
+  PrimExpr sorted_condition = tirx::const_true();
   for (const PrimExpr& constraint : constraints) {
     sorted_condition = sorted_condition && constraint;
   }

--- a/src/relax/ir/dataflow_matcher.h
+++ b/src/relax/ir/dataflow_matcher.h
@@ -32,6 +32,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <tvm/tirx/op.h>
 
 namespace tvm {
 namespace relax {
@@ -93,7 +94,7 @@ class DFPatternMatcher : public DFPatternFunctor<bool(const DFPattern&, const Ex
   std::unordered_map<DFPattern, Expr, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> memo_;
   var2val_t var2val_;
   std::vector<DFPattern> matched_nodes_;
-  PrimExpr symbolic_expr_condition_{Bool(true)};
+  PrimExpr symbolic_expr_condition_{IntImm(DataType::Bool(), 1)};
   arith::Analyzer analyzer_;
   bool memoize_ = true;
 };

--- a/src/relax/ir/dataflow_matcher.h
+++ b/src/relax/ir/dataflow_matcher.h
@@ -28,11 +28,11 @@
 #include <tvm/relax/dataflow_matcher.h>
 #include <tvm/relax/dataflow_pattern.h>
 #include <tvm/relax/dataflow_pattern_functor.h>
+#include <tvm/tirx/op.h>
 
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <tvm/tirx/op.h>
 
 namespace tvm {
 namespace relax {

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -231,15 +231,14 @@ TupleGetItem::TupleGetItem(Expr tuple, int index, Span span) {
 TupleGetItem WithFields(TupleGetItem tuple_get_item, ffi::Optional<Expr> opt_tuple,
                         ffi::Optional<int64_t> opt_index, ffi::Optional<Span> opt_span) {
   Expr tuple = opt_tuple.value_or(tuple_get_item->tuple);
-  Integer index = opt_index.value_or(tuple_get_item->index);
+  int64_t index = opt_index.value_or(tuple_get_item->index);
   Span span = opt_span.value_or(tuple_get_item->span);
 
   bool unchanged = tuple.same_as(tuple_get_item->tuple) && (index == tuple_get_item->index) &&
                    span.same_as(tuple_get_item->span);
   if (!unchanged) {
     TupleGetItemNode* cow_tuple_get_item_node = tuple_get_item.CopyOnWrite();
-    cow_tuple_get_item_node->tuple = tuple;
-    cow_tuple_get_item_node->index = index.IntValue();
+    cow_tuple_get_item_node->index = static_cast<int>(index);
     cow_tuple_get_item_node->span = span;
   }
   return tuple_get_item;

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -30,6 +30,7 @@
 #include <tvm/relax/analysis.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/type.h>
+#include <tvm/tirx/op.h>
 
 // functions to be overriden.
 #define RELAX_VISIT_BINDING_DISPATCH(OP)                                        \
@@ -798,7 +799,7 @@ Expr ExprMutator::VisitWithNewScope(const Expr& expr, ffi::Optional<ffi::Array<V
   TVM_FFI_ICHECK(expr->IsInstance<SeqExprNode>())
       << "Normal form requires all new scope is stored as SeqExpr";
 
-  PrimExpr constraint = Bool(true);
+  PrimExpr constraint = IntImm(DataType::Bool(), 1);
   if (params.defined()) {
     auto non_negative_expressions =
         CollectNonNegativeExpressions(TupleStructInfo(params.value().Map(GetStructInfo)));

--- a/src/relax/op/memory/view.cc
+++ b/src/relax/op/memory/view.cc
@@ -188,7 +188,7 @@ StructInfo InferStructInfoView(const Call& call, const BlockBuilder& ctx) {
       return std::nullopt;
     }
 
-    PrimExpr num_elements = Integer(1);
+    PrimExpr num_elements = IntImm(DataType::Int(32), 1);
     for (const auto& dim : shape.value()) {
       num_elements *= dim;
     }

--- a/src/relax/op/nn/convolution.cc
+++ b/src/relax/op/nn/convolution.cc
@@ -128,15 +128,18 @@ StructInfo InferStructInfoConv1d(const Call& call, const BlockBuilder& ctx) {
 
   PrimExpr input_w = data_NCW_shape[2];
   PrimExpr kernel_w = weight_OIW_shape[2];
-  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
+  PrimExpr padding_w =
+      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
 
   std::vector<PrimExpr> out_NCW_shape;
   out_NCW_shape.resize(3);
   out_NCW_shape[0] = data_NCW_shape[0];
   out_NCW_shape[1] = weight_OIW_shape[0];
 
-  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_w - 1) - 1;
-  out_NCW_shape[2] = analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
+  PrimExpr numerator_w =
+      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_w - 1) - 1;
+  out_NCW_shape[2] =
+      analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
 
   ffi::Array<PrimExpr> out_shape = out2NCW.BackwardShape(out_NCW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
@@ -299,18 +302,24 @@ StructInfo InferStructInfoConv2d(const Call& call, const BlockBuilder& ctx) {
   PrimExpr input_w = data_NCHW_shape[3];
   PrimExpr kernel_h = weight_OIHW_shape[2];
   PrimExpr kernel_w = weight_OIHW_shape[3];
-  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
-  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h =
+      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
+  PrimExpr padding_w =
+      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
 
   std::vector<PrimExpr> out_NCHW_shape;
   out_NCHW_shape.resize(4);
   out_NCHW_shape[0] = data_NCHW_shape[0];
   out_NCHW_shape[1] = weight_OIHW_shape[0];
 
-  PrimExpr numerator_h = input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_h - 1) - 1;
-  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_w - 1) - 1;
-  out_NCHW_shape[2] = analyzer->Simplify(floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
-  out_NCHW_shape[3] = analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[1])) + 1);
+  PrimExpr numerator_h =
+      input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_h - 1) - 1;
+  PrimExpr numerator_w =
+      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_w - 1) - 1;
+  out_NCHW_shape[2] =
+      analyzer->Simplify(floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
+  out_NCHW_shape[3] =
+      analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[1])) + 1);
 
   ffi::Array<PrimExpr> out_shape = out2NCHW.BackwardShape(out_NCHW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
@@ -512,21 +521,30 @@ StructInfo InferStructInfoConv3d(const Call& call, const BlockBuilder& ctx) {
   PrimExpr kernel_d = weight_OIDHW_shape[2];
   PrimExpr kernel_h = weight_OIDHW_shape[3];
   PrimExpr kernel_w = weight_OIDHW_shape[4];
-  PrimExpr padding_d = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
-  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
-  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
+  PrimExpr padding_d =
+      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h =
+      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
+  PrimExpr padding_w =
+      IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
 
   std::vector<PrimExpr> out_NCDHW_shape;
   out_NCDHW_shape.resize(5);
   out_NCDHW_shape[0] = data_NCDHW_shape[0];
   out_NCDHW_shape[1] = weight_OIDHW_shape[0];
 
-  PrimExpr numerator_d = input_d + padding_d - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_d - 1) - 1;
-  PrimExpr numerator_h = input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_h - 1) - 1;
-  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[2]) * (kernel_w - 1) - 1;
-  out_NCDHW_shape[2] = analyzer->Simplify(floordiv(numerator_d, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
-  out_NCDHW_shape[3] = analyzer->Simplify(floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[1])) + 1);
-  out_NCDHW_shape[4] = analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[2])) + 1);
+  PrimExpr numerator_d =
+      input_d + padding_d - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_d - 1) - 1;
+  PrimExpr numerator_h =
+      input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_h - 1) - 1;
+  PrimExpr numerator_w =
+      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[2]) * (kernel_w - 1) - 1;
+  out_NCDHW_shape[2] =
+      analyzer->Simplify(floordiv(numerator_d, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
+  out_NCDHW_shape[3] =
+      analyzer->Simplify(floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[1])) + 1);
+  out_NCDHW_shape[4] =
+      analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[2])) + 1);
 
   ffi::Array<PrimExpr> out_shape = out2NCDHW.BackwardShape(out_NCDHW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
@@ -701,7 +719,8 @@ StructInfo InferStructInfoConv1dTranspose(const Call& call, const BlockBuilder& 
 
   PrimExpr input_w = data_NCW_shape[2];
   PrimExpr kernel_w = weight_IOW_shape[2];
-  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
+  PrimExpr padding_w =
+      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
 
   std::vector<PrimExpr> out_NCW_shape;
   out_NCW_shape.resize(3);
@@ -895,8 +914,10 @@ StructInfo InferStructInfoConv2dTranspose(const Call& call, const BlockBuilder& 
   PrimExpr input_w = data_NCHW_shape[3];
   PrimExpr kernel_h = weight_IOHW_shape[2];
   PrimExpr kernel_w = weight_IOHW_shape[3];
-  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
-  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h =
+      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
+  PrimExpr padding_w =
+      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
 
   std::vector<PrimExpr> out_NCHW_shape;
   out_NCHW_shape.resize(4);
@@ -1132,9 +1153,12 @@ StructInfo InferStructInfoConv3dTranspose(const Call& call, const BlockBuilder& 
   PrimExpr kernel_d = weight_IODHW_shape[2];
   PrimExpr kernel_h = weight_IODHW_shape[3];
   PrimExpr kernel_w = weight_IODHW_shape[4];
-  PrimExpr padding_d = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
-  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
-  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
+  PrimExpr padding_d =
+      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h =
+      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
+  PrimExpr padding_w =
+      IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
 
   std::vector<PrimExpr> out_NCDHW_shape;
   out_NCDHW_shape.resize(5);

--- a/src/relax/op/nn/convolution.cc
+++ b/src/relax/op/nn/convolution.cc
@@ -128,15 +128,15 @@ StructInfo InferStructInfoConv1d(const Call& call, const BlockBuilder& ctx) {
 
   PrimExpr input_w = data_NCW_shape[2];
   PrimExpr kernel_w = weight_OIW_shape[2];
-  PrimExpr padding_w = Integer(attrs->padding[0]) + Integer(attrs->padding[1]);
+  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
 
   std::vector<PrimExpr> out_NCW_shape;
   out_NCW_shape.resize(3);
   out_NCW_shape[0] = data_NCW_shape[0];
   out_NCW_shape[1] = weight_OIW_shape[0];
 
-  PrimExpr numerator_w = input_w + padding_w - Integer(attrs->dilation[0]) * (kernel_w - 1) - 1;
-  out_NCW_shape[2] = analyzer->Simplify(floordiv(numerator_w, Integer(attrs->strides[0])) + 1);
+  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_w - 1) - 1;
+  out_NCW_shape[2] = analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
 
   ffi::Array<PrimExpr> out_shape = out2NCW.BackwardShape(out_NCW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
@@ -299,18 +299,18 @@ StructInfo InferStructInfoConv2d(const Call& call, const BlockBuilder& ctx) {
   PrimExpr input_w = data_NCHW_shape[3];
   PrimExpr kernel_h = weight_OIHW_shape[2];
   PrimExpr kernel_w = weight_OIHW_shape[3];
-  PrimExpr padding_h = Integer(attrs->padding[0]) + Integer(attrs->padding[2]);
-  PrimExpr padding_w = Integer(attrs->padding[1]) + Integer(attrs->padding[3]);
+  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
+  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
 
   std::vector<PrimExpr> out_NCHW_shape;
   out_NCHW_shape.resize(4);
   out_NCHW_shape[0] = data_NCHW_shape[0];
   out_NCHW_shape[1] = weight_OIHW_shape[0];
 
-  PrimExpr numerator_h = input_h + padding_h - Integer(attrs->dilation[0]) * (kernel_h - 1) - 1;
-  PrimExpr numerator_w = input_w + padding_w - Integer(attrs->dilation[1]) * (kernel_w - 1) - 1;
-  out_NCHW_shape[2] = analyzer->Simplify(floordiv(numerator_h, Integer(attrs->strides[0])) + 1);
-  out_NCHW_shape[3] = analyzer->Simplify(floordiv(numerator_w, Integer(attrs->strides[1])) + 1);
+  PrimExpr numerator_h = input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_h - 1) - 1;
+  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_w - 1) - 1;
+  out_NCHW_shape[2] = analyzer->Simplify(floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
+  out_NCHW_shape[3] = analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[1])) + 1);
 
   ffi::Array<PrimExpr> out_shape = out2NCHW.BackwardShape(out_NCHW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
@@ -512,21 +512,21 @@ StructInfo InferStructInfoConv3d(const Call& call, const BlockBuilder& ctx) {
   PrimExpr kernel_d = weight_OIDHW_shape[2];
   PrimExpr kernel_h = weight_OIDHW_shape[3];
   PrimExpr kernel_w = weight_OIDHW_shape[4];
-  PrimExpr padding_d = Integer(attrs->padding[0]) + Integer(attrs->padding[3]);
-  PrimExpr padding_h = Integer(attrs->padding[1]) + Integer(attrs->padding[4]);
-  PrimExpr padding_w = Integer(attrs->padding[2]) + Integer(attrs->padding[5]);
+  PrimExpr padding_d = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
+  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
 
   std::vector<PrimExpr> out_NCDHW_shape;
   out_NCDHW_shape.resize(5);
   out_NCDHW_shape[0] = data_NCDHW_shape[0];
   out_NCDHW_shape[1] = weight_OIDHW_shape[0];
 
-  PrimExpr numerator_d = input_d + padding_d - Integer(attrs->dilation[0]) * (kernel_d - 1) - 1;
-  PrimExpr numerator_h = input_h + padding_h - Integer(attrs->dilation[1]) * (kernel_h - 1) - 1;
-  PrimExpr numerator_w = input_w + padding_w - Integer(attrs->dilation[2]) * (kernel_w - 1) - 1;
-  out_NCDHW_shape[2] = analyzer->Simplify(floordiv(numerator_d, Integer(attrs->strides[0])) + 1);
-  out_NCDHW_shape[3] = analyzer->Simplify(floordiv(numerator_h, Integer(attrs->strides[1])) + 1);
-  out_NCDHW_shape[4] = analyzer->Simplify(floordiv(numerator_w, Integer(attrs->strides[2])) + 1);
+  PrimExpr numerator_d = input_d + padding_d - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_d - 1) - 1;
+  PrimExpr numerator_h = input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_h - 1) - 1;
+  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[2]) * (kernel_w - 1) - 1;
+  out_NCDHW_shape[2] = analyzer->Simplify(floordiv(numerator_d, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
+  out_NCDHW_shape[3] = analyzer->Simplify(floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[1])) + 1);
+  out_NCDHW_shape[4] = analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[2])) + 1);
 
   ffi::Array<PrimExpr> out_shape = out2NCDHW.BackwardShape(out_NCDHW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
@@ -701,16 +701,16 @@ StructInfo InferStructInfoConv1dTranspose(const Call& call, const BlockBuilder& 
 
   PrimExpr input_w = data_NCW_shape[2];
   PrimExpr kernel_w = weight_IOW_shape[2];
-  PrimExpr padding_w = Integer(attrs->padding[0]) + Integer(attrs->padding[1]);
+  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
 
   std::vector<PrimExpr> out_NCW_shape;
   out_NCW_shape.resize(3);
   out_NCW_shape[0] = data_NCW_shape[0];
   out_NCW_shape[1] = weight_IOW_shape[1] * attrs->groups;
 
-  PrimExpr out_w = (input_w - 1) * Integer(attrs->strides[0]) - padding_w +
-                   Integer(attrs->dilation[0]) * (kernel_w - 1) +
-                   Integer(attrs->output_padding[0]) + 1;
+  PrimExpr out_w = (input_w - 1) * IntImm(DataType::Int(32), attrs->strides[0]) - padding_w +
+                   IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_w - 1) +
+                   IntImm(DataType::Int(32), attrs->output_padding[0]) + 1;
   out_NCW_shape[2] = analyzer->Simplify(out_w);
 
   ffi::Array<PrimExpr> out_shape = out2NCW.BackwardShape(out_NCW_shape);
@@ -895,20 +895,20 @@ StructInfo InferStructInfoConv2dTranspose(const Call& call, const BlockBuilder& 
   PrimExpr input_w = data_NCHW_shape[3];
   PrimExpr kernel_h = weight_IOHW_shape[2];
   PrimExpr kernel_w = weight_IOHW_shape[3];
-  PrimExpr padding_h = Integer(attrs->padding[0]) + Integer(attrs->padding[2]);
-  PrimExpr padding_w = Integer(attrs->padding[1]) + Integer(attrs->padding[3]);
+  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
+  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
 
   std::vector<PrimExpr> out_NCHW_shape;
   out_NCHW_shape.resize(4);
   out_NCHW_shape[0] = data_NCHW_shape[0];
   out_NCHW_shape[1] = weight_IOHW_shape[1] * attrs->groups;
 
-  PrimExpr out_h = (input_h - 1) * Integer(attrs->strides[0]) - padding_h +
-                   Integer(attrs->dilation[0]) * (kernel_h - 1) +
-                   Integer(attrs->output_padding[0]) + 1;
-  PrimExpr out_w = (input_w - 1) * Integer(attrs->strides[1]) - padding_w +
-                   Integer(attrs->dilation[1]) * (kernel_w - 1) +
-                   Integer(attrs->output_padding[1]) + 1;
+  PrimExpr out_h = (input_h - 1) * IntImm(DataType::Int(32), attrs->strides[0]) - padding_h +
+                   IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_h - 1) +
+                   IntImm(DataType::Int(32), attrs->output_padding[0]) + 1;
+  PrimExpr out_w = (input_w - 1) * IntImm(DataType::Int(32), attrs->strides[1]) - padding_w +
+                   IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_w - 1) +
+                   IntImm(DataType::Int(32), attrs->output_padding[1]) + 1;
   out_NCHW_shape[2] = analyzer->Simplify(out_h);
   out_NCHW_shape[3] = analyzer->Simplify(out_w);
 
@@ -1132,24 +1132,24 @@ StructInfo InferStructInfoConv3dTranspose(const Call& call, const BlockBuilder& 
   PrimExpr kernel_d = weight_IODHW_shape[2];
   PrimExpr kernel_h = weight_IODHW_shape[3];
   PrimExpr kernel_w = weight_IODHW_shape[4];
-  PrimExpr padding_d = Integer(attrs->padding[0]) + Integer(attrs->padding[3]);
-  PrimExpr padding_h = Integer(attrs->padding[1]) + Integer(attrs->padding[4]);
-  PrimExpr padding_w = Integer(attrs->padding[2]) + Integer(attrs->padding[5]);
+  PrimExpr padding_d = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
+  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
 
   std::vector<PrimExpr> out_NCDHW_shape;
   out_NCDHW_shape.resize(5);
   out_NCDHW_shape[0] = data_NCDHW_shape[0];
   out_NCDHW_shape[1] = weight_IODHW_shape[1] * attrs->groups;
 
-  PrimExpr out_d = (input_d - 1) * Integer(attrs->strides[0]) - padding_d +
-                   Integer(attrs->dilation[0]) * (kernel_d - 1) +
-                   Integer(attrs->output_padding[0]) + 1;
-  PrimExpr out_h = (input_h - 1) * Integer(attrs->strides[1]) - padding_h +
-                   Integer(attrs->dilation[1]) * (kernel_h - 1) +
-                   Integer(attrs->output_padding[1]) + 1;
-  PrimExpr out_w = (input_w - 1) * Integer(attrs->strides[2]) - padding_w +
-                   Integer(attrs->dilation[2]) * (kernel_w - 1) +
-                   Integer(attrs->output_padding[2]) + 1;
+  PrimExpr out_d = (input_d - 1) * IntImm(DataType::Int(32), attrs->strides[0]) - padding_d +
+                   IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_d - 1) +
+                   IntImm(DataType::Int(32), attrs->output_padding[0]) + 1;
+  PrimExpr out_h = (input_h - 1) * IntImm(DataType::Int(32), attrs->strides[1]) - padding_h +
+                   IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_h - 1) +
+                   IntImm(DataType::Int(32), attrs->output_padding[1]) + 1;
+  PrimExpr out_w = (input_w - 1) * IntImm(DataType::Int(32), attrs->strides[2]) - padding_w +
+                   IntImm(DataType::Int(32), attrs->dilation[2]) * (kernel_w - 1) +
+                   IntImm(DataType::Int(32), attrs->output_padding[2]) + 1;
   out_NCDHW_shape[2] = analyzer->Simplify(out_d);
   out_NCDHW_shape[3] = analyzer->Simplify(out_h);
   out_NCDHW_shape[4] = analyzer->Simplify(out_w);

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -99,8 +99,8 @@ StructInfo InferStructInfoPool1D(const Call& call, const BlockBuilder& ctx) {
   ffi::Array<PrimExpr> data_NCW_shape = data2NCW.ForwardShape(data_shape.value()->values);
 
   PrimExpr input_w = data_NCW_shape[2];
-  PrimExpr kernel_w = Integer(attrs->pool_size[0]);
-  PrimExpr padding_w = Integer(attrs->padding[0]) + Integer(attrs->padding[1]);
+  PrimExpr kernel_w = IntImm(DataType::Int(32), attrs->pool_size[0]);
+  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
 
   arith::Analyzer* analyzer = ctx->GetAnalyzer();
   std::vector<PrimExpr> out_NCW_shape;
@@ -108,14 +108,14 @@ StructInfo InferStructInfoPool1D(const Call& call, const BlockBuilder& ctx) {
   out_NCW_shape[0] = data_NCW_shape[0];
   out_NCW_shape[1] = data_NCW_shape[1];
 
-  PrimExpr numerator_w = input_w + padding_w - Integer(attrs->dilation[0]) * (kernel_w - 1) - 1;
+  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_w - 1) - 1;
   if (attrs->ceil_mode) {
-    numerator_w += Integer(attrs->strides[0]) - 1;
+    numerator_w += IntImm(DataType::Int(32), attrs->strides[0]) - 1;
   }
-  PrimExpr raw_out_w = floordiv(numerator_w, Integer(attrs->strides[0])) + 1;
+  PrimExpr raw_out_w = floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[0])) + 1;
   if (attrs->ceil_mode) {
     PrimExpr invalid_last_w =
-        (raw_out_w - 1) * Integer(attrs->strides[0]) >= input_w + Integer(attrs->padding[0]);
+        (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >= input_w + IntImm(DataType::Int(32), attrs->padding[0]);
     out_NCW_shape[2] = analyzer->Simplify(if_then_else(invalid_last_w, raw_out_w - 1, raw_out_w));
   } else {
     out_NCW_shape[2] = analyzer->Simplify(raw_out_w);
@@ -223,10 +223,10 @@ StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
 
   PrimExpr input_h = data_NCHW_shape[2];
   PrimExpr input_w = data_NCHW_shape[3];
-  PrimExpr kernel_h = Integer(attrs->pool_size[0]);
-  PrimExpr kernel_w = Integer(attrs->pool_size[1]);
-  PrimExpr padding_h = Integer(attrs->padding[0]) + Integer(attrs->padding[2]);
-  PrimExpr padding_w = Integer(attrs->padding[1]) + Integer(attrs->padding[3]);
+  PrimExpr kernel_h = IntImm(DataType::Int(32), attrs->pool_size[0]);
+  PrimExpr kernel_w = IntImm(DataType::Int(32), attrs->pool_size[1]);
+  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
+  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
 
   arith::Analyzer* analyzer = ctx->GetAnalyzer();
   std::vector<PrimExpr> out_NCHW_shape;
@@ -234,19 +234,19 @@ StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
   out_NCHW_shape[0] = data_NCHW_shape[0];
   out_NCHW_shape[1] = data_NCHW_shape[1];
 
-  PrimExpr numerator_h = input_h + padding_h - Integer(attrs->dilation[0]) * (kernel_h - 1) - 1;
-  PrimExpr numerator_w = input_w + padding_w - Integer(attrs->dilation[1]) * (kernel_w - 1) - 1;
+  PrimExpr numerator_h = input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_h - 1) - 1;
+  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_w - 1) - 1;
   if (attrs->ceil_mode) {
-    numerator_h += Integer(attrs->strides[0]) - 1;
-    numerator_w += Integer(attrs->strides[1]) - 1;
+    numerator_h += IntImm(DataType::Int(32), attrs->strides[0]) - 1;
+    numerator_w += IntImm(DataType::Int(32), attrs->strides[1]) - 1;
   }
-  PrimExpr raw_out_h = floordiv(numerator_h, Integer(attrs->strides[0])) + 1;
-  PrimExpr raw_out_w = floordiv(numerator_w, Integer(attrs->strides[1])) + 1;
+  PrimExpr raw_out_h = floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[0])) + 1;
+  PrimExpr raw_out_w = floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[1])) + 1;
   if (attrs->ceil_mode) {
     PrimExpr invalid_last_h =
-        (raw_out_h - 1) * Integer(attrs->strides[0]) >= input_h + Integer(attrs->padding[0]);
+        (raw_out_h - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >= input_h + IntImm(DataType::Int(32), attrs->padding[0]);
     PrimExpr invalid_last_w =
-        (raw_out_w - 1) * Integer(attrs->strides[1]) >= input_w + Integer(attrs->padding[1]);
+        (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[1]) >= input_w + IntImm(DataType::Int(32), attrs->padding[1]);
     out_NCHW_shape[2] = analyzer->Simplify(if_then_else(invalid_last_h, raw_out_h - 1, raw_out_h));
     out_NCHW_shape[3] = analyzer->Simplify(if_then_else(invalid_last_w, raw_out_w - 1, raw_out_w));
   } else {
@@ -378,12 +378,12 @@ StructInfo InferStructInfoPool3D(const Call& call, const BlockBuilder& ctx) {
   PrimExpr input_d = data_NCDHW_shape[2];
   PrimExpr input_h = data_NCDHW_shape[3];
   PrimExpr input_w = data_NCDHW_shape[4];
-  PrimExpr kernel_d = Integer(attrs->pool_size[0]);
-  PrimExpr kernel_h = Integer(attrs->pool_size[1]);
-  PrimExpr kernel_w = Integer(attrs->pool_size[2]);
-  PrimExpr padding_d = Integer(attrs->padding[0]) + Integer(attrs->padding[3]);
-  PrimExpr padding_h = Integer(attrs->padding[1]) + Integer(attrs->padding[4]);
-  PrimExpr padding_w = Integer(attrs->padding[2]) + Integer(attrs->padding[5]);
+  PrimExpr kernel_d = IntImm(DataType::Int(32), attrs->pool_size[0]);
+  PrimExpr kernel_h = IntImm(DataType::Int(32), attrs->pool_size[1]);
+  PrimExpr kernel_w = IntImm(DataType::Int(32), attrs->pool_size[2]);
+  PrimExpr padding_d = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
+  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
 
   arith::Analyzer* analyzer = ctx->GetAnalyzer();
   std::vector<PrimExpr> out_NCDHW_shape;
@@ -391,24 +391,24 @@ StructInfo InferStructInfoPool3D(const Call& call, const BlockBuilder& ctx) {
   out_NCDHW_shape[0] = data_NCDHW_shape[0];
   out_NCDHW_shape[1] = data_NCDHW_shape[1];
 
-  PrimExpr numerator_d = input_d + padding_d - Integer(attrs->dilation[0]) * (kernel_d - 1) - 1;
-  PrimExpr numerator_h = input_h + padding_h - Integer(attrs->dilation[1]) * (kernel_h - 1) - 1;
-  PrimExpr numerator_w = input_w + padding_w - Integer(attrs->dilation[2]) * (kernel_w - 1) - 1;
+  PrimExpr numerator_d = input_d + padding_d - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_d - 1) - 1;
+  PrimExpr numerator_h = input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_h - 1) - 1;
+  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[2]) * (kernel_w - 1) - 1;
   if (attrs->ceil_mode) {
-    numerator_d += Integer(attrs->strides[0]) - 1;
-    numerator_h += Integer(attrs->strides[1]) - 1;
-    numerator_w += Integer(attrs->strides[2]) - 1;
+    numerator_d += IntImm(DataType::Int(32), attrs->strides[0]) - 1;
+    numerator_h += IntImm(DataType::Int(32), attrs->strides[1]) - 1;
+    numerator_w += IntImm(DataType::Int(32), attrs->strides[2]) - 1;
   }
-  PrimExpr raw_out_d = floordiv(numerator_d, Integer(attrs->strides[0])) + 1;
-  PrimExpr raw_out_h = floordiv(numerator_h, Integer(attrs->strides[1])) + 1;
-  PrimExpr raw_out_w = floordiv(numerator_w, Integer(attrs->strides[2])) + 1;
+  PrimExpr raw_out_d = floordiv(numerator_d, IntImm(DataType::Int(32), attrs->strides[0])) + 1;
+  PrimExpr raw_out_h = floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[1])) + 1;
+  PrimExpr raw_out_w = floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[2])) + 1;
   if (attrs->ceil_mode) {
     PrimExpr invalid_last_d =
-        (raw_out_d - 1) * Integer(attrs->strides[0]) >= input_d + Integer(attrs->padding[0]);
+        (raw_out_d - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >= input_d + IntImm(DataType::Int(32), attrs->padding[0]);
     PrimExpr invalid_last_h =
-        (raw_out_h - 1) * Integer(attrs->strides[1]) >= input_h + Integer(attrs->padding[1]);
+        (raw_out_h - 1) * IntImm(DataType::Int(32), attrs->strides[1]) >= input_h + IntImm(DataType::Int(32), attrs->padding[1]);
     PrimExpr invalid_last_w =
-        (raw_out_w - 1) * Integer(attrs->strides[2]) >= input_w + Integer(attrs->padding[2]);
+        (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[2]) >= input_w + IntImm(DataType::Int(32), attrs->padding[2]);
     out_NCDHW_shape[2] = analyzer->Simplify(if_then_else(invalid_last_d, raw_out_d - 1, raw_out_d));
     out_NCDHW_shape[3] = analyzer->Simplify(if_then_else(invalid_last_h, raw_out_h - 1, raw_out_h));
     out_NCDHW_shape[4] = analyzer->Simplify(if_then_else(invalid_last_w, raw_out_w - 1, raw_out_w));
@@ -563,7 +563,7 @@ StructInfo InferStructInfoAdaptiveAvgPool1D(const Call& call, const BlockBuilder
   ffi::Array<PrimExpr> data_NCW_shape = data2NCW.ForwardShape(data_shape.value()->values);
   ffi::Array<PrimExpr> out_NCW_shape(data_NCW_shape);
   if (attrs->output_size.defined()) {
-    out_NCW_shape.Set(2, Integer(attrs->output_size.value()[0]));
+    out_NCW_shape.Set(2, IntImm(DataType::Int(32), attrs->output_size.value()[0]));
   }
 
   ffi::Array<PrimExpr> out_shape = out2NCW.BackwardShape(out_NCW_shape);
@@ -648,8 +648,8 @@ StructInfo InferStructInfoAdaptiveAvgPool2D(const Call& call, const BlockBuilder
   ffi::Array<PrimExpr> data_NCHW_shape = data2NCHW.ForwardShape(data_shape.value()->values);
   ffi::Array<PrimExpr> out_NCHW_shape(data_NCHW_shape);
   if (attrs->output_size.defined()) {
-    out_NCHW_shape.Set(2, Integer(attrs->output_size.value()[0]));
-    out_NCHW_shape.Set(3, Integer(attrs->output_size.value()[1]));
+    out_NCHW_shape.Set(2, IntImm(DataType::Int(32), attrs->output_size.value()[0]));
+    out_NCHW_shape.Set(3, IntImm(DataType::Int(32), attrs->output_size.value()[1]));
   }
 
   ffi::Array<PrimExpr> out_shape = out2NCHW.BackwardShape(out_NCHW_shape);
@@ -750,9 +750,9 @@ StructInfo InferStructInfoAdaptiveAvgPool3D(const Call& call, const BlockBuilder
   ffi::Array<PrimExpr> data_NCDHW_shape = data2NCDHW.ForwardShape(data_shape.value()->values);
   ffi::Array<PrimExpr> out_NCDHW_shape(data_NCDHW_shape);
   if (attrs->output_size.defined()) {
-    out_NCDHW_shape.Set(2, Integer(attrs->output_size.value()[0]));
-    out_NCDHW_shape.Set(3, Integer(attrs->output_size.value()[1]));
-    out_NCDHW_shape.Set(4, Integer(attrs->output_size.value()[2]));
+    out_NCDHW_shape.Set(2, IntImm(DataType::Int(32), attrs->output_size.value()[0]));
+    out_NCDHW_shape.Set(3, IntImm(DataType::Int(32), attrs->output_size.value()[1]));
+    out_NCDHW_shape.Set(4, IntImm(DataType::Int(32), attrs->output_size.value()[2]));
   }
 
   ffi::Array<PrimExpr> out_shape = out2NCDHW.BackwardShape(out_NCDHW_shape);

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -100,7 +100,8 @@ StructInfo InferStructInfoPool1D(const Call& call, const BlockBuilder& ctx) {
 
   PrimExpr input_w = data_NCW_shape[2];
   PrimExpr kernel_w = IntImm(DataType::Int(32), attrs->pool_size[0]);
-  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
+  PrimExpr padding_w =
+      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
 
   arith::Analyzer* analyzer = ctx->GetAnalyzer();
   std::vector<PrimExpr> out_NCW_shape;
@@ -108,14 +109,15 @@ StructInfo InferStructInfoPool1D(const Call& call, const BlockBuilder& ctx) {
   out_NCW_shape[0] = data_NCW_shape[0];
   out_NCW_shape[1] = data_NCW_shape[1];
 
-  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_w - 1) - 1;
+  PrimExpr numerator_w =
+      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_w - 1) - 1;
   if (attrs->ceil_mode) {
     numerator_w += IntImm(DataType::Int(32), attrs->strides[0]) - 1;
   }
   PrimExpr raw_out_w = floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[0])) + 1;
   if (attrs->ceil_mode) {
-    PrimExpr invalid_last_w =
-        (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >= input_w + IntImm(DataType::Int(32), attrs->padding[0]);
+    PrimExpr invalid_last_w = (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >=
+                              input_w + IntImm(DataType::Int(32), attrs->padding[0]);
     out_NCW_shape[2] = analyzer->Simplify(if_then_else(invalid_last_w, raw_out_w - 1, raw_out_w));
   } else {
     out_NCW_shape[2] = analyzer->Simplify(raw_out_w);
@@ -225,8 +227,10 @@ StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
   PrimExpr input_w = data_NCHW_shape[3];
   PrimExpr kernel_h = IntImm(DataType::Int(32), attrs->pool_size[0]);
   PrimExpr kernel_w = IntImm(DataType::Int(32), attrs->pool_size[1]);
-  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
-  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h =
+      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
+  PrimExpr padding_w =
+      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
 
   arith::Analyzer* analyzer = ctx->GetAnalyzer();
   std::vector<PrimExpr> out_NCHW_shape;
@@ -234,8 +238,10 @@ StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
   out_NCHW_shape[0] = data_NCHW_shape[0];
   out_NCHW_shape[1] = data_NCHW_shape[1];
 
-  PrimExpr numerator_h = input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_h - 1) - 1;
-  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_w - 1) - 1;
+  PrimExpr numerator_h =
+      input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_h - 1) - 1;
+  PrimExpr numerator_w =
+      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_w - 1) - 1;
   if (attrs->ceil_mode) {
     numerator_h += IntImm(DataType::Int(32), attrs->strides[0]) - 1;
     numerator_w += IntImm(DataType::Int(32), attrs->strides[1]) - 1;
@@ -243,10 +249,10 @@ StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
   PrimExpr raw_out_h = floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[0])) + 1;
   PrimExpr raw_out_w = floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[1])) + 1;
   if (attrs->ceil_mode) {
-    PrimExpr invalid_last_h =
-        (raw_out_h - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >= input_h + IntImm(DataType::Int(32), attrs->padding[0]);
-    PrimExpr invalid_last_w =
-        (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[1]) >= input_w + IntImm(DataType::Int(32), attrs->padding[1]);
+    PrimExpr invalid_last_h = (raw_out_h - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >=
+                              input_h + IntImm(DataType::Int(32), attrs->padding[0]);
+    PrimExpr invalid_last_w = (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[1]) >=
+                              input_w + IntImm(DataType::Int(32), attrs->padding[1]);
     out_NCHW_shape[2] = analyzer->Simplify(if_then_else(invalid_last_h, raw_out_h - 1, raw_out_h));
     out_NCHW_shape[3] = analyzer->Simplify(if_then_else(invalid_last_w, raw_out_w - 1, raw_out_w));
   } else {
@@ -381,9 +387,12 @@ StructInfo InferStructInfoPool3D(const Call& call, const BlockBuilder& ctx) {
   PrimExpr kernel_d = IntImm(DataType::Int(32), attrs->pool_size[0]);
   PrimExpr kernel_h = IntImm(DataType::Int(32), attrs->pool_size[1]);
   PrimExpr kernel_w = IntImm(DataType::Int(32), attrs->pool_size[2]);
-  PrimExpr padding_d = IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
-  PrimExpr padding_h = IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
-  PrimExpr padding_w = IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
+  PrimExpr padding_d =
+      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h =
+      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
+  PrimExpr padding_w =
+      IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
 
   arith::Analyzer* analyzer = ctx->GetAnalyzer();
   std::vector<PrimExpr> out_NCDHW_shape;
@@ -391,9 +400,12 @@ StructInfo InferStructInfoPool3D(const Call& call, const BlockBuilder& ctx) {
   out_NCDHW_shape[0] = data_NCDHW_shape[0];
   out_NCDHW_shape[1] = data_NCDHW_shape[1];
 
-  PrimExpr numerator_d = input_d + padding_d - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_d - 1) - 1;
-  PrimExpr numerator_h = input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_h - 1) - 1;
-  PrimExpr numerator_w = input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[2]) * (kernel_w - 1) - 1;
+  PrimExpr numerator_d =
+      input_d + padding_d - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_d - 1) - 1;
+  PrimExpr numerator_h =
+      input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_h - 1) - 1;
+  PrimExpr numerator_w =
+      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[2]) * (kernel_w - 1) - 1;
   if (attrs->ceil_mode) {
     numerator_d += IntImm(DataType::Int(32), attrs->strides[0]) - 1;
     numerator_h += IntImm(DataType::Int(32), attrs->strides[1]) - 1;
@@ -403,12 +415,12 @@ StructInfo InferStructInfoPool3D(const Call& call, const BlockBuilder& ctx) {
   PrimExpr raw_out_h = floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[1])) + 1;
   PrimExpr raw_out_w = floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[2])) + 1;
   if (attrs->ceil_mode) {
-    PrimExpr invalid_last_d =
-        (raw_out_d - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >= input_d + IntImm(DataType::Int(32), attrs->padding[0]);
-    PrimExpr invalid_last_h =
-        (raw_out_h - 1) * IntImm(DataType::Int(32), attrs->strides[1]) >= input_h + IntImm(DataType::Int(32), attrs->padding[1]);
-    PrimExpr invalid_last_w =
-        (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[2]) >= input_w + IntImm(DataType::Int(32), attrs->padding[2]);
+    PrimExpr invalid_last_d = (raw_out_d - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >=
+                              input_d + IntImm(DataType::Int(32), attrs->padding[0]);
+    PrimExpr invalid_last_h = (raw_out_h - 1) * IntImm(DataType::Int(32), attrs->strides[1]) >=
+                              input_h + IntImm(DataType::Int(32), attrs->padding[1]);
+    PrimExpr invalid_last_w = (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[2]) >=
+                              input_w + IntImm(DataType::Int(32), attrs->padding[2]);
     out_NCDHW_shape[2] = analyzer->Simplify(if_then_else(invalid_last_d, raw_out_d - 1, raw_out_d));
     out_NCDHW_shape[3] = analyzer->Simplify(if_then_else(invalid_last_h, raw_out_h - 1, raw_out_h));
     out_NCDHW_shape[4] = analyzer->Simplify(if_then_else(invalid_last_w, raw_out_w - 1, raw_out_w));

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -474,7 +474,7 @@ InferLayoutOutput InferLayoutStridedSlice(
   }
 
   return InferLayoutOutput({existing_layout}, {existing_layout}, call->attrs,
-                           {{1, relax::Tuple(new_axes)}});
+                           {{IntImm(DataType::Int(32), 1), relax::Tuple(new_axes)}});
 }
 
 TVM_REGISTER_OP("relax.strided_slice")

--- a/src/relax/op/vision/multibox_transform_loc.cc
+++ b/src/relax/op/vision/multibox_transform_loc.cc
@@ -179,7 +179,7 @@ StructInfo InferStructInfoMultiboxTransformLoc(const Call& call, const BlockBuil
     }
   }
 
-  ffi::Array<PrimExpr> boxes_shape = {batch, num_anchors, Integer(4)};
+  ffi::Array<PrimExpr> boxes_shape = {batch, num_anchors, IntImm(DataType::Int(32), 4)};
   ffi::Array<PrimExpr> scores_shape = {batch, num_classes, num_anchors};
   ffi::Array<StructInfo> fields = {
       TensorStructInfo(ShapeExpr(boxes_shape), cls_sinfo->dtype, vdev),

--- a/src/relax/op/vision/roi_align.cc
+++ b/src/relax/op/vision/roi_align.cc
@@ -118,7 +118,8 @@ StructInfo InferStructInfoROIAlign(const Call& call, const BlockBuilder& ctx) {
   ffi::Array<PrimExpr> data_shape = data_sinfo->shape.as<ShapeExprNode>()->values;
   ffi::Array<PrimExpr> out_shape;
   if (attrs->layout == "NCHW") {
-    out_shape = {rois_shape->values[0], data_shape[1], IntImm(DataType::Int(32), attrs->pooled_size[0]),
+    out_shape = {rois_shape->values[0], data_shape[1],
+                 IntImm(DataType::Int(32), attrs->pooled_size[0]),
                  IntImm(DataType::Int(32), attrs->pooled_size[1])};
   } else {
     out_shape = {rois_shape->values[0], IntImm(DataType::Int(32), attrs->pooled_size[0]),

--- a/src/relax/op/vision/roi_align.cc
+++ b/src/relax/op/vision/roi_align.cc
@@ -118,11 +118,11 @@ StructInfo InferStructInfoROIAlign(const Call& call, const BlockBuilder& ctx) {
   ffi::Array<PrimExpr> data_shape = data_sinfo->shape.as<ShapeExprNode>()->values;
   ffi::Array<PrimExpr> out_shape;
   if (attrs->layout == "NCHW") {
-    out_shape = {rois_shape->values[0], data_shape[1], Integer(attrs->pooled_size[0]),
-                 Integer(attrs->pooled_size[1])};
+    out_shape = {rois_shape->values[0], data_shape[1], IntImm(DataType::Int(32), attrs->pooled_size[0]),
+                 IntImm(DataType::Int(32), attrs->pooled_size[1])};
   } else {
-    out_shape = {rois_shape->values[0], Integer(attrs->pooled_size[0]),
-                 Integer(attrs->pooled_size[1]), data_shape[3]};
+    out_shape = {rois_shape->values[0], IntImm(DataType::Int(32), attrs->pooled_size[0]),
+                 IntImm(DataType::Int(32), attrs->pooled_size[1]), data_shape[3]};
   }
   return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice);
 }

--- a/src/relax/op/vision/roi_pool.cc
+++ b/src/relax/op/vision/roi_pool.cc
@@ -110,7 +110,8 @@ StructInfo InferStructInfoROIPool(const Call& call, const BlockBuilder& ctx) {
 
   ffi::Array<PrimExpr> data_shape = data_sinfo->shape.as<ShapeExprNode>()->values;
   ffi::Array<PrimExpr> out_shape = {rois_shape->values[0], data_shape[1],
-                                    IntImm(DataType::Int(32), attrs->pooled_size[0]), IntImm(DataType::Int(32), attrs->pooled_size[1])};
+                                    IntImm(DataType::Int(32), attrs->pooled_size[0]),
+                                    IntImm(DataType::Int(32), attrs->pooled_size[1])};
   return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice);
 }
 

--- a/src/relax/op/vision/roi_pool.cc
+++ b/src/relax/op/vision/roi_pool.cc
@@ -110,7 +110,7 @@ StructInfo InferStructInfoROIPool(const Call& call, const BlockBuilder& ctx) {
 
   ffi::Array<PrimExpr> data_shape = data_sinfo->shape.as<ShapeExprNode>()->values;
   ffi::Array<PrimExpr> out_shape = {rois_shape->values[0], data_shape[1],
-                                    Integer(attrs->pooled_size[0]), Integer(attrs->pooled_size[1])};
+                                    IntImm(DataType::Int(32), attrs->pooled_size[0]), IntImm(DataType::Int(32), attrs->pooled_size[1])};
   return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice);
 }
 

--- a/src/relax/transform/adjust_matmul_order.cc
+++ b/src/relax/transform/adjust_matmul_order.cc
@@ -35,6 +35,7 @@
 
 #include "../op/tensor/linear_algebra.h"
 #include "../op/tensor/manipulate.h"
+#include <tvm/tirx/op.h>
 
 namespace tvm {
 namespace relax {
@@ -72,7 +73,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
   auto pat = pat_matmul_on_lhs | pat_matmul_on_rhs | pat_permuted_matmul_on_lhs |
              pat_permuted_matmul_on_rhs;
 
-  PrimExpr symbolic_var_constraints = Bool(true);
+  PrimExpr symbolic_var_constraints = IntImm(DataType::Bool(), 1);
   auto upper_bounds = func->GetAttr<ffi::Map<ffi::String, Any>>("tir_var_upper_bound");
   auto lower_bounds = func->GetAttr<ffi::Map<ffi::String, Any>>("tir_var_lower_bound");
 

--- a/src/relax/transform/adjust_matmul_order.cc
+++ b/src/relax/transform/adjust_matmul_order.cc
@@ -28,6 +28,7 @@
 #include <tvm/relax/expr.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/transform.h>
+#include <tvm/tirx/op.h>
 
 #include <optional>
 #include <unordered_set>
@@ -35,7 +36,6 @@
 
 #include "../op/tensor/linear_algebra.h"
 #include "../op/tensor/manipulate.h"
-#include <tvm/tirx/op.h>
 
 namespace tvm {
 namespace relax {
@@ -73,7 +73,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
   auto pat = pat_matmul_on_lhs | pat_matmul_on_rhs | pat_permuted_matmul_on_lhs |
              pat_permuted_matmul_on_rhs;
 
-  PrimExpr symbolic_var_constraints = IntImm(DataType::Bool(), 1);
+  PrimExpr symbolic_var_constraints = tirx::const_true();
   auto upper_bounds = func->GetAttr<ffi::Map<ffi::String, Any>>("tir_var_upper_bound");
   auto lower_bounds = func->GetAttr<ffi::Map<ffi::String, Any>>("tir_var_lower_bound");
 

--- a/src/relax/transform/allocate_workspace.cc
+++ b/src/relax/transform/allocate_workspace.cc
@@ -61,7 +61,8 @@ class ExternFunctionRewriter : ExprMutator {
       // Append the workspace parameter to this function.
       ffi::Array<Var> new_params = func_node->params;
 
-      auto sinfo = TensorStructInfo(ShapeExpr({IntImm(DataType::Int(32), max_workspace_size_)}), DataType::UInt(8));
+      auto sinfo = TensorStructInfo(ShapeExpr({IntImm(DataType::Int(32), max_workspace_size_)}),
+                                    DataType::UInt(8));
       Var workspace_param(name_sup_->FreshName("workspace"), sinfo);
 
       if (func_node->GetAttr<ffi::String>(attr::kCodegen)) {

--- a/src/relax/transform/allocate_workspace.cc
+++ b/src/relax/transform/allocate_workspace.cc
@@ -61,7 +61,7 @@ class ExternFunctionRewriter : ExprMutator {
       // Append the workspace parameter to this function.
       ffi::Array<Var> new_params = func_node->params;
 
-      auto sinfo = TensorStructInfo(ShapeExpr({Integer(max_workspace_size_)}), DataType::UInt(8));
+      auto sinfo = TensorStructInfo(ShapeExpr({IntImm(DataType::Int(32), max_workspace_size_)}), DataType::UInt(8));
       Var workspace_param(name_sup_->FreshName("workspace"), sinfo);
 
       if (func_node->GetAttr<ffi::String>(attr::kCodegen)) {
@@ -148,7 +148,7 @@ class WorkspaceProvider : ExprMutator {
   BindingBlock VisitBindingBlock_(const DataflowBlockNode* block_node) final {
     builder_->BeginDataflowBlock();
     if (!workspace_var_main_.defined()) {
-      auto shape = ShapeExpr({Integer(max_workspace_size_)});
+      auto shape = ShapeExpr({IntImm(DataType::Int(32), max_workspace_size_)});
       auto ty = DataTypeImm(DataType::UInt(8));
       auto workspace = MakeAllocTensor(shape, ty, PrimValue::Int64(0));
       workspace_var_main_ = builder_->Emit(workspace, "workspace_main");

--- a/src/relax/transform/dataflow_inplace.cc
+++ b/src/relax/transform/dataflow_inplace.cc
@@ -981,7 +981,7 @@ ffi::Array<ffi::ObjectRef> DataflowAliasAnalysis(const DataflowBlock& block,
   auto alias_sets = res.first;
   auto tuple_map = res.second;
   ffi::Map<Var, ffi::Array<int64_t>> new_alias_sets;
-  ffi::Map<Integer, ffi::Array<ffi::Array<int64_t>>> new_tuple_map;
+  ffi::Map<IntImm, ffi::Array<ffi::Array<int64_t>>> new_tuple_map;
   for (auto kv : alias_sets) {
     ffi::Array<int64_t> aliases;
     for (auto alias : kv.second) {
@@ -998,7 +998,7 @@ ffi::Array<ffi::ObjectRef> DataflowAliasAnalysis(const DataflowBlock& block,
       }
       elem_aliases.push_back(dim_aliases);
     }
-    new_tuple_map.Set(kv.first, elem_aliases);
+    new_tuple_map.Set(IntImm(DataType::Int(32), kv.first), elem_aliases);
   }
   return {new_alias_sets, new_tuple_map};
 }

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -24,8 +24,8 @@
 #include <tvm/relax/struct_info.h>
 #include <tvm/relax/transform.h>
 #include <tvm/s_tir/transform.h>
-#include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt_functor.h>
 
 #include <unordered_map>
 #include <unordered_set>
@@ -155,7 +155,7 @@ class SymbolicMatcher : ExprFunctor<void(const PrimExpr& n, const PrimExpr& othe
 
   arith::Analyzer* analyzer_;
   ffi::Map<tirx::Var, PrimExpr>* var_remap_;
-  PrimExpr must_prove_ = IntImm(DataType::Bool(), 1);
+  PrimExpr must_prove_ = const_true();
 };
 
 /*!

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -25,6 +25,7 @@
 #include <tvm/relax/transform.h>
 #include <tvm/s_tir/transform.h>
 #include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/op.h>
 
 #include <unordered_map>
 #include <unordered_set>
@@ -154,7 +155,7 @@ class SymbolicMatcher : ExprFunctor<void(const PrimExpr& n, const PrimExpr& othe
 
   arith::Analyzer* analyzer_;
   ffi::Map<tirx::Var, PrimExpr>* var_remap_;
-  PrimExpr must_prove_ = Bool(true);
+  PrimExpr must_prove_ = IntImm(DataType::Bool(), 1);
 };
 
 /*!
@@ -1020,7 +1021,7 @@ class FusedTIRConstructor : public ExprVisitor {
 
     body = subst.Substitute(body);
     body = tirx::SBlock({}, {}, {}, "root", std::move(body), std::nullopt, alloc_buffers);
-    body = tirx::SBlockRealize({}, Bool(true), Downcast<tirx::SBlock>(body));
+    body = tirx::SBlockRealize({}, IntImm(DataType::Bool(), 1), Downcast<tirx::SBlock>(body));
     tirx::PrimFunc func(func_info_.params, body, VoidType(), func_info_.buffer_map,
                         DictAttrs(attr_map));
     // Renew function defs to prevent using the same symbolic vars in different functions

--- a/src/relax/transform/infer_amp_utils.cc
+++ b/src/relax/transform/infer_amp_utils.cc
@@ -54,11 +54,11 @@ NType NTypeMerge(const NType& a, const NType& b) {
 }
 
 ffi::Array<ffi::ObjectRef> InferMixedPrecisionFollow(const Call& call, const DataType& out_dtype) {
-  return {Integer(MixedPrecisionPolicyKind::kFollow), call};
+  return {IntImm(DataType::Int(32), MixedPrecisionPolicyKind::kFollow), call};
 }
 
 ffi::Array<ffi::ObjectRef> InferMixedPrecisionNever(const Call& call, const DataType& out_dtype) {
-  return {Integer(MixedPrecisionPolicyKind::kNever), call};
+  return {IntImm(DataType::Int(32), MixedPrecisionPolicyKind::kNever), call};
 }
 
 }  // namespace relax

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -106,7 +106,7 @@ class InferLayoutOutputNode : public ffi::Object {
   ffi::Array<NLayout> input_layouts;
   ffi::Array<NLayout> output_layouts;
   Attrs new_attrs;
-  ffi::Map<Integer, Expr> new_args;
+  ffi::Map<IntImm, Expr> new_args;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -124,7 +124,7 @@ class InferLayoutOutputNode : public ffi::Object {
 class InferLayoutOutput : public ffi::ObjectRef {
  public:
   explicit InferLayoutOutput(ffi::Array<NLayout> input_layouts, ffi::Array<NLayout> output_layouts,
-                             Attrs new_attrs, ffi::Map<Integer, Expr> new_args = {}) {
+                             Attrs new_attrs, ffi::Map<IntImm, Expr> new_args = {}) {
     auto n = ffi::make_object<InferLayoutOutputNode>();
     n->input_layouts = std::move(input_layouts);
     n->output_layouts = std::move(output_layouts);

--- a/src/relax/transform/reorder_permute_dims_after_concat.cc
+++ b/src/relax/transform/reorder_permute_dims_after_concat.cc
@@ -163,9 +163,9 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
     TVM_FFI_ICHECK_LT(old_concat_axis, ndim)
         << "concat axis " << old_concat_axis << " out of range for " << ndim << "-D input";
 
-    Integer new_concat_axis = permute_dims_axes[static_cast<size_t>(old_concat_axis)];
+    int64_t new_concat_axis = permute_dims_axes[static_cast<size_t>(old_concat_axis)];
 
-    auto new_concat = concat(Tuple(args), new_concat_axis->value);
+    auto new_concat = concat(Tuple(args), new_concat_axis);
     auto new_permute_dims = permute_dims(new_concat, permute_axes);
 
     return new_permute_dims;

--- a/src/relax/transform/split_call_tir_by_pattern.cc
+++ b/src/relax/transform/split_call_tir_by_pattern.cc
@@ -581,7 +581,7 @@ std::pair<PrimFunc, ffi::Optional<PrimFunc>> SplitFunctions(
   ffi::Array<ffi::Any> codegen_result = f_codegen(match_results);
   TVM_FFI_ICHECK(codegen_result.size() == 3);
   ffi::String library_code = Downcast<ffi::String>(codegen_result[0]);
-  int num_matched_ops = Downcast<Integer>(codegen_result[1])->value;
+  int num_matched_ops = Downcast<IntImm>(codegen_result[1])->value;
   ffi::Array<Buffer> func1_args = Downcast<ffi::Array<Buffer>>(codegen_result[2]);
   if (num_matched_ops == 0) {
     return {func, std::nullopt};

--- a/src/s_tir/analysis/identify_memcpy.cc
+++ b/src/s_tir/analysis/identify_memcpy.cc
@@ -29,6 +29,7 @@
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/tirx/analysis.h>
 #include <tvm/tirx/buffer.h>
+#include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt.h>
 
 #include <optional>
@@ -105,7 +106,7 @@ std::variant<MemCpyDetails, std::string> IdentifyMemCpyImpl(const For& loop,
   // for i in T.serial(16):
   //     B[i] = A[T.abs(i-8)]
 
-  auto src_iter_map = arith::DetectIterMap({src_index}, loop_ranges, Bool(true),
+  auto src_iter_map = arith::DetectIterMap({src_index}, loop_ranges, const_true(),
                                            arith::IterMapLevel::Bijective, analyzer);
   if (src_iter_map->errors.size()) {
     return static_cast<const std::stringstream&>(std::stringstream()
@@ -115,7 +116,7 @@ std::variant<MemCpyDetails, std::string> IdentifyMemCpyImpl(const For& loop,
                                                  << " for src_index = " << src_index)
         .str();
   }
-  auto dst_iter_map = arith::DetectIterMap({dst_index}, loop_ranges, Bool(true),
+  auto dst_iter_map = arith::DetectIterMap({dst_index}, loop_ranges, const_true(),
                                            arith::IterMapLevel::Bijective, analyzer);
   if (dst_iter_map->errors.size()) {
     return static_cast<const std::stringstream&>(std::stringstream()

--- a/src/s_tir/meta_schedule/arg_info.cc
+++ b/src/s_tir/meta_schedule/arg_info.cc
@@ -149,8 +149,7 @@ TensorInfo TensorInfo::FromJSON(const ffi::ObjectRef& json_obj) {
                               << "\nThe error is: " << e.what();
   }
   std::vector<int64_t> s;
-  std::transform(shape.begin(), shape.end(), std::back_inserter(s),
-                 [](int64_t i) { return i; });
+  std::transform(shape.begin(), shape.end(), std::back_inserter(s), [](int64_t i) { return i; });
   return TensorInfo(DataType(dtype), ffi::Shape(s.begin(), s.end()));
 }
 

--- a/src/s_tir/meta_schedule/arg_info.cc
+++ b/src/s_tir/meta_schedule/arg_info.cc
@@ -150,7 +150,7 @@ TensorInfo TensorInfo::FromJSON(const ffi::ObjectRef& json_obj) {
   }
   std::vector<int64_t> s;
   std::transform(shape.begin(), shape.end(), std::back_inserter(s),
-                 [](Integer i) { return i.IntValue(); });
+                 [](int64_t i) { return i; });
   return TensorInfo(DataType(dtype), ffi::Shape(s.begin(), s.end()));
 }
 

--- a/src/s_tir/meta_schedule/database/json_database.cc
+++ b/src/s_tir/meta_schedule/database/json_database.cc
@@ -116,7 +116,7 @@ class JSONDatabaseNode : public DatabaseNode {
     this->tuning_records_.insert(record);
     JSONFileAppendLine(this->path_tuning_record,
                        JSONDumps(ffi::Array<Any>{
-                           /*workload_index=*/Integer(this->workloads2idx_.at(record->workload)),
+                           /*workload_index=*/IntImm(DataType::Int(32), this->workloads2idx_.at(record->workload)),
                            /*tuning_record=*/record->AsJSON()  //
                        }));
   }

--- a/src/s_tir/meta_schedule/database/json_database.cc
+++ b/src/s_tir/meta_schedule/database/json_database.cc
@@ -114,11 +114,12 @@ class JSONDatabaseNode : public DatabaseNode {
 
   void CommitTuningRecord(const TuningRecord& record) {
     this->tuning_records_.insert(record);
-    JSONFileAppendLine(this->path_tuning_record,
-                       JSONDumps(ffi::Array<Any>{
-                           /*workload_index=*/IntImm(DataType::Int(32), this->workloads2idx_.at(record->workload)),
-                           /*tuning_record=*/record->AsJSON()  //
-                       }));
+    JSONFileAppendLine(
+        this->path_tuning_record,
+        JSONDumps(ffi::Array<Any>{
+            /*workload_index=*/IntImm(DataType::Int(32), this->workloads2idx_.at(record->workload)),
+            /*tuning_record=*/record->AsJSON()  //
+        }));
   }
 
   ffi::Array<TuningRecord> GetTopK(const Workload& workload, int top_k) {

--- a/src/s_tir/meta_schedule/mutator/mutate_parallel.cc
+++ b/src/s_tir/meta_schedule/mutator/mutate_parallel.cc
@@ -54,7 +54,7 @@ bool IsAnnotateWithParallel(const Instruction& inst) {
 Instruction ReplaceAnnValue(Instruction inst, int64_t ann_val) {
   TVM_FFI_ICHECK_EQ(inst->inputs.size(), 2);
   return Instruction(/*kind=*/inst->kind,                             //
-                     /*inputs=*/{inst->inputs[0], Integer(ann_val)},  //
+                     /*inputs=*/{inst->inputs[0], IntImm(DataType::Int(32), ann_val)},  //
                      /*attrs=*/inst->attrs,
                      /*outputs=*/inst->outputs);
 }

--- a/src/s_tir/meta_schedule/mutator/mutate_parallel.cc
+++ b/src/s_tir/meta_schedule/mutator/mutate_parallel.cc
@@ -53,7 +53,7 @@ bool IsAnnotateWithParallel(const Instruction& inst) {
  */
 Instruction ReplaceAnnValue(Instruction inst, int64_t ann_val) {
   TVM_FFI_ICHECK_EQ(inst->inputs.size(), 2);
-  return Instruction(/*kind=*/inst->kind,                             //
+  return Instruction(/*kind=*/inst->kind,                                               //
                      /*inputs=*/{inst->inputs[0], IntImm(DataType::Int(32), ann_val)},  //
                      /*attrs=*/inst->attrs,
                      /*outputs=*/inst->outputs);

--- a/src/s_tir/meta_schedule/mutator/mutate_tile_size.cc
+++ b/src/s_tir/meta_schedule/mutator/mutate_tile_size.cc
@@ -214,7 +214,7 @@ ffi::Optional<Trace> MutateSampleTileSize(const Trace& trace, Instruction inst,
     if (y != n_splits - 1) {
       divide_factor = factors[s_tir::SampleInt(rand_state, 1, factors.size())];
     } else {
-      int64_t limit = Downcast<Integer>(inst->attrs[1])->value;
+      int64_t limit = Downcast<IntImm>(inst->attrs[1])->value;
       int max_factor_index = static_cast<int>(factors.size()) - 1;
       for (; max_factor_index >= 1; max_factor_index--) {
         if (factors[max_factor_index] * tiles[y] <= limit) {

--- a/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
@@ -199,29 +199,29 @@ bool RewriteCooperativeFetchNode::Apply(const s_tir::Schedule& sch) {
       if (thread_extent_y != -1) {
         if (vector_lane > 1) {
           ffi::Array<s_tir::LoopRV> split = sch->Split(fused, {std::nullopt,              //
-                                                               Integer(thread_extent_y),  //
-                                                               Integer(thread_extent_x),  //
-                                                               Integer(vector_lane)});
+                                                               IntImm(DataType::Int(32), thread_extent_y),  //
+                                                               IntImm(DataType::Int(32), thread_extent_x),  //
+                                                               IntImm(DataType::Int(32), vector_lane)});
           sch->Vectorize(split[3]);
           sch->Bind(split[2], "threadIdx.x");
           sch->Bind(split[1], "threadIdx.y");
         } else {
           ffi::Array<s_tir::LoopRV> split = sch->Split(fused, {std::nullopt,              //
-                                                               Integer(thread_extent_y),  //
-                                                               Integer(thread_extent_x)});
+                                                               IntImm(DataType::Int(32), thread_extent_y),  //
+                                                               IntImm(DataType::Int(32), thread_extent_x)});
           sch->Bind(split[2], "threadIdx.x");
           sch->Bind(split[1], "threadIdx.y");
         }
       } else {
         if (vector_lane > 1) {
           ffi::Array<s_tir::LoopRV> split = sch->Split(fused, {std::nullopt,              //
-                                                               Integer(thread_extent_x),  //
-                                                               Integer(vector_lane)});
+                                                               IntImm(DataType::Int(32), thread_extent_x),  //
+                                                               IntImm(DataType::Int(32), vector_lane)});
           sch->Vectorize(split[2]);
           sch->Bind(split[1], "threadIdx.x");
         } else {
           ffi::Array<s_tir::LoopRV> split =
-              sch->Split(fused, {std::nullopt, Integer(thread_extent_x)});
+              sch->Split(fused, {std::nullopt, IntImm(DataType::Int(32), thread_extent_x)});
           sch->Bind(split[1], "threadIdx.x");
         }
       }

--- a/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
@@ -66,7 +66,7 @@ ffi::Optional<SBlockRV> ParseAnnotate(const Schedule& sch, const Instruction& in
   if (ann_key != s_tir::attr::meta_schedule_cooperative_fetch) {
     return std::nullopt;
   }
-  *vector_lane = Downcast<Integer>(sch->Get(Downcast<ExprRV>(inst->inputs[1])))->value;
+  *vector_lane = Downcast<IntImm>(sch->Get(Downcast<ExprRV>(inst->inputs[1])))->value;
   return Downcast<SBlockRV>(inst->inputs[0]);
 }
 

--- a/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
@@ -198,25 +198,28 @@ bool RewriteCooperativeFetchNode::Apply(const s_tir::Schedule& sch) {
       }
       if (thread_extent_y != -1) {
         if (vector_lane > 1) {
-          ffi::Array<s_tir::LoopRV> split = sch->Split(fused, {std::nullopt,              //
-                                                               IntImm(DataType::Int(32), thread_extent_y),  //
-                                                               IntImm(DataType::Int(32), thread_extent_x),  //
-                                                               IntImm(DataType::Int(32), vector_lane)});
+          ffi::Array<s_tir::LoopRV> split =
+              sch->Split(fused, {std::nullopt,                                //
+                                 IntImm(DataType::Int(32), thread_extent_y),  //
+                                 IntImm(DataType::Int(32), thread_extent_x),  //
+                                 IntImm(DataType::Int(32), vector_lane)});
           sch->Vectorize(split[3]);
           sch->Bind(split[2], "threadIdx.x");
           sch->Bind(split[1], "threadIdx.y");
         } else {
-          ffi::Array<s_tir::LoopRV> split = sch->Split(fused, {std::nullopt,              //
-                                                               IntImm(DataType::Int(32), thread_extent_y),  //
-                                                               IntImm(DataType::Int(32), thread_extent_x)});
+          ffi::Array<s_tir::LoopRV> split =
+              sch->Split(fused, {std::nullopt,                                //
+                                 IntImm(DataType::Int(32), thread_extent_y),  //
+                                 IntImm(DataType::Int(32), thread_extent_x)});
           sch->Bind(split[2], "threadIdx.x");
           sch->Bind(split[1], "threadIdx.y");
         }
       } else {
         if (vector_lane > 1) {
-          ffi::Array<s_tir::LoopRV> split = sch->Split(fused, {std::nullopt,              //
-                                                               IntImm(DataType::Int(32), thread_extent_x),  //
-                                                               IntImm(DataType::Int(32), vector_lane)});
+          ffi::Array<s_tir::LoopRV> split =
+              sch->Split(fused, {std::nullopt,                                //
+                                 IntImm(DataType::Int(32), thread_extent_x),  //
+                                 IntImm(DataType::Int(32), vector_lane)});
           sch->Vectorize(split[2]);
           sch->Bind(split[1], "threadIdx.x");
         } else {

--- a/src/s_tir/meta_schedule/postproc/rewrite_layout.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_layout.cc
@@ -126,9 +126,9 @@ ffi::Array<Buffer> CollectLayoutFreeBuffers(const PrimFuncNode* func) {
       func->GetAttr(s_tir::attr::layout_free_buffers, ffi::Array<int64_t>()).value();
 
   ffi::Array<Buffer> layout_free_buffers;
-  for (const Integer& index : layout_free_buffer_index) {
-    TVM_FFI_ICHECK(static_cast<size_t>(index->value) < func->params.size());
-    const Var& param = func->params[index->value];
+  for (int64_t index : layout_free_buffer_index) {
+    TVM_FFI_ICHECK(static_cast<size_t>(index) < func->params.size());
+    const Var& param = func->params[index];
     layout_free_buffers.push_back(func->buffer_map.at(param));
   }
 

--- a/src/s_tir/meta_schedule/postproc/rewrite_parallel_vectorize_unroll.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_parallel_vectorize_unroll.cc
@@ -380,7 +380,7 @@ void RewriteFuseSplitParallelVectorize(const Schedule& sch, ffi::Array<LoopRV>* 
                                        int vec_len) {
   size_t n_loops = loop_rvs->size();
   LoopRV fused = sch->Fuse({loop_rvs->begin(), loop_rvs->end()});
-  ffi::Array<LoopRV> split = sch->Split(fused, {std::nullopt, Integer(vec_len)});
+  ffi::Array<LoopRV> split = sch->Split(fused, {std::nullopt, IntImm(DataType::Int(32), vec_len)});
   TVM_FFI_ICHECK_EQ(split.size(), 2);
   const LoopRV& outer = split[0];
   const LoopRV& inner = split[1];

--- a/src/s_tir/meta_schedule/postproc/rewrite_unbound_block.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_unbound_block.cc
@@ -127,7 +127,7 @@ bool RewriteUnboundBlockNode::Apply(const s_tir::Schedule& sch) {
   using s_tir::Schedule;
   TVM_FFI_ICHECK_NE(this->max_threads_per_block_, -1);
   auto get_factor = [t = this->max_threads_per_block_](int max_extent) -> ExprRV {
-    return Integer(std::min(t, max_extent));
+    return IntImm(DataType::Int(32), std::min(t, max_extent));
   };
   std::vector<std::pair<tirx::StmtSRef, ffi::String>> unbound_blocks =
       s_tir::UnboundBlockFinder::Find(sch->state());

--- a/src/s_tir/meta_schedule/postproc/verify_gpu_code.cc
+++ b/src/s_tir/meta_schedule/postproc/verify_gpu_code.cc
@@ -129,8 +129,8 @@ class VerifyGPUCodeNode : public PostprocNode {
     this->target_constraints_ = ffi::Map<ffi::String, PrimExpr>{
         {"max_shared_memory_per_block", Extract(this->target_, "max_shared_memory_per_block")},
         {"max_threads_per_block", Extract(this->target_, "max_threads_per_block")},
-        {"max_vthread", Integer(8)},
-        {"max_vector_bytes", Integer(16)},
+        {"max_vthread", IntImm(DataType::Int(32), 8)},
+        {"max_vector_bytes", IntImm(DataType::Int(32), 16)},
     };
     thread_warp_size_ = Extract(this->target_, "thread_warp_size").IntValue();
   }

--- a/src/s_tir/meta_schedule/postproc/verify_gpu_code.cc
+++ b/src/s_tir/meta_schedule/postproc/verify_gpu_code.cc
@@ -107,10 +107,10 @@ namespace s_tir {
 namespace meta_schedule {
 
 /*! \brief Extract attribute from a target. */
-Integer Extract(const Target& target, const char* name) {
+IntImm Extract(const Target& target, const char* name) {
   TVM_FFI_ICHECK(target.defined());
   if (ffi::Optional<int64_t> v = target->GetAttr<int64_t>(name)) {
-    return v.value();
+    return IntImm(DataType::Int(64), v.value());
   }
   TVM_FFI_THROW(AttributedError) << "\"" << name << "\" is not defined in the target";
   throw;
@@ -132,7 +132,7 @@ class VerifyGPUCodeNode : public PostprocNode {
         {"max_vthread", IntImm(DataType::Int(32), 8)},
         {"max_vector_bytes", IntImm(DataType::Int(32), 16)},
     };
-    thread_warp_size_ = Extract(this->target_, "thread_warp_size").IntValue();
+    thread_warp_size_ = static_cast<int>(Extract(this->target_, "thread_warp_size")->value);
   }
 
   bool Verify(const IRModule& mod) const {

--- a/src/s_tir/meta_schedule/schedule/cuda/thread_bind.cc
+++ b/src/s_tir/meta_schedule/schedule/cuda/thread_bind.cc
@@ -85,9 +85,9 @@ ffi::Array<LoopRV> BindSpatialLoop(Schedule sch, LoopRV loop, int64_t max_thread
     sch->Bind(splits[1], "threadIdx.x");
     return {splits[0], splits[1]};
   } else {
-    ffi::Array<LoopRV> splits = sch->Split(loop, {std::nullopt,
-                                                  IntImm(DataType::Int(32), max_threadblocks),  //
-                                                  IntImm(DataType::Int(32), max_threads_per_block)});
+    ffi::Array<LoopRV> splits =
+        sch->Split(loop, {std::nullopt, IntImm(DataType::Int(32), max_threadblocks),  //
+                          IntImm(DataType::Int(32), max_threads_per_block)});
     TVM_FFI_ICHECK_EQ(splits.size(), 3);
     sch->Reorder({splits[1], splits[2], splits[0]});
     sch->Bind(splits[1], "blockIdx.x");

--- a/src/s_tir/meta_schedule/schedule/cuda/thread_bind.cc
+++ b/src/s_tir/meta_schedule/schedule/cuda/thread_bind.cc
@@ -86,8 +86,8 @@ ffi::Array<LoopRV> BindSpatialLoop(Schedule sch, LoopRV loop, int64_t max_thread
     return {splits[0], splits[1]};
   } else {
     ffi::Array<LoopRV> splits = sch->Split(loop, {std::nullopt,
-                                                  Integer(max_threadblocks),  //
-                                                  Integer(max_threads_per_block)});
+                                                  IntImm(DataType::Int(32), max_threadblocks),  //
+                                                  IntImm(DataType::Int(32), max_threads_per_block)});
     TVM_FFI_ICHECK_EQ(splits.size(), 3);
     sch->Reorder({splits[1], splits[2], splits[0]});
     sch->Bind(splits[1], "blockIdx.x");

--- a/src/s_tir/meta_schedule/schedule/cuda/winograd.cc
+++ b/src/s_tir/meta_schedule/schedule/cuda/winograd.cc
@@ -150,8 +150,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                SBlockRV output = sch->GetConsumers(inverse)[0];
                ffi::Array<LoopRV> nchw = sch->GetLoops(output);
                TVM_FFI_ICHECK_EQ(nchw.size(), 4);
-               ffi::Array<LoopRV> hs = sch->Split(nchw[2], {std::nullopt, Integer(tile_size)});
-               ffi::Array<LoopRV> ws = sch->Split(nchw[3], {std::nullopt, Integer(tile_size)});
+               ffi::Array<LoopRV> hs = sch->Split(nchw[2], {std::nullopt, IntImm(DataType::Int(32), tile_size)});
+               ffi::Array<LoopRV> ws = sch->Split(nchw[3], {std::nullopt, IntImm(DataType::Int(32), tile_size)});
                sch->Reorder({hs[0], ws[0], hs[1], ws[1]});
                outer = ws[0];
              }

--- a/src/s_tir/meta_schedule/schedule/cuda/winograd.cc
+++ b/src/s_tir/meta_schedule/schedule/cuda/winograd.cc
@@ -150,8 +150,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                SBlockRV output = sch->GetConsumers(inverse)[0];
                ffi::Array<LoopRV> nchw = sch->GetLoops(output);
                TVM_FFI_ICHECK_EQ(nchw.size(), 4);
-               ffi::Array<LoopRV> hs = sch->Split(nchw[2], {std::nullopt, IntImm(DataType::Int(32), tile_size)});
-               ffi::Array<LoopRV> ws = sch->Split(nchw[3], {std::nullopt, IntImm(DataType::Int(32), tile_size)});
+               ffi::Array<LoopRV> hs =
+                   sch->Split(nchw[2], {std::nullopt, IntImm(DataType::Int(32), tile_size)});
+               ffi::Array<LoopRV> ws =
+                   sch->Split(nchw[3], {std::nullopt, IntImm(DataType::Int(32), tile_size)});
                sch->Reorder({hs[0], ws[0], hs[1], ws[1]});
                outer = ws[0];
              }

--- a/src/s_tir/meta_schedule/schedule_rule/add_rfactor.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/add_rfactor.cc
@@ -115,7 +115,7 @@ ffi::Array<s_tir::Schedule> AddRFactorNode::Apply(const s_tir::Schedule& sch,
 
       // Annotate that the rfactor block, which is now the producer of the original block, needs to
       // be considered by the rule Random-Compute-Location.
-      sch_tmp->Annotate(block_rv, s_tir::attr::meta_schedule_random_compute_producer, Integer(1));
+      sch_tmp->Annotate(block_rv, s_tir::attr::meta_schedule_random_compute_producer, IntImm(DataType::Int(32), 1));
       res.push_back(sch_tmp);
     } catch (const tvm::ffi::Error& e) {
     }

--- a/src/s_tir/meta_schedule/schedule_rule/add_rfactor.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/add_rfactor.cc
@@ -115,7 +115,8 @@ ffi::Array<s_tir::Schedule> AddRFactorNode::Apply(const s_tir::Schedule& sch,
 
       // Annotate that the rfactor block, which is now the producer of the original block, needs to
       // be considered by the rule Random-Compute-Location.
-      sch_tmp->Annotate(block_rv, s_tir::attr::meta_schedule_random_compute_producer, IntImm(DataType::Int(32), 1));
+      sch_tmp->Annotate(block_rv, s_tir::attr::meta_schedule_random_compute_producer,
+                        IntImm(DataType::Int(32), 1));
       res.push_back(sch_tmp);
     } catch (const tvm::ffi::Error& e) {
     }

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling.cc
@@ -284,9 +284,9 @@ std::vector<State> MultiLevelTilingNode::TileLoopNest(State state,
       low_inclusive = this->thread_warp_size_;
     }
     sch->Annotate(block_rv, s_tir::attr::meta_schedule_thread_extent_low_inclusive,
-                  Integer(low_inclusive));
+                  IntImm(DataType::Int(32), low_inclusive));
     sch->Annotate(block_rv, s_tir::attr::meta_schedule_thread_extent_high_inclusive,
-                  Integer(high_inclusive));
+                  IntImm(DataType::Int(32), high_inclusive));
   }
   return {state};
 }

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
@@ -675,7 +675,8 @@ std::vector<State> MultiLevelTilingTensorCoreNode::AddSoftwarePipeline(
       }
     } else {
       // Add local stage and double buffering
-      sch->Annotate(cache_read, s_tir::attr::manifest_shared_memory_local_stage, IntImm(DataType::Int(32), 1));
+      sch->Annotate(cache_read, s_tir::attr::manifest_shared_memory_local_stage,
+                    IntImm(DataType::Int(32), 1));
       sch->Annotate(cache_read, s_tir::attr::double_buffer_scope, IntImm(DataType::Int(32), 0));
     }
   }

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
@@ -425,9 +425,9 @@ std::vector<State> MultiLevelTilingTensorCoreNode::MMATileLoopNest(TensorCoreSta
       low_inclusive = this->thread_warp_size_;
     }
     sch->Annotate(block_rv, s_tir::attr::meta_schedule_thread_extent_low_inclusive,
-                  Integer(low_inclusive));
+                  IntImm(DataType::Int(32), low_inclusive));
     sch->Annotate(block_rv, s_tir::attr::meta_schedule_thread_extent_high_inclusive,
-                  Integer(high_inclusive));
+                  IntImm(DataType::Int(32), high_inclusive));
   }
   return {state};
 }
@@ -668,15 +668,15 @@ std::vector<State> MultiLevelTilingTensorCoreNode::AddSoftwarePipeline(
     const s_tir::SBlockRV cache_read = state->read_reuse.at(i);
     if (state->is_mma) {
       // Add vector bytes for memhammer
-      sch->Annotate(cache_read, s_tir::attr::vector_bytes, Integer(16));
+      sch->Annotate(cache_read, s_tir::attr::vector_bytes, IntImm(DataType::Int(32), 16));
       if (!state->use_async) {
-        sch->Annotate(cache_read, s_tir::attr::local_stage, Integer(1));
-        sch->Annotate(cache_read, s_tir::attr::double_buffer_scope, Integer(0));
+        sch->Annotate(cache_read, s_tir::attr::local_stage, IntImm(DataType::Int(32), 1));
+        sch->Annotate(cache_read, s_tir::attr::double_buffer_scope, IntImm(DataType::Int(32), 0));
       }
     } else {
       // Add local stage and double buffering
-      sch->Annotate(cache_read, s_tir::attr::manifest_shared_memory_local_stage, Integer(1));
-      sch->Annotate(cache_read, s_tir::attr::double_buffer_scope, Integer(0));
+      sch->Annotate(cache_read, s_tir::attr::manifest_shared_memory_local_stage, IntImm(DataType::Int(32), 1));
+      sch->Annotate(cache_read, s_tir::attr::double_buffer_scope, IntImm(DataType::Int(32), 0));
     }
   }
 
@@ -908,7 +908,7 @@ inline std::vector<State> MultiLevelTilingTensorCoreNode::TransformForTensorizat
                        state->intrin_group.compute_intrin);
   state->sch->Annotate(state->block_rv, s_tir::attr::meta_schedule_auto_tensorize_init,
                        state->intrin_group.init_intrin);
-  state->sch->Annotate(state->block_rv, s_tir::attr::warp_execution, Integer(1));
+  state->sch->Annotate(state->block_rv, s_tir::attr::warp_execution, IntImm(DataType::Int(32), 1));
   return {std::move(state)};
 }
 

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_wide_vector.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_wide_vector.cc
@@ -125,13 +125,13 @@ MultiLevelTilingWideVectorNode::SplitLoop(const Schedule& sch, SBlockRV block_rv
 }
 
 ScheduleRule ScheduleRule::MultiLevelTilingWideVector(
-    ffi::String structure, Integer vector_length_in_bits,
+    ffi::String structure, int64_t vector_length_in_bits,
     ffi::Optional<int64_t> max_innermost_factor,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_read,
     ffi::Optional<ffi::Map<ffi::String, ffi::Any>> reuse_write) {
   auto node = MultiLevelTilingInitCommon<MultiLevelTilingWideVectorNode>(
       structure, std::nullopt, max_innermost_factor, std::nullopt, reuse_read, reuse_write);
-  node->vector_length_in_bits = vector_length_in_bits->value;
+  node->vector_length_in_bits = vector_length_in_bits;
   return ScheduleRule(node);
 }
 

--- a/src/s_tir/meta_schedule/schedule_rule/parallel_vectorize_unroll.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/parallel_vectorize_unroll.cc
@@ -64,11 +64,11 @@ class ParallelizeVectorizeUnrollNode : public ScheduleRuleNode {
     // Parallelization
     if (max_jobs_per_core != -1) {
       sch->Annotate(root_rv, s_tir::attr::meta_schedule_parallel,
-                    Integer(this->max_parallel_extent_));
+                    IntImm(DataType::Int(32), this->max_parallel_extent_));
     }
     // Vectorization
     if (max_vectorize_extent != -1) {
-      sch->Annotate(root_rv, s_tir::attr::meta_schedule_vectorize, Integer(max_vectorize_extent));
+      sch->Annotate(root_rv, s_tir::attr::meta_schedule_vectorize, IntImm(DataType::Int(32), max_vectorize_extent));
     }
     // Unroll
     if (!unroll_max_steps.empty() && !s_tir::CheckSpatialPrimFunc(sch, root_rv)) {

--- a/src/s_tir/meta_schedule/schedule_rule/parallel_vectorize_unroll.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/parallel_vectorize_unroll.cc
@@ -68,7 +68,8 @@ class ParallelizeVectorizeUnrollNode : public ScheduleRuleNode {
     }
     // Vectorization
     if (max_vectorize_extent != -1) {
-      sch->Annotate(root_rv, s_tir::attr::meta_schedule_vectorize, IntImm(DataType::Int(32), max_vectorize_extent));
+      sch->Annotate(root_rv, s_tir::attr::meta_schedule_vectorize,
+                    IntImm(DataType::Int(32), max_vectorize_extent));
     }
     // Unroll
     if (!unroll_max_steps.empty() && !s_tir::CheckSpatialPrimFunc(sch, root_rv)) {

--- a/src/s_tir/meta_schedule/space_generator/space_generator.cc
+++ b/src/s_tir/meta_schedule/space_generator/space_generator.cc
@@ -49,10 +49,10 @@ ffi::String GetRuleKindFromTarget(const Target& target) {
     ffi::Map<ffi::String, ffi::Any> target_json =
         target::canonicalizer::llvm::aprofile::Canonicalize(target->ToConfig());
 
-    if (Downcast<Bool>(target_json.at("feature.has_dotprod"))) {
+    if (Downcast<IntImm>(target_json.at("feature.has_dotprod"))->value) {
       return "dotprod";
     }
-    if (Downcast<Bool>(target_json.at("feature.has_asimd"))) {
+    if (Downcast<IntImm>(target_json.at("feature.has_asimd"))->value) {
       return "asimd";
     }
     return "llvm";

--- a/src/s_tir/meta_schedule/utils.h
+++ b/src/s_tir/meta_schedule/utils.h
@@ -655,9 +655,9 @@ class SBlockCollector : public tirx::StmtVisitor {
 
     // If filter function is provided, use it to selectively collect blocks.
     // Otherwise collect all blocks.
-    Bool collect_block = Bool(true);
+    bool collect_block = true;
     if (f_block_filter_ != nullptr) {
-      collect_block = f_block_filter_(ffi::GetRef<tirx::SBlock>(block)).cast<Bool>();
+      collect_block = f_block_filter_(ffi::GetRef<tirx::SBlock>(block)).cast<IntImm>()->value != 0;
     }
     if (collect_block) {
       blocks_to_collect_.push_back(block->name_hint);

--- a/src/s_tir/schedule/analysis/layout.cc
+++ b/src/s_tir/schedule/analysis/layout.cc
@@ -218,14 +218,16 @@ ffi::Optional<IndexMap> SuggestIndexMap(const Buffer& buffer, const ffi::Array<P
     for (int i = 0, n = indices.size(); i < n; ++i) {
       const Var& index = indices[inverse_order[i]];
       inv_permuted_indices.push_back(index);
-      analyzer->Bind(index, Range::FromMinExtent(0, IntImm(DataType::Int(32), split_exprs[i].extent)));
+      analyzer->Bind(index,
+                     Range::FromMinExtent(0, IntImm(DataType::Int(32), split_exprs[i].extent)));
     }
 
     // Step 6.2: Fuse all the indices. This is the inverse of Step 5.2.
     PrimExpr flattened_index = make_const(indices[0]->dtype, 0);
     int64_t stride = 1;
     for (int i = static_cast<int>(split_exprs.size()) - 1; i >= 0; --i) {
-      flattened_index = inv_permuted_indices[i] * IntImm(DataType::Int(32), stride) + flattened_index;
+      flattened_index =
+          inv_permuted_indices[i] * IntImm(DataType::Int(32), stride) + flattened_index;
       stride *= split_exprs[i].extent;
     }
     // Step 6.3: Split the flattened index into multiple indices. This is the inverse of Step 5.1.

--- a/src/s_tir/schedule/analysis/layout.cc
+++ b/src/s_tir/schedule/analysis/layout.cc
@@ -218,14 +218,14 @@ ffi::Optional<IndexMap> SuggestIndexMap(const Buffer& buffer, const ffi::Array<P
     for (int i = 0, n = indices.size(); i < n; ++i) {
       const Var& index = indices[inverse_order[i]];
       inv_permuted_indices.push_back(index);
-      analyzer->Bind(index, Range::FromMinExtent(0, Integer(split_exprs[i].extent)));
+      analyzer->Bind(index, Range::FromMinExtent(0, IntImm(DataType::Int(32), split_exprs[i].extent)));
     }
 
     // Step 6.2: Fuse all the indices. This is the inverse of Step 5.2.
     PrimExpr flattened_index = make_const(indices[0]->dtype, 0);
     int64_t stride = 1;
     for (int i = static_cast<int>(split_exprs.size()) - 1; i >= 0; --i) {
-      flattened_index = inv_permuted_indices[i] * Integer(stride) + flattened_index;
+      flattened_index = inv_permuted_indices[i] * IntImm(DataType::Int(32), stride) + flattened_index;
       stride *= split_exprs[i].extent;
     }
     // Step 6.3: Split the flattened index into multiple indices. This is the inverse of Step 5.1.

--- a/src/s_tir/schedule/concrete_schedule.cc
+++ b/src/s_tir/schedule/concrete_schedule.cc
@@ -488,7 +488,7 @@ ffi::Array<LoopRV> ConcreteScheduleNode::Split(const LoopRV& loop_rv,
   // infer factor if needed and check validity of factors
   for (size_t i = 0; i < factor_rvs.size(); i++) {
     if (!factor_rvs[i].defined()) {
-      factors.push_back(Integer(-1));
+      factors.push_back(IntImm(DataType::Int(32), -1));
       if (infer_index != -1) {
         throw NotSingleInferFactorError(state_->mod);
       }
@@ -555,7 +555,7 @@ ffi::Array<LoopRV> ConcreteScheduleNode::LoopPartition(
   // infer factor if needed and check validity of factors
   for (size_t i = 0; i < factor_rvs.size(); i++) {
     if (!factor_rvs[i].defined()) {
-      factors.push_back(Integer(-1));
+      factors.push_back(IntImm(DataType::Int(32), -1));
       if (infer_index != -1) {
         throw NotSingleInferFactorError(state_->mod);
       }

--- a/src/s_tir/schedule/concrete_schedule.h
+++ b/src/s_tir/schedule/concrete_schedule.h
@@ -268,7 +268,7 @@ inline PrimExpr ConcreteScheduleNode::Get(const ExprRV& expr_rv) const {
     }
     const ffi::ObjectRef& obj = (*it).second;
     const auto* int_imm = TVM_TYPE_AS(obj, IntImmNode);
-    return Integer(int_imm->value);
+    return IntImm(DataType::Int(32), int_imm->value);
   });
   return this->analyzer_->Simplify(transformed);
 }
@@ -370,7 +370,7 @@ inline T ConcreteScheduleNode::CreateRV(const StmtSRef& sref) {
 
 inline ExprRV ConcreteScheduleNode::CreateRV(int64_t value) {
   Var rv("v" + std::to_string(this->symbol_table_.size() + 1), DataType::Int(32));
-  this->symbol_table_.Set(rv, Integer(static_cast<int32_t>(value)));
+  this->symbol_table_.Set(rv, IntImm(DataType::Int(32), static_cast<int32_t>(value)));
   return rv;
 }
 

--- a/src/s_tir/schedule/instruction_traits.h
+++ b/src/s_tir/schedule/instruction_traits.h
@@ -112,8 +112,8 @@ using namespace tvm::tirx;
  *   static ffi::Array<Var> UnpackedApplyToSchedule(
  *      Schedule sch,
  *      LoopRV loop_rv,
- *      Integer n,
- *      Integer max_innermost_factor,
+ *      IntImm n,
+ *      IntImm max_innermost_factor,
  *      ffi::Optional<ffi::Array<int64_t>> decision) {
  *     return sch->SamplePerfectTile(loop_rv, n->value, max_innermost_factor->value, decision);
  *   }
@@ -127,8 +127,8 @@ using namespace tvm::tirx;
  *   static ffi::String UnpackedAsPython(
  *      ffi::Array<ffi::String> outputs,
  *      ffi::String loop_rv,
- *      Integer n,
- *      Integer max_innermost_factor,
+ *      IntImm n,
+ *      IntImm max_innermost_factor,
  *      ffi::Optional<ffi::Array<int64_t>> decision) {
  *     PythonAPICall py("sample_perfect_tile");
  *     py.Input("loop", loop_rv);

--- a/src/s_tir/schedule/primitive/annotate_buffer_access.cc
+++ b/src/s_tir/schedule/primitive/annotate_buffer_access.cc
@@ -122,8 +122,8 @@ struct AnnotateBufferAccessTraits : public UnpackedInstTraits<AnnotateBufferAcce
   static constexpr size_t kNumAttrs = 0;
   static constexpr size_t kNumDecisions = 0;
 
-  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block, Integer buffer_index,
-                                      Integer buffer_index_type, IndexMap index_map) {
+  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block, IntImm buffer_index,
+                                      IntImm buffer_index_type, IndexMap index_map) {
     return sch->AnnotateBufferAccess(block, buffer_index->value,
                                      static_cast<BufferIndexType>(buffer_index_type->value),
                                      index_map);
@@ -150,7 +150,7 @@ struct AnnotateBufferAccessTraits : public UnpackedInstTraits<AnnotateBufferAcce
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
-                                      Integer buffer_index, Integer buffer_index_type,
+                                      IntImm buffer_index, IntImm buffer_index_type,
                                       IndexMap index_map) {
     PythonAPICall py("annotate_buffer_access");
     py.Input("block", block);

--- a/src/s_tir/schedule/primitive/block_annotate.cc
+++ b/src/s_tir/schedule/primitive/block_annotate.cc
@@ -383,15 +383,15 @@ struct StorageAlignTraits : public UnpackedInstTraits<StorageAlignTraits> {
   static constexpr size_t kNumAttrs = 4;
   static constexpr size_t kNumDecisions = 0;
 
-  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, Integer buffer_index,
-                                      Integer axis, Integer factor, Integer offset) {
+  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, IntImm buffer_index,
+                                      IntImm axis, IntImm factor, IntImm offset) {
     return sch->StorageAlign(block_rv, buffer_index->value, axis->value, factor->value,
                              offset->value);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block_rv,
-                                      Integer buffer_index, Integer axis, Integer factor,
-                                      Integer offset) {
+                                      IntImm buffer_index, IntImm axis, IntImm factor,
+                                      IntImm offset) {
     PythonAPICall py("storage_align");
     py.Input("block", block_rv);
     py.Input("buffer_index", buffer_index);
@@ -414,13 +414,13 @@ struct SetScopeTraits : public UnpackedInstTraits<SetScopeTraits> {
   static constexpr size_t kNumAttrs = 2;
   static constexpr size_t kNumDecisions = 0;
 
-  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, Integer buffer_index,
+  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, IntImm buffer_index,
                                       ffi::String storage_scope) {
     return sch->SetScope(block_rv, buffer_index->value, storage_scope);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block_rv,
-                                      Integer buffer_index, ffi::String storage_scope) {
+                                      IntImm buffer_index, ffi::String storage_scope) {
     PythonAPICall py("set_scope");
     py.Input("block", block_rv);
     py.Input("buffer_index", buffer_index);
@@ -441,13 +441,13 @@ struct UnsafeSetDTypeTraits : public UnpackedInstTraits<UnsafeSetDTypeTraits> {
   static constexpr size_t kNumAttrs = 2;
   static constexpr size_t kNumDecisions = 0;
 
-  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, Integer buffer_index,
+  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, IntImm buffer_index,
                                       ffi::String dtype) {
     return sch->UnsafeSetDType(block_rv, buffer_index->value, dtype);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block_rv,
-                                      Integer buffer_index, ffi::String dtype) {
+                                      IntImm buffer_index, ffi::String dtype) {
     PythonAPICall py("unsafe_set_dtype");
     py.Input("block", block_rv);
     py.Input("buffer_index", buffer_index);

--- a/src/s_tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/s_tir/schedule/primitive/blockize_tensorize.cc
@@ -139,8 +139,8 @@ ffi::Array<ffi::Array<arith::IterMark>> TrivialSubspaceDivision(
       return {};
     }
   }
-  res.push_back({arith::IterMark(arith::IterSumExpr({}, 0), Bool(true)),
-                 arith::IterMark(arith::IterSumExpr({}, 0), Bool(true))});
+  res.push_back({arith::IterMark(arith::IterSumExpr({}, 0), const_true()),
+                 arith::IterMark(arith::IterSumExpr({}, 0), const_true())});
   return res;
 }
 

--- a/src/s_tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/s_tir/schedule/primitive/blockize_tensorize.cc
@@ -876,21 +876,21 @@ struct BlockizeTraits : public UnpackedInstTraits<BlockizeTraits> {
   static constexpr size_t kNumDecisions = 0;
 
   static SBlockRV UnpackedApplyToSchedule(Schedule sch, ffi::ObjectRef target,
-                                          Bool preserve_unit_iters) {
+                                          IntImm preserve_unit_iters) {
     if (auto loop = target.as<LoopRV>()) {
-      return sch->Blockize(loop.value(), preserve_unit_iters.operator bool());
+      return sch->Blockize(loop.value(), preserve_unit_iters->value != 0);
     } else if (auto blocks = target.as<ffi::Array<SBlockRV>>()) {
-      return sch->Blockize(blocks.value(), preserve_unit_iters.operator bool());
+      return sch->Blockize(blocks.value(), preserve_unit_iters->value != 0);
     }
     TVM_FFI_THROW(TypeError) << "expect Loop or list of SBlocks, but gets:" << target->GetTypeKey();
     TVM_FFI_UNREACHABLE();
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::ObjectRef target,
-                                      Bool preserve_unit_iters) {
+                                      IntImm preserve_unit_iters) {
     PythonAPICall py("blockize");
     py.Input("target", target);
-    py.Input("preserve_unit_iters", preserve_unit_iters.operator bool());
+    py.Input("preserve_unit_iters", preserve_unit_iters->value != 0);
     py.SingleOutput(outputs);
     return py.Str();
   }
@@ -909,11 +909,11 @@ struct TensorizeTraits : public UnpackedInstTraits<TensorizeTraits> {
   static constexpr size_t kNumDecisions = 0;
 
   static void UnpackedApplyToSchedule(Schedule sch, ffi::ObjectRef block_or_loop_rv,
-                                      ffi::String intrin, Bool preserve_unit_iters) {
+                                      ffi::String intrin, IntImm preserve_unit_iters) {
     if (auto block = block_or_loop_rv.as<SBlockRV>()) {
-      sch->Tensorize(block.value(), intrin, preserve_unit_iters.operator bool());
+      sch->Tensorize(block.value(), intrin, preserve_unit_iters->value != 0);
     } else if (auto loop = block_or_loop_rv.as<LoopRV>()) {
-      sch->Tensorize(loop.value(), intrin, preserve_unit_iters.operator bool());
+      sch->Tensorize(loop.value(), intrin, preserve_unit_iters->value != 0);
     } else {
       TVM_FFI_THROW(TypeError) << "Expected SBlock or Loop, but gets: "
                                << block_or_loop_rv->GetTypeKey();
@@ -921,11 +921,11 @@ struct TensorizeTraits : public UnpackedInstTraits<TensorizeTraits> {
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block_or_loop_rv,
-                                      ffi::String intrin, Bool preserve_unit_iters) {
+                                      ffi::String intrin, IntImm preserve_unit_iters) {
     PythonAPICall py("tensorize");
     py.Input("block_or_loop", block_or_loop_rv);
     py.Input("tensor_intrin", intrin);
-    py.Input("preserve_unit_iters", preserve_unit_iters.operator bool());
+    py.Input("preserve_unit_iters", preserve_unit_iters->value != 0);
     return py.Str();
   }
 

--- a/src/s_tir/schedule/primitive/cache_index.cc
+++ b/src/s_tir/schedule/primitive/cache_index.cc
@@ -507,12 +507,12 @@ struct CacheIndexTraits : public UnpackedInstTraits<CacheIndexTraits> {
 
   static ffi::Array<SBlockRV> UnpackedApplyToSchedule(Schedule sch, SBlockRV block,
                                                       ffi::String storage_scope,
-                                                      Integer cse_thresh) {
+                                                      IntImm cse_thresh) {
     return sch->CacheIndex(block, storage_scope, cse_thresh->value);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
-                                      ffi::String storage_scope, Integer cse_thresh) {
+                                      ffi::String storage_scope, IntImm cse_thresh) {
     PythonAPICall py("cache_index");
     py.Input("block", block);
     py.Input("storage_scope", storage_scope);

--- a/src/s_tir/schedule/primitive/cache_read_write.cc
+++ b/src/s_tir/schedule/primitive/cache_read_write.cc
@@ -2396,13 +2396,13 @@ struct CacheReadTraits : public UnpackedInstTraits<CacheReadTraits> {
 
   static SBlockRV UnpackedApplyToSchedule(Schedule sch, SBlockRV block,
                                           ffi::Array<SBlockRV> consumer_blocks,
-                                          Integer read_buffer_index, ffi::String storage_scope) {
+                                          IntImm read_buffer_index, ffi::String storage_scope) {
     return sch->CacheRead(block, read_buffer_index->value, storage_scope, consumer_blocks);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
                                       ffi::Array<ffi::String> consumer_blocks,
-                                      Integer read_buffer_index, ffi::String storage_scope) {
+                                      IntImm read_buffer_index, ffi::String storage_scope) {
     PythonAPICall py("cache_read");
     py.Input("block", block);
     py.Input("read_buffer_index", read_buffer_index->value);
@@ -2430,13 +2430,13 @@ struct CacheWriteTraits : public UnpackedInstTraits<CacheWriteTraits> {
 
   static SBlockRV UnpackedApplyToSchedule(Schedule sch, SBlockRV block,
                                           ffi::Array<SBlockRV> consumer_blocks,
-                                          Integer write_buffer_index, ffi::String storage_scope) {
+                                          IntImm write_buffer_index, ffi::String storage_scope) {
     return sch->CacheWrite(block, write_buffer_index->value, storage_scope, consumer_blocks);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
                                       ffi::Array<ffi::String> consumer_blocks,
-                                      Integer write_buffer_index, ffi::String storage_scope) {
+                                      IntImm write_buffer_index, ffi::String storage_scope) {
     PythonAPICall py("cache_write");
     py.Input("block", block);
     py.Input("write_buffer_index", write_buffer_index->value);
@@ -2463,13 +2463,13 @@ struct CacheInplaceTraits : public UnpackedInstTraits<CacheInplaceTraits> {
   static constexpr size_t kNumDecisions = 0;
 
   static ffi::Array<SBlockRV> UnpackedApplyToSchedule(Schedule sch, SBlockRV block,
-                                                      Integer read_buffer_index,
+                                                      IntImm read_buffer_index,
                                                       ffi::String storage_scope) {
     return sch->CacheInplace(block, read_buffer_index->value, storage_scope);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
-                                      Integer read_buffer_index, ffi::String storage_scope) {
+                                      IntImm read_buffer_index, ffi::String storage_scope) {
     PythonAPICall py("cache_inplace");
     py.Input("block", block);
     py.Input("read_buffer_index", read_buffer_index->value);
@@ -2491,14 +2491,14 @@ struct ReIndexTraits : public UnpackedInstTraits<ReIndexTraits> {
   static constexpr size_t kNumAttrs = 2;
   static constexpr size_t kNumDecisions = 0;
 
-  static SBlockRV UnpackedApplyToSchedule(Schedule sch, SBlockRV block, Integer buffer_index,
-                                          Integer buffer_index_type) {
-    return sch->ReIndex(block, buffer_index.IntValue(),
+  static SBlockRV UnpackedApplyToSchedule(Schedule sch, SBlockRV block, IntImm buffer_index,
+                                          IntImm buffer_index_type) {
+    return sch->ReIndex(block, buffer_index->value,
                         static_cast<BufferIndexType>(buffer_index_type->value));
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
-                                      Integer buffer_index, Integer buffer_index_type) {
+                                      IntImm buffer_index, IntImm buffer_index_type) {
     PythonAPICall py("reindex");
     py.Input("block", block);
     std::ostringstream os;
@@ -2523,12 +2523,12 @@ struct ReindexCacheReadTraits : public UnpackedInstTraits<ReindexCacheReadTraits
   static constexpr size_t kNumDecisions = 0;
 
   static SBlockRV UnpackedApplyToSchedule(Schedule sch, SBlockRV block, IndexMap index_map,
-                                          Integer read_buffer_index, ffi::String storage_scope) {
+                                          IntImm read_buffer_index, ffi::String storage_scope) {
     return sch->ReindexCacheRead(block, read_buffer_index->value, storage_scope, index_map);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
-                                      IndexMap index_map, Integer read_buffer_index,
+                                      IndexMap index_map, IntImm read_buffer_index,
                                       ffi::String storage_scope) {
     PythonAPICall py("reindex_cache_read");
     py.Input("block", block);
@@ -2553,12 +2553,12 @@ struct ReindexCacheWriteTraits : public UnpackedInstTraits<ReindexCacheWriteTrai
   static constexpr size_t kNumDecisions = 0;
 
   static SBlockRV UnpackedApplyToSchedule(Schedule sch, SBlockRV block, IndexMap index_map,
-                                          Integer write_buffer_index, ffi::String storage_scope) {
+                                          IntImm write_buffer_index, ffi::String storage_scope) {
     return sch->ReindexCacheWrite(block, write_buffer_index->value, storage_scope, index_map);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
-                                      IndexMap index_map, Integer write_buffer_index,
+                                      IndexMap index_map, IntImm write_buffer_index,
                                       ffi::String storage_scope) {
     PythonAPICall py("reindex_cache_write");
     py.Input("block", block);

--- a/src/s_tir/schedule/primitive/cache_read_write.cc
+++ b/src/s_tir/schedule/primitive/cache_read_write.cc
@@ -189,13 +189,13 @@ SBlock MakeReindexCacheStage(const BufferRegion& cache_region, ReindexCacheStage
   Region& old_region = (is_cache_read) ? read_access_region : write_access_region;
   for (const Range& range : cache_region->region) {
     old_indices.push_back(Substitute(range->min, var_map));
-    old_region.push_back(Range::FromMinExtent(old_indices.back(), Integer(1)));
+    old_region.push_back(Range::FromMinExtent(old_indices.back(), IntImm(DataType::Int(32), 1)));
   }
   ffi::Array<PrimExpr>& new_indices = (is_cache_read) ? write_access_indices : read_access_indices;
   Region& new_region = (is_cache_read) ? write_access_region : read_access_region;
   for (const PrimExpr& idx : info->indices) {
     new_indices.push_back(Substitute((idx), var_map));
-    new_region.push_back(Range::FromMinExtent(new_indices.back(), Integer(1)));
+    new_region.push_back(Range::FromMinExtent(new_indices.back(), IntImm(DataType::Int(32), 1)));
   }
 
   // Create New Block
@@ -562,7 +562,7 @@ static PrimExpr CollectNestedBlockPredicates(const Stmt& body, const Buffer& buf
                                              BufferIndexType index_type) {
   struct Collector : public StmtVisitor {
     Collector(const Buffer& buf, BufferIndexType idx_type)
-        : buffer_(buf), index_type_(idx_type), result_(Bool(false)), found_(false) {}
+        : buffer_(buf), index_type_(idx_type), result_(const_false()), found_(false) {}
 
     void VisitStmt_(const SBlockRealizeNode* realize) final {
       const SBlockNode* block = realize->block.get();
@@ -604,7 +604,7 @@ static PrimExpr CollectNestedBlockPredicates(const Stmt& body, const Buffer& buf
   collector(body);
   // If no nested block accessed the buffer, return true (no restriction — the caller
   // will fall back to the original scope-block reads / FullRegion path).
-  return collector.found_ ? collector.result_ : Bool(true);
+  return collector.found_ ? collector.result_ : const_true();
 }
 
 /*!
@@ -621,7 +621,7 @@ static PrimExpr CollectNestedBlockPredicates(const Stmt& body, const Buffer& buf
 BufferRegion RelaxBufferRegion(ScheduleState self, const BufferRegion& buffer_region,
                                const StmtSRef& block_sref, const StmtSRef& dom_low_inclusive,
                                const StmtSRef& dom_high_exclusive,
-                               PrimExpr extra_predicate = Bool(true)) {
+                               PrimExpr extra_predicate = const_true()) {
   SBlockRealize realize = GetSBlockRealize(self, block_sref);
   ffi::Map<Var, PrimExpr> binding = GetBindings(realize);
   const Buffer& buffer = buffer_region->buffer;
@@ -1089,7 +1089,7 @@ class ReindexCacheReadRewriter : public CacheReadRewriter {
         if (buf_region->buffer.same_as(info_->read_buffer)) {
           Region region;
           for (const PrimExpr index : new_indices_) {
-            region.push_back(Range::FromMinExtent(index, Integer(1)));
+            region.push_back(Range::FromMinExtent(index, IntImm(DataType::Int(32), 1)));
           }
           new_reads.push_back(BufferRegion(info_->write_buffer, region));
         } else {
@@ -1105,7 +1105,7 @@ class ReindexCacheReadRewriter : public CacheReadRewriter {
         if (source->buffer.same_as(info_->read_buffer)) {
           Region region;
           for (const PrimExpr index : new_indices_) {
-            region.push_back(Range::FromMinExtent(index, Integer(1)));
+            region.push_back(Range::FromMinExtent(index, IntImm(DataType::Int(32), 1)));
           }
           new_match_buffers.push_back(MatchBufferRegion(match_buffer_region->buffer,
                                                         BufferRegion(info_->write_buffer, region)));
@@ -1378,7 +1378,7 @@ class ReindexCacheWriteRewriter : public CacheWriteRewriter {
         if (buf_region->buffer.same_as(info_->write_buffer)) {
           Region region;
           for (const PrimExpr index : new_indices_) {
-            region.push_back(Range::FromMinExtent(index, Integer(1)));
+            region.push_back(Range::FromMinExtent(index, IntImm(DataType::Int(32), 1)));
           }
           new_reads.push_back(BufferRegion(info_->read_buffer, region));
         } else {
@@ -1394,7 +1394,7 @@ class ReindexCacheWriteRewriter : public CacheWriteRewriter {
         if (source->buffer.same_as(info_->write_buffer)) {
           Region region;
           for (const PrimExpr index : new_indices_) {
-            region.push_back(Range::FromMinExtent(index, Integer(1)));
+            region.push_back(Range::FromMinExtent(index, IntImm(DataType::Int(32), 1)));
           }
           new_match_buffers.push_back(MatchBufferRegion(match_buffer_region->buffer,
                                                         BufferRegion(info_->read_buffer, region)));
@@ -1781,7 +1781,7 @@ StmtSRef CacheRead(ScheduleState self, const StmtSRef& block_sref, int read_buff
         GetBufferRegionFromBuffer(block->reads, read_buffer);
     PrimExpr nested_pred = read_region_opt ? CollectNestedBlockPredicates(block->body, read_buffer,
                                                                           BufferIndexType::kRead)
-                                           : Bool(true);
+                                           : const_true();
     if (read_region_opt && !is_one(nested_pred) && block_sref->parent != nullptr) {
       StmtSRef parent_sref = ffi::GetRef<StmtSRef>(block_sref->parent);
       cache_region = RelaxBufferRegion(self, read_region_opt.value(), block_sref, parent_sref,

--- a/src/s_tir/schedule/primitive/compute_at.cc
+++ b/src/s_tir/schedule/primitive/compute_at.cc
@@ -300,7 +300,7 @@ class ScopeReconstructor : private StmtMutator {
       const Var& loop_var = loop_vars[i];
       const PrimExpr& loop_extent = loop_extents[i];
       new_subtree = For(/*loop_var=*/loop_var,
-                        /*min=*/Integer(0),
+                        /*min=*/IntImm(DataType::Int(32), 0),
                         /*extent=*/loop_extent,
                         /*ForKind=*/ForKind::kSerial,
                         /*body=*/std::move(new_subtree));

--- a/src/s_tir/schedule/primitive/compute_at.cc
+++ b/src/s_tir/schedule/primitive/compute_at.cc
@@ -815,16 +815,16 @@ struct ComputeAtTraits : public UnpackedInstTraits<ComputeAtTraits> {
   static constexpr size_t kNumDecisions = 0;
 
   static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, LoopRV loop_rv,
-                                      Bool preserve_unit_loops, IntImm index) {
-    return sch->ComputeAt(block_rv, loop_rv, preserve_unit_loops.operator bool(), index->value);
+                                      IntImm preserve_unit_loops, IntImm index) {
+    return sch->ComputeAt(block_rv, loop_rv, preserve_unit_loops->value != 0, index->value);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block_rv,
-                                      ffi::String loop_rv, Bool preserve_unit_loops, IntImm index) {
+                                      ffi::String loop_rv, IntImm preserve_unit_loops, IntImm index) {
     PythonAPICall py("compute_at");
     py.Input("block", block_rv);
     py.Input("loop", loop_rv);
-    py.Input("preserve_unit_loops", preserve_unit_loops.operator bool());
+    py.Input("preserve_unit_loops", preserve_unit_loops->value != 0);
     py.Input("index", index);
     return py.Str();
   }
@@ -843,17 +843,17 @@ struct ReverseComputeAtTraits : public UnpackedInstTraits<ReverseComputeAtTraits
   static constexpr size_t kNumDecisions = 0;
 
   static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, LoopRV loop_rv,
-                                      Bool preserve_unit_loops, IntImm index) {
-    return sch->ReverseComputeAt(block_rv, loop_rv, preserve_unit_loops.operator bool(),
+                                      IntImm preserve_unit_loops, IntImm index) {
+    return sch->ReverseComputeAt(block_rv, loop_rv, preserve_unit_loops->value != 0,
                                  index->value);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block_rv,
-                                      ffi::String loop_rv, Bool preserve_unit_loops, IntImm index) {
+                                      ffi::String loop_rv, IntImm preserve_unit_loops, IntImm index) {
     PythonAPICall py("reverse_compute_at");
     py.Input("block", block_rv);
     py.Input("loop", loop_rv);
-    py.Input("preserve_unit_loops", preserve_unit_loops.operator bool());
+    py.Input("preserve_unit_loops", preserve_unit_loops->value != 0);
     py.Input("index", index);
     return py.Str();
   }

--- a/src/s_tir/schedule/primitive/compute_at.cc
+++ b/src/s_tir/schedule/primitive/compute_at.cc
@@ -820,7 +820,8 @@ struct ComputeAtTraits : public UnpackedInstTraits<ComputeAtTraits> {
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block_rv,
-                                      ffi::String loop_rv, IntImm preserve_unit_loops, IntImm index) {
+                                      ffi::String loop_rv, IntImm preserve_unit_loops,
+                                      IntImm index) {
     PythonAPICall py("compute_at");
     py.Input("block", block_rv);
     py.Input("loop", loop_rv);
@@ -844,12 +845,12 @@ struct ReverseComputeAtTraits : public UnpackedInstTraits<ReverseComputeAtTraits
 
   static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, LoopRV loop_rv,
                                       IntImm preserve_unit_loops, IntImm index) {
-    return sch->ReverseComputeAt(block_rv, loop_rv, preserve_unit_loops->value != 0,
-                                 index->value);
+    return sch->ReverseComputeAt(block_rv, loop_rv, preserve_unit_loops->value != 0, index->value);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block_rv,
-                                      ffi::String loop_rv, IntImm preserve_unit_loops, IntImm index) {
+                                      ffi::String loop_rv, IntImm preserve_unit_loops,
+                                      IntImm index) {
     PythonAPICall py("reverse_compute_at");
     py.Input("block", block_rv);
     py.Input("loop", loop_rv);

--- a/src/s_tir/schedule/primitive/compute_inline.cc
+++ b/src/s_tir/schedule/primitive/compute_inline.cc
@@ -625,7 +625,7 @@ class ReverseComputeInliner : public BaseInliner {
         producer_block_(producer_block),
         consumer_block_(consumer_block_realize->block.get()) {
     // Initialize the predicates to ensure consumer block iters are in-bound
-    consumer_iter_in_bound_ = Bool(true);
+    consumer_iter_in_bound_ = const_true();
     for (const IterVar& iter : consumer_block_realize->block->iter_vars) {
       consumer_iter_in_bound_ =
           consumer_iter_in_bound_ &&

--- a/src/s_tir/schedule/primitive/layout_transformation.cc
+++ b/src/s_tir/schedule/primitive/layout_transformation.cc
@@ -1579,18 +1579,18 @@ struct TransformLayoutTraits : public UnpackedInstTraits<TransformLayoutTraits> 
   static constexpr size_t kNumDecisions = 0;
 
   static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, IndexMap index_map,
-                                      Integer buffer_index, Integer buffer_index_type,
+                                      IntImm buffer_index, IntImm buffer_index_type,
                                       ffi::Optional<IndexMap> pad_value,
-                                      Bool assume_injective_transform) {
-    return sch->TransformLayout(block_rv, buffer_index.IntValue(),
+                                      IntImm assume_injective_transform) {
+    return sch->TransformLayout(block_rv, buffer_index->value,
                                 static_cast<BufferIndexType>(buffer_index_type->value), index_map,
-                                pad_value, assume_injective_transform.operator bool());
+                                pad_value, assume_injective_transform->value != 0);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block_rv,
-                                      IndexMap index_map, Integer buffer_index,
-                                      Integer buffer_index_type, ffi::Optional<IndexMap> pad_value,
-                                      Bool assume_injective_transform) {
+                                      IndexMap index_map, IntImm buffer_index,
+                                      IntImm buffer_index_type, ffi::Optional<IndexMap> pad_value,
+                                      IntImm assume_injective_transform) {
     PythonAPICall py("transform_layout");
     py.Input("block", block_rv);
 
@@ -1600,7 +1600,7 @@ struct TransformLayoutTraits : public UnpackedInstTraits<TransformLayoutTraits> 
     py.Input("buffer", os.str());
     py.Input("index_map", index_map->ToPythonString());
     py.Input("pad_value", pad_value ? pad_value.value()->ToPythonString() : "None");
-    py.Input("assume_injective_transform", assume_injective_transform.operator bool());
+    py.Input("assume_injective_transform", assume_injective_transform->value != 0);
 
     return py.Str();
   }
@@ -1691,16 +1691,16 @@ struct SetAxisSeparatorTraits : public UnpackedInstTraits<SetAxisSeparatorTraits
   static constexpr size_t kNumAttrs = 3;
   static constexpr size_t kNumDecisions = 0;
 
-  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, Integer buffer_index,
-                                      Integer buffer_index_type,
+  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block_rv, IntImm buffer_index,
+                                      IntImm buffer_index_type,
                                       ffi::Array<IntImm> axis_separators) {
-    return sch->SetAxisSeparator(block_rv, buffer_index.IntValue(),
+    return sch->SetAxisSeparator(block_rv, buffer_index->value,
                                  static_cast<BufferIndexType>(buffer_index_type->value),
                                  axis_separators);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block_rv,
-                                      Integer buffer_index, Integer buffer_index_type,
+                                      IntImm buffer_index, IntImm buffer_index_type,
                                       ffi::Array<IntImm> axis_separators) {
     PythonAPICall py("set_axis_separator");
     py.Input("block", block_rv);

--- a/src/s_tir/schedule/primitive/layout_transformation.cc
+++ b/src/s_tir/schedule/primitive/layout_transformation.cc
@@ -492,7 +492,7 @@ class TransformLayoutPlanner : private StmtExprVisitor {
     std::stringstream block_name;
     block_name << "buffer_" << new_buffer->name << "_assumptions";
     auto read_region = BufferRegion::FromPoint(new_buffer, indices);
-    stmt = SBlockRealize(iter_values, Bool(true),
+    stmt = SBlockRealize(iter_values, const_true(),
                          SBlock(iter_vars, {read_region}, {}, block_name.str(), stmt));
 
     for (size_t rev_i = 0; rev_i < inverse->initial_indices.size(); rev_i++) {
@@ -1187,7 +1187,7 @@ void TransformLayout(ScheduleState self, const StmtSRef& block_sref, int buffer_
   const SBlockNode* scope_block = TVM_SREF_TO_SBLOCK(scope_sref);
 
   ffi::Optional<IndexMap> opt_inverse = std::nullopt;
-  PrimExpr padding_predicate = Bool(false);
+  PrimExpr padding_predicate = const_false();
   if (!assume_injective_transform) {
     std::tie(opt_inverse, padding_predicate) = [&]() {
       ffi::Array<Range> region;

--- a/src/s_tir/schedule/primitive/loop_transformation.cc
+++ b/src/s_tir/schedule/primitive/loop_transformation.cc
@@ -1200,20 +1200,20 @@ struct SplitTraits : public UnpackedInstTraits<SplitTraits> {
 
   static ffi::Array<LoopRV> UnpackedApplyToSchedule(Schedule sch, LoopRV loop_rv,
                                                     ffi::Array<ffi::Optional<ExprRV>> factors,
-                                                    Bool preserve_unit_iters,
-                                                    Bool disable_predication) {
-    return sch->Split(loop_rv, factors, preserve_unit_iters.operator bool(),
-                      disable_predication.operator bool());
+                                                    IntImm preserve_unit_iters,
+                                                    IntImm disable_predication) {
+    return sch->Split(loop_rv, factors, preserve_unit_iters->value != 0,
+                      disable_predication->value != 0);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String loop_rv,
-                                      ffi::Array<Any> factors, Bool preserve_unit_iters,
-                                      Bool disable_predication) {
+                                      ffi::Array<Any> factors, IntImm preserve_unit_iters,
+                                      IntImm disable_predication) {
     PythonAPICall py("split");
     py.Input("loop", loop_rv);
     py.Input("factors", factors);
-    py.Input("preserve_unit_iters", preserve_unit_iters.operator bool());
-    py.Input("disable_predication", disable_predication.operator bool());
+    py.Input("preserve_unit_iters", preserve_unit_iters->value != 0);
+    py.Input("disable_predication", disable_predication->value != 0);
     py.OutputList(outputs);
     return py.Str();
   }
@@ -1243,16 +1243,16 @@ struct LoopPartitionTraits : public UnpackedInstTraits<LoopPartitionTraits> {
 
   static ffi::Array<LoopRV> UnpackedApplyToSchedule(Schedule sch, LoopRV loop_rv,
                                                     ffi::Array<ffi::Optional<ExprRV>> factors,
-                                                    Bool preserve_unit_iters) {
-    return sch->LoopPartition(loop_rv, factors, preserve_unit_iters.operator bool());
+                                                    IntImm preserve_unit_iters) {
+    return sch->LoopPartition(loop_rv, factors, preserve_unit_iters->value != 0);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String loop_rv,
-                                      ffi::Array<Any> factors, Bool preserve_unit_iters) {
+                                      ffi::Array<Any> factors, IntImm preserve_unit_iters) {
     PythonAPICall py("loop_partition");
     py.Input("loop", loop_rv);
     py.Input("factors", factors);
-    py.Input("preserve_unit_iters", preserve_unit_iters.operator bool());
+    py.Input("preserve_unit_iters", preserve_unit_iters->value != 0);
     py.OutputList(outputs);
     return py.Str();
   }
@@ -1308,17 +1308,17 @@ struct FuseTraits : public UnpackedInstTraits<FuseTraits> {
   }
 
   static LoopRV UnpackedApplyToSchedule(Schedule sch, ffi::Array<LoopRV> loop_rvs,
-                                        Bool preserve_unit_iters) {
-    return sch->Fuse(loop_rvs, preserve_unit_iters.operator bool());
+                                        IntImm preserve_unit_iters) {
+    return sch->Fuse(loop_rvs, preserve_unit_iters->value != 0);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs,
-                                      ffi::Array<ffi::String> loop_rvs, Bool preserve_unit_iters) {
+                                      ffi::Array<ffi::String> loop_rvs, IntImm preserve_unit_iters) {
     PythonAPICall py("fuse");
     for (const ffi::String& loop_rv : loop_rvs) {
       py.Input("", loop_rv);
     }
-    py.Input("preserve_unit_iters", preserve_unit_iters.operator bool());
+    py.Input("preserve_unit_iters", preserve_unit_iters->value != 0);
     py.SingleOutput(outputs);
     return py.Str();
   }

--- a/src/s_tir/schedule/primitive/loop_transformation.cc
+++ b/src/s_tir/schedule/primitive/loop_transformation.cc
@@ -743,13 +743,14 @@ class LoopReconstructor : private StmtMutator {
       new_stmts.push_back(new_stmt);
       this->need_remove_loop_.push_back(loops_[i].back());
     }
-    auto new_loop = For(new_loop_vars[0], IntImm(DataType::Int(32), 0), new_loop_extents[0], ForKind::kSerial,
-                        SeqStmt(std::move(new_stmts)));
+    auto new_loop = For(new_loop_vars[0], IntImm(DataType::Int(32), 0), new_loop_extents[0],
+                        ForKind::kSerial, SeqStmt(std::move(new_stmts)));
     this->new_inner_loop_ = new_loop;
     for (size_t i = 1; i < new_loop_vars.size(); ++i) {
       const Var& loop_var = new_loop_vars[i];
       const PrimExpr& loop_extent = new_loop_extents[i];
-      new_loop = For(loop_var, IntImm(DataType::Int(32), 0), loop_extent, ForKind::kSerial, new_loop);
+      new_loop =
+          For(loop_var, IntImm(DataType::Int(32), 0), loop_extent, ForKind::kSerial, new_loop);
     }
     this->new_outer_loop_ = new_loop;
   }
@@ -1313,7 +1314,8 @@ struct FuseTraits : public UnpackedInstTraits<FuseTraits> {
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs,
-                                      ffi::Array<ffi::String> loop_rvs, IntImm preserve_unit_iters) {
+                                      ffi::Array<ffi::String> loop_rvs,
+                                      IntImm preserve_unit_iters) {
     PythonAPICall py("fuse");
     for (const ffi::String& loop_rv : loop_rvs) {
       py.Input("", loop_rv);

--- a/src/s_tir/schedule/primitive/loop_transformation.cc
+++ b/src/s_tir/schedule/primitive/loop_transformation.cc
@@ -743,13 +743,13 @@ class LoopReconstructor : private StmtMutator {
       new_stmts.push_back(new_stmt);
       this->need_remove_loop_.push_back(loops_[i].back());
     }
-    auto new_loop = For(new_loop_vars[0], Integer(0), new_loop_extents[0], ForKind::kSerial,
+    auto new_loop = For(new_loop_vars[0], IntImm(DataType::Int(32), 0), new_loop_extents[0], ForKind::kSerial,
                         SeqStmt(std::move(new_stmts)));
     this->new_inner_loop_ = new_loop;
     for (size_t i = 1; i < new_loop_vars.size(); ++i) {
       const Var& loop_var = new_loop_vars[i];
       const PrimExpr& loop_extent = new_loop_extents[i];
-      new_loop = For(loop_var, Integer(0), loop_extent, ForKind::kSerial, new_loop);
+      new_loop = For(loop_var, IntImm(DataType::Int(32), 0), loop_extent, ForKind::kSerial, new_loop);
     }
     this->new_outer_loop_ = new_loop;
   }

--- a/src/s_tir/schedule/primitive/pad_einsum.cc
+++ b/src/s_tir/schedule/primitive/pad_einsum.cc
@@ -183,7 +183,7 @@ struct BufferPadding {
     }
     Stmt body{nullptr};
     if (is_read) {
-      PrimExpr predicate = Bool(true);
+      PrimExpr predicate = const_true();
       for (int i = 0; i < ndim; ++i) {
         if (!analyzer->CanProveEqual(buffer->shape[i], padded_buffer->shape[i])) {
           predicate = predicate && (indices[i] < buffer->shape[i]);
@@ -203,7 +203,7 @@ struct BufferPadding {
     SBlock new_block(iter_vars, {read_region}, {write_region}, padded_buffer->name,
                      std::move(body));
     blocks->push_back(new_block);
-    body = SBlockRealize(ffi::Array<PrimExpr>{loop_vars.begin(), loop_vars.end()}, Bool(true),
+    body = SBlockRealize(ffi::Array<PrimExpr>{loop_vars.begin(), loop_vars.end()}, const_true(),
                          new_block);
     for (int i = ndim - 1; i >= 0; --i) {
       body = For(loop_vars[i], loop_doms[i]->min, loop_doms[i]->extent, ForKind::kSerial,

--- a/src/s_tir/schedule/primitive/read_write_at.cc
+++ b/src/s_tir/schedule/primitive/read_write_at.cc
@@ -371,12 +371,12 @@ struct ReadAtTraits : public UnpackedInstTraits<ReadAtTraits> {
   StmtSRef ReadAt(ScheduleState self, const StmtSRef& loop_sref, const StmtSRef& block_sref,
                   int buffer_index, const ffi::String& storage_scope);
   static SBlockRV UnpackedApplyToSchedule(Schedule sch, LoopRV loop, SBlockRV block,
-                                          Integer read_buffer_index, ffi::String storage_scope) {
+                                          IntImm read_buffer_index, ffi::String storage_scope) {
     return sch->ReadAt(loop, block, read_buffer_index->value, storage_scope);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String loop,
-                                      ffi::String block, Integer read_buffer_index,
+                                      ffi::String block, IntImm read_buffer_index,
                                       ffi::String storage_scope) {
     PythonAPICall py("read_at");
     py.Input("loop", loop);
@@ -401,12 +401,12 @@ struct WriteAtTraits : public UnpackedInstTraits<WriteAtTraits> {
   static constexpr size_t kNumDecisions = 0;
 
   static SBlockRV UnpackedApplyToSchedule(Schedule sch, LoopRV loop, SBlockRV block,
-                                          Integer write_buffer_index, ffi::String storage_scope) {
+                                          IntImm write_buffer_index, ffi::String storage_scope) {
     return sch->WriteAt(loop, block, write_buffer_index->value, storage_scope);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String loop,
-                                      ffi::String block, Integer write_buffer_index,
+                                      ffi::String block, IntImm write_buffer_index,
                                       ffi::String storage_scope) {
     PythonAPICall py("write_at");
     py.Input("loop", loop);

--- a/src/s_tir/schedule/primitive/read_write_at.cc
+++ b/src/s_tir/schedule/primitive/read_write_at.cc
@@ -306,7 +306,7 @@ struct ReadWriteAtImpl {
     }
     Stmt stmt = BufferStore(copy_to, /*value=*/BufferLoad(copy_from, indices), /*indices=*/indices);
     for (int i = n - 1; i >= 0; --i) {
-      stmt = For(loop_vars[i], Integer(0), domain[i]->extent, ForKind::kSerial, stmt);
+      stmt = For(loop_vars[i], IntImm(DataType::Int(32), 0), domain[i]->extent, ForKind::kSerial, stmt);
     }
     return SBlockRealize(
         /*values=*/iter_values,

--- a/src/s_tir/schedule/primitive/read_write_at.cc
+++ b/src/s_tir/schedule/primitive/read_write_at.cc
@@ -306,7 +306,8 @@ struct ReadWriteAtImpl {
     }
     Stmt stmt = BufferStore(copy_to, /*value=*/BufferLoad(copy_from, indices), /*indices=*/indices);
     for (int i = n - 1; i >= 0; --i) {
-      stmt = For(loop_vars[i], IntImm(DataType::Int(32), 0), domain[i]->extent, ForKind::kSerial, stmt);
+      stmt = For(loop_vars[i], IntImm(DataType::Int(32), 0), domain[i]->extent, ForKind::kSerial,
+                 stmt);
     }
     return SBlockRealize(
         /*values=*/iter_values,

--- a/src/s_tir/schedule/primitive/reduction.cc
+++ b/src/s_tir/schedule/primitive/reduction.cc
@@ -158,8 +158,8 @@ class LoopHeightError : public ScheduleError {
 };
 
 PrimExpr RemakePredicate(PrimExpr pred, const std::unordered_set<const VarNode*>& discarded_loops) {
-  if (is_one(pred)) return Bool(true);
-  PrimExpr new_pred = Bool(true);
+  if (is_one(pred)) return const_true();
+  PrimExpr new_pred = const_true();
   auto f = [&](const VarNode* var) { return discarded_loops.count(var); };
   arith::PVar<PrimExpr> lhs, rhs, rest;
   for (;;) {

--- a/src/s_tir/schedule/primitive/reduction.cc
+++ b/src/s_tir/schedule/primitive/reduction.cc
@@ -1334,12 +1334,12 @@ struct RFactorTraits : public UnpackedInstTraits<RFactorTraits> {
   static constexpr size_t kNumAttrs = 1;
   static constexpr size_t kNumDecisions = 0;
 
-  static SBlockRV UnpackedApplyToSchedule(Schedule sch, LoopRV loop_rv, Integer factor_axis) {
+  static SBlockRV UnpackedApplyToSchedule(Schedule sch, LoopRV loop_rv, IntImm factor_axis) {
     return sch->RFactor(loop_rv, factor_axis->value);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String loop_rv,
-                                      Integer factor_axis) {
+                                      IntImm factor_axis) {
     PythonAPICall py("rfactor");
     py.Input("loop", loop_rv);
     py.Input("factor_axis", factor_axis->value);

--- a/src/s_tir/schedule/primitive/reorder_block_iter_var.cc
+++ b/src/s_tir/schedule/primitive/reorder_block_iter_var.cc
@@ -88,8 +88,8 @@ void ReorderBlockIterVar(ScheduleState self, const StmtSRef& block_sref,
                          const ffi::Array<int64_t>& new_order) {
   const SBlockNode* block_n = TVM_SREF_TO_SBLOCK(block_sref);
   std::vector<int> new_order_vec;
-  for (const Integer& x : new_order) {
-    new_order_vec.push_back(x->value);
+  for (int64_t x : new_order) {
+    new_order_vec.push_back(static_cast<int>(x));
   }
   // check whether new_order is valid or not;
   size_t num_block_itervars = block_n->iter_vars.size();

--- a/src/s_tir/schedule/primitive/rolling_buffer.cc
+++ b/src/s_tir/schedule/primitive/rolling_buffer.cc
@@ -458,12 +458,12 @@ struct RollingBufferTraits : public UnpackedInstTraits<RollingBufferTraits> {
   static constexpr size_t kNumAttrs = 1;
   static constexpr size_t kNumDecisions = 0;
 
-  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block, Integer write_buffer_index) {
-    return sch->RollingBuffer(block, write_buffer_index.IntValue());
+  static void UnpackedApplyToSchedule(Schedule sch, SBlockRV block, IntImm write_buffer_index) {
+    return sch->RollingBuffer(block, write_buffer_index->value);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String block,
-                                      Integer write_buffer_index) {
+                                      IntImm write_buffer_index) {
     PythonAPICall py("rolling_buffer");
     py.Input("block", block);
     py.Input("write_buffer_index", write_buffer_index);

--- a/src/s_tir/schedule/primitive/sampling.cc
+++ b/src/s_tir/schedule/primitive/sampling.cc
@@ -493,14 +493,14 @@ struct SamplePerfectTileTraits : public UnpackedInstTraits<SamplePerfectTileTrai
   static constexpr size_t kNumAttrs = 2;
   static constexpr size_t kNumDecisions = 1;
 
-  static ffi::Array<ExprRV> UnpackedApplyToSchedule(Schedule sch, LoopRV loop_rv, Integer n,
-                                                    Integer max_innermost_factor,
+  static ffi::Array<ExprRV> UnpackedApplyToSchedule(Schedule sch, LoopRV loop_rv, IntImm n,
+                                                    IntImm max_innermost_factor,
                                                     ffi::Optional<ffi::Array<int64_t>> decision) {
     return sch->SamplePerfectTile(loop_rv, n->value, max_innermost_factor->value, decision);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String loop_rv,
-                                      Integer n, Integer max_innermost_factor,
+                                      IntImm n, IntImm max_innermost_factor,
                                       ffi::Optional<ffi::Array<int64_t>> decision) {
     PythonAPICall py("sample_perfect_tile");
     py.Input("loop", loop_rv);
@@ -524,15 +524,15 @@ struct SamplePartitionedTileTraits : public UnpackedInstTraits<SamplePartitioned
   static constexpr size_t kNumAttrs = 3;
   static constexpr size_t kNumDecisions = 1;
 
-  static ffi::Array<ExprRV> UnpackedApplyToSchedule(Schedule sch, LoopRV loop_rv, Integer n,
-                                                    Integer partition_pos, Integer innerpart_factor,
+  static ffi::Array<ExprRV> UnpackedApplyToSchedule(Schedule sch, LoopRV loop_rv, IntImm n,
+                                                    IntImm partition_pos, IntImm innerpart_factor,
                                                     ffi::Optional<ffi::Array<int64_t>> decision) {
     return sch->SamplePartitionedTile(loop_rv, n->value, partition_pos->value,
                                       innerpart_factor->value, decision);
   }
 
   static ffi::String UnpackedAsPython(ffi::Array<ffi::String> outputs, ffi::String loop_rv,
-                                      Integer n, Integer partition_pos, Integer innerpart_factor,
+                                      IntImm n, IntImm partition_pos, IntImm innerpart_factor,
                                       ffi::Optional<ffi::Array<int64_t>> decision) {
     PythonAPICall py("sample_partitioned_tile");
     py.Input("loop", loop_rv);

--- a/src/s_tir/schedule/state.cc
+++ b/src/s_tir/schedule/state.cc
@@ -1013,11 +1013,11 @@ void ScheduleStateNode::UpdateScopeSBlockInfo(const Stmt& stmt) {
   SBlockInfoCollector::Collect(this, stmt);
 }
 
-TVM_DLL ffi::Array<Bool> GetCachedFlags(const ScheduleState& self, const StmtSRef& block_sref) {
+TVM_DLL ffi::Array<IntImm> GetCachedFlags(const ScheduleState& self, const StmtSRef& block_sref) {
   const SBlockInfo& info = self->GetSBlockInfo(block_sref);
-  return {Bool(info.affine_binding),  //
-          Bool(info.region_cover),    //
-          Bool(info.stage_pipeline)};
+  return {IntImm(DataType::Bool(), info.affine_binding),  //
+          IntImm(DataType::Bool(), info.region_cover),    //
+          IntImm(DataType::Bool(), info.stage_pipeline)};
 }
 
 /**************** FFI ****************/

--- a/src/s_tir/schedule/trace.cc
+++ b/src/s_tir/schedule/trace.cc
@@ -405,7 +405,7 @@ ffi::ObjectRef TraceNode::AsJSON(bool remove_postproc) const {
     Any decision = this->GetDecision(inst);
     if (decision != nullptr) {
       json_decisions.push_back(ffi::Array<ffi::Any>{
-          /* 0: index    */ Integer(i),
+          /* 0: index    */ IntImm(DataType::Int(32), i),
           /* 1: decision */ decision,
       });
     }

--- a/src/s_tir/schedule/traced_schedule.cc
+++ b/src/s_tir/schedule/traced_schedule.cc
@@ -78,7 +78,7 @@ ffi::Array<ExprRV> TracedScheduleNode::SamplePerfectTile(
   static const InstructionKind& kind = InstructionKind::Get("SamplePerfectTile");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,  //
                                       /*inputs=*/{loop_rv},
-                                      /*attrs=*/{Integer(n), Integer(max_innermost_factor)},
+                                      /*attrs=*/{IntImm(DataType::Int(32), n), IntImm(DataType::Int(32), max_innermost_factor)},
                                       /*outputs=*/results),
                  /*decision=*/decision);
   return results;
@@ -94,7 +94,7 @@ ffi::Array<ExprRV> TracedScheduleNode::SamplePartitionedTile(
   trace_->Append(/*inst=*/Instruction(
                      /*kind=*/kind,  //
                      /*inputs=*/{loop_rv},
-                     /*attrs=*/{Integer(n), Integer(partition_pos), Integer(innerpart_factor)},
+                     /*attrs=*/{IntImm(DataType::Int(32), n), IntImm(DataType::Int(32), partition_pos), IntImm(DataType::Int(32), innerpart_factor)},
                      /*outputs=*/results),
                  /*decision=*/decision);
   return results;
@@ -223,7 +223,7 @@ LoopRV TracedScheduleNode::Fuse(const ffi::Array<LoopRV>& loop_rvs, bool preserv
   static const InstructionKind& kind = InstructionKind::Get("Fuse");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/loop_rvs,
-                                      /*attrs=*/{Integer(preserve_unit_loops)},
+                                      /*attrs=*/{IntImm(DataType::Int(32), preserve_unit_loops)},
                                       /*outputs=*/{result}));
   return result;
 }
@@ -266,7 +266,7 @@ ffi::Array<LoopRV> TracedScheduleNode::LoopPartition(
   static const InstructionKind& kind = InstructionKind::Get("LoopPartition");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/inputs,
-                                      /*attrs=*/{Integer(preserve_unit_iters)},
+                                      /*attrs=*/{IntImm(DataType::Int(32), preserve_unit_iters)},
                                       /*outputs=*/results));
   return results;
 }
@@ -364,7 +364,7 @@ SBlockRV TracedScheduleNode::CacheRead(const SBlockRV& block_rv, int read_buffer
   static const InstructionKind& kind = InstructionKind::Get("CacheRead");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{block_rv, consumer_blocks},
-                                      /*attrs=*/{Integer(read_buffer_index), storage_scope},
+                                      /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
                                       /*outputs=*/{result}));
   return result;
 }
@@ -378,7 +378,7 @@ SBlockRV TracedScheduleNode::CacheWrite(const SBlockRV& block_rv, int write_buff
   static const InstructionKind& kind = InstructionKind::Get("CacheWrite");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{block_rv, consumer_blocks},
-                                      /*attrs=*/{Integer(write_buffer_index), storage_scope},
+                                      /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index), storage_scope},
                                       /*outputs=*/{result}));
   return result;
 }
@@ -394,7 +394,7 @@ SBlockRV TracedScheduleNode::ReindexCacheRead(const SBlockRV& block_rv, int read
       /*inst=*/Instruction(
           /*kind=*/kind,
           /*inputs=*/{block_rv, index_map},
-          /*attrs=*/{Integer(read_buffer_index), storage_scope},
+          /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
           /*outputs=*/{result}));
   return result;
 }
@@ -410,7 +410,7 @@ SBlockRV TracedScheduleNode::ReindexCacheWrite(const SBlockRV& block_rv, int wri
       /*inst=*/Instruction(
           /*kind=*/kind,
           /*inputs=*/{block_rv, index_map},
-          /*attrs=*/{Integer(write_buffer_index), storage_scope},
+          /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index), storage_scope},
           /*outputs=*/{result}));
   return result;
 }
@@ -427,7 +427,7 @@ ffi::Array<SBlockRV> TracedScheduleNode::CacheInplace(const SBlockRV& block_rv,
   static const InstructionKind& kind = InstructionKind::Get("CacheInplace");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{block_rv},
-                                      /*attrs=*/{Integer(read_buffer_index), storage_scope},
+                                      /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
                                       /*outputs=*/results));
   return result;
 }
@@ -444,7 +444,7 @@ ffi::Array<SBlockRV> TracedScheduleNode::CacheIndex(const SBlockRV& block_rv,
   static const InstructionKind& kind = InstructionKind::Get("CacheIndex");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{block_rv},
-                                      /*attrs=*/{storage_scope, Integer(cse_thresh)},
+                                      /*attrs=*/{storage_scope, IntImm(DataType::Int(32), cse_thresh)},
                                       /*outputs=*/outputs));
   return result;
 }
@@ -456,7 +456,7 @@ SBlockRV TracedScheduleNode::ReIndex(const SBlockRV& block_rv, int buffer_index,
   static const InstructionKind& kind = InstructionKind::Get("ReIndex");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{block_rv},
-                                      /*attrs=*/{Integer(buffer_index), Integer(buffer_index_type)},
+                                      /*attrs=*/{IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), static_cast<int>(buffer_index_type))},
                                       /*outputs=*/{result}));
   return result;
 }
@@ -471,7 +471,7 @@ SBlockRV TracedScheduleNode::ReadAt(const LoopRV& loop_rv, const SBlockRV& block
   static const InstructionKind& kind = InstructionKind::Get("ReadAt");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{loop_rv, block_rv},
-                                      /*attrs=*/{Integer(read_buffer_index), storage_scope},
+                                      /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
                                       /*outputs=*/{result}));
   return result;
 }
@@ -484,7 +484,7 @@ SBlockRV TracedScheduleNode::WriteAt(const LoopRV& loop_rv, const SBlockRV& bloc
   static const InstructionKind& kind = InstructionKind::Get("WriteAt");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{loop_rv, block_rv},
-                                      /*attrs=*/{Integer(write_buffer_index), storage_scope},
+                                      /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index), storage_scope},
                                       /*outputs=*/{result}));
   return result;
 }
@@ -499,7 +499,7 @@ void TracedScheduleNode::ComputeAt(const SBlockRV& block_rv, const LoopRV& loop_
   trace_->Append(
       /*inst=*/Instruction(/*kind=*/kind,
                            /*inputs=*/{block_rv, loop_rv},
-                           /*attrs=*/{Integer(preserve_unit_loops), Integer(index)},
+                           /*attrs=*/{IntImm(DataType::Int(32), preserve_unit_loops), IntImm(DataType::Int(32), index)},
                            /*outputs=*/{}));
 }
 
@@ -510,7 +510,7 @@ void TracedScheduleNode::ReverseComputeAt(const SBlockRV& block_rv, const LoopRV
   static const InstructionKind& kind = InstructionKind::Get("ReverseComputeAt");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{block_rv, loop_rv},
-                                      /*attrs=*/{Integer(preserve_unit_loops), Integer(index)},
+                                      /*attrs=*/{IntImm(DataType::Int(32), preserve_unit_loops), IntImm(DataType::Int(32), index)},
                                       /*outputs=*/{}));
 }
 
@@ -562,7 +562,7 @@ SBlockRV TracedScheduleNode::RFactor(const LoopRV& loop_rv, int factor_axis) {
   static const InstructionKind& kind = InstructionKind::Get("RFactor");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{loop_rv},
-                                      /*attrs=*/{Integer(factor_axis)},
+                                      /*attrs=*/{IntImm(DataType::Int(32), factor_axis)},
                                       /*outputs=*/{result}));
   return result;
 }
@@ -576,7 +576,7 @@ void TracedScheduleNode::StorageAlign(const SBlockRV& block_rv, int buffer_index
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{Integer(buffer_index), Integer(axis), Integer(factor), Integer(offset)},
+      /*attrs=*/{IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), axis), IntImm(DataType::Int(32), factor), IntImm(DataType::Int(32), offset)},
       /*outputs=*/{}));
 }
 
@@ -587,7 +587,7 @@ void TracedScheduleNode::SetScope(const SBlockRV& block_rv, int buffer_index,
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{Integer(buffer_index), storage_scope},
+      /*attrs=*/{IntImm(DataType::Int(32), buffer_index), storage_scope},
       /*outputs=*/{}));
 }
 
@@ -598,7 +598,7 @@ void TracedScheduleNode::UnsafeSetDType(const SBlockRV& block_rv, int buffer_ind
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{Integer(buffer_index), dtype},
+      /*attrs=*/{IntImm(DataType::Int(32), buffer_index), dtype},
       /*outputs=*/{}));
 }
 
@@ -610,7 +610,7 @@ SBlockRV TracedScheduleNode::Blockize(const LoopRV& loop_rv, bool preserve_unit_
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{loop_rv},
-      /*attrs=*/{Bool(preserve_unit_iters)},
+      /*attrs=*/{IntImm(DataType::Bool(), preserve_unit_iters)},
       /*outputs=*/{new_block}));
   return new_block;
 }
@@ -622,7 +622,7 @@ SBlockRV TracedScheduleNode::Blockize(const ffi::Array<SBlockRV>& blocks,
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{blocks},
-      /*attrs=*/{Bool(preserve_unit_iters)},
+      /*attrs=*/{IntImm(DataType::Bool(), preserve_unit_iters)},
       /*outputs=*/{new_block}));
   return new_block;
 }
@@ -634,7 +634,7 @@ void TracedScheduleNode::Tensorize(const LoopRV& loop_rv, const ffi::String& int
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{loop_rv},
-      /*attrs=*/{intrin, Bool(preserve_unit_iters)},
+      /*attrs=*/{intrin, IntImm(DataType::Bool(), preserve_unit_iters)},
       /*outputs=*/{}));
 }
 
@@ -645,7 +645,7 @@ void TracedScheduleNode::Tensorize(const SBlockRV& block_rv, const ffi::String& 
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{intrin, Bool(preserve_unit_iters)},
+      /*attrs=*/{intrin, IntImm(DataType::Bool(), preserve_unit_iters)},
       /*outputs=*/{}));
 }
 
@@ -704,8 +704,8 @@ void TracedScheduleNode::TransformLayout(const SBlockRV& block_rv, int buffer_in
           /*kind=*/kind,
           /*inputs=*/{block_rv, index_map},
           /*attrs=*/
-          {Integer(buffer_index), Integer(buffer_index_type), pad_value,
-           Bool(assume_injective_transform)},
+          {IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), pad_value,
+           IntImm(DataType::Bool(), assume_injective_transform)},
           /*outputs=*/{}));
 }
 
@@ -728,7 +728,7 @@ void TracedScheduleNode::SetAxisSeparator(const SBlockRV& block_rv, int buffer_i
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{Integer(buffer_index), Integer(buffer_index_type), axis_separators},
+      /*attrs=*/{IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), axis_separators},
       /*outputs=*/{}));
 }
 
@@ -762,7 +762,7 @@ void TracedScheduleNode::RollingBuffer(const SBlockRV& block_rv, int write_buffe
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{Integer(write_buffer_index)},
+      /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index)},
       /*outputs=*/{}));
 }
 
@@ -796,7 +796,7 @@ void TracedScheduleNode::AnnotateBufferAccess(const SBlockRV& block_rv, int buff
   static const InstructionKind& kind = InstructionKind::Get("AnnotateBufferAccess");
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
-      /*inputs=*/{block_rv, Integer(buffer_index), Integer(buffer_index_type), index_map},
+      /*inputs=*/{block_rv, IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), index_map},
       /*attrs=*/{},
       /*outputs=*/{}));
 }

--- a/src/s_tir/schedule/traced_schedule.cc
+++ b/src/s_tir/schedule/traced_schedule.cc
@@ -76,11 +76,13 @@ ffi::Array<ExprRV> TracedScheduleNode::SamplePerfectTile(
                                                max_innermost_factor, &decision),
                /*convert_negone_to_none=*/true);
   static const InstructionKind& kind = InstructionKind::Get("SamplePerfectTile");
-  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,  //
-                                      /*inputs=*/{loop_rv},
-                                      /*attrs=*/{IntImm(DataType::Int(32), n), IntImm(DataType::Int(32), max_innermost_factor)},
-                                      /*outputs=*/results),
-                 /*decision=*/decision);
+  trace_->Append(
+      /*inst=*/Instruction(
+          /*kind=*/kind,  //
+          /*inputs=*/{loop_rv},
+          /*attrs=*/{IntImm(DataType::Int(32), n), IntImm(DataType::Int(32), max_innermost_factor)},
+          /*outputs=*/results),
+      /*decision=*/decision);
   return results;
 }
 
@@ -94,7 +96,9 @@ ffi::Array<ExprRV> TracedScheduleNode::SamplePartitionedTile(
   trace_->Append(/*inst=*/Instruction(
                      /*kind=*/kind,  //
                      /*inputs=*/{loop_rv},
-                     /*attrs=*/{IntImm(DataType::Int(32), n), IntImm(DataType::Int(32), partition_pos), IntImm(DataType::Int(32), innerpart_factor)},
+                     /*attrs=*/
+                     {IntImm(DataType::Int(32), n), IntImm(DataType::Int(32), partition_pos),
+                      IntImm(DataType::Int(32), innerpart_factor)},
                      /*outputs=*/results),
                  /*decision=*/decision);
   return results;
@@ -362,10 +366,11 @@ SBlockRV TracedScheduleNode::CacheRead(const SBlockRV& block_rv, int read_buffer
       ConcreteScheduleNode::CacheRead(block_rv, read_buffer_index, storage_scope, consumer_blocks);
 
   static const InstructionKind& kind = InstructionKind::Get("CacheRead");
-  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
-                                      /*inputs=*/{block_rv, consumer_blocks},
-                                      /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
-                                      /*outputs=*/{result}));
+  trace_->Append(
+      /*inst=*/Instruction(/*kind=*/kind,
+                           /*inputs=*/{block_rv, consumer_blocks},
+                           /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
+                           /*outputs=*/{result}));
   return result;
 }
 
@@ -376,10 +381,11 @@ SBlockRV TracedScheduleNode::CacheWrite(const SBlockRV& block_rv, int write_buff
                                                      consumer_blocks);
 
   static const InstructionKind& kind = InstructionKind::Get("CacheWrite");
-  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
-                                      /*inputs=*/{block_rv, consumer_blocks},
-                                      /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index), storage_scope},
-                                      /*outputs=*/{result}));
+  trace_->Append(
+      /*inst=*/Instruction(/*kind=*/kind,
+                           /*inputs=*/{block_rv, consumer_blocks},
+                           /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index), storage_scope},
+                           /*outputs=*/{result}));
   return result;
 }
 
@@ -425,10 +431,11 @@ ffi::Array<SBlockRV> TracedScheduleNode::CacheInplace(const SBlockRV& block_rv,
     results.push_back(r);
   }
   static const InstructionKind& kind = InstructionKind::Get("CacheInplace");
-  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
-                                      /*inputs=*/{block_rv},
-                                      /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
-                                      /*outputs=*/results));
+  trace_->Append(
+      /*inst=*/Instruction(/*kind=*/kind,
+                           /*inputs=*/{block_rv},
+                           /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
+                           /*outputs=*/results));
   return result;
 }
 
@@ -442,10 +449,11 @@ ffi::Array<SBlockRV> TracedScheduleNode::CacheIndex(const SBlockRV& block_rv,
     outputs.push_back(r);
   }
   static const InstructionKind& kind = InstructionKind::Get("CacheIndex");
-  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
-                                      /*inputs=*/{block_rv},
-                                      /*attrs=*/{storage_scope, IntImm(DataType::Int(32), cse_thresh)},
-                                      /*outputs=*/outputs));
+  trace_->Append(
+      /*inst=*/Instruction(/*kind=*/kind,
+                           /*inputs=*/{block_rv},
+                           /*attrs=*/{storage_scope, IntImm(DataType::Int(32), cse_thresh)},
+                           /*outputs=*/outputs));
   return result;
 }
 
@@ -454,10 +462,13 @@ SBlockRV TracedScheduleNode::ReIndex(const SBlockRV& block_rv, int buffer_index,
   SBlockRV result = ConcreteScheduleNode::ReIndex(block_rv, buffer_index, buffer_index_type);
 
   static const InstructionKind& kind = InstructionKind::Get("ReIndex");
-  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
-                                      /*inputs=*/{block_rv},
-                                      /*attrs=*/{IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), static_cast<int>(buffer_index_type))},
-                                      /*outputs=*/{result}));
+  trace_->Append(
+      /*inst=*/Instruction(/*kind=*/kind,
+                           /*inputs=*/{block_rv},
+                           /*attrs=*/
+                           {IntImm(DataType::Int(32), buffer_index),
+                            IntImm(DataType::Int(32), static_cast<int>(buffer_index_type))},
+                           /*outputs=*/{result}));
   return result;
 }
 
@@ -469,10 +480,11 @@ SBlockRV TracedScheduleNode::ReadAt(const LoopRV& loop_rv, const SBlockRV& block
       ConcreteScheduleNode::ReadAt(loop_rv, block_rv, read_buffer_index, storage_scope);
 
   static const InstructionKind& kind = InstructionKind::Get("ReadAt");
-  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
-                                      /*inputs=*/{loop_rv, block_rv},
-                                      /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
-                                      /*outputs=*/{result}));
+  trace_->Append(
+      /*inst=*/Instruction(/*kind=*/kind,
+                           /*inputs=*/{loop_rv, block_rv},
+                           /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
+                           /*outputs=*/{result}));
   return result;
 }
 
@@ -482,10 +494,11 @@ SBlockRV TracedScheduleNode::WriteAt(const LoopRV& loop_rv, const SBlockRV& bloc
       ConcreteScheduleNode::WriteAt(loop_rv, block_rv, write_buffer_index, storage_scope);
 
   static const InstructionKind& kind = InstructionKind::Get("WriteAt");
-  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
-                                      /*inputs=*/{loop_rv, block_rv},
-                                      /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index), storage_scope},
-                                      /*outputs=*/{result}));
+  trace_->Append(
+      /*inst=*/Instruction(/*kind=*/kind,
+                           /*inputs=*/{loop_rv, block_rv},
+                           /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index), storage_scope},
+                           /*outputs=*/{result}));
   return result;
 }
 
@@ -497,10 +510,12 @@ void TracedScheduleNode::ComputeAt(const SBlockRV& block_rv, const LoopRV& loop_
 
   static const InstructionKind& kind = InstructionKind::Get("ComputeAt");
   trace_->Append(
-      /*inst=*/Instruction(/*kind=*/kind,
-                           /*inputs=*/{block_rv, loop_rv},
-                           /*attrs=*/{IntImm(DataType::Int(32), preserve_unit_loops), IntImm(DataType::Int(32), index)},
-                           /*outputs=*/{}));
+      /*inst=*/Instruction(
+          /*kind=*/kind,
+          /*inputs=*/{block_rv, loop_rv},
+          /*attrs=*/
+          {IntImm(DataType::Int(32), preserve_unit_loops), IntImm(DataType::Int(32), index)},
+          /*outputs=*/{}));
 }
 
 void TracedScheduleNode::ReverseComputeAt(const SBlockRV& block_rv, const LoopRV& loop_rv,
@@ -508,10 +523,11 @@ void TracedScheduleNode::ReverseComputeAt(const SBlockRV& block_rv, const LoopRV
   ConcreteScheduleNode::ReverseComputeAt(block_rv, loop_rv, preserve_unit_loops, index);
 
   static const InstructionKind& kind = InstructionKind::Get("ReverseComputeAt");
-  trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
-                                      /*inputs=*/{block_rv, loop_rv},
-                                      /*attrs=*/{IntImm(DataType::Int(32), preserve_unit_loops), IntImm(DataType::Int(32), index)},
-                                      /*outputs=*/{}));
+  trace_->Append(/*inst=*/Instruction(
+      /*kind=*/kind,
+      /*inputs=*/{block_rv, loop_rv},
+      /*attrs=*/{IntImm(DataType::Int(32), preserve_unit_loops), IntImm(DataType::Int(32), index)},
+      /*outputs=*/{}));
 }
 
 void TracedScheduleNode::ComputeInline(const SBlockRV& block_rv) {
@@ -576,7 +592,9 @@ void TracedScheduleNode::StorageAlign(const SBlockRV& block_rv, int buffer_index
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), axis), IntImm(DataType::Int(32), factor), IntImm(DataType::Int(32), offset)},
+      /*attrs=*/
+      {IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), axis),
+       IntImm(DataType::Int(32), factor), IntImm(DataType::Int(32), offset)},
       /*outputs=*/{}));
 }
 
@@ -704,7 +722,8 @@ void TracedScheduleNode::TransformLayout(const SBlockRV& block_rv, int buffer_in
           /*kind=*/kind,
           /*inputs=*/{block_rv, index_map},
           /*attrs=*/
-          {IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), pad_value,
+          {IntImm(DataType::Int(32), buffer_index),
+           IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), pad_value,
            IntImm(DataType::Bool(), assume_injective_transform)},
           /*outputs=*/{}));
 }
@@ -728,7 +747,9 @@ void TracedScheduleNode::SetAxisSeparator(const SBlockRV& block_rv, int buffer_i
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), axis_separators},
+      /*attrs=*/
+      {IntImm(DataType::Int(32), buffer_index),
+       IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), axis_separators},
       /*outputs=*/{}));
 }
 
@@ -796,7 +817,9 @@ void TracedScheduleNode::AnnotateBufferAccess(const SBlockRV& block_rv, int buff
   static const InstructionKind& kind = InstructionKind::Get("AnnotateBufferAccess");
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
-      /*inputs=*/{block_rv, IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), index_map},
+      /*inputs=*/
+      {block_rv, IntImm(DataType::Int(32), buffer_index),
+       IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), index_map},
       /*attrs=*/{},
       /*outputs=*/{}));
 }

--- a/src/s_tir/schedule/transform.cc
+++ b/src/s_tir/schedule/transform.cc
@@ -407,7 +407,7 @@ ffi::Optional<LoopRV> TileWithTensorIntrin(const s_tir::Schedule& sch,
     // Do the split. Leave the outer extent as std::nullopt (unspecified) so that the split factors
     // can be used for different extents (needed during tuning).
     ffi::Array<LoopRV> split =
-        sch->Split(loop2rv.at(block_loop_sref), {std::nullopt, Integer(inner)});
+        sch->Split(loop2rv.at(block_loop_sref), {std::nullopt, IntImm(DataType::Int(32), inner)});
     TVM_FFI_ICHECK_EQ(split.size(), 2);
     inner_loops.insert(sch->GetSRef(split[1]).operator->());
     // The inner split will be reordered to the loop domain that is tensorized
@@ -549,7 +549,7 @@ ffi::Optional<ffi::ObjectRef> NormalizePrimFunc(Schedule sch) {
     bool is_reduction = IsReductionBlock(sch->state(),         //
                                          sch->GetSRef(block),  //
                                          sch->GetSRef(root_block));
-    block_is_reduction.push_back(Bool(is_reduction));
+    block_is_reduction.push_back(IntImm(DataType::Bool(), is_reduction));
   }
   return ffi::Array<ffi::ObjectRef>{leaf_blocks, block_loops, block_iters, block_is_reduction};
 }

--- a/src/s_tir/support/nd_int_set.h
+++ b/src/s_tir/support/nd_int_set.h
@@ -51,7 +51,7 @@ inline NDIntSet NDIntSetFromRegion(const tirx::Region& region) {
  * \return The constructed set.
  */
 inline NDIntSet NDIntSetFromShape(const ffi::Array<PrimExpr>& shape) {
-  PrimExpr zero = Integer(0);
+  PrimExpr zero = IntImm(DataType::Int(32), 0);
   NDIntSet result;
   result.reserve(shape.size());
   for (const PrimExpr& extent : shape) {

--- a/src/s_tir/transform/default_gpu_schedule.cc
+++ b/src/s_tir/transform/default_gpu_schedule.cc
@@ -70,15 +70,17 @@ void ThreadBind(s_tir::Schedule sch, const s_tir::SBlockRV& block, int64_t max_t
   }
   // schedule the fused loop
   if (product > max_thread_per_block * max_threadblocks) {
-    ffi::Array<s_tir::LoopRV> splits = sch->Split(
-        fused,
-        /*factors=*/{std::nullopt, IntImm(DataType::Int(32), max_threadblocks), IntImm(DataType::Int(32), max_thread_per_block)});
+    ffi::Array<s_tir::LoopRV> splits =
+        sch->Split(fused,
+                   /*factors=*/{std::nullopt, IntImm(DataType::Int(32), max_threadblocks),
+                                IntImm(DataType::Int(32), max_thread_per_block)});
     sch->Reorder(/*ordered_loop_rvs=*/{splits[1], splits[2], splits[0]});
     sch->Bind(splits[1], "blockIdx.x");
     sch->Bind(splits[2], "threadIdx.x");
   } else {
     ffi::Array<s_tir::LoopRV> splits = sch->Split(
-        fused, /*factors=*/{std::nullopt, IntImm(DataType::Int(32), std::min(product, max_thread_per_block))});
+        fused, /*factors=*/{std::nullopt,
+                            IntImm(DataType::Int(32), std::min(product, max_thread_per_block))});
     sch->Bind(splits[0], "blockIdx.x");
     sch->Bind(splits[1], "threadIdx.x");
   }

--- a/src/s_tir/transform/default_gpu_schedule.cc
+++ b/src/s_tir/transform/default_gpu_schedule.cc
@@ -72,13 +72,13 @@ void ThreadBind(s_tir::Schedule sch, const s_tir::SBlockRV& block, int64_t max_t
   if (product > max_thread_per_block * max_threadblocks) {
     ffi::Array<s_tir::LoopRV> splits = sch->Split(
         fused,
-        /*factors=*/{std::nullopt, Integer(max_threadblocks), Integer(max_thread_per_block)});
+        /*factors=*/{std::nullopt, IntImm(DataType::Int(32), max_threadblocks), IntImm(DataType::Int(32), max_thread_per_block)});
     sch->Reorder(/*ordered_loop_rvs=*/{splits[1], splits[2], splits[0]});
     sch->Bind(splits[1], "blockIdx.x");
     sch->Bind(splits[2], "threadIdx.x");
   } else {
     ffi::Array<s_tir::LoopRV> splits = sch->Split(
-        fused, /*factors=*/{std::nullopt, Integer(std::min(product, max_thread_per_block))});
+        fused, /*factors=*/{std::nullopt, IntImm(DataType::Int(32), std::min(product, max_thread_per_block))});
     sch->Bind(splits[0], "blockIdx.x");
     sch->Bind(splits[1], "threadIdx.x");
   }
@@ -146,7 +146,7 @@ tirx::PrimFunc WrapBareSBlockBody(const tirx::PrimFunc& func) {
                           /*writes=*/ffi::Array<tirx::BufferRegion>{},
                           /*name_hint=*/"root", /*body=*/for_stmt);
   tirx::SBlockRealize root_realize(/*iter_values=*/ffi::Array<tvm::PrimExpr>{},
-                                   /*predicate=*/tvm::Bool(true), root_block);
+                                   /*predicate=*/const_true(), root_block);
   tirx::PrimFunc result = func;
   result.CopyOnWrite()->body = std::move(root_realize);
   return result;

--- a/src/s_tir/transform/inject_software_pipeline.cc
+++ b/src/s_tir/transform/inject_software_pipeline.cc
@@ -1218,7 +1218,7 @@ class PipelineInjector : private StmtExprMutator {
 
     auto it = op->annotations.find(s_tir::attr::double_buffer_scope);
     if (it != op->annotations.end()) {
-      int buffer_index = Downcast<Integer>((*it).second).IntValue();
+      int buffer_index = static_cast<int>(Downcast<IntImm>((*it).second)->value);
       TVM_FFI_CHECK(buffer_index >= 0 && static_cast<size_t>(buffer_index) < op->writes.size(),
                     ValueError)
           << "Index of the buffer exceeds the size of the write regions of the block. ("

--- a/src/s_tir/transform/inject_software_pipeline.cc
+++ b/src/s_tir/transform/inject_software_pipeline.cc
@@ -246,7 +246,7 @@ class PipelineBodyRewriter : public StmtExprMutator {
               ? Range::FromMinExtent(0, new_buffer->shape[0])
               : Range::FromMinExtent(floormod((pipeline_loop_->loop_var - pipeline_loop_->min),
                                               new_buffer->shape[0]),
-                                     Integer(1));
+                                     IntImm(DataType::Int(32), 1));
       new_region.insert(new_region.begin(), accessed_version);
       return BufferRegion(new_buffer, new_region);
     }
@@ -397,7 +397,7 @@ class PipelineRewriter : public StmtExprMutator {
     }
     SBlock block = MakeSBlock(stmt, buffer_data_to_buffer_);
     block.CopyOnWrite()->alloc_buffers = std::move(alloc_buffers);
-    return SBlockRealize({}, Bool(true), block);
+    return SBlockRealize({}, const_true(), block);
   }
 
  private:
@@ -824,7 +824,7 @@ class PipelineRewriter : public StmtExprMutator {
     PrimExpr new_loop_var;
     PrimExpr extent = end - start;
 
-    auto make_nop = []() { return SBlockRealize({}, Bool(true), MakeSBlock(Evaluate(0), {})); };
+    auto make_nop = []() { return SBlockRealize({}, const_true(), MakeSBlock(Evaluate(0), {})); };
 
     if (analyzer_.CanProve(extent <= 0)) {
       return make_nop();
@@ -970,7 +970,7 @@ class PipelineRewriter : public StmtExprMutator {
       }
     }
 
-    return SBlockRealize({}, Bool(true), MakeSBlock(std::move(new_loop), buffer_data_to_buffer_));
+    return SBlockRealize({}, const_true(), MakeSBlock(std::move(new_loop), buffer_data_to_buffer_));
   }
 
   arith::Analyzer analyzer_;

--- a/src/s_tir/transform/lower_cross_thread_reduction.cc
+++ b/src/s_tir/transform/lower_cross_thread_reduction.cc
@@ -149,8 +149,8 @@ ffi::Array<Buffer> MakeScratchpads(const ffi::Array<Buffer>& reduction_buffers,
     name = name + "_thread_" + buffer->name;
     new_buffers.push_back(Buffer(/*ptr=*/Var(name, PointerType(PrimType(buffer->dtype), "local")),
                                  /*dtype=*/buffer->dtype,
-                                 /*shape=*/{Integer(1)},
-                                 /*strides=*/{Integer(1)},
+                                 /*shape=*/{IntImm(DataType::Int(32), 1)},
+                                 /*strides=*/{IntImm(DataType::Int(32), 1)},
                                  /*elem_offset=*/PrimExpr{nullptr},
                                  /*name=*/name,
                                  /*data_alignment=*/0,
@@ -336,7 +336,7 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
     inits.reserve(n_buffers);
     for (int i = 0; i < n_buffers; ++i) {
       inits.push_back(
-          BufferStore(it_buffers.value()[i], reducer->identity_element[i], {Integer(0)}));
+          BufferStore(it_buffers.value()[i], reducer->identity_element[i], {IntImm(DataType::Int(32), 0)}));
     }
     stmts.push_back(SBlockRealize(/*iter_values=*/{},
                                   /*predicate=*/const_true(),
@@ -380,7 +380,7 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
     // Next `n_buffers` arguments: sources
     if (it_buffers.defined()) {
       for (int i = 0; i < n_buffers; ++i) {
-        parameters.push_back(BufferLoad(it_buffers.value()[i], {Integer(0)}));
+        parameters.push_back(BufferLoad(it_buffers.value()[i], {IntImm(DataType::Int(32), 0)}));
       }
     } else {
       parameters.insert(parameters.end(), combiner_rhs.begin(), combiner_rhs.end());
@@ -465,7 +465,7 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
     }
     for (int i = 0; i < n_buffers; ++i) {
       wb_updates.push_back(
-          BufferStore(wb_buffers[i], BufferLoad(ct_buffers[i], {Integer(0)}), wb_indices));
+          BufferStore(wb_buffers[i], BufferLoad(ct_buffers[i], {IntImm(DataType::Int(32), 0)}), wb_indices));
       wb_regions.push_back(BufferRegion(wb_buffers[i], region));
     }
 

--- a/src/s_tir/transform/lower_cross_thread_reduction.cc
+++ b/src/s_tir/transform/lower_cross_thread_reduction.cc
@@ -335,8 +335,8 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
     ffi::Array<Stmt> inits;
     inits.reserve(n_buffers);
     for (int i = 0; i < n_buffers; ++i) {
-      inits.push_back(
-          BufferStore(it_buffers.value()[i], reducer->identity_element[i], {IntImm(DataType::Int(32), 0)}));
+      inits.push_back(BufferStore(it_buffers.value()[i], reducer->identity_element[i],
+                                  {IntImm(DataType::Int(32), 0)}));
     }
     stmts.push_back(SBlockRealize(/*iter_values=*/{},
                                   /*predicate=*/const_true(),
@@ -464,8 +464,8 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
       wb_indices.push_back(Substitute(old_wb_indices[d], var_map));
     }
     for (int i = 0; i < n_buffers; ++i) {
-      wb_updates.push_back(
-          BufferStore(wb_buffers[i], BufferLoad(ct_buffers[i], {IntImm(DataType::Int(32), 0)}), wb_indices));
+      wb_updates.push_back(BufferStore(
+          wb_buffers[i], BufferLoad(ct_buffers[i], {IntImm(DataType::Int(32), 0)}), wb_indices));
       wb_regions.push_back(BufferRegion(wb_buffers[i], region));
     }
 

--- a/src/s_tir/transform/lower_opaque_block.cc
+++ b/src/s_tir/transform/lower_opaque_block.cc
@@ -80,7 +80,7 @@ class OpaqueBlockLower : public StmtExprMutator {
     std::vector<std::pair<std::string, PrimExpr>> pragma_attrs;
     HandleAnnotations(new_block->annotations, &pragma_attrs, /*is_block=*/true);
     for (auto it = pragma_attrs.rbegin(); it != pragma_attrs.rend(); ++it) {
-      body = AttrStmt(Integer(0), it->first, it->second, std::move(body));
+      body = AttrStmt(IntImm(DataType::Int(32), 0), it->first, it->second, std::move(body));
     }
     return body;
   }

--- a/src/s_tir/transform/memhammer_coalesce.cc
+++ b/src/s_tir/transform/memhammer_coalesce.cc
@@ -67,7 +67,7 @@ Stmt FuseNestLoops(Stmt body) {
  */
 Stmt SplitBindVectorize(const Stmt& stmt, const ConstraintSet& constraints) {
   const ForNode* loop = TVM_TYPE_AS(stmt, ForNode);
-  int loop_extent = Downcast<Integer>(loop->extent)->value;
+  int loop_extent = Downcast<IntImm>(loop->extent)->value;
   int vector_bytes = constraints.vector_bytes;
   int data_bits = constraints.data_bits;
   int vector_len = std::max(1, vector_bytes * 8 / data_bits);

--- a/src/s_tir/transform/memhammer_coalesce.cc
+++ b/src/s_tir/transform/memhammer_coalesce.cc
@@ -191,7 +191,7 @@ Stmt InverseMapping::Rewrite(const Stmt& stmt, const ConstraintSet& constraints,
   arith::Analyzer analyzer;
   DiagnosticContext diag_ctx(DiagnosticContext::Default(IRModule()));
   auto iter_map =
-      arith::DetectIterMap(mapping_pattern, var_range, Bool(true), arith::Bijective, &analyzer);
+      arith::DetectIterMap(mapping_pattern, var_range, const_true(), arith::Bijective, &analyzer);
   TVM_FFI_ICHECK_EQ(iter_map->indices.size(), loop_vars.size());
   ffi::Map<Var, PrimExpr> inverse_mapping =
       arith::InverseAffineIterMap(iter_map->indices, loop_vars);

--- a/src/s_tir/transform/memhammer_intermediate_stage.cc
+++ b/src/s_tir/transform/memhammer_intermediate_stage.cc
@@ -131,7 +131,7 @@ class IndexPatternFinder : public ExprVisitor {
         switch (o.kind) {
           case Operator::OpKind::Mul:
             max *= o.operand;
-            index = index * Integer(o.operand);
+            index = index * IntImm(DataType::Int(32), o.operand);
             break;
           case Operator::OpKind::FloorDiv:
             if (max % o.operand != 0 && o.operand % max != 0) {
@@ -146,7 +146,7 @@ class IndexPatternFinder : public ExprVisitor {
               success_ = false;
               return;
             }
-            index = floordiv(index, Integer(o.operand));
+            index = floordiv(index, IntImm(DataType::Int(32), o.operand));
             break;
           case Operator::OpKind::FloorMod:
             int64_t step = max / extent;
@@ -161,12 +161,12 @@ class IndexPatternFinder : public ExprVisitor {
               extent = std::max(static_cast<int64_t>(1), std::min(extent, o.operand / step));
               max = extent * step;
             }
-            index = floormod(index, Integer(o.operand));
+            index = floormod(index, IntImm(DataType::Int(32), o.operand));
         }
       }
       if (extent > 1) {
         TVM_FFI_ICHECK(max % extent == 0);
-        access_shape_.push_back(Integer(extent));
+        access_shape_.push_back(IntImm(DataType::Int(32), extent));
         resulting_index_->push_back(floordiv(index, max / extent));
       }
     }

--- a/src/s_tir/transform/memhammer_lower_auto_copy.cc
+++ b/src/s_tir/transform/memhammer_lower_auto_copy.cc
@@ -484,9 +484,9 @@ class AutoPadder {
       if (op->kind != ForKind::kThreadBinding) {
         substitute_map_.Set(op->loop_var, op->min);
       } else {
-        Integer extent =
+        int64_t extent =
             warp_thread_extent_.Get(op->thread_binding.value()->thread_tag).value_or(1);
-        var_range_.Set(op->loop_var, Range::FromMinExtent(op->min, extent));
+        var_range_.Set(op->loop_var, Range::FromMinExtent(op->min, IntImm(DataType::Int(64), extent)));
       }
       if (op->kind == ForKind::kVectorized) {
         vector_var = op->loop_var;

--- a/src/s_tir/transform/memhammer_lower_auto_copy.cc
+++ b/src/s_tir/transform/memhammer_lower_auto_copy.cc
@@ -486,7 +486,8 @@ class AutoPadder {
       } else {
         int64_t extent =
             warp_thread_extent_.Get(op->thread_binding.value()->thread_tag).value_or(1);
-        var_range_.Set(op->loop_var, Range::FromMinExtent(op->min, IntImm(DataType::Int(64), extent)));
+        var_range_.Set(op->loop_var,
+                       Range::FromMinExtent(op->min, IntImm(DataType::Int(64), extent)));
       }
       if (op->kind == ForKind::kVectorized) {
         vector_var = op->loop_var;

--- a/src/s_tir/transform/memhammer_lower_auto_copy.cc
+++ b/src/s_tir/transform/memhammer_lower_auto_copy.cc
@@ -464,14 +464,14 @@ class AutoPadder {
     bool CheckVarContiguous(PrimExpr e, Var var, const ffi::Map<Var, PrimExpr>& subst_map) {
       PrimExpr e1 = Substitute(e, [var](const Var& v) -> ffi::Optional<PrimExpr> {
         if (v.same_as(var)) {
-          return Integer(0);
+          return IntImm(DataType::Int(32), 0);
         } else {
           return v;
         }
       });
       PrimExpr e2 = Substitute(e, [var](const Var& v) -> ffi::Optional<PrimExpr> {
         if (v.same_as(var)) {
-          return Integer(1);
+          return IntImm(DataType::Int(32), 1);
         } else {
           return v;
         }

--- a/src/s_tir/transform/memhammer_rewrite_rule.h
+++ b/src/s_tir/transform/memhammer_rewrite_rule.h
@@ -64,10 +64,10 @@ struct ConstraintSet {
         write_region(write_region),
         data_bits(data_bits) {
     if (auto add_local_stage = ann.Get("local_stage")) {
-      this->add_local_stage = Downcast<Integer>(add_local_stage.value())->value;
+      this->add_local_stage = Downcast<IntImm>(add_local_stage.value())->value;
     }
     if (auto vector_bytes = ann.Get("vector_bytes")) {
-      this->vector_bytes = Downcast<Integer>(vector_bytes.value())->value;
+      this->vector_bytes = Downcast<IntImm>(vector_bytes.value())->value;
     }
   }
 };

--- a/src/s_tir/transform/memhammer_tensorcore_rewrite.cc
+++ b/src/s_tir/transform/memhammer_tensorcore_rewrite.cc
@@ -129,7 +129,7 @@ Stmt RewriteWmmaLoad(Stmt stmt) {
   Buffer new_src_buffer(
       /*data=*/Var("src", PointerType(PrimType(dtype), src_buffer.scope())),
       /*dtype=*/dtype,
-      /*shape=*/{Integer(16), Integer(16)},
+      /*shape=*/{IntImm(DataType::Int(32), 16), IntImm(DataType::Int(32), 16)},
       /*strides=*/{Var("s1", int32), Var("s0", int32)},
       /*elem_offset=*/Var("src_elem_offset", int32),
       /*name=*/"src",
@@ -139,7 +139,7 @@ Stmt RewriteWmmaLoad(Stmt stmt) {
   Buffer new_tgt_buffer(
       /*data=*/Var("tgt", PointerType(PrimType(dtype), tgt_buffer.scope())),
       /*dtype=*/dtype,
-      /*shape=*/{Integer(16), Integer(16)},
+      /*shape=*/{IntImm(DataType::Int(32), 16), IntImm(DataType::Int(32), 16)},
       /*strides=*/{},
       /*elem_offset=*/Var("tgt_elem_offset", int32),
       /*name=*/"tgt",
@@ -150,7 +150,7 @@ Stmt RewriteWmmaLoad(Stmt stmt) {
   ffi::Array<Range> write_region = RelaxIndices(buf_store->indices, tgt_buffer->shape, var_dom);
   Stmt wmma_body = SBlockRealize(
       /*iter_values=*/{},
-      /*predicate=*/Bool(true),
+      /*predicate=*/const_true(),
       SBlock(
           /*iter_vars=*/{},
           /*reads=*/{BufferRegion(src_buffer, read_region)},
@@ -238,7 +238,7 @@ Stmt RewriteWmmaStore(Stmt stmt) {
 
   Buffer new_src_buffer(/*data=*/Var("src", PointerType(PrimType(dtype), src_buffer.scope())),
                         /*dtype=*/dtype,
-                        /*shape=*/{Integer(16), Integer(16)},
+                        /*shape=*/{IntImm(DataType::Int(32), 16), IntImm(DataType::Int(32), 16)},
                         /*strides=*/{},
                         /*elem_offset=*/Var("src_elem_offset", int32),
                         /*name=*/"src",
@@ -247,7 +247,7 @@ Stmt RewriteWmmaStore(Stmt stmt) {
                         /*buffer_type=*/kDefault);
   Buffer new_tgt_buffer(/*data=*/Var("tgt", PointerType(PrimType(dtype), tgt_buffer.scope())),
                         /*dtype=*/dtype,
-                        /*shape=*/{Integer(16), Integer(16)},
+                        /*shape=*/{IntImm(DataType::Int(32), 16), IntImm(DataType::Int(32), 16)},
                         /*strides=*/{Var("s1", int32), Var("s0", int32)},
                         /*elem_offset=*/Var("tgt_elem_offset", int32),
                         /*name=*/"tgt",
@@ -259,7 +259,7 @@ Stmt RewriteWmmaStore(Stmt stmt) {
   ffi::Array<Range> write_region = RelaxIndices(buf_store->indices, tgt_buffer->shape, var_dom);
   Stmt wmma_body = SBlockRealize(
       /*iter_values=*/{},  //
-      /*predicate=*/Bool(true),
+      /*predicate=*/const_true(),
       SBlock(/*iter_vars=*/{},
              /*reads=*/{BufferRegion(src_buffer, read_region)},
              /*writes=*/{BufferRegion(tgt_buffer, write_region)},
@@ -458,7 +458,7 @@ Stmt RewriteMmaStore(Stmt stmt) {
   const DataType dtype = src_buffer->dtype;
   Buffer new_src_buffer(/*data=*/Var("src", PointerType(PrimType(dtype), src_buffer.scope())),
                         /*dtype=*/dtype,
-                        /*shape=*/{Integer(8), Integer(8)},
+                        /*shape=*/{IntImm(DataType::Int(32), 8), IntImm(DataType::Int(32), 8)},
                         /*strides=*/{},
                         /*elem_offset=*/Var("src_elem_offset", int32),
                         /*name=*/"src",
@@ -467,7 +467,7 @@ Stmt RewriteMmaStore(Stmt stmt) {
                         /*buffer_type=*/kDefault);
   Buffer new_tgt_buffer(/*data=*/Var("tgt", PointerType(PrimType(dtype), tgt_buffer.scope())),
                         /*dtype=*/dtype,
-                        /*shape=*/{Integer(8), Integer(8)},
+                        /*shape=*/{IntImm(DataType::Int(32), 8), IntImm(DataType::Int(32), 8)},
                         /*strides=*/{Var("s1", int32), Var("s0", int32)},
                         /*elem_offset=*/Var("tgt_elem_offset", int32),
                         /*name=*/"tgt",
@@ -486,7 +486,7 @@ Stmt RewriteMmaStore(Stmt stmt) {
   Var vec = Var("vec");
   Stmt mma_body = SBlockRealize(
       /*iter_values=*/{},  //
-      /*predicate=*/Bool(true),
+      /*predicate=*/const_true(),
       SBlock(/*iter_vars=*/{},
              /*reads=*/{BufferRegion(src_buffer, read_region)},
              /*writes=*/{BufferRegion(tgt_buffer, write_region)},
@@ -498,7 +498,7 @@ Stmt RewriteMmaStore(Stmt stmt) {
                      /*iter_type=*/IterVarType::kThreadIndex,
                      /*thread_tag=*/"threadIdx.x"),
                  /*attr_key=*/"thread_extent",
-                 /*value=*/Integer(32),
+                 /*value=*/IntImm(DataType::Int(32), 32),
                  /*body=*/
                  For(vec, 0, 2, ForKind::kVectorized,
                      /*body=*/

--- a/src/s_tir/transform/plan_update_buffer_allocation_location.cc
+++ b/src/s_tir/transform/plan_update_buffer_allocation_location.cc
@@ -216,7 +216,7 @@ class BufferAllocationLocator : public StmtExprMutator {
         GetSBlockReadWriteRegion(opaque_block, buffer_data_to_buffer_);
     n->reads = access[0];
     n->writes = access[1];
-    SBlockRealize realize({}, Bool(true), SBlock(n));
+    SBlockRealize realize({}, const_true(), SBlock(n));
     return realize;
   }
 

--- a/src/s_tir/transform/transform_mma_buffer_layout.cc
+++ b/src/s_tir/transform/transform_mma_buffer_layout.cc
@@ -68,7 +68,7 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
           new_shape.push_back(buffer->shape[i]);
         }
         new_shape.insert(new_shape.end(),
-                         {Integer(dim0->value / 16), Integer(dim1->value / 8), 2, 2});
+                         {IntImm(DataType::Int(32), dim0->value / 16), IntImm(DataType::Int(32), dim1->value / 8), 2, 2});
 
         Buffer new_buffer = decl_buffer(std::move(new_shape), buffer->dtype, buffer->name, "local",
                                         buffer->axis_separators);
@@ -90,7 +90,7 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
           new_shape.push_back(buffer->shape[i]);
         }
         new_shape.insert(new_shape.end(),
-                         {Integer(dim0->value / 32), Integer(dim1->value / 8), 4, 2});
+                         {IntImm(DataType::Int(32), dim0->value / 32), IntImm(DataType::Int(32), dim1->value / 8), 4, 2});
 
         Buffer new_buffer = decl_buffer(std::move(new_shape), buffer->dtype, buffer->name, "local",
                                         buffer->axis_separators);
@@ -112,7 +112,7 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
           new_shape.push_back(buffer->shape[i]);
         }
         new_shape.insert(new_shape.end(),
-                         {Integer(dim0->value / 8), Integer(dim1->value / 32), 1, 8});
+                         {IntImm(DataType::Int(32), dim0->value / 8), IntImm(DataType::Int(32), dim1->value / 32), 1, 8});
 
         Buffer new_buffer = decl_buffer(std::move(new_shape), buffer->dtype, buffer->name, "local",
                                         buffer->axis_separators);

--- a/src/s_tir/transform/transform_mma_buffer_layout.cc
+++ b/src/s_tir/transform/transform_mma_buffer_layout.cc
@@ -67,8 +67,8 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
         for (size_t i = 0; i < size - 2; ++i) {
           new_shape.push_back(buffer->shape[i]);
         }
-        new_shape.insert(new_shape.end(),
-                         {IntImm(DataType::Int(32), dim0->value / 16), IntImm(DataType::Int(32), dim1->value / 8), 2, 2});
+        new_shape.insert(new_shape.end(), {IntImm(DataType::Int(32), dim0->value / 16),
+                                           IntImm(DataType::Int(32), dim1->value / 8), 2, 2});
 
         Buffer new_buffer = decl_buffer(std::move(new_shape), buffer->dtype, buffer->name, "local",
                                         buffer->axis_separators);
@@ -89,8 +89,8 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
         for (size_t i = 0; i < size - 2; ++i) {
           new_shape.push_back(buffer->shape[i]);
         }
-        new_shape.insert(new_shape.end(),
-                         {IntImm(DataType::Int(32), dim0->value / 32), IntImm(DataType::Int(32), dim1->value / 8), 4, 2});
+        new_shape.insert(new_shape.end(), {IntImm(DataType::Int(32), dim0->value / 32),
+                                           IntImm(DataType::Int(32), dim1->value / 8), 4, 2});
 
         Buffer new_buffer = decl_buffer(std::move(new_shape), buffer->dtype, buffer->name, "local",
                                         buffer->axis_separators);
@@ -111,8 +111,8 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
         for (size_t i = 0; i < size - 2; ++i) {
           new_shape.push_back(buffer->shape[i]);
         }
-        new_shape.insert(new_shape.end(),
-                         {IntImm(DataType::Int(32), dim0->value / 8), IntImm(DataType::Int(32), dim1->value / 32), 1, 8});
+        new_shape.insert(new_shape.end(), {IntImm(DataType::Int(32), dim0->value / 8),
+                                           IntImm(DataType::Int(32), dim1->value / 32), 1, 8});
 
         Buffer new_buffer = decl_buffer(std::move(new_shape), buffer->dtype, buffer->name, "local",
                                         buffer->axis_separators);

--- a/src/s_tir/transform/using_assume_to_reduce_branches.cc
+++ b/src/s_tir/transform/using_assume_to_reduce_branches.cc
@@ -177,7 +177,7 @@ class ParseAssumeAndOvercompute : public IRMutatorWithAnalyzer {
 
   PrimExpr CurrentScopePredicate() const {
     /* This combines all the constraints in a scope */
-    PrimExpr predicate = Bool(true);
+    PrimExpr predicate = const_true();
     for (const auto& condition : conditions_) {
       predicate = predicate && condition;
     }
@@ -281,7 +281,7 @@ class ParseAssumeAndOvercompute : public IRMutatorWithAnalyzer {
   }
 
   void AssumeConstraintComponent(PrimExpr assumption) {
-    PrimExpr additional_predicate = Bool(true);
+    PrimExpr additional_predicate = const_true();
     assume_struct buf_data;
 
     std::vector<PrimExpr> buffer_exprs;

--- a/src/script/printer/ir/distributed.cc
+++ b/src/script/printer/ir/distributed.cc
@@ -29,7 +29,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
       ffi::Array<ExprDoc> results;
       results.reserve(s);
       for (int i = 0; i < s; ++i) {
-        results.push_back(d->AsDoc<ExprDoc>(Integer(n[i]), n_p->ArrayItem(i)));
+        results.push_back(d->AsDoc<ExprDoc>(IntImm(DataType::Int(32), n[i]), n_p->ArrayItem(i)));
       }
       return TupleDoc(results);
     });

--- a/src/target/cuda/codegen_cuda.cc
+++ b/src/target/cuda/codegen_cuda.cc
@@ -197,12 +197,12 @@ class ThreadIdxExtractor : public tirx::StmtVisitor {
   }
 
  public:
-  PrimExpr threadIdx_x_ext = Integer(1);
-  PrimExpr threadIdx_y_ext = Integer(1);
-  PrimExpr threadIdx_z_ext = Integer(1);
-  PrimExpr clusterCtaIdx_x_ext = Integer(1);
-  PrimExpr clusterCtaIdx_y_ext = Integer(1);
-  PrimExpr clusterCtaIdx_z_ext = Integer(1);
+  PrimExpr threadIdx_x_ext = IntImm(DataType::Int(32), 1);
+  PrimExpr threadIdx_y_ext = IntImm(DataType::Int(32), 1);
+  PrimExpr threadIdx_z_ext = IntImm(DataType::Int(32), 1);
+  PrimExpr clusterCtaIdx_x_ext = IntImm(DataType::Int(32), 1);
+  PrimExpr clusterCtaIdx_y_ext = IntImm(DataType::Int(32), 1);
+  PrimExpr clusterCtaIdx_z_ext = IntImm(DataType::Int(32), 1);
   bool is_persistent_kernel = false;
 };
 

--- a/src/target/cuda/codegen_cuda.cc
+++ b/src/target/cuda/codegen_cuda.cc
@@ -1051,7 +1051,7 @@ void CodeGenCUDA::VisitExpr_(const CallNode* op, std::ostream& os) {
     std::string b_bias = this->PrintExpr(op->args[9]);
     std::string c_ref = this->PrintExpr(op->args[10]);
     std::string c_bias = this->PrintExpr(op->args[11]);
-    bool saturate = Downcast<Bool>(op->args[12])->value;
+    bool saturate = Downcast<IntImm>(op->args[12])->value;
     std::string bit_op = op->args.size() > 13 ? Downcast<StringImm>(op->args[13])->value : "";
     std::string asm_code =
         PrintMMAAssembly(shape, A_layout, B_layout, A_dtype, B_dtype, C_dtype, a_ref, a_bias, b_ref,
@@ -1091,14 +1091,14 @@ void CodeGenCUDA::VisitExpr_(const CallNode* op, std::ostream& os) {
     std::string metadata = this->PrintExpr(op->args[12]);
     std::string metadata_offset = this->PrintExpr(op->args[13]);
     std::string sparse_selector = this->PrintExpr(op->args[14]);
-    bool saturate = Downcast<Bool>(op->args[15])->value;
+    bool saturate = Downcast<IntImm>(op->args[15])->value;
     std::string asm_code = PrintMMAAssembly(
         shape, A_layout, B_layout, A_dtype, B_dtype, C_dtype, a_ref, a_offset, b_ref, b_offset,
         c_ref, c_offset, metadata, metadata_offset, sparse_selector, "", true, saturate);
     this->stream << asm_code;
   } else if (op->op.same_as(builtin::mma_store())) {
-    int m = Downcast<Integer>(op->args[0])->value;
-    int n = Downcast<Integer>(op->args[1])->value;
+    int m = Downcast<IntImm>(op->args[0])->value;
+    int n = Downcast<IntImm>(op->args[1])->value;
     std::string dst = this->PrintExpr(op->args[2]);
     std::string src = this->PrintExpr(op->args[3]);
     std::string src_offset = this->PrintExpr(op->args[4]);
@@ -1172,7 +1172,7 @@ void CodeGenCUDA::VisitExpr_(const CallNode* op, std::ostream& os) {
     std::string b_bias = this->PrintExpr(op->args[9]);
     std::string c_ref = this->PrintExpr(op->args[10]);
     std::string c_bias = this->PrintExpr(op->args[11]);
-    bool saturate = Downcast<Bool>(op->args[12])->value;
+    bool saturate = Downcast<IntImm>(op->args[12])->value;
     std::string bit_op = op->args.size() > 13 ? Downcast<StringImm>(op->args[13])->value : "";
     this->stream << PrintMMAAssembly(shape, A_layout, B_layout, A_dtype, B_dtype, C_dtype, a_ref,
                                      a_bias, b_ref, b_bias, c_ref, c_bias, "", "", "", bit_op,
@@ -1209,8 +1209,8 @@ void CodeGenCUDA::VisitExpr_(const CallNode* op, std::ostream& os) {
     // args: m, n, dst_ptr, src_ptr_var, src_offset, dst_stride
     // (dst_ptr is typically an access_ptr Call that already encodes
     // dst.elem_offset and the global pointer cast.)
-    int m = Downcast<Integer>(op->args[0])->value;
-    int n = Downcast<Integer>(op->args[1])->value;
+    int m = Downcast<IntImm>(op->args[0])->value;
+    int n = Downcast<IntImm>(op->args[1])->value;
     std::string dst = this->PrintExpr(op->args[2]);
     std::string src = this->PrintExpr(op->args[3]);
     std::string src_offset = this->PrintExpr(op->args[4]);

--- a/src/target/source/codegen_c.h
+++ b/src/target/source/codegen_c.h
@@ -232,7 +232,7 @@ class CodeGenC : public ExprFunctor<void(const PrimExpr&, std::ostream&)>,
   // Print restrict keyword for a given Var if applicable
   virtual void PrintRestrict(const Var& v, std::ostream& os);
 
-  virtual void SetConstantsByteAlignment(Integer constants_byte_alignment) {
+  virtual void SetConstantsByteAlignment(int64_t constants_byte_alignment) {
     constants_byte_alignment_ = constants_byte_alignment;
   }
 
@@ -323,7 +323,7 @@ class CodeGenC : public ExprFunctor<void(const PrimExpr&, std::ostream&)>,
   // cache commonly used ops
   const Op& builtin_call_extern_ = builtin::call_extern();
   const Op& builtin_call_pure_extern_ = builtin::call_pure_extern();
-  Integer constants_byte_alignment_ = 16;
+  int64_t constants_byte_alignment_ = 16;
   /*! \brief whether to print in SSA form */
   bool print_ssa_form_{false};
   /*! \brief whether the module has a main function declared */

--- a/src/target/target.cc
+++ b/src/target/target.cc
@@ -177,7 +177,7 @@ Target Target::WithoutHost() const {
 
 int TargetNode::GetTargetDeviceType() const {
   if (ffi::Optional<int64_t> device_type = GetAttr<int64_t>("target_device_type")) {
-    return Downcast<Integer>(device_type)->value;
+    return Downcast<IntImm>(device_type)->value;
   }
   return kind->default_device_type;
 }

--- a/src/target/target_kind.cc
+++ b/src/target/target_kind.cc
@@ -277,11 +277,11 @@ ffi::Map<ffi::String, ffi::Any> UpdateROCmAttrs(ffi::Map<ffi::String, ffi::Any> 
 ffi::Map<ffi::String, ffi::Any> UpdateWebGPUAttrs(ffi::Map<ffi::String, ffi::Any> target) {
   bool subgroups = false;
   if (target.count("supports_subgroups")) {
-    subgroups = Downcast<Bool>(target.at("supports_subgroups"));
+    subgroups = Downcast<IntImm>(target.at("supports_subgroups"))->value != 0;
   }
 
   if (target.count("thread_warp_size")) {
-    int64_t thread_warp_size = Downcast<Integer>(target.at("thread_warp_size"))->value;
+    int64_t thread_warp_size = Downcast<IntImm>(target.at("thread_warp_size"))->value;
     TVM_FFI_ICHECK(subgroups || thread_warp_size <= 1)
         << "WebGPU target with thread_warp_size=" << thread_warp_size
         << " requires supports_subgroups=true";

--- a/src/target/vulkan/codegen_spirv.cc
+++ b/src/target/vulkan/codegen_spirv.cc
@@ -627,7 +627,7 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const ShuffleNode* op) {
       << "SPIR-V codegen only supports shuffle "
       << "of one vector with one index";
   spirv::Value vector = MakeValue(op->vectors[0]);
-  int index = Downcast<Integer>(op->indices[0])->value;
+  int index = Downcast<IntImm>(op->indices[0])->value;
   spirv::SType etype = builder_->GetSType(op->dtype);
   spirv::Value element = builder_->MakeValue(spv::OpCompositeExtract, etype, vector, index);
   return element;

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -27,8 +27,8 @@
 #include <tvm/te/operation.h>
 #include <tvm/tirx/analysis.h>
 #include <tvm/tirx/function.h>
-#include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt_functor.h>
 
 #include <algorithm>
 #include <set>
@@ -545,7 +545,7 @@ Stmt GenerateStmtFromCompute(const te::ComputeOp& compute_op, CreateFuncInfo* in
     Stmt body =
         GenerateBodyStmt(leaf.store_indices, buffers, leaf.axes_remap, expr_body, info, analyzer);
     seq_stmt.push_back(SBlockRealize(/*iter_values=*/leaf.bindings,
-                                     /*predicate=*/IntImm(DataType::Bool(), 1),
+                                     /*predicate=*/const_true(),
                                      /*block=*/
                                      SBlock(/*iter_vars=*/leaf.block_iters,
                                             /*reads=*/{},

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -28,6 +28,7 @@
 #include <tvm/tirx/analysis.h>
 #include <tvm/tirx/function.h>
 #include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/op.h>
 
 #include <algorithm>
 #include <set>
@@ -544,7 +545,7 @@ Stmt GenerateStmtFromCompute(const te::ComputeOp& compute_op, CreateFuncInfo* in
     Stmt body =
         GenerateBodyStmt(leaf.store_indices, buffers, leaf.axes_remap, expr_body, info, analyzer);
     seq_stmt.push_back(SBlockRealize(/*iter_values=*/leaf.bindings,
-                                     /*predicate=*/Bool(true),
+                                     /*predicate=*/IntImm(DataType::Bool(), 1),
                                      /*block=*/
                                      SBlock(/*iter_vars=*/leaf.block_iters,
                                             /*reads=*/{},
@@ -566,7 +567,7 @@ Stmt GenerateStmtFromCompute(const te::ComputeOp& compute_op, CreateFuncInfo* in
       Stmt body = GenerateBodyStmt(leaf.store_indices, {buffers[i]}, leaf.axes_remap, expr_body,
                                    info, analyzer);
       seq_stmt.push_back(SBlockRealize(/*iter_values=*/leaf.bindings,
-                                       /*predicate=*/Bool(true),
+                                       /*predicate=*/IntImm(DataType::Bool(), 1),
                                        /*block=*/
                                        SBlock(/*iter_vars=*/leaf.block_iters,
                                               /*reads=*/{},
@@ -599,7 +600,7 @@ Stmt GenerateStmtFromCompute(const te::ComputeOp& compute_op, CreateFuncInfo* in
 
       // wrap nested block
       body = SBlockRealize(/*iter_values=*/cur.bindings,
-                           /*predicate=*/Bool(true),
+                           /*predicate=*/IntImm(DataType::Bool(), 1),
                            /*block=*/
                            SBlock(/*iter_vars=*/block_iters,
                                   /*reads=*/{},
@@ -659,7 +660,7 @@ Stmt GenerateStmtFromExternOp(const te::ExternOp& extern_op, CreateFuncInfo* inf
 
   // Step 4. Generate opaque block as body.
   return SBlockRealize(/*iter_values=*/{},
-                       /*predicate=*/Bool(true),
+                       /*predicate=*/IntImm(DataType::Bool(), 1),
                        /*block=*/
                        SBlock(/*iter_vars=*/{},
                               /*reads=*/{},

--- a/src/tirx/ir/data_type_rewriter.cc
+++ b/src/tirx/ir/data_type_rewriter.cc
@@ -630,7 +630,7 @@ bool IndexDataTypeNormalizer::CanRewriteDType(DataType dtype) const {
 
 PrimExpr IndexDataTypeNormalizer::VisitExpr_(const IntImmNode* op) {
   if (is_enabled_ && CanRewriteDType(op->dtype)) {
-    TVM_FFI_ICHECK_LE(op->value, Downcast<Integer>(max_value(target_data_type_))->value);
+    TVM_FFI_ICHECK_LE(op->value, Downcast<IntImm>(max_value(target_data_type_))->value);
     return cast(target_data_type_, ffi::GetRef<IntImm>(op));
   }
   return ffi::GetRef<IntImm>(op);

--- a/src/tirx/ir/expr.cc
+++ b/src/tirx/ir/expr.cc
@@ -692,7 +692,7 @@ PrimExpr Shuffle::Concat(ffi::Array<PrimExpr> vectors, Span span) {
 }
 
 PrimExpr Shuffle::ExtractElement(PrimExpr vector, int index, Span span) {
-  return Shuffle({vector}, {Integer(index)}, span);
+  return Shuffle({vector}, {IntImm(DataType::Int(32), index)}, span);
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/tirx/ir/index_map.cc
+++ b/src/tirx/ir/index_map.cc
@@ -67,7 +67,7 @@ std::pair<IndexMap, PrimExpr> IndexMapInverseImpl(const IndexMap& self,
     // return the pre-defined inverse index map if exists.  In this
     // case, the user-defined inverse is assumed to be correct and
     // bijective.
-    PrimExpr padding_predicate = Bool(false);
+    PrimExpr padding_predicate = IntImm(DataType::Bool(), 0);
     return {Downcast<IndexMap>(self->inverse_index_map.value()), padding_predicate};
   }
 

--- a/src/tirx/ir/script/script_complete.cc
+++ b/src/tirx/ir/script/script_complete.cc
@@ -28,6 +28,7 @@
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/s_tir/stmt.h>
 #include <tvm/tirx/analysis.h>
+#include <tvm/tirx/op.h>
 
 #include <utility>
 
@@ -153,7 +154,7 @@ PrimFunc ScriptComplete(PrimFunc func, const ffi::Array<Buffer>& root_allocates,
 
   if (s_tir && should_insert_root) {
     SBlock root_block({}, {}, {}, "root", std::move(res), std::nullopt, root_allocates);
-    res = SBlockRealize({}, Bool(true), std::move(root_block));
+    res = SBlockRealize({}, IntImm(DataType::Bool(), 1), std::move(root_block));
   }
 
   // generate surrounding loops automatically

--- a/src/tirx/script/builder/frame.cc
+++ b/src/tirx/script/builder/frame.cc
@@ -195,7 +195,8 @@ void SBlockFrameNode::ExitWithScope() {
         << "`T.where` is not allowed when `no_realize=True`";
     AddToParent(block);
   } else {
-    AddToParent(tvm::tirx::SBlockRealize(iter_values, predicate.value_or(IntImm(DataType::Bool(), 1)), block));
+    AddToParent(tvm::tirx::SBlockRealize(iter_values,
+                                         predicate.value_or(IntImm(DataType::Bool(), 1)), block));
   }
 }
 

--- a/src/tirx/script/builder/frame.cc
+++ b/src/tirx/script/builder/frame.cc
@@ -195,7 +195,7 @@ void SBlockFrameNode::ExitWithScope() {
         << "`T.where` is not allowed when `no_realize=True`";
     AddToParent(block);
   } else {
-    AddToParent(tvm::tirx::SBlockRealize(iter_values, predicate.value_or(Bool(true)), block));
+    AddToParent(tvm::tirx::SBlockRealize(iter_values, predicate.value_or(IntImm(DataType::Bool(), 1)), block));
   }
 }
 

--- a/src/tirx/transform/force_narrow_index_to_i32.cc
+++ b/src/tirx/transform/force_narrow_index_to_i32.cc
@@ -56,7 +56,7 @@ class Int32DTypeNarrower : public IndexDataTypeNormalizer {
   PrimExpr VisitExpr_(const IntImmNode* op) final {
     // ignore the enabled condition and always rewrite i64
     if (op->dtype == DataType::Int(64)) {
-      TVM_FFI_ICHECK_LE(op->value, Downcast<Integer>(max_value(target_data_type_))->value);
+      TVM_FFI_ICHECK_LE(op->value, Downcast<IntImm>(max_value(target_data_type_))->value);
       return IntImm(DataType::Int(32), op->value);
     }
     return ffi::GetRef<IntImm>(op);

--- a/src/tirx/transform/lower_device_kernel_launch.cc
+++ b/src/tirx/transform/lower_device_kernel_launch.cc
@@ -142,7 +142,7 @@ class DeviceInfoCollector : public StmtVisitor {
           << "Only one dynamic shared memory allocation is allowed.";
       TVM_FFI_ICHECK_GT(op->buffer->shape.size(), 0);
 
-      PrimExpr dyn_size = Integer(1);
+      PrimExpr dyn_size = IntImm(DataType::Int(32), 1);
       for (const auto& extent : op->buffer->shape) {
         dyn_size *= extent;
       }

--- a/src/tirx/transform/lower_tvm_builtin.cc
+++ b/src/tirx/transform/lower_tvm_builtin.cc
@@ -241,7 +241,7 @@ class BuiltinLower : public StmtExprMutator {
     Stmt stmt = StmtExprMutator::VisitStmt_(op);
     op = stmt.as<AllocBufferNode>();
     if (op->annotations.count(transform::kDisableLowerTVMBuiltin)) {
-      if (Downcast<Bool>(op->annotations[transform::kDisableLowerTVMBuiltin])) {
+      if (Downcast<IntImm>(op->annotations[transform::kDisableLowerTVMBuiltin])->value) {
         return stmt;
       }
     }

--- a/src/tirx/transform/lower_tvm_builtin.cc
+++ b/src/tirx/transform/lower_tvm_builtin.cc
@@ -45,7 +45,7 @@ class BuiltinLower : public StmtExprMutator {
   static PrimFunc Build(PrimFunc func) {
     ffi::Optional<PrimExpr> device_type = std::nullopt;
     if (auto target = func->GetAttr<Target>(tvm::attr::kTarget)) {
-      device_type = Integer(target.value()->kind->default_device_type);
+      device_type = IntImm(DataType::Int(32), target.value()->kind->default_device_type);
     }
 
     BuiltinLower mutator(device_type);

--- a/src/tirx/transform/make_packed_api.cc
+++ b/src/tirx/transform/make_packed_api.cc
@@ -228,7 +228,7 @@ PrimFunc MakePackedAPI(PrimFunc func) {
 
   // The device context
   Var device_id("dev_id");
-  Integer device_type(target_device_type);
+  IntImm device_type(DataType::Int(32), target_device_type);
 
   // Create TVMFFIABIBuilder and decode all packed args
   TVMFFIABIBuilder binder(name_hint, func_ptr->params, func_ptr->buffer_map, v_packed_args,

--- a/src/tirx/transform/make_packed_api.cc
+++ b/src/tirx/transform/make_packed_api.cc
@@ -268,7 +268,7 @@ PrimFunc MakePackedAPI(PrimFunc func) {
   }
 
   // Return error code of zero on success
-  body = SeqStmt({body, Evaluate(ret(Integer(0)))});
+  body = SeqStmt({body, Evaluate(ret(IntImm(DataType::Int(32), 0)))});
 
   body = MergeNest({std::move(result.init_nest), seq_check, std::move(result.asserts),
                     std::move(result.decl_buffers)},

--- a/src/tirx/transform/unroll_loop.cc
+++ b/src/tirx/transform/unroll_loop.cc
@@ -103,13 +103,13 @@ class LoopUnroller : public StmtExprMutator {
 
   Stmt VisitStmt_(const AttrStmtNode* op) final {
     if (op->attr_key == "pragma_auto_unroll_max_step") {
-      int value = static_cast<int>(Downcast<Integer>(op->value)->value);
+      int value = static_cast<int>(Downcast<IntImm>(op->value)->value);
       std::swap(value, auto_max_step_);
       Stmt ret = this->VisitStmt(op->body);
       std::swap(value, auto_max_step_);
       return ret;
     } else if (op->attr_key == "pragma_unroll_explicit") {
-      bool explicit_unroll = Downcast<Integer>(op->value)->value;
+      bool explicit_unroll = Downcast<IntImm>(op->value)->value;
       std::swap(explicit_unroll, explicit_unroll_);
       Stmt ret = this->VisitStmt(op->body);
       std::swap(explicit_unroll, explicit_unroll_);

--- a/src/topi/einsum.cc
+++ b/src/topi/einsum.cc
@@ -109,7 +109,7 @@ PrimExpr GetBroadcastedExtent(const PrimExpr& extent1, const PrimExpr& extent2) 
     if (extent1_imm->value == extent2_imm->value) {
       return extent1;
     } else if (extent1_imm->value == 1 || extent2_imm->value == 1) {
-      return Integer(std::max(extent1_imm->value, extent2_imm->value));
+      return IntImm(DataType::Int(32), std::max(extent1_imm->value, extent2_imm->value));
     }
     TVM_FFI_THROW(InternalError) << "Cannot broadcast extents " << extent1 << " and " << extent2;
     throw;

--- a/src/topi/nn.cc
+++ b/src/topi/nn.cc
@@ -68,14 +68,14 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def_packed("topi.nn.space_to_batch_nd",
                   [](ffi::PackedArgs args, ffi::Any* rv) {
                     *rv = space_to_batch_nd(
-                        args[0].cast<te::Tensor>(), args[1].cast<ffi::Array<Integer>>(),
+                        args[0].cast<te::Tensor>(), args[1].cast<ffi::Array<int64_t>>(),
                         args[2].cast<ffi::Array<PrimExpr>>(), args[3].cast<ffi::Array<PrimExpr>>(),
                         args[4].cast<PrimExpr>());
                   })
       .def_packed("topi.nn.batch_to_space_nd",
                   [](ffi::PackedArgs args, ffi::Any* rv) {
                     *rv = batch_to_space_nd(
-                        args[0].cast<te::Tensor>(), args[1].cast<ffi::Array<Integer>>(),
+                        args[0].cast<te::Tensor>(), args[1].cast<ffi::Array<int64_t>>(),
                         args[2].cast<ffi::Array<PrimExpr>>(), args[3].cast<ffi::Array<PrimExpr>>(),
                         args[4].cast<std::string>());
                   })
@@ -107,7 +107,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def_packed("topi.nn.dilate", [](ffi::PackedArgs args, ffi::Any* rv) {
-    *rv = nn::dilate(args[0].cast<te::Tensor>(), args[1].cast<ffi::Array<Integer>>(),
+    *rv = nn::dilate(args[0].cast<te::Tensor>(), args[1].cast<ffi::Array<PrimExpr>>(),
                      args[2].cast<double>());
   });
 }
@@ -239,7 +239,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def_packed("topi.nn.layer_norm", [](ffi::PackedArgs args, ffi::Any* rv) {
     *rv = nn::layer_norm(args[0].cast<te::Tensor>(), args[1].cast<te::Tensor>(),
-                         args[2].cast<te::Tensor>(), args[3].cast<ffi::Array<Integer>>(),
+                         args[2].cast<te::Tensor>(), args[3].cast<ffi::Array<int64_t>>(),
                          args[4].cast<double>());
   });
 }
@@ -250,7 +250,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::GlobalDef().def_packed("topi.nn.group_norm", [](ffi::PackedArgs args, ffi::Any* rv) {
     *rv = nn::group_norm(args[0].cast<te::Tensor>(), args[1].cast<te::Tensor>(),
                          args[2].cast<te::Tensor>(), args[3].cast<int>(), args[4].cast<int>(),
-                         args[5].cast<ffi::Array<Integer>>(), args[6].cast<double>());
+                         args[5].cast<ffi::Array<int64_t>>(), args[6].cast<double>());
   });
 }
 
@@ -260,7 +260,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::GlobalDef().def_packed("topi.nn.instance_norm", [](ffi::PackedArgs args, ffi::Any* rv) {
     *rv = nn::instance_norm(args[0].cast<te::Tensor>(), args[1].cast<te::Tensor>(),
                             args[2].cast<te::Tensor>(), args[3].cast<int>(),
-                            args[4].cast<ffi::Array<Integer>>(), args[5].cast<double>());
+                            args[4].cast<ffi::Array<int64_t>>(), args[5].cast<double>());
   });
 }
 
@@ -269,7 +269,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def_packed("topi.nn.rms_norm", [](ffi::PackedArgs args, ffi::Any* rv) {
     *rv = nn::rms_norm(args[0].cast<te::Tensor>(), args[1].cast<te::Tensor>(),
-                       args[2].cast<ffi::Array<Integer>>(), args[3].cast<double>());
+                       args[2].cast<ffi::Array<int64_t>>(), args[3].cast<double>());
   });
 }
 

--- a/src/topi/reduction.cc
+++ b/src/topi/reduction.cc
@@ -76,7 +76,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                                     args[2].cast<bool>());
                   })
       .def_packed("topi.collapse_sum", [](ffi::PackedArgs args, ffi::Any* rv) {
-        *rv = topi::collapse_sum(args[0].cast<te::Tensor>(), args[1].cast<ffi::Array<Integer>>());
+        *rv = topi::collapse_sum(args[0].cast<te::Tensor>(), args[1].cast<ffi::Array<PrimExpr>>());
       });
 }
 

--- a/src/topi/transform.cc
+++ b/src/topi/transform.cc
@@ -224,9 +224,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
             bool assume_inbound = args[6].cast<bool>();
             if (IsConstIntArray(begin) && IsConstIntArray(end) && IsConstIntArray(strides) &&
                 IsConstIntArray(x->shape)) {
-              ffi::Array<int64_t> begin_static = args[1].cast<ffi::Array<int64_t>>();
-              ffi::Array<int64_t> end_static = args[2].cast<ffi::Array<int64_t>>();
-              ffi::Array<int64_t> strides_static = args[3].cast<ffi::Array<int64_t>>();
+              ffi::Array<ffi::Optional<IntImm>> begin_static =
+                  args[1].cast<ffi::Array<ffi::Optional<IntImm>>>();
+              ffi::Array<ffi::Optional<IntImm>> end_static =
+                  args[2].cast<ffi::Array<ffi::Optional<IntImm>>>();
+              ffi::Array<IntImm> strides_static = args[3].cast<ffi::Array<IntImm>>();
               auto slice_mode = args[5].cast<std::string>();
               if (axes.size()) {
                 *rv = strided_slice_with_axes(x, begin_static, end_static, strides_static, axes,

--- a/src/topi/transform.cc
+++ b/src/topi/transform.cc
@@ -48,7 +48,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def_packed("topi.transpose",
                   [](ffi::PackedArgs args, ffi::Any* rv) {
                     *rv = transpose(args[0].cast<te::Tensor>(),
-                                    args[1].cast<ffi::Optional<ffi::Array<Integer>>>());
+                                    args[1].cast<ffi::Optional<ffi::Array<int64_t>>>());
                   })
       .def_packed("topi.flip",
                   [](ffi::PackedArgs args, ffi::Any* rv) {
@@ -68,8 +68,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def_packed("topi.sliding_window",
                   [](ffi::PackedArgs args, ffi::Any* rv) {
                     *rv = sliding_window(args[0].cast<te::Tensor>(), args[1].cast<int>(),
-                                         args[2].cast<ffi::Array<Integer>>(),
-                                         args[3].cast<ffi::Array<Integer>>());
+                                         args[2].cast<ffi::Array<int64_t>>(),
+                                         args[3].cast<ffi::Array<int64_t>>());
                   })
       .def_packed("topi.squeeze",
                   [](ffi::PackedArgs args, ffi::Any* rv) {
@@ -98,7 +98,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                                              args[2].cast<int>());
                     } else {
                       *rv = split_indices_array(args[0].cast<te::Tensor>(),
-                                                args[1].cast<ffi::Array<Integer>>(),
+                                                args[1].cast<ffi::Array<PrimExpr>>(),
                                                 args[2].cast<int>());
                     }
                   })
@@ -154,7 +154,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                   })
       .def_packed("topi.tile",
                   [](ffi::PackedArgs args, ffi::Any* rv) {
-                    *rv = tile(args[0].cast<te::Tensor>(), args[1].cast<ffi::Array<Integer>>());
+                    *rv = tile(args[0].cast<te::Tensor>(), args[1].cast<ffi::Array<int64_t>>());
                   })
       .def_packed("topi.dyn_tile",
                   [](ffi::PackedArgs args, ffi::Any* rv) {
@@ -220,13 +220,13 @@ TVM_FFI_STATIC_INIT_BLOCK() {
             ffi::Array<PrimExpr> begin = args[1].cast<ffi::Array<PrimExpr>>();
             ffi::Array<PrimExpr> end = args[2].cast<ffi::Array<PrimExpr>>();
             ffi::Array<PrimExpr> strides = args[3].cast<ffi::Array<PrimExpr>>();
-            ffi::Array<Integer> axes = args[4].cast<ffi::Array<Integer>>();
+            ffi::Array<int64_t> axes = args[4].cast<ffi::Array<int64_t>>();
             bool assume_inbound = args[6].cast<bool>();
             if (IsConstIntArray(begin) && IsConstIntArray(end) && IsConstIntArray(strides) &&
                 IsConstIntArray(x->shape)) {
-              ffi::Array<Integer> begin_static = args[1].cast<ffi::Array<Integer>>();
-              ffi::Array<Integer> end_static = args[2].cast<ffi::Array<Integer>>();
-              ffi::Array<Integer> strides_static = args[3].cast<ffi::Array<Integer>>();
+              ffi::Array<int64_t> begin_static = args[1].cast<ffi::Array<int64_t>>();
+              ffi::Array<int64_t> end_static = args[2].cast<ffi::Array<int64_t>>();
+              ffi::Array<int64_t> strides_static = args[3].cast<ffi::Array<int64_t>>();
               auto slice_mode = args[5].cast<std::string>();
               if (axes.size()) {
                 *rv = strided_slice_with_axes(x, begin_static, end_static, strides_static, axes,

--- a/tests/cpp/arith_simplify_test.cc
+++ b/tests/cpp/arith_simplify_test.cc
@@ -45,8 +45,8 @@ TEST(Simplify, Mul) {
 
 TEST(Simplify, Mod) {
   tvm::arith::Analyzer ana;
-  auto x = tvm::Integer(10);
-  auto y = tvm::Integer(12);
+  auto x = tvm::IntImm(DataType::Int(32), 10);
+  auto y = tvm::IntImm(DataType::Int(32), 12);
   // Mod::make is used instead of % to avoid constant folding during
   // calling operator%(x,y). Mod::make doesn't try constant folding,
   // and therefore, the constant folding will be attempted in CanonicalSimplify

--- a/tests/cpp/arith_simplify_test.cc
+++ b/tests/cpp/arith_simplify_test.cc
@@ -45,8 +45,8 @@ TEST(Simplify, Mul) {
 
 TEST(Simplify, Mod) {
   tvm::arith::Analyzer ana;
-  auto x = tvm::IntImm(DataType::Int(32), 10);
-  auto y = tvm::IntImm(DataType::Int(32), 12);
+  auto x = tvm::IntImm(tvm::DataType::Int(32), 10);
+  auto y = tvm::IntImm(tvm::DataType::Int(32), 12);
   // Mod::make is used instead of % to avoid constant folding during
   // calling operator%(x,y). Mod::make doesn't try constant folding,
   // and therefore, the constant folding will be attempted in CanonicalSimplify

--- a/tests/cpp/ir_functor_test.cc
+++ b/tests/cpp/ir_functor_test.cc
@@ -58,8 +58,8 @@ TEST(IRF, CountVar) {
 TEST(IRF, PreOrderVisit) {
   using namespace tvm;
   using namespace tvm::tirx;
-  Stmt init = IfThenElse(const_true(), Evaluate(Integer(0)), Evaluate(Integer(0)));
-  Stmt body = Evaluate(Integer(1));
+  Stmt init = IfThenElse(const_true(), Evaluate(IntImm(DataType::Int(32), 0)), Evaluate(IntImm(DataType::Int(32), 0)));
+  Stmt body = Evaluate(IntImm(DataType::Int(32), 1));
   SBlock block(/*iter_vars=*/{}, /*reads=*/{},
                /*writes=*/{}, /*name_hint=*/"block", /*body=*/body,
                /*init=*/init);

--- a/tests/cpp/ir_functor_test.cc
+++ b/tests/cpp/ir_functor_test.cc
@@ -58,7 +58,8 @@ TEST(IRF, CountVar) {
 TEST(IRF, PreOrderVisit) {
   using namespace tvm;
   using namespace tvm::tirx;
-  Stmt init = IfThenElse(const_true(), Evaluate(IntImm(DataType::Int(32), 0)), Evaluate(IntImm(DataType::Int(32), 0)));
+  Stmt init = IfThenElse(const_true(), Evaluate(IntImm(DataType::Int(32), 0)),
+                         Evaluate(IntImm(DataType::Int(32), 0)));
   Stmt body = Evaluate(IntImm(DataType::Int(32), 1));
   SBlock block(/*iter_vars=*/{}, /*reads=*/{},
                /*writes=*/{}, /*name_hint=*/"block", /*body=*/body,

--- a/tests/cpp/nested_msg_test.cc
+++ b/tests/cpp/nested_msg_test.cc
@@ -152,23 +152,23 @@ TEST(NestedMsg, MapAndDecompose) {
   relax::Expr t0 = bb->Normalize(Tuple({x, y}));
   relax::Expr t1 = bb->Normalize(Tuple({t0, x, z, t0}));
 
-  auto c0 = Integer(0);
-  auto c1 = Integer(1);
-  auto c2 = Integer(2);
+  auto c0 = IntImm(DataType::Int(32), 0);
+  auto c1 = IntImm(DataType::Int(32), 1);
+  auto c2 = IntImm(DataType::Int(32), 2);
 
-  auto output = MapToNestedMsg<Integer>(t1, [&](Expr value) {
+  auto output = MapToNestedMsg<IntImm>(t1, [&](Expr value) {
     if (value.same_as(x)) return c0;
     if (value.same_as(y)) return c1;
     return c2;
   });
 
-  NestedMsg<Integer> expected = {{c0, c1}, c0, c2, {c0, c1}};
+  NestedMsg<IntImm> expected = {{c0, c1}, c0, c2, {c0, c1}};
 
   EXPECT_TRUE(Equal(output, expected,
-                    [](Integer lhs, Integer rhs) -> bool { return lhs->value == rhs->value; }));
+                    [](IntImm lhs, IntImm rhs) -> bool { return lhs->value == rhs->value; }));
 
   auto output2 =
-      MapToNestedMsg<Integer>(GetStructInfo(t1), [&](StructInfo sinfo) -> NestedMsg<Integer> {
+      MapToNestedMsg<IntImm>(GetStructInfo(t1), [&](StructInfo sinfo) -> NestedMsg<IntImm> {
         const auto* prim_sinfo = sinfo.as<PrimStructInfoNode>();
         if (prim_sinfo == nullptr) return std::nullopt;
         int bits = prim_sinfo->dtype.bits();
@@ -179,11 +179,11 @@ TEST(NestedMsg, MapAndDecompose) {
       });
 
   EXPECT_TRUE(Equal(output2, expected,
-                    [](Integer lhs, Integer rhs) -> bool { return lhs->value == rhs->value; }));
+                    [](IntImm lhs, IntImm rhs) -> bool { return lhs->value == rhs->value; }));
 
   int x_count = 0, y_count = 0, z_count = 0;
 
-  DecomposeNestedMsg(t1, expected, [&](Expr value, NestedMsg<Integer> msg) {
+  DecomposeNestedMsg(t1, expected, [&](Expr value, NestedMsg<IntImm> msg) {
     if (value.same_as(x)) {
       EXPECT_TRUE(msg.LeafValue().same_as(c0));
       ++x_count;
@@ -226,16 +226,16 @@ TEST(NestedMsg, NestedMsgToExpr) {
   auto sf0 = TensorStructInfo(DataType::Float(32), /*ndim=*/0);
   auto sf1 = TupleStructInfo({sf0, sf0});
 
-  auto c0 = Integer(0);
-  auto c1 = Integer(1);
-  auto c2 = Integer(2);
+  auto c0 = IntImm(DataType::Int(32), 0);
+  auto c1 = IntImm(DataType::Int(32), 1);
+  auto c2 = IntImm(DataType::Int(32), 2);
 
   relax::Var x("x", sf0), y("y", sf0), z("z", sf0);
 
-  NestedMsg<Integer> msg = {c0, {c0, c1}, {c0, {c1, c2}}};
-  auto expr = NestedMsgToExpr<Integer>(msg, [&](ffi::Optional<Integer> leaf) {
+  NestedMsg<IntImm> msg = {c0, {c0, c1}, {c0, {c1, c2}}};
+  auto expr = NestedMsgToExpr<IntImm>(msg, [&](ffi::Optional<IntImm> leaf) {
     TVM_FFI_ICHECK(leaf.defined());
-    int value = leaf.value().IntValue();
+    int value = leaf.value()->value;
     switch (value) {
       case 0:
         return x;
@@ -257,51 +257,51 @@ TEST(NestedMsg, NestedMsgToExpr) {
 }
 
 TEST(NestedMsg, CombineNestedMsg) {
-  auto c0 = Integer(0);
-  auto c1 = Integer(1);
-  auto c2 = Integer(2);
+  auto c0 = IntImm(DataType::Int(32), 0);
+  auto c1 = IntImm(DataType::Int(32), 1);
+  auto c2 = IntImm(DataType::Int(32), 2);
 
-  NestedMsg<Integer> lhs = {c0, {c0, c1}, std::nullopt, {c0, {c1, c2}}};
-  NestedMsg<Integer> rhs = {c1, {c2, std::nullopt}, std::nullopt, {c1, {c2, c2}}};
-  NestedMsg<Integer> expected = {c1, {c2, c1}, std::nullopt, {c1, {c2, c2}}};
+  NestedMsg<IntImm> lhs = {c0, {c0, c1}, std::nullopt, {c0, {c1, c2}}};
+  NestedMsg<IntImm> rhs = {c1, {c2, std::nullopt}, std::nullopt, {c1, {c2, c2}}};
+  NestedMsg<IntImm> expected = {c1, {c2, c1}, std::nullopt, {c1, {c2, c2}}};
 
-  auto output = CombineNestedMsg(lhs, rhs, [](Integer x, Integer y) {
+  auto output = CombineNestedMsg(lhs, rhs, [](IntImm x, IntImm y) {
     if (x->value > y->value) return x;
     return y;
   });
 
   EXPECT_TRUE(Equal(output, expected,
-                    [](Integer lhs, Integer rhs) -> bool { return lhs->value == rhs->value; }));
+                    [](IntImm lhs, IntImm rhs) -> bool { return lhs->value == rhs->value; }));
 }
 
 TEST(NestedMsg, MapNestedMsg) {
-  auto c0 = Integer(0);
-  auto c1 = Integer(1);
-  auto c2 = Integer(2);
-  auto c3 = Integer(3);
+  auto c0 = IntImm(DataType::Int(32), 0);
+  auto c1 = IntImm(DataType::Int(32), 1);
+  auto c2 = IntImm(DataType::Int(32), 2);
+  auto c3 = IntImm(DataType::Int(32), 3);
 
-  NestedMsg<Integer> msg = {c0, {c0, c1}, std::nullopt, {c0, {c2, c1}}};
-  NestedMsg<Integer> expected = {c3, {c3, std::nullopt}, std::nullopt, {c3, {c2, std::nullopt}}};
+  NestedMsg<IntImm> msg = {c0, {c0, c1}, std::nullopt, {c0, {c2, c1}}};
+  NestedMsg<IntImm> expected = {c3, {c3, std::nullopt}, std::nullopt, {c3, {c2, std::nullopt}}};
 
-  auto output = MapNestedMsg(msg, [](Integer x) {
+  auto output = MapNestedMsg(msg, [](IntImm x) {
     if (x->value == 0) {
-      return NestedMsg<Integer>(Integer(3));
+      return NestedMsg<IntImm>(IntImm(DataType::Int(32), 3));
     } else if (x->value == 1) {
-      return NestedMsg<Integer>();
+      return NestedMsg<IntImm>();
     } else {
-      return NestedMsg<Integer>(x);
+      return NestedMsg<IntImm>(x);
     }
   });
 
   EXPECT_TRUE(Equal(output, expected,
-                    [](Integer lhs, Integer rhs) -> bool { return lhs->value == rhs->value; }));
+                    [](IntImm lhs, IntImm rhs) -> bool { return lhs->value == rhs->value; }));
 }
 
 TEST(NestedMsg, TransformTupleLeaf) {
-  auto c0 = Integer(0);
-  auto c1 = Integer(1);
-  auto c2 = Integer(2);
-  using NInt = NestedMsg<Integer>;
+  auto c0 = IntImm(DataType::Int(32), 0);
+  auto c1 = IntImm(DataType::Int(32), 1);
+  auto c2 = IntImm(DataType::Int(32), 2);
+  using NInt = NestedMsg<IntImm>;
 
   NInt msg1 = {c0, {c0, c1}, c2, {c0, {c1, c2}}};
   NInt msg2 = {c1, {c2, c0}, c2, {c1, {c2, c0}}};
@@ -312,8 +312,8 @@ TEST(NestedMsg, TransformTupleLeaf) {
   Expr expr = bb->Normalize(Tuple({x, Tuple({x, x}), x, Tuple({x, Tuple({x, x})})}));
 
   auto ftransleaf = [&](Expr value, std::array<NInt, 2> msgs) -> Expr {
-    int lhs = Downcast<Integer>(msgs[0].LeafValue())->value;
-    int rhs = Downcast<Integer>(msgs[1].LeafValue())->value;
+    int lhs = Downcast<IntImm>(msgs[0].LeafValue())->value;
+    int rhs = Downcast<IntImm>(msgs[1].LeafValue())->value;
     if (lhs > rhs)
       return z;
     else if (lhs == rhs)


### PR DESCRIPTION
## Background

`class Integer : public IntImm` and `class Bool : public IntImm` were thin
wrappers sharing `IntImmNode` with no separate node class and no FFI
registration.  They existed to provide implicit int→Integer constructors and
a `.IntValue()` / `operator bool()` accessor, but the same functionality is
available directly through `IntImm`.

## What this PR does

Migrates all call sites away from `Integer` / `Bool` and then deletes the
class definitions.  The changes are split into four commits, each
independently buildable:

**Commit 1 – [REFACTOR][TIR]** Replace IR-position `Integer(N)` / `Bool(b)`
constructors with `IntImm(DataType::Int(32), N)` / `IntImm(DataType::Bool(), b)`
across ~62 source files (arith, relax analysis, s_tir schedule state, transform
passes, codegen).

**Commit 2 – [REFACTOR][SCHEDULE]** Migrate `Schedule` and `MetaSchedule`
trace-boxing code: `Integer(N)` attrs in `TracedSchedule` → `IntImm(DataType::Int(32), N)`;
`ffi::Array<Integer>` schedule-rule parameters → `int64_t`; `Bool(b)` attrs →
`IntImm(DataType::Bool(), b)`.

**Commit 3 – [REFACTOR][TOPI]** Migrate topi container signatures
(`ffi::Array<Integer>` → `ffi::Array<int64_t>`) and update all internal
usages (`.IntValue()` → plain int64_t, `.defined()` → removed,
`->value` → direct indexing).  Also handles stray `Integer` / `Bool`
variables in clml codegen, make_packed_api, infer_layout_utils, and
relax distributed code.

**Commit 4 – [REFACTOR][IR]** Delete `class Bool`, `class Integer`,
`TypeTraits<Bool>`, and `TypeTraits<Integer>` from `include/tvm/ir/expr.h`.

## Canonical replacements

| Old | New |
|-----|-----|
| `Integer(N)` | `IntImm(DataType::Int(32), N)` |
| `Bool(b)` | `IntImm(DataType::Bool(), b)` |
| `x.IntValue()` | `x->value` |
| `x` as bool | `x->value != 0` |
| `ffi::Array<Integer>` | `ffi::Array<int64_t>` |

## Testing

- All 118 C++ unit tests pass (`./cpptest`)
- `tests/python/s_tir/` — 1251 passed (14 pre-existing failures unrelated to this change, all in TIR transform tests with annotation-mismatch errors)
- `tests/python/relax/` — passes (excluding pre-existing torch/torchvision import failures in frontend tests)