### PR TITLE
[REFACTOR][SCRIPT] Revive buffer_dtype as a top-level PrinterConfig field

### DIFF
--- a/include/tvm/script/printer/config.h
+++ b/include/tvm/script/printer/config.h
@@ -99,7 +99,6 @@ class PrinterConfigNode : public ffi::Object {
    *
    * Keys are conventionally namespaced as "<dialect>.<knob>", e.g.:
    *   "tirx.prefix"              — the TIR prefix (default "T")
-   *   "tirx.buffer_dtype"        — default buffer dtype (default float32)
    *   "relax.prefix"             — the Relax prefix (default "R")
    *   "relax.show_all_struct_info" — whether to show all struct info (default true)
    *
@@ -127,6 +126,7 @@ class PrinterConfigNode : public ffi::Object {
         .def_ro("show_meta", &PrinterConfigNode::show_meta)
         .def_ro("ir_prefix", &PrinterConfigNode::ir_prefix)
         .def_ro("module_alias", &PrinterConfigNode::module_alias)
+        .def_ro("buffer_dtype", &PrinterConfigNode::buffer_dtype)
         .def_ro("int_dtype", &PrinterConfigNode::int_dtype)
         .def_ro("float_dtype", &PrinterConfigNode::float_dtype)
         .def_ro("verbose_expr", &PrinterConfigNode::verbose_expr)

--- a/python/tvm/runtime/script_printer.py
+++ b/python/tvm/runtime/script_printer.py
@@ -38,6 +38,7 @@ class PrinterConfig(Object):
     tir_import_module: str
     relax_prefix: str
     module_alias: str
+    buffer_dtype: str
     int_dtype: str
     float_dtype: str
     verbose_expr: bool
@@ -86,6 +87,7 @@ class PrinterConfig(Object):
             "tir_import_module": tir_import_module,
             "relax_prefix": relax_prefix,
             "module_alias": module_alias,
+            "buffer_dtype": buffer_dtype,
             "int_dtype": int_dtype,
             "float_dtype": float_dtype,
             "verbose_expr": verbose_expr,
@@ -100,7 +102,6 @@ class PrinterConfig(Object):
             "obj_to_annotate": obj_to_annotate,
             # Dialect-specific config via dotted keys in extra_config
             "tirx.prefix": tir_prefix,
-            "tirx.buffer_dtype": buffer_dtype,
             "relax.prefix": relax_prefix,
             "relax.show_all_struct_info": show_all_struct_info,
         }

--- a/src/script/printer/script_printer.cc
+++ b/src/script/printer/script_printer.cc
@@ -80,6 +80,9 @@ PrinterConfig::PrinterConfig(ffi::Map<ffi::String, Any> config_dict) {
   if (auto v = config_dict.Get("module_alias")) {
     n->module_alias = Downcast<ffi::String>(v.value());
   }
+  if (auto v = config_dict.Get("buffer_dtype")) {
+    n->buffer_dtype = DataType(ffi::StringToDLDataType(Downcast<ffi::String>(v.value())));
+  }
   if (auto v = config_dict.Get("int_dtype")) {
     n->int_dtype = DataType(ffi::StringToDLDataType(Downcast<ffi::String>(v.value())));
   }
@@ -128,11 +131,6 @@ PrinterConfig::PrinterConfig(ffi::Map<ffi::String, Any> config_dict) {
     if (auto v = config_dict.Get(key)) {
       n->extra_config.Set(ffi::String(key), v.value());
     }
-  }
-  // "tirx.buffer_dtype" is passed as a DLDataType string from Python; convert to DataType.
-  if (auto v = config_dict.Get("tirx.buffer_dtype")) {
-    DataType dt(ffi::StringToDLDataType(Downcast<ffi::String>(v.value())));
-    n->extra_config.Set(ffi::String("tirx.buffer_dtype"), ffi::Any(dt));
   }
   // Boolean dialect keys.
   if (auto v = config_dict.Get("relax.show_all_struct_info")) {


### PR DESCRIPTION
## Summary

Restore `buffer_dtype` as a top-level field on `PrinterConfig` (alongside `int_dtype` and `float_dtype`). The tvmscript streamline refactor moved it into `extra_config`, but `buffer_dtype` is a shared scalar-literal default rather than a dialect-specific knob. Bringing it back to top-level keeps it discoverable, type-checked at the C++ layer, and consistent with its sibling scalar dtype fields.

## Files

- `include/tvm/script/printer/config.h` — restore `DataType buffer_dtype` field + reflection registration.
- `src/script/printer/script_printer.cc` — restore the top-level `"buffer_dtype"` string→DataType conversion in the `PrinterConfig` constructor.
- `src/tirx/script/printer/buffer.cc` — use `cfg->buffer_dtype` directly instead of `GetExtraConfig<DataType>("tirx.buffer_dtype", ...)`.
- `python/tvm/runtime/script_printer.py` — re-add `buffer_dtype: str = "float32"` field and kwarg.