### PR TITLE
[RPC] Import tvm.testing lazily in rpc.testing

### DIFF
--- a/python/tvm/rpc/testing.py
+++ b/python/tvm/rpc/testing.py
@@ -21,7 +21,6 @@
 import numpy as np
 
 import tvm
-import tvm.testing
 
 
 # RPC test functions to be registered for unit-tests purposes
@@ -64,7 +63,12 @@ def _my_module(name):
     if name == "get_arr":
         return lambda: nd
     if name == "ref_count":
-        return lambda: tvm.testing.object_use_count(nd)
+        # Imported lazily: rpc.server imports this module to register the
+        # rpc.test.* helpers, so a top-level ``import tvm.testing`` would drag
+        # tvm.testing (which imports pytest) into the plain ``import tvm`` path.
+        from tvm.testing import object_use_count
+
+        return lambda: object_use_count(nd)
     if name == "get_elem":
         return lambda idx: nd.numpy()[idx]
     if name == "get_arr_elem":


### PR DESCRIPTION
### Motivation

`tvm.testing` imports `pytest` at module load (`tvm/testing/utils.py`). `tvm.rpc.server` imports `tvm.rpc.testing` (to register the `rpc.test.*` helpers), and `tvm.rpc.testing` imported `tvm.testing` at the top level, so a plain `import tvm` / `import tvm.relax` pulls `pytest` in through:

```
tvm.relax -> tvm.runtime.vm -> tvm.rpc -> rpc.server -> rpc.testing -> tvm.testing -> pytest
```

As a result `pytest` is effectively a runtime dependency: a user who installs TVM without `pytest` hits `ModuleNotFoundError: No module named 'pytest'` on import. This is easy to miss because test environments install `pytest`.

### Change

`tvm.rpc.testing` only uses `tvm.testing.object_use_count` in a single test helper, so import it lazily at the call site instead of at module top level. This keeps the `rpc.test.*` registration and the helper behavior intact while removing `tvm.testing` (and `pytest`) from the `import tvm` path, so `pytest` can remain a test-only dependency.

No functional change; `rpc.testing` is still imported by `rpc.server` and still registers the same global functions.