### PR TITLE
fix: align Relax ONNX ArgMax/ArgMin NaN handling with ONNX Runtime

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -4203,6 +4203,17 @@ def _argreduce_select_last_index(bb, data, axis, keepdims, op):
     return relax.op.subtract(offset, flipped_idx)
 
 
+def _argreduce_sanitize_nan(bb, data, *, for_min):
+    """Match ONNX Runtime ArgMax/ArgMin behavior by making NaN win comparisons."""
+    dtype = data.struct_info.dtype
+    if not _relax_dtype_is_floating_point(dtype):
+        return data
+    replacement = -_np.inf if for_min else _np.inf
+    return bb.emit(
+        relax.op.where(relax.op.isnan(data), relax.const(replacement, dtype), data)
+    )
+
+
 class ArgMax(OnnxOpConverter):
     """Converts an onnx ArgMax node into an equivalent Relax expression."""
 
@@ -4218,19 +4229,19 @@ class ArgMax(OnnxOpConverter):
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
-        data = inputs[0]
+        data = _argreduce_sanitize_nan(bb, inputs[0], for_min=False)
         axis, keepdims = cls._check_attrs(data, attr, False)
         return relax.op.argmax(data, axis, keepdims)
 
     @classmethod
     def _impl_v11(cls, bb, inputs, attr, params):
-        data = inputs[0]
+        data = _argreduce_sanitize_nan(bb, inputs[0], for_min=False)
         axis, keepdims = cls._check_attrs(data, attr)
         return relax.op.argmax(data, axis, keepdims)
 
     @classmethod
     def _impl_v12(cls, bb, inputs, attr, params):
-        data = inputs[0]
+        data = _argreduce_sanitize_nan(bb, inputs[0], for_min=False)
         axis, keepdims = cls._check_attrs(data, attr)
         select_last_index = attr.get("select_last_index", False)
         if select_last_index:
@@ -4253,19 +4264,19 @@ class ArgMin(OnnxOpConverter):
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
-        data = inputs[0]
+        data = _argreduce_sanitize_nan(bb, inputs[0], for_min=True)
         axis, keepdims = cls._check_attrs(data, attr, False)
         return relax.op.argmin(data, axis, keepdims)
 
     @classmethod
     def _impl_v11(cls, bb, inputs, attr, params):
-        data = inputs[0]
+        data = _argreduce_sanitize_nan(bb, inputs[0], for_min=True)
         axis, keepdims = cls._check_attrs(data, attr)
         return relax.op.argmin(data, axis, keepdims)
 
     @classmethod
     def _impl_v12(cls, bb, inputs, attr, params):
-        data = inputs[0]
+        data = _argreduce_sanitize_nan(bb, inputs[0], for_min=True)
         axis, keepdims = cls._check_attrs(data, attr)
         select_last_index = attr.get("select_last_index", False)
         if select_last_index:

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -2932,6 +2932,28 @@ def test_arg_min_max_nan_select_last_index(op_name):
 
 
 @pytest.mark.parametrize("op_name", ["ArgMax", "ArgMin"])
+@pytest.mark.parametrize("select_last_index", [0, 1])
+def test_arg_min_max_nan_with_real_infinities(op_name, select_last_index):
+    data = np.array(
+        [
+            [np.nan, np.inf, 3.0, -np.inf],
+            [np.inf, np.nan, -np.inf, 0.0],
+            [-np.inf, 1.0, np.nan, np.inf],
+        ],
+        dtype=np.float32,
+    )
+    model = _make_arg_min_max_model(
+        op_name,
+        data.shape,
+        [3],
+        axis=1,
+        keepdims=0,
+        select_last_index=select_last_index,
+    )
+    check_correctness(model, inputs={"data": data}, opset=12)
+
+
+@pytest.mark.parametrize("op_name", ["ArgMax", "ArgMin"])
 def test_arg_min_max_finite_regression(op_name):
     data = np.array(
         [[2.0, 4.0, 7.0, 1.0, 5.0], [3.0, -2.0, 8.0, 6.0, 0.0]],

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -2860,6 +2860,87 @@ def test_arg_min_max(in_dtype, axis, keepdims):
     verify_arg_min_max([3, 4, 4], in_dtype, "ArgMin", axis, keepdims)
 
 
+def _make_arg_min_max_model(
+    op_name, data_shape, out_shape, axis, keepdims, select_last_index=0
+):
+    node = helper.make_node(
+        op_name,
+        inputs=["data"],
+        outputs=["out"],
+        axis=axis,
+        keepdims=keepdims,
+        select_last_index=select_last_index,
+    )
+    graph = helper.make_graph(
+        [node],
+        "arg_min_max_nan_test",
+        inputs=[helper.make_tensor_value_info("data", TensorProto.FLOAT, list(data_shape))],
+        outputs=[helper.make_tensor_value_info("out", TensorProto.INT64, out_shape)],
+    )
+    return helper.make_model(graph, producer_name="arg_min_max_nan_test")
+
+
+@pytest.mark.parametrize("op_name", ["ArgMax", "ArgMin"])
+def test_arg_min_max_nan_matches_ort_indices(op_name):
+    data = np.array(
+        [
+            [2.0, np.nan, 7.0, 4.0, 1.0],
+            [np.nan, 2.0, 7.0, 4.0, 1.0],
+            [2.0, 4.0, 7.0, 1.0, np.nan],
+        ],
+        dtype=np.float32,
+    )
+    expected = np.array([1, 0, 4], dtype=np.int64)
+    numpy_result = np.argmax(data, axis=1) if op_name == "ArgMax" else np.argmin(data, axis=1)
+    np.testing.assert_array_equal(numpy_result, expected)
+
+    model = _make_arg_min_max_model(op_name, data.shape, [3], axis=1, keepdims=0)
+    check_correctness(model, inputs={"data": data}, opset=12)
+
+
+@pytest.mark.parametrize("op_name", ["ArgMax", "ArgMin"])
+def test_arg_min_max_nan_keepdims_and_all_nan(op_name):
+    data = np.array(
+        [
+            [[np.nan, np.nan, np.nan], [5.0, np.nan, 1.0]],
+            [[2.0, 3.0, np.nan], [np.nan, -1.0, -2.0]],
+        ],
+        dtype=np.float32,
+    )
+    model = _make_arg_min_max_model(op_name, data.shape, [2, 2, 1], axis=2, keepdims=1)
+    check_correctness(model, inputs={"data": data}, opset=12)
+
+
+@pytest.mark.parametrize("op_name", ["ArgMax", "ArgMin"])
+def test_arg_min_max_nan_select_last_index(op_name):
+    data = np.array(
+        [
+            [[np.nan, 2.0, np.nan, 1.0], [np.nan, np.nan, np.nan, np.nan]],
+            [[5.0, np.nan, 1.0, np.nan], [4.0, 3.0, 2.0, 1.0]],
+        ],
+        dtype=np.float32,
+    )
+    model = _make_arg_min_max_model(
+        op_name,
+        data.shape,
+        [2, 2],
+        axis=2,
+        keepdims=0,
+        select_last_index=1,
+    )
+    check_correctness(model, inputs={"data": data}, opset=12)
+
+
+@pytest.mark.parametrize("op_name", ["ArgMax", "ArgMin"])
+def test_arg_min_max_finite_regression(op_name):
+    data = np.array(
+        [[2.0, 4.0, 7.0, 1.0, 5.0], [3.0, -2.0, 8.0, 6.0, 0.0]],
+        dtype=np.float32,
+    )
+    model = _make_arg_min_max_model(op_name, data.shape, [2], axis=1, keepdims=0)
+    check_correctness(model, inputs={"data": data}, opset=12)
+
+
 @pytest.mark.parametrize("axis", [-1, 0, 1])
 @pytest.mark.parametrize("largest", [True, False])
 def test_topk(axis: int, largest: int):


### PR DESCRIPTION
## Summary

ONNX models that run `ArgMax`/`ArgMin` over float tensors containing NaN now import through the Relax frontend with the same winning index that ONNX Runtime returns.

## Why this matters

Issue [#19558](https://github.com/apache/tvm/issues/19558) reports that the Relax ONNX frontend picks a different index than ORT and NumPy when NaN is present: ORT lets NaN win `>` comparisons so a leading NaN survives, while `topi.argmax` drops NaN through `val > current_max` and returns the first finite extreme instead. Maintainer swjng confirmed this is an ORT-compatibility gap in the frontend rather than a spec issue, and suggested substituting NaN before the reduction. The fix lives only in the ONNX converter (`onnx_frontend.py`), where ORT parity is the contract, so the generic `topi`/Relax operator is untouched.

## Testing

A new `_argreduce_sanitize_nan` helper in `python/tvm/relax/frontend/onnx/onnx_frontend.py` replaces NaN with `+inf` for `ArgMax` and `-inf` for `ArgMin` on floating-point inputs before `argmax`/`argmin`, across the `_impl_v1`/`_impl_v11`/`_impl_v12` paths. Added tests in `tests/python/relax/test_frontend_onnx.py` cover the issue's `[2, NaN, 7, 4, 1]`-style cases against ORT indices `1, 0, 4`, all-NaN and `keepdims=1`, `select_last_index=1`, and a finite-only regression case. Covered by the new tests in this PR; full suite runs in CI.

Fixes #19558
