### PR TITLE
fix: ONNX ConvTranspose bias broadcast mismatch in Relax frontend

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1820,10 +1820,13 @@ class ConvTranspose(OnnxOpConverter):
         strides = attr.get("strides", [1] * spatial_dims)
         dilations = attr.get("dilations", [1] * spatial_dims)
         output_padding = attr.get("output_padding", [0] * spatial_dims)
+        groups = attr.get("group", 1)
+        weight_shape = inputs[1].ty.shape
+        out_channels = weight_shape.values[1] * groups
         if "kernel_shape" in attr:
             kernel_shape = list(attr["kernel_shape"])
         else:
-            kernel_shape = [int(s) for s in inputs[1].ty.shape.values[2:]]
+            kernel_shape = [int(s) for s in weight_shape.values[2:]]
 
         # Resolve `auto_pad` per ONNX ConvTranspose spec. Unlike Conv, the spec
         # derives `pads` from `output_shape`/`strides` when auto_pad is SAME_*,
@@ -1872,13 +1875,42 @@ class ConvTranspose(OnnxOpConverter):
             padding=attr.get("pads", 0),
             output_padding=output_padding,
             dilation=dilations,
-            groups=attr.get("group", 1),
+            groups=groups,
             data_layout=data_layout,
             kernel_layout=kernel_layout,
         )
 
         if inputs[2] is not None:
-            bias = relax.op.reshape(inputs[2], [1, -1] + [1] * (ndim - 2))
+            bias_shape = inputs[2].ty.shape
+            if hasattr(inputs[2].ty, "ndim"):
+                bias_ndim = inputs[2].ty.ndim
+            else:
+                bias_ndim = len(bias_shape)
+            if bias_ndim != 1:
+                raise ValueError(f"ConvTranspose bias must be a 1D tensor, but got ndim={bias_ndim}")
+
+            def _as_static_int(dim):
+                try:
+                    return int(dim)
+                except (TypeError, ValueError, TVMError):
+                    return None
+
+            if isinstance(bias_shape, relax.ShapeExpr):
+                bias_channels = bias_shape.values[0]
+                static_bias_channels = _as_static_int(bias_channels)
+                static_out_channels = _as_static_int(out_channels)
+                if (
+                    static_bias_channels is not None
+                    and static_out_channels is not None
+                    and static_bias_channels != static_out_channels
+                ):
+                    raise ValueError(
+                        "ConvTranspose bias length must equal output channels "
+                        f"(weight.shape[1] * group = {static_out_channels}), "
+                        f"but got {static_bias_channels}."
+                    )
+
+            bias = relax.op.reshape(inputs[2], [1, out_channels] + [1] * (ndim - 2))
             conv_out = relax.op.add(conv_out, bias)
 
         return conv_out

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1887,12 +1887,14 @@ class ConvTranspose(OnnxOpConverter):
             else:
                 bias_ndim = len(bias_shape)
             if bias_ndim != 1:
-                raise ValueError(f"ConvTranspose bias must be a 1D tensor, but got ndim={bias_ndim}")
+                raise ValueError(
+                    f"ConvTranspose bias must be a 1D tensor, but got ndim={bias_ndim}"
+                )
 
             def _as_static_int(dim):
                 try:
                     return int(dim)
-                except (TypeError, ValueError, TVMError):
+                except (TypeError, ValueError, RuntimeError):
                     return None
 
             if isinstance(bias_shape, relax.ShapeExpr):

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -3504,9 +3504,9 @@ def test_conv(stride: int, dilation: int, pad: int, bias: bool, auto_pad: str):
 @pytest.mark.parametrize("pad", [0, 2])
 @pytest.mark.parametrize("output_pad", [0, 1])
 def test_conv_transpose(stride: int, dilation: int, pad: int, bias: bool, output_pad: int):
-    def _verify_conv_transpose(input_shape, weight_shape):
+    def _verify_conv_transpose(input_shape, weight_shape, group=1):
         nd = len(weight_shape) - 2
-        output_shape = [input_shape[0], weight_shape[0]] + [
+        output_shape = [input_shape[0], weight_shape[1] * group] + [
             (input_shape[i] - 1) * stride
             - 2 * pad
             + dilation * (weight_shape[i] - 1)
@@ -3523,7 +3523,7 @@ def test_conv_transpose(stride: int, dilation: int, pad: int, bias: bool, output
             dilations=[dilation] * nd,
             pads=[pad] * nd * 2,
             output_padding=[output_pad] * nd,
-            group=input_shape[1] // weight_shape[1],
+            group=group,
         )
         graph = helper.make_graph(
             [conv_node],
@@ -3540,14 +3540,38 @@ def test_conv_transpose(stride: int, dilation: int, pad: int, bias: bool, output
         check_correctness(model, atol=1e-4)
 
     # ConvTranspose1D
-    _verify_conv_transpose([3, 4, 32], [4, 4, 3])
-    _verify_conv_transpose([3, 4, 32], [4, 2, 3])  # group=2
+    _verify_conv_transpose([3, 4, 32], [4, 6, 3])
+    _verify_conv_transpose([3, 4, 32], [4, 3, 3], group=2)
     # ConvTranspose2D
-    _verify_conv_transpose([3, 4, 32, 32], [4, 4, 3, 3])
-    _verify_conv_transpose([3, 4, 32, 32], [4, 2, 3, 3])  # group=2
+    _verify_conv_transpose([3, 4, 32, 32], [4, 6, 3, 3])
+    _verify_conv_transpose([3, 4, 32, 32], [4, 3, 3, 3], group=2)
     # ConvTranspose3D
-    _verify_conv_transpose([3, 4, 12, 12, 12], [4, 4, 3, 3, 3])
-    _verify_conv_transpose([3, 4, 12, 12, 12], [4, 2, 3, 3, 3])  # group=2
+    _verify_conv_transpose([3, 4, 12, 12, 12], [4, 6, 3, 3, 3])
+    _verify_conv_transpose([3, 4, 12, 12, 12], [4, 3, 3, 3, 3], group=2)
+
+
+def test_conv_transpose_invalid_bias_channel_count():
+    conv_node = helper.make_node(
+        "ConvTranspose",
+        inputs=["x", "w", "b"],
+        outputs=["y"],
+        pads=[0, 0, 0, 0],
+        group=2,
+    )
+    graph = helper.make_graph(
+        [conv_node],
+        "conv_transpose_invalid_bias_test",
+        inputs=[
+            helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4, 5, 5]),
+            helper.make_tensor_value_info("w", TensorProto.FLOAT, [4, 3, 3, 3]),
+            helper.make_tensor_value_info("b", TensorProto.FLOAT, [5]),
+        ],
+        outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 6, 7, 7])],
+    )
+
+    model = helper.make_model(graph, producer_name="conv_transpose_invalid_bias_test")
+    with pytest.raises(ValueError, match="ConvTranspose bias length"):
+        from_onnx(model, opset=14, keep_params_in_input=True)
 
 
 @pytest.mark.parametrize("auto_pad", ["SAME_UPPER", "SAME_LOWER", "VALID"])

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -3550,6 +3550,29 @@ def test_conv_transpose(stride: int, dilation: int, pad: int, bias: bool, output
     _verify_conv_transpose([3, 4, 12, 12, 12], [4, 3, 3, 3, 3], group=2)
 
 
+def test_conv_transpose_valid_bias_channel_count():
+    conv_node = helper.make_node(
+        "ConvTranspose",
+        inputs=["x", "w", "b"],
+        outputs=["y"],
+        pads=[0, 0, 0, 0],
+        group=1,
+    )
+    graph = helper.make_graph(
+        [conv_node],
+        "conv_transpose_valid_bias_test",
+        inputs=[
+            helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 32, 8, 8]),
+            helper.make_tensor_value_info("w", TensorProto.FLOAT, [32, 16, 3, 3]),
+            helper.make_tensor_value_info("b", TensorProto.FLOAT, [16]),
+        ],
+        outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 16, 10, 10])],
+    )
+
+    model = helper.make_model(graph, producer_name="conv_transpose_valid_bias_test")
+    check_correctness(model, atol=1e-4)
+
+
 def test_conv_transpose_invalid_bias_channel_count():
     conv_node = helper.make_node(
         "ConvTranspose",


### PR DESCRIPTION
## Summary

ONNX models with a `ConvTranspose` node that carries a bias now import through the Relax frontend instead of failing on a broadcast check, matching the output ONNX Runtime produces.

## Why this matters

Issue [#18600](https://github.com/apache/tvm/issues/18600) reports `InternalError: ... relax.add ... dim 1 is 16 and ... 32, which are not broadcastable` when importing a ConvTranspose model that runs fine under ONNX Runtime and onnx's ReferenceEvaluator. The converter derived output channels from `weight.shape[0]`, but for ConvTranspose the weight layout is `(in_channels, out_channels/groups, *kernel)`, so true output channels are `weight.shape[1] * groups`. The 16-length bias was then broadcast against a wrong 32-channel shape.

## Testing

The `ConvTranspose` converter in `python/tvm/relax/frontend/onnx/onnx_frontend.py` now computes `out_channels = weight.shape[1] * groups`, reshapes the bias to `[1, out_channels, 1, ...]`, and raises a clear `ValueError` when a static bias length genuinely mismatches the output channels. Tests in `tests/python/relax/test_frontend_onnx.py` were extended so `_verify_conv_transpose` checks 1D/2D/3D variants with `group=1` and `group=2`, plus a new `test_conv_transpose_invalid_bias_channel_count` asserting the error path. Covered by the updated tests in this PR; full suite runs in CI.

Fixes #18600
