### PR TITLE
[Bump] tvm-ffi to 59da4c0

### DIFF
--- a/src/ir/access_path_repr.cc
+++ b/src/ir/access_path_repr.cc
@@ -23,19 +23,19 @@
  *
  * This file:
  *  - Registers node.AsRepr (for backward Python compatibility) via ffi::ReprPrint.
- *  - Registers __ffi_repr__ hooks for ffi::reflection::AccessPath and AccessStep
- *    so that ffi.ReprPrint formats them as concise "<root>.field[idx]" strings.
+ *
+ * Note: __ffi_repr__ hooks for ffi::reflection::AccessPath and AccessStep are
+ * registered by tvm-ffi itself (src/ffi/extra/reflection_extra.cc, landed in
+ * apache/tvm-ffi#598). The duplicate registrations that previously lived here
+ * were removed when bumping tvm-ffi to 59da4c0 to avoid a double-registration
+ * abort at library load time.
  *
  * Note: tvm::Dump() has been removed (zero in-tree callers). Use
  * tvm::ffi::ReprPrint(any) directly from gdb instead.
  */
-#include <tvm/ffi/cast.h>
 #include <tvm/ffi/extra/dataclass.h>
 #include <tvm/ffi/function.h>
-#include <tvm/ffi/reflection/access_path.h>
 #include <tvm/ffi/reflection/registry.h>
-
-#include <sstream>
 
 namespace tvm {
 
@@ -45,51 +45,5 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   // Python's tvm.runtime._ffi_node_api sets __object_repr__ = AsRepr via init_ffi_api.
   refl::GlobalDef().def("node.AsRepr",
                         [](ffi::Any obj) -> ffi::String { return ffi::ReprPrint(obj); });
-  // Register __ffi_repr__ for ffi::reflection::AccessPath/AccessStep so that ffi.ReprPrint
-  // uses the concise "<root>.field[idx]" format.
-  //
-  // AccessStep: format one step fragment (e.g. ".field", "[0]", "[key]?").
-  refl::TypeAttrDef<ffi::reflection::AccessStepObj>().def(
-      refl::type_attr::kRepr,
-      [](ffi::reflection::AccessStep step, ffi::Function fn_repr) -> ffi::String {
-        using ffi::reflection::AccessKind;
-        std::ostringstream os;
-        switch (step->kind) {
-          case AccessKind::kAttr:
-            os << "." << step->key.cast<ffi::String>();
-            break;
-          case AccessKind::kArrayItem:
-            os << "[" << step->key.cast<int64_t>() << "]";
-            break;
-          case AccessKind::kMapItem:
-            os << "[" << fn_repr(step->key).cast<ffi::String>() << "]";
-            break;
-          case AccessKind::kAttrMissing:
-            os << "." << step->key.cast<ffi::String>() << "?";
-            break;
-          case AccessKind::kArrayItemMissing:
-            os << "[" << step->key.cast<int64_t>() << "]?";
-            break;
-          case AccessKind::kMapItemMissing:
-            os << "[" << fn_repr(step->key).cast<ffi::String>() << "]?";
-            break;
-        }
-        return os.str();
-      });
-  // ffi::reflection::AccessPath: recurse through parent via fn_repr rather than walking the
-  // linked list manually.  Root (no step) emits "<root>"; each non-root node
-  // prepends its parent's repr and appends the current step's repr.
-  refl::TypeAttrDef<ffi::reflection::AccessPathObj>().def(
-      refl::type_attr::kRepr,
-      [](ffi::reflection::AccessPath path, ffi::Function fn_repr) -> ffi::String {
-        if (!path->step.has_value()) {
-          // Root node: no parent, no step.
-          return "<root>";
-        }
-        std::ostringstream os;
-        os << fn_repr(path->parent.value()).cast<ffi::String>();
-        os << fn_repr(path->step.value()).cast<ffi::String>();
-        return os.str();
-      });
 }
 }  // namespace tvm


### PR DESCRIPTION
[Bump] tvm-ffi to 59da4c0

Bumps `3rdparty/tvm-ffi` from 98d0029 to 59da4c0, picking up seven
commits from apache/tvm-ffi:

- [FEAT] Optimize Expected<T> for minimal compiled code and efficiency (#599)
- [FEAT] Streamline AccessPath/AccessStep print format (#598)
- [CI] Use uv tool run for sdist build instead of pipx (#600)
- [CORE] Make AnyView trivially copyable — match C-ABI struct passing (#602)
- feat(python): add tensor methods to align with C++ APIs (#604)
- [FIX] Drop test_empty_tensor_attributes (numpy dlpack stride change) (#607)
- [TEST] Relax test_shared_dag_hash_scaling_not_exponential ratio to 4x (#612)

The bump range is additive for almost all of the above (performance
improvements to Expected<T>, new Python tensor methods, AnyView ABI
alignment, CI toolchain switch). One commit required a TVM-side
migration:

apache/tvm-ffi#598 moved the `__ffi_repr__` hooks for
`ffi::reflection::AccessPath` and `AccessStep` into tvm-ffi itself
(src/ffi/extra/reflection_extra.cc, compiled into libtvm_ffi.so).
TVM already registered the same hooks in src/ir/access_path_repr.cc,
causing a double-registration abort at library load time. This commit
removes the duplicate AccessPath/AccessStep `__ffi_repr__` registrations
from access_path_repr.cc, keeping only the `node.AsRepr` global function
that tvm-ffi does not provide. The format emitted by tvm-ffi's hooks is
equivalent for common cases; missing-item steps now use the
`[<missing:...>]` notation from tvm-ffi rather than the `...?` suffix
that TVM used previously.