### PR TITLE
[RELEASE] Bump web npm version to 0.25.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tvmjs",
-  "version": "0.25.0-dev0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tvmjs",
-      "version": "0.25.0-dev0",
+      "version": "0.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "audit": "^0.0.6",

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "description": "TVM WASM/WebGPU runtime for JS/TS",
   "license": "Apache-2.0",
   "homepage": "https://github.com/apache/tvm/tree/main/web",
-  "version": "0.25.0-dev0",
+  "version": "0.25.0",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
This commit bumps the version numbers under `web/` for v0.25.0.