### PR TITLE
[CI] Target apache-tvm for PyPI wheel publishing

### DIFF
--- a/.github/workflows/publish_wheel.yml
+++ b/.github/workflows/publish_wheel.yml
@@ -31,7 +31,6 @@ on:
         type: choice
         options:
           - none
-          - testpypi
           - pypi
 
 permissions:
@@ -224,14 +223,6 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: dist/*
-
-      - name: Publish package distributions to TestPyPI
-        if: ${{ inputs.publish_repository == 'testpypi' }}
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-        with:
-          attestations: true
-          verbose: true
-          repository-url: https://test.pypi.org/legacy/
 
       - name: Publish package distributions to PyPI
         if: ${{ inputs.publish_repository == 'pypi' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires = ["scikit-build-core>=0.11", "setuptools-scm>=8"]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "tvm"
+name = "apache-tvm"
 # The version is derived from the most recent Git tag by setuptools_scm at build
 # time (see [tool.setuptools_scm]); no manual version stamping is required.
 dynamic = ["version"]
@@ -144,7 +144,7 @@ BUILD_TESTING = "OFF"
 # Version comes from the most recent Git tag (vMAJOR.MINOR.devN or vMAJOR.MINOR.PATCH).
 # guess-next-dev reproduces the previous version.py behaviour for vMAJOR.MINOR.devN
 # tags (e.g. v0.25.dev0 + N commits -> 0.25.devN). local_scheme = "no-local-version"
-# drops the +g<hash> local segment: PyPI/TestPyPI reject local versions on upload, and
+# drops the +g<hash> local segment: PyPI rejects local versions on upload, and
 # this matches the public version the old version.py stamped.
 version_file = "python/tvm/_version.py"
 version_scheme = "guess-next-dev"


### PR DESCRIPTION
This PR cherry-picks #19686 to v0.25.0 branch for release, since the wheel build depends on the package rename from "tvm" to "apache-tvm".