### PR TITLE
[Python] Bump apache-tvm-ffi floor to >=0.1.12 on v0.25.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "apache-tvm-ffi>=0.1.11",
+  "apache-tvm-ffi>=0.1.12",
   "ml_dtypes",
   "numpy",
   "psutil",


### PR DESCRIPTION
Bumping tvm-ffi minimal requirement since v0.1.12 is released.