### PR TITLE
[CI] Pin actions by version tag, trim wheel perms

### DIFF
--- a/.github/actions/build-wheel-for-publish/action.yml
+++ b/.github/actions/build-wheel-for-publish/action.yml
@@ -55,7 +55,7 @@ runs:
 
     # ---- Cache LLVM prefix ----
     - name: Cache LLVM
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@v5.0.5
       id: llvm-cache
       with:
         path: ${{ runner.os == 'Windows' && 'C:/opt/llvm' || '/opt/llvm' }}
@@ -64,7 +64,7 @@ runs:
     # ---- Install LLVM via conda (cache miss only) ----
     - name: Setup conda
       if: steps.llvm-cache.outputs.cache-hit != 'true'
-      uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
+      uses: conda-incubator/setup-miniconda@v4.0.1
       continue-on-error: true
       id: conda1
       with:
@@ -73,7 +73,7 @@ runs:
 
     - name: Setup conda (retry with tar.bz2)
       if: steps.llvm-cache.outputs.cache-hit != 'true' && steps.conda1.outcome == 'failure'
-      uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
+      uses: conda-incubator/setup-miniconda@v4.0.1
       with:
         miniforge-version: latest
         use-only-tar-bz2: true
@@ -108,7 +108,7 @@ runs:
 
     # ---- Build and test wheels ----
     - name: Build and test wheels
-      uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
+      uses: pypa/cibuildwheel@v3.3.1
       with:
         package-dir: .
         output-dir: wheelhouse

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,13 +1,13 @@
 runs:
  using: "composite"
  steps:
-  - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+  - uses: actions/cache@v5.0.5
     env:
       CACHE_NUMBER: 2
     with:
       path: ~/conda_pkgs_dir
       key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/scripts/package/build-environment.yaml') }}
-  - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
+  - uses: conda-incubator/setup-miniconda@v4.0.1
     continue-on-error: true
     id: conda1
     with:
@@ -19,7 +19,7 @@ runs:
       python-version: "3.10"
       condarc-file: tests/conda/condarc
       conda-remove-defaults: true
-  - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
+  - uses: conda-incubator/setup-miniconda@v4.0.1
     if: steps.conda1.outcome == 'failure'
     with:
       activate-environment: tvm-build

--- a/.github/workflows/cc_bot.yml
+++ b/.github/workflows/cc_bot.yml
@@ -35,7 +35,7 @@ jobs:
     if: github.repository == 'apache/tvm'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: "recursive"
       - name: Add cc'ed reviewers

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,8 +31,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.repository == 'apache/tvm' }}
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: 'recursive'
       - name: Set up environment
@@ -79,7 +79,7 @@ jobs:
     if: ${{ github.repository == 'apache/tvm' }}
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: 'recursive'
       - name: Set up environment

--- a/.github/workflows/nightly_docker_update.yml
+++ b/.github/workflows/nightly_docker_update.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'apache/tvm'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6.0.2
       - name: Open PR to update Docker images
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ping_reviewers.yml
+++ b/.github/workflows/ping_reviewers.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'apache/tvm'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6.0.2
       - name: Ping reviewers
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_wheel.yml
+++ b/.github/workflows/publish_wheel.yml
@@ -82,7 +82,7 @@ jobs:
         run: git config --global --add safe.directory '*'
 
       - name: Checkout source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive
@@ -92,7 +92,7 @@ jobs:
       # Windows has no manylinux interpreter; the script's pip install needs one.
       - name: Set up Python (Windows host)
         if: runner.os == 'Windows'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.10"
 
@@ -107,7 +107,7 @@ jobs:
         run: call ${{ matrix.script }}
 
       - name: Upload CUDA runtime sidecar
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tvm-cuda-runtime-${{ matrix.arch }}
           path: ${{ matrix.lib }}
@@ -150,7 +150,7 @@ jobs:
             artifact_suffix: windows-amd64
     steps:
       - name: Checkout source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive
@@ -163,7 +163,7 @@ jobs:
       # mount expects it. Skipped on CPU-only rows (macOS).
       - name: Download CUDA runtime sidecar
         if: ${{ matrix.include_cuda_runtime == '1' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v8.0.1
         with:
           name: tvm-cuda-runtime-${{ matrix.arch }}
           path: build-wheel-cuda/lib
@@ -177,7 +177,7 @@ jobs:
           include_cuda_runtime: ${{ matrix.include_cuda_runtime }}
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tvm-wheel-${{ matrix.artifact_suffix }}
           path: wheelhouse/*.whl
@@ -190,12 +190,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.publish_repository }}
     permissions:
-      actions: read
-      contents: read
       id-token: write
       attestations: write
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@v8.0.1
         with:
           pattern: tvm-wheel-*
           path: dist
@@ -208,13 +206,13 @@ jobs:
         run: ls -alh dist/*.whl
 
       - name: Generate artifact attestation for wheels
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@v4.1.0
         with:
           subject-path: dist/*
 
       - name: Publish package distributions to PyPI
         if: ${{ inputs.publish_repository == 'pypi' }}
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           attestations: true
           verbose: true

--- a/.github/workflows/tag_teams.yml
+++ b/.github/workflows/tag_teams.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.repository == 'apache/tvm'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6.0.2
       - name: Tag people from relevant teams
         env:
           PR: ${{ toJson(github.event.pull_request) }}

--- a/.github/workflows/tvmbot.yml
+++ b/.github/workflows/tvmbot.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ github.event.issue.pull_request && github.repository == 'apache/tvm' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6.0.2
       - name: Run tvm-bot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_last_successful_branch.yml
+++ b/.github/workflows/update_last_successful_branch.yml
@@ -35,7 +35,7 @@ jobs:
     if: github.repository == 'apache/tvm'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6.0.2
       - name: Update last-successful branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_nightly_branch.yml
+++ b/.github/workflows/update_nightly_branch.yml
@@ -33,7 +33,7 @@ jobs:
     if: github.repository == 'apache/tvm'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6.0.2
       - name: Update nightly branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Convert SHA-pinned third-party actions to their full version tags across all workflows and composite actions; each tag verified to resolve to the same commit that was pinned.

Drop the unused actions:read / contents:read permissions from the upload_pypi job (aligns with apache/tvm-ffi). No behavior change.