### PR TITLE
[Tests] Skip source-tree-only tests in wheel testing

### DIFF
--- a/tests/python/codegen/test_codegen_assert.py
+++ b/tests/python/codegen/test_codegen_assert.py
@@ -22,7 +22,10 @@ import tvm
 import tvm.testing
 from tvm.script import tirx as T
 
-codegen_target = tvm.testing.parameter("llvm", "c")
+codegen_target = tvm.testing.parameter(
+    "llvm",
+    pytest.param("c", marks=tvm.testing.skip_if_wheel_test),
+)
 
 
 def test_assert_runtime_error(codegen_target):

--- a/tests/python/codegen/test_codegen_error_handling.py
+++ b/tests/python/codegen/test_codegen_error_handling.py
@@ -31,7 +31,10 @@ import tvm.testing
 from tvm.script import tirx as T
 
 # Parameterize over both LLVM and C backends
-codegen_target = tvm.testing.parameter("llvm", "c")
+codegen_target = tvm.testing.parameter(
+    "llvm",
+    pytest.param("c", marks=tvm.testing.skip_if_wheel_test),
+)
 
 
 # ── Argument count errors ────────────────────────────────────

--- a/tests/python/codegen/test_target_codegen_c_host.py
+++ b/tests/python/codegen/test_target_codegen_c_host.py
@@ -24,6 +24,7 @@ from tvm.script import tirx as T
 from tvm.support import utils
 
 
+@tvm.testing.skip_if_wheel_test
 def test_add():
     nn = 1024
 
@@ -61,6 +62,7 @@ def test_add():
     check_c()
 
 
+@tvm.testing.skip_if_wheel_test
 def test_reinterpret():
     nn = 1024
 
@@ -96,6 +98,7 @@ def test_reinterpret():
     check_c()
 
 
+@tvm.testing.skip_if_wheel_test
 def test_ceil():
     nn = 1024
 
@@ -131,6 +134,7 @@ def test_ceil():
     check_c()
 
 
+@tvm.testing.skip_if_wheel_test
 def test_floor():
     nn = 1024
 
@@ -166,6 +170,7 @@ def test_floor():
     check_c()
 
 
+@tvm.testing.skip_if_wheel_test
 def test_round():
     nn = 1024
 

--- a/tests/python/codegen/test_target_codegen_cuda.py
+++ b/tests/python/codegen/test_target_codegen_cuda.py
@@ -977,6 +977,7 @@ def test_cuda_float_const_hex_format():
     assert "0x1.2f684bda12f68p-5f" in cuda_code
 
 
+@tvm.testing.skip_if_wheel_test
 @tvm.testing.requires_cuda
 def test_device_host_call_same_func():
     @I.ir_module(s_tir=True)

--- a/tests/python/driver/test_compile.py
+++ b/tests/python/driver/test_compile.py
@@ -85,6 +85,7 @@ def test_compile_relax():
     tvm.testing.assert_allclose(z.numpy(), x_np + y_np)
 
 
+@tvm.testing.skip_if_wheel_test
 @tvm.testing.skip_if_32bit(reason="skipping test for i386.")
 def test_compile_mixed_module():
     @tvm.script.ir_module

--- a/tests/python/relax/test_frontend_nn_extern_module.py
+++ b/tests/python/relax/test_frontend_nn_extern_module.py
@@ -145,6 +145,7 @@ def _compile_cc(src: Path, dst: Path):
             raise RuntimeError(msg)
 
 
+@tvm.testing.skip_if_wheel_test
 def test_extern_object():
     with tempfile.TemporaryDirectory() as temp_dir_str:
         path = Path(temp_dir_str) / "main.o"
@@ -198,6 +199,7 @@ def test_extern_object():
         _test_infer_sym(compiled["test_sym"], x=3, y=4, z=2)
 
 
+@tvm.testing.skip_if_wheel_test
 def test_extern_source():
     source = Path(__file__).parent / "frontend_nn_extern_module.cc"
 

--- a/tests/python/relax/test_vm_build.py
+++ b/tests/python/relax/test_vm_build.py
@@ -35,7 +35,7 @@ from tvm.script import relax as R
 from tvm.script import tirx as T
 from tvm.support import cc, popen_pool, utils
 
-EXEC_MODE = ["bytecode", "compiled"]
+EXEC_MODE = [pytest.param("bytecode", marks=tvm.testing.skip_if_wheel_test), "compiled"]
 
 
 @pytest.fixture(params=EXEC_MODE)

--- a/tests/python/relax/test_vm_codegen_only.py
+++ b/tests/python/relax/test_vm_codegen_only.py
@@ -109,6 +109,7 @@ def test_if_cond_const(exec_mode):
     tvm.testing.assert_allclose(res.numpy(), inp.numpy())
 
 
+@tvm.testing.skip_if_wheel_test
 @pytest.mark.parametrize("exec_mode", EXEC_MODE)
 def test_vm_exec_serialize_export_library(exec_mode):
     @tvm.script.ir_module

--- a/tests/python/runtime/test_executable.py
+++ b/tests/python/runtime/test_executable.py
@@ -228,6 +228,7 @@ def test_executable_integration():
             shutil.rmtree(temp_dir)
 
 
+@tvm.testing.skip_if_wheel_test
 def test_executable_jit_force_recompile():
     """Test jit method with force_recompile=True."""
     # Create target and build


### PR DESCRIPTION
This pr skip tests that require a source checkout when running against the Python wheel.

The `apache-tvm==0.25.0rc0` wheel does not include the source/include tree needed by `tvm.libinfo.find_include_path()`. Some tests call `export_library()` or JIT through the C host backend, which then fails in wheel testing with:

```text
AssertionError: Cannot find the source directory given ffi_dir: .../site-packages/tvm