### PR TITLE
[Tests] Fix s_tir tests using removed T.block API in TIRx script

### DIFF
--- a/tests/python/s_tir/meta_schedule/test_meta_schedule_postproc_rewrite_parallel_vectorize_unroll.py
+++ b/tests/python/s_tir/meta_schedule/test_meta_schedule_postproc_rewrite_parallel_vectorize_unroll.py
@@ -189,10 +189,10 @@ def before_postproc_dynamic_shape_vectorize(
     n = T.int64()
     A = T.match_buffer(a, (n,), dtype="float32")
     B = T.match_buffer(b, (n,), dtype="float32")
-    with T.block("root"):
-        T.block_attr({"meta_schedule.vectorize": 64})
+    with T.sblock("root"):
+        T.sblock_attr({"meta_schedule.vectorize": 64})
         for i in T.serial(0, n):
-            with T.block("copy"):
+            with T.sblock("copy"):
                 vi = T.axis.spatial(n, i)
                 T.reads(A[vi])
                 T.writes(B[vi])

--- a/tests/python/s_tir/meta_schedule/test_meta_schedule_schedule_rule_auto_inline.py
+++ b/tests/python/s_tir/meta_schedule/test_meta_schedule_schedule_rule_auto_inline.py
@@ -542,13 +542,13 @@ def test_no_inline_root_block():
             data_red: T.Buffer((), "float32"),
         ):
             T.func_attr({"tir.noalias": T.bool(True)})
-            with T.block("data_red"):
+            with T.sblock("data_red"):
                 T.reads(data[0:8, 0:8])
                 T.writes(data_red[()])
                 with T.init():
                     data_red[()] = T.float32(-3.4e38)
                 for i, j in T.grid(8, 8):
-                    with T.block("update"):
+                    with T.sblock("update"):
                         T.reads(data_red[()], data[i, j])
                         T.writes(data_red[()])
                         data_red[()] = T.max(data_red[()], data[i, j])


### PR DESCRIPTION
Two test files under `tests/python/s_tir/meta_schedule/` use the TIRx script dialect (`from tvm.script import tirx as T`) but still call the old TIR block API, which does not exist in `tvm.tirx.script.
This pr fixes this