### PR TITLE
[Wheel] Fix include path discovery for installed wheels

### DIFF
--- a/python/tvm/libinfo.py
+++ b/python/tvm/libinfo.py
@@ -22,6 +22,7 @@ import os
 import sys
 from pathlib import Path
 
+from tvm_ffi import libinfo as tvm_ffi_libinfo
 from tvm_ffi.libinfo import load_lib_ctypes
 
 
@@ -34,6 +35,16 @@ def use_runtime_lib() -> bool:
     return os.environ.get("TVM_USE_RUNTIME_LIB", "0").lower() in ("1", "true", "yes")
 
 
+def _rel_top_directory() -> Path:
+    """Get the current directory of this file."""
+    return Path(__file__).parent
+
+
+def _dev_top_directory() -> Path:
+    """Get the top-level development directory."""
+    return _rel_top_directory() / ".." / ".."
+
+
 def package_lib_paths() -> list[Path]:
     """Return search directories for TVM's shared libraries.
 
@@ -44,14 +55,13 @@ def package_lib_paths() -> list[Path]:
     pick the basenames they want (e.g. ``libtvm_runtime.so``) and the load
     mode; this function only returns the search path.
     """
-    pkg = Path(__file__).parent  # python/tvm/
     paths: list[Path] = []
     if os.environ.get("TVM_LIBRARY_PATH"):
         paths.append(Path(os.environ["TVM_LIBRARY_PATH"]))
     paths += [
-        pkg / "lib",  # wheel layout
-        pkg.parent.parent / "build" / "lib",  # dev: <worktree>/build/lib
-        pkg.parent.parent / "lib",  # dev: <worktree>/lib
+        _rel_top_directory() / "lib",  # wheel layout
+        _dev_top_directory() / "build" / "lib",  # dev: <worktree>/build/lib
+        _dev_top_directory() / "lib",  # dev: <worktree>/lib
     ]
     return paths
 
@@ -95,232 +105,130 @@ def split_env_var(env_var, split):
     return []
 
 
-def get_dll_directories():
-    """Get the possible dll directories"""
-    # NB: This will either be the source directory (if TVM is run
-    # inplace) or the install directory (if TVM is installed).
-    # An installed TVM's curr_path will look something like:
-    #   $PREFIX/lib/python3.6/site-packages/tvm/_ffi
-    ffi_dir = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
-    source_dir = os.path.join(ffi_dir, "..", "..")
-    install_lib_dir = os.path.join(ffi_dir, "..", "..", "..")
-
-    dll_path = []
-
-    if os.environ.get("TVM_LIBRARY_PATH", None):
-        dll_path.append(os.environ["TVM_LIBRARY_PATH"])
-
-    if sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
-        dll_path.extend(split_env_var("LD_LIBRARY_PATH", ":"))
-        dll_path.extend(split_env_var("PATH", ":"))
+def _lib_search_directories() -> list[Path]:
+    """Return directories searched when locating libraries and web assets by name."""
+    paths = package_lib_paths()
+    for top in (_rel_top_directory(), _dev_top_directory()):
+        paths += [
+            top / "build" / "lib" / "Release",  # Windows CMake build
+            top / "build" / "Release",
+            top / "build",
+            top / "build" / "3rdparty" / "cutlass_fpA_intB_gemm" / "cutlass_kernels",
+            top / "build" / "3rdparty" / "libflash_attn" / "src",
+            top / "web" / "dist" / "wasm",
+            top / "web" / "dist",
+        ]
+    if sys.platform.startswith("win32"):
+        paths += [Path(p) for p in split_env_var("PATH", ";")]
     elif sys.platform.startswith("darwin"):
-        dll_path.extend(split_env_var("DYLD_LIBRARY_PATH", ":"))
-        dll_path.extend(split_env_var("PATH", ":"))
-    elif sys.platform.startswith("win32"):
-        dll_path.extend(split_env_var("PATH", ";"))
-
-    # Pip lib directory
-    dll_path.append(ffi_dir)
-    dll_path.append(os.path.join(ffi_dir, "lib"))
-    # Default CMake build directory: shared libs are placed under build/lib/
-    # to mirror the tvm-ffi layout (so wheel install + dev-mode dlopen find
-    # them via the same `lib/` subdir).
-    dll_path.append(os.path.join(source_dir, "build", "lib"))
-    dll_path.append(os.path.join(source_dir, "build", "lib", "Release"))
-    dll_path.append(os.path.join(source_dir, "build"))
-    dll_path.append(os.path.join(source_dir, "build", "Release"))
-    # Default make build directory
-    dll_path.append(os.path.join(source_dir, "lib"))
-
-    dll_path.append(install_lib_dir)
-
-    # use extra TVM_HOME environment for finding libraries.
-    if os.environ.get("TVM_HOME", None):
-        tvm_source_home_dir = os.environ["TVM_HOME"]
+        paths += [Path(p) for p in split_env_var("DYLD_LIBRARY_PATH", ":")]
+        paths += [Path(p) for p in split_env_var("PATH", ":")]
     else:
-        tvm_source_home_dir = source_dir
-
-    if os.path.isdir(tvm_source_home_dir):
-        dll_path.append(os.path.join(tvm_source_home_dir, "web", "dist", "wasm"))
-        dll_path.append(os.path.join(tvm_source_home_dir, "web", "dist"))
-
-    dll_path = [os.path.realpath(x) for x in dll_path]
-    return [x for x in dll_path if os.path.isdir(x)]
+        paths += [Path(p) for p in split_env_var("LD_LIBRARY_PATH", ":")]
+        paths += [Path(p) for p in split_env_var("PATH", ":")]
+    return paths
 
 
-def find_lib_path(name=None, search_path=None, optional=False):
+_TVM_LIB_TARGETS = ["tvm_compiler", "tvm_runtime"]
+_TVM_EXT_LIB_TARGETS = ["fpA_intB_gemm", "flash_attn"]
+
+
+def find_lib_path(name=None, optional=False):
     """Find dynamic library files.
 
     Parameters
     ----------
-    name : list of str
-        List of names to be found.
+    name : str or list of str, optional
+        File name(s) to search for across the TVM library directories. When
+        None, search for TVM's own compiler/runtime libraries (plus the
+        optional extension libraries) by their platform-specific names.
+    optional : bool
+        If True, return None instead of raising when nothing is found.
 
     Returns
     -------
     lib_path : list(string)
-        List of all found path to the libraries
+        List of all found paths to the libraries.
     """
-    use_runtime = use_runtime_lib()
-    dll_path = get_dll_directories()
-    # When the caller asks for a specific ``name`` we honour it directly
-    # regardless of TVM_USE_RUNTIME_LIB; that env var is interpreted by
-    # ``base.py::_load_lib`` to choose which name to ask for. This avoids
-    # the runtime/compiler dual-list logic below from making `name` paths
-    # unreachable when the user sets TVM_USE_RUNTIME_LIB.
-    if name is not None:
-        use_runtime = False
-
-    if search_path is not None:
-        if isinstance(search_path, list):
-            dll_path = dll_path + search_path
-        else:
-            dll_path.append(search_path)
+    search_dirs = _lib_search_directories()
 
     if name is not None:
-        if isinstance(name, list):
-            lib_dll_path = []
-            for n in name:
-                lib_dll_path += [os.path.join(p, n) for p in dll_path]
-        else:
-            lib_dll_path = [os.path.join(p, name) for p in dll_path]
-        runtime_dll_path = []
-        ext_lib_dll_path = []
+        # Honour explicit names directly regardless of TVM_USE_RUNTIME_LIB;
+        # that env var is interpreted by ``base.py::_load_lib`` to choose
+        # which name to ask for.
+        names = name if isinstance(name, list) else [name]
+        lib_found = []
+        for search_dir in search_dirs:
+            for n in names:
+                try:
+                    candidate = (search_dir / n).resolve()
+                    found = candidate.is_file()
+                except OSError:
+                    continue
+                if found and str(candidate) not in lib_found:
+                    lib_found.append(str(candidate))
     else:
-        if sys.platform.startswith("win32"):
-            lib_dll_names = ["libtvm_compiler.dll", "tvm_compiler.dll"]
-            runtime_dll_names = ["libtvm_runtime.dll", "tvm_runtime.dll"]
-            ext_lib_dll_names = [
-                "3rdparty/cutlass_fpA_intB_gemm/cutlass_kernels/libfpA_intB_gemm.dll",
-                "3rdparty/libflash_attn/src/libflash_attn.dll",
-            ]
-        elif sys.platform.startswith("darwin"):
-            lib_dll_names = ["libtvm_compiler.dylib"]
-            runtime_dll_names = ["libtvm_runtime.dylib"]
-            ext_lib_dll_names = []
-        else:
-            lib_dll_names = ["libtvm_compiler.so"]
-            runtime_dll_names = ["libtvm_runtime.so"]
-            ext_lib_dll_names = [
-                "3rdparty/cutlass_fpA_intB_gemm/cutlass_kernels/libfpA_intB_gemm.so",
-                "3rdparty/libflash_attn/src/libflash_attn.so",
-            ]
-
-        name = lib_dll_names + runtime_dll_names + ext_lib_dll_names
-        lib_dll_path = [
-            os.path.join(p, name)
-            for name in lib_dll_names
-            for p in dll_path
-            if not p.endswith("python/tvm")
-        ]
-        runtime_dll_path = [
-            os.path.join(p, name)
-            for name in runtime_dll_names
-            for p in dll_path
-            if not p.endswith("python/tvm")
-        ]
-        ext_lib_dll_path = [os.path.join(p, name) for name in ext_lib_dll_names for p in dll_path]
-    if not use_runtime:
-        # try to find lib_dll_path
-        lib_found = [p for p in lib_dll_path if os.path.exists(p) and os.path.isfile(p)]
-        lib_found += [p for p in runtime_dll_path if os.path.exists(p) and os.path.isfile(p)]
-        lib_found += [p for p in ext_lib_dll_path if os.path.exists(p) and os.path.isfile(p)]
-    else:
-        # try to find runtime_dll_path
-        use_runtime = True
-        lib_found = [p for p in runtime_dll_path if os.path.exists(p) and os.path.isfile(p)]
+        use_runtime = use_runtime_lib()
+        names = ["tvm_runtime"] if use_runtime else _TVM_LIB_TARGETS + _TVM_EXT_LIB_TARGETS
+        lib_found = []
+        for target in names:
+            try:
+                lib_found.append(
+                    str(
+                        tvm_ffi_libinfo._find_library_by_basename(
+                            "tvm", target, extra_lib_paths=search_dirs
+                        )
+                    )
+                )
+            except RuntimeError:
+                continue
+        if use_runtime and lib_found:
+            sys.stderr.write(f"Loading runtime library {lib_found[0]}... exec only\n")
+            sys.stderr.flush()
 
     if not lib_found:
-        if not optional:
-            message = (
-                f"Cannot find libraries: {name}\n"
-                + "List of candidates:\n"
-                + "\n".join(lib_dll_path + runtime_dll_path)
-            )
-            raise RuntimeError(message)
-        return None
-
-    if use_runtime:
-        sys.stderr.write(f"Loading runtime library {lib_found[0]}... exec only\n")
-        sys.stderr.flush()
+        if optional:
+            return None
+        raise RuntimeError(
+            f"Cannot find libraries: {names}\n"
+            + "List of directories searched:\n"
+            + "\n".join(str(p) for p in search_dirs)
+        )
     return lib_found
 
 
-def find_include_path(name=None, search_path=None, optional=False):
+def find_tvm_include_path() -> str:
+    """Find TVM's own public header directory for C compilation."""
+    if ret := tvm_ffi_libinfo._resolve_and_validate(
+        paths=[
+            _rel_top_directory() / "include",  # Standard install
+            _dev_top_directory() / "include",  # Development mode
+        ],
+        cond=lambda p: (p / "tvm" / "runtime").is_dir(),
+    ):
+        return ret
+    raise RuntimeError("Cannot find TVM include path.")
+
+
+def find_include_path(optional=False):
     """Find header files for C compilation.
 
     Parameters
     ----------
-    name : list of str
-        List of directory names to be searched.
+    optional : bool
+        If True, return None instead of raising when headers cannot be found.
 
     Returns
     -------
     include_path : list(string)
         List of all found paths to header files.
     """
-    if os.environ.get("TVM_SOURCE_DIR", None):
-        source_dir = os.environ["TVM_SOURCE_DIR"]
-    elif os.environ.get("TVM_HOME", None):
-        source_dir = os.environ["TVM_HOME"]
-    else:
-        ffi_dir = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-        for source_dir in ["..", "../..", "../../.."]:
-            source_dir = os.path.join(ffi_dir, source_dir)
-            if os.path.isdir(os.path.join(source_dir, "include")):
-                break
-        else:
-            raise AssertionError(f"Cannot find the source directory given ffi_dir: {ffi_dir}")
-    third_party_dir = os.path.join(source_dir, "3rdparty")
-
-    header_path = []
-
-    if os.environ.get("TVM_INCLUDE_PATH", None):
-        header_path.append(os.environ["TVM_INCLUDE_PATH"])
-
-    header_path.append(source_dir)
-    header_path.append(third_party_dir)
-
-    header_path = [os.path.abspath(x) for x in header_path]
-    if search_path is not None:
-        if isinstance(search_path, list):
-            header_path = header_path + search_path
-        else:
-            header_path.append(search_path)
-    if name is not None:
-        if isinstance(name, list):
-            tvm_include_path = []
-            for n in name:
-                tvm_include_path += [os.path.join(p, n) for p in header_path]
-        else:
-            tvm_include_path = [os.path.join(p, name) for p in header_path]
-        dlpack_include_path = []
-    else:
-        tvm_include_path = [os.path.join(p, "include") for p in header_path]
-        tvm_ffi_include_path = [
-            os.path.join(p, "3rdparty", "tvm-ffi", "include") for p in header_path
-        ]
-        dlpack_include_path = [
-            os.path.join(p, "3rdparty", "tvm-ffi", "3rdparty", "dlpack", "include")
-            for p in header_path
-        ]
-
-        # try to find include path
-        include_found = [p for p in tvm_include_path if os.path.exists(p) and os.path.isdir(p)]
-        include_found += [p for p in tvm_ffi_include_path if os.path.exists(p) and os.path.isdir(p)]
-        include_found += [p for p in dlpack_include_path if os.path.exists(p) and os.path.isdir(p)]
-
-    if not include_found:
-        message = (
-            "Cannot find the files.\n"
-            + "List of candidates:\n"
-            + str("\n".join(tvm_include_path + dlpack_include_path))
-        )
-        if not optional:
-            raise RuntimeError(message)
-        return None
-
-    return include_found
+    try:
+        return [find_tvm_include_path(), *tvm_ffi_libinfo.include_paths()]
+    except RuntimeError:
+        if optional:
+            return None
+        raise
 
 
 # The version is written by setuptools_scm into _version.py at build time


### PR DESCRIPTION
This PR rewrites `tvm.libinfo.find_include_path()` so that C codegen works from both a source checkout and an installed wheel.

What it does:
- Resolves TVM's own public headers relative to `__file__`: installed package layout first (`tvm/include`, already shipped into the wheel by the existing CMake install rule), with the development source tree as fallback.
- Delegates the FFI and dlpack include paths to the FFI package's own libinfo utilities, which already handle both installed and development layouts.
- Removes the `TVM_HOME` / `TVM_SOURCE_DIR` / `TVM_INCLUDE_PATH` based source-tree guessing and the unused `name` / `search_path` parameters.