### PR TITLE
[CI] Merge PR against its target branch instead of main

### DIFF
--- a/ci/jenkins/generated/arm_jenkinsfile.groovy
+++ b/ci/jenkins/generated/arm_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2026-05-21T18:31:35.598730
+// Generated at 2026-06-09T19:52:01.246622
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -133,12 +133,15 @@ def init_git() {
   )
 
   // Determine merge commit to use for all stages
-  if (env.BRANCH_NAME == 'main') {
-    // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
-    update_upstream_revision("HEAD")
+  if (env.CHANGE_TARGET) {
+    // This is a PR build, so merge with the latest of the PR's target branch
+    // (e.g. main or a release branch like v0.25.0).
+    merge_with_target()
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is a branch build (main or a release branch). Only set
+    // upstream_revision to HEAD and skip merging to avoid a race with another
+    // commit merged to the branch.
+    update_upstream_revision("HEAD")
   }
 
   sh(
@@ -162,15 +165,16 @@ def update_upstream_revision(git_ref) {
   }
 }
 
-def merge_with_main() {
+def merge_with_target() {
+  def target = env.CHANGE_TARGET
   sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
+    script: "git fetch origin ${target}",
+    label: "Fetch target branch ${target}",
   )
   update_upstream_revision("FETCH_HEAD")
   sh (
     script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
+    label: "Merge to origin/${target}"
   )
 }
 

--- a/ci/jenkins/generated/cpu_jenkinsfile.groovy
+++ b/ci/jenkins/generated/cpu_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2026-05-21T18:31:35.583867
+// Generated at 2026-06-09T19:52:01.232631
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -133,12 +133,15 @@ def init_git() {
   )
 
   // Determine merge commit to use for all stages
-  if (env.BRANCH_NAME == 'main') {
-    // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
-    update_upstream_revision("HEAD")
+  if (env.CHANGE_TARGET) {
+    // This is a PR build, so merge with the latest of the PR's target branch
+    // (e.g. main or a release branch like v0.25.0).
+    merge_with_target()
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is a branch build (main or a release branch). Only set
+    // upstream_revision to HEAD and skip merging to avoid a race with another
+    // commit merged to the branch.
+    update_upstream_revision("HEAD")
   }
 
   sh(
@@ -162,15 +165,16 @@ def update_upstream_revision(git_ref) {
   }
 }
 
-def merge_with_main() {
+def merge_with_target() {
+  def target = env.CHANGE_TARGET
   sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
+    script: "git fetch origin ${target}",
+    label: "Fetch target branch ${target}",
   )
   update_upstream_revision("FETCH_HEAD")
   sh (
     script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
+    label: "Merge to origin/${target}"
   )
 }
 

--- a/ci/jenkins/generated/docker_jenkinsfile.groovy
+++ b/ci/jenkins/generated/docker_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2026-02-09T16:32:44.070917
+// Generated at 2026-06-09T19:52:01.257919
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -133,12 +133,15 @@ def init_git() {
   )
 
   // Determine merge commit to use for all stages
-  if (env.BRANCH_NAME == 'main') {
-    // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
-    update_upstream_revision("HEAD")
+  if (env.CHANGE_TARGET) {
+    // This is a PR build, so merge with the latest of the PR's target branch
+    // (e.g. main or a release branch like v0.25.0).
+    merge_with_target()
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is a branch build (main or a release branch). Only set
+    // upstream_revision to HEAD and skip merging to avoid a race with another
+    // commit merged to the branch.
+    update_upstream_revision("HEAD")
   }
 
   sh(
@@ -162,15 +165,16 @@ def update_upstream_revision(git_ref) {
   }
 }
 
-def merge_with_main() {
+def merge_with_target() {
+  def target = env.CHANGE_TARGET
   sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
+    script: "git fetch origin ${target}",
+    label: "Fetch target branch ${target}",
   )
   update_upstream_revision("FETCH_HEAD")
   sh (
     script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
+    label: "Merge to origin/${target}"
   )
 }
 

--- a/ci/jenkins/generated/gpu_jenkinsfile.groovy
+++ b/ci/jenkins/generated/gpu_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2026-05-21T18:31:35.612295
+// Generated at 2026-06-09T19:52:01.271485
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -133,12 +133,15 @@ def init_git() {
   )
 
   // Determine merge commit to use for all stages
-  if (env.BRANCH_NAME == 'main') {
-    // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
-    update_upstream_revision("HEAD")
+  if (env.CHANGE_TARGET) {
+    // This is a PR build, so merge with the latest of the PR's target branch
+    // (e.g. main or a release branch like v0.25.0).
+    merge_with_target()
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is a branch build (main or a release branch). Only set
+    // upstream_revision to HEAD and skip merging to avoid a race with another
+    // commit merged to the branch.
+    update_upstream_revision("HEAD")
   }
 
   sh(
@@ -162,15 +165,16 @@ def update_upstream_revision(git_ref) {
   }
 }
 
-def merge_with_main() {
+def merge_with_target() {
+  def target = env.CHANGE_TARGET
   sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
+    script: "git fetch origin ${target}",
+    label: "Fetch target branch ${target}",
   )
   update_upstream_revision("FETCH_HEAD")
   sh (
     script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
+    label: "Merge to origin/${target}"
   )
 }
 

--- a/ci/jenkins/generated/wasm_jenkinsfile.groovy
+++ b/ci/jenkins/generated/wasm_jenkinsfile.groovy
@@ -60,7 +60,7 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2026-02-09T16:32:44.060039
+// Generated at 2026-06-09T19:52:01.285310
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
@@ -133,12 +133,15 @@ def init_git() {
   )
 
   // Determine merge commit to use for all stages
-  if (env.BRANCH_NAME == 'main') {
-    // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
-    update_upstream_revision("HEAD")
+  if (env.CHANGE_TARGET) {
+    // This is a PR build, so merge with the latest of the PR's target branch
+    // (e.g. main or a release branch like v0.25.0).
+    merge_with_target()
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is a branch build (main or a release branch). Only set
+    // upstream_revision to HEAD and skip merging to avoid a race with another
+    // commit merged to the branch.
+    update_upstream_revision("HEAD")
   }
 
   sh(
@@ -162,15 +165,16 @@ def update_upstream_revision(git_ref) {
   }
 }
 
-def merge_with_main() {
+def merge_with_target() {
+  def target = env.CHANGE_TARGET
   sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
+    script: "git fetch origin ${target}",
+    label: "Fetch target branch ${target}",
   )
   update_upstream_revision("FETCH_HEAD")
   sh (
     script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
+    label: "Merge to origin/${target}"
   )
 }
 

--- a/ci/jenkins/templates/utils/Prepare.groovy.j2
+++ b/ci/jenkins/templates/utils/Prepare.groovy.j2
@@ -15,12 +15,15 @@ def init_git() {
   )
 
   // Determine merge commit to use for all stages
-  if (env.BRANCH_NAME == 'main') {
-    // Only set upstream_revision to HEAD and skip merging to avoid a race with another commit merged to main.
-    update_upstream_revision("HEAD")
+  if (env.CHANGE_TARGET) {
+    // This is a PR build, so merge with the latest of the PR's target branch
+    // (e.g. main or a release branch like v0.25.0).
+    merge_with_target()
   } else {
-    // This is PR branch so merge with latest main.
-    merge_with_main()
+    // This is a branch build (main or a release branch). Only set
+    // upstream_revision to HEAD and skip merging to avoid a race with another
+    // commit merged to the branch.
+    update_upstream_revision("HEAD")
   }
 
   sh(
@@ -44,15 +47,16 @@ def update_upstream_revision(git_ref) {
   }
 }
 
-def merge_with_main() {
+def merge_with_target() {
+  def target = env.CHANGE_TARGET
   sh (
-    script: 'git fetch origin main',
-    label: 'Fetch upstream',
+    script: "git fetch origin ${target}",
+    label: "Fetch target branch ${target}",
   )
   update_upstream_revision("FETCH_HEAD")
   sh (
     script: "git -c user.name=TVM-Jenkins -c user.email=jenkins@tvm.apache.org merge ${upstream_revision}",
-    label: 'Merge to origin/main'
+    label: "Merge to origin/${target}"
   )
 }
 


### PR DESCRIPTION
Jenkins' init_git() pre-build step unconditionally merged origin/main into every non-main branch build. For PRs targeting a release branch (e.g. v0.25.0), this merged main's diverged state into the PR and failed with conflicts in web/package.json and web/package-lock.json (main is on 0.25.0-dev1 while v0.25.0 is on 0.25.0), erroring out every CI stage before any build or test ran.

Use env.CHANGE_TARGET to merge against the PR's actual target branch, and gate the merge on a PR build (CHANGE_TARGET != null) so direct release branch builds skip merging just like main does.