### PR TITLE
[Refactor][Meta-schedule] Remove meta-schedule as_string mechanism in favor of default representation

### DIFF
--- a/include/tvm/s_tir/meta_schedule/cost_model.h
+++ b/include/tvm/s_tir/meta_schedule/cost_model.h
@@ -108,12 +108,6 @@ class PyCostModelNode : public CostModelNode {
    */
   using FPredict = ffi::TypedFunction<void(const TuneContext&, const ffi::Array<MeasureCandidate>&,
                                            void* p_addr)>;
-  /*!
-   * \brief Get the cost model as string with name.
-   * \return The string representation of the cost model.
-   */
-  using FAsString = ffi::TypedFunction<ffi::String()>;
-
   /*! \brief The packed function to the `Load` function. */
   FLoad f_load;
   /*! \brief The packed function to the `Save` function. */
@@ -122,8 +116,6 @@ class PyCostModelNode : public CostModelNode {
   FUpdate f_update;
   /*! \brief The packed function to the `Predict` function. */
   FPredict f_predict;
-  /*! \brief The packed function to the `AsString` function. */
-  FAsString f_as_string;
 
   void Load(const ffi::String& path);
   void Save(const ffi::String& path);
@@ -142,19 +134,17 @@ class PyCostModelNode : public CostModelNode {
 class CostModel : public ffi::ObjectRef {
  public:
   /*!
-   * \brief Create a feature extractor with customized methods on the python-side.
+   * \brief Create a cost model with customized methods on the python-side.
    * \param f_load The packed function of `Load`.
    * \param f_save The packed function of `Save`.
    * \param f_update The packed function of `Update`.
    * \param f_predict The packed function of `Predict`.
-   * \param f_as_string The packed function of `AsString`.
-   * \return The feature extractor created.
+   * \return The cost model created.
    */
-  TVM_DLL static CostModel PyCostModel(PyCostModelNode::FLoad f_load,        //
-                                       PyCostModelNode::FSave f_save,        //
-                                       PyCostModelNode::FUpdate f_update,    //
-                                       PyCostModelNode::FPredict f_predict,  //
-                                       PyCostModelNode::FAsString f_as_string);
+  TVM_DLL static CostModel PyCostModel(PyCostModelNode::FLoad f_load,      //
+                                       PyCostModelNode::FSave f_save,      //
+                                       PyCostModelNode::FUpdate f_update,  //
+                                       PyCostModelNode::FPredict f_predict);
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(CostModel, ffi::ObjectRef, CostModelNode);
 };
 

--- a/include/tvm/s_tir/meta_schedule/feature_extractor.h
+++ b/include/tvm/s_tir/meta_schedule/feature_extractor.h
@@ -67,20 +67,11 @@ class PyFeatureExtractorNode : public FeatureExtractorNode {
    */
   using FExtractFrom = ffi::TypedFunction<ffi::Array<tvm::runtime::Tensor>(
       const TuneContext& context, const ffi::Array<MeasureCandidate>& candidates)>;
-  /*!
-   * \brief Get the feature extractor as string with name.
-   * \return The string of the feature extractor.
-   */
-  using FAsString = ffi::TypedFunction<ffi::String()>;
-
   /*! \brief The packed function to the `ExtractFrom` function. */
   FExtractFrom f_extract_from;
-  /*! \brief The packed function to the `AsString` function. */
-  FAsString f_as_string;
 
   static void RegisterReflection() {
     // `f_extract_from` is not registered
-    // `f_as_string` is not registered
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PyFeatureExtractorNode>();
   }
@@ -114,12 +105,10 @@ class FeatureExtractor : public ffi::ObjectRef {
   /*!
    * \brief Create a feature extractor with customized methods on the python-side.
    * \param f_extract_from The packed function of `ExtractFrom`.
-   * \param f_as_string The packed function of `AsString`.
    * \return The feature extractor created.
    */
   TVM_DLL static FeatureExtractor PyFeatureExtractor(
-      PyFeatureExtractorNode::FExtractFrom f_extract_from,
-      PyFeatureExtractorNode::FAsString f_as_string);
+      PyFeatureExtractorNode::FExtractFrom f_extract_from);
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(FeatureExtractor, ffi::ObjectRef,
                                              FeatureExtractorNode);
 };

--- a/include/tvm/s_tir/meta_schedule/measure_callback.h
+++ b/include/tvm/s_tir/meta_schedule/measure_callback.h
@@ -84,20 +84,11 @@ class PyMeasureCallbackNode : public MeasureCallbackNode {
                                          const ffi::Array<MeasureCandidate>& measure_candidates,  //
                                          const ffi::Array<BuilderResult>& builds,                 //
                                          const ffi::Array<RunnerResult>& results)>;
-  /*!
-   * \brief Get the measure callback function as string with name.
-   * \return The string of the measure callback function.
-   */
-  using FAsString = ffi::TypedFunction<ffi::String()>;
-
   /*! \brief The packed function to the `Apply` function. */
   FApply f_apply;
-  /*! \brief The packed function to the `AsString` function. */
-  FAsString f_as_string;
 
   static void RegisterReflection() {
     // `f_apply` is not registered
-    // `f_as_string` is not registered
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PyMeasureCallbackNode>();
   }
@@ -135,11 +126,9 @@ class MeasureCallback : public ffi::ObjectRef {
   /*!
    * \brief Create a measure callback with customized methods on the python-side.
    * \param f_apply The packed function of `Apply`.
-   * \param f_as_string The packed function of `AsString`.
    * \return The measure callback created.
    */
-  TVM_DLL static MeasureCallback PyMeasureCallback(PyMeasureCallbackNode::FApply f_apply,
-                                                   PyMeasureCallbackNode::FAsString f_as_string);
+  TVM_DLL static MeasureCallback PyMeasureCallback(PyMeasureCallbackNode::FApply f_apply);
   /*! \brief The default list of measure callbacks. */
   TVM_DLL static ffi::Array<MeasureCallback, void> Default();
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(MeasureCallback, ffi::ObjectRef, MeasureCallbackNode);

--- a/include/tvm/s_tir/meta_schedule/mutator.h
+++ b/include/tvm/s_tir/meta_schedule/mutator.h
@@ -95,11 +95,6 @@ class Mutator : public ffi::ObjectRef {
    * \return The cloned mutator.
    */
   using FClone = ffi::TypedFunction<Mutator()>;
-  /*!
-   * \brief Get the mutator as string with name.
-   * \return The string of the mutator.
-   */
-  using FAsString = ffi::TypedFunction<ffi::String()>;
   /*! \brief Create a Mutator that mutates the decision of instruction Sample-Perfect-Tile */
   TVM_DLL static Mutator MutateTileSize();
   /*!
@@ -128,11 +123,10 @@ class Mutator : public ffi::ObjectRef {
    * \param f_initialize_with_tune_context The packed function of `InitializeWithTuneContext`.
    * \param f_apply The packed function of `Apply`.
    * \param f_clone The packed function of `Clone`.
-   * \param f_as_string The packed function of `AsString`.
    * \return The mutator created.
    */
   TVM_DLL static Mutator PyMutator(FInitializeWithTuneContext f_initialize_with_tune_context,
-                                   FApply f_apply, FClone f_clone, FAsString f_as_string);
+                                   FApply f_apply, FClone f_clone);
   /*! \brief Create default mutators for LLVM */
   TVM_DLL static ffi::Map<Mutator, FloatImm, void> DefaultLLVM();
   /*! \brief Create default mutators for CUDA */
@@ -151,15 +145,12 @@ class PyMutatorNode : public MutatorNode {
   using FInitializeWithTuneContext = Mutator::FInitializeWithTuneContext;
   using FApply = Mutator::FApply;
   using FClone = Mutator::FClone;
-  using FAsString = Mutator::FAsString;
   /*! \brief The packed function to the `InitializeWithTuneContext` function. */
   FInitializeWithTuneContext f_initialize_with_tune_context;
   /*! \brief The packed function to the `Apply` function. */
   FApply f_apply;
   /*! \brief The packed function to the `Clone` function. */
   FClone f_clone;
-  /*! \brief The packed function to the `AsString` function. */
-  FAsString f_as_string;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -167,7 +158,6 @@ class PyMutatorNode : public MutatorNode {
     // `f_initialize_with_tune_context` is not registered
     // `f_apply` is not registered
     // `f_clone` is not registered
-    // `f_as_string` is not registered
   }
 
   void InitializeWithTuneContext(const TuneContext& context) final;

--- a/include/tvm/s_tir/meta_schedule/postproc.h
+++ b/include/tvm/s_tir/meta_schedule/postproc.h
@@ -92,22 +92,15 @@ class Postproc : public ffi::ObjectRef {
    */
   using FClone = ffi::TypedFunction<Postproc()>;
   /*!
-   * \brief Get the postprocessor function as string with name.
-   * \return The string of the postprocessor function.
-   */
-  using FAsString = ffi::TypedFunction<ffi::String()>;
-  /*!
    * \brief Create a postprocessor with customized methods on the python-side.
    * \param f_initialize_with_tune_context The packed function of `InitializeWithTuneContext`.
    * \param f_apply The packed function of `Apply`.
    * \param f_clone The packed function of `Clone`.
-   * \param f_as_string The packed function of `AsString`.
    * \return The postprocessor created.
    */
   TVM_DLL static Postproc PyPostproc(FInitializeWithTuneContext f_initialize_with_tune_context,  //
                                      FApply f_apply,                                             //
-                                     FClone f_clone,                                             //
-                                     FAsString f_as_string);
+                                     FClone f_clone);
   /*!
    * \brief Create a postprocessor that checks if all loops are static
    * \return The postprocessor created
@@ -186,21 +179,17 @@ class PyPostprocNode : public PostprocNode {
   using FInitializeWithTuneContext = Postproc::FInitializeWithTuneContext;
   using FApply = Postproc::FApply;
   using FClone = Postproc::FClone;
-  using FAsString = Postproc::FAsString;
   /*! \brief The packed function to the `InitializeWithTuneContext` function. */
   FInitializeWithTuneContext f_initialize_with_tune_context;
   /*! \brief The packed function to the `Apply` function. */
   FApply f_apply;
   /*! \brief The packed function to the `Clone` function. */
   FClone f_clone;
-  /*! \brief The packed function to the `AsString` function. */
-  FAsString f_as_string;
 
   static void RegisterReflection() {
     // `f_initialize_with_tune_context` is not registered
     // `f_apply` is not registered
     // `f_clone` is not registered
-    // `f_as_string` is not registered
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PyPostprocNode>();
   }

--- a/include/tvm/s_tir/meta_schedule/schedule_rule.h
+++ b/include/tvm/s_tir/meta_schedule/schedule_rule.h
@@ -93,11 +93,6 @@ class ScheduleRule : public ffi::ObjectRef {
   using FApply = ffi::TypedFunction<ffi::Array<s_tir::Schedule>(const s_tir::Schedule&,
                                                                 const s_tir::SBlockRV&)>;
   /*!
-   * \brief Get the schedule rule as string with name.
-   * \return The string of the schedule rule.
-   */
-  using FAsString = ffi::TypedFunction<ffi::String()>;
-  /*!
    * \brief The function type of `Clone` method.
    * \return The cloned schedule rule.
    */
@@ -290,14 +285,12 @@ class ScheduleRule : public ffi::ObjectRef {
    * \param f_initialize_with_tune_context The packed function of `InitializeWithTuneContext`.
    * \param f_apply The packed function of `Apply`.
    * \param f_clone The packed function of `Clone`.
-   * \param f_as_string The packed function of `AsString`.
    * \return The schedule rule created.
    */
   TVM_DLL static ScheduleRule PyScheduleRule(
       FInitializeWithTuneContext f_initialize_with_tune_context,  //
       FApply f_apply,                                             //
-      FClone f_clone,                                             //
-      FAsString f_as_string);
+      FClone f_clone);
 
   /*! \brief Create default schedule rules for LLVM */
   TVM_DLL static ffi::Array<ScheduleRule, void> DefaultLLVM();
@@ -323,21 +316,17 @@ class PyScheduleRuleNode : public ScheduleRuleNode {
   using FInitializeWithTuneContext = ScheduleRule::FInitializeWithTuneContext;
   using FApply = ScheduleRule::FApply;
   using FClone = ScheduleRule::FClone;
-  using FAsString = ScheduleRule::FAsString;
 
   /*! \brief The packed function to the `InitializeWithTuneContext` function. */
   FInitializeWithTuneContext f_initialize_with_tune_context;
   /*! \brief The packed function to the `Apply` function. */
   FApply f_apply;
-  /*! \brief The packed function to the `AsString` function. */
-  FAsString f_as_string;
   /*! \brief The packed function to the `Clone` function. */
   FClone f_clone;
 
   static void RegisterReflection() {
     // `f_initialize_with_tune_context` is not registered
     // `f_apply` is not registered
-    // `f_as_string` is not registered
     // `f_clone` is not registered
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PyScheduleRuleNode>();

--- a/python/tvm/ir/utils.py
+++ b/python/tvm/ir/utils.py
@@ -70,13 +70,13 @@ def derived_object(cls: type[T]) -> type[T]:
             # extract functions that differ from the base class
             if not hasattr(base_cls, name):
                 continue
-            if getattr(base_cls, name) is getattr(inherit_cls, name) and name != "__str__":
+            if getattr(base_cls, name) is getattr(inherit_cls, name):
                 continue
             return method
 
         # for task scheduler return None means calling default function
         # otherwise it will trigger a TVMError of method not implemented
-        # on the c++ side when you call the method, __str__ not required
+        # on the c++ side when you call the method
         return None
 
     assert isinstance(cls.__base__, type)

--- a/python/tvm/s_tir/meta_schedule/cost_model/cost_model.py
+++ b/python/tvm/s_tir/meta_schedule/cost_model/cost_model.py
@@ -35,7 +35,6 @@ from .. import _ffi_api
 from ..runner import RunnerResult
 from ..search_strategy import MeasureCandidate
 from ..tune_context import TuneContext
-from ..utils import _get_default_str
 
 
 @register_object("s_tir.meta_schedule.CostModel")
@@ -169,7 +168,6 @@ class _PyCostModel(CostModel):
         f_save: Callable | None = None,
         f_update: Callable | None = None,
         predict_func: Callable | None = None,
-        f_as_string: Callable | None = None,
     ):
         """Constructor."""
 
@@ -189,7 +187,6 @@ class _PyCostModel(CostModel):
             f_save,
             f_update,
             f_predict,
-            f_as_string,
         )
 
 
@@ -203,7 +200,7 @@ class PyCostModel:
 
     _tvm_metadata = {
         "cls": _PyCostModel,
-        "methods": ["load", "save", "update", "predict", "__str__"],
+        "methods": ["load", "save", "update", "predict"],
     }
 
     def load(self, path: str) -> None:
@@ -261,13 +258,3 @@ class PyCostModel:
             The predicted normalized score.
         """
         raise NotImplementedError
-
-    def __str__(self) -> str:
-        """Get the cost model as string with name.
-
-        Return
-        ------
-        result : str
-            Get the cost model as string with name.
-        """
-        return _get_default_str(self)

--- a/python/tvm/s_tir/meta_schedule/feature_extractor/feature_extractor.py
+++ b/python/tvm/s_tir/meta_schedule/feature_extractor/feature_extractor.py
@@ -33,7 +33,6 @@ from tvm.runtime._tensor import Tensor
 from .. import _ffi_api
 from ..search_strategy import MeasureCandidate
 from ..tune_context import TuneContext
-from ..utils import _get_default_str
 
 
 @register_object("s_tir.meta_schedule.FeatureExtractor")
@@ -87,13 +86,12 @@ class _PyFeatureExtractor(FeatureExtractor):
     See also: PyFeatureExtractor
     """
 
-    def __init__(self, f_extract_from: Callable, f_as_string: Callable | None = None):
+    def __init__(self, f_extract_from: Callable):
         """Constructor."""
 
         self.__init_handle_by_constructor__(
             _ffi_api.FeatureExtractorPyFeatureExtractor,  # type: ignore # pylint: disable=no-member
             f_extract_from,
-            f_as_string,
         )
 
 
@@ -107,7 +105,7 @@ class PyFeatureExtractor:
 
     _tvm_metadata = {
         "cls": _PyFeatureExtractor,
-        "methods": ["extract_from", "__str__"],
+        "methods": ["extract_from"],
     }
 
     def extract_from(
@@ -128,6 +126,3 @@ class PyFeatureExtractor:
             The feature tvm ndarray extracted.
         """
         raise NotImplementedError
-
-    def __str__(self) -> str:
-        return _get_default_str(self)

--- a/python/tvm/s_tir/meta_schedule/measure_callback/measure_callback.py
+++ b/python/tvm/s_tir/meta_schedule/measure_callback/measure_callback.py
@@ -33,7 +33,6 @@ from .. import _ffi_api
 from ..builder import BuilderResult
 from ..runner import RunnerResult
 from ..search_strategy import MeasureCandidate
-from ..utils import _get_default_str
 
 if TYPE_CHECKING:
     from ..task_scheduler import TaskScheduler
@@ -94,13 +93,12 @@ class _PyMeasureCallback(MeasureCallback):
     See also: PyMeasureCallback
     """
 
-    def __init__(self, f_apply: Callable, f_as_string: Callable | None = None):
+    def __init__(self, f_apply: Callable):
         """Constructor."""
 
         self.__init_handle_by_constructor__(
             _ffi_api.MeasureCallbackPyMeasureCallback,  # type: ignore # pylint: disable=no-member
             f_apply,
-            f_as_string,
         )
 
 
@@ -114,7 +112,7 @@ class PyMeasureCallback:
 
     _tvm_metadata = {
         "cls": _PyMeasureCallback,
-        "methods": ["apply", "__str__"],
+        "methods": ["apply"],
     }
 
     def apply(
@@ -141,6 +139,3 @@ class PyMeasureCallback:
             The runner results by running the built measure candidates.
         """
         raise NotImplementedError
-
-    def __str__(self) -> str:
-        return _get_default_str(self)

--- a/python/tvm/s_tir/meta_schedule/mutator/mutator.py
+++ b/python/tvm/s_tir/meta_schedule/mutator/mutator.py
@@ -31,7 +31,6 @@ from tvm.runtime import Object
 from tvm.s_tir.schedule import Trace
 
 from .. import _ffi_api
-from ..utils import _get_default_str
 
 if TYPE_CHECKING:
     from ..tune_context import TuneContext
@@ -129,7 +128,6 @@ class _PyMutator(Mutator):
         f_initialize_with_tune_context: Callable | None = None,
         f_apply: Callable | None = None,
         f_clone: Callable | None = None,
-        f_as_string: Callable | None = None,
     ):
         """Constructor."""
 
@@ -138,7 +136,6 @@ class _PyMutator(Mutator):
             f_initialize_with_tune_context,
             f_apply,
             f_clone,
-            f_as_string,
         )
 
 
@@ -152,7 +149,7 @@ class PyMutator:
 
     _tvm_metadata = {
         "cls": _PyMutator,
-        "methods": ["_initialize_with_tune_context", "apply", "clone", "__str__"],
+        "methods": ["_initialize_with_tune_context", "apply", "clone"],
     }
 
     def _initialize_with_tune_context(self, context: "TuneContext") -> None:
@@ -189,13 +186,3 @@ class PyMutator:
             The cloned mutator.
         """
         raise NotImplementedError
-
-    def __str__(self) -> str:
-        """Get the mutator as string with name.
-
-        Return
-        ------
-        result : str
-            Get the mutator as string with name.
-        """
-        return _get_default_str(self)

--- a/python/tvm/s_tir/meta_schedule/postproc/postproc.py
+++ b/python/tvm/s_tir/meta_schedule/postproc/postproc.py
@@ -31,7 +31,6 @@ from tvm.runtime import Object
 from tvm.s_tir.schedule import Schedule
 
 from .. import _ffi_api
-from ..utils import _get_default_str
 
 if TYPE_CHECKING:
     from ..tune_context import TuneContext
@@ -123,7 +122,6 @@ class _PyPostproc(Postproc):
         f_initialize_with_tune_context: Callable | None = None,
         f_apply: Callable | None = None,
         f_clone: Callable | None = None,
-        f_as_string: Callable | None = None,
     ):
         """Constructor."""
 
@@ -132,7 +130,6 @@ class _PyPostproc(Postproc):
             f_initialize_with_tune_context,
             f_apply,
             f_clone,
-            f_as_string,
         )
 
 
@@ -146,7 +143,7 @@ class PyPostproc:
 
     _tvm_metadata = {
         "cls": _PyPostproc,
-        "methods": ["_initialize_with_tune_context", "apply", "clone", "__str__"],
+        "methods": ["_initialize_with_tune_context", "apply", "clone"],
     }
 
     def _initialize_with_tune_context(self, context: "TuneContext") -> None:
@@ -183,13 +180,3 @@ class PyPostproc:
             The cloned postprocessor.
         """
         raise NotImplementedError
-
-    def __str__(self) -> str:
-        """Get the post processor as string with name.
-
-        Return
-        ------
-        result : str
-            Get the post processor as string with name.
-        """
-        return _get_default_str(self)

--- a/python/tvm/s_tir/meta_schedule/schedule_rule/schedule_rule.py
+++ b/python/tvm/s_tir/meta_schedule/schedule_rule/schedule_rule.py
@@ -34,7 +34,6 @@ from tvm.runtime import Object
 from tvm.s_tir.schedule import SBlockRV, Schedule
 
 from .. import _ffi_api
-from ..utils import _get_default_str
 
 if TYPE_CHECKING:
     from ..tune_context import TuneContext
@@ -130,7 +129,6 @@ class _PyScheduleRule(ScheduleRule):
         f_initialize_with_tune_context: Callable | None = None,
         f_apply: Callable | None = None,
         f_clone: Callable | None = None,
-        f_as_string: Callable | None = None,
     ):
         """Constructor."""
 
@@ -139,7 +137,6 @@ class _PyScheduleRule(ScheduleRule):
             f_initialize_with_tune_context,
             f_apply,
             f_clone,
-            f_as_string,
         )
 
 
@@ -153,7 +150,7 @@ class PyScheduleRule:
 
     _tvm_metadata = {
         "cls": _PyScheduleRule,
-        "methods": ["_initialize_with_tune_context", "apply", "clone", "__str__"],
+        "methods": ["_initialize_with_tune_context", "apply", "clone"],
     }
 
     def _initialize_with_tune_context(self, context: "TuneContext") -> None:
@@ -192,13 +189,3 @@ class PyScheduleRule:
             The cloned schedule rule.
         """
         raise NotImplementedError
-
-    def __str__(self) -> str:
-        """Get the schedule rule as string with name.
-
-        Return
-        ------
-        result : str
-            Get the schedule rule as string with name.
-        """
-        return _get_default_str(self)

--- a/python/tvm/s_tir/meta_schedule/utils.py
+++ b/python/tvm/s_tir/meta_schedule/utils.py
@@ -16,7 +16,6 @@
 # under the License.
 """Utilities for meta schedule"""
 
-import ctypes
 import os
 import shutil
 from collections.abc import Callable
@@ -245,29 +244,6 @@ def shash2hex(mod: IRModule) -> str:
     """
     func = get_global_func("s_tir.meta_schedule._SHash2Hex")
     return str(func(mod))
-
-
-def _get_default_str(obj: Any) -> str:
-    return (
-        # pylint: disable=protected-access
-        f"s_tir.meta_schedule.{obj.__class__.__name__}"
-        + f"({_to_hex_address(obj._outer().__ctypes_handle__())})"  # type: ignore
-        # pylint: enable=protected-access
-    )
-
-
-def _to_hex_address(handle: ctypes.c_void_p) -> str:
-    """Get the hexadecimal address of a handle.
-    Parameters
-    ----------
-    handle : ctypes.c_void_p
-        The handle to be converted.
-    Returns
-    -------
-    result : str
-        The hexadecimal address of the handle.
-    """
-    return hex(ctypes.cast(handle, ctypes.c_void_p).value)
 
 
 def fork_seed(seed: int | None, n: int) -> list[int]:

--- a/src/s_tir/meta_schedule/cost_model/cost_model.cc
+++ b/src/s_tir/meta_schedule/cost_model/cost_model.cc
@@ -49,17 +49,15 @@ std::vector<double> PyCostModelNode::Predict(const TuneContext& context,
   return result;
 }
 
-CostModel CostModel::PyCostModel(PyCostModelNode::FLoad f_load,        //
-                                 PyCostModelNode::FSave f_save,        //
-                                 PyCostModelNode::FUpdate f_update,    //
-                                 PyCostModelNode::FPredict f_predict,  //
-                                 PyCostModelNode::FAsString f_as_string) {
+CostModel CostModel::PyCostModel(PyCostModelNode::FLoad f_load,      //
+                                 PyCostModelNode::FSave f_save,      //
+                                 PyCostModelNode::FUpdate f_update,  //
+                                 PyCostModelNode::FPredict f_predict) {
   ffi::ObjectPtr<PyCostModelNode> n = ffi::make_object<PyCostModelNode>();
   n->f_load = std::move(f_load);
   n->f_save = std::move(f_save);
   n->f_update = std::move(f_update);
   n->f_predict = std::move(f_predict);
-  n->f_as_string = std::move(f_as_string);
   return CostModel(n);
 }
 

--- a/src/s_tir/meta_schedule/feature_extractor/feature_extractor.cc
+++ b/src/s_tir/meta_schedule/feature_extractor/feature_extractor.cc
@@ -32,11 +32,9 @@ ffi::Array<tvm::runtime::Tensor> PyFeatureExtractorNode::ExtractFrom(
 }
 
 FeatureExtractor FeatureExtractor::PyFeatureExtractor(
-    PyFeatureExtractorNode::FExtractFrom f_extract_from,  //
-    PyFeatureExtractorNode::FAsString f_as_string) {
+    PyFeatureExtractorNode::FExtractFrom f_extract_from) {
   ffi::ObjectPtr<PyFeatureExtractorNode> n = ffi::make_object<PyFeatureExtractorNode>();
   n->f_extract_from = std::move(f_extract_from);
-  n->f_as_string = std::move(f_as_string);
   return FeatureExtractor(n);
 }
 

--- a/src/s_tir/meta_schedule/measure_callback/measure_callback.cc
+++ b/src/s_tir/meta_schedule/measure_callback/measure_callback.cc
@@ -30,15 +30,13 @@ void PyMeasureCallbackNode::Apply(const TaskScheduler& task_scheduler,          
                                   const ffi::Array<BuilderResult>& builds,                 //
                                   const ffi::Array<RunnerResult>& results) {
   TVM_FFI_ICHECK(f_apply != nullptr) << "PyMeasureCallback's Apply method not implemented!";
-  auto _ = Profiler::TimedScope("MeasureCallback/" + this->f_as_string());
+  auto _ = Profiler::TimedScope("MeasureCallback/PyMeasureCallback");
   return f_apply(task_scheduler, task_id, measure_candidates, builds, results);
 }
 
-MeasureCallback MeasureCallback::PyMeasureCallback(PyMeasureCallbackNode::FApply f_apply,  //
-                                                   PyMeasureCallbackNode::FAsString f_as_string) {
+MeasureCallback MeasureCallback::PyMeasureCallback(PyMeasureCallbackNode::FApply f_apply) {
   ffi::ObjectPtr<PyMeasureCallbackNode> n = ffi::make_object<PyMeasureCallbackNode>();
   n->f_apply = std::move(f_apply);
-  n->f_as_string = std::move(f_as_string);
   return MeasureCallback(n);
 }
 

--- a/src/s_tir/meta_schedule/mutator/mutator.cc
+++ b/src/s_tir/meta_schedule/mutator/mutator.cc
@@ -44,13 +44,11 @@ Mutator PyMutatorNode::Clone() const {
 Mutator Mutator::PyMutator(
     PyMutatorNode::FInitializeWithTuneContext f_initialize_with_tune_context,  //
     PyMutatorNode::FApply f_apply,                                             //
-    PyMutatorNode::FClone f_clone,                                             //
-    PyMutatorNode::FAsString f_as_string) {
+    PyMutatorNode::FClone f_clone) {
   ffi::ObjectPtr<PyMutatorNode> n = ffi::make_object<PyMutatorNode>();
   n->f_initialize_with_tune_context = std::move(f_initialize_with_tune_context);
   n->f_apply = std::move(f_apply);
   n->f_clone = std::move(f_clone);
-  n->f_as_string = std::move(f_as_string);
   return Mutator(n);
 }
 

--- a/src/s_tir/meta_schedule/postproc/postproc.cc
+++ b/src/s_tir/meta_schedule/postproc/postproc.cc
@@ -43,13 +43,11 @@ Postproc PyPostprocNode::Clone() const {
 Postproc Postproc::PyPostproc(
     PyPostprocNode::FInitializeWithTuneContext f_initialize_with_tune_context,  //
     PyPostprocNode::FApply f_apply,                                             //
-    PyPostprocNode::FClone f_clone,                                             //
-    PyPostprocNode::FAsString f_as_string) {
+    PyPostprocNode::FClone f_clone) {
   ffi::ObjectPtr<PyPostprocNode> n = ffi::make_object<PyPostprocNode>();
   n->f_initialize_with_tune_context = std::move(f_initialize_with_tune_context);
   n->f_apply = std::move(f_apply);
   n->f_clone = std::move(f_clone);
-  n->f_as_string = std::move(f_as_string);
   return Postproc(n);
 }
 

--- a/src/s_tir/meta_schedule/schedule_rule/schedule_rule.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/schedule_rule.cc
@@ -45,13 +45,11 @@ ScheduleRule PyScheduleRuleNode::Clone() const {
 ScheduleRule ScheduleRule::PyScheduleRule(
     PyScheduleRuleNode::FInitializeWithTuneContext f_initialize_with_tune_context,  //
     PyScheduleRuleNode::FApply f_apply,                                             //
-    PyScheduleRuleNode::FClone f_clone,                                             //
-    PyScheduleRuleNode::FAsString f_as_string) {
+    PyScheduleRuleNode::FClone f_clone) {
   ffi::ObjectPtr<PyScheduleRuleNode> n = ffi::make_object<PyScheduleRuleNode>();
   n->f_initialize_with_tune_context = std::move(f_initialize_with_tune_context);
   n->f_apply = std::move(f_apply);
   n->f_clone = std::move(f_clone);
-  n->f_as_string = std::move(f_as_string);
   return ScheduleRule(n);
 }
 

--- a/tests/python/s_tir/meta_schedule/test_meta_schedule_cost_model.py
+++ b/tests/python/s_tir/meta_schedule/test_meta_schedule_cost_model.py
@@ -17,7 +17,6 @@
 # pylint: disable=missing-docstring
 # ruff: noqa: F401
 import os
-import re
 import shutil
 import tempfile
 import unittest
@@ -99,31 +98,6 @@ def test_meta_schedule_cost_model():
         TuneContext(), [MeasureCandidate(Schedule(mod=Matmul), []) for _ in range(10)]
     )
     assert results.shape == (10,)
-
-
-def test_meta_schedule_cost_model_as_string():
-    @derived_object
-    class NotSoFancyCostModel(PyCostModel):
-        def load(self, path: str) -> None:
-            pass
-
-        def save(self, path: str) -> None:
-            pass
-
-        def update(
-            self,
-            context: TuneContext,
-            candidates: list[MeasureCandidate],
-            results: list[RunnerResult],
-        ) -> None:
-            pass
-
-        def predict(self, context: TuneContext, candidates: list[MeasureCandidate]) -> np.ndarray:
-            return np.random.rand(10)
-
-    cost_model = NotSoFancyCostModel()
-    pattern = re.compile(r"s_tir.meta_schedule.NotSoFancyCostModel\(0x[a-f|0-9]*\)")
-    assert pattern.match(str(cost_model))
 
 
 def test_meta_schedule_random_model():

--- a/tests/python/s_tir/meta_schedule/test_meta_schedule_feature_extractor.py
+++ b/tests/python/s_tir/meta_schedule/test_meta_schedule_feature_extractor.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-module-docstring,missing-function-docstring,missing-class-docstring
-import re
 
 import numpy as np
 
@@ -42,21 +41,5 @@ def test_meta_schedule_feature_extractor():
     assert features[0].shape == (4, 5)
 
 
-def test_meta_schedule_feature_extractor_as_string():
-    @derived_object
-    class NotSoFancyFeatureExtractor(PyFeatureExtractor):
-        def extract_from(
-            self,
-            context: TuneContext,  # pylint: disable = unused-argument
-            candidates: list[MeasureCandidate],  # pylint: disable = unused-argument
-        ) -> list[np.ndarray]:
-            return []
-
-    feature_extractor = NotSoFancyFeatureExtractor()
-    pattern = re.compile(r"s_tir.meta_schedule.NotSoFancyFeatureExtractor\(0x[a-f|0-9]*\)")
-    assert pattern.match(str(feature_extractor))
-
-
 if __name__ == "__main__":
     test_meta_schedule_feature_extractor()
-    test_meta_schedule_feature_extractor_as_string()

--- a/tests/python/s_tir/meta_schedule/test_meta_schedule_measure_callback.py
+++ b/tests/python/s_tir/meta_schedule/test_meta_schedule_measure_callback.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-module-docstring,missing-function-docstring,missing-class-docstring
-import re
 import tempfile
 
 import pytest
@@ -106,24 +105,6 @@ def test_meta_schedule_measure_callback_fail():
         )
 
 
-def test_meta_schedule_measure_callback_as_string():
-    @derived_object
-    class NotSoFancyMeasureCallback(ms.measure_callback.PyMeasureCallback):
-        def apply(
-            self,
-            task_scheduler: ms.task_scheduler.TaskScheduler,
-            task_id: int,
-            measure_candidates: list[ms.MeasureCandidate],
-            builder_results: list[ms.builder.BuilderResult],
-            runner_results: list[ms.runner.RunnerResult],
-        ) -> None:
-            pass
-
-    measure_callback = NotSoFancyMeasureCallback()
-    pattern = re.compile(r"s_tir.meta_schedule.NotSoFancyMeasureCallback\(0x[a-f|0-9]*\)")
-    assert pattern.match(str(measure_callback))
-
-
 @pytest.mark.skip("Tuning test - launches runner")
 def test_meta_schedule_measure_callback_update_cost_model_with_zero():
     @derived_object
@@ -179,6 +160,5 @@ def test_meta_schedule_measure_callback_update_cost_model_with_runtime_error():
 if __name__ == "__main__":
     test_meta_schedule_measure_callback()
     test_meta_schedule_measure_callback_fail()
-    test_meta_schedule_measure_callback_as_string()
     test_meta_schedule_measure_callback_update_cost_model_with_zero()
     test_meta_schedule_measure_callback_update_cost_model_with_runtime_error()


### PR DESCRIPTION
Python-side meta-schedule classes (`PyCostModel`, `PyFeatureExtractor`, `PyMeasureCallback`, `PyScheduleRule`, `PyMutator`, `PyPostproc`) carried an `f_as_string` callback whose only purpose was to produce a repr-style string (`s_tir.meta_schedule.<SubclassName>(0x...)`) for `str(...)`.

This mechanism stopped working after #19461 migrated `ReprPrinter` to the tvm-ffi `__ffi_repr__` mechanism and intentionally removed the per-type `set_dispatch<Py*Node>` hooks that called back into `f_as_string`, which broke three `*_as_string` tests:
- `test_meta_schedule_cost_model.py::test_meta_schedule_cost_model_as_string`
- `test_meta_schedule_feature_extractor.py::test_meta_schedule_feature_extractor_as_string`
- `test_meta_schedule_measure_callback.py::test_meta_schedule_measure_callback_as_string`

Rather than restoring the old behavior, this PR removes the mechanism entirely: the string it produced is just a repr, and tvm-ffi reflection already provides an auto-generated default repr for every object. Keeping a dedicated Python → FFI → C++ callback chain alive only to reproduce that is not worth the complexity.