### PR TITLE
[CI] Fix CI script test subprocess environment

### DIFF
--- a/tests/python/ci/test_utils.py
+++ b/tests/python/ci/test_utils.py
@@ -19,6 +19,7 @@
 Constants used in various CI tests
 """
 
+import os
 import pathlib
 import subprocess
 from typing import Any
@@ -64,6 +65,9 @@ def run_script(command: list[Any], check: bool = True, **kwargs):
         "stderr": subprocess.PIPE,
         "encoding": "utf-8",
     }
+    env = kwargs.pop("env", None)
+    if env is not None:
+        kwargs_to_send["env"] = {**os.environ, **env}
     kwargs_to_send.update(kwargs)
     proc = subprocess.run(
         command,


### PR DESCRIPTION
This fixes CI script tests that accidentally run helper scripts with the wrong Python interpreter.

Some tests call `run_script(..., env={...})` to pass test-specific environment variables. `subprocess.run` treats `env` as a full environment replacement, so the subprocess lost the current `PATH`. Since these scripts use a shebang like:

```python
#!/usr/bin/env python3
```

they could fall back to the system Python instead of the active test Python.

In the wheel test environment this caused the CI helper scripts to run under Python 3.8, even though TVM requires Python >=3.10. Importing `ci/scripts/jenkins/git_utils.py` then failed on PEP 604 annotations such as:

```python
Any | None
tuple[str, str] | None
```

with:

```text
TypeError: unsupported operand type(s) for |: '_SpecialForm' and 'NoneType'
```

This patch updates `tests/python/ci/test_utils.py::run_script` to merge test-provided environment variables into `os.environ` instead of replacing the entire environment. This preserves the active Python/PATH while still allowing each test to override or add variables.