### PR TITLE
[Runtime][Tests] Fix contrib wheel tests

### DIFF
--- a/src/runtime/extra/contrib/random/mt_random_engine.cc
+++ b/src/runtime/extra/contrib/random/mt_random_engine.cc
@@ -142,6 +142,19 @@ class RandomEngine {
   }
 
  private:
+  static int64_t GetFillElementCount(DLTensor* tensor) {
+    size_t data_size = ffi::GetDataSize(*tensor);
+    DLDataType dtype = tensor->dtype;
+    if (dtype.bits == 1 || dtype.bits == 4 || dtype.bits == 8) {
+      return static_cast<int64_t>(data_size);
+    }
+
+    TVM_FFI_ICHECK_EQ(dtype.bits % 8, 0) << "Unsupported dtype bits " << dtype.bits;
+    size_t bytes_per_element = dtype.bits / 8;
+    TVM_FFI_ICHECK_EQ(data_size % bytes_per_element, 0);
+    return static_cast<int64_t>(data_size / bytes_per_element);
+  }
+
   void FillDataImpl(void* data, int64_t st, int64_t ed, DLDataType dtype) {
     // Make the value be 1.0 - 10.0, not (0.0 - 1.0) so that we could satisfy
     // quantized dtype (uint8 / int8) data non-empty requirement
@@ -175,14 +188,10 @@ class RandomEngine {
   }
 
   void FillData(DLTensor* tensor) {
-    int64_t size = 1;
-    for (int i = 0; i < tensor->ndim; ++i) {
-      size *= tensor->shape[i];
-    }
     DLDataType dtype = tensor->dtype;
     if (dtype.bits == 1 || dtype.bits == 4 || dtype.bits == 8 || dtype.bits == 16 ||
         dtype.bits == 32 || dtype.bits == 64) {
-      FillDataImpl(tensor->data, 0, size, dtype);
+      FillDataImpl(tensor->data, 0, GetFillElementCount(tensor), dtype);
     } else {
       TVM_FFI_THROW(InternalError)
           << "Doesn't support dtype code " << dtype.code << " dtype bits " << dtype.bits;
@@ -214,10 +223,7 @@ class RandomEngine {
     task.self = this;
     task.data = tensor->data;
     DLDataType dtype = task.dtype = tensor->dtype;
-    int64_t& size = task.size = 1;
-    for (int i = 0; i < tensor->ndim; ++i) {
-      size *= tensor->shape[i];
-    }
+    task.size = GetFillElementCount(tensor);
     if (dtype.bits == 1 || dtype.bits == 4 || dtype.bits == 8 || dtype.bits == 16 ||
         dtype.bits == 32 || dtype.bits == 64) {
       int res = TVMBackendParallelLaunch(ParallelTask::RunTask, &task, 0);

--- a/src/runtime/extra/contrib/random/mt_random_engine.cc
+++ b/src/runtime/extra/contrib/random/mt_random_engine.cc
@@ -145,10 +145,6 @@ class RandomEngine {
   static int64_t GetFillElementCount(DLTensor* tensor) {
     size_t data_size = ffi::GetDataSize(*tensor);
     DLDataType dtype = tensor->dtype;
-    if (dtype.bits == 1 || dtype.bits == 4 || dtype.bits == 8) {
-      return static_cast<int64_t>(data_size);
-    }
-
     TVM_FFI_ICHECK_EQ(dtype.bits % 8, 0) << "Unsupported dtype bits " << dtype.bits;
     size_t bytes_per_element = dtype.bits / 8;
     TVM_FFI_ICHECK_EQ(data_size % bytes_per_element, 0);
@@ -189,8 +185,7 @@ class RandomEngine {
 
   void FillData(DLTensor* tensor) {
     DLDataType dtype = tensor->dtype;
-    if (dtype.bits == 1 || dtype.bits == 4 || dtype.bits == 8 || dtype.bits == 16 ||
-        dtype.bits == 32 || dtype.bits == 64) {
+    if (dtype.bits == 8 || dtype.bits == 16 || dtype.bits == 32 || dtype.bits == 64) {
       FillDataImpl(tensor->data, 0, GetFillElementCount(tensor), dtype);
     } else {
       TVM_FFI_THROW(InternalError)
@@ -224,8 +219,7 @@ class RandomEngine {
     task.data = tensor->data;
     DLDataType dtype = task.dtype = tensor->dtype;
     task.size = GetFillElementCount(tensor);
-    if (dtype.bits == 1 || dtype.bits == 4 || dtype.bits == 8 || dtype.bits == 16 ||
-        dtype.bits == 32 || dtype.bits == 64) {
+    if (dtype.bits == 8 || dtype.bits == 16 || dtype.bits == 32 || dtype.bits == 64) {
       int res = TVMBackendParallelLaunch(ParallelTask::RunTask, &task, 0);
       TVM_FFI_ICHECK_EQ(res, 0) << "RandomFillForMeasure: TVMBackendParallelLaunch failed";
     } else {

--- a/src/runtime/extra/contrib/random/mt_random_engine.cc
+++ b/src/runtime/extra/contrib/random/mt_random_engine.cc
@@ -142,29 +142,12 @@ class RandomEngine {
   }
 
  private:
-  static int64_t GetFillElementCount(DLTensor* tensor) {
-    size_t data_size = ffi::GetDataSize(*tensor);
-    DLDataType dtype = tensor->dtype;
-    TVM_FFI_ICHECK_EQ(dtype.bits % 8, 0) << "Unsupported dtype bits " << dtype.bits;
-    size_t bytes_per_element = dtype.bits / 8;
-    TVM_FFI_ICHECK_EQ(data_size % bytes_per_element, 0);
-    return static_cast<int64_t>(data_size / bytes_per_element);
-  }
-
   void FillDataImpl(void* data, int64_t st, int64_t ed, DLDataType dtype) {
     // Make the value be 1.0 - 10.0, not (0.0 - 1.0) so that we could satisfy
     // quantized dtype (uint8 / int8) data non-empty requirement
     std::uniform_real_distribution<> dist(1.0, 10.0);
     // Use float representation could make us work well on float / int type too.
-    if (dtype.bits == 1) {
-      std::generate_n(static_cast<bool*>(data) + st, ed - st, [&]() { return dist(rnd_engine_); });
-    } else if (dtype.bits == 4) {
-      // For uint4/int4 we pack two values into a single byte.
-      // Thus, to ensure both values are non-zero, we use a distribution of 17 - 30.
-      std::uniform_real_distribution<> packed_dist(17.0, 30.0);
-      std::generate_n(reinterpret_cast<uint8_t*>(data) + st, ed - st,
-                      [&]() { return packed_dist(rnd_engine_); });
-    } else if (dtype.bits == 8) {
+    if (dtype.bits == 8) {
       std::generate_n(static_cast<uint8_t*>(data) + st, ed - st,
                       [&]() { return dist(rnd_engine_); });
     } else if (dtype.bits == 16) {
@@ -184,9 +167,13 @@ class RandomEngine {
   }
 
   void FillData(DLTensor* tensor) {
+    int64_t size = 1;
+    for (int i = 0; i < tensor->ndim; ++i) {
+      size *= tensor->shape[i];
+    }
     DLDataType dtype = tensor->dtype;
     if (dtype.bits == 8 || dtype.bits == 16 || dtype.bits == 32 || dtype.bits == 64) {
-      FillDataImpl(tensor->data, 0, GetFillElementCount(tensor), dtype);
+      FillDataImpl(tensor->data, 0, size, dtype);
     } else {
       TVM_FFI_THROW(InternalError)
           << "Doesn't support dtype code " << dtype.code << " dtype bits " << dtype.bits;
@@ -218,7 +205,10 @@ class RandomEngine {
     task.self = this;
     task.data = tensor->data;
     DLDataType dtype = task.dtype = tensor->dtype;
-    task.size = GetFillElementCount(tensor);
+    int64_t& size = task.size = 1;
+    for (int i = 0; i < tensor->ndim; ++i) {
+      size *= tensor->shape[i];
+    }
     if (dtype.bits == 8 || dtype.bits == 16 || dtype.bits == 32 || dtype.bits == 64) {
       int res = TVMBackendParallelLaunch(ParallelTask::RunTask, &task, 0);
       TVM_FFI_ICHECK_EQ(res, 0) << "RandomFillForMeasure: TVMBackendParallelLaunch failed";

--- a/tests/python/contrib/test_memoize.py
+++ b/tests/python/contrib/test_memoize.py
@@ -28,10 +28,14 @@ import tvm.testing
 TEST_SCRIPT_FILE = pathlib.Path(__file__).with_name("pickle_memoize_script.py").resolve()
 
 
+def run_test_script(*args, **kwargs):
+    subprocess.check_call([sys.executable, str(TEST_SCRIPT_FILE), *args], **kwargs)
+
+
 def test_cache_dir_not_in_current_working_dir():
     with tempfile.TemporaryDirectory(prefix="tvm_") as temp_dir:
         temp_dir = pathlib.Path(temp_dir)
-        subprocess.check_call([TEST_SCRIPT_FILE, "1", "1"], cwd=temp_dir)
+        run_test_script("1", "1", cwd=temp_dir)
 
         new_files = list(temp_dir.iterdir())
         assert not new_files, (
@@ -62,7 +66,7 @@ def test_cache_dir_defaults_to_home_config_cache():
     with tempfile.TemporaryDirectory(prefix="tvm_") as temp_dir:
         temp_dir = pathlib.Path(temp_dir)
 
-        subprocess.check_call([TEST_SCRIPT_FILE, "1", "0"], cwd=temp_dir)
+        run_test_script("1", "0", cwd=temp_dir)
 
         new_files = list(temp_dir.iterdir())
         assert not new_files, (
@@ -83,8 +87,9 @@ def test_cache_dir_respects_xdg_cache_home():
         temp_cache_dir = pathlib.Path(temp_cache_dir)
         temp_working_dir = pathlib.Path(temp_working_dir)
 
-        subprocess.check_call(
-            [TEST_SCRIPT_FILE, "1", "0"],
+        run_test_script(
+            "1",
+            "0",
             cwd=temp_working_dir,
             env={
                 **os.environ,
@@ -111,8 +116,9 @@ def test_cache_dir_only_created_when_used():
         temp_cache_dir = pathlib.Path(temp_cache_dir)
         temp_working_dir = pathlib.Path(temp_working_dir)
 
-        subprocess.check_call(
-            [TEST_SCRIPT_FILE, "0", "1"],
+        run_test_script(
+            "0",
+            "1",
             cwd=temp_working_dir,
             env={
                 **os.environ,

--- a/tests/python/contrib/test_memoize.py
+++ b/tests/python/contrib/test_memoize.py
@@ -28,14 +28,10 @@ import tvm.testing
 TEST_SCRIPT_FILE = pathlib.Path(__file__).with_name("pickle_memoize_script.py").resolve()
 
 
-def run_test_script(*args, **kwargs):
-    subprocess.check_call([sys.executable, str(TEST_SCRIPT_FILE), *args], **kwargs)
-
-
 def test_cache_dir_not_in_current_working_dir():
     with tempfile.TemporaryDirectory(prefix="tvm_") as temp_dir:
         temp_dir = pathlib.Path(temp_dir)
-        run_test_script("1", "1", cwd=temp_dir)
+        subprocess.check_call([sys.executable, str(TEST_SCRIPT_FILE), "1", "1"], cwd=temp_dir)
 
         new_files = list(temp_dir.iterdir())
         assert not new_files, (
@@ -66,7 +62,7 @@ def test_cache_dir_defaults_to_home_config_cache():
     with tempfile.TemporaryDirectory(prefix="tvm_") as temp_dir:
         temp_dir = pathlib.Path(temp_dir)
 
-        run_test_script("1", "0", cwd=temp_dir)
+        subprocess.check_call([sys.executable, str(TEST_SCRIPT_FILE), "1", "0"], cwd=temp_dir)
 
         new_files = list(temp_dir.iterdir())
         assert not new_files, (
@@ -87,9 +83,8 @@ def test_cache_dir_respects_xdg_cache_home():
         temp_cache_dir = pathlib.Path(temp_cache_dir)
         temp_working_dir = pathlib.Path(temp_working_dir)
 
-        run_test_script(
-            "1",
-            "0",
+        subprocess.check_call(
+            [sys.executable, str(TEST_SCRIPT_FILE), "1", "0"],
             cwd=temp_working_dir,
             env={
                 **os.environ,
@@ -116,9 +111,8 @@ def test_cache_dir_only_created_when_used():
         temp_cache_dir = pathlib.Path(temp_cache_dir)
         temp_working_dir = pathlib.Path(temp_working_dir)
 
-        run_test_script(
-            "0",
-            "1",
+        subprocess.check_call(
+            [sys.executable, str(TEST_SCRIPT_FILE), "0", "1"],
             cwd=temp_working_dir,
             env={
                 **os.environ,


### PR DESCRIPTION
This pr fixes two contrib test failures that show up when running source-tree tests against the `apache-tvm` wheel.

- Launch the pickle memoize helper script with `sys.executable` so subprocesses use the same Python environment as pytest.
- Fix `tvm.contrib.random.random_fill` for packed sub-byte dtypes by using the actual tensor storage size instead of the logical element count.

## Root Cause

`tests/python/contrib/test_memoize.py` executed `pickle_memoize_script.py` directly. In a wheel test environment, the shebang can resolve to a different Python than the active wheel venv, causing `ModuleNotFoundError: No module named 'tvm'`.

`random_fill` used the product of tensor shape as the number of values to write. For packed dtypes such as `int4`, two logical elements share one byte, so this wrote past the allocated storage and caused native heap corruption / process abort.