### PR TITLE
[Codegen][LLVM] Accept splat form in VLA broadcast test

### DIFF
--- a/tests/python/codegen/test_target_codegen_llvm_vla.py
+++ b/tests/python/codegen/test_target_codegen_llvm_vla.py
@@ -109,9 +109,13 @@ def test_scalable_broadcast(target):
         mod = tvm.tirx.build(my_func)
 
     llvm = mod.inspect_source("ll")
+    # Older LLVM versions print the broadcast as a shufflevector of an insertelement,
+    # newer ones print it as a splat constant.
     assert re.findall(
         r"shufflevector \(<vscale x 4 x float> insertelement \(<vscale x 4 x float>", llvm
-    ), "No scalable broadcast in generated LLVM."
+    ) or re.findall(r"store <vscale x 4 x float> splat \(float 1\.000000e\+00\)", llvm), (
+        "No scalable broadcast in generated LLVM."
+    )
     assert re.findall(r" store <vscale x 4 x float>", llvm), "No scalable store in generated LLVM."
 
 

--- a/tests/python/codegen/test_target_codegen_llvm_vla.py
+++ b/tests/python/codegen/test_target_codegen_llvm_vla.py
@@ -111,11 +111,10 @@ def test_scalable_broadcast(target):
     llvm = mod.inspect_source("ll")
     # Older LLVM versions print the broadcast as a shufflevector of an insertelement,
     # newer ones print it as a splat constant.
-    assert re.findall(
-        r"shufflevector \(<vscale x 4 x float> insertelement \(<vscale x 4 x float>", llvm
-    ) or re.findall(r"store <vscale x 4 x float> splat \(float 1\.000000e\+00\)", llvm), (
-        "No scalable broadcast in generated LLVM."
-    )
+    assert (
+        "shufflevector (<vscale x 4 x float> insertelement (<vscale x 4 x float>" in llvm
+        or "store <vscale x 4 x float> splat (float 1.000000e+00)" in llvm
+    ), "No scalable broadcast in generated LLVM."
     assert re.findall(r" store <vscale x 4 x float>", llvm), "No scalable store in generated LLVM."
 
 


### PR DESCRIPTION
Newer LLVM versions (observed with LLVM 20) print a scalable broadcast store as a splat constant, e.g.
`store <vscale x 4 x float> splat (float 1.000000e+00)`, instead of the older `shufflevector (<vscale x 4 x float> insertelement (...` form. Accept either representation in test_scalable_broadcast so the test passes across LLVM versions while still verifying scalable vector codegen.