### PR TITLE
[DOCS] Clarify loading serialized artifacts requires a trusted source

### DIFF
--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -51,6 +51,9 @@ RPC data exchange between the tracker, server and client are in plain-text.
 It is recommended to use them under trusted networking environment or encrypted channels.
 
 
+Loading serialized artifacts must only be done with input from a trusted source.
+
+
 Security Advisories
 -------------------
 


### PR DESCRIPTION
Clarify in the Security Guide that loading serialized artifacts must only be done with input from a trusted source.