### PR TITLE
[Tests][Disco] Skip CCL tests when runtime support is absent

### DIFF
--- a/tests/python/disco/test_ccl.py
+++ b/tests/python/disco/test_ccl.py
@@ -32,7 +32,10 @@ from tvm.s_tir import dlight as dl
 from tvm.script import relax as R
 
 _all_session_kinds = [di.ThreadedSession, di.ProcessSession]
-_ccl = [get_global_func("runtime.disco.compiled_ccl")()]
+_compiled_ccl = get_global_func("runtime.disco.compiled_ccl", allow_missing=True)
+if _compiled_ccl is None:
+    pytest.skip("Disco CCL is not enabled in this TVM build", allow_module_level=True)
+_ccl = [_compiled_ccl()]
 
 
 def create_device_target(ccl):

--- a/tests/python/disco/test_custom_allreduce.py
+++ b/tests/python/disco/test_custom_allreduce.py
@@ -45,7 +45,10 @@ _strategies = [
     AllReduceStrategyType.AUTO,
 ]
 
-_ccl = [ccl for ccl in tvm.get_global_func("runtime.disco.compiled_ccl")() if ccl == "nccl"]
+_compiled_ccl = tvm.get_global_func("runtime.disco.compiled_ccl", allow_missing=True)
+if _compiled_ccl is None:
+    pytest.skip("Disco CCL is not enabled in this TVM build", allow_module_level=True)
+_ccl = [ccl for ccl in _compiled_ccl() if ccl == "nccl"]
 
 
 @pytest.mark.parametrize("shape", _shapes)


### PR DESCRIPTION
The disco CCL tests called tvm.get_global_func("runtime.disco.compiled_ccl") at module import time, which raises ValueError on TVM builds without Disco CCL support (e.g. published wheels), failing pytest collection. Resolve the function with allow_missing=True and skip the module when it is absent.