### PR TITLE
[Relax][PyTorch][DLight] Fix exported-program CUDA test failures

### DIFF
--- a/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
+++ b/python/tvm/relax/frontend/torch/base_fx_graph_translator.py
@@ -1684,6 +1684,20 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         if isinstance(dim, list | tuple) and len(dim) == 0:
             dim = None
         keepdim = args[2] if len(node.args) > 2 else node.kwargs.get("keepdim", False)
+        dtype = node.kwargs.get("dtype", None)
+        if dtype is not None:
+            x = self.block_builder.emit(
+                relax.op.astype(x, self._convert_data_type(dtype, self.env))
+            )
+        else:
+            # Match PyTorch type promotion: summing bool or integer tensors
+            # accumulates in int64 unless an explicit dtype is given.
+            input_dtype = x.struct_info.dtype
+            if input_dtype == "bool" or (
+                (input_dtype.startswith("int") or input_dtype.startswith("uint"))
+                and input_dtype != "int64"
+            ):
+                x = self.block_builder.emit(relax.op.astype(x, "int64"))
         return self.block_builder.emit(relax.op.sum(x, dim, keepdims=keepdim))
 
     def _var(self, node: fx.Node) -> relax.Var:
@@ -1995,6 +2009,17 @@ class BaseFXGraphImporter(metaclass=abc.ABCMeta):
         if len(non_none_indices) == 1:
             axis, index_tensor = non_none_indices[0]
             return self.block_builder.emit(relax.op.take(data, index_tensor, axis=axis))
+
+        # If no dimension is sliced (no None entries), this is plain NumPy-style
+        # advanced indexing: the index tensors broadcast together and are applied
+        # jointly ("zipped"), which is exactly relax.op.index_tensor's semantics.
+        # Note that the sequential-take path below is NOT equivalent: it computes
+        # an outer product over the index tensors, which only matches PyTorch
+        # when the index shapes are mutually orthogonal (e.g. (H, 1) and (W,)).
+        if len(non_none_indices) == len(indices):
+            return self.block_builder.emit(
+                relax.op.index_tensor(data, [idx for _, idx in non_none_indices])
+            )
 
         # Check if all indices can be squeezed to 1D for sequential take
         def is_squeezable(idx):

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -2030,6 +2030,21 @@ class ExportedProgramImporter(BaseFXGraphImporter):
                 )
                 output_args = self._flatten_output_args(output_args)
 
+                # Functionalization in torch.export prepends mutation outputs
+                # (e.g. buffer mutations from in-place ops such as `copy_`) to the
+                # graph outputs. Only user-facing outputs should be returned so the
+                # Relax function matches the original module's calling convention.
+                output_kind = torch.export.graph_signature.OutputKind
+                output_specs = exported_program.graph_signature.output_specs
+                if len(output_specs) == len(output_args):
+                    user_outputs = tuple(
+                        arg
+                        for arg, spec in zip(output_args, output_specs)
+                        if spec.kind in (output_kind.USER_OUTPUT, output_kind.LOSS_OUTPUT)
+                    )
+                    if user_outputs:
+                        output_args = user_outputs
+
                 if unwrap_unit_return_tuple and len(output_args) == 1:
                     ret = output_args[0]
                 elif no_bind_return_tuple:

--- a/python/tvm/s_tir/dlight/gpu/fallback.py
+++ b/python/tvm/s_tir/dlight/gpu/fallback.py
@@ -26,6 +26,24 @@ from ..base import try_inline
 from .base import GPUScheduleRule
 
 
+def _has_internal_thread_env(stmt: tirx.Stmt) -> bool:
+    """Check whether a statement already launches GPU threads internally,
+    e.g. via `T.launch_thread` (AttrStmt "thread_extent") or nested
+    thread-bound loops. Such blocks manage their own thread environment
+    and must not be wrapped in an additional thread binding."""
+    found = False
+
+    def _visit(node):
+        nonlocal found
+        if isinstance(node, tirx.AttrStmt) and node.attr_key in ("thread_extent", "virtual_thread"):
+            found = True
+        elif isinstance(node, tirx.For) and node.kind == tirx.ForKind.THREAD_BINDING:
+            found = True
+
+    tirx.stmt_functor.post_order_visit(stmt, _visit)
+    return found
+
+
 class Fallback(GPUScheduleRule):
     """
     A fallback schedule rule for all GPU operators. It will try to inline all the blocks first,
@@ -57,15 +75,14 @@ class Fallback(GPUScheduleRule):
             dom_kind = block.dom_kind()
             block = block.block_rv
 
-            if (
-                any(
-                    [
-                        sch.get(loop_rv).thread_binding is not None
-                        for loop_rv in sch.get_loops(block)
-                    ]
-                )
-                or len(sch.get_loops(block)) == 0
+            if any(
+                [sch.get(loop_rv).thread_binding is not None for loop_rv in sch.get_loops(block)]
             ):
+                continue
+
+            if len(sch.get_loops(block)) == 0 and _has_internal_thread_env(sch.get(block).body):
+                # The block (e.g. an opaque sort kernel) launches its own
+                # threads; binding an outer loop would conflict with them.
                 continue
 
             for loop, iter_type in zip(sch.get_loops(block), dom_kind):

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -361,7 +361,7 @@ def test_extended_unary_ops():
     class expected_dropout_for_3:
         @R.function
         def main(input: R.Tensor((1, 3, 10, 10), dtype="float32")) -> R.Tuple(
-            R.Tensor((1, 3, 10, 10), dtype="float32"), R.Tensor((1, 3, 10, 10), dtype="float32")
+            R.Tensor((1, 3, 10, 10), dtype="float32")
         ):
             # block 0
             with R.dataflow():
@@ -372,10 +372,7 @@ def test_extended_unary_ops():
                     lv, R.const(0.5, "float32")
                 )
                 lv2: R.Tensor((1, 3, 10, 10), dtype="float32") = R.multiply(input, lv1)
-                gv: R.Tuple(
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                ) = (lv2, lv2)
+                gv: R.Tuple(R.Tensor((1, 3, 10, 10), dtype="float32")) = (lv2,)
                 R.output(gv)
             return gv
 
@@ -504,7 +501,7 @@ def test_extended_unary_ops():
     class expected_hardswish_for_3:
         @R.function
         def main(input: R.Tensor((1, 3, 10, 10), dtype="float32")) -> R.Tuple(
-            R.Tensor((1, 3, 10, 10), dtype="float32"), R.Tensor((1, 3, 10, 10), dtype="float32")
+            R.Tensor((1, 3, 10, 10), dtype="float32")
         ):
             with R.dataflow():
                 lv: R.Tensor((1, 3, 10, 10), dtype="float32") = R.add(
@@ -520,10 +517,7 @@ def test_extended_unary_ops():
                 lv4: R.Tensor((1, 3, 10, 10), dtype="float32") = R.divide(
                     lv3, R.const(6.0, "float32")
                 )
-                gv: R.Tuple(
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                ) = (lv4, lv4)
+                gv: R.Tuple(R.Tensor((1, 3, 10, 10), dtype="float32")) = (lv4,)
                 R.output(gv)
             return gv
 
@@ -726,16 +720,13 @@ def test_extended_unary_ops():
     class expected_relu6_3:
         @R.function
         def main(x: R.Tensor((1, 3, 10, 10), dtype="float32")) -> R.Tuple(
-            R.Tensor((1, 3, 10, 10), dtype="float32"), R.Tensor((1, 3, 10, 10), dtype="float32")
+            R.Tensor((1, 3, 10, 10), dtype="float32")
         ):
             with R.dataflow():
                 lv: R.Tensor((1, 3, 10, 10), dtype="float32") = R.clip(
                     x, R.prim_value(0), R.prim_value(6)
                 )
-                gv: R.Tuple(
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                ) = (lv, lv)
+                gv: R.Tuple(R.Tensor((1, 3, 10, 10), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 
@@ -800,18 +791,12 @@ def test_extended_unary_ops():
     class expected_silu_:
         @R.function
         def main(input: R.Tensor((1, 3, 10, 10), dtype="float32")) -> R.Tuple(
-            R.Tensor((1, 3, 10, 10), dtype="float32"), R.Tensor((1, 3, 10, 10), dtype="float32")
+            R.Tensor((1, 3, 10, 10), dtype="float32")
         ):
             with R.dataflow():
                 lv: R.Tensor((1, 3, 10, 10), dtype="float32") = R.sigmoid(input)
                 lv1: R.Tensor((1, 3, 10, 10), dtype="float32") = R.multiply(input, lv)
-                gv: R.Tuple(
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                ) = (
-                    lv1,
-                    lv1,
-                )
+                gv: R.Tuple(R.Tensor((1, 3, 10, 10), dtype="float32")) = (lv1,)
                 R.output(gv)
             return gv
 
@@ -889,27 +874,11 @@ def test_hardtanh():
                 R.output(gv)
             return gv
 
-    @tvm.script.ir_module
-    class expected_hardtanh_for_3:
-        @R.function
-        def main(inp_0: R.Tensor((1, 3, 10, 10), dtype="float32")) -> R.Tuple(
-            R.Tensor((1, 3, 10, 10), dtype="float32"), R.Tensor((1, 3, 10, 10), dtype="float32")
-        ):
-            with R.dataflow():
-                lv: R.Tensor((1, 3, 10, 10), dtype="float32") = R.clip(
-                    inp_0, R.prim_value(T.float64(-1.0)), R.prim_value(T.float64(1.0))
-                )
-                gv: R.Tuple(
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                ) = (lv, lv)
-                R.output(gv)
-            return gv
-
     example_args = (torch.randn(1, 3, 10, 10, dtype=torch.float32),)
     verify_model(Hardtanh(), example_args, {}, expected_for_1_2)
     verify_model(Hardtanh2(), example_args, {}, expected_for_1_2)
-    verify_model(Hardtanh3(), example_args, {}, expected_hardtanh_for_3)
+    # In-place hardtanh_ yields the same program; mutation outputs are dropped.
+    verify_model(Hardtanh3(), example_args, {}, expected_for_1_2)
 
 
 def test_softplus():
@@ -994,26 +963,11 @@ def test_leakyrelu():
                 R.output(gv)
             return gv
 
-    @tvm.script.ir_module
-    class expected_for_3:
-        @R.function
-        def main(input: R.Tensor((1, 3, 10, 10), dtype="float32")) -> R.Tuple(
-            R.Tensor((1, 3, 10, 10), dtype="float32"), R.Tensor((1, 3, 10, 10), dtype="float32")
-        ):
-            # block 0
-            with R.dataflow():
-                lv: R.Tensor((1, 3, 10, 10), dtype="float32") = R.nn.leakyrelu(input, alpha=0.02)
-                gv: R.Tuple(
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                    R.Tensor((1, 3, 10, 10), dtype="float32"),
-                ) = (lv, lv)
-                R.output(gv)
-            return gv
-
     example_args = (torch.randn(1, 3, 10, 10, dtype=torch.float32),)
     verify_model(LeakyReLU0(), example_args, {}, expected_for_1_2)
     verify_model(LeakyReLU1(), example_args, {}, expected_for_1_2)
-    verify_model(LeakyReLU2(), example_args, {}, expected_for_3)
+    # In-place leaky_relu_ yields the same program; mutation outputs are dropped.
+    verify_model(LeakyReLU2(), example_args, {}, expected_for_1_2)
 
 
 def test_logaddexp():
@@ -1419,21 +1373,6 @@ def test_binary1(op, relax_op):
                 R.output(gv)
             return gv
 
-    @tvm.script.ir_module
-    class expected_binary1_inplace:
-        @R.function
-        def main(
-            lhs: R.Tensor((10, 10), dtype="float32"),
-            rhs: R.Tensor((10, 10), dtype="float32"),
-        ) -> R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tensor((10, 10), dtype="float32")):
-            with R.dataflow():
-                lv: R.Tensor((10, 10), dtype="float32") = relax_op(lhs, rhs)
-                gv: R.Tuple(
-                    R.Tensor((10, 10), dtype="float32"), R.Tensor((10, 10), dtype="float32")
-                ) = (lv, lv)
-                R.output(gv)
-            return gv
-
     class Binary2(Module):
         def __init__(self, op):
             super().__init__()
@@ -1454,30 +1393,10 @@ def test_binary1(op, relax_op):
                 R.output(gv)
             return gv
 
-    @tvm.script.ir_module
-    class expected_binary2_inplace:
-        @R.function
-        def main(
-            lhs: R.Tensor((10, 10), dtype="float32"),
-        ) -> R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tensor((10, 10), dtype="float32")):
-            with R.dataflow():
-                lv: R.Tensor((10, 10), dtype="float32") = relax_op(lhs, R.const(1.0))
-                gv: R.Tuple(
-                    R.Tensor((10, 10), dtype="float32"), R.Tensor((10, 10), dtype="float32")
-                ) = (lv, lv)
-                R.output(gv)
-            return gv
-
-    inplace_ops = [
-        torch.ops.aten.add_,
-        torch.ops.aten.bitwise_or_,
-        torch.ops.aten.mul_,
-    ]
-
-    expected1 = expected_binary1_inplace if op in inplace_ops else expected_binary1
-    expected2 = expected_binary2_inplace if op in inplace_ops else expected_binary2
-    verify_model(Binary1(op), example_args1, {}, expected1)
-    verify_model(Binary2(op), example_args2, {}, expected2)
+    # In-place ops (add_, mul_, ...) produce the same Relax program as their
+    # functional counterparts: mutation outputs are dropped by the importer.
+    verify_model(Binary1(op), example_args1, {}, expected_binary1)
+    verify_model(Binary2(op), example_args2, {}, expected_binary2)
 
 
 operator_binary_scalar = [
@@ -1943,12 +1862,7 @@ def test_batchnorm2d():
             w2: R.Tensor((3,), dtype="float32"),
             w3: R.Tensor((3,), dtype="float32"),
             w4: R.Tensor((3,), dtype="float32"),
-        ) -> R.Tuple(
-            R.Tensor((3,), dtype="float32"),
-            R.Tensor((3,), dtype="float32"),
-            R.Tensor((), dtype="int64"),
-            R.Tensor((2, 3, 4, 4), dtype="float32"),
-        ):
+        ) -> R.Tuple(R.Tensor((2, 3, 4, 4), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((), dtype="int64") = R.add(R.const(0, "int64"), R.const(1, "int64"))
                 lv1: R.Tuple(
@@ -1981,12 +1895,7 @@ def test_batchnorm2d():
                 lv6: R.Tensor((2, 3, 4, 4), dtype="float32") = lv5[0]
                 lv7: R.Tensor((3,), dtype="float32") = lv5[3]
                 lv8: R.Tensor((3,), dtype="float32") = lv5[4]
-                gv: R.Tuple(
-                    R.Tensor((3,), dtype="float32"),
-                    R.Tensor((3,), dtype="float32"),
-                    R.Tensor((), dtype="int64"),
-                    R.Tensor((2, 3, 4, 4), dtype="float32"),
-                ) = (lv7, lv8, lv, lv6)
+                gv: R.Tuple(R.Tensor((2, 3, 4, 4), dtype="float32")) = (lv6,)
                 R.output(gv)
             return gv
 
@@ -6368,15 +6277,13 @@ def test_fill_inplace():
     class Expected:
         @R.function
         def main(input: R.Tensor((2, 3), dtype="float32")) -> R.Tuple(
-            R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")
+            R.Tensor((2, 3), dtype="float32")
         ):
             with R.dataflow():
                 lv: R.Tensor((2, 3), dtype="float32") = R.full_like(
                     input, R.const(42.0, "float32"), dtype="void"
                 )
-                gv: R.Tuple(
-                    R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")
-                ) = (lv, lv)
+                gv: R.Tuple(R.Tensor((2, 3), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 
@@ -6416,13 +6323,11 @@ def test_masked_fill_inplace():
         @R.function
         def main(
             input: R.Tensor((128, 128), dtype="float32"), mask: R.Tensor((128, 128), dtype="bool")
-        ) -> R.Tuple(R.Tensor((128, 128), dtype="float32"), R.Tensor((128, 128), dtype="float32")):
+        ) -> R.Tuple(R.Tensor((128, 128), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((), dtype="float32") = R.const(1.5, "float32")
                 lv1: R.Tensor((128, 128), dtype="float32") = R.where(mask, lv, input)
-                gv: R.Tuple(
-                    R.Tensor((128, 128), dtype="float32"), R.Tensor((128, 128), dtype="float32")
-                ) = (lv1, lv1)
+                gv: R.Tuple(R.Tensor((128, 128), dtype="float32")) = (lv1,)
                 R.output(gv)
             return gv
 
@@ -6519,17 +6424,12 @@ def test_copy():
     class expected_copy:
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32"), src: R.Tensor((), dtype="int64")) -> R.Tuple(
-            R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")
+            R.Tensor((2, 3), dtype="float32")
         ):
             with R.dataflow():
                 lv: R.Tensor((), dtype="float32") = R.astype(src, dtype="float32")
                 lv1: R.Tensor((2, 3), dtype="float32") = R.broadcast_to(lv, (2, 3))
-                gv: R.Tuple(
-                    R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")
-                ) = (
-                    lv1,
-                    lv1,
-                )
+                gv: R.Tuple(R.Tensor((2, 3), dtype="float32")) = (lv1,)
                 R.output(gv)
             return gv
 
@@ -6869,18 +6769,13 @@ def test_zero_inplace():
     class Expected:
         @R.function
         def main(input: R.Tensor((128, 128), dtype="float32")) -> R.Tuple(
-            R.Tensor((128, 128), dtype="float32"), R.Tensor((128, 128), dtype="float32")
+            R.Tensor((128, 128), dtype="float32")
         ):
             with R.dataflow():
                 lv: R.Tensor((128, 128), dtype="float32") = R.full_like(
                     input, R.const(0, "int32"), dtype="void"
                 )
-                gv: R.Tuple(
-                    R.Tensor((128, 128), dtype="float32"), R.Tensor((128, 128), dtype="float32")
-                ) = (
-                    lv,
-                    lv,
-                )
+                gv: R.Tuple(R.Tensor((128, 128), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 
@@ -7141,15 +7036,12 @@ def test_index_put():
             data: R.Tensor((64,), dtype="float32"),
             indices_0: R.Tensor((128,), dtype="int64"),
             values: R.Tensor((128,), dtype="float32"),
-        ) -> R.Tuple(R.Tensor((64,), dtype="float32"), R.Tensor((64,), dtype="float32")):
+        ) -> R.Tuple(R.Tensor((64,), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((64,), dtype="float32") = R.index_put(
                     data, (indices_0,), values, accumulate=False
                 )
-                gv: R.Tuple(R.Tensor((64,), dtype="float32"), R.Tensor((64,), dtype="float32")) = (
-                    lv,
-                    lv,
-                )
+                gv: R.Tuple(R.Tensor((64,), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 
@@ -7174,14 +7066,12 @@ def test_index_put():
             indices_0: R.Tensor((128,), dtype="int64"),
             indices_1: R.Tensor((128,), dtype="int64"),
             values: R.Tensor((128,), dtype="float32"),
-        ) -> R.Tuple(R.Tensor((32, 64), dtype="float32"), R.Tensor((32, 64), dtype="float32")):
+        ) -> R.Tuple(R.Tensor((32, 64), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((32, 64), dtype="float32") = R.index_put(
                     data, (indices_0, indices_1), values, accumulate=False
                 )
-                gv: R.Tuple(
-                    R.Tensor((32, 64), dtype="float32"), R.Tensor((32, 64), dtype="float32")
-                ) = (lv, lv)
+                gv: R.Tuple(R.Tensor((32, 64), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 
@@ -7208,16 +7098,12 @@ def test_index_put():
             indices_1: R.Tensor((128,), dtype="int64"),
             indices_2: R.Tensor((128,), dtype="int64"),
             values: R.Tensor((128,), dtype="float32"),
-        ) -> R.Tuple(
-            R.Tensor((16, 32, 64), dtype="float32"), R.Tensor((16, 32, 64), dtype="float32")
-        ):
+        ) -> R.Tuple(R.Tensor((16, 32, 64), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((16, 32, 64), dtype="float32") = R.index_put(
                     data, (indices_0, indices_1, indices_2), values, accumulate=False
                 )
-                gv: R.Tuple(
-                    R.Tensor((16, 32, 64), dtype="float32"), R.Tensor((16, 32, 64), dtype="float32")
-                ) = (lv, lv)
+                gv: R.Tuple(R.Tensor((16, 32, 64), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 
@@ -7246,10 +7132,7 @@ def test_index_put():
             indices_2: R.Tensor((128,), dtype="int64"),
             indices_3: R.Tensor((128,), dtype="int64"),
             values: R.Tensor((128,), dtype="float32"),
-        ) -> R.Tuple(
-            R.Tensor((8, 16, 32, 64), dtype="float32"),
-            R.Tensor((8, 16, 32, 64), dtype="float32"),
-        ):
+        ) -> R.Tuple(R.Tensor((8, 16, 32, 64), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((8, 16, 32, 64), dtype="float32") = R.index_put(
                     data,
@@ -7257,10 +7140,7 @@ def test_index_put():
                     values,
                     accumulate=False,
                 )
-                gv: R.Tuple(
-                    R.Tensor((8, 16, 32, 64), dtype="float32"),
-                    R.Tensor((8, 16, 32, 64), dtype="float32"),
-                ) = (lv, lv)
+                gv: R.Tuple(R.Tensor((8, 16, 32, 64), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 
@@ -7291,10 +7171,7 @@ def test_index_put():
             indices_3: R.Tensor((128,), dtype="int64"),
             indices_4: R.Tensor((128,), dtype="int64"),
             values: R.Tensor((128,), dtype="float32"),
-        ) -> R.Tuple(
-            R.Tensor((4, 8, 16, 32, 64), dtype="float32"),
-            R.Tensor((4, 8, 16, 32, 64), dtype="float32"),
-        ):
+        ) -> R.Tuple(R.Tensor((4, 8, 16, 32, 64), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((4, 8, 16, 32, 64), dtype="float32") = R.index_put(
                     data,
@@ -7302,10 +7179,7 @@ def test_index_put():
                     values,
                     accumulate=False,
                 )
-                gv: R.Tuple(
-                    R.Tensor((4, 8, 16, 32, 64), dtype="float32"),
-                    R.Tensor((4, 8, 16, 32, 64), dtype="float32"),
-                ) = (lv, lv)
+                gv: R.Tuple(R.Tensor((4, 8, 16, 32, 64), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 
@@ -7328,7 +7202,7 @@ def test_index_put():
         def main(
             data: R.Tensor((32, 64), dtype="float32"),
             indices_1: R.Tensor((10,), dtype="int64"),
-        ) -> R.Tuple(R.Tensor((32, 64), dtype="float32"), R.Tensor((32, 64), dtype="float32")):
+        ) -> R.Tuple(R.Tensor((32, 64), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((32,), dtype="int64") = R.arange(
                     R.prim_value(0), R.prim_value(32), R.prim_value(1), dtype="int64"
@@ -7340,9 +7214,7 @@ def test_index_put():
                 lv3: R.Tensor((32, 64), dtype="float32") = R.index_put(
                     data, (lv1, indices_1), lv2, accumulate=False
                 )
-                gv: R.Tuple(
-                    R.Tensor((32, 64), dtype="float32"), R.Tensor((32, 64), dtype="float32")
-                ) = (lv3, lv3)
+                gv: R.Tuple(R.Tensor((32, 64), dtype="float32")) = (lv3,)
                 R.output(gv)
             return gv
 
@@ -7364,7 +7236,7 @@ def test_index_put():
         def main(
             data: R.Tensor((32, 64), dtype="float32"),
             indices_0: R.Tensor((10,), dtype="int64"),
-        ) -> R.Tuple(R.Tensor((32, 64), dtype="float32"), R.Tensor((32, 64), dtype="float32")):
+        ) -> R.Tuple(R.Tensor((32, 64), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((64,), dtype="int64") = R.arange(
                     R.prim_value(0), R.prim_value(64), R.prim_value(1), dtype="int64"
@@ -7376,9 +7248,7 @@ def test_index_put():
                 lv3: R.Tensor((32, 64), dtype="float32") = R.index_put(
                     data, (indices_0, lv1), lv2, accumulate=False
                 )
-                gv: R.Tuple(
-                    R.Tensor((32, 64), dtype="float32"), R.Tensor((32, 64), dtype="float32")
-                ) = (lv3, lv3)
+                gv: R.Tuple(R.Tensor((32, 64), dtype="float32")) = (lv3,)
                 R.output(gv)
             return gv
 
@@ -7401,9 +7271,7 @@ def test_index_put():
         def main(
             data: R.Tensor((16, 32, 64), dtype="float32"),
             indices_1: R.Tensor((10,), dtype="int64"),
-        ) -> R.Tuple(
-            R.Tensor((16, 32, 64), dtype="float32"), R.Tensor((16, 32, 64), dtype="float32")
-        ):
+        ) -> R.Tuple(R.Tensor((16, 32, 64), dtype="float32")):
             with R.dataflow():
                 lv: R.Tensor((16,), dtype="int64") = R.arange(
                     R.prim_value(0), R.prim_value(16), R.prim_value(1), dtype="int64"
@@ -7419,9 +7287,7 @@ def test_index_put():
                 lv5: R.Tensor((16, 32, 64), dtype="float32") = R.index_put(
                     data, (lv1, indices_1, lv3), lv4, accumulate=False
                 )
-                gv: R.Tuple(
-                    R.Tensor((16, 32, 64), dtype="float32"), R.Tensor((16, 32, 64), dtype="float32")
-                ) = (lv5, lv5)
+                gv: R.Tuple(R.Tensor((16, 32, 64), dtype="float32")) = (lv5,)
                 R.output(gv)
             return gv
 
@@ -7558,19 +7424,17 @@ def test_index_put_mutation_through_alias_regression():
         ) -> R.Tuple(
             R.Tensor((5,), dtype="float32"),
             R.Tensor((5,), dtype="float32"),
-            R.Tensor((5,), dtype="float32"),
         ):
             with R.dataflow():
                 lv: R.Tensor((5,), dtype="float32") = R.index_put(
                     x, (idx,), values, accumulate=False
                 )
-                # ExportedProgram may include an additional mutation output.
+                # Mutation outputs introduced by functionalization are dropped;
+                # only the user outputs (x, y) remain.
                 gv: R.Tuple(
                     R.Tensor((5,), dtype="float32"),
                     R.Tensor((5,), dtype="float32"),
-                    R.Tensor((5,), dtype="float32"),
                 ) = (
-                    lv,
                     lv,
                     lv,
                 )
@@ -8258,11 +8122,12 @@ def test_cross_entropy():
                 lv11: R.Tensor((4,), dtype="bool") = R.not_equal(
                     R.const([0, 1, 2, 1], dtype="int64"), R.const(-100, "int64")
                 )
-                lv12: R.Tensor((), dtype="bool") = R.sum(lv11, axis=None, keepdims=False)
-                lv13: R.Tensor((), dtype="float32") = R.astype(lv12, dtype="float32")
-                lv14: R.Tensor((), dtype="float32") = R.sum(lv10, axis=None, keepdims=False)
-                lv15: R.Tensor((), dtype="float32") = R.divide(lv14, lv13)
-                gv: R.Tuple(R.Tensor((), dtype="float32")) = (lv15,)
+                lv12: R.Tensor((4,), dtype="int64") = R.astype(lv11, dtype="int64")
+                lv13: R.Tensor((), dtype="int64") = R.sum(lv12, axis=None, keepdims=False)
+                lv14: R.Tensor((), dtype="float32") = R.astype(lv13, dtype="float32")
+                lv15: R.Tensor((), dtype="float32") = R.sum(lv10, axis=None, keepdims=False)
+                lv16: R.Tensor((), dtype="float32") = R.divide(lv15, lv14)
+                gv: R.Tuple(R.Tensor((), dtype="float32")) = (lv16,)
                 R.output(gv)
             return gv
 
@@ -8857,13 +8722,11 @@ def test_exponential():
     class Expected:
         @R.function
         def main(x: R.Tensor((4, 8), dtype="float32")) -> R.Tuple(
-            R.Tensor((4, 8), dtype="float32"), R.Tensor((4, 8), dtype="float32")
+            R.Tensor((4, 8), dtype="float32")
         ):
             with R.dataflow():
                 lv: R.Tensor((4, 8), dtype="float32") = R.zeros_like(x, dtype="void")
-                gv: R.Tuple(
-                    R.Tensor((4, 8), dtype="float32"), R.Tensor((4, 8), dtype="float32")
-                ) = (lv, lv)
+                gv: R.Tuple(R.Tensor((4, 8), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
 


### PR DESCRIPTION
This pr fixes the failures in tests/python/nightly/test_nnapi/test_from_exported_to_cuda.py (PyTorch export -> Relax -> CUDA), which despite the directory name are plain CUDA exported-program tests.

1. test_index_tensor: aten.index.Tensor with multiple index tensors and no None entries was lowered through a sequential-take fast path, which computes an outer product over the index tensors. PyTorch/NumPy advanced indexing broadcasts the index tensors together and applies them jointly, so e.g. x[[0, 1], [0, 1]] on a (5, 5, 5, 5) tensor produced shape (2, 2, 5, 5) instead of (2, 5, 5). Route the no-None case directly to relax.op.index_tensor (topi.adv_index), which implements the correct broadcast-and-zip semantics. The sequential-take path is kept for the sliced (None-containing) decomposed-interpolate pattern, whose orthogonal index shapes make the outer product equivalent.

2. test_copy_ (and any in-place op on a buffer/user input): functionalization in torch.export prepends mutation outputs (BUFFER_MUTATION / USER_INPUT_MUTATION) to the graph outputs, and the importer returned them as part of the Relax function's output tuple. Callers indexing outputs positionally then read the mutated-buffer value instead of the model output. Filter the outputs through the graph signature's output_specs and keep only user-facing outputs (USER_OUTPUT / LOSS_OUTPUT). Frontend test expectations that asserted the extra mutation outputs are updated.

3. test_cross_entropy_module:
   - aten.sum over a bool tensor was emitted as relax.op.sum on the bool input, which keeps dtype bool, so the non-ignored-target count in the decomposed cross-entropy collapsed to 1.0 and the mean reduction degenerated to a sum. Match PyTorch type promotion by casting bool and sub-64-bit integer inputs to int64 (or the explicit dtype argument) before summing.
   - The dlight GPU Fallback rule skipped blocks with zero loops entirely, so rank-0 kernels (the scalar divide) were marked tirx.is_scheduled without any thread binding and failed VerifyMemory. Bind such blocks through the existing add-unit-loop path, and only skip zero-loop blocks that already launch threads internally (e.g. opaque sort kernels), detected via thread_extent attrs / thread-bound loops in the block body.