### PR TITLE
[CI] Run s_tir/transform tests in the python-unittest stage

### DIFF
--- a/tests/scripts/task_python_unittest.sh
+++ b/tests/scripts/task_python_unittest.sh
@@ -51,6 +51,7 @@ TEST_FILES=(
   "s_tir/schedule"
   "s_tir/dlight"
   "s_tir/analysis"
+  "s_tir/transform"
   "tirx-analysis"
   "tirx-base"
   "tirx-transform"


### PR DESCRIPTION
The python-unittest stage enumerates test directories explicitly, and tests/python/s_tir/transform was never enrolled when the transform tests were migrated into the s_tir namespace (#18722). As a result the directory has not been exercised by CI at all, which let several regressions land on main unnoticed

Add the directory to TEST_FILES so the s_tir transform passes are covered. GPU-marked tests are filtered by the -m gpu marker selection in the gpuonly variant, so CPU enrollment is safe.