### PR TITLE
[CI] Align cuda-python with PyTorch cuda-bindings

### DIFF
--- a/docker/install/ubuntu_install_cuda_python.sh
+++ b/docker/install/ubuntu_install_cuda_python.sh
@@ -20,4 +20,4 @@ set -e
 set -u
 set -o pipefail
 
-uv pip install cuda-python==12.8.0
+uv pip install cuda-python==12.9.4


### PR DESCRIPTION
This updates the CI GPU Docker dependency pin for `cuda-python` from `12.8.0` to `12.9.4`.

`torch==2.10.0`, installed later by `ubuntu_install_onnx.sh`, requires `cuda-bindings==12.9.4` on Linux x86_64.  However, `cuda-python==12.8.0` constrains `cuda-bindings` to the `12.8.x` series, leaving the CI Python CUDA dependency set inconsistent.

Using `cuda-python==12.9.4` keeps the `cuda-bindings` requirement aligned with the PyTorch wheel already used in the CI image.  This does not change the CUDA base image.