### PR TITLE
[TIRx] Use canonical PTX async script API in s_tir test

### DIFF
--- a/tests/python/s_tir/transform/test_s_tir_transform_inject_ptx_async_copy.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_inject_ptx_async_copy.py
@@ -926,8 +926,8 @@ def test_multiplication_nodes_are_inlined():
                 A_shared[T.Ramp(tx * T.int64(128) + cse_v1 * T.int64(8), T.int64(1), 8)] = (
                     A_flattened[T.Ramp(tx * T.int64(128) + cse_v1 * T.int64(8), T.int64(1), 8)]
                 )
-            T.ptx_commit_group()
-            T.ptx_wait_group(0)
+            T.ptx.cp_async.commit_group()
+            T.ptx.cp_async.wait_group(0)
 
     @I.ir_module(s_tir=True)
     class Expected:
@@ -946,8 +946,8 @@ def test_multiplication_nodes_are_inlined():
                     tx * T.int64(128) + cse_v1 * T.int64(8),
                     16,
                 )
-            T.ptx_commit_group()
-            T.ptx_wait_group(0)
+            T.ptx.cp_async.commit_group()
+            T.ptx.cp_async.wait_group(0)
 
     After = tvm.s_tir.transform.InjectPTXAsyncCopy()(Before)
     tvm.ir.assert_structural_equal(After, Expected)


### PR DESCRIPTION
Update `test_multiplication_nodes_are_inlined` to use the current TIRX PTX async script namespace:

- `T.ptx.cp_async.commit_group()`
- `T.ptx.cp_async.wait_group(0)`

The test still used the older top-level names `T.ptx_commit_group()` and `T.ptx_wait_group(0)`, which are not exposed by the current `tvm.tirx.script` namespace.  This caused parsing to fail before `InjectPTXAsyncCopy` could be tested.

This keeps the test aligned with the rest of the TIRX PTX async tests and with the TVMScript printer output, without adding extra legacy aliases to the public script namespace.