### PR TITLE
[Tests] Check WebGPU volatile allreduce annotation structurally

### DIFF
--- a/tests/python/s_tir/transform/test_s_tir_transform_lower_thread_all_reduce.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_lower_thread_all_reduce.py
@@ -23,6 +23,18 @@ from tvm.script import ir as I
 from tvm.script import tirx as T
 
 
+def _has_volatile_alloc_buffer(mod):
+    has_volatile_alloc = False
+
+    def visit(node):
+        nonlocal has_volatile_alloc
+        if isinstance(node, tvm.tirx.AllocBuffer) and "tirx.volatile" in node.annotations:
+            has_volatile_alloc = has_volatile_alloc or node.annotations["tirx.volatile"] is True
+
+    tvm.tirx.stmt_functor.post_order_visit(mod["main"].body, visit)
+    return has_volatile_alloc
+
+
 def test_basic():
     transform = tvm.s_tir.transform.LowerThreadAllreduce()
 
@@ -503,7 +515,7 @@ def test_webgpu_multi_warp_reduce():
     After_script = After.script()
     assert "tvm_warp_shuffle_down" in After_script
     assert "tvm_storage_sync" in After_script
-    assert '"tirx.volatile": T.bool(True)' in After_script
+    assert _has_volatile_alloc_buffer(After)
     assert "T.uint32(" not in After_script
 
 


### PR DESCRIPTION
This pr updates the WebGPU multi-warp allreduce test to check the generated `tirx.volatile` allocation annotation structurally instead of matching the exact TVMScript printer output.

The test is intended to verify that `LowerThreadAllreduce` marks the generated shared allocation as volatile.  It previously checked for the exact string:

```python
"tirx.volatile": T.bool(True)
```

However, the current printer emits the same annotation as:

```python
annotations={"tirx.volatile": True}
```

The transform behavior is unchanged; only the printer spelling differs.  This patch walks the generated TIRX body and checks for an `AllocBuffer` with `tirx.volatile=True`, which matches the actual semantic requirement of the test without depending on bool literal formatting.