### PR TITLE
[Codegen][LLVM][Tests] Gate +v9a vscale_range expectation on LLVM version

### DIFF
--- a/tests/python/codegen/test_target_codegen_aarch64.py
+++ b/tests/python/codegen/test_target_codegen_aarch64.py
@@ -587,7 +587,10 @@ def test_memcpy(dtype):
     [
         ("+neon", False),
         ("+sve", True),
-        ("+v9a", True),
+        # Since LLVM 19, SVE/SVE2 are optional extensions of Armv9.0-A, so
+        # "+v9a" no longer implies "+sve" and no vscale_range() is added:
+        # https://releases.llvm.org/19.1.0/docs/ReleaseNotes.html#changes-to-the-aarch64-backend
+        ("+v9a", llvm_version_major() < 19),
         ("+sme", True),
     ],
 )


### PR DESCRIPTION
Since LLVM 19, SVE/SVE2 are optional extensions of Armv9.0-A (llvm/llvm-project#96007), so "+v9a" no longer implies "+sve" and CodeGenAArch64 does not add the vscale_range() function attribute. Gate the expectation in test_vscale_range_function_attribute on llvm_version_major() < 19 so the test passes on both older LLVM (15-17, as used in CI) and LLVM 19+.