### PR TITLE
[Tests][LLVM] Gate stepvector intrinsic rename on LLVM 20

### DIFF
--- a/tests/python/tirx-base/test_tir_scalable_datatype.py
+++ b/tests/python/tirx-base/test_tir_scalable_datatype.py
@@ -32,8 +32,11 @@ def test_create_scalable_data_type_python_api():
     assert str(dtype) == "float32xvscalex4"
 
 
+# LLVM 20 renamed llvm.experimental.stepvector to llvm.stepvector and dropped
+# the old name from the intrinsic table:
+# https://releases.llvm.org/20.1.0/docs/ReleaseNotes.html
 _STEPVECTOR_NAME = (
-    "llvm.stepvector" if llvm_version_major() >= 18 else "llvm.experimental.stepvector"
+    "llvm.stepvector" if llvm_version_major() >= 20 else "llvm.experimental.stepvector"
 )
 
 


### PR DESCRIPTION
llvm.experimental.stepvector was renamed to llvm.stepvector in LLVM 20, not LLVM 18. On LLVM 18 and 19 the test picked the new name, which those versions do not know, failing call_llvm_intrin with "Unknown llvm intrinsic function llvm.stepvector". Use the new name only for LLVM >= 20.