### PR TITLE
[Tests] Fix flaky popen pool executor test

### DIFF
--- a/tests/python/support/test_popen_pool.py
+++ b/tests/python/support/test_popen_pool.py
@@ -90,7 +90,7 @@ def test_popen_pool_executor():
 
     import tvm
 
-    pool = PopenPoolExecutor(max_workers=2, timeout=0.01)
+    pool = PopenPoolExecutor(max_workers=2, timeout=0.015)
     value1 = pool.submit(identity_after, 1, 100)
     value2 = pool.submit(terminate_self)
     value3 = pool.submit(identity_after, 3, 0)


### PR DESCRIPTION
This pr increases the timeout in `test_popen_pool_executor` from 10ms to 15ms.

The original 10ms timeout could race with the `terminate_self()` case under local/full-suite load, causing the worker-exit path to be reported as `TimeoutError` instead of `ChildProcessError`.
