### PR TITLE
[Runtime][Tests] Drop int4 from random_fill test, fix dtype error message

### DIFF
--- a/src/runtime/extra/contrib/random/mt_random_engine.cc
+++ b/src/runtime/extra/contrib/random/mt_random_engine.cc
@@ -161,8 +161,8 @@ class RandomEngine {
       std::generate_n(static_cast<double*>(data) + st, ed - st,
                       [&]() { return dist(rnd_engine_); });
     } else {
-      TVM_FFI_THROW(InternalError)
-          << "Doesn't support dtype code " << dtype.code << " dtype bits " << dtype.bits;
+      TVM_FFI_THROW(InternalError) << "Doesn't support dtype code " << static_cast<int>(dtype.code)
+                                   << " dtype bits " << static_cast<int>(dtype.bits);
     }
   }
 
@@ -175,8 +175,8 @@ class RandomEngine {
     if (dtype.bits == 8 || dtype.bits == 16 || dtype.bits == 32 || dtype.bits == 64) {
       FillDataImpl(tensor->data, 0, size, dtype);
     } else {
-      TVM_FFI_THROW(InternalError)
-          << "Doesn't support dtype code " << dtype.code << " dtype bits " << dtype.bits;
+      TVM_FFI_THROW(InternalError) << "Doesn't support dtype code " << static_cast<int>(dtype.code)
+                                   << " dtype bits " << static_cast<int>(dtype.bits);
     }
   }
 
@@ -213,8 +213,8 @@ class RandomEngine {
       int res = TVMBackendParallelLaunch(ParallelTask::RunTask, &task, 0);
       TVM_FFI_ICHECK_EQ(res, 0) << "RandomFillForMeasure: TVMBackendParallelLaunch failed";
     } else {
-      TVM_FFI_THROW(InternalError)
-          << "Doesn't support dtype code " << dtype.code << " dtype bits " << dtype.bits;
+      TVM_FFI_THROW(InternalError) << "Doesn't support dtype code " << static_cast<int>(dtype.code)
+                                   << " dtype bits " << static_cast<int>(dtype.bits);
     }
   }
 

--- a/tests/python/contrib/test_random.py
+++ b/tests/python/contrib/test_random.py
@@ -141,9 +141,10 @@ def test_random_fill():
 
         check_remote(rpc.Server("127.0.0.1"))
 
+    # Packed sub-byte dtypes (e.g. int4) are intentionally unsupported by
+    # random_fill since #19714 and raise an error instead.
     for dtype in [
         "bool",
-        "int4",
         "int8",
         "uint8",
         "int16",


### PR DESCRIPTION
#19714 intentionally removed packed sub-byte (bits 1/4) support from RandomEngine after the int4 fill path was found to write past the allocated storage, but left "int4" in test_random_fill's dtype list, so the test now fails with InternalError on every run. Remove it from the list to match the supported set.

Also cast dtype.code / dtype.bits to int in the unsupported-dtype error messages: both fields are uint8_t and were streamed as (invisible) characters, e.g. "Doesn't support dtype code dtype bits".