### PR TITLE
[TIRX][Tests] Fix LLVM version gate for vectorized lround

### DIFF
--- a/tests/python/tirx-transform/test_tir_transform_vectorize.py
+++ b/tests/python/tirx-transform/test_tir_transform_vectorize.py
@@ -806,7 +806,10 @@ def test_vectorize_llvm_pure_intrin_fail(extent, vec_str, target):
     with tvm.target.Target(target):
         mod = tvm.tirx.transform.VectorizeLoop()(Before)
         tvm.ir.assert_structural_equal(mod, After)
-        if llvm_version_major() >= 21:
+        # LLVM 20 added vector support for llvm.lround/llvm.llround.  The IR Verifier's
+        # "Intrinsic does not support vectors" check was removed in release/20.x, so
+        # compilation only fails on LLVM <= 19.
+        if llvm_version_major() >= 20:
             tvm.compile(mod, target=target)
         else:
             with pytest.raises(Exception, match="Intrinsic does not support vectors"):


### PR DESCRIPTION
LLVM 20 added vector support for llvm.lround/llvm.llround. In LLVM release/19.x, the IR Verifier still rejects vector operands/results for these intrinsics with "Intrinsic does not support vectors". In release/20.x, that verifier check was removed, and LLVM 20.1 compiles the vectorized lround module successfully.

This updates the test gate so LLVM <= 19 still exercises the expected failure path, while LLVM 20+ uses the successful compile path.