### PR TITLE
[CI] Updated cibw to 4.1.0

### DIFF
--- a/.github/actions/build-wheel-for-publish/action.yml
+++ b/.github/actions/build-wheel-for-publish/action.yml
@@ -108,7 +108,7 @@ runs:
 
     # ---- Build and test wheels ----
     - name: Build and test wheels
-      uses: pypa/cibuildwheel@v3.3.1
+      uses: pypa/cibuildwheel@v4.1.0
       with:
         package-dir: .
         output-dir: wheelhouse

--- a/.github/workflows/publish_wheel.yml
+++ b/.github/workflows/publish_wheel.yml
@@ -44,8 +44,9 @@ env:
 
 jobs:
   # Build the CUDA runtime sidecar once per arch and upload it as an artifact that
-  # build_wheels bundles. The Linux legs build inside a manylinux_2_28 image -- the
-  # same glibc baseline cibuildwheel targets for the wheel -- so the sidecar stays
+  # build_wheels bundles. The Linux legs build inside the official manylinux_2_28
+  # CUDA image (CUDA toolkit preinstalled, see pypa/manylinux) -- the same glibc
+  # baseline cibuildwheel targets for the wheel -- so the sidecar stays
   # ABI-compatible with the wheel's libtvm_runtime.so regardless of the exact tag.
   build_cuda_runtime:
     name: ${{ matrix.name }}
@@ -57,13 +58,13 @@ jobs:
         include:
           - name: "CUDA runtime sidecar (Linux x86_64, manylinux_2_28)"
             os: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_28_x86_64:latest
+            container: quay.io/manylinux_cuda/manylinux_2_28_x86_64_cuda13_1:latest
             arch: x86_64
             script: ci/scripts/package/manylinux_build_libtvm_runtime_cuda.sh
             lib: build-wheel-cuda/lib/libtvm_runtime_cuda.so
           - name: "CUDA runtime sidecar (Linux aarch64, manylinux_2_28)"
             os: ubuntu-24.04-arm
-            container: quay.io/pypa/manylinux_2_28_aarch64:latest
+            container: quay.io/manylinux_cuda/manylinux_2_28_aarch64_cuda13_1:latest
             arch: aarch64
             script: ci/scripts/package/manylinux_build_libtvm_runtime_cuda.sh
             lib: build-wheel-cuda/lib/libtvm_runtime_cuda.so

--- a/ci/scripts/package/manylinux_build_libtvm_runtime_cuda.sh
+++ b/ci/scripts/package/manylinux_build_libtvm_runtime_cuda.sh
@@ -16,9 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Build libtvm_runtime_cuda.so inside a manylinux container, run by the
-# build_cuda_runtime CI job. Installs the pinned CUDA toolkit and builds the
-# sidecar into build-wheel-cuda/lib/ for the wheel build to bundle.
+# Build libtvm_runtime_cuda.so inside a manylinux CUDA container, run by the
+# build_cuda_runtime CI job. The official quay.io/manylinux_cuda images ship
+# the CUDA toolkit preinstalled under /usr/local/cuda, so no toolkit install
+# is needed here. Builds the sidecar into build-wheel-cuda/lib/ for the wheel
+# build to bundle.
 #
 # Usage: manylinux_build_libtvm_runtime_cuda.sh
 set -euxo pipefail
@@ -28,21 +30,9 @@ build_dir="${repo_root}/build-wheel-cuda"
 python_bin="/opt/python/cp310-cp310/bin/python"
 parallel="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
 
-# Install the pinned CUDA toolkit into the manylinux_2_28 container. The RHEL8
-# local-repo RPM is compatible with manylinux_2_28 for both x86_64 and aarch64.
-arch="$(uname -m)"
-cuda_rpm="cuda-repo-rhel8-13-0-local-13.0.2_580.95.05-1.${arch}.rpm"
-curl -fsSLo "/tmp/${cuda_rpm}" \
-  "https://developer.download.nvidia.com/compute/cuda/13.0.2/local_installers/${cuda_rpm}"
-rpm -i "/tmp/${cuda_rpm}"
-dnf clean all
-dnf -y --disablerepo=epel install cuda-toolkit-13-0
-rm -f "/tmp/${cuda_rpm}"
-dnf clean all
-
 # Build the CUDA runtime sidecar with CUDA on and LLVM off, so it does not need
-# the LLVM prefix; the main CPU wheel links LLVM statically. The manylinux image
-# ships no cmake/ninja, so install the build tools here.
+# the LLVM prefix; the main CPU wheel links LLVM statically. pip-install
+# cmake/ninja rather than relying on whatever the image ships.
 export PATH="/opt/python/cp310-cp310/bin:/usr/local/cuda/bin:${PATH}"
 "${python_bin}" -m pip install -U pip cmake ninja
 nvcc --version


### PR DESCRIPTION
This pr follows the cibuildwheel 4.0 announcement, the official prebuilt quay.io/manylinux_cuda images ship the CUDA toolkit preinstalled under /usr/local/cuda on the same manylinux_2_28 baseline the wheel targets.

also switchs the Linux build_cuda_runtime sidecar legs to quay.io/manylinux_cuda/manylinux_2_28_{x86_64,aarch64}_cuda13_1 and drop the per-run NVIDIA local-repo RPM download plus dnf install of the toolkit, which pulled several GB from developer.download.nvidia.com on every run and was the main source of sidecar build-time variance. This moves the Linux sidecar from CUDA 13.0.2 to 13.1; the soname stays libcudart.so.13, so the repair-step glob excludes (libcudart.so.*) are unaffected and the sidecar carries no device code. The Windows sidecar keeps using conda and is unchanged.