### PR TITLE
[REFACTOR][VM] Move CUDA graph VM builtin back under VM runtime

### DIFF
--- a/cmake/modules/CUDA.cmake
+++ b/cmake/modules/CUDA.cmake
@@ -63,7 +63,7 @@ if(USE_CUDA)
   message(STATUS "Build cuda device runtime")
 
   tvm_file_glob(GLOB RUNTIME_CUDA_SRCS src/backend/cuda/runtime/*.cc)
-  tvm_file_glob(GLOB VM_CUDA_BUILTIN_SRC_CC src/backend/cuda/runtime/vm/*.cc)
+  tvm_file_glob(GLOB VM_CUDA_BUILTIN_SRC_CC src/runtime/vm/cuda/*.cc)
 
   add_library(tvm_runtime_cuda_objs OBJECT ${RUNTIME_CUDA_SRCS} ${VM_CUDA_BUILTIN_SRC_CC})
   target_link_libraries(tvm_runtime_cuda_objs PUBLIC tvm_ffi_header)

--- a/src/runtime/vm/cuda/cuda_graph_builtin.cc
+++ b/src/runtime/vm/cuda/cuda_graph_builtin.cc
@@ -18,7 +18,7 @@
  */
 
 /*!
- * \file src/runtime/vm/cuda_graph_builtin.cc
+ * \file src/runtime/vm/cuda/cuda_graph_builtin.cc
  * \brief The CUDA graph related builtin functions for Relax virtual machine.
  */
 
@@ -28,8 +28,8 @@
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/runtime/vm/vm.h>
 
-#include "../../../../support/utils.h"
-#include "../cuda_common.h"
+#include "../../../backend/cuda/runtime/cuda_common.h"
+#include "../../../support/utils.h"
 namespace tvm {
 namespace runtime {
 namespace vm {


### PR DESCRIPTION
CUDA graph VM support is Relax VM functionality, so it should stay with the VM runtime layout instead of living under the CUDA backend runtime tree introduced by the backend reorg.

This moves the CUDA graph builtin back under src/runtime/vm/cuda and points the CUDA runtime CMake source glob at that VM-owned location while preserving the existing symbols and behavior.