### PR TITLE
[MetaScheduler] Improve print info about builder/runner state

### DIFF
--- a/src/s_tir/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/s_tir/meta_schedule/task_scheduler/task_scheduler.cc
@@ -205,7 +205,18 @@ void TaskSchedulerNode::Tune(ffi::Array<TuneContext> ctxs, ffi::Array<FloatImm> 
       num_trials_already += num_candidates;
       TVM_PY_LOG(INFO, this->logger) << "Sending " << num_candidates << " sample(s) to builder";
       SendToBuilder(task, builder);
-      TVM_PY_LOG(INFO, this->logger) << "Sending " << num_candidates << " sample(s) to runner";
+      int n_build_errs = 0;
+      const ffi::Array<BuilderResult>& builder_results = task->builder_results.value();
+      for (int i = 0; i < num_candidates; i++) {
+        if (builder_results[i]->error_msg.has_value())
+          ++n_build_errs;
+      }
+      if (n_build_errs > 0) {
+        TVM_PY_LOG(INFO, this->logger) << "Build errors: " << n_build_errs << " sample(s)";
+      }
+      TVM_PY_LOG(INFO, this->logger) << "Sending "
+                                     << num_candidates - n_build_errs
+                                     << " valid sample(s) to runner";
       SendToRunner(task, runner);
     } else {
       TerminateTask(task_id);


### PR DESCRIPTION

Adds on-screen info about samples failed to build, that may happen in early stages.

----------

#### Before:
```
2026-06-14 18:36:30 [INFO] [task_scheduler.cc:196] TaskScheduler picks Task #0: "dense"
2026-06-14 18:36:32 [INFO] [task_scheduler.cc:209] Sending 64 sample(s) to builder
2026-06-14 18:38:47 [INFO] [task_scheduler.cc:211] Sending 64 sample(s) to runner

```

#### After:
```
2026-06-14 19:53:23 [INFO] [task_scheduler.cc:193] TaskScheduler picks Task #0: "dense"
2026-06-14 19:53:25 [INFO] [task_scheduler.cc:206] Sending 64 sample(s) to builder
2026-06-14 19:55:39 [INFO] [task_scheduler.cc:215] Build errors: 64 sample(s)
2026-06-14 19:55:39 [INFO] [task_scheduler.cc:217] Sending 0 valid sample(s) to runner
```
