### PR TITLE
[Relax][ONNX] Support exclusive option in CumSum

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -1905,7 +1905,7 @@ class CumSum(OnnxOpConverter):
     def _impl_v14(cls, bb, inputs, attr, params):
         data = inputs[0]
         axis_input = get_constant(inputs[1], params)
-        assert not attr.get("exclusive", False), "Exclusive option not yet supported."
+        exclusive = attr.get("exclusive", 0) != 0
 
         if isinstance(axis_input, relax.Constant):
             axis_data = axis_input.data.numpy()
@@ -1933,7 +1933,7 @@ class CumSum(OnnxOpConverter):
         if attr.get("reverse", 0) != 0:
             data = bb.emit_te(topi.flip, data, axis=axis)
 
-        data = relax.op.cumsum(data, axis)
+        data = relax.op.cumsum(data, axis, exclusive=exclusive)
         data = bb.normalize(data)
 
         if attr.get("reverse", 0) != 0:

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -2001,7 +2001,7 @@ def test_pow():
 
 
 @pytest.mark.parametrize("reverse", [True, False])
-@pytest.mark.parametrize("exclusive", [False])
+@pytest.mark.parametrize("exclusive", [True, False])
 def test_cumsum(reverse, exclusive):
     cumsum_node = helper.make_node(
         "CumSum", ["x", "axis"], ["y"], reverse=reverse, exclusive=exclusive


### PR DESCRIPTION
### Root Cause

The ONNX `CumSum` converter in the Relax frontend rejected any node with `exclusive=1` via a bare
`assert not attr.get("exclusive", False), "Exclusive option not yet supported."`, so importing a
model that used exclusive cumulative sums failed with `AssertionError: Exclusive option not yet
supported.`. The underlying op already supports the exclusive form: `relax.op.cumsum` forwards an
`exclusive` flag to the FFI and `topi/scan.py` implements the exclusive branch, so the converter
only needed to pass the attribute through.

### Solution

Drop the assert and read the attribute as `exclusive = attr.get("exclusive", 0) != 0` (matching the
existing `attr.get("reverse", 0) != 0` idiom in the same converter), then pass it to
`relax.op.cumsum(data, axis, exclusive=exclusive)`. The existing reverse handling
(`flip -> cumsum -> flip`) composes correctly with exclusive, so `reverse=1, exclusive=1` lowers to
an exclusive scan over the reversed axis.

### Test Plan

Extended `test_cumsum` in `tests/python/relax/test_frontend_onnx.py` to parametrize `exclusive` over
`[True, False]`, so `check_correctness` now exercises all four `(reverse, exclusive)` combinations
against ONNX Runtime:

```
python -m pytest tests/python/relax/test_frontend_onnx.py::test_cumsum -v
```

### Issue

Fixes #19692
