### PR TITLE
[Docs][CI] Bump tlcpack-sphinx-addon to restore search result summaries

### DIFF
--- a/docker/install/ubuntu_install_sphinx.sh
+++ b/docker/install/ubuntu_install_sphinx.sh
@@ -30,4 +30,4 @@ uv pip install \
     sphinx_autodoc_annotation~=1.0 \
     sphinx-gallery==0.20.0 \
     sphinx_rtd_theme==3.1.0 \
-    git+https://github.com/tlc-pack/tlcpack-sphinx-addon.git@99c6947b05b1ae26ff5003277fb7cff57ce78353
+    git+https://github.com/tlc-pack/tlcpack-sphinx-addon.git@dded1a3fbaf549485d8f7bb3f79ecb0484a11629


### PR DESCRIPTION
The docs search page (search.html) showed no per-result summaries and spammed "Failed to execute 'appendChild' on 'Node'" errors in the browser console (apache/tvm#19765). The addon's layout.html omitted the data-content_root attribute that Sphinx >= 7.2 searchtools.js reads via document.documentElement.dataset.content_root to fetch pages and build the summaries; with it undefined the summary fetch resolved to "undefined...html" (404), so no summary rendered and makeSearchSummary returned null into appendChild.

tlc-pack/tlcpack-sphinx-addon#14 adds the attribute. Bump the pin used by the docs (ci_gpu) image from 99c6947 to dded1a3 to pick it up.