### PR TITLE
[Tests] Make TargetCreation.DeduplicateKeys host-agnostic on AArch64

### DIFF
--- a/tests/cpp/target_test.cc
+++ b/tests/cpp/target_test.cc
@@ -379,7 +379,7 @@ TEST(TargetCreation, DeduplicateKeys) {
   TVM_FFI_ICHECK_EQ(target->keys.size(), 2U);
   TVM_FFI_ICHECK_EQ(target->keys[0], "cpu");
   TVM_FFI_ICHECK_EQ(target->keys[1], "arm_cpu");
-  TVM_FFI_ICHECK_EQ(target->attrs.size(), 2U);
+  TVM_FFI_ICHECK_EQ(target->attrs.count("keys"), 0U);
   TVM_FFI_ICHECK_EQ(target->GetAttr<ffi::String>("device"), "arm_cpu");
 }
 


### PR DESCRIPTION
This pr fixes #19718. The test asserted target->attrs.size()==2, which is host-specific: LLVM target canonicalization legitimately adds host attrs (feature.has_sve / has_asimd / is_aarch64 / mtriple on AArch64), so the target ends up with 9 attrs there and the assertion fails, while it happens to be 2 on x86. The test only means to verify that duplicate keys are deduplicated, so assert that the "keys" entry did not leak into the generic attrs map instead of pinning the host-specific attr count.