### PR TITLE
[Tests] Replace remaining requires_* helpers with standard pytest

### DIFF
--- a/python/tvm/contrib/hexagon/pytest_plugin.py
+++ b/python/tvm/contrib/hexagon/pytest_plugin.py
@@ -59,23 +59,6 @@ def shape_nhwc(batch, in_channel, in_size):
     return (batch, in_size, in_size, in_channel)
 
 
-def _compose(args, decs):
-    """Helper to apply multiple markers"""
-    if len(args) > 0:
-        func = args[0]
-        for dec in reversed(decs):
-            func = dec(func)
-        return func
-    return decs
-
-
-def requires_hexagon_toolchain(func):
-    """Skip a test unless the Hexagon toolchain is available (compile-only)."""
-    return pytest.mark.skipif(
-        not tvm.testing.env.has_hexagon_toolchain(), reason="need hexagon toolchain"
-    )(func)
-
-
 def android_serial_number() -> str | None:
     """Return the android serial number"""
     serial = os.getenv(ANDROID_SERIAL_NUMBER, default="")

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -589,49 +589,6 @@ def skip_if_no_reference_system(func):
     return skip_if_32bit(reason="Reference system unavailable in i386 container")(func)
 
 
-def requires_package(*packages):
-    """Mark a test as requiring python packages to run.
-
-    If the packages listed are not available, tests marked with
-    `requires_package` will appear in the pytest results as being skipped.
-    This is equivalent to using ``foo = pytest.importorskip('foo')`` inside
-    the test body.
-
-    Parameters
-    ----------
-    packages : List[str]
-
-        The python packages that should be available for the test to
-        run.
-
-    Returns
-    -------
-    mark: pytest mark
-
-        The pytest mark to be applied to unit tests that require this
-
-    """
-
-    def has_package(package):
-        try:
-            __import__(package)
-            return True
-        except ImportError:
-            return False
-
-    marks = [
-        pytest.mark.skipif(not has_package(package), reason=f"Cannot import '{package}'")
-        for package in packages
-    ]
-
-    def wrapper(func):
-        for mark in marks:
-            func = mark(func)
-        return func
-
-    return wrapper
-
-
 def parametrize_targets(*args):
     """Parametrize a test over a specific set of targets.
 

--- a/tests/python/relax/backend/adreno/test_clml_ops.py
+++ b/tests/python/relax/backend/adreno/test_clml_ops.py
@@ -44,7 +44,7 @@ from mod_utils import (
     get_relax_reshape_mod,
     get_unary_op_mod,
 )
-from utils import requires_adreno_clml, verify_results
+from utils import skip_unless_adreno_clml, verify_results
 
 import tvm
 import tvm.testing
@@ -105,7 +105,8 @@ def verify(
         verify_results(clml_mod, target=clml_target, ref_target=ref_target)
 
 
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize(
     "kernel_h, kernel_w, padding, stride, dilation, out_channels, shape, has_bias, has_bn, has_activation, has_pad, is_depthwise",
@@ -199,7 +200,8 @@ def test_conv2d_offload(
     verify(mod, clml_codegen, inputs_np, params_np)
 
 
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize(
     "dshape, kshape, channels, kernel_size, strides, padding, out_shape",
@@ -244,7 +246,8 @@ def test_conv2d_transpose(
     verify(mod, clml_codegen, inputs_np, params_np, target_test=False)
 
 
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 @pytest.mark.skipif(
     CLML_VERSION < 3,
     reason="Requires compiler supporting CLML v5 or above",
@@ -314,7 +317,8 @@ def test_batchnorm(dtype, trials):
     verify(mod, clml_codegen, inputs_np, params_np)
 
 
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize(
     "a_shape, b_shape, op",
@@ -333,7 +337,8 @@ def test_batchnorm(dtype, trials):
         ((1, 256), (1, 256), R.maximum),
     ],
 )
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 def test_binary_ops(a_shape, b_shape, op, dtype):
     (mod, inputs_np) = get_binary_op_mod(a_shape, b_shape, op, dtype)
     clml_codegen = [
@@ -368,7 +373,8 @@ def test_binary_ops(a_shape, b_shape, op, dtype):
     verify(mod, clml_codegen, inputs_np, {})
 
 
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -384,7 +390,8 @@ def test_binary_ops(a_shape, b_shape, op, dtype):
         ((1, 14, 14, 256), R.nn.relu),
     ],
 )
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 def test_unary_ops(a_shape, op, dtype):
     (mod, inputs_np) = get_unary_op_mod(a_shape, op, dtype)
     clml_codegen = [
@@ -412,7 +419,8 @@ def test_unary_ops(a_shape, op, dtype):
     verify(mod, clml_codegen, inputs_np, {})
 
 
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize(
     "trials",
@@ -439,7 +447,8 @@ def test_max_pool(dtype, trials):
     verify(mod, clml_codegen, inputs_np, {})
 
 
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize(
     "trials",
@@ -467,7 +476,8 @@ def test_avg_pool(dtype, trials):
     verify(mod, clml_codegen, inputs_np, {})
 
 
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize(
     "trials",
@@ -488,7 +498,8 @@ def test_reshape(dtype, trials):
 
 
 @pytest.mark.skip(reason="Codegen Comparision Failing")
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize(
     "trials",
@@ -514,7 +525,8 @@ def test_global_avg_pool(dtype, trials):
     verify(mod, clml_codegen, inputs_np, {})
 
 
-@requires_adreno_clml
+@pytest.mark.gpu
+@skip_unless_adreno_clml
 @pytest.mark.parametrize("dtype", ["float32"])
 @pytest.mark.parametrize(
     "trials",

--- a/tests/python/relax/backend/adreno/test_texture_ops.py
+++ b/tests/python/relax/backend/adreno/test_texture_ops.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import pytest
-from utils import requires_adreno_opencl_vulkan, verify_results
+from utils import skip_unless_adreno_opencl_vulkan, verify_results
 
 import tvm
 import tvm.testing
@@ -30,7 +30,8 @@ TARGETS = [
 ref_target = tvm.target.Target("llvm")
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d(target):
     @I.ir_module
@@ -47,7 +48,8 @@ def test_conv2d(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_relu(target):
     @I.ir_module
@@ -65,7 +67,8 @@ def test_conv2d_relu(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_relu_conv2d_relu(target):
     @I.ir_module
@@ -84,7 +87,8 @@ def test_relu_conv2d_relu(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_relu_tanh(target):
     @I.ir_module
@@ -103,7 +107,8 @@ def test_conv2d_relu_tanh(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_add(target):
     @I.ir_module
@@ -123,7 +128,8 @@ def test_conv2d_add(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_sum(target):
     @I.ir_module
@@ -141,7 +147,8 @@ def test_conv2d_sum(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_sum_keepdims(target):
     @I.ir_module
@@ -159,7 +166,8 @@ def test_conv2d_sum_keepdims(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_sum_reduce(target):
     @I.ir_module
@@ -177,7 +185,8 @@ def test_conv2d_sum_reduce(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_transpose(target):
     @I.ir_module
@@ -195,7 +204,8 @@ def test_conv2d_transpose(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_expand_dims(target):
     @I.ir_module
@@ -213,7 +223,8 @@ def test_conv2d_expand_dims(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_squeeze(target):
     @I.ir_module
@@ -231,7 +242,8 @@ def test_conv2d_squeeze(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_strided_slice(target):
     @I.ir_module
@@ -251,7 +263,8 @@ def test_conv2d_strided_slice(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_relu_concat(target):
     @I.ir_module
@@ -270,7 +283,8 @@ def test_conv2d_relu_concat(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_relu_concat_split(target):
     @I.ir_module
@@ -290,7 +304,8 @@ def test_conv2d_relu_concat_split(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_relu_concat_split_transpose_concat(target):
     @I.ir_module
@@ -312,7 +327,8 @@ def test_conv2d_relu_concat_split_transpose_concat(target):
 
 
 @pytest.mark.skip(reason="Known failure: numerical mismatch in texture lowering")
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_maxpool2d(target):
     @I.ir_module
@@ -338,7 +354,8 @@ def test_conv2d_maxpool2d(target):
 
 
 @pytest.mark.skip(reason="Known failure: numerical mismatch in texture lowering")
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_avgpool2d(target):
     @I.ir_module
@@ -356,7 +373,8 @@ def test_conv2d_avgpool2d(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_softmax(target):
     @I.ir_module
@@ -374,7 +392,8 @@ def test_conv2d_softmax(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_layernorm(target):
     @I.ir_module
@@ -397,7 +416,8 @@ def test_conv2d_layernorm(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_binary_broadcast(target):
     @I.ir_module
@@ -417,7 +437,8 @@ def test_binary_broadcast(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_binary_ewise_scalar(target):
     @I.ir_module
@@ -435,7 +456,8 @@ def test_binary_ewise_scalar(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_residual_block(target):
     r"""
@@ -483,7 +505,8 @@ def test_residual_block(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_conv2d_fallback_to_buffer_conv2d(target):
     r"""
@@ -522,7 +545,8 @@ def test_conv2d_conv2d_fallback_to_buffer_conv2d(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_conv2d_conv2d_conv2d_concat(target):
     r"""
@@ -562,7 +586,8 @@ def test_conv2d_conv2d_conv2d_concat(target):
 
 
 @pytest.mark.skip(reason="Known failure: numerical mismatch in texture lowering")
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_pooling_branching_texture_params(target):
     r"""
@@ -613,7 +638,8 @@ def test_pooling_branching_texture_params(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_injective_inputs1(target):
     r"""
@@ -662,7 +688,8 @@ def test_injective_inputs1(target):
     verify_results(Input, target, ref_target)
 
 
-@requires_adreno_opencl_vulkan
+@pytest.mark.gpu
+@skip_unless_adreno_opencl_vulkan
 @tvm.testing.parametrize_targets(*TARGETS)
 def test_injective_nwo_inputs2(target):
     r"""

--- a/tests/python/relax/backend/adreno/utils.py
+++ b/tests/python/relax/backend/adreno/utils.py
@@ -56,49 +56,19 @@ class run_time_check:
         return self.check
 
 
-def _adreno_requires(predicate, reason):
-    """Tag a GPU test with the ``gpu`` marker plus an eager runtime skip.
-
-    The predicate is evaluated when the decorator is applied (at collection
-    time), so the skip condition is resolved eagerly.
-    """
-
-    def decorator(func):
-        func = pytest.mark.skipif(not predicate(), reason=reason)(func)
-        return pytest.mark.gpu(func)
-
-    return decorator
-
+# Eager skips for Adreno GPU tests, resolved at import time. Pair each with
+# ``@pytest.mark.gpu`` at the test site so CI's ``-m gpu`` filter selects it.
 
 # OpenCL or Vulkan
-requires_adreno_opencl_vulkan = _adreno_requires(
-    run_time_check("any").check,
-    "need adreno opencl or vulkan",
-)
-
-# Any Vulkan
-requires_adreno_vulkan = _adreno_requires(
-    lambda: tvm.runtime.enabled("vulkan") and run_time_check("vulkan").check(),
-    "need adreno vulkan",
-)
-
-# Any OpenCL
-requires_adreno_opencl = _adreno_requires(
-    lambda: tvm.runtime.enabled("opencl") and run_time_check("opencl").check(),
-    "need adreno opencl",
-)
-
-# Real Adreno GPU OpenCL Target
-requires_adreno_opencl_real = _adreno_requires(
-    lambda: tvm.runtime.enabled("opencl") and run_time_check("real").check(),
-    "need real adreno opencl",
+skip_unless_adreno_opencl_vulkan = pytest.mark.skipif(
+    not run_time_check("any").check(),
+    reason="need adreno opencl or vulkan",
 )
 
 # CLML Codegen
-requires_adreno_clml = _adreno_requires(
-    lambda: tvm.get_global_func("relax.is_openclml_runtime_enabled", allow_missing=True)
-    is not None,
-    "need adreno openclml",
+skip_unless_adreno_clml = pytest.mark.skipif(
+    tvm.get_global_func("relax.is_openclml_runtime_enabled", allow_missing=True) is None,
+    reason="need adreno openclml",
 )
 
 

--- a/tests/python/runtime/test_runtime_dlpack.py
+++ b/tests/python/runtime/test_runtime_dlpack.py
@@ -15,13 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 import numpy as np
+import pytest
 
 import tvm
 import tvm.testing
 from tvm import te
 
+# These tests exercise the PyTorch DLPack interop path; skip the whole module
+# when torch is unavailable.
+pytest.importorskip("torch")
 
-@tvm.testing.requires_package("torch")
+
 def test_from_dlpack_shape_one():
     # A test case for the issue https://github.com/pytorch/pytorch/issues/99803
     import torch
@@ -47,7 +51,6 @@ def test_from_dlpack_shape_one():
     tvm.testing.assert_allclose(c.numpy(), a.numpy() + b.numpy())
 
 
-@tvm.testing.requires_package("torch")
 def test_from_dlpack_strided():
     import torch
     from torch.utils.dlpack import to_dlpack


### PR DESCRIPTION
This pr is the Follow-up to #19777. This pr removes the last `requires_*` decorators so test gating is plain pytest everywhere, with no custom indirection left.