### PR TITLE
[Web] Destroy GPUDevice once on buffer creation error

### DIFF
--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -169,9 +169,18 @@ function tryCreateBuffer(device: GPUDevice, descriptor: GPUBufferDescriptor) {
 
   const buffer = device.createBuffer(descriptor);
 
-  device.popErrorScope().then((error) => {if (error) {device.destroy(); console.error(error);}});
-  device.popErrorScope().then((error) => {if (error) {device.destroy(); console.error(error);}});
-  device.popErrorScope().then((error) => {if (error) {device.destroy(); console.error(error);}});
+  // Destroy at most once even if multiple error types fire.
+  Promise.all([
+    device.popErrorScope(),
+    device.popErrorScope(),
+    device.popErrorScope(),
+  ]).then((errors) => {
+    const captured = errors.filter((error) => error !== null);
+    if (captured.length > 0) {
+      device.destroy();
+      captured.forEach((error) => console.error(error));
+    }
+  });
 
   return buffer;
 }

--- a/web/src/webgpu.ts
+++ b/web/src/webgpu.ts
@@ -175,11 +175,13 @@ function tryCreateBuffer(device: GPUDevice, descriptor: GPUBufferDescriptor) {
     device.popErrorScope(),
     device.popErrorScope(),
   ]).then((errors) => {
-    const captured = errors.filter((error) => error !== null);
+    const captured = errors.filter((error): error is GPUError => error !== null);
     if (captured.length > 0) {
       device.destroy();
       captured.forEach((error) => console.error(error));
     }
+  }).catch((err) => {
+    console.error("Failed to pop error scopes:", err);
   });
 
   return buffer;


### PR DESCRIPTION
## Why

In `tryCreateBuffer`, each of the three popped error scopes independently called `device.destroy()` and `console.error`, so a buffer that triggers more than one error type destroyed the device repeatedly and logged duplicate errors.

## How

- Collect all three `popErrorScope()` results via `Promise.all` and call `device.destroy()` at most once
- Log every captured error instead of relying on per-scope handlers