### PR TITLE
[REFACTOR][TIRX] Add IntImm common scalar ctor and streamline MakeConst

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -515,6 +515,33 @@ class IntImm : public PrimExpr {
    */
   TVM_DLL IntImm(DataType dtype, int64_t value, Span span = Span());
 
+  /*!
+   * \brief Construct a scalar boolean constant.
+   * \param value The boolean value.
+   * \param span The location of this object in the source code.
+   */
+  static IntImm Bool(bool value, Span span = Span()) {
+    return IntImm(DataType::Bool(), value, span);
+  }
+
+  /*!
+   * \brief Construct a scalar int32 constant.
+   * \param value The integer value.
+   * \param span The location of this object in the source code.
+   */
+  static IntImm Int32(int64_t value, Span span = Span()) {
+    return IntImm(DataType::Int(32), value, span);
+  }
+
+  /*!
+   * \brief Construct a scalar int64 constant.
+   * \param value The integer value.
+   * \param span The location of this object in the source code.
+   */
+  static IntImm Int64(int64_t value, Span span = Span()) {
+    return IntImm(DataType::Int(64), value, span);
+  }
+
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntImm, PrimExpr, IntImmNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(IntImmNode);
 };
@@ -636,7 +663,7 @@ struct TypeTraits<FloatImm> : public ObjectRefWithFallbackTraitsBase<FloatImm, d
 
 // define automatic conversion from bool, int64_t, double to PrimExpr
 TVM_FFI_INLINE PrimExpr TypeTraits<PrimExpr>::ConvertFallbackValue(StrictBool value) {
-  return IntImm(DataType::Bool(), value, Span());
+  return IntImm::Bool(value);
 }
 
 TVM_FFI_INLINE PrimExpr TypeTraits<PrimExpr>::ConvertFallbackValue(int64_t value) {

--- a/include/tvm/ir/node_functor.h
+++ b/include/tvm/ir/node_functor.h
@@ -47,7 +47,7 @@ namespace tvm {
  *     return prefix + "IntImm"
  *   });
  *
- *   Expr x = make_const(1);
+ *   Expr x = MakeConst(1);
  *   Expr y = x + x;
  *   // dispatch to IntImm, outputs "MyIntImm"
  *   LOG(INFO) << tostr(x, "My");

--- a/include/tvm/script/printer/doc.h
+++ b/include/tvm/script/printer/doc.h
@@ -277,7 +277,7 @@ class LiteralDoc : public ExprDoc {
    * \param p The object path
    */
   static LiteralDoc Int(int64_t v, const ffi::Optional<AccessPath>& p) {
-    return LiteralDoc(IntImm(DataType::Int(64), v), p);
+    return LiteralDoc(IntImm::Int64(v), p);
   }
   /*!
    * \brief Create a LiteralDoc to represent boolean.
@@ -285,7 +285,7 @@ class LiteralDoc : public ExprDoc {
    * \param p The object path
    */
   static LiteralDoc Boolean(bool v, const ffi::Optional<AccessPath>& p) {
-    return LiteralDoc(IntImm(DataType::Bool(), v), p);
+    return LiteralDoc(IntImm::Bool(v), p);
   }
   /*!
    * \brief Create a LiteralDoc to represent float.

--- a/include/tvm/tirx/buffer.h
+++ b/include/tvm/tirx/buffer.h
@@ -206,7 +206,7 @@ class Buffer : public ffi::ObjectRef {
    * \param input_extent The extent of ptr.
    */
   TVM_DLL PrimExpr access_ptr(int access_mask, DataType ptr_type = DataType::Handle(),
-                              int content_lanes = 1, PrimExpr offset = IntImm(DataType::Int(32), 0),
+                              int content_lanes = 1, PrimExpr offset = IntImm::Int32(0),
                               ffi::Optional<PrimExpr> input_extent = std::nullopt) const;
   /*!
    * \brief Create an Expr that does a vector load at begin index.

--- a/include/tvm/tirx/op.h
+++ b/include/tvm/tirx/op.h
@@ -52,7 +52,7 @@ namespace tvm {
 // Most common operators can be overloaded by argument type(PrimExpr).
 // So we put them under the root namespace.
 //
-// We put more developer oriented APIs -- make_const and is_const under tirx
+// We put more developer oriented APIs -- MakeConst and is_const under tirx
 // as they are more specific to the tirx namespace.
 
 /*!
@@ -816,7 +816,14 @@ inline bool IsPointerType(const Type& type, const DataType& element_type) {
 
 /*!
  * \brief Make a const value with certain data type.
- * \param t The target type.
+ *
+ * Prefer direct IntImm or FloatImm construction when dtype is known to be
+ * scalar integer or floating point. This makes the compiled code more compact
+ * and efficient. Keep MakeConst for generic overload cases where dtype can be
+ * integer, floating point, or vector-valued and the caller needs its
+ * scalar/vector dispatch.
+ *
+ * \param dtype The target type.
  * \param value The input value
  * \return the result expression.
  * \tparam ValueType The constant value type
@@ -825,32 +832,14 @@ inline bool IsPointerType(const Type& type, const DataType& element_type) {
 template <typename ValueType,
           typename = typename std::enable_if<std::is_standard_layout<ValueType>::value &&
                                              std::is_trivial<ValueType>::value>::type>
-inline PrimExpr make_const(DataType t, ValueType value, Span span = Span());
+inline PrimExpr MakeConst(DataType dtype, ValueType value, Span span = Span());
 /*!
- * \brief Make a const zero expr.
- * \param t The target type.
- * \param span The location of this operation in the source.
- * \return the result expression.
- */
-inline PrimExpr make_zero(DataType t, Span span = Span());
-/*!
- * \brief Make a constant true expression.
- * \param lanes The number of lanes in the bool
+ * \brief Make a constant handle value.
+ * \param value The integer payload to reinterpret as a handle.
  * \param span The location of this operation in the source.
  * \return The result expression.
  */
-inline PrimExpr const_true(int lanes = 1, Span span = Span()) {
-  return make_const(DataType::Bool(lanes), 1);
-}
-/*!
- * \brief Make a constant false expression.
- * \param lanes The number of lanes in the bool
- * \param span The location of this operation in the source.
- * \return The result expression.
- */
-inline PrimExpr const_false(int lanes = 1, Span span = Span()) {
-  return make_const(DataType::Bool(lanes), 0);
-}
+inline PrimExpr ConstHandle(int64_t value, Span span = Span());
 /*!
  * \brief Get x as constant int expression.
  * \param x The expression
@@ -981,53 +970,52 @@ inline bool is_no_op(const tirx::Stmt& stmt) {
 }
 
 template <typename ValueType>
-inline PrimExpr MakeConstScalar(DataType t, ValueType value, Span span = Span()) {
-  if (t.is_int() || t.is_bool()) return IntImm(t, static_cast<int64_t>(value), span);
-  if (t.is_uint()) {
+inline PrimExpr MakeConstScalar(DataType dtype, ValueType value, Span span = Span()) {
+  if (dtype.is_int() || dtype.is_bool()) return IntImm(dtype, static_cast<int64_t>(value), span);
+  if (dtype.is_uint()) {
     // Use IntImm if it is a small integer
     uint64_t uval = static_cast<uint64_t>(value);
     if (value < static_cast<ValueType>(0)) {
       TVM_FFI_THROW(InternalError) << "cannot make uint from negative value " << value;
     } else if (uval <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-      return IntImm(t, static_cast<int64_t>(value), span);
+      return IntImm(dtype, static_cast<int64_t>(value), span);
     } else {
       uint64_t mask = (static_cast<uint64_t>(1) << 32U) - 1U;
       uint64_t low = uval & mask;
       uint64_t high = uval >> 32U;
-      return LargeUIntImm(t, static_cast<int64_t>(low), static_cast<int64_t>(high), span);
+      return LargeUIntImm(dtype, static_cast<int64_t>(low), static_cast<int64_t>(high), span);
     }
   }
-  if (t.is_float() || t.is_bfloat16() || t.is_float8() || t.is_float6() || t.is_float4())
-    return FloatImm(t, static_cast<double>(value), span);
-  TVM_FFI_THROW(InternalError) << "cannot make const for type " << t;
+  if (dtype.is_float() || dtype.is_bfloat16() || dtype.is_float8() || dtype.is_float6() ||
+      dtype.is_float4()) {
+    return FloatImm(dtype, static_cast<double>(value), span);
+  }
+  TVM_FFI_THROW(InternalError) << "cannot make const for type " << dtype;
   throw;
 }
 
 template <>
-inline PrimExpr MakeConstScalar(DataType t, bool value, Span span) {
-  return MakeConstScalar(t, static_cast<int>(value), span);
+inline PrimExpr MakeConstScalar(DataType dtype, bool value, Span span) {
+  return MakeConstScalar(dtype, static_cast<int>(value), span);
 }
 
 template <typename ValueType, typename>
-inline PrimExpr make_const(DataType t, ValueType value, Span span) {
-  if (t.is_scalar()) {
-    return MakeConstScalar(t, value, span);
+inline PrimExpr MakeConst(DataType dtype, ValueType value, Span span) {
+  if (dtype.is_scalar()) {
+    return MakeConstScalar(dtype, value, span);
   } else {
-    if (t.is_fixed_length_vector()) {
-      return tirx::Broadcast(MakeConstScalar(t.element_of(), value, span), t.lanes(), span);
+    if (dtype.is_fixed_length_vector()) {
+      return tirx::Broadcast(MakeConstScalar(dtype.element_of(), value, span), dtype.lanes(), span);
     } else {
-      PrimExpr lanes =
-          tirx::Mul(tirx::Call(DataType::Int(32), tirx::builtin::vscale(), {}), t.vscale_factor());
-      return tirx::Broadcast(MakeConstScalar(t.element_of(), value, span), lanes, span);
+      PrimExpr lanes = tirx::Mul(tirx::Call(DataType::Int(32), tirx::builtin::vscale(), {}),
+                                 dtype.vscale_factor());
+      return tirx::Broadcast(MakeConstScalar(dtype.element_of(), value, span), lanes, span);
     }
   }
 }
 
-inline PrimExpr make_zero(DataType t, Span span) {
-  if (t.is_handle()) {
-    return reinterpret(t, make_const(DataType::UInt(64), 0, span));
-  }
-  return make_const(t, 0, span);
+inline PrimExpr ConstHandle(int64_t value, Span span) {
+  return reinterpret(DataType::Handle(), IntImm(DataType::UInt(64), value, span));
 }
 
 }  // namespace tirx
@@ -1043,13 +1031,13 @@ inline PrimExpr make_zero(DataType t, Span span) {
   inline PrimExpr Name(const PrimExpr& a, float b) { return Name(a, PrimExpr(b)); } \
   inline PrimExpr Name(float a, const PrimExpr& b) { return Name(PrimExpr(a), b); } \
   inline PrimExpr Name(int a, const PrimExpr& b) {                                  \
-    return Name(tirx::make_const(b.dtype(), a), b);                                 \
+    return Name(tirx::MakeConst(b.dtype(), a), b);                                  \
   }                                                                                 \
   inline PrimExpr Name(const PrimExpr& a, int b) {                                  \
-    return Name(a, tirx::make_const(a.dtype(), b));                                 \
+    return Name(a, tirx::MakeConst(a.dtype(), b));                                  \
   }                                                                                 \
   inline PrimExpr Name(const PrimExpr& a, double b) {                               \
-    return Name(a, tirx::make_const(DataType::Float(64), b));                       \
+    return Name(a, FloatImm(DataType::Float(64), b));                               \
   }
 
 #define TVM_DEFINE_BINOP_CONST_VAL_OVERLOAD_SPANNED(Name)                 \
@@ -1060,13 +1048,13 @@ inline PrimExpr make_zero(DataType t, Span span) {
     return Name(PrimExpr(a), b, span);                                    \
   }                                                                       \
   inline PrimExpr Name(int a, const PrimExpr& b, Span span = Span()) {    \
-    return Name(tirx::make_const(b.dtype(), a), b, span);                 \
+    return Name(tirx::MakeConst(b.dtype(), a), b, span);                  \
   }                                                                       \
   inline PrimExpr Name(const PrimExpr& a, int b, Span span = Span()) {    \
-    return Name(a, tirx::make_const(a.dtype(), b), span);                 \
+    return Name(a, tirx::MakeConst(a.dtype(), b), span);                  \
   }                                                                       \
   inline PrimExpr Name(const PrimExpr& a, double b, Span span = Span()) { \
-    return Name(a, tirx::make_const(DataType::Float(64), b), span);       \
+    return Name(a, FloatImm(DataType::Float(64), b), span);               \
   }
 
 #define TVM_DEFINE_LOGICAL_OP_CONST_VAL_OVERLOAD(Name)                             \
@@ -1081,18 +1069,18 @@ inline PrimExpr make_zero(DataType t, Span span) {
     return Name(PrimExpr(a), b, span);                                  \
   }
 
-#define TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD(Name)  \
-  inline PrimExpr Name(const PrimExpr& a, int b) {  \
-    return Name(a, tirx::make_const(a.dtype(), b)); \
-  }                                                 \
-  inline PrimExpr Name(int a, const PrimExpr& b) { return Name(tirx::make_const(b.dtype(), a), b); }
+#define TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD(Name) \
+  inline PrimExpr Name(const PrimExpr& a, int b) { \
+    return Name(a, tirx::MakeConst(a.dtype(), b)); \
+  }                                                \
+  inline PrimExpr Name(int a, const PrimExpr& b) { return Name(tirx::MakeConst(b.dtype(), a), b); }
 
 #define TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD_SPANNED(Name)             \
   inline PrimExpr Name(const PrimExpr& a, int b, Span span = Span()) { \
-    return Name(a, tirx::make_const(a.dtype(), b), span);              \
+    return Name(a, tirx::MakeConst(a.dtype(), b), span);               \
   }                                                                    \
   inline PrimExpr Name(int a, const PrimExpr& b, Span span = Span()) { \
-    return Name(tirx::make_const(b.dtype(), a), b, span);              \
+    return Name(tirx::MakeConst(b.dtype(), a), b, span);               \
   }
 
 TVM_DEFINE_ASSIGN_OP_OVERLOAD(operator+=, operator+);

--- a/include/tvm/topi/detail/broadcast.h
+++ b/include/tvm/topi/detail/broadcast.h
@@ -130,7 +130,7 @@ inline tvm::ffi::Array<tvm::PrimExpr> InputIndexFromBroadcast(
     // Only inject 0 here if we have not yet reached the dimension of I
     // (i.e. this must be a 1)
     if (!found && (ovars.size() - i) <= expected_dims) {
-      ivars.push_back(tvm::tirx::make_zero(ovars[i].dtype()));
+      ivars.push_back(tvm::IntImm(ovars[i].dtype(), 0));
     }
   }
   TVM_FFI_ICHECK(expected_dims == ivars.size());

--- a/include/tvm/topi/detail/extern.h
+++ b/include/tvm/topi/detail/extern.h
@@ -108,13 +108,12 @@ inline PrimExpr pack_buffer(Buffer buf) {
   } else {
     strides = 0;
   }
-  ffi::Array<PrimExpr> pack_args{
-      buf->data,
-      shape,
-      strides,
-      make_const(DataType::Int(32), static_cast<int64_t>(buf->shape.size())),
-      make_const(buf->dtype, 0),
-      buf->elem_offset};
+  ffi::Array<PrimExpr> pack_args{buf->data,
+                                 shape,
+                                 strides,
+                                 IntImm::Int32(static_cast<int64_t>(buf->shape.size())),
+                                 MakeConst(buf->dtype, 0),
+                                 buf->elem_offset};
   return tvm::tirx::Call(DataType::Handle(), tvm::tirx::builtin::tvm_stack_make_array(), pack_args);
 }
 

--- a/include/tvm/topi/detail/strided_slice.h
+++ b/include/tvm/topi/detail/strided_slice.h
@@ -99,10 +99,10 @@ inline ffi::Array<PrimExpr> StridedSliceCanonicalizeBegin(const ffi::Array<PrimE
     if (ishape[ax]->IsInstance<tvm::IntImmNode>()) {
       int64_t dim_i = GetConstInt(ishape[ax]);
       int64_t begin_i = CanonicalizeIndex(begin[i], dim_i, strides[i]);
-      begin_expr.push_back(make_const(dtype, begin_i));
+      begin_expr.push_back(MakeConst(dtype, begin_i));
     } else {
       auto idim = ishape[ax];
-      auto b_expr = make_const(dtype, begin[i]);
+      auto b_expr = MakeConst(dtype, begin[i]);
       PrimExpr b = begin[i] < 0 ? b_expr + idim : b_expr;
       auto s = strides[i];
       if (s < 0) {

--- a/include/tvm/topi/elemwise.h
+++ b/include/tvm/topi/elemwise.h
@@ -82,22 +82,22 @@ TOPI_DECLARE_UNARY_OP(isinf);
 inline Tensor fast_tanh_float(const Tensor& in, std::string name, std::string tag) {
   // Clamp the inputs to the range [-9, 9] since anything outside
   // this range is +/-1.0f in single-precision.
-  auto x = maximum(make_const(in->dtype, -9.0), minimum(make_const(in->dtype, 9.0), in));
+  auto x = maximum(MakeConst(in->dtype, -9.0), minimum(MakeConst(in->dtype, 9.0), in));
 
   // The monomial coefficients of the numerator polynomial (odd).
-  auto alpha_1 = make_const(in->dtype, 4.89352455891786e-03);
-  auto alpha_3 = make_const(in->dtype, 6.37261928875436e-04);
-  auto alpha_5 = make_const(in->dtype, 1.48572235717979e-05);
-  auto alpha_7 = make_const(in->dtype, 5.12229709037114e-08);
-  auto alpha_9 = make_const(in->dtype, -8.60467152213735e-11);
-  auto alpha_11 = make_const(in->dtype, 2.00018790482477e-13);
-  auto alpha_13 = make_const(in->dtype, -2.76076847742355e-16);
+  auto alpha_1 = MakeConst(in->dtype, 4.89352455891786e-03);
+  auto alpha_3 = MakeConst(in->dtype, 6.37261928875436e-04);
+  auto alpha_5 = MakeConst(in->dtype, 1.48572235717979e-05);
+  auto alpha_7 = MakeConst(in->dtype, 5.12229709037114e-08);
+  auto alpha_9 = MakeConst(in->dtype, -8.60467152213735e-11);
+  auto alpha_11 = MakeConst(in->dtype, 2.00018790482477e-13);
+  auto alpha_13 = MakeConst(in->dtype, -2.76076847742355e-16);
 
   // The monomial coefficients of the denominator polynomial (even).
-  auto beta_0 = make_const(in->dtype, 4.89352518554385e-03);
-  auto beta_2 = make_const(in->dtype, 2.26843463243900e-03);
-  auto beta_4 = make_const(in->dtype, 1.18534705686654e-04);
-  auto beta_6 = make_const(in->dtype, 1.19825839466702e-06);
+  auto beta_0 = MakeConst(in->dtype, 4.89352518554385e-03);
+  auto beta_2 = MakeConst(in->dtype, 2.26843463243900e-03);
+  auto beta_4 = MakeConst(in->dtype, 1.18534705686654e-04);
+  auto beta_6 = MakeConst(in->dtype, 1.19825839466702e-06);
 
   return compute(
       x->shape,
@@ -209,9 +209,9 @@ inline Tensor sign(const Tensor& x, std::string name = "T_sign", std::string tag
   return compute(
       x->shape,
       [&](const ffi::Array<Var>& i) {
-        PrimExpr zero = make_zero(x->dtype);
-        PrimExpr one = make_const(x->dtype, 1);
-        PrimExpr minus_one = make_const(x->dtype, -1);
+        PrimExpr zero = MakeConst(x->dtype, 0);
+        PrimExpr one = MakeConst(x->dtype, 1);
+        PrimExpr minus_one = MakeConst(x->dtype, -1);
         auto s1 = tvm::tirx::Select((x(i) < zero), minus_one, zero);
         auto s2 = tvm::tirx::Select((x(i) > zero), one, s1);
         return s2;
@@ -232,7 +232,7 @@ inline Tensor rsqrt(const Tensor& x, std::string name = "tensor", std::string ta
   return compute(
       x->shape,
       [&](const ffi::Array<Var>& i) {
-        PrimExpr one = make_const(x->dtype, 1);
+        PrimExpr one = MakeConst(x->dtype, 1);
         return one / tvm::sqrt(x(i));
       },
       name, tag);
@@ -392,19 +392,19 @@ inline Tensor full_like(const Tensor& x, const PrimExpr fill_value,
  * y = exp(f) = 1 + 2 * P(x**2)/(Q(x**2) - P(x**2))
  */
 inline Tensor fast_exp_float32(const Tensor& _x, std::string name, std::string tag) {
-  auto x_hi = make_const(DataType::Float(32), 88.3762626647950f);
-  auto x_lo = make_const(DataType::Float(32), -88.3762626647949f);
-  auto log2e = make_const(DataType::Float(32), 1.44269504088896341f);
-  auto ln2 = make_const(DataType::Float(32), 0.6931471805599453f);
-  PrimExpr p[6] = {make_const(DataType::Float(32), 1.9875691500E-4f),
-                   make_const(DataType::Float(32), 1.3981999507E-3f),
-                   make_const(DataType::Float(32), 8.3334519073E-3f),
-                   make_const(DataType::Float(32), 4.1665795894E-2f),
-                   make_const(DataType::Float(32), 1.6666665459E-1f),
-                   make_const(DataType::Float(32), 5.0000001201E-1f)};
-  auto one = make_const(DataType::Float(32), 1.0f);
-  auto one_half = make_const(DataType::Float(32), 0.5f);
-  auto b = make_const(DataType::Float(32), 127.0f);
+  auto x_hi = FloatImm(DataType::Float(32), 88.3762626647950f);
+  auto x_lo = FloatImm(DataType::Float(32), -88.3762626647949f);
+  auto log2e = FloatImm(DataType::Float(32), 1.44269504088896341f);
+  auto ln2 = FloatImm(DataType::Float(32), 0.6931471805599453f);
+  PrimExpr p[6] = {FloatImm(DataType::Float(32), 1.9875691500E-4f),
+                   FloatImm(DataType::Float(32), 1.3981999507E-3f),
+                   FloatImm(DataType::Float(32), 8.3334519073E-3f),
+                   FloatImm(DataType::Float(32), 4.1665795894E-2f),
+                   FloatImm(DataType::Float(32), 1.6666665459E-1f),
+                   FloatImm(DataType::Float(32), 5.0000001201E-1f)};
+  auto one = FloatImm(DataType::Float(32), 1.0f);
+  auto one_half = FloatImm(DataType::Float(32), 0.5f);
+  auto b = FloatImm(DataType::Float(32), 127.0f);
 
   return compute(
       _x->shape,

--- a/include/tvm/topi/nn.h
+++ b/include/tvm/topi/nn.h
@@ -57,7 +57,7 @@ inline tvm::te::Tensor relu(const tvm::te::Tensor& t, T threshold = static_cast<
   return tvm::te::compute(
       t->shape,
       [&](const tvm::ffi::Array<tvm::tirx::Var>& i) {
-        auto threshold_const = tvm::tirx::make_const(t->dtype, threshold);
+        auto threshold_const = tvm::tirx::MakeConst(t->dtype, threshold);
         return tvm::max(t(i), threshold_const);
       },
       name, tag);
@@ -80,7 +80,7 @@ inline tvm::te::Tensor leaky_relu(const tvm::te::Tensor& t, double alpha = 0.1,
       t->shape,
       [&](const tvm::ffi::Array<tvm::tirx::Var>& i) {
         auto value = t(i);
-        auto calpha = tvm::tirx::make_const(value.dtype(), alpha);
+        auto calpha = tvm::tirx::MakeConst(value.dtype(), alpha);
         return tvm::tirx::Select(value > 0, value, value * calpha);
       },
       name, tag);
@@ -194,7 +194,7 @@ inline tvm::te::Tensor pad(
   }
 
   if (!pad_value.defined()) {
-    pad_value = tvm::tirx::make_const(t->dtype, 0);
+    pad_value = tvm::tirx::MakeConst(t->dtype, 0);
   }
 
   auto l = [&](tvm::ffi::Array<tvm::tirx::Var> ovars) {
@@ -232,12 +232,12 @@ inline tvm::te::Tensor pad(
       if (pad_mode == "constant") {
         return tvm::if_then_else(
             foldl([](PrimExpr a, PrimExpr b, Span span) { return tvm::logical_and(a, b, span); },
-                  const_true(1), sel),
+                  IntImm::Bool(true), sel),
             t(indices), pad_value);
       } else if (pad_mode == "edge" || pad_mode == "reflect") {
         return tvm::if_then_else(
             foldl([](PrimExpr a, PrimExpr b, Span span) { return tvm::logical_and(a, b, span); },
-                  const_true(1), sel),
+                  IntImm::Bool(true), sel),
             t(indices), t(pad_idx));
       }
     }
@@ -507,7 +507,7 @@ inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
 
   // pad the input with paddings provided
   if (!pad_value.defined()) {
-    pad_value = tvm::tirx::make_const(data->dtype, 0);
+    pad_value = tvm::tirx::MakeConst(data->dtype, 0);
   }
   padded_t = pad(data, pad_before_int32, pad_after_int32, pad_value);
 
@@ -534,7 +534,7 @@ inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
         << padded_input << ")"
         << " must be divisible by its block size (" << block_size << ")";
 
-    PrimExpr bs = IntImm(DataType::Int(64), block_shape[i - 1]);
+    PrimExpr bs = IntImm::Int64(block_shape[i - 1]);
     r_shape.push_back(div(padded_shape[i], bs));
     r_shape.push_back(bs);
     block_shape_prod *= bs;
@@ -549,7 +549,7 @@ inline tvm::te::Tensor space_to_batch_nd(const tvm::te::Tensor& data,
   }
   o_shape.push_back(tvm::PrimExpr(batch) * block_shape_prod);
   for (size_t i = 1; i <= num_block_dims; i++) {
-    PrimExpr bs = IntImm(DataType::Int(64), block_shape[i - 1]);
+    PrimExpr bs = IntImm::Int64(block_shape[i - 1]);
     o_shape.push_back(div(padded_shape[i], bs));
   }
   // append remaining shape
@@ -595,7 +595,7 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
   int batch = static_cast<int>(GetConstInt(in_shape[0]));
 
   for (size_t i = 0; i < num_block_dims; i++) {
-    PrimExpr bs = IntImm(DataType::Int(64), block_shape[i]);
+    PrimExpr bs = IntImm::Int64(block_shape[i]);
     r_shape.push_back(bs);
     block_shape_prod *= bs;
   }
@@ -614,7 +614,7 @@ inline tvm::te::Tensor batch_to_space_nd(const tvm::te::Tensor& data,
   ffi::Array<PrimExpr> r_p_shape;
   r_p_shape.push_back(batch / block_shape_prod);
   for (size_t i = 1; i <= num_block_dims; i++) {
-    PrimExpr bs = IntImm(DataType::Int(64), block_shape[i - 1]);
+    PrimExpr bs = IntImm::Int64(block_shape[i - 1]);
     r_p_shape.push_back(in_shape[i] * bs);
   }
   for (size_t i = num_block_dims + 1; i < num_input_dims; i++) {
@@ -677,7 +677,7 @@ inline Tensor nll_loss(const Tensor& predictions, const Tensor& targets, const T
         [&](const tvm::ffi::Array<tvm::tirx::Var>& target_indices) {
           auto c = targets();
           return tvm::tirx::Select(c != ignore_index, -predictions(c) * weights(c),
-                                   tvm::tirx::make_const(predictions->dtype, 0));
+                                   tvm::tirx::MakeConst(predictions->dtype, 0));
         },
         name, tag);
     if (reduction == "mean") {
@@ -686,7 +686,7 @@ inline Tensor nll_loss(const Tensor& predictions, const Tensor& targets, const T
           [&](const tvm::ffi::Array<tvm::tirx::Var>& target_indices) {
             auto c = targets();
             return tvm::tirx::Select(c != ignore_index, weights(c),
-                                     tvm::tirx::make_const(predictions->dtype, 0));
+                                     tvm::tirx::MakeConst(predictions->dtype, 0));
           },
           name, tag);
       return topi::divide(T, W);
@@ -705,7 +705,7 @@ inline Tensor nll_loss(const Tensor& predictions, const Tensor& targets, const T
           pred_indices.push_back(target_indices[i]);  // indices for multidimensional loss
         }
         return tvm::tirx::Select(c != ignore_index, -predictions(pred_indices) * weights(c),
-                                 tvm::tirx::make_const(predictions->dtype, 0));
+                                 tvm::tirx::MakeConst(predictions->dtype, 0));
       },
       name, tag);
   TVM_FFI_ICHECK(T->shape.size() != 0);
@@ -715,7 +715,7 @@ inline Tensor nll_loss(const Tensor& predictions, const Tensor& targets, const T
         [&](const tvm::ffi::Array<tvm::tirx::Var>& target_indices) {
           auto c = targets(target_indices);
           return tvm::tirx::Select(c != ignore_index, weights(c),
-                                   tvm::tirx::make_const(predictions->dtype, 0));
+                                   tvm::tirx::MakeConst(predictions->dtype, 0));
         },
         name, tag);
     return topi::divide(topi::sum(T, tvm::ffi::Array<int64_t>(nullptr)),

--- a/include/tvm/topi/nn/bnn.h
+++ b/include/tvm/topi/nn/bnn.h
@@ -71,7 +71,7 @@ inline tvm::te::Tensor binarize_pack(const tvm::te::Tensor& data, int axis,
           start_idx.push_back(i == static_cast<size_t>(axis) ? indices[i] * 32
                                                              : static_cast<PrimExpr>(indices[i]));
         }
-        auto packed = make_const(DataType::UInt(32), 0);
+        PrimExpr packed = IntImm(DataType::UInt(32), 0);
         for (size_t j = 0; j < 32; ++j) {
           ffi::Array<PrimExpr> idx;
           for (size_t i = 0; i < n; ++i) {

--- a/include/tvm/topi/nn/dilate.h
+++ b/include/tvm/topi/nn/dilate.h
@@ -95,7 +95,7 @@ inline Tensor dilate(const Tensor& x, ffi::Array<PrimExpr> strides, double dilat
         if (not_zero.size() > 0) {
           auto all_not_zero = all(not_zero);
           return tvm::if_then_else(all_not_zero, x(index_tuple),
-                                   make_const(x->dtype, dilation_value));
+                                   MakeConst(x->dtype, dilation_value));
         }
         return x(index_tuple);
       },

--- a/include/tvm/topi/nn/group_norm.h
+++ b/include/tvm/topi/nn/group_norm.h
@@ -126,7 +126,7 @@ inline Tensor group_norm(const Tensor& data, const Tensor& gamma, const Tensor& 
 
   auto temp_x = temp_x_x2[0];
   auto temp_x2 = temp_x_x2[1];
-  auto reduce_extent = make_const(DataType::Float(32), 1);
+  PrimExpr reduce_extent = FloatImm(DataType::Float(32), 1);
   for (auto axis : new_axes) {
     reduce_extent *= data_reshaped->shape[axis];
   }
@@ -143,7 +143,7 @@ inline Tensor group_norm(const Tensor& data, const Tensor& gamma, const Tensor& 
     auto mean = temp_x(non_reduce_indices) / reduce_extent;
     auto var = temp_x2(non_reduce_indices) / reduce_extent - mean * mean;
     PrimExpr group_norm =
-        (data_reshaped(indices) - mean) * tvm::rsqrt(var + make_const(data->dtype, epsilon));
+        (data_reshaped(indices) - mean) * tvm::rsqrt(var + MakeConst(data->dtype, epsilon));
     if (is_float16) {
       group_norm = Cast(DataType::Float(16), group_norm);
     }

--- a/include/tvm/topi/nn/instance_norm.h
+++ b/include/tvm/topi/nn/instance_norm.h
@@ -106,7 +106,7 @@ inline Tensor instance_norm(const Tensor& data, const Tensor& gamma, const Tenso
   auto temp_x = temp_x_x2[0];
   auto temp_x2 = temp_x_x2[1];
 
-  auto reduce_extent = make_const(data->dtype, 1);
+  auto reduce_extent = MakeConst(data->dtype, 1);
   for (int i : real_axis) {
     reduce_extent *= data->shape[i];
   }
@@ -124,7 +124,7 @@ inline Tensor instance_norm(const Tensor& data, const Tensor& gamma, const Tenso
     channel = indices[channel_axis];
     auto mean = temp_x(non_reduce_indices) / reduce_extent;
     auto var = temp_x2(non_reduce_indices) / reduce_extent - mean * mean;
-    auto instance_norm = (data(indices) - mean) * tvm::rsqrt(var + make_const(var->dtype, epsilon));
+    auto instance_norm = (data(indices) - mean) * tvm::rsqrt(var + MakeConst(var->dtype, epsilon));
     if (is_float16) {
       instance_norm = Cast(DataType::Float(16), instance_norm);
     }

--- a/include/tvm/topi/nn/layer_norm.h
+++ b/include/tvm/topi/nn/layer_norm.h
@@ -102,7 +102,7 @@ inline Tensor layer_norm(const Tensor& data, const Tensor& gamma, const Tensor& 
       data->op->name + "_sum", kCommReduce);
 
   DataType reduce_dtype = is_float16 ? DataType::Float(32) : data->dtype;
-  PrimExpr reduce_extent = make_const(reduce_dtype, 1);
+  PrimExpr reduce_extent = MakeConst(reduce_dtype, 1);
   for (int i : real_axis) {
     reduce_extent *= data->shape[i];
   }
@@ -138,7 +138,7 @@ inline Tensor layer_norm(const Tensor& data, const Tensor& gamma, const Tensor& 
     }
     auto mean = temp_mean(non_reduce_indices);
     auto var = temp_var_sum(non_reduce_indices) / reduce_extent;
-    auto layer_norm = (data(indices) - mean) * rsqrt(var + make_const(var->dtype, epsilon));
+    auto layer_norm = (data(indices) - mean) * rsqrt(var + MakeConst(var->dtype, epsilon));
     if (is_float16) {
       layer_norm = Cast(DataType::Float(16), layer_norm);
     }

--- a/include/tvm/topi/nn/local_response_norm.h
+++ b/include/tvm/topi/nn/local_response_norm.h
@@ -79,9 +79,9 @@ inline Tensor lrn(const Tensor& data, int size, int axis = 1, float alpha = 0.00
         },
         "tensor", "sqr_sum");
   }
-  PrimExpr alpha_imm = tvm::te::make_const(data->dtype, alpha);
-  PrimExpr beta_imm = tvm::te::make_const(data->dtype, beta);
-  PrimExpr bias_imm = tvm::te::make_const(data->dtype, bias);
+  PrimExpr alpha_imm = tvm::te::MakeConst(data->dtype, alpha);
+  PrimExpr beta_imm = tvm::te::MakeConst(data->dtype, beta);
+  PrimExpr bias_imm = tvm::te::MakeConst(data->dtype, bias);
   auto sqrt_sum_up = tvm::te::compute(
       input_shape,
       [&](Var i, Var j, Var k, Var l) {

--- a/include/tvm/topi/nn/pooling.h
+++ b/include/tvm/topi/nn/pooling.h
@@ -145,17 +145,17 @@ inline Tensor pool_grad_impl(const Tensor& out_grad, const Tensor& x,
           out_idx.Set(width_axis, (inds[width_axis] + pad_left) / stride_width - windoww);
 
           PrimExpr out_idx_lower_h = tirx::Select(
-              pad_inds[height_axis] < kernel_height, make_const(pad_inds[height_axis].dtype(), 0),
+              pad_inds[height_axis] < kernel_height, IntImm(pad_inds[height_axis].dtype(), 0),
               (pad_inds[height_axis] - kernel_height) / stride_height + 1);
           PrimExpr out_idx_lower_w = tirx::Select(
-              pad_inds[width_axis] < kernel_width, make_const(pad_inds[width_axis].dtype(), 0),
+              pad_inds[width_axis] < kernel_width, IntImm(pad_inds[width_axis].dtype(), 0),
               (pad_inds[width_axis] - kernel_width) / stride_width + 1);
 
           return tvm::sum(
               tvm::if_then_else(tirx::And(tirx::And(out_idx[height_axis] >= out_idx_lower_h,
                                                     out_idx[width_axis] >= out_idx_lower_w),
                                           mp_inds(out_idx) == idx),
-                                out_grad(out_idx), make_const(x->dtype, 0)),
+                                out_grad(out_idx), MakeConst(x->dtype, 0)),
               {windowh, windoww});
         },
         "T_pool_grad", "pool_grad_max");
@@ -176,10 +176,10 @@ inline Tensor pool_grad_impl(const Tensor& out_grad, const Tensor& x,
           out_idx.Set(width_axis, (pad_w_idx / stride_width - windoww));
 
           PrimExpr out_idx_lower_h =
-              tirx::Select(pad_h_idx < kernel_height, make_const(pad_h_idx.dtype(), 0),
+              tirx::Select(pad_h_idx < kernel_height, IntImm(pad_h_idx.dtype(), 0),
                            (pad_h_idx - kernel_height) / stride_height + 1);
           PrimExpr out_idx_lower_w =
-              tirx::Select(pad_w_idx < kernel_width, make_const(pad_w_idx.dtype(), 0),
+              tirx::Select(pad_w_idx < kernel_width, IntImm(pad_w_idx.dtype(), 0),
                            (pad_w_idx - kernel_width) / stride_width + 1);
 
           PrimExpr divide_factor;  // number of pooled elements
@@ -191,17 +191,16 @@ inline Tensor pool_grad_impl(const Tensor& out_grad, const Tensor& x,
 
             PrimExpr h_end = min(h_start + kernel_height, height);
             PrimExpr w_end = min(w_start + kernel_width, width);
-            h_start = max(h_start, make_const(h_start.dtype(), 0));
-            w_start = max(w_start, make_const(w_start.dtype(), 0));
-            divide_factor =
-                max((h_end - h_start) * (w_end - w_start), make_const(h_end.dtype(), 1));
+            h_start = max(h_start, IntImm(h_start.dtype(), 0));
+            w_start = max(w_start, IntImm(w_start.dtype(), 0));
+            divide_factor = max((h_end - h_start) * (w_end - w_start), MakeConst(h_end.dtype(), 1));
           }
           return tvm::sum(
               tvm::if_then_else(tirx::And(tirx::And(out_idx[height_axis] >= out_idx_lower_h,
                                                     out_idx[height_axis] < out_height),
                                           tirx::And(out_idx[width_axis] >= out_idx_lower_w,
                                                     out_idx[width_axis] < out_width)),
-                                out_grad(out_idx) / divide_factor, make_const(out_grad->dtype, 0)),
+                                out_grad(out_idx) / divide_factor, MakeConst(out_grad->dtype, 0)),
               {windowh, windoww});
         },
         "T_pool_grad", "pool_grad_avg");
@@ -627,7 +626,7 @@ inline Tensor pool_impl_nd(const Tensor& x, const ffi::Array<PrimExpr>& kernel_s
           if (count_include_pad) {
             std::vector<PrimExpr> start(k_size);
             std::vector<PrimExpr> end(k_size);
-            auto num_el = make_const(DataType::Int(32), 1);
+            auto num_el = IntImm::Int32(1);
             for (int i = 0; i < k_size; i++) {
               int ii = axis[i];
               start[i] = output[ii] * stride[i] - pad_head[i];
@@ -643,7 +642,7 @@ inline Tensor pool_impl_nd(const Tensor& x, const ffi::Array<PrimExpr>& kernel_s
           } else {
             std::vector<PrimExpr> start(k_size);
             std::vector<PrimExpr> end(k_size);
-            auto num_el = make_const(DataType::Int(32), 1);
+            auto num_el = IntImm::Int32(1);
             for (int i = 0; i < k_size; i++) {
               int ii = axis[i];
 
@@ -658,13 +657,13 @@ inline Tensor pool_impl_nd(const Tensor& x, const ffi::Array<PrimExpr>& kernel_s
               // number that represents the number of steps along the dilated kernel to reach a
               // non-padded value. Otherwise this should be 0.
               PrimExpr jumps_to_non_pad = (dilation[i] - 1 - start[i]) / dilation[i];
-              jumps_to_non_pad = max(jumps_to_non_pad, make_const(jumps_to_non_pad.dtype(), 0));
+              jumps_to_non_pad = max(jumps_to_non_pad, IntImm(jumps_to_non_pad.dtype(), 0));
 
               end[i] = min(end[i], data_shape[ii] - 1);
               num_el *= (end[i] - (start[i] + dilation[i] * jumps_to_non_pad)) / dilation[i] + 1;
             }
 
-            PrimExpr divide_factor = max(num_el, make_const(DataType::Int(32), 1));
+            PrimExpr divide_factor = max(num_el, IntImm::Int32(1));
             return div(pool_sum(indices), divide_factor);
           }
         },

--- a/include/tvm/topi/nn/rms_norm.h
+++ b/include/tvm/topi/nn/rms_norm.h
@@ -63,7 +63,7 @@ inline Tensor rms_norm(const Tensor& data, const Tensor& weight, const ffi::Arra
   auto ndim = data_fp32->shape.size();
   TVM_FFI_ICHECK_NE(ndim, 0) << "Cannot reduce a 0 dim Tensor";
   auto real_axis = GetRealAxis(static_cast<int>(ndim), axis);
-  auto reduce_extent = make_const(data_fp32->dtype, 1);
+  auto reduce_extent = MakeConst(data_fp32->dtype, 1);
   for (int i : real_axis) {
     reduce_extent *= data_fp32->shape[i];
   }
@@ -75,7 +75,7 @@ inline Tensor rms_norm(const Tensor& data, const Tensor& weight, const ffi::Arra
       }
     }
     auto output =
-        tvm::rsqrt(square_sum(non_reduce_indices) / reduce_extent + make_const(data_type, epsilon));
+        tvm::rsqrt(square_sum(non_reduce_indices) / reduce_extent + MakeConst(data_type, epsilon));
     return output;
   };
   auto rsqrt_shape = ffi::Array<PrimExpr>();

--- a/include/tvm/topi/nn/softmax.h
+++ b/include/tvm/topi/nn/softmax.h
@@ -61,7 +61,7 @@ inline Tensor softmax(const Tensor& x, int axis = -1, std::string name = "tensor
   auto reduced_shape = MakeReduceTargetShape({axis}, x, false, false);
 
   tvm::ffi::Map<ffi::String, ffi::Any> attrs;
-  attrs.Set("axis", IntImm(DataType::Int(32), axis));
+  attrs.Set("axis", IntImm::Int32(axis));
 
   auto insert_reduce_index = [axis, ndim](const ffi::Array<Var>& indices,
                                           const IterVar& reduce_index) {

--- a/include/tvm/topi/reduction.h
+++ b/include/tvm/topi/reduction.h
@@ -286,7 +286,7 @@ inline FCommReduce MakeCommReducer(FCombine fcombine, FIdentity fidentity,
 
     auto result = fcombine(lhs, rhs);
     auto id_elem = fidentity(dtypes);
-    auto cond = condition != nullptr ? *condition : tirx::const_true();
+    auto cond = condition != nullptr ? *condition : IntImm::Bool(true);
 
     auto combiner = tvm::tirx::CommReducer(lhs, rhs, result, id_elem);
     ffi::Array<PrimExpr> outputs;
@@ -479,8 +479,8 @@ inline FCommReduce MakeArgminReducer(bool select_last_index = false) {
   };
   auto fidentity = [&](std::vector<DataType> types) {
     ffi::Array<PrimExpr> result;
-    result.push_back(tvm::tirx::make_const(types[0], -1));  // idx
-    result.push_back(tvm::max_value(types[1]));             // val
+    result.push_back(tvm::tirx::MakeConst(types[0], -1));  // idx
+    result.push_back(tvm::max_value(types[1]));            // val
     return result;
   };
   return MakeCommReducer(fcombine, fidentity, "argmin");
@@ -541,8 +541,8 @@ inline FCommReduce MakeArgmaxReducer(bool select_last_index = false) {
   };
   auto fidentity = [&](std::vector<DataType> types) {
     ffi::Array<PrimExpr> result;
-    result.push_back(tvm::tirx::make_const(types[0], -1));  // idx
-    result.push_back(tvm::min_value(types[1]));             // val
+    result.push_back(tvm::tirx::MakeConst(types[0], -1));  // idx
+    result.push_back(tvm::min_value(types[1]));            // val
     return result;
   };
   return MakeCommReducer(fcombine, fidentity, "argmax");
@@ -604,7 +604,7 @@ inline FCommReduce MakeTupleSumReducer() {
   auto fidentity = [](std::vector<DataType> types) {
     ffi::Array<PrimExpr> result;
     for (size_t i = 0; i < types.size(); ++i) {
-      result.push_back(tvm::tirx::make_const(types[i], 0));
+      result.push_back(tvm::tirx::MakeConst(types[i], 0));
     }
     return result;
   };

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -98,16 +98,16 @@ inline Tensor sliding_window(const Tensor& x, int axis, ffi::Array<int64_t> wind
     // Length of the shape along this dimension.
     auto dim_len = x->shape[_axis + i];
     // Length of the window along this dimension.
-    PrimExpr window_len = IntImm(DataType::Int(64), window_shape[i]);
+    PrimExpr window_len = IntImm::Int64(window_shape[i]);
     // Strides along this dimension.
-    PrimExpr stride = IntImm(DataType::Int(64), strides[i]);
+    PrimExpr stride = IntImm::Int64(strides[i]);
 
     new_shape.push_back(floordiv(dim_len - (window_len - 1) + stride - 1, stride));
   }
 
   // Dimensions comprising the window.
   for (size_t i = 0; i < window_shape.size(); ++i) {
-    new_shape.push_back(IntImm(DataType::Int(64), window_shape[i]));
+    new_shape.push_back(IntImm::Int64(window_shape[i]));
   }
 
   TVM_FFI_ICHECK(new_shape.size() == _axis + 2 * window_shape.size());
@@ -129,7 +129,7 @@ inline Tensor sliding_window(const Tensor& x, int axis, ffi::Array<int64_t> wind
           // Which index within the window we are indexing.
           auto idx_within_window = indices[_axis + window_shape.size() + i];
           // Stride value for this dimension.
-          PrimExpr stride = IntImm(DataType::Int(64), strides[i]);
+          PrimExpr stride = IntImm::Int64(strides[i]);
 
           idx.push_back(window_idx * stride + idx_within_window);
         }
@@ -842,7 +842,7 @@ inline te::Tensor dynamic_strided_slice(const te::Tensor& x, const te::Tensor& b
 
   ffi::Array<PrimExpr> begin_expr, end_expr, strides_expr;
   for (int64_t i = 0; i < num_dynamic_axes; ++i) {
-    auto ind = make_const(index_dtype, i);
+    auto ind = MakeConst(index_dtype, i);
     begin_expr.push_back(begin(ind));
     end_expr.push_back(end(ind));
     strides_expr.push_back(strides(ind));
@@ -938,7 +938,7 @@ inline Tensor strided_slice_with_axes(
         for (size_t i = 0; i < out_shape.size(); ++i) real_indices.push_back(indices[i]);
         for (size_t i = 0; i < normalized_axes.size(); ++i) {
           int64_t ax = normalized_axes[i];
-          auto stride = make_const(strides[i]->dtype, strides_vec[i]);
+          auto stride = MakeConst(strides[i]->dtype, strides_vec[i]);
           PrimExpr ind = indices[ax] * stride + begin_expr[i];
           real_indices.Set(ax, ind);
         }
@@ -1118,7 +1118,7 @@ inline Tensor sequence_mask(const Tensor& data, const Tensor& valid_length, doub
         len_index.push_back(bid);
         PrimExpr ret =
             tvm::if_then_else(tvm::cast(valid_length->dtype, tid) >= valid_length(len_index),
-                              tvm::tirx::make_const(data->dtype, mask_value), data(out_index));
+                              tvm::tirx::MakeConst(data->dtype, mask_value), data(out_index));
         return ret;
       },
       name, tag);
@@ -1293,7 +1293,7 @@ inline Tensor take(const Tensor& a, ffi::Variant<Tensor, PrimExpr> indices, int 
           PrimExpr in_bounds = idx >= 0 && idx < axis_dim;
           return tvm::if_then_else(
               in_bounds, a(real_indices),
-              tvm::tirx::make_const(a->dtype, std::numeric_limits<float>::quiet_NaN()));
+              tvm::tirx::MakeConst(a->dtype, std::numeric_limits<float>::quiet_NaN()));
         },
         name, tag);
   } else {  // mode == "wrap"
@@ -1428,16 +1428,16 @@ inline Tensor tile(const Tensor& x, ffi::Array<int64_t> reps, std::string name =
   if (ndim == rdim) {
     for (size_t i = 0; i < ndim; ++i) {
       data_shape.push_back(x->shape[i]);
-      reps_shape.push_back(IntImm(DataType::Int(64), reps[i]));
+      reps_shape.push_back(IntImm::Int64(reps[i]));
     }
   } else if (ndim > rdim) {
     for (size_t i = 0; i < ndim; ++i) data_shape.push_back(x->shape[i]);
     for (size_t i = 0; i < (ndim - rdim); ++i) reps_shape.push_back(1);
-    for (size_t i = 0; i < rdim; ++i) reps_shape.push_back(IntImm(DataType::Int(64), reps[i]));
+    for (size_t i = 0; i < rdim; ++i) reps_shape.push_back(IntImm::Int64(reps[i]));
   } else {
     for (size_t i = 0; i < (rdim - ndim); ++i) data_shape.push_back(1);
     for (size_t i = 0; i < ndim; ++i) data_shape.push_back(x->shape[i]);
-    for (size_t i = 0; i < rdim; ++i) reps_shape.push_back(IntImm(DataType::Int(64), reps[i]));
+    for (size_t i = 0; i < rdim; ++i) reps_shape.push_back(IntImm::Int64(reps[i]));
   }
   for (size_t i = 0; i < tdim; ++i) new_shape.push_back(data_shape[i] * reps_shape[i]);
 
@@ -1592,7 +1592,7 @@ inline Tensor gather_nd(const Tensor& data, const Tensor& indices, int batch_dim
           real_indices.push_back(out_index[i]);
         }
         for (size_t i = 0; i < indices_dim0; ++i) {
-          indices_position.Set(0, make_const(DataType::Int(32), i));
+          indices_position.Set(0, IntImm::Int32(i));
           if (indices->dtype.is_int() || indices->dtype.is_uint()) {
             real_indices.push_back(indices(indices_position));
           } else {
@@ -1960,7 +1960,7 @@ inline Tensor meta_schedule_layout_transform(
   ffi::Array<Range> iter_domain;
   iter_domain.reserve(src->shape.size());
   for (const PrimExpr& e : src->shape) {
-    iter_domain.push_back(Range::FromMinExtent(make_zero(e->dtype), e));
+    iter_domain.push_back(Range::FromMinExtent(IntImm(e->dtype, 0), e));
   }
   ffi::Array<PrimExpr> post_transform_shape = index_map->MapShape(src->shape, analyzer);
   return compute(
@@ -2046,7 +2046,7 @@ inline Tensor one_hot(const Tensor& indices, const PrimExpr on_value, const Prim
     int indices_index = 0;
     for (int i = 0; i < ndim; i++) {
       if (i == true_axis) {
-        oshape.push_back(IntImm(DataType::Int(32), depth));
+        oshape.push_back(IntImm::Int32(depth));
       } else {
         oshape.push_back(indices->shape[indices_index++]);
       }
@@ -2268,7 +2268,7 @@ inline te::Tensor dynamic_strided_slice(const te::Tensor& x, const te::Tensor& b
       [&](const ffi::Array<tvm::tirx::Var>& indices) {
         ffi::Array<PrimExpr> real_indices;
         for (size_t i = 0; i < num_dynamic_axes; ++i) {
-          auto ind = make_const(DataType::Int(64), i);
+          auto ind = IntImm::Int64(i);
           real_indices.push_back(indices[i] * strides(ind) + tvm::min(begin(ind), x->shape[i] - 1));
         }
         return x(real_indices);

--- a/src/arith/analyzer.cc
+++ b/src/arith/analyzer.cc
@@ -70,7 +70,7 @@ void AnalyzerObj::Bind(const Var& var, const Range& range, bool allow_override) 
 void AnalyzerObj::MarkGlobalNonNegValue(const PrimExpr& value) {
   // decompose value as symbol * scale + offset
   int64_t offset = 0;
-  PrimExpr symbol_scale = tirx::make_const(value.dtype(), 0);
+  PrimExpr symbol_scale = tirx::MakeConst(value.dtype(), 0);
 
   auto fcollect_sum = [&](PrimExpr val, int sign) {
     if (const auto* intimm = val.as<IntImmNode>()) {
@@ -87,7 +87,7 @@ void AnalyzerObj::MarkGlobalNonNegValue(const PrimExpr& value) {
 
   // split out the symbol and non-symbolic part
   int64_t cscale = 1;
-  PrimExpr symbol = tirx::make_const(value.dtype(), 1);
+  PrimExpr symbol = tirx::MakeConst(value.dtype(), 1);
   auto fcollect_prod = [&](PrimExpr val) {
     if (const auto* intimm = val.as<IntImmNode>()) {
       cscale *= intimm->value;

--- a/src/arith/canonical_simplify.cc
+++ b/src/arith/canonical_simplify.cc
@@ -130,18 +130,18 @@ class SplitExprNode : public CanonicalExprNode {
     PrimExpr res = this->index;
     DataType dtype = this->dtype;
     if (this->scale == 0) {
-      return make_const(dtype, 0);
+      return IntImm(dtype, 0);
     }
     if (this->upper_factor != SplitExprNode::kPosInf) {
-      res = ModImpl(res, make_const(dtype, this->upper_factor), div_mode);
+      res = ModImpl(res, MakeConst(dtype, this->upper_factor), div_mode);
     }
     if (this->lower_factor != 1) {
-      res = DivImpl(res, make_const(dtype, this->lower_factor), div_mode);
+      res = DivImpl(res, MakeConst(dtype, this->lower_factor), div_mode);
     }
     sscale *= this->scale;
     if (sscale != 1) {
       TVM_FFI_ICHECK(!dtype.is_uint() || sscale > 0);
-      res = res * make_const(dtype, sscale);
+      res = res * MakeConst(dtype, sscale);
     }
     return res;
   }
@@ -172,20 +172,20 @@ class SplitExprNode : public CanonicalExprNode {
       return false;
     }
     if (this->upper_factor != SplitExprNode::kPosInf) {
-      res = ModImpl(res, make_const(this->dtype, this->upper_factor), div_mode);
+      res = ModImpl(res, MakeConst(this->dtype, this->upper_factor), div_mode);
       if (!CastIsSafe(dtype, res, analyzer)) {
         return false;
       }
     }
     if (this->lower_factor != 1) {
-      res = DivImpl(res, make_const(this->dtype, this->lower_factor), div_mode);
+      res = DivImpl(res, MakeConst(this->dtype, this->lower_factor), div_mode);
       if (!CastIsSafe(dtype, res, analyzer)) {
         return false;
       }
     }
     if (this->scale != 1) {
       TVM_FFI_ICHECK(!this->dtype.is_uint() || this->scale > 0);
-      res = res * make_const(this->dtype, this->scale);
+      res = res * MakeConst(this->dtype, this->scale);
       if (!CastIsSafe(dtype, res, analyzer)) {
         return false;
       }
@@ -252,7 +252,7 @@ class SumExprNode : public CanonicalExprNode {
   PrimExpr Normalize() const final {
     // quick path 1.
     if (this->args.size() == 0) {
-      return make_const(this->dtype, this->base);
+      return MakeConst(this->dtype, this->base);
     }
     return Normalize_(this->dtype, SimplifySplitExprs(args), base);
   }
@@ -344,7 +344,7 @@ class SumExprNode : public CanonicalExprNode {
     if (dtype.bits() >= this->dtype.bits()) {
       return true;  // upcast is safe
     }
-    PrimExpr res = make_const(dtype, 0);
+    PrimExpr res = IntImm(dtype, 0);
     for (size_t i = 0; i < args.size(); ++i) {
       if (args[i]->scale > 0) {
         res = res + args[i]->Normalize();
@@ -354,7 +354,7 @@ class SumExprNode : public CanonicalExprNode {
       }
     }
     if (base > 0 || is_min_value) {
-      res = res + make_const(dtype, base);
+      res = res + MakeConst(dtype, base);
       if (!CastIsSafe(dtype, res, analyzer)) {
         return false;
       }
@@ -369,7 +369,7 @@ class SumExprNode : public CanonicalExprNode {
       }
     }
     if (base < 0 && !is_min_value) {
-      res = res - make_const(dtype, -base);
+      res = res - MakeConst(dtype, -base);
       if (!CastIsSafe(dtype, res, analyzer)) {
         return false;
       }
@@ -500,14 +500,14 @@ class SumExprNode : public CanonicalExprNode {
     bool is_min_value = dtype.bits() == 64 ? base == std::numeric_limits<int64_t>::lowest()
                                            : base == -(1LL << (dtype.bits() - 1));
     // Positive scales first
-    PrimExpr res = make_const(dtype, 0);
+    PrimExpr res = IntImm(dtype, 0);
     for (size_t i = 0; i < args.size(); ++i) {
       if (args[i]->scale > 0) {
         res = res + args[i]->Normalize();
       }
     }
     if (base > 0 || is_min_value) {
-      res = res + make_const(dtype, base);
+      res = res + MakeConst(dtype, base);
     }
     // negative scales follows using sub.
     for (size_t i = 0; i < args.size(); ++i) {
@@ -516,7 +516,7 @@ class SumExprNode : public CanonicalExprNode {
       }
     }
     if (base < 0 && !is_min_value) {
-      res = res - make_const(dtype, -base);
+      res = res - MakeConst(dtype, -base);
     }
     return res;
   }
@@ -834,11 +834,11 @@ SplitExpr CanonicalSimplifier::Impl::SplitDivConst(SplitExpr lhs, int64_t cval, 
       return lhs;
     } else if (lhs->upper_factor <= (lhs->lower_factor * scaled_cval)) {
       // (x % c1) / c2  => 0 when c2 >= c1
-      return ToSplitExpr(make_zero(lhs.dtype()));
+      return ToSplitExpr(IntImm(lhs.dtype(), 0));
     } else {
       // move the upper_factor modular into index.
       lhs.CopyOnWrite()->index =
-          ModImpl(lhs->index, make_const(lhs.dtype(), lhs->upper_factor), div_mode);
+          ModImpl(lhs->index, MakeConst(lhs.dtype(), lhs->upper_factor), div_mode);
       lhs.CopyOnWrite()->upper_factor = SplitExprNode::kPosInf;
       lhs.CopyOnWrite()->scale = 1;
       lhs.CopyOnWrite()->lower_factor *= scaled_cval;
@@ -862,8 +862,8 @@ bool CanonicalSimplifier::Impl::ProdDivSimplify(PrimExpr* plhs, PrimExpr* prhs,
   if (prhs->as<IntImmNode>()) return false;
   // collect lhs products and try to eliminate by matching them to prod in rhs
   ffi::Array<ffi::Optional<PrimExpr>> lhs_prods;
-  PrimExpr new_rhs = make_const(prhs->dtype(), 1);
-  PrimExpr new_common_scale = make_const(prhs->dtype(), 1);
+  PrimExpr new_rhs = MakeConst(prhs->dtype(), 1);
+  PrimExpr new_common_scale = MakeConst(prhs->dtype(), 1);
   int64_t lhs_cscale = 1, rhs_cscale = 1;
   int num_elimination = 0;
 
@@ -905,13 +905,13 @@ bool CanonicalSimplifier::Impl::ProdDivSimplify(PrimExpr* plhs, PrimExpr* prhs,
   if (num_elimination == 0 && cscale_gcd == 1) return false;
 
   // construct prod via canonical form
-  PrimExpr new_lhs = make_const(plhs->dtype(), 1);
+  PrimExpr new_lhs = MakeConst(plhs->dtype(), 1);
   for (ffi::Optional<PrimExpr> val : lhs_prods) {
     if (val.defined()) new_lhs = new_lhs * val.value();
   }
-  *plhs = new_lhs * make_const(plhs->dtype(), lhs_cscale);
-  *prhs = new_rhs * make_const(prhs->dtype(), rhs_cscale);
-  *common_scale = new_common_scale * make_const(prhs->dtype(), cscale_gcd);
+  *plhs = new_lhs * MakeConst(plhs->dtype(), lhs_cscale);
+  *prhs = new_rhs * MakeConst(prhs->dtype(), rhs_cscale);
+  *common_scale = new_common_scale * MakeConst(prhs->dtype(), cscale_gcd);
   return true;
 }
 
@@ -958,7 +958,7 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const DivNode* op) {
       // if a >= 0 && a < cval, then result == 0
       auto cbound = analyzer_->const_int_bound(Normalize(a));
       if (cbound->min_value >= 0 && cbound->max_value < cval) {
-        return make_zero(a.dtype());
+        return IntImm(a.dtype(), 0);
       }
     }
     return SplitDivConst(ToSplitExpr(std::move(a)), cval, kTruncDiv);
@@ -1019,7 +1019,7 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
       // if a >= 0 && a < cval, then result == 0
       auto cbound = analyzer_->const_int_bound(Normalize(a));
       if (cbound->min_value >= 0 && cbound->max_value < cval) {
-        return make_zero(a.dtype());
+        return IntImm(a.dtype(), 0);
       }
     }
     // Identity: floordiv(floormod(index, m*n), n) = floormod(floordiv(index, n), m)
@@ -1049,7 +1049,7 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
             }
             // Apply floormod(floordiv_result, m) to complete the identity
             PrimExpr div_result = Normalize(lhs);
-            return this->VisitExpr(floormod(div_result, make_const(a.dtype(), new_mod)));
+            return this->VisitExpr(floormod(div_result, MakeConst(a.dtype(), new_mod)));
           }
         }
       }
@@ -1096,7 +1096,7 @@ SplitExpr CanonicalSimplifier::Impl::SplitModConst(SplitExpr lhs, int64_t cval, 
       // Do a recursive call to simplify the mod with the new factor.
       if (new_upper_factor < lhs->upper_factor && lhs->upper_factor != SplitExprNode::kPosInf) {
         auto updated = ToSplitExpr(this->VisitExpr(
-            ModImpl(lhs->index, make_const(lhs.dtype(), new_upper_factor), div_mode)));
+            ModImpl(lhs->index, MakeConst(lhs.dtype(), new_upper_factor), div_mode)));
         // re-apply the lower_factor
         if (lhs->lower_factor != 1) {
           auto ret = SplitDivConst(updated, lhs->lower_factor, div_mode);
@@ -1144,7 +1144,7 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const ModNode* op) {
       SumExpr lhs, extra;
       SeparateDivisibleParts(psum, cval, &lhs, &extra);
       if (extra->IsZero()) {
-        return make_zero(a.dtype());
+        return IntImm(a.dtype(), 0);
       }
       // both lhs and extra are non-negative
       if (analyzer_->CanProveGreaterEqual(lhs->Normalize(), 0) &&
@@ -1414,11 +1414,11 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const LTNode* op) {
     DataType dtype = divisible->dtype;
     TVM_FFI_ICHECK(extra->dtype == dtype);
     PrimExpr normal_extra = extra->Normalize();
-    if (this->analyzer_->CanProve(normal_extra < make_const(dtype, gcd)) &&
-        this->analyzer_->CanProve(normal_extra >= make_const(dtype, 0))) {
+    if (this->analyzer_->CanProve(normal_extra < MakeConst(dtype, gcd)) &&
+        this->analyzer_->CanProve(normal_extra >= IntImm(dtype, 0))) {
       // Case 1. 0 <= xn < d
       divisible.CopyOnWrite()->DivideBy(gcd);
-      return Rewriter::VisitExpr(divisible->Normalize() < make_zero(dtype));
+      return Rewriter::VisitExpr(divisible->Normalize() < IntImm(dtype, 0));
     } else if (extra->args.size() == 1 && extra->args[0]->scale == 1 &&
                extra->args[0]->upper_factor != ConstIntBoundNode::kPosInf &&
                extra->args[0]->upper_factor % (gcd * extra->args[0]->lower_factor) == 0) {
@@ -1435,7 +1435,7 @@ PrimExpr CanonicalSimplifier::Impl::VisitExpr_(const LTNode* op) {
       int64_t lower_factor = gcd * extra->args[0]->lower_factor;
       PrimExpr extra_expr = floormod(floordiv(split_expr->index, lower_factor),
                                      floordiv(split_expr->upper_factor, lower_factor));
-      return Rewriter::VisitExpr(divisible->Normalize() + extra_expr < make_zero(dtype));
+      return Rewriter::VisitExpr(divisible->Normalize() + extra_expr < IntImm(dtype, 0));
     }
   }
 

--- a/src/arith/conjunctive_normal_form.cc
+++ b/src/arith/conjunctive_normal_form.cc
@@ -139,16 +139,15 @@ class AndOfOrs {
   /*! \brief Mapping from PrimExpr to internal Key */
   std::unordered_map<PrimExpr, Key, ffi::StructuralHash, ffi::StructuralEqual> expr_to_key_;
 
-  /*! \brief Cached key representing tirx::IntImm(DataType::Bool(), 1) */
+  /*! \brief Cached key representing IntImm::Bool(true) */
   Key key_true_;
 
-  /*! \brief Cached key representing tirx::IntImm(DataType::Bool(), 0) */
+  /*! \brief Cached key representing IntImm::Bool(false) */
   Key key_false_;
 };
 
 AndOfOrs::AndOfOrs(const PrimExpr& expr)
-    : key_true_(GetKey(IntImm(DataType::Bool(), 1))),
-      key_false_(GetKey(IntImm(DataType::Bool(), 0))) {
+    : key_true_(GetKey(IntImm::Bool(true))), key_false_(GetKey(IntImm::Bool(false))) {
   VisitAndExpressions(expr, [&](const PrimExpr& outer_expr) {
     std::vector<Key> or_components;
     VisitOrExpressions(outer_expr, [&](const PrimExpr& inner_expr) {
@@ -235,9 +234,9 @@ PrimExpr AndOfOrs::GetExpr(AndOfOrs::Key key) const {
 }
 
 PrimExpr AndOfOrs::AsPrimExpr() const {
-  PrimExpr expr = IntImm(DataType::Bool(), 1);
+  PrimExpr expr = IntImm::Bool(true);
   for (const auto& chunk : chunks_) {
-    PrimExpr chunk_expr = IntImm(DataType::Bool(), 0);
+    PrimExpr chunk_expr = IntImm::Bool(false);
     for (Key j : chunk) {
       chunk_expr = chunk_expr || GetExpr(j);
     }
@@ -368,7 +367,7 @@ void AndOfOrs::SimplifyAcrossChunks(AnalyzerObj* analyzer) {
           // When attempting to simplify (B and C), the analyzer may
           // assume that A is false.
           PrimExpr known = [&]() {
-            PrimExpr known = IntImm(DataType::Bool(), 1);
+            PrimExpr known = IntImm::Bool(true);
             for (const auto& key : i_chunk) {
               if (&key != &key_i) {
                 known = known && analyzer->Simplify(!GetExpr(key));

--- a/src/arith/const_fold.h
+++ b/src/arith/const_fold.h
@@ -263,7 +263,8 @@ inline ffi::Optional<PrimExpr> TryConstFold<tirx::Mod>(PrimExpr a, PrimExpr b) {
       if (pa->value == 0) return a;
     }
     if (pb) {
-      if (pb->value == 1) return tirx::make_zero(rtype);
+      // MakeConst can handle both vector and scalar types.
+      if (pb->value == 1) return tirx::MakeConst(rtype, 0);
       TVM_FFI_ICHECK_NE(pb->value, 0) << "Divide by zero";
     }
   });
@@ -318,7 +319,8 @@ inline ffi::Optional<PrimExpr> TryConstFold<tirx::FloorMod>(PrimExpr a, PrimExpr
       if (pa->value == 0) return a;
     }
     if (pb) {
-      if (pb->value == 1) return tirx::make_zero(rtype);
+      // MakeConst can handle both vector and scalar types.
+      if (pb->value == 1) return tirx::MakeConst(rtype, 0);
       TVM_FFI_ICHECK_NE(pb->value, 0) << "Divide by zero";
     }
   });
@@ -350,8 +352,8 @@ inline ffi::Optional<PrimExpr> TryConstFold<tirx::Max>(PrimExpr a, PrimExpr b) {
 template <>
 inline ffi::Optional<PrimExpr> TryConstFold<tirx::GT>(PrimExpr a, PrimExpr b) {
   TVM_ARITH_CONST_PROPAGATION({
-    if (pa && pb) return IntImm(DataType::Bool(), pa->value > pb->value);
-    if (fa && fb) return IntImm(DataType::Bool(), fa->value > fb->value);
+    if (pa && pb) return IntImm::Bool(pa->value > pb->value);
+    if (fa && fb) return IntImm::Bool(fa->value > fb->value);
   });
   return std::nullopt;
 }
@@ -359,8 +361,8 @@ inline ffi::Optional<PrimExpr> TryConstFold<tirx::GT>(PrimExpr a, PrimExpr b) {
 template <>
 inline ffi::Optional<PrimExpr> TryConstFold<tirx::GE>(PrimExpr a, PrimExpr b) {
   TVM_ARITH_CONST_PROPAGATION({
-    if (pa && pb) return IntImm(DataType::Bool(), pa->value >= pb->value);
-    if (fa && fb) return IntImm(DataType::Bool(), fa->value >= fb->value);
+    if (pa && pb) return IntImm::Bool(pa->value >= pb->value);
+    if (fa && fb) return IntImm::Bool(fa->value >= fb->value);
   });
   return std::nullopt;
 }
@@ -368,8 +370,8 @@ inline ffi::Optional<PrimExpr> TryConstFold<tirx::GE>(PrimExpr a, PrimExpr b) {
 template <>
 inline ffi::Optional<PrimExpr> TryConstFold<tirx::LT>(PrimExpr a, PrimExpr b) {
   TVM_ARITH_CONST_PROPAGATION({
-    if (pa && pb) return IntImm(DataType::Bool(), pa->value < pb->value);
-    if (fa && fb) return IntImm(DataType::Bool(), fa->value < fb->value);
+    if (pa && pb) return IntImm::Bool(pa->value < pb->value);
+    if (fa && fb) return IntImm::Bool(fa->value < fb->value);
   });
   return std::nullopt;
 }
@@ -377,8 +379,8 @@ inline ffi::Optional<PrimExpr> TryConstFold<tirx::LT>(PrimExpr a, PrimExpr b) {
 template <>
 inline ffi::Optional<PrimExpr> TryConstFold<tirx::LE>(PrimExpr a, PrimExpr b) {
   TVM_ARITH_CONST_PROPAGATION({
-    if (pa && pb) return IntImm(DataType::Bool(), pa->value <= pb->value);
-    if (fa && fb) return IntImm(DataType::Bool(), fa->value <= fb->value);
+    if (pa && pb) return IntImm::Bool(pa->value <= pb->value);
+    if (fa && fb) return IntImm::Bool(fa->value <= fb->value);
   });
   return std::nullopt;
 }
@@ -386,8 +388,8 @@ inline ffi::Optional<PrimExpr> TryConstFold<tirx::LE>(PrimExpr a, PrimExpr b) {
 template <>
 inline ffi::Optional<PrimExpr> TryConstFold<tirx::EQ>(PrimExpr a, PrimExpr b) {
   TVM_ARITH_CONST_PROPAGATION({
-    if (pa && pb) return IntImm(DataType::Bool(), pa->value == pb->value);
-    if (fa && fb) return IntImm(DataType::Bool(), fa->value == fb->value);
+    if (pa && pb) return IntImm::Bool(pa->value == pb->value);
+    if (fa && fb) return IntImm::Bool(fa->value == fb->value);
   });
   return std::nullopt;
 }
@@ -395,8 +397,8 @@ inline ffi::Optional<PrimExpr> TryConstFold<tirx::EQ>(PrimExpr a, PrimExpr b) {
 template <>
 inline ffi::Optional<PrimExpr> TryConstFold<tirx::NE>(PrimExpr a, PrimExpr b) {
   TVM_ARITH_CONST_PROPAGATION({
-    if (pa && pb) return IntImm(DataType::Bool(), pa->value != pb->value);
-    if (fa && fb) return IntImm(DataType::Bool(), fa->value != fb->value);
+    if (pa && pb) return IntImm::Bool(pa->value != pb->value);
+    if (fa && fb) return IntImm::Bool(fa->value != fb->value);
   });
   return std::nullopt;
 }
@@ -427,7 +429,7 @@ template <>
 inline ffi::Optional<PrimExpr> TryConstFold<tirx::Not>(PrimExpr a) {
   const IntImmNode* pa = a.as<IntImmNode>();
   if (pa) {
-    return IntImm(DataType::Bool(), !(pa->value));
+    return IntImm::Bool(!(pa->value));
   }
   return std::nullopt;
 }

--- a/src/arith/detect_linear_equation.cc
+++ b/src/arith/detect_linear_equation.cc
@@ -54,10 +54,10 @@ class LinearEqDetector : public ExprFunctor<LinearEqEntry(const PrimExpr&, const
     *ret = VisitExpr(e, e);
     if (fail_) return false;
     if (!ret->base.defined()) {
-      ret->base = make_zero(var_.dtype());
+      ret->base = IntImm(var_.dtype(), 0);
     }
     if (!ret->coeff.defined()) {
-      ret->coeff = make_zero(var_.dtype());
+      ret->coeff = IntImm(var_.dtype(), 0);
     }
     return true;
   }
@@ -102,7 +102,7 @@ class LinearEqDetector : public ExprFunctor<LinearEqEntry(const PrimExpr&, const
     LinearEqEntry ret;
     if (op == var_.get()) {
       auto dtype = op->dtype;
-      ret.coeff = make_const(DataType::Int(dtype.bits(), dtype.lanes()), 1);
+      ret.coeff = MakeConst(DataType::Int(dtype.bits(), dtype.lanes()), 1);
     } else {
       ret.base = e;
     }
@@ -195,13 +195,13 @@ bool DetectClipBound(const PrimExpr& cond,
   PrimExpr canonical;
   if (const LTNode* op = cond.as<LTNode>()) {
     if (!op->a.dtype().is_int()) return false;
-    canonical = op->b - op->a - make_const(op->a.dtype(), 1);
+    canonical = op->b - op->a - MakeConst(op->a.dtype(), 1);
   } else if (const LENode* op = cond.as<LENode>()) {
     if (!op->a.dtype().is_int()) return false;
     canonical = op->b - op->a;
   } else if (const GTNode* op = cond.as<GTNode>()) {
     if (!op->a.dtype().is_int()) return false;
-    canonical = op->a - op->b - make_const(op->a.dtype(), 1);
+    canonical = op->a - op->b - MakeConst(op->a.dtype(), 1);
   } else if (const GENode* op = cond.as<GENode>()) {
     if (!op->a.dtype().is_int()) return false;
     canonical = op->a - op->b;

--- a/src/arith/int_constraints.cc
+++ b/src/arith/int_constraints.cc
@@ -86,7 +86,7 @@ IntGroupBounds::IntGroupBounds(PrimExpr coef, ffi::Array<PrimExpr> lower,
 
 IntGroupBounds IntGroupBounds::FromRange(const Range& r) {
   Analyzer analyzer;
-  PrimExpr coef = tirx::make_const(r->min.dtype(), 1);
+  PrimExpr coef = tirx::MakeConst(r->min.dtype(), 1);
   ffi::Array<PrimExpr> equal;
   ffi::Array<PrimExpr> lower;
   ffi::Array<PrimExpr> upper;

--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -46,8 +46,7 @@ namespace arith {
 
 using tirx::is_one;
 using tirx::is_zero;
-using tirx::make_const;
-using tirx::make_zero;
+using tirx::MakeConst;
 
 TVM_FFI_STATIC_INIT_BLOCK() { IntervalSetNode::RegisterReflection(); }
 
@@ -133,7 +132,7 @@ inline IntervalSet Combine(AnalyzerObj* analyzer, IntervalSet a, IntervalSet b, 
     return IntervalSet::SinglePoint(expr);
   }
   if (is_logical_op<Op>::value) {
-    return IntervalSet(make_const(dtype, 0), make_const(dtype, 1));
+    return IntervalSet(IntImm(dtype, 0), IntImm(dtype, 1));
   }
   if (a->IsEmpty()) return a;
   if (b->IsEmpty()) return b;
@@ -196,7 +195,7 @@ inline IntervalSet Combine<tirx::Mul>(AnalyzerObj* analyzer, IntervalSet a, Inte
       return IntervalSet(min_value, max_value);
     } else if (a->HasUpperBound() && a->HasLowerBound()) {
       using tirx::Select;
-      PrimExpr sign = b->min_value >= make_zero(b->min_value.dtype().element_of());
+      PrimExpr sign = b->min_value >= IntImm(b->min_value.dtype().element_of(), 0);
       PrimExpr e1 = a->min_value * b->min_value;
       PrimExpr e2 = a->max_value * b->min_value;
       return IntervalSet(Select(sign, e1, e2), Select(sign, e2, e1));
@@ -230,7 +229,7 @@ inline IntervalSet Combine<tirx::Div>(AnalyzerObj* analyzer, IntervalSet a, Inte
       return IntervalSet(min_value, max_value);
     } else if (a->HasUpperBound() && a->HasLowerBound()) {
       using tirx::Select;
-      PrimExpr sign = b->min_value >= make_zero(b->min_value.dtype().element_of());
+      PrimExpr sign = b->min_value >= IntImm(b->min_value.dtype().element_of(), 0);
       PrimExpr e1 = a->min_value / b->min_value;
       PrimExpr e2 = a->max_value / b->min_value;
       return IntervalSet(Select(sign, e1, e2), Select(sign, e2, e1));
@@ -259,7 +258,7 @@ inline IntervalSet Combine<tirx::Mod>(AnalyzerObj* analyzer, IntervalSet a, Inte
     // is the case of our application.
     // TODO(tqchen): add bound constraints for a.
     if (analyzer->CanProveGreaterEqual(divisor, 0)) {
-      return IntervalSet(make_zero(divisor.dtype()), divisor - 1);
+      return IntervalSet(IntImm(divisor.dtype(), 0), divisor - 1);
     } else {
       PrimExpr bound = abs(divisor) - 1;
       return IntervalSet(-bound, bound);
@@ -293,7 +292,7 @@ inline IntervalSet Combine<tirx::FloorDiv>(AnalyzerObj* analyzer, IntervalSet a,
       return IntervalSet(min_value, max_value);
     } else if (a->HasUpperBound() && a->HasLowerBound()) {
       using tirx::Select;
-      PrimExpr sign = b->min_value >= make_zero(b->min_value.dtype().element_of());
+      PrimExpr sign = b->min_value >= IntImm(b->min_value.dtype().element_of(), 0);
       PrimExpr e1 = floordiv(a->min_value, b->min_value);
       PrimExpr e2 = floordiv(a->max_value, b->min_value);
       return IntervalSet(Select(sign, e1, e2), Select(sign, e2, e1));
@@ -349,12 +348,12 @@ inline IntervalSet Combine<tirx::FloorMod>(AnalyzerObj* analyzer, IntervalSet a,
             int64_t max_mod_result = max_quotient * gcd + (dividend_mod->base % gcd);
 
             if (max_mod_result >= 0 && max_mod_result < div_val) {
-              return IntervalSet(make_zero(op->dtype), make_const(op->dtype, max_mod_result));
+              return IntervalSet(IntImm(op->dtype, 0), IntImm(op->dtype, max_mod_result));
             }
           }
         }
       }
-      return IntervalSet(make_zero(divisor.dtype()), divisor - 1);
+      return IntervalSet(IntImm(divisor.dtype(), 0), divisor - 1);
     } else {
       PrimExpr bound = abs(divisor) - 1;
       return IntervalSet(-bound, bound);
@@ -528,25 +527,25 @@ class IntervalSetEvaluator : public ExprFunctor<IntervalSet(const PrimExpr&)> {
       if (op->lanes->IsInstance<IntImmNode>()) {
         int lanes = static_cast<int>(Downcast<IntImm>(op->lanes)->value);
         if (vstride > 0) {
-          PrimExpr stride_expr = make_const(t, vstride * (lanes - 1));
+          PrimExpr stride_expr = MakeConst(t, vstride * (lanes - 1));
           auto add_op = tirx::Add(op->base, stride_expr);
           auto add_node = add_op.as<tirx::AddNode>();
-          return Combine<Add>(analyzer_, base, IntervalSet(make_zero(t), stride_expr), add_node);
+          return Combine<Add>(analyzer_, base, IntervalSet(IntImm(t, 0), stride_expr), add_node);
         } else {
-          PrimExpr stride_expr = make_const(t, vstride * (lanes - 1));
+          PrimExpr stride_expr = MakeConst(t, vstride * (lanes - 1));
           auto add_op = tirx::Add(op->base, stride_expr);
           auto add_node = add_op.as<tirx::AddNode>();
-          return Combine<Add>(analyzer_, base, IntervalSet(stride_expr, make_zero(t)), add_node);
+          return Combine<Add>(analyzer_, base, IntervalSet(stride_expr, IntImm(t, 0)), add_node);
         }
       } else { /* Scalable vector */
         if (vstride > 0) {
-          auto add_op = tirx::Add(op->base, make_zero(t));
+          auto add_op = tirx::Add(op->base, IntImm(t, 0));
           auto add_node = add_op.as<tirx::AddNode>();
-          return Combine<Add>(analyzer_, base, IntervalSet(make_zero(t), pos_inf()), add_node);
+          return Combine<Add>(analyzer_, base, IntervalSet(IntImm(t, 0), pos_inf()), add_node);
         } else {
-          auto add_op = tirx::Add(op->base, make_zero(t));
+          auto add_op = tirx::Add(op->base, IntImm(t, 0));
           auto add_node = add_op.as<tirx::AddNode>();
-          return Combine<Add>(analyzer_, base, IntervalSet(neg_inf(), make_zero(t)), add_node);
+          return Combine<Add>(analyzer_, base, IntervalSet(neg_inf(), IntImm(t, 0)), add_node);
         }
       }
     }

--- a/src/arith/ir_mutator_with_analyzer.cc
+++ b/src/arith/ir_mutator_with_analyzer.cc
@@ -55,10 +55,10 @@ void AppendFloorDivConstraints(const FloorDivNode* div, int64_t value, CompareKi
   if (!TryGetIntImm(div->b, &divisor_value) || divisor_value <= 0) return;
 
   DataType dtype = div->a.dtype();
-  PrimExpr divisor = make_const(dtype, divisor_value);
-  PrimExpr k = make_const(dtype, value);
+  PrimExpr divisor = MakeConst(dtype, divisor_value);
+  PrimExpr k = MakeConst(dtype, value);
   PrimExpr lo = k * divisor;
-  PrimExpr hi = (k + make_const(dtype, 1)) * divisor;
+  PrimExpr hi = (k + MakeConst(dtype, 1)) * divisor;
 
   switch (kind) {
     case CompareKind::kEQ:
@@ -160,7 +160,7 @@ void IRMutatorWithAnalyzer::MarkBufferMapShapes(const tirx::PrimFunc& func) {
 
 ffi::Array<PrimExpr> IRMutatorWithAnalyzer::IterMapSimplifyWithContext(
     const ffi::Array<PrimExpr>& indices, bool non_trivial_only) {
-  PrimExpr pred = const_true();
+  PrimExpr pred = IntImm::Bool(true);
   for (PrimExpr val : iter_predicates_) {
     pred = pred && val;
   }
@@ -260,7 +260,7 @@ Stmt IRMutatorWithAnalyzer::VisitStmt_(const AttrStmtNode* op) {
     if (op->attr_key == tirx::attr::thread_extent || op->attr_key == s_tir::attr::virtual_thread) {
       IterVar iv = Downcast<IterVar>(op->node);
       TVM_FFI_ICHECK_NE(iv->thread_tag.length(), 0U);
-      Range dom = Range::FromMinExtent(make_zero(op->value.dtype()), op->value);
+      Range dom = Range::FromMinExtent(IntImm(op->value.dtype(), 0), op->value);
       analyzer_->Bind(iv->var, dom);
       iter_vars_.Set(iv->var, dom);
     }

--- a/src/arith/iter_affine_map.cc
+++ b/src/arith/iter_affine_map.cc
@@ -66,7 +66,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
 IterSplitExpr::IterSplitExpr(IterMark source) {
   auto n = ffi::make_object<IterSplitExprNode>();
-  auto one = make_const(source->source->dtype, 1);
+  auto one = MakeConst(source->source->dtype, 1);
   n->dtype = source->source->dtype;
   n->source = std::move(source);
   n->extent = n->source->extent;
@@ -77,7 +77,7 @@ IterSplitExpr::IterSplitExpr(IterMark source) {
 
 IterSplitExpr::IterSplitExpr(IterMark source, PrimExpr scale) {
   auto n = ffi::make_object<IterSplitExprNode>();
-  auto one = make_const(source->source->dtype, 1);
+  auto one = MakeConst(source->source->dtype, 1);
   n->dtype = source->source->dtype;
   n->source = std::move(source);
   n->extent = n->source->extent;
@@ -180,7 +180,7 @@ class IterMapRewriter : public ExprMutator {
       : analyzer_(analyzer),
         check_level_(check_level),
         errors_(*errors),
-        padding_predicate_(const_false()) {
+        padding_predicate_(IntImm::Bool(false)) {
     for (auto kv : input_iters) {
       const Var& var = kv.first;
       const Range& vrng = kv.second;
@@ -563,7 +563,7 @@ class IterMapRewriter : public ExprMutator {
                                                IterMapLevel check_level) {
     std::vector<bool> used(splits.size(), false);
     std::vector<IterSplitExpr> iters;
-    PrimExpr expected_lower_factor = make_const(mark->source->dtype, 1);
+    PrimExpr expected_lower_factor = MakeConst(mark->source->dtype, 1);
 
     for (size_t i = 0; i < splits.size(); ++i) {
       size_t j = 0;
@@ -694,7 +694,7 @@ class IterMapRewriter : public ExprMutator {
       PrimExpr iter_min = mark_offset;
       PrimExpr iter_max = iter_min + mark->extent;
       // the delta of iter_min when it is updated when the lower bound predicate is present
-      PrimExpr iter_min_delta = make_const(iter_min.dtype(), 0);
+      PrimExpr iter_min_delta = IntImm(iter_min.dtype(), 0);
       if (predicate_induced_min.defined()) {
         iter_min_delta = max(predicate_induced_min.value(), iter_min) - iter_min;
         iter_min = max(predicate_induced_min.value(), iter_min);
@@ -788,7 +788,7 @@ class IterMapRewriter : public ExprMutator {
     for (IterSplitExpr split : expr->args) {
       int64_t symbol_prod_count = 0;
       int64_t cscale = 1;
-      PrimExpr res = tirx::make_const(split.dtype(), 1);
+      PrimExpr res = tirx::MakeConst(split.dtype(), 1);
       auto fcollect = [&](PrimExpr val) {
         if (const auto* intimm = val.as<IntImmNode>()) {
           cscale *= intimm->value;
@@ -799,7 +799,7 @@ class IterMapRewriter : public ExprMutator {
       };
       UnpackReduction<tirx::MulNode>(split->scale, fcollect);
       if (cscale != 1) {
-        res = res * tirx::make_const(res.dtype(), cscale);
+        res = res * tirx::MakeConst(res.dtype(), cscale);
       }
       split.CopyOnWrite()->scale = res;
       items.emplace_back(Item{cscale, symbol_prod_count, split});
@@ -830,7 +830,7 @@ class IterMapRewriter : public ExprMutator {
     if (auto op = expr.as<IterSumExpr>()) {
       return op.value();
     } else if (auto op = expr.as<IterSplitExpr>()) {
-      return IterSumExpr({op.value()}, make_zero(expr->dtype));
+      return IterSumExpr({op.value()}, IntImm(expr->dtype, 0));
     } else {
       TVM_FFI_ICHECK(!expr->IsInstance<IterMapExprNode>());
       return IterSumExpr({}, expr);
@@ -1103,8 +1103,8 @@ class IterMapRewriter : public ExprMutator {
     std::vector<IterSplitExpr> flattened_iters, grouped_iters;
 
     // check if it can be remapped into a fused pattern.
-    PrimExpr expected_extra_base = make_const(expr.dtype(), 0);
-    PrimExpr tail_extent = make_const(expr.dtype(), 0);
+    PrimExpr expected_extra_base = IntImm(expr.dtype(), 0);
+    PrimExpr tail_extent = IntImm(expr.dtype(), 0);
     PrimExpr expected_scale = base_scale;
     int first_possible_unit_extent_pos = FindFirstPossibleUnitExtentIndex(expr);
 
@@ -1200,10 +1200,10 @@ class IterMapRewriter : public ExprMutator {
     IterSumExpr structured_form = expr, flattened_form = expr;
     flattened_form.CopyOnWrite()->args =
         ffi::Array<IterSplitExpr>(flattened_iters.rbegin(), flattened_iters.rend());
-    flattened_form.CopyOnWrite()->base = make_const(expr.dtype(), 0);
+    flattened_form.CopyOnWrite()->base = IntImm(expr.dtype(), 0);
     structured_form.CopyOnWrite()->args =
         ffi::Array<IterSplitExpr>(grouped_iters.rbegin(), grouped_iters.rend());
-    structured_form.CopyOnWrite()->base = make_const(expr.dtype(), 0);
+    structured_form.CopyOnWrite()->base = IntImm(expr.dtype(), 0);
     auto it = sum_fuse_map_.find(flattened_form);
     if (it != sum_fuse_map_.end()) {
       // old iter
@@ -1245,7 +1245,7 @@ class IterMapRewriter : public ExprMutator {
     if (sign > 0) {
       lhs->args.push_back(rhs);
     } else {
-      rhs.CopyOnWrite()->scale = make_zero(rhs->scale.dtype()) - rhs->scale;
+      rhs.CopyOnWrite()->scale = IntImm(rhs->scale.dtype(), 0) - rhs->scale;
       lhs->args.push_back(rhs);
     }
   }
@@ -1677,7 +1677,7 @@ PrimExpr IterMapRewriter::VisitExpr_(const MulNode* op) {
 IterSumExpr IterMapRewriter::PreprocessDividend(IterMapExpr dividend, PrimExpr original_dividend) {
   if (dividend->IsInstance<IterSplitExprNode>()) {
     auto split = Downcast<IterSplitExpr>(dividend);
-    return IterSumExpr({split}, make_zero(split.dtype()));
+    return IterSumExpr({split}, IntImm(split.dtype(), 0));
   } else if (dividend->IsInstance<IterSumExprNode>()) {
     auto sum = Downcast<IterSumExpr>(dividend);
     if (sum->args.empty()) {
@@ -1715,7 +1715,7 @@ PrimExpr ApproxLeastCommonMultiple(const PrimExpr& a, const PrimExpr& b, Analyze
   };
   auto p1 = fsplit(a);
   auto p2 = fsplit(b);
-  auto const_lcm = IntImm(DataType::Int(32), LeastCommonMultiple(p1.second, p2.second));
+  auto const_lcm = IntImm::Int32(LeastCommonMultiple(p1.second, p2.second));
   if (analyzer->CanProveEqual(p1.first, p2.first)) {
     return p1.first * const_lcm;
   } else if (analyzer->CanProveEqual(floormod(p1.first, p2.first), 0)) {
@@ -1880,12 +1880,12 @@ PrimExpr IterMapRewriter::SplitFloorDivConst(IterSplitExpr lhs, PrimExpr base, P
     } else if (CanProveDivisible(rhs, lhs->scale) && is_zero(base)) {
       // floordiv(x*c1, c1*c2) = floordiv(x, c2), c2=rhs/scale
       rhs = floordiv(rhs, lhs->scale);
-      lhs.CopyOnWrite()->scale = make_const(rhs->dtype, 1);
+      lhs.CopyOnWrite()->scale = MakeConst(rhs->dtype, 1);
     } else if (CanProveDivisible(rhs, lhs->scale) && CanProveDivisible(base, lhs->scale)) {
       // floordiv(x*c1 + y*c1, c1*c2) = floordiv(x+y, c2), c2=rhs/scale
       base = floordiv(base, lhs->scale);
       rhs = floordiv(rhs, lhs->scale);
-      lhs.CopyOnWrite()->scale = make_const(rhs->dtype, 1);
+      lhs.CopyOnWrite()->scale = MakeConst(rhs->dtype, 1);
     } else {
       // mark as unresolved.
       ErrorLogger(this) << "Cannot represent as IterMap: the numerator's scaling factor, "
@@ -1931,7 +1931,7 @@ PrimExpr IterMapRewriter::SplitFloorDivConst(IterSplitExpr lhs, PrimExpr base, P
     new_split = IterSplitExpr(IterMark(padded, padded->extent),
                               /* lower_factor = */ rhs,
                               /* extent = */ analyzer_->Simplify(ceildiv(padded->extent, rhs)),
-                              /* scale = */ make_const(rhs->dtype, 1));
+                              /* scale = */ MakeConst(rhs->dtype, 1));
   }
 
   auto new_base = analyzer_->Simplify(floordiv(base - left_pad, rhs), 6);
@@ -1987,13 +1987,13 @@ PrimExpr IterMapRewriter::SplitFloorModConst(IterSplitExpr lhs, PrimExpr base, P
 
   if (is_one(rhs)) {
     // floormod(x, 1) = 0
-    return make_zero(lhs->dtype);
+    return IntImm(lhs->dtype, 0);
   }
 
   if (!is_one(lhs->scale)) {
     if (CanProveDivisible(lhs->scale, rhs) && CanProveDivisible(base, rhs)) {
       // floormod(x*c1*c2, c1) = 0
-      return make_zero(lhs->dtype);
+      return IntImm(lhs->dtype, 0);
     } else if (CanProveDivisible(rhs, lhs->scale) && is_zero(base)) {
       // floormod(x*c1, c1*c2) = (floormod(x, c2)) * c1, where c2 = rhs/scale
       rhs = floordiv(rhs, lhs->scale);
@@ -2113,7 +2113,7 @@ class IterMapToExprNormalizer : public ExprMutator {
       // simplify trivial iters like `vi \in [0, 1)`, which can be useful for subsequent analysis
       // like tensorization.
       if (is_one(expr->extent) && !is_one(expr->source->extent)) {
-        return make_const(expr->extent->dtype, 0);
+        return IntImm(expr->extent->dtype, 0);
       }
       return floordiv(source, expr->lower_factor) * expr->scale;
     } else {
@@ -2168,7 +2168,7 @@ ffi::Array<PrimExpr> IterMapSimplify(const ffi::Array<PrimExpr>& indices,
     // The input predicate may cause detect iter map to fail
     // but we can still detect the iter map without the input predicate
     // in which case the resulting iter map is valid and can be used for simplification.
-    rewrite = DetectIterMap(indices, input_iters, const_true(), check_level, ana,
+    rewrite = DetectIterMap(indices, input_iters, IntImm::Bool(true), check_level, ana,
                             /*simplify_trivial_iterators=*/simplify_trivial_iterators)
                   ->indices;
   }
@@ -2256,14 +2256,14 @@ class SubspaceDivider {
 
     static DivisionResult Inner(const IterMapExpr& iter, const PrimExpr& extent) {
       auto dtype = iter.dtype();
-      return DivisionResult(IterSumExpr({}, make_const(dtype, 0)), make_const(dtype, 1), iter,
-                            extent, Kind::kInner);
+      return DivisionResult(IterSumExpr({}, IntImm(dtype, 0)), IntImm(dtype, 1), iter, extent,
+                            Kind::kInner);
     }
 
     static DivisionResult Outer(const IterMapExpr& iter, const PrimExpr& extent) {
       auto dtype = iter.dtype();
-      return DivisionResult(iter, extent, IterSumExpr({}, make_const(dtype, 0)),
-                            make_const(dtype, 1), Kind::kOuter);
+      return DivisionResult(iter, extent, IterSumExpr({}, IntImm(dtype, 0)), IntImm(dtype, 1),
+                            Kind::kOuter);
     }
 
     // Special value to indicate the division is not possible
@@ -2288,8 +2288,8 @@ class SubspaceDivider {
     auto dtype = expr.dtype();
     if (expr->args.empty()) {
       // base
-      return DivisionResult(IterSumExpr({}, make_const(dtype, 0)), make_const(dtype, 1),
-                            IterSumExpr({}, expr->base), make_const(dtype, 1));
+      return DivisionResult(IterSumExpr({}, IntImm(dtype, 0)), IntImm(dtype, 1),
+                            IterSumExpr({}, expr->base), IntImm(dtype, 1));
     } else if (expr->args.size() == 1) {
       // arg + base, if arg=Y*E(X)+X, then arg+base = Y*E(X)+(X+base)
       if (!is_one(expr->args[0]->scale)) {
@@ -2303,7 +2303,7 @@ class SubspaceDivider {
     // arg1 + arg2 + ... + argn + base
     // then we can write it as Y*E(X)+X
     // if it starts with contiguous outer splits, followed by contiguous inner splits
-    PrimExpr extent = make_const(dtype, 1);
+    PrimExpr extent = IntImm(dtype, 1);
     std::vector<IterSplitExpr> outer_args, inner_args;
     bool inner = true, scale_is_one = false;
     // we check in inverse order so we can visit from inner to outer
@@ -2335,7 +2335,7 @@ class SubspaceDivider {
       return DivisionResult::Failure();
     }
     bool need_predicate = !analyzer_->CanProveEqual(extent, mark_extent);
-    const IterMark& outer_mark = MarkFromArgsAndBase(outer_args, make_const(dtype, 0));
+    const IterMark& outer_mark = MarkFromArgsAndBase(outer_args, IntImm(dtype, 0));
     const IterMark& inner_mark = MarkFromArgsAndBase(inner_args, expr->base);
     IterSumExpr outer_source = Downcast<IterSumExpr>(outer_mark->source);
     IterSumExpr inner_source = Downcast<IterSumExpr>(inner_mark->source);
@@ -2377,7 +2377,7 @@ class SubspaceDivider {
   // args are sorted from inner to outer
   static IterMark MarkFromArgsAndBase(const std::vector<IterSplitExpr>& args, PrimExpr base) {
     std::vector<IterSplitExpr> res;
-    PrimExpr extent = make_const(base.dtype(), 1);
+    PrimExpr extent = MakeConst(base.dtype(), 1);
     for (const IterSplitExpr& it : args) {
       IterSplitExpr arg = it;
       arg.CopyOnWrite()->scale = extent;
@@ -2429,7 +2429,7 @@ class SubspaceDivider {
       bool encountered_boundary = mark_division.IsOuter();
       std::vector<bool> used(splits.size(), false);
       std::vector<IterSplitExpr> inner_iters, outer_iters;
-      PrimExpr expected_lower_factor = make_const(expr->source->source->dtype, 1);
+      PrimExpr expected_lower_factor = MakeConst(expr->source->source->dtype, 1);
       // find the boundary of outer and inner, like case 1 above
       for (size_t i = 0; i < splits.size(); ++i) {
         size_t j = 0;
@@ -2485,7 +2485,7 @@ class SubspaceDivider {
   std::unordered_map<IterSplitExpr, DivisionResult, ffi::ObjectPtrHash, ffi::ObjectPtrEqual>
       split_map_;
   // predicate of outer space and inner space;
-  PrimExpr outer_preds_{const_true()}, inner_preds_{const_true()};
+  PrimExpr outer_preds_{IntImm::Bool(true)}, inner_preds_{IntImm::Bool(true)};
 };
 
 ffi::Array<ffi::Array<IterMark>> SubspaceDivide(const ffi::Array<PrimExpr>& bindings,
@@ -2547,7 +2547,7 @@ class InverseAffineIterMapTransformer {
 
     // initialize back propagation accumulator
     for (const IterMapExprNode* node : post_dfs_order) {
-      backprop_.Set(ffi::GetRef<IterMapExpr>(node), IntImm(DataType::Int(32), 0));
+      backprop_.Set(ffi::GetRef<IterMapExpr>(node), IntImm::Int32(0));
     }
     for (size_t i = 0; i < iter_map.size(); i++) {
       backprop_.Set(iter_map[i], outputs[i]);

--- a/src/arith/modular_set.cc
+++ b/src/arith/modular_set.cc
@@ -303,7 +303,7 @@ class ModularSetAnalyzer::Impl : public ExprFunctor<ModularSetAnalyzer::Entry(co
     Entry b = VisitExpr(op->args[1]);
     if (b.is_const()) {
       int shift;
-      if (is_const_power_of_two_integer(IntImm(DataType::Int(32), b.base + 1), &shift)) {
+      if (is_const_power_of_two_integer(IntImm::Int32(b.base + 1), &shift)) {
         return ModByConst(op->args[0], static_cast<int64_t>(1) << shift, true);
       }
     }

--- a/src/arith/pattern_match.h
+++ b/src/arith/pattern_match.h
@@ -377,7 +377,7 @@ class PConstWithTypeLike : public Pattern<PConstWithTypeLike<TA>> {
     }
   }
 
-  PrimExpr Eval() const { return tirx::make_const(ref_.Eval().dtype(), value_); }
+  PrimExpr Eval() const { return tirx::MakeConst(ref_.Eval().dtype(), value_); }
 
  private:
   typename TA::Nested ref_;

--- a/src/arith/presburger_set.cc
+++ b/src/arith/presburger_set.cc
@@ -126,11 +126,11 @@ void PresburgerSetNode::UpdateConstraint(const PrimExpr& constraint, const ffi::
 }
 
 PrimExpr PresburgerSetNode::GenerateConstraint() const {
-  PrimExpr constraint = const_false();
+  PrimExpr constraint = IntImm::Bool(false);
   for (const IntegerRelation& disjunct : disjuncts) {
-    PrimExpr union_entry = const_true();
+    PrimExpr union_entry = IntImm::Bool(true);
     for (unsigned i = 0, e = disjunct.getNumEqualities(); i < e; ++i) {
-      PrimExpr linear_eq = IntImm(DataType::Int(64), 0);
+      PrimExpr linear_eq = IntImm::Int64(0);
       if (disjunct.getNumCols() > 1) {
         for (unsigned j = 0, f = disjunct.getNumCols() - 1; j < f; ++j) {
 #if TVM_MLIR_VERSION >= 160
@@ -139,9 +139,9 @@ PrimExpr PresburgerSetNode::GenerateConstraint() const {
           auto coeff = disjunct.atEq(i, j);
 #endif
           if (coeff >= 0 || is_zero(linear_eq)) {
-            linear_eq = linear_eq + IntImm(DataType::Int(64), coeff) * vars[j];
+            linear_eq = linear_eq + IntImm::Int64(coeff) * vars[j];
           } else {
-            linear_eq = linear_eq - IntImm(DataType::Int(64), -coeff) * vars[j];
+            linear_eq = linear_eq - IntImm::Int64(-coeff) * vars[j];
           }
         }
       }
@@ -150,11 +150,11 @@ PrimExpr PresburgerSetNode::GenerateConstraint() const {
 #else
       auto c0 = disjunct.atEq(i, disjunct.getNumCols() - 1);
 #endif
-      linear_eq = linear_eq + IntImm(DataType::Int(64), c0);
+      linear_eq = linear_eq + IntImm::Int64(c0);
       union_entry = (union_entry && (linear_eq == 0));
     }
     for (unsigned i = 0, e = disjunct.getNumInequalities(); i < e; ++i) {
-      PrimExpr linear_eq = IntImm(DataType::Int(64), 0);
+      PrimExpr linear_eq = IntImm::Int64(0);
       if (disjunct.getNumCols() > 1) {
         for (unsigned j = 0, f = disjunct.getNumCols() - 1; j < f; ++j) {
 #if TVM_MLIR_VERSION >= 160
@@ -163,9 +163,9 @@ PrimExpr PresburgerSetNode::GenerateConstraint() const {
           auto coeff = disjunct.atIneq(i, j);
 #endif
           if (coeff >= 0 || is_zero(linear_eq)) {
-            linear_eq = linear_eq + IntImm(DataType::Int(64), coeff) * vars[j];
+            linear_eq = linear_eq + IntImm::Int64(coeff) * vars[j];
           } else {
-            linear_eq = linear_eq - IntImm(DataType::Int(64), -coeff) * vars[j];
+            linear_eq = linear_eq - IntImm::Int64(-coeff) * vars[j];
           }
         }
       }
@@ -175,9 +175,9 @@ PrimExpr PresburgerSetNode::GenerateConstraint() const {
       auto c0 = disjunct.atIneq(i, disjunct.getNumCols() - 1);
 #endif
       if (c0 >= 0) {
-        linear_eq = linear_eq + IntImm(DataType::Int(64), c0);
+        linear_eq = linear_eq + IntImm::Int64(c0);
       } else {
-        linear_eq = linear_eq - IntImm(DataType::Int(64), -c0);
+        linear_eq = linear_eq - IntImm::Int64(-c0);
       }
       union_entry = (union_entry && (linear_eq >= 0));
     }
@@ -245,15 +245,15 @@ IntSet EvalSet(const PrimExpr& e, const PresburgerSet& set) {
     auto maxRoundedDown(simplex.computeOptimum(Simplex::Direction::Up, coeffs));
     auto opt = range.first.getOptimumIfBounded();
 #if TVM_MLIR_VERSION >= 160
-    auto min = opt.has_value() ? IntImm(DataType::Int(64), int64_t(opt.value())) : neg_inf();
+    auto min = opt.has_value() ? IntImm::Int64(int64_t(opt.value())) : neg_inf();
 #else
-    auto min = opt.hasValue() ? IntImm(DataType::Int(64), opt.getValue()) : neg_inf();
+    auto min = opt.hasValue() ? IntImm::Int64(opt.getValue()) : neg_inf();
 #endif
     opt = range.second.getOptimumIfBounded();
 #if TVM_MLIR_VERSION >= 160
-    auto max = opt.has_value() ? IntImm(DataType::Int(64), int64_t(opt.value())) : pos_inf();
+    auto max = opt.has_value() ? IntImm::Int64(int64_t(opt.value())) : pos_inf();
 #else
-    auto max = opt.hasValue() ? IntImm(DataType::Int(64), opt.getValue()) : pos_inf();
+    auto max = opt.hasValue() ? IntImm::Int64(opt.getValue()) : pos_inf();
 #endif
     auto interval = IntervalSet(min, max);
     result = Union({result, interval});

--- a/src/arith/product_normal_form.h
+++ b/src/arith/product_normal_form.h
@@ -79,7 +79,7 @@ inline void UnpackSum(const PrimExpr& value, FLeaf fleaf, int sign = 1) {
  */
 inline PrimExpr MulAndNormalize(const PrimExpr& lhs, const PrimExpr& rhs) {
   int64_t cscale = 1;
-  PrimExpr res = tirx::make_const(lhs.dtype(), 1);
+  PrimExpr res = tirx::MakeConst(lhs.dtype(), 1);
   auto fcollect = [&](PrimExpr val) {
     if (const auto* intimm = val.as<IntImmNode>()) {
       cscale *= intimm->value;
@@ -90,7 +90,7 @@ inline PrimExpr MulAndNormalize(const PrimExpr& lhs, const PrimExpr& rhs) {
   UnpackReduction<tirx::MulNode>(lhs, fcollect);
   UnpackReduction<tirx::MulNode>(rhs, fcollect);
   if (cscale != 1) {
-    res = res * tirx::make_const(res.dtype(), cscale);
+    res = res * tirx::MakeConst(res.dtype(), cscale);
   }
   return res;
 }

--- a/src/arith/rewrite_simplify.cc
+++ b/src/arith/rewrite_simplify.cc
@@ -237,7 +237,7 @@ CompareResult RewriteSimplifier::Impl::TryComparisonOfProductAndSum(const PrimEx
                    (B * A) + (A + B) * C,
                }
                    .Match(diff)) {
-      return std::tuple{A.Eval(), B.Eval(), C.Eval(), IntImm(DataType::Int(32), -1)};
+      return std::tuple{A.Eval(), B.Eval(), C.Eval(), IntImm::Int32(-1)};
     } else {
       return std::nullopt;
     }
@@ -543,7 +543,7 @@ std::function<void()> RewriteSimplifier::Impl::EnterConstraint(const PrimExpr& c
         // applied.
         negation = NormalizeBooleanOperators(Not(subconstraint));
       } else {
-        negation = subconstraint == make_zero(subconstraint.dtype());
+        negation = subconstraint == IntImm(subconstraint.dtype(), 0);
       }
       literal_constraints_.push_back(Not(negation));
     }
@@ -839,7 +839,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const DivNode* op) {
     if (truncdiv(c1, c2).Match(ret)) {
       int64_t c1val = c1.Eval()->value;
       int64_t c2val = c2.Eval()->value;
-      return make_const(op->dtype, truncdiv(c1val, c2val));
+      return MakeConst(op->dtype, truncdiv(c1val, c2val));
     }
 
     // while it is always true for trunc div
@@ -1019,7 +1019,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const ModNode* op) {
     // canonicalization: x % c == x % (-c) for truncated division
     // NOTE: trunc div required
     TVM_TRY_RECURSIVE_REWRITE_IF(
-        truncmod(x, c1), truncmod(x, PConst<PrimExpr>(make_const(op->dtype, -c1.Eval()->value))),
+        truncmod(x, c1), truncmod(x, PConst<PrimExpr>(MakeConst(op->dtype, -c1.Eval()->value))),
         c1.Eval()->value < 0);
 
     // try modular analysis
@@ -1089,7 +1089,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
         floordiv(y + x * c1, c2).Match(ret)) {
       int64_t c1val = c1.Eval()->value;
       int64_t c2val = c2.Eval()->value;
-      PrimExpr yval = y.EvalOr(IntImm(DataType::Int(32), 0));
+      PrimExpr yval = y.EvalOr(IntImm::Int32(0));
       if (c2val == 0) return ret;
 
       // try eliminate residue part
@@ -1098,8 +1098,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const FloorDivNode* op) {
       PrimExpr y_div = CanProveEqual(floordiv(yval, c2val), 0) ? 0 : floordiv(yval, c2val);
       auto bound = analyzer_->const_int_bound(residue);
       if (bound.defined() && bound->max_value == bound->min_value) {
-        return x.Eval() * floordiv(c1val, c2.Eval()) +
-               (y_div + IntImm(DataType::Int(32), bound->max_value));
+        return x.Eval() * floordiv(c1val, c2.Eval()) + (y_div + IntImm::Int32(bound->max_value));
       }
 
       // try simplify divisor
@@ -1687,10 +1686,10 @@ ffi::Optional<PrimExpr> RewriteSimplifier::Impl::TryMatchLiteralConstraint(
   ExprDeepEqual expr_equal;
   for (const auto& constraint : literal_constraints_) {
     if (expr_equal(constraint, expr)) {
-      return make_const(expr->dtype, true);
+      return MakeConst(expr->dtype, true);
     }
     if (expr_equal(constraint, negation)) {
-      return make_const(expr->dtype, false);
+      return MakeConst(expr->dtype, false);
     }
   }
   return std::nullopt;
@@ -1716,7 +1715,7 @@ PrimExpr RewriteSimplifier::Impl::ApplyRewriteRules(EQ ret) {
   // Pattern var match IntImm
   PVar<IntImm> c1, c2;
   PVar<PrimExpr> lanes;
-  PConst<PrimExpr> ctrue(make_const(ret->dtype, true));
+  PConst<PrimExpr> ctrue(MakeConst(ret->dtype, true));
 
   // vector rule
   if (ret->dtype.is_scalable_or_fixed_length_vector()) {
@@ -1726,10 +1725,10 @@ PrimExpr RewriteSimplifier::Impl::ApplyRewriteRules(EQ ret) {
   if (IsIndexType(ret->a.dtype())) {
     CompareResult result = TryCompare(ret->a, ret->b);
     if (result == CompareResult::kEQ) {
-      return make_const(ret->dtype, true);
+      return MakeConst(ret->dtype, true);
     } else if (result == CompareResult::kNE || result == CompareResult::kGT ||
                result == CompareResult::kLT) {
-      return make_const(ret->dtype, false);
+      return MakeConst(ret->dtype, false);
     }
     TVM_TRY_REWRITE(c1 == x, x == c1);
 
@@ -1763,9 +1762,9 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const NENode* op) {
     CompareResult result = TryCompare(op->a, op->b);
     if (result == CompareResult::kNE || result == CompareResult::kGT ||
         result == CompareResult::kLT) {
-      return make_const(op->dtype, true);
+      return MakeConst(op->dtype, true);
     } else if (result == CompareResult::kEQ) {
-      return make_const(op->dtype, false);
+      return MakeConst(op->dtype, false);
     } else if (result == CompareResult::kGE) {
       // Known: a >= b
       //
@@ -1807,9 +1806,9 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const LENode* op) {
     CompareResult result = TryCompare(op->a, op->b);
     if (result == CompareResult::kLE || result == CompareResult::kLT ||
         result == CompareResult::kEQ) {
-      return make_const(op->dtype, true);
+      return MakeConst(op->dtype, true);
     } else if (result == CompareResult::kGT) {
-      return make_const(op->dtype, false);
+      return MakeConst(op->dtype, false);
     } else if (result == CompareResult::kNE) {
       // Known: a != b
       //
@@ -1866,11 +1865,11 @@ PrimExpr RewriteSimplifier::Impl::ApplyRewriteRules(LT ret) {
   if (IsIndexType(ret->a.dtype())) {
     CompareResult result = TryCompare(ret->a, ret->b);
     if (result == CompareResult::kLT) {
-      return make_const(ret->dtype, true);
+      return MakeConst(ret->dtype, true);
     }
     if (result == CompareResult::kEQ || result == CompareResult::kGT ||
         result == CompareResult::kGE) {
-      return make_const(ret->dtype, false);
+      return MakeConst(ret->dtype, false);
     }
 
     // clang-format off
@@ -1988,9 +1987,9 @@ PrimExpr RewriteSimplifier::Impl::ApplyRewriteRules(LT ret) {
       } else if (diff == 1) {
         return lhs <= rhs;
       } else if (diff < 0 && rhs_offset != 0) {
-        return lhs + make_const(lhs.dtype(), -diff) < rhs;
+        return lhs + MakeConst(lhs.dtype(), -diff) < rhs;
       } else if (diff > 0 && lhs_offset != 0) {
-        return lhs < rhs + make_const(rhs.dtype(), diff);
+        return lhs < rhs + MakeConst(rhs.dtype(), diff);
       }
 
       return std::nullopt;
@@ -2105,7 +2104,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const AndNode* op) {
     TVM_TRY_REWRITE(broadcast(x, lanes) && broadcast(y, lanes), broadcast(x && y, lanes));
   }
 
-  auto cfalse = PConst<PrimExpr>(make_const(op->dtype, false));
+  auto cfalse = PConst<PrimExpr>(MakeConst(op->dtype, false));
   TVM_TRY_REWRITE(x == y && x != y, cfalse);
   TVM_TRY_REWRITE(x != y && x == y, cfalse);
   TVM_TRY_REWRITE(x && !x, cfalse);
@@ -2253,7 +2252,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const OrNode* op) {
     TVM_TRY_REWRITE(broadcast(x, lanes) || broadcast(y, lanes), broadcast(x || y, lanes));
   }
 
-  auto ctrue = PConst<PrimExpr>(make_const(op->dtype, true));
+  auto ctrue = PConst<PrimExpr>(MakeConst(op->dtype, true));
 
   TVM_TRY_REWRITE(x == y || x != y, ctrue);
   TVM_TRY_REWRITE(x != y || x == y, ctrue);
@@ -2342,7 +2341,7 @@ PrimExpr RewriteSimplifier::Impl::VisitExpr_(const CallNode* op) {
   } else if (op->op.same_as(clz_op)) {
     if (const auto* arg_int = op->args[0].as<IntImmNode>()) {
       int bits = arg_int->dtype.bits();
-      if (arg_int->value == 0) return make_const(op->dtype, bits);
+      if (arg_int->value == 0) return MakeConst(op->dtype, bits);
       for (int i = bits - 1; i >= 0; --i) {
         if ((int64_t(1) << i) & arg_int->value) {
           return IntImm(op->dtype, bits - i - 1);

--- a/src/arith/solve_linear_equation.cc
+++ b/src/arith/solve_linear_equation.cc
@@ -133,10 +133,10 @@ void SmithNormalFormDiag(std::vector<std::vector<int64_t>>* S, std::vector<std::
           (*S)[i][j] = new_i_j;
         }
         // We have to do the same with rhs
-        PrimExpr ea = tirx::make_const((*y)[index].dtype(), a);
-        PrimExpr eb = tirx::make_const((*y)[i].dtype(), b);
-        PrimExpr e_m_g = tirx::make_const((*y)[i].dtype(), m_g);
-        PrimExpr e_n_g = tirx::make_const((*y)[index].dtype(), n_g);
+        PrimExpr ea = tirx::MakeConst((*y)[index].dtype(), a);
+        PrimExpr eb = tirx::MakeConst((*y)[i].dtype(), b);
+        PrimExpr e_m_g = tirx::MakeConst((*y)[i].dtype(), m_g);
+        PrimExpr e_n_g = tirx::MakeConst((*y)[index].dtype(), n_g);
         PrimExpr new_index_rhs = ea * (*y)[index] + eb * (*y)[i];
         PrimExpr new_i_rhs = e_n_g * (*y)[index] - e_m_g * (*y)[i];
         (*y)[index] = new_index_rhs;
@@ -193,10 +193,10 @@ void SmithNormalFormDiag(std::vector<std::vector<int64_t>>* S, std::vector<std::
           (*V)[i][j] = new_i_j;
         }
         // And apply reverse transformations to new_to_old.
-        PrimExpr ea = tirx::make_const((*x)[j].dtype(), a);
-        PrimExpr eb = tirx::make_const((*x)[index].dtype(), b);
-        PrimExpr e_m_g = tirx::make_const((*x)[index].dtype(), m_g);
-        PrimExpr e_n_g = tirx::make_const((*x)[j].dtype(), n_g);
+        PrimExpr ea = tirx::MakeConst((*x)[j].dtype(), a);
+        PrimExpr eb = tirx::MakeConst((*x)[index].dtype(), b);
+        PrimExpr e_m_g = tirx::MakeConst((*x)[index].dtype(), m_g);
+        PrimExpr e_n_g = tirx::MakeConst((*x)[j].dtype(), n_g);
         PrimExpr new_index = e_m_g * (*x)[index] + e_n_g * (*x)[j];
         PrimExpr new_j = eb * (*x)[index] - ea * (*x)[j];
         (*x)[index] = new_index;
@@ -369,7 +369,7 @@ IntConstraintsTransform SolveLinearEquations(const IntConstraints& system_to_sol
                                      IntConstraints(
                                          /*variables=*/{},
                                          /*ranges=*/{},
-                                         /*relations=*/{tirx::make_zero(DataType::Bool())}),
+                                         /*relations=*/{IntImm::Bool(false)}),
                                      {}, {});
     } else if (!tirx::is_const_int(new_relation, 1)) {
       new_relations.push_back(new_relation);
@@ -403,12 +403,12 @@ IntConstraintsTransform SolveLinearEquations(const IntConstraints& system_to_sol
       // The j-th variable is just a single value, don't create a tvm variable
       // S^{-1}_{nxm} Uy_{mxn}
       if (S[j][j] >= 0) {
-        PrimExpr a = tirx::make_const(Uy[j].dtype(), S[j][j]);
+        PrimExpr a = tirx::MakeConst(Uy[j].dtype(), S[j][j]);
         solution_for_V_inv_x.push_back(analyzer_problem->Simplify(floordiv(Uy[j], a)));
       } else {
         // This is required because some simplifiers
         // have problems with dividing by negative numbers
-        PrimExpr a = tirx::make_const(Uy[j].dtype(), -S[j][j]);
+        PrimExpr a = tirx::MakeConst(Uy[j].dtype(), -S[j][j]);
         solution_for_V_inv_x.push_back(analyzer_problem->Simplify(floordiv(-Uy[j], a)));
       }
     }
@@ -416,9 +416,9 @@ IntConstraintsTransform SolveLinearEquations(const IntConstraints& system_to_sol
 
   // V V^{-1} x = x
   for (size_t i = 0; i < num_vars; ++i) {
-    PrimExpr e = tirx::make_zero(system_to_solve->variables[i].dtype());
+    PrimExpr e = IntImm(system_to_solve->variables[i].dtype(), 0);
     for (size_t j = 0; j < num_vars; ++j) {
-      e = e + tirx::make_const(e.dtype(), V[i][j]) * solution_for_V_inv_x[j];
+      e = e + tirx::MakeConst(e.dtype(), V[i][j]) * solution_for_V_inv_x[j];
     }
     e = analyzer_problem->Simplify(e);
     old_to_new_map.Set(system_to_solve->variables[i], e);

--- a/src/arith/solve_linear_inequality.cc
+++ b/src/arith/solve_linear_inequality.cc
@@ -92,9 +92,9 @@ class NormalizeComparisons : public ExprMutator {
   PrimExpr Make(const PrimExpr& a, const PrimExpr& b) {
     // rewrite LT to LE for ints
     if (std::is_same<T, LT>::value && (a.dtype().is_int() || a.dtype().is_uint())) {
-      return LE(analyzer_->Simplify(a - b + 1), make_zero(a.dtype()));
+      return LE(analyzer_->Simplify(a - b + 1), IntImm(a.dtype(), 0));
     }
-    return T(analyzer_->Simplify(a - b), make_zero(a.dtype()));
+    return T(analyzer_->Simplify(a - b), IntImm(a.dtype(), 0));
   }
   arith::Analyzer analyzer_;
 };
@@ -248,11 +248,11 @@ PartialSolvedInequalities SolveLinearInequalities(const IntConstraints& system_t
     for (const auto& pos : coef_pos) {
       for (const auto& neg : coef_neg) {
         auto first_gcd = ExtendedEuclidean(pos.first, -neg.first, &gcd_x, &gcd_y);
-        PrimExpr c_pos = make_const(v.dtype(), neg.first / first_gcd);
-        PrimExpr c_neg = make_const(v.dtype(), pos.first / first_gcd);
+        PrimExpr c_pos = MakeConst(v.dtype(), neg.first / first_gcd);
+        PrimExpr c_neg = MakeConst(v.dtype(), pos.first / first_gcd);
         // eliminate the current variable
         PrimExpr new_lhs = c_neg * neg.second - c_pos * pos.second;
-        PrimExpr new_ineq = LE(new_lhs, make_zero(pos.second.dtype()));
+        PrimExpr new_ineq = LE(new_lhs, IntImm(pos.second.dtype(), 0));
         // we need rewrite_simplify -> canonical_simplify -> rewrite_simplify
         // to help simplify things like (((y + 10) - (-1*(y - 20))) <= 0) => y - 5 <= 0
         // with steps = 2 it's (y*2) - 10 <= 0
@@ -281,7 +281,7 @@ PartialSolvedInequalities SolveLinearInequalities(const IntConstraints& system_t
     lower_bounds.reserve(coef_neg.size());
 
     for (const auto& pos : coef_pos) {
-      PrimExpr bound = make_const(v.dtype(), -coef_lcm / pos.first) * pos.second;
+      PrimExpr bound = MakeConst(v.dtype(), -coef_lcm / pos.first) * pos.second;
       bound = analyzer->Simplify(bound, kSimplifyRewriteCanonicalRewrite);
       // Don't add if any of the existing bounds is better
       if (std::any_of(upper_bounds.begin(), upper_bounds.end(),
@@ -302,7 +302,7 @@ PartialSolvedInequalities SolveLinearInequalities(const IntConstraints& system_t
       upper_bounds.push_back(bound);
     }
     for (const auto& neg : coef_neg) {
-      PrimExpr bound = make_const(v.dtype(), -coef_lcm / neg.first) * neg.second;
+      PrimExpr bound = MakeConst(v.dtype(), -coef_lcm / neg.first) * neg.second;
       bound = analyzer->Simplify(bound, kSimplifyRewriteCanonicalRewrite);
       // Don't add if any of the existing bounds is better
       if (std::any_of(lower_bounds.begin(), lower_bounds.end(),
@@ -330,7 +330,7 @@ PartialSolvedInequalities SolveLinearInequalities(const IntConstraints& system_t
     std::sort(equal_list.begin(), equal_list.end(), ExprLess());
 
     // Write it to the result.
-    IntGroupBounds bnds(make_const(v.dtype(), coef_lcm),
+    IntGroupBounds bnds(MakeConst(v.dtype(), coef_lcm),
                         ffi::Array<PrimExpr>(lower_bounds.begin(), lower_bounds.end()),
                         ffi::Array<PrimExpr>(equal_list.begin(), equal_list.end()),
                         ffi::Array<PrimExpr>(upper_bounds.begin(), upper_bounds.end()));
@@ -345,7 +345,7 @@ PartialSolvedInequalities SolveLinearInequalities(const IntConstraints& system_t
     PrimExpr e_simp = analyzer->Simplify(e, kSimplifyRewriteCanonicalRewrite);
     if (is_const_int(e_simp, 0)) {
       // contradiction detected
-      other_conditions = {const_false()};
+      other_conditions = {IntImm::Bool(false)};
       break;
     } else if (is_const_int(e_simp, 1)) {
       continue;
@@ -413,7 +413,7 @@ IntConstraints SolveInequalitiesToRange(const IntConstraints& inequalities) {
         if (analyzer->CanProveGreaterEqual(-best_range->extent, 0)) {
           // range.extent <= 0 implies the input inequality system is unsolvable
           return IntConstraints(/*variables=*/{}, /*ranges=*/{},
-                                /*relations=*/{tirx::make_zero(DataType::Bool())});
+                                /*relations=*/{IntImm::Bool(false)});
         }
         res_ranges.Set(var, best_range);
         vranges.Set(var, best_range);
@@ -498,7 +498,7 @@ IntConstraintsTransform SolveInequalitiesDeskewRange(const IntConstraints& inequ
                                        IntConstraints(
                                            /*variables=*/{},
                                            /*ranges=*/{},
-                                           /*relations=*/{tirx::make_zero(DataType::Bool())}),
+                                           /*relations=*/{IntImm::Bool(false)}),
                                        {}, {});
       } else {
         // created new_var starts from 0
@@ -509,7 +509,7 @@ IntConstraintsTransform SolveInequalitiesDeskewRange(const IntConstraints& inequ
                            analyzer->Simplify(var - Substitute(best_range->min, res_dst_to_src)));
 
         // Add the new var to the resulting axis
-        auto range = Range(make_zero(new_var.dtype()), best_range->extent);
+        auto range = Range(IntImm(new_var.dtype(), 0), best_range->extent);
         res_variables.push_back(new_var);
         res_ranges.Set(new_var, range);
 

--- a/src/backend/cuda/codegen/codegen_cuda.cc
+++ b/src/backend/cuda/codegen/codegen_cuda.cc
@@ -201,12 +201,12 @@ class ThreadIdxExtractor : public tirx::StmtVisitor {
   }
 
  public:
-  PrimExpr threadIdx_x_ext = IntImm(DataType::Int(32), 1);
-  PrimExpr threadIdx_y_ext = IntImm(DataType::Int(32), 1);
-  PrimExpr threadIdx_z_ext = IntImm(DataType::Int(32), 1);
-  PrimExpr clusterCtaIdx_x_ext = IntImm(DataType::Int(32), 1);
-  PrimExpr clusterCtaIdx_y_ext = IntImm(DataType::Int(32), 1);
-  PrimExpr clusterCtaIdx_z_ext = IntImm(DataType::Int(32), 1);
+  PrimExpr threadIdx_x_ext = IntImm::Int32(1);
+  PrimExpr threadIdx_y_ext = IntImm::Int32(1);
+  PrimExpr threadIdx_z_ext = IntImm::Int32(1);
+  PrimExpr clusterCtaIdx_x_ext = IntImm::Int32(1);
+  PrimExpr clusterCtaIdx_y_ext = IntImm::Int32(1);
+  PrimExpr clusterCtaIdx_z_ext = IntImm::Int32(1);
 };
 
 void CodeGenCUDA::PrintExtraAttrs(const PrimFunc& f, std::ostream& os) {

--- a/src/backend/hexagon/codegen/llvm/intrin_rule_hexagon.cc
+++ b/src/backend/hexagon/codegen/llvm/intrin_rule_hexagon.cc
@@ -135,16 +135,17 @@ TVM_REGISTER_OP("tirx.tanh")
         return TVMExternCall(call, tvm_wrapper);
       }
 #endif
-      PrimExpr one = tirx::make_const(x.dtype(), 1);
-      PrimExpr two = tirx::make_const(x.dtype(), 2);
-      PrimExpr neg_two = tirx::make_const(x.dtype(), -2);
+      PrimExpr one = tirx::MakeConst(x.dtype(), 1);
+      PrimExpr two = tirx::MakeConst(x.dtype(), 2);
+      PrimExpr neg_two = tirx::MakeConst(x.dtype(), -2);
 
       PrimExpr exp_neg2x = exp(neg_two * x);
       PrimExpr exp_pos2x = exp(two * x);
 
       PrimExpr tanh_pos = (one - exp_neg2x) / (one + exp_neg2x);
       PrimExpr tanh_neg = (exp_pos2x - one) / (exp_pos2x + one);
-      PrimExpr tanh_x = tirx::Select(x >= tirx::make_zero(x.dtype()), tanh_pos, tanh_neg);
+      // MakeConst can handle both vector and scalar types.
+      PrimExpr tanh_x = tirx::Select(x >= tirx::MakeConst(x.dtype(), 0), tanh_pos, tanh_neg);
       return tanh_x;
     });
 
@@ -194,8 +195,8 @@ TVM_REGISTER_OP("tirx.sigmoid")
         useqhl = tstring.find("+hvx-qfloat") != std::string::npos;
       }
 
-      PrimExpr MinBound = tirx::make_const(x.dtype(), -8);
-      PrimExpr MaxBound = tirx::make_const(x.dtype(), 8);
+      PrimExpr MinBound = tirx::MakeConst(x.dtype(), -8);
+      PrimExpr MaxBound = tirx::MakeConst(x.dtype(), 8);
       const PrimExpr v1 = tirx::Max(x, MinBound);
       const PrimExpr v2 = tirx::Min(v1, MaxBound);
 
@@ -208,7 +209,7 @@ TVM_REGISTER_OP("tirx.sigmoid")
         return TVMExternCall(new_call.get(), tvm_wrapper);
       }
 #endif
-      PrimExpr one = tirx::make_const(x.dtype(), 1);
+      PrimExpr one = tirx::MakeConst(x.dtype(), 1);
       return one / (one + exp(-x));
     });
 

--- a/src/backend/opencl/codegen/codegen_opencl.cc
+++ b/src/backend/opencl/codegen/codegen_opencl.cc
@@ -457,7 +457,7 @@ void CodeGenOpenCL::VisitExpr_(const CallNode* op, std::ostream& os) {
     os << ", ";
     this->PrintExpr(op->args[3], os);
     os << ", ";
-    this->PrintExpr(make_const(DataType::Int(32), 0), os);
+    this->PrintExpr(IntImm::Int32(0), os);
     os << "), ";
     os << "as_";
     this->PrintType(channel_type, os);
@@ -490,7 +490,7 @@ void CodeGenOpenCL::VisitExpr_(const CallNode* op, std::ostream& os) {
     ss << ", ";
     this->PrintExpr(op->args[3], ss);
     ss << ", ";
-    this->PrintExpr(make_const(DataType::Int(32), 0), ss);
+    this->PrintExpr(IntImm::Int32(0), ss);
     ss << "))))";
 
     std::string rhs = SSAGetID(ss.str(), op->dtype.with_lanes(data_lanes));

--- a/src/backend/rocm/codegen/llvm/intrin_rule_rocm.cc
+++ b/src/backend/rocm/codegen/llvm/intrin_rule_rocm.cc
@@ -69,8 +69,8 @@ inline PrimExpr DispatchShuffle(const PrimExpr& e) {
   TVM_FFI_ICHECK_EQ(var.dtype().bits(), 32);
 
   // get own lane in self (__lane_id)
-  PrimExpr minus_one = tirx::make_const(DataType::Int(32), -1);
-  PrimExpr zero = tirx::make_zero(DataType::Int(32));
+  PrimExpr minus_one = IntImm::Int32(-1);
+  PrimExpr zero = IntImm::Int32(0);
   PrimExpr lo = Call(DataType::Int(32), builtin::call_pure_extern(),
                      {StringImm("llvm.amdgcn.mbcnt.lo"), minus_one, zero});
   PrimExpr self = Call(DataType::Int(32), builtin::call_pure_extern(),
@@ -111,7 +111,7 @@ void RegisterROCMIntrinRules() {
 // dummy because we don't have the activemask
 TVM_REGISTER_OP("tirx.tvm_warp_activemask")
     .set_attr<FLowerIntrinsic>("rocm.FLowerIntrinsic", [](const PrimExpr& e) -> PrimExpr {
-      PrimExpr zero = tirx::make_zero(DataType::Int(32));
+      PrimExpr zero = IntImm::Int32(0);
       return zero;
     });
 

--- a/src/backend/trn/transform/lower_trainium_layout.cc
+++ b/src/backend/trn/transform/lower_trainium_layout.cc
@@ -147,7 +147,7 @@ class TrainiumLayoutApplier : public arith::IRMutatorWithAnalyzer {
       if (auto tile_layout = buf->layout.as<TileLayoutNode>();
           tile_layout && tile_layout->HasThreadAxis()) {
         arith::Analyzer ana;
-        PrimExpr mem_span = make_const(DataType::Int(32), 1);
+        PrimExpr mem_span = IntImm::Int32(1);
         for (const auto& iter : tile_layout->shard) {
           if (iter->axis->IsMemoryAxis()) {
             mem_span = mem_span + (iter->extent - 1) * iter->stride;

--- a/src/backend/vulkan/codegen/codegen_spirv.cc
+++ b/src/backend/vulkan/codegen/codegen_spirv.cc
@@ -536,7 +536,7 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const RampNode* op) {
   for (int i = 0; i < lanes; ++i) {
     spirv::Value v = base;
     if (i != 0) {
-      spirv::Value offset = MakeValue(make_const(op->stride.dtype(), i) * op->stride);
+      spirv::Value offset = MakeValue(MakeConst(op->stride.dtype(), i) * op->stride);
       v = builder_->Add(v, offset);
     }
     values.push_back(v);

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -46,7 +46,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   RangeNode::RegisterReflection();
 }
 
-PrimExpr::PrimExpr(int32_t value) : PrimExpr(IntImm(DataType::Int(32), value)) {}
+PrimExpr::PrimExpr(int32_t value) : PrimExpr(IntImm::Int32(value)) {}
 
 PrimExpr::PrimExpr(float value) : PrimExpr(FloatImm(DataType::Float(32), value)) {}
 

--- a/src/relax/analysis/struct_info_analysis.cc
+++ b/src/relax/analysis/struct_info_analysis.cc
@@ -648,97 +648,97 @@ class StructInfoBasePreconditionCollector
   PrimExpr VisitStructInfo(const StructInfo& lhs, const StructInfo& other) override {
     if (lhs.same_as(other)) {
       // Early bail-out if the StructInfo has reference equality.
-      return tirx::const_true();
+      return IntImm::Bool(true);
     } else {
       return StructInfoFunctor::VisitStructInfo(lhs, other);
     }
   }
 
   PrimExpr VisitStructInfo_(const ObjectStructInfoNode* lhs, const StructInfo& other) final {
-    return IntImm(DataType::Bool(), 1);
+    return IntImm::Bool(true);
   }
 
   PrimExpr VisitStructInfo_(const PrimStructInfoNode* lhs, const StructInfo& other) final {
     auto* rhs = other.as<PrimStructInfoNode>();
     if (rhs == nullptr) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     if (lhs->dtype != rhs->dtype) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     if (lhs->value.defined() && rhs->value.defined()) {
       return lhs->value.value() == rhs->value.value();
     } else if (lhs->value.defined() && !rhs->value.defined()) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     } else {
-      return IntImm(DataType::Bool(), 1);
+      return IntImm::Bool(true);
     }
   }
 
   PrimExpr VisitStructInfo_(const ShapeStructInfoNode* lhs, const StructInfo& other) final {
     auto* rhs = other.as<ShapeStructInfoNode>();
     if (rhs == nullptr) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
     // lhs have unknown ndim
     if (lhs->IsUnknownNdim()) {
-      return IntImm(DataType::Bool(), 1);
+      return IntImm::Bool(true);
     }
 
     // ndim must match
     if (lhs->ndim != rhs->ndim) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     if (lhs->values.defined() && rhs->values.defined()) {
       return ArrayCheck(lhs->values.value(), rhs->values.value());
     } else if (lhs->values.defined() && !rhs->values.defined()) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     } else {
-      return IntImm(DataType::Bool(), 1);
+      return IntImm::Bool(true);
     }
   }
 
   PrimExpr VisitStructInfo_(const TensorStructInfoNode* lhs, const StructInfo& other) final {
     auto* rhs = other.as<TensorStructInfoNode>();
     if (rhs == nullptr) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
     // dtype mismatch
     if (!lhs->IsUnknownDtype() && lhs->dtype != rhs->dtype) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     // ndim mismatch
     if (!lhs->IsUnknownNdim() && lhs->ndim != rhs->ndim) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     // vdevice mismatch
     if (lhs->vdevice.defined() && !rhs->vdevice.defined()) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
     if (lhs->vdevice.defined() && rhs->vdevice.defined()) {
       VDevice lhs_vdevice = lhs->vdevice.value();
       VDevice rhs_vdevice = rhs->vdevice.value();
       if (lhs_vdevice->target.defined() && !rhs_vdevice->target.defined()) {
-        return IntImm(DataType::Bool(), 0);
+        return IntImm::Bool(false);
       }
       // mismatch in either the target, vdevice_id, or memory_scope
       if ((lhs_vdevice->target.defined() && rhs_vdevice->target.defined()) &&
           (lhs_vdevice->target != rhs_vdevice->target ||
            lhs_vdevice->vdevice_id != rhs_vdevice->vdevice_id ||
            lhs_vdevice->memory_scope != rhs_vdevice->memory_scope)) {
-        return IntImm(DataType::Bool(), 0);
+        return IntImm::Bool(false);
       }
     }
 
     if (lhs->shape.same_as(rhs->shape)) {
-      return IntImm(DataType::Bool(), 1);
+      return IntImm::Bool(true);
     } else if (lhs->shape.defined() && !rhs->shape.defined()) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     auto* lhs_shape = lhs->shape.as<ShapeExprNode>();
@@ -746,23 +746,23 @@ class StructInfoBasePreconditionCollector
     if (lhs_shape && rhs_shape) {
       return ArrayCheck(lhs_shape->values, rhs_shape->values);
     } else if (lhs_shape && !rhs_shape) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
-    return IntImm(DataType::Bool(), 1);
+    return IntImm::Bool(true);
   }
 
   PrimExpr VisitStructInfo_(const distributed::DTensorStructInfoNode* lhs,
                             const StructInfo& other) final {
     auto* rhs = other.as<distributed::DTensorStructInfoNode>();
     if (rhs == nullptr) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     ffi::StructuralEqual struct_equal;
     if (!struct_equal(lhs->device_mesh, rhs->device_mesh) ||
         !struct_equal(lhs->placement, rhs->placement)) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     return this->VisitStructInfo(lhs->tensor_sinfo, rhs->tensor_sinfo);
@@ -771,7 +771,7 @@ class StructInfoBasePreconditionCollector
   PrimExpr VisitStructInfo_(const TupleStructInfoNode* lhs, const StructInfo& other) final {
     auto* rhs = other.as<TupleStructInfoNode>();
     if (rhs == nullptr) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
     return ArrayCheck(lhs->fields, rhs->fields);
   }
@@ -779,19 +779,19 @@ class StructInfoBasePreconditionCollector
   PrimExpr VisitStructInfo_(const FuncStructInfoNode* lhs, const StructInfo& other) override {
     auto* rhs = other.as<FuncStructInfoNode>();
     if (rhs == nullptr) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     // Check purity: Pure functions are a subtype of impure functions
     if (lhs->purity && !rhs->purity) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     if (lhs->derive_func.defined() && !lhs->derive_func.same_as(rhs->derive_func)) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
     if (lhs->params.defined() && !rhs->params.defined()) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
     PrimExpr all_match = VisitStructInfo(lhs->ret, rhs->ret);
@@ -800,7 +800,7 @@ class StructInfoBasePreconditionCollector
     if (lhs->params.defined()) {
       param_check = ArrayCheck(lhs->params.value(), rhs->params.value());
     } else {
-      param_check = IntImm(DataType::Bool(), 1);
+      param_check = IntImm::Bool(true);
     }
 
     PrimExpr ret_check = VisitStructInfo(lhs->ret, rhs->ret);
@@ -811,10 +811,10 @@ class StructInfoBasePreconditionCollector
  private:
   PrimExpr ArrayCheck(const ffi::Array<PrimExpr>& lhs, const ffi::Array<PrimExpr>& rhs) {
     if (lhs.size() != rhs.size()) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
-    PrimExpr all_equal = IntImm(DataType::Bool(), 1);
+    PrimExpr all_equal = IntImm::Bool(true);
     for (size_t i = 0; i < lhs.size(); i++) {
       all_equal = all_equal && (lhs[i] == rhs[i]);
     }
@@ -823,10 +823,10 @@ class StructInfoBasePreconditionCollector
 
   PrimExpr ArrayCheck(const ffi::Array<StructInfo>& lhs, const ffi::Array<StructInfo>& rhs) {
     if (lhs.size() != rhs.size()) {
-      return IntImm(DataType::Bool(), 0);
+      return IntImm::Bool(false);
     }
 
-    PrimExpr all_pass = IntImm(DataType::Bool(), 1);
+    PrimExpr all_pass = IntImm::Bool(true);
 
     for (size_t i = 0; i < lhs.size(); ++i) {
       all_pass = all_pass && VisitStructInfo(lhs[i], rhs[i]);

--- a/src/relax/analysis/tir_op_pattern_kind.cc
+++ b/src/relax/analysis/tir_op_pattern_kind.cc
@@ -445,7 +445,7 @@ bool HasReshapePattern(const PrimFunc& func) {
         return arith::IterMapSimplify(
             /*indices=*/{idx},
             /*input_iters=*/var_range,
-            /*input_pred=*/const_true(),
+            /*input_pred=*/IntImm::Bool(true),
             /*check_level=*/arith::IterMapLevel::Surjective,
             /*analyzer=*/ana_,
             /*simplify_trivial_iterators=*/true)[0];
@@ -459,7 +459,7 @@ bool HasReshapePattern(const PrimFunc& func) {
         for (int i = 0; i < static_cast<int>(block->iter_vars.size()); ++i) {
           if (!(indices[i].same_as(block->iter_vars[i]->var) &&
                 this->ana_->CanProveEqual(block->iter_vars[i]->dom->min,
-                                          IntImm(DataType::Int(64), /*value=*/0)) &&
+                                          IntImm::Int64(/*value=*/0)) &&
                 this->ana_->CanProveEqual(buffer->shape[i], block->iter_vars[i]->dom->extent))) {
             return false;
           }
@@ -495,7 +495,7 @@ bool HasReshapePattern(const PrimFunc& func) {
         ffi::Array<PrimExpr> simplify_res = arith::IterMapSimplify(
             /*indices=*/{flattened_idx},
             /*input_iters=*/{{fused_var, Range(IntImm(dtype, /*value=*/0), stride)}},
-            /*input_pred=*/const_true(),
+            /*input_pred=*/IntImm::Bool(true),
             /*check_level=*/arith::IterMapLevel::Surjective,
             /*analyzer=*/this->ana_,
             /*simplify_trivial_iterators=*/true);

--- a/src/relax/backend/contrib/clml/codegen.cc
+++ b/src/relax/backend/contrib/clml/codegen.cc
@@ -48,8 +48,7 @@ struct OpenCLMLCompilerConfigNode : public ffi::Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<OpenCLMLCompilerConfigNode>().def_ro(
         "clml_version", &OpenCLMLCompilerConfigNode::clml_version,
-        "OpenCLML version as (major, minor, patch).",
-        refl::DefaultValue(IntImm(DataType::Int(32), 3)));
+        "OpenCLML version as (major, minor, patch).", refl::DefaultValue(IntImm::Int32(3)));
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ext.attrs.OpenCLMLCompilerConfig",
                                     OpenCLMLCompilerConfigNode, ffi::Object);
@@ -335,9 +334,9 @@ inline constexpr bool IsOpenCLMLRuntimeEnabled() {
  */
 IntImm GetOpenCLMLVersion() {
 #if TVM_GRAPH_EXECUTOR_CLML
-  return IntImm(DataType::Int(32), TVM_CLML_VERSION);
+  return IntImm::Int32(TVM_CLML_VERSION);
 #else
-  return IntImm(DataType::Int(32), 3);
+  return IntImm::Int32(3);
 #endif  // TVM_GRAPH_EXECUTOR_CLML
 }
 

--- a/src/relax/backend/contrib/utils.cc
+++ b/src/relax/backend/contrib/utils.cc
@@ -57,7 +57,7 @@ ffi::Map<ffi::String, IntImm> ExtractArgIdx(ffi::String pattern_name, Function f
     auto exp = matched_expr.value()[pat];
     if (auto arg_var = exp.as<VarNode>()) {
       if (auto idx = find_index(f->params, ffi::GetRef<Var>(arg_var))) {
-        arg_idx.Set(name, IntImm(DataType::Int(64), *idx));
+        arg_idx.Set(name, IntImm::Int64(*idx));
       }
     }
   }

--- a/src/relax/backend/vm/codegen_vm_tir.cc
+++ b/src/relax/backend/vm/codegen_vm_tir.cc
@@ -82,9 +82,9 @@ class CodeGenVMTIR : public ExprFunctor<ffi::Optional<PrimExpr>(const Expr&)> {
  private:
   int64_t NewRegister() { return registers_num_++; }
 
-  static IntImm ConstInt64(int64_t value) { return IntImm(DataType::Int(64), value); }
+  static IntImm ConstInt64(int64_t value) { return IntImm::Int64(value); }
 
-  static IntImm ConstInt32(int64_t value) { return IntImm(DataType::Int(32), value); }
+  static IntImm ConstInt32(int64_t value) { return IntImm::Int32(value); }
 
   PrimExpr RegListGet(int64_t slot) const {
     // use 128 bits to represent any
@@ -231,8 +231,7 @@ class CodeGenVMTIR : public ExprFunctor<ffi::Optional<PrimExpr>(const Expr&)> {
     Call call = ffi::GetRef<Call>(call_node);
 
     if (call_node->op == null_value_op_) {
-      return tirx::Call(DataType::Handle(), tirx::builtin::reinterpret(),
-                        {IntImm(DataType::Int(64), 0)});
+      return tirx::Call(DataType::Handle(), tirx::builtin::reinterpret(), {IntImm::Int64(0)});
     }
     int64_t dst_reg = HasVoidStructInfo(call) ? -1 : NewRegister();
     if (call->op.as<OpNode>()) {

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -472,7 +472,7 @@ PrimExpr DFPatternMatcher::SimplifyCondition(PrimExpr condition) {
       constraints.begin(), constraints.end(),
       [&sort_key](const PrimExpr& a, const PrimExpr& b) { return sort_key(a) < sort_key(b); });
 
-  PrimExpr sorted_condition = tirx::const_true();
+  PrimExpr sorted_condition = IntImm::Bool(true);
   for (const PrimExpr& constraint : constraints) {
     sorted_condition = sorted_condition && constraint;
   }
@@ -505,7 +505,7 @@ std::tuple<PrimExpr, bool> SameShapeConstraintNode::AsPrimExpr(
   bool all_shapes_defined = true;
 
   // The expression that must be true in order
-  PrimExpr all_dimensions_equal = IntImm(DataType::Bool(), 1);
+  PrimExpr all_dimensions_equal = IntImm::Bool(true);
 
   for (const auto& arg : args) {
     if (auto opt_var = match_state(arg.get())) {
@@ -524,7 +524,7 @@ std::tuple<PrimExpr, bool> SameShapeConstraintNode::AsPrimExpr(
       if (!opt_var_shape.defined()) {
         // The pattern has matched to something without a shape.
         // Therefore, it cannot have the same shape as something else.
-        return {PrimExpr(IntImm(DataType::Bool(), 0)), true};
+        return {PrimExpr(IntImm::Bool(false)), true};
       }
       auto var_shape = opt_var_shape.value();
 
@@ -541,7 +541,7 @@ std::tuple<PrimExpr, bool> SameShapeConstraintNode::AsPrimExpr(
           // The shapes have different dimensionality.  No need to
           // perform potentially-expensive simplifications, because
           // the dimensions do not match.
-          return {PrimExpr(IntImm(DataType::Bool(), 0)), true};
+          return {PrimExpr(IntImm::Bool(false)), true};
         }
 
       } else {

--- a/src/relax/ir/dataflow_matcher.h
+++ b/src/relax/ir/dataflow_matcher.h
@@ -94,7 +94,7 @@ class DFPatternMatcher : public DFPatternFunctor<bool(const DFPattern&, const Ex
   std::unordered_map<DFPattern, Expr, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> memo_;
   var2val_t var2val_;
   std::vector<DFPattern> matched_nodes_;
-  PrimExpr symbolic_expr_condition_{IntImm(DataType::Bool(), 1)};
+  PrimExpr symbolic_expr_condition_{IntImm::Bool(true)};
   arith::Analyzer analyzer_;
   bool memoize_ = true;
 };

--- a/src/relax/ir/emit_te.cc
+++ b/src/relax/ir/emit_te.cc
@@ -49,7 +49,7 @@ te::Tensor TETensor(Expr value, ffi::Map<tirx::Var, PrimExpr> tir_var_map, std::
     ffi::Array<PrimExpr> shape;
     shape.reserve(ndim);
     for (int i = 0; i < ndim; ++i) {
-      shape.push_back(IntImm(DataType::Int(64), shape_tuple[i]));
+      shape.push_back(IntImm::Int64(shape_tuple[i]));
     }
     n->shape = std::move(shape);
     return te::PlaceholderOp(n).output(0);

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -342,7 +342,7 @@ Constant::Constant(runtime::Tensor data, ffi::Optional<StructInfo> struct_info_a
   ffi::Array<PrimExpr> values;
   auto shape_tuple = n->data.Shape();
   for (size_t dim = 0; dim < shape_tuple.size(); ++dim) {
-    values.push_back(IntImm(DataType::Int(64), shape_tuple[dim]));
+    values.push_back(IntImm::Int64(shape_tuple[dim]));
   }
   if (struct_info_annotation.defined()) {
     n->struct_info_ = struct_info_annotation.value();
@@ -371,7 +371,7 @@ PrimValue::PrimValue(PrimExpr value, Span span) {
 }
 
 PrimValue PrimValue::Int64(int64_t value, Span span) {
-  return PrimValue(IntImm(DataType::Int(64), value), span);
+  return PrimValue(IntImm::Int64(value), span);
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -799,7 +799,7 @@ Expr ExprMutator::VisitWithNewScope(const Expr& expr, ffi::Optional<ffi::Array<V
   TVM_FFI_ICHECK(expr->IsInstance<SeqExprNode>())
       << "Normal form requires all new scope is stored as SeqExpr";
 
-  PrimExpr constraint = IntImm(DataType::Bool(), 1);
+  PrimExpr constraint = IntImm::Bool(true);
   if (params.defined()) {
     auto non_negative_expressions =
         CollectNonNegativeExpressions(TupleStructInfo(params.value().Map(GetStructInfo)));

--- a/src/relax/op/distributed/statistical.cc
+++ b/src/relax/op/distributed/statistical.cc
@@ -68,7 +68,7 @@ StructInfo InferDistStructInfoStatistical(const Call& call, const BlockBuilder& 
     if (attrs->axis.defined() && std::find(axes.begin(), axes.end(), i) == axes.end()) {
       out_shape.push_back(data_shape->values[i]);
     } else if (attrs->keepdims) {
-      out_shape.push_back(IntImm(DataType::Int(64), /*value=*/1));
+      out_shape.push_back(IntImm::Int64(/*value=*/1));
     }
   }
   TVM_FFI_ICHECK_EQ(static_cast<int>(out_shape.size()), out_ndim);

--- a/src/relax/op/image/resize.cc
+++ b/src/relax/op/image/resize.cc
@@ -414,10 +414,10 @@ StructInfo InferStructInfoAffineGrid(const Call& call, const BlockBuilder& ctx) 
 
   // Output shape: [batch, 2, target_height, target_width]
   ffi::Array<PrimExpr> out_shape;
-  out_shape.push_back(data_shape->values[0]);         // batch
-  out_shape.push_back(IntImm(DataType::Int(64), 2));  // 2 (spatial dimensions)
-  out_shape.push_back(size_value->values[0]);         // target_height
-  out_shape.push_back(size_value->values[1]);         // target_width
+  out_shape.push_back(data_shape->values[0]);  // batch
+  out_shape.push_back(IntImm::Int64(2));       // 2 (spatial dimensions)
+  out_shape.push_back(size_value->values[0]);  // target_height
+  out_shape.push_back(size_value->values[1]);  // target_width
 
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype, data_sinfo->vdevice);
 }

--- a/src/relax/op/memory/view.cc
+++ b/src/relax/op/memory/view.cc
@@ -129,7 +129,7 @@ StructInfo InferStructInfoView(const Call& call, const BlockBuilder& ctx) {
 
     if (HasVoidStructInfo(arg_relative_byte_offset)) {
       // No byte offset is specified, so no change is applied.
-      return IntImm(DataType::Int(64), 0);
+      return IntImm::Int64(0);
     } else if (auto prim_sinfo = sinfo.as<PrimStructInfoNode>()) {
       TVM_FFI_CHECK_EQ(prim_sinfo->dtype, DataType::Int(64), TypeError)
           << "Operator " << call->op
@@ -177,7 +177,7 @@ StructInfo InferStructInfoView(const Call& call, const BlockBuilder& ctx) {
       return std::nullopt;
     } else {
       auto size_bits = dtype.bits() * dtype.lanes();
-      return IntImm(DataType::Int(64), (size_bits + 7) / 8);
+      return IntImm::Int64((size_bits + 7) / 8);
     }
   };
 
@@ -189,7 +189,7 @@ StructInfo InferStructInfoView(const Call& call, const BlockBuilder& ctx) {
       return std::nullopt;
     }
 
-    PrimExpr num_elements = IntImm(DataType::Int(32), 1);
+    PrimExpr num_elements = IntImm::Int32(1);
     for (const auto& dim : shape.value()) {
       num_elements *= dim;
     }

--- a/src/relax/op/nn/convolution.cc
+++ b/src/relax/op/nn/convolution.cc
@@ -128,8 +128,7 @@ StructInfo InferStructInfoConv1d(const Call& call, const BlockBuilder& ctx) {
 
   PrimExpr input_w = data_NCW_shape[2];
   PrimExpr kernel_w = weight_OIW_shape[2];
-  PrimExpr padding_w =
-      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
+  PrimExpr padding_w = IntImm::Int32(attrs->padding[0]) + IntImm::Int32(attrs->padding[1]);
 
   std::vector<PrimExpr> out_NCW_shape;
   out_NCW_shape.resize(3);
@@ -137,9 +136,9 @@ StructInfo InferStructInfoConv1d(const Call& call, const BlockBuilder& ctx) {
   out_NCW_shape[1] = weight_OIW_shape[0];
 
   PrimExpr numerator_w =
-      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_w - 1) - 1;
+      input_w + padding_w - IntImm::Int32(attrs->dilation[0]) * (kernel_w - 1) - 1;
   out_NCW_shape[2] =
-      analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
+      analyzer->Simplify(floordiv(numerator_w, IntImm::Int32(attrs->strides[0])) + 1);
 
   ffi::Array<PrimExpr> out_shape = out2NCW.BackwardShape(out_NCW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
@@ -301,10 +300,8 @@ StructInfo InferStructInfoConv2d(const Call& call, const BlockBuilder& ctx) {
   PrimExpr input_w = data_NCHW_shape[3];
   PrimExpr kernel_h = weight_OIHW_shape[2];
   PrimExpr kernel_w = weight_OIHW_shape[3];
-  PrimExpr padding_h =
-      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
-  PrimExpr padding_w =
-      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h = IntImm::Int32(attrs->padding[0]) + IntImm::Int32(attrs->padding[2]);
+  PrimExpr padding_w = IntImm::Int32(attrs->padding[1]) + IntImm::Int32(attrs->padding[3]);
 
   std::vector<PrimExpr> out_NCHW_shape;
   out_NCHW_shape.resize(4);
@@ -312,13 +309,13 @@ StructInfo InferStructInfoConv2d(const Call& call, const BlockBuilder& ctx) {
   out_NCHW_shape[1] = weight_OIHW_shape[0];
 
   PrimExpr numerator_h =
-      input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_h - 1) - 1;
+      input_h + padding_h - IntImm::Int32(attrs->dilation[0]) * (kernel_h - 1) - 1;
   PrimExpr numerator_w =
-      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_w - 1) - 1;
+      input_w + padding_w - IntImm::Int32(attrs->dilation[1]) * (kernel_w - 1) - 1;
   out_NCHW_shape[2] =
-      analyzer->Simplify(floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
+      analyzer->Simplify(floordiv(numerator_h, IntImm::Int32(attrs->strides[0])) + 1);
   out_NCHW_shape[3] =
-      analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[1])) + 1);
+      analyzer->Simplify(floordiv(numerator_w, IntImm::Int32(attrs->strides[1])) + 1);
 
   ffi::Array<PrimExpr> out_shape = out2NCHW.BackwardShape(out_NCHW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
@@ -518,12 +515,9 @@ StructInfo InferStructInfoConv3d(const Call& call, const BlockBuilder& ctx) {
   PrimExpr kernel_d = weight_OIDHW_shape[2];
   PrimExpr kernel_h = weight_OIDHW_shape[3];
   PrimExpr kernel_w = weight_OIDHW_shape[4];
-  PrimExpr padding_d =
-      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
-  PrimExpr padding_h =
-      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
-  PrimExpr padding_w =
-      IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
+  PrimExpr padding_d = IntImm::Int32(attrs->padding[0]) + IntImm::Int32(attrs->padding[3]);
+  PrimExpr padding_h = IntImm::Int32(attrs->padding[1]) + IntImm::Int32(attrs->padding[4]);
+  PrimExpr padding_w = IntImm::Int32(attrs->padding[2]) + IntImm::Int32(attrs->padding[5]);
 
   std::vector<PrimExpr> out_NCDHW_shape;
   out_NCDHW_shape.resize(5);
@@ -531,17 +525,17 @@ StructInfo InferStructInfoConv3d(const Call& call, const BlockBuilder& ctx) {
   out_NCDHW_shape[1] = weight_OIDHW_shape[0];
 
   PrimExpr numerator_d =
-      input_d + padding_d - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_d - 1) - 1;
+      input_d + padding_d - IntImm::Int32(attrs->dilation[0]) * (kernel_d - 1) - 1;
   PrimExpr numerator_h =
-      input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_h - 1) - 1;
+      input_h + padding_h - IntImm::Int32(attrs->dilation[1]) * (kernel_h - 1) - 1;
   PrimExpr numerator_w =
-      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[2]) * (kernel_w - 1) - 1;
+      input_w + padding_w - IntImm::Int32(attrs->dilation[2]) * (kernel_w - 1) - 1;
   out_NCDHW_shape[2] =
-      analyzer->Simplify(floordiv(numerator_d, IntImm(DataType::Int(32), attrs->strides[0])) + 1);
+      analyzer->Simplify(floordiv(numerator_d, IntImm::Int32(attrs->strides[0])) + 1);
   out_NCDHW_shape[3] =
-      analyzer->Simplify(floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[1])) + 1);
+      analyzer->Simplify(floordiv(numerator_h, IntImm::Int32(attrs->strides[1])) + 1);
   out_NCDHW_shape[4] =
-      analyzer->Simplify(floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[2])) + 1);
+      analyzer->Simplify(floordiv(numerator_w, IntImm::Int32(attrs->strides[2])) + 1);
 
   ffi::Array<PrimExpr> out_shape = out2NCDHW.BackwardShape(out_NCDHW_shape);
   return TensorStructInfo(ShapeExpr(out_shape), out_dtype, vdevice);
@@ -714,17 +708,16 @@ StructInfo InferStructInfoConv1dTranspose(const Call& call, const BlockBuilder& 
 
   PrimExpr input_w = data_NCW_shape[2];
   PrimExpr kernel_w = weight_IOW_shape[2];
-  PrimExpr padding_w =
-      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
+  PrimExpr padding_w = IntImm::Int32(attrs->padding[0]) + IntImm::Int32(attrs->padding[1]);
 
   std::vector<PrimExpr> out_NCW_shape;
   out_NCW_shape.resize(3);
   out_NCW_shape[0] = data_NCW_shape[0];
   out_NCW_shape[1] = weight_IOW_shape[1] * attrs->groups;
 
-  PrimExpr out_w = (input_w - 1) * IntImm(DataType::Int(32), attrs->strides[0]) - padding_w +
-                   IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_w - 1) +
-                   IntImm(DataType::Int(32), attrs->output_padding[0]) + 1;
+  PrimExpr out_w = (input_w - 1) * IntImm::Int32(attrs->strides[0]) - padding_w +
+                   IntImm::Int32(attrs->dilation[0]) * (kernel_w - 1) +
+                   IntImm::Int32(attrs->output_padding[0]) + 1;
   out_NCW_shape[2] = analyzer->Simplify(out_w);
 
   ffi::Array<PrimExpr> out_shape = out2NCW.BackwardShape(out_NCW_shape);
@@ -907,22 +900,20 @@ StructInfo InferStructInfoConv2dTranspose(const Call& call, const BlockBuilder& 
   PrimExpr input_w = data_NCHW_shape[3];
   PrimExpr kernel_h = weight_IOHW_shape[2];
   PrimExpr kernel_w = weight_IOHW_shape[3];
-  PrimExpr padding_h =
-      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
-  PrimExpr padding_w =
-      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr padding_h = IntImm::Int32(attrs->padding[0]) + IntImm::Int32(attrs->padding[2]);
+  PrimExpr padding_w = IntImm::Int32(attrs->padding[1]) + IntImm::Int32(attrs->padding[3]);
 
   std::vector<PrimExpr> out_NCHW_shape;
   out_NCHW_shape.resize(4);
   out_NCHW_shape[0] = data_NCHW_shape[0];
   out_NCHW_shape[1] = weight_IOHW_shape[1] * attrs->groups;
 
-  PrimExpr out_h = (input_h - 1) * IntImm(DataType::Int(32), attrs->strides[0]) - padding_h +
-                   IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_h - 1) +
-                   IntImm(DataType::Int(32), attrs->output_padding[0]) + 1;
-  PrimExpr out_w = (input_w - 1) * IntImm(DataType::Int(32), attrs->strides[1]) - padding_w +
-                   IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_w - 1) +
-                   IntImm(DataType::Int(32), attrs->output_padding[1]) + 1;
+  PrimExpr out_h = (input_h - 1) * IntImm::Int32(attrs->strides[0]) - padding_h +
+                   IntImm::Int32(attrs->dilation[0]) * (kernel_h - 1) +
+                   IntImm::Int32(attrs->output_padding[0]) + 1;
+  PrimExpr out_w = (input_w - 1) * IntImm::Int32(attrs->strides[1]) - padding_w +
+                   IntImm::Int32(attrs->dilation[1]) * (kernel_w - 1) +
+                   IntImm::Int32(attrs->output_padding[1]) + 1;
   out_NCHW_shape[2] = analyzer->Simplify(out_h);
   out_NCHW_shape[3] = analyzer->Simplify(out_w);
 
@@ -1144,27 +1135,24 @@ StructInfo InferStructInfoConv3dTranspose(const Call& call, const BlockBuilder& 
   PrimExpr kernel_d = weight_IODHW_shape[2];
   PrimExpr kernel_h = weight_IODHW_shape[3];
   PrimExpr kernel_w = weight_IODHW_shape[4];
-  PrimExpr padding_d =
-      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
-  PrimExpr padding_h =
-      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
-  PrimExpr padding_w =
-      IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
+  PrimExpr padding_d = IntImm::Int32(attrs->padding[0]) + IntImm::Int32(attrs->padding[3]);
+  PrimExpr padding_h = IntImm::Int32(attrs->padding[1]) + IntImm::Int32(attrs->padding[4]);
+  PrimExpr padding_w = IntImm::Int32(attrs->padding[2]) + IntImm::Int32(attrs->padding[5]);
 
   std::vector<PrimExpr> out_NCDHW_shape;
   out_NCDHW_shape.resize(5);
   out_NCDHW_shape[0] = data_NCDHW_shape[0];
   out_NCDHW_shape[1] = weight_IODHW_shape[1] * attrs->groups;
 
-  PrimExpr out_d = (input_d - 1) * IntImm(DataType::Int(32), attrs->strides[0]) - padding_d +
-                   IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_d - 1) +
-                   IntImm(DataType::Int(32), attrs->output_padding[0]) + 1;
-  PrimExpr out_h = (input_h - 1) * IntImm(DataType::Int(32), attrs->strides[1]) - padding_h +
-                   IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_h - 1) +
-                   IntImm(DataType::Int(32), attrs->output_padding[1]) + 1;
-  PrimExpr out_w = (input_w - 1) * IntImm(DataType::Int(32), attrs->strides[2]) - padding_w +
-                   IntImm(DataType::Int(32), attrs->dilation[2]) * (kernel_w - 1) +
-                   IntImm(DataType::Int(32), attrs->output_padding[2]) + 1;
+  PrimExpr out_d = (input_d - 1) * IntImm::Int32(attrs->strides[0]) - padding_d +
+                   IntImm::Int32(attrs->dilation[0]) * (kernel_d - 1) +
+                   IntImm::Int32(attrs->output_padding[0]) + 1;
+  PrimExpr out_h = (input_h - 1) * IntImm::Int32(attrs->strides[1]) - padding_h +
+                   IntImm::Int32(attrs->dilation[1]) * (kernel_h - 1) +
+                   IntImm::Int32(attrs->output_padding[1]) + 1;
+  PrimExpr out_w = (input_w - 1) * IntImm::Int32(attrs->strides[2]) - padding_w +
+                   IntImm::Int32(attrs->dilation[2]) * (kernel_w - 1) +
+                   IntImm::Int32(attrs->output_padding[2]) + 1;
   out_NCDHW_shape[2] = analyzer->Simplify(out_d);
   out_NCDHW_shape[3] = analyzer->Simplify(out_h);
   out_NCDHW_shape[4] = analyzer->Simplify(out_w);

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -280,7 +280,7 @@ StructInfo InferStructInfoPad(const Call& call, const BlockBuilder& ctx) {
     const auto* data_shape = input_sinfo[0]->shape.as<ShapeExprNode>();
     for (int i = 0; i < ndim; i++) {
       // Sum pad width for this axis.
-      PrimExpr added_width = IntImm(DataType::Int(64), pad_width[2 * i] + pad_width[(2 * i) + 1]);
+      PrimExpr added_width = IntImm::Int64(pad_width[2 * i] + pad_width[(2 * i) + 1]);
       const PrimExpr current_width = data_shape->values[i];
       out_shape.push_back(current_width + added_width);
     }
@@ -337,7 +337,7 @@ StructInfo InferStructInfoPixelShuffle(const Call& call, const BlockBuilder& ctx
   PrimExpr h_in = in_shape[h_idx];
   PrimExpr w_in = in_shape[w_idx];
 
-  PrimExpr r_expr = IntImm(DataType::Int(32), r);
+  PrimExpr r_expr = IntImm::Int32(r);
   PrimExpr r_squared = r_expr * r_expr;
 
   const auto* c_in_imm = c_in.as<IntImmNode>();
@@ -1214,7 +1214,7 @@ StructInfo InferStructInfoBatchFlatten(const Call& call, const BlockBuilder& ctx
   }
 
   PrimExpr batch_dim = data_shape->values[0];
-  PrimExpr flat_dim = IntImm(DataType::Int(64), 1);
+  PrimExpr flat_dim = IntImm::Int64(1);
   for (size_t i = 1; i < data_shape->values.size(); ++i) {
     flat_dim = flat_dim * data_shape->values[i];
   }

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -99,9 +99,8 @@ StructInfo InferStructInfoPool1D(const Call& call, const BlockBuilder& ctx) {
   ffi::Array<PrimExpr> data_NCW_shape = data2NCW.ForwardShape(data_shape.value()->values);
 
   PrimExpr input_w = data_NCW_shape[2];
-  PrimExpr kernel_w = IntImm(DataType::Int(32), attrs->pool_size[0]);
-  PrimExpr padding_w =
-      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[1]);
+  PrimExpr kernel_w = IntImm::Int32(attrs->pool_size[0]);
+  PrimExpr padding_w = IntImm::Int32(attrs->padding[0]) + IntImm::Int32(attrs->padding[1]);
 
   arith::Analyzer analyzer = ctx->GetAnalyzer();
   std::vector<PrimExpr> out_NCW_shape;
@@ -110,14 +109,14 @@ StructInfo InferStructInfoPool1D(const Call& call, const BlockBuilder& ctx) {
   out_NCW_shape[1] = data_NCW_shape[1];
 
   PrimExpr numerator_w =
-      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_w - 1) - 1;
+      input_w + padding_w - IntImm::Int32(attrs->dilation[0]) * (kernel_w - 1) - 1;
   if (attrs->ceil_mode) {
-    numerator_w += IntImm(DataType::Int(32), attrs->strides[0]) - 1;
+    numerator_w += IntImm::Int32(attrs->strides[0]) - 1;
   }
-  PrimExpr raw_out_w = floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[0])) + 1;
+  PrimExpr raw_out_w = floordiv(numerator_w, IntImm::Int32(attrs->strides[0])) + 1;
   if (attrs->ceil_mode) {
-    PrimExpr invalid_last_w = (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >=
-                              input_w + IntImm(DataType::Int(32), attrs->padding[0]);
+    PrimExpr invalid_last_w = (raw_out_w - 1) * IntImm::Int32(attrs->strides[0]) >=
+                              input_w + IntImm::Int32(attrs->padding[0]);
     out_NCW_shape[2] = analyzer->Simplify(if_then_else(invalid_last_w, raw_out_w - 1, raw_out_w));
   } else {
     out_NCW_shape[2] = analyzer->Simplify(raw_out_w);
@@ -225,12 +224,10 @@ StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
 
   PrimExpr input_h = data_NCHW_shape[2];
   PrimExpr input_w = data_NCHW_shape[3];
-  PrimExpr kernel_h = IntImm(DataType::Int(32), attrs->pool_size[0]);
-  PrimExpr kernel_w = IntImm(DataType::Int(32), attrs->pool_size[1]);
-  PrimExpr padding_h =
-      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[2]);
-  PrimExpr padding_w =
-      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[3]);
+  PrimExpr kernel_h = IntImm::Int32(attrs->pool_size[0]);
+  PrimExpr kernel_w = IntImm::Int32(attrs->pool_size[1]);
+  PrimExpr padding_h = IntImm::Int32(attrs->padding[0]) + IntImm::Int32(attrs->padding[2]);
+  PrimExpr padding_w = IntImm::Int32(attrs->padding[1]) + IntImm::Int32(attrs->padding[3]);
 
   arith::Analyzer analyzer = ctx->GetAnalyzer();
   std::vector<PrimExpr> out_NCHW_shape;
@@ -239,20 +236,20 @@ StructInfo InferStructInfoPool2D(const Call& call, const BlockBuilder& ctx) {
   out_NCHW_shape[1] = data_NCHW_shape[1];
 
   PrimExpr numerator_h =
-      input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_h - 1) - 1;
+      input_h + padding_h - IntImm::Int32(attrs->dilation[0]) * (kernel_h - 1) - 1;
   PrimExpr numerator_w =
-      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_w - 1) - 1;
+      input_w + padding_w - IntImm::Int32(attrs->dilation[1]) * (kernel_w - 1) - 1;
   if (attrs->ceil_mode) {
-    numerator_h += IntImm(DataType::Int(32), attrs->strides[0]) - 1;
-    numerator_w += IntImm(DataType::Int(32), attrs->strides[1]) - 1;
+    numerator_h += IntImm::Int32(attrs->strides[0]) - 1;
+    numerator_w += IntImm::Int32(attrs->strides[1]) - 1;
   }
-  PrimExpr raw_out_h = floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[0])) + 1;
-  PrimExpr raw_out_w = floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[1])) + 1;
+  PrimExpr raw_out_h = floordiv(numerator_h, IntImm::Int32(attrs->strides[0])) + 1;
+  PrimExpr raw_out_w = floordiv(numerator_w, IntImm::Int32(attrs->strides[1])) + 1;
   if (attrs->ceil_mode) {
-    PrimExpr invalid_last_h = (raw_out_h - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >=
-                              input_h + IntImm(DataType::Int(32), attrs->padding[0]);
-    PrimExpr invalid_last_w = (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[1]) >=
-                              input_w + IntImm(DataType::Int(32), attrs->padding[1]);
+    PrimExpr invalid_last_h = (raw_out_h - 1) * IntImm::Int32(attrs->strides[0]) >=
+                              input_h + IntImm::Int32(attrs->padding[0]);
+    PrimExpr invalid_last_w = (raw_out_w - 1) * IntImm::Int32(attrs->strides[1]) >=
+                              input_w + IntImm::Int32(attrs->padding[1]);
     out_NCHW_shape[2] = analyzer->Simplify(if_then_else(invalid_last_h, raw_out_h - 1, raw_out_h));
     out_NCHW_shape[3] = analyzer->Simplify(if_then_else(invalid_last_w, raw_out_w - 1, raw_out_w));
   } else {
@@ -384,15 +381,12 @@ StructInfo InferStructInfoPool3D(const Call& call, const BlockBuilder& ctx) {
   PrimExpr input_d = data_NCDHW_shape[2];
   PrimExpr input_h = data_NCDHW_shape[3];
   PrimExpr input_w = data_NCDHW_shape[4];
-  PrimExpr kernel_d = IntImm(DataType::Int(32), attrs->pool_size[0]);
-  PrimExpr kernel_h = IntImm(DataType::Int(32), attrs->pool_size[1]);
-  PrimExpr kernel_w = IntImm(DataType::Int(32), attrs->pool_size[2]);
-  PrimExpr padding_d =
-      IntImm(DataType::Int(32), attrs->padding[0]) + IntImm(DataType::Int(32), attrs->padding[3]);
-  PrimExpr padding_h =
-      IntImm(DataType::Int(32), attrs->padding[1]) + IntImm(DataType::Int(32), attrs->padding[4]);
-  PrimExpr padding_w =
-      IntImm(DataType::Int(32), attrs->padding[2]) + IntImm(DataType::Int(32), attrs->padding[5]);
+  PrimExpr kernel_d = IntImm::Int32(attrs->pool_size[0]);
+  PrimExpr kernel_h = IntImm::Int32(attrs->pool_size[1]);
+  PrimExpr kernel_w = IntImm::Int32(attrs->pool_size[2]);
+  PrimExpr padding_d = IntImm::Int32(attrs->padding[0]) + IntImm::Int32(attrs->padding[3]);
+  PrimExpr padding_h = IntImm::Int32(attrs->padding[1]) + IntImm::Int32(attrs->padding[4]);
+  PrimExpr padding_w = IntImm::Int32(attrs->padding[2]) + IntImm::Int32(attrs->padding[5]);
 
   arith::Analyzer analyzer = ctx->GetAnalyzer();
   std::vector<PrimExpr> out_NCDHW_shape;
@@ -401,26 +395,26 @@ StructInfo InferStructInfoPool3D(const Call& call, const BlockBuilder& ctx) {
   out_NCDHW_shape[1] = data_NCDHW_shape[1];
 
   PrimExpr numerator_d =
-      input_d + padding_d - IntImm(DataType::Int(32), attrs->dilation[0]) * (kernel_d - 1) - 1;
+      input_d + padding_d - IntImm::Int32(attrs->dilation[0]) * (kernel_d - 1) - 1;
   PrimExpr numerator_h =
-      input_h + padding_h - IntImm(DataType::Int(32), attrs->dilation[1]) * (kernel_h - 1) - 1;
+      input_h + padding_h - IntImm::Int32(attrs->dilation[1]) * (kernel_h - 1) - 1;
   PrimExpr numerator_w =
-      input_w + padding_w - IntImm(DataType::Int(32), attrs->dilation[2]) * (kernel_w - 1) - 1;
+      input_w + padding_w - IntImm::Int32(attrs->dilation[2]) * (kernel_w - 1) - 1;
   if (attrs->ceil_mode) {
-    numerator_d += IntImm(DataType::Int(32), attrs->strides[0]) - 1;
-    numerator_h += IntImm(DataType::Int(32), attrs->strides[1]) - 1;
-    numerator_w += IntImm(DataType::Int(32), attrs->strides[2]) - 1;
+    numerator_d += IntImm::Int32(attrs->strides[0]) - 1;
+    numerator_h += IntImm::Int32(attrs->strides[1]) - 1;
+    numerator_w += IntImm::Int32(attrs->strides[2]) - 1;
   }
-  PrimExpr raw_out_d = floordiv(numerator_d, IntImm(DataType::Int(32), attrs->strides[0])) + 1;
-  PrimExpr raw_out_h = floordiv(numerator_h, IntImm(DataType::Int(32), attrs->strides[1])) + 1;
-  PrimExpr raw_out_w = floordiv(numerator_w, IntImm(DataType::Int(32), attrs->strides[2])) + 1;
+  PrimExpr raw_out_d = floordiv(numerator_d, IntImm::Int32(attrs->strides[0])) + 1;
+  PrimExpr raw_out_h = floordiv(numerator_h, IntImm::Int32(attrs->strides[1])) + 1;
+  PrimExpr raw_out_w = floordiv(numerator_w, IntImm::Int32(attrs->strides[2])) + 1;
   if (attrs->ceil_mode) {
-    PrimExpr invalid_last_d = (raw_out_d - 1) * IntImm(DataType::Int(32), attrs->strides[0]) >=
-                              input_d + IntImm(DataType::Int(32), attrs->padding[0]);
-    PrimExpr invalid_last_h = (raw_out_h - 1) * IntImm(DataType::Int(32), attrs->strides[1]) >=
-                              input_h + IntImm(DataType::Int(32), attrs->padding[1]);
-    PrimExpr invalid_last_w = (raw_out_w - 1) * IntImm(DataType::Int(32), attrs->strides[2]) >=
-                              input_w + IntImm(DataType::Int(32), attrs->padding[2]);
+    PrimExpr invalid_last_d = (raw_out_d - 1) * IntImm::Int32(attrs->strides[0]) >=
+                              input_d + IntImm::Int32(attrs->padding[0]);
+    PrimExpr invalid_last_h = (raw_out_h - 1) * IntImm::Int32(attrs->strides[1]) >=
+                              input_h + IntImm::Int32(attrs->padding[1]);
+    PrimExpr invalid_last_w = (raw_out_w - 1) * IntImm::Int32(attrs->strides[2]) >=
+                              input_w + IntImm::Int32(attrs->padding[2]);
     out_NCDHW_shape[2] = analyzer->Simplify(if_then_else(invalid_last_d, raw_out_d - 1, raw_out_d));
     out_NCDHW_shape[3] = analyzer->Simplify(if_then_else(invalid_last_h, raw_out_h - 1, raw_out_h));
     out_NCDHW_shape[4] = analyzer->Simplify(if_then_else(invalid_last_w, raw_out_w - 1, raw_out_w));
@@ -575,7 +569,7 @@ StructInfo InferStructInfoAdaptiveAvgPool1D(const Call& call, const BlockBuilder
   ffi::Array<PrimExpr> data_NCW_shape = data2NCW.ForwardShape(data_shape.value()->values);
   ffi::Array<PrimExpr> out_NCW_shape(data_NCW_shape);
   if (attrs->output_size.defined()) {
-    out_NCW_shape.Set(2, IntImm(DataType::Int(32), attrs->output_size.value()[0]));
+    out_NCW_shape.Set(2, IntImm::Int32(attrs->output_size.value()[0]));
   }
 
   ffi::Array<PrimExpr> out_shape = out2NCW.BackwardShape(out_NCW_shape);
@@ -660,8 +654,8 @@ StructInfo InferStructInfoAdaptiveAvgPool2D(const Call& call, const BlockBuilder
   ffi::Array<PrimExpr> data_NCHW_shape = data2NCHW.ForwardShape(data_shape.value()->values);
   ffi::Array<PrimExpr> out_NCHW_shape(data_NCHW_shape);
   if (attrs->output_size.defined()) {
-    out_NCHW_shape.Set(2, IntImm(DataType::Int(32), attrs->output_size.value()[0]));
-    out_NCHW_shape.Set(3, IntImm(DataType::Int(32), attrs->output_size.value()[1]));
+    out_NCHW_shape.Set(2, IntImm::Int32(attrs->output_size.value()[0]));
+    out_NCHW_shape.Set(3, IntImm::Int32(attrs->output_size.value()[1]));
   }
 
   ffi::Array<PrimExpr> out_shape = out2NCHW.BackwardShape(out_NCHW_shape);
@@ -762,9 +756,9 @@ StructInfo InferStructInfoAdaptiveAvgPool3D(const Call& call, const BlockBuilder
   ffi::Array<PrimExpr> data_NCDHW_shape = data2NCDHW.ForwardShape(data_shape.value()->values);
   ffi::Array<PrimExpr> out_NCDHW_shape(data_NCDHW_shape);
   if (attrs->output_size.defined()) {
-    out_NCDHW_shape.Set(2, IntImm(DataType::Int(32), attrs->output_size.value()[0]));
-    out_NCDHW_shape.Set(3, IntImm(DataType::Int(32), attrs->output_size.value()[1]));
-    out_NCDHW_shape.Set(4, IntImm(DataType::Int(32), attrs->output_size.value()[2]));
+    out_NCDHW_shape.Set(2, IntImm::Int32(attrs->output_size.value()[0]));
+    out_NCDHW_shape.Set(3, IntImm::Int32(attrs->output_size.value()[1]));
+    out_NCDHW_shape.Set(4, IntImm::Int32(attrs->output_size.value()[2]));
   }
 
   ffi::Array<PrimExpr> out_shape = out2NCDHW.BackwardShape(out_NCDHW_shape);

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -91,7 +91,7 @@ StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx,
 
   auto get_shape = [](const StructInfo& sinfo) -> ffi::Optional<ffi::Array<PrimExpr>> {
     if (sinfo.as<PrimStructInfoNode>()) {
-      return ffi::Array<PrimExpr>{IntImm(DataType::Int(64), 1)};
+      return ffi::Array<PrimExpr>{IntImm::Int64(1)};
     } else if (const auto* tensor = sinfo.as<TensorStructInfoNode>()) {
       return tensor->GetShape();
     } else {

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -387,7 +387,7 @@ StructInfo InferStructInfoStridedSlice(const Call& call, const BlockBuilder& ctx
 
       strides_tuple = opt_strides_tuple.value();
     } else {
-      strides_tuple = ffi::Array<PrimExpr>(axes_tuple.size(), IntImm(DataType::Int(64), 1));
+      strides_tuple = ffi::Array<PrimExpr>(axes_tuple.size(), IntImm::Int64(1));
     }
 
     TVM_FFI_ICHECK_EQ(axes_tuple.size(), strides_tuple.size())
@@ -475,7 +475,7 @@ InferLayoutOutput InferLayoutStridedSlice(
   }
 
   return InferLayoutOutput({existing_layout}, {existing_layout}, call->attrs,
-                           {{IntImm(DataType::Int(32), 1), relax::Tuple(new_axes)}});
+                           {{IntImm::Int32(1), relax::Tuple(new_axes)}});
 }
 
 TVM_REGISTER_OP("relax.strided_slice")

--- a/src/relax/op/tensor/inspect.cc
+++ b/src/relax/op/tensor/inspect.cc
@@ -93,11 +93,10 @@ tirx::PrimFunc GetDLTensorField(tirx::builtin::TVMStructFieldKind field, DataTyp
 
   tirx::Var value("value", field_dtype);
 
-  tirx::Stmt body =
-      tirx::SeqStmt({tirx::Bind(value, tirx::Call(field_dtype, tirx::builtin::tvm_struct_get(),
-                                                  {dlpack_handle, IntImm(DataType::Int(32), 0),
-                                                   IntImm(DataType::Int(32), field)})),
-                     tirx::Evaluate(tvm::ret(value))});
+  tirx::Stmt body = tirx::SeqStmt(
+      {tirx::Bind(value, tirx::Call(field_dtype, tirx::builtin::tvm_struct_get(),
+                                    {dlpack_handle, IntImm::Int32(0), IntImm::Int32(field)})),
+       tirx::Evaluate(tvm::ret(value))});
 
   DictAttrs attrs({{"tirx.is_scheduled", true}, {"tirx.is_host_func", true}});
 
@@ -309,19 +308,18 @@ Expr LegalizeTensorShape(const BlockBuilder& bb, const Call& call) {
     tirx::Stmt body = tirx::SeqStmt(
         {tirx::AssertStmt(0 <= axis, tirx::StringImm("RuntimeError"),
                           {tirx::StringImm("Specified axis may not be negative")}),
-         tirx::Bind(ndim, tirx::Call(ndim->dtype, tirx::builtin::tvm_struct_get(),
-                                     {dlpack_handle, IntImm(DataType::Int(32), 0),
-                                      IntImm(DataType::Int(32),
-                                             tirx::builtin::TVMStructFieldKind::kDLTensorNDim)})),
+         tirx::Bind(ndim,
+                    tirx::Call(ndim->dtype, tirx::builtin::tvm_struct_get(),
+                               {dlpack_handle, IntImm::Int32(0),
+                                IntImm::Int32(tirx::builtin::TVMStructFieldKind::kDLTensorNDim)})),
          tirx::AssertStmt(
              axis < tvm::cast(axis->dtype, ndim), tirx::StringImm("RuntimeError"),
              {tirx::StringImm(
                  "Specified axis may not be larger than the tensor's dimensionality")}),
          tirx::Bind(shape_buffer->data,
                     tirx::Call(DataType::Handle(), tirx::builtin::tvm_struct_get(),
-                               {dlpack_handle, IntImm(DataType::Int(32), 0),
-                                IntImm(DataType::Int(32),
-                                       tirx::builtin::TVMStructFieldKind::kDLTensorShape)})),
+                               {dlpack_handle, IntImm::Int32(0),
+                                IntImm::Int32(tirx::builtin::TVMStructFieldKind::kDLTensorShape)})),
          tirx::DeclBuffer(shape_buffer), tirx::Bind(extent, tirx::BufferLoad(shape_buffer, {axis})),
          tirx::Evaluate(tvm::ret(extent))});
 
@@ -379,7 +377,7 @@ StructInfo InferStructInfoTensorStride(const Call& call, const BlockBuilder&) {
     // striding of a tensor, it implicitly requires compact striding
     // for any legalizable Tensor.
     auto tensor_shape = opt_tensor_shape.value();
-    PrimExpr stride = IntImm(DataType::Int(64), 1);
+    PrimExpr stride = IntImm::Int64(1);
     for (size_t axis = int_imm_axis->value + 1; axis < tensor_shape.size(); axis++) {
       stride = stride * tensor_shape[axis];
     }

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -168,11 +168,11 @@ ffi::Optional<ffi::Array<PrimExpr>> CheckConcatOutputShape(
       return structural_equal(a[axis], first_concat_dim);
     });
     if (all_same) {
-      return first_concat_dim * IntImm(DataType::Int(64), shape_values.size());
+      return first_concat_dim * IntImm::Int64(shape_values.size());
     }
 
     // General case, add up the dimensions along the specified axis.
-    PrimExpr concat_sum = IntImm(DataType::Int(64), 0);
+    PrimExpr concat_sum = IntImm::Int64(0);
     for (ffi::Array<PrimExpr> shape_value : shape_values) {
       concat_sum += shape_value[axis];
     }
@@ -439,7 +439,7 @@ StructInfo InferStructInfoExpandDims(const Call& call, const BlockBuilder& ctx) 
   std::vector<PrimExpr> output_shape;
   output_shape.resize(output_ndim, PrimExpr());
   for (int i = 0; i < n_new_dim; ++i) {
-    output_shape[axes[i]] = IntImm(DataType::Int(64), 1);
+    output_shape[axes[i]] = IntImm::Int64(1);
   }
 
   int i_data_shape = 0;
@@ -507,7 +507,7 @@ TVM_REGISTER_OP("relax.expand_dims")
 
 // Helper function for flatten and reshape.
 PrimExpr ComputeShapeProduct(const ffi::Array<PrimExpr>& shape_values) {
-  PrimExpr shape_prod = IntImm(DataType::Int(64), 1);
+  PrimExpr shape_prod = IntImm::Int64(1);
   for (PrimExpr value : shape_values) {
     shape_prod *= value;
   }
@@ -623,7 +623,7 @@ StructInfo InferStructInfoIndexTensor(const Call& call, const BlockBuilder& ctx)
     // initialise broadcast result with 1's
     ffi::Array<PrimExpr> out_shape;
     for (int i = 0; i < max_index_ndim; ++i) {
-      out_shape.push_back(IntImm(DataType::Int(64), 1));
+      out_shape.push_back(IntImm::Int64(1));
     }
 
     for (const auto& ishape : index_shapes) {
@@ -973,7 +973,7 @@ Expr ConvertNewShapeToExpr(const Expr& data,
 
   // Set any -1 dimensions to complete the number of appropriate elements.
   // Start by computing the shape product of all positive indices.
-  PrimExpr new_shape_prod = IntImm(DataType::Int(64), 1);
+  PrimExpr new_shape_prod = IntImm::Int64(1);
   for (int i = 0; i < static_cast<int>(array_ref.size()); ++i) {
     PrimExpr new_dim = array_ref[i];
     const auto* int_dim = new_dim.as<IntImmNode>();
@@ -1076,7 +1076,7 @@ Expr split(Expr x, ffi::Variant<IntImm, ffi::Array<IntImm>> indices_or_sections,
         << "Split op expects the input number of sections to be a "
            "positive integer. However, the given number of sections is "
         << n_section->value;
-    indices_or_sections_obj = IntImm(DataType::Int(64), n_section->value);
+    indices_or_sections_obj = IntImm::Int64(n_section->value);
   } else {
     TVM_FFI_THROW(InternalError)
         << "Split op expects the input indices_or_sections to be either an Array of "
@@ -1478,7 +1478,7 @@ ffi::Optional<ffi::Array<PrimExpr>> CheckStackOutputShape(
   for (int i = 0; i < axis; ++i) {
     output_shape.push_back(shape_values[0][i]);
   }
-  output_shape.push_back(IntImm(DataType::Int(64), shape_values.size()));  // Stack dimension
+  output_shape.push_back(IntImm::Int64(shape_values.size()));  // Stack dimension
   for (int i = axis; i < static_cast<int>(shape_values[0].size()); ++i) {
     output_shape.push_back(shape_values[0][i]);
   }
@@ -1920,11 +1920,10 @@ StructInfo InferStructInfoTile(const Call& call, const BlockBuilder& ctx) {
     if (i < l_delta) {
       out_shape.push_back(data_shape->values[i - ndim_delta]);
     } else if (i < ndim_delta) {
-      out_shape.push_back(IntImm(DataType::Int(64), attrs->repeats[i - l_delta]));
+      out_shape.push_back(IntImm::Int64(attrs->repeats[i - l_delta]));
     } else {
-      out_shape.push_back(
-          analyzer->Simplify(data_shape->values[i - ndim_delta] *
-                             IntImm(DataType::Int(64), attrs->repeats[i - l_delta])));
+      out_shape.push_back(analyzer->Simplify(data_shape->values[i - ndim_delta] *
+                                             IntImm::Int64(attrs->repeats[i - l_delta])));
     }
   }
 

--- a/src/relax/op/tensor/set.cc
+++ b/src/relax/op/tensor/set.cc
@@ -93,7 +93,7 @@ StructInfo InferStructInfoUnique(const Call& call, const BlockBuilder& ctx) {
 
   // unique values
   if (data_sinfo->ndim == 0) {
-    output_sinfo.push_back(TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}),
+    output_sinfo.push_back(TensorStructInfo(ShapeExpr({IntImm::Int64(/*value=*/1)}),
                                             data_sinfo->dtype, data_sinfo->vdevice));
   } else if (axis.defined()) {
     output_sinfo.push_back(
@@ -107,8 +107,8 @@ StructInfo InferStructInfoUnique(const Call& call, const BlockBuilder& ctx) {
   if (f_convert_to_int64(return_index->value)) {
     TensorStructInfo index_sinfo{nullptr};
     if (data_sinfo->ndim == 0) {
-      index_sinfo = TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}),
-                                     DataType::Int(64), data_sinfo->vdevice);
+      index_sinfo = TensorStructInfo(ShapeExpr({IntImm::Int64(/*value=*/1)}), DataType::Int(64),
+                                     data_sinfo->vdevice);
     } else {
       index_sinfo = TensorStructInfo(DataType::Int(64), /*ndim=*/1, data_sinfo->vdevice);
     }
@@ -119,8 +119,8 @@ StructInfo InferStructInfoUnique(const Call& call, const BlockBuilder& ctx) {
   if (f_convert_to_int64(return_inverse->value)) {
     TensorStructInfo inverse_sinfo{nullptr};
     if (data_sinfo->ndim == 0) {
-      inverse_sinfo = TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}),
-                                       DataType::Int(64), data_sinfo->vdevice);
+      inverse_sinfo = TensorStructInfo(ShapeExpr({IntImm::Int64(/*value=*/1)}), DataType::Int(64),
+                                       data_sinfo->vdevice);
     } else {
       inverse_sinfo = TensorStructInfo(DataType::Int(64), /*ndim=*/1, data_sinfo->vdevice);
     }
@@ -131,8 +131,8 @@ StructInfo InferStructInfoUnique(const Call& call, const BlockBuilder& ctx) {
   if (f_convert_to_int64(return_counts->value)) {
     TensorStructInfo counts_sinfo{nullptr};
     if (data_sinfo->ndim == 0) {
-      counts_sinfo = TensorStructInfo(ShapeExpr({IntImm(DataType::Int(64), /*value=*/1)}),
-                                      DataType::Int(64), data_sinfo->vdevice);
+      counts_sinfo = TensorStructInfo(ShapeExpr({IntImm::Int64(/*value=*/1)}), DataType::Int(64),
+                                      data_sinfo->vdevice);
     } else {
       counts_sinfo = TensorStructInfo(DataType::Int(64), /*ndim=*/1, data_sinfo->vdevice);
     }

--- a/src/relax/op/tensor/statistical.cc
+++ b/src/relax/op/tensor/statistical.cc
@@ -68,9 +68,8 @@ StructInfo InferStructInfoStatistical(const Call& call, const BlockBuilder& ctx)
   const auto* data_shape = data_sinfo->shape.as<ShapeExprNode>();
   if (data_shape == nullptr) {
     if (!attrs->axis.defined() && attrs->keepdims && out_ndim != kUnknownNDim) {
-      return TensorStructInfo(
-          ShapeExpr(ffi::Array<PrimExpr>(out_ndim, IntImm(DataType::Int(64), /*value=*/1))),
-          data_sinfo->dtype, data_sinfo->vdevice);
+      return TensorStructInfo(ShapeExpr(ffi::Array<PrimExpr>(out_ndim, IntImm::Int64(/*value=*/1))),
+                              data_sinfo->dtype, data_sinfo->vdevice);
     } else {
       return out_ndim == 0 ? TensorStructInfo(ShapeExpr(ffi::Array<PrimExpr>()), data_sinfo->dtype,
                                               data_sinfo->vdevice)
@@ -84,7 +83,7 @@ StructInfo InferStructInfoStatistical(const Call& call, const BlockBuilder& ctx)
     if (attrs->axis.defined() && std::find(axes.begin(), axes.end(), i) == axes.end()) {
       out_shape.push_back(data_shape->values[i]);
     } else if (attrs->keepdims) {
-      out_shape.push_back(IntImm(DataType::Int(64), /*value=*/1));
+      out_shape.push_back(IntImm::Int64(/*value=*/1));
     }
   }
   TVM_FFI_ICHECK_EQ(static_cast<int>(out_shape.size()), out_ndim);
@@ -211,9 +210,8 @@ StructInfo InferStructInfoStatisticalExtension(const Call& call, const BlockBuil
   const auto* data_shape = data_sinfo->shape.as<ShapeExprNode>();
   if (data_shape == nullptr) {
     if (!attrs->axis.defined() && attrs->keepdims && out_ndim != kUnknownNDim) {
-      return TensorStructInfo(
-          ShapeExpr(ffi::Array<PrimExpr>(out_ndim, IntImm(DataType::Int(64), /*value=*/1))),
-          data_sinfo->dtype, data_sinfo->vdevice);
+      return TensorStructInfo(ShapeExpr(ffi::Array<PrimExpr>(out_ndim, IntImm::Int64(/*value=*/1))),
+                              data_sinfo->dtype, data_sinfo->vdevice);
     }
     if (out_ndim == 0) {
       return TensorStructInfo(ShapeExpr(ffi::Array<PrimExpr>()), data_sinfo->dtype,
@@ -229,7 +227,7 @@ StructInfo InferStructInfoStatisticalExtension(const Call& call, const BlockBuil
     if (attrs->axis.defined() && std::find(axes.begin(), axes.end(), i) == axes.end()) {
       out_shape.push_back(data_shape->values[i]);
     } else if (attrs->keepdims) {
-      out_shape.push_back(IntImm(DataType::Int(64), /*value=*/1));
+      out_shape.push_back(IntImm::Int64(/*value=*/1));
     }
   }
   TVM_FFI_ICHECK_EQ(static_cast<int>(out_shape.size()), out_ndim);

--- a/src/relax/op/vision/multibox_transform_loc.cc
+++ b/src/relax/op/vision/multibox_transform_loc.cc
@@ -177,7 +177,7 @@ StructInfo InferStructInfoMultiboxTransformLoc(const Call& call, const BlockBuil
     }
   }
 
-  ffi::Array<PrimExpr> boxes_shape = {batch, num_anchors, IntImm(DataType::Int(32), 4)};
+  ffi::Array<PrimExpr> boxes_shape = {batch, num_anchors, IntImm::Int32(4)};
   ffi::Array<PrimExpr> scores_shape = {batch, num_classes, num_anchors};
   ffi::Array<StructInfo> fields = {
       TensorStructInfo(ShapeExpr(boxes_shape), cls_sinfo->dtype, vdev),

--- a/src/relax/op/vision/nms.cc
+++ b/src/relax/op/vision/nms.cc
@@ -331,8 +331,7 @@ StructInfo InferStructInfoNMS(const Call& call, const BlockBuilder& ctx) {
       tvm::ffi::Array<StructInfo> fields = {
           TensorStructInfo(ffi::GetRef<ShapeExpr>(data_shape), data_sinfo->dtype, vdev),
           TensorStructInfo(ShapeExpr({batch, num_anchors}), DataType::Int(32), vdev),
-          TensorStructInfo(ShapeExpr({batch, IntImm(DataType::Int(64), 1)}), DataType::Int(32),
-                           vdev)};
+          TensorStructInfo(ShapeExpr({batch, IntImm::Int64(1)}), DataType::Int(32), vdev)};
       return TupleStructInfo(fields);
     }
 
@@ -346,8 +345,7 @@ StructInfo InferStructInfoNMS(const Call& call, const BlockBuilder& ctx) {
     auto num_anchors = data_shape->values[1];
     tvm::ffi::Array<StructInfo> fields = {
         TensorStructInfo(ShapeExpr({batch, num_anchors}), DataType::Int(32), vdev),
-        TensorStructInfo(ShapeExpr({batch, IntImm(DataType::Int(64), 1)}), DataType::Int(32),
-                         vdev)};
+        TensorStructInfo(ShapeExpr({batch, IntImm::Int64(1)}), DataType::Int(32), vdev)};
     return TupleStructInfo(fields);
   }
 

--- a/src/relax/op/vision/roi_align.cc
+++ b/src/relax/op/vision/roi_align.cc
@@ -119,12 +119,11 @@ StructInfo InferStructInfoROIAlign(const Call& call, const BlockBuilder& ctx) {
   ffi::Array<PrimExpr> data_shape = data_sinfo->shape.as<ShapeExprNode>()->values;
   ffi::Array<PrimExpr> out_shape;
   if (attrs->layout == "NCHW") {
-    out_shape = {rois_shape->values[0], data_shape[1],
-                 IntImm(DataType::Int(32), attrs->pooled_size[0]),
-                 IntImm(DataType::Int(32), attrs->pooled_size[1])};
+    out_shape = {rois_shape->values[0], data_shape[1], IntImm::Int32(attrs->pooled_size[0]),
+                 IntImm::Int32(attrs->pooled_size[1])};
   } else {
-    out_shape = {rois_shape->values[0], IntImm(DataType::Int(32), attrs->pooled_size[0]),
-                 IntImm(DataType::Int(32), attrs->pooled_size[1]), data_shape[3]};
+    out_shape = {rois_shape->values[0], IntImm::Int32(attrs->pooled_size[0]),
+                 IntImm::Int32(attrs->pooled_size[1]), data_shape[3]};
   }
   return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice);
 }

--- a/src/relax/op/vision/roi_pool.cc
+++ b/src/relax/op/vision/roi_pool.cc
@@ -111,8 +111,8 @@ StructInfo InferStructInfoROIPool(const Call& call, const BlockBuilder& ctx) {
 
   ffi::Array<PrimExpr> data_shape = data_sinfo->shape.as<ShapeExprNode>()->values;
   ffi::Array<PrimExpr> out_shape = {rois_shape->values[0], data_shape[1],
-                                    IntImm(DataType::Int(32), attrs->pooled_size[0]),
-                                    IntImm(DataType::Int(32), attrs->pooled_size[1])};
+                                    IntImm::Int32(attrs->pooled_size[0]),
+                                    IntImm::Int32(attrs->pooled_size[1])};
   return TensorStructInfo(ShapeExpr(out_shape), data_sinfo->dtype, data_sinfo->vdevice);
 }
 

--- a/src/relax/transform/adjust_matmul_order.cc
+++ b/src/relax/transform/adjust_matmul_order.cc
@@ -49,7 +49,7 @@ ffi::Array<PrimExpr> GetBatchPrefix(const ffi::Array<PrimExpr>& shape) {
 }
 
 PrimExpr ProductDims(const ffi::Array<PrimExpr>& dims) {
-  PrimExpr product = IntImm(DataType::Int(64), 1);
+  PrimExpr product = IntImm::Int64(1);
   for (const auto& dim : dims) product = product * dim;
   return product;
 }
@@ -95,7 +95,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
   auto pat = pat_matmul_on_lhs | pat_matmul_on_rhs | pat_permuted_matmul_on_lhs |
              pat_permuted_matmul_on_rhs;
 
-  PrimExpr symbolic_var_constraints = tirx::const_true();
+  PrimExpr symbolic_var_constraints = IntImm::Bool(true);
   auto upper_bounds = func->GetAttr<ffi::Map<ffi::String, Any>>("tir_var_upper_bound");
   auto lower_bounds = func->GetAttr<ffi::Map<ffi::String, Any>>("tir_var_lower_bound");
 

--- a/src/relax/transform/allocate_workspace.cc
+++ b/src/relax/transform/allocate_workspace.cc
@@ -61,8 +61,8 @@ class ExternFunctionRewriter : ExprMutator {
       // Append the workspace parameter to this function.
       ffi::Array<Var> new_params = func_node->params;
 
-      auto sinfo = TensorStructInfo(ShapeExpr({IntImm(DataType::Int(32), max_workspace_size_)}),
-                                    DataType::UInt(8));
+      auto sinfo =
+          TensorStructInfo(ShapeExpr({IntImm::Int32(max_workspace_size_)}), DataType::UInt(8));
       Var workspace_param(name_sup_->FreshName("workspace"), sinfo);
 
       if (func_node->GetAttr<ffi::String>(attr::kCodegen)) {
@@ -149,7 +149,7 @@ class WorkspaceProvider : ExprMutator {
   BindingBlock VisitBindingBlock_(const DataflowBlockNode* block_node) final {
     builder_->BeginDataflowBlock();
     if (!workspace_var_main_.defined()) {
-      auto shape = ShapeExpr({IntImm(DataType::Int(32), max_workspace_size_)});
+      auto shape = ShapeExpr({IntImm::Int32(max_workspace_size_)});
       auto ty = DataTypeImm(DataType::UInt(8));
       auto workspace = MakeAllocTensor(shape, ty, PrimValue::Int64(0));
       workspace_var_main_ = builder_->Emit(workspace, "workspace_main");

--- a/src/relax/transform/alter_op_impl.cc
+++ b/src/relax/transform/alter_op_impl.cc
@@ -45,7 +45,7 @@ static constexpr const char* kOperatorName = "operator_name";
 
 /*! \brief Construct ranges from shape dimensions */
 static ffi::Array<Range> ConstructRangeFromShape(const ffi::Array<PrimExpr>& shape) {
-  return shape.Map([](const PrimExpr& dim) { return Range(tirx::make_zero(dim.dtype()), dim); });
+  return shape.Map([](const PrimExpr& dim) { return Range(IntImm(dim.dtype(), 0), dim); });
 }
 
 static ffi::Array<PrimExpr> GetShapeFromTensorStructInfo(const TensorStructInfo& tensor_sinfo) {

--- a/src/relax/transform/combine_parallel_matmul.cc
+++ b/src/relax/transform/combine_parallel_matmul.cc
@@ -234,7 +234,7 @@ ffi::TypedFunction<ffi::Map<Var, Expr>(ffi::Map<DFPattern, Var>, ffi::Map<Var, E
         TVM_FFI_CHECK(width, InternalError)
             << "All splits except the last one must have a static shape";
         split_index += width->value;
-        sections.push_back(IntImm(DataType::Int(64), split_index));
+        sections.push_back(IntImm::Int64(split_index));
       }
 
       int lhs_dim = GetTensorSInfo(lhs)->ndim;

--- a/src/relax/transform/dataflow_inplace.cc
+++ b/src/relax/transform/dataflow_inplace.cc
@@ -368,7 +368,7 @@ class AliasAnalyzer {
 
 // given a shape, return the number of elements corresponding to it (product of elements)
 PrimExpr NumElements(const ShapeExpr& shape) {
-  PrimExpr ret = IntImm(DataType::Int(64), 1);
+  PrimExpr ret = IntImm::Int64(1);
   for (auto dim : shape->values) {
     ret *= dim;
   }
@@ -1063,7 +1063,7 @@ ffi::Array<ffi::ObjectRef> DataflowAliasAnalysis(const DataflowBlock& block,
       }
       elem_aliases.push_back(dim_aliases);
     }
-    new_tuple_map.Set(IntImm(DataType::Int(32), kv.first), elem_aliases);
+    new_tuple_map.Set(IntImm::Int32(kv.first), elem_aliases);
   }
   return {new_alias_sets, new_tuple_map};
 }

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -376,7 +376,7 @@ class ConstantFolder : public ExprMutator {
           int64_t num_elems = ndarray->shape[0];
           ffi::Array<PrimExpr> shape_values;
           for (int64_t i = 0; i < num_elems; i++) {
-            shape_values.push_back(IntImm(DataType::Int(64), data[i]));
+            shape_values.push_back(IntImm::Int64(data[i]));
           }
           return ShapeExpr(shape_values);
         }

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -155,7 +155,7 @@ class SymbolicMatcher : ExprFunctor<void(const PrimExpr& n, const PrimExpr& othe
 
   arith::AnalyzerObj* analyzer_;
   ffi::Map<tirx::Var, PrimExpr>* var_remap_;
-  PrimExpr must_prove_ = const_true();
+  PrimExpr must_prove_ = IntImm::Bool(true);
 };
 
 /*!
@@ -1021,7 +1021,7 @@ class FusedTIRConstructor : public ExprVisitor {
 
     body = subst.Substitute(body);
     body = tirx::SBlock({}, {}, {}, "root", std::move(body), std::nullopt, alloc_buffers);
-    body = tirx::SBlockRealize({}, IntImm(DataType::Bool(), 1), Downcast<tirx::SBlock>(body));
+    body = tirx::SBlockRealize({}, IntImm::Bool(true), Downcast<tirx::SBlock>(body));
     tirx::PrimFunc func(func_info_.params, body, VoidType(), func_info_.buffer_map,
                         DictAttrs(attr_map));
     // Renew function defs to prevent using the same symbolic vars in different functions

--- a/src/relax/transform/infer_amp_utils.cc
+++ b/src/relax/transform/infer_amp_utils.cc
@@ -54,11 +54,11 @@ NType NTypeMerge(const NType& a, const NType& b) {
 }
 
 ffi::Array<ffi::ObjectRef> InferMixedPrecisionFollow(const Call& call, const DataType& out_dtype) {
-  return {IntImm(DataType::Int(32), MixedPrecisionPolicyKind::kFollow), call};
+  return {IntImm::Int32(MixedPrecisionPolicyKind::kFollow), call};
 }
 
 ffi::Array<ffi::ObjectRef> InferMixedPrecisionNever(const Call& call, const DataType& out_dtype) {
-  return {IntImm(DataType::Int(32), MixedPrecisionPolicyKind::kNever), call};
+  return {IntImm::Int32(MixedPrecisionPolicyKind::kNever), call};
 }
 
 }  // namespace relax

--- a/src/relax/transform/lazy_transform_params.cc
+++ b/src/relax/transform/lazy_transform_params.cc
@@ -100,13 +100,12 @@ class LazyInputMutator : public ExprMutator {
     if (plan_) {
       Var var = ffi::GetRef<Var>(op);
       if (auto it = plan_->param_lookup.find(var); it != plan_->param_lookup.end()) {
-        auto untyped =
-            builder_->Emit(relax::Call(plan_->fget_param,
-                                       {
-                                           PrimValue(IntImm(DataType::Int(64), it->second)),
-                                           StringImm(var->name_hint()),
-                                       }),
-                           var->name_hint() + "_untyped");
+        auto untyped = builder_->Emit(relax::Call(plan_->fget_param,
+                                                  {
+                                                      PrimValue(IntImm::Int64(it->second)),
+                                                      StringImm(var->name_hint()),
+                                                  }),
+                                      var->name_hint() + "_untyped");
         return builder_->EmitMatchCast(untyped, GetStructInfo(var), var->name_hint());
       }
     }
@@ -173,8 +172,7 @@ class LazyOutputMutator : public ExprMutator {
     BindingBlock end_of_func = [&]() {
       ffi::Array<Binding> propagated_params;
       for (const auto& [output_index, expr] : inline_outputs) {
-        Call fset_output_call(fset_output,
-                              {PrimValue(IntImm(DataType::Int(64), output_index)), expr});
+        Call fset_output_call(fset_output, {PrimValue(IntImm::Int64(output_index)), expr});
         Var void_output("_void", TupleStructInfo(ffi::Array<StructInfo>{}));
         propagated_params.push_back(VarBinding(void_output, fset_output_call));
       }
@@ -215,8 +213,7 @@ class LazyOutputMutator : public ExprMutator {
     if (plan_.has_value()) {
       if (auto it = plan_->output_lookup.find(var); it != plan_->output_lookup.end()) {
         for (auto output_index : it->second) {
-          callback(
-              Call(plan_->fset_output, {PrimValue(IntImm(DataType::Int(64), output_index)), var}));
+          callback(Call(plan_->fset_output, {PrimValue(IntImm::Int64(output_index)), var}));
         }
       }
     }

--- a/src/relax/transform/lower_alloc_tensor.cc
+++ b/src/relax/transform/lower_alloc_tensor.cc
@@ -72,7 +72,7 @@ class Mutator : public ExprMutator {
       }();
 
       PrimExpr nbytes = [&]() -> PrimExpr {
-        PrimExpr nbytes = tirx::make_const(DataType::Int(64), dtype->value.bytes());
+        PrimExpr nbytes = IntImm::Int64(dtype->value.bytes());
         for (const auto& dim : shape) {
           nbytes *= dim;
         }
@@ -89,7 +89,7 @@ class Mutator : public ExprMutator {
 
       if (vdevice.defined()) {
         std::string dev_kind = vdevice.value()->target->kind->name;
-        PrimExpr dev_size = tirx::make_const(DataType::Int(64), 1);
+        PrimExpr dev_size = IntImm::Int64(1);
         if (vdevice.value()->memory_scope != "global") {
           auto device_size_handler =
               tvm::ffi::Function::GetGlobal(std::string("DeviceGetMemSize.") + dev_kind);

--- a/src/relax/transform/rewrite_cuda_graph.cc
+++ b/src/relax/transform/rewrite_cuda_graph.cc
@@ -785,10 +785,10 @@ class CUDAGraphRewriter : public ExprMutator {
       TVM_FFI_ICHECK(plan->inputs.empty());
       auto gv_alloc = gv_global_alloc_.value();
       auto ret_struct_info = Downcast<FuncStructInfo>(gv_alloc->struct_info_.value())->ret;
-      launch_subgraph = Call(
-          call_builtin_with_ctx_op,
-          {builtin_get_cached_alloc, Tuple({gv_alloc, PrimValue(IntImm(DataType::Int(64), 0))})},
-          Attrs(), {ret_struct_info});
+      launch_subgraph =
+          Call(call_builtin_with_ctx_op,
+               {builtin_get_cached_alloc, Tuple({gv_alloc, PrimValue(IntImm::Int64(0))})}, Attrs(),
+               {ret_struct_info});
     } else {
       auto gv_func = builder_->AddFunction(
           plan->func, current_func_.value()->name_hint + "_cuda_graph_capture");
@@ -816,7 +816,7 @@ class CUDAGraphRewriter : public ExprMutator {
       }
       // Arguments of builtin_run_or_capture
       ffi::Array<Expr> tuple_arg_fields{gv_func, Tuple(args),
-                                        PrimValue(IntImm(DataType::Int(64), index_capture_++))};
+                                        PrimValue(IntImm::Int64(index_capture_++))};
       if (plan->propogated_tir_vars.defined()) {
         // The shape expr is explicitly passed twice, one as the last argument of the lifted
         // function, one as the last argument of builtin_run_or_capture as the cache key. Explicitly

--- a/src/relax/transform/split_layout_rewrite_preproc.cc
+++ b/src/relax/transform/split_layout_rewrite_preproc.cc
@@ -80,7 +80,7 @@ class SplitPrimFuncLayoutRewrite : public StmtMutator {
                                                           : SeqStmt(layout_rewrite_preproc_stmts_);
     body = SBlockRealize(
         /*iter_values=*/ffi::Array<PrimExpr>(),
-        /*predicate=*/const_true(),
+        /*predicate=*/IntImm::Bool(true),
         /*block=*/
         SBlock(/*iter_vars=*/{}, /*reads=*/{}, /*writes=*/{},
                /*name_hint=*/"root", body));
@@ -124,7 +124,7 @@ class SplitPrimFuncLayoutRewrite : public StmtMutator {
 
     body = SBlockRealize(
         /*iter_values=*/ffi::Array<PrimExpr>(),
-        /*predicate=*/const_true(),
+        /*predicate=*/IntImm::Bool(true),
         /*block=*/
         SBlock(/*iter_vars=*/{}, /*reads=*/{}, /*writes=*/{},
                /*name_hint=*/"root", body,

--- a/src/relax/transform/static_plan_block_memory.cc
+++ b/src/relax/transform/static_plan_block_memory.cc
@@ -139,7 +139,7 @@ class StorageToken : public ffi::ObjectRef {
                         ffi::Optional<VDevice> vdevice = std::nullopt) {
     // Compute the tensor size from the shape.
     int64_t const_coeff = dtype.bytes() * dtype.lanes();
-    PrimExpr size = tirx::make_const(DataType::Int(64), 1);
+    PrimExpr size = IntImm::Int64(1);
     bool size_computed = false;
 
     if (vdevice.defined()) {
@@ -173,7 +173,7 @@ class StorageToken : public ffi::ObjectRef {
       }
     }
 
-    size = tirx::make_const(DataType::Int(64), const_coeff) * size;
+    size = IntImm::Int64(const_coeff) * size;
 
     ffi::ObjectPtr<StorageTokenNode> n = ffi::make_object<StorageTokenNode>();
     n->bytes = size;
@@ -259,7 +259,7 @@ class TokenAllocatorMixed {
       TVM_FFI_ICHECK_GE(available_size, 0);
       TVM_FFI_ICHECK_GE(size, available_size);
       // Enlarge the token size.
-      available_token->bytes = tirx::make_const(DataType::Int(64), size);
+      available_token->bytes = IntImm::Int64(size);
       available_token->ref_counter = prototype->ref_counter;
       pool.erase(mid);
       return available_token;
@@ -447,8 +447,8 @@ void SetTIRVarRangeConstraints(Function func, arith::AnalyzerObj* ana,
     if (it_upper != var_upper_bound_attr.end()) {
       int64_t lower = (it_lower != var_lower_bound_attr.end()) ? it_lower->second->value : 0;
       int64_t upper = it_upper->second->value;
-      tvm::Range range = tvm::Range::FromMinExtent(
-          tvm::IntImm(DataType::Int(64), lower), tvm::IntImm(DataType::Int(64), upper - lower + 1));
+      tvm::Range range = tvm::Range::FromMinExtent(tvm::IntImm::Int64(lower),
+                                                   tvm::IntImm::Int64(upper - lower + 1));
       ana->Bind(tir_var, range);
       dom_map->Set(tir_var, arith::IntSet::FromRange(range));
     } else if (it_lower != var_lower_bound_attr.end() && it_lower->second->value >= 0) {
@@ -483,7 +483,7 @@ ffi::Array<PrimExpr> GetUpperBoundShape(ffi::Array<PrimExpr> shape, arith::Analy
         upper_bounded_shape.push_back(dim_len);
       }
     } else {
-      upper_bounded_shape.push_back(tvm::IntImm(DataType::Int(64), max_bound));
+      upper_bounded_shape.push_back(tvm::IntImm::Int64(max_bound));
     }
   }
   return upper_bounded_shape;
@@ -900,7 +900,7 @@ class StorageAllocationRewriter : public ExprMutator {
       }
       constexpr static const char* plan_dyn_attr_ = "relax.memory_plan_dynamic_func_output";
       plan_dynamic_output_ = static_cast<bool>(
-          func_->GetAttr<IntImm>(plan_dyn_attr_).value_or(IntImm(DataType::Int(32), 0))->value);
+          func_->GetAttr<IntImm>(plan_dyn_attr_).value_or(IntImm::Int32(0))->value);
       if (plan_dynamic_output_) {
         SetTIRVarRangeConstraints(ffi::GetRef<Function>(func_), ana_.get(), &dom_map_);
       }
@@ -1058,7 +1058,7 @@ PrimExpr GetTextureMemorySizeFromVDevice(ffi::Array<PrimExpr> pshape, DataType d
 
   size_t size = runtime::GetTextureMemorySize<Shape>(shape, dtype.bytes() * 8, dtype.lanes(),
                                                      vdevice->memory_scope, image_row_align);
-  return tirx::make_const(DataType::Int(64), size);
+  return IntImm::Int64(size);
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/s_tir/analysis/identify_memcpy.cc
+++ b/src/s_tir/analysis/identify_memcpy.cc
@@ -107,7 +107,7 @@ std::variant<MemCpyDetails, std::string> IdentifyMemCpyImpl(const For& loop,
   //     B[i] = A[T.abs(i-8)]
 
   arith::Analyzer analyzer_ref = ffi::GetRef<arith::Analyzer>(analyzer);
-  auto src_iter_map = arith::DetectIterMap({src_index}, loop_ranges, const_true(),
+  auto src_iter_map = arith::DetectIterMap({src_index}, loop_ranges, IntImm::Bool(true),
                                            arith::IterMapLevel::Bijective, analyzer_ref);
   if (src_iter_map->errors.size()) {
     return static_cast<const std::stringstream&>(std::stringstream()
@@ -117,7 +117,7 @@ std::variant<MemCpyDetails, std::string> IdentifyMemCpyImpl(const For& loop,
                                                  << " for src_index = " << src_index)
         .str();
   }
-  auto dst_iter_map = arith::DetectIterMap({dst_index}, loop_ranges, const_true(),
+  auto dst_iter_map = arith::DetectIterMap({dst_index}, loop_ranges, IntImm::Bool(true),
                                            arith::IterMapLevel::Bijective, analyzer_ref);
   if (dst_iter_map->errors.size()) {
     return static_cast<const std::stringstream&>(std::stringstream()

--- a/src/s_tir/analysis/sblock_access_region_detector.cc
+++ b/src/s_tir/analysis/sblock_access_region_detector.cc
@@ -348,7 +348,7 @@ ffi::Array<BufferRegion> BlockReadWriteDetector::CollectRegions(
       const tvm::arith::IntSet& range = regions[i][j];
       if (range.CanProveSinglePoint(ana_)) {
         PrimExpr min = range.min();
-        region.push_back(Range::FromMinExtent(min, make_const(min.dtype(), 1)));
+        region.push_back(Range::FromMinExtent(min, MakeConst(min.dtype(), 1)));
       } else {
         region.push_back(range.CoverRange(Range::FromMinExtent(0, buffers[i]->shape[j])));
       }

--- a/src/s_tir/backend/adreno/inject_texture_alloc.cc
+++ b/src/s_tir/backend/adreno/inject_texture_alloc.cc
@@ -78,10 +78,10 @@ class TextureAllocInjector : public arith::IRMutatorWithAnalyzer {
       auto texture = ApplyTexture2DFlattening<PrimExpr>(extents, extents.size(), axis);
       ffi::Array<PrimExpr> args;
       args.push_back(StringImm(storage_scope));
-      args.push_back(IntImm(DataType::Int(64), 3));
+      args.push_back(IntImm::Int64(3));
       args.push_back(Call(DataType::Handle(), builtin::tvm_stack_make_shape(),
                           {texture.width, texture.height, texture.depth}));
-      args.push_back(IntImm(DataType::Int(64), channel_size));
+      args.push_back(IntImm::Int64(channel_size));
       stmt = Bind(op->buffer->data,
                   Call(op->buffer->data.dtype(), builtin::nd_mem_alloc_with_scope(), args));
     }

--- a/src/s_tir/backend/adreno/texture_flatten.cc
+++ b/src/s_tir/backend/adreno/texture_flatten.cc
@@ -58,7 +58,7 @@ class TextureLoweringBase : public StmtExprMutator {
 
   inline PrimExpr SimplifyOffset(const ffi::Array<PrimExpr>& shape,
                                  const ffi::Array<PrimExpr>& index) const {
-    PrimExpr base = make_const(DataType::Int(32), 0);
+    PrimExpr base = IntImm::Int32(0);
     TVM_FFI_ICHECK_EQ(shape.size(), index.size());
     if (index.size() > 0) {
       PrimExpr offset = index[0];

--- a/src/s_tir/meta_schedule/database/json_database.cc
+++ b/src/s_tir/meta_schedule/database/json_database.cc
@@ -118,7 +118,7 @@ class JSONDatabaseNode : public DatabaseNode {
     JSONFileAppendLine(
         this->path_tuning_record,
         JSONDumps(ffi::Array<Any>{
-            /*workload_index=*/IntImm(DataType::Int(32), this->workloads2idx_.at(record->workload)),
+            /*workload_index=*/IntImm::Int32(this->workloads2idx_.at(record->workload)),
             /*tuning_record=*/record->AsJSON()  //
         }));
   }

--- a/src/s_tir/meta_schedule/feature_extractor/per_store_feature.cc
+++ b/src/s_tir/meta_schedule/feature_extractor/per_store_feature.cc
@@ -273,12 +273,12 @@ Pass SimplifyForFeatureExtraction() {
           HasBufferLoad(node->condition)) {
         return ffi::GetRef<Select>(node);
       }
-      return make_const(node->dtype, 1.0);
+      return MakeConst(node->dtype, 1.0);
     }
 
     PrimExpr VisitExpr_(const VarNode* var) final {
       if (unit_vars_.count(ffi::GetRef<Var>(var))) {
-        return make_const(var->dtype, 0.0);
+        return MakeConst(var->dtype, 0.0);
       }
       return ffi::GetRef<Var>(var);
     }

--- a/src/s_tir/meta_schedule/mutator/mutate_parallel.cc
+++ b/src/s_tir/meta_schedule/mutator/mutate_parallel.cc
@@ -53,8 +53,8 @@ bool IsAnnotateWithParallel(const Instruction& inst) {
  */
 Instruction ReplaceAnnValue(Instruction inst, int64_t ann_val) {
   TVM_FFI_ICHECK_EQ(inst->inputs.size(), 2);
-  return Instruction(/*kind=*/inst->kind,                                               //
-                     /*inputs=*/{inst->inputs[0], IntImm(DataType::Int(32), ann_val)},  //
+  return Instruction(/*kind=*/inst->kind,                                   //
+                     /*inputs=*/{inst->inputs[0], IntImm::Int32(ann_val)},  //
                      /*attrs=*/inst->attrs,
                      /*outputs=*/inst->outputs);
 }

--- a/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
@@ -199,33 +199,30 @@ bool RewriteCooperativeFetchNode::Apply(const s_tir::Schedule& sch) {
       }
       if (thread_extent_y != -1) {
         if (vector_lane > 1) {
-          ffi::Array<s_tir::LoopRV> split =
-              sch->Split(fused, {std::nullopt,                                //
-                                 IntImm(DataType::Int(32), thread_extent_y),  //
-                                 IntImm(DataType::Int(32), thread_extent_x),  //
-                                 IntImm(DataType::Int(32), vector_lane)});
+          ffi::Array<s_tir::LoopRV> split = sch->Split(fused, {std::nullopt,                    //
+                                                               IntImm::Int32(thread_extent_y),  //
+                                                               IntImm::Int32(thread_extent_x),  //
+                                                               IntImm::Int32(vector_lane)});
           sch->Vectorize(split[3]);
           sch->Bind(split[2], "threadIdx.x");
           sch->Bind(split[1], "threadIdx.y");
         } else {
-          ffi::Array<s_tir::LoopRV> split =
-              sch->Split(fused, {std::nullopt,                                //
-                                 IntImm(DataType::Int(32), thread_extent_y),  //
-                                 IntImm(DataType::Int(32), thread_extent_x)});
+          ffi::Array<s_tir::LoopRV> split = sch->Split(fused, {std::nullopt,                    //
+                                                               IntImm::Int32(thread_extent_y),  //
+                                                               IntImm::Int32(thread_extent_x)});
           sch->Bind(split[2], "threadIdx.x");
           sch->Bind(split[1], "threadIdx.y");
         }
       } else {
         if (vector_lane > 1) {
-          ffi::Array<s_tir::LoopRV> split =
-              sch->Split(fused, {std::nullopt,                                //
-                                 IntImm(DataType::Int(32), thread_extent_x),  //
-                                 IntImm(DataType::Int(32), vector_lane)});
+          ffi::Array<s_tir::LoopRV> split = sch->Split(fused, {std::nullopt,                    //
+                                                               IntImm::Int32(thread_extent_x),  //
+                                                               IntImm::Int32(vector_lane)});
           sch->Vectorize(split[2]);
           sch->Bind(split[1], "threadIdx.x");
         } else {
           ffi::Array<s_tir::LoopRV> split =
-              sch->Split(fused, {std::nullopt, IntImm(DataType::Int(32), thread_extent_x)});
+              sch->Split(fused, {std::nullopt, IntImm::Int32(thread_extent_x)});
           sch->Bind(split[1], "threadIdx.x");
         }
       }

--- a/src/s_tir/meta_schedule/postproc/rewrite_parallel_vectorize_unroll.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_parallel_vectorize_unroll.cc
@@ -380,7 +380,7 @@ void RewriteFuseSplitParallelVectorize(const Schedule& sch, ffi::Array<LoopRV>* 
                                        int vec_len) {
   size_t n_loops = loop_rvs->size();
   LoopRV fused = sch->Fuse({loop_rvs->begin(), loop_rvs->end()});
-  ffi::Array<LoopRV> split = sch->Split(fused, {std::nullopt, IntImm(DataType::Int(32), vec_len)});
+  ffi::Array<LoopRV> split = sch->Split(fused, {std::nullopt, IntImm::Int32(vec_len)});
   TVM_FFI_ICHECK_EQ(split.size(), 2);
   const LoopRV& outer = split[0];
   const LoopRV& inner = split[1];
@@ -418,9 +418,8 @@ void RewriteUnroll(const Schedule& sch, int unroll_explicit, int max_step, const
     return;
   }
 
-  sch->Annotate(loop, tirx::attr::pragma_auto_unroll_max_step, IntImm(DataType::Int(32), max_step));
-  sch->Annotate(loop, tirx::attr::pragma_unroll_explicit,
-                IntImm(DataType::Int(32), unroll_explicit));
+  sch->Annotate(loop, tirx::attr::pragma_auto_unroll_max_step, IntImm::Int32(max_step));
+  sch->Annotate(loop, tirx::attr::pragma_unroll_explicit, IntImm::Int32(unroll_explicit));
 }
 
 }  // namespace s_tir

--- a/src/s_tir/meta_schedule/postproc/rewrite_unbound_block.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_unbound_block.cc
@@ -127,7 +127,7 @@ bool RewriteUnboundBlockNode::Apply(const s_tir::Schedule& sch) {
   using s_tir::Schedule;
   TVM_FFI_ICHECK_NE(this->max_threads_per_block_, -1);
   auto get_factor = [t = this->max_threads_per_block_](int max_extent) -> ExprRV {
-    return IntImm(DataType::Int(32), std::min(t, max_extent));
+    return IntImm::Int32(std::min(t, max_extent));
   };
   std::vector<std::pair<tirx::StmtSRef, ffi::String>> unbound_blocks =
       s_tir::UnboundBlockFinder::Find(sch->state());

--- a/src/s_tir/meta_schedule/postproc/verify_gpu_code.cc
+++ b/src/s_tir/meta_schedule/postproc/verify_gpu_code.cc
@@ -110,7 +110,7 @@ namespace meta_schedule {
 IntImm Extract(const Target& target, const char* name) {
   TVM_FFI_ICHECK(target.defined());
   if (ffi::Optional<int64_t> v = target->GetAttr<int64_t>(name)) {
-    return IntImm(DataType::Int(64), v.value());
+    return IntImm::Int64(v.value());
   }
   TVM_FFI_THROW(AttributedError) << "\"" << name << "\" is not defined in the target";
   throw;
@@ -129,8 +129,8 @@ class VerifyGPUCodeNode : public PostprocNode {
     this->target_constraints_ = ffi::Map<ffi::String, PrimExpr>{
         {"max_shared_memory_per_block", Extract(this->target_, "max_shared_memory_per_block")},
         {"max_threads_per_block", Extract(this->target_, "max_threads_per_block")},
-        {"max_vthread", IntImm(DataType::Int(32), 8)},
-        {"max_vector_bytes", IntImm(DataType::Int(32), 16)},
+        {"max_vthread", IntImm::Int32(8)},
+        {"max_vector_bytes", IntImm::Int32(16)},
     };
     thread_warp_size_ = static_cast<int>(Extract(this->target_, "thread_warp_size")->value);
   }

--- a/src/s_tir/meta_schedule/schedule/cuda/thread_bind.cc
+++ b/src/s_tir/meta_schedule/schedule/cuda/thread_bind.cc
@@ -55,10 +55,10 @@ std::function<ExprRV(int64_t)> MakeFactorSampler(Schedule sch, ffi::Array<int64_
     }
     int n = extents.size();
     if (n == 0) {
-      return IntImm(DataType::Int(32), max_extent);
+      return IntImm::Int32(max_extent);
     }
     if (n == 1) {
-      return IntImm(DataType::Int(32), extents[0]);
+      return IntImm::Int32(extents[0]);
     }
     ffi::Array<FloatImm> probs(n, FloatImm(DataType::Float(32), 1.0 / n));
     return sch->SampleCategorical(extents, probs);
@@ -85,9 +85,8 @@ ffi::Array<LoopRV> BindSpatialLoop(Schedule sch, LoopRV loop, int64_t max_thread
     sch->Bind(splits[1], "threadIdx.x");
     return {splits[0], splits[1]};
   } else {
-    ffi::Array<LoopRV> splits =
-        sch->Split(loop, {std::nullopt, IntImm(DataType::Int(32), max_threadblocks),  //
-                          IntImm(DataType::Int(32), max_threads_per_block)});
+    ffi::Array<LoopRV> splits = sch->Split(loop, {std::nullopt, IntImm::Int32(max_threadblocks),  //
+                                                  IntImm::Int32(max_threads_per_block)});
     TVM_FFI_ICHECK_EQ(splits.size(), 3);
     sch->Reorder({splits[1], splits[2], splits[0]});
     sch->Bind(splits[1], "blockIdx.x");

--- a/src/s_tir/meta_schedule/schedule/cuda/winograd.cc
+++ b/src/s_tir/meta_schedule/schedule/cuda/winograd.cc
@@ -139,36 +139,35 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              }
              return {sch};
            })
-      .def("s_tir.meta_schedule.cuda.conv2d_nchw_winograd_inverse",
-           [](Schedule sch, SBlockRV inverse) -> ffi::Array<Schedule> {
-             GetWinogradProducerAndInlineConst(sch, inverse);
-             // loops on top of the inverse block: [CO, P, tile_size, tile_size, alpha, alpha]
-             int64_t tile_size =
-                 Downcast<IntImm>(sch->Get(inverse)->writes[0]->buffer->shape[2])->value;
-             LoopRV outer{ffi::UnsafeInit()};
-             {
-               SBlockRV output = sch->GetConsumers(inverse)[0];
-               ffi::Array<LoopRV> nchw = sch->GetLoops(output);
-               TVM_FFI_ICHECK_EQ(nchw.size(), 4);
-               ffi::Array<LoopRV> hs =
-                   sch->Split(nchw[2], {std::nullopt, IntImm(DataType::Int(32), tile_size)});
-               ffi::Array<LoopRV> ws =
-                   sch->Split(nchw[3], {std::nullopt, IntImm(DataType::Int(32), tile_size)});
-               sch->Reorder({hs[0], ws[0], hs[1], ws[1]});
-               outer = ws[0];
-             }
-             {
-               sch->ComputeAt(inverse, /*loop_rv=*/outer, /*preserve_unit_loops=*/true);
-               sch->SetScope(inverse, /*buffer_index=*/0, /*storage_scope=*/"local");
-               ffi::Array<LoopRV> loops = sch->GetLoops(inverse);
-               TVM_FFI_ICHECK_EQ(loops.size(), 10);
-               sch->Unroll(loops[6]);
-               sch->Unroll(loops[7]);
-               sch->Unroll(loops[8]);
-               sch->Unroll(loops[9]);
-             }
-             return {sch};
-           });
+      .def(
+          "s_tir.meta_schedule.cuda.conv2d_nchw_winograd_inverse",
+          [](Schedule sch, SBlockRV inverse) -> ffi::Array<Schedule> {
+            GetWinogradProducerAndInlineConst(sch, inverse);
+            // loops on top of the inverse block: [CO, P, tile_size, tile_size, alpha, alpha]
+            int64_t tile_size =
+                Downcast<IntImm>(sch->Get(inverse)->writes[0]->buffer->shape[2])->value;
+            LoopRV outer{ffi::UnsafeInit()};
+            {
+              SBlockRV output = sch->GetConsumers(inverse)[0];
+              ffi::Array<LoopRV> nchw = sch->GetLoops(output);
+              TVM_FFI_ICHECK_EQ(nchw.size(), 4);
+              ffi::Array<LoopRV> hs = sch->Split(nchw[2], {std::nullopt, IntImm::Int32(tile_size)});
+              ffi::Array<LoopRV> ws = sch->Split(nchw[3], {std::nullopt, IntImm::Int32(tile_size)});
+              sch->Reorder({hs[0], ws[0], hs[1], ws[1]});
+              outer = ws[0];
+            }
+            {
+              sch->ComputeAt(inverse, /*loop_rv=*/outer, /*preserve_unit_loops=*/true);
+              sch->SetScope(inverse, /*buffer_index=*/0, /*storage_scope=*/"local");
+              ffi::Array<LoopRV> loops = sch->GetLoops(inverse);
+              TVM_FFI_ICHECK_EQ(loops.size(), 10);
+              sch->Unroll(loops[6]);
+              sch->Unroll(loops[7]);
+              sch->Unroll(loops[8]);
+              sch->Unroll(loops[9]);
+            }
+            return {sch};
+          });
 }
 
 }  // namespace meta_schedule

--- a/src/s_tir/meta_schedule/schedule_rule/add_rfactor.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/add_rfactor.cc
@@ -116,7 +116,7 @@ ffi::Array<s_tir::Schedule> AddRFactorNode::Apply(const s_tir::Schedule& sch,
       // Annotate that the rfactor block, which is now the producer of the original block, needs to
       // be considered by the rule Random-Compute-Location.
       sch_tmp->Annotate(block_rv, s_tir::attr::meta_schedule_random_compute_producer,
-                        IntImm(DataType::Int(32), 1));
+                        IntImm::Int32(1));
       res.push_back(sch_tmp);
     } catch (const tvm::ffi::Error& e) {
     }

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling.cc
@@ -284,9 +284,9 @@ std::vector<State> MultiLevelTilingNode::TileLoopNest(State state,
       low_inclusive = this->thread_warp_size_;
     }
     sch->Annotate(block_rv, s_tir::attr::meta_schedule_thread_extent_low_inclusive,
-                  IntImm(DataType::Int(32), low_inclusive));
+                  IntImm::Int32(low_inclusive));
     sch->Annotate(block_rv, s_tir::attr::meta_schedule_thread_extent_high_inclusive,
-                  IntImm(DataType::Int(32), high_inclusive));
+                  IntImm::Int32(high_inclusive));
   }
   return {state};
 }

--- a/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/multi_level_tiling_tensor_core.cc
@@ -425,9 +425,9 @@ std::vector<State> MultiLevelTilingTensorCoreNode::MMATileLoopNest(TensorCoreSta
       low_inclusive = this->thread_warp_size_;
     }
     sch->Annotate(block_rv, s_tir::attr::meta_schedule_thread_extent_low_inclusive,
-                  IntImm(DataType::Int(32), low_inclusive));
+                  IntImm::Int32(low_inclusive));
     sch->Annotate(block_rv, s_tir::attr::meta_schedule_thread_extent_high_inclusive,
-                  IntImm(DataType::Int(32), high_inclusive));
+                  IntImm::Int32(high_inclusive));
   }
   return {state};
 }
@@ -668,16 +668,15 @@ std::vector<State> MultiLevelTilingTensorCoreNode::AddSoftwarePipeline(
     const s_tir::SBlockRV cache_read = state->read_reuse.at(i);
     if (state->is_mma) {
       // Add vector bytes for memhammer
-      sch->Annotate(cache_read, s_tir::attr::vector_bytes, IntImm(DataType::Int(32), 16));
+      sch->Annotate(cache_read, s_tir::attr::vector_bytes, IntImm::Int32(16));
       if (!state->use_async) {
-        sch->Annotate(cache_read, s_tir::attr::local_stage, IntImm(DataType::Int(32), 1));
-        sch->Annotate(cache_read, s_tir::attr::double_buffer_scope, IntImm(DataType::Int(32), 0));
+        sch->Annotate(cache_read, s_tir::attr::local_stage, IntImm::Int32(1));
+        sch->Annotate(cache_read, s_tir::attr::double_buffer_scope, IntImm::Int32(0));
       }
     } else {
       // Add local stage and double buffering
-      sch->Annotate(cache_read, s_tir::attr::manifest_shared_memory_local_stage,
-                    IntImm(DataType::Int(32), 1));
-      sch->Annotate(cache_read, s_tir::attr::double_buffer_scope, IntImm(DataType::Int(32), 0));
+      sch->Annotate(cache_read, s_tir::attr::manifest_shared_memory_local_stage, IntImm::Int32(1));
+      sch->Annotate(cache_read, s_tir::attr::double_buffer_scope, IntImm::Int32(0));
     }
   }
 
@@ -909,7 +908,7 @@ inline std::vector<State> MultiLevelTilingTensorCoreNode::TransformForTensorizat
                        state->intrin_group.compute_intrin);
   state->sch->Annotate(state->block_rv, s_tir::attr::meta_schedule_auto_tensorize_init,
                        state->intrin_group.init_intrin);
-  state->sch->Annotate(state->block_rv, s_tir::attr::warp_execution, IntImm(DataType::Int(32), 1));
+  state->sch->Annotate(state->block_rv, s_tir::attr::warp_execution, IntImm::Int32(1));
   return {std::move(state)};
 }
 

--- a/src/s_tir/meta_schedule/schedule_rule/parallel_vectorize_unroll.cc
+++ b/src/s_tir/meta_schedule/schedule_rule/parallel_vectorize_unroll.cc
@@ -64,12 +64,12 @@ class ParallelizeVectorizeUnrollNode : public ScheduleRuleNode {
     // Parallelization
     if (max_jobs_per_core != -1) {
       sch->Annotate(root_rv, s_tir::attr::meta_schedule_parallel,
-                    IntImm(DataType::Int(32), this->max_parallel_extent_));
+                    IntImm::Int32(this->max_parallel_extent_));
     }
     // Vectorization
     if (max_vectorize_extent != -1) {
       sch->Annotate(root_rv, s_tir::attr::meta_schedule_vectorize,
-                    IntImm(DataType::Int(32), max_vectorize_extent));
+                    IntImm::Int32(max_vectorize_extent));
     }
     // Unroll
     if (!unroll_max_steps.empty() && !s_tir::CheckSpatialPrimFunc(sch, root_rv)) {

--- a/src/s_tir/schedule/analysis/layout.cc
+++ b/src/s_tir/schedule/analysis/layout.cc
@@ -40,7 +40,7 @@ ffi::Array<PrimExpr> GetStrides(const Buffer& buffer) {
     return {};
   }
   ffi::Array<PrimExpr> strides(ndim, PrimExpr{nullptr});
-  PrimExpr stride = make_const(buffer->DefaultIndexType(), 1);
+  PrimExpr stride = MakeConst(buffer->DefaultIndexType(), 1);
   for (int i = ndim - 1; i >= 0; --i) {
     strides.Set(i, stride);
     stride = stride * buffer->shape[i];
@@ -146,7 +146,7 @@ ffi::Optional<IndexMap> SuggestIndexMap(const Buffer& buffer, const ffi::Array<P
   // Step 2. Calculate a functor that flattens a multi-dimensional index
   auto f_flatten_index = [ndim, strides = GetStrides(buffer), dtype = buffer->DefaultIndexType()](
                              const ffi::Array<PrimExpr>& indices) -> PrimExpr {
-    PrimExpr flatten_index = make_const(dtype, 0);
+    PrimExpr flatten_index = IntImm(dtype, 0);
     for (int i = 0; i < ndim; ++i) {
       flatten_index = flatten_index + strides[i] * indices[i];
     }
@@ -219,16 +219,14 @@ ffi::Optional<IndexMap> SuggestIndexMap(const Buffer& buffer, const ffi::Array<P
     for (int i = 0, n = indices.size(); i < n; ++i) {
       const Var& index = indices[inverse_order[i]];
       inv_permuted_indices.push_back(index);
-      analyzer->Bind(index,
-                     Range::FromMinExtent(0, IntImm(DataType::Int(32), split_exprs[i].extent)));
+      analyzer->Bind(index, Range::FromMinExtent(0, IntImm::Int32(split_exprs[i].extent)));
     }
 
     // Step 6.2: Fuse all the indices. This is the inverse of Step 5.2.
-    PrimExpr flattened_index = make_const(indices[0]->dtype, 0);
+    PrimExpr flattened_index = IntImm(indices[0]->dtype, 0);
     int64_t stride = 1;
     for (int i = static_cast<int>(split_exprs.size()) - 1; i >= 0; --i) {
-      flattened_index =
-          inv_permuted_indices[i] * IntImm(DataType::Int(32), stride) + flattened_index;
+      flattened_index = inv_permuted_indices[i] * IntImm::Int32(stride) + flattened_index;
       stride *= split_exprs[i].extent;
     }
     // Step 6.3: Split the flattened index into multiple indices. This is the inverse of Step 5.1.

--- a/src/s_tir/schedule/concrete_schedule.cc
+++ b/src/s_tir/schedule/concrete_schedule.cc
@@ -488,7 +488,7 @@ ffi::Array<LoopRV> ConcreteScheduleNode::Split(const LoopRV& loop_rv,
   // infer factor if needed and check validity of factors
   for (size_t i = 0; i < factor_rvs.size(); i++) {
     if (!factor_rvs[i].defined()) {
-      factors.push_back(IntImm(DataType::Int(32), -1));
+      factors.push_back(IntImm::Int32(-1));
       if (infer_index != -1) {
         throw NotSingleInferFactorError(state_->mod);
       }
@@ -555,7 +555,7 @@ ffi::Array<LoopRV> ConcreteScheduleNode::LoopPartition(
   // infer factor if needed and check validity of factors
   for (size_t i = 0; i < factor_rvs.size(); i++) {
     if (!factor_rvs[i].defined()) {
-      factors.push_back(IntImm(DataType::Int(32), -1));
+      factors.push_back(IntImm::Int32(-1));
       if (infer_index != -1) {
         throw NotSingleInferFactorError(state_->mod);
       }

--- a/src/s_tir/schedule/concrete_schedule.h
+++ b/src/s_tir/schedule/concrete_schedule.h
@@ -268,7 +268,7 @@ inline PrimExpr ConcreteScheduleNode::Get(const ExprRV& expr_rv) const {
     }
     const ffi::ObjectRef& obj = (*it).second;
     const auto* int_imm = TVM_TYPE_AS(obj, IntImmNode);
-    return IntImm(DataType::Int(32), int_imm->value);
+    return IntImm::Int32(int_imm->value);
   });
   return this->analyzer_->Simplify(transformed);
 }
@@ -370,7 +370,7 @@ inline T ConcreteScheduleNode::CreateRV(const StmtSRef& sref) {
 
 inline ExprRV ConcreteScheduleNode::CreateRV(int64_t value) {
   Var rv("v" + std::to_string(this->symbol_table_.size() + 1), DataType::Int(32));
-  this->symbol_table_.Set(rv, IntImm(DataType::Int(32), static_cast<int32_t>(value)));
+  this->symbol_table_.Set(rv, IntImm::Int32(static_cast<int32_t>(value)));
   return rv;
 }
 

--- a/src/s_tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/s_tir/schedule/primitive/blockize_tensorize.cc
@@ -37,7 +37,7 @@ bool UsesVar(const T& x, const Var& var) {
 }
 
 Range RangeFromExtent(const PrimExpr& extent) {
-  return Range::FromMinExtent(make_zero(extent->dtype), extent);
+  return Range::FromMinExtent(IntImm(extent->dtype, 0), extent);
 }
 
 template <class T>
@@ -139,8 +139,8 @@ ffi::Array<ffi::Array<arith::IterMark>> TrivialSubspaceDivision(
       return {};
     }
   }
-  res.push_back({arith::IterMark(arith::IterSumExpr({}, 0), const_true()),
-                 arith::IterMark(arith::IterSumExpr({}, 0), const_true())});
+  res.push_back({arith::IterMark(arith::IterSumExpr({}, 0), IntImm::Bool(true)),
+                 arith::IterMark(arith::IterSumExpr({}, 0), IntImm::Bool(true))});
   return res;
 }
 
@@ -256,7 +256,7 @@ ffi::Map<Var, PrimExpr> DeriveBlockBinding(
       // substitution
       if (is_one(outer_mark->extent) && !preserve_unit_iters) {
         // Simplify outer if not preserve_unit_iters
-        sub = make_zero(outer_mark->extent.dtype());
+        sub = IntImm(outer_mark->extent.dtype(), 0);
       } else {
         sub = outer_iter;
       }
@@ -829,7 +829,7 @@ void Tensorize(ScheduleState self, const StmtSRef& sref, const TensorIntrin& int
     new_region.reserve(cur->shape.size());
     for (int i = 0; i < offset; i++) {
       PrimExpr min = indices_base[i];
-      PrimExpr extent = make_const(min.dtype(), 1);
+      PrimExpr extent = MakeConst(min.dtype(), 1);
       new_region.push_back(Range::FromMinExtent(min, extent));
     }
     for (int i = 0; i < static_cast<int>(old_region.size()); i++) {

--- a/src/s_tir/schedule/primitive/cache_index.cc
+++ b/src/s_tir/schedule/primitive/cache_index.cc
@@ -63,8 +63,8 @@ DataType DetermineDatatype(const arith::IntSet& range) {
   if (ana->CanProve(range.min() >= INT32_MIN && range.max() <= INT32_MAX)) {
     return DataType::Int(32);
   } else {
-    TVM_FFI_ICHECK(ana->CanProve(range.min() >= make_const(DataType::Int(64), INT64_MIN) &&
-                                 range.max() <= make_const(DataType::Int(64), INT64_MAX)));
+    TVM_FFI_ICHECK(ana->CanProve(range.min() >= IntImm::Int64(INT64_MIN) &&
+                                 range.max() <= IntImm::Int64(INT64_MAX)));
     return DataType::Int(64);
   }
 }
@@ -297,14 +297,14 @@ ffi::Array<SBlock> MakeIndexCacheStage(IndexInfo* info, const ffi::String& stora
     for (size_t i = 0; i < info->origin_block_vars[expr_index].size(); i++) {
       const Var& block_var = info->origin_block_vars[expr_index][i];
       Var var("v" + std::to_string(access_indices.size()), block_var.dtype());
-      Range range = Range::FromMinExtent(make_zero(block_var.dtype()),
+      Range range = Range::FromMinExtent(IntImm(block_var.dtype(), 0),
                                          info->range_map.at(iter_vars[i])->extent);
       block_vars.push_back(IterVar(/*dom=*/range,
                                    /*var=*/var,
                                    /*IterVarType=*/kDataPar));
 
       access_indices.push_back(var);
-      access_region.push_back(Range::FromMinExtent(var, make_const(var.dtype(), 1)));
+      access_region.push_back(Range::FromMinExtent(var, MakeConst(var.dtype(), 1)));
       block_var_map.Set(block_var, var);
     }
 
@@ -324,7 +324,7 @@ ffi::Array<SBlock> MakeIndexCacheStage(IndexInfo* info, const ffi::String& stora
     blocks.push_back(block);
     // Create the block realize node
     Stmt body = SBlockRealize(/*values=*/iter_values,
-                              /*predicate=*/const_true(),
+                              /*predicate=*/IntImm::Bool(true),
                               /*block=*/block);
     // Create surrounding loops
     for (size_t i = loop_vars.size(); i >= 1; --i) {

--- a/src/s_tir/schedule/primitive/cache_read_write.cc
+++ b/src/s_tir/schedule/primitive/cache_read_write.cc
@@ -189,13 +189,13 @@ SBlock MakeReindexCacheStage(const BufferRegion& cache_region, ReindexCacheStage
   Region& old_region = (is_cache_read) ? read_access_region : write_access_region;
   for (const Range& range : cache_region->region) {
     old_indices.push_back(Substitute(range->min, var_map));
-    old_region.push_back(Range::FromMinExtent(old_indices.back(), IntImm(DataType::Int(32), 1)));
+    old_region.push_back(Range::FromMinExtent(old_indices.back(), IntImm::Int32(1)));
   }
   ffi::Array<PrimExpr>& new_indices = (is_cache_read) ? write_access_indices : read_access_indices;
   Region& new_region = (is_cache_read) ? write_access_region : read_access_region;
   for (const PrimExpr& idx : info->indices) {
     new_indices.push_back(Substitute((idx), var_map));
-    new_region.push_back(Range::FromMinExtent(new_indices.back(), IntImm(DataType::Int(32), 1)));
+    new_region.push_back(Range::FromMinExtent(new_indices.back(), IntImm::Int32(1)));
   }
 
   // Create New Block
@@ -213,7 +213,7 @@ SBlock MakeReindexCacheStage(const BufferRegion& cache_region, ReindexCacheStage
       /*buf_doms=*/{});
   // Create SBlock Realize node
   Stmt body = SBlockRealize(/*values=*/iter_values,
-                            /*predicate=*/const_true(),
+                            /*predicate=*/IntImm::Bool(true),
                             /*block=*/block);
   // Create surrounding loops
   for (size_t i = loop_vars.size(); i >= 1; --i) {
@@ -265,32 +265,32 @@ SBlock MakeCacheStage(const BufferRegion& cache_region, CacheStageInfo* info,
     Var var("v" + std::to_string(read_access_indices.size()), axis_range->extent.dtype());
     if (cache_full_region) {
       PrimExpr dim = cache_region->buffer->shape[i];
-      block_vars.push_back(IterVar(/*dom=*/Range::FromMinExtent(make_zero(dim->dtype), dim),
+      block_vars.push_back(IterVar(/*dom=*/Range::FromMinExtent(IntImm(dim->dtype, 0), dim),
                                    /*var=*/var,
                                    /*IterVarType=*/kDataPar));
       read_access_indices.push_back(var);
       write_access_indices.push_back(var);
-      read_access_region.push_back(Range::FromMinExtent(var, make_const(var.dtype(), 1)));
-      write_access_region.push_back(Range::FromMinExtent(var, make_const(var.dtype(), 1)));
+      read_access_region.push_back(Range::FromMinExtent(var, MakeConst(var.dtype(), 1)));
+      write_access_region.push_back(Range::FromMinExtent(var, MakeConst(var.dtype(), 1)));
     } else {
       block_vars.push_back(IterVar(
-          /*dom=*/Range::FromMinExtent(make_zero(axis_range->extent.dtype()), axis_range->extent),
+          /*dom=*/Range::FromMinExtent(IntImm(axis_range->extent.dtype(), 0), axis_range->extent),
           /*var=*/var,
           /*IterVarType=*/kDataPar));
       if (cache_region->buffer.same_as(info->read_buffer)) {
         // cache_read
         read_access_indices.push_back(axis_range->min + var);
         read_access_region.push_back(
-            Range::FromMinExtent(axis_range->min + var, make_const(var.dtype(), 1)));
+            Range::FromMinExtent(axis_range->min + var, MakeConst(var.dtype(), 1)));
         write_access_indices.push_back(var);
-        write_access_region.push_back(Range::FromMinExtent(var, make_const(var.dtype(), 1)));
+        write_access_region.push_back(Range::FromMinExtent(var, MakeConst(var.dtype(), 1)));
       } else {
         // cache_write
         write_access_indices.push_back(axis_range->min + var);
         write_access_region.push_back(
-            Range::FromMinExtent(axis_range->min + var, make_const(var.dtype(), 1)));
+            Range::FromMinExtent(axis_range->min + var, MakeConst(var.dtype(), 1)));
         read_access_indices.push_back(var);
-        read_access_region.push_back(Range::FromMinExtent(var, make_const(var.dtype(), 1)));
+        read_access_region.push_back(Range::FromMinExtent(var, MakeConst(var.dtype(), 1)));
       }
     }
   }
@@ -313,7 +313,7 @@ SBlock MakeCacheStage(const BufferRegion& cache_region, CacheStageInfo* info,
       /*annotations=*/{});
   // Create the block realize node
   Stmt body = SBlockRealize(/*values=*/iter_values,
-                            /*predicate=*/const_true(),
+                            /*predicate=*/IntImm::Bool(true),
                             /*block=*/block);
   // Create surrounding loops
   for (size_t i = loop_vars.size(); i >= 1; --i) {
@@ -422,7 +422,7 @@ SBlock MakeReIndexStage(const SBlock& block, CacheStageInfo* info,
 
   // Create the block realize node
   Stmt body = SBlockRealize(/*values=*/iter_values,
-                            /*predicate=*/const_true(),
+                            /*predicate=*/IntImm::Bool(true),
                             /*block=*/new_block);
 
   // Create the chain of loops
@@ -562,7 +562,7 @@ static PrimExpr CollectNestedBlockPredicates(const Stmt& body, const Buffer& buf
                                              BufferIndexType index_type) {
   struct Collector : public StmtVisitor {
     Collector(const Buffer& buf, BufferIndexType idx_type)
-        : buffer_(buf), index_type_(idx_type), result_(const_false()), found_(false) {}
+        : buffer_(buf), index_type_(idx_type), result_(IntImm::Bool(false)), found_(false) {}
 
     void VisitStmt_(const SBlockRealizeNode* realize) final {
       const SBlockNode* block = realize->block.get();
@@ -604,7 +604,7 @@ static PrimExpr CollectNestedBlockPredicates(const Stmt& body, const Buffer& buf
   collector(body);
   // If no nested block accessed the buffer, return true (no restriction — the caller
   // will fall back to the original scope-block reads / FullRegion path).
-  return collector.found_ ? collector.result_ : const_true();
+  return collector.found_ ? collector.result_ : IntImm::Bool(true);
 }
 
 /*!
@@ -621,7 +621,7 @@ static PrimExpr CollectNestedBlockPredicates(const Stmt& body, const Buffer& buf
 BufferRegion RelaxBufferRegion(ScheduleState self, const BufferRegion& buffer_region,
                                const StmtSRef& block_sref, const StmtSRef& dom_low_inclusive,
                                const StmtSRef& dom_high_exclusive,
-                               PrimExpr extra_predicate = const_true()) {
+                               PrimExpr extra_predicate = IntImm::Bool(true)) {
   SBlockRealize realize = GetSBlockRealize(self, block_sref);
   ffi::Map<Var, PrimExpr> binding = GetBindings(realize);
   const Buffer& buffer = buffer_region->buffer;
@@ -1089,7 +1089,7 @@ class ReindexCacheReadRewriter : public CacheReadRewriter {
         if (buf_region->buffer.same_as(info_->read_buffer)) {
           Region region;
           for (const PrimExpr index : new_indices_) {
-            region.push_back(Range::FromMinExtent(index, IntImm(DataType::Int(32), 1)));
+            region.push_back(Range::FromMinExtent(index, IntImm::Int32(1)));
           }
           new_reads.push_back(BufferRegion(info_->write_buffer, region));
         } else {
@@ -1105,7 +1105,7 @@ class ReindexCacheReadRewriter : public CacheReadRewriter {
         if (source->buffer.same_as(info_->read_buffer)) {
           Region region;
           for (const PrimExpr index : new_indices_) {
-            region.push_back(Range::FromMinExtent(index, IntImm(DataType::Int(32), 1)));
+            region.push_back(Range::FromMinExtent(index, IntImm::Int32(1)));
           }
           new_match_buffers.push_back(MatchBufferRegion(match_buffer_region->buffer,
                                                         BufferRegion(info_->write_buffer, region)));
@@ -1378,7 +1378,7 @@ class ReindexCacheWriteRewriter : public CacheWriteRewriter {
         if (buf_region->buffer.same_as(info_->write_buffer)) {
           Region region;
           for (const PrimExpr index : new_indices_) {
-            region.push_back(Range::FromMinExtent(index, IntImm(DataType::Int(32), 1)));
+            region.push_back(Range::FromMinExtent(index, IntImm::Int32(1)));
           }
           new_reads.push_back(BufferRegion(info_->read_buffer, region));
         } else {
@@ -1394,7 +1394,7 @@ class ReindexCacheWriteRewriter : public CacheWriteRewriter {
         if (source->buffer.same_as(info_->write_buffer)) {
           Region region;
           for (const PrimExpr index : new_indices_) {
-            region.push_back(Range::FromMinExtent(index, IntImm(DataType::Int(32), 1)));
+            region.push_back(Range::FromMinExtent(index, IntImm::Int32(1)));
           }
           new_match_buffers.push_back(MatchBufferRegion(match_buffer_region->buffer,
                                                         BufferRegion(info_->read_buffer, region)));
@@ -1781,7 +1781,7 @@ StmtSRef CacheRead(ScheduleState self, const StmtSRef& block_sref, int read_buff
         GetBufferRegionFromBuffer(block->reads, read_buffer);
     PrimExpr nested_pred = read_region_opt ? CollectNestedBlockPredicates(block->body, read_buffer,
                                                                           BufferIndexType::kRead)
-                                           : const_true();
+                                           : IntImm::Bool(true);
     if (read_region_opt && !is_one(nested_pred) && block_sref->parent != nullptr) {
       StmtSRef parent_sref = ffi::GetRef<StmtSRef>(block_sref->parent);
       cache_region = RelaxBufferRegion(self, read_region_opt.value(), block_sref, parent_sref,

--- a/src/s_tir/schedule/primitive/compute_at.cc
+++ b/src/s_tir/schedule/primitive/compute_at.cc
@@ -263,7 +263,7 @@ class ScopeReconstructor : private StmtMutator {
     loop_vars.reserve(n_iters);
     loop_extents.reserve(n_iters);
     iter_values.reserve(n_iters);
-    PrimExpr predicate = const_true();
+    PrimExpr predicate = IntImm::Bool(true);
     for (int i = 0; i < n_iters; ++i) {
       Range iter_dom = iter_doms[i].dom.CoverRange(block_->iter_vars[i]->dom);
       if (preserve_unit_loops || !is_one(iter_dom->extent)) {
@@ -300,7 +300,7 @@ class ScopeReconstructor : private StmtMutator {
       const Var& loop_var = loop_vars[i];
       const PrimExpr& loop_extent = loop_extents[i];
       new_subtree = For(/*loop_var=*/loop_var,
-                        /*min=*/IntImm(DataType::Int(32), 0),
+                        /*min=*/IntImm::Int32(0),
                         /*extent=*/loop_extent,
                         /*ForKind=*/ForKind::kSerial,
                         /*body=*/std::move(new_subtree));
@@ -569,7 +569,7 @@ bool UpdateBlockVarDomainAffine(const BufferNode* buffer, const ffi::Array<IterV
   for (size_t i = 0; i < ndim; ++i) {
     provide_indices.push_back(provided_region[i].min());
   }
-  auto res = arith::DetectIterMap(provide_indices, dom_map, const_true(),
+  auto res = arith::DetectIterMap(provide_indices, dom_map, IntImm::Bool(true),
                                   arith::IterMapLevel::Bijective, analyzer_ref, false);
   if (res->indices.empty()) {
     return false;
@@ -578,7 +578,7 @@ bool UpdateBlockVarDomainAffine(const BufferNode* buffer, const ffi::Array<IterV
   NDIntSet required_bound;
   for (size_t i = 0; i < ndim; ++i) {
     required_bound.push_back(
-        arith::IntSet::Interval(make_zero(buffer->shape[i]->dtype), max(buffer->shape[i] - 1, 0)));
+        arith::IntSet::Interval(IntImm(buffer->shape[i]->dtype, 0), max(buffer->shape[i] - 1, 0)));
   }
   ffi::Map<Var, arith::IntSet> var_dom =
       InverseAffineIterMap(res->indices, required_region, analyzer);

--- a/src/s_tir/schedule/primitive/compute_inline.cc
+++ b/src/s_tir/schedule/primitive/compute_inline.cc
@@ -625,7 +625,7 @@ class ReverseComputeInliner : public BaseInliner {
         producer_block_(producer_block),
         consumer_block_(consumer_block_realize->block.get()) {
     // Initialize the predicates to ensure consumer block iters are in-bound
-    consumer_iter_in_bound_ = const_true();
+    consumer_iter_in_bound_ = IntImm::Bool(true);
     for (const IterVar& iter : consumer_block_realize->block->iter_vars) {
       consumer_iter_in_bound_ =
           consumer_iter_in_bound_ &&
@@ -726,7 +726,7 @@ class ReverseComputeInliner : public BaseInliner {
     if (producer_block->annotations.count(s_tir::attr::auto_copy) != 0) {
       auto bind = [&](const ForNode* loop) {
         analyzer_->Bind(loop->loop_var,
-                        Range::FromMinExtent(make_zero(loop->extent->dtype), loop->extent));
+                        Range::FromMinExtent(IntImm(loop->extent->dtype, 0), loop->extent));
       };
       const ForNode* producer_inner_loop = producer_block->body.as<ForNode>();
       while (producer_inner_loop->body.as<ForNode>()) {
@@ -1288,7 +1288,7 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
   };
 
   // Identity element for reduction (assumed to be 0 for addition-based reductions)
-  PrimExpr identity_elem = tirx::make_zero(epilogue_output_buffer_->dtype);
+  PrimExpr identity_elem = MakeConst(epilogue_output_buffer_->dtype, 0);
 
   // Substitute reduction buffer load with identity element
   InitSubstituter init_subst(inlined_buffer_, identity_elem);

--- a/src/s_tir/schedule/primitive/decompose_padding.cc
+++ b/src/s_tir/schedule/primitive/decompose_padding.cc
@@ -139,7 +139,7 @@ class PaddingInfoAnalyzer {
 
   /*! \brief Rewrite predicate to left recursive conjunction, drop likely annotation. */
   PrimExpr RewritePredicate(const PrimExpr& predicate) {
-    PrimExpr res = const_true();
+    PrimExpr res = IntImm::Bool(true);
     std::function<void(PrimExpr)> update = [&res, &update](PrimExpr e) {
       arith::PVar<PrimExpr> a, b;
       if ((a && b).Match(e)) {
@@ -291,7 +291,7 @@ static std::pair<Stmt, SBlockRealize> CreateInBoundBlock(const SBlockRealizeNode
     const IterVar& origin_itervar = block->iter_vars[i];
     Var new_var = origin_itervar->var.copy_with_suffix("");
     Range new_range =
-        Range::FromMinExtent(make_const(new_var->dtype, 0), info.in_bound_region[i]->extent);
+        Range::FromMinExtent(IntImm(new_var->dtype, 0), info.in_bound_region[i]->extent);
     new_iter_vars.push_back(IterVar(new_range, new_var, IterVarType::kDataPar));
     repl_dict.Set(origin_itervar->var, new_var + info.in_bound_region[i]->min);
 

--- a/src/s_tir/schedule/primitive/layout_transformation.cc
+++ b/src/s_tir/schedule/primitive/layout_transformation.cc
@@ -315,7 +315,7 @@ class TransformLayoutPlanner : private StmtExprVisitor {
         PrimExpr dim = new_buffer->shape[i];
         new_iter_values.push_back(var);
         new_iter_vars.push_back(
-            IterVar(Range::FromMinExtent(make_zero(dim.dtype()), dim), virtual_var, kDataPar));
+            IterVar(Range::FromMinExtent(IntImm(dim.dtype(), 0), dim), virtual_var, kDataPar));
         loop_var_to_virtual_var.Set(var, virtual_var);
       }
 
@@ -494,7 +494,7 @@ class TransformLayoutPlanner : private StmtExprVisitor {
     std::stringstream block_name;
     block_name << "buffer_" << new_buffer->name << "_assumptions";
     auto read_region = BufferRegion::FromPoint(new_buffer, indices);
-    stmt = SBlockRealize(iter_values, const_true(),
+    stmt = SBlockRealize(iter_values, IntImm::Bool(true),
                          SBlock(iter_vars, {read_region}, {}, block_name.str(), stmt));
 
     for (size_t rev_i = 0; rev_i < inverse->initial_indices.size(); rev_i++) {
@@ -1141,7 +1141,7 @@ IndexMap LegalizeIndexMapDType(const IndexMap& index_map, const ffi::Array<PrimE
     auto final_indices = index_map->final_indices.Map([&](PrimExpr index) {
       if (auto* ptr = index.as<IntImmNode>()) {
         TVM_FFI_ICHECK(index_dtype.has_value());
-        return tirx::make_const(*index_dtype, ptr->value);
+        return tirx::MakeConst(*index_dtype, ptr->value);
       } else {
         return SubstituteWithDataTypeLegalization(index,
                                                   [&](const Var& var) { return var_map.Get(var); });
@@ -1190,12 +1190,12 @@ void TransformLayout(ScheduleState self, const StmtSRef& block_sref, int buffer_
   const SBlockNode* scope_block = TVM_SREF_TO_SBLOCK(scope_sref);
 
   ffi::Optional<IndexMap> opt_inverse = std::nullopt;
-  PrimExpr padding_predicate = const_false();
+  PrimExpr padding_predicate = IntImm::Bool(false);
   if (!assume_injective_transform) {
     std::tie(opt_inverse, padding_predicate) = [&]() {
       ffi::Array<Range> region;
       for (const auto& dim : old_buffer->shape) {
-        region.push_back(Range::FromMinExtent(make_zero(dim.dtype()), dim));
+        region.push_back(Range::FromMinExtent(IntImm(dim.dtype(), 0), dim));
       }
       return index_map.NonSurjectiveInverse(region, analyzer);
     }();
@@ -1427,7 +1427,7 @@ void TransformBlockLayout(ScheduleState self, const StmtSRef& block_sref,
     }
     auto dtype = new_block_var.dtype();
     new_block_iters.push_back(IterVar(
-        /*dom=*/Range::FromMinExtent(make_zero(dtype), cast(dtype, new_block_iter_range[i])),
+        /*dom=*/Range::FromMinExtent(IntImm(dtype, 0), cast(dtype, new_block_iter_range[i])),
         /*var=*/std::move(new_block_var), /*iter_type=*/iter_type));
   }
 
@@ -1438,7 +1438,7 @@ void TransformBlockLayout(ScheduleState self, const StmtSRef& block_sref,
   {
     ffi::Array<Range> initial_ranges;
     for (const PrimExpr& extent : block_iter_range_array) {
-      initial_ranges.push_back(Range::FromMinExtent(make_const(extent.dtype(), 0), extent));
+      initial_ranges.push_back(Range::FromMinExtent(IntImm(extent.dtype(), 0), extent));
     }
     IndexMap inverse_index_map{nullptr};
     try {
@@ -1508,8 +1508,8 @@ class BufferAxisSeparatorMutator : private ReplaceBufferMutator {
       if (new_target_buffer->shape.size() == new_source_buffer->shape.size()) {
         new_target_buffer.CopyOnWrite()->axis_separators = new_source_buffer->axis_separators;
       } else {
-        new_target_buffer.CopyOnWrite()->axis_separators = ffi::Array<IntImm>(
-            new_source_buffer->axis_separators.size(), IntImm(DataType::Int(32), 0));
+        new_target_buffer.CopyOnWrite()->axis_separators =
+            ffi::Array<IntImm>(new_source_buffer->axis_separators.size(), IntImm::Int32(0));
         LOG(WARNING) << "Buffer view " << new_target_buffer
                      << " has different dimensionality than backing buffer " << new_source_buffer
                      << ".  The `axis_separators` for " << new_target_buffer << "."

--- a/src/s_tir/schedule/primitive/loop_transformation.cc
+++ b/src/s_tir/schedule/primitive/loop_transformation.cc
@@ -419,14 +419,14 @@ ffi::Array<StmtSRef> Split(ScheduleState self, const StmtSRef& loop_sref,
     dtype = DataType::Int(bits);
   }
   int n = factors.size();
-  PrimExpr substitute_value = make_const(dtype, 0);
+  PrimExpr substitute_value = IntImm(dtype, 0);
   std::vector<Var> new_loop_vars;
   new_loop_vars.reserve(n);
   for (int i = 0; i < n; i++) {
     const PrimExpr& factor = factors[i];
     Var var = loop->loop_var.copy_with_suffix("_" + std::to_string(i)).copy_with_dtype(dtype);
     substitute_value = substitute_value * factor + var;
-    analyzer->Bind(var, Range::FromMinExtent(make_const(dtype, 0), tvm::cast(dtype, factor)));
+    analyzer->Bind(var, Range::FromMinExtent(IntImm(dtype, 0), tvm::cast(dtype, factor)));
     new_loop_vars.emplace_back(std::move(var));
   }
   ffi::Map<SBlock, SBlock> opaque_block_reuse;
@@ -693,7 +693,7 @@ ffi::Array<StmtSRef> LoopPartition(ScheduleState self, const StmtSRef& loop_sref
   }
 
   // Create common block with all the partitioned blocks as its children blocks
-  SBlockRealize common({}, make_const(DataType::Bool(), 1),
+  SBlockRealize common({}, IntImm::Bool(true),
                        SBlock({}, {}, {}, block_name + "_common", tirx::SeqStmt(block_partitions)));
 
   // Replace existing loop with the newly created common block
@@ -744,14 +744,13 @@ class LoopReconstructor : private StmtMutator {
       new_stmts.push_back(new_stmt);
       this->need_remove_loop_.push_back(loops_[i].back());
     }
-    auto new_loop = For(new_loop_vars[0], IntImm(DataType::Int(32), 0), new_loop_extents[0],
-                        ForKind::kSerial, SeqStmt(std::move(new_stmts)));
+    auto new_loop = For(new_loop_vars[0], IntImm::Int32(0), new_loop_extents[0], ForKind::kSerial,
+                        SeqStmt(std::move(new_stmts)));
     this->new_inner_loop_ = new_loop;
     for (size_t i = 1; i < new_loop_vars.size(); ++i) {
       const Var& loop_var = new_loop_vars[i];
       const PrimExpr& loop_extent = new_loop_extents[i];
-      new_loop =
-          For(loop_var, IntImm(DataType::Int(32), 0), loop_extent, ForKind::kSerial, new_loop);
+      new_loop = For(loop_var, IntImm::Int32(0), loop_extent, ForKind::kSerial, new_loop);
     }
     this->new_outer_loop_ = new_loop;
   }

--- a/src/s_tir/schedule/primitive/pad_einsum.cc
+++ b/src/s_tir/schedule/primitive/pad_einsum.cc
@@ -183,15 +183,15 @@ struct BufferPadding {
     }
     Stmt body{nullptr};
     if (is_read) {
-      PrimExpr predicate = const_true();
+      PrimExpr predicate = IntImm::Bool(true);
       for (int i = 0; i < ndim; ++i) {
         if (!analyzer->CanProveEqual(buffer->shape[i], padded_buffer->shape[i])) {
           predicate = predicate && (indices[i] < buffer->shape[i]);
         }
       }
       PrimExpr rhs = BufferLoad(buffer, indices);
-      body =
-          BufferStore(padded_buffer, if_then_else(predicate, rhs, make_zero(rhs->dtype)), indices);
+      body = BufferStore(padded_buffer, if_then_else(predicate, rhs, MakeConst(rhs->dtype, 0)),
+                         indices);
     } else {
       body = BufferStore(buffer, BufferLoad(padded_buffer, indices), indices);
     }
@@ -203,8 +203,8 @@ struct BufferPadding {
     SBlock new_block(iter_vars, {read_region}, {write_region}, padded_buffer->name,
                      std::move(body));
     blocks->push_back(new_block);
-    body = SBlockRealize(ffi::Array<PrimExpr>{loop_vars.begin(), loop_vars.end()}, const_true(),
-                         new_block);
+    body = SBlockRealize(ffi::Array<PrimExpr>{loop_vars.begin(), loop_vars.end()},
+                         IntImm::Bool(true), new_block);
     for (int i = ndim - 1; i >= 0; --i) {
       body = For(loop_vars[i], loop_doms[i]->min, loop_doms[i]->extent, ForKind::kSerial,
                  std::move(body));

--- a/src/s_tir/schedule/primitive/read_write_at.cc
+++ b/src/s_tir/schedule/primitive/read_write_at.cc
@@ -306,12 +306,11 @@ struct ReadWriteAtImpl {
     }
     Stmt stmt = BufferStore(copy_to, /*value=*/BufferLoad(copy_from, indices), /*indices=*/indices);
     for (int i = n - 1; i >= 0; --i) {
-      stmt = For(loop_vars[i], IntImm(DataType::Int(32), 0), domain[i]->extent, ForKind::kSerial,
-                 stmt);
+      stmt = For(loop_vars[i], IntImm::Int32(0), domain[i]->extent, ForKind::kSerial, stmt);
     }
     return SBlockRealize(
         /*values=*/iter_values,
-        /*predicate=*/const_true(),
+        /*predicate=*/IntImm::Bool(true),
         SBlock(/*iter_vars=*/iter_vars,
                /*reads=*/{BufferRegion(copy_from, domain)},
                /*writes=*/{BufferRegion(copy_to, domain)},

--- a/src/s_tir/schedule/primitive/reduction.cc
+++ b/src/s_tir/schedule/primitive/reduction.cc
@@ -158,8 +158,8 @@ class LoopHeightError : public ScheduleError {
 };
 
 PrimExpr RemakePredicate(PrimExpr pred, const std::unordered_set<const VarNode*>& discarded_loops) {
-  if (is_one(pred)) return const_true();
-  PrimExpr new_pred = const_true();
+  if (is_one(pred)) return IntImm::Bool(true);
+  PrimExpr new_pred = IntImm::Bool(true);
   auto f = [&](const VarNode* var) { return discarded_loops.count(var); };
   arith::PVar<PrimExpr> lhs, rhs, rest;
   for (;;) {
@@ -318,7 +318,7 @@ struct ReducerRegistry {
                   return ffi::Array<PrimExpr>{x[0] + y[0]};
                 },
                 [](const ffi::Array<PrimExpr>& values) {
-                  return ffi::Array<PrimExpr>{make_const(values[0]->dtype, 0)};
+                  return ffi::Array<PrimExpr>{MakeConst(values[0]->dtype, 0)};
                 }),
             CreateReducerGetter(
                 /*n_buffers=*/1,
@@ -326,7 +326,7 @@ struct ReducerRegistry {
                   return ffi::Array<PrimExpr>{x[0] * y[0]};
                 },
                 [](const ffi::Array<PrimExpr>& values) {
-                  return ffi::Array<PrimExpr>{make_const(values[0]->dtype, 1)};
+                  return ffi::Array<PrimExpr>{MakeConst(values[0]->dtype, 1)};
                 }),
             CreateReducerGetter(
                 /*n_buffers=*/1,
@@ -350,8 +350,8 @@ struct ReducerRegistry {
                   return ffi::Array<PrimExpr>{x[0] + y[0], x[1] + y[1]};
                 },
                 [](const ffi::Array<PrimExpr>& values) {
-                  return ffi::Array<PrimExpr>{make_const(values[0]->dtype, 0),
-                                              make_const(values[1]->dtype, 0)};
+                  return ffi::Array<PrimExpr>{MakeConst(values[0]->dtype, 0),
+                                              MakeConst(values[1]->dtype, 0)};
                 }),
             CreateReducerGetter(
                 /*n_buffers=*/2,
@@ -361,7 +361,7 @@ struct ReducerRegistry {
                   return ffi::Array<PrimExpr>{idx, val};
                 },
                 [](const ffi::Array<PrimExpr>& values) {
-                  return ffi::Array<PrimExpr>{make_const(values[0]->dtype, -1),
+                  return ffi::Array<PrimExpr>{MakeConst(values[0]->dtype, -1),
                                               min_value(values[1]->dtype)};
                 }),
             CreateReducerGetter(
@@ -374,7 +374,7 @@ struct ReducerRegistry {
                   return ffi::Array<PrimExpr>{idx, val};
                 },
                 [](const ffi::Array<PrimExpr>& values) {
-                  return ffi::Array<PrimExpr>{make_const(values[0]->dtype, -1),
+                  return ffi::Array<PrimExpr>{MakeConst(values[0]->dtype, -1),
                                               min_value(values[1]->dtype)};
                 }),
             CreateReducerGetter(
@@ -385,7 +385,7 @@ struct ReducerRegistry {
                   return ffi::Array<PrimExpr>{idx, val};
                 },
                 [](const ffi::Array<PrimExpr>& values) {
-                  return ffi::Array<PrimExpr>{make_const(values[0]->dtype, -1),
+                  return ffi::Array<PrimExpr>{MakeConst(values[0]->dtype, -1),
                                               max_value(values[1]->dtype)};
                 }),
             CreateReducerGetter(
@@ -397,7 +397,7 @@ struct ReducerRegistry {
                   return ffi::Array<PrimExpr>{idx, val};
                 },
                 [](const ffi::Array<PrimExpr>& values) {
-                  return ffi::Array<PrimExpr>{make_const(values[0]->dtype, -1),
+                  return ffi::Array<PrimExpr>{MakeConst(values[0]->dtype, -1),
                                               max_value(values[1]->dtype)};
                 })} {}
 
@@ -693,7 +693,7 @@ class BaseBlockCreator {
     CreateReadWriteRegions();
 
     ffi::String new_block_name = old_block_realize_->block->name_hint;
-    PrimExpr predicate = const_true();
+    PrimExpr predicate = IntImm::Bool(true);
     if (is_rf_block_) {
       new_block_name = new_block_name + "_rf";
       predicate = old_block_realize_->predicate;
@@ -930,9 +930,9 @@ class RFactorBlockCreator : public BaseBlockCreator {
     write_regions_.reserve(old_block->writes.size());
     for (const BufferRegion& write_region : old_block->writes) {
       ffi::Array<Range> region = write_region->region;
-      region.insert(region.begin() + factor_axis_,
-                    Range::FromMinExtent(additional_iter_->var,
-                                         make_const(additional_iter_->var.dtype(), 1)));
+      region.insert(
+          region.begin() + factor_axis_,
+          Range::FromMinExtent(additional_iter_->var, MakeConst(additional_iter_->var.dtype(), 1)));
       ffi::Optional<Buffer> rf_buffer = buffer_map.Get(write_region->buffer);
       TVM_FFI_ICHECK(rf_buffer.defined());
       write_regions_.push_back(BufferRegion(rf_buffer.value(), Substitute(region, var_map_)));
@@ -1025,7 +1025,7 @@ class WriteBackBlockCreator : public BaseBlockCreator {
       ffi::Array<Range> region;
       region.reserve(buf_load->indices.size());
       for (const PrimExpr& index : buf_load->indices) {
-        region.push_back(Range::FromMinExtent(index, make_const(index.dtype(), 1)));
+        region.push_back(Range::FromMinExtent(index, MakeConst(index.dtype(), 1)));
       }
       buf_regions.push_back(BufferRegion(buf_load->buffer, std::move(region)));
     }

--- a/src/s_tir/schedule/state.cc
+++ b/src/s_tir/schedule/state.cc
@@ -1017,9 +1017,9 @@ void ScheduleStateNode::UpdateScopeSBlockInfo(const Stmt& stmt) {
 
 TVM_DLL ffi::Array<IntImm> GetCachedFlags(const ScheduleState& self, const StmtSRef& block_sref) {
   const SBlockInfo& info = self->GetSBlockInfo(block_sref);
-  return {IntImm(DataType::Bool(), info.affine_binding),  //
-          IntImm(DataType::Bool(), info.region_cover),    //
-          IntImm(DataType::Bool(), info.stage_pipeline)};
+  return {IntImm::Bool(info.affine_binding),  //
+          IntImm::Bool(info.region_cover),    //
+          IntImm::Bool(info.stage_pipeline)};
 }
 
 /**************** FFI ****************/

--- a/src/s_tir/schedule/trace.cc
+++ b/src/s_tir/schedule/trace.cc
@@ -405,7 +405,7 @@ ffi::ObjectRef TraceNode::AsJSON(bool remove_postproc) const {
     Any decision = this->GetDecision(inst);
     if (decision != nullptr) {
       json_decisions.push_back(ffi::Array<ffi::Any>{
-          /* 0: index    */ IntImm(DataType::Int(32), i),
+          /* 0: index    */ IntImm::Int32(i),
           /* 1: decision */ decision,
       });
     }

--- a/src/s_tir/schedule/traced_schedule.cc
+++ b/src/s_tir/schedule/traced_schedule.cc
@@ -80,7 +80,7 @@ ffi::Array<ExprRV> TracedScheduleNode::SamplePerfectTile(
       /*inst=*/Instruction(
           /*kind=*/kind,  //
           /*inputs=*/{loop_rv},
-          /*attrs=*/{IntImm(DataType::Int(32), n), IntImm(DataType::Int(32), max_innermost_factor)},
+          /*attrs=*/{IntImm::Int32(n), IntImm::Int32(max_innermost_factor)},
           /*outputs=*/results),
       /*decision=*/decision);
   return results;
@@ -93,14 +93,14 @@ ffi::Array<ExprRV> TracedScheduleNode::SamplePartitionedTile(
       &this->rand_state_, this->GetSRef(loop_rv), n, partition_pos, innerpart_factor, &decision));
 
   static const InstructionKind& kind = InstructionKind::Get("SamplePartitionedTile");
-  trace_->Append(/*inst=*/Instruction(
-                     /*kind=*/kind,  //
-                     /*inputs=*/{loop_rv},
-                     /*attrs=*/
-                     {IntImm(DataType::Int(32), n), IntImm(DataType::Int(32), partition_pos),
-                      IntImm(DataType::Int(32), innerpart_factor)},
-                     /*outputs=*/results),
-                 /*decision=*/decision);
+  trace_->Append(
+      /*inst=*/Instruction(
+          /*kind=*/kind,  //
+          /*inputs=*/{loop_rv},
+          /*attrs=*/
+          {IntImm::Int32(n), IntImm::Int32(partition_pos), IntImm::Int32(innerpart_factor)},
+          /*outputs=*/results),
+      /*decision=*/decision);
   return results;
 }
 
@@ -227,7 +227,7 @@ LoopRV TracedScheduleNode::Fuse(const ffi::Array<LoopRV>& loop_rvs, bool preserv
   static const InstructionKind& kind = InstructionKind::Get("Fuse");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/loop_rvs,
-                                      /*attrs=*/{IntImm(DataType::Int(32), preserve_unit_loops)},
+                                      /*attrs=*/{IntImm::Int32(preserve_unit_loops)},
                                       /*outputs=*/{result}));
   return result;
 }
@@ -270,7 +270,7 @@ ffi::Array<LoopRV> TracedScheduleNode::LoopPartition(
   static const InstructionKind& kind = InstructionKind::Get("LoopPartition");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/inputs,
-                                      /*attrs=*/{IntImm(DataType::Int(32), preserve_unit_iters)},
+                                      /*attrs=*/{IntImm::Int32(preserve_unit_iters)},
                                       /*outputs=*/results));
   return results;
 }
@@ -369,7 +369,7 @@ SBlockRV TracedScheduleNode::CacheRead(const SBlockRV& block_rv, int read_buffer
   trace_->Append(
       /*inst=*/Instruction(/*kind=*/kind,
                            /*inputs=*/{block_rv, consumer_blocks},
-                           /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
+                           /*attrs=*/{IntImm::Int32(read_buffer_index), storage_scope},
                            /*outputs=*/{result}));
   return result;
 }
@@ -384,7 +384,7 @@ SBlockRV TracedScheduleNode::CacheWrite(const SBlockRV& block_rv, int write_buff
   trace_->Append(
       /*inst=*/Instruction(/*kind=*/kind,
                            /*inputs=*/{block_rv, consumer_blocks},
-                           /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index), storage_scope},
+                           /*attrs=*/{IntImm::Int32(write_buffer_index), storage_scope},
                            /*outputs=*/{result}));
   return result;
 }
@@ -400,7 +400,7 @@ SBlockRV TracedScheduleNode::ReindexCacheRead(const SBlockRV& block_rv, int read
       /*inst=*/Instruction(
           /*kind=*/kind,
           /*inputs=*/{block_rv, index_map},
-          /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
+          /*attrs=*/{IntImm::Int32(read_buffer_index), storage_scope},
           /*outputs=*/{result}));
   return result;
 }
@@ -416,7 +416,7 @@ SBlockRV TracedScheduleNode::ReindexCacheWrite(const SBlockRV& block_rv, int wri
       /*inst=*/Instruction(
           /*kind=*/kind,
           /*inputs=*/{block_rv, index_map},
-          /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index), storage_scope},
+          /*attrs=*/{IntImm::Int32(write_buffer_index), storage_scope},
           /*outputs=*/{result}));
   return result;
 }
@@ -434,7 +434,7 @@ ffi::Array<SBlockRV> TracedScheduleNode::CacheInplace(const SBlockRV& block_rv,
   trace_->Append(
       /*inst=*/Instruction(/*kind=*/kind,
                            /*inputs=*/{block_rv},
-                           /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
+                           /*attrs=*/{IntImm::Int32(read_buffer_index), storage_scope},
                            /*outputs=*/results));
   return result;
 }
@@ -452,7 +452,7 @@ ffi::Array<SBlockRV> TracedScheduleNode::CacheIndex(const SBlockRV& block_rv,
   trace_->Append(
       /*inst=*/Instruction(/*kind=*/kind,
                            /*inputs=*/{block_rv},
-                           /*attrs=*/{storage_scope, IntImm(DataType::Int(32), cse_thresh)},
+                           /*attrs=*/{storage_scope, IntImm::Int32(cse_thresh)},
                            /*outputs=*/outputs));
   return result;
 }
@@ -463,12 +463,12 @@ SBlockRV TracedScheduleNode::ReIndex(const SBlockRV& block_rv, int buffer_index,
 
   static const InstructionKind& kind = InstructionKind::Get("ReIndex");
   trace_->Append(
-      /*inst=*/Instruction(/*kind=*/kind,
-                           /*inputs=*/{block_rv},
-                           /*attrs=*/
-                           {IntImm(DataType::Int(32), buffer_index),
-                            IntImm(DataType::Int(32), static_cast<int>(buffer_index_type))},
-                           /*outputs=*/{result}));
+      /*inst=*/Instruction(
+          /*kind=*/kind,
+          /*inputs=*/{block_rv},
+          /*attrs=*/
+          {IntImm::Int32(buffer_index), IntImm::Int32(static_cast<int>(buffer_index_type))},
+          /*outputs=*/{result}));
   return result;
 }
 
@@ -483,7 +483,7 @@ SBlockRV TracedScheduleNode::ReadAt(const LoopRV& loop_rv, const SBlockRV& block
   trace_->Append(
       /*inst=*/Instruction(/*kind=*/kind,
                            /*inputs=*/{loop_rv, block_rv},
-                           /*attrs=*/{IntImm(DataType::Int(32), read_buffer_index), storage_scope},
+                           /*attrs=*/{IntImm::Int32(read_buffer_index), storage_scope},
                            /*outputs=*/{result}));
   return result;
 }
@@ -497,7 +497,7 @@ SBlockRV TracedScheduleNode::WriteAt(const LoopRV& loop_rv, const SBlockRV& bloc
   trace_->Append(
       /*inst=*/Instruction(/*kind=*/kind,
                            /*inputs=*/{loop_rv, block_rv},
-                           /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index), storage_scope},
+                           /*attrs=*/{IntImm::Int32(write_buffer_index), storage_scope},
                            /*outputs=*/{result}));
   return result;
 }
@@ -514,7 +514,7 @@ void TracedScheduleNode::ComputeAt(const SBlockRV& block_rv, const LoopRV& loop_
           /*kind=*/kind,
           /*inputs=*/{block_rv, loop_rv},
           /*attrs=*/
-          {IntImm(DataType::Int(32), preserve_unit_loops), IntImm(DataType::Int(32), index)},
+          {IntImm::Int32(preserve_unit_loops), IntImm::Int32(index)},
           /*outputs=*/{}));
 }
 
@@ -526,7 +526,7 @@ void TracedScheduleNode::ReverseComputeAt(const SBlockRV& block_rv, const LoopRV
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv, loop_rv},
-      /*attrs=*/{IntImm(DataType::Int(32), preserve_unit_loops), IntImm(DataType::Int(32), index)},
+      /*attrs=*/{IntImm::Int32(preserve_unit_loops), IntImm::Int32(index)},
       /*outputs=*/{}));
 }
 
@@ -578,7 +578,7 @@ SBlockRV TracedScheduleNode::RFactor(const LoopRV& loop_rv, int factor_axis) {
   static const InstructionKind& kind = InstructionKind::Get("RFactor");
   trace_->Append(/*inst=*/Instruction(/*kind=*/kind,
                                       /*inputs=*/{loop_rv},
-                                      /*attrs=*/{IntImm(DataType::Int(32), factor_axis)},
+                                      /*attrs=*/{IntImm::Int32(factor_axis)},
                                       /*outputs=*/{result}));
   return result;
 }
@@ -593,8 +593,8 @@ void TracedScheduleNode::StorageAlign(const SBlockRV& block_rv, int buffer_index
       /*kind=*/kind,
       /*inputs=*/{block_rv},
       /*attrs=*/
-      {IntImm(DataType::Int(32), buffer_index), IntImm(DataType::Int(32), axis),
-       IntImm(DataType::Int(32), factor), IntImm(DataType::Int(32), offset)},
+      {IntImm::Int32(buffer_index), IntImm::Int32(axis), IntImm::Int32(factor),
+       IntImm::Int32(offset)},
       /*outputs=*/{}));
 }
 
@@ -605,7 +605,7 @@ void TracedScheduleNode::SetScope(const SBlockRV& block_rv, int buffer_index,
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{IntImm(DataType::Int(32), buffer_index), storage_scope},
+      /*attrs=*/{IntImm::Int32(buffer_index), storage_scope},
       /*outputs=*/{}));
 }
 
@@ -616,7 +616,7 @@ void TracedScheduleNode::UnsafeSetDType(const SBlockRV& block_rv, int buffer_ind
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{IntImm(DataType::Int(32), buffer_index), dtype},
+      /*attrs=*/{IntImm::Int32(buffer_index), dtype},
       /*outputs=*/{}));
 }
 
@@ -628,7 +628,7 @@ SBlockRV TracedScheduleNode::Blockize(const LoopRV& loop_rv, bool preserve_unit_
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{loop_rv},
-      /*attrs=*/{IntImm(DataType::Bool(), preserve_unit_iters)},
+      /*attrs=*/{IntImm::Bool(preserve_unit_iters)},
       /*outputs=*/{new_block}));
   return new_block;
 }
@@ -640,7 +640,7 @@ SBlockRV TracedScheduleNode::Blockize(const ffi::Array<SBlockRV>& blocks,
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{blocks},
-      /*attrs=*/{IntImm(DataType::Bool(), preserve_unit_iters)},
+      /*attrs=*/{IntImm::Bool(preserve_unit_iters)},
       /*outputs=*/{new_block}));
   return new_block;
 }
@@ -652,7 +652,7 @@ void TracedScheduleNode::Tensorize(const LoopRV& loop_rv, const ffi::String& int
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{loop_rv},
-      /*attrs=*/{intrin, IntImm(DataType::Bool(), preserve_unit_iters)},
+      /*attrs=*/{intrin, IntImm::Bool(preserve_unit_iters)},
       /*outputs=*/{}));
 }
 
@@ -663,7 +663,7 @@ void TracedScheduleNode::Tensorize(const SBlockRV& block_rv, const ffi::String& 
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{intrin, IntImm(DataType::Bool(), preserve_unit_iters)},
+      /*attrs=*/{intrin, IntImm::Bool(preserve_unit_iters)},
       /*outputs=*/{}));
 }
 
@@ -722,9 +722,8 @@ void TracedScheduleNode::TransformLayout(const SBlockRV& block_rv, int buffer_in
           /*kind=*/kind,
           /*inputs=*/{block_rv, index_map},
           /*attrs=*/
-          {IntImm(DataType::Int(32), buffer_index),
-           IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), pad_value,
-           IntImm(DataType::Bool(), assume_injective_transform)},
+          {IntImm::Int32(buffer_index), IntImm::Int32(static_cast<int>(buffer_index_type)),
+           pad_value, IntImm::Bool(assume_injective_transform)},
           /*outputs=*/{}));
 }
 
@@ -748,8 +747,8 @@ void TracedScheduleNode::SetAxisSeparator(const SBlockRV& block_rv, int buffer_i
       /*kind=*/kind,
       /*inputs=*/{block_rv},
       /*attrs=*/
-      {IntImm(DataType::Int(32), buffer_index),
-       IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), axis_separators},
+      {IntImm::Int32(buffer_index), IntImm::Int32(static_cast<int>(buffer_index_type)),
+       axis_separators},
       /*outputs=*/{}));
 }
 
@@ -783,7 +782,7 @@ void TracedScheduleNode::RollingBuffer(const SBlockRV& block_rv, int write_buffe
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/{block_rv},
-      /*attrs=*/{IntImm(DataType::Int(32), write_buffer_index)},
+      /*attrs=*/{IntImm::Int32(write_buffer_index)},
       /*outputs=*/{}));
 }
 
@@ -818,8 +817,8 @@ void TracedScheduleNode::AnnotateBufferAccess(const SBlockRV& block_rv, int buff
   trace_->Append(/*inst=*/Instruction(
       /*kind=*/kind,
       /*inputs=*/
-      {block_rv, IntImm(DataType::Int(32), buffer_index),
-       IntImm(DataType::Int(32), static_cast<int>(buffer_index_type)), index_map},
+      {block_rv, IntImm::Int32(buffer_index), IntImm::Int32(static_cast<int>(buffer_index_type)),
+       index_map},
       /*attrs=*/{},
       /*outputs=*/{}));
 }

--- a/src/s_tir/schedule/transform.cc
+++ b/src/s_tir/schedule/transform.cc
@@ -407,7 +407,7 @@ ffi::Optional<LoopRV> TileWithTensorIntrin(const s_tir::Schedule& sch,
     // Do the split. Leave the outer extent as std::nullopt (unspecified) so that the split factors
     // can be used for different extents (needed during tuning).
     ffi::Array<LoopRV> split =
-        sch->Split(loop2rv.at(block_loop_sref), {std::nullopt, IntImm(DataType::Int(32), inner)});
+        sch->Split(loop2rv.at(block_loop_sref), {std::nullopt, IntImm::Int32(inner)});
     TVM_FFI_ICHECK_EQ(split.size(), 2);
     inner_loops.insert(sch->GetSRef(split[1]).operator->());
     // The inner split will be reordered to the loop domain that is tensorized
@@ -537,7 +537,7 @@ ffi::Optional<ffi::ObjectRef> NormalizePrimFunc(Schedule sch) {
       }
     }
     if (index_map_outputs.empty() || !has_spatial_iter) {
-      index_map_outputs.insert(index_map_outputs.begin(), tirx::make_const(DataType::Int(64), 0));
+      index_map_outputs.insert(index_map_outputs.begin(), IntImm::Int64(0));
     }
     try {
       sch->TransformBlockLayout(block, IndexMap(index_map_inputs, index_map_outputs));
@@ -549,7 +549,7 @@ ffi::Optional<ffi::ObjectRef> NormalizePrimFunc(Schedule sch) {
     bool is_reduction = IsReductionBlock(sch->state(),         //
                                          sch->GetSRef(block),  //
                                          sch->GetSRef(root_block));
-    block_is_reduction.push_back(IntImm(DataType::Bool(), is_reduction));
+    block_is_reduction.push_back(IntImm::Bool(is_reduction));
   }
   return ffi::Array<ffi::ObjectRef>{leaf_blocks, block_loops, block_iters, block_is_reduction};
 }

--- a/src/s_tir/support/nd_int_set.h
+++ b/src/s_tir/support/nd_int_set.h
@@ -51,7 +51,7 @@ inline NDIntSet NDIntSetFromRegion(const tirx::Region& region) {
  * \return The constructed set.
  */
 inline NDIntSet NDIntSetFromShape(const ffi::Array<PrimExpr>& shape) {
-  PrimExpr zero = IntImm(DataType::Int(32), 0);
+  PrimExpr zero = IntImm::Int32(0);
   NDIntSet result;
   result.reserve(shape.size());
   for (const PrimExpr& extent : shape) {

--- a/src/s_tir/transform/bound_checker.cc
+++ b/src/s_tir/transform/bound_checker.cc
@@ -126,7 +126,7 @@ class BoundChecker : public StmtExprMutator {
 
     new_shape.MutateByApply([&](const PrimExpr& dim) {
       // Cast to uint64 to avoid potential overflow.
-      return make_const(DataType::UInt(64), type.lanes()) * dim;
+      return IntImm(DataType::UInt(64), type.lanes()) * dim;
     });
     mem_to_shape_[buffer_var.get()] = new_shape;
   }
@@ -214,7 +214,7 @@ class BoundChecker : public StmtExprMutator {
         upper_bound = Cast(DataType::Int(64), upper_bound);
 
         // Looks like a lower bound should always be zero after normalization.
-        PrimExpr lower_bound = make_zero(DataType::Int(64));
+        PrimExpr lower_bound = IntImm::Int64(0);
 
         PrimExpr current_condition = And(GE(index, lower_bound), LT(index, upper_bound));
         condition = condition.defined() ? And(condition, current_condition) : current_condition;

--- a/src/s_tir/transform/canonicalize_loop.cc
+++ b/src/s_tir/transform/canonicalize_loop.cc
@@ -47,7 +47,7 @@ class LoopCanonicalizer : public StmtExprMutator {
       return StmtExprMutator::VisitStmt_(op);
     }
     const auto* loop_var = op->loop_var.get();
-    PrimExpr step = op->step.value_or(make_const(loop_var->dtype, 1));
+    PrimExpr step = op->step.value_or(MakeConst(loop_var->dtype, 1));
 
     // report warning for negative step, since it would be a forever loop
     if (!analyzer_->CanProveGreaterEqual(step, 1)) {
@@ -59,7 +59,7 @@ class LoopCanonicalizer : public StmtExprMutator {
     new_iter_info_[loop_var] = std::make_pair(step, op->min);
     auto n = CopyOnWrite(op);
     n->body = VisitStmt(op->body);
-    n->min = make_zero(loop_var->dtype);
+    n->min = IntImm(loop_var->dtype, 0);
     n->extent = analyzer_->Simplify(ceildiv(op->extent, step));
     n->step = std::nullopt;
     new_iter_info_.erase(loop_var);

--- a/src/s_tir/transform/compact_buffer_region.cc
+++ b/src/s_tir/transform/compact_buffer_region.cc
@@ -322,7 +322,7 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
       ancestor_iters_.push_back(iter);
       Range dom = iter->dom;
       if (!dom.defined()) {  // dom is empty for legacy te schedule
-        dom = Range::FromMinExtent(make_zero(op->value->dtype), op->value);
+        dom = Range::FromMinExtent(IntImm(op->value->dtype, 0), op->value);
       }
       dom_analyzer_->Bind(iter->var, dom);
       dom_map_.emplace(iter->var.get(), arith::IntSet::FromRange(dom));
@@ -368,13 +368,13 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
       // Step 2. Relax the access region
       auto normalize_pred = [](const PrimExpr& pred) {
         if (pred->dtype.is_bool()) return pred;
-        return pred != make_zero(pred->dtype);
+        return pred != IntImm(pred->dtype, 0);
       };
-      PrimExpr predicate = dom_analyzer_->Simplify(
-          std::accumulate(pending_conditions_.begin(), pending_conditions_.end(), const_true(),
-                          [normalize_pred](const PrimExpr& x, const PrimExpr& y) {
-                            return normalize_pred(x) && normalize_pred(y);
-                          }));
+      PrimExpr predicate = dom_analyzer_->Simplify(std::accumulate(
+          pending_conditions_.begin(), pending_conditions_.end(), PrimExpr(IntImm::Bool(true)),
+          [normalize_pred](const PrimExpr& x, const PrimExpr& y) {
+            return normalize_pred(x) && normalize_pred(y);
+          }));
       NDIntSet nd_int_set =
           NDIntSetEval(buffer_region->region, predicate, dom_map_, dom_analyzer_.get());
 
@@ -439,7 +439,7 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
     for (size_t i = 0; i < nd_int_set.size(); ++i) {
       const arith::IntSet& int_set = nd_int_set[i];
       Range original =
-          Range(/*begin=*/make_zero(original_shape[i]->dtype), /*end=*/original_shape[i]);
+          Range(/*begin=*/IntImm(original_shape[i]->dtype, 0), /*end=*/original_shape[i]);
       Range range = int_set.CoverRange(original);
       PrimExpr min, extent;
       if (collect_inbound_) {
@@ -470,7 +470,7 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
         // try estimate a constant upperbound on region's extent
         int64_t upperbound = dom_analyzer_->const_int_bound(extent)->max_value;
         if (upperbound != arith::ConstIntBound::kPosInf) {
-          extent = make_const(extent->dtype, upperbound);
+          extent = MakeConst(extent->dtype, upperbound);
         } else {
           result_region.Set(i, original);
           continue;
@@ -699,15 +699,15 @@ ffi::Array<PrimExpr> CalcStrides(const BufferAllocInfo& alloc_info,
   if (alloc_info.dim_aligns.size()) {
     TVM_FFI_ICHECK(alloc_info.dim_aligns.size() == shape.size());
     strides.resize(shape.size());
-    PrimExpr stride = make_const(shape[0].dtype(), 1);
+    PrimExpr stride = MakeConst(shape[0].dtype(), 1);
     for (size_t i = shape.size(); i != 0; --i) {
       size_t dim = i - 1;
       DimAlignInfo info = alloc_info.dim_aligns[dim];
       int align_factor = info.align_factor;
       int align_offset = info.align_offset;
       if (align_factor != 0) {
-        PrimExpr factor = make_const(stride.dtype(), align_factor);
-        PrimExpr offset = make_const(stride.dtype(), align_offset);
+        PrimExpr factor = MakeConst(stride.dtype(), align_factor);
+        PrimExpr offset = MakeConst(stride.dtype(), align_offset);
         stride = stride + indexmod(factor + offset - indexmod(stride, factor), factor);
       }
       strides[dim] = stride;

--- a/src/s_tir/transform/decorate_device_scope.cc
+++ b/src/s_tir/transform/decorate_device_scope.cc
@@ -31,7 +31,7 @@ namespace s_tir {
 using namespace tvm::tirx;
 
 Stmt DecorateDeviceScopeImpl(Stmt&& stmt) {
-  Stmt body = AttrStmt(make_zero(DataType::Int(32)), tirx::attr::device_scope, 0, stmt);
+  Stmt body = AttrStmt(IntImm::Int32(0), tirx::attr::device_scope, 0, stmt);
   return body;
 }
 

--- a/src/s_tir/transform/default_gpu_schedule.cc
+++ b/src/s_tir/transform/default_gpu_schedule.cc
@@ -72,15 +72,14 @@ void ThreadBind(s_tir::Schedule sch, const s_tir::SBlockRV& block, int64_t max_t
   if (product > max_thread_per_block * max_threadblocks) {
     ffi::Array<s_tir::LoopRV> splits =
         sch->Split(fused,
-                   /*factors=*/{std::nullopt, IntImm(DataType::Int(32), max_threadblocks),
-                                IntImm(DataType::Int(32), max_thread_per_block)});
+                   /*factors=*/{std::nullopt, IntImm::Int32(max_threadblocks),
+                                IntImm::Int32(max_thread_per_block)});
     sch->Reorder(/*ordered_loop_rvs=*/{splits[1], splits[2], splits[0]});
     sch->Bind(splits[1], "blockIdx.x");
     sch->Bind(splits[2], "threadIdx.x");
   } else {
     ffi::Array<s_tir::LoopRV> splits = sch->Split(
-        fused, /*factors=*/{std::nullopt,
-                            IntImm(DataType::Int(32), std::min(product, max_thread_per_block))});
+        fused, /*factors=*/{std::nullopt, IntImm::Int32(std::min(product, max_thread_per_block))});
     sch->Bind(splits[0], "blockIdx.x");
     sch->Bind(splits[1], "threadIdx.x");
   }
@@ -148,7 +147,7 @@ tirx::PrimFunc WrapBareSBlockBody(const tirx::PrimFunc& func) {
                           /*writes=*/ffi::Array<tirx::BufferRegion>{},
                           /*name_hint=*/"root", /*body=*/for_stmt);
   tirx::SBlockRealize root_realize(/*iter_values=*/ffi::Array<tvm::PrimExpr>{},
-                                   /*predicate=*/const_true(), root_block);
+                                   /*predicate=*/IntImm::Bool(true), root_block);
   tirx::PrimFunc result = func;
   result.CopyOnWrite()->body = std::move(root_realize);
   return result;

--- a/src/s_tir/transform/inject_double_buffer.cc
+++ b/src/s_tir/transform/inject_double_buffer.cc
@@ -164,15 +164,15 @@ class DoubleBufferInjector : public StmtExprMutator {
             << "It is better to split with multiple of 2";
         TVM_FFI_ICHECK(is_zero(old_loop->min));
         PrimExpr zero = old_loop->min;
-        PrimExpr new_ext = old_loop->extent - make_const(old_loop->loop_var.dtype(), 1);
-        PrimExpr factor = make_const(new_ext.dtype(), split_loop_);
+        PrimExpr new_ext = old_loop->extent - MakeConst(old_loop->loop_var.dtype(), 1);
+        PrimExpr factor = MakeConst(new_ext.dtype(), split_loop_);
         PrimExpr outer_ext = new_ext / factor;
         PrimExpr tail_base = outer_ext * factor;
         Var outer_var(old_loop->loop_var->name_hint + ".outer", old_loop->loop_var.dtype());
         std::unordered_map<const VarNode*, PrimExpr> vmap;
         std::vector<Stmt> loop_seq;
         for (int32_t i = 0; i < split_loop_; ++i) {
-          vmap[old_loop->loop_var.get()] = outer_var * factor + make_const(factor.dtype(), i);
+          vmap[old_loop->loop_var.get()] = outer_var * factor + MakeConst(factor.dtype(), i);
           loop_seq.emplace_back(Substitute(old_loop->body, vmap));
         }
         Stmt loop = For(outer_var, zero, outer_ext, old_loop->kind, SeqStmt::Flatten(loop_seq));
@@ -180,7 +180,7 @@ class DoubleBufferInjector : public StmtExprMutator {
         std::vector<Stmt> tail_seq;
         Stmt tail_body = StripDoubleBufferWrite()(old_loop->body);
         for (int32_t i = 0; i < split_loop_; ++i) {
-          PrimExpr idx = tail_base + make_const(tail_base.dtype(), i);
+          PrimExpr idx = tail_base + MakeConst(tail_base.dtype(), i);
           vmap[old_loop->loop_var.get()] = idx;
           tail_seq.emplace_back(IfThenElse(idx < old_loop->extent, Substitute(tail_body, vmap)));
         }
@@ -274,9 +274,9 @@ class DoubleBufferInjector : public StmtExprMutator {
     }
     StorageEntry& e = it->second;
     e.loop = loop_nest_.back();
-    PrimExpr zero = make_const(e.loop->loop_var.dtype(), 0);
-    PrimExpr one = make_const(e.loop->loop_var.dtype(), 1);
-    PrimExpr two = make_const(e.loop->loop_var.dtype(), 2);
+    PrimExpr zero = IntImm(e.loop->loop_var.dtype(), 0);
+    PrimExpr one = IntImm(e.loop->loop_var.dtype(), 1);
+    PrimExpr two = IntImm(e.loop->loop_var.dtype(), 2);
     PrimExpr loop_shift = e.loop->loop_var + one;
     e.switch_write_var = Var(e.loop->loop_var->name_hint + ".db", e.loop->loop_var.dtype());
     e.switch_read_var = indexmod(e.loop->loop_var, two);

--- a/src/s_tir/transform/inject_ptx_ldg32.cc
+++ b/src/s_tir/transform/inject_ptx_ldg32.cc
@@ -88,15 +88,14 @@ class PTXRewriter : public StmtMutator {
         EnsureBuffers();
         needs_buffer = true;
         local_addr = store->indices[0];
-        BufferStore addr_store(addr_buffer, global_addr, {IntImm(DataType::Int(32), 0)});
-        BufferStore local_addr_store(addr_buffer, local_addr, {IntImm(DataType::Int(32), 1)});
-        BufferStore predicate_store(predicate_buffer, predicate, {IntImm(DataType::Int(32), 0)});
+        BufferStore addr_store(addr_buffer, global_addr, {IntImm::Int32(0)});
+        BufferStore local_addr_store(addr_buffer, local_addr, {IntImm::Int32(1)});
+        BufferStore predicate_store(predicate_buffer, predicate, {IntImm::Int32(0)});
         PrimExpr new_lhs, new_rhs, new_predicate, new_indice;
-        new_lhs =
-            BufferLoad(load->buffer, {BufferLoad(addr_buffer, {IntImm(DataType::Int(32), 0)})});
-        new_rhs = IntImm(DataType::Int(32), 0);
-        new_predicate = BufferLoad(predicate_buffer, {IntImm(DataType::Int(32), 0)});
-        new_indice = BufferLoad(addr_buffer, {IntImm(DataType::Int(32), 1)});
+        new_lhs = BufferLoad(load->buffer, {BufferLoad(addr_buffer, {IntImm::Int32(0)})});
+        new_rhs = IntImm::Int32(0);
+        new_predicate = BufferLoad(predicate_buffer, {IntImm::Int32(0)});
+        new_indice = BufferLoad(addr_buffer, {IntImm::Int32(1)});
         BufferStore value_store(store->buffer, imm_value, {new_indice});
         static const Op& ptx_ldg32_op = Op::Get("tirx.ptx.ldg32");
         Evaluate ptx_load(Call(store->buffer->dtype, ptx_ldg32_op,
@@ -116,9 +115,8 @@ class PTXRewriter : public StmtMutator {
     }
     has_buffer_1 = true;
     // addr[0] -> global_addr /  addr[1] -> local_addr
-    addr_buffer = decl_buffer({IntImm(DataType::Int(32), 2)}, DataType::Int(32), "addr", "local");
-    predicate_buffer =
-        decl_buffer({IntImm(DataType::Int(32), 1)}, DataType::Bool(), "predicate", "local");
+    addr_buffer = decl_buffer({IntImm::Int32(2)}, DataType::Int(32), "addr", "local");
+    predicate_buffer = decl_buffer({IntImm::Int32(1)}, DataType::Bool(), "predicate", "local");
   }
 
   bool has_buffer_1 = false, has_buffer_2 = false;

--- a/src/s_tir/transform/inject_software_pipeline.cc
+++ b/src/s_tir/transform/inject_software_pipeline.cc
@@ -160,7 +160,7 @@ class PipelineOpaqueAccessRewriter {
     int fragment_size = GetWmmaFragmentSize(old_buffer);
     PrimExpr offset =
         floordiv(foldl([](PrimExpr a, PrimExpr b, Span span) { return mul(a, b, span); },
-                       make_const(DataType::Int(32), 1), old_buffer->shape),
+                       IntImm::Int32(1), old_buffer->shape),
                  fragment_size);
     new_buffer_offset +=
         floormod(pipeline_loop_->loop_var - pipeline_loop_->min, new_buffer->shape[0]) * offset;
@@ -170,7 +170,7 @@ class PipelineOpaqueAccessRewriter {
   PrimExpr RewriteBufferAccess(const Call& call, const std::vector<int> arg_indices) {
     auto product = [](const ffi::Array<PrimExpr>& input) {
       return foldl([](PrimExpr a, PrimExpr b, Span span) { return mul(a, b, span); },
-                   make_const(DataType::Int(32), 1), input);
+                   IntImm::Int32(1), input);
     };
     ffi::Array<PrimExpr> new_args = call->args;
     for (int i : arg_indices) {
@@ -247,7 +247,7 @@ class PipelineBodyRewriter : public StmtExprMutator {
               ? Range::FromMinExtent(0, new_buffer->shape[0])
               : Range::FromMinExtent(floormod((pipeline_loop_->loop_var - pipeline_loop_->min),
                                               new_buffer->shape[0]),
-                                     IntImm(DataType::Int(32), 1));
+                                     IntImm::Int32(1));
       new_region.insert(new_region.begin(), accessed_version);
       return BufferRegion(new_buffer, new_region);
     }
@@ -398,7 +398,7 @@ class PipelineRewriter : public StmtExprMutator {
     }
     SBlock block = MakeSBlock(stmt, buffer_data_to_buffer_);
     block.CopyOnWrite()->alloc_buffers = std::move(alloc_buffers);
-    return SBlockRealize({}, const_true(), block);
+    return SBlockRealize({}, IntImm::Bool(true), block);
   }
 
  private:
@@ -757,7 +757,7 @@ class PipelineRewriter : public StmtExprMutator {
         auto attach_wait_scope = [&new_blocks](int i, int stage_id, PrimExpr wait_count) {
           auto& block = new_blocks[i].block;
           SBlockNode* n = block.CopyOnWrite();
-          auto zero = make_zero(DataType::Int(32));
+          auto zero = IntImm::Int32(0);
           n->body =
               AttrStmt(zero, s_tir::attr::async_wait_queue_scope, stage_id,
                        AttrStmt(zero, s_tir::attr::async_wait_inflight_count, wait_count, n->body));
@@ -801,8 +801,8 @@ class PipelineRewriter : public StmtExprMutator {
         }
 
         for (auto body : group_bodies) {
-          auto commit_queue_scope = AttrStmt(make_zero(DataType::Int(32)),
-                                             s_tir::attr::async_commit_queue_scope, stage_id, body);
+          auto commit_queue_scope =
+              AttrStmt(IntImm::Int32(0), s_tir::attr::async_commit_queue_scope, stage_id, body);
           auto new_block = MakeSBlock(commit_queue_scope, buffer_data_to_buffer_);
           stmts.push_back(SBlockRealize({}, predicate, new_block));
         }
@@ -825,7 +825,9 @@ class PipelineRewriter : public StmtExprMutator {
     PrimExpr new_loop_var;
     PrimExpr extent = end - start;
 
-    auto make_nop = []() { return SBlockRealize({}, const_true(), MakeSBlock(Evaluate(0), {})); };
+    auto make_nop = []() {
+      return SBlockRealize({}, IntImm::Bool(true), MakeSBlock(Evaluate(0), {}));
+    };
 
     if (analyzer_->CanProve(extent <= 0)) {
       return make_nop();
@@ -918,7 +920,7 @@ class PipelineRewriter : public StmtExprMutator {
         }
 
         SBlockNode* n = new_block.CopyOnWrite();
-        n->body = AttrStmt(make_zero(DataType::Int(32)), s_tir::attr::async_scope, 1, n->body);
+        n->body = AttrStmt(IntImm::Int32(0), s_tir::attr::async_scope, 1, n->body);
       }
 
       new_blocks.push_back(
@@ -973,7 +975,8 @@ class PipelineRewriter : public StmtExprMutator {
       }
     }
 
-    return SBlockRealize({}, const_true(), MakeSBlock(std::move(new_loop), buffer_data_to_buffer_));
+    return SBlockRealize({}, IntImm::Bool(true),
+                         MakeSBlock(std::move(new_loop), buffer_data_to_buffer_));
   }
 
   arith::Analyzer analyzer_;

--- a/src/s_tir/transform/inject_virtual_thread.cc
+++ b/src/s_tir/transform/inject_virtual_thread.cc
@@ -225,7 +225,7 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
       visit_touched_var_ = true;
       PrimExpr offset = this->VisitExpr(op->args[2]);
       PrimExpr extent = this->VisitExpr(op->args[3]);
-      PrimExpr stride = it->second / make_const(offset.dtype(), dtype.lanes());
+      PrimExpr stride = it->second / MakeConst(offset.dtype(), dtype.lanes());
       offset = RewriteIndex(offset, stride);
 
       return Call(op->dtype, op->op, {op->args[0], op->args[1], offset, extent, op->args[4]});
@@ -465,14 +465,14 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
       // do unrolling if it is inside innermost content.
       ffi::Array<Stmt> seq;
       for (int i = 0; i < num_threads_; ++i) {
-        seq.push_back(Substitute(stmt, {{var_, make_const(var_.dtype(), i)}}));
+        seq.push_back(Substitute(stmt, {{var_, MakeConst(var_.dtype(), i)}}));
       }
       return SeqStmt::Flatten(seq);
     } else {
       // insert a for loop
       Var idx(var_->name_hint + ".s", var_->dtype);
       stmt = Substitute(stmt, {{var_, idx}});
-      return For(idx, make_zero(idx.dtype()), make_const(idx.dtype(), num_threads_),
+      return For(idx, IntImm(idx.dtype(), 0), MakeConst(idx.dtype(), num_threads_),
                  ForKind::kSerial, stmt);
     }
   }

--- a/src/s_tir/transform/loop_partition.cc
+++ b/src/s_tir/transform/loop_partition.cc
@@ -261,7 +261,7 @@ class PartitionFinder : public StmtExprVisitor {
       const IterVarNode* thread_axis = op->node.as<IterVarNode>();
       TVM_FFI_ICHECK(thread_axis);
       const VarNode* var = thread_axis->var.get();
-      IntSet dom = IntSet::FromRange(Range(make_zero(op->value.dtype()), op->value));
+      IntSet dom = IntSet::FromRange(Range(IntImm(op->value.dtype(), 0), op->value));
       hint_map_.insert({var, dom});
       relax_map_.insert({var, dom});
       StmtExprVisitor::VisitStmt_(op);
@@ -368,7 +368,7 @@ class ConditionEliminator : public StmtExprMutator {
 
   PrimExpr VisitExpr(const PrimExpr& e) final {
     if (ps_.find(e) != ps_.end()) {
-      return VisitExpr(cond_value_ ? const_true() : const_false());
+      return VisitExpr(cond_value_ ? IntImm::Bool(true) : IntImm::Bool(false));
     }
     return StmtExprMutator::VisitExpr(e);
   }
@@ -458,11 +458,11 @@ class LoopPartitioner : public StmtMutator {
     Stmt res;
     if (scope.rank == 1) {
       // threadIdx should be put into relax map, in case of divergence.
-      relax_map_.insert({var.get(), IntSet::Interval(make_zero(var.dtype()), op->value - 1)});
+      relax_map_.insert({var.get(), IntSet::Interval(IntImm(var.dtype(), 0), op->value - 1)});
       res = StmtMutator::VisitStmt_(op);
       relax_map_.erase(var.get());
     } else {
-      hint_map_.insert({var.get(), IntSet::Interval(make_zero(var.dtype()), op->value - 1)});
+      hint_map_.insert({var.get(), IntSet::Interval(IntImm(var.dtype(), 0), op->value - 1)});
       res = StmtMutator::VisitStmt_(op);
       hint_map_.erase(var.get());
     }
@@ -753,7 +753,7 @@ Stmt LoopPartitioner::TryPartition(const Stmt& stmt, Var var, PrimExpr min, Prim
     }
     s = SeqStmt::Flatten(pre_stmt, mid_stmt, post_stmt);
   } else {
-    PrimExpr cond = const_true();
+    PrimExpr cond = IntImm::Bool(true);
     if (!analyzer_->CanProve(body_begin == min)) cond = cond && (var >= body_begin);
     if (!analyzer_->CanProve(post_doubt_begin == (max + 1)))
       cond = cond && (var < post_doubt_begin);
@@ -767,10 +767,10 @@ inline Stmt LoopPartitioner::MakeFor(const ffi::Object* node, PrimExpr extent, S
   const ForNode* for_node = static_cast<const ForNode*>(node);
   TVM_FFI_ICHECK(for_node);
 
-  if (analyzer_->CanProve(extent == make_const(DataType::Int(32), 1)) &&
-      !no_unroll_loop_with_extent_one_ && for_node->annotations.empty()) {
+  if (analyzer_->CanProve(extent == IntImm::Int32(1)) && !no_unroll_loop_with_extent_one_ &&
+      for_node->annotations.empty()) {
     // If the loop extent is 1, do not create the loop anymore
-    return Substitute(body, {{Var{for_node->loop_var}, make_const(DataType::Int(32), 0)}});
+    return Substitute(body, {{Var{for_node->loop_var}, IntImm::Int32(0)}});
   } else {
     TVM_FFI_ICHECK(for_node->kind != ForKind::kThreadBinding);
     auto new_loop = ffi::make_object<ForNode>(*for_node);

--- a/src/s_tir/transform/lower_cross_thread_reduction.cc
+++ b/src/s_tir/transform/lower_cross_thread_reduction.cc
@@ -149,8 +149,8 @@ ffi::Array<Buffer> MakeScratchpads(const ffi::Array<Buffer>& reduction_buffers,
     name = name + "_thread_" + buffer->name;
     new_buffers.push_back(Buffer(/*ptr=*/Var(name, PointerType(PrimType(buffer->dtype), "local")),
                                  /*dtype=*/buffer->dtype,
-                                 /*shape=*/{IntImm(DataType::Int(32), 1)},
-                                 /*strides=*/{IntImm(DataType::Int(32), 1)},
+                                 /*shape=*/{IntImm::Int32(1)},
+                                 /*strides=*/{IntImm::Int32(1)},
                                  /*elem_offset=*/PrimExpr{nullptr},
                                  /*name=*/name,
                                  /*data_alignment=*/0,
@@ -335,11 +335,11 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
     ffi::Array<Stmt> inits;
     inits.reserve(n_buffers);
     for (int i = 0; i < n_buffers; ++i) {
-      inits.push_back(BufferStore(it_buffers.value()[i], reducer->identity_element[i],
-                                  {IntImm(DataType::Int(32), 0)}));
+      inits.push_back(
+          BufferStore(it_buffers.value()[i], reducer->identity_element[i], {IntImm::Int32(0)}));
     }
     stmts.push_back(SBlockRealize(/*iter_values=*/{},
-                                  /*predicate=*/const_true(),
+                                  /*predicate=*/IntImm::Bool(true),
                                   /*block=*/
                                   SBlock(/*iter_vars=*/{},
                                          /*reads=*/{},
@@ -376,17 +376,17 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
     ffi::Array<PrimExpr> parameters;
     parameters.reserve(reduction_loops.size() + 4);
     // 1-st argument: number of buffers
-    parameters.push_back(make_const(DataType::UInt(32), n_buffers));
+    parameters.push_back(IntImm(DataType::UInt(32), n_buffers));
     // Next `n_buffers` arguments: sources
     if (it_buffers.defined()) {
       for (int i = 0; i < n_buffers; ++i) {
-        parameters.push_back(BufferLoad(it_buffers.value()[i], {IntImm(DataType::Int(32), 0)}));
+        parameters.push_back(BufferLoad(it_buffers.value()[i], {IntImm::Int32(0)}));
       }
     } else {
       parameters.insert(parameters.end(), combiner_rhs.begin(), combiner_rhs.end());
     }
     // Next argument: predicate
-    parameters.push_back(const_true());
+    parameters.push_back(IntImm::Bool(true));
     // Next `n_buffers` arguments: destinations
     for (int i = 0; i < n_buffers; ++i) {
       parameters.push_back(BufferLoad(ct_buffers[i], {0}));
@@ -412,7 +412,7 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
     }
     stmts.push_back(SBlockRealize(
         /*iter_values=*/std::move(bindings),
-        /*predicate=*/const_true(),
+        /*predicate=*/IntImm::Bool(true),
         /*block=*/
         SBlock(/*iter_vars=*/std::move(iter_vars),
                /*reads=*/std::move(reads),
@@ -421,7 +421,7 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
                /*body=*/
                AttrStmt(/*node=*/reducer,
                         /*attr_key=*/s_tir::attr::reduce_scope,
-                        /*value=*/make_zero(DataType::Handle()),
+                        /*value=*/ConstHandle(0),
                         /*body=*/
                         Evaluate(Call(/*dtype=*/DataType::Handle(),
                                       /*op=*/tirx::builtin::tvm_thread_allreduce(),
@@ -464,15 +464,15 @@ Stmt TransformReductionBlock(const SBlockRealizeNode* realize,                  
       wb_indices.push_back(Substitute(old_wb_indices[d], var_map));
     }
     for (int i = 0; i < n_buffers; ++i) {
-      wb_updates.push_back(BufferStore(
-          wb_buffers[i], BufferLoad(ct_buffers[i], {IntImm(DataType::Int(32), 0)}), wb_indices));
+      wb_updates.push_back(
+          BufferStore(wb_buffers[i], BufferLoad(ct_buffers[i], {IntImm::Int32(0)}), wb_indices));
       wb_regions.push_back(BufferRegion(wb_buffers[i], region));
     }
 
     // Construct the predicate of the write-back block. It is the conjunction of
     // - each predicate clause of the original block which contains spatial loop var, and
     // - `t == 0` for each reduction thread dim when the write-back buffer is not local.
-    PrimExpr wb_predicate = const_true();
+    PrimExpr wb_predicate = IntImm::Bool(true);
     std::unordered_set<const VarNode*> reduction_loop_vars;
     reduction_loop_vars.reserve(reduction_loops.size());
     for (const ForNode* reduction_loop : reduction_loops) {

--- a/src/s_tir/transform/lower_match_buffer.cc
+++ b/src/s_tir/transform/lower_match_buffer.cc
@@ -212,7 +212,7 @@ class MatchBufferLower : public StmtExprMutator {
         // Non-zero elem_offset is ill-defined for non-flat memory.
         // If needed in the future, will require `ffi::Array<PrimExpr>
         // elem_offsets`, with one offset for each flattened index.
-        Bind(buffer->elem_offset, make_const(buffer->elem_offset.dtype(), 0));
+        Bind(buffer->elem_offset, IntImm(buffer->elem_offset.dtype(), 0));
       }
     }
 
@@ -223,7 +223,7 @@ class MatchBufferLower : public StmtExprMutator {
     if (!buffer->strides.empty()) {
       TVM_FFI_ICHECK_EQ(buffer->strides.size(), buffer->shape.size());
       if (source_buffer->strides.empty()) {
-        PrimExpr stride = make_const(buffer->strides.back().dtype(), 1);
+        PrimExpr stride = MakeConst(buffer->strides.back().dtype(), 1);
         for (size_t i = buffer->shape.size(); i > 0; --i) {
           const PrimExpr& shape = source_buffer->shape[i - 1 + offset];
           Bind(buffer->strides[i - 1], stride, buffer->name + ".strides_" + std::to_string(i - 1));

--- a/src/s_tir/transform/lower_opaque_block.cc
+++ b/src/s_tir/transform/lower_opaque_block.cc
@@ -72,7 +72,7 @@ class OpaqueBlockLower : public StmtExprMutator {
         allocate_annotations.Set(s_tir::attr::buffer_dim_align, allocate_aligns);
       }
       allocate_annotations.Set(tirx::attr::buffer_data_alignment,
-                               IntImm(DataType::Int(32), buffer->data_alignment));
+                               IntImm::Int32(buffer->data_alignment));
       allocate_annotations.Set(tirx::attr::buffer_allocated_addr, buffer->allocated_addr);
       body = SeqStmt::Flatten(AllocBuffer(buffer, allocate_annotations), std::move(body));
     }
@@ -80,7 +80,7 @@ class OpaqueBlockLower : public StmtExprMutator {
     std::vector<std::pair<std::string, PrimExpr>> pragma_attrs;
     HandleAnnotations(new_block->annotations, &pragma_attrs, /*is_block=*/true);
     for (auto it = pragma_attrs.rbegin(); it != pragma_attrs.rend(); ++it) {
-      body = AttrStmt(IntImm(DataType::Int(32), 0), it->first, it->second, std::move(body));
+      body = AttrStmt(IntImm::Int32(0), it->first, it->second, std::move(body));
     }
     return body;
   }

--- a/src/s_tir/transform/lower_thread_allreduce.cc
+++ b/src/s_tir/transform/lower_thread_allreduce.cc
@@ -305,7 +305,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
     // In the second stage we use the first 16 lanes of the first warp to reduce
     // the remaining elements, and this reduction can also be optimized by
     // shuffle_down warp-level primitives.
-    PrimExpr zero_index = make_const(reduce_index->dtype, 0);
+    PrimExpr zero_index = IntImm(reduce_index->dtype, 0);
     if (IsWarpReduction(types, group_extent, reduce_extent, contiguous_reduce_extent)) {
       std::vector<PrimExpr> reduce_results;
       DataType mask_dtype = DataType::UInt(32);
@@ -336,7 +336,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         staging_shared_bufs.reserve(size);
         for (size_t i = 0; i < size; ++i) {
           Buffer staging_shared_buf = decl_buffer(
-              /*shape=*/{make_const(reduce_index->dtype, n_warps * group_extent)},
+              /*shape=*/{MakeConst(reduce_index->dtype, n_warps * group_extent)},
               /*dtype=*/buffers[i]->dtype, /*name=*/"red_buf_staging", /*storage_scope=*/"shared");
           staging_shared_bufs.push_back(staging_shared_buf);
           new_alloc_bufs.push_back(staging_shared_buf);
@@ -370,7 +370,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         }
         std::tie(reduce_results, local_bufs) = MakeWarpAllreduce(
             values, types, combiner, reduce_index, n_warps, group_index, mask,
-            /*predicate=*/reduce_index < make_const(reduce_index->dtype, n_warps), &seq);
+            /*predicate=*/reduce_index < MakeConst(reduce_index->dtype, n_warps), &seq);
         new_alloc_bufs.insert(new_alloc_bufs.end(), local_bufs.begin(), local_bufs.end());
 
         // 5. Create shared memory buffer(s) of `group_extent` elements, storing
@@ -380,7 +380,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         for (size_t i = 0; i < size; ++i) {
           new_alloc_bufs.push_back(Downcast<BufferLoad>(reduce_results[i])->buffer);
           Buffer broadcast_shared_buf = decl_buffer(
-              /*shape=*/{make_const(reduce_index->dtype, group_extent)},
+              /*shape=*/{MakeConst(reduce_index->dtype, group_extent)},
               /*dtype=*/buffers[i]->dtype, /*name=*/"red_result", /*storage_scope=*/"shared");
           write_result.push_back(
               BufferStore(broadcast_shared_buf, reduce_results[i], {group_index}));
@@ -428,9 +428,9 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
                                         reduce_extent, group_extent, contiguous_reduce_extent));
       for (size_t idx = 0; idx < size; ++idx) {
         TVM_FFI_ICHECK(!load_remap_.count(buffers[idx]->data.get()));
-        PrimExpr pred = const_true(types[idx].lanes());
+        PrimExpr pred = MakeConst(DataType::Bool(types[idx].lanes()), true);
         BufferLoad load(shared_bufs[idx],
-                        {BufIndex(make_zero(reduce_index.dtype()), group_index, reduce_extent)});
+                        {BufIndex(IntImm(reduce_index.dtype(), 0), group_index, reduce_extent)});
         TVM_FFI_ICHECK_EQ(load->dtype, types[idx]);
         load_remap_[buffers[idx]->data.get()] = load;
         alloc_remap_[buffers[idx]->data.get()] = shared_bufs[idx];
@@ -692,7 +692,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
     int& total_extent = *out_total_extent;
     total_extent = 1;
     if (tvec.size() == 0) {
-      return make_zero(DataType::Int(32));
+      return IntImm::Int32(0);
     }
 
     PrimExpr ret;
@@ -728,9 +728,9 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
     if (mask_buffer.defined()) {
       mask = BufferLoad(mask_buffer.value(), indices);
     } else {
-      mask = IntImm(DataType::Int(32), 0);
+      mask = IntImm::Int32(0);
     }
-    PrimExpr width = IntImm(DataType::Int(32), warp_size_);
+    PrimExpr width = IntImm::Int32(warp_size_);
     ffi::Array<PrimExpr> args{mask, val, delta_or_lane, width, width};
     return Call(val.dtype(), op, args);
   }

--- a/src/s_tir/transform/lower_vtcm_alloc.cc
+++ b/src/s_tir/transform/lower_vtcm_alloc.cc
@@ -42,7 +42,7 @@ class VtcmAllocator : public StmtExprMutator {
     if (IsVtcmStorage(storage_scope)) {
       ffi::Array<PrimExpr> args;
       args.push_back(StringImm(storage_scope));
-      args.push_back(IntImm(DataType::Int(64), op->buffer->shape.size()));
+      args.push_back(IntImm::Int64(op->buffer->shape.size()));
       args.push_back(Call(DataType::Handle(), builtin::tvm_stack_make_shape(), op->buffer->shape));
       return Bind(op->buffer->data,
                   Call(op->buffer->data.dtype(), builtin::nd_mem_alloc_with_scope(), args));

--- a/src/s_tir/transform/memhammer_coalesce.cc
+++ b/src/s_tir/transform/memhammer_coalesce.cc
@@ -189,8 +189,8 @@ Stmt InverseMapping::Rewrite(const Stmt& stmt, const ConstraintSet& constraints,
   }
   // Step 2. Get Inverse mapping
   arith::Analyzer analyzer;
-  auto iter_map =
-      arith::DetectIterMap(mapping_pattern, var_range, const_true(), arith::Bijective, analyzer);
+  auto iter_map = arith::DetectIterMap(mapping_pattern, var_range, IntImm::Bool(true),
+                                       arith::Bijective, analyzer);
   TVM_FFI_ICHECK_EQ(iter_map->indices.size(), loop_vars.size());
   ffi::Map<Var, PrimExpr> inverse_mapping =
       arith::InverseAffineIterMap(iter_map->indices, loop_vars);

--- a/src/s_tir/transform/memhammer_intermediate_stage.cc
+++ b/src/s_tir/transform/memhammer_intermediate_stage.cc
@@ -131,7 +131,7 @@ class IndexPatternFinder : public ExprVisitor {
         switch (o.kind) {
           case Operator::OpKind::Mul:
             max *= o.operand;
-            index = index * IntImm(DataType::Int(32), o.operand);
+            index = index * IntImm::Int32(o.operand);
             break;
           case Operator::OpKind::FloorDiv:
             if (max % o.operand != 0 && o.operand % max != 0) {
@@ -146,7 +146,7 @@ class IndexPatternFinder : public ExprVisitor {
               success_ = false;
               return;
             }
-            index = floordiv(index, IntImm(DataType::Int(32), o.operand));
+            index = floordiv(index, IntImm::Int32(o.operand));
             break;
           case Operator::OpKind::FloorMod:
             int64_t step = max / extent;
@@ -161,12 +161,12 @@ class IndexPatternFinder : public ExprVisitor {
               extent = std::max(static_cast<int64_t>(1), std::min(extent, o.operand / step));
               max = extent * step;
             }
-            index = floormod(index, IntImm(DataType::Int(32), o.operand));
+            index = floormod(index, IntImm::Int32(o.operand));
         }
       }
       if (extent > 1) {
         TVM_FFI_ICHECK(max % extent == 0);
-        access_shape_.push_back(IntImm(DataType::Int(32), extent));
+        access_shape_.push_back(IntImm::Int32(extent));
         resulting_index_->push_back(floordiv(index, max / extent));
       }
     }

--- a/src/s_tir/transform/memhammer_lower_auto_copy.cc
+++ b/src/s_tir/transform/memhammer_lower_auto_copy.cc
@@ -465,14 +465,14 @@ class AutoPadder {
     bool CheckVarContiguous(PrimExpr e, Var var, const ffi::Map<Var, PrimExpr>& subst_map) {
       PrimExpr e1 = Substitute(e, [var](const Var& v) -> ffi::Optional<PrimExpr> {
         if (v.same_as(var)) {
-          return IntImm(DataType::Int(32), 0);
+          return IntImm::Int32(0);
         } else {
           return v;
         }
       });
       PrimExpr e2 = Substitute(e, [var](const Var& v) -> ffi::Optional<PrimExpr> {
         if (v.same_as(var)) {
-          return IntImm(DataType::Int(32), 1);
+          return IntImm::Int32(1);
         } else {
           return v;
         }
@@ -487,8 +487,7 @@ class AutoPadder {
       } else {
         int64_t extent =
             warp_thread_extent_.Get(op->thread_binding.value()->thread_tag).value_or(1);
-        var_range_.Set(op->loop_var,
-                       Range::FromMinExtent(op->min, IntImm(DataType::Int(64), extent)));
+        var_range_.Set(op->loop_var, Range::FromMinExtent(op->min, IntImm::Int64(extent)));
       }
       if (op->kind == ForKind::kVectorized) {
         vector_var = op->loop_var;

--- a/src/s_tir/transform/memhammer_tensorcore_rewrite.cc
+++ b/src/s_tir/transform/memhammer_tensorcore_rewrite.cc
@@ -130,7 +130,7 @@ Stmt RewriteWmmaLoad(Stmt stmt) {
   Buffer new_src_buffer(
       /*data=*/Var("src", PointerType(PrimType(dtype), src_buffer.scope())),
       /*dtype=*/dtype,
-      /*shape=*/{IntImm(DataType::Int(32), 16), IntImm(DataType::Int(32), 16)},
+      /*shape=*/{IntImm::Int32(16), IntImm::Int32(16)},
       /*strides=*/{Var("s1", int32), Var("s0", int32)},
       /*elem_offset=*/Var("src_elem_offset", int32),
       /*name=*/"src",
@@ -140,7 +140,7 @@ Stmt RewriteWmmaLoad(Stmt stmt) {
   Buffer new_tgt_buffer(
       /*data=*/Var("tgt", PointerType(PrimType(dtype), tgt_buffer.scope())),
       /*dtype=*/dtype,
-      /*shape=*/{IntImm(DataType::Int(32), 16), IntImm(DataType::Int(32), 16)},
+      /*shape=*/{IntImm::Int32(16), IntImm::Int32(16)},
       /*strides=*/{},
       /*elem_offset=*/Var("tgt_elem_offset", int32),
       /*name=*/"tgt",
@@ -152,7 +152,7 @@ Stmt RewriteWmmaLoad(Stmt stmt) {
   static const Op& tvm_load_matrix_sync_op = Op::Get("tirx.tvm_load_matrix_sync");
   Stmt wmma_body = SBlockRealize(
       /*iter_values=*/{},
-      /*predicate=*/const_true(),
+      /*predicate=*/IntImm::Bool(true),
       SBlock(
           /*iter_vars=*/{},
           /*reads=*/{BufferRegion(src_buffer, read_region)},
@@ -240,7 +240,7 @@ Stmt RewriteWmmaStore(Stmt stmt) {
 
   Buffer new_src_buffer(/*data=*/Var("src", PointerType(PrimType(dtype), src_buffer.scope())),
                         /*dtype=*/dtype,
-                        /*shape=*/{IntImm(DataType::Int(32), 16), IntImm(DataType::Int(32), 16)},
+                        /*shape=*/{IntImm::Int32(16), IntImm::Int32(16)},
                         /*strides=*/{},
                         /*elem_offset=*/Var("src_elem_offset", int32),
                         /*name=*/"src",
@@ -249,7 +249,7 @@ Stmt RewriteWmmaStore(Stmt stmt) {
                         /*buffer_type=*/kDefault);
   Buffer new_tgt_buffer(/*data=*/Var("tgt", PointerType(PrimType(dtype), tgt_buffer.scope())),
                         /*dtype=*/dtype,
-                        /*shape=*/{IntImm(DataType::Int(32), 16), IntImm(DataType::Int(32), 16)},
+                        /*shape=*/{IntImm::Int32(16), IntImm::Int32(16)},
                         /*strides=*/{Var("s1", int32), Var("s0", int32)},
                         /*elem_offset=*/Var("tgt_elem_offset", int32),
                         /*name=*/"tgt",
@@ -262,7 +262,7 @@ Stmt RewriteWmmaStore(Stmt stmt) {
   static const Op& tvm_store_matrix_sync_op = Op::Get("tirx.tvm_store_matrix_sync");
   Stmt wmma_body = SBlockRealize(
       /*iter_values=*/{},  //
-      /*predicate=*/const_true(),
+      /*predicate=*/IntImm::Bool(true),
       SBlock(/*iter_vars=*/{},
              /*reads=*/{BufferRegion(src_buffer, read_region)},
              /*writes=*/{BufferRegion(tgt_buffer, write_region)},
@@ -461,7 +461,7 @@ Stmt RewriteMmaStore(Stmt stmt) {
   const DataType dtype = src_buffer->dtype;
   Buffer new_src_buffer(/*data=*/Var("src", PointerType(PrimType(dtype), src_buffer.scope())),
                         /*dtype=*/dtype,
-                        /*shape=*/{IntImm(DataType::Int(32), 8), IntImm(DataType::Int(32), 8)},
+                        /*shape=*/{IntImm::Int32(8), IntImm::Int32(8)},
                         /*strides=*/{},
                         /*elem_offset=*/Var("src_elem_offset", int32),
                         /*name=*/"src",
@@ -470,7 +470,7 @@ Stmt RewriteMmaStore(Stmt stmt) {
                         /*buffer_type=*/kDefault);
   Buffer new_tgt_buffer(/*data=*/Var("tgt", PointerType(PrimType(dtype), tgt_buffer.scope())),
                         /*dtype=*/dtype,
-                        /*shape=*/{IntImm(DataType::Int(32), 8), IntImm(DataType::Int(32), 8)},
+                        /*shape=*/{IntImm::Int32(8), IntImm::Int32(8)},
                         /*strides=*/{Var("s1", int32), Var("s0", int32)},
                         /*elem_offset=*/Var("tgt_elem_offset", int32),
                         /*name=*/"tgt",
@@ -489,7 +489,7 @@ Stmt RewriteMmaStore(Stmt stmt) {
   Var vec = Var("vec");
   Stmt mma_body = SBlockRealize(
       /*iter_values=*/{},  //
-      /*predicate=*/const_true(),
+      /*predicate=*/IntImm::Bool(true),
       SBlock(/*iter_vars=*/{},
              /*reads=*/{BufferRegion(src_buffer, read_region)},
              /*writes=*/{BufferRegion(tgt_buffer, write_region)},
@@ -501,7 +501,7 @@ Stmt RewriteMmaStore(Stmt stmt) {
                      /*iter_type=*/IterVarType::kThreadIndex,
                      /*thread_tag=*/"threadIdx.x"),
                  /*attr_key=*/"thread_extent",
-                 /*value=*/IntImm(DataType::Int(32), 32),
+                 /*value=*/IntImm::Int32(32),
                  /*body=*/
                  For(vec, 0, 2, ForKind::kVectorized,
                      /*body=*/

--- a/src/s_tir/transform/plan_update_buffer_allocation_location.cc
+++ b/src/s_tir/transform/plan_update_buffer_allocation_location.cc
@@ -216,7 +216,7 @@ class BufferAllocationLocator : public StmtExprMutator {
         GetSBlockReadWriteRegion(opaque_block, buffer_data_to_buffer_);
     n->reads = access[0];
     n->writes = access[1];
-    SBlockRealize realize({}, const_true(), SBlock(n));
+    SBlockRealize realize({}, IntImm::Bool(true), SBlock(n));
     return realize;
   }
 

--- a/src/s_tir/transform/thread_storage_sync.cc
+++ b/src/s_tir/transform/thread_storage_sync.cc
@@ -297,7 +297,7 @@ class ThreadSyncAfterWaitQueueInserter : public StmtExprMutator {
                                 {StringImm(sync_scope_.to_string())}));
       auto inner = op->body.as<AttrStmtNode>();
       TVM_FFI_ICHECK(inner && inner->attr_key == s_tir::attr::async_wait_inflight_count);
-      auto zero = make_zero(DataType::Int(32));
+      auto zero = IntImm::Int32(0);
       auto new_body = SeqStmt({sync, inner->body});
       return AttrStmt(
           zero, s_tir::attr::async_wait_queue_scope, op->value,

--- a/src/s_tir/transform/transform_mma_buffer_layout.cc
+++ b/src/s_tir/transform/transform_mma_buffer_layout.cc
@@ -67,8 +67,8 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
         for (size_t i = 0; i < size - 2; ++i) {
           new_shape.push_back(buffer->shape[i]);
         }
-        new_shape.insert(new_shape.end(), {IntImm(DataType::Int(32), dim0->value / 16),
-                                           IntImm(DataType::Int(32), dim1->value / 8), 2, 2});
+        new_shape.insert(new_shape.end(),
+                         {IntImm::Int32(dim0->value / 16), IntImm::Int32(dim1->value / 8), 2, 2});
 
         Buffer new_buffer = decl_buffer(std::move(new_shape), buffer->dtype, buffer->name, "local",
                                         buffer->axis_separators);
@@ -89,8 +89,8 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
         for (size_t i = 0; i < size - 2; ++i) {
           new_shape.push_back(buffer->shape[i]);
         }
-        new_shape.insert(new_shape.end(), {IntImm(DataType::Int(32), dim0->value / 32),
-                                           IntImm(DataType::Int(32), dim1->value / 8), 4, 2});
+        new_shape.insert(new_shape.end(),
+                         {IntImm::Int32(dim0->value / 32), IntImm::Int32(dim1->value / 8), 4, 2});
 
         Buffer new_buffer = decl_buffer(std::move(new_shape), buffer->dtype, buffer->name, "local",
                                         buffer->axis_separators);
@@ -111,8 +111,8 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
         for (size_t i = 0; i < size - 2; ++i) {
           new_shape.push_back(buffer->shape[i]);
         }
-        new_shape.insert(new_shape.end(), {IntImm(DataType::Int(32), dim0->value / 8),
-                                           IntImm(DataType::Int(32), dim1->value / 32), 1, 8});
+        new_shape.insert(new_shape.end(),
+                         {IntImm::Int32(dim0->value / 8), IntImm::Int32(dim1->value / 32), 1, 8});
 
         Buffer new_buffer = decl_buffer(std::move(new_shape), buffer->dtype, buffer->name, "local",
                                         buffer->axis_separators);

--- a/src/s_tir/transform/using_assume_to_reduce_branches.cc
+++ b/src/s_tir/transform/using_assume_to_reduce_branches.cc
@@ -177,7 +177,7 @@ class ParseAssumeAndOvercompute : public IRMutatorWithAnalyzer {
 
   PrimExpr CurrentScopePredicate() const {
     /* This combines all the constraints in a scope */
-    PrimExpr predicate = const_true();
+    PrimExpr predicate = IntImm::Bool(true);
     for (const auto& condition : conditions_) {
       predicate = predicate && condition;
     }
@@ -281,7 +281,7 @@ class ParseAssumeAndOvercompute : public IRMutatorWithAnalyzer {
   }
 
   void AssumeConstraintComponent(PrimExpr assumption) {
-    PrimExpr additional_predicate = const_true();
+    PrimExpr additional_predicate = IntImm::Bool(true);
     assume_struct buf_data;
 
     std::vector<PrimExpr> buffer_exprs;

--- a/src/script/printer/ir/distributed.cc
+++ b/src/script/printer/ir/distributed.cc
@@ -29,7 +29,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
       ffi::Array<ExprDoc> results;
       results.reserve(s);
       for (int i = 0; i < s; ++i) {
-        results.push_back(d->AsDoc<ExprDoc>(IntImm(DataType::Int(32), n[i]), n_p->ArrayItem(i)));
+        results.push_back(d->AsDoc<ExprDoc>(IntImm::Int32(n[i]), n_p->ArrayItem(i)));
       }
       return TupleDoc(results);
     });

--- a/src/target/intrin_rule.cc
+++ b/src/target/intrin_rule.cc
@@ -133,8 +133,8 @@ TVM_REGISTER_OP("tirx.tvm_access_ptr")
       PrimExpr offset = call->args[2];
       TVM_FFI_ICHECK(call->dtype.is_handle());
       if (dtype.lanes() != 1) {
-        offset = offset * make_const(offset.dtype(), dtype.lanes());
-        offset = Ramp(offset, make_const(offset.dtype(), 1), dtype.lanes());
+        offset = offset * MakeConst(offset.dtype(), dtype.lanes());
+        offset = Ramp(offset, MakeConst(offset.dtype(), 1), dtype.lanes());
       }
       Buffer dummy_buf(buffer_var, dtype.element_of(), {offset + 1}, {}, 0, buffer_var->name_hint,
                        0, 0, kDefault);
@@ -159,21 +159,21 @@ PrimExpr DispatchFastErf(const PrimExpr& e) {
 }
 
 PrimExpr DispatchNumericalStableTanh(const PrimExpr& e) {
-  using tirx::make_const;
-  using tirx::make_zero;
+  using tirx::MakeConst;
   const tirx::CallNode* call = e.as<tirx::CallNode>();
   TVM_FFI_ICHECK(call != nullptr);
   const PrimExpr& x = call->args[0];
-  PrimExpr one = make_const(x.dtype(), 1);
-  PrimExpr two = make_const(x.dtype(), 2);
-  PrimExpr neg_two = make_const(x.dtype(), -2);
+  PrimExpr one = MakeConst(x.dtype(), 1);
+  PrimExpr two = MakeConst(x.dtype(), 2);
+  PrimExpr neg_two = MakeConst(x.dtype(), -2);
 
   PrimExpr exp_neg2x = exp(neg_two * x);
   PrimExpr exp_pos2x = exp(two * x);
 
   PrimExpr tanh_pos = (one - exp_neg2x) / (one + exp_neg2x);
   PrimExpr tanh_neg = (exp_pos2x - one) / (exp_pos2x + one);
-  return tirx::Select(x >= make_zero(x.dtype()), tanh_pos, tanh_neg);
+  // MakeConst can handle both vector and scalar types.
+  return tirx::Select(x >= MakeConst(x.dtype(), 0), tanh_pos, tanh_neg);
 }
 
 }  // namespace intrin
@@ -186,7 +186,7 @@ TVM_REGISTER_OP("tirx.rsqrt")
     .set_attr<FLegalize>("default.FLegalize", [](const PrimExpr& e) -> PrimExpr {
       const CallNode* call = e.as<CallNode>();
       TVM_FFI_ICHECK(call != nullptr);
-      auto one = make_const(call->args[0].dtype(), 1);
+      auto one = MakeConst(call->args[0].dtype(), 1);
       return one / sqrt(call->args[0]);
     });
 
@@ -194,7 +194,7 @@ TVM_REGISTER_OP("tirx.sigmoid")
     .set_attr<FLegalize>("default.FLegalize", [](const PrimExpr& e) -> PrimExpr {
       const CallNode* call = e.as<CallNode>();
       TVM_FFI_ICHECK(call != nullptr);
-      auto one = make_const(call->args[0].dtype(), 1);
+      auto one = MakeConst(call->args[0].dtype(), 1);
       return one / (one + exp(-call->args[0]));
     });
 
@@ -236,7 +236,7 @@ static PrimExpr QMultiplyShift(PrimExpr x, PrimExpr y, PrimExpr q, PrimExpr left
   DataType lp_dtype = DataType::Int(32, x.dtype().lanes());
 
   // 1) Cast and Multiply the integer multiplier
-  PrimExpr one = make_const(hp_dtype, 1);
+  PrimExpr one = MakeConst(hp_dtype, 1);
   x = cast(hp_dtype, x);
   y = cast(hp_dtype, y);
   x = tirx::Select(is_left_shift_required, x << left_shift, x);
@@ -258,7 +258,7 @@ static PrimExpr QMultiplyShift(PrimExpr x, PrimExpr y, PrimExpr q, PrimExpr left
 
 TVM_REGISTER_OP("tirx.q_multiply_shift")
     .set_attr<FLegalize>("default.FLegalize", [](const PrimExpr& e) -> PrimExpr {
-      using tirx::make_const;
+      using tirx::MakeConst;
 
       const tirx::CallNode* call = e.as<tirx::CallNode>();
       TVM_FFI_ICHECK(call != nullptr);
@@ -291,7 +291,7 @@ TVM_REGISTER_OP("tirx.q_multiply_shift")
         } else {
           // power of 2 is less than 0, round and then apply right shift.
           DataType lp_dtype = DataType::Int(32, x.dtype().lanes());
-          PrimExpr one = make_const(lp_dtype, 1);
+          PrimExpr one = MakeConst(lp_dtype, 1);
           exp = -exp;
           PrimExpr rounding_factor = one << (exp - 1);
           PrimExpr rounded_t = x + rounding_factor;
@@ -301,8 +301,8 @@ TVM_REGISTER_OP("tirx.q_multiply_shift")
         // Only int32 types are supported (any number of lanes is allowed)
         TVM_FFI_ICHECK(s.dtype().code() == DLDataTypeCode::kDLInt && s.dtype().bits() == 32);
 
-        // Calculating integer shifts
-        PrimExpr zero = make_const(s.dtype(), 0);
+        // Calculating integer shifts. MakeConst can handle both vector and scalar types.
+        PrimExpr zero = MakeConst(s.dtype(), 0);
         PrimExpr left_shift = tirx::Select(s > zero, s, zero);
         PrimExpr right_shift = tirx::Select(s > zero, zero, -s);
         PrimExpr is_left_shift_required = (left_shift != zero);

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -1191,9 +1191,9 @@ void CodeGenCPU::VisitStmt_(const ForNode* op) {
         CreateSerialFor(MakeValue(task_id), MakeValue(end), MakeValue(num_task), op->loop_var,
                         op->body);
       } else {
-        PrimExpr step = (op->extent + num_task - make_const(t, 1)) / num_task;
+        PrimExpr step = (op->extent + num_task - MakeConst(t, 1)) / num_task;
         PrimExpr begin = min(task_id * step, op->extent);
-        end = min((task_id + make_const(t, 1)) * step, end);
+        end = min((task_id + MakeConst(t, 1)) * step, end);
         CreateSerialFor(MakeValue(begin), MakeValue(end),
                         llvm::ConstantInt::getSigned(GetLLVMType(end), 1), op->loop_var, op->body);
       }

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1873,7 +1873,7 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const RampNode* op) {
   int lanes = op->dtype.lanes();
   for (int i = 0; i < lanes; ++i) {
     vec = builder_->CreateInsertElement(
-        vec, MakeValue(op->base + op->stride * make_const(op->stride.dtype(), i)), ConstInt32(i));
+        vec, MakeValue(op->base + op->stride * MakeConst(op->stride.dtype(), i)), ConstInt32(i));
   }
   return vec;
 }
@@ -1959,7 +1959,7 @@ void CodeGenLLVM::VisitStmt_(const ForNode* op) {
   } else {
     TVM_FFI_ICHECK(op->kind == ForKind::kSerial);
   }
-  PrimExpr step = op->step.value_or(make_const(op->extent->dtype, 1));
+  PrimExpr step = op->step.value_or(MakeConst(op->extent->dtype, 1));
   PrimExpr end = is_zero(op->min) ? op->extent : analyzer_->Simplify(op->min + op->extent);
   llvm::Value* begin_value = MakeValue(op->min);
   llvm::Value* end_value = MakeValue(end);
@@ -2327,7 +2327,7 @@ static void CodegenLLVMRegisterReflection() {
         for (auto it = features.begin(); it != features.end(); ++it) {
           std::string name = it->getKey().str();
           bool value = it->getValue();
-          ret.Set(name, IntImm(DataType::Bool(), value));
+          ret.Set(name, IntImm::Bool(value));
         }
         return ret;
 #else
@@ -2337,7 +2337,7 @@ static void CodegenLLVMRegisterReflection() {
         for (auto it = features.begin(); it != features.end(); ++it) {
           std::string name = it->getKey().str();
           bool value = it->getValue();
-          ret.Set(name, IntImm(DataType::Bool(), value));
+          ret.Set(name, IntImm::Bool(value));
         }
         return ret;
       }

--- a/src/target/llvm/codegen_x86_64.cc
+++ b/src/target/llvm/codegen_x86_64.cc
@@ -69,7 +69,7 @@ llvm::Value* CodeGenX86_64::VisitExpr_(const CastNode* op) {
                                    {op->value})),
               MakeValue(tirx::Broadcast(FloatImm(DataType::Float(32), 0), from.lanes())),
               /*mask=*/MakeValue(IntImm(DataType::Int(16), -1)),
-              /*rounding-mode=*/MakeValue(IntImm(DataType::Int(32), 4)),
+              /*rounding-mode=*/MakeValue(IntImm::Int32(4)),
           });
     }
   }

--- a/src/target/llvm/intrin_rule_llvm.cc
+++ b/src/target/llvm/intrin_rule_llvm.cc
@@ -122,12 +122,11 @@ using tirx::FLegalize;
 
 TVM_REGISTER_OP("tirx.exp10")
     .set_attr<FLegalize>("llvm.FLegalize", [](const PrimExpr& e) -> PrimExpr {
-      using tirx::make_const;
-      using tirx::make_zero;
+      using tirx::MakeConst;
       const tirx::CallNode* call = e.as<tirx::CallNode>();
       TVM_FFI_ICHECK(call != nullptr);
       const PrimExpr& x = call->args[0];
-      PrimExpr ln10 = make_const(x.dtype(), 2.302585093);
+      PrimExpr ln10 = MakeConst(x.dtype(), 2.302585093);
       PrimExpr ret = exp(x * ln10);
       return ret;
     });
@@ -159,12 +158,12 @@ TVM_REGISTER_OP("tirx.acos")
 
 TVM_REGISTER_OP("tirx.atanh")
     .set_attr<FLegalize>("llvm.FLegalize", [](const PrimExpr& e) -> PrimExpr {
-      using tirx::make_const;
+      using tirx::MakeConst;
       const tirx::CallNode* call = e.as<tirx::CallNode>();
       TVM_FFI_ICHECK(call != nullptr) << "Invalid call node in atanh legalization";
       const PrimExpr& x = call->args[0];
-      PrimExpr one = make_const(x.dtype(), 1.0);
-      return (log(one + x) - log(one - x)) * make_const(x.dtype(), 0.5);
+      PrimExpr one = MakeConst(x.dtype(), 1.0);
+      return (log(one + x) - log(one - x)) * MakeConst(x.dtype(), 0.5);
     });
 
 TVM_REGISTER_OP("tirx.clz")

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -319,7 +319,7 @@ ffi::Map<ffi::String, ffi::Any> GenerateBlockAnnotations(const te::ComputeOp& co
     }
   }
   // Set script_parsing_detect_access
-  annotations.Set(s_tir::attr::script_parsing_detect_access, IntImm(DataType::Int(32), 3));
+  annotations.Set(s_tir::attr::script_parsing_detect_access, IntImm::Int32(3));
   return annotations;
 }
 
@@ -517,7 +517,7 @@ Stmt GenerateStmtFromCompute(const te::ComputeOp& compute_op, CreateFuncInfo* in
         TVM_FFI_ICHECK(scopes[i - 1].axes_remap.count(axis->var));
         PrimExpr prev_binding = scopes[i - 1].axes_remap.at(axis->var);
         Var block_var("v_" + axis->var->name_hint, index_type);
-        Range dom = Range::FromMinExtent(prev_binding, make_const(index_type, 1));
+        Range dom = Range::FromMinExtent(prev_binding, MakeConst(index_type, 1));
         IterVar new_block_iter(dom, block_var, axis->iter_type, axis->thread_tag, axis->span);
         cur_scope.AddBlockIter(axis, new_block_iter, prev_binding);
       }
@@ -545,7 +545,7 @@ Stmt GenerateStmtFromCompute(const te::ComputeOp& compute_op, CreateFuncInfo* in
     Stmt body =
         GenerateBodyStmt(leaf.store_indices, buffers, leaf.axes_remap, expr_body, info, analyzer);
     seq_stmt.push_back(SBlockRealize(/*iter_values=*/leaf.bindings,
-                                     /*predicate=*/const_true(),
+                                     /*predicate=*/IntImm::Bool(true),
                                      /*block=*/
                                      SBlock(/*iter_vars=*/leaf.block_iters,
                                             /*reads=*/{},
@@ -567,7 +567,7 @@ Stmt GenerateStmtFromCompute(const te::ComputeOp& compute_op, CreateFuncInfo* in
       Stmt body = GenerateBodyStmt(leaf.store_indices, {buffers[i]}, leaf.axes_remap, expr_body,
                                    info, analyzer);
       seq_stmt.push_back(SBlockRealize(/*iter_values=*/leaf.bindings,
-                                       /*predicate=*/IntImm(DataType::Bool(), 1),
+                                       /*predicate=*/IntImm::Bool(true),
                                        /*block=*/
                                        SBlock(/*iter_vars=*/leaf.block_iters,
                                               /*reads=*/{},
@@ -600,7 +600,7 @@ Stmt GenerateStmtFromCompute(const te::ComputeOp& compute_op, CreateFuncInfo* in
 
       // wrap nested block
       body = SBlockRealize(/*iter_values=*/cur.bindings,
-                           /*predicate=*/IntImm(DataType::Bool(), 1),
+                           /*predicate=*/IntImm::Bool(true),
                            /*block=*/
                            SBlock(/*iter_vars=*/block_iters,
                                   /*reads=*/{},
@@ -660,7 +660,7 @@ Stmt GenerateStmtFromExternOp(const te::ExternOp& extern_op, CreateFuncInfo* inf
 
   // Step 4. Generate opaque block as body.
   return SBlockRealize(/*iter_values=*/{},
-                       /*predicate=*/IntImm(DataType::Bool(), 1),
+                       /*predicate=*/IntImm::Bool(true),
                        /*block=*/
                        SBlock(/*iter_vars=*/{},
                               /*reads=*/{},

--- a/src/te/tensor.cc
+++ b/src/te/tensor.cc
@@ -65,7 +65,7 @@ inline PrimExpr Tensor::IndexTensor(ffi::Array<PrimExpr> indices,
   if (support_negative_indices) {
     for (size_t i = 0; i < shape.size(); i++) {
       PrimExpr new_index =
-          Select(indices[i] < make_const(indices[i]->dtype, 0), indices[i] + shape[i], indices[i]);
+          Select(indices[i] < IntImm(indices[i]->dtype, 0), indices[i] + shape[i], indices[i]);
       indices.Set(i, new_index);
     }
   }

--- a/src/tirx/analysis/exec_context.cc
+++ b/src/tirx/analysis/exec_context.cc
@@ -39,7 +39,7 @@ namespace {
 
 constexpr int kWarpSize = 32;
 
-PrimExpr I64(int64_t value) { return IntImm(DataType::Int(64), value); }
+PrimExpr I64(int64_t value) { return IntImm::Int64(value); }
 
 AxisRange MakeRange(int64_t extent, int64_t offset = 0, int64_t stride = 1) {
   return AxisRange{I64(extent), I64(offset), I64(stride)};

--- a/src/tirx/ir/buffer.cc
+++ b/src/tirx/ir/buffer.cc
@@ -328,14 +328,14 @@ inline ffi::Array<PrimExpr> BufferOffset(const BufferNode* n, ffi::Array<PrimExp
   // get the offset in number of scalars.
   if (n->dtype.lanes() != 1) {
     PrimExpr last_offset = offsets[offsets.size() - 1];
-    offsets.Set(offsets.size() - 1, last_offset * make_const(last_offset.dtype(), dtype.lanes()));
+    offsets.Set(offsets.size() - 1, last_offset * MakeConst(last_offset.dtype(), dtype.lanes()));
   }
 
   // If the requested type has more than one lane, make a RampNode at
   // that offset.
   if (dtype.lanes() != 1) {
     PrimExpr last_offset = offsets[offsets.size() - 1];
-    PrimExpr stride = make_const(last_offset.dtype(), 1);
+    PrimExpr stride = MakeConst(last_offset.dtype(), 1);
     offsets.Set(offsets.size() - 1, tirx::Ramp(last_offset, stride, dtype.lanes()));
   }
 
@@ -484,7 +484,7 @@ Buffer Buffer::MakeStrideView() const {
   const BufferNode* self = operator->();
   TVM_FFI_ICHECK(self != nullptr);
   auto n = ffi::make_object<BufferNode>(*self);
-  PrimExpr acc = make_const(n->DefaultIndexType(), 1);
+  PrimExpr acc = MakeConst(n->DefaultIndexType(), 1);
   for (size_t i = n->shape.size(); i != 0; --i) {
     temp.push_back(acc);
     acc = acc * n->shape[i - 1];
@@ -544,20 +544,20 @@ PrimExpr Buffer::access_ptr(int access_mask, DataType ptr_type, int content_lane
   PrimExpr e_dtype;
   PrimExpr extent;
   if (self->shape.size() == 0) {
-    extent = make_const(self->DefaultIndexType(), 1);
+    extent = MakeConst(self->DefaultIndexType(), 1);
   } else if (self->strides.size() == self->shape.size()) {
     int highest_dim = 0;
     extent = self->strides[highest_dim] * self->shape[highest_dim] - offset;
   } else {
     extent = foldl([](PrimExpr a, PrimExpr b, Span span) { return mul(a, b, span); },
-                   make_const(DataType::Int(32), 1), self->shape) -
+                   IntImm::Int32(1), self->shape) -
              offset;
   }
   PrimExpr elem_offset = self->elem_offset + offset;
   if (content_lanes > 1) {
     e_dtype = tirx::TypeAnnotation(self->dtype.with_lanes(content_lanes));
-    extent = extent / make_const(self->elem_offset.dtype(), content_lanes);
-    elem_offset = self->elem_offset / make_const(self->elem_offset.dtype(), content_lanes);
+    extent = extent / MakeConst(self->elem_offset.dtype(), content_lanes);
+    elem_offset = self->elem_offset / MakeConst(self->elem_offset.dtype(), content_lanes);
   } else {
     e_dtype = tirx::TypeAnnotation(self->dtype);
   }
@@ -566,7 +566,7 @@ PrimExpr Buffer::access_ptr(int access_mask, DataType ptr_type, int content_lane
     extent = input_extent.value();
   }
   ffi::Array<PrimExpr> acc_args{e_dtype, self->data, elem_offset, extent,
-                                make_const(DataType::Int(32), access_mask)};
+                                IntImm::Int32(access_mask)};
   return tirx::Call(ptr_type, tirx::builtin::tvm_access_ptr(), acc_args);
 }
 
@@ -606,7 +606,7 @@ Buffer::Buffer(Var data, DataType dtype, ffi::Array<PrimExpr> shape, ffi::Array<
   n->axis_separators = std::move(axis_separators);
   n->name = std::move(name);
   if (!elem_offset.defined()) {
-    elem_offset = make_const(n->DefaultIndexType(), 0);
+    elem_offset = IntImm(n->DefaultIndexType(), 0);
   }
   if (data_alignment <= 0) {
     data_alignment = runtime::kAllocAlignment;

--- a/src/tirx/ir/exec_scope.cc
+++ b/src/tirx/ir/exec_scope.cc
@@ -388,9 +388,9 @@ ffi::Array<PrimExpr> ResolveCuda(ScopeBinding binding,
       static const Op& ptx_fetch_register_op = Op::Get("tirx.ptx.fetch_register");
       ffi::Array<PrimExpr> ret;
       for (int i = 0; i < out_dim; ++i) {
-        ret.push_back(tirx::Call(
-            DataType::Int(32), ptx_fetch_register_op,
-            {IntImm(DataType::Int(32), 32), StringImm("clusterid." + std::string(1, 'x' + i))}));
+        ret.push_back(
+            tirx::Call(DataType::Int(32), ptx_fetch_register_op,
+                       {IntImm::Int32(32), StringImm("clusterid." + std::string(1, 'x' + i))}));
       }
       return ret;
     }
@@ -440,8 +440,7 @@ PrimExpr ScopeIdResolve::ComputeWarpIdInCta(const LaunchParams& params) {
   PrimExpr warp_id = FloorDiv(GetLinearThreadIndex(params), 32);
   PrimExpr mask = IntImm(DataType::UInt(32), 0xffffffff);
   return Call(warp_id.dtype(), builtin::tvm_warp_shuffle(),
-              {mask, warp_id, IntImm(DataType::Int(32), 0), IntImm(DataType::Int(32), 32),
-               IntImm(DataType::Int(32), 32)});
+              {mask, warp_id, IntImm::Int32(0), IntImm::Int32(32), IntImm::Int32(32)});
 }
 
 }  // namespace tirx

--- a/src/tirx/ir/expr.cc
+++ b/src/tirx/ir/expr.cc
@@ -628,7 +628,7 @@ static ffi::Array<PrimExpr> ConvertCallArgs(ffi::Array<CallArg> args) {
         if (is_one(r->extent)) {
           indices.push_back(r->min);
         } else if (r->extent.as<IntImmNode>()) {
-          indices.push_back(tirx::Ramp(r->min, make_const(r->min->dtype, 1), r->extent));
+          indices.push_back(tirx::Ramp(r->min, MakeConst(r->min->dtype, 1), r->extent));
         } else {
           TVM_FFI_THROW(ValueError)
               << "Cannot convert to BufferLoad: " << ffi::GetRef<BufferRegion>(br);
@@ -706,14 +706,14 @@ PrimExpr Shuffle::Concat(ffi::Array<PrimExpr> vectors, Span span) {
   int index = 0;
   for (const PrimExpr& e : vectors) {
     for (int i = 0; i < e.dtype().lanes(); ++i) {
-      indices.push_back(IntImm(DataType::Int(32), index++));
+      indices.push_back(IntImm::Int32(index++));
     }
   }
   return Shuffle(vectors, indices, span);
 }
 
 PrimExpr Shuffle::ExtractElement(PrimExpr vector, int index, Span span) {
-  return Shuffle({vector}, {IntImm(DataType::Int(32), index)}, span);
+  return Shuffle({vector}, {IntImm::Int32(index)}, span);
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {
@@ -798,7 +798,7 @@ Reduce::Reduce(CommReducer combiner, ffi::Array<PrimExpr> source, ffi::Array<Ite
         << "Can only take axis created by reduce_axis";
   }
   if (!condition.defined()) {
-    condition = const_true();
+    condition = IntImm::Bool(true);
   }
   auto n = ffi::make_object<ReduceNode>();
   TVM_FFI_ICHECK(source.defined());

--- a/src/tirx/ir/index_map.cc
+++ b/src/tirx/ir/index_map.cc
@@ -68,7 +68,7 @@ std::pair<IndexMap, PrimExpr> IndexMapInverseImpl(const IndexMap& self,
     // return the pre-defined inverse index map if exists.  In this
     // case, the user-defined inverse is assumed to be correct and
     // bijective.
-    PrimExpr padding_predicate = IntImm(DataType::Bool(), 0);
+    PrimExpr padding_predicate = IntImm::Bool(false);
     return {Downcast<IndexMap>(self->inverse_index_map.value()), padding_predicate};
   }
 
@@ -275,7 +275,7 @@ ffi::Array<PrimExpr> IndexMapNode::MapShape(const ffi::Array<PrimExpr>& shape,
 
   ffi::Array<Range> ranges;
   for (auto& dim : shape) {
-    ranges.push_back(Range(make_zero(dim.dtype()), dim));
+    ranges.push_back(Range(IntImm(dim.dtype(), 0), dim));
   }
   ffi::Array<Range> mapped = MapRanges(std::move(ranges), analyzer);
 

--- a/src/tirx/ir/layout/tile_core.cc
+++ b/src/tirx/ir/layout/tile_core.cc
@@ -163,7 +163,7 @@ ffi::Map<ffi::String, PrimExpr> TileLayoutNode::Apply(const ffi::Array<PrimExpr>
     ffi::Array<PrimExpr> per_shard_coords;
     per_shard_coords.reserve(grouped->shard.size());
     for (size_t i = 0; i < grouped->shard.size(); ++i) {
-      per_shard_coords.push_back(IntImm(DataType::Int(32), 0));
+      per_shard_coords.push_back(IntImm::Int32(0));
     }
     for (size_t d = 0; d < shape.size(); ++d) {
       int64_t start = seps[d];

--- a/src/tirx/ir/layout/tile_slice.cc
+++ b/src/tirx/ir/layout/tile_slice.cc
@@ -118,7 +118,7 @@ ffi::Optional<TileLayout> SlicePerGroup(TileLayout layout, PrimExpr begin, PrimE
     return TileLayout(new_shard, layout->replica, new_offset);
   }
 
-  PrimExpr two = make_const(rem.dtype(), 2);
+  PrimExpr two = MakeConst(rem.dtype(), 2);
   PrimExpr c = analyzer->Simplify(floordiv(rem, two));
   bool even = analyzer->CanProveEqual(floormod(rem, two), 0);
   bool mid = analyzer->CanProveEqual(analyzer->Simplify(d0[pivot] + c), Ek);
@@ -131,7 +131,7 @@ ffi::Optional<TileLayout> SlicePerGroup(TileLayout layout, PrimExpr begin, PrimE
       PrimExpr delta =
           analyzer->Simplify((pivot > 0 ? shard[pivot - 1]->stride : PrimExpr(0)) - (Ek - c) * Sk);
       std::vector<Iter> new_shard;
-      new_shard.push_back(Iter(make_const(c.dtype(), 2), delta, ak));
+      new_shard.push_back(Iter(MakeConst(c.dtype(), 2), delta, ak));
       new_shard.push_back(Iter(c, Sk, ak));
       new_shard.insert(new_shard.end(), peeled_rev.rbegin(), peeled_rev.rend());
       return TileLayout(new_shard, layout->replica, new_offset);

--- a/src/tirx/ir/layout/utils.cc
+++ b/src/tirx/ir/layout/utils.cc
@@ -73,7 +73,7 @@ std::vector<PrimExpr> GetDefaultStrides(const ffi::Array<PrimExpr>& data, PrimEx
   // get int32 strides and structurally differ from parser output.
   PrimExpr current_stride = initial_stride;
   if (const auto* imm = current_stride.as<IntImmNode>()) {
-    current_stride = make_const(data[0].dtype(), imm->value);
+    current_stride = MakeConst(data[0].dtype(), imm->value);
   }
   for (int i = static_cast<int>(n) - 1; i >= 0; --i) {
     strides[i] = current_stride;

--- a/src/tirx/ir/script/script_complete.cc
+++ b/src/tirx/ir/script/script_complete.cc
@@ -154,7 +154,7 @@ PrimFunc ScriptComplete(PrimFunc func, const ffi::Array<Buffer>& root_allocates,
 
   if (s_tir && should_insert_root) {
     SBlock root_block({}, {}, {}, "root", std::move(res), std::nullopt, root_allocates);
-    res = SBlockRealize({}, IntImm(DataType::Bool(), 1), std::move(root_block));
+    res = SBlockRealize({}, IntImm::Bool(true), std::move(root_block));
   }
 
   // generate surrounding loops automatically

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -156,7 +156,7 @@ For::For(Var loop_var, PrimExpr min, PrimExpr extent, ForKind kind, Stmt body,
         << ") is narrower than that of `min` or `extent` (" << e.dtype() << ")";
     const IntImmNode* a = e.as<IntImmNode>();
     if (a && e.dtype().bits() < loop_var.dtype().bits()) {
-      return make_const(loop_var.dtype(), a->value);
+      return MakeConst(loop_var.dtype(), a->value);
     } else {
       return e;
     }
@@ -478,7 +478,7 @@ PrimExpr BufferRegionNode::ToPrimExpr() const {
     if (tvm::tirx::is_one(r->extent)) {
       indices.push_back(r->min);
     } else if (r->extent.as<IntImmNode>()) {
-      indices.push_back(tirx::Ramp(r->min, tvm::tirx::make_const(r->min->dtype, 1), r->extent));
+      indices.push_back(tirx::Ramp(r->min, tvm::tirx::MakeConst(r->min->dtype, 1), r->extent));
     } else {
       TVM_FFI_THROW(ValueError) << "Cannot convert to BufferLoad: "
                                 << ffi::GetRef<BufferRegion>(this);
@@ -512,7 +512,7 @@ BufferRegion BufferRegion::FromPoint(Buffer buffer, ffi::Array<PrimExpr> indices
       region.push_back(
           Range::FromMinExtent(ramp_index->base, ramp_index->stride * ramp_index->lanes));
     } else {
-      region.push_back(Range::FromMinExtent(index, make_const(index.dtype(), 1)));
+      region.push_back(Range::FromMinExtent(index, MakeConst(index.dtype(), 1)));
     }
   }
   return BufferRegion(buffer, region);

--- a/src/tirx/op/op.cc
+++ b/src/tirx/op/op.cc
@@ -144,10 +144,9 @@ Type GetTypeFromRuntimeDataType(const DataType& dtype) {
 
 // LargeUIntImm
 PrimExpr LargeUIntImm(DataType t, int64_t low, int64_t high, Span span) {
-  return tirx::Call(
-      t, tirx::builtin::large_uint_imm(),
-      {make_const(DataType::UInt(32), low, span), make_const(DataType::UInt(32), high, span)}, {},
-      span);
+  return tirx::Call(t, tirx::builtin::large_uint_imm(),
+                    {IntImm(DataType::UInt(32), low, span), IntImm(DataType::UInt(32), high, span)},
+                    {}, span);
 }
 
 // Q-multiplication
@@ -313,7 +312,7 @@ PrimExpr max_value(const DataType& dtype, Span span) {
     }
   } else if (dtype.is_uint()) {
     if (dtype.bits() == 64) {
-      return make_const(dtype, std::numeric_limits<uint64_t>::max(), span);
+      return MakeConst(dtype, std::numeric_limits<uint64_t>::max(), span);
     } else if (dtype.bits() < 64) {
       uint64_t val = 1;
       val = (val << static_cast<uint64_t>(dtype.bits())) - 1;
@@ -457,9 +456,9 @@ PrimExpr cast(const DataType& t, PrimExpr value, Span span) {
   // const fold IntImm as they are used in index computations
   if (t.is_scalar()) {
     if (const IntImmNode* op = value.as<IntImmNode>()) {
-      return make_const(t, op->value, op->span);
+      return MakeConst(t, op->value, op->span);
     } else if (const FloatImmNode* op = value.as<FloatImmNode>()) {
-      return make_const(t, op->value, op->span);
+      return MakeConst(t, op->value, op->span);
     }
     TVM_FFI_ICHECK(!value.dtype().is_handle()) << "Can't cast a handle to other types.";
     return tirx::Cast(t, value, span);
@@ -469,9 +468,9 @@ PrimExpr cast(const DataType& t, PrimExpr value, Span span) {
       // manually unroll cast
       if (value.dtype() != vtype) {
         if (const IntImmNode* op = value.as<IntImmNode>()) {
-          value = make_const(vtype, op->value, op->span);
+          value = MakeConst(vtype, op->value, op->span);
         } else if (const FloatImmNode* op = value.as<FloatImmNode>()) {
-          value = make_const(vtype, op->value, op->span);
+          value = MakeConst(vtype, op->value, op->span);
         } else {
           value = tirx::Cast(vtype, value, span);
         }
@@ -538,7 +537,7 @@ PrimExpr neg(PrimExpr a, Span span) {
   const FloatImmNode* fa = a.as<FloatImmNode>();
   if (pa) return IntImm(a.dtype(), -pa->value, span);
   if (fa) return FloatImm(a.dtype(), -fa->value, span);
-  return make_zero(a.dtype(), span) - a;
+  return MakeConst(a.dtype(), 0, span) - a;
 }
 
 PrimExpr operator-(PrimExpr a, PrimExpr b) { return sub(a, b); }
@@ -906,7 +905,8 @@ PrimExpr abs(PrimExpr x, Span span) {
     if (px) {
       return IntImm(x.dtype(), std::abs(px->value), px->span);
     }
-    return tirx::Select(x >= make_zero(x.dtype()), x, -x, span);
+    // MakeConst can handle both vector and scalar types.
+    return tirx::Select(x >= MakeConst(x.dtype(), 0), x, -x, span);
   } else if (x.dtype().is_float() || x.dtype().is_bfloat()) {
     using tirx::FloatImmNode;
     const FloatImmNode* fx = x.as<FloatImmNode>();
@@ -930,12 +930,12 @@ TVM_TIR_REGISTER_PURE_UNARY_OP("fabs").set_attr<TVectorizable>("TVectorizable", 
 PrimExpr isnan(PrimExpr x, Span span) {
   DataType t = DataType::Bool(x.dtype().lanes());
   if (x.dtype().is_int() || x.dtype().is_uint()) {
-    return make_const(t, false);
+    return MakeConst(t, false);
   } else if (x.dtype().is_float()) {
     using tirx::FloatImmNode;
     const FloatImmNode* fx = x.as<FloatImmNode>();
     if (fx) {
-      return make_const(t, std::isnan(fx->value), fx->span);
+      return MakeConst(t, std::isnan(fx->value), fx->span);
     }
     if (x.dtype().bits() == 16) {
       static const Op& isnan_op = Op::Get("tirx.isnan");
@@ -955,7 +955,7 @@ PrimExpr isnan(PrimExpr x, Span span) {
 PrimExpr isinf(PrimExpr x, Span span) {
   DataType t = DataType::Bool(x.dtype().lanes());
   if (x.dtype().is_int() || x.dtype().is_uint()) {
-    return make_const(t, false, span);
+    return MakeConst(t, false, span);
   } else if (x.dtype().is_float()) {
     PrimExpr infX = infinity(x.dtype(), span);
     return abs(x, span) == infX && !isnan(x, span);
@@ -971,27 +971,27 @@ PrimExpr isfinite(PrimExpr x, Span span) { return !isinf(x, span) && !isnan(x, s
 PrimExpr sum(PrimExpr source, ffi::Array<IterVar> rdom, ffi::Array<PrimExpr> init, Span span) {
   Var x("x", source.dtype(), span), y("y", source.dtype(), span);
   PrimExpr result = tirx::Add(x, y, span);
-  PrimExpr identity_element = make_zero(source.dtype(), span);
+  PrimExpr identity_element = MakeConst(source.dtype(), 0, span);
   tirx::CommReducer combiner = tirx::CommReducer({x}, {y}, {result}, {identity_element}, span);
-  return tirx::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(), true), 0, init, span);
+  return tirx::Reduce(combiner, {source}, rdom, IntImm::Bool(true), 0, init, span);
 }
 
 PrimExpr all(PrimExpr source, ffi::Array<IterVar> rdom, ffi::Array<PrimExpr> init, Span span) {
   type_check_boolean_args(source, "tvm::all");
   Var x("x", source.dtype(), span), y("y", source.dtype());
   PrimExpr result = tirx::And(x, y, span);
-  PrimExpr identity_element = make_const(source.dtype(), true, span);
+  PrimExpr identity_element = MakeConst(source.dtype(), true, span);
   tirx::CommReducer combiner = tirx::CommReducer({x}, {y}, {result}, {identity_element}, span);
-  return tirx::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(), true), 0, init, span);
+  return tirx::Reduce(combiner, {source}, rdom, IntImm::Bool(true), 0, init, span);
 }
 
 PrimExpr any(PrimExpr source, ffi::Array<IterVar> rdom, ffi::Array<PrimExpr> init, Span span) {
   type_check_boolean_args(source, "tvm::any");
   Var x("x", source.dtype(), span), y("y", source.dtype(), span);
   PrimExpr result = tirx::Or(x, y, span);
-  PrimExpr identity_element = make_const(source.dtype(), false, span);
+  PrimExpr identity_element = MakeConst(source.dtype(), false, span);
   tirx::CommReducer combiner = tirx::CommReducer({x}, {y}, {result}, {identity_element}, span);
-  return tirx::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(), true), 0, init, span);
+  return tirx::Reduce(combiner, {source}, rdom, IntImm::Bool(true), 0, init, span);
 }
 
 PrimExpr max(PrimExpr source, ffi::Array<IterVar> rdom, ffi::Array<PrimExpr> init, Span span) {
@@ -999,7 +999,7 @@ PrimExpr max(PrimExpr source, ffi::Array<IterVar> rdom, ffi::Array<PrimExpr> ini
   PrimExpr result = tirx::Max(x, y, span);
   PrimExpr identity_element = min_value(source.dtype(), span);
   tirx::CommReducer combiner = tirx::CommReducer({x}, {y}, {result}, {identity_element}, span);
-  return tirx::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(), true), 0, init, span);
+  return tirx::Reduce(combiner, {source}, rdom, IntImm::Bool(true), 0, init, span);
 }
 
 PrimExpr min(PrimExpr source, ffi::Array<IterVar> rdom, ffi::Array<PrimExpr> init, Span span) {
@@ -1007,7 +1007,7 @@ PrimExpr min(PrimExpr source, ffi::Array<IterVar> rdom, ffi::Array<PrimExpr> ini
   PrimExpr result = tirx::Min(x, y, span);
   PrimExpr identity_element = max_value(source.dtype(), span);
   tirx::CommReducer combiner = tirx::CommReducer({x}, {y}, {result}, {identity_element}, span);
-  return tirx::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(), true), 0, init, span);
+  return tirx::Reduce(combiner, {source}, rdom, IntImm::Bool(true), 0, init, span);
 }
 
 PrimExpr prod(PrimExpr source, ffi::Array<IterVar> rdom, ffi::Array<PrimExpr> init, Span span) {
@@ -1019,10 +1019,9 @@ PrimExpr prod(PrimExpr source, ffi::Array<IterVar> rdom, ffi::Array<PrimExpr> in
     // For non-bool types, we lower prod through Mul.
     Var x("x", source.dtype(), span), y("y", source.dtype(), span);
     PrimExpr result = tirx::Mul(x, y, span);
-    PrimExpr identity_element = make_const(source.dtype(), 1, span);
+    PrimExpr identity_element = MakeConst(source.dtype(), 1, span);
     tirx::CommReducer combiner = tirx::CommReducer({x}, {y}, {result}, {identity_element}, span);
-    return tirx::Reduce(combiner, {source}, rdom, make_const(DataType::Bool(), true), 0, init,
-                        span);
+    return tirx::Reduce(combiner, {source}, rdom, IntImm::Bool(true), 0, init, span);
   }
 }
 
@@ -1186,9 +1185,9 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def_packed("node._const",
                   [](ffi::PackedArgs args, ffi::Any* ret) {
                     if (auto opt = args[0].try_cast<int64_t>()) {
-                      *ret = tirx::make_const(args[1].cast<DataType>(), *opt, args[2].cast<Span>());
+                      *ret = tirx::MakeConst(args[1].cast<DataType>(), *opt, args[2].cast<Span>());
                     } else if (auto opt = args[0].try_cast<double>()) {
-                      *ret = tirx::make_const(args[1].cast<DataType>(), *opt, args[2].cast<Span>());
+                      *ret = tirx::MakeConst(args[1].cast<DataType>(), *opt, args[2].cast<Span>());
                     } else {
                       TVM_FFI_THROW(InternalError)
                           << "First argument to tvm.tirx.const must be int, float, or bool, "
@@ -1238,7 +1237,6 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](PrimExpr cond, PrimExpr true_value, PrimExpr false_value, Span span) {
              return if_then_else(cond, true_value, false_value, span);
            })
-      .def("tirx.const_true", [](DataType t, Span span) { return const_true(t.lanes(), span); })
       .DEF_MAKE_BINARY_OP(_OpAdd, add)
       .DEF_MAKE_BINARY_OP(_OpSub, sub)
       .DEF_MAKE_BINARY_OP(_OpMul, mul)
@@ -1271,24 +1269,24 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 }
 
 PrimExpr fast_erf_float_expr(PrimExpr arg, int bits) {
-  auto plus_4 = make_const(DataType::Float(bits), 4.f);
-  auto minus_4 = make_const(DataType::Float(bits), -4.f);
+  auto plus_4 = FloatImm(DataType::Float(bits), 4.f);
+  auto minus_4 = FloatImm(DataType::Float(bits), -4.f);
 
   // The monomial coefficients of the numerator polynomial (odd).
-  auto alpha_1 = make_const(DataType::Float(bits), -1.60960333262415e-02f);
-  auto alpha_3 = make_const(DataType::Float(bits), -2.95459980854025e-03f);
-  auto alpha_5 = make_const(DataType::Float(bits), -7.34990630326855e-04f);
-  auto alpha_7 = make_const(DataType::Float(bits), -5.69250639462346e-05f);
-  auto alpha_9 = make_const(DataType::Float(bits), -2.10102402082508e-06f);
-  auto alpha_11 = make_const(DataType::Float(bits), 2.77068142495902e-08f);
-  auto alpha_13 = make_const(DataType::Float(bits), -2.72614225801306e-10f);
+  auto alpha_1 = FloatImm(DataType::Float(bits), -1.60960333262415e-02f);
+  auto alpha_3 = FloatImm(DataType::Float(bits), -2.95459980854025e-03f);
+  auto alpha_5 = FloatImm(DataType::Float(bits), -7.34990630326855e-04f);
+  auto alpha_7 = FloatImm(DataType::Float(bits), -5.69250639462346e-05f);
+  auto alpha_9 = FloatImm(DataType::Float(bits), -2.10102402082508e-06f);
+  auto alpha_11 = FloatImm(DataType::Float(bits), 2.77068142495902e-08f);
+  auto alpha_13 = FloatImm(DataType::Float(bits), -2.72614225801306e-10f);
 
   // The monomial coefficients of the denominator polynomial (even).
-  auto beta_0 = make_const(DataType::Float(bits), -1.42647390514189e-02f);
-  auto beta_2 = make_const(DataType::Float(bits), -7.37332916720468e-03f);
-  auto beta_4 = make_const(DataType::Float(bits), -1.68282697438203e-03f);
-  auto beta_6 = make_const(DataType::Float(bits), -2.13374055278905e-04f);
-  auto beta_8 = make_const(DataType::Float(bits), -1.45660718464996e-05f);
+  auto beta_0 = FloatImm(DataType::Float(bits), -1.42647390514189e-02f);
+  auto beta_2 = FloatImm(DataType::Float(bits), -7.37332916720468e-03f);
+  auto beta_4 = FloatImm(DataType::Float(bits), -1.68282697438203e-03f);
+  auto beta_6 = FloatImm(DataType::Float(bits), -2.13374055278905e-04f);
+  auto beta_8 = FloatImm(DataType::Float(bits), -1.45660718464996e-05f);
 
   // clamp x
   auto x = tvm::max(tvm::min(arg, plus_4), minus_4);
@@ -1347,9 +1345,9 @@ PrimExpr PrintOpPacked(Var data, DataType dtype, bool is_string, bool is_scalar,
   ffi::Array<PrimExpr> args;
   args.push_back(data);
   args.push_back(tirx::StringImm(ffi::DLDataTypeToString(dtype)));
-  args.push_back(make_const(DataType::Bool(), is_string));
-  args.push_back(make_const(DataType::Bool(), is_scalar));
-  args.push_back(make_const(DataType::UInt(32), dim_num));
+  args.push_back(IntImm::Bool(is_string));
+  args.push_back(IntImm::Bool(is_scalar));
+  args.push_back(IntImm(DataType::UInt(32), dim_num));
   for (const auto& dim : shape) {
     args.push_back(dim);
   }

--- a/src/tirx/script/builder/frame.cc
+++ b/src/tirx/script/builder/frame.cc
@@ -182,7 +182,7 @@ void SBlockFrameNode::ExitWithScope() {
   }
   ffi::Map<ffi::String, Any> attrs = annotations.value_or({});
   if (int detect_access = (!reads.defined()) | (!writes.defined() << 1)) {
-    attrs.Set("tirx.script_parsing_detect_access", tvm::IntImm(DataType::Int(64), detect_access));
+    attrs.Set("tirx.script_parsing_detect_access", tvm::IntImm::Int64(detect_access));
   }
   tvm::tirx::SBlock block(iter_vars, reads.value_or(ffi::Array<tvm::tirx::BufferRegion>()),
                           writes.value_or(ffi::Array<tvm::tirx::BufferRegion>()), name,
@@ -195,8 +195,8 @@ void SBlockFrameNode::ExitWithScope() {
         << "`T.where` is not allowed when `no_realize=True`";
     AddToParent(block);
   } else {
-    AddToParent(tvm::tirx::SBlockRealize(iter_values,
-                                         predicate.value_or(IntImm(DataType::Bool(), 1)), block));
+    AddToParent(
+        tvm::tirx::SBlockRealize(iter_values, predicate.value_or(IntImm::Bool(true)), block));
   }
 }
 
@@ -331,8 +331,7 @@ void HintFrameNode::ExitWithScope() {
   for (const auto& [k, v] : attrs) {
     full_attrs.Set(k, v);
   }
-  AddToParent(
-      tvm::tirx::AttrStmt(full_attrs, "tirx_hint", IntImm(DataType::Int(32), 1), AsStmt(stmts)));
+  AddToParent(tvm::tirx::AttrStmt(full_attrs, "tirx_hint", IntImm::Int32(1), AsStmt(stmts)));
 }
 
 }  // namespace tirx

--- a/src/tirx/script/builder/ir.cc
+++ b/src/tirx/script/builder/ir.cc
@@ -245,7 +245,7 @@ ffi::Array<tvm::tirx::Var> CtaId(ffi::Optional<ffi::Array<PrimExpr>> extents, ff
 
 ffi::Array<tvm::tirx::Var> CtaIdInPair() {
   ffi::Array<tvm::tirx::Var> scope_ids{tvm::tirx::Var("")};
-  tvm::tirx::ScopeIdDef def(scope_ids, ffi::Array<PrimExpr>{IntImm(DataType::Int(32), 2)},
+  tvm::tirx::ScopeIdDef def(scope_ids, ffi::Array<PrimExpr>{IntImm::Int32(2)},
                             tvm::tirx::ScopeBinding::kClusterCtaPair);
   AddToParent(tvm::tirx::ScopeIdDefStmt(def));
   return scope_ids;
@@ -551,7 +551,7 @@ ForFrame Grid(ffi::Array<ffi::Variant<PrimExpr, ffi::Tuple<PrimExpr, PrimExpr>>>
       // extent is a single PrimExpr
       DataType dtype = prim_expr.value().dtype();
       n->vars.push_back(Var("v", dtype));
-      n->doms.push_back(Range(tvm::tirx::make_const(dtype, 0), prim_expr.value()));
+      n->doms.push_back(Range(tvm::IntImm(dtype, 0), prim_expr.value()));
     } else if (auto tuple = extent.as<ffi::Tuple<PrimExpr, PrimExpr>>()) {
       // extent is a tuple of two PrimExpr (start, extent)
       DataType dtype = tuple.value().get<0>().dtype();
@@ -621,7 +621,7 @@ LaunchThreadFrame LaunchThread(Var var, PrimExpr extent) {
   ffi::ObjectPtr<LaunchThreadFrameNode> n = ffi::make_object<LaunchThreadFrameNode>();
   if (!iter_var->dom.defined()) {
     const_cast<tvm::tirx::IterVarNode*>(iter_var.get())->dom =
-        Range(tvm::tirx::make_zero(extent.dtype()), extent);
+        Range(tvm::IntImm(extent.dtype(), 0), extent);
   } else if (!arith::Analyzer()->CanProveEqual(iter_var->dom->extent, extent)) {
     TVM_FFI_THROW(InternalError) << "ValueError: Inconsistent extents of environment thread. "
                                  << iter_var->dom->extent << " vs " << extent;
@@ -657,8 +657,8 @@ AttrFrame DeviceEntry() {
   // enclosing PrimFuncFrame: ``IRBuilderFrameNode::ExitWithScope`` runs
   // callbacks before popping itself, so the AttrFrame is closed and its
   // emitted ``AttrStmt`` lands in the PrimFunc's body sequence.
-  AttrFrame frame = Attr(IntImm(DataType::Int(32), 0), ffi::String(tvm::tirx::attr::kDeviceEntry),
-                         IntImm(DataType::Bool(), 1));
+  AttrFrame frame =
+      Attr(IntImm::Int32(0), ffi::String(tvm::tirx::attr::kDeviceEntry), IntImm::Bool(true));
   IRBuilder builder = IRBuilder::Current();
   ffi::Optional<PrimFuncFrame> pf_frame = builder->FindFrame<PrimFuncFrame>();
   TVM_FFI_ICHECK(pf_frame.defined())

--- a/src/tirx/transform/dtype_conversion.cc
+++ b/src/tirx/transform/dtype_conversion.cc
@@ -57,7 +57,7 @@ PrimExpr DTypeConversion(PrimExpr src_value, DataType tgt_dtype, RoundingMode ro
     TVM_FFI_ICHECK(round_mode == RoundingMode::kHalfToEven)
         << "Currently we only support HalfToEven rounding mode.";
     PrimExpr rounding_bias = ((src_uint_value >> (-mantissa_delta)) & 1) +
-                             make_const(src_uint, (int64_t(1) << (-mantissa_delta - 1)) - 1);
+                             MakeConst(src_uint, (int64_t(1) << (-mantissa_delta - 1)) - 1);
     src_uint_value = src_uint_value + rounding_bias;
   }
   if (exponent_delta == 0) {
@@ -69,9 +69,9 @@ PrimExpr DTypeConversion(PrimExpr src_value, DataType tgt_dtype, RoundingMode ro
       ret = cast(tgt_uint, ret >> (-mantissa_delta));
     }
     if (bias_delta > 0) {
-      ret = ret + (make_const(tgt_uint, bias_delta) << tgt_fp.mantissa);
+      ret = ret + (MakeConst(tgt_uint, bias_delta) << tgt_fp.mantissa);
     } else if (bias_delta < 0) {
-      ret = ret - (make_const(tgt_uint, -bias_delta) << tgt_fp.mantissa);
+      ret = ret - (MakeConst(tgt_uint, -bias_delta) << tgt_fp.mantissa);
     }
     return reinterpret(tgt_dtype, ret);
   } else {
@@ -79,7 +79,7 @@ PrimExpr DTypeConversion(PrimExpr src_value, DataType tgt_dtype, RoundingMode ro
     PrimExpr ret_mantissa =
         (mantissa_delta >= 0 ? (cast(tgt_uint, src_uint_value) << mantissa_delta)
                              : (cast(tgt_uint, src_uint_value >> (-mantissa_delta)))) &
-        make_const(tgt_uint, (int64_t(1) << (tgt_fp.mantissa)) - 1);
+        MakeConst(tgt_uint, (int64_t(1) << (tgt_fp.mantissa)) - 1);
     PrimExpr exponent_before_delta = ((src_uint_value << 1) >> (src_fp.mantissa + 1));
     PrimExpr ret_sign = cast(tgt_uint, (src_uint_value >> (src_fp.mantissa + src_fp.exponent)))
                         << (tgt_fp.mantissa + tgt_fp.exponent);
@@ -92,7 +92,8 @@ PrimExpr DTypeConversion(PrimExpr src_value, DataType tgt_dtype, RoundingMode ro
       PrimExpr round_to_zero = exponent_before_delta < (-bias_delta);
       PrimExpr ret_exponent = cast(tgt_uint, exponent_before_delta - (-bias_delta))
                               << tgt_fp.mantissa;
-      return reinterpret(tgt_dtype, if_then_else(round_to_zero, make_const(tgt_uint, 0),
+      // MakeConst can handle both vector and scalar types.
+      return reinterpret(tgt_dtype, if_then_else(round_to_zero, MakeConst(tgt_uint, 0),
                                                  ret_mantissa | ret_exponent | ret_sign));
     }
   }

--- a/src/tirx/transform/force_narrow_index_to_i32.cc
+++ b/src/tirx/transform/force_narrow_index_to_i32.cc
@@ -57,7 +57,7 @@ class Int32DTypeNarrower : public IndexDataTypeNormalizer {
     // ignore the enabled condition and always rewrite i64
     if (op->dtype == DataType::Int(64)) {
       TVM_FFI_ICHECK_LE(op->value, Downcast<IntImm>(max_value(target_data_type_))->value);
-      return IntImm(DataType::Int(32), op->value);
+      return IntImm::Int32(op->value);
     }
     return ffi::GetRef<IntImm>(op);
   }

--- a/src/tirx/transform/ir_utils.h
+++ b/src/tirx/transform/ir_utils.h
@@ -97,8 +97,7 @@ inline ffi::Array<T> UpdateArray(ffi::Array<T> arr, F fupdate) {
  */
 inline PrimExpr TVMStructGet(DataType dtype, Var handle, int index,
                              builtin::TVMStructFieldKind kind) {
-  ffi::Array<PrimExpr> args = {handle, make_const(DataType::Int(32), index),
-                               make_const(DataType::Int(32), static_cast<int>(kind))};
+  ffi::Array<PrimExpr> args = {handle, IntImm::Int32(index), IntImm::Int32(static_cast<int>(kind))};
   return Call(dtype, builtin::tvm_struct_get(), args);
 }
 
@@ -109,7 +108,7 @@ inline PrimExpr TVMStructGet(DataType dtype, Var handle, int index,
  * \param offset the offset index.
  */
 inline PrimExpr AddressOffset(Var handle, DataType dtype, int offset) {
-  PrimExpr offset_expr = make_const(DataType::Int(32), offset * dtype.lanes());
+  PrimExpr offset_expr = IntImm::Int32(offset * dtype.lanes());
   ffi::Array<PrimExpr> shape = {offset_expr + 1};
   Buffer dummy_buf(handle, dtype, shape, {}, 0, handle->name_hint, 0, 0, kDefault, {}, Span(),
                    std::nullopt);
@@ -126,8 +125,8 @@ inline PrimExpr AddressOffset(Var handle, DataType dtype, int offset) {
  */
 inline PrimExpr AddressOffset(Var handle, DataType dtype, PrimExpr offset) {
   if (dtype.lanes() != 1) {
-    offset = offset * make_const(offset.dtype(), dtype.lanes());
-    offset = Ramp(offset, make_const(offset.dtype(), 1), dtype.lanes());
+    offset = offset * MakeConst(offset.dtype(), dtype.lanes());
+    offset = Ramp(offset, MakeConst(offset.dtype(), 1), dtype.lanes());
   }
 
   ffi::Array<PrimExpr> shape = {offset + 1};
@@ -147,8 +146,8 @@ inline PrimExpr AddressOffset(Var handle, DataType dtype, PrimExpr offset) {
  * \return the set stmt.
  */
 inline Stmt TVMStructSet(Var handle, int index, builtin::TVMStructFieldKind kind, PrimExpr value) {
-  ffi::Array<PrimExpr> args = {handle, make_const(DataType::Int(32), index),
-                               make_const(DataType::Int(32), static_cast<int>(kind)), value};
+  ffi::Array<PrimExpr> args = {handle, IntImm::Int32(index), IntImm::Int32(static_cast<int>(kind)),
+                               value};
   return Evaluate(Call(DataType::Int(32), builtin::tvm_struct_set(), args));
 }
 
@@ -190,7 +189,7 @@ inline int GetTempAllocaAlignment(DataType type, int32_t const_size) {
  */
 inline PrimExpr ConstInt32(size_t index) {
   TVM_FFI_ICHECK_LE(index, std::numeric_limits<int>::max());
-  return make_const(DataType::Int(32), static_cast<int>(index));
+  return IntImm::Int32(static_cast<int>(index));
 }
 
 /*!

--- a/src/tirx/transform/lower_intrin.cc
+++ b/src/tirx/transform/lower_intrin.cc
@@ -122,7 +122,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
 
     if (support_bitwise_op_ && is_const_power_of_two_integer(op->b, &shift)) {
       // lower to right shift if possible.
-      return op->a >> make_const(dtype, shift);
+      return op->a >> MakeConst(dtype, shift);
     }
 
     if (analyzer_->CanProveGreaterEqual(op->b, 0)) {
@@ -135,8 +135,8 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
         if (auto opt_c_value = TryFindShiftCoefficientForPositiveRange(op->a, b_value)) {
           int64_t c_value = *opt_c_value;
           // now we can safely lower to truncdiv
-          return truncdiv(op->a + make_const(dtype, b_value * c_value), op->b) -
-                 make_const(dtype, c_value);
+          return truncdiv(op->a + MakeConst(dtype, b_value * c_value), op->b) -
+                 MakeConst(dtype, c_value);
         }
       }
       DLOG(INFO) << "LowerFloorDiv: Cannot decide the sign of divident";
@@ -147,9 +147,9 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
       // So we need to correct these cases.
       if ((dtype == DataType::Int(32) || dtype == DataType::Int(64)) && support_bitwise_op_) {
         // equivalent to rdiv + (rmod >= 0 ? 0: -1);
-        return rdiv + (rmod >> make_const(dtype, dtype.bits() - 1));
+        return rdiv + (rmod >> MakeConst(dtype, dtype.bits() - 1));
       } else {
-        return tirx::Select(rmod >= 0, rdiv, rdiv - make_const(dtype, 1));
+        return tirx::Select(rmod >= 0, rdiv, rdiv - MakeConst(dtype, 1));
       }
 
     } else {
@@ -166,7 +166,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
         PrimExpr let_rdiv =
             tirx::Let(rdiv, truncdiv(op->a, op->b),
                       tirx::Select((op->b >= 0 && rmod >= 0) || (op->b < 0 && rmod <= 0), rdiv,
-                                   rdiv - make_const(dtype, 1)));
+                                   rdiv - MakeConst(dtype, 1)));
         return Let(rmod, truncmod(op->a, op->b), let_rdiv);
       }
     }
@@ -184,7 +184,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
     if (support_bitwise_op_ && is_const_power_of_two_integer(op->b, &shift)) {
       // lower to masking if possible.
       int64_t mask = (static_cast<int64_t>(1) << static_cast<int64_t>(shift)) - 1;
-      return op->a & make_const(dtype, mask);
+      return op->a & MakeConst(dtype, mask);
     }
 
     if (analyzer_->CanProveGreaterEqual(op->b, 0)) {
@@ -197,7 +197,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
         if (auto opt_c_value = TryFindShiftCoefficientForPositiveRange(op->a, b_value)) {
           int64_t c_value = *opt_c_value;
           // floormod(a, b) == floormod(a + b*c, b)  == truncmod(a + b*c, b)
-          return truncmod(op->a + make_const(dtype, c_value * b_value), op->b);
+          return truncmod(op->a + MakeConst(dtype, c_value * b_value), op->b);
         }
       }
       DLOG(INFO) << "LowerFloorMod: Cannot decide the sign of divident";
@@ -209,7 +209,7 @@ class IntrinInjecter : public tvm::arith::IRMutatorWithAnalyzer {
         // (rmod >> shift) & b
         // -> (rmod >= 0 ? 0: -1) & b
         // -> rmod >= 0 ? 0 : b
-        return rmod + (op->b & (rmod >> make_const(dtype, dtype.bits() - 1)));
+        return rmod + (op->b & (rmod >> MakeConst(dtype, dtype.bits() - 1)));
       } else {
         return tirx::Select(rmod >= 0, rmod, rmod + op->b);
       }

--- a/src/tirx/transform/lower_tirx_cleanup.cc
+++ b/src/tirx/transform/lower_tirx_cleanup.cc
@@ -140,7 +140,7 @@ class LayoutApplier : public arith::IRMutatorWithAnalyzer {
           tile_layout && tile_layout->HasThreadAxis()) {
         // Logical alloc_buffer with thread axes: physical shape = memory-axis span
         arith::Analyzer ana;
-        PrimExpr mem_span = make_const(DataType::Int(32), 1);
+        PrimExpr mem_span = IntImm::Int32(1);
         for (const auto& iter : tile_layout->shard) {
           if (iter->axis->IsMemoryAxis()) {
             mem_span = mem_span + (iter->extent - 1) * iter->stride;

--- a/src/tirx/transform/lower_tirx_opaque.cc
+++ b/src/tirx/transform/lower_tirx_opaque.cc
@@ -91,7 +91,7 @@ class TIRxOpaqueLower : public StmtExprMutator {
     auto it = pool_sizes_.find(op->buffer->data);
     if (it != pool_sizes_.end()) {
       auto* n = alloc_buf.CopyOnWrite();
-      n->shape = {IntImm(DataType::Int(64), it->second)};
+      n->shape = {IntImm::Int64(it->second)};
     }
     if (alloc_buf.same_as(op->buffer)) {
       return stmt;

--- a/src/tirx/transform/lower_tvm_builtin.cc
+++ b/src/tirx/transform/lower_tvm_builtin.cc
@@ -46,7 +46,7 @@ class BuiltinLower : public StmtExprMutator {
   static PrimFunc Build(PrimFunc func) {
     ffi::Optional<PrimExpr> device_type = std::nullopt;
     if (auto target = func->GetAttr<Target>(tvm::attr::kTarget)) {
-      device_type = IntImm(DataType::Int(32), target.value()->kind->default_device_type);
+      device_type = IntImm::Int32(target.value()->kind->default_device_type);
     }
 
     BuiltinLower mutator(device_type);
@@ -130,8 +130,7 @@ class BuiltinLower : public StmtExprMutator {
     {
       // NOTE: this scope reference is invalid after any mutation is applied to alloca_scope_.
       auto& scope = precheck.alloca_scope_.back();
-      scope.stack_shape =
-          decl_buffer({IntImm(DataType::Int(64), 0)}, DataType::Int(64), "stack_shape");
+      scope.stack_shape = decl_buffer({IntImm::Int64(0)}, DataType::Int(64), "stack_shape");
     }
 
     precheck.VisitStmt(stmt);
@@ -171,7 +170,7 @@ class BuiltinLower : public StmtExprMutator {
       }
 
       if (scope.max_sizes.shape_stack != -1) {
-        scope.stack_shape = decl_buffer({IntImm(DataType::Int(64), scope.max_sizes.shape_stack)},
+        scope.stack_shape = decl_buffer({IntImm::Int64(scope.max_sizes.shape_stack)},
                                         DataType::Int(64), "stack_shape");
         alloca_stmts.push_back(
             Bind(scope.stack_shape->data, StackAlloca("shape", scope.max_sizes.shape_stack)));
@@ -261,7 +260,7 @@ class BuiltinLower : public StmtExprMutator {
         }
       }
     }
-    PrimExpr total_bytes = make_const(DataType::UInt(64), nbytes);
+    PrimExpr total_bytes = IntImm(DataType::UInt(64), nbytes);
     for (size_t i = 0; i < op->buffer->shape.size(); ++i) {
       total_bytes = total_bytes * op->buffer->shape[i];
     }
@@ -277,17 +276,17 @@ class BuiltinLower : public StmtExprMutator {
     PrimExpr free_op = Call(DataType::Int(32), free_workspace_op,
                             {cast(DataType::Int(32), device_type_.value()),
                              cast(DataType::Int(32), device_id_.value()), op->buffer->data});
-    Stmt free_stmt = IfThenElse(free_op != make_zero(DataType::Int(32)), throw_last_error);
+    Stmt free_stmt = IfThenElse(free_op != IntImm::Int32(0), throw_last_error);
 
     // Push free to enclosing scope's pending_frees (LIFO ordering preserved).
     scope_.Current().pending_frees.push_back(free_stmt);
 
-    Stmt alloc_bind =
-        Bind(op->buffer->data, Call(op->buffer->data.dtype(), alloc_workspace_op,
-                                    {cast(DataType::Int(32), device_type_.value()),
-                                     cast(DataType::Int(32), device_id_.value()), total_bytes,
-                                     IntImm(DataType::Int(32), op->buffer->dtype.code()),
-                                     IntImm(DataType::Int(32), op->buffer->dtype.bits())}));
+    Stmt alloc_bind = Bind(
+        op->buffer->data,
+        Call(op->buffer->data.dtype(), alloc_workspace_op,
+             {cast(DataType::Int(32), device_type_.value()),
+              cast(DataType::Int(32), device_id_.value()), total_bytes,
+              IntImm::Int32(op->buffer->dtype.code()), IntImm::Int32(op->buffer->dtype.bits())}));
 
     return SeqStmt({alloc_bind, alloc_nullptr_check});
   }
@@ -390,7 +389,7 @@ class BuiltinLower : public StmtExprMutator {
     } else if (op->op.same_as(builtin::tvm_stack_make_array())) {
       return MakeArray(op);
     } else if (op->op.same_as(builtin::tvm_context_id())) {
-      return make_zero(op->dtype);
+      return IntImm(op->dtype, 0);
     } else if (op->op.same_as(builtin::dma_copy())) {
       return MakeDMACopy(op);
     } else if (op->op.same_as(builtin::dma_wait())) {
@@ -494,25 +493,24 @@ class BuiltinLower : public StmtExprMutator {
         TVMStructSet(scope.stack_array, idx, builtin::kDLTensorShape, op->args[1]));
     PrimExpr strides = op->args[2];
     if (!strides.defined() || is_zero(strides)) {
-      strides = make_zero(DataType::Handle());
+      strides = ConstHandle(0);
     }
     prep_seq.emplace_back(TVMStructSet(scope.stack_array, idx, builtin::kDLTensorStrides, strides));
     prep_seq.emplace_back(
         TVMStructSet(scope.stack_array, idx, builtin::kDLTensorNDim, op->args[3]));
     DataType dtype = op->args[4].dtype();
-    prep_seq.emplace_back(
-        TVMStructSet(scope.stack_array, idx, builtin::kDLTensorTypeCode,
-                     make_const(DataType::UInt(8), static_cast<int>(dtype.code()))));
+    prep_seq.emplace_back(TVMStructSet(scope.stack_array, idx, builtin::kDLTensorTypeCode,
+                                       IntImm(DataType::UInt(8), static_cast<int>(dtype.code()))));
     prep_seq.emplace_back(TVMStructSet(scope.stack_array, idx, builtin::kDLTensorTypeBits,
-                                       make_const(DataType::UInt(8), dtype.bits())));
+                                       IntImm(DataType::UInt(8), dtype.bits())));
     prep_seq.emplace_back(TVMStructSet(scope.stack_array, idx, builtin::kDLTensorTypeLanes,
-                                       make_const(DataType::UInt(16), dtype.lanes())));
+                                       IntImm(DataType::UInt(16), dtype.lanes())));
     // set byte offset
     int data_bytes = GetVectorBytes(dtype);
     PrimExpr elem_offset = op->args[5];
     PrimExpr byte_offset;
     if (!is_zero(elem_offset)) {
-      byte_offset = elem_offset * make_const(elem_offset.dtype(), data_bytes);
+      byte_offset = elem_offset * MakeConst(elem_offset.dtype(), data_bytes);
     } else {
       byte_offset = elem_offset;
     }
@@ -635,7 +633,7 @@ class BuiltinLower : public StmtExprMutator {
     prep_seq.emplace_back(
         TVMStructSet(scope.stack_ffi_any, num_args, builtin::kTVMFFIAnyZeroPadding, ConstInt32(0)));
     prep_seq.emplace_back(TVMStructSet(scope.stack_ffi_any, num_args, builtin::kTVMFFIAnyUnionValue,
-                                       make_zero(DataType::Int(64))));
+                                       IntImm::Int64(0)));
     // Verify stack size matches earlier value.
     if (is_precheck_) {
       scope.UpdateMax();
@@ -665,11 +663,8 @@ class BuiltinLower : public StmtExprMutator {
         let->var->type_annotation.as<PointerTypeNode>()->element_type.as<PrimTypeNode>()->dtype;
 
     ffi::Array<PrimExpr> args = {
-        GetDeviceMethodName("alloc_nd"),
-        device_type_.value(),
-        device_id_.value(),
-        IntImm(DataType::Int(32), dtype.code()),
-        IntImm(DataType::Int(32), dtype.bits()),
+        GetDeviceMethodName("alloc_nd"), device_type_.value(),        device_id_.value(),
+        IntImm::Int32(dtype.code()),     IntImm::Int32(dtype.bits()),
     };
 
     for (size_t i = 0; i < call->args.size(); ++i) {
@@ -686,7 +681,7 @@ class BuiltinLower : public StmtExprMutator {
     Call free_op = Call(DataType::Int(32), builtin::tvm_call_packed(),
                         {GetDeviceMethodName("free_nd"), device_type_.value(), device_id_.value(),
                          storage_scope, let->var});
-    Stmt free_stmt = IfThenElse(free_op != make_zero(DataType::Int(32)), throw_last_error);
+    Stmt free_stmt = IfThenElse(free_op != IntImm::Int32(0), throw_last_error);
     // Visit the free_stmt so tvm_call_packed builtins inside it get lowered.
     free_stmt = StmtExprMutator::VisitStmt(free_stmt);
     scope_.Current().pending_frees.push_back(free_stmt);

--- a/src/tirx/transform/lower_warp_memory.cc
+++ b/src/tirx/transform/lower_warp_memory.cc
@@ -276,9 +276,8 @@ class WarpAccessRewriter : protected StmtExprMutator {
     warp_group_ = (alloc_size + (factor - 1)) / factor;
     alloc_size = warp_group_ * factor;
 
-    Buffer new_buf(op->buffer->data, op->buffer->dtype,
-                   {make_const(DataType::Int(32), alloc_size / width_)}, {}, PrimExpr(),
-                   op->buffer->data->name_hint, 0, 0, BufferType::kDefault);
+    Buffer new_buf(op->buffer->data, op->buffer->dtype, {IntImm::Int32(alloc_size / width_)}, {},
+                   PrimExpr(), op->buffer->data->name_hint, 0, 0, BufferType::kDefault);
     Stmt rewritten_body = this->VisitStmt(body);
     return SeqStmt::Flatten(AllocBuffer(new_buf, op->annotations), rewritten_body);
   }
@@ -406,10 +405,10 @@ class WarpAccessRewriter : protected StmtExprMutator {
       TVM_FFI_ICHECK(arith::ramp(base, 1, index.dtype().lanes()).Match(index));
 
       auto [local_index, group] = SplitIndexByGroup(base.Eval());
-      local_index = Ramp(local_index, make_const(local_index.dtype(), 1), index.dtype().lanes());
+      local_index = Ramp(local_index, MakeConst(local_index.dtype(), 1), index.dtype().lanes());
       return std::make_pair(local_index, group);
     }
-    PrimExpr m = make_const(index.dtype(), warp_coeff_);
+    PrimExpr m = MakeConst(index.dtype(), warp_coeff_);
 
     // simple case, warp index is on the highest.
     if (warp_group_ == 1) {
@@ -418,9 +417,9 @@ class WarpAccessRewriter : protected StmtExprMutator {
       return std::make_pair(x, z);
     } else {
       PrimExpr x = analyzer_->canonical_simplify(indexmod(index, m));
-      PrimExpr y = index / make_const(index.dtype(), warp_coeff_ * width_);
+      PrimExpr y = index / MakeConst(index.dtype(), warp_coeff_ * width_);
       y = y * m + x;
-      PrimExpr z = indexdiv(indexmod(index, make_const(index.dtype(), warp_coeff_ * width_)), m);
+      PrimExpr z = indexdiv(indexmod(index, MakeConst(index.dtype(), warp_coeff_ * width_)), m);
       return std::make_pair(analyzer_->canonical_simplify(y), analyzer_->canonical_simplify(z));
     }
   }

--- a/src/tirx/transform/make_packed_api.cc
+++ b/src/tirx/transform/make_packed_api.cc
@@ -102,20 +102,18 @@ class ReturnRewriter : public StmtMutator {
 
   Stmt WriteToOut(PrimExpr val) {
     auto info = ConvertForFFI(val);
-    Stmt store_tindex =
-        tirx::Evaluate(tirx::Call(DataType::Int(32), tirx::builtin::tvm_struct_set(),
-                                  {ret_var_, IntImm(DataType::Int(32), 0),
-                                   IntImm(DataType::Int(32), tirx::builtin::kTVMFFIAnyTypeIndex),
-                                   IntImm(DataType::Int(32), info.type_index)}));
-    Stmt store_zero_padding =
-        tirx::Evaluate(tirx::Call(DataType::Int(32), tirx::builtin::tvm_struct_set(),
-                                  {ret_var_, IntImm(DataType::Int(32), 0),
-                                   IntImm(DataType::Int(32), tirx::builtin::kTVMFFIAnyZeroPadding),
-                                   IntImm(DataType::Int(32), 0)}));
-    Stmt store_val = tirx::Evaluate(
+    Stmt store_tindex = tirx::Evaluate(
         tirx::Call(DataType::Int(32), tirx::builtin::tvm_struct_set(),
-                   {ret_var_, IntImm(DataType::Int(32), 0),
-                    IntImm(DataType::Int(32), tirx::builtin::kTVMFFIAnyUnionValue), info.expr}));
+                   {ret_var_, IntImm::Int32(0), IntImm::Int32(tirx::builtin::kTVMFFIAnyTypeIndex),
+                    IntImm::Int32(info.type_index)}));
+    Stmt store_zero_padding = tirx::Evaluate(
+        tirx::Call(DataType::Int(32), tirx::builtin::tvm_struct_set(),
+                   {ret_var_, IntImm::Int32(0), IntImm::Int32(tirx::builtin::kTVMFFIAnyZeroPadding),
+                    IntImm::Int32(0)}));
+    Stmt store_val =
+        tirx::Evaluate(tirx::Call(DataType::Int(32), tirx::builtin::tvm_struct_set(),
+                                  {ret_var_, IntImm::Int32(0),
+                                   IntImm::Int32(tirx::builtin::kTVMFFIAnyUnionValue), info.expr}));
     Stmt ret_zero = Evaluate(tvm::ret(0));
     return SeqStmt({store_tindex, store_zero_padding, store_val, ret_zero});
   }
@@ -154,7 +152,7 @@ class SubroutineCallRewriter : public StmtExprMutator {
         }
 
         // push an empty handle to be compatible with current cpacked convention
-        cpacked_args.push_back(tirx::make_zero(DataType::Handle()));
+        cpacked_args.push_back(tirx::ConstHandle(0));
         made_change_ = true;
         return tirx::Call(node->dtype, tirx::builtin::tvm_call_cpacked(), cpacked_args);
       }
@@ -250,8 +248,7 @@ PrimFunc MakePackedAPI(PrimFunc func) {
                                       ffi::symbol::tvm_ffi_symbol_prefix + global_symbol.value()}});
 
   Stmt body = ReturnRewriter(v_result)(func_ptr->body);
-  body = AttrStmt(make_zero(DataType::Int(32)), attr::compute_scope,
-                  StringImm(name_hint + "_compute_"), body);
+  body = AttrStmt(IntImm::Int32(0), attr::compute_scope, StringImm(name_hint + "_compute_"), body);
   // Set device context
   if (need_set_device) {
     ffi::Any node = ffi::String("default");
@@ -267,7 +264,7 @@ PrimFunc MakePackedAPI(PrimFunc func) {
   }
 
   // Return error code of zero on success
-  body = SeqStmt({body, Evaluate(ret(IntImm(DataType::Int(32), 0)))});
+  body = SeqStmt({body, Evaluate(ret(IntImm::Int32(0)))});
 
   body = MergeNest({std::move(result.init_nest), seq_check, std::move(result.asserts),
                     std::move(result.decl_buffers)},

--- a/src/tirx/transform/split_host_device.cc
+++ b/src/tirx/transform/split_host_device.cc
@@ -349,7 +349,7 @@ class DeviceInfoCollector : public StmtVisitor {
           << "Only one dynamic shared memory allocation is allowed.";
       TVM_FFI_ICHECK_GT(op->buffer->shape.size(), 0);
 
-      PrimExpr dyn_size = IntImm(DataType::Int(32), 1);
+      PrimExpr dyn_size = IntImm::Int32(1);
       for (const auto& extent : op->buffer->shape) {
         dyn_size *= extent;
       }

--- a/src/tirx/transform/storage_rewrite.cc
+++ b/src/tirx/transform/storage_rewrite.cc
@@ -494,7 +494,7 @@ class StoragePlanRewriter : public StmtExprMutator {
       uint64_t elem_bits = dtype.bits() * dtype.lanes();
       TVM_FFI_ICHECK_EQ(se->bits_offset % elem_bits, 0U);
       if (se->bits_offset != 0) {
-        offset = make_const(offset.dtype(), se->bits_offset / elem_bits) + offset;
+        offset = MakeConst(offset.dtype(), se->bits_offset / elem_bits) + offset;
       }
       return Call(op->dtype, op->op, {op->args[0], se->alloc_var, offset, extent, op->args[4]},
                   op->attrs, op->span);
@@ -633,7 +633,7 @@ class StoragePlanRewriter : public StmtExprMutator {
     if (e->bits_offset == 0) return index;
     uint64_t elem_bits = dtype.bits();
     TVM_FFI_ICHECK_EQ(e->bits_offset % elem_bits, 0U);
-    return make_const(index.dtype(), e->bits_offset / elem_bits) + index;
+    return MakeConst(index.dtype(), e->bits_offset / elem_bits) + index;
   }
   // Prepare the new allocations
   void PrepareNewAlloc() {
@@ -732,7 +732,7 @@ class StoragePlanRewriter : public StmtExprMutator {
                              << " bits, which is greater than the maximum of"
                                 " int32. The size is cast to int64."
                              << "\n";
-                sz = make_const(DataType::Int(64), imm->value);
+                sz = IntImm::Int64(imm->value);
               }
             }
             // transform to bits
@@ -749,7 +749,7 @@ class StoragePlanRewriter : public StmtExprMutator {
           combo_size = indexdiv(combo_size, type_bits);
           // round up for can not divided
           if (!divided) {
-            combo_size = combo_size + make_const(DataType::Int(32), 1);
+            combo_size = combo_size + IntImm::Int32(1);
           }
           combo_size = analyzer_->Simplify(combo_size);
           Buffer buf(e->alloc_var, alloc_type, {combo_size}, {}, PrimExpr(),
@@ -788,8 +788,8 @@ class StoragePlanRewriter : public StmtExprMutator {
       }
     }
     uint64_t type_bits = e->elem_type.bits() * e->elem_type.lanes();
-    PrimExpr alloc_size = make_const(e->allocs[0]->buffer->shape[0].dtype(),
-                                     (total_bits + type_bits - 1) / type_bits);
+    PrimExpr alloc_size =
+        MakeConst(e->allocs[0]->buffer->shape[0].dtype(), (total_bits + type_bits - 1) / type_bits);
     Buffer buf(e->alloc_var, e->elem_type, {alloc_size}, {}, PrimExpr(), e->alloc_var->name_hint, 0,
                0, BufferType::kDefault);
     bool any_volatile = e->is_volatile;
@@ -1531,7 +1531,7 @@ class VectorTypeRewriter : public StmtExprMutator {
 
     if (ramp_index && is_one(ramp_index->stride) && ramp_index->lanes->IsInstance<IntImmNode>()) {
       int lanes = static_cast<int>(Downcast<IntImm>(ramp_index->lanes)->value);
-      PrimExpr new_index = ramp_index->base / make_const(ramp_index->base.dtype(), lanes);
+      PrimExpr new_index = ramp_index->base / MakeConst(ramp_index->base.dtype(), lanes);
       if (lanes != info.factor()) {
         TVM_FFI_ICHECK(info.factor() && lanes % info.factor() == 0);
         int new_lanes = lanes / info.factor();
@@ -1541,7 +1541,7 @@ class VectorTypeRewriter : public StmtExprMutator {
     } else if (last_dim_index.dtype().lanes() == 1 && info.factor() > 1) {
       arith::ModularSet me = analyzer_->modular_set(last_dim_index);
       TVM_FFI_ICHECK(me->coeff == 0 || info.factor() % me->coeff == 0);
-      PrimExpr new_index = last_dim_index / make_const(last_dim_index.dtype(), info.factor());
+      PrimExpr new_index = last_dim_index / MakeConst(last_dim_index.dtype(), info.factor());
       shuffle_index = me->base % info.factor();
       indices.Set(indices.size() - 1, new_index);
     }
@@ -1612,7 +1612,7 @@ class VectorTypeRewriter : public StmtExprMutator {
 
       ffi::Array<PrimExpr> shape = buf->shape;
       PrimExpr last_dim = shape[shape.size() - 1];
-      shape.Set(shape.size() - 1, last_dim / make_const(last_dim.dtype(), info.factor()));
+      shape.Set(shape.size() - 1, last_dim / MakeConst(last_dim.dtype(), info.factor()));
 
       auto writer = buf.CopyOnWrite();
       writer->data = info.new_buffer_var;
@@ -1647,8 +1647,8 @@ class VectorTypeRewriter : public StmtExprMutator {
 
       PrimExpr e_dtype = tirx::TypeAnnotation(info.new_element_dtype);
       int factor = info.factor();
-      extent = extent / make_const(extent.dtype(), factor);
-      index = index / make_const(index.dtype(), factor);
+      extent = extent / MakeConst(extent.dtype(), factor);
+      index = index / MakeConst(index.dtype(), factor);
       ffi::Array<PrimExpr> acc_args{e_dtype, info.new_buffer_var, index, extent, flag};
       // tvm_access_ptr produces a pointer; its Call.dtype must be handle
       // (the lowering rule in src/target/intrin_rule.cc ICHECKs this).

--- a/src/tirx/transform/tile_primitive_dispatch.cc
+++ b/src/tirx/transform/tile_primitive_dispatch.cc
@@ -179,7 +179,7 @@ class ScopeIdDefRemover : public StmtExprMutator {
     // Drop the def stmt by replacing with a no-op Evaluate(0). It will be
     // flattened away by SeqStmt::Flatten elsewhere or stay as a benign
     // no-op for downstream passes.
-    return Evaluate(IntImm(DataType::Int(32), 0));
+    return Evaluate(IntImm::Int32(0));
   }
 };
 
@@ -595,8 +595,8 @@ class TilePrimitiveDispatcher : public StmtExprMutator {
   // dispatched impls too.
   void PrepareLaunchParams(const AttrStmtNode* entry_node, Stmt body,
                            std::vector<std::pair<Var, PrimExpr>>* scope_binds) {
-    Stmt gather_target = AttrStmt(IntImm(DataType::Int(32), 0), tvm::tirx::attr::kDeviceEntry,
-                                  IntImm(DataType::Bool(), 1), body);
+    Stmt gather_target =
+        AttrStmt(IntImm::Int32(0), tvm::tirx::attr::kDeviceEntry, IntImm::Bool(true), body);
     std::vector<ScopeIdDefWithSource> gathered = ScopeIdDefGather::Gather(gather_target);
     Array<ScopeIdDef> defs;
     defs.reserve(gathered.size());
@@ -627,8 +627,8 @@ class TilePrimitiveDispatcher : public StmtExprMutator {
                             std::vector<std::pair<Var, const StmtNode*>>* implicit_scope_id_evals) {
     // Gather from a temporary stmt synthesized as the device-entry marker
     // so direct ScopeIdDefStmt children are attributed back to entry_node.
-    Stmt gather_target = AttrStmt(IntImm(DataType::Int(32), 0), tvm::tirx::attr::kDeviceEntry,
-                                  IntImm(DataType::Bool(), 1), body);
+    Stmt gather_target =
+        AttrStmt(IntImm::Int32(0), tvm::tirx::attr::kDeviceEntry, IntImm::Bool(true), body);
     std::vector<ScopeIdDefWithSource> gathered = ScopeIdDefGather::Gather(gather_target);
     // Remap the synthetic source pointer back to the real entry_node so the
     // injector matches against the actual node present in the post-processed
@@ -1413,7 +1413,7 @@ class TilePrimitiveDispatcher : public StmtExprMutator {
     if (pred.dtype().is_bool()) {
       return pred;
     }
-    return pred != make_zero(pred.dtype());
+    return pred != IntImm(pred.dtype(), 0);
   }
 
   ffi::Map<Var, Range> var_range_map_;

--- a/src/tirx/transform/tvm_ffi_binder.cc
+++ b/src/tirx/transform/tvm_ffi_binder.cc
@@ -368,8 +368,8 @@ void TVMFFIABIBuilder::BindBuffer(const Buffer& arg, const Buffer& value,
     if (BindScalar(arg->elem_offset, value->elem_offset, offset_path, false)) {
       if (arg->offset_factor > 1) {
         PrimExpr offset = value->elem_offset;
-        PrimExpr factor = make_const(offset.dtype(), arg->offset_factor);
-        PrimExpr zero = make_zero(offset.dtype());
+        PrimExpr factor = IntImm(offset.dtype(), arg->offset_factor);
+        PrimExpr zero = IntImm(offset.dtype(), 0);
         PrimExpr acond = analyzer_->Simplify(truncmod(offset, factor) == zero);
         if (is_zero(acond)) {
           TVM_FFI_THROW(InternalError)
@@ -423,8 +423,8 @@ void TVMFFIABIBuilder::BindBuffer(const Buffer& arg, const Buffer& value,
 /*! \brief Load the i-th packed argument as the given type. */
 PrimExpr TVMFFIABIBuilder::LoadTVMFFIAnyUnionValue(const Var& v_packed_args, int param_index,
                                                    DataType arg_type) {
-  ffi::Array<PrimExpr> call_args{v_packed_args, IntImm(DataType::Int(32), param_index),
-                                 IntImm(DataType::Int(32), builtin::kTVMFFIAnyUnionValue)};
+  ffi::Array<PrimExpr> call_args{v_packed_args, IntImm::Int32(param_index),
+                                 IntImm::Int32(builtin::kTVMFFIAnyUnionValue)};
   DataType api_type = APIType(arg_type);
   PrimExpr res = Call(api_type, builtin::tvm_struct_get(), call_args);
   if (api_type != arg_type) {
@@ -449,7 +449,7 @@ PrimExpr TVMFFIABIBuilder::DecodeParamOpaqueHandle(int param_index, const Var& t
   PrimExpr arg_value =
       LoadTVMFFIAnyUnionValue(v_packed_args_, param_index, params_[param_index].dtype());
   PrimExpr handle_from_tensor = Call(DataType::Handle(), tirx::builtin::handle_add_byte_offset(),
-                                     {arg_value, IntImm(DataType::Int(32), object_cell_offset)});
+                                     {arg_value, IntImm::Int32(object_cell_offset)});
   return Select(type_index == ffi::TypeIndex::kTVMFFITensor, handle_from_tensor, arg_value);
 }
 
@@ -496,10 +496,9 @@ void TVMFFIABIBuilder::DecodeParam(int param_index) {
 
   // Extract type_index from packed_args
   Var type_index(param->name_hint + ".type_index", DataType::Int(32));
-  init_nest_.push_back(
-      Bind(type_index, tirx::Call(DataType::Int(32), builtin::tvm_struct_get(),
-                                  {v_packed_args_, IntImm(DataType::Int(32), param_index),
-                                   IntImm(DataType::Int(32), builtin::kTVMFFIAnyTypeIndex)})));
+  init_nest_.push_back(Bind(type_index, tirx::Call(DataType::Int(32), builtin::tvm_struct_get(),
+                                                   {v_packed_args_, IntImm::Int32(param_index),
+                                                    IntImm::Int32(builtin::kTVMFFIAnyTypeIndex)})));
 
   // Type-check and load value via per-dtype dispatch
   PrimExpr arg_value;
@@ -577,7 +576,7 @@ void TVMFFIABIBuilder::BindCompactStrides(const Buffer& buffer, const Var& strid
                                           const PrimExpr& v_strides_is_null,
                                           const ffi::reflection::AccessPath& param_path) {
   DataType stype = buffer->DefaultIndexType();
-  PrimExpr expect_stride = make_const(stype, 1);
+  PrimExpr expect_stride = MakeConst(stype, 1);
   ffi::Array<PrimExpr> conds;
   for (size_t i = buffer->shape.size(); i != 0; --i) {
     size_t k = i - 1;
@@ -589,7 +588,7 @@ void TVMFFIABIBuilder::BindCompactStrides(const Buffer& buffer, const Var& strid
     int param_index = GetParamIndex(param_path);
     Stmt check = AssertStmt(
         foldl([](PrimExpr a, PrimExpr b, Span span) { return logical_and(a, b, span); },
-              const_true(1), conds),
+              IntImm::Bool(true), conds),
         StringImm("ValueError"),
         ffi::Array<StringImm>({StringImm("Mismatched "), StringImm(buffer->name),
                                StringImm(".strides on argument #"),
@@ -604,7 +603,7 @@ void TVMFFIABIBuilder::BindAutoBroadcastStrides(const Buffer& buffer, const Var&
                                                 const PrimExpr& v_strides_is_null,
                                                 const ffi::reflection::AccessPath& param_path) {
   DataType stype = buffer->DefaultIndexType();
-  PrimExpr stride = make_const(stype, 1);
+  PrimExpr stride = MakeConst(stype, 1);
   for (size_t i = buffer->shape.size(); i != 0; --i) {
     size_t k = i - 1;
     PrimExpr value = cast(buffer->shape[k].dtype(), LoadInt64ArrayElem(strides_ptr, k));
@@ -652,7 +651,7 @@ void TVMFFIABIBuilder::DecodeParamDLTensor(const Buffer& buffer, const PrimExpr&
 
   // ── Section: ndim ────────────────────────────────────────────
   PrimExpr v_ndim = TVMStructGet(tvm_ndim_type, handle, 0, builtin::kDLTensorNDim);
-  PrimExpr a_ndim = make_const(tvm_ndim_type, static_cast<int64_t>(buffer->shape.size()));
+  PrimExpr a_ndim = MakeConst(tvm_ndim_type, static_cast<int64_t>(buffer->shape.size()));
   EmitAssert(a_ndim == v_ndim, "ValueError",  //
              "Mismatched ", buf_name, ".ndim on argument #", std::to_string(param_index),
              when_calling_imm_, sig_imm_, "`,\n  expected ", std::to_string(buffer->shape.size()));
@@ -702,19 +701,19 @@ void TVMFFIABIBuilder::DecodeParamDLTensor(const Buffer& buffer, const PrimExpr&
   int data_bytes = GetVectorBytes(buffer->dtype);
   ffi::reflection::AccessPath byte_offset_path = param_path->Attr(ffi::String("byte_offset"));
   if (const auto* const_offset = buffer->elem_offset.as<IntImmNode>()) {
-    BindScalar(make_const(DataType::UInt(64), const_offset->value * data_bytes),
+    BindScalar(IntImm(DataType::UInt(64), const_offset->value * data_bytes),
                TVMStructGet(DataType::UInt(64), handle, 0, builtin::kDLTensorByteOffset),
                byte_offset_path, true);
   } else {
     if (BindScalar(buffer->elem_offset,
                    cast(buffer->elem_offset.dtype(),
                         (TVMStructGet(DataType::UInt(64), handle, 0, builtin::kDLTensorByteOffset) /
-                         make_const(DataType::UInt(64), data_bytes))),
+                         MakeConst(DataType::UInt(64), data_bytes))),
                    byte_offset_path, true)) {
       if (buffer->offset_factor > 1) {
         PrimExpr offset = buffer->elem_offset;
-        PrimExpr factor = make_const(offset.dtype(), buffer->offset_factor);
-        PrimExpr zero = make_zero(offset.dtype());
+        PrimExpr factor = IntImm(offset.dtype(), buffer->offset_factor);
+        PrimExpr zero = IntImm(offset.dtype(), 0);
         PrimExpr acond = analyzer_->Simplify(truncmod(offset, factor) == zero);
         if (is_zero(acond)) {
           TVM_FFI_THROW(InternalError)
@@ -736,8 +735,7 @@ void TVMFFIABIBuilder::DecodeParamDLTensor(const Buffer& buffer, const PrimExpr&
         TVMStructGet(DataType::Int(32), handle, 0, builtin::kDLTensorDeviceType);
     // Use custom assertion for device_type to show human-readable device name
     if (const auto* const_dt = device_type_.as<IntImmNode>()) {
-      PrimExpr cond =
-          analyzer_->Simplify(make_const(DataType::Int(32), const_dt->value) == actual_device_type);
+      PrimExpr cond = analyzer_->Simplify(IntImm::Int32(const_dt->value) == actual_device_type);
       if (!is_one(cond)) {
         std::string device_name = runtime::DLDeviceType2Str(static_cast<int>(const_dt->value));
         EmitAssert(cond, "ValueError",  //
@@ -785,8 +783,8 @@ void TVMFFIABIBuilder::DecodeParamDLTensor(const Buffer& buffer, const PrimExpr&
           PrimExpr ptr_as_int =
               Call(DataType::UInt(64), builtin::reinterpret(), {cast(DataType::Handle(), vptr)});
           PrimExpr align_cond =
-              truncmod(ptr_as_int, make_const(DataType::UInt(64), buffer->data_alignment)) ==
-              make_const(DataType::UInt(64), 0);
+              truncmod(ptr_as_int, IntImm(DataType::UInt(64), buffer->data_alignment)) ==
+              IntImm(DataType::UInt(64), 0);
           asserts_.emplace_back(AssertStmt(
               alloc_size == 0 || align_cond, StringImm("ValueError"),
               ffi::Array<StringImm>({StringImm("Misaligned Tensor data on argument #"),
@@ -798,13 +796,11 @@ void TVMFFIABIBuilder::DecodeParamDLTensor(const Buffer& buffer, const PrimExpr&
         // mark alignment of external bufs — must be after the alignment assertion
         // so the compiler does not emit aligned loads before the check fires.
         asserts_.emplace_back(AttrStmt(vptr, tirx::attr::storage_alignment,
-                                       IntImm(DataType::Int(32), buffer->data_alignment),
-                                       Evaluate(0)));
+                                       IntImm::Int32(buffer->data_alignment), Evaluate(0)));
       } else {
         // Even without alignment check, mark alignment for the compiler.
         init_nest_.emplace_back(AttrStmt(vptr, tirx::attr::storage_alignment,
-                                         IntImm(DataType::Int(32), buffer->data_alignment),
-                                         Evaluate(0)));
+                                         IntImm::Int32(buffer->data_alignment), Evaluate(0)));
       }
     }
   }

--- a/src/tirx/transform/unroll_loop.cc
+++ b/src/tirx/transform/unroll_loop.cc
@@ -225,7 +225,7 @@ class LoopUnroller : public StmtExprMutator {
     ffi::Map<Var, PrimExpr> vmap;
     ffi::Array<Stmt> unrolled;
     for (int i = 0; i < value; ++i) {
-      vmap.Set(op->loop_var, op->min + make_const(op->loop_var.dtype(), i));
+      vmap.Set(op->loop_var, op->min + MakeConst(op->loop_var.dtype(), i));
       Stmt step = Substitute(body, vmap);
       unrolled.push_back(step);
     }

--- a/src/tirx/transform/vectorize_loop.cc
+++ b/src/tirx/transform/vectorize_loop.cc
@@ -449,7 +449,7 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
       int op_lanes = static_cast<int>(Downcast<IntImm>(op->lanes)->value);
       int base_ramp_lanes = static_cast<int>(Downcast<IntImm>(base_ramp->lanes)->value);
       if (analyzer_->CanProve(base_ramp->stride ==
-                              stride * make_const(stride.dtype(), base_ramp_lanes))) {
+                              stride * MakeConst(stride.dtype(), base_ramp_lanes))) {
         return Ramp(base_ramp->base, stride, op_lanes * base_ramp_lanes);
       }
     }
@@ -987,7 +987,7 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
         const RampNode* a_ramp = a.as<RampNode>();
         if (a.dtype().is_scalar() && b_ramp) {
           return Ramp(fcompute(a, b_ramp->base),
-                      fcompute(make_zero(b_ramp->stride.dtype()), b_ramp->stride), b_ramp->lanes);
+                      fcompute(IntImm(b_ramp->stride.dtype(), 0), b_ramp->stride), b_ramp->lanes);
         }
         if (b.dtype().is_scalar() && a_ramp) {
           return Ramp(fcompute(a_ramp->base, b), a_ramp->stride, a_ramp->lanes);
@@ -1047,8 +1047,8 @@ class LoopVectorizer : public StmtMutator {
     // selects the runtime vector length with vsetvli.
     static constexpr int kDefaultVScaleFactor = 4;
     DataType index_dtype = op->loop_var->dtype;
-    PrimExpr zero = make_const(index_dtype, 0);
-    PrimExpr fixed_extent = make_const(index_dtype, extent);
+    PrimExpr zero = IntImm(index_dtype, 0);
+    PrimExpr fixed_extent = IntImm(index_dtype, extent);
     PrimExpr scalable_lanes = CreateNewLanes(/*is_scalable=*/true, kDefaultVScaleFactor);
     DataType lane_dtype = scalable_lanes.dtype();
     PrimExpr scalable_lanes_index = scalable_lanes;
@@ -1066,7 +1066,7 @@ class LoopVectorizer : public StmtMutator {
     PrimExpr index = outer * scalable_lanes_index + inner_index;
     Stmt body = Substitute(op->body, {{op->loop_var, index}});
     Stmt guarded_body = IfThenElse(index < fixed_extent, body, std::nullopt, op->span);
-    Stmt vector_loop = For(inner, make_const(lane_dtype, 0), scalable_lanes, ForKind::kVectorized,
+    Stmt vector_loop = For(inner, IntImm(lane_dtype, 0), scalable_lanes, ForKind::kVectorized,
                            guarded_body, std::nullopt, op->annotations, std::nullopt, op->span);
     Stmt loop = For(outer, zero, num_chunks, ForKind::kSerial, vector_loop, std::nullopt, {},
                     std::nullopt, op->span);

--- a/src/topi/einsum.cc
+++ b/src/topi/einsum.cc
@@ -109,7 +109,7 @@ PrimExpr GetBroadcastedExtent(const PrimExpr& extent1, const PrimExpr& extent2) 
     if (extent1_imm->value == extent2_imm->value) {
       return extent1;
     } else if (extent1_imm->value == 1 || extent2_imm->value == 1) {
-      return IntImm(DataType::Int(32), std::max(extent1_imm->value, extent2_imm->value));
+      return IntImm::Int32(std::max(extent1_imm->value, extent2_imm->value));
     }
     TVM_FFI_THROW(InternalError) << "Cannot broadcast extents " << extent1 << " and " << extent2;
     throw;
@@ -127,7 +127,7 @@ PrimExpr GetIndexForBroadcastedDim(const Var& index, const PrimExpr& extent,
   // Check if current dimension is being broadcasted to `broadcasted_extent` (symbolic shape is
   // handled)
   if (is_one(extent) && !is_one(broadcasted_extent)) {
-    return make_zero(index.dtype());
+    return IntImm(index.dtype(), 0);
   }
   return index;
 }
@@ -219,7 +219,7 @@ class EinsumBuilder {
     PrepareOutputIndicesMapping(indices, &label_to_index, &ellipsis_indices);
     PrepareReductionIndicesMapping(indices, &label_to_index, &ellipsis_indices, &reduce_axes);
 
-    auto zero = make_zero(inputs[0]->dtype);
+    auto zero = MakeConst(inputs[0]->dtype, 0);
 
     PrimExpr result = zero;
     for (int i = 0, n = static_cast<int>(inputs.size()); i < n; ++i) {

--- a/tests/cpp/arith_simplify_test.cc
+++ b/tests/cpp/arith_simplify_test.cc
@@ -45,8 +45,8 @@ TEST(Simplify, Mul) {
 
 TEST(Simplify, Mod) {
   tvm::arith::Analyzer ana;
-  auto x = tvm::IntImm(tvm::DataType::Int(32), 10);
-  auto y = tvm::IntImm(tvm::DataType::Int(32), 12);
+  auto x = tvm::IntImm::Int32(10);
+  auto y = tvm::IntImm::Int32(12);
   // Mod::make is used instead of % to avoid constant folding during
   // calling operator%(x,y). Mod::make doesn't try constant folding,
   // and therefore, the constant folding will be attempted in CanonicalSimplify
@@ -77,19 +77,17 @@ TEST(AnalyzerObjectRef, ConstHandleRefCanMutateAnalyzerState) {
 
 TEST(ConstantFold, Broadcast) {
   tvm::ffi::StructuralEqual checker;
-  auto i32x4 = tvm::tirx::Broadcast(tvm::IntImm(tvm::DataType::Int(32), 10), 4);
+  auto i32x4 = tvm::tirx::Broadcast(tvm::IntImm::Int32(10), 4);
   auto i64x4 = tvm::cast(i32x4->dtype.with_bits(64), i32x4);
-  auto i64x4_expected = tvm::tirx::Broadcast(tvm::IntImm(tvm::DataType::Int(64), 10), 4);
+  auto i64x4_expected = tvm::tirx::Broadcast(tvm::IntImm::Int64(10), 4);
   ASSERT_TRUE(checker(i64x4, i64x4_expected));
 }
 
 TEST(ConstantFold, Ramp) {
   tvm::ffi::StructuralEqual checker;
-  auto i32x4 = tvm::tirx::Ramp(tvm::IntImm(tvm::DataType::Int(32), 10),
-                               tvm::IntImm(tvm::DataType::Int(32), 1), 4);
+  auto i32x4 = tvm::tirx::Ramp(tvm::IntImm::Int32(10), tvm::IntImm::Int32(1), 4);
   auto i64x4 = tvm::cast(i32x4->dtype.with_bits(64), i32x4);
-  auto i64x4_expected = tvm::tirx::Ramp(tvm::IntImm(tvm::DataType::Int(64), 10),
-                                        tvm::IntImm(tvm::DataType::Int(64), 1), 4);
+  auto i64x4_expected = tvm::tirx::Ramp(tvm::IntImm::Int64(10), tvm::IntImm::Int64(1), 4);
   ASSERT_TRUE(checker(i64x4, i64x4_expected));
 
   auto f32x4 = tvm::cast(tvm::DataType::Float(32, 4), i32x4);

--- a/tests/cpp/ir_functor_test.cc
+++ b/tests/cpp/ir_functor_test.cc
@@ -58,9 +58,9 @@ TEST(IRF, CountVar) {
 TEST(IRF, PreOrderVisit) {
   using namespace tvm;
   using namespace tvm::tirx;
-  Stmt init = IfThenElse(const_true(), Evaluate(IntImm(DataType::Int(32), 0)),
-                         Evaluate(IntImm(DataType::Int(32), 0)));
-  Stmt body = Evaluate(IntImm(DataType::Int(32), 1));
+  Stmt init =
+      IfThenElse(IntImm::Bool(true), Evaluate(IntImm::Int32(0)), Evaluate(IntImm::Int32(0)));
+  Stmt body = Evaluate(IntImm::Int32(1));
   SBlock block(/*iter_vars=*/{}, /*reads=*/{},
                /*writes=*/{}, /*name_hint=*/"block", /*body=*/body,
                /*init=*/init);
@@ -176,7 +176,7 @@ TEST(IRF, StmtVisitor) {
     // construct block and block_realize
     SBlock block = SBlock({}, {buffer_region}, {buffer_region}, "block", body, body, {},
                           {match_buffer_region});
-    Stmt block_realize = SBlockRealize({}, const_true(), block);
+    Stmt block_realize = SBlockRealize({}, IntImm::Bool(true), block);
 
     v.count = 0;
     v(block_realize);
@@ -309,7 +309,7 @@ TEST(IRF, StmtMutator) {
     // construct block and block_realize
     SBlock block = SBlock({}, {buffer_region}, {buffer_region}, "block", body, body, {},
                           {match_buffer_region});
-    Stmt block_realize = SBlockRealize({}, const_true(), block);
+    Stmt block_realize = SBlockRealize({}, IntImm::Bool(true), block);
     body = v(std::move(block_realize));
     // the body should be changed
     SBlock new_block = body.as<SBlockRealizeNode>()->block;
@@ -351,7 +351,7 @@ TEST(IRF, Substitute) {
     Var y = x.copy_with_suffix("subst");
     Var m("m", DataType::Int(32));
     Buffer buffer = fmakebuffer();
-    Stmt store = BufferStore(buffer, FloatImm(dtype, 0), {IntImm(DataType::Int(32), 0)});
+    Stmt store = BufferStore(buffer, FloatImm(dtype, 0), {IntImm::Int32(0)});
     Stmt decl = SeqStmt({DeclBuffer(buffer), store});
     auto f_subst = [&](const Var& var) -> ffi::Optional<PrimExpr> {
       if (var.same_as(x)) return y;
@@ -370,7 +370,7 @@ TEST(IRF, Substitute) {
   {
     // test identity substitution on expression
     Buffer buffer = fmakebuffer();
-    PrimExpr expr = BufferLoad(buffer, {IntImm(DataType::Int(32), 0)});
+    PrimExpr expr = BufferLoad(buffer, {IntImm::Int32(0)});
     auto f_subst = [&](const Var& var) -> ffi::Optional<PrimExpr> { return var; };
     PrimExpr new_expr = Substitute(expr, f_subst);
     // the expression is not changed

--- a/tests/cpp/nested_msg_test.cc
+++ b/tests/cpp/nested_msg_test.cc
@@ -152,9 +152,9 @@ TEST(NestedMsg, MapAndDecompose) {
   relax::Expr t0 = bb->Normalize(Tuple({x, y}));
   relax::Expr t1 = bb->Normalize(Tuple({t0, x, z, t0}));
 
-  auto c0 = IntImm(DataType::Int(32), 0);
-  auto c1 = IntImm(DataType::Int(32), 1);
-  auto c2 = IntImm(DataType::Int(32), 2);
+  auto c0 = IntImm::Int32(0);
+  auto c1 = IntImm::Int32(1);
+  auto c2 = IntImm::Int32(2);
 
   auto output = MapToNestedMsg<IntImm>(t1, [&](Expr value) {
     if (value.same_as(x)) return c0;
@@ -226,9 +226,9 @@ TEST(NestedMsg, NestedMsgToExpr) {
   auto sf0 = TensorStructInfo(DataType::Float(32), /*ndim=*/0);
   auto sf1 = TupleStructInfo({sf0, sf0});
 
-  auto c0 = IntImm(DataType::Int(32), 0);
-  auto c1 = IntImm(DataType::Int(32), 1);
-  auto c2 = IntImm(DataType::Int(32), 2);
+  auto c0 = IntImm::Int32(0);
+  auto c1 = IntImm::Int32(1);
+  auto c2 = IntImm::Int32(2);
 
   relax::Var x("x", sf0), y("y", sf0), z("z", sf0);
 
@@ -257,9 +257,9 @@ TEST(NestedMsg, NestedMsgToExpr) {
 }
 
 TEST(NestedMsg, CombineNestedMsg) {
-  auto c0 = IntImm(DataType::Int(32), 0);
-  auto c1 = IntImm(DataType::Int(32), 1);
-  auto c2 = IntImm(DataType::Int(32), 2);
+  auto c0 = IntImm::Int32(0);
+  auto c1 = IntImm::Int32(1);
+  auto c2 = IntImm::Int32(2);
 
   NestedMsg<IntImm> lhs = {c0, {c0, c1}, std::nullopt, {c0, {c1, c2}}};
   NestedMsg<IntImm> rhs = {c1, {c2, std::nullopt}, std::nullopt, {c1, {c2, c2}}};
@@ -275,17 +275,17 @@ TEST(NestedMsg, CombineNestedMsg) {
 }
 
 TEST(NestedMsg, MapNestedMsg) {
-  auto c0 = IntImm(DataType::Int(32), 0);
-  auto c1 = IntImm(DataType::Int(32), 1);
-  auto c2 = IntImm(DataType::Int(32), 2);
-  auto c3 = IntImm(DataType::Int(32), 3);
+  auto c0 = IntImm::Int32(0);
+  auto c1 = IntImm::Int32(1);
+  auto c2 = IntImm::Int32(2);
+  auto c3 = IntImm::Int32(3);
 
   NestedMsg<IntImm> msg = {c0, {c0, c1}, std::nullopt, {c0, {c2, c1}}};
   NestedMsg<IntImm> expected = {c3, {c3, std::nullopt}, std::nullopt, {c3, {c2, std::nullopt}}};
 
   auto output = MapNestedMsg(msg, [](IntImm x) {
     if (x->value == 0) {
-      return NestedMsg<IntImm>(IntImm(DataType::Int(32), 3));
+      return NestedMsg<IntImm>(IntImm::Int32(3));
     } else if (x->value == 1) {
       return NestedMsg<IntImm>();
     } else {
@@ -298,9 +298,9 @@ TEST(NestedMsg, MapNestedMsg) {
 }
 
 TEST(NestedMsg, TransformTupleLeaf) {
-  auto c0 = IntImm(DataType::Int(32), 0);
-  auto c1 = IntImm(DataType::Int(32), 1);
-  auto c2 = IntImm(DataType::Int(32), 2);
+  auto c0 = IntImm::Int32(0);
+  auto c1 = IntImm::Int32(1);
+  auto c2 = IntImm::Int32(2);
   using NInt = NestedMsg<IntImm>;
 
   NInt msg1 = {c0, {c0, c1}, c2, {c0, {c1, c2}}};

--- a/tests/cpp/tir_scalable_datatype.cc
+++ b/tests/cpp/tir_scalable_datatype.cc
@@ -185,15 +185,15 @@ TEST(ScalableDataType, TestScalableUInt) {
 // -----------
 // Integration
 // -----------
+#ifdef TVM_LLVM_VERSION
 TEST(ScalableDataType, TestScalableIntrinCall) {
   tvm::DataType scalable_type = tvm::DataType(kDLInt, 32, 4, true);
-  tvm::tirx::Call call =
-      tvm::tirx::Call(scalable_type, tvm::tirx::builtin::call_llvm_intrin(),
+  tvm::tirx::Call call = tvm::tirx::Call(scalable_type, tvm::tirx::builtin::call_llvm_intrin(),
 #if TVM_LLVM_VERSION >= 200
-                      {tvm::IntImm(tvm::DataType::Int(32), ::llvm::Intrinsic::stepvector)});
+                                         {tvm::IntImm::Int32(::llvm::Intrinsic::stepvector)});
 #else
-                      {tvm::IntImm(tvm::DataType::Int(32),
-                                   ::llvm::Intrinsic::experimental_stepvector)});
+                                         {tvm::IntImm::Int32(
+                                             ::llvm::Intrinsic::experimental_stepvector)});
 #endif
   ASSERT_EQ(call->dtype, scalable_type);
   ASSERT_EQ(tvm::Script(call),
@@ -203,6 +203,7 @@ TEST(ScalableDataType, TestScalableIntrinCall) {
             "T.call_llvm_intrin(\"int32xvscalex4\", \"llvm.experimental.stepvector\")");
 #endif
 }
+#endif
 
 TEST(ScalableDataType, TestTIRScriptScalableDtype2Str) {
   tvm::DataType scalable_type = tvm::DataType(kDLInt, 32, 4, true);


### PR DESCRIPTION
## Summary

Common bool, int32, and int64 scalar constants show up throughout TIRX and related lowering code. Named constructors make these call sites easier to read than repeated `DataType` spelling, and avoid routing obvious scalar constants through the generic `MakeConst` helper.

## Usage guideline

Prefer direct `IntImm` or `FloatImm` construction when dtype is known to be scalar integer or floating point. This makes the compiled code more compact and efficient. Keep `MakeConst` for generic overload cases where dtype can be integer, floating point, or vector-valued and the caller needs its scalar/vector dispatch.

This PR establishes the scalar-constant construction policy:

- Prefer `IntImm::Bool`, `IntImm::Int32`, and `IntImm::Int64` for common known scalar bool, int32, and int64 constants.
- Prefer direct `IntImm` or `FloatImm` construction when dtype is known to be scalar integer or floating point.
- Keep `MakeConst` for generic overload cases where dtype can be integer, floating point, or vector-valued and the caller needs its scalar/vector dispatch.
- Phase out `make_zero` in favor of explicit scalar constructors, or `ConstHandle(0)` for null handles.

## Changes

- Add `IntImm::Bool`, `IntImm::Int32`, and `IntImm::Int64` helpers.
- Rename `make_const` to `MakeConst` and document it as the generic/vector construction helper.
- Migrate deterministic scalar constant construction to the clearer APIs while keeping generic and vector-aware paths on `MakeConst`.
- Remove `make_zero`, `const_true`, `const_false`, and the unused `tirx.const_true` registry entry.
