### PR TITLE
[CMAKE] Revert build baseline to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,9 +439,9 @@ include(cmake/utils/CCache.cmake)
 
 include(CheckCXXCompilerFlag)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-set(CMAKE_CUDA_STANDARD 20)
+set(CMAKE_CUDA_STANDARD 17)
 
 # Module rules
 include(cmake/modules/CUDA.cmake)

--- a/cmake/utils/FindLLVM.cmake
+++ b/cmake/utils/FindLLVM.cmake
@@ -254,9 +254,9 @@ macro(find_llvm use_llvm)
     # compiler-appropriate form so the probe works under MSVC as well.
     if(NOT CMAKE_CXX_STANDARD)
       if(MSVC)
-        set(CMAKE_REQUIRED_FLAGS "/std:c++20")
+        set(CMAKE_REQUIRED_FLAGS "/std:c++17")
       else()
-        set(CMAKE_REQUIRED_FLAGS "-std=c++20")
+        set(CMAKE_REQUIRED_FLAGS "-std=c++17")
       endif()
     endif()
     check_cxx_source_compiles("

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -35,15 +35,11 @@ Apache TVM requires the following dependencies:
 - CMake (>= 3.24.0)
 - LLVM (recommended >= 15)
 - Git
-- A recent C++ compiler supporting C++ 20, at the minimum
-    - GCC 10
-    - Clang 10
-    - Apple Clang 14
-    - Visual Studio 2022
-
-  Optional dependencies that use newer C++20 standard library facilities, such
-  as ``std::format``, may require a newer standard library (for example GCC 13
-  or newer on Linux).
+- A recent C++ compiler supporting C++ 17, at the minimum
+    - GCC 7.1
+    - Clang 5.0
+    - Apple Clang 9.3
+    - Visual Studio 2019 (v16.7)
 - Python (>= 3.10)
 - (Optional) Conda (Strongly Recommended)
 


### PR DESCRIPTION
Revert the CMake C++/CUDA standard from C++20 back to C++17, undoing the standard-setting portion of #19734 and restoring the v0.25.0.rc0 build baseline.

The C++20 baseline broke the manylinux Linux wheels: under C++20, libstdc++'s constexpr std::string paths reference symbols newer than the manylinux_2_28 runtime baseline (e.g. _M_replace_cold @ GLIBCXX_3.4.30, GCC 12.1+), so the wheel fails to import with "undefined symbol". The compiler (GCC 14.2.1) is unchanged from rc0 -- only the standard differs -- so C++17 restores the working symbol set.

Only the standard-setting surfaces are reverted (CMakeLists.txt, the LLVM compile probe, docs); the C++17-compatible source modernizations from #19734 are intentionally kept to avoid reintroducing deprecated constructs.