### PR TITLE
[FIX][TIRX] Fix dangling Op static reference warning

### DIFF
--- a/include/tvm/tirx/op.h
+++ b/include/tvm/tirx/op.h
@@ -739,7 +739,7 @@ inline void CheckMathUnaryOpInputDType(const char* op_name, DataType dtype) {
 // Intrinsic operators
 #define TVM_DECLARE_INTRIN_UNARY_WITH_CHECK(OpName, CheckInputDType)         \
   inline PrimExpr OpName(PrimExpr x, Span span = Span()) {                   \
-    static const Op& op = Op::Get("tirx." #OpName);                          \
+    static const Op op = Op::Get("tirx." #OpName);                           \
     CheckInputDType(#OpName, x.dtype());                                     \
     if (x.dtype().is_bfloat16()) {                                           \
       DataType bf16_dtype = x.dtype();                                       \
@@ -786,7 +786,7 @@ TVM_DECLARE_INTRIN_UNARY(clz);
 
 #define TVM_DECLARE_INTRIN_BINARY(OpName)                              \
   inline PrimExpr OpName(PrimExpr x, PrimExpr y, Span span = Span()) { \
-    static const Op& op = Op::Get("tirx." #OpName);                    \
+    static const Op op = Op::Get("tirx." #OpName);                     \
     return tirx::Call(x.dtype(), op, {x, y}, {}, span);                \
   }
 


### PR DESCRIPTION
## Summary

GCC can diagnose the TIRX intrinsic helper macros when a static local reference binds to the value returned by `Op::Get`.

- Store the unary and binary intrinsic macro lookup result as `static const Op`.
- Preserve the existing generated helper behavior while avoiding the dangling-reference pattern.