### PR TITLE
[Fix] Revert C++20-only lambda captures for C++17 build

### DIFF
--- a/src/relax/transform/run_codegen.cc
+++ b/src/relax/transform/run_codegen.cc
@@ -155,7 +155,7 @@ class CodeGenRunner : ExprMutator {
     if (opt_codegen) {
       auto ext_symbol = GetExtSymbol(func);
       size_t count = 0;
-      PostOrderVisit(func->body, [=, this, &count](Expr e) {
+      PostOrderVisit(func->body, [=, &count](Expr e) {
         if (e->IsInstance<ConstantNode>()) {
           // Make sure to pick a unique name
           auto name = ext_symbol + "_" + opt_codegen.value() + "_const_" + std::to_string(count++);

--- a/src/runtime/extra/contrib/cudnn/cudnn_json_runtime.cc
+++ b/src/runtime/extra/contrib/cudnn/cudnn_json_runtime.cc
@@ -162,7 +162,7 @@ class cuDNNJSONRuntime : public JSONRuntimeBase {
                            conv_dtype, false, &best_algo);
 
     int algo = best_algo.cast<int>();
-    std::function<void()> op_exec = [=, this]() {
+    std::function<void()> op_exec = [=]() {
       int device_id;
       TVM_FFI_CHECK_CUDA_ERROR(cudaGetDevice(&device_id));
       cudaStream_t stream = static_cast<cudaStream_t>(TVMFFIEnvGetStream(kDLCUDA, device_id));
@@ -223,7 +223,7 @@ class cuDNNJSONRuntime : public JSONRuntimeBase {
     auto runner = tvm::contrib::CuDNNSDPARunner::Create();
     runner->Init(batch, seq_len, num_heads, num_kv_heads, head_size, head_size_v, scale, dtype,
                  layout);
-    return [=, this]() {
+    return [=]() {
       auto qkv = GetInput(node, 0);
       auto workspace = const_cast<DLTensor*>(GetInput(node, 1));
       auto out = const_cast<DLTensor*>(data_entry_[EntryID(outputs_[0])]);

--- a/src/s_tir/transform/inject_software_pipeline.cc
+++ b/src/s_tir/transform/inject_software_pipeline.cc
@@ -708,7 +708,7 @@ class PipelineRewriter : public StmtExprMutator {
         }
       }
 
-      auto wait_count = [=, this, &ana_normalized]() {
+      auto wait_count = [=, &ana_normalized]() {
         auto sum = PrimExpr(0);
         for (auto producer_head : producer_head_per_commit) {
           if (producer_head && ana_normalized->CanProve(producer_head.value() >= 0)) {


### PR DESCRIPTION
Revert four explicit-this lambda captures ([=, this, ...] -> [=, ...]) in run_codegen.cc, inject_software_pipeline.cc, and cudnn_json_runtime.cc.

These were introduced by the C++20 baseline upgrade (#19734); after reverting the baseline to C++17, MSVC rejects capturing 'this' explicitly under a '=' capture-default (error C3791) -- that form is C++20-only. GCC and Clang accept it as an extension in C++17, which is why only the Windows wheel build failed. Dropping the explicit 'this' ('=' captures it implicitly in C++17) restores the MSVC build with no behavior change.