### PR TITLE
[BUILD] Hide static linked library symbols in shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,14 +684,6 @@ target_link_libraries(tvm_runtime PRIVATE ${TVM_RUNTIME_LINKER_LIBS})
 # Set flags for clang
 include(cmake/modules/ClangFlags.cmake)
 set(TVM_TEST_LIBRARY_NAME tvm_compiler)
-if (HIDE_PRIVATE_SYMBOLS AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set(HIDE_SYMBOLS_LINKER_FLAGS "-Wl,--exclude-libs,ALL")
-  # Note: 'target_link_options' with 'PRIVATE' keyword would be cleaner
-  # but it's not available until CMake 3.13. Switch to 'target_link_options'
-  # once minimum CMake version is bumped up to 3.13 or above.
-  target_link_libraries(tvm_compiler PRIVATE ${HIDE_SYMBOLS_LINKER_FLAGS})
-  target_link_libraries(tvm_runtime PRIVATE ${HIDE_SYMBOLS_LINKER_FLAGS})
-endif()
 
 # Create the `cpptest` target if we can find GTest.  If not, we create dummy
 # targets that give the user an informative error message.

--- a/cmake/utils/Library.cmake
+++ b/cmake/utils/Library.cmake
@@ -17,6 +17,18 @@
 
 # Helpers for configuring library targets.
 
+# Hide symbols from static archives linked into a shared library. This prevents
+# downstream libraries from accidentally binding to private archive symbols such
+# as those from libstdc++_nonshared.a.
+function(tvm_hide_static_linked_lib_symbols target_name)
+  if(HIDE_PRIVATE_SYMBOLS
+     AND CMAKE_SYSTEM_NAME MATCHES "Linux|Android|FreeBSD|NetBSD|OpenBSD"
+     AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"
+  )
+    target_link_options(${target_name} PRIVATE "-Wl,--exclude-libs,ALL")
+  endif()
+endfunction()
+
 #######################################################
 # tvm_configure_target_library(target_name [RUNTIME_MODULE])
 #
@@ -24,6 +36,10 @@
 # ($ORIGIN / @loader_path) so that sibling shared libraries in the same
 # directory resolve each other regardless of the install location (e.g. inside a
 # Python wheel).
+#
+# For shared libraries and runtime modules, hide symbols that come from linked
+# static archives so downstream libraries cannot accidentally bind to private
+# archive symbols such as those from libstdc++_nonshared.a.
 #
 # With the RUNTIME_MODULE option -- used for the optional runtime backend
 # libraries (tvm_runtime_cuda, tvm_runtime_vulkan, ...) -- the target is also
@@ -49,6 +65,11 @@ function(tvm_configure_target_library target_name)
       BUILD_RPATH "\$ORIGIN"
       INSTALL_RPATH "\$ORIGIN"
     )
+  endif()
+
+  get_target_property(TVM_TARGET_TYPE ${target_name} TYPE)
+  if(TVM_TARGET_TYPE STREQUAL "SHARED_LIBRARY" OR TVM_TARGET_TYPE STREQUAL "MODULE_LIBRARY")
+    tvm_hide_static_linked_lib_symbols(${target_name})
   endif()
 
   if(ARG_RUNTIME_MODULE)


### PR DESCRIPTION
This PR bumps the tvm-ffi submodule and applies `-Wl,--exclude-libs,ALL` to TVM shared library targets through `tvm_configure_target_library`. This avoids exporting symbols pulled in from static archives such as `libstdc++_nonshared.a` and prevents downstream libraries from accidentally binding to those private definitions.

The TVM-side helper is local to `cmake/utils/Library.cmake` so the behavior is available to early-created targets before `3rdparty/tvm-ffi` is added as a subdirectory. This covers the core shared libraries and runtime module DSOs that use `tvm_configure_target_library`, including `libtvm_compiler.so`, `libtvm_runtime.so`, `libtvm_runtime_extra.so`, and `libtvm_runtime_*` backends.

Validation:
- `cmake -S . -B build-hide-static-symbols-probe -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DCMAKE_C_COMPILER_LAUNCHER=/opt/rust/bin/sccache -DCMAKE_CXX_COMPILER_LAUNCHER=/opt/rust/bin/sccache -DUSE_LLVM=OFF -DUSE_CUDA=OFF -DUSE_OPENCL=ON -DUSE_VULKAN=ON -DUSE_ROCM=OFF -DUSE_METAL=OFF -DUSE_HEXAGON=OFF`
- Generated `build.ninja` contains `-Wl,--exclude-libs,ALL` for `libtvm_compiler.so`, `libtvm_runtime.so`, `libtvm_runtime_extra.so`, `libtvm_runtime_opencl.so`, and `libtvm_runtime_vulkan.so`
- `ninja -C build-hide-static-symbols-probe tvm_runtime tvm_runtime_extra tvm_runtime_opencl tvm_runtime_vulkan`
- `ninja -C build-hide-static-symbols-probe tvm_compiler`
- `nm -D --defined-only` / `readelf -Ws` probe found no defined dynamic libbacktrace or static-libstdc++ nonshared probe symbols in `libtvm_compiler.so`, `libtvm_runtime.so`, `libtvm_runtime_opencl.so`, or `libtvm_runtime_vulkan.so`; remaining CXXABI/libstdc++ matches are undefined imports.
- `pre-commit run --files cmake/utils/Library.cmake`
- `git diff --check`