### PR TITLE
[Tests] Remove dead helpers and unused probes from tvm.testing

### DIFF
--- a/python/tvm/testing/__init__.py
+++ b/python/tvm/testing/__init__.py
@@ -21,9 +21,7 @@
 
 from ._ffi_api import (
     echo,
-    nop,
     object_use_count,
-    run_check_signal,
     test_raise_error,
 )
 from .runner import local_run, rpc_run

--- a/python/tvm/testing/env.py
+++ b/python/tvm/testing/env.py
@@ -28,8 +28,8 @@ with plain pytest markers and ``skipif``::
     def test_my_cuda_kernel():
         ...
 
-Every probe is memoized with :func:`functools.cache`, so the
-underlying device query / ``nvcc`` subprocess runs at most once per
+Each probe's expensive query (device lookup, ``nvcc`` subprocess, libinfo)
+is memoized with :func:`functools.cache`, so it runs at most once per
 process even though ``skipif`` evaluates the predicate at import time for
 every decorated test.  Probes never raise: when support is absent they
 return ``False`` (or a zero version tuple) rather than propagating an
@@ -42,20 +42,18 @@ Three kinds of probe live here:
 * **build-support** probes (``has_cudnn`` …, ``build_flag_enabled`` …) ask whether
   an optional library was compiled into the runtime;
 * **version / capability** probes (``has_cuda_compute``,
-  ``has_tensorcore`` …) ask about a finer capability of a present device
+  ``has_nvcc_version`` …) ask about a finer capability of a present device
   or toolchain.
 """
 
 import functools
 import os
-import platform
 
 import tvm
 
 __all__ = [
     "build_flag_enabled",
     "has_adreno_opencl",
-    "has_aprofile_aem_fvp",
     # cpu features
     "has_cpu_feature",
     "has_cublas",
@@ -82,13 +80,9 @@ __all__ = [
     "has_nvshmem",
     "has_opencl",
     "has_rocm",
-    "has_tensorcore",
     "has_vulkan",
     "has_x86_avx512",
     "has_x86_vnni",
-    "is_aarch64",
-    # host architecture
-    "is_x86",
 ]
 
 
@@ -331,17 +325,6 @@ def has_llvm_min_version(major: int) -> bool:
 
 
 @functools.cache
-def has_tensorcore() -> bool:
-    """True if a CUDA device with Tensor Core support (compute >= 7) exists."""
-    try:
-        from tvm.support import nvcc  # pylint: disable=import-outside-toplevel
-
-        return has_cuda() and bool(nvcc.have_tensorcore(tvm.cuda().compute_version))
-    except Exception:  # pylint: disable=broad-except
-        return False
-
-
-@functools.cache
 def has_matrixcore() -> bool:
     """True if a ROCm device with Matrix Core support (compute >= 8) exists."""
     try:
@@ -404,17 +387,6 @@ def has_adreno_opencl() -> bool:
     return build_flag_enabled("USE_OPENCL") and os.environ.get("RPC_TARGET") is not None
 
 
-@functools.cache
-def has_aprofile_aem_fvp() -> bool:
-    """True if the AProfile AEM FVP simulator is on PATH."""
-    try:
-        import shutil  # pylint: disable=import-outside-toplevel
-
-        return shutil.which("FVP_Base_RevC-2xAEMvA") is not None
-    except Exception:  # pylint: disable=broad-except
-        return False
-
-
 # --- cpu feature probes ----------------------------------------------------
 
 
@@ -446,16 +418,3 @@ def has_x86_vnni() -> bool:
 def has_x86_avx512() -> bool:
     """True if the host CPU supports the x86 AVX512 extensions."""
     return has_cpu_feature(["avx512bw", "avx512cd", "avx512dq", "avx512vl", "avx512f"])
-
-
-# --- host architecture probes ----------------------------------------------
-
-
-def is_x86() -> bool:
-    """True if running on an x86_64 host."""
-    return platform.machine() == "x86_64"
-
-
-def is_aarch64() -> bool:
-    """True if running on an aarch64 host."""
-    return platform.machine() == "aarch64"

--- a/python/tvm/testing/plugin.py
+++ b/python/tvm/testing/plugin.py
@@ -61,19 +61,6 @@ def pytest_configure(config):
     print("pytest marker:", config.option.markexpr)
 
 
-def pytest_addoption(parser):
-    """Add pytest options."""
-    parser.addoption("--gtest_args", action="store", default="")
-
-
-def pytest_generate_tests(metafunc):
-    """Called once per unit test, modifies/parametrizes it as needed."""
-    # Process gtest arguments
-    option_value = metafunc.config.option.gtest_args
-    if "gtest_args" in metafunc.fixturenames and option_value is not None:
-        metafunc.parametrize("gtest_args", [option_value])
-
-
 def pytest_collection_modifyitems(config, items):
     """Called after all tests are chosen, currently used for bookkeeping."""
     # pylint: disable=unused-argument

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -584,10 +584,6 @@ def skip_if_32bit(reason):
     return decorator
 
 
-def skip_if_no_reference_system(func):
-    return skip_if_32bit(reason="Reference system unavailable in i386 container")(func)
-
-
 def parameter(*values, ids=None, by_dict=None):
     """Convenience function to define pytest parametrized fixtures.
 
@@ -738,35 +734,6 @@ def fixture(func=None, *, cache_return_value=False):
         return wraps
 
     return wraps(func)
-
-
-def get_dtype_range(dtype: str) -> tuple[int, int]:
-    """
-    Produces the min,max for a give data type.
-
-    Parameters
-    ----------
-    dtype : str
-        a type string (e.g., int8, float64)
-
-    Returns
-    -------
-    type_info.min : int
-        the minimum of the range
-    type_info.max : int
-        the maximum of the range
-    """
-    type_info = None
-    np_dtype = np.dtype(dtype)
-    kind = np_dtype.kind
-
-    if kind == "f":
-        type_info = np.finfo(np_dtype)
-    elif kind in ["i", "u"]:
-        type_info = np.iinfo(np_dtype)
-    else:
-        raise TypeError(f"dtype ({dtype}) must indicate some floating-point or integral data type.")
-    return type_info.min, type_info.max
 
 
 class _DeepCopyAllowedClasses(dict):

--- a/tests/python/testing/test_env.py
+++ b/tests/python/testing/test_env.py
@@ -40,20 +40,16 @@ _BOOL_PROBES = [
     env.has_hipblas,
     env.has_nvshmem,
     # version / capability
-    env.has_tensorcore,
     env.has_matrixcore,
     env.has_cudagraph,
     # toolchain / environment
     env.has_hexagon,
     env.has_hexagon_toolchain,
     env.has_adreno_opencl,
-    env.has_aprofile_aem_fvp,
     # cpu features
     env.has_x86_vnni,
     env.has_x86_avx512,
     # host architecture
-    env.is_x86,
-    env.is_aarch64,
 ]
 
 


### PR DESCRIPTION
Drop accumulated dead code in the test-support package: helpers with zero call sites, unused capability probes, dead FFI re-exports, and orphaned pytest plumbing. Verified by repo-wide grep that nothing references any of these.