### PR TITLE
[CI] Drop redundant conda LLVM install in GH Actions build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,10 +44,6 @@ jobs:
           submodules: 'recursive'
       - name: Set up environment
         uses: ./.github/actions/setup
-      - name: Install LLVM dependencies
-        shell: bash -l {0}
-        run: |
-          conda install -c conda-forge llvmdev cmake ninja zlib
       - name: Build TVM wheel
         shell: bash -l {0}
         run: |
@@ -84,10 +80,6 @@ jobs:
           submodules: 'recursive'
       - name: Set up environment
         uses: ./.github/actions/setup
-      - name: Install LLVM dependencies
-        shell: cmd /C call {0}
-        run: |
-          conda install -c conda-forge llvmdev cmake ninja zlib libxml2-devel
       - name: Install TVM
         shell: cmd /C call {0}
         run: |


### PR DESCRIPTION
The MacOS and Windows jobs run `Set up environment` (`./.github/actions/setup`), which creates the conda env from `ci/scripts/package/build-environment.yaml`. That file already provides llvmdev, cmake, ninja, zlib and libxml2-devel, so the subsequent `Install LLVM dependencies` step re-installs packages already present.