### PR TITLE
[Tests] Migrate off tvm.testing.parametrize_targets to native pytest

### DIFF
--- a/docs/contribute/code_guide.rst
+++ b/docs/contribute/code_guide.rst
@@ -131,15 +131,18 @@ We use `pytest <https://docs.pytest.org/en/stable/>`_ for all python testing. ``
 See :doc:`testing` for details on running tests, target parametrization,
 and the target-specific marks used by CI.
 
-If you want your test to run over a variety of targets, use the :py:func:`tvm.testing.parametrize_targets` decorator. For example:
+If you want your test to run over a variety of targets, parametrize over ``target`` with ``@pytest.mark.parametrize``, tag GPU targets with ``@pytest.mark.gpu`` so the CI routes them to GPU nodes, and skip a target that is unavailable on the current machine with :py:func:`tvm.testing.device_enabled`. For example:
 
 .. code:: python
 
-  @tvm.testing.parametrize_targets
-  def test_mytest(target, dev):
-    ...
+  @pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
+  def test_mytest(target):
+      if not tvm.testing.device_enabled(target):
+          pytest.skip(f"{target} not enabled")
+      dev = tvm.device(target)
+      ...
 
-will run ``test_mytest`` with ``target="llvm"``, ``target="cuda"``, and few others. This also ensures that your test is run on the correct hardware by the CI. If you only want to test against a couple targets use ``@tvm.testing.parametrize_targets("target_1", "target_2")``. If you want to test on a single target, gate the test on the corresponding capability probe instead of using a per-target decorator. Mark GPU tests with ``@pytest.mark.gpu`` so the CI can select them, and skip when the required feature is unavailable with ``@pytest.mark.skipif``. For example, CUDA tests use:
+will run ``test_mytest`` with ``target="llvm"`` and ``target="cuda"``, skipping any target whose device is not present. If you only want to test against a single target, drop the parametrization and hardcode the target. Mark GPU tests with ``@pytest.mark.gpu`` so the CI can select them, and skip when the required feature is unavailable with ``@pytest.mark.skipif``. For example, CUDA tests use:
 
 .. code:: python
 

--- a/docs/contribute/testing.rst
+++ b/docs/contribute/testing.rst
@@ -57,79 +57,68 @@ Unit-Test File Contents
 
 .. _pytest-marks: https://docs.pytest.org/en/stable/how-to/mark.html
 
-The recommended method to run a test on multiple targets is by
-parametrizing the test.  This can be done explicitly for a fixed list
-of targets by decorating with
-``@tvm.testing.parametrize_targets('target_1', 'target_2', ...)``, and
-accepting ``target`` or ``dev`` as function arguments.  The function
-will be run once for each target listed, and the success/failure of
-each target is reported separately.  If a target cannot be run because
-it is disabled in the `config.cmake`, or because no appropriate
-hardware is present, then that target will be reported as skipped.
+The recommended way to run a test on multiple targets is to parametrize
+over ``target`` with ``@pytest.mark.parametrize``.  Tag each GPU target
+with ``pytest.mark.gpu`` so the CI routes it to a GPU node, skip a target
+that cannot run on the current machine with
+:py:func:`tvm.testing.device_enabled`, and obtain its device with
+``tvm.device(target)``.  The function is run once per target, the
+success/failure of each is reported separately, and a target whose device
+is disabled in ``config.cmake`` or absent from the machine is reported as
+skipped.
 
 .. code-block:: python
 
-    # Explicit listing of targets to use.
-    @tvm.testing.parametrize_targets('llvm', 'cuda')
-    def test_function(target, dev):
+    @pytest.mark.parametrize(
+        "target",
+        ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)],
+    )
+    def test_function(target):
+        if not tvm.testing.device_enabled(target):
+            pytest.skip(f"{target} not enabled")
+        dev = tvm.device(target)
         # Test code goes here
 
-For tests that should run correctly on all targets, the decorator can
-be omitted.  Any test that accepts a ``target`` or ``dev`` argument
-will automatically be parametrized over all targets specified in
-``TVM_TEST_TARGETS``.  The parametrization provides the same
-pass/fail/skipped report for each target, while allowing the test
-suite to be easily extended to cover additional targets.
+For a test that only applies to a single target, omit the parametrization
+and gate the test with ``@pytest.mark.skipif`` (plus ``@pytest.mark.gpu``
+for a GPU target):
 
 .. code-block:: python
 
-    # Implicitly parametrized to run on all targets
-    # in environment variable TVM_TEST_TARGETS
-    def test_function(target, dev):
+    @pytest.mark.gpu
+    @pytest.mark.skipif(
+        not tvm.testing.device_enabled("cuda"), reason="cuda not enabled"
+    )
+    def test_function():
+        target = "cuda"
+        dev = tvm.device(target)
         # Test code goes here
 
-The ``@tvm.testing.parametrize_targets`` can also be used as a bare
-decorator to explicitly draw attention to the parametrization, but has
-no additional effect.
+To exclude a target, leave it out of the parametrize list.  To mark a
+target as expected to fail, wrap it with
+``pytest.param("target", marks=pytest.mark.xfail(reason=...))``.
+
+Additional parameters can be combined with the target parametrization by
+stacking ``@pytest.mark.parametrize`` decorators, or by listing tuples of
+arguments.  Tag the GPU rows with ``pytest.mark.gpu`` and skip in the body
+as above:
 
 .. code-block:: python
 
-    # Explicitly parametrized to run on all targets
-    # in environment variable TVM_TEST_TARGETS
-    @tvm.testing.parametrize_targets
-    def test_function(target, dev):
-        # Test code goes here
-
-
-Specific targets can be excluded or marked as expected to fail using
-the ``@tvm.testing.exclude_targets`` or
-``@tvm.testing.known_failing_targets`` decorators.  For more
-information on their intended use cases, please see their docstrings.
-
-In some cases it may be necessary to parametrize across multiple
-parameters.  For instance, there may be target-specific
-implementations that should be tested, where some targets have more
-than one implementation.  These can be done by explicitly
-parametrizing over tuples of arguments, such as shown below.  In these
-cases, only the explicitly listed targets will run, and each target is
-automatically gated on whether it can run on the current machine (a GPU
-target gets ``@pytest.mark.gpu`` plus a skip when no device is present).
-
-.. code-block:: python
-
-   @pytest.mark.parametrize('target,impl', [
-        ('llvm', cpu_implementation),
-        ('cuda', gpu_implementation_small_batch),
-        ('cuda', gpu_implementation_large_batch),
+   @pytest.mark.parametrize("target,impl", [
+        ("llvm", cpu_implementation),
+        pytest.param("cuda", gpu_implementation_small_batch, marks=pytest.mark.gpu),
+        pytest.param("cuda", gpu_implementation_large_batch, marks=pytest.mark.gpu),
     ])
-    def test_function(target, dev, impl):
+    def test_function(target, impl):
+        if not tvm.testing.device_enabled(target):
+            pytest.skip(f"{target} not enabled")
+        dev = tvm.device(target)
         # Test code goes here
 
 
-The parametrization functionality is implemented
-on top of pytest marks.  Each test function can
-be decorated with `pytest marks <pytest-marks>`_
-to include metadata.  The most frequently applied
+Tests gate on hardware and carry metadata using
+`pytest marks <pytest-marks>`_.  The most frequently applied
 marks are as follows.
 
 - ``@pytest.mark.gpu`` - Tags a function as using GPU
@@ -156,12 +145,6 @@ marks are as follows.
   module, when called at import time) if an optional Python package is
   not installed.  Use this instead of a ``skipif`` for package
   dependencies.
-
-When using ``tvm.testing.parametrize_targets()``, each parametrized run
-is gated automatically on whether its target can run on the current
-machine.  As a result, if a target is disabled in ``config.cmake`` or
-does not have appropriate hardware to run, it will be explicitly listed
-as skipped, and GPU targets are tagged with ``@pytest.mark.gpu`` for you.
 
 There also exists a ``tvm.testing.enabled_targets()`` that returns
 all targets that are enabled and runnable on the current machine,

--- a/python/tvm/testing/plugin.py
+++ b/python/tvm/testing/plugin.py
@@ -35,8 +35,7 @@ directory as the test scripts.
 import _pytest
 import pytest
 
-import tvm
-from tvm.testing import env, utils
+from tvm.testing import utils
 
 try:
     from xdist.scheduler.loadscope import LoadScopeScheduling
@@ -69,9 +68,6 @@ def pytest_addoption(parser):
 
 def pytest_generate_tests(metafunc):
     """Called once per unit test, modifies/parametrizes it as needed."""
-    _auto_parametrize_target(metafunc)
-    _add_target_specific_marks(metafunc)
-
     # Process gtest arguments
     option_value = metafunc.config.option.gtest_args
     if "gtest_args" in metafunc.fixturenames and option_value is not None:
@@ -86,136 +82,12 @@ def pytest_collection_modifyitems(config, items):
     _sort_tests(items)
 
 
-@pytest.fixture
-def dev(target):
-    """Give access to the device to tests that need it."""
-    if isinstance(target, dict):
-        return tvm.device(target["kind"])
-    return tvm.device(target)
-
-
 def pytest_sessionfinish(session, exitstatus):
     # Don't exit with an error if we select a subset of tests that doesn't
     # include anything
     if session.config.option.markexpr != "":
         if exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED:
             session.exitstatus = pytest.ExitCode.OK
-
-
-def _auto_parametrize_target(metafunc):
-    """Automatically applies parametrize_targets
-
-    Used if a test function uses the "target" fixture, but isn't
-    already marked with @tvm.testing.parametrize_targets.  Intended
-    for use in the pytest_generate_tests() handler of a conftest.py
-    file.
-
-    """
-
-    if "target" in metafunc.fixturenames:
-        # Check if any explicit parametrizations exist, and apply one
-        # if they do not.  If the function is marked with either
-        # excluded or known failing targets, use these to determine
-        # the targets to be used.
-        parametrized_args = [
-            arg.strip()
-            for mark in metafunc.definition.iter_markers("parametrize")
-            for arg in mark.args[0].split(",")
-        ]
-        if "target" not in parametrized_args:
-            excluded_targets = getattr(metafunc.function, "tvm_excluded_targets", [])
-
-            # Add a parametrize marker instead of calling
-            # metafunc.parametrize so that the parametrize rewriting
-            # can still occur.
-            mark = pytest.mark.parametrize(
-                "target",
-                [
-                    t["target"]
-                    for t in utils._get_targets()
-                    if t["target_kind"] not in excluded_targets
-                ],
-                scope="session",
-            )
-            metafunc.definition.add_marker(mark)
-
-
-def _add_target_specific_marks(metafunc):
-    """Add any target-specific marks to parametrizations over target"""
-
-    def update_parametrize_target_arg(
-        mark,
-        argnames,
-        argvalues,
-        *args,
-        **kwargs,
-    ):
-        args = [arg.strip() for arg in argnames.split(",") if arg.strip()]
-        if "target" in args:
-            target_i = args.index("target")
-
-            new_argvalues = []
-            for argvalue in argvalues:
-                if isinstance(argvalue, _pytest.mark.structures.ParameterSet):
-                    # The parametrized value is already a
-                    # pytest.param, so track any marks already
-                    # defined.
-                    param_set = argvalue.values
-                    target = param_set[target_i]
-                    additional_marks = argvalue.marks
-                elif len(args) == 1:
-                    # Single value parametrization, argvalue is a list of values.
-                    target = argvalue
-                    param_set = (target,)
-                    additional_marks = []
-                else:
-                    # Multiple correlated parameters, argvalue is a list of tuple of values.
-                    param_set = argvalue
-                    target = param_set[target_i]
-                    additional_marks = []
-
-                if mark in metafunc.definition.own_markers:
-                    xfail_targets = getattr(metafunc.function, "tvm_known_failing_targets", [])
-                    if isinstance(target, str):
-                        target_kind = target.split()[0]
-                    elif isinstance(target, dict):
-                        target_kind = target["kind"]
-                    else:
-                        target_kind = target.kind.name
-                    if target_kind in xfail_targets:
-                        additional_marks.append(
-                            pytest.mark.xfail(
-                                reason=f'Known failing test for target "{target_kind}"'
-                            )
-                        )
-
-                new_argvalues.append(
-                    pytest.param(
-                        *param_set, marks=_target_to_requirement(target) + additional_marks
-                    )
-                )
-
-            try:
-                argvalues[:] = new_argvalues
-            except TypeError as err:
-                pyfunc = metafunc.definition.function
-                filename = pyfunc.__code__.co_filename
-                line_number = pyfunc.__code__.co_firstlineno
-                msg = (
-                    f"Unit test {metafunc.function.__name__} ({filename}:{line_number}) "
-                    "is parametrized using a tuple of parameters instead of a list "
-                    "of parameters."
-                )
-                raise TypeError(msg) from err
-
-    if "target" in metafunc.fixturenames:
-        # Update any explicit use of @pytest.mark.parametrize to
-        # parametrize over targets.  This attaches the appropriate
-        # per-target gating markers (pytest.mark.gpu for GPU-family
-        # targets, plus a pytest.mark.skipif guarded by the relevant
-        # tvm.testing.env.has_*() probe) via _target_to_requirement.
-        for mark in metafunc.definition.iter_markers("parametrize"):
-            update_parametrize_target_arg(mark, *mark.args, **mark.kwargs)
 
 
 def _count_num_fixture_uses(items):
@@ -277,41 +149,6 @@ def _sort_tests(items):
         return filename, lineno, test_name
 
     items.sort(key=sort_key)
-
-
-# GPU-family target kinds carry the ``gpu`` selection marker; CPU-family kinds
-# (llvm, hexagon) only skip. The skip condition is the matching tvm.testing.env
-# probe, resolved by name, so there is no per-kind ladder of has_* calls.
-_GPU_TARGET_KINDS = frozenset(
-    {"cuda", "cudnn", "cublas", "rocm", "vulkan", "nvptx", "metal", "opencl"}
-)
-_CPU_TARGET_KINDS = frozenset({"llvm", "hexagon"})
-
-
-def _target_to_requirement(target):
-    if isinstance(target, str | dict):
-        target = tvm.target.Target(target)
-
-    # A cuda target carrying an accelerator library gates on that library's probe
-    # (cudnn before cublas) instead of plain cuda.
-    kind = target.kind.name
-    if kind == "cuda":
-        libs = target.attrs.get("libs", [])
-        if "cudnn" in libs:
-            kind = "cudnn"
-        elif "cublas" in libs:
-            kind = "cublas"
-
-    if kind in _GPU_TARGET_KINDS:
-        is_gpu = True
-    elif kind in _CPU_TARGET_KINDS:
-        is_gpu = False
-    else:
-        return []
-
-    marks = [pytest.mark.gpu] if is_gpu else []
-    marks.append(pytest.mark.skipif(not getattr(env, f"has_{kind}")(), reason=f"need {kind}"))
-    return marks
 
 
 # pytest-xdist isn't required but is used in CI, so guard on its presence

--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -55,12 +55,12 @@ There is one ``has_*`` (or ``is_*``) probe per capability -- for example
 and :py:func:`tvm.testing.env.has_vulkan`.  For optional Python packages,
 prefer ``pytest.importorskip("pkg_name")`` instead of a ``skipif``.
 
-To run a test against a variety of targets, use
-:py:func:`tvm.testing.parametrize_targets`; it parametrizes the test over
-the enabled targets and applies the appropriate ``gpu`` tag and skip
-conditions per target automatically.  The set of enabled targets is
-controlled by the ``TVM_TEST_TARGETS`` environment variable, so the CI
-can run different targets on different testing nodes.
+To run a test against a variety of targets, parametrize over ``target`` with
+``@pytest.mark.parametrize("target", [...])`` -- tag GPU targets with
+``pytest.mark.gpu`` so the CI routes them to GPU nodes, and skip an unavailable
+target with ``pytest.mark.skipif(not tvm.testing.device_enabled(target))``.  The
+set of enabled targets is controlled by the ``TVM_TEST_TARGETS`` environment
+variable, so the CI can run different targets on different testing nodes.
 
 """
 
@@ -459,8 +459,8 @@ DEFAULT_TEST_TARGETS = [
 def device_enabled(target):
     """Check if a target should be used when testing.
 
-    It is recommended that you use :py:func:`tvm.testing.parametrize_targets`
-    instead of manually checking if a target is enabled.
+    Gate a device-specific test on this with
+    ``@pytest.mark.skipif(not tvm.testing.device_enabled(target))``.
 
     This allows the user to control which devices they are testing against. In
     tests, this should be used to check if a device should be used when said
@@ -501,8 +501,8 @@ def device_enabled(target):
 def enabled_targets():
     """Get all enabled targets with associated devices.
 
-    In most cases, you should use :py:func:`tvm.testing.parametrize_targets` instead of
-    this function.
+    In most cases, parametrize over the specific targets you need with
+    ``@pytest.mark.parametrize`` instead of iterating this function.
 
     In this context, enabled means that TVM was built with support for
     this target, the target name appears in the TVM_TEST_TARGETS
@@ -586,133 +586,6 @@ def skip_if_32bit(reason):
 
 def skip_if_no_reference_system(func):
     return skip_if_32bit(reason="Reference system unavailable in i386 container")(func)
-
-
-def parametrize_targets(*args):
-    """Parametrize a test over a specific set of targets.
-
-    Use this decorator when you want your test to be run over a
-    specific set of targets and devices.  It is intended for use where
-    a test is applicable only to a specific target, and is
-    inapplicable to any others (e.g. verifying target-specific
-    assembly code matches known assembly code).  In most
-    circumstances, :py:func:`tvm.testing.exclude_targets` or
-    :py:func:`tvm.testing.known_failing_targets` should be used
-    instead.
-
-    If used as a decorator without arguments, the test will be
-    parametrized over all targets in
-    :py:func:`tvm.testing.enabled_targets`.  This behavior is
-    automatically enabled for any target that accepts arguments of
-    ``target`` or ``dev``, so the explicit use of the bare decorator
-    is no longer needed, and is maintained for backwards
-    compatibility.
-
-    Parameters
-    ----------
-    f : function
-        Function to parametrize. Must be of the form `def test_xxxxxxxxx(target, dev)`:,
-        where `xxxxxxxxx` is any name.
-    targets : list[str], optional
-        Set of targets to run against. If not supplied,
-        :py:func:`tvm.testing.enabled_targets` will be used.
-
-    Example
-    -------
-    >>> @tvm.testing.parametrize_targets("llvm", "cuda")
-    >>> def test_mytest(target, dev):
-    >>>     ...  # do something
-    """
-
-    # Backwards compatibility, when used as a decorator with no
-    # arguments implicitly parametrizes over "target".  The
-    # parametrization is now handled by _auto_parametrize_target, so
-    # this use case can just return the decorated function.
-    if len(args) == 1 and callable(args[0]):
-        return args[0]
-
-    return pytest.mark.parametrize("target", list(args), scope="session")
-
-
-def exclude_targets(*args):
-    """Exclude a test from running on a particular target.
-
-    Use this decorator when you want your test to be run over a
-    variety of targets and devices (including cpu and gpu devices),
-    but want to exclude some particular target or targets.  For
-    example, a test may wish to be run against all targets in
-    tvm.testing.enabled_targets(), except for a particular target that
-    does not support the capabilities.
-
-    Applies pytest.mark.skipif to the targets given.
-
-    Parameters
-    ----------
-    f : function
-        Function to parametrize. Must be of the form `def test_xxxxxxxxx(target, dev)`:,
-        where `xxxxxxxxx` is any name.
-    targets : list[str]
-        Set of targets to exclude.
-
-    Example
-    -------
-    >>> @tvm.testing.exclude_targets("cuda")
-    >>> def test_mytest(target, dev):
-    >>>     ...  # do something
-
-    Or
-
-    >>> @tvm.testing.exclude_targets("llvm", "cuda")
-    >>> def test_mytest(target, dev):
-    >>>     ...  # do something
-
-    """
-
-    def wraps(func):
-        func.tvm_excluded_targets = args
-        return func
-
-    return wraps
-
-
-def known_failing_targets(*args):
-    """Skip a test that is known to fail on a particular target.
-
-    Use this decorator when you want your test to be run over a
-    variety of targets and devices (including cpu and gpu devices),
-    but know that it fails for some targets.  For example, a newly
-    implemented runtime may not support all features being tested, and
-    should be excluded.
-
-    Applies pytest.mark.xfail to the targets given.
-
-    Parameters
-    ----------
-    f : function
-        Function to parametrize. Must be of the form `def test_xxxxxxxxx(target, dev)`:,
-        where `xxxxxxxxx` is any name.
-    targets : list[str]
-        Set of targets to skip.
-
-    Example
-    -------
-    >>> @tvm.testing.known_failing_targets("cuda")
-    >>> def test_mytest(target, dev):
-    >>>     ...  # do something
-
-    Or
-
-    >>> @tvm.testing.known_failing_targets("llvm", "cuda")
-    >>> def test_mytest(target, dev):
-    >>>     ...  # do something
-
-    """
-
-    def wraps(func):
-        func.tvm_known_failing_targets = args
-        return func
-
-    return wraps
 
 
 def parameter(*values, ids=None, by_dict=None):

--- a/tests/python/codegen/test_gpu_codegen_allreduce.py
+++ b/tests/python/codegen/test_gpu_codegen_allreduce.py
@@ -77,8 +77,17 @@ def generate_param_sets():
 dims = tvm.testing.parameter(*generate_param_sets())
 
 
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_allreduce_sum(dims, target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("cuda", marks=pytest.mark.gpu),
+        pytest.param("metal", marks=pytest.mark.gpu),
+    ],
+)
+def test_allreduce_sum(dims, target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     d1, d2, d3 = dims
     mod = _reduce_sum_module(d1, d2, d3)
     f = tvm.compile(mod, target=target)
@@ -131,8 +140,17 @@ def test_allreduce_sum_compile(optional_metal_compile_callback):
     tvm.compile(mod, target=target)
 
 
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_allreduce_max(dims, target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("cuda", marks=pytest.mark.gpu),
+        pytest.param("metal", marks=pytest.mark.gpu),
+    ],
+)
+def test_allreduce_max(dims, target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     d1, d2, d3 = dims
     mod = _reduce_max_module(d1, d2, d3)
     f = tvm.compile(mod, target=target)

--- a/tests/python/codegen/test_target_codegen.py
+++ b/tests/python/codegen/test_target_codegen.py
@@ -20,11 +20,13 @@ import numpy as np
 import pytest
 
 import tvm
+import tvm.testing
 from tvm.script import tirx as T
 
 
-@tvm.testing.parametrize_targets("c")
-def test_buffer_store_predicate_not_supported(target):
+def test_buffer_store_predicate_not_supported():
+    target = "c"
+
     @T.prim_func(s_tir=True)
     def func(b: T.handle):
         B = T.match_buffer(b, (8,), "float32")
@@ -36,10 +38,20 @@ def test_buffer_store_predicate_not_supported(target):
             tvm.compile(func)
 
 
-@tvm.testing.parametrize_targets(
-    "cuda", "opencl", "metal", "rocm", {"kind": "vulkan", "from_device": 0}
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("cuda", marks=pytest.mark.gpu),
+        pytest.param("opencl", marks=pytest.mark.gpu),
+        pytest.param("metal", marks=pytest.mark.gpu),
+        pytest.param("rocm", marks=pytest.mark.gpu),
+        pytest.param({"kind": "vulkan", "from_device": 0}, marks=pytest.mark.gpu),
+    ],
 )
 def test_buffer_store_predicate_not_supported_gpu(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
     @T.prim_func(s_tir=True)
     def func(a: T.handle, b: T.handle):
         A = T.match_buffer(a, (2, 3), "float32")
@@ -56,8 +68,9 @@ def test_buffer_store_predicate_not_supported_gpu(target):
             tvm.compile(func)
 
 
-@tvm.testing.parametrize_targets("c")
-def test_buffer_load_predicate_not_supported(target):
+def test_buffer_load_predicate_not_supported():
+    target = "c"
+
     @T.prim_func(s_tir=True)
     def func(a: T.handle, b: T.handle):
         A = T.match_buffer(a, (8,), "float32")
@@ -74,10 +87,20 @@ def test_buffer_load_predicate_not_supported(target):
             tvm.compile(func)
 
 
-@tvm.testing.parametrize_targets(
-    "cuda", "opencl", "metal", "rocm", {"kind": "vulkan", "from_device": 0}
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("cuda", marks=pytest.mark.gpu),
+        pytest.param("opencl", marks=pytest.mark.gpu),
+        pytest.param("metal", marks=pytest.mark.gpu),
+        pytest.param("rocm", marks=pytest.mark.gpu),
+        pytest.param({"kind": "vulkan", "from_device": 0}, marks=pytest.mark.gpu),
+    ],
 )
 def test_buffer_load_predicate_not_supported_gpu(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
     @T.prim_func(s_tir=True)
     def func(a: T.handle, b: T.handle):
         A = T.match_buffer(a, (8,), "float32")
@@ -94,8 +117,11 @@ def test_buffer_load_predicate_not_supported_gpu(target):
             tvm.compile(func)
 
 
-@tvm.testing.parametrize_targets("c", "llvm")
+@pytest.mark.parametrize("target", ["c", "llvm"])
 def test_codegen_loop_step(target):
+    if target != "c" and not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
     @T.prim_func(s_tir=True)
     def test_loop_step(
         A: T.Buffer((1024,), "float32"),

--- a/tests/python/codegen/test_target_codegen_bool.py
+++ b/tests/python/codegen/test_target_codegen_bool.py
@@ -26,8 +26,12 @@ from tvm.script import tirx as T
 
 
 @pytest.mark.gpu
-@tvm.testing.exclude_targets("nvptx")
-def test_cmp_load_store(target, dev):
+@pytest.mark.parametrize("target", ["llvm", "cuda", "rocm", "vulkan", "metal", "opencl"])
+def test_cmp_load_store(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
+
     @I.ir_module(s_tir=True)
     class GPUModule:
         @T.prim_func(s_tir=True)

--- a/tests/python/codegen/test_target_codegen_cuda.py
+++ b/tests/python/codegen/test_target_codegen_cuda.py
@@ -328,8 +328,18 @@ def test_cuda_inf_nan():
     check_inf_nan(dev, 1, float("nan"), "float64")
 
 
-@tvm.testing.parametrize_targets("cuda", "rocm")
-def test_crossthread_reduction1(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("cuda", marks=pytest.mark.gpu),
+        pytest.param("rocm", marks=pytest.mark.gpu),
+    ],
+)
+def test_crossthread_reduction1(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
+
     def sched(nthd):
         @I.ir_module(s_tir=True)
         class Module:
@@ -372,8 +382,18 @@ def test_crossthread_reduction1(target, dev):
     verify(64)
 
 
-@tvm.testing.parametrize_targets("cuda", "rocm")
-def test_crossthread_reduction2(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("cuda", marks=pytest.mark.gpu),
+        pytest.param("rocm", marks=pytest.mark.gpu),
+    ],
+)
+def test_crossthread_reduction2(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
+
     def sched(nthdx, nthdy):
         @I.ir_module(s_tir=True)
         class Module:

--- a/tests/python/codegen/test_target_codegen_gpu_common.py
+++ b/tests/python/codegen/test_target_codegen_gpu_common.py
@@ -28,11 +28,20 @@ from tvm.testing import env
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
-@tvm.testing.parametrize_targets(
-    "cuda", "metal", {"kind": "vulkan", "supports_int64": True}, "opencl"
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("cuda", marks=pytest.mark.gpu),
+        pytest.param("metal", marks=pytest.mark.gpu),
+        pytest.param({"kind": "vulkan", "supports_int64": True}, marks=pytest.mark.gpu),
+        pytest.param("opencl", marks=pytest.mark.gpu),
+    ],
 )
 @pytest.mark.parametrize("dtype", ["int32", "uint32", "int64", "uint64"])
-def test_int_intrin(target, dev, dtype):
+def test_int_intrin(target, dtype):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target["kind"] if isinstance(target, dict) else target)
     test_funcs = [
         (T.clz, lambda x, dtype: int(dtype[-2:]) - (len(bin(x)) - 2)),
     ]

--- a/tests/python/codegen/test_target_codegen_llvm_vla.py
+++ b/tests/python/codegen/test_target_codegen_llvm_vla.py
@@ -24,6 +24,7 @@ import re
 import pytest
 
 import tvm
+import tvm.testing
 from tvm.script import tirx as T
 from tvm.target.codegen import llvm_version_major
 
@@ -31,17 +32,22 @@ from tvm.target.codegen import llvm_version_major
 @pytest.mark.skipif(
     llvm_version_major() < 11, reason="Vscale is not supported in earlier versions of LLVM"
 )
-@tvm.testing.parametrize_targets(
-    {"kind": "llvm", "mtriple": "aarch64-linux-gnu", "mattr": ["+sve"]},
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv64-linux-gnu",
-        "mcpu": "generic-rv64",
-        "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
-    },
+@pytest.mark.parametrize(
+    "target",
+    [
+        {"kind": "llvm", "mtriple": "aarch64-linux-gnu", "mattr": ["+sve"]},
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv64-linux-gnu",
+            "mcpu": "generic-rv64",
+            "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
+        },
+    ],
 )
 def test_codegen_vscale(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
     vscale = tvm.tirx.vscale()
 
     @T.prim_func(s_tir=True)
@@ -59,17 +65,23 @@ def test_codegen_vscale(target):
 @pytest.mark.skipif(
     llvm_version_major() < 11, reason="Vscale is not supported in earlier versions of LLVM"
 )
-@tvm.testing.parametrize_targets(
-    {"kind": "llvm", "mtriple": "aarch64-linux-gnu", "mattr": ["+sve"]},
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv64-linux-gnu",
-        "mcpu": "generic-rv64",
-        "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
-    },
+@pytest.mark.parametrize(
+    "target",
+    [
+        {"kind": "llvm", "mtriple": "aarch64-linux-gnu", "mattr": ["+sve"]},
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv64-linux-gnu",
+            "mcpu": "generic-rv64",
+            "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
+        },
+    ],
 )
 def test_scalable_buffer_load_store(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
     @T.prim_func(s_tir=True)
     def my_func(a: T.handle, b: T.handle):
         A = T.match_buffer(a, (128,), "float32")
@@ -88,17 +100,23 @@ def test_scalable_buffer_load_store(target):
 @pytest.mark.skipif(
     llvm_version_major() < 11, reason="Vscale is not supported in earlier versions of LLVM"
 )
-@tvm.testing.parametrize_targets(
-    {"kind": "llvm", "mtriple": "aarch64-linux-gnu", "mattr": ["+sve"]},
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv64-linux-gnu",
-        "mcpu": "generic-rv64",
-        "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
-    },
+@pytest.mark.parametrize(
+    "target",
+    [
+        {"kind": "llvm", "mtriple": "aarch64-linux-gnu", "mattr": ["+sve"]},
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv64-linux-gnu",
+            "mcpu": "generic-rv64",
+            "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
+        },
+    ],
 )
 def test_scalable_broadcast(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
     @T.prim_func(s_tir=True)
     def my_func(a: T.handle):
         A = T.match_buffer(a, (128,), "float32")
@@ -121,17 +139,23 @@ def test_scalable_broadcast(target):
 @pytest.mark.skip(
     reason="Vscale and get.active.lane.mask are not supported in earlier versions of LLVM",
 )
-@tvm.testing.parametrize_targets(
-    {"kind": "llvm", "mtriple": "aarch64-linux-gnu", "mattr": ["+sve"]},
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv64-linux-gnu",
-        "mcpu": "generic-rv64",
-        "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
-    },
+@pytest.mark.parametrize(
+    "target",
+    [
+        {"kind": "llvm", "mtriple": "aarch64-linux-gnu", "mattr": ["+sve"]},
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv64-linux-gnu",
+            "mcpu": "generic-rv64",
+            "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
+        },
+    ],
 )
 def test_get_active_lane_mask(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
     @T.prim_func(s_tir=True)
     def before(a: T.handle):
         A = T.match_buffer(a, (30,), "int1")
@@ -148,17 +172,23 @@ def test_get_active_lane_mask(target):
 @pytest.mark.skip(
     reason="Vscale and get.active.lane.mask are not supported in earlier versions of LLVM",
 )
-@tvm.testing.parametrize_targets(
-    {"kind": "llvm", "mtriple": "aarch64-linux-gnu", "mattr": ["+sve"]},
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv64-linux-gnu",
-        "mcpu": "generic-rv64",
-        "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
-    },
+@pytest.mark.parametrize(
+    "target",
+    [
+        {"kind": "llvm", "mtriple": "aarch64-linux-gnu", "mattr": ["+sve"]},
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv64-linux-gnu",
+            "mcpu": "generic-rv64",
+            "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
+        },
+    ],
 )
 def test_predicated_scalable_buffer(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
     @T.prim_func(s_tir=True)
     def before(a: T.handle, b: T.handle):
         A = T.match_buffer(a, (16,), "float32")

--- a/tests/python/codegen/test_target_codegen_opencl.py
+++ b/tests/python/codegen/test_target_codegen_opencl.py
@@ -223,8 +223,17 @@ def test_opencl_type_casting():
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_opencl(), reason="need opencl")
-@tvm.testing.parametrize_targets("opencl", {"kind": "opencl", "device": "adreno"})
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("opencl", marks=pytest.mark.gpu),
+        pytest.param({"kind": "opencl", "device": "adreno"}, marks=pytest.mark.gpu),
+    ],
+)
 def test_opencl_ceil_log2(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
     def _check(target, n, dtype):
         target_obj = tvm.target.Target(target)
         is_adreno = "adreno" in target_obj.attrs.get("device", "")

--- a/tests/python/codegen/test_target_codegen_riscv.py
+++ b/tests/python/codegen/test_target_codegen_riscv.py
@@ -28,37 +28,43 @@ from tvm.testing import env
 
 
 @pytest.mark.skipif(not env.has_llvm_min_version(14), reason="need llvm >= 14")
-@tvm.testing.parametrize_targets(
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv32-linux-gnu",
-        "mcpu": "generic-rv32",
-        "mattr": ["+i", "+m"],
-    },
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv32-linux-gnu",
-        "mcpu": "generic-rv32",
-        "mattr": ["+i", "+m", "+v"],
-    },
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv64-linux-gnu",
-        "mcpu": "generic-rv64",
-        "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m"],
-    },
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv64-linux-gnu",
-        "mcpu": "generic-rv64",
-        "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
-    },
+@pytest.mark.parametrize(
+    "target",
+    [
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv32-linux-gnu",
+            "mcpu": "generic-rv32",
+            "mattr": ["+i", "+m"],
+        },
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv32-linux-gnu",
+            "mcpu": "generic-rv32",
+            "mattr": ["+i", "+m", "+v"],
+        },
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv64-linux-gnu",
+            "mcpu": "generic-rv64",
+            "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m"],
+        },
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv64-linux-gnu",
+            "mcpu": "generic-rv64",
+            "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
+        },
+    ],
 )
 def test_rvv(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
     def check_rvv_presence(N, extent):
         @T.prim_func(s_tir=True)
         def load_vec(A: T.Buffer((N,), "int8")):
@@ -78,23 +84,29 @@ def test_rvv(target):
 
 
 @pytest.mark.skipif(not env.has_llvm_min_version(14), reason="need llvm >= 14")
-@tvm.testing.parametrize_targets(
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv32-linux-gnu",
-        "mcpu": "generic-rv32",
-        "mattr": ["+i", "+m", "+v"],
-    },
-    {
-        "kind": "llvm",
-        "device": "riscv_cpu",
-        "mtriple": "riscv64-linux-gnu",
-        "mcpu": "generic-rv64",
-        "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
-    },
+@pytest.mark.parametrize(
+    "target",
+    [
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv32-linux-gnu",
+            "mcpu": "generic-rv32",
+            "mattr": ["+i", "+m", "+v"],
+        },
+        {
+            "kind": "llvm",
+            "device": "riscv_cpu",
+            "mtriple": "riscv64-linux-gnu",
+            "mcpu": "generic-rv64",
+            "mattr": ["+64bit", "+a", "+c", "+d", "+f", "+m", "+v"],
+        },
+    ],
 )
 def test_rvv_vscale_llvm_dbginfo(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
     # fmt: off
     @T.prim_func(s_tir=True)
     def rvv_with_vscale(A_handle: T.handle, B_handle: T.handle, C_handle: T.handle):

--- a/tests/python/codegen/test_target_codegen_vulkan.py
+++ b/tests/python/codegen/test_target_codegen_vulkan.py
@@ -36,8 +36,22 @@ fuzz_seed = tvm.testing.parameter(range(25))
 
 # Explicitly specify a target, as this test is looking at the
 # generated shader code, and is not running on an actual device.
-@tvm.testing.parametrize_targets(
-    {
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not tvm.testing.device_enabled(
+        {
+            "kind": "vulkan",
+            "supports_int8": 1,
+            "supports_8bit_buffer": 1,
+            "supports_storage_buffer_storage_class": 1,
+            "supports_float16": 1,
+            "supports_16bit_buffer": 1,
+        }
+    ),
+    reason="vulkan not enabled",
+)
+def test_vector_comparison(dtype):
+    target = {
         "kind": "vulkan",
         "supports_int8": 1,
         "supports_8bit_buffer": 1,
@@ -45,8 +59,6 @@ fuzz_seed = tvm.testing.parameter(range(25))
         "supports_float16": 1,
         "supports_16bit_buffer": 1,
     }
-)
-def test_vector_comparison(target, dev, dtype):
     target = tvm.target.Target(target)
     zero = tvm.tirx.const(0, dtype)
     one = tvm.tirx.const(1, dtype)
@@ -74,7 +86,22 @@ def test_vector_comparison(target, dev, dtype):
     assert len(matches) == 1
 
 
-def test_array_copy(dev, dtype, fuzz_seed):
+@pytest.mark.parametrize(
+    "target",
+    [
+        "llvm",
+        pytest.param("cuda", marks=pytest.mark.gpu),
+        pytest.param("rocm", marks=pytest.mark.gpu),
+        pytest.param("vulkan", marks=pytest.mark.gpu),
+        pytest.param("metal", marks=pytest.mark.gpu),
+        pytest.param("opencl", marks=pytest.mark.gpu),
+        pytest.param("nvptx", marks=pytest.mark.gpu),
+    ],
+)
+def test_array_copy(target, dtype, fuzz_seed):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     np.random.seed(fuzz_seed)
 
     log_arr_size = np.random.uniform(low=np.log(1), high=np.log(32768))
@@ -86,8 +113,14 @@ def test_array_copy(dev, dtype, fuzz_seed):
     tvm.testing.assert_allclose(a_np, a.numpy())
 
 
-@tvm.testing.parametrize_targets({"kind": "vulkan", "from_device": 0})
-def test_array_vectorize_add(target, dev, dtype):
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not tvm.testing.device_enabled({"kind": "vulkan", "from_device": 0}),
+    reason="vulkan not enabled",
+)
+def test_array_vectorize_add(dtype):
+    target = {"kind": "vulkan", "from_device": 0}
+    dev = tvm.device(target["kind"])
     target = tvm.target.Target(target)
     arr_size = 64
     lanes = 2
@@ -115,8 +148,14 @@ def test_array_vectorize_add(target, dev, dtype):
     tvm.testing.assert_allclose(c.numpy(), a.numpy() + 1)
 
 
-@tvm.testing.parametrize_targets({"kind": "vulkan", "from_device": 0})
-def test_vulkan_bool_load(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not tvm.testing.device_enabled({"kind": "vulkan", "from_device": 0}),
+    reason="vulkan not enabled",
+)
+def test_vulkan_bool_load():
+    target = {"kind": "vulkan", "from_device": 0}
+    dev = tvm.device(target["kind"])
     target = tvm.target.Target(target)
     arr_size = 1024
 
@@ -147,8 +186,14 @@ vulkan_parameter_dtype = tvm.testing.parameter("int32", "float32", "int64")
 
 # Only run on vulkan because extremely large numbers of input
 # parameters can crash cuda/llvm compiler.
-@tvm.testing.parametrize_targets({"kind": "vulkan", "from_device": 0})
-def test_vulkan_constant_passing(target, dev, vulkan_parameter_impl, vulkan_parameter_dtype):
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not tvm.testing.device_enabled({"kind": "vulkan", "from_device": 0}),
+    reason="vulkan not enabled",
+)
+def test_vulkan_constant_passing(vulkan_parameter_impl, vulkan_parameter_dtype):
+    target = {"kind": "vulkan", "from_device": 0}
+    dev = tvm.device(target["kind"])
     target = tvm.target.Target(target)
     dtype = vulkan_parameter_dtype
 
@@ -209,8 +254,14 @@ def test_vulkan_constant_passing(target, dev, vulkan_parameter_impl, vulkan_para
     tvm.testing.assert_allclose(a.numpy() + sum(scalars), b.numpy())
 
 
-@tvm.testing.parametrize_targets({"kind": "vulkan", "from_device": 0})
-def test_vulkan_while_if(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not tvm.testing.device_enabled({"kind": "vulkan", "from_device": 0}),
+    reason="vulkan not enabled",
+)
+def test_vulkan_while_if():
+    target = {"kind": "vulkan", "from_device": 0}
+    dev = tvm.device(target["kind"])
     target = tvm.target.Target(target)
     n = 1
     dtype = "int32"
@@ -239,8 +290,14 @@ def test_vulkan_while_if(target, dev):
     tvm.testing.assert_allclose(b.numpy(), [210])
 
 
-@tvm.testing.parametrize_targets({"kind": "vulkan", "from_device": 0})
-def test_vulkan_local_threadidx(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not tvm.testing.device_enabled({"kind": "vulkan", "from_device": 0}),
+    reason="vulkan not enabled",
+)
+def test_vulkan_local_threadidx():
+    target = {"kind": "vulkan", "from_device": 0}
+    dev = tvm.device(target["kind"])
     target = tvm.target.Target(target)
     n = 32
 
@@ -266,9 +323,15 @@ def test_vulkan_local_threadidx(target, dev):
     tvm.testing.assert_allclose(b.numpy(), a_np)
 
 
-@tvm.testing.parametrize_targets({"kind": "vulkan", "from_device": 0})
-def test_vectorized_index_ramp(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not tvm.testing.device_enabled({"kind": "vulkan", "from_device": 0}),
+    reason="vulkan not enabled",
+)
+def test_vectorized_index_ramp():
     """Test vectorized copy with ramp indices (load N values, write to N locations)"""
+    target = {"kind": "vulkan", "from_device": 0}
+    dev = tvm.device(target["kind"])
     n = 4
     ramp_index = tvm.tirx.Ramp(0, 1, 4)
 
@@ -296,9 +359,15 @@ def test_vectorized_index_ramp(target, dev):
     tvm.testing.assert_allclose(b.numpy(), a_np)
 
 
-@tvm.testing.parametrize_targets({"kind": "vulkan", "from_device": 0})
-def test_vectorized_index_broadcast(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not tvm.testing.device_enabled({"kind": "vulkan", "from_device": 0}),
+    reason="vulkan not enabled",
+)
+def test_vectorized_index_broadcast():
     """Test broadcast index (load 1 value, write to N locations)"""
+    target = {"kind": "vulkan", "from_device": 0}
+    dev = tvm.device(target["kind"])
     n = 4
     broadcast_index = tvm.tirx.Broadcast(0, 4)
     ramp_index = tvm.tirx.Ramp(0, 1, 4)
@@ -329,8 +398,12 @@ def test_vectorized_index_broadcast(target, dev):
     tvm.testing.assert_allclose(b.numpy(), np.full(n, a_np[0]))
 
 
-@tvm.testing.parametrize_targets({"kind": "vulkan", "from_device": 0})
-def test_negative_operand_divmod(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not tvm.testing.device_enabled({"kind": "vulkan", "from_device": 0}),
+    reason="vulkan not enabled",
+)
+def test_negative_operand_divmod():
     """Test handling of negative offsets to floormod/floordiv
 
     Even though the SPIR-V spec states that OpSRem and OpSMod can give
@@ -343,6 +416,8 @@ def test_negative_operand_divmod(target, dev):
     SPIR-V: https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpSRem
     Vulkan: https://registry.khronos.org/vulkan/specs/1.3/html/chap37.html#spirvenv-op-prec
     """
+    target = {"kind": "vulkan", "from_device": 0}
+    dev = tvm.device(target["kind"])
 
     N = 32
     offset = 16

--- a/tests/python/nightly/test_nnapi/test_from_exported_to_cuda.py
+++ b/tests/python/nightly/test_nnapi/test_from_exported_to_cuda.py
@@ -17,6 +17,7 @@
 # ruff: noqa: E501, F401
 
 import numpy as np
+import pytest
 import torch
 from torch import nn
 from torch.export import export
@@ -66,8 +67,12 @@ def assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, tar
         tvm.testing.assert_allclose(actual=actual, desired=desired, rtol=1e-5, atol=1e-5)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_index_tensor(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_index_tensor():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class IndexModel0(nn.Module):
         def __init__(self):
             super().__init__()
@@ -168,8 +173,12 @@ def test_index_tensor(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_full(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_full():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class FullModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -182,8 +191,12 @@ def test_full(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_full_like(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_full_like():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class FullLike(nn.Module):
         def __init__(self):
             super().__init__()
@@ -197,8 +210,12 @@ def test_full_like(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_ones(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_ones():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class FullModel(nn.Module):
         def __init__(self):
             super().__init__()
@@ -211,8 +228,12 @@ def test_ones(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_sort(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_sort():
+    target = "cuda"
+    dev = tvm.device(target)
+
     raw_data = np.array([[4, 1, 13], [-30, 1, 3], [4, 0, 10]]).astype("float32")
 
     # Test values
@@ -236,8 +257,12 @@ def test_sort(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_tensor_clamp(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_tensor_clamp():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class ClampBothTensor(torch.nn.Module):
         def __init__(self):
             super().__init__()
@@ -317,8 +342,12 @@ def test_tensor_clamp(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module6, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_tensor_expand_as(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_tensor_expand_as():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class ExpandAs0(torch.nn.Module):
         def __init__(self):
             super().__init__()
@@ -364,8 +393,12 @@ def test_tensor_expand_as(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module3, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_copy_(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_copy_():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class CopyTester(nn.Module):
         def __init__(self, size):
             super().__init__()
@@ -382,12 +415,16 @@ def test_copy_(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_upsample_with_size(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_upsample_with_size():
     """
     The Upsample module can be used with the size arugment or the scale
     factor argument but not both. This tests the former.
     """
+    target = "cuda"
+    dev = tvm.device(target)
+
     batch_size = 1
     channels = 3
     height, width = 8, 8
@@ -399,8 +436,12 @@ def test_upsample_with_size(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_detach_no_change(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_detach_no_change():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # In TVM, detach() is just identity
     class DetachTester(nn.Module):
         def forward(self, x):
@@ -412,12 +453,16 @@ def test_detach_no_change(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_upsample_with_scale_factor(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_upsample_with_scale_factor():
     """
     The Upsample module can be used with the size arugment or the scale
     factor argument but not both. This tests the latter.
     """
+    target = "cuda"
+    dev = tvm.device(target)
+
     batch_size = 2
     channels = 3
     height, width = 32, 32
@@ -430,8 +475,12 @@ def test_upsample_with_scale_factor(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_linalg_vector_norm(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_linalg_vector_norm():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class VectorNorm0(torch.nn.Module):
         def forward(self, x):
             return torch.linalg.vector_norm(x, ord=1, dim=-1)
@@ -461,8 +510,12 @@ def test_linalg_vector_norm(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module3, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_batch_norm_prog(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_batch_norm_prog():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # Default args, in a pytorch program (to ensure output is in proper type and format)
     raw_data = np.random.randn(2, 3, 2, 2).astype(np.float32)
 
@@ -480,8 +533,12 @@ def test_batch_norm_prog(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_split_size(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_split_size():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # Test split using the split_size argument such that it is not a divisor
     # of the dimension to split (the last tensor will be smaller)
     batch = 2
@@ -504,8 +561,12 @@ def test_split_size(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_split_sections_list(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_split_sections_list():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # Test split using a list of section sizes
     batch = 3
     channels = 2
@@ -528,8 +589,12 @@ def test_split_sections_list(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_batch_norm0(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_batch_norm0():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # Eval, no momentum, no affine, no running stats
     raw_data = np.random.randn(8, 3, 4, 4).astype(np.float32)
     torch_module = nn.BatchNorm2d(
@@ -538,8 +603,12 @@ def test_batch_norm0(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_batch_norm1(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_batch_norm1():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # Eval, with momentum, no affine, with running stats
     raw_data = np.random.randn(1, 4, 2, 2).astype(np.float32)
     torch_module = nn.BatchNorm2d(
@@ -548,8 +617,12 @@ def test_batch_norm1(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_batch_norm2(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_batch_norm2():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # Eval, with momentum, affine, no running stats
     raw_data = np.random.randn(3, 4, 2, 2).astype(np.float32)
     torch_module = nn.BatchNorm2d(
@@ -558,8 +631,12 @@ def test_batch_norm2(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_batch_norm3(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_batch_norm3():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # Eval, no momentum, affine, with running stats
     raw_data = np.random.randn(1, 2, 2, 2).astype(np.float32)
     torch_module = nn.BatchNorm2d(
@@ -568,8 +645,12 @@ def test_batch_norm3(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_chunk_even(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_chunk_even():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # Chunks is a divisor of the dimension size
     batch = 6
     channels = 2
@@ -592,8 +673,12 @@ def test_chunk_even(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_chunk_uneven(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_chunk_uneven():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # Chunks is not a divisor of the dimension size
     batch = 2
     channels = 5
@@ -616,8 +701,12 @@ def test_chunk_uneven(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_chunk_too_many(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_chunk_too_many():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # If user asks for more chunks than the size of the dim, pytorch simply splits in sections of size 1
     batch = 1
     channels = 3
@@ -640,8 +729,12 @@ def test_chunk_too_many(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_arange(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_arange():
+    target = "cuda"
+    dev = tvm.device(target)
+
     # arange.default
     raw_data = np.array([0, 0, 0, 0, 0])
 
@@ -673,8 +766,12 @@ def test_arange(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_index_select(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_index_select():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class IndexSelectModel(nn.Module):
         def forward(self, x):
             indices = torch.tensor([0, 2])
@@ -685,8 +782,12 @@ def test_index_select(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_stack(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_stack():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class StackModel(nn.Module):
         def forward(self, x):
             val1 = x[1, 4]
@@ -700,8 +801,12 @@ def test_stack(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_sum(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_sum():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class SumModel(nn.Module):
         def forward(self, x):
             new_vec = x[1, 4]
@@ -712,8 +817,12 @@ def test_sum(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_mul(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_mul():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class MulModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -727,8 +836,12 @@ def test_mul(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_concat(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_concat():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class ConcatFour(nn.Module):
         def __init__(self, dim=0):
             super().__init__()
@@ -745,8 +858,12 @@ def test_concat(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_leakyrelu_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_leakyrelu_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class LeakyReLUModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -760,8 +877,12 @@ def test_leakyrelu_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_log_softmax_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_log_softmax_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class LogSoftmaxModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -775,8 +896,12 @@ def test_log_softmax_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_softmax_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_softmax_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class SoftmaxModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -790,8 +915,12 @@ def test_softmax_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_adaptive_avg_pool2d_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_adaptive_avg_pool2d_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class AdaptiveAvgPool2dModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -805,8 +934,12 @@ def test_adaptive_avg_pool2d_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_avg_pool2d_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_avg_pool2d_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class AvgPool2dModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -820,8 +953,12 @@ def test_avg_pool2d_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_conv1d_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_conv1d_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class Conv1dModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -835,8 +972,12 @@ def test_conv1d_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_conv2d_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_conv2d_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class Conv2dModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -850,8 +991,12 @@ def test_conv2d_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_conv3d_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_conv3d_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class Conv3dModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -865,8 +1010,12 @@ def test_conv3d_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_group_norm_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_group_norm_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class GroupNormModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -880,8 +1029,12 @@ def test_group_norm_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_layer_norm_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_layer_norm_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class LayerNormModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -895,8 +1048,12 @@ def test_layer_norm_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_linear_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_linear_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class LinearModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -910,8 +1067,12 @@ def test_linear_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_max_pool2d_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_max_pool2d_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class MaxPool2dModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -925,8 +1086,12 @@ def test_max_pool2d_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_embedding_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_embedding_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class EmbeddingModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -940,8 +1105,12 @@ def test_embedding_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_flatten_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_flatten_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class FlattenModule(nn.Module):
         def __init__(self):
             super().__init__()
@@ -955,8 +1124,12 @@ def test_flatten_module(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_numel(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_numel():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class NumelModule(nn.Module):
         def forward(self, x):
             return torch.tensor(x.numel())
@@ -966,8 +1139,12 @@ def test_numel(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_size(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_size():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class SizeModule(nn.Module):
         def forward(self, x):
             return torch.tensor(x.size(0))
@@ -977,8 +1154,12 @@ def test_size(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_tensor(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_tensor():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class TensorModule(nn.Module):
         def forward(self, x):
             return torch.tensor([1, 2, 3])
@@ -988,8 +1169,12 @@ def test_tensor(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_type(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_type():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class TypeModule(nn.Module):
         def forward(self, x):
             return x.type(torch.float16)
@@ -999,8 +1184,12 @@ def test_type(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_float(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_float():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class FloatModule(nn.Module):
         def forward(self, x):
             return x.float()
@@ -1010,8 +1199,12 @@ def test_float(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_half(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_half():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class HalfModule(nn.Module):
         def forward(self, x):
             return x.half()
@@ -1021,8 +1214,12 @@ def test_half(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_getattr(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_getattr():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class GetAttrModule(nn.Module):
         def forward(self, x):
             # Use getattr to call the ndimension method.
@@ -1033,8 +1230,12 @@ def test_getattr(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_sym_size_int(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_sym_size_int():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class SymSizeIntModule(nn.Module):
         def forward(self, x):
             return torch.tensor(x.shape[1])
@@ -1044,8 +1245,12 @@ def test_sym_size_int(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_interpolate(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_interpolate():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class InterpolateModule(nn.Module):
         def forward(self, x):
             # Upsample to a fixed size.
@@ -1056,8 +1261,12 @@ def test_interpolate(target, dev):
     assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, target, dev)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_cross_entropy_module(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_cross_entropy_module():
+    target = "cuda"
+    dev = tvm.device(target)
+
     class CrossEntropyModule(nn.Module):
         def __init__(self):
             super().__init__()

--- a/tests/python/relax/backend/adreno/test_texture_network.py
+++ b/tests/python/relax/backend/adreno/test_texture_network.py
@@ -41,8 +41,11 @@ from tvm.script.ir_builder import relax as relax_builder
 TARGETS = [tvm.target.Target("qcom/adreno-opencl-texture")]
 
 
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_network_resnet(target):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_network_resnet():
+    target = TARGETS[0]
+
     @I.ir_module
     class Resnet:
         @R.function

--- a/tests/python/relax/backend/adreno/test_texture_ops.py
+++ b/tests/python/relax/backend/adreno/test_texture_ops.py
@@ -32,8 +32,10 @@ ref_target = tvm.target.Target("llvm")
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -50,8 +52,10 @@ def test_conv2d(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_relu(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_relu():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -69,8 +73,10 @@ def test_conv2d_relu(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_relu_conv2d_relu(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_relu_conv2d_relu():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -89,8 +95,10 @@ def test_relu_conv2d_relu(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_relu_tanh(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_relu_tanh():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -109,8 +117,10 @@ def test_conv2d_relu_tanh(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_add(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_add():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -130,8 +140,10 @@ def test_conv2d_add(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_sum(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_sum():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -149,8 +161,10 @@ def test_conv2d_sum(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_sum_keepdims(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_sum_keepdims():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -168,8 +182,10 @@ def test_conv2d_sum_keepdims(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_sum_reduce(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_sum_reduce():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -187,8 +203,10 @@ def test_conv2d_sum_reduce(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_transpose(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_transpose():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -206,8 +224,10 @@ def test_conv2d_transpose(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_expand_dims(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_expand_dims():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -225,8 +245,10 @@ def test_conv2d_expand_dims(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_squeeze(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_squeeze():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -244,8 +266,10 @@ def test_conv2d_squeeze(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_strided_slice(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_strided_slice():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -265,8 +289,10 @@ def test_conv2d_strided_slice(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_relu_concat(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_relu_concat():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -285,8 +311,10 @@ def test_conv2d_relu_concat(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_relu_concat_split(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_relu_concat_split():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -306,8 +334,10 @@ def test_conv2d_relu_concat_split(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_relu_concat_split_transpose_concat(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_relu_concat_split_transpose_concat():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -329,8 +359,10 @@ def test_conv2d_relu_concat_split_transpose_concat(target):
 @pytest.mark.skip(reason="Known failure: numerical mismatch in texture lowering")
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_maxpool2d(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_maxpool2d():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -356,8 +388,10 @@ def test_conv2d_maxpool2d(target):
 @pytest.mark.skip(reason="Known failure: numerical mismatch in texture lowering")
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_avgpool2d(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_avgpool2d():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -375,8 +409,10 @@ def test_conv2d_avgpool2d(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_softmax(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_softmax():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -394,8 +430,10 @@ def test_conv2d_softmax(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_layernorm(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_layernorm():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -418,8 +456,10 @@ def test_conv2d_layernorm(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_binary_broadcast(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_binary_broadcast():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -439,8 +479,10 @@ def test_binary_broadcast(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_binary_ewise_scalar(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_binary_ewise_scalar():
+    target = TARGETS[0]
+
     @I.ir_module
     class Input:
         @R.function
@@ -458,8 +500,9 @@ def test_binary_ewise_scalar(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_residual_block(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_residual_block():
+    target = TARGETS[0]
     r"""
     - some kind of residual block followed by convolution to have texture after residual block
     - scalar data type verification which should be mapped to global memory scope
@@ -507,8 +550,9 @@ def test_residual_block(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_conv2d_fallback_to_buffer_conv2d(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_conv2d_fallback_to_buffer_conv2d():
+    target = TARGETS[0]
     r"""
         layout_transform (NCHW->NCHW4c)
                   |                      <- texture
@@ -547,8 +591,9 @@ def test_conv2d_conv2d_fallback_to_buffer_conv2d(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_conv2d_conv2d_conv2d_concat(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_conv2d_conv2d_conv2d_concat():
+    target = TARGETS[0]
     r"""
         layout_transform (NCHW->NCHW4c)
                   |                      <- texture
@@ -588,8 +633,9 @@ def test_conv2d_conv2d_conv2d_concat(target):
 @pytest.mark.skip(reason="Known failure: numerical mismatch in texture lowering")
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_pooling_branching_texture_params(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_pooling_branching_texture_params():
+    target = TARGETS[0]
     r"""
     Verification of the pooling and many branches having textures
                 layout_transform (NCHW->NCHW4c)
@@ -640,8 +686,9 @@ def test_pooling_branching_texture_params(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_injective_inputs1(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_injective_inputs1():
+    target = TARGETS[0]
     r"""
                                      Input
                                /                   \
@@ -690,8 +737,9 @@ def test_injective_inputs1(target):
 
 @pytest.mark.gpu
 @skip_unless_adreno_opencl_vulkan
-@tvm.testing.parametrize_targets(*TARGETS)
-def test_injective_nwo_inputs2(target):
+@pytest.mark.skipif(not tvm.testing.device_enabled(TARGETS[0]), reason="opencl not enabled")
+def test_injective_nwo_inputs2():
+    target = TARGETS[0]
     r"""
                                      Input
                                /             \

--- a/tests/python/relax/test_backend_dispatch_sort_scan.py
+++ b/tests/python/relax/test_backend_dispatch_sort_scan.py
@@ -410,9 +410,18 @@ def test_dispatch_topk_gpu():
     assert_structural_equal(mod, expected_mod)
 
 
-@tvm.testing.parametrize_targets("cuda", {"kind": "vulkan", "supports_int64": True})
-def test_dispatch_cumsum_gpu(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("cuda", marks=pytest.mark.gpu),
+        pytest.param({"kind": "vulkan", "supports_int64": True}, marks=pytest.mark.gpu),
+    ],
+)
+def test_dispatch_cumsum_gpu(target):
     """Test cumsum kernel dispatch and numerical correctness"""
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target["kind"] if isinstance(target, dict) else target)
 
     @I.ir_module
     class Module:

--- a/tests/python/relax/test_frontend_nn_llm_sequence_prefill_masked.py
+++ b/tests/python/relax/test_frontend_nn_llm_sequence_prefill_masked.py
@@ -186,9 +186,15 @@ def _run_case(
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_valid_len_zero(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [pytest.param("cuda", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
+)
+def test_valid_len_zero(target):
     """All samples are fully padded: kernel must not crash and must stay bounded."""
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     _run_case(
         target=target,
         dev=dev,
@@ -203,9 +209,15 @@ def test_valid_len_zero(target, dev):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_valid_len_full(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [pytest.param("cuda", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
+)
+def test_valid_len_full(target):
     """All samples are fully valid: must match a plain unmasked attention."""
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     _run_case(
         target=target,
         dev=dev,
@@ -220,9 +232,15 @@ def test_valid_len_full(target, dev):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_valid_len_mixed(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [pytest.param("cuda", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
+)
+def test_valid_len_mixed(target):
     """Typical encoder batch with different valid lengths per sample."""
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     _run_case(
         target=target,
         dev=dev,
@@ -237,9 +255,15 @@ def test_valid_len_mixed(target, dev):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_valid_len_mixed_gqa(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [pytest.param("cuda", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
+)
+def test_valid_len_mixed_gqa(target):
     """Grouped-query attention: ``group_size = h_q / h_kv > 1``."""
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     _run_case(
         target=target,
         dev=dev,
@@ -254,9 +278,15 @@ def test_valid_len_mixed_gqa(target, dev):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_causal_padded_left_valid_len_zero(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [pytest.param("cuda", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
+)
+def test_causal_padded_left_valid_len_zero(target):
     """Causal left-pad: all samples are fully padded."""
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     _run_case(
         target=target,
         dev=dev,
@@ -272,9 +302,15 @@ def test_causal_padded_left_valid_len_zero(target, dev):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_causal_padded_left_valid_len_full(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [pytest.param("cuda", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
+)
+def test_causal_padded_left_valid_len_full(target):
     """Causal left-pad: all samples are fully valid — degenerates to plain causal attention."""
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     _run_case(
         target=target,
         dev=dev,
@@ -290,9 +326,15 @@ def test_causal_padded_left_valid_len_full(target, dev):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_causal_padded_left_valid_len_mixed(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [pytest.param("cuda", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
+)
+def test_causal_padded_left_valid_len_mixed(target):
     """Causal left-pad: typical decoder-embedding batch with mixed lengths."""
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     _run_case(
         target=target,
         dev=dev,
@@ -308,9 +350,15 @@ def test_causal_padded_left_valid_len_mixed(target, dev):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_causal_padded_left_valid_len_mixed_gqa(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [pytest.param("cuda", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
+)
+def test_causal_padded_left_valid_len_mixed_gqa(target):
     """Causal left-pad: grouped-query attention with mixed lengths."""
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     _run_case(
         target=target,
         dev=dev,
@@ -326,9 +374,15 @@ def test_causal_padded_left_valid_len_mixed_gqa(target, dev):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
-@tvm.testing.parametrize_targets("cuda", "metal")
-def test_causal_padded_left_qo_len_differs_from_kv_len(target, dev):
+@pytest.mark.parametrize(
+    "target",
+    [pytest.param("cuda", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
+)
+def test_causal_padded_left_qo_len_differs_from_kv_len(target):
     """Causal left-pad: Q and K/V may have different padded lengths."""
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
     _run_case(
         target=target,
         dev=dev,

--- a/tests/python/relax/test_op_gradient_numeric.py
+++ b/tests/python/relax/test_op_gradient_numeric.py
@@ -221,8 +221,10 @@ def relax_check_gradients(
         (relax.op.tanh, True),
     ],
 )
-@tvm.testing.parametrize_targets("llvm")
-def test_unary(target, dev, unary_op_func, can_be_neg):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_unary(unary_op_func, can_be_neg):
+    target = "llvm"
+    dev = tvm.device(target)
     (low, high) = (-1, 1) if can_be_neg else (0.1, 1)
     data_numpy = np.random.uniform(low, high, (3, 3)).astype(np.float32)
     relax_check_gradients(unary_op_func, [data_numpy], target, dev)
@@ -241,16 +243,20 @@ def test_unary(target, dev, unary_op_func, can_be_neg):
         relax.op.power,
     ],
 )
-@tvm.testing.parametrize_targets("llvm")
-def test_binary_arith(target, dev, binary_arith_op_func):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_binary_arith(binary_arith_op_func):
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
     data2_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
     relax_check_gradients(binary_arith_op_func, [data1_numpy, data2_numpy], target, dev)
 
 
 @pytest.mark.parametrize("binary_minmax_op_func", [relax.op.maximum, relax.op.minimum])
-@tvm.testing.parametrize_targets("llvm")
-def test_binary_minmax(target, dev, binary_minmax_op_func):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_binary_minmax(binary_minmax_op_func):
+    target = "llvm"
+    dev = tvm.device(target)
     # Checking numerical gradient of min and max requires data1_numpy[i] != data2_numpy[i]
     # for all possible i.
     # If data1_numpy[i] == data2_numpy[i], the operator is not differentiable w.r.t. place i
@@ -272,8 +278,10 @@ def test_binary_minmax(target, dev, binary_minmax_op_func):
         relax.op.not_equal,
     ],
 )
-@tvm.testing.parametrize_targets("llvm")
-def test_binary_cmp(target, dev, binary_cmp_op_func):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_binary_cmp(binary_cmp_op_func):
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
     data2_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
     relax_check_gradients(
@@ -285,14 +293,18 @@ def test_binary_cmp(target, dev, binary_cmp_op_func):
 
 
 @pytest.mark.parametrize("like_op_func", [relax.op.zeros_like, relax.op.ones_like])
-@tvm.testing.parametrize_targets("llvm")
-def test_ones_zeros_like(target, dev, like_op_func):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_ones_zeros_like(like_op_func):
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(-1, 1, (3, 3)).astype(np.float32)
     relax_check_gradients(like_op_func, [data_numpy], target, dev, ignore_grads=[0])
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_full_like(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_full_like():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(-1, 1, (3, 3)).astype(np.float32)
     fill_value = np.random.uniform(-1, 1, ()).astype(np.float32)
     relax_check_gradients(
@@ -301,15 +313,19 @@ def test_full_like(target, dev):
 
 
 @pytest.mark.parametrize("create_op_func", [relax.op.zeros, relax.op.ones])
-@tvm.testing.parametrize_targets("llvm")
-def test_ones_zeros(target, dev, create_op_func):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_ones_zeros(create_op_func):
+    target = "llvm"
+    dev = tvm.device(target)
     relax_check_gradients(
         create_op_func, [], target, dev, ignore_grads=[0], shape=(3, 3), dtype="float32"
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_triu(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_triu():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(-1, 1, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.triu, [data_numpy], target, dev, k=0)
 
@@ -317,56 +333,74 @@ def test_triu(target, dev):
 ##################### Statistical #####################
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_sum(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_sum():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.sum, [data1_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_sum_with_axis(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_sum_with_axis():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
     relax_check_gradients(relax.op.sum, [data1_numpy], target, dev, axis=[1, 3])
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_sum_keepdims(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_sum_keepdims():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.sum, [data1_numpy], target, dev, keepdims=True, axis=1)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_mean(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_mean():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.mean, [data1_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_mean_with_axis(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_mean_with_axis():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
     relax_check_gradients(relax.op.mean, [data1_numpy], target, dev, axis=[1, 3])
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_mean_keepdims(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_mean_keepdims():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.mean, [data1_numpy], target, dev, keepdims=True, axis=1)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_variance(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_variance():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.variance, [data1_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_variance_with_axis(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_variance_with_axis():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
     relax_check_gradients(relax.op.variance, [data1_numpy], target, dev, axis=[1, 3])
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_variance_keepdims(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_variance_keepdims():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.variance, [data1_numpy], target, dev, keepdims=True, axis=1)
 
@@ -374,30 +408,38 @@ def test_variance_keepdims(target, dev):
 ##################### Manipulate #####################
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_reshape(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_reshape():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(0, 16, (2, 3, 5)).astype(np.float32)
     relax_check_gradients(
         relax.op.reshape, [data_numpy], target, dev, ignore_grads=[1], shape=(5, 6)
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_reshape_infer_dim(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_reshape_infer_dim():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(0, 16, (2, 3, 5)).astype(np.float32)
     relax_check_gradients(
         relax.op.reshape, [data_numpy], target, dev, ignore_grads=[1], shape=(5, 2, 1, -1)
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_permute_dims(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_permute_dims():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
     relax_check_gradients(relax.op.permute_dims, [data_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_permute_dims_with_axes(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_permute_dims_with_axes():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
     relax_check_gradients(
         relax.op.permute_dims,
@@ -408,8 +450,10 @@ def test_permute_dims_with_axes(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_concat(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_concat():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy1 = np.random.uniform(1, 16, (3, 3)).astype(np.float32)
     data_numpy2 = np.random.uniform(1, 16, (3, 4)).astype(np.float32)
     data_numpy3 = np.random.uniform(1, 16, (3, 5)).astype(np.float32)
@@ -423,8 +467,10 @@ def test_concat(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_split_indices(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_split_indices():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(1, 16, (3, 12)).astype(np.float32)
     relax_check_gradients(
         relax.op.split,
@@ -436,8 +482,10 @@ def test_split_indices(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_split_section(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_split_section():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(1, 16, (3, 12)).astype(np.float32)
     relax_check_gradients(
         relax.op.split,
@@ -449,8 +497,10 @@ def test_split_section(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_reshape(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_reshape():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(1, 16, (3, 4)).astype(np.float32)
 
     relax_check_gradients(
@@ -463,8 +513,10 @@ def test_reshape(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_cumsum(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_cumsum():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy1 = np.random.uniform(1, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(
         relax.op.cumsum,
@@ -475,8 +527,10 @@ def test_cumsum(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_cumsum_no_axis(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_cumsum_no_axis():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy1 = np.random.uniform(1, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(
         relax.op.cumsum,
@@ -486,20 +540,26 @@ def test_cumsum_no_axis(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_expand_dims(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_expand_dims():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(1, 16, (3, 12)).astype(np.float32)
     relax_check_gradients(relax.op.expand_dims, [data_numpy], target, dev, axis=1)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_expand_dims_list(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_expand_dims_list():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(1, 16, (3, 12)).astype(np.float32)
     relax_check_gradients(relax.op.expand_dims, [data_numpy], target, dev, axis=(0, 2, 3))
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_broadcast_to(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_broadcast_to():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(1, 16, (3, 4)).astype(np.float32)
     relax_check_gradients(
         relax.op.broadcast_to,
@@ -514,8 +574,10 @@ def test_broadcast_to(target, dev):
 ##################### Index #####################
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_take(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_take():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(0, 16, size=(2, 3, 4)).astype(np.float32)
     indices = np.array([0, 1])
     relax_check_gradients(
@@ -528,8 +590,10 @@ def test_take(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_take_no_axis(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_take_no_axis():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(0, 16, size=(5,)).astype(np.float32)
     indices = np.array([1, 3])
     relax_check_gradients(
@@ -544,8 +608,10 @@ def test_take_no_axis(target, dev):
 ##################### Search #####################
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_where(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_where():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 1, size=(3, 3)) > 0.5
     data2_numpy = np.random.uniform(0, 16, size=(3, 3)).astype(np.float32)
     data3_numpy = np.random.uniform(0, 16, size=(3, 3)).astype(np.float32)
@@ -562,36 +628,46 @@ def test_where(target, dev):
 ##################### Linear Algebra #####################
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_matmul_2_2(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_matmul_2_2():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (2, 3)).astype(np.float32)
     data2_numpy = np.random.uniform(0, 16, (3, 4)).astype(np.float32)
     relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_matmul_1_1(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_matmul_1_1():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (4,)).astype(np.float32)
     data2_numpy = np.random.uniform(0, 16, (4,)).astype(np.float32)
     relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_matmul_1_4(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_matmul_1_4():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (4,)).astype(np.float32)
     data2_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
     relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_matmul_4_1(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_matmul_4_1():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
     data2_numpy = np.random.uniform(0, 16, (5,)).astype(np.float32)
     relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_matmul_5_4(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_matmul_5_4():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (2, 3, 1, 4, 5)).astype(np.float32)
     data2_numpy = np.random.uniform(0, 16, (3, 2, 5, 4)).astype(np.float32)
     relax_check_gradients(
@@ -605,8 +681,10 @@ def test_matmul_5_4(target, dev):
 ##################### Datatype #####################
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_astype(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_astype():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(0, 16, size=(3, 3)).astype(np.float64)
     relax_check_gradients(relax.op.astype, [data_numpy], target, dev, dtype="float32")
 
@@ -614,46 +692,60 @@ def test_astype(target, dev):
 ##################### Neural network #####################
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_relu(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_relu():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0.2, 1, (3, 3)).astype(np.float32)
     sign = np.random.randint(0, 2, (3, 3)).astype(np.float32) * 2 - 1
     data1_numpy *= sign
     relax_check_gradients(relax.op.nn.relu, [data1_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_silu(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_silu():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.nn.silu, [data1_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_softmax(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_softmax():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.nn.softmax, [data1_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_softmax_with_axis(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_softmax_with_axis():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.nn.softmax, [data1_numpy], target, dev, axis=1)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_log_softmax(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_log_softmax():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.nn.log_softmax, [data1_numpy], target, dev)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_log_softmax_with_axis(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_log_softmax_with_axis():
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(relax.op.nn.log_softmax, [data1_numpy], target, dev, axis=1)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_cross_entropy_with_logits(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_cross_entropy_with_logits():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy1 = np.random.uniform(1, 16, (3,)).astype(np.float32)
     data_numpy2 = np.random.uniform(1, 16, (3,)).astype(np.float32)
     relax_check_gradients(
@@ -664,8 +756,10 @@ def test_cross_entropy_with_logits(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_cross_entropy_with_logits_batch(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_cross_entropy_with_logits_batch():
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy1 = np.random.uniform(1, 16, (2, 3)).astype(np.float32)
     data_numpy2 = np.random.uniform(1, 16, (2, 3)).astype(np.float32)
     relax_check_gradients(
@@ -687,8 +781,10 @@ def test_cross_entropy_with_logits_batch(target, dev):
         ("mean", False, 1),
     ],
 )
-@tvm.testing.parametrize_targets("llvm")
-def test_nll_loss(target, dev, nll_reduction, nll_weighted, nll_ignore_index):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_nll_loss(nll_reduction, nll_weighted, nll_ignore_index):
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (2, 3, 4)).astype(np.float32)
     data2_numpy = np.random.randint(0, 3, (2, 4)).astype(np.int64)
     # force a position in targets it not ignore_index, to avoid zero total weight
@@ -718,8 +814,10 @@ def test_nll_loss(target, dev, nll_reduction, nll_weighted, nll_ignore_index):
         ("none", True, -1),
     ],
 )
-@tvm.testing.parametrize_targets("llvm")
-def test_nll_loss_no_batch(target, dev, nll_reduction1, nll_weighted1, nll_ignore_index1):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_nll_loss_no_batch(nll_reduction1, nll_weighted1, nll_ignore_index1):
+    target = "llvm"
+    dev = tvm.device(target)
     data1_numpy = np.random.uniform(0, 16, (3,)).astype(np.float32)
     data2_numpy = np.random.randint(0, 3, ()).astype(np.int64)
     # weight > 0
@@ -774,8 +872,10 @@ def test_nll_loss_no_batch(target, dev, nll_reduction1, nll_weighted1, nll_ignor
         ),
     ],
 )
-@tvm.testing.parametrize_targets("llvm")
-def test_conv2d(target, dev, c2d_shape1, c2d_shape2, c2d_kwargs):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_conv2d(c2d_shape1, c2d_shape2, c2d_kwargs):
+    target = "llvm"
+    dev = tvm.device(target)
     import pytest
 
     # Use smaller range to reduce numerical errors in gradient check
@@ -813,8 +913,10 @@ pool_params = [
 
 
 @pytest.mark.parametrize("pool_size,pool_kwargs", pool_params)
-@tvm.testing.parametrize_targets("llvm")
-def test_max_pool2d(target, dev, pool_size, pool_kwargs):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_max_pool2d(pool_size, pool_kwargs):
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(0, 3, size=(3, 2, 10, 10)).astype(np.float32)
     relax_check_gradients(
         relax.op.nn.max_pool2d,
@@ -827,8 +929,10 @@ def test_max_pool2d(target, dev, pool_size, pool_kwargs):
 
 
 @pytest.mark.parametrize("pool_size,pool_kwargs", pool_params)
-@tvm.testing.parametrize_targets("llvm")
-def test_avg_pool2d(target, dev, pool_size, pool_kwargs):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_avg_pool2d(pool_size, pool_kwargs):
+    target = "llvm"
+    dev = tvm.device(target)
     data_numpy = np.random.uniform(0, 3, size=(3, 2, 10, 10)).astype(np.float32)
     relax_check_gradients(
         relax.op.nn.avg_pool2d,

--- a/tests/python/relax/test_op_take.py
+++ b/tests/python/relax/test_op_take.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import numpy as np
+import pytest
 
 import tvm
 import tvm.testing
@@ -26,14 +27,16 @@ from tvm.script import tirx as T
 axis = tvm.testing.parameter(0, 1)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_take_scalar_tensor_as_index(target, dev, axis):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_take_scalar_tensor_as_index(axis):
     """The index of R.take may be a scalar tensor
 
     Using a scalar tensor as the index reduces the dimension of the
     output.
 
     """
+    target = "llvm"
+    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -53,13 +56,15 @@ def test_take_scalar_tensor_as_index(target, dev, axis):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_take_1d_tensor_as_index(target, dev, axis):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_take_1d_tensor_as_index(axis):
     """The index of R.take may be a non-scalar tensor
 
     In general, `R.take` outputs a tensor of dimension
     `data.ndim + indices.ndim - 1`.
     """
+    target = "llvm"
+    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -79,9 +84,11 @@ def test_take_1d_tensor_as_index(target, dev, axis):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_take_2d_tensor_as_index(target, dev, axis):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_take_2d_tensor_as_index(axis):
     """The index of R.take may be a 2-d tensor"""
+    target = "llvm"
+    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -101,14 +108,16 @@ def test_take_2d_tensor_as_index(target, dev, axis):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_take_constant_prim_value_as_index(target, dev, axis):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_take_constant_prim_value_as_index(axis):
     """The index of R.take may be a R.prim_value
 
     The `R.prim_value` produces output equivalent to a scalar
     tensor.
 
     """
+    target = "llvm"
+    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -128,14 +137,16 @@ def test_take_constant_prim_value_as_index(target, dev, axis):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_take_dynamic_prim_value_as_index(target, dev, axis):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_take_dynamic_prim_value_as_index(axis):
     """The index of R.take may be a dynamic R.prim_value
 
     The `R.prim_value` produces output equivalent to a scalar
     tensor.
 
     """
+    target = "llvm"
+    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -156,11 +167,13 @@ def test_take_dynamic_prim_value_as_index(target, dev, axis):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_take_nan_mode_OOB_indices(target, dev, axis):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_take_nan_mode_OOB_indices(axis):
     """Test R.take with mode="nan" and out-of-bounds indices.
     This test checks that out-of-bounds indices produce NaN values in the output tensor.
     """
+    target = "llvm"
+    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -189,11 +202,13 @@ def test_take_nan_mode_OOB_indices(target, dev, axis):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_take_wrap_mode_OOB_indices(target, dev, axis):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_take_wrap_mode_OOB_indices(axis):
     """Test R.take with mode="wrap" and out-of-bounds indices.
     This test checks that out-of-bounds indices wrap around to the valid range.
     """
+    target = "llvm"
+    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -213,11 +228,13 @@ def test_take_wrap_mode_OOB_indices(target, dev, axis):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_take_clip_mode_OOB_indices(target, dev, axis):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_take_clip_mode_OOB_indices(axis):
     """Test R.take with mode="clip" and out-of-bounds indices.
     This test checks that out-of-bounds indices are clipped to the valid range.
     """
+    target = "llvm"
+    dev = tvm.device(target)
 
     @I.ir_module
     class Module:

--- a/tests/python/relax/test_op_view.py
+++ b/tests/python/relax/test_op_view.py
@@ -653,8 +653,12 @@ def test_lower_runtime_builtin_view_with_multiple_updated_fields():
     tvm.ir.assert_structural_equal(Expected, After)
 
 
-@tvm.testing.parametrize_targets("llvm", "cuda")
-def test_execute_no_op_view(target, dev):
+@pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
+def test_execute_no_op_view(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
+
     @I.ir_module
     class Module:
         @R.function
@@ -673,8 +677,12 @@ def test_execute_no_op_view(target, dev):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm", "cuda")
-def test_execute_view_with_new_shape(target, dev):
+@pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
+def test_execute_view_with_new_shape(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
+
     @I.ir_module
     class Module:
         @R.function
@@ -693,8 +701,12 @@ def test_execute_view_with_new_shape(target, dev):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm", "cuda")
-def test_execute_view_with_new_byte_offset(target, dev):
+@pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
+def test_execute_view_with_new_byte_offset(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
+
     @I.ir_module
     class Module:
         @R.function
@@ -717,8 +729,12 @@ def test_execute_view_with_new_byte_offset(target, dev):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm", "cuda")
-def test_execute_view_with_new_dtype(target, dev):
+@pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
+def test_execute_view_with_new_dtype(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
+
     @I.ir_module
     class Module:
         @R.function
@@ -737,8 +753,12 @@ def test_execute_view_with_new_dtype(target, dev):
     tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
 
-@tvm.testing.parametrize_targets("llvm", "cuda")
-def test_execute_view_with_multiple_updated_fields(target, dev):
+@pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
+def test_execute_view_with_multiple_updated_fields(target):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target)
+
     @I.ir_module
     class Module:
         @R.function

--- a/tests/python/relax/test_training_optimizer_numeric.py
+++ b/tests/python/relax/test_training_optimizer_numeric.py
@@ -65,7 +65,6 @@ def _assert_run_result_same(tvm_func: Callable, np_func: Callable, np_inputs: li
     _assert_allclose_nested(result, expected)
 
 
-@tvm.testing.parametrize_targets("llvm")
 def _test_optimizer(target, dev, np_func, opt_type, *args, **kwargs):
     x = relax.Var("x", R.Tensor((3, 3), "float32"))
     y = relax.Var("y", R.Tensor((3,), "float32"))
@@ -87,8 +86,11 @@ def _test_optimizer(target, dev, np_func, opt_type, *args, **kwargs):
         (0.01, 0.02),
     ],
 )
-@tvm.testing.parametrize_targets("llvm")
-def test_sgd(target, dev, lr, weight_decay):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_sgd(lr, weight_decay):
+    target = "llvm"
+    dev = tvm.device(target)
+
     def np_func(param_tuple, grad_tuple, state_tuple):
         num_steps = state_tuple[0]
         param_tuple_new, state_tuple_new = [], []
@@ -110,8 +112,11 @@ def test_sgd(target, dev, lr, weight_decay):
         (0.01, 0.9, 0.85, 0.02, True),
     ],
 )
-@tvm.testing.parametrize_targets("llvm")
-def test_momentum_sgd(target, dev, lr, momentum, dampening, weight_decay, nesterov):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_momentum_sgd(lr, momentum, dampening, weight_decay, nesterov):
+    target = "llvm"
+    dev = tvm.device(target)
+
     def np_func(param_tuple, grad_tuple, state_tuple):
         num_steps = state_tuple[0]
         param_tuple_new, state_tuple_new = [], []
@@ -144,8 +149,11 @@ def test_momentum_sgd(target, dev, lr, momentum, dampening, weight_decay, nester
         (0.01, (0.8, 0.85), 1e-07, 0.1),
     ],
 )
-@tvm.testing.parametrize_targets("llvm")
-def test_adam(target, dev, lr, betas, eps, weight_decay):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_adam(lr, betas, eps, weight_decay):
+    target = "llvm"
+    dev = tvm.device(target)
+
     def np_func(param_tuple, grad_tuple, state_tuple):
         num_steps = state_tuple[0]
         num_steps_new = num_steps + 1

--- a/tests/python/relax/test_training_trainer_numeric.py
+++ b/tests/python/relax/test_training_trainer_numeric.py
@@ -53,8 +53,10 @@ def _make_dataset():
     return [[np.ones((1, 10)).astype(np.float32), np.array([[0, 0, 1, 0, 0]], np.float32)]] * N
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_execute(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_execute():
+    target = "llvm"
+    dev = tvm.device(target)
     backbone = _get_backbone()
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
 
@@ -77,8 +79,10 @@ def test_execute(target, dev):
     trainer.update(dataset[0][0], dataset[0][1])
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_execute_numeric(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_execute_numeric():
+    target = "llvm"
+    dev = tvm.device(target)
     backbone = _get_backbone()
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
 
@@ -106,8 +110,10 @@ def test_execute_numeric(target, dev):
     tvm.testing.assert_allclose(result.numpy(), result_expected)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_load_export_params(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_load_export_params():
+    target = "llvm"
+    dev = tvm.device(target)
     backbone = _get_backbone()
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
 
@@ -141,8 +147,10 @@ def test_load_export_params(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_setting_error(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_setting_error():
+    target = "llvm"
+    dev = tvm.device(target)
     backbone = _get_backbone()
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
 

--- a/tests/python/relax/test_transform_gradient_numeric.py
+++ b/tests/python/relax/test_transform_gradient_numeric.py
@@ -16,6 +16,7 @@
 # under the License.
 # ruff: noqa: E741
 import numpy as np
+import pytest
 
 import tvm
 import tvm.testing
@@ -36,8 +37,11 @@ def _legalize_and_build(mod, target, dev):
     return vm
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_manual_gradient(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_manual_gradient():
+    target = "llvm"
+    dev = tvm.device(target)
+
     # The expression computed is sum((2x - 2y) * (y + z))
     # the gradient of x is broadcast_to(2y + 2z, x.shape)
     # the gradient of y is collapse_sum_to((2x - 4y - 2z), y.shape)
@@ -82,8 +86,10 @@ def test_manual_gradient(target, dev):
         assert_allclose(i.numpy(), j, atol=1e-4)
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_mlp_blockbuilder(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_mlp_blockbuilder():
+    target = "llvm"
+    dev = tvm.device(target)
     layers, in_size, out_size, hidden_size, batch_size = 3, 5, 5, 5, 4
 
     input_list = [relax.Var("x", R.Tensor((batch_size, in_size), "float32"))]
@@ -138,8 +144,10 @@ def test_mlp_blockbuilder(target, dev):
     check_numerical_grads(func, [i.numpy() for i in args[1:-1]], [i.numpy() for i in grad])
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_complex(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_complex():
+    target = "llvm"
+    dev = tvm.device(target)
     cst = relax.const(np.ones((6,)), dtype="float32")
     cst1 = relax.const(np.array(3), dtype="int64")
 
@@ -194,8 +202,11 @@ def test_complex(target, dev):
     check_numerical_grads(func, [i.numpy() for i in args], [i.numpy() for i in grad])
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_matmul(target, dev):
+@pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
+def test_matmul():
+    target = "llvm"
+    dev = tvm.device(target)
+
     @tvm.script.ir_module
     class Before:
         @R.function

--- a/tests/python/relax/test_transform_legalize_ops_manipulate.py
+++ b/tests/python/relax/test_transform_legalize_ops_manipulate.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 # ruff: noqa: E501, E731, F841
+import pytest
+
 import tvm
 import tvm.testing
 from tvm import relax
@@ -1551,9 +1553,11 @@ def test_scatter_elements_symbolic():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_scatter_elements_gpu(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_scatter_elements_gpu():
     """scatter_elements lowered for GPU must build"""
+    target = "cuda"
 
     @I.ir_module(s_tir=True)
     class Mod:
@@ -1861,9 +1865,11 @@ def test_scatter_nd():
     tvm.ir.assert_structural_equal(After, Expected)
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_scatter_nd_gpu(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_scatter_nd_gpu():
     """scatter_nd lowered for GPU must build"""
+    target = "cuda"
 
     @I.ir_module(s_tir=True)
     class Mod:

--- a/tests/python/relax/test_vm_builtin.py
+++ b/tests/python/relax/test_vm_builtin.py
@@ -54,8 +54,9 @@ def test_multinomial_from_uniform():
     tvm.testing.assert_allclose(res.numpy(), np.array([[4], [0], [4]]).astype(np.int64))
 
 
-@tvm.testing.parametrize_targets("cuda")
-def test_alloc_tensor_raises_out_of_memory(target, dev):
+@pytest.mark.gpu
+@pytest.mark.skipif(not tvm.testing.device_enabled("cuda"), reason="cuda not enabled")
+def test_alloc_tensor_raises_out_of_memory():
     """Out-of-memory exceptions may be raised from VM
 
     This is a regression test.  In previous implementations, the Relax
@@ -63,6 +64,8 @@ def test_alloc_tensor_raises_out_of_memory(target, dev):
     "vm.builtin.alloc_storage" was unable to allocate the requested
     buffer.
     """
+    target = "cuda"
+    dev = tvm.device(target)
 
     @I.ir_module
     class Module:

--- a/tests/python/relax/test_vm_callback_function.py
+++ b/tests/python/relax/test_vm_callback_function.py
@@ -17,6 +17,7 @@
 # ruff: noqa: F841
 
 import numpy as np
+import pytest
 
 import tvm
 import tvm.testing
@@ -24,10 +25,13 @@ from tvm.script import relax as R
 
 exec_mode = tvm.testing.parameter("bytecode", "compiled")
 
-pytestmark = tvm.testing.parametrize_targets("llvm")
+pytestmark = pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 
 
-def test_pass_tensor_to_function(exec_mode, target, dev):
+def test_pass_tensor_to_function(exec_mode):
+    target = "llvm"
+    dev = tvm.device(target)
+
     @R.function
     def relax_func(
         A: R.Tensor([16], "int32"),
@@ -59,7 +63,10 @@ def test_pass_tensor_to_function(exec_mode, target, dev):
     np.testing.assert_array_equal(np_A * 2, from_callback.numpy())
 
 
-def test_generate_tensor_in_function(exec_mode, target, dev):
+def test_generate_tensor_in_function(exec_mode):
+    target = "llvm"
+    dev = tvm.device(target)
+
     @R.function
     def relax_func(
         callback: R.Callable([], R.Tensor([16], "int32")),
@@ -85,7 +92,10 @@ def test_generate_tensor_in_function(exec_mode, target, dev):
     np.testing.assert_array_equal(np_A * 2, output.numpy())
 
 
-def test_catch_exception_with_full_stack_trace(exec_mode, target, dev):
+def test_catch_exception_with_full_stack_trace(exec_mode):
+    target = "llvm"
+    dev = tvm.device(target)
+
     @R.function
     def relax_func(
         callback: R.Callable([], R.Tensor([16], "int32")),

--- a/tests/python/testing/test_tvm_testing_features.py
+++ b/tests/python/testing/test_tvm_testing_features.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: E731, F401, RUF012
+# ruff: noqa: F401, RUF012
 
 import os
 import sys
@@ -30,82 +30,6 @@ import tvm.testing
 # these tests are distributed/parallelized using pytest-xdist or
 # similar, all tests in this file should run sequentially on the same
 # node.  (See https://stackoverflow.com/a/59504228)
-
-
-class TestTargetAutoParametrization:
-    targets_used = []
-    devices_used = []
-    enabled_targets = [target for target, dev in tvm.testing.enabled_targets()]
-    enabled_devices = [dev for target, dev in tvm.testing.enabled_targets()]
-
-    def test_target_parametrization(self, target):
-        assert target in self.enabled_targets
-        self.targets_used.append(target)
-
-    def test_device_parametrization(self, dev):
-        assert dev in self.enabled_devices
-        self.devices_used.append(dev)
-
-    def test_all_targets_used(self):
-        sort_key = lambda t: str(t)
-        assert sorted(self.targets_used, key=sort_key) == sorted(self.enabled_targets, key=sort_key)
-
-    def test_all_devices_used(self):
-        sort_key = lambda dev: (dev.dlpack_device_type(), dev.index)
-        assert sorted(self.devices_used, key=sort_key) == sorted(self.enabled_devices, key=sort_key)
-
-    targets_with_explicit_list = []
-
-    @tvm.testing.parametrize_targets("llvm")
-    def test_explicit_list(self, target):
-        assert target == "llvm"
-        self.targets_with_explicit_list.append(target)
-
-    def test_no_repeats_in_explicit_list(self):
-        if tvm.testing.device_enabled("llvm"):
-            assert self.targets_with_explicit_list == ["llvm"]
-        else:
-            assert self.targets_with_explicit_list == []
-
-    targets_with_exclusion = []
-
-    @tvm.testing.exclude_targets("llvm")
-    def test_exclude_target(self, target):
-        target_kind = target["kind"] if isinstance(target, dict) else target
-        assert "llvm" not in target_kind
-        self.targets_with_exclusion.append(target)
-
-    def test_all_nonexcluded_targets_ran(self):
-        def _get_kind(t):
-            return t["kind"] if isinstance(t, dict) else t
-
-        sort_key = lambda t: str(t)
-        assert sorted(self.targets_with_exclusion, key=sort_key) == sorted(
-            [target for target in self.enabled_targets if not _get_kind(target).startswith("llvm")],
-            key=sort_key,
-        )
-
-    run_targets_with_known_failure = []
-
-    @tvm.testing.known_failing_targets("llvm")
-    def test_known_failing_target(self, target):
-        # This test runs for all targets, but intentionally fails for
-        # llvm.  The behavior is working correctly if this test shows
-        # up as an expected failure, xfail.
-        self.run_targets_with_known_failure.append(target)
-        target_kind = target["kind"] if isinstance(target, dict) else target
-        assert "llvm" not in target_kind
-
-    def test_all_targets_ran(self):
-        sort_key = lambda t: str(t)
-        assert sorted(self.run_targets_with_known_failure, key=sort_key) == sorted(
-            self.enabled_targets, key=sort_key
-        )
-
-    @tvm.testing.known_failing_targets("llvm")
-    @tvm.testing.parametrize_targets("llvm")
-    def test_known_failing_explicit_list(self, target):
-        assert target != "llvm"
 
 
 class TestParameter:
@@ -206,57 +130,6 @@ class TestBrokenFixture:
 
     def test_num_uses_cached(self):
         assert self.num_uses_broken_cached_fixture == 0
-
-
-class TestAutomaticMarks:
-    @staticmethod
-    def check_marks(request, target):
-        decorators = tvm.testing.plugin._target_to_requirement(target)
-        required_marks = [decorator.mark for decorator in decorators]
-        applied_marks = list(request.node.iter_markers())
-
-        for required_mark in required_marks:
-            assert required_mark in applied_marks
-
-    def test_automatic_fixture(self, request, target):
-        self.check_marks(request, target)
-
-    @tvm.testing.parametrize_targets
-    def test_bare_parametrize(self, request, target):
-        self.check_marks(request, target)
-
-    @tvm.testing.parametrize_targets("llvm", "cuda", "vulkan")
-    def test_explicit_parametrize(self, request, target):
-        self.check_marks(request, target)
-
-    @pytest.mark.parametrize("target", ["llvm", "cuda", "vulkan"])
-    def test_pytest_mark(self, request, target):
-        self.check_marks(request, target)
-
-    @pytest.mark.parametrize("target,other_param", [("llvm", 0), ("cuda", 1), ("vulkan", 2)])
-    def test_pytest_mark_covariant(self, request, target, other_param):
-        self.check_marks(request, target)
-
-
-def test_target_to_requirement_cuda_libs():
-    """cuda+cudnn / cuda+cublas select their own probe; cudnn wins when both are present."""
-    ttr = tvm.testing.plugin._target_to_requirement
-
-    def skip_reasons(target):
-        return [d.mark.kwargs["reason"] for d in ttr(target) if d.mark.name == "skipif"]
-
-    assert skip_reasons({"kind": "cuda", "libs": ["cudnn"]}) == ["need cudnn"]
-    assert skip_reasons({"kind": "cuda", "libs": ["cublas"]}) == ["need cublas"]
-    # cudnn is checked before cublas, so it wins when both are present.
-    assert skip_reasons({"kind": "cuda", "libs": ["cudnn", "cublas"]}) == ["need cudnn"]
-    assert skip_reasons("cuda") == ["need cuda"]
-    # every cuda variant is GPU-family and carries the `gpu` selection marker.
-    assert any(d.mark.name == "gpu" for d in ttr({"kind": "cuda", "libs": ["cudnn"]}))
-
-
-def test_target_to_requirement_unknown_kind_has_no_marks():
-    """A target kind with no requirement entry produces no marks (no gpu, no skip)."""
-    assert tvm.testing.plugin._target_to_requirement("c") == []
 
 
 @pytest.mark.skipif(

--- a/tests/python/tirx-base/test_tir_intrin.py
+++ b/tests/python/tirx-base/test_tir_intrin.py
@@ -276,8 +276,14 @@ def test_ldexp():
 dtype = tvm.testing.parameter("int32", "int64")
 
 
-@tvm.testing.parametrize_targets("llvm", {"kind": "vulkan", "from_device": 0})
-def test_clz(target, dev, dtype):
+@pytest.mark.parametrize(
+    "target",
+    ["llvm", pytest.param({"kind": "vulkan", "from_device": 0}, marks=pytest.mark.gpu)],
+)
+def test_clz(target, dtype):
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+    dev = tvm.device(target["kind"] if isinstance(target, dict) else target)
     target = tvm.target.Target(target)
     if (
         target.kind.name == "vulkan"


### PR DESCRIPTION
This pr moves target selection and per-target device gating off the TVM pytest plugin onto plain pytest, and remove the now-dead machinery.
