### PR TITLE
[CPP_RPC] Implement tracker into the tvm_rpc utility

### DIFF
--- a/apps/cpp_rpc/CMakeLists.txt
+++ b/apps/cpp_rpc/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TVM_RPC_SOURCES
   main.cc
   rpc_env.cc
   rpc_server.cc
+  rpc_tracker.cc
 )
 
 set(TVM_RPC_LINKER_LIBS "")

--- a/apps/cpp_rpc/README.md
+++ b/apps/cpp_rpc/README.md
@@ -68,15 +68,22 @@ This folder contains a simple recipe to make RPC server in c++.
 ```
 Command line usage
  server       - Start the server
---host        - The hostname of the server, Default=0.0.0.0
---port        - The port of the RPC, Default=9090
---port-end    - The end search port of the RPC, Default=9199
+--host        - The listen address of the RPC server, Default=0.0.0.0
+--port        - The port of the RPC server, Default=9090
+--port-end    - The end search port of the RPC server, Default=9099
 --tracker     - The RPC tracker address in host:port format e.g. 10.1.1.2:9190 Default=""
 --key         - The key used to identify the device type in tracker. Default=""
 --custom-addr - Custom IP Address to Report to RPC Tracker. Default=""
 --silent      - Whether to run in silent mode. Default=False
-  Example
-  ./tvm_rpc server --host=0.0.0.0 --port=9000 --port-end=9090 --tracker=127.0.0.1:9190 --key=rasp
+ tracker      - Start the tracker
+--host        - The listen address of the RPC tracker, Default=0.0.0.0
+--port        - The port of the RPC tracker, Default=9190
+--port-end    - The end search port of the RPC tracker, Default=9199
+--silent      - Whether to run in silent mode. Default=False
+  Examples
+  ./tvm_rpc server --host=0.0.0.0 --port=9090 --port-end=9099 --tracker=127.0.0.1:9190 --key=rasp
+
+  ./tvm_rpc tracker --host=0.0.0.0 --port=9190 --port-end=9199
 ```
 
 ## Note

--- a/apps/cpp_rpc/main.cc
+++ b/apps/cpp_rpc/main.cc
@@ -37,6 +37,7 @@
 #include "../../src/support/socket.h"
 #include "../../src/support/utils.h"
 #include "rpc_server.h"
+#include "rpc_tracker.h"
 
 #if defined(_WIN32)
 #include "win32_process.h"
@@ -49,25 +50,33 @@ using namespace tvm::support;
 static const string kUsage =
     "Command line usage\n"
     " server       - Start the server\n"
-    "--host        - The hostname of the server, Default=0.0.0.0\n"
-    "--port        - The port of the RPC, Default=9090\n"
-    "--port-end    - The end search port of the RPC, Default=9099\n"
-    "--tracker     - The RPC tracker address in host:port format e.g. 10.1.1.2:9190 Default=\"\"\n"
-    "--key         - The key used to identify the device type in tracker. Default=\"\"\n"
-    "--custom-addr - Custom IP Address to Report to RPC Tracker. Default=\"\"\n"
-    "--work-dir    - Custom work directory. Default=\"\"\n"
-    "--silent      - Whether to run in silent mode. Default=False\n"
+    "  --host        - The listen address of the RPC server, Default=0.0.0.0 (any)\n"
+    "  --port        - The port of the RPC server, Default=9090\n"
+    "  --port-end    - The end search port of the RPC server, Default=9099\n"
+    "  --tracker     - The RPC tracker address in host:port format e.g. 10.1.1.2:9190 "
+    "Default=\"\"\n"
+    "  --key         - The key used to identify the device type in tracker. Default=\"\"\n"
+    "  --custom-addr - Custom IP Address to Report to RPC Tracker. Default=\"\"\n"
+    "  --work-dir    - Custom work directory. Default=\"\"\n"
+    "  --silent      - Whether to run in silent mode. Default=False\n"
+    " tracker      - Start the tracker\n"
+    "  --host        - The listen adddress of the RPC tracker, Default=0.0.0.0 (any)\n"
+    "  --port        - The port of the RPC tracker, Default=9190\n"
+    "  --port-end    - The end search port of the RPC tracker, Default=9199\n"
+    "  --silent      - Whether to run in silent mode. Default=False\n"
     "\n"
-    "  Example\n"
-    "  ./tvm_rpc server --host=0.0.0.0 --port=9000 --port-end=9090 "
-    " --tracker=127.0.0.1:9190 --key=rasp"
+    "  Examples\n"
+    "  ./tvm_rpc server --host=0.0.0.0 --port=9090 --port-end=9099 --tracker=127.0.0.1:9190 "
+    "--key=rasp\n"
+    "\n"
+    "  ./tvm_rpc tracker --host=0.0.0.0 --port=9190 --port-end=9199\n"
     "\n";
 
 /*!
  * \brief RpcServerArgs.
- * \arg host The hostname of the server, Default=0.0.0.0
- * \arg port The port of the RPC, Default=9090
- * \arg port_end The end search port of the RPC, Default=9099
+ * \arg host The listen address of the RPC server, Default=0.0.0.0
+ * \arg port The port of the RPC server, Default=9090
+ * \arg port_end The end search port of the RPC server, Default=9099
  * \arg tracker The address of RPC tracker in host:port format e.g. 10.77.1.234:9190 Default=""
  * \arg key The key used to identify the device type in tracker. Default=""
  * \arg custom_addr Custom IP Address to Report to RPC Tracker. Default=""
@@ -89,10 +98,27 @@ struct RpcServerArgs {
 };
 
 /*!
- * \brief PrintArgs print the contents of RpcServerArgs
+ * \brief RpcTrackerArgs.
+ * \arg host The listen address of the RPC tracker, Default=0.0.0.0
+ * \arg port The port of the RPC tracker, Default=9190
+ * \arg port_end The end search port of the RPC tracker, Default=9199
+ * \arg silent Whether run in silent mode. Default=False
+ */
+struct RpcTrackerArgs {
+  string host = "0.0.0.0";
+  int port = 9190;
+  int port_end = 9199;
+  bool silent = false;
+#if defined(WIN32)
+  std::string mmap_path;
+#endif
+};
+
+/*!
+ * \brief PrintRPCServerArgs print the contents of RpcServerArgs
  * \param args RpcServerArgs structure
  */
-void PrintArgs(const RpcServerArgs& args) {
+void PrintRPCServerArgs(const RpcServerArgs& args) {
   LOG(INFO) << "host        = " << args.host;
   LOG(INFO) << "port        = " << args.port;
   LOG(INFO) << "port_end    = " << args.port_end;
@@ -100,6 +126,17 @@ void PrintArgs(const RpcServerArgs& args) {
   LOG(INFO) << "key         = " << args.key;
   LOG(INFO) << "custom_addr = " << args.custom_addr;
   LOG(INFO) << "work_dir    = " << args.work_dir;
+  LOG(INFO) << "silent      = " << ((args.silent) ? ("True") : ("False"));
+}
+
+/*!
+ * \brief PrintRPCTrackerArgs print the contents of RpcTrackerArgs
+ * \param args RpcTrackerArgs structure
+ */
+void PrintRPCTrackerArgs(const RpcTrackerArgs& args) {
+  LOG(INFO) << "host        = " << args.host;
+  LOG(INFO) << "port        = " << args.port;
+  LOG(INFO) << "port_end    = " << args.port_end;
   LOG(INFO) << "silent      = " << ((args.silent) ? ("True") : ("False"));
 }
 
@@ -245,6 +282,49 @@ void ParseCmdArgs(int argc, char* argv[], struct RpcServerArgs& args) {
   }
 }
 
+void ParseCmdArgs(int argc, char* argv[], struct RpcTrackerArgs& args) {
+  const string silent = GetCmdOption(argc, argv, "--silent", true);
+  if (!silent.empty()) {
+    args.silent = true;
+  }
+
+  const string host = GetCmdOption(argc, argv, "--host=");
+  if (!host.empty()) {
+    if (!ValidateIP(host)) {
+      LOG(WARNING) << "Wrong host address format.";
+      LOG(INFO) << kUsage;
+      exit(1);
+    }
+    args.host = host;
+  }
+
+  const string port = GetCmdOption(argc, argv, "--port=");
+  if (!port.empty()) {
+    if (!IsNumber(port) || stoi(port) > 65535) {
+      LOG(WARNING) << "Wrong port number.";
+      LOG(INFO) << kUsage;
+      exit(1);
+    }
+    args.port = stoi(port);
+  }
+
+  const string port_end = GetCmdOption(argc, argv, "--port-end=");
+  if (!port_end.empty()) {
+    if (!IsNumber(port_end) || stoi(port_end) > 65535) {
+      LOG(WARNING) << "Wrong port-end number.";
+      LOG(INFO) << kUsage;
+      exit(1);
+    }
+    args.port_end = stoi(port_end);
+  }
+#if defined(WIN32)
+  const string mmap_path = GetCmdOption(argc, argv, "--child_proc=");
+  if (!mmap_path.empty()) {
+    args.mmap_path = mmap_path;
+  }
+#endif
+}
+
 /*!
  * \brief RpcServer Starts the RPC server.
  * \param argc arg counter
@@ -256,9 +336,9 @@ int RpcServer(int argc, char* argv[]) {
 
   /* parse the command line args */
   ParseCmdArgs(argc, argv, args);
-  PrintArgs(args);
+  PrintRPCServerArgs(args);
 
-  LOG(INFO) << "Starting CPP Server, Press Ctrl+C to stop.";
+  LOG(INFO) << "Starting RPC Server, Press Ctrl+C to stop.";
 #if defined(__linux__) || defined(__ANDROID__)
   // Ctrl+C handler
   HandleCtrlC();
@@ -284,6 +364,44 @@ int RpcServer(int argc, char* argv[]) {
 }
 
 /*!
+ * \brief RpcTracker Starts the RPC tracker.
+ * \param argc arg counter
+ * \param argv arg values
+ * \return result of operation.
+ */
+int RpcTracker(int argc, char* argv[]) {
+  RpcTrackerArgs args;
+
+  /* parse the command line args */
+  ParseCmdArgs(argc, argv, args);
+  PrintRPCTrackerArgs(args);
+
+  LOG(INFO) << "Starting CPP Tracker, Press Ctrl+C to stop.";
+#if defined(__linux__) || defined(__ANDROID__)
+  // Ctrl+C handler
+  HandleCtrlC();
+#endif
+
+#if defined(WIN32)
+  if (!args.mmap_path.empty()) {
+    int ret = 0;
+
+    try {
+      ChildProcSocketHandler(args.mmap_path);
+    } catch (const std::exception&) {
+      ret = -1;
+    }
+
+    return ret;
+  }
+#endif
+
+  RPCTrackerCreate(args.host, args.port, args.port_end, args.silent);
+
+  return 0;
+}
+
+/*!
  * \brief main The main function.
  * \param argc arg counter
  * \param argv arg values
@@ -303,6 +421,11 @@ int main(int argc, char* argv[]) {
 
   if (0 == strcmp(argv[1], "server")) {
     return RpcServer(argc, argv);
+  } else if (0 == strcmp(argv[1], "tracker")) {
+    return RpcTracker(argc, argv);
+  } else {
+    LOG(FATAL) << "Unsupported working mode: " << argv[1];
+    exit(0);
   }
 
   LOG(INFO) << kUsage;

--- a/apps/cpp_rpc/rpc_server.cc
+++ b/apps/cpp_rpc/rpc_server.cc
@@ -137,7 +137,7 @@ class RPCServer {
   void Start() {
     listen_sock_.Create();
     my_port_ = listen_sock_.TryBindHost(host_, port_search_start_, port_search_end_);
-    LOG(INFO) << "bind to " << host_ << ":" << my_port_;
+    LOG(INFO) << "Bind to " << host_ << ":" << my_port_;
     listen_sock_.Listen(1);
     std::future<void> proc(std::async(std::launch::async, &RPCServer::ListenLoopProc, this));
     proc.get();
@@ -384,9 +384,9 @@ void ServerLoopFromChild(SOCKET socket) {
 
 /*!
  * \brief RPCServerCreate Creates the RPC Server.
- * \param host The hostname of the server, Default=0.0.0.0
- * \param port The port of the RPC, Default=9090
- * \param port_end The end search port of the RPC, Default=9099
+ * \param host The listen address of the server, Default=0.0.0.0
+ * \param port The port of the RPC server, Default=9090
+ * \param port_end The end search port of the RPC server, Default=9099
  * \param tracker_addr The address of RPC tracker in host:port format e.g. 10.77.1.234:9190
  * Default="" \param key The key used to identify the device type in tracker. Default="" \param
  * custom_addr Custom IP Address to Report to RPC Tracker. Default="" \param silent Whether run in

--- a/apps/cpp_rpc/rpc_server.h
+++ b/apps/cpp_rpc/rpc_server.h
@@ -42,9 +42,9 @@ void ServerLoopFromChild(SOCKET socket);
 
 /*!
  * \brief RPCServerCreate Creates the RPC Server.
- * \param host The hostname of the server, Default=0.0.0.0
- * \param port The port of the RPC, Default=9090
- * \param port_end The end search port of the RPC, Default=9099
+ * \param host The listen address of the server, Default=0.0.0.0
+ * \param port The port of the RPC server, Default=9090
+ * \param port_end The end search port of the RPC server, Default=9099
  * \param tracker The address of RPC tracker in host:port format e.g. 10.77.1.234:9190 Default=""
  * \param key The key used to identify the device type in tracker. Default=""
  * \param custom_addr Custom IP Address to Report to RPC Tracker. Default=""

--- a/apps/cpp_rpc/rpc_tracker.cc
+++ b/apps/cpp_rpc/rpc_tracker.cc
@@ -1,0 +1,552 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file rpc_tracker.cc
+ * \brief RPC Tracker implementation.
+ */
+#include "../../apps/cpp_rpc/rpc_tracker.h"
+
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/reflection/registry.h>
+
+#include <algorithm>
+#include <any>
+#include <array>
+#include <condition_variable>
+#include <functional>
+#include <future>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <set>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "../../apps/cpp_rpc/rpc_tracker_server.h"
+
+namespace tvm {
+namespace runtime {
+
+static std::string setToString(const std::set<std::string>& inputSet) {
+  std::string result = "[";
+  bool first = true;
+  for (const auto& str : inputSet) {
+    if (!first) result += ", ";
+    result += "\"" + str + "\"";
+    first = false;
+  }
+
+  return result + "]";
+}
+
+static std::string stripQuotes(const std::string& Str, char quote = '"') {
+  if (Str.size() >= 2 && Str[0] == quote && Str[Str.size() - 1] == quote) {
+    return Str.substr(1, Str.size() - 2);
+  }
+
+  return Str;
+}
+
+static std::vector<std::string> ParseArray(std::string Raw) {
+  std::vector<std::string> elements;
+
+  if (Raw.size() >= 2 && Raw.front() == '[' && Raw.back() == ']') {
+    Raw = Raw.substr(1, Raw.size() - 2);
+  }
+
+  std::string current;
+  int brace_level = 0;
+  int bracket_level = 0;
+  bool in_quotes = false;
+
+  for (size_t i = 0; i < Raw.size(); ++i) {
+    char c = Raw[i];
+
+    if (c == '"') {
+      in_quotes = !in_quotes;
+    }
+
+    if (!in_quotes) {
+      if (c == '[')
+        bracket_level++;
+      else if (c == ']')
+        bracket_level--;
+      else if (c == '{')
+        brace_level++;
+      else if (c == '}')
+        brace_level--;
+
+      if (c == ',' && bracket_level == 0 && brace_level == 0) {
+        if (!current.empty()) elements.push_back(current);
+        current.clear();
+        if (i + 1 < Raw.size() && Raw[i + 1] == ' ') i++;
+        continue;
+      }
+    }
+    current += c;
+  }
+
+  if (!current.empty()) elements.push_back(current);
+
+  return elements;
+}
+
+static std::map<std::string, std::string> ParseJSONDict(std::string input) {
+  std::map<std::string, std::string> result;
+  size_t pos = 0;
+
+  while ((pos = input.find("\"", pos)) != std::string::npos) {
+    size_t key_start = ++pos;
+    size_t key_end = input.find("\"", key_start);
+    if (key_end == std::string::npos) break;
+
+    std::string key = input.substr(key_start, key_end - key_start);
+    pos = key_end + 1;
+
+    pos = input.find(':', pos);
+    if (pos == std::string::npos) break;
+    pos++;
+
+    while (pos < input.length() && (input[pos] == ' ' || input[pos] == '\t' || input[pos] == '\n'))
+      pos++;
+
+    size_t val_start = pos;
+    size_t val_end = pos;
+
+    if (input[pos] == '"') {
+      val_start++;
+      val_end = input.find('"', val_start);
+      pos = val_end + 1;
+    } else if (input[pos] == '[') {
+      int depth = 1;
+      val_end = val_start + 1;
+      while (val_end < input.length() && depth > 0) {
+        if (input[val_end] == '[')
+          depth++;
+        else if (input[val_end] == ']')
+          depth--;
+        val_end++;
+      }
+      pos = val_end;
+    } else {
+      val_end = input.find_first_of(",}", val_start);
+      pos = val_end;
+    }
+
+    if (val_end != std::string::npos) {
+      result[key] = input.substr(val_start, val_end - val_start);
+    }
+  }
+
+  return result;
+}
+
+PriorityScheduler::PriorityScheduler(const std::string& key) : _key(key), _request_cnt(0) {}
+
+void PriorityScheduler::_schedule() {
+  std::lock_guard<std::mutex> lock(_lock);
+  while (!_requests.empty() && !_values.empty()) {
+    Request item = _requests.top();
+    ResourceData value = _values.front();
+    if (item.callback(value)) {
+      _values.erase(_values.begin());
+      _requests.pop();
+    } else {
+      break;
+    }
+  }
+}
+
+void PriorityScheduler::put(const ResourceData& value) {
+  {
+    std::lock_guard<std::mutex> lock(_lock);
+    _values.push_back(value);
+  }
+  _schedule();
+}
+
+void PriorityScheduler::request(const std::string& user, int priority, ResourceCallback callback) {
+  {
+    std::lock_guard<std::mutex> lock(_lock);
+    _requests.push({priority, _request_cnt++, callback});
+  }
+  _schedule();
+}
+
+void PriorityScheduler::remove(const ResourceData& value) {
+  std::lock_guard<std::mutex> lock(_lock);
+  auto it = std::find(_values.begin(), _values.end(), value);
+  if (it != _values.end()) {
+    _values.erase(it);
+  }
+}
+
+std::string PriorityScheduler::summary() {
+  std::lock_guard<std::mutex> lock(_lock);
+  return "{\"free\": " + std::to_string(_values.size()) +
+         ", \"pending\": " + std::to_string(_requests.size()) + "}";
+}
+
+RPCTracker::RPCTracker(const std::string& host, int port, int port_end, bool silent)
+    : host_(host), port_start_(port), port_end_(port_end), silent_(silent) {
+  _addr = host;
+}
+
+RPCTracker::~RPCTracker() { Stop(); }
+
+void RPCTracker::Start() {
+  is_running_ = true;
+  server_sock_.Create();
+  listen_port_ = server_sock_.TryBindHost(host_, port_start_, port_end_);
+  if (listen_port_ < 0) {
+    LOG(FATAL) << "Failed to bind to any port in range " << port_start_ << "-" << port_end_;
+  }
+  LOG(INFO) << "Bind to " << host_ << ":" << listen_port_;
+  server_sock_.Listen(128);
+  schedule_thread_ = std::thread(&RPCTracker::ScheduleLoop, this);
+  ListenLoop();
+  server_sock_.Close();
+  is_running_ = false;
+}
+
+void RPCTracker::Stop() {
+  if (!is_running_) return;
+  is_running_ = false;
+  if (!server_sock_.IsClosed()) {
+    server_sock_.Close();
+  }
+  scheduler_cv_.notify_all();
+  if (schedule_thread_.joinable()) schedule_thread_.join();
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& pair : active_connections_) {
+      if (pair.second) {
+        pair.second->Close();
+      }
+    }
+    active_connections_.clear();
+  }
+  LOG(INFO) << "Tracker server stopped.";
+}
+
+void RPCTracker::ListenLoop() {
+  while (is_running_) {
+    SockAddr client_addr;
+    TCPSocket client_sock = server_sock_.Accept(&client_addr);
+    if (client_sock.IsClosed()) {
+      if (!is_running_) break;
+      continue;
+    }
+    LOG(INFO) << "New session from " << client_addr.AsString();
+    std::thread([this, client_sock = std::move(client_sock), client_addr]() mutable {
+      this->HandleConnection(std::move(client_sock), client_addr);
+    }).detach();
+  }
+}
+
+bool RPCTracker::ReadMessage(TCPSocket& sock, std::string* out_data) {
+  int32_t msg_len = 0;
+  if (sock.RecvAll(&msg_len, sizeof(msg_len)) != sizeof(msg_len)) return false;
+  out_data->resize(msg_len);
+  if (sock.RecvAll(&(*out_data)[0], msg_len) != static_cast<size_t>(msg_len)) return false;
+  return true;
+}
+
+bool RPCTracker::WriteMessage(TCPSocket& sock, const std::string& data) {
+  int32_t msg_len = static_cast<int32_t>(data.size());
+  if (sock.SendAll(&msg_len, sizeof(msg_len)) != sizeof(msg_len)) return false;
+  if (sock.SendAll(data.data(), msg_len) != static_cast<size_t>(msg_len)) return false;
+  return true;
+}
+
+bool RPCTracker::WriteCode(TCPSocket& sock, TrackerCode code) {
+  return WriteMessage(sock, std::to_string(static_cast<int>(code)));
+}
+
+void RPCTracker::HandleConnection(TCPSocket client_sock, SockAddr addr) {
+  const auto remote_ip = addr.ipaddr();
+  const auto remote_port = std::to_string(addr.port());
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    int fd = client_sock.sockfd;
+    auto socket_ptr = std::make_unique<TCPSocket>(std::move(client_sock));
+    active_connections_[fd] = std::move(socket_ptr);
+  }
+
+  try {
+    int32_t magic = 0;
+    int n = client_sock.RecvAll(&magic, sizeof(magic));
+    if (n != sizeof(magic) || magic != kRPCTrackerMagic) {
+      LOG(INFO) << "Handshake with " << remote_ip << ":" << remote_port << " failed - Magic: 0x"
+                << magic;
+      client_sock.Close();
+      return;
+    }
+    LOG(INFO) << "Handshake with " << remote_ip << ":" << remote_port << " successful";
+    client_sock.SendAll(&magic, sizeof(magic));
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      _connections.insert(remote_ip);
+    }
+  } catch (const std::exception& e) {
+    TVM_FFI_THROW(InternalError) << "Connection handler error";
+  } catch (...) {
+    TVM_FFI_THROW(InternalError) << "Unknown error in connection handler";
+  }
+
+  while (is_running_) {
+    std::string raw_message;
+    if (!ReadMessage(client_sock, &raw_message)) break;
+
+    const auto args = ParseArray(raw_message);
+    if (args.empty()) break;
+
+    const int code = std::stoi(args[0]);
+    TrackerCode opcode = static_cast<TrackerCode>(code);
+
+    if (opcode == TrackerCode::kPing) {
+      WriteCode(client_sock, TrackerCode::kSuccess);
+    } else if (opcode == TrackerCode::kPut) {
+      ProcessPut(client_sock, remote_ip, args);
+    } else if (opcode == TrackerCode::kRequest) {
+      LOG(INFO) << "Request using key '" << stripQuotes(args[1]) << "'"
+                << " from " << remote_ip << ":" << remote_port;
+      ProcessRequest(client_sock, args);
+    } else if (opcode == TrackerCode::kUpdateInfo) {
+      LOG(INFO) << "Received key '" << ParseJSONDict(args[1])["key"] << "'"
+                << " from " << remote_ip << ":" << remote_port;
+      ProcessUpdateInfo(client_sock, remote_ip, args);
+    } else if (opcode == TrackerCode::kGetPendingMatchKeys) {
+      ProcessGetPendingMatches(client_sock);
+    } else if (opcode == TrackerCode::kSummary) {
+      LOG(INFO) << "Summary requested from " << remote_ip << ":" << remote_port;
+      ProcessSummary(client_sock);
+    }
+  }
+
+  LOG(INFO) << "End session with " << remote_ip << ":" << remote_port;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    active_connections_.erase(client_sock.sockfd);
+    client_sock.Close();
+  }
+}
+
+void RPCTracker::ProcessPut(TCPSocket& sock, const std::string& remote_ip,
+                            const std::vector<std::string>& args) {
+  if (args.size() < 4) {
+    TVM_FFI_THROW(InternalError) << "Invalid ProcessPut arguments received";
+  }
+
+  const auto key = stripQuotes(args[1]);
+  const auto data = ParseArray(args[2]);
+  const auto ipaddr = stripQuotes(args[3]);
+  const auto port = stripQuotes(data[0]);
+  const auto matchkey = stripQuotes(data[1]);
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    pending_matchkeys.insert(matchkey);
+  }
+
+  ResourceData value;
+  if ((args.size() >= 4) && (args[3] != "null")) {
+    value = ResourceData{ipaddr, port, matchkey};
+  } else {
+    value = ResourceData{remote_ip, port, matchkey};
+  }
+
+  if (!_scheduler_map.count(key)) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!_scheduler_map.count(key)) {
+      _scheduler_map[key] = std::make_shared<PriorityScheduler>(key);
+    }
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    _scheduler_map[key]->put(value);
+    put_values.push_back(value);
+  }
+
+  WriteCode(sock, TrackerCode::kSuccess);
+  scheduler_cv_.notify_all();
+}
+
+void RPCTracker::ProcessRequest(TCPSocket& sock, const std::vector<std::string>& args) {
+  if (args.size() < 4) {
+    TVM_FFI_THROW(InternalError) << "Invalid ProcessRequest arguments received";
+  }
+
+  const auto key = stripQuotes(args[1]);
+  const auto user = stripQuotes(args[2]);
+  const int prio = std::stoi(args[3]);
+
+  ResourceCallback cb = [this, sock](const ResourceData& data) mutable -> bool {
+    if (sock.GetSockError() || sock.BadSocket()) return false;
+
+    const auto [ipaddr, port, matchkey] = data;
+    std::string response = "[" + std::to_string(static_cast<int>(TrackerCode::kSuccess)) + ", [\"" +
+                           ipaddr + "\", " + port + ", \"" + matchkey + "\"]]";
+
+    auto remote_addr = sock.GetRemoteAddr();
+    if (!remote_addr.has_value()) {
+      TVM_FFI_THROW(InternalError) << "Socket has no valid remote address.";
+    }
+    LOG(INFO) << "Offering matchkey '" << matchkey << "@" << ipaddr << ":" << port << "'"
+              << " to " << remote_addr.value().AsString();
+
+    return this->WriteMessage(sock, response);
+  };
+
+  if (!_scheduler_map.count(key)) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!_scheduler_map.count(key)) {
+      _scheduler_map[key] = std::make_shared<PriorityScheduler>(key);
+    }
+  }
+  _scheduler_map[key]->request(user, prio, cb);
+
+  scheduler_cv_.notify_all();
+}
+
+void RPCTracker::ProcessUpdateInfo(TCPSocket& sock, const std::string& remote_ip,
+                                   const std::vector<std::string>& args) {
+  if (args.size() != 2) {
+    TVM_FFI_THROW(InternalError) << "Invalid ProcessUpdateInfo arguments received";
+  }
+
+  auto dict = ParseJSONDict(args[1]);
+  const auto addr = ParseArray(dict["addr"]);
+
+  auto ipaddr = remote_ip;
+  if (addr[0] != "null") ipaddr = stripQuotes(addr[0]);
+  std::string port = stripQuotes(addr[1]);
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    _info[dict["key"]] =
+        "{\"key\": \"" + dict["key"] + "\", \"addr\": [\"" + ipaddr + "\", \"" + port + "\"]}";
+  }
+
+  WriteCode(sock, TrackerCode::kSuccess);
+  scheduler_cv_.notify_all();
+}
+
+void RPCTracker::ProcessGetPendingMatches(TCPSocket& sock) {
+  std::string response = setToString(pending_matchkeys);
+  WriteMessage(sock, response);
+  scheduler_cv_.notify_all();
+}
+
+void RPCTracker::ProcessSummary(TCPSocket& sock) {
+  std::string info =
+      "[" + std::to_string(static_cast<int>(TrackerCode::kSuccess)) + ", {\"queue_info\": {";
+  bool first = true;
+  for (const auto& [key, sch_ptr] : _scheduler_map) {
+    if (sch_ptr) {
+      if (!first) info += ",";
+      const auto summary = sch_ptr->summary();
+      info += " \"" + key + "\": " + summary;
+      first = false;
+    }
+  }
+
+  info += "}, \"server_info\": [";
+
+  first = true;
+  for (const auto& [key, data] : _info) {
+    if (!first) info += ", ";
+    info += data;
+    first = false;
+  }
+
+  info += "]}]";
+
+  WriteMessage(sock, info);
+  scheduler_cv_.notify_all();
+}
+
+void RPCTracker::ScheduleLoop() {
+  while (is_running_) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    scheduler_cv_.wait_for(lock, std::chrono::seconds(1));
+    if (!is_running_) break;
+
+    std::vector<std::string> keys;
+    for (const auto& kv : client_queues_) keys.push_back(kv.first);
+
+    for (const std::string& key : keys) {
+      auto& clients = client_queues_[key];
+      auto& servers = server_resources_[key];
+
+      while (!clients.empty() && !servers.empty()) {
+        RequestInfo client_req = clients.front();
+        clients.erase(clients.begin());
+        ServerInfo server_res = servers.front();
+        servers.erase(servers.begin());
+
+        bool notify_success = true;
+        if (!server_res.control_sock.IsClosed()) {
+          std::string payload = "[" + std::to_string(static_cast<int>(TrackerCode::kRequest)) +
+                                ", \"" + server_res.matchkey + "\"]";
+          if (!WriteMessage(server_res.control_sock, payload)) notify_success = false;
+        }
+
+        if (notify_success) {
+          std::string payload = "[" + std::to_string(static_cast<int>(TrackerCode::kRequest)) +
+                                ", [\"" + server_res.addr + "\", " +
+                                std::to_string(server_res.port) + ", \"" + server_res.matchkey +
+                                "\"]]";
+          if (!WriteMessage(client_req.client_sock, payload)) {
+            servers.insert(servers.begin(), server_res);
+          }
+        } else {
+          clients.insert(clients.begin(), client_req);
+        }
+      }
+    }
+  }
+}
+
+/*!
+ * \brief RPCTrackerCreate Creates the RPC Tracker.
+ * \param host The listen address of the tracker, Default=0.0.0.0
+ * \param port The port of the RPC tracker, Default=9190
+ * \param port_end The end search port of the RPC tracker, Default=9199
+ * silent mode. Default=True
+ */
+void RPCTrackerCreate(std::string host, int port, int port_end, bool silent) {
+  RPCTracker tracker(std::move(host), port, port_end, silent);
+  tracker.Start();
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def("rpc.TrackerCreate", RPCTrackerCreate);
+}
+
+}  // namespace runtime
+}  // namespace tvm

--- a/apps/cpp_rpc/rpc_tracker.h
+++ b/apps/cpp_rpc/rpc_tracker.h
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file rpc_tracker.h
+ * \brief RPC Tracker implementation.
+ */
+#ifndef TVM_APPS_CPP_RPC_TRACKER_H_
+#define TVM_APPS_CPP_RPC_TRACKER_H_
+
+#include <string>
+
+#include "tvm/runtime/base.h"
+
+namespace tvm {
+namespace runtime {
+
+/*!
+ * \brief RPCTrackerCreate Creates the RPC Tracker.
+ * \param host The listen address of tracker, Default=0.0.0.0
+ * \param port The port of the RPC tracker, Default=9190
+ * \param port_end The end search port of the RPC tracker, Default=9199
+ * \param silent Whether run in silent mode. Default=True
+ */
+void RPCTrackerCreate(std::string host = "", int port = 9190, int port_end = 9199,
+                      bool silent = true);
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // TVM_APPS_CPP_RPC_TRACKER_H_

--- a/apps/cpp_rpc/rpc_tracker_server.h
+++ b/apps/cpp_rpc/rpc_tracker_server.h
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file rpc_tracker_server.h
+ * \brief RPC Tracker implementation.
+ */
+#ifndef TVM_APPS_CPP_RPC_TRACKER_SERVER_H_
+#define TVM_APPS_CPP_RPC_TRACKER_SERVER_H_
+
+#include <map>
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include "../../src/runtime/rpc/rpc_endpoint.h"
+#include "../../src/runtime/rpc/rpc_socket_impl.h"
+#include "../../src/support/socket.h"
+
+using namespace tvm::support;
+
+namespace tvm {
+namespace runtime {
+
+/*! \brief Server resource entry for active TVM RPC Server node */
+struct ServerInfo {
+  std::string addr;
+  int port;
+  std::string matchkey;
+  std::string key;
+  double last_ping_time;
+  TCPSocket control_sock;
+};
+
+/*! \brief Client request entry for server node availablility */
+struct RequestInfo {
+  std::string key;
+  std::string user;
+  int priority;
+  TCPSocket client_sock;
+};
+
+using ResourceData = std::tuple<std::string, std::string, std::string>;
+using ResourceCallback = std::function<bool(const ResourceData&)>;
+
+/*!
+ * \brief Scheduler base class.
+ */
+class Scheduler {
+ public:
+  virtual ~Scheduler() = default;
+  virtual void put(const ResourceData& value) = 0;
+  virtual void request(const std::string& user, int priority, ResourceCallback callback) = 0;
+  virtual void remove(const ResourceData& value) = 0;
+  virtual std::string summary() = 0;
+};
+
+/*!
+ * \brief PriorityScheduler class.
+ * \param key The key used to identify the device type in tracker.
+ */
+class PriorityScheduler : public Scheduler {
+ public:
+  explicit PriorityScheduler(const std::string& key);
+
+  void put(const ResourceData& value) override;
+  void request(const std::string& user, int priority, ResourceCallback callback) override;
+  void remove(const ResourceData& value) override;
+  std::string summary() override;
+
+ private:
+  struct Request {
+    int priority;
+    int order;
+    ResourceCallback callback;
+
+    bool operator<(const Request& other) const {
+      if (priority != other.priority) return priority < other.priority;
+      return order > other.order;
+    }
+  };
+
+  void _schedule();
+
+  std::string _key;
+  std::vector<ResourceData> _values;
+  std::priority_queue<Request> _requests;
+
+  std::mutex _lock;
+  int _request_cnt;
+};
+
+/*!
+ * \brief The main rpc tracker server class.
+ * Manages resource registration, routing, and distribution schedules.
+ */
+class RPCTracker {
+ public:
+  RPCTracker(const std::string& host, int port, int port_end, bool silent);
+  ~RPCTracker();
+
+  void Start();
+  void Stop();
+
+ private:
+  std::string host_;
+  int port_start_;
+  int port_end_;
+  int listen_port_;
+  bool silent_;
+
+  bool is_running_{false};
+  TCPSocket server_sock_;
+
+  std::mutex mutex_;
+  std::thread schedule_thread_;
+  std::condition_variable scheduler_cv_;
+
+  std::unordered_map<int, std::unique_ptr<TCPSocket>> active_connections_;
+  std::map<std::string, std::vector<RequestInfo>> client_queues_;
+  std::map<std::string, std::vector<ServerInfo>> server_resources_;
+
+  void ListenLoop();
+  void ScheduleLoop();
+  void HandleConnection(TCPSocket client_sock, SockAddr addr);
+
+  bool ReadMessage(TCPSocket& sock, std::string* out_data);
+  bool WriteMessage(TCPSocket& sock, const std::string& data);
+  bool WriteCode(TCPSocket& sock, TrackerCode code);
+
+  void ProcessPut(TCPSocket& sock, const std::string& client_ip,
+                  const std::vector<std::string>& args);
+  void ProcessRequest(TCPSocket& sock, const std::vector<std::string>& args);
+  void ProcessUpdateInfo(TCPSocket& sock, const std::string& client_ip,
+                         const std::vector<std::string>& args);
+  void ProcessGetPendingMatches(TCPSocket& sock);
+  void ProcessSummary(TCPSocket& sock);
+
+  std::string _addr;
+  std::unordered_map<std::string, std::string> _info;
+  std::set<std::string> _connections;
+
+  std::set<std::string> pending_matchkeys;
+  std::vector<ResourceData> put_values;
+  std::unordered_map<std::string, std::shared_ptr<Scheduler>> _scheduler_map;
+};
+
+}  // namespace runtime
+}  // namespace tvm
+
+#endif  // TVM_APPS_CPP_RPC_TRACKER_SERVER_H_

--- a/src/support/socket.h
+++ b/src/support/socket.h
@@ -52,6 +52,7 @@
 #include <tvm/support/io.h>
 
 #include <cstring>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -165,10 +166,8 @@ struct SockAddr {
                      ? reinterpret_cast<const sockaddr_in6*>(&addr)->sin6_port
                      : reinterpret_cast<const sockaddr_in*>(&addr)->sin_port);
   }
-  /*! \brief return the ip address family */
-  int ss_family() const { return addr.ss_family; }
-  /*! \return a string representation of the address */
-  std::string AsString() const {
+  /*! \brief return ip of the address */
+  std::string ipaddr() const {
     std::string buf;
     buf.resize(256);
 
@@ -192,7 +191,15 @@ struct SockAddr {
 #endif
     TVM_FFI_ICHECK(s != nullptr) << "cannot decode address";
     std::ostringstream os;
-    os << s << ":" << port();
+    os << s;
+    return os.str();
+  }
+  /*! \brief return the ip address family */
+  int ss_family() const { return addr.ss_family; }
+  /*! \return a string representation of the address */
+  std::string AsString() const {
+    std::ostringstream os;
+    os << ipaddr() << ":" << port();
     return os.str();
   }
 };
@@ -557,6 +564,21 @@ class TCPSocket : public Socket, public Stream {
   size_t Read(void* data, size_t size) final { return RecvAll(data, size); }
 
   size_t Write(const void* data, size_t size) final { return SendAll(data, size); }
+
+  /*!
+   * \brief Get the address of the remote.
+   * \return SockAddr holding the address
+   */
+  std::optional<SockAddr> GetRemoteAddr() {
+    sockaddr_storage addr_storage{};
+    socklen_t addr_len = sizeof(addr_storage);
+    if (getpeername(sockfd, reinterpret_cast<sockaddr*>(&addr_storage), &addr_len) == 0) {
+      SockAddr remote_addr;
+      remote_addr.addr = addr_storage;
+      return remote_addr;
+    }
+    return std::nullopt;
+  }
 };
 
 /*! \brief helper data structure to perform poll */


### PR DESCRIPTION

Implements the tracker service into the existing ```tvm_cpp``` tool.
This is a standalone & portable alternative to the current python only ```tvm.exec.rpc_tracker``` counterpart.

---

#### Implementation details

* Implementation follows the TVM tracker full specifications, including the mandatory priority scheduling
* It can be considered *experimental* due to limited tests done involving a setup with two remote edge nodes


Brief usage:
```
$ ./tvm_rpc
{...} Command line usage
 server       - Start the server
   {...}
 tracker      - Start the tracker
  --host        - The listen adddress of the RPC tracker, Default=0.0.0.0 (any)
  --port        - The port of the RPC tracker, Default=9190
  --port-end    - The end search port of the RPC tracker, Default=9199
  --silent      - Whether to run in silent mode. Default=False

  Examples
  ./tvm_rpc server --host=0.0.0.0 --port=9090 --port-end=9099 --tracker=127.0.0.1:9190 --key=rasp

  ./tvm_rpc tracker --host=0.0.0.0 --port=9190 --port-end=9199

```

Live example:
```
$ ./tvm_rpc tracker
[11:37:03] {...}/main.cc:136: host        = 0.0.0.0
[11:37:03] {...}/main.cc:137: port        = 9190
[11:37:03] {...}/main.cc:138: port_end    = 9199
[11:37:03] {...}/main.cc:139: silent      = False
[11:37:03] {...}/main.cc:378: Starting CPP Tracker, Press Ctrl+C to stop.
[11:37:03] {...}/rpc_tracker.cc:231: Bind to 0.0.0.0:9190

<-- a remote edge [192.168.1.10] tvm_rpc server having 'opi5' key connects to tracker

[11:37:06] {...}/rpc_tracker.cc:265: New session from 192.168.1.10:46392
[11:37:06] {...}/rpc_tracker.cc:315: Handshake with 192.168.1.10:46392 successful
[11:37:06] {...}/rpc_tracker.cc:345: Received key 'server:opi5' from 192.168.1.10:46392

<-- a tuner process [127.0.0.1] launches multiple peering sessions using 'opi5' key
---> tracker always responds the tuner with any available sessions from its prio-scheduler

[11:38:18] {...}/rpc_tracker.cc:265: New session from 127.0.0.1:38706
[11:38:18] {...}/rpc_tracker.cc:315: Handshake with 127.0.0.1:38706 successful
[11:38:18] {...}/rpc_tracker.cc:341: Request using key 'opi5' from 127.0.0.1:38706
[11:38:18] {...}/rpc_tracker.cc:419: Offering matchkey 'opi5:0.692392@192.168.1.10:9000' to 127.0.0.1:38706
[11:38:18] {...}/rpc_tracker.cc:357: End session with 127.0.0.1:38706

[11:38:20] {...}/rpc_tracker.cc:265: New session from 127.0.0.1:38716
[11:38:20] {...}/rpc_tracker.cc:315: Handshake with 127.0.0.1:38716 successful
[11:38:20] {...}/rpc_tracker.cc:341: Request using key 'opi5' from 127.0.0.1:38716
[11:38:20] {...}/rpc_tracker.cc:419: Offering matchkey 'opi5:0.218548@192.168.1.10:9000' to 127.0.0.1:38716
[11:38:20] {...}/rpc_tracker.cc:357: End session with 127.0.0.1:38716

{...}
{...}
{...}

<-- another remote edge [192.168.1.5] tvm_rpc server having 'riscv' key steps in to the tracker

[11:44:58] {...}/rpc_tracker.cc:265: New session from 192.168.1.5:43390
[11:44:58] {...}/rpc_tracker.cc:315: Handshake with 192.168.1.5:43390 successful
[11:44:58] {...}/rpc_tracker.cc:345: Received key 'server:riscv' from 192.168.1.5:43390

<-- a remote ```python3 -m tvm.exec.query_rpc_tracker --host 127.0.0.1 --port 9190``` query
---> tracker gives a summary of its available peers and usage stats

[11:45:11] {...}/rpc_tracker.cc:265: New session from 127.0.0.1:41410
[11:45:11] {...}/rpc_tracker.cc:315: Handshake with 127.0.0.1:41410 successful
[11:45:11] {...}/rpc_tracker.cc:351: Summary requested from 127.0.0.1:41410
[11:45:11] {...}/rpc_tracker.cc:357: End session with 127.0.0.1:41410

---> the query peer receives the summary and display it as:

$ python3 -m tvm.exec.query_rpc_tracker --host 127.0.0.1 --port 9190
Tracker address 127.0.0.1:9190

Server List
------------------------------
server-address           key
------------------------------
192.168.1.10:9000        server:opi5
192.168.1.5:9000         server:riscv
------------------------------

Queue Status
-----------------------------
key     total  free  pending
-----------------------------
opi5    1      1     0      
riscv   1      1     0      
-----------------------------
```
