### PR TITLE
[Docker] Bump CI image deps: sphinx-book-theme + z3-static

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -32,7 +32,6 @@ uv pip install --upgrade \
     Pillow==12.1.1 \
     "psutil~=7.0" \
     "pytest~=8.3" \
-    git+https://github.com/tlc-pack/tlcpack-sphinx-addon.git@768ec1dce349fe4708f6ad68be1ebb3f3dabafa1 \
     "pytest-profiling~=1.8" \
     "pytest-xdist~=3.6" \
     pytest-rerunfailures==16.1 \
@@ -42,4 +41,5 @@ uv pip install --upgrade \
     junitparser==4.0.2 \
     "six~=1.17" \
     "tornado~=6.4" \
-    "ml_dtypes~=0.5"
+    "ml_dtypes~=0.5" \
+    z3-static==4.16.0.post1

--- a/docker/install/ubuntu_install_sphinx.sh
+++ b/docker/install/ubuntu_install_sphinx.sh
@@ -29,5 +29,5 @@ uv pip install \
     sphinx==8.1.3 \
     sphinx_autodoc_annotation~=1.0 \
     sphinx-gallery==0.20.0 \
-    sphinx_rtd_theme==3.1.0 \
-    git+https://github.com/tlc-pack/tlcpack-sphinx-addon.git@dded1a3fbaf549485d8f7bb3f79ecb0484a11629
+    sphinx-book-theme==1.1.4 \
+    pydata-sphinx-theme==0.15.4


### PR DESCRIPTION
This pr bumps the CI image Python dependencies, batched into one docker rebuild:
  
  **Docs theme** (for the sphinx-book-theme migration):
  - `ubuntu_install_sphinx.sh`: replace `sphinx_rtd_theme` + `tlcpack-sphinx-addon` with `sphinx-book-theme==1.1.4` + `pydata-sphinx-theme==0.15.4`. 1.1.4 (not 1.2.0) is used because it supports both Sphinx 8.1.3 (`sphinx>=6.1`, no upper bound) and the image's Python 3.10 (`requires-python>=3.9`); 1.2.0 requires Python>=3.11. 1.1.4 hard-pins `pydata-sphinx-theme==0.15.4`. 
  - `ubuntu_install_python_package.sh`: drop the now-unused `tlcpack-sphinx-addon` pin.
  
  **Z3 prover:**
  - `ubuntu_install_python_package.sh`: add `z3-static==4.16.0.post1` for the optional Z3-backed Analyzer proving.