### PR TITLE
[BUILD] Sync fallback version strings to 0.26 dev cycle

### DIFF
--- a/include/tvm/runtime/base.h
+++ b/include/tvm/runtime/base.h
@@ -32,7 +32,7 @@
 // passes the setuptools_scm-resolved version through CMake). The literal below is the
 // fallback for a bare build with no override.
 #ifndef TVM_VERSION
-#define TVM_VERSION "0.25.dev0"
+#define TVM_VERSION "0.26.dev0"
 #endif
 
 // TVM ships two shared libraries: libtvm_compiler and libtvm_runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,13 +153,13 @@ BUILD_TESTING = "OFF"
 [tool.setuptools_scm]
 # Version comes from the most recent Git tag (vMAJOR.MINOR.devN or vMAJOR.MINOR.PATCH).
 # guess-next-dev reproduces the previous version.py behaviour for vMAJOR.MINOR.devN
-# tags (e.g. v0.25.dev0 + N commits -> 0.25.devN). local_scheme = "no-local-version"
+# tags (e.g. v0.26.dev0 + N commits -> 0.26.devN). local_scheme = "no-local-version"
 # drops the +g<hash> local segment: PyPI rejects local versions on upload, and
 # this matches the public version the old version.py stamped.
 version_file = "python/tvm/_version.py"
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
-fallback_version = "0.25.dev0"
+fallback_version = "0.26.dev0"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/python/tvm/libinfo.py
+++ b/python/tvm/libinfo.py
@@ -96,4 +96,4 @@ def find_include_path() -> str:
 try:
     from ._version import version as __version__
 except ImportError:  # pragma: no cover - source tree without a build
-    __version__ = "0.25.dev0"
+    __version__ = "0.26.dev0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tvmjs",
-  "version": "0.25.0-dev1",
+  "version": "0.26.0-dev0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tvmjs",
-      "version": "0.25.0-dev1",
+      "version": "0.26.0-dev0",
       "license": "Apache-2.0",
       "dependencies": {
         "audit": "^0.0.6",

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "description": "TVM WASM/WebGPU runtime for JS/TS",
   "license": "Apache-2.0",
   "homepage": "https://github.com/apache/tvm/tree/main/web",
-  "version": "0.25.0-dev1",
+  "version": "0.26.0-dev0",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
The next dev-cycle tag v0.26.dev0 is already on main, so setuptools_scm derives the version of normal git builds straight from the tag as 0.26.devN (verified: it resolves to 0.26.dev117 on this branch). This commit does not change those builds.

It only updates the versions setuptools_scm does not produce: the hardcoded fallbacks used when there is no git metadata to read, e.g. sdists or bare source checkouts (`TVM_VERSION` in `include/tvm/runtime/base.h`, `fallback_version` in `pyproject.toml`, `__version__` in `python/tvm/libinfo.py`), plus the hand-managed tvmjs npm version (`web/package.json`, `web/package-lock.json`). All move from the old 0.25 cycle to 0.26.