### PR TITLE
[Tests] Clean unused tvm.testing helpers

### DIFF
--- a/python/tvm/testing/plugin.py
+++ b/python/tvm/testing/plugin.py
@@ -35,30 +35,12 @@ directory as the test scripts.
 import _pytest
 import pytest
 
-from tvm.testing import utils
-
 try:
     from xdist.scheduler.loadscope import LoadScopeScheduling
 
     HAVE_XDIST = True
 except ImportError:
     HAVE_XDIST = False
-
-
-def pytest_configure(config):
-    """Runs at pytest configure time.
-
-    Hardware/feature markers are declared statically in pyproject.toml; this
-    hook only reports the active target configuration.
-    """
-
-    print(
-        "enabled targets:",
-        "; ".join(
-            map(lambda x: str(x[0]) if isinstance(x[0], dict) else x[0], utils.enabled_targets())
-        ),
-    )
-    print("pytest marker:", config.option.markexpr)
 
 
 def pytest_collection_modifyitems(config, items):

--- a/python/tvm/testing/runner.py
+++ b/python/tvm/testing/runner.py
@@ -128,23 +128,20 @@ def local_run(  # pylint: disable=too-many-arguments,too-many-locals
         export_func(mod, artifact_path)
         device: Device = device(device_type, 0)
 
-        try:
-            args = _args_to_device(args, device)
-            remote_mod = load_module(artifact_path)
-            profile_result = remote_mod.time_evaluator(
-                func_name=remote_mod.entry_name,
-                dev=device,
-                number=evaluator_config.number,
-                repeat=evaluator_config.repeat,
-                min_repeat_ms=evaluator_config.min_repeat_ms,
-                f_preproc="cache_flush_cpu_non_first_arg"
-                if evaluator_config.enable_cpu_cache_flush
-                else "",
-            )(*args)
-            remote_mod(*args)
-            args = _args_to_numpy(args)
-        finally:
-            pass
+        args = _args_to_device(args, device)
+        remote_mod = load_module(artifact_path)
+        profile_result = remote_mod.time_evaluator(
+            func_name=remote_mod.entry_name,
+            dev=device,
+            number=evaluator_config.number,
+            repeat=evaluator_config.repeat,
+            min_repeat_ms=evaluator_config.min_repeat_ms,
+            f_preproc="cache_flush_cpu_non_first_arg"
+            if evaluator_config.enable_cpu_cache_flush
+            else "",
+        )(*args)
+        remote_mod(*args)
+        args = _args_to_numpy(args)
 
     return args, profile_result
 


### PR DESCRIPTION
This PR removes a small amount of unused/no-op code from `tvm.testing`.