### PR TITLE
[RUNTIME][VM] Lift LoadVMModule() interface to VM runtime

### DIFF
--- a/include/tvm/runtime/disco/builtin.h
+++ b/include/tvm/runtime/disco/builtin.h
@@ -57,13 +57,6 @@ inline std::string ReduceKind2String(ReduceKind kind) {
 }
 
 /*!
- * \brief Load a runtime Module, then create and initialize a RelaxVM
- * \param path The path to the runtime Module (a DSO file) to be loaded
- * \param device The default device used to initialize the RelaxVM
- * \return The RelaxVM as a runtime Module
- */
-TVM_RUNTIME_DLL ffi::Module LoadVMModule(std::string path, ffi::Optional<Device> device);
-/*!
  * \brief Create an uninitialized empty Tensor
  * \param shape The shape of the Tensor
  * \param dtype The dtype of the Tensor

--- a/include/tvm/runtime/vm/vm.h
+++ b/include/tvm/runtime/vm/vm.h
@@ -219,6 +219,14 @@ class VirtualMachine : public ffi::ModuleObj {
   std::unordered_map<uint32_t, Any> extensions;
 };
 
+/*!
+ * \brief Load a runtime Module, then create and initialize a RelaxVM
+ * \param path The path to the runtime Module (a DSO file) to be loaded
+ * \param device The device used to initialize the RelaxVM
+ * \return The RelaxVM as a runtime Module
+ */
+TVM_RUNTIME_DLL ffi::Module LoadVMModule(const std::string& path, const Device& device);
+
 }  // namespace vm
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/extra/disco/builtin.cc
+++ b/src/runtime/extra/disco/builtin.cc
@@ -32,45 +32,6 @@
 namespace tvm {
 namespace runtime {
 
-class DSOLibraryCache {
- public:
-  ffi::Module Open(const std::string& library_path) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = cache_.find(library_path);
-    if (it == cache_.end()) {
-      ffi::Module lib = ffi::Module::LoadFromFile(library_path);
-      cache_.emplace(library_path, lib);
-      return lib;
-    }
-    return it->second;
-  }
-
-  std::unordered_map<std::string, ffi::Module> cache_;
-  std::mutex mutex_;
-};
-
-ffi::Module LoadVMModule(std::string path, ffi::Optional<Device> device) {
-  static DSOLibraryCache cache;
-  ffi::Module dso_mod = cache.Open(path);
-  Device dev = UseDefaultDeviceIfNone(device);
-  ffi::Optional<ffi::Function> vm_load_executable = dso_mod->GetFunction("vm_load_executable");
-  if (!vm_load_executable.has_value()) {
-    // not built by RelaxVM, return the dso_mod directly
-    return dso_mod;
-  }
-  auto mod = (*vm_load_executable)().cast<ffi::Module>();
-  ffi::Optional<ffi::Function> vm_initialization = mod->GetFunction("vm_initialization");
-  if (!vm_initialization.has_value()) {
-    TVM_FFI_THROW(ValueError)
-        << "File `" << path
-        << "` is not built by RelaxVM, because `vm_initialization` does not exist";
-  }
-  (*vm_initialization)(static_cast<int>(dev.device_type), static_cast<int>(dev.device_id),
-                       static_cast<int>(AllocatorType::kPooled), static_cast<int>(kDLCPU), 0,
-                       static_cast<int>(AllocatorType::kPooled));
-  return mod;
-}
-
 Tensor DiscoEmptyTensor(ffi::Shape shape, DataType dtype, ffi::Optional<Device> device) {
   return Tensor::Empty(shape, dtype, UseDefaultDeviceIfNone(device));
 }
@@ -129,7 +90,12 @@ void SyncWorker() {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef()
-      .def("runtime.disco.load_vm_module", LoadVMModule)
+      .def("runtime.disco.load_vm_module",
+           [](std::string path, ffi::Optional<Device> device) -> ffi::Module {
+             Device dev = UseDefaultDeviceIfNone(device);
+             ffi::Module mod = tvm::runtime::vm::LoadVMModule(path, dev);
+             return mod;
+           })
       .def("runtime.disco.empty",
            [](ffi::Shape shape, DataType dtype, ffi::Optional<Device> device, bool worker0_only,
               bool in_group) -> ffi::Optional<Tensor> {

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -28,6 +28,7 @@
 #include <tvm/runtime/vm/vm.h>
 #include <tvm/support/cuda/nvtx.h>
 
+#include <mutex>
 #include <thread>
 
 #include "./module_utils.h"
@@ -969,6 +970,50 @@ ffi::Function VirtualMachineImpl::_LookupFunction(const ffi::String& name) {
     });
   }
   return ffi::Function(nullptr);
+}
+
+class DSOLibraryCache {
+ public:
+  ffi::Module Open(const std::string& library_path) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = cache_.find(library_path);
+    if (it == cache_.end()) {
+      ffi::Module lib = ffi::Module::LoadFromFile(library_path);
+      cache_.emplace(library_path, lib);
+      return lib;
+    }
+    return it->second;
+  }
+
+  std::unordered_map<std::string, ffi::Module> cache_;
+  std::mutex mutex_;
+};
+
+/*!
+ * \brief Load a runtime Module, then create and initialize a RelaxVM
+ * \param path The path to the runtime Module (a DSO file) to be loaded
+ * \param device The device used to initialize the RelaxVM
+ * \return The RelaxVM as a runtime Module
+ */
+ffi::Module LoadVMModule(const std::string& path, const Device& device) {
+  static DSOLibraryCache cache;
+  ffi::Module dso_mod = cache.Open(path);
+  ffi::Optional<ffi::Function> vm_load_executable = dso_mod->GetFunction("vm_load_executable");
+  if (!vm_load_executable.has_value()) {
+    // not built by RelaxVM, return the dso_mod directly
+    return dso_mod;
+  }
+  auto mod = (*vm_load_executable)().cast<ffi::Module>();
+  ffi::Optional<ffi::Function> vm_initialization = mod->GetFunction("vm_initialization");
+  if (!vm_initialization.has_value()) {
+    TVM_FFI_THROW(ValueError)
+        << "File `" << path
+        << "` is not built by RelaxVM, because `vm_initialization` does not exist";
+  }
+  (*vm_initialization)(static_cast<int>(device.device_type), static_cast<int>(device.device_id),
+                       static_cast<int>(AllocatorType::kPooled), static_cast<int>(kDLCPU), 0,
+                       static_cast<int>(AllocatorType::kPooled));
+  return mod;
 }
 
 }  // namespace vm


### PR DESCRIPTION
Lifts the LoadVMModule() API from disco submodule to vm submodule in the runtime.
Having it main in the VM runtime instead, not only disco benefits but becomes a usable public C++ API.

Related to #19849 which also close the gap to a functional c++ inference using pre-exported DSOs.

---

### Issue

Using an exported DSO module from a simple C++ program:
```
// #include <runtime/disco/builtin.h> 
#include <runtime/vm/vm.h>

int main() {

    tvm::Device dev = {kDLCPU, 0};
    // auto mod = tvm::runtime::LoadVMModule("./lib.tar.so", dev);
    auto mod = tvm::runtime::vm::LoadVMModule("./lib.tar.so", dev);

    return 0;
}

```
#### Before
  * From initial disco submodule, ```tvm_runtime_extra``` was also needed, ending with a ```disco``` error:
  ```
  $ c++ -I/usr/include/tvm dso-run-tvm.cpp -o dso-run-tvm -ltvm_ffi -ltvm_runtime -ltvm_runtime_extra
  $ ./dso-run-tvm
  terminate called after throwing an instance of 'tvm::ffi::Error'
    what():  Check failed: (ret) is false: The current thread is not a DiscoWorker thread
  Aborted                    (core dumped) ./dso-run-tvm
  $
  ```
#### After
  * Only ```tvm_runtime``` is needed, it works fine:
  ```
  $ c++ -I/usr/include/tvm dso-run-tvm.cpp -o dso-run-tvm -ltvm_ffi -ltvm_runtime
  $ ./dso-run-tvm
  $
  ```
