### PR TITLE
[Relax][ONNX] Support AffineGrid align_corners false

### DIFF
--- a/include/tvm/relax/attrs/image.h
+++ b/include/tvm/relax/attrs/image.h
@@ -149,6 +149,19 @@ struct GridSampleAttrs : public AttrsNode {
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.GridSampleAttrs", GridSampleAttrs, AttrsNode);
 };  // struct GridSampleAttrs
 
+/*! \brief Attributes used in image affine_grid operator */
+struct AffineGridAttrs : public AttrsNode {
+  bool align_corners;
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<AffineGridAttrs>().def_ro(
+        "align_corners", &AffineGridAttrs::align_corners,
+        "If True, the corner pixels of the output grid are aligned to -1 and 1.");
+  }
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.AffineGridAttrs", AffineGridAttrs, AttrsNode);
+};  // struct AffineGridAttrs
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -3321,10 +3321,7 @@ class AffineGrid(OnnxOpConverter):
     def _impl_v20(cls, bb, inputs, attr, params):
         theta = inputs[0]  # [N, 2, 3] for 2D
         size = get_constant(inputs[1], params)  # [N, C, H, W] for 2D
-        align_corners = attr.get("align_corners", 0)
-
-        if align_corners != 1:
-            raise NotImplementedError("AffineGrid with align_corners=0 is not yet supported in TVM")
+        align_corners = bool(attr.get("align_corners", 0))
 
         # Extract size values
         if isinstance(size, relax.Constant):
@@ -3340,7 +3337,9 @@ class AffineGrid(OnnxOpConverter):
         target_h, target_w = size_vals[2], size_vals[3]
 
         # Relax affine_grid outputs [N, 2, H, W]
-        grid = bb.emit(relax.op.image.affine_grid(theta, (target_h, target_w)))
+        grid = bb.emit(
+            relax.op.image.affine_grid(theta, (target_h, target_w), align_corners=align_corners)
+        )
         # Permute to ONNX convention [N, H, W, 2]
         return bb.emit(relax.op.permute_dims(grid, axes=[0, 2, 3, 1]))
 

--- a/python/tvm/relax/op/image/image.py
+++ b/python/tvm/relax/op/image/image.py
@@ -237,6 +237,7 @@ def grid_sample(
 def affine_grid(
     data: Expr,
     size: Expr | SizeLike,
+    align_corners: bool = True,
 ) -> Expr:
     """Generate a 2D sampling grid using an affine transformation matrix.
 
@@ -253,20 +254,18 @@ def affine_grid(
         The target output spatial shape (H, W). If a single integer or PrimExpr
         is provided, it is interpreted as a square output shape (size, size).
 
+    align_corners : bool
+        If true, -1 and 1 refer to the centers of the corner output pixels.
+        If false, -1 and 1 refer to the outer corners of the output image.
+
     Returns
     -------
     result : relax.Expr
         The output grid tensor with shape [batch, 2, H, W].
-
-    Note
-    ----
-    Only `align_corners=True` is supported by this operator, matching the
-    behavior of the underlying TOPI implementation. When using this operator
-    via PyTorch or ONNX frontends, `align_corners=False` will be rejected.
     """
     if isinstance(size, int | PrimExpr):
         size = (size, size)
     if isinstance(size, tuple | list):
         size = ShapeExpr(size)
 
-    return cast(Expr, _ffi_api.affine_grid(data, size))
+    return cast(Expr, _ffi_api.affine_grid(data, size, align_corners))

--- a/python/tvm/relax/op/op_attrs.py
+++ b/python/tvm/relax/op/op_attrs.py
@@ -171,6 +171,11 @@ class Resize2DAttrs(Attrs):
     """Attributes used in image resize2d operator"""
 
 
+@tvm_ffi.register_object("relax.attrs.AffineGridAttrs")
+class AffineGridAttrs(Attrs):
+    """Attributes used in image affine_grid operator"""
+
+
 @tvm_ffi.register_object("relax.attrs.ArgmaxArgminAttrs")
 class ArgmaxArgminAttrs(Attrs):
     """Attributes for argmax/argmin operator"""

--- a/python/tvm/relax/transform/legalize_ops/image.py
+++ b/python/tvm/relax/transform/legalize_ops/image.py
@@ -62,10 +62,12 @@ def _image_affine_grid(bb: BlockBuilder, call: Call) -> Expr:
                 f"affine_grid legalization requires static target_shape, got symbolic value: {v}"
             )
     target_shape = [int(v) for v in call.args[1].values]
+    align_corners = call.attrs.align_corners if call.attrs is not None else True
     return bb.call_te(
         topi.image.affine_grid,
         call.args[0],
         target_shape=target_shape,
+        align_corners=align_corners,
     )
 
 

--- a/python/tvm/topi/image/grid_sample.py
+++ b/python/tvm/topi/image/grid_sample.py
@@ -20,7 +20,7 @@
 from tvm import te, tirx
 
 
-def affine_grid(data, target_shape):
+def affine_grid(data, target_shape, align_corners=True):
     """affine_grid operator that generates 2D sampling grid.
 
     This operation is described in https://arxiv.org/pdf/1506.02025.pdf. It generates a uniform
@@ -35,6 +35,10 @@ def affine_grid(data, target_shape):
     target_shape: list/tuple of two int
         Specifies the output shape (H, W).
 
+    align_corners : bool
+        If true, -1 and 1 refer to the centers of the corner output pixels.
+        If false, -1 and 1 refer to the outer corners of the output image.
+
     Returns
     -------
     Output : tvm.Tensor
@@ -47,13 +51,20 @@ def affine_grid(data, target_shape):
     )
 
     dtype = data.dtype
-    y_step = tirx.const((2.0 - 1e-7) / (target_shape[0] - 1), dtype=dtype)
-    x_step = tirx.const((2.0 - 1e-7) / (target_shape[1] - 1), dtype=dtype)
-    start = tirx.const(-1.0, dtype=dtype)
+    if align_corners:
+        y_step = tirx.const((2.0 - 1e-7) / (target_shape[0] - 1), dtype=dtype)
+        x_step = tirx.const((2.0 - 1e-7) / (target_shape[1] - 1), dtype=dtype)
+        y_start = tirx.const(-1.0, dtype=dtype)
+        x_start = tirx.const(-1.0, dtype=dtype)
+    else:
+        y_step = tirx.const(2.0 / target_shape[0], dtype=dtype)
+        x_step = tirx.const(2.0 / target_shape[1], dtype=dtype)
+        y_start = tirx.const((1.0 / target_shape[0]) - 1.0, dtype=dtype)
+        x_start = tirx.const((1.0 / target_shape[1]) - 1.0, dtype=dtype)
 
     def _compute(n, dim, i, j):
-        y = start + i * y_step
-        x = start + j * x_step
+        y = y_start + i * y_step
+        x = x_start + j * x_step
         return data[n, dim, 0] * x + data[n, dim, 1] * y + data[n, dim, 2]
 
     oshape = (data.shape[0], len(target_shape), *target_shape)

--- a/python/tvm/topi/testing/grid_sample_python.py
+++ b/python/tvm/topi/testing/grid_sample_python.py
@@ -22,10 +22,14 @@ import math
 import numpy as np
 
 
-def affine_grid_python(data, target_shape):
+def affine_grid_python(data, target_shape, align_corners=True):
     yv, xv = np.meshgrid(np.arange(target_shape[0]), np.arange(target_shape[1]))
-    yv = yv.T * 2 / (target_shape[0] - 1) - 1
-    xv = xv.T * 2 / (target_shape[1] - 1) - 1
+    if align_corners:
+        yv = yv.T * 2 / (target_shape[0] - 1) - 1
+        xv = xv.T * 2 / (target_shape[1] - 1) - 1
+    else:
+        yv = (yv.T * 2 + 1) / target_shape[0] - 1
+        xv = (xv.T * 2 + 1) / target_shape[1] - 1
     ones = np.ones_like(xv)
     grid = np.stack([xv, yv, ones]).reshape(3, -1)
     return data.reshape(-1, 3).dot(grid).reshape(data.shape[0], 2, *target_shape)

--- a/src/relax/op/image/resize.cc
+++ b/src/relax/op/image/resize.cc
@@ -354,9 +354,14 @@ TVM_REGISTER_OP("relax.image.grid_sample")
 
 /* relax.image.affine_grid */
 
-Expr affine_grid(Expr data, Expr size) {
+TVM_FFI_STATIC_INIT_BLOCK() { AffineGridAttrs::RegisterReflection(); }
+
+Expr affine_grid(Expr data, Expr size, bool align_corners) {
+  ffi::ObjectPtr<AffineGridAttrs> attrs = ffi::make_object<AffineGridAttrs>();
+  attrs->align_corners = align_corners;
+
   static const Op& op = Op::Get("relax.image.affine_grid");
-  return Call(op, {std::move(data), std::move(size)}, Attrs(), {});
+  return Call(op, {std::move(data), std::move(size)}, Attrs(attrs), {});
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {
@@ -435,6 +440,7 @@ StructInfo InferStructInfoAffineGrid(const Call& call, const BlockBuilder& ctx) 
 }
 
 TVM_REGISTER_OP("relax.image.affine_grid")
+    .set_attrs_type<AffineGridAttrs>()
     .set_num_inputs(2)
     .add_argument("data", "Tensor", "The input affine matrix tensor.")
     .add_argument("size", "Shape", "The target output shape (H, W).")

--- a/src/relax/op/image/resize.h
+++ b/src/relax/op/image/resize.h
@@ -49,7 +49,7 @@ Expr grid_sample(Expr data, Expr grid, ffi::String method, ffi::String layout,
                  ffi::String padding_mode, bool align_corners);
 
 /*! \brief Image affine_grid operator. */
-Expr affine_grid(Expr data, Expr size);
+Expr affine_grid(Expr data, Expr size, bool align_corners);
 
 }  // namespace relax
 }  // namespace tvm

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -5555,12 +5555,16 @@ def test_nms_score_threshold():
         )
 
 
-def test_affine_grid():
+@pytest.mark.parametrize("align_corners", [None, 0, 1])
+def test_affine_grid(align_corners):
+    node_attrs = {}
+    if align_corners is not None:
+        node_attrs["align_corners"] = align_corners
     affine_grid_node = helper.make_node(
         "AffineGrid",
         ["theta", "size"],
         ["grid"],
-        align_corners=1,
+        **node_attrs,
     )
 
     graph = helper.make_graph(

--- a/tests/python/relax/test_op_image.py
+++ b/tests/python/relax/test_op_image.py
@@ -33,6 +33,9 @@ def test_op_correctness():
     assert relax.op.image.resize2d(x, (28, 28)).op == Op.get("relax.image.resize2d")
     theta = relax.Var("theta", R.Tensor((2, 2, 3), "float32"))
     assert relax.op.image.affine_grid(theta, (16, 16)).op == Op.get("relax.image.affine_grid")
+    affine_grid = relax.op.image.affine_grid(theta, (16, 16), align_corners=False)
+    assert affine_grid.op == Op.get("relax.image.affine_grid")
+    assert not affine_grid.attrs.align_corners
     y = relax.Var("y", R.Tensor((2, 3, 8, 16, 32), "float32"))
     assert relax.op.image.resize3d(y, (4, 8, 12)).op == Op.get("relax.image.resize3d")
 
@@ -394,6 +397,11 @@ def test_affine_grid_infer_struct_info():
     )
     _check_inference(
         bb,
+        relax.op.image.affine_grid(x0, size=(16, 20), align_corners=False),
+        relax.TensorStructInfo((2, 2, 16, 20), "float32"),
+    )
+    _check_inference(
+        bb,
         relax.op.image.affine_grid(x2, size=(16, 16)),
         relax.TensorStructInfo(dtype="float32", ndim=4),
     )
@@ -464,14 +472,15 @@ def test_affine_grid_wrong_size_ndim():
         (4, 32, 32),
     ],
 )
-def test_affine_grid_e2e(batch, target_h, target_w):
+@pytest.mark.parametrize("align_corners", [True, False])
+def test_affine_grid_e2e(batch, target_h, target_w, align_corners):
     """End-to-end numerical correctness test: build, run, compare with numpy reference."""
 
     @tvm.script.ir_module
     class AffineGridModule:
         @R.function
         def main(theta: R.Tensor(("batch", 2, 3), "float32")) -> R.Tensor("float32", ndim=4):
-            gv = R.image.affine_grid(theta, size=(target_h, target_w))
+            gv = R.image.affine_grid(theta, size=(target_h, target_w), align_corners=align_corners)
             return gv
 
     target = "llvm"
@@ -485,7 +494,9 @@ def test_affine_grid_e2e(batch, target_h, target_w):
     out_nd = vm["main"](theta_nd)
     out_np = out_nd.numpy()
 
-    ref_np = tvm.topi.testing.affine_grid_python(theta_np, (target_h, target_w))
+    ref_np = tvm.topi.testing.affine_grid_python(
+        theta_np, (target_h, target_w), align_corners=align_corners
+    )
 
     tvm.testing.assert_allclose(out_np, ref_np, rtol=1e-5, atol=1e-5)
 

--- a/tests/python/relax/test_transform_legalize_ops_image.py
+++ b/tests/python/relax/test_transform_legalize_ops_image.py
@@ -138,6 +138,95 @@ def test_image_affine_grid():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_image_affine_grid_no_attrs_backward_compatibility():
+    theta = relax.Var("theta", R.Tensor((2, 2, 3), "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("main", [theta]):
+        gv = bb.emit(
+            relax.Call(
+                tvm.ir.Op.get("relax.image.affine_grid"),
+                [theta, relax.ShapeExpr((16, 16))],
+                attrs=None,
+            )
+        )
+        bb.emit_func_output(gv)
+    AffineGrid = bb.get()
+
+    seen_call_with_no_attrs = False
+
+    def _visit(expr):
+        nonlocal seen_call_with_no_attrs
+        if isinstance(expr, relax.Call) and isinstance(expr.op, tvm.ir.Op):
+            if expr.op.name == "relax.image.affine_grid" and expr.attrs is None:
+                seen_call_with_no_attrs = True
+
+    relax.analysis.post_order_visit(AffineGrid["main"].body, _visit)
+    assert seen_call_with_no_attrs
+
+    # fmt: off
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main(theta: R.Tensor((2, 2, 3), "float32")) -> R.Tensor((2, 2, 16, 16), "float32"):
+            gv = R.call_tir(Expected.affine_grid, (theta,), R.Tensor((2, 2, 16, 16), dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True, s_tir=True)
+        def affine_grid(var_theta: T.handle, var_compute: T.handle):
+            T.func_attr({"tirx.noalias": True})
+            theta = T.match_buffer(var_theta, (T.int64(2), T.int64(2), T.int64(3)))
+            compute = T.match_buffer(var_compute, (T.int64(2), T.int64(2), T.int64(16), T.int64(16)))
+            with T.sblock("root"):
+                T.reads()
+                T.writes()
+                for n, dim, i, j in T.grid(T.int64(2), T.int64(2), T.int64(16), T.int64(16)):
+                    with T.sblock("compute"):
+                        v_n, v_dim, v_i, v_j = T.axis.remap("SSSS", [n, dim, i, j])
+                        T.reads(theta[v_n, v_dim, T.int64(0):T.int64(3)])
+                        T.writes(compute[v_n, v_dim, v_i, v_j])
+                        compute[v_n, v_dim, v_i, v_j] = theta[v_n, v_dim, T.int64(0)] * (T.float32(-1.0) + T.Cast("float32", v_j) * T.float32(0.13333332666666667)) + theta[v_n, v_dim, T.int64(1)] * (T.float32(-1.0) + T.Cast("float32", v_i) * T.float32(0.13333332666666667)) + theta[v_n, v_dim, T.int64(2)]
+    # fmt: on
+
+    mod = LegalizeOps()(AffineGrid)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
+def test_image_affine_grid_align_corners_false():
+    # fmt: off
+    @tvm.script.ir_module
+    class AffineGrid:
+        @R.function
+        def main(theta: R.Tensor((2, 2, 3), "float32")) -> R.Tensor((2, 2, 16, 16), "float32"):
+            gv: R.Tensor((2, 2, 16, 16), "float32") = R.image.affine_grid(theta, size=(16, 16), align_corners=False)
+            return gv
+
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main(theta: R.Tensor((2, 2, 3), "float32")) -> R.Tensor((2, 2, 16, 16), "float32"):
+            gv = R.call_tir(Expected.affine_grid, (theta,), R.Tensor((2, 2, 16, 16), dtype="float32"))
+            return gv
+
+        @T.prim_func(private=True, s_tir=True)
+        def affine_grid(var_theta: T.handle, var_compute: T.handle):
+            T.func_attr({"tirx.noalias": True})
+            theta = T.match_buffer(var_theta, (T.int64(2), T.int64(2), T.int64(3)))
+            compute = T.match_buffer(var_compute, (T.int64(2), T.int64(2), T.int64(16), T.int64(16)))
+            with T.sblock("root"):
+                T.reads()
+                T.writes()
+                for n, dim, i, j in T.grid(T.int64(2), T.int64(2), T.int64(16), T.int64(16)):
+                    with T.sblock("compute"):
+                        v_n, v_dim, v_i, v_j = T.axis.remap("SSSS", [n, dim, i, j])
+                        T.reads(theta[v_n, v_dim, T.int64(0):T.int64(3)])
+                        T.writes(compute[v_n, v_dim, v_i, v_j])
+                        compute[v_n, v_dim, v_i, v_j] = theta[v_n, v_dim, T.int64(0)] * (T.float32(-0.9375) + T.Cast("float32", v_j) * T.float32(0.125)) + theta[v_n, v_dim, T.int64(1)] * (T.float32(-0.9375) + T.Cast("float32", v_i) * T.float32(0.125)) + theta[v_n, v_dim, T.int64(2)]
+    # fmt: on
+
+    mod = LegalizeOps()(AffineGrid)
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
 def test_image_resize3d():
     # fmt: off
     @tvm.script.ir_module


### PR DESCRIPTION
  ### Motivation

  ONNX AffineGrid has an `align_corners` attribute, and the ONNX default is
  `align_corners=0`. The Relax ONNX frontend previously rejected that default with
  `NotImplementedError`, so an ONNX model that omitted the attribute could not be
  imported.

  Fixes #19690.

  ### Changes

  This PR threads `align_corners` through Relax `image.affine_grid`, legalization,
  and the TOPI implementation. The Relax API keeps the existing
  `align_corners=True` default to preserve current behavior, while the ONNX
  frontend reads the ONNX attribute and uses ONNX's default value of `0`.

  The tests cover Relax struct-info inference, legalization, numerical execution,
  and ONNX import/execution for both `align_corners=0` and `align_corners=1`.

  ### Testing

  - `cmake --build build --parallel $(nproc)`
  - `pre-commit run --files include/tvm/relax/attrs/image.h python/tvm/relax/frontend/onnx/
  onnx_frontend.py python/tvm/relax/op/image/image.py python/tvm/relax/op/op_attrs.py python/
  tvm/relax/transform/legalize_ops/image.py python/tvm/topi/image/grid_sample.py python/tvm/
  topi/testing/grid_sample_python.py src/relax/op/image/resize.cc src/relax/op/image/resize.h
  tests/python/relax/test_frontend_onnx.py tests/python/relax/test_op_image.py tests/python/
  relax/test_transform_legalize_ops_image.py`
  - `pytest tests/python/relax/test_op_image.py tests/python/relax/
  test_transform_legalize_ops_image.py -q`
  - `pytest tests/python/relax/test_frontend_onnx.py -k 'affine_grid or grid_sample' -q`