### PR TITLE
[Relax][Frontend][TFLite] Add legacy embedding operator coverage

### DIFF
--- a/python/tvm/relax/frontend/tflite/tflite_frontend.py
+++ b/python/tvm/relax/frontend/tflite/tflite_frontend.py
@@ -212,6 +212,7 @@ class OperatorConverter:
             "COMPLEX_ABS": self.convert_complex_abs,
             "CAST": self.convert_cast,
             "CEIL": functools.partial(self._convert_unary_elemwise, relax_op=_op.ceil),
+            "CONCAT_EMBEDDINGS": self.convert_concat_embeddings,
             "CONCATENATION": self.convert_concatenation,
             "CONV_2D": functools.partial(self.convert_conv, conv_type="conv2d"),
             "CONV_3D": self.convert_conv3d,
@@ -274,6 +275,7 @@ class OperatorConverter:
             "LOGICAL_NOT": self.convert_logical_not,
             "LOGICAL_OR": functools.partial(self._convert_logical_binary, relax_op=_op.logical_or),
             "LOGISTIC": self.convert_logistic,
+            "LSH_PROJECTION": self.convert_lsh_projection,
             "LSTM": self.convert_lstm,
             "MATRIX_DIAG": self.convert_matrix_diag,
             "MATRIX_SET_DIAG": self.convert_matrix_set_diag,
@@ -328,6 +330,7 @@ class OperatorConverter:
             "SHAPE": self.convert_shape,
             "SIGN": functools.partial(self._convert_unary_elemwise, relax_op=_op.sign),
             "SIN": functools.partial(self._convert_unary_elemwise, relax_op=_op.sin),
+            "SKIP_GRAM": self.convert_skip_gram,
             "SLICE": self.convert_slice,
             "SOFTMAX": self.convert_softmax,
             "SPACE_TO_BATCH_ND": self.convert_space_to_batch_nd,
@@ -6571,6 +6574,42 @@ class OperatorConverter:
             indices = self.get_tensor_expr(indices_tensor)
         return relax.op.take(params, indices, axis=0)
 
+    def convert_concat_embeddings(self, op):
+        """Reject legacy TFLite CONCAT_EMBEDDINGS with a targeted diagnostic."""
+        from tflite.ConcatEmbeddingsOptions import ConcatEmbeddingsOptions
+
+        input_tensors = self.get_input_tensors(op)
+        output_tensors = self.get_output_tensors(op)
+        if len(output_tensors) != 1:
+            raise tvm.error.OpNotImplemented("CONCAT_EMBEDDINGS expects one output tensor")
+
+        op_options = op.BuiltinOptions()
+        if op_options is None:
+            raise tvm.error.OpNotImplemented("CONCAT_EMBEDDINGS requires ConcatEmbeddingsOptions")
+
+        concat_options = ConcatEmbeddingsOptions()
+        concat_options.Init(op_options.Bytes, op_options.Pos)
+        num_channels = concat_options.NumChannels()
+        if num_channels <= 0:
+            raise tvm.error.OpNotImplemented("CONCAT_EMBEDDINGS requires at least one channel")
+        if concat_options.NumColumnsPerChannelLength() != num_channels:
+            raise tvm.error.OpNotImplemented(
+                "CONCAT_EMBEDDINGS num_columns_per_channel must match num_channels"
+            )
+        if concat_options.EmbeddingDimPerChannelLength() != num_channels:
+            raise tvm.error.OpNotImplemented(
+                "CONCAT_EMBEDDINGS embedding_dim_per_channel must match num_channels"
+            )
+        if len(input_tensors) < num_channels:
+            raise tvm.error.OpNotImplemented(
+                "CONCAT_EMBEDDINGS expects at least one input per channel"
+            )
+
+        raise tvm.error.OpNotImplemented(
+            "CONCAT_EMBEDDINGS legacy embedding semantics are not lowered by the "
+            "Relax TFLite frontend yet"
+        )
+
     def convert_embedding_lookup_sparse(self, op):
         """Convert TFLite EMBEDDING_LOOKUP_SPARSE."""
         from tflite.CombinerType import CombinerType
@@ -6686,6 +6725,93 @@ class OperatorConverter:
         bucket_counts = relax.op.broadcast_to(bucket_counts, output_shape)
         return relax.op.where(
             relax.op.greater(bucket_counts, relax.const(0.0, "float32")), normalized, value_base
+        )
+
+    def convert_lsh_projection(self, op):
+        """Reject TFLite LSH_PROJECTION with a targeted diagnostic."""
+        from tflite.LSHProjectionOptions import LSHProjectionOptions
+        from tflite.LSHProjectionType import LSHProjectionType
+        from tflite.TensorType import TensorType
+
+        input_tensors = self.get_input_tensors(op)
+        output_tensors = self.get_output_tensors(op)
+        if len(input_tensors) not in (2, 3) or len(output_tensors) != 1:
+            raise tvm.error.OpNotImplemented(
+                "LSH_PROJECTION expects hash and input tensors, optional weights, and one output"
+            )
+
+        hash_tensor, input_tensor = input_tensors[:2]
+        output_tensor = output_tensors[0]
+        hash_shape = to_int_list(self.get_tensor_shape(hash_tensor))
+        input_shape = to_int_list(self.get_tensor_shape(input_tensor))
+        output_shape = to_int_list(self.get_tensor_shape(output_tensor))
+        if hash_tensor.tensor.Type() != TensorType.FLOAT32:
+            raise tvm.error.OpNotImplemented("LSH_PROJECTION hash tensor must be float32")
+        if len(hash_shape) != 2 or hash_shape[0] < 1 or hash_shape[1] > 32:
+            raise tvm.error.OpNotImplemented(
+                "LSH_PROJECTION hash tensor must be rank 2 with at most 32 bits"
+            )
+        if len(input_shape) < 1 or input_shape[0] < 1:
+            raise tvm.error.OpNotImplemented("LSH_PROJECTION input tensor must be rank >= 1")
+        if len(input_tensors) == 3:
+            weight_tensor = input_tensors[2]
+            weight_shape = to_int_list(self.get_tensor_shape(weight_tensor))
+            if weight_tensor.tensor.Type() != TensorType.FLOAT32 or weight_shape != [
+                input_shape[0]
+            ]:
+                raise tvm.error.OpNotImplemented(
+                    "LSH_PROJECTION weights must be rank-1 float32 and match input dimension 0"
+                )
+        if output_tensor.tensor.Type() != TensorType.INT32:
+            raise tvm.error.OpNotImplemented("LSH_PROJECTION output must be int32")
+
+        op_options = op.BuiltinOptions()
+        if op_options is None:
+            raise tvm.error.OpNotImplemented("LSH_PROJECTION requires LSHProjectionOptions")
+        lsh_options = LSHProjectionOptions()
+        lsh_options.Init(op_options.Bytes, op_options.Pos)
+        projection_type = lsh_options.Type()
+        if projection_type == LSHProjectionType.SPARSE:
+            expected_output_shape = [hash_shape[0]]
+        elif projection_type == LSHProjectionType.DENSE:
+            expected_output_shape = [hash_shape[0] * hash_shape[1]]
+        else:
+            raise tvm.error.OpNotImplemented("LSH_PROJECTION requires SPARSE or DENSE type")
+        if output_shape != expected_output_shape:
+            raise tvm.error.OpNotImplemented(
+                "LSH_PROJECTION output shape must match the projection type"
+            )
+
+        raise tvm.error.OpNotImplemented(
+            "LSH_PROJECTION requires TFLite fingerprint hash semantics that are not lowered "
+            "by the Relax TFLite frontend yet"
+        )
+
+    def convert_skip_gram(self, op):
+        """Reject TFLite SKIP_GRAM with a targeted diagnostic."""
+        from tflite.SkipGramOptions import SkipGramOptions
+
+        input_tensors = self.get_input_tensors(op)
+        output_tensors = self.get_output_tensors(op)
+        if len(input_tensors) != 1 or len(output_tensors) != 1:
+            raise tvm.error.OpNotImplemented("SKIP_GRAM expects one input and one output")
+        if not self._is_tflite_string_type(input_tensors[0].tensor.Type()):
+            raise tvm.error.OpNotImplemented("SKIP_GRAM input must be TensorType.STRING")
+        if not self._is_tflite_string_type(output_tensors[0].tensor.Type()):
+            raise tvm.error.OpNotImplemented("SKIP_GRAM output must be TensorType.STRING")
+
+        op_options = op.BuiltinOptions()
+        if op_options is None:
+            raise tvm.error.OpNotImplemented("SKIP_GRAM requires SkipGramOptions")
+        skip_gram_options = SkipGramOptions()
+        skip_gram_options.Init(op_options.Bytes, op_options.Pos)
+        if skip_gram_options.NgramSize() <= 0:
+            raise tvm.error.OpNotImplemented("SKIP_GRAM ngram_size must be positive")
+        if skip_gram_options.MaxSkipSize() < 0:
+            raise tvm.error.OpNotImplemented("SKIP_GRAM max_skip_size must be non-negative")
+
+        raise tvm.error.OpNotImplemented(
+            "SKIP_GRAM requires TensorType.STRING support in Relax TFLite frontend"
         )
 
     def convert_batch_matmul(self, op):

--- a/python/tvm/relax/frontend/tflite/tflite_frontend.py
+++ b/python/tvm/relax/frontend/tflite/tflite_frontend.py
@@ -707,6 +707,10 @@ class OperatorConverter:
         return tuple(int(dim) for dim in tensor_wrapper.tensor.ShapeAsNumpy())
 
     @staticmethod
+    def _is_missing_tensor(tensor_wrapper):
+        return tensor_wrapper is None or tensor_wrapper.tensor_idx < 0
+
+    @staticmethod
     def _has_tensor_buffer_data(tensor_wrapper):
         return (
             tensor_wrapper.buffer is not None
@@ -6742,6 +6746,15 @@ class OperatorConverter:
 
         hash_tensor, input_tensor = input_tensors[:2]
         output_tensor = output_tensors[0]
+        if (
+            self._is_missing_tensor(hash_tensor)
+            or self._is_missing_tensor(input_tensor)
+            or self._is_missing_tensor(output_tensor)
+        ):
+            raise tvm.error.OpNotImplemented(
+                "LSH_PROJECTION expects valid hash, input, and output tensors"
+            )
+
         hash_shape = to_int_list(self.get_tensor_shape(hash_tensor))
         input_shape = to_int_list(self.get_tensor_shape(input_tensor))
         output_shape = to_int_list(self.get_tensor_shape(output_tensor))
@@ -6755,13 +6768,14 @@ class OperatorConverter:
             raise tvm.error.OpNotImplemented("LSH_PROJECTION input tensor must be rank >= 1")
         if len(input_tensors) == 3:
             weight_tensor = input_tensors[2]
-            weight_shape = to_int_list(self.get_tensor_shape(weight_tensor))
-            if weight_tensor.tensor.Type() != TensorType.FLOAT32 or weight_shape != [
-                input_shape[0]
-            ]:
-                raise tvm.error.OpNotImplemented(
-                    "LSH_PROJECTION weights must be rank-1 float32 and match input dimension 0"
-                )
+            if not self._is_missing_tensor(weight_tensor):
+                weight_shape = to_int_list(self.get_tensor_shape(weight_tensor))
+                if weight_tensor.tensor.Type() != TensorType.FLOAT32 or weight_shape != [
+                    input_shape[0]
+                ]:
+                    raise tvm.error.OpNotImplemented(
+                        "LSH_PROJECTION weights must be rank-1 float32 and match input dimension 0"
+                    )
         if output_tensor.tensor.Type() != TensorType.INT32:
             raise tvm.error.OpNotImplemented("LSH_PROJECTION output must be int32")
 
@@ -6795,6 +6809,8 @@ class OperatorConverter:
         output_tensors = self.get_output_tensors(op)
         if len(input_tensors) != 1 or len(output_tensors) != 1:
             raise tvm.error.OpNotImplemented("SKIP_GRAM expects one input and one output")
+        if self._is_missing_tensor(input_tensors[0]) or self._is_missing_tensor(output_tensors[0]):
+            raise tvm.error.OpNotImplemented("SKIP_GRAM expects valid input and output tensors")
         if not self._is_tflite_string_type(input_tensors[0].tensor.Type()):
             raise tvm.error.OpNotImplemented("SKIP_GRAM input must be TensorType.STRING")
         if not self._is_tflite_string_type(output_tensors[0].tensor.Type()):

--- a/tests/python/relax/test_frontend_tflite.py
+++ b/tests/python/relax/test_frontend_tflite.py
@@ -4368,6 +4368,54 @@ def _build_embedding_lookup_sparse_options(builder, combiner):
     return sparse_options.EmbeddingLookupSparseOptionsEnd(builder)
 
 
+def _build_concat_embeddings_options(builder, num_columns_per_channel, embedding_dim_per_channel):
+    try:
+        concat_options = _get_tflite_schema_module("ConcatEmbeddingsOptions")
+    except ModuleNotFoundError:
+        pytest.skip("TFLite schema does not provide ConcatEmbeddingsOptions")
+
+    num_channels = len(num_columns_per_channel)
+    num_columns_vec = _tflite_int32_vector(
+        builder,
+        concat_options.ConcatEmbeddingsOptionsStartNumColumnsPerChannelVector,
+        num_columns_per_channel,
+    )
+    embedding_dim_vec = _tflite_int32_vector(
+        builder,
+        concat_options.ConcatEmbeddingsOptionsStartEmbeddingDimPerChannelVector,
+        embedding_dim_per_channel,
+    )
+    concat_options.ConcatEmbeddingsOptionsStart(builder)
+    concat_options.ConcatEmbeddingsOptionsAddNumChannels(builder, num_channels)
+    concat_options.ConcatEmbeddingsOptionsAddNumColumnsPerChannel(builder, num_columns_vec)
+    concat_options.ConcatEmbeddingsOptionsAddEmbeddingDimPerChannel(builder, embedding_dim_vec)
+    return concat_options.ConcatEmbeddingsOptionsEnd(builder)
+
+
+def _build_lsh_projection_options(builder, projection_type):
+    try:
+        lsh_options = _get_tflite_schema_module("LSHProjectionOptions")
+    except ModuleNotFoundError:
+        pytest.skip("TFLite schema does not provide LSHProjectionOptions")
+
+    lsh_options.LSHProjectionOptionsStart(builder)
+    lsh_options.LSHProjectionOptionsAddType(builder, projection_type)
+    return lsh_options.LSHProjectionOptionsEnd(builder)
+
+
+def _build_skip_gram_options(builder, ngram_size=2, max_skip_size=1, include_all_ngrams=True):
+    try:
+        skip_gram_options = _get_tflite_schema_module("SkipGramOptions")
+    except ModuleNotFoundError:
+        pytest.skip("TFLite schema does not provide SkipGramOptions")
+
+    skip_gram_options.SkipGramOptionsStart(builder)
+    skip_gram_options.SkipGramOptionsAddNgramSize(builder, ngram_size)
+    skip_gram_options.SkipGramOptionsAddMaxSkipSize(builder, max_skip_size)
+    skip_gram_options.SkipGramOptionsAddIncludeAllNgrams(builder, include_all_ngrams)
+    return skip_gram_options.SkipGramOptionsEnd(builder)
+
+
 def _load_model_from_buffer(model_bytes):
     if hasattr(tflite.Model, "Model"):
         tflite_model = tflite.Model.Model.GetRootAsModel(model_bytes, 0)
@@ -6552,6 +6600,113 @@ def _build_tflite_embedding_lookup_sparse_model(
     )
 
 
+def _build_tflite_concat_embeddings_model():
+    """Build a model containing one legacy CONCAT_EMBEDDINGS operator."""
+    builder = flatbuffers.Builder(1024)
+
+    concat_options = _build_concat_embeddings_options(
+        builder, num_columns_per_channel=[1, 1], embedding_dim_per_channel=[2, 2]
+    )
+
+    input_0 = _build_tensor(builder, 0, [1, 2], tensor_type=_tfl_tensor_type.FLOAT32)
+    input_1 = _build_tensor(builder, 1, [1, 2], tensor_type=_tfl_tensor_type.FLOAT32)
+    output = _build_tensor(builder, 2, [1, 4], tensor_type=_tfl_tensor_type.FLOAT32)
+    concat_embeddings = _build_operator(
+        builder,
+        0,
+        [0, 1],
+        [2],
+        builtin_options_type=_get_builtin_options_type("ConcatEmbeddingsOptions"),
+        builtin_options=concat_options,
+    )
+    subgraph = _build_subgraph(
+        builder,
+        tensors=[input_0, input_1, output],
+        operators=[concat_embeddings],
+        inputs=[],
+        outputs=[2],
+    )
+    operator_codes = [_build_operator_code(builder, _get_builtin_operator("CONCAT_EMBEDDINGS"))]
+    buffers = [_build_buffer(builder) for _ in range(3)]
+    return _finish_tflite_model(
+        builder,
+        subgraph=subgraph,
+        operator_codes=operator_codes,
+        buffers=buffers,
+    )
+
+
+def _build_tflite_lsh_projection_model():
+    """Build a model containing one LSH_PROJECTION operator."""
+    builder = flatbuffers.Builder(1024)
+
+    lsh_projection_type = _get_tflite_schema_enum("LSHProjectionType")
+    lsh_options = _build_lsh_projection_options(builder, lsh_projection_type.SPARSE)
+
+    hash_tensor = _build_tensor(builder, 0, [2, 3], tensor_type=_tfl_tensor_type.FLOAT32)
+    input_tensor = _build_tensor(builder, 1, [4], tensor_type=_tfl_tensor_type.FLOAT32)
+    weight_tensor = _build_tensor(builder, 2, [4], tensor_type=_tfl_tensor_type.FLOAT32)
+    output_tensor = _build_tensor(builder, 3, [2], tensor_type=_tfl_tensor_type.INT32)
+    lsh_projection = _build_operator(
+        builder,
+        0,
+        [0, 1, 2],
+        [3],
+        builtin_options_type=_get_builtin_options_type("LSHProjectionOptions"),
+        builtin_options=lsh_options,
+    )
+    subgraph = _build_subgraph(
+        builder,
+        tensors=[hash_tensor, input_tensor, weight_tensor, output_tensor],
+        operators=[lsh_projection],
+        inputs=[],
+        outputs=[3],
+    )
+    operator_codes = [_build_operator_code(builder, _get_builtin_operator("LSH_PROJECTION"))]
+    buffers = [_build_buffer(builder) for _ in range(4)]
+    return _finish_tflite_model(
+        builder,
+        subgraph=subgraph,
+        operator_codes=operator_codes,
+        buffers=buffers,
+    )
+
+
+def _build_tflite_skip_gram_model():
+    """Build a model containing one SKIP_GRAM operator."""
+    builder = flatbuffers.Builder(1024)
+
+    string_type = _get_string_tensor_type()
+    skip_gram_options = _build_skip_gram_options(builder)
+    input_data = _build_tflite_string_buffer(["the quick brown fox"])
+
+    input_tensor = _build_tensor(builder, 0, [1], tensor_type=string_type)
+    output_tensor = _build_tensor(builder, 1, [1], tensor_type=string_type)
+    skip_gram = _build_operator(
+        builder,
+        0,
+        [0],
+        [1],
+        builtin_options_type=_get_builtin_options_type("SkipGramOptions"),
+        builtin_options=skip_gram_options,
+    )
+    subgraph = _build_subgraph(
+        builder,
+        tensors=[input_tensor, output_tensor],
+        operators=[skip_gram],
+        inputs=[],
+        outputs=[1],
+    )
+    operator_codes = [_build_operator_code(builder, _get_builtin_operator("SKIP_GRAM"))]
+    buffers = [_build_buffer(builder, input_data), _build_buffer(builder)]
+    return _finish_tflite_model(
+        builder,
+        subgraph=subgraph,
+        operator_codes=operator_codes,
+        buffers=buffers,
+    )
+
+
 def _build_tflite_hashtable_lookup_model(*, value_shape, value_type=None):
     """Build a model containing one HASHTABLE_LOOKUP operator."""
     builder = flatbuffers.Builder(1024)
@@ -6580,6 +6735,24 @@ def _build_tflite_hashtable_lookup_model(*, value_shape, value_type=None):
         operator_codes=operator_codes,
         buffers=buffers,
     )
+
+
+def test_concat_embeddings_unsupported():
+    """Test CONCAT_EMBEDDINGS reports a targeted unsupported diagnostic."""
+    with pytest.raises(tvm.error.OpNotImplemented, match="CONCAT_EMBEDDINGS legacy"):
+        _load_model_from_buffer(_build_tflite_concat_embeddings_model())
+
+
+def test_lsh_projection_unsupported():
+    """Test LSH_PROJECTION reports a targeted unsupported diagnostic."""
+    with pytest.raises(tvm.error.OpNotImplemented, match="TFLite fingerprint hash semantics"):
+        _load_model_from_buffer(_build_tflite_lsh_projection_model())
+
+
+def test_skip_gram_unsupported():
+    """Test SKIP_GRAM reports the string tensor frontend limitation."""
+    with pytest.raises(tvm.error.OpNotImplemented, match="TensorType.STRING support"):
+        _load_model_from_buffer(_build_tflite_skip_gram_model())
 
 
 def test_resource_variable_call_once_init_read():

--- a/tests/python/relax/test_frontend_tflite.py
+++ b/tests/python/relax/test_frontend_tflite.py
@@ -6636,7 +6636,7 @@ def _build_tflite_concat_embeddings_model():
     )
 
 
-def _build_tflite_lsh_projection_model():
+def _build_tflite_lsh_projection_model(include_weights=True):
     """Build a model containing one LSH_PROJECTION operator."""
     builder = flatbuffers.Builder(1024)
 
@@ -6645,25 +6645,35 @@ def _build_tflite_lsh_projection_model():
 
     hash_tensor = _build_tensor(builder, 0, [2, 3], tensor_type=_tfl_tensor_type.FLOAT32)
     input_tensor = _build_tensor(builder, 1, [4], tensor_type=_tfl_tensor_type.FLOAT32)
-    weight_tensor = _build_tensor(builder, 2, [4], tensor_type=_tfl_tensor_type.FLOAT32)
-    output_tensor = _build_tensor(builder, 3, [2], tensor_type=_tfl_tensor_type.INT32)
+    tensors = [hash_tensor, input_tensor]
+    operator_inputs = [0, 1]
+    output_index = 2
+    if include_weights:
+        weight_tensor = _build_tensor(builder, 2, [4], tensor_type=_tfl_tensor_type.FLOAT32)
+        tensors.append(weight_tensor)
+        operator_inputs.append(2)
+        output_index = 3
+    else:
+        operator_inputs.append(-1)
+    output_tensor = _build_tensor(builder, output_index, [2], tensor_type=_tfl_tensor_type.INT32)
+    tensors.append(output_tensor)
     lsh_projection = _build_operator(
         builder,
         0,
-        [0, 1, 2],
-        [3],
+        operator_inputs,
+        [output_index],
         builtin_options_type=_get_builtin_options_type("LSHProjectionOptions"),
         builtin_options=lsh_options,
     )
     subgraph = _build_subgraph(
         builder,
-        tensors=[hash_tensor, input_tensor, weight_tensor, output_tensor],
+        tensors=tensors,
         operators=[lsh_projection],
         inputs=[],
-        outputs=[3],
+        outputs=[output_index],
     )
     operator_codes = [_build_operator_code(builder, _get_builtin_operator("LSH_PROJECTION"))]
-    buffers = [_build_buffer(builder) for _ in range(4)]
+    buffers = [_build_buffer(builder) for _ in range(output_index + 1)]
     return _finish_tflite_model(
         builder,
         subgraph=subgraph,
@@ -6672,7 +6682,7 @@ def _build_tflite_lsh_projection_model():
     )
 
 
-def _build_tflite_skip_gram_model():
+def _build_tflite_skip_gram_model(missing_input=False):
     """Build a model containing one SKIP_GRAM operator."""
     builder = flatbuffers.Builder(1024)
 
@@ -6680,25 +6690,34 @@ def _build_tflite_skip_gram_model():
     skip_gram_options = _build_skip_gram_options(builder)
     input_data = _build_tflite_string_buffer(["the quick brown fox"])
 
-    input_tensor = _build_tensor(builder, 0, [1], tensor_type=string_type)
-    output_tensor = _build_tensor(builder, 1, [1], tensor_type=string_type)
+    if missing_input:
+        tensors = [_build_tensor(builder, 0, [1], tensor_type=string_type)]
+        operator_inputs = [-1]
+        operator_outputs = [0]
+        buffers = [_build_buffer(builder)]
+    else:
+        input_tensor = _build_tensor(builder, 0, [1], tensor_type=string_type)
+        output_tensor = _build_tensor(builder, 1, [1], tensor_type=string_type)
+        tensors = [input_tensor, output_tensor]
+        operator_inputs = [0]
+        operator_outputs = [1]
+        buffers = [_build_buffer(builder, input_data), _build_buffer(builder)]
     skip_gram = _build_operator(
         builder,
         0,
-        [0],
-        [1],
+        operator_inputs,
+        operator_outputs,
         builtin_options_type=_get_builtin_options_type("SkipGramOptions"),
         builtin_options=skip_gram_options,
     )
     subgraph = _build_subgraph(
         builder,
-        tensors=[input_tensor, output_tensor],
+        tensors=tensors,
         operators=[skip_gram],
         inputs=[],
-        outputs=[1],
+        outputs=operator_outputs,
     )
     operator_codes = [_build_operator_code(builder, _get_builtin_operator("SKIP_GRAM"))]
-    buffers = [_build_buffer(builder, input_data), _build_buffer(builder)]
     return _finish_tflite_model(
         builder,
         subgraph=subgraph,
@@ -6749,10 +6768,22 @@ def test_lsh_projection_unsupported():
         _load_model_from_buffer(_build_tflite_lsh_projection_model())
 
 
+def test_lsh_projection_without_weights_unsupported():
+    """Test LSH_PROJECTION accepts an absent optional weights slot before rejecting."""
+    with pytest.raises(tvm.error.OpNotImplemented, match="TFLite fingerprint hash semantics"):
+        _load_model_from_buffer(_build_tflite_lsh_projection_model(include_weights=False))
+
+
 def test_skip_gram_unsupported():
     """Test SKIP_GRAM reports the string tensor frontend limitation."""
     with pytest.raises(tvm.error.OpNotImplemented, match="TensorType.STRING support"):
         _load_model_from_buffer(_build_tflite_skip_gram_model())
+
+
+def test_skip_gram_missing_input_unsupported():
+    """Test SKIP_GRAM reports a targeted diagnostic for a missing input tensor."""
+    with pytest.raises(tvm.error.OpNotImplemented, match="valid input and output"):
+        _load_model_from_buffer(_build_tflite_skip_gram_model(missing_input=True))
 
 
 def test_resource_variable_call_once_init_read():


### PR DESCRIPTION
## Summary

This PR adds explicit Relax TFLite frontend coverage for the remaining legacy
embedding operators from #19519 group D:

- `CONCAT_EMBEDDINGS`
- `LSH_PROJECTION`
- `SKIP_GRAM`

These are legacy or string/hash-dependent TFLite builtins rather than direct
Relax tensor operator mappings. The frontend now recognizes them through
dedicated handlers, validates the operator options and tensor metadata that can
be checked safely at import time, and raises targeted `OpNotImplemented`
diagnostics instead of falling through to the generic unsupported-operator path.

## Design

`CONCAT_EMBEDDINGS` parses `ConcatEmbeddingsOptions` and validates the channel
metadata before rejecting the legacy embedding semantics. This keeps malformed
models distinguishable from unsupported-but-recognized models.

`LSH_PROJECTION` parses `LSHProjectionOptions`, validates the hash/input/weight
arity, supported projection type, output dtype, and projection-dependent output
shape. It remains unsupported because correct lowering requires TensorFlow
Lite's fingerprint hash semantics.

`SKIP_GRAM` parses `SkipGramOptions` and validates the string input/output
contract. It remains unsupported because the Relax TFLite frontend does not yet
model `TensorType.STRING`.

## Tests

The tests manually build minimal TFLite flatbuffers for each legacy operator
and assert that import raises the targeted diagnostic.

Local validation:

```bash
python -m ruff format \
  python/tvm/relax/frontend/tflite/tflite_frontend.py \
  tests/python/relax/test_frontend_tflite.py

python -m ruff check \
  python/tvm/relax/frontend/tflite/tflite_frontend.py \
  tests/python/relax/test_frontend_tflite.py

python -m pytest \
  tests/python/relax/test_frontend_tflite.py \
  -k "concat_embeddings or lsh_projection or skip_gram" \
  -q

python -m pytest tests/python/relax/test_frontend_tflite.py -q
```

Result:

```text
ruff format: 1 file reformatted, 1 file left unchanged
ruff check: All checks passed
targeted legacy embedding tests: 5 passed, 545 deselected
full test_frontend_tflite.py: 550 passed
```

## References

- Issue #19519 item D: legacy embedding / sparse embedding operators
- Issue comment: https://github.com/apache/tvm/issues/19519#issuecomment-4764085992
