### PR TITLE
[Relax] Fix test_dropout call_tir kwarg after Type unification

### DIFF
--- a/tests/python/relax/test_transform_legalize_ops_nn.py
+++ b/tests/python/relax/test_transform_legalize_ops_nn.py
@@ -4198,7 +4198,7 @@ def test_dropout():
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tuple(R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")):
             cls = Expected
-            gv = R.call_tir(cls.dropout, (x,), out_sinfo=[R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")])
+            gv = R.call_tir(cls.dropout, (x,), out_ty=[R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")])
             return gv
     # fmt: on
 


### PR DESCRIPTION
## Why

`test_dropout` still used the old `out_sinfo= kwarg`, which broke after `call_tir` was renamed to `out_ty=` in the `StructInfo/Type` unification.

## How

- Rename `out_sinfo=` to `out_ty=` in the dropout legalize test.