### PR TITLE
[CI] Stop building ci_lint Docker image

### DIFF
--- a/ci/jenkins/generate.py
+++ b/ci/jenkins/generate.py
@@ -39,7 +39,6 @@ _IMAGE_PLATFORMS = {
     "ci_arm": "ARM",
     "ci_cpu": "CPU",
     "ci_gpu": "GPU",
-    "ci_lint": "CPU",
     "ci_wasm": "CPU",
 }
 

--- a/ci/jenkins/generated/arm_jenkinsfile.groovy
+++ b/ci/jenkins/generated/arm_jenkinsfile.groovy
@@ -60,12 +60,11 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2026-06-16T13:42:33.948016
+// Generated at 2026-06-23T03:28:14.520193
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
 // image tags in that file
-ci_lint = ''
 ci_gpu = ''
 ci_cpu = ''
 ci_minimal = ''
@@ -82,7 +81,6 @@ properties([
     string(name: 'ci_arm_param', defaultValue: ''),
     string(name: 'ci_cpu_param', defaultValue: ''),
     string(name: 'ci_gpu_param', defaultValue: ''),
-    string(name: 'ci_lint_param', defaultValue: ''),
     string(name: 'ci_wasm_param', defaultValue: ''),
   ])
 ])
@@ -92,7 +90,6 @@ properties([
   built_ci_arm = null;
   built_ci_cpu = null;
   built_ci_gpu = null;
-  built_ci_lint = null;
   built_ci_wasm = null;
 
 // Global variable assigned during Sanity Check that holds the sha1 which should be
@@ -347,7 +344,7 @@ def prepare(node_type) {
 
         if (env.DETERMINE_DOCKER_IMAGES == 'yes') {
           sh(
-            script: "./${jenkins_scripts_root}/determine_docker_images.py ci_arm ci_cpu ci_gpu ci_lint ci_wasm ",
+            script: "./${jenkins_scripts_root}/determine_docker_images.py ci_arm ci_cpu ci_gpu ci_wasm ",
             label: 'Decide whether to use tlcpack or tlcpackstaging for Docker images',
           )
           // Pull image names from the results of should_rebuild_docker.py
@@ -366,11 +363,6 @@ def prepare(node_type) {
             label: "Find docker image name for ci_gpu",
             returnStdout: true,
           ).trim()
-          ci_lint = sh(
-            script: "cat .docker-image-names/ci_lint",
-            label: "Find docker image name for ci_lint",
-            returnStdout: true,
-          ).trim()
           ci_wasm = sh(
             script: "cat .docker-image-names/ci_wasm",
             label: "Find docker image name for ci_wasm",
@@ -381,7 +373,6 @@ def prepare(node_type) {
         ci_arm = params.ci_arm_param ?: ci_arm
         ci_cpu = params.ci_cpu_param ?: ci_cpu
         ci_gpu = params.ci_gpu_param ?: ci_gpu
-        ci_lint = params.ci_lint_param ?: ci_lint
         ci_wasm = params.ci_wasm_param ?: ci_wasm
 
         sh (script: """
@@ -389,7 +380,6 @@ def prepare(node_type) {
           echo " ci_arm = ${ci_arm}"
           echo " ci_cpu = ${ci_cpu}"
           echo " ci_gpu = ${ci_gpu}"
-          echo " ci_lint = ${ci_lint}"
           echo " ci_wasm = ${ci_wasm}"
         """, label: 'Docker image names')
 

--- a/ci/jenkins/generated/cpu_jenkinsfile.groovy
+++ b/ci/jenkins/generated/cpu_jenkinsfile.groovy
@@ -60,12 +60,11 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2026-06-16T13:42:33.935741
+// Generated at 2026-06-23T03:28:14.505504
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
 // image tags in that file
-ci_lint = ''
 ci_gpu = ''
 ci_cpu = ''
 ci_minimal = ''
@@ -82,7 +81,6 @@ properties([
     string(name: 'ci_arm_param', defaultValue: ''),
     string(name: 'ci_cpu_param', defaultValue: ''),
     string(name: 'ci_gpu_param', defaultValue: ''),
-    string(name: 'ci_lint_param', defaultValue: ''),
     string(name: 'ci_wasm_param', defaultValue: ''),
   ])
 ])
@@ -92,7 +90,6 @@ properties([
   built_ci_arm = null;
   built_ci_cpu = null;
   built_ci_gpu = null;
-  built_ci_lint = null;
   built_ci_wasm = null;
 
 // Global variable assigned during Sanity Check that holds the sha1 which should be
@@ -347,7 +344,7 @@ def prepare(node_type) {
 
         if (env.DETERMINE_DOCKER_IMAGES == 'yes') {
           sh(
-            script: "./${jenkins_scripts_root}/determine_docker_images.py ci_arm ci_cpu ci_gpu ci_lint ci_wasm ",
+            script: "./${jenkins_scripts_root}/determine_docker_images.py ci_arm ci_cpu ci_gpu ci_wasm ",
             label: 'Decide whether to use tlcpack or tlcpackstaging for Docker images',
           )
           // Pull image names from the results of should_rebuild_docker.py
@@ -366,11 +363,6 @@ def prepare(node_type) {
             label: "Find docker image name for ci_gpu",
             returnStdout: true,
           ).trim()
-          ci_lint = sh(
-            script: "cat .docker-image-names/ci_lint",
-            label: "Find docker image name for ci_lint",
-            returnStdout: true,
-          ).trim()
           ci_wasm = sh(
             script: "cat .docker-image-names/ci_wasm",
             label: "Find docker image name for ci_wasm",
@@ -381,7 +373,6 @@ def prepare(node_type) {
         ci_arm = params.ci_arm_param ?: ci_arm
         ci_cpu = params.ci_cpu_param ?: ci_cpu
         ci_gpu = params.ci_gpu_param ?: ci_gpu
-        ci_lint = params.ci_lint_param ?: ci_lint
         ci_wasm = params.ci_wasm_param ?: ci_wasm
 
         sh (script: """
@@ -389,7 +380,6 @@ def prepare(node_type) {
           echo " ci_arm = ${ci_arm}"
           echo " ci_cpu = ${ci_cpu}"
           echo " ci_gpu = ${ci_gpu}"
-          echo " ci_lint = ${ci_lint}"
           echo " ci_wasm = ${ci_wasm}"
         """, label: 'Docker image names')
 

--- a/ci/jenkins/generated/docker_jenkinsfile.groovy
+++ b/ci/jenkins/generated/docker_jenkinsfile.groovy
@@ -60,12 +60,11 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2026-06-16T13:42:33.958277
+// Generated at 2026-06-23T03:28:14.487314
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
 // image tags in that file
-ci_lint = ''
 ci_gpu = ''
 ci_cpu = ''
 ci_minimal = ''
@@ -82,7 +81,6 @@ properties([
     string(name: 'ci_arm_param', defaultValue: ''),
     string(name: 'ci_cpu_param', defaultValue: ''),
     string(name: 'ci_gpu_param', defaultValue: ''),
-    string(name: 'ci_lint_param', defaultValue: ''),
     string(name: 'ci_wasm_param', defaultValue: ''),
   ])
 ])
@@ -92,7 +90,6 @@ properties([
   built_ci_arm = null;
   built_ci_cpu = null;
   built_ci_gpu = null;
-  built_ci_lint = null;
   built_ci_wasm = null;
 
 // Global variable assigned during Sanity Check that holds the sha1 which should be
@@ -347,7 +344,7 @@ def prepare(node_type) {
 
         if (env.DETERMINE_DOCKER_IMAGES == 'yes') {
           sh(
-            script: "./${jenkins_scripts_root}/determine_docker_images.py ci_arm ci_cpu ci_gpu ci_lint ci_wasm ",
+            script: "./${jenkins_scripts_root}/determine_docker_images.py ci_arm ci_cpu ci_gpu ci_wasm ",
             label: 'Decide whether to use tlcpack or tlcpackstaging for Docker images',
           )
           // Pull image names from the results of should_rebuild_docker.py
@@ -366,11 +363,6 @@ def prepare(node_type) {
             label: "Find docker image name for ci_gpu",
             returnStdout: true,
           ).trim()
-          ci_lint = sh(
-            script: "cat .docker-image-names/ci_lint",
-            label: "Find docker image name for ci_lint",
-            returnStdout: true,
-          ).trim()
           ci_wasm = sh(
             script: "cat .docker-image-names/ci_wasm",
             label: "Find docker image name for ci_wasm",
@@ -381,7 +373,6 @@ def prepare(node_type) {
         ci_arm = params.ci_arm_param ?: ci_arm
         ci_cpu = params.ci_cpu_param ?: ci_cpu
         ci_gpu = params.ci_gpu_param ?: ci_gpu
-        ci_lint = params.ci_lint_param ?: ci_lint
         ci_wasm = params.ci_wasm_param ?: ci_wasm
 
         sh (script: """
@@ -389,7 +380,6 @@ def prepare(node_type) {
           echo " ci_arm = ${ci_arm}"
           echo " ci_cpu = ${ci_cpu}"
           echo " ci_gpu = ${ci_gpu}"
-          echo " ci_lint = ${ci_lint}"
           echo " ci_wasm = ${ci_wasm}"
         """, label: 'Docker image names')
 
@@ -571,7 +561,6 @@ def deploy() {
                       update_docker(built_ci_arm, "tlcpackstaging/ci_arm:${tag}")
                       update_docker(built_ci_cpu, "tlcpackstaging/ci_cpu:${tag}")
                       update_docker(built_ci_gpu, "tlcpackstaging/ci_gpu:${tag}")
-                      update_docker(built_ci_lint, "tlcpackstaging/ci_lint:${tag}")
                       update_docker(built_ci_wasm, "tlcpackstaging/ci_wasm:${tag}")
                     } finally {
                       sh(
@@ -643,20 +632,6 @@ def deploy() {
                             label: 'Tag tlcpackstaging/ci_gpu image to tlcpack',
                           )
                         }
-                        if (ci_lint.contains("tlcpackstaging")) {
-                          // Push image to tlcpack
-                          def tag = ci_lint.split(":")[1]
-                          sh(
-                            script: """
-                              set -eux
-                              . ${jenkins_scripts_root}/retry.sh
-                              docker pull tlcpackstaging/ci_lint:${tag}
-                              docker tag tlcpackstaging/ci_lint:${tag} tlcpack/ci-lint:${tag}
-                              retry 5 docker push tlcpack/ci-lint:${tag}
-                            """,
-                            label: 'Tag tlcpackstaging/ci_lint image to tlcpack',
-                          )
-                        }
                         if (ci_wasm.contains("tlcpackstaging")) {
                           // Push image to tlcpack
                           def tag = ci_wasm.split(":")[1]
@@ -725,17 +700,6 @@ if (rebuild_docker_images) {
             // are not yet being uploaded to tlcpack
             // ci_gpu = build_image('ci_gpu')
             built_ci_gpu = build_image('ci_gpu');
-          }
-        }
-      },
-      'ci_lint': {
-        node('CPU') {
-          timeout(time: max_time, unit: 'MINUTES') {
-            init_git()
-            // We're purposefully not setting the built image here since they
-            // are not yet being uploaded to tlcpack
-            // ci_lint = build_image('ci_lint')
-            built_ci_lint = build_image('ci_lint');
           }
         }
       },

--- a/ci/jenkins/generated/gpu_jenkinsfile.groovy
+++ b/ci/jenkins/generated/gpu_jenkinsfile.groovy
@@ -60,12 +60,11 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2026-06-16T13:42:33.970141
+// Generated at 2026-06-23T03:28:14.533751
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
 // image tags in that file
-ci_lint = ''
 ci_gpu = ''
 ci_cpu = ''
 ci_minimal = ''
@@ -82,7 +81,6 @@ properties([
     string(name: 'ci_arm_param', defaultValue: ''),
     string(name: 'ci_cpu_param', defaultValue: ''),
     string(name: 'ci_gpu_param', defaultValue: ''),
-    string(name: 'ci_lint_param', defaultValue: ''),
     string(name: 'ci_wasm_param', defaultValue: ''),
   ])
 ])
@@ -92,7 +90,6 @@ properties([
   built_ci_arm = null;
   built_ci_cpu = null;
   built_ci_gpu = null;
-  built_ci_lint = null;
   built_ci_wasm = null;
 
 // Global variable assigned during Sanity Check that holds the sha1 which should be
@@ -347,7 +344,7 @@ def prepare(node_type) {
 
         if (env.DETERMINE_DOCKER_IMAGES == 'yes') {
           sh(
-            script: "./${jenkins_scripts_root}/determine_docker_images.py ci_arm ci_cpu ci_gpu ci_lint ci_wasm ",
+            script: "./${jenkins_scripts_root}/determine_docker_images.py ci_arm ci_cpu ci_gpu ci_wasm ",
             label: 'Decide whether to use tlcpack or tlcpackstaging for Docker images',
           )
           // Pull image names from the results of should_rebuild_docker.py
@@ -366,11 +363,6 @@ def prepare(node_type) {
             label: "Find docker image name for ci_gpu",
             returnStdout: true,
           ).trim()
-          ci_lint = sh(
-            script: "cat .docker-image-names/ci_lint",
-            label: "Find docker image name for ci_lint",
-            returnStdout: true,
-          ).trim()
           ci_wasm = sh(
             script: "cat .docker-image-names/ci_wasm",
             label: "Find docker image name for ci_wasm",
@@ -381,7 +373,6 @@ def prepare(node_type) {
         ci_arm = params.ci_arm_param ?: ci_arm
         ci_cpu = params.ci_cpu_param ?: ci_cpu
         ci_gpu = params.ci_gpu_param ?: ci_gpu
-        ci_lint = params.ci_lint_param ?: ci_lint
         ci_wasm = params.ci_wasm_param ?: ci_wasm
 
         sh (script: """
@@ -389,7 +380,6 @@ def prepare(node_type) {
           echo " ci_arm = ${ci_arm}"
           echo " ci_cpu = ${ci_cpu}"
           echo " ci_gpu = ${ci_gpu}"
-          echo " ci_lint = ${ci_lint}"
           echo " ci_wasm = ${ci_wasm}"
         """, label: 'Docker image names')
 

--- a/ci/jenkins/generated/wasm_jenkinsfile.groovy
+++ b/ci/jenkins/generated/wasm_jenkinsfile.groovy
@@ -60,12 +60,11 @@
 // 'python3 jenkins/generate.py'
 // Note: This timestamp is here to ensure that updates to the Jenkinsfile are
 // always rebased on main before merging:
-// Generated at 2026-06-16T13:42:33.982453
+// Generated at 2026-06-23T03:28:14.550555
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
 // image tags in that file
-ci_lint = ''
 ci_gpu = ''
 ci_cpu = ''
 ci_minimal = ''
@@ -82,7 +81,6 @@ properties([
     string(name: 'ci_arm_param', defaultValue: ''),
     string(name: 'ci_cpu_param', defaultValue: ''),
     string(name: 'ci_gpu_param', defaultValue: ''),
-    string(name: 'ci_lint_param', defaultValue: ''),
     string(name: 'ci_wasm_param', defaultValue: ''),
   ])
 ])
@@ -92,7 +90,6 @@ properties([
   built_ci_arm = null;
   built_ci_cpu = null;
   built_ci_gpu = null;
-  built_ci_lint = null;
   built_ci_wasm = null;
 
 // Global variable assigned during Sanity Check that holds the sha1 which should be
@@ -347,7 +344,7 @@ def prepare(node_type) {
 
         if (env.DETERMINE_DOCKER_IMAGES == 'yes') {
           sh(
-            script: "./${jenkins_scripts_root}/determine_docker_images.py ci_arm ci_cpu ci_gpu ci_lint ci_wasm ",
+            script: "./${jenkins_scripts_root}/determine_docker_images.py ci_arm ci_cpu ci_gpu ci_wasm ",
             label: 'Decide whether to use tlcpack or tlcpackstaging for Docker images',
           )
           // Pull image names from the results of should_rebuild_docker.py
@@ -366,11 +363,6 @@ def prepare(node_type) {
             label: "Find docker image name for ci_gpu",
             returnStdout: true,
           ).trim()
-          ci_lint = sh(
-            script: "cat .docker-image-names/ci_lint",
-            label: "Find docker image name for ci_lint",
-            returnStdout: true,
-          ).trim()
           ci_wasm = sh(
             script: "cat .docker-image-names/ci_wasm",
             label: "Find docker image name for ci_wasm",
@@ -381,7 +373,6 @@ def prepare(node_type) {
         ci_arm = params.ci_arm_param ?: ci_arm
         ci_cpu = params.ci_cpu_param ?: ci_cpu
         ci_gpu = params.ci_gpu_param ?: ci_gpu
-        ci_lint = params.ci_lint_param ?: ci_lint
         ci_wasm = params.ci_wasm_param ?: ci_wasm
 
         sh (script: """
@@ -389,7 +380,6 @@ def prepare(node_type) {
           echo " ci_arm = ${ci_arm}"
           echo " ci_cpu = ${ci_cpu}"
           echo " ci_gpu = ${ci_gpu}"
-          echo " ci_lint = ${ci_lint}"
           echo " ci_wasm = ${ci_wasm}"
         """, label: 'Docker image names')
 

--- a/ci/jenkins/templates/utils/base.groovy.j2
+++ b/ci/jenkins/templates/utils/base.groovy.j2
@@ -52,7 +52,6 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 // These are set at runtime from data in ci/jenkins/docker-images.yml, update
 // image tags in that file
-ci_lint = ''
 ci_gpu = ''
 ci_cpu = ''
 ci_minimal = ''

--- a/ci/scripts/jenkins/git_change_docker.sh
+++ b/ci/scripts/jenkins/git_change_docker.sh
@@ -28,6 +28,11 @@ fi
 FILES_THAT_SHOULDNT_TRIGGER_REBUILDS=(
     "docker/bash.sh"
     "docker/with_the_same_user"
+    "docker/README.md"
+    "docker/Dockerfile.ci_lint"
+    "docker/install/ubuntu_install_clang_format.sh"
+    "docker/lint.sh"
+    "docker/clear-stale-images.sh"
     "README.md"
     "lint.sh"
     "clear-stale-images.sh"

--- a/ci/scripts/jenkins/open_docker_update_pr.py
+++ b/ci/scripts/jenkins/open_docker_update_pr.py
@@ -37,6 +37,7 @@ IMAGES_FILE = JENKINS_DIR / "docker-images.ini"
 GENERATE_SCRIPT = JENKINS_DIR / "generate.py"
 GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
 BRANCH = "nightly-docker-update"
+RETIRED_IMAGES = {"ci_lint"}
 
 
 def _testing_docker_api(data: dict[str, Any]) -> Callable[[str], dict[str, Any]]:
@@ -142,6 +143,9 @@ if __name__ == "__main__":
     replacements = {}
     for key in config.options("jenkins"):
         if key == "ci_tag":
+            continue
+        if key in RETIRED_IMAGES:
+            logging.info(f"Skipping retired image {key}")
             continue
         image_spec = config.get("jenkins", key)
         logging.info(f"Found {key} = {image_spec}")

--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -1264,6 +1264,7 @@ def test_open_docker_update_pr(
         if line not in proc.stdout:
             raise RuntimeError(f"Missing line {line} in output:\n{proc.stdout}")
 
+    assert_in("Skipping retired image ci_lint", proc.stdout)
     assert_in(expected, proc.stdout)
 
 

--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -1238,7 +1238,6 @@ def test_open_docker_update_pr(
         "ci_cortexm",
         "ci_cpu",
         "ci_gpu",
-        "ci_lint",
         "ci_minimal",
         "ci_riscv",
         "ci_wasm",
@@ -1270,10 +1269,10 @@ def test_open_docker_update_pr(
 
 @parameterize_named(
     use_tlcpack=dict(
-        images=["ci_arm", "ci_lint"],
+        images=["ci_arm", "ci_cpu"],
         expected={
             "ci_arm": "tlcpack/ci-arm:abc-abc-123",
-            "ci_lint": "tlcpack/ci-lint:abc-abc-234",
+            "ci_cpu": "tlcpack/ci-cpu:abc-abc-234",
         },
     ),
     use_staging=dict(
@@ -1291,12 +1290,12 @@ def test_determine_docker_images(tmpdir_factory, images, expected):
 
     docker_data = {
         "repositories/tlcpack/ci-arm/tags/abc-abc-123": {},
-        "repositories/tlcpack/ci-lint/tags/abc-abc-234": {},
+        "repositories/tlcpack/ci-cpu/tags/abc-abc-234": {},
     }
 
     images_data = {
         "ci_arm": "tlcpack/ci-arm:abc-abc-123",
-        "ci_lint": "tlcpack/ci-lint:abc-abc-234",
+        "ci_cpu": "tlcpack/ci-cpu:abc-abc-234",
         "ci_arm2": "tlcpack/ci-arm2:abc-abc-123",
     }
 

--- a/tests/python/ci/test_ci.py
+++ b/tests/python/ci/test_ci.py
@@ -1238,6 +1238,7 @@ def test_open_docker_update_pr(
         "ci_cortexm",
         "ci_cpu",
         "ci_gpu",
+        "ci_lint",
         "ci_minimal",
         "ci_riscv",
         "ci_wasm",
@@ -1264,7 +1265,6 @@ def test_open_docker_update_pr(
         if line not in proc.stdout:
             raise RuntimeError(f"Missing line {line} in output:\n{proc.stdout}")
 
-    assert_in("Skipping retired image ci_lint", proc.stdout)
     assert_in(expected, proc.stdout)
 
 

--- a/tests/scripts/ci.py
+++ b/tests/scripts/ci.py
@@ -167,7 +167,6 @@ def docker(
 
     # As sccache is added to these images these can be uncommented
     sccache_images = {
-        # "ci_lint",
         "ci_gpu",
         "ci_cpu",
         # "ci_wasm",
@@ -333,25 +332,26 @@ def serve_docs(directory: str = "_docs") -> None:
     cmd([sys.executable, "-m", "http.server"], cwd=directory_path)
 
 
-def lint(interactive: bool = False, fix: bool = False, docker_image: str | None = None) -> None:
+def lint(interactive: bool = False, docker_image: str | None = None) -> None:
     """
-    Run CI's Sanity Check step
+    Run lint checks locally.
 
     arguments:
-    interactive -- start a shell after running build / test scripts
-    fix -- where possible (currently black and clang-format) edit files in place with formatting fixes
-    docker-image -- manually specify the docker image to use
+    interactive -- start a shell after running build / test scripts when using --docker-image
+    docker-image -- manually specify a docker image to use
     """
-    env = {}
-    if fix:
-        env["IS_LOCAL"] = "true"
-        env["INPLACE_FORMAT"] = "true"
+    scripts = ["pre-commit run --all-files"]
+    if docker_image is None:
+        if interactive:
+            clean_exit("--interactive requires --docker-image")
+        cmd(scripts[0].split())
+        return
 
     docker(
-        name=gen_name("ci-lint"),
-        image="ci_lint" if docker_image is None else docker_image,
-        scripts=["pre-commit run --all-files"],
-        env=env,
+        name=gen_name("lint"),
+        image=docker_image,
+        scripts=scripts,
+        env={},
         interactive=interactive,
     )
 


### PR DESCRIPTION
This is the first step in retiring the unused `ci_lint` Docker image.

This PR removes `ci_lint` from the generated Jenkins Docker image matrix so new Jenkinsfiles no longer resolve, build, or deploy that image. It also skips `ci_lint` in the nightly Docker image updater and teaches `git_change_docker.sh` to ignore the lint Docker files that will be removed later.

The actual lint Docker files are intentionally kept in this PR for compatibility with the current Jenkins PR bootstrap path. Some PR Docker jobs may still run the main-branch pipeline while reading files from the PR checkout, and that older pipeline still passes `ci_lint` to `determine_docker_images.py` during prepare. Keeping the files and the temporary `docker-images.ini` entry avoids failing before the updated generated Jenkinsfiles take effect.

A follow-up PR can delete `docker/Dockerfile.ci_lint`, `docker/install/ubuntu_install_clang_format.sh`, `docker/lint.sh`, and the README lint Docker example after this lands.