### PR TITLE
[Relax] Update dropout call_tir out_ty spelling

### DIFF
--- a/tests/python/relax/test_transform_legalize_ops_nn.py
+++ b/tests/python/relax/test_transform_legalize_ops_nn.py
@@ -4198,7 +4198,7 @@ def test_dropout():
         @R.function
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tuple(R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")):
             cls = Expected
-            gv = R.call_tir(cls.dropout, (x,), out_sinfo=[R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")])
+            gv = R.call_tir(cls.dropout, (x,), out_ty=[R.Tensor((2, 3), dtype="float32"), R.Tensor((2, 3), dtype="float32")])
             return gv
     # fmt: on
 


### PR DESCRIPTION
This updates the remaining dropout expected TVMScript after the Relax call_tir spelling changed from out_sinfo to out_ty.

The affected call returns two tensors, matching nearby multi-output call_tir sites that already use out_ty=[...].