### PR TITLE
[CI][CMAKE] Install CUDA driver stub for libtvm_runtime_cuda

### DIFF
--- a/ci/scripts/package/manylinux_build_libtvm_runtime_cuda.sh
+++ b/ci/scripts/package/manylinux_build_libtvm_runtime_cuda.sh
@@ -18,9 +18,9 @@
 #
 # Build libtvm_runtime_cuda.so inside a manylinux CUDA container, run by the
 # build_cuda_runtime CI job. The official quay.io/manylinux_cuda images ship
-# the CUDA toolkit preinstalled under /usr/local/cuda, so no toolkit install
-# is needed here. Builds the sidecar into build-wheel-cuda/lib/ for the wheel
-# build to bundle.
+# the CUDA toolkit preinstalled under /usr/local/cuda, but omit the libcuda
+# driver stub, so we install just cuda-driver-devel from the image's CUDA repo.
+# Builds the sidecar into build-wheel-cuda/lib/ for the wheel build to bundle.
 #
 # Usage: manylinux_build_libtvm_runtime_cuda.sh
 set -euxo pipefail
@@ -28,6 +28,10 @@ set -euxo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 build_dir="${repo_root}/build-wheel-cuda"
 parallel="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+
+# The image ships the toolkit but not the libcuda driver stub; install it from
+# the image's CUDA repo so the sidecar links libcuda.so.1 (sync version with tag).
+dnf -y install cuda-driver-devel-13-1
 
 # Build the CUDA runtime sidecar with CUDA on and LLVM off, so it does not need
 # the LLVM prefix; the main CPU wheel links LLVM statically. The manylinux CUDA

--- a/cmake/modules/CUDA.cmake
+++ b/cmake/modules/CUDA.cmake
@@ -62,6 +62,13 @@ endif(USE_CUDA)
 if(USE_CUDA)
   message(STATUS "Build cuda device runtime")
 
+  # tvm_runtime_cuda links libcuda; without it the .so silently drops its
+  # libcuda.so.1 dependency, so fail configure instead.
+  if(NOT CUDA_CUDA_LIBRARY)
+    message(FATAL_ERROR "USE_CUDA is on but libcuda was not found. "
+      "Set -DCUDA_CUDA_LIBRARY=<path to libcuda.so> or make the driver stub discoverable.")
+  endif()
+
   tvm_file_glob(GLOB RUNTIME_CUDA_SRCS src/backend/cuda/runtime/*.cc)
   tvm_file_glob(GLOB VM_CUDA_BUILTIN_SRC_CC src/runtime/vm/cuda/*.cc)
 


### PR DESCRIPTION
The quay.io/manylinux_cuda image ships the CUDA toolkit but omits the libcuda driver stub (cuda-driver-devel). Without it CMake's FindCUDA leaves CUDA_CUDA_LIBRARY empty, and since a shared library links fine with undefined symbols, libtvm_runtime_cuda built with no libcuda.so.1 dependency -- ldd/readelf did not list it -- breaking downstream use.

Install cuda-driver-devel-13-1 from the CUDA repo already configured in the image (a ~45 KB package with no dependencies, not the full toolkit download). The stub lands under /usr/local/cuda/.../stubs where FindCUDA looks, so the sidecar links libcuda.so.1 again.

Also fail CMake configure with a clear error when CUDA_CUDA_LIBRARY is unset, so a missing driver stub can never again silently ship a runtime sidecar without its libcuda dependency.