### PR TITLE
[REFACTOR][RELAX] Rename Relax base type to AnyType

### DIFF
--- a/docs/arch/tvmscript.rst
+++ b/docs/arch/tvmscript.rst
@@ -275,7 +275,7 @@ The Relax builder (``ir_builder/relax/ir.py``) provides:
 - ``R.Tensor(shape, dtype)`` — tensor type
 - ``R.Tuple(*fields)`` — tuple type
 - ``R.Shape(values)`` — shape type
-- ``R.Object()`` — opaque object type
+- ``R.Any()`` — any Relax value type
 
 **Calling conventions**:
 
@@ -492,7 +492,7 @@ Function definition
        return result
 
 - ``R.Tensor(shape, dtype)`` — tensor type annotation.
-- ``R.Tuple(...)``, ``R.Shape(...)``, ``R.Object()`` — other Relax type annotations.
+- ``R.Tuple(...)``, ``R.Shape(...)``, ``R.Any()`` — other Relax type annotations.
 - ``R.function(private=True)`` — marks the function as module-private.
 - ``R.function(pure=False)`` — marks the function as having side effects.
 

--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -91,27 +91,31 @@ class PackedFuncType : public Type {
  * and simplifies assumptions during type deduction.
  */
 /*!
- * \brief Opaque object.
+ * \brief Any Relax value.
  */
-class ObjectTypeNode : public TypeNode {
+class AnyTypeNode : public TypeNode {
  public:
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
-    refl::ObjectDef<ObjectTypeNode>();
+    refl::ObjectDef<AnyTypeNode>();
   }
-  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.ObjectType", ObjectTypeNode, TypeNode);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.AnyType", AnyTypeNode, TypeNode);
 };
 
 /*!
- * \brief Managed reference to ObjectTypeNode.
- * \sa ObjectTypeNode
+ * \brief Managed reference to AnyTypeNode.
+ * \sa AnyTypeNode
  */
-class ObjectType : public Type {
+class AnyType : public Type {
  public:
-  TVM_DLL ObjectType(Span span = Span());
+  TVM_DLL AnyType(Span span = Span());
 
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(ObjectType, Type, ObjectTypeNode);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(AnyType, Type, AnyTypeNode);
 };
+
+// Compatibility aliases for existing C++ callers.  New code should use AnyType.
+using ObjectTypeNode = AnyTypeNode;
+using ObjectType = AnyType;
 
 /*!
  * \brief Type of shape value.
@@ -275,7 +279,7 @@ class FuncTypeNode : public TypeNode {
   /*!
    * \brief Derivation function of opaque functions that may take any number of parameters.
    * \note When derive_func is not empty, then params should be std::nullopt,
-   *       ret should be ObjectType()
+   *       ret should be AnyType()
    */
   ffi::Optional<TypeDeriveFunc> derive_func;
   /*!
@@ -333,7 +337,7 @@ class FuncType : public Type {
    * \param span The span of the AST.
    *
    * \return The FuncType for opaque packedfunc.
-   * \note Defaults to an derive func that always return ObjectType if not specified.
+   * \note Defaults to an derive func that always return AnyType if not specified.
    */
   TVM_DLL static FuncType OpaqueFunc(TypeDeriveFunc derive_func, bool purity = false,
                                      Span span = Span());
@@ -347,10 +351,9 @@ class FuncType : public Type {
    * \param span The span of the AST.
    *
    * \return The FuncType for opaque packedfunc.
-   * \note Defaults to an derive func that always return ObjectType if not specified.
+   * \note Defaults to an derive func that always return AnyType if not specified.
    */
-  TVM_DLL static FuncType OpaqueFunc(Type ret = ObjectType(), bool purity = false,
-                                     Span span = Span());
+  TVM_DLL static FuncType OpaqueFunc(Type ret = AnyType(), bool purity = false, Span span = Span());
 
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(FuncType, Type, FuncTypeNode);
 };

--- a/include/tvm/relax/type_functor.h
+++ b/include/tvm/relax/type_functor.h
@@ -77,7 +77,7 @@ class TypeFunctor<R(const Type& n, Args...)> {
     return vtable(n, this, std::forward<Args>(args)...);
   }
   // Functions that can be overriden by subclass
-  virtual R VisitType_(const ObjectTypeNode* op, Args... args) RELAX_TYPE_FUNCTOR_DEFAULT;
+  virtual R VisitType_(const AnyTypeNode* op, Args... args) RELAX_TYPE_FUNCTOR_DEFAULT;
   virtual R VisitType_(const PrimTypeNode* op, Args... args) RELAX_TYPE_FUNCTOR_DEFAULT;
   virtual R VisitType_(const ShapeTypeNode* op, Args... args) RELAX_TYPE_FUNCTOR_DEFAULT;
   virtual R VisitType_(const TensorTypeNode* op, Args... args) RELAX_TYPE_FUNCTOR_DEFAULT;
@@ -95,7 +95,7 @@ class TypeFunctor<R(const Type& n, Args...)> {
   static FType InitVTable() {
     FType vtable;
     // Set dispatch
-    TVM_RELAX_TYPE_FUNCTOR_DISPATCH(ObjectTypeNode);
+    TVM_RELAX_TYPE_FUNCTOR_DISPATCH(AnyTypeNode);
     TVM_RELAX_TYPE_FUNCTOR_DISPATCH(PrimTypeNode);
     TVM_RELAX_TYPE_FUNCTOR_DISPATCH(ShapeTypeNode);
     TVM_RELAX_TYPE_FUNCTOR_DISPATCH(TensorTypeNode);
@@ -114,7 +114,7 @@ class TypeFunctor<R(const Type& n, Args...)> {
  */
 class TVM_DLL TypeVisitor : public TypeFunctor<void(const Type& n)> {
  public:
-  void VisitType_(const ObjectTypeNode* op) override;
+  void VisitType_(const AnyTypeNode* op) override;
   void VisitType_(const PrimTypeNode* op) override;
   void VisitType_(const ShapeTypeNode* op) override;
   void VisitType_(const TensorTypeNode* op) override;
@@ -133,7 +133,7 @@ class TVM_DLL TypeVisitor : public TypeFunctor<void(const Type& n)> {
  */
 class TVM_DLL TypeMutator : public TypeFunctor<Type(const Type& n)> {
  public:
-  Type VisitType_(const ObjectTypeNode* op) override;
+  Type VisitType_(const AnyTypeNode* op) override;
   Type VisitType_(const PrimTypeNode* op) override;
   Type VisitType_(const ShapeTypeNode* op) override;
   Type VisitType_(const TensorTypeNode* op) override;

--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -53,6 +53,7 @@ from .expr import const, extern, get_shape_of
 # Type
 from .type import (
     Type,
+    AnyType,
     ObjectType,
     ShapeType,
     TensorType,

--- a/python/tvm/relax/frontend/nn/core.py
+++ b/python/tvm/relax/frontend/nn/core.py
@@ -46,7 +46,7 @@ from tvm.target import Target
 from .... import relax as rx
 from ...block_builder import BlockBuilder
 from ...type import (
-    ObjectType,
+    AnyType,
     ShapeType,
     TensorType,
     TupleType,
@@ -311,7 +311,7 @@ class Parameter(Tensor):
 
 class Object:
     """A wrapper on top of relax.Expr whose ty is the base
-    ObjectType (rather than any its subclass). Object effectively
+    AnyType, rather than a more specific subtype. Object effectively
     represents non-tensor frontend components such as KV caches.
     """
 
@@ -322,7 +322,7 @@ class Object:
         if not isinstance(_expr, rx.Var):
             _expr = BlockBuilder.current().emit(_expr, _name)
         self._expr = _expr
-        assert isinstance(self._expr.ty, ObjectType)
+        assert isinstance(self._expr.ty, AnyType)
 
 
 class Effect:

--- a/python/tvm/relax/frontend/nn/exporter.py
+++ b/python/tvm/relax/frontend/nn/exporter.py
@@ -26,7 +26,7 @@ from tvm.ir import IRModule
 
 from .... import relax as rx
 from ...block_builder import BlockBuilder
-from ...type import ObjectType, ShapeType, TupleType
+from ...type import AnyType, ShapeType, TupleType
 from . import core, extern
 from . import spec as _spec
 from .modules import IOEffect
@@ -311,7 +311,7 @@ def _method_spec_to_inputs(
                 name=arg_name,
             )
         elif isinstance(arg_spec, _spec.Object):
-            arg = arg_spec.object_type(_expr=rx.Var(arg_name, ObjectType()), _name=arg_name)
+            arg = arg_spec.object_type(_expr=rx.Var(arg_name, AnyType()), _name=arg_name)
         elif isinstance(arg_spec, _spec.Tuple):
             elements = type(arg_spec.elements)(
                 [

--- a/python/tvm/relax/frontend/nn/llm/kv_cache.py
+++ b/python/tvm/relax/frontend/nn/llm/kv_cache.py
@@ -241,7 +241,7 @@ class PagedKVCache(Object):  # pylint: disable=too-few-public-methods
                 self._expr,
                 rx.PrimValue(layer_id),  # type: ignore[arg-type]
                 kv._expr,
-                ty_args=rx.ObjectType(),
+                ty_args=rx.AnyType(),
             ),
             _name="paged_kv_cache",
         )
@@ -505,7 +505,7 @@ class FlashInferPagedKVCache(PagedKVCache):  # pylint: disable=too-few-public-me
             _expr=rx.call_pure_packed(
                 "vm.builtin.paged_attention_kv_cache_create",
                 *args,
-                ty_args=rx.ObjectType(),
+                ty_args=rx.AnyType(),
             ),
             _name=name,
         )
@@ -680,7 +680,7 @@ class TIRPagedKVCache(PagedKVCache):  # pylint: disable=too-few-public-methods
             _expr=rx.call_pure_packed(
                 "vm.builtin.paged_attention_kv_cache_create",
                 *args,
-                ty_args=rx.ObjectType(),
+                ty_args=rx.AnyType(),
             ),
             _name=name,
         )

--- a/python/tvm/relax/frontend/nn/modules.py
+++ b/python/tvm/relax/frontend/nn/modules.py
@@ -43,7 +43,7 @@ class IOEffect(Effect):
 
     def create(self, name_hint: str) -> list[rx.Var]:
         assert self.effect is None
-        effect = rx.Var(f"{name_hint}.io", ty=rx.ObjectType())
+        effect = rx.Var(f"{name_hint}.io", ty=rx.AnyType())
         return [effect]
 
     def set_state(self, state_vars: list[rx.Var]) -> None:
@@ -812,7 +812,7 @@ class KVCache(Effect):
                     rx.op.zeros(init_shape, self.dtype),
                     init_shape,
                     rx.PrimValue(0),
-                    ty_args=rx.ObjectType(),
+                    ty_args=rx.AnyType(),
                 ),
                 name_hint=name_hint,
             )
@@ -832,7 +832,7 @@ class KVCache(Effect):
         ret : List[relax.Var]
             The relax.Var for KVCache.
         """
-        cache = rx.Var(name_hint, ty=rx.ObjectType())
+        cache = rx.Var(name_hint, ty=rx.AnyType())
         return [cache]
 
     def set_state(self, state_vars: list[rx.Var]) -> None:
@@ -908,7 +908,7 @@ class KVCache(Effect):
                 self.cache,
                 new_element._expr,
                 inplace_indices=[0],
-                ty_args=rx.ObjectType(),
+                ty_args=rx.AnyType(),
             )
         )
 

--- a/python/tvm/relax/frontend/nn/op.py
+++ b/python/tvm/relax/frontend/nn/op.py
@@ -2280,7 +2280,7 @@ def debug_func(
             rx.StringImm(name),
             rx.StringImm(_line_info),
             *converted_args,
-            ty_args=[rx.ObjectType()],
+            ty_args=[rx.AnyType()],
         ),
         name_hint=io.effect.name_hint,
     )

--- a/python/tvm/relax/frontend/torch/exported_program_translator.py
+++ b/python/tvm/relax/frontend/torch/exported_program_translator.py
@@ -1433,7 +1433,7 @@ class ExportedProgramImporter(BaseFXGraphImporter):
                 elif hasattr(operand, "ty"):
                     si = operand.ty
                 else:
-                    si = relax.ObjectType()
+                    si = relax.AnyType()
                 param = relax.Var(ph.name, si)
                 params.append(param)
                 self.env[ph] = param

--- a/python/tvm/relax/script/parser/__init__.py
+++ b/python/tvm/relax/script/parser/__init__.py
@@ -24,7 +24,7 @@ from tvm.relax.script.builder import *  # pylint: disable=redefined-builtin
 from tvm.relax.script.builder import ir as _relax
 
 from . import parser as _parser
-from .entry import Callable, Object, Prim, Shape, Tensor, Tuple, match_cast
+from .entry import Any, Callable, Object, Prim, Shape, Tensor, Tuple, match_cast
 
 from . import dist
 from .dist import *  # pylint: disable=wildcard-import,redefined-builtin
@@ -39,6 +39,7 @@ else:
 
 __all__ = _relax.__all__ + [
     "dist",
+    "Any",
     "Callable",
     "Object",
     "Prim",

--- a/python/tvm/relax/script/parser/entry.py
+++ b/python/tvm/relax/script/parser/entry.py
@@ -22,10 +22,10 @@ from typing import Any, TypeVar
 import tvm
 from tvm.ir import PrimType
 from tvm.relax import (
+    AnyType,
     Expr,
     Function,
     FuncType,
-    ObjectType,
     SeqExpr,
     ShapeExpr,
     ShapeType,
@@ -156,11 +156,11 @@ class TypeProxy(ObjectConvertible):
         return self.as_ty(None)
 
 
-############################### R.Object ################################
+############################### R.Any ################################
 
 
-class ObjectProxy(TypeProxy):
-    """The proxy fo ObjectType.
+class AnyProxy(TypeProxy):
+    """The proxy for AnyType.
 
     Parameters
     ----------
@@ -177,12 +177,19 @@ class ObjectProxy(TypeProxy):
     def get_symbolic_vars(self) -> set[str]:
         return set()
 
-    def as_ty(self, dict_globals: dict[str, Any] | None = None) -> ObjectType:
-        return ObjectType()
+    def as_ty(self, dict_globals: dict[str, Any] | None = None) -> AnyType:
+        return AnyType()
 
 
-def Object() -> ObjectProxy:
-    return ObjectProxy()
+def Any() -> AnyProxy:
+    return AnyProxy()
+
+
+ObjectProxy = AnyProxy
+
+
+def Object() -> AnyProxy:
+    return AnyProxy()
 
 
 ############################### R.Tensor ###############################

--- a/python/tvm/relax/script/parser/parser.py
+++ b/python/tvm/relax/script/parser/parser.py
@@ -269,9 +269,9 @@ def visit_tvm_declare_function(self: Parser, node: doc.FunctionDef) -> GlobalVar
         collect_symbolic_var_from_params(self, node)
 
         if node.returns is None:
-            # Use ObjectType as unknown return type
+            # Use AnyType as unknown return type
             # NOTE: Cannot use VoidType here because the return type can be refined later.
-            ret_ty = relax.ObjectType()
+            ret_ty = relax.AnyType()
         else:
             ret_ty = eval_ty(self, node.returns, eval_str=True)
         params = []

--- a/python/tvm/relax/testing/ast_printer.py
+++ b/python/tvm/relax/testing/ast_printer.py
@@ -240,8 +240,8 @@ class ASTPrinter(ExprFunctor):
         """
         if isinstance(type_node, relax.ShapeType):
             return self.build_ast_node("ShapeType", ndim=str(type_node.ndim))
-        if isinstance(type_node, relax.ObjectType):
-            return self.build_ast_node("ObjectType")
+        if isinstance(type_node, relax.AnyType):
+            return self.build_ast_node("AnyType")
         if isinstance(type_node, relax.PackedFuncType):
             return self.build_ast_node("PackedFuncType")
         if isinstance(type_node, tvm.ir.PrimType):
@@ -279,8 +279,8 @@ class ASTPrinter(ExprFunctor):
             if ty_node.values is not None:
                 fields["values"] = self.build_list(map(self.visit_prim_expr_, ty_node.values))
             return self.build_ast_node("ShapeType", **fields)
-        elif isinstance(ty_node, relax.ObjectType):
-            return self.build_ast_node("ObjectType")
+        elif isinstance(ty_node, relax.AnyType):
+            return self.build_ast_node("AnyType")
         elif isinstance(ty_node, tvm.ir.PrimType):
             return self.build_ast_node("PrimType", dtype=ty_node.dtype)
         elif isinstance(ty_node, relax.TensorType):

--- a/python/tvm/relax/transform/lazy_transform_params.py
+++ b/python/tvm/relax/transform/lazy_transform_params.py
@@ -177,12 +177,12 @@ class LazyTransformParamsFuncCreator:
             if leaf_outputs:
                 new_bindings = [
                     relax.VarBinding(
-                        relax.Var("_", relax.ObjectType()),
+                        relax.Var("_", relax.AnyType()),
                         relax.Call(
                             relax.ExternFunc(self.fset_item),
                             [*self.extra_set_item_params, index, expr],
                             None,
-                            [relax.ObjectType()],
+                            [relax.AnyType()],
                         ),
                     )
                     for expr, indices in leaf_outputs.items()
@@ -222,7 +222,7 @@ class LazyTransformParamsFuncCreator:
         return relax.Function(
             params,
             new_body,
-            relax.ObjectType(),
+            relax.AnyType(),
             attrs=func.attrs,
             is_pure=False,
         ).without_attr("relax.force_pure")
@@ -268,7 +268,7 @@ class LazyInputMutator(PyExprMutator):
                     relax.ExternFunc(self.func_creator.fget_item),
                     self.func_creator.extra_get_item_params + [relax.PrimValue(index)],
                     None,
-                    [relax.ObjectType()],
+                    [relax.AnyType()],
                 )
             )
             match_cast = relax.MatchCast(var, get_item_result, var.ty)
@@ -289,7 +289,7 @@ class LazyInputMutator(PyExprMutator):
                     relax.ExternFunc(self.func_creator.fget_item),
                     self.func_creator.extra_get_item_params + [relax.PrimValue(node.index)],
                     None,
-                    [relax.ObjectType()],
+                    [relax.AnyType()],
                 )
             )
             return self.builder_.match_cast(get_item_result, ty)
@@ -329,7 +329,7 @@ class LazyOutputMutator(PyExprMutator):
                                 self.func_creator.extra_set_item_params
                                 + [index, super().visit_var_(var)],
                                 None,
-                                [relax.ObjectType()],
+                                [relax.AnyType()],
                             ),
                             name_hint="_",
                         )

--- a/python/tvm/relax/transform/lower_gpu_ipc_alloc_storage.py
+++ b/python/tvm/relax/transform/lower_gpu_ipc_alloc_storage.py
@@ -74,7 +74,7 @@ class _Rewriter(PyExprMutator):
         ipc_alloc_storage = relax.Call(
             relax.ExternFunc("runtime.disco.cuda_ipc.alloc_storage"),
             args=[shape, dtype],
-            ty_args=[relax.ObjectType()],
+            ty_args=[relax.AnyType()],
         )
         return relax.Call(
             self.memory_alloc_tensor_op,

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -334,7 +334,7 @@ def LazyGetInput() -> tvm.ir.transform.Pass:
             ...
 
         @R.function
-        def after(fget_param: R.Callable([R.Prim('int64'), R.Object], R.Object)):
+        def after(fget_param: R.Callable([R.Prim('int64'), R.Any], R.Any)):
             A_untyped = fget_param(0, R.str('A'))
             A = R.match_cast(A_untyped, R.Tensor([16,32], "float32")
             ...
@@ -372,7 +372,7 @@ def LazySetOutput() -> tvm.ir.transform.Pass:
             return (A, B)
 
         @R.function
-        def after(args, fset_param: R.Callable([R.Prim('int64'), R.Object])):
+        def after(args, fset_param: R.Callable([R.Prim('int64'), R.Any])):
             ...
             fset_param(0, A)
             ...

--- a/python/tvm/relax/type.py
+++ b/python/tvm/relax/type.py
@@ -28,12 +28,15 @@ from .expr import Expr, ShapeExpr, Type
 from .ty import PackedFuncType
 
 
-@tvm_ffi.register_object("relax.ObjectType")
-class ObjectType(Type):
-    """Type of an Object."""
+@tvm_ffi.register_object("relax.AnyType")
+class AnyType(Type):
+    """Type of any Relax value."""
 
     def __init__(self, span: Span = None) -> None:
-        self.__init_handle_by_constructor__(_ffi_api.ObjectType, span)  # type: ignore
+        self.__init_handle_by_constructor__(_ffi_api.AnyType, span)  # type: ignore
+
+
+ObjectType = AnyType
 
 
 @tvm_ffi.register_object("relax.ShapeType")

--- a/src/relax/analysis/type_analysis.cc
+++ b/src/relax/analysis/type_analysis.cc
@@ -41,7 +41,7 @@ namespace relax {
 //--------------------------
 class StaticTypeDeriver : public TypeFunctor<Type(const Type&)> {
  public:
-  Type VisitType_(const ObjectTypeNode* op) final { return ObjectType(op->span); }
+  Type VisitType_(const AnyTypeNode* op) final { return AnyType(op->span); }
 
   Type VisitType_(const PrimTypeNode* op) final { return tvm::PrimType(op->dtype); }
 
@@ -52,7 +52,7 @@ class StaticTypeDeriver : public TypeFunctor<Type(const Type&)> {
   }
 
   // module: distributed
-  Type VisitType_(const distributed::DTensorTypeNode* op) final { return ObjectType(); }
+  Type VisitType_(const distributed::DTensorTypeNode* op) final { return AnyType(); }
   // end-module: distributed
 
   Type VisitType_(const TupleTypeNode* op) final {
@@ -83,8 +83,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 //--------------------------
 
 Type TypeFromStaticType(const Type& type) {
-  if (type.as<ObjectTypeNode>()) {
-    return ObjectType(type->span);
+  if (type.as<AnyTypeNode>()) {
+    return AnyType(type->span);
   } else if (const PrimTypeNode* prim_type = type.as<PrimTypeNode>()) {
     return tvm::PrimType(prim_type->dtype);
   } else if (const tvm::PrimTypeNode* prim_type = type.as<tvm::PrimTypeNode>()) {
@@ -305,15 +305,15 @@ class TypeBaseChecker : public TypeFunctor<BaseCheckResult(const Type&, const Ty
     return TypeFunctor::VisitType(lhs, other);
   }
 
-  // ffi::Object is base of everything
-  BaseCheckResult VisitType_(const ObjectTypeNode* lhs, const Type& other) final {
+  // AnyType is base of every Relax type
+  BaseCheckResult VisitType_(const AnyTypeNode* lhs, const Type& other) final {
     return BaseCheckResult::kPass;
   }
 
   BaseCheckResult VisitType_(const PrimTypeNode* lhs, const Type& other) final {
     auto* rhs = other.as<PrimTypeNode>();
     if (rhs == nullptr) {
-      if (other.as<ObjectTypeNode>()) return BaseCheckResult::kFailL1;
+      if (other.as<AnyTypeNode>()) return BaseCheckResult::kFailL1;
       return BaseCheckResult::kFailL0;
     }
 
@@ -327,7 +327,7 @@ class TypeBaseChecker : public TypeFunctor<BaseCheckResult(const Type&, const Ty
   BaseCheckResult VisitType_(const ShapeTypeNode* lhs, const Type& other) final {
     auto* rhs = other.as<ShapeTypeNode>();
     if (rhs == nullptr) {
-      if (other.as<ObjectTypeNode>()) return BaseCheckResult::kFailL1;
+      if (other.as<AnyTypeNode>()) return BaseCheckResult::kFailL1;
       return BaseCheckResult::kFailL0;
     }
     // lhs have unknown ndim
@@ -351,7 +351,7 @@ class TypeBaseChecker : public TypeFunctor<BaseCheckResult(const Type&, const Ty
   BaseCheckResult VisitType_(const TensorTypeNode* lhs, const Type& other) final {
     auto* rhs = other.as<TensorTypeNode>();
     if (rhs == nullptr) {
-      if (other.as<ObjectTypeNode>()) return BaseCheckResult::kFailL1;
+      if (other.as<AnyTypeNode>()) return BaseCheckResult::kFailL1;
       return BaseCheckResult::kFailL0;
     }
     // dtype mismatch
@@ -394,7 +394,7 @@ class TypeBaseChecker : public TypeFunctor<BaseCheckResult(const Type&, const Ty
   BaseCheckResult VisitType_(const distributed::DTensorTypeNode* lhs, const Type& other) final {
     auto* rhs = other.as<distributed::DTensorTypeNode>();
     if (rhs == nullptr) {
-      if (other.as<ObjectTypeNode>()) return BaseCheckResult::kFailL1;
+      if (other.as<AnyTypeNode>()) return BaseCheckResult::kFailL1;
       return BaseCheckResult::kFailL0;
     }
     BaseCheckResult tensor_ty_check_result = this->VisitType(lhs->tensor_ty, rhs->tensor_ty);
@@ -412,7 +412,7 @@ class TypeBaseChecker : public TypeFunctor<BaseCheckResult(const Type&, const Ty
   BaseCheckResult VisitType_(const TupleTypeNode* lhs, const Type& other) final {
     auto* rhs = other.as<TupleTypeNode>();
     if (rhs == nullptr) {
-      if (other.as<ObjectTypeNode>()) return BaseCheckResult::kFailL1;
+      if (other.as<AnyTypeNode>()) return BaseCheckResult::kFailL1;
       return BaseCheckResult::kFailL0;
     }
     return ArrayCheck(lhs->fields, rhs->fields);
@@ -421,7 +421,7 @@ class TypeBaseChecker : public TypeFunctor<BaseCheckResult(const Type&, const Ty
   BaseCheckResult VisitType_(const FuncTypeNode* lhs, const Type& other) override {
     auto* rhs = other.as<FuncTypeNode>();
     if (rhs == nullptr) {
-      if (other.as<ObjectTypeNode>()) return BaseCheckResult::kFailL1;
+      if (other.as<AnyTypeNode>()) return BaseCheckResult::kFailL1;
       return BaseCheckResult::kFailL0;
     }
 
@@ -625,7 +625,7 @@ class TypeBasePreconditionCollector : public TypeFunctor<PrimExpr(const Type&, c
     }
   }
 
-  PrimExpr VisitType_(const ObjectTypeNode* lhs, const Type& other) final {
+  PrimExpr VisitType_(const AnyTypeNode* lhs, const Type& other) final {
     return IntImm::Bool(true);
   }
 
@@ -977,25 +977,25 @@ class TypeLCAFinder : public TypeFunctor<Type(const Type&, const Type&)> {
     return TypeFunctor::VisitType(lhs, other);
   }
 
-  // ffi::Object is based of everything, unify to object.
-  Type VisitType_(const ObjectTypeNode* lhs, const Type& other) final {
+  // AnyType is base of every Relax type, unify to Any.
+  Type VisitType_(const AnyTypeNode* lhs, const Type& other) final {
     return ffi::GetRef<Type>(lhs);
   }
 
   Type VisitType_(const PrimTypeNode* lhs, const Type& other) final {
     auto* rhs = other.as<PrimTypeNode>();
-    if (rhs == nullptr) return ObjectType(lhs->span);
+    if (rhs == nullptr) return AnyType(lhs->span);
     if (lhs->dtype != rhs->dtype) {
-      // PrimType will be treated as their boxed(object) values
-      // as a result we can unify to object.
-      return ObjectType(lhs->span);
+      // PrimType will be treated as their boxed Any values
+      // as a result we can unify to Any.
+      return AnyType(lhs->span);
     }
     return ffi::GetRef<Type>(lhs);
   }
 
   Type VisitType_(const ShapeTypeNode* lhs, const Type& other) final {
     auto* rhs = other.as<ShapeTypeNode>();
-    if (rhs == nullptr) return ObjectType(lhs->span);
+    if (rhs == nullptr) return AnyType(lhs->span);
 
     int ndim = lhs->ndim == rhs->ndim ? lhs->ndim : kUnknownNDim;
     if (lhs->ndim != rhs->ndim || !lhs->values.defined() || !rhs->values.defined() ||
@@ -1014,7 +1014,7 @@ class TypeLCAFinder : public TypeFunctor<Type(const Type&, const Type&)> {
 
   Type VisitType_(const TensorTypeNode* lhs, const Type& other) final {
     auto* rhs = other.as<TensorTypeNode>();
-    if (rhs == nullptr) return ObjectType(lhs->span);
+    if (rhs == nullptr) return AnyType(lhs->span);
 
     // find the target dtype, ndim, and vdevice.
     PrimType dtype = lhs->dtype->dtype == rhs->dtype->dtype
@@ -1049,10 +1049,10 @@ class TypeLCAFinder : public TypeFunctor<Type(const Type&, const Type&)> {
 
   Type VisitType_(const TupleTypeNode* lhs, const Type& other) final {
     auto* rhs = other.as<TupleTypeNode>();
-    if (rhs == nullptr) return ObjectType(lhs->span);
+    if (rhs == nullptr) return AnyType(lhs->span);
     ffi::Optional<ffi::Array<Type>> fields = UnifyArray(lhs->fields, rhs->fields);
     // tuple length not the same.
-    if (!fields.defined()) return ObjectType(lhs->span);
+    if (!fields.defined()) return AnyType(lhs->span);
 
     // same length tuple.
     if (!fields.same_as(lhs->fields)) {
@@ -1064,7 +1064,7 @@ class TypeLCAFinder : public TypeFunctor<Type(const Type&, const Type&)> {
 
   Type VisitType_(const FuncTypeNode* lhs, const Type& other) final {
     auto* rhs = other.as<FuncTypeNode>();
-    if (rhs == nullptr) return ObjectType(lhs->span);
+    if (rhs == nullptr) return AnyType(lhs->span);
 
     // the unified function is pure only if both are pure
     bool purity = lhs->purity && rhs->purity;
@@ -1076,7 +1076,7 @@ class TypeLCAFinder : public TypeFunctor<Type(const Type&, const Type&)> {
           return ffi::GetRef<Type>(lhs);
         } else {
           // Create a new opaque with object return
-          return FuncType::OpaqueFunc(ObjectType(), purity, lhs->span);
+          return FuncType::OpaqueFunc(AnyType(), purity, lhs->span);
         }
       } else {
         // no derivation function, only depends on ret

--- a/src/relax/backend/vm/lower_runtime_builtin.cc
+++ b/src/relax/backend/vm/lower_runtime_builtin.cc
@@ -217,7 +217,7 @@ class LowerRuntimeBuiltinMutator : public ExprMutator {
   }
 
   const Op& call_builtin_with_ctx_op_ = Op::Get("relax.call_builtin_with_ctx");
-  const Type object_ty_ = ObjectType();
+  const Type object_ty_ = AnyType();
   const Type void_ty_ = TupleType(ffi::Array<Type>({}));
   // object to pattern match.
   const Op& call_tir_dyn_op_ = Op::Get("relax.vm.call_tir_dyn");

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -337,9 +337,9 @@ class VMShapeLowerMutator
       UpdateType(call, heap_ty);
       return VarBinding(var, call);
     } else {
-      Var var("shape_heap", ObjectType());
+      Var var("shape_heap", AnyType());
       Call call(null_value_op_, {});
-      UpdateType(call, ObjectType());
+      UpdateType(call, AnyType());
       return VarBinding(var, call);
     }
   }
@@ -638,7 +638,7 @@ class VMShapeLowerMutator
     return TypeFunctor::VisitType(ty, value, always_check, dynamic_only, err_ctx, match_todos);
   }
 
-  void VisitType_(const ObjectTypeNode* op, Expr value, bool always_check, bool dynamic_only,
+  void VisitType_(const AnyTypeNode* op, Expr value, bool always_check, bool dynamic_only,
                   const ffi::String& err_ctx, std::vector<MatchShapeTodoItem>* match_todos) final {}
 
   void VisitType_(const PrimTypeNode* op, Expr value, bool always_check, bool dynamic_only,
@@ -717,7 +717,7 @@ class VMShapeLowerMutator
     } else {
       // call runtime tuple get item, and return a object.
       Call call(builtin_tuple_getitem_, {value, PrimValue::Int64(index)}, Attrs(), {object_ty_});
-      UpdateType(call, ObjectType());
+      UpdateType(call, AnyType());
       return call;
     }
   }
@@ -776,7 +776,7 @@ class VMShapeLowerMutator
   const Op& call_builtin_with_ctx_op_ = Op::Get("relax.call_builtin_with_ctx");
   const Op& null_value_op_ = Op::Get("relax.null_value");
   // common type
-  const Type object_ty_ = ObjectType();
+  const Type object_ty_ = AnyType();
   const Type void_ty_ = TupleType(ffi::Array<Type>({}));
   // check function
   const ExternFunc builtin_alloc_shape_heap_{"vm.builtin.alloc_shape_heap"};

--- a/src/relax/ir/dependent_type.cc
+++ b/src/relax/ir/dependent_type.cc
@@ -31,21 +31,23 @@ namespace tvm {
 namespace relax {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
-  ObjectTypeNode::RegisterReflection();
+  AnyTypeNode::RegisterReflection();
   ShapeTypeNode::RegisterReflection();
   TensorTypeNode::RegisterReflection();
   FuncTypeNode::RegisterReflection();
 }
 
-ObjectType::ObjectType(Span span) {
-  ffi::ObjectPtr<ObjectTypeNode> n = ffi::make_object<ObjectTypeNode>();
+AnyType::AnyType(Span span) {
+  ffi::ObjectPtr<AnyTypeNode> n = ffi::make_object<AnyTypeNode>();
   n->span = span;
   data_ = std::move(n);
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("relax.ObjectType", [](Span span) { return ObjectType(span); });
+  refl::GlobalDef()
+      .def("relax.AnyType", [](Span span) { return AnyType(span); })
+      .def("relax.ObjectType", [](Span span) { return AnyType(span); });
 }
 
 // Shape
@@ -141,7 +143,7 @@ FuncType::FuncType(ffi::Array<Type> params, Type ret, bool purity, Span span) {
 FuncType FuncType::OpaqueFunc(TypeDeriveFunc derive_func, bool purity, Span span) {
   ffi::ObjectPtr<FuncTypeNode> n = ffi::make_object<FuncTypeNode>();
   n->derive_func = std::move(derive_func);
-  n->ret = ObjectType();
+  n->ret = AnyType();
   n->purity = std::move(purity);
   n->span = span;
   return FuncType(n);
@@ -167,7 +169,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           TVM_FFI_CHECK(!ret.defined(), ValueError) << "Cannot specify both ret and derive_func";
           return FuncType::OpaqueFunc(derive_func.value(), purity, span);
         } else {
-          return FuncType::OpaqueFunc(ret.value_or(ObjectType()), purity, span);
+          return FuncType::OpaqueFunc(ret.value_or(AnyType()), purity, span);
         }
       });
 }

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -386,7 +386,7 @@ StringImm::StringImm(ffi::String value, Span span) {
   ffi::ObjectPtr<StringImmNode> n = ffi::make_object<StringImmNode>();
   n->value = std::move(value);
   n->span = std::move(span);
-  n->ty = ObjectType();
+  n->ty = AnyType();
   data_ = std::move(n);
 }
 
@@ -400,7 +400,7 @@ DataTypeImm::DataTypeImm(DLDataType value, Span span) {
   ffi::ObjectPtr<DataTypeImmNode> n = ffi::make_object<DataTypeImmNode>();
   n->value = value;
   n->span = std::move(span);
-  n->ty = ObjectType();
+  n->ty = AnyType();
   data_ = std::move(n);
 }
 
@@ -656,7 +656,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   auto infer_by_ty_args = [](const Call& call, const BlockBuilder& ctx) -> Type {
     TVM_FFI_ICHECK(call->ty_args.defined()) << "ty_args field of CallNode should always be defined";
     if (call->ty_args.empty()) {
-      return ObjectType();
+      return AnyType();
     } else if (call->ty_args.size() == 1) {
       return call->ty_args[0];
     } else {

--- a/src/relax/ir/type_functor.cc
+++ b/src/relax/ir/type_functor.cc
@@ -27,7 +27,7 @@
 namespace tvm {
 namespace relax {
 
-void TypeVisitor::VisitType_(const ObjectTypeNode* op) {}
+void TypeVisitor::VisitType_(const AnyTypeNode* op) {}
 
 void TypeVisitor::VisitType_(const PrimTypeNode* op) {}
 
@@ -64,7 +64,7 @@ void TypeVisitor::VisitType_(const FuncTypeNode* op) {
   this->VisitType(op->ret);
 }
 
-Type TypeMutator::VisitType_(const ObjectTypeNode* op) { return ffi::GetRef<Type>(op); }
+Type TypeMutator::VisitType_(const AnyTypeNode* op) { return ffi::GetRef<Type>(op); }
 
 Type TypeMutator::VisitType_(const PrimTypeNode* op) { return ffi::GetRef<Type>(op); }
 

--- a/src/relax/op/memory/view.cc
+++ b/src/relax/op/memory/view.cc
@@ -108,12 +108,12 @@ Type InferTypeView(const Call& call, const BlockBuilder& ctx) {
     // In general, Type inference should only depend on the
     // Type of the arguments, and not on the arguments
     // themselves.  However, `relax::DataTypeImm` uses
-    // `ObjectType`, so we need to inspect the argument itself
+    // `AnyType`, so we need to inspect the argument itself
     // in this case.
     if (auto dtype_imm = arg_value.as<DataTypeImmNode>()) {
       // We know the datatype for the view.
       return dtype_imm->value;
-    } else if (ty.as<ObjectTypeNode>()) {
+    } else if (ty.as<AnyTypeNode>()) {
       // The view changes the datatype, but we don't know what it is
       // being changed into.
       return DLDataType{kDLOpaqueHandle, 0, 0};

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -63,7 +63,7 @@ Type ReturnVoidType(const Call& call, const BlockBuilder& ctx) {
   return TupleType(ffi::Array<Type>());
 }
 
-Type ReturnObjectType(const Call& call, const BlockBuilder& ctx) { return ObjectType(); }
+Type ReturnAnyType(const Call& call, const BlockBuilder& ctx) { return AnyType(); }
 
 Type InferTypeShapeOf(const Call& call, const BlockBuilder& ctx) {
   // use the Type of the argument
@@ -942,7 +942,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
 TVM_REGISTER_OP("relax.null_value")
     .set_num_inputs(0)
-    .set_attr<FInferType>("FInferType", ReturnObjectType)
+    .set_attr<FInferType>("FInferType", ReturnAnyType)
     .set_attr<bool>("FPurity", true);
 
 Expr MakeCallNullValue() {
@@ -1032,7 +1032,7 @@ TVM_REGISTER_OP("relax.make_closure")
     .set_num_inputs(2)
     .add_argument("func", "Expr", "The closure.")
     .add_argument("args", "Tuple", "The captured variables.")
-    .set_attr<FInferType>("FInferType", ReturnObjectType)
+    .set_attr<FInferType>("FInferType", ReturnAnyType)
     .set_attr<bool>("FPurity", true);
 
 Expr MakeClosure(Expr func, Tuple args) {
@@ -1049,7 +1049,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
 Type InferTypeInvokeClosure(const Call& call, const BlockBuilder& ctx) {
   if (call->ty_args.empty()) {
-    return ObjectType();
+    return AnyType();
   } else if (call->ty_args.size() == 1) {
     return call->ty_args[0];
   } else {
@@ -1263,7 +1263,7 @@ TVM_REGISTER_OP("relax.memory.alloc_storage")
     .add_argument("storage_scope", "StringImm",
                   "The storage scope of the storage to allocate. Default is global.")
     .add_argument("dtype", "DataTypeImm", "The dtype of the tensor to allocate.")
-    .set_attr<FInferType>("FInferType", ReturnObjectType)
+    .set_attr<FInferType>("FInferType", ReturnAnyType)
     // memory allocation isn't considered a "visible effect" as far as purity is concerned
     .set_attr<bool>("FPurity", true)
     .set_attr<bool>("TAllocator", true);
@@ -1389,7 +1389,7 @@ TVM_REGISTER_OP("relax.vm.alloc_storage")
                   "to be allocated at runtime.")
     .add_argument("storage_scope", "StringImm",
                   "The storage scope of the storage to allocate. Default is global.")
-    .set_attr<FInferType>("FInferType", ReturnObjectType)
+    .set_attr<FInferType>("FInferType", ReturnAnyType)
     // memory allocation isn't considered a "visible effect" as far as purity is concerned
     .set_attr<bool>("FPurity", true)
     .set_attr<bool>("TAllocator", true);

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -208,10 +208,10 @@ template <typename PrimType = PrimExpr,
 ffi::Optional<ffi::Array<PrimType>> UnpackTupleOfPrimValue(ffi::Optional<Type> ty) {
   if (!ty) return std::nullopt;
 
-  // An ObjectType may contain a tuple of the desired type, but
+  // An AnyType may contain a tuple of the desired type, but
   // it isn't yet known whether it does.  Return early, as we cannot
   // provide a known `ffi::Array<PrimType>` to the caller.
-  if (ty.as<ObjectTypeNode>()) return std::nullopt;
+  if (ty.as<AnyTypeNode>()) return std::nullopt;
 
   auto tuple = ty.as<TupleTypeNode>();
   TVM_FFI_CHECK(tuple, TypeError) << "The type " << ty
@@ -222,7 +222,7 @@ ffi::Optional<ffi::Array<PrimType>> UnpackTupleOfPrimValue(ffi::Optional<Type> t
   for (size_t i = 0; i < tuple->fields.size(); i++) {
     auto field = tuple->fields[i];
 
-    if (field.as<ObjectTypeNode>()) return std::nullopt;
+    if (field.as<AnyTypeNode>()) return std::nullopt;
 
     auto prim_ty = field.as<PrimTypeNode>();
     TVM_FFI_CHECK(prim_ty, TypeError)
@@ -321,7 +321,7 @@ Type InferTypeStridedSlice(const Call& call, const BlockBuilder& ctx) {
   // so will require a way to represent a `relax::TupleType` of
   // unknown length, where each element has the same `Type`.
   auto is_base_of_tuple_of_int64 = [&](const Type& ty) -> bool {
-    if (ty.as<ObjectTypeNode>()) {
+    if (ty.as<AnyTypeNode>()) {
       return true;
     }
 

--- a/src/relax/script/printer/dependent_type.cc
+++ b/src/relax/script/printer/dependent_type.cc
@@ -26,10 +26,8 @@ namespace script {
 namespace printer {
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::ObjectType>(  //
-        "", [](relax::ObjectType n, AccessPath n_p, IRDocsifier d) -> Doc {
-          return Relax(d, "Object");
-        });
+    .set_dispatch<relax::AnyType>(  //
+        "", [](relax::AnyType n, AccessPath n_p, IRDocsifier d) -> Doc { return Relax(d, "Any"); });
 
 ExprDoc PrintShapeVar(const PrimExpr& e, const AccessPath& e_p, const IRDocsifier& d) {
   ExprDoc expr_doc = d->AsDoc<ExprDoc>(e, e_p);
@@ -130,7 +128,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
             ffi::Array<ffi::String> keys;
             ffi::Array<ExprDoc, void> values;
 
-            if (!n->ret->IsInstance<relax::ObjectTypeNode>()) {
+            if (!n->ret->IsInstance<relax::AnyTypeNode>()) {
               keys.push_back("ret");
               values.push_back(ret_doc);
             }
@@ -155,7 +153,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           return Relax(d, "Callable")->Call({TupleDoc(params_doc), ret_doc, purity_doc});
         });
 
-TVM_REGISTER_SCRIPT_AS_REPR(relax::ObjectTypeNode, ReprPrintRelax);
+TVM_REGISTER_SCRIPT_AS_REPR(relax::AnyTypeNode, ReprPrintRelax);
 TVM_REGISTER_SCRIPT_AS_REPR(relax::ShapeTypeNode, ReprPrintRelax);
 TVM_REGISTER_SCRIPT_AS_REPR(relax::TensorTypeNode, ReprPrintRelax);
 TVM_REGISTER_SCRIPT_AS_REPR(relax::FuncTypeNode, ReprPrintRelax);

--- a/src/relax/script/printer/function.cc
+++ b/src/relax/script/printer/function.cc
@@ -25,7 +25,7 @@ namespace printer {
 static bool HasDefaultExternFuncType(const relax::ExternFunc& n) {
   const auto* ty = n->ty.as<relax::FuncTypeNode>();
   if (ty == nullptr || ty->params.defined() || ty->purity ||
-      !ty->ret->IsInstance<relax::ObjectTypeNode>()) {
+      !ty->ret->IsInstance<relax::AnyTypeNode>()) {
     return false;
   }
   return true;

--- a/src/relax/transform/kill_after_last_use.cc
+++ b/src/relax/transform/kill_after_last_use.cc
@@ -197,7 +197,7 @@ class CollectLastUsage : public ExprVisitor {
 
   // Storage objects, eligible for R.vm.kill_object.  This cannot be
   // determined solely from the Type, because the
-  // `R.*.alloc_storage` operators return ObjectType
+  // `R.*.alloc_storage` operators return AnyType
   std::unordered_set<const VarNode*> storage_objects_;
 
   // Constants, which do not have a VM register, and may *not* have

--- a/src/relax/transform/lazy_transform_params.cc
+++ b/src/relax/transform/lazy_transform_params.cc
@@ -65,7 +65,7 @@ class LazyInputMutator : public ExprMutator {
       param_lookup.insert({func->params[i], i - num_input_params});
     }
 
-    Var fget_param("fget_param", FuncType({PrimType::Int(64), ObjectType()}, ObjectType()));
+    Var fget_param("fget_param", FuncType({PrimType::Int(64), AnyType()}, AnyType()));
 
     ffi::Array<Var> new_params(func->params.begin(), func->params.begin() + num_input_params);
     new_params.push_back(fget_param);
@@ -144,7 +144,7 @@ class LazyOutputMutator : public ExprMutator {
       define_lookup(0, func_body->body);
     }
 
-    Var fset_output("fset_output", FuncType({PrimType::Int(64), ObjectType()},
+    Var fset_output("fset_output", FuncType({PrimType::Int(64), AnyType()},
                                             TupleType(ffi::Array<Type>{}), /* purity = */ false));
     plan_ = FunctionPlan{std::move(output_lookup), fset_output};
 

--- a/src/relax/transform/rewrite_cuda_graph.cc
+++ b/src/relax/transform/rewrite_cuda_graph.cc
@@ -552,7 +552,7 @@ class CUDAGraphRewritePlanner : public ExprVisitor {
       }
     } else if (const auto* tuple_ty = ty.as<TupleTypeNode>()) {
       return IsStatic(tuple_ty->fields, vars_collector, tir_vars_collector);
-    } else if (ty.as<ObjectTypeNode>() || ty.as<PrimTypeNode>()) {
+    } else if (ty.as<AnyTypeNode>() || ty.as<PrimTypeNode>()) {
       return true;
     }
     return false;

--- a/src/tirx/ir/function.cc
+++ b/src/tirx/ir/function.cc
@@ -52,7 +52,7 @@ tvm::Type InferType(const PrimFunc& prim_func) {
       if (auto prim_type = param->type_annotation.as<PrimTypeNode>()) {
         const DLDataType& dtype = prim_type->dtype;
         if (dtype.code == kDLOpaqueHandle && (dtype.bits != 0 || dtype.lanes != 0)) {
-          return relax::ObjectType();
+          return relax::AnyType();
         }
       }
 
@@ -67,7 +67,7 @@ tvm::Type InferType(const PrimFunc& prim_func) {
     } else if (IsVoidType(prim_func->ret_type)) {
       return relax::TupleType(ffi::Array<tvm::Type>{});
     } else {
-      return relax::ObjectType();
+      return relax::AnyType();
     }
   }();
 

--- a/tests/python/disco/test_callback.py
+++ b/tests/python/disco/test_callback.py
@@ -42,7 +42,7 @@ def test_callback():
     @R.function
     def transform_params(
         rank_arg: R.Prim(value="rank"),
-        fget_item: R.Callable([R.Object, R.Prim("int64")], R.Object),
+        fget_item: R.Callable([R.Any, R.Prim("int64")], R.Any),
     ):
         rank = T.int64()
 

--- a/tests/python/disco/test_loader.py
+++ b/tests/python/disco/test_loader.py
@@ -260,7 +260,7 @@ def test_load_shard_in_relax():
     class Module:  # pylint: disable=too-few-public-methods
         @R.function
         def main(
-            loader: R.Object,
+            loader: R.Any,
         ) -> R.Tuple(R.Tensor((64, 64), "float32"), R.Tensor((16, 128), "float32")):
             R.func_attr({"global_symbol": "main"})
             with R.dataflow():

--- a/tests/python/relax/distributed/test_distributed_transform_lower_global_to_local_view.py
+++ b/tests/python/relax/distributed/test_distributed_transform_lower_global_to_local_view.py
@@ -651,7 +651,7 @@ def test_llama_attention():
             mask: R.DTensor((1, 1, 256, 256), "float16", "mesh[0]", "R"),
             div_const: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]"),
             maximum_const: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]"),
-            kv_cache: R.Tuple(R.Object, R.Object),
+            kv_cache: R.Tuple(R.Any, R.Any),
             linear_weight: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
             linear_weight1: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
             linear_weight2: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
@@ -733,19 +733,19 @@ def test_llama_attention():
                 (lv15,),
                 out_ty=R.DTensor((256, 32, 128), "float16", "mesh[0]", "S[1]"),
             )
-            lv20: R.Object = kv_cache[0]
-            lv21: R.Object = R.call_packed(
+            lv20: R.Any = kv_cache[0]
+            lv21: R.Any = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_append",
                 lv20,
                 lv18,
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
-            lv22: R.Object = kv_cache[1]
-            lv23: R.Object = R.call_packed(
+            lv22: R.Any = kv_cache[1]
+            lv23: R.Any = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_append",
                 lv22,
                 lv19,
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
             lv24: R.DTensor((256, 32, 128), "float16", "mesh[0]", "S[1]") = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_view",
@@ -1325,7 +1325,7 @@ def test_llama_attention():
             mask: R.DTensor((1, 1, 256, 256), "float16", "mesh[0]", "R"),
             div_const: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]"),
             maximum_const: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]"),
-            kv_cache: R.Tuple(R.Object, R.Object),
+            kv_cache: R.Tuple(R.Any, R.Any),
             linear_weight: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
             linear_weight1: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
             linear_weight2: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
@@ -1431,19 +1431,19 @@ def test_llama_attention():
                     out_ty=R.DTensor((256, 32, 128), "float16", "mesh[0]", "S[1]"),
                 )
             )
-            lv20: R.Object = kv_cache[0]
-            lv21: R.Object = R.call_packed(
+            lv20: R.Any = kv_cache[0]
+            lv21: R.Any = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_append",
                 lv20,
                 lv18,
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
-            lv22: R.Object = kv_cache[1]
-            lv23: R.Object = R.call_packed(
+            lv22: R.Any = kv_cache[1]
+            lv23: R.Any = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_append",
                 lv22,
                 lv19,
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
             lv24: R.DTensor((256, 32, 128), "float16", "mesh[0]", "S[1]") = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_view",

--- a/tests/python/relax/distributed/test_distributed_transform_propagate_sharding.py
+++ b/tests/python/relax/distributed/test_distributed_transform_propagate_sharding.py
@@ -460,7 +460,7 @@ def test_decoder_layer():
             mask: R.Tensor((1, 1, 256, 256), dtype="float16"),
             div_const: R.Tensor((1, 32, 256, 256), dtype="float16"),
             maximum_const: R.Tensor((1, 32, 256, 256), dtype="float16"),
-            kv_cache: R.Tuple(R.Object, R.Object),
+            kv_cache: R.Tuple(R.Any, R.Any),
             linear_weight: R.Tensor((4096, 4096), dtype="float16"),
             linear_weight1: R.Tensor((4096, 4096), dtype="float16"),
             linear_weight2: R.Tensor((4096, 4096), dtype="float16"),
@@ -525,13 +525,13 @@ def test_decoder_layer():
             lv19: R.Tensor((256, 32, 128), dtype="float16") = R.reshape(
                 lv15, R.shape([256, 32, 128])
             )
-            lv20: R.Object = kv_cache[0]
-            lv21: R.Object = R.call_packed(
-                "vm.builtin.attention_kv_cache_append", lv20, lv18, ty_args=(R.Object,)
+            lv20: R.Any = kv_cache[0]
+            lv21: R.Any = R.call_packed(
+                "vm.builtin.attention_kv_cache_append", lv20, lv18, ty_args=(R.Any,)
             )
-            lv22: R.Object = kv_cache[1]
-            lv23: R.Object = R.call_packed(
-                "vm.builtin.attention_kv_cache_append", lv22, lv19, ty_args=(R.Object,)
+            lv22: R.Any = kv_cache[1]
+            lv23: R.Any = R.call_packed(
+                "vm.builtin.attention_kv_cache_append", lv22, lv19, ty_args=(R.Any,)
             )
             lv24: R.Tensor((256, 32, 128), dtype="float16") = R.call_packed(
                 "vm.builtin.attention_kv_cache_view",
@@ -665,7 +665,7 @@ def test_decoder_layer():
             mask: R.DTensor((1, 1, 256, 256), "float16", "mesh[0]", "R"),
             div_const: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]"),
             maximum_const: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]"),
-            kv_cache: R.Tuple(R.Object, R.Object),
+            kv_cache: R.Tuple(R.Any, R.Any),
             linear_weight: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
             linear_weight1: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
             linear_weight2: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
@@ -723,19 +723,19 @@ def test_decoder_layer():
             lv19: R.DTensor((256, 32, 128), "float16", "mesh[0]", "S[1]") = R.reshape(
                 lv15, R.shape([256, 32, 128])
             )
-            lv20: R.Object = kv_cache[0]
-            lv21: R.Object = R.call_packed(
+            lv20: R.Any = kv_cache[0]
+            lv21: R.Any = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_append",
                 lv20,
                 lv18,
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
-            lv22: R.Object = kv_cache[1]
-            lv23: R.Object = R.call_packed(
+            lv22: R.Any = kv_cache[1]
+            lv23: R.Any = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_append",
                 lv22,
                 lv19,
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
             lv24: R.DTensor((256, 32, 128), "float16", "mesh[0]", "S[1]") = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_view",
@@ -1224,7 +1224,7 @@ def test_decoder_layer_tir():
             mask: R.Tensor((1, 1, 256, 256), dtype="float16"),
             div_const: R.Tensor((1, 32, 256, 256), dtype="float16"),
             maximum_const: R.Tensor((1, 32, 256, 256), dtype="float16"),
-            kv_cache: R.Tuple(R.Object, R.Object),
+            kv_cache: R.Tuple(R.Any, R.Any),
             linear_weight: R.Tensor((4096, 4096), dtype="float16"),
             linear_weight1: R.Tensor((4096, 4096), dtype="float16"),
             linear_weight2: R.Tensor((4096, 4096), dtype="float16"),
@@ -1291,13 +1291,13 @@ def test_decoder_layer_tir():
             lv19 = R.call_tir(
                 cls.reshape1, (lv15,), out_ty=R.Tensor((256, 32, 128), dtype="float16")
             )
-            lv20: R.Object = kv_cache[0]
-            lv21: R.Object = R.call_packed(
-                "vm.builtin.attention_kv_cache_append", lv20, lv18, ty_args=(R.Object,)
+            lv20: R.Any = kv_cache[0]
+            lv21: R.Any = R.call_packed(
+                "vm.builtin.attention_kv_cache_append", lv20, lv18, ty_args=(R.Any,)
             )
-            lv22: R.Object = kv_cache[1]
-            lv23: R.Object = R.call_packed(
-                "vm.builtin.attention_kv_cache_append", lv22, lv19, ty_args=(R.Object,)
+            lv22: R.Any = kv_cache[1]
+            lv23: R.Any = R.call_packed(
+                "vm.builtin.attention_kv_cache_append", lv22, lv19, ty_args=(R.Any,)
             )
             lv24: R.Tensor((256, 32, 128), dtype="float16") = R.call_packed(
                 "vm.builtin.attention_kv_cache_view",
@@ -1384,7 +1384,7 @@ def test_decoder_layer_tir():
             mask: R.DTensor((1, 1, 256, 256), "float16", "mesh[0]", "R"),
             div_const: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]"),
             maximum_const: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]"),
-            kv_cache: R.Tuple(R.Object, R.Object),
+            kv_cache: R.Tuple(R.Any, R.Any),
             linear_weight: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
             linear_weight1: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
             linear_weight2: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
@@ -1464,19 +1464,19 @@ def test_decoder_layer_tir():
                 (lv15,),
                 out_ty=R.DTensor((256, 32, 128), "float16", "mesh[0]", "S[1]"),
             )
-            lv20: R.Object = kv_cache[0]
-            lv21: R.Object = R.call_packed(
+            lv20: R.Any = kv_cache[0]
+            lv21: R.Any = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_append",
                 lv20,
                 lv18,
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
-            lv22: R.Object = kv_cache[1]
-            lv23: R.Object = R.call_packed(
+            lv22: R.Any = kv_cache[1]
+            lv23: R.Any = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_append",
                 lv22,
                 lv19,
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
             lv24: R.DTensor((256, 32, 128), "float16", "mesh[0]", "S[1]") = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_view",
@@ -1672,7 +1672,7 @@ def test_decoder_layer_dynamic_shape():
         def foo(
             input_tokens: R.Tensor((1, "n", 4096), dtype="float16"),
             mask: R.Tensor((1, 1, "n", "m"), dtype="float16"),
-            kv_cache: R.Tuple(R.Object, R.Object),
+            kv_cache: R.Tuple(R.Any, R.Any),
             linear_weight: R.Tensor((4096, 4096), dtype="float16"),
             linear_weight1: R.Tensor((4096, 4096), dtype="float16"),
             linear_weight2: R.Tensor((4096, 4096), dtype="float16"),
@@ -1735,13 +1735,13 @@ def test_decoder_layer_dynamic_shape():
             )
             lv18: R.Tensor((n, 32, 128), dtype="float16") = R.reshape(lv17, R.shape([n, 32, 128]))
             lv19: R.Tensor((n, 32, 128), dtype="float16") = R.reshape(lv15, R.shape([n, 32, 128]))
-            lv20: R.Object = kv_cache[0]
-            lv21: R.Object = R.call_packed(
-                "vm.builtin.attention_kv_cache_append", lv20, lv18, ty_args=(R.Object,)
+            lv20: R.Any = kv_cache[0]
+            lv21: R.Any = R.call_packed(
+                "vm.builtin.attention_kv_cache_append", lv20, lv18, ty_args=(R.Any,)
             )
-            lv22: R.Object = kv_cache[1]
-            lv23: R.Object = R.call_packed(
-                "vm.builtin.attention_kv_cache_append", lv22, lv19, ty_args=(R.Object,)
+            lv22: R.Any = kv_cache[1]
+            lv23: R.Any = R.call_packed(
+                "vm.builtin.attention_kv_cache_append", lv22, lv19, ty_args=(R.Any,)
             )
             lv24: R.Tensor((m, 32, 128), dtype="float16") = R.call_packed(
                 "vm.builtin.attention_kv_cache_view",
@@ -1880,7 +1880,7 @@ def test_decoder_layer_dynamic_shape():
         def foo(
             input_tokens: R.DTensor((1, "n", 4096), "float16", "mesh[0]", "R"),
             mask: R.DTensor((1, 1, "n", "m"), "float16", "mesh[0]", "R"),
-            kv_cache: R.Tuple(R.Object, R.Object),
+            kv_cache: R.Tuple(R.Any, R.Any),
             linear_weight: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
             linear_weight1: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
             linear_weight2: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]"),
@@ -1942,19 +1942,19 @@ def test_decoder_layer_dynamic_shape():
             lv19: R.DTensor((n, 32, 128), "float16", "mesh[0]", "S[1]") = R.reshape(
                 lv15, R.shape([n, 32, 128])
             )
-            lv20: R.Object = kv_cache[0]
-            lv21: R.Object = R.call_packed(
+            lv20: R.Any = kv_cache[0]
+            lv21: R.Any = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_append",
                 lv20,
                 lv18,
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
-            lv22: R.Object = kv_cache[1]
-            lv23: R.Object = R.call_packed(
+            lv22: R.Any = kv_cache[1]
+            lv23: R.Any = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_append",
                 lv22,
                 lv19,
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
             lv24: R.DTensor((m, 32, 128), "float16", "mesh[0]", "S[1]") = R.call_packed(
                 "vm.builtin.distributed.attention_kv_cache_view",

--- a/tests/python/relax/test_analysis_contains_impure_call.py
+++ b/tests/python/relax/test_analysis_contains_impure_call.py
@@ -39,7 +39,7 @@ def test_simple_impure_case():
     @tvm.script.ir_module
     class ImpureTest:
         @R.function(pure=False)
-        def impure_func() -> R.Object:
+        def impure_func() -> R.Any:
             y = R.print(format="I am a message")
             return y
 
@@ -53,7 +53,7 @@ def test_nested_function():
         def pure_with_impure_nested() -> R.Tensor((), "int32"):
             # unused
             @R.function(pure=False)
-            def impure_inner() -> R.Object:
+            def impure_inner() -> R.Any:
                 y = R.print(format="Another, worse, message")
                 return y
 
@@ -73,7 +73,7 @@ def test_ignoring_recursive_call():
     @tvm.script.ir_module
     class RecursiveTest:
         @R.function(pure=False)
-        def recursive_impure() -> R.Object:
+        def recursive_impure() -> R.Any:
             x = R.const(1, "int32")
             y = R.add(x, x)
             z = R.print(x, y, format="{} {}")

--- a/tests/python/relax/test_analysis_detect_recursion.py
+++ b/tests/python/relax/test_analysis_detect_recursion.py
@@ -38,11 +38,11 @@ def test_no_recursion():
     @tvm.script.ir_module
     class NoRecursion:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             return x
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             return x
 
     groups = detect_recursion(NoRecursion)
@@ -53,7 +53,7 @@ def test_simple_recursion():
     @tvm.script.ir_module
     class SimpleRecursion:
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             return SimpleRecursion.c(x)
 
     groups = detect_recursion(SimpleRecursion)
@@ -65,24 +65,24 @@ def test_tree():
     @tvm.script.ir_module
     class Tree:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             return Tree.b(x)
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             return Tree.c(x)
 
         @R.function
-        def c(x: R.Object) -> R.Object:
-            z: R.Object = Tree.d(x)
+        def c(x: R.Any) -> R.Any:
+            z: R.Any = Tree.d(x)
             return Tree.e(z)
 
         @R.function
-        def d(x: R.Object) -> R.Object:
+        def d(x: R.Any) -> R.Any:
             return Tree.e(x)
 
         @R.function
-        def e(x: R.Object) -> R.Object:
+        def e(x: R.Any) -> R.Any:
             return x
 
     groups = detect_recursion(Tree)
@@ -93,16 +93,16 @@ def test_two_function_case():
     @tvm.script.ir_module
     class TwoFunctionCase:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             return TwoFunctionCase.b(x)
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             return TwoFunctionCase.a(x)
 
         # not part of the group, shouldn't be reported
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             return x
 
     groups = detect_recursion(TwoFunctionCase)
@@ -113,24 +113,24 @@ def test_two_groups_of_two():
     @tvm.script.ir_module
     class TwoGroupsOfTwo:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             return TwoGroupsOfTwo.b(x)
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             return TwoGroupsOfTwo.a(x)
 
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             return TwoGroupsOfTwo.d(x)
 
         @R.function
-        def d(x: R.Object) -> R.Object:
+        def d(x: R.Any) -> R.Any:
             return TwoGroupsOfTwo.c(x)
 
         # not part of either group, shouldn't be reported
         @R.function
-        def e(x: R.Object) -> R.Object:
+        def e(x: R.Any) -> R.Any:
             return x
 
     groups = detect_recursion(TwoGroupsOfTwo)
@@ -141,16 +141,16 @@ def test_mutual_recursion_and_simple_recursion():
     @tvm.script.ir_module
     class MutualAndSimple:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             return MutualAndSimple.b(x)
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             return MutualAndSimple.a(x)
 
         # forms its own group
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             return MutualAndSimple.c(x)
 
     groups = detect_recursion(MutualAndSimple)
@@ -163,12 +163,12 @@ def test_simultaneous_mutual_and_simple_recursion():
     @tvm.script.ir_module
     class SimultaneousMutualAndSimple:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             cls = SimultaneousMutualAndSimple
             return cls.b(cls.a(x))
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             cls = SimultaneousMutualAndSimple
             return cls.a(cls.b(x))
 
@@ -180,15 +180,15 @@ def test_three_function_case():
     @tvm.script.ir_module
     class ThreeFunctionCase:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             return ThreeFunctionCase.b(x)
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             return ThreeFunctionCase.c(x)
 
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             return ThreeFunctionCase.a(x)
 
     groups = detect_recursion(ThreeFunctionCase)
@@ -201,24 +201,24 @@ def test_call_from_outside_of_group():
         # A calls into a group of mutually recursive functions,
         # but is not part of the cycle
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             return CallFromOutOfGroup.d(x)
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             return CallFromOutOfGroup.c(x)
 
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             return CallFromOutOfGroup.d(x)
 
         @R.function
-        def d(x: R.Object) -> R.Object:
+        def d(x: R.Any) -> R.Any:
             return CallFromOutOfGroup.b(x)
 
         # E also calls into the cycle but isn't part of it
         @R.function
-        def e(x: R.Object) -> R.Object:
+        def e(x: R.Any) -> R.Any:
             return CallFromOutOfGroup.b(x)
 
     groups = detect_recursion(CallFromOutOfGroup)
@@ -231,21 +231,21 @@ def test_call_from_group_to_outside():
         # A calls into a group of mutually recursive functions,
         # but is not part of the cycle
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             return CallFromGroupToOutside.b(x)
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             # d is called from a member of the group but it is not part of the cycle
-            z: R.Object = CallFromGroupToOutside.d(x)
+            z: R.Any = CallFromGroupToOutside.d(x)
             return CallFromGroupToOutside.c(z)
 
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             return CallFromGroupToOutside.a(x)
 
         @R.function
-        def d(x: R.Object) -> R.Object:
+        def d(x: R.Any) -> R.Any:
             return x
 
     groups = detect_recursion(CallFromGroupToOutside)
@@ -267,28 +267,28 @@ def test_group_with_two_cycles():
     @tvm.script.ir_module
     class GroupWithTwoCycles:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             return GroupWithTwoCycles.b(x)
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             return GroupWithTwoCycles.c(x)
 
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             y = GroupWithTwoCycles.d(x)
             return GroupWithTwoCycles.e(y)
 
         @R.function
-        def d(x: R.Object) -> R.Object:
+        def d(x: R.Any) -> R.Any:
             return GroupWithTwoCycles.a(x)
 
         @R.function
-        def e(x: R.Object) -> R.Object:
+        def e(x: R.Any) -> R.Any:
             return GroupWithTwoCycles.f(x)
 
         @R.function
-        def f(x: R.Object) -> R.Object:
+        def f(x: R.Any) -> R.Any:
             return GroupWithTwoCycles.b(x)
 
     groups = detect_recursion(GroupWithTwoCycles)
@@ -310,43 +310,43 @@ def test_multicycle_example():
     @tvm.script.ir_module
     class MulticycleExample:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             cls = MulticycleExample
             y = cls.b(x)
             return cls.e(y)
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             cls = MulticycleExample
             y = cls.a(x)
             z = cls.c(y)
             return cls.d(z)
 
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             cls = MulticycleExample
             y = cls.g(x)
             return cls.b(y)
 
         @R.function
-        def d(x: R.Object) -> R.Object:
+        def d(x: R.Any) -> R.Any:
             cls = MulticycleExample
             return cls.f(x)
 
         @R.function
-        def e(x: R.Object) -> R.Object:
+        def e(x: R.Any) -> R.Any:
             cls = MulticycleExample
             y = cls.f(x)
             return cls.a(y)
 
         @R.function
-        def f(x: R.Object) -> R.Object:
+        def f(x: R.Any) -> R.Any:
             cls = MulticycleExample
             y = cls.g(x)
             return cls.e(y)
 
         @R.function
-        def g(x: R.Object) -> R.Object:
+        def g(x: R.Any) -> R.Any:
             cls = MulticycleExample
             y = cls.f(x)
             return cls.c(y)
@@ -359,7 +359,7 @@ def test_control_flow():
     @tvm.script.ir_module
     class ControlFlowExample:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             cls = ControlFlowExample
             y: R.Tensor((), dtype="bool") = R.const(True, dtype="bool")
             if y:
@@ -369,12 +369,12 @@ def test_control_flow():
             return ret
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             cls = ControlFlowExample
             return cls.a(x)
 
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             cls = ControlFlowExample
             return cls.a(x)
 
@@ -386,7 +386,7 @@ def test_returning_self():
     @tvm.script.ir_module
     class ReturnsSelf:
         @R.function
-        def a() -> R.Object:
+        def a() -> R.Any:
             # this is also a form of recursion
             return ReturnsSelf.a
 
@@ -398,17 +398,17 @@ def test_mutual_recursion_via_references():
     @tvm.script.ir_module
     class GatherReferences:
         @R.function
-        def a(x: R.Object) -> R.Object:
+        def a(x: R.Any) -> R.Any:
             cls = GatherReferences
             return cls.b(x)
 
         @R.function
-        def b(x: R.Object) -> R.Object:
+        def b(x: R.Any) -> R.Any:
             cls = GatherReferences
             return (cls.a, cls.b, cls.c)
 
         @R.function
-        def c(x: R.Object) -> R.Object:
+        def c(x: R.Any) -> R.Any:
             cls = GatherReferences
             return cls.a(x)
 
@@ -433,13 +433,13 @@ def test_disregard_primfuncs():
                     B[vi0, vi1] = C[vi0, vi1]
 
         @R.function
-        def a(x: R.Tensor((4, 4), "float32")) -> R.Object:
+        def a(x: R.Tensor((4, 4), "float32")) -> R.Any:
             cls = CallPrimFunc
             y = R.call_tir(cls.identity_identity, x, R.Tensor((4, 4), "float32"))
             return cls.b(y)
 
         @R.function
-        def b(x: R.Tensor((4, 4), "float32")) -> R.Object:
+        def b(x: R.Tensor((4, 4), "float32")) -> R.Any:
             cls = CallPrimFunc
             y = R.call_tir(cls.identity_identity, x, R.Tensor((4, 4), "float32"))
             return cls.a(y)

--- a/tests/python/relax/test_analysis_estimate_memory_usage.py
+++ b/tests/python/relax/test_analysis_estimate_memory_usage.py
@@ -71,7 +71,7 @@ def test_basic():
         @R.function(pure=False)
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
             cls = Module
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([32]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(
@@ -82,7 +82,7 @@ def test_basic():
             lv1: R.Tensor((8,), dtype="float32") = R.call_packed(
                 "vm.builtin.reshape", lv, R.shape([8]), ty_args=[R.Tensor((8,), dtype="float32")]
             )
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([40]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc1: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(

--- a/tests/python/relax/test_analysis_type_analysis.py
+++ b/tests/python/relax/test_analysis_type_analysis.py
@@ -31,8 +31,8 @@ from tvm.script import tirx as T
 
 def test_get_static_type_basic():
     # object
-    s0 = rx.ObjectType()
-    tvm.ir.assert_structural_equal(rx.analysis.get_static_type(s0), rx.ObjectType())
+    s0 = rx.AnyType()
+    tvm.ir.assert_structural_equal(rx.analysis.get_static_type(s0), rx.AnyType())
 
     # prim
     s1 = tvm.ir.PrimType("float32")
@@ -63,7 +63,7 @@ def test_get_static_type_tensor():
 def test_get_static_type_tuple():
     # tuple
     n, m = tirx.Var("n", "int64"), tirx.Var("m", "int64")
-    s0 = rx.ObjectType()
+    s0 = rx.AnyType()
     s2 = rx.ShapeType([1, n + 1, m])
     s4 = rx.TensorType([1, n + 1, m], "int64")
     t0 = rx.TupleType([s4, s0])
@@ -73,7 +73,7 @@ def test_get_static_type_tuple():
         rx.analysis.get_static_type(t1),
         rx.TupleType(
             [
-                rx.TupleType([rx.TensorType(ndim=3, dtype="int64"), rx.ObjectType()]),
+                rx.TupleType([rx.TensorType(ndim=3, dtype="int64"), rx.AnyType()]),
                 rx.ShapeType(ndim=3),
             ]
         ),
@@ -101,7 +101,7 @@ def test_get_static_type_func():
 
 
 def test_erase_to_well_defined_basic():
-    s0 = rx.ObjectType()
+    s0 = rx.AnyType()
     tvm.ir.assert_structural_equal(rx.analysis.erase_to_well_defined(s0), s0)
 
     # prim
@@ -172,7 +172,7 @@ def test_erase_to_well_defined_tensor():
 
 def test_erase_to_well_defined_tuple():
     n, m = tirx.Var("n", "int64"), tirx.Var("m", "int64")
-    s0 = rx.ObjectType()
+    s0 = rx.AnyType()
     s2 = rx.ShapeType([1, m])
     s4 = rx.TensorType([1, n + 1, m], "int64")
     t0 = rx.TupleType([s4, s0])
@@ -182,7 +182,7 @@ def test_erase_to_well_defined_tuple():
         rx.analysis.erase_to_well_defined(t1, {m: m + 1}),
         rx.TupleType(
             [
-                rx.TupleType([rx.TensorType(ndim=3, dtype="int64"), rx.ObjectType()]),
+                rx.TupleType([rx.TensorType(ndim=3, dtype="int64"), rx.AnyType()]),
                 rx.ShapeType([1, m + 1]),
             ]
         ),
@@ -207,7 +207,7 @@ def test_base_check():
     bcheck = rx.analysis.type_base_check
 
     n, m = tirx.Var("n", "int64"), tirx.Var("m", "int64")
-    obj0 = rx.ObjectType()
+    obj0 = rx.AnyType()
     prim0 = tvm.ir.PrimType("int32")
     prim1 = tvm.ir.PrimType("float32")
 
@@ -361,7 +361,7 @@ def _check_derive(ctx, finfo, args_ty, ret):
 
 
 def test_derive_call_ret_type():
-    obj0 = rx.ObjectType()
+    obj0 = rx.AnyType()
     prim0 = tvm.ir.PrimType("float32")
 
     n, m = tirx.Var("n0", "int64"), tirx.Var("m0", "int64")
@@ -516,7 +516,7 @@ def _check_lca(lhs, rhs, target):
 
 def test_type_lca():
     n, m = tirx.Var("n", "int64"), tirx.Var("m", "int64")
-    obj0 = rx.ObjectType()
+    obj0 = rx.AnyType()
     prim0 = tvm.ir.PrimType("int32")
     prim1 = tvm.ir.PrimType("float32")
 
@@ -670,22 +670,22 @@ def _generate_prim_test_cases():
                 # Unlike R.Tensor, R.Prim does not currently support a
                 # value with an unknown datatype.  If the dtype
                 # differs between the two annotations, the next wider
-                # category is R.Object.
-                yield (R.Prim(dtype_a), R.Prim(dtype_b), R.Object)
+                # category is R.Any.
+                yield (R.Prim(dtype_a), R.Prim(dtype_b), R.Any)
 
                 # Because the dtypes are different, even `R.Prim` containing
                 # the same value in different representations (e.g.
-                # `T.float32(0)` vs `T.float16(0)`) fall back to `R.Object`.
+                # `T.float32(0)` vs `T.float16(0)`) fall back to `R.Any`.
                 yield (
                     R.Prim(value=tirx.const(0, dtype_a)),
                     R.Prim(value=tirx.const(0, dtype_b)),
-                    R.Object,
+                    R.Any,
                 )
 
                 # And the same is true for known variable values
                 var_N = tirx.Var("N", dtype_a)
                 var_M = tirx.Var("M", dtype_b)
-                yield (R.Prim(value=var_N), R.Prim(value=var_M), R.Object)
+                yield (R.Prim(value=var_N), R.Prim(value=var_M), R.Any)
 
 
 @pytest.mark.parametrize("test_case", list(_generate_prim_test_cases()))

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -1254,11 +1254,11 @@ def test_var_binding_may_have_less_constrained_ty():
         def main(
             A: R.Tensor(shape=[128, 32], dtype="float32"),
         ):
-            B: R.Object = R.add(A, A)
+            B: R.Any = R.add(A, A)
             return B
 
-    assert isinstance(Module["main"].body.blocks[0].bindings[0].var.ty, tvm.relax.ObjectType), (
-        "Validity of this test requires a variable with R.Object type"
+    assert isinstance(Module["main"].body.blocks[0].bindings[0].var.ty, tvm.relax.AnyType), (
+        "Validity of this test requires a variable with R.Any type"
     )
 
     rx.analysis.well_formed(Module)
@@ -1353,7 +1353,7 @@ def test_ty_may_be_incomplete():
             A: R.Tensor(shape=[128, 32], dtype="float32"),
             B: R.Tensor(shape=[128, 32], dtype="float32"),
         ):
-            C: R.Object = R.add(A, B)
+            C: R.Any = R.add(A, B)
             return C
 
     rx.analysis.well_formed(Module)

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -257,8 +257,8 @@ def test_types():
     printer = ASTPrinter()
     assert strip_whitespace(printer.visit_type_(rx.ShapeType(ndim=-1))) == "ShapeType(ndim=-1)"
     assert strip_whitespace(printer.visit_type_(rx.ShapeType(ndim=1))) == "ShapeType(ndim=1)"
-    object_type = rx.ObjectType()
-    assert strip_whitespace(printer.visit_type_(object_type)) == "ObjectType()"
+    object_type = rx.AnyType()
+    assert strip_whitespace(printer.visit_type_(object_type)) == "AnyType()"
     packed_type = rx.PackedFuncType()
     assert strip_whitespace(printer.visit_type_(packed_type)) == "PackedFuncType()"
     tensor_type = rx.TensorType(ndim=2, dtype="int32")
@@ -268,7 +268,7 @@ def test_types():
     tuple_type = rx.TupleType([rx.ShapeType(ndim=-1), object_type])
     assert_fields(
         "TupleType",
-        {"fields": "[ShapeType(ndim=-1),ObjectType()]"},
+        {"fields": "[ShapeType(ndim=-1),AnyType()]"},
         strip_whitespace(printer.visit_type_(tuple_type)),
     )
 
@@ -287,7 +287,7 @@ def test_types():
 def test_ty():
     printer = ASTPrinter()
 
-    assert printer.visit_ty_(rx.ObjectType()) == "ObjectType()"
+    assert printer.visit_ty_(rx.AnyType()) == "AnyType()"
 
     assert printer.visit_ty_(tvm.ir.PrimType("int32")) == "PrimType(dtype=int32)"
 
@@ -340,10 +340,10 @@ def test_ty():
         """
     )
 
-    simple_func = rx.FuncType([], rx.ObjectType())
+    simple_func = rx.FuncType([], rx.AnyType())
     assert (
         strip_whitespace(printer.visit_ty_(simple_func))
-        == "FuncType(params=[],ret=ObjectType(),purity=True)"
+        == "FuncType(params=[],ret=AnyType(),purity=True)"
     )
 
 
@@ -354,15 +354,15 @@ def test_call_packed():
         x: R.Tensor((32, "m"), "float32"),
         y: R.Tensor(("m",), "float32"),
         r: R.Tensor(dtype="int64"),
-    ) -> R.Object:
+    ) -> R.Any:
         m = T.int64()
         z: R.Tensor((32, m), "float32") = R.multiply(x, y)
         w: R.Tensor(ndim=2) = R.multiply(z, z)
         q: R.Tensor = R.add(w, w)
         t = R.add(w, z)
         sh: R.Shape = R.shape_of(t)
-        o: R.Object = R.call_packed(
-            "contrib.tensor_array_stack", x, y, ty_args=R.Object(), test_attr=True
+        o: R.Any = R.call_packed(
+            "contrib.tensor_array_stack", x, y, ty_args=R.Any(), test_attr=True
         )
         return o
 
@@ -376,7 +376,7 @@ def test_call_packed():
     )
 
     # the function has an annotated return type
-    assert "ret_ty=ObjectType()" in f_str
+    assert "ret_ty=AnyType()" in f_str
     # the purity attribute is set to false
     assert "is_pure=False"
 
@@ -393,7 +393,7 @@ def test_call_packed():
         {
             "op": 'ExternFunc(global_symbol="contrib.tensor_array_stack")',
             "args": '[Var(name_hint="x"), Var(name_hint="y")]',
-            "ty_args": "[ObjectType()]",
+            "ty_args": "[AnyType()]",
             "attrs": '{"test_attr": True}',
         },
         extern_call_text,
@@ -670,7 +670,7 @@ def test_string_imm():
         """
         StringImm(
             value="test",
-            ty=ObjectType()
+            ty=AnyType()
         )
     """
     )
@@ -683,7 +683,7 @@ def test_datatype_imm():
         """
         DataTypeImm(
             value=int32,
-            ty=ObjectType()
+            ty=AnyType()
         )
     """
     )

--- a/tests/python/relax/test_backend_transform_shape_lower.py
+++ b/tests/python/relax/test_backend_transform_shape_lower.py
@@ -84,14 +84,14 @@ def test_static_fn_check():
     @tvm.script.ir_module
     class Before:
         @R.function
-        def main(f: R.Callable([R.Object], R.Object), y: R.Shape([1, 2])):
+        def main(f: R.Callable([R.Any], R.Any), y: R.Shape([1, 2])):
             R.func_attr({"relax.force_pure": True})
             return y
 
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(f: R.Callable([R.Object], R.Object), y: R.Shape([1, 2])):
+        def main(f: R.Callable([R.Any], R.Any), y: R.Shape([1, 2])):
             R.func_attr({"relax.force_pure": True})
             shape_heap = R.null_value()
             _ = R.call_packed("vm.builtin.check_func_info", f, "", ty_args=[R.Tuple()])
@@ -382,7 +382,7 @@ def test_return_match_check():
     @tvm.script.ir_module
     class Before:
         @R.function
-        def main(x: R.Tensor(["n", "m"], "float32"), y: R.Object) -> R.Tuple(
+        def main(x: R.Tensor(["n", "m"], "float32"), y: R.Any) -> R.Tuple(
             R.Tensor(["n", "m"], "float32")
         ):
             R.func_attr({"relax.force_pure": True})
@@ -397,7 +397,7 @@ def test_return_match_check():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor(["n", "m"], "float32"), y: R.Object) -> R.Tuple(
+        def main(x: R.Tensor(["n", "m"], "float32"), y: R.Any) -> R.Tuple(
             R.Tensor(["n", "m"], "float32")
         ):
             R.func_attr({"relax.force_pure": True})
@@ -423,7 +423,7 @@ def test_return_match_check():
             )
             _ = R.call_packed("vm.builtin.check_tuple_info", y, 1, "", ty_args=[R.Tuple()])
             # emit runtime function call since y do not have the right type.
-            y1 = R.call_packed("vm.builtin.tuple_getitem", y, 0, ty_args=[R.Object])
+            y1 = R.call_packed("vm.builtin.tuple_getitem", y, 0, ty_args=[R.Any])
             # run check
             _ = R.call_packed(
                 "vm.builtin.check_tensor_info",
@@ -469,7 +469,7 @@ def test_return_match_check_with_new_expr():
         @R.function
         def main(x: R.Tensor(["n", "n"], "float32")) -> R.Tensor(["n * n"], "float32"):
             R.func_attr({"relax.force_pure": True})
-            out = R.call_packed("flatten_matrix", x, ty_args=R.Object)
+            out = R.call_packed("flatten_matrix", x, ty_args=R.Any)
             return out
 
     # slot assignment:
@@ -506,7 +506,7 @@ def test_return_match_check_with_new_expr():
 
             _ = Expected.shape_func(shape_heap)
 
-            out = R.call_packed("flatten_matrix", x, ty_args=R.Object)
+            out = R.call_packed("flatten_matrix", x, ty_args=R.Any)
             _ = R.call_packed(
                 "vm.builtin.check_tensor_info",
                 out,
@@ -665,7 +665,7 @@ def test_check_lifted_weights():
             R.Tensor((16, 16), dtype="float32")
         ):
             R.func_attr({"relax.force_pure": True})
-            shape_heap: R.Object = R.null_value()
+            shape_heap: R.Any = R.null_value()
             _: R.Tuple = R.call_packed(
                 "vm.builtin.check_tuple_info",
                 params,
@@ -701,7 +701,7 @@ def test_check_lifted_weights():
             x: R.Tensor((16, 16), dtype="float32"), param_0: R.Tensor((16, 16), dtype="float32")
         ) -> R.Tuple(R.Tensor((16, 16), dtype="float32"), R.Tensor((16, 16), dtype="float32")):
             R.func_attr({"num_input": 1, "relax.force_pure": True})
-            shape_heap: R.Object = R.null_value()
+            shape_heap: R.Any = R.null_value()
             _: R.Tuple = R.call_packed(
                 "vm.builtin.check_tensor_info",
                 x,

--- a/tests/python/relax/test_dataflow_rewriter.py
+++ b/tests/python/relax/test_dataflow_rewriter.py
@@ -1120,7 +1120,7 @@ def test_rewrite_of_implicit_tuple_with_three_elements():
     def before(
         state: R.Tensor([4096], "float32"),
         proj_qkv: R.Tensor([12288, 4096], "float32"),
-        kv_cache: R.Object,
+        kv_cache: R.Any,
     ):
         qkv = R.matmul(proj_qkv, state)
         qkv_tuple = R.split(qkv, 3, axis=0)
@@ -1142,7 +1142,7 @@ def test_rewrite_of_implicit_tuple_with_three_elements():
     def expected(
         state: R.Tensor([4096], "float32"),
         proj_qkv: R.Tensor([12288, 4096], "float32"),
-        kv_cache: R.Object,
+        kv_cache: R.Any,
     ):
         qkv = R.matmul(proj_qkv, state)
         embedded_qkv_tuple = R.call_pure_packed(

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -105,16 +105,16 @@ def test_tuple() -> None:
 
 
 def test_tuple_ty_inferred_on_construction():
-    v0 = rx.Var("v0", rx.ObjectType())
-    v1 = rx.Var("v1", rx.ObjectType())
+    v0 = rx.Var("v0", rx.AnyType())
+    v1 = rx.Var("v1", rx.AnyType())
     tup = rx.Tuple((v0, v1))
 
     assert tup.ty is not None
-    tvm.ir.assert_structural_equal(tup.ty, rx.TupleType([rx.ObjectType(), rx.ObjectType()]))
+    tvm.ir.assert_structural_equal(tup.ty, rx.TupleType([rx.AnyType(), rx.AnyType()]))
 
 
 def test_tuple_ty_requires_fields_with_known_ty():
-    v0 = rx.Var("v0", rx.ObjectType())
+    v0 = rx.Var("v0", rx.AnyType())
     v1 = rx.Var("v1")
     tup = rx.Tuple((v0, v1))
 

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -8395,11 +8395,11 @@ def test_tensor_none_tuple():
     class Expected:
         @R.function
         def main(x: R.Tensor((3,), dtype="float32")) -> R.Tuple(
-            R.Tensor((3,), dtype="float32"), R.Object
+            R.Tensor((3,), dtype="float32"), R.Any
         ):
             with R.dataflow():
                 lv: R.Tensor((3,), dtype="float32") = R.add(x, R.const(1.0, "float32"))
-                gv: R.Tuple(R.Tensor((3,), dtype="float32"), R.Object) = (lv, R.null_value())
+                gv: R.Tuple(R.Tensor((3,), dtype="float32"), R.Any) = (lv, R.null_value())
                 R.output(gv)
             return gv
 

--- a/tests/python/relax/test_frontend_nn_exporter.py
+++ b/tests/python/relax/test_frontend_nn_exporter.py
@@ -95,7 +95,7 @@ def test_debug_effect():
         @R.function
         def forward(
             x: R.Tensor([3, 3], dtype="float32"),
-            _io: R.Object,
+            _io: R.Any,
         ):
             R.func_attr({"num_input": 2})
             with R.dataflow():
@@ -462,17 +462,17 @@ def test_linear_dynamic_shape():
     @R.function
     def forward(
         x: R.Tensor((1, 4), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor(("n", 4), dtype="float32"),
         bias: R.Tensor(("n",), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((1, "n"), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((1, "n"), dtype="float32"), R.Tuple(R.Any)):
         n = T.int64()
         R.func_attr({"num_input": 2})
         with R.dataflow():
             permute_dims: R.Tensor((4, n), dtype="float32") = R.permute_dims(weight, axes=None)
             matmul: R.Tensor((1, n), dtype="float32") = R.matmul(x, permute_dims, out_dtype="void")
             add: R.Tensor((1, n), dtype="float32") = R.add(matmul, bias)
-            gv1: R.Tuple(R.Tensor((1, n), dtype="float32"), R.Tuple(R.Object)) = add, (_io,)
+            gv1: R.Tuple(R.Tensor((1, n), dtype="float32"), R.Tuple(R.Any)) = add, (_io,)
             R.output(gv1)
         return gv1
 

--- a/tests/python/relax/test_frontend_nn_modules.py
+++ b/tests/python/relax/test_frontend_nn_modules.py
@@ -34,12 +34,12 @@ def test_relu():
     @R.function
     def forward(
         x: R.Tensor((3, 3), dtype="float32"),
-        _io: R.Object,
-    ) -> R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Object)):
+        _io: R.Any,
+    ) -> R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             relu: R.Tensor((3, 3), dtype="float32") = R.nn.relu(x)
-            gv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Object)) = relu, (_io,)
+            gv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Any)) = relu, (_io,)
             R.output(gv1)
         return gv1
 
@@ -52,12 +52,12 @@ def test_silu():
     @R.function
     def forward(
         x: R.Tensor((3, 3), dtype="float32"),
-        _io: R.Object,
-    ) -> R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Object)):
+        _io: R.Any,
+    ) -> R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             silu: R.Tensor((3, 3), dtype="float32") = R.nn.silu(x)
-            gv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Object)) = silu, (_io,)
+            gv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Any)) = silu, (_io,)
             R.output(gv1)
         return gv1
 
@@ -70,12 +70,12 @@ def test_gelu():
     @R.function
     def forward(
         x: R.Tensor((3, 3), dtype="float32"),
-        _io: R.Object,
-    ) -> R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Object)):
+        _io: R.Any,
+    ) -> R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             gelu: R.Tensor((3, 3), dtype="float32") = R.nn.gelu(x)
-            gv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Object)) = gelu, (_io,)
+            gv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Any)) = gelu, (_io,)
             R.output(gv1)
         return gv1
 
@@ -88,11 +88,11 @@ def test_identity():
     @R.function
     def forward(
         x: R.Tensor((3, 3), dtype="float32"),
-        _io: R.Object,
-    ) -> R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Object)):
+        _io: R.Any,
+    ) -> R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
-            gv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Object)) = x, (_io,)
+            gv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Any)) = x, (_io,)
             R.output(gv1)
         return gv1
 
@@ -105,16 +105,16 @@ def test_linear():
     @R.function
     def forward(
         x: R.Tensor((1, 4), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor((8, 4), dtype="float32"),
         bias: R.Tensor((8,), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((1, 8), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((1, 8), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             permute_dims: R.Tensor((4, 8), dtype="float32") = R.permute_dims(weight, axes=None)
             matmul: R.Tensor((1, 8), dtype="float32") = R.matmul(x, permute_dims, out_dtype="void")
             add: R.Tensor((1, 8), dtype="float32") = R.add(matmul, bias)
-            gv1: R.Tuple(R.Tensor((1, 8), dtype="float32"), R.Tuple(R.Object)) = add, (_io,)
+            gv1: R.Tuple(R.Tensor((1, 8), dtype="float32"), R.Tuple(R.Any)) = add, (_io,)
             R.output(gv1)
         return gv1
 
@@ -127,10 +127,10 @@ def test_conv1d():
     @R.function
     def forward(
         x: R.Tensor((1, 3, 32), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor((32, 3, 3), dtype="float32"),
         bias: R.Tensor((32,), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((1, 32, 30), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((1, 32, 30), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             lv1: R.Tensor((1, 32, 30), dtype="float32") = R.nn.conv1d(
@@ -147,7 +147,7 @@ def test_conv1d():
             )
             lv2: R.Tensor((1, 32, 1), dtype="float32") = R.reshape(bias, R.shape([1, 32, 1]))
             conv1d: R.Tensor((1, 32, 30), dtype="float32") = R.add(lv1, lv2)
-            gv1: R.Tuple(R.Tensor((1, 32, 30), dtype="float32"), R.Tuple(R.Object)) = conv1d, (_io,)
+            gv1: R.Tuple(R.Tensor((1, 32, 30), dtype="float32"), R.Tuple(R.Any)) = conv1d, (_io,)
             R.output(gv1)
         return gv1
 
@@ -166,13 +166,13 @@ def test_conv1d():
 def test_conv1d_transpose():
     # fmt: off
     @R.function
-    def forward(x: R.Tensor((1, 3, 30), dtype="float32"), _io: R.Object, weight: R.Tensor((3, 32, 3), dtype="float32"), bias: R.Tensor((32,), dtype="float32")) -> R.Tuple(R.Tensor((1, 32, 32), dtype="float32"), R.Tuple(R.Object)):
+    def forward(x: R.Tensor((1, 3, 30), dtype="float32"), _io: R.Any, weight: R.Tensor((3, 32, 3), dtype="float32"), bias: R.Tensor((32,), dtype="float32")) -> R.Tuple(R.Tensor((1, 32, 32), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             lv1: R.Tensor((1, 32, 32), dtype="float32") = R.nn.conv1d_transpose(x, weight, strides=[1], padding=[0, 0], output_padding=[0], dilation=[1], groups=1, data_layout="NCW", kernel_layout="IOW", out_layout="NCW", out_dtype="void")
             lv2: R.Tensor((1, 32, 1), dtype="float32") = R.reshape(bias, R.shape([1, 32, 1]))
             conv1d_transpose: R.Tensor((1, 32, 32), dtype="float32") = R.add(lv1, lv2)
-            gv1: R.Tuple(R.Tensor((1, 32, 32), dtype="float32"), R.Tuple(R.Object)) = conv1d_transpose, (_io,)
+            gv1: R.Tuple(R.Tensor((1, 32, 32), dtype="float32"), R.Tuple(R.Any)) = conv1d_transpose, (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -193,16 +193,16 @@ def test_layer_norm():
     @R.function
     def forward(
         x: R.Tensor((2, 4, 8), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor((8,), dtype="float32"),
         bias: R.Tensor((8,), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             layer_norm: R.Tensor((2, 4, 8), dtype="float32") = R.nn.layer_norm(
                 x, weight, bias, axes=[-1], epsilon=1.0000000000000001e-05, center=True, scale=True
             )
-            gv1: R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Object)) = (
+            gv1: R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Any)) = (
                 layer_norm,
                 (_io,),
             )
@@ -220,16 +220,16 @@ def test_conv2d():
     @R.function
     def forward(
         x: R.Tensor((1, 3, 32, 32), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor((32, 3, 3, 3), dtype="float32"),
         bias: R.Tensor((32,), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((1, 32, 30, 30), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((1, 32, 30, 30), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             lv1: R.Tensor((1, 32, 30, 30), dtype="float32") = R.nn.conv2d(x, weight)
             lv2: R.Tensor((1, 32, 1, 1), dtype="float32") = R.reshape(bias, R.shape([1, 32, 1, 1]))
             conv2d: R.Tensor((1, 32, 30, 30), dtype="float32") = R.add(lv1, lv2)
-            gv1: R.Tuple(R.Tensor((1, 32, 30, 30), dtype="float32"), R.Tuple(R.Object)) = (
+            gv1: R.Tuple(R.Tensor((1, 32, 30, 30), dtype="float32"), R.Tuple(R.Any)) = (
                 conv2d,
                 (_io,),
             )
@@ -252,10 +252,10 @@ def test_conv3d():
     @R.function
     def forward(
         x: R.Tensor((1, 3, 32, 32, 32), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor((32, 3, 3, 3, 3), dtype="float32"),
         bias: R.Tensor((32,), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((1, 32, 30, 30, 30), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((1, 32, 30, 30, 30), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             lv1: R.Tensor((1, 32, 30, 30, 30), dtype="float32") = R.nn.conv3d(x, weight)
@@ -263,7 +263,7 @@ def test_conv3d():
                 bias, R.shape([1, 32, 1, 1, 1])
             )
             conv3d: R.Tensor((1, 32, 30, 30, 30), dtype="float32") = R.add(lv1, lv2)
-            gv1: R.Tuple(R.Tensor((1, 32, 30, 30, 30), dtype="float32"), R.Tuple(R.Object)) = (
+            gv1: R.Tuple(R.Tensor((1, 32, 30, 30, 30), dtype="float32"), R.Tuple(R.Any)) = (
                 conv3d,
                 (_io,),
             )
@@ -286,10 +286,10 @@ def test_conv2d_dynamic():
     @R.function
     def forward(
         x: R.Tensor(("n", "c", "h", "w"), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor((32, "in_channels", 3, 3), dtype="float32"),
         bias: R.Tensor((32,), dtype="float32"),
-    ) -> R.Tuple(R.Tensor(("n", 32, "h - 2", "w - 2"), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor(("n", 32, "h - 2", "w - 2"), dtype="float32"), R.Tuple(R.Any)):
         n = T.int64()
         h = T.int64()
         w = T.int64()
@@ -300,7 +300,7 @@ def test_conv2d_dynamic():
             lv1: R.Tensor((n, 32, h - 2, w - 2), dtype="float32") = R.nn.conv2d(x, weight)
             lv2: R.Tensor((1, 32, 1, 1), dtype="float32") = R.reshape(bias, R.shape([1, 32, 1, 1]))
             conv2d: R.Tensor((n, 32, h - 2, w - 2), dtype="float32") = R.add(lv1, lv2)
-            gv1: R.Tuple(R.Tensor((n, 32, h - 2, w - 2), dtype="float32"), R.Tuple(R.Object)) = (
+            gv1: R.Tuple(R.Tensor((n, 32, h - 2, w - 2), dtype="float32"), R.Tuple(R.Any)) = (
                 conv2d,
                 (_io,),
             )
@@ -323,15 +323,15 @@ def test_rms_norm():
     @R.function
     def forward(
         x: R.Tensor((2, 4, 8), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor((8,), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             rms_norm: R.Tensor((2, 4, 8), dtype="float32") = R.nn.rms_norm(
                 x, weight, axes=[2], epsilon=1.0000000000000001e-05
             )
-            gv1: R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Object)) = rms_norm, (_io,)
+            gv1: R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Any)) = rms_norm, (_io,)
             R.output(gv1)
         return gv1
 
@@ -346,16 +346,16 @@ def test_group_norm():
     @R.function
     def forward(
         x: R.Tensor((2, 4, 8), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor((4,), dtype="float32"),
         bias: R.Tensor((4,), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             group_norm: R.Tensor((2, 4, 8), dtype="float32") = R.nn.group_norm(
                 x, weight, bias, num_groups=2, channel_axis=1, axes=[2]
             )
-            gv1: R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Object)) = (
+            gv1: R.Tuple(R.Tensor((2, 4, 8), dtype="float32"), R.Tuple(R.Any)) = (
                 group_norm,
                 (_io,),
             )
@@ -373,13 +373,13 @@ def test_embedding_1d():
     @R.function
     def forward(
         x: R.Tensor((4,), dtype="int32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor((8, 16), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((4, 16), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((4, 16), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             take: R.Tensor((4, 16), dtype="float32") = R.take(weight, x, axis=0)
-            gv1: R.Tuple(R.Tensor((4, 16), dtype="float32"), R.Tuple(R.Object)) = take, (_io,)
+            gv1: R.Tuple(R.Tensor((4, 16), dtype="float32"), R.Tuple(R.Any)) = take, (_io,)
             R.output(gv1)
         return gv1
 
@@ -392,15 +392,15 @@ def test_embedding_2d():
     @R.function
     def forward(
         x: R.Tensor((1, 4), dtype="int32"),
-        _io: R.Object,
+        _io: R.Any,
         weight: R.Tensor((4, 8), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((1, 4, 8), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((1, 4, 8), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             reshape: R.Tensor((4,), dtype="int32") = R.reshape(x, R.shape([4]))
             take: R.Tensor((4, 8), dtype="float32") = R.take(weight, reshape, axis=0)
             reshape1: R.Tensor((1, 4, 8), dtype="float32") = R.reshape(take, R.shape([1, 4, 8]))
-            gv1: R.Tuple(R.Tensor((1, 4, 8), dtype="float32"), R.Tuple(R.Object)) = reshape1, (_io,)
+            gv1: R.Tuple(R.Tensor((1, 4, 8), dtype="float32"), R.Tuple(R.Any)) = reshape1, (_io,)
             R.output(gv1)
         return gv1
 
@@ -414,13 +414,13 @@ def test_timestep_embedding():
     def forward(
         sample: R.Tensor((32, 32), dtype="float32"),
         condition: R.Tensor((32, 16), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         linear_1_weight: R.Tensor((32, 32), dtype="float32"),
         linear_1_bias: R.Tensor((32,), dtype="float32"),
         cond_proj_weight: R.Tensor((32, 16), dtype="float32"),
         linear_2_weight: R.Tensor((32, 32), dtype="float32"),
         linear_2_bias: R.Tensor((32,), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((32, 32), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((32, 32), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 3})
         with R.dataflow():
             permute_dims: R.Tensor((16, 32), dtype="float32") = R.permute_dims(
@@ -445,7 +445,7 @@ def test_timestep_embedding():
                 silu, permute_dims2, out_dtype="void"
             )
             add2: R.Tensor((32, 32), dtype="float32") = R.add(matmul2, linear_2_bias)
-            gv1: R.Tuple(R.Tensor((32, 32), dtype="float32"), R.Tuple(R.Object)) = add2, (_io,)
+            gv1: R.Tuple(R.Tensor((32, 32), dtype="float32"), R.Tuple(R.Any)) = add2, (_io,)
             R.output(gv1)
         return gv1
 
@@ -464,8 +464,8 @@ def test_timestep_embedding():
 
 def test_timesteps():
     @R.function
-    def forward(x: R.Tensor((3,), dtype="float32"), _io: R.Object) -> R.Tuple(
-        R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Object)
+    def forward(x: R.Tensor((3,), dtype="float32"), _io: R.Any) -> R.Tuple(
+        R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Any)
     ):
         R.func_attr({"num_input": 2})
         with R.dataflow():
@@ -487,7 +487,7 @@ def test_timesteps():
             get_timestep_embedding: R.Tensor((3, 10), dtype="float32") = R.astype(
                 lv11, dtype="float32"
             )
-            gv1: R.Tuple(R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Object)) = (
+            gv1: R.Tuple(R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Any)) = (
                 get_timestep_embedding,
                 (_io,),
             )
@@ -503,18 +503,18 @@ def test_kv_cache():
     @I.ir_module
     class Module:
         @R.function
-        def _initialize_effect() -> R.Tuple(R.Object, R.Object):
+        def _initialize_effect() -> R.Tuple(R.Any, R.Any):
             with R.dataflow():
-                _io: R.Object = R.null_value()
+                _io: R.Any = R.null_value()
                 lv: R.Tensor((8, 2, 4), dtype="float32") = R.zeros(
                     R.shape([8, 2, 4]), dtype="float32"
                 )
-                cache: R.Object = R.call_pure_packed(
+                cache: R.Any = R.call_pure_packed(
                     "vm.builtin.attention_kv_cache_create",
                     lv,
                     R.shape([8, 2, 4]),
                     R.prim_value(0),
-                    ty_args=[R.Object()],
+                    ty_args=[R.Any()],
                 )
                 lv1 = _io, cache
                 gv = lv1
@@ -522,17 +522,17 @@ def test_kv_cache():
             return gv
 
         @R.function
-        def forward(
-            x: R.Tensor((2, 4), dtype="float32"), _io: R.Object, cache: R.Object
-        ) -> R.Tuple(R.Tensor((4, 2, 4), dtype="float32"), R.Tuple(R.Object, R.Object)):
+        def forward(x: R.Tensor((2, 4), dtype="float32"), _io: R.Any, cache: R.Any) -> R.Tuple(
+            R.Tensor((4, 2, 4), dtype="float32"), R.Tuple(R.Any, R.Any)
+        ):
             R.func_attr({"num_input": 3})
             with R.dataflow():
-                lv2: R.Object = R.call_inplace_packed(
+                lv2: R.Any = R.call_inplace_packed(
                     "vm.builtin.attention_kv_cache_append",
                     cache,
                     x,
                     inplace_indices=[0],
-                    ty_args=[R.Object()],
+                    ty_args=[R.Any()],
                 )
                 lv3: R.Tensor((4, 2, 4), dtype="float32") = R.call_pure_packed(
                     "vm.builtin.attention_kv_cache_view",
@@ -540,7 +540,7 @@ def test_kv_cache():
                     R.shape([4, 2, 4]),
                     ty_args=(R.Tensor((4, 2, 4), dtype="float32"),),
                 )
-                gv1: R.Tuple(R.Tensor((4, 2, 4), dtype="float32"), R.Tuple(R.Object, R.Object)) = (
+                gv1: R.Tuple(R.Tensor((4, 2, 4), dtype="float32"), R.Tuple(R.Any, R.Any)) = (
                     lv3,
                     (_io, lv2),
                 )
@@ -566,7 +566,7 @@ def test_attention():
     def forward(
         hidden_states: R.Tensor((2, 4096, 640), dtype="float32"),
         encoder_hidden_states: R.Tensor((2, 77, 2048), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
         to_q_weight: R.Tensor((640, 640), dtype="float32"),
         to_k_weight: R.Tensor((640, 2048), dtype="float32"),
         to_v_weight: R.Tensor((640, 2048), dtype="float32"),
@@ -574,7 +574,7 @@ def test_attention():
         group_norm_bias: R.Tensor((640,), dtype="float32"),
         to_out_0_weight: R.Tensor((640, 640), dtype="float32"),
         to_out_0_bias: R.Tensor((640,), dtype="float32"),
-    ) -> R.Tuple(R.Tensor((2, 4096, 640), dtype="float32"), R.Tuple(R.Object)):
+    ) -> R.Tuple(R.Tensor((2, 4096, 640), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 3})
         with R.dataflow():
             group_norm: R.Tensor((2, 4096, 640), dtype="float32") = R.nn.group_norm(
@@ -628,7 +628,7 @@ def test_attention():
                 reshape3, permute_dims3, out_dtype="void"
             )
             add: R.Tensor((2, 4096, 640), dtype="float32") = R.add(matmul3, to_out_0_bias)
-            gv1: R.Tuple(R.Tensor((2, 4096, 640), dtype="float32"), R.Tuple(R.Object)) = add, (_io,)
+            gv1: R.Tuple(R.Tensor((2, 4096, 640), dtype="float32"), R.Tuple(R.Any)) = add, (_io,)
             R.output(gv1)
         return gv1
 
@@ -659,14 +659,14 @@ def test_nn_module_tuple_input():
 
     # fmt: off
     @R.function
-    def forward(x: R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), _io: R.Object) -> R.Tuple(R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), R.Tuple(R.Object)):
+    def forward(x: R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), _io: R.Any) -> R.Tuple(R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             lv1: R.Tensor((10, 5), dtype="float32") = x[0]
             lv2: R.Tensor((10, 5), dtype="float32") = x[1]
             add: R.Tensor((10, 5), dtype="float32") = R.add(lv1, lv2)
             subtract: R.Tensor((10, 5), dtype="float32") = R.subtract(lv1, lv2)
-            gv1: R.Tuple(R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), R.Tuple(R.Object)) = (add, subtract), (_io,)
+            gv1: R.Tuple(R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), R.Tuple(R.Any)) = (add, subtract), (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -698,14 +698,14 @@ def test_nn_module_list_input():
 
     # fmt: off
     @R.function
-    def forward(x: R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), _io: R.Object) -> R.Tuple(R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), R.Tuple(R.Object)):
+    def forward(x: R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), _io: R.Any) -> R.Tuple(R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             lv1: R.Tensor((10, 5), dtype="float32") = x[0]
             lv2: R.Tensor((10, 5), dtype="float32") = x[1]
             add: R.Tensor((10, 5), dtype="float32") = R.add(lv1, lv2)
             subtract: R.Tensor((10, 5), dtype="float32") = R.subtract(lv1, lv2)
-            gv1: R.Tuple(R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), R.Tuple(R.Object)) = (add, subtract), (_io,)
+            gv1: R.Tuple(R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((10, 5), dtype="float32")), R.Tuple(R.Any)) = (add, subtract), (_io,)
             R.output(gv1)
         return gv1
     # fmt: on

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -40,7 +40,7 @@ def test_unary():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((1, 10), dtype="float32"), _io: R.Object):
+    def test(x: R.Tensor((1, 10), dtype="float32"), _io: R.Any):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             square: R.Tensor((1, 10), dtype="float32") = R.square(x)
@@ -79,7 +79,7 @@ def test_binary():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((1, 10), dtype="float32"), y: R.Tensor((10, 1), dtype="float32"), _io: R.Object):
+    def test(x: R.Tensor((1, 10), dtype="float32"), y: R.Tensor((10, 1), dtype="float32"), _io: R.Any):
         R.func_attr({"num_input": 3})
         with R.dataflow():
             add: R.Tensor((10, 10), dtype="float32") = R.add(x, y)
@@ -116,11 +116,11 @@ def test_sum():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((3, 5, 2, 4), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Object)):
+    def test(x: R.Tensor((3, 5, 2, 4), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             sum: R.Tensor((3, 1, 1, 4), dtype="float32") = R.sum(x, axis=[1, 2], keepdims=True)
-            gv1: R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Object)) = sum, (_io,)
+            gv1: R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Any)) = sum, (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -140,11 +140,11 @@ def test_max():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((3, 5, 2, 4), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Object)):
+    def test(x: R.Tensor((3, 5, 2, 4), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             max: R.Tensor((3, 1, 1, 4), dtype="float32") = R.max(x, axis=[1, 2], keepdims=True)
-            gv1: R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Object)) = max, (_io,)
+            gv1: R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Any)) = max, (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -164,11 +164,11 @@ def test_min():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((3, 5, 2, 4), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Object)):
+    def test(x: R.Tensor((3, 5, 2, 4), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             min: R.Tensor((3, 1, 1, 4), dtype="float32") = R.min(x, axis=[1, 2], keepdims=True)
-            gv1: R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Object)) = min, (_io,)
+            gv1: R.Tuple(R.Tensor((3, 1, 1, 4), dtype="float32"), R.Tuple(R.Any)) = min, (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -194,7 +194,7 @@ def test_manipulate():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((1, 5, 2), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tuple(R.Tensor((2, 5, 2), dtype="float32"), R.Tensor((2, 5, 1), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10, 2), dtype="float32"), R.Tensor((5, 2), dtype="float32"), R.Tensor((1, 1, 5, 2), dtype="float32"), R.Tensor((2, 5, 2), dtype="float32")), R.Tuple(R.Object)):
+    def test(x: R.Tensor((1, 5, 2), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tuple(R.Tensor((2, 5, 2), dtype="float32"), R.Tensor((2, 5, 1), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10, 2), dtype="float32"), R.Tensor((5, 2), dtype="float32"), R.Tensor((1, 1, 5, 2), dtype="float32"), R.Tensor((2, 5, 2), dtype="float32")), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             broadcast_to: R.Tensor((2, 5, 2), dtype="float32") = R.broadcast_to(x, R.shape([2, 5, 2]))
@@ -204,7 +204,7 @@ def test_manipulate():
             squeeze: R.Tensor((5, 2), dtype="float32") = R.squeeze(x, axis=[0])
             unsqueeze: R.Tensor((1, 1, 5, 2), dtype="float32") = R.expand_dims(x, axis=0)
             concat: R.Tensor((2, 5, 2), dtype="float32") = R.concat([x, x], axis=0)
-            gv1: R.Tuple(R.Tuple(R.Tensor((2, 5, 2), dtype="float32"), R.Tensor((2, 5, 1), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10, 2), dtype="float32"), R.Tensor((5, 2), dtype="float32"), R.Tensor((1, 1, 5, 2), dtype="float32"), R.Tensor((2, 5, 2), dtype="float32")), R.Tuple(R.Object)) = (broadcast_to, permute_dims, reshape, repeat, squeeze, unsqueeze, concat), (_io,)
+            gv1: R.Tuple(R.Tuple(R.Tensor((2, 5, 2), dtype="float32"), R.Tensor((2, 5, 1), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10, 2), dtype="float32"), R.Tensor((5, 2), dtype="float32"), R.Tensor((1, 1, 5, 2), dtype="float32"), R.Tensor((2, 5, 2), dtype="float32")), R.Tuple(R.Any)) = (broadcast_to, permute_dims, reshape, repeat, squeeze, unsqueeze, concat), (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -223,11 +223,11 @@ def test_index():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((2, 1, 10), dtype="float32"), y: R.Tensor((5,), dtype="int32"), _io: R.Object) -> R.Tuple(R.Tensor((2, 1, 5), dtype="float32"), R.Tuple(R.Object)):
+    def test(x: R.Tensor((2, 1, 10), dtype="float32"), y: R.Tensor((5,), dtype="int32"), _io: R.Any) -> R.Tuple(R.Tensor((2, 1, 5), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 3})
         with R.dataflow():
             take: R.Tensor((2, 1, 5), dtype="float32") = R.take(x, y, axis=2)
-            gv1: R.Tuple(R.Tensor((2, 1, 5), dtype="float32"), R.Tuple(R.Object)) = take, (_io,)
+            gv1: R.Tuple(R.Tensor((2, 1, 5), dtype="float32"), R.Tuple(R.Any)) = take, (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -249,11 +249,11 @@ def test_datatype():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((2, 1, 10), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tensor((2, 1, 10), dtype="float16"), R.Tuple(R.Object)):
+    def test(x: R.Tensor((2, 1, 10), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tensor((2, 1, 10), dtype="float16"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             astype: R.Tensor((2, 1, 10), dtype="float16") = R.astype(x, dtype="float16")
-            gv1: R.Tuple(R.Tensor((2, 1, 10), dtype="float16"), R.Tuple(R.Object)) = astype, (_io,)
+            gv1: R.Tuple(R.Tensor((2, 1, 10), dtype="float16"), R.Tuple(R.Any)) = astype, (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -277,12 +277,12 @@ def test_image():
         x: R.Tensor((1, 3, 32, 32), dtype="float32"),
         weight: R.Tensor((32, 3, 3, 3), dtype="float32"),
         bias: R.Tensor((32,), dtype="float32"),
-        _io: R.Object,
+        _io: R.Any,
     ) -> R.Tuple(
         R.Tuple(
             R.Tensor((1, 32, 32, 32), dtype="float32"), R.Tensor((1, 3, 40, 40), dtype="float32")
         ),
-        R.Tuple(R.Object),
+        R.Tuple(R.Any),
     ):
         R.func_attr({"num_input": 4})
         with R.dataflow():
@@ -319,7 +319,7 @@ def test_image():
                     R.Tensor((1, 32, 32, 32), dtype="float32"),
                     R.Tensor((1, 3, 40, 40), dtype="float32"),
                 ),
-                R.Tuple(R.Object),
+                R.Tuple(R.Any),
             ) = (conv2d, interpolate), (_io,)
             R.output(gv1)
         return gv1
@@ -345,14 +345,14 @@ def test_chunk():
             return chunk
 
     @R.function
-    def test(x: R.Tensor((8,), dtype="float32"), _io: R.Object) -> R.Tuple(
+    def test(x: R.Tensor((8,), dtype="float32"), _io: R.Any) -> R.Tuple(
         R.Tuple(
             R.Tensor((2,), dtype="float32"),
             R.Tensor((2,), dtype="float32"),
             R.Tensor((2,), dtype="float32"),
             R.Tensor((2,), dtype="float32"),
         ),
-        R.Tuple(R.Object),
+        R.Tuple(R.Any),
     ):
         R.func_attr({"num_input": 2})
         with R.dataflow():
@@ -373,7 +373,7 @@ def test_chunk():
                     R.Tensor((2,), dtype="float32"),
                     R.Tensor((2,), dtype="float32"),
                 ),
-                R.Tuple(R.Object),
+                R.Tuple(R.Any),
             ) = (chunk_0, chunk_1, chunk_2, chunk_3), (_io,)
             R.output(gv1)
         return gv1
@@ -409,8 +409,8 @@ def test_nn():
         x: R.Tensor((2, 3, 4, 5), dtype="float32"),
         weight: R.Tensor((4, 5), dtype="float32"),
         bias: R.Tensor((3,), dtype="float32"),
-        _io: R.Object,
-    ) -> R.Tuple(R.Tensor((2, 3, 4, 5), dtype="float32"), R.Tuple(R.Object)):
+        _io: R.Any,
+    ) -> R.Tuple(R.Tensor((2, 3, 4, 5), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 4})
         with R.dataflow():
             log: R.Tensor((2, 3, 4, 5), dtype="float32") = R.log(x)
@@ -437,7 +437,7 @@ def test_nn():
             group_norm: R.Tensor((2, 3, 4, 5), dtype="float32") = R.nn.group_norm(
                 x, bias, bias, num_groups=1, channel_axis=1, axes=[2, 3]
             )
-            gv1: R.Tuple(R.Tensor((2, 3, 4, 5), dtype="float32"), R.Tuple(R.Object)) = x, (_io,)
+            gv1: R.Tuple(R.Tensor((2, 3, 4, 5), dtype="float32"), R.Tuple(R.Any)) = x, (_io,)
             R.output(gv1)
         return gv1
 
@@ -475,7 +475,7 @@ def test_create():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((10, 10), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tuple(R.Object)):
+    def test(x: R.Tensor((10, 10), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             triu: R.Tensor((10, 10), dtype="float32") = R.triu(x, k=0)
@@ -485,7 +485,7 @@ def test_create():
             zeros: R.Tensor((10, 10), dtype="float32") = R.zeros(R.shape([10, 10]), dtype="float32")
             zeros1: R.Tensor((10, 10), dtype="float16") = R.zeros(R.shape([10, 10]), dtype="float16")
             arange: R.Tensor((10,), dtype="float32") = R.arange(T.int64(0), T.int64(10), T.int64(1), dtype="float32")
-            gv1: R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tuple(R.Object)) = x, (_io,)
+            gv1: R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tuple(R.Any)) = x, (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -505,8 +505,8 @@ def test_timestep_embedding():
             return get_timestep_out
 
     @R.function
-    def test(x: R.Tensor((3,), dtype="float32"), _io: R.Object) -> R.Tuple(
-        R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Object)
+    def test(x: R.Tensor((3,), dtype="float32"), _io: R.Any) -> R.Tuple(
+        R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Any)
     ):
         R.func_attr({"num_input": 2})
         with R.dataflow():
@@ -531,7 +531,7 @@ def test_timestep_embedding():
             get_timestep_embedding: R.Tensor((3, 10), dtype="float32") = R.astype(
                 lv11, dtype="float32"
             )
-            gv1: R.Tuple(R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Object)) = (
+            gv1: R.Tuple(R.Tensor((3, 10), dtype="float32"), R.Tuple(R.Any)) = (
                 get_timestep_embedding,
                 (_io,),
             )
@@ -554,14 +554,14 @@ def test_scaled_dot_product_attention():
         query: R.Tensor((1, 32, 32, 32), dtype="float32"),
         key: R.Tensor((1, 32, 32, 32), dtype="float32"),
         value: R.Tensor((1, 32, 32, 32), dtype="float32"),
-        _io: R.Object,
-    ) -> R.Tuple(R.Tensor((1, 32, 32, 32), dtype="float32"), R.Tuple(R.Object)):
+        _io: R.Any,
+    ) -> R.Tuple(R.Tensor((1, 32, 32, 32), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 4})
         with R.dataflow():
             scaled_dot_product_attention: R.Tensor((1, 32, 32, 32), dtype="float32") = (
                 R.nn.attention(query, key, value, scale=None, causal_mask=None)
             )
-            gv1: R.Tuple(R.Tensor((1, 32, 32, 32), dtype="float32"), R.Tuple(R.Object)) = (
+            gv1: R.Tuple(R.Tensor((1, 32, 32, 32), dtype="float32"), R.Tuple(R.Any)) = (
                 scaled_dot_product_attention,
                 (_io,),
             )
@@ -605,21 +605,21 @@ def test_tensor_expr_op():
                     T_add[v_ax0, v_ax1] = A[v_ax0, v_ax1] + T.float32(1)
 
         @R.function
-        def _initialize_effect() -> R.Tuple(R.Object):
+        def _initialize_effect() -> R.Tuple(R.Any):
             with R.dataflow():
-                _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                _io: R.Any = R.null_value()
+                lv: R.Tuple(R.Any) = (_io,)
+                gv: R.Tuple(R.Any) = lv
                 R.output(gv)
             return gv
 
         @R.function
-        def test(x: R.Tensor((10, 10), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tuple(R.Object)):
+        def test(x: R.Tensor((10, 10), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tuple(R.Any)):
             cls = Expected
             R.func_attr({"num_input": 2})
             with R.dataflow():
                 lv1 = R.call_tir(cls.add_one, (x,), out_ty=R.Tensor((10, 10), dtype="float32"))
-                gv1: R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tuple(R.Object)) = lv1, (_io,)
+                gv1: R.Tuple(R.Tensor((10, 10), dtype="float32"), R.Tuple(R.Any)) = lv1, (_io,)
                 R.output(gv1)
             return gv1
     # fmt: on
@@ -686,16 +686,16 @@ def test_tensor_ir_op():
             T.evaluate(offset)
 
         @R.function
-        def _initialize_effect() -> R.Tuple(R.Object):
+        def _initialize_effect() -> R.Tuple(R.Any):
             with R.dataflow():
-                _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                _io: R.Any = R.null_value()
+                lv: R.Tuple(R.Any) = (_io,)
+                gv: R.Tuple(R.Any) = lv
                 R.output(gv)
             return gv
 
         @R.function
-        def test(qkv: R.Tensor((1, 1, 24, 16), dtype="float16"), offset: R.Shape(["offset_1"]), _io: R.Object) -> R.Tuple(R.Tuple(R.Tensor((1, 1, 8, 16), dtype="float16"), R.Tensor((1, 1, 8, 16), dtype="float16"), R.Tensor((1, 1, 8, 16), dtype="float16")), R.Tuple(R.Object)):
+        def test(qkv: R.Tensor((1, 1, 24, 16), dtype="float16"), offset: R.Shape(["offset_1"]), _io: R.Any) -> R.Tuple(R.Tuple(R.Tensor((1, 1, 8, 16), dtype="float16"), R.Tensor((1, 1, 8, 16), dtype="float16"), R.Tensor((1, 1, 8, 16), dtype="float16")), R.Tuple(R.Any)):
             offset_1 = T.int64()
             R.func_attr({"num_input": 3})
             cls = Expected
@@ -704,7 +704,7 @@ def test_tensor_ir_op():
                 llama_fused_rope_0: R.Tensor((1, 1, 8, 16), dtype="float16") = lv1[0]
                 llama_fused_rope_1: R.Tensor((1, 1, 8, 16), dtype="float16") = lv1[1]
                 llama_fused_rope_2: R.Tensor((1, 1, 8, 16), dtype="float16") = lv1[2]
-                gv1: R.Tuple(R.Tuple(R.Tensor((1, 1, 8, 16), dtype="float16"), R.Tensor((1, 1, 8, 16), dtype="float16"), R.Tensor((1, 1, 8, 16), dtype="float16")), R.Tuple(R.Object)) = (llama_fused_rope_0, llama_fused_rope_1, llama_fused_rope_2), (_io,)
+                gv1: R.Tuple(R.Tuple(R.Tensor((1, 1, 8, 16), dtype="float16"), R.Tensor((1, 1, 8, 16), dtype="float16"), R.Tensor((1, 1, 8, 16), dtype="float16")), R.Tuple(R.Any)) = (llama_fused_rope_0, llama_fused_rope_1, llama_fused_rope_2), (_io,)
                 R.output(gv1)
             return gv1
     # fmt: on
@@ -775,11 +775,11 @@ def test_tensor_ir_inplace_op():
                     embeddings[v0 + offset, v1] = weight[pos[v0], v1]
 
         @R.function
-        def _initialize_effect() -> R.Tuple(R.Object):
+        def _initialize_effect() -> R.Tuple(R.Any):
             with R.dataflow():
-                _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                _io: R.Any = R.null_value()
+                lv: R.Tuple(R.Any) = (_io,)
+                gv: R.Tuple(R.Any) = lv
                 R.output(gv)
             return gv
 
@@ -877,20 +877,20 @@ def test_extern():
     @I.ir_module(s_tir=True)
     class Expected:
         @R.function
-        def _initialize_effect() -> R.Tuple(R.Object):
+        def _initialize_effect() -> R.Tuple(R.Any):
             with R.dataflow():
-                _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                _io: R.Any = R.null_value()
+                lv: R.Tuple(R.Any) = (_io,)
+                gv: R.Tuple(R.Any) = lv
                 R.output(gv)
             return gv
 
         @R.function
-        def test(q: R.Tensor((1, 1, 16, 8), dtype="float32"), k: R.Tensor((64, 16, 8), dtype="float32"), v: R.Tensor((64, 16, 8), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tensor((1, 1, 128), dtype="float16"), R.Tuple(R.Object)):
+        def test(q: R.Tensor((1, 1, 16, 8), dtype="float32"), k: R.Tensor((64, 16, 8), dtype="float32"), v: R.Tensor((64, 16, 8), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tensor((1, 1, 128), dtype="float16"), R.Tuple(R.Any)):
             R.func_attr({"num_input": 4})
             with R.dataflow():
                 flashinfer_single_decode = R.call_dps_packed("flashinfer.single_decode", (q, k, v, R.prim_value(0), R.prim_value(0), R.prim_value(T.float64(1)), R.prim_value(T.float64(10000))), out_ty=R.Tensor((1, 1, 128), dtype="float16"))
-                gv1: R.Tuple(R.Tensor((1, 1, 128), dtype="float16"), R.Tuple(R.Object)) = flashinfer_single_decode, (_io,)
+                gv1: R.Tuple(R.Tensor((1, 1, 128), dtype="float16"), R.Tuple(R.Any)) = flashinfer_single_decode, (_io,)
                 R.output(gv1)
             return gv1
     # fmt: on
@@ -944,20 +944,20 @@ def test_multinomial_from_uniform():
     @I.ir_module(s_tir=True)
     class Expected:
         @R.function
-        def _initialize_effect() -> R.Tuple(R.Object):
+        def _initialize_effect() -> R.Tuple(R.Any):
             with R.dataflow():
-                _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                _io: R.Any = R.null_value()
+                lv: R.Tuple(R.Any) = (_io,)
+                gv: R.Tuple(R.Any) = lv
                 R.output(gv)
             return gv
 
         @R.function
-        def foo(prob: R.Tensor((3, 5), dtype="float32"), uniform_sample: R.Tensor((6, 1), dtype="float32"), sample_indices: R.Tensor((6, 1), dtype="int64"), _io: R.Object) -> R.Tuple(R.Tensor((6, 1), dtype="int64"), R.Tuple(R.Object)):
+        def foo(prob: R.Tensor((3, 5), dtype="float32"), uniform_sample: R.Tensor((6, 1), dtype="float32"), sample_indices: R.Tensor((6, 1), dtype="int64"), _io: R.Any) -> R.Tuple(R.Tensor((6, 1), dtype="int64"), R.Tuple(R.Any)):
             R.func_attr({"num_input": 4})
             with R.dataflow():
                 multinomial_from_uniform: R.Tensor((6, 1), dtype="int64") = R.multinomial_from_uniform(prob, uniform_sample, sample_indices, dtype="int64")
-                gv1: R.Tuple(R.Tensor((6, 1), dtype="int64"), R.Tuple(R.Object)) = multinomial_from_uniform, (_io,)
+                gv1: R.Tuple(R.Tensor((6, 1), dtype="int64"), R.Tuple(R.Any)) = multinomial_from_uniform, (_io,)
                 R.output(gv1)
             return gv1
     # fmt: on
@@ -1073,23 +1073,23 @@ def test_sample_top_p_top_k_from_sorted_prob():
                                     renorm_prob[v_ax0, 0] = cumsum_sorted[v_ax0, v_ax1 + T.int64(1)]
 
         @R.function
-        def _initialize_effect() -> R.Tuple(R.Object):
+        def _initialize_effect() -> R.Tuple(R.Any):
             with R.dataflow():
-                _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                _io: R.Any = R.null_value()
+                lv: R.Tuple(R.Any) = (_io,)
+                gv: R.Tuple(R.Any) = lv
                 R.output(gv)
             return gv
 
         @R.function
-        def foo(prob: R.Tensor((2, 3), dtype="float32"), index: R.Tensor((2, 3), dtype="int64"), top_p: R.Tensor((2, 1), dtype="float32"), top_k: R.Tensor((2, 1), dtype="int64"), uniform_sample: R.Tensor((3, 1), dtype="float32"), sample_indices: R.Tensor((3, 1), dtype="int64"), _io: R.Object,) -> R.Tuple(R.Tensor((3, 1), dtype="int64"), R.Tuple(R.Object)):
+        def foo(prob: R.Tensor((2, 3), dtype="float32"), index: R.Tensor((2, 3), dtype="int64"), top_p: R.Tensor((2, 1), dtype="float32"), top_k: R.Tensor((2, 1), dtype="int64"), uniform_sample: R.Tensor((3, 1), dtype="float32"), sample_indices: R.Tensor((3, 1), dtype="int64"), _io: R.Any,) -> R.Tuple(R.Tensor((3, 1), dtype="int64"), R.Tuple(R.Any)):
             R.func_attr({"num_input": 7})
             cls = Expected
             with R.dataflow():
                 cumsum: R.Tensor((2, 3), dtype="float32") = R.cumsum(prob, axis=1, dtype="void", exclusive=None)
                 lv1 = R.call_tir(cls.get_renorm_prob, (cumsum, top_p, top_k), out_ty=R.Tensor((2, 1), dtype="float32"))
                 lv2 = R.call_tir(cls.get_index_from_sorted, (cumsum, index, lv1, uniform_sample, sample_indices), out_ty=R.Tensor((3, 1), dtype="int64"))
-                gv1: R.Tuple(R.Tensor((3, 1), dtype="int64"), R.Tuple(R.Object)) = lv2, (_io,)
+                gv1: R.Tuple(R.Tensor((3, 1), dtype="int64"), R.Tuple(R.Any)) = lv2, (_io,)
                 R.output(gv1)
             return gv1
     # fmt: on
@@ -1191,16 +1191,16 @@ def test_renormalize_top_p_top_k_prob():
                                     cutoff[v_ax0, 0] = sorted_prob[v_ax0, v_ax1 + T.int64(1)]
 
         @R.function
-        def _initialize_effect() -> R.Tuple(R.Object):
+        def _initialize_effect() -> R.Tuple(R.Any):
             with R.dataflow():
-                _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                _io: R.Any = R.null_value()
+                lv: R.Tuple(R.Any) = (_io,)
+                gv: R.Tuple(R.Any) = lv
                 R.output(gv)
             return gv
 
         @R.function
-        def foo(prob: R.Tensor((2, 3), dtype="float32"), sorted_prob: R.Tensor((2, 3), dtype="float32"), top_p: R.Tensor((2, 1), dtype="float32"), top_k: R.Tensor((2, 1), dtype="int64"), _io: R.Object) -> R.Tuple(R.Tensor((2, 3), dtype="float32"), R.Tuple(R.Object)):
+        def foo(prob: R.Tensor((2, 3), dtype="float32"), sorted_prob: R.Tensor((2, 3), dtype="float32"), top_p: R.Tensor((2, 1), dtype="float32"), top_k: R.Tensor((2, 1), dtype="int64"), _io: R.Any) -> R.Tuple(R.Tensor((2, 3), dtype="float32"), R.Tuple(R.Any)):
             R.func_attr({"num_input": 5})
             cls = Expected
             with R.dataflow():
@@ -1209,7 +1209,7 @@ def test_renormalize_top_p_top_k_prob():
                 lv2 = R.call_tir(cls.filter_with_top_p_top_k, (prob, lv1), out_ty=R.Tensor((2, 3), dtype="float32"))
                 sum: R.Tensor((2, 1), dtype="float32") = R.sum(lv2, axis=[1], keepdims=True)
                 divide: R.Tensor((2, 3), dtype="float32") = R.divide(lv2, sum)
-                gv1: R.Tuple(R.Tensor((2, 3), dtype="float32"), R.Tuple(R.Object)) = divide, (_io,)
+                gv1: R.Tuple(R.Tensor((2, 3), dtype="float32"), R.Tuple(R.Any)) = divide, (_io,)
                 R.output(gv1)
             return gv1
     # fmt: on

--- a/tests/python/relax/test_frontend_nn_subroutines.py
+++ b/tests/python/relax/test_frontend_nn_subroutines.py
@@ -47,9 +47,9 @@ def test_linear():
         @R.function
         def forward(
             state: R.Tensor(("batch_size", 64), dtype="float32"),
-            _io: R.Object,
+            _io: R.Any,
             weights: R.Tensor((64, 32), dtype="float32"),
-        ) -> R.Tuple(R.Tensor(("batch_size", 32), dtype="float32"), R.Tuple(R.Object)):
+        ) -> R.Tuple(R.Tensor(("batch_size", 32), dtype="float32"), R.Tuple(R.Any)):
             R.func_attr({"num_input": 2})
             with R.dataflow():
                 state = Expected.layer(state, weights)
@@ -58,11 +58,11 @@ def test_linear():
             return dataflow_output
 
         @R.function
-        def _initialize_effect() -> R.Tuple(R.Object):
+        def _initialize_effect() -> R.Tuple(R.Any):
             with R.dataflow():
-                _io: R.Object = R.null_value()
-                lv: R.Tuple(R.Object) = (_io,)
-                gv: R.Tuple(R.Object) = lv
+                _io: R.Any = R.null_value()
+                lv: R.Tuple(R.Any) = (_io,)
+                gv: R.Tuple(R.Any) = lv
                 R.output(gv)
 
             return gv

--- a/tests/python/relax/test_frontend_nn_tensor.py
+++ b/tests/python/relax/test_frontend_nn_tensor.py
@@ -55,7 +55,7 @@ def test_tensor_op_binary_tensor_tensor():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((1, 10), dtype="float32"), y: R.Tensor((2, 1), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tuple(R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32")), R.Tuple(R.Object)):
+    def test(x: R.Tensor((1, 10), dtype="float32"), y: R.Tensor((2, 1), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tuple(R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32")), R.Tuple(R.Any)):
         R.func_attr({"num_input": 3})
         with R.dataflow():
             add: R.Tensor((2, 10), dtype="float32") = R.add(x, y)
@@ -63,7 +63,7 @@ def test_tensor_op_binary_tensor_tensor():
             divide: R.Tensor((2, 10), dtype="float32") = R.divide(x, y)
             maximum: R.Tensor((2, 10), dtype="float32") = R.maximum(x, y)
             minimum: R.Tensor((2, 10), dtype="float32") = R.minimum(x, y)
-            gv1: R.Tuple(R.Tuple(R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32")), R.Tuple(R.Object)) = (add, mul, divide, maximum, minimum), (_io,)
+            gv1: R.Tuple(R.Tuple(R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32"), R.Tensor((2, 10), dtype="float32")), R.Tuple(R.Any)) = (add, mul, divide, maximum, minimum), (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -91,7 +91,7 @@ def test_tensor_op_binary_tensor_scalar():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((1, 10), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tuple(R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32")), R.Tuple(R.Object)):
+    def test(x: R.Tensor((1, 10), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tuple(R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32")), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             add: R.Tensor((1, 10), dtype="float32") = R.add(x, R.const(10, "float32"))
@@ -100,7 +100,7 @@ def test_tensor_op_binary_tensor_scalar():
             divide: R.Tensor((1, 10), dtype="float32") = R.divide(x, R.const(10, "float32"))
             maximum: R.Tensor((1, 10), dtype="float32") = R.maximum(x, R.const(10, "float32"))
             minimum: R.Tensor((1, 10), dtype="float32") = R.minimum(x, R.const(10, "float32"))
-            gv1: R.Tuple(R.Tuple(R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32")), R.Tuple(R.Object)) = (add, add1, mul, divide, maximum, minimum), (_io,)
+            gv1: R.Tuple(R.Tuple(R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32"), R.Tensor((1, 10), dtype="float32")), R.Tuple(R.Any)) = (add, add1, mul, divide, maximum, minimum), (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -119,11 +119,11 @@ def test_tensor_op_datatype():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((1, 10), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tensor((1, 10), dtype="float16"), R.Tuple(R.Object)):
+    def test(x: R.Tensor((1, 10), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tensor((1, 10), dtype="float16"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             astype: R.Tensor((1, 10), dtype="float16") = R.astype(x, dtype="float16")
-            gv1: R.Tuple(R.Tensor((1, 10), dtype="float16"), R.Tuple(R.Object)) = astype, (_io,)
+            gv1: R.Tuple(R.Tensor((1, 10), dtype="float16"), R.Tuple(R.Any)) = astype, (_io,)
             R.output(gv1)
         return gv1
     # fmt: on
@@ -144,13 +144,13 @@ def test_tensor_op_manipulate():
 
     # fmt: off
     @R.function
-    def test(x: R.Tensor((2, 1, 10), dtype="float32"), _io: R.Object) -> R.Tuple(R.Tuple(R.Tensor((2, 5, 2), dtype="float32"), R.Tensor((10, 1, 2), dtype="float32"), R.Tensor((2, 2, 10), dtype="float32")), R.Tuple(R.Object)):
+    def test(x: R.Tensor((2, 1, 10), dtype="float32"), _io: R.Any) -> R.Tuple(R.Tuple(R.Tensor((2, 5, 2), dtype="float32"), R.Tensor((10, 1, 2), dtype="float32"), R.Tensor((2, 2, 10), dtype="float32")), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
             reshape: R.Tensor((2, 5, 2), dtype="float32") = R.reshape(x, R.shape([2, 5, 2]))
             permute_dims: R.Tensor((10, 1, 2), dtype="float32") = R.permute_dims(x, axes=[2, 1, 0])
             repeat: R.Tensor((2, 2, 10), dtype="float32") = R.repeat(x, repeats=2, axis=1)
-            gv1: R.Tuple(R.Tuple(R.Tensor((2, 5, 2), dtype="float32"), R.Tensor((10, 1, 2), dtype="float32"), R.Tensor((2, 2, 10), dtype="float32")), R.Tuple(R.Object)) = (reshape, permute_dims, repeat), (_io,)
+            gv1: R.Tuple(R.Tuple(R.Tensor((2, 5, 2), dtype="float32"), R.Tensor((10, 1, 2), dtype="float32"), R.Tensor((2, 2, 10), dtype="float32")), R.Tuple(R.Any)) = (reshape, permute_dims, repeat), (_io,)
             R.output(gv1)
         return gv1
     # fmt: on

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -3073,7 +3073,7 @@ def test_reverse_sequence_infer_ty_wrong_inputs():
     seq_lengths_float = relax.Var("seq_lengths", R.Tensor((2,), "float32"))
     seq_lengths_int16 = relax.Var("seq_lengths", R.Tensor((2,), "int16"))
     seq_lengths_mismatch = relax.Var("seq_lengths", R.Tensor((3,), "int32"))
-    not_tensor = relax.Var("seq_lengths", relax.ObjectType())
+    not_tensor = relax.Var("seq_lengths", relax.AnyType())
 
     with pytest.raises(TypeError):
         bb.normalize(relax.op.reverse_sequence(x, not_tensor))

--- a/tests/python/relax/test_op_view.py
+++ b/tests/python/relax/test_op_view.py
@@ -293,12 +293,12 @@ def test_infer_dtype_of_view_with_unknown_dtype():
     """
 
     @R.function(private=True)
-    def explicit_ty(A: R.Tensor("float32"), dtype: R.Object) -> R.Tensor:
+    def explicit_ty(A: R.Tensor("float32"), dtype: R.Any) -> R.Tensor:
         B: R.Tensor = R.memory.view(A, dtype=dtype)
         return B
 
     @R.function(private=True)
-    def inferred_ty(A: R.Tensor("float32"), dtype: R.Object):
+    def inferred_ty(A: R.Tensor("float32"), dtype: R.Any):
         B = R.memory.view(A, dtype=dtype)
         return B
 

--- a/tests/python/relax/test_pipeline.py
+++ b/tests/python/relax/test_pipeline.py
@@ -67,7 +67,7 @@ def test_pipeline_with_kv_cache():
                 init_data,
                 R.shape([m, 4]),
                 0,
-                ty_args=[R.Object()],
+                ty_args=[R.Any()],
             )
             return kv_cache
 
@@ -76,14 +76,14 @@ def test_pipeline_with_kv_cache():
             x: R.Tensor((1, 4), "float32"),
             y: R.Tensor((1, 4), "float32"),
             shape: R.Shape(["L", 4]),
-            kv_cache: R.Object,
+            kv_cache: R.Any,
         ):
             L = T.int64()
             # computation of the current value
             curr_value = R.add(x, y)
             # update cache
             kv_cache = R.call_packed(
-                "vm.builtin.attention_kv_cache_append", kv_cache, curr_value, ty_args=[R.Object]
+                "vm.builtin.attention_kv_cache_append", kv_cache, curr_value, ty_args=[R.Any]
             )
             # return the updated cache view
             kv = R.call_packed(

--- a/tests/python/relax/test_transform.py
+++ b/tests/python/relax/test_transform.py
@@ -152,7 +152,7 @@ def test_transform_remove_purity_checking():
             return res
 
         @R.function(pure=False)
-        def impure_func() -> R.Object:
+        def impure_func() -> R.Any:
             y = R.print(format="I am impure!")
             return y
 
@@ -171,7 +171,7 @@ def test_transform_remove_purity_checking():
         @R.function(pure=False)
         def nested_impure_func() -> R.Tensor((), "int32"):
             @R.function(pure=False)
-            def nested() -> R.Object:
+            def nested() -> R.Any:
                 x = R.print(format="Oops!")
                 return x
 
@@ -203,7 +203,7 @@ def test_transform_remove_purity_checking():
             return res
 
         @R.function(pure=False)
-        def impure_func() -> R.Object:
+        def impure_func() -> R.Any:
             y = R.print(format="I am impure!")
             return y
 
@@ -225,7 +225,7 @@ def test_transform_remove_purity_checking():
         @R.function(pure=False)
         def nested_impure_func() -> R.Tensor((), "int32"):
             @R.function(pure=False)
-            def nested() -> R.Object:
+            def nested() -> R.Any:
                 x = R.print(format="Oops!")
                 return x
 
@@ -557,7 +557,7 @@ def test_inplace_mutation_with_non_tensor_argument_raises_error():
         @I.ir_module(s_tir=True)
         class Module:
             @R.function
-            def main(A: R.Object):
+            def main(A: R.Any):
                 gv1 = R.call_tir_inplace(
                     Module.multiply_by_two,
                     [A],

--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -133,18 +133,18 @@ def test_casting():
     @I.ir_module
     class TestCasting:
         @R.function
-        def main(x: R.Tensor) -> R.Object:
+        def main(x: R.Tensor) -> R.Any:
             y = x
-            # z will be treated as object type even though it's a tensor
-            z: R.Object = y
+            # z will be treated as Any even though it's a tensor
+            z: R.Any = y
             return z
 
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor) -> R.Object:
+        def main(x: R.Tensor) -> R.Any:
             # Cannot unify because the cast indicates user intent
-            z: R.Object = x
+            z: R.Any = x
             return z
 
     verify(TestCasting, Expected)

--- a/tests/python/relax/test_transform_cse.py
+++ b/tests/python/relax/test_transform_cse.py
@@ -441,9 +441,7 @@ def test_do_not_eliminate_dtype():
     class Before:
         @R.function(pure=False)
         def foo() -> R.Tensor((32, 64), "int32"):
-            obj: R.Object = R.vm.alloc_storage(
-                R.shape([24576]), runtime_device_index=0, dtype="uint8"
-            )
+            obj: R.Any = R.vm.alloc_storage(R.shape([24576]), runtime_device_index=0, dtype="uint8")
             a: R.Tensor([32, 64], dtype="int32") = R.vm.alloc_tensor(
                 obj, offset=0, shape=R.shape([32, 64]), dtype="int32"
             )

--- a/tests/python/relax/test_transform_fuse_ops.py
+++ b/tests/python/relax/test_transform_fuse_ops.py
@@ -1356,7 +1356,7 @@ def test_shape_expr_arg():
     @I.ir_module(s_tir=True)
     class Before:
         @R.function
-        def main(s: R.Shape(["n"]), kv_cache: R.Object):
+        def main(s: R.Shape(["n"]), kv_cache: R.Any):
             n = T.int64()
             with R.dataflow():
                 lv0 = R.emit_te(topi.full, [n, n], "float32", 0)
@@ -1387,7 +1387,7 @@ def test_shape_expr_arg():
             return gv
 
         @R.function
-        def main(s: R.Shape(["n"]), kv_cache: R.Object):
+        def main(s: R.Shape(["n"]), kv_cache: R.Any):
             cls = Expected
             n = T.int64()
             with R.dataflow():

--- a/tests/python/relax/test_transform_ipc_allreduce_rewrite.py
+++ b/tests/python/relax/test_transform_ipc_allreduce_rewrite.py
@@ -37,7 +37,7 @@ def test_ipc_allreduce_rewrite():
             alloc1: R.Tensor((m, n), dtype="float16") = R.builtin.alloc_tensor(  # type: ignore
                 R.shape([m, n]), R.dtype("float16"), R.prim_value(0), R.str("global")
             )
-            _: R.Object = R.call_packed(
+            _: R.Any = R.call_packed(
                 "runtime.disco.allreduce", lv1, R.shape([0]), R.prim_value(True), alloc1
             )
             return alloc1
@@ -55,7 +55,7 @@ def test_ipc_allreduce_rewrite():
             alloc1: R.Tensor((m, n), dtype="float16") = R.builtin.alloc_tensor(  # type: ignore
                 R.shape([m, n]), R.dtype("float16"), R.prim_value(0), R.str("global")
             )
-            _: R.Object = R.call_packed(
+            _: R.Any = R.call_packed(
                 "runtime.disco.cuda_ipc.custom_allreduce", lv1, R.prim_value(1), alloc1
             )
             return alloc1
@@ -87,7 +87,7 @@ def test_ipc_allreduce_spread_along_reshape():
             alloc1: R.Tensor((m * n,), dtype="float16") = R.builtin.alloc_tensor(  # type: ignore
                 R.shape([m * n]), R.dtype("float16"), R.prim_value(0), R.str("global")
             )
-            _: R.Object = R.call_packed(
+            _: R.Any = R.call_packed(
                 "runtime.disco.allreduce", lv1, R.shape([0]), R.prim_value(False), alloc1
             )
             return alloc1
@@ -109,7 +109,7 @@ def test_ipc_allreduce_spread_along_reshape():
             alloc1: R.Tensor((m * n,), dtype="float16") = R.builtin.alloc_tensor(  # type: ignore
                 R.shape([m * n]), R.dtype("float16"), R.prim_value(0), R.str("global")
             )
-            _: R.Object = R.call_packed(
+            _: R.Any = R.call_packed(
                 "runtime.disco.cuda_ipc.custom_allreduce", lv1, R.prim_value(1), alloc1
             )
             return alloc1
@@ -141,7 +141,7 @@ def test_ipc_allreduce_skip_reducer_other_than_sum():
             alloc1: R.Tensor((m, n), dtype="float16") = R.builtin.alloc_tensor(  # type: ignore
                 R.shape([m, n]), R.dtype("float16"), R.prim_value(0), R.str("global")
             )
-            _: R.Object = R.call_packed(
+            _: R.Any = R.call_packed(
                 "runtime.disco.allreduce", lv1, R.shape([1]), R.prim_value(True), alloc1
             )
             return alloc1

--- a/tests/python/relax/test_transform_lambda_lift.py
+++ b/tests/python/relax/test_transform_lambda_lift.py
@@ -145,7 +145,7 @@ def test_closure():
             return r_1
 
         @R.function(private=True)
-        def main_outer_func(y: R.Tensor((2, 3), "float32")) -> R.Object:
+        def main_outer_func(y: R.Tensor((2, 3), "float32")) -> R.Any:
             inner_func = R.make_closure(Expected.main_inner_func, (y,))
             return inner_func
 

--- a/tests/python/relax/test_transform_lazy_transform_params.py
+++ b/tests/python/relax/test_transform_lazy_transform_params.py
@@ -82,14 +82,14 @@ def test_lazy_transform_params():
         @R.function(pure=False)
         def main_transform_params() -> R.Tuple:
             cls = Expected
-            lv: R.Object = R.call_packed("get_item", R.prim_value(1), ty_args=(R.Object,))
+            lv: R.Any = R.call_packed("get_item", R.prim_value(1), ty_args=(R.Any,))
             gv1: R.Tensor((16, 16, 3, 3), dtype="float32") = R.match_cast(
                 lv, R.Tensor((16, 16, 3, 3), dtype="float32")
             )
             lv_m: R.Tensor((16, 16, 3, 3), dtype="float32") = gv1
-            _: R.Object = R.call_packed("set_item", R.prim_value(0), lv_m, ty_args=(R.Object,))
+            _: R.Any = R.call_packed("set_item", R.prim_value(0), lv_m, ty_args=(R.Any,))
             _1: R.Tuple = R.vm.kill_object(lv_m)
-            lv1: R.Object = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Object,))
+            lv1: R.Any = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Any,))
             gv3: R.Tensor((3, 16, 3, 3), dtype="float32") = R.match_cast(
                 lv1, R.Tensor((3, 16, 3, 3), dtype="float32")
             )
@@ -100,7 +100,7 @@ def test_lazy_transform_params():
                 out_ty=R.Tensor((16, 3, 3, 3), dtype="float32"),
             )
             _2: R.Tuple = R.vm.kill_object(lv1_m)
-            _3: R.Object = R.call_packed("set_item", R.prim_value(1), lv2, ty_args=(R.Object,))
+            _3: R.Any = R.call_packed("set_item", R.prim_value(1), lv2, ty_args=(R.Any,))
             gv: R.Tuple = R.tuple()
             return gv
 
@@ -166,12 +166,12 @@ def test_get_item_only():
             R.Tensor((16, 16, 3, 3), dtype="float32"), R.Tensor((16, 3, 3, 3), dtype="float32")
         ):
             cls = Expected
-            gv: R.Object = R.call_packed("get_item_0", R.prim_value(1), ty_args=(R.Object,))
+            gv: R.Any = R.call_packed("get_item_0", R.prim_value(1), ty_args=(R.Any,))
             gv1: R.Tensor((16, 16, 3, 3), dtype="float32") = R.match_cast(
                 gv, R.Tensor((16, 16, 3, 3), dtype="float32")
             )
             lv: R.Tensor((16, 16, 3, 3), dtype="float32") = gv1
-            gv2: R.Object = R.call_packed("get_item_0", R.prim_value(0), ty_args=(R.Object,))
+            gv2: R.Any = R.call_packed("get_item_0", R.prim_value(0), ty_args=(R.Any,))
             gv3: R.Tensor((3, 16, 3, 3), dtype="float32") = R.match_cast(
                 gv2, R.Tensor((3, 16, 3, 3), dtype="float32")
             )
@@ -245,16 +245,16 @@ def test_extra_get_item_params():
                     out[o, i, h, w] = w1[i, o, h, w]
 
         @R.function(pure=False)
-        def main_transform_params(loader: R.Object) -> R.Tuple:
+        def main_transform_params(loader: R.Any) -> R.Tuple:
             cls = Expected
-            gv: R.Object = R.call_packed("get_item", loader, R.prim_value(1), ty_args=(R.Object,))
+            gv: R.Any = R.call_packed("get_item", loader, R.prim_value(1), ty_args=(R.Any,))
             gv1: R.Tensor((16, 16, 3, 3), dtype="float32") = R.match_cast(
                 gv, R.Tensor((16, 16, 3, 3), dtype="float32")
             )
             lv: R.Tensor((16, 16, 3, 3), dtype="float32") = gv1
-            _: R.Object = R.call_packed("set_item", R.prim_value(0), lv, ty_args=(R.Object,))
+            _: R.Any = R.call_packed("set_item", R.prim_value(0), lv, ty_args=(R.Any,))
             _1: R.Tuple = R.vm.kill_object(lv)
-            gv2: R.Object = R.call_packed("get_item", loader, R.prim_value(0), ty_args=(R.Object,))
+            gv2: R.Any = R.call_packed("get_item", loader, R.prim_value(0), ty_args=(R.Any,))
             gv3: R.Tensor((3, 16, 3, 3), dtype="float32") = R.match_cast(
                 gv2, R.Tensor((3, 16, 3, 3), dtype="float32")
             )
@@ -266,11 +266,11 @@ def test_extra_get_item_params():
             )
             _2: R.Tuple = R.vm.kill_object(lv1)
             lv3: R.Tensor((16, 3, 3, 3), dtype="float32") = R.add(lv2, R.const(1, "float32"))
-            _3: R.Object = R.call_packed("set_item", R.prim_value(1), lv3, ty_args=(R.Object,))
+            _3: R.Any = R.call_packed("set_item", R.prim_value(1), lv3, ty_args=(R.Any,))
             gv_1: R.Tuple = R.tuple()
             return gv_1
 
-    after = LazyTransformParams(extra_get_item_params=[relax.Var("loader", relax.ObjectType())])(
+    after = LazyTransformParams(extra_get_item_params=[relax.Var("loader", relax.AnyType())])(
         Before
     )
     tvm.ir.assert_structural_equal(after, Expected, map_free_vars=True)
@@ -330,18 +330,16 @@ def test_extra_set_item_params():
                     out[o, i, h, w] = w1[i, o, h, w]
 
         @R.function(pure=False)
-        def main_transform_params(setter: R.Object) -> R.Tuple:
+        def main_transform_params(setter: R.Any) -> R.Tuple:
             cls = Expected
-            gv: R.Object = R.call_packed("get_item", R.prim_value(1), ty_args=(R.Object,))
+            gv: R.Any = R.call_packed("get_item", R.prim_value(1), ty_args=(R.Any,))
             gv1: R.Tensor((16, 16, 3, 3), dtype="float32") = R.match_cast(
                 gv, R.Tensor((16, 16, 3, 3), dtype="float32")
             )
             lv: R.Tensor((16, 16, 3, 3), dtype="float32") = gv1
-            _: R.Object = R.call_packed(
-                "set_item", setter, R.prim_value(0), lv, ty_args=(R.Object,)
-            )
+            _: R.Any = R.call_packed("set_item", setter, R.prim_value(0), lv, ty_args=(R.Any,))
             _1: R.Tuple = R.vm.kill_object(lv)
-            gv2: R.Object = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Object,))
+            gv2: R.Any = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Any,))
             gv3: R.Tensor((3, 16, 3, 3), dtype="float32") = R.match_cast(
                 gv2, R.Tensor((3, 16, 3, 3), dtype="float32")
             )
@@ -353,13 +351,11 @@ def test_extra_set_item_params():
             )
             _2: R.Tuple = R.vm.kill_object(lv1)
             lv3: R.Tensor((16, 3, 3, 3), dtype="float32") = R.add(lv2, R.const(1, "float32"))
-            _3: R.Object = R.call_packed(
-                "set_item", setter, R.prim_value(1), lv3, ty_args=(R.Object,)
-            )
+            _3: R.Any = R.call_packed("set_item", setter, R.prim_value(1), lv3, ty_args=(R.Any,))
             gv_1: R.Tuple = R.tuple()
             return gv_1
 
-    after = LazyTransformParams(extra_set_item_params=[relax.Var("setter", relax.ObjectType())])(
+    after = LazyTransformParams(extra_set_item_params=[relax.Var("setter", relax.AnyType())])(
         Before
     )
     tvm.ir.assert_structural_equal(after, Expected, map_free_vars=True)
@@ -382,25 +378,25 @@ def test_extra_set_item_params_with_const_output():
     @I.ir_module(s_tir=True)
     class Expected:
         @R.function(pure=False)
-        def main_transform_params(setter: R.Object) -> R.Tuple:
+        def main_transform_params(setter: R.Any) -> R.Tuple:
             output = R.tuple()
             _ = R.call_packed(
                 "set_item",
                 setter,
                 R.prim_value(0),
                 R.const(np.array([1, 2]).astype("float32")),
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
             _ = R.call_packed(
                 "set_item",
                 setter,
                 R.prim_value(1),
                 R.const(np.array([3, 4]).astype("float32")),
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
             return output
 
-    after = LazyTransformParams(extra_set_item_params=[relax.Var("setter", relax.ObjectType())])(
+    after = LazyTransformParams(extra_set_item_params=[relax.Var("setter", relax.AnyType())])(
         Before
     )
     tvm.ir.assert_structural_equal(after, Expected)
@@ -453,7 +449,7 @@ def test_lazy_transform_params_with_symbolic_vars():
 
             slice_index = T.int64()
 
-            param = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Object,))
+            param = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Any,))
             gv: R.Tensor((16, 16), dtype="float32") = R.match_cast(
                 param, R.Tensor((16, 16), dtype="float32")
             )
@@ -465,7 +461,7 @@ def test_lazy_transform_params_with_symbolic_vars():
                 out_ty=R.Tensor((16,), dtype="float32"),
             )
             unused_1_ = R.vm.kill_object(param_m)
-            unused_2_ = R.call_packed("set_item", R.prim_value(0), transformed, ty_args=(R.Object,))
+            unused_2_ = R.call_packed("set_item", R.prim_value(0), transformed, ty_args=(R.Any,))
 
             output = R.tuple()
             return output
@@ -544,14 +540,14 @@ def test_param_shape_symbolic():
         def main_transform_params() -> R.Tuple:
             ic = T.int64()
             cls = Expected
-            gv: R.Object = R.call_packed("get_item", R.prim_value(1), ty_args=(R.Object,))
+            gv: R.Any = R.call_packed("get_item", R.prim_value(1), ty_args=(R.Any,))
             gv1: R.Tensor((16, 16, 3, 3), dtype="float32") = R.match_cast(
                 gv, R.Tensor((16, 16, 3, 3), dtype="float32")
             )
             lv: R.Tensor((16, 16, 3, 3), dtype="float32") = gv1
-            _: R.Object = R.call_packed("set_item", R.prim_value(0), lv, ty_args=(R.Object,))
+            _: R.Any = R.call_packed("set_item", R.prim_value(0), lv, ty_args=(R.Any,))
             _1: R.Tuple = R.vm.kill_object(lv)
-            gv2: R.Object = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Object,))
+            gv2: R.Any = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Any,))
             gv3: R.Tensor((3, ic, 3, 3), dtype="float32") = R.match_cast(
                 gv2, R.Tensor((3, ic, 3, 3), dtype="float32")
             )
@@ -562,7 +558,7 @@ def test_param_shape_symbolic():
                 out_ty=R.Tensor((ic, 3, 3, 3), dtype="float32"),
             )
             _2: R.Tuple = R.vm.kill_object(lv1)
-            _3: R.Object = R.call_packed("set_item", R.prim_value(1), lv2, ty_args=(R.Object,))
+            _3: R.Any = R.call_packed("set_item", R.prim_value(1), lv2, ty_args=(R.Any,))
             gv4: R.Tuple = R.tuple()
             return gv4
 
@@ -605,14 +601,14 @@ def test_output_with_use_site():
         @R.function(pure=False)
         def main_transform_params() -> R.Tuple:
             cls = Expected
-            x: R.Object = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Object,))
+            x: R.Any = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Any,))
             gv: R.Tensor((), dtype="float32") = R.match_cast(x, R.Tensor((), dtype="float32"))
             x_m: R.Tensor((), dtype="float32") = gv
             y = R.call_tir(cls.copy, (x_m,), out_ty=R.Tensor((), dtype="float32"))
             _: R.Tuple = R.vm.kill_object(x_m)
             z = R.call_tir(cls.copy, (y,), out_ty=R.Tensor((), dtype="float32"))
-            _1: R.Object = R.call_packed("set_item", R.prim_value(0), y, ty_args=(R.Object,))
-            _2: R.Object = R.call_packed("set_item", R.prim_value(1), z, ty_args=(R.Object,))
+            _1: R.Any = R.call_packed("set_item", R.prim_value(0), y, ty_args=(R.Any,))
+            _2: R.Any = R.call_packed("set_item", R.prim_value(1), z, ty_args=(R.Any,))
             gv: R.Tuple = R.tuple()
             return gv
 
@@ -699,26 +695,22 @@ def test_duplicate_outputs():
     class Expected:
         @R.function(pure=False)
         def main_transform_params() -> R.Tuple:
-            gv: R.Object = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Object,))
+            gv: R.Any = R.call_packed("get_item", R.prim_value(0), ty_args=(R.Any,))
             gv1: R.Tensor((16,), dtype="int32") = R.match_cast(gv, R.Tensor((16,), dtype="int32"))
             param0: R.Tensor((16,), dtype="int32") = gv1
 
-            gv2: R.Object = R.call_packed("get_item", R.prim_value(1), ty_args=(R.Object,))
+            gv2: R.Any = R.call_packed("get_item", R.prim_value(1), ty_args=(R.Any,))
             gv3: R.Tensor((16,), dtype="int32") = R.match_cast(gv2, R.Tensor((16,), dtype="int32"))
             param1: R.Tensor((16,), dtype="int32") = gv3
 
             transformed0: R.Tensor((16,), dtype="int32") = R.add(param0, R.const(1, "int32"))
             _: R.Tuple = R.vm.kill_object(param0)
-            _: R.Object = R.call_packed(
-                "set_item", R.prim_value(0), transformed0, ty_args=(R.Object,)
-            )
-            _: R.Object = R.call_packed(
-                "set_item", R.prim_value(2), transformed0, ty_args=(R.Object,)
-            )
+            _: R.Any = R.call_packed("set_item", R.prim_value(0), transformed0, ty_args=(R.Any,))
+            _: R.Any = R.call_packed("set_item", R.prim_value(2), transformed0, ty_args=(R.Any,))
 
             transformed1: R.Tensor((16,), dtype="int32") = R.add(param1, R.const(2, "int32"))
             _ = R.vm.kill_object(param1)
-            _ = R.call_packed("set_item", R.prim_value(1), transformed1, ty_args=(R.Object,))
+            _ = R.call_packed("set_item", R.prim_value(1), transformed1, ty_args=(R.Any,))
             output = R.tuple()
             return output
 
@@ -739,11 +731,11 @@ def test_params_without_tuple():
     class Expected:
         @R.function(pure=False)
         def transform_params():
-            A = R.call_packed("get_item", R.prim_value(0), ty_args=[R.Object])
+            A = R.call_packed("get_item", R.prim_value(0), ty_args=[R.Any])
             A = R.match_cast(A, R.Tensor([16, 16], "float32"))
             C = R.multiply(A, R.const(2, "float32"))
 
-            B = R.call_packed("get_item", R.prim_value(1), ty_args=[R.Object])
+            B = R.call_packed("get_item", R.prim_value(1), ty_args=[R.Any])
             B = R.match_cast(B, R.Tensor([16, 16], "float32"))
             D = R.add(C, B)
             return (D, B)
@@ -781,13 +773,13 @@ def test_retain_before_num_input():
             R.func_attr({"num_input": 1})
             rank = T.int64()
 
-            A = R.call_packed("get_item", R.prim_value(0), ty_args=[R.Object])
+            A = R.call_packed("get_item", R.prim_value(0), ty_args=[R.Any])
             A = R.match_cast(A, R.Tensor([16, 16], "float32"))
             A_sharded = R.strided_slice(
                 A, axes=[0], begin=[rank * 8], end=[(rank + 1) * 8], assume_inbound=True
             )
 
-            B = R.call_packed("get_item", R.prim_value(1), ty_args=[R.Object])
+            B = R.call_packed("get_item", R.prim_value(1), ty_args=[R.Any])
             B = R.match_cast(B, R.Tensor([16, 16], "float32"))
             B_sharded = R.strided_slice(
                 B, axes=[1], begin=[rank * 8], end=[(rank + 1) * 8], assume_inbound=True
@@ -803,15 +795,15 @@ def test_params_without_tuple_with_symbolic_var():
     @I.ir_module(s_tir=True)
     class Before:
         @R.function
-        def transform_params(A: R.Object):
+        def transform_params(A: R.Any):
             return (A,)
 
     @I.ir_module(s_tir=True)
     class Expected:
         @R.function(pure=False)
         def transform_params():
-            A = R.call_packed("get_item", R.prim_value(0), ty_args=[R.Object])
-            A = R.match_cast(A, R.Object)
+            A = R.call_packed("get_item", R.prim_value(0), ty_args=[R.Any])
+            A = R.match_cast(A, R.Any)
 
             return (A,)
 
@@ -831,7 +823,7 @@ def test_get_item_callback():
     @I.ir_module(s_tir=True)
     class Expected:
         @R.function
-        def transform_params(fget_param: R.Callable([R.Prim("int64"), R.Object], R.Object)):
+        def transform_params(fget_param: R.Callable([R.Prim("int64"), R.Any], R.Any)):
             R.func_attr({"num_input": 1})
             A = fget_param(R.prim_value(0), R.str("A"))
             A = R.match_cast(A, R.Tensor([16, 16], "float32"))
@@ -898,7 +890,7 @@ def test_get_item_callback_num_attrs():
         def transform_params(
             rank_arg: R.Prim(value="rank"),
             world_size_arg: R.Prim(value="world_size"),
-            fget_item: R.Callable([R.Prim("int64"), R.Object], R.Object),
+            fget_item: R.Callable([R.Prim("int64"), R.Any], R.Any),
         ):
             R.func_attr({"num_input": 3})
 
@@ -958,7 +950,7 @@ def test_get_item_callback_dynamic_shape():
     class Expected:
         @R.function
         def transform_params(
-            fget_param: R.Callable([R.Prim("int64"), R.Object], R.Object),
+            fget_param: R.Callable([R.Prim("int64"), R.Any], R.Any),
         ) -> R.Tuple(R.Tensor(ndim=2, dtype="float32"), R.Tensor(ndim=2, dtype="float32")):
             R.func_attr({"num_input": 1})
             m = T.int64()
@@ -998,7 +990,7 @@ def test_set_output_callback():
         def transform_params(
             A: R.Tensor([16, 16], "float32"),
             B: R.Tensor([16, 16], "float32"),
-            fset_output: R.Callable([R.Prim("int64"), R.Object], R.Tuple([]), purity=False),
+            fset_output: R.Callable([R.Prim("int64"), R.Any], R.Tuple([]), purity=False),
         ):
             C = R.multiply(A, R.const(2, "float32"))
             fset_output(R.prim_value(1), C)
@@ -1032,7 +1024,7 @@ def test_set_output_callback_of_param():
         def transform_params(
             A: R.Tensor([16, 16], "float32"),
             B: R.Tensor([16, 16], "float32"),
-            fset_output: R.Callable([R.Prim("int64"), R.Object], R.Tuple([]), purity=False),
+            fset_output: R.Callable([R.Prim("int64"), R.Any], R.Tuple([]), purity=False),
         ):
             fset_output(R.prim_value(1), B)
             C = R.multiply(A, R.const(2, "float32"))
@@ -1065,7 +1057,7 @@ def test_set_output_callback_num_input():
         @R.function(pure=False)
         def transform_params(
             A: R.Tensor([16, 16], "float32"),
-            fset_output: R.Callable([R.Prim("int64"), R.Object], R.Tuple([]), purity=False),
+            fset_output: R.Callable([R.Prim("int64"), R.Any], R.Tuple([]), purity=False),
             B: R.Tensor([16, 16], "float32"),
         ):
             R.func_attr({"num_input": 2})
@@ -1101,7 +1093,7 @@ def test_set_output_callback_with_duplicate_output():
         def transform_params(
             A: R.Tensor([16, 16], "float32"),
             B: R.Tensor([16, 16], "float32"),
-            fset_output: R.Callable([R.Prim("int64"), R.Object], R.Tuple([]), purity=False),
+            fset_output: R.Callable([R.Prim("int64"), R.Any], R.Tuple([]), purity=False),
         ):
             C = R.multiply(A, R.const(2, "float32"))
             D = R.add(C, B)
@@ -1136,7 +1128,7 @@ def test_set_output_callback_with_inline_const():
         def transform_params(
             A: R.Tensor([16, 16], "float32"),
             B: R.Tensor([16, 16], "float32"),
-            fset_output: R.Callable([R.Prim("int64"), R.Object], R.Tuple([]), purity=False),
+            fset_output: R.Callable([R.Prim("int64"), R.Any], R.Tuple([]), purity=False),
         ):
             C = R.multiply(A, R.const(2, "float32"))
             fset_output(R.prim_value(0), C)
@@ -1167,7 +1159,7 @@ def test_set_output_callback_with_non_tuple_output():
         def transform_params(
             A: R.Tensor([16, 16], "float32"),
             B: R.Tensor([16, 16], "float32"),
-            fset_output: R.Callable([R.Prim("int64"), R.Object], R.Tuple([]), purity=False),
+            fset_output: R.Callable([R.Prim("int64"), R.Any], R.Tuple([]), purity=False),
         ):
             C = R.multiply(A, R.const(2, "float32"))
             D = R.add(C, B)

--- a/tests/python/relax/test_transform_lower_gpu_ipc_alloc_storage.py
+++ b/tests/python/relax/test_transform_lower_gpu_ipc_alloc_storage.py
@@ -30,7 +30,7 @@ def test_alloc_storage():
         def main(shape: R.Shape(["m", "n"])):  # type: ignore
             m = T.int64()
             n = T.int64()
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([m, n]), R.prim_value(0), R.str("ipc_memory"), R.dtype("float16")
             )
             alloc: R.Tensor((m, n), dtype="float16") = R.memory.alloc_tensor(  # type: ignore
@@ -44,11 +44,11 @@ def test_alloc_storage():
         def main(shape: R.Shape(["m", "n"])):  # type: ignore
             m = T.int64()
             n = T.int64()
-            storage: R.Object = R.call_packed(
+            storage: R.Any = R.call_packed(
                 "runtime.disco.cuda_ipc.alloc_storage",
                 R.shape([m, n]),
                 R.dtype("float16"),
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
             alloc: R.Tensor((m, n), dtype="float16") = R.memory.alloc_tensor(  # type: ignore
                 storage, R.prim_value(0), R.shape([m, n]), R.dtype("float16")
@@ -66,7 +66,7 @@ def test_builtin_alloc_tensor():
         def main(shape: R.Shape(["m", "n"])):  # type: ignore
             m = T.int64()
             n = T.int64()
-            tensor: R.Object = R.builtin.alloc_tensor(
+            tensor: R.Any = R.builtin.alloc_tensor(
                 R.shape([m, n]), R.dtype("float16"), R.prim_value(0), R.str("ipc_memory")
             )
             return tensor
@@ -77,11 +77,11 @@ def test_builtin_alloc_tensor():
         def main(shape: R.Shape(["m", "n"])):  # type: ignore
             m = T.int64()
             n = T.int64()
-            gv: R.Object = R.call_packed(
+            gv: R.Any = R.call_packed(
                 "runtime.disco.cuda_ipc.alloc_storage",
                 R.shape([m, n]),
                 R.dtype("float16"),
-                ty_args=(R.Object,),
+                ty_args=(R.Any,),
             )
             tensor: R.Tensor((m, n), dtype="float16") = R.memory.alloc_tensor(  # type: ignore
                 gv, R.prim_value(0), R.shape([m, n]), R.dtype("float16")

--- a/tests/python/relax/test_transform_rewrite_cuda_graph.py
+++ b/tests/python/relax/test_transform_rewrite_cuda_graph.py
@@ -55,17 +55,17 @@ def test_rewrite_cuda_graph():
             # force_pure is expected because purity checking should be disabled before this pass
             R.func_attr({"relax.force_pure": True})
             cls = Before
-            storage: R.Object = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
+            storage: R.Any = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, 0, R.shape([2, 4]), "float32")
             _1: R.Tuple = cls.exp(x, alloc)
-            storage1: R.Object = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
+            storage1: R.Any = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
             alloc1: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage1, 0, R.shape([2, 4]), "float32")
             _2: R.Tuple = cls.exp(alloc, alloc1)
             _3: R.Tuple = R.memory.kill_tensor(alloc)
             alloc2: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, 0, R.shape([2, 4]), "float32")
             _4: R.Tuple = cls.exp(alloc1, alloc2)
             _5: R.Tuple = R.memory.kill_tensor(alloc1)
-            storage2: R.Object = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
+            storage2: R.Any = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
             alloc3: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage2, 0, R.shape([2, 4]), "float32")
             _6: R.Tuple = cls.exp(alloc2, alloc3)
             _7: R.Tuple = R.memory.kill_tensor(alloc2)
@@ -96,16 +96,16 @@ def test_rewrite_cuda_graph():
                         compute[i0, i1] = T.exp(rxplaceholder[i0, i1], dtype="float32")
 
         @R.function(private=True)
-        def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object, R.Object):
+        def cuda_graph_alloc() -> R.Tuple(R.Any, R.Any, R.Any):
             R.func_attr({"relax.force_pure": True})
-            storage: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
-            storage1: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
-            storage2: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
-            gv: R.Tuple(R.Object, R.Object, R.Object) = (storage, storage1, storage2)
+            storage: R.Any = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage2: R.Any = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            gv: R.Tuple(R.Any, R.Any, R.Any) = (storage, storage1, storage2)
             return gv
 
         @R.function(private=True)
-        def main_cuda_graph_capture(alloc: R.Tensor((2, 4), dtype="float32"), alloc1: R.Tensor((2, 4), dtype="float32"), storage: R.Object, storage2: R.Object) -> R.Tuple(R.Tensor((2, 4), dtype="float32")):
+        def main_cuda_graph_capture(alloc: R.Tensor((2, 4), dtype="float32"), alloc1: R.Tensor((2, 4), dtype="float32"), storage: R.Any, storage2: R.Any) -> R.Tuple(R.Tensor((2, 4), dtype="float32")):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
             _2: R.Tuple = cls.exp(alloc, alloc1)
@@ -124,13 +124,13 @@ def test_rewrite_cuda_graph():
             # this comes after RemovePurityChecking, so we expect purity to be forced
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            gv: R.Tuple(R.Object, R.Object, R.Object) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.get_cached_alloc", (cls.cuda_graph_alloc, R.prim_value(0)), ty_args=(R.Tuple(R.Object, R.Object, R.Object),))
-            storage: R.Object = gv[0]
+            gv: R.Tuple(R.Any, R.Any, R.Any) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.get_cached_alloc", (cls.cuda_graph_alloc, R.prim_value(0)), ty_args=(R.Tuple(R.Any, R.Any, R.Any),))
+            storage: R.Any = gv[0]
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([2, 4]), R.dtype("float32"))
             _1: R.Tuple = cls.exp(x, alloc)
-            storage1: R.Object = gv[1]
+            storage1: R.Any = gv[1]
             alloc1: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([2, 4]), R.dtype("float32"))
-            storage2: R.Object = gv[2]
+            storage2: R.Any = gv[2]
             gv1: R.Tuple(R.Tensor((2, 4), dtype="float32")) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.run_or_capture", (cls.main_cuda_graph_capture, (alloc, alloc1, storage, storage2), R.prim_value(0)), ty_args=(R.Tuple(R.Tensor((2, 4), dtype="float32")),))
             alloc3: R.Tensor((2, 4), dtype="float32") = gv1[0]
             alloc4: R.Tensor((2, 4), dtype="float32") = R.builtin.alloc_tensor(R.shape([2, 4]), R.dtype("float32"), R.prim_value(0))
@@ -170,10 +170,10 @@ def test_tuple():
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((2, 4), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Before
-            storage: R.Object = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
+            storage: R.Any = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, 0, R.shape([2, 4]), "float32")
             _: R.Tuple = cls.exp(x, alloc)
-            storage1: R.Object = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
+            storage1: R.Any = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
             alloc1: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage1, 0, R.shape([2, 4]), "float32")
             _: R.Tuple = cls.exp(alloc, alloc1)
             lv0 = (alloc1,)
@@ -207,15 +207,15 @@ def test_tuple():
                         compute[i0, i1] = T.exp(rxplaceholder[i0, i1])
 
         @R.function(private=True)
-        def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object):
+        def cuda_graph_alloc() -> R.Tuple(R.Any, R.Any):
             R.func_attr({"relax.force_pure": True})
-            storage: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
-            storage1: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
-            gv: R.Tuple(R.Object, R.Object) = (storage, storage1)
+            storage: R.Any = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            gv: R.Tuple(R.Any, R.Any) = (storage, storage1)
             return gv
 
         @R.function(private=True)
-        def main_cuda_graph_capture(alloc: R.Tensor((2, 4), dtype="float32"), alloc1: R.Tensor((2, 4), dtype="float32"), storage: R.Object) -> R.Tuple(R.Tensor((2, 4), dtype="float32")):
+        def main_cuda_graph_capture(alloc: R.Tensor((2, 4), dtype="float32"), alloc1: R.Tensor((2, 4), dtype="float32"), storage: R.Any) -> R.Tuple(R.Tensor((2, 4), dtype="float32")):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
             _: R.Tuple = cls.exp(alloc, alloc1)
@@ -234,11 +234,11 @@ def test_tuple():
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((2, 4), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            gv: R.Tuple(R.Object, R.Object) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.get_cached_alloc", (cls.cuda_graph_alloc, R.prim_value(0)), ty_args=(R.Tuple(R.Object, R.Object),))
-            storage: R.Object = gv[0]
+            gv: R.Tuple(R.Any, R.Any) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.get_cached_alloc", (cls.cuda_graph_alloc, R.prim_value(0)), ty_args=(R.Tuple(R.Any, R.Any),))
+            storage: R.Any = gv[0]
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([2, 4]), R.dtype("float32"))
             _: R.Tuple = cls.exp(x, alloc)
-            storage1: R.Object = gv[1]
+            storage1: R.Any = gv[1]
             alloc1: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([2, 4]), R.dtype("float32"))
             gv1: R.Tuple(R.Tensor((2, 4), dtype="float32")) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.run_or_capture", (cls.main_cuda_graph_capture, (alloc, alloc1, storage), R.prim_value(0)), ty_args=(R.Tuple(R.Tensor((2, 4), dtype="float32")),))
             alloc2: R.Tensor((2, 4), dtype="float32") = gv1[0]
@@ -275,10 +275,10 @@ def test_vm_builtin():
             # force_pure is expected because purity checking should be disabled before this pass
             R.func_attr({"relax.force_pure": True})
             cls = Before
-            storage: R.Object = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
+            storage: R.Any = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, 0, R.shape([2, 4]), "float32")
             _1: R.Tuple = cls.exp(x, alloc)
-            storage1: R.Object = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
+            storage1: R.Any = R.memory.alloc_storage(R.shape([32]), 0, "global", "float32")
             alloc1: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage1, 0, R.shape([2, 4]), "float32")
             _2: R.Tuple = cls.exp(alloc, alloc1)
             _3: R.Tuple = R.memory.kill_tensor(alloc)
@@ -308,15 +308,15 @@ def test_vm_builtin():
                         compute[i0, i1] = T.exp(rxplaceholder[i0, i1])
 
         @R.function(private=True)
-        def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object):
+        def cuda_graph_alloc() -> R.Tuple(R.Any, R.Any):
             R.func_attr({"relax.force_pure": True})
-            storage: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
-            storage1: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
-            gv: R.Tuple(R.Object, R.Object) = (storage, storage1)
+            storage: R.Any = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            gv: R.Tuple(R.Any, R.Any) = (storage, storage1)
             return gv
 
         @R.function(private=True)
-        def main_cuda_graph_capture(alloc: R.Tensor((2, 4), dtype="float32"), alloc1: R.Tensor((2, 4), dtype="float32"), storage: R.Object) -> R.Tuple(R.Tensor((2, 4), dtype="float32"), R.Tensor((2, 4), dtype="float32")):
+        def main_cuda_graph_capture(alloc: R.Tensor((2, 4), dtype="float32"), alloc1: R.Tensor((2, 4), dtype="float32"), storage: R.Any) -> R.Tuple(R.Tensor((2, 4), dtype="float32"), R.Tensor((2, 4), dtype="float32")):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
             _2: R.Tuple = cls.exp(alloc, alloc1)
@@ -330,11 +330,11 @@ def test_vm_builtin():
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((2,4), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            gv: R.Tuple(R.Object, R.Object) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.get_cached_alloc", (cls.cuda_graph_alloc, R.prim_value(0)), ty_args=(R.Tuple(R.Object, R.Object),))
-            storage: R.Object = gv[0]
+            gv: R.Tuple(R.Any, R.Any) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.get_cached_alloc", (cls.cuda_graph_alloc, R.prim_value(0)), ty_args=(R.Tuple(R.Any, R.Any),))
+            storage: R.Any = gv[0]
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([2, 4]), R.dtype("float32"))
             _1: R.Tuple = cls.exp(x, alloc)
-            storage1: R.Object = gv[1]
+            storage1: R.Any = gv[1]
             alloc1: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([2, 4]), R.dtype("float32"))
             gv1: R.Tuple(R.Tensor((2, 4), dtype="float32"), R.Tensor((2, 4), dtype="float32")) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.run_or_capture", (cls.main_cuda_graph_capture, (alloc, alloc1, storage), R.prim_value(0)), ty_args=(R.Tuple(R.Tensor((2, 4), dtype="float32"), R.Tensor((2, 4), dtype="float32")),))
             alloc2: R.Tensor((2, 4), dtype="float32") = gv1[1]
@@ -514,15 +514,15 @@ def test_capture_fixed_inputs():
                     )
 
         @R.function(private=True)
-        def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object):
+        def cuda_graph_alloc() -> R.Tuple(R.Any, R.Any):
             R.func_attr({"relax.force_pure": True})
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([524288]), R.prim_value(0), R.str("global"), R.dtype("float16")
             )
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([524288]), R.prim_value(0), R.str("global"), R.dtype("float16")
             )
-            gv: R.Tuple(R.Object, R.Object) = storage, storage1
+            gv: R.Tuple(R.Any, R.Any) = storage, storage1
             return gv
 
         @R.function(private=True)
@@ -538,7 +538,7 @@ def test_capture_fixed_inputs():
                 R.Tensor((16,), dtype="float16"),
                 R.Tensor((16,), dtype="float16"),
             ),
-            storage: R.Object,
+            storage: R.Any,
         ) -> R.Tuple(
             R.Tensor((16, 32, 32, 16), dtype="float16"),
             R.Tensor((16, 3, 3, 16), dtype="float16"),
@@ -610,19 +610,19 @@ def test_capture_fixed_inputs():
             R.func_attr({"num_input": 1, "relax.force_pure": True})
             cls = Expected
             lv: R.Tensor((16, 3, 3, 16), dtype="float16") = params[0]
-            gv: R.Tuple(R.Object, R.Object) = R.call_builtin_with_ctx(
+            gv: R.Tuple(R.Any, R.Any) = R.call_builtin_with_ctx(
                 "vm.builtin.cuda_graph.get_cached_alloc",
                 (cls.cuda_graph_alloc, R.prim_value(0)),
-                ty_args=(R.Tuple(R.Object, R.Object),),
+                ty_args=(R.Tuple(R.Any, R.Any),),
             )
-            storage: R.Object = gv[0]
+            storage: R.Any = gv[0]
             alloc: R.Tensor((16, 32, 32, 16), dtype="float16") = R.memory.alloc_tensor(
                 storage, R.prim_value(0), R.shape([16, 32, 32, 16]), R.dtype("float16")
             )
             _: R.Tuple = cls.fused_conv2d_relu(data, lv, alloc)
             lv_1: R.Tensor((16, 32, 32, 16), dtype="float16") = alloc
             lv1: R.Tensor((16, 3, 3, 16), dtype="float16") = params[1]
-            storage1: R.Object = gv[1]
+            storage1: R.Any = gv[1]
             alloc1: R.Tensor((16, 32, 32, 16), dtype="float16") = R.memory.alloc_tensor(
                 storage1, R.prim_value(0), R.shape([16, 32, 32, 16]), R.dtype("float16")
             )
@@ -678,10 +678,10 @@ def test_null_value():
     @I.ir_module(s_tir=True)
     class Before:
         @R.function
-        def main() -> R.Tuple(R.Object):
-            _io: R.Object = R.null_value()
-            lv: R.Tuple(R.Object) = (_io,)
-            gv: R.Tuple(R.Object) = lv
+        def main() -> R.Tuple(R.Any):
+            _io: R.Any = R.null_value()
+            lv: R.Tuple(R.Any) = (_io,)
+            gv: R.Tuple(R.Any) = lv
             return gv
 
     Expected = Before
@@ -721,30 +721,30 @@ def test_static_args():
     @I.ir_module(s_tir=True)
     class Expected:
         @R.function(private=True)
-        def cuda_graph_alloc() -> R.Tuple(R.Object):
+        def cuda_graph_alloc() -> R.Tuple(R.Any):
             R.func_attr({"relax.force_pure": True})
-            storage0: R.Object = R.memory.alloc_storage(
+            storage0: R.Any = R.memory.alloc_storage(
                 R.shape([8]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
-            gv: R.Tuple(R.Object) = (storage0,)
+            gv: R.Tuple(R.Any) = (storage0,)
             return gv
 
         @R.function(private=True)
         def main_cuda_graph_capture(alloc0: R.Tensor((8,), dtype="float32")) -> R.Tuple:
             R.func_attr({"relax.force_pure": True})
-            _: R.Object = R.call_packed("dummy_func", alloc0, R.dtype("float32"), R.str("string"))
+            _: R.Any = R.call_packed("dummy_func", alloc0, R.dtype("float32"), R.str("string"))
             gv: R.Tuple = R.tuple()
             return gv
 
         @R.function(pure=False)
         def main() -> R.Tuple:
             cls = Expected
-            gv: R.Tuple(R.Object) = R.call_builtin_with_ctx(
+            gv: R.Tuple(R.Any) = R.call_builtin_with_ctx(
                 "vm.builtin.cuda_graph.get_cached_alloc",
                 (cls.cuda_graph_alloc, R.prim_value(0)),
-                ty_args=(R.Tuple(R.Object),),
+                ty_args=(R.Tuple(R.Any),),
             )
-            storage0: R.Object = gv[0]
+            storage0: R.Any = gv[0]
             alloc0: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(
                 storage0, R.prim_value(0), R.shape([8]), R.dtype("float32")
             )
@@ -780,14 +780,14 @@ def test_dynamic_capture():
                 {"relax.rewrite_cuda_graph.capture_symbolic_vars": ["m"], "relax.force_pure": True}
             )
             m = T.int64()
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([16]), 0, "global", "float32"
             )  # assume m is upper-bounded
             alloc1: R.Tensor((m,), "float32") = R.memory.alloc_tensor(
                 storage, 0, R.shape([m]), "float32"
             )
             _ = Before.add_one(x, alloc1)
-            storage1: R.Object = R.memory.alloc_storage(R.shape([16]), 0, "global", "float32")
+            storage1: R.Any = R.memory.alloc_storage(R.shape([16]), 0, "global", "float32")
             alloc2: R.Tensor((m,), "float32") = R.memory.alloc_tensor(
                 storage1, 0, R.shape([m]), "float32"
             )
@@ -814,15 +814,15 @@ def test_dynamic_capture():
                     y[vi] = x[vi] + T.float32(1)
 
         @R.function(private=True)
-        def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object):
+        def cuda_graph_alloc() -> R.Tuple(R.Any, R.Any):
             R.func_attr({"relax.force_pure": True})
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([16]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([16]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
-            gv: R.Tuple(R.Object, R.Object) = storage, storage1
+            gv: R.Tuple(R.Any, R.Any) = storage, storage1
             return gv
 
         @R.function(private=True)
@@ -845,17 +845,17 @@ def test_dynamic_capture():
                 {"relax.force_pure": True, "relax.rewrite_cuda_graph.capture_symbolic_vars": ["m"]}
             )
             cls = Expected
-            gv: R.Tuple(R.Object, R.Object) = R.call_builtin_with_ctx(
+            gv: R.Tuple(R.Any, R.Any) = R.call_builtin_with_ctx(
                 "vm.builtin.cuda_graph.get_cached_alloc",
                 (cls.cuda_graph_alloc, R.prim_value(0)),
-                ty_args=(R.Tuple(R.Object, R.Object),),
+                ty_args=(R.Tuple(R.Any, R.Any),),
             )
-            storage: R.Object = gv[0]
+            storage: R.Any = gv[0]
             alloc1: R.Tensor((m,), dtype="float32") = R.memory.alloc_tensor(
                 storage, R.prim_value(0), R.shape([m]), R.dtype("float32")
             )
             cls.add_one(x, alloc1)
-            storage1: R.Object = gv[1]
+            storage1: R.Any = gv[1]
             alloc2: R.Tensor((m,), dtype="float32") = R.memory.alloc_tensor(
                 storage1, R.prim_value(0), R.shape([m]), R.dtype("float32")
             )
@@ -911,21 +911,21 @@ def test_merge_alloc_funcs():
     @I.ir_module(s_tir=True)
     class Expected:
         @R.function(private=True)
-        def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object, R.Object, R.Object):
+        def cuda_graph_alloc() -> R.Tuple(R.Any, R.Any, R.Any, R.Any):
             R.func_attr({"relax.force_pure": True})
-            storage4: R.Object = R.memory.alloc_storage(
+            storage4: R.Any = R.memory.alloc_storage(
                 R.shape([512]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([192]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
-            storage2: R.Object = R.memory.alloc_storage(
+            storage2: R.Any = R.memory.alloc_storage(
                 R.shape([64]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
-            storage3: R.Object = R.memory.alloc_storage(
+            storage3: R.Any = R.memory.alloc_storage(
                 R.shape([1024]), R.prim_value(0), R.str("ipc_memory"), R.dtype("float32")
             )
-            gv: R.Tuple(R.Object, R.Object, R.Object, R.Object) = (
+            gv: R.Tuple(R.Any, R.Any, R.Any, R.Any) = (
                 storage4,
                 storage1,
                 storage2,
@@ -937,14 +937,14 @@ def test_merge_alloc_funcs():
         def func1() -> R.Tuple:
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            gv: R.Tuple(R.Object, R.Object, R.Object, R.Object) = R.call_builtin_with_ctx(
+            gv: R.Tuple(R.Any, R.Any, R.Any, R.Any) = R.call_builtin_with_ctx(
                 "vm.builtin.cuda_graph.get_cached_alloc",
                 (cls.cuda_graph_alloc, R.prim_value(0)),
-                ty_args=(R.Tuple(R.Object, R.Object, R.Object, R.Object),),
+                ty_args=(R.Tuple(R.Any, R.Any, R.Any, R.Any),),
             )
-            storage1: R.Object = gv[1]
-            storage2: R.Object = gv[0]
-            storage3: R.Object = gv[3]
+            storage1: R.Any = gv[1]
+            storage2: R.Any = gv[0]
+            storage3: R.Any = gv[3]
             alloc1: R.Tensor((128,), dtype="float32") = R.memory.alloc_tensor(
                 storage1, R.prim_value(0), R.shape([128]), R.dtype("float32")
             )
@@ -976,15 +976,15 @@ def test_merge_alloc_funcs():
         def func2() -> R.Tuple:
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            gv2: R.Tuple(R.Object, R.Object, R.Object, R.Object) = R.call_builtin_with_ctx(
+            gv2: R.Tuple(R.Any, R.Any, R.Any, R.Any) = R.call_builtin_with_ctx(
                 "vm.builtin.cuda_graph.get_cached_alloc",
                 (cls.cuda_graph_alloc, R.prim_value(0)),
-                ty_args=(R.Tuple(R.Object, R.Object, R.Object, R.Object),),
+                ty_args=(R.Tuple(R.Any, R.Any, R.Any, R.Any),),
             )
-            storage11: R.Object = gv2[1]
-            storage21: R.Object = gv2[2]
-            storage31: R.Object = gv2[3]
-            storage4: R.Object = gv2[0]
+            storage11: R.Any = gv2[1]
+            storage21: R.Any = gv2[2]
+            storage31: R.Any = gv2[3]
+            storage4: R.Any = gv2[0]
             alloc1: R.Tensor((192,), dtype="float32") = R.memory.alloc_tensor(
                 storage11, R.prim_value(0), R.shape([192]), R.dtype("float32")
             )
@@ -1041,15 +1041,15 @@ def test_disable_capture_output():
     @I.ir_module(s_tir=True)
     class Expected:
         @R.function(private=True)
-        def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object):
+        def cuda_graph_alloc() -> R.Tuple(R.Any, R.Any):
             R.func_attr({"relax.force_pure": True})
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([8]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
-            storage2: R.Object = R.memory.alloc_storage(
+            storage2: R.Any = R.memory.alloc_storage(
                 R.shape([8]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
-            gv: R.Tuple(R.Object, R.Object) = storage1, storage2
+            gv: R.Tuple(R.Any, R.Any) = storage1, storage2
             return gv
 
         @R.function(private=True)
@@ -1065,17 +1065,17 @@ def test_disable_capture_output():
         def main(x: R.Tensor((8,), dtype="float32")) -> R.Tuple(R.Tensor((8,), dtype="float32")):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            gv: R.Tuple(R.Object, R.Object) = R.call_builtin_with_ctx(
+            gv: R.Tuple(R.Any, R.Any) = R.call_builtin_with_ctx(
                 "vm.builtin.cuda_graph.get_cached_alloc",
                 (cls.cuda_graph_alloc, R.prim_value(0)),
-                ty_args=(R.Tuple(R.Object, R.Object),),
+                ty_args=(R.Tuple(R.Any, R.Any),),
             )
-            storage1: R.Object = gv[0]
+            storage1: R.Any = gv[0]
             alloc1: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(
                 storage1, R.prim_value(0), R.shape([8]), R.dtype("float32")
             )
             R.call_packed("dummy", x, alloc1, ty_args=(R.Tuple,))
-            storage2: R.Object = gv[1]
+            storage2: R.Any = gv[1]
             alloc2: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(
                 storage2, R.prim_value(0), R.shape([8]), R.dtype("float32")
             )
@@ -1084,7 +1084,7 @@ def test_disable_capture_output():
                 (cls.main_cuda_graph_capture, (alloc1, alloc2), R.prim_value(0)),
                 ty_args=(R.Tuple,),
             )
-            storage3: R.Object = R.memory.alloc_storage(
+            storage3: R.Any = R.memory.alloc_storage(
                 R.shape([8]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
             alloc3: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(
@@ -1120,15 +1120,15 @@ def test_static_input_with_symbolic_shape():
     @I.ir_module(s_tir=True)
     class Expected:
         @R.function(private=True)
-        def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object):
+        def cuda_graph_alloc() -> R.Tuple(R.Any, R.Any):
             R.func_attr({"relax.force_pure": True})
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([8]), R.prim_value(0), R.str("global"), R.dtype("float16")
             )
-            storage2: R.Object = R.memory.alloc_storage(
+            storage2: R.Any = R.memory.alloc_storage(
                 R.shape([8]), R.prim_value(0), R.str("global"), R.dtype("float16")
             )
-            gv: R.Tuple(R.Object, R.Object) = storage1, storage2
+            gv: R.Tuple(R.Any, R.Any) = storage1, storage2
             return gv
 
         @R.function(private=True)
@@ -1151,17 +1151,17 @@ def test_static_input_with_symbolic_shape():
             m = T.int64()
             R.func_attr({"num_input": 1, "relax.force_pure": True})
             cls = Expected
-            gv: R.Tuple(R.Object, R.Object) = R.call_builtin_with_ctx(
+            gv: R.Tuple(R.Any, R.Any) = R.call_builtin_with_ctx(
                 "vm.builtin.cuda_graph.get_cached_alloc",
                 (cls.cuda_graph_alloc, R.prim_value(0)),
-                ty_args=(R.Tuple(R.Object, R.Object),),
+                ty_args=(R.Tuple(R.Any, R.Any),),
             )
-            storage1: R.Object = gv[0]
+            storage1: R.Any = gv[0]
             alloc1: R.Tensor((8,), dtype="float16") = R.memory.alloc_tensor(
                 storage1, R.prim_value(0), R.shape([8]), R.dtype("float16")
             )
             R.call_packed("dummy", x, w, alloc1, ty_args=(R.Tuple,))
-            storage2: R.Object = gv[1]
+            storage2: R.Any = gv[1]
             alloc2: R.Tensor((8,), dtype="float16") = R.memory.alloc_tensor(
                 storage2, R.prim_value(0), R.shape([8]), R.dtype("float16")
             )
@@ -1175,7 +1175,7 @@ def test_static_input_with_symbolic_shape():
                 ),
                 ty_args=(R.Tuple,),
             )
-            storage3: R.Object = R.memory.alloc_storage(
+            storage3: R.Any = R.memory.alloc_storage(
                 R.shape([8]), R.prim_value(0), R.str("global"), R.dtype("float16")
             )
             alloc3: R.Tensor((8,), dtype="float16") = R.memory.alloc_tensor(

--- a/tests/python/relax/test_transform_static_plan_block_memory.py
+++ b/tests/python/relax/test_transform_static_plan_block_memory.py
@@ -107,12 +107,12 @@ def test_basic():
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(R.shape([32]), virtual_device_index=0, storage_scope="global", dtype="float32")
+            storage: R.Any = R.memory.alloc_storage(R.shape([32]), virtual_device_index=0, storage_scope="global", dtype="float32")
             alloc: R.Tensor((2, 4), dtype="float32") = R.memory.alloc_tensor(storage, 0, R.shape([2, 4]), dtype="float32")
             _ = cls.exp(x, alloc)
             lv: R.Tensor((2, 4), dtype="float32") = alloc
             lv1: R.Tensor((8,), dtype="float32") = R.reshape(lv, (8,))
-            storage1: R.Object = R.memory.alloc_storage(R.shape([40]), virtual_device_index=0, storage_scope="global", dtype="float32")
+            storage1: R.Any = R.memory.alloc_storage(R.shape([40]), virtual_device_index=0, storage_scope="global", dtype="float32")
             alloc1: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(storage1, 0, R.shape([8]), dtype="float32")
             _ = cls.relu(lv1, alloc1)
             lv2: R.Tensor((8,), dtype="float32") = alloc1
@@ -157,12 +157,12 @@ def test_basic():
         def main(x: R.Tensor((2, 4), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = ExpectedLowered
-            storage: R.Object = R.vm.alloc_storage(R.shape([32]), R.prim_value(0), R.dtype("uint8"))
+            storage: R.Any = R.vm.alloc_storage(R.shape([32]), R.prim_value(0), R.dtype("uint8"))
             alloc: R.Tensor((2, 4), dtype="float32") = R.vm.alloc_tensor(storage, R.prim_value(0), R.shape([2, 4]), R.dtype("float32"))
             _: R.Tuple = cls.exp(x, alloc)
             lv1: R.Tensor((8,), dtype="float32") = R.call_packed("vm.builtin.reshape", alloc, R.shape([8]), ty_args=(R.Tensor((8,), dtype="float32"),))
             _ = R.vm.kill_object(alloc)
-            storage1: R.Object = R.vm.alloc_storage(R.shape([40]), R.prim_value(0), R.dtype("uint8"))
+            storage1: R.Any = R.vm.alloc_storage(R.shape([40]), R.prim_value(0), R.dtype("uint8"))
             alloc1: R.Tensor((8,), dtype="float32") = R.vm.alloc_tensor(storage1, R.prim_value(0), R.shape([8]), R.dtype("float32"))
             _ = cls.relu(lv1, alloc1)
             _ = R.vm.kill_object(lv1)
@@ -174,7 +174,7 @@ def test_basic():
             _ = R.vm.kill_object(storage1)
             _ = cls.pad(alloc2, alloc3)
             _ = R.vm.kill_object(alloc2)
-            storage2: R.Object = R.vm.alloc_storage(R.shape([40]), R.prim_value(0), R.dtype("uint8"))
+            storage2: R.Any = R.vm.alloc_storage(R.shape([40]), R.prim_value(0), R.dtype("uint8"))
             alloc4: R.Tensor((10,), dtype="float32") = R.vm.alloc_tensor(storage2, R.prim_value(0), R.shape([10]), R.dtype("float32"))
             _ = R.vm.kill_object(storage2)
             _ = cls.log(alloc3, alloc4)
@@ -251,7 +251,7 @@ def test_different_dtype():
         ) -> R.Tensor((2, 3), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
@@ -259,7 +259,7 @@ def test_different_dtype():
             )
             _: R.Tuple() = cls.add(x, x, alloc)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="int32"
             )
             alloc1: R.Tensor((2, 3), dtype="int32") = R.memory.alloc_tensor(
@@ -309,7 +309,7 @@ def test_dtype_bool():
         def main(y: R.Tensor((2, 3), dtype="bool")) -> R.Tensor((2, 3), dtype="bool"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([6]), virtual_device_index=0, storage_scope="global", dtype="bool"
             )
             alloc: R.Tensor((2, 3), dtype="bool") = R.memory.alloc_tensor(
@@ -368,7 +368,7 @@ def test_same_dtype():
         ) -> R.Tensor((2, 3), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
@@ -558,7 +558,7 @@ def test_nested_tuple():
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
@@ -566,7 +566,7 @@ def test_nested_tuple():
             )
             _: R.Tuple() = cls.exp(x, alloc)
             y1: R.Tensor((2, 3), dtype="float32") = alloc
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc1: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
@@ -574,7 +574,7 @@ def test_nested_tuple():
             )
             _1: R.Tuple() = cls.exp(x, alloc1)
             y2: R.Tensor((2, 3), dtype="float32") = alloc1
-            storage2: R.Object = R.memory.alloc_storage(
+            storage2: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc2: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
@@ -596,7 +596,7 @@ def test_nested_tuple():
             y1_: R.Tensor((2, 3), dtype="float32") = nt0[0]
             y2_: R.Tensor((2, 3), dtype="float32") = nt0[1]
             y3_: R.Tensor((2, 3), dtype="float32") = nt[1]
-            storage3: R.Object = R.memory.alloc_storage(
+            storage3: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc3: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
@@ -660,7 +660,7 @@ def test_call_packed_external_func():
     class Expected:
         @R.function(pure=False)
         def main(x: R.Tensor((2, 3), dtype="float32")) -> R.Tensor((2, 3), dtype="float32"):
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([24]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
@@ -718,7 +718,7 @@ def test_symbolic_shape():
             n = T.int64()
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([4 * (m * n)]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
             alloc: R.Tensor((m, n), dtype="float32") = R.memory.alloc_tensor(
@@ -748,7 +748,7 @@ def test_zero_reference():
         @R.function
         def main(x: R.Tensor((2, 3), "float32")):
             R.func_attr({"relax.force_pure": True})
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
@@ -869,7 +869,7 @@ def test_multiple_functions():
         ) -> R.Tensor((2, 3), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
@@ -877,7 +877,7 @@ def test_multiple_functions():
             )
             _: R.Tuple() = cls.add(x, x, alloc)
             gv1: R.Tensor((2, 3), dtype="float32") = alloc
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="int32"
             )
             alloc1: R.Tensor((2, 3), dtype="int32") = R.memory.alloc_tensor(
@@ -893,7 +893,7 @@ def test_multiple_functions():
         ) -> R.Tensor((2, 3), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([24]), virtual_device_index=0, storage_scope="global", dtype="float32"
             )
             alloc: R.Tensor((2, 3), dtype="float32") = R.memory.alloc_tensor(
@@ -994,12 +994,12 @@ def test_tir_var_upper_bound():
             n = T.int64()
             R.func_attr({"tir_var_upper_bound": {"n": 4}, "relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage: R.Any = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc: R.Tensor((2, n), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([2, n]), R.dtype("float32"))
             _: R.Tuple = cls.exp(x, alloc)
             lv: R.Tensor((2, n), dtype="float32") = alloc
             lv1: R.Tensor((2 * n,), dtype="float32") = R.reshape(lv, R.shape([2 * n]))
-            storage1: R.Object = R.memory.alloc_storage(R.shape([40]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([40]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc1: R.Tensor((2 * n,), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([2 * n]), R.dtype("float32"))
             _1: R.Tuple = cls.relu(lv1, alloc1)
             lv2: R.Tensor((2 * n,), dtype="float32") = alloc1
@@ -1101,19 +1101,19 @@ def test_lower_bound_only():
             n = T.int64()
             R.func_attr({"tir_var_lower_bound": {"n": 2}, "relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(R.shape([8 * n]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage: R.Any = R.memory.alloc_storage(R.shape([8 * n]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc: R.Tensor((2, n), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([2, n]), R.dtype("float32"), R.prim_value(0))
             _: R.Tuple = cls.exp(x, alloc)
             lv: R.Tensor((2, n), dtype="float32") = alloc
             lv1: R.Tensor((2 * n,), dtype="float32") = R.reshape(lv, R.shape([2 * n]))
-            storage1: R.Object = R.memory.alloc_storage(R.shape([4 * (2 * n)]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([4 * (2 * n)]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc1: R.Tensor((2 * n,), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([2 * n]), R.dtype("float32"))
             _1: R.Tuple = cls.relu(lv1, alloc1)
             lv2: R.Tensor((2 * n,), dtype="float32") = alloc1
             alloc2: R.Tensor((2 * n,), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([2 * n]), R.dtype("float32"))
             _2: R.Tuple = cls.add(lv2, R.const(1, "float32"), alloc2)
             lv3: R.Tensor((2 * n,), dtype="float32") = alloc2
-            storage2: R.Object = R.memory.alloc_storage(R.shape([4 * (2 * n + 2)]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage2: R.Any = R.memory.alloc_storage(R.shape([4 * (2 * n + 2)]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc3: R.Tensor((2 * n + 2,), dtype="float32") = R.memory.alloc_tensor(storage2, R.prim_value(0), R.shape([2 * n + 2]), R.dtype("float32"), R.prim_value(0))
             _3: R.Tuple = cls.pad(lv3, alloc3)
             lv4: R.Tensor((2 * n + 2,), dtype="float32") = alloc3
@@ -1209,12 +1209,12 @@ def test_upper_and_lower_bounds():
             n = T.int64()
             R.func_attr({"tir_var_upper_bound": {"n": 4}, "tir_var_lower_bound": {"n": 2}, "relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage: R.Any = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc: R.Tensor((2, n), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([2, n]), R.dtype("float32"))
             _: R.Tuple = cls.exp(x, alloc)
             lv: R.Tensor((2, n), dtype="float32") = alloc
             lv1: R.Tensor((2 * n,), dtype="float32") = R.reshape(lv, R.shape([2 * n]))
-            storage1: R.Object = R.memory.alloc_storage(R.shape([40]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([40]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc1: R.Tensor((2 * n,), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([2 * n]), R.dtype("float32"))
             _1: R.Tuple = cls.relu(lv1, alloc1)
             lv2: R.Tensor((2 * n,), dtype="float32") = alloc1
@@ -1295,11 +1295,11 @@ def test_tir_var_decreasing_monotone():
             m = T.int64()
             R.func_attr({"tir_var_upper_bound": {"m": 5, "n": 20}, "relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(R.shape([8000]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage: R.Any = R.memory.alloc_storage(R.shape([8000]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([n, m, T.max(n - m, 1)]), R.dtype("float32"))
             _: R.Tuple = cls.tir_exp(x, alloc)
             y: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = alloc
-            storage1: R.Object = R.memory.alloc_storage(R.shape([8000]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([8000]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc1: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([n, m, T.max(n - m, 1)]), R.dtype("float32"))
             _1: R.Tuple = cls.tir_exp(y, alloc1)
             z: R.Tensor((n, m, T.max(n - m, 1)), dtype="float32") = alloc1
@@ -1356,11 +1356,11 @@ def test_call_tir_dyn():
             n = T.int64()
             R.func_attr({"tir_var_upper_bound": {"n": 20}, "relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(R.shape([80]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage: R.Any = R.memory.alloc_storage(R.shape([80]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc: R.Tensor((n,), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([n]), R.dtype("float32"))
             _: R.Tuple = R.vm.call_tir_dyn(cls.tir_full, (alloc, R.shape([n])))
             full: R.Tensor((n,), dtype="float32") = alloc
-            storage1: R.Object = R.memory.alloc_storage(R.shape([80]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([80]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc1: R.Tensor((n,), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([n]), R.dtype("float32"))
             _1: R.Tuple = cls.tir_exp(full, alloc1)
             lv2: R.Tensor((n,), dtype="float32") = alloc1
@@ -1417,15 +1417,15 @@ def test_call_tir_dyn_plan_dynamic_func_output():
             n = T.int64()
             R.func_attr({"tir_var_upper_bound": {"n": 20}, "relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(R.shape([80]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage: R.Any = R.memory.alloc_storage(R.shape([80]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc: R.Tensor((n,), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([n]), R.dtype("float32"))
             _: R.Tuple = R.vm.call_tir_dyn(cls.tir_full, (alloc, R.shape([n])))
             full: R.Tensor((n,), dtype="float32") = alloc
-            storage1: R.Object = R.memory.alloc_storage(R.shape([80]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([80]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc1: R.Tensor((n,), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([n]), R.dtype("float32"))
             _1: R.Tuple = cls.tir_exp(full, alloc1)
             lv2: R.Tensor((n,), dtype="float32") = alloc1
-            storage2: R.Object = R.memory.alloc_storage(R.shape([80]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage2: R.Any = R.memory.alloc_storage(R.shape([80]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc2: R.Tensor((n,), dtype="float32") = R.memory.alloc_tensor(storage2, R.prim_value(0), R.shape([n]), R.dtype("float32"))
             _2: R.Tuple = cls.tir_exp(lv2, alloc2)
             lv3: R.Tensor((n,), dtype="float32") = alloc2
@@ -1484,18 +1484,18 @@ def test_call_tir_dyn_plan_partially_dynamic():
             m = T.int64()
             R.func_attr({"relax.force_pure": True, "tir_var_upper_bound": {"n": 20}})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(R.shape([80 * m]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage: R.Any = R.memory.alloc_storage(R.shape([80 * m]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc: R.Tensor((n, m), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([n, m]), R.dtype("float32"))
             _: R.Tuple = R.vm.call_tir_dyn(cls.tir_full, (alloc, R.shape([n, m])))
             full: R.Tensor((n, m), dtype="float32") = alloc
-            storage1: R.Object = R.memory.alloc_storage(R.shape([80 * m]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([80 * m]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc1: R.Tensor((n, m), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([n, m]), R.dtype("float32"))
             _1: R.Tuple = cls.tir_exp(full, alloc1)
             lv2: R.Tensor((n, m), dtype="float32") = alloc1
             alloc2: R.Tensor((n, m), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([n, m]), R.dtype("float32"))
             _2: R.Tuple = cls.tir_exp(lv2, alloc2)
             lv3: R.Tensor((n, m), dtype="float32") = alloc2
-            storage2: R.Object = R.memory.alloc_storage(R.shape([20 * m * 4]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage2: R.Any = R.memory.alloc_storage(R.shape([20 * m * 4]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc3: R.Tensor((n, m), dtype="float32") = R.memory.alloc_tensor(storage2, R.prim_value(0), R.shape([n, m]), R.dtype("float32"))
             _3: R.Tuple = cls.tir_exp(lv3, alloc3)
             lv4 = alloc3
@@ -1548,7 +1548,7 @@ def test_function_independence():
         def func1(x: R.Tensor((8,), dtype="float32")) -> R.Tensor((8,), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage: R.Any = R.memory.alloc_storage(R.shape([32]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc: R.Tensor((8,), dtype="float32") = R.memory.alloc_tensor(storage, R.prim_value(0), R.shape([8]), R.dtype("float32"))
             _: R.Tuple = cls.exp(x, alloc)
             lv: R.Tensor((8,), dtype="float32") = alloc
@@ -1561,7 +1561,7 @@ def test_function_independence():
         def func2(x: R.Tensor((10,), dtype="float32")) -> R.Tensor((10,), dtype="float32"):
             R.func_attr({"relax.force_pure": True})
             cls = Expected
-            storage1: R.Object = R.memory.alloc_storage(R.shape([40]), R.prim_value(0), R.str("global"), R.dtype("float32"))
+            storage1: R.Any = R.memory.alloc_storage(R.shape([40]), R.prim_value(0), R.str("global"), R.dtype("float32"))
             alloc: R.Tensor((10,), dtype="float32") = R.memory.alloc_tensor(storage1, R.prim_value(0), R.shape([10]), R.dtype("float32"))
             _: R.Tuple = cls.exp(x, alloc)
             lv: R.Tensor((10,), dtype="float32") = alloc
@@ -1642,7 +1642,7 @@ def test_add():
                 }
             )
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([32 * vocab_size * 4 * 2 + 4194304]),
                 R.prim_value(0),
                 R.str("global"),
@@ -1657,7 +1657,7 @@ def test_add():
                 R.shape([2 * (batch_size * vocab_size * 4) + 4194304]),
                 R.dtype("uint8"),
             )
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([128 * vocab_size]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
             alloc1: R.Tensor((batch_size, vocab_size), dtype="float32") = R.memory.alloc_tensor(
@@ -1705,7 +1705,7 @@ def test_view():
         @R.function
         def main() -> R.Tensor((128,), dtype="float32"):
             cls = Expected
-            storage: R.Object = R.memory.alloc_storage(
+            storage: R.Any = R.memory.alloc_storage(
                 R.shape([1024]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
             x: R.Tensor((16, 16), dtype="float32") = R.memory.alloc_tensor(
@@ -1715,7 +1715,7 @@ def test_view():
                 x, R.shape([128]), R.dtype("float32"), R.prim_value(0)
             )
             x2: R.Tensor((128,), dtype="float32") = R.memory.ensure_zero_offset(x1)
-            storage1: R.Object = R.memory.alloc_storage(
+            storage1: R.Any = R.memory.alloc_storage(
                 R.shape([512]), R.prim_value(0), R.str("global"), R.dtype("float32")
             )
             y: R.Tensor((128,), dtype="float32") = R.memory.alloc_tensor(

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -853,11 +853,11 @@ def test_call_packed():
 
 def test_call_packed_without_ty_args():
     @R.function(pure=False)
-    def foo(x: R.Object) -> R.Object:
+    def foo(x: R.Any) -> R.Any:
         z = R.call_packed("test", x)
         return z
 
-    x = relax.Var("x", R.Object())
+    x = relax.Var("x", R.Any())
     bb = relax.BlockBuilder()
     with bb.function("foo", (x), pure=False):
         z = bb.emit(
@@ -873,13 +873,21 @@ def test_call_packed_without_ty_args():
     _check(foo, bb.get()["foo"])
 
 
+def test_object_proxy_compat_alias():
+    @R.function
+    def foo(x: R.Object) -> R.Object:
+        return x
+
+    assert isinstance(foo.ret_ty, relax.AnyType)
+
+
 def test_annotation():
     @R.function(pure=False)
     def foo(
         x: R.Tensor((32, "m"), "float32"),
         y: R.Tensor(("m",), "float32"),
         r: R.Tensor(dtype="int64"),
-    ) -> R.Object:
+    ) -> R.Any:
         m = T.int64()
         z: R.Tensor((32, m), "float32") = R.multiply(x, y)
         w: R.Tensor(ndim=2) = R.multiply(z, z)
@@ -887,7 +895,7 @@ def test_annotation():
         t = R.add(w, z)
         sh: R.Shape = R.call_packed("shape_of", x, ty_args=R.Shape)
         lv: R.Tensor(sh, dtype="float32") = R.reshape(x, sh)
-        o: R.Object = R.call_packed("contrib.tensor_array_stack", x, y, ty_args=R.Object)
+        o: R.Any = R.call_packed("contrib.tensor_array_stack", x, y, ty_args=R.Any)
         return o
 
     def _check_ty(binding, expected_ty):
@@ -896,7 +904,7 @@ def test_annotation():
 
     # Cannot use block builder here because we need to check the annotated type,
     # which may be inconsistent with deduced type.
-    assert isinstance(foo.ret_ty, relax.ObjectType)
+    assert isinstance(foo.ret_ty, relax.AnyType)
     m = relax.get_shape_of(foo.params[0])[1]
     bindings = foo.body.blocks[0].bindings
     sh = bindings[4].var
@@ -907,21 +915,21 @@ def test_annotation():
     _check_ty(bindings[3], relax.TensorType(dtype="", ndim=2))
     _check_ty(bindings[4], relax.ShapeType(ndim=-1))
     _check_ty(bindings[5], relax.TensorType(sh))
-    _check_ty(bindings[6], relax.ObjectType())
+    _check_ty(bindings[6], relax.AnyType())
 
 
 def test_annotate_override():
     @R.function
     def foo(x: R.Tensor):
         y = x
-        # z will be treated as object type even though it's a tensor
-        z: R.Object = R.add(x, y)
+        # z will be treated as Any even though it's a tensor
+        z: R.Any = R.add(x, y)
         return z
 
-    assert isinstance(foo.ret_ty, relax.ObjectType)
+    assert isinstance(foo.ret_ty, relax.AnyType)
     y_bind, z_bind = foo.body.blocks[0].bindings
     assert isinstance(y_bind.var.ty, relax.TensorType)
-    assert isinstance(z_bind.var.ty, relax.ObjectType)
+    assert isinstance(z_bind.var.ty, relax.AnyType)
 
     with pytest.raises(tvm.error.DiagnosticError):
 
@@ -934,7 +942,7 @@ def test_annotate_override():
     @R.function
     def bar(x: R.Tensor):
         # x is of Tensor Type, the annotation of `z` is ignored.
-        z: R.Object = x
+        z: R.Any = x
         return z
 
     assert isinstance(bar.ret_ty, relax.TensorType)
@@ -1728,7 +1736,7 @@ def test_function_void_return_type():
     _check(Foo)
     # Since the return type of function `mul` is not annotated,
     # the function `main` regards it as a generic return type.
-    assert isinstance(Foo["main"].ret_ty, relax.ObjectType)
+    assert isinstance(Foo["main"].ret_ty, relax.AnyType)
     assert isinstance(Foo["mul"].ret_ty, relax.TensorType)
 
     @tvm.script.ir_module
@@ -2024,13 +2032,13 @@ def test_call_pure_packed():
 
 def test_call_pure_packed_returning_object():
     @R.function
-    def foo() -> R.Object:
-        z = R.call_pure_packed("dummy_func", ty_args=R.Object)
+    def foo() -> R.Any:
+        z = R.call_pure_packed("dummy_func", ty_args=R.Any)
         return z
 
     bb = relax.BlockBuilder()
     with bb.function("foo", params=[]):
-        z = bb.emit(R.call_pure_packed("dummy_func", ty_args=[relax.ObjectType()]))
+        z = bb.emit(R.call_pure_packed("dummy_func", ty_args=[relax.AnyType()]))
         bb.emit_func_output(z)
 
     _check(foo, bb.get()["foo"])

--- a/tests/python/relax/test_tvmscript_printer_relax.py
+++ b/tests/python/relax/test_tvmscript_printer_relax.py
@@ -169,10 +169,10 @@ class Module:
 
 
 def test_object_ty():
-    obj = relax.ObjectType()
+    obj = relax.AnyType()
     _assert_print(
         obj,
-        "R.Object",
+        "R.Any",
     )
 
 
@@ -224,14 +224,14 @@ def test_tuple_ty():
     obj = relax.TupleType(
         [
             tvm.ir.PrimType("float32"),
-            relax.ObjectType(),
+            relax.AnyType(),
             relax.ShapeType([1, tirx.Var("a", "int64"), 3]),
         ]
     )
     _assert_print(
         obj._relax_script(),  # pylint: disable=protected-access
         """
-R.Tuple(T.float32, R.Object, R.Shape([1, a, 3]))
+R.Tuple(T.float32, R.Any, R.Shape([1, a, 3]))
 """,
     )
 
@@ -240,7 +240,7 @@ def test_func_ty():
     obj = relax.FuncType(
         params=[
             tvm.ir.PrimType("float32"),
-            relax.ObjectType(),
+            relax.AnyType(),
             relax.ShapeType([1, tirx.Var("a", "int64"), 3]),
             tvm.ir.PrimType("int64"),
         ],
@@ -252,7 +252,7 @@ def test_func_ty():
     _assert_print(
         obj,
         "a = T.int64()\n"
-        "R.Callable((T.float32, R.Object, R.Shape([1, a, 3]), T.int64), "
+        "R.Callable((T.float32, R.Any, R.Shape([1, a, 3]), T.int64), "
         'R.Tensor((1, 2, 3), dtype="float32"), True)',
     )
 
@@ -263,8 +263,8 @@ def test_shape_type():
 
 
 def test_object_type():
-    obj = relax.ObjectType()
-    _assert_print(obj, "R.Object")
+    obj = relax.AnyType()
+    _assert_print(obj, "R.Any")
 
 
 def test_dyn_tensor_type():
@@ -278,17 +278,17 @@ def test_packed_func_type():
 
 
 def test_tuple_type():
-    obj = relax.TupleType([relax.ShapeType(ndim=3), relax.ObjectType()])
+    obj = relax.TupleType([relax.ShapeType(ndim=3), relax.AnyType()])
     _assert_print(
         obj._relax_script(),  # pylint: disable=protected-access
-        "R.Tuple(R.Shape(ndim=3), R.Object)",
+        "R.Tuple(R.Shape(ndim=3), R.Any)",
     )
 
 
 def test_func_type():
     obj = relax.FuncType(
         params=[
-            relax.ObjectType(),
+            relax.AnyType(),
             relax.ShapeType(ndim=3),
         ],
         ret=relax.TensorType(
@@ -298,7 +298,7 @@ def test_func_type():
     )
     _assert_print(
         obj._relax_script(),  # pylint: disable=protected-access
-        'R.Callable((R.Object, R.Shape(ndim=3)), R.Tensor(dtype="float32", ndim=3), True)',
+        'R.Callable((R.Any, R.Shape(ndim=3)), R.Tensor(dtype="float32", ndim=3), True)',
     )
 
 

--- a/tests/python/relax/test_type.py
+++ b/tests/python/relax/test_type.py
@@ -40,16 +40,24 @@ def _check_json_roundtrip(x):
     return xret
 
 
-def test_object_ty():
-    s0 = rx.ObjectType()
-    s1 = rx.ObjectType()
+def test_any_ty():
+    s0 = rx.AnyType()
+    s1 = rx.AnyType()
 
     # can turn into str
     str(s0)
     _check_equal(s0, s1)
 
-    assert isinstance(s0, rx.ObjectType)
+    assert isinstance(s0, rx.AnyType)
     _check_json_roundtrip(s0)
+
+
+def test_object_ty_compat_alias():
+    s0 = rx.ObjectType()
+
+    assert isinstance(s0, rx.AnyType)
+    assert rx.ObjectType is rx.AnyType
+    _check_equal(s0, rx.AnyType())
 
 
 def test_shape_type():
@@ -181,10 +189,10 @@ def test_tuple_ty():
     n, m = tirx.Var("n", "int64"), tirx.Var("m", "int64")
 
     s0 = rx.TensorType([1, 2, m + n], "float32")
-    s1 = rx.ObjectType()
+    s1 = rx.AnyType()
 
     t0 = rx.TupleType([s0, s1])
-    t1 = rx.TupleType([s0, rx.ObjectType()])
+    t1 = rx.TupleType([s0, rx.AnyType()])
     t2 = rx.TupleType([s0, s0])
 
     _check_equal(t0, t1)
@@ -229,7 +237,7 @@ def test_func_ty():
     assert f2.derive_func is None
     assert f3.params is None
     assert f3.derive_func is None
-    _check_equal(f3.ret, rx.ObjectType())
+    _check_equal(f3.ret, rx.AnyType())
 
     assert isinstance(f0, rx.FuncType)
     f0 = _check_json_roundtrip(f0)

--- a/tests/python/relax/test_vm_build.py
+++ b/tests/python/relax/test_vm_build.py
@@ -88,7 +88,7 @@ def test_match_check(exec_mode):
     @tvm.script.ir_module
     class TestMatchCheck:
         @R.function
-        def foo(x: R.Tensor(["n", "m"], "int32"), y: R.Object) -> R.Tensor(["m", "n"], dtype=None):
+        def foo(x: R.Tensor(["n", "m"], "int32"), y: R.Any) -> R.Tensor(["m", "n"], dtype=None):
             return y
 
     mod = TestMatchCheck
@@ -798,14 +798,14 @@ def test_sub_func_call(exec_mode):
         @R.function
         def relax_matmul_packed(
             x: R.Tensor((32, 32), "float32"), w: R.Tensor((32, 32), "float32")
-        ) -> R.Object:
+        ) -> R.Any:
             gv0 = R.call_pure_packed(
                 "test.vm.mul", x, w, ty_args=(R.Tensor(ndim=2, dtype="float32"))
             )
             return gv0
 
         @R.function
-        def main(x: R.Tensor((32, 32), "float32"), w: R.Tensor((32, 32), "float32")) -> R.Object:
+        def main(x: R.Tensor((32, 32), "float32"), w: R.Tensor((32, 32), "float32")) -> R.Any:
             cls = TestVMSubFunction
             gv0 = cls.relax_matmul_tir(x, w)
             gv1 = cls.relax_matmul_packed(gv0, gv0)

--- a/tests/python/relax/test_vm_codegen_only.py
+++ b/tests/python/relax/test_vm_codegen_only.py
@@ -391,7 +391,7 @@ def test_vm_kill_object(exec_mode):
         def main() -> R.Tensor((4,), dtype="float32"):
             R.func_attr({"global_symbol": "main"})
             cls = TestKillObject
-            storage: R.Object = R.vm.alloc_storage(R.shape([16]), R.prim_value(0), R.dtype("uint8"))
+            storage: R.Any = R.vm.alloc_storage(R.shape([16]), R.prim_value(0), R.dtype("uint8"))
             alloc: R.Tensor((4,), dtype="float32") = R.vm.alloc_tensor(
                 storage, R.prim_value(0), R.shape([4]), R.dtype("float32")
             )
@@ -404,9 +404,7 @@ def test_vm_kill_object(exec_mode):
             _1: R.Tuple = cls.full(alloc1)
             _1_1: R.Tuple = R.vm.kill_object(alloc1)
             y: R.Tensor((4,), dtype="float32") = alloc1
-            storage_1: R.Object = R.vm.alloc_storage(
-                R.shape([16]), R.prim_value(0), R.dtype("uint8")
-            )
+            storage_1: R.Any = R.vm.alloc_storage(R.shape([16]), R.prim_value(0), R.dtype("uint8"))
             alloc2: R.Tensor((4,), dtype="float32") = R.vm.alloc_tensor(
                 storage_1, R.prim_value(0), R.shape([4]), R.dtype("float32")
             )

--- a/tests/python/relax/test_vm_cuda_graph.py
+++ b/tests/python/relax/test_vm_cuda_graph.py
@@ -36,14 +36,14 @@ class Module:
     def main(x: R.Tensor((16, 16), dtype="float32")) -> R.Tensor((16, 16), dtype="float32"):
         cls = Module
         R.func_attr({"global_symbol": "main"})
-        gv: R.Tuple(R.Object, R.Object) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.get_cached_alloc", (cls.cuda_graph_alloc, R.prim_value(0)), ty_args=(R.Tuple(R.Object, R.Object),))
-        storage: R.Object = gv[0]
+        gv: R.Tuple(R.Any, R.Any) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.get_cached_alloc", (cls.cuda_graph_alloc, R.prim_value(0)), ty_args=(R.Tuple(R.Any, R.Any),))
+        storage: R.Any = gv[0]
         alloc = R.vm.alloc_tensor(storage, R.prim_value(0), R.shape((16, 16)), R.dtype("float32"))
         _: R.Tuple = cls.add(x, alloc)
-        storage1: R.Object = gv[1]
-        gv1: R.Tuple(R.Tensor(dtype="float32"), R.Object, R.Object) = (alloc, storage1, storage)
+        storage1: R.Any = gv[1]
+        gv1: R.Tuple(R.Tensor(dtype="float32"), R.Any, R.Any) = (alloc, storage1, storage)
         gv2: R.Tuple(R.Tensor((16, 16), dtype="float32")) = R.call_builtin_with_ctx("vm.builtin.cuda_graph.run_or_capture", (cls.cuda_graph_capture, gv1, R.prim_value(0)), ty_args=(R.Tuple(R.Tensor((16, 16), dtype="float32")),))
-        storage2: R.Object = R.vm.alloc_storage(R.shape((1024,)), R.prim_value(0), R.dtype("uint8"))
+        storage2: R.Any = R.vm.alloc_storage(R.shape((1024,)), R.prim_value(0), R.dtype("uint8"))
         alloc3 = R.vm.alloc_tensor(storage2, R.prim_value(0), R.shape((16, 16)), R.dtype("float32"))
         lv4: R.Tensor((16, 16), dtype="float32") = gv2[0]
         _3: R.Tuple = cls.add(lv4, alloc3)
@@ -61,15 +61,15 @@ class Module:
                         B[vi, vj] = A[vi, vj] + T.float32(1)
 
     @R.function
-    def cuda_graph_alloc() -> R.Tuple(R.Object, R.Object):
+    def cuda_graph_alloc() -> R.Tuple(R.Any, R.Any):
         R.func_attr({"global_symbol": "cuda_graph_alloc"})
-        storage: R.Object = R.vm.alloc_storage(R.shape((1024,)), R.prim_value(0), R.dtype("uint8"))
-        storage1: R.Object = R.vm.alloc_storage(R.shape((1024,)), R.prim_value(0), R.dtype("uint8"))
-        gv: R.Tuple(R.Object, R.Object) = (storage, storage1)
+        storage: R.Any = R.vm.alloc_storage(R.shape((1024,)), R.prim_value(0), R.dtype("uint8"))
+        storage1: R.Any = R.vm.alloc_storage(R.shape((1024,)), R.prim_value(0), R.dtype("uint8"))
+        gv: R.Tuple(R.Any, R.Any) = (storage, storage1)
         return gv
 
     @R.function(pure=False)
-    def cuda_graph_capture(alloc: R.Tensor((16, 16), dtype="float32"), storage1: R.Object, storage: R.Object) -> R.Tuple(R.Tensor((16, 16), dtype="float32")):
+    def cuda_graph_capture(alloc: R.Tensor((16, 16), dtype="float32"), storage1: R.Any, storage: R.Any) -> R.Tuple(R.Tensor((16, 16), dtype="float32")):
         cls = Module
         R.func_attr({"global_symbol": "cuda_graph_capture"})
         lv0: R.Tensor((16, 16), dtype="float32") = alloc

--- a/tests/python/tvmscript/test_tvmscript_roundtrip.py
+++ b/tests/python/tvmscript/test_tvmscript_roundtrip.py
@@ -3230,7 +3230,7 @@ def relax_match_cast_ty_proxy():
     def make_ir_generator(proxy_subclass):
         def inner():
             @R.function
-            def func(A: R.Object):
+            def func(A: R.Any):
                 B = R.match_cast(A, proxy_subclass)
                 return B
 
@@ -3243,7 +3243,7 @@ def relax_match_cast_ty_proxy():
     # This list is a subset of `TypeProxy.__subclasses__()`,
     # excluding `PrimProxy` and `DTensorProxy`.
     subclasses = [
-        tvm.script.parser.relax.entry.ObjectProxy,
+        tvm.script.parser.relax.entry.AnyProxy,
         tvm.script.parser.relax.entry.TensorProxy,
         tvm.script.parser.relax.entry.CallableProxy,
         tvm.script.parser.relax.entry.TupleProxy,


### PR DESCRIPTION
This PR introduces Relax AnyType as the primary top/base type spelling, replacing the previous ObjectType naming for the type that represents any Relax value.

Changes:
- Add AnyType/AnyTypeNode with relax.AnyType registration and keep ObjectType/R.Object compatibility aliases.
- Update Relax type analysis, type visitors, opaque function defaults, and script printer/parser handling to use AnyType/R.Any.
- Migrate affected Python/C++ call sites, docs, and focused tests to the new spelling.

Validation:
- cmake --build build --parallel 16
- Focused Relax/TVMScript pytest: 704 passed, 1 xfailed
- pre_commit run --files <changed files>