### PR TITLE
[Relax] Use optional dtype for absent Relax dtype fields

### DIFF
--- a/docs/deep_dive/relax/tutorials/relax_creation.py
+++ b/docs/deep_dive/relax/tutorials/relax_creation.py
@@ -122,7 +122,7 @@ RelaxModuleWithTIR.show()
 #   .. code-block:: python
 #
 #     lv: R.Tensor((784, 128), dtype="float32") = R.permute_dims(w0, axes=None)
-#     lv1: R.Tensor((n, 128), dtype="float32") = R.matmul(data, lv, out_dtype="void")
+#     lv1: R.Tensor((n, 128), dtype="float32") = R.matmul(data, lv)
 #     lv0: R.Tensor((n, 128), dtype="float32") = R.add(lv1, b0)
 #
 

--- a/docs/get_started/tutorials/ir_module.py
+++ b/docs/get_started/tutorials/ir_module.py
@@ -135,11 +135,11 @@ class TVMScriptModule:
         R.func_attr({"num_input": 1})
         with R.dataflow():
             permute_dims = R.permute_dims(fc1_weight, axes=None)
-            matmul = R.matmul(x, permute_dims, out_dtype="void")
+            matmul = R.matmul(x, permute_dims, out_dtype=None)
             add = R.add(matmul, fc1_bias)
             relu = R.nn.relu(add)
             permute_dims1 = R.permute_dims(fc2_weight, axes=None)
-            matmul1 = R.matmul(relu, permute_dims1, out_dtype="void")
+            matmul1 = R.matmul(relu, permute_dims1, out_dtype=None)
             add1 = R.add(matmul1, fc2_bias)
             gv = add1
             R.output(gv)

--- a/include/tvm/relax/attrs/create.h
+++ b/include/tvm/relax/attrs/create.h
@@ -31,7 +31,7 @@ namespace relax {
 
 /*! \brief Attributes used in full/full_like, ones/ones_like, and zeros/zeros_like operators */
 struct InitAttrs : public AttrsNode {
-  DLDataType dtype;
+  ffi::Optional<DLDataType> dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;

--- a/include/tvm/relax/attrs/image.h
+++ b/include/tvm/relax/attrs/image.h
@@ -39,7 +39,7 @@ struct Resize2DAttrs : public AttrsNode {
   double cubic_alpha;
   int cubic_exclude;
   double extrapolation_value;
-  DLDataType out_dtype;
+  ffi::Optional<DLDataType> out_dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -88,7 +88,7 @@ struct Resize3DAttrs : public AttrsNode {
   double cubic_alpha;
   int cubic_exclude;
   double extrapolation_value;
-  DLDataType out_dtype;
+  ffi::Optional<DLDataType> out_dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;

--- a/include/tvm/relax/attrs/linear_algebra.h
+++ b/include/tvm/relax/attrs/linear_algebra.h
@@ -31,7 +31,7 @@ namespace relax {
 
 /*! \brief Attributes for matmul operator */
 struct MatmulAttrs : public AttrsNode {
-  DLDataType out_dtype;
+  ffi::Optional<DLDataType> out_dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;

--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -38,7 +38,7 @@ struct Conv1DAttrs : public AttrsNode {
   ffi::String data_layout;
   ffi::String kernel_layout;
   ffi::String out_layout;
-  DLDataType out_dtype;
+  ffi::Optional<DLDataType> out_dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -82,7 +82,7 @@ struct Conv2DAttrs : public AttrsNode {
   ffi::String data_layout;
   ffi::String kernel_layout;
   ffi::String out_layout;
-  DLDataType out_dtype;
+  ffi::Optional<DLDataType> out_dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -128,7 +128,7 @@ struct Conv3DAttrs : public AttrsNode {
   ffi::String data_layout;
   ffi::String kernel_layout;
   ffi::String out_layout;
-  DLDataType out_dtype;
+  ffi::Optional<DLDataType> out_dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -177,7 +177,7 @@ struct Conv1DTransposeAttrs : public AttrsNode {
   ffi::String data_layout;
   ffi::String kernel_layout;
   ffi::String out_layout;
-  DLDataType out_dtype;
+  ffi::Optional<DLDataType> out_dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -226,7 +226,7 @@ struct Conv2DTransposeAttrs : public AttrsNode {
   ffi::String data_layout;
   ffi::String kernel_layout;
   ffi::String out_layout;
-  DLDataType out_dtype;
+  ffi::Optional<DLDataType> out_dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -277,7 +277,7 @@ struct Conv3DTransposeAttrs : public AttrsNode {
   ffi::String data_layout;
   ffi::String kernel_layout;
   ffi::String out_layout;
-  DLDataType out_dtype;
+  ffi::Optional<DLDataType> out_dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;

--- a/include/tvm/relax/attrs/sorting.h
+++ b/include/tvm/relax/attrs/sorting.h
@@ -54,7 +54,7 @@ struct SortAttrs : public AttrsNode {
 struct ArgsortAttrs : public AttrsNode {
   int axis;
   bool descending;
-  DLDataType dtype;
+  ffi::Optional<DLDataType> dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -67,8 +67,7 @@ struct ArgsortAttrs : public AttrsNode {
                 "Whether to argsort in descending order."
                 "If it is not specified, it defaults to the ascending order.",
                 refl::DefaultValue(false))
-        .def_ro("dtype", &ArgsortAttrs::dtype, "DType of the output indices.",
-                refl::DefaultValue((DLDataType{kDLOpaqueHandle, 0, 0})));
+        .def_ro("dtype", &ArgsortAttrs::dtype, "DType of the output indices.");
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.ArgsortAttrs", ArgsortAttrs, AttrsNode);
 };  // struct ArgsortAttrs
@@ -79,7 +78,7 @@ struct TopKAttrs : public AttrsNode {
   int axis;
   bool largest;
   ffi::String ret_type;
-  DLDataType dtype;
+  ffi::Optional<DLDataType> dtype;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -97,8 +96,7 @@ struct TopKAttrs : public AttrsNode {
                 "Whether to return largest or smallest elements."
                 "By default, return the largest k elements.",
                 refl::DefaultValue(true))
-        .def_ro("dtype", &TopKAttrs::dtype, "Data type of the output indices.",
-                refl::DefaultValue((DLDataType{kDLOpaqueHandle, 0, 0})));
+        .def_ro("dtype", &TopKAttrs::dtype, "Data type of the output indices.");
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.attrs.TopKAttrs", TopKAttrs, AttrsNode);
 };  // struct TopKAttrs

--- a/include/tvm/relax/attrs/statistical.h
+++ b/include/tvm/relax/attrs/statistical.h
@@ -50,7 +50,7 @@ struct StatisticalAttrs : public AttrsNode {
 /*! \brief Attributes used in scan operators like cumsum, cumprod */
 struct ScanopAttrs : public AttrsNode {
   ffi::Optional<int64_t> axis;
-  DLDataType dtype;
+  ffi::Optional<DLDataType> dtype;
   bool exclusive = false;
 
   static void RegisterReflection() {

--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -192,15 +192,6 @@ class TensorTypeNode : public TypeNode {
   /*! \return Whether the type contains unknown dtype. */
   bool IsUnknownDtype() const { return !dtype.defined(); }
 
-  /*! \return The known dtype. */
-  tvm::PrimType GetDtype() const {
-    TVM_FFI_ICHECK(dtype.defined()) << "TensorType has unknown dtype";
-    return dtype.value();
-  }
-
-  /*! \return The known dtype as a raw DLPack dtype. */
-  DLDataType GetDtypeRaw() const { return GetDtype()->dtype; }
-
   /*! \return Shape if it is known. */
   ffi::Optional<ffi::Array<PrimExpr>> GetShape() const {
     if (!shape.defined()) return {};

--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -178,8 +178,8 @@ class TensorTypeNode : public TypeNode {
    *  is expected to be executed.
    */
   ffi::Optional<VDevice> vdevice;
-  /*! \brief The content dtype, use void to denote the dtype is unknown. */
-  tvm::PrimType dtype{DLDataType{kDLOpaqueHandle, 0, 0}};
+  /*! \brief The content dtype, or nullopt if the dtype is unknown. */
+  ffi::Optional<tvm::PrimType> dtype{std::nullopt};
   /*!
    * \brief The number of dimension of the tensor, can be unknown.
    * \sa kUnknownNDim
@@ -190,7 +190,16 @@ class TensorTypeNode : public TypeNode {
   bool IsUnknownNdim() const { return ndim == kUnknownNDim; }
 
   /*! \return Whether the type contains unknown dtype. */
-  bool IsUnknownDtype() const { return dtype->dtype == DLDataType{kDLOpaqueHandle, 0, 0}; }
+  bool IsUnknownDtype() const { return !dtype.defined(); }
+
+  /*! \return The known dtype. */
+  tvm::PrimType GetDtype() const {
+    TVM_FFI_ICHECK(dtype.defined()) << "TensorType has unknown dtype";
+    return dtype.value();
+  }
+
+  /*! \return The known dtype as a raw DLPack dtype. */
+  DLDataType GetDtypeRaw() const { return GetDtype()->dtype; }
 
   /*! \return Shape if it is known. */
   ffi::Optional<ffi::Array<PrimExpr>> GetShape() const {
@@ -234,8 +243,8 @@ class TensorType : public Type {
    *
    * \note shape must already be normalized.
    */
-  TVM_DLL TensorType(Expr shape, tvm::PrimType dtype, ffi::Optional<VDevice> vdevice = std::nullopt,
-                     Span span = Span());
+  TVM_DLL TensorType(Expr shape, ffi::Optional<tvm::PrimType> dtype = std::nullopt,
+                     ffi::Optional<VDevice> vdevice = std::nullopt, Span span = Span());
 
   /*!
    * \brief Construction with an unknown shape expression.
@@ -244,8 +253,8 @@ class TensorType : public Type {
    * \param vdevice The virtual device.
    * \param span The span of the AST.
    */
-  TVM_DLL TensorType(tvm::PrimType dtype, int ndim, ffi::Optional<VDevice> vdevice = std::nullopt,
-                     Span span = Span());
+  TVM_DLL TensorType(ffi::Optional<tvm::PrimType> dtype, int ndim,
+                     ffi::Optional<VDevice> vdevice = std::nullopt, Span span = Span());
 
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TensorType, Type, TensorTypeNode);
 };

--- a/python/tvm/relax/op/memory/view.py
+++ b/python/tvm/relax/op/memory/view.py
@@ -32,6 +32,7 @@ from tvm.relax import DataTypeImm, Expr, ShapeExpr
 from tvm.relax.expr import prim_value
 from tvm.tirx import PrimExpr
 
+from ..base import null_value
 from . import _ffi_api
 
 PrimExprLike = int | PrimExpr
@@ -89,7 +90,7 @@ def view(
             return relax_cls(expr)
 
     shape = _normalize(shape, ShapeExpr)
-    dtype = _normalize(dtype, DataTypeImm)
+    dtype = null_value() if dtype is None else _normalize(dtype, DataTypeImm)
     relative_byte_offset = (
         relative_byte_offset
         if relative_byte_offset is None or isinstance(relative_byte_offset, Expr)

--- a/python/tvm/relax/transform/legalize_ops/linear_algebra.py
+++ b/python/tvm/relax/transform/legalize_ops/linear_algebra.py
@@ -93,7 +93,7 @@ def _matmul(bb: BlockBuilder, call: Call) -> Expr:
                     b_indices.append(idx_spatial[-1])
 
                 dtype = call.attrs.out_dtype
-                if dtype != "":
+                if dtype is not None and dtype != "":
                     return a(*a_indices).astype(dtype) * b(*b_indices).astype(dtype)
                 return a(*a_indices) * b(*b_indices)
 

--- a/python/tvm/relax/type.py
+++ b/python/tvm/relax/type.py
@@ -110,6 +110,8 @@ class TensorType(Type):
     ) -> None:
         if isinstance(shape, list | tuple | Array):
             shape = ShapeExpr(shape)
+        if dtype == "":
+            dtype = None
         self.__init_handle_by_constructor__(
             _ffi_api.TensorType,
             shape,

--- a/src/relax/analysis/type_analysis.cc
+++ b/src/relax/analysis/type_analysis.cc
@@ -355,10 +355,11 @@ class TypeBaseChecker : public TypeFunctor<BaseCheckResult(const Type&, const Ty
       return BaseCheckResult::kFailL0;
     }
     // dtype mismatch
-    if (!lhs->IsUnknownDtype() && lhs->dtype != rhs->dtype) {
+    if (!lhs->IsUnknownDtype() && !rhs->IsUnknownDtype() && lhs->GetDtype() != rhs->GetDtype()) {
       if (rhs->IsUnknownDtype()) return BaseCheckResult::kFailL1;
       return BaseCheckResult::kFailL0;
     }
+    if (!lhs->IsUnknownDtype() && rhs->IsUnknownDtype()) return BaseCheckResult::kFailL1;
 
     // ndim mismatch
     if (!lhs->IsUnknownNdim() && lhs->ndim != rhs->ndim) {
@@ -672,7 +673,10 @@ class TypeBasePreconditionCollector : public TypeFunctor<PrimExpr(const Type&, c
       return IntImm::Bool(false);
     }
     // dtype mismatch
-    if (!lhs->IsUnknownDtype() && lhs->dtype != rhs->dtype) {
+    if (!lhs->IsUnknownDtype() && !rhs->IsUnknownDtype() && lhs->GetDtype() != rhs->GetDtype()) {
+      return IntImm::Bool(false);
+    }
+    if (!lhs->IsUnknownDtype() && rhs->IsUnknownDtype()) {
       return IntImm::Bool(false);
     }
 
@@ -1017,9 +1021,10 @@ class TypeLCAFinder : public TypeFunctor<Type(const Type&, const Type&)> {
     if (rhs == nullptr) return AnyType(lhs->span);
 
     // find the target dtype, ndim, and vdevice.
-    PrimType dtype = lhs->dtype->dtype == rhs->dtype->dtype
-                         ? PrimType(lhs->dtype->dtype)
-                         : PrimType(DLDataType{kDLOpaqueHandle, 0, 0});
+    ffi::Optional<PrimType> dtype =
+        (!lhs->IsUnknownDtype() && !rhs->IsUnknownDtype() && lhs->GetDtype() == rhs->GetDtype())
+            ? ffi::Optional<PrimType>(lhs->GetDtype())
+            : std::nullopt;
     int ndim = lhs->ndim == rhs->ndim ? lhs->ndim : kUnknownNDim;
     VDevice vdev = VDevice();
     if (lhs->vdevice.defined() && rhs->vdevice.defined() &&
@@ -1032,7 +1037,7 @@ class TypeLCAFinder : public TypeFunctor<Type(const Type&, const Type&)> {
         !CanProveShapeEqual(lhs->shape.value(), rhs->shape.value(),
                             ffi::GetRef<arith::Analyzer>(analyzer_))) {
       // reuse lhs when possible
-      if (!lhs->shape.defined() && lhs->dtype->dtype == dtype->dtype && lhs->ndim == ndim &&
+      if (!lhs->shape.defined() && lhs->dtype == dtype && lhs->ndim == ndim &&
           (!lhs->vdevice.defined() || vdev.defined())) {
         return ffi::GetRef<Type>(lhs);
       } else {
@@ -1040,7 +1045,7 @@ class TypeLCAFinder : public TypeFunctor<Type(const Type&, const Type&)> {
       }
     }
     // symbolic shape and vdevice match but dtype mismatch
-    if (lhs->dtype->dtype != dtype->dtype || (lhs->vdevice.defined() && !vdev.defined())) {
+    if (lhs->dtype != dtype || (lhs->vdevice.defined() && !vdev.defined())) {
       return TensorType(lhs->shape.value(), dtype, vdev, lhs->span);
     } else {
       return ffi::GetRef<Type>(lhs);

--- a/src/relax/analysis/type_analysis.cc
+++ b/src/relax/analysis/type_analysis.cc
@@ -355,7 +355,8 @@ class TypeBaseChecker : public TypeFunctor<BaseCheckResult(const Type&, const Ty
       return BaseCheckResult::kFailL0;
     }
     // dtype mismatch
-    if (!lhs->IsUnknownDtype() && !rhs->IsUnknownDtype() && lhs->GetDtype() != rhs->GetDtype()) {
+    if (!lhs->IsUnknownDtype() && !rhs->IsUnknownDtype() &&
+        lhs->dtype.value() != rhs->dtype.value()) {
       if (rhs->IsUnknownDtype()) return BaseCheckResult::kFailL1;
       return BaseCheckResult::kFailL0;
     }
@@ -673,7 +674,8 @@ class TypeBasePreconditionCollector : public TypeFunctor<PrimExpr(const Type&, c
       return IntImm::Bool(false);
     }
     // dtype mismatch
-    if (!lhs->IsUnknownDtype() && !rhs->IsUnknownDtype() && lhs->GetDtype() != rhs->GetDtype()) {
+    if (!lhs->IsUnknownDtype() && !rhs->IsUnknownDtype() &&
+        lhs->dtype.value() != rhs->dtype.value()) {
       return IntImm::Bool(false);
     }
     if (!lhs->IsUnknownDtype() && rhs->IsUnknownDtype()) {
@@ -1021,10 +1023,10 @@ class TypeLCAFinder : public TypeFunctor<Type(const Type&, const Type&)> {
     if (rhs == nullptr) return AnyType(lhs->span);
 
     // find the target dtype, ndim, and vdevice.
-    ffi::Optional<PrimType> dtype =
-        (!lhs->IsUnknownDtype() && !rhs->IsUnknownDtype() && lhs->GetDtype() == rhs->GetDtype())
-            ? ffi::Optional<PrimType>(lhs->GetDtype())
-            : std::nullopt;
+    ffi::Optional<PrimType> dtype = (!lhs->IsUnknownDtype() && !rhs->IsUnknownDtype() &&
+                                     lhs->dtype.value() == rhs->dtype.value())
+                                        ? ffi::Optional<PrimType>(lhs->dtype.value())
+                                        : std::nullopt;
     int ndim = lhs->ndim == rhs->ndim ? lhs->ndim : kUnknownNDim;
     VDevice vdev = VDevice();
     if (lhs->vdevice.defined() && rhs->vdevice.defined() &&

--- a/src/relax/backend/contrib/codegen_c/codegen_c.h
+++ b/src/relax/backend/contrib/codegen_c/codegen_c.h
@@ -347,7 +347,7 @@ class CodegenCBase {
    */
   std::string GetDtypeString(const TensorTypeNode* tensor_ty) {
     std::string dtype;
-    DLDataType raw_dtype = tensor_ty->dtype->dtype;
+    DLDataType raw_dtype = tensor_ty->GetDtypeRaw();
     if (raw_dtype == DLDataType{kDLFloat, 32, 1}) {
       dtype = "float";
     } else if (raw_dtype == DLDataType{kDLFloat, 16, 1}) {

--- a/src/relax/backend/contrib/codegen_c/codegen_c.h
+++ b/src/relax/backend/contrib/codegen_c/codegen_c.h
@@ -347,7 +347,7 @@ class CodegenCBase {
    */
   std::string GetDtypeString(const TensorTypeNode* tensor_ty) {
     std::string dtype;
-    DLDataType raw_dtype = tensor_ty->GetDtypeRaw();
+    DLDataType raw_dtype = tensor_ty->dtype.value()->dtype;
     if (raw_dtype == DLDataType{kDLFloat, 32, 1}) {
       dtype = "float";
     } else if (raw_dtype == DLDataType{kDLFloat, 16, 1}) {

--- a/src/relax/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relax/backend/contrib/codegen_json/codegen_json.h
@@ -282,7 +282,7 @@ class JSONSerializer : public relax::MemoizedExprTranslator<NodeEntries> {
         ShapeExpr output_shape = tensor_ty->shape.value().as_or_throw<ShapeExpr>();
         ret.push_back(JSONGraphNodeEntry(node_id, i));
         shape.emplace_back(GetIntShape(output_shape->values));
-        dtype.emplace_back(DType2String(tensor_ty->GetDtypeRaw()));
+        dtype.emplace_back(DType2String(tensor_ty->dtype.value()->dtype));
       }
       node->SetNumOutput(tuple_ty->fields.size());
     } else {
@@ -292,7 +292,7 @@ class JSONSerializer : public relax::MemoizedExprTranslator<NodeEntries> {
       ShapeExpr output_shape = tensor_ty->shape.value().as_or_throw<ShapeExpr>();
 
       shape.emplace_back(GetIntShape(output_shape->values));
-      dtype.emplace_back(DType2String(tensor_ty->GetDtypeRaw()));
+      dtype.emplace_back(DType2String(tensor_ty->dtype.value()->dtype));
       ret.push_back(JSONGraphNodeEntry(node_id, 0));
     }
     node->SetShape(shape);

--- a/src/relax/backend/contrib/codegen_json/codegen_json.h
+++ b/src/relax/backend/contrib/codegen_json/codegen_json.h
@@ -282,7 +282,7 @@ class JSONSerializer : public relax::MemoizedExprTranslator<NodeEntries> {
         ShapeExpr output_shape = tensor_ty->shape.value().as_or_throw<ShapeExpr>();
         ret.push_back(JSONGraphNodeEntry(node_id, i));
         shape.emplace_back(GetIntShape(output_shape->values));
-        dtype.emplace_back(DType2String(tensor_ty->dtype->dtype));
+        dtype.emplace_back(DType2String(tensor_ty->GetDtypeRaw()));
       }
       node->SetNumOutput(tuple_ty->fields.size());
     } else {
@@ -292,7 +292,7 @@ class JSONSerializer : public relax::MemoizedExprTranslator<NodeEntries> {
       ShapeExpr output_shape = tensor_ty->shape.value().as_or_throw<ShapeExpr>();
 
       shape.emplace_back(GetIntShape(output_shape->values));
-      dtype.emplace_back(DType2String(tensor_ty->dtype->dtype));
+      dtype.emplace_back(DType2String(tensor_ty->GetDtypeRaw()));
       ret.push_back(JSONGraphNodeEntry(node_id, 0));
     }
     node->SetShape(shape);

--- a/src/relax/backend/contrib/cutlass/codegen.cc
+++ b/src/relax/backend/contrib/cutlass/codegen.cc
@@ -167,7 +167,7 @@ class CodegenCutlass : public relax::MemoizedExprTranslator<OutputType>,
     for (const auto& arg : ext_func_args_) {
       auto ty = GetType(arg);
       if (const auto* tensor_ty = ty.as<TensorTypeNode>()) {
-        arg_types.emplace_back(backend::DType2String(tensor_ty->dtype->dtype));
+        arg_types.emplace_back(backend::DType2String(tensor_ty->GetDtypeRaw()));
       } else if (const auto* shape_ty = ty.as<ShapeTypeNode>()) {
         arg_types.emplace_back(backend::DType2String(shape_ty->values.value()[0].ty()->dtype));
       } else {
@@ -302,7 +302,7 @@ class CodegenCutlass : public relax::MemoizedExprTranslator<OutputType>,
 
     std::vector<std::string> out_types;
     if (const auto* tensor_ty = ty.as<TensorTypeNode>()) {
-      out_types.emplace_back(backend::DType2String(tensor_ty->dtype->dtype));
+      out_types.emplace_back(backend::DType2String(tensor_ty->GetDtypeRaw()));
     } else {
       TVM_FFI_THROW(InternalError) << "Unimplemented ty type: " << ty;
     }

--- a/src/relax/backend/contrib/cutlass/codegen.cc
+++ b/src/relax/backend/contrib/cutlass/codegen.cc
@@ -167,7 +167,7 @@ class CodegenCutlass : public relax::MemoizedExprTranslator<OutputType>,
     for (const auto& arg : ext_func_args_) {
       auto ty = GetType(arg);
       if (const auto* tensor_ty = ty.as<TensorTypeNode>()) {
-        arg_types.emplace_back(backend::DType2String(tensor_ty->GetDtypeRaw()));
+        arg_types.emplace_back(backend::DType2String(tensor_ty->dtype.value()->dtype));
       } else if (const auto* shape_ty = ty.as<ShapeTypeNode>()) {
         arg_types.emplace_back(backend::DType2String(shape_ty->values.value()[0].ty()->dtype));
       } else {
@@ -302,7 +302,7 @@ class CodegenCutlass : public relax::MemoizedExprTranslator<OutputType>,
 
     std::vector<std::string> out_types;
     if (const auto* tensor_ty = ty.as<TensorTypeNode>()) {
-      out_types.emplace_back(backend::DType2String(tensor_ty->GetDtypeRaw()));
+      out_types.emplace_back(backend::DType2String(tensor_ty->dtype.value()->dtype));
     } else {
       TVM_FFI_THROW(InternalError) << "Unimplemented ty type: " << ty;
     }

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -682,7 +682,7 @@ class VMShapeLowerMutator
     if (always_check || !IsBaseOf(TensorType(op->dtype, op->ndim), GetType(value))) {
       // check_tensor_info(value, ndim, dtype, err_ctx)
       Expr dtype_arg = op->IsUnknownDtype() ? Expr(Call(null_value_op_, {}))
-                                            : Expr(DataTypeImm(op->GetDtypeRaw()));
+                                            : Expr(DataTypeImm(op->dtype.value()->dtype));
       Call call(builtin_check_tensor_info_,
                 {value, IntImm::Int64(op->ndim), dtype_arg, GetErrContext(err_ctx)}, Attrs(),
                 {void_ty_});

--- a/src/relax/backend/vm/vm_shape_lower.cc
+++ b/src/relax/backend/vm/vm_shape_lower.cc
@@ -679,12 +679,13 @@ class VMShapeLowerMutator
       // if we only check dynamic shapes, and the shape is static, we can skip.
       return;
     }
-    if (always_check || !IsBaseOf(TensorType(PrimType(op->dtype), op->ndim), GetType(value))) {
+    if (always_check || !IsBaseOf(TensorType(op->dtype, op->ndim), GetType(value))) {
       // check_tensor_info(value, ndim, dtype, err_ctx)
-      Call call(
-          builtin_check_tensor_info_,
-          {value, IntImm::Int64(op->ndim), DataTypeImm(op->dtype->dtype), GetErrContext(err_ctx)},
-          Attrs(), {void_ty_});
+      Expr dtype_arg = op->IsUnknownDtype() ? Expr(Call(null_value_op_, {}))
+                                            : Expr(DataTypeImm(op->GetDtypeRaw()));
+      Call call(builtin_check_tensor_info_,
+                {value, IntImm::Int64(op->ndim), dtype_arg, GetErrContext(err_ctx)}, Attrs(),
+                {void_ty_});
       builder_->Emit(call, "_");
     }
 

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -573,7 +573,7 @@ bool DFPatternMatcher::VisitDFPattern_(const DataTypePatternNode* op, const Expr
   // no need to jump, as var.dtype == value.dtype
   auto expr_ty = expr.as<ExprNode>()->ty;
   if (const TensorTypeNode* tensor_ty = expr_ty.as<TensorTypeNode>()) {
-    return op->dtype == tensor_ty->GetDtypeRaw() && VisitDFPattern(op->pattern, expr);
+    return op->dtype == tensor_ty->dtype.value()->dtype && VisitDFPattern(op->pattern, expr);
   }
   return false;
 }

--- a/src/relax/ir/dataflow_matcher.cc
+++ b/src/relax/ir/dataflow_matcher.cc
@@ -573,7 +573,7 @@ bool DFPatternMatcher::VisitDFPattern_(const DataTypePatternNode* op, const Expr
   // no need to jump, as var.dtype == value.dtype
   auto expr_ty = expr.as<ExprNode>()->ty;
   if (const TensorTypeNode* tensor_ty = expr_ty.as<TensorTypeNode>()) {
-    return op->dtype == tensor_ty->dtype->dtype && VisitDFPattern(op->pattern, expr);
+    return op->dtype == tensor_ty->GetDtypeRaw() && VisitDFPattern(op->pattern, expr);
   }
   return false;
 }

--- a/src/relax/ir/dependent_type.cc
+++ b/src/relax/ir/dependent_type.cc
@@ -88,7 +88,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 }
 
 // Tensor
-TensorType::TensorType(Expr shape, PrimType dtype, ffi::Optional<VDevice> vdevice, Span span) {
+TensorType::TensorType(Expr shape, ffi::Optional<PrimType> dtype, ffi::Optional<VDevice> vdevice,
+                       Span span) {
   ffi::ObjectPtr<TensorTypeNode> n = ffi::make_object<TensorTypeNode>();
   // assign ndim before move
   TVM_FFI_ICHECK(shape.defined()) << "Must provide a shape in this constructor";
@@ -105,7 +106,8 @@ TensorType::TensorType(Expr shape, PrimType dtype, ffi::Optional<VDevice> vdevic
   data_ = std::move(n);
 }
 
-TensorType::TensorType(PrimType dtype, int ndim, ffi::Optional<VDevice> vdevice, Span span) {
+TensorType::TensorType(ffi::Optional<PrimType> dtype, int ndim, ffi::Optional<VDevice> vdevice,
+                       Span span) {
   ffi::ObjectPtr<TensorTypeNode> n = ffi::make_object<TensorTypeNode>();
   TVM_FFI_ICHECK(ndim >= -1) << "ndim of TensorType must be >= -1, but got " << ndim;
   n->ndim = ndim;
@@ -120,12 +122,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::GlobalDef().def(
       "relax.TensorType", [](ffi::Optional<Expr> shape, ffi::Optional<PrimType> dtype, int ndim,
                              VDevice vdevice, Span span) {
-        PrimType resolved_dtype = dtype.value_or(PrimType(DLDataType{kDLOpaqueHandle, 0, 0}));
         if (shape.defined()) {
           TVM_FFI_CHECK_EQ(ndim, kUnknownNDim, ValueError) << "Cannot both specify shape and ndim";
-          return TensorType(shape.value(), resolved_dtype, vdevice, span);
+          return TensorType(shape.value(), dtype, vdevice, span);
         } else {
-          return TensorType(resolved_dtype, ndim, vdevice, span);
+          return TensorType(dtype, ndim, vdevice, span);
         }
       });
 }

--- a/src/relax/ir/emit_te.cc
+++ b/src/relax/ir/emit_te.cc
@@ -64,7 +64,7 @@ te::Tensor TETensor(Expr value, ffi::Map<tirx::Var, PrimExpr> tir_var_map, std::
       << "to constrain the shape before passing into te_tensor";
   n->shape = shape_expr->values.Map(
       [&tir_var_map](const PrimExpr& e) { return tirx::Substitute(e, tir_var_map); });
-  n->dtype = tensor_ty->GetDtype();
+  n->dtype = tensor_ty->dtype.value();
   return te::PlaceholderOp(n).output(0);
 }
 

--- a/src/relax/ir/emit_te.cc
+++ b/src/relax/ir/emit_te.cc
@@ -64,7 +64,7 @@ te::Tensor TETensor(Expr value, ffi::Map<tirx::Var, PrimExpr> tir_var_map, std::
       << "to constrain the shape before passing into te_tensor";
   n->shape = shape_expr->values.Map(
       [&tir_var_map](const PrimExpr& e) { return tirx::Substitute(e, tir_var_map); });
-  n->dtype = tensor_ty->dtype;
+  n->dtype = tensor_ty->GetDtype();
   return te::PlaceholderOp(n).output(0);
 }
 

--- a/src/relax/op/ccl/ccl.cc
+++ b/src/relax/op/ccl/ccl.cc
@@ -85,7 +85,7 @@ Type InferTypeAllGather(const Call& call, const BlockBuilder& ctx) {
   const auto* attrs = call->attrs.as<AllGatherAttrs>();
   int num_workers = attrs->num_workers;
 
-  PrimType output_dtype = input_ty->dtype;
+  ffi::Optional<PrimType> output_dtype = input_ty->dtype;
   auto input_shape = input_ty->GetShape();
   if (!input_shape.defined()) {
     return input_ty;
@@ -143,7 +143,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
 Type InferTypeScatter(const Call& call, const BlockBuilder& ctx) {
   TensorType input_ty = GetUnaryInputTensorType(call, ctx);
-  PrimType output_dtype = input_ty->dtype;
+  ffi::Optional<PrimType> output_dtype = input_ty->dtype;
 
   const auto* attrs = call->attrs.as<ScatterCollectiveAttrs>();
   int num_workers = attrs->num_workers;

--- a/src/relax/op/distributed/binary.h
+++ b/src/relax/op/distributed/binary.h
@@ -42,7 +42,7 @@ Type InferDistTypeBroadcast(const Call& call, const BlockBuilder& ctx, FType f_c
   TensorType x2_ty = input_dtensor_tys[1]->tensor_ty;
 
   // Dtype
-  PrimType output_dtype = f_compute_out_dtype(call, ctx, x1_ty, x2_ty);
+  ffi::Optional<PrimType> output_dtype = f_compute_out_dtype(call, ctx, x1_ty, x2_ty);
 
   // ndims
   TVM_FFI_ICHECK(!x1_ty->IsUnknownNdim() && !x2_ty->IsUnknownNdim())

--- a/src/relax/op/distributed/distributed.cc
+++ b/src/relax/op/distributed/distributed.cc
@@ -154,7 +154,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
 Type InferTypeRtoS(const Call& call, const BlockBuilder& ctx) {
   TensorType input_ty = GetUnaryInputTensorType(call, ctx);
-  PrimType output_dtype = input_ty->dtype;
+  ffi::Optional<PrimType> output_dtype = input_ty->dtype;
 
   const auto* attrs = call->attrs.as<ScatterCollectiveAttrs>();
   int num_workers = attrs->num_workers;

--- a/src/relax/op/distributed/linear_algebra.cc
+++ b/src/relax/op/distributed/linear_algebra.cc
@@ -32,9 +32,9 @@ Type InferDistTypeMatmul(const Call& call, const BlockBuilder& ctx) {
   TensorType x2_ty = input_dtensor_tys[1]->tensor_ty;
 
   const auto* attrs = call->attrs.as<MatmulAttrs>();
-  PrimType out_dtype = attrs->out_dtype == DLDataType{kDLOpaqueHandle, 0, 0}
-                           ? InferBinaryArithOpOutDtype(call, ctx, x1_ty, x2_ty)
-                           : PrimType(attrs->out_dtype);
+  ffi::Optional<PrimType> out_dtype = attrs->out_dtype.has_value()
+                                          ? PrimType(attrs->out_dtype.value())
+                                          : InferBinaryArithOpOutDtype(call, ctx, x1_ty, x2_ty);
 
   if (x1_ty->IsUnknownNdim() || x2_ty->IsUnknownNdim()) {
     TVM_FFI_VISIT_THROW(ValueError, call)

--- a/src/relax/op/distributed/nn.cc
+++ b/src/relax/op/distributed/nn.cc
@@ -33,9 +33,9 @@ Type InferDistTypeSoftmax(const Call& call, const BlockBuilder& ctx) {
   if (input_tensor_ty->IsUnknownNdim()) {
     TVM_FFI_VISIT_THROW(ValueError, call) << "Input of distributed operator must have known ndim";
   }
-  PrimType input_dtype = input_tensor_ty->dtype;
   // Softmax validation preserves the old float-kind check; lanes do not affect this policy.
-  if (!input_tensor_ty->IsUnknownDtype() && !input_dtype.MatchesCode(DLDataTypeCode::kDLFloat)) {
+  if (!input_tensor_ty->IsUnknownDtype() &&
+      !input_tensor_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call) << "Softmax requires the input tensor to have float "
                                             "dtype. However, the given input dtype is "
                                          << input_tensor_ty->dtype;

--- a/src/relax/op/distributed/nn.cc
+++ b/src/relax/op/distributed/nn.cc
@@ -35,7 +35,7 @@ Type InferDistTypeSoftmax(const Call& call, const BlockBuilder& ctx) {
   }
   // Softmax validation preserves the old float-kind check; lanes do not affect this policy.
   if (!input_tensor_ty->IsUnknownDtype() &&
-      !input_tensor_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat)) {
+      !input_tensor_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLFloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call) << "Softmax requires the input tensor to have float "
                                             "dtype. However, the given input dtype is "
                                          << input_tensor_ty->dtype;

--- a/src/relax/op/distributed/unary.h
+++ b/src/relax/op/distributed/unary.h
@@ -40,17 +40,16 @@ Type InferDistTypeUnary(const Call& call, const BlockBuilder& ctx, FType f_compu
   distributed::DTensorType input_dtensor_ty = input_dtensor_tys[0];
   TensorType input_tensor_ty = input_dtensor_ty->tensor_ty;
 
-  PrimType input_dtype = input_tensor_ty->dtype;
   // Unary op validation preserves the old float-kind check; lanes do not affect this policy.
   if (require_float_dtype && !input_tensor_ty->IsUnknownDtype() &&
-      !input_dtype.MatchesCode(DLDataTypeCode::kDLFloat)) {
+      !input_tensor_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << call->op
         << " requires the input tensor to have float dtype. However, the given input dtype is "
         << input_tensor_ty->dtype;
   }
   auto output_ty = ffi::make_object<TensorTypeNode>(*input_tensor_ty.get());
-  PrimType computed_dtype = f_compute_out_dtype(input_tensor_ty);
+  ffi::Optional<PrimType> computed_dtype = f_compute_out_dtype(input_tensor_ty);
   output_ty->dtype = computed_dtype;
   TensorType out_tensor_ty(output_ty);
   return distributed::DTensorType(out_tensor_ty, input_dtensor_ty->device_mesh,

--- a/src/relax/op/distributed/unary.h
+++ b/src/relax/op/distributed/unary.h
@@ -42,7 +42,7 @@ Type InferDistTypeUnary(const Call& call, const BlockBuilder& ctx, FType f_compu
 
   // Unary op validation preserves the old float-kind check; lanes do not affect this policy.
   if (require_float_dtype && !input_tensor_ty->IsUnknownDtype() &&
-      !input_tensor_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat)) {
+      !input_tensor_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLFloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << call->op
         << " requires the input tensor to have float dtype. However, the given input dtype is "

--- a/src/relax/op/image/resize.cc
+++ b/src/relax/op/image/resize.cc
@@ -51,7 +51,7 @@ Expr resize2d(Expr data, Expr size, ffi::Array<FloatImm> roi, ffi::String layout
   attrs->cubic_alpha = cubic_alpha;
   attrs->cubic_exclude = cubic_exclude;
   attrs->extrapolation_value = extrapolation_value;
-  attrs->out_dtype = out_dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->out_dtype = out_dtype;
 
   static const Op& op = Op::Get("relax.image.resize2d");
   return Call(op, {std::move(data), std::move(size)}, Attrs(attrs), {});
@@ -93,9 +93,9 @@ Type InferTypeResize2D(const Call& call, const BlockBuilder& ctx) {
                                                     /*tgt_layout=*/"NCHW",     //
                                                     /*tensor_name=*/"data");
 
-  PrimType out_dtype = attrs->out_dtype == DLDataType{kDLOpaqueHandle, 0, 0}
-                           ? data_ty->dtype
-                           : PrimType(attrs->out_dtype);
+  ffi::Optional<PrimType> out_dtype =
+      attrs->out_dtype.has_value() ? ffi::Optional<PrimType>(PrimType(attrs->out_dtype.value()))
+                                   : data_ty->dtype;
 
   ffi::Optional<ShapeExpr> data_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, ffi::GetRef<TensorType>(data_ty), data_layout);
@@ -167,7 +167,7 @@ Expr resize3d(Expr data, Expr size, ffi::Array<FloatImm> roi, ffi::String layout
   attrs->cubic_alpha = cubic_alpha;
   attrs->cubic_exclude = cubic_exclude;
   attrs->extrapolation_value = extrapolation_value;
-  attrs->out_dtype = out_dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->out_dtype = out_dtype;
 
   static const Op& op = Op::Get("relax.image.resize3d");
   return Call(op, {std::move(data), std::move(size)}, Attrs(attrs), {});
@@ -209,9 +209,9 @@ Type InferTypeResize3D(const Call& call, const BlockBuilder& ctx) {
                                                      /*tgt_layout=*/"NCDHW",    //
                                                      /*tensor_name=*/"data");
 
-  PrimType out_dtype = attrs->out_dtype == DLDataType{kDLOpaqueHandle, 0, 0}
-                           ? data_ty->dtype
-                           : PrimType(attrs->out_dtype);
+  ffi::Optional<PrimType> out_dtype =
+      attrs->out_dtype.has_value() ? ffi::Optional<PrimType>(PrimType(attrs->out_dtype.value()))
+                                   : data_ty->dtype;
 
   ffi::Optional<ShapeExpr> data_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, ffi::GetRef<TensorType>(data_ty), data_layout);
@@ -319,7 +319,7 @@ Type InferTypeGridSample(const Call& call, const BlockBuilder& ctx) {
                                                    /*tgt_layout=*/is_ncdhw ? "NCDHW" : "NCHW",
                                                    /*tensor_name=*/"data");
 
-  PrimType out_dtype = data_ty->dtype;
+  ffi::Optional<PrimType> out_dtype = data_ty->dtype;
 
   ffi::Optional<ShapeExpr> data_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, ffi::GetRef<TensorType>(data_ty), data_layout);
@@ -426,7 +426,7 @@ Type InferTypeAffineGrid(const Call& call, const BlockBuilder& ctx) {
     }
   }
 
-  PrimType out_dtype = data_ty->dtype;
+  ffi::Optional<PrimType> out_dtype = data_ty->dtype;
 
   if (data_shape == nullptr || size_value == nullptr) {
     return TensorType(out_dtype, /*ndim=*/4, data_ty->vdevice);

--- a/src/relax/op/memory/view.cc
+++ b/src/relax/op/memory/view.cc
@@ -124,6 +124,10 @@ Type InferTypeView(const Call& call, const BlockBuilder& ctx) {
     // in this case.
     if (auto dtype_imm = arg_value.as<DataTypeImmNode>()) {
       // We know the datatype for the view.
+      TVM_FFI_CHECK(!PrimType(dtype_imm->value).IsVoid(), TypeError)
+          << "Operator " << call->op
+          << " expects the dtype argument to be a concrete tensor datatype, "
+          << "but received void.  Use relax.null_value() if no dtype change is requested.";
       return PrimType(dtype_imm->value);
     } else if (ty.as<AnyTypeNode>()) {
       // The view changes the datatype, but we don't know what it is

--- a/src/relax/op/memory/view.cc
+++ b/src/relax/op/memory/view.cc
@@ -210,7 +210,7 @@ Type InferTypeView(const Call& call, const BlockBuilder& ctx) {
   ffi::Optional<PrimExpr> output_nelements = get_num_elements(output_shape);
 
   ffi::Optional<IntImm> input_element_size =
-      data_ty->dtype.defined() ? get_size_bytes(data_ty->GetDtypeRaw()) : std::nullopt;
+      data_ty->dtype.defined() ? get_size_bytes(data_ty->dtype.value()->dtype) : std::nullopt;
   ffi::Optional<IntImm> output_element_size =
       output_dtype.defined() ? get_size_bytes(output_dtype.value()->dtype) : std::nullopt;
 
@@ -366,7 +366,7 @@ Expr LowerBuiltinView(const BlockBuilder& bb, const Call& call) {
         << "or the input dtype is known.  "
         << "However, in expression " << call << ", no output dtype is specified, "
         << "and the input " << data << " of type " << data->ty << " has unknown dtype.";
-    dtype = relax::DataTypeImm(data_tensor_ty->GetDtypeRaw());
+    dtype = relax::DataTypeImm(data_tensor_ty->dtype.value()->dtype);
   }
 
   if (HasVoidType(relative_byte_offset)) {

--- a/src/relax/op/memory/view.cc
+++ b/src/relax/op/memory/view.cc
@@ -87,7 +87,8 @@ Type InferTypeView(const Call& call, const BlockBuilder& ctx) {
     }
   }();
 
-  auto view_dtype = [&]() -> std::optional<DLDataType> {
+  bool view_dtype_arg_present = false;
+  auto view_dtype = [&]() -> ffi::Optional<PrimType> {
     Type ty = GetType(arg_dtype);
 
     if (HasVoidType(arg_dtype)) {
@@ -105,6 +106,17 @@ Type InferTypeView(const Call& call, const BlockBuilder& ctx) {
       }
     }
 
+    static const Op& null_value_op = Op::Get("relax.null_value");
+    if (const CallNode* call_node = arg_value.as<CallNode>()) {
+      if (call_node->op.same_as(null_value_op)) {
+        // No datatype change is applied.  This is the non-void
+        // representation used for missing optional dtype arguments.
+        return std::nullopt;
+      }
+    }
+
+    view_dtype_arg_present = true;
+
     // In general, Type inference should only depend on the
     // Type of the arguments, and not on the arguments
     // themselves.  However, `relax::DataTypeImm` uses
@@ -112,11 +124,11 @@ Type InferTypeView(const Call& call, const BlockBuilder& ctx) {
     // in this case.
     if (auto dtype_imm = arg_value.as<DataTypeImmNode>()) {
       // We know the datatype for the view.
-      return dtype_imm->value;
+      return PrimType(dtype_imm->value);
     } else if (ty.as<AnyTypeNode>()) {
       // The view changes the datatype, but we don't know what it is
       // being changed into.
-      return DLDataType{kDLOpaqueHandle, 0, 0};
+      return std::nullopt;
     } else {
       TVM_FFI_THROW(TypeError) << "Operator " << call->op
                                << " expects the dtype argument to be a relax::DataTypeImm, "
@@ -167,8 +179,7 @@ Type InferTypeView(const Call& call, const BlockBuilder& ctx) {
     output_ndim = data_ty->ndim;
   }
 
-  DLDataType output_raw_dtype = view_dtype.value_or(data_ty->dtype->dtype);
-  PrimType output_dtype(output_raw_dtype);
+  ffi::Optional<PrimType> output_dtype = view_dtype_arg_present ? view_dtype : data_ty->dtype;
 
   // Helper function returns the number of bytes per vectorized element.
   auto get_size_bytes = [](DLDataType dtype) -> ffi::Optional<IntImm> {
@@ -198,8 +209,10 @@ Type InferTypeView(const Call& call, const BlockBuilder& ctx) {
   ffi::Optional<PrimExpr> input_nelements = get_num_elements(input_shape);
   ffi::Optional<PrimExpr> output_nelements = get_num_elements(output_shape);
 
-  ffi::Optional<IntImm> input_element_size = get_size_bytes(data_ty->dtype->dtype);
-  ffi::Optional<IntImm> output_element_size = get_size_bytes(output_raw_dtype);
+  ffi::Optional<IntImm> input_element_size =
+      data_ty->dtype.defined() ? get_size_bytes(data_ty->GetDtypeRaw()) : std::nullopt;
+  ffi::Optional<IntImm> output_element_size =
+      output_dtype.defined() ? get_size_bytes(output_dtype.value()->dtype) : std::nullopt;
 
   if (input_nelements && output_nelements && input_element_size && output_element_size &&
       view_relative_byte_offset) {
@@ -259,7 +272,7 @@ Type InferTypeView(const Call& call, const BlockBuilder& ctx) {
         << view_dtype.value() << ", increasing the size per element from " << input_element_size
         << " bytes to " << output_element_size << " bytes.  "
         << "Consider providing a new shape for the R.view.";
-  } else if (input_nelements && output_nelements && !view_dtype) {
+  } else if (input_nelements && output_nelements && !view_dtype_arg_present) {
     // The shape is being updated, while keeping the datatype the
     // same.  Even though we don't know the size of each element, we
     // know it must be the same for the input and output arrays.  An
@@ -306,7 +319,25 @@ Expr LowerBuiltinView(const BlockBuilder& bb, const Call& call) {
   Expr dtype = call->args[2];
   Expr relative_byte_offset = call->args[3];
 
-  if (HasVoidType(shape) && HasVoidType(dtype) && HasVoidType(relative_byte_offset)) {
+  auto is_null_value = [&bb](Expr arg) {
+    while (auto arg_var = arg.as<Var>()) {
+      if (auto bound_value = bb->LookupBinding(arg_var.value())) {
+        arg = bound_value.value();
+      } else {
+        break;
+      }
+    }
+
+    static const Op& null_value_op = Op::Get("relax.null_value");
+    if (const CallNode* call_node = arg.as<CallNode>()) {
+      return call_node->op.same_as(null_value_op);
+    }
+    return false;
+  };
+
+  bool dtype_is_unspecified = HasVoidType(dtype) || is_null_value(dtype);
+
+  if (HasVoidType(shape) && dtype_is_unspecified && HasVoidType(relative_byte_offset)) {
     // Special-case, no change is required by the view.
     return data;
   }
@@ -327,16 +358,15 @@ Expr LowerBuiltinView(const BlockBuilder& bb, const Call& call) {
     shape = ShapeExpr(data_shape.value());
   }
 
-  if (HasVoidType(dtype)) {
-    DLDataType data_dtype = data->ty.as<TensorType>().value()->dtype->dtype;
-    TVM_FFI_ICHECK(!(((data_dtype).code == kDLOpaqueHandle) && ((data_dtype).bits == 0) &&
-                     ((data_dtype).lanes == 0)))
+  if (dtype_is_unspecified) {
+    auto data_tensor_ty = data->ty.as<TensorType>().value();
+    TVM_FFI_ICHECK(!data_tensor_ty->IsUnknownDtype())
         << "Legalization of " << call->op
         << " requires that either the output dtype be explicitly specified, "
         << "or the input dtype is known.  "
         << "However, in expression " << call << ", no output dtype is specified, "
         << "and the input " << data << " of type " << data->ty << " has unknown dtype.";
-    dtype = relax::DataTypeImm(data_dtype);
+    dtype = relax::DataTypeImm(data_tensor_ty->GetDtypeRaw());
   }
 
   if (HasVoidType(relative_byte_offset)) {

--- a/src/relax/op/nn/convolution.cc
+++ b/src/relax/op/nn/convolution.cc
@@ -62,7 +62,7 @@ Expr conv1d(Expr data, Expr weight, ffi::Array<int64_t> strides, ffi::Array<int6
   return MakeConv<Conv1DAttrs>(std::move(data), std::move(weight), std::move(strides),
                                std::move(padding), std::move(dilation), groups, data_layout,
                                std::move(kernel_layout), out_layout.value_or(data_layout),
-                               out_dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0})),
+                               out_dtype,
                                /*op_name=*/"relax.nn.conv1d");
 }
 
@@ -92,9 +92,9 @@ Type InferTypeConv1d(const Call& call, const BlockBuilder& ctx) {
   ffi::Optional<ShapeExpr> weight_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, weight_ty, weight_layout);
 
-  PrimType out_dtype = attrs->out_dtype == DLDataType{kDLOpaqueHandle, 0, 0}
-                           ? InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty)
-                           : PrimType(attrs->out_dtype);
+  ffi::Optional<PrimType> out_dtype =
+      attrs->out_dtype.has_value() ? PrimType(attrs->out_dtype.value())
+                                   : InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty);
   ffi::Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, data_ty, weight_ty);
   if (!data_shape.defined() || !weight_shape.defined()) {
     return TensorType(out_dtype, out_layout.ndim(), vdevice);
@@ -232,7 +232,7 @@ Expr conv2d(Expr data, Expr weight, ffi::Array<int64_t> strides, ffi::Array<int6
   return MakeConv<Conv2DAttrs>(std::move(data), std::move(weight), std::move(strides),
                                std::move(padding), std::move(dilation), groups, data_layout,
                                std::move(kernel_layout), out_layout.value_or(data_layout),
-                               out_dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0})),
+                               out_dtype,
                                /*op_name=*/"relax.nn.conv2d");
 }
 
@@ -262,9 +262,9 @@ Type InferTypeConv2d(const Call& call, const BlockBuilder& ctx) {
   ffi::Optional<ShapeExpr> weight_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, weight_ty, weight_layout);
 
-  PrimType out_dtype = attrs->out_dtype == DLDataType{kDLOpaqueHandle, 0, 0}
-                           ? InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty)
-                           : PrimType(attrs->out_dtype);
+  ffi::Optional<PrimType> out_dtype =
+      attrs->out_dtype.has_value() ? PrimType(attrs->out_dtype.value())
+                                   : InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty);
   ffi::Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, data_ty, weight_ty);
   if (!data_shape.defined() || !weight_shape.defined()) {
     return TensorType(out_dtype, out_layout.ndim(), vdevice);
@@ -446,7 +446,7 @@ Expr conv3d(Expr data, Expr weight, ffi::Array<int64_t> strides, ffi::Array<int6
   return MakeConv<Conv3DAttrs>(std::move(data), std::move(weight), std::move(strides),
                                std::move(padding), std::move(dilation), groups, data_layout,
                                std::move(kernel_layout), out_layout.value_or(data_layout),
-                               out_dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0})),
+                               out_dtype,
                                /*op_name=*/"relax.nn.conv3d");
 }
 
@@ -476,9 +476,9 @@ Type InferTypeConv3d(const Call& call, const BlockBuilder& ctx) {
   ffi::Optional<ShapeExpr> weight_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, weight_ty, weight_layout);
 
-  PrimType out_dtype = attrs->out_dtype == DLDataType{kDLOpaqueHandle, 0, 0}
-                           ? InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty)
-                           : PrimType(attrs->out_dtype);
+  ffi::Optional<PrimType> out_dtype =
+      attrs->out_dtype.has_value() ? PrimType(attrs->out_dtype.value())
+                                   : InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty);
   ffi::Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, data_ty, weight_ty);
   if (!data_shape.defined() || !weight_shape.defined()) {
     return TensorType(out_dtype, out_layout.ndim(), vdevice);
@@ -634,7 +634,7 @@ Expr conv1d_transpose(Expr data, Expr weight, ffi::Array<int64_t> strides,
   attrs->data_layout = data_layout;
   attrs->kernel_layout = std::move(kernel_layout);
   attrs->out_layout = out_layout.value_or(data_layout);
-  attrs->out_dtype = out_dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->out_dtype = out_dtype;
   const Op& op = Op::Get("relax.nn.conv1d_transpose");
   return Call(op, {data, weight}, Attrs(attrs), {});
 }
@@ -664,9 +664,9 @@ Type InferTypeConv1dTranspose(const Call& call, const BlockBuilder& ctx) {
   ffi::Optional<ShapeExpr> weight_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, weight_ty, weight_layout);
 
-  PrimType out_dtype = attrs->out_dtype == DLDataType{kDLOpaqueHandle, 0, 0}
-                           ? InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty)
-                           : PrimType(attrs->out_dtype);
+  ffi::Optional<PrimType> out_dtype =
+      attrs->out_dtype.has_value() ? PrimType(attrs->out_dtype.value())
+                                   : InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty);
   ffi::Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, data_ty, weight_ty);
   if (!data_shape.defined() || !weight_shape.defined()) {
     return TensorType(out_dtype, out_layout.ndim(), vdevice);
@@ -825,7 +825,7 @@ Expr conv2d_transpose(Expr data, Expr weight, ffi::Array<int64_t> strides,
   attrs->data_layout = data_layout;
   attrs->kernel_layout = std::move(kernel_layout);
   attrs->out_layout = out_layout.value_or(data_layout);
-  attrs->out_dtype = out_dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->out_dtype = out_dtype;
   const Op& op = Op::Get("relax.nn.conv2d_transpose");
   return Call(op, {data, weight}, Attrs(attrs), {});
 }
@@ -856,9 +856,9 @@ Type InferTypeConv2dTranspose(const Call& call, const BlockBuilder& ctx) {
   ffi::Optional<ShapeExpr> weight_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, weight_ty, weight_layout);
 
-  PrimType out_dtype = attrs->out_dtype == DLDataType{kDLOpaqueHandle, 0, 0}
-                           ? InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty)
-                           : PrimType(attrs->out_dtype);
+  ffi::Optional<PrimType> out_dtype =
+      attrs->out_dtype.has_value() ? PrimType(attrs->out_dtype.value())
+                                   : InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty);
   ffi::Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, data_ty, weight_ty);
   if (!data_shape.defined() || !weight_shape.defined()) {
     return TensorType(out_dtype, out_layout.ndim(), vdevice);
@@ -1057,7 +1057,7 @@ Expr conv3d_transpose(Expr data, Expr weight, ffi::Array<int64_t> strides,
   attrs->data_layout = data_layout;
   attrs->kernel_layout = std::move(kernel_layout);
   attrs->out_layout = out_layout.value_or(data_layout);
-  attrs->out_dtype = out_dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->out_dtype = out_dtype;
   const Op& op = Op::Get("relax.nn.conv3d_transpose");
   return Call(op, {data, weight}, Attrs(attrs), {});
 }
@@ -1088,9 +1088,9 @@ Type InferTypeConv3dTranspose(const Call& call, const BlockBuilder& ctx) {
   ffi::Optional<ShapeExpr> weight_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, weight_ty, weight_layout);
 
-  PrimType out_dtype = attrs->out_dtype == DLDataType{kDLOpaqueHandle, 0, 0}
-                           ? InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty)
-                           : PrimType(attrs->out_dtype);
+  ffi::Optional<PrimType> out_dtype =
+      attrs->out_dtype.has_value() ? PrimType(attrs->out_dtype.value())
+                                   : InferBinaryArithOpOutDtype(call, ctx, data_ty, weight_ty);
   ffi::Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, data_ty, weight_ty);
   if (!data_shape.defined() || !weight_shape.defined()) {
     return TensorType(out_dtype, out_layout.ndim(), vdevice);

--- a/src/relax/op/nn/convolution.h
+++ b/src/relax/op/nn/convolution.h
@@ -39,7 +39,7 @@ template <typename T>
 inline Expr MakeConv(Expr data, Expr weight, ffi::Array<int64_t> strides,
                      ffi::Array<int64_t> padding, ffi::Array<int64_t> dilation, int groups,
                      ffi::String data_layout, ffi::String kernel_layout, ffi::String out_layout,
-                     DLDataType out_dtype, std::string op_name) {
+                     ffi::Optional<DLDataType> out_dtype, std::string op_name) {
   auto attrs = ffi::make_object<T>();
   attrs->strides = std::move(strides);
   attrs->padding = std::move(padding);

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -123,7 +123,7 @@ Type InferTypePRelu(const Call& call, const BlockBuilder& ctx) {
     return data_ty;
   }
   // PRelu preserves the old float-kind check; vector lanes are irrelevant to this check.
-  if (!data_ty->IsUnknownDtype() && !data_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat)) {
+  if (!data_ty->IsUnknownDtype() && !data_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLFloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call) << "Prelu requires the input tensor to have float "
                                             "dtype. However, the given input dtype is "
                                          << data_ty->dtype;
@@ -188,7 +188,7 @@ Type InferTypeSoftmax(const Call& call, const BlockBuilder& ctx) {
     return data_ty;
   }
   if (!data_ty->IsUnknownDtype()) {
-    PrimType data_dtype = data_ty->GetDtype();
+    PrimType data_dtype = data_ty->dtype.value();
     // Softmax only requires a floating element kind; lane encoding is irrelevant to the check.
     if (!data_dtype.MatchesCode(kDLFloat, kDLBfloat)) {
       TVM_FFI_VISIT_THROW(TypeError, call) << "Softmax requires the input tensor to have float "
@@ -386,7 +386,7 @@ bool NormCheckDtypeAndShape(const Call& call, const BlockBuilder& ctx,
   }
   int n_axis = axes.size();
   if (!data_ty->IsUnknownDtype()) {
-    PrimType data_dtype = data_ty->GetDtype();
+    PrimType data_dtype = data_ty->dtype.value();
     // Norm ops only require a floating element kind; lane encoding is irrelevant to the check.
     if (!data_dtype.MatchesCode(kDLFloat, kDLBfloat)) {
       TVM_FFI_VISIT_THROW(TypeError, call)
@@ -630,7 +630,7 @@ Type InferTypeGroupNorm(const Call& call, const BlockBuilder& ctx) {
     }
   }
   // GroupNorm preserves the old float-kind check; vector lanes are irrelevant to this check.
-  if (!data_ty->IsUnknownDtype() && !data_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat)) {
+  if (!data_ty->IsUnknownDtype() && !data_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLFloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << op << " expects that data must be float, but got " << data_ty->dtype;
   }
@@ -1023,7 +1023,7 @@ Type InferTypeNLLLoss(const Call& call, const BlockBuilder& ctx) {
 
   // the type of targets must be int/uint.
   if (!tgt_ty->IsUnknownDtype()) {
-    PrimType target_dtype = tgt_ty->GetDtype();
+    PrimType target_dtype = tgt_ty->dtype.value();
     // NLLLoss only needs the target element kind; vector lanes do not affect target indexing.
     if (!target_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
         !target_dtype.MatchesCode(DLDataTypeCode::kDLUInt)) {

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -122,9 +122,8 @@ Type InferTypePRelu(const Call& call, const BlockBuilder& ctx) {
   if (data_ty->IsUnknownNdim()) {
     return data_ty;
   }
-  PrimType data_dtype = data_ty->dtype;
   // PRelu preserves the old float-kind check; vector lanes are irrelevant to this check.
-  if (!data_ty->IsUnknownDtype() && !data_dtype.MatchesCode(DLDataTypeCode::kDLFloat)) {
+  if (!data_ty->IsUnknownDtype() && !data_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call) << "Prelu requires the input tensor to have float "
                                             "dtype. However, the given input dtype is "
                                          << data_ty->dtype;
@@ -189,7 +188,7 @@ Type InferTypeSoftmax(const Call& call, const BlockBuilder& ctx) {
     return data_ty;
   }
   if (!data_ty->IsUnknownDtype()) {
-    PrimType data_dtype = data_ty->dtype;
+    PrimType data_dtype = data_ty->GetDtype();
     // Softmax only requires a floating element kind; lane encoding is irrelevant to the check.
     if (!data_dtype.MatchesCode(kDLFloat, kDLBfloat)) {
       TVM_FFI_VISIT_THROW(TypeError, call) << "Softmax requires the input tensor to have float "
@@ -387,7 +386,7 @@ bool NormCheckDtypeAndShape(const Call& call, const BlockBuilder& ctx,
   }
   int n_axis = axes.size();
   if (!data_ty->IsUnknownDtype()) {
-    PrimType data_dtype = data_ty->dtype;
+    PrimType data_dtype = data_ty->GetDtype();
     // Norm ops only require a floating element kind; lane encoding is irrelevant to the check.
     if (!data_dtype.MatchesCode(kDLFloat, kDLBfloat)) {
       TVM_FFI_VISIT_THROW(TypeError, call)
@@ -472,7 +471,7 @@ Type InferTypeBatchNorm(const Call& call, const BlockBuilder& ctx) {
   const auto* attrs = call->attrs.as<BatchNormAttrs>();
   bool unknown_shape = NormCheckDtypeAndShape(call, ctx, input_ty, {attrs->axis});
 
-  PrimType dtype = input_ty[0]->dtype;
+  ffi::Optional<PrimType> dtype = input_ty[0]->dtype;
   if (unknown_shape) {
     auto vdev = input_ty[0]->vdevice;
     return TupleType({TensorType(dtype, input_ty[0]->ndim, vdev),
@@ -630,9 +629,8 @@ Type InferTypeGroupNorm(const Call& call, const BlockBuilder& ctx) {
           << channel_axis << ", axes: " << attrs->axes;
     }
   }
-  PrimType data_dtype = data_ty->dtype;
   // GroupNorm preserves the old float-kind check; vector lanes are irrelevant to this check.
-  if (!data_ty->IsUnknownDtype() && !data_dtype.MatchesCode(DLDataTypeCode::kDLFloat)) {
+  if (!data_ty->IsUnknownDtype() && !data_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << op << " expects that data must be float, but got " << data_ty->dtype;
   }
@@ -902,7 +900,7 @@ Type InferTypeCrossEntropy(const Call& call, const BlockBuilder& ctx) {
   TensorType label_ty = input_ty[1];
 
   // infer dtype
-  PrimType dtype = InferBinaryArithOpOutDtype(call, ctx, pred_ty, label_ty);
+  ffi::Optional<PrimType> dtype = InferBinaryArithOpOutDtype(call, ctx, pred_ty, label_ty);
 
   // infer vdevice
   ffi::Optional<VDevice> vdevice = InferBinaryArithOpOutVDevice(call, ctx, pred_ty, label_ty);
@@ -1014,7 +1012,7 @@ Type InferTypeNLLLoss(const Call& call, const BlockBuilder& ctx) {
   }
 
   // infer dtype, vdevice
-  PrimType output_dtype =
+  ffi::Optional<PrimType> output_dtype =
       wgt_ty != nullptr ? InferBinaryArithOpOutDtype(call, ctx, ffi::GetRef<TensorType>(pred_ty),
                                                      ffi::GetRef<TensorType>(wgt_ty))
                         : pred_ty->dtype;
@@ -1025,7 +1023,7 @@ Type InferTypeNLLLoss(const Call& call, const BlockBuilder& ctx) {
 
   // the type of targets must be int/uint.
   if (!tgt_ty->IsUnknownDtype()) {
-    PrimType target_dtype = tgt_ty->dtype;
+    PrimType target_dtype = tgt_ty->GetDtype();
     // NLLLoss only needs the target element kind; vector lanes do not affect target indexing.
     if (!target_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
         !target_dtype.MatchesCode(DLDataTypeCode::kDLUInt)) {

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -199,7 +199,7 @@ template <bool require_float_dtype, typename FType>
 inline Type InferTypeUnary(const Call& call, const BlockBuilder& ctx, FType f_compute_out_dtype) {
   TensorType input_ty = GetUnaryInputTensorType(call, ctx);
   if (require_float_dtype && !input_ty->IsUnknownDtype() &&
-      !input_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat, DLDataTypeCode::kDLBfloat)) {
+      !input_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLFloat, DLDataTypeCode::kDLBfloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << call->op
         << " requires the input tensor to have float dtype. However, the given input dtype is "

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -203,7 +203,7 @@ inline Type InferTypeUnary(const Call& call, const BlockBuilder& ctx, FType f_co
     TVM_FFI_VISIT_THROW(TypeError, call)
         << call->op
         << " requires the input tensor to have float dtype. However, the given input dtype is "
-        << input_ty->dtype;
+        << input_ty->dtype.value();
   }
   auto output_ty = ffi::make_object<TensorTypeNode>(*input_ty.get());
   ffi::Optional<PrimType> computed_dtype = f_compute_out_dtype(input_ty);

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -198,16 +198,15 @@ std::tuple<ArgTypes...> GetArgType(const Call& call, const BlockBuilder& ctx) {
 template <bool require_float_dtype, typename FType>
 inline Type InferTypeUnary(const Call& call, const BlockBuilder& ctx, FType f_compute_out_dtype) {
   TensorType input_ty = GetUnaryInputTensorType(call, ctx);
-  PrimType input_dtype = input_ty->dtype;
   if (require_float_dtype && !input_ty->IsUnknownDtype() &&
-      !input_dtype.MatchesCode(DLDataTypeCode::kDLFloat, DLDataTypeCode::kDLBfloat)) {
+      !input_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat, DLDataTypeCode::kDLBfloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << call->op
         << " requires the input tensor to have float dtype. However, the given input dtype is "
         << input_ty->dtype;
   }
   auto output_ty = ffi::make_object<TensorTypeNode>(*input_ty.get());
-  PrimType computed_dtype = f_compute_out_dtype(input_ty);
+  ffi::Optional<PrimType> computed_dtype = f_compute_out_dtype(input_ty);
   output_ty->dtype = computed_dtype;
   if (call->ty_args.size() > 0) {
     auto defined_ty = call->ty_args[0].as<TensorTypeNode>();
@@ -279,7 +278,11 @@ inline std::optional<PrimType> GetElementDType(const Type& ty) {
   if (const auto* prim = ty.as<PrimTypeNode>()) {
     return ffi::GetRef<PrimType>(prim);
   } else if (const auto* tensor = ty.as<TensorTypeNode>()) {
-    return tensor->dtype;
+    if (tensor->dtype.defined()) {
+      return tensor->dtype.value();
+    } else {
+      return std::nullopt;
+    }
   } else {
     return std::nullopt;
     TVM_FFI_THROW(TypeError) << "Only PrimType and TensorType "
@@ -297,10 +300,13 @@ inline std::optional<PrimType> GetElementDType(const Type& ty) {
  * \return The inferred output dtype.
  * \throw Throw exception if the dtype of two input TensorType don’t match
  */
-inline PrimType InferBinaryArithOpOutDtype(const Call& call, const BlockBuilder& ctx,
-                                           const Type& lhs_ty, const Type& rhs_ty) {
+inline ffi::Optional<PrimType> InferBinaryArithOpOutDtype(const Call& call, const BlockBuilder& ctx,
+                                                          const Type& lhs_ty, const Type& rhs_ty) {
   auto opt_lhs_dtype = GetElementDType(lhs_ty);
   if (!opt_lhs_dtype) {
+    if (const auto* lhs_tensor = lhs_ty.as<TensorTypeNode>()) {
+      if (lhs_tensor->IsUnknownDtype()) return std::nullopt;
+    }
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Binary operators must have the same datatype for both operands.  "
         << "However, " << call << " has argument " << call->args[0] << " on the LHS, with type "
@@ -311,6 +317,9 @@ inline PrimType InferBinaryArithOpOutDtype(const Call& call, const BlockBuilder&
 
   auto opt_rhs_dtype = GetElementDType(rhs_ty);
   if (!opt_rhs_dtype) {
+    if (const auto* rhs_tensor = rhs_ty.as<TensorTypeNode>()) {
+      if (rhs_tensor->IsUnknownDtype()) return std::nullopt;
+    }
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Binary operators must have the same datatype for both operands.  "
         << "However, " << call << " has argument " << call->args[1] << " on the RHS, with type "
@@ -319,10 +328,8 @@ inline PrimType InferBinaryArithOpOutDtype(const Call& call, const BlockBuilder&
   }
   auto rhs_dtype = opt_rhs_dtype.value();
 
-  if (lhs_dtype.IsVoid() || rhs_dtype.IsVoid()) {
-    return PrimType::Void();
-  } else if (lhs_dtype != rhs_dtype && !lhs_dtype.MatchesCode(DLDataTypeCode::kDLBool) &&
-             !rhs_dtype.MatchesCode(DLDataTypeCode::kDLBool)) {
+  if (lhs_dtype != rhs_dtype && !lhs_dtype.MatchesCode(DLDataTypeCode::kDLBool) &&
+      !rhs_dtype.MatchesCode(DLDataTypeCode::kDLBool)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Binary operators must have the same datatype for both operands.  "
         << "However, " << call << " uses datatype " << lhs_dtype << " on the LHS (Type of "

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -52,10 +52,11 @@ Type InferTypeBroadcast(const Call& call, const BlockBuilder& ctx, FType f_compu
       << "but expression " << call << " has RHS " << call->args[1] << ", which has Type " << rhs_ty;
 
   // Dtype
-  PrimType output_dtype = f_compute_out_dtype(call, ctx, lhs_ty, rhs_ty);
+  ffi::Optional<PrimType> output_dtype = f_compute_out_dtype(call, ctx, lhs_ty, rhs_ty);
 
   if (lhs_ty.as<PrimTypeNode>() && rhs_ty.as<PrimTypeNode>()) {
-    return output_dtype;
+    TVM_FFI_ICHECK(output_dtype.defined());
+    return output_dtype.value();
   }
 
   // VDevice

--- a/src/relax/op/tensor/create.cc
+++ b/src/relax/op/tensor/create.cc
@@ -59,7 +59,7 @@ Expr full(ffi::Variant<Expr, ffi::Array<PrimExpr>> shape, Expr fill_value,
   }
 
   ffi::ObjectPtr<InitAttrs> attrs = ffi::make_object<InitAttrs>();
-  attrs->dtype = dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->dtype = dtype;
 
   static const Op& op = Op::Get("relax.full");
   return Call(op, {std::move(shape_in_expr), std::move(fill_value)}, Attrs(attrs), {});
@@ -88,8 +88,9 @@ Type InferTypeFull(const Call& call, const BlockBuilder& ctx) {
   }
 
   const auto* attrs = call->attrs.as<InitAttrs>();
-  PrimType out_dtype = attrs->dtype == DLDataType{kDLOpaqueHandle, 0, 0} ? fill_value_ty->dtype
-                                                                         : PrimType(attrs->dtype);
+  ffi::Optional<PrimType> out_dtype = attrs->dtype.has_value()
+                                          ? ffi::Optional<PrimType>(PrimType(attrs->dtype.value()))
+                                          : fill_value_ty->dtype;
   return TensorType(/*shape=*/call->args[0], out_dtype, fill_value_ty->vdevice);
 }
 
@@ -107,7 +108,7 @@ TVM_REGISTER_OP("relax.full")
 /* relax.full_like */
 Expr full_like(Expr x, Expr fill_value, ffi::Optional<DLDataType> dtype) {
   ffi::ObjectPtr<InitAttrs> attrs = ffi::make_object<InitAttrs>();
-  attrs->dtype = dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->dtype = dtype;
   static const Op& op = Op::Get("relax.full_like");
   return Call(op, {std::move(x), std::move(fill_value)}, Attrs(attrs), {});
 }
@@ -128,11 +129,11 @@ Type InferTypeFullLike(const Call& call, const BlockBuilder& ctx) {
   }
 
   const auto* attrs = call->attrs.as<InitAttrs>();
-  if (attrs->dtype == DLDataType{kDLOpaqueHandle, 0, 0}) {
+  if (!attrs->dtype.has_value()) {
     return data_ty;
   } else {
     auto output_ty = ffi::make_object<TensorTypeNode>(*data_ty.get());
-    output_ty->dtype = PrimType(attrs->dtype);
+    output_ty->dtype = PrimType(attrs->dtype.value());
     return TensorType(output_ty);
   }
 }
@@ -159,18 +160,19 @@ Type InferTypeOnesZeros(const Call& call, const BlockBuilder& ctx) {
         << call->args[0]->ty->GetTypeKey();
   }
   const auto* attrs = call->attrs.as<InitAttrs>();
-  return TensorType(/*shape=*/call->args[0], PrimType(attrs->dtype));
+  TVM_FFI_ICHECK(attrs->dtype.has_value());
+  return TensorType(/*shape=*/call->args[0], PrimType(attrs->dtype.value()));
 }
 
 // Structure info inference for ones_like and zeros_like
 Type InferTypeOnesLikeZerosLike(const Call& call, const BlockBuilder& ctx) {
   TensorType data_ty = GetUnaryInputTensorType(call, ctx);
   const auto* attrs = call->attrs.as<InitAttrs>();
-  if (attrs->dtype == DLDataType{kDLOpaqueHandle, 0, 0}) {
+  if (!attrs->dtype.has_value()) {
     return data_ty;
   } else {
     auto output_ty = ffi::make_object<TensorTypeNode>(*data_ty.get());
-    output_ty->dtype = PrimType(attrs->dtype);
+    output_ty->dtype = PrimType(attrs->dtype.value());
     return TensorType(output_ty);
   }
 }
@@ -188,7 +190,7 @@ Expr ones(Expr shape, DLDataType dtype) {
 
 Expr ones_like(Expr x, ffi::Optional<DLDataType> dtype) {
   ffi::ObjectPtr<InitAttrs> attrs = ffi::make_object<InitAttrs>();
-  attrs->dtype = dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->dtype = dtype;
   static const Op& op = Op::Get("relax.ones_like");
   return Call(op, {std::move(x)}, Attrs(attrs), {});
 }
@@ -226,7 +228,7 @@ Expr zeros(Expr shape, DLDataType dtype) {
 
 Expr zeros_like(Expr x, ffi::Optional<DLDataType> dtype) {
   ffi::ObjectPtr<InitAttrs> attrs = ffi::make_object<InitAttrs>();
-  attrs->dtype = dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->dtype = dtype;
   static const Op& op = Op::Get("relax.zeros_like");
   return Call(op, {std::move(x)}, Attrs(attrs), {});
 }
@@ -261,7 +263,7 @@ Expr eye(PrimExpr n, PrimExpr m, PrimExpr k, DLDataType dtype) {
 
 Expr eye_like(Expr x, PrimExpr k, ffi::Optional<DLDataType> dtype) {
   ffi::ObjectPtr<InitAttrs> attrs = ffi::make_object<InitAttrs>();
-  attrs->dtype = dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->dtype = dtype;
   static const Op& op = Op::Get("relax.eye_like");
   return Call(op, {std::move(x), std::move(k)}, Attrs(attrs), {});
 }
@@ -288,7 +290,9 @@ Type InferTypeEye(const Call& call, const BlockBuilder& ctx) {
   PrimExpr n = get_prim_value(call->args[0], "n");
   PrimExpr m = get_prim_value(call->args[1], "m");
 
-  DLDataType dtype = call->attrs.as<InitAttrs>()->dtype;
+  const auto* attrs = call->attrs.as<InitAttrs>();
+  TVM_FFI_ICHECK(attrs->dtype.has_value());
+  DLDataType dtype = attrs->dtype.value();
   return TensorType(ShapeExpr({n, m}), PrimType(dtype));
 }
 
@@ -312,8 +316,9 @@ Type InferTypeEyeLike(const Call& call, const BlockBuilder& ctx) {
   }
 
   const auto* attrs = call->attrs.as<InitAttrs>();
-  PrimType out_dtype =
-      attrs->dtype == DLDataType{kDLOpaqueHandle, 0, 0} ? x_ty->dtype : PrimType(attrs->dtype);
+  ffi::Optional<PrimType> out_dtype = attrs->dtype.has_value()
+                                          ? ffi::Optional<PrimType>(PrimType(attrs->dtype.value()))
+                                          : x_ty->dtype;
 
   return TensorType(x_ty->shape.value(), out_dtype, x_ty->vdevice);
 }
@@ -366,7 +371,9 @@ Type InferTypeArange(const Call& call, const BlockBuilder& ctx) {
   PrimExpr start = get_prim_value(call->args[0], "start");
   PrimExpr end = get_prim_value(call->args[1], "end");
   PrimExpr step = get_prim_value(call->args[2], "step");
-  DLDataType dtype = call->attrs.as<InitAttrs>()->dtype;
+  const auto* attrs = call->attrs.as<InitAttrs>();
+  TVM_FFI_ICHECK(attrs->dtype.has_value());
+  DLDataType dtype = attrs->dtype.value();
   PrimExpr num_elem;
   if (start.ty().code() == DLDataTypeCode::kDLInt && end.ty().code() == DLDataTypeCode::kDLInt &&
       step.ty().code() == DLDataTypeCode::kDLInt) {
@@ -406,7 +413,9 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 }
 
 Type InferTypeHammingWindow(const Call& call, const BlockBuilder& ctx) {
-  DLDataType dtype = call->attrs.as<InitAttrs>()->dtype;
+  const auto* attrs = call->attrs.as<InitAttrs>();
+  TVM_FFI_ICHECK(attrs->dtype.has_value());
+  DLDataType dtype = attrs->dtype.value();
   if (dtype.code == DLDataTypeCode::kDLInt || dtype.code == DLDataTypeCode::kDLUInt) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Hamming Window expects the datatype to be float but got " << dtype;

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -85,7 +85,7 @@ Type InferTypeTake(const Call& call, const BlockBuilder& ctx) {
   if (indices_ty->IsUnknownDtype()) {
     LOG(WARNING) << "Data type of indices has not been specified. Assume it has an integer type.";
   } else {
-    PrimType indices_dtype = indices_ty->GetDtype();
+    PrimType indices_dtype = indices_ty->dtype.value();
     if (!indices_dtype.MatchesCode(DLDataTypeCode::kDLInt, DLDataTypeCode::kDLUInt)) {
       TVM_FFI_VISIT_THROW(TypeError, call)
           << "Take op requires the input indices to have integer dtype. However, the "

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -313,7 +313,7 @@ Type InferTypeStridedSlice(const Call& call, const BlockBuilder& ctx) {
     }
   }();
 
-  TVM_FFI_ICHECK(IsBaseOf(relax::TensorType(PrimType::Void(), kUnknownNDim), GetType(data)))
+  TVM_FFI_ICHECK(IsBaseOf(relax::TensorType(std::nullopt, kUnknownNDim), GetType(data)))
       << "Operator " << call->op << " requires the first argument to be a tensor.  "
       << "However, in expression " << call << ", the first argument " << data << " has type "
       << GetType(data);

--- a/src/relax/op/tensor/index.cc
+++ b/src/relax/op/tensor/index.cc
@@ -85,7 +85,7 @@ Type InferTypeTake(const Call& call, const BlockBuilder& ctx) {
   if (indices_ty->IsUnknownDtype()) {
     LOG(WARNING) << "Data type of indices has not been specified. Assume it has an integer type.";
   } else {
-    PrimType indices_dtype = indices_ty->dtype;
+    PrimType indices_dtype = indices_ty->GetDtype();
     if (!indices_dtype.MatchesCode(DLDataTypeCode::kDLInt, DLDataTypeCode::kDLUInt)) {
       TVM_FFI_VISIT_THROW(TypeError, call)
           << "Take op requires the input indices to have integer dtype. However, the "
@@ -350,7 +350,7 @@ Type InferTypeStridedSlice(const Call& call, const BlockBuilder& ctx) {
 
   const auto* data_ty = data->ty.as<TensorTypeNode>();
 
-  PrimType dtype(DLDataType{kDLOpaqueHandle, 0, 0});
+  ffi::Optional<PrimType> dtype = std::nullopt;
   ffi::Optional<VDevice> vdevice = std::nullopt;
   int ndim = kUnknownNDim;
   if (data_ty) {

--- a/src/relax/op/tensor/inspect.cc
+++ b/src/relax/op/tensor/inspect.cc
@@ -102,7 +102,7 @@ tirx::PrimFunc GetDLTensorField(tirx::builtin::TVMStructFieldKind field, PrimTyp
 
   tirx::PrimFunc func(ffi::Array<tirx::Var>{dlpack_handle}, body, field_ty, {}, attrs);
 
-  FuncType ty({TensorType(PrimType::Void(), kUnknownNDim)}, field_ty);
+  FuncType ty({TensorType(std::nullopt, kUnknownNDim)}, field_ty);
   func->ty = ty;
 
   return func;
@@ -282,7 +282,7 @@ Expr LegalizeTensorShape(const BlockBuilder& bb, const Call& call) {
 
     tirx::PrimFunc func({dlpack_handle, axis}, body, field_ty, {}, attrs);
 
-    FuncType ty({TensorType(PrimType::Void(), kUnknownNDim), axis.ty()}, field_ty);
+    FuncType ty({TensorType(std::nullopt, kUnknownNDim), axis.ty()}, field_ty);
     func->ty = ty;
     return func;
   }();

--- a/src/relax/op/tensor/linear_algebra.cc
+++ b/src/relax/op/tensor/linear_algebra.cc
@@ -44,7 +44,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
 Expr matmul(Expr x1, Expr x2, ffi::Optional<DLDataType> out_dtype) {
   ffi::ObjectPtr<MatmulAttrs> attrs = ffi::make_object<MatmulAttrs>();
-  attrs->out_dtype = out_dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->out_dtype = out_dtype;
 
   static const Op& op = Op::Get("relax.matmul");
   return Call(op, {std::move(x1), std::move(x2)}, Attrs(attrs), {});
@@ -74,9 +74,9 @@ Type InferTypeMatmul(const Call& call, const BlockBuilder& ctx) {
   }
 
   const auto* attrs = call->attrs.as<MatmulAttrs>();
-  PrimType out_dtype = attrs->out_dtype == DLDataType{kDLOpaqueHandle, 0, 0}
-                           ? InferBinaryArithOpOutDtype(call, ctx, x1_ty, x2_ty)
-                           : PrimType(attrs->out_dtype);
+  ffi::Optional<PrimType> out_dtype = attrs->out_dtype.has_value()
+                                          ? PrimType(attrs->out_dtype.value())
+                                          : InferBinaryArithOpOutDtype(call, ctx, x1_ty, x2_ty);
 
   if (x1_ty->IsUnknownNdim() || x2_ty->IsUnknownNdim()) {
     if (vdev.defined()) {
@@ -218,7 +218,7 @@ Type InferTypeEinsum(const Call& call, const BlockBuilder& ctx) {
 
   ffi::String subscripts = attrs->subscripts;
 
-  PrimType operand_ty = operands_tensor_ty[0]->dtype;
+  ffi::Optional<PrimType> operand_ty = operands_tensor_ty[0]->dtype;
   std::vector<ffi::Array<PrimExpr>> input_shapes;
   input_shapes.reserve(operands_tensor_ty.size());
 

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -580,9 +580,8 @@ Type InferTypeIndexTensor(const Call& call, const BlockBuilder& ctx) {
   // Indices must be integers
   for (int i = 0; i < n_indices; ++i) {
     const auto& s = indices_ty[i];
-    PrimType index_dtype = s->GetDtype();
     // Indexing only requires integer element kind; vector lanes do not affect shape inference.
-    if (!s->IsUnknownDtype() && index_dtype.code() != DLDataTypeCode::kDLInt) {
+    if (!s->IsUnknownDtype() && s->dtype.value().code() != DLDataTypeCode::kDLInt) {
       TVM_FFI_VISIT_THROW(TypeError, call)
           << "index_tensor requires every index tensor to have an integer dtype; "
           << "index " << i << " has dtype " << s->dtype;
@@ -2105,7 +2104,7 @@ Type InferTypeReverseSequence(const Call& call, const BlockBuilder& ctx) {
   }
   ffi::Optional<PrimType> seq_lengths_dtype = seq_lengths_ty->dtype;
   if (!seq_lengths_ty->IsUnknownDtype() &&
-      !seq_lengths_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLInt)) {
+      !seq_lengths_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLInt)) {
     TVM_FFI_VISIT_THROW(ValueError, call)
         << "ReverseSequence requires seq_lengths to have dtype int32 or int64. However, "
            "seq_lengths has dtype "
@@ -2199,9 +2198,8 @@ Type InferTypeGatherElements(const Call& call, const BlockBuilder& ctx) {
         << call->args[1]->ty->GetTypeKey();
   }
 
-  ffi::Optional<PrimType> indices_dtype = indices_ty->dtype;
   // Gather indices only require integer element kind; vector lanes do not affect shape inference.
-  if (!indices_ty->IsUnknownDtype() && indices_ty->GetDtype().code() != DLDataTypeCode::kDLInt) {
+  if (!indices_ty->IsUnknownDtype() && indices_ty->dtype.value().code() != DLDataTypeCode::kDLInt) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "GatherElements requires the input indices to have int64 dtype. However, the "
         << "given indices dtype is " << indices_ty->dtype;
@@ -2440,7 +2438,7 @@ Type InferTypeIndexPut(const Call& call, const BlockBuilder& ctx) {
       LOG(WARNING) << "Data type of index tensor " << i
                    << " has not been specified. Assume it has an integer type.";
     } else {
-      PrimType index_dtype = tensor_ty->GetDtype();
+      PrimType index_dtype = tensor_ty->dtype.value();
       if (!index_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
           !index_dtype.MatchesCode(DLDataTypeCode::kDLUInt)) {
         TVM_FFI_VISIT_THROW(TypeError, call)
@@ -2697,7 +2695,7 @@ Type InferTypeScatterElements(const Call& call, const BlockBuilder& ctx) {
   if (indices_ty->IsUnknownDtype()) {
     LOG(WARNING) << "Data type of indices has not been specified. Assume it has an integer type.";
   } else {
-    PrimType indices_dtype = indices_ty->GetDtype();
+    PrimType indices_dtype = indices_ty->dtype.value();
     if (!indices_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
         !indices_dtype.MatchesCode(DLDataTypeCode::kDLUInt)) {
       TVM_FFI_VISIT_THROW(TypeError, call)
@@ -2821,7 +2819,7 @@ Type InferTypeScatterND(const Call& call, const BlockBuilder& ctx) {
   if (indices_ty->IsUnknownDtype()) {
     LOG(WARNING) << "Data type of indices has not been specified. Assume it has an integer type.";
   } else {
-    PrimType indices_dtype = indices_ty->GetDtype();
+    PrimType indices_dtype = indices_ty->dtype.value();
     if (!indices_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
         !indices_dtype.MatchesCode(DLDataTypeCode::kDLUInt)) {
       TVM_FFI_VISIT_THROW(TypeError, call)
@@ -3141,7 +3139,7 @@ Type InferTypeOneHot(const Call& call, const BlockBuilder& ctx) {
   if (indices_ty->IsUnknownDtype()) {
     LOG(WARNING) << "Data type of indices has not been specified. Assume it has an integer type.";
   } else {
-    PrimType indices_dtype = indices_ty->GetDtype();
+    PrimType indices_dtype = indices_ty->dtype.value();
     if (!indices_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
         !indices_dtype.MatchesCode(DLDataTypeCode::kDLUInt)) {
       TVM_FFI_VISIT_THROW(TypeError, call)

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -219,7 +219,7 @@ Type InferTypeConcat(const Call& call, const BlockBuilder& ctx) {
 
   const auto* attrs = call->attrs.as<ConcatAttrs>();
   int output_ndim = attrs->axis.has_value() ? kUnknownNDim : 1;
-  PrimType output_dtype = PrimType::Void();
+  ffi::Optional<PrimType> output_dtype = std::nullopt;
   ffi::Optional<VDevice> vdev = std::nullopt;
   bool shape_unknown = false;
   bool is_void_dtype = false;
@@ -231,7 +231,7 @@ Type InferTypeConcat(const Call& call, const BlockBuilder& ctx) {
     // Update the output dtype.
     if (ty->IsUnknownDtype()) {
       is_void_dtype = true;
-    } else if (output_dtype.IsVoid()) {
+    } else if (!output_dtype.defined()) {
       output_dtype = ty->dtype;
     } else if (ty->dtype != output_dtype) {
       TVM_FFI_VISIT_THROW(TypeError, call)
@@ -285,7 +285,7 @@ Type InferTypeConcat(const Call& call, const BlockBuilder& ctx) {
   }
 
   if (is_void_dtype) {
-    output_dtype = PrimType::Void();
+    output_dtype = std::nullopt;
   }
   if (vdevice_unknown) {
     vdev = std::nullopt;
@@ -573,14 +573,14 @@ Type InferTypeIndexTensor(const Call& call, const BlockBuilder& ctx) {
         << "index_tensor expects a non‑empty tuple of index tensors";
   }
 
-  PrimType output_dtype = data_ty->dtype;
+  ffi::Optional<PrimType> output_dtype = data_ty->dtype;
   int n_indices = static_cast<int>(indices_ty.size());
   ffi::Optional<VDevice> vdev = data_ty->vdevice;
 
   // Indices must be integers
   for (int i = 0; i < n_indices; ++i) {
     const auto& s = indices_ty[i];
-    PrimType index_dtype = s->dtype;
+    PrimType index_dtype = s->GetDtype();
     // Indexing only requires integer element kind; vector lanes do not affect shape inference.
     if (!s->IsUnknownDtype() && index_dtype.code() != DLDataTypeCode::kDLInt) {
       TVM_FFI_VISIT_THROW(TypeError, call)
@@ -1493,7 +1493,7 @@ Type InferTypeStack(const Call& call, const BlockBuilder& ctx) {
 
   // Default axis is 0 if not specified
   int output_ndim = tensor_ty[0]->ndim + 1;  // Stack adds one dimension
-  PrimType output_dtype = PrimType::Void();
+  ffi::Optional<PrimType> output_dtype = std::nullopt;
   ffi::Optional<VDevice> vdev = std::nullopt;
   bool shape_unknown = false;
   bool is_void_dtype = false;
@@ -1505,7 +1505,7 @@ Type InferTypeStack(const Call& call, const BlockBuilder& ctx) {
     // Check dtype consistency
     if (ty->IsUnknownDtype()) {
       is_void_dtype = true;
-    } else if (output_dtype.IsVoid()) {
+    } else if (!output_dtype.defined()) {
       output_dtype = ty->dtype;
     } else if (ty->dtype != output_dtype) {
       TVM_FFI_VISIT_THROW(TypeError, call)
@@ -1546,7 +1546,7 @@ Type InferTypeStack(const Call& call, const BlockBuilder& ctx) {
     }
   }
 
-  if (is_void_dtype) output_dtype = PrimType::Void();
+  if (is_void_dtype) output_dtype = std::nullopt;
   if (vdevice_unknown) vdev = std::nullopt;
 
   // Normalize axis (default to 0 if not specified)
@@ -1654,7 +1654,7 @@ Type InferTypeCollapseSumLike(const Call& call, const BlockBuilder& ctx) {
   TensorType data_ty = input_ty[0];
   TensorType collapse_target_ty = input_ty[1];
 
-  PrimType output_dtype = data_ty->dtype;
+  ffi::Optional<PrimType> output_dtype = data_ty->dtype;
 
   ffi::Optional<ffi::Array<PrimExpr>> data_shape_value;
   if (data_ty->shape.defined()) {
@@ -1715,7 +1715,7 @@ Type InferTypeCollapseSumTo(const Call& call, const BlockBuilder& ctx) {
         << call->args[1]->ty->GetTypeKey();
   }
 
-  PrimType output_dtype = data_ty->dtype;
+  ffi::Optional<PrimType> output_dtype = data_ty->dtype;
 
   ffi::Optional<ffi::Array<PrimExpr>> data_shape_value;
   if (data_ty->shape.defined()) {
@@ -2103,15 +2103,17 @@ Type InferTypeReverseSequence(const Call& call, const BlockBuilder& ctx) {
         << "ReverseSequence requires seq_lengths to be 1-D. However, seq_lengths has ndim "
         << seq_lengths_ty->ndim;
   }
-  PrimType seq_lengths_dtype = seq_lengths_ty->dtype;
-  if (!seq_lengths_ty->IsUnknownDtype() && !seq_lengths_dtype.MatchesCode(DLDataTypeCode::kDLInt)) {
+  ffi::Optional<PrimType> seq_lengths_dtype = seq_lengths_ty->dtype;
+  if (!seq_lengths_ty->IsUnknownDtype() &&
+      !seq_lengths_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLInt)) {
     TVM_FFI_VISIT_THROW(ValueError, call)
         << "ReverseSequence requires seq_lengths to have dtype int32 or int64. However, "
            "seq_lengths has dtype "
         << seq_lengths_ty->dtype;
   }
-  if (seq_lengths_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
-      seq_lengths_dtype->dtype.bits != 32 && seq_lengths_dtype->dtype.bits != 64) {
+  if (seq_lengths_dtype.defined() &&
+      seq_lengths_dtype.value().MatchesCode(DLDataTypeCode::kDLInt) &&
+      seq_lengths_dtype.value()->dtype.bits != 32 && seq_lengths_dtype.value()->dtype.bits != 64) {
     TVM_FFI_VISIT_THROW(ValueError, call)
         << "ReverseSequence requires seq_lengths to have dtype int32 or int64. However, "
            "seq_lengths has dtype "
@@ -2197,9 +2199,9 @@ Type InferTypeGatherElements(const Call& call, const BlockBuilder& ctx) {
         << call->args[1]->ty->GetTypeKey();
   }
 
-  PrimType indices_dtype = indices_ty->dtype;
+  ffi::Optional<PrimType> indices_dtype = indices_ty->dtype;
   // Gather indices only require integer element kind; vector lanes do not affect shape inference.
-  if (!indices_ty->IsUnknownDtype() && indices_dtype.code() != DLDataTypeCode::kDLInt) {
+  if (!indices_ty->IsUnknownDtype() && indices_ty->GetDtype().code() != DLDataTypeCode::kDLInt) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "GatherElements requires the input indices to have int64 dtype. However, the "
         << "given indices dtype is " << indices_ty->dtype;
@@ -2438,7 +2440,7 @@ Type InferTypeIndexPut(const Call& call, const BlockBuilder& ctx) {
       LOG(WARNING) << "Data type of index tensor " << i
                    << " has not been specified. Assume it has an integer type.";
     } else {
-      PrimType index_dtype = tensor_ty->dtype;
+      PrimType index_dtype = tensor_ty->GetDtype();
       if (!index_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
           !index_dtype.MatchesCode(DLDataTypeCode::kDLUInt)) {
         TVM_FFI_VISIT_THROW(TypeError, call)
@@ -2542,7 +2544,7 @@ Type InferTypeMeshgrid(const Call& call, const BlockBuilder& ctx) {
   }
 
   std::vector<PrimExpr> lengths;
-  PrimType common_dtype = PrimType::Void();
+  ffi::Optional<PrimType> common_dtype = std::nullopt;
   bool shape_unknown = false;
   ffi::Optional<VDevice> vdev = std::nullopt;
   bool vdevice_unknown = false;
@@ -2558,7 +2560,7 @@ Type InferTypeMeshgrid(const Call& call, const BlockBuilder& ctx) {
 
     if (ty->IsUnknownDtype()) {
       continue;
-    } else if (common_dtype.IsVoid()) {
+    } else if (!common_dtype.defined()) {
       common_dtype = ty->dtype;
     } else if (ty->dtype != common_dtype) {
       TVM_FFI_VISIT_THROW(TypeError, call)
@@ -2695,7 +2697,7 @@ Type InferTypeScatterElements(const Call& call, const BlockBuilder& ctx) {
   if (indices_ty->IsUnknownDtype()) {
     LOG(WARNING) << "Data type of indices has not been specified. Assume it has an integer type.";
   } else {
-    PrimType indices_dtype = indices_ty->dtype;
+    PrimType indices_dtype = indices_ty->GetDtype();
     if (!indices_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
         !indices_dtype.MatchesCode(DLDataTypeCode::kDLUInt)) {
       TVM_FFI_VISIT_THROW(TypeError, call)
@@ -2819,7 +2821,7 @@ Type InferTypeScatterND(const Call& call, const BlockBuilder& ctx) {
   if (indices_ty->IsUnknownDtype()) {
     LOG(WARNING) << "Data type of indices has not been specified. Assume it has an integer type.";
   } else {
-    PrimType indices_dtype = indices_ty->dtype;
+    PrimType indices_dtype = indices_ty->GetDtype();
     if (!indices_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
         !indices_dtype.MatchesCode(DLDataTypeCode::kDLUInt)) {
       TVM_FFI_VISIT_THROW(TypeError, call)
@@ -3139,7 +3141,7 @@ Type InferTypeOneHot(const Call& call, const BlockBuilder& ctx) {
   if (indices_ty->IsUnknownDtype()) {
     LOG(WARNING) << "Data type of indices has not been specified. Assume it has an integer type.";
   } else {
-    PrimType indices_dtype = indices_ty->dtype;
+    PrimType indices_dtype = indices_ty->GetDtype();
     if (!indices_dtype.MatchesCode(DLDataTypeCode::kDLInt) &&
         !indices_dtype.MatchesCode(DLDataTypeCode::kDLUInt)) {
       TVM_FFI_VISIT_THROW(TypeError, call)

--- a/src/relax/op/tensor/qdq.cc
+++ b/src/relax/op/tensor/qdq.cc
@@ -52,6 +52,12 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::GlobalDef().def("relax.op.quantize", quantize);
 }
 
+TensorType WithUnknownDtype(const TensorType& input_ty) {
+  auto output_ty = ffi::make_object<TensorTypeNode>(*input_ty.get());
+  output_ty->dtype = ffi::Optional<PrimType>();
+  return TensorType(output_ty);
+}
+
 Type InferTypeQuantize(const Call& call, const BlockBuilder& ctx) {
   const auto* attrs = call->attrs.as<QuantizeAttrs>();
   if (attrs->out_dtype != DLDataType{kDLInt, 8, 1} &&
@@ -69,6 +75,9 @@ Type InferTypeQuantize(const Call& call, const BlockBuilder& ctx) {
   TensorType input_ty = GetInputTensorType(call, ctx)[0];
   TensorType scale_ty = GetInputTensorType(call, ctx)[1];
   TensorType zp_ty = GetInputTensorType(call, ctx)[2];
+  if (input_ty->IsUnknownDtype() || scale_ty->IsUnknownDtype() || zp_ty->IsUnknownDtype()) {
+    return WithUnknownDtype(input_ty);
+  }
   PrimType input_dtype = input_ty->dtype.value();
   PrimType scale_dtype = scale_ty->dtype.value();
   PrimType zp_dtype = zp_ty->dtype.value();
@@ -171,6 +180,9 @@ Type InferTypeDequantize(const Call& call, const BlockBuilder& ctx) {
   TensorType input_ty = GetInputTensorType(call, ctx)[0];
   TensorType scale_ty = GetInputTensorType(call, ctx)[1];
   TensorType zp_ty = GetInputTensorType(call, ctx)[2];
+  if (input_ty->IsUnknownDtype() || scale_ty->IsUnknownDtype() || zp_ty->IsUnknownDtype()) {
+    return WithUnknownDtype(input_ty);
+  }
   PrimType input_dtype = input_ty->dtype.value();
   PrimType scale_dtype = scale_ty->dtype.value();
   PrimType zp_dtype = zp_ty->dtype.value();

--- a/src/relax/op/tensor/qdq.cc
+++ b/src/relax/op/tensor/qdq.cc
@@ -69,9 +69,9 @@ Type InferTypeQuantize(const Call& call, const BlockBuilder& ctx) {
   TensorType input_ty = GetInputTensorType(call, ctx)[0];
   TensorType scale_ty = GetInputTensorType(call, ctx)[1];
   TensorType zp_ty = GetInputTensorType(call, ctx)[2];
-  PrimType input_dtype = input_ty->GetDtype();
-  PrimType scale_dtype = scale_ty->GetDtype();
-  PrimType zp_dtype = zp_ty->GetDtype();
+  PrimType input_dtype = input_ty->dtype.value();
+  PrimType scale_dtype = scale_ty->dtype.value();
+  PrimType zp_dtype = zp_ty->dtype.value();
 
   // Check input datatype:
   if (input_dtype != PrimType::Float(16) && input_dtype != PrimType::Float(32)) {
@@ -171,9 +171,9 @@ Type InferTypeDequantize(const Call& call, const BlockBuilder& ctx) {
   TensorType input_ty = GetInputTensorType(call, ctx)[0];
   TensorType scale_ty = GetInputTensorType(call, ctx)[1];
   TensorType zp_ty = GetInputTensorType(call, ctx)[2];
-  PrimType input_dtype = input_ty->GetDtype();
-  PrimType scale_dtype = scale_ty->GetDtype();
-  PrimType zp_dtype = zp_ty->GetDtype();
+  PrimType input_dtype = input_ty->dtype.value();
+  PrimType scale_dtype = scale_ty->dtype.value();
+  PrimType zp_dtype = zp_ty->dtype.value();
 
   // Check input datatype:
   if (input_dtype != PrimType::Int(8) && input_dtype != PrimType::UInt(8) &&

--- a/src/relax/op/tensor/qdq.cc
+++ b/src/relax/op/tensor/qdq.cc
@@ -69,9 +69,9 @@ Type InferTypeQuantize(const Call& call, const BlockBuilder& ctx) {
   TensorType input_ty = GetInputTensorType(call, ctx)[0];
   TensorType scale_ty = GetInputTensorType(call, ctx)[1];
   TensorType zp_ty = GetInputTensorType(call, ctx)[2];
-  PrimType input_dtype = input_ty->dtype;
-  PrimType scale_dtype = scale_ty->dtype;
-  PrimType zp_dtype = zp_ty->dtype;
+  PrimType input_dtype = input_ty->GetDtype();
+  PrimType scale_dtype = scale_ty->GetDtype();
+  PrimType zp_dtype = zp_ty->GetDtype();
 
   // Check input datatype:
   if (input_dtype != PrimType::Float(16) && input_dtype != PrimType::Float(32)) {
@@ -171,9 +171,9 @@ Type InferTypeDequantize(const Call& call, const BlockBuilder& ctx) {
   TensorType input_ty = GetInputTensorType(call, ctx)[0];
   TensorType scale_ty = GetInputTensorType(call, ctx)[1];
   TensorType zp_ty = GetInputTensorType(call, ctx)[2];
-  PrimType input_dtype = input_ty->dtype;
-  PrimType scale_dtype = scale_ty->dtype;
-  PrimType zp_dtype = zp_ty->dtype;
+  PrimType input_dtype = input_ty->GetDtype();
+  PrimType scale_dtype = scale_ty->GetDtype();
+  PrimType zp_dtype = zp_ty->GetDtype();
 
   // Check input datatype:
   if (input_dtype != PrimType::Int(8) && input_dtype != PrimType::UInt(8) &&

--- a/src/relax/op/tensor/sampling.cc
+++ b/src/relax/op/tensor/sampling.cc
@@ -62,7 +62,7 @@ Type InferTypeMultinomialFromUniform(const Call& call, const BlockBuilder& ctx) 
 
   // Only the element kind matters here; shape inference does not depend on vector lanes.
   if (!prob_ty->IsUnknownDtype() &&
-      !prob_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat, DLDataTypeCode::kDLBfloat)) {
+      !prob_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLFloat, DLDataTypeCode::kDLBfloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Multinomial_from_uniform op requires the input prob to have float dtype. "
            "However, the given prob dtype is "
@@ -70,8 +70,8 @@ Type InferTypeMultinomialFromUniform(const Call& call, const BlockBuilder& ctx) 
   }
   // Only the element kind matters here; shape inference does not depend on vector lanes.
   if (!uniform_sample_ty->IsUnknownDtype() &&
-      !uniform_sample_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat,
-                                                 DLDataTypeCode::kDLBfloat)) {
+      !uniform_sample_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLFloat,
+                                                    DLDataTypeCode::kDLBfloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Multinomial_from_uniform op requires the input uniform_sample to have float "
            "dtype. However, the given uniform_sample dtype is "
@@ -79,7 +79,7 @@ Type InferTypeMultinomialFromUniform(const Call& call, const BlockBuilder& ctx) 
   }
   // Only the element kind matters here; shape inference does not depend on vector lanes.
   if (!sample_indices_ty->IsUnknownDtype() &&
-      !sample_indices_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLInt)) {
+      !sample_indices_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLInt)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Multinomial from uniform op requires the input sample_indices to have int "
            "dtype. However, the given sample_indices dtype is "

--- a/src/relax/op/tensor/sampling.cc
+++ b/src/relax/op/tensor/sampling.cc
@@ -61,21 +61,25 @@ Type InferTypeMultinomialFromUniform(const Call& call, const BlockBuilder& ctx) 
   const auto* attrs = call->attrs.as<MultinomialFromUniformAttrs>();
 
   // Only the element kind matters here; shape inference does not depend on vector lanes.
-  if (!prob_ty->dtype.MatchesCode(DLDataTypeCode::kDLFloat, DLDataTypeCode::kDLBfloat)) {
+  if (!prob_ty->IsUnknownDtype() &&
+      !prob_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat, DLDataTypeCode::kDLBfloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Multinomial_from_uniform op requires the input prob to have float dtype. "
            "However, the given prob dtype is "
         << prob_ty->dtype;
   }
   // Only the element kind matters here; shape inference does not depend on vector lanes.
-  if (!uniform_sample_ty->dtype.MatchesCode(DLDataTypeCode::kDLFloat, DLDataTypeCode::kDLBfloat)) {
+  if (!uniform_sample_ty->IsUnknownDtype() &&
+      !uniform_sample_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat,
+                                                 DLDataTypeCode::kDLBfloat)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Multinomial_from_uniform op requires the input uniform_sample to have float "
            "dtype. However, the given uniform_sample dtype is "
         << uniform_sample_ty->dtype;
   }
   // Only the element kind matters here; shape inference does not depend on vector lanes.
-  if (!sample_indices_ty->dtype.MatchesCode(DLDataTypeCode::kDLInt)) {
+  if (!sample_indices_ty->IsUnknownDtype() &&
+      !sample_indices_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLInt)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Multinomial from uniform op requires the input sample_indices to have int "
            "dtype. However, the given sample_indices dtype is "

--- a/src/relax/op/tensor/search.cc
+++ b/src/relax/op/tensor/search.cc
@@ -119,7 +119,7 @@ Type InferTypeWhere(const Call& call, const BlockBuilder& ctx) {
   }
 
   // Where condition validation only checks the boolean element kind; lanes are irrelevant here.
-  if (!cond_ty->IsUnknownDtype() && !cond_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLBool)) {
+  if (!cond_ty->IsUnknownDtype() && !cond_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLBool)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Where requires the input condition tensor to have boolean dtype. However, "
            "the given condition dtype is "

--- a/src/relax/op/tensor/search.cc
+++ b/src/relax/op/tensor/search.cc
@@ -118,15 +118,14 @@ Type InferTypeWhere(const Call& call, const BlockBuilder& ctx) {
     }
   }
 
-  PrimType cond_dtype = cond_ty->dtype;
   // Where condition validation only checks the boolean element kind; lanes are irrelevant here.
-  if (!cond_dtype.MatchesCode(DLDataTypeCode::kDLBool)) {
+  if (!cond_ty->IsUnknownDtype() && !cond_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLBool)) {
     TVM_FFI_VISIT_THROW(TypeError, call)
         << "Where requires the input condition tensor to have boolean dtype. However, "
            "the given condition dtype is "
         << cond_ty->dtype;
   }
-  PrimType output_dtype = InferBinaryArithOpOutDtype(call, ctx, x1_ty, x2_ty);
+  ffi::Optional<PrimType> output_dtype = InferBinaryArithOpOutDtype(call, ctx, x1_ty, x2_ty);
 
   int output_ndim;
   if (cond_ty->IsUnknownNdim() || x1_ty->IsUnknownNdim() || x2_ty->IsUnknownNdim()) {

--- a/src/relax/op/tensor/sorting.cc
+++ b/src/relax/op/tensor/sorting.cc
@@ -66,7 +66,7 @@ TVM_REGISTER_OP("relax.sort")
 
 /* relax.argsort */
 
-Expr argsort(Expr data, int axis, bool descending, DLDataType dtype) {
+Expr argsort(Expr data, int axis, bool descending, ffi::Optional<DLDataType> dtype) {
   auto attrs = ffi::make_object<ArgsortAttrs>();
   attrs->axis = std::move(axis);
   attrs->descending = std::move(descending);
@@ -84,8 +84,9 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 Type InferTypeArgsort(const Call& call, const BlockBuilder& ctx) {
   TensorType data_ty = GetUnaryInputTensorType(call, ctx);
   const auto* attrs = call->attrs.as<ArgsortAttrs>();
-  PrimType out_type =
-      attrs->dtype == DLDataType{kDLOpaqueHandle, 0, 0} ? data_ty->dtype : PrimType(attrs->dtype);
+  ffi::Optional<PrimType> out_type = attrs->dtype.has_value()
+                                         ? ffi::Optional<PrimType>(PrimType(attrs->dtype.value()))
+                                         : data_ty->dtype;
   if (data_ty->shape.defined()) {
     return TensorType(data_ty->shape.value(), out_type, data_ty->vdevice);
   }
@@ -101,7 +102,8 @@ TVM_REGISTER_OP("relax.argsort")
 
 /* relax.topk */
 
-Expr topk(Expr data, int k, int axis, ffi::String ret_type, bool largest, DLDataType dtype) {
+Expr topk(Expr data, int k, int axis, ffi::String ret_type, bool largest,
+          ffi::Optional<DLDataType> dtype) {
   auto attrs = ffi::make_object<TopKAttrs>();
   attrs->k = std::move(k);
   attrs->axis = std::move(axis);
@@ -122,8 +124,9 @@ Type InferTypeTopK(const Call& call, const BlockBuilder& ctx) {
   TensorType data_ty = GetUnaryInputTensorType(call, ctx);
   const auto* data_shape = data_ty->shape.as<ShapeExprNode>();
   const auto* attrs = call->attrs.as<TopKAttrs>();
-  PrimType indices_type =
-      attrs->dtype == DLDataType{kDLOpaqueHandle, 0, 0} ? data_ty->dtype : PrimType(attrs->dtype);
+  ffi::Optional<PrimType> indices_type =
+      attrs->dtype.has_value() ? ffi::Optional<PrimType>(PrimType(attrs->dtype.value()))
+                               : data_ty->dtype;
   int ndim = data_ty->ndim;
   int k = attrs->k;
   ffi::String ret_type = attrs->ret_type;

--- a/src/relax/op/tensor/sorting.h
+++ b/src/relax/op/tensor/sorting.h
@@ -51,7 +51,7 @@ Expr sort(Expr data, int axis, bool descending);
  * \param dtype The data type of the output indices.
  * \return The computed result.
  */
-Expr argsort(Expr data, int axis, bool descending, DLDataType dtype);
+Expr argsort(Expr data, int axis, bool descending, ffi::Optional<DLDataType> dtype);
 
 /*!
  * \brief Get the top k elements in an input tensor along the given axis.
@@ -63,7 +63,8 @@ Expr argsort(Expr data, int axis, bool descending, DLDataType dtype);
  * \param dtype The data type of the indices output.
  * \return The computed result.
  */
-Expr topk(Expr data, int k, int axis, ffi::String ret_type, bool largest, DLDataType dtype);
+Expr topk(Expr data, int k, int axis, ffi::String ret_type, bool largest,
+          ffi::Optional<DLDataType> dtype);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/statistical.cc
+++ b/src/relax/op/tensor/statistical.cc
@@ -155,8 +155,9 @@ Type InferTypeScan(const Call& call, const BlockBuilder& ctx) {
   TensorType data_ty = GetUnaryInputTensorType(call, ctx);
   const auto* attrs = call->attrs.as<ScanopAttrs>();
 
-  PrimType out_type =
-      attrs->dtype == DLDataType{kDLOpaqueHandle, 0, 0} ? data_ty->dtype : PrimType(attrs->dtype);
+  ffi::Optional<PrimType> out_type = attrs->dtype.has_value()
+                                         ? ffi::Optional<PrimType>(PrimType(attrs->dtype.value()))
+                                         : data_ty->dtype;
 
   if (!attrs->axis.has_value()) {
     // flattened
@@ -243,7 +244,7 @@ Expr cumprod(Expr data, ffi::Optional<int64_t> axis, ffi::Optional<DLDataType> d
              bool exclusive) {
   auto attrs = ffi::make_object<ScanopAttrs>();
   attrs->axis = std::move(axis);
-  attrs->dtype = dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->dtype = dtype;
   attrs->exclusive = exclusive;
 
   static const Op& op = Op::Get("relax.cumprod");
@@ -267,7 +268,7 @@ Expr cumsum(Expr data, ffi::Optional<int64_t> axis, ffi::Optional<DLDataType> dt
             bool exclusive) {
   auto attrs = ffi::make_object<ScanopAttrs>();
   attrs->axis = std::move(axis);
-  attrs->dtype = dtype.value_or((DLDataType{kDLOpaqueHandle, 0, 0}));
+  attrs->dtype = dtype;
   attrs->exclusive = exclusive;
 
   static const Op& op = Op::Get("relax.cumsum");

--- a/src/relax/op/tensor/ternary.cc
+++ b/src/relax/op/tensor/ternary.cc
@@ -57,9 +57,9 @@ Type InferTypeEwiseFMA(const Call& call, const BlockBuilder& ctx) {
     }
   }
 
-  PrimType output_dtype = PrimType::Void();
+  ffi::Optional<PrimType> output_dtype = std::nullopt;
   if (t1->IsUnknownDtype() || t2->IsUnknownDtype() || t3->IsUnknownDtype()) {
-    output_dtype = PrimType::Void();
+    output_dtype = std::nullopt;
   } else if (t1->dtype != t2->dtype || t2->dtype != t3->dtype) {
     TVM_FFI_VISIT_THROW(TypeError, call) << "Data types " << t1->dtype << ", " << t2->dtype
                                          << ", and " << t3->dtype << " must be equal for EwiseFMA";

--- a/src/relax/script/printer/dependent_type.cc
+++ b/src/relax/script/printer/dependent_type.cc
@@ -98,7 +98,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           }
           if (!n->IsUnknownDtype()) {
             kwargs_keys.push_back("dtype");
-            kwargs_values.push_back(LiteralDoc::DataType(n->dtype->dtype, n_p->Attr("dtype")));
+            kwargs_values.push_back(LiteralDoc::DataType(n->GetDtypeRaw(), n_p->Attr("dtype")));
           }
           if (!n->shape.defined() && !n->IsUnknownNdim()) {
             kwargs_keys.push_back("ndim");

--- a/src/relax/script/printer/dependent_type.cc
+++ b/src/relax/script/printer/dependent_type.cc
@@ -98,7 +98,8 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           }
           if (!n->IsUnknownDtype()) {
             kwargs_keys.push_back("dtype");
-            kwargs_values.push_back(LiteralDoc::DataType(n->GetDtypeRaw(), n_p->Attr("dtype")));
+            kwargs_values.push_back(
+                LiteralDoc::DataType(n->dtype.value()->dtype, n_p->Attr("dtype")));
           }
           if (!n->shape.defined() && !n->IsUnknownNdim()) {
             kwargs_keys.push_back("ndim");

--- a/src/relax/script/printer/distributed.cc
+++ b/src/relax/script/printer/distributed.cc
@@ -61,11 +61,12 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           }
           if (!n->tensor_ty->IsUnknownDtype()) {
             if (!require_kwargs) {
-              args.push_back(LiteralDoc::DataType(n->tensor_ty->GetDtypeRaw(), n_p->Attr("dtype")));
+              args.push_back(
+                  LiteralDoc::DataType(n->tensor_ty->dtype.value()->dtype, n_p->Attr("dtype")));
             } else {
               kwargs_keys.push_back("dtype");
               kwargs_values.push_back(
-                  LiteralDoc::DataType(n->tensor_ty->GetDtypeRaw(), n_p->Attr("dtype")));
+                  LiteralDoc::DataType(n->tensor_ty->dtype.value()->dtype, n_p->Attr("dtype")));
             }
           } else {
             require_kwargs = true;

--- a/src/relax/script/printer/distributed.cc
+++ b/src/relax/script/printer/distributed.cc
@@ -61,11 +61,11 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           }
           if (!n->tensor_ty->IsUnknownDtype()) {
             if (!require_kwargs) {
-              args.push_back(LiteralDoc::DataType(n->tensor_ty->dtype->dtype, n_p->Attr("dtype")));
+              args.push_back(LiteralDoc::DataType(n->tensor_ty->GetDtypeRaw(), n_p->Attr("dtype")));
             } else {
               kwargs_keys.push_back("dtype");
               kwargs_values.push_back(
-                  LiteralDoc::DataType(n->tensor_ty->dtype->dtype, n_p->Attr("dtype")));
+                  LiteralDoc::DataType(n->tensor_ty->GetDtypeRaw(), n_p->Attr("dtype")));
             }
           } else {
             require_kwargs = true;

--- a/src/relax/transform/adjust_matmul_order.cc
+++ b/src/relax/transform/adjust_matmul_order.cc
@@ -208,11 +208,9 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
     // If two of the three are compile-time, group those two values
     // together, to allow them to be lifted out and pre-computed.
     if (is_compile_time(expr_a) && is_compile_time(expr_b)) {
-      return matmul(matmul(expr_a, expr_b, (DLDataType{kDLOpaqueHandle, 0, 0})), expr_c,
-                    (DLDataType{kDLOpaqueHandle, 0, 0}));
+      return matmul(matmul(expr_a, expr_b, std::nullopt), expr_c, std::nullopt);
     } else if (is_compile_time(expr_b) && is_compile_time(expr_c)) {
-      return matmul(expr_a, matmul(expr_b, expr_c, (DLDataType{kDLOpaqueHandle, 0, 0})),
-                    (DLDataType{kDLOpaqueHandle, 0, 0}));
+      return matmul(expr_a, matmul(expr_b, expr_c, std::nullopt), std::nullopt);
     }
 
     // Otherwise, select the order that reduces the total number of
@@ -287,11 +285,9 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
                       size_N > 0 && size_R > 0 && size_M > 0 && size_B > 0);
 
     if (analyzer->CanProve(ops_with_lhs_first < ops_with_rhs_first)) {
-      return matmul(matmul(expr_a, expr_b, (DLDataType{kDLOpaqueHandle, 0, 0})), expr_c,
-                    (DLDataType{kDLOpaqueHandle, 0, 0}));
+      return matmul(matmul(expr_a, expr_b, std::nullopt), expr_c, std::nullopt);
     } else if (analyzer->CanProve(ops_with_rhs_first < ops_with_lhs_first)) {
-      return matmul(expr_a, matmul(expr_b, expr_c, (DLDataType{kDLOpaqueHandle, 0, 0})),
-                    (DLDataType{kDLOpaqueHandle, 0, 0}));
+      return matmul(expr_a, matmul(expr_b, expr_c, std::nullopt), std::nullopt);
     }
 
     // If we cannot determine which order is best, keep the existing order.

--- a/src/relax/transform/alter_op_impl.cc
+++ b/src/relax/transform/alter_op_impl.cc
@@ -264,7 +264,7 @@ class AlterOpImplMutator : public ExprMutator {
           TransformLayout(expr, inverse_index_map, axis_separator, input_axis_separator));
       const auto& tensor_ty = padded_expr->ty.as_or_throw<TensorType>();
 
-      GlobalVar gv_remove_pad = GetOrCreateRemovePadOp(old_shape, tensor_ty->GetDtypeRaw());
+      GlobalVar gv_remove_pad = GetOrCreateRemovePadOp(old_shape, tensor_ty->dtype.value()->dtype);
       return Call(call_tir_op_, {gv_remove_pad, Tuple({padded_expr})}, {}, {old_tensor_ty});
     }
   }

--- a/src/relax/transform/alter_op_impl.cc
+++ b/src/relax/transform/alter_op_impl.cc
@@ -264,7 +264,7 @@ class AlterOpImplMutator : public ExprMutator {
           TransformLayout(expr, inverse_index_map, axis_separator, input_axis_separator));
       const auto& tensor_ty = padded_expr->ty.as_or_throw<TensorType>();
 
-      GlobalVar gv_remove_pad = GetOrCreateRemovePadOp(old_shape, tensor_ty->dtype->dtype);
+      GlobalVar gv_remove_pad = GetOrCreateRemovePadOp(old_shape, tensor_ty->GetDtypeRaw());
       return Call(call_tir_op_, {gv_remove_pad, Tuple({padded_expr})}, {}, {old_tensor_ty});
     }
   }

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -92,7 +92,7 @@ class CallTIRMutator : public ExprMutator {
         if (!is_inplace) {
           outs.push_back(builder_->Emit(Call(alloc_tensor_op,
                                              {output_ty->shape.value().as_or_throw<ShapeExpr>(),
-                                              DataTypeImm(output_ty->GetDtypeRaw()),
+                                              DataTypeImm(output_ty->dtype.value()->dtype),
                                               IntImm::Int64(dev_index), StringImm(scope)},
                                              Attrs(), {output_ty}),
                                         "alloc"));
@@ -129,7 +129,7 @@ class CallTIRMutator : public ExprMutator {
             outs.push_back(
                 builder_->Emit(Call(alloc_tensor_op,
                                     {field_tensor->shape.value().as_or_throw<ShapeExpr>(),
-                                     DataTypeImm(field_tensor->GetDtypeRaw()),
+                                     DataTypeImm(field_tensor->dtype.value()->dtype),
                                      IntImm::Int64(dev_index), StringImm(scope)},
                                     Attrs(), {field_tensor}),
                                "alloc"));

--- a/src/relax/transform/call_tir_rewrite.cc
+++ b/src/relax/transform/call_tir_rewrite.cc
@@ -92,7 +92,7 @@ class CallTIRMutator : public ExprMutator {
         if (!is_inplace) {
           outs.push_back(builder_->Emit(Call(alloc_tensor_op,
                                              {output_ty->shape.value().as_or_throw<ShapeExpr>(),
-                                              DataTypeImm(output_ty->dtype->dtype),
+                                              DataTypeImm(output_ty->GetDtypeRaw()),
                                               IntImm::Int64(dev_index), StringImm(scope)},
                                              Attrs(), {output_ty}),
                                         "alloc"));
@@ -129,7 +129,7 @@ class CallTIRMutator : public ExprMutator {
             outs.push_back(
                 builder_->Emit(Call(alloc_tensor_op,
                                     {field_tensor->shape.value().as_or_throw<ShapeExpr>(),
-                                     DataTypeImm(field_tensor->dtype->dtype),
+                                     DataTypeImm(field_tensor->GetDtypeRaw()),
                                      IntImm::Int64(dev_index), StringImm(scope)},
                                     Attrs(), {field_tensor}),
                                "alloc"));

--- a/src/relax/transform/combine_parallel_matmul.cc
+++ b/src/relax/transform/combine_parallel_matmul.cc
@@ -202,7 +202,7 @@ ffi::TypedFunction<ffi::Map<Var, Expr>(ffi::Map<DFPattern, Var>, ffi::Map<Var, E
       }
 
       auto concat_rhs = concat(Tuple(rhs), rhs_dim - 1);
-      DLDataType out_dtype = GetTensorType(matchings[patterns.matmul[indices[0]]])->dtype->dtype;
+      DLDataType out_dtype = GetTensorType(matchings[patterns.matmul[indices[0]]])->GetDtypeRaw();
       auto matmul_combined = matmul(lhs, concat_rhs, out_dtype);
 
       if (branch_info.bias_dim) {

--- a/src/relax/transform/combine_parallel_matmul.cc
+++ b/src/relax/transform/combine_parallel_matmul.cc
@@ -202,7 +202,8 @@ ffi::TypedFunction<ffi::Map<Var, Expr>(ffi::Map<DFPattern, Var>, ffi::Map<Var, E
       }
 
       auto concat_rhs = concat(Tuple(rhs), rhs_dim - 1);
-      DLDataType out_dtype = GetTensorType(matchings[patterns.matmul[indices[0]]])->GetDtypeRaw();
+      DLDataType out_dtype =
+          GetTensorType(matchings[patterns.matmul[indices[0]]])->dtype.value()->dtype;
       auto matmul_combined = matmul(lhs, concat_rhs, out_dtype);
 
       if (branch_info.bias_dim) {

--- a/src/relax/transform/dataflow_inplace.cc
+++ b/src/relax/transform/dataflow_inplace.cc
@@ -383,7 +383,7 @@ std::unordered_set<Type, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> GatherCandidat
     const Type& result_ty) {
   if (auto* tensor_info = result_ty.as<TensorTypeNode>()) {
     // don't consider void dtype (don't know the size at compile time)
-    if (tensor_info->dtype.IsVoid()) {
+    if (tensor_info->IsUnknownDtype()) {
       return {};
     }
     // don't consider cases where we don't know the shape at compile time

--- a/src/relax/transform/decompose_ops.cc
+++ b/src/relax/transform/decompose_ops.cc
@@ -66,7 +66,7 @@ Tuple DecomposeBatchNorm(const Call& call) {
   Expr moving_var = ExpandToMatchInput(call->args[4], ty->ndim, {attrs->axis});
 
   // output = (x - mean) / sqrt(var + epsilon) * gamma + beta
-  Expr epsilon = MakeConstantScalar(attrs->epsilon, ty->GetDtypeRaw());
+  Expr epsilon = MakeConstantScalar(attrs->epsilon, ty->dtype.value()->dtype);
   Expr sqrt_var = sqrt(add(moving_var, epsilon));
   Expr out = divide(subtract(data, moving_mean), sqrt_var);
 
@@ -103,8 +103,8 @@ Expr MutateBatchNormForTraining(Call call) {
   Expr data_mean = mean(data, reduce_axes, false);
   Expr data_var = variance(data, reduce_axes, false);
 
-  Expr momentum = MakeConstantScalar(attrs->momentum, ty->GetDtypeRaw());
-  Expr one_minus_mom = MakeConstantScalar(1 - attrs->momentum, ty->GetDtypeRaw());
+  Expr momentum = MakeConstantScalar(attrs->momentum, ty->dtype.value()->dtype);
+  Expr one_minus_mom = MakeConstantScalar(1 - attrs->momentum, ty->dtype.value()->dtype);
 
   Expr new_moving_mean = add(multiply(one_minus_mom, moving_mean), multiply(momentum, data_mean));
   Expr new_moving_var = add(multiply(one_minus_mom, moving_var), multiply(momentum, data_var));
@@ -128,7 +128,7 @@ Expr DecomposeLayerNorm(const Call& call) {
   Expr data_var = variance(data, attrs->axes, true);
 
   // output = (x - mean) / sqrt(var + epsilon) * gamma + beta
-  Expr epsilon = MakeConstantScalar(attrs->epsilon, ty->GetDtypeRaw());
+  Expr epsilon = MakeConstantScalar(attrs->epsilon, ty->dtype.value()->dtype);
   Expr sqrt_var = sqrt(add(data_var, epsilon));
   Expr out = divide(subtract(data, data_mean), sqrt_var);
 

--- a/src/relax/transform/decompose_ops.cc
+++ b/src/relax/transform/decompose_ops.cc
@@ -66,7 +66,7 @@ Tuple DecomposeBatchNorm(const Call& call) {
   Expr moving_var = ExpandToMatchInput(call->args[4], ty->ndim, {attrs->axis});
 
   // output = (x - mean) / sqrt(var + epsilon) * gamma + beta
-  Expr epsilon = MakeConstantScalar(attrs->epsilon, ty->dtype->dtype);
+  Expr epsilon = MakeConstantScalar(attrs->epsilon, ty->GetDtypeRaw());
   Expr sqrt_var = sqrt(add(moving_var, epsilon));
   Expr out = divide(subtract(data, moving_mean), sqrt_var);
 
@@ -103,8 +103,8 @@ Expr MutateBatchNormForTraining(Call call) {
   Expr data_mean = mean(data, reduce_axes, false);
   Expr data_var = variance(data, reduce_axes, false);
 
-  Expr momentum = MakeConstantScalar(attrs->momentum, ty->dtype->dtype);
-  Expr one_minus_mom = MakeConstantScalar(1 - attrs->momentum, ty->dtype->dtype);
+  Expr momentum = MakeConstantScalar(attrs->momentum, ty->GetDtypeRaw());
+  Expr one_minus_mom = MakeConstantScalar(1 - attrs->momentum, ty->GetDtypeRaw());
 
   Expr new_moving_mean = add(multiply(one_minus_mom, moving_mean), multiply(momentum, data_mean));
   Expr new_moving_var = add(multiply(one_minus_mom, moving_var), multiply(momentum, data_var));
@@ -128,7 +128,7 @@ Expr DecomposeLayerNorm(const Call& call) {
   Expr data_var = variance(data, attrs->axes, true);
 
   // output = (x - mean) / sqrt(var + epsilon) * gamma + beta
-  Expr epsilon = MakeConstantScalar(attrs->epsilon, ty->dtype->dtype);
+  Expr epsilon = MakeConstantScalar(attrs->epsilon, ty->GetDtypeRaw());
   Expr sqrt_var = sqrt(add(data_var, epsilon));
   Expr out = divide(subtract(data, data_mean), sqrt_var);
 

--- a/src/relax/transform/expand_matmul_of_sum.cc
+++ b/src/relax/transform/expand_matmul_of_sum.cc
@@ -88,8 +88,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
       rhs_b = permute_dims(rhs_b, axes);
     }
 
-    return add(matmul(lhs, rhs_a, (DLDataType{kDLOpaqueHandle, 0, 0})),
-               matmul(lhs, rhs_b, (DLDataType{kDLOpaqueHandle, 0, 0})));
+    return add(matmul(lhs, rhs_a, std::nullopt), matmul(lhs, rhs_b, std::nullopt));
   };
 
   return {pat_matmul, rewriter};

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -244,7 +244,7 @@ class ConstantFolder : public ExprMutator {
       auto tensor_ty = tuple_ty->fields[i].as_or_throw<TensorType>();
       if (tensor_ty->IsUnknownDtype()) return std::nullopt;
       ret_tensors.push_back(
-          runtime::Tensor::Empty(shape.value(), tensor_ty->GetDtypeRaw(), cpu_dev));
+          runtime::Tensor::Empty(shape.value(), tensor_ty->dtype.value()->dtype, cpu_dev));
     }
 
     // Pack input args + all output tensors.
@@ -290,7 +290,7 @@ class ConstantFolder : public ExprMutator {
     if (shape) {
       TensorType ret_ty = call->ty.as_or_throw<TensorType>();
       return ConstEvaluateCallTIR(func.value(), arr_args.value(), shape.value(),
-                                  ret_ty->GetDtypeRaw())
+                                  ret_ty->dtype.value()->dtype)
           .value_or({});
     }
     return {};

--- a/src/relax/transform/fold_constant.cc
+++ b/src/relax/transform/fold_constant.cc
@@ -244,7 +244,7 @@ class ConstantFolder : public ExprMutator {
       auto tensor_ty = tuple_ty->fields[i].as_or_throw<TensorType>();
       if (tensor_ty->IsUnknownDtype()) return std::nullopt;
       ret_tensors.push_back(
-          runtime::Tensor::Empty(shape.value(), tensor_ty->dtype->dtype, cpu_dev));
+          runtime::Tensor::Empty(shape.value(), tensor_ty->GetDtypeRaw(), cpu_dev));
     }
 
     // Pack input args + all output tensors.
@@ -290,7 +290,7 @@ class ConstantFolder : public ExprMutator {
     if (shape) {
       TensorType ret_ty = call->ty.as_or_throw<TensorType>();
       return ConstEvaluateCallTIR(func.value(), arr_args.value(), shape.value(),
-                                  ret_ty->dtype->dtype)
+                                  ret_ty->GetDtypeRaw())
           .value_or({});
     }
     return {};

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -969,7 +969,7 @@ class FusedTIRConstructor : public ExprVisitor {
       // Case 1. The relax param is a Tensor, we directly create a tirx var and buffer
       const auto* shape_expr = tensor->shape.as<ShapeExprNode>();
       TVM_FFI_ICHECK(shape_expr) << "FuseTIR expects all Tensor parameters have a known shape.";
-      PrimType dtype = tensor->GetDtype();
+      PrimType dtype = tensor->dtype.value();
       tirx::Buffer buffer;
       if (tir_buffer_param.defined()) {
         buffer = tirx::decl_buffer(shape_expr->values, dtype, name_hint,

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -969,7 +969,7 @@ class FusedTIRConstructor : public ExprVisitor {
       // Case 1. The relax param is a Tensor, we directly create a tirx var and buffer
       const auto* shape_expr = tensor->shape.as<ShapeExprNode>();
       TVM_FFI_ICHECK(shape_expr) << "FuseTIR expects all Tensor parameters have a known shape.";
-      PrimType dtype = tensor->dtype;
+      PrimType dtype = tensor->GetDtype();
       tirx::Buffer buffer;
       if (tir_buffer_param.defined()) {
         buffer = tirx::decl_buffer(shape_expr->values, dtype, name_hint,

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -304,7 +304,7 @@ class BackwardBindingGenerator : private ExprVisitor {
 
     // Initialize the adjoint of target_var as ones op. We have already checked the target.
     auto* target_ty = GetTypeAs<TensorTypeNode>(target_var);
-    generator.UpdateAdjoint(target_var, ones(target_ty->shape.value(), target_ty->dtype->dtype));
+    generator.UpdateAdjoint(target_var, ones(target_ty->shape.value(), target_ty->GetDtypeRaw()));
 
     // Do reverse-mode ad, so visit bindings backwards
     for (auto it = forward_block->bindings.rbegin(); it != forward_block->bindings.rend(); ++it) {
@@ -546,7 +546,7 @@ class BackwardBindingGenerator : private ExprVisitor {
       auto* tensor_ty = ty.as<TensorTypeNode>();
       TVM_FFI_ICHECK(tensor_ty) << "The leaf of adjoint should be a Tensor.";
       TVM_FFI_ICHECK(tensor_ty->shape.defined()) << "Missing shape when building zeros tuple.";
-      const Expr& init = zeros(tensor_ty->shape.value(), tensor_ty->dtype->dtype);
+      const Expr& init = zeros(tensor_ty->shape.value(), tensor_ty->GetDtypeRaw());
       return init;
     });
     return AdjointMsgToExpr(msg);
@@ -708,7 +708,8 @@ class GradientMutator : private ExprMutator {
   static bool IsFloatTensorType(const Type& ty) {
     auto* tensor_ty = ty.as<TensorTypeNode>();
     // Gradient eligibility preserves the old float-kind check; lanes do not affect this policy.
-    return tensor_ty && tensor_ty->dtype.MatchesCode(DLDataTypeCode::kDLFloat);
+    return tensor_ty && !tensor_ty->IsUnknownDtype() &&
+           tensor_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat);
   }
 
   // When the return value is a Var, it is the target;

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -304,7 +304,8 @@ class BackwardBindingGenerator : private ExprVisitor {
 
     // Initialize the adjoint of target_var as ones op. We have already checked the target.
     auto* target_ty = GetTypeAs<TensorTypeNode>(target_var);
-    generator.UpdateAdjoint(target_var, ones(target_ty->shape.value(), target_ty->GetDtypeRaw()));
+    generator.UpdateAdjoint(target_var,
+                            ones(target_ty->shape.value(), target_ty->dtype.value()->dtype));
 
     // Do reverse-mode ad, so visit bindings backwards
     for (auto it = forward_block->bindings.rbegin(); it != forward_block->bindings.rend(); ++it) {
@@ -546,7 +547,7 @@ class BackwardBindingGenerator : private ExprVisitor {
       auto* tensor_ty = ty.as<TensorTypeNode>();
       TVM_FFI_ICHECK(tensor_ty) << "The leaf of adjoint should be a Tensor.";
       TVM_FFI_ICHECK(tensor_ty->shape.defined()) << "Missing shape when building zeros tuple.";
-      const Expr& init = zeros(tensor_ty->shape.value(), tensor_ty->GetDtypeRaw());
+      const Expr& init = zeros(tensor_ty->shape.value(), tensor_ty->dtype.value()->dtype);
       return init;
     });
     return AdjointMsgToExpr(msg);
@@ -709,7 +710,7 @@ class GradientMutator : private ExprMutator {
     auto* tensor_ty = ty.as<TensorTypeNode>();
     // Gradient eligibility preserves the old float-kind check; lanes do not affect this policy.
     return tensor_ty && !tensor_ty->IsUnknownDtype() &&
-           tensor_ty->GetDtype().MatchesCode(DLDataTypeCode::kDLFloat);
+           tensor_ty->dtype.value().MatchesCode(DLDataTypeCode::kDLFloat);
   }
 
   // When the return value is a Var, it is the target;

--- a/src/relax/transform/infer_amp_utils.cc
+++ b/src/relax/transform/infer_amp_utils.cc
@@ -27,7 +27,7 @@ NType NTypeFrom(const Type& ty, DLDataType dtype) {
     const auto* tensor = ty.as<TensorTypeNode>();
     TVM_FFI_ICHECK(tensor) << "Expected TensorType, but got " << ty;
     if (dtype == DLDataType{kDLOpaqueHandle, 0, 0})
-      return NType(DLDataTypeToString(tensor->GetDtypeRaw()));
+      return NType(DLDataTypeToString(tensor->dtype.value()->dtype));
     else
       return NType(DLDataTypeToString(dtype));
   };

--- a/src/relax/transform/infer_amp_utils.cc
+++ b/src/relax/transform/infer_amp_utils.cc
@@ -26,10 +26,12 @@ NType NTypeFrom(const Type& ty, DLDataType dtype) {
   auto fmapleaf = [&](const Type& ty) -> NType {
     const auto* tensor = ty.as<TensorTypeNode>();
     TVM_FFI_ICHECK(tensor) << "Expected TensorType, but got " << ty;
-    if (dtype == DLDataType{kDLOpaqueHandle, 0, 0})
+    if (dtype == DLDataType{kDLOpaqueHandle, 0, 0}) {
+      if (tensor->IsUnknownDtype()) return NType(ffi::String(""));
       return NType(DLDataTypeToString(tensor->dtype.value()->dtype));
-    else
+    } else {
       return NType(DLDataTypeToString(dtype));
+    }
   };
   return MapToNestedMsg<ffi::String>(ty, fmapleaf);
 }

--- a/src/relax/transform/infer_amp_utils.cc
+++ b/src/relax/transform/infer_amp_utils.cc
@@ -27,7 +27,7 @@ NType NTypeFrom(const Type& ty, DLDataType dtype) {
     const auto* tensor = ty.as<TensorTypeNode>();
     TVM_FFI_ICHECK(tensor) << "Expected TensorType, but got " << ty;
     if (dtype == DLDataType{kDLOpaqueHandle, 0, 0})
-      return NType(DLDataTypeToString(tensor->dtype->dtype));
+      return NType(DLDataTypeToString(tensor->GetDtypeRaw()));
     else
       return NType(DLDataTypeToString(dtype));
   };

--- a/src/relax/transform/reorder_take_after_matmul.cc
+++ b/src/relax/transform/reorder_take_after_matmul.cc
@@ -92,7 +92,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
       // indices.shape = [outfeatures]
 
       // out_table.shape = [*batch, table_size]
-      auto out_table = matmul(lhs, weights, (DLDataType{kDLOpaqueHandle, 0, 0}));
+      auto out_table = matmul(lhs, weights, std::nullopt);
       // new_output.shape = [*batch, outfeatures]
       auto new_output = take(out_table, indices, matmul_ty->ndim - 1);
 
@@ -116,7 +116,7 @@ std::tuple<DFPattern, ffi::TypedFunction<Expr(Expr, ffi::Map<DFPattern, Expr>)>>
       auto fused_weight = reshape(reordered_weight,
                                   ShapeExpr({weight_shape[1], weight_shape[0] * weight_shape[2]}));
       // fused_output.shape = [batch1, batch2, table_size * outfeatures]
-      auto fused_output = matmul(lhs, fused_weight, (DLDataType{kDLOpaqueHandle, 0, 0}));
+      auto fused_output = matmul(lhs, fused_weight, std::nullopt);
       // indexed_output.shape = [batch1, batch2, table_size, outfeatures]
       auto indexed_output = reshape(
           fused_output, ShapeExpr({lhs_shape[0], lhs_shape[1], weight_shape[0], weight_shape[2]}));

--- a/src/relax/transform/specialize_primfunc_based_on_callsite.cc
+++ b/src/relax/transform/specialize_primfunc_based_on_callsite.cc
@@ -99,8 +99,8 @@ class SpecializeTIRCallArgs : ExprMutator {
         name = std::string({static_cast<char>('A' + i)});
       }
 
-      const Buffer& buffer =
-          tirx::decl_buffer(GetShapeFromTensorType(tensor_ty), tensor_ty->GetDtype(), name, scope);
+      const Buffer& buffer = tirx::decl_buffer(GetShapeFromTensorType(tensor_ty),
+                                               tensor_ty->dtype.value(), name, scope);
       param_map.Set(pfunc->params[i], buffer);
     }
     ffi::String scope = "global";
@@ -111,7 +111,7 @@ class SpecializeTIRCallArgs : ExprMutator {
         scope = ty->vdevice.value()->memory_scope;
       }
       const Buffer& buffer =
-          tirx::decl_buffer(GetShapeFromTensorType(ty), ty->GetDtype(), "ret_val", scope);
+          tirx::decl_buffer(GetShapeFromTensorType(ty), ty->dtype.value(), "ret_val", scope);
       param_map.Set(pfunc->params[pfunc->params.size() - 1], buffer);
     } else {
       TVM_FFI_ICHECK(out_ty->IsInstance<TupleTypeNode>())
@@ -132,7 +132,7 @@ class SpecializeTIRCallArgs : ExprMutator {
           scope = ty->vdevice.value()->memory_scope;
         }
 
-        const Buffer& buffer = tirx::decl_buffer(GetShapeFromTensorType(ty), ty->GetDtype(),
+        const Buffer& buffer = tirx::decl_buffer(GetShapeFromTensorType(ty), ty->dtype.value(),
                                                  "ret_val_" + std::to_string(index), scope);
         param_map.Set(pfunc->params[args.size() + index], buffer);
         index++;

--- a/src/relax/transform/specialize_primfunc_based_on_callsite.cc
+++ b/src/relax/transform/specialize_primfunc_based_on_callsite.cc
@@ -100,7 +100,7 @@ class SpecializeTIRCallArgs : ExprMutator {
       }
 
       const Buffer& buffer =
-          tirx::decl_buffer(GetShapeFromTensorType(tensor_ty), tensor_ty->dtype, name, scope);
+          tirx::decl_buffer(GetShapeFromTensorType(tensor_ty), tensor_ty->GetDtype(), name, scope);
       param_map.Set(pfunc->params[i], buffer);
     }
     ffi::String scope = "global";
@@ -111,7 +111,7 @@ class SpecializeTIRCallArgs : ExprMutator {
         scope = ty->vdevice.value()->memory_scope;
       }
       const Buffer& buffer =
-          tirx::decl_buffer(GetShapeFromTensorType(ty), ty->dtype, "ret_val", scope);
+          tirx::decl_buffer(GetShapeFromTensorType(ty), ty->GetDtype(), "ret_val", scope);
       param_map.Set(pfunc->params[pfunc->params.size() - 1], buffer);
     } else {
       TVM_FFI_ICHECK(out_ty->IsInstance<TupleTypeNode>())
@@ -132,7 +132,7 @@ class SpecializeTIRCallArgs : ExprMutator {
           scope = ty->vdevice.value()->memory_scope;
         }
 
-        const Buffer& buffer = tirx::decl_buffer(GetShapeFromTensorType(ty), ty->dtype,
+        const Buffer& buffer = tirx::decl_buffer(GetShapeFromTensorType(ty), ty->GetDtype(),
                                                  "ret_val_" + std::to_string(index), scope);
         param_map.Set(pfunc->params[args.size() + index], buffer);
         index++;

--- a/src/relax/transform/static_plan_block_memory.cc
+++ b/src/relax/transform/static_plan_block_memory.cc
@@ -640,7 +640,7 @@ class StorageAllocatorInit : public StorageAllocatorBaseVisitor {
     const auto* shape = ty->shape.as<ShapeExprNode>();
     TVM_FFI_ICHECK_NOTNULL(shape);
     TVM_FFI_ICHECK(!ty->IsUnknownDtype());
-    TVM_FFI_ICHECK(ty->dtype->dtype == call->args[1].as_or_throw<DataTypeImm>()->value);
+    TVM_FFI_ICHECK(ty->GetDtypeRaw() == call->args[1].as_or_throw<DataTypeImm>()->value);
     TVM_FFI_ICHECK(!token_map_.count(call));
 
     // Use the upper bounds of TIR vars as their values. The upper bound shape can still be dynamic
@@ -657,7 +657,7 @@ class StorageAllocatorInit : public StorageAllocatorBaseVisitor {
     }
     ffi::Optional<VDevice> vdevice = GetGlobalVDevice(ctx_mod_, vdevice_index);
 
-    StorageToken token(upper_bounded_shape, ty->dtype->dtype, storage_scope->value, vdevice);
+    StorageToken token(upper_bounded_shape, ty->GetDtypeRaw(), storage_scope->value, vdevice);
 
     Tokens tokens(token);
     SetTokens(call, tokens);
@@ -955,7 +955,7 @@ class StorageAllocationRewriter : public ExprMutator {
 
       // And always create a `memory.alloc_tensor` for the old `builtin.alloc_tensor`.
       PrimExpr offset = IntImm::Int64(0);
-      DLDataType dtype = ty->dtype->dtype;
+      DLDataType dtype = ty->GetDtypeRaw();
       return Call(mem_alloc_tensor,
                   {storage_var, offset, ty->shape.value(), DataTypeImm(dtype), call->args[2]},
                   Attrs());
@@ -974,12 +974,12 @@ class StorageAllocationRewriter : public ExprMutator {
           GetUpperBoundShape(shape->values, ana_.get(), dom_map_);
       if (!IsStaticShape(shape->values)) {
         TVM_FFI_ICHECK(!ty->IsUnknownDtype());
-        TVM_FFI_ICHECK_EQ(ty->dtype->dtype, call->args[1].as_or_throw<DataTypeImm>()->value);
+        TVM_FFI_ICHECK_EQ(ty->GetDtypeRaw(), call->args[1].as_or_throw<DataTypeImm>()->value);
         PrimExpr bytes = upper_bounded_shape[0];
         for (int i = 1; i < static_cast<int>(upper_bounded_shape.size()); ++i) {
           bytes *= upper_bounded_shape[i];
         }
-        DLDataType dtype = ty->dtype->dtype;
+        DLDataType dtype = ty->GetDtypeRaw();
         PrimType dtype_ty(dtype);
         TVM_FFI_ICHECK(!dtype_ty.IsScalableVector())
             << "Cannot statically plan storage size for scalable vector dtype " << dtype_ty;

--- a/src/relax/transform/static_plan_block_memory.cc
+++ b/src/relax/transform/static_plan_block_memory.cc
@@ -640,7 +640,7 @@ class StorageAllocatorInit : public StorageAllocatorBaseVisitor {
     const auto* shape = ty->shape.as<ShapeExprNode>();
     TVM_FFI_ICHECK_NOTNULL(shape);
     TVM_FFI_ICHECK(!ty->IsUnknownDtype());
-    TVM_FFI_ICHECK(ty->GetDtypeRaw() == call->args[1].as_or_throw<DataTypeImm>()->value);
+    TVM_FFI_ICHECK(ty->dtype.value()->dtype == call->args[1].as_or_throw<DataTypeImm>()->value);
     TVM_FFI_ICHECK(!token_map_.count(call));
 
     // Use the upper bounds of TIR vars as their values. The upper bound shape can still be dynamic
@@ -657,7 +657,8 @@ class StorageAllocatorInit : public StorageAllocatorBaseVisitor {
     }
     ffi::Optional<VDevice> vdevice = GetGlobalVDevice(ctx_mod_, vdevice_index);
 
-    StorageToken token(upper_bounded_shape, ty->GetDtypeRaw(), storage_scope->value, vdevice);
+    StorageToken token(upper_bounded_shape, ty->dtype.value()->dtype, storage_scope->value,
+                       vdevice);
 
     Tokens tokens(token);
     SetTokens(call, tokens);
@@ -955,7 +956,7 @@ class StorageAllocationRewriter : public ExprMutator {
 
       // And always create a `memory.alloc_tensor` for the old `builtin.alloc_tensor`.
       PrimExpr offset = IntImm::Int64(0);
-      DLDataType dtype = ty->GetDtypeRaw();
+      DLDataType dtype = ty->dtype.value()->dtype;
       return Call(mem_alloc_tensor,
                   {storage_var, offset, ty->shape.value(), DataTypeImm(dtype), call->args[2]},
                   Attrs());
@@ -974,12 +975,13 @@ class StorageAllocationRewriter : public ExprMutator {
           GetUpperBoundShape(shape->values, ana_.get(), dom_map_);
       if (!IsStaticShape(shape->values)) {
         TVM_FFI_ICHECK(!ty->IsUnknownDtype());
-        TVM_FFI_ICHECK_EQ(ty->GetDtypeRaw(), call->args[1].as_or_throw<DataTypeImm>()->value);
+        TVM_FFI_ICHECK_EQ(ty->dtype.value()->dtype,
+                          call->args[1].as_or_throw<DataTypeImm>()->value);
         PrimExpr bytes = upper_bounded_shape[0];
         for (int i = 1; i < static_cast<int>(upper_bounded_shape.size()); ++i) {
           bytes *= upper_bounded_shape[i];
         }
-        DLDataType dtype = ty->GetDtypeRaw();
+        DLDataType dtype = ty->dtype.value()->dtype;
         PrimType dtype_ty(dtype);
         TVM_FFI_ICHECK(!dtype_ty.IsScalableVector())
             << "Cannot statically plan storage size for scalable vector dtype " << dtype_ty;

--- a/src/relax/transform/to_mixed_precision.cc
+++ b/src/relax/transform/to_mixed_precision.cc
@@ -315,7 +315,7 @@ class ToMixedPrecisionRewriter : public ExprMutator {
       if (NTypeEqual()(to[0], NTypeFrom(expr))) return expr;
       // We only rewrite the expr if the dtype is fp16 or fp32, dtypes such as int32, float64 is not
       // supported to be rewritten
-      DLDataType tensor_dtype = tensor->dtype->dtype;
+      DLDataType tensor_dtype = tensor->GetDtypeRaw();
       if (tensor_dtype != fp16_ && tensor_dtype != fp32_) return expr;
       return astype(expr, ffi::StringToDLDataType(to[0].LeafValue()));
     };

--- a/src/relax/transform/to_mixed_precision.cc
+++ b/src/relax/transform/to_mixed_precision.cc
@@ -313,6 +313,8 @@ class ToMixedPrecisionRewriter : public ExprMutator {
       TVM_FFI_ICHECK(tensor != nullptr) << "Only support rewriting tensor expr";
       // We only rewrite the expr if the dtype is not the same as the given dtype
       if (NTypeEqual()(to[0], NTypeFrom(expr))) return expr;
+      // If the source dtype is unknown, there is no concrete dtype to cast from.
+      if (tensor->IsUnknownDtype()) return expr;
       // We only rewrite the expr if the dtype is fp16 or fp32, dtypes such as int32, float64 is not
       // supported to be rewritten
       DLDataType tensor_dtype = tensor->dtype.value()->dtype;

--- a/src/relax/transform/to_mixed_precision.cc
+++ b/src/relax/transform/to_mixed_precision.cc
@@ -125,7 +125,7 @@ class DTypeDecisionCollector : public ExprVisitor {
   }
 
  private:
-  NType GetDType(const Var& var) {
+  NType GetTrackedDType(const Var& var) {
     auto it = only_fp16_map_.find(var);
     if (it == only_fp16_map_.end()) {
       // we never encounter this var before
@@ -209,14 +209,14 @@ class DTypeDecisionCollector : public ExprVisitor {
 
   void VisitBinding_(const VarBindingNode* binding, const TupleNode* tuple_node) final {
     // require input fields to be the type of the lhs field respectively
-    NType lhs_type = GetDType(binding->var);
+    NType lhs_type = GetTrackedDType(binding->var);
     RequireArgsToType(tuple_node->fields, lhs_type.NestedArray());
   }
 
   void VisitBinding_(const VarBindingNode* binding,
                      const TupleGetItemNode* tuple_get_item_node) final {
     // require the i-th field rhs tuple to be the type of the lhs
-    NType lhs_type = GetDType(binding->var);
+    NType lhs_type = GetTrackedDType(binding->var);
     std::vector<NType> require_rhs;
     const TupleTypeNode* ty = tuple_get_item_node->tuple->ty.as<TupleTypeNode>();
     TVM_FFI_ICHECK(ty != nullptr) << "TupleGetItemNode must have TupleType";
@@ -315,7 +315,7 @@ class ToMixedPrecisionRewriter : public ExprMutator {
       if (NTypeEqual()(to[0], NTypeFrom(expr))) return expr;
       // We only rewrite the expr if the dtype is fp16 or fp32, dtypes such as int32, float64 is not
       // supported to be rewritten
-      DLDataType tensor_dtype = tensor->GetDtypeRaw();
+      DLDataType tensor_dtype = tensor->dtype.value()->dtype;
       if (tensor_dtype != fp16_ && tensor_dtype != fp32_) return expr;
       return astype(expr, ffi::StringToDLDataType(to[0].LeafValue()));
     };

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -183,8 +183,12 @@ bool IsBoolType(const Type& ty, bool permit_unknown_rank, bool permit_unknown_dt
   int ndim;
 
   if (const auto* tensor = ty.as<TensorTypeNode>()) {
-    dtype = tensor->dtype.value()->dtype;
     ndim = tensor->ndim;
+    if (tensor->IsUnknownDtype()) {
+      bool correct_rank = ndim == 0 || (permit_unknown_rank && ndim == -1);
+      return permit_unknown_dtype && correct_rank;
+    }
+    dtype = tensor->dtype.value()->dtype;
   } else if (const auto* prim = ty.as<PrimTypeNode>()) {
     dtype = prim->dtype;
     ndim = 0;

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -183,7 +183,7 @@ bool IsBoolType(const Type& ty, bool permit_unknown_rank, bool permit_unknown_dt
   int ndim;
 
   if (const auto* tensor = ty.as<TensorTypeNode>()) {
-    dtype = tensor->GetDtypeRaw();
+    dtype = tensor->dtype.value()->dtype;
     ndim = tensor->ndim;
   } else if (const auto* prim = ty.as<PrimTypeNode>()) {
     dtype = prim->dtype;

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -183,7 +183,7 @@ bool IsBoolType(const Type& ty, bool permit_unknown_rank, bool permit_unknown_dt
   int ndim;
 
   if (const auto* tensor = ty.as<TensorTypeNode>()) {
-    dtype = tensor->dtype->dtype;
+    dtype = tensor->GetDtypeRaw();
     ndim = tensor->ndim;
   } else if (const auto* prim = ty.as<PrimTypeNode>()) {
     dtype = prim->dtype;

--- a/src/runtime/vm/builtin.cc
+++ b/src/runtime/vm/builtin.cc
@@ -243,14 +243,14 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 void CheckTensorInfo(ffi::PackedArgs args, ffi::Any* rv) {
   ffi::AnyView arg = args[0];
   int ndim = args[1].cast<int>();
-  DLDataType dtype;
+  ffi::Optional<DLDataType> dtype;
   ffi::Optional<ffi::String> err_ctx;
 
   if (args.size() == 3) {
-    dtype = DLDataType{kDLOpaqueHandle, 0, 0};
+    dtype = std::nullopt;
     err_ctx = args[2].cast<ffi::Optional<ffi::String>>();
   } else {
-    dtype = args[2].cast<DLDataType>();
+    dtype = args[2].cast<ffi::Optional<DLDataType>>();
     err_ctx = args[3].cast<ffi::Optional<ffi::String>>();
   }
 
@@ -264,9 +264,9 @@ void CheckTensorInfo(ffi::PackedArgs args, ffi::Any* rv) {
         << err_ctx.value_or("") << " expect Tensor with ndim " << ndim << " but get " << ptr->ndim;
   }
 
-  if (dtype != DLDataType{kDLOpaqueHandle, 0, 0}) {
-    TVM_FFI_CHECK(ptr->dtype == dtype, ValueError)
-        << err_ctx.value_or("") << " expect Tensor with dtype " << dtype << " but get "
+  if (dtype) {
+    TVM_FFI_CHECK(ptr->dtype == dtype.value(), ValueError)
+        << err_ctx.value_or("") << " expect Tensor with dtype " << dtype.value() << " but get "
         << ptr->dtype;
   }
 }

--- a/tests/python/relax/backend/adreno/test_texture_network.py
+++ b/tests/python/relax/backend/adreno/test_texture_network.py
@@ -181,7 +181,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv5: R.Tuple(
                     R.Tensor((1, 64, 112, 112), dtype="float32"),
@@ -244,7 +243,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv17: R.Tuple(
                     R.Tensor((1, 64, 56, 56), dtype="float32"),
@@ -276,7 +274,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv23: R.Tensor((1, 64, 56, 56), dtype="float32") = R.add(lv22, lv10)
                 lv24: R.Tuple(
@@ -309,7 +306,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv30: R.Tuple(
                     R.Tensor((1, 64, 56, 56), dtype="float32"),
@@ -341,7 +337,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv36: R.Tensor((1, 64, 56, 56), dtype="float32") = R.add(lv35, lv23)
                 lv37: R.Tuple(
@@ -374,7 +369,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv43: R.Tuple(
                     R.Tensor((1, 128, 28, 28), dtype="float32"),
@@ -406,7 +400,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv49: R.Tensor((1, 128, 28, 28), dtype="float32") = R.nn.conv2d(
                     lv41,
@@ -418,7 +411,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv50: R.Tensor((1, 128, 28, 28), dtype="float32") = R.add(lv48, lv49)
                 lv51: R.Tuple(
@@ -451,7 +443,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv57: R.Tuple(
                     R.Tensor((1, 128, 28, 28), dtype="float32"),
@@ -483,7 +474,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv63: R.Tensor((1, 128, 28, 28), dtype="float32") = R.add(lv62, lv50)
                 lv64: R.Tuple(
@@ -516,7 +506,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv70: R.Tuple(
                     R.Tensor((1, 256, 14, 14), dtype="float32"),
@@ -548,7 +537,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv76: R.Tensor((1, 256, 14, 14), dtype="float32") = R.nn.conv2d(
                     lv68,
@@ -560,7 +548,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv77: R.Tensor((1, 256, 14, 14), dtype="float32") = R.add(lv75, lv76)
                 lv78: R.Tuple(
@@ -593,7 +580,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv84: R.Tuple(
                     R.Tensor((1, 256, 14, 14), dtype="float32"),
@@ -625,7 +611,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv90: R.Tensor((1, 256, 14, 14), dtype="float32") = R.add(lv89, lv77)
                 lv91: R.Tuple(
@@ -658,7 +643,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv97: R.Tuple(
                     R.Tensor((1, 512, 7, 7), dtype="float32"),
@@ -690,7 +674,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv103: R.Tensor((1, 512, 7, 7), dtype="float32") = R.nn.conv2d(
                     lv95,
@@ -702,7 +685,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv104: R.Tensor((1, 512, 7, 7), dtype="float32") = R.add(lv102, lv103)
                 lv105: R.Tuple(
@@ -735,7 +717,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv111: R.Tuple(
                     R.Tensor((1, 512, 7, 7), dtype="float32"),
@@ -767,7 +748,6 @@ def test_network_resnet():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 lv117: R.Tensor((1, 512, 7, 7), dtype="float32") = R.add(lv116, lv104)
                 lv118: R.Tuple(
@@ -797,9 +777,7 @@ def test_network_resnet():
                 lv125: R.Tensor((512, 1000), dtype="float32") = R.permute_dims(
                     resnetv22_dense0_weight, axes=[1, 0]
                 )
-                lv126: R.Tensor((1, 1000), dtype="float32") = R.matmul(
-                    lv124, lv125, out_dtype="void"
-                )
+                lv126: R.Tensor((1, 1000), dtype="float32") = R.matmul(lv124, lv125)
                 gv: R.Tensor((1, 1000), dtype="float32") = R.add(lv126, resnetv22_dense0_bias)
                 R.output(gv)
             return gv

--- a/tests/python/relax/distributed/test_distributed_transform_propagate_sharding.py
+++ b/tests/python/relax/distributed/test_distributed_transform_propagate_sharding.py
@@ -65,13 +65,9 @@ def test_mlp():
             weight1: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]"),
             weight2: R.DTensor((128, 128), "float32", "mesh[0]", "S[0]"),
         ) -> R.DTensor((128, 128), "float32", "mesh[0]", "R"):
-            lv0: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.matmul(
-                x, weight1, out_dtype="void"
-            )
+            lv0: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.matmul(x, weight1)
             lv1: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.nn.gelu(lv0)
-            lv3: R.DTensor((128, 128), "float32", "mesh[0]", "R") = R.matmul(
-                lv1, weight2, out_dtype="void"
-            )
+            lv3: R.DTensor((128, 128), "float32", "mesh[0]", "R") = R.matmul(lv1, weight2)
             return lv3
 
     after = relax.distributed.transform.PropagateSharding()(MLP)
@@ -167,9 +163,7 @@ def test_mlp_with_tuple():
         ) -> R.DTensor((64, 128), "float32", "mesh[0]", "R"):
             cls = ShardedMLPWithTuple
             weight1: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = weight_packed[0]
-            lv0: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.matmul(
-                x, weight1, out_dtype="void"
-            )
+            lv0: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.matmul(x, weight1)
             lv1: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.nn.gelu(lv0)
             gv = R.dist.call_tir(
                 cls.split1,
@@ -181,9 +175,7 @@ def test_mlp_with_tuple():
             )
             lv2: R.DTensor((64, 128), "float32", "mesh[0]", "S[1]") = gv[0]
             weight2: R.DTensor((128, 128), "float32", "mesh[0]", "S[0]") = weight_packed[1]
-            lv4: R.DTensor((64, 128), "float32", "mesh[0]", "R") = R.matmul(
-                lv2, weight2, out_dtype="void"
-            )
+            lv4: R.DTensor((64, 128), "float32", "mesh[0]", "R") = R.matmul(lv2, weight2)
             return lv4
 
     after = relax.distributed.transform.PropagateSharding()(MLPWithTuple)
@@ -229,16 +221,12 @@ def test_mlp_const():
             weight1: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]"),
             weight2: R.DTensor((128, 128), "float32", "mesh[0]", "S[0]"),
         ) -> R.DTensor((128, 128), "float32", "mesh[0]", "R"):
-            lv0: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.matmul(
-                x, weight1, out_dtype="void"
-            )
+            lv0: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.matmul(x, weight1)
             lv1: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.nn.gelu(lv0)
             lv2: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.add(
                 lv1, R.dist.const(2, R.DTensor((), "float32", "mesh[0]", "R"))
             )
-            lv4: R.DTensor((128, 128), "float32", "mesh[0]", "R") = R.matmul(
-                lv2, weight2, out_dtype="void"
-            )
+            lv4: R.DTensor((128, 128), "float32", "mesh[0]", "R") = R.matmul(lv2, weight2)
             return lv4
 
     after = relax.distributed.transform.PropagateSharding()(MLPWithConst)
@@ -287,13 +275,9 @@ def test_mlp_dynamic_shape():
             n = T.int64()
             k0 = T.int64()
             k1 = T.int64()
-            lv0: R.DTensor((m, k1), "float32", "mesh[0]", "S[1]") = R.matmul(
-                x, weight1, out_dtype="void"
-            )
+            lv0: R.DTensor((m, k1), "float32", "mesh[0]", "S[1]") = R.matmul(x, weight1)
             lv1: R.DTensor((m, k1), "float32", "mesh[0]", "S[1]") = R.nn.gelu(lv0)
-            lv3: R.DTensor((m, n), "float32", "mesh[0]", "R") = R.matmul(
-                lv1, weight2, out_dtype="void"
-            )
+            lv3: R.DTensor((m, n), "float32", "mesh[0]", "R") = R.matmul(lv1, weight2)
             return lv3
 
     after = relax.distributed.transform.PropagateSharding()(MLPDynamicShape)
@@ -350,23 +334,15 @@ def test_mlp_pipeline_parallelism():
             weight3: R.DTensor((128, 128), "float32", "mesh[1]", "S[1]"),
             weight4: R.DTensor((128, 128), "float32", "mesh[1]", "S[0]"),
         ) -> R.DTensor((128, 128), "float32", "mesh[1]", "R"):
-            lv0: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.matmul(
-                x, weight1, out_dtype="void"
-            )
+            lv0: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.matmul(x, weight1)
             lv1: R.DTensor((128, 128), "float32", "mesh[0]", "S[1]") = R.nn.gelu(lv0)
-            lv3: R.DTensor((128, 128), "float32", "mesh[0]", "R") = R.matmul(
-                lv1, weight2, out_dtype="void"
-            )
+            lv3: R.DTensor((128, 128), "float32", "mesh[0]", "R") = R.matmul(lv1, weight2)
             lv4: R.DTensor((128, 128), "float32", "mesh[1]", "R") = R.dist.redistribute(
                 lv3, device_mesh="mesh[1]", placement="R"
             )
-            lv5: R.DTensor((128, 128), "float32", "mesh[1]", "S[1]") = R.matmul(
-                lv4, weight3, out_dtype="void"
-            )
+            lv5: R.DTensor((128, 128), "float32", "mesh[1]", "S[1]") = R.matmul(lv4, weight3)
             lv6: R.DTensor((128, 128), "float32", "mesh[1]", "S[1]") = R.nn.gelu(lv5)
-            lv8: R.DTensor((128, 128), "float32", "mesh[1]", "R") = R.matmul(
-                lv6, weight4, out_dtype="void"
-            )
+            lv8: R.DTensor((128, 128), "float32", "mesh[1]", "R") = R.matmul(lv6, weight4)
             return lv8
 
     after = relax.distributed.transform.PropagateSharding()(PipelineMLP)
@@ -479,9 +455,7 @@ def test_decoder_layer():
             lv7_copy: R.Tensor((4096, 4096), dtype="float16") = R.dist.annotate_sharding(
                 lv7, "mesh[0]", "S[1]"
             )
-            lv8: R.Tensor((1, 256, 4096), dtype="float16") = R.matmul(
-                lv6, lv7_copy, out_dtype="void"
-            )
+            lv8: R.Tensor((1, 256, 4096), dtype="float16") = R.matmul(lv6, lv7_copy)
             lv9: R.Tensor((1, 256, 32, 128), dtype="float16") = R.reshape(
                 lv8, R.shape([1, 256, 32, 128])
             )
@@ -491,9 +465,7 @@ def test_decoder_layer():
             lv10_copy: R.Tensor((4096, 4096), dtype="float16") = R.dist.annotate_sharding(
                 lv10, "mesh[0]", "S[1]"
             )
-            lv11: R.Tensor((1, 256, 4096), dtype="float16") = R.matmul(
-                lv6, lv10_copy, out_dtype="void"
-            )
+            lv11: R.Tensor((1, 256, 4096), dtype="float16") = R.matmul(lv6, lv10_copy)
             lv12: R.Tensor((1, 256, 32, 128), dtype="float16") = R.reshape(
                 lv11, R.shape([1, 256, 32, 128])
             )
@@ -503,9 +475,7 @@ def test_decoder_layer():
             lv13_copy: R.Tensor((4096, 4096), dtype="float16") = R.dist.annotate_sharding(
                 lv13, "mesh[0]", "S[1]"
             )
-            lv14: R.Tensor((1, 256, 4096), dtype="float16") = R.matmul(
-                lv6, lv13_copy, out_dtype="void"
-            )
+            lv14: R.Tensor((1, 256, 4096), dtype="float16") = R.matmul(lv6, lv13_copy)
             lv15: R.Tensor((1, 256, 32, 128), dtype="float16") = R.reshape(
                 lv14, R.shape([1, 256, 32, 128])
             )
@@ -563,18 +533,14 @@ def test_decoder_layer():
             lv31: R.Tensor((1, 32, 128, 256), dtype="float16") = R.permute_dims(
                 lv29, axes=[0, 1, 3, 2]
             )
-            lv32: R.Tensor((1, 32, 256, 256), dtype="float16") = R.matmul(
-                lv28, lv31, out_dtype="void"
-            )
+            lv32: R.Tensor((1, 32, 256, 256), dtype="float16") = R.matmul(lv28, lv31)
             lv33: R.Tensor((1, 32, 256, 256), dtype="float16") = R.divide(lv32, div_const)
             lv34: R.Tensor((1, 32, 256, 256), dtype="float16") = R.maximum(lv33, maximum_const)
             lv35: R.Tensor((1, 32, 256, 256), dtype="float16") = R.minimum(lv34, mask)
             # lv36: R.Tensor((1, 32, 256, 256), dtype="float32") = R.astype(lv35, dtype="float32")
             lv37: R.Tensor((1, 32, 256, 256), dtype="float16") = R.nn.softmax(lv35, axis=-1)
             # lv38: R.Tensor((1, 32, 256, 256), dtype="float16") = R.astype(lv37, dtype="float16")
-            lv39: R.Tensor((1, 32, 256, 128), dtype="float16") = R.matmul(
-                lv37, lv30, out_dtype="void"
-            )
+            lv39: R.Tensor((1, 32, 256, 128), dtype="float16") = R.matmul(lv37, lv30)
             lv40: R.Tensor((1, 256, 32, 128), dtype="float16") = R.permute_dims(
                 lv39, axes=[0, 2, 1, 3]
             )
@@ -584,7 +550,7 @@ def test_decoder_layer():
             lv42: R.Tensor((4096, 4096), dtype="float16") = R.permute_dims(
                 linear_weight3, axes=None
             )
-            lv43: R.Tensor((1, 256, 4096), dtype="float16") = R.matmul(lv41, lv42, out_dtype="void")
+            lv43: R.Tensor((1, 256, 4096), dtype="float16") = R.matmul(lv41, lv42)
             lv44: R.Tensor((1, 256, 4096), dtype="float16") = R.add(input_tokens, lv43)
             gv = lv44
 
@@ -683,27 +649,21 @@ def test_decoder_layer():
             lv7: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[1]") = R.permute_dims(
                 linear_weight, axes=None
             )
-            lv8: R.DTensor((1, 256, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(
-                lv6, lv7, out_dtype="void"
-            )
+            lv8: R.DTensor((1, 256, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(lv6, lv7)
             lv9: R.DTensor((1, 256, 32, 128), "float16", "mesh[0]", "S[2]") = R.reshape(
                 lv8, R.shape([1, 256, 32, 128])
             )
             lv10: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[1]") = R.permute_dims(
                 linear_weight1, axes=None
             )
-            lv11: R.DTensor((1, 256, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(
-                lv6, lv10, out_dtype="void"
-            )
+            lv11: R.DTensor((1, 256, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(lv6, lv10)
             lv12: R.DTensor((1, 256, 32, 128), "float16", "mesh[0]", "S[2]") = R.reshape(
                 lv11, R.shape([1, 256, 32, 128])
             )
             lv13: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[1]") = R.permute_dims(
                 linear_weight2, axes=None
             )
-            lv14: R.DTensor((1, 256, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(
-                lv6, lv13, out_dtype="void"
-            )
+            lv14: R.DTensor((1, 256, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(lv6, lv13)
             lv15: R.DTensor((1, 256, 32, 128), "float16", "mesh[0]", "S[2]") = R.reshape(
                 lv14, R.shape([1, 256, 32, 128])
             )
@@ -767,9 +727,7 @@ def test_decoder_layer():
             lv31: R.DTensor((1, 32, 128, 256), "float16", "mesh[0]", "S[1]") = R.permute_dims(
                 lv29, axes=[0, 1, 3, 2]
             )
-            lv32: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]") = R.matmul(
-                lv28, lv31, out_dtype="void"
-            )
+            lv32: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]") = R.matmul(lv28, lv31)
             lv33: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]") = R.divide(
                 lv32, div_const
             )
@@ -780,9 +738,7 @@ def test_decoder_layer():
             lv37: R.DTensor((1, 32, 256, 256), "float16", "mesh[0]", "S[1]") = R.nn.softmax(
                 lv35, axis=-1
             )
-            lv39: R.DTensor((1, 32, 256, 128), "float16", "mesh[0]", "S[1]") = R.matmul(
-                lv37, lv30, out_dtype="void"
-            )
+            lv39: R.DTensor((1, 32, 256, 128), "float16", "mesh[0]", "S[1]") = R.matmul(lv37, lv30)
             lv40: R.DTensor((1, 256, 32, 128), "float16", "mesh[0]", "S[2]") = R.permute_dims(
                 lv39, axes=[0, 2, 1, 3]
             )
@@ -792,9 +748,7 @@ def test_decoder_layer():
             lv42: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]") = R.permute_dims(
                 linear_weight3, axes=None
             )
-            lv43: R.DTensor((1, 256, 4096), "float16", "mesh[0]", "R") = R.matmul(
-                lv41, lv42, out_dtype="void"
-            )
+            lv43: R.DTensor((1, 256, 4096), "float16", "mesh[0]", "R") = R.matmul(lv41, lv42)
             lv44: R.DTensor((1, 256, 4096), "float16", "mesh[0]", "R") = R.add(input_tokens, lv43)
             gv: R.DTensor((1, 256, 4096), "float16", "mesh[0]", "R") = lv44
             return gv
@@ -1693,7 +1647,7 @@ def test_decoder_layer_dynamic_shape():
             lv7_copy: R.Tensor((4096, 4096), dtype="float16") = R.dist.annotate_sharding(
                 lv7, "mesh[0]", "S[1]"
             )
-            lv8: R.Tensor((1, n, 4096), dtype="float16") = R.matmul(lv6, lv7_copy, out_dtype="void")
+            lv8: R.Tensor((1, n, 4096), dtype="float16") = R.matmul(lv6, lv7_copy)
             lv9: R.Tensor((1, n, 32, 128), dtype="float16") = R.reshape(
                 lv8, R.shape([1, n, 32, 128])
             )
@@ -1703,9 +1657,7 @@ def test_decoder_layer_dynamic_shape():
             lv10_copy: R.Tensor((4096, 4096), dtype="float16") = R.dist.annotate_sharding(
                 lv10, "mesh[0]", "S[1]"
             )
-            lv11: R.Tensor((1, n, 4096), dtype="float16") = R.matmul(
-                lv6, lv10_copy, out_dtype="void"
-            )
+            lv11: R.Tensor((1, n, 4096), dtype="float16") = R.matmul(lv6, lv10_copy)
             lv12: R.Tensor((1, n, 32, 128), dtype="float16") = R.reshape(
                 lv11, R.shape([1, n, 32, 128])
             )
@@ -1715,9 +1667,7 @@ def test_decoder_layer_dynamic_shape():
             lv13_copy: R.Tensor((4096, 4096), dtype="float16") = R.dist.annotate_sharding(
                 lv13, "mesh[0]", "S[1]"
             )
-            lv14: R.Tensor((1, n, 4096), dtype="float16") = R.matmul(
-                lv6, lv13_copy, out_dtype="void"
-            )
+            lv14: R.Tensor((1, n, 4096), dtype="float16") = R.matmul(lv6, lv13_copy)
             lv15: R.Tensor((1, n, 32, 128), dtype="float16") = R.reshape(
                 lv14, R.shape([1, n, 32, 128])
             )
@@ -1773,7 +1723,7 @@ def test_decoder_layer_dynamic_shape():
             lv31: R.Tensor((1, 32, 128, m), dtype="float16") = R.permute_dims(
                 lv29, axes=[0, 1, 3, 2]
             )
-            lv32: R.Tensor((1, 32, n, m), dtype="float16") = R.matmul(lv28, lv31, out_dtype="void")
+            lv32: R.Tensor((1, 32, n, m), dtype="float16") = R.matmul(lv28, lv31)
             lv33: R.Tensor((1, 32, n, m), dtype="float16") = R.divide(
                 lv32, R.const(8, dtype="float16")
             )  # just choose some random value
@@ -1784,9 +1734,7 @@ def test_decoder_layer_dynamic_shape():
             # lv36: R.Tensor((1, 32, n, m), dtype="float32") = R.astype(lv35, dtype="float32")
             lv37: R.Tensor((1, 32, n, m), dtype="float16") = R.nn.softmax(lv35, axis=-1)
             # lv38: R.Tensor((1, 32, n, m), dtype="float16") = R.astype(lv37, dtype="float16")
-            lv39: R.Tensor((1, 32, n, 128), dtype="float16") = R.matmul(
-                lv37, lv30, out_dtype="void"
-            )
+            lv39: R.Tensor((1, 32, n, 128), dtype="float16") = R.matmul(lv37, lv30)
             lv40: R.Tensor((1, n, 32, 128), dtype="float16") = R.permute_dims(
                 lv39, axes=[0, 2, 1, 3]
             )
@@ -1794,7 +1742,7 @@ def test_decoder_layer_dynamic_shape():
             lv42: R.Tensor((4096, 4096), dtype="float16") = R.permute_dims(
                 linear_weight3, axes=None
             )
-            lv43: R.Tensor((1, n, 4096), dtype="float16") = R.matmul(lv41, lv42, out_dtype="void")
+            lv43: R.Tensor((1, n, 4096), dtype="float16") = R.matmul(lv41, lv42)
             lv44: R.Tensor((1, n, 4096), dtype="float16") = R.add(input_tokens, lv43)
             gv = lv44
 
@@ -1900,27 +1848,21 @@ def test_decoder_layer_dynamic_shape():
             lv7: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[1]") = R.permute_dims(
                 linear_weight, axes=None
             )
-            lv8: R.DTensor((1, n, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(
-                lv6, lv7, out_dtype="void"
-            )
+            lv8: R.DTensor((1, n, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(lv6, lv7)
             lv9: R.DTensor((1, n, 32, 128), "float16", "mesh[0]", "S[2]") = R.reshape(
                 lv8, R.shape([1, n, 32, 128])
             )
             lv10: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[1]") = R.permute_dims(
                 linear_weight1, axes=None
             )
-            lv11: R.DTensor((1, n, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(
-                lv6, lv10, out_dtype="void"
-            )
+            lv11: R.DTensor((1, n, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(lv6, lv10)
             lv12: R.DTensor((1, n, 32, 128), "float16", "mesh[0]", "S[2]") = R.reshape(
                 lv11, R.shape([1, n, 32, 128])
             )
             lv13: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[1]") = R.permute_dims(
                 linear_weight2, axes=None
             )
-            lv14: R.DTensor((1, n, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(
-                lv6, lv13, out_dtype="void"
-            )
+            lv14: R.DTensor((1, n, 4096), "float16", "mesh[0]", "S[2]") = R.matmul(lv6, lv13)
             lv15: R.DTensor((1, n, 32, 128), "float16", "mesh[0]", "S[2]") = R.reshape(
                 lv14, R.shape([1, n, 32, 128])
             )
@@ -1986,9 +1928,7 @@ def test_decoder_layer_dynamic_shape():
             lv31: R.DTensor((1, 32, 128, m), "float16", "mesh[0]", "S[1]") = R.permute_dims(
                 lv29, axes=[0, 1, 3, 2]
             )
-            lv32: R.DTensor((1, 32, n, m), "float16", "mesh[0]", "S[1]") = R.matmul(
-                lv28, lv31, out_dtype="void"
-            )
+            lv32: R.DTensor((1, 32, n, m), "float16", "mesh[0]", "S[1]") = R.matmul(lv28, lv31)
             lv33: R.DTensor((1, 32, n, m), "float16", "mesh[0]", "S[1]") = R.divide(
                 lv32, R.dist.const(8, R.DTensor((), "float16", "mesh[0]", "R"))
             )
@@ -1999,9 +1939,7 @@ def test_decoder_layer_dynamic_shape():
             lv37: R.DTensor((1, 32, n, m), "float16", "mesh[0]", "S[1]") = R.nn.softmax(
                 lv35, axis=-1
             )
-            lv39: R.DTensor((1, 32, n, 128), "float16", "mesh[0]", "S[1]") = R.matmul(
-                lv37, lv30, out_dtype="void"
-            )
+            lv39: R.DTensor((1, 32, n, 128), "float16", "mesh[0]", "S[1]") = R.matmul(lv37, lv30)
             lv40: R.DTensor((1, n, 32, 128), "float16", "mesh[0]", "S[2]") = R.permute_dims(
                 lv39, axes=[0, 2, 1, 3]
             )
@@ -2011,9 +1949,7 @@ def test_decoder_layer_dynamic_shape():
             lv42: R.DTensor((4096, 4096), "float16", "mesh[0]", "S[0]") = R.permute_dims(
                 linear_weight3, axes=None
             )
-            lv43: R.DTensor((1, n, 4096), "float16", "mesh[0]", "R") = R.matmul(
-                lv41, lv42, out_dtype="void"
-            )
+            lv43: R.DTensor((1, n, 4096), "float16", "mesh[0]", "R") = R.matmul(lv41, lv42)
             lv44: R.DTensor((1, n, 4096), "float16", "mesh[0]", "R") = R.add(input_tokens, lv43)
             gv: R.DTensor((1, n, 4096), "float16", "mesh[0]", "R") = lv44
             return gv

--- a/tests/python/relax/distributed/test_distributed_tvmscript_printer.py
+++ b/tests/python/relax/distributed/test_distributed_tvmscript_printer.py
@@ -45,7 +45,7 @@ def test_constant():
 
 def test_dtensor_type():
     tensor_ty1 = TensorType((32, 32), "float32")
-    tensor_ty2 = TensorType((32, 32), "void")
+    tensor_ty2 = TensorType((32, 32), None)
     obj0 = DTensorType(tensor_ty1, DeviceMesh((2, 2), Range(0, 4)), Placement.from_text("S[1], R"))
     assert (
         obj0.__str__()

--- a/tests/python/relax/test_backend_transform_shape_lower.py
+++ b/tests/python/relax/test_backend_transform_shape_lower.py
@@ -220,9 +220,8 @@ def test_symbolic_compute():
                 "",
                 ty_args=[R.Tuple()],
             )
-            _ = R.call_packed(
-                "vm.builtin.check_tensor_info", y, 3, R.dtype(""), "", ty_args=[R.Tuple()]
-            )
+            gv = R.null_value()
+            _ = R.call_packed("vm.builtin.check_tensor_info", y, 3, gv, "", ty_args=[R.Tuple()])
             _ = R.call_packed(
                 "vm.builtin.match_shape",
                 x,

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -548,7 +548,7 @@ def test_cutlass_partition_matmul_tuple_return_blocked():
                 #     R.func_attr({"Composite": "cutlass.matmul_transposed", "Primitive": True})
                 #     with R.dataflow():
                 #         gv: R.Tensor((4, 4), dtype="float32") = R.permute_dims(y, axes=None)
-                #         gv1: R.Tensor((4, 4), dtype="float32") = R.matmul(x, gv, out_dtype="void")
+                #         gv1: R.Tensor((4, 4), dtype="float32") = R.matmul(x, gv)
                 #         R.output(gv, gv1)
                 #     return (gv, gv1)  # Cannot get `gv` if dispatch to cutlass kernel.
                 lv2 = R.matmul(x, lv1)

--- a/tests/python/relax/test_dataflow_inplace.py
+++ b/tests/python/relax/test_dataflow_inplace.py
@@ -1003,8 +1003,16 @@ class TestViewOpSharedStorageAndNoInplace:
         params = list(func.params)
 
         alias_sets, _ = dataflow_alias_analysis(block, params)
-        a_var = block.bindings[0].var
-        b_var = block.bindings[1].var
+        view_vars = [
+            binding.var
+            for binding in block.bindings
+            if (
+                isinstance(binding.value, relax.Call)
+                and isinstance(binding.value.op, tvm.ir.Op)
+                and binding.value.op.name == view_op
+            )
+        ]
+        a_var, b_var = view_vars[:2]
         assert alias_sets[a_var] & alias_sets[b_var], (
             f"{view_op}: duplicate views should share alias sets, but got "
             f"{alias_sets[a_var]} and {alias_sets[b_var]}"

--- a/tests/python/relax/test_dataflow_pattern.py
+++ b/tests/python/relax/test_dataflow_pattern.py
@@ -1117,7 +1117,7 @@ def test_combine_matmul_twice():
             lv1_1 = R.strided_slice(lv1, axes=[2], begin=[640], end=[1280])
             lv2 = R.strided_slice(lv1, axes=[2], begin=[1280], end=[1920])
             lv2_1 = R.concat((w3, w4, w5), axis=1)
-            lv3 = R.matmul(x2, lv2_1, out_dtype="void")
+            lv3 = R.matmul(x2, lv2_1)
             lv3_1 = R.strided_slice(lv3, axes=[2], begin=[0], end=[640])
             lv4 = R.strided_slice(lv3, axes=[2], begin=[640], end=[1280])
             lv5 = R.strided_slice(lv3, axes=[2], begin=[1280], end=[1920])
@@ -1217,7 +1217,7 @@ def test_combine_matmul_emit_order():
             w1_t_t = R.permute_dims(w1_t, axes=None)
             w2_t = R.permute_dims(w2, axes=None)
             lv = R.concat((w0_t, w1_t_t, w2_t), axis=1)
-            lv1 = R.matmul(x1, lv, out_dtype="void")
+            lv1 = R.matmul(x1, lv)
             lv0 = R.strided_slice(lv1, axes=[2], begin=[0], end=[640])
             lv1_1 = R.strided_slice(lv1, axes=[2], begin=[640], end=[1280])
             lv2 = R.strided_slice(lv1, axes=[2], begin=[1280], end=[1920])
@@ -1272,7 +1272,7 @@ def test_combine_transposed_matmul_twice():
         with R.dataflow():
             lv: R.Tensor((1280, 640), dtype="float32") = R.concat((w0, w1), axis=0)
             lv1: R.Tensor((640, 1280), dtype="float32") = R.permute_dims(lv, axes=None)
-            lv2: R.Tensor((2, 1024, 1280), dtype="float32") = R.matmul(x1, lv1, out_dtype="void")
+            lv2: R.Tensor((2, 1024, 1280), dtype="float32") = R.matmul(x1, lv1)
             lv3: R.Tuple(
                 R.Tensor((2, 1024, 640), dtype="float32"),
                 R.Tensor((2, 1024, 640), dtype="float32"),
@@ -1281,9 +1281,7 @@ def test_combine_transposed_matmul_twice():
             lv1_1: R.Tensor((2, 1024, 640), dtype="float32") = lv3[1]
             lv_1: R.Tensor((1280, 640), dtype="float32") = R.concat((w2, w3), axis=0)
             lv1_2: R.Tensor((640, 1280), dtype="float32") = R.permute_dims(lv_1, axes=None)
-            lv2_1: R.Tensor((2, 1024, 1280), dtype="float32") = R.matmul(
-                x2, lv1_2, out_dtype="void"
-            )
+            lv2_1: R.Tensor((2, 1024, 1280), dtype="float32") = R.matmul(x2, lv1_2)
             lv3_1: R.Tuple(
                 R.Tensor((2, 1024, 640), dtype="float32"),
                 R.Tensor((2, 1024, 640), dtype="float32"),

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -54,6 +54,10 @@ def test_var() -> None:
     tvm.ir.assert_structural_equal(v1.ty, rx.TensorType(shape, "float32"))
 
 
+def test_tensor_type_empty_dtype_is_unknown() -> None:
+    tvm.ir.assert_structural_equal(rx.TensorType([1, 2], dtype=""), rx.TensorType([1, 2], None))
+
+
 def test_relax_expr_ty_running_example() -> None:
     m = tirx.Var("m", "int64")
     x = rx.Var("x", R.Tensor([m, 16], "float32"))

--- a/tests/python/relax/test_frontend_dynamo.py
+++ b/tests/python/relax/test_frontend_dynamo.py
@@ -484,7 +484,7 @@ def test_masked_fill():
         ) -> R.Tensor((256, 256), dtype="float32"):
             with R.dataflow():
                 lv: R.Tensor((256, 256), dtype="float32") = R.full_like(
-                    inp_1, R.const(0, "int32"), dtype="void"
+                    inp_1, R.const(0, "int32"), dtype=None
                 )
                 lv1: R.Tensor((256, 256), dtype="float32") = R.where(inp_0, lv, inp_1)
                 gv: R.Tensor((256, 256), dtype="float32") = lv1

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -4430,7 +4430,6 @@ def test_interpolate():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0.0,
-                    out_dtype="void",
                 )
                 gv: R.Tuple(R.Tensor((1, 3, 224, 224), dtype="float32")) = (lv,)
                 R.output(gv)
@@ -4459,7 +4458,6 @@ def test_interpolate():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0.0,
-                    out_dtype="void",
                 )
                 gv: R.Tuple(R.Tensor((1, 3, 224, 224), dtype="float32")) = (lv,)
                 R.output(gv)
@@ -4921,7 +4919,6 @@ def test_interpolate_antialiased():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0.0,
-                    out_dtype="void",
                 )
                 gv: R.Tuple(R.Tensor((1, 3, 64, 64), dtype="float32")) = (lv,)
                 R.output(gv)
@@ -6340,7 +6337,7 @@ def test_fill():
         ):
             with R.dataflow():
                 lv: R.Tensor((10, 10), dtype="float32") = R.full_like(
-                    input, R.const(1.5, "float32"), dtype="void"
+                    input, R.const(1.5, "float32")
                 )
                 gv: R.Tuple(R.Tensor((10, 10), dtype="float32")) = (lv,)
                 R.output(gv)
@@ -6363,9 +6360,7 @@ def test_fill_inplace():
             R.Tensor((2, 3), dtype="float32")
         ):
             with R.dataflow():
-                lv: R.Tensor((2, 3), dtype="float32") = R.full_like(
-                    input, R.const(42.0, "float32"), dtype="void"
-                )
+                lv: R.Tensor((2, 3), dtype="float32") = R.full_like(input, R.const(42.0, "float32"))
                 gv: R.Tuple(R.Tensor((2, 3), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
@@ -6831,9 +6826,7 @@ def test_ones_like():
             R.Tensor((128, 128), dtype="float32")
         ):
             with R.dataflow():
-                lv: R.Tensor((128, 128), dtype="float32") = R.full_like(
-                    input, R.const(1, "int32"), dtype="void"
-                )
+                lv: R.Tensor((128, 128), dtype="float32") = R.full_like(input, R.const(1, "int32"))
                 gv: R.Tuple(R.Tensor((128, 128), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
@@ -6855,9 +6848,7 @@ def test_zero_inplace():
             R.Tensor((128, 128), dtype="float32")
         ):
             with R.dataflow():
-                lv: R.Tensor((128, 128), dtype="float32") = R.full_like(
-                    input, R.const(0, "int32"), dtype="void"
-                )
+                lv: R.Tensor((128, 128), dtype="float32") = R.full_like(input, R.const(0, "int32"))
                 gv: R.Tuple(R.Tensor((128, 128), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
@@ -6903,9 +6894,7 @@ def test_zeros_like():
             R.Tensor((128, 128), dtype="float32")
         ):
             with R.dataflow():
-                lv: R.Tensor((128, 128), dtype="float32") = R.full_like(
-                    input, R.const(0, "int32"), dtype="void"
-                )
+                lv: R.Tensor((128, 128), dtype="float32") = R.full_like(input, R.const(0, "int32"))
                 gv: R.Tuple(R.Tensor((128, 128), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv
@@ -8808,7 +8797,7 @@ def test_exponential():
             R.Tensor((4, 8), dtype="float32")
         ):
             with R.dataflow():
-                lv: R.Tensor((4, 8), dtype="float32") = R.zeros_like(x, dtype="void")
+                lv: R.Tensor((4, 8), dtype="float32") = R.zeros_like(x)
                 gv: R.Tuple(R.Tensor((4, 8), dtype="float32")) = (lv,)
                 R.output(gv)
             return gv

--- a/tests/python/relax/test_frontend_from_fx.py
+++ b/tests/python/relax/test_frontend_from_fx.py
@@ -3654,7 +3654,6 @@ def test_interpolate():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 3, 5, 5), dtype="float32") = lv
                 R.output(gv)
@@ -3691,7 +3690,6 @@ def test_interpolate():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 3, 20, 20), dtype="float32") = lv
                 R.output(gv)
@@ -3728,7 +3726,6 @@ def test_interpolate():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 3, 20, 10), dtype="float32") = lv
                 R.output(gv)
@@ -3765,7 +3762,6 @@ def test_interpolate():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 3, 20, 10), dtype="float32") = lv
                 R.output(gv)
@@ -3803,7 +3799,6 @@ def test_interpolate():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 3, 8, 20, 20), dtype="float32") = lv
                 R.output(gv)
@@ -3839,7 +3834,6 @@ def test_interpolate():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 3, 8, 40, 40), dtype="float32") = lv
                 R.output(gv)
@@ -3874,7 +3868,6 @@ def test_interpolate():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 3, 8, 40, 40), dtype="float32") = lv
                 R.output(gv)
@@ -3909,7 +3902,6 @@ def test_interpolate():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 3, 8, 40, 40), dtype="float32") = lv
                 R.output(gv)
@@ -3945,7 +3937,6 @@ def test_interpolate_nhwc_layout():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 3, 5, 5), dtype="float32") = lv
                 R.output(gv)
@@ -3983,7 +3974,6 @@ def test_interpolate_nhwc_layout():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 5, 5, 3), dtype="float32") = lv
                 R.output(gv)
@@ -4021,7 +4011,6 @@ def test_interpolate_nhwc_layout():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 20, 20, 3), dtype="float32") = lv
                 R.output(gv)
@@ -4062,7 +4051,6 @@ def test_interpolate_nhwc_layout():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 8, 40, 40, 3), dtype="float32") = lv
                 R.output(gv)
@@ -4101,7 +4089,6 @@ def test_interpolate_nhwc_layout():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="",
                 )
                 gv: R.Tensor((1, 8, 40, 40, 3), dtype="float32") = lv
                 R.output(gv)
@@ -4403,7 +4390,7 @@ def test_masked_fill_inplace():
         ) -> R.Tensor((10, 10), dtype="float32"):
             with R.dataflow():
                 lv: R.Tensor((10, 10), dtype="float32") = R.full_like(
-                    input, R.const(1.5, "float32"), dtype="void"
+                    input, R.const(1.5, "float32")
                 )
                 lv1: R.Tensor((10, 10), dtype="float32") = R.where(mask, lv, input)
                 gv: R.Tensor((10, 10), dtype="float32") = lv1
@@ -6085,7 +6072,7 @@ def test_ones_like():
             (128, 128), dtype="float32"
         ):
             with R.dataflow():
-                lv: R.Tensor((128, 128), dtype="float32") = R.ones_like(inp_0, dtype="void")
+                lv: R.Tensor((128, 128), dtype="float32") = R.ones_like(inp_0)
                 gv: R.Tensor((128, 128), dtype="float32") = lv
                 R.output(gv)
             return gv
@@ -6105,7 +6092,7 @@ def test_zero_inplace():
             (128, 128), dtype="float32"
         ):
             with R.dataflow():
-                lv: R.Tensor((128, 128), dtype="float32") = R.zeros_like(inp_0, dtype="void")
+                lv: R.Tensor((128, 128), dtype="float32") = R.zeros_like(inp_0)
                 gv: R.Tensor((128, 128), dtype="float32") = lv
                 R.output(gv)
             return gv
@@ -6125,7 +6112,7 @@ def test_zeros_like():
             (128, 128), dtype="float32"
         ):
             with R.dataflow():
-                lv: R.Tensor((128, 128), dtype="float32") = R.zeros_like(inp_0, dtype="void")
+                lv: R.Tensor((128, 128), dtype="float32") = R.zeros_like(inp_0)
                 gv: R.Tensor((128, 128), dtype="float32") = lv
                 R.output(gv)
             return gv

--- a/tests/python/relax/test_frontend_nn_exporter.py
+++ b/tests/python/relax/test_frontend_nn_exporter.py
@@ -470,7 +470,7 @@ def test_linear_dynamic_shape():
         R.func_attr({"num_input": 2})
         with R.dataflow():
             permute_dims: R.Tensor((4, n), dtype="float32") = R.permute_dims(weight, axes=None)
-            matmul: R.Tensor((1, n), dtype="float32") = R.matmul(x, permute_dims, out_dtype="void")
+            matmul: R.Tensor((1, n), dtype="float32") = R.matmul(x, permute_dims)
             add: R.Tensor((1, n), dtype="float32") = R.add(matmul, bias)
             gv1: R.Tuple(R.Tensor((1, n), dtype="float32"), R.Tuple(R.Any)) = add, (_io,)
             R.output(gv1)

--- a/tests/python/relax/test_frontend_nn_modules.py
+++ b/tests/python/relax/test_frontend_nn_modules.py
@@ -112,7 +112,7 @@ def test_linear():
         R.func_attr({"num_input": 2})
         with R.dataflow():
             permute_dims: R.Tensor((4, 8), dtype="float32") = R.permute_dims(weight, axes=None)
-            matmul: R.Tensor((1, 8), dtype="float32") = R.matmul(x, permute_dims, out_dtype="void")
+            matmul: R.Tensor((1, 8), dtype="float32") = R.matmul(x, permute_dims)
             add: R.Tensor((1, 8), dtype="float32") = R.add(matmul, bias)
             gv1: R.Tuple(R.Tensor((1, 8), dtype="float32"), R.Tuple(R.Any)) = add, (_io,)
             R.output(gv1)
@@ -143,7 +143,6 @@ def test_conv1d():
                 data_layout="NCW",
                 kernel_layout="OIW",
                 out_layout="NCW",
-                out_dtype="void",
             )
             lv2: R.Tensor((1, 32, 1), dtype="float32") = R.reshape(bias, R.shape([1, 32, 1]))
             conv1d: R.Tensor((1, 32, 30), dtype="float32") = R.add(lv1, lv2)
@@ -169,7 +168,7 @@ def test_conv1d_transpose():
     def forward(x: R.Tensor((1, 3, 30), dtype="float32"), _io: R.Any, weight: R.Tensor((3, 32, 3), dtype="float32"), bias: R.Tensor((32,), dtype="float32")) -> R.Tuple(R.Tensor((1, 32, 32), dtype="float32"), R.Tuple(R.Any)):
         R.func_attr({"num_input": 2})
         with R.dataflow():
-            lv1: R.Tensor((1, 32, 32), dtype="float32") = R.nn.conv1d_transpose(x, weight, strides=[1], padding=[0, 0], output_padding=[0], dilation=[1], groups=1, data_layout="NCW", kernel_layout="IOW", out_layout="NCW", out_dtype="void")
+            lv1: R.Tensor((1, 32, 32), dtype="float32") = R.nn.conv1d_transpose(x, weight, strides=[1], padding=[0, 0], output_padding=[0], dilation=[1], groups=1, data_layout="NCW", kernel_layout="IOW", out_layout="NCW")
             lv2: R.Tensor((1, 32, 1), dtype="float32") = R.reshape(bias, R.shape([1, 32, 1]))
             conv1d_transpose: R.Tensor((1, 32, 32), dtype="float32") = R.add(lv1, lv2)
             gv1: R.Tuple(R.Tensor((1, 32, 32), dtype="float32"), R.Tuple(R.Any)) = conv1d_transpose, (_io,)
@@ -426,24 +425,18 @@ def test_timestep_embedding():
             permute_dims: R.Tensor((16, 32), dtype="float32") = R.permute_dims(
                 cond_proj_weight, axes=None
             )
-            matmul: R.Tensor((32, 32), dtype="float32") = R.matmul(
-                condition, permute_dims, out_dtype="void"
-            )
+            matmul: R.Tensor((32, 32), dtype="float32") = R.matmul(condition, permute_dims)
             add: R.Tensor((32, 32), dtype="float32") = R.add(sample, matmul)
             permute_dims1: R.Tensor((32, 32), dtype="float32") = R.permute_dims(
                 linear_1_weight, axes=None
             )
-            matmul1: R.Tensor((32, 32), dtype="float32") = R.matmul(
-                add, permute_dims1, out_dtype="void"
-            )
+            matmul1: R.Tensor((32, 32), dtype="float32") = R.matmul(add, permute_dims1)
             add1: R.Tensor((32, 32), dtype="float32") = R.add(matmul1, linear_1_bias)
             silu: R.Tensor((32, 32), dtype="float32") = R.nn.silu(add1)
             permute_dims2: R.Tensor((32, 32), dtype="float32") = R.permute_dims(
                 linear_2_weight, axes=None
             )
-            matmul2: R.Tensor((32, 32), dtype="float32") = R.matmul(
-                silu, permute_dims2, out_dtype="void"
-            )
+            matmul2: R.Tensor((32, 32), dtype="float32") = R.matmul(silu, permute_dims2)
             add2: R.Tensor((32, 32), dtype="float32") = R.add(matmul2, linear_2_bias)
             gv1: R.Tuple(R.Tensor((32, 32), dtype="float32"), R.Tuple(R.Any)) = add2, (_io,)
             R.output(gv1)
@@ -591,20 +584,18 @@ def test_attention():
             permute_dims: R.Tensor((640, 640), dtype="float32") = R.permute_dims(
                 to_q_weight, axes=None
             )
-            matmul: R.Tensor((2, 4096, 640), dtype="float32") = R.matmul(
-                group_norm, permute_dims, out_dtype="void"
-            )
+            matmul: R.Tensor((2, 4096, 640), dtype="float32") = R.matmul(group_norm, permute_dims)
             permute_dims1: R.Tensor((2048, 640), dtype="float32") = R.permute_dims(
                 to_k_weight, axes=None
             )
             matmul1: R.Tensor((2, 77, 640), dtype="float32") = R.matmul(
-                encoder_hidden_states, permute_dims1, out_dtype="void"
+                encoder_hidden_states, permute_dims1
             )
             permute_dims2: R.Tensor((2048, 640), dtype="float32") = R.permute_dims(
                 to_v_weight, axes=None
             )
             matmul2: R.Tensor((2, 77, 640), dtype="float32") = R.matmul(
-                encoder_hidden_states, permute_dims2, out_dtype="void"
+                encoder_hidden_states, permute_dims2
             )
             reshape: R.Tensor((2, 4096, 10, 64), dtype="float32") = R.reshape(
                 matmul, R.shape([2, 4096, 10, 64])
@@ -624,9 +615,7 @@ def test_attention():
             permute_dims3: R.Tensor((640, 640), dtype="float32") = R.permute_dims(
                 to_out_0_weight, axes=None
             )
-            matmul3: R.Tensor((2, 4096, 640), dtype="float32") = R.matmul(
-                reshape3, permute_dims3, out_dtype="void"
-            )
+            matmul3: R.Tensor((2, 4096, 640), dtype="float32") = R.matmul(reshape3, permute_dims3)
             add: R.Tensor((2, 4096, 640), dtype="float32") = R.add(matmul3, to_out_0_bias)
             gv1: R.Tuple(R.Tensor((2, 4096, 640), dtype="float32"), R.Tuple(R.Any)) = add, (_io,)
             R.output(gv1)

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -85,7 +85,7 @@ def test_binary():
             add: R.Tensor((10, 10), dtype="float32") = R.add(x, y)
             mul: R.Tensor((10, 10), dtype="float32") = R.multiply(x, y)
             divide: R.Tensor((10, 10), dtype="float32") = R.divide(x, y)
-            matmul: R.Tensor((1, 1), dtype="float32") = R.matmul(x, y, out_dtype="void")
+            matmul: R.Tensor((1, 1), dtype="float32") = R.matmul(x, y, out_dtype=None)
             maximum: R.Tensor((10, 10), dtype="float32") = R.maximum(x, y)
             minimum: R.Tensor((10, 10), dtype="float32") = R.minimum(x, y)
             subtract: R.Tensor((10, 10), dtype="float32") = R.subtract(x, y)
@@ -297,7 +297,7 @@ def test_image():
                 data_layout="NCHW",
                 kernel_layout="OIHW",
                 out_layout="NCHW",
-                out_dtype="void",
+                out_dtype=None,
             )
             lv2: R.Tensor((1, 32, 1, 1), dtype="float32") = R.reshape(bias, R.shape([1, 32, 1, 1]))
             conv2d: R.Tensor((1, 32, 32, 32), dtype="float32") = R.add(lv1, lv2)
@@ -312,7 +312,7 @@ def test_image():
                 cubic_alpha=-0.75,
                 cubic_exclude=0,
                 extrapolation_value=0,
-                out_dtype="void",
+                out_dtype=None,
             )
             gv1: R.Tuple(
                 R.Tuple(
@@ -1086,7 +1086,7 @@ def test_sample_top_p_top_k_from_sorted_prob():
             R.func_attr({"num_input": 7})
             cls = Expected
             with R.dataflow():
-                cumsum: R.Tensor((2, 3), dtype="float32") = R.cumsum(prob, axis=1, dtype="void", exclusive=None)
+                cumsum: R.Tensor((2, 3), dtype="float32") = R.cumsum(prob, axis=1, dtype=None, exclusive=None)
                 lv1 = R.call_tir(cls.get_renorm_prob, (cumsum, top_p, top_k), out_ty=R.Tensor((2, 1), dtype="float32"))
                 lv2 = R.call_tir(cls.get_index_from_sorted, (cumsum, index, lv1, uniform_sample, sample_indices), out_ty=R.Tensor((3, 1), dtype="int64"))
                 gv1: R.Tuple(R.Tensor((3, 1), dtype="int64"), R.Tuple(R.Any)) = lv2, (_io,)
@@ -1204,7 +1204,7 @@ def test_renormalize_top_p_top_k_prob():
             R.func_attr({"num_input": 5})
             cls = Expected
             with R.dataflow():
-                cumsum: R.Tensor((2, 3), dtype="float32") = R.cumsum(sorted_prob, axis=1, dtype="void", exclusive=None)
+                cumsum: R.Tensor((2, 3), dtype="float32") = R.cumsum(sorted_prob, axis=1, dtype=None, exclusive=None)
                 lv1 = R.call_tir(cls.get_renorm_cutoff, (sorted_prob, cumsum, top_p, top_k), out_ty=R.Tensor((2, 1), dtype="float32"))
                 lv2 = R.call_tir(cls.filter_with_top_p_top_k, (prob, lv1), out_ty=R.Tensor((2, 3), dtype="float32"))
                 sum: R.Tensor((2, 1), dtype="float32") = R.sum(lv2, axis=[1], keepdims=True)

--- a/tests/python/relax/test_frontend_tflite.py
+++ b/tests/python/relax/test_frontend_tflite.py
@@ -1289,7 +1289,7 @@ def test_fill_dynamic_dims():
                     lv2, R.Shape([fill_dim_0, fill_dim_1])
                 )
                 gv: R.Tensor((fill_dim_0, fill_dim_1), dtype="float32") = R.full(
-                    R.shape([fill_dim_0, fill_dim_1]), value, dtype="void"
+                    R.shape([fill_dim_0, fill_dim_1]), value
                 )
                 R.output(gv)
             return gv
@@ -1876,7 +1876,7 @@ def test_fully_connected():
                 lv: R.Tensor((8, 3), dtype="float32") = R.permute_dims(
                     R.const(np.arange(24, dtype=np.float32).reshape((3, 8))), axes=[1, 0]
                 )
-                lv1: R.Tensor((1, 3), dtype="float32") = R.matmul(x, lv, out_dtype="void")
+                lv1: R.Tensor((1, 3), dtype="float32") = R.matmul(x, lv)
                 gv: R.Tensor((1, 3), dtype="float32") = R.add(
                     lv1, R.const(np.array([0.5, 1.0, -1.0], dtype=np.float32))
                 )
@@ -1925,7 +1925,6 @@ def test_depthwise_conv2d():
                     data_layout="NHWC",
                     kernel_layout="HWOI",
                     out_layout="NHWC",
-                    out_dtype="void",
                 )
                 gv: R.Tensor((1, 8, 8, 2), dtype="float32") = R.add(
                     lv2, R.const(np.zeros((2,), dtype="float32"))
@@ -2386,7 +2385,6 @@ def test_conv2d_same():
                     data_layout="NHWC",
                     kernel_layout="HWIO",
                     out_layout="NHWC",
-                    out_dtype="void",
                 )
                 gv: R.Tensor((1, 128, 128, 32), dtype="float32") = R.add(
                     lv2, R.const(np.zeros((32,), dtype="float32"))
@@ -2427,7 +2425,6 @@ def test_conv2d_valid():
                     data_layout="NHWC",
                     kernel_layout="HWIO",
                     out_layout="NHWC",
-                    out_dtype="void",
                 )
                 gv: R.Tensor((1, 126, 126, 32), dtype="float32") = R.add(
                     lv2, R.const(np.zeros((32,), dtype="float32"))
@@ -2479,7 +2476,6 @@ def test_conv3d_valid():
                     data_layout="NDHWC",
                     kernel_layout="DHWIO",
                     out_layout="NDHWC",
-                    out_dtype="void",
                 )
                 R.output(gv)
             return gv
@@ -2509,7 +2505,6 @@ def test_conv3d_same():
                     data_layout="NDHWC",
                     kernel_layout="DHWIO",
                     out_layout="NDHWC",
-                    out_dtype="void",
                 )
                 R.output(gv)
             return gv
@@ -2578,7 +2573,6 @@ def test_conv3d_transpose_valid():
                     data_layout="NDHWC",
                     kernel_layout="DHWOI",
                     out_layout="NDHWC",
-                    out_dtype="void",
                 )
                 R.output(gv)
             return gv
@@ -2611,7 +2605,6 @@ def test_conv3d_transpose_same():
                     data_layout="NDHWC",
                     kernel_layout="DHWOI",
                     out_layout="NDHWC",
-                    out_dtype="void",
                 )
                 R.output(gv)
             return gv
@@ -3171,7 +3164,7 @@ def test_batch_matmul():
         ) -> R.Tensor((2, 3, 5), dtype="float32"):
             R.func_attr({"num_input": 2})
             with R.dataflow():
-                lv: R.Tensor((2, 3, 5), dtype="float32") = R.matmul(x, y, out_dtype="void")
+                lv: R.Tensor((2, 3, 5), dtype="float32") = R.matmul(x, y)
                 gv: R.Tensor((2, 3, 5), dtype="float32") = R.reshape(lv, R.shape([2, 3, 5]))
                 R.output(gv)
             return gv
@@ -3201,7 +3194,7 @@ def test_batch_matmul_adj():
             with R.dataflow():
                 lv: R.Tensor((2, 3, 4), dtype="float32") = R.permute_dims(x, axes=[0, 2, 1])
                 lv1: R.Tensor((2, 4, 5), dtype="float32") = R.permute_dims(y, axes=[0, 2, 1])
-                lv2: R.Tensor((2, 3, 5), dtype="float32") = R.matmul(lv, lv1, out_dtype="void")
+                lv2: R.Tensor((2, 3, 5), dtype="float32") = R.matmul(lv, lv1)
                 gv: R.Tensor((2, 3, 5), dtype="float32") = R.reshape(lv2, R.shape([2, 3, 5]))
                 R.output(gv)
             return gv
@@ -3935,7 +3928,6 @@ def _make_resize_expected(
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0.0,
-                    out_dtype="void",
                 )
             )
         bb.emit_func_output(gv)
@@ -10750,7 +10742,7 @@ def test_stablehlo_dot_general():
         ) -> R.Tensor((2, 4), dtype="float32"):
             R.func_attr({"num_input": 2})
             with R.dataflow():
-                gv: R.Tensor((2, 4), dtype="float32") = R.matmul(lhs, rhs, out_dtype="void")
+                gv: R.Tensor((2, 4), dtype="float32") = R.matmul(lhs, rhs)
                 R.output(gv)
             return gv
 
@@ -10892,7 +10884,6 @@ def test_stablehlo_convolution():
                     data_layout="NHWC",
                     kernel_layout="HWIO",
                     out_layout="NHWC",
-                    out_dtype="void",
                 )
                 R.output(gv)
             return gv
@@ -11301,7 +11292,6 @@ def test_quantized_conv2d_per_tensor_uses_qdq():
                     data_layout="NHWC",
                     kernel_layout="HWIO",
                     out_layout="NHWC",
-                    out_dtype="void",
                 )
                 gv: R.Tensor((1, 2, 2, 2), dtype="int8") = R.quantize(
                     lv3,
@@ -11426,7 +11416,6 @@ def test_quantized_conv2d_per_channel_weight_uses_remapped_axis():
                     data_layout="NHWC",
                     kernel_layout="HWIO",
                     out_layout="NHWC",
-                    out_dtype="void",
                 )
                 gv: R.Tensor((1, 2, 2, 2), dtype="int8") = R.quantize(
                     lv3,
@@ -11970,7 +11959,6 @@ def test_quantized_conv2d_with_int32_bias_dequantizes_bias():
                     data_layout="NHWC",
                     kernel_layout="HWIO",
                     out_layout="NHWC",
-                    out_dtype="void",
                 )
                 lv4: R.Tensor((), dtype="float32") = R.multiply(
                     R.const(0.5, "float32"),
@@ -12092,7 +12080,6 @@ def test_quantized_conv2d_per_channel_weight_with_int32_bias_dequantizes_bias():
                     data_layout="NHWC",
                     kernel_layout="HWIO",
                     out_layout="NHWC",
-                    out_dtype="void",
                 )
                 lv4: R.Tensor((2,), dtype="float32") = R.multiply(
                     R.const(0.5, "float32"),
@@ -12501,7 +12488,7 @@ def test_quantized_fully_connected_with_int32_bias_dequantizes_bias():
                     out_dtype="float32",
                     axis=1,
                 )
-                lv3: R.Tensor((1, 2), dtype="float32") = R.matmul(lv, lv2, out_dtype="void")
+                lv3: R.Tensor((1, 2), dtype="float32") = R.matmul(lv, lv2)
                 lv4: R.Tensor((), dtype="float32") = R.multiply(
                     R.const(0.5, "float32"),
                     R.const(0.25, "float32"),
@@ -12865,7 +12852,6 @@ def test_densify_with_conv2d():
                     data_layout="NHWC",
                     kernel_layout="HWIO",
                     out_layout="NHWC",
-                    out_dtype="void",
                 )
                 R.output(gv)
             return gv
@@ -12890,7 +12876,7 @@ def test_densify_with_fully_connected():
                 weight_t: R.Tensor((4, 4), dtype="float32") = R.permute_dims(
                     R.const(_DENSIFY_FC_WEIGHT_DENSE_OI), axes=[1, 0]
                 )
-                gv: R.Tensor((1, 4), dtype="float32") = R.matmul(x, weight_t, out_dtype="void")
+                gv: R.Tensor((1, 4), dtype="float32") = R.matmul(x, weight_t)
                 R.output(gv)
             return gv
 
@@ -13340,15 +13326,11 @@ def test_lstm_none_activation():
                 lv: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv1: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_0, lv, out_dtype="void"
-                )
+                lv1: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_0, lv)
                 lv2: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv3: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_10, lv2, out_dtype="void"
-                )
+                lv3: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_10, lv2)
                 lv4: R.Tensor((2, 2), dtype="float32") = R.add(lv1, lv3)
                 lv5: R.Tensor((2, 2), dtype="float32") = R.add(
                     lv4, R.const(np.zeros(2, dtype=np.float32))
@@ -13357,15 +13339,11 @@ def test_lstm_none_activation():
                 lv7: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv8: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_0, lv7, out_dtype="void"
-                )
+                lv8: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_0, lv7)
                 lv9: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv10: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_10, lv9, out_dtype="void"
-                )
+                lv10: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_10, lv9)
                 lv11: R.Tensor((2, 2), dtype="float32") = R.add(lv8, lv10)
                 lv12: R.Tensor((2, 2), dtype="float32") = R.add(
                     lv11, R.const(np.zeros(2, dtype=np.float32))
@@ -13376,15 +13354,11 @@ def test_lstm_none_activation():
                 lv16: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv17: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_0, lv16, out_dtype="void"
-                )
+                lv17: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_0, lv16)
                 lv18: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv19: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_10, lv18, out_dtype="void"
-                )
+                lv19: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_10, lv18)
                 lv20: R.Tensor((2, 2), dtype="float32") = R.add(lv17, lv19)
                 lv21: R.Tensor((2, 2), dtype="float32") = R.add(
                     lv20, R.const(np.zeros(2, dtype=np.float32))
@@ -13445,15 +13419,11 @@ def test_lstm_tanh_activation():
                 lv: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv1: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_0, lv, out_dtype="void"
-                )
+                lv1: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_0, lv)
                 lv2: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv3: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_10, lv2, out_dtype="void"
-                )
+                lv3: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_10, lv2)
                 lv4: R.Tensor((2, 2), dtype="float32") = R.add(lv1, lv3)
                 lv5: R.Tensor((2, 2), dtype="float32") = R.add(
                     lv4, R.const(np.zeros(2, dtype=np.float32))
@@ -13462,15 +13432,11 @@ def test_lstm_tanh_activation():
                 lv7: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv8: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_0, lv7, out_dtype="void"
-                )
+                lv8: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_0, lv7)
                 lv9: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv10: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_10, lv9, out_dtype="void"
-                )
+                lv10: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_10, lv9)
                 lv11: R.Tensor((2, 2), dtype="float32") = R.add(lv8, lv10)
                 lv12: R.Tensor((2, 2), dtype="float32") = R.add(
                     lv11, R.const(np.zeros(2, dtype=np.float32))
@@ -13481,15 +13447,11 @@ def test_lstm_tanh_activation():
                 lv16: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv17: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_0, lv16, out_dtype="void"
-                )
+                lv17: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_0, lv16)
                 lv18: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv19: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    tvmgen_tensor_10, lv18, out_dtype="void"
-                )
+                lv19: R.Tensor((2, 2), dtype="float32") = R.matmul(tvmgen_tensor_10, lv18)
                 lv20: R.Tensor((2, 2), dtype="float32") = R.add(lv17, lv19)
                 lv21: R.Tensor((2, 2), dtype="float32") = R.add(
                     lv20, R.const(np.zeros(2, dtype=np.float32))
@@ -13817,7 +13779,6 @@ def test_svdf_shared_state_updates_exp_tab():
                 lv8: R.Tensor((1, 2), dtype="float32") = R.matmul(
                     tvmgen_tensor_0,
                     lv7,
-                    out_dtype="void",
                 )
                 lv9: R.Tensor((1, 2, 1), dtype="float32") = R.expand_dims(lv8, axis=[-1])
                 lv10: R.Tensor((1, 2, 3), dtype="float32") = R.concat((lv6, lv9), axis=2)
@@ -14342,21 +14303,17 @@ def test_bidirectional_sequence_rnn_none_activation():
             with R.dataflow():
                 x_t: R.Tensor((2, 2), dtype="float32") = R.squeeze(x, axis=[1])
                 fw_w_t: R.Tensor((2, 2), dtype="float32") = R.permute_dims(R.const(fw_w), axes=None)
-                fw_x: R.Tensor((2, 2), dtype="float32") = R.matmul(x_t, fw_w_t, out_dtype="void")
+                fw_x: R.Tensor((2, 2), dtype="float32") = R.matmul(x_t, fw_w_t)
                 fw_r_t: R.Tensor((2, 2), dtype="float32") = R.permute_dims(R.const(fw_r), axes=None)
-                fw_h_proj: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    fw_h, fw_r_t, out_dtype="void"
-                )
+                fw_h_proj: R.Tensor((2, 2), dtype="float32") = R.matmul(fw_h, fw_r_t)
                 fw_out: R.Tensor((2, 2), dtype="float32") = R.add(
                     R.add(fw_x, fw_h_proj), R.const(fw_b)
                 )
                 fw_stacked: R.Tensor((2, 1, 2), dtype="float32") = R.stack((fw_out,), axis=1)
                 bw_w_t: R.Tensor((2, 2), dtype="float32") = R.permute_dims(R.const(bw_w), axes=None)
-                bw_x: R.Tensor((2, 2), dtype="float32") = R.matmul(x_t, bw_w_t, out_dtype="void")
+                bw_x: R.Tensor((2, 2), dtype="float32") = R.matmul(x_t, bw_w_t)
                 bw_r_t: R.Tensor((2, 2), dtype="float32") = R.permute_dims(R.const(bw_r), axes=None)
-                bw_h_proj: R.Tensor((2, 2), dtype="float32") = R.matmul(
-                    bw_h, bw_r_t, out_dtype="void"
-                )
+                bw_h_proj: R.Tensor((2, 2), dtype="float32") = R.matmul(bw_h, bw_r_t)
                 bw_out: R.Tensor((2, 2), dtype="float32") = R.add(
                     R.add(bw_x, bw_h_proj), R.const(bw_b)
                 )
@@ -14879,12 +14836,12 @@ def test_unidirectional_sequence_rnn_none_activation():
                 lv1: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv2: R.Tensor((2, 2), dtype="float32") = R.matmul(lv, lv1, out_dtype="void")
+                lv2: R.Tensor((2, 2), dtype="float32") = R.matmul(lv, lv1)
                 lv3: R.Tensor((2, 2), dtype="float32") = R.zeros(R.shape([2, 2]), dtype="float32")
                 lv4: R.Tensor((2, 2), dtype="float32") = R.permute_dims(
                     R.const(np.eye(2, dtype=np.float32)), axes=None
                 )
-                lv5: R.Tensor((2, 2), dtype="float32") = R.matmul(lv3, lv4, out_dtype="void")
+                lv5: R.Tensor((2, 2), dtype="float32") = R.matmul(lv3, lv4)
                 lv6: R.Tensor((2, 2), dtype="float32") = R.add(lv2, lv5)
                 lv7: R.Tensor((2, 2), dtype="float32") = R.add(
                     lv6, R.const(np.zeros(2, dtype=np.float32))

--- a/tests/python/relax/test_op_ccl.py
+++ b/tests/python/relax/test_op_ccl.py
@@ -48,9 +48,9 @@ def test_allreduce_infer_ty():
     _check_inference(bb, relax.op.ccl.allreduce(x0), relax.TensorType((2, 3), "float32"))
     _check_inference(bb, relax.op.ccl.allreduce(x1), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.ccl.allreduce(x2), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.ccl.allreduce(x3), relax.TensorType((2, 3), dtype=""))
-    _check_inference(bb, relax.op.ccl.allreduce(x4), relax.TensorType(dtype=""))
-    _check_inference(bb, relax.op.ccl.allreduce(x5), relax.TensorType((3, 4), dtype=""))
+    _check_inference(bb, relax.op.ccl.allreduce(x3), relax.TensorType((2, 3), dtype=None))
+    _check_inference(bb, relax.op.ccl.allreduce(x4), relax.TensorType(dtype=None))
+    _check_inference(bb, relax.op.ccl.allreduce(x5), relax.TensorType((3, 4), dtype=None))
 
 
 def test_allreduce_infer_ty_shape_symbolic():
@@ -98,9 +98,9 @@ def test_allgather_infer_ty():
     _check_inference(bb, relax.op.ccl.allgather(x0, 2), relax.TensorType((4, 3), "float32"))
     _check_inference(bb, relax.op.ccl.allgather(x1, 2), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.ccl.allgather(x2, 2), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.ccl.allgather(x3, 2), relax.TensorType((4, 3), dtype=""))
-    _check_inference(bb, relax.op.ccl.allgather(x4, 2), relax.TensorType(dtype=""))
-    _check_inference(bb, relax.op.ccl.allgather(x5, 2), relax.TensorType((6, 4), dtype=""))
+    _check_inference(bb, relax.op.ccl.allgather(x3, 2), relax.TensorType((4, 3), dtype=None))
+    _check_inference(bb, relax.op.ccl.allgather(x4, 2), relax.TensorType(dtype=None))
+    _check_inference(bb, relax.op.ccl.allgather(x5, 2), relax.TensorType((6, 4), dtype=None))
 
 
 def test_allgather_infer_ty_shape_symbolic():
@@ -153,11 +153,11 @@ def test_broadcast_from_worker0_infer_ty():
     )
     _check_inference(bb, relax.op.ccl.broadcast_from_worker0(x2), relax.TensorType(dtype="float32"))
     _check_inference(
-        bb, relax.op.ccl.broadcast_from_worker0(x3), relax.TensorType((2, 3), dtype="")
+        bb, relax.op.ccl.broadcast_from_worker0(x3), relax.TensorType((2, 3), dtype=None)
     )
-    _check_inference(bb, relax.op.ccl.broadcast_from_worker0(x4), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.ccl.broadcast_from_worker0(x4), relax.TensorType(dtype=None))
     _check_inference(
-        bb, relax.op.ccl.broadcast_from_worker0(x5), relax.TensorType((3, 4), dtype="")
+        bb, relax.op.ccl.broadcast_from_worker0(x5), relax.TensorType((3, 4), dtype=None)
     )
 
 
@@ -209,7 +209,7 @@ def test_scatter_from_worker0_infer_ty():
         bb, relax.op.ccl.scatter_from_worker0(x0, 2), relax.TensorType((1, 3), "float32")
     )
     _check_inference(
-        bb, relax.op.ccl.scatter_from_worker0(x1, 3), relax.TensorType((1, 4, 5), dtype="")
+        bb, relax.op.ccl.scatter_from_worker0(x1, 3), relax.TensorType((1, 4, 5), dtype=None)
     )
 
 

--- a/tests/python/relax/test_op_create.py
+++ b/tests/python/relax/test_op_create.py
@@ -78,19 +78,19 @@ def test_full_infer_ty():
     _check_inference(bb, relax.op.full(s3, v1, "float16"), relax.TensorType(s3, "float16"))
     _check_inference(bb, relax.op.full(s3, v1), relax.TensorType(s3, "float32"))
     _check_inference(bb, relax.op.full((2, 3), v2, "float16"), relax.TensorType((2, 3), "float16"))
-    _check_inference(bb, relax.op.full((2, 3), v2), relax.TensorType((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full((2, 3), v2), relax.TensorType((2, 3), dtype=None))
     _check_inference(bb, relax.op.full(s0, v2, "float16"), relax.TensorType((2, 3), "float16"))
-    _check_inference(bb, relax.op.full(s0, v2), relax.TensorType((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full(s0, v2), relax.TensorType((2, 3), dtype=None))
     _check_inference(bb, relax.op.full(s1, v2, "float16"), relax.TensorType(s1, "float16"))
-    _check_inference(bb, relax.op.full(s1, v2), relax.TensorType(s1, dtype=""))
+    _check_inference(bb, relax.op.full(s1, v2), relax.TensorType(s1, dtype=None))
     _check_inference(bb, relax.op.full(s2, v2, "float16"), relax.TensorType(s2, "float16"))
-    _check_inference(bb, relax.op.full(s2, v2), relax.TensorType(s2, dtype=""))
+    _check_inference(bb, relax.op.full(s2, v2), relax.TensorType(s2, dtype=None))
     _check_inference(bb, relax.op.full(s3, v2, "float16"), relax.TensorType(s3, "float16"))
-    _check_inference(bb, relax.op.full(s3, v2), relax.TensorType(s3, dtype=""))
+    _check_inference(bb, relax.op.full(s3, v2), relax.TensorType(s3, dtype=None))
     _check_inference(bb, relax.op.full((2, 3), v3, "float16"), relax.TensorType((2, 3), "float16"))
-    _check_inference(bb, relax.op.full((2, 3), v3), relax.TensorType((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full((2, 3), v3), relax.TensorType((2, 3), dtype=None))
     _check_inference(bb, relax.op.full(s0, v3, "float16"), relax.TensorType((2, 3), "float16"))
-    _check_inference(bb, relax.op.full(s0, v3), relax.TensorType((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full(s0, v3), relax.TensorType((2, 3), dtype=None))
     _check_inference(bb, relax.op.full(s1, v3, "float16"), relax.TensorType(s1, "float16"))
     _check_inference(
         bb,
@@ -98,7 +98,7 @@ def test_full_infer_ty():
             s1,
             v3,
         ),
-        relax.TensorType(s1, dtype=""),
+        relax.TensorType(s1, dtype=None),
     )
     _check_inference(bb, relax.op.full(s2, v3, "float16"), relax.TensorType(s2, "float16"))
     _check_inference(
@@ -107,10 +107,10 @@ def test_full_infer_ty():
             s2,
             v3,
         ),
-        relax.TensorType(s2, dtype=""),
+        relax.TensorType(s2, dtype=None),
     )
     _check_inference(bb, relax.op.full(s3, v3, "float16"), relax.TensorType(s3, "float16"))
-    _check_inference(bb, relax.op.full(s3, v3), relax.TensorType(s3, dtype=""))
+    _check_inference(bb, relax.op.full(s3, v3), relax.TensorType(s3, dtype=None))
 
 
 def test_full_infer_ty_shape_symbolic():
@@ -229,18 +229,18 @@ def test_full_like_infer_ty():
     _check_inference(bb, relax.op.full_like(x2, v1), relax.TensorType(dtype="float32"))
     _check_inference(bb, relax.op.full_like(x2, v2), relax.TensorType(dtype="float32"))
     _check_inference(bb, relax.op.full_like(x2, v3), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.full_like(x3, v0), relax.TensorType((2, 3), dtype=""))
-    _check_inference(bb, relax.op.full_like(x3, v1), relax.TensorType((2, 3), dtype=""))
-    _check_inference(bb, relax.op.full_like(x3, v2), relax.TensorType((2, 3), dtype=""))
-    _check_inference(bb, relax.op.full_like(x3, v3), relax.TensorType((2, 3), dtype=""))
-    _check_inference(bb, relax.op.full_like(x4, v0), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.full_like(x4, v1), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.full_like(x4, v2), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.full_like(x4, v3), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.full_like(x5, v0), relax.TensorType(dtype=""))
-    _check_inference(bb, relax.op.full_like(x5, v1), relax.TensorType(dtype=""))
-    _check_inference(bb, relax.op.full_like(x5, v2), relax.TensorType(dtype=""))
-    _check_inference(bb, relax.op.full_like(x5, v3), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.full_like(x3, v0), relax.TensorType((2, 3), dtype=None))
+    _check_inference(bb, relax.op.full_like(x3, v1), relax.TensorType((2, 3), dtype=None))
+    _check_inference(bb, relax.op.full_like(x3, v2), relax.TensorType((2, 3), dtype=None))
+    _check_inference(bb, relax.op.full_like(x3, v3), relax.TensorType((2, 3), dtype=None))
+    _check_inference(bb, relax.op.full_like(x4, v0), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.full_like(x4, v1), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.full_like(x4, v2), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.full_like(x4, v3), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.full_like(x5, v0), relax.TensorType(dtype=None))
+    _check_inference(bb, relax.op.full_like(x5, v1), relax.TensorType(dtype=None))
+    _check_inference(bb, relax.op.full_like(x5, v2), relax.TensorType(dtype=None))
+    _check_inference(bb, relax.op.full_like(x5, v3), relax.TensorType(dtype=None))
     _check_inference(
         bb, relax.op.full_like(x0, v0, dtype="float16"), relax.TensorType((2, 3), "float16")
     )
@@ -264,7 +264,7 @@ def test_full_like_infer_ty_shape_symbolic():
     v = relax.Var("v", R.Tensor((), "float16"))
 
     _check_inference(bb, relax.op.full_like(x0, v), relax.TensorType((m, n), "float32"))
-    _check_inference(bb, relax.op.full_like(x1, v), relax.TensorType((m, n), dtype=""))
+    _check_inference(bb, relax.op.full_like(x1, v), relax.TensorType((m, n), dtype=None))
 
 
 def test_full_like_infer_ty_shape_var():
@@ -445,9 +445,9 @@ def test_ones_like_zeros_like_infer_ty():
     _check_inference(bb, relax.op.ones_like(x0), relax.TensorType((2, 3), "float32"))
     _check_inference(bb, relax.op.zeros_like(x1), relax.TensorType(dtype="float32", ndim=2))
     _check_inference(bb, relax.op.ones_like(x2), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.zeros_like(x3), relax.TensorType((2, 3), dtype=""))
-    _check_inference(bb, relax.op.ones_like(x4), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.zeros_like(x5), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.zeros_like(x3), relax.TensorType((2, 3), dtype=None))
+    _check_inference(bb, relax.op.ones_like(x4), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.zeros_like(x5), relax.TensorType(dtype=None))
     _check_inference(
         bb, relax.op.ones_like(x0, dtype="float16"), relax.TensorType((2, 3), "float16")
     )
@@ -464,7 +464,7 @@ def test_ones_like_zeros_like_infer_ty_shape_symbolic():
     x1 = relax.Var("x", R.Tensor((m, n)))
 
     _check_inference(bb, relax.op.ones_like(x0), relax.TensorType((m, n), "float32"))
-    _check_inference(bb, relax.op.zeros_like(x1), relax.TensorType((m, n), dtype=""))
+    _check_inference(bb, relax.op.zeros_like(x1), relax.TensorType((m, n), dtype=None))
 
 
 def test_ones_like_zeros_like_infer_ty_shape_var():
@@ -530,7 +530,7 @@ def test_eye_like_infer_ty():
 
     _check_inference(bb, relax.op.eye_like(x0), relax.TensorType((3, 4), "float32"))
     _check_inference(bb, relax.op.eye_like(x1), relax.TensorType((2, 5), "int64"))
-    _check_inference(bb, relax.op.eye_like(x2), relax.TensorType((3, 3), dtype=""))
+    _check_inference(bb, relax.op.eye_like(x2), relax.TensorType((3, 3), dtype=None))
     _check_inference(bb, relax.op.eye_like(x0, k=1), relax.TensorType((3, 4), "float32"))
     _check_inference(
         bb, relax.op.eye_like(x1, dtype="float32"), relax.TensorType((2, 5), "float32")
@@ -640,9 +640,9 @@ def test_tril_triu_infer_ty():
     _check_inference(bb, relax.op.tril(x0), relax.TensorType((2, 3, 4), "float32"))
     _check_inference(bb, relax.op.triu(x1), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.tril(x2), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.triu(x3), relax.TensorType((2, 3, 4), dtype=""))
-    _check_inference(bb, relax.op.tril(x4), relax.TensorType(dtype="", ndim=3))
-    _check_inference(bb, relax.op.triu(x5), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.triu(x3), relax.TensorType((2, 3, 4), dtype=None))
+    _check_inference(bb, relax.op.tril(x4), relax.TensorType(dtype=None, ndim=3))
+    _check_inference(bb, relax.op.triu(x5), relax.TensorType(dtype=None))
     _check_inference(bb, relax.op.tril(x6), relax.TensorType((2, 3, 4), "float32", vdev0))
 
 
@@ -659,11 +659,11 @@ def test_tril_triu_infer_ty_shape_symbolic():
 
     # Dynamic tensor, static offset
     _check_inference(bb, relax.op.tril(x0), relax.TensorType((a, b, c), "float32"))
-    _check_inference(bb, relax.op.triu(x1), relax.TensorType((a, b, c), dtype=""))
+    _check_inference(bb, relax.op.triu(x1), relax.TensorType((a, b, c), dtype=None))
     _check_inference(bb, relax.op.tril(x2), relax.TensorType((a, b, c), "float32", vdev0))
 
     # Static tensor, dynamic offset
-    _check_inference(bb, relax.op.tril(x3, a), relax.TensorType((16, 32, 64), dtype=""))
+    _check_inference(bb, relax.op.tril(x3, a), relax.TensorType((16, 32, 64), dtype=None))
 
     # Dynamic tensor, dynamic offset
     _check_inference(bb, relax.op.tril(x0, a), relax.TensorType((a, b, c), "float32"))

--- a/tests/python/relax/test_op_index.py
+++ b/tests/python/relax/test_op_index.py
@@ -73,27 +73,27 @@ def test_take_infer_ty():
     _check_inference(bb, relax.op.take(x0, idx0, axis=-1), relax.TensorType((4, 6), "float32"))
     _check_inference(bb, relax.op.take(x1, idx0, axis=1), relax.TensorType(dtype="float32", ndim=2))
     _check_inference(bb, relax.op.take(x2, idx0, axis=1), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.take(x3, idx0, axis=1), relax.TensorType((4, 6), dtype=""))
-    _check_inference(bb, relax.op.take(x4, idx0, axis=1), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.take(x5, idx0, axis=1), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.take(x3, idx0, axis=1), relax.TensorType((4, 6), dtype=None))
+    _check_inference(bb, relax.op.take(x4, idx0, axis=1), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.take(x5, idx0, axis=1), relax.TensorType(dtype=None))
     _check_inference(bb, relax.op.take(x0, idx1, axis=1), relax.TensorType(dtype="float32", ndim=2))
     _check_inference(bb, relax.op.take(x1, idx1, axis=1), relax.TensorType(dtype="float32", ndim=2))
     _check_inference(bb, relax.op.take(x2, idx1, axis=1), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.take(x3, idx1, axis=1), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.take(x4, idx1, axis=1), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.take(x5, idx1, axis=1), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.take(x3, idx1, axis=1), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.take(x4, idx1, axis=1), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.take(x5, idx1, axis=1), relax.TensorType(dtype=None))
     _check_inference(bb, relax.op.take(x0, idx2, axis=1), relax.TensorType((4, 6), "float32"))
     _check_inference(bb, relax.op.take(x1, idx2, axis=1), relax.TensorType(dtype="float32", ndim=2))
     _check_inference(bb, relax.op.take(x2, idx2, axis=1), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.take(x3, idx2, axis=1), relax.TensorType((4, 6), dtype=""))
-    _check_inference(bb, relax.op.take(x4, idx2, axis=1), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.take(x5, idx2, axis=1), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.take(x3, idx2, axis=1), relax.TensorType((4, 6), dtype=None))
+    _check_inference(bb, relax.op.take(x4, idx2, axis=1), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.take(x5, idx2, axis=1), relax.TensorType(dtype=None))
     _check_inference(bb, relax.op.take(x0, idx3, axis=1), relax.TensorType(dtype="float32", ndim=2))
     _check_inference(bb, relax.op.take(x1, idx3, axis=1), relax.TensorType(dtype="float32", ndim=2))
     _check_inference(bb, relax.op.take(x2, idx3, axis=1), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.take(x3, idx3, axis=1), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.take(x4, idx3, axis=1), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.take(x5, idx3, axis=1), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.take(x3, idx3, axis=1), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.take(x4, idx3, axis=1), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.take(x5, idx3, axis=1), relax.TensorType(dtype=None))
     _check_inference(
         bb, relax.op.take(x0, idx4, axis=0), relax.TensorType((6, 4, 10), dtype="float32")
     )
@@ -102,16 +102,16 @@ def test_take_infer_ty():
     )
     _check_inference(bb, relax.op.take(x1, idx4, axis=1), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.take(x2, idx4, axis=1), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.take(x3, idx4, axis=1), relax.TensorType((4, 6, 4), dtype=""))
-    _check_inference(bb, relax.op.take(x4, idx4, axis=1), relax.TensorType(dtype="", ndim=3))
-    _check_inference(bb, relax.op.take(x5, idx4, axis=1), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.take(x3, idx4, axis=1), relax.TensorType((4, 6, 4), dtype=None))
+    _check_inference(bb, relax.op.take(x4, idx4, axis=1), relax.TensorType(dtype=None, ndim=3))
+    _check_inference(bb, relax.op.take(x5, idx4, axis=1), relax.TensorType(dtype=None))
     _check_inference(bb, relax.op.take(x0, idx5, axis=0), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.take(x0, idx5, axis=1), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.take(x1, idx5, axis=1), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.take(x2, idx5, axis=1), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.take(x3, idx5, axis=1), relax.TensorType(dtype="", ndim=3))
-    _check_inference(bb, relax.op.take(x4, idx5, axis=1), relax.TensorType(dtype="", ndim=3))
-    _check_inference(bb, relax.op.take(x5, idx5, axis=1), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.take(x3, idx5, axis=1), relax.TensorType(dtype=None, ndim=3))
+    _check_inference(bb, relax.op.take(x4, idx5, axis=1), relax.TensorType(dtype=None, ndim=3))
+    _check_inference(bb, relax.op.take(x5, idx5, axis=1), relax.TensorType(dtype=None))
     _check_inference(
         bb, relax.op.take(x0, idx6, axis=0), relax.TensorType((6, 4, 10), dtype="float32")
     )
@@ -120,48 +120,48 @@ def test_take_infer_ty():
     )
     _check_inference(bb, relax.op.take(x1, idx6, axis=1), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.take(x2, idx6, axis=1), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.take(x3, idx6, axis=1), relax.TensorType((4, 6, 4), dtype=""))
-    _check_inference(bb, relax.op.take(x4, idx6, axis=1), relax.TensorType(dtype="", ndim=3))
-    _check_inference(bb, relax.op.take(x5, idx6, axis=1), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.take(x3, idx6, axis=1), relax.TensorType((4, 6, 4), dtype=None))
+    _check_inference(bb, relax.op.take(x4, idx6, axis=1), relax.TensorType(dtype=None, ndim=3))
+    _check_inference(bb, relax.op.take(x5, idx6, axis=1), relax.TensorType(dtype=None))
     _check_inference(bb, relax.op.take(x0, idx7, axis=0), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.take(x0, idx7, axis=1), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.take(x1, idx7, axis=1), relax.TensorType(dtype="float32", ndim=3))
     _check_inference(bb, relax.op.take(x2, idx7, axis=1), relax.TensorType(dtype="float32"))
-    _check_inference(bb, relax.op.take(x3, idx7, axis=1), relax.TensorType(dtype="", ndim=3))
-    _check_inference(bb, relax.op.take(x4, idx7, axis=1), relax.TensorType(dtype="", ndim=3))
-    _check_inference(bb, relax.op.take(x5, idx7, axis=1), relax.TensorType(dtype=""))
+    _check_inference(bb, relax.op.take(x3, idx7, axis=1), relax.TensorType(dtype=None, ndim=3))
+    _check_inference(bb, relax.op.take(x4, idx7, axis=1), relax.TensorType(dtype=None, ndim=3))
+    _check_inference(bb, relax.op.take(x5, idx7, axis=1), relax.TensorType(dtype=None))
     _check_inference(bb, relax.op.take(y0, idx0), relax.TensorType((6,), "float32"))
     _check_inference(bb, relax.op.take(y1, idx0), relax.TensorType(dtype="float32", ndim=1))
-    _check_inference(bb, relax.op.take(y2, idx0), relax.TensorType((6,), dtype=""))
-    _check_inference(bb, relax.op.take(y3, idx0), relax.TensorType(dtype="", ndim=1))
+    _check_inference(bb, relax.op.take(y2, idx0), relax.TensorType((6,), dtype=None))
+    _check_inference(bb, relax.op.take(y3, idx0), relax.TensorType(dtype=None, ndim=1))
     _check_inference(bb, relax.op.take(y0, idx1), relax.TensorType(dtype="float32", ndim=1))
     _check_inference(bb, relax.op.take(y1, idx1), relax.TensorType(dtype="float32", ndim=1))
-    _check_inference(bb, relax.op.take(y2, idx1), relax.TensorType(dtype="", ndim=1))
-    _check_inference(bb, relax.op.take(y3, idx1), relax.TensorType(dtype="", ndim=1))
+    _check_inference(bb, relax.op.take(y2, idx1), relax.TensorType(dtype=None, ndim=1))
+    _check_inference(bb, relax.op.take(y3, idx1), relax.TensorType(dtype=None, ndim=1))
     _check_inference(bb, relax.op.take(y0, idx2), relax.TensorType((6,), "float32"))
     _check_inference(bb, relax.op.take(y1, idx2), relax.TensorType(dtype="float32", ndim=1))
-    _check_inference(bb, relax.op.take(y2, idx2), relax.TensorType((6,), dtype=""))
-    _check_inference(bb, relax.op.take(y3, idx2), relax.TensorType(dtype="", ndim=1))
+    _check_inference(bb, relax.op.take(y2, idx2), relax.TensorType((6,), dtype=None))
+    _check_inference(bb, relax.op.take(y3, idx2), relax.TensorType(dtype=None, ndim=1))
     _check_inference(bb, relax.op.take(y0, idx3), relax.TensorType(dtype="float32", ndim=1))
     _check_inference(bb, relax.op.take(y1, idx3), relax.TensorType(dtype="float32", ndim=1))
-    _check_inference(bb, relax.op.take(y2, idx3), relax.TensorType(dtype="", ndim=1))
-    _check_inference(bb, relax.op.take(y3, idx3), relax.TensorType(dtype="", ndim=1))
+    _check_inference(bb, relax.op.take(y2, idx3), relax.TensorType(dtype=None, ndim=1))
+    _check_inference(bb, relax.op.take(y3, idx3), relax.TensorType(dtype=None, ndim=1))
     _check_inference(bb, relax.op.take(y0, idx4), relax.TensorType((6, 4), "float32"))
     _check_inference(bb, relax.op.take(y1, idx4), relax.TensorType(dtype="float32", ndim=2))
-    _check_inference(bb, relax.op.take(y2, idx4), relax.TensorType((6, 4), dtype=""))
-    _check_inference(bb, relax.op.take(y3, idx4), relax.TensorType(dtype="", ndim=2))
+    _check_inference(bb, relax.op.take(y2, idx4), relax.TensorType((6, 4), dtype=None))
+    _check_inference(bb, relax.op.take(y3, idx4), relax.TensorType(dtype=None, ndim=2))
     _check_inference(bb, relax.op.take(y0, idx5), relax.TensorType(dtype="float32", ndim=2))
     _check_inference(bb, relax.op.take(y1, idx5), relax.TensorType(dtype="float32", ndim=2))
-    _check_inference(bb, relax.op.take(y2, idx5), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.take(y3, idx5), relax.TensorType(dtype="", ndim=2))
+    _check_inference(bb, relax.op.take(y2, idx5), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.take(y3, idx5), relax.TensorType(dtype=None, ndim=2))
     _check_inference(bb, relax.op.take(y0, idx6), relax.TensorType((6, 4), "float32"))
     _check_inference(bb, relax.op.take(y1, idx6), relax.TensorType(dtype="float32", ndim=2))
-    _check_inference(bb, relax.op.take(y2, idx6), relax.TensorType((6, 4), dtype=""))
-    _check_inference(bb, relax.op.take(y3, idx6), relax.TensorType(dtype="", ndim=2))
+    _check_inference(bb, relax.op.take(y2, idx6), relax.TensorType((6, 4), dtype=None))
+    _check_inference(bb, relax.op.take(y3, idx6), relax.TensorType(dtype=None, ndim=2))
     _check_inference(bb, relax.op.take(y0, idx7), relax.TensorType(dtype="float32", ndim=2))
     _check_inference(bb, relax.op.take(y1, idx7), relax.TensorType(dtype="float32", ndim=2))
-    _check_inference(bb, relax.op.take(y2, idx7), relax.TensorType(dtype="", ndim=2))
-    _check_inference(bb, relax.op.take(y3, idx7), relax.TensorType(dtype="", ndim=2))
+    _check_inference(bb, relax.op.take(y2, idx7), relax.TensorType(dtype=None, ndim=2))
+    _check_inference(bb, relax.op.take(y3, idx7), relax.TensorType(dtype=None, ndim=2))
 
 
 def test_take_infer_ty_scalar_tensor_index():
@@ -208,17 +208,21 @@ def test_take_infer_ty_shape_symbolic():
     )
 
     _check_inference(bb, relax.op.take(x0, idx0, axis=1), relax.TensorType((m, i), "float32"))
-    _check_inference(bb, relax.op.take(x1, idx0, axis=1), relax.TensorType((m, i), dtype=""))
+    _check_inference(bb, relax.op.take(x1, idx0, axis=1), relax.TensorType((m, i), dtype=None))
     _check_inference(bb, relax.op.take(x0, idx1, axis=1), relax.TensorType((m, i), "float32"))
-    _check_inference(bb, relax.op.take(x1, idx1, axis=1), relax.TensorType((m, i), dtype=""))
-    _check_inference(bb, relax.op.take(x1, idx2, axis=1), relax.TensorType((m, i, j, k), dtype=""))
-    _check_inference(bb, relax.op.take(x1, idx2, axis=1), relax.TensorType((m, i, j, k), dtype=""))
+    _check_inference(bb, relax.op.take(x1, idx1, axis=1), relax.TensorType((m, i), dtype=None))
+    _check_inference(
+        bb, relax.op.take(x1, idx2, axis=1), relax.TensorType((m, i, j, k), dtype=None)
+    )
+    _check_inference(
+        bb, relax.op.take(x1, idx2, axis=1), relax.TensorType((m, i, j, k), dtype=None)
+    )
     _check_inference(bb, relax.op.take(y0, idx0), relax.TensorType((i,), "float32"))
-    _check_inference(bb, relax.op.take(y1, idx0), relax.TensorType((i,), dtype=""))
+    _check_inference(bb, relax.op.take(y1, idx0), relax.TensorType((i,), dtype=None))
     _check_inference(bb, relax.op.take(y0, idx1), relax.TensorType((i,), "float32"))
-    _check_inference(bb, relax.op.take(y1, idx1), relax.TensorType((i,), dtype=""))
+    _check_inference(bb, relax.op.take(y1, idx1), relax.TensorType((i,), dtype=None))
     _check_inference(bb, relax.op.take(y0, idx2), relax.TensorType((i, j, k), "float32"))
-    _check_inference(bb, relax.op.take(y1, idx2), relax.TensorType((i, j, k), dtype=""))
+    _check_inference(bb, relax.op.take(y1, idx2), relax.TensorType((i, j, k), dtype=None))
 
 
 def test_take_infer_ty_shape_var():
@@ -371,21 +375,21 @@ def test_strided_slice_infer_ty():
         relax.op.strided_slice(
             x3, axes=[0, 1, 3], begin=[1, 0, 8], end=[8, 9, 0], strides=[2, 1, -3]
         ),
-        relax.TensorType((4, 9, 10, 3), dtype=""),
+        relax.TensorType((4, 9, 10, 3), dtype=None),
     )
     _check_inference(
         bb,
         relax.op.strided_slice(
             x4, axes=[0, 1, 3], begin=[1, 0, 8], end=[8, 9, 0], strides=[2, 1, -3]
         ),
-        relax.TensorType(dtype="", ndim=4),
+        relax.TensorType(dtype=None, ndim=4),
     )
     _check_inference(
         bb,
         relax.op.strided_slice(
             x5, axes=[0, 1, 3], begin=[1, 0, 8], end=[8, 9, 0], strides=[2, 1, -3]
         ),
-        relax.TensorType(dtype=""),
+        relax.TensorType(dtype=None),
     )
     _check_inference(
         bb,
@@ -454,12 +458,12 @@ def test_strided_slice_infer_ty_shape_symbolic():
     _check_inference(
         bb,
         relax.op.strided_slice(x1, axes=[0], begin=[1], end=[3]),
-        relax.TensorType((tirx.min(3, m) - tirx.min(1, m), n), dtype=""),
+        relax.TensorType((tirx.min(3, m) - tirx.min(1, m), n), dtype=None),
     )
     _check_inference(
         bb,
         relax.op.strided_slice(x1, axes=[0], begin=[1], end=[8], strides=[3]),
-        relax.TensorType(((tirx.min(8, m) + 2 - tirx.min(1, m)) // 3, n), dtype=""),
+        relax.TensorType(((tirx.min(8, m) + 2 - tirx.min(1, m)) // 3, n), dtype=None),
     )
 
 
@@ -471,9 +475,9 @@ def test_strided_slice_infer_ty_shape_var():
     x0 = relax.Var("x", relax.TensorType(s0, "float32"))
     x1 = relax.Var("x", relax.TensorType(s1, "float32"))
     x2 = relax.Var("x", relax.TensorType(s2, "float32"))
-    x3 = relax.Var("x", relax.TensorType(s0, dtype=""))
-    x4 = relax.Var("x", relax.TensorType(s1, dtype=""))
-    x5 = relax.Var("x", relax.TensorType(s2, dtype=""))
+    x3 = relax.Var("x", relax.TensorType(s0, dtype=None))
+    x4 = relax.Var("x", relax.TensorType(s1, dtype=None))
+    x5 = relax.Var("x", relax.TensorType(s2, dtype=None))
 
     _check_inference(
         bb,
@@ -493,17 +497,17 @@ def test_strided_slice_infer_ty_shape_var():
     _check_inference(
         bb,
         relax.op.strided_slice(x3, axes=[0], begin=[0], end=[8]),
-        relax.TensorType(shape=[8, 10], dtype=""),
+        relax.TensorType(shape=[8, 10], dtype=None),
     )
     _check_inference(
         bb,
         relax.op.strided_slice(x4, axes=[0], begin=[0], end=[8]),
-        relax.TensorType(dtype="", ndim=2),
+        relax.TensorType(dtype=None, ndim=2),
     )
     _check_inference(
         bb,
         relax.op.strided_slice(x5, axes=[0], begin=[0], end=[8]),
-        relax.TensorType(dtype=""),
+        relax.TensorType(dtype=None),
     )
 
 

--- a/tests/python/relax/test_op_qdq.py
+++ b/tests/python/relax/test_op_qdq.py
@@ -49,6 +49,34 @@ def test_qdq_op_infer_ty():
     )
 
 
+def test_qdq_op_infer_ty_unknown_dtype():
+    bb = relax.BlockBuilder()
+    x = relax.Var("x", R.Tensor((2, 3), dtype=None))
+    dx = relax.Var("dx", R.Tensor((2, 3), dtype=None))
+    s = relax.Var("s", R.Tensor([3], "float32"))
+    s_unknown = relax.Var("s_unknown", R.Tensor([3], dtype=None))
+    zp = relax.Var("zp", R.Tensor([3], "int8"))
+    zp_unknown = relax.Var("zp_unknown", R.Tensor([3], dtype=None))
+    _check_inference(
+        bb, relax.op.quantize(x, s, zp, 1, "int8"), relax.TensorType((2, 3), dtype=None)
+    )
+    _check_inference(
+        bb,
+        relax.op.quantize(dx, s_unknown, zp, 1, "int8"),
+        relax.TensorType((2, 3), dtype=None),
+    )
+    _check_inference(
+        bb,
+        relax.op.quantize(dx, s, zp_unknown, 1, "int8"),
+        relax.TensorType((2, 3), dtype=None),
+    )
+    _check_inference(
+        bb,
+        relax.op.dequantize(dx, s, zp, 1, "float32"),
+        relax.TensorType((2, 3), dtype=None),
+    )
+
+
 def test_qdq_op_infer_ty_symbolic():
     bb = relax.BlockBuilder()
     n = tirx.Var("n", "int64")

--- a/tests/python/relax/test_op_search.py
+++ b/tests/python/relax/test_op_search.py
@@ -189,7 +189,7 @@ def test_where_infer_ty_more_input_dtype():
 def test_where_infer_ty_cond_not_boolean():
     bb = relax.BlockBuilder()
     cond0 = relax.Var("cond", R.Tensor((2, 3), "float32"))
-    cond1 = relax.Var("cond", R.Tensor((2, 3)))
+    cond1 = relax.Var("cond", relax.TensorType(dtype="int32", ndim=2))
     x = relax.Var("x", R.Tensor((2, 3), "float32"))
     y = relax.Var("y", R.Tensor((2, 3), "float32"))
 

--- a/tests/python/relax/test_op_view.py
+++ b/tests/python/relax/test_op_view.py
@@ -482,6 +482,7 @@ def test_lower_runtime_builtin_shape_change():
     class Expected:
         @R.function
         def main(A: R.Tensor([4096], "float32")):
+            _ = R.null_value()
             B = R.ExternFunc(
                 "runtime.TVMTensorCreateView",
                 R.Callable(
@@ -514,6 +515,7 @@ def test_lower_runtime_builtin_view_shape_from_unknown():
     class Expected:
         @R.function
         def main(A: R.Tensor(dtype="float32")):
+            _ = R.null_value()
             B = R.ExternFunc(
                 "runtime.TVMTensorCreateView",
                 R.Callable(
@@ -574,6 +576,7 @@ def test_lower_runtime_builtin_byte_offset():
     class Expected:
         @R.function
         def main(A: R.Tensor([4096], "float32")):
+            _ = R.null_value()
             B = R.ExternFunc(
                 "runtime.TVMTensorCreateView",
                 R.Callable(

--- a/tests/python/relax/test_op_view.py
+++ b/tests/python/relax/test_op_view.py
@@ -244,6 +244,15 @@ def test_infer_dtype_of_float32_view():
     tvm.ir.assert_structural_equal(explicit_ty, inferred_ty)
 
 
+def test_error_if_view_dtype_is_void():
+    with pytest.raises(tvm.error.DiagnosticError):
+
+        @R.function
+        def func(A: R.Tensor("float32")):
+            B = R.memory.view(A, dtype=R.dtype("void"))
+            return B
+
+
 def test_view_without_explicit_dtype_keeps_input_dtype():
     """If R.memory.view only specifies the shape, the dtype is unchanged"""
 

--- a/tests/python/relax/test_runtime_builtin.py
+++ b/tests/python/relax/test_runtime_builtin.py
@@ -92,8 +92,8 @@ def test_check_tensor_info():
 
     check_tensor_info(x, 2, "int32", "")
     check_tensor_info(x, -1, "int32", "")
-    check_tensor_info(x, 2, "", "")
-    check_tensor_info(x, -1, "", "")
+    check_tensor_info(x, 2, None, "")
+    check_tensor_info(x, -1, None, "")
 
     # allow not passing in dtype
     check_tensor_info(x, 2, "")
@@ -113,7 +113,7 @@ def test_check_tensor_info():
 
     # wrong type
     with pytest.raises(TypeError):
-        check_tensor_info([], 2, "", "")
+        check_tensor_info([], 2, None, "")
 
 
 def test_check_tuple_info():

--- a/tests/python/relax/test_training_loss.py
+++ b/tests/python/relax/test_training_loss.py
@@ -74,7 +74,7 @@ def test_l1_loss_append():
     ) -> R.Tensor((), "float32"):
         R.func_attr({"global_symbol": "forward_loss"})
         with R.dataflow():
-            lv: R.Tensor((2, 4), "float32") = R.matmul(x, w, out_dtype="")
+            lv: R.Tensor((2, 4), "float32") = R.matmul(x, w)
             out: R.Tensor((2, 4), "float32") = R.add(lv, b)
             lv1: R.Tensor((2, 4), "float32") = R.subtract(out, targets)
             lv11: R.Tensor((2, 4), "float32") = R.abs(lv1)
@@ -123,7 +123,7 @@ def test_mse_loss_append():
     ) -> R.Tensor((), "float32"):
         R.func_attr({"global_symbol": "forward_loss"})
         with R.dataflow():
-            lv: R.Tensor((2, 4), "float32") = R.matmul(x, w, out_dtype="")
+            lv: R.Tensor((2, 4), "float32") = R.matmul(x, w)
             out: R.Tensor((2, 4), "float32") = R.add(lv, b)
             lv1: R.Tensor((2, 4), "float32") = R.subtract(out, targets)
             lv11: R.Tensor((2, 4), "float32") = R.multiply(lv1, lv1)
@@ -204,7 +204,7 @@ def test_cross_entropy_loss_append():
     ) -> R.Tensor((), "float32"):
         R.func_attr({"global_symbol": "forward_loss"})
         with R.dataflow():
-            lv: R.Tensor((2, 4), "float32") = R.matmul(x, w, out_dtype="")
+            lv: R.Tensor((2, 4), "float32") = R.matmul(x, w)
             out: R.Tensor((2, 4), "float32") = R.add(lv, b)
             lv1: R.Tensor((2, 4), "float32") = R.nn.log_softmax(out, axis=-1)
             gv: R.Tensor((), "float32") = R.nn.nll_loss(

--- a/tests/python/relax/test_transform_canonicalize_bindings.py
+++ b/tests/python/relax/test_transform_canonicalize_bindings.py
@@ -390,7 +390,7 @@ def test_fold_variables_from_match_cast():
 
             # The symbolic shapes propagate downstream.
             lhs: R.Tensor([N1 + N2, M], "float32") = R.concat((lhs_A, lhs_B), axis=0)
-            proj_concat: R.Tensor([N1 + N2], "float32") = R.matmul(lhs, rhs, out_dtype="void")
+            proj_concat: R.Tensor([N1 + N2], "float32") = R.matmul(lhs, rhs)
             proj_A = R.strided_slice(
                 proj_concat,
                 (R.prim_value(0),),
@@ -420,7 +420,7 @@ def test_fold_variables_from_match_cast():
             # statically-known shapes.
 
             lhs: R.Tensor([32, 16], dtype="float32") = R.concat((A, B), axis=0)
-            proj_concat: R.Tensor([32], dtype="float32") = R.matmul(lhs, state, out_dtype="void")
+            proj_concat: R.Tensor([32], dtype="float32") = R.matmul(lhs, state)
             proj_A: R.Tensor([16], dtype="float32") = R.strided_slice(
                 proj_concat,
                 [R.prim_value(0)],
@@ -469,7 +469,7 @@ def test_inconsistent_match_cast_raises_error():
             rhs = R.match_cast(state, R.Tensor([M], dtype="float32"))
 
             lhs: R.Tensor([N1 + N2, M], "float32") = R.concat((lhs_A, lhs_B), axis=0)
-            proj_concat: R.Tensor([N1 + N2], "float32") = R.matmul(lhs, rhs, out_dtype="void")
+            proj_concat: R.Tensor([N1 + N2], "float32") = R.matmul(lhs, rhs)
             proj_A = R.strided_slice(
                 proj_concat,
                 (R.prim_value(0),),

--- a/tests/python/relax/test_transform_codegen_pass.py
+++ b/tests/python/relax/test_transform_codegen_pass.py
@@ -328,7 +328,7 @@ def test_dynamic_shape():
             ) -> R.Tensor((1, r1), dtype="float16"):
                 R.func_attr({"Composite": "cublas.matmul"})
                 with R.dataflow():
-                    gv_1: R.Tensor((1, r1), dtype="float16") = R.matmul(x_1, w1_1, out_dtype="void")
+                    gv_1: R.Tensor((1, r1), dtype="float16") = R.matmul(x_1, w1_1, out_dtype=None)
                     R.output(gv_1)
                 return gv_1
 

--- a/tests/python/relax/test_transform_combine_parallel_matmul.py
+++ b/tests/python/relax/test_transform_combine_parallel_matmul.py
@@ -382,9 +382,9 @@ def test_rhs_batched():
             lv1 = R.matmul(x, lv, out_dtype="float32")
             lv2 = R.split(lv1, indices_or_sections=[640], axis=2)
             lv0 = lv2[0]
-            lv1_1 = R.matmul(x, w1, out_dtype="void")
+            lv1_1 = R.matmul(x, w1, out_dtype=None)
             lv2_1 = lv2[1]
-            lv3 = R.matmul(x, w3, out_dtype="void")
+            lv3 = R.matmul(x, w3, out_dtype=None)
             out = lv0, lv1_1, lv2_1, lv3
             R.output(out)
         return out
@@ -517,8 +517,8 @@ def test_check():
             lv0 = lv2[0]
             lv1_1 = lv2[1]
             lv2_1 = lv2[2]
-            lv3 = R.matmul(x2, w3, out_dtype="void")
-            lv4 = R.matmul(x2, w4, out_dtype="void")
+            lv3 = R.matmul(x2, w3, out_dtype=None)
+            lv4 = R.matmul(x2, w4, out_dtype=None)
             out = (lv0, lv1_1, lv2_1, lv3, lv4)
             R.output(out)
         return out

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -1439,7 +1439,6 @@ def test_conv2d_resize2d():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="void",
                 )
                 gv2: R.Tensor((2, 4, 52, 52), dtype="float32") = R.permute_dims(
                     lv2, axes=[0, 3, 1, 2]
@@ -1482,7 +1481,6 @@ def test_resize2d_conv2d():
                     cubic_alpha=-0.75,
                     cubic_exclude=0,
                     extrapolation_value=0,
-                    out_dtype="void",
                 )
                 lv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.permute_dims(w, axes=[0, 2, 3, 1])
                 lv2: R.Tensor((2, 50, 50, 4), dtype="float32") = R.nn.conv2d(

--- a/tests/python/relax/test_transform_fuse_ops_by_pattern.py
+++ b/tests/python/relax/test_transform_fuse_ops_by_pattern.py
@@ -413,7 +413,7 @@ class Conv2dx2_partitioned:
                     data_layout="NHWC",
                     kernel_layout="OHWI",
                     out_layout="NHWC",
-                    out_dtype="void",
+                    out_dtype=None,
                 )
                 R.output(gv_2)
             return gv_2

--- a/tests/python/relax/test_transform_gradient.py
+++ b/tests/python/relax/test_transform_gradient.py
@@ -952,10 +952,10 @@ def test_simplify_matmul_pattern():
                 lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
                 lv: R.Tensor((3, 3), dtype="float32") = R.permute_dims(lv3_adjoint, axes=[1, 0])
                 lv1_1: R.Tensor((3, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
-                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.matmul(lv, lv1_1, out_dtype="void")
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.matmul(lv, lv1_1)
                 lv2_1: R.Tensor((3, 3), dtype="float32") = R.permute_dims(y, axes=[1, 0])
                 lv3_1: R.Tensor((3, 3), dtype="float32") = R.permute_dims(lv3_adjoint, axes=[1, 0])
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.matmul(lv2_1, lv3_1, out_dtype="void")
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.matmul(lv2_1, lv3_1)
                 x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
                 y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
                 R.output(gv, x_adjoint_out, y_adjoint_out)
@@ -1290,7 +1290,7 @@ def test_mlp_script():
         @R.function
         def main_adjoint(x: R.Tensor((3, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32"), label: R.Tensor((3, 5), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((5,), dtype="float32"))):
             with R.dataflow():
-                lv0: R.Tensor((3, 5), dtype="float32") = R.matmul(x, w0, out_dtype="void")
+                lv0: R.Tensor((3, 5), dtype="float32") = R.matmul(x, w0)
                 out: R.Tensor((3, 5), dtype="float32") = R.add(lv0, b0)
                 logits: R.Tensor((3, 5), dtype="float32") = R.nn.log_softmax(out, axis=-1)
                 loss: R.Tensor((), dtype="float32") = R.nn.cross_entropy_with_logits(logits, label)
@@ -1305,7 +1305,7 @@ def test_mlp_script():
                 lv0_adjoint: R.Tensor((3, 5), dtype="float32") = out_adjoint
                 b0_adjoint: R.Tensor((5,), dtype="float32") = R.collapse_sum_to(out_adjoint, R.shape([5]))
                 lv7: R.Tensor((10, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
-                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.matmul(lv7, lv0_adjoint, out_dtype="void")
+                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.matmul(lv7, lv0_adjoint)
                 w0_adjoint_out: R.Tensor((10, 5), dtype="float32") = w0_adjoint
                 b0_adjoint_out: R.Tensor((5,), dtype="float32") = b0_adjoint
                 R.output(loss, w0_adjoint_out, b0_adjoint_out)
@@ -1314,7 +1314,7 @@ def test_mlp_script():
         @R.function
         def main(x: R.Tensor((3, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32"), label: R.Tensor((3, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv0: R.Tensor((3, 5), dtype="float32") = R.matmul(x, w0, out_dtype="void")
+                lv0: R.Tensor((3, 5), dtype="float32") = R.matmul(x, w0)
                 out: R.Tensor((3, 5), dtype="float32") = R.add(lv0, b0)
                 logits: R.Tensor((3, 5), dtype="float32") = R.nn.log_softmax(out, axis=-1)
                 loss: R.Tensor((), dtype="float32") = R.nn.cross_entropy_with_logits(logits, label)

--- a/tests/python/relax/test_transform_lift_transform_params.py
+++ b/tests/python/relax/test_transform_lift_transform_params.py
@@ -85,7 +85,6 @@ def test_basic(consume_params):
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 conv2: R.Tensor((1, 16, 224, 224), dtype="float32") = R.nn.conv2d(
                     conv1,
@@ -97,7 +96,6 @@ def test_basic(consume_params):
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 R.output(conv2)
             return conv2
@@ -158,7 +156,6 @@ def test_basic(consume_params):
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 conv2: R.Tensor((1, 16, 224, 224), dtype="float32") = R.nn.conv2d(
                     conv1,
@@ -170,7 +167,6 @@ def test_basic(consume_params):
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 R.output(conv2)
             return conv2
@@ -276,7 +272,6 @@ def test_tuple():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 conv2: R.Tensor((1, 16, 224, 224), dtype="float32") = R.nn.conv2d(
                     conv1,
@@ -288,7 +283,6 @@ def test_tuple():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 R.output(conv2)
             return conv2
@@ -420,7 +414,7 @@ def test_multiple_functions():
         ) -> R.Tensor((256, 256), dtype="float32"):
             R.func_attr({"num_input": 1})
             with R.dataflow():
-                y: R.Tensor((256, 256), dtype="float32") = R.matmul(x, param0, out_dtype="void")
+                y: R.Tensor((256, 256), dtype="float32") = R.matmul(x, param0)
                 R.output(y)
             return y
 
@@ -443,7 +437,7 @@ def test_multiple_functions():
         ) -> R.Tensor((256, 128), dtype="float32"):
             R.func_attr({"num_input": 1})
             with R.dataflow():
-                y: R.Tensor((256, 128), dtype="float32") = R.matmul(x, param0, out_dtype="void")
+                y: R.Tensor((256, 128), dtype="float32") = R.matmul(x, param0)
                 R.output(y)
             return y
 
@@ -465,7 +459,7 @@ def test_multiple_functions():
         ) -> R.Tensor((256, 256), dtype="float32"):
             with R.dataflow():
                 w1_t: R.Tensor((256, 256), dtype="float32") = R.permute_dims(w1, axes=[1, 0])
-                y: R.Tensor((256, 256), dtype="float32") = R.matmul(x, w1_t, out_dtype="void")
+                y: R.Tensor((256, 256), dtype="float32") = R.matmul(x, w1_t)
                 R.output(y)
             return y
 
@@ -1381,7 +1375,7 @@ def test_stop_lifting():
             R.func_attr({"num_input": 1})
             with R.dataflow():
                 w1_add: R.Tensor((256, 256), dtype="float32") = R.add(param0, R.const(1, "float32"))
-                y: R.Tensor((256, 256), dtype="float32") = R.matmul(x, w1_add, out_dtype="void")
+                y: R.Tensor((256, 256), dtype="float32") = R.matmul(x, w1_add)
                 R.output(y)
             return y
 
@@ -1663,7 +1657,6 @@ def test_symbolic_var_in_param_shape():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 conv2: R.Tensor((1, 16, 224, n), dtype="float32") = R.nn.conv2d(
                     conv1,
@@ -1675,7 +1668,6 @@ def test_symbolic_var_in_param_shape():
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="void",
                 )
                 R.output(conv2)
             return conv2

--- a/tests/python/relax/test_transform_merge_composite_functions.py
+++ b/tests/python/relax/test_transform_merge_composite_functions.py
@@ -234,7 +234,7 @@ class Diamond_merged:
                     data_layout="NCHW",
                     kernel_layout="OIHW",
                     out_layout="NCHW",
-                    out_dtype="",
+                    out_dtype=None,
                 )
                 R.output(gv4)
             return gv4

--- a/tests/python/relax/test_transform_to_mixed_precision.py
+++ b/tests/python/relax/test_transform_to_mixed_precision.py
@@ -169,6 +169,20 @@ def test_conv2d_relu():
     _assert_test(Input, Expected, Expected2)
 
 
+def test_unknown_dtype_is_not_rewritten():
+    @I.ir_module(s_tir=True)
+    class Input:
+        @R.function
+        def main(x: R.Tensor((2, 3), dtype=None)) -> R.Tensor((2, 3), dtype=None):
+            with R.dataflow():
+                gv: R.Tensor((2, 3), dtype=None) = R.nn.relu(x)
+                R.output(gv)
+            return gv
+
+    mod = ToMixedPrecision()(Input)
+    tvm.ir.assert_structural_equal(mod, Input)
+
+
 def test_relu_conv2d_relu():
     @I.ir_module(s_tir=True)
     class Input:

--- a/tests/python/relax/test_tvmscript_parser.py
+++ b/tests/python/relax/test_tvmscript_parser.py
@@ -910,9 +910,9 @@ def test_annotation():
     sh = bindings[4].var
 
     _check_ty(bindings[0], relax.TensorType([32, m], "float32"))
-    _check_ty(bindings[1], relax.TensorType(dtype="", ndim=2))
-    _check_ty(bindings[2], relax.TensorType(dtype="", ndim=-1))
-    _check_ty(bindings[3], relax.TensorType(dtype="", ndim=2))
+    _check_ty(bindings[1], relax.TensorType(dtype=None, ndim=2))
+    _check_ty(bindings[2], relax.TensorType(dtype=None, ndim=-1))
+    _check_ty(bindings[3], relax.TensorType(dtype=None, ndim=2))
     _check_ty(bindings[4], relax.ShapeType(ndim=-1))
     _check_ty(bindings[5], relax.TensorType(sh))
     _check_ty(bindings[6], relax.AnyType())


### PR DESCRIPTION
This PR replaces Relax uses of void dtype sentinels for semantically absent dtypes with explicit optional/null representations.

Summary:
- Make unknown `TensorType` dtype optional instead of represented as `void`.
- Convert optional Relax dtype attrs to optional values and update inference paths to check presence directly.
- Represent `R.memory.view(..., dtype=None)` with `R.null_value()` at the expression boundary, and lower to a concrete runtime dtype when required.
- Reject `R.memory.view(..., dtype=R.dtype("void"))` in inference instead of treating the legacy void spelling as absence.
- Handle review feedback around unknown optional dtype propagation in utility, qdq, and mixed-precision paths.
