### PR TITLE
[DOCS] Refine tvm pypi wheel optional install guidance

### DIFF
--- a/docs/how_to/tutorials/bring_your_own_codegen.py
+++ b/docs/how_to/tutorials/bring_your_own_codegen.py
@@ -193,6 +193,9 @@ else:
 #   into the engine it builds, so bind the parameters before partitioning.
 # - **Real values.** TensorRT actually computes, so we build for CUDA, run on
 #   the GPU, and cross-check against a plain CPU build -- not just the shape.
+#
+# The build-and-run cells below execute only when TensorRT and CUDA are
+# available. In CPU-only documentation builds, they produce no output.
 
 trt_mod = relax.transform.BindParams("main", {"weight": weight_np})(ConvReLU)
 trt_mod = partition_for_tensorrt(trt_mod)
@@ -218,8 +221,6 @@ if has_tensorrt and has_cuda:
 
     np.testing.assert_allclose(trt_out, cpu_out, rtol=1e-2, atol=1e-2)
     print("TensorRT output shape:", trt_out.shape, "- matches the CPU reference.")
-else:
-    print("TensorRT/CUDA unavailable; skipping the GPU build and run.")
 
 ######################################################################
 # A real backend also exposes knobs the stub does not.  Setting ``use_fp16``
@@ -244,8 +245,6 @@ if has_tensorrt and has_cuda:
 
     np.testing.assert_allclose(fp16_out, cpu_out, rtol=5e-2, atol=5e-2)
     print("TensorRT FP16 output shape:", fp16_out.shape, "- matches within FP16 tolerance.")
-else:
-    print("TensorRT/CUDA unavailable; skipping the FP16 build.")
 
 ######################################################################
 # Example NPU vs TensorRT at a glance
@@ -322,8 +321,6 @@ if has_torch and has_tensorrt and has_cuda:
 
     np.testing.assert_allclose(deployed, torch_ref, rtol=1e-2, atol=1e-2)
     print("Deployed PyTorch model on TensorRT; output", deployed.shape, "matches PyTorch.")
-else:
-    print("PyTorch / TensorRT / CUDA unavailable; skipping the deployment example.")
 
 ######################################################################
 # Real deployment builds once and reuses the artifact.  Export the compiled
@@ -340,8 +337,6 @@ if has_torch and has_tensorrt and has_cuda:
         )[0].numpy()
         np.testing.assert_allclose(reran, torch_ref, rtol=1e-2, atol=1e-2)
         print("Reloaded the exported library and reran; output", reran.shape, "still matches.")
-else:
-    print("PyTorch / TensorRT / CUDA unavailable; skipping the export/reload step.")
 
 ######################################################################
 # Notes for real deployments

--- a/docs/install/pypi.rst
+++ b/docs/install/pypi.rst
@@ -30,6 +30,21 @@ TVM wheel from PyPI:
 This installs the Python package, including modules such as ``tvm.tirx``, and
 is suitable for trying tutorials that do not require a custom build.
 
+CUDA environments
+-----------------
+
+Some CUDA workflows use NVIDIA's Python CUDA bindings for runtime compilation.
+Install the CUDA extra in the same environment as TVM when you need this path:
+
+.. code-block:: bash
+
+   pip install "apache-tvm[cuda]"
+
+This extra installs Python-side CUDA bindings only. It does not make the PyPI
+wheel a CUDA-enabled TVM build, and it does not install NVIDIA drivers or a CUDA
+toolkit. If you need CUDA support in TVM itself, build TVM from source with
+``USE_CUDA=ON``.
+
 For more details on installing the TIRx compiler and optional kernel library,
 visit the :doc:`TIRx installation </tirx/install>` page. If you need to
 customize TVM's build configuration, visit the

--- a/docs/tirx/install.rst
+++ b/docs/tirx/install.rst
@@ -85,16 +85,3 @@ kernel):
    * - ``flashinfer``
      - ``nvfp4_gemm``
      - optional — quantization and the baseline
-
-Build from source
------------------
-
-To develop TIRx or build the docs, build TVM from source and make it importable.
-See :doc:`/install/from_source` for the full instructions; in short:
-
-.. code-block:: bash
-
-   export TVM_HOME=/path/to/tvm
-   export TVM_LIBRARY_PATH=$TVM_HOME/build
-   export PYTHONPATH=$TVM_HOME/python:$PYTHONPATH
-   python -c "import tvm, tvm.tirx; print(tvm.__file__)"


### PR DESCRIPTION
This PR refines the PyPI and optional backend installation docs.

It adds lightweight CUDA environment guidance for PyPI installs, removes duplicated TIRx source-build instructions, and avoids showing optional TensorRT/CUDA skip messages in the BYOC tutorial output.
