### PR TITLE
[CI][Docker] Move CI images to Ubuntu 24.04 (noble)

### DIFF
--- a/docker/Dockerfile.ci_arm
+++ b/docker/Dockerfile.ci_arm
@@ -18,7 +18,7 @@
 # CI docker arm env
 # tag: v0.02
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 COPY --from=ghcr.io/astral-sh/uv:0.10.5 /uv /uvx /bin/
 
 COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear

--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -16,7 +16,7 @@
 # under the License.
 
 # CI docker CPU env
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 COPY --from=ghcr.io/astral-sh/uv:0.10.5 /uv /uvx /bin/
 
 COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear

--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -17,7 +17,7 @@
 
 # CI docker GPU env
 # tag: v0.60
-FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
 COPY --from=ghcr.io/astral-sh/uv:0.10.5 /uv /uvx /bin/
 
 COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear
@@ -25,7 +25,7 @@ COPY utils/download-and-verify.sh /usr/local/bin/download-and-verify
 
 # Per https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
 # we need to add a new GPG key before running apt update.
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/3bf863cc.pub
 
 # Base scripts
 RUN rm -f /etc/apt/sources.list.d/nvidia-ml.list && apt-get clean

--- a/docker/Dockerfile.ci_wasm
+++ b/docker/Dockerfile.ci_wasm
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 COPY --from=ghcr.io/astral-sh/uv:0.10.5 /uv /uvx /bin/
 
 COPY utils/apt-install-and-clear.sh /usr/local/bin/apt-install-and-clear

--- a/docker/install/ubuntu_install_core.sh
+++ b/docker/install/ubuntu_install_core.sh
@@ -35,9 +35,9 @@ apt-get update && apt-install-and-clear -y --no-install-recommends \
     libcurl4-openssl-dev \
     libopenblas-dev \
     libssl-dev \
-    libtinfo-dev \
+    libncurses-dev \
     libz-dev \
-    lsb-core \
+    lsb-release \
     make \
     ninja-build \
     parallel \

--- a/docker/install/ubuntu_install_llvm.sh
+++ b/docker/install/ubuntu_install_llvm.sh
@@ -20,20 +20,6 @@ set -e
 set -u
 set -o pipefail
 
-wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key \
-    | gpg --dearmor -o /usr/share/keyrings/llvm-archive.gpg
-
-cat > /etc/apt/sources.list.d/llvm.list <<'EOF'
-deb [signed-by=/usr/share/keyrings/llvm-archive.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main
-deb-src [signed-by=/usr/share/keyrings/llvm-archive.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main
-deb [signed-by=/usr/share/keyrings/llvm-archive.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
-deb-src [signed-by=/usr/share/keyrings/llvm-archive.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
-deb [signed-by=/usr/share/keyrings/llvm-archive.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main
-deb-src [signed-by=/usr/share/keyrings/llvm-archive.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main
-deb [signed-by=/usr/share/keyrings/llvm-archive.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy main
-deb-src [signed-by=/usr/share/keyrings/llvm-archive.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy main
-EOF
-
 apt-get update && apt-install-and-clear -y \
      llvm-15 llvm-16 llvm-17\
      clang-15 libclang-15-dev \

--- a/docker/install/ubuntu_install_rocm.sh
+++ b/docker/install/ubuntu_install_rocm.sh
@@ -23,8 +23,8 @@ set -o pipefail
 # Install ROCm cross compilation toolchain.
 wget -qO - https://repo.radeon.com/rocm/rocm.gpg.key \
     | gpg --dearmor -o /usr/share/keyrings/rocm.gpg
-echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/5.3 jammy main' \
+echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.4.4 noble main' \
     > /etc/apt/sources.list.d/rocm.list
 apt-get update && apt-install-and-clear -y \
-    rocm-dev5.3.0 \
+    rocm-dev6.4.4 \
     lld-15

--- a/docker/install/ubuntu_install_vulkan.sh
+++ b/docker/install/ubuntu_install_vulkan.sh
@@ -20,7 +20,7 @@ set -u
 set -o pipefail
 
 VULKAN_VERSION=1.4.309
-UBUNTU_VERSION=jammy
+UBUNTU_VERSION=noble
 
 wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc \
 	| gpg --dearmor -o /usr/share/keyrings/lunarg-vulkan.gpg


### PR DESCRIPTION
Bump ci_cpu, ci_arm, ci_wasm and ci_gpu from Ubuntu 22.04 (jammy) to 24.04 (noble) so the default g++ is gcc-13, which fully implements C++20 (TVM builds with CMAKE_CXX_STANDARD 20).

- ci_gpu: nvidia/cuda 12.8.1-cudnn-devel base to ubuntu24.04 and CUDA apt GPG key path ubuntu2204 -> ubuntu2404.
- ubuntu_install_core.sh: libtinfo-dev -> libncurses-dev and lsb-core -> lsb-release (both removed on noble).
- ubuntu_install_llvm.sh: install llvm/clang 15/16/17 from the distro repos (noble universe ships them); drop the apt.llvm.org source (no noble debs for 15/16).
- ubuntu_install_rocm.sh: ROCm apt 5.3/jammy -> 6.4.4/noble (5.3 has no noble pool); keep lld-15 to match the LLVM 15 TVM is built with on the GPU image.
- ubuntu_install_vulkan.sh: LunarG SDK list jammy -> noble.