### PR TITLE
[Relax][ONNX] Guard integer Div with dynamic zero divisor

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -546,7 +546,15 @@ class Div(BinaryBase):
         if isinstance(inputs[1], relax.Constant) and bool(_np.any(inputs[1].data.numpy() == 0)):
             raise ValueError("ONNX Div with integer inputs encountered divisor value 0.")
 
-        return cls.base_impl(bb, inputs, attr, params)
+        if isinstance(inputs[1], relax.Constant):
+            return cls.base_impl(bb, inputs, attr, params)
+
+        rhs_dtype = inputs[1].ty.dtype.dtype
+        rhs_nonzero = bb.normalize(relax.op.not_equal(inputs[1], relax.const(0, rhs_dtype)))
+        safe_rhs = bb.normalize(relax.op.where(rhs_nonzero, inputs[1], relax.const(1, rhs_dtype)))
+        quotient = bb.normalize(relax.op.divide(inputs[0], safe_rhs))
+        quotient_dtype = quotient.ty.dtype.dtype
+        return relax.op.where(rhs_nonzero, quotient, relax.const(0, quotient_dtype))
 
 
 class Pow(BinaryBase):

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -658,6 +658,82 @@ def test_div_integer_constant_zero_divisor_raises_valueerror():
         from_onnx(model, opset=18, keep_params_in_input=False)
 
 
+def _make_div_integer_dynamic_model(a_shape, b_shape, y_shape):
+    node = helper.make_node("Div", ["a", "b"], ["y"])
+    graph = helper.make_graph(
+        [node],
+        "div_dyn_zero",
+        [
+            helper.make_tensor_value_info("a", TensorProto.INT32, a_shape),
+            helper.make_tensor_value_info("b", TensorProto.INT32, b_shape),
+        ],
+        [helper.make_tensor_value_info("y", TensorProto.INT32, y_shape)],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+    model.ir_version = 9
+    return model
+
+
+def test_div_integer_dynamic_zero_divisor_runtime():
+    a = np.array([42, 99, -50, 7], dtype=np.int32)
+    b = np.array([3, 0, 0, 1], dtype=np.int32)
+    model = _make_div_integer_dynamic_model([4], [4], [4])
+    out = run_in_tvm(model, inputs={"a": a, "b": b}, ir_version=9, opset=18).numpy()
+
+    assert out.dtype == np.int32
+    assert out.shape == (4,)
+    np.testing.assert_array_equal(out[[0, 3]], np.array([14, 7], dtype=np.int32))
+    np.testing.assert_array_equal(out[[1, 2]], np.array([0, 0], dtype=np.int32))
+
+
+def test_div_integer_dynamic_zero_divisor_ir_guard():
+    tvm_model = from_onnx(
+        _make_div_integer_dynamic_model([4], [4], [4]), opset=18, keep_params_in_input=True
+    )
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(a: R.Tensor((4,), dtype="int32"), b: R.Tensor((4,), dtype="int32")) -> R.Tensor(
+            (4,), dtype="int32"
+        ):
+            R.func_attr({"num_input": 2})
+            with R.dataflow():
+                lv: R.Tensor((4,), dtype="bool") = R.not_equal(b, R.const(0, "int32"))
+                lv1: R.Tensor((4,), dtype="int32") = R.where(lv, b, R.const(1, "int32"))
+                lv2: R.Tensor((4,), dtype="int32") = R.divide(a, lv1)
+                gv: R.Tensor((4,), dtype="int32") = R.where(lv, lv2, R.const(0, "int32"))
+                R.output(gv)
+            return gv
+
+    tvm.ir.assert_structural_equal(tvm_model, Expected)
+
+
+def test_div_integer_dynamic_zero_divisor_broadcast_ir_guard():
+    tvm_model = from_onnx(
+        _make_div_integer_dynamic_model([2, 4], [4], [2, 4]),
+        opset=18,
+        keep_params_in_input=True,
+    )
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(a: R.Tensor((2, 4), dtype="int32"), b: R.Tensor((4,), dtype="int32")) -> R.Tensor(
+            (2, 4), dtype="int32"
+        ):
+            R.func_attr({"num_input": 2})
+            with R.dataflow():
+                lv: R.Tensor((4,), dtype="bool") = R.not_equal(b, R.const(0, "int32"))
+                lv1: R.Tensor((4,), dtype="int32") = R.where(lv, b, R.const(1, "int32"))
+                lv2: R.Tensor((2, 4), dtype="int32") = R.divide(a, lv1)
+                gv: R.Tensor((2, 4), dtype="int32") = R.where(lv, lv2, R.const(0, "int32"))
+                R.output(gv)
+            return gv
+
+    tvm.ir.assert_structural_equal(tvm_model, Expected)
+
+
 @pytest.mark.parametrize("int_mode", [True, False])
 def test_mod(int_mode: bool):
     if int_mode:


### PR DESCRIPTION
## Summary

This PR fixes Relax ONNX frontend handling for integer `Div` when the divisor
is dynamic and may contain zero.

Issue #19541 reports a `SIGFPE` crash when an ONNX `Div` model has integer
inputs and the divisor is supplied as a graph input containing zero. PR #19566
already added an import-time error for constant integer divisors containing
zero, but dynamic divisors still imported to a bare `relax.divide`. After
legalization, LLVM could still see integer `sdiv` / `udiv` with a zero divisor.

ONNX integer division by zero is undefined. This PR keeps exact integer
division for every non-zero divisor lane, and returns zero for lanes where the
runtime divisor is zero. The result is deterministic and avoids exposing
integer division by zero to LLVM.

## Design

### Guarded Dynamic Integer Div

For integer operands with a non-constant RHS, `Div._impl_v7` now emits a
guarded Relax subgraph:

```python
rhs_nonzero = relax.op.not_equal(rhs, relax.const(0, rhs_dtype))
safe_rhs = relax.op.where(rhs_nonzero, rhs, relax.const(1, rhs_dtype))
quotient = relax.op.divide(lhs, safe_rhs)
result = relax.op.where(rhs_nonzero, quotient, relax.const(0, quotient_dtype))
```

The divisor passed to `relax.divide` is therefore never zero. The final
`where` restores the deterministic zero result for the originally-zero divisor
lanes.

The importer normalizes the intermediate expressions whose inferred type is
needed by later `where` construction. It uses scalar constants for the zero and
one guard values so the imported Relax graph does not allocate separate
filled tensors for the guard.

### Constant and Non-Integer Paths

The existing non-integer behavior is unchanged: non-integer `Div` still uses
the normal binary frontend implementation.

For integer `Div` with a constant RHS:

- constants containing zero still raise `ValueError` at import time
- constants without zero still use the normal binary frontend implementation

This keeps the PR #19566 behavior for constants while only adding runtime
guarding where import-time zero detection is impossible.

### No Float Fallback

The implementation intentionally avoids casting integer tensors through float
types. The guarded Relax graph preserves integer division semantics on all
non-zero lanes and avoids precision loss or float-to-int `inf` behavior.

### Frontend-Local Runtime Guard

This is intentionally a frontend-local runtime guard rather than a global
Relax, TIR, or LLVM integer-division policy. The check is not an import-time
Python decision for dynamic inputs; it is expressed as Relax IR and executes
with the model at runtime.

Handling this in a generic Relax/TIR pass would affect all producers of integer
division and would need a project-wide policy for undefined integer
division-by-zero behavior: whether to trap, raise a controlled runtime error,
or return a deterministic value. This PR only addresses the ONNX frontend bug
reported in #19541 and keeps the deterministic zero result local to imported
ONNX integer `Div`.

## Updated Converter Behavior

| Case | Previous behavior | New behavior |
|---|---|---|
| integer `Div` with dynamic integer RHS | imports to bare `relax.divide`; LLVM can see integer division by zero at runtime | imports to a guarded Relax subgraph; non-zero divisor lanes keep exact integer division, zero-divisor lanes return zero |
| integer `Div` with constant integer RHS containing zero | import-time `ValueError` from PR #19566 | unchanged |
| integer `Div` with constant integer RHS without zero | normal binary lowering | unchanged |
| non-integer `Div` | normal binary lowering | unchanged |

## Safety Checks

- Constant integer divisors containing zero raise
  `ValueError("ONNX Div with integer inputs encountered divisor value 0.")`.
- Dynamic integer divisors are replaced with scalar `1` only for the
  division operand when the divisor lane is zero.
- Zero-divisor lanes are overwritten with scalar `0` after the
  division.
- The guarded graph is asserted with structural Relax IR tests, so the frontend
  cannot silently regress to a bare `relax.divide` or wire the guard operands
  incorrectly.

## Out of Scope / Non-Goals

- This PR does not define global Relax, TIR, or LLVM integer division-by-zero
  semantics.
- This PR does not use a float-cast fallback for integer division.
- This PR does not change ONNX `Div` floating-point behavior.
- This PR does not change other frontends or other ONNX operators.

## Tests

The tests primarily lock the imported Relax graph shape, with one minimal VM
runtime smoke test for the original execution-time crash path.

| Test | Coverage |
|---|---|
| `test_div_integer_constant_zero_divisor_raises_valueerror` | keeps PR #19566 constant-zero import-time error |
| `test_div_integer_dynamic_zero_divisor_runtime` | runs one dynamic INT32 ONNX `Div` model through `DecomposeOpsForInference`, `LegalizeOps`, LLVM compile, and VM execution; asserts dtype, shape, exact non-zero divisor results, and deterministic zero results for zero-divisor lanes |
| `test_div_integer_dynamic_zero_divisor_ir_guard` | uses `tvm.ir.assert_structural_equal` to lock the exact guarded Relax subgraph before legalization |
| `test_div_integer_dynamic_zero_divisor_broadcast_ir_guard` | uses `tvm.ir.assert_structural_equal` to lock the guarded Relax subgraph when RHS broadcasting is required |

Local validation:

```bash
python -m pytest \
  tests/python/relax/test_frontend_onnx.py::test_div_integer_dynamic_zero_divisor_runtime \
  -xvs

python -m pytest tests/python/relax/test_frontend_onnx.py -k "div" -xvs

python -m ruff check \
  python/tvm/relax/frontend/onnx/onnx_frontend.py \
  tests/python/relax/test_frontend_onnx.py
```

Result:

```text
test_div_integer_dynamic_zero_divisor_runtime: passed
test_frontend_onnx.py -k "div": 7 passed
ruff check: All checks passed
```

## References

- Closes [#19541](https://github.com/apache/tvm/issues/19541): ONNX integer
  `Div` with a dynamic zero divisor can crash at runtime.
- Follows up PR #19566: previous constant-zero divisor import-time error.
