### PR TITLE
[TOPI][CUDA] Fix topk/sort gridDim overflow by remapping grid axes in sort_ir

### DIFF
--- a/python/tvm/topi/gpu/sort.py
+++ b/python/tvm/topi/gpu/sort.py
@@ -499,8 +499,10 @@ def _sort_common(
             nbx = tvm.tirx.generic.cast(ceil_div(width, max_threads * thread_work), "int32")
             nbz = tvm.tirx.generic.cast(ceil_div(size, width), "int32")
 
-        tx, bx, by, _, _, _ = _get_threads(ntx, nbx, nthread_by)
-        bz = te.thread_axis("blockIdx.z")
+        tx = te.thread_axis("threadIdx.x")
+        bx = te.thread_axis("blockIdx.z")  # nbx
+        by = te.thread_axis("blockIdx.y")  # batch
+        bz = te.thread_axis("blockIdx.x")  # nbz (largest extent)
         with T.frame_scope(
             [
                 T.attr(tx, "thread_extent", ntx),

--- a/python/tvm/topi/gpu/sort.py
+++ b/python/tvm/topi/gpu/sort.py
@@ -499,17 +499,17 @@ def _sort_common(
             nbx = tvm.tirx.generic.cast(ceil_div(width, max_threads * thread_work), "int32")
             nbz = tvm.tirx.generic.cast(ceil_div(size, width), "int32")
 
-        tx, bx, by, _, _, _ = _get_threads(ntx, nbx, nthread_by * nbz)
+        tx, bx, by, _, _, _ = _get_threads(ntx, nbx, nthread_by)
+        bz = te.thread_axis("blockIdx.z")
         with T.frame_scope(
             [
                 T.attr(tx, "thread_extent", ntx),
                 T.attr(bx, "thread_extent", nbx),
-                T.attr(by, "thread_extent", nthread_by * nbz),
+                T.attr(by, "thread_extent", nthread_by),
+                T.attr(bz, "thread_extent", nbz),
             ]
         ):
-            by_val = by % nthread_by
-            bz = by // nthread_by
-            base_idx = by_val * size
+            base_idx = by * size
 
             # calculate the start, mid, and end points of this section
             start_pos = width * bz

--- a/python/tvm/topi/gpu/sort.py
+++ b/python/tvm/topi/gpu/sort.py
@@ -30,9 +30,15 @@ from ..utils import ceil_div, prod, swap
 
 
 def _get_threads(nthread_tx, nthread_bx, nthread_by):
+    target = tvm.target.Target.current(allow_none=True)
+    is_cuda = target is not None and target.kind.name == "cuda"
     tx = te.thread_axis("threadIdx.x")
-    bx = te.thread_axis("blockIdx.x")
-    by = te.thread_axis("blockIdx.y")
+    if is_cuda:
+        bx = te.thread_axis("blockIdx.y")
+        by = te.thread_axis("blockIdx.x")
+    else:
+        bx = te.thread_axis("blockIdx.x")
+        by = te.thread_axis("blockIdx.y")
     return tx, bx, by, nthread_tx, nthread_bx, nthread_by
 
 
@@ -501,10 +507,15 @@ def _sort_common(
             nbx = cast(ceil_div(width, max_threads * thread_work), "int32")
             nbz = cast(ceil_div(size, width), "int32")
 
+        is_cuda = target.kind.name == "cuda"
         tx = te.thread_axis("threadIdx.x")
         bx = te.thread_axis("blockIdx.z")  # nbx
-        by = te.thread_axis("blockIdx.y")  # batch
-        bz = te.thread_axis("blockIdx.x")  # nbz (largest extent)
+        if is_cuda:
+            by = te.thread_axis("blockIdx.x")  # batch
+            bz = te.thread_axis("blockIdx.y")  # nbz
+        else:
+            by = te.thread_axis("blockIdx.y")  # batch
+            bz = te.thread_axis("blockIdx.x")  # nbz
         with T.frame_scope(
             [
                 T.attr(tx, "thread_extent", ntx),

--- a/python/tvm/topi/gpu/sort.py
+++ b/python/tvm/topi/gpu/sort.py
@@ -501,8 +501,10 @@ def _sort_common(
             nbx = cast(ceil_div(width, max_threads * thread_work), "int32")
             nbz = cast(ceil_div(size, width), "int32")
 
-        tx, bx, by, _, _, _ = _get_threads(ntx, nbx, nthread_by)
-        bz = te.thread_axis("blockIdx.z")
+        tx = te.thread_axis("threadIdx.x")
+        bx = te.thread_axis("blockIdx.z")  # nbx
+        by = te.thread_axis("blockIdx.y")  # batch
+        bz = te.thread_axis("blockIdx.x")  # nbz (largest extent)
         with T.frame_scope(
             [
                 T.attr(tx, "thread_extent", ntx),

--- a/python/tvm/topi/gpu/sort.py
+++ b/python/tvm/topi/gpu/sort.py
@@ -501,17 +501,17 @@ def _sort_common(
             nbx = cast(ceil_div(width, max_threads * thread_work), "int32")
             nbz = cast(ceil_div(size, width), "int32")
 
-        tx, bx, by, _, _, _ = _get_threads(ntx, nbx, nthread_by * nbz)
+        tx, bx, by, _, _, _ = _get_threads(ntx, nbx, nthread_by)
+        bz = te.thread_axis("blockIdx.z")
         with T.frame_scope(
             [
                 T.attr(tx, "thread_extent", ntx),
                 T.attr(bx, "thread_extent", nbx),
-                T.attr(by, "thread_extent", nthread_by * nbz),
+                T.attr(by, "thread_extent", nthread_by),
+                T.attr(bz, "thread_extent", nbz),
             ]
         ):
-            by_val = by % nthread_by
-            bz = by // nthread_by
-            base_idx = by_val * size
+            base_idx = by * size
 
             # calculate the start, mid, and end points of this section
             start_pos = width * bz

--- a/tests/python/relax/test_backend_dispatch_sort_scan.py
+++ b/tests/python/relax/test_backend_dispatch_sort_scan.py
@@ -410,6 +410,73 @@ def test_dispatch_topk_gpu():
     assert_structural_equal(mod, expected_mod)
 
 
+@pytest.mark.gpu
+@pytest.mark.parametrize("size", [300, 600])
+def test_dispatch_sort_cuda_large_batch(size):
+    target = "cuda"
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(x: R.Tensor(("m", "n"), "float32")):
+            with R.dataflow():
+                gv = R.sort(x, axis=-1, descending=False)
+                R.output(gv)
+            return gv
+
+    batch = 65600  # > CUDA's 65535 gridDim.y/z limit
+    np_data = np.random.uniform(size=(batch, size)).astype("float32")
+    np_sorted = np.sort(np_data, axis=-1)
+
+    with tvm.target.Target(target):
+        mod = DispatchSortScan()(Module)
+        ex = tvm.compile(mod, target)
+
+    def run_and_check():
+        dev = tvm.device_from_target(target)
+        vm = tvm.relax.VirtualMachine(ex, dev)
+        tvm_data = tvm.runtime.tensor(np_data, dev)
+        sorted_data = vm["main"](tvm_data)
+        tvm.testing.assert_allclose(sorted_data.numpy(), np_sorted)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
+
+
+@pytest.mark.gpu
+def test_dispatch_topk_cuda_large_batch():
+    target = "cuda"
+    if not tvm.testing.device_enabled(target):
+        pytest.skip(f"{target} not enabled")
+
+    @I.ir_module
+    class Module:
+        @R.function
+        def main(x: R.Tensor(("m", "n"), "float32")):
+            with R.dataflow():
+                gv = R.topk(x, k=1, axis=-1, ret_type="values", largest=True)
+                R.output(gv)
+            return gv
+
+    batch, size = 65600, 300
+    np_data = np.random.uniform(size=(batch, size)).astype("float32")
+    np_values = np.sort(np_data, axis=-1)[:, -1:]
+
+    with tvm.target.Target(target):
+        mod = DispatchSortScan()(Module)
+        ex = tvm.compile(mod, target)
+
+    def run_and_check():
+        dev = tvm.device_from_target(target)
+        vm = tvm.relax.VirtualMachine(ex, dev)
+        tvm_data = tvm.runtime.tensor(np_data, dev)
+        values = vm["main"](tvm_data)
+        tvm.testing.assert_allclose(values.numpy(), np_values)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
+
+
 @pytest.mark.parametrize(
     "target",
     [


### PR DESCRIPTION
Hi Committers,

This PR addresses issue https://github.com/apache/tvm/issues/19549. Any suggestions would be appreciated if you are available.