### PR TITLE
[Relax] Clean up deprecated void-dtype sentinel usage

### DIFF
--- a/src/relax/op/tensor/create.cc
+++ b/src/relax/op/tensor/create.cc
@@ -179,7 +179,6 @@ Type InferTypeOnesLikeZerosLike(const Call& call, const BlockBuilder& ctx) {
 
 /* relax.ones & relax.ones_like */
 Expr ones(Expr shape, DLDataType dtype) {
-  TVM_FFI_ICHECK(!PrimType(dtype).IsVoid()) << "Ones op expects the input dtype not to be void";
   ffi::ObjectPtr<InitAttrs> attrs = ffi::make_object<InitAttrs>();
   attrs->dtype = dtype;
 
@@ -216,7 +215,6 @@ TVM_REGISTER_OP("relax.ones_like")
 
 /* relax.zeros & relax.zeros_like */
 Expr zeros(Expr shape, DLDataType dtype) {
-  TVM_FFI_ICHECK(!PrimType(dtype).IsVoid()) << "Zeros op expects the input dtype not to be void";
   ffi::ObjectPtr<InitAttrs> attrs = ffi::make_object<InitAttrs>();
   attrs->dtype = dtype;
 

--- a/src/relax/op/tensor/create.cc
+++ b/src/relax/op/tensor/create.cc
@@ -179,8 +179,7 @@ Type InferTypeOnesLikeZerosLike(const Call& call, const BlockBuilder& ctx) {
 
 /* relax.ones & relax.ones_like */
 Expr ones(Expr shape, DLDataType dtype) {
-  TVM_FFI_ICHECK((dtype != DLDataType{kDLOpaqueHandle, 0, 0}))
-      << "Ones op expects the input dtype not to be void";
+  TVM_FFI_ICHECK(!PrimType(dtype).IsVoid()) << "Ones op expects the input dtype not to be void";
   ffi::ObjectPtr<InitAttrs> attrs = ffi::make_object<InitAttrs>();
   attrs->dtype = dtype;
 
@@ -217,8 +216,7 @@ TVM_REGISTER_OP("relax.ones_like")
 
 /* relax.zeros & relax.zeros_like */
 Expr zeros(Expr shape, DLDataType dtype) {
-  TVM_FFI_ICHECK((dtype != DLDataType{kDLOpaqueHandle, 0, 0}))
-      << "Zeros op expects the input dtype not to be void";
+  TVM_FFI_ICHECK(!PrimType(dtype).IsVoid()) << "Zeros op expects the input dtype not to be void";
   ffi::ObjectPtr<InitAttrs> attrs = ffi::make_object<InitAttrs>();
   attrs->dtype = dtype;
 

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -196,9 +196,9 @@ bool IsBoolType(const Type& ty, bool permit_unknown_rank, bool permit_unknown_dt
     return false;
   }
 
-  // Bool-type matching preserves the old element-code-only behavior; rank is checked separately.
-  bool correct_dtype = dtype.code == DLDataTypeCode::kDLBool ||
-                       (permit_unknown_dtype && dtype == DLDataType{kDLOpaqueHandle, 0, 0});
+  // Bool-type matching uses element-code-only behavior; rank is checked separately.
+  // Unknown dtype is already handled above via IsUnknownDtype().
+  bool correct_dtype = dtype.code == DLDataTypeCode::kDLBool;
   bool correct_rank = ndim == 0 || (permit_unknown_rank && ndim == -1);
   return correct_dtype && correct_rank;
 }

--- a/tests/python/relax/test_op_create.py
+++ b/tests/python/relax/test_op_create.py
@@ -414,12 +414,8 @@ def test_ones_zeros_shape_not_tuple():
 def test_ones_zeros_wrong_dtype():
     with pytest.raises(TypeError):
         relax.op.ones((2, 3))
-    with pytest.raises(tvm.error.InternalError):
-        relax.op.ones((2, 3), "")
     with pytest.raises(TypeError):
         relax.op.zeros((2, 3))
-    with pytest.raises(tvm.error.InternalError):
-        relax.op.zeros((2, 3), "")
 
 
 def test_ones_zeros_infer_ty_wrong_input_type():


### PR DESCRIPTION
## Why

After #19890 moved Relax dtype to optional, two spots still used the deprecated `DLDataType{kDLOpaqueHandle, 0, 0}` void sentinel.

## How

- Drop the now-unreachable unknown-dtype branch in IsBoolType (handled earlier by IsUnknownDtype()).
- Replace the raw void-sentinel comparison in ones/zeros with PrimType::IsVoid().