### PR TITLE
[CI][Docker] Install libpolly-15-dev for noble llvm-15 static linking

### DIFF
--- a/docker/install/ubuntu_install_llvm.sh
+++ b/docker/install/ubuntu_install_llvm.sh
@@ -22,6 +22,6 @@ set -o pipefail
 
 apt-get update && apt-install-and-clear -y \
      llvm-15 llvm-16 llvm-17\
-     clang-15 libclang-15-dev \
+     clang-15 libclang-15-dev libpolly-15-dev \
      clang-16 libclang-16-dev libpolly-16-dev \
      clang-17 libclang-17-dev libpolly-17-dev libzstd-dev


### PR DESCRIPTION
#19893 switched the LLVM install from apt.llvm.org to noble's own repos. Unlike apt.llvm.org, noble splits Polly's static libs into a per-version libpolly-<N>-dev package. The install list added libpolly-16-dev and libpolly-17-dev but not libpolly-15-dev, so `llvm-config-15 --link-static` (used by the GPU build) cannot find libPolly.a / libPollyISL.a, breaking the libtvm_compiler.so link. Add libpolly-15-dev.