### PR TITLE
[Target][RISC-V] Use riscv_cpu device key for RISC-V target tags

### DIFF
--- a/python/tvm/target/tag_registry/riscv_cpu.py
+++ b/python/tvm/target/tag_registry/riscv_cpu.py
@@ -20,7 +20,7 @@ from .registry import register_tag
 
 
 def _register_riscv_tag(name, config):
-    base = {"kind": "llvm", "keys": ["arm_cpu", "cpu"], "device": "arm_cpu"}
+    base = {"kind": "llvm", "keys": ["riscv_cpu", "cpu"], "device": "riscv_cpu"}
     base.update(config)
     register_tag(name, base)
 
@@ -67,6 +67,17 @@ _register_riscv_tag(
         "num-cores": 8,
         "mtriple": "riscv64-unknown-linux-gnu",
         "mcpu": "spacemit-x60",
+        "mfloat-abi": "hard",
+        "mabi": "lp64d",
+    },
+)
+
+_register_riscv_tag(
+    "riscv/spacemit-k3",
+    {
+        "num-cores": 8,
+        "mtriple": "riscv64-unknown-linux-gnu",
+        "mcpu": "spacemit-x100",
         "mfloat-abi": "hard",
         "mabi": "lp64d",
     },


### PR DESCRIPTION
RISC-V target tags use the LLVM codegen backend, so their target kind should remain "llvm".  However, the target metadata should still identify the target as a RISC-V CPU rather than an ARM CPU.

Previously, the RISC-V tag helper used the ARM CPU keys and device metadata, so Target("riscv/...") expanded with keys ["arm_cpu", "cpu"] and device "arm_cpu".  

```python
{"kind": "llvm", "keys": ["arm_cpu", "cpu"], "device": "arm_cpu"}
```

This is misleading for code that inspects target keys or device metadata to distinguish CPU families.

This change updates the RISC-V tag helper to use keys ["riscv_cpu", "cpu"] and device "riscv_cpu", while keeping kind="llvm".  It also adds the SpacemiT K3 RISC-V target tag.
