### PR TITLE
Fix issue #18379: Handle string annotations for TIR function arguments

### DIFF
--- a/python/tvm/tirx/script/parser/parser.py
+++ b/python/tvm/tirx/script/parser/parser.py
@@ -618,6 +618,11 @@ def visit_function_def(self: Parser, node: doc.FunctionDef) -> None:
             T.func_name(node.name)
             if node.returns is not None:
                 ret_type = self.eval_expr(node.returns)
+                if isinstance(ret_type, str):
+                    from tvm.script.parser.core.doc import parse
+
+                    ret_type_expr = parse(ret_type, mode="eval").body
+                    ret_type = self.eval_expr(ret_type_expr)
                 if callable(ret_type):
                     ret_type = PrimType(ret_type().dtype)
                 T.func_ret(ret_type)
@@ -634,6 +639,11 @@ def visit_function_def(self: Parser, node: doc.FunctionDef) -> None:
                         self.report_error(arg, "Type annotation required for function parameters.")
                     try:
                         ann = self.eval_expr(arg.annotation)
+                        if isinstance(ann, str):
+                            from tvm.script.parser.core.doc import parse
+
+                            ann_expr = parse(ann, mode="eval").body
+                            ann = self.eval_expr(ann_expr)
                         if callable(ann) and ann is not _constexpr_sentinel:
                             ann = ann()
                     except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
When using from __future__ import annotations, Python evaluates type hints as strings. This caused the TVMScript parser to crash when trying to parse TIR functions (throwing an Unexpected type for TIR Arg: ffi.String error). I added logic in the TIR parser (tirx/script/parser/parser.py) to detect if an argument or return annotation evaluates to a string. If it does, we parse the string back into a valid TVMScript AST expression and re-evaluate it against the current environment.

Validation: Verified that TVMScript can now correctly parse string-based type annotations that reference local variables (e.g., M in T.Buffer((M,), "float32")) without throwing unexpected type errors, ensuring full compatibility with Python's modern type hinting standards. Code syntax and parser logic have been validated locally.