### PR TITLE
[Fix][TOPI] Swap CUDA topk thread axis to bypass gridDim.y limits

### DIFF
--- a/python/tvm/topi/gpu/sort.py
+++ b/python/tvm/topi/gpu/sort.py
@@ -31,8 +31,8 @@ from ..utils import ceil_div, prod, swap
 
 def _get_threads(nthread_tx, nthread_bx, nthread_by):
     tx = te.thread_axis("threadIdx.x")
-    bx = te.thread_axis("blockIdx.x")
-    by = te.thread_axis("blockIdx.y")
+    bx = te.thread_axis("blockIdx.y")
+    by = te.thread_axis("blockIdx.x")
     return tx, bx, by, nthread_tx, nthread_bx, nthread_by
 
 


### PR DESCRIPTION
Fixes issue #19549 by mapping the block index representing chunk size (which is bound by the dimension of the data) to lockIdx.y and mapping the block index for batches (which easily exceeds 65535) to lockIdx.x (limit ~2 billion).