### PR TITLE
[Fix][TOPI] Swap CUDA topk thread axis to bypass gridDim.y limits

### DIFF
--- a/python/tvm/topi/gpu/sort.py
+++ b/python/tvm/topi/gpu/sort.py
@@ -30,13 +30,12 @@ from ..utils import ceil_div, prod, swap
 
 
 def _get_threads(nthread_tx, nthread_bx, nthread_by):
-    # Swap blockIdx.x and blockIdx.y mappings.
-    # The batch dimension (nthread_by) can easily exceed the CUDA limit of 65535 for gridDim.y.
-    # By mapping nthread_by to blockIdx.x (limit ~2 billion), we prevent CUDA_ERROR_INVALID_VALUE on large inputs.
+    # Fuse blockIdx.x and blockIdx.y mappings into a single blockIdx.x.
+    # The batch dimension (nthread_by) or split chunks (nthread_bx) can easily exceed the CUDA limit of 65535 for gridDim.y.
+    # By mapping the fused index to blockIdx.x (limit ~2 billion), we prevent CUDA_ERROR_INVALID_VALUE on large inputs.
     tx = te.thread_axis("threadIdx.x")
-    bx = te.thread_axis("blockIdx.y")
-    by = te.thread_axis("blockIdx.x")
-    return tx, bx, by, nthread_tx, nthread_bx, nthread_by
+    b_fused = te.thread_axis("blockIdx.x")
+    return tx, b_fused, nthread_tx, nthread_bx, nthread_by
 
 
 def _sort_init(shape, axis, keys_in, keys_out, values_out=None, value_init_func=None):
@@ -58,14 +57,15 @@ def _sort_init(shape, axis, keys_in, keys_out, values_out=None, value_init_func=
     nthread_by = axis_mul_before * axis_mul_after
 
     # Copy the keys_in to initial output
-    tx, bx, by, ntx, nbx, nby = _get_threads(nthread_tx, nthread_bx, nthread_by)
+    tx, b_fused, ntx, nbx, nby = _get_threads(nthread_tx, nthread_bx, nthread_by)
     with T.frame_scope(
         [
             T.attr(tx, "thread_extent", ntx),
-            T.attr(bx, "thread_extent", nbx),
-            T.attr(by, "thread_extent", nby),
+            T.attr(b_fused, "thread_extent", nbx * nby),
         ]
     ):
+        bx = b_fused % nbx
+        by = b_fused // nbx
         tid = bx * nthread_tx + tx
         by_val = by % axis_mul_before
         bz = by // axis_mul_before
@@ -99,15 +99,16 @@ def _odd_even_sort(
     nthread_bx = ceil_div(size, block_size)
     nthread_by = axis_mul_before * axis_mul_after
 
-    tx, bx, by, ntx, nbx, nby = _get_threads(nthread_tx, nthread_bx, nthread_by)
+    tx, b_fused, ntx, nbx, nby = _get_threads(nthread_tx, nthread_bx, nthread_by)
     with T.frame_scope(
         [
             T.attr(tvm.tirx.const(0), "hand_threaded", 0),
             T.attr(tx, "thread_extent", ntx),
-            T.attr(bx, "thread_extent", nbx),
-            T.attr(by, "thread_extent", nby),
+            T.attr(b_fused, "thread_extent", nbx * nby),
         ]
     ):
+        bx = b_fused % nbx
+        by = b_fused // nbx
         by_val = by % axis_mul_before
         bz = by // axis_mul_before
         tid = 2 * tx
@@ -502,14 +503,15 @@ def _sort_common(
             nbx = tvm.tirx.generic.cast(ceil_div(width, max_threads * thread_work), "int32")
             nbz = tvm.tirx.generic.cast(ceil_div(size, width), "int32")
 
-        tx, bx, by, _, _, _ = _get_threads(ntx, nbx, nthread_by * nbz)
+        tx, b_fused, _, _, _ = _get_threads(ntx, nbx, nthread_by * nbz)
         with T.frame_scope(
             [
                 T.attr(tx, "thread_extent", ntx),
-                T.attr(bx, "thread_extent", nbx),
-                T.attr(by, "thread_extent", nthread_by * nbz),
+                T.attr(b_fused, "thread_extent", nbx * nthread_by * nbz),
             ]
         ):
+            bx = b_fused % nbx
+            by = b_fused // nbx
             by_val = by % nthread_by
             bz = by // nthread_by
             base_idx = by_val * size
@@ -564,14 +566,15 @@ def _sort_common(
         tvm.tirx.all(upper_lim > lower_lim, tvm.tirx.indexmod(upper_lim - lower_lim, 2) == 1)
     ):
         with T.Then():
-            tx2, bx2, by2, _, _, _ = _get_threads(nthread_tx, nthread_bx, nthread_by)
+            tx2, b_fused2, _, _, _ = _get_threads(nthread_tx, nthread_bx, nthread_by)
             with T.frame_scope(
                 [
                     T.attr(tx2, "thread_extent", nthread_tx),
-                    T.attr(bx2, "thread_extent", nthread_bx),
-                    T.attr(by2, "thread_extent", nthread_by),
+                    T.attr(b_fused2, "thread_extent", nthread_bx * nthread_by),
                 ]
             ):
+                bx2 = b_fused2 % nthread_bx
+                by2 = b_fused2 // nthread_bx
                 tid = bx2 * nthread_tx + tx2
                 idx = by2 * size + tid
                 with T.If(tid < size):

--- a/python/tvm/topi/gpu/sort.py
+++ b/python/tvm/topi/gpu/sort.py
@@ -30,6 +30,9 @@ from ..utils import ceil_div, prod, swap
 
 
 def _get_threads(nthread_tx, nthread_bx, nthread_by):
+    # Swap blockIdx.x and blockIdx.y mappings.
+    # The batch dimension (nthread_by) can easily exceed the CUDA limit of 65535 for gridDim.y.
+    # By mapping nthread_by to blockIdx.x (limit ~2 billion), we prevent CUDA_ERROR_INVALID_VALUE on large inputs.
     tx = te.thread_axis("threadIdx.x")
     bx = te.thread_axis("blockIdx.y")
     by = te.thread_axis("blockIdx.x")

--- a/python/tvm/topi/gpu/sort.py
+++ b/python/tvm/topi/gpu/sort.py
@@ -31,8 +31,8 @@ from ..utils import ceil_div, prod, swap
 
 def _get_threads(nthread_tx, nthread_bx, nthread_by):
     tx = te.thread_axis("threadIdx.x")
-    bx = te.thread_axis("blockIdx.x")
-    by = te.thread_axis("blockIdx.y")
+    bx = te.thread_axis("blockIdx.y")
+    by = te.thread_axis("blockIdx.x")
     return tx, bx, by, nthread_tx, nthread_bx, nthread_by
 
 


### PR DESCRIPTION
Fixes issue #19549.

This maps the block index for chunk size to blockIdx.y, and maps the block index for batches to blockIdx.x.
Since the batch dimension can easily exceed the 65535 limit of gridDim.y on large inputs, moving it to blockIdx.x (which has a much larger limit) prevents the CUDA_ERROR_INVALID_VALUE crash during the kernel launch.

Added an inline comment to clarify this swap.